### PR TITLE
feat(mc): G-1114.C.4 — agents panel capability badges + offline-state rendering

### DIFF
--- a/src/surface/mc/__tests__/api-agents.test.ts
+++ b/src/surface/mc/__tests__/api-agents.test.ts
@@ -145,6 +145,34 @@ describe("GET /api/agents", () => {
     expect(echo.started_at).toBeNull();
   });
 
+  it("surfaces offline_reason for the inferred TTL lapse, and null while online (G-1114.C.4)", async () => {
+    const view: AgentPresenceView = {
+      getAgents: () => [
+        rec({ agentId: "luna", state: "online", lastHeartbeatAt: 9000, lastSeenAt: 9000 }),
+        rec({
+          agentId: "sage",
+          state: "offline",
+          offlineReason: "ttl_lapse",
+          lastHeartbeatAt: 1000,
+          lastSeenAt: 1000,
+        }),
+      ],
+    };
+    c = startWith(() => view);
+    const body = await (await fetch(`${c.baseUrl}/api/agents`)).json();
+
+    const luna = body.agents.find((a: { agent_id: string }) => a.agent_id === "luna");
+    expect(luna.state).toBe("online");
+    // Online agents carry no offline reason.
+    expect(luna.offline_reason).toBeNull();
+
+    const sage = body.agents.find((a: { agent_id: string }) => a.agent_id === "sage");
+    expect(sage.state).toBe("offline");
+    // The reaper-inferred reason rides the DTO so the panel can render it as a
+    // timed-out / "no heartbeat" agent distinct from a graceful shutdown.
+    expect(sage.offline_reason).toBe("ttl_lapse");
+  });
+
   it("resolves the getter lazily per request (registry attaches after boot)", async () => {
     // Holder is empty at boot — mirrors cortex.ts where the registry starts
     // AFTER the MC embed. A later assignment must become visible.

--- a/src/surface/mc/dashboard-v2/__tests__/agents-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/agents-display.test.ts
@@ -10,6 +10,11 @@ import { describe, it, expect } from "bun:test";
 import {
   pickAgentsPanelMode,
   formatRelativeTime,
+  offlineReasonLabel,
+  isTtlLapse,
+  formatCapabilities,
+  NO_CAPABILITIES_LABEL,
+  TTL_LAPSE_REASON,
   type AgentsPanelInput,
 } from "../lib/agents-display";
 import type { AgentPresenceTile } from "../hooks/use-agents";
@@ -88,5 +93,66 @@ describe("formatRelativeTime", () => {
 
   it("formats days", () => {
     expect(formatRelativeTime(now - 5 * 86_400_000, now)).toBe("5d ago");
+  });
+});
+
+describe("offlineReasonLabel — G-1114.C.4", () => {
+  it("maps the inferred TTL lapse to a 'no heartbeat' label (the agent went silent)", () => {
+    expect(offlineReasonLabel(TTL_LAPSE_REASON)).toBe("no heartbeat");
+    expect(offlineReasonLabel("ttl_lapse")).toBe("no heartbeat");
+  });
+
+  it("maps each graceful announced reason to a distinct human label", () => {
+    expect(offlineReasonLabel("shutdown")).toBe("shut down");
+    expect(offlineReasonLabel("restart")).toBe("restarting");
+    expect(offlineReasonLabel("error")).toBe("errored");
+  });
+
+  it("renders a generic 'offline' for a missing/empty reason (still distinct from online)", () => {
+    expect(offlineReasonLabel(null)).toBe("offline");
+    expect(offlineReasonLabel(undefined)).toBe("offline");
+    expect(offlineReasonLabel("")).toBe("offline");
+  });
+
+  it("echoes an unknown/future reason rather than blanking it", () => {
+    expect(offlineReasonLabel("graceful-shutdown")).toBe("graceful-shutdown");
+    expect(offlineReasonLabel("some-future-reason")).toBe("some-future-reason");
+  });
+});
+
+describe("isTtlLapse — G-1114.C.4", () => {
+  it("is true only for the TTL-lapse reason", () => {
+    expect(isTtlLapse(TTL_LAPSE_REASON)).toBe(true);
+    expect(isTtlLapse("ttl_lapse")).toBe(true);
+  });
+
+  it("is false for graceful reasons and absent reasons", () => {
+    expect(isTtlLapse("shutdown")).toBe(false);
+    expect(isTtlLapse("restart")).toBe(false);
+    expect(isTtlLapse("error")).toBe(false);
+    expect(isTtlLapse(null)).toBe(false);
+    expect(isTtlLapse(undefined)).toBe(false);
+  });
+});
+
+describe("formatCapabilities — G-1114.C.4", () => {
+  it("yields one badge per capability, preserving registry order", () => {
+    const badges = formatCapabilities(["review.code", "review.design", "moderate"]);
+    expect(badges).toEqual([
+      { label: "review.code", placeholder: false },
+      { label: "review.design", placeholder: false },
+      { label: "moderate", placeholder: false },
+    ]);
+  });
+
+  it("yields a single placeholder badge for an empty capability set", () => {
+    const badges = formatCapabilities([]);
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toEqual({ label: NO_CAPABILITIES_LABEL, placeholder: true });
+  });
+
+  it("does not de-duplicate or sort (it reflects what the registry reported)", () => {
+    const badges = formatCapabilities(["b", "a", "b"]);
+    expect(badges.map((x) => x.label)).toEqual(["b", "a", "b"]);
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-preview-view.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-preview-view.test.tsx
@@ -114,4 +114,105 @@ describe("NetworkPreviewView — live agents panel (G-1114.B.4)", () => {
     const rowCount = (html.match(/agents-panel-row /g) ?? []).length;
     expect(rowCount).toBe(3);
   });
+
+  // --- G-1114.C.4: capability badges + offline-state rendering --------------
+
+  it("renders each capability as a distinct badge chip, not a comma string", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [
+        tile({
+          agent_id: "luna",
+          capabilities: ["review.code", "review.design", "moderate"],
+        }),
+      ],
+    });
+    const chipCount = (html.match(/agents-panel-cap"/g) ?? []).length;
+    expect(chipCount).toBe(3);
+    // Not rendered as a single comma-joined blob.
+    expect(html).not.toContain("review.code, review.design");
+  });
+
+  it("renders the empty-capabilities placeholder for an agent with no caps", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [tile({ agent_id: "echo", capabilities: [] })],
+    });
+    expect(html).toContain("no capabilities declared");
+    expect(html).toContain("agents-panel-cap-none");
+  });
+
+  it("renders a TTL-lapsed agent as a timed-out 'no heartbeat' / 'last seen' row", () => {
+    const lastBeat = Date.now() - 6 * 60_000; // 6 minutes ago
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [
+        tile({
+          agent_id: "sage",
+          assistant_name: "Sage",
+          state: "offline",
+          offline_reason: "ttl_lapse",
+          last_heartbeat_at: lastBeat,
+        }),
+      ],
+    });
+    expect(html).toContain('data-state="offline"');
+    expect(html).toContain('data-offline-reason="ttl_lapse"');
+    expect(html).toContain("agents-panel-row-ttl-lapse");
+    expect(html).toContain("no heartbeat");
+    expect(html).toContain("last seen");
+    // The TTL-lapse reason gets the warning treatment, not the graceful one.
+    expect(html).toContain("agents-panel-reason-ttl-lapse");
+  });
+
+  it("renders a gracefully shut-down agent distinctly from a TTL lapse", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [
+        tile({
+          agent_id: "echo",
+          assistant_name: "Echo",
+          state: "offline",
+          offline_reason: "shutdown",
+        }),
+      ],
+    });
+    expect(html).toContain('data-state="offline"');
+    expect(html).toContain('data-offline-reason="shutdown"');
+    expect(html).toContain("shut down");
+    // A graceful shutdown is NOT the TTL-lapse warning treatment.
+    expect(html).not.toContain("agents-panel-row-ttl-lapse");
+    expect(html).not.toContain("no heartbeat");
+    expect(html).not.toContain("last seen");
+  });
+
+  it("maps restart and error reasons to their own labels", () => {
+    const restart = render({
+      loaded: true,
+      error: null,
+      agents: [tile({ agent_id: "r", state: "offline", offline_reason: "restart" })],
+    });
+    expect(restart).toContain("restarting");
+
+    const errored = render({
+      loaded: true,
+      error: null,
+      agents: [tile({ agent_id: "e", state: "offline", offline_reason: "error" })],
+    });
+    expect(errored).toContain("errored");
+  });
+
+  it("does not show an offline reason or 'last seen' qualifier for an online agent", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [tile({ agent_id: "luna", state: "online", last_heartbeat_at: Date.now() })],
+    });
+    expect(html).not.toContain("agents-panel-reason");
+    expect(html).not.toContain("last seen");
+  });
 });

--- a/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
@@ -74,6 +74,9 @@ export function NetworkPreviewView({ state }: NetworkPreviewViewProps) {
                 data-agent-id={a.agent_id}
                 data-state={a.state}
                 data-offline-reason={offline ? (a.offline_reason ?? "") : undefined}
+                aria-label={`${a.assistant_name ?? a.agent_id} — ${
+                  offline ? `offline (${reasonLabel})` : "online"
+                }`}
               >
                 <div className="agents-panel-identity">
                   <span className="agents-panel-name">
@@ -82,13 +85,15 @@ export function NetworkPreviewView({ state }: NetworkPreviewViewProps) {
                   <span className="agents-panel-id dim">{a.agent_id}</span>
                 </div>
                 <div className="agents-panel-caps">
-                  {formatCapabilities(a.capabilities).map((badge) =>
+                  {formatCapabilities(a.capabilities).map((badge, i) =>
                     badge.placeholder ? (
                       <span key="__none__" className="agents-panel-cap-none dim">
                         {badge.label}
                       </span>
                     ) : (
-                      <span key={badge.label} className="agents-panel-cap">
+                      // Key on label+index: the capability schema doesn't enforce
+                      // uniqueness, so a duplicate label must not collide on the key.
+                      <span key={`${badge.label}-${i}`} className="agents-panel-cap">
                         {badge.label}
                       </span>
                     )

--- a/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-preview-view.tsx
@@ -15,7 +15,13 @@
 
 import { useState } from "react";
 import type { AgentsState } from "../hooks/use-agents";
-import { pickAgentsPanelMode, formatRelativeTime } from "../lib/agents-display";
+import {
+  pickAgentsPanelMode,
+  formatRelativeTime,
+  formatCapabilities,
+  offlineReasonLabel,
+  isTtlLapse,
+} from "../lib/agents-display";
 
 export interface NetworkPreviewViewProps {
   state: AgentsState;
@@ -50,47 +56,71 @@ export function NetworkPreviewView({ state }: NetworkPreviewViewProps) {
       )}
       {mode === "list" && (
         <ul className="agents-panel-list" aria-label="Agents">
-          {state.agents.map((a) => (
-            <li
-              key={a.key}
-              className={`agents-panel-row agents-panel-row-${a.state}`}
-              data-agent-id={a.agent_id}
-              data-state={a.state}
-            >
-              <div className="agents-panel-identity">
-                <span className="agents-panel-name">
-                  {a.assistant_name ?? a.agent_id}
-                </span>
-                <span className="agents-panel-id dim">{a.agent_id}</span>
-              </div>
-              <div className="agents-panel-caps">
-                {a.capabilities.length === 0 ? (
-                  <span className="dim">no capabilities declared</span>
-                ) : (
-                  a.capabilities.map((cap) => (
-                    <span key={cap} className="agents-panel-cap">
-                      {cap}
+          {state.agents.map((a) => {
+            const offline = a.state === "offline";
+            const ttlLapse = offline && isTtlLapse(a.offline_reason);
+            // The offline qualifier shown beside the OFFLINE label: a graceful
+            // reason ("shut down") or the inferred TTL lapse ("no heartbeat").
+            const reasonLabel = offline
+              ? offlineReasonLabel(a.offline_reason)
+              : null;
+            return (
+              <li
+                key={a.key}
+                className={
+                  `agents-panel-row agents-panel-row-${a.state}` +
+                  (ttlLapse ? " agents-panel-row-ttl-lapse" : "")
+                }
+                data-agent-id={a.agent_id}
+                data-state={a.state}
+                data-offline-reason={offline ? (a.offline_reason ?? "") : undefined}
+              >
+                <div className="agents-panel-identity">
+                  <span className="agents-panel-name">
+                    {a.assistant_name ?? a.agent_id}
+                  </span>
+                  <span className="agents-panel-id dim">{a.agent_id}</span>
+                </div>
+                <div className="agents-panel-caps">
+                  {formatCapabilities(a.capabilities).map((badge) =>
+                    badge.placeholder ? (
+                      <span key="__none__" className="agents-panel-cap-none dim">
+                        {badge.label}
+                      </span>
+                    ) : (
+                      <span key={badge.label} className="agents-panel-cap">
+                        {badge.label}
+                      </span>
+                    )
+                  )}
+                </div>
+                <div className="agents-panel-liveness">
+                  <span
+                    className={`agents-panel-state state-${a.state}`}
+                    title={offline ? `offline: ${reasonLabel}` : "online"}
+                  >
+                    {a.state}
+                  </span>
+                  {offline && (
+                    <span
+                      className={
+                        "agents-panel-reason dim" +
+                        (ttlLapse ? " agents-panel-reason-ttl-lapse" : "")
+                      }
+                    >
+                      {reasonLabel}
                     </span>
-                  ))
-                )}
-              </div>
-              <div className="agents-panel-liveness">
-                <span
-                  className={`agents-panel-state state-${a.state}`}
-                  title={
-                    a.state === "offline" && a.offline_reason
-                      ? `offline: ${a.offline_reason}`
-                      : a.state
-                  }
-                >
-                  {a.state}
-                </span>
-                <span className="agents-panel-heartbeat dim">
-                  {formatRelativeTime(a.last_heartbeat_at, now)}
-                </span>
-              </div>
-            </li>
-          ))}
+                  )}
+                  <span className="agents-panel-heartbeat dim">
+                    {/* For a TTL-lapse the last heartbeat is the "last seen"
+                        signal the principal cares about ("last seen 6m ago"). */}
+                    {ttlLapse ? "last seen " : ""}
+                    {formatRelativeTime(a.last_heartbeat_at, now)}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>

--- a/src/surface/mc/dashboard-v2/lib/agents-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/agents-display.ts
@@ -56,3 +56,83 @@ export function formatRelativeTime(
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
 }
+
+/**
+ * The TTL-lapse offline reason the registry's liveness reaper (G-1114.C.3)
+ * stamps when heartbeats STOP with no `agent.offline` envelope (the agent went
+ * silent — possibly crashed). Mirrors `TTL_LAPSE_OFFLINE_REASON` from the bus
+ * registry, duplicated here so the surface layer stays bus-free (the DTO carries
+ * the string; the panel never imports the bus type).
+ */
+export const TTL_LAPSE_REASON = "ttl_lapse" as const;
+
+/**
+ * Human-readable label for an agent's offline reason, distinguishing the
+ * inferred TTL-lapse path (the agent went silent — "timed out", possibly
+ * crashed) from the graceful, announced reasons (`shutdown`/`restart`/`error`,
+ * each carried by an explicit `agent.offline` envelope).
+ *
+ * `ttl_lapse` is the load-bearing distinction (G-1114.C.4): a timed-out agent is
+ * rendered as "no heartbeat" rather than a clean shutdown, because the principal
+ * needs to know the difference between "this agent left on purpose" and "this
+ * agent stopped answering". Unknown / future reasons degrade to a titled-case
+ * echo of the raw string so a new wire reason never renders as blank.
+ */
+export function offlineReasonLabel(reason: string | null | undefined): string {
+  switch (reason) {
+    case TTL_LAPSE_REASON:
+      return "no heartbeat";
+    case "shutdown":
+      return "shut down";
+    case "restart":
+      return "restarting";
+    case "error":
+      return "errored";
+    case null:
+    case undefined:
+    case "":
+      // Offline with no recorded reason — still distinct from online.
+      return "offline";
+    default:
+      // A reason we don't have a friendly label for (a future wire value, or a
+      // legacy `graceful-shutdown`-style string): echo it rather than blank it.
+      return reason;
+  }
+}
+
+/**
+ * True when an offline agent went offline because its heartbeats LAPSED (the
+ * reaper inferred it — the agent went silent, possibly crashed) rather than via
+ * a graceful, announced `agent.offline`. Drives the panel's distinct
+ * "timed out" treatment + the "last seen Xm ago" emphasis.
+ */
+export function isTtlLapse(reason: string | null | undefined): boolean {
+  return reason === TTL_LAPSE_REASON;
+}
+
+/** One capability chip to render. */
+export interface CapabilityBadge {
+  /** The capability id (`review.code`, …). */
+  label: string;
+  /** True for the synthetic empty-set placeholder (rendered dimmed, not as a real cap). */
+  placeholder: boolean;
+}
+
+/** The placeholder text shown when an agent declares no capabilities. */
+export const NO_CAPABILITIES_LABEL = "no capabilities declared";
+
+/**
+ * Project a capability list into the badge set the panel renders. An empty set
+ * yields a single placeholder badge ("no capabilities declared") so the column
+ * is never blank; a non-empty set yields one real badge per capability, in the
+ * order the registry reported them (no re-sorting — the registry's order is the
+ * agent's declared order).
+ */
+export function formatCapabilities(
+  capabilities: readonly string[]
+): CapabilityBadge[] {
+  if (capabilities.length === 0) {
+    return [{ label: NO_CAPABILITIES_LABEL, placeholder: true }];
+  }
+  return capabilities.map((cap) => ({ label: cap, placeholder: false }));
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -367,6 +367,11 @@ html, body {
   background: var(--panel); padding: 10px 14px;
 }
 .agents-panel-view .agents-panel-row-offline { opacity: 0.6; }
+/* A TTL-lapse (the agent went silent — possibly crashed) reads as a warning,
+   distinct from a graceful shutdown's neutral dimming. */
+.agents-panel-view .agents-panel-row-ttl-lapse {
+  border-color: color-mix(in oklch, var(--warn, #b58900) 45%, var(--line));
+}
 .agents-panel-view .agents-panel-identity { display: flex; flex-direction: column; gap: 2px; }
 .agents-panel-view .agents-panel-name { font-size: 13px; font-weight: 600; }
 .agents-panel-view .agents-panel-id { font-size: 11px; }
@@ -378,6 +383,7 @@ html, body {
   border: 1px solid var(--line); border-radius: 4px;
   color: var(--fg-faint);
 }
+.agents-panel-view .agents-panel-cap-none { font-size: 11px; font-style: italic; }
 .agents-panel-view .agents-panel-liveness {
   display: flex; flex-direction: column; align-items: flex-end; gap: 2px;
 }
@@ -386,6 +392,8 @@ html, body {
 }
 .agents-panel-view .agents-panel-state.state-online { color: var(--ok); }
 .agents-panel-view .agents-panel-state.state-offline { color: var(--fg-faint); }
+.agents-panel-view .agents-panel-reason { font-size: 10.5px; }
+.agents-panel-view .agents-panel-reason-ttl-lapse { color: var(--warn, #b58900); }
 .agents-panel-view .agents-panel-heartbeat { font-size: 11px; }
 
 /* G-1113.C.7 — per-repository panel */


### PR DESCRIPTION
## What

The final Phase C slice of umbrella #355 — capability badges + offline-state polish on the B.4 agents panel (`docs/plan-agent-network-topology.md` §4.3).

- **`offline_reason` in the DTO** — already exposed by B.4; this slice adds a test pinning that the C.3 reaper-inferred `ttl_lapse` reason surfaces on `/api/agents` (and is `null` while online). No DTO field added — the contract was already there; C.4 is the consumer.
- **Capability badges** — capabilities render as distinct badge chips (not a comma string), via a new pure `formatCapabilities` helper, with a `"no capabilities declared"` placeholder for the empty set.
- **Offline-distinct rendering** — offline agents render visually distinct, and the *reason* is distinguished:
  - `ttl_lapse` (the agent went silent — possibly crashed) → **"no heartbeat"** + **"last seen Xm ago"**, warning treatment (`agents-panel-row-ttl-lapse`).
  - graceful (`shutdown`/`restart`/`error`) → **"shut down"** / **"restarting"** / **"errored"**, neutral dimming.
- Still the simple list **PANEL** — the rich React Flow + ELK topology graph is Phase D (G-1114.D).

## Reason → label mapping

| `offline_reason` | label | treatment |
|---|---|---|
| `ttl_lapse` | `no heartbeat` (+ "last seen …") | warning (silent/crashed) |
| `shutdown` | `shut down` | graceful |
| `restart` | `restarting` | graceful |
| `error` | `errored` | graceful |
| null/empty | `offline` | graceful |
| unknown/future | *echoed verbatim* | graceful |

## Deploy note

The dashboard frontend is deployed separately (CF Pages). This change **needs a dashboard rebuild + deploy** (`bun run build:dashboard` → `wrangler pages deploy`) to show live; the backend DTO already carries `offline_reason`.

## Test plan

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, none in changed files)
- `bun test` — full suite, 5606 pass / 0 fail
- `bash scripts/check-carveouts.sh` on changed files — PASS
- `bun run build:dashboard` — bundles clean
- New tests: `agents-display` helpers (reason→label, ttl-lapse, capability badges + empty placeholder); `network-preview-view` (ttl_lapse vs graceful distinct rendering, badge chips, empty caps, online has no reason); `api-agents` (ttl_lapse surfaces, null while online).

refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)