### PR TITLE
feat(mc): G-1114.C.3 — agent-presence liveness FSM (5-min TTL reaper)

### DIFF
--- a/src/bus/agent-network/__tests__/registry.test.ts
+++ b/src/bus/agent-network/__tests__/registry.test.ts
@@ -18,6 +18,9 @@ import {
   AgentPresenceRegistry,
   agentPresenceSubject,
   startAgentPresenceRegistry,
+  PRESENCE_LIVENESS_TTL_MS,
+  TTL_LAPSE_OFFLINE_REASON,
+  type PresenceReaperScheduler,
 } from "../registry";
 import {
   createAgentOnlineEvent,
@@ -171,13 +174,15 @@ describe("AgentPresenceRegistry.apply", () => {
     expect(reg.getAgents()[0]?.state).toBe("online");
   });
 
-  test("B records lastHeartbeatAt but NEVER expires a record (no TTL/FSM)", () => {
+  test("a bare registry (reaper NOT started) NEVER expires a record", () => {
     let clock = 0;
     const reg = new AgentPresenceRegistry({ now: () => clock });
     clock = 100;
     reg.apply(online());
     clock = 100 + 10 * 60_000; // 10 minutes later — well past the 5-min TTL
-    // No reaper in B: the record stays online until an explicit offline.
+    // The reaper is opt-in (G-1114.C.3): without startReaper()/reapStale() the
+    // record stays online until an explicit offline. This preserves the B.3
+    // "records-only, no FSM" contract for fold-only callers.
     expect(reg.getAgents()[0]?.state).toBe("online");
   });
 
@@ -335,5 +340,252 @@ describe("startAgentPresenceRegistry (wiring)", () => {
     // After stop, fan-out is unregistered — new fires are ignored.
     runtime.fire(online(), "local.andreas.meta-factory.agent.online");
     expect(handle.registry.getAgents().length).toBe(0);
+  });
+
+  test("starts the liveness reaper by default; stop() stops it", async () => {
+    const runtime = makeFakeRuntime();
+    const handle = await startAgentPresenceRegistry({
+      runtime,
+      principal: "andreas",
+      stack: "meta-factory",
+    });
+    expect(handle.registry.isReaperRunning()).toBe(true);
+    await handle.stop();
+    expect(handle.registry.isReaperRunning()).toBe(false);
+  });
+
+  test("startReaper: false leaves the reaper dormant (fold-only callers)", async () => {
+    const runtime = makeFakeRuntime();
+    const handle = await startAgentPresenceRegistry({
+      runtime,
+      principal: "andreas",
+      stack: "meta-factory",
+      startReaper: false,
+    });
+    expect(handle.registry.isReaperRunning()).toBe(false);
+    await handle.stop();
+  });
+});
+
+// --- G-1114.C.3 liveness FSM / TTL reaper ------------------------------------
+
+/**
+ * A deterministic interval scheduler: it captures the registered tick callback
+ * and exposes `tick()` so a test drives sweeps explicitly instead of waiting on
+ * wall-clock `setInterval`. `cleared` records that the registry cancelled the
+ * interval on stop.
+ */
+function makeFakeScheduler(): PresenceReaperScheduler & {
+  tick(): void;
+  readonly cleared: boolean;
+  readonly scheduled: boolean;
+} {
+  let fn: (() => void) | null = null;
+  let cleared = false;
+  const handle = {};
+  return {
+    setInterval(cb: () => void) {
+      fn = cb;
+      return handle;
+    },
+    clearInterval(h: unknown) {
+      if (h === handle) {
+        cleared = true;
+        fn = null;
+      }
+    },
+    tick() {
+      if (fn) fn();
+    },
+    get cleared() {
+      return cleared;
+    },
+    get scheduled() {
+      return fn !== null;
+    },
+  };
+}
+
+describe("AgentPresenceRegistry liveness reaper (C.3)", () => {
+  test("TTL constant is 5 minutes", () => {
+    expect(PRESENCE_LIVENESS_TTL_MS).toBe(5 * 60_000);
+  });
+
+  test("online → heartbeats keep online → silence past TTL → offline(ttl_lapse)", () => {
+    let clock = 0;
+    const sched = makeFakeScheduler();
+    const reg = new AgentPresenceRegistry({ now: () => clock, scheduler: sched });
+    reg.startReaper();
+    expect(sched.scheduled).toBe(true);
+
+    const changes: { state: string; reason?: string }[] = [];
+    reg.onChange((_k, rec) => {
+      changes.push({ state: rec.state, reason: rec.offlineReason });
+    });
+
+    // boot
+    clock = 1_000;
+    reg.apply(online());
+    // heartbeat at +1min, +2min, +3min, +4min — each within the 5-min window.
+    for (const t of [60_000, 120_000, 180_000, 240_000]) {
+      clock = 1_000 + t;
+      reg.apply(heartbeat());
+      reg.reapStale(); // a sweep between beats must NOT trip (still fresh)
+      expect(reg.getAgents()[0]?.state).toBe("online");
+    }
+    // Now go silent. A sweep just before the TTL line — still online.
+    clock = 1_000 + 240_000 + PRESENCE_LIVENESS_TTL_MS - 1;
+    sched.tick();
+    expect(reg.getAgents()[0]?.state).toBe("online");
+
+    // Cross the TTL line (last heartbeat was at clock=241_000).
+    clock = 241_000 + PRESENCE_LIVENESS_TTL_MS + 1;
+    sched.tick();
+    const rec = reg.getAgents()[0];
+    expect(rec?.state).toBe("offline");
+    expect(rec?.offlineReason).toBe(TTL_LAPSE_OFFLINE_REASON);
+    // lastHeartbeatAt survives the reap (last-seen liveness preserved).
+    expect(rec?.lastHeartbeatAt).toBe(241_000);
+
+    // onChange fired ONCE for the offline transition (state changed once).
+    const offlineEvents = changes.filter((c) => c.state === "offline");
+    expect(offlineEvents.length).toBe(1);
+    expect(offlineEvents[0]?.reason).toBe(TTL_LAPSE_OFFLINE_REASON);
+  });
+
+  test("graceful agent.offline BEFORE the TTL wins (reason: shutdown, not ttl_lapse)", () => {
+    let clock = 0;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    clock = 1_000;
+    reg.apply(online());
+    clock = 60_000;
+    reg.apply(heartbeat());
+    // Graceful offline well before the TTL would lapse.
+    clock = 90_000;
+    reg.apply(offline());
+    expect(reg.getAgents()[0]?.state).toBe("offline");
+    expect(reg.getAgents()[0]?.offlineReason).toBe("shutdown");
+    // A later sweep must NOT re-stamp ttl_lapse over the graceful reason.
+    clock = 90_000 + PRESENCE_LIVENESS_TTL_MS + 1_000;
+    const reaped = reg.reapStale();
+    expect(reaped).toEqual([]);
+    expect(reg.getAgents()[0]?.offlineReason).toBe("shutdown");
+  });
+
+  test("heartbeat AFTER a TTL-lapse offline REVIVES the record to online", () => {
+    let clock = 0;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    clock = 1_000;
+    reg.apply(online());
+    // Lapse it.
+    clock = 1_000 + PRESENCE_LIVENESS_TTL_MS + 1;
+    expect(reg.reapStale()).toEqual(["andreas/meta-factory/luna"]);
+    expect(reg.getAgents()[0]?.state).toBe("offline");
+    expect(reg.getAgents()[0]?.offlineReason).toBe(TTL_LAPSE_OFFLINE_REASON);
+    // A fresh heartbeat revives it (applyHeartbeat upserts online).
+    clock = 1_000 + PRESENCE_LIVENESS_TTL_MS + 10_000;
+    reg.apply(heartbeat());
+    const rec = reg.getAgents()[0];
+    expect(rec?.state).toBe("online");
+    expect(rec?.offlineReason).toBeUndefined();
+    expect(rec?.lastHeartbeatAt).toBe(1_000 + PRESENCE_LIVENESS_TTL_MS + 10_000);
+    // And it survives subsequent in-window sweeps.
+    reg.reapStale();
+    expect(reg.getAgents()[0]?.state).toBe("online");
+  });
+
+  test("reaper is idempotent — an already-offline record does not re-emit", () => {
+    let clock = 0;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    clock = 1_000;
+    reg.apply(online());
+    const changes: string[] = [];
+    reg.onChange((_k, rec) => changes.push(rec.state));
+    // First sweep past TTL → one offline transition.
+    clock = 1_000 + PRESENCE_LIVENESS_TTL_MS + 1;
+    expect(reg.reapStale()).toEqual(["andreas/meta-factory/luna"]);
+    // Subsequent sweeps at ever-later times reap nothing + emit nothing.
+    clock += 10 * 60_000;
+    expect(reg.reapStale()).toEqual([]);
+    clock += 10 * 60_000;
+    expect(reg.reapStale()).toEqual([]);
+    expect(changes.filter((s) => s === "offline").length).toBe(1);
+  });
+
+  test("an online record that never heartbeated times out against lastSeenAt", () => {
+    let clock = 0;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    clock = 1_000;
+    reg.apply(online()); // lastSeenAt = 1_000, no lastHeartbeatAt
+    // Just before the TTL relative to lastSeenAt — still online.
+    clock = 1_000 + PRESENCE_LIVENESS_TTL_MS - 1;
+    expect(reg.reapStale()).toEqual([]);
+    // Past it — reaped.
+    clock = 1_000 + PRESENCE_LIVENESS_TTL_MS + 1;
+    expect(reg.reapStale()).toEqual(["andreas/meta-factory/luna"]);
+    expect(reg.getAgents()[0]?.offlineReason).toBe(TTL_LAPSE_OFFLINE_REASON);
+  });
+
+  test("a reaper tick AFTER stopReaper() is a no-op", () => {
+    let clock = 0;
+    const sched = makeFakeScheduler();
+    const reg = new AgentPresenceRegistry({ now: () => clock, scheduler: sched });
+    reg.startReaper();
+    clock = 1_000;
+    reg.apply(online());
+    reg.stopReaper();
+    expect(sched.cleared).toBe(true);
+    expect(reg.isReaperRunning()).toBe(false);
+    // Even if a stale tick somehow fired, the captured fn is cleared → no-op.
+    clock = 1_000 + PRESENCE_LIVENESS_TTL_MS + 1;
+    sched.tick();
+    expect(reg.getAgents()[0]?.state).toBe("online");
+  });
+
+  test("startReaper() is idempotent — does not stack a second interval", () => {
+    const sched = makeFakeScheduler();
+    const setSpy = mock(sched.setInterval.bind(sched));
+    const reg = new AgentPresenceRegistry({
+      scheduler: { setInterval: setSpy, clearInterval: sched.clearInterval.bind(sched) },
+    });
+    reg.startReaper();
+    reg.startReaper();
+    reg.startReaper();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    reg.stopReaper();
+  });
+
+  test("stopReaper() is idempotent + safe when never started", () => {
+    const reg = new AgentPresenceRegistry();
+    expect(() => reg.stopReaper()).not.toThrow();
+    reg.startReaper();
+    reg.stopReaper();
+    expect(() => reg.stopReaper()).not.toThrow();
+    expect(reg.isReaperRunning()).toBe(false);
+  });
+
+  test("reaper sweeps multiple agents in one tick; only stale ones flip", () => {
+    let clock = 0;
+    const reg = new AgentPresenceRegistry({ now: () => clock });
+    // luna (the shared IDENTITY) + a second agent echo.
+    clock = 1_000;
+    reg.apply(online());
+    clock = 2_000;
+    reg.apply(
+      createAgentOnlineEvent({
+        source: SOURCE,
+        identity: { ...IDENTITY, agent_id: "echo", nkey_public_key: "UECHO" },
+        scope: SCOPE,
+        capabilities: [],
+        startedAt: new Date("2026-06-10T09:00:00.000Z"),
+      }),
+    );
+    // luna last-seen 1_000, echo last-seen 2_000. Set clock so only luna is stale.
+    clock = 1_000 + PRESENCE_LIVENESS_TTL_MS + 1; // echo still within window (2_000 + TTL > clock)
+    const reaped = reg.reapStale();
+    expect(reaped).toEqual(["andreas/meta-factory/luna"]);
+    const byKey = new Map(reg.getAgents().map((r) => [r.agentId, r.state]));
+    expect(byKey.get("luna")).toBe("offline");
+    expect(byKey.get("echo")).toBe("online");
   });
 });

--- a/src/bus/agent-network/registry.ts
+++ b/src/bus/agent-network/registry.ts
@@ -510,7 +510,10 @@ export class AgentPresenceRegistry {
       // Liveness floor: prefer the last heartbeat; fall back to last-seen for a
       // record that announced online but never heartbeated.
       const lastLive = rec.lastHeartbeatAt ?? rec.lastSeenAt;
-      if (lastLive > cutoff) continue;
+      // Strict: reap only when STRICTLY older than the TTL (now - lastLive > ttl),
+      // matching the design's "older than" wording. At exactly the TTL the agent
+      // is still live; the next 30s sweep reaps it (immaterial at sweep grain).
+      if (lastLive >= cutoff) continue;
       const next: AgentPresenceRecord = {
         ...rec,
         state: "offline",

--- a/src/bus/agent-network/registry.ts
+++ b/src/bus/agent-network/registry.ts
@@ -1,5 +1,6 @@
 /**
  * G-1114.B.3 — stack-local runtime agent-presence registry (subscriber).
+ * G-1114.C.3 — + liveness FSM / 5-min TTL reaper (this module's reaper methods).
  *
  * The consumer half of the Phase B end-to-end wiring. It subscribes to the
  * stack's own `local.{principal}.{stack}.agent.>` subtree (STACK-LOCAL ONLY —
@@ -22,18 +23,29 @@
  *                                    (B records the LATEST set only; the full
  *                                    diff/reconcile handling is Phase C).
  *
- * ## Boundary — what it does NOT do (deferred to Phase C / G-1114.C)
+ * ## Liveness FSM / TTL reaper (G-1114.C.3 — ADDED on top of the B.3 fold)
  *
- *   - **No liveness FSM / TTL expiry.** B records `lastHeartbeatAt` + the last
- *     explicit state only. The 5-minute liveness TTL → `offline` transition
- *     (a record going stale because heartbeats STOPPED, with no `agent.offline`
- *     envelope) is Phase C's reaper. B never times anything out — a record stays
- *     `online` until an explicit `agent.offline` arrives. This is the
- *     deliberate B/C split (ADR-0007 §Consequences: "the liveness FSM … TTL
- *     lapse" is its own line item).
- *   - **No capability diffing.** B stores the latest set; C computes the delta
- *     against the prior record + reconciles.
- *   - **No federation.** B subscribes to `local.` only. The `federated.`
+ *   - The reaper is the OPT-IN second half of the FSM. B.3 records
+ *     `lastHeartbeatAt` + the last explicit state; C.3 adds the
+ *     `online`→`offline` transition when heartbeats STOP (a record going stale
+ *     with no `agent.offline` envelope — there was no agent left to send one).
+ *     {@link AgentPresenceRegistry.startReaper} schedules a periodic
+ *     {@link AgentPresenceRegistry.reapStale} sweep; any `online` record whose
+ *     last heartbeat is older than {@link PRESENCE_LIVENESS_TTL_MS} (5 min)
+ *     transitions to `offline` with reason {@link TTL_LAPSE_OFFLINE_REASON} and
+ *     fires `onChange` (so the WS push → panel update lands on the transition).
+ *   - The reaper stays OPT-IN so a bare registry that only folds envelopes
+ *     (tests, the cap-consistency harness) keeps the pure B.3 "no FSM" behaviour
+ *     until `startReaper()` is called. The wired path calls it.
+ *   - A graceful `agent.offline` before the TTL still wins (already handled by
+ *     `applyOffline`); a heartbeat AFTER a TTL-lapse offline REVIVES the record
+ *     to `online` (already handled by `applyHeartbeat`'s online upsert).
+ *
+ * ## Boundary — what it STILL does NOT do (deferred to later Phase C / E)
+ *
+ *   - **No capability diffing.** B stores the latest set; the delta/reconcile
+ *     (C.2) computes it against the prior record.
+ *   - **No federation.** It subscribes to `local.` only. The `federated.`
  *     subtree is Phase E.
  *
  * ## Observability seam (for B.4 + the MC API)
@@ -73,14 +85,53 @@ import {
 } from "./envelopes";
 
 /**
+ * The liveness TTL — the maximum age (epoch-ms span) a record's
+ * `lastHeartbeatAt` may reach before the Phase C reaper times it out to
+ * `offline`. ADR-0007 §Consequences + design §7: **5 minutes**. The presence
+ * heartbeat fires every 60s (`DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS`), so a
+ * 5-minute window tolerates losing 4 consecutive beats before declaring an
+ * agent stale (the 5th missed beat trips the reaper).
+ */
+export const PRESENCE_LIVENESS_TTL_MS = 5 * 60_000;
+
+/**
+ * Default reaper tick cadence (epoch-ms). The reaper sweeps for stale records
+ * on this interval; it is independent of (and finer than) the TTL so a lapse is
+ * detected within ~one tick of crossing the 5-minute line rather than only on
+ * the next inbound envelope. 30s gives ≤30s detection latency on a 5-min TTL.
+ * Injectable via {@link AgentPresenceRegistryOptions.scheduler} for tests.
+ */
+export const DEFAULT_PRESENCE_REAPER_INTERVAL_MS = 30_000;
+
+/**
+ * Reason an agent is `offline`. A SUPERSET of the on-the-wire
+ * {@link AgentOfflineReason} (`shutdown`/`restart`/`error`, all carried by an
+ * explicit `agent.offline` envelope) plus the subscriber-INFERRED `ttl_lapse` —
+ * the record went stale because heartbeats STOPPED, with no `agent.offline`
+ * envelope (there was no agent left to send one). The distinct value lets the
+ * panel (Phase C.4 / D) render a timed-out agent differently from a gracefully
+ * shut-down one. `ttl_lapse` never rides the wire — it is only ever stamped by
+ * the reaper here.
+ */
+export type PresenceOfflineReason = AgentOfflineReason | "ttl_lapse";
+
+/**
+ * The {@link PresenceOfflineReason} the reaper stamps on a TTL-lapse offline.
+ * Exported so downstream renderers (and tests) compare against the constant
+ * rather than re-typing the literal.
+ */
+export const TTL_LAPSE_OFFLINE_REASON = "ttl_lapse" as const;
+
+/**
  * The observable presence state for one agent. Keyed in the registry by
  * {@link AgentPresenceRecord.key} (`{principal}/{stack}/{agent_id}` — see
  * {@link recordKey}).
  *
- * `state` carries only what B observes from explicit envelopes: an agent is
- * `online` after `agent.online` / `agent.heartbeat`, `offline` after an
- * explicit `agent.offline`. There is deliberately NO `"stale"`/TTL-derived
- * state in B — that transition is Phase C's liveness FSM.
+ * `state` is `online` after `agent.online` / `agent.heartbeat`, and `offline`
+ * after either an explicit `agent.offline` envelope OR a Phase C TTL lapse
+ * (heartbeats stopped for longer than {@link PRESENCE_LIVENESS_TTL_MS}). The
+ * two offline paths are distinguished by {@link AgentPresenceRecord.offlineReason}
+ * (`ttl_lapse` = inferred; `shutdown`/`restart`/`error` = announced).
  */
 export interface AgentPresenceRecord {
   /** Stable map key — `{principal}/{stack}/{agent_id}`. */
@@ -97,10 +148,14 @@ export interface AgentPresenceRecord {
   stack: string;
   /** Latest known declared capability set. */
   capabilities: readonly string[];
-  /** Last explicit liveness state observed from an envelope. */
+  /** Last liveness state — explicit (envelope) or inferred (TTL reaper). */
   state: "online" | "offline";
-  /** Reason from the last `agent.offline`, when `state === "offline"`. */
-  offlineReason?: AgentOfflineReason;
+  /**
+   * Why the record is offline, when `state === "offline"`: an announced
+   * {@link AgentOfflineReason} from the last `agent.offline`, or the
+   * reaper-inferred `ttl_lapse`. Undefined while online.
+   */
+  offlineReason?: PresenceOfflineReason;
   /** Boot time from the last `agent.online` (ISO-8601), when known. */
   startedAt?: string;
   /**
@@ -133,10 +188,45 @@ function recordKey(principal: string, stack: string, agentId: string): string {
   return `${principal}/${stack}/${agentId}`;
 }
 
-/** Optional injection points — tests pass a clock; production omits. */
+/**
+ * Pluggable interval scheduler — the reaper schedules its sweep through this so
+ * tests can drive ticks deterministically (a fake scheduler invokes the
+ * callback on demand) instead of waiting real wall-clock time. Production
+ * defaults to `setInterval`/`clearInterval`. Mirrors the heartbeat-ticker's
+ * injectable-timer pattern.
+ */
+export interface PresenceReaperScheduler {
+  /** Schedule `fn` every `intervalMs`; returns an opaque cancel handle. */
+  setInterval(fn: () => void, intervalMs: number): unknown;
+  /** Cancel a handle from {@link PresenceReaperScheduler.setInterval}. */
+  clearInterval(handle: unknown): void;
+}
+
+const DEFAULT_SCHEDULER: PresenceReaperScheduler = {
+  setInterval: (fn, ms) => setInterval(fn, ms),
+  clearInterval: (handle) => {
+    clearInterval(handle as ReturnType<typeof setInterval>);
+  },
+};
+
+/** Optional injection points — tests pass a clock + scheduler; production omits. */
 export interface AgentPresenceRegistryOptions {
-  /** Receiver clock for `lastHeartbeatAt` / `lastSeenAt`. Defaults to `Date.now`. */
+  /** Receiver clock for `lastHeartbeatAt` / `lastSeenAt` + TTL math. Defaults to `Date.now`. */
   now?: () => number;
+  /**
+   * Liveness TTL in epoch-ms — a record whose `lastHeartbeatAt` is older than
+   * `now() - ttlMs` is reaped to `offline`. Defaults to
+   * {@link PRESENCE_LIVENESS_TTL_MS} (5 min). Injectable for tests.
+   */
+  ttlMs?: number;
+  /** Interval scheduler for the reaper. Defaults to {@link DEFAULT_SCHEDULER}. */
+  scheduler?: PresenceReaperScheduler;
+  /**
+   * Reaper sweep cadence in epoch-ms. Defaults to
+   * {@link DEFAULT_PRESENCE_REAPER_INTERVAL_MS} (30s). Only used once
+   * {@link AgentPresenceRegistry.startReaper} is called.
+   */
+  reaperIntervalMs?: number;
 }
 
 /**
@@ -149,9 +239,18 @@ export class AgentPresenceRegistry {
   private readonly records = new Map<string, AgentPresenceRecord>();
   private readonly listeners = new Set<AgentPresenceChangeListener>();
   private readonly now: () => number;
+  private readonly ttlMs: number;
+  private readonly scheduler: PresenceReaperScheduler;
+  private readonly reaperIntervalMs: number;
+  /** Active reaper interval handle, or `null` when the reaper is not running. */
+  private reaperHandle: unknown = null;
 
   constructor(opts: AgentPresenceRegistryOptions = {}) {
     this.now = opts.now ?? Date.now;
+    this.ttlMs = opts.ttlMs ?? PRESENCE_LIVENESS_TTL_MS;
+    this.scheduler = opts.scheduler ?? DEFAULT_SCHEDULER;
+    this.reaperIntervalMs =
+      opts.reaperIntervalMs ?? DEFAULT_PRESENCE_REAPER_INTERVAL_MS;
   }
 
   /**
@@ -351,6 +450,78 @@ export class AgentPresenceRegistry {
       },
     };
   }
+
+  // --- Liveness FSM / TTL reaper (G-1114.C.3) ------------------------------
+
+  /**
+   * Start the periodic liveness reaper. Schedules {@link reapStale} on the
+   * injected scheduler's interval (default 30s). Idempotent — a second call
+   * while the reaper is running is a no-op (it does NOT stack a second
+   * interval). The reaper is OPT-IN: a bare registry never times anything out
+   * until `startReaper()` is called, preserving the Phase B "records-only,
+   * no FSM" contract for callers that fold envelopes without wiring liveness.
+   */
+  startReaper(): void {
+    if (this.reaperHandle !== null) return;
+    this.reaperHandle = this.scheduler.setInterval(() => {
+      this.reapStale();
+    }, this.reaperIntervalMs);
+  }
+
+  /**
+   * Stop the reaper interval. Idempotent — safe to call when not running, and
+   * safe to call twice (shutdown drain may double-invoke). Clears the handle so
+   * a post-stop tick can never fire (the scheduler cancel + the null-guard in
+   * {@link startReaper} together guarantee no tick-after-stop).
+   */
+  stopReaper(): void {
+    if (this.reaperHandle === null) return;
+    this.scheduler.clearInterval(this.reaperHandle);
+    this.reaperHandle = null;
+  }
+
+  /** True while the reaper interval is scheduled. (Mostly for tests.) */
+  isReaperRunning(): boolean {
+    return this.reaperHandle !== null;
+  }
+
+  /**
+   * Single liveness sweep: for every record currently `online` whose last
+   * heartbeat is older than `now() - ttlMs`, transition it to `offline` with
+   * reason {@link TTL_LAPSE_OFFLINE_REASON} and fire `onChange` (so the WS push
+   * → panel update happens on the transition, not just on the next inbound
+   * envelope). Returns the keys reaped this sweep.
+   *
+   * Idempotency / no repeat-emit: an already-`offline` record is skipped (the
+   * reaper only acts on the `online`→`offline` edge), so a record that lapsed
+   * on a previous tick does NOT re-emit on subsequent ticks. A record with no
+   * `lastHeartbeatAt` yet (online via `agent.online` but never heartbeated) is
+   * timed out against `lastSeenAt` as the liveness floor — an agent that
+   * announced and then went silent without ever heartbeating is just as stale.
+   *
+   * Exposed publicly so tests can drive a deterministic sweep, and so a future
+   * lazy-on-read path could call it; the wired path uses {@link startReaper}.
+   */
+  reapStale(): string[] {
+    const cutoff = this.now() - this.ttlMs;
+    const reaped: string[] = [];
+    for (const [key, rec] of this.records) {
+      if (rec.state !== "online") continue;
+      // Liveness floor: prefer the last heartbeat; fall back to last-seen for a
+      // record that announced online but never heartbeated.
+      const lastLive = rec.lastHeartbeatAt ?? rec.lastSeenAt;
+      if (lastLive > cutoff) continue;
+      const next: AgentPresenceRecord = {
+        ...rec,
+        state: "offline",
+        offlineReason: TTL_LAPSE_OFFLINE_REASON,
+      };
+      this.records.set(key, next);
+      reaped.push(key);
+      this.emit(key, next);
+    }
+    return reaped;
+  }
 }
 
 /**
@@ -386,6 +557,12 @@ export interface StartAgentPresenceRegistryOptions {
   registry?: AgentPresenceRegistry;
   /** Injected clock, forwarded to a freshly-constructed registry (tests). */
   now?: () => number;
+  /**
+   * Whether to start the liveness reaper (G-1114.C.3). Defaults to `true` — the
+   * wired path wants TTL expiry. Tests that supply their own registry + drive
+   * `reapStale` manually pass `false` to avoid a real `setInterval`.
+   */
+  startReaper?: boolean;
 }
 
 /**
@@ -405,6 +582,13 @@ export async function startAgentPresenceRegistry(
     opts.registry ??
     new AgentPresenceRegistry(opts.now !== undefined ? { now: opts.now } : {});
   const pattern = agentPresenceSubject(opts.principal, opts.stack);
+
+  // G-1114.C.3 — start the liveness reaper (TTL expiry). Opt-out for tests that
+  // drive `reapStale` deterministically. `startReaper` is idempotent + the
+  // handle's `stop()` stops it (registered in the cortex.ts shutdown drain).
+  if (opts.startReaper !== false) {
+    registry.startReaper();
+  }
 
   const handler: EnvelopeHandler = (envelope, subject) => {
     if (!subjectMatches(pattern, subject)) return;
@@ -436,6 +620,9 @@ export async function startAgentPresenceRegistry(
     stop: async (): Promise<void> => {
       if (stopped) return;
       stopped = true;
+      // Stop the liveness reaper FIRST so no sweep can fire mid-teardown.
+      // Idempotent + a no-op when the reaper was never started.
+      registry.stopReaper();
       registration.unregister();
       // The runtime tracks `subscribe()` subscribers and drains them on
       // `runtime.stop()`, but we stop ours explicitly so a listener-scoped

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3196,9 +3196,14 @@ export async function startCortex(
   // is safe to run without a bus — the producer simply emits into the void and
   // the registry stays empty.
   //
-  // FSM/TTL boundary: the registry records `lastHeartbeatAt` + last explicit
-  // state ONLY. The 5-min liveness-TTL → offline reaper is Phase C (G-1114.C),
-  // not wired here.
+  // Liveness FSM (G-1114.C.3): `startAgentPresenceRegistry` starts the 5-min
+  // TTL reaper by default — an `online` record whose `agent.heartbeat` stops for
+  // longer than PRESENCE_LIVENESS_TTL_MS transitions to `offline`
+  // (reason `ttl_lapse`, distinct from a graceful `agent.offline`), firing
+  // onChange → the WS broadcast below → the live panel. The reaper interval is
+  // owned by the registry handle and stopped by `presenceRegistryHandle.stop()`
+  // in the shutdown drain (the "agent-presence registry stop" slot), so no
+  // separate drain slot is needed.
   let presenceRegistryHandle: AgentPresenceRegistryHandle | null = null;
   let presenceProducer: AgentPresenceProducer | null = null;
   // The onChange→WS-broadcast subscription handle, captured so shutdown can


### PR DESCRIPTION
## What

Phase C of the agent-network-topology umbrella (#355). Phase B deliberately deferred TTL expiry (records-only fold — a record stayed `online` until an explicit `agent.offline`). **C.3 adds the reaper that closes the liveness FSM** (ADR-0007 §Consequences + design §7: online while heartbeats within TTL → offline on graceful offline **or** TTL lapse; 5-min TTL on the NEW `agent.heartbeat`).

- `AgentPresenceRegistry` gains an **opt-in liveness reaper**. `startReaper()` schedules a periodic `reapStale()` sweep on an injectable scheduler; any `online` record whose last heartbeat is older than `PRESENCE_LIVENESS_TTL_MS` (5 min) transitions to `offline` with the distinct reaper-inferred reason **`ttl_lapse`** and fires `onChange` — so the WS push → live panel update lands on the **transition**, not just on the next inbound envelope. (Interval reaper preferred over lazy-on-read precisely so the panel's WS push fires.)
- `PresenceOfflineReason` widens the record's offline reason to the on-the-wire `AgentOfflineReason` (`shutdown`/`restart`/`error`) **plus** `ttl_lapse`. `ttl_lapse` never rides the wire — only the reaper stamps it — so the panel (C.4/D) can render a timed-out agent differently from a gracefully shut-down one.
- The reaper is **opt-in**, so a bare fold-only registry (the cap-consistency harness, unit folds) keeps the pure B.3 "records-only, no FSM" behaviour. The heartbeat floor falls back to `lastSeenAt` for an agent that announced `online` but never heartbeated.

## Constants

| Constant | Value | Why |
|---|---|---|
| `PRESENCE_LIVENESS_TTL_MS` | `5 * 60_000` (5 min) | ADR-0007 / design §7. Presence heartbeat is 60s ⇒ tolerate 4 missed beats; the 5th trips the reaper. |
| `DEFAULT_PRESENCE_REAPER_INTERVAL_MS` | `30_000` (30s) | Sweep cadence — independent of (and finer than) the TTL ⇒ ≤30s detection latency. |

Both injectable for tests (`scheduler` + `now` clock + `ttlMs`/`reaperIntervalMs`).

## Offline-reason model

`state: "online" | "offline"` + `offlineReason?: PresenceOfflineReason` where `PresenceOfflineReason = "shutdown" | "restart" | "error" | "ttl_lapse"`. Graceful (`agent.offline`) ⇒ wire reason; inferred (reaper) ⇒ `ttl_lapse` (exported as `TTL_LAPSE_OFFLINE_REASON`).

## Revive path

A heartbeat **after** a TTL-lapse offline upserts the record back to `online` (existing `applyHeartbeat` online upsert) and clears the reason — confirmed + tested.

## Wiring

`startAgentPresenceRegistry` starts the reaper by default (`startReaper !== false`). The reaper interval is **owned by the registry handle** and stopped by `presenceRegistryHandle.stop()` in the **existing** `"agent-presence registry stop"` shutdown-drain slot — no separate `allSlots` entry, no tick-after-stop (scheduler cancel + null-guard). The `src/cortex.ts` change is **comment-only** (no logic touched in the producer or dashboard paths — no conflict with C.1 / C.4).

## Test plan

`src/bus/agent-network/__tests__/registry.test.ts` (the C.5 fixture-replay tests fold in here), scripted clock + fake scheduler:
- online → heartbeats keep online → silence past 5 min → `offline(ttl_lapse)`, `onChange` fires **once** (not every tick)
- graceful `agent.offline` before TTL wins (`shutdown`, not `ttl_lapse`); a later sweep doesn't re-stamp
- revive via heartbeat after TTL-offline → online, reason cleared
- reaper idempotent — already-offline never re-emits
- online-but-never-heartbeated times out against `lastSeenAt`
- reaper tick **after** `stopReaper()` is a no-op
- `startReaper`/`stopReaper` idempotent
- multi-agent sweep flips only the stale one
- wiring: reaper starts by default + `stop()` stops it; `startReaper: false` stays dormant

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (27 pre-existing warnings in unrelated files)
- `bun test` — 5583 pass / 0 fail / 2 skip (322 files)
- `scripts/check-carveouts.sh` — PASS (never bare "operator", never `{org}`)

refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)