### PR TITLE
feat(cli): F-6a — cortex config merge (capabilities/policy fragments → config-split layers)

### DIFF
--- a/src/cli/cortex/commands/__tests__/config-merge.test.ts
+++ b/src/cli/cortex/commands/__tests__/config-merge.test.ts
@@ -1,0 +1,468 @@
+/**
+ * config-merge tests (F-6a, cortex#858) — TDD-first, mirroring the
+ * normalize-config test style: pure merge functions with fixtures + the CLI
+ * file-I/O path (runConfigMerge against a tmp config-split dir).
+ *
+ * Coverage:
+ *   Pure
+ *     1. CapabilityMergeFragmentSchema — accepts caps-only, policy-only, both
+ *     2. CapabilityMergeFragmentSchema — rejects empty, rejects extra keys
+ *     3. mergeFragmentIntoLayer — append new capability into empty layer
+ *     4. mergeFragmentIntoLayer — idempotent (same fragment twice → skipped)
+ *     5. mergeFragmentIntoLayer — fragment-wins on id-match-but-different
+ *     6. mergeFragmentIntoLayer — policy principals + roles id-keyed append
+ *     7. mergeFragmentIntoLayer — does not mutate input
+ *     8. removeFragmentFromLayer — removes by id; absent id is a no-op
+ *     9. summariseNotes — added/skipped/changed phrasing + idempotent marker
+ *    10. deepMerge edge cases via id-keyed merge (empty base / null policy)
+ *   CLI (file I/O)
+ *    11. --help exits 0
+ *    12. missing --config / --fragment → exit 2 (usage)
+ *    13. merge into config-split stacks/research.yaml + writes backup
+ *    14. idempotent: second run = no write (no new backup)
+ *    15. --dry-run: validates, prints diff, no write
+ *    16. --stack required when >1 stack file; selects correct file
+ *    17. --rollback removes the capability
+ *    18. merged config that breaks CortexConfigSchema → exit 1, no write
+ *    19. fragment with extra top-level key → exit 1 (schema reject)
+ */
+
+import { describe, expect, test, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, chmodSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import YAML from "yaml";
+
+import {
+  CapabilityMergeFragmentSchema,
+  mergeFragmentIntoLayer,
+  removeFragmentFromLayer,
+  summariseNotes,
+  resolveTarget,
+  runConfigMerge,
+  type CapabilityMergeFragment,
+} from "../config-merge";
+
+type Rec = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CAP_DEV: Rec = {
+  id: "dev.implement",
+  description: "Dev agent implementation",
+  tags: ["dev"],
+  provided_by: ["dev-agent"],
+};
+
+const CAP_DEV_V2: Rec = {
+  id: "dev.implement",
+  description: "Dev agent implementation (revised)",
+  tags: ["dev", "code"],
+  provided_by: ["dev-agent"],
+};
+
+const ROLE_DEVELOP: Rec = {
+  id: "develop",
+  capabilities: ["dev.implement"],
+};
+
+const PRINCIPAL_DEV: Rec = {
+  id: "dev-agent",
+  home_principal: "andreas",
+  home_stack: "andreas/research",
+  role: ["develop"],
+};
+
+function fragment(partial: Rec): CapabilityMergeFragment {
+  return CapabilityMergeFragmentSchema.parse(partial);
+}
+
+// A complete, valid cortex.yaml shape for a config-split stack layer. Combined
+// with the minimal system.yaml below it composes into a valid CortexConfig.
+function stackLayer(extra: Rec = {}): Rec {
+  return {
+    principal: { id: "andreas", displayName: "Andreas", discordId: "123456789012345678" },
+    stack: { id: "andreas/research" },
+    agents: [
+      {
+        id: "dev-agent",
+        displayName: "Dev Agent",
+        persona: "./personas/dev.md",
+        presence: {
+          discord: {
+            token: "DISCORD_TOKEN",
+            guildId: "123456789012345678",
+            agentChannelId: "234567890123456789",
+            logChannelId: "345678901234567890",
+          },
+        },
+      },
+    ],
+    ...extra,
+  };
+}
+
+const SYSTEM_YAML = YAML.stringify({
+  claude: { model: "claude-opus-4-5", apiKey: "env:ANTHROPIC_API_KEY" },
+});
+
+// ---------------------------------------------------------------------------
+// 1–2. Fragment schema
+// ---------------------------------------------------------------------------
+
+describe("CapabilityMergeFragmentSchema", () => {
+  test("accepts capabilities-only", () => {
+    const f = CapabilityMergeFragmentSchema.safeParse({ capabilities: [CAP_DEV] });
+    expect(f.success).toBe(true);
+  });
+
+  test("accepts policy-only", () => {
+    const f = CapabilityMergeFragmentSchema.safeParse({
+      policy: { principals: [PRINCIPAL_DEV], roles: [ROLE_DEVELOP] },
+    });
+    expect(f.success).toBe(true);
+  });
+
+  test("accepts both capabilities + policy", () => {
+    const f = CapabilityMergeFragmentSchema.safeParse({
+      capabilities: [CAP_DEV],
+      policy: { roles: [ROLE_DEVELOP] },
+    });
+    expect(f.success).toBe(true);
+  });
+
+  test("rejects empty fragment (no capabilities, no policy)", () => {
+    const f = CapabilityMergeFragmentSchema.safeParse({});
+    expect(f.success).toBe(false);
+  });
+
+  test("rejects extra top-level key (agents)", () => {
+    const f = CapabilityMergeFragmentSchema.safeParse({
+      capabilities: [CAP_DEV],
+      agents: [{ id: "x" }],
+    });
+    expect(f.success).toBe(false);
+  });
+
+  test("rejects extra policy sub-key", () => {
+    const f = CapabilityMergeFragmentSchema.safeParse({
+      policy: { principals: [], roles: [], superRefineTrap: true },
+    });
+    expect(f.success).toBe(false);
+  });
+
+  test("rejects malformed capability id (uppercase)", () => {
+    const f = CapabilityMergeFragmentSchema.safeParse({
+      capabilities: [{ ...CAP_DEV, id: "Dev.Implement" }],
+    });
+    expect(f.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3–7. mergeFragmentIntoLayer
+// ---------------------------------------------------------------------------
+
+describe("mergeFragmentIntoLayer", () => {
+  test("appends a new capability into an empty layer", () => {
+    const { layer, notes } = mergeFragmentIntoLayer({}, fragment({ capabilities: [CAP_DEV] }));
+    const caps = layer.capabilities as Rec[];
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.id).toBe("dev.implement");
+    expect(notes).toEqual([{ kind: "capability", id: "dev.implement", action: "added" }]);
+  });
+
+  test("idempotent — same fragment twice yields skipped on second", () => {
+    const f = fragment({ capabilities: [CAP_DEV] });
+    const first = mergeFragmentIntoLayer({}, f);
+    const second = mergeFragmentIntoLayer(first.layer, f);
+    expect((second.layer.capabilities as Rec[])).toHaveLength(1);
+    expect(second.notes).toEqual([{ kind: "capability", id: "dev.implement", action: "skipped" }]);
+  });
+
+  test("fragment wins on id-match-but-different (changed)", () => {
+    const base = mergeFragmentIntoLayer({}, fragment({ capabilities: [CAP_DEV] })).layer;
+    const { layer, notes } = mergeFragmentIntoLayer(base, fragment({ capabilities: [CAP_DEV_V2] }));
+    const caps = layer.capabilities as Rec[];
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.description).toBe("Dev agent implementation (revised)");
+    expect(notes).toEqual([{ kind: "capability", id: "dev.implement", action: "changed" }]);
+  });
+
+  test("policy principals + roles id-keyed append", () => {
+    const { layer, notes } = mergeFragmentIntoLayer(
+      {},
+      fragment({ policy: { principals: [PRINCIPAL_DEV], roles: [ROLE_DEVELOP] } }),
+    );
+    const policy = layer.policy as Rec;
+    expect((policy.principals as Rec[])).toHaveLength(1);
+    expect((policy.roles as Rec[])).toHaveLength(1);
+    expect(notes.some((n) => n.kind === "principal" && n.action === "added")).toBe(true);
+    expect(notes.some((n) => n.kind === "role" && n.action === "added")).toBe(true);
+  });
+
+  test("merges into an existing policy without dropping prior principals", () => {
+    const existing: Rec = {
+      policy: {
+        principals: [{ id: "andreas", home_principal: "andreas", home_stack: "andreas/research", role: [] }],
+        roles: [],
+      },
+    };
+    const { layer } = mergeFragmentIntoLayer(existing, fragment({ policy: { principals: [PRINCIPAL_DEV] } }));
+    const principals = (layer.policy as Rec).principals as Rec[];
+    expect(principals.map((p) => p.id).sort()).toEqual(["andreas", "dev-agent"]);
+  });
+
+  test("does not mutate input layer", () => {
+    const input: Rec = { capabilities: [structuredClone(CAP_DEV)] };
+    const snapshot = JSON.stringify(input);
+    mergeFragmentIntoLayer(input, fragment({ capabilities: [CAP_DEV_V2] }));
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. removeFragmentFromLayer
+// ---------------------------------------------------------------------------
+
+describe("removeFragmentFromLayer", () => {
+  test("removes a capability by id", () => {
+    const base = mergeFragmentIntoLayer({}, fragment({ capabilities: [CAP_DEV] })).layer;
+    const { layer, notes } = removeFragmentFromLayer(base, fragment({ capabilities: [CAP_DEV] }));
+    expect((layer.capabilities as Rec[])).toHaveLength(0);
+    expect(notes).toEqual([{ kind: "capability", id: "dev.implement", action: "removed" }]);
+  });
+
+  test("absent id is a no-op (absent note)", () => {
+    const { layer, notes } = removeFragmentFromLayer({}, fragment({ capabilities: [CAP_DEV] }));
+    expect((layer.capabilities as Rec[])).toHaveLength(0);
+    expect(notes).toEqual([{ kind: "capability", id: "dev.implement", action: "absent" }]);
+  });
+
+  test("removes policy principals + roles by id", () => {
+    const base = mergeFragmentIntoLayer(
+      {},
+      fragment({ policy: { principals: [PRINCIPAL_DEV], roles: [ROLE_DEVELOP] } }),
+    ).layer;
+    const { layer } = removeFragmentFromLayer(
+      base,
+      fragment({ policy: { principals: [PRINCIPAL_DEV], roles: [ROLE_DEVELOP] } }),
+    );
+    const policy = layer.policy as Rec;
+    expect((policy.principals as Rec[])).toHaveLength(0);
+    expect((policy.roles as Rec[])).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. summariseNotes
+// ---------------------------------------------------------------------------
+
+describe("summariseNotes", () => {
+  test("phrases added + skipped", () => {
+    const s = summariseNotes([
+      { kind: "capability", id: "a", action: "added" },
+      { kind: "capability", id: "b", action: "added" },
+      { kind: "role", id: "r", action: "skipped" },
+    ]);
+    expect(s).toContain("2 capabilities added");
+    expect(s).toContain("1 roles skipped");
+  });
+
+  test("marks idempotent no-op when every note is skipped/absent", () => {
+    const s = summariseNotes([{ kind: "capability", id: "a", action: "skipped" }]);
+    expect(s).toContain("idempotent no-op");
+  });
+
+  test("empty notes → no changes", () => {
+    expect(summariseNotes([])).toBe("no changes");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI file-I/O — runConfigMerge against tmp config-split dirs
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "config-merge-test-"));
+});
+
+/** Build a config-split dir with system/ + one (or more) stack files. */
+function makeSplitDir(stacks: Record<string, Rec>): string {
+  const dir = join(tmpDir, `cfg-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(join(dir, "system"), { recursive: true });
+  mkdirSync(join(dir, "stacks"), { recursive: true });
+  writeFileSync(join(dir, "system", "system.yaml"), SYSTEM_YAML, "utf-8");
+  for (const [name, content] of Object.entries(stacks)) {
+    writeFileSync(join(dir, "stacks", `${name}.yaml`), YAML.stringify(content, { lineWidth: 0 }), "utf-8");
+  }
+  return dir;
+}
+
+function writeFragment(name: string, content: Rec): string {
+  const p = join(tmpDir, name);
+  writeFileSync(p, YAML.stringify(content, { lineWidth: 0 }), "utf-8");
+  return p;
+}
+
+describe("runConfigMerge — CLI", () => {
+  test("--help exits 0", async () => {
+    expect(await runConfigMerge(["--help"])).toBe(0);
+  });
+
+  test("missing --config exits 2 (usage)", async () => {
+    expect(await runConfigMerge(["--fragment", "x.yaml"])).toBe(2);
+  });
+
+  test("missing --fragment exits 2 (usage)", async () => {
+    expect(await runConfigMerge(["--config", "x"])).toBe(2);
+  });
+
+  test("unknown flag exits 2 (usage)", async () => {
+    expect(await runConfigMerge(["--nope"])).toBe(2);
+  });
+
+  test("merges a capability into a single-stack split dir + writes backup", async () => {
+    const dir = makeSplitDir({ research: stackLayer() });
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV] });
+
+    const code = await runConfigMerge(["--config", dir, "--fragment", frag]);
+    expect(code).toBe(0);
+
+    const written = YAML.parse(readFileSync(join(dir, "stacks", "research.yaml"), "utf-8")) as Rec;
+    const caps = written.capabilities as Rec[];
+    expect(caps.map((c) => c.id)).toContain("dev.implement");
+
+    const backups = readdirSync(join(dir, "stacks")).filter((f) => f.includes(".pre-config-merge-"));
+    expect(backups.length).toBe(1);
+  });
+
+  test("idempotent — second run writes nothing (no second backup)", async () => {
+    const dir = makeSplitDir({ research: stackLayer() });
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV] });
+
+    expect(await runConfigMerge(["--config", dir, "--fragment", frag])).toBe(0);
+    expect(await runConfigMerge(["--config", dir, "--fragment", frag])).toBe(0);
+
+    const backups = readdirSync(join(dir, "stacks")).filter((f) => f.includes(".pre-config-merge-"));
+    expect(backups.length).toBe(1); // only the first run produced a backup
+  });
+
+  test("--dry-run validates + prints diff but does NOT write", async () => {
+    const dir = makeSplitDir({ research: stackLayer() });
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV] });
+    const before = readFileSync(join(dir, "stacks", "research.yaml"), "utf-8");
+
+    const code = await runConfigMerge(["--config", dir, "--fragment", frag, "--dry-run"]);
+    expect(code).toBe(0);
+
+    const after = readFileSync(join(dir, "stacks", "research.yaml"), "utf-8");
+    expect(after).toBe(before);
+    const backups = readdirSync(join(dir, "stacks")).filter((f) => f.includes(".pre-config-merge-"));
+    expect(backups.length).toBe(0);
+  });
+
+  test("--stack required when >1 stack file; selects the right one", async () => {
+    const dir = makeSplitDir({
+      research: stackLayer(),
+      work: stackLayer({ stack: { id: "andreas/work" } }),
+    });
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV] });
+
+    // No --stack with 2 stack files → exit 1 (ambiguous target).
+    expect(await runConfigMerge(["--config", dir, "--fragment", frag])).toBe(1);
+
+    // --stack by declared id selects work.yaml.
+    const code = await runConfigMerge(["--config", dir, "--fragment", frag, "--stack", "andreas/work"]);
+    expect(code).toBe(0);
+
+    const work = YAML.parse(readFileSync(join(dir, "stacks", "work.yaml"), "utf-8")) as Rec;
+    expect((work.capabilities as Rec[]).map((c) => c.id)).toContain("dev.implement");
+    const research = YAML.parse(readFileSync(join(dir, "stacks", "research.yaml"), "utf-8")) as Rec;
+    expect(research.capabilities).toBeUndefined(); // untouched
+  });
+
+  test("--rollback removes the capability", async () => {
+    const dir = makeSplitDir({ research: stackLayer({ capabilities: [CAP_DEV] }) });
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV] });
+
+    const code = await runConfigMerge(["--config", dir, "--fragment", frag, "--rollback"]);
+    expect(code).toBe(0);
+
+    const written = YAML.parse(readFileSync(join(dir, "stacks", "research.yaml"), "utf-8")) as Rec;
+    expect((written.capabilities as Rec[])).toHaveLength(0);
+  });
+
+  test("merge that breaks CortexConfigSchema → exit 1, no write", async () => {
+    // Capability whose provided_by names a non-existent agent → the
+    // composed-whole superRefine (dangling provider) fails.
+    const dir = makeSplitDir({ research: stackLayer() });
+    const badCap = { ...CAP_DEV, provided_by: ["ghost-agent"] };
+    const frag = writeFragment("frag.yaml", { capabilities: [badCap] });
+    const before = readFileSync(join(dir, "stacks", "research.yaml"), "utf-8");
+
+    const code = await runConfigMerge(["--config", dir, "--fragment", frag]);
+    expect(code).toBe(1);
+
+    const after = readFileSync(join(dir, "stacks", "research.yaml"), "utf-8");
+    expect(after).toBe(before); // original intact
+  });
+
+  test("fragment with extra top-level key → exit 1 (schema reject)", async () => {
+    const dir = makeSplitDir({ research: stackLayer() });
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV], nats: { subjects: [] } });
+    expect(await runConfigMerge(["--config", dir, "--fragment", frag])).toBe(1);
+  });
+
+  test("nonexistent --config exits 1", async () => {
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV] });
+    expect(await runConfigMerge(["--config", join(tmpDir, "nope"), "--fragment", frag])).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTarget — single-file legacy form
+// ---------------------------------------------------------------------------
+
+describe("resolveTarget", () => {
+  test("single-file legacy: target IS the cortex.yaml", () => {
+    const p = join(tmpDir, "cortex.yaml");
+    writeFileSync(p, YAML.stringify(stackLayer()), "utf-8");
+    const t = resolveTarget(p, undefined);
+    expect(t.singleFile).toBe(true);
+    expect(t.filePath).toBe(p);
+  });
+
+  test("single-file + --stack → throws", () => {
+    const p = join(tmpDir, "cortex.yaml");
+    writeFileSync(p, YAML.stringify(stackLayer()), "utf-8");
+    expect(() => resolveTarget(p, "andreas/research")).toThrow();
+  });
+
+  test("split dir with 1 stack + no --stack → that stack", () => {
+    const dir = makeSplitDir({ research: stackLayer() });
+    const t = resolveTarget(dir, undefined);
+    expect(t.singleFile).toBe(false);
+    expect(t.filePath.endsWith("research.yaml")).toBe(true);
+  });
+
+  test("merges into single-file legacy config end-to-end", async () => {
+    const p = join(tmpDir, "cortex.yaml");
+    // Single-file form carries `claude` inline (no system/ layer to supply it).
+    const single = stackLayer({ claude: { model: "claude-opus-4-5", apiKey: "env:ANTHROPIC_API_KEY" } });
+    writeFileSync(p, YAML.stringify(single, { lineWidth: 0 }), "utf-8");
+    chmodSync(p, 0o600); // single-file loader enforces chmod 600 (TC-4a)
+    const frag = join(tmpDir, "frag.yaml");
+    writeFileSync(frag, YAML.stringify({ capabilities: [CAP_DEV] }, { lineWidth: 0 }), "utf-8");
+
+    const code = await runConfigMerge(["--config", p, "--fragment", frag]);
+    expect(code).toBe(0);
+    const written = YAML.parse(readFileSync(p, "utf-8")) as Rec;
+    expect((written.capabilities as Rec[]).map((c) => c.id)).toContain("dev.implement");
+    expect(existsSync(p)).toBe(true);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/config-merge.test.ts
+++ b/src/cli/cortex/commands/__tests__/config-merge.test.ts
@@ -28,7 +28,16 @@
  */
 
 import { describe, expect, test, beforeEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, chmodSync } from "fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+  chmodSync,
+  statSync,
+} from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import YAML from "yaml";
@@ -135,6 +144,19 @@ describe("CapabilityMergeFragmentSchema", () => {
 
   test("rejects empty fragment (no capabilities, no policy)", () => {
     const f = CapabilityMergeFragmentSchema.safeParse({});
+    expect(f.success).toBe(false);
+  });
+
+  test("rejects all-empty-arrays fragment (capabilities: [])", () => {
+    // review NIT-3: an empty capabilities array merges nothing.
+    const f = CapabilityMergeFragmentSchema.safeParse({ capabilities: [] });
+    expect(f.success).toBe(false);
+  });
+
+  test("rejects empty policy block (policy: {} → no principals/roles)", () => {
+    // review NIT-3: `policy: {}` would otherwise materialise as
+    // `policy: {principals: [], roles: []}`. Reject it.
+    const f = CapabilityMergeFragmentSchema.safeParse({ policy: {} });
     expect(f.success).toBe(false);
   });
 
@@ -339,6 +361,12 @@ describe("runConfigMerge — CLI", () => {
 
     const backups = readdirSync(join(dir, "stacks")).filter((f) => f.includes(".pre-config-merge-"));
     expect(backups.length).toBe(1);
+
+    // review NIT-1: the backup is chmod 600 (secret-at-rest perm).
+    const backupName = backups[0];
+    expect(backupName).toBeDefined();
+    const backupPath = join(dir, "stacks", backupName ?? "");
+    expect(statSync(backupPath).mode & 0o777).toBe(0o600);
   });
 
   test("idempotent — second run writes nothing (no second backup)", async () => {
@@ -364,6 +392,24 @@ describe("runConfigMerge — CLI", () => {
     expect(after).toBe(before);
     const backups = readdirSync(join(dir, "stacks")).filter((f) => f.includes(".pre-config-merge-"));
     expect(backups.length).toBe(0);
+  });
+
+  test("--dry-run (split form) leaves the target byte-identical AND mtime-unchanged", async () => {
+    // review MAJOR-1: validateComposed must NOT writeFileSync the real target
+    // (even transiently) for the split form — content AND mtime must be
+    // untouched after a dry-run that exercises the compose-validation path.
+    const dir = makeSplitDir({ research: stackLayer() });
+    const targetPath = join(dir, "stacks", "research.yaml");
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV] });
+
+    const before = readFileSync(targetPath, "utf-8");
+    const beforeMtime = statSync(targetPath).mtimeMs;
+
+    const code = await runConfigMerge(["--config", dir, "--fragment", frag, "--dry-run"]);
+    expect(code).toBe(0);
+
+    expect(readFileSync(targetPath, "utf-8")).toBe(before);
+    expect(statSync(targetPath).mtimeMs).toBe(beforeMtime); // never written, not even transiently
   });
 
   test("--stack required when >1 stack file; selects the right one", async () => {
@@ -395,6 +441,34 @@ describe("runConfigMerge — CLI", () => {
 
     const written = YAML.parse(readFileSync(join(dir, "stacks", "research.yaml"), "utf-8")) as Rec;
     expect((written.capabilities as Rec[])).toHaveLength(0);
+  });
+
+  test("--rollback that would orphan a role reference → exit 1, file unchanged", async () => {
+    // review MAJOR-2: rollback routes through validateComposed. A principal
+    // still references role `develop` (role[]); rolling back the role that
+    // declares it would leave a dangling principal.role[] ref → the composed
+    // config fails PolicySchema's cross-ref guard. The rollback must be REFUSED
+    // (exit 1) so the stack never goes unloadable, and the file stays put.
+    const dir = makeSplitDir({
+      research: stackLayer({
+        policy: {
+          principals: [PRINCIPAL_DEV], // PRINCIPAL_DEV.role = ["develop"]
+          roles: [ROLE_DEVELOP], // declares "develop"
+        },
+      }),
+    });
+    const targetPath = join(dir, "stacks", "research.yaml");
+    const before = readFileSync(targetPath, "utf-8");
+
+    // Roll back ONLY the role — the principal that references it survives.
+    const frag = writeFragment("frag.yaml", { policy: { roles: [ROLE_DEVELOP] } });
+    const code = await runConfigMerge(["--config", dir, "--fragment", frag, "--rollback"]);
+    expect(code).toBe(1);
+
+    // File untouched — rollback refused, stack stays valid.
+    expect(readFileSync(targetPath, "utf-8")).toBe(before);
+    const backups = readdirSync(join(dir, "stacks")).filter((f) => f.includes(".pre-config-merge-"));
+    expect(backups.length).toBe(0);
   });
 
   test("merge that breaks CortexConfigSchema → exit 1, no write", async () => {

--- a/src/cli/cortex/commands/config-merge.ts
+++ b/src/cli/cortex/commands/config-merge.ts
@@ -1,0 +1,843 @@
+#!/usr/bin/env bun
+/**
+ * `cortex config merge` — merge a package-declared capability/policy fragment
+ * into a cortex stack's config-split layers (F-6a, cortex#858).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * When arc installs a package onto a cortex stack (e.g. the `dev-loop`
+ * blueprint), the package's manifests declare the **capabilities** the new
+ * agents provide and the **policy** entries (principals + roles) that grant
+ * them. Today a principal must hand-edit `stacks/{stack-id}.yaml` to wire those
+ * in. F-6a delivers an automated, validated, idempotent merge so the arc
+ * install lifecycle (design §6.2 step 3) can compose config without a human in
+ * the loop.
+ *
+ * This slice ships the cortex-side verb only. The arc-side `cortex_config`
+ * manifest field + the `arc install` step-6c hook that CALLS this verb are a
+ * follow-up (cortex#858 "Arc Install Integration" + companion arc work).
+ *
+ * SCOPE — capabilities + policy ONLY
+ * ----------------------------------
+ * A merge fragment is a constrained subset of a cortex.yaml: it may carry
+ * `capabilities[]` and/or `policy{ principals[], roles[] }` and NOTHING else.
+ * It is NOT a full CortexConfig (which requires `principal` + `agents[]`); a
+ * fragment on its own is meaningless. The fragment is validated against
+ * `CapabilityMergeFragmentSchema` (this file), then MERGED onto the stack's
+ * existing config, and the COMPOSED WHOLE is validated against
+ * `CortexConfigSchema` before anything is written.
+ *
+ * MERGE SEMANTICS — id-keyed append, fragment-wins on conflict
+ * ------------------------------------------------------------
+ * `capabilities[]`, `policy.principals[]`, `policy.roles[]` are id-keyed
+ * collections, NOT replace-wholesale arrays. The loader's `deepMerge`
+ * (loader.ts:254) replaces arrays wholesale — correct for `nats.subjects[]`,
+ * WRONG here (it would drop every capability already declared on the stack).
+ * So this verb does an id-keyed UNION:
+ *   - id absent from the target → APPEND the fragment entry.
+ *   - id already present + byte-identical → SKIP (idempotent no-op + note).
+ *   - id already present + DIFFERENT → fragment WINS (replace the entry),
+ *     and a `changed:` note records the override.
+ * Scalar/object policy sub-keys outside the three id-keyed arrays are
+ * deep-merged fragment-wins via the same recursive merge as the loader.
+ *
+ * IDEMPOTENCY
+ * -----------
+ * Running the same fragment twice yields the same file on the second run:
+ * every entry matches an existing id byte-for-byte → all SKIP. This lets arc
+ * retry a partially-failed install safely.
+ *
+ * ROLLBACK (--rollback)
+ * ---------------------
+ * Given a fragment, REMOVE the corresponding capabilities/policy ids from the
+ * target (uninstall / recovery). Removal is by id; the post-removal config is
+ * re-validated against `CortexConfigSchema` so a rollback can't leave the stack
+ * in a state that won't load (e.g. an agent still referencing a removed
+ * capability surfaces as a Zod error, exit 1, no write).
+ *
+ * Usage:
+ *   bun src/cli/cortex/commands/config-merge.ts \
+ *     --config <cortex.yaml|config-dir> \
+ *     --fragment <fragment.yaml> \
+ *     [--stack <stack-id>] [--dry-run] [--rollback] [-h|--help]
+ *
+ * Flags:
+ *   --config DIR/FILE   Stack config-split dir (or legacy single cortex.yaml).
+ *   --fragment FILE     YAML fragment (capabilities + policy only).
+ *   --stack ID          Target stack id ({principal}/{stack}); required when
+ *                       the config dir holds more than one stacks/*.yaml.
+ *   --dry-run           Print the diff, validate, exit 0 — NO write.
+ *   --rollback          Remove the fragment's ids instead of merging them in.
+ *   -h, --help          Show this help.
+ *
+ * Exit codes:
+ *   0  — merged / rolled-back successfully (or idempotent no-op).
+ *   1  — failure (read/parse/schema error, ambiguous target, validation fail).
+ *   2  — usage error (bad flags, missing required arg).
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import YAML from "yaml";
+import { z } from "zod/v4";
+
+import { composeRawConfig } from "../../../common/config/loader";
+import { CapabilitySchema } from "../../../common/types/capability";
+import {
+  CortexConfigSchema,
+  PolicyPrincipalSchema,
+  PolicyRoleSchema,
+} from "../../../common/types/cortex-config";
+
+// =============================================================================
+// Fragment schema — capabilities + policy ONLY (the constrained subset)
+// =============================================================================
+
+/**
+ * The policy subset a fragment may carry. Mirrors the id-keyed arrays of the
+ * full `PolicySchema` but WITHOUT the `superRefine` cross-field guards — those
+ * only make sense on the composed WHOLE (a fragment's role refs resolve against
+ * the merged config, not the fragment in isolation). Structural per-entry
+ * validation (id grammar, required fields) still runs via the reused
+ * `PolicyPrincipalSchema` / `PolicyRoleSchema`.
+ *
+ * `.strict()` so a fragment author can't smuggle extra policy keys (e.g. a
+ * `superRefine`-only field) past the subset boundary.
+ */
+const FragmentPolicySchema = z
+  .object({
+    principals: z.array(PolicyPrincipalSchema).default([]),
+    roles: z.array(PolicyRoleSchema).default([]),
+  })
+  .strict();
+
+/**
+ * A merge fragment: capabilities + policy ONLY. `.strict()` rejects any other
+ * top-level key (`agents`, `principal`, `nats`, …) so a caller can't sneak a
+ * transport/identity change in through the merge path — those are NOT a
+ * package's to declare. At least one of the two blocks must be present (an
+ * empty fragment is a caller error, not a silent no-op).
+ */
+export const CapabilityMergeFragmentSchema = z
+  .object({
+    capabilities: z.array(CapabilitySchema).optional(),
+    policy: FragmentPolicySchema.optional(),
+  })
+  .strict()
+  .refine(
+    (f) => f.capabilities !== undefined || f.policy !== undefined,
+    {
+      message:
+        "fragment must declare at least one of `capabilities:` or `policy:` — an empty fragment merges nothing",
+    },
+  );
+
+export type CapabilityMergeFragment = z.infer<typeof CapabilityMergeFragmentSchema>;
+
+// =============================================================================
+// Pure merge core — no file I/O
+// =============================================================================
+
+/** A note describing one entry's disposition during a merge or rollback. */
+export interface MergeNote {
+  kind: "capability" | "principal" | "role";
+  id: string;
+  /** added: new entry. skipped: byte-identical idempotent no-op. changed:
+   * fragment overrode an existing different entry. removed: rollback removed
+   * it. absent: rollback target id was not present (no-op removal). */
+  action: "added" | "skipped" | "changed" | "removed" | "absent";
+}
+
+export interface MergeResult {
+  /** The merged target-layer object (deep clone; inputs are not mutated). */
+  layer: Record<string, unknown>;
+  notes: MergeNote[];
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Stable structural equality via canonical JSON (key order is irrelevant for
+ * config objects parsed from YAML; YAML.parse yields plain objects/arrays/
+ * scalars so JSON round-trips losslessly). Used to detect byte-identical
+ * idempotent entries. */
+function deepEqual(a: unknown, b: unknown): boolean {
+  return canonicalize(a) === canonicalize(b);
+}
+
+function canonicalize(v: unknown): string {
+  if (Array.isArray(v)) return `[${v.map(canonicalize).join(",")}]`;
+  if (isPlainObject(v)) {
+    const keys = Object.keys(v).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalize(v[k])}`).join(",")}}`;
+  }
+  if (v === undefined) return "null";
+  return JSON.stringify(v);
+}
+
+/** An id-keyed entry — the shape capabilities / principals / roles all share. */
+interface IdEntry {
+  readonly id: string;
+}
+
+/** Coerce the on-disk `base` value (which arrives as `unknown` from YAML.parse)
+ * into a cloned array of records. A missing/non-array base contributes []. */
+function cloneBaseArray(base: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(base)) return [];
+  return base.map((e) => structuredClone(e) as Record<string, unknown>);
+}
+
+/**
+ * Merge an id-keyed collection: append new ids, skip byte-identical, replace
+ * (fragment-wins) on id-match-but-different. Returns a new array + notes.
+ */
+function mergeIdKeyed(
+  base: unknown,
+  incoming: readonly IdEntry[],
+  kind: MergeNote["kind"],
+): { merged: Record<string, unknown>[]; notes: MergeNote[] } {
+  const out = cloneBaseArray(base);
+  const notes: MergeNote[] = [];
+  for (const entry of incoming) {
+    const id = entry.id;
+    const idx = out.findIndex((e) => String(e.id) === id);
+    const clone = structuredClone(entry) as unknown as Record<string, unknown>;
+    if (idx === -1) {
+      out.push(clone);
+      notes.push({ kind, id, action: "added" });
+    } else if (deepEqual(out[idx], entry)) {
+      notes.push({ kind, id, action: "skipped" });
+    } else {
+      out[idx] = clone;
+      notes.push({ kind, id, action: "changed" });
+    }
+  }
+  return { merged: out, notes };
+}
+
+/**
+ * Remove ids of an id-keyed collection (rollback). Returns a new array + notes.
+ */
+function removeIdKeyed(
+  base: unknown,
+  incoming: readonly IdEntry[],
+  kind: MergeNote["kind"],
+): { merged: Record<string, unknown>[]; notes: MergeNote[] } {
+  const out = cloneBaseArray(base);
+  const notes: MergeNote[] = [];
+  for (const entry of incoming) {
+    const id = entry.id;
+    const idx = out.findIndex((e) => String(e.id) === id);
+    if (idx === -1) {
+      notes.push({ kind, id, action: "absent" });
+    } else {
+      out.splice(idx, 1);
+      notes.push({ kind, id, action: "removed" });
+    }
+  }
+  return { merged: out, notes };
+}
+
+/**
+ * Merge `fragment` into `layer` (the target stack-layer object), id-keyed
+ * append fragment-wins. PURE — `layer` is not mutated. Empty result arrays are
+ * pruned so an unchanged block doesn't materialise as `capabilities: []`.
+ */
+export function mergeFragmentIntoLayer(
+  layer: Record<string, unknown>,
+  fragment: CapabilityMergeFragment,
+): MergeResult {
+  const out: Record<string, unknown> = structuredClone(layer);
+  const notes: MergeNote[] = [];
+
+  if (fragment.capabilities !== undefined) {
+    const { merged, notes: n } = mergeIdKeyed(out.capabilities, fragment.capabilities, "capability");
+    out.capabilities = merged;
+    notes.push(...n);
+  }
+
+  if (fragment.policy !== undefined) {
+    const policy: Record<string, unknown> = isPlainObject(out.policy)
+      ? structuredClone(out.policy)
+      : {};
+    if (fragment.policy.principals.length > 0) {
+      const { merged, notes: n } = mergeIdKeyed(policy.principals, fragment.policy.principals, "principal");
+      policy.principals = merged;
+      notes.push(...n);
+    }
+    if (fragment.policy.roles.length > 0) {
+      const { merged, notes: n } = mergeIdKeyed(policy.roles, fragment.policy.roles, "role");
+      policy.roles = merged;
+      notes.push(...n);
+    }
+    out.policy = policy;
+  }
+
+  return { layer: out, notes };
+}
+
+/**
+ * Rollback: remove the fragment's ids from `layer`. PURE. Mirror of
+ * `mergeFragmentIntoLayer`.
+ */
+export function removeFragmentFromLayer(
+  layer: Record<string, unknown>,
+  fragment: CapabilityMergeFragment,
+): MergeResult {
+  const out: Record<string, unknown> = structuredClone(layer);
+  const notes: MergeNote[] = [];
+
+  if (fragment.capabilities !== undefined) {
+    const { merged, notes: n } = removeIdKeyed(out.capabilities, fragment.capabilities, "capability");
+    out.capabilities = merged;
+    notes.push(...n);
+  }
+
+  if (fragment.policy !== undefined && isPlainObject(out.policy)) {
+    const policy: Record<string, unknown> = structuredClone(out.policy);
+    if (fragment.policy.principals.length > 0) {
+      const { merged, notes: n } = removeIdKeyed(policy.principals, fragment.policy.principals, "principal");
+      policy.principals = merged;
+      notes.push(...n);
+    }
+    if (fragment.policy.roles.length > 0) {
+      const { merged, notes: n } = removeIdKeyed(policy.roles, fragment.policy.roles, "role");
+      policy.roles = merged;
+      notes.push(...n);
+    }
+    out.policy = policy;
+  }
+
+  return { layer: out, notes };
+}
+
+/**
+ * Summarise notes into a human line, e.g.
+ *   "2 capabilities added, 1 skipped; 1 role changed".
+ * Returns "no changes" when every note is a no-op (skipped/absent).
+ */
+export function summariseNotes(notes: MergeNote[]): string {
+  const counts = new Map<string, number>();
+  for (const n of notes) {
+    const key = `${n.action}:${n.kind}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const order: MergeNote["action"][] = ["added", "changed", "removed", "skipped", "absent"];
+  const kindPlural: Record<MergeNote["kind"], string> = {
+    capability: "capabilities",
+    principal: "principals",
+    role: "roles",
+  };
+  const parts: string[] = [];
+  for (const action of order) {
+    for (const kind of ["capability", "principal", "role"] as MergeNote["kind"][]) {
+      const c = counts.get(`${action}:${kind}`);
+      if (c !== undefined && c > 0) {
+        parts.push(`${c} ${kindPlural[kind]} ${action}`);
+      }
+    }
+  }
+  if (parts.length === 0) return "no changes";
+  const effective = notes.some(
+    (n) => n.action === "added" || n.action === "changed" || n.action === "removed",
+  );
+  return effective ? parts.join(", ") : `${parts.join(", ")} (idempotent no-op)`;
+}
+
+// =============================================================================
+// Target-layer resolution
+// =============================================================================
+
+/** The marker file whose presence selects the config-split directory layout. */
+const LAYOUT_MARKER = join("system", "system.yaml");
+
+export interface ResolvedTarget {
+  /** Absolute path to the layer file the merge writes to. */
+  filePath: string;
+  /** The config dir to re-compose for whole-config validation. */
+  configDir: string;
+  /** Path to hand `composeRawConfig` (the config dir's pointer / the file). */
+  composePath: string;
+  /** True for the legacy single-file form (target IS the cortex.yaml). */
+  singleFile: boolean;
+}
+
+function listStackFiles(stacksDir: string): string[] {
+  if (!existsSync(stacksDir)) return [];
+  return readdirSync(stacksDir)
+    .filter((f) => !f.startsWith("."))
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+    .sort()
+    .map((f) => join(stacksDir, f));
+}
+
+/** Read a stack file's declared `stack.id` (or undefined if not declared). */
+function readStackId(filePath: string): string | undefined {
+  try {
+    const parsed = YAML.parse(readFileSync(filePath, "utf-8")) as unknown;
+    if (isPlainObject(parsed) && isPlainObject(parsed.stack) && typeof parsed.stack.id === "string") {
+      return parsed.stack.id;
+    }
+  } catch {
+    // A malformed stack file surfaces later during re-compose; for target
+    // resolution we just treat its id as undeclared (it won't match --stack).
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve which file the merge writes to from `--config` + optional `--stack`.
+ *
+ *  - Single-file legacy (`--config` points at a cortex.yaml with no sibling
+ *    system/system.yaml): the target IS that file.
+ *  - Config-split dir: target a `stacks/*.yaml`. `--stack` matches a file's
+ *    declared `stack.id` (or the file basename without extension). With no
+ *    `--stack`: one stack file → use it; zero or many → error.
+ *
+ * Throws (Error) with a clear, target-naming message on any ambiguity.
+ */
+export function resolveTarget(configPath: string, stackId: string | undefined): ResolvedTarget {
+  const resolved = resolve(configPath);
+  const stat = existsSync(resolved) ? statSync(resolved) : undefined;
+  if (stat === undefined) {
+    throw new Error(`--config path does not exist: ${resolved}`);
+  }
+
+  // Determine the config dir + the system marker location.
+  const configDir = stat.isDirectory() ? resolved : dirname(resolved);
+  const markerPath = join(configDir, LAYOUT_MARKER);
+
+  if (!existsSync(markerPath)) {
+    // Single-file legacy form. The target IS the cortex.yaml file. When
+    // `--config` is a directory with no marker we can't pick a single file.
+    if (stat.isDirectory()) {
+      throw new Error(
+        `--config ${resolved} is a directory with no ${LAYOUT_MARKER} marker — ` +
+          `point --config at the single cortex.yaml file, or at a config-split dir`,
+      );
+    }
+    if (stackId !== undefined) {
+      throw new Error(
+        `--stack ${stackId} given but --config ${resolved} is a single-file (legacy) config with no stacks/ layer`,
+      );
+    }
+    return { filePath: resolved, configDir, composePath: resolved, singleFile: true };
+  }
+
+  // Config-split dir. Pick a stacks/*.yaml.
+  const stacksDir = join(configDir, "stacks");
+  const stackFiles = listStackFiles(stacksDir);
+  if (stackFiles.length === 0) {
+    throw new Error(`config-split dir ${configDir} has no stacks/*.yaml layer to merge into`);
+  }
+
+  // composePath: the composer keys layout detection off `dirname(path)` and
+  // looks for `dirname(path)/system/system.yaml`. So we MUST hand it a path
+  // whose dirname is the config dir (NOT the marker file itself — passing the
+  // marker would make dirname = `<configDir>/system`, miss the nested marker,
+  // and fall into the single-file branch that chmod-600-gates the marker).
+  // A virtual pointer basename inside configDir is the correct shape; the file
+  // need not exist because the marker presence selects the directory layout.
+  const composePath = join(configDir, "config-merge-pointer.yaml");
+
+  if (stackId === undefined) {
+    const [only] = stackFiles;
+    if (stackFiles.length === 1 && only !== undefined) {
+      return { filePath: only, configDir, composePath, singleFile: false };
+    }
+    const names = stackFiles.map((f) => f.replace(`${stacksDir}/`, "")).join(", ");
+    throw new Error(
+      `config-split dir ${configDir} has ${stackFiles.length} stack files (${names}); ` +
+        `pass --stack <id> to pick one`,
+    );
+  }
+
+  // Match --stack against declared stack.id OR the file basename (no ext).
+  const wanted = stackId;
+  const wantedTail = stackId.includes("/") ? stackId.slice(stackId.lastIndexOf("/") + 1) : stackId;
+  for (const file of stackFiles) {
+    const declaredId = readStackId(file);
+    const base = file.slice(file.lastIndexOf("/") + 1).replace(/\.ya?ml$/, "");
+    if (declaredId === wanted || base === wanted || base === wantedTail) {
+      return { filePath: file, configDir, composePath, singleFile: false };
+    }
+  }
+  const names = stackFiles.map((f) => f.replace(`${stacksDir}/`, "")).join(", ");
+  throw new Error(
+    `--stack ${stackId} matched no stack file in ${stacksDir} (have: ${names}). ` +
+      `Match against a file's declared stack.id or its basename.`,
+  );
+}
+
+// =============================================================================
+// Timestamped backup helper (mirrors normalize-config)
+// =============================================================================
+
+function buildBackupPath(filePath: string): string {
+  const now = new Date();
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  const stamp = [
+    now.getFullYear(),
+    pad(now.getMonth() + 1),
+    pad(now.getDate()),
+    "T",
+    pad(now.getHours()),
+    pad(now.getMinutes()),
+    pad(now.getSeconds()),
+  ].join("");
+  return `${filePath}.pre-config-merge-${stamp}.bak`;
+}
+
+// =============================================================================
+// CLI argument parsing — hand-rolled (mirrors normalize-config)
+// =============================================================================
+
+export interface ParsedArgs {
+  config: string | undefined;
+  fragment: string | undefined;
+  stack: string | undefined;
+  dryRun: boolean;
+  rollback: boolean;
+  help: boolean;
+}
+
+function takeValue(argv: string[], i: number, flag: string): string {
+  const next = argv[i + 1];
+  if (next === undefined || next.startsWith("--")) {
+    throw new Error(`${flag} requires a value argument`);
+  }
+  return next;
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = {
+    config: undefined,
+    fragment: undefined,
+    stack: undefined,
+    dryRun: false,
+    rollback: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i] ?? "";
+    if (a === "--help" || a === "-h") {
+      args.help = true;
+    } else if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--rollback") {
+      args.rollback = true;
+    } else if (a === "--config") {
+      args.config = takeValue(argv, i, "--config");
+      i++;
+    } else if (a.startsWith("--config=")) {
+      args.config = a.slice("--config=".length);
+    } else if (a === "--fragment") {
+      args.fragment = takeValue(argv, i, "--fragment");
+      i++;
+    } else if (a.startsWith("--fragment=")) {
+      args.fragment = a.slice("--fragment=".length);
+    } else if (a === "--stack") {
+      args.stack = takeValue(argv, i, "--stack");
+      i++;
+    } else if (a.startsWith("--stack=")) {
+      args.stack = a.slice("--stack=".length);
+    } else if (a.startsWith("--")) {
+      throw new Error(`unknown flag: ${a}`);
+    } else {
+      throw new Error(`unexpected positional argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    "cortex config merge — merge a capability/policy fragment into a stack's config-split layers\n\n" +
+      "Usage:\n" +
+      "  bun src/cli/cortex/commands/config-merge.ts --config <dir|cortex.yaml> --fragment <fragment.yaml> [options]\n\n" +
+      "Options:\n" +
+      "  --config DIR/FILE   Stack config-split dir (or legacy single cortex.yaml)\n" +
+      "  --fragment FILE     YAML fragment (capabilities + policy ONLY)\n" +
+      "  --stack ID          Target stack id; required when >1 stacks/*.yaml exist\n" +
+      "  --dry-run           Print the diff, validate, exit 0 — no write\n" +
+      "  --rollback          Remove the fragment's ids instead of merging them in\n" +
+      "  -h, --help          Show this help\n\n" +
+      "Exit codes: 0 ok | 1 failure | 2 usage error\n",
+  );
+}
+
+// =============================================================================
+// Main — exported for testing
+// =============================================================================
+
+/**
+ * Load + structurally validate the fragment file. Throws on read/parse/schema
+ * error with a message the caller surfaces verbatim.
+ */
+export function loadFragment(fragmentPath: string): CapabilityMergeFragment {
+  const resolved = resolve(fragmentPath);
+  let raw: string;
+  try {
+    raw = readFileSync(resolved, "utf-8");
+  } catch (err) {
+    throw new Error(`cannot read fragment ${resolved}: ${err instanceof Error ? err.message : String(err)}`, {
+      cause: err,
+    });
+  }
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(raw);
+  } catch (err) {
+    throw new Error(`invalid YAML in fragment ${resolved}: ${err instanceof Error ? err.message : String(err)}`, {
+      cause: err,
+    });
+  }
+  const validated = CapabilityMergeFragmentSchema.safeParse(parsed ?? {});
+  if (!validated.success) {
+    throw new Error(`fragment ${resolved} failed CapabilityMergeFragmentSchema: ${validated.error.message}`);
+  }
+  return validated.data;
+}
+
+/**
+ * Run the config-merge workflow. Exported so the in-process test harness can
+ * call it without spawning a subprocess. Returns the exit code.
+ *
+ * @param argv  Arguments following the script name (process.argv.slice(2))
+ */
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function runConfigMerge(argv: string[]): Promise<number> {
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n\n`);
+    printHelp();
+    return 2;
+  }
+
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+
+  if (!args.config) {
+    process.stderr.write("Error: --config is required\n\n");
+    printHelp();
+    return 2;
+  }
+  if (!args.fragment) {
+    process.stderr.write("Error: --fragment is required\n\n");
+    printHelp();
+    return 2;
+  }
+
+  // 1. Load + validate the fragment structurally.
+  let fragment: CapabilityMergeFragment;
+  try {
+    fragment = loadFragment(args.fragment);
+  } catch (err) {
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+
+  // 2. Resolve the target layer file.
+  let target: ResolvedTarget;
+  try {
+    target = resolveTarget(args.config, args.stack);
+  } catch (err) {
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+
+  // 3. Read the target layer file as-is.
+  let originalText: string;
+  try {
+    originalText = readFileSync(target.filePath, "utf-8");
+  } catch (err) {
+    process.stderr.write(
+      `Error: cannot read target ${target.filePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+  let layer: Record<string, unknown>;
+  try {
+    const parsed = YAML.parse(originalText) as unknown;
+    layer = isPlainObject(parsed) ? parsed : {};
+  } catch (err) {
+    process.stderr.write(
+      `Error: invalid YAML in target ${target.filePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+
+  // 4. Merge (or remove for rollback) — pure, fragment-wins, id-keyed.
+  const { layer: mergedLayer, notes } = args.rollback
+    ? removeFragmentFromLayer(layer, fragment)
+    : mergeFragmentIntoLayer(layer, fragment);
+
+  const verb = args.rollback ? "rollback" : "merge";
+  const summary = summariseNotes(notes);
+  process.stderr.write(`config ${verb}: target ${target.filePath}\n`);
+  process.stderr.write(`config ${verb}: ${summary}\n`);
+  for (const n of notes) {
+    process.stderr.write(`  ${n.action.padEnd(8)} ${n.kind} ${n.id}\n`);
+  }
+
+  const newText = YAML.stringify(mergedLayer, { indent: 2, lineWidth: 0 });
+
+  // 5. Validate the COMPOSED WHOLE against CortexConfigSchema BEFORE write.
+  //    We compose by writing the candidate to a temp copy of the layer? No —
+  //    re-compose deterministically by substituting our merged layer for the
+  //    on-disk one in-memory: easiest correct path is to write, re-compose,
+  //    validate, and roll back on failure. To avoid a write-then-revert dance
+  //    we compose against the merged layer directly for the single-file form,
+  //    and for the split form we stage the write under a backup so a failed
+  //    validation restores the original.
+  const composedValidation = validateComposed(target, newText, originalText);
+  if (!composedValidation.ok) {
+    process.stderr.write(
+      `config ${verb}: composed config failed CortexConfigSchema — NOT writing.\n` +
+        `  ${composedValidation.error}\n`,
+    );
+    return 1;
+  }
+
+  // 6. Dry-run: report + exit, no write.
+  if (args.dryRun) {
+    process.stderr.write(`config ${verb} --dry-run: validation PASSED; no file written\n`);
+    if (newText !== originalText) {
+      process.stdout.write(renderDiff(target.filePath, originalText, newText));
+    }
+    return 0;
+  }
+
+  // 7. Idempotent no-op: nothing changed → don't rewrite or drop a backup
+  //    (rewriting would reformat the file + falsely signal a modification).
+  if (newText === originalText) {
+    process.stderr.write(`config ${verb}: target already in desired state — nothing written\n`);
+    return 0;
+  }
+
+  // 8. Timestamped backup, then in-place write.
+  const backupPath = buildBackupPath(target.filePath);
+  try {
+    writeFileSync(backupPath, originalText, "utf-8");
+    process.stderr.write(`config ${verb}: backup saved to ${backupPath}\n`);
+  } catch (err) {
+    process.stderr.write(
+      `Error: cannot write backup ${backupPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+  try {
+    writeFileSync(target.filePath, newText, "utf-8");
+    process.stderr.write(`config ${verb}: wrote ${target.filePath}\n`);
+  } catch (err) {
+    process.stderr.write(
+      `Error: cannot write ${target.filePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+
+  // 9. Re-compose from disk + re-validate (belt-and-braces; the in-memory
+  //    validation in step 5 already passed, but a disk re-compose catches any
+  //    serialization surprise — e.g. a YAML anchor the stringify introduced).
+  try {
+    const recomposed = composeRawConfig(target.composePath);
+    const reval = CortexConfigSchema.safeParse(recomposed);
+    if (!reval.success) {
+      // Restore from backup — never leave the stack in an unloadable state.
+      writeFileSync(target.filePath, originalText, "utf-8");
+      process.stderr.write(
+        `config ${verb}: post-write re-compose FAILED validation — restored original from backup.\n` +
+          `  ${reval.error.message}\n`,
+      );
+      return 1;
+    }
+  } catch (err) {
+    writeFileSync(target.filePath, originalText, "utf-8");
+    process.stderr.write(
+      `config ${verb}: post-write re-compose threw — restored original from backup.\n` +
+        `  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+
+  process.stderr.write(`config ${verb}: ${summary} — OK\n`);
+  return 0;
+}
+
+/**
+ * Validate the composed whole with the merged layer substituted in. For the
+ * single-file form the merged layer IS the whole config. For the split form we
+ * compose with the on-disk layers but swap our merged candidate in for the
+ * target layer by writing it, composing, then restoring — done here behind a
+ * try/finally so a validation failure never leaves the disk dirty.
+ */
+function validateComposed(
+  target: ResolvedTarget,
+  newLayerText: string,
+  originalLayerText: string,
+): { ok: true } | { ok: false; error: string } {
+  if (target.singleFile) {
+    // The whole config is the single file — validate the merged candidate.
+    let parsed: unknown;
+    try {
+      parsed = YAML.parse(newLayerText);
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+    const res = CortexConfigSchema.safeParse(parsed);
+    return res.success ? { ok: true } : { ok: false, error: res.error.message };
+  }
+
+  // Split form: temporarily stage the candidate layer on disk, compose, then
+  // ALWAYS restore the original (try/finally) so this validation is pure from
+  // the disk's point of view.
+  let composed: Record<string, unknown>;
+  try {
+    writeFileSync(target.filePath, newLayerText, "utf-8");
+    composed = composeRawConfig(target.composePath);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    writeFileSync(target.filePath, originalLayerText, "utf-8");
+  }
+  const res = CortexConfigSchema.safeParse(composed);
+  return res.success ? { ok: true } : { ok: false, error: res.error.message };
+}
+
+/** A minimal line-oriented diff for --dry-run output (added/removed prefixes). */
+function renderDiff(label: string, before: string, after: string): string {
+  const b = before.split("\n");
+  const a = after.split("\n");
+  const bSet = new Set(b);
+  const aSet = new Set(a);
+  const lines: string[] = [`--- ${label} (current)`, `+++ ${label} (merged)`];
+  for (const line of a) {
+    if (!bSet.has(line)) lines.push(`+ ${line}`);
+  }
+  for (const line of b) {
+    if (!aSet.has(line)) lines.push(`- ${line}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+if (import.meta.main) {
+  runConfigMerge(process.argv.slice(2)).then(
+    (code) => {
+      process.exit(code);
+    },
+    (err: unknown) => {
+      process.stderr.write(`Fatal: ${String(err)}\n`);
+      process.exit(1);
+    },
+  );
+}

--- a/src/cli/cortex/commands/config-merge.ts
+++ b/src/cli/cortex/commands/config-merge.ts
@@ -76,8 +76,19 @@
  *   2  — usage error (bad flags, missing required arg).
  */
 
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
-import { dirname, join, resolve } from "path";
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { dirname, join, relative, resolve } from "path";
 import YAML from "yaml";
 import { z } from "zod/v4";
 
@@ -109,14 +120,23 @@ const FragmentPolicySchema = z
     principals: z.array(PolicyPrincipalSchema).default([]),
     roles: z.array(PolicyRoleSchema).default([]),
   })
-  .strict();
+  .strict()
+  // review NIT-3 (cortex#876): a `policy:` block with both arrays empty
+  // contributes nothing — same as omitting `policy:` — but would otherwise
+  // materialise as `policy: {principals: [], roles: []}` in the written file.
+  // Reject it so the only way to write a policy block is to actually populate
+  // it. (An empty fragment is a caller error, not a silent no-op.)
+  .refine((p) => p.principals.length > 0 || p.roles.length > 0, {
+    message:
+      "fragment `policy:` block declares no principals or roles — populate it or omit the `policy:` key entirely",
+  });
 
 /**
  * A merge fragment: capabilities + policy ONLY. `.strict()` rejects any other
  * top-level key (`agents`, `principal`, `nats`, …) so a caller can't sneak a
  * transport/identity change in through the merge path — those are NOT a
- * package's to declare. At least one of the two blocks must be present (an
- * empty fragment is a caller error, not a silent no-op).
+ * package's to declare. At least one NON-EMPTY block must be present (an empty
+ * — or all-empty-arrays — fragment is a caller error, not a silent no-op).
  */
 export const CapabilityMergeFragmentSchema = z
   .object({
@@ -125,10 +145,10 @@ export const CapabilityMergeFragmentSchema = z
   })
   .strict()
   .refine(
-    (f) => f.capabilities !== undefined || f.policy !== undefined,
+    (f) => (f.capabilities !== undefined && f.capabilities.length > 0) || f.policy !== undefined,
     {
       message:
-        "fragment must declare at least one of `capabilities:` or `policy:` — an empty fragment merges nothing",
+        "fragment must declare at least one capability or a non-empty `policy:` block — an empty fragment merges nothing",
     },
   );
 
@@ -241,8 +261,9 @@ function removeIdKeyed(
 
 /**
  * Merge `fragment` into `layer` (the target stack-layer object), id-keyed
- * append fragment-wins. PURE — `layer` is not mutated. Empty result arrays are
- * pruned so an unchanged block doesn't materialise as `capabilities: []`.
+ * append fragment-wins. PURE — `layer` is not mutated. A `policy:` block is
+ * materialised only when the fragment carries policy (the schema rejects an
+ * all-empty policy fragment, so this never writes an empty `policy: {}`).
  */
 export function mergeFragmentIntoLayer(
   layer: Record<string, unknown>,
@@ -688,15 +709,12 @@ export async function runConfigMerge(argv: string[]): Promise<number> {
 
   const newText = YAML.stringify(mergedLayer, { indent: 2, lineWidth: 0 });
 
-  // 5. Validate the COMPOSED WHOLE against CortexConfigSchema BEFORE write.
-  //    We compose by writing the candidate to a temp copy of the layer? No —
-  //    re-compose deterministically by substituting our merged layer for the
-  //    on-disk one in-memory: easiest correct path is to write, re-compose,
-  //    validate, and roll back on failure. To avoid a write-then-revert dance
-  //    we compose against the merged layer directly for the single-file form,
-  //    and for the split form we stage the write under a backup so a failed
-  //    validation restores the original.
-  const composedValidation = validateComposed(target, newText, originalText);
+  // 5. Validate the COMPOSED WHOLE against CortexConfigSchema BEFORE any write.
+  //    `validateComposed` substitutes the merged layer in WITHOUT touching the
+  //    real file — single-file form validates in-memory; split form composes a
+  //    temp mirror of the config dir (review MAJOR-1, cortex#876). This makes
+  //    the pre-check — and therefore `--dry-run` — provably side-effect-free.
+  const composedValidation = validateComposed(target, newText);
   if (!composedValidation.ok) {
     process.stderr.write(
       `config ${verb}: composed config failed CortexConfigSchema — NOT writing.\n` +
@@ -725,6 +743,12 @@ export async function runConfigMerge(argv: string[]): Promise<number> {
   const backupPath = buildBackupPath(target.filePath);
   try {
     writeFileSync(backupPath, originalText, "utf-8");
+    // Secret-at-rest perm (review NIT-1, cortex#876): a single-file cortex.yaml
+    // carries inline platform tokens, so its backup must match the chmod-600
+    // gate the live loader enforces on the original — don't leave a 0644 copy
+    // of secrets on disk. Cheap + harmless for the split form (stack layers
+    // hold no tokens), so we apply it unconditionally.
+    chmodSync(backupPath, 0o600);
     process.stderr.write(`config ${verb}: backup saved to ${backupPath}\n`);
   } catch (err) {
     process.stderr.write(
@@ -771,19 +795,26 @@ export async function runConfigMerge(argv: string[]): Promise<number> {
 }
 
 /**
- * Validate the composed whole with the merged layer substituted in. For the
- * single-file form the merged layer IS the whole config. For the split form we
- * compose with the on-disk layers but swap our merged candidate in for the
- * target layer by writing it, composing, then restoring — done here behind a
- * try/finally so a validation failure never leaves the disk dirty.
+ * Validate the composed whole with the merged layer substituted in, WITHOUT
+ * ever writing to the real target file (review MAJOR-1, cortex#876). This is a
+ * pure pre-check: under `--dry-run` the help text promises "no write", and even
+ * a write-then-restore dance has a 2-syscall window where a SIGKILL would leave
+ * the real file in the candidate state. So:
+ *
+ *   - Single-file form: the merged layer IS the whole config → parse + validate
+ *     the in-memory candidate text. No disk write at all.
+ *   - Split form: mirror the config dir into an OS temp dir (`cpSync`),
+ *     overwrite ONLY the target layer's copy with the candidate, compose the
+ *     mirror, and validate. The real config dir is read-only throughout; the
+ *     temp mirror is removed in `finally`.
  */
 function validateComposed(
   target: ResolvedTarget,
   newLayerText: string,
-  originalLayerText: string,
 ): { ok: true } | { ok: false; error: string } {
   if (target.singleFile) {
-    // The whole config is the single file — validate the merged candidate.
+    // The whole config is the single file — validate the merged candidate text
+    // in-memory; nothing is written.
     let parsed: unknown;
     try {
       parsed = YAML.parse(newLayerText);
@@ -794,35 +825,67 @@ function validateComposed(
     return res.success ? { ok: true } : { ok: false, error: res.error.message };
   }
 
-  // Split form: temporarily stage the candidate layer on disk, compose, then
-  // ALWAYS restore the original (try/finally) so this validation is pure from
-  // the disk's point of view.
-  let composed: Record<string, unknown>;
+  // Split form: compose a TEMP MIRROR of the config dir with the candidate
+  // layer swapped in. The real dir is never written.
+  let mirrorRoot: string | undefined;
   try {
-    writeFileSync(target.filePath, newLayerText, "utf-8");
-    composed = composeRawConfig(target.composePath);
+    mirrorRoot = mkdtempSync(join(tmpdir(), "cortex-config-merge-check-"));
+    // Mirror the whole config dir (system/, network/, surfaces/, stacks/, …).
+    cpSync(target.configDir, mirrorRoot, { recursive: true });
+    // Overwrite the target layer's mirrored copy with the candidate. The
+    // target's path relative to configDir locates it inside the mirror.
+    const rel = relative(target.configDir, target.filePath);
+    writeFileSync(join(mirrorRoot, rel), newLayerText, "utf-8");
+    // Compose the mirror via a pointer whose dirname is the mirror root.
+    const composed = composeRawConfig(join(mirrorRoot, "config-merge-pointer.yaml"));
+    const res = CortexConfigSchema.safeParse(composed);
+    return res.success ? { ok: true } : { ok: false, error: res.error.message };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   } finally {
-    writeFileSync(target.filePath, originalLayerText, "utf-8");
+    if (mirrorRoot !== undefined) {
+      try {
+        rmSync(mirrorRoot, { recursive: true, force: true });
+      } catch (cleanupErr) {
+        // Best-effort cleanup of an OS temp dir; a leaked temp dir is harmless
+        // (the OS reaps tmpdir) and must not mask the validation result.
+        process.stderr.write(
+          `config merge: warning — could not remove temp validation dir ${mirrorRoot}: ` +
+            `${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}\n`,
+        );
+      }
+    }
   }
-  const res = CortexConfigSchema.safeParse(composed);
-  return res.success ? { ok: true } : { ok: false, error: res.error.message };
 }
 
-/** A minimal line-oriented diff for --dry-run output (added/removed prefixes). */
+/**
+ * A minimal line-oriented diff for --dry-run output. Positional with shared
+ * common-prefix/suffix trimming so DUPLICATE lines are NOT swallowed (review
+ * NIT-2, cortex#876 — the previous Set-based compare filtered any line present
+ * in both arrays, making repeated lines invisible). This is a presentation aid,
+ * not a minimal-edit (Myers) diff — the changed middle block is shown verbatim
+ * as removed-then-added, which is correct (never hides a real change) if not
+ * always the tightest rendering.
+ */
 function renderDiff(label: string, before: string, after: string): string {
   const b = before.split("\n");
   const a = after.split("\n");
-  const bSet = new Set(b);
-  const aSet = new Set(a);
+
+  // Trim the shared common prefix.
+  let start = 0;
+  while (start < b.length && start < a.length && b[start] === a[start]) start++;
+
+  // Trim the shared common suffix (not overlapping the prefix).
+  let bEnd = b.length;
+  let aEnd = a.length;
+  while (bEnd > start && aEnd > start && b[bEnd - 1] === a[aEnd - 1]) {
+    bEnd--;
+    aEnd--;
+  }
+
   const lines: string[] = [`--- ${label} (current)`, `+++ ${label} (merged)`];
-  for (const line of a) {
-    if (!bSet.has(line)) lines.push(`+ ${line}`);
-  }
-  for (const line of b) {
-    if (!aSet.has(line)) lines.push(`- ${line}`);
-  }
+  for (let i = start; i < bEnd; i++) lines.push(`- ${b[i]}`);
+  for (let i = start; i < aEnd; i++) lines.push(`+ ${a[i]}`);
   return lines.join("\n") + "\n";
 }
 


### PR DESCRIPTION
Closes #858 — refs cortex#835 (dev-loop epic) / phase cortex#869.

Implements **dev-loop F-6a**: the `cortex config merge` verb that an arc install will call to compose package-declared capabilities + policy into a stack's config-split layers (design `docs/design-agentic-dev-pipeline.md` §6.2 step 3 / §6.4 F-6a).

## Merge semantics (as built)

A **merge fragment** is a strict subset of a cortex.yaml — `capabilities[]` and/or `policy{ principals[], roles[] }` and **nothing else** (`CapabilityMergeFragmentSchema`, `.strict()`, ≥1 block required). It is NOT a full `CortexConfig`; it is merged onto the stack's existing config and the **composed whole** is validated.

- **id-keyed UNION, fragment-wins** (NOT the loader's replace-wholesale `deepMerge`, which would drop every prior capability):
  - id absent → **append**
  - id present + byte-identical → **skip** (idempotent no-op + note)
  - id present + different → **fragment wins** (replace + `changed:` note)
- **Idempotent** — same fragment twice = no write on the second run (no second backup).
- **validate-before-write** — the merged layer is substituted in, re-composed, and validated against `CortexConfigSchema`; a merge that breaks the schema (e.g. a capability whose `provided_by` names an undeclared agent) **refuses to write** (exit 1, original intact). Proven against the repo's `docs/config-layout/` template.
- **Target resolution** — writes to `stacks/{id}.yaml` (`--stack` by declared `stack.id` or basename; single-stack auto-detect; >1 stack with no `--stack` → exit 1). Legacy single-file `cortex.yaml` form supported.
- **--dry-run** prints the diff + validates, no write. **--rollback** removes the fragment's ids by id, re-validating after removal. **Timestamped backup** before every in-place write; **restore-from-backup** if the post-write re-compose fails.
- Standalone-command conventions mirror `normalize-config.ts`: hand-rolled `parseArgs`, exit codes **0 ok / 1 failure / 2 usage**.

## Tests

**35 tests** (TDD, mirroring normalize-config's style): pure merge/remove/schema/summarise functions with fixtures + the CLI file-I/O path (`runConfigMerge` against tmp config-split + single-file dirs) — append, idempotency, fragment-wins, policy union, no-mutation, rollback, `--stack` selection, dry-run-no-write, schema-reject (extra key + dangling provider), ambiguous/missing target.

## Gates

| Gate | Result |
|---|---|
| `bunx tsc --noEmit` | ✅ clean |
| `bunx eslint --quiet src/` | ✅ clean |
| `bun test` (full) | ✅ 5288 pass / 0 fail / 2 skip |
| `bash scripts/check-carveouts.sh` | ✅ PASS |
| boot smoke (`src/cortex.ts` import) | ✅ OK |

## Divergences / notes

- **Arc integration is a FOLLOW-UP, not this slice.** The arc-side `cortex_config` manifest field + the `arc install` step-6c hook that CALLS `cortex config merge` are companion arc work per cortex#858 "Arc Install Integration". This PR ships the cortex-side verb only.
- **No central `cortex --help` registry / `docs/cli-reference.md` exists** in this repo — the AC items "listed in `cortex --help`" and "documented in docs/cli-reference.md" reference artifacts that don't yet exist; the verb follows the established **standalone-command convention** (`bun src/cli/cortex/commands/config-merge.ts`, like `normalize-config` / `migrate-config`). Registering into a future top-level dispatcher + cli-reference is deferred with the arc-hook follow-up.
- The merge replaces the loader's array-wholesale `deepMerge` with an **id-keyed union** for the three append-semantics collections (`deepMerge` stays correct and untouched for `nats.subjects[]` etc.; it is the wrong tool for capability/policy append, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)