### PR TITLE
feat(bus): consumer-side sovereignty gate (governance Stage 1b)

### DIFF
--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -2196,3 +2196,122 @@ describe("ReviewConsumer — federated DIRECT mode (cortex#725, ADR 0001/0002 §
     expect(runtime.publishedOnSubject).toHaveLength(0);
   });
 });
+
+describe("ReviewConsumer.processEnvelope — consumer-side sovereignty gate (Stage 1b)", () => {
+  // makeRequest() defaults to model_class=local-only / frontier_ok=false, so a
+  // frontier-class agent claiming it is a sovereignty violation.
+
+  test("enforce: frontier agent + local-only task → term wont_do, reviewer never spawns", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    let pipelineRan = false;
+
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        agent: buildAgent({ modelClass: "frontier" }),
+        sovereigntyEnforce: true,
+        pipelineRunner: fixedPipeline(() => {
+          pipelineRan = true;
+          throw new Error("reviewer must NOT spawn on a sovereignty-denied task");
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      `local.metafactory.tasks.code-review.typescript`,
+      null,
+    );
+
+    expect(decision.kind).toBe("term");
+    if (decision.kind === "term") expect(decision.reason).toContain("wont_do");
+    expect(pipelineRan).toBe(false);
+    // A dispatch.task.failed (wont_do) is published back to the requester.
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed");
+    expect(failed).toBeDefined();
+  });
+
+  test("audit-parity (default): frontier agent + local-only task → still runs", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "approved");
+    let pipelineRan = false;
+
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        agent: buildAgent({ modelClass: "frontier" }),
+        // sovereigntyEnforce omitted → audit-parity
+        pipelineRunner: fixedPipeline(() => {
+          pipelineRan = true;
+          return { kind: "verdict", envelope: verdict };
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      `local.metafactory.tasks.code-review.typescript`,
+      null,
+    );
+
+    expect(decision).toEqual({ kind: "ack" });
+    expect(pipelineRan).toBe(true);
+  });
+
+  test("enforce: local-only agent + local-only task → runs (no violation)", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "approved");
+    let pipelineRan = false;
+
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        agent: buildAgent({ modelClass: "local-only" }),
+        sovereigntyEnforce: true,
+        pipelineRunner: fixedPipeline(() => {
+          pipelineRan = true;
+          return { kind: "verdict", envelope: verdict };
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      `local.metafactory.tasks.code-review.typescript`,
+      null,
+    );
+
+    expect(decision).toEqual({ kind: "ack" });
+    expect(pipelineRan).toBe(true);
+  });
+
+  test("enforce: agent with no declared modelClass + local-only task → fail closed (term)", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    let pipelineRan = false;
+
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        agent: buildAgent({}), // no modelClass
+        sovereigntyEnforce: true,
+        pipelineRunner: fixedPipeline(() => {
+          pipelineRan = true;
+          throw new Error("must not spawn");
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      `local.metafactory.tasks.code-review.typescript`,
+      null,
+    );
+
+    expect(decision.kind).toBe("term");
+    expect(pipelineRan).toBe(false);
+  });
+});

--- a/src/bus/__tests__/sovereignty-gate.test.ts
+++ b/src/bus/__tests__/sovereignty-gate.test.ts
@@ -21,7 +21,16 @@ describe("evaluateSovereignty — the breach is guarded", () => {
   });
 
   it("denies on frontier_ok:false even when model_class is 'any'", () => {
+    // model_class 'any' does not itself demand local — frontier_ok:false does.
     expect(evaluateSovereignty({ model_class: "any", frontier_ok: false }, "frontier").decision).toBe("deny");
+  });
+
+  it("denies a frontier agent when frontier_ok is MISSING (fail closed, not 'frontier is fine')", () => {
+    // A missing frontier_ok is treated as "not cleared for frontier".
+    expect(evaluateSovereignty({ model_class: "any" }, "frontier").decision).toBe("deny");
+    expect(evaluateSovereignty({ model_class: "any" }, "any").decision).toBe("deny");
+    // A local-only agent is still fine — it cannot leak to a frontier model.
+    expect(evaluateSovereignty({ model_class: "any" }, "local-only").decision).toBe("allow");
   });
 
   it("allows a local-only agent a local-only task", () => {

--- a/src/bus/__tests__/sovereignty-gate.test.ts
+++ b/src/bus/__tests__/sovereignty-gate.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Consumer-side sovereignty gate tests (governance Stage 1b).
+ *
+ * The fail-closed invariants are the spec: an agent that cannot prove its
+ * model class is compliant is denied, never waved through. The breach
+ * guarded is confidential payload reaching a frontier model.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { evaluateSovereignty } from "../sovereignty-gate";
+
+describe("evaluateSovereignty — the breach is guarded", () => {
+  it("denies a frontier agent a local-only task", () => {
+    const d = evaluateSovereignty({ model_class: "local-only", frontier_ok: false }, "frontier");
+    expect(d.decision).toBe("deny");
+    expect(d.reason).toContain("sovereignty violation");
+  });
+
+  it("denies an 'any' agent a local-only task (any includes frontier)", () => {
+    expect(evaluateSovereignty({ model_class: "local-only" }, "any").decision).toBe("deny");
+  });
+
+  it("denies on frontier_ok:false even when model_class is 'any'", () => {
+    expect(evaluateSovereignty({ model_class: "any", frontier_ok: false }, "frontier").decision).toBe("deny");
+  });
+
+  it("allows a local-only agent a local-only task", () => {
+    expect(evaluateSovereignty({ model_class: "local-only", frontier_ok: false }, "local-only").decision).toBe("allow");
+  });
+
+  it("allows a frontier agent a frontier-ok task", () => {
+    expect(evaluateSovereignty({ model_class: "any", frontier_ok: true }, "frontier").decision).toBe("allow");
+  });
+
+  it("allows a local-only agent any task (it cannot leak to frontier)", () => {
+    expect(evaluateSovereignty({ model_class: "frontier", frontier_ok: true }, "local-only").decision).toBe("allow");
+    expect(evaluateSovereignty({ model_class: "any" }, "local-only").decision).toBe("allow");
+  });
+});
+
+describe("evaluateSovereignty — fail-closed invariants", () => {
+  it("denies when the agent class is missing", () => {
+    expect(evaluateSovereignty({ model_class: "any", frontier_ok: true }, undefined).decision).toBe("deny");
+  });
+
+  it("denies when the agent class is unknown", () => {
+    expect(evaluateSovereignty({ model_class: "any" }, "gpu" as never).decision).toBe("deny");
+  });
+
+  it("denies when the envelope has no sovereignty block", () => {
+    expect(evaluateSovereignty(null, "local-only").decision).toBe("deny");
+    expect(evaluateSovereignty(undefined, "frontier").decision).toBe("deny");
+  });
+
+  it("a local-only task with no agent class denies (cannot prove compliance)", () => {
+    expect(evaluateSovereignty({ model_class: "local-only" }, undefined).decision).toBe("deny");
+  });
+});

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -70,6 +70,7 @@ import type { MyelinRuntime } from "./myelin/runtime";
 import type { Envelope } from "./myelin/envelope-validator";
 import { getActorPrincipal } from "./myelin/envelope-validator";
 import { resolveSourceNetwork } from "./surface-router";
+import { evaluateSovereignty, type AgentModelClass } from "./sovereignty-gate";
 import type { PolicyFederatedNetwork } from "../common/types/cortex-config";
 import type { MyelinSubscriber } from "./myelin/subscriber";
 import type { AckDecision } from "./myelin/subscriber";
@@ -120,6 +121,14 @@ export interface ReviewConsumerAgent {
    * undefined, the agent is treated as unbounded — see §7.3.
    */
   maxConcurrent?: number;
+  /**
+   * Governance Stage 1b — the kind of model this agent runs (`local-only`
+   * | `frontier` | `any`). Consumed by the consumer-side sovereignty gate
+   * to refuse a task whose envelope demands a local model when this agent
+   * is frontier-capable. Absent → the gate fails closed for local-only
+   * tasks (see {@link evaluateSovereignty}).
+   */
+  modelClass?: AgentModelClass;
 }
 
 /**
@@ -278,6 +287,19 @@ export interface ReviewConsumerOpts {
    */
   federatedNetworks?: readonly PolicyFederatedNetwork[];
   /**
+   * Governance Stage 1b — when `true`, the consumer-side sovereignty gate
+   * HARD-DENIES (term + `dispatch.task.failed` `wont_do`) a claim whose
+   * envelope demands a local model while this agent is frontier-capable.
+   * When `false`/absent the gate runs in **audit-parity**: it evaluates and
+   * logs the verdict to stderr but lets the work proceed.
+   *
+   * Default `false` because a self-declared `modelClass` is honest-but-
+   * spoofable; the hard-deny posture should wait until model class is bound
+   * to the signing identity (cortex#327 audit→enforce). Audit-parity ships
+   * the evaluation now so the denial rate is observable before it bites.
+   */
+  sovereigntyEnforce?: boolean;
+  /**
    * Test seam — clock. Defaults to `() => new Date()`. Tests inject a
    * fixed clock so emitted `startedAt`/`completedAt` are deterministic.
    */
@@ -393,6 +415,8 @@ export class ReviewConsumer {
    * are configured.
    */
   private readonly federatedNetworksById: Map<string, PolicyFederatedNetwork>;
+  /** Governance Stage 1b — hard-deny on sovereignty mismatch vs. audit-parity. */
+  private readonly sovereigntyEnforce: boolean;
   private readonly clock: () => Date;
 
   /** Promises for in-flight pipelines so `stop()` can drain. */
@@ -426,6 +450,7 @@ export class ReviewConsumer {
     for (const network of opts.federatedNetworks ?? []) {
       this.federatedNetworksById.set(network.id, network);
     }
+    this.sovereigntyEnforce = opts.sovereigntyEnforce ?? false;
     this.clock = opts.clock ?? (() => new Date());
 
     this.flavors = deriveFlavors(opts.agent.capabilities);
@@ -714,6 +739,40 @@ export class ReviewConsumer {
         requester,
       );
       return { kind: "term", reason: "no capability match" };
+    }
+
+    // 3b. Consumer-side sovereignty gate (governance Stage 1b). The envelope
+    //     DECLARES model_class / frontier_ok; this is where the consumer
+    //     refuses to run a task whose sovereignty its own model class would
+    //     violate — confidential payload must not reach a frontier model. The
+    //     manifest declares; this gate bites.
+    //
+    //     Audit-parity by default: evaluate + log, but proceed (a self-declared
+    //     modelClass is spoofable until bound to the signing identity,
+    //     cortex#327). With sovereigntyEnforce, deny → term + wont_do.
+    {
+      const sov = evaluateSovereignty(envelope.sovereignty, this.agent.modelClass);
+      if (sov.decision === "deny") {
+        if (this.sovereigntyEnforce) {
+          process.stderr.write(
+            `cortex/review-consumer: sovereignty DENIED (enforce) for ` +
+              `agent="${this.agent.id}" subject=${subject} envelope=${envelope.id} — ${sov.reason}\n`,
+          );
+          await this.publishFailed(
+            envelope,
+            { kind: "wont_do", detail: sov.reason },
+            `sovereignty refusal for ${subject}`,
+            responseRouting,
+            requester,
+          );
+          return { kind: "term", reason: `wont_do: ${sov.reason}` };
+        }
+        // Audit-parity: the denial is observable but does not yet bite.
+        process.stderr.write(
+          `cortex/review-consumer: sovereignty would DENY (audit-parity) for ` +
+            `agent="${this.agent.id}" subject=${subject} envelope=${envelope.id} — ${sov.reason}\n`,
+        );
+      }
     }
 
     // 4. Concurrency gate (§7.3) — over maxConcurrent → nak `not_now`.

--- a/src/bus/sovereignty-gate.ts
+++ b/src/bus/sovereignty-gate.ts
@@ -1,0 +1,72 @@
+/**
+ * Consumer-side sovereignty gate (governance Stage 1b).
+ *
+ * The envelope DECLARES `model_class` / `frontier_ok`; until something refuses
+ * a claim that violates it, the declaration is documentation. Today the only
+ * "I am a frontier model, this task is local-only, therefore I refuse" logic
+ * lives in demo fleet simulators — voluntary, application-layer. This gate
+ * makes the refusal mandatory at the consumer, before the reviewer spawns.
+ *
+ * Pure decision core, fail-closed (mirrors the pulse enforcement gate and
+ * Magnús Smárason's enforcement-gate SPEC.md invariants): an agent whose model
+ * class cannot be proven compliant is DENIED, never waved through.
+ *
+ * Scope boundary: this gate guards the data-sovereignty breach — confidential
+ * payload reaching a frontier model. It is NOT a capability-match check (that
+ * is the dispatcher's job) and NOT the cross-principal `peers[]` gate (that
+ * guards the requester). It composes alongside both.
+ */
+
+/** Sovereignty requirement carried on the inbound envelope. */
+export interface EnvelopeSovereignty {
+  model_class?: "local-only" | "frontier" | "any";
+  frontier_ok?: boolean;
+}
+
+/** The executing agent's own model class — what kind of model it actually runs. */
+export type AgentModelClass = "local-only" | "frontier" | "any";
+
+export interface SovereigntyDecision {
+  decision: "allow" | "deny";
+  reason: string;
+}
+
+/**
+ * Decide whether an agent of `agentClass` may execute a task carrying
+ * `sovereignty`. Fail-closed: a missing/unknown agent class, or a missing
+ * sovereignty block, denies.
+ *
+ * The breach guarded: a task that demands a local model (model_class
+ * "local-only" OR frontier_ok === false) must NOT be executed by a
+ * frontier-capable agent (class "frontier" or "any"). Everything the demand
+ * permits is allowed.
+ */
+export function evaluateSovereignty(
+  sovereignty: EnvelopeSovereignty | null | undefined,
+  agentClass: AgentModelClass | undefined,
+): SovereigntyDecision {
+  // Fail closed: an agent that can't prove its class can't prove compliance.
+  if (agentClass !== "local-only" && agentClass !== "frontier" && agentClass !== "any") {
+    return { decision: "deny", reason: `agent model class missing or unknown (got ${String(agentClass)}) — failing closed` };
+  }
+  // Fail closed: an envelope with no sovereignty block carries no permission to read.
+  if (!sovereignty || typeof sovereignty !== "object") {
+    return { decision: "deny", reason: "envelope carries no sovereignty block — failing closed" };
+  }
+
+  const demandsLocal = sovereignty.model_class === "local-only" || sovereignty.frontier_ok === false;
+
+  if (demandsLocal && (agentClass === "frontier" || agentClass === "any")) {
+    return {
+      decision: "deny",
+      reason:
+        `sovereignty violation: task requires a local model ` +
+        `(model_class=${sovereignty.model_class ?? "?"}, frontier_ok=${sovereignty.frontier_ok ?? "?"}) ` +
+        `but agent model class is '${agentClass}'`,
+    };
+  }
+
+  // A local-only agent may always execute (it cannot leak to a frontier model);
+  // a frontier/any agent may execute anything the demand does not restrict.
+  return { decision: "allow", reason: "agent model class satisfies the task sovereignty demand" };
+}

--- a/src/bus/sovereignty-gate.ts
+++ b/src/bus/sovereignty-gate.ts
@@ -17,7 +17,15 @@
  * guards the requester). It composes alongside both.
  */
 
-/** Sovereignty requirement carried on the inbound envelope. */
+/**
+ * Sovereignty requirement carried on the inbound envelope.
+ *
+ * Both fields are OPTIONAL here, deliberately looser than the canonical
+ * `Envelope["sovereignty"]` (where both are required): the gate is a pure
+ * function callable from outside the envelope pipeline (tests, future bus
+ * sources that haven't stamped a full block). The fail-closed logic below
+ * treats a missing field conservatively, so the loosening never opens a hole.
+ */
 export interface EnvelopeSovereignty {
   model_class?: "local-only" | "frontier" | "any";
   frontier_ok?: boolean;
@@ -36,10 +44,14 @@ export interface SovereigntyDecision {
  * `sovereignty`. Fail-closed: a missing/unknown agent class, or a missing
  * sovereignty block, denies.
  *
- * The breach guarded: a task that demands a local model (model_class
- * "local-only" OR frontier_ok === false) must NOT be executed by a
- * frontier-capable agent (class "frontier" or "any"). Everything the demand
- * permits is allowed.
+ * The breach guarded: a task that demands a local model must NOT be executed
+ * by a frontier-capable agent (class "frontier" or "any"). A task "demands
+ * local" when model_class is "local-only" OR frontier_ok is anything other
+ * than an explicit `true` — i.e. a MISSING frontier_ok is treated as "not
+ * cleared for frontier" (fail closed), not "frontier is fine". On a real
+ * Envelope frontier_ok is required so this only bites callers outside the
+ * pipeline; the conservative default keeps the gate safe for them too.
+ * Everything the demand explicitly permits is allowed.
  */
 export function evaluateSovereignty(
   sovereignty: EnvelopeSovereignty | null | undefined,
@@ -54,7 +66,9 @@ export function evaluateSovereignty(
     return { decision: "deny", reason: "envelope carries no sovereignty block — failing closed" };
   }
 
-  const demandsLocal = sovereignty.model_class === "local-only" || sovereignty.frontier_ok === false;
+  // frontier_ok !== true (not just === false) so a MISSING frontier_ok also
+  // demands local — fail closed for callers that omit the field.
+  const demandsLocal = sovereignty.model_class === "local-only" || sovereignty.frontier_ok !== true;
 
   if (demandsLocal && (agentClass === "frontier" || agentClass === "any")) {
     return {

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -523,6 +523,29 @@ export const AgentRuntimeSchema = z.object({
     .int("agent.runtime.maxConcurrent must be an integer (got a fractional number)")
     .positive("agent.runtime.maxConcurrent must be a positive integer (omit the field for unbounded concurrency)")
     .optional(),
+  /**
+   * cortex#xxx (governance Stage 1b) — the kind of model this agent actually
+   * runs, used by the consumer-side sovereignty gate to refuse a task whose
+   * envelope demands a local model (`model_class: local-only` or
+   * `frontier_ok: false`) when this agent is frontier-capable.
+   *
+   *   - `local-only` — runs a local model exclusively (Ollama, on-box); may
+   *                    execute any task (it cannot leak to a frontier model).
+   *   - `frontier`   — runs a frontier (cloud) model; refused local-only tasks.
+   *   - `any`        — may run either; treated as frontier-capable by the gate.
+   *
+   * **Optional.** When unset the sovereignty gate fails closed for tasks that
+   * demand a local model (an agent that cannot prove its class cannot prove
+   * compliance); tasks that permit any model are unaffected. Mirrors the
+   * `model_class` axis of the myelin envelope so the agent-side declaration
+   * and the envelope-side requirement share one taxonomy.
+   *
+   * NOTE: a self-declared class is honest-but-spoofable. The hard-deny posture
+   * ties trust in this value to the signing identity (cortex#327 audit→enforce);
+   * until that lands the gate runs in audit-parity (logs the verdict, does not
+   * drop).
+   */
+  modelClass: z.enum(["local-only", "frontier", "any"]).optional(),
 }).refine(
   // Echo M2 on cortex#62 — a `standalone` agent with zero capabilities parses
   // fine but routes zero work. The daemon connects to NATS, publishes nothing

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -524,7 +524,7 @@ export const AgentRuntimeSchema = z.object({
     .positive("agent.runtime.maxConcurrent must be a positive integer (omit the field for unbounded concurrency)")
     .optional(),
   /**
-   * cortex#xxx (governance Stage 1b) — the kind of model this agent actually
+   * cortex#906 (governance Stage 1b) — the kind of model this agent actually
    * runs, used by the consumer-side sovereignty gate to refuse a task whose
    * envelope demands a local model (`model_class: local-only` or
    * `frontier_ok: false`) when this agent is frontier-capable.

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1366,6 +1366,12 @@ export async function startCortex(
         ...(agent.runtime?.maxConcurrent !== undefined && {
           maxConcurrent: agent.runtime.maxConcurrent,
         }),
+        // Governance Stage 1b — the agent's declared model class feeds the
+        // consumer-side sovereignty gate. Absent → the gate fails closed for
+        // local-only tasks.
+        ...(agent.runtime?.modelClass !== undefined && {
+          modelClass: agent.runtime.modelClass,
+        }),
       };
       // cortex#327 follow-up (D1) — build the per-agent signature verifier
       // closure when this agent declares a non-empty `trust:[]` list.


### PR DESCRIPTION
## What

A fail-closed, consumer-side gate that refuses a claimed task whose sovereignty the agent's own model class would violate — confidential payload must not reach a frontier model.

## Why

Reading the code: `model_class`/`frontier_ok` are validated for **shape, never for truth**. They are copied into *audit* envelopes (`dispatch-listener.ts`), never checked. The only "I am frontier, this task is local-only, therefore I refuse" logic lives in the SOC demo's `fleet-sim.ts` — application-layer, voluntary. The `--violate` demo passes because the sim agent *chooses* to refuse. Nothing stopped a frontier-class consumer from claiming a `local-only` task.

This is Magnus Smárason's manifest-vs-gate point applied to the bus, and the load-bearing stage of the governance upgrade plan (pulse#28): the sovereignty cage that doesn't currently lock.

## How

- `evaluateSovereignty(sovereignty, agentClass)` — pure, fail-closed: a `local-only`/`frontier_ok:false` task run by a frontier-capable agent (`frontier`/`any`) → deny; an agent that can't prove its class → deny; a `local-only` agent → always allowed (can't leak to frontier).
- `AgentRuntimeSchema.modelClass` (`local-only|frontier|any`), threaded into `ReviewConsumerAgent` and the boot wiring.
- `ReviewConsumer` runs the gate after capability match. `sovereigntyEnforce: true` → `term` + `dispatch.task.failed` `wont_do`. Default **audit-parity** → evaluate + log to stderr, proceed.

## The audit-parity default (deliberate)

A self-declared `modelClass` is honest-but-spoofable. The hard-deny posture should wait until model class is bound to the **signing identity** (cortex#327 audit→enforce). Audit-parity ships the evaluation now so the denial rate is observable *before* it bites. Flip `sovereigntyEnforce` on once signing enforces.

## Tests

- 10 pure-gate tests (`sovereignty-gate.test.ts`) — the fail-closed invariants
- 4 consumer-path tests — enforce term+wont_do, audit-parity proceeds, local-only passes, unknown-class fails closed
- Full suite green: 1836 tests, `tsc --noEmit` clean

Companion to pulse `feat/p-700-enforcement-gate` (same spec, one layer up). Both derive from Magnus' enforcement-gate blueprint — built from the spec, not his code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)