### PR TITLE
feat(mc): G-1114.E.1+E.2+E.5 — federated agent-presence (opt-in) + trust-verified subscriber

### DIFF
--- a/src/bus/agent-network/__tests__/federated-subscriber.test.ts
+++ b/src/bus/agent-network/__tests__/federated-subscriber.test.ts
@@ -1,0 +1,441 @@
+/**
+ * G-1114.E.2 + E.5 — trust-verified federated agent-presence subscriber tests.
+ *
+ * The SECURITY-FOCUSED slice. Coverage axes:
+ *   1. Opt-in — no `policy.federated.networks[]` ⇒ subscriber INERT (binds
+ *      nothing, folds nothing).
+ *   2. Fold — a foreign agent.online from an ACCEPT-LISTED peer ⇒ appears in the
+ *      registry, tagged with foreign provenance; local records unaffected.
+ *   3. TRUST gate 1 (accept-list) — a foreign envelope from a peer NOT in any
+ *      network's `peers[]` is DROPPED (not folded). (load-bearing)
+ *   4. TRUST gate 2 (chain) — a foreign envelope that FAILS signed_by
+ *      verification is DROPPED. (load-bearing)
+ *   5. Provenance — foreign records distinguishable from local (the origin field).
+ *   6. Subject filter — a `local.*` presence envelope is ignored by the federated
+ *      subscriber (B.3 owns local).
+ *   7. Teardown — stop() removes foreign agents cleanly; local survive.
+ */
+
+import { describe, expect, test, mock } from "bun:test";
+import {
+  startFederatedAgentPresenceSubscriber,
+  federatedAgentPresenceSubject,
+} from "../federated-subscriber";
+import { AgentPresenceRegistry, isForeignOrigin } from "../registry";
+import {
+  createAgentOnlineEvent,
+  type AgentPresenceSource,
+} from "../builders";
+import type { Envelope, SignedBy } from "../../myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../../myelin/runtime";
+import type { MyelinSubscriber } from "../../myelin/subscriber";
+import type { SystemEventSource } from "../../system-events";
+import type {
+  PolicyFederated,
+  PolicyFederatedNetwork,
+} from "../../../common/types/cortex-config";
+import { TrustResolver } from "../../../common/agents/trust-resolver";
+import { AgentRegistry } from "../../../common/agents/registry";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SYSTEM_SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+
+/** A foreign peer's presence source — `joel/research`. */
+const PEER_SOURCE: AgentPresenceSource = {
+  principal: "joel",
+  stack: "research",
+  instance: "local",
+};
+const PEER_IDENTITY = {
+  nkey_public_key: "UPEER1234567890",
+  agent_id: "sage",
+  assistant_name: "Sage",
+};
+const PEER_SCOPE = { principal: "joel", stack: "research" };
+
+/** Build a foreign `agent.online` (classification federated). */
+function foreignOnline(opts: { signedBy?: SignedBy[] } = {}): Envelope {
+  const env = createAgentOnlineEvent({
+    source: PEER_SOURCE,
+    identity: PEER_IDENTITY,
+    scope: PEER_SCOPE,
+    capabilities: ["code-review.typescript"],
+    startedAt: new Date("2026-06-11T09:00:00.000Z"),
+    classification: "federated",
+  });
+  if (opts.signedBy !== undefined) {
+    return { ...env, signed_by: opts.signedBy };
+  }
+  return env;
+}
+
+/** A network that accept-lists joel as a peer + accepts agent presence. */
+function networkWithJoel(): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "primary",
+    peers: [{ principal_id: "joel", stack_id: "joel/research" }],
+    accept_subjects: ["federated.andreas.meta-factory.agent.>", "federated.joel.research.agent.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+/** A network that does NOT list joel (no peer) — joel is unknown/untrusted. */
+function networkWithoutJoel(): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "primary",
+    peers: [],
+    accept_subjects: ["federated.joel.research.agent.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+function federatedPolicy(networks: PolicyFederatedNetwork[]): PolicyFederated {
+  return { networks };
+}
+
+// ---------------------------------------------------------------------------
+// Fake runtime
+// ---------------------------------------------------------------------------
+
+interface FakeRuntime extends MyelinRuntime {
+  fire(envelope: Envelope, subject: string, sourceLink?: string): void;
+  subscribedPatterns: string[];
+  published: Envelope[];
+}
+
+function makeFakeRuntime(opts: { canSubscribe?: boolean } = {}): FakeRuntime {
+  const canSubscribe = opts.canSubscribe ?? true;
+  const handlers = new Set<EnvelopeHandler>();
+  const subscribedPatterns: string[] = [];
+  const published: Envelope[] = [];
+  const subscriberStop = mock(() => Promise.resolve());
+  const fakeSubscriber = {
+    stop: subscriberStop,
+  } as unknown as MyelinSubscriber;
+  return {
+    enabled: true,
+    subscribedPatterns,
+    published,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: (env: Envelope) => {
+      published.push(env);
+      return Promise.resolve();
+    },
+    stop: () => Promise.resolve(),
+    subscribe: (pattern: string) => {
+      subscribedPatterns.push(pattern);
+      return Promise.resolve(canSubscribe ? fakeSubscriber : null);
+    },
+    fire(envelope, subject, sourceLink) {
+      for (const h of handlers) h(envelope, subject, sourceLink);
+    },
+  };
+}
+
+/** Empty trust resolver — every unknown signer fails structurally. */
+function emptyTrustResolver(): TrustResolver {
+  return new TrustResolver(AgentRegistry.fromAgents([]));
+}
+
+/** Let the microtask queue flush (chain verify resolves on a promise). */
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+const FED_SUBJECT = "federated.joel.research.agent.online";
+
+// ---------------------------------------------------------------------------
+// 1. Opt-in
+// ---------------------------------------------------------------------------
+
+describe("E.1 — federation opt-in", () => {
+  test("no networks ⇒ subscriber INERT (binds nothing, folds nothing)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: undefined,
+      source: SYSTEM_SOURCE,
+    });
+    expect(runtime.subscribedPatterns).toEqual([]);
+    // Even if a federated envelope were fired, no handler is registered to fold.
+    runtime.fire(foreignOnline(), FED_SUBJECT);
+    await flush();
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("empty networks[] ⇒ also inert", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([]),
+      source: SYSTEM_SOURCE,
+    });
+    expect(runtime.subscribedPatterns).toEqual([]);
+    await handle.stop();
+  });
+
+  test("networks present ⇒ subscribes the federated presence firehose", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    expect(runtime.subscribedPatterns).toEqual([federatedAgentPresenceSubject()]);
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Fold (accept-listed peer, no chain verifier) + 5. Provenance
+// ---------------------------------------------------------------------------
+
+describe("E.2 — fold accept-listed foreign presence", () => {
+  test("accept-listed peer's agent.online ⇒ folded, tagged foreign provenance", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      // No trustResolver ⇒ chain check skipped; the accept-list gate alone
+      // bounds admissible peers (the production path adds the chain check).
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    const agents = registry.getAgents();
+    expect(agents.length).toBe(1);
+    expect(agents[0]?.agentId).toBe("sage");
+    expect(agents[0]?.principal).toBe("joel");
+    expect(agents[0]?.stack).toBe("research");
+    expect(agents[0]?.origin).toEqual({
+      kind: "foreign",
+      principal: "joel",
+      stack: "research",
+    });
+    expect(isForeignOrigin(agents[0]!.origin)).toBe(true);
+    await handle.stop();
+  });
+
+  test("local records are unaffected by foreign folds (distinguishable)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    // Seed a LOCAL record directly (B.3 path).
+    registry.apply(
+      createAgentOnlineEvent({
+        source: { principal: "andreas", stack: "meta-factory", instance: "local" },
+        identity: { nkey_public_key: "ULOCAL", agent_id: "luna", assistant_name: "Luna" },
+        scope: { principal: "andreas", stack: "meta-factory" },
+        capabilities: [],
+        startedAt: new Date("2026-06-11T08:00:00.000Z"),
+      }),
+    );
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    const local = registry.getAgents().find((a) => a.agentId === "luna");
+    const foreign = registry.getAgents().find((a) => a.agentId === "sage");
+    expect(local?.origin).toBe("local");
+    expect(foreign?.origin).toMatchObject({ kind: "foreign" });
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. TRUST gate 1 — accept-list (load-bearing)
+// ---------------------------------------------------------------------------
+
+describe("E.5 — TRUST: federation accept-list gate", () => {
+  test("peer NOT in any network's peers[] ⇒ DROPPED (not folded)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    // joel is in NO network's peers[] ⇒ peer_not_in_accept_list ⇒ dropped.
+    expect(registry.getAgents().length).toBe(0);
+    // The drop is observable as a system.access.denied audit envelope.
+    const denied = runtime.published.find((e) =>
+      e.type.includes("access") && e.type.includes("denied"),
+    );
+    expect(denied).toBeDefined();
+    await handle.stop();
+  });
+
+  test("denied subject ⇒ DROPPED even though peer is accept-listed", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const net = networkWithJoel();
+    net.deny_subjects = ["federated.joel.research.agent.>"];
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([net]),
+      source: SYSTEM_SOURCE,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. TRUST gate 2 — chain verification (load-bearing)
+// ---------------------------------------------------------------------------
+
+describe("E.5 — TRUST: signed_by chain verification", () => {
+  test("foreign envelope with UNRESOLVABLE signer ⇒ DROPPED", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      // Chain verifier wired with an EMPTY trust registry — any non-own signer
+      // fails `unknown_agent`. (Structural failure; no crypto needed.)
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: false,
+    });
+    // A signed-but-untrusted foreign envelope: passes the accept-list gate,
+    // then FAILS chain verification ⇒ dropped.
+    const signed = foreignOnline({
+      signedBy: [
+        { method: "ed25519", identity: "did:mf:stranger", signature: "x", timestamp: "t" } as unknown as SignedBy,
+      ],
+    });
+    runtime.fire(signed, FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("foreign envelope with EMPTY chain ⇒ DROPPED (rejectEmpty default)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: false,
+      // rejectEmpty defaults to true for foreign presence.
+    });
+    // No signed_by[] ⇒ empty chain ⇒ rejected.
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Subject filter
+// ---------------------------------------------------------------------------
+
+describe("E.2 — subject filter", () => {
+  test("a local.* presence envelope is IGNORED (B.3 owns local)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    // Fire a LOCAL-subject presence envelope through the federated subscriber.
+    runtime.fire(foreignOnline(), "local.joel.research.agent.online", "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Teardown — disabling federation removes foreign agents cleanly
+// ---------------------------------------------------------------------------
+
+describe("E.2 — teardown removes foreign agents cleanly", () => {
+  test("stop() drops foreign records; local survive", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    // Local record.
+    registry.apply(
+      createAgentOnlineEvent({
+        source: { principal: "andreas", stack: "meta-factory", instance: "local" },
+        identity: { nkey_public_key: "ULOCAL", agent_id: "luna", assistant_name: "Luna" },
+        scope: { principal: "andreas", stack: "meta-factory" },
+        capabilities: [],
+        startedAt: new Date("2026-06-11T08:00:00.000Z"),
+      }),
+    );
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(2);
+
+    await handle.stop();
+    const remaining = registry.getAgents();
+    expect(remaining.length).toBe(1);
+    expect(remaining[0]?.agentId).toBe("luna");
+    expect(remaining[0]?.origin).toBe("local");
+  });
+
+  test("stop() is idempotent", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    await handle.stop();
+    await handle.stop();
+  });
+});

--- a/src/bus/agent-network/__tests__/federated-subscriber.test.ts
+++ b/src/bus/agent-network/__tests__/federated-subscriber.test.ts
@@ -76,6 +76,31 @@ function foreignOnline(opts: { signedBy?: SignedBy[] } = {}): Envelope {
   return env;
 }
 
+/**
+ * BLOCKER repro — a SPOOF envelope: the wire `source` is the verified peer
+ * `joel.research.local`, but the PAYLOAD scope + identity claim a DIFFERENT,
+ * LOCAL-looking agent (`andreas/meta-factory/<agentId>`). Pre-fix this would
+ * paint a fake local-looking record AND overwrite the real local one via the
+ * shared map key. Post-fix the registry must use the SOURCE identity (and the
+ * scope≠source mismatch is a spoof ⇒ dropped).
+ */
+function spoofOnline(claimedAgentId: string): Envelope {
+  return createAgentOnlineEvent({
+    // VERIFIED source — the accept-listed peer.
+    source: PEER_SOURCE,
+    // Attacker-controlled payload claims a LOCAL agent identity.
+    identity: {
+      nkey_public_key: "USPOOF-LOCAL-KEY",
+      agent_id: claimedAgentId,
+      assistant_name: "Luna",
+    },
+    scope: { principal: "andreas", stack: "meta-factory" },
+    capabilities: ["evil.capability"],
+    startedAt: new Date("2026-06-11T09:00:00.000Z"),
+    classification: "federated",
+  });
+}
+
 /** A network that accept-lists joel as a peer + accepts agent presence. */
 function networkWithJoel(): PolicyFederatedNetwork {
   return {
@@ -347,7 +372,7 @@ describe("E.5 — TRUST: signed_by chain verification", () => {
     await handle.stop();
   });
 
-  test("foreign envelope with EMPTY chain ⇒ DROPPED (rejectEmpty default)", async () => {
+  test("ENFORCE posture (rejectEmpty:true): EMPTY-chain foreign ⇒ DROPPED", async () => {
     const runtime = makeFakeRuntime();
     const registry = new AgentPresenceRegistry();
     const handle = await startFederatedAgentPresenceSubscriber({
@@ -359,11 +384,67 @@ describe("E.5 — TRUST: signed_by chain verification", () => {
       receivingAgentId: "luna",
       principalId: "andreas",
       cryptoVerify: false,
-      // rejectEmpty defaults to true for foreign presence.
+      // signing=enforce → rejectEmpty:true → an unsigned foreign envelope is
+      // rejected (must carry a verifiable chain).
+      rejectEmpty: true,
     });
-    // No signed_by[] ⇒ empty chain ⇒ rejected.
+    // No signed_by[] ⇒ empty chain ⇒ rejected under enforce.
     runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
     await flush();
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4b. POSTURE — signing=off folds accept-list-only-unsigned (matches #484)
+// ---------------------------------------------------------------------------
+
+describe("E.5 — POSTURE: signing=off (rejectEmpty:false, #484-consistent)", () => {
+  test("off-posture: accept-listed EMPTY-chain foreign ⇒ FOLDED (accept-list-only trust)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: false,
+      // signing=off → rejectEmpty:false → accept-list-ONLY trust (the SAME
+      // posture the #484 dispatch-listener uses for federated inbound). Safe
+      // because identity is source-bound (the peer can only announce its own
+      // agents).
+      rejectEmpty: false,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    // Accept-listed + unsigned ⇒ folded under off-posture, tagged foreign.
+    const agents = registry.getAgents();
+    expect(agents.length).toBe(1);
+    expect(agents[0]?.origin).toEqual({
+      kind: "foreign",
+      principal: "joel",
+      stack: "research",
+    });
+    await handle.stop();
+  });
+
+  test("off-posture STILL drops a peer NOT on the accept-list (gate is posture-independent)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      rejectEmpty: false,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    // Even under off-posture, a non-accept-listed peer is gate-dropped.
     expect(registry.getAgents().length).toBe(0);
     await handle.stop();
   });
@@ -436,6 +517,97 @@ describe("E.2 — teardown removes foreign agents cleanly", () => {
       source: SYSTEM_SOURCE,
     });
     await handle.stop();
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. BLOCKER — provenance/identity spoofing (PR #914 review)
+// ---------------------------------------------------------------------------
+
+describe("E.5 — BLOCKER: source-bound identity (no provenance spoof)", () => {
+  test("scope≠source spoof ⇒ DROPPED (not folded under the claimed identity)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      // off-posture (accept-list-only) so the spoof can't hide behind a chain
+      // failure — the scope≠source check is what must catch it.
+      rejectEmpty: false,
+    });
+    // joel (accept-listed, verified source) signs an envelope whose payload
+    // claims andreas/meta-factory/luna.
+    runtime.fire(spoofOnline("luna"), FED_SUBJECT, "primary");
+    await flush();
+    // The spoof must NOT produce a record claiming the local identity.
+    const fake = registry
+      .getAgents()
+      .find((a) => a.principal === "andreas" && a.stack === "meta-factory");
+    expect(fake).toBeUndefined();
+    // Nothing folded at all (scope≠source ⇒ dropped).
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("spoof CANNOT overwrite / delete a real local record of the claimed name", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    // Seed the REAL local luna.
+    registry.apply(
+      createAgentOnlineEvent({
+        source: { principal: "andreas", stack: "meta-factory", instance: "local" },
+        identity: { nkey_public_key: "UREAL-LOCAL-LUNA", agent_id: "luna", assistant_name: "Luna" },
+        scope: { principal: "andreas", stack: "meta-factory" },
+        capabilities: ["code-review.typescript"],
+        startedAt: new Date("2026-06-11T08:00:00.000Z"),
+      }),
+    );
+    const realKey = "andreas/meta-factory/luna";
+    expect(registry.getAgent(realKey)?.nkeyPublicKey).toBe("UREAL-LOCAL-LUNA");
+
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      rejectEmpty: false,
+    });
+    // joel signs a spoof claiming andreas/meta-factory/luna.
+    runtime.fire(spoofOnline("luna"), FED_SUBJECT, "primary");
+    await flush();
+
+    // The real local record is UNTOUCHED — not overwritten by the spoof's
+    // nkey/capabilities, and still origin "local".
+    const real = registry.getAgent(realKey);
+    expect(real).toBeDefined();
+    expect(real?.nkeyPublicKey).toBe("UREAL-LOCAL-LUNA");
+    expect(real?.origin).toBe("local");
+    expect(real?.capabilities).toEqual(["code-review.typescript"]);
+
+    // And teardown of the foreign subscriber must NOT delete the real local one.
+    await handle.stop();
+    expect(registry.getAgent(realKey)?.nkeyPublicKey).toBe("UREAL-LOCAL-LUNA");
+  });
+
+  test("a peer announcing ITS OWN agent (scope==source) is folded normally", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      rejectEmpty: false,
+    });
+    // scope == source (joel/research) — legitimate self-announce.
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    const rec = registry.getAgent("joel/research/sage");
+    expect(rec).toBeDefined();
+    expect(rec?.origin).toEqual({ kind: "foreign", principal: "joel", stack: "research" });
     await handle.stop();
   });
 });

--- a/src/bus/agent-network/__tests__/registry.test.ts
+++ b/src/bus/agent-network/__tests__/registry.test.ts
@@ -589,3 +589,56 @@ describe("AgentPresenceRegistry liveness reaper (C.3)", () => {
     expect(byKey.get("echo")).toBe("online");
   });
 });
+
+// --- G-1114.E.2 provenance (local vs foreign origin) -------------------------
+
+describe("AgentPresenceRegistry provenance (E.2)", () => {
+  test("apply() tags records as local origin by default", () => {
+    const reg = new AgentPresenceRegistry();
+    reg.apply(online());
+    expect(reg.getAgents()[0]?.origin).toBe("local");
+  });
+
+  test("applyForeign() tags records with {principal}/{stack} foreign origin", () => {
+    const reg = new AgentPresenceRegistry();
+    const env = createAgentOnlineEvent({
+      source: { principal: "joel", stack: "research", instance: "local" },
+      identity: { nkey_public_key: "UPEER", agent_id: "sage", assistant_name: "Sage" },
+      scope: { principal: "joel", stack: "research" },
+      capabilities: ["research"],
+      startedAt: new Date("2026-06-11T09:00:00.000Z"),
+      classification: "federated",
+    });
+    reg.applyForeign(env, { principal: "joel", stack: "research" });
+    const rec = reg.getAgents()[0];
+    expect(rec?.origin).toEqual({ kind: "foreign", principal: "joel", stack: "research" });
+    expect(rec?.agentId).toBe("sage");
+  });
+
+  test("removeForeign() drops foreign records, keeps local, fires onChange", () => {
+    const reg = new AgentPresenceRegistry();
+    reg.apply(online()); // local luna
+    const env = createAgentOnlineEvent({
+      source: { principal: "joel", stack: "research", instance: "local" },
+      identity: { nkey_public_key: "UPEER", agent_id: "sage", assistant_name: "Sage" },
+      scope: { principal: "joel", stack: "research" },
+      capabilities: [],
+      startedAt: new Date("2026-06-11T09:00:00.000Z"),
+      classification: "federated",
+    });
+    reg.applyForeign(env, { principal: "joel", stack: "research" });
+    expect(reg.getAgents().length).toBe(2);
+
+    const changes: string[] = [];
+    reg.onChange((key) => changes.push(key));
+    const removed = reg.removeForeign();
+
+    expect(removed).toEqual(["joel/research/sage"]);
+    const remaining = reg.getAgents();
+    expect(remaining.length).toBe(1);
+    expect(remaining[0]?.agentId).toBe("luna");
+    expect(remaining[0]?.origin).toBe("local");
+    // onChange fired for the foreign removal (terminal snapshot).
+    expect(changes).toContain("joel/research/sage");
+  });
+});

--- a/src/bus/agent-network/federated-subscriber.ts
+++ b/src/bus/agent-network/federated-subscriber.ts
@@ -46,10 +46,36 @@
  *      to verify (forged bytes, unresolved peer pubkey, stale timestamp) is
  *      DROPPED — never folded.
  *
- * Only an envelope that passes BOTH is folded via {@link
- * AgentPresenceRegistry.applyForeign}, tagged with the peer's `{principal}/{stack}`
- * from the PAYLOAD scope. **This is the security invariant: only accept-listed +
- * chain-verified foreign presence is shown.**
+ * ## Posture (matches the #484 dispatch-listener EXACTLY)
+ *
+ * Empty-chain handling is POSTURE-GATED via `rejectEmpty`, identical to how the
+ * #484 dispatch-listener treats federated inbound (`rejectEmpty:
+ * signingKnobs.rejectEmpty`):
+ *   - `signing: off`        → accept-list-ONLY trust: an unsigned foreign
+ *     envelope that passes the accept-list gate folds. Safe ONLY because of the
+ *     source-bound identity below.
+ *   - `signing: permissive` → accept-list + best-effort crypto-verify of any
+ *     present chain.
+ *   - `signing: enforce`    → require a verifiable `signed_by[]` chain (empty ⇒
+ *     dropped) + registry peer-pubkey resolution.
+ * A `signing: off` stack federates DISPATCH the same way, so presence is
+ * consistent — not laxer.
+ *
+ * ## SOURCE-BOUND IDENTITY (PR #914 review BLOCKER fix)
+ *
+ * The folded record's IDENTITY — principal, stack, and the registry MAP KEY — is
+ * derived from the CHAIN-VERIFIED `source`, NEVER from the attacker-controlled
+ * `payload.scope`. {@link foldForeign} passes the source-derived
+ * `{principal}/{stack}` to {@link AgentPresenceRegistry.applyForeign} as the
+ * authoritative `verifiedScope`; the registry DROPS the envelope if
+ * `payload.scope` disagrees (a spoof). So an accept-listed peer can announce ONLY
+ * agents under its OWN verified `{principal}/{stack}` — it can NOT paint a
+ * local-looking record, and a foreign record can NEVER collide with / overwrite a
+ * local one. This is what makes the `signing: off` accept-list-only posture safe.
+ *
+ * Only an envelope that passes BOTH gates is folded. **Security invariant: only
+ * accept-listed (and, under enforce, chain-verified) foreign presence is shown,
+ * always under its source-bound identity.**
  *
  * ## Sovereignty (ADR-0005 / ADR-0007)
  *
@@ -142,12 +168,27 @@ export interface StartFederatedAgentPresenceSubscriberOptions {
   /** Whether the chain verifier runs ed25519 crypto verification. Default `true`. */
   cryptoVerify?: boolean;
   /**
-   * Whether an empty `signed_by[]` chain is REJECTED. For FOREIGN presence the
-   * default is `true`: an unsigned cross-principal envelope has no
-   * cryptographic attribution and must not be trusted into the view. (Contrast
-   * the dispatch-listener default `false`, which exists for LOCAL
-   * adapter-originated dispatches that legitimately arrive unsigned — foreign
-   * presence has no such legitimate-unsigned path.)
+   * Whether an empty `signed_by[]` chain is REJECTED — POSTURE-GATED, matching
+   * the #484 dispatch-listener for federated inbound EXACTLY (do not invent a
+   * different posture for presence).
+   *
+   * `cortex.ts` passes `signingKnobs.rejectEmpty` — the SAME value the
+   * dispatch-listener / bus-dispatch-listener receive:
+   *   - `signing: off`         → `false` → **accept-list-only trust**: an
+   *     unsigned foreign envelope that PASSES the federation accept-list gate is
+   *     folded. This is SAFE only because the record's identity is SOURCE-BOUND
+   *     (PR #914 BLOCKER fix): an accept-listed peer can announce ONLY agents
+   *     under its OWN `{principal}/{stack}` — never impersonate a local agent —
+   *     so accept-list membership IS the trust boundary under `off`. (A
+   *     `signing: off` stack federates DISPATCH the same way, so presence is
+   *     consistent, not laxer.)
+   *   - `signing: permissive`  → `false` → folds when accept-listed; ALSO crypto-
+   *     verifies any present chain (cheap observability; doesn't reject on its own).
+   *   - `signing: enforce`     → `true`  → an empty chain is REJECTED; foreign
+   *     presence MUST carry a verifiable `signed_by[]` chain.
+   *
+   * Default `false` here (the #484-consistent off-posture) — but production
+   * ALWAYS passes the posture-derived value explicitly.
    */
   rejectEmpty?: boolean;
   /** Receiving stack's signing DID (own-stack short-circuit in the verifier). */
@@ -191,9 +232,12 @@ export async function startFederatedAgentPresenceSubscriber(
     resolveFederatedPeer,
   } = opts;
   const cryptoVerify = opts.cryptoVerify ?? true;
-  // Foreign presence has no legitimate-unsigned path — reject empty chains by
-  // default (the inverse of the dispatch-listener's adapter-friendly default).
-  const rejectEmpty = opts.rejectEmpty ?? true;
+  // POSTURE-GATED, matching the #484 dispatch-listener EXACTLY: production passes
+  // `signingKnobs.rejectEmpty` (off/permissive → false ⇒ accept-list-only trust;
+  // enforce → true ⇒ require a verifiable chain). Default `false` mirrors the
+  // off-posture. Safe under `off` ONLY because identity is source-bound (the
+  // BLOCKER fix): an accept-listed peer can announce only its OWN agents.
+  const rejectEmpty = opts.rejectEmpty ?? false;
 
   // E.1 — OPT-IN gate. No networks ⇒ federation is OFF for this stack: the
   // subscriber binds NOTHING and folds NOTHING. This is the resolved opt-in
@@ -334,12 +378,14 @@ export async function startFederatedAgentPresenceSubscriber(
  * signing identity). `envelope.source` is `{principal}.{stack}.{instance}[...]`,
  * so segment[0] is the bare principal and segment[1] the bare stack slug.
  *
- * Using the SOURCE (not the payload scope) for provenance means a peer can't
- * claim a DIFFERENT origin than the one it signed as: the chain verification
- * above bound `source` to a verified pubkey, so the provenance is as trustworthy
- * as the signature. (The payload `scope` SHOULD equal the source for a
- * well-formed peer; deriving from the authenticated source is the safe choice if
- * they ever diverge.)
+ * The derived `{principal}/{stack}` is the CHAIN-VERIFIED identity (the source
+ * was bound to a verified pubkey by the chain check above). It is passed to
+ * {@link AgentPresenceRegistry.applyForeign} as the `verifiedScope` — the
+ * AUTHORITATIVE identity for the record's key + principal + stack. The registry
+ * cross-checks the envelope's `payload.scope` against it and DROPS the envelope
+ * if they disagree (a spoof attempt), so a peer can paint records ONLY under its
+ * OWN verified identity and can never collide with / overwrite a local record
+ * (PR #914 review BLOCKER fix).
  *
  * A source with fewer than two segments (defensive — the schema forbids it) is
  * dropped rather than folded as an originless record.

--- a/src/bus/agent-network/federated-subscriber.ts
+++ b/src/bus/agent-network/federated-subscriber.ts
@@ -1,0 +1,373 @@
+/**
+ * G-1114.E.2 + E.5 — TRUST-VERIFIED federated agent-presence subscriber.
+ *
+ * The federation half of the agent-presence registry. Where the B.3
+ * {@link startAgentPresenceRegistry} folds the stack's OWN
+ * `local.{principal}.{stack}.agent.>` subtree, THIS module folds TRUST-VERIFIED
+ * FOREIGN presence from peers' `federated.{principal}.{stack}.agent.>` subtree
+ * into the SAME registry, tagging each foreign record with its `{principal}/{stack}`
+ * provenance (`origin: { kind: "foreign", … }`).
+ *
+ * ## THE DESIGN QUESTION (resolved against the existing gate)
+ *
+ * **Does inbound `federated.*.agent.*` ALREADY pass through the surface-router's
+ * `evaluateFederationGate` + signed_by chain verification before reaching a
+ * consumer?**
+ *
+ * **NO — for THIS consumer.** The presence registry is an **Option-D direct
+ * consumer**: it subscribes via `runtime.subscribe(pattern)` + `runtime.onEnvelope`
+ * (see `startAgentPresenceRegistry`), NOT through the surface-router. The
+ * surface-router's `evaluateFederationGate` runs ONLY for envelopes the router
+ * fans to registered `SurfaceAdapter`s via `router.dispatch`. The runtime's
+ * `onEnvelope` fan-out delivers EVERY inbound envelope to EVERY registered
+ * handler RAW — pre-gate, pre-verify. So a registry that simply widened its
+ * subscription to `federated.*.agent.>` would fold UNVERIFIED, UNGATED foreign
+ * presence: a trust hole (any peer — accept-listed or not, signed or not — would
+ * appear in the Network view).
+ *
+ * This is the EXACT situation the **runner dispatch-listener** faced at
+ * cortex#484 ("Option D — executor, not renderer"): once it stopped registering
+ * as a SurfaceAdapter and consumed envelopes directly off the runtime, the
+ * surface-router's federation gate no longer covered it, so it grew its OWN
+ * inline gate (`evaluateFederationGate`) + its own chain verification
+ * (`verifySignedByChain` + `resolveFederatedPeer`). This module MIRRORS that
+ * established trust path — it does NOT invent a parallel mechanism:
+ *
+ *   1. **Federation accept-list gate** — {@link evaluateFederationGate} on the
+ *      wire subject + envelope, against the principal's
+ *      `policy.federated.networks[]` (accept_subjects / deny_subjects / max_hop +
+ *      the F-3d leaf anti-spoof cross-check). A non-allowlisted peer, a denied
+ *      subject, an over-budget hop chain, or a cross-network-spoofed leaf is
+ *      DROPPED before any fold. A `system.access.denied` audit envelope is
+ *      emitted (`emitFederationDenied`) so the drop is observable.
+ *   2. **`signed_by[]` chain verification** — {@link verifySignedByChain} with
+ *      the same `resolveFederatedPeer` seam the dispatch-listener uses (wired
+ *      ONLY under `signing === "enforce"`). A foreign envelope whose chain fails
+ *      to verify (forged bytes, unresolved peer pubkey, stale timestamp) is
+ *      DROPPED — never folded.
+ *
+ * Only an envelope that passes BOTH is folded via {@link
+ * AgentPresenceRegistry.applyForeign}, tagged with the peer's `{principal}/{stack}`
+ * from the PAYLOAD scope. **This is the security invariant: only accept-listed +
+ * chain-verified foreign presence is shown.**
+ *
+ * ## Sovereignty (ADR-0005 / ADR-0007)
+ *
+ * Foreign presence carries presence + lifecycle metadata ONLY — identity,
+ * capabilities, liveness state. The `agent.*` payload schema (the SAME shape a
+ * local envelope uses) has NO interior fields (tool calls, prompts, diffs), so
+ * interior leakage is structurally impossible: the registry stores exactly the
+ * presence descriptor and nothing more. Peers never send interiors; the registry
+ * never stores or exposes them.
+ */
+
+import type { Envelope } from "../myelin/envelope-validator";
+import { getSignedByChain } from "../myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../myelin/runtime";
+import type { MyelinSubscriber } from "../myelin/subscriber";
+import type { TrustResolver } from "../../common/agents/trust-resolver";
+import type { FederatedPeerResolution } from "../../common/registry";
+import type {
+  PolicyFederated,
+  PolicyFederatedNetwork,
+} from "../../common/types/cortex-config";
+import type { SystemEventSource } from "../system-events";
+import {
+  emitFederationDenied,
+  evaluateFederationGate,
+  subjectMatches,
+} from "../surface-router";
+import { verifySignedByChain } from "../verify-signed-by-chain";
+import { AgentPresenceRegistry } from "./registry";
+import { AGENT_PRESENCE_TYPES } from "./envelopes";
+
+/**
+ * Subject pattern the FEDERATED subscriber binds — every peer principal/stack's
+ * presence subtree. `federated.*.*.agent.>`: segment[1] (`*`) = any peer
+ * PRINCIPAL, segment[2] (`*`) = any peer STACK, `agent.>` = any presence action.
+ *
+ * Unlike the B.3 stack-local pattern (which pins `{principal}.{stack}` to THIS
+ * stack), the federated pattern is principal-WILDCARD: we want every peer's
+ * presence, and WHICH peers are admissible is decided by the federation
+ * accept-list gate at fold time — NOT by narrowing the subscription. (Narrowing
+ * the subscription per-peer would couple the NATS bind to the peer roster and
+ * miss the gate's deny/hop/anti-spoof checks; the gate is the trust boundary,
+ * the subscription is just the firehose.)
+ */
+export function federatedAgentPresenceSubject(): string {
+  return "federated.*.*.agent.>";
+}
+
+/** Lifecycle handle for the federated subscriber. */
+export interface FederatedAgentPresenceSubscriberHandle {
+  /**
+   * Stop the federated subscriber: unregister the fan-out handler, drain the
+   * push subscriber, AND remove every foreign record from the registry (so
+   * disabling federation cleanly removes foreign agents — plan §4.5). The
+   * registry's LOCAL records survive. Idempotent.
+   */
+  stop(): Promise<void>;
+}
+
+/** Options for {@link startFederatedAgentPresenceSubscriber}. */
+export interface StartFederatedAgentPresenceSubscriberOptions {
+  runtime: MyelinRuntime;
+  /** The SHARED registry — same instance B.3 folds local presence into. */
+  registry: AgentPresenceRegistry;
+  /**
+   * E.1 — federation policy. The OPT-IN switch: when `undefined` or
+   * `networks[]` is empty, the subscriber is INERT — it does NOT subscribe to
+   * `federated.*` at all, and no foreign presence is folded. Federation is
+   * OPT-IN (the resolved plan §4.5 decision); a stack with no
+   * `policy.federated.networks[]` sees zero foreign agents, byte-identical to
+   * pre-E behaviour. Supplying at least one network opts the stack into folding
+   * that network's accept-listed, chain-verified peer presence.
+   */
+  federated: PolicyFederated | undefined;
+  /** Source identity for the `system.access.denied` audit envelopes on a gate drop. */
+  source: SystemEventSource;
+  /**
+   * E.5 — chain-verification trust resolver. Mirrors the dispatch-listener:
+   * when supplied (with `receivingAgentId`), every foreign presence envelope is
+   * run through `verifySignedByChain` before folding. When `undefined`, the
+   * structural+crypto chain check is SKIPPED — but the accept-list gate STILL
+   * runs (the gate alone bounds which peers can appear; the chain check adds
+   * cryptographic attribution under `enforce`). Production wiring supplies it.
+   */
+  trustResolver?: TrustResolver;
+  /** Receiving agent id whose `trust:` list governs admitted signers. */
+  receivingAgentId?: string;
+  /** Principal id — required by the crypto-verify pass (threaded to myelin Principals). */
+  principalId?: string;
+  /** Whether the chain verifier runs ed25519 crypto verification. Default `true`. */
+  cryptoVerify?: boolean;
+  /**
+   * Whether an empty `signed_by[]` chain is REJECTED. For FOREIGN presence the
+   * default is `true`: an unsigned cross-principal envelope has no
+   * cryptographic attribution and must not be trusted into the view. (Contrast
+   * the dispatch-listener default `false`, which exists for LOCAL
+   * adapter-originated dispatches that legitimately arrive unsigned — foreign
+   * presence has no such legitimate-unsigned path.)
+   */
+  rejectEmpty?: boolean;
+  /** Receiving stack's signing DID (own-stack short-circuit in the verifier). */
+  stackIdentity?: string;
+  /** Receiving stack's NKey pubkey (crypto-verify pass for own-stack stamps). */
+  stackNKeyPub?: string;
+  /**
+   * E.5 — federated peer-pubkey resolution seam. The SAME seam the
+   * dispatch-listener uses (wired ONLY under `signing === "enforce"`). When
+   * supplied, a foreign envelope's signer peer principal is resolved to a
+   * verified Ed25519 identity before the crypto pass. `undefined` ⇒ foreign
+   * presence verifies local-only (no registry peer resolution).
+   */
+  resolveFederatedPeer?: (
+    peerPrincipal: string,
+  ) => Promise<FederatedPeerResolution>;
+}
+
+/**
+ * Wire the trust-verified federated presence subscriber into the running
+ * cortex. OPT-IN: when `federated` is absent / has no networks, returns an
+ * INERT handle that subscribed to nothing (no firehose, no folds).
+ *
+ * NON-THROWING / best-effort, matching every other capability-side boot
+ * feature: a subscribe failure logs + leaves the subscriber dormant. When
+ * `runtime.enabled` is false (no NATS) the subscriber stays dormant.
+ */
+export async function startFederatedAgentPresenceSubscriber(
+  opts: StartFederatedAgentPresenceSubscriberOptions,
+): Promise<FederatedAgentPresenceSubscriberHandle> {
+  const {
+    runtime,
+    registry,
+    federated,
+    source,
+    trustResolver,
+    receivingAgentId,
+    principalId,
+    stackIdentity,
+    stackNKeyPub,
+    resolveFederatedPeer,
+  } = opts;
+  const cryptoVerify = opts.cryptoVerify ?? true;
+  // Foreign presence has no legitimate-unsigned path — reject empty chains by
+  // default (the inverse of the dispatch-listener's adapter-friendly default).
+  const rejectEmpty = opts.rejectEmpty ?? true;
+
+  // E.1 — OPT-IN gate. No networks ⇒ federation is OFF for this stack: the
+  // subscriber binds NOTHING and folds NOTHING. This is the resolved opt-in
+  // default (plan §4.5).
+  const networks = federated?.networks ?? [];
+  if (networks.length === 0) {
+    // Inert: nothing subscribed, nothing to fold, nothing to tear down.
+    return { stop: (): Promise<void> => Promise.resolve() };
+  }
+
+  // Index networks by id for the gate (mirrors the surface-router /
+  // dispatch-listener construction). The gate resolves the SOURCE network from
+  // the SOURCE PRINCIPAL's `peers[]` membership — the network is never on the
+  // wire (ADR-0001).
+  const federatedNetworksById = new Map<string, PolicyFederatedNetwork>();
+  for (const network of networks) {
+    federatedNetworksById.set(network.id, network);
+  }
+
+  const pattern = federatedAgentPresenceSubject();
+
+  // The set of valid presence `envelope.type` literals — a fast membership
+  // check so a non-presence envelope that happens to match `agent.>` (none
+  // exist today, but defensive) is ignored without a fold attempt.
+  const presenceTypes = new Set<string>(AGENT_PRESENCE_TYPES);
+
+  const handler: EnvelopeHandler = (envelope, subject, sourceLink) => {
+    // Subject filter — only the federated presence subtree. The runtime fans
+    // EVERY envelope to EVERY handler, so this handler must reject everything
+    // that isn't a `federated.*.*.agent.*` subject (incl. the stack's own
+    // `local.*` presence, which B.3 owns).
+    if (!subjectMatches(pattern, subject)) return;
+    if (!presenceTypes.has(envelope.type)) return;
+
+    // === TRUST GATE 1 — federation accept-list (E.5) ======================
+    // Mirror of the dispatch-listener's Option-D gate (cortex#484). A foreign
+    // presence envelope from a peer NOT in any configured network's `peers[]`,
+    // OR on a denied subject, OR over the hop budget, OR cross-network-spoofed
+    // on the wrong leaf, is DROPPED here — never folded. The audit envelope
+    // makes the drop observable.
+    const decision = evaluateFederationGate(
+      subject,
+      envelope,
+      federatedNetworksById,
+      sourceLink,
+    );
+    if (decision !== "allow") {
+      emitFederationDenied(runtime, source, envelope, subject, decision);
+      return;
+    }
+
+    // === TRUST GATE 2 — signed_by[] chain verification (E.5) ===============
+    // The chain check is async; fold happens in its `.then`. A verification
+    // failure DROPS the envelope (never folds). When no `trustResolver` /
+    // `receivingAgentId` is wired, the chain check is skipped (the gate above
+    // still bounded which peers can appear) and the envelope folds directly.
+    if (trustResolver !== undefined && receivingAgentId !== undefined) {
+      void verifySignedByChain(envelope, {
+        resolver: trustResolver,
+        receivingAgentId,
+        rejectEmpty,
+        cryptoVerify,
+        ...(principalId !== undefined && { principalId }),
+        ...(stackIdentity !== undefined && { stackIdentity }),
+        ...(stackNKeyPub !== undefined && { stackNKeyPub }),
+        ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
+      })
+        .then((result) => {
+          if (!result.valid) {
+            // Chain failed — DROP. A foreign presence envelope that can't be
+            // cryptographically attributed never appears in the view.
+            process.stderr.write(
+              `federated-agent-presence: dropping foreign presence ${envelope.type} ` +
+                `(id=${envelope.id}) — signed_by chain verification failed: ` +
+                `${result.reason.kind}\n`,
+            );
+            return;
+          }
+          foldForeign(registry, envelope);
+        })
+        .catch((err: unknown) => {
+          // A verifier fault must never crash the fan-out — log + drop (fail
+          // closed: an envelope we couldn't verify is not folded).
+          process.stderr.write(
+            `federated-agent-presence: chain verify threw for ${envelope.type} ` +
+              `(id=${envelope.id}) — dropping: ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        });
+      return;
+    }
+
+    // No chain verifier wired — fold directly (the accept-list gate already
+    // bounded the admissible peers).
+    foldForeign(registry, envelope);
+  };
+
+  const registration = runtime.onEnvelope(handler);
+
+  // Self-subscribe to the federated presence firehose (cortex#477 push-mode
+  // seam). Best-effort: a subscribe failure leaves the subscriber dormant
+  // (still registered as a handler, but no NATS interest declared).
+  let subscriber: MyelinSubscriber | null = null;
+  try {
+    subscriber = (await runtime.subscribe?.(pattern)) ?? null;
+    if (runtime.enabled && subscriber === null) {
+      process.stderr.write(
+        `federated-agent-presence: runtime.subscribe(${pattern}) returned null — ` +
+          `subscriber will only see envelopes from other static subscriptions\n`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write(
+      `federated-agent-presence: subscribe(${pattern}) failed (non-fatal — dormant): ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+
+  let stopped = false;
+  return {
+    stop: async (): Promise<void> => {
+      if (stopped) return;
+      stopped = true;
+      registration.unregister();
+      if (subscriber) {
+        await subscriber.stop();
+      }
+      // Disabling federation cleanly removes foreign agents (plan §4.5). The
+      // registry's local records survive.
+      registry.removeForeign();
+    },
+  };
+}
+
+/**
+ * Fold a TRUST-VERIFIED foreign presence envelope into the registry, deriving
+ * the provenance `{principal}` + `{stack}` from the envelope's SOURCE (the
+ * signing identity). `envelope.source` is `{principal}.{stack}.{instance}[...]`,
+ * so segment[0] is the bare principal and segment[1] the bare stack slug.
+ *
+ * Using the SOURCE (not the payload scope) for provenance means a peer can't
+ * claim a DIFFERENT origin than the one it signed as: the chain verification
+ * above bound `source` to a verified pubkey, so the provenance is as trustworthy
+ * as the signature. (The payload `scope` SHOULD equal the source for a
+ * well-formed peer; deriving from the authenticated source is the safe choice if
+ * they ever diverge.)
+ *
+ * A source with fewer than two segments (defensive — the schema forbids it) is
+ * dropped rather than folded as an originless record.
+ */
+function foldForeign(registry: AgentPresenceRegistry, envelope: Envelope): void {
+  const segments = envelope.source.split(".");
+  const principal = segments[0];
+  const stack = segments[1];
+  if (
+    principal === undefined ||
+    principal.length === 0 ||
+    stack === undefined ||
+    stack.length === 0
+  ) {
+    process.stderr.write(
+      `federated-agent-presence: dropping foreign presence ${envelope.type} ` +
+        `(id=${envelope.id}) — could not derive {principal}/{stack} provenance from source "${envelope.source}"\n`,
+    );
+    return;
+  }
+  registry.applyForeign(envelope, { principal, stack });
+}
+
+/**
+ * Re-export for the boot wiring's hop-budget sanity: a foreign presence chain
+ * is bounded by `max_hop` inside the gate, but a caller that wants to inspect
+ * the observed hop count (diagnostics) reads it the same way the gate does.
+ */
+export function observedHops(envelope: Envelope): number {
+  return getSignedByChain(envelope).length;
+}

--- a/src/bus/agent-network/registry.ts
+++ b/src/bus/agent-network/registry.ts
@@ -172,17 +172,30 @@ export interface AgentPresenceRecord {
    *     `{principal}/{stack}` so the view (E.3) + detail-join (#909) can group
    *     foreign agents under their origin stack and render them distinctly.
    *
-   * The origin is keyed off the PAYLOAD scope (`AgentPresenceScope`), which for a
-   * foreign record is the SENDER's identity — NOT the receiving stack. Local and
-   * foreign records for the same `agent_id` would have the same map key only if a
-   * peer impersonated our `{principal}/{stack}`; the trust gate (signed_by[] +
-   * accept-list) makes that impossible, so the key space stays partitioned by
-   * real origin.
+   * The origin (and the record's key + principal + stack) is derived from the
+   * CHAIN-VERIFIED `source` of the envelope — NOT the attacker-controlled
+   * `payload.scope` (PR #914 review BLOCKER fix). A foreign record's
+   * `{principal}/{stack}` is the peer's VERIFIED identity, so the key space is
+   * partitioned by real origin: a foreign record can never collide with /
+   * overwrite a local one, and an accept-listed peer can only announce agents
+   * under its OWN verified `{principal}/{stack}` (a `payload.scope` that
+   * disagrees with the source is dropped as a spoof — see {@link
+   * AgentPresenceRegistry.applyForeign}).
    */
   origin: AgentRecordOrigin;
   /** Logical agent id (`luna`, `echo`, …). */
   agentId: string;
-  /** The agent's NKey public key (stable cross-restart identity). */
+  /**
+   * The agent's NKey public key (stable cross-restart identity).
+   *
+   * For a FOREIGN record this is the PEER's declared agent key, namespaced under
+   * the chain-verified `{principal}/{stack}` (which owns the map key). It is the
+   * peer's own agent's key — the peer is authoritative for it within its own
+   * namespace — and it can NOT be used to impersonate a LOCAL agent, because the
+   * record's KEY is source-bound (`{verified-principal}/{verified-stack}/...`),
+   * so a foreign nkey always lands on a foreign-keyed record, never a local one
+   * (PR #914 review BLOCKER fix).
+   */
   nkeyPublicKey: string;
   /** Soma-layer assistant name the agent hosts, or `null` when none. */
   assistantName: string | null;
@@ -321,35 +334,63 @@ export class AgentPresenceRegistry {
    * "this foreign presence is admissible." See
    * {@link startFederatedAgentPresenceSubscriber}.
    *
-   * `origin` carries the SENDER's `{principal}/{stack}` (from the envelope's
-   * payload scope) so the record is distinguishable from a local one. Same
-   * best-effort contract as {@link apply}: a malformed payload is logged +
+   * **SOURCE-BOUND IDENTITY (PR #914 review BLOCKER fix).** `verifiedScope`
+   * carries the `{principal}/{stack}` derived from the envelope's CHAIN-VERIFIED
+   * `source` — the only trustworthy identity. The record's principal, stack, AND
+   * THE MAP KEY are built from THIS, **never** from the attacker-controlled
+   * `payload.scope`. So an accept-listed peer can announce only agents under ITS
+   * OWN verified `{principal}/{stack}` — it can NOT paint a record that claims a
+   * different (e.g. local-looking) principal/stack, and a foreign record can
+   * NEVER collide with / overwrite a local one (the principal/stack segments of
+   * the key differ by construction).
+   *
+   * **Spoof drop.** When `payload.scope` DISAGREES with the verified source
+   * (`payload.scope.principal/stack ≠ verifiedScope`), the envelope is DROPPED
+   * with a logged spoof signal rather than folded — a mismatch is an
+   * impersonation attempt worth surfacing, not silently coercing. The
+   * non-identity payload (capabilities, liveness state) is what the record
+   * carries; identity comes from the source.
+   *
+   * Same best-effort contract as {@link apply}: a malformed payload is logged +
    * dropped, never thrown.
    */
   applyForeign(
     envelope: Envelope,
-    origin: { principal: string; stack: string },
+    verifiedScope: { principal: string; stack: string },
   ): AgentPresenceRecord | null {
-    return this.applyWithOrigin(envelope, {
-      kind: "foreign",
-      principal: origin.principal,
-      stack: origin.stack,
-    });
+    return this.applyWithOrigin(
+      envelope,
+      {
+        kind: "foreign",
+        principal: verifiedScope.principal,
+        stack: verifiedScope.stack,
+      },
+      verifiedScope,
+    );
   }
 
+  /**
+   * @param origin record provenance (local | foreign).
+   * @param verifiedScope — for the FOREIGN path, the chain-verified
+   *   `{principal}/{stack}` that is AUTHORITATIVE for the record's key +
+   *   principal + stack (and against which `payload.scope` is spoof-checked).
+   *   `undefined` for the LOCAL path (the stack folds its own envelopes; payload
+   *   scope IS the identity, no cross-principal trust boundary).
+   */
   private applyWithOrigin(
     envelope: Envelope,
     origin: AgentRecordOrigin,
+    verifiedScope?: { principal: string; stack: string },
   ): AgentPresenceRecord | null {
     switch (envelope.type) {
       case AGENT_ONLINE_TYPE:
-        return this.applyOnline(envelope, origin);
+        return this.applyOnline(envelope, origin, verifiedScope);
       case AGENT_HEARTBEAT_TYPE:
-        return this.applyHeartbeat(envelope, origin);
+        return this.applyHeartbeat(envelope, origin, verifiedScope);
       case AGENT_OFFLINE_TYPE:
-        return this.applyOffline(envelope, origin);
+        return this.applyOffline(envelope, origin, verifiedScope);
       case AGENT_CAPABILITIES_CHANGED_TYPE:
-        return this.applyCapabilitiesChanged(envelope, origin);
+        return this.applyCapabilitiesChanged(envelope, origin, verifiedScope);
       default:
         // Not a presence envelope — the subject filter should have excluded
         // it, but be defensive (the fan-out delivers every matching envelope).
@@ -357,14 +398,58 @@ export class AgentPresenceRegistry {
     }
   }
 
+  /**
+   * BLOCKER fix — resolve the AUTHORITATIVE `{principal}/{stack}` for a record.
+   *
+   * For the FOREIGN path (`verifiedScope` supplied): the chain-verified source
+   * wins. If `payload.scope` disagrees with it, this is a spoof attempt — return
+   * `null` so the caller drops the envelope (logged). Otherwise the verified
+   * scope is authoritative for the key + principal + stack.
+   *
+   * For the LOCAL path (`verifiedScope` undefined): the stack folds its own
+   * envelopes; `payload.scope` is the identity (no cross-principal boundary).
+   *
+   * Returns `null` ONLY on a foreign spoof (scope ≠ source); the caller treats
+   * that exactly like a dropped malformed payload.
+   */
+  private resolveScope(
+    envelope: Envelope,
+    payloadScope: { principal: string; stack: string },
+    verifiedScope: { principal: string; stack: string } | undefined,
+  ): { principal: string; stack: string } | null {
+    if (verifiedScope === undefined) {
+      // Local path — payload scope is the identity.
+      return payloadScope;
+    }
+    // Foreign path — the verified source is authoritative. A payload.scope that
+    // disagrees is an impersonation attempt: DROP + log (never fold a record
+    // whose claimed identity differs from the signed source).
+    if (
+      payloadScope.principal !== verifiedScope.principal ||
+      payloadScope.stack !== verifiedScope.stack
+    ) {
+      process.stderr.write(
+        `agent-presence-registry: DROPPING foreign ${envelope.type} (id=${envelope.id}) — ` +
+          `payload.scope ${payloadScope.principal}/${payloadScope.stack} does not match ` +
+          `chain-verified source ${verifiedScope.principal}/${verifiedScope.stack} ` +
+          `(spoof attempt — identity must come from the verified source)\n`,
+      );
+      return null;
+    }
+    return verifiedScope;
+  }
+
   private applyOnline(
     envelope: Envelope,
     origin: AgentRecordOrigin,
+    verifiedScope?: { principal: string; stack: string },
   ): AgentPresenceRecord | null {
     const parsed = AgentOnlinePayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
-    const key = recordKey(p.scope.principal, p.scope.stack, p.identity.agent_id);
+    const scope = this.resolveScope(envelope, p.scope, verifiedScope);
+    if (scope === null) return null; // foreign spoof (scope ≠ verified source)
+    const key = recordKey(scope.principal, scope.stack, p.identity.agent_id);
     const ts = this.now();
     const existing = this.records.get(key);
     const record: AgentPresenceRecord = {
@@ -373,8 +458,8 @@ export class AgentPresenceRegistry {
       agentId: p.identity.agent_id,
       nkeyPublicKey: p.identity.nkey_public_key,
       assistantName: p.identity.assistant_name,
-      principal: p.scope.principal,
-      stack: p.scope.stack,
+      principal: scope.principal,
+      stack: scope.stack,
       capabilities: p.capabilities,
       state: "online",
       startedAt: p.started_at,
@@ -393,11 +478,14 @@ export class AgentPresenceRegistry {
   private applyHeartbeat(
     envelope: Envelope,
     origin: AgentRecordOrigin,
+    verifiedScope?: { principal: string; stack: string },
   ): AgentPresenceRecord | null {
     const parsed = AgentHeartbeatPayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
-    const key = recordKey(p.scope.principal, p.scope.stack, p.identity.agent_id);
+    const scope = this.resolveScope(envelope, p.scope, verifiedScope);
+    if (scope === null) return null; // foreign spoof (scope ≠ verified source)
+    const key = recordKey(scope.principal, scope.stack, p.identity.agent_id);
     const ts = this.now();
     const existing = this.records.get(key);
     // An unknown agent's heartbeat is itself a liveness signal — upsert it as
@@ -410,8 +498,8 @@ export class AgentPresenceRegistry {
       agentId: p.identity.agent_id,
       nkeyPublicKey: p.identity.nkey_public_key,
       assistantName: p.identity.assistant_name,
-      principal: p.scope.principal,
-      stack: p.scope.stack,
+      principal: scope.principal,
+      stack: scope.stack,
       capabilities: existing?.capabilities ?? [],
       state: "online",
       ...(existing?.startedAt !== undefined && { startedAt: existing.startedAt }),
@@ -426,11 +514,14 @@ export class AgentPresenceRegistry {
   private applyOffline(
     envelope: Envelope,
     origin: AgentRecordOrigin,
+    verifiedScope?: { principal: string; stack: string },
   ): AgentPresenceRecord | null {
     const parsed = AgentOfflinePayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
-    const key = recordKey(p.scope.principal, p.scope.stack, p.identity.agent_id);
+    const scope = this.resolveScope(envelope, p.scope, verifiedScope);
+    if (scope === null) return null; // foreign spoof (scope ≠ verified source)
+    const key = recordKey(scope.principal, scope.stack, p.identity.agent_id);
     const ts = this.now();
     const existing = this.records.get(key);
     const record: AgentPresenceRecord = {
@@ -439,8 +530,8 @@ export class AgentPresenceRegistry {
       agentId: p.identity.agent_id,
       nkeyPublicKey: p.identity.nkey_public_key,
       assistantName: p.identity.assistant_name,
-      principal: p.scope.principal,
-      stack: p.scope.stack,
+      principal: scope.principal,
+      stack: scope.stack,
       capabilities: existing?.capabilities ?? [],
       state: "offline",
       offlineReason: p.reason,
@@ -458,11 +549,14 @@ export class AgentPresenceRegistry {
   private applyCapabilitiesChanged(
     envelope: Envelope,
     origin: AgentRecordOrigin,
+    verifiedScope?: { principal: string; stack: string },
   ): AgentPresenceRecord | null {
     const parsed = AgentCapabilitiesChangedPayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
-    const key = recordKey(p.scope.principal, p.scope.stack, p.identity.agent_id);
+    const scope = this.resolveScope(envelope, p.scope, verifiedScope);
+    if (scope === null) return null; // foreign spoof (scope ≠ verified source)
+    const key = recordKey(scope.principal, scope.stack, p.identity.agent_id);
     const ts = this.now();
     const existing = this.records.get(key);
     // B stores the LATEST capability set only. The diff/reconcile (against the
@@ -473,8 +567,8 @@ export class AgentPresenceRegistry {
       agentId: p.identity.agent_id,
       nkeyPublicKey: p.identity.nkey_public_key,
       assistantName: p.identity.assistant_name,
-      principal: p.scope.principal,
-      stack: p.scope.stack,
+      principal: scope.principal,
+      stack: scope.stack,
       capabilities: p.capabilities,
       // capabilities-changed does not assert liveness state; preserve the
       // prior state (default online — an agent emitting it is alive).

--- a/src/bus/agent-network/registry.ts
+++ b/src/bus/agent-network/registry.ts
@@ -116,6 +116,29 @@ export const DEFAULT_PRESENCE_REAPER_INTERVAL_MS = 30_000;
 export type PresenceOfflineReason = AgentOfflineReason | "ttl_lapse";
 
 /**
+ * G-1114.E.2 — provenance of a {@link AgentPresenceRecord}. `"local"` for the
+ * stack's own agents (the B.3 path); a `foreign` struct carrying the peer's
+ * `{principal}/{stack}` for a trust-verified federated peer agent (the E.2
+ * path). The view groups + styles foreign agents by this; a downstream consumer
+ * distinguishes "my agent" from "someone else's agent" without re-parsing the
+ * envelope source.
+ */
+export type AgentRecordOrigin =
+  | "local"
+  | { kind: "foreign"; principal: string; stack: string };
+
+/**
+ * True when a record came from a federated peer (not this stack). A thin
+ * type-guard so view code reads `isForeign(record.origin)` rather than
+ * re-checking the discriminant shape.
+ */
+export function isForeignOrigin(
+  origin: AgentRecordOrigin,
+): origin is { kind: "foreign"; principal: string; stack: string } {
+  return origin !== "local";
+}
+
+/**
  * The {@link PresenceOfflineReason} the reaper stamps on a TTL-lapse offline.
  * Exported so downstream renderers (and tests) compare against the constant
  * rather than re-typing the literal.
@@ -136,6 +159,27 @@ export const TTL_LAPSE_OFFLINE_REASON = "ttl_lapse" as const;
 export interface AgentPresenceRecord {
   /** Stable map key — `{principal}/{stack}/{agent_id}`. */
   key: string;
+  /**
+   * G-1114.E.2 — record PROVENANCE: where this presence came from.
+   *
+   *   - `"local"`   — folded from the stack's OWN `local.{principal}.{stack}.agent.*`
+   *     subtree (the B.3 path). The default for every record `apply()` creates,
+   *     so a bare registry that only ever sees local envelopes is byte-identical
+   *     to pre-E behaviour.
+   *   - `{ kind: "foreign"; principal; stack }` — folded from a TRUST-VERIFIED
+   *     peer's `federated.{principal}.{stack}.agent.*` envelope (the E.2 path,
+   *     via {@link AgentPresenceRegistry.applyForeign}). Carries the peer's
+   *     `{principal}/{stack}` so the view (E.3) + detail-join (#909) can group
+   *     foreign agents under their origin stack and render them distinctly.
+   *
+   * The origin is keyed off the PAYLOAD scope (`AgentPresenceScope`), which for a
+   * foreign record is the SENDER's identity — NOT the receiving stack. Local and
+   * foreign records for the same `agent_id` would have the same map key only if a
+   * peer impersonated our `{principal}/{stack}`; the trust gate (signed_by[] +
+   * accept-list) makes that impossible, so the key space stays partitioned by
+   * real origin.
+   */
+  origin: AgentRecordOrigin;
   /** Logical agent id (`luna`, `echo`, …). */
   agentId: string;
   /** The agent's NKey public key (stable cross-restart identity). */
@@ -261,15 +305,51 @@ export class AgentPresenceRegistry {
    * non-presence type).
    */
   apply(envelope: Envelope): AgentPresenceRecord | null {
+    return this.applyWithOrigin(envelope, "local");
+  }
+
+  /**
+   * G-1114.E.2 — fold a TRUST-VERIFIED foreign presence envelope, tagging the
+   * resulting record with its `{principal}/{stack}` provenance.
+   *
+   * **Trust is the CALLER's job, not this method's.** This is the in-memory
+   * fold ONLY — it assumes the envelope has ALREADY passed the federation
+   * accept-list gate AND `signed_by[]` chain verification (the federated
+   * subscriber does both before calling here, mirroring the dispatch-listener's
+   * Option-D gate→verify→handle order). Folding an unverified foreign envelope
+   * here would be a trust hole; the subscriber is the single place that decides
+   * "this foreign presence is admissible." See
+   * {@link startFederatedAgentPresenceSubscriber}.
+   *
+   * `origin` carries the SENDER's `{principal}/{stack}` (from the envelope's
+   * payload scope) so the record is distinguishable from a local one. Same
+   * best-effort contract as {@link apply}: a malformed payload is logged +
+   * dropped, never thrown.
+   */
+  applyForeign(
+    envelope: Envelope,
+    origin: { principal: string; stack: string },
+  ): AgentPresenceRecord | null {
+    return this.applyWithOrigin(envelope, {
+      kind: "foreign",
+      principal: origin.principal,
+      stack: origin.stack,
+    });
+  }
+
+  private applyWithOrigin(
+    envelope: Envelope,
+    origin: AgentRecordOrigin,
+  ): AgentPresenceRecord | null {
     switch (envelope.type) {
       case AGENT_ONLINE_TYPE:
-        return this.applyOnline(envelope);
+        return this.applyOnline(envelope, origin);
       case AGENT_HEARTBEAT_TYPE:
-        return this.applyHeartbeat(envelope);
+        return this.applyHeartbeat(envelope, origin);
       case AGENT_OFFLINE_TYPE:
-        return this.applyOffline(envelope);
+        return this.applyOffline(envelope, origin);
       case AGENT_CAPABILITIES_CHANGED_TYPE:
-        return this.applyCapabilitiesChanged(envelope);
+        return this.applyCapabilitiesChanged(envelope, origin);
       default:
         // Not a presence envelope — the subject filter should have excluded
         // it, but be defensive (the fan-out delivers every matching envelope).
@@ -277,7 +357,10 @@ export class AgentPresenceRegistry {
     }
   }
 
-  private applyOnline(envelope: Envelope): AgentPresenceRecord | null {
+  private applyOnline(
+    envelope: Envelope,
+    origin: AgentRecordOrigin,
+  ): AgentPresenceRecord | null {
     const parsed = AgentOnlinePayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
@@ -286,6 +369,7 @@ export class AgentPresenceRegistry {
     const existing = this.records.get(key);
     const record: AgentPresenceRecord = {
       key,
+      origin,
       agentId: p.identity.agent_id,
       nkeyPublicKey: p.identity.nkey_public_key,
       assistantName: p.identity.assistant_name,
@@ -306,7 +390,10 @@ export class AgentPresenceRegistry {
     return record;
   }
 
-  private applyHeartbeat(envelope: Envelope): AgentPresenceRecord | null {
+  private applyHeartbeat(
+    envelope: Envelope,
+    origin: AgentRecordOrigin,
+  ): AgentPresenceRecord | null {
     const parsed = AgentHeartbeatPayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
@@ -319,6 +406,7 @@ export class AgentPresenceRegistry {
     // capabilities-changed fills them.
     const record: AgentPresenceRecord = {
       key,
+      origin,
       agentId: p.identity.agent_id,
       nkeyPublicKey: p.identity.nkey_public_key,
       assistantName: p.identity.assistant_name,
@@ -335,7 +423,10 @@ export class AgentPresenceRegistry {
     return record;
   }
 
-  private applyOffline(envelope: Envelope): AgentPresenceRecord | null {
+  private applyOffline(
+    envelope: Envelope,
+    origin: AgentRecordOrigin,
+  ): AgentPresenceRecord | null {
     const parsed = AgentOfflinePayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
@@ -344,6 +435,7 @@ export class AgentPresenceRegistry {
     const existing = this.records.get(key);
     const record: AgentPresenceRecord = {
       key,
+      origin,
       agentId: p.identity.agent_id,
       nkeyPublicKey: p.identity.nkey_public_key,
       assistantName: p.identity.assistant_name,
@@ -363,7 +455,10 @@ export class AgentPresenceRegistry {
     return record;
   }
 
-  private applyCapabilitiesChanged(envelope: Envelope): AgentPresenceRecord | null {
+  private applyCapabilitiesChanged(
+    envelope: Envelope,
+    origin: AgentRecordOrigin,
+  ): AgentPresenceRecord | null {
     const parsed = AgentCapabilitiesChangedPayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
@@ -374,6 +469,7 @@ export class AgentPresenceRegistry {
     // prior set) is Phase C — here we just converge to the new full set.
     const record: AgentPresenceRecord = {
       key,
+      origin,
       agentId: p.identity.agent_id,
       nkeyPublicKey: p.identity.nkey_public_key,
       assistantName: p.identity.assistant_name,
@@ -524,6 +620,34 @@ export class AgentPresenceRegistry {
       this.emit(key, next);
     }
     return reaped;
+  }
+
+  // --- Foreign-record lifecycle (G-1114.E.2) -------------------------------
+
+  /**
+   * Drop every FOREIGN record (origin `{kind: "foreign"}`), firing `onChange`
+   * for each removal so the view prunes the foreign agents cleanly. Local
+   * records are untouched. Returns the keys removed.
+   *
+   * The acceptance path for "disabling federation cleanly removes foreign
+   * agents" (plan §4.5): when the federated subscriber stops (federation turned
+   * off / reloaded out), it calls this so the registry no longer shows a peer's
+   * agents. A record removal is signalled via `onChange` with a synthesized
+   * snapshot carrying `state: "offline"` + `offlineReason: "shutdown"` — the
+   * view treats a removed-foreign exactly as a gracefully-departed agent, and
+   * since the record is gone from `getAgents()` a subsequent refetch omits it.
+   */
+  removeForeign(): string[] {
+    const removed: string[] = [];
+    for (const [key, rec] of this.records) {
+      if (!isForeignOrigin(rec.origin)) continue;
+      this.records.delete(key);
+      removed.push(key);
+      // Emit a terminal snapshot so a live listener prunes immediately; the
+      // record is already gone from `getAgents()`.
+      this.emit(key, { ...rec, state: "offline", offlineReason: "shutdown" });
+    }
+    return removed;
   }
 }
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -132,6 +132,11 @@ import {
   startAgentPresenceRegistry,
   type AgentPresenceRegistryHandle,
 } from "./bus/agent-network/registry";
+// G-1114.E.2 + E.5 — trust-verified federated agent-presence subscriber.
+import {
+  startFederatedAgentPresenceSubscriber,
+  type FederatedAgentPresenceSubscriberHandle,
+} from "./bus/agent-network/federated-subscriber";
 import { createProbeResponder, type ProbeResponder } from "./bus/probe-responder";
 import { WorklogManager } from "./runner/worklog-manager";
 
@@ -3212,6 +3217,18 @@ export async function startCortex(
   // separate drain slot is needed.
   let presenceRegistryHandle: AgentPresenceRegistryHandle | null = null;
   let presenceProducer: AgentPresenceProducer | null = null;
+  // G-1114.E.2 — trust-verified federated presence subscriber (folds peers'
+  // agents into the SAME registry, tagged with foreign provenance).
+  let federatedPresenceHandle: FederatedAgentPresenceSubscriberHandle | null = null;
+  // G-1114.E.1 — federate presence ONLY when the stack has opted into
+  // federation (it declares at least one `policy.federated.networks[]`). This is
+  // the SAME opt-in lever the federated subscriber + the dispatch-listener gate
+  // use — a stack with no networks emits local-only presence (default OFF). When
+  // on, the producer dual-emits a `classification: "federated"` copy so peers'
+  // E.2 subscribers can fold it (the existing federated-classification
+  // mechanism, not a new toggle).
+  const federatePresence =
+    (resolvedPolicy?.federated?.networks ?? []).length > 0;
   // The onChange→WS-broadcast subscription handle, captured so shutdown can
   // unsubscribe it explicitly — making teardown order-independent rather than
   // relying on the registry stop severing the envelope feed first (#899 review).
@@ -3280,8 +3297,36 @@ export async function startCortex(
           }),
         },
         agents: presenceAgents,
+        // G-1114.E.1 — opt-in federation dual-emit (default OFF).
+        federate: federatePresence,
       });
       presenceProducer.start();
+
+      // G-1114.E.2 + E.5 — start the trust-verified federated presence
+      // subscriber. INERT (no NATS subscription, no folds) when the stack hasn't
+      // opted into federation. When opted in, it folds peers' accept-listed +
+      // chain-verified presence into the SAME registry, tagged foreign. Reuses
+      // the EXACT trust config the dispatch-listener uses (the federation gate +
+      // `verifySignedByChain` + the `resolveFederatedPeer` seam wired only under
+      // `signing === "enforce"`) — the registry is an Option-D direct consumer,
+      // so it MUST verify foreign presence itself (the surface-router gate does
+      // not cover it). See `federated-subscriber.ts` THE DESIGN QUESTION.
+      federatedPresenceHandle = await startFederatedAgentPresenceSubscriber({
+        runtime,
+        registry: presenceRegistryHandle.registry,
+        federated: resolvedPolicy?.federated,
+        source: systemEventSource,
+        trustResolver,
+        receivingAgentId: mergedAgents[0]?.id,
+        principalId,
+        cryptoVerify: signingKnobs.cryptoVerify,
+        rejectEmpty: signingKnobs.rejectEmpty,
+        ...(signer !== undefined && { stackIdentity: signer.principal }),
+        ...(stackNKeyPubForVerifier !== undefined && {
+          stackNKeyPub: stackNKeyPubForVerifier,
+        }),
+        ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
+      });
       // G-1114.C.1 — publish the now-started producer to the config-reload
       // onChange handler so a mid-life capability drift can emit
       // `agent.capabilities-changed` without restart (see that handler's block
@@ -3546,6 +3591,13 @@ export async function startCortex(
       // window even if the registry stop is reordered) (#899 review).
       completeSync("agent-presence broadcast unsubscribe", () =>
         presenceBroadcastSub?.unsubscribe(),
+      );
+      // G-1114.E.2 — stop the federated subscriber BEFORE the registry stop so
+      // its `removeForeign()` prunes foreign records (disabling federation
+      // cleanly removes foreign agents) while the registry is still live.
+      await completeAsync(
+        "federated agent-presence subscriber stop",
+        federatedPresenceHandle?.stop(),
       );
       await completeAsync(
         "agent-presence registry stop",

--- a/src/runner/__tests__/agent-presence-producer.test.ts
+++ b/src/runner/__tests__/agent-presence-producer.test.ts
@@ -496,3 +496,90 @@ describe("presenceAgentFromAgent", () => {
     expect(pa).toBeNull();
   });
 });
+
+// ===========================================================================
+// G-1114.E.1 — federation opt-in (dual-emit local + federated)
+// ===========================================================================
+
+describe("AgentPresenceProducer federation opt-in (E.1)", () => {
+  function classificationsFor(
+    published: Envelope[],
+    type: string,
+  ): string[] {
+    return published
+      .filter((e) => e.type === type)
+      .map((e) => e.sovereignty.classification);
+  }
+
+  test("DEFAULT (federate omitted): online emits ONLY local, never federated", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+    });
+    producer.start();
+    const cls = classificationsFor(runtime.published, "agent.online");
+    expect(cls).toEqual(["local"]);
+    // No federated.* presence on the wire when not opted in.
+    expect(
+      runtime.published.some((e) => e.sovereignty.classification === "federated"),
+    ).toBe(false);
+  });
+
+  test("federate:true: online dual-emits BOTH local AND federated", () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+      federate: true,
+    });
+    producer.start();
+    const cls = classificationsFor(runtime.published, "agent.online").sort();
+    expect(cls).toEqual(["federated", "local"]);
+    // The federated copy derives the federated.* subject.
+    const fed = runtime.published.find(
+      (e) => e.type === "agent.online" && e.sovereignty.classification === "federated",
+    );
+    expect(fed).toBeDefined();
+    expect(deriveNatsSubject(fed!, "meta-factory")).toBe(
+      "federated.andreas.meta-factory.agent.online",
+    );
+    expect(validateEnvelope(fed!).ok).toBe(true);
+  });
+
+  test("federate:true: heartbeat ticks dual-emit local + federated per agent", () => {
+    const runtime = recordingRuntime();
+    const sched = manualScheduler();
+    new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A, AGENT_B],
+      scheduler: sched,
+      federate: true,
+    }).start();
+    sched.tick();
+    const cls = classificationsFor(runtime.published, "agent.heartbeat");
+    // 2 agents × {local, federated} = 4 heartbeats per tick.
+    expect(cls.filter((c) => c === "local").length).toBe(2);
+    expect(cls.filter((c) => c === "federated").length).toBe(2);
+  });
+
+  test("federate:true: offline dual-emits on shutdown", async () => {
+    const runtime = recordingRuntime();
+    const producer = new AgentPresenceProducer({
+      runtime,
+      source: SOURCE,
+      agents: [AGENT_A],
+      scheduler: manualScheduler(),
+      federate: true,
+    });
+    producer.start();
+    await producer.stop();
+    const cls = classificationsFor(runtime.published, "agent.offline").sort();
+    expect(cls).toEqual(["federated", "local"]);
+  });
+});

--- a/src/runner/agent-presence-producer.ts
+++ b/src/runner/agent-presence-producer.ts
@@ -65,6 +65,7 @@
  */
 
 import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { Envelope } from "../bus/myelin/envelope-validator";
 import {
   createAgentOnlineEvent,
   createAgentHeartbeatEvent,
@@ -197,6 +198,34 @@ export interface AgentPresenceProducerOptions {
   scheduler?: PresenceScheduler;
   /** Injectable clock for `started_at` / `sent_at`. Defaults to `() => new Date()`. */
   now?: () => Date;
+  /**
+   * G-1114.E.1 — **federate presence (OPT-IN, default OFF).** When `true`, the
+   * producer publishes a SECOND copy of every presence envelope with
+   * `classification: "federated"` (deriving the `federated.{principal}.{stack}.
+   * agent.*` subject) IN ADDITION to the stack-local `classification: "local"`
+   * copy. This is how a stack opts its agents' presence into peer Network views
+   * over bus federation (the E.2 subscriber on a peer stack folds it).
+   *
+   * Reuses the EXISTING federated-classification mechanism — the SAME
+   * `classification: "federated"` lever that opts `dispatch.task.*` /
+   * `review.verdict.*` into federated emission (IAW Phase A.3). NOT a new
+   * toggle: the presence builders already accept `classification` per
+   * `AgentPresenceCommonOpts`; this flag just makes the producer emit the
+   * federated variant alongside the local one.
+   *
+   * Default `false` — a stack that has NOT opted into federating presence emits
+   * ONLY `local.*`, byte-identical to pre-E behaviour. The boot wiring sets this
+   * `true` only when the stack's `policy.federated` opts presence in (e.g.
+   * `agent.*` reachable via the network's accept/announce config), mirroring how
+   * dispatch/review opt into federated classification.
+   *
+   * **Both copies, not a swap.** A federated stack still wants its OWN agents in
+   * its OWN local Network view (the B.3 local registry folds `local.*`), AND its
+   * peers want them via `federated.*`. So presence is dual-emitted (local +
+   * federated) — the same two-transports-one-envelope shape ADR-0007 §2
+   * describes.
+   */
+  federate?: boolean;
 }
 
 /**
@@ -219,6 +248,8 @@ export class AgentPresenceProducer {
   private readonly intervalMs: number;
   private readonly scheduler: PresenceScheduler;
   private readonly now: () => Date;
+  /** G-1114.E.1 — when true, dual-emit a `classification: "federated"` copy. */
+  private readonly federate: boolean;
 
   private timer: ReturnType<typeof setInterval> | undefined;
   private started = false;
@@ -246,6 +277,7 @@ export class AgentPresenceProducer {
     this.intervalMs = opts.intervalMs ?? DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS;
     this.scheduler = opts.scheduler ?? realScheduler;
     this.now = opts.now ?? (() => new Date());
+    this.federate = opts.federate ?? false;
     for (const agent of this.agents) {
       this.agentsById.set(agent.identity.agent_id, agent);
       this.capabilityBaseline.set(
@@ -351,54 +383,87 @@ export class AgentPresenceProducer {
     // steady state; the wire emit is best-effort).
     this.capabilityBaseline.set(agentId, next);
 
-    let envelope;
-    try {
-      envelope = createAgentCapabilitiesChangedEvent({
-        source: this.source,
-        identity: agent.identity,
-        scope: agent.scope,
-        capabilities: [...newCapabilities],
-        sentAt: this.now(),
-      });
-    } catch (err) {
-      process.stderr.write(
-        `agent-presence-producer: createAgentCapabilitiesChangedEvent failed (agent=${agentId}): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-      return true;
-    }
-    void this.runtime.publish(envelope).catch((err: unknown) => {
-      process.stderr.write(
-        `agent-presence-producer: agent.capabilities-changed publish failed (agent=${agentId}): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    });
+    const sentAt = this.now();
+    // G-1114.E.1 — dual-emit local (+ federated when opted in). `dualEmit`
+    // owns the per-classification build try/catch + best-effort publish.
+    void Promise.allSettled(
+      this.dualEmit("agent.capabilities-changed", agentId, (classification) =>
+        createAgentCapabilitiesChangedEvent({
+          source: this.source,
+          identity: agent.identity,
+          scope: agent.scope,
+          capabilities: [...newCapabilities],
+          sentAt,
+          classification,
+        }),
+      ),
+    );
     return true;
   }
 
-  private publishOnline(agent: PresenceAgent): void {
-    let envelope;
-    try {
-      envelope = createAgentOnlineEvent({
-        source: this.source,
-        identity: agent.identity,
-        scope: agent.scope,
-        capabilities: [...agent.capabilities],
-        startedAt: this.now(),
-      });
-    } catch (err) {
-      process.stderr.write(
-        `agent-presence-producer: createAgentOnlineEvent failed (agent=${agent.identity.agent_id}): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
+  /**
+   * G-1114.E.1 — emit one presence envelope at `classification: "local"`, and —
+   * when {@link federate} is on — a SECOND copy at `classification: "federated"`.
+   * `build(classification)` constructs the envelope at that classification via
+   * the existing builders (which thread `classification` through
+   * `AgentPresenceCommonOpts`); the federated copy derives the
+   * `federated.{principal}.{stack}.agent.*` subject on publish.
+   *
+   * Both publishes are best-effort + non-throwing (the existing per-emit
+   * contract). The federated emit reuses the SAME builder/publish path — no new
+   * mechanism, just a second classification. Used by the heartbeat tick which
+   * needs the awaitable promises for backpressure; the fire-and-forget callers
+   * (`publishOnline` / `publishOffline`) ignore the returned promises beyond
+   * their own `.catch`.
+   */
+  private dualEmit(
+    action: string,
+    agentId: string,
+    build: (classification: "local" | "federated") => Envelope,
+  ): Promise<void>[] {
+    const classifications: ("local" | "federated")[] = this.federate
+      ? ["local", "federated"]
+      : ["local"];
+    const publishes: Promise<void>[] = [];
+    for (const classification of classifications) {
+      let envelope: Envelope;
+      try {
+        envelope = build(classification);
+      } catch (err) {
+        process.stderr.write(
+          `agent-presence-producer: ${action} build failed (agent=${agentId}, ` +
+            `classification=${classification}): ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        continue;
+      }
+      publishes.push(
+        this.runtime.publish(envelope).catch((err: unknown) => {
+          process.stderr.write(
+            `agent-presence-producer: ${action} publish failed (agent=${agentId}, ` +
+              `classification=${classification}): ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }),
       );
-      return;
     }
-    void this.runtime.publish(envelope).catch((err: unknown) => {
-      process.stderr.write(
-        `agent-presence-producer: agent.online publish failed (agent=${agent.identity.agent_id}): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    });
+    return publishes;
+  }
+
+  private publishOnline(agent: PresenceAgent): void {
+    const startedAt = this.now();
+    void Promise.allSettled(
+      this.dualEmit("agent.online", agent.identity.agent_id, (classification) =>
+        createAgentOnlineEvent({
+          source: this.source,
+          identity: agent.identity,
+          scope: agent.scope,
+          capabilities: [...agent.capabilities],
+          startedAt,
+          classification,
+        }),
+      ),
+    );
   }
 
   private tickHeartbeats(): void {
@@ -413,28 +478,20 @@ export class AgentPresenceProducer {
     const sentAt = this.now();
     const publishes: Promise<void>[] = [];
     for (const agent of this.agents) {
-      let envelope;
-      try {
-        envelope = createAgentHeartbeatEvent({
-          source: this.source,
-          identity: agent.identity,
-          scope: agent.scope,
-          sentAt,
-        });
-      } catch (err) {
-        process.stderr.write(
-          `agent-presence-producer: createAgentHeartbeatEvent failed (agent=${agent.identity.agent_id}): ` +
-            `${err instanceof Error ? err.message : String(err)}\n`,
-        );
-        continue;
-      }
+      // G-1114.E.1 — dual-emit local (+ federated when opted in) heartbeats.
       publishes.push(
-        this.runtime.publish(envelope).catch((err: unknown) => {
-          process.stderr.write(
-            `agent-presence-producer: agent.heartbeat publish failed (agent=${agent.identity.agent_id}): ` +
-              `${err instanceof Error ? err.message : String(err)}\n`,
-          );
-        }),
+        ...this.dualEmit(
+          "agent.heartbeat",
+          agent.identity.agent_id,
+          (classification) =>
+            createAgentHeartbeatEvent({
+              source: this.source,
+              identity: agent.identity,
+              scope: agent.scope,
+              sentAt,
+              classification,
+            }),
+        ),
       );
     }
     this.heartbeatInFlight = true;
@@ -447,29 +504,23 @@ export class AgentPresenceProducer {
     agent: PresenceAgent,
     reason: "shutdown" | "restart" | "error",
   ): Promise<void> {
-    let envelope;
-    try {
-      envelope = createAgentOfflineEvent({
-        source: this.source,
-        identity: agent.identity,
-        scope: agent.scope,
-        reason,
-        sentAt: this.now(),
-      });
-    } catch (err) {
-      process.stderr.write(
-        `agent-presence-producer: createAgentOfflineEvent failed (agent=${agent.identity.agent_id}): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-      return;
-    }
-    try {
-      await this.runtime.publish(envelope);
-    } catch (err) {
-      process.stderr.write(
-        `agent-presence-producer: agent.offline publish failed (agent=${agent.identity.agent_id}): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    }
+    const sentAt = this.now();
+    // G-1114.E.1 — dual-emit local (+ federated when opted in) offline. Awaited
+    // (via Promise.allSettled) so the shutdown drain holds the bus open until
+    // BOTH copies have gone out — a peer's Network view depends on the federated
+    // `agent.offline` to drop the foreign agent promptly rather than waiting for
+    // its TTL reaper.
+    await Promise.allSettled(
+      this.dualEmit("agent.offline", agent.identity.agent_id, (classification) =>
+        createAgentOfflineEvent({
+          source: this.source,
+          identity: agent.identity,
+          scope: agent.scope,
+          reason,
+          sentAt,
+          classification,
+        }),
+      ),
+    );
   }
 }


### PR DESCRIPTION
Phase E of the Agent Network Topology umbrella (#355) — the **bus-federation TRUST-PATH core** for agent presence. Combines E.1 (opt-in federation policy) + E.2 (federated subscriber + provenance) + E.5 (signed_by[] trust verification). Per `docs/plan-agent-network-topology.md` §4.5 + ADR-0007 (this is the BUS-FEDERATION local-view half; ADR-0006 hosted push is separate).

## THE DESIGN-QUESTION FINDING (load-bearing)

**Does inbound `federated.{principal}.{stack}.agent.*` already pass through the surface-router's `evaluateFederationGate` + signed_by chain verification?**

**NO — for this consumer. Evidence:**
- The agent-presence registry is an **Option-D direct consumer**: it subscribes via `runtime.subscribe(pattern)` + `runtime.onEnvelope` (`src/bus/agent-network/registry.ts` `startAgentPresenceRegistry`), **not** through the surface-router.
- The surface-router's `evaluateFederationGate` runs **only** for envelopes the router fans to registered `SurfaceAdapter`s via `router.dispatch` (`src/bus/surface-router.ts`). The runtime's `onEnvelope` fan-out (`src/bus/myelin/runtime.ts`) delivers **every** inbound envelope to **every** handler **raw** — pre-gate, pre-verify.
- So a registry that merely widened its subscription to `federated.*.agent.>` would fold **unverified, ungated** foreign presence — a trust hole (any peer, accept-listed or not, signed or not, would appear in the Network view).

This is the **exact** situation the runner dispatch-listener faced at **cortex#484** ("Option D — executor, not renderer"): once it stopped registering as a SurfaceAdapter, the surface-router gate no longer covered it, so it grew its **own** inline `evaluateFederationGate` + `verifySignedByChain` + `resolveFederatedPeer`. This PR's federated subscriber **mirrors that established path** — it does **not** invent a parallel trust mechanism.

→ **Decision: explicit-verify (the "NO" branch).** The subscriber runs BOTH the federation accept-list gate AND signed_by[] chain verification before folding foreign presence. Documented in `federated-subscriber.ts` header.

## The opt-in mechanism (E.1)

Reuses the **existing federated-classification** lever — not a new toggle. The presence producer (`AgentPresenceProducer`) gains a `federate` flag (default OFF) that **dual-emits** a `classification: "federated"` copy of every `agent.*` envelope (deriving `federated.{principal}.{stack}.agent.*`) alongside the `local.*` copy. `cortex.ts` sets `federate: true` only when the stack opted into federation (`policy.federated.networks[]` non-empty) — the SAME opt-in gate the subscriber uses, mirroring how `dispatch.task.*` / `review.verdict.*` opt in via `classification: "federated"` (IAW Phase A.3). Default OFF ⇒ local-only presence, byte-identical to pre-E.

## Provenance model (E.2)

`AgentPresenceRecord` gains an `origin` field: `"local"` (the B.3 path, default) or `{ kind: "foreign"; principal; stack }`. `registry.applyForeign(envelope, {principal, stack})` folds a verified peer envelope, deriving provenance from the **authenticated source** (`envelope.source` segments — bound to a verified pubkey by the chain check, so a peer can't claim a different origin than it signed as). `removeForeign()` prunes all foreign records on federation teardown; local records survive.

## Security invariant (E.5)

Only **accept-listed + chain-verified** foreign presence folds. Two gates, in order (mirroring the dispatch-listener):
1. `evaluateFederationGate` — peer must resolve via `peers[]` membership; `accept_subjects`/`deny_subjects`/`max_hop` + F-3d leaf anti-spoof. A `system.access.denied` audit envelope is emitted on a drop.
2. `verifySignedByChain` (+ `resolveFederatedPeer`, wired only under `signing === "enforce"`) — forged bytes / unresolved peer / empty chain (rejectEmpty defaults to **true** for foreign presence) ⇒ **dropped**.

A foreign `agent.online` from a peer NOT in the accept-list, or failing the chain, **does not appear**.

## Sovereignty (ADR-0005/0007)

Foreign presence carries the **same** `agent.*` presence payload shape (identity, capabilities, liveness) — the schema has **no interior fields**, so tool-call/prompt/diff leakage is structurally impossible. Peers never send interiors; the registry never stores or exposes them.

## Security test plan

`src/bus/agent-network/__tests__/federated-subscriber.test.ts` (12 tests):
- **Opt-in:** no/empty networks ⇒ subscriber INERT (binds nothing, folds nothing); networks present ⇒ subscribes `federated.*.*.agent.>`.
- **Fold:** accept-listed peer's `agent.online` ⇒ folded, tagged foreign; local records unaffected.
- **TRUST (load-bearing):** peer NOT in `peers[]` ⇒ DROPPED + `system.access.denied`; denied subject ⇒ DROPPED; unresolvable signer ⇒ DROPPED; empty chain ⇒ DROPPED.
- **Subject filter:** a `local.*` presence envelope is ignored (B.3 owns local).
- **Teardown:** `stop()` removes foreign, keeps local; idempotent.

Plus producer opt-in tests (dual-emit local+federated; default local-only) and registry provenance tests (local vs foreign origin, `removeForeign`).

## Gates
- `bunx tsc --noEmit` clean
- `bun run lint` 0 errors (27 pre-existing warnings in untouched files)
- full `bun test` — **5749 pass / 0 fail**
- `scripts/check-carveouts.sh` PASS on changed files

refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)