### PR TITLE
feat(mc): G-1114.C.1 — agent.capabilities-changed producer

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3028,6 +3028,14 @@ export async function startCortex(
   await router.start();
 
   // Config watcher (hot-reload for safe fields).
+  //
+  // G-1114.C.1 — the agent-presence producer is constructed LATER (the
+  // MC-registry block below), but the config-reload onChange handler needs a
+  // reference to emit `agent.capabilities-changed` on a mid-life capability
+  // drift. Forward-declare the holder here and read it lazily inside the
+  // closure (it's still `null` until the registry block assigns it — a reload
+  // that races boot before the producer exists simply skips the emit).
+  let presenceProducerForReload: AgentPresenceProducer | null = null;
   let configWatcher: ConfigWatcher | null = null;
   if (
     !options.disableConfigWatcher
@@ -3035,10 +3043,6 @@ export async function startCortex(
     && existsSync(expandedConfigPath)
   ) {
     configWatcher = new ConfigWatcher(expandedConfigPath, config, (event) => {
-      // cortex#237: capability-registry re-publish lands here once
-      // AgentsDirectoryWatcher is wired — see boot block ~line 540 for
-      // rationale (AgentConfig hot-reload's SAFE_FIELDS doesn't include
-      // capabilities; mergedAgents isn't re-built).
       dispatchHandler.updateConfig(event.config, expandedConfigPath);
       for (const adapter of adapters) adapter.updateConfig?.(event.config);
       if (cloudPublisher) {
@@ -3049,6 +3053,48 @@ export async function startCortex(
       }
       if (event.requiresRestart.length > 0) {
         console.warn(`cortex: ${event.requiresRestart.length} field(s) require restart:`, event.requiresRestart.join(", "));
+      }
+
+      // G-1114.C.1 — capability-delta re-emit (THE FINDING, honest scope).
+      //
+      // Per-agent capabilities live on `Agent.runtime.capabilities[]` (the
+      // agents.d/ fragments), NOT on `AgentConfig` (the `event.config` this
+      // reload carries) — and the ConfigWatcher does not rebuild `mergedAgents`.
+      // So today capabilities are effectively RESTART-ONLY: the only daemon-level
+      // watcher is this one, it fires on the bot.yaml/pointer config (not on a
+      // fragment edit), and a fresh capability set normally arrives via the next
+      // boot's `agent.online`. This block is the defensive EMIT side: when a
+      // reload DOES fire, we re-scan the agents.d/ fragments (the same load boot
+      // does) and ask the producer to diff each known agent's capability set
+      // against its tracked baseline — emitting `agent.capabilities-changed` only
+      // on a real delta. It is a no-op in the common case (no fragment changed,
+      // or no producer yet), and becomes a live hot-reload path the moment a
+      // capability fragment is edited under a watched config dir. Best-effort:
+      // a fragment re-load fault must never break the rest of the reload.
+      const producer = presenceProducerForReload;
+      if (producer !== null) {
+        try {
+          const freshFragments = loadAgentsDirectory(agentsDir);
+          const freshById = new Map(freshFragments.map((a) => [a.id, a]));
+          let emitted = 0;
+          for (const prior of mergedAgents) {
+            const fresh = freshById.get(prior.id);
+            if (fresh === undefined) continue; // removed/renamed — not a cap delta
+            const caps = fresh.runtime?.capabilities ?? [];
+            if (producer.publishCapabilitiesChanged(prior.id, caps)) emitted += 1;
+          }
+          if (emitted > 0) {
+            console.log(
+              `cortex: agent-presence — emitted ${emitted} agent.capabilities-changed on reload`,
+            );
+          }
+        } catch (err) {
+          // FragmentLoadError or any re-scan fault: log + carry on. The producer
+          // keeps its prior baseline; the next clean reload (or restart) reconciles.
+          process.stderr.write(
+            `cortex: capabilities-changed re-scan skipped on reload — ${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
       }
     });
     configWatcher.start();
@@ -3225,6 +3271,12 @@ export async function startCortex(
         agents: presenceAgents,
       });
       presenceProducer.start();
+      // G-1114.C.1 — publish the now-started producer to the config-reload
+      // onChange handler so a mid-life capability drift can emit
+      // `agent.capabilities-changed` without restart (see that handler's block
+      // for THE FINDING — restart-only in the common case, this is the
+      // defensive emit side).
+      presenceProducerForReload = presenceProducer;
       console.log(
         `cortex: agent-presence producer + registry started — ${presenceAgents.length} agent(s) announced ` +
           `(stack-local; heartbeat every ${DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS}ms)`,

--- a/src/runner/__tests__/agent-presence-producer.test.ts
+++ b/src/runner/__tests__/agent-presence-producer.test.ts
@@ -279,6 +279,171 @@ describe("producer → registry roundtrip", () => {
   });
 });
 
+describe("AgentPresenceProducer.publishCapabilitiesChanged", () => {
+  // G-1114.C.1 — the mid-life capability-mutation emit path. See the producer's
+  // class doc + the FINDING in the PR: capabilities are restart-only at the
+  // daemon today (ConfigWatcher carries no per-agent caps; AgentsDirectoryWatcher
+  // isn't wired into cortex.ts), so this method exists for the moment a capability
+  // hot-reload becomes possible — the diff logic is the load-bearing half.
+
+  test("emits agent.capabilities-changed with the FULL new set + correct subject", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A, AGENT_B],
+      scheduler: manualScheduler(),
+      now: () => new Date("2026-06-10T10:00:00.000Z"),
+    });
+    producer.start();
+    const emitted = producer.publishCapabilitiesChanged("luna", [
+      "code-review.typescript",
+      "research",
+    ]);
+    expect(emitted).toBe(true);
+    const changes = runtime.published.filter(
+      (e) => e.type === "agent.capabilities-changed",
+    );
+    expect(changes.length).toBe(1);
+    const env = changes[0]!;
+    // FULL new set (not a diff) on the payload.
+    expect((env.payload as { capabilities: string[] }).capabilities).toEqual([
+      "code-review.typescript",
+      "research",
+    ]);
+    // Identity is the agent's, not the other agent's.
+    expect((env.payload as { identity: { agent_id: string } }).identity.agent_id).toBe(
+      "luna",
+    );
+    expect((env.payload as { sent_at: string }).sent_at).toBe(
+      "2026-06-10T10:00:00.000Z",
+    );
+    // Subject derives to the stack-local capabilities-changed subject.
+    expect(deriveNatsSubject(env, "meta-factory")).toBe(
+      "local.andreas.meta-factory.agent.capabilities-changed",
+    );
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("diff: no-op (no emit) when the capability set is unchanged", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    // AGENT_A's caps are exactly ["code-review.typescript"] — same set.
+    const emitted = producer.publishCapabilitiesChanged("luna", [
+      "code-review.typescript",
+    ]);
+    expect(emitted).toBe(false);
+    expect(
+      runtime.published.filter((e) => e.type === "agent.capabilities-changed").length,
+    ).toBe(0);
+  });
+
+  test("diff is order-insensitive: same set in different order is a no-op", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [
+        {
+          identity: { nkey_public_key: "UAAA", agent_id: "luna", assistant_name: "Luna" },
+          scope: { principal: "andreas", stack: "meta-factory" },
+          capabilities: ["a", "b", "c"],
+        },
+      ],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    expect(producer.publishCapabilitiesChanged("luna", ["c", "a", "b"])).toBe(false);
+    expect(
+      runtime.published.filter((e) => e.type === "agent.capabilities-changed").length,
+    ).toBe(0);
+  });
+
+  test("emits on a real delta (added capability) and updates the tracked set", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    // First change: add "research".
+    expect(
+      producer.publishCapabilitiesChanged("luna", [
+        "code-review.typescript",
+        "research",
+      ]),
+    ).toBe(true);
+    // A repeat of the SAME new set is now a no-op — the producer tracks the
+    // post-change set as the new baseline.
+    expect(
+      producer.publishCapabilitiesChanged("luna", [
+        "code-review.typescript",
+        "research",
+      ]),
+    ).toBe(false);
+    expect(
+      runtime.published.filter((e) => e.type === "agent.capabilities-changed").length,
+    ).toBe(1);
+  });
+
+  test("emits when capabilities are fully revoked (new set is empty)", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    expect(producer.publishCapabilitiesChanged("luna", [])).toBe(true);
+    const [env] = runtime.published.filter(
+      (e) => e.type === "agent.capabilities-changed",
+    );
+    expect((env!.payload as { capabilities: string[] }).capabilities).toEqual([]);
+  });
+
+  test("returns false (no emit) for an unknown agent id", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    expect(producer.publishCapabilitiesChanged("nobody", ["x"])).toBe(false);
+    expect(
+      runtime.published.filter((e) => e.type === "agent.capabilities-changed").length,
+    ).toBe(0);
+  });
+
+  test("roundtrip: capabilities-changed folds into the registry as the new set", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    producer.publishCapabilitiesChanged("luna", ["research", "code-review.typescript"]);
+    const registry = new AgentPresenceRegistry();
+    for (const env of runtime.published) registry.apply(env);
+    const [rec] = registry.getAgents();
+    expect(rec?.agentId).toBe("luna");
+    expect(rec?.state).toBe("online");
+    expect(rec?.capabilities).toEqual(["research", "code-review.typescript"]);
+  });
+});
+
 describe("presenceAgentFromAgent", () => {
   const baseAgent = (over: Partial<Agent> = {}): Agent => ({
     id: "luna",

--- a/src/runner/agent-presence-producer.ts
+++ b/src/runner/agent-presence-producer.ts
@@ -23,6 +23,26 @@
  *      agent BEFORE the runtime/bus tears down (the boot wiring registers
  *      {@link AgentPresenceProducer.stop} in the cortex.ts shutdown drain ahead
  *      of `runtime stop`).
+ *   4. (G-1114.C.1) on a mid-life capability mutation, publishes ONE
+ *      `agent.capabilities-changed` carrying the FULL new steady-state set —
+ *      {@link AgentPresenceProducer.publishCapabilitiesChanged}. Diff-guarded:
+ *      a no-op when the new set equals the tracked set (order-insensitive), so
+ *      an idempotent reload that re-asserts the same caps emits nothing.
+ *
+ * **The C.1 FINDING — capabilities are RESTART-ONLY at the daemon today.**
+ * Per-agent capabilities live on `Agent.runtime.capabilities[]` (the agents.d/
+ * fragments), NOT on `AgentConfig.agent` (bot.yaml). The only daemon-level
+ * config watcher wired into `cortex.ts` is the `ConfigWatcher`, whose SAFE_FIELDS
+ * / RESTART_FIELDS cover `AgentConfig` only — it never sees a capability change,
+ * and cortex.ts does NOT rebuild `mergedAgents` on reload (see the cortex.ts
+ * capability-registry boot block). The `AgentsDirectoryWatcher` CAN diff per-agent
+ * capability changes (its `agentsChanged`), but it is not instantiated in
+ * cortex.ts. So today a capability change requires a daemon RESTART, and the next
+ * boot's `agent.online` already carries the new set (item 1). This method is the
+ * EMIT side for the moment a capability hot-reload becomes possible: it is wired
+ * defensively into the config-reload onChange handler (cortex.ts) so that IF/WHEN
+ * mergedAgents starts being rebuilt mid-life, the delta flows without restart.
+ * The diff logic is the load-bearing half and is fully exercised regardless.
  *
  * **Mirrors `src/runner/heartbeat-ticker.ts`** — the dispatch HeartbeatTicker's
  * interval-publish + injectable-scheduler + idempotent-stop pattern — but it is
@@ -49,6 +69,7 @@ import {
   createAgentOnlineEvent,
   createAgentHeartbeatEvent,
   createAgentOfflineEvent,
+  createAgentCapabilitiesChangedEvent,
   type AgentPresenceSource,
 } from "../bus/agent-network/builders";
 import type {
@@ -134,6 +155,22 @@ export function presenceAgentFromAgent(
   };
 }
 
+/**
+ * Order-insensitive set equality for capability lists. Capabilities are an
+ * UNORDERED set of ids (ADR-0007 §3) — `["a","b"]` and `["b","a"]` advertise the
+ * same agent, so a reorder must NOT count as a delta. Compares membership only.
+ */
+function capabilitySetsEqual(
+  a: ReadonlySet<string>,
+  b: ReadonlySet<string>,
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const cap of a) {
+    if (!b.has(cap)) return false;
+  }
+  return true;
+}
+
 /** Injectable scheduler — tests pass a controllable fake; production omits. */
 export interface PresenceScheduler {
   setInterval(handler: () => void, ms: number): ReturnType<typeof setInterval>;
@@ -189,6 +226,19 @@ export class AgentPresenceProducer {
   /** Bound the in-flight heartbeat publishes to 1 per agent-batch (backpressure). */
   private heartbeatInFlight = false;
 
+  /**
+   * The producer's view of each agent's CURRENT advertised capability set,
+   * keyed by `agent_id`. Seeded from each {@link PresenceAgent.capabilities}
+   * (the same set stamped on the boot `agent.online`), then advanced by
+   * {@link publishCapabilitiesChanged} on every emitted delta. This is the
+   * baseline the diff compares against — keeping it in sync with what's gone out
+   * on the wire is what makes a re-asserted same-set reload a no-op (G-1114.C.1).
+   */
+  private readonly capabilityBaseline = new Map<string, ReadonlySet<string>>();
+
+  /** `agent_id` → identity/scope, for routing a capabilities-changed emit. */
+  private readonly agentsById = new Map<string, PresenceAgent>();
+
   constructor(opts: AgentPresenceProducerOptions) {
     this.runtime = opts.runtime;
     this.source = opts.source;
@@ -196,6 +246,13 @@ export class AgentPresenceProducer {
     this.intervalMs = opts.intervalMs ?? DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS;
     this.scheduler = opts.scheduler ?? realScheduler;
     this.now = opts.now ?? (() => new Date());
+    for (const agent of this.agents) {
+      this.agentsById.set(agent.identity.agent_id, agent);
+      this.capabilityBaseline.set(
+        agent.identity.agent_id,
+        new Set(agent.capabilities),
+      );
+    }
   }
 
   /**
@@ -246,6 +303,77 @@ export class AgentPresenceProducer {
     await Promise.allSettled(
       this.agents.map((agent) => this.publishOffline(agent, reason)),
     );
+  }
+
+  /**
+   * G-1114.C.1 — emit `agent.capabilities-changed` for `agentId` carrying the
+   * FULL new steady-state capability set (ADR-0007 §3: the subscriber computes
+   * the diff against its current record; we carry the whole set so a subscriber
+   * that missed an earlier delta still converges).
+   *
+   * **Diff-guarded.** Returns `false` WITHOUT emitting when:
+   *   - `agentId` is not a known hosted agent (nothing to announce), or
+   *   - `newCapabilities` equals the producer's tracked baseline for that agent
+   *     (order-insensitive set equality) — an idempotent reload that re-asserts
+   *     the same caps emits nothing.
+   *
+   * On an actual change it publishes one envelope, advances the tracked baseline
+   * to the new set, and returns `true`. Best-effort like the other emits: a
+   * builder/publish fault is logged to stderr and swallowed (the baseline is
+   * still advanced so a transient publish failure doesn't wedge the diff into
+   * re-emitting on every subsequent reload). The caller (the cortex.ts
+   * config-reload onChange handler) treats the return purely as "did a delta
+   * fire" for logging.
+   *
+   * @param agentId the hosted agent whose capabilities changed (`agent_id`).
+   * @param newCapabilities the agent's complete new capability set.
+   * @returns `true` if an envelope was emitted (real delta), else `false`.
+   */
+  publishCapabilitiesChanged(
+    agentId: string,
+    newCapabilities: readonly string[],
+  ): boolean {
+    const agent = this.agentsById.get(agentId);
+    if (agent === undefined) {
+      // Unknown agent — never seen on boot, so there's no presence record to
+      // mutate. Silently ignore (the reload handler iterates only known agents,
+      // so this is a belt-and-braces guard, not an expected path).
+      return false;
+    }
+    const baseline = this.capabilityBaseline.get(agentId) ?? new Set<string>();
+    const next = new Set(newCapabilities);
+    if (capabilitySetsEqual(baseline, next)) {
+      // No actual change — emit nothing.
+      return false;
+    }
+    // Advance the baseline up-front so a publish fault below doesn't leave the
+    // diff re-firing on every subsequent reload (we've decided this IS the new
+    // steady state; the wire emit is best-effort).
+    this.capabilityBaseline.set(agentId, next);
+
+    let envelope;
+    try {
+      envelope = createAgentCapabilitiesChangedEvent({
+        source: this.source,
+        identity: agent.identity,
+        scope: agent.scope,
+        capabilities: [...newCapabilities],
+        sentAt: this.now(),
+      });
+    } catch (err) {
+      process.stderr.write(
+        `agent-presence-producer: createAgentCapabilitiesChangedEvent failed (agent=${agentId}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return true;
+    }
+    void this.runtime.publish(envelope).catch((err: unknown) => {
+      process.stderr.write(
+        `agent-presence-producer: agent.capabilities-changed publish failed (agent=${agentId}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    });
+    return true;
   }
 
   private publishOnline(agent: PresenceAgent): void {


### PR DESCRIPTION
## THE FINDING — capabilities are RESTART-ONLY at the daemon today

**Can an agent's capabilities change at RUNTIME (hot-reload) vs require a restart?** → **Restart-only**, with the hot-reload machinery present but unwired.

Evidence:

- Per-agent capabilities live on **`Agent.runtime.capabilities[]`** (the `agents.d/` fragments / `cortex-config` `Agent` type), **NOT** on `AgentConfig.agent` (bot.yaml). `presenceAgentFromAgent` reads `agent.runtime?.capabilities`.
- The only daemon-level config watcher wired into `cortex.ts` is **`ConfigWatcher`** (`src/common/config/watcher.ts`). Its `SAFE_FIELDS` / `RESTART_FIELDS` sets enumerate `AgentConfig` fields only — capabilities are not among them. So a capability edit never classifies as a hot-reloadable field there.
- `cortex.ts` does **not** rebuild `mergedAgents` on a `ConfigWatcher` reload — this is stated outright in the capability-registry boot block (`src/cortex.ts`): *"we do NOT wire a re-publish into the AgentConfig hot-reload path because (a) capabilities live on `Agent`, not `AgentConfig`, and (b) cortex.ts does not currently run an agents.d/ fragment watcher at the daemon level."*
- `AgentsDirectoryWatcher` (same file) **can** diff per-agent capability changes (its `agentsChanged` set), but it is **not instantiated** in `cortex.ts` (`grep "new AgentsDirectoryWatcher" src/cortex.ts` → none).

**Conclusion:** a capability change requires a daemon **restart**, and the next boot's `agent.online` already carries the new set (the B.2 producer's item 1). So a runtime `agent.capabilities-changed` envelope only fires in a narrow case — which is exactly what this PR builds the honest emit side for, without forcing a hot-reload mechanism that doesn't exist.

## What I built (method + trigger, per the restart-only branch)

- **`AgentPresenceProducer.publishCapabilitiesChanged(agentId, newCaps): boolean`** — emits ONE `agent.capabilities-changed` carrying the **FULL new steady-state set** (ADR-0007 §3; the subscriber computes the diff), via the B.1 builder `createAgentCapabilitiesChangedEvent`. Best-effort (builder/publish faults logged to stderr and swallowed, like the sibling emits).
- **Diff logic** — the producer tracks a per-agent capability baseline (seeded from `PresenceAgent.capabilities`, i.e. the same set stamped on the boot `agent.online`, then advanced on every emitted delta). `publishCapabilitiesChanged` emits **only on a real change** via order-insensitive set equality (`capabilitySetsEqual`); a re-asserted same set — even reordered — is a no-op and returns `false`. Unknown `agentId` → `false`, no emit. Empty new set (full revoke) → emits `capabilities: []`.
- **Reload-path wiring (defensive emit side)** — in the `cortex.ts` **config-reload `onChange` handler**, when a reload fires, re-scan the `agents.d/` fragments (the same `loadAgentsDirectory` boot uses), diff each known agent's capability set against the producer baseline, and call `publishCapabilitiesChanged`. No-op in the common case (no fragment changed, or no producer yet); becomes a **live hot-reload path** the moment a capability fragment is edited under a watched config dir — so IF/WHEN a capability hot-reload becomes possible, the delta flows without restart. Fragment re-load faults are logged and never break the rest of the reload.

Consistency with B.5's dual-emit story: the set carried in `agent.capabilities-changed` is sourced from the same `agent.runtime.capabilities[]` that feeds `agent.online` / the legacy `agents.capabilities.registered` — one source of truth, no divergence.

### cortex.ts region touched
- The **config-watcher `onChange` handler** (~3031–3057): forward-declared a `presenceProducerForReload` holder + the capability-delta re-scan/emit block.
- One **single-line holder assignment** at the producer `.start()` site (~3274): `presenceProducerForReload = presenceProducer;`. **Not** the `startAgentPresenceRegistry` registry-start block (left for C.3's reaper).

## Files changed
- `src/runner/agent-presence-producer.ts` — method, diff helper, baseline tracker, doc with THE FINDING.
- `src/runner/__tests__/agent-presence-producer.test.ts` — new `publishCapabilitiesChanged` describe block.
- `src/cortex.ts` — config-reload onChange wiring + producer holder assignment.

## Test plan
- Emits `agent.capabilities-changed` with the correct FULL new set, valid envelope, subject `local.{principal}.{stack}.agent.capabilities-changed`.
- Diff: no-op when unchanged; order-insensitive no-op; emit on real delta then baseline advances (repeat = no-op); emit on full revoke (`[]`); `false` for unknown agent.
- Roundtrip: produced envelope folds into `AgentPresenceRegistry` as the new capability set.
- Gates: `bunx tsc --noEmit` clean · `bun run lint` 0 errors (27 pre-existing warnings, none in changed files) · `bash scripts/check-carveouts.sh` PASS · full `bun test` 5578 pass / 0 fail.

refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)