### PR TITLE
feat(mc): G-1114.D.5 — Network filters + Cmd+K spotlight search

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-filter-bar.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-filter-bar.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * G-1114.D.5 — NetworkFilterBar render tests.
+ *
+ * Pure presentational component (no hooks / no xyflow) → renders under
+ * `renderToStaticMarkup` like the other D-phase card inners. Asserts the state
+ * toggle reflects the active filter, the capability dropdown lists the options +
+ * marks the selection, the Clear affordance shows only when a filter is active,
+ * and the spotlight trigger renders.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { NetworkFilterBar } from "../components/network-filter-bar";
+import type { NetworkFilterBarProps } from "../components/network-filter-bar";
+import { DEFAULT_NETWORK_FILTER } from "../lib/network-graph-filter";
+
+function render(over: Partial<NetworkFilterBarProps> = {}): string {
+  const props: NetworkFilterBarProps = {
+    filter: DEFAULT_NETWORK_FILTER,
+    capabilityOptions: ["moderate", "review.code"],
+    onStateChange: () => {},
+    onCapabilityChange: () => {},
+    onClear: () => {},
+    onOpenSpotlight: () => {},
+    ...over,
+  };
+  return renderToStaticMarkup(createElement(NetworkFilterBar, props));
+}
+
+describe("NetworkFilterBar — state toggle (G-1114.D.5)", () => {
+  it("renders the three state options", () => {
+    const html = render();
+    expect(html).toContain('data-state-filter="all"');
+    expect(html).toContain('data-state-filter="online"');
+    expect(html).toContain('data-state-filter="offline"');
+  });
+
+  it("marks the active state with aria-pressed", () => {
+    const html = render({ filter: { state: "online", capability: null } });
+    // The online button is pressed; all is not.
+    expect(html).toContain('aria-pressed="true" data-state-filter="online"');
+    expect(html).not.toContain('aria-pressed="true" data-state-filter="all"');
+  });
+
+  it("defaults to 'all' pressed", () => {
+    const html = render();
+    expect(html).toContain('aria-pressed="true" data-state-filter="all"');
+  });
+});
+
+describe("NetworkFilterBar — capability dropdown (G-1114.D.5)", () => {
+  it("renders an 'Any capability' default option plus each capability", () => {
+    const html = render();
+    expect(html).toContain("Any capability");
+    expect(html).toContain("moderate");
+    expect(html).toContain("review.code");
+  });
+
+  it("marks the selected capability", () => {
+    const html = render({ filter: { state: "all", capability: "review.code" } });
+    // react-dom serialises a controlled <select value> via the matching option's selected attr.
+    expect(html).toContain('value="review.code" selected');
+  });
+});
+
+describe("NetworkFilterBar — clear affordance (G-1114.D.5)", () => {
+  it("hides Clear when no filter is active", () => {
+    const html = render({ filter: DEFAULT_NETWORK_FILTER });
+    expect(html).not.toContain("network-filter-clear");
+  });
+
+  it("shows Clear when a state filter is active", () => {
+    const html = render({ filter: { state: "online", capability: null } });
+    expect(html).toContain("network-filter-clear");
+    expect(html).toContain("Clear filters");
+  });
+
+  it("shows Clear when a capability filter is active", () => {
+    const html = render({ filter: { state: "all", capability: "moderate" } });
+    expect(html).toContain("network-filter-clear");
+  });
+});
+
+describe("NetworkFilterBar — spotlight trigger (G-1114.D.5)", () => {
+  it("renders a Find-agent trigger with the ⌘K hint", () => {
+    const html = render();
+    expect(html).toContain("network-filter-spotlight");
+    expect(html).toContain("Find agent");
+    expect(html).toContain("⌘");
+    expect(html).toContain("K");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-filter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-filter.test.ts
@@ -1,0 +1,177 @@
+/**
+ * G-1114.D.5 — network graph FILTER tests.
+ *
+ * Asserts the pure filter that narrows the agents snapshot before it feeds the
+ * graph adapter: a state filter (online / offline / all), a capability filter
+ * (show only agents declaring a chosen capability), the two combined, the empty
+ * result, and the capability-option derivation (the distinct, sorted capability
+ * set offered in the filter bar's dropdown).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  DEFAULT_NETWORK_FILTER,
+  filterAgents,
+  collectCapabilityOptions,
+  isFilterActive,
+  type NetworkFilterState,
+} from "../lib/network-graph-filter";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+function tile(
+  over: Partial<AgentPresenceTile> & { agent_id: string },
+): AgentPresenceTile {
+  const { agent_id } = over;
+  return {
+    key: `andreas/research/${agent_id}`,
+    assistant_name: null,
+    nkey_public_key: `N${agent_id}`,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+    ...over,
+  };
+}
+
+const luna = tile({
+  agent_id: "luna",
+  assistant_name: "Luna",
+  state: "online",
+  capabilities: ["review.code", "review.design"],
+});
+const echo = tile({
+  agent_id: "echo",
+  assistant_name: "Echo",
+  state: "online",
+  capabilities: ["review.code"],
+});
+const sage = tile({
+  agent_id: "sage",
+  assistant_name: "Sage",
+  state: "offline",
+  offline_reason: "ttl_lapse",
+  capabilities: ["moderate"],
+});
+const all = [luna, echo, sage];
+
+describe("filterAgents — state filter (G-1114.D.5)", () => {
+  it("returns every agent for the default (all) filter", () => {
+    expect(filterAgents(all, DEFAULT_NETWORK_FILTER)).toEqual(all);
+  });
+
+  it("'all' state passes online and offline alike", () => {
+    const out = filterAgents(all, { state: "all", capability: null });
+    expect(out).toHaveLength(3);
+  });
+
+  it("'online' keeps only online agents", () => {
+    const out = filterAgents(all, { state: "online", capability: null });
+    expect(out.map((a) => a.agent_id)).toEqual(["luna", "echo"]);
+  });
+
+  it("'offline' keeps only offline agents", () => {
+    const out = filterAgents(all, { state: "offline", capability: null });
+    expect(out.map((a) => a.agent_id)).toEqual(["sage"]);
+  });
+
+  it("preserves snapshot order (deterministic layout input)", () => {
+    const out = filterAgents([echo, luna, sage], { state: "online", capability: null });
+    expect(out.map((a) => a.agent_id)).toEqual(["echo", "luna"]);
+  });
+});
+
+describe("filterAgents — capability filter (G-1114.D.5)", () => {
+  it("null capability passes every agent", () => {
+    const out = filterAgents(all, { state: "all", capability: null });
+    expect(out).toHaveLength(3);
+  });
+
+  it("keeps only agents declaring the chosen capability", () => {
+    const out = filterAgents(all, { state: "all", capability: "review.code" });
+    expect(out.map((a) => a.agent_id)).toEqual(["luna", "echo"]);
+  });
+
+  it("returns an empty result when no agent declares the capability", () => {
+    const out = filterAgents(all, { state: "all", capability: "deploy" });
+    expect(out).toEqual([]);
+  });
+
+  it("a capability declared by exactly one agent narrows to that agent", () => {
+    const out = filterAgents(all, { state: "all", capability: "moderate" });
+    expect(out.map((a) => a.agent_id)).toEqual(["sage"]);
+  });
+});
+
+describe("filterAgents — combined state + capability (G-1114.D.5)", () => {
+  it("applies both filters (AND)", () => {
+    // online AND review.code → luna, echo (sage is offline; sage lacks review.code anyway)
+    const out = filterAgents(all, { state: "online", capability: "review.code" });
+    expect(out.map((a) => a.agent_id)).toEqual(["luna", "echo"]);
+  });
+
+  it("can produce an empty result from the intersection", () => {
+    // offline AND review.code → none (sage is offline but only has 'moderate')
+    const out = filterAgents(all, { state: "offline", capability: "review.code" });
+    expect(out).toEqual([]);
+  });
+
+  it("offline AND moderate → sage", () => {
+    const out = filterAgents(all, { state: "offline", capability: "moderate" });
+    expect(out.map((a) => a.agent_id)).toEqual(["sage"]);
+  });
+});
+
+describe("filterAgents — edge cases (G-1114.D.5)", () => {
+  it("an empty snapshot yields an empty result for any filter", () => {
+    expect(filterAgents([], { state: "online", capability: "review.code" })).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [...all];
+    filterAgents(input, { state: "online", capability: null });
+    expect(input).toEqual(all);
+  });
+});
+
+describe("collectCapabilityOptions (G-1114.D.5)", () => {
+  it("returns the distinct capabilities across all agents, sorted", () => {
+    expect(collectCapabilityOptions(all)).toEqual([
+      "moderate",
+      "review.code",
+      "review.design",
+    ]);
+  });
+
+  it("de-duplicates a capability declared by several agents", () => {
+    // review.code is on both luna and echo — appears once.
+    const opts = collectCapabilityOptions(all);
+    expect(opts.filter((c) => c === "review.code")).toHaveLength(1);
+  });
+
+  it("returns an empty list when no agent declares a capability", () => {
+    expect(collectCapabilityOptions([tile({ agent_id: "x", capabilities: [] })])).toEqual([]);
+  });
+
+  it("returns an empty list for an empty snapshot", () => {
+    expect(collectCapabilityOptions([])).toEqual([]);
+  });
+});
+
+describe("isFilterActive (G-1114.D.5)", () => {
+  it("is false for the default filter", () => {
+    expect(isFilterActive(DEFAULT_NETWORK_FILTER)).toBe(false);
+  });
+
+  it("is true when a state filter is set", () => {
+    expect(isFilterActive({ state: "online", capability: null })).toBe(true);
+  });
+
+  it("is true when a capability filter is set", () => {
+    expect(isFilterActive({ state: "all", capability: "review.code" })).toBe(true);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-spotlight-overlay.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-spotlight-overlay.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * G-1114.D.5 — NetworkSpotlight overlay + buildAgentCommands tests.
+ *
+ * The spotlight REUSES the MC-base CommandPalette. These cover:
+ *   - `buildAgentCommands` (pure): one command per agent, label encodes
+ *     name+id+capabilities, group carries liveness, `run()` selects the key +
+ *     closes;
+ *   - the overlay render: when open, it shows the agents; when closed, it renders
+ *     nothing (CommandPalette returns null);
+ *   - selection: invoking a command's `run` calls `onSelect` with the agent key
+ *     and `onClose` (the Enter/click → select-node path D.4 consumes).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import {
+  NetworkSpotlight,
+  buildAgentCommands,
+} from "../components/network-spotlight";
+import type { NetworkSpotlightProps } from "../components/network-spotlight";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+function tile(
+  over: Partial<AgentPresenceTile> & { agent_id: string },
+): AgentPresenceTile {
+  const { agent_id } = over;
+  return {
+    key: `andreas/research/${agent_id}`,
+    assistant_name: null,
+    nkey_public_key: `N${agent_id}`,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+    ...over,
+  };
+}
+
+const luna = tile({
+  agent_id: "luna",
+  assistant_name: "Luna",
+  capabilities: ["review.code", "review.design"],
+});
+const sage = tile({
+  agent_id: "sage",
+  assistant_name: "Sage",
+  state: "offline",
+  offline_reason: "ttl_lapse",
+  capabilities: ["moderate"],
+});
+
+function render(over: Partial<NetworkSpotlightProps> = {}): string {
+  const props: NetworkSpotlightProps = {
+    open: true,
+    onClose: () => {},
+    agents: [luna, sage],
+    onSelect: () => {},
+    ...over,
+  };
+  return renderToStaticMarkup(createElement(NetworkSpotlight, props));
+}
+
+describe("buildAgentCommands (G-1114.D.5)", () => {
+  it("maps one command per agent, keyed by the registry key", () => {
+    const cmds = buildAgentCommands([luna, sage], () => {}, () => {});
+    expect(cmds.map((c) => c.id)).toEqual([
+      "andreas/research/luna",
+      "andreas/research/sage",
+    ]);
+  });
+
+  it("encodes name + id + capabilities into the searchable label", () => {
+    const [cmd] = buildAgentCommands([luna], () => {}, () => {});
+    expect(cmd!.label).toContain("Luna");
+    expect(cmd!.label).toContain("luna");
+    expect(cmd!.label).toContain("review.code");
+    expect(cmd!.label).toContain("review.design");
+  });
+
+  it("falls back to the agent id as the display name", () => {
+    const anon = tile({ agent_id: "zeta", assistant_name: null });
+    const [cmd] = buildAgentCommands([anon], () => {}, () => {});
+    expect(cmd!.label).toContain("zeta");
+  });
+
+  it("carries liveness in the command group", () => {
+    const cmds = buildAgentCommands([luna, sage], () => {}, () => {});
+    expect(cmds[0]!.group).toBe("online");
+    expect(cmds[1]!.group).toBe("offline");
+  });
+
+  it("run() selects the agent key and closes the spotlight", () => {
+    const selectedKeys: string[] = [];
+    let closed = false;
+    const cmds = buildAgentCommands(
+      [luna],
+      (k) => {
+        selectedKeys.push(k);
+      },
+      () => {
+        closed = true;
+      },
+    );
+    cmds[0]!.run();
+    expect(selectedKeys).toEqual(["andreas/research/luna"]);
+    expect(closed).toBe(true);
+  });
+
+  it("never embeds a session interior in the label (ADR-0007)", () => {
+    const [cmd] = buildAgentCommands([luna], () => {}, () => {});
+    for (const forbidden of ["prompt", "transcript", "diff", "tool_call"]) {
+      expect(cmd!.label.toLowerCase()).not.toContain(forbidden);
+    }
+  });
+});
+
+describe("NetworkSpotlight overlay (G-1114.D.5)", () => {
+  it("renders nothing when closed", () => {
+    const html = render({ open: false });
+    expect(html).toBe("");
+  });
+
+  it("renders the agents when open", () => {
+    const html = render({ open: true });
+    expect(html).toContain("Luna");
+    expect(html).toContain("Sage");
+    // The reused CommandPalette overlay chrome.
+    expect(html).toContain("cmdk");
+  });
+
+  it("renders the empty list copy when there are no agents", () => {
+    const html = render({ open: true, agents: [] });
+    expect(html).toContain("no matches");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-spotlight.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-spotlight.test.ts
@@ -1,0 +1,177 @@
+/**
+ * G-1114.D.5 — Network spotlight match/rank tests.
+ *
+ * The spotlight finds an agent by assistant name / agent id / capability and
+ * SELECTS its node. The match/rank logic is pure (a query + the agents snapshot
+ * → a ranked list of {key, ...} hits) so it's unit-testable without a DOM, the
+ * same pure/wrapper split D.1-4 use. Also covers the Cmd+K / Esc key helpers.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  searchAgents,
+  isSpotlightOpenChord,
+  type SpotlightHit,
+} from "../lib/network-spotlight";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+function tile(
+  over: Partial<AgentPresenceTile> & { agent_id: string },
+): AgentPresenceTile {
+  const { agent_id } = over;
+  return {
+    key: `andreas/research/${agent_id}`,
+    assistant_name: null,
+    nkey_public_key: `N${agent_id}`,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+    ...over,
+  };
+}
+
+const luna = tile({
+  agent_id: "luna",
+  assistant_name: "Luna",
+  capabilities: ["review.code", "review.design"],
+});
+const echo = tile({
+  agent_id: "echo",
+  assistant_name: "Echo",
+  capabilities: ["review.code"],
+});
+const sage = tile({
+  agent_id: "sage",
+  assistant_name: "Sage",
+  state: "offline",
+  offline_reason: "ttl_lapse",
+  capabilities: ["moderate"],
+});
+const all = [luna, echo, sage];
+
+function keys(hits: SpotlightHit[]): string[] {
+  return hits.map((h) => h.key);
+}
+
+describe("searchAgents — empty query (G-1114.D.5)", () => {
+  it("returns every agent (in snapshot order) for an empty query", () => {
+    expect(keys(searchAgents(all, ""))).toEqual([
+      "andreas/research/luna",
+      "andreas/research/echo",
+      "andreas/research/sage",
+    ]);
+  });
+
+  it("returns every agent for a whitespace-only query", () => {
+    expect(searchAgents(all, "   ")).toHaveLength(3);
+  });
+
+  it("returns an empty list for an empty snapshot", () => {
+    expect(searchAgents([], "luna")).toEqual([]);
+  });
+});
+
+describe("searchAgents — match by name (G-1114.D.5)", () => {
+  it("matches the assistant name, case-insensitively", () => {
+    expect(keys(searchAgents(all, "lun"))).toEqual(["andreas/research/luna"]);
+    expect(keys(searchAgents(all, "LUNA"))).toEqual(["andreas/research/luna"]);
+  });
+
+  it("falls back to agent id when assistant_name is null", () => {
+    const anon = tile({ agent_id: "zeta", assistant_name: null });
+    expect(keys(searchAgents([anon], "zeta"))).toEqual(["andreas/research/zeta"]);
+  });
+});
+
+describe("searchAgents — match by id (G-1114.D.5)", () => {
+  it("matches the agent id", () => {
+    expect(keys(searchAgents(all, "echo"))).toEqual(["andreas/research/echo"]);
+  });
+});
+
+describe("searchAgents — match by capability (G-1114.D.5)", () => {
+  it("matches a declared capability", () => {
+    // review.code is on luna and echo
+    expect(keys(searchAgents(all, "review.code")).sort()).toEqual(
+      ["andreas/research/echo", "andreas/research/luna"].sort(),
+    );
+  });
+
+  it("matches a capability substring", () => {
+    expect(keys(searchAgents(all, "moderate"))).toEqual(["andreas/research/sage"]);
+  });
+});
+
+describe("searchAgents — ranking (G-1114.D.5)", () => {
+  it("ranks a name-prefix match above a mid-string / capability match", () => {
+    // query "re": "review.*" capability hits, but no name starts with "re".
+    // Add an agent whose NAME starts with "re" — it should rank first.
+    const rex = tile({ agent_id: "rex", assistant_name: "Rex", capabilities: [] });
+    const hits = searchAgents([luna, echo, rex], "re");
+    expect(hits[0]!.key).toBe("andreas/research/rex");
+  });
+
+  it("ranks an exact id match at the top", () => {
+    const hits = searchAgents(all, "luna");
+    expect(hits[0]!.key).toBe("andreas/research/luna");
+  });
+});
+
+describe("searchAgents — no match (G-1114.D.5)", () => {
+  it("returns an empty list when nothing matches", () => {
+    expect(searchAgents(all, "nonexistent-xyz")).toEqual([]);
+  });
+});
+
+describe("searchAgents — hit shape (G-1114.D.5)", () => {
+  it("carries the key, display name, id, and state for the result row", () => {
+    const [hit] = searchAgents([luna], "luna");
+    expect(hit).toEqual({
+      key: "andreas/research/luna",
+      agentId: "luna",
+      displayName: "Luna",
+      state: "online",
+      capabilities: ["review.code", "review.design"],
+    });
+  });
+
+  it("uses agent id as the display name when assistant_name is null", () => {
+    const anon = tile({ agent_id: "zeta", assistant_name: null });
+    const [hit] = searchAgents([anon], "zeta");
+    expect(hit!.displayName).toBe("zeta");
+  });
+
+  it("never leaks session-interior fields onto a hit (ADR-0007)", () => {
+    const [hit] = searchAgents([luna], "luna");
+    expect(Object.keys(hit!).sort()).toEqual(
+      ["agentId", "capabilities", "displayName", "key", "state"].sort(),
+    );
+  });
+});
+
+describe("isSpotlightOpenChord (G-1114.D.5)", () => {
+  it("matches Cmd+K (meta)", () => {
+    expect(isSpotlightOpenChord({ metaKey: true, ctrlKey: false, key: "k" })).toBe(true);
+  });
+
+  it("matches Ctrl+K", () => {
+    expect(isSpotlightOpenChord({ metaKey: false, ctrlKey: true, key: "k" })).toBe(true);
+  });
+
+  it("is case-insensitive on the key", () => {
+    expect(isSpotlightOpenChord({ metaKey: true, ctrlKey: false, key: "K" })).toBe(true);
+  });
+
+  it("does not match a bare 'k'", () => {
+    expect(isSpotlightOpenChord({ metaKey: false, ctrlKey: false, key: "k" })).toBe(false);
+  });
+
+  it("does not match Cmd+other", () => {
+    expect(isSpotlightOpenChord({ metaKey: true, ctrlKey: false, key: "j" })).toBe(false);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-view.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-view.test.tsx
@@ -82,4 +82,20 @@ describe("NetworkView (G-1114.D.1)", () => {
     expect(html).toContain("Network");
     expect(html).toContain("topology");
   });
+
+  it("renders the D.5 filter bar in the list state", () => {
+    const html = render({
+      loaded: true,
+      error: null,
+      agents: [
+        tile({ agent_id: "luna", assistant_name: "Luna", capabilities: ["review.code"] }),
+      ],
+    });
+    // The filter bar + capability option derived from the snapshot.
+    expect(html).toContain("network-filter-bar");
+    expect(html).toContain('data-state-filter="online"');
+    expect(html).toContain("review.code");
+    // The spotlight trigger.
+    expect(html).toContain("network-filter-spotlight");
+  });
 });

--- a/src/surface/mc/dashboard-v2/components/network-filter-bar.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-filter-bar.tsx
@@ -1,0 +1,119 @@
+/**
+ * G-1114.D.5 — Network FILTER BAR.
+ *
+ * A small presentational bar above the graph canvas: a state toggle
+ * (All / Online / Offline) + a capability dropdown (Any capability / one of the
+ * declared capabilities) + a Clear affordance (shown only when a filter is
+ * active) + a Cmd+K spotlight hint.
+ *
+ * Pure / state-lifted: the filter state lives in `network-view` (so it can feed
+ * both the graph adapter and the spotlight off ONE filtered snapshot); this
+ * component just renders the controls and calls back on change. No xyflow import,
+ * so it stays in the MAIN bundle (never the lazy network-canvas chunk) and renders
+ * under `renderToStaticMarkup` in tests.
+ *
+ * CSS lives in styles/global.css under .network-filter-bar.
+ */
+
+import { Keycap } from "./keycap";
+import {
+  isFilterActive,
+  type NetworkFilterState,
+  type NetworkStateFilter,
+} from "../lib/network-graph-filter";
+
+const STATE_OPTIONS: readonly { value: NetworkStateFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "online", label: "Online" },
+  { value: "offline", label: "Offline" },
+];
+
+export interface NetworkFilterBarProps {
+  filter: NetworkFilterState;
+  /** The distinct capability ids to offer in the dropdown (sorted upstream). */
+  capabilityOptions: readonly string[];
+  onStateChange: (state: NetworkStateFilter) => void;
+  /** `null` clears the capability filter (the "Any capability" option). */
+  onCapabilityChange: (capability: string | null) => void;
+  onClear: () => void;
+  /** Open the Cmd+K spotlight (the hint button is also a click target). */
+  onOpenSpotlight: () => void;
+}
+
+export function NetworkFilterBar({
+  filter,
+  capabilityOptions,
+  onStateChange,
+  onCapabilityChange,
+  onClear,
+  onOpenSpotlight,
+}: NetworkFilterBarProps) {
+  const active = isFilterActive(filter);
+  return (
+    <div className="network-filter-bar" role="toolbar" aria-label="Network filters">
+      <div className="network-filter-group" role="group" aria-label="Liveness filter">
+        <span className="network-filter-label">State</span>
+        {STATE_OPTIONS.map((opt) => {
+          const on = filter.state === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              className={`network-filter-state-btn${on ? " on" : ""}`}
+              aria-pressed={on}
+              data-state-filter={opt.value}
+              onClick={() => onStateChange(opt.value)}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="network-filter-group">
+        <label className="network-filter-label" htmlFor="network-capability-filter">
+          Capability
+        </label>
+        <select
+          id="network-capability-filter"
+          className="network-filter-select"
+          value={filter.capability ?? ""}
+          aria-label="Filter by capability"
+          onChange={(e) =>
+            onCapabilityChange(e.target.value === "" ? null : e.target.value)
+          }
+        >
+          <option value="">Any capability</option>
+          {capabilityOptions.map((cap) => (
+            <option key={cap} value={cap}>
+              {cap}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {active && (
+        <button
+          type="button"
+          className="network-filter-clear"
+          onClick={onClear}
+        >
+          Clear filters
+        </button>
+      )}
+
+      <button
+        type="button"
+        className="network-filter-spotlight"
+        onClick={onOpenSpotlight}
+        title="Find an agent (⌘K / Ctrl+K)"
+      >
+        <span aria-hidden="true">⌕</span> Find agent
+        <span className="network-filter-kbd" aria-hidden="true">
+          <Keycap>⌘</Keycap>
+          <Keycap>K</Keycap>
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/network-spotlight.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-spotlight.tsx
@@ -1,0 +1,78 @@
+/**
+ * G-1114.D.5 — Network SPOTLIGHT (Cmd+K find-agent).
+ *
+ * REUSES the MC-base `CommandPalette` component (the dashboard's existing ⌘K
+ * overlay — keyboard nav, fuzzy substring filter, Esc-close) rather than building
+ * a bespoke overlay. We feed it a "find agent" command source: one `Command` per
+ * agent whose `run()` selects that agent's node (D.4's selection path —
+ * `onSelect(key)` → the view sets `selectedKey` → the detail panel opens).
+ *
+ * The command LABEL encodes the agent's display name + id + capabilities so the
+ * palette's built-in substring filter matches all three search dimensions
+ * (name / id / capability) the spotlight promises. The `group` carries liveness
+ * so an offline agent reads as such in the list.
+ *
+ * Open/close + the Cmd+K listener + Esc-precedence (spotlight closes before the
+ * D.4 detail panel) are owned by `network-view`; this component is the overlay +
+ * the pure agents→commands mapping. The mapping (`buildAgentCommands`) is pure
+ * and unit-tested; the overlay renders via the reused `CommandPalette`.
+ *
+ * ADR-0007: commands carry identity + presence + capabilities only — never any
+ * session interior.
+ */
+
+import { CommandPalette, type Command } from "./command-palette";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+export interface NetworkSpotlightProps {
+  open: boolean;
+  onClose: () => void;
+  /** The (already filter-narrowed) agents to search. */
+  agents: readonly AgentPresenceTile[];
+  /** Select an agent's node by key — D.4's selection path. */
+  onSelect: (key: string) => void;
+}
+
+/**
+ * Map the agents snapshot into the `CommandPalette` command list.
+ *
+ * Pure (no DOM): one command per agent. The label embeds the display name, the
+ * agent id, and the capabilities so the palette's substring filter matches a
+ * query against any of them; the group carries liveness. `run()` closes the
+ * spotlight and selects the agent's node.
+ *
+ * Exported for unit testing — asserts the label/group encoding + that `run`
+ * selects the right key and closes.
+ */
+export function buildAgentCommands(
+  agents: readonly AgentPresenceTile[],
+  onSelect: (key: string) => void,
+  onClose: () => void,
+): Command[] {
+  return agents.map((a) => {
+    const name = a.assistant_name ?? a.agent_id;
+    const caps = a.capabilities.length > 0 ? a.capabilities.join(" ") : "";
+    // The label is what the palette filters + displays. We show the name + id;
+    // the capabilities ride along (searchable) after a separator.
+    const capSuffix = caps ? `  ·  ${caps}` : "";
+    return {
+      id: a.key,
+      group: a.state === "online" ? "online" : "offline",
+      label: `${name} (${a.agent_id})${capSuffix}`,
+      run: () => {
+        onSelect(a.key);
+        onClose();
+      },
+    };
+  });
+}
+
+export function NetworkSpotlight({
+  open,
+  onClose,
+  agents,
+  onSelect,
+}: NetworkSpotlightProps) {
+  const commands = buildAgentCommands(agents, onSelect, onClose);
+  return <CommandPalette open={open} onClose={onClose} commands={commands} />;
+}

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -36,7 +36,17 @@ import {
   resolveSelectedAgent,
   selectAgentDispatchActivity,
 } from "../lib/network-detail-display";
+import {
+  DEFAULT_NETWORK_FILTER,
+  collectCapabilityOptions,
+  filterAgents,
+  type NetworkFilterState,
+  type NetworkStateFilter,
+} from "../lib/network-graph-filter";
+import { isSpotlightOpenChord } from "../lib/network-spotlight";
 import { NetworkDetailPanel } from "./network-detail-panel";
+import { NetworkFilterBar } from "./network-filter-bar";
+import { NetworkSpotlight } from "./network-spotlight";
 
 // Lazy: the xyflow + elk engine chunk loads only when this resolves (first
 // entry into the Network tab). Keep this the ONLY dynamic import in the view —
@@ -67,10 +77,35 @@ export function NetworkView({
 }: NetworkViewProps) {
   const mode = pickAgentsPanelMode(state);
 
-  // Pure: snapshot → React-Flow graph (re-derived only when the agents change).
-  // Tiny + engine-free, so it stays in the main bundle; the lazy canvas takes
-  // the built graph and runs ELK over it.
-  const graph = useMemo(() => buildNetworkGraph(state.agents), [state.agents]);
+  // D.5 — filters. The filter state lives here so it feeds BOTH the graph adapter
+  // and the spotlight off ONE filtered snapshot (filter + search stay consistent).
+  // Capability options are derived from the FULL (unfiltered) snapshot so the
+  // dropdown never drops the option that's currently selected as agents come/go.
+  const [filter, setFilter] = useState<NetworkFilterState>(DEFAULT_NETWORK_FILTER);
+  const capabilityOptions = useMemo(
+    () => collectCapabilityOptions(state.agents),
+    [state.agents],
+  );
+  const filteredAgents = useMemo(
+    () => filterAgents(state.agents, filter),
+    [state.agents, filter],
+  );
+
+  // Pure: filtered snapshot → React-Flow graph (re-derived when agents OR the
+  // filter change). Tiny + engine-free, so it stays in the main bundle; the lazy
+  // canvas takes the built graph and runs ELK over it.
+  const graph = useMemo(() => buildNetworkGraph(filteredAgents), [filteredAgents]);
+
+  // Filter callbacks.
+  const onStateChange = useCallback(
+    (s: NetworkStateFilter) => setFilter((f) => ({ ...f, state: s })),
+    [],
+  );
+  const onCapabilityChange = useCallback(
+    (cap: string | null) => setFilter((f) => ({ ...f, capability: cap })),
+    [],
+  );
+  const onClearFilters = useCallback(() => setFilter(DEFAULT_NETWORK_FILTER), []);
 
   // D.4 — node-click selection. The canvas lifts the clicked agent's key here;
   // the panel re-reads the LIVE tile off the snapshot by key, so it reflects
@@ -100,15 +135,51 @@ export function NetworkView({
 
   const closePanel = useCallback(() => setSelectedKey(null), []);
 
-  // Esc dismisses the detail panel (keyboard a11y; button + pane-click also close).
+  // D.5 — Cmd+K spotlight. Open state is local to the Network view (the spotlight
+  // only makes sense here), and selecting a hit reuses D.4's selection path.
+  const [spotlightOpen, setSpotlightOpen] = useState(false);
+  const openSpotlight = useCallback(() => setSpotlightOpen(true), []);
+  const closeSpotlight = useCallback(() => setSpotlightOpen(false), []);
+  const onSpotlightSelect = useCallback((key: string) => {
+    // Reuse D.4's selection: set the key → the live tile resolves → panel opens.
+    setSelectedKey(key);
+  }, []);
+
+  // Cmd+K / Ctrl+K opens the spotlight. Registered on the CAPTURE phase so it
+  // runs BEFORE the app-level global ⌘K palette (a bubble-phase listener) and
+  // `stopPropagation()`s it — on the Network tab, ⌘K opens the agent spotlight,
+  // not the generic command palette. Only armed while the view is mounted (the
+  // tab is active), so it doesn't shadow ⌘K elsewhere.
   useEffect(() => {
-    if (selectedKey === null) return;
+    const onKeyCapture = (e: KeyboardEvent) => {
+      if (isSpotlightOpenChord(e)) {
+        e.preventDefault();
+        e.stopPropagation();
+        setSpotlightOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener("keydown", onKeyCapture, true);
+    return () => window.removeEventListener("keydown", onKeyCapture, true);
+  }, []);
+
+  // Esc precedence (D.5 over D.4): if the spotlight is open, Esc closes IT first
+  // and the detail panel stays; only when the spotlight is closed does Esc
+  // dismiss the panel. The spotlight overlay (CommandPalette) also handles its
+  // own Esc internally, but this guard makes the precedence explicit + covers the
+  // case where focus isn't in the overlay input.
+  useEffect(() => {
+    if (selectedKey === null && !spotlightOpen) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closePanel();
+      if (e.key !== "Escape") return;
+      if (spotlightOpen) {
+        setSpotlightOpen(false);
+        return;
+      }
+      closePanel();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [selectedKey, closePanel]);
+  }, [selectedKey, spotlightOpen, closePanel]);
 
   return (
     <section className="scaffold-section network-view" aria-label="Network (agent topology)">
@@ -129,24 +200,48 @@ export function NetworkView({
         <div className="network-view-empty">No agents observed yet.</div>
       )}
       {mode === "list" && (
-        <div className="network-canvas-wrap">
-          <Suspense
-            fallback={
-              // The graph-engine chunk is downloading on first tab entry.
-              <div className="network-view-empty">Loading network…</div>
-            }
-          >
-            <NetworkCanvas graph={graph} onSelectAgent={setSelectedKey} />
-          </Suspense>
-          {selectedAgent && (
-            <NetworkDetailPanel
-              agent={selectedAgent}
-              dispatch={dispatch}
-              onClose={closePanel}
-              onViewInWorkingGrid={onViewInWorkingGrid}
-            />
-          )}
-        </div>
+        <>
+          <NetworkFilterBar
+            filter={filter}
+            capabilityOptions={capabilityOptions}
+            onStateChange={onStateChange}
+            onCapabilityChange={onCapabilityChange}
+            onClear={onClearFilters}
+            onOpenSpotlight={openSpotlight}
+          />
+          <div className="network-canvas-wrap">
+            {filteredAgents.length === 0 ? (
+              // The snapshot has agents but the active filter excludes them all.
+              // Keep the filter bar above so the principal can clear/relax it.
+              <div className="network-view-empty">
+                No agents match the current filters.
+              </div>
+            ) : (
+              <Suspense
+                fallback={
+                  // The graph-engine chunk is downloading on first tab entry.
+                  <div className="network-view-empty">Loading network…</div>
+                }
+              >
+                <NetworkCanvas graph={graph} onSelectAgent={setSelectedKey} />
+              </Suspense>
+            )}
+            {selectedAgent && (
+              <NetworkDetailPanel
+                agent={selectedAgent}
+                dispatch={dispatch}
+                onClose={closePanel}
+                onViewInWorkingGrid={onViewInWorkingGrid}
+              />
+            )}
+          </div>
+          <NetworkSpotlight
+            open={spotlightOpen}
+            onClose={closeSpotlight}
+            agents={filteredAgents}
+            onSelect={onSpotlightSelect}
+          />
+        </>
       )}
     </section>
   );

--- a/src/surface/mc/dashboard-v2/lib/network-graph-filter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-filter.ts
@@ -1,0 +1,97 @@
+/**
+ * G-1114.D.5 — network graph FILTER (pure).
+ *
+ * Narrows the agents snapshot BEFORE it reaches the graph adapter
+ * (`buildNetworkGraph`). The pipeline is:
+ *
+ *   agents snapshot → filterAgents(agents, filter) → buildNetworkGraph(filtered)
+ *                   → ELK layout → React Flow canvas
+ *
+ * Keeping the filter as a pure `(agents, filter) → agents` function (rather than
+ * folding it into the adapter) means it's trivially unit-testable without a DOM,
+ * AND it composes cleanly: the same filtered snapshot also feeds the D.5 spotlight
+ * search, so filter + spotlight see one consistent set of agents.
+ *
+ * Two orthogonal axes, AND-combined:
+ *   - **state** — `online` / `offline` / `all` (the agent's last explicit liveness).
+ *   - **capability** — `null` (any) or a single capability id; keep agents that
+ *     DECLARE it.
+ *
+ * The filter never touches the synthetic stack-hub (it isn't an agent — it's
+ * synthesised by the adapter from whatever agents survive the filter). When the
+ * filter empties the agent set, the adapter returns an empty graph and the view
+ * shows its empty state, exactly as it does for a genuinely empty snapshot.
+ *
+ * ADR-0007: this operates on presence + lifecycle fields only — never session
+ * interiors (there are none on the tile to begin with).
+ */
+
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+/** The state-axis options offered in the filter bar. */
+export type NetworkStateFilter = "all" | "online" | "offline";
+
+/** The two-axis filter the Network view holds and threads through the pipeline. */
+export interface NetworkFilterState {
+  /** Liveness filter; `all` passes both online and offline agents. */
+  state: NetworkStateFilter;
+  /**
+   * Capability filter; `null` passes every agent, otherwise keep only agents
+   * that DECLARE this capability id.
+   */
+  capability: string | null;
+}
+
+/** The no-op filter: every agent passes. The view's initial filter state. */
+export const DEFAULT_NETWORK_FILTER: NetworkFilterState = {
+  state: "all",
+  capability: null,
+};
+
+/**
+ * Apply the two-axis filter to the agents snapshot.
+ *
+ * Pure + order-preserving: the survivors keep their snapshot (registry) order, so
+ * the downstream layout stays deterministic. Returns a NEW array — never mutates
+ * the input. An empty input (or a filter that excludes everything) yields `[]`.
+ */
+export function filterAgents(
+  agents: readonly AgentPresenceTile[],
+  filter: NetworkFilterState,
+): AgentPresenceTile[] {
+  return agents.filter((a) => {
+    if (filter.state === "online" && a.state !== "online") return false;
+    if (filter.state === "offline" && a.state !== "offline") return false;
+    if (filter.capability !== null && !a.capabilities.includes(filter.capability)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Collect the distinct capability ids declared across the snapshot, sorted, for
+ * the filter bar's capability dropdown. De-duplicates capabilities declared by
+ * several agents (one option each). An empty / capability-less snapshot yields
+ * `[]` (the dropdown renders only the "any capability" default).
+ *
+ * Sorted for a stable, scannable option list (the registry order is per-agent;
+ * the option list wants a single global order).
+ */
+export function collectCapabilityOptions(
+  agents: readonly AgentPresenceTile[],
+): string[] {
+  const set = new Set<string>();
+  for (const a of agents) {
+    for (const cap of a.capabilities) set.add(cap);
+  }
+  return [...set].sort();
+}
+
+/**
+ * True when the filter narrows anything (i.e. it isn't the default all/any).
+ * Drives the filter bar's "Clear" affordance + an "active filter" badge.
+ */
+export function isFilterActive(filter: NetworkFilterState): boolean {
+  return filter.state !== "all" || filter.capability !== null;
+}

--- a/src/surface/mc/dashboard-v2/lib/network-spotlight.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-spotlight.ts
@@ -1,0 +1,119 @@
+/**
+ * G-1114.D.5 — Network spotlight search (pure match/rank + key helpers).
+ *
+ * The spotlight (Cmd+K / Ctrl+K on the Network tab) lets a principal find an
+ * agent by assistant name / agent id / capability and SELECT its node — reusing
+ * D.4's selection path (set `selectedKey` → opens the detail panel). The
+ * overlay itself reuses the MC-base `CommandPalette` component; this module is
+ * the pure brain behind it:
+ *
+ *   - `searchAgents(agents, query)` → a ranked list of `SpotlightHit`s. Pure, so
+ *     it's unit-tested without a DOM (the D.1-4 pure/wrapper split).
+ *   - `isSpotlightOpenChord(e)` → the Cmd+K / Ctrl+K predicate, testable as a
+ *     plain function so the keyboard wiring stays a thin effect.
+ *
+ * Matching is a case-insensitive substring over {display name, agent id,
+ * capabilities}. Ranking biases toward the most "this is the agent I meant"
+ * signal: an exact id/name match, then a name/id PREFIX match, then any other
+ * substring hit (capability or mid-string). Ties keep snapshot order (stable).
+ *
+ * ADR-0007: a hit carries presence + identity + capabilities only — never any
+ * session interior (the source tile has none anyway).
+ */
+
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+/** One spotlight result row — identity + presence + capabilities, nothing else. */
+export interface SpotlightHit {
+  /** Stable registry key (`{principal}/{stack}/{agent_id}`) — the selection key. */
+  key: string;
+  /** Logical agent id. */
+  agentId: string;
+  /** Assistant name, or the agent id when no name is declared. */
+  displayName: string;
+  /** Liveness, for the row's state dot. */
+  state: "online" | "offline";
+  /** Declared capabilities, for the row's subtitle. */
+  capabilities: readonly string[];
+}
+
+/** Rank buckets (lower = better). Within a bucket, snapshot order is kept. */
+const RANK_EXACT = 0;
+const RANK_PREFIX = 1;
+const RANK_SUBSTRING = 2;
+
+interface RankedHit {
+  hit: SpotlightHit;
+  rank: number;
+  order: number;
+}
+
+function toHit(a: AgentPresenceTile): SpotlightHit {
+  return {
+    key: a.key,
+    agentId: a.agent_id,
+    displayName: a.assistant_name ?? a.agent_id,
+    state: a.state,
+    capabilities: a.capabilities,
+  };
+}
+
+/**
+ * Search the agents snapshot for `query`, returning the matching agents ranked
+ * best-first.
+ *
+ * - **Empty / whitespace query →** every agent, in snapshot order (the spotlight
+ *   opens showing the full list to pick from).
+ * - **Non-empty →** case-insensitive substring over {display name, agent id,
+ *   capabilities}; ranked exact → name/id-prefix → other-substring; ties keep
+ *   snapshot order.
+ *
+ * Pure: no DOM, no mutation of the input.
+ */
+export function searchAgents(
+  agents: readonly AgentPresenceTile[],
+  query: string,
+): SpotlightHit[] {
+  const q = query.trim().toLowerCase();
+  if (q === "") return agents.map(toHit);
+
+  const ranked: RankedHit[] = [];
+  agents.forEach((a, order) => {
+    const hit = toHit(a);
+    const name = hit.displayName.toLowerCase();
+    const id = hit.agentId.toLowerCase();
+    const caps = hit.capabilities.map((c) => c.toLowerCase());
+
+    const inName = name.includes(q);
+    const inId = id.includes(q);
+    const inCap = caps.some((c) => c.includes(q));
+    if (!inName && !inId && !inCap) return;
+
+    let rank = RANK_SUBSTRING;
+    if (name === q || id === q) {
+      rank = RANK_EXACT;
+    } else if (name.startsWith(q) || id.startsWith(q)) {
+      rank = RANK_PREFIX;
+    }
+    ranked.push({ hit, rank, order });
+  });
+
+  ranked.sort((x, y) => (x.rank !== y.rank ? x.rank - y.rank : x.order - y.order));
+  return ranked.map((r) => r.hit);
+}
+
+/** The minimal keyboard-event shape `isSpotlightOpenChord` needs (testable). */
+export interface ChordEvent {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  key: string;
+}
+
+/**
+ * True when the event is the spotlight-open chord: Cmd+K (mac) or Ctrl+K
+ * (everywhere). Case-insensitive on the key. Extracted as a pure predicate so
+ * the network-view keyboard effect is a one-line delegation.
+ */
+export function isSpotlightOpenChord(e: ChordEvent): boolean {
+  return (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k";
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -416,6 +416,48 @@ html, body {
 }
 .network-view .react-flow { background: var(--bg); }
 
+/* G-1114.D.5 — filter bar (state toggle + capability dropdown + spotlight). */
+.network-filter-bar {
+  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+  margin: 0 0 10px 0; padding: 8px 10px;
+  border: 1px solid var(--line); border-radius: 8px; background: var(--panel);
+}
+.network-filter-group { display: flex; align-items: center; gap: 6px; }
+.network-filter-label {
+  font-size: 11px; color: var(--fg-faint);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.network-filter-state-btn {
+  appearance: none; cursor: pointer; font: inherit; font-size: 12px;
+  padding: 3px 9px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--fg-faint);
+}
+.network-filter-state-btn:hover { color: var(--fg); }
+.network-filter-state-btn.on {
+  background: var(--accent-soft); color: var(--fg);
+  border-color: color-mix(in oklch, var(--accent) 50%, transparent);
+}
+.network-filter-select {
+  appearance: auto; font: inherit; font-size: 12px;
+  padding: 3px 6px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--fg);
+}
+.network-filter-clear {
+  appearance: none; cursor: pointer; font: inherit; font-size: 12px;
+  padding: 3px 9px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--fg-faint);
+}
+.network-filter-clear:hover { color: var(--fg); }
+.network-filter-spotlight {
+  margin-left: auto;
+  appearance: none; cursor: pointer; font: inherit; font-size: 12px;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 9px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--bg); color: var(--fg);
+}
+.network-filter-spotlight:hover { background: var(--accent-soft); }
+.network-filter-kbd { display: inline-flex; gap: 2px; margin-left: 2px; }
+
 /* Custom nodes — reuse the agents-panel chrome language so the graph + panel
    read identically. */
 .network-node {


### PR DESCRIPTION
Final Phase D slice of umbrella #355 (per `docs/plan-agent-network-topology.md` §4.4 D.5). Completes the stack-local Network view with filters + a Cmd+K spotlight find-agent search.

## What

**Filters (pure):**
- `lib/network-graph-filter.ts` — `filterAgents(agents, filter)` AND-combines a **state** axis (`all` / `online` / `offline`) and a **capability** axis (`null` = any, else keep agents declaring it). Pipeline: `agents → filterAgents → buildNetworkGraph → ELK → canvas`. Order-preserving, non-mutating. Plus `collectCapabilityOptions` (distinct, sorted) + `isFilterActive`.
- `components/network-filter-bar.tsx` — state toggle + capability dropdown + Clear (shown only when a filter is active) + a Find-agent / ⌘K trigger. Pure, main bundle, no xyflow.
- The filter narrows the **live snapshot** (re-derived on each presence refetch). When the filter empties the set, the view shows a "No agents match the current filters" state with the bar still above so the principal can clear it.

**Cmd+K spotlight (reused command-palette — not bespoke):**
- **Reused** the MC-base `CommandPalette` (the dashboard's existing ⌘K overlay: keyboard nav, substring filter, Esc-close) via `components/network-spotlight.tsx`. `buildAgentCommands` maps each agent → a `Command` whose label encodes name + id + capabilities (so the palette's substring filter matches all three search dimensions) and whose `run()` selects the agent's node (D.4's `selectedKey` path → detail panel opens) and closes.
- `lib/network-spotlight.ts` (pure) — `searchAgents` match/rank (exact → name/id-prefix → substring; ties keep snapshot order; matches name/id/capability) + `isSpotlightOpenChord` (Cmd+K / Ctrl+K predicate). Unit-tested.

**Keyboard wiring (network-view.tsx):**
- Cmd+K / Ctrl+K listener registered on the **capture phase** so it pre-empts the app-level global ⌘K palette (a bubble-phase listener) and `stopPropagation()`s it — on the Network tab, ⌘K opens the **agent spotlight**, not the generic command palette.
- **Esc precedence (spotlight-then-panel):** if the spotlight is open, Esc closes it first and the D.4 detail panel stays; only when the spotlight is closed does Esc dismiss the panel.

## Bundle / chunk split

Filters + spotlight live in the **entry bundle + pure libs** — they do **not** pull xyflow/elk into the main chunk. Verified post-`build:dashboard`: the entry bundle (`index-*.js`, 1.23 MB) contains no `xyflow`/`elkjs`; the engine stays in the lazy `network-canvas-*.js` chunk (3.50 MB). **Chunk split preserved.**

## Test plan

`bunx tsc --noEmit` clean · `bun run lint` 0 errors · full `bun test` 5710 pass / 0 fail · `check-carveouts.sh` PASS · `build:dashboard` builds + keeps the network-canvas chunk split.

New tests:
- `network-graph-filter.test.ts` — state / capability / combined / empty-result / options / isFilterActive / no-mutation.
- `network-spotlight.test.ts` — match by name/id/capability, ranking, no-match, hit shape (ADR-0007 allowlist), Cmd+K chord helper.
- `network-filter-bar.test.tsx` — state toggle aria-pressed, capability dropdown + selection, Clear visibility, spotlight trigger.
- `network-spotlight-overlay.test.tsx` — `buildAgentCommands` label/group/run encoding + the overlay render (open/closed/empty) + selection.
- `network-view.test.tsx` — extended for the D.5 filter bar in list mode.

Pure/wrapper pattern (xyflow stays untested-runtime, validated by the build gate + manual dashboard rebuild).

refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)