### PR TITLE
docs: rewrite README for humans + add README-AGENTS install guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,7 +456,7 @@ The `build:dashboard` + `watch:dashboard` scripts in `package.json` codify steps
 - The backend (`cortex` bot via `arc upgrade Cortex`) and the frontend (CF Pages via `wrangler`) are deployed independently.
 
 **Architecture:**
-- `cortex` serves the REST API + WebSocket at `localhost:8766` locally, or via the CF Worker at `grove.meta-factory.ai/api/*` in production (`src/surface/mc/worker/`).
+- `cortex` serves the REST API + WebSocket at `localhost:8767` locally, or via the CF Worker at `grove.meta-factory.ai/api/*` in production (`src/surface/mc/worker/`).
 - The dashboard frontend is static HTML/JS hosted on CF Pages.
 - Frontend connects to the API via URL params (`?api=`) or auto-detection.
 - CF Access cookies cover dashboard + API on each TLD (`.ai`, `.dev`, `.io`) — no cross-origin cookie issue, no bypass-everyone policies (see Critical Rules).

--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -79,7 +79,7 @@ and rename the pointer file to `<slug>.yaml`.
 |---|---|---|
 | `<slug>.yaml` | pointer | Nothing. Contents ignored; dirname selects the layout; **basename names the PID file** — must be per-stack, never a uniform `cortex.yaml`, or a second daemon collides on the PID file. |
 | `system/system.yaml` | substrate/transport | `nats.url` + identity block. **Leave `nats.subjects: []`** unless you know you need push-mode fan-out — see §3.4. |
-| `stacks/<slug>.yaml` | per-deployment | Fill `<REPLACE_ME>`: principal id + Discord id, `stack.id` (`<principal>/<slug>`), `nkey_seed_path`, post-first-boot `nkey_pub`, `policy` block, agents, `github.repos`. **`chmod 600`** (carries the bot token if inline). |
+| `stacks/<slug>.yaml` | per-deployment | Fill `<REPLACE_ME>`: principal id + Discord id, `stack.id` (`<principal>/<slug>`), `nkey_seed_path`, `policy` block, agents, `github.repos`. Set `nkey_pub` only after §3.3 prints the `U…` key. **`chmod 600`** (carries the bot token if inline). |
 | `surfaces/surfaces.yaml` | surface bindings (optional) | Discord `token` / `guildId` / `agentChannelId` / `logChannelId` per agent. Credential surface-of-truth; folds into the matching agent's `presence` block at load. |
 | `network/*.yaml` | federation (optional) | Leave absent/commented unless federating (§6). |
 | `personas/<assistant>.md` | persona | The assistant's persona; append a repo-scope note listing allowed repo slugs. |

--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -23,8 +23,10 @@ Verify each before starting:
 | guild id + channel ids | — | Discord client → Developer Mode → copy id. |
 | `arc` (optional) | `arc --version` | metafactory package manager; manages install + launchd lifecycle + signing-seed provisioning. |
 
-Platform: macOS (launchd plists ship in `src/services/`) or Linux (systemd
-user units — same pattern, principal-provided unit files).
+Platform: macOS (launchd plists ship in `src/services/`) or Linux (no systemd
+template ships in-repo — mirror the launchd plists in `src/services/` as a user
+unit: `ExecStart=<path>/cortex start --config <pointer>`, `Restart=always`,
+plus the `CORTEX_CHANNEL` env var and a `PATH` that includes `~/.bun/bin`).
 
 ## 2. Install
 
@@ -34,10 +36,14 @@ user units — same pattern, principal-provided unit files).
 arc upgrade Cortex
 ```
 
-This installs the released package, renders + loads the launchd agents
-(`ai.meta-factory.cortex.*`), and auto-provisions the stack signing seed at the
-conventional path on first install. Note: `arc upgrade` tracks **GitHub
-releases**, not `main`.
+This installs the released package and renders + loads the launchd agents
+(`ai.meta-factory.cortex.*`). Note: `arc upgrade` tracks **GitHub releases**,
+not `main`.
+
+**Ordering:** seed auto-provisioning reads `stack.nkey_seed_path` from the
+stack config — which doesn't exist until §3.1 scaffolds it. On a fresh machine:
+install (this section) → configure (§3) → re-run `arc upgrade Cortex` (or
+provision manually per §3.3) so the seed lands at the declared path.
 
 **Path B — from source:**
 
@@ -212,7 +218,8 @@ in v1 — keep dispatch scope tight on public-facing stacks.
 **Instrument any Claude Code session** onto the Mission Control dashboard:
 
 ```bash
-CORTEX_CHANNEL=<label> CORTEX_AGENT_NAME=<display> CORTEX_AGENT_ID=<id> claude
+CORTEX_CHANNEL=<label> CORTEX_AGENT_NAME=<display> CORTEX_AGENT_ID=<id> \
+  CORTEX_PRINCIPAL=<principal> claude
 ```
 
 `CORTEX_CHANNEL` is the required enabler; `CORTEX_PRINCIPAL` stamps the human
@@ -230,7 +237,8 @@ discord read
 **Dashboard frontend** (only when serving your own): built + deployed
 separately from the daemon —
 `bun run build:dashboard` then
-`bunx wrangler pages deploy dist/dashboard-v2 --project-name grove-dashboard`.
+`bunx wrangler pages deploy dist/dashboard-v2 --project-name <your-cf-project>`
+(your own Cloudflare Pages project; `grove-dashboard` is the metafactory's).
 
 **Bus code review:** publishers send `tasks.code-review.*` envelopes; cortex
 claims via a JetStream durable and emits verdict + lifecycle envelopes. Tune

--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -1,0 +1,264 @@
+# cortex — Install & Configure Guide (for AI agents)
+
+Audience: an AI agent (or human operator) installing, configuring, and
+verifying a cortex stack on a principal's machine. For what cortex *is*, read
+[`README.md`](README.md). For working on this *codebase*, read `CLAUDE.md`
+(generated — never hand-edit).
+
+This guide is deterministic: follow the steps in order, verify each gate before
+proceeding, and prefer the dry-run form of every command before `--apply`.
+
+---
+
+## 1. Prerequisites
+
+Verify each before starting:
+
+| Requirement | Check | Notes |
+|---|---|---|
+| Bun | `bun --version` | The only supported runtime. Never use npm/yarn/node. |
+| NATS server with JetStream | `nats-server --version` | One isolated bus per stack (see §4). |
+| Claude Code, authenticated | `claude --version` | Default execution substrate for dispatched work. |
+| Discord bot token + guild | — | Bot must already be a **member of the target guild** with the **Message Content intent enabled** (Developer Portal). Only the principal can do this. |
+| guild id + channel ids | — | Discord client → Developer Mode → copy id. |
+| `arc` (optional) | `arc --version` | metafactory package manager; manages install + launchd lifecycle + signing-seed provisioning. |
+
+Platform: macOS (launchd plists ship in `src/services/`) or Linux (systemd
+user units — same pattern, principal-provided unit files).
+
+## 2. Install
+
+**Path A — arc-managed (preferred when `arc` is available):**
+
+```bash
+arc upgrade Cortex
+```
+
+This installs the released package, renders + loads the launchd agents
+(`ai.meta-factory.cortex.*`), and auto-provisions the stack signing seed at the
+conventional path on first install. Note: `arc upgrade` tracks **GitHub
+releases**, not `main`.
+
+**Path B — from source:**
+
+```bash
+git clone https://github.com/the-metafactory/cortex
+cd cortex
+bun install
+```
+
+Run the daemon directly with `bun src/cortex.ts start --config <pointer>` or
+via an installed `cortex` binary. Verify with `bun test` and `bun run lint`.
+
+## 3. Configure a stack
+
+cortex uses the **config-split (multi-file) layout** as the standard. A stack's
+config is a directory under `~/.config/cortex/<slug>/`; the daemon's `--config`
+points at a **pointer file** inside it. The single-file `cortex.yaml`
+(`cortex.yaml.example`) is legacy — it still loads, but do not create new
+installs with it.
+
+### 3.1 Scaffold
+
+```bash
+# Dry-run FIRST (default — prints the file set, touches nothing):
+cortex stack create <slug> --principal <principal>
+
+# Then write:
+cortex stack create <slug> --principal <principal> --apply
+```
+
+This scaffolds `~/.config/cortex/<slug>/` "born aligned": dir basename == slug
+== trailing segment of `stack.id`. It refuses dir collisions and duplicate
+`stack.id`s. Manual fallback: `cp -R docs/config-layout ~/.config/cortex/<slug>`
+and rename the pointer file to `<slug>.yaml`.
+
+### 3.2 The files and what to fill
+
+| File | Layer | Action |
+|---|---|---|
+| `<slug>.yaml` | pointer | Nothing. Contents ignored; dirname selects the layout; **basename names the PID file** — must be per-stack, never a uniform `cortex.yaml`, or a second daemon collides on the PID file. |
+| `system/system.yaml` | substrate/transport | `nats.url` + identity block. **Leave `nats.subjects: []`** unless you know you need push-mode fan-out — see §3.4. |
+| `stacks/<slug>.yaml` | per-deployment | Fill `<REPLACE_ME>`: principal id + Discord id, `stack.id` (`<principal>/<slug>`), `nkey_seed_path`, post-first-boot `nkey_pub`, `policy` block, agents, `github.repos`. **`chmod 600`** (carries the bot token if inline). |
+| `surfaces/surfaces.yaml` | surface bindings (optional) | Discord `token` / `guildId` / `agentChannelId` / `logChannelId` per agent. Credential surface-of-truth; folds into the matching agent's `presence` block at load. |
+| `network/*.yaml` | federation (optional) | Leave absent/commented unless federating (§6). |
+| `personas/<assistant>.md` | persona | The assistant's persona; append a repo-scope note listing allowed repo slugs. |
+
+Composition precedence (later wins on leaf keys):
+`system/` → `network/*` (sorted) → `surfaces/` → `stacks/*` (sorted).
+
+### 3.3 Signing identity
+
+`arc upgrade Cortex` auto-provisions the seed at
+`~/.config/nats/cortex-<slug>.nk`. Manual alternative:
+
+```bash
+cortex provision-stack generate <principal> \
+  --seed-path ~/.config/nats/cortex-<slug>.nk \
+  --stack-id <principal>/<slug>
+```
+
+Seed stays `chmod 600`. Record the printed `nkey_pub` (`U…`) into
+`stacks/<slug>.yaml`. Local-only stacks do NOT need `--register` and may keep
+`security.signing: off` — own-stack implicit trust admits the stack's own
+envelopes. Registration matters only for federated `signing: enforce`.
+
+### 3.4 The `nats.subjects` landmine
+
+`nats.subjects` lives in **exactly one place**: `system/system.yaml`. A
+duplicate declaration in any stack file double-binds the boot subscriber and
+double-delivers every envelope (cortex#491). The loader validates loudly, but
+never re-declare it. Default `[]` is correct for pull-only capability dispatch.
+
+### 3.5 Policy: principal-only access
+
+For any guild others can join, list **only** the principal (with their Discord
+id under `platform_ids.discord`) in `policy.principals[]`. A non-principal's
+@mention is hard-blocked silently — a `system.access.denied` audit envelope on
+the bus, no channel reply. Size `claude.bashAllowlist` (in `system/system.yaml`)
+least-privilege: it gates every command in dispatched sessions, even the
+principal's, and the bash-guard auto-approves matching commands so async
+dispatch never stalls. Restrict `gh` reach via `bashAllowlist.repos`.
+
+## 4. Stand up the bus
+
+One isolated NATS server per stack. The isolation wall is the **absence** of
+any `leafnodes{}` / `cluster{}` / `gateway{}` block. `~/.config/nats/<slug>.conf`:
+
+```hocon
+server_name: <slug>-<principal>
+listen: 127.0.0.1:<port>            # pick a free port; pair with a free monitor port
+http: 127.0.0.1:<monitor-port>
+jetstream {
+  store_dir: ~/.config/nats/<slug>-jetstream
+  max_mem: 64mb
+  max_file: 1gb
+  domain: <slug>-<principal>
+}
+```
+
+Load it via a launchd plist (`ai.meta-factory.nats.<slug>.plist`) or systemd
+unit, then verify: `lsof -nP -iTCP:<port> -sTCP:LISTEN | grep nats`.
+
+Point `system/system.yaml` `nats.url` at `nats://127.0.0.1:<port>`.
+
+> Gotcha: a stray system-wide `nats-server` (e.g. homebrew, no JetStream) on
+> the same port silently hijacks connections — JetStream consumers go dormant.
+> Verify which process owns the port before debugging anything else.
+
+## 5. Start and verify
+
+```bash
+# Validate schema + agent registry resolution without starting:
+cortex start --config ~/.config/cortex/<slug>/<slug>.yaml --dry-run
+
+# Start (launchd/systemd handles this in steady state):
+cortex start --config ~/.config/cortex/<slug>/<slug>.yaml
+```
+
+Daemonised: `~/Library/LaunchAgents/ai.meta-factory.cortex.<slug>.plist` →
+`cortex start --config …/<slug>.yaml`, logs to
+`~/.config/cortex/logs/cortex-<slug>.{log,error.log}`.
+
+**Healthy-boot gate** — all of these lines must appear:
+
+```bash
+grep -E "Stack:|connected to nats|policy-engine active|connected as|Guild:" \
+  ~/.config/cortex/logs/cortex-<slug>.log | tail
+```
+
+Expect: `Stack: <principal>/<slug>` · `connected to nats://…:<port>` ·
+`policy-engine active — principals=N` · `discord adapter started (… guild: …)`
+· `connected as <Bot>#NNNN`.
+
+**Functional gate:**
+
+1. @mention the assistant as the principal → it replies.
+2. @mention from a non-principal account → silence (no reply, no refusal
+   post). This proves the principal-only gate.
+
+## 6. Federate (optional)
+
+Federation joins the stack's bus to a network of peer principals. Summary —
+full procedure in [`docs/sop-network-join.md`](docs/sop-network-join.md) and
+[`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md) Part 2:
+
+1. **Hard prerequisite:** the local bus must be **operator-mode** (NSC
+   operator + system account + resolver blocks defining the leaf account). An
+   anonymous bus from §4 **cannot federate** — `cortex network join` refuses
+   fail-fast (#794). Convert the bus config first.
+2. Obtain a leaf `.creds` for this stack from the hub admin →
+   `~/.config/nats/<network>.creds`; note its account NKey (`A…`).
+3. Add the `stack.nats_infra` + `policy.federated.registry` blocks to
+   `stacks/<slug>.yaml`.
+4. Register + join (dry-run first; add `--apply` to write):
+
+```bash
+cortex provision-stack register <principal> --seed-path <seed> \
+  --registry-url https://network.meta-factory.ai --stack-id <principal>/<slug>
+cortex network join <network> --config ~/.config/cortex/<slug>/<slug>.yaml --apply
+```
+
+A principal's **2nd+ stack** must pass `--principal-seed <root-seed>` (the
+first stack's seed) so the add-stack claim is root-signed and existing stacks
+survive the merge (#791).
+
+Verify: `cortex network status --principal <principal>` → leaf `link:`
+established + expected peers. Note: federated payloads are cleartext-over-TLS
+in v1 — keep dispatch scope tight on public-facing stacks.
+
+## 7. Optional integrations
+
+**Instrument any Claude Code session** onto the Mission Control dashboard:
+
+```bash
+CORTEX_CHANNEL=<label> CORTEX_AGENT_NAME=<display> CORTEX_AGENT_ID=<id> claude
+```
+
+`CORTEX_CHANNEL` is the required enabler; `CORTEX_PRINCIPAL` stamps the human
+for correlation. Event pipeline: CC hooks → `~/.claude/events/raw/` →
+cortex-relay → `~/.claude/events/published/` → daemon → bus → dashboard.
+
+**Discord CLI** from any terminal:
+
+```bash
+discord post "message"                      # default channel
+discord post --channel <name> "message"
+discord read
+```
+
+**Dashboard frontend** (only when serving your own): built + deployed
+separately from the daemon —
+`bun run build:dashboard` then
+`bunx wrangler pages deploy dist/dashboard-v2 --project-name grove-dashboard`.
+
+**Bus code review:** publishers send `tasks.code-review.*` envelopes; cortex
+claims via a JetStream durable and emits verdict + lifecycle envelopes. Tune
+via `bus.review`; see [`docs/sop-bus-review.md`](docs/sop-bus-review.md).
+
+## 8. Gotchas (ranked by damage)
+
+| Gotcha | Consequence | Rule |
+|---|---|---|
+| Duplicate `nats.subjects` | Every envelope delivered twice | Declare in `system/system.yaml` only (§3.4). |
+| Uniform pointer filename across stacks | Second daemon kills the first's PID file | Pointer basename = stack slug, always. |
+| Anonymous bus + `network join` | Historically: bus down (`cannot find local account`); now: fail-fast refusal | Convert to operator-mode before joining (§6). |
+| dir/slug ≠ `stack.id` trailing segment | Stack federates as one identity, labelled another ("drift") | Use `stack create` (born aligned); reconcile drift by renaming the dir, never rewriting `stack.id` (ADR-0004). |
+| Stray nats-server on the stack's port | JetStream consumers silently dormant | Verify port ownership; connect via `127.0.0.1`, not `localhost`. |
+| Oversized `bashAllowlist` | Dispatched sessions auto-approve too much | Least privilege; scope `gh` with `bashAllowlist.repos`. |
+| Secrets in world-readable config | Token leak | `chmod 600` on `stacks/*.yaml` / `surfaces/surfaces.yaml`. |
+
+## 9. Reference index
+
+| Topic | Doc |
+|---|---|
+| End-to-end stack stand-up | [`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md) |
+| Config template (canonical) | [`docs/config-layout/`](docs/config-layout/) |
+| Config-split rationale + migration | [`docs/migrations/0003-config-split-layout.md`](docs/migrations/0003-config-split-layout.md) |
+| Stack signing identity | [`docs/sop-stack-identity.md`](docs/sop-stack-identity.md) |
+| Slug authority decision | [`docs/adr/0004-stack-slug-authority.md`](docs/adr/0004-stack-slug-authority.md) |
+| Network join / leave / status | [`docs/sop-network-join.md`](docs/sop-network-join.md) |
+| Peer-principal onboarding | [`docs/sop-federation-onboarding.md`](docs/sop-federation-onboarding.md) |
+| Bus review path | [`docs/sop-bus-review.md`](docs/sop-bus-review.md) |
+| Architecture | [`docs/architecture.md`](docs/architecture.md) |
+| Domain vocabulary | [`CONTEXT.md`](CONTEXT.md) |

--- a/README.md
+++ b/README.md
@@ -1,204 +1,162 @@
 # cortex
 
-The metafactory ecosystem's **layer-7 collaboration surface** — the M7
-application that consumes the Myelin stack (M2–M6) and presents collaboration,
-dispatch, and observability to operators across Discord, Mattermost, and the
-Mission Control dashboard.
+**Talk to your AI agents from Discord. Watch them work on a dashboard. Let them
+collaborate across machines — and across people.**
 
-## What cortex is
+cortex is the collaboration surface of the [metafactory](https://github.com/the-metafactory)
+ecosystem. It runs named AI assistants (powered by Claude Code and other
+substrates), connects them to the chat platforms you already use, routes work to
+them over a message bus, and makes everything they do visible in one place.
 
-Cortex is the conscious processing surface of the metafactory stack. It is one
-M7 application among siblings (alongside pilot, signal, future apps); it does
-not own M1–M6, it consumes their contracts.
+## What can you do with it?
 
-In one sentence: cortex is what operators talk to when they ask an AI agent to
-do work, and it is where that work becomes visible.
+- **Chat-dispatch work.** Mention an assistant in a Discord (or Mattermost,
+  or Slack) channel — "fix the failing test in #cortex", "review PR 54" — and
+  cortex spawns a Claude Code session, streams its progress back to the thread,
+  and posts the result. Prefix with `async:` for fire-and-forget tasks or
+  `team:` to spawn a multi-agent team.
+- **Watch everything on Mission Control.** A web dashboard shows every running
+  session, task queue, attention items needing your input, and GitHub activity
+  (issues, PRs, checks) — so chat doesn't have to choose between "flood the
+  channel with tool calls" and "go silent for ten minutes".
+- **Route code reviews over the bus.** Publish a review request; any agent
+  declaring the `code-review` capability claims it, runs the review, and posts
+  the verdict — no point-to-point wiring between requester and reviewer.
+- **Instrument your own terminal sessions.** Set one environment variable and
+  your local Claude Code session's events appear live on the dashboard.
+- **Federate with other people.** Your stack and a collaborator's stack can
+  join the same network: their assistant can answer in a shared channel, claim
+  work you offer, and reply to yours — each side keeping its own keys, policy,
+  and data.
 
-Concretely, cortex provides:
+## How it works, in one paragraph
 
-- **Platform adapters** — Discord and Mattermost presence per agent. Inbound
-  messages route to a workflow runner; outbound replies + lifecycle events
-  render back to the surface.
-- **Workflow runner** — spawns and supervises Claude Code sessions per
-  conversation, with per-thread session persistence, attachment handling,
-  multi-agent teams, async tasks, and a content-policy filter.
-- **Myelin bus client** — NATS-backed M2–M6 transport with vendored envelope
-  schema validation, subject-pattern subscriptions, and reconnect-aware
-  subscription lifecycle.
-- **Mission Control dashboard** — React surface at `grove.meta-factory.ai` for
-  task observation, dispatch, and principal input.
-- **GitHub taps** — webhook proxy + in-bot handlers for issues/PRs/checks
-  visibility into Discord threads.
-- **CC event pipeline** — Claude Code hook events flow through a relay (with
-  declarative policy filtering) into the bus and onward to renderers.
+You (the **principal** — the human who owns the deployment) run one or more
+**stacks**: cortex deployments with their own config, signing identity, and
+message-bus namespace. A stack hosts **assistants** — named beings like Luna,
+Echo, or Ivy with a persona and a Discord identity. All communication is
+**envelopes on a NATS message bus**: a Discord mention becomes a signed dispatch
+envelope, an assistant's runtime picks it up, executes it on a substrate
+(usually a Claude Code session), and emits lifecycle events that the chat
+adapter and the dashboard both render. Because the bus — not Discord — is the
+medium, the same work can be dispatched from chat, from the dashboard, from a
+GitHub webhook, or from another agent entirely.
 
-## Status
+Work reaches an assistant in one of three **dispatch modes**:
 
-**MIG-7 complete; v1.0.0 cutover candidate.**
+| Mode | How the recipient is chosen |
+|---|---|
+| **Direct** | You name the assistant (`@echo`); it does the task, one shot. |
+| **Offer** | You publish to a capability (`code-review.typescript`); exactly one capable assistant claims it. |
+| **Delegate** | You name an assistant that orchestrates a multi-step outcome via a multi-agent team. |
 
-Cortex is the destination of the `the-metafactory/grove-v2` → `cortex`
-migration. MIG-7 lands the entrypoint, agent registry, trust resolver, presence
-adapters, renderers, config migration helper, and arc-manifest cutover. The
-next principal-facing milestones:
+## Where cortex sits
 
-- **MIG-7.9** — principal config rename (`~/.config/grove/bot.yaml` →
-  `~/.config/cortex/cortex.yaml`) via the `migrate-config` helper.
-- **MIG-7.13** — final integration test (all adapters connect, dashboard
-  renders, NATS+myelin operational, fixture inbound round-trips).
-- **MIG-7.14** — version bump to **v1.0.0** (per plan §6.3 lean).
-- **MIG-8** — archive `the-metafactory/grove` (legacy v0.29.0) and
-  `the-metafactory/grove-v2` on GitHub.
+cortex is the top layer (M7) of the **Myelin layer model** — an OSI-style stack
+where the protocol layers below are owned by the sibling
+[myelin](https://github.com/the-metafactory/myelin) project:
 
-Until MIG-7.14 lands the version stays at v0.1.0 / v0.2.0. See
-[`docs/plan-cortex-migration.md`](docs/plan-cortex-migration.md) for the
-authoritative phase-by-phase tracker.
+```
+M7  SURFACES      cortex (this repo) · pilot · signal · future apps
+M6  COMPOSITION   myelin — interaction patterns
+M5  DISCOVERY     myelin — capability registry
+M4  IDENTITY      myelin — verifiable sender per envelope
+M3  ENVELOPE      myelin — message format + sovereignty metadata
+M2  TRANSPORT     myelin — abstract bus (NATS underneath)
+M1  CONNECTIVITY  NATS leaf nodes / federation
+```
 
-## Install
+cortex consumes the contracts of M2–M6 and owns none of them. That separation
+is what lets several M7 applications (cortex for collaboration, signal for
+telemetry, pilot for review loops) share one bus without sharing code.
 
-Cortex installs via the metafactory package manager (`arc`):
+The full picture — event architecture, visibility tiers, the agent/assistant
+model, internal componentisation — lives in
+[`docs/architecture.md`](docs/architecture.md). The precise domain vocabulary
+(what exactly a *stack*, *capability*, or *dispatch sink* is) lives in
+[`CONTEXT.md`](CONTEXT.md).
+
+## A small glossary
+
+| Term | Meaning |
+|---|---|
+| **Principal** | The human who owns and runs stacks; root of trust and policy. |
+| **Stack** | One cortex deployment under a principal — own config, signing key, bus namespace. |
+| **Assistant** | The named being (Luna, Echo, Ivy…) with a persona; what you `@mention`. |
+| **Agent** | The long-lived runtime that hosts an assistant on the bus. |
+| **Capability** | A bus-routable ability an assistant declares (`chat`, `code-review.typescript`). |
+| **Envelope** | The signed wrapper every bus message travels in. |
+| **Network** | A federation of principals whose stacks interconnect at the NATS layer. |
+| **Mission Control** | The principal-facing dashboard surface. |
+
+## Getting started
+
+The short version (full procedure in
+[`README-AGENTS.md`](README-AGENTS.md) and
+[`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md)):
 
 ```bash
-arc upgrade Cortex
+# Scaffold a stack config (dry-run by default; --apply writes it)
+cortex stack create mystack --principal yourname --apply
+
+# Fill in the <REPLACE_ME> secrets (Discord token, guild + channel ids)
+$EDITOR ~/.config/cortex/mystack/stacks/mystack.yaml
+
+# Validate, then start
+cortex start --config ~/.config/cortex/mystack/mystack.yaml --dry-run
+cortex start --config ~/.config/cortex/mystack/mystack.yaml
 ```
 
-This is the single command that performs the full cutover from legacy grove
-(if present): it kills any lingering `~/bin/grove-bot` / `~/bin/grove-relay`
-PIDs, unloads + removes the legacy `com.grove.{bot,relay}.plist` launchd
-agents, renders cortex's `ai.meta-factory.cortex.{bot,relay}.plist` into
-`~/Library/LaunchAgents/`, and loads them. See plan §4 MIG-7.7 / MIG-7.8 for
-the lifecycle-script detail.
+Then @mention your assistant in the bound Discord guild and watch it answer.
+The Mission Control dashboard runs at `localhost:8766` locally (hosted
+deployments serve it via Cloudflare).
 
-**Pre-flight (recommended, no longer load-bearing):**
+You will need: [Bun](https://bun.sh), a local
+[NATS server](https://nats.io) with JetStream, a Discord bot token (or
+Mattermost/Slack credentials), and an Anthropic-authenticated Claude Code
+install for the default execution substrate.
 
-```bash
-arc uninstall Grove          # remove legacy if installed
-```
+## What's in this repo
 
-**Verify:**
+| Path | What it is |
+|---|---|
+| `src/cortex.ts` | Top-level entrypoint — wires bus + adapters + runner + taps + renderers. |
+| `src/bus/` | Bus client: NATS connection, envelope validation, subscriptions, routing. |
+| `src/adapters/` | Platform adapters — Discord, Mattermost, Slack presence per assistant. |
+| `src/runner/` | Workflow runner — spawns and supervises Claude Code sessions per conversation. |
+| `src/surface/mc/` | Mission Control — REST/WebSocket API, state DB, React dashboard, CF Worker. |
+| `src/taps/` | Publishers onto the bus — Claude Code hook events, GitHub webhooks. |
+| `src/cli/` | CLIs — `cortex` (stack + network management), `discord` (post/read from terminal). |
+| `src/renderers/` | Dispatch sinks — dashboard renderer, PagerDuty fail-safe. |
+| `docs/` | Architecture spec, design docs, SOPs, ADRs, the config template (`docs/config-layout/`). |
 
-```bash
-launchctl list | grep ai.meta-factory.cortex   # two entries (bot + relay)
-pgrep -f "${HOME}/bin/cortex start"            # non-empty PID
-```
+## Documentation map
 
-## Quick start
+- [`docs/architecture.md`](docs/architecture.md) — canonical architecture reference
+- [`CONTEXT.md`](CONTEXT.md) — domain glossary (one canonical term per concept)
+- [`README-AGENTS.md`](README-AGENTS.md) — install + configure guide for AI agents (and impatient humans)
+- [`docs/config-layout/`](docs/config-layout/) — the copy-and-fill config template
+- [`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md) — stand up a new stack, end to end
+- [`docs/sop-network-join.md`](docs/sop-network-join.md) — federate a stack onto a network
+- [`docs/sop-bus-review.md`](docs/sop-bus-review.md) — the bus code-review path
+- [`docs/design-collaboration-surface.md`](docs/design-collaboration-surface.md) — why a collaboration surface, the framing
 
-```bash
-# Migrate your config from grove-v2 if you had one
-mkdir -p ~/.config/cortex/
-bun src/cli/cortex/commands/migrate-config.ts \
-    ~/.config/grove/bot.yaml > ~/.config/cortex/cortex.yaml
+## Provenance
 
-# Dry-run validates schema + agent registry resolution
-cortex start --config ~/.config/cortex/cortex.yaml --dry-run
-
-# Start cortex (launchd handles this automatically post-install)
-cortex start --config ~/.config/cortex/cortex.yaml
-```
-
-The Mission Control dashboard is at **https://grove.meta-factory.ai** (the
-domain name stays during the cortex cutover for principal continuity; it can be
-renamed post-MIG-8).
-
-From Discord, mention any configured agent in a configured channel and cortex
-routes the message through the workflow runner to a Claude Code session.
-
-From any terminal, post to Discord:
-
-```bash
-discord post "deploy notes here"            # default channel
-discord post --channel tasks "shipping"     # specific channel
-```
-
-From any Claude Code session, instrument events into the dashboard:
-
-```bash
-CORTEX_CHANNEL=andreas CORTEX_AGENT_NAME=Andreas claude
-```
-
-(The `cldyo-live` wrapper at `~/.local/bin/` does this for you.)
-
-## Bus Review Path
-
-Cortex owns the code-review bus consumer. Pilot or sage-shaped publishers send
-`tasks.code-review.*` envelopes to `local.{principal}.{stack}.tasks.code-review.*`;
-Cortex claims them through a JetStream durable, runs the configured review
-substrate, and emits `dispatch.task.started`, `review.verdict.*`, and
-`dispatch.task.completed` with `correlation_id` set to the request envelope id.
-
-Principal checks:
-
-```bash
-arc nats provision-streams --network <principal> --agent <agent>
-nats stream info CODE_REVIEW
-nats consumer info CODE_REVIEW cortex-review-consumer-<principal>-<agent>
-```
-
-Use `bus.review` in `cortex.yaml` to tune stream retention/storage and durable
-redelivery. Keep `nats.subjects: []` for pull-only capability dispatch unless
-you also need broad push-mode fan-out. See
-[`docs/sop-bus-review.md`](docs/sop-bus-review.md).
-
-## Architecture
-
-The canonical architecture spec is
-**[`docs/architecture.md`](docs/architecture.md)** — M1–M7 stack model, agent +
-presence/renderer model, M7 application architecture, agent task routing,
-three-tier visibility, internal componentisation.
-
-cortex is one M7 application among siblings:
-
-```
-M7  cortex (this repo) · pilot · signal · future apps
-M6  Composition (myelin)
-M5  Discovery (myelin)
-M4  Identity (myelin — MY-400)
-M3  Envelope (myelin — schema + namespace)
-M2  Transport (myelin — NATS abstraction)
-M1  Connectivity (NATS)
-```
-
-See `docs/architecture.md` §2 for the layered model and §5 for sibling-app
-context.
-
-Selected design references inside `docs/`:
-
-- `design-collaboration-surface.md` — layer-7 framing + flybridge-cockpit + event architecture
-- `design-mission-control.md` — the mc-v3 dashboard architecture
-- `iteration-collaboration-surface.md` — G-1100..G-1110 ladder retro
-- `design-agent-visibility.md` + `design-github-visibility.md` — visibility tiers
-
-The full `design-*.md` and `iteration-*.md` set is lifted from grove-v2 at
-MIG-7.11.
-
-## Migration provenance
-
-This repo is the destination of the grove-v2 → cortex migration. While the
-migration is in flight (MIG-0 through MIG-8), the migration plan is itself
-load-bearing:
-
-- **[`docs/plan-cortex-migration.md`](docs/plan-cortex-migration.md)** — phase
-  plan, per-file inventory, checklist per phase, acceptance criteria, open
-  questions. Retires when MIG-8 closes.
-
-Once MIG-8 closes (legacy + grove-v2 archived), the migration plan becomes
-historical reference rather than active tracker.
+cortex is the destination of a migration from `the-metafactory/grove-v2` (and
+before that, `grove`), completed through the phased plan in
+[`docs/plan-cortex-migration.md`](docs/plan-cortex-migration.md). You may still
+see `grove` in a few hostnames (the dashboard at `grove.meta-factory.ai`) and
+historical docs; the product is cortex.
 
 ## Contributing
 
-Cortex follows the metafactory ecosystem SOPs maintained in
-[`the-metafactory/compass`](https://github.com/the-metafactory/compass). The
-ones most often activated here:
-
-- `compass/sops/dev-pipeline.md` — branches, PRs, merge flow
-- `compass/sops/worktree-discipline.md` — multi-agent worktree pattern
-- `compass/sops/versioning.md` — version bumps, releases
-- `compass/sops/design-process.md` — specs, design docs, research docs
-- `compass/sops/pr-review.md` — PR review checklist
-- `compass/sops/retrospective-and-process-mining.md` — post-work retros
-
-`CLAUDE.md` at the repo root captures the project-specific rules and is
-**fully generated** by `arc upgrade compass` — never hand-edit.
+cortex follows the metafactory ecosystem SOPs maintained in
+[`the-metafactory/compass`](https://github.com/the-metafactory/compass) —
+branching, PR review, versioning, worktree discipline, design process.
+`CLAUDE.md` at the repo root carries the project rules for AI agents working
+*on* this codebase and is fully generated (`arc upgrade compass`) — never
+hand-edit it.
 
 ## Authors
 
@@ -207,8 +165,8 @@ ones most often activated here:
 
 ## License
 
-[AGPL-3.0-only](LICENSE). cortex is the M7 **reference implementation** of the
+[AGPL-3.0-only](LICENSE). cortex is the M7 reference implementation of the
 metafactory stack; the AGPL's network-use copyleft (§13) keeps modifications
 shared when cortex is run as a service. See
-[`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md) for upstream patterns +
-code incorporated into cortex.
+[`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md) for incorporated upstream
+patterns and code.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ M5  DISCOVERY     myelin — capability registry
 M4  IDENTITY      myelin — verifiable sender per envelope
 M3  ENVELOPE      myelin — message format + sovereignty metadata
 M2  TRANSPORT     myelin — abstract bus (NATS underneath)
-M1  CONNECTIVITY  NATS leaf nodes / federation
+M1  CONNECTIVITY  TCP/TLS · federation topology (NATS leaf nodes)
 ```
 
 cortex consumes the contracts of M2–M6 and owns none of them. That separation
@@ -108,7 +108,7 @@ cortex start --config ~/.config/cortex/mystack/mystack.yaml
 ```
 
 Then @mention your assistant in the bound Discord guild and watch it answer.
-The Mission Control dashboard runs at `localhost:8766` locally (hosted
+The Mission Control dashboard runs at `localhost:8767` locally (hosted
 deployments serve it via Cloudflare).
 
 You will need: [Bun](https://bun.sh), a local

--- a/docs/agents-md/dashboard-deployment.md
+++ b/docs/agents-md/dashboard-deployment.md
@@ -22,7 +22,7 @@ The `build:dashboard` + `watch:dashboard` scripts in `package.json` codify steps
 - The backend (`cortex` bot via `arc upgrade Cortex`) and the frontend (CF Pages via `wrangler`) are deployed independently.
 
 **Architecture:**
-- `cortex` serves the REST API + WebSocket at `localhost:8766` locally, or via the CF Worker at `grove.meta-factory.ai/api/*` in production (`src/surface/mc/worker/`).
+- `cortex` serves the REST API + WebSocket at `localhost:8767` locally, or via the CF Worker at `grove.meta-factory.ai/api/*` in production (`src/surface/mc/worker/`).
 - The dashboard frontend is static HTML/JS hosted on CF Pages.
 - Frontend connects to the API via URL params (`?api=`) or auto-detection.
 - CF Access cookies cover dashboard + API on each TLD (`.ai`, `.dev`, `.io`) — no cross-origin cookie issue, no bypass-everyone policies (see Critical Rules).


### PR DESCRIPTION
## Summary

- **README.md** rewritten as a human-first introduction. The previous version led with migration-phase status (MIG-7.x checklists, grove-v2 cutover detail) that is unintelligible without the development context. New structure: what cortex does in plain language → concrete use cases → one-paragraph mental model (principal / stack / assistant / bus) → dispatch-modes table → Myelin M1–M7 placement → small glossary → quick start → repo layout → docs map. Migration content compressed to a short *Provenance* section.
- **README-AGENTS.md** (new): a deterministic install/configure runbook for AI agents and operators — prerequisites with check commands, install paths (arc vs source), config-split layout with per-file fill instructions, signing identity, isolated-bus stand-up, healthy-boot verification gates, federation summary (operator-mode prerequisite), optional integrations, damage-ranked gotchas table, reference index.

Content sourced from `CONTEXT.md`, `docs/architecture.md`, `docs/sop-stack-onboarding.md`, and `docs/config-layout/README.md` — no invented claims.

## Out of scope / known limitations

- `docs/sop-discord-channel-routing.md` is referenced by the generated `CLAUDE.md` but does not exist in this repo; the new READMEs simply omit the link. Fixing the CLAUDE.md source (`docs/agents-md/`) is a separate change since CLAUDE.md is generated.
- Quick-start commands (`cortex stack create`, `cortex start --dry-run`) are taken verbatim from the existing SOPs/template docs, not re-executed end-to-end in this PR.
- No code changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)