### PR TITLE
feat(mc): G-1114.E.3+E.4 — federated agents in the Network view (multi-hub grouping + scope filter + foreign visuals)

### DIFF
--- a/src/surface/mc/__tests__/api-agents.test.ts
+++ b/src/surface/mc/__tests__/api-agents.test.ts
@@ -38,6 +38,7 @@ function rec(
   const { agentId } = over;
   return {
     key: `andreas/research/${agentId}`,
+    origin: "local",
     nkeyPublicKey: `N${agentId.toUpperCase()}`,
     assistantName: null,
     principal: "andreas",
@@ -143,6 +144,35 @@ describe("GET /api/agents", () => {
     expect(echo.offline_reason).toBe("graceful-shutdown");
     expect(echo.last_heartbeat_at).toBeNull();
     expect(echo.started_at).toBeNull();
+  });
+
+  it("exposes origin: a local agent as \"local\", a foreign agent as {principal,stack} (G-1114.E.4)", async () => {
+    const view: AgentPresenceView = {
+      getAgents: () => [
+        rec({ agentId: "luna", origin: "local" }),
+        rec({
+          // A federated peer agent: keyed + scoped under the peer's VERIFIED
+          // {principal}/{stack} (#914 source-bound identity).
+          agentId: "sage",
+          key: "jc/research/sage",
+          principal: "jc",
+          stack: "research",
+          origin: { kind: "foreign", principal: "jc", stack: "research" },
+        }),
+      ],
+    };
+    c = startWith(() => view);
+    const body = await (await fetch(`${c.baseUrl}/api/agents`)).json();
+
+    const luna = body.agents.find((a: { agent_id: string }) => a.agent_id === "luna");
+    // A local agent surfaces the bare "local" string (object-vs-string is the
+    // foreign discriminant on the wire).
+    expect(luna.origin).toBe("local");
+
+    const sage = body.agents.find((a: { agent_id: string }) => a.agent_id === "sage");
+    // A foreign agent flattens to {principal, stack} — the `kind` discriminant is
+    // dropped (object shape already discriminates foreign from local).
+    expect(sage.origin).toEqual({ principal: "jc", stack: "research" });
   });
 
   it("surfaces offline_reason for the inferred TTL lapse, and null while online (G-1114.C.4)", async () => {

--- a/src/surface/mc/api/agents.ts
+++ b/src/surface/mc/api/agents.ts
@@ -46,6 +46,13 @@ export interface AgentPresenceView {
  */
 export interface AgentPresenceSnapshotRecord {
   key: string;
+  /**
+   * G-1114.E.2 — record PROVENANCE. `"local"` for a stack-own agent (the B.3
+   * path); a `{kind:"foreign", principal, stack}` struct for a trust-verified
+   * federated peer agent (the E.2 path). The registry's `AgentRecordOrigin`
+   * assigns to this structurally — the surface layer never imports the bus type.
+   */
+  origin: "local" | { kind: "foreign"; principal: string; stack: string };
   agentId: string;
   nkeyPublicKey: string;
   assistantName: string | null;
@@ -59,10 +66,28 @@ export interface AgentPresenceSnapshotRecord {
   lastSeenAt: number;
 }
 
+/**
+ * G-1114.E.4 — an agent's federation provenance, snake_case for the DTO.
+ *
+ *   - `"local"` — a stack-own agent (the default; byte-identical to pre-E DTOs).
+ *   - `{ principal, stack }` — a trust-verified FOREIGN peer agent, carrying the
+ *     peer's chain-verified `{principal}/{stack}`. The object form IS the
+ *     "foreign" discriminant — a consumer reads `origin === "local"` vs an
+ *     object. The `{principal}/{stack}` here is the VERIFIED source identity
+ *     (PR #914), safe to render as provenance + group by.
+ */
+export type AgentOrigin = "local" | { principal: string; stack: string };
+
 /** One agent row in the `GET /api/agents` response. */
 export interface AgentPresenceTile {
   /** Stable registry key — `{principal}/{stack}/{agent_id}`. */
   key: string;
+  /**
+   * G-1114.E.4 — federation provenance: `"local"` for a stack-own agent, or the
+   * foreign peer's `{principal, stack}`. The Network view groups agents under
+   * their origin stack-hub and renders foreign agents distinctly off this.
+   */
+  origin: AgentOrigin;
   /** Logical agent id (`luna`, `echo`, …). */
   agent_id: string;
   /** Soma-layer assistant name the agent hosts, or `null`. */
@@ -92,10 +117,23 @@ export interface ListAgentsResponse {
   agents: AgentPresenceTile[];
 }
 
+/**
+ * Flatten the registry's `AgentRecordOrigin` (`"local"` |
+ * `{kind:"foreign",principal,stack}`) into the DTO `AgentOrigin` (`"local"` |
+ * `{principal,stack}`). The `kind` discriminant is dropped — the object-vs-string
+ * shape already discriminates foreign from local on the wire.
+ */
+function toOrigin(origin: AgentPresenceSnapshotRecord["origin"]): AgentOrigin {
+  return origin === "local"
+    ? "local"
+    : { principal: origin.principal, stack: origin.stack };
+}
+
 /** Project one registry record into the snake_case API DTO. */
 function toTile(r: AgentPresenceSnapshotRecord): AgentPresenceTile {
   return {
     key: r.key,
+    origin: toOrigin(r.origin),
     agent_id: r.agentId,
     assistant_name: r.assistantName,
     nkey_public_key: r.nkeyPublicKey,

--- a/src/surface/mc/dashboard-v2/__tests__/agents-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/agents-display.test.ts
@@ -22,6 +22,7 @@ import type { AgentPresenceTile } from "../hooks/use-agents";
 function tile(): AgentPresenceTile {
   return {
     key: "andreas/research/luna",
+    origin: "local",
     agent_id: "luna",
     assistant_name: "Luna",
     nkey_public_key: "NLUNA",

--- a/src/surface/mc/dashboard-v2/__tests__/network-detail-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-detail-display.test.ts
@@ -23,6 +23,7 @@ function tile(
   const { agent_id } = over;
   return {
     key: `andreas/research/${agent_id}`,
+    origin: "local",
     assistant_name: null,
     nkey_public_key: `N${agent_id}`,
     principal: "andreas",

--- a/src/surface/mc/dashboard-v2/__tests__/network-detail-panel.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-detail-panel.test.tsx
@@ -22,6 +22,7 @@ function tile(
   const { agent_id } = over;
   return {
     key: `andreas/research/${agent_id}`,
+    origin: "local",
     assistant_name: null,
     nkey_public_key: `N${agent_id}`,
     principal: "andreas",

--- a/src/surface/mc/dashboard-v2/__tests__/network-filter-bar.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-filter-bar.test.tsx
@@ -21,6 +21,7 @@ function render(over: Partial<NetworkFilterBarProps> = {}): string {
     capabilityOptions: ["moderate", "review.code"],
     onStateChange: () => {},
     onCapabilityChange: () => {},
+    onScopeChange: () => {},
     onClear: () => {},
     onOpenSpotlight: () => {},
     ...over,
@@ -37,7 +38,7 @@ describe("NetworkFilterBar — state toggle (G-1114.D.5)", () => {
   });
 
   it("marks the active state with aria-pressed", () => {
-    const html = render({ filter: { state: "online", capability: null } });
+    const html = render({ filter: { state: "online", capability: null, scope: "include-federated" } });
     // The online button is pressed; all is not.
     expect(html).toContain('aria-pressed="true" data-state-filter="online"');
     expect(html).not.toContain('aria-pressed="true" data-state-filter="all"');
@@ -58,9 +59,46 @@ describe("NetworkFilterBar — capability dropdown (G-1114.D.5)", () => {
   });
 
   it("marks the selected capability", () => {
-    const html = render({ filter: { state: "all", capability: "review.code" } });
+    const html = render({ filter: { state: "all", capability: "review.code", scope: "include-federated" } });
     // react-dom serialises a controlled <select value> via the matching option's selected attr.
     expect(html).toContain('value="review.code" selected');
+  });
+});
+
+describe("NetworkFilterBar — scope toggle (G-1114.E.4)", () => {
+  it("renders both scope options", () => {
+    const html = render();
+    expect(html).toContain('data-scope-filter="include-federated"');
+    expect(html).toContain('data-scope-filter="local-only"');
+  });
+
+  it("marks 'include-federated' pressed by default", () => {
+    const html = render();
+    expect(html).toContain(
+      'aria-pressed="true" data-scope-filter="include-federated"',
+    );
+    expect(html).not.toContain(
+      'aria-pressed="true" data-scope-filter="local-only"',
+    );
+  });
+
+  it("marks 'local-only' pressed when scope is local-only", () => {
+    const html = render({
+      filter: { state: "all", capability: null, scope: "local-only" },
+    });
+    expect(html).toContain(
+      'aria-pressed="true" data-scope-filter="local-only"',
+    );
+    expect(html).not.toContain(
+      'aria-pressed="true" data-scope-filter="include-federated"',
+    );
+  });
+
+  it("shows Clear when scope narrows to local-only", () => {
+    const html = render({
+      filter: { state: "all", capability: null, scope: "local-only" },
+    });
+    expect(html).toContain("network-filter-clear");
   });
 });
 
@@ -71,13 +109,13 @@ describe("NetworkFilterBar — clear affordance (G-1114.D.5)", () => {
   });
 
   it("shows Clear when a state filter is active", () => {
-    const html = render({ filter: { state: "online", capability: null } });
+    const html = render({ filter: { state: "online", capability: null, scope: "include-federated" } });
     expect(html).toContain("network-filter-clear");
     expect(html).toContain("Clear filters");
   });
 
   it("shows Clear when a capability filter is active", () => {
-    const html = render({ filter: { state: "all", capability: "moderate" } });
+    const html = render({ filter: { state: "all", capability: "moderate", scope: "include-federated" } });
     expect(html).toContain("network-filter-clear");
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from "bun:test";
 import {
   buildNetworkGraph,
   STACK_HUB_NODE_ID,
+  FOREIGN_HUB_ID_PREFIX,
   type AgentNodeData,
   type StackHubNodeData,
 } from "../lib/network-graph-adapter";
@@ -22,6 +23,7 @@ function tile(
   const { agent_id } = over;
   return {
     key: `andreas/research/${agent_id}`,
+    origin: "local",
     assistant_name: null,
     nkey_public_key: `N${agent_id.toUpperCase()}`,
     principal: "andreas",
@@ -34,6 +36,24 @@ function tile(
     last_seen_at: 1000,
     ...over,
   };
+}
+
+/** A FOREIGN (federated peer) tile — keyed + scoped under the peer's verified id. */
+function foreignTile(
+  over: Partial<AgentPresenceTile> & {
+    agent_id: string;
+    principal: string;
+    stack: string;
+  },
+): AgentPresenceTile {
+  const { agent_id, principal, stack } = over;
+  return tile({
+    ...over,
+    key: `${principal}/${stack}/${agent_id}`,
+    principal,
+    stack,
+    origin: { principal, stack },
+  });
 }
 
 describe("buildNetworkGraph (G-1114.D.2)", () => {
@@ -50,6 +70,7 @@ describe("buildNetworkGraph (G-1114.D.2)", () => {
     expect(hub!.type).toBe("stackHub");
     const data = hub!.data as StackHubNodeData;
     expect(data.kind).toBe("stack-hub");
+    expect(data.origin).toBe("local");
     expect(data.principal).toBe("andreas");
     expect(data.stack).toBe("research");
     expect(data.agentCount).toBe(1);
@@ -122,9 +143,12 @@ describe("buildNetworkGraph (G-1114.D.2)", () => {
         "kind",
         "lastHeartbeatAt",
         "offlineReason",
+        "origin",
         "state",
       ].sort(),
     );
+    // The local agent carries the bare "local" origin.
+    expect(d.origin).toBe("local");
   });
 
   it("carries the offline reason for a TTL-lapsed agent", () => {
@@ -156,5 +180,97 @@ describe("buildNetworkGraph (G-1114.D.2)", () => {
     const g = buildNetworkGraph([tile({ agent_id: "luna" })]);
     expect(g.nodes[0]!.id).toBe(STACK_HUB_NODE_ID);
     expect(STACK_HUB_NODE_ID).toBe("__stack__");
+  });
+});
+
+describe("buildNetworkGraph — federated multi-hub grouping (G-1114.E.3)", () => {
+  it("lays out a LOCAL-only snapshot byte-identically to Phase D (one hub)", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      tile({ agent_id: "echo" }),
+    ]);
+    const hubs = g.nodes.filter((n) => n.type === "stackHub");
+    expect(hubs).toHaveLength(1);
+    expect(hubs[0]!.id).toBe(STACK_HUB_NODE_ID);
+    expect((hubs[0]!.data as StackHubNodeData).origin).toBe("local");
+    // every edge sourced from the single local hub
+    for (const e of g.edges) expect(e.source).toBe(STACK_HUB_NODE_ID);
+  });
+
+  it("synthesises one hub per distinct foreign {principal}/{stack}, plus the local hub", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+      foreignTile({ agent_id: "atlas", principal: "jc", stack: "research" }),
+      foreignTile({ agent_id: "nova", principal: "kim", stack: "ops" }),
+    ]);
+    const hubs = g.nodes.filter((n) => n.type === "stackHub");
+    // local + jc/research + kim/ops = 3 hubs
+    expect(hubs).toHaveLength(3);
+    const hubIds = hubs.map((h) => h.id);
+    expect(hubIds).toContain(STACK_HUB_NODE_ID);
+    expect(hubIds).toContain(`${FOREIGN_HUB_ID_PREFIX}jc/research`);
+    expect(hubIds).toContain(`${FOREIGN_HUB_ID_PREFIX}kim/ops`);
+  });
+
+  it("clusters each agent under ITS OWN stack's hub (origin-grouped edges)", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+      foreignTile({ agent_id: "nova", principal: "kim", stack: "ops" }),
+    ]);
+    const edgeFor = (key: string) => g.edges.find((e) => e.target === key)!;
+    expect(edgeFor("andreas/research/luna").source).toBe(STACK_HUB_NODE_ID);
+    expect(edgeFor("jc/research/sage").source).toBe(
+      `${FOREIGN_HUB_ID_PREFIX}jc/research`,
+    );
+    expect(edgeFor("kim/ops/nova").source).toBe(
+      `${FOREIGN_HUB_ID_PREFIX}kim/ops`,
+    );
+  });
+
+  it("tags each foreign hub with its peer provenance + agent count", () => {
+    const g = buildNetworkGraph([
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+      foreignTile({ agent_id: "atlas", principal: "jc", stack: "research" }),
+    ]);
+    const hub = g.nodes.find(
+      (n) => n.id === `${FOREIGN_HUB_ID_PREFIX}jc/research`,
+    )!;
+    const d = hub.data as StackHubNodeData;
+    expect(d.origin).toEqual({ principal: "jc", stack: "research" });
+    expect(d.principal).toBe("jc");
+    expect(d.stack).toBe("research");
+    expect(d.agentCount).toBe(2);
+  });
+
+  it("carries the foreign provenance onto each foreign agent's node data", () => {
+    const g = buildNetworkGraph([
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+    ]);
+    const d = g.nodes.find((n) => n.type === "agent")!.data as AgentNodeData;
+    expect(d.origin).toEqual({ principal: "jc", stack: "research" });
+  });
+
+  it("emits the LOCAL hub first even when a foreign agent leads the snapshot", () => {
+    const g = buildNetworkGraph([
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+      tile({ agent_id: "luna" }),
+    ]);
+    const firstHub = g.nodes.find((n) => n.type === "stackHub")!;
+    expect(firstHub.id).toBe(STACK_HUB_NODE_ID);
+  });
+
+  it("handles a foreign-ONLY snapshot (no local hub) without error", () => {
+    const g = buildNetworkGraph([
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+    ]);
+    const hubs = g.nodes.filter((n) => n.type === "stackHub");
+    expect(hubs).toHaveLength(1);
+    expect(hubs[0]!.id).toBe(`${FOREIGN_HUB_ID_PREFIX}jc/research`);
+  });
+
+  it("returns an empty graph for an empty snapshot (federated path too)", () => {
+    expect(buildNetworkGraph([])).toEqual({ nodes: [], edges: [] });
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-filter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-filter.test.ts
@@ -24,6 +24,7 @@ function tile(
   const { agent_id } = over;
   return {
     key: `andreas/research/${agent_id}`,
+    origin: "local",
     assistant_name: null,
     nkey_public_key: `N${agent_id}`,
     principal: "andreas",
@@ -65,44 +66,44 @@ describe("filterAgents — state filter (G-1114.D.5)", () => {
   });
 
   it("'all' state passes online and offline alike", () => {
-    const out = filterAgents(all, { state: "all", capability: null });
+    const out = filterAgents(all, { state: "all", capability: null, scope: "include-federated" });
     expect(out).toHaveLength(3);
   });
 
   it("'online' keeps only online agents", () => {
-    const out = filterAgents(all, { state: "online", capability: null });
+    const out = filterAgents(all, { state: "online", capability: null, scope: "include-federated" });
     expect(out.map((a) => a.agent_id)).toEqual(["luna", "echo"]);
   });
 
   it("'offline' keeps only offline agents", () => {
-    const out = filterAgents(all, { state: "offline", capability: null });
+    const out = filterAgents(all, { state: "offline", capability: null, scope: "include-federated" });
     expect(out.map((a) => a.agent_id)).toEqual(["sage"]);
   });
 
   it("preserves snapshot order (deterministic layout input)", () => {
-    const out = filterAgents([echo, luna, sage], { state: "online", capability: null });
+    const out = filterAgents([echo, luna, sage], { state: "online", capability: null, scope: "include-federated" });
     expect(out.map((a) => a.agent_id)).toEqual(["echo", "luna"]);
   });
 });
 
 describe("filterAgents — capability filter (G-1114.D.5)", () => {
   it("null capability passes every agent", () => {
-    const out = filterAgents(all, { state: "all", capability: null });
+    const out = filterAgents(all, { state: "all", capability: null, scope: "include-federated" });
     expect(out).toHaveLength(3);
   });
 
   it("keeps only agents declaring the chosen capability", () => {
-    const out = filterAgents(all, { state: "all", capability: "review.code" });
+    const out = filterAgents(all, { state: "all", capability: "review.code", scope: "include-federated" });
     expect(out.map((a) => a.agent_id)).toEqual(["luna", "echo"]);
   });
 
   it("returns an empty result when no agent declares the capability", () => {
-    const out = filterAgents(all, { state: "all", capability: "deploy" });
+    const out = filterAgents(all, { state: "all", capability: "deploy", scope: "include-federated" });
     expect(out).toEqual([]);
   });
 
   it("a capability declared by exactly one agent narrows to that agent", () => {
-    const out = filterAgents(all, { state: "all", capability: "moderate" });
+    const out = filterAgents(all, { state: "all", capability: "moderate", scope: "include-federated" });
     expect(out.map((a) => a.agent_id)).toEqual(["sage"]);
   });
 });
@@ -110,30 +111,30 @@ describe("filterAgents — capability filter (G-1114.D.5)", () => {
 describe("filterAgents — combined state + capability (G-1114.D.5)", () => {
   it("applies both filters (AND)", () => {
     // online AND review.code → luna, echo (sage is offline; sage lacks review.code anyway)
-    const out = filterAgents(all, { state: "online", capability: "review.code" });
+    const out = filterAgents(all, { state: "online", capability: "review.code", scope: "include-federated" });
     expect(out.map((a) => a.agent_id)).toEqual(["luna", "echo"]);
   });
 
   it("can produce an empty result from the intersection", () => {
     // offline AND review.code → none (sage is offline but only has 'moderate')
-    const out = filterAgents(all, { state: "offline", capability: "review.code" });
+    const out = filterAgents(all, { state: "offline", capability: "review.code", scope: "include-federated" });
     expect(out).toEqual([]);
   });
 
   it("offline AND moderate → sage", () => {
-    const out = filterAgents(all, { state: "offline", capability: "moderate" });
+    const out = filterAgents(all, { state: "offline", capability: "moderate", scope: "include-federated" });
     expect(out.map((a) => a.agent_id)).toEqual(["sage"]);
   });
 });
 
 describe("filterAgents — edge cases (G-1114.D.5)", () => {
   it("an empty snapshot yields an empty result for any filter", () => {
-    expect(filterAgents([], { state: "online", capability: "review.code" })).toEqual([]);
+    expect(filterAgents([], { state: "online", capability: "review.code", scope: "include-federated" })).toEqual([]);
   });
 
   it("does not mutate the input array", () => {
     const input = [...all];
-    filterAgents(input, { state: "online", capability: null });
+    filterAgents(input, { state: "online", capability: null, scope: "include-federated" });
     expect(input).toEqual(all);
   });
 });
@@ -168,10 +169,10 @@ describe("isFilterActive (G-1114.D.5)", () => {
   });
 
   it("is true when a state filter is set", () => {
-    expect(isFilterActive({ state: "online", capability: null })).toBe(true);
+    expect(isFilterActive({ state: "online", capability: null, scope: "include-federated" })).toBe(true);
   });
 
   it("is true when a capability filter is set", () => {
-    expect(isFilterActive({ state: "all", capability: "review.code" })).toBe(true);
+    expect(isFilterActive({ state: "all", capability: "review.code", scope: "include-federated" })).toBe(true);
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
@@ -29,6 +29,7 @@ function tile(
   const { agent_id } = over;
   return {
     key: `andreas/research/${agent_id}`,
+    origin: "local",
     assistant_name: null,
     nkey_public_key: `N${agent_id}`,
     principal: "andreas",
@@ -41,6 +42,24 @@ function tile(
     last_seen_at: 1000,
     ...over,
   };
+}
+
+/** A FOREIGN tile under a peer's verified {principal}/{stack}. */
+function foreignTile(
+  over: Partial<AgentPresenceTile> & {
+    agent_id: string;
+    principal: string;
+    stack: string;
+  },
+): AgentPresenceTile {
+  const { agent_id, principal, stack } = over;
+  return tile({
+    ...over,
+    key: `${principal}/${stack}/${agent_id}`,
+    principal,
+    stack,
+    origin: { principal, stack },
+  });
 }
 
 describe("toElkGraph (G-1114.D.3)", () => {
@@ -72,8 +91,27 @@ describe("toElkGraph (G-1114.D.3)", () => {
     }
   });
 
-  it("uses the radial algorithm (star around the hub)", () => {
-    expect(NETWORK_ELK_OPTIONS["elk.algorithm"]).toContain("radial");
+  it("uses the force algorithm with component separation (multi-cluster stars)", () => {
+    // E.3: several disconnected stack-clusters (local + each peer) — force +
+    // separateConnectedComponents lays each out as its own group rather than
+    // forcing a single radial root.
+    expect(NETWORK_ELK_OPTIONS["elk.algorithm"]).toContain("force");
+    expect(NETWORK_ELK_OPTIONS["elk.separateConnectedComponents"]).toBe("true");
+  });
+
+  it("maps a multi-stack graph into ELK children + per-cluster edges (E.3)", () => {
+    const graph = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+    ]);
+    const elk = toElkGraph(graph);
+    // 2 hubs (local + jc/research) + 2 agents = 4 children
+    expect(elk.children).toHaveLength(4);
+    // 2 edges, each sourced from its own cluster's hub (disconnected components)
+    expect(elk.edges).toHaveLength(2);
+    const sources = elk.edges.flatMap((e) => e.sources).sort();
+    expect(sources).toContain(STACK_HUB_NODE_ID);
+    expect(sources).toContain("__stack__:jc/research");
   });
 });
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
@@ -29,6 +29,7 @@ function agentData(over: Partial<AgentNodeData> = {}): AgentNodeData {
   return {
     kind: "agent",
     key: "andreas/research/luna",
+    origin: "local",
     agentId: "luna",
     assistantName: "Luna",
     capabilities: [],
@@ -134,6 +135,7 @@ describe("StackHubCard (G-1114.D.1)", () => {
   it("renders the principal/stack label and agent count", () => {
     const html = renderHub({
       kind: "stack-hub",
+      origin: "local",
       principal: "andreas",
       stack: "research",
       agentCount: 3,
@@ -146,6 +148,7 @@ describe("StackHubCard (G-1114.D.1)", () => {
   it("singularises the agent count for a single agent", () => {
     const html = renderHub({
       kind: "stack-hub",
+      origin: "local",
       principal: "andreas",
       stack: "research",
       agentCount: 1,
@@ -157,11 +160,67 @@ describe("StackHubCard (G-1114.D.1)", () => {
   it("degrades to a 'stack' label when principal/stack are unknown", () => {
     const html = renderHub({
       kind: "stack-hub",
+      origin: "local",
       principal: null,
       stack: null,
       agentCount: 0,
     });
     expect(html).toContain("stack");
+  });
+
+  it("marks the LOCAL hub distinctly from a federated hub (E.4)", () => {
+    const html = renderHub({
+      kind: "stack-hub",
+      origin: "local",
+      principal: "andreas",
+      stack: "research",
+      agentCount: 2,
+    });
+    expect(html).toContain('data-hub-origin="local"');
+    expect(html).toContain("network-node-hub-local");
+    expect(html).not.toContain("network-node-hub-foreign");
+    // a local hub's eyebrow is plain "stack", not "federated stack"
+    expect(html).not.toContain("federated stack");
+  });
+
+  it("renders a FOREIGN hub with the federated eyebrow + distinct treatment (E.4)", () => {
+    const html = renderHub({
+      kind: "stack-hub",
+      origin: { principal: "jc", stack: "research" },
+      principal: "jc",
+      stack: "research",
+      agentCount: 1,
+    });
+    expect(html).toContain('data-hub-origin="foreign"');
+    expect(html).toContain("network-node-hub-foreign");
+    expect(html).toContain("federated stack");
+    expect(html).toContain("jc/research");
+  });
+});
+
+describe("AgentNodeCard — federated provenance (G-1114.E.4)", () => {
+  it("renders a local agent with no provenance badge + a local origin marker", () => {
+    const html = renderAgent(agentData({ origin: "local" }));
+    expect(html).toContain('data-agent-origin="local"');
+    expect(html).not.toContain("network-node-foreign");
+    expect(html).not.toContain("network-node-provenance");
+  });
+
+  it("renders a FOREIGN agent distinctly with a `{principal}/{stack}` provenance badge", () => {
+    const html = renderAgent(
+      agentData({
+        key: "jc/research/sage",
+        agentId: "sage",
+        assistantName: "Sage",
+        origin: { principal: "jc", stack: "research" },
+      }),
+    );
+    expect(html).toContain('data-agent-origin="foreign"');
+    expect(html).toContain("network-node-foreign");
+    expect(html).toContain("network-node-provenance");
+    expect(html).toContain("jc/research");
+    // accessible label names it a federated peer
+    expect(html).toContain("federated peer jc/research");
   });
 });
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-spotlight-overlay.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-spotlight-overlay.test.tsx
@@ -27,6 +27,7 @@ function tile(
   const { agent_id } = over;
   return {
     key: `andreas/research/${agent_id}`,
+    origin: "local",
     assistant_name: null,
     nkey_public_key: `N${agent_id}`,
     principal: "andreas",

--- a/src/surface/mc/dashboard-v2/__tests__/network-spotlight.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-spotlight.test.ts
@@ -21,6 +21,7 @@ function tile(
   const { agent_id } = over;
   return {
     key: `andreas/research/${agent_id}`,
+    origin: "local",
     assistant_name: null,
     nkey_public_key: `N${agent_id}`,
     principal: "andreas",

--- a/src/surface/mc/dashboard-v2/__tests__/network-view.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-view.test.tsx
@@ -29,6 +29,7 @@ function tile(
   const { agent_id } = over;
   return {
     key: `andreas/research/${agent_id}`,
+    origin: "local",
     assistant_name: null,
     nkey_public_key: `N${agent_id}`,
     principal: "andreas",

--- a/src/surface/mc/dashboard-v2/components/network-detail-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-detail-panel.tsx
@@ -34,6 +34,8 @@ import {
   formatCapabilities,
   offlineReasonLabel,
   isTtlLapse,
+  isForeignOrigin,
+  originProvenanceLabel,
 } from "../lib/agents-display";
 import type { AgentPresenceTile } from "../hooks/use-agents";
 import type { AgentDispatchActivity } from "../lib/network-detail-display";
@@ -80,20 +82,35 @@ export function NetworkDetailPanel({
   const reasonLabel = offline ? offlineReasonLabel(agent.offline_reason) : null;
   const name = agent.assistant_name ?? agent.agent_id;
   const caps = formatCapabilities(agent.capabilities);
+  // E.4: a FOREIGN (federated peer) agent shows its origin + a "activity not
+  // local" note instead of a dispatch join (#909 — working-agents is local-only).
+  const foreign = isForeignOrigin(agent.origin);
+  const provenance = originProvenanceLabel(agent.origin);
 
   return (
     <aside
       className={
-        "network-detail-panel" + (ttlLapse ? " network-detail-ttl-lapse" : "")
+        "network-detail-panel" +
+        (ttlLapse ? " network-detail-ttl-lapse" : "") +
+        (foreign ? " network-detail-foreign" : "")
       }
       data-agent-id={agent.agent_id}
       data-state={agent.state}
+      data-agent-origin={foreign ? "foreign" : "local"}
       aria-label={`Agent detail — ${name}`}
     >
       <header className="network-detail-header">
         <div className="network-detail-identity">
           <span className="network-detail-name">{name}</span>
           <span className="network-detail-id dim">{agent.agent_id}</span>
+          {foreign && provenance && (
+            <span className="network-detail-provenance" title={`federated peer — ${provenance}`}>
+              <span className="network-detail-federated-badge" aria-hidden="true">
+                ⇄
+              </span>
+              federated peer · {provenance}
+            </span>
+          )}
         </div>
         <button
           type="button"
@@ -153,10 +170,18 @@ export function NetworkDetailPanel({
         </div>
       </section>
 
-      {/* Dispatch lifecycle (LIGHT — pointer only, never interiors) --------- */}
+      {/* Dispatch lifecycle (LIGHT — pointer only, never interiors) ---------
+          E.4 / #909: a FOREIGN peer agent shows NO local dispatch activity —
+          working-agents is the LOCAL stack's projection, never joined for a
+          foreign agent. The principal sees that the activity simply isn't local,
+          not an empty "idle" that would misrepresent a busy peer. */}
       <section className="network-detail-section network-detail-activity">
         <span className="network-detail-section-label dim">recent activity</span>
-        {dispatch ? (
+        {foreign ? (
+          <span className="network-detail-foreign-activity dim">
+            Federated peer — activity not local.
+          </span>
+        ) : dispatch ? (
           <div className="network-detail-dispatch">
             <div className="network-detail-dispatch-line">
               <span
@@ -185,7 +210,9 @@ export function NetworkDetailPanel({
             No active dispatch.
           </span>
         )}
-        {onViewInWorkingGrid && (
+        {/* The working grid is the LOCAL stack's dispatch surface — the pointer
+            is meaningless for a foreign peer agent (#909), so it's hidden. */}
+        {!foreign && onViewInWorkingGrid && (
           <button
             type="button"
             className="network-detail-grid-link"

--- a/src/surface/mc/dashboard-v2/components/network-filter-bar.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-filter-bar.tsx
@@ -20,12 +20,19 @@ import {
   isFilterActive,
   type NetworkFilterState,
   type NetworkStateFilter,
+  type NetworkScopeFilter,
 } from "../lib/network-graph-filter";
 
 const STATE_OPTIONS: readonly { value: NetworkStateFilter; label: string }[] = [
   { value: "all", label: "All" },
   { value: "online", label: "Online" },
   { value: "offline", label: "Offline" },
+];
+
+// E.4 — the scope toggle: show federated peers, or focus on this stack only.
+const SCOPE_OPTIONS: readonly { value: NetworkScopeFilter; label: string }[] = [
+  { value: "include-federated", label: "All stacks" },
+  { value: "local-only", label: "This stack" },
 ];
 
 export interface NetworkFilterBarProps {
@@ -35,6 +42,8 @@ export interface NetworkFilterBarProps {
   onStateChange: (state: NetworkStateFilter) => void;
   /** `null` clears the capability filter (the "Any capability" option). */
   onCapabilityChange: (capability: string | null) => void;
+  /** E.4 — flip federation scope (include foreign peers vs this stack only). */
+  onScopeChange: (scope: NetworkScopeFilter) => void;
   onClear: () => void;
   /** Open the Cmd+K spotlight (the hint button is also a click target). */
   onOpenSpotlight: () => void;
@@ -45,6 +54,7 @@ export function NetworkFilterBar({
   capabilityOptions,
   onStateChange,
   onCapabilityChange,
+  onScopeChange,
   onClear,
   onOpenSpotlight,
 }: NetworkFilterBarProps) {
@@ -63,6 +73,25 @@ export function NetworkFilterBar({
               aria-pressed={on}
               data-state-filter={opt.value}
               onClick={() => onStateChange(opt.value)}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="network-filter-group" role="group" aria-label="Federation scope filter">
+        <span className="network-filter-label">Scope</span>
+        {SCOPE_OPTIONS.map((opt) => {
+          const on = filter.scope === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              className={`network-filter-scope-btn${on ? " on" : ""}`}
+              aria-pressed={on}
+              data-scope-filter={opt.value}
+              onClick={() => onScopeChange(opt.value)}
             >
               {opt.label}
             </button>

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -28,6 +28,8 @@ import {
   formatCapabilities,
   offlineReasonLabel,
   isTtlLapse,
+  isForeignOrigin,
+  originProvenanceLabel,
 } from "../lib/agents-display";
 import type {
   AgentNodeData,
@@ -46,9 +48,21 @@ export function StackHubCard({ data }: StackHubCardProps) {
     data.principal && data.stack
       ? `${data.principal}/${data.stack}`
       : (data.stack ?? data.principal ?? "stack");
+  // E.4: a FOREIGN (federated peer) hub renders distinctly from YOUR local hub —
+  // a "federated" eyebrow + a dimmer/bordered treatment via the modifier class.
+  const foreign = isForeignOrigin(data.origin);
   return (
-    <div className="network-node network-node-hub" data-node-kind="stack-hub">
-      <span className="network-hub-eyebrow dim">stack</span>
+    <div
+      className={
+        "network-node network-node-hub" +
+        (foreign ? " network-node-hub-foreign" : " network-node-hub-local")
+      }
+      data-node-kind="stack-hub"
+      data-hub-origin={foreign ? "foreign" : "local"}
+    >
+      <span className="network-hub-eyebrow dim">
+        {foreign ? "federated stack" : "stack"}
+      </span>
       <span className="network-hub-label">{label}</span>
       <span className="network-hub-count dim">
         {data.agentCount} agent{data.agentCount === 1 ? "" : "s"}
@@ -85,22 +99,40 @@ export function AgentNodeCard({ data, now = Date.now() }: AgentNodeCardProps) {
   const ttlLapse = offline && isTtlLapse(data.offlineReason);
   const reasonLabel = offline ? offlineReasonLabel(data.offlineReason) : null;
   const name = data.assistantName ?? data.agentId;
+  // E.4: a FOREIGN agent renders distinctly — a "federated" border/dimmer
+  // treatment (modifier class) + a provenance badge (`jc/research`) showing where
+  // the peer agent actually lives.
+  const foreign = isForeignOrigin(data.origin);
+  const provenance = originProvenanceLabel(data.origin);
 
   return (
     <div
       className={
         `network-node network-node-agent network-node-${data.state}` +
-        (ttlLapse ? " network-node-ttl-lapse" : "")
+        (ttlLapse ? " network-node-ttl-lapse" : "") +
+        (foreign ? " network-node-foreign" : "")
       }
       data-node-kind="agent"
       data-agent-id={data.agentId}
       data-state={data.state}
+      data-agent-origin={foreign ? "foreign" : "local"}
       data-offline-reason={offline ? (data.offlineReason ?? "") : undefined}
-      aria-label={`${name} — ${offline ? `offline (${reasonLabel})` : "online"}`}
+      aria-label={
+        `${name} — ${offline ? `offline (${reasonLabel})` : "online"}` +
+        (provenance ? ` — federated peer ${provenance}` : "")
+      }
     >
       <div className="network-node-identity">
         <span className="network-node-name">{name}</span>
         <span className="network-node-id dim">{data.agentId}</span>
+        {foreign && provenance && (
+          <span className="network-node-provenance" title={`federated peer — ${provenance}`}>
+            <span className="network-node-federated-badge" aria-hidden="true">
+              ⇄
+            </span>
+            {provenance}
+          </span>
+        )}
       </div>
 
       <div className="network-node-caps">

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -198,9 +198,9 @@ export function NetworkView({
     <section className="scaffold-section network-view" aria-label="Network (agent topology)">
       <h2>Network</h2>
       <p className="dim network-view-subtitle">
-        Stack-local agent <strong>topology</strong> — the agents on this stack,
-        their declared capabilities, and their liveness, laid out around the
-        stack hub. Cross-stack federated peers arrive in G-1114.E.
+        Agent <strong>topology</strong> — the agents on this stack and any
+        federated peers, their declared capabilities, and their liveness, laid
+        out around each stack&rsquo;s hub. Filter by scope to focus on this stack.
       </p>
 
       {mode === "error" && (

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -42,6 +42,7 @@ import {
   filterAgents,
   type NetworkFilterState,
   type NetworkStateFilter,
+  type NetworkScopeFilter,
 } from "../lib/network-graph-filter";
 import { isSpotlightOpenChord } from "../lib/network-spotlight";
 import { NetworkDetailPanel } from "./network-detail-panel";
@@ -103,6 +104,13 @@ export function NetworkView({
   );
   const onCapabilityChange = useCallback(
     (cap: string | null) => setFilter((f) => ({ ...f, capability: cap })),
+    [],
+  );
+  // E.4 — scope toggle: include-federated (show local + foreign) vs local-only
+  // (hide every foreign peer agent). Threads onto the SAME filter the adapter +
+  // spotlight read, so flipping it cleanly removes/restores foreign agents.
+  const onScopeChange = useCallback(
+    (scope: NetworkScopeFilter) => setFilter((f) => ({ ...f, scope })),
     [],
   );
   const onClearFilters = useCallback(() => setFilter(DEFAULT_NETWORK_FILTER), []);
@@ -211,6 +219,7 @@ export function NetworkView({
             capabilityOptions={capabilityOptions}
             onStateChange={onStateChange}
             onCapabilityChange={onCapabilityChange}
+            onScopeChange={onScopeChange}
             onClear={onClearFilters}
             onOpenSpotlight={openSpotlight}
           />

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -125,9 +125,14 @@ export function NetworkView({
     }
   }, [selectedKey, selectedAgent]);
 
+  // D.4 + #909: join the LOCAL working-agents projection ONLY for a LOCAL agent.
+  // A foreign peer agent's dispatch activity lives on ITS stack, not ours — the
+  // working-agents projection is this stack's, so joining it for a foreign agent
+  // would be wrong (and could false-match a same-named local agent_id). Foreign →
+  // null; the detail panel renders "federated peer — activity not local".
   const dispatch = useMemo(
     () =>
-      selectedAgent
+      selectedAgent && selectedAgent.origin === "local"
         ? selectAgentDispatchActivity(workingAgents, selectedAgent.agent_id)
         : null,
     [workingAgents, selectedAgent],

--- a/src/surface/mc/dashboard-v2/hooks/use-agents.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-agents.ts
@@ -26,7 +26,7 @@ import { ApiFailure, getJson } from "../lib/api";
 import type { AgentPresenceTile, ListAgentsResponse } from "../../api/agents";
 import type { WsClient, WsMessage } from "./use-websocket";
 
-export type { AgentPresenceTile } from "../../api/agents";
+export type { AgentPresenceTile, AgentOrigin } from "../../api/agents";
 
 export interface AgentsState {
   agents: AgentPresenceTile[];

--- a/src/surface/mc/dashboard-v2/lib/agents-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/agents-display.ts
@@ -5,7 +5,29 @@
  * selection) is unit-testable without a DOM, mirroring `working-grid-display.ts`.
  */
 
-import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { AgentPresenceTile, AgentOrigin } from "../hooks/use-agents";
+
+/**
+ * G-1114.E.4 — true when an origin is a FOREIGN (federated peer) provenance.
+ * A thin guard so view code reads `isForeignOrigin(origin)` rather than
+ * re-checking the `"local"`-string-vs-object discriminant. Mirrors the bus-side
+ * `isForeignOrigin`, re-declared here so the surface layer stays bus-free.
+ */
+export function isForeignOrigin(
+  origin: AgentOrigin,
+): origin is { principal: string; stack: string } {
+  return origin !== "local";
+}
+
+/**
+ * G-1114.E.4 — the provenance label for a foreign agent / hub: `{principal}/{stack}`
+ * (e.g. `jc/research`). `null` for a local origin (local nodes carry no foreign
+ * provenance badge). Used by the node cards + the detail panel to render where a
+ * federated peer agent actually lives.
+ */
+export function originProvenanceLabel(origin: AgentOrigin): string | null {
+  return origin === "local" ? null : `${origin.principal}/${origin.stack}`;
+}
 
 /** Panel render mode, selected from load/error/data state. */
 export type AgentsPanelMode = "error" | "loading" | "empty" | "list";

--- a/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
@@ -1,5 +1,6 @@
 /**
  * G-1114.D.2 — graph data adapter (registry snapshot → React Flow graph).
+ * G-1114.E.3 — + FEDERATED multi-hub grouping by verified origin.
  *
  * Pure projection from the agents-panel snapshot (`AgentPresenceTile[]`, the
  * same data `useAgents` feeds the panel) into the React Flow `nodes`/`edges`
@@ -7,35 +8,65 @@
  * so the mapping is unit-testable without a DOM — the canvas component consumes
  * the output and hands it to ELK (G-1114.D.3) for positioning.
  *
- * ## Topology for stack-local Phase D
+ * ## Topology — local hub + one hub per federated peer stack (E.3)
  *
- * There are NO inherent agent-to-agent edges yet: federation topology (peer
- * principals) is Phase E and capability-routing edges are Phase F. So for the
- * stack-local cut we synthesise a single **stack-root hub node** and attach
- * every agent to it with one `stack → agent` edge. That gives ELK a real tree
- * to lay out (a radial/star around the hub reads as "the agents on this stack")
- * AND visually groups the agents under their stack — strictly better than a pile
- * of disconnected nodes ELK would scatter arbitrarily.
+ * Phase D shipped a SINGLE stack-root hub with every agent fanned around it.
+ * Phase E folds trust-verified FOREIGN peer agents into the same snapshot (each
+ * tile carries an `origin`: `"local"` or the peer's `{principal,stack}`), so the
+ * graph now shows:
  *
- * The hub is derived, not an agent: its id is reserved (`__stack__`) so it can
- * never collide with an agent key, and it carries the `{principal}/{stack}`
- * label lifted from the agents (all stack-local agents share one principal+stack;
- * if the snapshot is somehow mixed, the first agent's pair labels the hub and the
- * rest still attach — the hub is a layout anchor, not an assertion).
+ *   - the LOCAL stack-hub (the reserved `__stack__` id) — YOUR stack, distinguished;
+ *   - one FOREIGN stack-hub per distinct `{principal}/{stack}` an agent's verified
+ *     origin names (id `__stack__:{principal}/{stack}`);
+ *
+ * with each agent clustered under ITS OWN stack's hub via a `hub → agent` edge.
+ * The grouping key is the agent's VERIFIED origin (`{principal}/{stack}` for a
+ * foreign agent, the local hub for a local agent) — the ADR-0003 roster
+ * membership, NOT an attacker-controlled wire token. A local-only snapshot lays
+ * out byte-identically to Phase D (one hub, the local one).
+ *
+ * The hubs are derived, not agents: the local hub id is reserved (`__stack__`)
+ * and each foreign hub id is namespaced under `__stack__:` + the peer's
+ * `{principal}/{stack}` — neither can collide with an agent key
+ * (`{principal}/{stack}/{agent_id}`).
  *
  * ADR-0007: nodes carry presence + lifecycle metadata only (identity,
- * capabilities, state, offline reason, heartbeat) — NEVER session interiors.
+ * capabilities, state, offline reason, heartbeat, ORIGIN) — NEVER session
+ * interiors. A foreign agent's origin is presence-level provenance, not an
+ * interior. #909: foreign agents show NO local dispatch activity — the detail
+ * panel renders "federated peer — activity not local" for them.
  */
 
-import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { AgentPresenceTile, AgentOrigin } from "../hooks/use-agents";
 
-/** Reserved id for the synthetic stack-root hub node (never a valid agent key). */
+/** Reserved id for the synthetic LOCAL stack-root hub node (never a valid agent key). */
 export const STACK_HUB_NODE_ID = "__stack__";
 
-/** React Flow node `data` payload for the synthetic stack-root hub. */
+/** Prefix for a synthetic FOREIGN stack-hub id (`__stack__:{principal}/{stack}`). */
+export const FOREIGN_HUB_ID_PREFIX = "__stack__:";
+
+/**
+ * Compute the hub node id for an agent's origin.
+ *   - `"local"` → the reserved {@link STACK_HUB_NODE_ID}.
+ *   - `{principal,stack}` → `__stack__:{principal}/{stack}` — namespaced under the
+ *     reserved prefix so it can never collide with an agent key.
+ */
+export function hubIdForOrigin(origin: AgentOrigin): string {
+  return origin === "local"
+    ? STACK_HUB_NODE_ID
+    : `${FOREIGN_HUB_ID_PREFIX}${origin.principal}/${origin.stack}`;
+}
+
+/** React Flow node `data` payload for a synthetic stack-root hub. */
 export interface StackHubNodeData {
   kind: "stack-hub";
-  /** `{principal}` the stack belongs to (best-effort from the agents). */
+  /**
+   * G-1114.E.3 — hub provenance. `"local"` for YOUR stack's hub (distinguished),
+   * or the peer's `{principal,stack}` for a federated stack-hub (rendered
+   * distinctly + carrying the provenance label).
+   */
+  origin: AgentOrigin;
+  /** `{principal}` the stack belongs to. */
   principal: string | null;
   /** `{stack}` label. */
   stack: string | null;
@@ -48,6 +79,13 @@ export interface AgentNodeData {
   kind: "agent";
   /** Stable registry key (`{principal}/{stack}/{agent_id}`). */
   key: string;
+  /**
+   * G-1114.E.4 — federation provenance: `"local"` for a stack-own agent, or the
+   * verified `{principal,stack}` of a foreign peer agent. Drives the foreign
+   * node's distinct visuals + provenance label (`jc/research`). Presence-level
+   * metadata, never an interior (ADR-0007).
+   */
+  origin: AgentOrigin;
   /** Logical agent id (`luna`, `echo`, …). */
   agentId: string;
   /** Soma assistant name, or `null` (falls back to `agentId` at render). */
@@ -87,16 +125,35 @@ export interface NetworkGraph {
   edges: NetworkGraphEdge[];
 }
 
+/** The `{principal}/{stack}` an agent's origin resolves to (for hub grouping). */
+function originScope(a: AgentPresenceTile): { principal: string; stack: string } {
+  // A foreign agent's origin carries the peer's verified {principal,stack}; a
+  // local agent's origin scope is its own tile's principal/stack (the local hub).
+  return a.origin === "local"
+    ? { principal: a.principal, stack: a.stack }
+    : { principal: a.origin.principal, stack: a.origin.stack };
+}
+
 /**
  * Project the agents snapshot into a React-Flow graph.
  *
  * - **Empty snapshot →** an empty graph (`{ nodes: [], edges: [] }`). The view
  *   renders its empty state rather than a lone hub with nothing attached.
- * - **Non-empty →** one stack-hub node + one agent node per tile + one
- *   `hub → agent` edge per tile.
+ * - **Non-empty →** one stack-hub node per distinct origin stack (the LOCAL hub
+ *   plus one per federated peer `{principal}/{stack}`), one agent node per tile,
+ *   and one `hub → agent` edge wiring each agent to ITS OWN stack's hub.
  *
- * Pure and order-preserving: agent nodes follow the snapshot order (the registry
- * order), so the layout is deterministic for a given snapshot.
+ * ## Hub ordering + grouping (E.3)
+ *
+ * Agents are grouped by their VERIFIED origin (`hubIdForOrigin`): a local agent
+ * lands under the reserved `__stack__` hub, a foreign agent under its peer's
+ * `__stack__:{principal}/{stack}` hub. Hubs are emitted FIRST (local hub first
+ * when present, then foreign hubs in first-seen order) so ELK has the cluster
+ * roots up front; agent nodes follow in snapshot order. A local-only snapshot is
+ * byte-identical to Phase D (a single `__stack__` hub).
+ *
+ * Pure and order-preserving for the agents within a snapshot, so the layout is
+ * deterministic for a given snapshot.
  */
 export function buildNetworkGraph(
   agents: readonly AgentPresenceTile[],
@@ -105,43 +162,80 @@ export function buildNetworkGraph(
     return { nodes: [], edges: [] };
   }
 
-  const first = agents[0]!;
-  const hub: NetworkGraphNode = {
-    id: STACK_HUB_NODE_ID,
-    type: "stackHub",
-    position: { x: 0, y: 0 },
-    data: {
-      kind: "stack-hub",
-      principal: first.principal ?? null,
-      stack: first.stack ?? null,
-      agentCount: agents.length,
-    },
-  };
+  // First pass: bucket agents by their origin hub id, preserving first-seen order
+  // of hubs and snapshot order of agents within each hub.
+  interface HubBucket {
+    hubId: string;
+    origin: AgentOrigin;
+    principal: string;
+    stack: string;
+    agents: AgentPresenceTile[];
+  }
+  const buckets = new Map<string, HubBucket>();
+  for (const a of agents) {
+    const hubId = hubIdForOrigin(a.origin);
+    let bucket = buckets.get(hubId);
+    if (!bucket) {
+      const scope = originScope(a);
+      bucket = {
+        hubId,
+        origin: a.origin,
+        principal: scope.principal,
+        stack: scope.stack,
+        agents: [],
+      };
+      buckets.set(hubId, bucket);
+    }
+    bucket.agents.push(a);
+  }
 
-  const nodes: NetworkGraphNode[] = [hub];
+  // Emit the LOCAL hub first (when present) so YOUR stack reads as the anchor,
+  // then the foreign hubs in first-seen order.
+  const orderedBuckets = [...buckets.values()].sort((x, y) => {
+    const xLocal = x.hubId === STACK_HUB_NODE_ID ? 0 : 1;
+    const yLocal = y.hubId === STACK_HUB_NODE_ID ? 0 : 1;
+    return xLocal - yLocal; // stable sort keeps first-seen order within a tier
+  });
+
+  const nodes: NetworkGraphNode[] = [];
   const edges: NetworkGraphEdge[] = [];
 
-  for (const a of agents) {
+  for (const bucket of orderedBuckets) {
     nodes.push({
-      id: a.key,
-      type: "agent",
+      id: bucket.hubId,
+      type: "stackHub",
       position: { x: 0, y: 0 },
       data: {
-        kind: "agent",
-        key: a.key,
-        agentId: a.agent_id,
-        assistantName: a.assistant_name,
-        capabilities: a.capabilities,
-        state: a.state,
-        offlineReason: a.offline_reason,
-        lastHeartbeatAt: a.last_heartbeat_at,
+        kind: "stack-hub",
+        origin: bucket.origin,
+        principal: bucket.principal ?? null,
+        stack: bucket.stack ?? null,
+        agentCount: bucket.agents.length,
       },
     });
-    edges.push({
-      id: `hub-${a.key}`,
-      source: STACK_HUB_NODE_ID,
-      target: a.key,
-    });
+    for (const a of bucket.agents) {
+      nodes.push({
+        id: a.key,
+        type: "agent",
+        position: { x: 0, y: 0 },
+        data: {
+          kind: "agent",
+          key: a.key,
+          origin: a.origin,
+          agentId: a.agent_id,
+          assistantName: a.assistant_name,
+          capabilities: a.capabilities,
+          state: a.state,
+          offlineReason: a.offline_reason,
+          lastHeartbeatAt: a.last_heartbeat_at,
+        },
+      });
+      edges.push({
+        id: `hub-${a.key}`,
+        source: bucket.hubId,
+        target: a.key,
+      });
+    }
   }
 
   return { nodes, edges };

--- a/src/surface/mc/dashboard-v2/lib/network-graph-filter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-filter.ts
@@ -31,7 +31,20 @@ import type { AgentPresenceTile } from "../hooks/use-agents";
 /** The state-axis options offered in the filter bar. */
 export type NetworkStateFilter = "all" | "online" | "offline";
 
-/** The two-axis filter the Network view holds and threads through the pipeline. */
+/**
+ * G-1114.E.4 — the SCOPE-axis options: whether to show federated peer agents.
+ *   - `"include-federated"` — show local AND foreign agents (federation visible).
+ *   - `"local-only"`        — hide every foreign agent (focus on YOUR stack).
+ *
+ * The DEFAULT is `"include-federated"`: federation is opt-in at the bus layer
+ * (E.1), so once a peer's agents are actually in the snapshot the principal opted
+ * in — showing them by default makes that federation visible (the whole point of
+ * Phase E). `"local-only"` is the deliberate focus filter that cleanly removes
+ * foreign agents from the view (the §4.5 acceptance criterion).
+ */
+export type NetworkScopeFilter = "include-federated" | "local-only";
+
+/** The filter the Network view holds and threads through the pipeline. */
 export interface NetworkFilterState {
   /** Liveness filter; `all` passes both online and offline agents. */
   state: NetworkStateFilter;
@@ -40,12 +53,18 @@ export interface NetworkFilterState {
    * that DECLARE this capability id.
    */
   capability: string | null;
+  /**
+   * Federation scope; `include-federated` passes local + foreign, `local-only`
+   * drops every foreign agent. Defaults to `include-federated`.
+   */
+  scope: NetworkScopeFilter;
 }
 
 /** The no-op filter: every agent passes. The view's initial filter state. */
 export const DEFAULT_NETWORK_FILTER: NetworkFilterState = {
   state: "all",
   capability: null,
+  scope: "include-federated",
 };
 
 /**
@@ -65,6 +84,10 @@ export function filterAgents(
     if (filter.capability !== null && !a.capabilities.includes(filter.capability)) {
       return false;
     }
+    // E.4 scope: `local-only` drops every foreign agent (cleanly removing the
+    // federation from the view — the §4.5 acceptance criterion). A foreign agent
+    // is one whose origin is not the `"local"` string.
+    if (filter.scope === "local-only" && a.origin !== "local") return false;
     return true;
   });
 }
@@ -89,9 +112,14 @@ export function collectCapabilityOptions(
 }
 
 /**
- * True when the filter narrows anything (i.e. it isn't the default all/any).
- * Drives the filter bar's "Clear" affordance + an "active filter" badge.
+ * True when the filter narrows anything (i.e. it isn't the default
+ * all/any/include-federated). Drives the filter bar's "Clear" affordance + an
+ * "active filter" badge.
  */
 export function isFilterActive(filter: NetworkFilterState): boolean {
-  return filter.state !== "all" || filter.capability !== null;
+  return (
+    filter.state !== "all" ||
+    filter.capability !== null ||
+    filter.scope !== "include-federated"
+  );
 }

--- a/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
@@ -1,11 +1,21 @@
 /**
  * G-1114.D.3 — ELK layout for the Network graph.
+ * G-1114.E.3 — + multi-cluster (one star per stack-hub) layout.
  *
  * Positions the stack-hub + agent nodes (from {@link buildNetworkGraph}) using
- * elkjs. The topology is a star — one hub with every agent as a spoke — so ELK's
- * **radial** algorithm is the natural fit: it places the root (the hub) at the
- * centre and fans the agents around it on a ring. That reads as "the agents on
- * this stack" far better than a left-to-right layered DAG would.
+ * elkjs.
+ *
+ * Phase D's topology was a SINGLE star — one hub with every agent as a spoke —
+ * for which ELK's `radial` (root-centred concentric placement) was the natural
+ * fit. Phase E adds federated peer stacks, so the graph is now potentially
+ * SEVERAL disconnected star-clusters (the local hub + one per foreign
+ * `{principal}/{stack}`). `radial` is single-rooted and would have to pick ONE
+ * root, scattering the other clusters; the **force** (stress) algorithm instead
+ * lays disconnected components out as separate, internally-clustered groups —
+ * each hub-and-its-agents stays together, and the clusters separate cleanly.
+ * That reads as "your stack here, each peer stack as its own cluster". A
+ * single-cluster (local-only) graph still lays out as one tidy group, so the
+ * Phase-D experience is preserved.
  *
  * ELK runs asynchronously (`elk.layout` returns a promise), so the view computes
  * the layout in an effect and stores the positioned nodes in state (see
@@ -21,17 +31,22 @@ export const HUB_NODE_SIZE = { width: 180, height: 64 } as const;
 export const AGENT_NODE_SIZE = { width: 200, height: 96 } as const;
 
 /**
- * ELK layout options for the radial star. Tuned for a hub-and-spoke:
- *   - `algorithm: radial` — root-centred concentric placement.
- *   - a generous `radius` so agent cards (≤200px) don't overlap on the ring.
- *   - `spacing.nodeNode` keeps siblings apart when the ring gets crowded.
+ * ELK layout options for the multi-cluster star layout. Tuned for one-or-more
+ * hub-and-spoke groups:
+ *   - `algorithm: force` (stress) — keeps each hub's agents clustered around it
+ *     AND lays disconnected stack-clusters out as separate groups (the local
+ *     stack + each federated peer stack), rather than forcing a single root.
+ *   - `spacing.nodeNode` keeps agent cards (≤200px) from overlapping.
+ *   - `separateConnectedComponents` packs the per-stack clusters side-by-side
+ *     instead of overlapping them.
  */
 export const NETWORK_ELK_OPTIONS: Record<string, string> = {
-  "elk.algorithm": "org.eclipse.elk.radial",
-  "elk.radial.radius": "220",
-  "elk.spacing.nodeNode": "60",
-  // Centre the hub (the layout root) at the origin so the agents fan around it.
-  "elk.radial.centerOnRoot": "true",
+  "elk.algorithm": "org.eclipse.elk.force",
+  "elk.spacing.nodeNode": "80",
+  "elk.force.repulsion": "5.0",
+  // Pack each disconnected stack-cluster as its own group (local + each peer).
+  "elk.separateConnectedComponents": "true",
+  "elk.spacing.componentComponent": "120",
 };
 
 /** One ELK input node (subset of the elkjs node shape we set). */

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -427,13 +427,16 @@ html, body {
   font-size: 11px; color: var(--fg-faint);
   text-transform: uppercase; letter-spacing: 0.04em;
 }
-.network-filter-state-btn {
+.network-filter-state-btn,
+.network-filter-scope-btn {
   appearance: none; cursor: pointer; font: inherit; font-size: 12px;
   padding: 3px 9px; border-radius: 6px;
   border: 1px solid var(--line); background: var(--bg); color: var(--fg-faint);
 }
-.network-filter-state-btn:hover { color: var(--fg); }
-.network-filter-state-btn.on {
+.network-filter-state-btn:hover,
+.network-filter-scope-btn:hover { color: var(--fg); }
+.network-filter-state-btn.on,
+.network-filter-scope-btn.on {
   background: var(--accent-soft); color: var(--fg);
   border-color: color-mix(in oklch, var(--accent) 50%, transparent);
 }
@@ -482,6 +485,25 @@ html, body {
 .network-node-ttl-lapse {
   border-color: color-mix(in oklch, var(--warn) 50%, var(--line));
 }
+
+/* E.4 — FOREIGN (federated peer) agents + hubs render distinctly: a dashed
+   border in a cooler accent marks "not your stack", and a provenance badge
+   shows the verified {principal}/{stack} the peer agent actually lives on. */
+.network-node-foreign {
+  border-style: dashed;
+  border-color: color-mix(in oklch, var(--accent) 45%, var(--line));
+  background: color-mix(in oklch, var(--panel) 88%, var(--accent-soft));
+}
+.network-node-hub-foreign {
+  border-style: dashed;
+  border-color: color-mix(in oklch, var(--accent) 55%, transparent);
+}
+.network-node-provenance {
+  display: inline-flex; align-items: center; gap: 3px;
+  font-size: 10px; font-family: var(--mono);
+  color: color-mix(in oklch, var(--accent) 70%, var(--fg-faint));
+}
+.network-node-federated-badge { font-size: 11px; line-height: 1; }
 .network-node-identity { display: flex; flex-direction: column; gap: 1px; }
 .network-node-name { font-size: 12.5px; font-weight: 600; }
 .network-node-id { font-size: 10.5px; font-family: var(--mono); }
@@ -536,6 +558,19 @@ html, body {
 .network-detail-panel.network-detail-ttl-lapse {
   border-color: color-mix(in oklch, var(--warn) 50%, var(--line));
 }
+/* E.4 — FOREIGN peer agent detail: dashed accent border + provenance line +
+   an italic "activity not local" note (the #909 no-local-join surface). */
+.network-detail-panel.network-detail-foreign {
+  border-style: dashed;
+  border-color: color-mix(in oklch, var(--accent) 50%, var(--line));
+}
+.network-detail-provenance {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 11px; font-family: var(--mono);
+  color: color-mix(in oklch, var(--accent) 70%, var(--fg-faint));
+}
+.network-detail-federated-badge { font-size: 12px; line-height: 1; }
+.network-detail-foreign-activity { font-size: 11.5px; font-style: italic; }
 .network-detail-header {
   display: flex; align-items: flex-start; justify-content: space-between; gap: 8px;
 }


### PR DESCRIPTION
## What

Federated peer agents now surface in the Network view, distinct from local agents and grouped by their **verified** origin stack.

- **`origin` in the `/api/agents` DTO** (`api/agents.ts`): each tile carries `"local"` or the foreign peer's `{principal, stack}`, flattened from the registry's `AgentRecordOrigin` (the `kind` discriminant drops — object-vs-string already discriminates on the wire).
- **Multi-stack-hub grouping by VERIFIED origin** (`network-graph-adapter.ts`): the local stack gets the reserved `__stack__` hub; each distinct foreign `{principal}/{stack}` gets a `__stack__:{principal}/{stack}` hub. Grouping key is the chain-verified origin (PR #914 / ADR-0003 roster membership), **never an attacker-controlled wire token**. A local-only snapshot lays out byte-identically to Phase D.
- **Foreign visuals + provenance** (`network-nodes.tsx`, CSS): foreign agents and foreign hubs render with a distinct dashed-accent treatment + a `⇄ {principal}/{stack}` provenance badge.
- **Scope filter** (`network-graph-filter.ts` + `network-filter-bar.tsx`): a *Scope* toggle (**All stacks** / **This stack**) that cleanly hides/restores every foreign agent.
- **Foreign detail shows origin, not local activity** (`network-detail-panel.tsx`, #909): a foreign peer agent gets **no** local working-agents join — the panel shows the origin + "Federated peer — activity not local" rather than a misleading idle/empty state. Peer interiors never visible.

`refs #355`. Closes the **G-1114.E.4** ("UI: scope filter + foreign-agent visuals") and **E.3** ("registry-roster grouping") sub-features of `docs/plan-agent-network-topology.md §4.5`, per ADR-0007.

## Salvaged + finished

The E.3+E.4 implementation was **salvaged** after the building agent died on a socket error mid-task (committed at `d832421`). This PR's second commit (`5e0c94d`) **finishes** it without rewriting the implementation:

1. **Required-vs-optional decision → required.** The salvaged DTO/adapter always set `origin`, and every filter always carries a `scope`, so both fields are kept **required** for type honesty; the breakage was simply existing fixtures not yet propagating them. Fixed by adding `origin: "local"` to each test's local `tile()` factory base and `scope: "include-federated"` to each filter literal.
2. **Two half-done features completed:**
   - The salvaged commit shipped the scope **data model + `filterAgents` logic** but **no UI control** — added the scope toggle to `NetworkFilterBar`, the `onScopeChange` prop + view wiring, and render tests.
   - The components emitted foreign-node / foreign-hub / provenance / foreign-detail classes that were **never styled** — added the distinct dashed-accent CSS so foreign agents render visibly distinct.

## Default-scope choice

**`include-federated`** (show local + foreign by default). Federation is opt-in at the bus layer (E.1), so once a peer's agents are actually in the snapshot the principal has opted in — surfacing them by default makes the federation **visible**, which is the whole point of Phase E. `local-only` is the deliberate focus filter.

## Test plan + gate results (all green)

| Gate | Result |
|---|---|
| `bunx tsc --noEmit` | **0 errors** |
| `bun run lint` | **0 errors** (27 pre-existing warnings, none in changed files) |
| `bun test` (full) | **5773 pass / 0 fail / 1 skip** (334 files) |
| `check-carveouts.sh` (changed files) | **clean** — no bare `operator` / `{org}` |
| `bun run build:dashboard` | **OK** — `network-canvas` chunk stays split (3.50 MB, separate from 1.23 MB main) |

New tests: `NetworkFilterBar — scope toggle (G-1114.E.4)` (renders both options, default pressed, local-only pressed, Clear shows on narrow). Existing D.4 NetworkDetailPanel + D.1 NetworkView suites pass with propagated fixtures.

> ⚠️ Do not merge — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)