### PR TITLE
fix(config): mc/cockpit blocks must be on CortexConfigSchema (MC dark on every live stack)

### DIFF
--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -127,6 +127,14 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
       encryption: { payload: "off", at_rest: "off" },
       transport: { mtls: "off" },
     },
+    mc: { enabled: false, configPath: "", dbPath: "", port: 0 },
+    cockpit: {
+      enabled: false,
+      docsDir: "docs",
+      repo: "",
+      refreshIntervalMs: 300_000,
+      attention: { surface: "discord", channel: "" },
+    },
   };
 }
 

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -417,6 +417,33 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     expect(principal?.discordId).toBe("285727653603049472");
   });
 
+  // fix/c-844 — the mc:/cockpit: blocks must survive the cortex-shape parse.
+  // They were defined on AgentConfigSchema only; CortexConfigSchema's
+  // strip-by-default parse silently dropped them, so `mc.enabled: true` in a
+  // live config-split stack re-defaulted to false and MC never booted. These
+  // tests pin BOTH directions (present → carried; absent → defaulted) on the
+  // cortex shape specifically — the legacy-schema tests passed all along, which
+  // is exactly why the divergence went unnoticed until the live deploy.
+  test("carries mc + cockpit through the cortex-shape parse when enabled", () => {
+    const cfg = minimalCortex();
+    cfg.mc = { enabled: true, dbPath: "/tmp/mc-test/mission-control.db" };
+    cfg.cockpit = { enabled: true, repo: "the-metafactory/cortex", docsDir: "/tmp/docs" };
+    const { config } = loadConfigWithAgents(writeCortexConfig(testDir, cfg));
+    expect(config.mc.enabled).toBe(true);
+    expect(config.mc.dbPath).toBe("/tmp/mc-test/mission-control.db");
+    expect(config.cockpit.enabled).toBe(true);
+    expect(config.cockpit.repo).toBe("the-metafactory/cortex");
+  });
+
+  test("defaults mc + cockpit to disabled on the cortex shape when absent", () => {
+    const { config } = loadConfigWithAgents(writeCortexConfig(testDir, minimalCortex()));
+    expect(config.mc.enabled).toBe(false);
+    expect(config.mc.port).toBe(0);
+    expect(config.cockpit.enabled).toBe(false);
+    // Inner defaults still re-applied via the shared transform.
+    expect(config.cockpit.attention.surface).toBe("discord");
+  });
+
   test("flattens agents[*].presence.discord into AgentConfig.discord[]", () => {
     const cfg = minimalCortex();
     (cfg.agents as Record<string, unknown>[]).push({

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -713,6 +713,14 @@ function loadCortexShape(
     // defaults), so this is a plain passthrough — omitting it would silently
     // default the posture to `off` for every cortex-shape deployment.
     security: cortexConfig.security,
+    // MC-I1 (ADR-0005, fix/c-844) — carry the cockpit + in-process MC config
+    // through to the synthesized AgentConfig. Both are now on CortexConfigSchema
+    // (shared McSchema/CockpitSchema), so they survive the strip-by-default
+    // parse; without these passthroughs `AgentConfigSchema.parse(merged)` would
+    // re-default them to `enabled: false` and MC would never boot on any
+    // cortex-shape deployment (same failure mode the `security` comment warns of).
+    mc: cortexConfig.mc,
+    cockpit: cortexConfig.cockpit,
     ...(cortexConfig.nats !== undefined && { nats: cortexConfig.nats }),
   };
 

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -347,6 +347,89 @@ export type NetworkFile = z.infer<typeof NetworkFileSchema>;
 // Main config schema
 // =============================================================================
 
+/**
+ * MC-I1.S1 (ADR-0005): in-process Mission Control embed schema. Extracted as a
+ * SHARED const (fix/c-844) so BOTH top-level config schemas reference the same
+ * definition — `AgentConfigSchema` (legacy bot.yaml) and `CortexConfigSchema`
+ * (the modern config-split shape every live stack loads). Defining it inline on
+ * only one schema is exactly how `mc.enabled: true` got silently stripped for
+ * every cortex-shape deployment (the strip-by-default parse drops unknown keys).
+ * One definition → the two schemas cannot drift again.
+ *
+ * Embedded mode deliberately overrides db + cursor + port; an MC yaml at
+ * `configPath` governs only hooks / ws / log (ADR-0005 §2). Empty `dbPath` /
+ * `port` resolve to the per-slug default / the MC yaml's port at boot.
+ */
+export const McSchema = z.object({
+  enabled: z.boolean().default(false),
+  /** Optional MC yaml supplying hooks/ws/log settings. Empty → MC defaults. */
+  configPath: z.string().default(""),
+  /**
+   * Absolute (or leading-`~`) db path. Empty → per-slug default at boot.
+   * ONE db per stack is required: the hook cursor lands beside the db
+   * (`mc-hook-cursor.json`), so two stacks pointed at the same explicit
+   * `dbPath` would share — and race — the cursor (and the db itself). The
+   * per-slug default keeps stacks isolated; only override with a path unique
+   * to this stack.
+   */
+  dbPath: z.string().default(""),
+  /** Listen port. 0 → fall back to the MC yaml's port (default 8767). */
+  port: z.number().int().nonnegative().default(0),
+}).default(emptyDefault()).transform((val) => ({
+  // `.default(emptyDefault())` returns `{}` literally rather than re-parsing
+  // the inner defaults, so the fields would be undefined. Re-apply the inner
+  // defaults so callers get the populated shape. The `??` chains are
+  // load-bearing (not redundant) for the all-defaults parse path.
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+  enabled: val.enabled ?? false,
+  configPath: val.configPath ?? "",
+  dbPath: val.dbPath ?? "",
+  port: val.port ?? 0,
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+}));
+
+/**
+ * G-1113 ML.5: Mission Control Cockpit live-refresh schema. SHARED const
+ * (fix/c-844) for the same reason as {@link McSchema} — referenced by both
+ * `AgentConfigSchema` and `CortexConfigSchema` so the cockpit block survives
+ * the cortex-shape parse. When `enabled`, the bot runs `refreshCockpit` on
+ * `refreshIntervalMs` (plan-doc ingestion → work-item ingestion → attention
+ * reconcile) and publishes `system.attention.*` notifications; `attention.
+ * channel` is the review-sink destination those render to (empty → notifications
+ * stay on the bus but aren't routed).
+ */
+export const CockpitSchema = z.object({
+  enabled: z.boolean().default(false),
+  /** Path to the plan/iteration docs dir (relative to cwd or absolute). */
+  docsDir: z.string().default("docs"),
+  /** Default repo ("owner/name") for short umbrella refs + doc URLs. */
+  repo: z.string().default(""),
+  /** Refresh interval in ms (default 5 min). */
+  refreshIntervalMs: z.number().int().positive().default(300_000),
+  /** Attention notification destination (the review-sink's attentionRouting). */
+  attention: z.object({
+    surface: z.string().default("discord"),
+    channel: z.string().default(""),
+    thread: z.string().optional(),
+  }).default(emptyDefault()),
+}).default(emptyDefault()).transform((val) => ({
+  // `.default(emptyDefault())` returns `{}` literally rather than re-parsing
+  // the inner defaults, so `cockpit.attention` would be undefined. Re-apply the
+  // inner defaults so callers get the populated shape. The `??` chains are
+  // load-bearing (not redundant) for the all-defaults parse path.
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+  enabled: val.enabled ?? false,
+  docsDir: val.docsDir ?? "docs",
+  repo: val.repo ?? "",
+  refreshIntervalMs: val.refreshIntervalMs ?? 300_000,
+  attention: {
+    surface: val.attention?.surface ?? "discord",
+    channel: val.attention?.channel ?? "",
+    ...(val.attention?.thread !== undefined && { thread: val.attention.thread }),
+  },
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+}));
+
 export const AgentConfigSchema = z.object({
   agent: z.object({
     name: z.string().min(1),
@@ -536,34 +619,7 @@ export const AgentConfigSchema = z.object({
    * `configPath` governs only hooks / ws / log (ADR-0005 §2). Empty `dbPath` /
    * `port` resolve to the per-slug default / the MC yaml's port at boot.
    */
-  mc: z.object({
-    enabled: z.boolean().default(false),
-    /** Optional MC yaml supplying hooks/ws/log settings. Empty → MC defaults. */
-    configPath: z.string().default(""),
-    /**
-     * Absolute (or leading-`~`) db path. Empty → per-slug default at boot.
-     * ONE db per stack is required: the hook cursor lands beside the db
-     * (`mc-hook-cursor.json`), so two stacks pointed at the same explicit
-     * `dbPath` would share — and race — the cursor (and the db itself). The
-     * per-slug default keeps stacks isolated; only override with a path unique
-     * to this stack.
-     */
-    dbPath: z.string().default(""),
-    /** Listen port. 0 → fall back to the MC yaml's port (default 8767). */
-    port: z.number().int().nonnegative().default(0),
-  }).default(emptyDefault()).transform((val) => ({
-    // Same `emptyDefault()` quirk documented on the `cockpit` block below:
-    // `.default(emptyDefault())` returns `{}` literally rather than re-parsing
-    // the inner defaults, so the fields would be undefined. Re-apply the inner
-    // defaults so callers get the populated shape. The `??` chains are
-    // load-bearing (not redundant) for the all-defaults parse path.
-    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-    enabled: val.enabled ?? false,
-    configPath: val.configPath ?? "",
-    dbPath: val.dbPath ?? "",
-    port: val.port ?? 0,
-    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
-  })),
+  mc: McSchema,
 
   paths: z.object({
     publishedEventsDir: z.string().default("~/.claude/events/published"),
@@ -599,38 +655,7 @@ export const AgentConfigSchema = z.object({
    * notifications; `attention.channel` is the review-sink destination those
    * render to (empty → notifications stay on the bus but aren't routed).
    */
-  cockpit: z.object({
-    enabled: z.boolean().default(false),
-    /** Path to the plan/iteration docs dir (relative to cwd or absolute). */
-    docsDir: z.string().default("docs"),
-    /** Default repo ("owner/name") for short umbrella refs + doc URLs. */
-    repo: z.string().default(""),
-    /** Refresh interval in ms (default 5 min). */
-    refreshIntervalMs: z.number().int().positive().default(300_000),
-    /** Attention notification destination (the review-sink's attentionRouting). */
-    attention: z.object({
-      surface: z.string().default("discord"),
-      channel: z.string().default(""),
-      thread: z.string().optional(),
-    }).default(emptyDefault()),
-  }).default(emptyDefault()).transform((val) => ({
-    // Same `emptyDefault()` quirk documented on the `github` block above:
-    // `.default(emptyDefault())` returns `{}` literally rather than re-parsing
-    // the inner defaults, so `config.cockpit.attention` would be undefined.
-    // Re-apply the inner defaults so callers get the populated shape. The `??`
-    // chains are load-bearing (not redundant) for the all-defaults parse path.
-    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-    enabled: val.enabled ?? false,
-    docsDir: val.docsDir ?? "docs",
-    repo: val.repo ?? "",
-    refreshIntervalMs: val.refreshIntervalMs ?? 300_000,
-    attention: {
-      surface: val.attention?.surface ?? "discord",
-      channel: val.attention?.channel ?? "",
-      ...(val.attention?.thread !== undefined && { thread: val.attention.thread }),
-    },
-    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
-  })),
+  cockpit: CockpitSchema,
 
   /**
    * TC-0 (Trust & Confidentiality, #628): unified security posture toggles.

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -36,6 +36,8 @@ import { z } from "zod/v4";
 
 import { CapabilitySchema } from "./capability";
 import {
+  CockpitSchema,
+  McSchema,
   NetworkClaudeSchema,
   NetworkCloudSchema,
   NetworkFileSchema,
@@ -2177,6 +2179,17 @@ export const CortexConfigSchema = z.object({
    * shape even when the block is absent, matching the legacy bot.yaml default.
    */
   security: SecurityPostureSchema,
+
+  /**
+   * MC-I1 (ADR-0005): in-process Mission Control + cockpit live-refresh. SHARED
+   * with `AgentConfigSchema` via {@link McSchema} / {@link CockpitSchema} so the
+   * blocks survive the cortex-shape strip-by-default parse (fix/c-844 — they
+   * were silently dropped for every config-split deployment when defined on the
+   * legacy schema only). `loadCortexShape` carries them into the synthesized
+   * `AgentConfig` (the `merged` passthrough), same as `security`.
+   */
+  mc: McSchema,
+  cockpit: CockpitSchema,
 
   /** First-class agents — the canonical list. */
   agents: z.array(AgentSchema).min(1, "at least one agent is required"),


### PR DESCRIPTION
## The bug

The MC-I1.S1 `mc:` block (and the ML.5 `cockpit:` block) were defined **only** on `AgentConfigSchema` (the legacy bot.yaml shape). Every live stack loads through the config-split / cortex shape, which parses against **`CortexConfigSchema`** — and zod strips unknown keys by default. So `mc.enabled: true` in a real stack config was silently re-defaulted to `false`, and Mission Control never booted.

S1's unit tests passed because they exercised the legacy schema. The divergence only surfaced at the live deploy — the S2 "light the pane" step — which is exactly what live-verify is for.

This is the same failure class the existing `security:` passthrough comment in `loadCortexShape` warns about ("omitting it would silently default the posture to `off` for every cortex-shape deployment").

## The fix (divergence-proof)

- Extract `McSchema` + `CockpitSchema` as shared exported consts in `config.ts`. `AgentConfigSchema` now references them instead of inlining — so **both** top-level schemas point at one definition and can't drift again.
- Add `mc: McSchema` + `cockpit: CockpitSchema` to `CortexConfigSchema`.
- Carry them through `loadCortexShape`'s `merged` passthrough (like `security`), so `AgentConfigSchema.parse(merged)` sees the real values.
- Regression tests on the **cortex shape** specifically: present → carried, absent → defaulted.

## Verification

Against the live `meta-factory` stack config, `loadConfig` now returns `mc.enabled=true` / `cockpit.enabled=true` (was `false`). Full suite 5286 pass / 0 fail; tsc clean; lint 0 errors; carve-outs pass.

Part of #843, refs #844 (unblocks the S2 live-verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
