### PR TITLE
feat(mc): G-1114.B.4 — live agents panel (registry → MC API → dashboard)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3155,6 +3155,10 @@ export async function startCortex(
   // not wired here.
   let presenceRegistryHandle: AgentPresenceRegistryHandle | null = null;
   let presenceProducer: AgentPresenceProducer | null = null;
+  // The onChange→WS-broadcast subscription handle, captured so shutdown can
+  // unsubscribe it explicitly — making teardown order-independent rather than
+  // relying on the registry stop severing the envelope feed first (#899 review).
+  let presenceBroadcastSub: { unsubscribe: () => void } | null = null;
   if (config.mc.enabled) {
     try {
       presenceRegistryHandle = await startAgentPresenceRegistry({
@@ -3176,7 +3180,7 @@ export async function startCortex(
       presenceViewForApi = presenceRegistryHandle.registry;
       if (mcHandle !== null) {
         const broadcastWsRegistry = mcHandle.wsRegistry;
-        presenceRegistryHandle.registry.onChange((key, record) => {
+        presenceBroadcastSub = presenceRegistryHandle.registry.onChange((key, record) => {
           broadcastWsRegistry.broadcast({
             type: "agent.presence",
             key,
@@ -3419,6 +3423,7 @@ export async function startCortex(
       // runtime closes (the offline publish is a no-op once the runtime is
       // down), then stop the B.3 registry subscriber.
       "agent-presence producer stop (offline publish)",
+      "agent-presence broadcast unsubscribe",
       "agent-presence registry stop",
       "cockpit refresh loop stop",
       "mc embed stop",
@@ -3472,6 +3477,12 @@ export async function startCortex(
       await completeAsync(
         "agent-presence producer stop (offline publish)",
         presenceProducer?.stop("shutdown"),
+      );
+      // Unsubscribe the onChange→WS-broadcast handle BEFORE stopping the
+      // registry, so teardown is order-independent (no broadcast-after-stop
+      // window even if the registry stop is reordered) (#899 review).
+      completeSync("agent-presence broadcast unsubscribe", () =>
+        presenceBroadcastSub?.unsubscribe(),
       );
       await completeAsync(
         "agent-presence registry stop",

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -104,6 +104,7 @@ import { refreshCockpit, defaultWorkItemSourceFor } from "./surface/mc/refresh";
 import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/refresh-loop";
 // MC-I1.S1 (ADR-0005) — in-process Mission Control embed (supersedes api.*).
 import { startMissionControl, type MissionControlHandle } from "./surface/mc/embed";
+import type { AgentPresenceView } from "./surface/mc/api/agents";
 // MC-I1.S4 (ADR-0005 §4) — bus→MC dispatch-lifecycle projection renderer.
 import { createDispatchProjectionRenderer } from "./surface/mc/projection/dispatch-lifecycle-renderer";
 // MC-I1.S7 (#849) — funnel the event-driven failed_dispatch attention delta
@@ -3060,6 +3061,11 @@ export async function startCortex(
   // `api.enabled` to nudge off — `mc:` is the only embedded-dashboard path.
   let mcHandle: MissionControlHandle | null = null;
   let mcDb: BunDatabase | null = null;
+  // G-1114.B.4 — mutable holder threaded into the MC server as a lazy getter so
+  // `GET /api/agents` can read the stack-local agent-presence registry. The
+  // registry boots AFTER this embed (below), so the getter returns `null` until
+  // we assign it post-registry-start. The MC server resolves it per request.
+  let presenceViewForApi: AgentPresenceView | null = null;
   if (config.mc.enabled && !options.disableDashboard) {
     // Per-slug default keeps each stack's MC db isolated; the cursor lands beside it.
     const defaultDbPath = join(
@@ -3071,6 +3077,7 @@ export async function startCortex(
         configPath: config.mc.configPath || undefined,
         dbPath,
         port: config.mc.port,
+        agentPresence: () => presenceViewForApi,
       });
       mcDb = mcHandle.db;
       console.log(`cortex: Mission Control embed listening on http://localhost:${mcHandle.port} — db ${dbPath}`);
@@ -3155,6 +3162,28 @@ export async function startCortex(
         principal: principalId,
         stack: derivedStack.stack,
       });
+      // G-1114.B.4 — expose the live registry to `GET /api/agents` (the holder
+      // the MC embed's lazy getter reads) AND push live updates to dashboard WS
+      // clients. The `onChange` seam fires after every applied presence mutation;
+      // we broadcast a minimal additive `agent.presence` REFRESH SIGNAL (the
+      // panel refetches `/api/agents` on receipt — the frame is not
+      // authoritative). Reuses the embed's existing `wsRegistry.broadcast`,
+      // matching the S6 `mc.projection` fan-out pattern. Wired here — BEFORE the
+      // producer's own `agent.online` goes out below — so the roundtrip's first
+      // mutations already push live. Only active when the embed is up
+      // (`mcHandle` non-null); on a registry-without-embed boot the holder stays
+      // null and there are no WS clients to notify.
+      presenceViewForApi = presenceRegistryHandle.registry;
+      if (mcHandle !== null) {
+        const broadcastWsRegistry = mcHandle.wsRegistry;
+        presenceRegistryHandle.registry.onChange((key, record) => {
+          broadcastWsRegistry.broadcast({
+            type: "agent.presence",
+            key,
+            state: record.state,
+          });
+        });
+      }
       // Build the per-agent presence descriptors. The stack's own NKey pubkey
       // (captured when the signer was staged) is the fallback identity for any
       // agent that hasn't declared its own `nkey_pub`. Agents with no resolvable

--- a/src/surface/mc/__tests__/api-agents.test.ts
+++ b/src/surface/mc/__tests__/api-agents.test.ts
@@ -1,0 +1,181 @@
+/**
+ * G-1114.B.4 — `GET /api/agents` end-to-end tests.
+ *
+ * Drives the route through the real Bun.serve HTTP stack with a stub
+ * `AgentPresenceView` (the minimal read-only contract the server depends on —
+ * the bus registry isn't imported here). Covers: snapshot projection to the
+ * snake_case DTO, the graceful empty-list path when no registry is wired (the
+ * gating-mismatch case), lazy resolution of the getter (registry attaches after
+ * boot), and method gating.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+import { startServer } from "../server";
+import type { ServerContext } from "../server";
+import { initDatabase } from "../db/init";
+import { DEFAULT_CONFIG } from "../config";
+import type {
+  AgentPresenceSnapshotRecord,
+  AgentPresenceView,
+} from "../api/agents";
+import type { Database } from "bun:sqlite";
+
+const PORT_BIND_ANY = 0;
+
+function boundPort(ctx: ServerContext): number {
+  const port = ctx.server.port;
+  if (port === undefined) throw new Error("server.port unresolved after start");
+  return port;
+}
+
+function rec(
+  over: Partial<AgentPresenceSnapshotRecord> & { agentId: string }
+): AgentPresenceSnapshotRecord {
+  const { agentId } = over;
+  return {
+    key: `andreas/research/${agentId}`,
+    nkeyPublicKey: `N${agentId.toUpperCase()}`,
+    assistantName: null,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    lastSeenAt: 1000,
+    ...over,
+  };
+}
+
+interface Ctx {
+  db: Database;
+  ctx: ServerContext;
+  baseUrl: string;
+  tmpDir: string;
+}
+
+function startWith(
+  agentPresence?: () => AgentPresenceView | null
+): Ctx {
+  const tmpDir = join(tmpdir(), `mc-agents-test-${Date.now()}-${Math.random()}`);
+  const db = initDatabase(join(tmpDir, "test.db"));
+  const ctx = startServer(
+    { ...DEFAULT_CONFIG, port: PORT_BIND_ANY },
+    db,
+    agentPresence ? { agentPresence } : {}
+  );
+  return { db, ctx, baseUrl: `http://localhost:${boundPort(ctx)}`, tmpDir };
+}
+
+function teardown(c: Ctx): void {
+  c.ctx.stop(true);
+  c.db.close();
+  rmSync(c.tmpDir, { recursive: true, force: true });
+}
+
+describe("GET /api/agents", () => {
+  let c: Ctx;
+  afterEach(() => {
+    teardown(c);
+  });
+
+  it("returns an empty list when no presence registry is wired (gating mismatch)", async () => {
+    c = startWith(); // no agentPresence getter
+    const res = await fetch(`${c.baseUrl}/api/agents`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ agents: [] });
+  });
+
+  it("returns an empty list when the getter resolves to null", async () => {
+    c = startWith(() => null);
+    const res = await fetch(`${c.baseUrl}/api/agents`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).agents).toEqual([]);
+  });
+
+  it("projects the registry snapshot into the snake_case DTO", async () => {
+    const view: AgentPresenceView = {
+      getAgents: () => [
+        rec({
+          agentId: "luna",
+          assistantName: "Luna",
+          capabilities: ["review.code", "review.design"],
+          state: "online",
+          startedAt: "2026-06-10T00:00:00.000Z",
+          lastHeartbeatAt: 5000,
+          lastSeenAt: 5000,
+        }),
+        rec({
+          agentId: "echo",
+          assistantName: "Echo",
+          state: "offline",
+          offlineReason: "graceful-shutdown",
+          lastSeenAt: 4000,
+        }),
+      ],
+    };
+    c = startWith(() => view);
+    const res = await fetch(`${c.baseUrl}/api/agents`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agents).toHaveLength(2);
+
+    const luna = body.agents[0];
+    expect(luna.key).toBe("andreas/research/luna");
+    expect(luna.agent_id).toBe("luna");
+    expect(luna.assistant_name).toBe("Luna");
+    expect(luna.nkey_public_key).toBe("NLUNA");
+    expect(luna.principal).toBe("andreas");
+    expect(luna.stack).toBe("research");
+    expect(luna.capabilities).toEqual(["review.code", "review.design"]);
+    expect(luna.state).toBe("online");
+    expect(luna.offline_reason).toBeNull();
+    expect(luna.started_at).toBe("2026-06-10T00:00:00.000Z");
+    expect(luna.last_heartbeat_at).toBe(5000);
+    expect(luna.last_seen_at).toBe(5000);
+
+    const echo = body.agents[1];
+    expect(echo.agent_id).toBe("echo");
+    expect(echo.state).toBe("offline");
+    expect(echo.offline_reason).toBe("graceful-shutdown");
+    expect(echo.last_heartbeat_at).toBeNull();
+    expect(echo.started_at).toBeNull();
+  });
+
+  it("resolves the getter lazily per request (registry attaches after boot)", async () => {
+    // Holder is empty at boot — mirrors cortex.ts where the registry starts
+    // AFTER the MC embed. A later assignment must become visible.
+    let live: AgentPresenceView | null = null;
+    c = startWith(() => live);
+
+    const before = await fetch(`${c.baseUrl}/api/agents`);
+    expect((await before.json()).agents).toEqual([]);
+
+    live = { getAgents: () => [rec({ agentId: "luna", assistantName: "Luna" })] };
+    const after = await fetch(`${c.baseUrl}/api/agents`);
+    const body = await after.json();
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0].agent_id).toBe("luna");
+  });
+
+  it("405s on POST", async () => {
+    c = startWith(() => ({ getAgents: () => [] }));
+    const res = await fetch(`${c.baseUrl}/api/agents`, { method: "POST" });
+    expect(res.status).toBe(405);
+  });
+
+  it("returns a 500 JSON error when the registry view throws", async () => {
+    c = startWith(() => ({
+      getAgents: () => {
+        throw new Error("registry exploded");
+      },
+    }));
+    const res = await fetch(`${c.baseUrl}/api/agents`);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("registry exploded");
+  });
+});

--- a/src/surface/mc/api/agents.ts
+++ b/src/surface/mc/api/agents.ts
@@ -1,0 +1,141 @@
+/**
+ * G-1114.B.4 — `GET /api/agents` (live agents panel data source).
+ *
+ * Exposes the stack-local runtime agent-presence registry (G-1114.B.3) as a
+ * read-only REST snapshot the dashboard's agents panel renders. The registry is
+ * the bus-side observable store fed by the `agent.*` presence stream
+ * (`agent.online` / `agent.heartbeat` / `agent.offline` /
+ * `agent.capabilities-changed`); this handler projects its `getAgents()`
+ * snapshot into a stable DTO so the dashboard never touches bus internals.
+ *
+ * ## Dependency direction
+ *
+ * The MC surface layer must NOT import the bus. The server depends only on the
+ * minimal {@link AgentPresenceView} interface declared here — `cortex.ts` adapts
+ * the concrete `AgentPresenceRegistry` to it at boot. This keeps the
+ * registry→API seam one-directional (bus → surface), matching how `wsRegistry`
+ * and `db` are threaded.
+ *
+ * ## Gating-mismatch graceful path
+ *
+ * When MC is enabled but the presence registry is absent (e.g. a gating skew
+ * where the embed runs without the registry), the server passes `null` and this
+ * handler returns an empty list — never a 5xx. An empty panel is the correct
+ * "no agents observed yet" rendering.
+ */
+
+import type { Database } from "bun:sqlite";
+
+/**
+ * The minimal read-only contract the MC server depends on to serve
+ * `/api/agents`. The concrete `AgentPresenceRegistry` (from
+ * `src/bus/agent-network/registry.ts`) satisfies this structurally — the server
+ * never imports the bus type, only this interface. `cortex.ts` supplies the
+ * live registry; tests supply a hand-rolled stub.
+ */
+export interface AgentPresenceView {
+  /** Snapshot of every known agent presence record (copies — caller-safe). */
+  getAgents(): AgentPresenceSnapshotRecord[];
+}
+
+/**
+ * One agent's presence as the registry exposes it. A structural subset of the
+ * bus-side `AgentPresenceRecord` — only the fields the API surfaces. Declared
+ * here (not imported from the bus) so the surface layer stays bus-free; the
+ * registry's richer record assigns to this shape structurally.
+ */
+export interface AgentPresenceSnapshotRecord {
+  key: string;
+  agentId: string;
+  nkeyPublicKey: string;
+  assistantName: string | null;
+  principal: string;
+  stack: string;
+  capabilities: readonly string[];
+  state: "online" | "offline";
+  offlineReason?: string;
+  startedAt?: string;
+  lastHeartbeatAt?: number;
+  lastSeenAt: number;
+}
+
+/** One agent row in the `GET /api/agents` response. */
+export interface AgentPresenceTile {
+  /** Stable registry key — `{principal}/{stack}/{agent_id}`. */
+  key: string;
+  /** Logical agent id (`luna`, `echo`, …). */
+  agent_id: string;
+  /** Soma-layer assistant name the agent hosts, or `null`. */
+  assistant_name: string | null;
+  /** The agent's NKey public key (stable cross-restart identity). */
+  nkey_public_key: string;
+  /** `{principal}` the agent lives in. */
+  principal: string;
+  /** `{stack}` the agent lives in. */
+  stack: string;
+  /** Declared capability set (latest observed). */
+  capabilities: readonly string[];
+  /** Last explicit liveness state observed from the presence stream. */
+  state: "online" | "offline";
+  /** Reason from the last `agent.offline`, when `state === "offline"`. */
+  offline_reason: string | null;
+  /** Boot time from the last `agent.online` (ISO-8601), when known. */
+  started_at: string | null;
+  /** Epoch-ms of the last `agent.heartbeat` observed, when known. */
+  last_heartbeat_at: number | null;
+  /** Epoch-ms any presence envelope was last applied for this agent. */
+  last_seen_at: number;
+}
+
+/** `GET /api/agents` response body. */
+export interface ListAgentsResponse {
+  agents: AgentPresenceTile[];
+}
+
+/** Project one registry record into the snake_case API DTO. */
+function toTile(r: AgentPresenceSnapshotRecord): AgentPresenceTile {
+  return {
+    key: r.key,
+    agent_id: r.agentId,
+    assistant_name: r.assistantName,
+    nkey_public_key: r.nkeyPublicKey,
+    principal: r.principal,
+    stack: r.stack,
+    capabilities: r.capabilities,
+    state: r.state,
+    offline_reason: r.offlineReason ?? null,
+    started_at: r.startedAt ?? null,
+    last_heartbeat_at: r.lastHeartbeatAt ?? null,
+    last_seen_at: r.lastSeenAt,
+  };
+}
+
+/**
+ * Handle `GET /api/agents`.
+ *
+ * Read-only: projects the live registry snapshot. `db` is accepted for handler
+ * signature parity with the other `/api/*` handlers (the agents feed is
+ * registry-derived, not DB-derived, so it is unused — but keeping the parameter
+ * keeps the router call-site uniform and leaves room for a future DB join).
+ *
+ * `view === null` (MC enabled but no presence registry — a gating mismatch)
+ * returns an empty list gracefully rather than erroring.
+ */
+export function handleListAgents(
+  _db: Database,
+  view: AgentPresenceView | null,
+): Response {
+  try {
+    const records = view ? view.getAgents() : [];
+    const body: ListAgentsResponse = { agents: records.map(toTile) };
+    return Response.json(body);
+  } catch (err) {
+    process.stderr.write(
+      `[api] GET /api/agents failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return Response.json(
+      { error: `Failed to list agents: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 500 },
+    );
+  }
+}

--- a/src/surface/mc/dashboard-v2/__tests__/agents-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/agents-display.test.ts
@@ -1,0 +1,92 @@
+/**
+ * G-1114.B.4 — agents-panel display-helper tests.
+ *
+ * The panel mode selection + relative-time formatting are extracted into
+ * `lib/agents-display.ts` so they stay unit-testable without a DOM (same
+ * discipline as `working-grid-display`).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  pickAgentsPanelMode,
+  formatRelativeTime,
+  type AgentsPanelInput,
+} from "../lib/agents-display";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+function tile(): AgentPresenceTile {
+  return {
+    key: "andreas/research/luna",
+    agent_id: "luna",
+    assistant_name: "Luna",
+    nkey_public_key: "NLUNA",
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+  };
+}
+
+function input(over: Partial<AgentsPanelInput> = {}): AgentsPanelInput {
+  return { agents: [], loaded: false, error: null, ...over };
+}
+
+describe("pickAgentsPanelMode", () => {
+  it("returns 'error' on a boot error before anything loaded", () => {
+    expect(pickAgentsPanelMode(input({ error: "HTTP 500", loaded: false }))).toBe("error");
+  });
+
+  it("returns 'loading' pre-boot with no error", () => {
+    expect(pickAgentsPanelMode(input({ loaded: false }))).toBe("loading");
+  });
+
+  it("returns 'empty' when loaded with no agents", () => {
+    expect(pickAgentsPanelMode(input({ loaded: true }))).toBe("empty");
+  });
+
+  it("returns 'list' when there are agents", () => {
+    expect(pickAgentsPanelMode(input({ loaded: true, agents: [tile()] }))).toBe("list");
+  });
+
+  it("keeps the last-good list on a refetch error (error + loaded → not 'error')", () => {
+    // A swallowed refetch error after a successful boot: loaded stays true with
+    // a stale error string — the list must remain, not flip to the error card.
+    expect(
+      pickAgentsPanelMode(input({ loaded: true, error: "HTTP 500", agents: [tile()] }))
+    ).toBe("list");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  const now = 1_000_000_000_000;
+
+  it("returns 'never' for null/undefined", () => {
+    expect(formatRelativeTime(null, now)).toBe("never");
+    expect(formatRelativeTime(undefined, now)).toBe("never");
+  });
+
+  it("returns 'just now' under 5s (and for clock skew into the future)", () => {
+    expect(formatRelativeTime(now - 1000, now)).toBe("just now");
+    expect(formatRelativeTime(now + 5000, now)).toBe("just now");
+  });
+
+  it("formats seconds", () => {
+    expect(formatRelativeTime(now - 12_000, now)).toBe("12s ago");
+  });
+
+  it("formats minutes", () => {
+    expect(formatRelativeTime(now - 3 * 60_000, now)).toBe("3m ago");
+  });
+
+  it("formats hours", () => {
+    expect(formatRelativeTime(now - 2 * 3_600_000, now)).toBe("2h ago");
+  });
+
+  it("formats days", () => {
+    expect(formatRelativeTime(now - 5 * 86_400_000, now)).toBe("5d ago");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-preview-view.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-preview-view.test.tsx
@@ -1,70 +1,117 @@
 /**
- * G-1114.A — render test for the Network (preview) stub tab.
- *
- * Walks the rendered React tree (no DOM harness — same approach as
- * markdown.test.tsx) to assert the placeholder renders, names the preview
- * status, and lists the four `agent`-domain presence actions. NO data wiring is
- * exercised because there is none (inert grounding slice).
+ * G-1114.B.4 — render tests for the live agents panel (replaced the Phase A
+ * stub). Renders via `renderToStaticMarkup` (which runs the component's hooks)
+ * and asserts the panel projects the agents state: list rows with identity,
+ * capabilities, state, and heartbeat; the empty state; and the boot-error path.
  */
 
 import { describe, it, expect } from "bun:test";
-import { createElement, isValidElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
 import { NetworkPreviewView } from "../components/network-preview-view";
+import type { AgentsState } from "../hooks/use-agents";
+import type { AgentPresenceTile } from "../hooks/use-agents";
 
-interface El {
-  type: unknown;
-  props: { className?: string; children?: ReactNode; "aria-label"?: string };
+function tile(over: Partial<AgentPresenceTile> & { agent_id: string }): AgentPresenceTile {
+  const { agent_id } = over;
+  return {
+    key: `andreas/research/${agent_id}`,
+    assistant_name: null,
+    nkey_public_key: `N${agent_id.toUpperCase()}`,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+    ...over,
+  };
 }
 
-function isEl(node: unknown): node is El {
-  return isValidElement(node);
+function render(state: AgentsState): string {
+  return renderToStaticMarkup(createElement(NetworkPreviewView, { state }));
 }
 
-function collectText(node: ReactNode): string {
-  let out = "";
-  function walk(n: ReactNode): void {
-    if (n == null || typeof n === "boolean") return;
-    if (typeof n === "string" || typeof n === "number") {
-      out += String(n);
-      return;
-    }
-    if (Array.isArray(n)) {
-      for (const c of n) walk(c);
-      return;
-    }
-    if (isEl(n)) walk(n.props.children);
-  }
-  walk(node);
-  return out;
-}
-
-describe("NetworkPreviewView (G-1114.A stub)", () => {
-  const tree = createElement(NetworkPreviewView);
-  // NetworkPreviewView is a plain function component; invoke it to get its tree.
-  const rendered = NetworkPreviewView();
-
-  it("renders a section element", () => {
-    expect(isValidElement(tree)).toBe(true);
-    expect(isEl(rendered) && rendered.type).toBe("section");
+describe("NetworkPreviewView — live agents panel (G-1114.B.4)", () => {
+  it("renders the loading state before first load", () => {
+    const html = render({ agents: [], loaded: false, error: null });
+    expect(html).toContain("Loading");
   });
 
-  it("labels itself a preview", () => {
-    const text = collectText(rendered);
-    expect(text).toContain("Network (preview)");
-    expect(text).toContain("G-1114.B");
+  it("renders the empty state when loaded with no agents", () => {
+    const html = render({ agents: [], loaded: true, error: null });
+    expect(html).toContain("No agents observed yet");
   });
 
-  it("lists the four agent-domain presence actions", () => {
-    const text = collectText(rendered);
-    expect(text).toContain("agent.online");
-    expect(text).toContain("agent.heartbeat");
-    expect(text).toContain("agent.offline");
-    expect(text).toContain("agent.capabilities-changed");
+  it("renders the boot-error state", () => {
+    const html = render({ agents: [], loaded: false, error: "HTTP 500" });
+    expect(html).toContain("HTTP 500");
   });
 
-  it("distinguishes presence from the dispatch-scoped heartbeat", () => {
-    const text = collectText(rendered);
-    expect(text).toContain("system.agent.heartbeat");
-    expect(text.toLowerCase()).toContain("session interior");
+  it("renders an online agent with assistant name, id, capabilities, and state", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [
+        tile({
+          agent_id: "luna",
+          assistant_name: "Luna",
+          capabilities: ["review.code", "review.design"],
+          state: "online",
+          last_heartbeat_at: Date.now(),
+        }),
+      ],
+    });
+    expect(html).toContain("Luna");
+    expect(html).toContain("luna");
+    expect(html).toContain("review.code");
+    expect(html).toContain("review.design");
+    expect(html).toContain("online");
+    expect(html).toContain('data-agent-id="luna"');
+    expect(html).toContain('data-state="online"');
+  });
+
+  it("falls back to agent_id when assistant_name is null", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [tile({ agent_id: "echo", assistant_name: null })],
+    });
+    expect(html).toContain("echo");
+  });
+
+  it("renders an offline agent and notes no-capabilities", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [
+        tile({
+          agent_id: "echo",
+          assistant_name: "Echo",
+          state: "offline",
+          offline_reason: "graceful-shutdown",
+          capabilities: [],
+        }),
+      ],
+    });
+    expect(html).toContain("offline");
+    expect(html).toContain('data-state="offline"');
+    expect(html).toContain("no capabilities declared");
+  });
+
+  it("renders one row per agent", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [
+        tile({ agent_id: "luna", assistant_name: "Luna" }),
+        tile({ agent_id: "echo", assistant_name: "Echo" }),
+        tile({ agent_id: "sage", assistant_name: "Sage" }),
+      ],
+    });
+    const rowCount = (html.match(/agents-panel-row /g) ?? []).length;
+    expect(rowCount).toBe(3);
   });
 });

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -36,6 +36,7 @@ import { useRepositories } from "./hooks/use-repositories";
 import { usePlans } from "./hooks/use-plans";
 import { usePhaseDetail } from "./hooks/use-phase-detail";
 import { useAttention } from "./hooks/use-attention";
+import { useAgents } from "./hooks/use-agents";
 import { useWorkItemDetail } from "./hooks/use-work-item-detail";
 import { useTheme } from "./hooks/use-theme";
 import { useWebSocket } from "./hooks/use-websocket";
@@ -119,6 +120,9 @@ export function App() {
   const workItemDetail = useWorkItemDetail(view === "work-item-detail" ? selectedWorkItemId : null);
   // G-1113.E.3 — attention queue data (fetched only when on the Attention tab).
   const attention = useAttention(ws, softwareMode && view === "attention");
+  // G-1114.B.4 — stack-local agent-presence data (fetched only when on the
+  // Network tab); live-refreshed off the `agent.presence` WS frame.
+  const agents = useAgents(ws, view === "network-preview");
   // If software mode is toggled OFF while on a software-mode view (Repositories
   // / Plans / phase-detail / work-item-detail / attention), the tab + render
   // both gate off — reset to default so the main area isn't left blank.
@@ -524,9 +528,11 @@ export function App() {
         )}
 
         {view === "network-preview" && (
-          /* G-1114.A — Agent Network Topology placeholder. Inert: no producer,
-             no subscriber, no data yet (live panel lands in G-1114.B). */
-          <NetworkPreviewView />
+          /* G-1114.B.4 — live stack-local agents panel (replaced the Phase A
+             stub): agents pop up on boot, drop off when offline, fed by the
+             runtime presence registry via /api/agents + the agent.presence WS
+             frame. The topology graph is Phase D. */
+          <NetworkPreviewView state={agents} />
         )}
 
         {view === "repositories" && softwareMode && (

--- a/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
@@ -6,7 +6,7 @@
  * state, and last-heartbeat relative time. Data comes from `GET /api/agents`
  * via `useAgents`; live updates ride the additive `agent.presence` WS frame, so
  * agents pop up on boot and drop off when they go offline — the Phase B
- * operator-value line.
+ * value line.
  *
  * This is the simple PANEL. The rich React Flow + ELK topology graph is Phase D
  * (G-1114.D); cross-stack federated peers are Phase E. This view is deliberately

--- a/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
@@ -1,57 +1,98 @@
 /**
- * G-1114.A — Network (preview) tab.
+ * G-1114.B.4 — live agents panel (replaces the Phase A preview stub).
  *
- * A grounding-slice placeholder for the Agent Network Topology view (G-1114).
- * This renders a clear "preview — coming in G-1114.B" card and NO data: there
- * is no producer publishing `agent.*` presence envelopes and no subscriber /
- * runtime registry feeding this surface yet (ADR-0007 — the live producer +
- * subscriber land in Phase B). It exists so the work-in-flight is visible on
- * the dashboard and the tab slot is reserved.
+ * Renders the stack-local runtime agent-presence registry: one row per agent
+ * with its assistant name, agent id, declared capabilities, online/offline
+ * state, and last-heartbeat relative time. Data comes from `GET /api/agents`
+ * via `useAgents`; live updates ride the additive `agent.presence` WS frame, so
+ * agents pop up on boot and drop off when they go offline — the Phase B
+ * operator-value line.
  *
- * When G-1114.B wires the runtime registry, this view is replaced by the real
- * stack-local agents panel; when G-1114.D lands, by the React Flow + ELK graph.
+ * This is the simple PANEL. The rich React Flow + ELK topology graph is Phase D
+ * (G-1114.D); cross-stack federated peers are Phase E. This view is deliberately
+ * stack-local only.
  */
 
-/** The four `agent`-domain presence actions this view will eventually render. */
-const PRESENCE_ACTIONS = [
-  "online",
-  "heartbeat",
-  "offline",
-  "capabilities-changed",
-] as const;
+import { useState } from "react";
+import type { AgentsState } from "../hooks/use-agents";
+import { pickAgentsPanelMode, formatRelativeTime } from "../lib/agents-display";
 
-export function NetworkPreviewView() {
+export interface NetworkPreviewViewProps {
+  state: AgentsState;
+}
+
+export function NetworkPreviewView({ state }: NetworkPreviewViewProps) {
+  // One `now` per render so every row's relative time is computed against the
+  // same instant (no row-to-row drift within a paint).
+  const [now] = useState(() => Date.now());
+  const mode = pickAgentsPanelMode(state);
+
   return (
     <section
-      className="scaffold-section network-preview-view"
-      aria-label="Network topology (preview)"
+      className="scaffold-section agents-panel-view"
+      aria-label="Agents (stack-local presence)"
     >
-      <h2>Network (preview)</h2>
-      <p className="dim">
-        The <strong>Agent Network Topology</strong> view is in flight (G-1114).
-        It will render agent <strong>presence</strong> across stacks — which
-        agents are up and consuming the bus, their declared capabilities, and
-        their liveness — built from the new <code>agent</code>-domain presence
-        protocol on the bus.
+      <h2>Agents</h2>
+      <p className="dim agents-panel-subtitle">
+        Stack-local agent <strong>presence</strong> — which agents are up and
+        consuming the bus, their declared capabilities, and their liveness. The
+        cross-stack topology graph arrives in G-1114.D.
       </p>
-      <p className="dim">
-        Nothing is wired yet: this slice (G-1114.A) lands only the inert
-        protocol types. The live stack-local agents panel arrives in{" "}
-        <strong>G-1114.B</strong>; the graph view in G-1114.D.
-      </p>
-      <ul className="network-preview-actions" aria-label="Presence protocol actions">
-        {PRESENCE_ACTIONS.map((action) => (
-          <li key={action} className="network-preview-action">
-            <code>agent.{action}</code>
-          </li>
-        ))}
-      </ul>
-      <p className="dim network-preview-note">
-        Presence (<code>agent.heartbeat</code>) is distinct from the
-        dispatch-scoped <code>system.agent.heartbeat</code>: an idle agent has
-        presence without running a dispatch. Peer agents show presence and
-        dispatch-lifecycle metadata only — never session interiors.
-      </p>
+
+      {mode === "error" && (
+        <div className="agents-panel-error">⚠ {state.error}</div>
+      )}
+      {mode === "loading" && (
+        <div className="agents-panel-empty">Loading…</div>
+      )}
+      {mode === "empty" && (
+        <div className="agents-panel-empty">No agents observed yet.</div>
+      )}
+      {mode === "list" && (
+        <ul className="agents-panel-list" aria-label="Agents">
+          {state.agents.map((a) => (
+            <li
+              key={a.key}
+              className={`agents-panel-row agents-panel-row-${a.state}`}
+              data-agent-id={a.agent_id}
+              data-state={a.state}
+            >
+              <div className="agents-panel-identity">
+                <span className="agents-panel-name">
+                  {a.assistant_name ?? a.agent_id}
+                </span>
+                <span className="agents-panel-id dim">{a.agent_id}</span>
+              </div>
+              <div className="agents-panel-caps">
+                {a.capabilities.length === 0 ? (
+                  <span className="dim">no capabilities declared</span>
+                ) : (
+                  a.capabilities.map((cap) => (
+                    <span key={cap} className="agents-panel-cap">
+                      {cap}
+                    </span>
+                  ))
+                )}
+              </div>
+              <div className="agents-panel-liveness">
+                <span
+                  className={`agents-panel-state state-${a.state}`}
+                  title={
+                    a.state === "offline" && a.offline_reason
+                      ? `offline: ${a.offline_reason}`
+                      : a.state
+                  }
+                >
+                  {a.state}
+                </span>
+                <span className="agents-panel-heartbeat dim">
+                  {formatRelativeTime(a.last_heartbeat_at, now)}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/src/surface/mc/dashboard-v2/hooks/use-agents.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-agents.ts
@@ -1,0 +1,123 @@
+/**
+ * G-1114.B.4 — agent-presence panel hook.
+ *
+ * Fetches `GET /api/agents` (the stack-local runtime agent-presence registry
+ * snapshot) and keeps it fresh by subscribing to the additive `agent.presence`
+ * WebSocket frame: every applied presence mutation (`agent.online` /
+ * `agent.heartbeat` / `agent.offline` / `agent.capabilities-changed`) broadcasts
+ * a refresh signal, which triggers a debounced refetch — agents pop up on boot
+ * and drop off when they go offline, live, without a poll.
+ *
+ * The `agent.presence` frame is a REFRESH SIGNAL, not authoritative state: the
+ * panel always re-reads the API rather than mutating off the frame's fields,
+ * matching how `use-working-agents` refetches off `state.transition`.
+ *
+ * Only fetches when `enabled` (the Network tab is visible). A frame arriving
+ * while the tab is closed short-circuits (no pointless fetch) but the
+ * subscription stays attached so re-entering the tab is current.
+ *
+ * Lifetime/race guard: `aliveRef` + `genRef` (drop stale in-flight responses) +
+ * `AbortController`, the same discipline as `use-working-agents` /
+ * `use-attention`.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiFailure, getJson } from "../lib/api";
+import type { AgentPresenceTile, ListAgentsResponse } from "../../api/agents";
+import type { WsClient, WsMessage } from "./use-websocket";
+
+export type { AgentPresenceTile } from "../../api/agents";
+
+export interface AgentsState {
+  agents: AgentPresenceTile[];
+  loaded: boolean;
+  /** Boot error only — refetch failures are swallowed (warn-only). */
+  error: string | null;
+}
+
+/** Coalesce a burst of presence frames (a boot fan-out) into one refresh. */
+const REFETCH_DEBOUNCE_MS = 150;
+
+export function useAgents(ws: WsClient, enabled: boolean): AgentsState {
+  const [agents, setAgents] = useState<AgentPresenceTile[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const genRef = useRef(0);
+  const aliveRef = useRef(true);
+  const bootedRef = useRef(false);
+  const enabledRef = useRef(enabled);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const fetchAgents = useCallback(async (signal?: AbortSignal) => {
+    const myGen = ++genRef.current;
+    try {
+      const body = await getJson<ListAgentsResponse>(
+        "/api/agents",
+        signal ? { signal } : undefined
+      );
+      if (!aliveRef.current || genRef.current !== myGen) return;
+      setAgents(body.agents ?? []);
+      setError(null);
+      bootedRef.current = true;
+    } catch (e) {
+      if (!aliveRef.current || genRef.current !== myGen) return;
+      if ((e as { name?: string })?.name === "AbortError") return;
+      const msg =
+        e instanceof ApiFailure
+          ? e.info.message
+          : e instanceof Error
+            ? e.message
+            : String(e);
+      // Only surface boot errors; refetch failures stay quiet (parity with
+      // use-working-agents). `console.warn` is the only emit path in the bundle.
+      if (!bootedRef.current) {
+        setError(msg);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn("[use-agents] refetch failed:", msg);
+      }
+    } finally {
+      if (aliveRef.current && genRef.current === myGen) setLoaded(true);
+    }
+  }, []);
+
+  // Boot fetch — only when the tab is visible.
+  useEffect(() => {
+    if (!enabled) return;
+    const ac = new AbortController();
+    void fetchAgents(ac.signal);
+    return () => ac.abort();
+  }, [enabled, fetchAgents]);
+
+  // Live refresh on the `agent.presence` broadcast. Debounced so a boot
+  // fan-out (several agents announcing at once) collapses into one refetch.
+  // Gated on `enabled` via a ref so the subscription isn't torn down each time
+  // the tab flips — a frame arriving while closed just no-ops.
+  const subscribe = ws.subscribe;
+  useEffect(() => {
+    function onPresence(_msg: WsMessage) {
+      if (!enabledRef.current) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        debounceRef.current = null;
+        void fetchAgents();
+      }, REFETCH_DEBOUNCE_MS);
+    }
+    return subscribe("agent.presence", onPresence);
+  }, [subscribe, fetchAgents]);
+
+  return { agents, loaded, error };
+}

--- a/src/surface/mc/dashboard-v2/lib/agents-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/agents-display.ts
@@ -1,0 +1,58 @@
+/**
+ * G-1114.B.4 — pure display helpers for the agents panel.
+ *
+ * Kept out of the React component so the formatting (relative-time, panel mode
+ * selection) is unit-testable without a DOM, mirroring `working-grid-display.ts`.
+ */
+
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+/** Panel render mode, selected from load/error/data state. */
+export type AgentsPanelMode = "error" | "loading" | "empty" | "list";
+
+export interface AgentsPanelInput {
+  agents: AgentPresenceTile[];
+  loaded: boolean;
+  error: string | null;
+}
+
+/**
+ * Pick the panel's render mode.
+ *   - `error`   — boot fetch failed (and nothing loaded yet).
+ *   - `loading` — first fetch in flight.
+ *   - `empty`   — loaded, no agents observed.
+ *   - `list`    — loaded, ≥1 agent.
+ *
+ * A refetch error after a successful boot is intentionally NOT `error` (the hook
+ * swallows it warn-only) — the last-good list stays on screen.
+ */
+export function pickAgentsPanelMode(input: AgentsPanelInput): AgentsPanelMode {
+  if (input.error && !input.loaded) return "error";
+  if (!input.loaded) return "loading";
+  if (input.agents.length === 0) return "empty";
+  return "list";
+}
+
+/**
+ * Format an epoch-ms timestamp as a compact relative string ("just now",
+ * "12s ago", "3m ago", "2h ago", "5d ago"). `null`/`undefined` → "never".
+ * `now` is injectable for deterministic tests.
+ */
+export function formatRelativeTime(
+  epochMs: number | null | undefined,
+  now: number = Date.now()
+): string {
+  if (epochMs === null || epochMs === undefined) return "never";
+  const deltaMs = now - epochMs;
+  // A future or near-zero timestamp (clock skew) reads as "just now" rather
+  // than a negative duration.
+  if (deltaMs < 5_000) return "just now";
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -348,17 +348,45 @@ html, body {
 .sources-view .source-state.state-available { color: var(--fg-faint); }
 .sources-view .source-available .provider-label { color: var(--fg-faint); }
 
-/* G-1114.A — Network (preview) stub tab */
-.network-preview-view .network-preview-actions {
-  list-style: none; margin: 8px 0; padding: 0;
-  display: flex; flex-wrap: wrap; gap: 8px;
+/* G-1114.B.4 — live agents panel (replaced the Phase A preview stub) */
+.agents-panel-view .agents-panel-subtitle { margin: 4px 0 12px 0; }
+.agents-panel-view .agents-panel-empty,
+.agents-panel-view .agents-panel-error {
+  padding: 12px 14px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); color: var(--fg-faint); font-size: 12px;
 }
-.network-preview-view .network-preview-action code {
-  font-size: 11px; padding: 2px 8px;
-  border: 1px solid var(--line-soft); border-radius: 4px;
+.agents-panel-view .agents-panel-error { color: var(--bad); border-color: color-mix(in oklch, var(--bad) 40%, transparent); }
+.agents-panel-view .agents-panel-list {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.agents-panel-view .agents-panel-row {
+  display: grid; grid-template-columns: minmax(140px, 1fr) 2fr auto;
+  align-items: center; gap: 12px;
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); padding: 10px 14px;
+}
+.agents-panel-view .agents-panel-row-offline { opacity: 0.6; }
+.agents-panel-view .agents-panel-identity { display: flex; flex-direction: column; gap: 2px; }
+.agents-panel-view .agents-panel-name { font-size: 13px; font-weight: 600; }
+.agents-panel-view .agents-panel-id { font-size: 11px; }
+.agents-panel-view .agents-panel-caps {
+  display: flex; flex-wrap: wrap; gap: 6px;
+}
+.agents-panel-view .agents-panel-cap {
+  font-size: 10.5px; padding: 2px 8px;
+  border: 1px solid var(--line); border-radius: 4px;
   color: var(--fg-faint);
 }
-.network-preview-view .network-preview-note { margin-top: 8px; }
+.agents-panel-view .agents-panel-liveness {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 2px;
+}
+.agents-panel-view .agents-panel-state {
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600;
+}
+.agents-panel-view .agents-panel-state.state-online { color: var(--ok); }
+.agents-panel-view .agents-panel-state.state-offline { color: var(--fg-faint); }
+.agents-panel-view .agents-panel-heartbeat { font-size: 11px; }
 
 /* G-1113.C.7 — per-repository panel */
 .repos-view .repo-card {

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -22,6 +22,7 @@ import { ProcessManager } from "./session/process-manager";
 import { HookStreamPoller } from "./hooks/poller";
 import type { Config } from "./types";
 import type { WsClientRegistry } from "./ws/client-registry";
+import type { AgentPresenceView } from "./api/agents";
 
 export interface MissionControlHandle {
   db: Database;
@@ -48,6 +49,14 @@ export interface StartMissionControlOptions {
   dbPath: string;
   /** Listen port. `> 0` overrides the MC yaml's port; otherwise the yaml's port (default 8767) wins. */
   port?: number;
+  /**
+   * G-1114.B.4 — lazy accessor for the stack-local agent-presence registry
+   * view (serves `GET /api/agents`). A GETTER because the registry boots AFTER
+   * the embed in `cortex.ts`; resolving per request lets the server pick the
+   * registry up once it exists. Forwarded verbatim to `startServer`. Omitted →
+   * the route serves an empty list.
+   */
+  agentPresence?: () => AgentPresenceView | null;
 }
 
 /**
@@ -88,7 +97,10 @@ export async function startMissionControl(
   let hookPoller: HookStreamPoller | null = null;
   try {
     const processManager = new ProcessManager();
-    serverCtx = startServer(config, db, { processManager });
+    serverCtx = startServer(config, db, {
+      processManager,
+      ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
+    });
     const { server, wsRegistry } = serverCtx;
     hookPoller = new HookStreamPoller(db, config.hooks, wsRegistry);
     hookPoller.start();

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -39,6 +39,7 @@ import {
   IMAGE_BODY_MAX_BYTES,
 } from "./api/handlers";
 import { handleListGitLinks } from "./api/git-links";
+import { handleListAgents, type AgentPresenceView } from "./api/agents";
 import { handleListRepositories } from "./api/git-repos";
 import { handleListPlans } from "./api/plans";
 import { handleGetPhaseDetail } from "./api/phase-detail";
@@ -151,6 +152,18 @@ export interface StartServerOptions {
    * configure on the upstream `webhook-proxy`.
    */
   githubWebhookSecret?: string;
+  /**
+   * G-1114.B.4 — accessor for the stack-local runtime agent-presence registry
+   * (its `getAgents()` read-only view), serving `GET /api/agents`.
+   *
+   * A GETTER (not the value) because the registry boots AFTER the MC server in
+   * `cortex.ts` — the embed is started, THEN the presence registry self-
+   * subscribes. Resolving lazily at request time lets the server bind before
+   * the registry exists and pick it up once it does, without a boot-ordering
+   * dance. Returns `null` until/unless a registry is wired (MC enabled but no
+   * presence registry → the handler serves an empty list gracefully).
+   */
+  agentPresence?: () => AgentPresenceView | null;
 }
 
 export function startServer(
@@ -226,7 +239,10 @@ export function startServer(
 
       // --- REST API ---
       if (url.pathname.startsWith("/api/")) {
-        return handleApi(req, url, db, apiDeps);
+        // Resolve the agent-presence view lazily per request — the registry
+        // may not have booted when the server started (see StartServerOptions).
+        const agentPresence = options.agentPresence?.() ?? null;
+        return handleApi(req, url, db, apiDeps, agentPresence);
       }
 
       // --- Dashboard static ---
@@ -379,7 +395,8 @@ async function handleApi(
   req: Request,
   url: URL,
   db: Database,
-  deps: ApiDeps | null
+  deps: ApiDeps | null,
+  agentPresence: AgentPresenceView | null
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -529,6 +546,16 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListWorkingAgents(db);
+  }
+
+  // G-1114.B.4 — GET /api/agents — stack-local runtime agent-presence snapshot
+  // for the dashboard's agents panel. Registry-derived (not DB), read-only.
+  // `agentPresence === null` (MC enabled but no presence registry) → empty list.
+  if (pathname === "/api/agents") {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    return handleListAgents(db, agentPresence);
   }
 
   // F-17 — principal-driven GitHub iteration import.

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -107,6 +107,22 @@ export type WsServerMessage =
       sessionId?: string;
       assignmentId?: string;
     }
+  // G-1114.B.4 — agent-presence live refresh signal. Broadcast when the
+  // stack-local runtime agent-presence registry mutates a record
+  // (`agent.online` / `agent.heartbeat` / `agent.offline` /
+  // `agent.capabilities-changed`). Like `state.transition` and `mc.projection`
+  // it's a REFRESH SIGNAL, not an authoritative payload: the agents panel
+  // refetches `GET /api/agents` on receipt rather than trusting the frame's
+  // fields, so the wire contract stays minimal. ADDITIVE — older dashboard
+  // clients (whose type-keyed dispatcher has no `agent.presence` handler) ignore
+  // it; no `WS_PROTOCOL_VERSION` bump.
+  | {
+      type: "agent.presence";
+      /** The affected registry key — `{principal}/{stack}/{agent_id}`. */
+      key: string;
+      /** The post-mutation liveness state, for cheap client-side filtering. */
+      state: "online" | "offline";
+    }
   | { type: "pong" }
   | { type: "ping" }
   | {


### PR DESCRIPTION
## What

Phase B.4 of agent-network-topology umbrella #355 (per `docs/plan-agent-network-topology.md` §4.2): replace the Phase A **"Network (preview)" stub** with a real, live **stack-local agents panel** fed by the G-1114.B.3 runtime agent-presence registry. Agents pop up on boot and drop off when they go offline — the Phase B operator-value line.

**1. Registry exposed via the MC server.** New read-only `GET /api/agents` returns the registry's `getAgents()` snapshot (identity, capabilities, state, lastHeartbeat) projected to a snake_case DTO. The MC surface layer stays bus-free: the server depends only on a minimal `AgentPresenceView` interface declared in `api/agents.ts`; `cortex.ts` adapts the concrete `AgentPresenceRegistry` to it. Because the registry boots **after** the MC embed in `cortex.ts`, the handle is threaded as a **lazy getter** (`() => AgentPresenceView | null`) resolved per request — no boot-ordering dance. When MC is enabled but the presence registry is absent (gating mismatch), the route returns an **empty list gracefully**, never a 5xx.

**2. Live updates.** The registry's `onChange` seam is wired to broadcast a new **additive `agent.presence` WS frame** on every applied presence mutation. It's a **refresh signal** (not authoritative) — the panel refetches `/api/agents` on receipt, matching the S6 `mc.projection` pattern. It reuses the embed's existing `wsRegistry.broadcast`. Additive: older dashboard clients ignore the unknown frame; **no `WS_PROTOCOL_VERSION` bump**.

**3. Agents panel UI** (`dashboard-v2`). `use-agents` hook (boot fetch + `agent.presence` debounced refetch, gated on the Network tab visibility) + the panel rendering one row per agent: assistant name, agent id, capability badges, online/offline state, last-heartbeat relative time. Pure panel-mode + relative-time logic extracted to `lib/agents-display.ts`. The rich React Flow topology graph stays Phase D; federated peers stay Phase E — this is the simple stack-local panel.

## Live-update mechanism chosen

**New additive WS frame `agent.presence`** (`{ type, key, state }`), broadcast from the registry's `onChange` via the embed's `wsRegistry`. Chosen over reusing `mc.projection` because that frame's `family` is a closed union routed through `projection-routing`; a dedicated additive frame is a smaller, cleaner change and the panel's debounced refetch makes it a pure refresh signal. Old clients ignore it (type-keyed dispatcher no-ops).

## cortex.ts wiring touched (B.5 conflict check)

Only the **MC-embed block**:
- `startMissionControl(...)` gains `agentPresence: () => presenceViewForApi` (a holder declared just above the embed).
- After `startAgentPresenceRegistry(...)`: `presenceViewForApi = handle.registry` + (when the embed is up) `handle.registry.onChange(... wsRegistry.broadcast({ type: "agent.presence" }))`.
- One new type-only import.

**Untouched** (B.5 owns these): `src/runner/agent-presence-producer.ts`, `src/bus/capability-registry.ts`. `registry.ts` consumed read-only via its `getAgents()` + `onChange` seam.

## Test plan + gates

- New: `__tests__/api-agents.test.ts` (snapshot projection, empty/gating-mismatch path, **lazy getter resolution**, 405, 500), `dashboard-v2/__tests__/network-preview-view.test.tsx` (list/empty/error/offline render tree via `renderToStaticMarkup`), `dashboard-v2/__tests__/agents-display.test.ts` (panel mode + relative-time).
- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (pre-existing warnings only; none in changed files)
- `bun test` — **5568 pass, 2 skip, 0 fail** (321 files)
- `bash scripts/check-carveouts.sh` on changed files — PASS
- `bun build` dashboard — compiles clean

> **Note:** needs a **dashboard rebuild + CF Pages deploy** to show live (separate deploy step, per CLAUDE.md Dashboard Deployment).

refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)