### PR TITLE
fix(mc): wrangler CORS_ORIGIN tracks the 8767 local daemon port

### DIFF
--- a/src/surface/mc/worker/wrangler.toml
+++ b/src/surface/mc/worker/wrangler.toml
@@ -8,7 +8,7 @@ workers_dev = false
 
 # Base vars for local dev (wrangler dev)
 [vars]
-CORS_ORIGIN = "http://localhost:8766,http://localhost:8765"
+CORS_ORIGIN = "http://localhost:8767,http://localhost:8765"
 
 # Base bindings for local dev (wrangler dev uses these defaults)
 [[d1_databases]]
@@ -56,7 +56,7 @@ name = "DASHBOARD_SOCKET"
 class_name = "DashboardSocket"
 
 [env.dev.vars]
-CORS_ORIGIN = "https://cortex-dev.meta-factory.ai,https://cortex-dev.meta-factory.dev,https://cortex-dev.meta-factory.io,http://localhost:8766,http://localhost:8765"
+CORS_ORIGIN = "https://cortex-dev.meta-factory.ai,https://cortex-dev.meta-factory.dev,https://cortex-dev.meta-factory.io,http://localhost:8767,http://localhost:8765"
 ENVIRONMENT = "development"
 
 # Dev D1 (cortex-events-dev, provisioned 2026-06-04, region OC)


### PR DESCRIPTION
Follow-up nit from the cortex#894 post-merge review: `src/surface/mc/worker/wrangler.toml:11,59` still allowlisted `http://localhost:8766` while the MC default port moved to **8767** (`src/surface/mc/config.ts:19`). A local dashboard pointed at the worker from `localhost:8767` would hit a CORS reject.

Two-line change, both `CORS_ORIGIN` entries updated. `localhost:8765` left as-is (separate consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)