### PR TITLE
feat(mc): retention/prune for terminal orphan rows + events table (#857, #864)

### DIFF
--- a/src/surface/mc/__tests__/poller-retention.test.ts
+++ b/src/surface/mc/__tests__/poller-retention.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration: the hook poller runs the retention prune on its tick (throttled,
+ * best-effort), without breaking ingestion or the cursor (#857/#864).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { SCHEMA_SQL } from "../db/schema";
+import { applyTransition } from "../db/transitions";
+import { registerOrphanSession } from "../db/sessions";
+import { HookStreamPoller } from "../hooks/poller";
+import { ORPHAN_RETENTION_MS } from "../db/retention";
+import type { HooksConfig } from "../types";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+describe("HookStreamPoller retention prune wiring", () => {
+  let db: Database;
+  let tmp: string;
+  let config: HooksConfig;
+
+  beforeEach(() => {
+    db = setupDb();
+    tmp = mkdtempSync(join(tmpdir(), "mc-poller-retention-"));
+    config = {
+      // A dir with no .jsonl files: poll() ingests nothing but still runs the
+      // tail of the cycle (cursor save + prune).
+      rawEventsDir: tmp,
+      cursorPath: join(tmp, "cursor.json"),
+      pollInterval: 2000,
+    };
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("prunes an old terminal orphan on the first poll tick", () => {
+    const orphan = registerOrphanSession(db, "cc-poll-old")!;
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "start" });
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "complete" });
+    db.query(`UPDATE sessions SET ended_at = ? WHERE id = ?`).run(
+      new Date(Date.now() - ORPHAN_RETENTION_MS - DAY).toISOString(),
+      orphan.sessionId
+    );
+
+    const poller = new HookStreamPoller(db, config);
+    poller.poll(); // first tick → throttle fires
+
+    expect(db.query(`SELECT 1 FROM sessions WHERE id = ?`).get(orphan.sessionId)).toBeNull();
+    expect(db.query(`SELECT 1 FROM agents WHERE id = ?`).get(orphan.agentId)).toBeNull();
+    poller.stop();
+  });
+
+  it("retains a fresh orphan and the orphan-task anchor", () => {
+    const orphan = registerOrphanSession(db, "cc-poll-fresh")!;
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "start" });
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "complete" });
+    db.query(`UPDATE sessions SET ended_at = ? WHERE id = ?`).run(
+      new Date(Date.now() - DAY).toISOString(),
+      orphan.sessionId
+    );
+
+    const poller = new HookStreamPoller(db, config);
+    poller.poll();
+
+    expect(db.query(`SELECT 1 FROM sessions WHERE id = ?`).get(orphan.sessionId)).toBeTruthy();
+    expect(db.query(`SELECT 1 FROM tasks WHERE id = 'mc-orphan-task'`).get()).toBeTruthy();
+    poller.stop();
+  });
+
+  it("poll() does not throw even if the db is in a bad state for the prune", () => {
+    const poller = new HookStreamPoller(db, config);
+    db.close(); // prune will fail; best-effort path must swallow it
+    let threw = false;
+    try {
+      poller.poll();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    // re-open a throwaway so afterEach's db.close() is safe
+    db = setupDb();
+  });
+});

--- a/src/surface/mc/__tests__/retention-prune.test.ts
+++ b/src/surface/mc/__tests__/retention-prune.test.ts
@@ -1,0 +1,352 @@
+/**
+ * MC retention/prune tests (#857 orphan rows, #864 events table).
+ *
+ * Covers:
+ *   - `ended_at` is stamped on terminal orphan transitions (the missing piece).
+ *   - orphan rows older than the window prune (agent + assignment + session +
+ *     events all gone); within-window orphans are retained; the shared
+ *     `mc-orphan-task` anchor survives; real (non-orphan) tasks/agents/sessions
+ *     are NEVER pruned even when old.
+ *   - events older than the window prune; recent events retained; the prune is
+ *     idempotent and transactional.
+ *   - the throttle (prune does not run every tick) and best-effort posture (a
+ *     prune failure does not throw out of the caller).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { SCHEMA_SQL } from "../db/schema";
+import { applyTransition } from "../db/transitions";
+import { registerOrphanSession, ORPHAN_AGENT_PREFIX } from "../db/sessions";
+import { insertEvent } from "../db/events";
+import {
+  pruneOrphanSessions,
+  pruneOldEvents,
+  pruneRetention,
+  ORPHAN_RETENTION_MS,
+  EVENTS_RETENTION_MS,
+  ThrottledPrune,
+} from "../db/retention";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+/** Backdate a session's ended_at to N ms before now (ISO-8601 UTC). */
+function backdateEndedAt(db: Database, sessionId: string, msAgo: number): void {
+  const iso = new Date(Date.now() - msAgo).toISOString();
+  db.query(`UPDATE sessions SET ended_at = ? WHERE id = ?`).run(iso, sessionId);
+}
+
+/** Backdate an event's timestamp to N ms before now (ISO-8601 UTC). */
+function backdateEvent(db: Database, eventId: string, msAgo: number): void {
+  const iso = new Date(Date.now() - msAgo).toISOString();
+  db.query(`UPDATE events SET timestamp = ? WHERE id = ?`).run(iso, eventId);
+}
+
+function rowCount(db: Database, table: string): number {
+  return (db.query(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n: number }).n;
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("ended_at stamping on terminal transitions", () => {
+  let db: Database;
+  beforeEach(() => { db = setupDb(); });
+  afterEach(() => { db.close(); });
+
+  it("stamps ended_at when an orphan assignment completes", () => {
+    const orphan = registerOrphanSession(db, "cc-end-1");
+    expect(orphan).not.toBeNull();
+    // dispatched → running → completed
+    expect(applyTransition(db, orphan!.assignmentId, orphan!.sessionId, { type: "start" }).ok).toBe(true);
+    const completed = applyTransition(db, orphan!.assignmentId, orphan!.sessionId, { type: "complete" });
+    expect(completed.ok).toBe(true);
+
+    const row = db.query(`SELECT ended_at FROM sessions WHERE id = ?`).get(orphan!.sessionId) as { ended_at: string | null };
+    expect(row.ended_at).toBeTruthy();
+  });
+
+  it("stamps ended_at on fail and cancel terminals too", () => {
+    const o1 = registerOrphanSession(db, "cc-fail-1")!;
+    applyTransition(db, o1.assignmentId, o1.sessionId, { type: "start" });
+    applyTransition(db, o1.assignmentId, o1.sessionId, { type: "fail", error: "boom" });
+    const failedRow = db.query(`SELECT ended_at FROM sessions WHERE id = ?`).get(o1.sessionId) as { ended_at: string | null };
+    expect(failedRow.ended_at).toBeTruthy();
+
+    const o2 = registerOrphanSession(db, "cc-cancel-1")!;
+    applyTransition(db, o2.assignmentId, o2.sessionId, { type: "cancel" });
+    const cancelledRow = db.query(`SELECT ended_at FROM sessions WHERE id = ?`).get(o2.sessionId) as { ended_at: string | null };
+    expect(cancelledRow.ended_at).toBeTruthy();
+  });
+
+  it("does NOT stamp ended_at on a non-terminal transition", () => {
+    const orphan = registerOrphanSession(db, "cc-running-1")!;
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "start" }); // → running (non-terminal)
+    const row = db.query(`SELECT ended_at FROM sessions WHERE id = ?`).get(orphan.sessionId) as { ended_at: string | null };
+    expect(row.ended_at).toBeNull();
+  });
+
+  it("does not clobber an already-set ended_at on a second terminal-ish apply", () => {
+    const orphan = registerOrphanSession(db, "cc-idem-1")!;
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "start" });
+    const completed = applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "complete" });
+    expect(completed.ok).toBe(true);
+    const first = db.query(`SELECT ended_at FROM sessions WHERE id = ?`).get(orphan.sessionId) as { ended_at: string };
+    // A redundant transition from a terminal state is rejected by the state machine,
+    // so ended_at is untouched.
+    const again = applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "complete" });
+    expect(again.ok).toBe(false);
+    const second = db.query(`SELECT ended_at FROM sessions WHERE id = ?`).get(orphan.sessionId) as { ended_at: string };
+    expect(second.ended_at).toBe(first.ended_at);
+  });
+});
+
+describe("pruneOrphanSessions (#857)", () => {
+  let db: Database;
+  beforeEach(() => { db = setupDb(); });
+  afterEach(() => { db.close(); });
+
+  /** Register an orphan, drive it terminal, backdate ended_at, and return its ids. */
+  function terminalOrphan(ccId: string, ageMs: number) {
+    const orphan = registerOrphanSession(db, ccId)!;
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "start" });
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "complete" });
+    backdateEndedAt(db, orphan.sessionId, ageMs);
+    return orphan;
+  }
+
+  it("prunes orphan agent + assignment + session beyond the window", () => {
+    const old = terminalOrphan("cc-old-1", ORPHAN_RETENTION_MS + DAY);
+
+    const result = pruneOrphanSessions(db);
+    expect(result.prunedSessions).toBe(1);
+    expect(result.prunedAssignments).toBe(1);
+    expect(result.prunedAgents).toBe(1);
+
+    expect(db.query(`SELECT 1 FROM sessions WHERE id = ?`).get(old.sessionId)).toBeNull();
+    expect(db.query(`SELECT 1 FROM agent_task_assignment WHERE id = ?`).get(old.assignmentId)).toBeNull();
+    expect(db.query(`SELECT 1 FROM agents WHERE id = ?`).get(old.agentId)).toBeNull();
+  });
+
+  it("cascades the orphan session's events when the session prunes", () => {
+    const old = terminalOrphan("cc-old-ev", ORPHAN_RETENTION_MS + DAY);
+    insertEvent(db, { sessionId: old.sessionId, type: "stream-json", payload: { a: 1 } });
+    insertEvent(db, { sessionId: old.sessionId, type: "stream-json", payload: { b: 2 } });
+    expect(rowCount(db, "events")).toBeGreaterThanOrEqual(2);
+
+    pruneOrphanSessions(db);
+    const remaining = db.query(`SELECT COUNT(*) AS n FROM events WHERE session_id = ?`).get(old.sessionId) as { n: number };
+    expect(remaining.n).toBe(0);
+  });
+
+  it("retains orphan rows still inside the window", () => {
+    const fresh = terminalOrphan("cc-fresh-1", DAY); // 1 day old, window is 7d
+    const result = pruneOrphanSessions(db);
+    expect(result.prunedSessions).toBe(0);
+    expect(db.query(`SELECT 1 FROM sessions WHERE id = ?`).get(fresh.sessionId)).toBeTruthy();
+    expect(db.query(`SELECT 1 FROM agents WHERE id = ?`).get(fresh.agentId)).toBeTruthy();
+  });
+
+  it("retains terminal orphans whose ended_at is NULL (defensive — never computed-age NULL)", () => {
+    const orphan = registerOrphanSession(db, "cc-null-end")!;
+    // Force assignment terminal WITHOUT going through applyTransition's stamping,
+    // simulating a legacy row that predates the ended_at fix.
+    db.query(`UPDATE agent_task_assignment SET state = 'completed' WHERE id = ?`).run(orphan.assignmentId);
+    // ended_at stays NULL
+    const result = pruneOrphanSessions(db);
+    expect(result.prunedSessions).toBe(0);
+    expect(db.query(`SELECT 1 FROM sessions WHERE id = ?`).get(orphan.sessionId)).toBeTruthy();
+  });
+
+  it("never prunes a non-terminal (still-running) orphan even when old", () => {
+    const orphan = registerOrphanSession(db, "cc-running-old")!;
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "start" }); // running, ended_at NULL
+    // Even if we backdate started_at, a running session has no ended_at → not terminal.
+    db.query(`UPDATE sessions SET started_at = ? WHERE id = ?`)
+      .run(new Date(Date.now() - 30 * DAY).toISOString(), orphan.sessionId);
+    pruneOrphanSessions(db);
+    expect(db.query(`SELECT 1 FROM sessions WHERE id = ?`).get(orphan.sessionId)).toBeTruthy();
+  });
+
+  it("preserves the shared mc-orphan-task anchor", () => {
+    terminalOrphan("cc-anchor-1", ORPHAN_RETENTION_MS + DAY);
+    pruneOrphanSessions(db);
+    expect(db.query(`SELECT 1 FROM tasks WHERE id = 'mc-orphan-task'`).get()).toBeTruthy();
+  });
+
+  it("NEVER prunes real (non-orphan) tasks/agents/sessions even when old", () => {
+    // A real dispatch-projected agent + assignment + session, terminal and ancient.
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system, status) VALUES ('real-task', 'Real', 2, 'andreas', 'github', 'done')`);
+    db.exec(`INSERT INTO agents (id, name, type, persistent) VALUES ('real-agent', 'Echo', 'head', 1)`);
+    db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('real-ata', 'real-agent', 'real-task', 'completed')`);
+    const sid = "real-session";
+    db.query(`INSERT INTO sessions (id, assignment_id, cc_session_id, endpoint_kind, started_at, ended_at) VALUES (?, 'real-ata', 'cc-real', 'local.process.controlled', ?, ?)`)
+      .run(sid, new Date(Date.now() - 60 * DAY).toISOString(), new Date(Date.now() - 60 * DAY).toISOString());
+
+    const result = pruneOrphanSessions(db);
+    expect(result.prunedSessions).toBe(0);
+    expect(db.query(`SELECT 1 FROM sessions WHERE id = 'real-session'`).get()).toBeTruthy();
+    expect(db.query(`SELECT 1 FROM agents WHERE id = 'real-agent'`).get()).toBeTruthy();
+    expect(db.query(`SELECT 1 FROM agent_task_assignment WHERE id = 'real-ata'`).get()).toBeTruthy();
+    expect(db.query(`SELECT 1 FROM tasks WHERE id = 'real-task'`).get()).toBeTruthy();
+  });
+
+  it("is idempotent — a second prune over the same state is a no-op", () => {
+    terminalOrphan("cc-idem-prune", ORPHAN_RETENTION_MS + DAY);
+    const first = pruneOrphanSessions(db);
+    expect(first.prunedSessions).toBe(1);
+    const second = pruneOrphanSessions(db);
+    expect(second.prunedSessions).toBe(0);
+    expect(second.prunedAssignments).toBe(0);
+    expect(second.prunedAgents).toBe(0);
+  });
+
+  it("only prunes mc-orphan-prefixed agents", () => {
+    const old = terminalOrphan("cc-prefix-1", ORPHAN_RETENTION_MS + DAY);
+    expect(old.agentId.startsWith(ORPHAN_AGENT_PREFIX)).toBe(true);
+    pruneOrphanSessions(db);
+    // The agent is gone; verify no non-orphan agent id was touched by checking the
+    // (separately-inserted) shadow agent survives if present.
+    db.exec(`INSERT INTO agents (id, name, type, persistent) VALUES ('mc-shadow-agent', 'shadow', 'hands', 1) ON CONFLICT(id) DO NOTHING`);
+    pruneOrphanSessions(db);
+    expect(db.query(`SELECT 1 FROM agents WHERE id = 'mc-shadow-agent'`).get()).toBeTruthy();
+  });
+});
+
+describe("pruneOldEvents (#864)", () => {
+  let db: Database;
+  beforeEach(() => { db = setupDb(); });
+  afterEach(() => { db.close(); });
+
+  /** Create a retained (non-orphan, still-running) session to hang events on. */
+  function liveSession(): string {
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-live', 'Live', 2, 'andreas', 'internal') ON CONFLICT(id) DO NOTHING`);
+    db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-live', 'Live', 'head') ON CONFLICT(id) DO NOTHING`);
+    db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('ata-live', 'a-live', 't-live', 'running') ON CONFLICT(id) DO NOTHING`);
+    const sid = "s-live";
+    db.query(`INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at) VALUES (?, 'ata-live', 'local.observed', ?) ON CONFLICT(id) DO NOTHING`)
+      .run(sid, new Date().toISOString());
+    return sid;
+  }
+
+  it("prunes events older than the window, retaining recent ones", () => {
+    const sid = liveSession();
+    const oldEv = insertEvent(db, { sessionId: sid, type: "stream-json", payload: {} });
+    const newEv = insertEvent(db, { sessionId: sid, type: "stream-json", payload: {} });
+    backdateEvent(db, oldEv.id, EVENTS_RETENTION_MS + DAY);
+    backdateEvent(db, newEv.id, DAY);
+
+    const result = pruneOldEvents(db);
+    expect(result.prunedEvents).toBe(1);
+    expect(db.query(`SELECT 1 FROM events WHERE id = ?`).get(oldEv.id)).toBeNull();
+    expect(db.query(`SELECT 1 FROM events WHERE id = ?`).get(newEv.id)).toBeTruthy();
+  });
+
+  it("is idempotent", () => {
+    const sid = liveSession();
+    const oldEv = insertEvent(db, { sessionId: sid, type: "stream-json", payload: {} });
+    backdateEvent(db, oldEv.id, EVENTS_RETENTION_MS + DAY);
+    expect(pruneOldEvents(db).prunedEvents).toBe(1);
+    expect(pruneOldEvents(db).prunedEvents).toBe(0);
+  });
+
+  it("prunes old events even when their session is retained", () => {
+    const sid = liveSession(); // session stays (running, not orphan-terminal)
+    const oldEv = insertEvent(db, { sessionId: sid, type: "stream-json", payload: {} });
+    backdateEvent(db, oldEv.id, EVENTS_RETENTION_MS + DAY);
+    pruneOldEvents(db);
+    expect(db.query(`SELECT 1 FROM sessions WHERE id = ?`).get(sid)).toBeTruthy(); // session retained
+    expect(db.query(`SELECT 1 FROM events WHERE id = ?`).get(oldEv.id)).toBeNull(); // old event pruned
+  });
+});
+
+describe("pruneRetention (combined, transactional, best-effort)", () => {
+  let db: Database;
+  beforeEach(() => { db = setupDb(); });
+  afterEach(() => { db.close(); });
+
+  it("runs both prunes and reports a combined summary", () => {
+    const orphan = registerOrphanSession(db, "cc-combined")!;
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "start" });
+    applyTransition(db, orphan.assignmentId, orphan.sessionId, { type: "complete" });
+    backdateEndedAt(db, orphan.sessionId, ORPHAN_RETENTION_MS + DAY);
+
+    const summary = pruneRetention(db);
+    expect(summary.prunedSessions).toBe(1);
+    expect(summary.prunedAgents).toBe(1);
+    expect(summary.ok).toBe(true);
+  });
+
+  it("is best-effort: a prune over a closed db returns ok:false, never throws", () => {
+    db.close();
+    let threw = false;
+    const summary = (() => {
+      try {
+        return pruneRetention(db);
+      } catch {
+        threw = true;
+        return null;
+      }
+    })();
+    expect(threw).toBe(false);
+    expect(summary?.ok).toBe(false);
+  });
+});
+
+describe("ThrottledPrune (caller throttle)", () => {
+  it("runs on the first call then suppresses within the interval", () => {
+    let runs = 0;
+    let now = 1_000_000;
+    const throttle = new ThrottledPrune({
+      intervalMs: 60 * 60 * 1000, // 1h
+      now: () => now,
+      run: () => { runs += 1; },
+    });
+
+    throttle.maybeRun(); // first call → runs
+    expect(runs).toBe(1);
+
+    now += 60 * 1000; // +1 min, well within the 1h window
+    throttle.maybeRun();
+    expect(runs).toBe(1); // suppressed
+
+    now += 60 * 60 * 1000; // +1h, past the window
+    throttle.maybeRun();
+    expect(runs).toBe(2); // runs again
+  });
+
+  it("never throws out of maybeRun even when the run throws", () => {
+    const now = 0;
+    const throttle = new ThrottledPrune({
+      intervalMs: 1000,
+      now: () => now,
+      run: () => { throw new Error("prune blew up"); },
+    });
+    let threw = false;
+    try {
+      throttle.maybeRun();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+  });
+
+  it("advances the last-run clock even when the run throws (no tight-loop retry storm)", () => {
+    let runs = 0;
+    let now = 0;
+    const throttle = new ThrottledPrune({
+      intervalMs: 1000,
+      now: () => now,
+      run: () => { runs += 1; throw new Error("boom"); },
+    });
+    throttle.maybeRun();
+    expect(runs).toBe(1);
+    now += 100; // within window
+    throttle.maybeRun();
+    expect(runs).toBe(1); // suppressed despite the prior throw
+  });
+});

--- a/src/surface/mc/db/retention.ts
+++ b/src/surface/mc/db/retention.ts
@@ -42,7 +42,7 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { ORPHAN_AGENT_PREFIX } from "./sessions";
+import { ORPHAN_AGENT_PREFIX, ORPHAN_TASK_ID } from "./sessions";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -64,8 +64,9 @@ export const ORPHAN_RETENTION_MS = 7 * DAY_MS;
  */
 export const EVENTS_RETENTION_MS = 14 * DAY_MS;
 
-/** The shared orphan anchor task — preserved by the prune (only its children go). */
-const ORPHAN_TASK_ID = "mc-orphan-task";
+// ORPHAN_TASK_ID is imported from ./sessions — the shared orphan anchor task,
+// preserved by the prune (only its children go). Single source of truth so the
+// DELETE anchor can't drift from the registration site.
 
 export interface OrphanPruneResult {
   prunedSessions: number;

--- a/src/surface/mc/db/retention.ts
+++ b/src/surface/mc/db/retention.ts
@@ -1,0 +1,309 @@
+/**
+ * Mission Control retention / prune (#857 orphan rows, #864 events table).
+ *
+ * The live MC pane accretes two row families with no server-side retention:
+ *
+ *   1. **Orphan auto-registration (#857).** `registerOrphanSession` (db/sessions.ts)
+ *      lands one synthetic agent + assignment + session (+ a `state.transition`
+ *      event) per distinct `cc_session_id`, FOREVER. The working grid stays
+ *      clean (`listWorkingAgents` filters terminal states) but the underlying
+ *      agent/assignment/session rows never prune.
+ *
+ *   2. **Events table (#864).** `events` has only a client-side 500-row
+ *      in-memory cap; the hook ingestor + the S6 projection families are steady
+ *      writers with no server-side bound.
+ *
+ * This module is the SINGLE retention mechanism for both. It is hung off a
+ * periodic, throttled caller (see `ThrottledPrune`) so it runs at most once per
+ * interval regardless of how frequently the host loop ticks.
+ *
+ * ── Design choices (stated for the PR) ──────────────────────────────────────
+ *
+ *   - **Orphan terminal-age prune** keys off `sessions.ended_at` (the #857
+ *     `applyTransition` fix stamps it on every terminal transition). A row is
+ *     prunable iff it is an orphan (its agent carries the `mc-orphan-` prefix
+ *     AND hangs off the shared `mc-orphan-task`), its session is terminal
+ *     (`ended_at IS NOT NULL`), and that `ended_at` is older than
+ *     {@link ORPHAN_RETENTION_MS}. Real dispatch-projected / principal-created
+ *     rows are NEVER touched — the prune's WHERE is double-anchored on the
+ *     orphan prefix AND the orphan task id.
+ *
+ *   - **Events prune is AGE-based, not a per-session cap.** Age is the simpler
+ *     bound that still caps unbounded growth: a single indexed
+ *     `DELETE FROM events WHERE timestamp < cutoff` (served by
+ *     `idx_events_timestamp`) vs. a per-session window-function partition scan.
+ *     Pruning an orphan SESSION already CASCADE-drops its events
+ *     (`events.session_id → sessions.id ON DELETE CASCADE`); this age prune is
+ *     the complement that reaps old events whose session is RETAINED (e.g. a
+ *     long-lived observed session that keeps emitting).
+ *
+ *   - **Windows are module constants, not config.** Minimal blast radius: no
+ *     new schema on AgentConfigSchema/CortexConfigSchema. Tune here if needed.
+ */
+
+import type { Database } from "bun:sqlite";
+import { ORPHAN_AGENT_PREFIX } from "./sessions";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Orphan terminal-row retention window. Orphan agent/assignment/session rows
+ * whose session has been terminal (`ended_at`) for longer than this prune.
+ * 7 days keeps roughly a week of observed-session history queryable on the
+ * glass before it ages out — orphan volume is ~tens/month, so this is a
+ * comfortable buffer.
+ */
+export const ORPHAN_RETENTION_MS = 7 * DAY_MS;
+
+/**
+ * Events retention window. Events older than this prune (independent of whether
+ * their session row is retained). 14 days outlives the orphan window so an
+ * orphan session's events are reaped WITH the session (CASCADE) rather than
+ * ahead of it, and gives a fortnight of drill-down history for retained
+ * sessions.
+ */
+export const EVENTS_RETENTION_MS = 14 * DAY_MS;
+
+/** The shared orphan anchor task — preserved by the prune (only its children go). */
+const ORPHAN_TASK_ID = "mc-orphan-task";
+
+export interface OrphanPruneResult {
+  prunedSessions: number;
+  prunedAssignments: number;
+  prunedAgents: number;
+}
+
+export interface EventsPruneResult {
+  prunedEvents: number;
+}
+
+export interface RetentionSummary extends OrphanPruneResult, EventsPruneResult {
+  /** false when the prune failed (e.g. closed db) — best-effort, never throws. */
+  ok: boolean;
+  /** Present when `ok` is false. */
+  error?: string;
+}
+
+/**
+ * Select the orphan assignment ids whose session is terminal beyond the
+ * retention window. An assignment qualifies iff:
+ *   - its agent id starts with the orphan prefix, AND
+ *   - it hangs off the shared `mc-orphan-task` (double-anchor: belt + braces
+ *     against a non-orphan agent ever acquiring the prefix), AND
+ *   - it has a session whose `ended_at` is non-null and older than the cutoff,
+ *     AND it has NO session that is still open (ended_at IS NULL).
+ *
+ * The "no open session" guard means a re-observed orphan (a new dispatched/
+ * running session re-attached to the same assignment) is never pruned mid-turn.
+ */
+function selectPrunableOrphanAssignments(db: Database, cutoffIso: string): string[] {
+  const rows = db
+    .query(
+      `SELECT ata.id AS id
+         FROM agent_task_assignment ata
+         JOIN agents ag ON ag.id = ata.agent_id
+        WHERE ata.task_id = ?
+          AND ag.id LIKE ? || '%'
+          AND EXISTS (
+                SELECT 1 FROM sessions s
+                 WHERE s.assignment_id = ata.id
+                   AND s.ended_at IS NOT NULL
+                   AND s.ended_at < ?
+              )
+          AND NOT EXISTS (
+                SELECT 1 FROM sessions s
+                 WHERE s.assignment_id = ata.id
+                   AND s.ended_at IS NULL
+              )`
+    )
+    .all(ORPHAN_TASK_ID, ORPHAN_AGENT_PREFIX, cutoffIso) as { id: string }[];
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Prune orphan agent/assignment/session rows (and their CASCADEd events) that
+ * are terminal beyond {@link ORPHAN_RETENTION_MS}.
+ *
+ * Order is FK-safe and runs in ONE transaction (all-or-nothing, idempotent):
+ *   1. delete the qualifying sessions   — CASCADE drops their events.
+ *   2. delete the qualifying assignments — sessions already gone; the assignment
+ *      FK is `ON DELETE CASCADE` off the assignment too, but the agent/task FKs
+ *      are RESTRICT so order matters: assignment before agent.
+ *   3. delete the now-childless orphan agents — only those with NO remaining
+ *      assignment (a re-observed orphan agent may still anchor a live session).
+ *
+ * The shared `mc-orphan-task` is intentionally preserved (it is the stable
+ * anchor; only its child assignments + sessions are reaped).
+ */
+export function pruneOrphanSessions(db: Database): OrphanPruneResult {
+  const cutoffIso = new Date(Date.now() - ORPHAN_RETENTION_MS).toISOString();
+  const assignmentIds = selectPrunableOrphanAssignments(db, cutoffIso);
+
+  if (assignmentIds.length === 0) {
+    return { prunedSessions: 0, prunedAssignments: 0, prunedAgents: 0 };
+  }
+
+  const placeholders = assignmentIds.map(() => "?").join(", ");
+
+  // bun:sqlite's `Statement.run().changes` reports cumulative changes INCLUDING
+  // FK cascades (deleting a session also counts its cascaded events), so it
+  // can't be trusted for a per-table count. We therefore count the affected
+  // rows with explicit SELECTs inside the same transaction, before the deletes.
+  const txn = db.transaction(() => {
+    const prunedSessions = (
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM sessions WHERE assignment_id IN (${placeholders})`
+        )
+        .get(...assignmentIds) as { n: number }
+    ).n;
+
+    // Orphan agents that will be left childless once their assignments go.
+    const prunedAgents = (
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM agents ag
+            WHERE ag.id LIKE ? || '%'
+              AND ag.id IN (
+                    SELECT agent_id FROM agent_task_assignment WHERE id IN (${placeholders})
+                  )
+              AND NOT EXISTS (
+                    SELECT 1 FROM agent_task_assignment ata
+                     WHERE ata.agent_id = ag.id
+                       AND ata.id NOT IN (${placeholders})
+                  )`
+        )
+        .get(ORPHAN_AGENT_PREFIX, ...assignmentIds, ...assignmentIds) as { n: number }
+    ).n;
+
+    // 1. sessions (CASCADE drops events). Scoped to the prunable assignments.
+    db.query(`DELETE FROM sessions WHERE assignment_id IN (${placeholders})`).run(
+      ...assignmentIds
+    );
+
+    // 2. assignments. The agent/task FKs are RESTRICT so this must run AFTER
+    //    sessions (CASCADE off the assignment) and BEFORE the agent delete.
+    db.query(`DELETE FROM agent_task_assignment WHERE id IN (${placeholders})`).run(
+      ...assignmentIds
+    );
+
+    // 3. orphan agents left with no assignment. Re-anchored on the orphan
+    //    prefix so a non-orphan agent can never be swept, and on "no remaining
+    //    assignment" so a re-observed orphan agent keeps its live session.
+    db.query(
+      `DELETE FROM agents
+        WHERE id LIKE ? || '%'
+          AND NOT EXISTS (
+                SELECT 1 FROM agent_task_assignment ata
+                 WHERE ata.agent_id = agents.id
+              )`
+    ).run(ORPHAN_AGENT_PREFIX);
+
+    return {
+      prunedSessions,
+      prunedAssignments: assignmentIds.length,
+      prunedAgents,
+    };
+  });
+
+  return txn();
+}
+
+/**
+ * Prune `events` older than {@link EVENTS_RETENTION_MS}. Age-based (see module
+ * doc for the cap-vs-age rationale). Single indexed DELETE; idempotent.
+ *
+ * NOTE: this does NOT touch the hook cursor. The poller reads raw JSONL from
+ * `~/.claude/events/raw/` and tracks byte offsets in `mc-hook-cursor.json`; it
+ * never reads the `events` table, so pruning rows here cannot rewind or corrupt
+ * ingestion (verified against hooks/poller.ts + hooks/ingestor.ts).
+ */
+export function pruneOldEvents(db: Database): EventsPruneResult {
+  const cutoffIso = new Date(Date.now() - EVENTS_RETENTION_MS).toISOString();
+  const res = db.query(`DELETE FROM events WHERE timestamp < ?`).run(cutoffIso);
+  return { prunedEvents: res.changes };
+}
+
+/**
+ * Run the full retention sweep: orphan terminal-row prune + events age prune.
+ *
+ * Best-effort: any failure (e.g. a closed db handle, a locked table) is caught
+ * and reported as `ok: false` rather than thrown, so a prune failure can NEVER
+ * break the host loop that calls it (the hook poller — see embed.ts wiring).
+ * Each sub-prune is independently transactional; the combined call is NOT
+ * wrapped in an outer transaction (the two are unrelated row families, and the
+ * events prune should still run even if the orphan prune is a no-op).
+ */
+export function pruneRetention(db: Database): RetentionSummary {
+  try {
+    const orphans = pruneOrphanSessions(db);
+    const events = pruneOldEvents(db);
+    return { ok: true, ...orphans, ...events };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      prunedSessions: 0,
+      prunedAssignments: 0,
+      prunedAgents: 0,
+      prunedEvents: 0,
+    };
+  }
+}
+
+export interface ThrottledPruneOptions {
+  /** Minimum ms between runs. */
+  intervalMs: number;
+  /** The work to throttle (e.g. () => pruneRetention(db)). */
+  run: () => void;
+  /** Injectable clock (defaults to Date.now) for deterministic tests. */
+  now?: () => number;
+  /** Called with any error `run` throws. Defaults to a stderr line. */
+  onError?: (err: unknown) => void;
+}
+
+/**
+ * Gate a frequently-ticked caller down to one run per `intervalMs`.
+ *
+ * The hook poller ticks every ~2s; running a full table prune every tick would
+ * be wasteful and lock-prone. `ThrottledPrune.maybeRun()` is called every tick
+ * but only invokes `run` when at least `intervalMs` has elapsed since the last
+ * run STARTED.
+ *
+ * Crucially, the last-run clock advances even when `run` throws — so a failing
+ * prune does NOT turn into a tight-loop retry storm (it waits a full interval
+ * before retrying), and `maybeRun` never throws out of the caller.
+ */
+export class ThrottledPrune {
+  private lastRunMs = -Infinity;
+  private readonly intervalMs: number;
+  private readonly run: () => void;
+  private readonly now: () => number;
+  private readonly onError: (err: unknown) => void;
+
+  constructor(opts: ThrottledPruneOptions) {
+    this.intervalMs = opts.intervalMs;
+    this.run = opts.run;
+    this.now = opts.now ?? Date.now;
+    this.onError =
+      opts.onError ??
+      ((err: unknown) =>
+        process.stderr.write(
+          `[mc-retention] prune failed: ${err instanceof Error ? err.message : String(err)}\n`
+        ));
+  }
+
+  /** Run the prune iff the interval has elapsed. Never throws. */
+  maybeRun(): void {
+    const t = this.now();
+    if (t - this.lastRunMs < this.intervalMs) return;
+    // Advance the clock BEFORE running so a throw still consumes the interval
+    // (no tight-loop retry on a persistently-failing prune).
+    this.lastRunMs = t;
+    try {
+      this.run();
+    } catch (err) {
+      this.onError(err);
+    }
+  }
+}

--- a/src/surface/mc/db/sessions.ts
+++ b/src/surface/mc/db/sessions.ts
@@ -233,7 +233,10 @@ export function createShadowAssignmentAndSession(
 // observed session. Nothing in F-20 needs to special-case orphans.
 
 export const ORPHAN_AGENT_PREFIX = "mc-orphan-";
-const ORPHAN_TASK_ID = "mc-orphan-task";
+// Exported so the retention prune anchors on the SAME id (it's a DELETE
+// anchor — a silent drift between two copies would break the prune's
+// real-row safety guarantee). See db/retention.ts.
+export const ORPHAN_TASK_ID = "mc-orphan-task";
 const ORPHAN_TASK_TITLE = "Observed sessions (unregistered)";
 // Synthetic task needs a principal_id + source_system (both NOT NULL). The task
 // is an internal MC bookkeeping row, not a real provider work item.

--- a/src/surface/mc/db/transitions.ts
+++ b/src/surface/mc/db/transitions.ts
@@ -10,6 +10,25 @@ import type { Action, AssignmentState, BlockReason, McEvent } from "../types";
 import { transition } from "../state-machine";
 import { insertEvent } from "./events";
 
+/**
+ * Terminal assignment states (see state-machine.ts: `completed`/`cancelled`
+ * have no outgoing transitions; `failed` only allows `principal_requeue` back
+ * to `queued`). When a transition lands one of these, the assignment's turn is
+ * over — so we stamp the open session's `ended_at` in the SAME transaction.
+ *
+ * This is the #857 fix: before this, orphan (and any observed) sessions
+ * auto-completed via the ingestor but their `sessions.ended_at` was NEVER set,
+ * so "terminal age" was uncomputable and the retention prune had no anchor.
+ * Stamping here (rather than in the ingestor) keeps "assignment terminal" and
+ * "session ended" consistent across EVERY transition path, not just the
+ * ingestor's auto-complete.
+ */
+const TERMINAL_STATES: ReadonlySet<AssignmentState> = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
 interface AssignmentRow {
   id: string;
   agent_id: string;
@@ -101,6 +120,21 @@ export function applyTransition(
       throw new Error(
         `Concurrent transition: assignment '${assignmentId}' state changed during apply`
       );
+    }
+
+    // #857 — stamp ended_at on the assignment's open session when the
+    // transition lands a terminal state. Guarded on `ended_at IS NULL` so a
+    // session that was already ended (defense-in-depth; terminal states have
+    // no re-entry path through the state machine anyway) is never re-stamped
+    // with a later timestamp. Scoped to the assignment's currently-open
+    // session via the same partial-unique invariant the schema enforces
+    // (`idx_sessions_active_assignment`: at most one open session per
+    // assignment), so this touches exactly the row that just went terminal.
+    if (TERMINAL_STATES.has(result.state)) {
+      db.query(
+        `UPDATE sessions SET ended_at = ?
+         WHERE assignment_id = ? AND ended_at IS NULL`
+      ).run(now, assignmentId);
     }
 
     return insertEvent(db, {

--- a/src/surface/mc/hooks/poller.ts
+++ b/src/surface/mc/hooks/poller.ts
@@ -14,10 +14,19 @@ import { JsonlTailReader } from "./jsonl-reader";
 import { CursorStore } from "./cursor-store";
 import { ingestEvents } from "./ingestor";
 import { broadcastEvent } from "../notifications";
+import { ThrottledPrune, pruneRetention } from "../db/retention";
+
+/**
+ * How often the retention prune (#857 orphan rows, #864 events) runs. The
+ * poller ticks every ~2s; the prune is a full-table sweep, so we throttle it
+ * down to once an hour. Module constant (no config knob) — minimal scope.
+ */
+const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
 export class HookStreamPoller {
   private readonly reader: JsonlTailReader;
   private readonly cursorStore: CursorStore;
+  private readonly prune: ThrottledPrune;
   private timer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
@@ -27,6 +36,22 @@ export class HookStreamPoller {
   ) {
     this.reader = new JsonlTailReader();
     this.cursorStore = new CursorStore(config.cursorPath);
+
+    // Retention prune hung off the always-on poll tick (NOT the opt-in cockpit
+    // refresh loop) so it runs in every MC-enabled stack. Throttled to once an
+    // hour and best-effort — a prune failure routes to onError and never
+    // escapes the poll cycle. See db/retention.ts for the prune design.
+    this.prune = new ThrottledPrune({
+      intervalMs: PRUNE_INTERVAL_MS,
+      run: () => {
+        const summary = pruneRetention(this.db);
+        if (!summary.ok) {
+          process.stderr.write(
+            `[mission-control] hook-poller: retention prune failed: ${summary.error}\n`
+          );
+        }
+      },
+    });
 
     // Restore cursor state from disk
     const offsets = this.cursorStore.load();
@@ -105,6 +130,12 @@ export class HookStreamPoller {
     // this, those offset advances are lost on restart and the same bytes
     // would be re-read on next startup (F-4 review finding #4).
     this.cursorStore.save(this.reader.exportOffsets());
+
+    // Retention prune (#857/#864), throttled to once an hour. maybeRun() is
+    // best-effort and NEVER throws, so it can't break the poll cycle. Runs
+    // AFTER the cursor save so a (hypothetical) slow prune can't delay cursor
+    // persistence. The prune touches the events TABLE, never the hook cursor.
+    this.prune.maybeRun();
 
     return totalIngested;
   }


### PR DESCRIPTION
## Two growth sources (verified)

The live Mission Control pane accreted two row families with **no server-side retention**:

- **#857 — orphan rows.** `registerOrphanSession` (`src/surface/mc/db/sessions.ts`) lands one synthetic agent + assignment + session (+ a `state.transition` event) per distinct `cc_session_id`, **forever**. The working grid stays clean (`listWorkingAgents` filters terminal states) but the underlying agent/assignment/session rows never prune. Critically, `applyTransition` auto-completed orphans on Stop but **never set `sessions.ended_at`**, so "terminal age" was uncomputable.
- **#864 — events table.** `events` has only a client-side 500-row in-memory cap; the hook ingestor + the S6 projection families are steady writers with no server-side bound.

These are related row-growth issues, done as **one** PR.

## Prune design

### `ended_at` fix (the missing piece)
`applyTransition` (`db/transitions.ts`) now stamps `sessions.ended_at` on **every** terminal transition (`completed`/`failed`/`cancelled`), in the **same transaction** as the state update, guarded on `ended_at IS NULL`. Stamping here (not in the ingestor) keeps "assignment terminal" and "session ended" consistent across every transition path. This gives the prune a computable terminal-age anchor.

### Orphan terminal-row prune — window: **7 days** (module constant)
`pruneOrphanSessions` reaps orphan agent + assignment + session rows (events CASCADE off the session) whose session is terminal beyond the window. The WHERE is **double-anchored** on the `mc-orphan-` agent prefix **AND** the `mc-orphan-task` id, so real dispatch-projected / principal-created rows are **never** touched. The shared `mc-orphan-task` anchor is preserved; only its child assignments + sessions are pruned. A re-observed orphan (a new open session re-attached to the same assignment) is excluded via a `NOT EXISTS (ended_at IS NULL)` guard. Idempotent + transactional.

> Note: bun:sqlite's `Statement.run().changes` reports cumulative changes **including FK cascades**, so per-table counts are taken via explicit `SELECT COUNT(*)` inside the txn, not `.changes`.

### Events prune — window: **14 days** (module constant), **age-based**
`pruneOldEvents` is a single indexed `DELETE FROM events WHERE timestamp < cutoff` (served by `idx_events_timestamp`). **Age, not a per-session cap** — chosen as the simpler bound that still caps unbounded growth (a per-session cap needs a window-function partition scan per session). Pruning an orphan session already CASCADE-drops its events; this age prune is the complement that reaps old events whose session is **retained** (e.g. a long-lived observed session). The 14d window outlives the 7d orphan window so an orphan's events are reaped *with* its session, not ahead of it.

### Caller + throttle
`ThrottledPrune` is hung off `HookStreamPoller.poll()` — the **always-on** tick (runs whenever the MC DB is alive, **not** the opt-in cockpit refresh loop), the lower-blast-radius choice. Throttled to **once per hour** via a last-run timestamp. Best-effort: `maybeRun()` never throws, and the last-run clock advances even on failure (no tight-loop retry storm), so a prune failure can never break the poll cycle. The prune touches the events **table**, never the hook cursor (the poller reads raw JSONL from `~/.claude/events/raw/` — verified against `poller.ts`/`ingestor.ts`).

Windows are **module constants with doc comments**, not config — minimal blast radius (no new schema on AgentConfigSchema/CortexConfigSchema).

## Test plan (TDD)

- `ended_at` stamped on terminal orphan transitions (complete/fail/cancel); **not** on non-terminal; not clobbered.
- Orphan rows older than the window prune (agent + assignment + session + events all gone); within-window retained; the `mc-orphan-task` survives; **real (non-orphan) rows never pruned even when 60d old**; running orphans never pruned; idempotent; only `mc-orphan-`-prefixed agents swept.
- Events older than the window prune; recent retained; idempotent; old events pruned **even when their session is retained**.
- Throttle suppresses within the interval and re-fires after it; prune failure doesn't throw out of `maybeRun`; clock advances on throw.
- Integration: the hook poller prunes an old terminal orphan on its tick, retains a fresh one + the anchor, and `poll()` stays non-throwing on a bad prune.

## Gates
- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors on changed files
- `bun test` — 5359 pass / 2 fail; the 2 failures are the **known** `embed.test.ts` EADDRINUSE tests (#880, being fixed in parallel) — this PR adds **zero** new failures.

Closes #857
Closes #864
Part of #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)