### PR TITLE
refactor: ST-P6 — sub-agent → child/spawned session in display code (CONTEXT.md §Sessions)

### DIFF
--- a/src/adapters/discord/event-formatter.ts
+++ b/src/adapters/discord/event-formatter.ts
@@ -22,7 +22,7 @@ const EVENT_LABELS: Record<string, string> = {
   "agent.task.completed": "\u2705 completed",     // ✅
   "agent.task.failed": "\u274C failed",           // ❌
   "tool.file.changed": "\u{1F4DD} file changed",  // 📝
-  "tool.agent.spawned": "\u{1F916} subagent",    // 🤖
+  "tool.agent.spawned": "\u{1F916} spawned session",    // 🤖
   "tool.todo.updated": "\u{1F4CB} progress",     // 📋
 };
 

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -187,7 +187,7 @@ function formatToolProgress(toolName: string, input: Record<string, unknown>): s
     case "WebFetch":
       return `Fetching \`${asString(input.url).slice(0, 60)}\`...`;
     case "Agent":
-      return `Spawning sub-agent: ${asString(input.description) || asString(input.subagent_type) || "working"}...`;
+      return `Spawning session: ${asString(input.description) || asString(input.subagent_type) || "working"}...`;
     case "Skill":
       return `Using skill: \`${asString(input.skill)}\`...`;
     default:
@@ -1464,7 +1464,7 @@ export class DispatchHandler extends EventEmitter {
       "Live dashboard at `grove.meta-factory.ai`. Shows active sessions with real-time activity, recent completions per repo, GitHub events, and session detail views. Sessions stay visible after completion. CLI sessions via `cldyo-live` also appear on the dashboard.",
       "",
       "**Worklog**",
-      "Activity is logged to #worklog with threaded updates per task — file changes, commands, subagents, and progress.",
+      "Activity is logged to #worklog with threaded updates per task — file changes, commands, spawned sessions, and progress.",
       "",
       "**Tips**",
       "- Long tasks? Use `async:` to avoid waiting",

--- a/src/common/event-utils.ts
+++ b/src/common/event-utils.ts
@@ -82,7 +82,7 @@ export function extractActivityEntry(event: IngestEvent): SessionActivity | null
       const desc = asString(event.payload.agent_description) || asString(event.payload.summary);
       if (!desc) return null;
       const detail = desc.length > 100 ? desc.slice(0, 97) + "..." : desc;
-      return { timestamp: event.timestamp, icon: "\u{1F916}", label: "subagent", detail };
+      return { timestamp: event.timestamp, icon: "\u{1F916}", label: "spawned-session", detail };
     }
     case "tool.todo.updated": {
       const summary = event.payload.todo_summary as { total?: number; completed?: number } | undefined;

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -1,5 +1,5 @@
 /**
- * Sub-agent team orchestration adapted from Maestro's Group Chat pattern.
+ * Child-session (moderator + participant) team orchestration adapted from Maestro's Group Chat pattern.
  *
  * A team has a moderator CCSession that coordinates participant sessions.
  * The moderator decides what to delegate, participants do the work,

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -325,7 +325,7 @@ export class CCSession extends EventEmitter {
       this.timeoutId = null;
     }
     if (!this.proc) return;
-    // Give CC a chance to clean up sub-agents
+    // Give CC a chance to clean up child sessions
     this.proc.kill("SIGINT");
     const proc = this.proc;
     setTimeout(() => {

--- a/src/runner/event-utils.ts
+++ b/src/runner/event-utils.ts
@@ -120,7 +120,7 @@ export function extractActivityEntry(event: PublishedEvent): SessionActivity | n
       const desc = asString(event.payload.agent_description) || asString(event.payload.summary);
       if (!desc) return null;
       const detail = desc.length > 100 ? desc.slice(0, 97) + "..." : desc;
-      return { timestamp: event.timestamp, icon: "\u{1F916}", label: "subagent", detail };
+      return { timestamp: event.timestamp, icon: "\u{1F916}", label: "spawned-session", detail };
     }
     case "tool.todo.updated": {
       const summary = event.payload.todo_summary as { total?: number; completed?: number } | undefined;

--- a/src/runner/worklog-formatter.ts
+++ b/src/runner/worklog-formatter.ts
@@ -4,7 +4,7 @@
  *
  * Design goals:
  * - User-facing prompts shown as clean quoted text, not raw system prompts
- * - Sub-agent / moderator / participant prompts suppressed from channel-level
+ * - Spawned-session / moderator / participant prompts suppressed from channel-level
  * - Completion messages show duration and meaningful summary
  * - Thread names are human-scannable at a glance
  */
@@ -23,16 +23,17 @@ function asString(v: unknown): string {
 }
 
 /**
- * Detect whether an event is from a sub-agent (moderator, participant, internal).
- * These should be grouped under the parent task, not shown as top-level entries.
+ * Detect whether an event is from a spawned session (moderator, participant,
+ * Agent-tool child CC session). These should be grouped under the parent task,
+ * not shown as top-level entries.
  */
-export function isSubAgentEvent(event: PublishedEvent): boolean {
+export function isSpawnedSessionEvent(event: PublishedEvent): boolean {
   const preview = asString(event.payload.prompt_preview);
   // Moderator and participant system prompts from agent-team.ts
   if (/^You are a moderator coordinating/i.test(preview)) return true;
   if (/^You are "[^"]+", a specialist participant/i.test(preview)) return true;
   if (/^All participants have responded/i.test(preview)) return true;
-  // Internal sub-agent prompts (Agent tool spawns)
+  // Internal spawned-session prompts (Agent-tool child CC sessions)
   if (/^(Explore|Search|Research|Analyze|Check|Verify|Find|Look)\s/i.test(preview) && preview.length < 80) return true;
   return false;
 }

--- a/src/runner/worklog-manager.ts
+++ b/src/runner/worklog-manager.ts
@@ -16,7 +16,7 @@ import {
   formatChannelStart,
   formatChannelCompletion,
   formatDispatchEnvelopeForThread,
-  isSubAgentEvent,
+  isSpawnedSessionEvent,
   extractTaskDescription,
 } from "./worklog-formatter";
 import { detectProject, extractGitHubIssue } from "./event-utils";
@@ -70,7 +70,7 @@ export class WorklogManager {
   /**
    * Handle a published event — route to the correct worklog thread.
    * Creates a thread if this is the first event for a session.
-   * Sub-agent events are routed to parent thread only (not channel-level).
+   * Spawned-session (child session) events are routed to parent thread only (not channel-level).
    */
   async handleEvent(event: PublishedEvent): Promise<void> {
     const sessionId = event.session_id;
@@ -78,13 +78,13 @@ export class WorklogManager {
 
     this.sessionLastSeen.set(sessionId, Date.now());
 
-    // Sub-agent events (moderator, participant prompts) — skip channel-level posts.
+    // Spawned-session (child session) events (moderator, participant prompts) — skip channel-level posts.
     // They'll still appear inside their parent's thread as progress events.
-    if (isSubAgentEvent(event)) {
+    if (isSpawnedSessionEvent(event)) {
       if (event.event_type === "agent.task.started" || event.event_type === "agent.task.completed" || event.event_type === "agent.task.failed") {
-        return; // Don't create threads or post start/complete for sub-agents
+        return; // Don't create threads or post start/complete for child sessions
       }
-      // Progress events from sub-agents can still go to parent thread
+      // Progress events from child sessions can still go to parent thread
       await this.handleProgressEvent(event);
       return;
     }


### PR DESCRIPTION
## ST-P6 — Terminology sweep: sub-agent → child/spawned session in display code

Phase 6 of [`docs/refactor-mc-session-tree.md`](docs/refactor-mc-session-tree.md) §6 — **independent, display/comments only, no behavior change**. Closes #957, refs #952.

Per **CONTEXT.md §Sessions** + **§Assistants & agents**: the domain model is **agent → session → child session**. "Sub-agent" is Claude Code's **substrate-projection LABEL** for a child session, not a domain entity. MC's display copy and one code symbol are renamed to **child session / spawned session**; "sub-agent" survives only where it genuinely means the CC-lens substrate field.

### Renames (8 files)

| File | Change |
|---|---|
| `runner/agent-team.ts:2` | header comment "Sub-agent team orchestration" → "Child-session (moderator + participant) team orchestration" |
| `runner/cc-session.ts:328` | "clean up sub-agents" → "clean up child sessions" |
| `runner/worklog-formatter.ts:7,26,29,35` | **`isSubAgentEvent` → `isSpawnedSessionEvent`** (only code-symbol change) + comments |
| `runner/worklog-manager.ts:19,73,81,83,85,87` | import + call site updated to `isSpawnedSessionEvent`; comments → spawned/child session |
| `common/event-utils.ts:85` | `SessionActivity` `label: "subagent"` → `"spawned-session"` |
| `runner/event-utils.ts:123` | `SessionActivity` `label: "subagent"` → `"spawned-session"` (sibling producer of the same DTO; kept coherent) |
| `adapters/discord/event-formatter.ts:25` | `tool.agent.spawned` display label "🤖 subagent" → "🤖 spawned session" |
| `bus/dispatch-handler.ts:190,1467` | "Spawning sub-agent" display → "Spawning session"; help text "subagents" → "spawned sessions" |

### `label: "subagent"` — display string, not wire value (investigated)

The `SessionActivity.label` is **persisted** (`worker/src/routes/ingest.ts:316` binds it into `session_activity.label`) — so I checked whether it's a parsed wire value before changing it:

- It is read straight back at `worker/src/routes/state.ts:378` (`SELECT … label …`) and passed through to the frontend **as a display string**.
- It is **never matched, compared, or branched on** anywhere downstream (`grep "subagent"` finds only the two producers; no consumer compares `label === …`).
- Every sibling label in the same switch is free-form display copy (`"file changed"`, `"reading"`, `"command"`, `"progress"`).

→ It is a **display string**, so I changed the value. Historical rows keep their old `"subagent"` text (cosmetically harmless — mixed display copy in the same activity list, no enum/migration coupling). Both producers changed coherently.

### KEEP list (substrate-label-in-CC-lens — 1 hit)

| Hit | Rationale |
|---|---|
| `bus/dispatch-handler.ts:190` `input.subagent_type` | The literal **Claude Code `Agent`/`Task`-tool input field name** (read under `case "Agent":`). This is the substrate's own wire field — renaming it would break reading CC's tool input. Genuine CC-lens label; the surrounding display copy was renamed ("Spawning session"). |

Out of scope per task: `docs/` (historical design docs), `CONTEXT.md` (already done), and the event **type** string `tool.agent.spawned` (wire taxonomy) — all untouched.

### Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (27 pre-existing warnings in untouched files)
- `bun test` — **5820 pass / 0 fail** / 2 skip (338 files)

Closes #957
Refs #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)