### PR TITLE
feat(mc): G-1114.D.4 — Network node detail panel (presence + capabilities)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-detail-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-detail-display.test.ts
@@ -1,0 +1,184 @@
+/**
+ * G-1114.D.4 — Network detail-panel selection-logic tests.
+ *
+ * Covers the pure selection helpers extracted into `lib/network-detail-display.ts`
+ * (the panel's component render is covered separately in
+ * `network-detail-panel.test.tsx` via `renderToStaticMarkup`). These assert the
+ * load-bearing select / deselect / auto-close-on-disappear behaviour AND the
+ * lifecycle-only dispatch join — without a DOM.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveSelectedAgent,
+  selectAgentDispatchActivity,
+  agentKeyFromClickedNode,
+} from "../lib/network-detail-display";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { WorkingAgentTile } from "../hooks/use-working-agents";
+
+function tile(
+  over: Partial<AgentPresenceTile> & { agent_id: string },
+): AgentPresenceTile {
+  const { agent_id } = over;
+  return {
+    key: `andreas/research/${agent_id}`,
+    assistant_name: null,
+    nkey_public_key: `N${agent_id}`,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+    ...over,
+  };
+}
+
+function workingTile(
+  over: Partial<WorkingAgentTile> & { agent_id: string },
+): WorkingAgentTile {
+  return {
+    agent_name: over.agent_id,
+    agent_type: "head",
+    primary_state_rank: 1,
+    primary_state: "running",
+    primary_assignment: {
+      id: "assign-1",
+      task_id: "task-1",
+      task_title: "Build the thing",
+      task_priority: 1,
+      updated_at: "2026-06-11T00:00:00.000Z",
+    },
+    additional_active_count: 0,
+    ...over,
+  };
+}
+
+describe("resolveSelectedAgent (G-1114.D.4)", () => {
+  const agents = [
+    tile({ agent_id: "luna", assistant_name: "Luna" }),
+    tile({ agent_id: "echo", assistant_name: "Echo" }),
+  ];
+
+  it("returns null when nothing is selected", () => {
+    expect(resolveSelectedAgent(agents, null)).toBeNull();
+  });
+
+  it("returns the live tile for a selected, present agent", () => {
+    const got = resolveSelectedAgent(agents, "andreas/research/luna");
+    expect(got).not.toBeNull();
+    expect(got!.agent_id).toBe("luna");
+    expect(got!.assistant_name).toBe("Luna");
+  });
+
+  it("reads the LIVE tile, not a stale copy (presence update reflected)", () => {
+    // The selected agent went offline in the latest snapshot — resolving against
+    // the new snapshot returns the offline tile, so the panel reflects it live.
+    const refreshed = [
+      tile({
+        agent_id: "luna",
+        assistant_name: "Luna",
+        state: "offline",
+        offline_reason: "ttl_lapse",
+      }),
+      tile({ agent_id: "echo", assistant_name: "Echo" }),
+    ];
+    const got = resolveSelectedAgent(refreshed, "andreas/research/luna");
+    expect(got!.state).toBe("offline");
+    expect(got!.offline_reason).toBe("ttl_lapse");
+  });
+
+  it("auto-closes (returns null) when the selected agent disappears from the snapshot", () => {
+    const shrunk = [tile({ agent_id: "echo", assistant_name: "Echo" })];
+    expect(resolveSelectedAgent(shrunk, "andreas/research/luna")).toBeNull();
+  });
+
+  it("returns null for a key that was never in the snapshot", () => {
+    expect(resolveSelectedAgent(agents, "andreas/research/ghost")).toBeNull();
+  });
+
+  it("returns null against an empty snapshot", () => {
+    expect(resolveSelectedAgent([], "andreas/research/luna")).toBeNull();
+  });
+});
+
+describe("agentKeyFromClickedNode (G-1114.D.4)", () => {
+  it("returns the agent key for an agent node", () => {
+    expect(
+      agentKeyFromClickedNode({ type: "agent", id: "andreas/research/luna" }),
+    ).toBe("andreas/research/luna");
+  });
+
+  it("returns null for the stack-hub node (hub click deselects, no agent panel)", () => {
+    expect(
+      agentKeyFromClickedNode({ type: "stackHub", id: "__stack__" }),
+    ).toBeNull();
+  });
+});
+
+describe("selectAgentDispatchActivity (G-1114.D.4)", () => {
+  it("returns null when the agent has no active working-grid tile (idle)", () => {
+    expect(selectAgentDispatchActivity([], "luna")).toBeNull();
+  });
+
+  it("projects ONLY lifecycle metadata for an actively-dispatched agent", () => {
+    const activity = selectAgentDispatchActivity(
+      [
+        workingTile({
+          agent_id: "luna",
+          primary_state: "running",
+          additional_active_count: 2,
+        }),
+      ],
+      "luna",
+    );
+    expect(activity).not.toBeNull();
+    expect(activity!.primaryState).toBe("running");
+    expect(activity!.taskTitle).toBe("Build the thing");
+    expect(activity!.taskPriority).toBe(1);
+    expect(activity!.additionalActiveCount).toBe(2);
+    expect(activity!.updatedAt).toBe("2026-06-11T00:00:00.000Z");
+  });
+
+  it("matches by agent_id, ignoring other agents' tiles", () => {
+    const activity = selectAgentDispatchActivity(
+      [
+        workingTile({ agent_id: "echo" }),
+        workingTile({
+          agent_id: "luna",
+          primary_assignment: {
+            id: "a2",
+            task_id: "t2",
+            task_title: "Luna's task",
+            task_priority: 0,
+            updated_at: "2026-06-11T01:00:00.000Z",
+          },
+        }),
+      ],
+      "luna",
+    );
+    expect(activity!.taskTitle).toBe("Luna's task");
+    expect(activity!.taskPriority).toBe(0);
+  });
+
+  it("carries no session-interior fields — only the lifecycle projection keys", () => {
+    const activity = selectAgentDispatchActivity(
+      [workingTile({ agent_id: "luna" })],
+      "luna",
+    );
+    // The ADR-0007 boundary: the activity shape has EXACTLY the lifecycle keys,
+    // no prompt / tool-call / diff / transcript surface.
+    expect(Object.keys(activity!).sort()).toEqual(
+      [
+        "additionalActiveCount",
+        "primaryState",
+        "taskPriority",
+        "taskTitle",
+        "updatedAt",
+      ].sort(),
+    );
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-detail-panel.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-detail-panel.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * G-1114.D.4 — NetworkDetailPanel render tests.
+ *
+ * The panel is a PURE component (no hooks / no xyflow), so it renders under
+ * `renderToStaticMarkup` like the network-nodes card inners. These assert the
+ * presence / capability / dispatch-activity rendering across online / offline /
+ * TTL-lapse / idle / missing-data states — AND the ADR-0007 no-interiors
+ * boundary (the panel never surfaces prompts / tool calls / diffs).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { NetworkDetailPanel } from "../components/network-detail-panel";
+import type { NetworkDetailPanelProps } from "../components/network-detail-panel";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { AgentDispatchActivity } from "../lib/network-detail-display";
+
+function tile(
+  over: Partial<AgentPresenceTile> & { agent_id: string },
+): AgentPresenceTile {
+  const { agent_id } = over;
+  return {
+    key: `andreas/research/${agent_id}`,
+    assistant_name: null,
+    nkey_public_key: `N${agent_id}`,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+    ...over,
+  };
+}
+
+function dispatchActivity(
+  over: Partial<AgentDispatchActivity> = {},
+): AgentDispatchActivity {
+  return {
+    primaryState: "running",
+    taskTitle: "Build the thing",
+    taskPriority: 1,
+    updatedAt: "2026-06-11T00:00:00.000Z",
+    additionalActiveCount: 0,
+    ...over,
+  };
+}
+
+function render(
+  over: Partial<NetworkDetailPanelProps> & { agent: AgentPresenceTile },
+): string {
+  const props: NetworkDetailPanelProps = {
+    dispatch: null,
+    onClose: () => {},
+    now: Date.now(),
+    ...over,
+  };
+  return renderToStaticMarkup(createElement(NetworkDetailPanel, props));
+}
+
+describe("NetworkDetailPanel — presence (G-1114.D.4)", () => {
+  it("renders an online agent's name, id, and online state", () => {
+    const html = render({
+      agent: tile({
+        agent_id: "luna",
+        assistant_name: "Luna",
+        state: "online",
+        last_heartbeat_at: Date.now(),
+      }),
+    });
+    expect(html).toContain("Luna");
+    expect(html).toContain("luna");
+    expect(html).toContain("online");
+    expect(html).toContain('data-agent-id="luna"');
+    expect(html).toContain('data-state="online"');
+    expect(html).toContain("heartbeat");
+  });
+
+  it("falls back to agent_id when assistant_name is null", () => {
+    const html = render({ agent: tile({ agent_id: "echo", assistant_name: null }) });
+    expect(html).toContain("echo");
+  });
+
+  it("renders a TTL-lapsed agent as 'no heartbeat' / 'last seen' with the warning treatment", () => {
+    const now = Date.now();
+    const html = render({
+      agent: tile({
+        agent_id: "sage",
+        assistant_name: "Sage",
+        state: "offline",
+        offline_reason: "ttl_lapse",
+        last_heartbeat_at: now - 6 * 60_000,
+      }),
+      now,
+    });
+    expect(html).toContain('data-state="offline"');
+    expect(html).toContain("network-detail-ttl-lapse");
+    expect(html).toContain("no heartbeat");
+    expect(html).toContain("last seen");
+    expect(html).toContain("network-detail-reason-ttl-lapse");
+  });
+
+  it("renders a graceful shutdown distinctly from a TTL lapse", () => {
+    const html = render({
+      agent: tile({
+        agent_id: "echo",
+        state: "offline",
+        offline_reason: "shutdown",
+      }),
+    });
+    expect(html).toContain("shut down");
+    expect(html).not.toContain("network-detail-ttl-lapse");
+    expect(html).not.toContain("no heartbeat");
+  });
+
+  it("does not render an offline reason for an online agent", () => {
+    const html = render({
+      agent: tile({ agent_id: "luna", state: "online", last_heartbeat_at: Date.now() }),
+    });
+    expect(html).not.toContain("network-detail-reason");
+  });
+});
+
+describe("NetworkDetailPanel — capabilities (G-1114.D.4)", () => {
+  it("renders each capability as a distinct chip", () => {
+    const html = render({
+      agent: tile({
+        agent_id: "luna",
+        capabilities: ["review.code", "review.design", "moderate"],
+      }),
+    });
+    const chips = (html.match(/network-detail-cap"/g) ?? []).length;
+    expect(chips).toBe(3);
+    expect(html).toContain("review.code");
+    expect(html).not.toContain("review.code, review.design");
+  });
+
+  it("renders the no-capabilities placeholder", () => {
+    const html = render({ agent: tile({ agent_id: "luna", capabilities: [] }) });
+    expect(html).toContain("no capabilities declared");
+    expect(html).toContain("network-detail-cap-none");
+  });
+});
+
+describe("NetworkDetailPanel — dispatch activity (G-1114.D.4)", () => {
+  it("renders the active-dispatch lifecycle line when dispatched", () => {
+    const html = render({
+      agent: tile({ agent_id: "luna" }),
+      dispatch: dispatchActivity({
+        primaryState: "running",
+        taskTitle: "Wire the panel",
+        taskPriority: 0,
+        additionalActiveCount: 2,
+      }),
+    });
+    expect(html).toContain("running");
+    expect(html).toContain("Wire the panel");
+    expect(html).toContain("P0");
+    expect(html).toContain("+2 more active");
+    expect(html).toContain("updated");
+  });
+
+  it("renders the idle line when the agent has no active dispatch", () => {
+    const html = render({ agent: tile({ agent_id: "luna" }), dispatch: null });
+    expect(html).toContain("No active dispatch");
+  });
+
+  it("omits the 'more active' line when there are no additional assignments", () => {
+    const html = render({
+      agent: tile({ agent_id: "luna" }),
+      dispatch: dispatchActivity({ additionalActiveCount: 0 }),
+    });
+    expect(html).not.toContain("more active");
+  });
+
+  it("renders the 'view in working grid' link only when the callback is provided", () => {
+    const without = render({ agent: tile({ agent_id: "luna" }) });
+    expect(without).not.toContain("View in working grid");
+
+    const withLink = render({
+      agent: tile({ agent_id: "luna" }),
+      onViewInWorkingGrid: () => {},
+    });
+    expect(withLink).toContain("View in working grid");
+  });
+});
+
+describe("NetworkDetailPanel — ADR-0007 boundary (G-1114.D.4)", () => {
+  it("never renders session-interior surfaces (prompts / tool calls / diffs)", () => {
+    const html = render({
+      agent: tile({
+        agent_id: "luna",
+        capabilities: ["review.code"],
+      }),
+      dispatch: dispatchActivity(),
+      onViewInWorkingGrid: () => {},
+    });
+    // The panel is presence + caps + lifecycle metadata + a pointer. None of the
+    // session-interior vocabulary should ever appear in its markup.
+    for (const forbidden of [
+      "prompt",
+      "tool_call",
+      "tool call",
+      "transcript",
+      "diff",
+      "stdout",
+      "message-content",
+    ]) {
+      expect(html.toLowerCase()).not.toContain(forbidden);
+    }
+  });
+
+  it("exposes a close affordance", () => {
+    const html = render({ agent: tile({ agent_id: "luna" }) });
+    expect(html).toContain("network-detail-close");
+    expect(html).toContain("Close detail panel");
+  });
+});

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -533,7 +533,11 @@ export function App() {
              presence registry via /api/agents + the agent.presence WS frame.
              Replaced the G-1114.B.4 simple agents panel. Presence + lifecycle
              only (ADR-0007) — never session interiors. */
-          <NetworkView state={agents} />
+          <NetworkView
+            state={agents}
+            workingAgents={working.agents}
+            onViewInWorkingGrid={() => setView("default")}
+          />
         )}
 
         {view === "repositories" && softwareMode && (

--- a/src/surface/mc/dashboard-v2/components/network-canvas.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-canvas.tsx
@@ -18,7 +18,7 @@
  * ADR-0007: nodes carry presence + lifecycle only — never session interiors.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ReactFlow,
   Background,
@@ -35,6 +35,7 @@ import {
   type NetworkGraph,
   type NetworkGraphNode,
 } from "../lib/network-graph-adapter";
+import { agentKeyFromClickedNode } from "../lib/network-detail-display";
 import { layoutNetworkGraph } from "../lib/network-graph-layout";
 import { AgentNode, StackHubNode } from "./network-nodes";
 import { NetworkLegend } from "./network-legend";
@@ -59,10 +60,22 @@ function getElk(): InstanceType<typeof ELK> {
 export interface NetworkCanvasProps {
   /** The pre-built (un-positioned) graph from the main-bundle adapter. */
   graph: NetworkGraph;
+  /**
+   * Lift a node selection up to the view (D.4): an agent node → its key, the
+   * stack-hub node or empty canvas → `null` (deselect). The view holds the
+   * selected key and renders the detail panel.
+   */
+  onSelectAgent?: (key: string | null) => void;
 }
 
 /** The React Flow canvas — rendered once ELK has positioned the nodes. */
-function FlowCanvas({ nodes }: { nodes: NetworkGraphNode[] }) {
+function FlowCanvas({
+  nodes,
+  onSelectAgent,
+}: {
+  nodes: NetworkGraphNode[];
+  onSelectAgent?: (key: string | null) => void;
+}) {
   // React Flow's node `data` is typed `Record<string, unknown>`; our discriminated
   // `NetworkNodeData` is structurally compatible but lacks the index signature, so
   // we cast at this single boundary rather than polluting the adapter's data type.
@@ -84,6 +97,25 @@ function FlowCanvas({ nodes }: { nodes: NetworkGraphNode[] }) {
     [nodes],
   );
 
+  // Node click → lift the agent key up (D.4). The pure
+  // `agentKeyFromClickedNode` resolves agent-node→key / hub→null, so this
+  // handler is a thin delegation (the click→lift logic itself is unit-tested
+  // off the helper, since xyflow can't mount in `bun test`).
+  const onNodeClick = useCallback(
+    (_evt: unknown, node: RfNode) => {
+      if (!onSelectAgent) return;
+      onSelectAgent(
+        agentKeyFromClickedNode(node as unknown as NetworkGraphNode),
+      );
+    },
+    [onSelectAgent],
+  );
+
+  // Click on empty canvas → deselect (close the panel).
+  const onPaneClick = useCallback(() => {
+    onSelectAgent?.(null);
+  }, [onSelectAgent]);
+
   return (
     <ReactFlow
       nodes={rfNodes}
@@ -94,6 +126,8 @@ function FlowCanvas({ nodes }: { nodes: NetworkGraphNode[] }) {
       maxZoom={2}
       nodesDraggable={false}
       nodesConnectable={false}
+      onNodeClick={onNodeClick}
+      onPaneClick={onPaneClick}
       proOptions={{ hideAttribution: true }}
     >
       <Background gap={20} size={1} />
@@ -110,7 +144,10 @@ function FlowCanvas({ nodes }: { nodes: NetworkGraphNode[] }) {
  *
  * Default export so `React.lazy(() => import("./network-canvas"))` resolves it.
  */
-export default function NetworkCanvas({ graph }: NetworkCanvasProps) {
+export default function NetworkCanvas({
+  graph,
+  onSelectAgent,
+}: NetworkCanvasProps) {
   const [positioned, setPositioned] = useState<NetworkGraphNode[]>([]);
   const genRef = useRef(0);
 
@@ -150,7 +187,7 @@ export default function NetworkCanvas({ graph }: NetworkCanvasProps) {
 
   return (
     <ReactFlowProvider>
-      <FlowCanvas nodes={positioned} />
+      <FlowCanvas nodes={positioned} onSelectAgent={onSelectAgent} />
     </ReactFlowProvider>
   );
 }

--- a/src/surface/mc/dashboard-v2/components/network-detail-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-detail-panel.tsx
@@ -1,0 +1,208 @@
+/**
+ * G-1114.D.4 — Network node DETAIL PANEL.
+ *
+ * A PURE side panel that opens when a principal clicks an agent node in the
+ * Network graph. It shows that agent's presence + capabilities + a LIGHT
+ * dispatch-activity pointer — and nothing else.
+ *
+ * ## ADR-0007 boundary (load-bearing)
+ *
+ * This panel renders presence + capabilities + dispatch **lifecycle metadata**
+ * ONLY: identity, online/offline state (with the TTL-lapse-vs-graceful
+ * distinction), capabilities, last-heartbeat, and — IF the agent is actively
+ * dispatched — its current primary task title + priority + active count, joined
+ * from the working-agents projection. It NEVER renders session interiors: no
+ * prompts, no tool calls, no diffs, no transcripts. Those live in the dispatch
+ * surface, behind their own auth, and never enter the network graph. The
+ * "recent activity" section is a POINTER (a "view in working grid" link), not a
+ * window into the session.
+ *
+ * ## Why pure
+ *
+ * The panel takes the resolved agent tile + dispatch activity + callbacks as
+ * props (no hooks, no xyflow, no data fetching). That keeps it in the MAIN
+ * bundle (it imports only `agents-display` helpers + types — never the
+ * xyflow/elk engine, so it doesn't bloat the lazy network-canvas chunk) AND
+ * unit-testable under `renderToStaticMarkup` without a DOM, mirroring the
+ * network-nodes card inners. The selection/auto-close logic lives in
+ * `lib/network-detail-display.ts` (also pure); `network-view` wires the two
+ * together against the live `useAgents` snapshot.
+ */
+
+import {
+  formatRelativeTime,
+  formatCapabilities,
+  offlineReasonLabel,
+  isTtlLapse,
+} from "../lib/agents-display";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { AgentDispatchActivity } from "../lib/network-detail-display";
+
+/** Match the working-grid priority label (P0–P3, P? out-of-range). */
+function priorityLabel(p: number): string {
+  if (Number.isInteger(p) && p >= 0 && p <= 3) return `P${p}`;
+  return "P?";
+}
+
+export interface NetworkDetailPanelProps {
+  /** The live, snapshot-resolved agent tile to show. */
+  agent: AgentPresenceTile;
+  /**
+   * The agent's dispatch-lifecycle activity (joined from the working-agents
+   * projection), or `null` when the agent isn't actively dispatched (idle).
+   * LIFECYCLE METADATA ONLY — never session interiors (ADR-0007).
+   */
+  dispatch: AgentDispatchActivity | null;
+  /** Close the panel (deselect). */
+  onClose: () => void;
+  /**
+   * Jump to the working grid (where the dispatch lifecycle lives in full).
+   * Optional — when omitted, the "view in working grid" affordance is hidden.
+   */
+  onViewInWorkingGrid?: () => void;
+  /** Injectable clock for deterministic relative-time tests. */
+  now?: number;
+}
+
+/**
+ * The pure detail panel. Renders nothing privileged: presence + capabilities +
+ * a light dispatch pointer. A fixed side panel, closeable.
+ */
+export function NetworkDetailPanel({
+  agent,
+  dispatch,
+  onClose,
+  onViewInWorkingGrid,
+  now = Date.now(),
+}: NetworkDetailPanelProps) {
+  const offline = agent.state === "offline";
+  const ttlLapse = offline && isTtlLapse(agent.offline_reason);
+  const reasonLabel = offline ? offlineReasonLabel(agent.offline_reason) : null;
+  const name = agent.assistant_name ?? agent.agent_id;
+  const caps = formatCapabilities(agent.capabilities);
+
+  return (
+    <aside
+      className={
+        "network-detail-panel" + (ttlLapse ? " network-detail-ttl-lapse" : "")
+      }
+      data-agent-id={agent.agent_id}
+      data-state={agent.state}
+      aria-label={`Agent detail — ${name}`}
+    >
+      <header className="network-detail-header">
+        <div className="network-detail-identity">
+          <span className="network-detail-name">{name}</span>
+          <span className="network-detail-id dim">{agent.agent_id}</span>
+        </div>
+        <button
+          type="button"
+          className="network-detail-close"
+          onClick={onClose}
+          aria-label="Close detail panel"
+        >
+          ✕
+        </button>
+      </header>
+
+      {/* Presence ----------------------------------------------------------- */}
+      <section className="network-detail-section network-detail-presence">
+        <span className="network-detail-section-label dim">presence</span>
+        <div className="network-detail-liveness">
+          <span
+            className={`network-detail-state state-${agent.state}`}
+            title={offline ? `offline: ${reasonLabel}` : "online"}
+          >
+            {agent.state}
+          </span>
+          {offline && (
+            <span
+              className={
+                "network-detail-reason dim" +
+                (ttlLapse ? " network-detail-reason-ttl-lapse" : "")
+              }
+            >
+              {reasonLabel}
+            </span>
+          )}
+        </div>
+        <span className="network-detail-heartbeat dim">
+          {ttlLapse ? "last seen " : "heartbeat "}
+          {formatRelativeTime(agent.last_heartbeat_at, now)}
+        </span>
+      </section>
+
+      {/* Capabilities ------------------------------------------------------- */}
+      <section className="network-detail-section network-detail-caps-section">
+        <span className="network-detail-section-label dim">capabilities</span>
+        <div className="network-detail-caps">
+          {caps.map((badge, i) =>
+            badge.placeholder ? (
+              <span key="__none__" className="network-detail-cap-none dim">
+                {badge.label}
+              </span>
+            ) : (
+              <span
+                key={`${badge.label}-${i}`}
+                className="network-detail-cap"
+              >
+                {badge.label}
+              </span>
+            ),
+          )}
+        </div>
+      </section>
+
+      {/* Dispatch lifecycle (LIGHT — pointer only, never interiors) --------- */}
+      <section className="network-detail-section network-detail-activity">
+        <span className="network-detail-section-label dim">recent activity</span>
+        {dispatch ? (
+          <div className="network-detail-dispatch">
+            <div className="network-detail-dispatch-line">
+              <span
+                className={`network-detail-dispatch-state state-${dispatch.primaryState}`}
+              >
+                {dispatch.primaryState}
+              </span>
+              <span className="network-detail-dispatch-priority dim">
+                {priorityLabel(dispatch.taskPriority)}
+              </span>
+              <span className="network-detail-dispatch-task">
+                {dispatch.taskTitle}
+              </span>
+            </div>
+            {dispatch.additionalActiveCount > 0 && (
+              <span className="network-detail-dispatch-more dim">
+                +{dispatch.additionalActiveCount} more active
+              </span>
+            )}
+            <span className="network-detail-dispatch-updated dim">
+              updated {formatRelativeTime(Date.parse(dispatch.updatedAt), now)}
+            </span>
+          </div>
+        ) : (
+          <span className="network-detail-dispatch-idle dim">
+            No active dispatch.
+          </span>
+        )}
+        {onViewInWorkingGrid && (
+          <button
+            type="button"
+            className="network-detail-grid-link"
+            onClick={onViewInWorkingGrid}
+          >
+            View in working grid →
+          </button>
+        )}
+      </section>
+
+      {/*
+        ADR-0007 boundary: this panel intentionally stops here. It shows
+        presence + capabilities + dispatch LIFECYCLE METADATA (state, task,
+        priority, counts) and a pointer to the working grid — NEVER session
+        interiors (prompts, tool calls, diffs, transcripts). Those never enter
+        the network graph.
+      */}
+    </aside>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -100,6 +100,16 @@ export function NetworkView({
 
   const closePanel = useCallback(() => setSelectedKey(null), []);
 
+  // Esc dismisses the detail panel (keyboard a11y; button + pane-click also close).
+  useEffect(() => {
+    if (selectedKey === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closePanel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedKey, closePanel]);
+
   return (
     <section className="scaffold-section network-view" aria-label="Network (agent topology)">
       <h2>Network</h2>

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -27,10 +27,16 @@
  * ADR-0007: nodes carry presence + lifecycle only — never session interiors.
  */
 
-import { Suspense, lazy, useMemo } from "react";
+import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
 import type { AgentsState } from "../hooks/use-agents";
+import type { WorkingAgentTile } from "../hooks/use-working-agents";
 import { pickAgentsPanelMode } from "../lib/agents-display";
 import { buildNetworkGraph } from "../lib/network-graph-adapter";
+import {
+  resolveSelectedAgent,
+  selectAgentDispatchActivity,
+} from "../lib/network-detail-display";
+import { NetworkDetailPanel } from "./network-detail-panel";
 
 // Lazy: the xyflow + elk engine chunk loads only when this resolves (first
 // entry into the Network tab). Keep this the ONLY dynamic import in the view —
@@ -39,15 +45,60 @@ const NetworkCanvas = lazy(() => import("./network-canvas"));
 
 export interface NetworkViewProps {
   state: AgentsState;
+  /**
+   * The working-agents snapshot (already fetched at app scope for the working
+   * grid). D.4 joins it by `agent_id` to surface a LIGHT dispatch-activity
+   * pointer in the detail panel — never session interiors (ADR-0007). Defaults
+   * to empty (the panel renders "no active dispatch" without it).
+   */
+  workingAgents?: readonly WorkingAgentTile[];
+  /**
+   * Jump to the working grid (the dashboard's default view). When provided, the
+   * detail panel shows a "view in working grid" pointer for the dispatch
+   * lifecycle in full.
+   */
+  onViewInWorkingGrid?: () => void;
 }
 
-export function NetworkView({ state }: NetworkViewProps) {
+export function NetworkView({
+  state,
+  workingAgents = [],
+  onViewInWorkingGrid,
+}: NetworkViewProps) {
   const mode = pickAgentsPanelMode(state);
 
   // Pure: snapshot → React-Flow graph (re-derived only when the agents change).
   // Tiny + engine-free, so it stays in the main bundle; the lazy canvas takes
   // the built graph and runs ELK over it.
   const graph = useMemo(() => buildNetworkGraph(state.agents), [state.agents]);
+
+  // D.4 — node-click selection. The canvas lifts the clicked agent's key here;
+  // the panel re-reads the LIVE tile off the snapshot by key, so it reflects
+  // presence updates and auto-closes if the agent disappears.
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const selectedAgent = useMemo(
+    () => resolveSelectedAgent(state.agents, selectedKey),
+    [state.agents, selectedKey],
+  );
+
+  // Auto-close: if the selected agent dropped out of the snapshot (went away),
+  // clear the stale key so we don't hold a dead selection. `selectedAgent` is
+  // already null for the render; this resets the key for the next click.
+  useEffect(() => {
+    if (selectedKey !== null && selectedAgent === null) {
+      setSelectedKey(null);
+    }
+  }, [selectedKey, selectedAgent]);
+
+  const dispatch = useMemo(
+    () =>
+      selectedAgent
+        ? selectAgentDispatchActivity(workingAgents, selectedAgent.agent_id)
+        : null,
+    [workingAgents, selectedAgent],
+  );
+
+  const closePanel = useCallback(() => setSelectedKey(null), []);
 
   return (
     <section className="scaffold-section network-view" aria-label="Network (agent topology)">
@@ -75,8 +126,16 @@ export function NetworkView({ state }: NetworkViewProps) {
               <div className="network-view-empty">Loading network…</div>
             }
           >
-            <NetworkCanvas graph={graph} />
+            <NetworkCanvas graph={graph} onSelectAgent={setSelectedKey} />
           </Suspense>
+          {selectedAgent && (
+            <NetworkDetailPanel
+              agent={selectedAgent}
+              dispatch={dispatch}
+              onClose={closePanel}
+              onViewInWorkingGrid={onViewInWorkingGrid}
+            />
+          )}
         </div>
       )}
     </section>

--- a/src/surface/mc/dashboard-v2/lib/network-detail-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-detail-display.ts
@@ -1,0 +1,109 @@
+/**
+ * G-1114.D.4 — pure helpers for the Network node detail panel.
+ *
+ * The detail panel itself is a pure presentational component, but the
+ * SELECTION logic — "given the live agents snapshot + the currently-selected
+ * key, what does the panel show?" — is extracted here so it stays unit-testable
+ * without a DOM (the same discipline as `agents-display` / `working-grid-display`).
+ *
+ * The load-bearing rule (D.4 Build step 4): the panel reads off the LIVE
+ * `useAgents` snapshot looked up by key, so an open panel reflects presence
+ * updates — and if the selected agent disappears from the snapshot (e.g. the
+ * registry dropped it), the panel auto-closes. That "is the selection still
+ * present?" decision is `resolveSelectedAgent` below.
+ *
+ * The dispatch-lifecycle join (`selectAgentDispatchActivity`) is a pure FRONTEND
+ * join of the already-fetched working-agents projection by `agent_id` — NOT a
+ * new backend join. It surfaces ONLY lifecycle metadata (state, task title,
+ * priority, active count) — NEVER session interiors (ADR-0007).
+ */
+
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import type { NetworkGraphNode } from "./network-graph-adapter";
+
+/**
+ * Map a clicked graph node to the agent key the detail panel should select.
+ *
+ * - An **agent** node → its key (`{principal}/{stack}/{agent_id}`); the panel
+ *   opens for it.
+ * - The synthetic **stack-hub** node → `null`; clicking the hub doesn't open an
+ *   agent panel (it's a layout anchor, not an agent — D.4 keeps the hub-click
+ *   a deselect rather than building a stack-summary surface).
+ *
+ * Extracted as a pure function so the canvas's `onNodeClick` is a one-line
+ * delegation testable without mounting xyflow (which can't run in `bun test`).
+ */
+export function agentKeyFromClickedNode(
+  node: Pick<NetworkGraphNode, "type" | "id">,
+): string | null {
+  return node.type === "agent" ? node.id : null;
+}
+
+/**
+ * Resolve the currently-selected agent against the live snapshot.
+ *
+ * - `selectedKey === null` → `null` (nothing selected).
+ * - selected key present in the snapshot → the live tile (so the panel reflects
+ *   the latest presence — state/caps/heartbeat — as the snapshot refetches).
+ * - selected key ABSENT from the snapshot → `null` (the agent disappeared; the
+ *   caller treats `null` as "close the panel"). This is the auto-close path.
+ *
+ * Pure + snapshot-driven: the panel never holds its own copy of the agent's
+ * presence, it always re-reads the live tile, so it can't go stale.
+ */
+export function resolveSelectedAgent(
+  agents: readonly AgentPresenceTile[],
+  selectedKey: string | null,
+): AgentPresenceTile | null {
+  if (selectedKey === null) return null;
+  return agents.find((a) => a.key === selectedKey) ?? null;
+}
+
+/**
+ * One agent's dispatch-lifecycle activity, joined from the working-agents
+ * projection. LIFECYCLE METADATA ONLY (ADR-0007): the agent's current primary
+ * state, the task it's assigned to (title + priority), and how many additional
+ * active assignments it has. Explicitly NOT the prompt, tool calls, diffs, or
+ * any session interior — those never leave the working-grid projection and never
+ * enter the network detail panel.
+ */
+export interface AgentDispatchActivity {
+  /** The agent's current primary work state. */
+  primaryState: WorkingAgentTile["primary_state"];
+  /** Title of the task the agent is primarily assigned to. */
+  taskTitle: string;
+  /** Priority of that task (0–3; rendered as P0–P3). */
+  taskPriority: number;
+  /** `updated_at` ISO timestamp of the primary assignment. */
+  updatedAt: string;
+  /** Count of additional active assignments beyond the primary. */
+  additionalActiveCount: number;
+}
+
+/**
+ * Frontend join: find the selected agent's dispatch activity in the
+ * working-agents snapshot by `agent_id`.
+ *
+ * - No working-agents tile for this agent (it isn't actively dispatched) →
+ *   `null`; the panel renders an "idle / no active dispatch" line instead.
+ * - A tile present → the lifecycle-only projection above.
+ *
+ * The working-agents data is fetched ONCE at app scope (the working grid already
+ * consumes it), so this is a zero-cost re-projection — no extra request, no new
+ * backend endpoint.
+ */
+export function selectAgentDispatchActivity(
+  workingAgents: readonly WorkingAgentTile[],
+  agentId: string,
+): AgentDispatchActivity | null {
+  const tile = workingAgents.find((w) => w.agent_id === agentId);
+  if (!tile) return null;
+  return {
+    primaryState: tile.primary_state,
+    taskTitle: tile.primary_assignment.task_title,
+    taskPriority: tile.primary_assignment.task_priority,
+    updatedAt: tile.primary_assignment.updated_at,
+    additionalActiveCount: tile.additional_active_count,
+  };
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -478,6 +478,72 @@ html, body {
 .network-legend-swatch.swatch-offline { background: var(--fg-faint); }
 .network-legend-swatch.swatch-ttl-lapse { background: var(--warn); }
 
+/* G-1114.D.4 — node detail panel (slides in on the right of the canvas).
+   Presence + capabilities + a LIGHT dispatch pointer — never session
+   interiors (ADR-0007). */
+.network-detail-panel {
+  position: absolute; top: 10px; right: 10px; bottom: 10px; z-index: 6;
+  width: 280px; max-width: calc(100% - 20px);
+  display: flex; flex-direction: column; gap: 12px;
+  padding: 14px 16px; overflow-y: auto;
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); color: var(--fg);
+  box-shadow: -4px 0 18px color-mix(in oklch, var(--bg) 60%, transparent);
+  font-family: var(--sans);
+}
+.network-detail-panel.network-detail-ttl-lapse {
+  border-color: color-mix(in oklch, var(--warn) 50%, var(--line));
+}
+.network-detail-header {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 8px;
+}
+.network-detail-identity { display: flex; flex-direction: column; gap: 2px; }
+.network-detail-name { font-size: 14px; font-weight: 700; }
+.network-detail-id { font-size: 11px; font-family: var(--mono); }
+.network-detail-close {
+  background: none; border: none; cursor: pointer;
+  color: var(--fg-faint); font-size: 13px; line-height: 1; padding: 2px 4px;
+}
+.network-detail-close:hover { color: var(--fg); }
+.network-detail-section { display: flex; flex-direction: column; gap: 5px; }
+.network-detail-section-label {
+  font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em;
+}
+.network-detail-liveness { display: flex; align-items: center; gap: 8px; }
+.network-detail-state {
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600;
+}
+.network-detail-state.state-online { color: var(--ok); }
+.network-detail-state.state-offline { color: var(--fg-faint); }
+.network-detail-reason { font-size: 11px; }
+.network-detail-reason-ttl-lapse { color: var(--warn); }
+.network-detail-heartbeat { font-size: 11px; }
+.network-detail-caps { display: flex; flex-wrap: wrap; gap: 5px; }
+.network-detail-cap {
+  font-size: 10px; padding: 2px 7px;
+  border: 1px solid var(--line); border-radius: 4px; color: var(--fg-faint);
+}
+.network-detail-cap-none { font-size: 11px; font-style: italic; }
+.network-detail-dispatch { display: flex; flex-direction: column; gap: 4px; }
+.network-detail-dispatch-line {
+  display: flex; align-items: baseline; gap: 6px; flex-wrap: wrap;
+}
+.network-detail-dispatch-state {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600;
+  color: var(--accent);
+}
+.network-detail-dispatch-priority { font-size: 10px; font-family: var(--mono); }
+.network-detail-dispatch-task { font-size: 12px; }
+.network-detail-dispatch-more,
+.network-detail-dispatch-updated { font-size: 10.5px; }
+.network-detail-dispatch-idle { font-size: 11.5px; font-style: italic; }
+.network-detail-grid-link {
+  align-self: flex-start; margin-top: 4px;
+  background: none; border: none; cursor: pointer; padding: 0;
+  color: var(--accent); font-size: 11.5px;
+}
+.network-detail-grid-link:hover { text-decoration: underline; }
+
 /* G-1113.C.7 — per-repository panel */
 .repos-view .repo-card {
   border: 1px solid var(--line); border-radius: 8px;


### PR DESCRIPTION
## What

Phase D.4 of the agent-network-topology umbrella (#355). Click an agent node in the Network graph → a side panel showing that agent's **presence + capabilities + a light dispatch-activity pointer**.

- **Node-click → selection**: `network-canvas` wires xyflow `onNodeClick` to lift the clicked agent's key up to `network-view` (a new `onSelectAgent` callback prop); `onPaneClick` (empty canvas) deselects. Clicking the synthetic **stack-hub** node deselects (it's a layout anchor, not an agent — no stack-summary surface built in D.4). The click→lift logic is the pure `agentKeyFromClickedNode` helper, so it's unit-tested without mounting xyflow (which can't run in `bun test`).
- **DetailPanel** (`network-detail-panel.tsx`, new): a **pure** component (no hooks, no xyflow) taking the resolved agent tile + dispatch activity + callbacks. Renders identity, online/offline state (with the **TTL-lapse-vs-graceful** distinction, reusing `agents-display`), capability chips, last-heartbeat relative time, a **light dispatch-activity** section, and a closeable header.
- **Live + auto-close**: `network-view` holds `selectedAgentKey` and resolves it against the **live** `useAgents` snapshot by key (`resolveSelectedAgent`), so an open panel reflects presence updates (an agent going offline shows live), and **auto-closes** if the selected agent disappears from the snapshot.

## NEVER session interiors (ADR-0007)

The panel shows presence + capabilities + dispatch **lifecycle metadata** ONLY — never prompts, tool calls, diffs, or transcripts. The "recent activity" section is a **pointer** (a "view in working grid" link), not a window into the session. A test asserts the forbidden vocabulary (`prompt`/`tool call`/`diff`/`transcript`/…) never appears in the panel markup, and a comment marks the boundary in-component.

## Dispatch-lifecycle source decision: link-out + light frontend join (no new backend)

`selectAgentDispatchActivity` is a **pure frontend join** of the already-fetched `working-agents` projection (consumed at app scope for the working grid) by `agent_id` — surfacing only `primary_state` + task title + priority + active count. **No new backend join, no extra request.** When the agent isn't actively dispatched the panel shows "No active dispatch", plus an optional "View in working grid →" pointer (`onViewInWorkingGrid` → `setView("default")`) where the dispatch lifecycle lives in full.

## Panel bundle location: MAIN bundle

The DetailPanel imports only `agents-display` helpers + types — never xyflow/elk — so it stays **pure + main-bundle**, keeping the lazy `network-canvas` engine chunk untouched. Verified post-build: the `network-detail-close` marker is present in the entry chunk and **absent** from the lazy `network-canvas` chunk.

## Test plan

- `network-detail-display.test.ts` (pure): `resolveSelectedAgent` (select / deselect / live-tile-reflected / **auto-close-on-disappear** / empty), `agentKeyFromClickedNode` (agent→key, hub→null), `selectAgentDispatchActivity` (idle→null / lifecycle-only projection / match-by-id / **no-interior-keys**).
- `network-detail-panel.test.tsx` (pure, `renderToStaticMarkup` — same pattern as D.1-3 node-card tests): presence (online / TTL-lapse / graceful-shutdown / online-has-no-reason / name-fallback), capabilities (chips / placeholder), dispatch activity (active line / idle / more-active / link-gated-on-callback), **ADR-0007 no-interiors** boundary, close affordance.
- Coverage limit (as D.1-3 noted): the xyflow `onNodeClick`/`onPaneClick` *wiring* is runtime-only (xyflow needs the zustand provider + DOM, unavailable in `bun test`); the click→lift *logic* is fully covered via the pure `agentKeyFromClickedNode` helper, and the wiring itself is validated by the `build:dashboard` gate.

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, none in changed files)
- `bun test` — 5651 pass / 0 fail
- `bash scripts/check-carveouts.sh` (changed files) — PASS
- `bun run build:dashboard` — OK; the `network-canvas` engine chunk stays code-split (3.50 MB off the entry bundle)

refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)