### PR TITLE
feat(review): split review engine from LLM backend (engine: sage|persona)

### DIFF
--- a/src/__tests__/cortex.review-consumer.e2e.test.ts
+++ b/src/__tests__/cortex.review-consumer.e2e.test.ts
@@ -66,8 +66,8 @@ import type {
 } from "../runner/review-pipeline";
 import {
   makeSageReviewRunner,
-  type PiDevSpawnFn,
-  type PiDevSpawnResult,
+  type SageSpawnFn,
+  type SageSpawnResult,
 } from "../runner/substrate/sage-runner";
 import type { CCSessionFactory } from "../substrates/claude-code/harness";
 
@@ -763,7 +763,7 @@ describe("cortex#331 Phase 1 — pi-dev substrate dispatch (factory wired into R
     // Stub spawn that returns a canned successful sage subprocess.
     // Mirrors what the unit tests do but here it threads through the
     // real `makeSageReviewRunner` factory.
-    const spawnFake: PiDevSpawnFn = (_argv, _opts): PiDevSpawnResult => ({
+    const spawnFake: SageSpawnFn = (_argv, _opts): SageSpawnResult => ({
       stdout: new Response(stdoutMarkdown).body!,
       stderr: new Response("").body!,
       exited: Promise.resolve(0),

--- a/src/__tests__/cortex.review-consumer.e2e.test.ts
+++ b/src/__tests__/cortex.review-consumer.e2e.test.ts
@@ -65,10 +65,10 @@ import type {
   ReviewPipelineResult,
 } from "../runner/review-pipeline";
 import {
-  makePiDevPipelineRunner,
+  makeSageReviewRunner,
   type PiDevSpawnFn,
   type PiDevSpawnResult,
-} from "../runner/substrate/pi-dev-runner";
+} from "../runner/substrate/sage-runner";
 import type { CCSessionFactory } from "../substrates/claude-code/harness";
 
 // =============================================================================
@@ -736,7 +736,7 @@ describe("cortex#327 — signature verification gate", () => {
 //
 // Pins the cortex-side end-to-end round-trip for the `pi-dev` substrate
 // (sage). Uses the same in-process bus harness as the unsigned and signed
-// round-trips above, but injects `makePiDevPipelineRunner` (with a stubbed
+// round-trips above, but injects `makeSageReviewRunner` (with a stubbed
 // subprocess spawn) instead of the test-only inline stub. This proves the
 // production factory wires into a real `ReviewConsumer` cleanly — same
 // shape that `src/cortex.ts:807` boots when an agent declares
@@ -762,14 +762,14 @@ describe("cortex#331 Phase 1 — pi-dev substrate dispatch (factory wired into R
 
     // Stub spawn that returns a canned successful sage subprocess.
     // Mirrors what the unit tests do but here it threads through the
-    // real `makePiDevPipelineRunner` factory.
+    // real `makeSageReviewRunner` factory.
     const spawnFake: PiDevSpawnFn = (_argv, _opts): PiDevSpawnResult => ({
       stdout: new Response(stdoutMarkdown).body!,
       stderr: new Response("").body!,
       exited: Promise.resolve(0),
     });
 
-    const pipelineRunner = makePiDevPipelineRunner({
+    const pipelineRunner = makeSageReviewRunner({
       sageBin: "/usr/local/bin/sage",
       spawn: spawnFake,
     });

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -464,9 +464,25 @@ export type Presence = z.infer<typeof PresenceSchema>;
  * dropped under `agents.d/` SHOULD declare it for dashboard provenance.
  */
 export const AgentRuntimeSchema = z.object({
-  /** Execution substrate. Claude Code is the in-cortex default; other
-   *  substrates run as standalone arc-installed daemons. */
-  substrate: z.enum(["claude-code", "codex", "pi-dev", "cursor", "custom"]),
+  /**
+   * cortex#917 — review ENGINE: which reviewer cortex's ReviewConsumer runs.
+   *   - `sage`    — the standalone sage lens-CLI (deterministic pipeline:
+   *                 fixed lens registry + pure `decideVerdict`). Run via the
+   *                 sage runner; the LLM backend is `substrate` (claude|codex|pi).
+   *   - `persona` — a Claude-Code session that reads the CodeReview SKILL.md +
+   *                 the agent persona and reviews in-session (Echo/Luna/Holly).
+   *
+   * Orthogonal to `substrate` (the LLM backend). **Optional** for back-compat:
+   * when unset, `resolveReviewEngine` derives it from the legacy `substrate`
+   * value (`pi-dev` → sage; everything else → persona), preserving pre-split
+   * routing byte-for-byte. New configs SHOULD set it explicitly.
+   */
+  engine: z.enum(["sage", "persona"]).optional(),
+  /** Execution substrate / LLM backend. For `engine: sage` this is the backend
+   *  forwarded to `sage review --substrate` (`claude`|`codex`|`pi`). The legacy
+   *  engine-flavored values (`claude-code`, `pi-dev`) are still accepted and
+   *  normalized by `resolveReviewEngine` for back-compat. */
+  substrate: z.enum(["claude-code", "codex", "pi-dev", "cursor", "custom", "claude", "pi"]),
   /** Dispatch mode. `in-process` = cortex's runner spawns the substrate;
    *  `standalone` = arc-installed daemon connects to the bus directly. */
   mode: z.enum(["in-process", "standalone"]),

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -468,21 +468,32 @@ export const AgentRuntimeSchema = z.object({
    * cortex#917 — review ENGINE: which reviewer cortex's ReviewConsumer runs.
    *   - `sage`    — the standalone sage lens-CLI (deterministic pipeline:
    *                 fixed lens registry + pure `decideVerdict`). Run via the
-   *                 sage runner; the LLM backend is `substrate` (claude|codex|pi).
+   *                 sage runner; the LLM it runs lenses through is `model`.
    *   - `persona` — a Claude-Code session that reads the CodeReview SKILL.md +
    *                 the agent persona and reviews in-session (Echo/Luna/Holly).
    *
-   * Orthogonal to `substrate` (the LLM backend). **Optional** for back-compat:
-   * when unset, `resolveReviewEngine` derives it from the legacy `substrate`
-   * value (`pi-dev` → sage; everything else → persona), preserving pre-split
-   * routing byte-for-byte. New configs SHOULD set it explicitly.
+   * Distinct from `substrate` (the M6 execution harness) and `model` (sage's
+   * lens LLM). **Optional** for back-compat: when unset, `resolveReviewEngine`
+   * derives it from the legacy `substrate` value (`pi-dev` → sage; everything
+   * else → persona), preserving pre-split routing byte-for-byte. New configs
+   * SHOULD set it explicitly.
    */
   engine: z.enum(["sage", "persona"]).optional(),
-  /** Execution substrate / LLM backend. For `engine: sage` this is the backend
-   *  forwarded to `sage review --substrate` (`claude`|`codex`|`pi`). The legacy
-   *  engine-flavored values (`claude-code`, `pi-dev`) are still accepted and
-   *  normalized by `resolveReviewEngine` for back-compat. */
-  substrate: z.enum(["claude-code", "codex", "pi-dev", "cursor", "custom", "claude", "pi"]),
+  /**
+   * cortex#917 — the LLM `engine: sage` runs its lenses through, forwarded to
+   * `sage review --substrate <model>`. Closed enum so an unsupported value is
+   * rejected at config load (not silently coerced at dispatch). Only meaningful
+   * for `engine: sage`. When omitted the sage runner falls back to its own
+   * default (`SAGE_SUBSTRATE` env, else `pi`). NOT named `substrate` (reserved
+   * for the M6 harness) nor `backend` (an avoided alias) — see CONTEXT.md.
+   */
+  model: z.enum(["claude", "codex", "pi"]).optional(),
+  /** Execution substrate — the M6 harness (cortex#113 `HarnessId`). For
+   *  `engine: persona` this is the in-session harness (`claude-code`). Optional:
+   *  `engine: sage` agents run through the sage CLI (no HarnessId) and omit it;
+   *  the legacy `pi-dev` value is the back-compat shim that `resolveReviewEngine`
+   *  maps to `engine: sage`. */
+  substrate: z.enum(["claude-code", "codex", "pi-dev", "cursor", "custom"]).optional(),
   /** Dispatch mode. `in-process` = cortex's runner spawns the substrate;
    *  `standalone` = arc-installed daemon connects to the bus directly. */
   mode: z.enum(["in-process", "standalone"]),

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1446,15 +1446,16 @@ export async function startCortex(
       // subscribe path are retired. Cortex's review-consumer is now the
       // sole receiver for sage-owned review flavors.
       //
-      // cortex#917 — the engine/backend split. `resolveReviewEngine` reads
-      // `runtime.engine` (`sage` | `persona`); the LLM backend is the now-
-      // orthogonal `runtime.substrate`. `engine: sage` wires the sage lens-CLI
-      // runner (forwarding the backend to `sage review --substrate`); `persona`
+      // cortex#917 — the engine/model split. `resolveReviewEngine` reads
+      // `runtime.engine` (`sage` | `persona`); the sage lens LLM is the
+      // orthogonal `runtime.model` (claude|codex|pi), NOT `substrate` (which is
+      // the M6 harness). `engine: sage` wires the sage lens-CLI runner,
+      // forwarding `model` to `sage review --substrate <model>`; `persona`
       // (and the legacy default) leaves `pipelineRunner` undefined so the
       // ReviewConsumer falls through to `runReviewPipeline` → the Claude-Code
       // SKILL.md path (`ccSessionFactory` stays wired for it). The resolver's
-      // legacy shim keeps pre-split configs (`substrate: pi-dev`→sage, else
-      // persona) routing byte-for-byte.
+      // legacy shim keeps pre-split `substrate: pi-dev` configs routing to sage
+      // (no forced model — SAGE_SUBSTRATE env still honoured).
       //
       // The sage runner resolves its binary lazily at first use (see
       // `sage-runner.ts`'s lifetime note), so a missing sage on boot does not

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -74,7 +74,8 @@ import {
 } from "./bus/verify-signed-by-chain";
 import { bootVerifierSelfCheck } from "./bus/verifier-self-check";
 import { CCSession, type CCSessionOpts } from "./runner/cc-session";
-import { makePiDevPipelineRunner } from "./runner/substrate/pi-dev-runner";
+import { makeSageReviewRunner } from "./runner/substrate/sage-runner";
+import { resolveReviewEngine } from "./runner/review-engine";
 
 import { DiscordAdapter } from "./adapters/discord";
 import { createRenderer, type Renderer } from "./renderers";
@@ -1443,30 +1444,25 @@ export async function startCortex(
       // **Why this lives in cortex (not sage).** Sage went in-process at
       // sage#41 — its standalone launchd daemon and standalone NATS
       // subscribe path are retired. Cortex's review-consumer is now the
-      // sole receiver for sage-owned review flavors. The cross-repo scope
-      // split (sage#40 / sage#41 / cortex#331) deliberately puts
-      // cortex-side wiring HERE in cortex#331, NOT in sage's Phase 1 —
-      // sage stepped DOWN from owning its own bus subscription, cortex
-      // stepped UP to own substrate dispatch for in-process agents. The
-      // selection below is the substrate-dispatch fork that closes the
-      // round-trip; the adapter itself lives in
-      // `src/runner/substrate/pi-dev-runner.ts`.
+      // sole receiver for sage-owned review flavors.
       //
-      // Agents that declare `runtime.substrate: "pi-dev"` get the sage
-      // adapter wired in via `makePiDevPipelineRunner`. Every other agent
-      // (including those with the substrate field unset, which defaults
-      // to claude-code semantics) gets no `pipelineRunner` opt so the
-      // ReviewConsumer falls through to the existing `runReviewPipeline`
-      // → CC path (`ccSessionFactory` stays wired for that path; we do
-      // NOT remove it — see the issue's "out of scope" list).
+      // cortex#917 — the engine/backend split. `resolveReviewEngine` reads
+      // `runtime.engine` (`sage` | `persona`); the LLM backend is the now-
+      // orthogonal `runtime.substrate`. `engine: sage` wires the sage lens-CLI
+      // runner (forwarding the backend to `sage review --substrate`); `persona`
+      // (and the legacy default) leaves `pipelineRunner` undefined so the
+      // ReviewConsumer falls through to `runReviewPipeline` → the Claude-Code
+      // SKILL.md path (`ccSessionFactory` stays wired for it). The resolver's
+      // legacy shim keeps pre-split configs (`substrate: pi-dev`→sage, else
+      // persona) routing byte-for-byte.
       //
-      // The pi-dev runner resolves its sage binary lazily at first use
-      // (see `pi-dev-runner.ts`'s lifetime note), so a missing sage on
-      // boot does not crash this loop — review requests surface the
-      // failure as `dispatch.task.failed` envelopes instead.
-      const substrate = agent.runtime?.substrate ?? "claude-code";
+      // The sage runner resolves its binary lazily at first use (see
+      // `sage-runner.ts`'s lifetime note), so a missing sage on boot does not
+      // crash this loop — review requests surface the failure as
+      // `dispatch.task.failed` envelopes instead.
+      const { engine, backend } = resolveReviewEngine(agent.runtime);
       const pipelineRunner =
-        substrate === "pi-dev" ? makePiDevPipelineRunner({}) : undefined;
+        engine === "sage" ? makeSageReviewRunner({ substrate: backend }) : undefined;
 
       const reviewSessionOpts = buildReviewSessionOpts(config, agent);
 
@@ -1588,11 +1584,11 @@ export async function startCortex(
       // misled principals into chasing phantom misconfigs.
       if (started.subscribed) {
         console.log(
-          `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate}`,
+          `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} backend=${backend}`,
         );
       } else {
         console.log(
-          `cortex: review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)`,
+          `cortex: review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} backend=${backend} — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)`,
         );
       }
 
@@ -1650,11 +1646,11 @@ export async function startCortex(
           });
           if (federatedStarted.subscribed) {
             console.log(
-              `cortex: federated review consumer (${mode}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} pattern=${pattern}`,
+              `cortex: federated review consumer (${mode}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} backend=${backend} pattern=${pattern}`,
             );
           } else {
             console.log(
-              `cortex: federated review consumer (${mode}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
+              `cortex: federated review consumer (${mode}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} backend=${backend} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
             );
           }
         };

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1460,9 +1460,11 @@ export async function startCortex(
       // `sage-runner.ts`'s lifetime note), so a missing sage on boot does not
       // crash this loop — review requests surface the failure as
       // `dispatch.task.failed` envelopes instead.
-      const { engine, backend } = resolveReviewEngine(agent.runtime);
+      const { engine, model } = resolveReviewEngine(agent.runtime);
       const pipelineRunner =
-        engine === "sage" ? makeSageReviewRunner({ substrate: backend }) : undefined;
+        engine === "sage"
+          ? makeSageReviewRunner(model !== undefined ? { model } : {})
+          : undefined;
 
       const reviewSessionOpts = buildReviewSessionOpts(config, agent);
 
@@ -1584,11 +1586,11 @@ export async function startCortex(
       // misled principals into chasing phantom misconfigs.
       if (started.subscribed) {
         console.log(
-          `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} backend=${backend}`,
+          `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"}`,
         );
       } else {
         console.log(
-          `cortex: review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} backend=${backend} — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)`,
+          `cortex: review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)`,
         );
       }
 
@@ -1646,11 +1648,11 @@ export async function startCortex(
           });
           if (federatedStarted.subscribed) {
             console.log(
-              `cortex: federated review consumer (${mode}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} backend=${backend} pattern=${pattern}`,
+              `cortex: federated review consumer (${mode}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} pattern=${pattern}`,
             );
           } else {
             console.log(
-              `cortex: federated review consumer (${mode}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} backend=${backend} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
+              `cortex: federated review consumer (${mode}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
             );
           }
         };

--- a/src/runner/__tests__/review-engine.test.ts
+++ b/src/runner/__tests__/review-engine.test.ts
@@ -2,51 +2,56 @@ import { describe, test, expect } from "bun:test";
 import { resolveReviewEngine } from "../review-engine";
 
 describe("resolveReviewEngine — explicit engine", () => {
-  test("engine: sage + substrate: codex → sage via codex (the case that used to fall through)", () => {
-    expect(resolveReviewEngine({ engine: "sage", substrate: "codex" })).toEqual({
+  test("engine: sage + model: codex → sage via codex (the case that used to fall through)", () => {
+    expect(resolveReviewEngine({ engine: "sage", model: "codex" })).toEqual({
       engine: "sage",
-      backend: "codex",
+      model: "codex",
     });
   });
 
-  test("engine: sage + substrate: claude → sage via claude", () => {
-    expect(resolveReviewEngine({ engine: "sage", substrate: "claude" })).toEqual({
+  test("engine: sage + model: claude → sage via claude", () => {
+    expect(resolveReviewEngine({ engine: "sage", model: "claude" })).toEqual({
       engine: "sage",
-      backend: "claude",
+      model: "claude",
     });
   });
 
-  test("engine: sage + no substrate → sage via pi (sage default backend)", () => {
-    expect(resolveReviewEngine({ engine: "sage" })).toEqual({ engine: "sage", backend: "pi" });
+  test("engine: sage + no model → sage, model undefined (runner applies its default)", () => {
+    expect(resolveReviewEngine({ engine: "sage" })).toEqual({ engine: "sage" });
   });
 
-  test("engine: persona → persona regardless of substrate", () => {
-    expect(resolveReviewEngine({ engine: "persona", substrate: "codex" }).engine).toBe("persona");
+  test("engine: persona → persona, no model regardless of any model field", () => {
+    expect(resolveReviewEngine({ engine: "persona", model: "codex" })).toEqual({
+      engine: "persona",
+    });
   });
 });
 
 describe("resolveReviewEngine — legacy migration (no engine field)", () => {
   test("legacy substrate: pi-dev → sage via pi (only value that selected the sage runner before)", () => {
-    expect(resolveReviewEngine({ substrate: "pi-dev" })).toEqual({ engine: "sage", backend: "pi" });
+    expect(resolveReviewEngine({ substrate: "pi-dev" })).toEqual({ engine: "sage", model: "pi" });
   });
 
   test("legacy substrate: claude-code → persona (unchanged)", () => {
-    expect(resolveReviewEngine({ substrate: "claude-code" }).engine).toBe("persona");
+    expect(resolveReviewEngine({ substrate: "claude-code" })).toEqual({ engine: "persona" });
   });
 
   test("legacy substrate: codex → persona (unchanged — this was the silent-fallthrough bug)", () => {
-    expect(resolveReviewEngine({ substrate: "codex" }).engine).toBe("persona");
+    expect(resolveReviewEngine({ substrate: "codex" })).toEqual({ engine: "persona" });
   });
 
   test("no runtime → persona (the default CC path)", () => {
-    expect(resolveReviewEngine(undefined).engine).toBe("persona");
-    expect(resolveReviewEngine({}).engine).toBe("persona");
+    expect(resolveReviewEngine(undefined)).toEqual({ engine: "persona" });
+    expect(resolveReviewEngine({})).toEqual({ engine: "persona" });
   });
 });
 
-describe("resolveReviewEngine — backend normalization", () => {
-  test("pi-dev → pi, claude-code → claude (engine-flavored legacy values map to clean backends)", () => {
-    expect(resolveReviewEngine({ engine: "sage", substrate: "pi-dev" }).backend).toBe("pi");
-    expect(resolveReviewEngine({ engine: "sage", substrate: "claude-code" }).backend).toBe("claude");
+describe("resolveReviewEngine — no silent backend coercion (cortex#920)", () => {
+  test("model is passed through verbatim, never normalized to pi", () => {
+    // The schema's z.enum already constrains model to claude|codex|pi, so the
+    // resolver must NOT re-map — an out-of-enum value can't reach here, and a
+    // valid one is forwarded as-is (no fail-open).
+    expect(resolveReviewEngine({ engine: "sage", model: "pi" }).model).toBe("pi");
+    expect(resolveReviewEngine({ engine: "sage", model: "claude" }).model).toBe("claude");
   });
 });

--- a/src/runner/__tests__/review-engine.test.ts
+++ b/src/runner/__tests__/review-engine.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "bun:test";
+import { resolveReviewEngine } from "../review-engine";
+
+describe("resolveReviewEngine — explicit engine", () => {
+  test("engine: sage + substrate: codex → sage via codex (the case that used to fall through)", () => {
+    expect(resolveReviewEngine({ engine: "sage", substrate: "codex" })).toEqual({
+      engine: "sage",
+      backend: "codex",
+    });
+  });
+
+  test("engine: sage + substrate: claude → sage via claude", () => {
+    expect(resolveReviewEngine({ engine: "sage", substrate: "claude" })).toEqual({
+      engine: "sage",
+      backend: "claude",
+    });
+  });
+
+  test("engine: sage + no substrate → sage via pi (sage default backend)", () => {
+    expect(resolveReviewEngine({ engine: "sage" })).toEqual({ engine: "sage", backend: "pi" });
+  });
+
+  test("engine: persona → persona regardless of substrate", () => {
+    expect(resolveReviewEngine({ engine: "persona", substrate: "codex" }).engine).toBe("persona");
+  });
+});
+
+describe("resolveReviewEngine — legacy migration (no engine field)", () => {
+  test("legacy substrate: pi-dev → sage via pi (only value that selected the sage runner before)", () => {
+    expect(resolveReviewEngine({ substrate: "pi-dev" })).toEqual({ engine: "sage", backend: "pi" });
+  });
+
+  test("legacy substrate: claude-code → persona (unchanged)", () => {
+    expect(resolveReviewEngine({ substrate: "claude-code" }).engine).toBe("persona");
+  });
+
+  test("legacy substrate: codex → persona (unchanged — this was the silent-fallthrough bug)", () => {
+    expect(resolveReviewEngine({ substrate: "codex" }).engine).toBe("persona");
+  });
+
+  test("no runtime → persona (the default CC path)", () => {
+    expect(resolveReviewEngine(undefined).engine).toBe("persona");
+    expect(resolveReviewEngine({}).engine).toBe("persona");
+  });
+});
+
+describe("resolveReviewEngine — backend normalization", () => {
+  test("pi-dev → pi, claude-code → claude (engine-flavored legacy values map to clean backends)", () => {
+    expect(resolveReviewEngine({ engine: "sage", substrate: "pi-dev" }).backend).toBe("pi");
+    expect(resolveReviewEngine({ engine: "sage", substrate: "claude-code" }).backend).toBe("claude");
+  });
+});

--- a/src/runner/__tests__/review-engine.test.ts
+++ b/src/runner/__tests__/review-engine.test.ts
@@ -28,8 +28,11 @@ describe("resolveReviewEngine — explicit engine", () => {
 });
 
 describe("resolveReviewEngine — legacy migration (no engine field)", () => {
-  test("legacy substrate: pi-dev → sage via pi (only value that selected the sage runner before)", () => {
-    expect(resolveReviewEngine({ substrate: "pi-dev" })).toEqual({ engine: "sage", model: "pi" });
+  test("legacy substrate: pi-dev → sage with NO model (runner honors SAGE_SUBSTRATE env — true parity, cortex#920 round 2)", () => {
+    // Must NOT force model:pi — the pre-split `makePiDevPipelineRunner({})`
+    // deferred to SAGE_SUBSTRATE env, so an un-migrated pi-dev config with
+    // SAGE_SUBSTRATE=claude|codex kept that override.
+    expect(resolveReviewEngine({ substrate: "pi-dev" })).toEqual({ engine: "sage" });
   });
 
   test("legacy substrate: claude-code → persona (unchanged)", () => {

--- a/src/runner/review-engine.ts
+++ b/src/runner/review-engine.ts
@@ -1,0 +1,81 @@
+/**
+ * Review-engine resolution (cortex#917 follow-up).
+ *
+ * Two orthogonal axes were historically conflated in `runtime.substrate`:
+ *   - WHICH review ENGINE runs — the standalone sage lens-CLI (deterministic
+ *     pipeline: fixed lens registry + pure `decideVerdict`) vs a Claude-Code
+ *     PERSONA session that reads the CodeReview SKILL.md and reviews in-session.
+ *   - WHICH LLM BACKEND the engine's calls go through (`claude` | `codex` | `pi`).
+ *
+ * `substrate === "pi-dev"` used to mean "use the sage runner", so a sage agent
+ * configured `substrate: codex` silently fell through to the persona path —
+ * "codex" only names a backend, never the engine. This module splits the axes:
+ * `runtime.engine` selects the engine; `runtime.substrate` is purely the
+ * backend forwarded to `sage review --substrate <backend>`.
+ *
+ * Pure + deterministic — unit-tested in `review-engine.test.ts`.
+ */
+
+export type ReviewEngine = "sage" | "persona";
+
+export interface ResolvedReviewEngine {
+  /** sage = standalone lens CLI; persona = Claude-Code session + CodeReview skill. */
+  engine: ReviewEngine;
+  /**
+   * LLM backend the sage CLI runs its lenses through (`sage review --substrate
+   * <backend>`). Only meaningful when `engine === "sage"`; informational for
+   * persona (the CC session always spawns `claude`).
+   */
+  backend: "claude" | "codex" | "pi";
+}
+
+/** The runtime fields this resolver reads. Structural so it accepts AgentRuntime. */
+export interface ReviewEngineInput {
+  engine?: ReviewEngine;
+  substrate?: string;
+}
+
+/**
+ * Normalize a (possibly engine-flavored, legacy) substrate value to a sage
+ * backend. `pi-dev`→`pi`, `claude-code`→`claude`, `codex`→`codex`. Anything
+ * unrecognized (incl. undefined) → `pi` (sage's own default backend).
+ */
+function normalizeBackend(substrate: string | undefined): ResolvedReviewEngine["backend"] {
+  switch (substrate) {
+    case "pi":
+    case "pi-dev":
+      return "pi";
+    case "claude":
+    case "claude-code":
+      return "claude";
+    case "codex":
+      return "codex";
+    default:
+      return "pi";
+  }
+}
+
+/**
+ * Resolve `{engine, backend}` from an agent's runtime config.
+ *
+ * Precedence:
+ *   1. Explicit `runtime.engine` wins; `backend` = normalized `substrate`.
+ *   2. Legacy (no `engine`): only `substrate === "pi-dev"` selected the sage
+ *      runner before, so it maps to `{engine: sage, backend: pi}`. EVERY other
+ *      legacy substrate (`claude-code`, `codex`, `cursor`, `custom`, unset)
+ *      kept the Claude-Code path → `{engine: persona, …}`. This preserves
+ *      pre-split behaviour byte-for-byte for un-migrated configs.
+ */
+export function resolveReviewEngine(runtime?: ReviewEngineInput): ResolvedReviewEngine {
+  if (runtime?.engine === "sage") {
+    return { engine: "sage", backend: normalizeBackend(runtime.substrate) };
+  }
+  if (runtime?.engine === "persona") {
+    return { engine: "persona", backend: normalizeBackend(runtime.substrate) };
+  }
+  // Legacy migration — engine unset.
+  if (runtime?.substrate === "pi-dev") {
+    return { engine: "sage", backend: "pi" };
+  }
+  return { engine: "persona", backend: normalizeBackend(runtime?.substrate) };
+}

--- a/src/runner/review-engine.ts
+++ b/src/runner/review-engine.ts
@@ -45,7 +45,7 @@ export interface ReviewEngineInput {
  *   1. Explicit `runtime.engine` wins. For sage, `model` is the (already
  *      zod-validated) `runtime.model`; `undefined` defers to the runner default.
  *   2. Legacy (no `engine`): only `substrate === "pi-dev"` selected the sage
- *      runner before, so it maps to `{engine: sage, model: pi}` (its historical
+ *      runner before, so it maps to `{engine: sage}` with NO model (runner uses SAGE_SUBSTRATE env, else pi — true parity); legacy
  *      backend). EVERY other legacy substrate (`claude-code`, `codex`, `cursor`,
  *      `custom`, unset) kept the Claude-Code path → `{engine: persona}`. This
  *      preserves pre-split behaviour byte-for-byte for un-migrated configs.
@@ -63,9 +63,12 @@ export function resolveReviewEngine(runtime?: ReviewEngineInput): ResolvedReview
   if (runtime?.engine === "persona") {
     return { engine: "persona" };
   }
-  // Legacy migration — engine unset.
+  // Legacy migration — engine unset. NO `model`: the runner falls back to
+  // SAGE_SUBSTRATE env (else pi), exactly as pre-split `makePiDevPipelineRunner({})`
+  // did, so an un-migrated `substrate: pi-dev` config keeps honouring a
+  // `SAGE_SUBSTRATE=claude|codex` override (true parity, not forced-pi).
   if (runtime?.substrate === "pi-dev") {
-    return { engine: "sage", model: "pi" };
+    return { engine: "sage" };
   }
   return { engine: "persona" };
 }

--- a/src/runner/review-engine.ts
+++ b/src/runner/review-engine.ts
@@ -1,81 +1,71 @@
 /**
- * Review-engine resolution (cortex#917 follow-up).
+ * Review-engine resolution (cortex#917).
  *
  * Two orthogonal axes were historically conflated in `runtime.substrate`:
  *   - WHICH review ENGINE runs — the standalone sage lens-CLI (deterministic
  *     pipeline: fixed lens registry + pure `decideVerdict`) vs a Claude-Code
  *     PERSONA session that reads the CodeReview SKILL.md and reviews in-session.
- *   - WHICH LLM BACKEND the engine's calls go through (`claude` | `codex` | `pi`).
+ *   - WHICH LLM the sage engine runs its lenses through (`claude` | `codex` | `pi`).
  *
  * `substrate === "pi-dev"` used to mean "use the sage runner", so a sage agent
  * configured `substrate: codex` silently fell through to the persona path —
- * "codex" only names a backend, never the engine. This module splits the axes:
- * `runtime.engine` selects the engine; `runtime.substrate` is purely the
- * backend forwarded to `sage review --substrate <backend>`.
+ * "codex" only names a harness, never the engine. This module splits the axes:
+ * `runtime.engine` selects the engine; `runtime.model` is the LLM the sage CLI
+ * runs lenses through (forwarded to `sage review --substrate <model>`);
+ * `runtime.substrate` stays the M6 harness (CONTEXT.md).
  *
  * Pure + deterministic — unit-tested in `review-engine.test.ts`.
  */
 
 export type ReviewEngine = "sage" | "persona";
+export type SageModel = "claude" | "codex" | "pi";
 
 export interface ResolvedReviewEngine {
   /** sage = standalone lens CLI; persona = Claude-Code session + CodeReview skill. */
   engine: ReviewEngine;
   /**
-   * LLM backend the sage CLI runs its lenses through (`sage review --substrate
-   * <backend>`). Only meaningful when `engine === "sage"`; informational for
-   * persona (the CC session always spawns `claude`).
+   * The LLM the sage CLI runs its lenses through (`sage review --substrate
+   * <model>`). `undefined` ⇒ the sage runner applies its own default
+   * (`SAGE_SUBSTRATE` env, else `pi`). Only meaningful for `engine === "sage"`.
    */
-  backend: "claude" | "codex" | "pi";
+  model?: SageModel;
 }
 
 /** The runtime fields this resolver reads. Structural so it accepts AgentRuntime. */
 export interface ReviewEngineInput {
   engine?: ReviewEngine;
+  model?: SageModel;
   substrate?: string;
 }
 
 /**
- * Normalize a (possibly engine-flavored, legacy) substrate value to a sage
- * backend. `pi-dev`→`pi`, `claude-code`→`claude`, `codex`→`codex`. Anything
- * unrecognized (incl. undefined) → `pi` (sage's own default backend).
- */
-function normalizeBackend(substrate: string | undefined): ResolvedReviewEngine["backend"] {
-  switch (substrate) {
-    case "pi":
-    case "pi-dev":
-      return "pi";
-    case "claude":
-    case "claude-code":
-      return "claude";
-    case "codex":
-      return "codex";
-    default:
-      return "pi";
-  }
-}
-
-/**
- * Resolve `{engine, backend}` from an agent's runtime config.
+ * Resolve `{engine, model}` from an agent's runtime config.
  *
  * Precedence:
- *   1. Explicit `runtime.engine` wins; `backend` = normalized `substrate`.
+ *   1. Explicit `runtime.engine` wins. For sage, `model` is the (already
+ *      zod-validated) `runtime.model`; `undefined` defers to the runner default.
  *   2. Legacy (no `engine`): only `substrate === "pi-dev"` selected the sage
- *      runner before, so it maps to `{engine: sage, backend: pi}`. EVERY other
- *      legacy substrate (`claude-code`, `codex`, `cursor`, `custom`, unset)
- *      kept the Claude-Code path → `{engine: persona, …}`. This preserves
- *      pre-split behaviour byte-for-byte for un-migrated configs.
+ *      runner before, so it maps to `{engine: sage, model: pi}` (its historical
+ *      backend). EVERY other legacy substrate (`claude-code`, `codex`, `cursor`,
+ *      `custom`, unset) kept the Claude-Code path → `{engine: persona}`. This
+ *      preserves pre-split behaviour byte-for-byte for un-migrated configs.
+ *
+ * No coercion of unknown values — `model` is constrained to `SageModel` by the
+ * schema's `z.enum`, so an unsupported LLM is rejected at config load rather
+ * than silently falling open here.
  */
 export function resolveReviewEngine(runtime?: ReviewEngineInput): ResolvedReviewEngine {
   if (runtime?.engine === "sage") {
-    return { engine: "sage", backend: normalizeBackend(runtime.substrate) };
+    return runtime.model !== undefined
+      ? { engine: "sage", model: runtime.model }
+      : { engine: "sage" };
   }
   if (runtime?.engine === "persona") {
-    return { engine: "persona", backend: normalizeBackend(runtime.substrate) };
+    return { engine: "persona" };
   }
   // Legacy migration — engine unset.
   if (runtime?.substrate === "pi-dev") {
-    return { engine: "sage", backend: "pi" };
+    return { engine: "sage", model: "pi" };
   }
-  return { engine: "persona", backend: normalizeBackend(runtime?.substrate) };
+  return { engine: "persona" };
 }

--- a/src/runner/substrate/__tests__/sage-runner.test.ts
+++ b/src/runner/substrate/__tests__/sage-runner.test.ts
@@ -30,9 +30,9 @@ import type { ReviewPipelineOpts } from "../../review-pipeline";
 import type { CCSessionFactory } from "../../../substrates/claude-code/harness";
 import {
   makeSageReviewRunner,
-  type PiDevSpawnFn,
-  type PiDevSpawnResult,
-  type PiDevWhichFn,
+  type SageSpawnFn,
+  type SageSpawnResult,
+  type SageWhichFn,
 } from "../sage-runner";
 
 // ---------------------------------------------------------------------------
@@ -77,7 +77,7 @@ function makePipelineOpts(): ReviewPipelineOpts {
 }
 
 /**
- * Build a `PiDevSpawnResult` from a canned stdout, stderr, and exit code.
+ * Build a `SageSpawnResult` from a canned stdout, stderr, and exit code.
  * Uses `Response.body` to turn strings into the same `ReadableStream<Uint8Array>`
  * shape `Bun.spawn` returns — same trick the production runner uses to
  * drain via `new Response(stream).text()`.
@@ -86,7 +86,7 @@ function makeSpawnResult(
   stdout: string,
   stderr: string,
   exitCode: number,
-): PiDevSpawnResult {
+): SageSpawnResult {
   const stdoutStream = new Response(stdout).body!;
   const stderrStream = new Response(stderr).body!;
   return {
@@ -98,14 +98,14 @@ function makeSpawnResult(
 
 /**
  * Make a spawn fake that captures every argv it sees and returns the
- * given `PiDevSpawnResult`. Pins the argv shape the runner builds
+ * given `SageSpawnResult`. Pins the argv shape the runner builds
  * (`sage review owner/repo#N --substrate pi`).
  */
 function makeRecordingSpawn(
-  result: PiDevSpawnResult,
-): { fn: PiDevSpawnFn; calls: string[][] } {
+  result: SageSpawnResult,
+): { fn: SageSpawnFn; calls: string[][] } {
   const calls: string[][] = [];
-  const fn: PiDevSpawnFn = (argv, _opts) => {
+  const fn: SageSpawnFn = (argv, _opts) => {
     calls.push([...argv]);
     return result;
   };
@@ -114,9 +114,9 @@ function makeRecordingSpawn(
 
 /** `which` stub that returns a fixed sage binary path. */
 const FAKE_SAGE_BIN = "/usr/local/bin/sage";
-const whichSuccess: PiDevWhichFn = (cmd) =>
+const whichSuccess: SageWhichFn = (cmd) =>
   cmd === "sage" ? FAKE_SAGE_BIN : undefined;
-const whichMissing: PiDevWhichFn = () => undefined;
+const whichMissing: SageWhichFn = () => undefined;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -222,7 +222,7 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
     // No spawn call should happen — the runner must short-circuit before
     // any subprocess work when the binary is missing. We still pass a
     // spawn that would throw if invoked to pin that no-call invariant.
-    const spawnThatMustNotRun: PiDevSpawnFn = () => {
+    const spawnThatMustNotRun: SageSpawnFn = () => {
       throw new Error("pi-dev-runner test: spawn must not be called when sage is missing");
     };
 
@@ -287,7 +287,7 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
   });
 
   test("spawn throw (e.g. ENOENT mid-spawn) is caught and surfaces as a failed envelope, not an unhandled rejection", async () => {
-    const spawnThatThrows: PiDevSpawnFn = () => {
+    const spawnThatThrows: SageSpawnFn = () => {
       throw new Error("ENOENT: no such file or directory");
     };
     const runner = makeSageReviewRunner({

--- a/src/runner/substrate/__tests__/sage-runner.test.ts
+++ b/src/runner/substrate/__tests__/sage-runner.test.ts
@@ -29,11 +29,11 @@ import {
 import type { ReviewPipelineOpts } from "../../review-pipeline";
 import type { CCSessionFactory } from "../../../substrates/claude-code/harness";
 import {
-  makePiDevPipelineRunner,
+  makeSageReviewRunner,
   type PiDevSpawnFn,
   type PiDevSpawnResult,
   type PiDevWhichFn,
-} from "../pi-dev-runner";
+} from "../sage-runner";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -122,7 +122,7 @@ const whichMissing: PiDevWhichFn = () => undefined;
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
+describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
   test("happy path: sage exit 0 + stdout → verdict envelope with summary=stdout, correlation_id=requestEnvelope.id", async () => {
     // cortex#402 — guard the argv pin against an ambient SAGE_SUBSTRATE
     // env value. Before #402 the env var was inert; after #402 a
@@ -136,7 +136,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     try {
       const stdout = "## review body\n\nverdict: commented";
       const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         spawn: spawn.fn,
         which: whichSuccess,
       });
@@ -190,7 +190,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
   test("failure path: sage exit != 0 + stderr → failed envelope with reason.kind=cant_do carrying stderr in detail", async () => {
     const stderr = "sage: PR not found";
     const spawn = makeRecordingSpawn(makeSpawnResult("", stderr, 2));
-    const runner = makePiDevPipelineRunner({
+    const runner = makeSageReviewRunner({
       spawn: spawn.fn,
       which: whichSuccess,
     });
@@ -231,7 +231,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     const previousSageBin = process.env.SAGE_BIN;
     delete process.env.SAGE_BIN;
     try {
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         spawn: spawnThatMustNotRun,
         which: whichMissing,
       });
@@ -268,7 +268,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     const previousSageBin = process.env.SAGE_BIN;
     process.env.SAGE_BIN = "/different/env/sage";
     try {
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         sageBin: explicitBin,
         spawn: spawn.fn,
         which: whichSuccess, // returns yet another path — also overridden
@@ -290,7 +290,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     const spawnThatThrows: PiDevSpawnFn = () => {
       throw new Error("ENOENT: no such file or directory");
     };
-    const runner = makePiDevPipelineRunner({
+    const runner = makeSageReviewRunner({
       spawn: spawnThatThrows,
       which: whichSuccess,
     });
@@ -320,7 +320,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     process.env.SAGE_SUBSTRATE = "claude";
     try {
       const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         spawn: spawn.fn,
         which: whichSuccess,
       });
@@ -339,7 +339,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     delete process.env.SAGE_SUBSTRATE;
     try {
       const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         spawn: spawn.fn,
         which: whichSuccess,
       });
@@ -365,7 +365,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
       const spawn = makeRecordingSpawn(
         makeSpawnResult(stdout, "[sage] verdict: changes-requested", 1),
       );
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         spawn: spawn.fn,
         which: whichSuccess,
       });
@@ -387,7 +387,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
 
   test("cortex#409 — sage exit -1 (killed) → failed (not a verdict)", async () => {
     const spawn = makeRecordingSpawn(makeSpawnResult("", "killed", -1));
-    const runner = makePiDevPipelineRunner({
+    const runner = makeSageReviewRunner({
       spawn: spawn.fn,
       which: whichSuccess,
     });
@@ -409,7 +409,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     delete process.env.SAGE_SUBSTRATE;
     try {
       const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         spawn: spawn.fn,
         which: whichSuccess,
       });
@@ -438,7 +438,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     process.env.SAGE_SUBSTRATE = "codex";
     try {
       const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         spawn: spawn.fn,
         which: whichSuccess,
       });
@@ -478,7 +478,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     delete process.env.SAGE_SUBSTRATE;
     try {
       const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
-      const runner = makePiDevPipelineRunner({
+      const runner = makeSageReviewRunner({
         spawn: spawn.fn,
         which: whichSuccess,
       });
@@ -518,7 +518,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
   test("cortex#888 — exit 0 + block verdict=approved → review.verdict.approved (recovers approved)", async () => {
     const stdout = withBlock("## Sage code review — approved", SAMPLE_BLOCK);
     const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
-    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
     const opts = makePipelineOpts();
     const result = await runner(opts);
 
@@ -551,7 +551,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     // Exit 1 AND block both say changes-requested — they agree here; the
     // point is the findings counts come from the block.
     const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 1));
-    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
     const result = await runner(makePipelineOpts());
 
     expect(result.kind).toBe("verdict");
@@ -572,7 +572,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
       findings: { blockers: 1, majors: 0, nits: 0 },
     });
     const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
-    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
     const result = await runner(makePipelineOpts());
 
     expect(result.kind).toBe("verdict");
@@ -583,7 +583,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
   test("cortex#888 — malformed block falls back to exit-code mapping (exit 0 → commented)", async () => {
     const stdout = "## Sage code review — commented\n\n```json\n{ not valid json\n```";
     const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
-    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
     const result = await runner(makePipelineOpts());
 
     expect(result.kind).toBe("verdict");
@@ -597,7 +597,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
   test("cortex#888 — no block (older sage) falls back to exit-code mapping (exit 1 → changes-requested)", async () => {
     const stdout = "## Sage code review — changes-requested\n\n(no json block)";
     const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 1));
-    const runner = makePiDevPipelineRunner({ spawn: spawn.fn, which: whichSuccess });
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
     const result = await runner(makePipelineOpts());
 
     expect(result.kind).toBe("verdict");

--- a/src/runner/substrate/sage-runner.ts
+++ b/src/runner/substrate/sage-runner.ts
@@ -154,7 +154,14 @@ export type PiDevWhichFn = (cmd: string) => string | undefined;
  *   - Use the current process env (no scrubbing — sage piggybacks on the
  *     principal's `gh` auth and `GITHUB_TOKEN` via inherited env).
  */
-export interface MakePiDevRunnerOpts {
+export interface MakeSageRunnerOpts {
+  /**
+   * LLM backend forwarded to `sage review --substrate <backend>`
+   * (`claude`|`codex`|`pi`). cortex#917 — passed from the agent's resolved
+   * `runtime.substrate` so a sage agent runs its lenses through the configured
+   * backend. Falls back to `SAGE_SUBSTRATE` env, then `pi`.
+   */
+  substrate?: string;
   /**
    * Explicit sage binary path. Highest-priority resolution (skips env +
    * PATH lookup). Primarily a test seam; production callers typically
@@ -194,8 +201,8 @@ export interface MakePiDevRunnerOpts {
  * **No side effects at construction.** The factory just closes over
  * `opts`; no spawn, no I/O. Safe to call at boot time.
  */
-export function makePiDevPipelineRunner(
-  opts: MakePiDevRunnerOpts = {},
+export function makeSageReviewRunner(
+  opts: MakeSageRunnerOpts = {},
 ): (pipeline: ReviewPipelineOpts) => Promise<ReviewPipelineResult> {
   const spawn = opts.spawn ?? defaultSpawn;
   const which = opts.which ?? defaultWhich;
@@ -235,7 +242,7 @@ export function makePiDevPipelineRunner(
     // `sage review --help`; values outside that set surface as a sage-
     // side `--substrate` parse error (which the failure-mapping table
     // below maps to `cant_do`).
-    const substrate = process.env.SAGE_SUBSTRATE ?? "pi";
+    const substrate = opts.substrate ?? process.env.SAGE_SUBSTRATE ?? "pi";
     // cortex#888 — ask sage to append the structured verdict block as the
     // terminal stdout artefact (sage#83 `--emit-verdict-block`). We parse it
     // below to recover the REAL decision (`approved` is invisible to the

--- a/src/runner/substrate/sage-runner.ts
+++ b/src/runner/substrate/sage-runner.ts
@@ -114,7 +114,7 @@ import type {
 // breaking callers.
 
 /** The handle the runner needs from `Bun.spawn`. */
-export interface PiDevSpawnResult {
+export interface SageSpawnResult {
   stdout: ReadableStream<Uint8Array>;
   stderr: ReadableStream<Uint8Array>;
   exited: Promise<number>;
@@ -128,24 +128,24 @@ export interface PiDevSpawnResult {
  * `review <pr-ref> --substrate <pi|claude|codex>` arguments (substrate
  * value resolved from `SAGE_SUBSTRATE` env, defaults to `pi`).
  */
-export type PiDevSpawnFn = (
+export type SageSpawnFn = (
   argv: string[],
   opts: { stdout: "pipe"; stderr: "pipe" },
-) => PiDevSpawnResult;
+) => SageSpawnResult;
 
 /**
  * Binary resolver — returns the absolute path to the sage CLI, or
  * `undefined` if no binary is found. Production wires `Bun.which`; tests
  * stub this to simulate missing-binary cases.
  */
-export type PiDevWhichFn = (cmd: string) => string | undefined;
+export type SageWhichFn = (cmd: string) => string | undefined;
 
 // ---------------------------------------------------------------------------
 // Public factory
 // ---------------------------------------------------------------------------
 
 /**
- * Options for {@link makePiDevPipelineRunner}.
+ * Options for {@link makeSageReviewRunner}.
  *
  * All fields are optional; the default behaviour is:
  *
@@ -156,12 +156,12 @@ export type PiDevWhichFn = (cmd: string) => string | undefined;
  */
 export interface MakeSageRunnerOpts {
   /**
-   * LLM backend forwarded to `sage review --substrate <backend>`
-   * (`claude`|`codex`|`pi`). cortex#917 — passed from the agent's resolved
-   * `runtime.substrate` so a sage agent runs its lenses through the configured
-   * backend. Falls back to `SAGE_SUBSTRATE` env, then `pi`.
+   * The LLM forwarded to `sage review --substrate <model>` (`claude`|`codex`|
+   * `pi`). cortex#917 — passed from the agent's resolved `runtime.model` so a
+   * sage agent runs its lenses through the configured LLM. Falls back to
+   * `SAGE_SUBSTRATE` env, then `pi`.
    */
-  substrate?: string;
+  model?: string;
   /**
    * Explicit sage binary path. Highest-priority resolution (skips env +
    * PATH lookup). Primarily a test seam; production callers typically
@@ -170,14 +170,14 @@ export interface MakeSageRunnerOpts {
   sageBin?: string;
   /**
    * Spawn function — defaults to `Bun.spawn`. Tests inject a fake that
-   * yields a canned `PiDevSpawnResult`.
+   * yields a canned `SageSpawnResult`.
    */
-  spawn?: PiDevSpawnFn;
+  spawn?: SageSpawnFn;
   /**
    * `which`-style lookup — defaults to `Bun.which`. Tests stub this to
    * simulate the binary-not-found path without touching `$PATH`.
    */
-  which?: PiDevWhichFn;
+  which?: SageWhichFn;
 }
 
 /**
@@ -242,7 +242,7 @@ export function makeSageReviewRunner(
     // `sage review --help`; values outside that set surface as a sage-
     // side `--substrate` parse error (which the failure-mapping table
     // below maps to `cant_do`).
-    const substrate = opts.substrate ?? process.env.SAGE_SUBSTRATE ?? "pi";
+    const substrate = opts.model ?? process.env.SAGE_SUBSTRATE ?? "pi";
     // cortex#888 — ask sage to append the structured verdict block as the
     // terminal stdout artefact (sage#83 `--emit-verdict-block`). We parse it
     // below to recover the REAL decision (`approved` is invisible to the
@@ -263,7 +263,7 @@ export function makeSageReviewRunner(
       argv.push("--forge", forge);
     }
 
-    let proc: PiDevSpawnResult;
+    let proc: SageSpawnResult;
     try {
       proc = spawn(argv, { stdout: "pipe", stderr: "pipe" });
     } catch (err) {
@@ -352,7 +352,7 @@ export function makeSageReviewRunner(
 function defaultSpawn(
   argv: string[],
   opts: { stdout: "pipe"; stderr: "pipe" },
-): PiDevSpawnResult {
+): SageSpawnResult {
   const proc = Bun.spawn(argv, {
     stdout: opts.stdout,
     stderr: opts.stderr,

--- a/src/runner/verdict-block.ts
+++ b/src/runner/verdict-block.ts
@@ -6,7 +6,7 @@ import type { ReviewVerdictKind } from "../bus/review-events";
  * The reviewing skill / substrate emits a structured verdict block as the
  * terminal artefact of its stdout (a fenced ```json block, §4.5). Two runners
  * consume it: the Claude-Code substrate path (`review-pipeline.ts`) and the
- * `pi-dev` substrate path (`substrate/pi-dev-runner.ts`, where sage's
+ * sage-runner path (`substrate/sage-runner.ts`, where sage's
  * `--emit-verdict-block` output lands). Extracted here so both parse the SAME
  * contract — a single field-validation table, one place to evolve.
  */


### PR DESCRIPTION
## What
Introduces `runtime.engine: sage | persona` to select the review engine, decoupled from `runtime.substrate` (now purely the LLM backend). Resolves the cortex#917 design question.

## Why
`substrate` conflated two orthogonal axes: **which engine** (sage lens-CLI vs Claude-Code persona+skill) and **which LLM backend** (claude/codex/pi). `substrate === "pi-dev"` meant "use the sage runner", so a sage agent set `substrate: codex` **silently fell through to the persona path** — "codex" only names a backend. That's why sage reviews on this stack ran as generic claude, losing sage's deterministic lens pipeline.

## Changes
- `runtime.engine: "sage" | "persona"` (optional) on `AgentRuntimeSchema`. `substrate` is now the backend; added clean values `claude`/`pi`.
- `src/runner/review-engine.ts` — pure `resolveReviewEngine(runtime)` → `{engine, backend}`. Explicit engine wins; **legacy shim** maps `substrate: pi-dev`→sage, everything else→persona, preserving pre-split routing byte-for-byte.
- `cortex.ts` routes on the resolver: `engine === "sage"` wires the sage runner with the backend forwarded to `sage review --substrate`; persona/legacy → CC SKILL.md path.
- Renamed the misnomer `pi-dev-runner.ts` → `sage-runner.ts`, `makePiDevPipelineRunner` → `makeSageReviewRunner`; now accepts a `substrate` (backend) opt.

## Testing
- 9 resolver tests + 26 runner/resolver tests; **879 pass** across runner/boot/config suites; tsc clean.
- **Live end-to-end** (stack config migrated to `engine: sage, substrate: codex`, cortex reloaded): boot log shows `agent=sage … engine=sage backend=codex`. A bus review of cortex#919 returned a real `review.verdict.changes-requested` with populated payload — `findings: {blockers:0, majors:1, nits:0}`, real `commit_id`, full 5-lens review (incl. HonestOracle) — **not** the prior empty `commented` / "shall I post?" chat path.

## Context
Completes the chain with sage#83 (`--emit-verdict-block`, merged) + cortex#888 (parse the block, merged). Complementary to #911 (prompt-contract fix), which still benefits `persona`-engine agents (Echo/Luna/Holly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Live E2E evidence

Bus review of the-metafactory/cortex#919 through the migrated stack (`engine: sage, model: codex`), cortex reloaded:
- correlation_id `b0b33231-5cd8-4c34-81d1-9979162efb74`, subject `local.jc.default.tasks.code-review.typescript`
- returned `review.verdict.changes-requested` with populated payload: `findings: {blockers:0, majors:1, nits:0}`, `commit_id: 353aeb46…`, full 5-lens review (HonestOracle caught a scope-claim issue)
- boot log: `review consumer ready for agent=sage … engine=sage model=codex`

Contrast pre-split: empty `commented` `{}` + "shall I post?" chat path.
