### PR TITLE
fix(mc): embed tests bind ephemeral ports (no 8767 collision with the live pane)

### DIFF
--- a/src/surface/mc/__tests__/embed.test.ts
+++ b/src/surface/mc/__tests__/embed.test.ts
@@ -31,21 +31,32 @@ describe("startMissionControl (embed)", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  /** Write a minimal MC yaml that keeps the hook poller hermetic (tmp rawEventsDir). */
+  /**
+   * Write a minimal MC yaml that keeps the hook poller hermetic (tmp
+   * rawEventsDir) AND binds an OS-assigned ephemeral port.
+   *
+   * `port: 0` is load-bearing: the embed maps an absent/zero `opts.port` onto
+   * the yaml's `port`, and a yaml WITHOUT a `port` key falls back to the MC
+   * default 8767 (config.ts DEFAULT_CONFIG) — which collides (EADDRINUSE) with
+   * the live in-process MC pane a cortex daemon now runs on 8767 (cortex#880).
+   * Writing `port: 0` here makes `loaded.port` 0, so Bun.serve assigns a free
+   * port and `handle.port` reports the real bound one. Every test that boots the
+   * embed reads `handle.port` for its assertions, so no fixed port is assumed.
+   */
   function writeMcYaml(): string {
     const cfgPath = join(tmpDir, "mc.yaml");
     const rawEventsDir = join(tmpDir, "events", "raw");
     mkdirSync(rawEventsDir, { recursive: true });
-    writeFileSync(cfgPath, `hooks:\n  rawEventsDir: ${rawEventsDir}\n`);
+    writeFileSync(cfgPath, `port: 0\nhooks:\n  rawEventsDir: ${rawEventsDir}\n`);
     return cfgPath;
   }
 
   it("boots, serves /health, and lands db + cursor beside each other", async () => {
     const dbPath = join(tmpDir, "data", "mission-control.db");
     handle = await startMissionControl({
-      configPath: writeMcYaml(),
+      configPath: writeMcYaml(), // yaml carries `port: 0` → OS-assigned, no 8767 collision
       dbPath,
-      port: 0, // OS-assigned free port — hermetic, no fixed-port collisions
+      // port omitted → the yaml's `port: 0` governs → Bun.serve assigns a free port
     });
 
     // Bun.serve resolves port 0 to an assigned port; the handle exposes the real one.
@@ -78,9 +89,8 @@ describe("startMissionControl (embed)", () => {
 
   it("releases the port on stop()", async () => {
     handle = await startMissionControl({
-      configPath: writeMcYaml(),
+      configPath: writeMcYaml(), // yaml carries `port: 0` → OS-assigned, no 8767 collision
       dbPath: join(tmpDir, "data", "mission-control.db"),
-      port: 0,
     });
     const port = handle.port;
 


### PR DESCRIPTION
## The bug

`src/surface/mc/__tests__/embed.test.ts`'s `writeMcYaml()` helper wrote a yaml with **no `port` key**. The embed's port resolution (`embed.ts` line 73) is `opts.port && opts.port > 0 ? opts.port : loaded.port`, and `loadConfig` defaults a missing yaml `port` to **8767** (`config.ts` `DEFAULT_CONFIG.port`).

So passing `opts.port: 0` did **not** yield an ephemeral port — `0` is falsy, the embed fell back to `loaded.port`, and that was the default `8767`. Once a cortex daemon runs the in-process MC pane on 8767, the two tests that boot via `writeMcYaml()` (the `/health` test and the `releases the port on stop()` test) fail with `EADDRINUSE` on every local `bun test`. CI was unaffected (no daemon on runners), but local runs had 2 persistent failures.

## The fix

`writeMcYaml()` now emits `port: 0` into the yaml. That makes `loaded.port` `0`, which reaches `Bun.serve({ port: 0 })` → the OS assigns a free port, and the embed returns the real bound port via `handle.port` (the `server.port` mechanism established in #854). Both affected tests already read `handle.port` for their `/health` URL assertions, so no fixed port is assumed anywhere, and each test tears down via `stop()` so the port is released.

**No `embed.ts` change was needed** — the embed already binds ephemeral when `config.port` is 0; the bug was entirely in the test helper feeding it a port-less yaml.

The misleading `port: 0` comments on the two call sites (which implied `opts.port: 0` was ephemeral) were corrected to point at the yaml's `port: 0` as the real mechanism.

## Verification

A cortex daemon **was holding 8767** during verification (the exact collision condition). With it up:

- `bun test src/surface/mc/__tests__/embed.test.ts` → **4 pass / 0 fail** (was 2 pass / 2 fail before the change)
- Full `bun test` → **5337 pass / 2 skip / 0 fail** — these two were the only failures
- `bunx tsc --noEmit` → clean
- `bun run lint` → 0 errors (changed file `embed.test.ts` carve-out clean)

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)