### PR TITLE
feat(mc): G-1114.A — agent-presence grounding (inert agent.* types + Network preview tab)

### DIFF
--- a/blueprint.yaml
+++ b/blueprint.yaml
@@ -370,3 +370,99 @@ features:
       Pilot bus/legacy + mention-dispatch + Discord retirement, concluding
       with pilot v1.0.0. Sub-features on pilot:P-D1..P-D4.
     depends_on: [W3-CUTOVER]
+
+  G-1114:
+    name: Agent Network Topology (umbrella)
+    status: in-progress
+    description: >
+      Bus-driven agent-presence protocol (agent.online/heartbeat/offline/
+      capabilities-changed on the agent domain) + consumer-side runtime
+      registry + Strata-style Network view in Mission Control. Two transports,
+      one envelope: bus federation feeds the local view, the ADR-0006
+      registry-anchored push feeds the hosted pane. Reconciled to ADR-0007.
+      See docs/design-agent-network-topology.md and
+      docs/plan-agent-network-topology.md.
+    children: [G-1114.A, G-1114.B, G-1114.C, G-1114.D, G-1114.E, G-1114.F]
+
+  G-1114.A:
+    name: Phase A — Grounding & Protocol Types
+    status: in-progress
+    description: >
+      Land the reconciled design + plan on main, define the agent.* presence
+      payloads as inert types under src/bus/agent-network/, add a
+      "Network (preview)" stub tab in the dashboard. Zero runtime change.
+    parent: G-1114
+    children: [G-1114.A.1]
+
+  G-1114.A.1:
+    name: Grounding PR — reconciled docs + inert agent.* types + preview tab
+    status: in-progress
+    description: >
+      Single PR landing docs/design-agent-network-topology.md +
+      docs/plan-agent-network-topology.md (reconciled to ADR-0007), inert
+      agent.* payload shapes at src/bus/agent-network/envelopes.ts (no producer
+      / no subscriber), a "Network (preview)" placeholder tab in
+      src/surface/mc/dashboard-v2/, and G-1114 nodes in blueprint.yaml.
+    parent: G-1114.A
+
+  G-1114.B:
+    name: Phase B — Stack-Local Producer + Subscriber
+    status: planned
+    description: >
+      Wire the protocol end-to-end in one stack. Cortex boot emits
+      agent.online; periodic agent.heartbeat; graceful shutdown emits
+      agent.offline (the agent-domain presence heartbeat, distinct from the
+      dispatch-scoped system.agent.heartbeat). Runtime registry subscriber on
+      local.{principal}.{stack}.agent.> maintains the observable store. The
+      preview tab becomes a real agents panel. Dual-emit alongside the existing
+      agents.capabilities.registered during the deprecation window.
+    parent: G-1114
+    depends_on: [G-1114.A]
+
+  G-1114.C:
+    name: Phase C — Capabilities Delta + Liveness FSM
+    status: planned
+    description: >
+      agent.capabilities-changed envelope (producer + subscriber, full new
+      steady-state set). Liveness FSM (single 5-min TTL online<->offline,
+      consuming the new agent.heartbeat — never system.agent.heartbeat). UI:
+      capability badges update live without restart; offline agents render
+      muted with last-seen. Fixture-driven replay tests.
+    parent: G-1114
+    depends_on: [G-1114.B]
+
+  G-1114.D:
+    name: Phase D — Network View (stack-local)
+    status: planned
+    description: >
+      Lift Strata's React Flow + ELK UI primitives (FlowCanvas, ContextMenu,
+      DetailPanel, SpotlightSearch, Legend) into the MC dashboard. Render the
+      stack-local agent network as a graph; click for a detail panel (presence
+      + capabilities + dispatch lifecycle, never session interiors); filters +
+      Cmd+K spotlight search.
+    parent: G-1114
+    depends_on: [G-1114.C]
+
+  G-1114.E:
+    name: Phase E — Federation
+    status: planned
+    description: >
+      Subscribe to peers' federated.{principal}.{stack}.agent.* over the NATS
+      leaf per the federation accept-list (bus-federation transport — the
+      local-view half; the hosted-pane half is ADR-0006). Network membership
+      grouped by the registry roster (ADR-0003), never a wire token. Runtime
+      registry tags foreign agents with {principal}/{stack} provenance. Network
+      view scope toggle. Peer interiors never visible (ADR-0005).
+    parent: G-1114
+    depends_on: [G-1114.D]
+
+  G-1114.F:
+    name: Phase F — Capability-Routing UX
+    status: planned
+    description: >
+      Cross-component highlight: hover task -> matching agents pulse; hover
+      agent -> tasks the agent can pick up highlight. Right-click "Dispatch
+      direct" affordance publishes to
+      local.{principal}.{stack}.tasks.@{assistant}.{capability}.
+    parent: G-1114
+    depends_on: [G-1114.D, G-1114.E]

--- a/docs/design-agent-network-topology.md
+++ b/docs/design-agent-network-topology.md
@@ -1,0 +1,271 @@
+# Agent Network Topology
+
+**Status:** grounded — reconciled to [ADR-0007](adr/0007-agent-presence-protocol.md)
+**Umbrella:** G-1114 (issue #355)
+**Owners:** Andreas + Soma
+**Scope:** Bus-driven agent **presence** (announce / heartbeat / offline /
+capabilities-changed) on the reserved `agent` domain, a consumer-side runtime
+registry, two-transport cross-stack propagation, and the Mission Control
+"Network" view that renders the resulting topology.
+
+> **Reconciliation note.** This design predates several settled decisions and
+> was reconciled to [ADR-0007](adr/0007-agent-presence-protocol.md) during the
+> G-1114 grilling session (2026-06-10). The pre-grill draft used `{org}`,
+> `system.agent.*` envelope types, a `public.metafactory.agent.*` /
+> network-as-namespace framing, and treated presence and dispatch liveness as
+> one thing. **ADR-0007 is authoritative; this document is the reconciled
+> design.** Where this doc and ADR-0007 disagree, ADR-0007 wins.
+
+## 1. Purpose
+
+A cortex stack today knows which agents are *configured* (from the stack
+config) and which capabilities they declared at boot (one-shot
+`agents.capabilities.registered` envelopes). It does **not** know:
+
+- which configured agents are actually running right now,
+- when an agent joined or left the network,
+- which agents exist on *other* stacks reachable via NATS leaf federation,
+- whether a "supposed to be there" agent has gone quiet.
+
+This document specifies the **agent-presence protocol** + the consumer-side
+runtime registry + the Mission Control surface that makes the network of agents
+observable and reasoned-about as a first-class concept.
+
+The principal should be able to open Mission Control, see the agents present
+across the network they are part of, click an agent, see its capabilities, and
+see whether it is reachable — **without** ever seeing a peer's session interior.
+
+## 2. Core concept — agent presence
+
+**Agent presence** (CONTEXT.md term, resolved 2026-06-10) is *whether an agent
+process is up and consuming the bus — independent of any dispatch*. An idle
+agent has presence; it is not running a dispatch.
+
+Presence is carried on the reserved **`agent` domain** — the first concrete use
+of CONTEXT.md's reserved domain segment. Four actions:
+
+| Action | Meaning |
+|---|---|
+| `agent.online` | Emitted once on agent boot. Carries the full presence descriptor (identity, scope, **initial capability set**, started-at). |
+| `agent.heartbeat` | Emitted on a fixed interval while the agent is up (idle or not). Liveness only. |
+| `agent.offline` | Emitted on graceful shutdown / restart / announced error. |
+| `agent.capabilities-changed` | Emitted when the advertised capability set changes mid-life. Carries the full new steady state. |
+
+### 2.1 Presence is NOT dispatch liveness (ADR-0007 §1)
+
+Presence is **distinct from `system.agent.heartbeat`** (cortex#361), which is
+**dispatch-scoped** liveness — fired only *while a dispatch is in flight*, keyed
+by `correlation_id` ("this task is still progressing"). Two differently-scoped
+heartbeats by design:
+
+- `agent.heartbeat` answers *is this agent alive?*
+- `system.agent.heartbeat` answers *is this task progressing?*
+
+An idle agent emits the former, **never** the latter. The two never merge; the
+`agent`-domain presence heartbeat carries no `correlation_id`/`phase`, and the
+dispatch heartbeat stays exactly as cortex#361 shipped it.
+
+## 3. Subject grammar
+
+All subjects follow the canonical
+`{scope}.{principal}.{stack}.{domain}.{entity}.{action}` grammar (CONTEXT.md;
+[ADR-0001](adr/0001-federated-subject-grammar.md)). For presence, `{domain}` is
+`agent`. The domain segment is the leading segment of `envelope.type`, so
+myelin's `deriveSubject` (cortex's `deriveNatsSubject`) builds the subject from
+the type with no new helper.
+
+### 3.1 Stack-local subjects
+
+```
+local.{principal}.{stack}.agent.online
+local.{principal}.{stack}.agent.heartbeat
+local.{principal}.{stack}.agent.offline
+local.{principal}.{stack}.agent.capabilities-changed
+```
+
+The second segment is the **principal**, not an org — CONTEXT.md is authoritative
+(the `{org}→{principal}` vocabulary migration). The agent's own logical id
+(`luna`, `echo`, …) and NKey ride the **payload**, not a subject segment.
+
+### 3.2 Federation subjects
+
+```
+federated.{principal}.{stack}.agent.online
+federated.{principal}.{stack}.agent.heartbeat
+federated.{principal}.{stack}.agent.offline
+federated.{principal}.{stack}.agent.capabilities-changed
+```
+
+**Identical identity segments — only the scope prefix differs**
+([ADR-0001](adr/0001-federated-subject-grammar.md)). The federated subject
+carries `{principal}.{stack}`, preserving provenance
+(`federated.andreas.work.agent.online` is unambiguously from `andreas/work`).
+The **network is NEVER a subject segment**: a stack can be re-homed to a
+different network without changing its subjects. The target network is resolved
+from the principal via deployment topology (`policy.federated.networks[].peers[]`),
+not read off the wire.
+
+### 3.3 Network membership = registry roster, not a wire token (ADR-0007 §2)
+
+The pre-grill draft framed "network" as a subject namespace
+(`public.metafactory.agent.*`). **That framing is dropped.** Network membership
+is grouped by the **registry roster** ([ADR-0003](adr/0003-network-join-control-plane.md)):
+the registry (`network.meta-factory.ai`) is the pinned, signature-verified
+source of truth for `principal → pubkey` and per-network rosters. The Network
+view groups peer agents by which network's roster they appear in — resolved from
+identity + topology, never from a network name on a subject.
+
+### 3.4 Public scope — deferred
+
+`public.*` agent presence (ecosystem-wide discovery) is **out of scope for
+G-1114** and deferred to a candidate **G-1115** umbrella. G-1114 ships
+stack-local + federated only.
+
+## 4. Two transports, one envelope (ADR-0007 §2)
+
+The same `agent.*` presence envelope feeds two surfaces:
+
+1. **Local Network view via bus federation (G-1114.E).** A stack subscribes to
+   peers' `federated.{principal}.{stack}.agent.*` over the NATS leaf —
+   real-time, peer-to-peer, gated by the existing federation accept-list
+   (`accept_subjects: federated.{my-principal}.{my-stack}.>`). This feeds the
+   stack's own locally-served Network pane.
+2. **Hosted pane via registry-anchored push
+   ([ADR-0006](adr/0006-network-view-feed-registry-anchored.md)).** Each member
+   stack pushes only its **own-slice** presence metadata to the Mission Control
+   Worker/D1 (meta-factory.ai), NKey-signed, verified against the registry
+   roster. Peers' federated envelopes arriving at a stack are not that stack's
+   to upload — sovereignty stays with the originator.
+
+These compose: bus federation is the local half, ADR-0006 is the hosted half.
+Both carry the identical `agent.*` envelope; they differ only in transport and
+in who is allowed to relay what.
+
+## 5. Capability model (ADR-0007 §3)
+
+`agent.online` carries the **initial** capability set; `agent.capabilities-changed`
+carries the **full new steady state** on each change (not a diff — a subscriber
+that missed an earlier delta still converges). Together they **supersede** the
+observability-only boot-time `agents.capabilities.registered` envelope, via a
+**dual-emit deprecation window** then retirement.
+
+**Capability dispatch (cortex#237) is untouched.** Offer-mode dispatch routes on
+the `tasks.{capability}` subject via JetStream consumer filters — it does **not**
+do a registry lookup. So folding the capability-announce envelope into presence
+changes nothing about routing; the registered envelope was observability-only.
+
+## 6. Envelope payloads
+
+The cortex-side payload shapes are defined as **inert types** in
+`src/bus/agent-network/envelopes.ts` (G-1114.A — defined, exported, unit-tested,
+but no producer/subscriber yet). Each payload rides `envelope.payload`, which the
+myelin envelope schema leaves unconstrained ("Structure is domain-specific");
+the cortex schemas are the domain-specific contract.
+
+Each payload carries an `identity` block (`nkey_public_key`, `agent_id`,
+`assistant_name | null`) and a `scope` block (`principal`, `stack`):
+
+- **`agent.online`** — `identity`, `scope`, `capabilities[]` (initial), `started_at`.
+- **`agent.heartbeat`** — `identity`, `scope`, `sent_at`. Liveness only.
+- **`agent.offline`** — `identity`, `scope`, `reason` (`shutdown|restart|error`),
+  optional `detail`, `sent_at`.
+- **`agent.capabilities-changed`** — `identity`, `scope`, `capabilities[]`
+  (full new set), `sent_at`.
+
+All envelopes are signed through the normal stack-signing path; identity is
+attested by the envelope's `signed_by[]` chain.
+
+## 7. Liveness FSM
+
+A consumer-side registry runs a small state machine per observed agent:
+
+```
+              online ──(graceful agent.offline, OR no heartbeat within TTL)──▶ offline
+                 ▲                                                                │
+                 └────────────────(agent.heartbeat / agent.online again)─────────┘
+```
+
+- **TTL = 5 minutes.** A record is `online` while `agent.heartbeat` (or
+  `agent.online`) arrives within the TTL; it transitions to `offline` on a
+  graceful `agent.offline` **or** on TTL lapse.
+- The FSM consumes the **new `agent.heartbeat`**, NOT `system.agent.heartbeat`
+  (ADR-0007 — the dispatch heartbeat is not a presence signal).
+- Offline agents stay in the registry rendered as muted with a last-seen
+  timestamp; they don't vanish.
+
+## 8. Peer visibility — presence + dispatch lifecycle, never interiors (ADR-0007 §4)
+
+In the Network view, clicking a **peer principal's** agent reveals:
+
+- identity (`@assistant` on `{stack}`),
+- online / idle / offline state,
+- declared capabilities,
+- any federated `dispatch.task.*` lifecycle (received / dispatched / started /
+  completed / failed / aborted).
+
+It does **NOT** reveal tool calls, prompts, or diffs. This is the direct
+consequence of [ADR-0005](adr/0005-mission-control-integration-architecture.md):
+session interiors are `local`-scope and never federate. The boundary is enforced
+by **what is on the wire** — not a UI check. Drilling into your **own** agent
+still opens the full interior (local).
+
+## 9. Runtime registry
+
+A cortex-side subscriber maintains a single observable store keyed by NKey:
+
+- Subscribes to `local.{principal}.{stack}.agent.>` (always; G-1114.B).
+- Subscribes to `federated.{principal}.{stack}.agent.>` per federation policy
+  (G-1114.E).
+- For each envelope: `online` upserts + sets `online`; `heartbeat` refreshes
+  last-seen; `capabilities-changed` replaces the capability set; `offline` sets
+  `offline`. A reaper applies the 5-min TTL lapse.
+
+The registry is the source of truth for the Network view and (later) for
+principal-driven direct dispatch affordances. It does **not** change the
+capability-dispatch path.
+
+## 10. UI — Mission Control "Network" view
+
+A "Network" tab in `src/surface/mc/dashboard-v2/`. G-1114.A lands an inert
+**"Network (preview)"** placeholder; G-1114.B replaces it with the real
+stack-local agents panel; G-1114.D replaces that with the graph render (React
+Flow + ELK, lifting Strata's UI primitives). Detail panel, filters, and
+spotlight search land with the graph.
+
+## 11. Relation to existing cortex / myelin
+
+- **Adds** the `agent` domain's presence subjects + payload types. The
+  agent-lifecycle subjects are cortex M7 territory per `myelin/specs/namespace.md`;
+  a follow-up myelin PR may codify the `agent` domain in the namespace spec for
+  ecosystem consistency (not blocking).
+- **Supersedes** the boot-time `agents.capabilities.registered` per-pair emission
+  (dual-emit window, then retire).
+- **Does not change** the cortex#237 capability-dispatch path, nor the cortex#361
+  dispatch heartbeat.
+
+## 12. Phases
+
+| Phase | What the principal sees |
+|---|---|
+| A — Grounding (this slice) | Design + plan reconciled on `main`; inert `agent.*` payload types in the codebase; a "Network (preview)" placeholder tab. **Zero runtime change.** |
+| B — Local producer + subscriber | The preview tab becomes a real stack-local agents panel; agents pop up on boot, drop off after 5 min of silence (or instantly on graceful offline). |
+| C — Capabilities delta + liveness FSM | Live capability badges; offline agents render muted with last-seen. |
+| D — Network view (stack-local) | The graph render (React Flow + ELK); click for a detail panel; filters + spotlight. |
+| E — Federation | The view extends to federated peer stacks via the bus-federation transport; foreign agents render with `{principal}/{stack}` provenance. The hosted half is ADR-0006. |
+| F — Capability-routing UX | Hover a task → matching agents highlight; right-click an agent → "dispatch direct." |
+
+Public scope (`public.*` presence) is deferred to candidate G-1115.
+
+## 13. Open questions (resolved decisions are in the ADRs)
+
+Settled by ADR-0007: domain (`agent`, distinct from dispatch), subject grammar
+(`{principal}`, never `{org}`/network), supersession of
+`agents.capabilities.registered`, peer-visibility boundary, the 5-min TTL FSM,
+public-scope deferral. Remaining, deferred to the phase that needs each:
+
+1. Federation default — opt-in (safe) vs opt-out. → resolved at E.
+2. Subject re-publish mechanism — cortex republisher vs NATS leaf-node policy. → E.
+3. `AgentDescriptor` payload size limits. → B.
+4. Recent-work edge source for the graph — bounded tail vs dedicated envelope. → D.
+5. Principal annotations (pin / mute) persistence — local MC DB. → D.
+6. Soma assistant grouping in the graph (one assistant, many hosting agents). → D.

--- a/docs/plan-agent-network-topology.md
+++ b/docs/plan-agent-network-topology.md
@@ -1,0 +1,257 @@
+# Plan — Agent Network Topology (G-1114)
+
+**Status:** grounded — reconciled to [ADR-0007](adr/0007-agent-presence-protocol.md)
+**Design:** [`docs/design-agent-network-topology.md`](design-agent-network-topology.md)
+**Umbrella issue:** #355
+**Process:** umbrella → phase sub-issues → sub-feature PRs; one PR per
+sub-feature; pilot review loop with Echo primary.
+
+> **Reconciliation note.** Reconciled to
+> [ADR-0007](adr/0007-agent-presence-protocol.md) (G-1114 grilling, 2026-06-10):
+> `{org}→{principal}` throughout; `agent`-domain presence distinct from the
+> dispatch-scoped `system.agent.heartbeat`; network-as-namespace dropped in
+> favour of registry-roster grouping; public scope deferred to G-1115. When
+> this plan and ADR-0007 disagree, ADR-0007 wins. When this plan and the design
+> spec disagree on what the protocol *is*, the design spec wins.
+
+## 1. What we're building (recap)
+
+G-1114 makes **agent presence** (whether an agent process is up and consuming
+the bus, independent of any dispatch) observable across stacks:
+
+1. **Presence protocol** on the `agent` domain —
+   `local.{principal}.{stack}.agent.{online|heartbeat|offline|capabilities-changed}`
+   (and the `federated.` counterpart). Distinct from the dispatch-scoped
+   `system.agent.heartbeat` (cortex#361).
+2. **Consumer-side runtime registry** — a subscriber maintains an observable
+   "who is here, in what state, with what capabilities" store, with a 5-min
+   liveness FSM.
+3. **Network view in Mission Control** — a graph render (React Flow + ELK,
+   lifting Strata's UI). Presence + dispatch-lifecycle metadata only — never
+   peer session interiors (ADR-0005).
+4. **Two transports, one envelope** — bus federation feeds the local view
+   (G-1114.E); the [ADR-0006](adr/0006-network-view-feed-registry-anchored.md)
+   registry-anchored push feeds the hosted pane.
+
+The existing capability-matched dispatch path (cortex#237) is **unchanged** —
+the runtime registry is an observability + discovery layer on top.
+
+### 1.1 Iterative delivery — each phase ships visible value
+
+| Phase | What the principal sees after this phase |
+|---|---|
+| A — Grounding | Design + plan reconciled on `main`; inert `agent.*` payload types in the codebase (no producer / no subscriber); a "Network (preview)" placeholder tab. **Zero runtime change.** |
+| B — Local producer + subscriber | The preview tab becomes a real agents panel; agents pop up on boot, drop off after 5 min of silence. |
+| C — Capabilities delta + liveness FSM | Live capability badges; offline agents render muted with last-seen. |
+| D — Network view (stack-local) | A "Network" tab with the React Flow + ELK graph. Click for a detail panel. |
+| E — Federation | The view extends to federated peer stacks (bus-federation transport). Foreign agents render with `{principal}/{stack}` provenance. |
+| F — Capability-routing UX | Hover a task → matching agents highlight. Right-click an agent → "dispatch direct." |
+
+## 2. Issue + PR structure
+
+```
+G-1114  Agent Network Topology (umbrella, #355)
+  ├── G-1114.A  Phase A — Grounding & Protocol Types   (sub-issue → 1 PR)
+  │     └── G-1114.A.1  Grounding PR (this slice)
+  ├── G-1114.B  Phase B — Stack-Local Producer + Subscriber
+  ├── G-1114.C  Phase C — Capabilities Delta + Liveness FSM
+  ├── G-1114.D  Phase D — Network View (stack-local)
+  ├── G-1114.E  Phase E — Federation
+  └── G-1114.F  Phase F — Capability-Routing UX
+```
+
+Branch name `feat/g-1114-{phase-letter}-{slug}`. Title
+`feat(mc): G-1114.X — {scope}`.
+
+## 3. Phase sequencing
+
+```
+A  Grounding ──▶ B  Producer+Subscriber ──▶ C  Caps+FSM ──▶ D  Network View ──┐
+                                                                              ├──▶ F  Cap-Routing UX
+                                                       E  Federation ─────────┘
+```
+
+- `G-1114.A` ← no deps
+- `G-1114.B` ← `[G-1114.A]`
+- `G-1114.C` ← `[G-1114.B]`
+- `G-1114.D` ← `[G-1114.C]`
+- `G-1114.E` ← `[G-1114.D]`
+- `G-1114.F` ← `[G-1114.D, G-1114.E]`
+
+## 4. The phases
+
+### 4.1 Phase A — Grounding & Protocol Types (G-1114.A)
+
+**Goal:** land the reconciled design + plan on `main`, define the `agent.*`
+presence payloads as **inert** TypeScript/zod types, and put a "Network
+(preview)" placeholder on the dashboard. **Zero runtime behavior change** — no
+producer publishes, no subscriber consumes, no live data.
+
+**Sub-features:**
+
+- [x] **G-1114.A.1** — Grounding PR · single PR
+  - Reconcile + land `docs/design-agent-network-topology.md` +
+    `docs/plan-agent-network-topology.md` to ADR-0007.
+  - Add inert `agent.*` payload types at `src/bus/agent-network/envelopes.ts`
+    (defined + exported + unit-tested; no producer / no subscriber).
+  - Add a "Network (preview)" stub tab in `src/surface/mc/dashboard-v2/`.
+  - Unit tests: payload shape/validation + envelope round-trip + agent-domain
+    subject derivation; a render test for the stub tab.
+
+**Acceptance criteria:**
+
+- `bunx tsc --noEmit` clean, `bun run lint` 0 errors, full `bun test` green.
+- Inert types validate + round-trip through the myelin envelope validator;
+  subjects derive `{scope}.{principal}.{stack}.agent.{action}`.
+- "Network (preview)" tab visible in the dashboard.
+- No producer/consumer wired; no runtime behavior change.
+
+**Dependencies:** none.
+
+---
+
+### 4.2 Phase B — Stack-Local Producer + Subscriber (G-1114.B)
+
+**Goal:** wire the protocol end-to-end in one stack. Agent boot emits
+`agent.online`; periodic `agent.heartbeat`; graceful shutdown emits
+`agent.offline`. A subscriber on the same stack builds the runtime registry.
+
+**Sub-features (sketched — refined at phase start):**
+
+- [ ] **G-1114.B.1** — Envelope builders + signing path for the four payloads.
+- [ ] **G-1114.B.2** — Producer wired into cortex boot lifecycle (`agent.online`
+  on boot; `agent.heartbeat` on interval; `agent.offline` on graceful shutdown).
+- [ ] **G-1114.B.3** — Runtime registry subscriber on
+  `local.{principal}.{stack}.agent.>`; observable store; 5-min reaper.
+- [ ] **G-1114.B.4** — Agents panel UI (replaces the Phase A placeholder).
+- [ ] **G-1114.B.5** — Dual-emit with `agents.capabilities.registered` during
+  the deprecation window.
+
+**Acceptance criteria:** boot a fresh cortex process → its agent appears within
+~5 s; stop it → drops within 5 min (or instantly on graceful shutdown); no
+regression in capability dispatch.
+
+**Dependencies:** Phase A.
+
+---
+
+### 4.3 Phase C — Capabilities Delta + Liveness FSM (G-1114.C)
+
+**Goal:** capability changes flow through `agent.capabilities-changed` without
+restart, and the liveness FSM handles offline correctly.
+
+**Sub-features (sketched):**
+
+- [ ] **G-1114.C.1** — `agent.capabilities-changed` producer (emit on mutation).
+- [ ] **G-1114.C.2** — subscriber applies the full new set; reconciles state.
+- [ ] **G-1114.C.3** — liveness FSM (single 5-min TTL; consumes the NEW
+  `agent.heartbeat`, never `system.agent.heartbeat`; graceful-offline path).
+- [ ] **G-1114.C.4** — panel UI: capability badges + offline rendering.
+- [ ] **G-1114.C.5** — fixture tests replaying scripted envelope streams.
+
+**Dependencies:** Phase B.
+
+---
+
+### 4.4 Phase D — Network View (stack-local) (G-1114.D)
+
+**Goal:** the graph view. Lift Strata's React Flow + ELK pattern into the MC
+dashboard.
+
+**Sub-features (sketched):**
+
+- [ ] **G-1114.D.1** — lift Strata UI primitives (`FlowCanvas`, `ContextMenu`,
+  `DetailPanel`, `SpotlightSearch`, `Legend`).
+- [ ] **G-1114.D.2** — graph data adapter (registry → React Flow nodes/edges).
+- [ ] **G-1114.D.3** — ELK layout config.
+- [ ] **G-1114.D.4** — detail panel (presence + capabilities + dispatch
+  lifecycle; **never** session interiors).
+- [ ] **G-1114.D.5** — filters + spotlight search.
+
+**Dependencies:** Phase C.
+
+---
+
+### 4.5 Phase E — Federation (G-1114.E)
+
+**Goal:** the Network view extends to federated peer stacks via the
+bus-federation transport — subscribe to `federated.{principal}.{stack}.agent.*`
+per the federation accept-list. This is the **local-view** half; the hosted-pane
+half is [ADR-0006](adr/0006-network-view-feed-registry-anchored.md).
+
+**Sub-features (sketched):**
+
+- [ ] **G-1114.E.1** — federation policy (opt-in per envelope-type) in stack
+  config.
+- [ ] **G-1114.E.2** — subscriber path for the `federated.` namespace with
+  scope/provenance tagging (`{principal}/{stack}`).
+- [ ] **G-1114.E.3** — registry-roster grouping in the view (membership from the
+  ADR-0003 roster, never a wire token).
+- [ ] **G-1114.E.4** — UI: scope filter + foreign-agent visuals.
+- [ ] **G-1114.E.5** — trust extension (`signed_by[]` verification of foreign
+  presence envelopes).
+
+**Acceptance criteria:** two stacks federated via NATS leaf both show the
+other's agents (per opt-in policy); cross-stack provenance renders; disabling
+federation cleanly removes foreign agents. **Peer interiors never visible.**
+
+**Open question (resolve at E.1):** federation default — opt-in vs opt-out.
+
+**Dependencies:** Phase D.
+
+---
+
+### 4.6 Phase F — Capability-Routing UX (G-1114.F)
+
+**Goal:** make capability-matched dispatch visible and principal-driven.
+
+**Sub-features (sketched):**
+
+- [ ] **G-1114.F.1** — capability-match index (task ↔ agent map).
+- [ ] **G-1114.F.2** — hover affordances (cross-component highlight).
+- [ ] **G-1114.F.3** — "dispatch direct" affordance.
+
+**Dependencies:** Phase D + Phase E.
+
+---
+
+## 5. Sequencing summary
+
+| Phase | Depends on | Indicative PR count |
+|---|---|---|
+| A — Grounding & types | — | 1 |
+| B — Local producer + subscriber | A | 5 |
+| C — Capabilities delta + FSM | B | 5 |
+| D — Network view (stack-local) | C | 5 |
+| E — Federation | D | 5 |
+| F — Capability-routing UX | D + E | 3 |
+
+Total indicative: **~24 PRs** across the umbrella.
+
+## 6. Decisions settled by the ADRs
+
+- **Domain + dispatch distinction, supersession, peer-visibility boundary, TTL,
+  public-scope deferral** → [ADR-0007](adr/0007-agent-presence-protocol.md).
+- **Subject grammar (`{principal}.{stack}`, network never on the wire)** →
+  [ADR-0001](adr/0001-federated-subject-grammar.md).
+- **Network membership = registry roster** →
+  [ADR-0003](adr/0003-network-join-control-plane.md).
+- **Hosted-pane feed (own-slice, metadata-only, registry-anchored auth)** →
+  [ADR-0006](adr/0006-network-view-feed-registry-anchored.md).
+- **In-process MC, bus-projected sessions, session interiors stay local** →
+  [ADR-0005](adr/0005-mission-control-integration-architecture.md).
+
+## 7. Process notes
+
+- **Worktree discipline.** Each sub-feature gets its own worktree under
+  `../Cortex-g1114-{slug}` cut from `origin/main`.
+- **Review loop.** Echo primary on PR review via the pilot loop; in-session
+  Engineer sub-agent fallback when Echo dispatch flakes.
+- **Tick discipline.** Merging a sub-feature PR ticks the box here AND
+  comments-and-closes the sub-feature sub-issue. The phase sub-issue closes when
+  all its sub-features tick; the umbrella (#355) closes when all phases close.
+- **Plan vs blueprint.** The dependency graph lives in `blueprint.yaml` under
+  `G-1114` + `G-1114.A` .. `G-1114.F`.
+- **Relation to G-1113.** Independent umbrellas. G-1113's config-driven Stack
+  Agents panel is superseded by this bus-driven runtime registry when G-1114.B
+  lands. No hard blocking between the two.

--- a/src/bus/agent-network/__tests__/envelopes.test.ts
+++ b/src/bus/agent-network/__tests__/envelopes.test.ts
@@ -1,0 +1,273 @@
+/**
+ * G-1114.A — inert agent-presence protocol type tests.
+ *
+ * These assert the SHAPE of the four `agent`-domain presence payloads and that
+ * an envelope carrying each payload:
+ *   1. validates against the myelin envelope schema (payload is unconstrained —
+ *      the same property cortex#361's heartbeat relies on), and
+ *   2. derives the correct `agent`-domain subject
+ *      (`{scope}.{principal}.{stack}.agent.{action}`) via `deriveNatsSubject`.
+ *
+ * NO producer/consumer/integration coverage — nothing is live yet (ADR-0007;
+ * producers land in G-1114.B). This is the inert-shape gate only.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  AGENT_ONLINE_TYPE,
+  AGENT_HEARTBEAT_TYPE,
+  AGENT_OFFLINE_TYPE,
+  AGENT_CAPABILITIES_CHANGED_TYPE,
+  AGENT_PRESENCE_TYPES,
+  AGENT_PRESENCE_PAYLOAD_SCHEMAS,
+  AgentOnlinePayloadSchema,
+  AgentHeartbeatPayloadSchema,
+  AgentOfflinePayloadSchema,
+  AgentCapabilitiesChangedPayloadSchema,
+  AgentOfflineReasonSchema,
+  type AgentPresenceType,
+} from "../envelopes";
+import {
+  validateEnvelope,
+  deriveNatsSubject,
+} from "../../myelin/envelope-validator";
+
+const IDENTITY = {
+  nkey_public_key: "UABC1234567890",
+  agent_id: "luna",
+  assistant_name: "Luna",
+};
+const SCOPE = { principal: "andreas", stack: "meta-factory" };
+const NOW = "2026-06-10T09:00:00Z";
+
+/** Build a minimal valid myelin envelope wrapping a presence payload. */
+function envelopeFor(type: AgentPresenceType, payload: unknown, stack = "meta-factory"): unknown {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    // source = {principal}.{agent}.{instance}; firstSegment → principal "andreas"
+    source: `andreas.${stack}.cortex-01`,
+    type,
+    timestamp: NOW,
+    sovereignty: {
+      classification: "local",
+      data_residency: "DE",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload,
+  };
+}
+
+describe("agent-presence type constants", () => {
+  test("the four action type literals are the agent domain", () => {
+    expect(AGENT_ONLINE_TYPE).toBe("agent.online");
+    expect(AGENT_HEARTBEAT_TYPE).toBe("agent.heartbeat");
+    expect(AGENT_OFFLINE_TYPE).toBe("agent.offline");
+    expect(AGENT_CAPABILITIES_CHANGED_TYPE).toBe("agent.capabilities-changed");
+    // Every presence type rides the `agent` domain (leading subject segment),
+    // distinct from the dispatch-scoped `system.agent.heartbeat` (cortex#361).
+    for (const t of AGENT_PRESENCE_TYPES) {
+      expect(t.startsWith("agent.")).toBe(true);
+      expect(t).not.toBe("system.agent.heartbeat");
+    }
+  });
+
+  test("presence heartbeat is NOT the dispatch heartbeat type", () => {
+    // ADR-0007 §1 — two differently-scoped heartbeats by design.
+    expect(AGENT_HEARTBEAT_TYPE).not.toBe("system.agent.heartbeat");
+  });
+
+  test("the schema map covers every presence type", () => {
+    for (const t of AGENT_PRESENCE_TYPES) {
+      expect(AGENT_PRESENCE_PAYLOAD_SCHEMAS[t]).toBeDefined();
+    }
+  });
+});
+
+describe("agent.online payload", () => {
+  const valid = {
+    identity: IDENTITY,
+    scope: SCOPE,
+    capabilities: ["code-review.typescript", "code-review.documentation"],
+    started_at: NOW,
+  };
+
+  test("accepts a full descriptor", () => {
+    const parsed = AgentOnlinePayloadSchema.parse(valid);
+    expect(parsed.identity.agent_id).toBe("luna");
+    expect(parsed.scope.principal).toBe("andreas");
+    expect(parsed.capabilities).toHaveLength(2);
+  });
+
+  test("defaults capabilities to empty array when omitted", () => {
+    const { capabilities: _omit, ...rest } = valid;
+    const parsed = AgentOnlinePayloadSchema.parse(rest);
+    expect(parsed.capabilities).toEqual([]);
+  });
+
+  test("null assistant_name is accepted (bus-only / unassigned agent)", () => {
+    const parsed = AgentOnlinePayloadSchema.parse({
+      ...valid,
+      identity: { ...IDENTITY, assistant_name: null },
+    });
+    expect(parsed.identity.assistant_name).toBeNull();
+  });
+
+  test("rejects an uppercase / malformed capability id", () => {
+    expect(() =>
+      AgentOnlinePayloadSchema.parse({ ...valid, capabilities: ["CodeReview"] }),
+    ).toThrow();
+  });
+
+  test("rejects a missing principal", () => {
+    expect(() =>
+      AgentOnlinePayloadSchema.parse({
+        ...valid,
+        scope: { stack: "meta-factory" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("agent.heartbeat payload (presence, not dispatch)", () => {
+  const valid = { identity: IDENTITY, scope: SCOPE, sent_at: NOW };
+
+  test("accepts a minimal liveness ping", () => {
+    const parsed = AgentHeartbeatPayloadSchema.parse(valid);
+    expect(parsed.sent_at).toBe(NOW);
+  });
+
+  test("carries no dispatch fields (no correlation_id / phase)", () => {
+    // Presence heartbeat is liveness-only; dispatch progress is the cortex#361
+    // heartbeat's job. Zod strips unknowns, so an accidental dispatch field
+    // does not survive parse.
+    const parsed = AgentHeartbeatPayloadSchema.parse({
+      ...valid,
+      correlation_id: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+      phase: "thinking",
+    }) as Record<string, unknown>;
+    expect(parsed.correlation_id).toBeUndefined();
+    expect(parsed.phase).toBeUndefined();
+  });
+});
+
+describe("agent.offline payload", () => {
+  const valid = {
+    identity: IDENTITY,
+    scope: SCOPE,
+    reason: "shutdown" as const,
+    sent_at: NOW,
+  };
+
+  test("accepts each graceful + error reason", () => {
+    for (const reason of ["shutdown", "restart", "error"] as const) {
+      expect(AgentOfflinePayloadSchema.parse({ ...valid, reason }).reason).toBe(reason);
+    }
+  });
+
+  test("accepts an optional detail", () => {
+    const parsed = AgentOfflinePayloadSchema.parse({
+      ...valid,
+      reason: "error",
+      detail: "uncaught exception in cc-session",
+    });
+    expect(parsed.detail).toBe("uncaught exception in cc-session");
+  });
+
+  test("rejects an unknown reason", () => {
+    expect(() => AgentOfflineReasonSchema.parse("ttl-lapse")).toThrow();
+  });
+});
+
+describe("agent.capabilities-changed payload", () => {
+  const valid = {
+    identity: IDENTITY,
+    scope: SCOPE,
+    capabilities: ["code-review.typescript"],
+    sent_at: NOW,
+  };
+
+  test("carries the full new steady-state set (not a diff)", () => {
+    const parsed = AgentCapabilitiesChangedPayloadSchema.parse(valid);
+    expect(parsed.capabilities).toEqual(["code-review.typescript"]);
+  });
+
+  test("accepts an empty set (all capabilities revoked)", () => {
+    const parsed = AgentCapabilitiesChangedPayloadSchema.parse({
+      ...valid,
+      capabilities: [],
+    });
+    expect(parsed.capabilities).toEqual([]);
+  });
+});
+
+describe("envelope round-trip (myelin validator) + agent-domain subject derivation", () => {
+  const cases: { type: AgentPresenceType; payload: unknown; action: string }[] = [
+    {
+      type: AGENT_ONLINE_TYPE,
+      action: "online",
+      payload: { identity: IDENTITY, scope: SCOPE, capabilities: [], started_at: NOW },
+    },
+    {
+      type: AGENT_HEARTBEAT_TYPE,
+      action: "heartbeat",
+      payload: { identity: IDENTITY, scope: SCOPE, sent_at: NOW },
+    },
+    {
+      type: AGENT_OFFLINE_TYPE,
+      action: "offline",
+      payload: { identity: IDENTITY, scope: SCOPE, reason: "shutdown", sent_at: NOW },
+    },
+    {
+      type: AGENT_CAPABILITIES_CHANGED_TYPE,
+      action: "capabilities-changed",
+      payload: {
+        identity: IDENTITY,
+        scope: SCOPE,
+        capabilities: ["code-review.typescript"],
+        sent_at: NOW,
+      },
+    },
+  ];
+
+  for (const { type, action, payload } of cases) {
+    test(`${type} validates against the envelope schema (payload unconstrained)`, () => {
+      // Payload first passes its own cortex-side schema...
+      AGENT_PRESENCE_PAYLOAD_SCHEMAS[type].parse(payload);
+      // ...then the wrapping envelope validates (payload is domain-specific /
+      // unconstrained — confirms it rides the standard envelope, like the
+      // cortex#361 heartbeat work).
+      const result = validateEnvelope(envelopeFor(type, payload));
+      expect(result.ok).toBe(true);
+    });
+
+    test(`${type} derives local.{principal}.{stack}.agent.${action}`, () => {
+      const env = validateEnvelope(envelopeFor(type, payload));
+      expect(env.ok).toBe(true);
+      if (!env.ok) return;
+      const subject = deriveNatsSubject(env.envelope, "meta-factory");
+      expect(subject).toBe(`local.andreas.meta-factory.agent.${action}`);
+    });
+
+    test(`${type} derives the federated counterpart with the SAME identity segments`, () => {
+      // ADR-0001/0007 — the federated subject carries {principal}.{stack},
+      // never a network token; only the scope prefix differs.
+      const fedEnvelope = {
+        ...(envelopeFor(type, payload) as Record<string, unknown>),
+        sovereignty: {
+          classification: "federated",
+          data_residency: "DE",
+          max_hop: 1,
+          frontier_ok: false,
+          model_class: "local-only",
+        },
+      };
+      const env = validateEnvelope(fedEnvelope);
+      expect(env.ok).toBe(true);
+      if (!env.ok) return;
+      const subject = deriveNatsSubject(env.envelope, "meta-factory");
+      expect(subject).toBe(`federated.andreas.meta-factory.agent.${action}`);
+    });
+  }
+});

--- a/src/bus/agent-network/envelopes.ts
+++ b/src/bus/agent-network/envelopes.ts
@@ -1,0 +1,257 @@
+/**
+ * G-1114.A — Agent-presence protocol envelope payload types (INERT).
+ *
+ * These are the payload shapes for the four `agent`-domain presence envelopes
+ * introduced by the Agent Network Topology umbrella (G-1114). They are
+ * **inert**: defined, exported, and unit-tested for shape/validation, but NO
+ * producer publishes them and NO subscriber consumes them yet. The first live
+ * producer/subscriber lands in G-1114.B. This grounding slice lands only the
+ * protocol SHAPE, reconciled to ADR-0007.
+ *
+ * ## Grounding (ADR-0007 — agent-presence protocol)
+ *
+ * 1. **`agent` domain, distinct from dispatch liveness.** Presence rides the
+ *    reserved `agent` domain: `agent.{online|heartbeat|offline|capabilities-changed}`
+ *    on `local.{principal}.{stack}.agent.…`. It means "this agent process is up
+ *    and consuming the bus, idle or not." It is SEPARATE from the dispatch-scoped
+ *    `system.agent.heartbeat` (cortex#361, see {@link AgentHeartbeatPayload} in
+ *    `src/common/types/agent-heartbeat.ts`), which fires only WHILE a dispatch is
+ *    in flight, keyed by `correlation_id`. An idle agent emits `agent.heartbeat`,
+ *    never `system.agent.heartbeat` — two differently-scoped heartbeats by design.
+ *
+ * 2. **`{principal}`, never `{org}`.** The subject's second segment is the
+ *    PRINCIPAL (CONTEXT.md authoritative; ADR-0001). Subjects are
+ *    `local.{principal}.{stack}.agent.{action}` and the federated counterpart
+ *    `federated.{principal}.{stack}.agent.{action}` — the network is NEVER a wire
+ *    token (ADR-0001/0003): network membership is grouped by the registry ROSTER
+ *    (ADR-0003), resolved from topology, not from a `public.metafactory.agent.*`
+ *    namespace. Public scope is deferred to candidate G-1115.
+ *
+ * 3. **Supersedes `agents.capabilities.registered`.** `agent.online` carries the
+ *    initial capability set; `agent.capabilities-changed` carries deltas. They
+ *    subsume the observability-only boot-time capability-announce envelope
+ *    (dual-emit → retire). Capability DISPATCH (cortex#237) is untouched — it
+ *    routes on the `tasks.{capability}` subject via JetStream consumer filters,
+ *    not a registry lookup.
+ *
+ * 4. **Peer visibility = presence + dispatch-lifecycle metadata only, never
+ *    session interiors** (ADR-0005). These payloads carry identity, liveness, and
+ *    declared capabilities — they deliberately carry NO tool calls, prompts, or
+ *    diffs. The boundary is enforced by what is on the wire, not a UI check.
+ *
+ * ## Subject derivation
+ *
+ * The `agent` domain is expressed via the envelope's `type` field: an envelope
+ * with `type: "agent.online"` derives the subject
+ * `{scope}.{principal}.{stack}.agent.online` through myelin's `deriveSubject`
+ * (`deriveNatsSubject` in `src/bus/myelin/envelope-validator.ts`). No new subject
+ * helper is needed — the domain segment is the leading segment of `type`. The
+ * four `*_TYPE` constants below are the canonical `envelope.type` literals.
+ *
+ * ## Envelope schema fit
+ *
+ * The myelin envelope schema (`src/bus/myelin/vendor/envelope.schema.json`)
+ * declares `payload` as an unconstrained object ("Structure is domain-specific
+ * — the envelope does not constrain payload shape"). So each of these payloads
+ * lands on `envelope.payload` and round-trips through `validateEnvelope`
+ * unchanged — the same property the cortex#361 heartbeat work relies on. These
+ * schemas are the cortex-side shape contract for that domain-specific payload.
+ */
+
+import { z } from "zod/v4";
+
+/**
+ * Canonical `envelope.type` literals for the four agent-presence actions.
+ *
+ * Each derives the `agent`-domain subject for its action — e.g.
+ * `AGENT_ONLINE_TYPE` ("agent.online") derives
+ * `local.{principal}.{stack}.agent.online`. Exposed as constants so producers
+ * and subscribers filter without re-typing the string (mirrors
+ * `AGENT_HEARTBEAT_TYPE` for the dispatch-scoped heartbeat).
+ */
+export const AGENT_ONLINE_TYPE = "agent.online" as const;
+export const AGENT_HEARTBEAT_TYPE = "agent.heartbeat" as const;
+export const AGENT_OFFLINE_TYPE = "agent.offline" as const;
+export const AGENT_CAPABILITIES_CHANGED_TYPE = "agent.capabilities-changed" as const;
+
+/**
+ * The set of all agent-presence `envelope.type` literals, for exhaustive
+ * subject/type filtering by a future subscriber.
+ */
+export const AGENT_PRESENCE_TYPES = [
+  AGENT_ONLINE_TYPE,
+  AGENT_HEARTBEAT_TYPE,
+  AGENT_OFFLINE_TYPE,
+  AGENT_CAPABILITIES_CHANGED_TYPE,
+] as const;
+
+export type AgentPresenceType = (typeof AGENT_PRESENCE_TYPES)[number];
+
+/**
+ * Capability-id grammar for presence payloads — dot-separated lowercase
+ * segments (e.g. `code-review.typescript`). Identical rule to the config-side
+ * `CapabilityIdSchema` (`src/common/types/capability.ts`); duplicated here so
+ * the presence protocol does not couple to the config schema's internals. The
+ * presence envelope carries only the capability IDS an agent currently
+ * advertises (not the full rate/cost config envelope, which is principal-local).
+ */
+const PresenceCapabilityIdSchema = z
+  .string()
+  .min(1, "agent presence capability id is required and must be non-empty")
+  .regex(
+    /^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)*$/,
+    "agent presence capability id must be dot-separated lowercase segments, each starting with a letter (e.g. 'code-review.typescript')",
+  );
+
+/**
+ * Agent NKey public key — the stable cross-restart identity. The presence
+ * protocol does not re-validate the NKey shape here (the envelope's
+ * `signed_by[]` chain is the authoritative identity attestation); this is the
+ * logical key the registry indexes records by.
+ */
+const NkeyPublicKeySchema = z
+  .string()
+  .min(1, "agent nkey public key is required and must be non-empty");
+
+/**
+ * RFC-3339 / ISO-8601 timestamp string. Kept as a string (matching the
+ * envelope's own `timestamp` field) rather than a `Date` so the payload is
+ * JSON-faithful on the wire.
+ */
+const IsoTimestampSchema = z
+  .string()
+  .min(1, "timestamp is required")
+  .describe("ISO-8601 / RFC-3339 timestamp");
+
+/**
+ * The reason an agent went offline. `shutdown`/`restart` are graceful (the
+ * agent emitted `agent.offline` itself); `error` is an abnormal exit the agent
+ * still managed to announce. A TTL-lapse offline is inferred by the subscriber's
+ * liveness FSM and never rides an `agent.offline` envelope (there is no agent
+ * left to send one).
+ */
+export const AgentOfflineReasonSchema = z.enum(["shutdown", "restart", "error"]);
+export type AgentOfflineReason = z.infer<typeof AgentOfflineReasonSchema>;
+
+/**
+ * Identity block shared by presence payloads — the logical agent identity a
+ * subscriber keys its registry record on.
+ *
+ * - `nkey_public_key`: stable cross-restart identity.
+ * - `agent_id`: the logical `agent.name` from `cortex.yaml` (`luna`, `echo`,
+ *   `sage`, …). Stamped on the payload so dashboards can group by agent without
+ *   parsing the envelope source triple (mirrors the cortex#361 heartbeat's
+ *   `agent_id`).
+ * - `assistant_name`: the Soma-layer assistant identity the agent hosts, when
+ *   the agent is bound to one (an agent process is the stack-local identity; an
+ *   assistant is the persistent named being). `null` when the agent hosts no
+ *   named assistant.
+ */
+export const AgentPresenceIdentitySchema = z.object({
+  nkey_public_key: NkeyPublicKeySchema,
+  agent_id: z
+    .string()
+    .min(1, "agent_id is required and must be non-empty"),
+  assistant_name: z.string().min(1).nullable(),
+});
+export type AgentPresenceIdentity = z.infer<typeof AgentPresenceIdentitySchema>;
+
+/**
+ * Scope block — the `{principal}.{stack}` the agent lives in. This is identity
+ * provenance, NOT a network token: a federated `agent.*` envelope from
+ * `andreas/work` carries `principal: "andreas"`, `stack: "work"`, and the
+ * subscriber resolves which network that belongs to from the registry roster
+ * (ADR-0001/0003) — the network name is never on the wire.
+ */
+export const AgentPresenceScopeSchema = z.object({
+  principal: z
+    .string()
+    .min(1, "principal is required and must be non-empty"),
+  stack: z.string().min(1, "stack is required and must be non-empty"),
+});
+export type AgentPresenceScope = z.infer<typeof AgentPresenceScopeSchema>;
+
+/**
+ * `agent.online` payload — emitted once on agent boot.
+ *
+ * Carries the full presence descriptor: identity, scope, the INITIAL capability
+ * set (superseding the boot-time `agents.capabilities.registered` announce per
+ * ADR-0007 §3), and the boot time. A subscriber upserts an `online` registry
+ * record on receipt. Deliberately carries NO session interior (ADR-0005).
+ */
+export const AgentOnlinePayloadSchema = z.object({
+  identity: AgentPresenceIdentitySchema,
+  scope: AgentPresenceScopeSchema,
+  /** Capability ids the agent advertises at boot. May be empty. */
+  capabilities: z.array(PresenceCapabilityIdSchema).default([]),
+  /** When the agent process booted. */
+  started_at: IsoTimestampSchema,
+});
+export type AgentOnlinePayload = z.infer<typeof AgentOnlinePayloadSchema>;
+
+/**
+ * `agent.heartbeat` payload — emitted on a fixed interval while the agent is up
+ * (idle or not). This is the PRESENCE heartbeat (ADR-0007 §1), distinct from the
+ * dispatch-scoped `system.agent.heartbeat` (cortex#361). The subscriber's
+ * liveness FSM keeps a record `online` while heartbeats arrive within the
+ * 5-minute TTL, and transitions it to `offline` on TTL lapse.
+ *
+ * Carries only liveness — no capability list (that rides `online` /
+ * `capabilities-changed`) and no dispatch progress (that is the OTHER
+ * heartbeat's job).
+ */
+export const AgentHeartbeatPayloadSchema = z.object({
+  identity: AgentPresenceIdentitySchema,
+  scope: AgentPresenceScopeSchema,
+  /** When this heartbeat was emitted. */
+  sent_at: IsoTimestampSchema,
+});
+export type AgentHeartbeatPayload = z.infer<typeof AgentHeartbeatPayloadSchema>;
+
+/**
+ * `agent.offline` payload — emitted on graceful shutdown / restart, or on an
+ * abnormal-but-announced exit (`error`). The liveness FSM transitions the record
+ * to `offline` immediately on receipt (vs waiting out the TTL).
+ */
+export const AgentOfflinePayloadSchema = z.object({
+  identity: AgentPresenceIdentitySchema,
+  scope: AgentPresenceScopeSchema,
+  reason: AgentOfflineReasonSchema,
+  /** Optional human-readable detail (e.g. the error message for `error`). */
+  detail: z.string().min(1).optional(),
+  /** When the offline was emitted. */
+  sent_at: IsoTimestampSchema,
+});
+export type AgentOfflinePayload = z.infer<typeof AgentOfflinePayloadSchema>;
+
+/**
+ * `agent.capabilities-changed` payload — emitted when an agent's advertised
+ * capability set changes mid-life (plugin loaded, permission granted/revoked).
+ * Carries the FULL new steady-state capability set (not a diff) so a subscriber
+ * that missed an earlier delta still converges; the subscriber computes the diff
+ * against its current record. Supersedes mid-life re-emission of
+ * `agents.capabilities.registered` (ADR-0007 §3).
+ */
+export const AgentCapabilitiesChangedPayloadSchema = z.object({
+  identity: AgentPresenceIdentitySchema,
+  scope: AgentPresenceScopeSchema,
+  /** The agent's full capability set AFTER the change. May be empty. */
+  capabilities: z.array(PresenceCapabilityIdSchema).default([]),
+  /** When the capability change was emitted. */
+  sent_at: IsoTimestampSchema,
+});
+export type AgentCapabilitiesChangedPayload = z.infer<
+  typeof AgentCapabilitiesChangedPayloadSchema
+>;
+
+/**
+ * Map of `envelope.type` literal → the zod schema for its payload. Lets a
+ * future subscriber validate an inbound presence envelope's payload by its
+ * type without a switch statement. INERT in this slice — no caller yet.
+ */
+export const AGENT_PRESENCE_PAYLOAD_SCHEMAS = {
+  [AGENT_ONLINE_TYPE]: AgentOnlinePayloadSchema,
+  [AGENT_HEARTBEAT_TYPE]: AgentHeartbeatPayloadSchema,
+  [AGENT_OFFLINE_TYPE]: AgentOfflinePayloadSchema,
+  [AGENT_CAPABILITIES_CHANGED_TYPE]: AgentCapabilitiesChangedPayloadSchema,
+} as const;

--- a/src/surface/mc/dashboard-v2/__tests__/network-preview-view.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-preview-view.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * G-1114.A — render test for the Network (preview) stub tab.
+ *
+ * Walks the rendered React tree (no DOM harness — same approach as
+ * markdown.test.tsx) to assert the placeholder renders, names the preview
+ * status, and lists the four `agent`-domain presence actions. NO data wiring is
+ * exercised because there is none (inert grounding slice).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { createElement, isValidElement, type ReactNode } from "react";
+import { NetworkPreviewView } from "../components/network-preview-view";
+
+interface El {
+  type: unknown;
+  props: { className?: string; children?: ReactNode; "aria-label"?: string };
+}
+
+function isEl(node: unknown): node is El {
+  return isValidElement(node);
+}
+
+function collectText(node: ReactNode): string {
+  let out = "";
+  function walk(n: ReactNode): void {
+    if (n == null || typeof n === "boolean") return;
+    if (typeof n === "string" || typeof n === "number") {
+      out += String(n);
+      return;
+    }
+    if (Array.isArray(n)) {
+      for (const c of n) walk(c);
+      return;
+    }
+    if (isEl(n)) walk(n.props.children);
+  }
+  walk(node);
+  return out;
+}
+
+describe("NetworkPreviewView (G-1114.A stub)", () => {
+  const tree = createElement(NetworkPreviewView);
+  // NetworkPreviewView is a plain function component; invoke it to get its tree.
+  const rendered = NetworkPreviewView();
+
+  it("renders a section element", () => {
+    expect(isValidElement(tree)).toBe(true);
+    expect(isEl(rendered) && rendered.type).toBe("section");
+  });
+
+  it("labels itself a preview", () => {
+    const text = collectText(rendered);
+    expect(text).toContain("Network (preview)");
+    expect(text).toContain("G-1114.B");
+  });
+
+  it("lists the four agent-domain presence actions", () => {
+    const text = collectText(rendered);
+    expect(text).toContain("agent.online");
+    expect(text).toContain("agent.heartbeat");
+    expect(text).toContain("agent.offline");
+    expect(text).toContain("agent.capabilities-changed");
+  });
+
+  it("distinguishes presence from the dispatch-scoped heartbeat", () => {
+    const text = collectText(rendered);
+    expect(text).toContain("system.agent.heartbeat");
+    expect(text.toLowerCase()).toContain("session interior");
+  });
+});

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -25,6 +25,7 @@ import { PlansView } from "./components/plans-view";
 import { PhaseDetailView } from "./components/phase-detail-view";
 import { WorkItemDetailView } from "./components/work-item-detail-view";
 import { AttentionView } from "./components/attention-view";
+import { NetworkPreviewView } from "./components/network-preview-view";
 import { Toast } from "./components/toast";
 import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
@@ -58,7 +59,7 @@ import type { Command } from "./components/command-palette";
  * may upgrade to a hash route if deep-linking turns out to be
  * principal-requested; for now the in-memory view is sufficient.
  */
-type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "work-item-detail" | "attention" | "kanban-detail";
+type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "work-item-detail" | "attention" | "kanban-detail" | "network-preview";
 
 export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
@@ -329,6 +330,15 @@ export function App() {
         >
           Sources
         </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "network-preview"}
+          className={`tab${view === "network-preview" ? " active" : ""}`}
+          onClick={() => setView("network-preview")}
+        >
+          Network
+        </button>
         {softwareMode && (
           <button
             type="button"
@@ -511,6 +521,12 @@ export function App() {
         {view === "sources" && (
           /* G-1113.B.4 — provider-neutral Sources config view. */
           <SourcesView />
+        )}
+
+        {view === "network-preview" && (
+          /* G-1114.A — Agent Network Topology placeholder. Inert: no producer,
+             no subscriber, no data yet (live panel lands in G-1114.B). */
+          <NetworkPreviewView />
         )}
 
         {view === "repositories" && softwareMode && (

--- a/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
@@ -1,0 +1,57 @@
+/**
+ * G-1114.A — Network (preview) tab.
+ *
+ * A grounding-slice placeholder for the Agent Network Topology view (G-1114).
+ * This renders a clear "preview — coming in G-1114.B" card and NO data: there
+ * is no producer publishing `agent.*` presence envelopes and no subscriber /
+ * runtime registry feeding this surface yet (ADR-0007 — the live producer +
+ * subscriber land in Phase B). It exists so the work-in-flight is visible on
+ * the dashboard and the tab slot is reserved.
+ *
+ * When G-1114.B wires the runtime registry, this view is replaced by the real
+ * stack-local agents panel; when G-1114.D lands, by the React Flow + ELK graph.
+ */
+
+/** The four `agent`-domain presence actions this view will eventually render. */
+const PRESENCE_ACTIONS = [
+  "online",
+  "heartbeat",
+  "offline",
+  "capabilities-changed",
+] as const;
+
+export function NetworkPreviewView() {
+  return (
+    <section
+      className="scaffold-section network-preview-view"
+      aria-label="Network topology (preview)"
+    >
+      <h2>Network (preview)</h2>
+      <p className="dim">
+        The <strong>Agent Network Topology</strong> view is in flight (G-1114).
+        It will render agent <strong>presence</strong> across stacks — which
+        agents are up and consuming the bus, their declared capabilities, and
+        their liveness — built from the new <code>agent</code>-domain presence
+        protocol on the bus.
+      </p>
+      <p className="dim">
+        Nothing is wired yet: this slice (G-1114.A) lands only the inert
+        protocol types. The live stack-local agents panel arrives in{" "}
+        <strong>G-1114.B</strong>; the graph view in G-1114.D.
+      </p>
+      <ul className="network-preview-actions" aria-label="Presence protocol actions">
+        {PRESENCE_ACTIONS.map((action) => (
+          <li key={action} className="network-preview-action">
+            <code>agent.{action}</code>
+          </li>
+        ))}
+      </ul>
+      <p className="dim network-preview-note">
+        Presence (<code>agent.heartbeat</code>) is distinct from the
+        dispatch-scoped <code>system.agent.heartbeat</code>: an idle agent has
+        presence without running a dispatch. Peer agents show presence and
+        dispatch-lifecycle metadata only — never session interiors.
+      </p>
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -348,6 +348,18 @@ html, body {
 .sources-view .source-state.state-available { color: var(--fg-faint); }
 .sources-view .source-available .provider-label { color: var(--fg-faint); }
 
+/* G-1114.A — Network (preview) stub tab */
+.network-preview-view .network-preview-actions {
+  list-style: none; margin: 8px 0; padding: 0;
+  display: flex; flex-wrap: wrap; gap: 8px;
+}
+.network-preview-view .network-preview-action code {
+  font-size: 11px; padding: 2px 8px;
+  border: 1px solid var(--line-soft); border-radius: 4px;
+  color: var(--fg-faint);
+}
+.network-preview-view .network-preview-note { margin-top: 8px; }
+
 /* G-1113.C.7 — per-repository panel */
 .repos-view .repo-card {
   border: 1px solid var(--line); border-radius: 8px;


### PR DESCRIPTION
Phase A grounding for **Agent Network Topology** (G-1114, umbrella #355). Lands the protocol SHAPE, grounded in the just-merged **[ADR-0007](https://github.com/the-metafactory/cortex/blob/main/docs/adr/0007-agent-presence-protocol.md)**.

## ZERO runtime change

No producers, no subscribers, no live data. This slice lands only:
- **inert** `agent.*` payload types,
- a **stub** Network tab (placeholder, no wiring),
- the design + plan docs reconciled to ADR-0007,
- `blueprint.yaml` G-1114 nodes.

Nothing publishes or consumes a presence envelope yet — the live producer + subscriber land in G-1114.B.

## What

- **Inert protocol types** — `src/bus/agent-network/envelopes.ts`: zod schemas + inferred types + `envelope.type` constants for `agent.online` / `agent.heartbeat` / `agent.offline` / `agent.capabilities-changed`. Defined, exported, unit-tested for shape/validation; no caller.
- **Network (preview) stub tab** — `src/surface/mc/dashboard-v2/components/network-preview-view.tsx` + a plain "Network" tab in `app.tsx`. A clear "preview — coming in G-1114.B" placeholder.
- **Reconciled docs** — `docs/design-agent-network-topology.md` + `docs/plan-agent-network-topology.md` brought onto main off the pre-grill branch and corrected to ADR-0007.
- **blueprint.yaml** — G-1114 umbrella + phase nodes.

## ADR-0007 grounding — every pre-grill divergence reconciled

| Pre-grill (issue body / old branch) | Reconciled (this PR) |
|---|---|
| `{org}` | `{principal}` everywhere (CONTEXT.md authoritative; ADR-0001) |
| `local.{org}.{stack}.agent.{action}.@{principal}` | `local.{principal}.{stack}.agent.{action}` — the `agent` **domain**; agent id rides the **payload**, no `.@{principal}` tail |
| `system.agent.online/heartbeat/...` envelope types | `agent.*` presence, **distinct** from the dispatch-scoped `system.agent.heartbeat` (cortex#361) |
| `public.metafactory.agent.*` / network-as-namespace | **dropped** — membership groups by the **registry roster** (ADR-0003); network never on the wire; public scope deferred to **G-1115** |
| presence == dispatch liveness | two differently-scoped heartbeats by design; idle agent emits `agent.heartbeat`, never `system.agent.heartbeat` |
| `agents.capabilities.registered` | superseded by `agent.online` (initial caps) + `agent.capabilities-changed` (deltas), dual-emit → retire. Dispatch (cortex#237) **untouched** — routes on subject/consumer-filter, not a registry lookup |

Federation: **two transports, one envelope** — bus federation (`federated.…agent.*`) feeds the local Network view; the [ADR-0006](https://github.com/the-metafactory/cortex/blob/main/docs/adr/0006-network-view-feed-registry-anchored.md) registry-anchored push feeds the hosted pane. Peer visibility = presence + dispatch-lifecycle metadata only, **never session interiors** ([ADR-0005](https://github.com/the-metafactory/cortex/blob/main/docs/adr/0005-mission-control-integration-architecture.md)). Liveness FSM: 5-min TTL on the **new** `agent.heartbeat`.

## Test plan

- **Inert envelope types** (`src/bus/agent-network/__tests__/envelopes.test.ts`, 27 tests): each action's payload validates + round-trips through the myelin `validateEnvelope` (payload is unconstrained — confirmed, the property the cortex#361 work relies on), and derives `{scope}.{principal}.{stack}.agent.{action}` for **both** local and federated scopes (same identity segments, network never on the wire). Presence heartbeat asserted distinct from `system.agent.heartbeat`.
- **Stub tab render test** (4 tests): walks the React tree, asserts the preview placeholder, the four `agent.*` actions, and the presence-vs-dispatch distinction.
- No producer/consumer/integration tests — nothing is live yet.

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, none in new files)
- full `bun test` — **5457 pass / 0 fail / 2 skip**
- `check-carveouts.sh` — **PASS** on all new source/doc files (no `{org}`, no bare `operator`)

> Note: `check-carveouts.sh` in per-PR-diff mode flags pre-existing `operator` prose in `blueprint.yaml`'s **C-series** nodes (origin/main already fails these 14 — they belong to the separate 0002 vocabulary migration). My G-1114 blueprint additions use `principal` throughout; left the unrelated C-series prose untouched to avoid mixing migrations into a grounding PR.

refs #355
Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)