### PR TITLE
feat(config): CO-1 — capability offering policy model + policy.offerings[]

### DIFF
--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -34,6 +34,7 @@ import {
   PolicyFederatedRegistrySchema,
   PolicyFederatedSchema,
   PolicyPublicSchema,
+  PolicySchema,
   RendererSchema,
 } from "../cortex-config";
 
@@ -849,6 +850,54 @@ describe("CortexConfigSchema", () => {
     expect(parsed.agents[0]?.trust).toEqual(["echo", "ghost-agent-that-doesnt-exist"]);
   });
 
+  // CO-1 (epic cortex#939) — cross-block: an offered capability must EXIST in
+  // the stack's declared capabilities[]. This check lives on CortexConfigSchema
+  // (not PolicySchema) because it needs the top-level capabilities[] catalog.
+  test("CO-1: byte-identical — minConfig (no offerings) parses with policy absent", () => {
+    const parsed = CortexConfigSchema.parse(minConfig());
+    // No policy block ⇒ no offerings ⇒ every capability resolves local-only.
+    expect(parsed.policy).toBeUndefined();
+  });
+
+  test("CO-1: a config WITH a declared+provided capability may offer it", () => {
+    const parsed = CortexConfigSchema.parse({
+      ...minConfig(),
+      capabilities: [
+        {
+          id: "code-review.typescript",
+          description: "Reviews TypeScript PRs",
+          provided_by: ["luna"],
+        },
+      ],
+      policy: {
+        offerings: [
+          {
+            capability: "code-review.typescript",
+            scopes: ["public"],
+            accept: {
+              kind: "surface",
+              surface: "github",
+              predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+            },
+          },
+        ],
+      },
+    });
+    expect(parsed.policy?.offerings).toHaveLength(1);
+  });
+
+  test("CO-1: REJECTS offering a capability the stack does not declare", () => {
+    expect(() =>
+      CortexConfigSchema.parse({
+        ...minConfig(),
+        // capabilities[] omitted ⇒ catalog is empty
+        policy: {
+          offerings: [{ capability: "phantom.capability", scopes: ["local"] }],
+        },
+      }),
+    ).toThrow(/no matching entry exists in the top-level capabilities\[\] catalog/);
+  });
+
   test("defaults are applied for optional top-level blocks (Holly W2 — emptyDefault closes Zod quirk)", () => {
     // Before MIG-7.2 rev 2: outer `.default({} as any)` did NOT re-parse the
     // default through the inner schema, so omitting `attachments` gave `{}`
@@ -1032,6 +1081,106 @@ describe("PolicyPublicSchema — IAW S5 (#739) public-scope opt-in (OQ1 safe def
     expect(() =>
       PolicyPublicSchema.parse({ announce_capabilities: ["nodot"] }),
     ).toThrow();
+  });
+});
+
+describe("PolicySchema — CO-1 offerings (epic cortex#939)", () => {
+  test("defaults: offerings is absent (undefined) ⇒ default-deny baseline (byte-identical)", () => {
+    // Mirrors the sibling federated/public widening blocks: absent, not [].
+    // `resolveOffering(undefined)` is the single source of default-deny.
+    const parsed = PolicySchema.parse({});
+    expect(parsed.offerings).toBeUndefined();
+  });
+
+  test("accepts a valid local-only offering", () => {
+    const parsed = PolicySchema.parse({
+      offerings: [{ capability: "chat", scopes: ["local"] }],
+    });
+    expect(parsed.offerings).toHaveLength(1);
+    expect(parsed.offerings?.[0]?.capability).toBe("chat");
+  });
+
+  test("accepts a federated offering with a named network accept", () => {
+    const parsed = PolicySchema.parse({
+      offerings: [
+        {
+          capability: "chat",
+          scopes: ["federated"],
+          accept: { kind: "network", network: "mf-net" },
+        },
+      ],
+    });
+    expect(parsed.offerings?.[0]?.accept?.kind).toBe("network");
+  });
+
+  test("accepts a public offering with a metadata-only surface accept", () => {
+    const parsed = PolicySchema.parse({
+      offerings: [
+        {
+          capability: "code-review.typescript",
+          scopes: ["public"],
+          accept: {
+            kind: "surface",
+            surface: "github",
+            predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+            limits: { per_day: 100 },
+          },
+        },
+      ],
+    });
+    expect(parsed.offerings?.[0]?.accept?.kind).toBe("surface");
+  });
+
+  test("REJECTS a federated offering with no accept (default-deny)", () => {
+    expect(() =>
+      PolicySchema.parse({
+        offerings: [{ capability: "chat", scopes: ["federated"] }],
+      }),
+    ).toThrow(/DEFAULT-DENY/);
+  });
+
+  test("REJECTS a public offering with a content-dependent predicate", () => {
+    expect(() =>
+      PolicySchema.parse({
+        offerings: [
+          {
+            capability: "code-review.typescript",
+            scopes: ["public"],
+            accept: {
+              kind: "surface",
+              surface: "github",
+              // content-dependent predicate — no such `kind` in the closed set
+              predicate: { kind: "description-contains", value: "review me" },
+            },
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  test("REJECTS duplicate capability offerings", () => {
+    expect(() =>
+      PolicySchema.parse({
+        offerings: [
+          { capability: "chat", scopes: ["local"] },
+          { capability: "chat", scopes: ["local"] },
+        ],
+      }),
+    ).toThrow(/already declared at offerings\[0\]/);
+  });
+
+  test("REJECTS a local-only offering carrying an accept", () => {
+    expect(() =>
+      PolicySchema.parse({
+        offerings: [
+          {
+            capability: "chat",
+            scopes: ["local"],
+            accept: { kind: "network", network: "mf-net" },
+          },
+        ],
+      }),
+    ).toThrow(/local-only but carries an accept-policy/);
   });
 });
 

--- a/src/common/types/__tests__/offering.test.ts
+++ b/src/common/types/__tests__/offering.test.ts
@@ -349,6 +349,37 @@ describe("superRefineOfferings — coherence", () => {
     ]);
     expect(issues.length).toBe(2);
   });
+
+  // #962 review nit 3: CONTEXT.md endorses a capability offered at SEVERAL
+  // scopes at once. local+federated (local needs no accept, federated names a
+  // network) is valid — lock it so a future refactor can't silently reject it.
+  test("a local+federated multi-scope offering is valid", () => {
+    const issues = superRefineOfferings([
+      offering({
+        capability: "code-review.typescript",
+        scopes: ["local", "federated"],
+        accept: { kind: "network", network: "metafactory-net" },
+      }),
+    ]);
+    expect(issues).toEqual([]);
+  });
+
+  // #962 review nit 2: the top-level network? and the {kind:'network'} accept's
+  // own network are dual-source; the accept's network is authoritative. A
+  // divergence is a config error, not a value to merge.
+  test("top-level network disagreeing with the accept network is rejected", () => {
+    const issues = superRefineOfferings([
+      offering({
+        capability: "code-review.typescript",
+        scopes: ["federated"],
+        network: "wrong-net",
+        accept: { kind: "network", network: "metafactory-net" },
+      }),
+    ]);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.message).toContain("disagrees with its accept network");
+    expect(issues[0]?.path).toEqual([0, "network"]);
+  });
 });
 
 // =============================================================================

--- a/src/common/types/__tests__/offering.test.ts
+++ b/src/common/types/__tests__/offering.test.ts
@@ -1,0 +1,414 @@
+/**
+ * CO-1 (epic cortex#939) — capability offering model tests.
+ *
+ * Mirrors the cortex-config schema test style: schema accept/reject per field,
+ * the closed per-scope accept-policy tagged union, the metadata-only public
+ * predicate constraint (ADR-0010 DD-CO-8), the cross-offering coherence rules
+ * (`superRefineOfferings`: federated-requires-naming = default-deny, scope↔
+ * accept agreement, no-duplicate-capability), and the `resolveOffering`
+ * default-deny resolver (ADR-0008 DD-CO-1).
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  OfferScopeSchema,
+  OfferingSchema,
+  AcceptPolicySchema,
+  PublicPredicateSchema,
+  FederatedAcceptSchema,
+  PublicAcceptSchema,
+  PublicLimitsSchema,
+  superRefineOfferings,
+  resolveOffering,
+  type Offering,
+} from "../offering";
+
+// =============================================================================
+// OfferScope — the trust tier enum
+// =============================================================================
+
+describe("OfferScopeSchema", () => {
+  test("accepts local, federated, public", () => {
+    expect(OfferScopeSchema.parse("local")).toBe("local");
+    expect(OfferScopeSchema.parse("federated")).toBe("federated");
+    expect(OfferScopeSchema.parse("public")).toBe("public");
+  });
+
+  test("rejects an unknown scope", () => {
+    expect(() => OfferScopeSchema.parse("internal")).toThrow();
+    expect(() => OfferScopeSchema.parse("LOCAL")).toThrow();
+  });
+});
+
+// =============================================================================
+// OfferingSchema — structural per-entry shape
+// =============================================================================
+
+describe("OfferingSchema — structural", () => {
+  test("accepts a minimal local-only offering (capability + one scope)", () => {
+    const o = OfferingSchema.parse({
+      capability: "code-review.typescript",
+      scopes: ["local"],
+    });
+    expect(o.capability).toBe("code-review.typescript");
+    expect(o.scopes).toEqual(["local"]);
+    expect(o.accept).toBeUndefined();
+  });
+
+  test("rejects an empty scopes[] (offered nowhere)", () => {
+    expect(() =>
+      OfferingSchema.parse({ capability: "chat", scopes: [] }),
+    ).toThrow();
+  });
+
+  test("rejects a malformed capability id (uppercase / whitespace)", () => {
+    expect(() =>
+      OfferingSchema.parse({ capability: "Code-Review", scopes: ["local"] }),
+    ).toThrow();
+    expect(() =>
+      OfferingSchema.parse({ capability: "code review", scopes: ["local"] }),
+    ).toThrow();
+  });
+
+  test("rejects unknown keys (strict)", () => {
+    expect(() =>
+      OfferingSchema.parse({
+        capability: "chat",
+        scopes: ["local"],
+        bogus: true,
+      }),
+    ).toThrow();
+  });
+
+  test("accepts an optional network id of valid grammar", () => {
+    const o = OfferingSchema.parse({
+      capability: "chat",
+      scopes: ["federated"],
+      accept: { kind: "network", network: "metafactory-net" },
+      network: "metafactory-net",
+    });
+    expect(o.network).toBe("metafactory-net");
+  });
+});
+
+// =============================================================================
+// AcceptPolicy — the closed per-scope tagged union
+// =============================================================================
+
+describe("FederatedAcceptSchema", () => {
+  test("accepts {kind:'network'}", () => {
+    expect(
+      FederatedAcceptSchema.parse({ kind: "network", network: "mf-net" }),
+    ).toEqual({ kind: "network", network: "mf-net" });
+  });
+
+  test("accepts {kind:'principals'} with ≥1 principal", () => {
+    expect(
+      FederatedAcceptSchema.parse({ kind: "principals", principals: ["jcfischer"] }),
+    ).toEqual({ kind: "principals", principals: ["jcfischer"] });
+  });
+
+  test("rejects {kind:'principals'} with an empty list (names nobody)", () => {
+    expect(() =>
+      FederatedAcceptSchema.parse({ kind: "principals", principals: [] }),
+    ).toThrow();
+  });
+
+  test("rejects an unknown federated accept kind", () => {
+    expect(() =>
+      FederatedAcceptSchema.parse({ kind: "anyone" }),
+    ).toThrow();
+  });
+});
+
+describe("AcceptPolicySchema — closed union", () => {
+  test("accepts the federated and public variants", () => {
+    expect(
+      AcceptPolicySchema.parse({ kind: "network", network: "mf-net" }).kind,
+    ).toBe("network");
+    expect(
+      AcceptPolicySchema.parse({
+        kind: "surface",
+        surface: "github",
+        predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+      }).kind,
+    ).toBe("surface");
+  });
+
+  test("has NO free-form string variant (closed union)", () => {
+    // A free-form accept like the old design sketch ('public:rate-limited')
+    // must NOT parse — the union is closed on `kind`.
+    expect(() => AcceptPolicySchema.parse("public:rate-limited")).toThrow();
+    expect(() => AcceptPolicySchema.parse({ kind: "custom-dsl" })).toThrow();
+  });
+});
+
+// =============================================================================
+// Public predicate — METADATA-ONLY (ADR-0010 DD-CO-8)
+// =============================================================================
+
+describe("PublicPredicateSchema — metadata-only (ADR-0010 DD-CO-8)", () => {
+  test("accepts repo-membership", () => {
+    expect(
+      PublicPredicateSchema.parse({ kind: "repo-membership", repos: ["the-metafactory/*"] }).kind,
+    ).toBe("repo-membership");
+  });
+
+  test("accepts sender-allow / sender-block", () => {
+    expect(
+      PublicPredicateSchema.parse({ kind: "sender-allow", senders: ["octocat"] }).kind,
+    ).toBe("sender-allow");
+    expect(
+      PublicPredicateSchema.parse({ kind: "sender-block", senders: ["bad-actor"] }).kind,
+    ).toBe("sender-block");
+  });
+
+  test("accepts a rate predicate with ≥1 window", () => {
+    expect(
+      PublicPredicateSchema.parse({ kind: "rate", per_hour: 10 }).kind,
+    ).toBe("rate");
+  });
+
+  test("rejects an empty rate predicate (no window)", () => {
+    expect(() => PublicPredicateSchema.parse({ kind: "rate" })).toThrow();
+  });
+
+  // The HARD enforcement of DD-CO-8: a content-dependent predicate cannot be
+  // expressed. There is no `kind` for "description contains X" / "diff matches
+  // Y" — so it fails the discriminator. That IS the schema-level forbidding.
+  test("REJECTS a content-dependent predicate (description/diff matching)", () => {
+    expect(() =>
+      PublicPredicateSchema.parse({
+        kind: "description-contains",
+        value: "please review",
+      }),
+    ).toThrow();
+    expect(() =>
+      PublicPredicateSchema.parse({ kind: "diff-matches", pattern: ".*" }),
+    ).toThrow();
+    expect(() =>
+      PublicPredicateSchema.parse({ kind: "body-regex", regex: "trusted" }),
+    ).toThrow();
+  });
+
+  test("repo-membership requires ≥1 repo glob", () => {
+    expect(() =>
+      PublicPredicateSchema.parse({ kind: "repo-membership", repos: [] }),
+    ).toThrow();
+  });
+});
+
+describe("PublicAcceptSchema", () => {
+  test("accepts {kind:'surface', surface, predicate, limits?}", () => {
+    const a = PublicAcceptSchema.parse({
+      kind: "surface",
+      surface: "github",
+      predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+      limits: { per_day: 100, max_concurrent: 2 },
+    });
+    expect(a.surface).toBe("github");
+    expect(a.predicate.kind).toBe("repo-membership");
+    expect(a.limits?.per_day).toBe(100);
+  });
+
+  test("requires a surface", () => {
+    expect(() =>
+      PublicAcceptSchema.parse({
+        kind: "surface",
+        surface: "",
+        predicate: { kind: "rate", per_day: 5 },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("PublicLimitsSchema", () => {
+  test("rejects an empty limits block", () => {
+    expect(() => PublicLimitsSchema.parse({})).toThrow();
+  });
+  test("accepts a single bound", () => {
+    expect(PublicLimitsSchema.parse({ per_day: 50 }).per_day).toBe(50);
+  });
+});
+
+// =============================================================================
+// superRefineOfferings — cross-offering coherence rules
+// =============================================================================
+
+function offering(o: Offering): Offering {
+  return o;
+}
+
+describe("superRefineOfferings — coherence", () => {
+  test("no issues for a valid local-only offering", () => {
+    expect(
+      superRefineOfferings([offering({ capability: "chat", scopes: ["local"] })]),
+    ).toEqual([]);
+  });
+
+  test("DEFAULT-DENY: federated scope with no accept is an issue", () => {
+    const issues = superRefineOfferings([
+      offering({ capability: "chat", scopes: ["federated"] }),
+    ]);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.message).toContain("DEFAULT-DENY");
+    expect(issues[0]?.path).toEqual([0, "accept"]);
+  });
+
+  test("federated scope WITH a named network accept is clean", () => {
+    expect(
+      superRefineOfferings([
+        offering({
+          capability: "chat",
+          scopes: ["federated"],
+          accept: { kind: "network", network: "mf-net" },
+        }),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("federated scope with a PUBLIC accept is a kind-mismatch issue", () => {
+    const issues = superRefineOfferings([
+      offering({
+        capability: "chat",
+        scopes: ["federated"],
+        accept: {
+          kind: "surface",
+          surface: "github",
+          predicate: { kind: "rate", per_day: 1 },
+        },
+      }),
+    ]);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.message).toContain("requires a federated accept");
+  });
+
+  test("public scope with no accept is an issue", () => {
+    const issues = superRefineOfferings([
+      offering({ capability: "code-review.typescript", scopes: ["public"] }),
+    ]);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.message).toContain("two-stage metadata gate");
+  });
+
+  test("public scope WITH a surface accept is clean", () => {
+    expect(
+      superRefineOfferings([
+        offering({
+          capability: "code-review.typescript",
+          scopes: ["public"],
+          accept: {
+            kind: "surface",
+            surface: "github",
+            predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+          },
+        }),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("local-only offering carrying an accept is an issue", () => {
+    const issues = superRefineOfferings([
+      offering({
+        capability: "chat",
+        scopes: ["local"],
+        accept: { kind: "network", network: "mf-net" },
+      }),
+    ]);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.message).toContain("local-only but carries an accept-policy");
+  });
+
+  test("federated + public in one offering is rejected (single accept can't serve both)", () => {
+    const issues = superRefineOfferings([
+      offering({
+        capability: "chat",
+        scopes: ["federated", "public"],
+        accept: { kind: "network", network: "mf-net" },
+      }),
+    ]);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.message).toContain("both 'federated' and 'public'");
+  });
+
+  test("duplicate capability across two offerings is an issue", () => {
+    const issues = superRefineOfferings([
+      offering({ capability: "chat", scopes: ["local"] }),
+      offering({ capability: "chat", scopes: ["local"] }),
+    ]);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.message).toContain("already declared at offerings[0]");
+    expect(issues[0]?.path).toEqual([1, "capability"]);
+  });
+
+  test("batch-emits issues across multiple offenders", () => {
+    const issues = superRefineOfferings([
+      offering({ capability: "a.one", scopes: ["federated"] }), // no accept
+      offering({ capability: "b.two", scopes: ["public"] }), // no accept
+    ]);
+    expect(issues.length).toBe(2);
+  });
+});
+
+// =============================================================================
+// resolveOffering — the default-deny resolver (ADR-0008 DD-CO-1)
+// =============================================================================
+
+describe("resolveOffering — default-deny (ADR-0008 DD-CO-1)", () => {
+  test("an unoffered capability resolves to local-only", () => {
+    const r = resolveOffering("dev.implement", []);
+    expect(r).toEqual({ capability: "dev.implement", scopes: ["local"] });
+  });
+
+  test("undefined offerings ⇒ local-only (the byte-identical-boot case)", () => {
+    expect(resolveOffering("anything", undefined)).toEqual({
+      capability: "anything",
+      scopes: ["local"],
+    });
+  });
+
+  test("a matched offering resolves to its scopes + accept", () => {
+    const offerings: Offering[] = [
+      offering({
+        capability: "code-review.typescript",
+        scopes: ["public"],
+        accept: {
+          kind: "surface",
+          surface: "github",
+          predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+        },
+      }),
+    ];
+    const r = resolveOffering("code-review.typescript", offerings);
+    expect(r.scopes).toEqual(["public"]);
+    expect(r.accept?.kind).toBe("surface");
+  });
+
+  test("a capability NOT in a non-empty offerings list still resolves local-only", () => {
+    const offerings: Offering[] = [
+      offering({ capability: "chat", scopes: ["federated"], accept: { kind: "network", network: "mf-net" } }),
+    ];
+    expect(resolveOffering("dev.implement", offerings)).toEqual({
+      capability: "dev.implement",
+      scopes: ["local"],
+    });
+  });
+
+  test("an offering with an empty scopes[] defensively resolves local-only", () => {
+    // The schema rejects scopes:[], but the resolver is total and defends a
+    // programmatic caller that bypasses parse.
+    const offerings = [{ capability: "chat", scopes: [] }] as unknown as Offering[];
+    expect(resolveOffering("chat", offerings)).toEqual({
+      capability: "chat",
+      scopes: ["local"],
+    });
+  });
+
+  test("returned scopes is a defensive copy (caller cannot mutate the offering)", () => {
+    const off = offering({ capability: "chat", scopes: ["federated"], accept: { kind: "network", network: "mf-net" } });
+    const r = resolveOffering("chat", [off]);
+    r.scopes.push("public");
+    expect(off.scopes).toEqual(["federated"]);
+  });
+});

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -47,6 +47,7 @@ import {
 import { NKEY_PUBKEY_REGEX } from "./nkey";
 import { NatsSubjectsSchema } from "./nats-subjects";
 import { LETTER_PREFIX_ID_REGEX } from "./id";
+import { OfferingSchema, superRefineOfferings } from "./offering";
 import { StackConfigSchema, deriveStackId } from "./stack";
 
 // =============================================================================
@@ -1985,6 +1986,37 @@ export const PolicySchema = z.object({
   roles: z.array(PolicyRoleSchema).default([]),
   federated: PolicyFederatedSchema.optional(),
   public: PolicyPublicSchema.optional(),
+  /**
+   * CO-1 (epic cortex#939) — the capability **offering** policy block: the
+   * provider-side `(capability, offer-scope, accept-policy)` triples that
+   * elevate a flat `runtime.capabilities[]` tag into *exposed work* (design
+   * `docs/design-capability-offering.md` §2/§9, ADR-0008 DD-CO-1).
+   *
+   * **Per-stack runtime config (DD-CO-7, ADR-0009).** Offerings live
+   * self-contained on the stack layer; the boot composer never composes a
+   * shared `offerings/` layer — each stack fully describes what *it* exposes.
+   *
+   * **Default-defaulted ⇒ byte-identical boot (the CO-1 contract).** OPTIONAL
+   * and fully-defaulted: absent ⇒ `[]` ⇒ every capability resolves `local`-only
+   * via `resolveOffering` (`./offering.ts`) — exactly today's behaviour. No
+   * consumer wiring reads this in CO-1 (that's CO-2); no federation-config
+   * generation (CO-3). This is the source-of-truth shape those slices project.
+   *
+   * The structural per-entry schema is `OfferingSchema`; the cross-offering
+   * coherence rules (no-duplicate-capability, federated-requires-naming,
+   * scope↔accept agreement) run in `superRefineOfferings` (invoked in the
+   * superRefine below). The "offered capability must EXIST in the stack's
+   * declared capabilities" cross-block check lives on `CortexConfigSchema`
+   * (where `capabilities[]` + `agents[]` are in scope).
+   *
+   * **`.optional()`, not `.default([])`** — mirrors the sibling widening blocks
+   * `federated` / `public`, which are also `.optional()`: an absent `offerings`
+   * is the default-deny baseline (every capability resolves `local`-only via
+   * `resolveOffering`, which treats `undefined` exactly like `[]`), so a
+   * `Policy`-typed literal need not name it. The resolver — not a schema
+   * default — is the single source of the default-deny semantics.
+   */
+  offerings: z.array(OfferingSchema).optional(),
   // v2.0.0 cutover (cortex#297) — `parallel_mode_enabled` retired with
   // the parallel-mode plumbing in adapters. PolicyEngine is the sole
   // authorisation gate; legacy role-resolver is gone.
@@ -2218,6 +2250,22 @@ export const PolicySchema = z.object({
           }
         }
       });
+    });
+  }
+
+  // CO-1 (epic cortex#939) — cross-offering coherence. `superRefineOfferings`
+  // (`./offering.ts`) returns per-offender issues with paths RELATIVE to the
+  // offerings array; we prepend `["offerings", ...]` so the YAML-aware loader
+  // renders each inline at the bad token — same per-offender pattern as the
+  // principal/role/network rules above. Enforces: no duplicate capability;
+  // federated scope requires a named accept (DEFAULT-DENY, ADR-0008 DD-CO-1);
+  // public scope requires a {kind:'surface'} accept; accept-kind must agree
+  // with the offered scope; a local-only offering carries no accept.
+  for (const issue of superRefineOfferings(policy.offerings ?? [])) {
+    ctx.addIssue({
+      code: "custom",
+      message: issue.message,
+      path: ["offerings", ...issue.path],
     });
   }
 });
@@ -2617,6 +2665,40 @@ export const CortexConfigSchema = z.object({
       validateSubjectScope(network.accept_subjects, "accept_subjects");
       validateSubjectScope(network.deny_subjects, "deny_subjects");
     });
+  })
+  // CO-1 (epic cortex#939) — offered capability must EXIST in the stack.
+  //
+  // An offering names a capability by id; that id MUST resolve to a declared
+  // top-level `capabilities[]` entry (the same catalog the agent-side
+  // `runtime.capabilities[]` references). Offering a capability the stack does
+  // not provide is a config error — you'd be exposing a capability no agent
+  // here fulfills, so a consumer that claimed the Offer would dead-letter.
+  //
+  // This is an ERROR (not a warn) for parity with the existing capability
+  // dangling-reference checks above, all of which error — the offering policy
+  // is only meaningful relative to a real, provided capability. The check
+  // lives here (not in `PolicySchema.superRefine`) because `capabilities[]` is
+  // a top-level block the policy sub-schema does not see. Batch-emit so a
+  // config with several phantom offerings surfaces all of them in one pass.
+  .superRefine((config, ctx) => {
+    const offerings = config.policy?.offerings;
+    if (offerings === undefined || offerings.length === 0) return;
+    const catalogIds = new Set(config.capabilities.map((c) => c.id));
+    const declaredCatalog = [...catalogIds].sort().join(", ") || "(none)";
+    offerings.forEach((offering, offeringIdx) => {
+      if (!catalogIds.has(offering.capability)) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            `policy.offerings[${offeringIdx}] offers capability "${offering.capability}", ` +
+            `but no matching entry exists in the top-level capabilities[] catalog ` +
+            `(declared capability ids: ${declaredCatalog}). ` +
+            `An offering exposes a capability the stack PROVIDES; declare "${offering.capability}" ` +
+            `in capabilities[] (with a provided_by[] agent) before offering it.`,
+          path: ["policy", "offerings", offeringIdx, "capability"],
+        });
+      }
+    });
   });
 
 export type CortexConfig = z.infer<typeof CortexConfigSchema>;
@@ -2648,3 +2730,31 @@ export type { StackConfig, DerivedStackId, DeriveStackIdInput } from "./stack";
  */
 export { CapabilitySchema } from "./capability";
 export type { Capability, CapabilityRate, CapabilityCost } from "./capability";
+
+/**
+ * CO-1 (epic cortex#939) re-exports — the capability **offering** policy model
+ * ships in its own module (`./offering.ts`); downstream code pulling from this
+ * file shouldn't need a second import path. Mirrors the `CapabilitySchema`
+ * re-export above. `resolveOffering` is the default-deny resolver CO-2
+ * consumes; `OfferScopeSchema`/`AcceptPolicySchema` are the model's public
+ * surface.
+ */
+export {
+  OfferingSchema,
+  OfferScopeSchema,
+  AcceptPolicySchema,
+  PublicPredicateSchema,
+  PublicPredicateKindSchema,
+  resolveOffering,
+} from "./offering";
+export type {
+  Offering,
+  OfferScope,
+  AcceptPolicy,
+  FederatedAccept,
+  PublicAccept,
+  PublicPredicate,
+  PublicPredicateKind,
+  PublicLimits,
+  ResolvedOffering,
+} from "./offering";

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1997,7 +1997,7 @@ export const PolicySchema = z.object({
    * shared `offerings/` layer — each stack fully describes what *it* exposes.
    *
    * **Default-defaulted ⇒ byte-identical boot (the CO-1 contract).** OPTIONAL
-   * and fully-defaulted: absent ⇒ `[]` ⇒ every capability resolves `local`-only
+   * and fully-defaulted: absent ⇒ `undefined` ⇒ every capability resolves `local`-only
    * via `resolveOffering` (`./offering.ts`) — exactly today's behaviour. No
    * consumer wiring reads this in CO-1 (that's CO-2); no federation-config
    * generation (CO-3). This is the source-of-truth shape those slices project.

--- a/src/common/types/offering.ts
+++ b/src/common/types/offering.ts
@@ -17,7 +17,7 @@
  *     `announce_capabilities` / `accept_subjects` / registry registration is
  *     CO-3; this is the source-of-truth shape those projections will read.
  *   - **Byte-identical boot (the CO-1 contract).** `policy.offerings` is
- *     OPTIONAL and fully-defaulted; absent ⇒ empty ⇒ every capability resolves
+ *     OPTIONAL and fully-defaulted; absent ⇒ `undefined` ⇒ every capability resolves
  *     to `local`-only via {@link resolveOffering} — exactly today's behaviour.
  *
  * ## The model (design §2, ADR-0008 DD-CO-1)
@@ -495,6 +495,20 @@ export function superRefineOfferings(
         issues.push({
           message: `offering "${o.capability}" is offered at 'federated' scope but its accept-policy is {kind:'${acceptKind}'} — federated scope requires a federated accept ({kind:'network'} or {kind:'principals'})`,
           path: [i, "accept", "kind"],
+        });
+      } else if (
+        o.accept.kind === "network" &&
+        o.network !== undefined &&
+        o.network !== o.accept.network
+      ) {
+        // #962 review nit: the top-level `network?` and the {kind:'network'}
+        // accept's own `network` are dual-source. The accept's network is
+        // AUTHORITATIVE (routing uses it); the top-level field is design-parity
+        // documentation only. Reject divergence rather than silently pick one —
+        // a mismatch is a config error, not a value to merge.
+        issues.push({
+          message: `offering "${o.capability}" has a top-level network "${o.network}" that disagrees with its accept network "${o.accept.network}" — the accept-policy's network is authoritative; remove the top-level network or make them match`,
+          path: [i, "network"],
         });
       }
       return;

--- a/src/common/types/offering.ts
+++ b/src/common/types/offering.ts
@@ -1,0 +1,576 @@
+/**
+ * CO-1 (epic cortex#939) — the capability **offering** policy model.
+ *
+ * An **offering** is the PROVIDER side of the capability handshake
+ * (CONTEXT.md §Capability offering): the policy that elevates a flat,
+ * scope-blind `runtime.capabilities[]` tag into *exposed work* — the triple
+ * `(capability, offer-scope, accept-policy)`. It is the symmetric counterpart
+ * of Offer-mode dispatch (a consumer can only *Offer* work to a capability a
+ * provider has *offered*).
+ *
+ * This file is the DATA MODEL + VALIDATION only (design §9 CO-1). It is
+ * deliberately inert:
+ *
+ *   - **No consumer wiring.** Which scope prefixes a capability's JetStream
+ *     consumer binds on is CO-2; nothing here touches the dispatch path.
+ *   - **No federation-config generation.** `cortex offer` regenerating
+ *     `announce_capabilities` / `accept_subjects` / registry registration is
+ *     CO-3; this is the source-of-truth shape those projections will read.
+ *   - **Byte-identical boot (the CO-1 contract).** `policy.offerings` is
+ *     OPTIONAL and fully-defaulted; absent ⇒ empty ⇒ every capability resolves
+ *     to `local`-only via {@link resolveOffering} — exactly today's behaviour.
+ *
+ * ## The model (design §2, ADR-0008 DD-CO-1)
+ *
+ *   offer-scope  = the TRUST TIER a capability is reachable at — a subset of
+ *                  {local, federated, public}. A capability MAY be offered at
+ *                  several scopes at once.
+ *   accept-policy = WITHIN an offered scope, who may dispatch it. A CLOSED,
+ *                  per-scope tagged union (NOT a free-form DSL):
+ *                    local      → no accept-policy (it is *this* stack).
+ *                    federated  → {kind:'network'} | {kind:'principals'}
+ *                                 (default-deny: federated with no accept is a
+ *                                  VALIDATION ERROR — you must name).
+ *                    public     → {kind:'surface', predicate:<metadata-only>, limits}
+ *                                 (the predicate is constrained to METADATA-
+ *                                  evaluable forms — content-dependent
+ *                                  predicates FAIL schema validation, ADR-0010
+ *                                  DD-CO-8).
+ *
+ * ## Default-deny (ADR-0008 DD-CO-1)
+ *
+ * A capability not listed in `policy.offerings[]` (or listed with no scope)
+ * resolves to **`local`-only**. The secure default is internal exposure;
+ * widening to federated/public is a deliberate act. {@link resolveOffering} is
+ * the pure resolver CO-2 consumes to decide consumer-binding.
+ *
+ * Refs: docs/design-capability-offering.md §2/§6/§9 ·
+ *       docs/adr/0008-capability-offering-scope.md (DD-CO-1) ·
+ *       docs/adr/0009-offerings-per-stack-no-shared-layer.md (DD-CO-7 — this is
+ *         per-stack runtime config; the runtime never composes a shared layer) ·
+ *       docs/adr/0010-public-accept-gate-two-stage.md (DD-CO-8 — metadata-only
+ *         public predicates) · CONTEXT.md §Capability offering.
+ */
+
+import { z } from "zod/v4";
+
+import { LETTER_PREFIX_ID_REGEX } from "./id";
+
+// =============================================================================
+// Capability-id + network-id grammars (reused from the capability primitive)
+// =============================================================================
+
+/**
+ * Offering `capability` grammar — the same dot-separated lowercase-segment id
+ * grammar as a {@link CapabilitySchema} `id` (`./capability.ts`). An offering
+ * names a capability by id; it cannot name something that isn't a well-formed
+ * capability id. Kept as a local copy of the regex (rather than importing the
+ * private `CapabilityIdSchema`) so the two stay structurally identical without
+ * coupling the offering schema to a non-exported symbol; the cross-field check
+ * on `CortexConfigSchema` enforces that the named capability actually EXISTS.
+ */
+const OfferingCapabilityIdSchema = z
+  .string()
+  .min(1, "offering.capability is required and must be non-empty")
+  .regex(
+    /^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)*$/,
+    "offering.capability must be a capability id — dot-separated lowercase segments, each starting with a letter and containing only lowercase alphanumeric + hyphen/underscore (e.g. 'code-review.typescript')",
+  );
+
+/**
+ * A network id — matches the federated network id grammar
+ * (`PolicyFederatedNetworkSchema.id` letter-prefix). Used by the offering's
+ * top-level `network?` field and the `{kind:'network'}` federated accept.
+ */
+const OfferingNetworkIdSchema = z
+  .string()
+  .regex(
+    LETTER_PREFIX_ID_REGEX,
+    "offering network id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'metafactory-net')",
+  );
+
+/**
+ * A principal id — same letter-prefix grammar as a principal id. Used by the
+ * `{kind:'principals'}` federated accept-policy.
+ */
+const OfferingPrincipalIdSchema = z
+  .string()
+  .regex(
+    LETTER_PREFIX_ID_REGEX,
+    "offering principal id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'jcfischer')",
+  );
+
+// =============================================================================
+// OfferScope — the trust tier
+// =============================================================================
+
+/**
+ * Offer-scope = the trust tier a capability is reachable at (design §2,
+ * CONTEXT.md §Capability offering). NOT to be confused with transport-Scope's
+ * `local` (whose outer limit is the principal): offer-scope `local` binds
+ * NARROWER — the offering stack itself (multiple stacks = multiple locals).
+ */
+export const OfferScopeSchema = z.enum(["local", "federated", "public"]);
+
+export type OfferScope = z.infer<typeof OfferScopeSchema>;
+
+// =============================================================================
+// AcceptPolicy — the CLOSED, per-scope tagged union
+// =============================================================================
+
+/**
+ * Federated accept by NAMED network. Admits dispatch from any peer on the
+ * registry roster of `network`. Default-deny means a `federated` scope MUST
+ * carry one of the federated accept kinds — see the `superRefine` on the
+ * offering list (federated-requires-naming).
+ */
+export const FederatedNetworkAcceptSchema = z
+  .object({
+    kind: z.literal("network"),
+    network: OfferingNetworkIdSchema,
+  })
+  .strict();
+
+/**
+ * Federated accept by EXPLICIT principal allowlist. Admits dispatch only from
+ * the named principals (resolved over the registry roster at runtime — CO-2/3).
+ * At least one principal must be named: an empty `principals: []` is "name
+ * nobody", which contradicts the act of widening to `federated`, so it is
+ * rejected here rather than silently resolving to deny-all.
+ */
+export const FederatedPrincipalsAcceptSchema = z
+  .object({
+    kind: z.literal("principals"),
+    principals: z
+      .array(OfferingPrincipalIdSchema)
+      .min(
+        1,
+        "federated accept {kind:'principals'} must name at least one principal — an empty list names nobody (use a different scope, or name the principals)",
+      ),
+  })
+  .strict();
+
+/**
+ * The federated accept-policy: network-roster OR explicit principal allowlist.
+ * Discriminated on `kind` so a malformed entry fails at the precise variant.
+ */
+export const FederatedAcceptSchema = z.discriminatedUnion("kind", [
+  FederatedNetworkAcceptSchema,
+  FederatedPrincipalsAcceptSchema,
+]);
+
+export type FederatedAccept = z.infer<typeof FederatedAcceptSchema>;
+
+// -----------------------------------------------------------------------------
+// Public accept-policy — the two-stage gate (ADR-0010 DD-CO-8)
+// -----------------------------------------------------------------------------
+
+/**
+ * The CLOSED set of METADATA-evaluable public accept-predicate kinds. This is
+ * the hard enforcement of ADR-0010 DD-CO-8: Stage-1 admission is decided in
+ * code, pre-LLM, on surface-asserted trustworthy metadata ONLY — never on
+ * attacker-controlled request content.
+ *
+ * The kinds correspond 1:1 to the metadata the surface (e.g. GitHub via the
+ * gh-webhook tap) asserts and the HMAC validates:
+ *
+ *   - `repo-membership` — admit requests against repos matching a glob set
+ *     (e.g. `the-metafactory/*`). The repo is surface-asserted, HMAC-proven.
+ *   - `sender-allow`    — admit requests from an allowlist of surface sender
+ *     identities (e.g. GitHub logins). The sender is surface-asserted.
+ *   - `sender-block`    — deny requests from a blocklist of surface senders
+ *     (admit everything else within the scope, subject to the other gates).
+ *   - `rate`            — admit by a deterministic rate ceiling (no identity
+ *     dimension; the rate dimension of the metadata gate).
+ *
+ * A predicate `kind` that would require reading the request's CONTENT (the PR
+ * body/description/diff) is, by construction, NOT in this enum — so it cannot
+ * be expressed, and a YAML author who tries gets a closed-set enum error at
+ * schema-parse time (not a runtime surprise). That IS the enforcement: the
+ * predicate vocabulary is exactly the metadata-evaluable set, with no escape
+ * hatch for content.
+ */
+export const PublicPredicateKindSchema = z.enum([
+  "repo-membership",
+  "sender-allow",
+  "sender-block",
+  "rate",
+]);
+
+export type PublicPredicateKind = z.infer<typeof PublicPredicateKindSchema>;
+
+/**
+ * Admit requests whose surface-asserted repo matches one of `repos[]` (glob
+ * patterns, e.g. `the-metafactory/*`). The repo is part of the HMAC-validated
+ * webhook payload (ADR-0010 — surface-asserted, trustworthy), never derived
+ * from the request body.
+ */
+const RepoMembershipPredicateSchema = z
+  .object({
+    kind: z.literal("repo-membership"),
+    repos: z
+      .array(z.string().min(1))
+      .min(1, "repo-membership predicate must name at least one repo glob (e.g. 'the-metafactory/*')"),
+  })
+  .strict();
+
+/**
+ * Admit requests from surface sender identities (e.g. GitHub logins) on the
+ * allowlist. The sender identity is surface-asserted + HMAC-validated.
+ */
+const SenderAllowPredicateSchema = z
+  .object({
+    kind: z.literal("sender-allow"),
+    senders: z
+      .array(z.string().min(1))
+      .min(1, "sender-allow predicate must name at least one surface sender identity"),
+  })
+  .strict();
+
+/**
+ * Deny requests from surface sender identities on the blocklist; admit
+ * everything else in-scope (subject to the other gates).
+ */
+const SenderBlockPredicateSchema = z
+  .object({
+    kind: z.literal("sender-block"),
+    senders: z
+      .array(z.string().min(1))
+      .min(1, "sender-block predicate must name at least one surface sender identity"),
+  })
+  .strict();
+
+/**
+ * Admit by a deterministic rate ceiling — the identity-free dimension of the
+ * metadata gate. At least one window must be set (an empty rate predicate is
+ * no constraint, which is a different concept than a `rate` predicate).
+ */
+const RatePredicateSchema = z
+  .object({
+    kind: z.literal("rate"),
+    per_minute: z.number().int().positive().optional(),
+    per_hour: z.number().int().positive().optional(),
+    per_day: z.number().int().positive().optional(),
+  })
+  .strict()
+  .refine(
+    (r) => r.per_minute !== undefined || r.per_hour !== undefined || r.per_day !== undefined,
+    {
+      message:
+        "rate predicate must declare at least one window (per_minute, per_hour, or per_day)",
+    },
+  );
+
+/**
+ * The public accept-predicate — the discriminated union of the CLOSED
+ * metadata-only kinds. Because it is a discriminated union over
+ * {@link PublicPredicateKindSchema}, a content-referencing predicate cannot be
+ * constructed: there is no `kind` for it, so it fails the discriminator. That
+ * is how ADR-0010 DD-CO-8 ("content-dependent accept-predicates FORBIDDEN") is
+ * enforced *in the schema* rather than at runtime.
+ */
+export const PublicPredicateSchema = z.discriminatedUnion("kind", [
+  RepoMembershipPredicateSchema,
+  SenderAllowPredicateSchema,
+  SenderBlockPredicateSchema,
+  RatePredicateSchema,
+]);
+
+export type PublicPredicate = z.infer<typeof PublicPredicateSchema>;
+
+/**
+ * Public-scope rate/cost limits — the §5 gate-floor knobs (design §5 / §6 M6).
+ * Bounds adversarial inputs + token cost for public work. Fully optional
+ * (a public offering MAY ship without explicit limits in CO-1; CO-4 wires the
+ * enforcement and may tighten this to required). At least one field, when the
+ * block is present, must be set — an empty `limits: {}` is rejected so it
+ * cannot masquerade as "limited".
+ */
+export const PublicLimitsSchema = z
+  .object({
+    /** Max concurrent public review sessions admitted. */
+    max_concurrent: z.number().int().positive().optional(),
+    /** Per-day request ceiling for this public offering. */
+    per_day: z.number().int().positive().optional(),
+    /** Token-budget cap (cents) per request — ties to the BudgetCheck gap. */
+    cost_cents_per_request: z.number().nonnegative().optional(),
+  })
+  .strict()
+  .refine(
+    (l) =>
+      l.max_concurrent !== undefined ||
+      l.per_day !== undefined ||
+      l.cost_cents_per_request !== undefined,
+    {
+      message:
+        "public limits must declare at least one bound (max_concurrent, per_day, or cost_cents_per_request); omit the `limits:` block entirely to mean 'no explicit limit'",
+    },
+  );
+
+export type PublicLimits = z.infer<typeof PublicLimitsSchema>;
+
+/**
+ * The public accept-policy `{kind:'surface', surface, predicate, limits?}`
+ * (design §2). The `surface` names the trust anchor (e.g. `github`); the
+ * `predicate` is the metadata-only Stage-1 gate; `limits` is the gate floor.
+ */
+export const PublicAcceptSchema = z
+  .object({
+    kind: z.literal("surface"),
+    /**
+     * The surface that anchors trust for this public offering (e.g. `github`).
+     * The public requester holds no bus identity; the surface's HMAC-validated
+     * assertion of who/what is the trust anchor (ADR-0010 DD-CO-8).
+     */
+    surface: z.string().min(1, "public accept.surface is required (e.g. 'github')"),
+    /**
+     * The metadata-only Stage-1 admission predicate. Constrained to
+     * {@link PublicPredicateSchema} — content-dependent forms are not
+     * expressible.
+     */
+    predicate: PublicPredicateSchema,
+    /** Optional gate-floor limits (rate / cost / concurrency). */
+    limits: PublicLimitsSchema.optional(),
+  })
+  .strict();
+
+export type PublicAccept = z.infer<typeof PublicAcceptSchema>;
+
+/**
+ * The accept-policy — the CLOSED tagged union across all scopes:
+ *
+ *   federated → {kind:'network'} | {kind:'principals'}
+ *   public    → {kind:'surface', ...}
+ *
+ * `local` has NO accept variant — it is *this* stack, so no who-within-tier
+ * decision exists. (`local`-only offerings carry no `accept` at all.) Because
+ * the three federated/public kinds are discriminated on `kind`, the union is
+ * closed: there is no free-form string variant, and a content-dependent public
+ * predicate has no `kind` to land on.
+ */
+export const AcceptPolicySchema = z.discriminatedUnion("kind", [
+  FederatedNetworkAcceptSchema,
+  FederatedPrincipalsAcceptSchema,
+  PublicAcceptSchema,
+]);
+
+export type AcceptPolicy = z.infer<typeof AcceptPolicySchema>;
+
+// =============================================================================
+// Offering — the (capability × offer-scope × accept-policy) triple
+// =============================================================================
+
+/**
+ * A single capability offering (design §2). The structural schema; the
+ * cross-scope coherence rules (federated-requires-naming, scope↔accept-kind
+ * agreement, no-duplicate-capability) live in {@link superRefineOfferings},
+ * called from `PolicySchema.superRefine`; the "offered capability must exist"
+ * cross-block check lives on `CortexConfigSchema` (where `capabilities[]` is in
+ * scope).
+ */
+export const OfferingSchema = z
+  .object({
+    /**
+     * The capability this offering exposes — a capability id. The cross-field
+     * check on `CortexConfigSchema` enforces that it matches a declared
+     * capability some agent in the stack provides.
+     */
+    capability: OfferingCapabilityIdSchema,
+    /**
+     * The offer-scope(s) at which the capability is reachable. ≥1 scope; an
+     * offering with `scopes: []` is "offered nowhere", which is the same as
+     * not offering it (default-deny → local) and so is rejected as a likely
+     * mistake — drop the entry, or name the scopes.
+     */
+    scopes: z
+      .array(OfferScopeSchema)
+      .min(1, "offering.scopes must name at least one scope (local, federated, or public); omit the offering entirely to mean 'local-only' (the default-deny resolution)"),
+    /**
+     * The accept-policy — who, within an offered scope, may dispatch.
+     * Optional at the field level because `local`-only offerings carry no
+     * accept; the scope↔accept coherence rules in {@link superRefineOfferings}
+     * enforce that `federated`/`public` scopes DO carry the matching accept.
+     */
+    accept: AcceptPolicySchema.optional(),
+    /**
+     * Optional convenience: the network this offering's federated scope binds
+     * to, when the `{kind:'network'}` accept isn't used (or as documentation).
+     * Carried for parity with the design's `network?` field; the federated
+     * accept's own `network` is authoritative for the `{kind:'network'}` case.
+     */
+    network: OfferingNetworkIdSchema.optional(),
+  })
+  .strict();
+
+export type Offering = z.infer<typeof OfferingSchema>;
+
+// =============================================================================
+// Cross-offering validation — federated-requires-naming, scope↔accept, dedup
+// =============================================================================
+
+/**
+ * Minimal issue shape the {@link superRefineOfferings} helper emits, mirroring
+ * the `ctx.addIssue` calls in `PolicySchema.superRefine`. Keeping the helper
+ * decoupled from Zod's `RefinementCtx` import surface lets the policy schema
+ * own the `ctx` and just forward issues; the helper stays unit-testable
+ * against a plain collector.
+ */
+export interface OfferingIssue {
+  message: string;
+  /** Path RELATIVE to `policy` (the caller prepends `["offerings", ...]`). */
+  path: (string | number)[];
+}
+
+/**
+ * The cross-offering coherence rules (called from `PolicySchema.superRefine`):
+ *
+ *   1. **No duplicate capability.** Two offerings for the same capability are a
+ *      config error (which one wins?). One offering per capability; widen its
+ *      `scopes[]` instead of adding a second entry.
+ *   2. **Scope↔accept agreement.**
+ *        - `federated` in scopes  ⇒ MUST carry a federated accept
+ *          ({kind:'network'|'principals'}) — DEFAULT-DENY: federated with no
+ *          accept names nobody (ADR-0008 DD-CO-1, CONTEXT.md §Capability
+ *          offering). This is the headline default-deny enforcement.
+ *        - `public` in scopes     ⇒ MUST carry a public accept
+ *          ({kind:'surface', ...}).
+ *        - `accept` present but its `kind` doesn't match an offered scope ⇒
+ *          error (a federated accept on a local-only offering is meaningless).
+ *        - `local`-only offering   ⇒ MUST NOT carry an accept (nothing to gate).
+ *
+ * Note one offering carries at most ONE `accept`. An offering at BOTH
+ * `federated` and `public` would need two different accept shapes, which a
+ * single `accept` field can't express — so such an offering is rejected here
+ * with a pointed message (split it into the per-scope-natural separate
+ * offerings via distinct… no: distinct entries collide on capability). CO-1's
+ * model is therefore: an offering names one accept; offering a capability at
+ * both federated AND public is deferred (flagged, not silently mis-handled).
+ */
+export function superRefineOfferings(
+  offerings: readonly Offering[],
+): OfferingIssue[] {
+  const issues: OfferingIssue[] = [];
+
+  // 1. No duplicate capability.
+  const seen = new Map<string, number>();
+  offerings.forEach((o, i) => {
+    const dupAt = seen.get(o.capability);
+    if (dupAt !== undefined) {
+      issues.push({
+        message: `offering for capability "${o.capability}" already declared at offerings[${dupAt}] — one offering per capability; widen its scopes[] instead of adding a second entry`,
+        path: [i, "capability"],
+      });
+    } else {
+      seen.set(o.capability, i);
+    }
+  });
+
+  // 2. Scope↔accept agreement (+ default-deny for federated).
+  offerings.forEach((o, i) => {
+    const scopeSet = new Set(o.scopes);
+    const hasFederated = scopeSet.has("federated");
+    const hasPublic = scopeSet.has("public");
+    const acceptKind = o.accept?.kind;
+    const acceptIsFederated =
+      acceptKind === "network" || acceptKind === "principals";
+    const acceptIsPublic = acceptKind === "surface";
+
+    // A single offering cannot carry both a federated and a public scope —
+    // it would need two distinct accept shapes, and `accept` is singular.
+    if (hasFederated && hasPublic) {
+      issues.push({
+        message: `offering "${o.capability}" lists both 'federated' and 'public' scopes, but an offering carries a single accept-policy and these scopes need different accept shapes — declare them as separate concerns (offer one scope per capability entry in CO-1; multi-scope-with-distinct-accept is deferred)`,
+        path: [i, "scopes"],
+      });
+      return;
+    }
+
+    if (hasFederated) {
+      if (o.accept === undefined) {
+        issues.push({
+          message: `offering "${o.capability}" is offered at 'federated' scope but names no accept-policy — federated is DEFAULT-DENY: you must name a network ({kind:'network'}) or principals ({kind:'principals'}) (ADR-0008 DD-CO-1)`,
+          path: [i, "accept"],
+        });
+      } else if (!acceptIsFederated) {
+        issues.push({
+          message: `offering "${o.capability}" is offered at 'federated' scope but its accept-policy is {kind:'${acceptKind}'} — federated scope requires a federated accept ({kind:'network'} or {kind:'principals'})`,
+          path: [i, "accept", "kind"],
+        });
+      }
+      return;
+    }
+
+    if (hasPublic) {
+      if (o.accept === undefined) {
+        issues.push({
+          message: `offering "${o.capability}" is offered at 'public' scope but names no accept-policy — public requires {kind:'surface', surface, predicate, limits} (the two-stage metadata gate, ADR-0010 DD-CO-8)`,
+          path: [i, "accept"],
+        });
+      } else if (!acceptIsPublic) {
+        issues.push({
+          message: `offering "${o.capability}" is offered at 'public' scope but its accept-policy is {kind:'${acceptKind}'} — public scope requires a public accept ({kind:'surface', ...})`,
+          path: [i, "accept", "kind"],
+        });
+      }
+      return;
+    }
+
+    // local-only offering: an accept-policy is meaningless (it IS this stack).
+    if (o.accept !== undefined) {
+      issues.push({
+        message: `offering "${o.capability}" is local-only but carries an accept-policy — 'local' is this stack, so there is nobody-within-tier to gate; drop the accept (or widen the scope)`,
+        path: [i, "accept"],
+      });
+    }
+  });
+
+  return issues;
+}
+
+// =============================================================================
+// resolveOffering — the default-deny resolver (the CO-2 consumption point)
+// =============================================================================
+
+/**
+ * The resolved view of a capability's offering — what CO-2 reads to decide
+ * which scope prefixes its JetStream consumer binds on.
+ */
+export interface ResolvedOffering {
+  /** The capability id this resolves. */
+  capability: string;
+  /** The effective offer-scopes. Default-deny ⇒ `['local']`. */
+  scopes: OfferScope[];
+  /** The accept-policy, if the matched offering carried one. */
+  accept?: AcceptPolicy;
+}
+
+/**
+ * Resolve a capability against the stack's offerings list — the DEFAULT-DENY
+ * resolver (ADR-0008 DD-CO-1).
+ *
+ * A capability NOT present in `offerings` (or — defensively — present with an
+ * empty `scopes[]`, which the schema rejects but a programmatic caller could
+ * still pass) resolves to **`local`-only**: `{capability, scopes:['local']}`,
+ * no accept-policy. This is the contract that makes CO-1 byte-identical: with
+ * `policy.offerings` absent, EVERY capability resolves local-only — exactly
+ * today's behaviour. CO-2 consumes this to bind the consumer (today: always
+ * `local`); nothing downstream changes until something is offered wider.
+ *
+ * Pure + total: no I/O, no throw. An unmatched capability is the common case
+ * (default-deny), not an error.
+ */
+export function resolveOffering(
+  capability: string,
+  offerings: readonly Offering[] | undefined,
+): ResolvedOffering {
+  const match = offerings?.find((o) => o.capability === capability);
+  if (match === undefined || match.scopes.length === 0) {
+    return { capability, scopes: ["local"] };
+  }
+  return {
+    capability,
+    // Defensive copy so the caller can't mutate the offering's array.
+    scopes: [...match.scopes],
+    ...(match.accept !== undefined ? { accept: match.accept } : {}),
+  };
+}


### PR DESCRIPTION
## CO-1 — the offering policy model + `policy.offerings[]` config

The **foundation slice** of the Capability Offering epic: the provider-side `(capability, offer-scope, accept-policy)` model on the stack config layer. **Data model + config + validation only — byte-identical boot, no behavior change** (consumer wiring is CO-2, federation-config generation is CO-3).

Built from the **Accepted** design `docs/design-capability-offering.md` §2/§6/§9 + ADR-0008 (DD-CO-1 default-deny), ADR-0009 (DD-CO-7 per-stack, no shared layer), ADR-0010 (DD-CO-8 metadata-only public gate), grounded in the live `src/common/types/cortex-config.ts` policy substrate.

Closes #940
Refs #939 · ADR-0008 · ADR-0009 · ADR-0010

### The schema shape (as built)

`policy.offerings?: Offering[]` on `PolicySchema` (`.optional()`, mirroring the sibling `federated`/`public` widening blocks):

```ts
Offering        = { capability: string; scopes: OfferScope[]; accept?: AcceptPolicy; network?: string }
OfferScope      = 'local' | 'federated' | 'public'

// CLOSED, per-scope tagged union — NOT a free-form string:
AcceptPolicy =
  | { kind: 'network';    network: string }                                   // federated
  | { kind: 'principals'; principals: string[] /* ≥1 */ }                     // federated
  | { kind: 'surface';    surface: string; predicate: PublicPredicate;        // public
      limits?: { max_concurrent?; per_day?; cost_cents_per_request? } }

PublicPredicate =   // METADATA-evaluable only (ADR-0010 DD-CO-8)
  | { kind: 'repo-membership'; repos: string[] }
  | { kind: 'sender-allow';    senders: string[] }
  | { kind: 'sender-block';    senders: string[] }
  | { kind: 'rate'; per_minute?; per_hour?; per_day? }
```

### resolveOffering — the default-deny resolver (CO-2's consumption point)

```ts
function resolveOffering(
  capability: string,
  offerings: readonly Offering[] | undefined,
): ResolvedOffering   // { capability, scopes: OfferScope[], accept? }
```

A capability **not** in `offerings` (or `offerings` undefined, or an empty `scopes[]`) resolves to **`local`-only**. Pure + total (no I/O, no throw). This is the single source of the default-deny semantics — not a schema default — so absent offerings ⇒ every capability local-only = today's behaviour.

### How "public predicate metadata-only" is enforced in schema

`PublicPredicateSchema` is a **discriminated union over a CLOSED enum** of metadata-evaluable kinds (`repo-membership`/`sender-allow`/`sender-block`/`rate`). A content-dependent predicate (`description-contains`, `diff-matches`, `body-regex`, …) has **no `kind` to land on**, so it fails the discriminator at schema-parse time — not at runtime. The forbidding (ADR-0010 DD-CO-8) IS the closed vocabulary; there is no escape hatch for content.

### Validation (superRefine)

- `PolicySchema.superRefine` → `superRefineOfferings()`: **federated-requires-naming** (a `federated` scope with no accept is a VALIDATION ERROR — default-deny); **scope↔accept agreement** (public⇒surface accept; local-only⇒no accept; federated+public in one entry rejected — single `accept` can't serve both); **no-duplicate-capability**.
- `CortexConfigSchema.superRefine`: **offered capability must EXIST** in the top-level `capabilities[]` catalog (errors, parity with the existing capability dangling-ref checks; lives here because `capabilities[]` is out of `PolicySchema`'s scope).

### Byte-identical-boot proof

`policy.offerings` is `.optional()` — absent ⇒ `resolveOffering` treats `undefined` exactly like `[]` ⇒ every capability local-only. **No loader change** (the loader passes `policy: cortexConfig.policy` through wholesale; `offerings` rides the generic `deepMerge` + `PolicySchema` parse). **No consumer/dispatch change.** Boot smoke `src/__tests__/cortex.test.ts` unchanged: **27 pass / 0 fail**.

### Gates (real outputs)

| Gate | Result |
|---|---|
| `bunx tsc --noEmit` | clean (exit 0) |
| `bunx eslint --quiet src/` | clean (exit 0) |
| `bun test src/` | **5870 pass, 2 skip, 0 fail** (15138 expect, 339 files) |
| `bash scripts/check-carveouts.sh` | `PASS — no ungated deprecated-term live violations` |
| boot smoke `bun test src/__tests__/cortex.test.ts` | **27 pass / 0 fail** |

New tests: `offering.test.ts` (39) + a `PolicySchema — CO-1 offerings` block and 3 cross-block `CortexConfigSchema` tests in `cortex-config.test.ts` — schema accept/reject (valid offerings; federated-no-accept rejected; public content-dependent predicate rejected; duplicate-capability rejected; local-with-accept rejected; offered-capability-must-exist), the closed-union has-no-free-form-variant guard, and the default-deny resolution (`resolveOffering` → local).

### Divergence from the design (flagged, not silent)

- **`.optional()` instead of `.default([])`.** The task sketched `offerings` as fully-defaulted. I made it `.optional()` to match the two sibling widening blocks (`federated`/`public`, both `.optional()`) and to keep existing `Policy`-typed fixtures compiling without a churn of `offerings: []` additions. The default-deny semantics are unchanged — they live in `resolveOffering`, which treats `undefined` and `[]` identically. Net effect on boot is identical; this is a representation choice, not a behavior change.
- **`network?` field kept for design parity** but the `{kind:'network'}` accept's own `network` is authoritative; `network?` is documentation/convenience in CO-1.
- **federated+public in a single offering is rejected** (a single `accept` can't carry two shapes). CO-1's model is one accept per offering; multi-scope-with-distinct-accept is deferred and flagged with a pointed error rather than silently mis-handled.

Do **not** merge — orchestrator drives review→merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)