### PR TITLE
feat(mc): ST-P5 — working grid renders the session tree (final phase of #952)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-detail-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-detail-display.test.ts
@@ -54,6 +54,7 @@ function workingTile(
       updated_at: "2026-06-11T00:00:00.000Z",
     },
     additional_active_count: 0,
+    sessions: [],
     ...over,
   };
 }

--- a/src/surface/mc/dashboard-v2/__tests__/session-tree-rows.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/session-tree-rows.test.ts
@@ -1,0 +1,147 @@
+/**
+ * ST-P5 — tree → flat-render-rows expansion helper.
+ *
+ * `flattenSessionTree(forest, expanded)` walks the session forest depth-first
+ * and emits ONLY the rows currently visible given the expansion Set (keyed by
+ * `session_id`). Per D5 the default is COLLAPSED: a node's children appear only
+ * when the node's id is in `expanded`. Each row carries:
+ *   - `node`        — the SessionTreeNode
+ *   - `depth`       — 0 for roots, +1 per nesting level (drives indent)
+ *   - `hasChildren` — whether this node has any child sessions
+ *   - `isExpanded`  — whether this node is currently expanded
+ *   - `childCount`  — number of DIRECT children (for the collapsed badge)
+ *
+ * Pure + DOM-free so the expansion logic is unit-testable without a renderer.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { flattenSessionTree, toggleExpanded } from "../lib/session-tree-rows";
+import type { SessionTreeNode } from "../hooks/use-working-agents";
+
+function node(
+  id: string,
+  children: SessionTreeNode[] = [],
+  over: Partial<SessionTreeNode> = {}
+): SessionTreeNode {
+  return {
+    session_id: id,
+    parent_session_id: null,
+    substrate: "claude-code",
+    state: "running",
+    started_at: "2026-06-11T00:00:00.000Z",
+    ended_at: null,
+    agent_name: "Luna",
+    task_title: `work ${id}`,
+    children,
+    ...over,
+  };
+}
+
+describe("flattenSessionTree — D5 default-collapsed expansion", () => {
+  it("empty forest → no rows", () => {
+    expect(flattenSessionTree([], new Set())).toEqual([]);
+  });
+
+  it("flat roots (no children) → one row each at depth 0", () => {
+    const rows = flattenSessionTree([node("a"), node("b")], new Set());
+    expect(rows.map((r) => r.node.session_id)).toEqual(["a", "b"]);
+    expect(rows.every((r) => r.depth === 0)).toBe(true);
+    expect(rows.every((r) => r.hasChildren === false)).toBe(true);
+    expect(rows.every((r) => r.childCount === 0)).toBe(true);
+  });
+
+  it("collapsed parent hides its children (default per D5)", () => {
+    const tree = [node("root", [node("child1"), node("child2")])];
+    const rows = flattenSessionTree(tree, new Set()); // nothing expanded
+    expect(rows.map((r) => r.node.session_id)).toEqual(["root"]);
+    const root = rows[0]!;
+    expect(root.hasChildren).toBe(true);
+    expect(root.isExpanded).toBe(false);
+    expect(root.childCount).toBe(2);
+  });
+
+  it("expanded parent reveals its direct children at depth+1", () => {
+    const tree = [node("root", [node("child1"), node("child2")])];
+    const rows = flattenSessionTree(tree, new Set(["root"]));
+    expect(rows.map((r) => r.node.session_id)).toEqual([
+      "root",
+      "child1",
+      "child2",
+    ]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 1, 1]);
+    expect(rows[0]!.isExpanded).toBe(true);
+  });
+
+  it("deep nesting: only expanded ancestors reveal descendants", () => {
+    const tree = [
+      node("root", [node("mid", [node("leaf")])]),
+    ];
+    // root expanded, mid collapsed → leaf stays hidden
+    let rows = flattenSessionTree(tree, new Set(["root"]));
+    expect(rows.map((r) => r.node.session_id)).toEqual(["root", "mid"]);
+    expect(rows[1]!.hasChildren).toBe(true);
+    expect(rows[1]!.isExpanded).toBe(false);
+
+    // root + mid expanded → leaf visible at depth 2
+    rows = flattenSessionTree(tree, new Set(["root", "mid"]));
+    expect(rows.map((r) => r.node.session_id)).toEqual(["root", "mid", "leaf"]);
+    expect(rows.map((r) => r.depth)).toEqual([0, 1, 2]);
+  });
+
+  it("expanding a leaf has no effect (no children to reveal)", () => {
+    const rows = flattenSessionTree([node("a")], new Set(["a"]));
+    expect(rows.map((r) => r.node.session_id)).toEqual(["a"]);
+    expect(rows[0]!.hasChildren).toBe(false);
+    // A leaf is never reported as expanded — there is nothing to expand.
+    expect(rows[0]!.isExpanded).toBe(false);
+  });
+
+  it("preserves sibling + child input order", () => {
+    const tree = [
+      node("r1", [node("r1c2"), node("r1c1")]),
+      node("r2"),
+    ];
+    const rows = flattenSessionTree(tree, new Set(["r1"]));
+    expect(rows.map((r) => r.node.session_id)).toEqual([
+      "r1",
+      "r1c2",
+      "r1c1",
+      "r2",
+    ]);
+  });
+
+  it("multiple expanded roots interleave correctly", () => {
+    const tree = [
+      node("a", [node("a1")]),
+      node("b", [node("b1")]),
+    ];
+    const rows = flattenSessionTree(tree, new Set(["a", "b"]));
+    expect(rows.map((r) => r.node.session_id)).toEqual(["a", "a1", "b", "b1"]);
+  });
+});
+
+describe("toggleExpanded — immutable, copy-on-write expansion state", () => {
+  it("adds an id when absent (collapsed → expanded)", () => {
+    const next = toggleExpanded(new Set(), "s1");
+    expect(next.has("s1")).toBe(true);
+  });
+
+  it("removes an id when present (expanded → collapsed)", () => {
+    const next = toggleExpanded(new Set(["s1"]), "s1");
+    expect(next.has("s1")).toBe(false);
+  });
+
+  it("returns a NEW Set (does not mutate the input — React re-render)", () => {
+    const prev = new Set(["s1"]);
+    const next = toggleExpanded(prev, "s2");
+    expect(next).not.toBe(prev);
+    expect(prev.has("s2")).toBe(false); // input untouched
+    expect(next.has("s2")).toBe(true);
+  });
+
+  it("toggling preserves other ids (expansion of one row is independent)", () => {
+    const next = toggleExpanded(new Set(["a", "b"]), "a");
+    expect(next.has("a")).toBe(false);
+    expect(next.has("b")).toBe(true);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/substrate-label.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/substrate-label.test.ts
@@ -1,0 +1,47 @@
+/**
+ * ST-P5 — substrate-projection label matrix.
+ *
+ * THE DOMAIN RULE (CONTEXT.md §Sessions / §"Sub-agent"): the MC model speaks
+ * **session** / **child session**. "sub-agent" is NOT a domain entity — it is
+ * the Claude-Code-lens DISPLAY label for a `claude-code` child session, derived
+ * at render time only. Codex (or any other substrate) projects its own word.
+ *
+ * Matrix under test (`substrateLabel(substrate, hasParent)`):
+ *   claude-code + parent   → "sub-agent"   (the CC lens label for a child session)
+ *   claude-code + root     → "session"
+ *   <other>     + root     → "<other> session"   (e.g. "codex session")
+ *   <other>     + parent   → "<other> session"   (substrate-neutral; no CC label)
+ */
+
+import { describe, it, expect } from "bun:test";
+import { substrateLabel } from "../lib/substrate-label";
+
+describe("substrateLabel — substrate-projection display matrix", () => {
+  it("claude-code child session → 'sub-agent' (the CC-lens label)", () => {
+    expect(substrateLabel("claude-code", true)).toBe("sub-agent");
+  });
+
+  it("claude-code root session → 'session'", () => {
+    expect(substrateLabel("claude-code", false)).toBe("session");
+  });
+
+  it("codex root session → 'codex session' (substrate string itself)", () => {
+    expect(substrateLabel("codex", false)).toBe("codex session");
+  });
+
+  it("codex child session → 'codex session' (no CC sub-agent label)", () => {
+    // Other substrates project their own word; "sub-agent" is CC-only.
+    expect(substrateLabel("codex", true)).toBe("codex session");
+  });
+
+  it("unknown substrate → '<substrate> session' for both root and child", () => {
+    expect(substrateLabel("gemini-cli", false)).toBe("gemini-cli session");
+    expect(substrateLabel("gemini-cli", true)).toBe("gemini-cli session");
+  });
+
+  it("empty / whitespace substrate falls back to bare 'session'", () => {
+    // Defensive: a missing substrate must not render an orphaned " session".
+    expect(substrateLabel("", false)).toBe("session");
+    expect(substrateLabel("   ", true)).toBe("session");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/working-grid.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/working-grid.test.tsx
@@ -9,11 +9,17 @@
  */
 
 import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
 import {
   pickWorkingGridMode,
   priorityLabel,
 } from "../lib/working-grid-display";
-import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import { WorkingGrid } from "../components/working-grid";
+import type {
+  WorkingAgentTile,
+  SessionTreeNode,
+} from "../hooks/use-working-agents";
 
 function tile(over: Partial<WorkingAgentTile> = {}): WorkingAgentTile {
   return {
@@ -30,8 +36,41 @@ function tile(over: Partial<WorkingAgentTile> = {}): WorkingAgentTile {
       updated_at: "2026-04-26T00:00:00.000Z",
     },
     additional_active_count: 0,
+    sessions: [],
     ...over,
   };
+}
+
+function sessionNode(
+  id: string,
+  children: SessionTreeNode[] = [],
+  over: Partial<SessionTreeNode> = {}
+): SessionTreeNode {
+  return {
+    session_id: id,
+    parent_session_id: null,
+    substrate: "claude-code",
+    state: "running",
+    started_at: "2026-06-11T00:00:00.000Z",
+    ended_at: null,
+    agent_name: "Luna",
+    task_title: `work ${id}`,
+    children,
+    ...over,
+  };
+}
+
+function renderGrid(over: Partial<WorkingAgentTile> = {}): string {
+  return renderToStaticMarkup(
+    createElement(WorkingGrid, {
+      agents: [tile(over)],
+      loaded: true,
+      error: null,
+      focusItemCount: 0,
+      drillOpen: false,
+      onOpen: () => {},
+    })
+  );
 }
 
 describe("pickWorkingGridMode — F-9 Decision 7 branching", () => {
@@ -98,5 +137,102 @@ describe("priorityLabel — legacy parity", () => {
     expect(priorityLabel(99)).toBe("P?");
     expect(priorityLabel(1.5)).toBe("P?");
     expect(priorityLabel(NaN)).toBe("P?");
+  });
+});
+
+describe("WorkingGrid — ST-P5 session-tree render (static markup)", () => {
+  it("absent sessions → no tree chrome (pre-ST-P5 compat snapshot)", () => {
+    const html = renderGrid({ sessions: [] });
+    // The tile header is intact …
+    expect(html).toContain('data-agent-id="ag-1"');
+    expect(html).toContain("Implement focus area");
+    // … and NO session-tree markup is emitted at all.
+    expect(html).not.toContain("session-tree");
+    expect(html).not.toContain("session-row");
+    expect(html).not.toContain("aria-expanded");
+  });
+
+  it("keeps the primary_assignment / state header untouched when a tree is present", () => {
+    const html = renderGrid({
+      sessions: [sessionNode("root", [sessionNode("c1", [], { parent_session_id: "root" })])],
+    });
+    expect(html).toContain('data-agent-id="ag-1"');
+    expect(html).toContain("Implement focus area");
+    expect(html).toContain('class="agent"');
+    expect(html).toContain('class="task"');
+  });
+
+  it("default-collapsed: a parent renders an expander but NOT its children (D5)", () => {
+    const html = renderGrid({
+      sessions: [
+        sessionNode("root", [
+          sessionNode("child-1", [], { parent_session_id: "root", task_title: "deep work" }),
+        ]),
+      ],
+    });
+    // The root row exists with a COLLAPSED expander …
+    expect(html).toContain('data-session-id="root"');
+    expect(html).toContain('aria-expanded="false"');
+    // … the chevron points right (collapsed) …
+    expect(html).toContain("▸");
+    // … and the child row is NOT in the markup (hidden while collapsed).
+    expect(html).not.toContain('data-session-id="child-1"');
+  });
+
+  it("collapsed parent shows a child-count badge with accessible text (not color-only)", () => {
+    const html = renderGrid({
+      sessions: [
+        sessionNode("root", [
+          sessionNode("c1", [], { parent_session_id: "root" }),
+          sessionNode("c2", [], { parent_session_id: "root" }),
+        ]),
+      ],
+    });
+    expect(html).toContain("session-child-badge");
+    // Accessible text spells out the count + noun for AT.
+    expect(html).toContain("2 child sessions");
+  });
+
+  it("singular child-count badge text reads 'child session'", () => {
+    const html = renderGrid({
+      sessions: [
+        sessionNode("root", [sessionNode("only", [], { parent_session_id: "root" })]),
+      ],
+    });
+    expect(html).toContain("1 child session");
+    expect(html).not.toContain("1 child sessions");
+  });
+
+  it("derives the substrate-projection label: claude-code child → 'sub-agent'", () => {
+    const html = renderGrid({
+      sessions: [
+        sessionNode("root", [], { substrate: "claude-code" }),
+      ],
+    });
+    // A root claude-code session is labelled "session" (NOT sub-agent).
+    expect(html).toContain('class="session-label">session<');
+    // "sub-agent" must NOT appear for a root.
+    expect(html).not.toContain("sub-agent");
+  });
+
+  it("non-claude substrate root renders '<substrate> session', never 'sub-agent'", () => {
+    const html = renderGrid({
+      sessions: [sessionNode("root", [], { substrate: "codex" })],
+    });
+    expect(html).toContain("codex session");
+    expect(html).not.toContain("sub-agent");
+  });
+
+  it("leaf sessions render no expander (nothing to expand)", () => {
+    const html = renderGrid({ sessions: [sessionNode("leaf")] });
+    expect(html).toContain('data-session-id="leaf"');
+    expect(html).toContain("session-leaf");
+    expect(html).not.toContain("aria-expanded");
+  });
+
+  it("the tree group has an accessible label naming the agent", () => {
+    const html = renderGrid({ sessions: [sessionNode("s1")] });
+    expect(html).toContain('role="group"');
+    expect(html).toContain("Sessions for Luna");
   });
 });

--- a/src/surface/mc/dashboard-v2/components/working-grid.css
+++ b/src/surface/mc/dashboard-v2/components/working-grid.css
@@ -82,3 +82,103 @@
 .working-grid-error {
   color: var(--bad); font-size: 12px; padding: 8px 0;
 }
+
+/* ── ST-P5 session tree ──────────────────────────────────────────────────────
+ * The per-agent session tree sits below the tile in a wrapping cell so the tile
+ * keeps its fixed-height card look and the tree flows beneath it.
+ */
+.working-tile-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.session-tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.session-row {
+  /* Indent driven by --depth (set inline per row). */
+  padding-left: calc(var(--depth, 0) * 14px);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  line-height: 1.4;
+  min-height: 18px;
+}
+
+.session-expander,
+.session-leaf {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 1px 2px;
+  margin: 0;
+  font: inherit;
+  font-size: 11px;
+  color: var(--fg-dim);
+  cursor: pointer;
+  text-align: left;
+  border-radius: 4px;
+}
+.session-leaf { cursor: default; }
+
+.session-expander:hover { color: var(--fg); }
+.session-expander:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--accent);
+  color: var(--fg);
+}
+
+.session-expander .chevron,
+.session-leaf .chevron-spacer {
+  display: inline-block;
+  width: 10px;
+  color: var(--fg-faint);
+}
+
+.session-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100px;
+}
+
+.session-child-badge {
+  display: inline-flex;
+  align-items: center;
+  min-width: 14px;
+  padding: 0 5px;
+  font-size: 9px;
+  font-weight: 500;
+  color: var(--accent);
+  background: color-mix(in oklch, var(--accent) 12%, transparent);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+}
+
+.session-state {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--fg-faint);
+}
+.session-state.state-running { color: var(--accent); }
+
+/* Visually-hidden but available to assistive tech (label-not-color-only). */
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/surface/mc/dashboard-v2/components/working-grid.tsx
+++ b/src/surface/mc/dashboard-v2/components/working-grid.tsx
@@ -1,10 +1,19 @@
 /**
- * F-9 working-agent grid (MIG-5 port).
+ * F-9 working-agent grid (MIG-5 port) + ST-P5 session-tree render.
  *
  * Renders one tile per agent with at least one active-non-blocked
  * assignment, server-sorted by `primary_state_rank ASC, updated_at DESC`.
  * Tile click opens the F-7 drill-down on the primary assignment;
  * `+N` badge is inert per Decision 6.
+ *
+ * ST-P5 (refactor §7): each tile now also renders the owning agent's SESSION
+ * TREE beneath its (unchanged) primary_assignment/state header — root sessions
+ * listed, child sessions nested with an indent + an expander. Per D5 the tree is
+ * DEFAULT-COLLAPSED: a node's children appear only when its expander is toggled
+ * (chevron + child-count badge while collapsed). Each session's display word is
+ * the DERIVED substrate-projection label (`substrateLabel` — "sub-agent" appears
+ * ONLY here, as the Claude-Code lens for a child session; the model says child
+ * session). Empty/absent `sessions` ⇒ the tile renders exactly as pre-ST-P5.
  *
  * Empty-state behaviour (Decision 7):
  *   - section hidden when focus row has entries AND grid is empty
@@ -13,14 +22,24 @@
  *
  * Keyboard: arrow keys navigate tiles when one is focused, Enter opens
  * the drill-down. Gated on the drill-down being closed (mirrors F-8 /
- * legacy F-9 listener discipline).
+ * legacy F-9 listener discipline). Session-tree expanders are native
+ * <button>s — Enter/Space toggle them for free (G-1114.F a11y bar).
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import "./working-grid.css";
 import { priorityBorderClass } from "../lib/block-reason";
 import { pickWorkingGridMode, priorityLabel } from "../lib/working-grid-display";
-import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import {
+  flattenSessionTree,
+  toggleExpanded,
+  type SessionTreeRow,
+} from "../lib/session-tree-rows";
+import { substrateLabel } from "../lib/substrate-label";
+import type {
+  WorkingAgentTile,
+  SessionTreeNode,
+} from "../hooks/use-working-agents";
 
 export interface WorkingGridProps {
   agents: WorkingAgentTile[];
@@ -47,6 +66,15 @@ export function WorkingGrid({
 }: WorkingGridProps) {
   const [focusedIdx, setFocusedIdx] = useState(-1);
   const tileRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  // ST-P5 (D5) — expansion state local to the grid, keyed by session_id. Because
+  // the key is the stable session_id, expansion SURVIVES poll refreshes: a
+  // refetch that re-supplies the same session keeps its row expanded (the Set is
+  // never reset on data change).
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
+  const onToggleExpand = useCallback((sessionId: string) => {
+    setExpanded((prev) => toggleExpanded(prev, sessionId));
+  }, []);
 
   // Clamp the focused index when the grid shrinks underneath us.
   useEffect(() => {
@@ -98,33 +126,40 @@ export function WorkingGrid({
       {mode === "tiles" && (
         <div className="working-grid">
           {agents.map((a, idx) => (
-            <button
-              key={a.agent_id}
-              ref={(el) => { tileRefs.current[idx] = el; }}
-              type="button"
-              className={`working-tile ${priorityBorderClass(a.primary_assignment.task_priority)}${idx === focusedIdx ? " focused" : ""}`}
-              onClick={() => onOpen(a.primary_assignment.id)}
-              onKeyDown={(e) => onTileKeyDown(e, idx)}
-              onFocus={() => setFocusedIdx(idx)}
-              data-agent-id={a.agent_id}
-            >
-              <div className="agent">{a.agent_name}</div>
-              <div className="task">{a.primary_assignment.task_title}</div>
-              <div className="meta">
-                {priorityLabel(a.primary_assignment.task_priority)}
-                {" · "}
-                <span className={`state-${a.primary_state}`}>{a.primary_state}</span>
-              </div>
-              {a.additional_active_count > 0 && (
-                <div
-                  className="badge"
-                  title={`${a.additional_active_count} additional active assignment(s)`}
-                  aria-hidden="true"
-                >
-                  +{a.additional_active_count}
+            <div className="working-tile-wrap" key={a.agent_id}>
+              <button
+                ref={(el) => { tileRefs.current[idx] = el; }}
+                type="button"
+                className={`working-tile ${priorityBorderClass(a.primary_assignment.task_priority)}${idx === focusedIdx ? " focused" : ""}`}
+                onClick={() => onOpen(a.primary_assignment.id)}
+                onKeyDown={(e) => onTileKeyDown(e, idx)}
+                onFocus={() => setFocusedIdx(idx)}
+                data-agent-id={a.agent_id}
+              >
+                <div className="agent">{a.agent_name}</div>
+                <div className="task">{a.primary_assignment.task_title}</div>
+                <div className="meta">
+                  {priorityLabel(a.primary_assignment.task_priority)}
+                  {" · "}
+                  <span className={`state-${a.primary_state}`}>{a.primary_state}</span>
                 </div>
-              )}
-            </button>
+                {a.additional_active_count > 0 && (
+                  <div
+                    className="badge"
+                    title={`${a.additional_active_count} additional active assignment(s)`}
+                    aria-hidden="true"
+                  >
+                    +{a.additional_active_count}
+                  </div>
+                )}
+              </button>
+              <SessionTree
+                sessions={a.sessions}
+                agentName={a.agent_name}
+                expanded={expanded}
+                onToggleExpand={onToggleExpand}
+              />
+            </div>
           ))}
         </div>
       )}
@@ -132,3 +167,100 @@ export function WorkingGrid({
   );
 }
 
+interface SessionTreeProps {
+  sessions: SessionTreeNode[];
+  agentName: string;
+  expanded: ReadonlySet<string>;
+  onToggleExpand: (sessionId: string) => void;
+}
+
+/**
+ * The per-agent session tree, rendered as a flat indented list (a nested list
+ * with expander buttons — the simplest correct ARIA per the task's a11y note,
+ * preferred over a full tree-grid role). Absent/empty ⇒ renders nothing so the
+ * tile is byte-identical to pre-ST-P5.
+ */
+function SessionTree({
+  sessions,
+  agentName,
+  expanded,
+  onToggleExpand,
+}: SessionTreeProps) {
+  // Empty/compat: no tree chrome at all when the agent has no open sessions.
+  if (!sessions || sessions.length === 0) return null;
+
+  const rows = flattenSessionTree(sessions, expanded);
+
+  return (
+    <ul
+      className="session-tree"
+      role="group"
+      aria-label={`Sessions for ${agentName}`}
+    >
+      {rows.map((row) => (
+        <SessionTreeItem
+          key={row.node.session_id}
+          row={row}
+          onToggleExpand={onToggleExpand}
+        />
+      ))}
+    </ul>
+  );
+}
+
+interface SessionTreeItemProps {
+  row: SessionTreeRow;
+  onToggleExpand: (sessionId: string) => void;
+}
+
+function SessionTreeItem({ row, onToggleExpand }: SessionTreeItemProps) {
+  const { node, depth, hasChildren, isExpanded, childCount } = row;
+  // The derived substrate-projection label — the ONLY place "sub-agent" appears.
+  const label = substrateLabel(node.substrate, node.parent_session_id !== null);
+  // Indent by depth. Inline style is the only depth-driven value; everything
+  // else is class-based (the indent is data, not a fixed set of CSS classes).
+  const indentStyle = { ["--depth" as string]: String(depth) };
+
+  return (
+    <li
+      className="session-row"
+      style={indentStyle}
+      data-session-id={node.session_id}
+      data-depth={depth}
+    >
+      {hasChildren ? (
+        // Native <button>: Enter/Space toggle for free (no hover-only
+        // affordance). aria-expanded announces the state to AT.
+        <button
+          type="button"
+          className="session-expander"
+          aria-expanded={isExpanded}
+          onClick={() => onToggleExpand(node.session_id)}
+        >
+          <span className="chevron" aria-hidden="true">
+            {isExpanded ? "▾" : "▸"}
+          </span>
+          <span className="session-label">{label}</span>
+          {!isExpanded && (
+            <span className="session-child-badge">
+              {/* Accessible text, not color-only: AT reads the count + noun. */}
+              <span className="sr-only">
+                {childCount} child {childCount === 1 ? "session" : "sessions"}
+              </span>
+              <span aria-hidden="true">{childCount}</span>
+            </span>
+          )}
+        </button>
+      ) : (
+        // Leaf: no expander. A non-interactive labelled row.
+        <span className="session-leaf">
+          <span className="chevron-spacer" aria-hidden="true" />
+          <span className="session-label">{label}</span>
+        </span>
+      )}
+      {node.state && (
+        <span className={`session-state state-${node.state}`}>{node.state}</span>
+      )}
+    </li>
+  );
+}

--- a/src/surface/mc/dashboard-v2/hooks/use-working-agents.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-working-agents.ts
@@ -19,6 +19,33 @@ import { ApiFailure, getJson } from "../lib/api";
 import type { WsClient, WsMessage } from "./use-websocket";
 import { useProjectionRefetch } from "./use-projection-refetch";
 
+/**
+ * ST-P5 — one node in an agent's session tree, mirroring the server shape
+ * (`src/surface/mc/lib/session-tree.ts` → `SessionTreeNode`). Lifecycle
+ * metadata only (ADR-0005 — no session interiors). `children` is the recursive
+ * forest of child sessions (the `initiated-by` edge: a child names its
+ * `parent_session_id`; an agent-rooted session has none).
+ */
+export interface SessionTreeNode {
+  session_id: string;
+  /** Self-ref to the spawning session; null ⇒ agent-rooted (a tree root). */
+  parent_session_id: string | null;
+  /** The substrate this session runs on (claude-code | codex | …). */
+  substrate: string;
+  /** Lifecycle state — a display string the renderer derives badges from. */
+  state: string;
+  /** Session start (ISO-8601). */
+  started_at: string;
+  /** Terminal timestamp (ISO-8601), or null while the session is open. */
+  ended_at: string | null;
+  /** Owning agent display name, when known (a session is NOT an agent). */
+  agent_name?: string | null;
+  /** Title of the work the session is doing, when known. */
+  task_title?: string | null;
+  /** Child sessions (recursive). Empty array for a leaf. */
+  children: SessionTreeNode[];
+}
+
 export interface WorkingAgentTile {
   agent_id: string;
   agent_name: string;
@@ -33,6 +60,14 @@ export interface WorkingAgentTile {
     updated_at: string;
   };
   additional_active_count: number;
+  /**
+   * ST-P5 — the owning agent's session tree (refactor §7), mirroring the server
+   * projection's `sessions` field. ADDITIVE: every field above is byte-compatible
+   * with the pre-ST-P5 DTO. Absent/empty ⇒ the tile renders exactly as before
+   * (the working grid shows no tree). Defaulted to `[]` at the fetch boundary so
+   * older responses (or a dispatch-only agent with no open sessions) are safe.
+   */
+  sessions: SessionTreeNode[];
 }
 
 interface ListWorkingAgentsResponse {
@@ -75,7 +110,11 @@ export function useWorkingAgents(ws: WsClient): WorkingAgentsState {
         signal ? { signal } : undefined
       );
       if (!aliveRef.current || genRef.current !== myGen) return;
-      setAgents(body.agents ?? []);
+      // Normalize `sessions` to [] per tile so a pre-ST-P5 response (no
+      // `sessions` field) renders exactly as before — empty/compat path.
+      setAgents(
+        (body.agents ?? []).map((a) => ({ ...a, sessions: a.sessions ?? [] }))
+      );
       setError(null);
       bootedRef.current = true;
     } catch (e) {

--- a/src/surface/mc/dashboard-v2/lib/session-tree-rows.ts
+++ b/src/surface/mc/dashboard-v2/lib/session-tree-rows.ts
@@ -1,0 +1,84 @@
+/**
+ * ST-P5 — tree → flat-render-rows helper for the working grid.
+ *
+ * The working grid renders the session forest as an indented list. React maps
+ * cleanly over a FLAT array, so this pure helper walks the recursive
+ * {@link SessionTreeNode} forest depth-first and emits only the rows currently
+ * VISIBLE for a given expansion state. Per D5 (docs/refactor-mc-session-tree.md
+ * §3) the default is COLLAPSED: a node's children are emitted only when the
+ * node's `session_id` is present in the `expanded` Set.
+ *
+ * PURE + DOM-free so expansion logic is unit-testable without a renderer
+ * (`__tests__/session-tree-rows.test.ts`). The component owns the `expanded`
+ * Set as local state keyed by `session_id` (D5) so it survives poll refreshes.
+ */
+
+import type { SessionTreeNode } from "../hooks/use-working-agents";
+
+/** One visible row in the flattened tree render. */
+export interface SessionTreeRow {
+  /** The session this row renders. */
+  node: SessionTreeNode;
+  /** Nesting depth — 0 for roots, +1 per level. Drives the indent. */
+  depth: number;
+  /** Whether this node has any child sessions (drives the expander). */
+  hasChildren: boolean;
+  /** Whether this node is currently expanded (only meaningful if hasChildren). */
+  isExpanded: boolean;
+  /** Number of DIRECT children — shown in the collapsed child-count badge. */
+  childCount: number;
+}
+
+/**
+ * Defense-in-depth recursion cap. Mirrors the assembler's MAX_TREE_DEPTH
+ * (`src/surface/mc/lib/session-tree.ts`): even though the forest is already
+ * cycle-broken upstream, the flatten walk caps depth so a pathological tree can
+ * never blow the stack on the render path.
+ */
+const MAX_RENDER_DEPTH = 64;
+
+/**
+ * Flatten a session forest into the visible render rows for `expanded`.
+ *
+ * @param forest    root session nodes (an agent's session tree)
+ * @param expanded  Set of `session_id`s whose children should be shown
+ */
+export function flattenSessionTree(
+  forest: SessionTreeNode[],
+  expanded: ReadonlySet<string>
+): SessionTreeRow[] {
+  const rows: SessionTreeRow[] = [];
+
+  function walk(nodes: SessionTreeNode[], depth: number): void {
+    if (depth > MAX_RENDER_DEPTH) return;
+    for (const node of nodes) {
+      const childCount = node.children.length;
+      const hasChildren = childCount > 0;
+      // A leaf is never "expanded" — there is nothing to expand. Only a node
+      // with children reports its expansion state.
+      const isExpanded = hasChildren && expanded.has(node.session_id);
+      rows.push({ node, depth, hasChildren, isExpanded, childCount });
+      if (isExpanded) walk(node.children, depth + 1);
+    }
+  }
+
+  walk(forest, 0);
+  return rows;
+}
+
+/**
+ * Toggle a session's expansion in an immutable, copy-on-write fashion — returns
+ * a NEW Set so React state updates trigger a re-render. The grid keeps the
+ * expansion Set as local state keyed by `session_id` (D5); because the key is
+ * the stable `session_id`, expansion survives poll refreshes (a refetch that
+ * re-supplies the same session keeps its row expanded).
+ */
+export function toggleExpanded(
+  expanded: ReadonlySet<string>,
+  sessionId: string
+): Set<string> {
+  const next = new Set(expanded);
+  if (next.has(sessionId)) next.delete(sessionId);
+  else next.add(sessionId);
+  return next;
+}

--- a/src/surface/mc/dashboard-v2/lib/substrate-label.ts
+++ b/src/surface/mc/dashboard-v2/lib/substrate-label.ts
@@ -1,0 +1,44 @@
+/**
+ * ST-P5 — substrate-projection DISPLAY label (refactor §7, CONTEXT.md §Sessions).
+ *
+ * THE DOMAIN RULE: Mission Control's model + schema speak **session** /
+ * **child session**. The word **"sub-agent"** is NOT a domain entity — it is the
+ * *Claude-Code-lens* display label for a `claude-code` child session (a session
+ * with a `parent_session_id`). It is derived here, at render time, and appears
+ * nowhere in the model. Any other substrate (Codex, Gemini, …) projects its own
+ * word: we render the substrate string itself ("codex session").
+ *
+ * This is a PURE function (no React, no I/O) so the matrix is unit-testable in
+ * isolation — see `__tests__/substrate-label.test.ts`.
+ *
+ * Matrix:
+ *   claude-code + hasParent → "sub-agent"           (CC lens for a child session)
+ *   claude-code + root      → "session"
+ *   <other>     + (either)  → "<other> session"      (substrate-neutral)
+ *   missing/blank substrate → "session"              (defensive fallback)
+ */
+
+/** The substrate this label is the Claude-Code lens word for. */
+const CLAUDE_CODE = "claude-code";
+
+/**
+ * Derive the display label for a session row.
+ *
+ * @param substrate  the session's substrate (`claude-code` | `codex` | …)
+ * @param hasParent  true iff the session has a `parent_session_id` (a child)
+ */
+export function substrateLabel(substrate: string, hasParent: boolean): string {
+  const s = substrate.trim();
+
+  // Missing/blank substrate: render a bare "session" rather than " session".
+  if (s.length === 0) return "session";
+
+  if (s === CLAUDE_CODE) {
+    // The ONLY place "sub-agent" appears: the CC-lens label for a child session.
+    return hasParent ? "sub-agent" : "session";
+  }
+
+  // Every other substrate is substrate-neutral: the substrate string + "session"
+  // ("codex session"). No per-substrate child word — only Claude Code has one.
+  return `${s} session`;
+}


### PR DESCRIPTION
## ST-P5 — frontend session tree (final phase of #952)

The working grid now renders each agent's **session tree** beneath its tile: root sessions listed, child sessions nested behind an expander. This is the M7 surface half of the session-tree refactor (`docs/refactor-mc-session-tree.md`) — ST-P4 (#974) projected the tree on the API; ST-P5 renders it.

`Closes #975`. Refs #952.

### Salvage + finish

A prior build agent died on an **API rate-limit** mid-task; its work was committed as a `wip(mc): ST-P5 SALVAGED` commit **before any gate ran** (completeness unknown). This PR is the **verify-and-finish** pass on top of that salvage.

**Outcome:** the salvaged implementation was already complete and correct against the full ST-P5 spec — **no code changes were needed**. The finish commit is an empty marker recording that every gate now runs green and each spec point is met. The suspected gaps (a11y wiring, expansion-state persistence across poll refreshes) were checked and found already satisfied by the salvage.

### What the salvage delivered (verified against spec)

- **`lib/substrate-label.ts`** — pure `(substrate, hasParent) → label`: `claude-code`+parent → `"sub-agent"`, `claude-code` root → `"session"`, other substrate → `"<substrate> session"`, blank → `"session"`. Full matrix unit-tested. `"sub-agent"` appears **only** here, as the Claude-Code display lens (CONTEXT.md §Sessions / §Sub-agent — the model says *child session*).
- **`lib/session-tree-rows.ts`** — pure tree+expansion → visible rows with depth; **collapsed by default** (D5); immutable copy-on-write `toggleExpanded`. DOM-free, unit-tested.
- **`components/working-grid.tsx`** — per-tile session tree; roots listed, children behind an expander (chevron + child-count badge while collapsed). Existing tile header (`primary_assignment`/`state`) untouched.
- **A11y** — expander is a real `<button>` (Enter/Space for free), `aria-expanded`, `role="group"` with an accessible label naming the agent, `sr-only` child-count text (not color-only / not hover-only).
- **Expansion state** — local, keyed by `session_id` in a `Set`, **survives poll refetches** (the Set is never reset on data change; stable-key lookups keep expanded nodes open across re-renders).
- **Compat** — absent/empty `sessions` ⇒ the tile renders **exactly as pre-ST-P5** (explicit static-markup test asserts no tree chrome emitted).
- **`use-working-agents.ts`** — additive `sessions: SessionTreeNode[]` DTO field mirroring the ST-P4 server shape, defaulted to `[]` at the fetch boundary for old/empty responses.
- **`network-detail-display.test.ts`** — kept the **minimal** +1 line: the shared `WorkingAgentTile` fixture gained the now-required `sessions: []`. **No network-* component touched** (ADR-0007) — this is a test fixture sharing the DTO type, not a component change.
- **No new deps.**

### Gates (all green)

| Gate | Result |
|---|---|
| `bunx tsc --noEmit` | 0 errors |
| `bun run lint` | 0 errors (only pre-existing unrelated warnings) |
| `bun test` (full) | **6094 pass, 1 skip, 0 fail** |
| `bun run build:dashboard` | entry **1.24 MB**, `network-canvas` chunk **3.50 MB** (stays code-split) |
| `scripts/check-carveouts.sh` | PASS |

ST-P5 targeted suite: **48 pass / 0 fail** across the four touched test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)