### PR TITLE
feat(runner): F-4.1 — release.cut capability consumer (dormant; principal-gated)

### DIFF
--- a/src/__tests__/cortex.release-consumer-boot.test.ts
+++ b/src/__tests__/cortex.release-consumer-boot.test.ts
@@ -1,0 +1,402 @@
+/**
+ * cortex#835 F-4.1 — release-consumer boot wiring tests.
+ *
+ * Asserts the boot loop mirrors the review-consumer wiring:
+ *
+ *   for each agent in mergedAgents:
+ *     if agent.runtime?.capabilities contains "release" or "release.cut":
+ *       new ReleaseConsumer(...) → one instance per such agent → start()
+ *
+ * Covers:
+ *
+ *   1. One agent declaring `release.cut` → one consumer; ready log line;
+ *      subscribePull invoked once with the canonical pattern + durable +
+ *      stream.
+ *   2. THE HARD CONTRACT — zero release-capable agents → BYTE-IDENTICAL boot:
+ *      zero subscribePull calls AND no release-lane log line at all (the block
+ *      is fully gated; an opt-out roster boots exactly as before this PR).
+ *   3. Dormant subscribePull (returns null) → DORMANT log, not ready.
+ *   4. One consumer init throws → siblings still wire; boot completes; stderr
+ *      carries the failing agent id.
+ *
+ * Per-envelope behaviour (the grant gate, preconditions, lifecycle) is covered
+ * by `src/runner/__tests__/release-consumer.test.ts`. This boot test exercises
+ * instantiation + subscribe + the byte-identical-when-absent contract only.
+ *
+ * No real NATS, Discord, filesystem-watcher I/O, or `claude` spawning.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import type { Agent, AgentRuntime } from "../common/types/cortex-config";
+import { startCortex } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+  MyelinSubscribePullOpts,
+} from "../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+
+// ---------------------------------------------------------------------------
+// Test helpers — mirror cortex.review-consumer-boot.test.ts.
+// ---------------------------------------------------------------------------
+
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: {
+      name: "test-cortex",
+      displayName: "TestCortex",
+    },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-release-test-published" },
+    ...overrides,
+  });
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  onEnvelopeHandlers: Set<EnvelopeHandler>;
+  published: Envelope[];
+  subscribePullCalls: MyelinSubscribePullOpts[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+  return {
+    enabled: false,
+    onEnvelopeHandlers,
+    published,
+    subscribePullCalls,
+    onEnvelope(handler) {
+      onEnvelopeHandlers.add(handler);
+      return {
+        unregister: () => {
+          onEnvelopeHandlers.delete(handler);
+        },
+      };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    subscribePull: (opts: MyelinSubscribePullOpts): MyelinSubscriber => {
+      subscribePullCalls.push(opts);
+      return {
+        pattern: opts.pattern,
+        ready: Promise.resolve(),
+        stop: async () => {},
+      } as unknown as MyelinSubscriber;
+    },
+    stop: async () => {},
+  };
+}
+
+function makeAgent(
+  id: string,
+  capabilities: readonly string[] | undefined,
+  maxConcurrent?: number,
+): Agent {
+  const runtime: AgentRuntime | undefined =
+    capabilities === undefined
+      ? undefined
+      : {
+          substrate: "claude-code",
+          mode: "in-process",
+          capabilities: [...capabilities],
+          ...(maxConcurrent !== undefined && { maxConcurrent }),
+        };
+
+  return {
+    id,
+    displayName: id.charAt(0).toUpperCase() + id.slice(1),
+    persona: `/tmp/${id}-persona.md`,
+    trust: [],
+    presence: {},
+    ...(runtime !== undefined && { runtime }),
+  };
+}
+
+function withCapturedStderr<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; stderr: string }> {
+  const original = process.stderr.write.bind(process.stderr);
+  let buf = "";
+  process.stderr.write = (chunk: unknown): boolean => {
+    buf += typeof chunk === "string" ? chunk : String(chunk);
+    return true;
+  };
+  return fn()
+    .then((result) => {
+      process.stderr.write = original;
+      return { result, stderr: buf };
+    })
+    .catch((err: unknown) => {
+      process.stderr.write = original;
+      throw err;
+    });
+}
+
+function withCapturedConsoleLog<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; logs: string[] }> {
+  const original = console.log.bind(console);
+  const logs: string[] = [];
+  console.log = (...args: unknown[]): void => {
+    logs.push(args.map((a) => String(a)).join(" "));
+  };
+  return fn()
+    .then((result) => {
+      console.log = original;
+      return { result, logs };
+    })
+    .catch((err: unknown) => {
+      console.log = original;
+      throw err;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startCortex — release-consumer boot wiring (cortex#835 F-4.1)", () => {
+  test("one agent declaring release.cut → one consumer; ready log; subscribePull with canonical pattern + durable + stream", async () => {
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-relboot-1-"));
+    const inlineAgents: Agent[] = [makeAgent("forge", ["release.cut"])];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: "test-op" },
+      }),
+    );
+
+    const readyLines = logs.filter((l) =>
+      l.includes("cortex: release consumer ready"),
+    );
+    expect(readyLines.length).toBe(1);
+    expect(readyLines[0]!).toContain("agent=forge");
+    expect(readyLines[0]!).toContain("capability=release.cut");
+    expect(readyLines[0]!).toContain("PRINCIPAL-GATED");
+    expect(readyLines[0]!).toContain("ALWAYS-HUMAN");
+    // F-4.1 — the forge executor seam is not yet wired.
+    expect(readyLines[0]!).toContain("executor=none");
+
+    // Exactly one subscribePull, on the canonical release subject + durable.
+    const releaseCalls = runtime.subscribePullCalls.filter((c) =>
+      c.pattern.includes("tasks.release.cut"),
+    );
+    expect(releaseCalls.length).toBe(1);
+    expect(releaseCalls[0]!.pattern).toBe(
+      "local.test-op.default.tasks.release.cut",
+    );
+    expect(releaseCalls[0]!.durable).toBe(
+      "cortex-release-consumer-test-op-forge",
+    );
+    expect(releaseCalls[0]!.stream).toBe("RELEASE");
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("HARD CONTRACT — zero release-capable agents → byte-identical boot: NO release subscribePull, NO release log line", async () => {
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-relboot-zero-"));
+    // A roster with reviewers but no release-capable agent. The release block
+    // must add ZERO behaviour: no subscribePull on a release subject, and no
+    // release-lane log line at all (NOT even a "skipped" message — release is
+    // opt-in, unlike review's always-on first-install warning).
+    const inlineAgents: Agent[] = [
+      makeAgent("echo", ["code-review.typescript"]),
+      makeAgent("luna", undefined),
+      makeAgent("holly", ["research.web"]),
+    ];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: "test-op" },
+      }),
+    );
+
+    // No release subject was ever subscribed.
+    const releaseCalls = runtime.subscribePullCalls.filter((c) =>
+      c.pattern.includes("release"),
+    );
+    expect(releaseCalls.length).toBe(0);
+
+    // No release-lane log line — neither "ready", "DORMANT", nor any "release
+    // consumer" / "RELEASE" stream provisioning line. The block is fully gated.
+    const releaseLines = logs.filter(
+      (l) =>
+        l.includes("release consumer") ||
+        l.includes('stream "RELEASE"') ||
+        l.includes("release-consumer"),
+    );
+    expect(releaseLines).toEqual([]);
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("generic `release` capability also wires a consumer", async () => {
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-relboot-generic-"));
+    const inlineAgents: Agent[] = [makeAgent("forge", ["release"])];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: "test-op" },
+      }),
+    );
+
+    const readyLines = logs.filter((l) =>
+      l.includes("cortex: release consumer ready"),
+    );
+    expect(readyLines.length).toBe(1);
+    expect(
+      runtime.subscribePullCalls.filter((c) =>
+        c.pattern.includes("tasks.release.cut"),
+      ).length,
+    ).toBe(1);
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("dormant subscribePull (returns null) → DORMANT log, not ready", async () => {
+    const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+    const published: Envelope[] = [];
+    const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+    const dormantRuntime: RecordingRuntime = {
+      enabled: false,
+      onEnvelopeHandlers,
+      published,
+      subscribePullCalls,
+      onEnvelope(handler) {
+        onEnvelopeHandlers.add(handler);
+        return {
+          unregister: () => {
+            onEnvelopeHandlers.delete(handler);
+          },
+        };
+      },
+      publish: async (envelope: Envelope) => {
+        published.push(envelope);
+      },
+      subscribePull: (opts: MyelinSubscribePullOpts) => {
+        subscribePullCalls.push(opts);
+        return null;
+      },
+      stop: async () => {},
+    };
+
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-relboot-dormant-"));
+    const inlineAgents: Agent[] = [makeAgent("forge", ["release.cut"])];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: dormantRuntime,
+        inlineAgents,
+        principal: { id: "test-op" },
+      }),
+    );
+
+    const dormantLines = logs.filter((l) =>
+      l.includes("cortex: release consumer DORMANT"),
+    );
+    expect(dormantLines.length).toBe(1);
+    expect(dormantLines[0]!).toContain("agent=forge");
+    expect(dormantLines[0]!).toContain("G-1111 pending");
+
+    const readyLines = logs.filter((l) =>
+      l.includes("cortex: release consumer ready"),
+    );
+    expect(readyLines.length).toBe(0);
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("one consumer init throws → siblings still wire; boot completes; stderr logged with failing agent id", async () => {
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-relboot-throw-"));
+    const forgeAgent = makeAgent("forge", ["release.cut"]);
+    const sageAgent = makeAgent("sage", ["release.cut"]);
+
+    // Poison ONLY `maxConcurrent` (the filter reads `capabilities` only, so
+    // forge passes the filter; the per-iteration try/catch reads
+    // `maxConcurrent` to build consumerAgent — that read throws).
+    Object.defineProperty(forgeAgent.runtime!, "maxConcurrent", {
+      get: () => {
+        throw new Error("synthetic maxConcurrent-access failure");
+      },
+      configurable: true,
+    });
+
+    const { result: bootResult, stderr } = await withCapturedStderr(() =>
+      withCapturedConsoleLog(() =>
+        startCortex(minimalConfig(), {
+          disableConfigWatcher: true,
+          disableDashboard: true,
+          disableOutboundPoller: true,
+          agentsDir: tmpAgentsDir,
+          injectRuntime: runtime,
+          inlineAgents: [forgeAgent, sageAgent],
+          principal: { id: "test-op" },
+        }),
+      ),
+    );
+    const { result: handle, logs } = bootResult;
+
+    expect(handle).toBeDefined();
+    expect(stderr).toContain("release consumer init failed");
+    expect(stderr).toContain("agent=forge");
+    expect(stderr).toContain("synthetic maxConcurrent-access failure");
+
+    // Sage wired successfully despite forge's failure.
+    const sageReady = logs.find(
+      (l) => l.includes("release consumer ready") && l.includes("agent=sage"),
+    );
+    expect(sageReady).toBeDefined();
+
+    // Exactly one subscribePull (sage only).
+    const releaseCalls = runtime.subscribePullCalls.filter((c) =>
+      c.pattern.includes("tasks.release.cut"),
+    );
+    expect(releaseCalls.length).toBe(1);
+    expect(releaseCalls[0]!.durable).toBe(
+      "cortex-release-consumer-test-op-sage",
+    );
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+});

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -60,6 +60,10 @@ import {
   type SignatureVerifier,
 } from "./bus/review-consumer";
 import {
+  ReleaseConsumer,
+  type ReleaseConsumerAgent,
+} from "./runner/release-consumer";
+import {
   provisionReviewStream,
   provisionReviewConsumer,
 } from "./bus/jetstream/provision";
@@ -1503,6 +1507,158 @@ export async function startCortex(
     );
   }
 
+  // cortex#835 F-4.1 — release-consumer boot wiring (the `release.cut` gated
+  // capability). Mirrors the review-consumer block above: for each agent that
+  // declares `release.cut` (or the generic `release`) capability, instantiate a
+  // dedicated `ReleaseConsumer` and drive it through `start()` so it subscribes
+  // to the JetStream `local.{principal}.{stack}.tasks.release.cut` pull
+  // consumer.
+  //
+  // **HARD CONTRACT — byte-identical boot when no agent declares the capability.**
+  // The ENTIRE block (filter, array, stream/consumer provisioning, log lines) is
+  // gated behind `releaseCapableAgents.length > 0`. A roster with no
+  // release-capable agent adds ZERO new boot behaviour — no stream provisioned,
+  // no log line, no JSM round-trip — so the release lane is DORMANT-by-default
+  // and a stack that never opts into `release.cut` boots exactly as before this
+  // PR landed. (This differs from review-consumer's always-run "skipped" warning
+  // because release is an opt-in authority, not a default expectation.)
+  //
+  // **Executor seam — F-4.1 ships the consumer WITHOUT a production executor.**
+  // The consumer is constructed with no `executor`, so it operates
+  // dormant-but-present: it claims the capability on the bus + runs the full
+  // grant/precondition gate ladder, but every granted-and-gated claim terminates
+  // `cant_do: no release executor configured` until the real git/gh executor is
+  // wired (a follow-up slice — see the PR's Flags section). This keeps F-4.1 the
+  // gate + lifecycle + capability-declaration slice, with the side-effecting
+  // forge/command seam deferred behind the SAME `ReleaseExecutor` interface the
+  // tests already drive.
+  const releaseConsumers: ReleaseConsumer[] = [];
+  const releaseCapableAgents = mergedAgents.filter((a) => {
+    const caps = a.runtime?.capabilities ?? [];
+    return caps.some((c) => c === "release" || c === "release.cut");
+  });
+  if (releaseCapableAgents.length > 0) {
+    // Durable name convention mirrors the review lane:
+    // `cortex-release-consumer-{principal}-{agent}` — unique per (principal,
+    // agent) so dev + prod instances on the same principal share competing-
+    // consumer semantics and a restart resumes from the same offset.
+    const releaseSubjectPattern = `local.${principalId}.${derivedStack.stack}.tasks.release.cut`;
+    const releaseStream = "RELEASE";
+    // Reuse the review-lane stream defaults: a release-cut request is small +
+    // infrequent; 24h retention + 512MiB is ample and matches the operational
+    // posture principals already understand from CODE_REVIEW.
+    const releaseStreamMaxAgeNs = 86_400 * 1_000_000_000;
+    const releaseStreamMaxBytes = 512 * 1024 * 1024;
+    const releaseConsumerMaxDeliver = 5;
+
+    // Resolve the provisioning JSM once (same contained-failure contract as the
+    // review lane's `resolveReviewProvisioningJsm`): a dormant runtime → null →
+    // provisioning skipped + the consumer stays dormant in lockstep.
+    const releaseJsm = await resolveReviewProvisioningJsm(
+      runtime,
+      releaseCapableAgents,
+    );
+
+    if (releaseJsm !== null) {
+      try {
+        const outcome = await provisionReviewStream({
+          jsm: releaseJsm,
+          name: releaseStream,
+          subjects: [releaseSubjectPattern],
+          maxAgeNs: releaseStreamMaxAgeNs,
+          maxBytes: releaseStreamMaxBytes,
+        });
+        if (outcome === "created") {
+          console.log(
+            `cortex: provisioned JetStream stream "${releaseStream}" (subjects=[${releaseSubjectPattern}])`,
+          );
+        } else if (outcome === "exists") {
+          console.log(
+            `cortex: JetStream stream "${releaseStream}" already present — binding existing config`,
+          );
+        }
+      } catch (err) {
+        process.stderr.write(
+          `cortex: provisionReviewStream failed for "${releaseStream}": ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+
+    for (const agent of releaseCapableAgents) {
+      try {
+        const caps = agent.runtime?.capabilities ?? [];
+        const consumerAgent: ReleaseConsumerAgent = {
+          id: agent.id,
+          capabilities: caps,
+          ...(agent.runtime?.maxConcurrent !== undefined && {
+            maxConcurrent: agent.runtime.maxConcurrent,
+          }),
+        };
+        // F-4.1 — no executor wired yet (see block header). The consumer is
+        // dormant-but-present: capability declared + gate ladder live.
+        const consumer = new ReleaseConsumer({
+          agent: consumerAgent,
+          source: systemEventSource,
+          runtime,
+        });
+        releaseConsumers.push(consumer);
+
+        const durable = `cortex-release-consumer-${principalId}-${agent.id}`;
+        if (releaseJsm !== null) {
+          try {
+            const outcome = await provisionReviewConsumer({
+              jsm: releaseJsm,
+              stream: releaseStream,
+              durable,
+              maxDeliver: releaseConsumerMaxDeliver,
+            });
+            if (outcome === "created") {
+              console.log(
+                `cortex: provisioned JetStream durable "${durable}" on stream "${releaseStream}"`,
+              );
+            } else if (outcome === "updated") {
+              console.log(
+                `cortex: reconciled JetStream durable "${durable}" on stream "${releaseStream}"`,
+              );
+            }
+          } catch (provisionErr) {
+            process.stderr.write(
+              `cortex: provisionReviewConsumer failed for "${durable}": ` +
+                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+            );
+          }
+        }
+
+        const started = await consumer.start({
+          pattern: releaseSubjectPattern,
+          stream: releaseStream,
+          durable,
+        });
+        // F-4.1 — log line flags `executor=none` so a principal grepping boot
+        // can see the lane is declared but the forge seam is not yet wired.
+        if (started.subscribed) {
+          console.log(
+            `cortex: release consumer ready for agent=${agent.id} capability=release.cut executor=none (gated; principal-grant required) — PRINCIPAL-GATED, ALWAYS-HUMAN`,
+          );
+        } else {
+          console.log(
+            `cortex: release consumer DORMANT for agent=${agent.id} capability=release.cut executor=none — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.release.cut envelopes will not be claimed by this consumer)`,
+          );
+        }
+      } catch (err) {
+        // Per CLAUDE.md "no empty catch blocks": a single agent's release
+        // consumer crash does NOT abort boot — siblings still wire. The
+        // consumer stays in `releaseConsumers[]` so the shutdown drain still
+        // calls `.stop()` (idempotent — handles the "never subscribed" case).
+        process.stderr.write(
+          `cortex: release consumer init failed for agent=${agent.id}: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+  }
+
   // IAW Phase B.2a (refs cortex#114) — inbound peer-dispatch listener.
   // Subscribes via the runtime's onEnvelope fan-out, filters for
   // `dispatch.task.dispatched` envelopes from non-self sources, runs
@@ -2891,6 +3047,7 @@ export async function startCortex(
       "github webhook receiver stop",
       ...adapterCleanup.map((_, i) => `outbound poller stop[${i}]`),
       ...reviewConsumers.map((c, i) => `review-consumer stop[${i}] (agent=${c.agent.id})`),
+      ...releaseConsumers.map((c, i) => `release-consumer stop[${i}] (agent=${c.agent.id})`),
       "dispatch-listener stop",
       "dispatch-sink stop",
       "review-sink stop",
@@ -2949,6 +3106,19 @@ export async function startCortex(
         if (consumer) {
           await completeAsync(
             `review-consumer stop[${i}] (agent=${consumer.agent.id})`,
+            consumer.stop(),
+          );
+        }
+      }
+      // cortex#835 F-4.1 — drain release consumers on the same boundary as the
+      // review consumers (and before the dispatch listener) so any in-flight
+      // release cut publishes its terminal envelope before the runtime closes.
+      // `ReleaseConsumer.stop()` is idempotent (no-op when never subscribed).
+      for (let i = 0; i < releaseConsumers.length; i++) {
+        const consumer = releaseConsumers[i];
+        if (consumer) {
+          await completeAsync(
+            `release-consumer stop[${i}] (agent=${consumer.agent.id})`,
             consumer.stop(),
           );
         }

--- a/src/runner/__tests__/release-consumer.test.ts
+++ b/src/runner/__tests__/release-consumer.test.ts
@@ -324,6 +324,62 @@ describe("ReleaseConsumer — the principal-grant gate (§3.5 ALWAYS-HUMAN)", ()
     const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
     expect(reason?.kind).toBe("wont_do");
   });
+
+  // BLOCKER (mellanon review, cortex#874): a whitespace-only `approved_by`
+  // ("   ", length 3 > 0) must NOT pass the gate. The parser trims-before-
+  // non-empty so it never reaches the gate as present, and the gate ALSO trims
+  // (belt-and-suspenders) so a blank grant can never invoke the executor.
+  test("whitespace-only approved_by ('   ') is treated as ABSENT → wont_do + term; executor NEVER runs", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor();
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest({ approved_by: "   " }),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+
+    expect(decision.kind).toBe("term");
+    expect((decision as { reason: string }).reason).toContain("release gate is principal-held");
+
+    // Fail-closed: a whitespace-only grant must never reach the executor.
+    expect(executor.calls).toEqual([]);
+
+    // No started; a wont_do failed envelope was published.
+    expect(envelopesOfType(runtime, "dispatch.task.started").length).toBe(0);
+    const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
+    expect(reason?.kind).toBe("wont_do");
+  });
+
+  // MAJOR (mellanon review, cortex#874): the trust model is PRESENCE-ONLY, not
+  // authenticated. `approved_by` is whatever the envelope says — any principal
+  // who can publish to the gate's subject can stamp `approved_by: "andreas"`
+  // with no cryptographic proof. Authenticity rests on the NATS account layer
+  // controlling publish rights to `local.{principal}.{stack}.tasks.release.cut`.
+  // This test makes the presence-only model explicit: an UNRELATED principal's
+  // name in `approved_by` is accepted as a grant by the consumer (the consumer
+  // cannot tell — that is the documented v1 assumption; cryptographic proof is
+  // the cortex trust track TC-0/1/2).
+  test("TRUST MODEL is presence-only: any non-blank approved_by is accepted as a grant (NOT cryptographically verified)", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor();
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    // An attacker-controlled value the consumer has no way to authenticate.
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest({ approved_by: "not-the-real-principal" }),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+
+    // The gate PASSES on presence alone — the consumer cannot prove authenticity.
+    expect(decision.kind).not.toBe("term");
+    expect(envelopesOfType(runtime, "dispatch.task.started").length).toBe(1);
+    // The executor ran through to the mutating cutRelease — the unauthenticated
+    // grant was accepted because the consumer has no way to verify it.
+    expect(executor.calls).toContain("cutRelease");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -690,6 +746,16 @@ describe("ReleaseConsumer — helper units", () => {
   test("parseReleaseRequestPayload — empty approved_by collapses to absent", () => {
     const p = parseReleaseRequestPayload(makeReleaseRequest({ approved_by: "" }));
     expect(p?.approvedBy).toBeUndefined();
+  });
+
+  // BLOCKER (mellanon review, cortex#874): the parser trims BEFORE the non-empty
+  // test, so a whitespace-only grant ("   ", "\t", "\n") parses as ABSENT and the
+  // §3.5 gate refuses it — it can never reach the executor as a present grant.
+  test("parseReleaseRequestPayload — whitespace-only approved_by collapses to absent", () => {
+    for (const ws of ["   ", "\t", "\n", " \t\n "]) {
+      const p = parseReleaseRequestPayload(makeReleaseRequest({ approved_by: ws }));
+      expect(p?.approvedBy).toBeUndefined();
+    }
   });
 
   test("parseReleaseRequestPayload — bad repo / bad bump → null", () => {

--- a/src/runner/__tests__/release-consumer.test.ts
+++ b/src/runner/__tests__/release-consumer.test.ts
@@ -1,0 +1,722 @@
+/**
+ * cortex#835 F-4.1 — tests for `release-consumer.ts`.
+ *
+ * Mirrors the `review-consumer.test.ts` coverage axes for the release lane:
+ *
+ *   1. Happy path — granted, well-formed claim, all preconditions pass →
+ *      executor cuts the release → `dispatch.task.completed` published
+ *      (carrying version + URL) + AckDecision is `{ kind: "ack" }`.
+ *   2. THE GRANT GATE — well-formed claim with NO principal-grant marker
+ *      (`payload.approved_by` absent / empty) → `wont_do` failed envelope
+ *      ("release gate is principal-held") + AckDecision `{ kind: "term" }`,
+ *      and the executor is NEVER invoked (fail-closed).
+ *   3. Non-release subject → `cant_do` + term.
+ *   4. Bad payload (missing repo / bad bump) → `cant_do` + term.
+ *   5. No capability match → `cant_do` + term.
+ *   6. Precondition failures (each named): dirty branch / red checks / no
+ *      manifest → `cant_do` ("precondition <name>: …") + term; mutation
+ *      (`cutRelease`) is NEVER invoked.
+ *   7. Backpressure — release lane serialised (default maxConcurrent 1): a
+ *      second concurrent granted claim → `not_now` + nak.
+ *   8. Executor throws unexpectedly → defensive `not_now` + nak(0).
+ *   9. Redelivery > 1 → ALSO emits `dispatch.task.aborted`.
+ *  10. correlation_id contract — request envelope.id === every emitted
+ *      envelope's correlation_id (the load-bearing reactor contract).
+ *  11. Dormancy — no executor configured → `cant_do` ("no release executor")
+ *      + term; AND `start()` against a disabled runtime → `subscribed: false`.
+ *  12. The ack-table helper + payload parser unit cases.
+ *
+ * No real NATS, no real git/gh. All side effects flow through the recording
+ * runtime's `published[]` array and the recording executor's call log.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../../bus/myelin/runtime";
+import type { AckDecision } from "../../bus/myelin/subscriber";
+import type { DispatchEventSource, DispatchTaskFailedReason } from "../../bus/dispatch-events";
+import {
+  ReleaseConsumer,
+  RELEASE_LANE_MAX_CONCURRENT,
+  isReleaseCutEnvelope,
+  parseReleaseRequestPayload,
+  releaseFailedReasonToAckDecision,
+  type ReleaseConsumerAgent,
+  type ReleaseExecutor,
+  type DefaultBranchStatus,
+  type ChecksStatus,
+  type VersionManifest,
+  type ReleaseCutResult,
+} from "../release-consumer";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SOURCE: DispatchEventSource = {
+  principal: "andreas",
+  agent: "forge",
+  instance: "local",
+};
+
+const FIXED_CLOCK = () => new Date("2026-06-10T00:00:00.000Z");
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+  publishOutcomes: { ok: boolean; error?: Error }[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const published: Envelope[] = [];
+  const publishOutcomes: { ok: boolean; error?: Error }[] = [];
+  let publishCallIndex = 0;
+  const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+  return {
+    enabled: false,
+    published,
+    publishOutcomes,
+    onEnvelope(handler) {
+      onEnvelopeHandlers.add(handler);
+      return {
+        unregister: () => {
+          onEnvelopeHandlers.delete(handler);
+        },
+      };
+    },
+    publish: async (envelope: Envelope) => {
+      const idx = publishCallIndex++;
+      const outcome = publishOutcomes[idx];
+      if (outcome && !outcome.ok) {
+        throw outcome.error ?? new Error("publish failed");
+      }
+      published.push(envelope);
+    },
+    stop: async () => {},
+  };
+}
+
+function buildAgent(
+  overrides: Partial<ReleaseConsumerAgent> = {},
+): ReleaseConsumerAgent {
+  return {
+    id: "forge",
+    capabilities: ["release.cut"],
+    ...overrides,
+  };
+}
+
+/** A `tasks.release.cut` request envelope (the wire payload uses snake_case). */
+function makeReleaseRequest(
+  payload: Record<string, unknown> = {},
+): Envelope {
+  return {
+    id: crypto.randomUUID(),
+    source: `${SOURCE.principal}.work.${SOURCE.agent}`,
+    type: "tasks.release.cut",
+    timestamp: "2026-06-10T00:00:00.000Z",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: {
+      repo: "the-metafactory/cortex",
+      bump: "patch",
+      ...payload,
+    },
+  };
+}
+
+/**
+ * A recording executor whose every method is overridable per test. Defaults
+ * are the all-green happy path; tests override one seam to drive a failure.
+ */
+interface RecordingExecutor extends ReleaseExecutor {
+  calls: string[];
+}
+
+function createRecordingExecutor(
+  overrides: Partial<ReleaseExecutor> = {},
+): RecordingExecutor {
+  const calls: string[] = [];
+  const defaults: ReleaseExecutor = {
+    getDefaultBranchStatus: async (): Promise<DefaultBranchStatus> => ({
+      branch: "main",
+      clean: true,
+    }),
+    getChecksStatus: async (): Promise<ChecksStatus> => ({ allGreen: true }),
+    locateVersionManifest: async (): Promise<VersionManifest | null> => ({
+      path: "arc-manifest.yaml",
+      currentVersion: "5.5.0",
+    }),
+    cutRelease: async (): Promise<ReleaseCutResult> => ({
+      version: "v5.5.1",
+      releaseUrl: "https://github.com/the-metafactory/cortex/releases/tag/v5.5.1",
+    }),
+  };
+  return {
+    calls,
+    getDefaultBranchStatus: async (repo) => {
+      calls.push("getDefaultBranchStatus");
+      return (overrides.getDefaultBranchStatus ?? defaults.getDefaultBranchStatus)(repo);
+    },
+    getChecksStatus: async (repo) => {
+      calls.push("getChecksStatus");
+      return (overrides.getChecksStatus ?? defaults.getChecksStatus)(repo);
+    },
+    locateVersionManifest: async (repo) => {
+      calls.push("locateVersionManifest");
+      return (overrides.locateVersionManifest ?? defaults.locateVersionManifest)(repo);
+    },
+    cutRelease: async (input) => {
+      calls.push("cutRelease");
+      return (overrides.cutRelease ?? defaults.cutRelease)(input);
+    },
+  };
+}
+
+function makeConsumer(
+  agent: ReleaseConsumerAgent,
+  runtime: RecordingRuntime,
+  executor?: ReleaseExecutor,
+): ReleaseConsumer {
+  return new ReleaseConsumer({
+    agent,
+    source: SOURCE,
+    runtime,
+    ...(executor !== undefined && { executor }),
+    clock: FIXED_CLOCK,
+  });
+}
+
+/** The grant marker every "happy" test stamps. */
+const GRANTED = { approved_by: "andreas" };
+
+// ---------------------------------------------------------------------------
+// Helpers for assertions
+// ---------------------------------------------------------------------------
+
+function envelopesOfType(runtime: RecordingRuntime, type: string): Envelope[] {
+  return runtime.published.filter((e) => e.type === type);
+}
+
+function failedReason(env: Envelope): DispatchTaskFailedReason | undefined {
+  const p = env.payload as { reason?: DispatchTaskFailedReason };
+  return p.reason;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy path
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — happy path", () => {
+  test("granted + all preconditions green → cutRelease runs, completed published, ack", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor();
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const req = makeReleaseRequest(GRANTED);
+    const decision = await consumer.processEnvelope(req, "local.andreas.work.tasks.release.cut", null);
+
+    expect(decision).toEqual({ kind: "ack" });
+
+    // Preconditions verified, then the single mutating call.
+    expect(executor.calls).toEqual([
+      "getDefaultBranchStatus",
+      "getChecksStatus",
+      "locateVersionManifest",
+      "cutRelease",
+    ]);
+
+    // started then completed (in order), no failed.
+    const started = envelopesOfType(runtime, "dispatch.task.started");
+    const completed = envelopesOfType(runtime, "dispatch.task.completed");
+    const failed = envelopesOfType(runtime, "dispatch.task.failed");
+    expect(started.length).toBe(1);
+    expect(completed.length).toBe(1);
+    expect(failed.length).toBe(0);
+
+    // Completed carries the version + URL.
+    const cp = completed[0]!.payload;
+    expect(String(cp.result_summary)).toContain("v5.5.1");
+    expect(cp.chat_response).toBe(
+      "https://github.com/the-metafactory/cortex/releases/tag/v5.5.1",
+    );
+  });
+
+  test("cutRelease receives the located manifest, branch, bump, and grant", async () => {
+    const runtime = createRecordingRuntime();
+    let captured: Parameters<ReleaseExecutor["cutRelease"]>[0] | undefined;
+    const executor = createRecordingExecutor({
+      cutRelease: async (input) => {
+        captured = input;
+        return {
+          version: "v6.0.0",
+          releaseUrl: "https://example.test/r",
+        };
+      },
+    });
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    await consumer.processEnvelope(
+      makeReleaseRequest({ ...GRANTED, bump: "major", refs: ["cortex#835"] }),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+
+    expect(captured).toBeDefined();
+    expect(captured!.repo).toBe("the-metafactory/cortex");
+    expect(captured!.bump).toBe("major");
+    expect(captured!.branch).toBe("main");
+    expect(captured!.approvedBy).toBe("andreas");
+    expect(captured!.manifest.currentVersion).toBe("5.5.0");
+    expect(captured!.refs).toEqual(["cortex#835"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. THE GRANT GATE — the load-bearing ALWAYS-HUMAN contract
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — the principal-grant gate (§3.5 ALWAYS-HUMAN)", () => {
+  test("no approved_by marker → wont_do (release gate is principal-held) + term; executor NEVER runs", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor();
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(), // no approved_by
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+
+    expect(decision.kind).toBe("term");
+    expect((decision as { reason: string }).reason).toContain("release gate is principal-held");
+
+    // Fail-closed: the executor is never touched on an ungranted claim.
+    expect(executor.calls).toEqual([]);
+
+    // A failed envelope with a wont_do reason was published; NO started.
+    expect(envelopesOfType(runtime, "dispatch.task.started").length).toBe(0);
+    const failed = envelopesOfType(runtime, "dispatch.task.failed");
+    expect(failed.length).toBe(1);
+    const reason = failedReason(failed[0]!);
+    expect(reason?.kind).toBe("wont_do");
+    expect((reason as { detail: string }).detail).toContain("principal-held");
+    expect((reason as { detail: string }).detail).toContain("approved_by");
+  });
+
+  test("empty-string approved_by is treated as ABSENT → still refused", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor();
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest({ approved_by: "" }),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+
+    expect(decision.kind).toBe("term");
+    expect(executor.calls).toEqual([]);
+    const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
+    expect(reason?.kind).toBe("wont_do");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3–5. Routing / shape failures (cant_do + term)
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — routing + shape failures", () => {
+  test("non-release subject → cant_do + term", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = makeConsumer(buildAgent(), runtime, createRecordingExecutor());
+    const env = makeReleaseRequest(GRANTED);
+    env.type = "tasks.code-review.typescript"; // not release.cut
+
+    const decision = await consumer.processEnvelope(env, "local.andreas.work.tasks.code-review.typescript", null);
+    expect(decision.kind).toBe("term");
+    const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
+    expect(reason?.kind).toBe("cant_do");
+  });
+
+  test("bad payload (missing repo) → cant_do + term", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = makeConsumer(buildAgent(), runtime, createRecordingExecutor());
+    const env = makeReleaseRequest(GRANTED);
+    delete env.payload.repo;
+
+    const decision = await consumer.processEnvelope(env, "local.andreas.work.tasks.release.cut", null);
+    expect(decision.kind).toBe("term");
+    const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
+    expect(reason?.kind).toBe("cant_do");
+    expect((reason as { detail: string }).detail).toContain("payload validation");
+  });
+
+  test("bad payload (invalid bump) → cant_do + term", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = makeConsumer(buildAgent(), runtime, createRecordingExecutor());
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest({ ...GRANTED, bump: "huge" }),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(decision.kind).toBe("term");
+    expect(failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!)?.kind).toBe("cant_do");
+  });
+
+  test("agent does not claim release.cut → cant_do + term", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = makeConsumer(
+      buildAgent({ capabilities: ["code-review.typescript"] }),
+      runtime,
+      createRecordingExecutor(),
+    );
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(decision.kind).toBe("term");
+    const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
+    expect(reason?.kind).toBe("cant_do");
+    expect((reason as { detail: string }).detail).toContain("does not claim release.cut");
+  });
+
+  test("generic `release` capability also claims a release.cut request", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor();
+    const consumer = makeConsumer(
+      buildAgent({ capabilities: ["release"] }),
+      runtime,
+      executor,
+    );
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(decision).toEqual({ kind: "ack" });
+    expect(executor.calls).toContain("cutRelease");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Precondition failures (each named; mutation never runs)
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — precondition gates (release-checklist.md Phase 1)", () => {
+  test("dirty default branch → cant_do (precondition dirty_default_branch) + term; no cutRelease", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor({
+      getDefaultBranchStatus: async () => ({ branch: "main", clean: false }),
+    });
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(decision.kind).toBe("term");
+    expect((decision as { reason: string }).reason).toContain("dirty_default_branch");
+    expect(executor.calls).not.toContain("cutRelease");
+    const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
+    expect(reason?.kind).toBe("cant_do");
+    expect((reason as { detail: string }).detail).toContain("dirty_default_branch");
+  });
+
+  test("checks not green → cant_do (precondition checks_not_green) + term; no cutRelease", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor({
+      getChecksStatus: async () => ({ allGreen: false, summary: "tsc failing" }),
+    });
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(decision.kind).toBe("term");
+    expect((decision as { reason: string }).reason).toContain("checks_not_green");
+    expect(executor.calls).not.toContain("cutRelease");
+    const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
+    expect((reason as { detail: string }).detail).toContain("tsc failing");
+  });
+
+  test("manifest not found → cant_do (precondition manifest_not_found) + term; no cutRelease", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor({
+      locateVersionManifest: async () => null,
+    });
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(decision.kind).toBe("term");
+    expect((decision as { reason: string }).reason).toContain("manifest_not_found");
+    expect(executor.calls).not.toContain("cutRelease");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Backpressure — release lane serialised (default maxConcurrent 1)
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — concurrency (serialised release lane)", () => {
+  test("default maxConcurrent is 1 even when agent omits it", () => {
+    const consumer = makeConsumer(buildAgent(), createRecordingRuntime(), createRecordingExecutor());
+    expect(consumer.maxConcurrent).toBe(RELEASE_LANE_MAX_CONCURRENT);
+    expect(consumer.maxConcurrent).toBe(1);
+  });
+
+  test("second concurrent granted claim while one is in flight → not_now + nak", async () => {
+    const runtime = createRecordingRuntime();
+    // Gate the first cut so it stays in flight while the second arrives.
+    let releaseFirst: () => void = () => {};
+    const firstHeld = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const executor = createRecordingExecutor({
+      cutRelease: async () => {
+        await firstHeld;
+        return { version: "v5.5.1", releaseUrl: "https://example.test/r" };
+      },
+    });
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const first = consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    // Let the first reach the in-flight set + the cutRelease await.
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 5));
+
+    const secondDecision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(secondDecision.kind).toBe("nak");
+    expect((secondDecision as { delayMs: number }).delayMs).toBe(1000);
+    const failed = envelopesOfType(runtime, "dispatch.task.failed");
+    expect(failedReason(failed[failed.length - 1]!)?.kind).toBe("not_now");
+
+    releaseFirst();
+    expect((await first).kind).toBe("ack");
+  });
+
+  test("after a cut completes the counter decrements so the next claim admits", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor();
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const d1 = await consumer.processEnvelope(makeReleaseRequest(GRANTED), "s", null);
+    const d2 = await consumer.processEnvelope(makeReleaseRequest(GRANTED), "s", null);
+    expect(d1).toEqual({ kind: "ack" });
+    expect(d2).toEqual({ kind: "ack" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Defensive executor throw
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — defensive executor throw", () => {
+  test("executor throws → not_now + nak(0)", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor({
+      cutRelease: async () => {
+        throw new Error("gh exploded");
+      },
+    });
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(decision).toEqual({ kind: "nak", delayMs: 0 });
+    const failed = envelopesOfType(runtime, "dispatch.task.failed");
+    const reason = failedReason(failed[failed.length - 1]!);
+    expect(reason?.kind).toBe("not_now");
+    expect((reason as { detail: string }).detail).toContain("gh exploded");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Redelivery
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — redelivery", () => {
+  test("redelivery > 1 → emits dispatch.task.aborted in addition to the terminal", async () => {
+    const runtime = createRecordingRuntime();
+    const executor = createRecordingExecutor();
+    const consumer = makeConsumer(buildAgent(), runtime, executor);
+
+    const msg = { redelivered: true, info: { redeliveryCount: 2 } } as unknown as import("nats").JsMsg;
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      msg,
+    );
+    expect(decision).toEqual({ kind: "ack" });
+    expect(envelopesOfType(runtime, "dispatch.task.aborted").length).toBe(1);
+    expect(envelopesOfType(runtime, "dispatch.task.completed").length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. correlation_id contract
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — correlation_id contract", () => {
+  test("every emitted envelope echoes request.id as correlation_id (happy path)", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = makeConsumer(buildAgent(), runtime, createRecordingExecutor());
+    const req = makeReleaseRequest(GRANTED);
+
+    await consumer.processEnvelope(req, "local.andreas.work.tasks.release.cut", null);
+    expect(runtime.published.length).toBeGreaterThan(0);
+    for (const env of runtime.published) {
+      expect(env.correlation_id).toBe(req.id);
+    }
+  });
+
+  test("failed (grant-gate) envelope echoes request.id as correlation_id", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = makeConsumer(buildAgent(), runtime, createRecordingExecutor());
+    const req = makeReleaseRequest(); // ungranted
+
+    await consumer.processEnvelope(req, "local.andreas.work.tasks.release.cut", null);
+    const failed = envelopesOfType(runtime, "dispatch.task.failed");
+    expect(failed[0]!.correlation_id).toBe(req.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. Dormancy
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — dormancy", () => {
+  test("no executor configured → cant_do (no release executor) + term", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = makeConsumer(buildAgent(), runtime, undefined);
+
+    const decision = await consumer.processEnvelope(
+      makeReleaseRequest(GRANTED),
+      "local.andreas.work.tasks.release.cut",
+      null,
+    );
+    expect(decision.kind).toBe("term");
+    const reason = failedReason(envelopesOfType(runtime, "dispatch.task.failed")[0]!);
+    expect(reason?.kind).toBe("cant_do");
+    expect((reason as { detail: string }).detail).toContain("no release executor");
+  });
+
+  test("start() against a runtime with no subscribePull → subscribed: false (dormant)", async () => {
+    const runtime = createRecordingRuntime(); // no subscribePull helper
+    const consumer = makeConsumer(buildAgent(), runtime, createRecordingExecutor());
+
+    const info = await consumer.start({
+      pattern: "local.andreas.work.tasks.release.cut",
+      stream: "RELEASE",
+      durable: "cortex-release-consumer-andreas-forge",
+    });
+    expect(info).toEqual({ agentId: "forge", subscribed: false });
+  });
+
+  test("start() against a runtime whose subscribePull returns null → subscribed: false", async () => {
+    const runtime = createRecordingRuntime();
+    (runtime as MyelinRuntime & { subscribePull: unknown }).subscribePull = () => null;
+    const consumer = makeConsumer(buildAgent(), runtime, createRecordingExecutor());
+
+    const info = await consumer.start({
+      pattern: "local.andreas.work.tasks.release.cut",
+      stream: "RELEASE",
+      durable: "cortex-release-consumer-andreas-forge",
+    });
+    expect(info.subscribed).toBe(false);
+  });
+
+  test("stop() is idempotent and drains cleanly with no in-flight", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = makeConsumer(buildAgent(), runtime, createRecordingExecutor());
+    await consumer.stop();
+    await consumer.stop(); // second call resolves the same promise
+    expect(true).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. Unit helpers
+// ---------------------------------------------------------------------------
+
+describe("ReleaseConsumer — helper units", () => {
+  test("isReleaseCutEnvelope", () => {
+    expect(isReleaseCutEnvelope(makeReleaseRequest())).toBe(true);
+    const other = makeReleaseRequest();
+    other.type = "tasks.release.cutx";
+    expect(isReleaseCutEnvelope(other)).toBe(false);
+  });
+
+  test("parseReleaseRequestPayload — valid granted", () => {
+    const p = parseReleaseRequestPayload(
+      makeReleaseRequest({ approved_by: "andreas", refs: ["a", "b"] }),
+    );
+    expect(p).toEqual({
+      repo: "the-metafactory/cortex",
+      bump: "patch",
+      approvedBy: "andreas",
+      refs: ["a", "b"],
+    });
+  });
+
+  test("parseReleaseRequestPayload — valid ungranted (grant absent, NOT a parse failure)", () => {
+    const p = parseReleaseRequestPayload(makeReleaseRequest());
+    expect(p).toEqual({ repo: "the-metafactory/cortex", bump: "patch" });
+  });
+
+  test("parseReleaseRequestPayload — empty approved_by collapses to absent", () => {
+    const p = parseReleaseRequestPayload(makeReleaseRequest({ approved_by: "" }));
+    expect(p?.approvedBy).toBeUndefined();
+  });
+
+  test("parseReleaseRequestPayload — bad repo / bad bump → null", () => {
+    const bad1 = makeReleaseRequest();
+    bad1.payload.repo = "no-slash";
+    expect(parseReleaseRequestPayload(bad1)).toBeNull();
+
+    const bad2 = makeReleaseRequest({ bump: "nope" });
+    expect(parseReleaseRequestPayload(bad2)).toBeNull();
+  });
+
+  test("releaseFailedReasonToAckDecision — the four-way taxonomy", () => {
+    expect(releaseFailedReasonToAckDecision({ kind: "cant_do", detail: "x" })).toEqual({
+      kind: "term",
+      reason: "cant_do: x",
+    });
+    expect(releaseFailedReasonToAckDecision({ kind: "wont_do", detail: "y" })).toEqual({
+      kind: "term",
+      reason: "wont_do: y",
+    });
+    expect(
+      releaseFailedReasonToAckDecision({ kind: "not_now", detail: "z", retry_after_ms: 500 }),
+    ).toEqual({ kind: "nak", delayMs: 500 });
+    expect(releaseFailedReasonToAckDecision({ kind: "policy_denied", deny: { a: 1 } })).toEqual({
+      kind: "term",
+      reason: "policy_denied: a",
+    });
+    expect(releaseFailedReasonToAckDecision(undefined)).toEqual({ kind: "ack" });
+  });
+});

--- a/src/runner/release-consumer.ts
+++ b/src/runner/release-consumer.ts
@@ -36,6 +36,16 @@
  * override, no "dev-env exception" inside the consumer: the gate is the whole
  * point of the consumer existing as a capability rather than a cron job.
  *
+ * **Trust model (v1 — presence-only, NOT cryptographic).** `approved_by` is a
+ * PRESENCE marker, not a proof of authenticity. The envelope says whatever it
+ * says: any principal who can publish to
+ * `local.{principal}.{stack}.tasks.release.cut` can set `approved_by: "andreas"`
+ * with no cryptographic proof. The grant's authenticity therefore rests ENTIRELY
+ * on the NATS account credentials controlling who may publish to this gate's
+ * subject — this is the documented v1 assumption. The path to a
+ * cryptographically-proven grant is the cortex trust track (signing enforcement
+ * TC-0/1/2); until that lands the consumer trusts the transport's account ACLs.
+ *
  * **Failure-reason → ack/nak/term mapping (mirrors review-consumer's table):**
  *
  * | Outcome                                          | wire envelope          | JetStream control                  |
@@ -449,7 +459,17 @@ export class ReleaseConsumer {
     //    ungranted release cut is a `wont_do` (the agent COULD cut, but policy
     //    says only a principal-granted dispatch may) — permanent `term`, so a
     //    redelivery of the same ungranted envelope never sneaks through.
-    if (payload.approvedBy === undefined || payload.approvedBy.length === 0) {
+    //
+    //    Belt-and-suspenders: the parser already drops whitespace-only grants,
+    //    but the gate ALSO trims so a whitespace-only `approved_by` ("   ")
+    //    can never pass here even if the value reaches the gate by another path.
+    //    A bare `.length === 0` check would let "   " (length 3) through.
+    //
+    //    TRUST MODEL: approved_by is a presence marker, not a cryptographic proof.
+    //    Authenticity of this grant relies on NATS account credentials controlling
+    //    who can publish to this gate's subject. Cross-reference: signing enforcement
+    //    (cortex trust track TC-0/1/2) is the path to a cryptographically-proven grant.
+    if (!payload.approvedBy || payload.approvedBy.trim().length === 0) {
       await this.publishFailed(
         envelope,
         {
@@ -766,9 +786,12 @@ export function parseReleaseRequestPayload(
   };
 
   // The grant marker — accept the wire snake_case `approved_by`. Empty string
-  // is treated as ABSENT (the gate refuses it) so a blank grant can't sneak
-  // past the §3.5 check.
-  if (typeof p.approved_by === "string" && p.approved_by.length > 0) {
+  // AND whitespace-only strings are treated as ABSENT (the gate refuses them)
+  // so a blank or `"   "` grant can't sneak past the §3.5 check. We TRIM before
+  // the non-empty test: `"   ".length === 3 > 0` would otherwise parse as a
+  // present grant, and the gate's empty-string check (`.length === 0`) would
+  // not catch it — a whitespace-only grant must parse as ABSENT, not present.
+  if (typeof p.approved_by === "string" && p.approved_by.trim().length > 0) {
     out.approvedBy = p.approved_by;
   }
 

--- a/src/runner/release-consumer.ts
+++ b/src/runner/release-consumer.ts
@@ -1,0 +1,825 @@
+/**
+ * cortex#835 F-4.1 — `release-consumer.ts`
+ *
+ * **The gated release-cut capability consumer.** The mirror of
+ * `src/bus/review-consumer.ts` (the reference Offer consumer) for the
+ * `release.cut` capability: a JetStream pull consumer that claims
+ * `tasks.release.cut` Offer envelopes, runs the VERSIONING + RELEASE-CUT
+ * SOPs (`compass/sops/versioning.md` 4-step + `release-checklist.md`
+ * pre-deploy gates), and emits the cortex dispatch lifecycle envelopes back
+ * onto the bus.
+ *
+ * Anchors:
+ *   - `docs/design-agentic-dev-pipeline.md`
+ *       §3.1   — release-agent row (`release.cut` capability, gated).
+ *       §3.5   — the gate table: release/deploy is **ALWAYS-HUMAN** for prod.
+ *       F-4    — "Encode versioning/deployment/release-checklist SOPs as a
+ *                 gated consumer; announcements via the gateway."
+ *   - `compass/sops/versioning.md` — the 4-step release workflow this consumer
+ *       encodes: bump manifest → chore commit → push default branch →
+ *       `gh release create --generate-notes`.
+ *   - `compass/sops/release-checklist.md` — the pre-deploy gates the consumer
+ *       verifies as preconditions (clean default branch, checks green).
+ *
+ * **Scope carve-out — this consumer encodes VERSIONING + RELEASE-CUT ONLY.**
+ * It does NOT deploy. Deployment (`arc upgrade`, `wrangler deploy`) stays a
+ * separate, human-run step per design §3.5 (release/deploy is always-human for
+ * prod). The consumer's terminal success is "the GitHub release exists" — the
+ * release URL — never "the release is live in production".
+ *
+ * **The ALWAYS-HUMAN principal-grant gate (the load-bearing contract).**
+ * Cutting a release is a principal-held authority. The consumer REFUSES every
+ * claim that does not carry an explicit principal-grant marker on the task
+ * envelope (`payload.approved_by`, set by the dispatching H-gate per §3.5).
+ * An ungranted claim fails CLOSED as `wont_do` (reason: "release gate is
+ * principal-held") — a permanent `term` ack. There is no auto-grant, no env
+ * override, no "dev-env exception" inside the consumer: the gate is the whole
+ * point of the consumer existing as a capability rather than a cron job.
+ *
+ * **Failure-reason → ack/nak/term mapping (mirrors review-consumer's table):**
+ *
+ * | Outcome                                          | wire envelope          | JetStream control                  |
+ * |--------------------------------------------------|------------------------|------------------------------------|
+ * | release cut (manifest bumped + release created)  | `dispatch.task.completed` | `ack`                           |
+ * | ungranted claim (no principal-grant marker)      | `dispatch.task.failed` | `term` (`wont_do`, permanent)      |
+ * | bad subject / bad payload / no capability        | `dispatch.task.failed` | `term` (`cant_do`, permanent)      |
+ * | precondition failed (dirty branch / red checks / no manifest) | `dispatch.task.failed` | `term` (`cant_do`, permanent — a named precondition) |
+ * | maxConcurrent reached                            | `dispatch.task.failed` | `nak(retry_after_ms)` (`not_now`)  |
+ * | executor throws unexpectedly (defensive)         | `dispatch.task.failed` | `nak(0)` (transient)               |
+ * | Redelivery > 1 (BEFORE executor)                 | `dispatch.task.aborted`| continues; AckDecision per executor |
+ *
+ * **Seams — tests NEVER touch real git/gh.** Every side-effecting operation
+ * (read default-branch status, read CI checks, locate + read + write the
+ * version manifest, commit, push, create the release) flows through the
+ * injected {@link ReleaseExecutor}. Production wires a real forge/command
+ * executor; the F-4.1 slice ships the consumer + a `null`-safe default that
+ * keeps the consumer dormant when no executor is configured. The CC pipeline
+ * seam the review-consumer uses is deliberately ABSENT here: a release cut is
+ * deterministic SOP execution, not an LLM task (the cortex#491
+ * deterministic-surface-formatting rule applied to the release lane).
+ *
+ * **Anti-scope:**
+ *   - NOT a deployer — see the scope carve-out above.
+ *   - NOT a registry — the single-agent capability check matches review-consumer.
+ *   - NOT a renderer — emitted lifecycle envelopes flow through the existing
+ *     surface-router fan-out; the announce step is the gateway's job downstream.
+ *   - NOT federated — release is a same-principal authority (local subject scope
+ *     only); cross-principal release-cut is explicitly out of scope for F-4.1.
+ */
+
+import type { JsMsg } from "nats";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { MyelinSubscriber, AckDecision } from "../bus/myelin/subscriber";
+import {
+  createDispatchTaskStartedEvent,
+  createDispatchTaskCompletedEvent,
+  createDispatchTaskFailedEvent,
+  createDispatchTaskAbortedEvent,
+  type DispatchEventSource,
+  type DispatchTaskFailedReason,
+} from "../bus/dispatch-events";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal snapshot of the cortex.yaml `agents[]` data the consumer needs —
+ * the release-lane mirror of `ReviewConsumerAgent`. Kept narrow so tests can
+ * build a fixture without the full Zod-validated `Agent` shape.
+ */
+export interface ReleaseConsumerAgent {
+  /** Logical agent id (e.g. `"forge"`). Stamped onto every emitted envelope. */
+  id: string;
+  /**
+   * Capability ids this agent claims, e.g. `["release.cut", "release"]`.
+   * The consumer claims a `tasks.release.cut` request when the agent declares
+   * the exact `release.cut` capability OR the generic `release` capability.
+   */
+  capabilities: readonly string[];
+  /**
+   * Optional per-agent `maxConcurrent`. The default is **1** for the release
+   * lane (the task spec's `maxConcurrent 1`): two concurrent release cuts on
+   * one repo would race the manifest bump + push. When undefined, the consumer
+   * still applies the release-lane default of 1 (unlike review-consumer, which
+   * treats undefined as unbounded — a release cut is never safe to fan out).
+   */
+  maxConcurrent?: number;
+}
+
+/** Semantic-version bump kind, per `compass/sops/versioning.md`. */
+export type VersionBumpKind = "patch" | "minor" | "major";
+
+/**
+ * Canonical, validated `tasks.release.cut` request payload. The wire payload
+ * is normalised to this shape by {@link parseReleaseRequestPayload} before the
+ * executor ever sees it.
+ */
+export interface ReleaseRequestPayload {
+  /** Target repo, `owner/name` form (e.g. `the-metafactory/cortex`). */
+  repo: string;
+  /** Semantic-version bump kind. */
+  bump: VersionBumpKind;
+  /**
+   * The principal-grant marker (§3.5 ALWAYS-HUMAN gate). Present ONLY when the
+   * dispatching H-gate granted the cut; the consumer REFUSES (`wont_do`) when
+   * it is absent. Carries the granting principal's id for the audit trail +
+   * the commit/release attribution. Non-empty string when granted.
+   */
+  approvedBy?: string;
+  /** Optional free-form refs (issue/PR numbers, design §) for the audit trail. */
+  refs?: readonly string[];
+}
+
+/**
+ * Default `maxConcurrent` for the release lane. A release cut mutates the
+ * default branch (bump commit + push); two in flight on one repo race the
+ * push. The lane is serialised — `maxConcurrent` defaults to this even when
+ * the agent config omits it (the divergence from review-consumer's unbounded
+ * default is deliberate and documented on {@link ReleaseConsumerAgent}).
+ */
+export const RELEASE_LANE_MAX_CONCURRENT = 1;
+
+/**
+ * The named preconditions the consumer verifies BEFORE mutating anything, per
+ * `release-checklist.md` Phase 1. A failed precondition is a `cant_do` whose
+ * `detail` names WHICH gate tripped, so a principal grepping stderr /
+ * dead-letter sees `dirty_default_branch` / `checks_not_green` /
+ * `manifest_not_found` without cross-referencing tables.
+ */
+export type ReleasePrecondition =
+  | "dirty_default_branch"
+  | "checks_not_green"
+  | "manifest_not_found";
+
+/** Status of the repo's default branch — the `release-checklist.md` "clean branch" gate. */
+export interface DefaultBranchStatus {
+  /** Branch name (`main` for cortex). Echoed into the commit/push step. */
+  branch: string;
+  /** True when the working tree + index are clean (nothing to stash, no drift). */
+  clean: boolean;
+}
+
+/** Aggregate CI status — the `release-checklist.md` "all checks green" gate. */
+export interface ChecksStatus {
+  /** True when every required check on the default branch's head is green. */
+  allGreen: boolean;
+  /** Optional human-readable summary of failing checks (for the failure detail). */
+  summary?: string;
+}
+
+/** A located version manifest — `arc-manifest.yaml` / `package.json` per repo convention. */
+export interface VersionManifest {
+  /** Absolute (or repo-relative) path to the manifest file. */
+  path: string;
+  /** Current `version` value read from the manifest. */
+  currentVersion: string;
+}
+
+/** The outcome of a successful release cut — the terminal `completed` payload. */
+export interface ReleaseCutResult {
+  /** The version the manifest was bumped TO (e.g. `v5.5.1`). */
+  version: string;
+  /** The `gh release create` URL — the load-bearing success artifact. */
+  releaseUrl: string;
+}
+
+/**
+ * The single injected seam through which EVERY side effect flows. Production
+ * wires a real forge/command executor (git + gh); tests inject a recording
+ * double so no real git/gh runs. The methods are ordered as the SOP runs them:
+ * verify preconditions, then mutate.
+ *
+ * Returned as an injectable object (rather than the consumer importing git/gh
+ * helpers directly) for the same reason review-consumer injects its
+ * `pipelineRunner`: the consumer stays decoupled from the execution mechanism
+ * and unit-testable without a real repo.
+ */
+export interface ReleaseExecutor {
+  /**
+   * Read the default-branch cleanliness status — `release-checklist.md`
+   * "confirmed you are on the correct branch" + clean-tree gate.
+   */
+  getDefaultBranchStatus(repo: string): Promise<DefaultBranchStatus>;
+  /**
+   * Read the aggregate CI status for the default-branch head —
+   * `release-checklist.md` Phase 1.2 "all checks must pass".
+   */
+  getChecksStatus(repo: string): Promise<ChecksStatus>;
+  /**
+   * Locate + read the version manifest per the repo convention
+   * (`arc-manifest.yaml` for arc-managed repos, else `package.json`).
+   * Returns `null` when no manifest can be located → `manifest_not_found`.
+   */
+  locateVersionManifest(repo: string): Promise<VersionManifest | null>;
+  /**
+   * Compute the next version from the current + bump kind, write it to the
+   * manifest, create the conventional `chore:` bump commit, push the default
+   * branch, and run `gh release create --generate-notes`. Returns the cut
+   * result (version + release URL). The grant marker is threaded through for
+   * commit/release attribution.
+   *
+   * This is the single MUTATING call — kept as one method so the consumer
+   * never holds a half-applied release (the executor owns the bump→commit→
+   * push→release atomicity per `versioning.md`).
+   */
+  cutRelease(input: {
+    repo: string;
+    manifest: VersionManifest;
+    bump: VersionBumpKind;
+    branch: string;
+    approvedBy: string;
+    refs?: readonly string[];
+  }): Promise<ReleaseCutResult>;
+}
+
+/**
+ * Construction options. Every dependency is injected — no module-scope
+ * singletons, no env-derived defaults (mirrors `ReviewConsumerOpts`).
+ */
+export interface ReleaseConsumerOpts {
+  /** The agent this consumer serves. One consumer per agent. */
+  agent: ReleaseConsumerAgent;
+  /** Envelope source (`{principal}.{agent}.{instance}`) for lifecycle envelopes. */
+  source: DispatchEventSource;
+  /** The myelin runtime — used for `publish` (lifecycle envelopes). */
+  runtime: MyelinRuntime;
+  /**
+   * The injected SOP executor (forge + command seams). When `undefined`, the
+   * consumer treats every claim as `cant_do` (no executor configured) — the
+   * release lane is dormant-but-present, exactly like a review consumer whose
+   * runtime is disabled. Production wires a real executor.
+   */
+  executor?: ReleaseExecutor;
+  /** Test seam — clock. Defaults to `() => new Date()`. */
+  clock?: () => Date;
+}
+
+/**
+ * Options for {@link ReleaseConsumer.start} when binding to a real JetStream
+ * pull consumer. The consumer MUST already exist on the server (binds, does
+ * NOT provision) — same contract as `ReviewConsumerStartOpts`.
+ */
+export interface ReleaseConsumerStartOpts {
+  /** Subject pattern, e.g. `local.{principal}.{stack}.tasks.release.cut`. */
+  pattern: string;
+  /** JetStream stream name carrying the bound consumer. */
+  stream: string;
+  /** Durable consumer name. */
+  durable: string;
+  maxMessages?: number;
+  expiresMs?: number;
+  thresholdMessages?: number;
+}
+
+/**
+ * Boot/log info the consumer produces — the release-lane mirror of
+ * `ReviewConsumerStartedInfo`. `subscribed` distinguishes a live subscription
+ * from a dormant one (runtime disabled / `subscribePull` returned null) so the
+ * boot path logs "ready" vs "DORMANT" honestly.
+ */
+export interface ReleaseConsumerStartedInfo {
+  agentId: string;
+  subscribed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Class
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-agent capability-dispatch release-cut consumer.
+ *
+ * Lifecycle mirrors `ReviewConsumer`:
+ *   1. `new ReleaseConsumer(opts)` — registers nothing; does NOT subscribe.
+ *   2. `await consumer.start({...})` — opens the pull subscription (or stays
+ *      dormant when the runtime declines).
+ *   3. `await consumer.stop()` — drains in-flight cuts; idempotent.
+ *
+ * Tests drive `processEnvelope` directly (returns the full `AckDecision`)
+ * without standing up JetStream.
+ */
+export class ReleaseConsumer {
+  readonly agent: ReleaseConsumerAgent;
+  /** Effective per-agent concurrency cap (release-lane default = 1). */
+  readonly maxConcurrent: number;
+
+  private readonly source: DispatchEventSource;
+  private readonly runtime: MyelinRuntime;
+  private readonly executor: ReleaseExecutor | undefined;
+  private readonly clock: () => Date;
+
+  /** Promises for in-flight cuts so `stop()` can drain. */
+  private readonly inFlight = new Set<Promise<void>>();
+
+  private subscriber: MyelinSubscriber | null = null;
+  private stopped = false;
+  private stopPromise: Promise<void> | null = null;
+
+  constructor(opts: ReleaseConsumerOpts) {
+    this.agent = opts.agent;
+    this.source = opts.source;
+    this.runtime = opts.runtime;
+    this.executor = opts.executor;
+    this.clock = opts.clock ?? (() => new Date());
+    // Release lane is serialised by default — `maxConcurrent` falls back to 1
+    // even when the agent config omits it (see ReleaseConsumerAgent doc).
+    this.maxConcurrent = opts.agent.maxConcurrent ?? RELEASE_LANE_MAX_CONCURRENT;
+  }
+
+  /**
+   * Bind to a JetStream pull consumer. Returns once the subscriber is `ready`,
+   * or `{ subscribed: false }` when the runtime declines (disabled / no
+   * `subscribePull` helper). Mirrors `ReviewConsumer.start`.
+   */
+  async start(opts: ReleaseConsumerStartOpts): Promise<ReleaseConsumerStartedInfo> {
+    if (this.subscriber !== null) {
+      throw new Error(
+        `release-consumer: already started for agent="${this.agent.id}"`,
+      );
+    }
+    const subscribePullOpts: {
+      pattern: string;
+      stream: string;
+      durable: string;
+      onEnvelope: (envelope: Envelope, subject: string) => Promise<AckDecision>;
+      maxMessages?: number;
+      expiresMs?: number;
+      thresholdMessages?: number;
+    } = {
+      pattern: opts.pattern,
+      stream: opts.stream,
+      durable: opts.durable,
+      onEnvelope: async (envelope, subject) =>
+        this.processEnvelope(envelope, subject, null),
+    };
+    if (opts.maxMessages !== undefined) subscribePullOpts.maxMessages = opts.maxMessages;
+    if (opts.expiresMs !== undefined) subscribePullOpts.expiresMs = opts.expiresMs;
+    if (opts.thresholdMessages !== undefined) {
+      subscribePullOpts.thresholdMessages = opts.thresholdMessages;
+    }
+    // `subscribePull` is OPTIONAL on MyelinRuntime (legacy stubs must satisfy
+    // the interface byte-identically). Treat undefined like a null return: the
+    // consumer stays dormant.
+    const sub = this.runtime.subscribePull
+      ? this.runtime.subscribePull(subscribePullOpts)
+      : null;
+    if (sub === null) {
+      return { agentId: this.agent.id, subscribed: false };
+    }
+    this.subscriber = sub;
+    await this.subscriber.ready;
+    return { agentId: this.agent.id, subscribed: true };
+  }
+
+  /**
+   * Drive one envelope through the consumer's pipeline. Public for tests.
+   * Always returns an `AckDecision` (even on executor throw) so the subscriber
+   * can drive ack/nak/term without exception handling.
+   */
+  async processEnvelope(
+    envelope: Envelope,
+    subject: string,
+    msg: JsMsg | null,
+  ): Promise<AckDecision> {
+    // §2.3 (mirrored from review-consumer) — emit `dispatch.task.aborted` on
+    // redelivery > 1 BEFORE re-running. Advisory; the executor's terminal
+    // envelope remains the load-bearing reply.
+    const deliveryCount = redeliveryCountFrom(msg);
+    if (deliveryCount > 1) {
+      await this.safePublish(
+        createDispatchTaskAbortedEvent({
+          source: this.source,
+          taskId: crypto.randomUUID(),
+          agentId: this.agent.id,
+          correlationId: envelope.id,
+          startedAt: this.clock(),
+          abortedAt: this.clock(),
+          reason: `redelivery (attempt ${deliveryCount})`,
+        }),
+        "dispatch.task.aborted",
+      );
+    }
+
+    // 1. Validate subject + that this is a release.cut request.
+    if (!isReleaseCutEnvelope(envelope)) {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "cant_do",
+          detail: `envelope type "${envelope.type}" is not a tasks.release.cut request`,
+        },
+        `unrecognised release subject: ${subject}`,
+      );
+      return { kind: "term", reason: "non-release subject" };
+    }
+
+    // 2. Validate payload shape.
+    const payload = parseReleaseRequestPayload(envelope);
+    if (payload === null) {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "cant_do",
+          detail: "payload validation failed (missing/invalid repo or bump)",
+        },
+        `bad payload for ${subject}`,
+      );
+      return { kind: "term", reason: "payload validation failed" };
+    }
+
+    // 3. Capability routing — does THIS agent claim release.cut?
+    if (!this.claims()) {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "cant_do",
+          detail: `agent "${this.agent.id}" does not claim release.cut`,
+        },
+        "no capability match for release.cut",
+      );
+      return { kind: "term", reason: "no capability match" };
+    }
+
+    // 4. THE ALWAYS-HUMAN GATE (design §3.5). Refuse — fail CLOSED — unless the
+    //    task envelope carries an explicit principal-grant marker
+    //    (`payload.approved_by`, set by the dispatching H-gate). This is the
+    //    whole reason release.cut is a gated consumer and not a cron job: an
+    //    ungranted release cut is a `wont_do` (the agent COULD cut, but policy
+    //    says only a principal-granted dispatch may) — permanent `term`, so a
+    //    redelivery of the same ungranted envelope never sneaks through.
+    if (payload.approvedBy === undefined || payload.approvedBy.length === 0) {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "wont_do",
+          detail:
+            "release gate is principal-held — refusing release.cut with no principal-grant marker (payload.approved_by)",
+        },
+        "release.cut refused: no principal grant",
+      );
+      return { kind: "term", reason: "wont_do: release gate is principal-held" };
+    }
+
+    // 5. Concurrency gate — release lane is serialised (default 1). Over the
+    //    cap → nak `not_now`.
+    if (this.inFlight.size >= this.maxConcurrent) {
+      const retryAfterMs = 1000;
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "not_now",
+          detail: `release lane at maxConcurrent (${this.maxConcurrent}) — try again`,
+          retry_after_ms: retryAfterMs,
+        },
+        "release consumer at maxConcurrent",
+      );
+      return { kind: "nak", delayMs: retryAfterMs };
+    }
+
+    // 6. No executor configured → cant_do (release lane dormant-but-present).
+    if (this.executor === undefined) {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "cant_do",
+          detail: "no release executor configured (release lane dormant)",
+        },
+        "release consumer has no executor",
+      );
+      return { kind: "term", reason: "no release executor" };
+    }
+
+    // 7. Emit dispatch.task.started — paired with the terminal via correlation_id.
+    const startedAt = this.clock();
+    await this.safePublish(
+      createDispatchTaskStartedEvent({
+        source: this.source,
+        taskId: crypto.randomUUID(),
+        agentId: this.agent.id,
+        correlationId: envelope.id,
+        startedAt,
+      }),
+      "dispatch.task.started",
+    );
+
+    // 8. Run the cut. Track the promise for `stop()` drain.
+    const cutPromise = this.runCut(
+      envelope,
+      payload,
+      payload.approvedBy,
+      startedAt,
+      this.executor,
+    );
+    const tracked: Promise<{ decision: AckDecision }> = cutPromise.then(
+      (decision) => ({ decision }),
+    );
+    const drainSentinel = tracked.then(() => undefined);
+    this.inFlight.add(drainSentinel);
+    try {
+      const { decision } = await tracked;
+      return decision;
+    } finally {
+      this.inFlight.delete(drainSentinel);
+    }
+  }
+
+  /**
+   * Stop accepting new envelopes and drain in-flight cuts. Idempotent.
+   * Mirrors `ReviewConsumer.stop`.
+   */
+  async stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise;
+    this.stopPromise = (async () => {
+      this.stopped = true;
+      const sub = this.subscriber;
+      if (sub) {
+        try {
+          await sub.stop();
+        } catch (err) {
+          process.stderr.write(
+            `release-consumer: subscriber stop failed for agent=${this.agent.id}: ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
+      }
+      if (this.inFlight.size > 0) {
+        await Promise.allSettled(Array.from(this.inFlight));
+      }
+    })();
+    return this.stopPromise;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /** Capability claim: exact `release.cut` or the generic `release`. */
+  private claims(): boolean {
+    return (
+      this.agent.capabilities.includes("release.cut") ||
+      this.agent.capabilities.includes("release")
+    );
+  }
+
+  /**
+   * Run the SOP: verify preconditions (clean branch, green checks, manifest
+   * located), then cut (bump → commit → push → `gh release create`). Publishes
+   * the terminal envelope (completed on success; failed on a named precondition
+   * or a defensive executor throw) and returns the `AckDecision`.
+   */
+  private async runCut(
+    envelope: Envelope,
+    payload: ReleaseRequestPayload,
+    approvedBy: string,
+    startedAt: Date,
+    executor: ReleaseExecutor,
+  ): Promise<AckDecision> {
+    if (this.stopped) {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "not_now",
+          detail: "release consumer is shutting down",
+          retry_after_ms: 0,
+        },
+        "consumer shutting down before cut start",
+      );
+      return { kind: "nak", delayMs: 0 };
+    }
+
+    try {
+      // --- Preconditions (release-checklist.md Phase 1) — verify BEFORE any
+      //     mutation. A failed precondition is a `cant_do` whose detail NAMES
+      //     the gate that tripped.
+      const branch = await executor.getDefaultBranchStatus(payload.repo);
+      if (!branch.clean) {
+        return await this.failPrecondition(
+          envelope,
+          "dirty_default_branch",
+          `default branch "${branch.branch}" is not clean`,
+        );
+      }
+
+      const checks = await executor.getChecksStatus(payload.repo);
+      if (!checks.allGreen) {
+        const detail = checks.summary ?? "one or more required checks are not green";
+        return await this.failPrecondition(envelope, "checks_not_green", detail);
+      }
+
+      const manifest = await executor.locateVersionManifest(payload.repo);
+      if (manifest === null) {
+        return await this.failPrecondition(
+          envelope,
+          "manifest_not_found",
+          `no version manifest located for "${payload.repo}" (arc-manifest.yaml / package.json)`,
+        );
+      }
+
+      // --- The mutating step (versioning.md 4-step, executed atomically by the
+      //     executor): bump → chore commit → push → gh release create.
+      const result = await executor.cutRelease({
+        repo: payload.repo,
+        manifest,
+        bump: payload.bump,
+        branch: branch.branch,
+        approvedBy,
+        ...(payload.refs !== undefined && { refs: payload.refs }),
+      });
+
+      await this.safePublish(
+        createDispatchTaskCompletedEvent({
+          source: this.source,
+          taskId: crypto.randomUUID(),
+          agentId: this.agent.id,
+          correlationId: envelope.id,
+          startedAt,
+          completedAt: this.clock(),
+          resultSummary: `released ${payload.repo} ${result.version} — ${result.releaseUrl}`,
+          chatResponse: result.releaseUrl,
+        }),
+        "dispatch.task.completed",
+      );
+      return { kind: "ack" };
+    } catch (err) {
+      // Defensive — map any executor throw to a §7.6 transient failure so a
+      // dispatching reactor gets a retry-safe signal rather than a phantom.
+      const detail = err instanceof Error ? err.message : String(err);
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "not_now",
+          detail: `release executor threw unexpectedly: ${detail}`,
+          retry_after_ms: 0,
+        },
+        `release executor threw: ${detail}`,
+      );
+      return { kind: "nak", delayMs: 0 };
+    }
+  }
+
+  /**
+   * Publish a `cant_do` failure naming a specific {@link ReleasePrecondition}
+   * and return the `term` AckDecision. A precondition failure is permanent for
+   * THIS envelope — the dispatching gate must re-grant once the branch is
+   * clean / checks are green / a manifest exists.
+   */
+  private async failPrecondition(
+    envelope: Envelope,
+    precondition: ReleasePrecondition,
+    detail: string,
+  ): Promise<AckDecision> {
+    const failureDetail = `precondition ${precondition}: ${detail}`;
+    await this.publishFailed(
+      envelope,
+      { kind: "cant_do", detail: failureDetail },
+      `release precondition failed: ${precondition}`,
+    );
+    return { kind: "term", reason: failureDetail };
+  }
+
+  /**
+   * Build + publish a `dispatch.task.failed` envelope, threading
+   * `correlation_id = envelope.id`. The fresh `taskId` is for lifecycle
+   * stitching only. Mirrors `ReviewConsumer.publishFailed`.
+   */
+  private async publishFailed(
+    request: Envelope,
+    reason: DispatchTaskFailedReason,
+    errorSummary: string,
+  ): Promise<void> {
+    const now = this.clock();
+    const failed = createDispatchTaskFailedEvent({
+      source: this.source,
+      taskId: crypto.randomUUID(),
+      agentId: this.agent.id,
+      correlationId: request.id,
+      startedAt: now,
+      failedAt: now,
+      errorSummary,
+      reason,
+    });
+    await this.safePublish(failed, "dispatch.task.failed");
+  }
+
+  /**
+   * Single publish path — traps + logs publish errors per CLAUDE.md "no empty
+   * catch blocks". A failed publish must not crash the consumer or prevent the
+   * handler from returning an `AckDecision`. Mirrors `ReviewConsumer.safePublish`
+   * minus the federated branch (release is local-scope only — F-4.1 anti-scope).
+   */
+  private async safePublish(envelope: Envelope, label: string): Promise<void> {
+    try {
+      await this.runtime.publish(envelope);
+    } catch (err) {
+      process.stderr.write(
+        `release-consumer: publish failed for ${label} (agent=${this.agent.id}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Is this envelope a `tasks.release.cut` request? The envelope `type` (NOT the
+ * wire subject) is canonical — same rationale as `extractFlavor` in
+ * review-consumer (a malformed subject must not falsely match).
+ */
+export function isReleaseCutEnvelope(envelope: Envelope): boolean {
+  return envelope.type === "tasks.release.cut";
+}
+
+const OWNER_REPO_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
+const BUMP_KINDS: ReadonlySet<string> = new Set(["patch", "minor", "major"]);
+
+/**
+ * Parse + validate a `tasks.release.cut` envelope payload into the canonical
+ * {@link ReleaseRequestPayload}, or `null` on any shape violation.
+ *
+ * Required: `repo` (`owner/name`), `bump` (`patch|minor|major`). Optional:
+ * `approved_by` (the principal-grant marker — its PRESENCE is what the §3.5 gate
+ * keys on), `refs` (string[]).
+ *
+ * NOTE: this parser does NOT reject a missing grant — that is the consumer's
+ * §3.5 gate decision (it emits a `wont_do`, distinct from a `cant_do` payload
+ * violation). The grant marker is OPTIONAL at the payload layer precisely so
+ * the consumer can distinguish "malformed request" from "well-formed but
+ * ungranted request".
+ */
+export function parseReleaseRequestPayload(
+  envelope: Envelope,
+): ReleaseRequestPayload | null {
+  const p = envelope.payload as Record<string, unknown> | undefined;
+  if (!p || typeof p !== "object") return null;
+
+  if (typeof p.repo !== "string" || !OWNER_REPO_RE.test(p.repo)) return null;
+  if (typeof p.bump !== "string" || !BUMP_KINDS.has(p.bump)) return null;
+
+  const out: ReleaseRequestPayload = {
+    repo: p.repo,
+    bump: p.bump as VersionBumpKind,
+  };
+
+  // The grant marker — accept the wire snake_case `approved_by`. Empty string
+  // is treated as ABSENT (the gate refuses it) so a blank grant can't sneak
+  // past the §3.5 check.
+  if (typeof p.approved_by === "string" && p.approved_by.length > 0) {
+    out.approvedBy = p.approved_by;
+  }
+
+  if (Array.isArray(p.refs)) {
+    const refs = p.refs.filter((r): r is string => typeof r === "string");
+    if (refs.length > 0) out.refs = refs;
+  }
+
+  return out;
+}
+
+/**
+ * Map a `DispatchTaskFailedReason` to its JetStream `AckDecision`. Identical
+ * contract to review-consumer's `failedReasonToAckDecision` (the release lane
+ * uses the same four-way nak taxonomy). Re-implemented here (rather than
+ * imported) to keep the release lane's ack table self-contained + independently
+ * testable — the lanes share the wire vocabulary, not the module.
+ */
+export function releaseFailedReasonToAckDecision(
+  reason: DispatchTaskFailedReason | undefined,
+): AckDecision {
+  if (!reason) return { kind: "ack" };
+  switch (reason.kind) {
+    case "cant_do":
+      return { kind: "term", reason: `cant_do: ${reason.detail}` };
+    case "wont_do":
+      return { kind: "term", reason: `wont_do: ${reason.detail}` };
+    case "policy_denied": {
+      const denyKeys = Object.keys(reason.deny);
+      const summary = denyKeys.length > 0 ? denyKeys.join(",") : "(no deny detail)";
+      return { kind: "term", reason: `policy_denied: ${summary}` };
+    }
+    case "not_now": {
+      const out: AckDecision = { kind: "nak" };
+      if (reason.retry_after_ms !== undefined) out.delayMs = reason.retry_after_ms;
+      return out;
+    }
+    case "compliance_block":
+      return { kind: "term", reason: "v1 does not handle compliance_block" };
+  }
+}
+
+/**
+ * Read JetStream redelivery count from a `JsMsg`. Returns `1` when no msg is
+ * supplied (tests). Mirrors review-consumer's `redeliveryCountFrom`.
+ */
+function redeliveryCountFrom(msg: JsMsg | null): number {
+  if (!msg) return 1;
+  const info = (msg.info as { redeliveryCount?: number } | undefined) ?? undefined;
+  if (info && typeof info.redeliveryCount === "number") {
+    return info.redeliveryCount;
+  }
+  return msg.redelivered ? 2 : 1;
+}


### PR DESCRIPTION
## F-4.1 — `release.cut` capability consumer

Refs **cortex#835** (epic: dev-loop — the agentic dev pipeline on the IoAW bus).
Design: [`docs/design-agentic-dev-pipeline.md`](https://github.com/the-metafactory/cortex/blob/main/docs/design-agentic-dev-pipeline.md) §3.1 (release-agent row) + §3.5 (gate table: release/deploy is ALWAYS-HUMAN for prod).
SOPs encoded: [`compass/sops/versioning.md`](https://github.com/the-metafactory/compass/blob/main/sops/versioning.md) (4-step) + [`compass/sops/release-checklist.md`](https://github.com/the-metafactory/compass/blob/main/sops/release-checklist.md) (pre-deploy gates).

The gated release/versioning agent. A `release.cut` **Offer** consumer that mirrors the reference consumer `src/bus/review-consumer.ts`: it claims `tasks.release.cut`, runs the VERSIONING + RELEASE-CUT SOPs, and emits cortex dispatch lifecycle envelopes back onto the bus.

### What it does
On a **granted** claim (payload `repo`, `bump` patch|minor|major, optional `refs`):
1. emit `dispatch.task.started`
2. verify preconditions via injected forge/command seams — clean default branch, all checks green, version manifest located per repo convention (`arc-manifest.yaml`/`package.json`)
3. bump + conventional `chore:` commit + push + `gh release create --generate-notes` (all injected seams; **tests never touch real git/gh**)
4. emit `dispatch.task.completed` with the release URL — **or** a typed `cant_do` naming the failed precondition (`dirty_default_branch` / `checks_not_green` / `manifest_not_found`).

`maxConcurrent` defaults to **1** (release lane serialised). Same four-way nak taxonomy as the review lane (`cant_do`/`wont_do` → term; `not_now` → nak; defensive throw → nak(0)).

### Scope carve-out — VERSIONING + RELEASE-CUT only, NOT deployment
Deploy (`arc upgrade`, `wrangler deploy`) stays a **separate, human-run step** per design §3.5. The consumer's terminal success is "the GitHub release exists" (the release URL) — never "live in production".

### The grant-gate shape (the load-bearing ALWAYS-HUMAN contract, §3.5)
The consumer **REFUSES — fail-closed** — every claim that does not carry an explicit principal-grant marker on the task envelope:

```
payload.approved_by  (set by the dispatching H-gate)
  absent / empty  → wont_do, reason "release gate is principal-held"
                    → permanent `term` ack
                    → the executor is NEVER invoked
  non-empty string → grant present; the cut may proceed through the precondition ladder
```

The grant marker is **optional at the payload-parse layer** precisely so the consumer can distinguish a *malformed* request (`cant_do`) from a *well-formed-but-ungranted* one (`wont_do`). There is **no auto-grant, no env override, no dev-env exception** inside the consumer — the gate is the whole reason `release.cut` is a gated capability and not a cron job.

### Dormant-by-default — the byte-identical boot contract
Boot wiring mirrors review-consumer's capability gating: for each agent declaring `release.cut`/`release`, instantiate + `start()` a `ReleaseConsumer`. **HARD CONTRACT — the entire boot block is gated behind `releaseCapableAgents.length > 0`**, so a stack that never opts into the capability boots with *zero* new behaviour (no stream provisioned, no log line, no JSM round-trip). Verified by the boot test's byte-identical assertion.

F-4.1 ships the consumer **without a production executor** (dormant-but-present): the capability is declared on the bus and the full grant/precondition gate ladder is live, but a granted-and-gated claim terminates `cant_do: no release executor configured` until the real git/gh executor is wired behind the same `ReleaseExecutor` interface the tests already drive. See **Flags** below.

## Gates

| Gate | Result |
|---|---|
| `bunx tsc --noEmit` | ✅ exit 0 |
| `bun run lint:errors` (CI blocking) | ✅ exit 0 |
| `bun test` (whole suite) | ✅ 5287 pass / 2 skip / **0 fail** |
| `bash scripts/check-carveouts.sh` (whole-tree) | ✅ PASS |
| carve-out gate (diff-mode) | ✅ PASS |
| boot smoke (`cortex.release-consumer-boot.test.ts`) | ✅ 5/5 |
| consumer tests (`release-consumer.test.ts`) | ✅ 29/29 |

**Test count: 34 new tests** (29 consumer + 5 boot). No regressions.

## Flags

- **No production executor yet (intentional F-4.1 boundary).** The consumer is wired with no `executor`, so every granted+gated claim currently terminates `cant_do: no release executor configured`. The side-effecting forge/command seam (real `git` + `gh`) is a follow-up slice behind the **same** `ReleaseExecutor` interface — keeping F-4.1 the *gate + lifecycle + capability-declaration* slice. The log line flags `executor=none` so a principal grepping boot sees the lane is declared but the seam is unwired.
- **Local subject scope only.** Release is a same-principal authority; cross-principal/federated `release.cut` is explicitly out of scope for F-4.1 (no `federated.*` consumer, unlike review-consumer).
- **Announce step deferred.** Design F-4 includes "announce via the gateway"; this slice ships the cut + lifecycle envelopes. The announce is a downstream gateway concern off the `completed` envelope's release URL — not wired here.
- **Stream/consumer provisioning reuses `provisionReviewStream`/`provisionReviewConsumer`** (generic by `name`/`subjects`/`durable`) against a new `RELEASE` stream with the same retention posture as `CODE_REVIEW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)