### PR TITLE
feat(mc): MC dashboard subscribes to the mc.projection WS frame (live refetch)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/projection-refetch.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/projection-refetch.test.ts
@@ -1,0 +1,284 @@
+/**
+ * MC-I1.S6 / C-863 — `mc.projection` → debounced-refetch wiring tests.
+ *
+ * Covers (per the issue's test plan):
+ *   - the family→view routing policy (`projection-routing`);
+ *   - the subscriber core (`projection-subscriber`): a targeting frame fires a
+ *     debounced refetch; a burst of N frames coalesces into ONE; non-targeting
+ *     and unknown families are ignored; OTHER frame types are unaffected;
+ *     teardown cancels a pending refetch (no setState-after-unmount).
+ *
+ * No DOM: the subscriber is exercised against a fake `WsClient.subscribe` and a
+ * fake clock, mirroring the codebase's "extract the logic, unit-test the helper"
+ * convention (see working-grid / markdown tests).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  routeProjectionFamily,
+  projectionAffectsView,
+  PROJECTION_FAMILIES,
+} from "../lib/projection-routing";
+import {
+  attachProjectionRefetch,
+  type TimerLike,
+} from "../lib/projection-subscriber";
+import type { WsClient, WsMessage } from "../hooks/use-websocket";
+
+// ----- fake WS client: capture subscriptions, emit frames manually -----
+
+function makeFakeWs(): {
+  ws: Pick<WsClient, "subscribe">;
+  emit: (msg: WsMessage) => void;
+  subCount: (type: string) => number;
+} {
+  const subs = new Map<string, Set<(m: WsMessage) => void>>();
+  const subscribe: WsClient["subscribe"] = (type, handler) => {
+    let set = subs.get(type);
+    if (!set) {
+      set = new Set();
+      subs.set(type, set);
+    }
+    set.add(handler);
+    return () => {
+      set!.delete(handler);
+      if (set!.size === 0) subs.delete(type);
+    };
+  };
+  return {
+    ws: { subscribe },
+    emit: (msg) => subs.get(msg.type)?.forEach((h) => h(msg)),
+    subCount: (type) => subs.get(type)?.size ?? 0,
+  };
+}
+
+// ----- fake clock: manual trailing-debounce control -----
+
+function makeFakeTimer(): { timer: TimerLike; flush: () => void; pendingCount: () => number } {
+  let next = 1;
+  const cbs = new Map<number, () => void>();
+  const timer: TimerLike = {
+    set: (cb) => {
+      const id = next++;
+      cbs.set(id, cb);
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    clear: (h) => {
+      cbs.delete(h as unknown as number);
+    },
+  };
+  return {
+    timer,
+    flush: () => {
+      const snapshot = [...cbs.entries()];
+      cbs.clear();
+      for (const [, cb] of snapshot) cb();
+    },
+    pendingCount: () => cbs.size,
+  };
+}
+
+function projFrame(family: string, extra: Record<string, unknown> = {}): WsMessage {
+  return { type: "mc.projection", family, ...extra };
+}
+
+describe("routeProjectionFamily — S6 family → live-view policy", () => {
+  it("dispatch.lifecycle invalidates the working grid AND the task table", () => {
+    expect(routeProjectionFamily("dispatch.lifecycle")).toEqual([
+      "working-agents",
+      "tasks",
+    ]);
+  });
+
+  it("review.verdict invalidates the working grid AND the attention queue", () => {
+    expect(routeProjectionFamily("review.verdict")).toEqual([
+      "working-agents",
+      "attention",
+    ]);
+  });
+
+  it("agent.heartbeat invalidates only the working grid", () => {
+    expect(routeProjectionFamily("agent.heartbeat")).toEqual(["working-agents"]);
+  });
+
+  it("attention invalidates only the attention queue", () => {
+    expect(routeProjectionFamily("attention")).toEqual(["attention"]);
+  });
+
+  it("adapter.health touches no live execution pane (empty route)", () => {
+    expect(routeProjectionFamily("adapter.health")).toEqual([]);
+  });
+
+  it("an unknown family routes to nothing (defensive against future server families)", () => {
+    expect(routeProjectionFamily("future.thing")).toEqual([]);
+    expect(routeProjectionFamily("")).toEqual([]);
+  });
+
+  it("every declared family is routable without throwing", () => {
+    for (const fam of PROJECTION_FAMILIES) {
+      expect(Array.isArray(routeProjectionFamily(fam))).toBe(true);
+    }
+  });
+
+  it("projectionAffectsView agrees with the route", () => {
+    expect(projectionAffectsView("dispatch.lifecycle", "tasks")).toBe(true);
+    expect(projectionAffectsView("dispatch.lifecycle", "attention")).toBe(false);
+    expect(projectionAffectsView("attention", "attention")).toBe(true);
+    expect(projectionAffectsView("adapter.health", "working-agents")).toBe(false);
+  });
+});
+
+describe("attachProjectionRefetch — debounced refetch on mc.projection", () => {
+  it("subscribes to exactly the mc.projection frame type", () => {
+    const { ws, subCount } = makeFakeWs();
+    const { timer } = makeFakeTimer();
+    const teardown = attachProjectionRefetch({
+      subscribe: ws.subscribe,
+      view: "working-agents",
+      refetch: () => {},
+      debounceMs: 300,
+      timer,
+    });
+    expect(subCount("mc.projection")).toBe(1);
+    expect(subCount("state.transition")).toBe(0);
+    teardown();
+    expect(subCount("mc.projection")).toBe(0);
+  });
+
+  it("a targeting frame schedules a refetch that fires after the debounce window", () => {
+    const { ws, emit } = makeFakeWs();
+    const { timer, flush } = makeFakeTimer();
+    let calls = 0;
+    attachProjectionRefetch({
+      subscribe: ws.subscribe,
+      view: "working-agents",
+      refetch: () => calls++,
+      debounceMs: 300,
+      timer,
+    });
+
+    emit(projFrame("agent.heartbeat"));
+    expect(calls).toBe(0); // not yet — trailing debounce
+    flush();
+    expect(calls).toBe(1);
+  });
+
+  it("a burst of N targeting frames coalesces into ONE refetch", () => {
+    const { ws, emit } = makeFakeWs();
+    const { timer, flush, pendingCount } = makeFakeTimer();
+    let calls = 0;
+    attachProjectionRefetch({
+      subscribe: ws.subscribe,
+      view: "tasks",
+      refetch: () => calls++,
+      debounceMs: 300,
+      timer,
+    });
+
+    for (let i = 0; i < 5; i++) emit(projFrame("dispatch.lifecycle", { sessionId: `s${i}` }));
+    // Each frame resets the trailing timer → only one pending callback.
+    expect(pendingCount()).toBe(1);
+    flush();
+    expect(calls).toBe(1);
+  });
+
+  it("ignores frames whose family does not route to this view", () => {
+    const { ws, emit } = makeFakeWs();
+    const { timer, flush, pendingCount } = makeFakeTimer();
+    let calls = 0;
+    attachProjectionRefetch({
+      subscribe: ws.subscribe,
+      view: "attention",
+      refetch: () => calls++,
+      debounceMs: 300,
+      timer,
+    });
+
+    // agent.heartbeat → working-agents only, not attention.
+    emit(projFrame("agent.heartbeat"));
+    expect(pendingCount()).toBe(0);
+    flush();
+    expect(calls).toBe(0);
+
+    // attention → attention: now it fires.
+    emit(projFrame("attention"));
+    flush();
+    expect(calls).toBe(1);
+  });
+
+  it("ignores unknown families and malformed frames (no family / non-string family)", () => {
+    const { ws, emit } = makeFakeWs();
+    const { timer, flush } = makeFakeTimer();
+    let calls = 0;
+    attachProjectionRefetch({
+      subscribe: ws.subscribe,
+      view: "working-agents",
+      refetch: () => calls++,
+      debounceMs: 300,
+      timer,
+    });
+
+    emit(projFrame("future.unknown"));
+    emit({ type: "mc.projection" }); // no family
+    emit({ type: "mc.projection", family: 42 }); // non-string family
+    flush();
+    expect(calls).toBe(0);
+  });
+
+  it("does NOT react to other frame types (additive — existing handling untouched)", () => {
+    const { ws, emit } = makeFakeWs();
+    const { timer, flush } = makeFakeTimer();
+    let calls = 0;
+    attachProjectionRefetch({
+      subscribe: ws.subscribe,
+      view: "working-agents",
+      refetch: () => calls++,
+      debounceMs: 300,
+      timer,
+    });
+
+    emit({ type: "state.transition" });
+    emit({ type: "task.updated", task: {} });
+    emit({ type: "iteration.created" });
+    flush();
+    expect(calls).toBe(0);
+  });
+
+  it("teardown cancels a pending refetch — no fire after unmount", () => {
+    const { ws, emit, subCount } = makeFakeWs();
+    const { timer, flush, pendingCount } = makeFakeTimer();
+    let calls = 0;
+    const teardown = attachProjectionRefetch({
+      subscribe: ws.subscribe,
+      view: "working-agents",
+      refetch: () => calls++,
+      debounceMs: 300,
+      timer,
+    });
+
+    emit(projFrame("agent.heartbeat"));
+    expect(pendingCount()).toBe(1);
+    teardown();
+    expect(pendingCount()).toBe(0); // pending timer cleared
+    expect(subCount("mc.projection")).toBe(0); // unsubscribed
+    flush();
+    expect(calls).toBe(0); // never fired post-teardown
+  });
+
+  it("frames arriving after teardown are not handled (unsubscribed)", () => {
+    const { ws, emit } = makeFakeWs();
+    const { timer, flush } = makeFakeTimer();
+    let calls = 0;
+    const teardown = attachProjectionRefetch({
+      subscribe: ws.subscribe,
+      view: "working-agents",
+      refetch: () => calls++,
+      debounceMs: 300,
+      timer,
+    });
+    teardown();
+    emit(projFrame("agent.heartbeat"));
+    flush();
+    expect(calls).toBe(0);
+  });
+});

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -117,7 +117,7 @@ export function App() {
   // G-1113.D.5 — work-item-detail data (fetched whenever a work item is selected).
   const workItemDetail = useWorkItemDetail(view === "work-item-detail" ? selectedWorkItemId : null);
   // G-1113.E.3 — attention queue data (fetched only when on the Attention tab).
-  const attention = useAttention(softwareMode && view === "attention");
+  const attention = useAttention(ws, softwareMode && view === "attention");
   // If software mode is toggled OFF while on a software-mode view (Repositories
   // / Plans / phase-detail / work-item-detail / attention), the tab + render
   // both gate off — reset to default so the main area isn't left blank.

--- a/src/surface/mc/dashboard-v2/hooks/use-attention.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-attention.ts
@@ -2,41 +2,78 @@
  * G-1113.E.3 — fetch the open attention queue for the Attention surface.
  * Only fetches when `enabled` (software mode on + Attention tab visible).
  * Best-effort: a failure yields an empty queue, not an error surface.
+ *
+ * C-863 — when enabled, also refreshes off the S6 `mc.projection` broadcast so
+ * `attention`- and `review.verdict`-family projection writes (a blocking verdict
+ * opening/clearing an attention entry) push the queue live instead of waiting for
+ * the next tab re-entry. The projection subscription is a no-op while disabled
+ * (the WS frame still arrives, but `enabled=false` short-circuits the refetch).
  */
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getJson } from "../lib/api";
 import type { AttentionEntry } from "../../api/attention";
+import type { WsClient } from "./use-websocket";
+import { useProjectionRefetch } from "./use-projection-refetch";
 
 interface AttentionResponse {
   attention: AttentionEntry[];
 }
 
-export function useAttention(enabled: boolean): { entries: AttentionEntry[]; loaded: boolean } {
+export function useAttention(
+  ws: WsClient,
+  enabled: boolean
+): { entries: AttentionEntry[]; loaded: boolean } {
   const [entries, setEntries] = useState<AttentionEntry[]>([]);
   const [loaded, setLoaded] = useState(false);
 
+  // Lifetime guard so a projection-driven refetch resolving after unmount
+  // (or after the tab is left) can't setState on a dead component.
+  const aliveRef = useRef(true);
+  const enabledRef = useRef(enabled);
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const res = await getJson<AttentionResponse>(
+        "/api/attention",
+        signal ? { signal } : undefined
+      );
+      if (!aliveRef.current) return;
+      setEntries(res.attention ?? []);
+      setLoaded(true);
+    } catch (_err) {
+      // Best-effort: the surface shows an empty state rather than an error.
+      // AbortError (tab left / unmount mid-flight) is also swallowed here.
+      if (!aliveRef.current) return;
+      setEntries([]);
+      setLoaded(true);
+    }
+  }, []);
+
   useEffect(() => {
     if (!enabled) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const res = await getJson<AttentionResponse>("/api/attention");
-        if (!cancelled) {
-          setEntries(res.attention ?? []);
-          setLoaded(true);
-        }
-      } catch (_err) {
-        // Best-effort: the surface shows an empty state rather than an error.
-        if (!cancelled) {
-          setEntries([]);
-          setLoaded(true);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [enabled]);
+    const ac = new AbortController();
+    void load(ac.signal);
+    return () => ac.abort();
+  }, [enabled, load]);
+
+  // C-863 — projection-driven refresh, gated on `enabled` so a frame arriving
+  // while the tab is closed doesn't issue a pointless fetch. `refetch` is stable
+  // for the hook lifetime; the gate is read off a ref so the subscription isn't
+  // resubscribed each time `enabled` flips.
+  const refetch = useCallback(() => {
+    if (!enabledRef.current) return;
+    void load();
+  }, [load]);
+  useProjectionRefetch(ws, "attention", refetch);
 
   return { entries, loaded };
 }

--- a/src/surface/mc/dashboard-v2/hooks/use-projection-refetch.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-projection-refetch.ts
@@ -1,0 +1,41 @@
+/**
+ * MC-I1.S6 / C-863 — subscribe a live view to the `mc.projection` WS frame.
+ *
+ * Thin React wrapper over `attachProjectionRefetch` (`lib/projection-subscriber`).
+ * A data hook that already exposes a `refetch` calls this with its `view` tag to
+ * get live, debounced refreshes off projection writes (verdicts, heartbeats,
+ * attention, dispatch-lifecycle) — the same way `use-working-agents` already
+ * refreshes off `state.transition`, but driven by the S6 projection broadcast so
+ * bus→MC writes no longer wait for the next poll.
+ *
+ * The subscription + debounce + unmount-cancel all live in the pure core; this
+ * hook only manages the effect lifecycle so a pending refetch can never call
+ * `setState` after unmount.
+ */
+
+import { useEffect } from "react";
+import type { WsClient } from "./use-websocket";
+import { attachProjectionRefetch } from "../lib/projection-subscriber";
+import type { ProjectionView } from "../lib/projection-routing";
+
+/**
+ * Default trailing-debounce window for projection-driven refetches. A burst of
+ * projection frames (e.g. a dispatch fan-out that flips several rows at once)
+ * coalesces into one refetch this long after the last frame. Sits in the
+ * 250–500ms band the issue calls for — wider than the 100ms `state.transition`
+ * window because projection bursts (a team handoff, a verdict cascade) tend to
+ * arrive in clusters and the live panes tolerate a slightly later refresh.
+ */
+export const PROJECTION_REFETCH_DEBOUNCE_MS = 300;
+
+export function useProjectionRefetch(
+  ws: WsClient,
+  view: ProjectionView,
+  refetch: () => void,
+  debounceMs: number = PROJECTION_REFETCH_DEBOUNCE_MS
+): void {
+  const subscribe = ws.subscribe;
+  useEffect(() => {
+    return attachProjectionRefetch({ subscribe, view, refetch, debounceMs });
+  }, [subscribe, view, refetch, debounceMs]);
+}

--- a/src/surface/mc/dashboard-v2/hooks/use-tasks.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-tasks.ts
@@ -30,6 +30,7 @@ import {
   serializeHash,
 } from "../lib/task-table-hash";
 import type { WsClient, WsMessage } from "./use-websocket";
+import { useProjectionRefetch } from "./use-projection-refetch";
 import { ITERATION_STATES, type IterationState } from "../../db/iterations";
 import type { TaskListItem } from "../../db/tasks";
 import {
@@ -170,6 +171,13 @@ export function useTasks(ws: WsClient): TasksHookState {
       }
     };
   }, [subscribe, refetch]);
+
+  // C-863 — refresh off the S6 `mc.projection` broadcast: a `dispatch.lifecycle`
+  // projection write can flip a task's aggregate state (any dispatch transition
+  // ranks into the seven-state aggregate), so the task table re-reads on it. Uses
+  // its own (wider) trailing debounce so a dispatch fan-out coalesces into one
+  // refetch; `refetch` is the same stable zero-arg callback the WS effect uses.
+  useProjectionRefetch(ws, "tasks", refetch);
 
   // F-16 — patch the denormalised `iteration` tag on cached task rows
   // when an `iteration.updated` frame arrives. Two reasons NOT to

--- a/src/surface/mc/dashboard-v2/hooks/use-working-agents.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-working-agents.ts
@@ -17,6 +17,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiFailure, getJson } from "../lib/api";
 import type { WsClient, WsMessage } from "./use-websocket";
+import { useProjectionRefetch } from "./use-projection-refetch";
 
 export interface WorkingAgentTile {
   agent_id: string;
@@ -117,6 +118,15 @@ export function useWorkingAgents(ws: WsClient): WorkingAgentsState {
     }
     return subscribe("state.transition", onTransition);
   }, [subscribe, fetchAgents]);
+
+  // C-863 — also refresh off the S6 `mc.projection` broadcast so bus→MC
+  // projection writes (dispatch-lifecycle transitions, review verdicts, agent
+  // heartbeats) push the working grid live instead of waiting for the next
+  // `state.transition`-driven refetch. Its own (wider) trailing debounce
+  // coalesces projection bursts; the zero-arg `refetch` is stable for the hook
+  // lifetime so the subscription isn't torn down every render.
+  const refetch = useCallback(() => { void fetchAgents(); }, [fetchAgents]);
+  useProjectionRefetch(ws, "working-agents", refetch);
 
   return { agents, loaded, error };
 }

--- a/src/surface/mc/dashboard-v2/lib/projection-routing.ts
+++ b/src/surface/mc/dashboard-v2/lib/projection-routing.ts
@@ -1,0 +1,78 @@
+/**
+ * MC-I1.S6 / C-863 — `mc.projection` family → live-view routing.
+ *
+ * S6 (#862) added a server-side `mc.projection` WS broadcast: when the bus→MC
+ * projection renderer mutates MC state from an envelope (review verdicts, agent
+ * heartbeats, federated attention, adapter health, or a dispatch-lifecycle
+ * transition) it fans the write out to live dashboard clients. The frame is
+ * **family-hinted** — it carries a `family` discriminator plus optional
+ * `sessionId` / `assignmentId` joins — but, like `state.transition`, it is a
+ * REFRESH SIGNAL, not authoritative-by-payload: the rows still come from the
+ * REST API on refetch.
+ *
+ * This module owns the one piece of policy the wiring needs — which live views a
+ * given `family` can affect — kept pure so it's unit-testable without a DOM. A
+ * view subscribes to `mc.projection` and refetches only when the frame's family
+ * routes to it; a family that touches no live pane (today: `adapter.health`,
+ * which only feeds the adapter-health surface, not the three live execution
+ * panes) routes to the empty set and triggers no refetch.
+ */
+
+/** The projection families the server may stamp on an `mc.projection` frame. */
+export const PROJECTION_FAMILIES = [
+  "dispatch.lifecycle",
+  "review.verdict",
+  "agent.heartbeat",
+  "attention",
+  "adapter.health",
+] as const;
+
+export type ProjectionFamily = (typeof PROJECTION_FAMILIES)[number];
+
+/**
+ * The live views a `mc.projection` refetch can target. These are the
+ * data hooks whose REST payload a projection write can invalidate.
+ */
+export type ProjectionView = "working-agents" | "tasks" | "attention";
+
+/**
+ * Map a projection `family` → the live views it can invalidate.
+ *
+ *   - `dispatch.lifecycle` — a dispatch moved (queued → dispatched → running →
+ *     done/blocked). Re-reads the working grid AND the task table (a task's
+ *     aggregate state can flip on any dispatch transition).
+ *   - `review.verdict` — a reviewer posted a verdict. Touches the working grid
+ *     (the reviewed assignment's state) and the attention queue (a blocking
+ *     verdict can open/clear an attention entry).
+ *   - `agent.heartbeat` — an agent's liveness changed. Working grid only.
+ *   - `attention` — the attention queue itself changed.
+ *   - `adapter.health` — adapter up/down; no live execution pane reads it, so
+ *     it routes to nothing (additive future surface).
+ *
+ * An unknown / malformed family routes to the empty set (defensive: a future
+ * server family this client doesn't know about triggers no spurious refetch).
+ */
+export function routeProjectionFamily(family: string): readonly ProjectionView[] {
+  switch (family) {
+    case "dispatch.lifecycle":
+      return ["working-agents", "tasks"];
+    case "review.verdict":
+      return ["working-agents", "attention"];
+    case "agent.heartbeat":
+      return ["working-agents"];
+    case "attention":
+      return ["attention"];
+    case "adapter.health":
+      return [];
+    default:
+      return [];
+  }
+}
+
+/** Does an `mc.projection` frame of this family target the given view? */
+export function projectionAffectsView(
+  family: string,
+  view: ProjectionView
+): boolean {
+  return routeProjectionFamily(family).includes(view);
+}

--- a/src/surface/mc/dashboard-v2/lib/projection-subscriber.ts
+++ b/src/surface/mc/dashboard-v2/lib/projection-subscriber.ts
@@ -1,0 +1,77 @@
+/**
+ * MC-I1.S6 / C-863 — pure `mc.projection` → debounced-refetch core.
+ *
+ * Factored out of the React hook (`use-projection-refetch`) so the
+ * subscribe + family-filter + trailing-debounce + unmount-cancel logic is
+ * unit-testable without a DOM. The hook is a thin wrapper that supplies the
+ * real `subscribe` and lets the timers default to the platform ones.
+ *
+ * Behaviour (matches the issue's acceptance criteria):
+ *   - Subscribes to exactly the `mc.projection` frame type (additive — other
+ *     frame handling is untouched; old clients ignoring the frame keep working).
+ *   - Refetches only when the frame's `family` routes to this `view`
+ *     (`projection-routing.ts`). A non-targeting or unknown family is ignored.
+ *   - Trailing debounce: a burst of N targeting frames within the window
+ *     coalesces into ONE refetch, fired `debounceMs` after the LAST frame.
+ *   - The debounce is per-subscriber (one timer per `attach` call), and the
+ *     returned teardown cancels any pending timer — no refetch (and so no
+ *     setState) can fire after unmount.
+ */
+
+import type { WsClient, WsMessage } from "../hooks/use-websocket";
+import { projectionAffectsView, type ProjectionView } from "./projection-routing";
+
+/** Injection seam so tests can drive a fake clock. */
+export interface TimerLike {
+  set: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clear: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+const realTimer: TimerLike = {
+  set: (cb, ms) => setTimeout(cb, ms),
+  clear: (h) => clearTimeout(h),
+};
+
+export interface AttachProjectionRefetchArgs {
+  /** The single-WS client's `subscribe`. */
+  subscribe: WsClient["subscribe"];
+  /** Which live view this refetch belongs to. */
+  view: ProjectionView;
+  /** Re-read the view's REST payload. Called at most once per debounce window. */
+  refetch: () => void;
+  /** Trailing-debounce window, ms. */
+  debounceMs: number;
+  /** Test seam; defaults to real timers. */
+  timer?: TimerLike;
+}
+
+/**
+ * Wire an `mc.projection` debounced refetch for one view. Returns a teardown
+ * that unsubscribes AND cancels any pending debounced refetch.
+ */
+export function attachProjectionRefetch(args: AttachProjectionRefetchArgs): () => void {
+  const { subscribe, view, refetch, debounceMs, timer = realTimer } = args;
+
+  let pending: ReturnType<typeof setTimeout> | null = null;
+
+  const onProjection = (msg: WsMessage): void => {
+    const family = msg["family"];
+    if (typeof family !== "string") return;
+    if (!projectionAffectsView(family, view)) return;
+    if (pending !== null) timer.clear(pending);
+    pending = timer.set(() => {
+      pending = null;
+      refetch();
+    }, debounceMs);
+  };
+
+  const unsubscribe = subscribe("mc.projection", onProjection);
+
+  return () => {
+    unsubscribe();
+    if (pending !== null) {
+      timer.clear(pending);
+      pending = null;
+    }
+  };
+}


### PR DESCRIPTION
## What

Wires `dashboard-v2` to subscribe to the **`mc.projection`** WebSocket frame so the live pane refreshes the moment the bus→MC projection renderer writes — instead of waiting for the next `state.transition`-driven refetch.

## Why

S6 (#862, merged) added a **server-side** `mc.projection` WS broadcast: when the MC projection renderer mutates MC state from a bus envelope (review verdicts, agent heartbeats, federated attention, adapter health, dispatch-lifecycle transitions), the server fans the write out via `wsRegistry`. **But no dashboard-v2 client subscribed to it** — closing the consumer side of the S4 "projection writes bypass WS fan-out" gap is this PR.

## Frame-shape finding: **family-hinted** (not generic)

The S6 frame (`src/surface/mc/ws/types.ts` + `notifications.ts` `broadcastProjection`) is:

```ts
{ type: "mc.projection";
  family: "dispatch.lifecycle" | "review.verdict" | "agent.heartbeat" | "attention" | "adapter.health";
  sessionId?: string; assignmentId?: string }
```

So it carries a `family` discriminator. Like `state.transition`, it is a **refresh signal**, not authoritative-by-payload (rows still come from REST on refetch). We exploit the hint to refetch **only the relevant views per family** rather than refetching everything:

| family | refetches |
|---|---|
| `dispatch.lifecycle` | working-agents + tasks |
| `review.verdict` | working-agents + attention |
| `agent.heartbeat` | working-agents |
| `attention` | attention |
| `adapter.health` | — (no live execution pane reads it) |

Unknown / malformed families route to nothing (defensive against future server families).

## Approach

- **`lib/projection-routing.ts`** — pure family→view policy (`routeProjectionFamily`, `projectionAffectsView`).
- **`lib/projection-subscriber.ts`** — pure `attachProjectionRefetch`: subscribe to `mc.projection`, family-filter, **trailing debounce**, teardown cancels the pending timer (injectable timer seam for tests).
- **`hooks/use-projection-refetch.ts`** — thin React wrapper; manages effect lifecycle so no `setState` fires after unmount.
- Wired into **use-working-agents**, **use-tasks**, **use-attention** — each reuses its **existing** REST refetch (no new data layer). `use-attention` now takes `ws` and its projection refetch is gated on `enabled` (no fetch while the tab is closed).

**Debounce:** per-subscriber trailing window, **300ms** (in the issue's 250–500ms band), so a projection burst (team handoff, verdict cascade, dispatch fan-out) coalesces into one refetch. Cancels on unmount.

**Additive:** other frame handling is untouched; old clients ignoring the frame keep working.

## Test plan

`src/surface/mc/dashboard-v2/__tests__/projection-refetch.test.ts` (16 cases, all green):
- family→view routing for every family + unknown/empty;
- a targeting frame fires a debounced refetch after the window;
- a burst of N frames → **one** refetch (coalescing);
- non-targeting + unknown + malformed (no/non-string `family`) frames ignored;
- **other** frame types (`state.transition`, `task.updated`, `iteration.created`) unaffected;
- teardown cancels the pending refetch and unsubscribes (no fire after unmount).

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, none in changed files)
- `bun test` — full suite: 5333 pass / 2 fail; the 2 failures are `src/surface/mc/__tests__/embed.test.ts` (MC embed port/health boot), **pre-existing on clean origin/main** (verified) and unrelated to dashboard-v2.
- dashboard-v2 carve-out: 445 pass / 0 fail.

## Live note

The backend `mc.projection` frame is already live (pane up on localhost:8767; GET endpoints verified 200). **Full live verification of this client change needs a dashboard rebuild + deploy** (`bun build` → `wrangler pages deploy`) — that is the separate live step and is out of scope for this PR.

Closes #863
Part of #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)