### PR TITLE
fix(config): grove block must be on CortexConfigSchema (deep-links fall back to localhost on live stacks)

### DIFF
--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -135,6 +135,9 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
       refreshIntervalMs: 300_000,
       attention: { surface: "discord", channel: "" },
     },
+    // fix/c-844 — grove is now on CortexConfigSchema (shared GroveSchema); the
+    // transform fills defaults so the inferred OUTPUT type lists it as required.
+    grove: { notifications: { discord: false }, baseUrl: "" },
   };
 }
 

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -444,6 +444,33 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     expect(config.cockpit.attention.surface).toBe("discord");
   });
 
+  // fix/c-844 — the grove: block (F-11 Discord toggle + dashboard deep-link
+  // baseUrl) must survive the cortex-shape parse, for the SAME reason as
+  // mc:/cockpit: above. It was defined on AgentConfigSchema only, so
+  // CortexConfigSchema's strip-by-default parse dropped it — `config.grove.
+  // baseUrl` was always re-defaulted on every live config-split stack and the
+  // attention-notification deep-links (cortex.ts:2713/2745) fell back to
+  // localhost. These pin BOTH directions (present → carried; absent → defaulted)
+  // on the cortex shape specifically.
+  test("carries grove through the cortex-shape parse when configured", () => {
+    const cfg = minimalCortex();
+    cfg.grove = { baseUrl: "https://grove.meta-factory.ai", notifications: { discord: true } };
+    const { config } = loadConfigWithAgents(writeCortexConfig(testDir, cfg));
+    expect(config.grove.baseUrl).toBe("https://grove.meta-factory.ai");
+    expect(config.grove.notifications.discord).toBe(true);
+  });
+
+  test("defaults grove to empty baseUrl + discord off on the cortex shape when absent", () => {
+    const { config } = loadConfigWithAgents(writeCortexConfig(testDir, minimalCortex()));
+    // Empty string (not undefined) is load-bearing: cortex.ts deep-link code
+    // tests `config.grove.baseUrl !== ""` to decide the localhost fallback.
+    expect(config.grove.baseUrl).toBe("");
+    // Inner notifications default still re-applied via the shared transform —
+    // `config.grove.notifications` must be defined (a read of `.discord` would
+    // otherwise throw when grove is absent).
+    expect(config.grove.notifications.discord).toBe(false);
+  });
+
   test("flattens agents[*].presence.discord into AgentConfig.discord[]", () => {
     const cfg = minimalCortex();
     (cfg.agents as Record<string, unknown>[]).push({

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -721,6 +721,13 @@ function loadCortexShape(
     // cortex-shape deployment (same failure mode the `security` comment warns of).
     mc: cortexConfig.mc,
     cockpit: cortexConfig.cockpit,
+    // F-11 (fix/c-844) — carry the grove block (Discord push toggle + dashboard
+    // deep-link baseUrl) through to the synthesized AgentConfig. Now on
+    // CortexConfigSchema (shared GroveSchema), so it survives the
+    // strip-by-default parse; without this passthrough `AgentConfigSchema.parse(
+    // merged)` would re-default `grove.baseUrl` to "" and every attention-
+    // notification deep-link on a cortex-shape stack would fall back to localhost.
+    grove: cortexConfig.grove,
     ...(cortexConfig.nats !== undefined && { nats: cortexConfig.nats }),
   };
 

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -430,6 +430,49 @@ export const CockpitSchema = z.object({
   /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 }));
 
+/**
+ * F-11: grove platform-level config (cross-cutting, not bound to a single
+ * platform adapter). Extracted as a SHARED const (fix/c-844) so BOTH top-level
+ * config schemas reference the same definition — `AgentConfigSchema` (legacy
+ * bot.yaml) and `CortexConfigSchema` (the modern config-split shape every live
+ * stack loads). Defining it inline on only one schema is exactly how
+ * `grove.baseUrl` got silently stripped for every cortex-shape deployment (the
+ * strip-by-default parse drops unknown keys), leaving dashboard deep-links in
+ * attention notifications pointed at `undefined`/localhost instead of the
+ * configured public host. One definition → the two schemas cannot drift again.
+ * See `docs/design-mc-f11-discord-notifications.md` Decision 6.
+ *
+ * - `notifications.discord` — master toggle for the F-11 Discord push surface.
+ *   Default `false`; explicit off-by-default avoids surprising principals with
+ *   a DM torrent after a fresh install.
+ * - `baseUrl` — used to build dashboard deep links in notification bodies.
+ *   Empty (the default) → callers fall back to `http://localhost:${port}`;
+ *   Tier 2 should set `https://grove.meta-factory.ai`.
+ */
+export const GroveSchema = z.object({
+  notifications: z.object({
+    discord: z.boolean().default(false),
+  }).default(emptyDefault()),
+  baseUrl: z.string().default(""),
+}).default(emptyDefault()).transform((val) => ({
+  // Same `emptyDefault()` quirk documented on the `mc`/`cockpit` blocks:
+  // `.default(emptyDefault())` returns `{}` literally rather than re-parsing the
+  // inner defaults, so `baseUrl` would be `undefined` (not `""`) and
+  // `notifications` would be `undefined` when grove is absent — and `notifications`
+  // `{}` (so `.discord` undefined) when grove is present but notifications isn't.
+  // The deep-link consumers test `config.grove.baseUrl !== ""`, so an `undefined`
+  // baseUrl would render `undefined/…` links; reads of `config.grove.notifications.
+  // discord` would throw when grove is absent. Re-apply the inner defaults so
+  // callers get the populated shape. The `??` chains are load-bearing (not
+  // redundant) for the all-defaults parse path.
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+  notifications: {
+    discord: val.notifications?.discord ?? false,
+  },
+  baseUrl: val.baseUrl ?? "",
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+}));
+
 export const AgentConfigSchema = z.object({
   agent: z.object({
     name: z.string().min(1),
@@ -627,25 +670,12 @@ export const AgentConfigSchema = z.object({
   }).default(emptyDefault()),
 
   /**
-   * F-11: Grove platform-level config (cross-cutting, not bound to a
-   * single platform adapter). See
-   * `docs/design-mc-f11-discord-notifications.md` Decision 6.
-   *
-   * - `notifications.discord` — master toggle for the F-11 Discord push
-   *   surface. Default `false`; explicit off-by-default avoids
-   *   surprising principals with a DM torrent after a fresh install.
-   * - `baseUrl` — used to build dashboard deep links in notification
-   *   bodies. Tier 1 default `http://localhost:8766`; Tier 2 should set
-   *   `https://grove.meta-factory.ai`. When unset on Tier 2, F-11
-   *   renders the deep link as a plain assignment id with a one-line
-   *   warning instead of crashing.
+   * F-11: grove platform-level config (cross-cutting, not bound to a single
+   * platform adapter). SHARED with `CortexConfigSchema` via {@link GroveSchema}
+   * (fix/c-844) so the block survives the cortex-shape strip-by-default parse.
+   * See the schema's own docstring above for per-field semantics.
    */
-  grove: z.object({
-    notifications: z.object({
-      discord: z.boolean().default(false),
-    }).default(emptyDefault()),
-    baseUrl: z.string().default(""),
-  }).default(emptyDefault()),
+  grove: GroveSchema,
 
   /**
    * G-1113 ML.5: Mission Control Cockpit live-refresh. OFF by default (opt-in)

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -37,6 +37,7 @@ import { z } from "zod/v4";
 import { CapabilitySchema } from "./capability";
 import {
   CockpitSchema,
+  GroveSchema,
   McSchema,
   NetworkClaudeSchema,
   NetworkCloudSchema,
@@ -2190,6 +2191,18 @@ export const CortexConfigSchema = z.object({
    */
   mc: McSchema,
   cockpit: CockpitSchema,
+
+  /**
+   * F-11: grove platform-level config (Discord push toggle + dashboard
+   * `baseUrl` for deep links). SHARED with `AgentConfigSchema` via
+   * {@link GroveSchema} so the block survives the cortex-shape strip-by-default
+   * parse (fix/c-844 — it was defined on the legacy schema only, so
+   * `config.grove.baseUrl` was always `""`/`undefined` on live config-split
+   * stacks and attention-notification deep-links fell back to localhost).
+   * `loadCortexShape` carries it into the synthesized `AgentConfig` (the
+   * `merged` passthrough), same as `mc`/`cockpit`/`security`.
+   */
+  grove: GroveSchema,
 
   /** First-class agents — the canonical list. */
   agents: z.array(AgentSchema).min(1, "at least one agent is required"),


### PR DESCRIPTION
Fast-follow to #877. The **identical** schema-divergence bug, this time for the `grove:` block.

## The bug
The F-11 `grove:` block (`grove.notifications.discord` + `grove.baseUrl`) was defined **only** on `AgentConfigSchema` (the legacy `bot.yaml` shape). Every live stack loads through the config-split / cortex shape, which parses against `CortexConfigSchema` and **strips unknown keys by default** — so `grove` was silently dropped on every config-split deployment.

Consequence: `config.grove.baseUrl` was never the configured public host on real stacks. The MC dashboard deep-links in attention notifications fell back to `http://localhost:${port}`:
- `src/cortex.ts:2713` — dispatch-projection renderer
- `src/cortex.ts:2745` — cockpit loop

This matters for attention-notification deep-links on exactly the stacks MC is now enabled on.

## The fix (mirror #877 exactly — established, divergence-proof pattern)
- **config.ts**: extract `GroveSchema` as a shared exported const; `AgentConfigSchema` references it instead of inlining. Two top-level schemas → one definition → can't drift again.
- **cortex-config.ts**: import `GroveSchema`, add `grove: GroveSchema` to `CortexConfigSchema` (beside `mc`/`cockpit`).
- **loader.ts**: add `grove: cortexConfig.grove` to the `merged` passthrough in `loadCortexShape` (beside `mc`/`cockpit`/`security`).

## Nested-default transform — yes, it was needed (real latent bug, not theoretical)
The task flagged a question: does grove need a `.transform()` like mc/cockpit, or does its nested `notifications.default(emptyDefault())` resolve fine? I tested empirically against the repo's zod. It does **not** resolve — grove had the same `emptyDefault()` quirk (`emptyDefault()` returns `{}` literally instead of re-parsing inner defaults):

| Input | Before fix | After transform |
|---|---|---|
| grove absent | `baseUrl: undefined`, `notifications: undefined` | `baseUrl: ""`, `notifications.discord: false` |
| grove `{}` | `notifications: {}` (`.discord` undefined) | `notifications.discord: false` |
| grove partial (`baseUrl` only) | `notifications: {}` | `notifications.discord: false` |

This is worse than a silent default: `undefined !== ""` is **true**, so the deep-link code (`config.grove.baseUrl !== "" ? … : localhost`) would render `undefined/…` links when grove is absent, and any read of `config.grove.notifications.discord` would **throw**. The `.transform()` (mirroring mc/cockpit) re-applies inner defaults so `baseUrl` resolves to `""` and `notifications.discord` to `false`. Both paths are now pinned by regression tests.

## Verification
- `bunx tsc --noEmit`: clean
- `bun run lint`: 0 errors (changed files clean; 27 pre-existing unused-disable warnings in unrelated files)
- `bun test`: **5319 pass**. 2 failures are pre-existing + environmental — `startMissionControl (embed)` tests bind fixed port 8767 and hit `EADDRINUSE` from a running cortex daemon (PID held the port); they fail **identically on clean `origin/main`** and this PR touches no MC embed/server code. (Worth a follow-up: those embed tests should bind an ephemeral port.)
- `bash scripts/check-carveouts.sh` on changed files: PASS

## Files changed
Same 5 files #877 touched:
- `src/common/types/config.ts` — extract `GroveSchema`, reference from `AgentConfigSchema`
- `src/common/types/cortex-config.ts` — import + `grove: GroveSchema` on `CortexConfigSchema`
- `src/common/config/loader.ts` — `grove` passthrough in `loadCortexShape`
- `src/common/config/__tests__/loader.test.ts` — 2 regression tests (carried-when-configured / defaulted-when-absent on the cortex shape)
- `src/common/agents/__tests__/registry.test.ts` — fixture now carries `grove`

refs #877
Part of #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)