### PR TITLE
feat(mc): G-1114.B.1 — agent-presence envelope builders + signing path

### DIFF
--- a/src/bus/agent-network/__tests__/builders.test.ts
+++ b/src/bus/agent-network/__tests__/builders.test.ts
@@ -1,0 +1,332 @@
+/**
+ * G-1114.B.1 — tests for the `agent.*` presence envelope builders.
+ *
+ * Mirrors the coverage axes of `dispatch-events.test.ts` + the inert-shape
+ * `envelopes.test.ts`:
+ *   1. Shape — each builder sets the right `type`, source triple, sovereignty
+ *      posture; payload carries `identity`/`scope` + the action-specific
+ *      fields; optional fields are OMITTED (not `undefined`-valued) when the
+ *      caller doesn't pass them.
+ *   2. Validation — every constructed envelope passes the vendored myelin
+ *      schema (`validateEnvelope`) AND its payload passes the Phase A cortex
+ *      payload schema (`AGENT_PRESENCE_PAYLOAD_SCHEMAS`).
+ *   3. Subject — the derived subject is EXACTLY
+ *      `local.{principal}.{stack}.agent.{action}` (and the `federated.`
+ *      counterpart with the SAME identity segments — ADR-0001/0007).
+ *   4. Signing path — the builder output is UNSIGNED (`signed_by` absent): the
+ *      stack signs at publish via `runtime.publish`, never in the builder.
+ *
+ * NO producer/subscriber coverage — B.1 ships builders only; nothing wires
+ * them yet (G-1114.B.2/B.3).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  validateEnvelope,
+  deriveNatsSubject,
+  type Classification,
+} from "../../myelin/envelope-validator";
+import {
+  AGENT_ONLINE_TYPE,
+  AGENT_HEARTBEAT_TYPE,
+  AGENT_OFFLINE_TYPE,
+  AGENT_CAPABILITIES_CHANGED_TYPE,
+  AGENT_PRESENCE_PAYLOAD_SCHEMAS,
+} from "../envelopes";
+import {
+  createAgentOnlineEvent,
+  createAgentHeartbeatEvent,
+  createAgentOfflineEvent,
+  createAgentCapabilitiesChangedEvent,
+  type AgentPresenceSource,
+} from "../builders";
+
+const SOURCE: AgentPresenceSource = {
+  principal: "andreas",
+  stack: "meta-factory",
+  instance: "local",
+};
+const IDENTITY = {
+  nkey_public_key: "UABC1234567890",
+  agent_id: "luna",
+  assistant_name: "Luna",
+};
+const SCOPE = { principal: "andreas", stack: "meta-factory" };
+const STARTED_AT = new Date("2026-06-10T09:00:00.000Z");
+const SENT_AT = new Date("2026-06-10T09:05:00.000Z");
+
+/** Stack passed to the publish-side subject derivation (runtime supplies it). */
+const STACK = "meta-factory";
+
+describe("createAgentOnlineEvent", () => {
+  test("required fields populated; envelope + payload pass validation", () => {
+    const env = createAgentOnlineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      capabilities: ["code-review.typescript"],
+      startedAt: STARTED_AT,
+    });
+    expect(env.type).toBe("agent.online");
+    expect(env.source).toBe("andreas.meta-factory.local");
+    expect(env.payload).toMatchObject({
+      identity: IDENTITY,
+      scope: SCOPE,
+      capabilities: ["code-review.typescript"],
+      started_at: "2026-06-10T09:00:00.000Z",
+    });
+    expect(env.sovereignty).toEqual({
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+    AGENT_PRESENCE_PAYLOAD_SCHEMAS[AGENT_ONLINE_TYPE].parse(env.payload);
+  });
+
+  test("capabilities default to empty array when omitted", () => {
+    const env = createAgentOnlineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      startedAt: STARTED_AT,
+    });
+    expect(env.payload.capabilities).toEqual([]);
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("presence envelopes carry NO correlation_id", () => {
+    const env = createAgentOnlineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      startedAt: STARTED_AT,
+    });
+    // ADR-0007 §1 — presence is not correlated lifecycle; only the
+    // dispatch heartbeat (cortex#361) carries a correlation_id.
+    expect(env.correlation_id).toBeUndefined();
+  });
+});
+
+describe("createAgentHeartbeatEvent (presence, not dispatch)", () => {
+  test("liveness-only payload; passes validation", () => {
+    const env = createAgentHeartbeatEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      sentAt: SENT_AT,
+    });
+    expect(env.type).toBe("agent.heartbeat");
+    expect(env.payload).toMatchObject({
+      identity: IDENTITY,
+      scope: SCOPE,
+      sent_at: "2026-06-10T09:05:00.000Z",
+    });
+    // Liveness-only — no capability list, no dispatch progress fields.
+    expect("capabilities" in env.payload).toBe(false);
+    expect("phase" in env.payload).toBe(false);
+    expect("correlation_id" in env.payload).toBe(false);
+    expect(env.correlation_id).toBeUndefined();
+    expect(validateEnvelope(env).ok).toBe(true);
+    AGENT_PRESENCE_PAYLOAD_SCHEMAS[AGENT_HEARTBEAT_TYPE].parse(env.payload);
+  });
+});
+
+describe("createAgentOfflineEvent", () => {
+  test("required fields populated; detail omitted when absent", () => {
+    const env = createAgentOfflineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      reason: "shutdown",
+      sentAt: SENT_AT,
+    });
+    expect(env.type).toBe("agent.offline");
+    expect(env.payload).toMatchObject({
+      identity: IDENTITY,
+      scope: SCOPE,
+      reason: "shutdown",
+      sent_at: "2026-06-10T09:05:00.000Z",
+    });
+    expect("detail" in env.payload).toBe(false);
+    expect(validateEnvelope(env).ok).toBe(true);
+    AGENT_PRESENCE_PAYLOAD_SCHEMAS[AGENT_OFFLINE_TYPE].parse(env.payload);
+  });
+
+  test("detail lands in payload when provided", () => {
+    const env = createAgentOfflineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      reason: "error",
+      detail: "uncaught exception in cc-session",
+      sentAt: SENT_AT,
+    });
+    expect(env.payload.detail).toBe("uncaught exception in cc-session");
+    expect(env.payload.reason).toBe("error");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+});
+
+describe("createAgentCapabilitiesChangedEvent", () => {
+  test("carries the full new set; passes validation", () => {
+    const env = createAgentCapabilitiesChangedEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      capabilities: ["code-review.typescript", "code-review.documentation"],
+      sentAt: SENT_AT,
+    });
+    expect(env.type).toBe("agent.capabilities-changed");
+    expect(env.payload.capabilities).toEqual([
+      "code-review.typescript",
+      "code-review.documentation",
+    ]);
+    expect(env.payload.sent_at).toBe("2026-06-10T09:05:00.000Z");
+    expect(validateEnvelope(env).ok).toBe(true);
+    AGENT_PRESENCE_PAYLOAD_SCHEMAS[AGENT_CAPABILITIES_CHANGED_TYPE].parse(
+      env.payload,
+    );
+  });
+
+  test("capabilities default to empty (all revoked) when omitted", () => {
+    const env = createAgentCapabilitiesChangedEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      sentAt: SENT_AT,
+    });
+    expect(env.payload.capabilities).toEqual([]);
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+});
+
+describe("envelope hygiene shared across all four builders", () => {
+  const make = () => [
+    createAgentOnlineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      startedAt: STARTED_AT,
+    }),
+    createAgentHeartbeatEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      sentAt: SENT_AT,
+    }),
+    createAgentOfflineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      reason: "shutdown",
+      sentAt: SENT_AT,
+    }),
+    createAgentCapabilitiesChangedEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      sentAt: SENT_AT,
+    }),
+  ];
+
+  test("each call returns a fresh UUID id", () => {
+    const a = createAgentOnlineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      startedAt: STARTED_AT,
+    });
+    const b = createAgentOnlineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      startedAt: STARTED_AT,
+    });
+    expect(a.id).not.toBe(b.id);
+    expect(a.id).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+
+  test("builders emit UNSIGNED envelopes — the stack signs at publish, never the builder", () => {
+    // The signing path is `runtime.publish` → `signEnvelope` (stack NKey),
+    // mirroring dispatch-events. The builder must NOT pre-stamp `signed_by[]`.
+    for (const env of make()) {
+      expect(env.signed_by).toBeUndefined();
+    }
+  });
+});
+
+describe("agent-domain subject derivation (local + federated)", () => {
+  const cases: { env: () => ReturnType<typeof createAgentOnlineEvent>; action: string }[] = [
+    {
+      action: "online",
+      env: () =>
+        createAgentOnlineEvent({
+          source: SOURCE,
+          identity: IDENTITY,
+          scope: SCOPE,
+          startedAt: STARTED_AT,
+        }),
+    },
+    {
+      action: "heartbeat",
+      env: () =>
+        createAgentHeartbeatEvent({
+          source: SOURCE,
+          identity: IDENTITY,
+          scope: SCOPE,
+          sentAt: SENT_AT,
+        }),
+    },
+    {
+      action: "offline",
+      env: () =>
+        createAgentOfflineEvent({
+          source: SOURCE,
+          identity: IDENTITY,
+          scope: SCOPE,
+          reason: "shutdown",
+          sentAt: SENT_AT,
+        }),
+    },
+    {
+      action: "capabilities-changed",
+      env: () =>
+        createAgentCapabilitiesChangedEvent({
+          source: SOURCE,
+          identity: IDENTITY,
+          scope: SCOPE,
+          sentAt: SENT_AT,
+        }),
+    },
+  ];
+
+  for (const { action, env } of cases) {
+    test(`local builder derives local.andreas.meta-factory.agent.${action}`, () => {
+      const e = env();
+      expect(deriveNatsSubject(e, STACK)).toBe(
+        `local.andreas.meta-factory.agent.${action}`,
+      );
+    });
+  }
+
+  test("federated classification derives the federated counterpart with the SAME identity segments", () => {
+    // ADR-0001/0007 — the federated subject carries {principal}.{stack},
+    // never a network token; only the scope prefix differs.
+    const classification: Classification = "federated";
+    const env = createAgentOnlineEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      startedAt: STARTED_AT,
+      classification,
+    });
+    expect(env.sovereignty.classification).toBe("federated");
+    expect(validateEnvelope(env).ok).toBe(true);
+    expect(deriveNatsSubject(env, STACK)).toBe(
+      "federated.andreas.meta-factory.agent.online",
+    );
+  });
+});

--- a/src/bus/agent-network/builders.ts
+++ b/src/bus/agent-network/builders.ts
@@ -1,0 +1,297 @@
+/**
+ * G-1114.B.1 — `agent.*` presence envelope builders.
+ *
+ * Phase A (`envelopes.ts`) landed the four INERT presence payload types
+ * (`AgentOnlinePayload`, `AgentHeartbeatPayload`, `AgentOfflinePayload`,
+ * `AgentCapabilitiesChangedPayload`) + their `*_TYPE` constants. This file
+ * adds the **builders** on top: one constructor per presence action that wraps
+ * a payload in the full myelin envelope, ready for `runtime.publish`.
+ *
+ * **Mirrors `src/bus/dispatch-events.ts` exactly:**
+ *   - constructs the envelope via the shared `buildBaseEnvelope` skeleton
+ *     (`src/bus/envelope-builder.ts`) — same `id`/`timestamp`/`payload`/
+ *     `sovereignty` skeleton the `dispatch.task.*` + `system.*` domains use;
+ *   - a thin domain wrapper ({@link buildPresenceEnvelope}) threads the
+ *     presence-specific defaults (source-string assembly, sovereignty posture,
+ *     local|federated scope) so each per-action constructor stays a one-liner;
+ *   - each constructor sets `type: "agent.online"` / `"agent.heartbeat"` / … so
+ *     the subject derives to `{scope}.{principal}.{stack}.agent.{action}` via
+ *     myelin's `deriveSubject` (`deriveNatsSubject` in
+ *     `src/bus/myelin/envelope-validator.ts`). No new subject helper — the
+ *     `agent` domain rides `envelope.type`'s leading segment (ADR-0007).
+ *
+ * **Signing path — NOT in the builder.** Exactly like `dispatch-events.ts`,
+ * these builders produce an UNSIGNED envelope literal. Signing happens at
+ * publish: `MyelinRuntime.publish(envelope)` calls `signEnvelope` with the
+ * stack NKey seed and appends to `signed_by[]` before NATS publish, then
+ * derives the subject via `deriveNatsSubject(envelope, stack)`. The builder
+ * threads NO signer and stamps NO subject — the stack signs on publish. (See
+ * `src/bus/myelin/runtime.ts` `publishEnabled`.)
+ *
+ * **What this file is NOT (B.1 scope):**
+ *   - NOT a producer. Nothing calls these from boot/runtime yet — that is
+ *     G-1114.B.2 (producer wired into the cortex boot lifecycle).
+ *   - NOT a subscriber. The runtime registry subscriber is G-1114.B.3.
+ *   - NOT a signer. Signing is the runtime's job at publish (see above).
+ *   - NOT a renderer. Surfaces consume `agent.*` envelopes downstream.
+ *
+ * Builders are exported + unit-tested only. Inert beyond the builders.
+ */
+
+import type { Classification, Envelope } from "../myelin/envelope-validator";
+import { buildBaseEnvelope as buildSharedEnvelope } from "../envelope-builder";
+import {
+  AGENT_ONLINE_TYPE,
+  AGENT_HEARTBEAT_TYPE,
+  AGENT_OFFLINE_TYPE,
+  AGENT_CAPABILITIES_CHANGED_TYPE,
+  type AgentPresenceIdentity,
+  type AgentPresenceScope,
+  type AgentOfflineReason,
+} from "./envelopes";
+
+/**
+ * Source triple for an `agent.*` presence envelope — the dotted
+ * `envelope.source` (`{principal}.{stack}.{instance}`, exactly 3 segments per
+ * myelin#185). Mirrors `dispatch-events.ts`'s `DispatchEventSource`
+ * (= `SystemEventSource`): `deriveNatsSubject` reads segment[0] as the
+ * `{principal}` for the subject, and the stack-aware publish path supplies
+ * `{stack}` separately, so subject = `{scope}.{principal}.{stack}.agent.{action}`.
+ *
+ * Distinct from the payload's {@link AgentPresenceScope}: `source` is the
+ * envelope-level emitter address (who signed/emitted); `scope` is the
+ * payload-level identity-provenance block a subscriber keys its registry record
+ * on. They carry the same `{principal}`/`{stack}` values for a stack's own
+ * agent, but are separate fields by design (envelope wire address vs payload
+ * descriptor).
+ */
+export interface AgentPresenceSource {
+  /** Boot-resolved `principal.id` — first dotted segment of `envelope.source`. */
+  principal: string;
+  /** The principal's stack slug — second dotted segment of `envelope.source`. */
+  stack: string;
+  /** Stable instance name — usually `local` for in-process emission. */
+  instance: string;
+  /**
+   * Principal residency code stamped into `envelope.sovereignty.data_residency`.
+   * Defaults to `"NZ"` when omitted — same convention as `system-events.ts` /
+   * `dispatch-events.ts`. Principals in other jurisdictions pass their own
+   * ISO-3166-style code.
+   */
+  dataResidency?: string;
+}
+
+function buildSource(src: AgentPresenceSource): string {
+  return `${src.principal}.${src.stack}.${src.instance}`;
+}
+
+/**
+ * Default sovereignty for `agent.*` presence events.
+ *
+ * Same posture as `system.*` / `dispatch.task.*`: principal-only by default
+ * (`classification` defaults to `"local"`), local residency, `max_hop=0`,
+ * `frontier_ok=false`, `model_class="local-only"`. Presence carries identity +
+ * declared capabilities (never session interiors — ADR-0005), so it stays
+ * principal-private unless a caller explicitly opts into `"federated"` to feed
+ * a peer-principal Network view (G-1114.E).
+ *
+ * `data_residency` is sourced from `source.dataResidency` (defaulting to
+ * `"NZ"`). Returned as a fresh literal per call so a downstream mutation on one
+ * envelope's `sovereignty` cannot leak into a sibling envelope. Mirrors
+ * `dispatch-events.ts`'s `defaultDispatchSovereignty`.
+ */
+function defaultPresenceSovereignty(
+  source: AgentPresenceSource,
+  classification: Classification = "local",
+): Envelope["sovereignty"] {
+  return {
+    classification,
+    data_residency: source.dataResidency ?? "NZ",
+    max_hop: 0,
+    frontier_ok: false,
+    model_class: "local-only",
+  };
+}
+
+/**
+ * Fields every `agent.*` presence builder carries — the envelope emitter
+ * `source` triple plus the payload identity + scope blocks, and the optional
+ * scope classification. Spelled out as an interface so each per-action option
+ * type can `extends AgentPresenceCommonOpts` without redeclaring + drifting.
+ *
+ * Mirrors `dispatch-events.ts`'s `DispatchTaskCommonOpts` shape (common fields
+ * factored out, per-action extras added by each constructor's own opts type).
+ *
+ * Note — no `correlationId`: presence envelopes are NOT correlated lifecycle
+ * events (there is no task to stitch). The dispatch heartbeat (cortex#361)
+ * carries a `correlation_id`; this presence protocol deliberately does not
+ * (ADR-0007 §1 — two differently-scoped heartbeats by design).
+ */
+export interface AgentPresenceCommonOpts {
+  /** Envelope emitter address — assembled into `envelope.source`. */
+  source: AgentPresenceSource;
+  /** Payload identity block — the logical agent identity a subscriber keys on. */
+  identity: AgentPresenceIdentity;
+  /** Payload scope block — `{principal}.{stack}` identity provenance. */
+  scope: AgentPresenceScope;
+  /**
+   * Optional sovereignty classification. Defaults to `"local"`
+   * (principal-private). Set to `"federated"` when a presence envelope should
+   * reach peer principals' Network views (G-1114.E). A mismatch with the
+   * publish-time subject prefix is a protocol violation (the runtime's
+   * `validateSubjectEnvelopeAlignment` catches it).
+   */
+  classification?: Classification;
+}
+
+/**
+ * Domain-specific wrapper around `buildSharedEnvelope` (from
+ * `bus/envelope-builder.ts`). Threads presence-specific defaults: sovereignty
+ * posture + source-string assembly + the shared `identity`/`scope` payload
+ * head. Each per-action constructor passes only its action-specific payload
+ * extras.
+ *
+ * The shared helper handles the `id`/`timestamp`/`payload`/`sovereignty`
+ * skeleton; this thin wrapper exists so each `agent.*` constructor doesn't
+ * repeat the source-build + sovereignty + identity/scope boilerplate. Exactly
+ * the `buildBaseEnvelope` role in `dispatch-events.ts`.
+ *
+ * No `correlation_id` is set — see {@link AgentPresenceCommonOpts}.
+ */
+function buildPresenceEnvelope(
+  type: string,
+  common: AgentPresenceCommonOpts,
+  payloadExtras: Record<string, unknown>,
+): Envelope {
+  return buildSharedEnvelope({
+    type,
+    source: buildSource(common.source),
+    sovereignty: defaultPresenceSovereignty(common.source, common.classification),
+    payload: {
+      identity: common.identity,
+      scope: common.scope,
+      ...payloadExtras,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// agent.online
+// ---------------------------------------------------------------------------
+
+export interface AgentOnlineOpts extends AgentPresenceCommonOpts {
+  /**
+   * Capability ids the agent advertises at boot. Defaults to `[]` when
+   * omitted (the payload field defaults to an empty set per ADR-0007 §3).
+   */
+  capabilities?: string[];
+  /** When the agent process booted. */
+  startedAt: Date;
+}
+
+/**
+ * Construct an `agent.online` envelope per ADR-0007.
+ *
+ * Emitted once on agent boot. Carries the full presence descriptor: identity,
+ * scope, the INITIAL capability set (superseding the boot-time
+ * `agents.capabilities.registered` announce — ADR-0007 §3), and the boot time.
+ * Derives `{scope}.{principal}.{stack}.agent.online` on publish.
+ */
+export function createAgentOnlineEvent(opts: AgentOnlineOpts): Envelope {
+  return buildPresenceEnvelope(AGENT_ONLINE_TYPE, opts, {
+    capabilities: opts.capabilities ?? [],
+    started_at: opts.startedAt.toISOString(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// agent.heartbeat
+// ---------------------------------------------------------------------------
+
+export interface AgentHeartbeatOpts extends AgentPresenceCommonOpts {
+  /** When this heartbeat was emitted. */
+  sentAt: Date;
+}
+
+/**
+ * Construct an `agent.heartbeat` envelope per ADR-0007 §1.
+ *
+ * Emitted on a fixed interval while the agent is up (idle or not). This is the
+ * PRESENCE heartbeat — liveness ONLY: no capability list (that rides
+ * `agent.online` / `agent.capabilities-changed`) and NO `correlation_id` /
+ * `phase` (that is the dispatch-scoped `system.agent.heartbeat`'s shape,
+ * cortex#361 — NOT this one). Derives
+ * `{scope}.{principal}.{stack}.agent.heartbeat` on publish.
+ */
+export function createAgentHeartbeatEvent(opts: AgentHeartbeatOpts): Envelope {
+  return buildPresenceEnvelope(AGENT_HEARTBEAT_TYPE, opts, {
+    sent_at: opts.sentAt.toISOString(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// agent.offline
+// ---------------------------------------------------------------------------
+
+export interface AgentOfflineOpts extends AgentPresenceCommonOpts {
+  /** Why the agent went offline — `shutdown` / `restart` / `error`. */
+  reason: AgentOfflineReason;
+  /**
+   * Optional human-readable detail (e.g. the error message for `error`).
+   * OMITTED from the payload (not an empty string) when not provided — same
+   * absent-optional discipline as `dispatch-events.ts`'s `result_summary`.
+   */
+  detail?: string;
+  /** When the offline was emitted. */
+  sentAt: Date;
+}
+
+/**
+ * Construct an `agent.offline` envelope per ADR-0007.
+ *
+ * Emitted on graceful shutdown / restart, or on an abnormal-but-announced exit
+ * (`error`). A subscriber's liveness FSM transitions the record to `offline`
+ * immediately on receipt (vs waiting out the TTL). A TTL-lapse offline is
+ * inferred by the subscriber and never rides an `agent.offline` envelope (no
+ * agent left to send one). Derives `{scope}.{principal}.{stack}.agent.offline`.
+ */
+export function createAgentOfflineEvent(opts: AgentOfflineOpts): Envelope {
+  return buildPresenceEnvelope(AGENT_OFFLINE_TYPE, opts, {
+    reason: opts.reason,
+    ...(opts.detail !== undefined && { detail: opts.detail }),
+    sent_at: opts.sentAt.toISOString(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// agent.capabilities-changed
+// ---------------------------------------------------------------------------
+
+export interface AgentCapabilitiesChangedOpts extends AgentPresenceCommonOpts {
+  /**
+   * The agent's FULL new steady-state capability set (not a diff) so a
+   * subscriber that missed an earlier delta still converges. Defaults to `[]`
+   * (all capabilities revoked) when omitted.
+   */
+  capabilities?: string[];
+  /** When the capability change was emitted. */
+  sentAt: Date;
+}
+
+/**
+ * Construct an `agent.capabilities-changed` envelope per ADR-0007 §3.
+ *
+ * Emitted when an agent's advertised capability set changes mid-life (plugin
+ * loaded, permission granted/revoked). Carries the FULL new steady-state set
+ * (the subscriber computes the diff against its current record). Supersedes
+ * mid-life re-emission of `agents.capabilities.registered`. Derives
+ * `{scope}.{principal}.{stack}.agent.capabilities-changed`.
+ */
+export function createAgentCapabilitiesChangedEvent(
+  opts: AgentCapabilitiesChangedOpts,
+): Envelope {
+  return buildPresenceEnvelope(AGENT_CAPABILITIES_CHANGED_TYPE, opts, {
+    capabilities: opts.capabilities ?? [],
+    sent_at: opts.sentAt.toISOString(),
+  });
+}


### PR DESCRIPTION
## What

First slice of **Phase B** of the Agent Network Topology umbrella (#355). Adds the four `agent.*` presence envelope **builders** on top of the Phase A inert payload types (`src/bus/agent-network/envelopes.ts`, landed in #893).

- `createAgentOnlineEvent`, `createAgentHeartbeatEvent`, `createAgentOfflineEvent`, `createAgentCapabilitiesChangedEvent` in a new sibling `src/bus/agent-network/builders.ts`.
- **Mirrors `src/bus/dispatch-events.ts` exactly:** each builder wraps its payload in the full myelin envelope via the shared `buildBaseEnvelope` skeleton (`src/bus/envelope-builder.ts`) through a thin `buildPresenceEnvelope` domain wrapper — same shape as dispatch-events' `buildBaseEnvelope` (source-string assembly + sovereignty posture + shared payload head).
- Each sets `type: "agent.{action}"`, so the subject derives to `{scope}.{principal}.{stack}.agent.{action}` via myelin's `deriveNatsSubject`. No new subject helper — the `agent` domain rides `envelope.type`'s leading segment (per the A review + ADR-0007).
- Sovereignty posture matches `system.*` / `dispatch.task.*`: `local` by default (principal-private), `data_residency` from `source.dataResidency` (default `NZ`), `max_hop=0`, `frontier_ok=false`, `model_class=local-only`. Opt into `federated` for a peer-principal Network view (G-1114.E).

## Signing path

Signing is **NOT** in the builder. Builders emit an **UNSIGNED** envelope literal; the stack NKey signs at publish via `MyelinRuntime.publish` → `signEnvelope` (which also derives the subject via `deriveNatsSubject(envelope, stack)`). Identical to dispatch-events — confirmed against `src/bus/myelin/runtime.ts`.

## Heartbeat shape

The presence heartbeat is **liveness-only** — no `correlation_id` / `phase` (that is the dispatch-scoped `system.agent.heartbeat`'s shape, cortex#361, asserted by the A review — NOT this one).

## Scope (B.1 only)

- **NO producer** — nothing calls these from boot/runtime yet (G-1114.B.2).
- **NO subscriber** — runtime registry is G-1114.B.3.
- Builders are exported + unit-tested only. Inert beyond the builders.

## Test plan

`src/bus/agent-network/__tests__/builders.test.ts` (mirrors `dispatch-events.test.ts` + the A `envelopes.test.ts`):

- Each builder sets the right `type` / source triple / sovereignty; payload carries `identity`/`scope` + action fields.
- Every envelope round-trips through `validateEnvelope` AND its Phase A payload schema (`AGENT_PRESENCE_PAYLOAD_SCHEMAS`).
- Derived subject is exactly `local.{principal}.{stack}.agent.{action}` and the `federated.` counterpart with the SAME identity segments (ADR-0001/0007).
- Absent optional fields omitted (not `undefined`); fresh UUID `id` per call; **no `signed_by[]`** on builder output (the stack signs at publish).

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (27 pre-existing warnings in untouched files)
- `bun test` — 5514 pass / 0 fail (42 in agent-network)
- `bash scripts/check-carveouts.sh` on changed files — PASS (never bare `operator`, never `{org}`)

refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)