### PR TITLE
feat(bus): F-2.2 — provision DEV_IMPLEMENT stream (durable dev-consumer enabler)

### DIFF
--- a/src/__tests__/cortex.dev-stream-boot.test.ts
+++ b/src/__tests__/cortex.dev-stream-boot.test.ts
@@ -1,0 +1,345 @@
+/**
+ * F-2.2 (cortex#835 → cortex#865) — DEV_IMPLEMENT stream boot-wiring tests.
+ *
+ * cortex provisions a JetStream stream (`DEV_IMPLEMENT`) over the dev-task
+ * subject family so the agentic dev-loop's dev-agent consumer (F-2.1,
+ * cortex#853) can bind a DURABLE pull consumer and replay history instead of
+ * racing a transient core-NATS subscription against a virgin broker. cortex
+ * provisions the STREAM only; the durable consumer that reads it is F-2.1's
+ * concern (the F-2.1 PR flagged this stream as the sibling slice).
+ *
+ * This test is the EXACT sibling of `cortex.lifecycle-stream-boot.test.ts`
+ * (the REVIEW_LIFECYCLE provisioning test, cortex#851) — same recording-JSM
+ * infrastructure, same three pins:
+ *
+ *   1. With a JSM available, BOTH streams are provisioned — CODE_REVIEW (its
+ *      `…tasks.code-review.>` namespace) AND DEV_IMPLEMENT (the dev-task
+ *      family `…tasks.dev.>`).
+ *   2. OVERLAP INVARIANT — the two streams' subject sets are DISJOINT (no
+ *      subject of one is a prefix of, or prefixed by, any subject of the
+ *      other). JetStream rejects overlapping subjects across streams; this
+ *      test is the codified guard that the partition holds at boot.
+ *   3. Config gating — when the runtime exposes NO `jetstreamManager` (dormant
+ *      / NATS-absent), NEITHER stream is provisioned. The DEV_IMPLEMENT
+ *      provisioning rides the SAME `reviewJsm !== null` gate as CODE_REVIEW, so
+ *      byte-identical behaviour holds when the bus/JetStream is not configured.
+ *
+ * Test infrastructure mirrors the REVIEW_LIFECYCLE test (recording runtime +
+ * inline agents + captured logs + recording JSM stub) so the boot path's
+ * `streams.add` calls are observable without standing up a real broker. No
+ * real NATS, Discord, filesystem-watcher, or `claude` spawning.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import type { Agent, AgentRuntime } from "../common/types/cortex-config";
+import { startCortex } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+  MyelinSubscribePullOpts,
+} from "../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+import type { ProvisionJsm } from "../bus/jetstream/types";
+import type { ConsumerInfo, StreamInfo, StreamConfig } from "nats";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-dev-stream-test-published" },
+    ...overrides,
+  });
+}
+
+/** Records every `streams.add` so the boot test can read back the provisioned
+ *  stream configs. Stream/consumer `info` always 404s (virgin broker) so the
+ *  provisioning helpers take the create path. */
+interface JsmRecorder {
+  jsm: ProvisionJsm;
+  streamAdds: Partial<StreamConfig>[];
+}
+
+function makeRecordingJsm(): JsmRecorder {
+  const streamAdds: Partial<StreamConfig>[] = [];
+  const notFound = (kind: "stream" | "consumer"): Error => {
+    const err = new Error(`${kind} not found`);
+    (err as unknown as { api_error: { err_code: number } }).api_error = {
+      err_code: kind === "stream" ? 10059 : 10014,
+    };
+    return err;
+  };
+  const jsm: ProvisionJsm = {
+    streams: {
+      info: async () => {
+        throw notFound("stream");
+      },
+      add: async (cfg) => {
+        streamAdds.push(cfg);
+        return { config: cfg } as unknown as StreamInfo;
+      },
+    },
+    consumers: {
+      info: async () => {
+        throw notFound("consumer");
+      },
+      add: async (_stream, cfg) =>
+        ({ name: cfg.durable_name } as unknown as ConsumerInfo),
+      update: async (_stream, durable, cfg) =>
+        ({ name: durable, config: cfg } as unknown as ConsumerInfo),
+    },
+  };
+  return { jsm, streamAdds };
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  onEnvelopeHandlers: Set<EnvelopeHandler>;
+  published: Envelope[];
+  subscribePullCalls: MyelinSubscribePullOpts[];
+}
+
+/** A runtime that EXPOSES a recording `jetstreamManager` so the boot path
+ *  resolves a real JSM and provisions both streams. Omitting `jsm` omits the
+ *  helper entirely → `resolveReviewProvisioningJsm` returns null → dormant. */
+function createRecordingRuntime(opts: {
+  jsm?: ProvisionJsm;
+}): RecordingRuntime {
+  const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+  const runtime: RecordingRuntime = {
+    enabled: true,
+    onEnvelopeHandlers,
+    published,
+    subscribePullCalls,
+    onEnvelope(handler) {
+      onEnvelopeHandlers.add(handler);
+      return {
+        unregister: () => {
+          onEnvelopeHandlers.delete(handler);
+        },
+      };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    subscribePull: (o: MyelinSubscribePullOpts): MyelinSubscriber => {
+      subscribePullCalls.push(o);
+      return {
+        pattern: o.pattern,
+        ready: Promise.resolve(),
+        stop: async () => {},
+      } as unknown as MyelinSubscriber;
+    },
+    stop: async () => {},
+  };
+  if (opts.jsm !== undefined) {
+    runtime.jetstreamManager = async () => opts.jsm!;
+  }
+  return runtime;
+}
+
+function makeAgent(id: string, capabilities: readonly string[]): Agent {
+  const runtime: AgentRuntime = {
+    substrate: "claude-code",
+    mode: "in-process",
+    capabilities: [...capabilities],
+  };
+  return {
+    id,
+    displayName: id.charAt(0).toUpperCase() + id.slice(1),
+    persona: `/tmp/${id}-persona.md`,
+    trust: [],
+    presence: {},
+    runtime,
+  };
+}
+
+function withCapturedConsoleLog<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; logs: string[] }> {
+  const original = console.log.bind(console);
+  const logs: string[] = [];
+  console.log = (...args: unknown[]): void => {
+    logs.push(args.map((a) => String(a)).join(" "));
+  };
+  return fn()
+    .then((result) => {
+      console.log = original;
+      return { result, logs };
+    })
+    .catch((err: unknown) => {
+      console.log = original;
+      throw err;
+    });
+}
+
+/**
+ * Subject-set overlap predicate — true iff `a` and `b` would collide as
+ * JetStream stream subjects (one is a prefix of the other under the `.`
+ * token grammar, treating a trailing `>` as "matches the rest"). This is the
+ * relation JetStream uses to reject overlapping subjects across streams; the
+ * test asserts NO pair across the two streams satisfies it.
+ */
+function subjectsOverlap(a: string, b: string): boolean {
+  const at = a.split(".");
+  const bt = b.split(".");
+  const n = Math.min(at.length, bt.length);
+  for (let i = 0; i < n; i++) {
+    const x = at[i]!;
+    const y = bt[i]!;
+    if (x === ">" || y === ">") return true; // tail wildcard swallows the rest
+    if (x === "*" || y === "*") continue; // single-token wildcard matches either
+    if (x !== y) return false; // a literal token diverged → disjoint
+  }
+  // One subject is a strict token-prefix of the other with no divergence →
+  // they overlap only if the shorter ends in a wildcard tail; a shorter
+  // subject with no `>`/`*` tail does NOT subsume a longer one here.
+  return at.length === bt.length;
+}
+
+const PRINCIPAL = "test-op";
+const STACK = "default";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startCortex — DEV_IMPLEMENT stream boot wiring (F-2.2, cortex#835 → cortex#865)", () => {
+  test("provisions DEV_IMPLEMENT covering the dev-task family, alongside CODE_REVIEW", async () => {
+    const { jsm, streamAdds } = makeRecordingJsm();
+    const runtime = createRecordingRuntime({ jsm });
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-dev-stream-boot-"));
+    const inlineAgents: Agent[] = [makeAgent("echo", ["code-review.typescript"])];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    // BOTH streams provisioned.
+    const byName = new Map(streamAdds.map((c) => [c.name, c]));
+    expect(byName.has("CODE_REVIEW")).toBe(true);
+    expect(byName.has("DEV_IMPLEMENT")).toBe(true);
+
+    const dev = byName.get("DEV_IMPLEMENT")!;
+    // The dev-task family, stack-aware 6-segment grammar. Covers the exact
+    // subject the F-2.1 dev consumer subscribes (`…tasks.dev.implement`) plus
+    // room for future `tasks.dev.*` capabilities.
+    expect(dev.subjects).toEqual([
+      `local.${PRINCIPAL}.${STACK}.tasks.dev.>`,
+    ]);
+    // Config posture mirrors CODE_REVIEW EXACTLY: Interest retention, File
+    // storage, 24h max_age, finite 512 MiB max_bytes, single replica.
+    expect(String(dev.retention)).toBe("interest");
+    expect(String(dev.storage)).toBe("file");
+    expect(dev.max_age).toBe(24 * 3600 * 1e9);
+    expect(dev.max_bytes).toBe(512 * 1024 * 1024);
+    expect(dev.max_msgs).toBe(-1);
+    expect(dev.num_replicas).toBe(1);
+
+    // Boot log surfaces the provisioning.
+    const provisionedLog = logs.find(
+      (l) =>
+        l.includes('provisioned JetStream stream "DEV_IMPLEMENT"') ||
+        l.includes('JetStream stream "DEV_IMPLEMENT" already present'),
+    );
+    expect(provisionedLog).toBeDefined();
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("OVERLAP INVARIANT — CODE_REVIEW and DEV_IMPLEMENT subject sets are disjoint", async () => {
+    const { jsm, streamAdds } = makeRecordingJsm();
+    const runtime = createRecordingRuntime({ jsm });
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-dev-stream-overlap-"));
+    const inlineAgents: Agent[] = [makeAgent("echo", ["code-review.typescript"])];
+
+    const { result: handle } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    const byName = new Map(streamAdds.map((c) => [c.name, c]));
+    const codeReview = byName.get("CODE_REVIEW")!.subjects ?? [];
+    const dev = byName.get("DEV_IMPLEMENT")!.subjects ?? [];
+    expect(codeReview.length).toBeGreaterThan(0);
+    expect(dev.length).toBeGreaterThan(0);
+
+    // No cross-stream pair may overlap — JetStream would reject the second
+    // `streams.add` if any did. `tasks.code-review.>` and `tasks.dev.>` diverge
+    // at segment 5 (the token after `tasks.`), so the predicate returns false
+    // for every pair.
+    for (const cr of codeReview) {
+      for (const dv of dev) {
+        expect(subjectsOverlap(cr, dv)).toBe(false);
+      }
+    }
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("config gating — no jetstreamManager → NEITHER stream provisioned (byte-identical when bus/JS unconfigured)", async () => {
+    // Runtime omits `jetstreamManager` → `resolveReviewProvisioningJsm`
+    // returns null → the whole `reviewJsm !== null` block (both CODE_REVIEW
+    // AND DEV_IMPLEMENT provisioning) is skipped. No JSM stub means any
+    // accidental provisioning attempt would throw, so the witness is simply
+    // that boot completes cleanly and the dev provision log is absent.
+    const runtime = createRecordingRuntime({});
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-dev-stream-dormant-"));
+    const inlineAgents: Agent[] = [makeAgent("echo", ["code-review.typescript"])];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    const devProvisionLogs = logs.filter((l) =>
+      l.includes('JetStream stream "DEV_IMPLEMENT"'),
+    );
+    expect(devProvisionLogs.length).toBe(0);
+    // And no CODE_REVIEW provisioning either — confirms the SHARED gate.
+    const codeReviewProvisionLogs = logs.filter(
+      (l) =>
+        l.includes('provisioned JetStream stream "CODE_REVIEW"') ||
+        l.includes('JetStream stream "CODE_REVIEW" already present'),
+    );
+    expect(codeReviewProvisionLogs.length).toBe(0);
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+});

--- a/src/__tests__/cortex.dev-stream-boot.test.ts
+++ b/src/__tests__/cortex.dev-stream-boot.test.ts
@@ -285,19 +285,23 @@ describe("startCortex — DEV_IMPLEMENT stream boot wiring (F-2.2, cortex#835 �
       }),
     );
 
-    const byName = new Map(streamAdds.map((c) => [c.name, c]));
-    const codeReview = byName.get("CODE_REVIEW")!.subjects ?? [];
-    const dev = byName.get("DEV_IMPLEMENT")!.subjects ?? [];
-    expect(codeReview.length).toBeGreaterThan(0);
-    expect(dev.length).toBeGreaterThan(0);
-
-    // No cross-stream pair may overlap — JetStream would reject the second
-    // `streams.add` if any did. `tasks.code-review.>` and `tasks.dev.>` diverge
-    // at segment 5 (the token after `tasks.`), so the predicate returns false
-    // for every pair.
-    for (const cr of codeReview) {
-      for (const dv of dev) {
-        expect(subjectsOverlap(cr, dv)).toBe(false);
+    // #875 review nit 1: iterate EVERY cross-stream subject pair across ALL
+    // provisioned streams (N*(N-1)/2), not just CODE_REVIEW×DEV_IMPLEMENT, so
+    // the invariant self-hardens as more streams land (e.g. REVIEW_LIFECYCLE
+    // from cortex#851). JetStream rejects the second `streams.add` if ANY pair
+    // across ANY two streams overlaps.
+    const provisioned = streamAdds.filter((c) => (c.subjects ?? []).length > 0);
+    expect(provisioned.length).toBeGreaterThanOrEqual(2);
+    expect(provisioned.some((c) => c.name === "DEV_IMPLEMENT")).toBe(true);
+    for (let i = 0; i < provisioned.length; i++) {
+      for (let j = i + 1; j < provisioned.length; j++) {
+        const aSubjects = provisioned[i]?.subjects ?? [];
+        const bSubjects = provisioned[j]?.subjects ?? [];
+        for (const a of aSubjects) {
+          for (const b of bSubjects) {
+            expect(subjectsOverlap(a, b)).toBe(false);
+          }
+        }
       }
     }
 

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -72,6 +72,13 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
         },
         consumer: { maxDeliver: 5 },
       },
+      devImplement: {
+        stream: {
+          name: "DEV_IMPLEMENT",
+          maxAgeSeconds: 86_400,
+          maxBytes: 512 * 1024 * 1024,
+        },
+      },
     },
     agents,
     renderers: [],

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -19,6 +19,8 @@ import {
   AgentDetectionSchema,
   AgentSchema,
   AttachmentsConfigSchema,
+  BusConfigSchema,
+  BusDevImplementConfigSchema,
   ClaudeConfigSchema,
   CortexConfigSchema,
   DashboardRendererSchema,
@@ -700,6 +702,46 @@ describe("Cross-cutting schemas — defaults populated by emptyDefault helper", 
     const parsed = AgentDetectionSchema.parse({});
     expect(parsed.branchPatterns).toEqual(["^feat/(g|f|i)-\\d+"]);
     expect(parsed.commentPatterns).toEqual(["^Starting:", "^Completed:"]);
+  });
+
+  test("BusConfigSchema applies review + devImplement stream defaults (F-2.2, cortex#835)", () => {
+    const parsed = BusConfigSchema.parse({});
+    // Existing CODE_REVIEW posture — unchanged.
+    expect(parsed.review.stream.name).toBe("CODE_REVIEW");
+    expect(parsed.review.stream.maxAgeSeconds).toBe(86_400);
+    expect(parsed.review.stream.maxBytes).toBe(512 * 1024 * 1024);
+    expect(parsed.review.consumer.maxDeliver).toBe(5);
+    // New DEV_IMPLEMENT stream — mirrors CODE_REVIEW's stream posture exactly,
+    // and intentionally carries NO consumer sub-block (cortex provisions the
+    // stream; the dev-agent's durable consumer is F-2.1's concern, cortex#853).
+    expect(parsed.devImplement.stream.name).toBe("DEV_IMPLEMENT");
+    expect(parsed.devImplement.stream.maxAgeSeconds).toBe(86_400);
+    expect(parsed.devImplement.stream.maxBytes).toBe(512 * 1024 * 1024);
+    expect("consumer" in parsed.devImplement).toBe(false);
+    // The two stream names MUST differ — they own disjoint subject spaces, and
+    // a shared name would clash on `streams.add`.
+    expect(parsed.devImplement.stream.name).not.toBe(parsed.review.stream.name);
+  });
+
+  test("BusDevImplementConfigSchema honors explicit overrides", () => {
+    const parsed = BusDevImplementConfigSchema.parse({
+      stream: { name: "MY_DEV", maxAgeSeconds: 3600, maxBytes: 1024 },
+    });
+    expect(parsed.stream.name).toBe("MY_DEV");
+    expect(parsed.stream.maxAgeSeconds).toBe(3600);
+    expect(parsed.stream.maxBytes).toBe(1024);
+  });
+
+  test("BusDevImplementConfigSchema rejects non-positive stream limits", () => {
+    expect(() =>
+      BusDevImplementConfigSchema.parse({ stream: { maxAgeSeconds: 0 } }),
+    ).toThrow();
+    expect(() =>
+      BusDevImplementConfigSchema.parse({ stream: { maxBytes: -1 } }),
+    ).toThrow();
+    expect(() =>
+      BusDevImplementConfigSchema.parse({ stream: { name: "" } }),
+    ).toThrow();
   });
 });
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -987,6 +987,54 @@ export const BusReviewConfigSchema = z.object({
   }).default({ maxDeliver: 5 }),
 });
 
+/**
+ * dev.implement JetStream provisioning knobs (F-2.2, cortex#835 → cortex#865).
+ * Tune cortex's DEV_IMPLEMENT stream — the durable-history stream that carries
+ * the `tasks.dev.implement` request envelopes the agentic dev-loop's dev-agent
+ * consumer (F-2.1, cortex#853) binds a DURABLE pull consumer against, instead
+ * of racing a transient core-NATS subscription against a virgin broker.
+ *
+ * Subjects (derived at boot from the stack identity, NOT configured here):
+ *   - `local.{principal}.{stack}.tasks.dev.>`   (the dev task family)
+ *
+ * This NEVER overlaps the CODE_REVIEW stream (`…tasks.code-review.>`) NOR the
+ * REVIEW_LIFECYCLE stream (`…review.verdict.>` / `…code.pr.review.>` /
+ * `…dispatch.task.>`): JetStream rejects overlapping subjects across streams,
+ * and `tasks.dev.` and `tasks.code-review.` diverge at segment 5 (the token
+ * after `tasks.`), so no subject of one is a prefix of any subject of another.
+ *
+ * Posture mirrors `BusReviewConfigSchema.stream` EXACTLY (Interest retention,
+ * File storage, 24h max_age, finite 512 MiB max_bytes). There is intentionally
+ * NO `consumer` sub-block: cortex provisions the stream only; the durable
+ * consumer that reads it is the dev-agent's concern (F-2.1, cortex#853).
+ */
+export const BusDevImplementConfigSchema = z.object({
+  stream: z.object({
+    /**
+     * Stream name that carries the `tasks.dev.implement` request envelopes.
+     * MUST differ from `bus.review.stream.name` (the streams own disjoint
+     * subject spaces; a shared name would clash on `streams.add`).
+     */
+    name: z.string().min(1).default("DEV_IMPLEMENT"),
+    /** How long unclaimed dev-task messages remain replayable in JetStream. */
+    maxAgeSeconds: z
+      .number()
+      .int("bus.devImplement.stream.maxAgeSeconds must be an integer number of seconds")
+      .positive("bus.devImplement.stream.maxAgeSeconds must be positive")
+      .default(86_400),
+    /** Finite storage cap; avoids account-level reservation failures. */
+    maxBytes: z
+      .number()
+      .int("bus.devImplement.stream.maxBytes must be an integer number of bytes")
+      .positive("bus.devImplement.stream.maxBytes must be positive")
+      .default(512 * 1024 * 1024),
+  }).default({
+    name: "DEV_IMPLEMENT",
+    maxAgeSeconds: 86_400,
+    maxBytes: 512 * 1024 * 1024,
+  }),
+});
+
 export const BusConfigSchema = z.object({
   review: BusReviewConfigSchema.default({
     stream: {
@@ -996,10 +1044,23 @@ export const BusConfigSchema = z.object({
     },
     consumer: { maxDeliver: 5 },
   }),
+  // F-2.2 (cortex#835 → cortex#865) — DEV_IMPLEMENT stream knobs. Sibling of
+  // the REVIEW_LIFECYCLE block (cortex#851); both provision a SECOND durable
+  // stream over a disjoint subject space so a downstream durable consumer can
+  // replay history. Stream-only (no consumer sub-block) — the dev-agent's
+  // durable consumer (F-2.1, cortex#853) owns the consumer side.
+  devImplement: BusDevImplementConfigSchema.default({
+    stream: {
+      name: "DEV_IMPLEMENT",
+      maxAgeSeconds: 86_400,
+      maxBytes: 512 * 1024 * 1024,
+    },
+  }),
 });
 
 export type BusConfig = z.infer<typeof BusConfigSchema>;
 export type BusReviewConfig = z.infer<typeof BusReviewConfigSchema>;
+export type BusDevImplementConfig = z.infer<typeof BusDevImplementConfigSchema>;
 
 // =============================================================================
 // Cross-cutting infra blocks — carried forward in same shape as AgentConfig

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1221,6 +1221,14 @@ export async function startCortex(
     // this stream is a structural enabler. NOTE: retention is INTEREST — with
     // zero registered consumers the stream retains NOTHING, so replay-from-
     // history begins only once the first durable dev consumer is bound.
+    // KNOWN COUPLING (#875 review nit 2): the gate is `resolveReviewProvisioningJsm`,
+    // which returns null when there are zero REVIEW-capable agents. So a
+    // hypothetical dev-ONLY stack (a dev-capable agent but no code-review agent)
+    // would silently skip provisioning DEV_IMPLEMENT even though its dev consumer
+    // needs it. Not reachable today (every production stack runs a reviewer),
+    // but the proper fix is to gate DEV_IMPLEMENT on dev-capable-agent presence
+    // independently of review agents — tracked as a follow-up (see cortex#835
+    // phase #865). Documented here so a future dev-only operator isn't surprised.
     // (Boundary comment kept loud so the expected #851/#874 merge is trivial.)
     try {
       const devOutcome = await provisionReviewStream({

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1103,6 +1103,20 @@ export async function startCortex(
     reviewConfig?.stream.maxBytes ?? 512 * 1024 * 1024;
   const reviewConsumerMaxDeliver = reviewConfig?.consumer.maxDeliver ?? 5;
 
+  // ── F-2.2 (cortex#835 → cortex#865) DEV_IMPLEMENT config ──────────────────
+  // Resolve the DEV_IMPLEMENT stream knobs alongside the review knobs. Sibling
+  // of the REVIEW_LIFECYCLE block (cortex#851). The actual provisioning rides
+  // the SAME `reviewJsm !== null` gate below so it inherits byte-identical
+  // dormant behaviour when the bus/JetStream is unconfigured. (Boundary comment
+  // kept loud so the expected #851/#874 boot-section merge conflict is trivial.)
+  const devImplementConfig = options.bus?.devImplement;
+  const devImplementStream = devImplementConfig?.stream.name ?? "DEV_IMPLEMENT";
+  const devImplementStreamMaxAgeNs =
+    (devImplementConfig?.stream.maxAgeSeconds ?? 86_400) * 1_000_000_000;
+  const devImplementStreamMaxBytes =
+    devImplementConfig?.stream.maxBytes ?? 512 * 1024 * 1024;
+  // ── /F-2.2 DEV_IMPLEMENT config ───────────────────────────────────────────
+
   // cortex#338 — resolve the provisioning JSM and provision the
   // CODE_REVIEW stream up-front so the per-agent `ReviewConsumer.start`
   // calls below can bind without hitting "stream not found" against a
@@ -1135,6 +1149,34 @@ export async function startCortex(
       ]
     : [reviewSubjectPattern];
 
+  // ── F-2.2 (cortex#835 → cortex#865) DEV_IMPLEMENT subject set ─────────────
+  // The dev-loop's dev-agent consumer (F-2.1, cortex#853) subscribes on
+  // `local.{principal}.{stack}.tasks.dev.implement` and binds the durable on
+  // stream `DEV_IMPLEMENT`. The stream filter covers the whole `tasks.dev.>`
+  // family (the exact subject the consumer subscribes, plus room for future
+  // `tasks.dev.*` capabilities) so the consumer's `consumers.get(stream, …)`
+  // never hits "stream not found" against a virgin broker.
+  //
+  // OVERLAP ANALYSIS (JetStream rejects overlapping subjects across streams):
+  //   CODE_REVIEW       owns `…tasks.code-review.>`
+  //   REVIEW_LIFECYCLE  owns `…review.verdict.>` / `…code.pr.review.>` /
+  //                          `…dispatch.task.>`   (cortex#851, sibling stream)
+  //   DEV_IMPLEMENT     owns `…tasks.dev.>`        (THIS stream)
+  // `tasks.dev.` and `tasks.code-review.` diverge at segment 5 (the token after
+  // `tasks.`): neither is a prefix of the other, so no subject of DEV_IMPLEMENT
+  // is a prefix of (or prefixed by) any CODE_REVIEW / REVIEW_LIFECYCLE subject.
+  // The three streams partition the subject space cleanly. The overlap-invariant
+  // test (cortex.dev-stream-boot.test.ts) is the codified guard at boot.
+  //
+  // Federated dev traffic is intentionally NOT mirrored here — the dev-loop is
+  // principal-local (F-5 federation is a later slice); a federated-history
+  // follow-up can extend this set under `federationConfigured` the same way
+  // `reviewStreamSubjects` does, when a cross-principal dev consumer needs it.
+  const devImplementStreamSubjects = [
+    `local.${reviewPrincipalId}.${derivedStack.stack}.tasks.dev.>`,
+  ];
+  // ── /F-2.2 DEV_IMPLEMENT subject set ──────────────────────────────────────
+
   if (reviewJsm !== null) {
     try {
       const outcome = await provisionReviewStream({
@@ -1164,6 +1206,47 @@ export async function startCortex(
           `${err instanceof Error ? err.message : String(err)}\n`,
       );
     }
+
+    // ── F-2.2 (cortex#835 → cortex#865) provision DEV_IMPLEMENT ─────────────
+    // Provision the DEV_IMPLEMENT stream in the SAME `reviewJsm !== null` gate
+    // so it inherits the identical config posture as CODE_REVIEW: created iff a
+    // JSM resolved (review-capable agents present AND `runtime.jetstreamManager`
+    // available), skipped entirely when the runtime is dormant — byte-identical
+    // boot when the bus/JetStream is unconfigured. Reuses the generic
+    // `provisionReviewStream` helper (idempotent ensure, Interest retention,
+    // File storage, drift-warning) — only name / subjects / limits differ.
+    // A failure here does NOT abort boot, identical to CODE_REVIEW. The
+    // dev-agent consumer (F-2.1, cortex#853) binds its durable against this
+    // stream; until a dev-capable agent exists that consumer never wires, so
+    // this stream is a structural enabler. NOTE: retention is INTEREST — with
+    // zero registered consumers the stream retains NOTHING, so replay-from-
+    // history begins only once the first durable dev consumer is bound.
+    // (Boundary comment kept loud so the expected #851/#874 merge is trivial.)
+    try {
+      const devOutcome = await provisionReviewStream({
+        jsm: reviewJsm,
+        name: devImplementStream,
+        subjects: devImplementStreamSubjects,
+        maxAgeNs: devImplementStreamMaxAgeNs,
+        maxBytes: devImplementStreamMaxBytes,
+      });
+      if (devOutcome === "created") {
+        console.log(
+          `cortex: provisioned JetStream stream "${devImplementStream}" (subjects=[${devImplementStreamSubjects.join(", ")}])`,
+        );
+      } else if (devOutcome === "exists") {
+        console.log(
+          `cortex: JetStream stream "${devImplementStream}" already present — binding existing config`,
+        );
+      }
+      // config-drift-warning is already logged by the helper.
+    } catch (err) {
+      process.stderr.write(
+        `cortex: provisionReviewStream failed for "${devImplementStream}": ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    // ── /F-2.2 provision DEV_IMPLEMENT ──────────────────────────────────────
   }
 
   for (const agent of reviewCapableAgents) {


### PR DESCRIPTION
## What

Provisions a **`DEV_IMPLEMENT`** JetStream stream over the dev-task subject family `local.{principal}.{stack}.tasks.dev.>`, so the agentic dev-loop's **dev-agent consumer (F-2.1, cortex#853)** can bind a durable pull consumer and replay history instead of racing a transient core-NATS subscription against a virgin broker.

This is the **exact sibling** of the REVIEW_LIFECYCLE provisioning PR (cortex#851). The F-2.1 PR explicitly flagged this stream as the sibling slice (its boot block already references `stream: "DEV_IMPLEMENT"` + subscribes `…tasks.dev.implement`).

Refs **cortex#835** (epic) → **cortex#865** (phase). Design §6 / the F-2.1 flag.

## Changes

| File | Change |
|---|---|
| `src/common/types/cortex-config.ts` | New `BusDevImplementConfigSchema` (mirrors `BusReviewConfigSchema.stream` exactly — Interest/File/24h/512 MiB; **stream-only, no consumer sub-block**). Wired into `BusConfigSchema` as `bus.devImplement`. |
| `src/cortex.ts` | Boot block provisions `DEV_IMPLEMENT` via the generic `provisionReviewStream` helper, inside the **same `reviewJsm !== null` gate** as CODE_REVIEW. Delimited with loud `── F-2.2 ──` boundary comments. |
| `src/__tests__/cortex.dev-stream-boot.test.ts` | Boot-wiring tests (provision + **overlap-invariant** + config-gating), mirroring `cortex.lifecycle-stream-boot.test.ts`. |
| `src/common/types/__tests__/cortex-config.test.ts` | Schema defaults / override / reject tests. |
| `src/common/agents/__tests__/registry.test.ts` | Fixture: add `bus.devImplement` to the typed `CortexConfig` literal. |

## Stream config

```
name:       DEV_IMPLEMENT
subjects:   [ local.{principal}.{stack}.tasks.dev.> ]
retention:  Interest      storage:   File
max_age:    86_400 s      max_bytes: 512 MiB
max_msgs:   -1            num_replicas: 1
```

Subject set covers the exact subject the F-2.1 consumer subscribes (`…tasks.dev.implement`) plus room for future `tasks.dev.*` capabilities.

## Overlap analysis (no overlapping subjects — JetStream rejects them)

| Stream | Subjects |
|---|---|
| `CODE_REVIEW` | `…tasks.code-review.>` |
| `REVIEW_LIFECYCLE` (cortex#851) | `…review.verdict.>` / `…code.pr.review.>` / `…dispatch.task.>` |
| **`DEV_IMPLEMENT`** (this PR) | `…tasks.dev.>` |

`tasks.dev.` and `tasks.code-review.` **diverge at segment 5** (the token after `tasks.`): neither is a prefix of the other, so no subject of `DEV_IMPLEMENT` is a prefix of (or prefixed by) any `CODE_REVIEW`/`REVIEW_LIFECYCLE` subject. The three streams partition the subject space cleanly. The **overlap-invariant test** is the codified boot guard (mirrors #851's).

## Config-gated / byte-identical dormant boot

DEV_IMPLEMENT provisioning rides the **same `reviewJsm !== null` gate** as CODE_REVIEW: created iff a JSM resolves; skipped entirely when the runtime is dormant (NATS absent / JetStream unconfigured). Retention is `Interest` — with zero registered consumers the stream retains nothing, so this is a **structural enabler**; replay-from-history begins once F-2.1's first durable dev consumer binds.

## Merge-coordination note

⚠️ cortex#851 (REVIEW_LIFECYCLE) and cortex#874 (release-consumer boot) **also touch `src/cortex.ts`'s boot section** and are stacked behind the same gate. This PR's boot-block additions **will merge-conflict with theirs at batch-merge time — that is expected and resolved then.** The additions here are wrapped in loud `── F-2.2 ──` / `── /F-2.2 ──` boundary comments specifically so the conflict is trivial to resolve.

## Gates

- `bunx tsc --noEmit` — clean
- `bunx eslint --quiet src/` — clean
- `bun test` (full) — **5259 pass / 0 fail** (2 skip)
- `scripts/check-carveouts.sh` — PASS
- boot smoke (`cortex.*-boot.test.ts`) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)