### PR TITLE
chore: bump to v5.6.0 — dev-loop component set

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.5.2"
+version: "5.6.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release bump for the dev-loop epic (#835). Lands the agentic dev pipeline's component set onto main: dev.implement + release.cut consumers, REVIEW_LIFECYCLE + DEV_IMPLEMENT streams, and the F-6 packaging primitives (config-merge, identity/secret provisioning, library ordering, type:process schema). All components adversarially reviewed via the loop itself; merged this session (cortex#851/853/871/874/875, arc#230/231/233/234, pulse#20, mf#551, pilot#157-161).

Cuts release v5.6.0.