### PR TITLE
feat(mc): ST-P0 — canonical session schema convergence, local+D1 (ADR-0008)

### DIFF
--- a/src/surface/mc/__tests__/session-schema-parity.test.ts
+++ b/src/surface/mc/__tests__/session-schema-parity.test.ts
@@ -1,0 +1,177 @@
+/**
+ * ST-P0 / ADR-0008 — canonical session schema PARITY test (the load-bearing
+ * deliverable). Loads the single shared source
+ * ({@link CANONICAL_SESSION_COLUMNS}) and asserts BOTH physical schemas —
+ * the local bun:sqlite `sessions` DDL in `db/schema.ts` and the cloud D1
+ * `sessions` DDL in `worker/schema.sql` — carry every canonical column with the
+ * correct PER-SUBSTRATE physical name (`localName` vs `d1Name`).
+ *
+ * Drift (a canonical column missing from one physical schema, or present under a
+ * name the canonical source did not sanction) FAILS CI. This is the structural
+ * closure of the recurring schema-divergence bug class (#877/#879) that ADR-0008
+ * decision 5 mandates.
+ *
+ * Column extraction is intentionally string-level (parse the `CREATE TABLE
+ * sessions ( … )` body, split on top-level commas, read the leading identifier of
+ * each clause). That keeps the test independent of any DDL-builder and catches a
+ * hand-edit to either physical schema that silently drops/renames a column.
+ */
+import { test, expect, describe } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CANONICAL_SESSION_COLUMNS,
+  CANONICAL_SESSION_INDICES,
+} from "../db/canonical-session";
+import { SCHEMA_SQL } from "../db/schema";
+
+const MC_DIR = join(import.meta.dir, "..");
+const WORKER_SCHEMA = join(MC_DIR, "worker", "schema.sql");
+
+/**
+ * Extract the column names declared in a `CREATE TABLE sessions ( … )` body.
+ * Splits the parenthesised body on top-level commas, then takes the leading
+ * identifier of each clause — skipping table-level CHECK/FK/PRIMARY/UNIQUE
+ * clauses that don't begin with a column name.
+ */
+function extractSessionColumns(createTableSql: string): string[] {
+  // Strip `-- …` line comments FIRST — both physical DDLs carry inline comments
+  // that contain parens/commas (e.g. `(post-did:mf: strip)`); leaving them in
+  // would corrupt the paren-depth + comma split below.
+  const noComments = createTableSql
+    .split("\n")
+    .map((l) => {
+      const i = l.indexOf("--");
+      return i >= 0 ? l.slice(0, i) : l;
+    })
+    .join("\n");
+
+  const open = noComments.indexOf("(");
+  const close = noComments.lastIndexOf(")");
+  const body = noComments.slice(open + 1, close);
+
+  // Top-level comma split, paren-depth-aware so a `DEFAULT (datetime('now'))`
+  // (or any future nested paren) doesn't split a clause.
+  const clauses: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of body) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      clauses.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) clauses.push(current);
+
+  const TABLE_LEVEL = new Set([
+    "CHECK",
+    "FOREIGN",
+    "PRIMARY",
+    "UNIQUE",
+    "CONSTRAINT",
+  ]);
+  const cols: string[] = [];
+  for (const clause of clauses) {
+    const cleaned = clause.replace(/\s+/g, " ").trim();
+    if (!cleaned) continue;
+    const first = cleaned.split(/\s+/)[0];
+    if (!first || TABLE_LEVEL.has(first.toUpperCase())) continue;
+    cols.push(first);
+  }
+  return cols;
+}
+
+/** The local `sessions` CREATE TABLE statement, pulled from SCHEMA_SQL. */
+function localSessionsDdl(): string {
+  const ddl = SCHEMA_SQL.find((s) => /CREATE TABLE IF NOT EXISTS sessions\b/.test(s));
+  if (!ddl) throw new Error("no `sessions` CREATE TABLE found in db/schema.ts SCHEMA_SQL");
+  return ddl;
+}
+
+/** The D1 `sessions` CREATE TABLE statement, pulled from worker/schema.sql. */
+function d1SessionsDdl(): string {
+  const sql = readFileSync(WORKER_SCHEMA, "utf8");
+  const m = /CREATE TABLE IF NOT EXISTS sessions\s*\([\s\S]*?\n\);/.exec(sql);
+  if (!m) throw new Error("no `sessions` CREATE TABLE found in worker/schema.sql");
+  return m[0];
+}
+
+describe("canonical session schema parity (ADR-0008)", () => {
+  const localCols = new Set(extractSessionColumns(localSessionsDdl()));
+  const d1Cols = new Set(extractSessionColumns(d1SessionsDdl()));
+
+  test("local bun:sqlite sessions carries every canonical column under its localName", () => {
+    const missing: string[] = [];
+    for (const col of CANONICAL_SESSION_COLUMNS) {
+      if (!localCols.has(col.localName)) missing.push(col.localName);
+    }
+    expect(missing, `local sessions DDL missing canonical columns: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  test("cloud D1 sessions carries every canonical column under its d1Name", () => {
+    const missing: string[] = [];
+    for (const col of CANONICAL_SESSION_COLUMNS) {
+      if (!d1Cols.has(col.d1Name)) missing.push(col.d1Name);
+    }
+    expect(missing, `D1 sessions DDL missing canonical columns: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  test("the two name-split columns are deliberate Phase-2 renames, not accidental drift", () => {
+    const splits = CANONICAL_SESSION_COLUMNS.filter((c) => c.localName !== c.d1Name);
+    // Exactly the documented pair: identity (id↔session_id) + terminal (ended_at↔completed_at).
+    expect(splits.map((c) => c.d1Name).sort()).toEqual(["completed_at", "session_id"]);
+    for (const c of splits) {
+      // Each split MUST carry a phase2Rename rationale (the gate that proves it's
+      // intended). An undocumented localName!=d1Name would fail here.
+      expect(c.phase2Rename, `split column ${c.d1Name} lacks a phase2Rename rationale`).toBeTruthy();
+      // And both physical names must actually be present in their own schema.
+      expect(localCols.has(c.localName)).toBe(true);
+      expect(d1Cols.has(c.d1Name)).toBe(true);
+    }
+  });
+
+  test("the session-tree fields (parent_session_id, substrate) are present in both", () => {
+    for (const name of ["parent_session_id", "substrate"]) {
+      expect(localCols.has(name), `local missing ${name}`).toBe(true);
+      expect(d1Cols.has(name), `D1 missing ${name}`).toBe(true);
+    }
+  });
+
+  test("both schemas declare the canonical session indices", () => {
+    const localSql = SCHEMA_SQL.join("\n");
+    const d1Sql = readFileSync(WORKER_SCHEMA, "utf8");
+    for (const idx of CANONICAL_SESSION_INDICES) {
+      expect(localSql.includes(idx), `local missing index ${idx}`).toBe(true);
+      expect(d1Sql.includes(idx), `D1 missing index ${idx}`).toBe(true);
+    }
+  });
+});
+
+describe("canonical session column substrate-DDL emission", () => {
+  test("substrate column is NOT NULL DEFAULT 'claude-code' in both physical schemas", () => {
+    const substrate = CANONICAL_SESSION_COLUMNS.find(
+      (c) => c.d1Name === "substrate"
+    )!;
+    expect(substrate.notNull).toBe(true);
+    expect(substrate.default).toBe("'claude-code'");
+
+    const localSql = localSessionsDdl();
+    const d1Sql = d1SessionsDdl();
+    expect(/substrate\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'claude-code'/.test(localSql)).toBe(true);
+    // D1 mirrors with NOT NULL DEFAULT too (fresh-DB path); the migration uses a
+    // bare DEFAULT for the ALTER (SQLite can't ADD a NOT NULL col without default).
+    expect(/substrate\s+TEXT[\s\S]*DEFAULT\s+'claude-code'/.test(d1Sql)).toBe(true);
+  });
+
+  test("parent_session_id is nullable TEXT in both physical schemas", () => {
+    const parent = CANONICAL_SESSION_COLUMNS.find(
+      (c) => c.d1Name === "parent_session_id"
+    )!;
+    expect(parent.notNull).toBe(false);
+    expect(parent.localName).toBe("parent_session_id");
+  });
+});

--- a/src/surface/mc/__tests__/session-schema-parity.test.ts
+++ b/src/surface/mc/__tests__/session-schema-parity.test.ts
@@ -1,5 +1,5 @@
 /**
- * ST-P0 / ADR-0008 — canonical session schema PARITY test (the load-bearing
+ * ST-P0 / ADR-0011 — canonical session schema PARITY test (the load-bearing
  * deliverable). Loads the single shared source
  * ({@link CANONICAL_SESSION_COLUMNS}) and asserts BOTH physical schemas —
  * the local bun:sqlite `sessions` DDL in `db/schema.ts` and the cloud D1
@@ -8,7 +8,7 @@
  *
  * Drift (a canonical column missing from one physical schema, or present under a
  * name the canonical source did not sanction) FAILS CI. This is the structural
- * closure of the recurring schema-divergence bug class (#877/#879) that ADR-0008
+ * closure of the recurring schema-divergence bug class (#877/#879) that ADR-0011
  * decision 5 mandates.
  *
  * Column extraction is intentionally string-level (parse the `CREATE TABLE
@@ -23,7 +23,7 @@ import {
   CANONICAL_SESSION_COLUMNS,
   CANONICAL_SESSION_INDICES,
 } from "../db/canonical-session";
-import { SCHEMA_SQL } from "../db/schema";
+import { SCHEMA_SQL, COLUMN_ADD_MIGRATIONS } from "../db/schema";
 
 const MC_DIR = join(import.meta.dir, "..");
 const WORKER_SCHEMA = join(MC_DIR, "worker", "schema.sql");
@@ -100,7 +100,7 @@ function d1SessionsDdl(): string {
   return m[0];
 }
 
-describe("canonical session schema parity (ADR-0008)", () => {
+describe("canonical session schema parity (ADR-0011)", () => {
   const localCols = new Set(extractSessionColumns(localSessionsDdl()));
   const d1Cols = new Set(extractSessionColumns(d1SessionsDdl()));
 
@@ -142,7 +142,13 @@ describe("canonical session schema parity (ADR-0008)", () => {
   });
 
   test("both schemas declare the canonical session indices", () => {
-    const localSql = SCHEMA_SQL.join("\n");
+    // The two session-tree indices live in the COLUMN_ADD_MIGRATIONS post[]
+    // arrays (NOT in SCHEMA_SQL — see schema.ts: declaring them in SCHEMA_SQL
+    // crashes initDatabase on a pre-P0 DB whose columns the SCHEMA_SQL loop
+    // precedes). Scan BOTH sources so the canonical-contract assertion still
+    // holds after that move.
+    const postIndexSql = COLUMN_ADD_MIGRATIONS.flatMap((m) => m.post ?? []).join("\n");
+    const localSql = [...SCHEMA_SQL, postIndexSql].join("\n");
     const d1Sql = readFileSync(WORKER_SCHEMA, "utf8");
     for (const idx of CANONICAL_SESSION_INDICES) {
       expect(localSql.includes(idx), `local missing index ${idx}`).toBe(true);

--- a/src/surface/mc/__tests__/sessions-db.test.ts
+++ b/src/surface/mc/__tests__/sessions-db.test.ts
@@ -62,7 +62,7 @@ describe("createSession", () => {
     expect(row.pid).toBe(99);
   });
 
-  // --- ST-P0 / ADR-0008 canonical session columns ---
+  // --- ST-P0 / ADR-0011 canonical session columns ---
 
   it("defaults substrate to 'claude-code' when not provided", () => {
     const session = createSession(db, {

--- a/src/surface/mc/__tests__/sessions-db.test.ts
+++ b/src/surface/mc/__tests__/sessions-db.test.ts
@@ -61,6 +61,100 @@ describe("createSession", () => {
     expect(row).toBeTruthy();
     expect(row.pid).toBe(99);
   });
+
+  // --- ST-P0 / ADR-0008 canonical session columns ---
+
+  it("defaults substrate to 'claude-code' when not provided", () => {
+    const session = createSession(db, {
+      assignmentId: "ata-1",
+      endpointKind: "local.observed",
+    });
+    expect(session.substrate).toBe("claude-code");
+    expect(session.parent_session_id).toBeNull();
+
+    const row = db.query("SELECT substrate, parent_session_id FROM sessions WHERE id = ?").get(session.id) as any;
+    expect(row.substrate).toBe("claude-code");
+    expect(row.parent_session_id).toBeNull();
+  });
+
+  it("writes parentSessionId and substrate when provided", () => {
+    const parent = createSession(db, {
+      assignmentId: "ata-1",
+      endpointKind: "local.observed",
+    });
+    // End the parent so the partial unique index idx_sessions_active_assignment
+    // (one open session per assignment) permits the child on the same assignment.
+    endSession(db, parent.id);
+    const child = createSession(db, {
+      assignmentId: "ata-1",
+      endpointKind: "local.observed",
+      parentSessionId: parent.id,
+      substrate: "codex",
+    });
+
+    expect(child.parent_session_id).toBe(parent.id);
+    expect(child.substrate).toBe("codex");
+
+    const row = db
+      .query("SELECT substrate, parent_session_id FROM sessions WHERE id = ?")
+      .get(child.id) as any;
+    expect(row.substrate).toBe("codex");
+    expect(row.parent_session_id).toBe(parent.id);
+  });
+
+  it("writes the denormalized canonical columns when provided", () => {
+    const session = createSession(db, {
+      assignmentId: "ata-1",
+      endpointKind: "local.observed",
+      agentId: "luna",
+      agentName: "Luna",
+      principalId: "andreas",
+      status: "running",
+    });
+
+    expect(session.agent_id).toBe("luna");
+    expect(session.agent_name).toBe("Luna");
+    expect(session.principal_id).toBe("andreas");
+    expect(session.status).toBe("running");
+
+    const row = db
+      .query("SELECT agent_id, agent_name, principal_id, status FROM sessions WHERE id = ?")
+      .get(session.id) as any;
+    expect(row.agent_id).toBe("luna");
+    expect(row.agent_name).toBe("Luna");
+    expect(row.principal_id).toBe("andreas");
+    expect(row.status).toBe("running");
+  });
+
+  it("leaves new canonical columns NULL when not provided (no behavior change for existing callers)", () => {
+    const session = createSession(db, {
+      assignmentId: "ata-1",
+      endpointKind: "local.process.controlled",
+    });
+    expect(session.agent_id).toBeNull();
+    expect(session.agent_name).toBeNull();
+    expect(session.principal_id).toBeNull();
+    expect(session.status).toBeNull();
+    expect(session.parent_session_id).toBeNull();
+
+    const row = db
+      .query("SELECT agent_id, agent_name, principal_id, status FROM sessions WHERE id = ?")
+      .get(session.id) as any;
+    expect(row.agent_id).toBeNull();
+    expect(row.agent_name).toBeNull();
+    expect(row.principal_id).toBeNull();
+    expect(row.status).toBeNull();
+  });
+
+  it("enforces the parent_session_id self-FK", () => {
+    expect(() => {
+      createSession(db, {
+        assignmentId: "ata-1",
+        endpointKind: "local.observed",
+        parentSessionId: "ghost-session",
+      });
+    }).toThrow();
+  });
 });
 
 describe("findActiveSession", () => {

--- a/src/surface/mc/__tests__/st-p0-existing-db-migration.test.ts
+++ b/src/surface/mc/__tests__/st-p0-existing-db-migration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * ST-P0 / ADR-0011 — existing pre-P0 DB migration regression.
+ *
+ * The session-tree canonical columns (`parent_session_id`/`substrate` + the
+ * denormalized set) are ADDED to an already-initialised local DB by
+ * COLUMN_ADD_MIGRATIONS. This test proves `initDatabase` survives a faithful
+ * PRE-P0 sessions table -- the shape the running stacks at
+ * ~/.local/share/cortex/mc/<stack>/mission-control.db carry (no
+ * parent_session_id/substrate yet).
+ *
+ * REGRESSION GUARD (review 4473738000 blocker): the two session-tree
+ * CREATE INDEX ON sessions(parent_session_id) / (substrate) statements
+ * must NOT live in SCHEMA_SQL -- init.ts runs the full SCHEMA_SQL loop BEFORE
+ * COLUMN_ADD_MIGRATIONS adds those columns, so on an existing DB they reference
+ * columns that do not yet exist (no such column: parent_session_id), and
+ * initDatabase aborts so the daemon cannot open its DB. The indices belong in
+ * the COLUMN_ADD_MIGRATIONS post[] arrays (which run AFTER the ALTERs and
+ * unconditionally, so fresh DBs stay covered too). CI was green only because
+ * every other test uses a FRESH DB where the columns exist from CREATE TABLE.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { SCHEMA_SQL } from "../db/schema";
+import { initDatabase } from "../db/init";
+
+// The pre-P0 sessions shape: exactly the id..ended_at columns the running
+// stacks carry, BEFORE the ST-P0 canonical/session-tree columns were added.
+const OLD_SESSIONS = `CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  assignment_id TEXT NOT NULL REFERENCES agent_task_assignment(id) ON DELETE CASCADE,
+  cc_session_id TEXT,
+  endpoint_kind TEXT NOT NULL
+    CHECK(endpoint_kind IN ('local.process.controlled','local.observed','local.process.autonomous')),
+  pid INTEGER,
+  started_at TEXT NOT NULL DEFAULT (datetime('now')),
+  ended_at TEXT
+)`;
+
+/**
+ * Build a faithful pre-P0 DB: every table from SCHEMA_SQL EXCEPT `sessions`
+ * (replaced by its OLD shape), and crucially WITHOUT applying any
+ * COLUMN_ADD_MIGRATIONS — so the session-tree columns are genuinely absent,
+ * the way an already-running stack's DB is before this PR lands.
+ *
+ * SCHEMA_SQL index statements that reference the not-yet-existing session
+ * columns are the very thing under test — so we run SCHEMA_SQL as-is here only
+ * for the OTHER tables. The session-tree indices (if still wrongly in
+ * SCHEMA_SQL) are skipped at build time so the seed itself can be constructed;
+ * the regression is what happens when `initDatabase` re-runs the FULL SCHEMA_SQL
+ * over this old DB.
+ */
+function buildPreP0Db(path: string): Database {
+  const db = new Database(path, { create: true });
+  db.run("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) {
+    if (sql.includes("CREATE TABLE IF NOT EXISTS sessions (")) {
+      db.run(OLD_SESSIONS);
+      continue;
+    }
+    // Skip any index that targets the session-tree columns that don't exist on
+    // the pre-P0 table — building the seed must not depend on the bug we test.
+    if (/ON sessions\s*\(\s*(parent_session_id|substrate)\b/.test(sql)) continue;
+    db.run(sql);
+  }
+  return db;
+}
+
+describe("ST-P0 — existing pre-P0 DB session-tree migration", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) {
+      for (const suffix of ["", "-wal", "-shm"]) if (existsSync(p + suffix)) rmSync(p + suffix);
+    }
+    paths.length = 0;
+  });
+  function freshPath() {
+    const p = join(tmpdir(), `st-p0-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return p;
+  }
+
+  it("initDatabase succeeds on a pre-P0 sessions table and backfills the canonical columns", () => {
+    const path = freshPath();
+
+    // --- seed: a pre-P0 DB with a real session row under an assignment.
+    const old = buildPreP0Db(path);
+    old.run(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Echo', 'head')`);
+    old.run(
+      `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('t-1', 'A task', 'andreas', 'github', 'open')`
+    );
+    old.run(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('x-1', 'a-1', 't-1', 'running')`
+    );
+    old.run(
+      `INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at) VALUES ('s-1', 'x-1', 'local.process.controlled', datetime('now'))`
+    );
+    // Sanity: the pre-P0 table genuinely lacks the session-tree columns.
+    const preCols = old
+      .query(`SELECT name FROM pragma_table_info('sessions')`)
+      .all() as { name: string }[];
+    const preNames = preCols.map((c) => c.name);
+    expect(preNames).not.toContain("parent_session_id");
+    expect(preNames).not.toContain("substrate");
+    old.close();
+
+    // --- reopen via initDatabase → MUST NOT throw `no such column: …`.
+    const db = initDatabase(path);
+
+    // Canonical session-tree columns now exist on the migrated table.
+    const cols = db
+      .query(`SELECT name FROM pragma_table_info('sessions')`)
+      .all() as { name: string }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("parent_session_id");
+    expect(names).toContain("substrate");
+    for (const c of [
+      "agent_id",
+      "agent_name",
+      "principal_id",
+      "status",
+      "duration_ms",
+      "events_count",
+      "input_tokens",
+      "output_tokens",
+      "cache_read_tokens",
+      "cost_usd",
+      "classification",
+      "data_residency",
+      "home_principal",
+    ]) {
+      expect(names).toContain(c);
+    }
+
+    // The existing row survived: substrate backfilled to the NOT NULL default,
+    // parent_session_id left NULL (agent-rooted), original data intact.
+    const row = db.query(`SELECT * FROM sessions WHERE id='s-1'`).get() as Record<string, unknown>;
+    expect(row.substrate).toBe("claude-code");
+    expect(row.parent_session_id).toBeNull();
+    expect(row.assignment_id).toBe("x-1");
+
+    // The session-tree indices were created (by the COLUMN_ADD_MIGRATIONS post[]).
+    const idx = db
+      .query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='sessions'`)
+      .all() as { name: string }[];
+    const idxNames = idx.map((r) => r.name);
+    expect(idxNames).toContain("idx_sessions_parent_session_id");
+    expect(idxNames).toContain("idx_sessions_substrate");
+
+    expect(db.query(`PRAGMA foreign_key_check`).all()).toEqual([]);
+    db.close();
+  });
+
+  it("is idempotent — a second init over the migrated DB does not error, columns + indices intact", () => {
+    const path = freshPath();
+    const old = buildPreP0Db(path);
+    old.run(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Echo', 'head')`);
+    old.run(
+      `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('t-1', 'A', 'andreas', 'github', 'open')`
+    );
+    old.run(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('x-1', 'a-1', 't-1', 'running')`
+    );
+    old.run(
+      `INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at) VALUES ('s-1', 'x-1', 'local.observed', datetime('now'))`
+    );
+    old.close();
+
+    const db1 = initDatabase(path);
+    db1.close();
+    const db2 = initDatabase(path);
+    const names = (db2.query(`SELECT name FROM pragma_table_info('sessions')`).all() as { name: string }[]).map((c) => c.name);
+    expect(names).toContain("parent_session_id");
+    expect(names).toContain("substrate");
+    const idxNames = (db2.query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='sessions'`).all() as { name: string }[]).map((r) => r.name);
+    expect(idxNames).toContain("idx_sessions_parent_session_id");
+    expect(idxNames).toContain("idx_sessions_substrate");
+    expect(db2.query(`PRAGMA foreign_key_check`).all()).toEqual([]);
+    db2.close();
+  });
+
+  it("a fresh DB still gets the session-tree columns + indices (post[] runs unconditionally)", () => {
+    const path = freshPath();
+    const db = initDatabase(path);
+    const names = (db.query(`SELECT name FROM pragma_table_info('sessions')`).all() as { name: string }[]).map((c) => c.name);
+    expect(names).toContain("parent_session_id");
+    expect(names).toContain("substrate");
+    const idxNames = (db.query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='sessions'`).all() as { name: string }[]).map((r) => r.name);
+    expect(idxNames).toContain("idx_sessions_parent_session_id");
+    expect(idxNames).toContain("idx_sessions_substrate");
+    db.close();
+  });
+});

--- a/src/surface/mc/__tests__/types.test.ts
+++ b/src/surface/mc/__tests__/types.test.ts
@@ -61,6 +61,25 @@ describe("mission-control types", () => {
   });
 
   it("Session type accepts both controlled and observed kinds", () => {
+    // ST-P0 / ADR-0008 canonical session columns (denormalized fields nullable
+    // this phase; substrate NOT NULL with a default; parent_session_id self-ref).
+    const canonicalDefaults = {
+      parent_session_id: null,
+      substrate: "claude-code",
+      agent_id: null,
+      agent_name: null,
+      principal_id: null,
+      status: null,
+      duration_ms: null,
+      events_count: null,
+      input_tokens: null,
+      output_tokens: null,
+      cache_read_tokens: null,
+      cost_usd: null,
+      classification: null,
+      data_residency: null,
+      home_principal: null,
+    };
     const controlled: Session = {
       id: "s-1",
       assignment_id: "ata-1",
@@ -69,6 +88,7 @@ describe("mission-control types", () => {
       pid: 12345,
       started_at: "2026-04-17T00:00:00Z",
       ended_at: null,
+      ...canonicalDefaults,
     };
     const observed: Session = {
       id: "s-2",
@@ -78,9 +98,16 @@ describe("mission-control types", () => {
       pid: null,
       started_at: "2026-04-17T00:00:00Z",
       ended_at: null,
+      ...canonicalDefaults,
+      // a child session on a non-default substrate exercises the new fields
+      parent_session_id: "s-1",
+      substrate: "codex",
     };
     expect(controlled.endpoint_kind).toBe("local.process.controlled");
     expect(observed.endpoint_kind).toBe("local.observed");
+    expect(controlled.substrate).toBe("claude-code");
+    expect(observed.parent_session_id).toBe("s-1");
+    expect(observed.substrate).toBe("codex");
   });
 
   it("McEvent type accepts valid shape", () => {

--- a/src/surface/mc/__tests__/types.test.ts
+++ b/src/surface/mc/__tests__/types.test.ts
@@ -61,7 +61,7 @@ describe("mission-control types", () => {
   });
 
   it("Session type accepts both controlled and observed kinds", () => {
-    // ST-P0 / ADR-0008 canonical session columns (denormalized fields nullable
+    // ST-P0 / ADR-0011 canonical session columns (denormalized fields nullable
     // this phase; substrate NOT NULL with a default; parent_session_id self-ref).
     const canonicalDefaults = {
       parent_session_id: null,

--- a/src/surface/mc/db/canonical-session.ts
+++ b/src/surface/mc/db/canonical-session.ts
@@ -1,7 +1,7 @@
 /**
  * Canonical Mission Control session schema — the SINGLE shared source.
  *
- * ADR-0008 ("Unified Mission Control session schema across local + cloud"):
+ * ADR-0011 ("Unified Mission Control session schema across local + cloud"):
  * the MC backend is dual-substrate — a local **bun:sqlite** DB (`db/schema.ts`,
  * served at `:8767`) and a cloud **Cloudflare D1** DB (`worker/schema.sql`,
  * served at `grove.meta-factory.ai/api/*`). The two `sessions` schemas had
@@ -11,7 +11,7 @@
  * schemas are derived/validated from this list by a CI **parity test**
  * (`__tests__/session-schema-parity.test.ts`) that fails on drift.
  *
- * The canonical shape is the **flat (denormalized) session-view** per ADR-0008
+ * The canonical shape is the **flat (denormalized) session-view** per ADR-0011
  * decision 1: `agent_id`, `agent_name`, `principal_id`, `parent_session_id`,
  * `substrate`, `status`, started/ended, metrics, and the sovereignty columns
  * live directly on the `sessions` row. Local keeps `tasks`/`agent_task_assignment`
@@ -23,9 +23,9 @@
  * means), so it is deliberately NOT part of this canonical session row.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * NAMING RECONCILIATION (ADR-0008 — "identical schemas", prefer D1 names)
+ * NAMING RECONCILIATION (ADR-0011 — "identical schemas", prefer D1 names)
  * ─────────────────────────────────────────────────────────────────────────────
- * Two columns historically differ in name between the substrates. ADR-0008 says
+ * Two columns historically differ in name between the substrates. ADR-0011 says
  * prefer the D1 names (cloud is closer to the target), BUT Phase 0 is a
  * NO-BEHAVIOR-CHANGE foundation: renaming the local PK or the local
  * terminal-timestamp would cascade through FK columns (`events.session_id`,
@@ -45,7 +45,7 @@
  * {@link CanonicalSessionColumn.phase2Rename} TODO marker. The parity test reads
  * these so it asserts the RIGHT physical name per substrate (not a false drift).
  *
- * TODO(Phase 2, ADR-0008): converge the two split columns to a single physical
+ * TODO(Phase 2, ADR-0011): converge the two split columns to a single physical
  * name (`session_id`, `completed_at`) on the local side once the PK/timestamp
  * rename can be done with its FK + index + query cascade in one deliberate
  * migration. Until then `localName !== d1Name` is the *intended* state, gated by
@@ -62,7 +62,7 @@ export type CanonicalSqliteType = "TEXT" | "INTEGER" | "REAL";
  *   (c) the TS `Session` field (`types.ts`).
  */
 export interface CanonicalSessionColumn {
-  /** Canonical/logical name (D1-preferred per ADR-0008). */
+  /** Canonical/logical name (D1-preferred per ADR-0011). */
   d1Name: string;
   /**
    * Physical column name on the LOCAL bun:sqlite `sessions` table. Equals
@@ -77,7 +77,7 @@ export interface CanonicalSessionColumn {
   default: string | null;
   /**
    * Set when {@link localName} !== {@link d1Name} as a DELIBERATE Phase-2-deferred
-   * rename (ADR-0008). The parity test reads this to avoid flagging the split as
+   * rename (ADR-0011). The parity test reads this to avoid flagging the split as
    * accidental drift; the string is the rationale surfaced in the TODO.
    */
   phase2Rename?: string;
@@ -86,7 +86,7 @@ export interface CanonicalSessionColumn {
 }
 
 /**
- * THE canonical session column set (ADR-0008). Order matters only for readable
+ * THE canonical session column set (ADR-0011). Order matters only for readable
  * DDL output; the parity test compares as a set keyed by name.
  *
  * New canonical columns added beyond the pre-existing local `sessions` columns
@@ -94,7 +94,7 @@ export interface CanonicalSessionColumn {
  * `ended_at`) are nullable where the data does not exist yet on the local side
  * (`agent_id`, `agent_name`, `principal_id`, `status`, metrics, sovereignty) —
  * Phase 2 populates them on write. The two session-tree fields land NOT-NULL-ish
- * per ADR-0008: `parent_session_id` nullable (self-ref; agent-rooted sessions
+ * per ADR-0011: `parent_session_id` nullable (self-ref; agent-rooted sessions
  * have none), `substrate` NOT NULL DEFAULT 'claude-code'.
  */
 export const CANONICAL_SESSION_COLUMNS: CanonicalSessionColumn[] = [
@@ -106,10 +106,10 @@ export const CANONICAL_SESSION_COLUMNS: CanonicalSessionColumn[] = [
     notNull: true,
     default: null,
     phase2Rename:
-      "local PK is `id`; renaming to `session_id` cascades through events.session_id / attention_items.session_id FKs, the partial unique indices, and every read query — deferred to Phase 2 (ADR-0008).",
+      "local PK is `id`; renaming to `session_id` cascades through events.session_id / attention_items.session_id FKs, the partial unique indices, and every read query — deferred to Phase 2 (ADR-0011).",
     note: "Session identity (PK). Canonical name session_id; local physical PK stays `id` until the Phase-2 rename.",
   },
-  // --- ownership / attribution (denormalized onto the row, ADR-0008 decision 1) ---
+  // --- ownership / attribution (denormalized onto the row, ADR-0011 decision 1) ---
   {
     d1Name: "agent_id",
     localName: "agent_id",
@@ -134,7 +134,7 @@ export const CANONICAL_SESSION_COLUMNS: CanonicalSessionColumn[] = [
     default: null,
     note: "Principal the session belongs to. NULL on local until Phase 2 syncs it off tasks.principal_id.",
   },
-  // --- session tree (ADR-0008: canonical from the start) ---
+  // --- session tree (ADR-0011: canonical from the start) ---
   {
     d1Name: "parent_session_id",
     localName: "parent_session_id",
@@ -175,7 +175,7 @@ export const CANONICAL_SESSION_COLUMNS: CanonicalSessionColumn[] = [
     notNull: false,
     default: null,
     phase2Rename:
-      "local terminal timestamp is `ended_at`; renaming to `completed_at` touches the partial unique indices, transitions.ts terminal-stamping, and retention.ts reaping — deferred to Phase 2 (ADR-0008).",
+      "local terminal timestamp is `ended_at`; renaming to `completed_at` touches the partial unique indices, transitions.ts terminal-stamping, and retention.ts reaping — deferred to Phase 2 (ADR-0011).",
     note: "Terminal timestamp. Canonical name completed_at; local physical column stays `ended_at` until the Phase-2 rename.",
   },
   // --- metrics ---

--- a/src/surface/mc/db/canonical-session.ts
+++ b/src/surface/mc/db/canonical-session.ts
@@ -1,0 +1,299 @@
+/**
+ * Canonical Mission Control session schema — the SINGLE shared source.
+ *
+ * ADR-0008 ("Unified Mission Control session schema across local + cloud"):
+ * the MC backend is dual-substrate — a local **bun:sqlite** DB (`db/schema.ts`,
+ * served at `:8767`) and a cloud **Cloudflare D1** DB (`worker/schema.sql`,
+ * served at `grove.meta-factory.ai/api/*`). The two `sessions` schemas had
+ * **diverged** (normalized-local vs denormalized-cloud) with no shared source —
+ * the exact drift bug class of #877/#879. This module is the convergence point:
+ * the canonical session columns are defined ONCE here, and both physical
+ * schemas are derived/validated from this list by a CI **parity test**
+ * (`__tests__/session-schema-parity.test.ts`) that fails on drift.
+ *
+ * The canonical shape is the **flat (denormalized) session-view** per ADR-0008
+ * decision 1: `agent_id`, `agent_name`, `principal_id`, `parent_session_id`,
+ * `substrate`, `status`, started/ended, metrics, and the sovereignty columns
+ * live directly on the `sessions` row. Local keeps `tasks`/`agent_task_assignment`
+ * underneath for the dispatch control plane (synced on write, Phase 2); cloud was
+ * already flat.
+ *
+ * Interiors (`events`) stay LOCAL-ONLY (ADR-0005) — that is a *depth* difference
+ * (what data each substrate holds), not a *shape* divergence (what a session row
+ * means), so it is deliberately NOT part of this canonical session row.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * NAMING RECONCILIATION (ADR-0008 — "identical schemas", prefer D1 names)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Two columns historically differ in name between the substrates. ADR-0008 says
+ * prefer the D1 names (cloud is closer to the target), BUT Phase 0 is a
+ * NO-BEHAVIOR-CHANGE foundation: renaming the local PK or the local
+ * terminal-timestamp would cascade through FK columns (`events.session_id`,
+ * `attention_items.session_id`), the partial unique indices, `transitions.ts`,
+ * `retention.ts`, and every read query. So per the task's explicit carve-out
+ * ("local may keep its existing PK column name if renaming would cascade
+ * behavior changes — document as a Phase 2 TODO"), the local physical column
+ * name is preserved this phase while the *canonical meaning* is shared.
+ *
+ *   canonical concept   | D1 column      | local column | this phase
+ *   --------------------|----------------|--------------|---------------------------
+ *   session identity    | session_id     | id           | KEEP both (rename = Phase 2)
+ *   terminal timestamp  | completed_at   | ended_at     | KEEP both (rename = Phase 2)
+ *
+ * Each such split is recorded as a {@link CanonicalSessionColumn.localName} that
+ * differs from {@link CanonicalSessionColumn.d1Name}, plus a
+ * {@link CanonicalSessionColumn.phase2Rename} TODO marker. The parity test reads
+ * these so it asserts the RIGHT physical name per substrate (not a false drift).
+ *
+ * TODO(Phase 2, ADR-0008): converge the two split columns to a single physical
+ * name (`session_id`, `completed_at`) on the local side once the PK/timestamp
+ * rename can be done with its FK + index + query cascade in one deliberate
+ * migration. Until then `localName !== d1Name` is the *intended* state, gated by
+ * `phase2Rename`.
+ */
+
+/** SQLite/D1 affinity used by the canonical columns. */
+export type CanonicalSqliteType = "TEXT" | "INTEGER" | "REAL";
+
+/**
+ * One canonical session column. The shared source emits, from this list:
+ *   (a) the bun:sqlite DDL fragment (local `schema.ts`) — via {@link localName},
+ *   (b) the D1 DDL fragment (`worker/schema.sql`)        — via {@link d1Name},
+ *   (c) the TS `Session` field (`types.ts`).
+ */
+export interface CanonicalSessionColumn {
+  /** Canonical/logical name (D1-preferred per ADR-0008). */
+  d1Name: string;
+  /**
+   * Physical column name on the LOCAL bun:sqlite `sessions` table. Equals
+   * {@link d1Name} for every column EXCEPT the two pre-existing splits the PK /
+   * terminal-timestamp rename defers to Phase 2 (`id`, `ended_at`).
+   */
+  localName: string;
+  type: CanonicalSqliteType;
+  /** `true` ⇒ column is `NOT NULL` (with a `DEFAULT`); `false` ⇒ nullable. */
+  notNull: boolean;
+  /** SQL literal default (already quoted if TEXT), or null for no default. */
+  default: string | null;
+  /**
+   * Set when {@link localName} !== {@link d1Name} as a DELIBERATE Phase-2-deferred
+   * rename (ADR-0008). The parity test reads this to avoid flagging the split as
+   * accidental drift; the string is the rationale surfaced in the TODO.
+   */
+  phase2Rename?: string;
+  /** Short human note (mirrored into the DDL comment + the type doc). */
+  note: string;
+}
+
+/**
+ * THE canonical session column set (ADR-0008). Order matters only for readable
+ * DDL output; the parity test compares as a set keyed by name.
+ *
+ * New canonical columns added beyond the pre-existing local `sessions` columns
+ * (`id`/`assignment_id`/`cc_session_id`/`endpoint_kind`/`pid`/`started_at`/
+ * `ended_at`) are nullable where the data does not exist yet on the local side
+ * (`agent_id`, `agent_name`, `principal_id`, `status`, metrics, sovereignty) —
+ * Phase 2 populates them on write. The two session-tree fields land NOT-NULL-ish
+ * per ADR-0008: `parent_session_id` nullable (self-ref; agent-rooted sessions
+ * have none), `substrate` NOT NULL DEFAULT 'claude-code'.
+ */
+export const CANONICAL_SESSION_COLUMNS: CanonicalSessionColumn[] = [
+  // --- identity ---
+  {
+    d1Name: "session_id",
+    localName: "id",
+    type: "TEXT",
+    notNull: true,
+    default: null,
+    phase2Rename:
+      "local PK is `id`; renaming to `session_id` cascades through events.session_id / attention_items.session_id FKs, the partial unique indices, and every read query — deferred to Phase 2 (ADR-0008).",
+    note: "Session identity (PK). Canonical name session_id; local physical PK stays `id` until the Phase-2 rename.",
+  },
+  // --- ownership / attribution (denormalized onto the row, ADR-0008 decision 1) ---
+  {
+    d1Name: "agent_id",
+    localName: "agent_id",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note: "Owning agent (the bus runtime identity). NULL on local until Phase 2 syncs it off the assignment join.",
+  },
+  {
+    d1Name: "agent_name",
+    localName: "agent_name",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note: "Owning agent display name, carried as a SESSION column (a session is not an agent). NULL on local until Phase 2.",
+  },
+  {
+    d1Name: "principal_id",
+    localName: "principal_id",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note: "Principal the session belongs to. NULL on local until Phase 2 syncs it off tasks.principal_id.",
+  },
+  // --- session tree (ADR-0008: canonical from the start) ---
+  {
+    d1Name: "parent_session_id",
+    localName: "parent_session_id",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note: "Self-ref to the session that spawned this one. NULL ⇒ agent-rooted session. The session-tree edge (CONTEXT.md §Session tree).",
+  },
+  {
+    d1Name: "substrate",
+    localName: "substrate",
+    type: "TEXT",
+    notNull: true,
+    default: "'claude-code'",
+    note: "The substrate this session runs on (claude-code | codex | …). An attribute of a session, derived from HarnessId (refactor §3 D4).",
+  },
+  // --- lifecycle ---
+  {
+    d1Name: "status",
+    localName: "status",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note: "Denormalized lifecycle status. NULL on local until Phase 2 syncs it off agent_task_assignment.state.",
+  },
+  {
+    d1Name: "started_at",
+    localName: "started_at",
+    type: "TEXT",
+    notNull: true,
+    default: null,
+    note: "Session start (ISO 8601). The one timestamp whose name already agrees across substrates.",
+  },
+  {
+    d1Name: "completed_at",
+    localName: "ended_at",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    phase2Rename:
+      "local terminal timestamp is `ended_at`; renaming to `completed_at` touches the partial unique indices, transitions.ts terminal-stamping, and retention.ts reaping — deferred to Phase 2 (ADR-0008).",
+    note: "Terminal timestamp. Canonical name completed_at; local physical column stays `ended_at` until the Phase-2 rename.",
+  },
+  // --- metrics ---
+  {
+    d1Name: "duration_ms",
+    localName: "duration_ms",
+    type: "INTEGER",
+    notNull: false,
+    default: null,
+    note: "Wall-clock duration. NULL until known.",
+  },
+  {
+    d1Name: "events_count",
+    localName: "events_count",
+    type: "INTEGER",
+    notNull: false,
+    default: null,
+    note: "Number of events observed for the session.",
+  },
+  {
+    d1Name: "input_tokens",
+    localName: "input_tokens",
+    type: "INTEGER",
+    notNull: false,
+    default: null,
+    note: "Input tokens consumed.",
+  },
+  {
+    d1Name: "output_tokens",
+    localName: "output_tokens",
+    type: "INTEGER",
+    notNull: false,
+    default: null,
+    note: "Output tokens produced.",
+  },
+  {
+    d1Name: "cache_read_tokens",
+    localName: "cache_read_tokens",
+    type: "INTEGER",
+    notNull: false,
+    default: null,
+    note: "Prompt-cache read tokens.",
+  },
+  {
+    d1Name: "cost_usd",
+    localName: "cost_usd",
+    type: "REAL",
+    notNull: false,
+    default: null,
+    note: "Estimated cost in USD.",
+  },
+  // --- sovereignty (IAW D.5 — lifted off the myelin envelope) ---
+  {
+    d1Name: "classification",
+    localName: "classification",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note: "'local' | 'federated' | 'public' | NULL. NULL for pre-IAW publishers.",
+  },
+  {
+    d1Name: "data_residency",
+    localName: "data_residency",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note: "e.g. 'nz', 'eu', NULL.",
+  },
+  {
+    d1Name: "home_principal",
+    localName: "home_principal",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note: "principal.home_principal (post-did:mf: strip).",
+  },
+];
+
+/** The two indices the session-tree refactor adds to BOTH substrates (Phase 0). */
+export const CANONICAL_SESSION_INDICES = [
+  "idx_sessions_parent_session_id",
+  "idx_sessions_substrate",
+] as const;
+
+/**
+ * Render one column's DDL clause for a given substrate.
+ * `local` uses {@link CanonicalSessionColumn.localName}; `d1` uses
+ * {@link CanonicalSessionColumn.d1Name}.
+ */
+export function columnDdl(
+  col: CanonicalSessionColumn,
+  substrate: "local" | "d1"
+): string {
+  const name = substrate === "local" ? col.localName : col.d1Name;
+  let clause = `${name} ${col.type}`;
+  if (col.notNull) clause += " NOT NULL";
+  if (col.default !== null) clause += ` DEFAULT ${col.default}`;
+  return clause;
+}
+
+/** All canonical columns that did NOT pre-exist the session-tree refactor —
+ *  the additive set Phase 0 must ADD to both physical schemas. */
+export const CANONICAL_ADDED_COLUMNS = CANONICAL_SESSION_COLUMNS.filter((c) =>
+  [
+    "agent_id",
+    "agent_name",
+    "principal_id",
+    "parent_session_id",
+    "substrate",
+    "status",
+    "duration_ms",
+    "events_count",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cost_usd",
+    "classification",
+    "data_residency",
+    "home_principal",
+  ].includes(c.d1Name)
+);

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -86,7 +86,7 @@ export const SCHEMA_SQL: string[] = [
   // FK policy: CASCADE off assignment — sessions are detail rows of an
   // assignment; archiving an assignment should sweep its sessions with it.
   //
-  // ST-P0 / ADR-0008: the canonical (denormalized) session columns
+  // ST-P0 / ADR-0011: the canonical (denormalized) session columns
   // (agent_id/agent_name/principal_id/status/metrics/sovereignty) +
   // session-tree fields (parent_session_id/substrate) are defined ONCE in
   // db/canonical-session.ts (CANONICAL_SESSION_COLUMNS) and asserted against
@@ -94,7 +94,7 @@ export const SCHEMA_SQL: string[] = [
   // mirrored verbatim here (the DDL is the physical artifact; the shared source
   // is the contract the parity test enforces).
   //
-  // NAMING NOTE (ADR-0008): the canonical names prefer the D1 spelling, but the
+  // NAMING NOTE (ADR-0011): the canonical names prefer the D1 spelling, but the
   // local PK stays `id` and the terminal timestamp stays `ended_at` this phase
   // — renaming them to session_id/completed_at cascades through the
   // events/attention FKs, the partial unique indices, transitions.ts and
@@ -111,7 +111,7 @@ export const SCHEMA_SQL: string[] = [
     pid INTEGER,
     started_at TEXT NOT NULL DEFAULT (datetime('now')),
     ended_at TEXT,
-    -- ST-P0 / ADR-0008 canonical session columns (see canonical-session.ts) --
+    -- ST-P0 / ADR-0011 canonical session columns (see canonical-session.ts) --
     parent_session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE,
     substrate TEXT NOT NULL DEFAULT 'claude-code',
     agent_id TEXT,
@@ -159,11 +159,18 @@ export const SCHEMA_SQL: string[] = [
   `CREATE INDEX IF NOT EXISTS idx_ata_task_id ON agent_task_assignment(task_id)`,
   `CREATE INDEX IF NOT EXISTS idx_ata_state ON agent_task_assignment(state)`,
   `CREATE INDEX IF NOT EXISTS idx_sessions_assignment_id ON sessions(assignment_id)`,
-  // ST-P0 / ADR-0008 — session-tree lookups: children of a session, and
-  // sessions of a given substrate. Names are part of the canonical contract
-  // (CANONICAL_SESSION_INDICES) the parity test asserts on both substrates.
-  `CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id)`,
-  `CREATE INDEX IF NOT EXISTS idx_sessions_substrate ON sessions(substrate)`,
+  // ST-P0 / ADR-0011 — the session-tree lookup indices (children of a session;
+  // sessions of a given substrate) are DELIBERATELY NOT declared here. They
+  // index parent_session_id / substrate, columns that an existing pre-P0 DB does
+  // not yet carry when init.ts runs this SCHEMA_SQL loop (which precedes the
+  // COLUMN_ADD_MIGRATIONS loop). Declaring them here crashes initDatabase on
+  // those DBs with `no such column: parent_session_id`. They are created instead
+  // by the parent_session_id / substrate COLUMN_ADD_MIGRATIONS `post[]` arrays
+  // below — which run AFTER the column ALTERs AND unconditionally (init.ts always
+  // runs `post[]`, even when the ALTER is skipped on a fresh DB whose columns
+  // came from CREATE TABLE). Their names are part of the canonical contract
+  // (CANONICAL_SESSION_INDICES) the parity test asserts on both substrates; the
+  // parity test scans SCHEMA_SQL + the COLUMN_ADD_MIGRATIONS post[] strings.
   // F-20.F sweep — composite index for the "most-recent session per
   // assignment" subquery used by both `db/tasks.ts` (F-20.F denorm)
   // and `db/assignments.ts` (focus-area / drill-down). The
@@ -545,7 +552,7 @@ export const COLUMN_ADD_MIGRATIONS: ColumnAddMigration[] = [
     ],
   },
 
-  // ST-P0 / ADR-0008 — canonical session columns for EXISTING DBs. Fresh DBs
+  // ST-P0 / ADR-0011 — canonical session columns for EXISTING DBs. Fresh DBs
   // get these from the sessions CREATE TABLE above; an already-initialised DB
   // (the running stacks) backfills them here via the same pragma_table_info
   // gate the F-13/#857/#864 column-adds use. Names/types mirror

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -85,6 +85,23 @@ export const SCHEMA_SQL: string[] = [
   // --- sessions ---
   // FK policy: CASCADE off assignment — sessions are detail rows of an
   // assignment; archiving an assignment should sweep its sessions with it.
+  //
+  // ST-P0 / ADR-0008: the canonical (denormalized) session columns
+  // (agent_id/agent_name/principal_id/status/metrics/sovereignty) +
+  // session-tree fields (parent_session_id/substrate) are defined ONCE in
+  // db/canonical-session.ts (CANONICAL_SESSION_COLUMNS) and asserted against
+  // both physical schemas by __tests__/session-schema-parity.test.ts. They are
+  // mirrored verbatim here (the DDL is the physical artifact; the shared source
+  // is the contract the parity test enforces).
+  //
+  // NAMING NOTE (ADR-0008): the canonical names prefer the D1 spelling, but the
+  // local PK stays `id` and the terminal timestamp stays `ended_at` this phase
+  // — renaming them to session_id/completed_at cascades through the
+  // events/attention FKs, the partial unique indices, transitions.ts and
+  // retention.ts; that rename is a deliberate Phase-2 TODO (canonical-session.ts
+  // CanonicalSessionColumn.phase2Rename). The new denormalized columns are
+  // NULLABLE on local until Phase 2 syncs them on write; substrate is NOT NULL
+  // DEFAULT 'claude-code', parent_session_id is a nullable self-ref.
   `CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     assignment_id TEXT NOT NULL REFERENCES agent_task_assignment(id) ON DELETE CASCADE,
@@ -93,7 +110,23 @@ export const SCHEMA_SQL: string[] = [
       CHECK(endpoint_kind IN ('local.process.controlled','local.observed','local.process.autonomous')),
     pid INTEGER,
     started_at TEXT NOT NULL DEFAULT (datetime('now')),
-    ended_at TEXT
+    ended_at TEXT,
+    -- ST-P0 / ADR-0008 canonical session columns (see canonical-session.ts) --
+    parent_session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE,
+    substrate TEXT NOT NULL DEFAULT 'claude-code',
+    agent_id TEXT,
+    agent_name TEXT,
+    principal_id TEXT,
+    status TEXT,
+    duration_ms INTEGER,
+    events_count INTEGER,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cache_read_tokens INTEGER,
+    cost_usd REAL,
+    classification TEXT,
+    data_residency TEXT,
+    home_principal TEXT
   )`,
 
   // --- events ---
@@ -126,6 +159,11 @@ export const SCHEMA_SQL: string[] = [
   `CREATE INDEX IF NOT EXISTS idx_ata_task_id ON agent_task_assignment(task_id)`,
   `CREATE INDEX IF NOT EXISTS idx_ata_state ON agent_task_assignment(state)`,
   `CREATE INDEX IF NOT EXISTS idx_sessions_assignment_id ON sessions(assignment_id)`,
+  // ST-P0 / ADR-0008 — session-tree lookups: children of a session, and
+  // sessions of a given substrate. Names are part of the canonical contract
+  // (CANONICAL_SESSION_INDICES) the parity test asserts on both substrates.
+  `CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_sessions_substrate ON sessions(substrate)`,
   // F-20.F sweep — composite index for the "most-recent session per
   // assignment" subquery used by both `db/tasks.ts` (F-20.F denorm)
   // and `db/assignments.ts` (focus-area / drill-down). The
@@ -506,6 +544,49 @@ export const COLUMN_ADD_MIGRATIONS: ColumnAddMigration[] = [
       `CREATE INDEX IF NOT EXISTS idx_tasks_iteration ON tasks(iteration_id)`,
     ],
   },
+
+  // ST-P0 / ADR-0008 — canonical session columns for EXISTING DBs. Fresh DBs
+  // get these from the sessions CREATE TABLE above; an already-initialised DB
+  // (the running stacks) backfills them here via the same pragma_table_info
+  // gate the F-13/#857/#864 column-adds use. Names/types mirror
+  // canonical-session.ts CANONICAL_SESSION_COLUMNS (localName) verbatim — the
+  // parity test pins them.
+  //
+  // SQLite ALTER ADD COLUMN caveat: a NOT NULL column needs a constant DEFAULT
+  // (substrate qualifies). A self-referential FK cannot be added via ALTER on a
+  // table that already has rows in some SQLite builds, BUT bun:sqlite permits
+  // `ADD COLUMN x REFERENCES sessions(id)` with foreign_keys ON (the FK is only
+  // checked on write); existing rows have NULL parent_session_id which satisfies
+  // the FK. The session-tree CASCADE applies going forward.
+  {
+    table: "sessions",
+    column: "parent_session_id",
+    ddl: `ALTER TABLE sessions ADD COLUMN parent_session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE`,
+    post: [
+      `CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id)`,
+    ],
+  },
+  {
+    table: "sessions",
+    column: "substrate",
+    ddl: `ALTER TABLE sessions ADD COLUMN substrate TEXT NOT NULL DEFAULT 'claude-code'`,
+    post: [
+      `CREATE INDEX IF NOT EXISTS idx_sessions_substrate ON sessions(substrate)`,
+    ],
+  },
+  { table: "sessions", column: "agent_id", ddl: `ALTER TABLE sessions ADD COLUMN agent_id TEXT` },
+  { table: "sessions", column: "agent_name", ddl: `ALTER TABLE sessions ADD COLUMN agent_name TEXT` },
+  { table: "sessions", column: "principal_id", ddl: `ALTER TABLE sessions ADD COLUMN principal_id TEXT` },
+  { table: "sessions", column: "status", ddl: `ALTER TABLE sessions ADD COLUMN status TEXT` },
+  { table: "sessions", column: "duration_ms", ddl: `ALTER TABLE sessions ADD COLUMN duration_ms INTEGER` },
+  { table: "sessions", column: "events_count", ddl: `ALTER TABLE sessions ADD COLUMN events_count INTEGER` },
+  { table: "sessions", column: "input_tokens", ddl: `ALTER TABLE sessions ADD COLUMN input_tokens INTEGER` },
+  { table: "sessions", column: "output_tokens", ddl: `ALTER TABLE sessions ADD COLUMN output_tokens INTEGER` },
+  { table: "sessions", column: "cache_read_tokens", ddl: `ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER` },
+  { table: "sessions", column: "cost_usd", ddl: `ALTER TABLE sessions ADD COLUMN cost_usd REAL` },
+  { table: "sessions", column: "classification", ddl: `ALTER TABLE sessions ADD COLUMN classification TEXT` },
+  { table: "sessions", column: "data_residency", ddl: `ALTER TABLE sessions ADD COLUMN data_residency TEXT` },
+  { table: "sessions", column: "home_principal", ddl: `ALTER TABLE sessions ADD COLUMN home_principal TEXT` },
 ];
 
 /**

--- a/src/surface/mc/db/sessions.ts
+++ b/src/surface/mc/db/sessions.ts
@@ -7,6 +7,13 @@ import type { EndpointKind, Session } from "../types";
 import { generateId } from "./events";
 import { ensureAgentRow } from "./agents";
 
+/**
+ * The default substrate for a session whose harness is unknown — observed CC
+ * hook sessions and any pre-ST-P0 caller. Matches the schema column default and
+ * refactor §3 D4 ('claude-code').
+ */
+export const DEFAULT_SUBSTRATE = "claude-code";
+
 export function createSession(
   db: Database,
   params: {
@@ -14,21 +21,49 @@ export function createSession(
     endpointKind: EndpointKind;
     ccSessionId?: string;
     pid?: number;
+    // --- ST-P0 / ADR-0008 canonical session columns (all optional this phase;
+    // no existing caller passes them — defaults apply and behavior is unchanged). ---
+    /** Self-ref to the spawning session; omit for an agent-rooted session. */
+    parentSessionId?: string | null;
+    /** The substrate; defaults to {@link DEFAULT_SUBSTRATE} ('claude-code'). */
+    substrate?: string;
+    /** Owning agent id (denormalized). */
+    agentId?: string | null;
+    /** Owning agent display name (a session is NOT an agent). */
+    agentName?: string | null;
+    /** Principal the session belongs to (denormalized). */
+    principalId?: string | null;
+    /** Denormalized lifecycle status. */
+    status?: string | null;
   }
 ): Session {
   const id = generateId();
   const now = new Date().toISOString();
+  const substrate = params.substrate ?? DEFAULT_SUBSTRATE;
+  const parentSessionId = params.parentSessionId ?? null;
+  const agentId = params.agentId ?? null;
+  const agentName = params.agentName ?? null;
+  const principalId = params.principalId ?? null;
+  const status = params.status ?? null;
 
   db.query(
-    `INSERT INTO sessions (id, assignment_id, cc_session_id, endpoint_kind, pid, started_at)
-     VALUES (?, ?, ?, ?, ?, ?)`
+    `INSERT INTO sessions
+       (id, assignment_id, cc_session_id, endpoint_kind, pid, started_at,
+        parent_session_id, substrate, agent_id, agent_name, principal_id, status)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     id,
     params.assignmentId,
     params.ccSessionId ?? null,
     params.endpointKind,
     params.pid ?? null,
-    now
+    now,
+    parentSessionId,
+    substrate,
+    agentId,
+    agentName,
+    principalId,
+    status
   );
 
   return {
@@ -39,6 +74,21 @@ export function createSession(
     pid: params.pid ?? null,
     started_at: now,
     ended_at: null,
+    parent_session_id: parentSessionId,
+    substrate,
+    agent_id: agentId,
+    agent_name: agentName,
+    principal_id: principalId,
+    status,
+    duration_ms: null,
+    events_count: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_read_tokens: null,
+    cost_usd: null,
+    classification: null,
+    data_residency: null,
+    home_principal: null,
   };
 }
 
@@ -50,7 +100,61 @@ interface SessionRow {
   pid: number | null;
   started_at: string;
   ended_at: string | null;
+  parent_session_id: string | null;
+  substrate: string;
+  agent_id: string | null;
+  agent_name: string | null;
+  principal_id: string | null;
+  status: string | null;
+  duration_ms: number | null;
+  events_count: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_tokens: number | null;
+  cost_usd: number | null;
+  classification: string | null;
+  data_residency: string | null;
+  home_principal: string | null;
 }
+
+/**
+ * Single source of truth for mapping a `sessions` row → {@link Session}. Keeps
+ * the SELECT column list and the object shape in lockstep as the canonical
+ * columns grow (ST-P0 / ADR-0008). Callers that SELECT a partial row must pass a
+ * full row through here, so prefer {@link SESSION_SELECT_COLUMNS}.
+ */
+export function rowToSession(row: SessionRow): Session {
+  return {
+    id: row.id,
+    assignment_id: row.assignment_id,
+    cc_session_id: row.cc_session_id,
+    endpoint_kind: row.endpoint_kind,
+    pid: row.pid,
+    started_at: row.started_at,
+    ended_at: row.ended_at,
+    parent_session_id: row.parent_session_id,
+    substrate: row.substrate,
+    agent_id: row.agent_id,
+    agent_name: row.agent_name,
+    principal_id: row.principal_id,
+    status: row.status,
+    duration_ms: row.duration_ms,
+    events_count: row.events_count,
+    input_tokens: row.input_tokens,
+    output_tokens: row.output_tokens,
+    cache_read_tokens: row.cache_read_tokens,
+    cost_usd: row.cost_usd,
+    classification: row.classification,
+    data_residency: row.data_residency,
+    home_principal: row.home_principal,
+  };
+}
+
+/** Canonical SELECT column list for a full {@link Session} row mapping. */
+export const SESSION_SELECT_COLUMNS = `id, assignment_id, cc_session_id, endpoint_kind, pid,
+        started_at, ended_at, parent_session_id, substrate, agent_id, agent_name,
+        principal_id, status, duration_ms, events_count, input_tokens, output_tokens,
+        cache_read_tokens, cost_usd, classification, data_residency, home_principal`;
 
 /**
  * Shared lookup for the most-recent session of an assignment. `activeOnly`
@@ -71,8 +175,7 @@ function findSession(
     : `WHERE assignment_id = ?`;
   const row = db
     .query(
-      `SELECT id, assignment_id, cc_session_id, endpoint_kind, pid,
-              started_at, ended_at
+      `SELECT ${SESSION_SELECT_COLUMNS}
        FROM sessions
        ${whereClause}
        ORDER BY started_at DESC
@@ -82,15 +185,7 @@ function findSession(
 
   if (!row) return null;
 
-  return {
-    id: row.id,
-    assignment_id: row.assignment_id,
-    cc_session_id: row.cc_session_id,
-    endpoint_kind: row.endpoint_kind,
-    pid: row.pid,
-    started_at: row.started_at,
-    ended_at: row.ended_at,
-  };
+  return rowToSession(row);
 }
 
 export function findActiveSession(

--- a/src/surface/mc/db/sessions.ts
+++ b/src/surface/mc/db/sessions.ts
@@ -21,7 +21,7 @@ export function createSession(
     endpointKind: EndpointKind;
     ccSessionId?: string;
     pid?: number;
-    // --- ST-P0 / ADR-0008 canonical session columns (all optional this phase;
+    // --- ST-P0 / ADR-0011 canonical session columns (all optional this phase;
     // no existing caller passes them — defaults apply and behavior is unchanged). ---
     /** Self-ref to the spawning session; omit for an agent-rooted session. */
     parentSessionId?: string | null;
@@ -120,7 +120,7 @@ interface SessionRow {
 /**
  * Single source of truth for mapping a `sessions` row → {@link Session}. Keeps
  * the SELECT column list and the object shape in lockstep as the canonical
- * columns grow (ST-P0 / ADR-0008). Callers that SELECT a partial row must pass a
+ * columns grow (ST-P0 / ADR-0011). Callers that SELECT a partial row must pass a
  * full row through here, so prefer {@link SESSION_SELECT_COLUMNS}.
  */
 export function rowToSession(row: SessionRow): Session {

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -430,7 +430,7 @@ export interface Task {
  * consumer), ~1 per assistant×stack. This is **NOT a session**: the recurring
  * 1,044-tile bug (refactor §1) is exactly the conflation of a CC session with an
  * agent row. A session belongs to an agent and is modelled by {@link Session}
- * (with `agent_id`/`agent_name` as session columns per ADR-0008) — never as its
+ * (with `agent_id`/`agent_name` as session columns per ADR-0011) — never as its
  * own agent row. See CONTEXT.md §Sessions.
  */
 export interface Agent {
@@ -455,7 +455,7 @@ export interface AgentTaskAssignment {
  * One run of a substrate (CONTEXT.md §Sessions) — belongs to one agent, runs on
  * one substrate, and may be a child of another session.
  *
- * ST-P0 / ADR-0008: the canonical (flat/denormalized) session columns are the
+ * ST-P0 / ADR-0011: the canonical (flat/denormalized) session columns are the
  * shared shape across the local bun:sqlite and cloud D1 substrates — defined
  * once in `db/canonical-session.ts` and pinned to both physical schemas by the
  * parity test. The denormalized attribution/lifecycle/metric/sovereignty fields
@@ -464,7 +464,7 @@ export interface AgentTaskAssignment {
  *   - `parent_session_id` — self-ref; NULL ⇒ agent-rooted session.
  *   - `substrate`         — NOT NULL, defaults to 'claude-code'.
  *
- * NAMING (ADR-0008): canonical names prefer the D1 spelling, but the local
+ * NAMING (ADR-0011): canonical names prefer the D1 spelling, but the local
  * physical PK stays `id` and the terminal timestamp stays `ended_at` — the
  * `id→session_id` / `ended_at→completed_at` rename cascades through FKs, the
  * partial unique indices, transitions.ts and retention.ts, so it is a deliberate
@@ -480,7 +480,7 @@ export interface Session {
   started_at: string;
   /** Terminal timestamp. Canonical name `completed_at`; local stays `ended_at` (Phase-2 rename). */
   ended_at: string | null;
-  // --- ST-P0 / ADR-0008 canonical session columns ---
+  // --- ST-P0 / ADR-0011 canonical session columns ---
   /** Self-ref to the spawning session; NULL ⇒ agent-rooted. */
   parent_session_id: string | null;
   /** The substrate this session runs on (claude-code | codex | …). */

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -425,6 +425,14 @@ export interface Task {
   updated_at: number;
 }
 
+/**
+ * A dispatch/runtime agent — the bus runtime identity (NKey + JetStream
+ * consumer), ~1 per assistant×stack. This is **NOT a session**: the recurring
+ * 1,044-tile bug (refactor §1) is exactly the conflation of a CC session with an
+ * agent row. A session belongs to an agent and is modelled by {@link Session}
+ * (with `agent_id`/`agent_name` as session columns per ADR-0008) — never as its
+ * own agent row. See CONTEXT.md §Sessions.
+ */
 export interface Agent {
   id: string;
   name: string;
@@ -443,6 +451,26 @@ export interface AgentTaskAssignment {
   updated_at: string;
 }
 
+/**
+ * One run of a substrate (CONTEXT.md §Sessions) — belongs to one agent, runs on
+ * one substrate, and may be a child of another session.
+ *
+ * ST-P0 / ADR-0008: the canonical (flat/denormalized) session columns are the
+ * shared shape across the local bun:sqlite and cloud D1 substrates — defined
+ * once in `db/canonical-session.ts` and pinned to both physical schemas by the
+ * parity test. The denormalized attribution/lifecycle/metric/sovereignty fields
+ * are nullable on the local side until Phase 2 syncs them on write (this phase
+ * is foundation-only). The session-tree fields land now:
+ *   - `parent_session_id` — self-ref; NULL ⇒ agent-rooted session.
+ *   - `substrate`         — NOT NULL, defaults to 'claude-code'.
+ *
+ * NAMING (ADR-0008): canonical names prefer the D1 spelling, but the local
+ * physical PK stays `id` and the terminal timestamp stays `ended_at` — the
+ * `id→session_id` / `ended_at→completed_at` rename cascades through FKs, the
+ * partial unique indices, transitions.ts and retention.ts, so it is a deliberate
+ * Phase-2 TODO. This interface uses the local physical names (it backs the local
+ * row + helpers); the cloud projection maps to `session_id`/`completed_at`.
+ */
 export interface Session {
   id: string;
   assignment_id: string;
@@ -450,7 +478,33 @@ export interface Session {
   endpoint_kind: EndpointKind;
   pid: number | null;
   started_at: string;
+  /** Terminal timestamp. Canonical name `completed_at`; local stays `ended_at` (Phase-2 rename). */
   ended_at: string | null;
+  // --- ST-P0 / ADR-0008 canonical session columns ---
+  /** Self-ref to the spawning session; NULL ⇒ agent-rooted. */
+  parent_session_id: string | null;
+  /** The substrate this session runs on (claude-code | codex | …). */
+  substrate: string;
+  /** Owning agent id (denormalized). NULL until Phase 2 syncs it. */
+  agent_id: string | null;
+  /** Owning agent display name (a session is NOT an agent). NULL until Phase 2. */
+  agent_name: string | null;
+  /** Principal the session belongs to (denormalized). NULL until Phase 2. */
+  principal_id: string | null;
+  /** Denormalized lifecycle status. NULL until Phase 2 syncs it off the assignment. */
+  status: string | null;
+  /** Wall-clock duration in ms. NULL until known. */
+  duration_ms: number | null;
+  /** Events observed for the session. NULL until known. */
+  events_count: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_tokens: number | null;
+  cost_usd: number | null;
+  /** Sovereignty (IAW D.5): 'local' | 'federated' | 'public' | NULL. */
+  classification: string | null;
+  data_residency: string | null;
+  home_principal: string | null;
 }
 
 export interface McEvent {

--- a/src/surface/mc/worker/migrations/0005_session_tree.sql
+++ b/src/surface/mc/worker/migrations/0005_session_tree.sql
@@ -1,4 +1,4 @@
--- ST-P0 / ADR-0008 — session-tree convergence on the D1 (cloud) snapshot.
+-- ST-P0 / ADR-0011 — session-tree convergence on the D1 (cloud) snapshot.
 --
 -- Adds the two canonical session-tree fields to the deployed D1 `sessions`
 -- table so the cloud schema matches the local bun:sqlite schema and the shared

--- a/src/surface/mc/worker/migrations/0005_session_tree.sql
+++ b/src/surface/mc/worker/migrations/0005_session_tree.sql
@@ -1,0 +1,35 @@
+-- ST-P0 / ADR-0008 — session-tree convergence on the D1 (cloud) snapshot.
+--
+-- Adds the two canonical session-tree fields to the deployed D1 `sessions`
+-- table so the cloud schema matches the local bun:sqlite schema and the shared
+-- canonical source (../../db/canonical-session.ts, CANONICAL_SESSION_COLUMNS):
+--   - sessions.parent_session_id  (self-ref to the spawning session; NULL ⇒ agent-rooted)
+--   - sessions.substrate          (claude-code | codex | … — an attribute of a session)
+-- and the two session-tree indices.
+--
+-- The cloud `sessions` row was ALREADY flat/denormalized (agent_id, agent_name,
+-- principal_id, status, metrics, and the sovereignty columns are columns) — only
+-- these two fields were missing, so this migration is purely additive.
+--
+-- Apply: wrangler d1 execute grove-events --file=./migrations/0005_session_tree.sql
+--   (deploy is OUT OF SCOPE for ST-P0 — file only; applied dev→prod in a later phase)
+--
+-- Additive + idempotent-friendly: ADD COLUMN is one-shot (errors if re-applied on
+-- a DB that already has the column), the indices use IF NOT EXISTS. Mirrors the
+-- 0003/0004 format.
+--
+-- Scope note: the local SQLite `sessions` table gets these columns from
+-- ../../db/schema.ts (fresh DBs via CREATE TABLE; existing DBs via the
+-- COLUMN_ADD_MIGRATIONS pragma-gated ALTERs) and needs no migration here — D1
+-- carries no events/tasks/agents tables.
+
+ALTER TABLE sessions ADD COLUMN parent_session_id TEXT;
+-- SQLite ALTER ADD COLUMN with NOT NULL requires a constant DEFAULT (satisfied).
+ALTER TABLE sessions ADD COLUMN substrate TEXT NOT NULL DEFAULT 'claude-code';
+
+-- Session-tree lookups: children of a session, and sessions per substrate.
+CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_substrate ON sessions(substrate);
+
+-- Bump the schema_version row (schema.sql seeds version 1).
+INSERT OR IGNORE INTO schema_version (version) VALUES (2);

--- a/src/surface/mc/worker/schema.sql
+++ b/src/surface/mc/worker/schema.sql
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   classification TEXT,        -- 'local' | 'federated' | 'public' | NULL
   data_residency TEXT,        -- e.g. 'nz', 'eu', NULL
   home_principal TEXT,         -- principal.home_principal (post-`did:mf:` strip)
-  -- ST-P0 / ADR-0008 canonical session-tree fields. Defined ONCE in
+  -- ST-P0 / ADR-0011 canonical session-tree fields. Defined ONCE in
   -- ../db/canonical-session.ts (CANONICAL_SESSION_COLUMNS) and asserted against
   -- this DDL + ../db/schema.ts by ../__tests__/session-schema-parity.test.ts.
   -- The cloud sessions row was already flat (agent_id/agent_name/principal_id/
@@ -147,7 +147,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_completed ON sessions(completed_at);
 CREATE INDEX IF NOT EXISTS idx_sessions_principal ON sessions(principal_id);
 -- IAW D.5 — slicing the dashboard snapshot by home_principal on every poll
 CREATE INDEX IF NOT EXISTS idx_sessions_home_principal ON sessions(home_principal) WHERE home_principal IS NOT NULL;
--- ST-P0 / ADR-0008 — session-tree lookups (children of a session; sessions per
+-- ST-P0 / ADR-0011 — session-tree lookups (children of a session; sessions per
 -- substrate). Mirror of the local indices; names are the canonical contract
 -- (CANONICAL_SESSION_INDICES) the parity test pins on both substrates.
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);

--- a/src/surface/mc/worker/schema.sql
+++ b/src/surface/mc/worker/schema.sql
@@ -33,7 +33,15 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- All three are NULL for pre-IAW publishers. See migrations/0003_sovereignty.sql.
   classification TEXT,        -- 'local' | 'federated' | 'public' | NULL
   data_residency TEXT,        -- e.g. 'nz', 'eu', NULL
-  home_principal TEXT          -- principal.home_principal (post-`did:mf:` strip)
+  home_principal TEXT,         -- principal.home_principal (post-`did:mf:` strip)
+  -- ST-P0 / ADR-0008 canonical session-tree fields. Defined ONCE in
+  -- ../db/canonical-session.ts (CANONICAL_SESSION_COLUMNS) and asserted against
+  -- this DDL + ../db/schema.ts by ../__tests__/session-schema-parity.test.ts.
+  -- The cloud sessions row was already flat (agent_id/agent_name/principal_id/
+  -- status/metrics/sovereignty are columns above) — these two close the gap.
+  -- Added to deployed D1 via migrations/0005_session_tree.sql.
+  parent_session_id TEXT,                   -- self-ref to the spawning session; NULL ⇒ agent-rooted
+  substrate TEXT NOT NULL DEFAULT 'claude-code'  -- claude-code | codex | … (attribute of a session)
 );
 
 CREATE TABLE IF NOT EXISTS github_events (
@@ -139,6 +147,11 @@ CREATE INDEX IF NOT EXISTS idx_sessions_completed ON sessions(completed_at);
 CREATE INDEX IF NOT EXISTS idx_sessions_principal ON sessions(principal_id);
 -- IAW D.5 — slicing the dashboard snapshot by home_principal on every poll
 CREATE INDEX IF NOT EXISTS idx_sessions_home_principal ON sessions(home_principal) WHERE home_principal IS NOT NULL;
+-- ST-P0 / ADR-0008 — session-tree lookups (children of a session; sessions per
+-- substrate). Mirror of the local indices; names are the canonical contract
+-- (CANONICAL_SESSION_INDICES) the parity test pins on both substrates.
+CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_substrate ON sessions(substrate);
 CREATE INDEX IF NOT EXISTS idx_github_repo ON github_events(repo, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_agent ON github_events(agent_authored, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_principal ON github_events(principal_id);


### PR DESCRIPTION
## ST-P0 — Schema convergence: canonical session model (ADR-0008)

Phase 0 of [`docs/refactor-mc-session-tree.md`](docs/refactor-mc-session-tree.md), implementing the decision in [ADR-0008](docs/adr/0008-unified-mc-session-schema.md). **Foundation only — no behavior change.** Threads the session-tree fields and the denormalized canonical columns into both substrates, from a single shared source, guarded by a CI parity test.

### The shared source + parity test (the load-bearing deliverable)

- **`src/surface/mc/db/canonical-session.ts`** — defines each canonical session column **ONCE** (name, SQLite type, nullability, default). It is the convergence point ADR-0008 decision 5 mandates: the local bun:sqlite DDL, the D1 DDL, and the TS `Session` type are all derived/validated from this list.
- **`src/surface/mc/__tests__/session-schema-parity.test.ts`** — parses the `sessions` `CREATE TABLE` of **both** physical schemas (`db/schema.ts` `SCHEMA_SQL` + `worker/schema.sql`) and **fails CI** if either drifts from the shared source. This structurally closes the recurring schema-divergence bug class (#877/#879).

### Naming reconciliation (ADR-0008: "identical schemas", prefer D1 names)

Per the ADR I prefer the D1 spelling, **but Phase 0 is no-behavior-change**, so the two columns whose rename would cascade through FKs / partial unique indices / `transitions.ts` / `retention.ts` keep their local physical name this phase, recorded as deliberate **Phase-2 TODOs** (`CanonicalSessionColumn.phase2Rename`), not accidental drift (the parity test asserts this is intentional):

| canonical concept | D1 column | local column | this phase |
|---|---|---|---|
| session identity (PK) | `session_id` | `id` | keep both — rename = **Phase 2** |
| terminal timestamp | `completed_at` | `ended_at` | keep both — rename = **Phase 2** |

Every other canonical column shares one name across both substrates.

### Canonical column list settled

`session_id`(local `id`), `agent_id`, `agent_name`, `principal_id`, `parent_session_id` (nullable self-ref, `ON DELETE CASCADE`), `substrate` (**NOT NULL DEFAULT `'claude-code'`**), `status`, `started_at`, `completed_at`(local `ended_at`), `duration_ms`, `events_count`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cost_usd`, `classification`, `data_residency`, `home_principal`.

The denormalized attribution/lifecycle/metric/sovereignty columns are **nullable on local** until Phase 2 syncs them on write. The session-tree fields (`parent_session_id`, `substrate`) land now per ADR-0008.

### Changes

- **Local (`db/schema.ts`):** new columns + `idx_sessions_parent_session_id` / `idx_sessions_substrate`. Existing DBs backfill via the pragma-gated `COLUMN_ADD_MIGRATIONS` pattern (same mechanism F-13/#857 used); verified idempotent and self-FK enforced on write while existing rows get NULL `parent_session_id`.
- **Cloud (`worker/schema.sql` + new `worker/migrations/0005_session_tree.sql`):** two session-tree columns + indices + `schema_version` bump, mirroring `0004`'s format. **Migration file only — NOT applied/deployed** (deploy is a later phase).
- **`types.ts`:** `Session` gains the canonical fields; `Agent` gets the "dispatch/runtime agent, **NOT a session**" clarifying comment.
- **`createSession` (`db/sessions.ts`):** accepts new **optional** params (`parentSessionId`, `substrate`, `agentId`, `agentName`, `principalId`, `status`) and writes them; defaults apply, **no caller changes** (callers pass nothing new yet). Adds a `rowToSession` mapper + `SESSION_SELECT_COLUMNS` single-source helper so the row→`Session` mapping can't drift as columns grow.

### Deviations / TODOs flagged

- **Phase-2 rename TODO** (ADR-0008): converge local `id`→`session_id` and `ended_at`→`completed_at` once the FK + index + query cascade can be done in one deliberate migration. Gated by `CanonicalSessionColumn.phase2Rename`; the parity test asserts the splits are intended.
- No ingestor / orphan / retention behavior changes (Phases 2/3). `events`/interiors stay local-only (ADR-0005) — out of scope.

### Gates

- `bunx tsc --noEmit` ✅ clean
- `bun run lint` ✅ 0 errors (pre-existing warnings only, in untouched files)
- `bun test` ✅ **5832 pass / 2 skip / 0 fail**
- `scripts/check-carveouts.sh` ✅ PASS on changed files

Closes #954
Refs #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)