### PR TITLE
feat(mc): G-1114.B.2+B.3 — live agent-presence producer + runtime registry (stack-local)

### DIFF
--- a/src/__tests__/cortex.agent-presence-boot.test.ts
+++ b/src/__tests__/cortex.agent-presence-boot.test.ts
@@ -1,0 +1,194 @@
+/**
+ * G-1114.B.2 + B.3 — agent-presence producer + registry boot/shutdown wiring.
+ *
+ * Asserts the boot lifecycle integration in `startCortex`:
+ *
+ *   1. Gated ON (`config.mc.enabled: true`) → one `agent.online` per hosted
+ *      agent goes out on boot, carrying that agent's capabilities; the registry
+ *      subscriber self-subscribes to the stack-local `agent.>` pattern.
+ *   2. Gated OFF (`config.mc.enabled: false`) → NO `agent.*` envelopes.
+ *   3. Shutdown → `agent.offline` (reason: shutdown) publishes for every agent
+ *      BEFORE the runtime closes (ordering: offline lands while the recording
+ *      runtime is still accepting publishes, i.e. before `runtime.stop`).
+ *
+ * Mirrors the `cortex.capability-boot.test.ts` harness (NATS-absent recording
+ * runtime, inline agents, headless presence). The recording runtime records the
+ * order of `publish` vs `stop` so we can assert offline-before-close.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import type { Agent, AgentRuntime } from "../common/types/cortex-config";
+import { startCortex } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+
+function minimalConfig(overrides: Record<string, unknown> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-presence-test-published" },
+    ...overrides,
+  });
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+  subscribedPatterns: string[];
+  /** True once `stop()` has been called — lets tests assert publish-before-close. */
+  stopped: boolean;
+  /** Envelope types published AFTER `stop()` was called (should be empty). */
+  publishedAfterStop: string[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const handlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const subscribedPatterns: string[] = [];
+  const publishedAfterStop: string[] = [];
+  const fakeSubscriber: MyelinSubscriber = {
+    stop: () => Promise.resolve(),
+  } as unknown as MyelinSubscriber;
+  const rt: RecordingRuntime = {
+    enabled: true,
+    published,
+    subscribedPatterns,
+    stopped: false,
+    publishedAfterStop,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: (envelope: Envelope) => {
+      if (rt.stopped) publishedAfterStop.push(envelope.type);
+      published.push(envelope);
+      return Promise.resolve();
+    },
+    subscribe: (pattern: string) => {
+      subscribedPatterns.push(pattern);
+      return Promise.resolve(fakeSubscriber);
+    },
+    stop: () => {
+      rt.stopped = true;
+      return Promise.resolve();
+    },
+  };
+  return rt;
+}
+
+function makeAgent(id: string, capabilities: readonly string[]): Agent {
+  const runtime: AgentRuntime = {
+    substrate: "claude-code",
+    mode: "in-process",
+    capabilities: [...capabilities],
+  };
+  return {
+    id,
+    displayName: id.charAt(0).toUpperCase() + id.slice(1),
+    persona: `/tmp/${id}-persona.md`,
+    trust: [],
+    presence: {},
+    // A per-agent NKey so the presence identity resolves without a stack key.
+    nkey_pub: "UA" + id.toUpperCase().padEnd(54, "X"),
+    runtime,
+  };
+}
+
+const presenceTypes = (envs: Envelope[]): string[] =>
+  envs.map((e) => e.type).filter((t) => t.startsWith("agent."));
+
+describe("startCortex — agent-presence boot/shutdown (G-1114.B.2+B.3)", () => {
+  test("gated ON: agent.online per agent on boot + registry self-subscribes", async () => {
+    const runtime = createRecordingRuntime();
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-on-"));
+    const handle = await startCortex(
+      minimalConfig({ mc: { enabled: true, configPath: "", dbPath: "", port: 0 } }),
+      {
+        disableConfigWatcher: true,
+        disableDashboard: true, // skip the HTTP embed; presence still runs
+        disableOutboundPoller: true,
+        agentsDir: tmp,
+        injectRuntime: runtime,
+        inlineAgents: [
+          makeAgent("luna", ["code-review.typescript"]),
+          makeAgent("echo", ["research"]),
+        ],
+        principal: { id: "andreas" },
+      },
+    );
+
+    const onlines = runtime.published.filter((e) => e.type === "agent.online");
+    expect(onlines.length).toBe(2);
+    // Each carries its agent's capabilities.
+    const luna = onlines.find(
+      (e) => (e.payload as { identity: { agent_id: string } }).identity.agent_id === "luna",
+    );
+    expect((luna!.payload as { capabilities: string[] }).capabilities).toEqual([
+      "code-review.typescript",
+    ]);
+    // Stack-local subject (default-derived stack = "default").
+    expect(luna!.sovereignty.classification).toBe("local");
+    // Registry self-subscribed to the stack-local agent.> pattern.
+    expect(runtime.subscribedPatterns).toContain("local.andreas.default.agent.>");
+
+    await handle.stop();
+  });
+
+  test("gated OFF: no agent.* envelopes when mc.enabled is false", async () => {
+    const runtime = createRecordingRuntime();
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-off-"));
+    const handle = await startCortex(
+      minimalConfig({ mc: { enabled: false, configPath: "", dbPath: "", port: 0 } }),
+      {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmp,
+        injectRuntime: runtime,
+        inlineAgents: [makeAgent("luna", ["code-review.typescript"])],
+        principal: { id: "andreas" },
+      },
+    );
+    expect(presenceTypes(runtime.published)).toEqual([]);
+    expect(runtime.subscribedPatterns).not.toContain("local.andreas.default.agent.>");
+    await handle.stop();
+  });
+
+  test("shutdown: agent.offline publishes for every agent BEFORE runtime close", async () => {
+    const runtime = createRecordingRuntime();
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-shutdown-"));
+    const handle = await startCortex(
+      minimalConfig({ mc: { enabled: true, configPath: "", dbPath: "", port: 0 } }),
+      {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmp,
+        injectRuntime: runtime,
+        inlineAgents: [
+          makeAgent("luna", ["code-review.typescript"]),
+          makeAgent("echo", ["research"]),
+        ],
+        principal: { id: "andreas" },
+      },
+    );
+
+    await handle.stop();
+
+    const offlines = runtime.published.filter((e) => e.type === "agent.offline");
+    expect(offlines.length).toBe(2);
+    for (const off of offlines) {
+      expect((off.payload as { reason: string }).reason).toBe("shutdown");
+    }
+    // Ordering: every agent.offline landed BEFORE runtime.stop() ran. The
+    // recording runtime flags any publish that arrives after `stopped` — no
+    // agent.offline may appear there.
+    expect(runtime.publishedAfterStop).not.toContain("agent.offline");
+  });
+});

--- a/src/bus/agent-network/__tests__/registry.test.ts
+++ b/src/bus/agent-network/__tests__/registry.test.ts
@@ -1,0 +1,339 @@
+/**
+ * G-1114.B.3 — runtime agent-presence registry (subscriber) tests.
+ *
+ * Coverage axes:
+ *   1. Fold — a scripted online/heartbeat/offline/capabilities-changed stream
+ *      produces the correct snapshot via `getAgents()`.
+ *   2. Heartbeat-before-online — an unknown agent's heartbeat upserts it online.
+ *   3. Change seam — `onChange` fires after each mutation with the new record.
+ *   4. Malformed payload — dropped (not thrown), snapshot unchanged.
+ *   5. Boundary — B records `lastHeartbeatAt` but NEVER times anything out
+ *      (no TTL/FSM; Phase C).
+ *   6. Wiring — `startAgentPresenceRegistry` self-subscribes + filters by
+ *      subject; dormant when the runtime can't subscribe; `stop()` idempotent.
+ */
+
+import { describe, expect, test, mock } from "bun:test";
+import {
+  AgentPresenceRegistry,
+  agentPresenceSubject,
+  startAgentPresenceRegistry,
+} from "../registry";
+import {
+  createAgentOnlineEvent,
+  createAgentHeartbeatEvent,
+  createAgentOfflineEvent,
+  createAgentCapabilitiesChangedEvent,
+  type AgentPresenceSource,
+} from "../builders";
+import type { Envelope } from "../../myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../../myelin/runtime";
+import type { MyelinSubscriber } from "../../myelin/subscriber";
+
+const SOURCE: AgentPresenceSource = {
+  principal: "andreas",
+  stack: "meta-factory",
+  instance: "local",
+};
+const IDENTITY = {
+  nkey_public_key: "UABC1234567890",
+  agent_id: "luna",
+  assistant_name: "Luna",
+};
+const SCOPE = { principal: "andreas", stack: "meta-factory" };
+
+function online(caps: string[] = ["code-review.typescript"]): Envelope {
+  return createAgentOnlineEvent({
+    source: SOURCE,
+    identity: IDENTITY,
+    scope: SCOPE,
+    capabilities: caps,
+    startedAt: new Date("2026-06-10T09:00:00.000Z"),
+  });
+}
+function heartbeat(): Envelope {
+  return createAgentHeartbeatEvent({
+    source: SOURCE,
+    identity: IDENTITY,
+    scope: SCOPE,
+    sentAt: new Date("2026-06-10T09:05:00.000Z"),
+  });
+}
+function offline(): Envelope {
+  return createAgentOfflineEvent({
+    source: SOURCE,
+    identity: IDENTITY,
+    scope: SCOPE,
+    reason: "shutdown",
+    sentAt: new Date("2026-06-10T09:10:00.000Z"),
+  });
+}
+
+describe("AgentPresenceRegistry.apply", () => {
+  test("online → record present, online, capabilities + startedAt stored", () => {
+    let clock = 1000;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    clock = 2000;
+    reg.apply(online(["code-review.typescript", "research"]));
+    const agents = reg.getAgents();
+    expect(agents.length).toBe(1);
+    expect(agents[0]).toMatchObject({
+      key: "andreas/meta-factory/luna",
+      agentId: "luna",
+      nkeyPublicKey: "UABC1234567890",
+      assistantName: "Luna",
+      principal: "andreas",
+      stack: "meta-factory",
+      capabilities: ["code-review.typescript", "research"],
+      state: "online",
+      startedAt: "2026-06-10T09:00:00.000Z",
+      lastSeenAt: 2000,
+    });
+  });
+
+  test("scripted online→heartbeat→offline yields the correct final snapshot", () => {
+    let clock = 0;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    clock = 100;
+    reg.apply(online());
+    clock = 200;
+    reg.apply(heartbeat());
+    clock = 300;
+    reg.apply(offline());
+    const [rec] = reg.getAgents();
+    expect(rec?.state).toBe("offline");
+    expect(rec?.offlineReason).toBe("shutdown");
+    // heartbeat was recorded along the way and survives the offline.
+    expect(rec?.lastHeartbeatAt).toBe(200);
+    expect(rec?.lastSeenAt).toBe(300);
+  });
+
+  test("heartbeat bumps lastHeartbeatAt without losing capabilities", () => {
+    let clock = 0;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    clock = 100;
+    reg.apply(online(["research"]));
+    clock = 250;
+    reg.apply(heartbeat());
+    const [rec] = reg.getAgents();
+    expect(rec?.capabilities).toEqual(["research"]);
+    expect(rec?.lastHeartbeatAt).toBe(250);
+    expect(rec?.state).toBe("online");
+  });
+
+  test("heartbeat for an UNKNOWN agent upserts it online (liveness signal)", () => {
+    const clock = 500;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    reg.apply(heartbeat());
+    const [rec] = reg.getAgents();
+    expect(rec?.state).toBe("online");
+    expect(rec?.agentId).toBe("luna");
+    expect(rec?.capabilities).toEqual([]);
+    expect(rec?.lastHeartbeatAt).toBe(500);
+  });
+
+  test("online after offline clears the offline reason (re-online)", () => {
+    const reg = new AgentPresenceRegistry();
+    reg.apply(online());
+    reg.apply(offline());
+    expect(reg.getAgents()[0]?.state).toBe("offline");
+    reg.apply(online());
+    const [rec] = reg.getAgents();
+    expect(rec?.state).toBe("online");
+    expect(rec?.offlineReason).toBeUndefined();
+  });
+
+  test("capabilities-changed stores the latest full set (B: latest only)", () => {
+    const reg = new AgentPresenceRegistry();
+    reg.apply(online(["research"]));
+    reg.apply(
+      createAgentCapabilitiesChangedEvent({
+        source: SOURCE,
+        identity: IDENTITY,
+        scope: SCOPE,
+        capabilities: ["research", "code-review.typescript"],
+        sentAt: new Date("2026-06-10T09:07:00.000Z"),
+      }),
+    );
+    expect(reg.getAgents()[0]?.capabilities).toEqual([
+      "research",
+      "code-review.typescript",
+    ]);
+    // state unchanged — capabilities-changed does not assert liveness.
+    expect(reg.getAgents()[0]?.state).toBe("online");
+  });
+
+  test("getAgents returns COPIES — caller mutation does not corrupt state", () => {
+    const reg = new AgentPresenceRegistry();
+    reg.apply(online(["research"]));
+    const snap = reg.getAgents();
+    (snap[0] as { state: string }).state = "offline";
+    expect(reg.getAgents()[0]?.state).toBe("online");
+  });
+
+  test("B records lastHeartbeatAt but NEVER expires a record (no TTL/FSM)", () => {
+    let clock = 0;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    clock = 100;
+    reg.apply(online());
+    clock = 100 + 10 * 60_000; // 10 minutes later — well past the 5-min TTL
+    // No reaper in B: the record stays online until an explicit offline.
+    expect(reg.getAgents()[0]?.state).toBe("online");
+  });
+
+  test("malformed payload is dropped, not thrown; snapshot unchanged", () => {
+    const reg = new AgentPresenceRegistry();
+    reg.apply(online());
+    const bad = { ...heartbeat(), payload: { not: "a heartbeat" } } as Envelope;
+    expect(() => reg.apply(bad)).not.toThrow();
+    expect(reg.apply(bad)).toBeNull();
+    expect(reg.getAgents().length).toBe(1);
+    expect(reg.getAgents()[0]?.state).toBe("online");
+  });
+
+  test("non-presence envelope type is ignored", () => {
+    const reg = new AgentPresenceRegistry();
+    const notPresence: Envelope = { ...online(), type: "system.foo" };
+    expect(reg.apply(notPresence)).toBeNull();
+    expect(reg.getAgents().length).toBe(0);
+  });
+});
+
+describe("AgentPresenceRegistry.onChange", () => {
+  test("fires after each mutation with the affected key + new record", () => {
+    const reg = new AgentPresenceRegistry();
+    const seen: { key: string; state: string }[] = [];
+    const sub = reg.onChange((key, rec) => {
+      seen.push({ key, state: rec.state });
+    });
+    reg.apply(online());
+    reg.apply(offline());
+    expect(seen).toEqual([
+      { key: "andreas/meta-factory/luna", state: "online" },
+      { key: "andreas/meta-factory/luna", state: "offline" },
+    ]);
+    sub.unsubscribe();
+    reg.apply(online());
+    // No further events after unsubscribe.
+    expect(seen.length).toBe(2);
+  });
+
+  test("a throwing listener does not break sibling listeners or apply", () => {
+    const reg = new AgentPresenceRegistry();
+    let secondFired = false;
+    reg.onChange(() => {
+      throw new Error("boom");
+    });
+    reg.onChange(() => {
+      secondFired = true;
+    });
+    expect(() => reg.apply(online())).not.toThrow();
+    expect(secondFired).toBe(true);
+    expect(reg.getAgents().length).toBe(1);
+  });
+});
+
+describe("agentPresenceSubject", () => {
+  test("derives the stack-local agent.> pattern (no federated)", () => {
+    expect(agentPresenceSubject("andreas", "meta-factory")).toBe(
+      "local.andreas.meta-factory.agent.>",
+    );
+  });
+});
+
+// --- wiring -----------------------------------------------------------------
+
+interface FakeRuntime extends MyelinRuntime {
+  fire(envelope: Envelope, subject: string): void;
+  subscribedPatterns: string[];
+}
+
+function makeFakeRuntime(opts: { enabled?: boolean; canSubscribe?: boolean } = {}): FakeRuntime {
+  const enabled = opts.enabled ?? true;
+  const canSubscribe = opts.canSubscribe ?? true;
+  const handlers = new Set<EnvelopeHandler>();
+  const subscribedPatterns: string[] = [];
+  const subscriberStop = mock(() => Promise.resolve());
+  const fakeSubscriber: MyelinSubscriber = {
+    stop: subscriberStop,
+  } as unknown as MyelinSubscriber;
+  return {
+    enabled,
+    subscribedPatterns,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: () => Promise.resolve(),
+    stop: () => Promise.resolve(),
+    subscribe: (pattern: string) => {
+      subscribedPatterns.push(pattern);
+      return Promise.resolve(canSubscribe ? fakeSubscriber : null);
+    },
+    fire(envelope, subject) {
+      for (const h of handlers) h(envelope, subject);
+    },
+  };
+}
+
+describe("startAgentPresenceRegistry (wiring)", () => {
+  test("self-subscribes to the stack-local pattern + folds matching envelopes", async () => {
+    const runtime = makeFakeRuntime();
+    const handle = await startAgentPresenceRegistry({
+      runtime,
+      principal: "andreas",
+      stack: "meta-factory",
+    });
+    expect(runtime.subscribedPatterns).toEqual([
+      "local.andreas.meta-factory.agent.>",
+    ]);
+    // Fire an online envelope on the matching subject.
+    runtime.fire(online(), "local.andreas.meta-factory.agent.online");
+    expect(handle.registry.getAgents().length).toBe(1);
+    expect(handle.registry.getAgents()[0]?.state).toBe("online");
+    await handle.stop();
+  });
+
+  test("filters out envelopes on non-matching subjects", async () => {
+    const runtime = makeFakeRuntime();
+    const handle = await startAgentPresenceRegistry({
+      runtime,
+      principal: "andreas",
+      stack: "meta-factory",
+    });
+    // A different stack's subject must not land in this stack's registry.
+    runtime.fire(online(), "local.andreas.other-stack.agent.online");
+    expect(handle.registry.getAgents().length).toBe(0);
+    // A federated subject is NOT subscribed in B (Phase E).
+    runtime.fire(online(), "federated.andreas.meta-factory.agent.online");
+    expect(handle.registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("dormant when runtime cannot push-subscribe (returns null)", async () => {
+    const runtime = makeFakeRuntime({ enabled: true, canSubscribe: false });
+    const handle = await startAgentPresenceRegistry({
+      runtime,
+      principal: "andreas",
+      stack: "meta-factory",
+    });
+    // Still constructed + queryable; onEnvelope still folds (the fan-out is
+    // independent of the self-subscribe).
+    expect(handle.registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("stop() is idempotent + unregisters the fan-out handler", async () => {
+    const runtime = makeFakeRuntime();
+    const handle = await startAgentPresenceRegistry({
+      runtime,
+      principal: "andreas",
+      stack: "meta-factory",
+    });
+    await handle.stop();
+    await handle.stop(); // no throw
+    // After stop, fan-out is unregistered — new fires are ignored.
+    runtime.fire(online(), "local.andreas.meta-factory.agent.online");
+    expect(handle.registry.getAgents().length).toBe(0);
+  });
+});

--- a/src/bus/agent-network/registry.ts
+++ b/src/bus/agent-network/registry.ts
@@ -1,0 +1,448 @@
+/**
+ * G-1114.B.3 — stack-local runtime agent-presence registry (subscriber).
+ *
+ * The consumer half of the Phase B end-to-end wiring. It subscribes to the
+ * stack's own `local.{principal}.{stack}.agent.>` subtree (STACK-LOCAL ONLY —
+ * NO `federated.` namespace yet; that is Phase E / G-1114.E) and folds the
+ * inbound `agent.*` presence stream into an in-memory, observable map keyed by
+ * agent identity.
+ *
+ * ## What it records (B.3 scope)
+ *
+ *   - `agent.online`               → upsert a record, `state: "online"`, store
+ *                                    the initial capability set + `startedAt`.
+ *   - `agent.heartbeat`            → bump `lastHeartbeatAt` (+ refresh `lastSeenAt`);
+ *                                    an unknown agent is upserted as `online`
+ *                                    (a heartbeat is itself a liveness signal —
+ *                                    we never want a heartbeat from an agent we
+ *                                    missed the `online` for to be dropped).
+ *   - `agent.offline`              → mark the record `state: "offline"`, store
+ *                                    the reason.
+ *   - `agent.capabilities-changed` → store the latest full capability set
+ *                                    (B records the LATEST set only; the full
+ *                                    diff/reconcile handling is Phase C).
+ *
+ * ## Boundary — what it does NOT do (deferred to Phase C / G-1114.C)
+ *
+ *   - **No liveness FSM / TTL expiry.** B records `lastHeartbeatAt` + the last
+ *     explicit state only. The 5-minute liveness TTL → `offline` transition
+ *     (a record going stale because heartbeats STOPPED, with no `agent.offline`
+ *     envelope) is Phase C's reaper. B never times anything out — a record stays
+ *     `online` until an explicit `agent.offline` arrives. This is the
+ *     deliberate B/C split (ADR-0007 §Consequences: "the liveness FSM … TTL
+ *     lapse" is its own line item).
+ *   - **No capability diffing.** B stores the latest set; C computes the delta
+ *     against the prior record + reconciles.
+ *   - **No federation.** B subscribes to `local.` only. The `federated.`
+ *     subtree is Phase E.
+ *
+ * ## Observability seam (for B.4 + the MC API)
+ *
+ * The registry is queryable via {@link AgentPresenceRegistry.getAgents} (a
+ * snapshot copy — callers can't mutate internal state) and exposes a
+ * change-notification seam via {@link AgentPresenceRegistry.onChange} so the
+ * B.4 panel (and the MC projection) can subscribe to live updates rather than
+ * poll. Every applied envelope that mutates a record fires the change callbacks
+ * AFTER the mutation, with the affected agent key + the new snapshot.
+ *
+ * ## Wiring
+ *
+ * `startAgentPresenceRegistry` self-subscribes via `runtime.subscribe(pattern)`
+ * (the cortex#477 push-mode seam — same model the dispatch-listener uses) and
+ * registers a `runtime.onEnvelope` fan-out handler that filters by subject
+ * against the stack-local pattern. On `runtime.enabled === false` (no NATS) the
+ * registry stays dormant but constructed — `getAgents()` returns `[]` and the
+ * boot/shutdown wiring behaves identically whether or not the bus is up
+ * (matching every other capability-side boot feature).
+ */
+
+import type { Envelope } from "../myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../myelin/runtime";
+import type { MyelinSubscriber } from "../myelin/subscriber";
+import { subjectMatches } from "../surface-router";
+import {
+  AGENT_ONLINE_TYPE,
+  AGENT_HEARTBEAT_TYPE,
+  AGENT_OFFLINE_TYPE,
+  AGENT_CAPABILITIES_CHANGED_TYPE,
+  AgentOnlinePayloadSchema,
+  AgentHeartbeatPayloadSchema,
+  AgentOfflinePayloadSchema,
+  AgentCapabilitiesChangedPayloadSchema,
+  type AgentOfflineReason,
+} from "./envelopes";
+
+/**
+ * The observable presence state for one agent. Keyed in the registry by
+ * {@link AgentPresenceRecord.key} (`{principal}/{stack}/{agent_id}` — see
+ * {@link recordKey}).
+ *
+ * `state` carries only what B observes from explicit envelopes: an agent is
+ * `online` after `agent.online` / `agent.heartbeat`, `offline` after an
+ * explicit `agent.offline`. There is deliberately NO `"stale"`/TTL-derived
+ * state in B — that transition is Phase C's liveness FSM.
+ */
+export interface AgentPresenceRecord {
+  /** Stable map key — `{principal}/{stack}/{agent_id}`. */
+  key: string;
+  /** Logical agent id (`luna`, `echo`, …). */
+  agentId: string;
+  /** The agent's NKey public key (stable cross-restart identity). */
+  nkeyPublicKey: string;
+  /** Soma-layer assistant name the agent hosts, or `null` when none. */
+  assistantName: string | null;
+  /** `{principal}` the agent lives in. */
+  principal: string;
+  /** `{stack}` the agent lives in. */
+  stack: string;
+  /** Latest known declared capability set. */
+  capabilities: readonly string[];
+  /** Last explicit liveness state observed from an envelope. */
+  state: "online" | "offline";
+  /** Reason from the last `agent.offline`, when `state === "offline"`. */
+  offlineReason?: AgentOfflineReason;
+  /** Boot time from the last `agent.online` (ISO-8601), when known. */
+  startedAt?: string;
+  /**
+   * Timestamp of the last `agent.heartbeat` observed (epoch ms, receiver
+   * clock). Phase C's TTL reaper reads this; B only records it. Undefined
+   * until the first heartbeat arrives.
+   */
+  lastHeartbeatAt?: number;
+  /** Timestamp any presence envelope was last applied for this agent (epoch ms). */
+  lastSeenAt: number;
+}
+
+/** A change callback — invoked AFTER a record mutates, with the new snapshot. */
+export type AgentPresenceChangeListener = (
+  key: string,
+  record: AgentPresenceRecord,
+) => void;
+
+/** Unregister handle returned by {@link AgentPresenceRegistry.onChange}. */
+export interface AgentPresenceChangeSubscription {
+  unsubscribe(): void;
+}
+
+/**
+ * Compute the stable registry key for an identity+scope pair.
+ * `{principal}/{stack}/{agent_id}` — the same agent in two stacks is two
+ * records; the same agent_id across restarts is one record (state converges).
+ */
+function recordKey(principal: string, stack: string, agentId: string): string {
+  return `${principal}/${stack}/${agentId}`;
+}
+
+/** Optional injection points — tests pass a clock; production omits. */
+export interface AgentPresenceRegistryOptions {
+  /** Receiver clock for `lastHeartbeatAt` / `lastSeenAt`. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * In-memory observable agent-presence registry. Pure state + a fold over the
+ * `agent.*` envelope stream — no bus wiring of its own (that is
+ * {@link startAgentPresenceRegistry}'s job). Unit-testable by feeding
+ * envelopes to {@link apply} directly.
+ */
+export class AgentPresenceRegistry {
+  private readonly records = new Map<string, AgentPresenceRecord>();
+  private readonly listeners = new Set<AgentPresenceChangeListener>();
+  private readonly now: () => number;
+
+  constructor(opts: AgentPresenceRegistryOptions = {}) {
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Apply one presence envelope to the registry. Best-effort: an envelope
+   * whose payload fails the Phase A schema is logged + dropped (a malformed
+   * presence envelope must never throw into the bus fan-out path). Returns the
+   * mutated record, or `null` when the envelope was dropped (bad payload /
+   * non-presence type).
+   */
+  apply(envelope: Envelope): AgentPresenceRecord | null {
+    switch (envelope.type) {
+      case AGENT_ONLINE_TYPE:
+        return this.applyOnline(envelope);
+      case AGENT_HEARTBEAT_TYPE:
+        return this.applyHeartbeat(envelope);
+      case AGENT_OFFLINE_TYPE:
+        return this.applyOffline(envelope);
+      case AGENT_CAPABILITIES_CHANGED_TYPE:
+        return this.applyCapabilitiesChanged(envelope);
+      default:
+        // Not a presence envelope — the subject filter should have excluded
+        // it, but be defensive (the fan-out delivers every matching envelope).
+        return null;
+    }
+  }
+
+  private applyOnline(envelope: Envelope): AgentPresenceRecord | null {
+    const parsed = AgentOnlinePayloadSchema.safeParse(envelope.payload);
+    if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
+    const p = parsed.data;
+    const key = recordKey(p.scope.principal, p.scope.stack, p.identity.agent_id);
+    const ts = this.now();
+    const existing = this.records.get(key);
+    const record: AgentPresenceRecord = {
+      key,
+      agentId: p.identity.agent_id,
+      nkeyPublicKey: p.identity.nkey_public_key,
+      assistantName: p.identity.assistant_name,
+      principal: p.scope.principal,
+      stack: p.scope.stack,
+      capabilities: p.capabilities,
+      state: "online",
+      startedAt: p.started_at,
+      // online clears any prior offline reason (an online agent is not
+      // offline) but preserves a prior heartbeat timestamp if one exists.
+      ...(existing?.lastHeartbeatAt !== undefined && {
+        lastHeartbeatAt: existing.lastHeartbeatAt,
+      }),
+      lastSeenAt: ts,
+    };
+    this.records.set(key, record);
+    this.emit(key, record);
+    return record;
+  }
+
+  private applyHeartbeat(envelope: Envelope): AgentPresenceRecord | null {
+    const parsed = AgentHeartbeatPayloadSchema.safeParse(envelope.payload);
+    if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
+    const p = parsed.data;
+    const key = recordKey(p.scope.principal, p.scope.stack, p.identity.agent_id);
+    const ts = this.now();
+    const existing = this.records.get(key);
+    // An unknown agent's heartbeat is itself a liveness signal — upsert it as
+    // online rather than drop it (we may have missed the `online`). It carries
+    // no capability list, so capabilities default to [] until an online /
+    // capabilities-changed fills them.
+    const record: AgentPresenceRecord = {
+      key,
+      agentId: p.identity.agent_id,
+      nkeyPublicKey: p.identity.nkey_public_key,
+      assistantName: p.identity.assistant_name,
+      principal: p.scope.principal,
+      stack: p.scope.stack,
+      capabilities: existing?.capabilities ?? [],
+      state: "online",
+      ...(existing?.startedAt !== undefined && { startedAt: existing.startedAt }),
+      lastHeartbeatAt: ts,
+      lastSeenAt: ts,
+    };
+    this.records.set(key, record);
+    this.emit(key, record);
+    return record;
+  }
+
+  private applyOffline(envelope: Envelope): AgentPresenceRecord | null {
+    const parsed = AgentOfflinePayloadSchema.safeParse(envelope.payload);
+    if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
+    const p = parsed.data;
+    const key = recordKey(p.scope.principal, p.scope.stack, p.identity.agent_id);
+    const ts = this.now();
+    const existing = this.records.get(key);
+    const record: AgentPresenceRecord = {
+      key,
+      agentId: p.identity.agent_id,
+      nkeyPublicKey: p.identity.nkey_public_key,
+      assistantName: p.identity.assistant_name,
+      principal: p.scope.principal,
+      stack: p.scope.stack,
+      capabilities: existing?.capabilities ?? [],
+      state: "offline",
+      offlineReason: p.reason,
+      ...(existing?.startedAt !== undefined && { startedAt: existing.startedAt }),
+      ...(existing?.lastHeartbeatAt !== undefined && {
+        lastHeartbeatAt: existing.lastHeartbeatAt,
+      }),
+      lastSeenAt: ts,
+    };
+    this.records.set(key, record);
+    this.emit(key, record);
+    return record;
+  }
+
+  private applyCapabilitiesChanged(envelope: Envelope): AgentPresenceRecord | null {
+    const parsed = AgentCapabilitiesChangedPayloadSchema.safeParse(envelope.payload);
+    if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
+    const p = parsed.data;
+    const key = recordKey(p.scope.principal, p.scope.stack, p.identity.agent_id);
+    const ts = this.now();
+    const existing = this.records.get(key);
+    // B stores the LATEST capability set only. The diff/reconcile (against the
+    // prior set) is Phase C — here we just converge to the new full set.
+    const record: AgentPresenceRecord = {
+      key,
+      agentId: p.identity.agent_id,
+      nkeyPublicKey: p.identity.nkey_public_key,
+      assistantName: p.identity.assistant_name,
+      principal: p.scope.principal,
+      stack: p.scope.stack,
+      capabilities: p.capabilities,
+      // capabilities-changed does not assert liveness state; preserve the
+      // prior state (default online — an agent emitting it is alive).
+      state: existing?.state ?? "online",
+      ...(existing?.offlineReason !== undefined && {
+        offlineReason: existing.offlineReason,
+      }),
+      ...(existing?.startedAt !== undefined && { startedAt: existing.startedAt }),
+      ...(existing?.lastHeartbeatAt !== undefined && {
+        lastHeartbeatAt: existing.lastHeartbeatAt,
+      }),
+      lastSeenAt: ts,
+    };
+    this.records.set(key, record);
+    this.emit(key, record);
+    return record;
+  }
+
+  private dropMalformed(envelope: Envelope, err: unknown): null {
+    // Per CLAUDE.md "no empty catch blocks" — log + drop. A malformed presence
+    // payload is an observability gap, never a reason to throw into the bus
+    // fan-out (which would take down delivery for every other handler).
+    process.stderr.write(
+      `agent-presence-registry: dropping malformed ${envelope.type} envelope ` +
+        `(id=${envelope.id}): ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return null;
+  }
+
+  private emit(key: string, record: AgentPresenceRecord): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(key, record);
+      } catch (err) {
+        // A listener throwing must not break sibling listeners or the apply
+        // path. Log + continue.
+        process.stderr.write(
+          `agent-presence-registry: change listener threw (key=${key}): ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Snapshot of every known agent record. Returns COPIES so callers can't
+   * mutate internal state. Order is insertion order (Map semantics).
+   */
+  getAgents(): AgentPresenceRecord[] {
+    return Array.from(this.records.values()).map((r) => ({ ...r }));
+  }
+
+  /** Look up a single record by key, or `undefined`. Returns a copy. */
+  getAgent(key: string): AgentPresenceRecord | undefined {
+    const r = this.records.get(key);
+    return r ? { ...r } : undefined;
+  }
+
+  /**
+   * Register a change listener. Fires AFTER each record mutation with the
+   * affected key + the new (post-mutation) record. Returns an unsubscribe
+   * handle. B.4 + the MC projection use this to push live updates.
+   */
+  onChange(listener: AgentPresenceChangeListener): AgentPresenceChangeSubscription {
+    this.listeners.add(listener);
+    return {
+      unsubscribe: () => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+}
+
+/**
+ * Subject pattern the registry subscribes to — STACK-LOCAL ONLY.
+ * `local.{principal}.{stack}.agent.>` — the `>` matches every presence action
+ * (`online`/`heartbeat`/`offline`/`capabilities-changed`). The `federated.`
+ * counterpart is deliberately NOT subscribed (Phase E).
+ */
+export function agentPresenceSubject(principal: string, stack: string): string {
+  return `local.${principal}.${stack}.agent.>`;
+}
+
+/** Lifecycle handle for the wired registry. */
+export interface AgentPresenceRegistryHandle {
+  /** The observable store — `getAgents()` / `onChange()` for downstream. */
+  readonly registry: AgentPresenceRegistry;
+  /**
+   * Stop the subscriber: unregister the fan-out handler + drain the
+   * push subscriber. Idempotent. The in-memory store survives stop (a stopped
+   * registry just stops receiving updates).
+   */
+  stop(): Promise<void>;
+}
+
+/** Options for {@link startAgentPresenceRegistry}. */
+export interface StartAgentPresenceRegistryOptions {
+  runtime: MyelinRuntime;
+  /** Boot-resolved `{principal}` — the subject's second segment. */
+  principal: string;
+  /** Resolved `{stack}` — the subject's third segment. */
+  stack: string;
+  /** Optional pre-constructed registry (tests). Production constructs one. */
+  registry?: AgentPresenceRegistry;
+  /** Injected clock, forwarded to a freshly-constructed registry (tests). */
+  now?: () => number;
+}
+
+/**
+ * Wire the registry into the running cortex. Self-subscribes to the
+ * stack-local `agent.>` subtree (cortex#477 push-mode seam) and registers a
+ * fan-out handler that filters matching envelopes into the registry's `apply`.
+ *
+ * NON-THROWING / best-effort, matching every other capability-side boot
+ * feature: a subscribe failure logs + leaves the registry dormant (still
+ * constructed + queryable, just not receiving). When `runtime.enabled` is false
+ * (no NATS) the subscriber stays dormant.
+ */
+export async function startAgentPresenceRegistry(
+  opts: StartAgentPresenceRegistryOptions,
+): Promise<AgentPresenceRegistryHandle> {
+  const registry =
+    opts.registry ??
+    new AgentPresenceRegistry(opts.now !== undefined ? { now: opts.now } : {});
+  const pattern = agentPresenceSubject(opts.principal, opts.stack);
+
+  const handler: EnvelopeHandler = (envelope, subject) => {
+    if (!subjectMatches(pattern, subject)) return;
+    registry.apply(envelope);
+  };
+  const registration = opts.runtime.onEnvelope(handler);
+
+  // cortex#477 push-mode self-subscribe. `subscribe` is optional on the
+  // interface; treat undefined as "runtime can't push-subscribe" (dormant).
+  let subscriber: MyelinSubscriber | null = null;
+  try {
+    subscriber = (await opts.runtime.subscribe?.(pattern)) ?? null;
+    if (opts.runtime.enabled && subscriber === null) {
+      process.stderr.write(
+        `agent-presence-registry: runtime.subscribe(${pattern}) returned null — ` +
+          `registry will only see envelopes from other static subscriptions\n`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write(
+      `agent-presence-registry: subscribe(${pattern}) failed (non-fatal — registry dormant): ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+
+  let stopped = false;
+  return {
+    registry,
+    stop: async (): Promise<void> => {
+      if (stopped) return;
+      stopped = true;
+      registration.unregister();
+      // The runtime tracks `subscribe()` subscribers and drains them on
+      // `runtime.stop()`, but we stop ours explicitly so a listener-scoped
+      // teardown (tests, hot-reload) doesn't wait for full runtime shutdown.
+      if (subscriber) {
+        await subscriber.stop();
+      }
+    },
+  };
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -119,6 +119,18 @@ import type { Surfaces } from "./common/types/surfaces";
 import type { SurfaceGateway } from "./gateway/surface-gateway";
 
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
+// G-1114.B.2 — live agent-presence producer (online/heartbeat/offline) wired
+// into boot. G-1114.B.3 — the runtime registry subscriber it feeds.
+import {
+  AgentPresenceProducer,
+  presenceAgentFromAgent,
+  DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS,
+  type PresenceAgent,
+} from "./runner/agent-presence-producer";
+import {
+  startAgentPresenceRegistry,
+  type AgentPresenceRegistryHandle,
+} from "./bus/agent-network/registry";
 import { createProbeResponder, type ProbeResponder } from "./bus/probe-responder";
 import { WorklogManager } from "./runner/worklog-manager";
 
@@ -3107,6 +3119,91 @@ export async function startCortex(
     }
   }
 
+  // G-1114.B.2 + B.3 — live agent-presence producer + runtime registry
+  // subscriber (STACK-LOCAL ONLY — no federation; that is Phase E).
+  //
+  // Gated on `config.mc.enabled` — presence is the data the B.4 agents panel +
+  // the MC API render, so it only runs when MC is wanted. The producer and
+  // subscriber share this gate so they stay consistent (a stack that records
+  // presence also emits it, and vice-versa). Both are best-effort: a fault
+  // logs + boot continues.
+  //
+  // Independent of `disableDashboard`: the producer + registry are pure bus
+  // wiring (no MC DB / no HTTP port), so they run on the same `mc.enabled`
+  // signal even when the embed itself is skipped (e.g. tests that disable the
+  // HTTP embed but still want the presence roundtrip).
+  //
+  //   - The REGISTRY subscriber starts FIRST so it's listening before the
+  //     producer's own `agent.online` envelopes go out (the roundtrip lands the
+  //     hosted agents in the registry immediately).
+  //   - The PRODUCER then publishes one `agent.online` per hosted agent
+  //     (carrying its capabilities) + starts the heartbeat ticker.
+  //
+  // `runtime.publish` is a no-op when the runtime is dormant (no NATS), so this
+  // is safe to run without a bus — the producer simply emits into the void and
+  // the registry stays empty.
+  //
+  // FSM/TTL boundary: the registry records `lastHeartbeatAt` + last explicit
+  // state ONLY. The 5-min liveness-TTL → offline reaper is Phase C (G-1114.C),
+  // not wired here.
+  let presenceRegistryHandle: AgentPresenceRegistryHandle | null = null;
+  let presenceProducer: AgentPresenceProducer | null = null;
+  if (config.mc.enabled) {
+    try {
+      presenceRegistryHandle = await startAgentPresenceRegistry({
+        runtime,
+        principal: principalId,
+        stack: derivedStack.stack,
+      });
+      // Build the per-agent presence descriptors. The stack's own NKey pubkey
+      // (captured when the signer was staged) is the fallback identity for any
+      // agent that hasn't declared its own `nkey_pub`. Agents with no resolvable
+      // key are skipped (the presence payload requires a non-empty key).
+      const presenceAgents: PresenceAgent[] = [];
+      let skippedNoKey = 0;
+      for (const a of mergedAgents) {
+        const pa = presenceAgentFromAgent(
+          a,
+          { principal: principalId, stack: derivedStack.stack },
+          stackNKeyPubForVerifier,
+        );
+        if (pa === null) {
+          skippedNoKey += 1;
+          continue;
+        }
+        presenceAgents.push(pa);
+      }
+      if (skippedNoKey > 0) {
+        console.warn(
+          `cortex: agent-presence — ${skippedNoKey} agent(s) skipped (no agent.nkey_pub ` +
+            `and no stack NKey to fall back to); they will not appear in the presence registry`,
+        );
+      }
+      presenceProducer = new AgentPresenceProducer({
+        runtime,
+        source: {
+          principal: principalId,
+          stack: derivedStack.stack,
+          instance: "local",
+          ...(config.agent.dataResidency !== undefined && {
+            dataResidency: config.agent.dataResidency,
+          }),
+        },
+        agents: presenceAgents,
+      });
+      presenceProducer.start();
+      console.log(
+        `cortex: agent-presence producer + registry started — ${presenceAgents.length} agent(s) announced ` +
+          `(stack-local; heartbeat every ${DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS}ms)`,
+      );
+    } catch (err) {
+      console.error(
+        "cortex: agent-presence producer/registry startup error (non-fatal):",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
   // G-1113 ML.5 — cockpit live-refresh loop. Opt-in via `config.cockpit.enabled`;
   // runs refreshCockpit (ingest → reconcile) on an interval and publishes
   // `system.attention.*` notifications via the bus (the review-sink renders them
@@ -3289,6 +3386,11 @@ export async function startCortex(
     const rendererStopNames = renderers.map((r) => `renderer ${r.id} stop`);
     const allSlots: string[] = [
       "config-watcher stop",
+      // G-1114.B.2 — publish agent.offline for every hosted agent BEFORE the
+      // runtime closes (the offline publish is a no-op once the runtime is
+      // down), then stop the B.3 registry subscriber.
+      "agent-presence producer stop (offline publish)",
+      "agent-presence registry stop",
       "cockpit refresh loop stop",
       "mc embed stop",
       "github webhook receiver stop",
@@ -3334,6 +3436,18 @@ export async function startCortex(
 
     const drain = async (): Promise<void> => {
       completeSync("config-watcher stop", () => configWatcher?.stop());
+      // G-1114.B.2 — publish agent.offline (reason: shutdown) for every hosted
+      // agent FIRST, while the runtime/bus is still up. `stop()` awaits the
+      // offline publishes so they go out before any later step (and well before
+      // `runtime stop`). Then stop the registry subscriber.
+      await completeAsync(
+        "agent-presence producer stop (offline publish)",
+        presenceProducer?.stop("shutdown"),
+      );
+      await completeAsync(
+        "agent-presence registry stop",
+        presenceRegistryHandle?.stop(),
+      );
       // Await the cockpit loop's stop BEFORE the embed's stop: stop() now awaits
       // any in-flight refreshCockpit tick, so the bun:sqlite handle the embed
       // closes is only released after the last tick settles (no use-after-close).

--- a/src/runner/__tests__/agent-presence-producer.test.ts
+++ b/src/runner/__tests__/agent-presence-producer.test.ts
@@ -1,0 +1,333 @@
+/**
+ * G-1114.B.2 — agent-presence producer tests.
+ *
+ * Coverage axes:
+ *   1. Boot — `start()` publishes one `agent.online` per agent, carrying
+ *      identity + capabilities; the derived subject is the stack-local
+ *      `local.{principal}.{stack}.agent.online`.
+ *   2. Heartbeat — the injectable scheduler fires `agent.heartbeat` per agent
+ *      per tick (NOT immediately — online already announced at t=0).
+ *   3. Shutdown — `stop()` clears the ticker + publishes `agent.offline`
+ *      (reason: shutdown) per agent; idempotent.
+ *   4. Roundtrip — producer output → registry → snapshot shows the agent online
+ *      (through the real builders + validator + registry).
+ *   5. Mapping — `presenceAgentFromAgent` derives identity/scope/caps from an
+ *      Agent; falls back to the stack key; skips when no key resolvable.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  AgentPresenceProducer,
+  presenceAgentFromAgent,
+  DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS,
+  type PresenceAgent,
+  type PresenceScheduler,
+} from "../agent-presence-producer";
+import { AgentPresenceRegistry } from "../../bus/agent-network/registry";
+import {
+  deriveNatsSubject,
+  validateEnvelope,
+  type Envelope,
+} from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { Agent } from "../../common/types/cortex-config";
+
+const SOURCE = { principal: "andreas", stack: "meta-factory", instance: "local" };
+
+const AGENT_A: PresenceAgent = {
+  identity: { nkey_public_key: "UAAA", agent_id: "luna", assistant_name: "Luna" },
+  scope: { principal: "andreas", stack: "meta-factory" },
+  capabilities: ["code-review.typescript"],
+};
+const AGENT_B: PresenceAgent = {
+  identity: { nkey_public_key: "UBBB", agent_id: "echo", assistant_name: "Echo" },
+  scope: { principal: "andreas", stack: "meta-factory" },
+  capabilities: ["research"],
+};
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+}
+function recordingRuntime(): RecordingRuntime {
+  const published: Envelope[] = [];
+  return {
+    enabled: true,
+    published,
+    onEnvelope: () => ({ unregister: () => {} }),
+    publish: (env: Envelope) => {
+      published.push(env);
+      return Promise.resolve();
+    },
+    stop: () => Promise.resolve(),
+  };
+}
+
+/** Controllable scheduler — `tick()` fires the registered interval handler. */
+function manualScheduler(): PresenceScheduler & { tick(): void; cleared: boolean } {
+  let handler: (() => void) | null = null;
+  let cleared = false;
+  return {
+    setInterval: (h: () => void) => {
+      handler = h;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    },
+    clearInterval: () => {
+      cleared = true;
+      handler = null;
+    },
+    tick: () => {
+      if (handler) handler();
+    },
+    get cleared() {
+      return cleared;
+    },
+  };
+}
+
+describe("AgentPresenceProducer.start", () => {
+  test("publishes one agent.online per agent with capabilities", () => {
+    const runtime = recordingRuntime();
+    const sched = manualScheduler();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A, AGENT_B],
+      scheduler: sched,
+      now: () => new Date("2026-06-10T09:00:00.000Z"),
+    });
+    producer.start();
+    const onlines = runtime.published.filter((e) => e.type === "agent.online");
+    expect(onlines.length).toBe(2);
+    const luna = onlines.find(
+      (e) => (e.payload as { identity: { agent_id: string } }).identity.agent_id === "luna",
+    );
+    expect(luna).toBeDefined();
+    expect((luna!.payload as { capabilities: string[] }).capabilities).toEqual([
+      "code-review.typescript",
+    ]);
+    expect((luna!.payload as { started_at: string }).started_at).toBe(
+      "2026-06-10T09:00:00.000Z",
+    );
+    // Subject derivation — stack-local agent.online.
+    expect(deriveNatsSubject(luna!, "meta-factory")).toBe(
+      "local.andreas.meta-factory.agent.online",
+    );
+    expect(validateEnvelope(luna!).ok).toBe(true);
+  });
+
+  test("does NOT publish a heartbeat at t=0 (online already announced)", () => {
+    const runtime = recordingRuntime();
+    const sched = manualScheduler();
+    new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: sched,
+    }).start();
+    expect(runtime.published.filter((e) => e.type === "agent.heartbeat").length).toBe(0);
+  });
+
+  test("empty roster: no publishes, no scheduled ticker", () => {
+    const runtime = recordingRuntime();
+    const sched = manualScheduler();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [],
+      scheduler: sched,
+    });
+    producer.start();
+    expect(runtime.published.length).toBe(0);
+    sched.tick(); // no handler registered → no-op
+    expect(runtime.published.length).toBe(0);
+  });
+
+  test("double start() is ignored", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    producer.start();
+    expect(runtime.published.filter((e) => e.type === "agent.online").length).toBe(1);
+  });
+});
+
+describe("AgentPresenceProducer heartbeat ticker", () => {
+  test("each tick publishes agent.heartbeat per agent", async () => {
+    const runtime = recordingRuntime();
+    const sched = manualScheduler();
+    new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A, AGENT_B],
+      scheduler: sched,
+      now: () => new Date("2026-06-10T09:01:00.000Z"),
+    }).start();
+    sched.tick();
+    const hbs = runtime.published.filter((e) => e.type === "agent.heartbeat");
+    expect(hbs.length).toBe(2);
+    expect(deriveNatsSubject(hbs[0]!, "meta-factory")).toBe(
+      "local.andreas.meta-factory.agent.heartbeat",
+    );
+    // Let the prior batch's allSettled().finally() clear the backpressure
+    // guard (it resolves on the microtask queue), then the next tick → four.
+    await new Promise((r) => setTimeout(r, 0));
+    sched.tick();
+    expect(runtime.published.filter((e) => e.type === "agent.heartbeat").length).toBe(4);
+  });
+
+  test("backpressure: a tick is skipped while the prior batch is in flight", () => {
+    const runtime = recordingRuntime();
+    const sched = manualScheduler();
+    new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A, AGENT_B],
+      scheduler: sched,
+    }).start();
+    // Two synchronous ticks with no microtask flush between → the second is
+    // skipped (the first batch hasn't settled). Only one batch's worth emits.
+    sched.tick();
+    sched.tick();
+    expect(runtime.published.filter((e) => e.type === "agent.heartbeat").length).toBe(2);
+  });
+
+  test("default interval is 60s, well under the 5-min liveness TTL", () => {
+    expect(DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS).toBe(60_000);
+    expect(DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS).toBeLessThan(5 * 60_000);
+  });
+});
+
+describe("AgentPresenceProducer.stop", () => {
+  test("clears the ticker + publishes agent.offline per agent", async () => {
+    const runtime = recordingRuntime();
+    const sched = manualScheduler();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A, AGENT_B],
+      scheduler: sched,
+    });
+    producer.start();
+    await producer.stop("shutdown");
+    expect(sched.cleared).toBe(true);
+    const offlines = runtime.published.filter((e) => e.type === "agent.offline");
+    expect(offlines.length).toBe(2);
+    expect((offlines[0]!.payload as { reason: string }).reason).toBe("shutdown");
+    // Ticker is stopped — a post-stop tick publishes nothing new.
+    const before = runtime.published.length;
+    sched.tick();
+    expect(runtime.published.length).toBe(before);
+  });
+
+  test("stop() is idempotent — no duplicate offline", async () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    await producer.stop();
+    await producer.stop();
+    expect(runtime.published.filter((e) => e.type === "agent.offline").length).toBe(1);
+  });
+});
+
+describe("producer → registry roundtrip", () => {
+  test("online output folds into the registry as an online agent", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    // Feed the real produced envelope through the real registry.
+    const registry = new AgentPresenceRegistry();
+    for (const env of runtime.published) registry.apply(env);
+    const [rec] = registry.getAgents();
+    expect(rec?.agentId).toBe("luna");
+    expect(rec?.state).toBe("online");
+    expect(rec?.capabilities).toEqual(["code-review.typescript"]);
+    expect(rec?.assistantName).toBe("Luna");
+  });
+
+  test("online → heartbeat → offline roundtrip ends offline", async () => {
+    const runtime = recordingRuntime();
+    const sched = manualScheduler();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: sched,
+    });
+    producer.start();
+    sched.tick();
+    await producer.stop("shutdown");
+    const registry = new AgentPresenceRegistry();
+    for (const env of runtime.published) registry.apply(env);
+    const [rec] = registry.getAgents();
+    expect(rec?.state).toBe("offline");
+    expect(rec?.offlineReason).toBe("shutdown");
+  });
+});
+
+describe("presenceAgentFromAgent", () => {
+  const baseAgent = (over: Partial<Agent> = {}): Agent => ({
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    trust: [],
+    presence: {},
+    ...over,
+  });
+
+  test("maps id→agent_id, displayName→assistant_name, runtime caps→capabilities", () => {
+    const pa = presenceAgentFromAgent(
+      baseAgent({
+        nkey_pub: "UAGENTKEY",
+        runtime: {
+          substrate: "claude-code",
+          mode: "in-process",
+          capabilities: ["code-review.typescript", "research"],
+        },
+      }),
+      { principal: "andreas", stack: "meta-factory" },
+      "USTACKKEY",
+    );
+    expect(pa).not.toBeNull();
+    expect(pa!.identity).toEqual({
+      nkey_public_key: "UAGENTKEY",
+      agent_id: "luna",
+      assistant_name: "Luna",
+    });
+    expect(pa!.scope).toEqual({ principal: "andreas", stack: "meta-factory" });
+    expect(pa!.capabilities).toEqual(["code-review.typescript", "research"]);
+  });
+
+  test("falls back to the stack NKey when the agent declares none", () => {
+    const pa = presenceAgentFromAgent(
+      baseAgent(),
+      { principal: "andreas", stack: "meta-factory" },
+      "USTACKKEY",
+    );
+    expect(pa?.identity.nkey_public_key).toBe("USTACKKEY");
+    expect(pa?.capabilities).toEqual([]);
+  });
+
+  test("returns null when no key resolvable (agent + stack both absent)", () => {
+    const pa = presenceAgentFromAgent(
+      baseAgent(),
+      { principal: "andreas", stack: "meta-factory" },
+      undefined,
+    );
+    expect(pa).toBeNull();
+  });
+});

--- a/src/runner/agent-presence-producer.ts
+++ b/src/runner/agent-presence-producer.ts
@@ -1,0 +1,335 @@
+/**
+ * G-1114.B.2 — live agent-presence PRODUCER, wired into the cortex boot
+ * lifecycle.
+ *
+ * The producer half of the Phase B end-to-end wiring. For each hosted agent
+ * (an `Agent` from the assembled registry) it:
+ *
+ *   1. publishes ONE `agent.online` on boot — carrying the agent's identity
+ *      (`agent_id` + assistant name + NKey pubkey) and its declared
+ *      CAPABILITIES (the same `runtime.capabilities[]` used for dispatch
+ *      routing, ADR-0007 §3);
+ *   2. starts a presence HEARTBEAT ticker — publishes `agent.heartbeat` per
+ *      agent on a fixed interval ({@link DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS},
+ *      well under the ADR-0007 5-minute liveness TTL);
+ *   3. on graceful shutdown, publishes `agent.offline` (reason: `shutdown`) per
+ *      agent BEFORE the runtime/bus tears down (the boot wiring registers
+ *      {@link AgentPresenceProducer.stop} in the cortex.ts shutdown drain ahead
+ *      of `runtime stop`).
+ *
+ * **Mirrors `src/runner/heartbeat-ticker.ts`** — the dispatch HeartbeatTicker's
+ * interval-publish + injectable-scheduler + idempotent-stop pattern — but it is
+ * a SEPARATE, presence-scoped ticker. It publishes the PRESENCE `agent.heartbeat`
+ * (`"agent.heartbeat"`, from `bus/agent-network/builders.ts`), NEVER the
+ * dispatch `system.agent.heartbeat`. The two heartbeats are differently-scoped
+ * by design (ADR-0007 §1): presence = "process up, idle or not"; dispatch =
+ * "task in flight, keyed by correlation_id".
+ *
+ * **STACK-LOCAL ONLY.** Every envelope is `classification: "local"` (the
+ * builders default), so subjects derive to `local.{principal}.{stack}.agent.*`.
+ * Federation (`federated.` scope feeding peer Network views) is Phase E.
+ *
+ * **Non-throwing / best-effort.** A publish failure (NATS hiccup, signer fault)
+ * is logged to stderr and swallowed — a presence-producer fault must never
+ * crash boot or shutdown. `runtime.publish` itself is a no-op when the runtime
+ * is disabled (no NATS), so the producer is safe to run unconditionally; the
+ * boot wiring still gates it behind the presence flag for clarity + to skip the
+ * ticker churn when presence isn't wanted.
+ */
+
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import {
+  createAgentOnlineEvent,
+  createAgentHeartbeatEvent,
+  createAgentOfflineEvent,
+  type AgentPresenceSource,
+} from "../bus/agent-network/builders";
+import type {
+  AgentPresenceIdentity,
+  AgentPresenceScope,
+} from "../bus/agent-network/envelopes";
+import type { Agent } from "../common/types/cortex-config";
+
+/**
+ * Default presence-heartbeat interval — 60 s.
+ *
+ * Chosen WELL under the ADR-0007 5-minute (300 s) liveness TTL so Phase C's
+ * reaper sees ~5 heartbeats per TTL window: a single dropped heartbeat (one
+ * NATS hiccup) never flips an agent offline. 60 s also keeps envelope volume
+ * modest for an idle stack (one envelope/agent/minute) — lower than the
+ * dispatch ticker's 30 s because presence is liveness-only, not progress.
+ *
+ * Not config-driven in B: a module constant keeps the B surface minimal. If a
+ * future need to tune it per-stack arises, it would land on BOTH
+ * `AgentConfigSchema` AND `CortexConfigSchema` (cortex#877 dual-schema rule) —
+ * deliberately NOT added speculatively here.
+ */
+export const DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS = 60_000;
+
+/**
+ * One agent's presence descriptor — the identity + scope + capability set the
+ * producer stamps onto its `agent.*` envelopes. Derived from an assembled
+ * `Agent` by {@link presenceAgentFromAgent} at the boot site, kept as a narrow
+ * struct so the producer doesn't depend on the full `Agent` shape (and tests
+ * construct it directly).
+ */
+export interface PresenceAgent {
+  identity: AgentPresenceIdentity;
+  scope: AgentPresenceScope;
+  /** Capability ids the agent advertises (same as dispatch-routing caps). */
+  capabilities: readonly string[];
+}
+
+/**
+ * Build a {@link PresenceAgent} from an assembled `Agent` + the boot-resolved
+ * `{principal}` / `{stack}` scope.
+ *
+ * Identity mapping (ADR-0007 §4 — `@assistant on {stack}`):
+ *   - `agent_id`          ← `agent.id` (the logical `luna`/`echo`/… id).
+ *   - `assistant_name`    ← `agent.displayName` — the human-facing named being
+ *     the agent hosts. The `Agent` schema carries no separate `assistant`
+ *     field today; `displayName` IS that name (e.g. `Luna`, `Echo`). Never
+ *     `null` for a hosted agent (displayName is a required, non-empty field).
+ *   - `nkey_public_key`   ← `agent.nkey_pub` when declared, else the stack's
+ *     own NKey pubkey (`fallbackNkey`). At Phase B, presence is stack-local and
+ *     the stack signs every envelope, so the stack key is the honest fallback
+ *     identity for an agent that hasn't declared its own. When neither is
+ *     available the agent is SKIPPED (the payload schema requires a non-empty
+ *     key) — the caller logs the skip.
+ *   - `capabilities`      ← `agent.runtime.capabilities` (the SAME set used for
+ *     dispatch routing). Empty when the agent declares no runtime block.
+ *
+ * Returns `null` when no NKey can be resolved (so the boot site can log + skip
+ * rather than emit an unkeyed, schema-invalid presence envelope).
+ */
+export function presenceAgentFromAgent(
+  agent: Agent,
+  scope: { principal: string; stack: string },
+  fallbackNkey: string | undefined,
+): PresenceAgent | null {
+  const nkey = agent.nkey_pub ?? fallbackNkey;
+  if (nkey === undefined || nkey.length === 0) {
+    return null;
+  }
+  return {
+    identity: {
+      nkey_public_key: nkey,
+      agent_id: agent.id,
+      assistant_name: agent.displayName,
+    },
+    scope: { principal: scope.principal, stack: scope.stack },
+    capabilities: agent.runtime?.capabilities ?? [],
+  };
+}
+
+/** Injectable scheduler — tests pass a controllable fake; production omits. */
+export interface PresenceScheduler {
+  setInterval(handler: () => void, ms: number): ReturnType<typeof setInterval>;
+  clearInterval(handle: ReturnType<typeof setInterval>): void;
+}
+
+const realScheduler: PresenceScheduler = {
+  setInterval: (handler, ms) => setInterval(handler, ms),
+  clearInterval: (handle) => {
+    clearInterval(handle);
+  },
+};
+
+/** Construction options for {@link AgentPresenceProducer}. */
+export interface AgentPresenceProducerOptions {
+  runtime: MyelinRuntime;
+  /** The envelope emitter `source` triple (`{principal}.{stack}.{instance}`). */
+  source: AgentPresenceSource;
+  /** Hosted agents to announce presence for. */
+  agents: readonly PresenceAgent[];
+  /** Heartbeat interval. Defaults to {@link DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS}. */
+  intervalMs?: number;
+  /** Injectable scheduler (tests). Defaults to the real timers. */
+  scheduler?: PresenceScheduler;
+  /** Injectable clock for `started_at` / `sent_at`. Defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+/**
+ * Live agent-presence producer. One instance per cortex process, owning the
+ * presence lifecycle for every hosted agent.
+ *
+ * Lifecycle:
+ *   1. `new AgentPresenceProducer(opts)` — does nothing observable.
+ *   2. `start()` — publishes one `agent.online` per agent immediately, then
+ *      schedules the recurring `agent.heartbeat` ticks. The FIRST heartbeat
+ *      fires on the first interval (not immediately — `online` already
+ *      announced liveness at t=0).
+ *   3. `stop("shutdown")` — clears the interval + publishes one `agent.offline`
+ *      per agent. Idempotent; safe to call twice.
+ */
+export class AgentPresenceProducer {
+  private readonly runtime: MyelinRuntime;
+  private readonly source: AgentPresenceSource;
+  private readonly agents: readonly PresenceAgent[];
+  private readonly intervalMs: number;
+  private readonly scheduler: PresenceScheduler;
+  private readonly now: () => Date;
+
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private started = false;
+  private stopped = false;
+  /** Bound the in-flight heartbeat publishes to 1 per agent-batch (backpressure). */
+  private heartbeatInFlight = false;
+
+  constructor(opts: AgentPresenceProducerOptions) {
+    this.runtime = opts.runtime;
+    this.source = opts.source;
+    this.agents = opts.agents;
+    this.intervalMs = opts.intervalMs ?? DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS;
+    this.scheduler = opts.scheduler ?? realScheduler;
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  /**
+   * Publish `agent.online` for every agent, then begin the heartbeat ticker.
+   * No-op when there are no agents (nothing to announce — but the ticker isn't
+   * scheduled either, so an empty roster is free). Idempotent on re-entry: a
+   * second `start()` is ignored + logged (defensive — boot never re-starts).
+   */
+  start(): void {
+    if (this.started) {
+      process.stderr.write(
+        "agent-presence-producer: start() called twice — ignoring\n",
+      );
+      return;
+    }
+    this.started = true;
+    if (this.agents.length === 0) {
+      // Nothing to announce; leave the ticker unscheduled.
+      return;
+    }
+    for (const agent of this.agents) {
+      this.publishOnline(agent);
+    }
+    this.timer = this.scheduler.setInterval(() => {
+      this.tickHeartbeats();
+    }, this.intervalMs);
+  }
+
+  /**
+   * Stop the ticker + publish `agent.offline` for every agent. Returns a
+   * promise that resolves once every offline publish has settled (so the
+   * cortex.ts shutdown drain can await it BEFORE the runtime closes — an
+   * offline that loses the race with `runtime.stop()` is silently dropped by
+   * the disabled-runtime no-op). Idempotent.
+   *
+   * `reason` defaults to `"shutdown"` (the graceful-shutdown path). A future
+   * caller could pass `"restart"` / `"error"`.
+   */
+  async stop(reason: "shutdown" | "restart" | "error" = "shutdown"): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    if (this.timer !== undefined) {
+      this.scheduler.clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    // Publish offline for every agent and AWAIT them so the drain step holds
+    // the bus open until they've gone out.
+    await Promise.allSettled(
+      this.agents.map((agent) => this.publishOffline(agent, reason)),
+    );
+  }
+
+  private publishOnline(agent: PresenceAgent): void {
+    let envelope;
+    try {
+      envelope = createAgentOnlineEvent({
+        source: this.source,
+        identity: agent.identity,
+        scope: agent.scope,
+        capabilities: [...agent.capabilities],
+        startedAt: this.now(),
+      });
+    } catch (err) {
+      process.stderr.write(
+        `agent-presence-producer: createAgentOnlineEvent failed (agent=${agent.identity.agent_id}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return;
+    }
+    void this.runtime.publish(envelope).catch((err: unknown) => {
+      process.stderr.write(
+        `agent-presence-producer: agent.online publish failed (agent=${agent.identity.agent_id}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    });
+  }
+
+  private tickHeartbeats(): void {
+    // Backpressure guard — mirror heartbeat-ticker: if the previous tick's
+    // batch hasn't settled, the bus is slower than the interval; skip this tick.
+    if (this.heartbeatInFlight) {
+      process.stderr.write(
+        "agent-presence-producer: skipping heartbeat tick — previous batch still in flight\n",
+      );
+      return;
+    }
+    const sentAt = this.now();
+    const publishes: Promise<void>[] = [];
+    for (const agent of this.agents) {
+      let envelope;
+      try {
+        envelope = createAgentHeartbeatEvent({
+          source: this.source,
+          identity: agent.identity,
+          scope: agent.scope,
+          sentAt,
+        });
+      } catch (err) {
+        process.stderr.write(
+          `agent-presence-producer: createAgentHeartbeatEvent failed (agent=${agent.identity.agent_id}): ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        continue;
+      }
+      publishes.push(
+        this.runtime.publish(envelope).catch((err: unknown) => {
+          process.stderr.write(
+            `agent-presence-producer: agent.heartbeat publish failed (agent=${agent.identity.agent_id}): ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }),
+      );
+    }
+    this.heartbeatInFlight = true;
+    void Promise.allSettled(publishes).finally(() => {
+      this.heartbeatInFlight = false;
+    });
+  }
+
+  private async publishOffline(
+    agent: PresenceAgent,
+    reason: "shutdown" | "restart" | "error",
+  ): Promise<void> {
+    let envelope;
+    try {
+      envelope = createAgentOfflineEvent({
+        source: this.source,
+        identity: agent.identity,
+        scope: agent.scope,
+        reason,
+        sentAt: this.now(),
+      });
+    } catch (err) {
+      process.stderr.write(
+        `agent-presence-producer: createAgentOfflineEvent failed (agent=${agent.identity.agent_id}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return;
+    }
+    try {
+      await this.runtime.publish(envelope);
+    } catch (err) {
+      process.stderr.write(
+        `agent-presence-producer: agent.offline publish failed (agent=${agent.identity.agent_id}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}

--- a/src/runner/agent-presence-producer.ts
+++ b/src/runner/agent-presence-producer.ts
@@ -115,6 +115,11 @@ export function presenceAgentFromAgent(
     identity: {
       nkey_public_key: nkey,
       agent_id: agent.id,
+      // assistant_name is the human-facing named being (Luna/Echo) — AgentSchema
+      // has no dedicated assistant field, and `displayName` is `.min(1)` required,
+      // so this is always non-empty. The wire schema permits `assistant_name:
+      // string | null`; this direct map relies on the canonical Agent schema's
+      // required displayName, so there's no null/empty path here.
       assistant_name: agent.displayName,
     },
     scope: { principal: scope.principal, stack: scope.stack },


### PR DESCRIPTION
## What

Wires the agent-presence protocol end-to-end in one stack — **STACK-LOCAL ONLY** (no federation; that is Phase E). Phase B of umbrella #355, per `docs/plan-agent-network-topology.md` §4.2 + ADR-0007. Combined B.2 + B.3 because both wire into `cortex.ts` boot and the subscriber consumes what the producer emits (testable together).

### B.2 — producer (`src/runner/agent-presence-producer.ts`)
- On boot, publishes **one `agent.online` per hosted agent** carrying its identity (`agent_id` + assistant name + NKey pubkey) and its declared **capabilities** (the same `runtime.capabilities[]` used for dispatch routing, ADR-0007 §3).
- A **separate** presence heartbeat ticker (mirrors `heartbeat-ticker.ts`'s injectable-scheduler + idempotent-stop + backpressure pattern) publishes `agent.heartbeat` per agent on a fixed interval.
- On graceful shutdown publishes **`agent.offline` (reason: shutdown)** per agent.
- Uses the **PRESENCE** builders from `bus/agent-network/builders.ts` (`agent.heartbeat`), **never** the dispatch `system.agent.heartbeat`.

### B.3 — runtime registry subscriber (`src/bus/agent-network/registry.ts`)
- Self-subscribes to `local.{principal}.{stack}.agent.>` (cortex#477 push-mode seam) and folds the `agent.*` stream into an **in-memory observable** map keyed by `{principal}/{stack}/{agent_id}`.
- `online` → upsert online + capabilities + startedAt; `heartbeat` → bump `lastHeartbeatAt` (an unknown agent's heartbeat upserts it online — liveness signal); `offline` → mark offline + reason; `capabilities-changed` → store the latest full set.
- Queryable via `getAgents()` (snapshot **copies**) + a change seam `onChange()` for the B.4 panel + the MC API.

### Wiring (`cortex.ts`)
- Both **gated on `config.mc.enabled`** (presence is the data the B.4 panel + MC API render). Registry starts **first** (listening before the producer's onlines go out), then the producer.
- Shutdown drain: `agent.offline` publish + ticker stop + subscriber stop run **before `runtime stop`** (offline must publish while the bus is up). Best-effort throughout — a presence fault logs + boot continues.

## Heartbeat interval choice
**60s** (`DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS`, a module constant). Well under the ADR-0007 5-minute (300s) liveness TTL — ~5 heartbeats per TTL window, so a single dropped heartbeat never flips an agent offline. Not config-driven in B (keeps the surface minimal); a future tuning knob would land on **both** `AgentConfigSchema` and `CortexConfigSchema` per cortex#877.

## FSM / TTL boundary (Phase C)
B records `lastHeartbeatAt` + last explicit state **only**. The 5-min liveness-TTL → `offline` reaper / FSM is **Phase C (G-1114.C)** — a record stays `online` until an explicit `agent.offline` arrives. This is stated as a boundary in both modules + asserted by a test (`B records lastHeartbeatAt but NEVER expires a record`).

`refs #355`

## Test plan
- **Registry** (`registry.test.ts`, 17 tests): scripted online→heartbeat→offline fold; heartbeat-before-online upsert; capabilities-changed latest-set; getAgents copies; onChange seam (+ throwing-listener isolation); malformed-payload drop (no throw); the no-TTL boundary; wiring (self-subscribe pattern, subject filtering — non-matching + federated subjects ignored; dormant when subscribe returns null; idempotent stop).
- **Producer** (`agent-presence-producer.test.ts`, 14 tests): online-per-agent with capabilities + subject derivation; no heartbeat at t=0; injectable-scheduler tick → heartbeat-per-agent; backpressure skip; offline-on-stop + idempotent; producer→registry roundtrip through the real builders/validator; `presenceAgentFromAgent` mapping (+ stack-key fallback + skip-when-no-key).
- **Boot/shutdown integration** (`cortex.agent-presence-boot.test.ts`, 3 tests): gated ON → online-per-agent + registry self-subscribes; gated OFF → no `agent.*`; shutdown → `agent.offline` per agent publishes **before** runtime close (ordering asserted).

## Gate results
- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors
- `bun test` — **5548 pass, 0 fail** (2 skip)
- `bash scripts/check-carveouts.sh` on changed files — PASS (never bare "operator", never `{org}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)