### PR TITLE
feat(runner,taps): ST-P1 — parent-session linkage capture end-to-end (CORTEX_PARENT_SESSION_ID)

### DIFF
--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -289,6 +289,15 @@ export interface DispatchRuntime {
    * runner only sets this on thread continuations.
    */
   resumeSessionId?: string;
+  /**
+   * ST-P1 (cortex#964, refs #952) — the parent session id for the substrate
+   * spawn (session-tree linkage, CONTEXT.md §Session tree). The claude-code
+   * harness threads this onto `CCSessionOpts.parentSessionId`, which stamps
+   * `CORTEX_PARENT_SESSION_ID` on the child env so the child's EventLogger
+   * parents its events. Carried via env, not a CLI arg. Optional everywhere —
+   * absent for an agent-rooted dispatch.
+   */
+  parentSessionId?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runner/__tests__/agent-team-parent-session.test.ts
+++ b/src/runner/__tests__/agent-team-parent-session.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AgentTeamHarness,
+  type AgentTeamFactory,
+  type AgentTeamOpts,
+} from "../agent-team";
+import type { DispatchRequest } from "../../common/substrates/types";
+import type { DispatchEventSource } from "../../bus/dispatch-events";
+
+/**
+ * ST-P1 (cortex#964, refs #952) — the AgentTeamHarness threads the
+ * dispatch-level parent session id (`req.runtime.parentSessionId`) into the
+ * AgentTeamOpts so the team's moderator session is stamped as a child of the
+ * dispatch parent. Participants/synthesis are then parented to the MODERATOR's
+ * live session id (covered in the AgentTeam spawn-flow, not here).
+ */
+const SOURCE: DispatchEventSource = {
+  principal: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+function collectFactory(result: string): {
+  factory: AgentTeamFactory;
+  opts: AgentTeamOpts[];
+} {
+  const opts: AgentTeamOpts[] = [];
+  return {
+    opts,
+    factory: (teamOpts) => {
+      opts.push(teamOpts);
+      return {
+        start() {
+          return undefined;
+        },
+        async wait() {
+          return result;
+        },
+        on() {
+          return undefined;
+        },
+        getTraceContext() {
+          return { traceId: "trace-test", teamId: "team-test" };
+        },
+      };
+    },
+  };
+}
+
+function requestWithParent(parentSessionId?: string): DispatchRequest {
+  return {
+    prompt: "Coordinate the team",
+    tools: { allow: ["Read"] },
+    context: [],
+    agent: { id: "cortex", displayName: "Cortex" },
+    requestId: "22222222-2222-4222-8222-222222222222",
+    timeoutMs: 60_000,
+    runtime: {
+      ...(parentSessionId !== undefined && { parentSessionId }),
+    },
+  };
+}
+
+describe("AgentTeamHarness — ST-P1 parentSessionId threading", () => {
+  test("maps req.runtime.parentSessionId into AgentTeamOpts.parentSessionId", async () => {
+    const captured = collectFactory("done");
+    const harness = new AgentTeamHarness({
+      source: SOURCE,
+      agentTeamFactory: captured.factory,
+    });
+
+    for await (const _env of harness.dispatch(requestWithParent("dispatch-parent-session"))) {
+      // drain
+    }
+
+    expect(captured.opts).toHaveLength(1);
+    expect(captured.opts[0]?.parentSessionId).toBe("dispatch-parent-session");
+  });
+
+  test("leaves parentSessionId undefined when the request carries none", async () => {
+    const captured = collectFactory("done");
+    const harness = new AgentTeamHarness({
+      source: SOURCE,
+      agentTeamFactory: captured.factory,
+    });
+
+    for await (const _env of harness.dispatch(requestWithParent(undefined))) {
+      // drain
+    }
+
+    expect(captured.opts).toHaveLength(1);
+    expect(captured.opts[0]?.parentSessionId).toBeUndefined();
+  });
+});

--- a/src/runner/__tests__/cc-session-parent-env.test.ts
+++ b/src/runner/__tests__/cc-session-parent-env.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "bun:test";
+import { buildSessionEnv } from "../cc-session";
+
+/**
+ * ST-P1 (cortex#964, refs #952) — spawning a child CC session stamps the
+ * PINNED env var `CORTEX_PARENT_SESSION_ID` so the EventLogger hook in the
+ * child can read it and link the child's events to the parent session.
+ */
+describe("buildSessionEnv — ST-P1 stamps CORTEX_PARENT_SESSION_ID", () => {
+  const baseEnv = { PATH: "/usr/bin" } as Record<string, string>;
+
+  test("sets CORTEX_PARENT_SESSION_ID from opts.parentSessionId", () => {
+    const env = buildSessionEnv(baseEnv, {
+      parentSessionId: "moderator-session-123",
+    });
+    expect(env.CORTEX_PARENT_SESSION_ID).toBe("moderator-session-123");
+  });
+
+  test("omits CORTEX_PARENT_SESSION_ID when parentSessionId is unset", () => {
+    const env = buildSessionEnv(baseEnv, {
+      groveChannel: "ivy",
+    });
+    expect(env.CORTEX_PARENT_SESSION_ID).toBeUndefined();
+  });
+
+  test("preserves the inherited base env alongside the parent stamp", () => {
+    const env = buildSessionEnv(baseEnv, {
+      parentSessionId: "moderator-session-123",
+    });
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.CORTEX_PARENT_SESSION_ID).toBe("moderator-session-123");
+  });
+});

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -738,6 +738,58 @@ describe("dispatch-listener — success path", () => {
     expect(opts.resumeSessionId).toBe("prior-session");
   });
 
+  // ST-P1 (cortex#964, refs #952) — parent_session_id threads from the
+  // received payload through DispatchRuntime into CCSessionOpts.parentSessionId
+  // so the spawned child stamps CORTEX_PARENT_SESSION_ID for the EventLogger.
+  test("ST-P1: parent_session_id threads payload → CCSessionOpts.parentSessionId", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      makeReceivedEnvelope({
+        prompt: "child work",
+        parent_session_id: "parent-session-abc",
+      }),
+      CANONICAL_CORTEX_CHAT_SUBJECT,
+    );
+    await settle(() => r.published);
+
+    expect(optsCaptured).toHaveLength(1);
+    expect(optsCaptured[0]!.parentSessionId).toBe("parent-session-abc");
+  });
+
+  test("ST-P1: parentSessionId is undefined when the payload omits parent_session_id", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      makeReceivedEnvelope({ prompt: "root work" }),
+      CANONICAL_CORTEX_CHAT_SUBJECT,
+    );
+    await settle(() => r.published);
+
+    expect(optsCaptured).toHaveLength(1);
+    expect(optsCaptured[0]!.parentSessionId).toBeUndefined();
+  });
+
   // cortex#127 — RECEIVING-STACK-AUTHORITATIVE bash allowlist plumbing.
   // The bus dispatch path used to drop the stack's bashAllowlist, so the
   // spawned session never got CORTEX_BASH_GUARD set; the bash-guard hook

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -133,6 +133,15 @@ export interface AgentTeamOpts {
   entity?: string;
   principal?: string;
   /**
+   * ST-P1 (cortex#964, refs #952) — the DISPATCH-level parent session id. The
+   * team's moderator is stamped as a child of this (the dispatch that spawned
+   * the team). Participants and the synthesis session are NOT parented to this
+   * — they are parented to the MODERATOR's live session id once it is known
+   * (see `start()` / `spawnParticipant` / `triggerSynthesis`). Unset when the
+   * team is itself agent-rooted.
+   */
+  parentSessionId?: string;
+  /**
    * IAW Phase B.2b (cortex#114) — bus-peer dependencies. Required
    * when ANY participant has `kind: "bus-peer"`; the constructor
    * throws if a participant declares bus-peer routing without these
@@ -294,6 +303,9 @@ export class AgentTeamHarness implements SessionHarness {
       ...(req.tools.allow.length > 0 && { allowedTools: [...req.tools.allow] }),
       ...(req.tools.deny !== undefined && { disallowedTools: [...req.tools.deny] }),
       ...(req.runtime?.allowedDirs !== undefined && { allowedDirs: req.runtime.allowedDirs }),
+      // ST-P1 (cortex#964) — thread the dispatch-level parent session id onto
+      // the team so the moderator session is parented to the dispatch.
+      ...(req.runtime?.parentSessionId !== undefined && { parentSessionId: req.runtime.parentSessionId }),
       ...(req.timeoutMs !== undefined && { timeoutMs: req.timeoutMs }),
       ...(env.project !== undefined && { project: env.project }),
       ...(env.entity !== undefined && { entity: env.entity }),
@@ -570,6 +582,9 @@ export class AgentTeam extends EventEmitter {
       prompt: moderatorPrompt,
       groveChannel: this.opts.groveChannel,
       groveNetwork: this.opts.groveNetwork,
+      // ST-P1 (cortex#964) — the moderator is a child of the DISPATCH-level
+      // parent (the dispatch that spawned this team), if any.
+      ...(this.opts.parentSessionId !== undefined && { parentSessionId: this.opts.parentSessionId }),
       additionalArgs: this.opts.additionalArgs,
       allowedTools: this.opts.allowedTools,
       disallowedTools: this.opts.disallowedTools,
@@ -676,10 +691,21 @@ export class AgentTeam extends EventEmitter {
       "Start with a 1-3 sentence plain-text overview, then provide details.",
     ].join("\n");
 
+    // ST-P1 (cortex#964) — a participant is a CHILD of the moderator session.
+    // `spawnParticipant` runs from `handleModeratorResponse`, which fires on the
+    // moderator's `result` event — strictly AFTER its `init` event populated
+    // `this.moderator.sessionId` (see cc-session.ts processLine). So the
+    // moderator's live cc_session_id is reliably known here; prefer it. Fall
+    // back to the dispatch-level parent only in the (not-expected) case the id
+    // is still unset, so the participant is never left unparented.
+    const participantParent =
+      this.moderator?.sessionId ?? this.opts.parentSessionId;
+
     const session = new CCSession({
       prompt: participantPrompt,
       groveChannel: this.opts.groveChannel,
       groveNetwork: this.opts.groveNetwork,
+      ...(participantParent !== undefined && { parentSessionId: participantParent }),
       additionalArgs: this.opts.additionalArgs,
       allowedTools: config.allowedTools ?? this.opts.allowedTools,
       disallowedTools: config.disallowedTools ?? this.opts.disallowedTools,
@@ -850,9 +876,16 @@ export class AgentTeam extends EventEmitter {
     // Spawn a new moderator session for synthesis
     const synthesisPrompt = buildSynthesisPrompt(this.opts.prompt, participantResults);
 
+    // ST-P1 (cortex#964) — synthesis is a CHILD of the moderator session, same
+    // as participants. `triggerSynthesis` runs after every participant has
+    // responded, well after the moderator's `init`, so its session id is known.
+    const synthesisParent =
+      this.moderator?.sessionId ?? this.opts.parentSessionId;
+
     const synthSession = new CCSession({
       prompt: synthesisPrompt,
       groveChannel: this.opts.groveChannel,
+      ...(synthesisParent !== undefined && { parentSessionId: synthesisParent }),
       additionalArgs: this.opts.additionalArgs,
       allowedTools: this.opts.allowedTools,
       disallowedTools: this.opts.disallowedTools,

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -27,6 +27,13 @@ export interface CCSessionOpts {
   agentName?: string;
   agentId?: string;
   resumeSessionId?: string;
+  /**
+   * ST-P1 (cortex#964, refs #952) — the parent session id for this spawn. When
+   * set, `buildSessionEnv` stamps `CORTEX_PARENT_SESSION_ID` on the child's env
+   * so the child's EventLogger links its events to the parent session
+   * (CONTEXT.md §Session tree). Unset for an agent-rooted session.
+   */
+  parentSessionId?: string;
   allowedTools?: string[];
   disallowedTools?: string[];
   allowedDirs?: string[];
@@ -138,6 +145,7 @@ export function buildSessionEnv(
     | "project"
     | "entity"
     | "principal"
+    | "parentSessionId"
   >,
 ): Record<string, string> {
   return {
@@ -149,6 +157,9 @@ export function buildSessionEnv(
     ...(opts.project && { CORTEX_PROJECT: opts.project }),
     ...(opts.entity && { CORTEX_ENTITY: opts.entity }),
     ...(opts.principal && { CORTEX_PRINCIPAL: opts.principal }),
+    // ST-P1 (cortex#964) — child-session linkage. The spawned child's
+    // EventLogger reads CORTEX_PARENT_SESSION_ID to parent its events.
+    ...(opts.parentSessionId && { CORTEX_PARENT_SESSION_ID: opts.parentSessionId }),
   };
 }
 

--- a/src/runner/claude-invoker.ts
+++ b/src/runner/claude-invoker.ts
@@ -29,6 +29,14 @@ export interface ClaudeInvocationOpts {
   additionalArgs?: string[];
   /** If set, resume an existing CC session (for threaded conversations) */
   resumeSessionId?: string;
+  /**
+   * ST-P1 (cortex#964, refs #952) — the parent session id for this spawn.
+   * Carried to the child via the `CORTEX_PARENT_SESSION_ID` env var (stamped in
+   * `cc-session.ts` `buildSessionEnv`), NOT as a CLI arg — `buildClaudeArgs`
+   * never emits a flag for it. Present on the opts for symmetry with
+   * `CCSessionOpts` and so non-CCSession invokers can thread it through env.
+   */
+  parentSessionId?: string;
   /** Tools to allow (passed as --allowedTools) */
   allowedTools?: string[];
   /** Tools to deny (passed as --disallowedTools) */

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -201,6 +201,13 @@ export interface DispatchTaskReceivedPayload {
   grove_network?: string;
   agent_name?: string;
   resume_session_id?: string;
+  /**
+   * ST-P1 (cortex#964, refs #952) — the parent session id for this dispatch
+   * (session-tree linkage). `buildDispatchRequest` maps it onto
+   * `req.runtime.parentSessionId`; the claude-code harness then stamps it onto
+   * `CCSessionOpts.parentSessionId`. Name PINNED for the ST-P2 producer.
+   */
+  parent_session_id?: string;
   allowed_tools?: string[];
   disallowed_tools?: string[];
   /**
@@ -1087,6 +1094,8 @@ function buildDispatchRequest(
   if (payload.grove_channel !== undefined) runtime.groveChannel = payload.grove_channel;
   if (payload.grove_network !== undefined) runtime.groveNetwork = payload.grove_network;
   if (payload.resume_session_id !== undefined) runtime.resumeSessionId = payload.resume_session_id;
+  // ST-P1 (cortex#964) — map the session-tree parent onto the runtime block.
+  if (payload.parent_session_id !== undefined) runtime.parentSessionId = payload.parent_session_id;
   const hasRuntime = Object.keys(runtime).length > 0;
 
   // Env-kind context block carries principal/entity/project labels.

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -399,6 +399,9 @@ export class ClaudeCodeHarness implements SessionHarness {
       if (runtime.groveChannel !== undefined) opts.groveChannel = runtime.groveChannel;
       if (runtime.groveNetwork !== undefined) opts.groveNetwork = runtime.groveNetwork;
       if (runtime.resumeSessionId !== undefined) opts.resumeSessionId = runtime.resumeSessionId;
+      // ST-P1 (cortex#964) — thread the session-tree parent so the spawned
+      // child stamps CORTEX_PARENT_SESSION_ID (cc-session.ts buildSessionEnv).
+      if (runtime.parentSessionId !== undefined) opts.parentSessionId = runtime.parentSessionId;
     }
 
     // Surface env context kinds the substrate understands. Unknown kinds

--- a/src/taps/cc-events/__tests__/cc-events-parent-session.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events-parent-session.test.ts
@@ -1,0 +1,51 @@
+/**
+ * ST-P1 (cortex#964, refs #952) — the cc-events envelope carries the
+ * session-tree fields `parent_session_id` + `substrate` into the payload
+ * when the PublishedEvent supplies them. Both ingest paths (local relay →
+ * ingestor; cloud publisher → /api/ingest) read the envelope payload, so
+ * carrying the fields here is what makes Phase 2's ingestor able to parent
+ * a child session.
+ */
+import { describe, expect, test } from "bun:test";
+import { createCcEventEnvelope } from "../cc-events";
+import type { PublishedEvent } from "../hooks/lib/event-types";
+import { validateEnvelope } from "../../../bus/myelin/envelope-validator";
+
+function makeEvent(overrides: Partial<PublishedEvent> = {}): PublishedEvent {
+  return {
+    event_id: crypto.randomUUID(),
+    event_type: "agent.task.started",
+    timestamp: "2026-06-11T10:00:00.000Z",
+    session_id: "9d2c4e8a-1b3f-4c5d-9e6f-7a8b9c0d1e2f",
+    grove_channel: "andreas",
+    agent_id: "luna",
+    agent_name: "Luna",
+    network_id: "metafactory",
+    payload: { tool_name: "Bash" },
+    ...overrides,
+  };
+}
+
+describe("createCcEventEnvelope — ST-P1 parent_session_id + substrate", () => {
+  test("carries parent_session_id + substrate into the payload when present", () => {
+    const envelope = createCcEventEnvelope({
+      event: makeEvent({
+        parent_session_id: "moderator-session",
+        substrate: "claude-code",
+      }),
+    });
+
+    expect(envelope.payload.parent_session_id).toBe("moderator-session");
+    expect(envelope.payload.substrate).toBe("claude-code");
+    expect(validateEnvelope(envelope).ok).toBe(true);
+  });
+
+  test("omits parent_session_id + substrate from the payload when absent", () => {
+    const envelope = createCcEventEnvelope({
+      event: makeEvent(),
+    });
+
+    expect(envelope.payload.parent_session_id).toBeUndefined();
+    expect(envelope.payload.substrate).toBeUndefined();
+  });
+});

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -203,6 +203,11 @@ export function createCcEventEnvelope(
       // directly without re-parsing the envelope type.
       event_id: event.event_id,
       session_id: event.session_id,
+      // ST-P1 (cortex#964, refs #952) — carry the session-tree linkage onto the
+      // payload so both ingest paths (local relay → ingestor; cloud publisher →
+      // /api/ingest) can parent the session. Omitted when absent (root/non-CC).
+      ...(event.parent_session_id !== undefined && { parent_session_id: event.parent_session_id }),
+      ...(event.substrate !== undefined && { substrate: event.substrate }),
       ...(event.grove_channel !== undefined && { grove_channel: event.grove_channel }),
       ...(event.agent_id !== undefined && { agent_id: event.agent_id }),
       ...(event.agent_name !== undefined && { agent_name: event.agent_name }),

--- a/src/taps/cc-events/hooks/EventLogger.hook.ts
+++ b/src/taps/cc-events/hooks/EventLogger.hook.ts
@@ -49,6 +49,11 @@ interface HookInput {
   summary?: string;
   duration_ms?: number;
   session_id?: string;
+  // ST-P1 (cortex#964) — Claude Code does NOT natively surface a parent
+  // session id on the hook input today; this is the forward door for if/when
+  // it does. The load-bearing source is the `CORTEX_PARENT_SESSION_ID` env var
+  // stamped by the runner on a spawned child (see the read site in main()).
+  parent_session_id?: string;
 }
 
 interface UsageCache {
@@ -170,6 +175,16 @@ async function main() {
     const sessionId: string =
       hookInput.session_id ?? process.env.CLAUDE_SESSION_ID ?? "unknown";
 
+    // ST-P1 (cortex#964, refs #952) — session-tree linkage. The runner stamps
+    // `CORTEX_PARENT_SESSION_ID` on a spawned child session's env (see
+    // cc-session.ts `buildSessionEnv`); read it (preferring a native hook field
+    // if CC ever surfaces one). This hook IS the claude-code tap, so the
+    // substrate is always `claude-code`. Env read only — the hook stays
+    // non-blocking (CLAUDE.md: never call out from inside a hook).
+    const parentSessionId: string | undefined =
+      hookInput.parent_session_id ?? process.env.CORTEX_PARENT_SESSION_ID ?? undefined;
+    const substrate = "claude-code";
+
     if (hookType === "unknown" || !isHookEventName(hookType)) {
       // Unrecognised hook shape — write nothing, exit silently.
       process.exit(0);
@@ -246,6 +261,8 @@ async function main() {
 
     const event = createRawEvent(eventType, hookType, payload, {
       sessionId,
+      ...(parentSessionId !== undefined && { parentSessionId }),
+      substrate,
       toolName,
       networkId: groveNetwork,
     });
@@ -261,7 +278,12 @@ async function main() {
         EVENT_TYPES.SESSION_HEARTBEAT,
         hookType,
         { project: groveProject, entity: groveEntity, principal },
-        { sessionId, networkId: groveNetwork }
+        {
+          sessionId,
+          ...(parentSessionId !== undefined && { parentSessionId }),
+          substrate,
+          networkId: groveNetwork,
+        }
       );
       await postEvent(heartbeat);
       writeToJsonl(filePath, heartbeat);

--- a/src/taps/cc-events/hooks/lib/__tests__/event-types-parent-session.test.ts
+++ b/src/taps/cc-events/hooks/lib/__tests__/event-types-parent-session.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from "bun:test";
+import {
+  createRawEvent,
+  RawEventSchema,
+  PublishedEventSchema,
+} from "../event-types";
+
+/**
+ * ST-P1 (cortex#964, refs #952) — the cc-events RawEvent / PublishedEvent
+ * schemas carry the session-tree fields `parent_session_id` + `substrate`,
+ * and `createRawEvent` stamps them from its options.
+ *
+ * Wire-contract names are PINNED — `parent_session_id` and `substrate`
+ * (snake_case on the event/payload schema, per the ST-P2 consumer). Do not
+ * vary them.
+ */
+describe("ST-P1 — parent_session_id + substrate on cc-events schemas", () => {
+  test("RawEventSchema accepts parent_session_id + substrate (both optional)", () => {
+    const withFields = RawEventSchema.safeParse({
+      event_id: crypto.randomUUID(),
+      event_type: "agent.task.started",
+      timestamp: new Date().toISOString(),
+      session_id: "child-session",
+      parent_session_id: "moderator-session",
+      substrate: "claude-code",
+      source: { hook: "Stop" },
+      payload: {},
+    });
+    expect(withFields.success).toBe(true);
+
+    // Both fields are optional — a raw event without them still parses.
+    const withoutFields = RawEventSchema.safeParse({
+      event_id: crypto.randomUUID(),
+      event_type: "agent.task.started",
+      timestamp: new Date().toISOString(),
+      session_id: "root-session",
+      source: { hook: "Stop" },
+      payload: {},
+    });
+    expect(withoutFields.success).toBe(true);
+  });
+
+  test("PublishedEventSchema accepts parent_session_id + substrate (both optional)", () => {
+    const parsed = PublishedEventSchema.safeParse({
+      event_id: crypto.randomUUID(),
+      event_type: "agent.task.started",
+      timestamp: new Date().toISOString(),
+      session_id: "child-session",
+      parent_session_id: "moderator-session",
+      substrate: "claude-code",
+      payload: {},
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("createRawEvent stamps parentSessionId + substrate from options", () => {
+    const event = createRawEvent("agent.task.started", "Stop", {}, {
+      sessionId: "child-session",
+      parentSessionId: "moderator-session",
+      substrate: "claude-code",
+    });
+
+    expect(event.parent_session_id).toBe("moderator-session");
+    expect(event.substrate).toBe("claude-code");
+  });
+
+  test("createRawEvent omits parent_session_id + substrate when not supplied", () => {
+    const event = createRawEvent("agent.task.started", "Stop", {}, {
+      sessionId: "root-session",
+    });
+
+    expect(event.parent_session_id).toBeUndefined();
+    expect(event.substrate).toBeUndefined();
+  });
+
+  test("the stamped event round-trips through RawEventSchema", () => {
+    const event = createRawEvent("agent.task.started", "Stop", {}, {
+      sessionId: "child-session",
+      parentSessionId: "moderator-session",
+      substrate: "claude-code",
+    });
+    const parsed = RawEventSchema.safeParse(event);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/src/taps/cc-events/hooks/lib/event-types.ts
+++ b/src/taps/cc-events/hooks/lib/event-types.ts
@@ -15,6 +15,14 @@ export const RawEventSchema = z.object({
   event_type: z.string().min(1),
   timestamp: z.iso.datetime(),
   session_id: z.string().min(1),
+  // ST-P1 (cortex#964, refs #952) — session-tree linkage. `parent_session_id`
+  // names the session that spawned this one (a child session carries it; an
+  // agent-rooted session has none — CONTEXT.md §Sessions). `substrate` is the
+  // execution substrate the session runs on (`claude-code`, …). Both optional;
+  // the ingestor (Phase 2) reads them off the envelope payload to parent the
+  // session. Names PINNED for the ST-P2 consumer.
+  parent_session_id: z.string().optional(),
+  substrate: z.string().optional(),
   grove_channel: z.string().optional(),
   agent_id: z.string().optional(),
   agent_name: z.string().optional(),
@@ -43,6 +51,10 @@ export const PublishedEventSchema = z.object({
   event_type: z.string().min(1),
   timestamp: z.iso.datetime(),
   session_id: z.string().min(1),
+  // ST-P1 (cortex#964, refs #952) — session-tree linkage carried through to
+  // consumers (the relay propagates these from the RawEvent). See RawEventSchema.
+  parent_session_id: z.string().optional(),
+  substrate: z.string().optional(),
   grove_channel: z.string().optional(),
   agent_id: z.string().optional(),
   agent_name: z.string().optional(),
@@ -60,13 +72,17 @@ export function createRawEvent(
   eventType: string,
   hook: RawEvent["source"]["hook"],
   payload: Record<string, unknown>,
-  options?: { sessionId?: string; toolName?: string; groveChannel?: string; agentId?: string; agentName?: string; networkId?: string }
+  options?: { sessionId?: string; parentSessionId?: string; substrate?: string; toolName?: string; groveChannel?: string; agentId?: string; agentName?: string; networkId?: string }
 ): RawEvent {
   return {
     event_id: crypto.randomUUID(),
     event_type: eventType,
     timestamp: new Date().toISOString(),
     session_id: options?.sessionId ?? process.env.CLAUDE_SESSION_ID ?? "unknown",
+    // ST-P1 — stamp the session-tree fields only when supplied (an
+    // agent-rooted session has no parent; a non-CC tap may omit substrate).
+    ...(options?.parentSessionId !== undefined && { parent_session_id: options.parentSessionId }),
+    ...(options?.substrate !== undefined && { substrate: options.substrate }),
     // cortex#774: read CORTEX_* first, fall back to legacy GROVE_*.
     grove_channel: options?.groveChannel ?? resolveSurfaceEnv("CHANNEL"),
     agent_id: options?.agentId ?? resolveSurfaceEnv("AGENT_ID"),

--- a/src/taps/cc-events/lib/__tests__/policy-engine.test.ts
+++ b/src/taps/cc-events/lib/__tests__/policy-engine.test.ts
@@ -196,4 +196,24 @@ describe("processEvent", () => {
     const result = processEvent(event, basePolicy);
     expect(result!.grove_channel).toBe("luna");
   });
+
+  // ST-P1 (cortex#964, refs #952) — the relay must carry the session-tree
+  // fields through Raw → Published so the cc-events envelope can place them
+  // on the payload for both ingest paths.
+  test("propagates parent_session_id + substrate from raw to published", () => {
+    const event = makeRawEvent({
+      parent_session_id: "moderator-session",
+      substrate: "claude-code",
+    });
+    const result = processEvent(event, basePolicy);
+    expect(result!.parent_session_id).toBe("moderator-session");
+    expect(result!.substrate).toBe("claude-code");
+  });
+
+  test("omits parent_session_id + substrate when the raw event has none", () => {
+    const event = makeRawEvent();
+    const result = processEvent(event, basePolicy);
+    expect(result!.parent_session_id).toBeUndefined();
+    expect(result!.substrate).toBeUndefined();
+  });
 });

--- a/src/taps/cc-events/lib/policy-engine.ts
+++ b/src/taps/cc-events/lib/policy-engine.ts
@@ -136,6 +136,11 @@ export function processEvent(
     event_type: raw.event_type,
     timestamp: raw.timestamp,
     session_id: raw.session_id,
+    // ST-P1 (cortex#964) — carry the session-tree fields through unredacted.
+    // They are structural linkage, not payload content; omitted when absent so
+    // a root/non-CC event stays clean.
+    ...(raw.parent_session_id !== undefined && { parent_session_id: raw.parent_session_id }),
+    ...(raw.substrate !== undefined && { substrate: raw.substrate }),
     // cortex#774: read CORTEX_CHANNEL first, fall back to legacy GROVE_CHANNEL.
     grove_channel: raw.grove_channel ?? resolveSurfaceEnv("CHANNEL"),
     agent_id: raw.agent_id,


### PR DESCRIPTION
Phase 1 of the MC session-tree refactor (#952), per `docs/refactor-mc-session-tree.md` §6. Captures the **parent-session linkage** for runner-spawned children and carries it — with the **substrate** attribute — end-to-end from the spawn boundary through the cc-events envelope, so both ingest paths (local relay → ingestor; cloud publisher → `/api/ingest`) can parent a child session in Phase 2.

Builds on ST-P0 (#961: canonical schema + `parent_session_id`/`substrate` columns). Scope is **taps + runner + common only** — no `src/surface/mc/**` (owned by the parallel ST-P2 agent).

## Wire contract (PINNED — ST-P2 consumes exactly these)
- env var **`CORTEX_PARENT_SESSION_ID`**
- event/payload field **`parent_session_id`**
- field **`substrate`**

## Change map (§6 rows)
| Area | Change |
|---|---|
| `taps/.../event-types.ts` | `RawEventSchema` + `PublishedEventSchema` gain optional `parent_session_id` + `substrate`; `createRawEvent` accepts + stamps them |
| `taps/.../lib/policy-engine.ts` | relay propagates both fields Raw → Published |
| `taps/.../EventLogger.hook.ts` | reads `hookInput.parent_session_id ?? CORTEX_PARENT_SESSION_ID`; stamps `substrate: "claude-code"` (this hook **is** the claude-code tap); threads both into the main event + the heartbeat. **Env read only — hook stays non-blocking.** |
| `taps/cc-events/cc-events.ts` | envelope carries both into `payload` when present |
| `runner/cc-session.ts` | `CCSessionOpts.parentSessionId`; `buildSessionEnv` stamps `CORTEX_PARENT_SESSION_ID` |
| `runner/claude-invoker.ts` | `ClaudeInvocationOpts.parentSessionId` (carried via env, not a CLI arg) |
| `runner/agent-team.ts` | `AgentTeamOpts.parentSessionId`; `buildTeamOpts` maps `req.runtime?.parentSessionId`; threaded into all three spawn sites |
| `common/substrates/types.ts` | `DispatchRuntime.parentSessionId` |
| `runner/dispatch-listener.ts` | `DispatchTaskReceivedPayload.parent_session_id`; `buildDispatchRequest` maps `parent_session_id → runtime.parentSessionId` |
| `substrates/claude-code/harness.ts` | threads `runtime.parentSessionId → CCSessionOpts.parentSessionId` |

> Harness note: the §6 "locate" target resolved to `src/substrates/claude-code/harness.ts` (imported by `dispatch-handler`), not `src/common/substrates/`.

## Moderator-parent design choice (the §6 investigate-before-choosing decision)

**Decision: participants and the synthesis session are parented to the MODERATOR's live `cc_session_id`** (`this.moderator.sessionId`) — not the dispatch-level parent.

Investigation: `CCSession` exposes its session id as a public `sessionId` property, set from the `init` stream event (`cc-session.ts` `processLine` → `case "init"`, which also emits `session-id`). `spawnParticipant` runs from `handleModeratorResponse`, which fires on the moderator's **`result`** event — strictly *after* `init` populated `sessionId`. `triggerSynthesis` runs even later (after every participant responds). So the moderator's live session id is **reliably knowable** at participant/synthesis spawn time, and stamping it yields a *true* parent→child tree (moderator → participants/synthesis) rather than flattening them as siblings of the dispatch.

The **moderator itself** is parented to the dispatch-level parent (`opts.parentSessionId`, mapped from `req.runtime.parentSessionId`). A defensive fallback to `opts.parentSessionId` guards the not-expected case where `this.moderator.sessionId` is still unset, so a child is never left unparented.

(The dispatch that spawns the team has no CC session of its own; `opts.parentSessionId` is the dispatch-level parent passed in from above, which is `undefined` for an agent-rooted team.)

## Tests (TDD — written first, confirmed RED, then GREEN)
- schema round-trip + `createRawEvent` stamp (`event-types-parent-session.test.ts`)
- relay Raw → Published propagation (`policy-engine.test.ts`)
- envelope payload carry (`cc-events-parent-session.test.ts`)
- `buildSessionEnv` env-stamp (`cc-session-parent-env.test.ts`)
- `AgentTeamHarness` `parentSessionId` threading (`agent-team-parent-session.test.ts`)
- dispatch-listener payload → `CCSessionOpts.parentSessionId` end-to-end (`dispatch-listener.test.ts`)

## Gates
- `bunx tsc --noEmit` — clean (exit 0)
- `bun run lint` — 0 errors (27 pre-existing warnings, none in touched files)
- `bun test` — 5914 pass / 0 fail / 2 skip
- `scripts/check-carveouts.sh` — PASS

Closes #964
Refs #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)