### PR TITLE
docs(mc): session-tree domain model — terminology + ADR-0008 + refactor map

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,16 +39,26 @@ The named being cortex runs — Luna, Echo, Forge, Pilot. Has a persona, a voice
 _Avoid_: persona, bot, DA, character
 
 **Agent**:
-The stack-local, long-lived runtime identity (daemon) that hosts an **assistant** on the bus — its own NKey signing identity and a JetStream consumer. An agent has **no independent name**: it is reached via the **assistant** it hosts plus the **stack** it runs on. The same assistant may be hosted by different agents on different stacks ("same assistant, different agent surfaces").
-_Avoid_: bot, persona, daemon (as the domain term)
+The stack-local, long-lived runtime identity (daemon) that hosts an **assistant** on the bus — its own NKey signing identity and a JetStream consumer. An agent has **no independent name**: it is reached via the **assistant** it hosts plus the **stack** it runs on. The same assistant may be hosted by different agents on different stacks ("same assistant, different agent surfaces"). An agent **runs sessions** (it is not itself a session); distinct from the **substrate's** own word "agent" — a Claude Code `Agent`-tool spawn is a **child session**, not a cortex agent (that is a substrate label).
+_Avoid_: bot, persona, daemon (as the domain term); a **session** or **child session** (Claude Code's bare "agent"/"sub-agent" are substrate labels, not the bus-identity agent)
 
-**Sub-agent**:
-A short-lived task spawned via Claude Code's `Agent` tool — e.g. the Engineer or Explore sub-agents the pilot loop uses. Not an **agent**: no bus identity, no persistence. Always carries the `sub-` qualifier; never bare `agent`.
-_Avoid_: agent (bare), worker, helper
+**Sub-agent** (substrate-projection term):
+What the **Claude Code** substrate calls a **child session** spawned via its `Agent`/`Task` tool — e.g. the Engineer or Explore sub-agents the pilot loop uses. **A substrate label, not a domain entity:** the substrate-agnostic term is **child session** (a **session** with a `parent_session_id`); Codex projects a different word for the same row. Mission Control's model + schema speak **session** / **child session**; "sub-agent" survives only as the display label rendered through the Claude-Code lens. Not an **agent**: no bus identity, no persistence. Always carries the `sub-` qualifier; never bare `agent`.
+_Avoid_: agent (bare), worker, helper; "sub-agent" in the MC domain model or schema (say **child session**)
 
 **Agent presence**:
 Whether an **agent** process is up and consuming the bus — *independent of any dispatch*. Carried on the **`agent` domain** (`agent.{online|heartbeat|offline|capabilities-changed}`, G-1114), with a liveness FSM (online while heartbeats arrive within TTL → offline on graceful `offline` or TTL lapse). An idle agent has presence; it is not running a dispatch. Presence is what the Mission Control **Network view** renders across stacks. **Cross-principal, only presence + dispatch *lifecycle* metadata is visible** — never the **session interior** (ADR-0005): clicking a peer's agent shows identity, online state, capabilities, and any federated `dispatch.task.*` lifecycle, but never their tool calls/prompts/diffs (those never leave the peer's stack). Supersedes the observability-only `agents.capabilities.registered` envelope (folded into `agent.online` + `agent.capabilities-changed`; dual-emit then retire — routing is unaffected, it is subject/consumer-filter based, not registry-lookup based). (Resolved 2026-06-10, G-1114 grilling.)
 _Avoid_: liveness (that is the FSM, not the concept), availability; conflating presence with dispatch progress (`system.agent.heartbeat`)
+
+### Sessions
+
+**Session**:
+One run of a **substrate** — a single `claude-code`/`codex`/… execution with its own id (`cc_session_id`), lifecycle, and **session interior**. A session belongs to one **agent** and runs on one **substrate** (an attribute, not a separate hierarchy level). It is the unit Mission Control's working view renders. A session is either **agent-rooted** (started directly by its agent — no parent session) or a **child session** initiated by another session (see **Session tree**). The substrate-neutral term — soma's framing: *"Soma's living existence inside a session of a substrate."* (Resolved 2026-06-11, MC session-tree grilling.)
+_Avoid_: agent (a session is **not** an agent — that conflation is the bug the MC session-tree refactor fixes), run, instance (bare), thread (a platform word)
+
+**Session tree** (parent / child session):
+The recursive structure of an **agent**'s work: a **session** may spawn **child sessions**, each of which may spawn its own — a tree rooted at the agent. The edge is **initiated-by**: a child session carries a `parent_session_id` naming the session that spawned it; an agent-rooted session has none. A child session is structurally *agent-like* — it runs its own session and can spawn further children — but is **not an agent**: no bus identity, no persistence; it is identified with its session. What **Claude Code** calls a **sub-agent** is exactly a child session on the `claude-code` substrate (a substrate-projection label — see **Sub-agent**). (Resolved 2026-06-11.)
+_Avoid_: sub-agent tree (substrate term — say child session), delegation tree (the bus-layer concern an agent owns locally), modelling a child session as its own **agent** row
 
 ### The bus
 
@@ -151,7 +161,8 @@ _Avoid_: reading dashboard `role: operator` as the **principal**; conflating the
 - A **principal**'s **stacks** run in a single **cortex runtime** (one OS process); each stack stays its own isolated M1–M7 slice (identity, subjects, policy) and opens one NatsLink per **network** it joins.
 - A **stack** hosts one or more **agents**.
 - An **agent** hosts exactly one **assistant**; the same assistant may be hosted by different agents on different stacks.
-- An **agent** may spawn zero or more **sub-agents**.
+- An **agent** runs zero or more **sessions** (each one run of a **substrate**); a session belongs to exactly one agent.
+- A **session** may spawn **child sessions** — a **session tree** keyed by `parent_session_id` (the *initiated-by* edge); an agent-rooted session has no parent. Claude Code projects a child session as a **sub-agent**.
 - An **assistant** declares one or more **capabilities**.
 - Work is **dispatched** to an **assistant** as an **envelope** published on a **subject**.
 - A **subject** = `{scope}.{principal}.{stack}.{domain}.…`; its **scope** sets how far it travels.
@@ -176,6 +187,7 @@ _Avoid_: reading dashboard `role: operator` as the **principal**; conflating the
 
 - **`operator` → `principal`.** cortex historically said `operator` (`operator.id`, "operator cockpit", the `{org}` segment). Resolved: **`principal`** ecosystem-wide, matching `soma:principal`. Carries into `cortex.yaml` schema, subject derivation, Mission Control copy. **Carve-outs (two distinct concepts keep the word):** (1) the NATS **NSC operator** (account-tree root, `OP_ANDREAS`) — a NATS-infra identity (see §Identity & trust → NSC operator), always qualified ("NSC operator"), never bare; (2) the **Mission Control authorization role** `operator` (the `viewer | operator | admin` AAA tier) — a surface-only dashboard privilege level, *not* the identity (see §Identity & trust → Mission Control authorization role).
 - **`agent` was overloaded** — the named being, the runtime identity, *and* a Claude Code spawned task. Resolved into **assistant** / **agent** / **sub-agent**.
+- **`agent`/`sub-agent` are substrate-projection labels, not the MC domain model.** Resolved 2026-06-11: cortex's **agent** is the bus runtime identity; a Claude Code `Agent`-tool spawn is a **child session**. Mission Control carries the substrate-agnostic spine — **agent → session → child session** (`parent_session_id` tree), with **substrate** an attribute — and "sub-agent"/CC-"agent" survive only as labels *projected per substrate* (soma already qualifies them "Cortex agent" / "Claude Code sub-agent"). The current `agents`-row-per-session orphan model (`db/sessions.ts` `registerOrphanSession`) is the violation; refactor map in `docs/refactor-mc-session-tree.md`.
 - **`persona` → `assistant`.** `persona` is not a domain entity. `personas/luna.md` stays a valid filename ("the assistant's persona file").
 - **The `@`-segment names an `assistant`** — `@{assistant}`. myelin's `namespace.md` calls it a "principal address"; its examples ("Forge", "Pilot") are assistants. The hosting **agent** is resolved from `(stack, assistant)`; it carries no wire name.
 - **`stack` meant two things** — the M1–M7 layering *and* a deployment unit. Resolved: `stack` is the **deployment unit**; the M1–M7 layering is the **Myelin layer model**.
@@ -198,7 +210,8 @@ Reconciled in full in `compass/ecosystem/CONTEXT-MAP.md`:
 - `cortex:principal` **≡** `soma:principal` — identical concept, identical term (Q2).
 - `cortex:assistant` **≡** `soma:assistant` — the named being.
 - `cortex:agent` **≡** `soma:"Cortex agent"` — SOMA always qualifies `agent`; within cortex's own bounded context bare `agent` is canonical.
-- `cortex:sub-agent` **≡** `soma:"Claude Code sub-agent"`.
+- `cortex:sub-agent` **≡** `soma:"Claude Code sub-agent"` — both **substrate-projection** labels for a **child session**; the domain term is **child session**.
+- `cortex:session` **≡** the substrate-neutral **session** (one run of a **substrate**), seeded by soma's *presence-inside-a-session* framing and promoted to a CONTEXT-MAP boundary term (2026-06-11). A **child session** carries `parent_session_id`; each **substrate** projects its own label onto it (Claude Code → *sub-agent*). The substrate vocabulary is a projection layer; the spine is substrate-agnostic.
 - `cortex:capability` is **distinct from** `soma:skill` — a capability is the bus-routable ability tag; a skill is the packaged implementation that may fulfil it.
 - **myelin** owns the **subject** grammar (a published language cortex consumes). Pending myelin alignment, filed as a namespace.md issue: `{org}` → `{principal}`, the `@`-segment relabelled an *assistant address*, "Reach" → "Scope".
 - **signal** owns **network-wide observability** — the live, cross-peer view of the substrate (which principals'/stacks' leaves are actually connected to a network, leaf RTT/up-since, roster-as-liveness), per `docs/architecture.md` §3.6 (Tier 3). cortex owns only a **stack's own** control-plane federation state — its joined networks, its own leaf link, its accept-subjects (`cortex network status`). A cortex stack cannot observe another peer's leaf; that is a `signal` collection concern (the-metafactory/signal#113). Split: cortex = *what a stack knows about itself*; signal = *what is happening across the federation* — the metafactory analog of TCP/IP's layered diagnostics (ping/traceroute/tcpdump at the right layer).

--- a/docs/adr/0008-unified-mc-session-schema.md
+++ b/docs/adr/0008-unified-mc-session-schema.md
@@ -1,0 +1,96 @@
+# Unified Mission Control session schema across local + cloud
+
+Status: accepted (2026-06-11, grill-with-docs session — MC session-tree modelling)
+
+## Context
+
+The Mission Control backend is **dual-substrate**: a local **bun:sqlite** database
+(`src/surface/mc/db/schema.ts`) serves the in-process daemon at `:8767`, and a **Cloudflare
+D1** database (`src/surface/mc/worker/`) serves the hosted pane at
+`grove.meta-factory.ai/api/*`. They exist for complementary reasons:
+
+- **Local** — serve Mission Control for one stack **without internet access**; it is also
+  the only place the **session interior** lives (`events`/traces, `local`-scope per
+  ADR-0005).
+- **Cloud** — the complementary **network-wide** view: visibility across many principals'
+  stacks, **lifecycle-metadata only** (no interiors).
+
+These were built independently and **diverged into incompatible shapes** for the same
+concept, with **no shared schema source**:
+
+- **Local — normalized.** A "session" is `sessions → agent_task_assignment → agents +
+  tasks` (a 4-table join); `agent_name` lives in `agents`, `status` in
+  `agent_task_assignment.state`, `principal_id` in `tasks`. The orphan ingestor mints **one
+  `agents` row per `cc_session_id`** (the source of the 1,044-tile flood, 2026-06-11).
+- **Cloud — denormalized.** One flat `sessions` row carries `agent_id`, `agent_name`,
+  `principal_id`, `status`, metrics, and the sovereignty columns
+  (`classification`/`data_residency`/`home_principal`). No per-session agent row.
+
+Neither carries the session-tree fields (`parent_session_id`, `substrate`). Extending two
+diverged schemas separately is the exact drift bug class this session already hit
+(mc/cockpit/grove schema divergence, #877/#879). With only two users today, the cost of
+aligning is at its lowest.
+
+## Decision
+
+1. **One identical canonical session schema across both substrates.** The local and cloud
+   `sessions` rows have the **same columns with the same meaning** — derived from a single
+   shared schema source, not hand-maintained twice. The canonical shape is the **flat
+   (denormalized) session-view**: `session_id`, `agent_id`, `agent_name`, `principal_id`,
+   `parent_session_id`, `substrate`, `status`, `started_at`/`ended_at`, metrics, sovereignty
+   (`classification`/`data_residency`/`home_principal`). The session-tree fields
+   (`parent_session_id`, `substrate`) are part of the canonical schema **from the start**.
+
+2. **Local denormalizes its session row to match** (rather than the cloud normalizing to
+   the local model). Local keeps `tasks`/`agent_task_assignment` underneath **for the
+   dispatch control plane**, but the `sessions` row carries the canonical columns directly,
+   kept in sync on write. *(Rejected: a canonical SQL VIEW over the normalized tables — a
+   join-per-read that yields the same shape but not a literally-identical stored row; we
+   want byte-for-byte schema parity, so we denormalize.)*
+
+3. **No domain-mapping / anti-corruption layer between local and cloud — deferred.** The two
+   are kept as **one aligned data model**, not two domains with a translation seam. A
+   mapping layer is premature at two users; revisit only if/when local and cloud needs
+   genuinely diverge. *(Rejected for now: two-domains-plus-mapping — adds an interface and a
+   translation surface to maintain for zero present benefit.)*
+
+4. **Substrates differ in *reach* and *depth*, never *shape*.** Local = single-stack,
+   offline, **holds the interior** (`events`). Cloud = network-wide, online,
+   **metadata-only**. The `events`/interior table stays **local-only** — ADR-0005, interiors
+   never leave the stack. This is the **one principled local-only table**, and it is a
+   *depth* difference (what data), not a *shape* divergence (what a session row means).
+   Convergence is on the session metadata; interiors are out of scope and stay put.
+
+5. **A single shared schema source + a parity test prevent re-drift.** One canonical
+   definition generates the bun:sqlite DDL, the D1 DDL + migration, and the TS types; a CI
+   **parity test** fails if the two physical schemas drift. The **bus envelope is the
+   contract** both ingest paths read (local relay → ingestor; cloud `cloud-publisher` →
+   `/api/ingest`) — the session fields are added to the envelope once and both backends
+   inherit them.
+
+## Consequences
+
+- **The session-tree refactor (`docs/refactor-mc-session-tree.md`) lands on the canonical
+  schema once.** Its Phase 0 becomes **schema convergence** (define the canonical session
+  model + shared source + parity test), not "extend two diverged schemas."
+- **Local migration:** denormalize the `sessions` row to the canonical columns; **remove the
+  per-session orphan `agents` minting** (sessions are not agents — CONTEXT.md §Sessions);
+  observed sessions attach to the real owning agent with `agent_name` as a session column,
+  matching cloud.
+- **Cloud migration:** add `parent_session_id` + `substrate` to D1 (`schema.sql` +
+  `0005_session_tree.sql`); the cloud was already close (flat, `agent_name` a column).
+- **Drift is now caught in CI**, not in production on one surface — the recurring divergence
+  bug class is closed structurally.
+- **Future option preserved, not taken:** if a later need forces local and cloud apart, the
+  deferred mapping layer (decision 3) is where that seam would be introduced — recorded so
+  the next person knows it was a conscious "not yet," not an oversight.
+- **ADR-0005 intact:** interiors remain local; convergence is metadata-shape only.
+
+## References
+
+- `CONTEXT.md` §Sessions + Flagged ambiguities (2026-06-11) — session / session tree /
+  substrate-projection terminology.
+- `compass/ecosystem/CONTEXT-MAP.md` — `session` / `substrate` boundary terms.
+- `docs/refactor-mc-session-tree.md` — the deterministic change map (this ADR sets its
+  Phase 0).
+- ADR-0005 (session-interior locality), #877/#879 (the prior schema-divergence cluster).

--- a/docs/refactor-mc-session-tree.md
+++ b/docs/refactor-mc-session-tree.md
@@ -1,0 +1,314 @@
+# Refactor: Mission Control Session-Tree Domain Model
+
+**Status:** Planned · **Resolved:** 2026-06-11 (MC session-tree grilling) · **Tracking:** TBD (umbrella issue) · **Schema convergence:** [ADR-0008](adr/0008-unified-mc-session-schema.md)
+
+This is the deterministic refactoring map for moving Mission Control + the dev-loop from
+the *"every Claude Code session is an `agents` row"* model to the substrate-agnostic
+**session-tree** domain model resolved in `CONTEXT.md` (§Sessions) and
+`compass/ecosystem/CONTEXT-MAP.md` (boundary terms `session` / `substrate`, the
+projection relationship).
+
+Every section lists `file:line — current behavior — required change`. Line numbers are
+from the survey snapshot (2026-06-11); treat them as anchors, re-confirm before editing.
+
+---
+
+## 1. Why
+
+**The bug (observed 2026-06-11):** the dashboard rendered **1,044 identical "Luna —
+Observed sessions (unregistered)" tiles**. Root cause: the MC orphan ingestor mints **one
+`agents` row per `cc_session_id`**, typed `head` (`db/sessions.ts` `registerOrphanSession`
+→ `ensureOrphanAgent`). An overnight autonomous run is a **deep recursive tree of ~1,000
+sessions** (425 `tool.agent.spawned` edges); the model flattened that whole tree into
+sibling "agent" tiles, and none were reaped (stuck `running`, the prune only catches
+terminal rows).
+
+**The target model (substrate-agnostic):**
+
+```
+agent          the bus runtime identity (NKey + consumer); ~1 per assistant×stack
+  └─ session       one run of a substrate (cc_session_id, interior); belongs to the agent
+       └─ child session   a session with parent_session_id → the session that spawned it
+            └─ …          recursive
+   substrate = claude-code | codex | …   (an ATTRIBUTE of a session, derived from HarnessId)
+```
+
+- A **session is not an agent.** Orphan/observed sessions attach to the **real owning
+  agent** (Luna), as sessions — not as 1,044 synthetic agents.
+- **"sub-agent" is a substrate-projection label** (Claude Code's word for a child session),
+  *derived at render* from `substrate` + `parent_session_id != null` — never stored as an
+  entity type.
+- The working grid renders **agent → its session tree**; sub-agents nest under their parent
+  session.
+
+**Canonical schema (ADR-0008).** The MC backend is dual-substrate (local bun:sqlite + cloud
+D1), and the two `sessions` schemas had **diverged** (normalized-local vs denormalized-cloud,
+no shared source). Per [ADR-0008](adr/0008-unified-mc-session-schema.md), they converge onto
+**one identical canonical session schema** from a **single shared source + a CI parity
+test** — local **denormalizes** its `sessions` row to the flat canonical shape
+(`agent_name`/`principal_id`/`status`/`substrate`/`parent_session_id`/sovereignty as
+columns), cloud was already flat. The two differ only in **reach** (local = single-stack,
+offline; cloud = network-wide) and **depth** (local holds the interior `events`; cloud is
+metadata-only) — **never in shape**. No domain-mapping layer (deferred — two users). The
+session-tree fields land in the canonical schema, not bolted onto two diverged ones.
+
+---
+
+## 2. Invariants (must not break)
+
+1. **Session↔assignment binding** stays for **controlled / dispatch** sessions (every read
+   query joins from `agent_task_assignment` outward; `db/working-agents.ts:93-182`).
+2. **Partial unique indices** on `sessions` stay: `idx_sessions_active_assignment
+   (assignment_id) WHERE ended_at IS NULL` (one active controlled session per assignment)
+   and `idx_sessions_active_cc_session_id` (no duplicate live observed session).
+3. **Terminal → `ended_at` stamping** (`transitions.ts:133-138`) is the new anchor for
+   age-based reaping (replaces the `mc-orphan-` id-prefix anchor).
+4. **Orphan registration idempotency** — keyed on `cc_session_id` + `ended_at IS NULL`.
+5. **Network panel ≠ sessions (ADR-0007).** The G-1114 Network tab is **agent-presence
+   topology** (online/offline/capabilities/federation), *never* session interiors. This
+   refactor does **not** touch `network-*.tsx` / `lib/agents-display.ts` /
+   `lib/network-graph-adapter.ts`. Keep the boundary strict: Network = presence; Working
+   grid = session trees.
+6. **Dual-backend coherence.** The MC backend is **two databases** — local **bun:sqlite**
+   (`db/schema.ts`, `:8767`) and cloud **Cloudflare D1** (`src/surface/mc/worker/`,
+   `grove.meta-factory.ai/api/*`) — with **already-diverged** `sessions` schemas. Every
+   column/projection change applies to **both, in the same PR** (see §5b). The bus envelope
+   is the shared contract feeding both ingest paths — make it the source of truth. (This
+   session already hit this exact bug class: the mc/cockpit/grove schema divergence,
+   #877/#879.)
+
+---
+
+## 3. Open design decisions (resolve early)
+
+| # | Decision | Options | Recommendation |
+|---|---|---|---|
+| **D1** | **Parent-linkage capture** | (a) env-stamp `CORTEX_PARENT_SESSION_ID`; (b) spawn-prompt correlation (`tool.agent.spawned` ↔ child's first prompt); (c) native CC hook field | **Both (a)+(b).** cortex-runner-spawned children (agent-team moderator/participants, dispatched sessions) → **env-stamp (deterministic)**. Claude-Code-`Agent`-tool-spawned children (the orphan flood — the principal's own instrumented run, which cortex's runner never touches) → **prompt-correlation in the ingestor (v1 fallback)**. Adopt native CC parent-session if/when Claude Code exposes it. |
+| **D2** | **Orphan session ownership** | (a) keep per-session synthetic agent; (b) attach orphan sessions to the **real owning agent** | **(b).** Stop minting `mc-orphan-{uuid}` agents. An observed session belongs to the owning **agent** (e.g. Luna); store the observed display name as **session metadata**, not an agent row. Collapses 1,044 fake agents → 1 real agent + 1,044 sessions. |
+| **D3** | **`sessions.assignment_id`** | (a) keep NOT NULL (synthetic assignment for observed); (b) make nullable | **(a) short-term** (zero blast radius on the assignment-anchored joins), revisit to (b) once reads are session-anchored. The synthetic assignment now points at the **real agent**, not a per-session one. |
+| **D4** | **`substrate` column** | (a) `NOT NULL DEFAULT 'claude-code'`; (b) derive from HarnessId at read | **(a).** Store it (cheap, indexable, future substrates self-describe). Set from HarnessId at creation; default `claude-code` for observed hook sessions. |
+| **D5** | **Tree expand/collapse state** | local per-grid vs lifted | **Local component state**, default **collapsed** (child sessions shown on expand). Keyboard-navigable (Arrow up/down depth, left/right expand). |
+
+---
+
+## 4. Phases
+
+Phases are dependency-ordered. Each maps to a slice issue under the umbrella.
+
+### Phase 0 — Schema convergence + canonical session model (foundation) — see [ADR-0008](adr/0008-unified-mc-session-schema.md)
+Converge local + cloud onto **one identical canonical session schema** from a single shared
+source (DDL for both substrates + TS types generated from it; CI **parity test**). Local
+**denormalizes** its `sessions` row to the flat canonical columns (keeping `tasks`/
+`assignment` underneath for the dispatch control plane, synced on write); cloud adds the two
+new columns. The session-tree fields (`parent_session_id`, `substrate`) are part of the
+canonical schema. Interiors (`events`) stay local-only (ADR-0005). No behavior change yet —
+this is the foundation §5 / §5b / §6 build on.
+
+### Phase 1 — Parent-linkage capture (dev-loop / taps / runner)
+Thread `parentSessionId` end-to-end so the tree can be *built*. Per D1: env-stamp for
+runner-spawned, capture the field if present.
+
+### Phase 2 — Ingestor: sessions, not agents
+Stop minting per-session agents; attach observed sessions to the owning agent; set
+`parent_session_id` (env field) or defer to prompt-correlation; set `substrate`.
+
+### Phase 3 — Retention / reaping by session terminal-age
+Reap stuck-`running` and terminal sessions by `ended_at` age, not `mc-orphan-` prefix.
+(Also the immediate-relief mechanism for the zombie class.)
+
+### Phase 4 — API: `/api/working-agents` projects the session tree
+Project `parent_session_id`, `substrate`, `child_sessions[]`, grouped by owning agent.
+
+### Phase 5 — Frontend: render the session tree
+DTO rename + the new tree component (expander, indentation, a11y). Substrate-projection
+label derived at render.
+
+### Phase 6 — Terminology sweep
+Rename `sub-agent`/`subagent` in runner/taps/discord display code to child/spawned-session
+per CONTEXT.md.
+
+### Phase 7 — Tests
+Update fixtures + add tree/reaping/linkage coverage.
+
+---
+
+## 5. Change matrix — MC backend
+
+`src/surface/mc/`
+
+| File:line | Current | Change | Phase |
+|---|---|---|---|
+| `db/schema.ts:88-97` (`sessions` DDL) | no parent/substrate cols | **ADD** `parent_session_id TEXT NULL REFERENCES sessions(id) ON DELETE CASCADE`; **ADD** `substrate TEXT NOT NULL DEFAULT 'claude-code'`; optional `observed_agent_name TEXT` | 0 |
+| `db/schema.ts:128-151` (indices) | assignment-centric | **ADD** `idx_sessions_parent_session_id`, `idx_sessions_substrate` | 0 |
+| `db/schema.ts:56-62` (`agents` DDL) | conflated | keep for **runtime agents only**; add comment "NOT a CC session" | 0 |
+| `types.ts:446-454` (`Session`) | `{id, assignment_id, cc_session_id, endpoint_kind, pid, started_at, ended_at}` | **ADD** `parent_session_id?: string \| null`, `substrate: string`, optional `observed_agent_name?` | 0 |
+| `types.ts:428-434` (`Agent`) | bare | comment: dispatch/runtime agent, **not** a session | 0 |
+| `db/sessions.ts:10-43` (`createSession`) | basic insert | **ADD** params `parentSessionId?`, `substrate` (default `claude-code`), `observedAgentName?` | 0 |
+| `db/sessions.ts:235-288` (`ORPHAN_AGENT_PREFIX`, `orphanAgentId`, `ensureOrphanAgent`) | mints `mc-orphan-{cc}` agent per session | **REMOVE** per-session agent minting (D2) | 2 |
+| `db/sessions.ts:251-258` (`ensureOrphanTask`) | synthetic catch-all task | keep minimal (D3) — anchors the synthetic assignment, but assignment now points at the **real owning agent**, not a per-session orphan | 2 |
+| `db/sessions.ts:311-351` (`registerOrphanSession`) | task + per-orphan agent + assignment + session | **REWRITE**: resolve owning agent (real); insert **session** with `substrate`, `observed_agent_name`, `parent_session_id` (if known); no per-session agent | 2 |
+| `hooks/ingestor.ts:93-119` (orphan auto-register) | calls `registerOrphanSession` (mints agent) | call the rewritten path; **set `parent_session_id`** from the event field (Phase 1) or leave null for prompt-correlation; idempotent on `cc_session_id` | 2 |
+| `hooks/ingestor.ts` (new) | — | **ADD** prompt-correlation (D1b): on a child's first `UserPromptSubmit`, match a recent `tool.agent.spawned.payload.tool_input.prompt` from another session → set child's `parent_session_id` | 2 |
+| `api/handlers.ts:537-551` (`ensureNamedAgent`) | mints agent from wrapper id for observed | **REMOVE/relocate**: store wrapper `agentName` as session metadata, not an agent row | 2 |
+| `api/handlers.ts:600-918` (`handleCreateSession`) | ensures named/default agent; branches on kind | observed path: stop `ensureNamedAgent`; pass `substrate`, `parent_session_id`, `observed_agent_name` to `createSession` | 2 |
+| `api/handlers.ts:520-527` (`ensureDefaultAgent`) | mints `mc-default-agent` (`hands`) | keep (real dispatch agent); comment "not a session" | 2 |
+| `session/endpoint-resolver.ts:89-188` (`spawnControlledSession`) | creates controlled session | pass `substrate='claude-code'`, `parent_session_id=NULL` (top-level dispatch) | 2 |
+| `db/retention.ts:100-122` (`selectPrunableOrphanAssignments`) | filters `agent.id LIKE 'mc-orphan-%'` | **REWRITE**: select sessions by `ended_at < cutoff` (terminal) OR stuck-running past TTL; no agent-prefix filter | 3 |
+| `db/retention.ts:139-211` (`pruneOrphanSessions`) | deletes session+assignment+orphan-agent | delete **sessions** (CASCADE handles children); no orphan-agent delete | 3 |
+| `db/retention.ts:47-65` (consts) | `ORPHAN_RETENTION_MS` | rename `TERMINAL_SESSION_RETENTION_MS`; **ADD** `STUCK_RUNNING_TTL_MS` (reap zombies) | 3 |
+| `db/working-agents.ts:93-182` (`listWorkingAgents`) | joins agents→assignments→tasks | **REWRITE** to project, per owning agent, its **sessions** with `parent_session_id`/`substrate`; assemble `child_sessions[]` tree; keep assignment join for lifecycle | 4 |
+| `api/agents.ts:162-179` (`handleListAgents`) | runtime presence registry | **NO CHANGE** (bus agents, separate domain) | — |
+
+> **Reaping note (Phase 3 doubles as the zombie fix):** the 1,044 stuck-`running` orphans
+> cannot self-clear today (prune is terminal-only). The new `STUCK_RUNNING_TTL_MS` reaper
+> closes them on a liveness lapse — same TTL discipline as the G-1114 agent-presence FSM.
+
+---
+
+## 5b. Change matrix — Cloudflare D1 (cloud backend)
+
+**The MC backend is dual-substrate.** The local in-process daemon uses **bun:sqlite**
+(`db/schema.ts`, served at `:8767`); production uses **Cloudflare D1** behind the CF Worker
+(`src/surface/mc/worker/`, served at `grove.meta-factory.ai/api/*`). The two `sessions`
+schemas have **already diverged**:
+
+- **Local:** normalized — `sessions{id, assignment_id, cc_session_id, endpoint_kind, …}` +
+  `agents` / `agent_task_assignment` / `tasks`.
+- **D1:** flat summary — `sessions{session_id, agent_id, agent_name, project, status, …}`
+  (`agent_name` is **already a column** — *no per-session agent row in cloud*; the cloud
+  side is structurally closer to the target). Neither has `parent_session_id`/`substrate`.
+
+Both are fed by the **same bus envelope**: local via relay → ingestor; cloud via
+`taps/cc-events/cloud-publisher.ts` → `POST /api/ingest` → `worker/src/routes/ingest.ts`.
+**Phase 1 (envelope carries `parent_session_id` + `substrate`) is the single upstream
+change that feeds both** — the coherence anchor.
+
+| File:line | Current | Change | Phase |
+|---|---|---|---|
+| `worker/schema.sql:10-37` (`sessions` DDL) | no parent/substrate | **ADD** `parent_session_id TEXT`, `substrate TEXT DEFAULT 'claude-code'` | 0 |
+| `worker/schema.sql:137-141` (indices) | status/principal | **ADD** `idx_sessions_parent_session_id`, `idx_sessions_substrate` | 0 |
+| `worker/migrations/0005_session_tree.sql` (**NEW**) | next after 0004 | `ALTER TABLE sessions ADD COLUMN parent_session_id TEXT;` + `ADD COLUMN substrate TEXT DEFAULT 'claude-code';` + the two indices; bump `schema_version` (mirror 0004 format) | 0 |
+| `worker/src/routes/ingest.ts:172-177` (INSERT sessions) | no parent/substrate | write `parent_session_id`, `substrate` from the event payload | 2 |
+| `worker/src/routes/ingest.ts:177` (`ON CONFLICT … DO UPDATE`) | COALESCE later events | COALESCE-set the two new cols so later events fill nulls | 2 |
+| `worker/src/routes/ingest.ts:213,279` (UPDATE sessions) | lifecycle updates | preserve the two new cols | 2 |
+| `worker/src/routes/state.ts:243-248,406-409` (session projections) | select `agent_id, agent_name, …` | **SELECT** `parent_session_id`, `substrate`; assemble the **tree** in the cloud state response | 4 |
+| `/api/working-agents` (cloud) | **NOT served by the worker** (grep: none) | cloud working-grid reads `/api/state`; ensure that response carries the session tree, or add a worker `/api/working-agents` mirroring the local projection | 4 |
+| deploy | — | apply the D1 migration **dev → prod** (`wrangler d1 migrations apply <DB> --env dev`, verify, then `--env production`) per `compass/sops/deployment.md` | — |
+
+> **Divergence-coherence rule.** Any change to the session columns or their projection MUST
+> land in **both** backends in the **same PR**: bun:sqlite DDL + queries AND D1
+> schema.sql + migration + worker queries. A column added to one and not the other silently
+> renders the tree on one surface and not the other. The envelope (Phase 1) is the shared
+> contract both ingest paths read — fix it once, both backends inherit the fields.
+
+---
+
+## 6. Change matrix — dev-loop / runner / taps
+
+`src/runner/`, `src/taps/`, `src/common/`
+
+Per **D1**, the robust path for runner-spawned children is the env-stamp
+`CORTEX_PARENT_SESSION_ID`; the EventLogger reads it like any other `CORTEX_*` surface env.
+
+| File:line | Current | Change | Phase |
+|---|---|---|---|
+| `taps/cc-events/hooks/lib/event-types.ts:13-33` (`RawEventSchema`) | no parent field | **ADD** `parent_session_id?: z.string().optional()` | 1 |
+| `taps/cc-events/hooks/lib/event-types.ts:41-51` (`PublishedEventSchema`) | — | **ADD** `parent_session_id?` | 1 |
+| `taps/cc-events/hooks/lib/event-types.ts:59-81` (`createRawEvent`) | — | **ADD** `parentSessionId` option; stamp into result | 1 |
+| `taps/cc-events/hooks/EventLogger.hook.ts:39-52` (`HookInput`) | `session_id?` only | **ADD** `parent_session_id?` (note: not native — see D1) | 1 |
+| `taps/cc-events/hooks/EventLogger.hook.ts:~172` | reads `session_id` only | **ADD** `const parentSessionId = hookInput.parent_session_id ?? process.env.CORTEX_PARENT_SESSION_ID ?? undefined` | 1 |
+| `taps/cc-events/hooks/EventLogger.hook.ts:247-251` (`createRawEvent` call) | passes session/tool/network | **ADD** `parentSessionId` | 1 |
+| `taps/cc-events/cc-events.ts:199-215` (`createCcEventEnvelope`) | flattens event | carry `event.parent_session_id` into `payload.parent_session_id` when present | 1 |
+| `runner/cc-session.ts:22-85` (`CCSessionOpts`) | no parent | **ADD** `parentSessionId?: string` | 1 |
+| `runner/cc-session.ts:130-153` (`buildSessionEnv`) | builds `CORTEX_*` | **ADD** `...(opts.parentSessionId && { CORTEX_PARENT_SESSION_ID: opts.parentSessionId })` | 1 |
+| `runner/claude-invoker.ts:23-38` (`ClaudeInvocationOpts`) | no parent | **ADD** `parentSessionId?: string` (carried via env, not CLI arg) | 1 |
+| `runner/agent-team.ts:106-159` (`AgentTeamOpts`) | no parent | **ADD** `parentSessionId?: string` | 1 |
+| `runner/agent-team.ts:287-302` (`buildTeamOpts`) | maps DispatchRequest→opts | map `req.runtime?.parentSessionId` | 1 |
+| `runner/agent-team.ts:~575` (moderator spawn) | no parent | thread `parentSessionId: this.opts.parentSessionId` | 1 |
+| `runner/agent-team.ts:~686` (participant spawn) | no parent | thread `parentSessionId` | 1 |
+| `runner/agent-team.ts:~864` (synthesis spawn) | no parent | thread `parentSessionId` | 1 |
+| `common/substrates/types.ts:236-292` (`DispatchRuntime`) | `resumeSessionId` etc | **ADD** `parentSessionId?: string` | 1 |
+| `runner/dispatch-listener.ts:192-229` (`DispatchTaskReceivedPayload`) | wire schema | **ADD** `parent_session_id?: string` | 1 |
+| `runner/dispatch-listener.ts:~1570` (`buildDispatchRequest`) | maps payload→runtime | map `payload.parent_session_id → req.runtime.parentSessionId` | 1 |
+| `substrates/claude-code/harness.ts` (locate) | builds `CCSessionOpts` | thread `req.runtime.parentSessionId → CCSessionOpts.parentSessionId` | 1 |
+| `runner/session-manager.ts:6-11` (`SessionEntry`) | thread↔session map | **NO CHANGE** (domain conversation map, not substrate) | — |
+
+### Terminology sweep (Phase 6) — rename substrate-label "sub-agent" → child/spawned session
+
+| File:line | Current | Change |
+|---|---|---|
+| `runner/agent-team.ts:3` | "Sub-agent team orchestration" | "Child-session (moderator + participant) orchestration" |
+| `runner/cc-session.ts:328` | "clean up sub-agents" | "clean up child sessions" |
+| `runner/worklog-formatter.ts:7,26,31-36` | `isSubAgentEvent`, "sub-agent prompts" | `isSpawnedSessionEvent`; "spawned-session prompts (Agent-tool child CC sessions)" |
+| `runner/worklog-manager.ts` (grep `sub-agent`) | comments | "spawned/child session" |
+| `common/event-utils.ts:85` | `label: "subagent"` | `label: "spawned-session"` (or `"child-session"`) |
+| `adapters/discord/event-formatter.ts` (grep) | `tool.agent.spawned` → "subagent" | display label → "spawned-session" |
+
+> Keep "sub-agent" only where it genuinely means *the Claude Code substrate label* (docs,
+> user-facing CC-lens copy). In the **model / schema / API**, say **child session**.
+
+---
+
+## 7. Change matrix — MC frontend
+
+`src/surface/mc/dashboard-v2/`
+
+| File:line | Current | Change | Phase |
+|---|---|---|---|
+| `hooks/use-working-agents.ts:22-47` (`WorkingAgentTile`, response, state) | flat agent-tile DTO (`agent_id`, `agent_name`, `agent_type`, scalar state) | **RENAME → `SessionTreeTile`**: `session_id`, `parent_session_id`, `substrate`, owning `agent_id`, `session_label`, `child_sessions: SessionTreeTile[]`, `primary_session{state,...}`, `additional_active_sessions_count`; drop `agent_type` | 5 |
+| `components/working-grid.tsx:25-127` | flat `.map(agent => tile)` | **RENDER TREE**: group by owning **agent**; per session render tile with **derived substrate-projection label**; expander + nested `child_sessions` (D5); keyboard tree nav | 5 |
+| `lib/working-grid-display.ts:10-52` (`pickWorkingGridMode`) | `agents` input | rename `agents → sessions`; "tiles" mode = render tree; branching logic unchanged | 5 |
+| `lib/` (new) | — | **ADD** `substrate-label.ts`: pure `(substrate, hasParent) → display label` ("sub-agent" for `claude-code`+parent; substrate-neutral otherwise) | 5 |
+| `app.tsx:82,150-201` | `useWorkingAgents`; `<WorkingGrid agents=…>` | prop rename `agents → sessions`; dispatch handlers unchanged (agent-scoped) | 5 |
+| `lib/network-detail-display.ts:96-109` (`selectAgentDispatchActivity`) | per-agent activity join | rename `selectAgentDispatchSessions`; return `{primarySession, additionalSessions[]}` (still lifecycle-metadata only — ADR-0007) | 5 |
+| `components/network-detail-panel.tsx:56-109` | consumes the join | consume renamed/tree-shaped join | 5 |
+| text/aria: `working-grid.tsx:91,96` | "Working agents" / "No agents working" | "Working sessions" / "No sessions active" | 5 |
+| CSS `working-grid.tsx` (`.agent` etc.) | agent classes | `.session-tile`/`.session-label`/tree-row classes | 5 |
+| `components/agent-chips.tsx`, `drill-header.tsx` | assignment **agent** labels | **NO CHANGE** (assignment = agent-level contract) | — |
+| `lib/agents-display.ts`, all `network-*.tsx`, `network-graph-adapter.ts` | agent-presence topology | **NO CHANGE** (Network ≠ sessions; ADR-0007) | — |
+| `components/metrics-panel.tsx:213` | "No agent activity…" | **NO CHANGE** (per-agent aggregate) | — |
+
+---
+
+## 8. Tests (Phase 7)
+
+| File | Change |
+|---|---|
+| `mc/__tests__/sessions-db.test.ts` | cover `createSession` with `parent_session_id`, `substrate` |
+| `mc/__tests__/ingestor.test.ts` | assert orphan insert creates a **session row, not an agent row**; parent set from event field; prompt-correlation path |
+| `mc/__tests__/retention-prune.test.ts` | rewrite: terminal-age + stuck-running-TTL reaping; no agent-prefix filter |
+| `mc/__tests__/agents-ensure-row.test.ts` | clarify: dispatch agents only; observed sessions mint no agent row |
+| `dashboard-v2/__tests__/working-grid.test.tsx` | `sessionTile()` fixtures; tree render, expand/collapse, keyboard nav, derived substrate label |
+| `dashboard-v2/__tests__/network-detail-display.test.ts` | renamed join DTO |
+| taps/runner | env-stamp test: spawning a child sets `CORTEX_PARENT_SESSION_ID`; EventLogger carries `parent_session_id` into the envelope |
+
+---
+
+## 9. Sequencing
+
+```
+Phase 0 (schema+types) ─┬─> Phase 1 (capture: taps/runner)
+                        └─> Phase 2 (ingestor) ──> Phase 3 (reaping)
+                                                └─> Phase 4 (API projection) ──> Phase 5 (frontend)
+Phase 6 (terminology) — independent, any time
+Phase 7 (tests) — alongside each phase
+```
+
+Phase 3 can ship **first** as standalone zombie relief (reap stuck-running by TTL) even
+before the tree lands. Phases 4→5 are the visible payoff (the grid stops flattening the
+tree). Phase 1 is the prerequisite for *accurate* (non-correlation) parenting of
+runner-spawned children.
+
+---
+
+## 10. Provenance
+
+- Domain model resolved in `CONTEXT.md` §Sessions + Flagged ambiguities (2026-06-11) and
+  `compass/ecosystem/CONTEXT-MAP.md` (boundary terms `session`/`substrate`; projection
+  relationship).
+- Empirical basis: 1,029 distinct sessions / 425 `tool.agent.spawned` edges in the
+  2026-06-10 overnight backlog; Claude Code emits no native child→parent session pointer
+  (parent linkage is split across the parent's `tool.agent.spawned` event and the child's
+  first prompt).
+- ADR-0007 boundary preserved: Network view = agent presence; this refactor = working-grid
+  session trees. The two never merge.


### PR DESCRIPTION
Resolves the **agent / sub-agent / session** terminology (grill-with-docs, 2026-06-11) and specs the Mission Control **session-tree** refactor. Brings the sharpened domain model in so other development uses it.

## Why
The dashboard rendered **1,044 flat "Luna — Observed sessions" tiles** — every Claude Code session/sub-agent minted as an `agents` row. Two root causes: (1) no session hierarchy in the model, (2) the dual-backend (local bun:sqlite + cloud D1) `sessions` schemas had diverged.

## What
- **`CONTEXT.md`** — new **Session** + **Session tree** (parent/child) terms; **sub-agent** and bare **agent** reclassified as *substrate-projection labels*. The domain model is **agent → session → child session**, with **substrate** an attribute. "sub-agent" is what Claude Code *projects*; the neutral term is *child session*. Plus flagged-ambiguity + boundary records.
- **`docs/adr/0008-unified-mc-session-schema.md`** — **one identical canonical session schema** across local + cloud, from a single shared source + a CI parity test. Local denormalizes its session row; **no domain-mapping layer** (deferred — two users); interiors stay **local-only** (ADR-0005). The substrates differ in *reach* and *depth*, never *shape*.
- **`docs/refactor-mc-session-tree.md`** — deterministic `file:line` change map across **local SQLite**, **Cloudflare D1**, **dev-loop/runner** (parent-linkage capture), and the **frontend**. Phased: 0 schema convergence → 1 capture → 2 ingestor → 3 reaping → 4 API → 5 frontend → 6 terminology → 7 tests.

## Companion
`compass` PR updates `ecosystem/CONTEXT-MAP.md` with the `session` / `substrate` boundary terms + the projection relationship.

Docs-only. No code changes. The refactor itself is tracked in a follow-up umbrella issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)