### PR TITLE
feat(bus): CO-4 — gate posture per offer-scope (DD-CO-3 floor)

### DIFF
--- a/src/bus/__tests__/admit-offered-dispatch.test.ts
+++ b/src/bus/__tests__/admit-offered-dispatch.test.ts
@@ -1,0 +1,176 @@
+/**
+ * CO-4 (epic cortex#939) — admission-wiring tests.
+ *
+ * Pins the `resolveOffering` → `gateFloorForScope` composition, with the
+ * load-bearing BYTE-IDENTICAL-LOCAL contract front and centre: with no offering
+ * (or a local offering) a `local` dispatch admits unconditionally, reading
+ * NONE of the floor context — exactly today's home-bus admission.
+ *
+ * Anchors: docs/design-capability-offering.md §9-CO-4 · ADR-0008 DD-CO-3.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import { admitOfferedDispatch } from "../admit-offered-dispatch";
+import type { GateFloorContext } from "../gate-floor";
+import type { Offering } from "../../common/types/offering";
+
+/** A hostile context: nothing passes. Proves local NEVER reads it. */
+const hostileCtx: GateFloorContext = {
+  signed: false,
+  peerInNetwork: false,
+  surfaceVerified: false,
+  surfacePredicatePassed: false,
+  complianceOk: false,
+  rateOk: false,
+};
+
+/** A fully-admitting context for federated/public happy paths. */
+function okCtx(overrides: Partial<GateFloorContext> = {}): GateFloorContext {
+  return {
+    signed: true,
+    peerPrincipal: "jcfischer",
+    peerInNetwork: true,
+    surfaceVerified: true,
+    surfacePredicatePassed: true,
+    complianceOk: true,
+    rateOk: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Byte-identical-local
+// ---------------------------------------------------------------------------
+
+describe("admitOfferedDispatch — byte-identical local", () => {
+  test("no offerings + local arrival ⇒ admit, ignoring a hostile context", () => {
+    const d = admitOfferedDispatch({
+      capability: "dev.implement",
+      offerings: undefined,
+      arrivedScope: "local",
+      signing: "off",
+      ctx: hostileCtx,
+    });
+    expect(d.admit).toBe(true);
+  });
+
+  test("an explicit local-only offering + local arrival ⇒ admit (hostile ctx)", () => {
+    const offerings: Offering[] = [{ capability: "dev.implement", scopes: ["local"] }];
+    const d = admitOfferedDispatch({
+      capability: "dev.implement",
+      offerings,
+      arrivedScope: "local",
+      signing: "off",
+      ctx: hostileCtx,
+    });
+    expect(d.admit).toBe(true);
+  });
+
+  test("a capability offered wider STILL admits a local-arriving dispatch (local is in scope)", () => {
+    // Offered federated, but the dispatch arrived on a local subject → the
+    // local floor applies (no extra floor) — widening doesn't break the home bus.
+    const offerings: Offering[] = [
+      {
+        capability: "code-review.typescript",
+        scopes: ["local", "federated"],
+        accept: { kind: "network", network: "metafactory-net" },
+      },
+    ];
+    const d = admitOfferedDispatch({
+      capability: "code-review.typescript",
+      offerings,
+      arrivedScope: "local",
+      signing: "off",
+      ctx: hostileCtx,
+    });
+    expect(d.admit).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope-admission (defence-in-depth)
+// ---------------------------------------------------------------------------
+
+describe("admitOfferedDispatch — scope-admission", () => {
+  test("a dispatch arriving at a scope the capability is NOT offered at ⇒ policy_denied", () => {
+    // Offered local-only (default) but arrived public → not exposed at public.
+    const d = admitOfferedDispatch({
+      capability: "dev.implement",
+      offerings: undefined,
+      arrivedScope: "public",
+      signing: "enforce",
+      ctx: okCtx(),
+    });
+    expect(d.admit).toBe(false);
+    if (!d.admit) {
+      expect(d.refusal.kind).toBe("policy_denied");
+      expect(JSON.stringify((d.refusal as { deny: unknown }).deny)).toContain(
+        "scope_admission",
+      );
+    }
+  });
+
+  test("federated arrival for a federated offering, roster admits ⇒ admit", () => {
+    const offerings: Offering[] = [
+      {
+        capability: "code-review.typescript",
+        scopes: ["federated"],
+        accept: { kind: "network", network: "metafactory-net" },
+      },
+    ];
+    const d = admitOfferedDispatch({
+      capability: "code-review.typescript",
+      offerings,
+      arrivedScope: "federated",
+      signing: "permissive",
+      ctx: okCtx(),
+    });
+    expect(d.admit).toBe(true);
+  });
+
+  test("public arrival for a public offering, full floor cleared ⇒ admit", () => {
+    const offerings: Offering[] = [
+      {
+        capability: "code-review.typescript",
+        scopes: ["public"],
+        accept: {
+          kind: "surface",
+          surface: "github",
+          predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+        },
+      },
+    ];
+    const d = admitOfferedDispatch({
+      capability: "code-review.typescript",
+      offerings,
+      arrivedScope: "public",
+      signing: "enforce",
+      ctx: okCtx(),
+    });
+    expect(d.admit).toBe(true);
+  });
+
+  test("public arrival, rate tripped ⇒ not_now (transient) flows through the wiring", () => {
+    const offerings: Offering[] = [
+      {
+        capability: "code-review.typescript",
+        scopes: ["public"],
+        accept: {
+          kind: "surface",
+          surface: "github",
+          predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+        },
+      },
+    ];
+    const d = admitOfferedDispatch({
+      capability: "code-review.typescript",
+      offerings,
+      arrivedScope: "public",
+      signing: "enforce",
+      ctx: okCtx({ rateOk: false }),
+    });
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("not_now");
+  });
+});

--- a/src/bus/__tests__/gate-floor.test.ts
+++ b/src/bus/__tests__/gate-floor.test.ts
@@ -170,6 +170,19 @@ describe("gateFloorForScope — federated scope", () => {
     if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
   });
 
+  // #968 review nit: a principals accept with an ABSENT peer identity must
+  // refuse (default-to-refuse) — an unidentified peer is never "named".
+  test("principals accept — refuses an absent peer identity (peerPrincipal undefined)", () => {
+    const d = gateFloorForScope(
+      "federated",
+      principalsAccept,
+      "permissive",
+      ctx({ peerPrincipal: undefined }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
   test("REFUSES policy_denied when a federated offering carries no accept (default-deny)", () => {
     const d = gateFloorForScope("federated", undefined, "permissive", ctx());
     expect(d.admit).toBe(false);

--- a/src/bus/__tests__/gate-floor.test.ts
+++ b/src/bus/__tests__/gate-floor.test.ts
@@ -1,0 +1,292 @@
+/**
+ * CO-4 (epic cortex#939) — per-offer-scope gate-floor tests.
+ *
+ * `gateFloorForScope` is the testable core of CO-4 (ADR-0008 DD-CO-3): the
+ * pure function that, given a resolved offering's scope + accept-policy + the
+ * stack's signing posture + a per-request context, decides whether an
+ * offered-capability dispatch clears the STRUCTURAL gate floor its scope
+ * demands — and, on failure, maps to the right refusal taxonomy entry
+ * (`policy_denied` / `compliance_block` / `not_now`).
+ *
+ * The four pinned behaviours (task bar):
+ *   1. local        → NO floor (always admit) — byte-identical.
+ *   2. federated    → signing ≥ permissive + accept-policy roster check.
+ *   3. public       → signing-enforce (bus peers) + compliance + rate + bounded accept.
+ *   4. refusal mapping — each failed floor maps to the correct refusal kind.
+ *
+ * Anchors: docs/design-capability-offering.md §5 · ADR-0008 DD-CO-3 ·
+ *          ADR-0010 (the Stage-1 metadata gate this floor enforces) ·
+ *          CONTEXT.md §Capability offering / §Dispatch (refusal taxonomy).
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  gateFloorForScope,
+  type GateFloorContext,
+  type GateFloorDecision,
+} from "../gate-floor";
+import type {
+  FederatedAccept,
+  PublicAccept,
+} from "../../common/types/offering";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const networkAccept: FederatedAccept = {
+  kind: "network",
+  network: "metafactory-net",
+};
+
+const principalsAccept: FederatedAccept = {
+  kind: "principals",
+  principals: ["jcfischer", "alice"],
+};
+
+const publicAccept: PublicAccept = {
+  kind: "surface",
+  surface: "github",
+  predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+  limits: { per_day: 100 },
+};
+
+/** A minimal admitting context: signed peer, surface metadata that passes. */
+function ctx(overrides: Partial<GateFloorContext> = {}): GateFloorContext {
+  return {
+    signed: true,
+    peerPrincipal: "jcfischer",
+    peerInNetwork: true,
+    surfaceVerified: true,
+    surfacePredicatePassed: true,
+    complianceOk: true,
+    rateOk: true,
+    ...overrides,
+  };
+}
+
+function admit(d: GateFloorDecision): void {
+  expect(d.admit).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// 1. local → no floor (byte-identical)
+// ---------------------------------------------------------------------------
+
+describe("gateFloorForScope — local scope (no floor)", () => {
+  test("local admits regardless of signing posture", () => {
+    for (const signing of ["off", "permissive", "enforce"] as const) {
+      admit(gateFloorForScope("local", undefined, signing, ctx({ signed: false })));
+    }
+  });
+
+  test("local admits even with an empty/hostile context — the home bus IS the floor", () => {
+    const d = gateFloorForScope("local", undefined, "off", {
+      signed: false,
+      peerInNetwork: false,
+      surfaceVerified: false,
+      surfacePredicatePassed: false,
+      complianceOk: false,
+      rateOk: false,
+    });
+    expect(d.admit).toBe(true);
+  });
+
+  test("local ignores an (illegal) accept-policy rather than gating on it", () => {
+    // The schema forbids a local-only offering carrying an accept; defensively
+    // the floor still admits local (it never reads accept for local).
+    admit(
+      gateFloorForScope("local", networkAccept, "off", ctx({ signed: false })),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. federated → signing ≥ permissive + roster check
+// ---------------------------------------------------------------------------
+
+describe("gateFloorForScope — federated scope", () => {
+  test("admits when signing is permissive, peer is signed + on the network roster", () => {
+    admit(gateFloorForScope("federated", networkAccept, "permissive", ctx()));
+  });
+
+  test("admits when signing is enforce (a higher posture than the floor)", () => {
+    admit(gateFloorForScope("federated", networkAccept, "enforce", ctx()));
+  });
+
+  test("REFUSES policy_denied when signing is off (below the permissive floor)", () => {
+    const d = gateFloorForScope("federated", networkAccept, "off", ctx());
+    expect(d.admit).toBe(false);
+    if (!d.admit) {
+      expect(d.refusal.kind).toBe("policy_denied");
+    }
+  });
+
+  test("REFUSES policy_denied when the envelope is unsigned (federated needs proof)", () => {
+    const d = gateFloorForScope(
+      "federated",
+      networkAccept,
+      "permissive",
+      ctx({ signed: false }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
+  test("REFUSES policy_denied when the peer is NOT on the network roster", () => {
+    const d = gateFloorForScope(
+      "federated",
+      networkAccept,
+      "permissive",
+      ctx({ peerInNetwork: false }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) {
+      expect(d.refusal.kind).toBe("policy_denied");
+      // The deny payload names the roster miss for audit.
+      expect(JSON.stringify((d.refusal as { deny: unknown }).deny)).toContain(
+        "roster",
+      );
+    }
+  });
+
+  test("principals accept — admits a named principal, refuses an unnamed one", () => {
+    admit(
+      gateFloorForScope(
+        "federated",
+        principalsAccept,
+        "permissive",
+        ctx({ peerPrincipal: "alice" }),
+      ),
+    );
+    const d = gateFloorForScope(
+      "federated",
+      principalsAccept,
+      "permissive",
+      ctx({ peerPrincipal: "mallory" }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
+  test("REFUSES policy_denied when a federated offering carries no accept (default-deny)", () => {
+    const d = gateFloorForScope("federated", undefined, "permissive", ctx());
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. public → enforce + compliance + rate + bounded accept
+// ---------------------------------------------------------------------------
+
+describe("gateFloorForScope — public scope", () => {
+  test("admits when signing=enforce, surface verified, predicate passed, compliance + rate ok", () => {
+    admit(gateFloorForScope("public", publicAccept, "enforce", ctx()));
+  });
+
+  test("REFUSES policy_denied when signing is only permissive (public needs enforce)", () => {
+    const d = gateFloorForScope("public", publicAccept, "permissive", ctx());
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
+  test("REFUSES policy_denied when signing is off", () => {
+    const d = gateFloorForScope("public", publicAccept, "off", ctx());
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
+  test("REFUSES policy_denied when the surface is not HMAC-verified (no trust anchor)", () => {
+    const d = gateFloorForScope(
+      "public",
+      publicAccept,
+      "enforce",
+      ctx({ surfaceVerified: false }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
+  test("REFUSES policy_denied when the metadata accept-predicate did not pass (bounded accept)", () => {
+    const d = gateFloorForScope(
+      "public",
+      publicAccept,
+      "enforce",
+      ctx({ surfacePredicatePassed: false }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
+  test("REFUSES compliance_block when the compliance hook fails", () => {
+    const d = gateFloorForScope(
+      "public",
+      publicAccept,
+      "enforce",
+      ctx({ complianceOk: false }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("compliance_block");
+  });
+
+  test("REFUSES not_now when the rate-limit gate trips (transient backpressure)", () => {
+    const d = gateFloorForScope(
+      "public",
+      publicAccept,
+      "enforce",
+      ctx({ rateOk: false }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) {
+      expect(d.refusal.kind).toBe("not_now");
+      // not_now carries a retry hint so the requester can back off.
+      expect((d.refusal as { retry_after_ms?: number }).retry_after_ms).toBeDefined();
+    }
+  });
+
+  test("REFUSES policy_denied when a public offering carries no accept (default-deny)", () => {
+    const d = gateFloorForScope("public", undefined, "enforce", ctx());
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
+  test("REFUSES policy_denied when a federated accept is paired with a public scope (kind mismatch)", () => {
+    const d = gateFloorForScope("public", networkAccept, "enforce", ctx());
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. ordering — the most-severe / most-specific refusal wins deterministically
+// ---------------------------------------------------------------------------
+
+describe("gateFloorForScope — refusal ordering (deterministic)", () => {
+  test("public: signing floor is checked before compliance/rate (structural admission first)", () => {
+    // signing off + compliance also failing → the signing/structural refusal
+    // (policy_denied) wins; we never reach the compliance hook.
+    const d = gateFloorForScope(
+      "public",
+      publicAccept,
+      "off",
+      ctx({ complianceOk: false, rateOk: false }),
+    );
+    expect(d.admit).toBe(false);
+    if (!d.admit) expect(d.refusal.kind).toBe("policy_denied");
+  });
+
+  test("public: compliance is checked before rate (compliance is permanent, rate is transient)", () => {
+    const d = gateFloorForScope(
+      "public",
+      publicAccept,
+      "enforce",
+      ctx({ complianceOk: false, rateOk: false }),
+    );
+    expect(d.admit).toBe(false);
+    // Permanent compliance refusal wins over the transient rate refusal so a
+    // structurally-forbidden request is not endlessly retried.
+    if (!d.admit) expect(d.refusal.kind).toBe("compliance_block");
+  });
+});

--- a/src/bus/admit-offered-dispatch.ts
+++ b/src/bus/admit-offered-dispatch.ts
@@ -1,0 +1,134 @@
+/**
+ * CO-4 (epic cortex#939) — the admission-point wiring for the per-offer-scope
+ * gate floor. Composes CO-1's `resolveOffering` (the default-deny scope
+ * resolver) with CO-4's `gateFloorForScope` (the per-scope floor) into ONE
+ * call a capability consumer makes at its admission point, BEFORE the
+ * capability/payload/concurrency gates run.
+ *
+ * ## The contract: byte-identical for local-only
+ *
+ * With `policy.offerings` absent (the live state of every stack today), EVERY
+ * capability resolves to `local`-only via `resolveOffering` (ADR-0008 DD-CO-1),
+ * and `gateFloorForScope('local', …)` admits unconditionally. So
+ * {@link admitOfferedDispatch} returns `{ admit: true }` for the local case
+ * WITHOUT reading the context — the consumer's behaviour is unchanged and boot
+ * is byte-identical. The federated/public floors engage ONLY once a capability
+ * is offered wider (CO-3's `cortex offer`), at which point the consumer is also
+ * bound on the wider scope prefixes (CO-2). Until both land, this helper is a
+ * provingly-inert no-op on the local path.
+ *
+ * ## Why a separate module (not inlined in a consumer)
+ *
+ * The floor is consumed by BOTH the `dev`/`release` consumers (runner/) and the
+ * `review` consumer (bus/). Centralising the resolve→floor composition here
+ * keeps the two sibling consumers from drifting (the same discipline the
+ * `failedReasonToAckDecision` mapping is duplicated to preserve), and keeps the
+ * floor logic out of the consumer hot path so it stays unit-testable.
+ *
+ * ## Seams left for CO-2 / CO-5 / CO-7
+ *
+ *   - **CO-2** wires the consumer to read the resolved offer-scope and bind its
+ *     JetStream consumer on the admitted scope prefixes. Until CO-2, a consumer
+ *     calls this with `scope` derived from the subject it actually received
+ *     (local today). The `resolveOffering` call here is the same resolver CO-2
+ *     consumes for binding — single source of truth.
+ *   - **CO-5** (the gh-webhook Stage-1 tap) computes `surfaceVerified` /
+ *     `surfacePredicatePassed` for the public path and only THEN emits the
+ *     Offer; this helper reads those booleans off the {@link GateFloorContext}.
+ *   - **CO-7** computes `complianceOk` (the untrusted-content / persona /
+ *     egress compliance hook); this helper reads it and maps a `false` to
+ *     `compliance_block`.
+ *
+ * Anchors: docs/design-capability-offering.md §5/§9-CO-4 · ADR-0008 DD-CO-3 ·
+ *          ADR-0010 · CONTEXT.md §Capability offering.
+ */
+
+import type { SigningMode } from "../common/security-posture";
+import {
+  resolveOffering,
+  type Offering,
+  type OfferScope,
+} from "../common/types/offering";
+import {
+  gateFloorForScope,
+  type GateFloorContext,
+  type GateFloorDecision,
+} from "./gate-floor";
+
+/**
+ * Inputs to {@link admitOfferedDispatch}. The consumer supplies the capability
+ * it is about to serve, the stack's offerings list (from `policy.offerings`),
+ * the scope the dispatch arrived at, the stack's signing posture, and the
+ * per-request floor context.
+ */
+export interface AdmitOfferedDispatchInput {
+  /** The capability id the inbound dispatch targets (e.g. `dev.implement`). */
+  readonly capability: string;
+  /**
+   * The stack's offerings list (`config.policy.offerings`). `undefined` ⇒
+   * every capability resolves `local`-only (default-deny) ⇒ byte-identical.
+   */
+  readonly offerings: readonly Offering[] | undefined;
+  /**
+   * The offer-scope the dispatch ARRIVED at — derived from the subject prefix
+   * (`local.`/`federated.`/`public.`). Today consumers only bind `local`
+   * subjects, so this is `local`; CO-2 widens the binding. The floor is
+   * evaluated against THIS scope (the floor a request at this scope must
+   * clear), cross-checked against what the offering admits.
+   */
+  readonly arrivedScope: OfferScope;
+  /** The stack's `security.signing` posture. */
+  readonly signing: SigningMode;
+  /** The per-request floor context (unread for the local path). */
+  readonly ctx: GateFloorContext;
+}
+
+/**
+ * Resolve the capability's offering and evaluate the gate floor for the scope
+ * the dispatch arrived at. Pure + total.
+ *
+ * Two structural checks before the floor:
+ *
+ *   1. **Scope-admission.** The resolved offering must actually admit the
+ *      `arrivedScope`. A dispatch that arrived at `public` for a capability
+ *      offered only `local`/`federated` is refused `policy_denied` — the
+ *      capability is not exposed at that tier (defence-in-depth against a
+ *      mis-bound consumer or a forged-wide subject). For the local default
+ *      this is always satisfied (`resolveOffering` ⇒ `['local']`).
+ *   2. **Floor.** Given the admitted scope, delegate to
+ *      {@link gateFloorForScope} for the signing/roster/surface/compliance/rate
+ *      floor + refusal mapping.
+ *
+ * For the byte-identical local path (`arrivedScope === 'local'`, no offering or
+ * a local offering), step 1 passes and step 2 admits unconditionally.
+ */
+export function admitOfferedDispatch(
+  input: AdmitOfferedDispatchInput,
+): GateFloorDecision {
+  const resolved = resolveOffering(input.capability, input.offerings);
+
+  // 1. Scope-admission: is the capability offered at the scope it arrived on?
+  if (!resolved.scopes.includes(input.arrivedScope)) {
+    return {
+      admit: false,
+      refusal: {
+        kind: "policy_denied",
+        deny: {
+          floor: "scope_admission",
+          requirement: "capability_offered_at_scope",
+          capability: input.capability,
+          arrived_scope: input.arrivedScope,
+          offered_scopes: resolved.scopes,
+        },
+      },
+    };
+  }
+
+  // 2. The per-scope floor.
+  return gateFloorForScope(
+    input.arrivedScope,
+    resolved.accept,
+    input.signing,
+    input.ctx,
+  );
+}

--- a/src/bus/gate-floor.ts
+++ b/src/bus/gate-floor.ts
@@ -1,0 +1,361 @@
+/**
+ * CO-4 (epic cortex#939) — the per-offer-scope GATE FLOOR (ADR-0008 DD-CO-3).
+ *
+ * Offer-scope *raises the gate floor*. The further out a capability is
+ * offered, the more the gates matter — and offering at a wider scope makes
+ * those gates NON-OPTIONAL. This module is the pure, structural admission
+ * gate: given a resolved offering's scope + accept-policy, the stack's signing
+ * posture, and a per-request context, {@link gateFloorForScope} decides whether
+ * an offered-capability dispatch CLEARS the floor its scope demands — and, on
+ * failure, maps to the right entry in the dispatch refusal taxonomy
+ * (CONTEXT.md §Dispatch): `policy_denied` (accept/structural), `compliance_block`
+ * (compliance), `not_now` (rate-limit backpressure).
+ *
+ * ## The floor, per scope (design §5, ADR-0008 DD-CO-3)
+ *
+ * | scope     | trust anchor                | minimum gates this module enforces                                  |
+ * |-----------|-----------------------------|---------------------------------------------------------------------|
+ * | local     | the offering stack itself   | **none beyond the home bus** — always admit (byte-identical)        |
+ * | federated | the registry + peer pubkeys | signing ≥ permissive; signed envelope; accept-policy roster check    |
+ * | public    | the surface (e.g. GitHub)   | signing-enforce (bus peers); surface verified; bounded accept;      |
+ * |           |   + rate limit              | compliance gate; rate-limit                                         |
+ *
+ * Offer-scope is ORTHOGONAL to but a MINIMUM on the signing-posture knob: it
+ * raises a floor, never lowers the configured posture. A stack on
+ * `signing: enforce` clears the federated `≥ permissive` floor trivially; a
+ * stack on `signing: off` cannot offer at federated/public until it raises its
+ * posture (the floor refuses).
+ *
+ * ## Byte-identical-local (the CO-4 contract)
+ *
+ * A `local`-only offering — the default-deny resolution for EVERY capability
+ * today (CO-1 `resolveOffering`) — adds NO floor beyond today's home-bus
+ * admission: {@link gateFloorForScope} returns `{ admit: true }` for `local`
+ * unconditionally, reading neither the accept-policy nor the context. With
+ * `policy.offerings` absent every capability resolves `local`, so the floor is
+ * a no-op and boot + behaviour are byte-identical. The federated/public floors
+ * engage ONLY when something is offered wider (CO-3's `cortex offer`).
+ *
+ * ## Scope of CO-4 (the STRUCTURAL floor, not the deep handling)
+ *
+ * This module is the structural admission gate + refusal mapping ONLY. The
+ * inputs it reads (`surfaceVerified`, `surfacePredicatePassed`, `peerInNetwork`,
+ * `complianceOk`, `rateOk`) are DECISIONS made upstream by the seams CO-5 and
+ * CO-7 own — this module composes them into the floor verdict, it does not
+ * compute them:
+ *
+ *   - **CO-5 seam** — the gh-webhook Stage-1 tap (ADR-0010) is what HMAC-
+ *     validates the surface, evaluates the metadata-only accept-predicate, and
+ *     decides `surfaceVerified` / `surfacePredicatePassed` *before any Offer is
+ *     published*. CO-4 consumes those booleans; it does NOT parse webhooks or
+ *     evaluate predicates against request content. See
+ *     {@link GateFloorContext.surfaceVerified} / `.surfacePredicatePassed`.
+ *   - **CO-7 seam** — the untrusted-content & prompt-injection hardening
+ *     (M1–M6: boundary, least-privilege session, sandbox, egress, persona
+ *     hardening) is the DEEP content handling that runs AFTER the floor admits.
+ *     CO-4 is the admission floor; CO-7 is what a sandboxed reviewer does with
+ *     the content once it is in. `complianceOk` is the boolean a CO-7
+ *     compliance hook resolves; CO-4 maps a `false` to `compliance_block`.
+ *
+ * Anchors: docs/design-capability-offering.md §5 · docs/adr/0008-capability-offering-scope.md (DD-CO-3) ·
+ *          docs/adr/0010-public-accept-gate-two-stage.md · CONTEXT.md §Capability offering / §Dispatch.
+ */
+
+import type { SigningMode } from "../common/security-posture";
+import type { AcceptPolicy, OfferScope } from "../common/types/offering";
+import type { DispatchTaskFailedReason } from "./dispatch-events";
+
+// ---------------------------------------------------------------------------
+// Per-request context — the upstream decisions the floor composes
+// ---------------------------------------------------------------------------
+
+/**
+ * The per-request inputs {@link gateFloorForScope} reads to evaluate a
+ * federated/public floor. Every field is a DECISION made upstream (the
+ * envelope validator for `signed`/`peerPrincipal`; the registry/network
+ * resolver for `peerInNetwork`; the CO-5 Stage-1 tap for `surfaceVerified` /
+ * `surfacePredicatePassed`; a CO-7 compliance hook for `complianceOk`; a
+ * rate-limiter for `rateOk`). The floor COMPOSES them — it never recomputes
+ * them, and it never reads request CONTENT (ADR-0010: content can never
+ * influence whether a request gets in).
+ *
+ * `local` reads NONE of these — its floor is unconditional admit.
+ */
+export interface GateFloorContext {
+  /**
+   * Whether the inbound envelope carries a verified `signed_by[]` chain.
+   * Federated/public both require a signed bus peer (the requester proves
+   * *who*). For a PUBLIC request the requester is a surface, not a bus peer —
+   * `signed` then refers to the surface-relay's signed Offer on the bus, with
+   * the surface identity carried in `originator` (ADR-0010 DD-CO-8).
+   */
+  readonly signed: boolean;
+  /**
+   * The signed peer's principal id (stripped from `signed_by[0].principal`).
+   * Consulted by the `{kind:'principals'}` federated accept. `undefined` when
+   * unsigned.
+   */
+  readonly peerPrincipal?: string;
+  /**
+   * Whether the peer is on the registry roster of the accept-policy's network
+   * (the `{kind:'network'}` federated accept). Resolved by the network/registry
+   * resolver upstream; CO-4 reads the boolean. (CO-2/CO-3 wire the live
+   * resolution; until then a caller passes the resolved membership.)
+   */
+  readonly peerInNetwork: boolean;
+  /**
+   * **CO-5 seam.** Whether the surface (e.g. GitHub) was HMAC-verified by the
+   * Stage-1 tap — the public trust anchor. For non-public scopes this is
+   * unread. A public floor REFUSES (`policy_denied`) when the surface is not
+   * verified: with no trust anchor there is no admissible identity.
+   */
+  readonly surfaceVerified: boolean;
+  /**
+   * **CO-5 seam.** Whether the metadata-only accept-predicate (repo-membership
+   * / sender-allow / sender-block / rate — the bounded accept) PASSED at the
+   * Stage-1 tap (ADR-0010 DD-CO-8). CO-4 reads the boolean; it never evaluates
+   * a predicate against request content. A `false` is `policy_denied` (the
+   * accept-policy bounded what may be asked, and this request fell outside).
+   */
+  readonly surfacePredicatePassed: boolean;
+  /**
+   * **CO-7 seam.** Whether the compliance hook cleared the request. A `false`
+   * is `compliance_block` (a permanent refusal — the request is structurally
+   * forbidden, not merely throttled). The hook itself (STD-NPW-AI-001 / output
+   * egress / persona) is CO-7 territory; CO-4 maps its verdict.
+   */
+  readonly complianceOk: boolean;
+  /**
+   * Whether the rate-limit / cost-cap gate admits the request. A `false` is
+   * `not_now` (transient backpressure — retry safe). The limiter is the §5
+   * gate-floor knob (`PublicLimits`); CO-4 maps its verdict and attaches a
+   * retry hint.
+   */
+  readonly rateOk: boolean;
+  /**
+   * Optional backpressure hint (ms) attached to a `not_now` rate refusal.
+   * Defaults to {@link DEFAULT_RATE_RETRY_AFTER_MS} when the limiter doesn't
+   * supply one.
+   */
+  readonly rateRetryAfterMs?: number;
+}
+
+/**
+ * The floor verdict. Discriminated on `admit`:
+ *   - `{ admit: true }` — the dispatch clears the scope's floor; the consumer
+ *     proceeds to its capability/payload/concurrency gates.
+ *   - `{ admit: false, refusal }` — the floor refused; the consumer publishes
+ *     `dispatch.task.failed` with `refusal` and naks/terms per the standard
+ *     `failedReasonToAckDecision` mapping (`policy_denied`/`compliance_block`
+ *     → term; `not_now` → nak).
+ */
+export type GateFloorDecision =
+  | { admit: true }
+  | { admit: false; refusal: DispatchTaskFailedReason };
+
+/** Default `not_now` retry hint for a tripped rate-limit (5s). */
+export const DEFAULT_RATE_RETRY_AFTER_MS = 5000;
+
+// ---------------------------------------------------------------------------
+// Refusal builders — map a failed floor to the dispatch refusal taxonomy
+// ---------------------------------------------------------------------------
+
+/** A `policy_denied` refusal carrying a structured `deny` payload for audit. */
+function denied(deny: Record<string, unknown>): GateFloorDecision {
+  return { admit: false, refusal: { kind: "policy_denied", deny } };
+}
+
+/** A `compliance_block` refusal (permanent — compliance hook forbids it). */
+function complianceBlock(detail: string): GateFloorDecision {
+  return { admit: false, refusal: { kind: "compliance_block", detail } };
+}
+
+/** A `not_now` refusal (transient — rate-limit backpressure, retry safe). */
+function rateLimited(retryAfterMs: number): GateFloorDecision {
+  return {
+    admit: false,
+    refusal: {
+      kind: "not_now",
+      detail: "gate-floor rate-limit: request throttled — retry",
+      retry_after_ms: retryAfterMs,
+    },
+  };
+}
+
+const ADMIT: GateFloorDecision = { admit: true };
+
+// ---------------------------------------------------------------------------
+// The pure floor evaluator
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate the gate floor an offered-capability dispatch must clear, given the
+ * offering's `scope`, its `accept`-policy, the stack's `signing` posture, and
+ * the per-request `ctx`. Pure + total: no I/O, no throw.
+ *
+ * **Refusal ordering is deterministic + STRUCTURAL-FIRST.** Within a scope the
+ * floor checks the structural admission gates (signing posture, signed-peer
+ * proof, surface trust anchor, bounded accept-policy) BEFORE the
+ * compliance/rate gates, and a PERMANENT refusal (`policy_denied`,
+ * `compliance_block`) is preferred over a TRANSIENT one (`not_now`) — so a
+ * structurally-forbidden request is refused permanently (term) rather than
+ * naked into an endless retry loop.
+ *
+ * @param scope    the offer-scope being evaluated (from the resolved offering).
+ * @param accept   the accept-policy the offering carries (undefined for local).
+ * @param signing  the stack's `security.signing` posture (`off`/`permissive`/`enforce`).
+ * @param ctx      the per-request context (unread for `local`).
+ */
+export function gateFloorForScope(
+  scope: OfferScope,
+  accept: AcceptPolicy | undefined,
+  signing: SigningMode,
+  ctx: GateFloorContext,
+): GateFloorDecision {
+  switch (scope) {
+    case "local":
+      // The home bus IS the floor — nothing beyond it. Byte-identical: no
+      // accept, no signing, no context read. (A local offering carries no
+      // accept by schema; even if a caller passes one we never read it.)
+      return ADMIT;
+
+    case "federated":
+      return federatedFloor(accept, signing, ctx);
+
+    case "public":
+      return publicFloor(accept, signing, ctx);
+  }
+}
+
+/**
+ * The federated floor (DD-CO-3): signing ≥ permissive + a signed peer + the
+ * accept-policy's roster admits that peer. A federated offering with NO accept
+ * is default-deny (the CO-1 schema rejects it; defensively the floor refuses).
+ */
+function federatedFloor(
+  accept: AcceptPolicy | undefined,
+  signing: SigningMode,
+  ctx: GateFloorContext,
+): GateFloorDecision {
+  // Floor 1 — signing posture ≥ permissive. `off` is below the floor: a
+  // federated peer's identity must be cryptographically attachable.
+  if (signing === "off") {
+    return denied({
+      floor: "federated",
+      requirement: "signing>=permissive",
+      actual_signing: signing,
+    });
+  }
+
+  // Floor 2 — the envelope must be a signed peer (proof of *who*).
+  if (!ctx.signed) {
+    return denied({ floor: "federated", requirement: "signed_peer" });
+  }
+
+  // Floor 3 — the accept-policy must exist and be a federated accept.
+  if (accept === undefined) {
+    return denied({ floor: "federated", requirement: "accept_policy_present" });
+  }
+  if (accept.kind !== "network" && accept.kind !== "principals") {
+    return denied({
+      floor: "federated",
+      requirement: "federated_accept",
+      accept_kind: accept.kind,
+    });
+  }
+
+  // Floor 4 — the roster admits this peer.
+  if (accept.kind === "network") {
+    if (!ctx.peerInNetwork) {
+      return denied({
+        floor: "federated",
+        requirement: "network_roster",
+        network: accept.network,
+        peer: ctx.peerPrincipal ?? null,
+      });
+    }
+    return ADMIT;
+  }
+
+  // {kind:'principals'} — the named allowlist must contain the peer principal.
+  if (ctx.peerPrincipal === undefined || !accept.principals.includes(ctx.peerPrincipal)) {
+    return denied({
+      floor: "federated",
+      requirement: "principals_roster",
+      peer: ctx.peerPrincipal ?? null,
+    });
+  }
+  return ADMIT;
+}
+
+/**
+ * The public floor (DD-CO-3, ADR-0010): signing-enforce (bus peers) + a
+ * verified surface trust anchor + the bounded metadata accept-predicate passed
+ * + compliance + rate-limit. Structural gates first (signing → surface →
+ * predicate), then the permanent compliance gate, then the transient rate
+ * gate — so a structurally-forbidden or compliance-forbidden request terms
+ * rather than naking forever.
+ */
+function publicFloor(
+  accept: AcceptPolicy | undefined,
+  signing: SigningMode,
+  ctx: GateFloorContext,
+): GateFloorDecision {
+  // Floor 1 — signing-enforce for bus peers. Public is the highest trust bar:
+  // anything less than `enforce` cannot offer publicly.
+  if (signing !== "enforce") {
+    return denied({
+      floor: "public",
+      requirement: "signing==enforce",
+      actual_signing: signing,
+    });
+  }
+
+  // Floor 2 — the accept-policy must exist and be a public surface accept.
+  if (accept === undefined) {
+    return denied({ floor: "public", requirement: "accept_policy_present" });
+  }
+  if (accept.kind !== "surface") {
+    return denied({
+      floor: "public",
+      requirement: "public_accept",
+      accept_kind: accept.kind,
+    });
+  }
+
+  // Floor 3 — the surface is the trust anchor; it must be HMAC-verified
+  // (CO-5 Stage-1 tap). No verified surface ⇒ no admissible identity.
+  if (!ctx.surfaceVerified) {
+    return denied({
+      floor: "public",
+      requirement: "surface_verified",
+      surface: accept.surface,
+    });
+  }
+
+  // Floor 4 — the bounded metadata accept-predicate must have passed at the
+  // tap (ADR-0010 DD-CO-8). This is the "accept-policy bounds WHAT may be
+  // asked" gate — the offered capability only, never a sibling.
+  if (!ctx.surfacePredicatePassed) {
+    return denied({
+      floor: "public",
+      requirement: "accept_predicate",
+      surface: accept.surface,
+      predicate_kind: accept.predicate.kind,
+    });
+  }
+
+  // Floor 5 — compliance gate (CO-7 seam). PERMANENT refusal: a
+  // compliance-forbidden request is structurally not allowed, so it terms.
+  if (!ctx.complianceOk) {
+    return complianceBlock("gate-floor compliance hook denied the public request");
+  }
+
+  // Floor 6 — rate-limit / cost-cap (the §5 floor knob). TRANSIENT: the
+  // request is admissible, just throttled — nak with a retry hint.
+  if (!ctx.rateOk) {
+    return rateLimited(ctx.rateRetryAfterMs ?? DEFAULT_RATE_RETRY_AFTER_MS);
+  }
+
+  return ADMIT;
+}


### PR DESCRIPTION
## What

Builds **CO-4** of the Capability Offering epic (cortex#939): the per-offer-scope **gate floor** (ADR-0008 DD-CO-3). When a dispatch arrives for an **offered** capability, the gate is evaluated at the floor its offer-scope demands. Offer-scope *raises the trust floor* — orthogonal to, but a minimum on, the signing-posture knob.

`Closes #943` · Refs cortex#939 · ADR-0008 (DD-CO-3) · ADR-0010 (the Stage-1 metadata gate this floor enforces)

## The core — `gateFloorForScope`

```ts
gateFloorForScope(
  scope: OfferScope,            // 'local' | 'federated' | 'public'
  accept: AcceptPolicy | undefined,
  signing: SigningMode,        // 'off' | 'permissive' | 'enforce'
  ctx: GateFloorContext,
): GateFloorDecision            // { admit: true } | { admit: false, refusal }
```

Per-scope floor (design §5):

| scope | floor enforced | on fail |
|---|---|---|
| **local** | **none beyond the home bus** — admit unconditionally, reads neither accept nor ctx | — |
| **federated** | `signing >= permissive` + signed peer + accept-policy roster (`{kind:network}` network roster / `{kind:principals}` allowlist) | `policy_denied` |
| **public** | `signing == enforce` (bus peers) + verified surface trust anchor + bounded metadata accept-predicate passed + compliance hook + rate-limit | `policy_denied` (structural/accept), `compliance_block` (compliance, permanent), `not_now` (rate, transient) |

**Refusal mapping → taxonomy** (CONTEXT.md §Dispatch): accept/structural floor → `policy_denied`; compliance hook → `compliance_block` (term); rate-limit → `not_now` (nak, with `retry_after_ms`). Ordering is **structural-first, permanent-over-transient** — a structurally- or compliance-forbidden request terms rather than naking into an endless retry.

## Wiring — `admitOfferedDispatch`

Composes CO-1's `resolveOffering` (default-deny scope resolution) → `gateFloorForScope`, with a **scope-admission** defence-in-depth check (a dispatch arriving at a scope the capability is not offered at is `policy_denied`). This is the single call a capability consumer makes at its admission point. Kept as a shared bus module so the sibling `dev`/`release`/`review` consumers don't drift.

## Byte-identical-local proof

- The branch is **additive only**: 2 source files + 2 test files in `src/bus/`. **Zero** edits to any existing consumer or boot file (`git diff --name-only HEAD` against the branch base is empty; only the 4 new files are added).
- With `policy.offerings` absent (every live stack today), `resolveOffering` ⇒ `['local']` for every capability, and `gateFloorForScope('local', …)` returns `{ admit: true }` **without reading the context** — exactly today's home-bus admission.
- The floor is provingly-inert dead code on the local path until **CO-2** wires consumers to call `admitOfferedDispatch` and **CO-3** offers a capability wider.
- Boot smoke: the `src/cortex.ts` entrypoint loads cleanly with CO-4 in the tree (`MODULE_LOAD_OK`).
- Pinned by `admit-offered-dispatch.test.ts`: a hostile (all-false) context still admits the local path.

## Seams left (not built here)

- **CO-5** (the gh-webhook Stage-1 tap, ADR-0010) computes `surfaceVerified` / `surfacePredicatePassed` and only then emits the public Offer. CO-4 **consumes** those booleans; it never parses webhooks or evaluates predicates against request content. Documented on `GateFloorContext.surfaceVerified` / `.surfacePredicatePassed`.
- **CO-7** (untrusted-content & prompt-injection hardening, M1–M6) is the deep content handling that runs **after** the floor admits. `complianceOk` is the boolean a CO-7 compliance hook resolves; CO-4 maps a `false` → `compliance_block`.

## Gates

- `bunx tsc --noEmit` — clean
- `bunx eslint --quiet src/` — clean
- `bun test src/` — **5911 pass / 0 fail** (28 new CO-4 tests across 2 files)
- `scripts/check-carveouts.sh` — PASS
- boot smoke (entrypoint module load) — OK

## Overlap with CO-2 (flagged)

CO-2 (#941) is **not yet merged** — only CO-1 is on main, and nothing reads `resolveOffering` for consumer binding yet. CO-4 touches only new files in `src/bus/`; no overlap with the parallel MC session-refactor (`src/surface/mc/**`) or CO-2's eventual consumer-boot edits. When CO-2 lands it calls `admitOfferedDispatch` from the consumer admission point — that is the intended integration, not a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)