### PR TITLE
chore: bump to v5.5.2

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.5.1"
+version: "5.5.2"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Patch release: #879 (grove deep-links) + #881 (dashboard mc.projection live refetch) + #884 (embed test isolation) + #885 (MC retention/prune).