### PR TITLE
feat(runner): pi-dev parses sage's structured verdict block — closes #888

### DIFF
--- a/src/runner/review-pipeline.ts
+++ b/src/runner/review-pipeline.ts
@@ -82,7 +82,6 @@ import {
   type DispatchTaskFailedReason,
   type ReviewEventSource,
   type ReviewRequestPayload,
-  type ReviewVerdictKind,
   type ReviewVerdictPayload,
 } from "../bus/review-events";
 import type { AnyResponseRouting } from "../bus/dispatch-events";
@@ -91,6 +90,11 @@ import type {
   CCSessionLike,
 } from "../substrates/claude-code/harness";
 import type { CCSessionOpts, CCSessionResult } from "./cc-session";
+import {
+  extractVerdictBlock,
+  parseVerdictBlock,
+  type VerdictBlock,
+} from "./verdict-block";
 import {
   classifyCcFailure,
   classifyCcSpawnError,
@@ -547,142 +551,6 @@ function failed(
     }),
   });
   return { kind: "failed", envelope };
-}
-
-/**
- * Extract the LAST fenced JSON block from a CC stream's response text.
- *
- * Per §4.5 the skill emits the verdict block at the end of its output;
- * picking the last block is robust against the skill emitting earlier
- * exploratory JSON (e.g. lens-internal scratch output) before the
- * terminal verdict. Returns the raw block text (still fenced-free) for
- * the JSON parser, or `null` if no block is present.
- *
- * The fence regex accepts both `\`\`\`json` and `\`\`\`JSON` (case-insensitive
- * tag) and tolerates a `\r\n` line-ending — Windows-line-ending output
- * from CC is rare but cheap to support.
- */
-function extractVerdictBlock(response: string): string | null {
-  const re = /```json\s*\r?\n([\s\S]*?)\r?\n```/gi;
-  const matches: string[] = [];
-  let m: RegExpExecArray | null = re.exec(response);
-  while (m !== null) {
-    if (m[1] !== undefined) matches.push(m[1]);
-    m = re.exec(response);
-  }
-  if (matches.length === 0) return null;
-  // Last block wins — §4.5 says the verdict is the terminal artefact.
-  // Type assertion safe because length is checked above.
-  return matches[matches.length - 1] ?? null;
-}
-
-/** Internal shape of the parsed verdict block per §4.5's contract. */
-interface VerdictBlock {
-  verdict: ReviewVerdictKind;
-  summary: string;
-  github_review_id: number;
-  github_review_url: string;
-  submitted_at: string;
-  commit_id: string;
-  findings: { blockers: number; majors: number; nits: number };
-  inline_comments: number;
-}
-
-type ParseResult<T> =
-  | { ok: true; value: T }
-  | { ok: false; detail: string };
-
-/**
- * Parse + validate the verdict block JSON. Returns a structured error
- * detail for any failure mode (JSON parse, missing field, wrong type,
- * out-of-enum verdict). The detail flows into the `cant_do` envelope's
- * `reason.detail` so principals can see which field tripped on the
- * dashboard.
- *
- * Validation is hand-rolled (no Zod) to keep PR-5 dependency-free and
- * because the contract is small (8 fields). If the contract grows, a
- * Zod schema is the natural refactor — symmetric with PR-4's config
- * loader.
- */
-function parseVerdictBlock(raw: string): ParseResult<VerdictBlock> {
-  let value: unknown;
-  try {
-    value = JSON.parse(raw);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    return { ok: false, detail: `JSON.parse failed: ${detail}` };
-  }
-
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return { ok: false, detail: "expected JSON object at top level" };
-  }
-  const obj = value as Record<string, unknown>;
-
-  const verdict = obj.verdict;
-  if (
-    verdict !== "approved" &&
-    verdict !== "changes-requested" &&
-    verdict !== "commented"
-  ) {
-    return {
-      ok: false,
-      detail: `verdict must be one of "approved" | "changes-requested" | "commented" (got ${JSON.stringify(verdict)})`,
-    };
-  }
-
-  if (typeof obj.summary !== "string") {
-    return { ok: false, detail: "summary must be a string" };
-  }
-  if (typeof obj.github_review_id !== "number" || !Number.isInteger(obj.github_review_id)) {
-    return { ok: false, detail: "github_review_id must be an integer" };
-  }
-  if (typeof obj.github_review_url !== "string") {
-    return { ok: false, detail: "github_review_url must be a string" };
-  }
-  if (typeof obj.submitted_at !== "string") {
-    return { ok: false, detail: "submitted_at must be a string (ISO 8601)" };
-  }
-  if (typeof obj.commit_id !== "string") {
-    return { ok: false, detail: "commit_id must be a string" };
-  }
-  if (typeof obj.inline_comments !== "number" || !Number.isInteger(obj.inline_comments)) {
-    return { ok: false, detail: "inline_comments must be an integer" };
-  }
-  if (
-    typeof obj.findings !== "object" ||
-    obj.findings === null ||
-    Array.isArray(obj.findings)
-  ) {
-    return { ok: false, detail: "findings must be an object" };
-  }
-  const findings = obj.findings as Record<string, unknown>;
-  if (typeof findings.blockers !== "number" || !Number.isInteger(findings.blockers)) {
-    return { ok: false, detail: "findings.blockers must be an integer" };
-  }
-  if (typeof findings.majors !== "number" || !Number.isInteger(findings.majors)) {
-    return { ok: false, detail: "findings.majors must be an integer" };
-  }
-  if (typeof findings.nits !== "number" || !Number.isInteger(findings.nits)) {
-    return { ok: false, detail: "findings.nits must be an integer" };
-  }
-
-  return {
-    ok: true,
-    value: {
-      verdict,
-      summary: obj.summary,
-      github_review_id: obj.github_review_id,
-      github_review_url: obj.github_review_url,
-      submitted_at: obj.submitted_at,
-      commit_id: obj.commit_id,
-      findings: {
-        blockers: findings.blockers,
-        majors: findings.majors,
-        nits: findings.nits,
-      },
-      inline_comments: obj.inline_comments,
-    },
-  };
 }
 
 /**

--- a/src/runner/substrate/__tests__/pi-dev-runner.test.ts
+++ b/src/runner/substrate/__tests__/pi-dev-runner.test.ts
@@ -169,8 +169,10 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
       expect(payload.reviewer).toBe("sage");
       expect(payload.verdict).toBe("commented");
 
-      // Argv pin — `sage review owner/repo#N --substrate pi`, with the
-      // resolved binary path as argv[0].
+      // Argv pin — `sage review owner/repo#N --substrate pi
+      // --emit-verdict-block`, with the resolved binary path as argv[0].
+      // cortex#888 — the verdict-block flag is always passed so sage emits
+      // the structured block we parse back into the verdict envelope.
       expect(spawn.calls.length).toBe(1);
       expect(spawn.calls[0]).toEqual([
         FAKE_SAGE_BIN,
@@ -178,6 +180,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
         `${VALID_PAYLOAD.repo}#${VALID_PAYLOAD.pr}`,
         "--substrate",
         "pi",
+        "--emit-verdict-block",
       ]);
     } finally {
       if (prior !== undefined) process.env.SAGE_SUBSTRATE = prior;
@@ -324,7 +327,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
       const result = await runner(makePipelineOpts());
       expect(result.kind).toBe("verdict");
       expect(spawn.calls.length).toBe(1);
-      expect(spawn.calls[0]!.slice(-2)).toEqual(["--substrate", "claude"]);
+      expect(spawn.calls[0]!.slice(-3)).toEqual(["--substrate", "claude", "--emit-verdict-block"]);
     } finally {
       if (prior === undefined) delete process.env.SAGE_SUBSTRATE;
       else process.env.SAGE_SUBSTRATE = prior;
@@ -341,7 +344,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
         which: whichSuccess,
       });
       await runner(makePipelineOpts());
-      expect(spawn.calls[0]!.slice(-2)).toEqual(["--substrate", "pi"]);
+      expect(spawn.calls[0]!.slice(-3)).toEqual(["--substrate", "pi", "--emit-verdict-block"]);
     } finally {
       if (prior !== undefined) process.env.SAGE_SUBSTRATE = prior;
     }
@@ -422,6 +425,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
         `${VALID_PAYLOAD.repo}#${VALID_PAYLOAD.pr}`,
         "--substrate",
         "pi",
+        "--emit-verdict-block",
         "--post",
       ]);
     } finally {
@@ -458,6 +462,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
         "saca/secacademy#62",
         "--substrate",
         "codex",
+        "--emit-verdict-block",
         "--post",
         "--forge",
         "gitlab",
@@ -482,5 +487,121 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     } finally {
       if (prior !== undefined) process.env.SAGE_SUBSTRATE = prior;
     }
+  });
+
+  // cortex#888 — structured verdict-block recovery
+  // ---------------------------------------------------------------------
+  // sage appends a fenced ```json verdict block under --emit-verdict-block
+  // (sage#83). The runner parses it to recover the REAL decision (incl.
+  // `approved`, which the exit-code-only fallback cannot express) and the
+  // findings counts. A missing / malformed block falls back to exit-code
+  // mapping so a parse hiccup never drops an otherwise-valid review.
+
+  function withBlock(
+    body: string,
+    block: Record<string, unknown>,
+  ): string {
+    return `${body}\n\n\`\`\`json\n${JSON.stringify(block, null, 2)}\n\`\`\``;
+  }
+
+  const SAMPLE_BLOCK = {
+    verdict: "approved",
+    summary: "No findings. Sage approves.",
+    github_review_id: 999,
+    github_review_url: "https://github.com/o/r/pull/1#pullrequestreview-999",
+    submitted_at: "2026-06-10T09:11:36Z",
+    commit_id: "abc1234deadbeef",
+    findings: { blockers: 0, majors: 0, nits: 0 },
+    inline_comments: 0,
+  };
+
+  test("cortex#888 — exit 0 + block verdict=approved → review.verdict.approved (recovers approved)", async () => {
+    const stdout = withBlock("## Sage code review — approved", SAMPLE_BLOCK);
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
+    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const opts = makePipelineOpts();
+    const result = await runner(opts);
+
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    const envelope: Envelope = result.envelope;
+    // Exit code alone would yield `commented`; the block recovers `approved`.
+    expect(envelope.type).toBe("review.verdict.approved");
+    const payload = envelope.payload as {
+      verdict: string;
+      github_review_id: number;
+      commit_id: string;
+      findings: { blockers: number; majors: number; nits: number };
+      summary: string;
+    };
+    expect(payload.verdict).toBe("approved");
+    expect(payload.github_review_id).toBe(999);
+    expect(payload.commit_id).toBe("abc1234deadbeef");
+    expect(payload.findings).toEqual({ blockers: 0, majors: 0, nits: 0 });
+    // Full markdown stdout (block included) is preserved as the summary.
+    expect(payload.summary).toBe(stdout);
+  });
+
+  test("cortex#888 — block findings counts flow into the verdict payload", async () => {
+    const stdout = withBlock("## Sage code review — changes-requested", {
+      ...SAMPLE_BLOCK,
+      verdict: "changes-requested",
+      findings: { blockers: 1, majors: 2, nits: 3 },
+    });
+    // Exit 1 AND block both say changes-requested — they agree here; the
+    // point is the findings counts come from the block.
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 1));
+    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const result = await runner(makePipelineOpts());
+
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    expect(result.envelope.type).toBe("review.verdict.changes-requested");
+    const payload = result.envelope.payload as {
+      findings: { blockers: number; majors: number; nits: number };
+    };
+    expect(payload.findings).toEqual({ blockers: 1, majors: 2, nits: 3 });
+  });
+
+  test("cortex#888 — block decision OVERRIDES exit code (exit 0 but block changes-requested)", async () => {
+    // Defensive: if sage's exit code and block ever disagree, the structured
+    // block is authoritative (it carries the calibrated decision).
+    const stdout = withBlock("## Sage code review — changes-requested", {
+      ...SAMPLE_BLOCK,
+      verdict: "changes-requested",
+      findings: { blockers: 1, majors: 0, nits: 0 },
+    });
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
+    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const result = await runner(makePipelineOpts());
+
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    expect(result.envelope.type).toBe("review.verdict.changes-requested");
+  });
+
+  test("cortex#888 — malformed block falls back to exit-code mapping (exit 0 → commented)", async () => {
+    const stdout = "## Sage code review — commented\n\n```json\n{ not valid json\n```";
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
+    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const result = await runner(makePipelineOpts());
+
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    expect(result.envelope.type).toBe("review.verdict.commented");
+    // Fallback path → placeholder structured fields.
+    const payload = result.envelope.payload as { github_review_id: number };
+    expect(payload.github_review_id).toBe(0);
+  });
+
+  test("cortex#888 — no block (older sage) falls back to exit-code mapping (exit 1 → changes-requested)", async () => {
+    const stdout = "## Sage code review — changes-requested\n\n(no json block)";
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 1));
+    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const result = await runner(makePipelineOpts());
+
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    expect(result.envelope.type).toBe("review.verdict.changes-requested");
   });
 });

--- a/src/runner/substrate/pi-dev-runner.ts
+++ b/src/runner/substrate/pi-dev-runner.ts
@@ -90,6 +90,11 @@ import {
   createReviewVerdictEvent,
 } from "../../bus/review-events";
 import type { ReviewVerdictKind } from "../../bus/review-events";
+import {
+  extractVerdictBlock,
+  parseVerdictBlock,
+  type VerdictBlock,
+} from "../verdict-block";
 import type {
   ReviewPipelineOpts,
   ReviewPipelineResult,
@@ -231,7 +236,14 @@ export function makePiDevPipelineRunner(
     // side `--substrate` parse error (which the failure-mapping table
     // below maps to `cant_do`).
     const substrate = process.env.SAGE_SUBSTRATE ?? "pi";
-    const argv = [sageBin, "review", prRef, "--substrate", substrate];
+    // cortex#888 — ask sage to append the structured verdict block as the
+    // terminal stdout artefact (sage#83 `--emit-verdict-block`). We parse it
+    // below to recover the REAL decision (`approved` is invisible to the
+    // exit-code-only fallback) + findings counts. Older sage builds that
+    // don't know the flag would error on it — but the flag shipped in
+    // lockstep (sage#83) and the bundled sage is pinned, so this is safe;
+    // if the block is absent for any reason we fall back to exit-code mapping.
+    const argv = [sageBin, "review", prRef, "--substrate", substrate, "--emit-verdict-block"];
     // Propagate the dispatch's `--post` intent. `sage dispatch --post`
     // stamps `payload.post: true` (sage#8) and the review-consumer carries
     // it through; without this the verdict is computed but never posted to
@@ -298,10 +310,27 @@ export function makePiDevPipelineRunner(
       );
     }
 
-    // Map the exit code to the verdict decision. Exit 1 ⇒ changes-requested.
-    // Exit 0 stays `commented` because sage doesn't distinguish approved
-    // from commented via exit code — Phase 2 (sage `--format json`, sage#TBD)
-    // parses the structured verdict block to recover approved/findings.
+    // cortex#888 (Phase 2) — recover the real verdict from sage's structured
+    // block. sage emits it as the terminal ```json fence under
+    // `--emit-verdict-block` (sage#83). The block carries the true decision
+    // (incl. `approved`, invisible to the exit code) + findings counts +
+    // commit_id. A present, well-formed block wins; anything else
+    // (older sage, malformed JSON, missing block) falls back to the
+    // exit-code mapping below so a parse hiccup never drops a valid review.
+    const rawBlock = extractVerdictBlock(stdout);
+    if (rawBlock !== null) {
+      const parsed = parseVerdictBlock(rawBlock);
+      if (parsed.ok) {
+        return verdict(pipeline, correlationId, stdout, parsed.value.verdict, parsed.value);
+      }
+      // Block present but malformed — log + fall through to exit-code mapping.
+      console.error(
+        `[pi-dev] verdict block malformed (${parsed.detail}); falling back to exit-code mapping`,
+      );
+    }
+
+    // Fallback: exit 1 ⇒ changes-requested; exit 0 ⇒ commented (sage can't
+    // distinguish approved from commented via exit code alone).
     const decision: ReviewVerdictKind =
       exitCode === 1 ? "changes-requested" : "commented";
     return verdict(pipeline, correlationId, stdout, decision);
@@ -361,16 +390,22 @@ function failed(
 
 /**
  * Build a `review.verdict.{decision}` envelope carrying sage's markdown
- * stdout as `payload.summary`. `decision` is derived from sage's exit code
- * (changes-requested vs commented). `reviewer` is hardcoded to `sage`;
- * Phase 2 (sage `--format json`) derives reviewer + findings from the
- * structured verdict block.
+ * stdout as `payload.summary`.
+ *
+ * When `block` is supplied (cortex#888 — sage emitted a well-formed
+ * `--emit-verdict-block` artefact), the structured fields (findings counts,
+ * github review id/url, commit_id, submitted_at, inline_comments) come from
+ * it. Without a block (fallback path: older sage, malformed JSON), those
+ * fields surface as zeros / empty strings — pilot still sees a well-formed
+ * envelope and principals can grep the markdown summary for the values.
+ * `reviewer` stays `sage` (the substrate doing the review).
  */
 function verdict(
   pipeline: ReviewPipelineOpts,
   correlationId: string,
   stdout: string,
   decision: ReviewVerdictKind,
+  block?: VerdictBlock,
 ): ReviewPipelineResult {
   const payload = pipeline.payload;
   const source = pipeline.source;
@@ -381,24 +416,15 @@ function verdict(
     payload: {
       repo: payload.repo,
       pr: payload.pr,
-      // Phase 1 default — sage is the substrate doing the review.
-      // Phase 2 reads the reviewer agent identity from sage's
-      // structured verdict block.
       reviewer: "sage",
       verdict: decision,
       summary: stdout,
-      // Placeholder fields Phase 1 doesn't have access to without a
-      // structured verdict block. The verdict envelope schema requires
-      // these fields; we surface zeros / empty strings so pilot's
-      // subscriber still sees a well-formed envelope and principals can
-      // grep the markdown summary for the actual values. Phase 2
-      // populates these from sage's `--format json` block.
-      github_review_id: 0,
-      github_review_url: "",
-      submitted_at: new Date().toISOString(),
-      commit_id: "",
-      findings: { blockers: 0, majors: 0, nits: 0 },
-      inline_comments: 0,
+      github_review_id: block?.github_review_id ?? 0,
+      github_review_url: block?.github_review_url ?? "",
+      submitted_at: block?.submitted_at ?? new Date().toISOString(),
+      commit_id: block?.commit_id ?? "",
+      findings: block?.findings ?? { blockers: 0, majors: 0, nits: 0 },
+      inline_comments: block?.inline_comments ?? 0,
     },
   });
   return { kind: "verdict", envelope };

--- a/src/runner/verdict-block.ts
+++ b/src/runner/verdict-block.ts
@@ -1,0 +1,146 @@
+import type { ReviewVerdictKind } from "../bus/review-events";
+
+/**
+ * Shared verdict-block parser (cortex#888).
+ *
+ * The reviewing skill / substrate emits a structured verdict block as the
+ * terminal artefact of its stdout (a fenced ```json block, §4.5). Two runners
+ * consume it: the Claude-Code substrate path (`review-pipeline.ts`) and the
+ * `pi-dev` substrate path (`substrate/pi-dev-runner.ts`, where sage's
+ * `--emit-verdict-block` output lands). Extracted here so both parse the SAME
+ * contract — a single field-validation table, one place to evolve.
+ */
+
+/** Internal shape of the parsed verdict block per §4.5's contract. */
+export interface VerdictBlock {
+  verdict: ReviewVerdictKind;
+  summary: string;
+  github_review_id: number;
+  github_review_url: string;
+  submitted_at: string;
+  commit_id: string;
+  findings: { blockers: number; majors: number; nits: number };
+  inline_comments: number;
+}
+
+export type ParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; detail: string };
+
+/**
+ * Extract the LAST fenced JSON block from a stream's response text.
+ *
+ * Per §4.5 the skill emits the verdict block at the end of its output;
+ * picking the last block is robust against the skill emitting earlier
+ * exploratory JSON (e.g. lens-internal scratch output) before the
+ * terminal verdict. Returns the raw block text (still fenced-free) for
+ * the JSON parser, or `null` if no block is present.
+ *
+ * The fence regex accepts both ```json and ```JSON (case-insensitive
+ * tag) and tolerates a `\r\n` line-ending — Windows-line-ending output
+ * is rare but cheap to support.
+ */
+export function extractVerdictBlock(response: string): string | null {
+  const re = /```json\s*\r?\n([\s\S]*?)\r?\n```/gi;
+  const matches: string[] = [];
+  let m: RegExpExecArray | null = re.exec(response);
+  while (m !== null) {
+    if (m[1] !== undefined) matches.push(m[1]);
+    m = re.exec(response);
+  }
+  if (matches.length === 0) return null;
+  // Last block wins — §4.5 says the verdict is the terminal artefact.
+  // Type assertion safe because length is checked above.
+  return matches[matches.length - 1] ?? null;
+}
+
+/**
+ * Parse + validate the verdict block JSON. Returns a structured error
+ * detail for any failure mode (JSON parse, missing field, wrong type,
+ * out-of-enum verdict). The detail flows into the `cant_do` envelope's
+ * `reason.detail` so principals can see which field tripped on the
+ * dashboard.
+ *
+ * Validation is hand-rolled (no Zod) to keep the runner dependency-free
+ * and because the contract is small (8 fields).
+ */
+export function parseVerdictBlock(raw: string): ParseResult<VerdictBlock> {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, detail: `JSON.parse failed: ${detail}` };
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { ok: false, detail: "expected JSON object at top level" };
+  }
+  const obj = value as Record<string, unknown>;
+
+  const verdict = obj.verdict;
+  if (
+    verdict !== "approved" &&
+    verdict !== "changes-requested" &&
+    verdict !== "commented"
+  ) {
+    return {
+      ok: false,
+      detail: `verdict must be one of "approved" | "changes-requested" | "commented" (got ${JSON.stringify(verdict)})`,
+    };
+  }
+
+  if (typeof obj.summary !== "string") {
+    return { ok: false, detail: "summary must be a string" };
+  }
+  if (typeof obj.github_review_id !== "number" || !Number.isInteger(obj.github_review_id)) {
+    return { ok: false, detail: "github_review_id must be an integer" };
+  }
+  if (typeof obj.github_review_url !== "string") {
+    return { ok: false, detail: "github_review_url must be a string" };
+  }
+  if (typeof obj.submitted_at !== "string") {
+    return { ok: false, detail: "submitted_at must be a string (ISO 8601)" };
+  }
+  if (typeof obj.commit_id !== "string") {
+    return { ok: false, detail: "commit_id must be a string" };
+  }
+  if (typeof obj.inline_comments !== "number" || !Number.isInteger(obj.inline_comments)) {
+    return { ok: false, detail: "inline_comments must be an integer" };
+  }
+  if (
+    typeof obj.findings !== "object" ||
+    obj.findings === null ||
+    Array.isArray(obj.findings)
+  ) {
+    return { ok: false, detail: "findings must be an object" };
+  }
+  const findings = obj.findings as Record<string, unknown>;
+  if (typeof findings.blockers !== "number" || !Number.isInteger(findings.blockers)) {
+    return { ok: false, detail: "findings.blockers must be an integer" };
+  }
+  if (typeof findings.majors !== "number" || !Number.isInteger(findings.majors)) {
+    return { ok: false, detail: "findings.majors must be an integer" };
+  }
+  if (typeof findings.nits !== "number" || !Number.isInteger(findings.nits)) {
+    return { ok: false, detail: "findings.nits must be an integer" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      verdict,
+      summary: obj.summary,
+      github_review_id: obj.github_review_id,
+      github_review_url: obj.github_review_url,
+      submitted_at: obj.submitted_at,
+      commit_id: obj.commit_id,
+      findings: {
+        blockers: findings.blockers,
+        majors: findings.majors,
+        nits: findings.nits,
+      },
+      inline_comments: obj.inline_comments,
+    },
+  };
+}


### PR DESCRIPTION
## What

The `pi-dev` substrate runner now parses sage's structured verdict block to recover the real review decision + findings counts, instead of deriving the verdict from the process exit code alone. Closes #888. Pairs with **the-metafactory/sage#83** (`sage review --emit-verdict-block`).

## Why

`pi-dev-runner` (cortex#331 Phase 1) mapped sage's **exit code** to the verdict:

- exit 0 → `commented`
- exit 1 → `changes-requested`

So **`approved` was unreachable** — a clean PR exits 0 and was reported `commented` — and the findings counts (blockers/majors/nits) were placeholder zeros. pilot's merge gate never saw `approved`, blocking the autonomous loop. The module's own docblock flagged this as the planned Phase 2 ("sage `--format json`, sage#TBD").

Confirmed empirically: a `code-review.generic` dispatch to sage returned `review.verdict.commented` with an empty payload even though sage had run a full review.

## Changes

- **`src/runner/verdict-block.ts`** (new) — `extractVerdictBlock` + `parseVerdictBlock` + `VerdictBlock`, extracted verbatim from `review-pipeline.ts`. Both substrate paths (Claude-Code + pi-dev) now share one field-validation table for the same contract. No behavior change to the Claude-Code path — it imports the same functions it defined before.
- **`pi-dev-runner.ts`**:
  - passes `--emit-verdict-block` to `sage review` (always).
  - parses the terminal ```json block from sage stdout. A present, well-formed block is **authoritative**: its `verdict` (incl. `approved`), `findings`, `github_review_id`/`url`, `commit_id`, `submitted_at` populate the verdict envelope.
  - **fallback preserved**: a missing block (older sage) or malformed JSON falls back to the exit-code mapping + placeholder fields, so a parse hiccup never drops an otherwise-valid review (it logs and degrades).

## Testing

- Full runner suite: **487 pass / 0 fail**; `tsc --noEmit` clean.
- Argv pins updated for the new flag (5 existing tests).
- 5 new recovery tests: `approved` recovery (exit 0 + block), findings flow-through, block-overrides-exit-code (defensive), malformed-block fallback, no-block fallback.

## Sequencing

Merge order: **sage#83 first** (sage must emit the block), then this. With an older sage that doesn't know `--emit-verdict-block`, sage would error on the flag → exit ≥2 → `failed` envelope; the bundled sage is pinned and ships the flag in lockstep, so deploy the two together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
