### PR TITLE
chore: bump to v5.8.0 — MC session-tree + capability offerings

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.7.0"
+version: "5.8.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump for the v5.8.0 release: the complete MC session-tree refactor (#952, 7 PRs) + capability offerings CO-1..CO-6. 19 commits since v5.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)