### PR TITLE
feat(mc): U0.1 — sideband client + server proxy + loopback-enforced mc.sideband (P-14)

### DIFF
--- a/docs/config-layout/stacks/research.yaml
+++ b/docs/config-layout/stacks/research.yaml
@@ -177,6 +177,13 @@ mc:
   dbPath: ""                       # empty = per-slug default; set explicitly to adopt an existing db
   port: 0                          # 0 = MC default (8767); set when running panes for several stacks
   configPath: ""                   # optional MC yaml for hooks/ws/log tuning (db/port ignored when embedded)
+  # P-14 U0.1 — Tier-3 sideband endpoint (signal cortex-sideband.md §2/§3/§8).
+  # MC proxies /api/observability/* to this base URL SERVER-SIDE; the browser
+  # only ever talks to MC. LOOPBACK-ENFORCED: the sideband is a local-only
+  # daemon (binds 127.0.0.1, tokenless). A non-loopback value (0.0.0.0, a LAN
+  # IP, a hostname) is REFUSED at config-parse time — the daemon won't boot.
+  # Override only to change the port or front it with a same-host reverse proxy.
+  sideband: "http://127.0.0.1:9092"
 
 # -----------------------------------------------------------------------------
 # cockpit — G-1113 live-refresh loop (plan ingest → reconcile → attention).

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -141,7 +141,7 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
       encryption: { payload: "off", at_rest: "off" },
       transport: { mtls: "off" },
     },
-    mc: { enabled: false, configPath: "", dbPath: "", port: 0 },
+    mc: { enabled: false, configPath: "", dbPath: "", port: 0, sideband: "http://127.0.0.1:9092" },
     cockpit: {
       enabled: false,
       docsDir: "docs",

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -126,6 +126,7 @@ const TEST_CONFIG: AgentConfig = {
     configPath: "",
     dbPath: "",
     port: 0,
+    sideband: "http://127.0.0.1:9092",
   },
   networksDir: "./networks",
   networks: [],

--- a/src/common/sideband/__tests__/loopback.test.ts
+++ b/src/common/sideband/__tests__/loopback.test.ts
@@ -1,0 +1,86 @@
+/**
+ * P-14 U0.1 — loopback enforcement matrix (signal cortex-sideband.md §3/§8).
+ *
+ * The invariant under test: MC NEVER proxies to a non-loopback sideband. The
+ * gate is fail-closed — anything not provably loopback is REFUSED.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  checkLoopbackSideband,
+  isLoopbackSideband,
+  DEFAULT_SIDEBAND_URL,
+} from "../loopback";
+
+describe("checkLoopbackSideband — accept set (§3 loopback boundary)", () => {
+  const accepted = [
+    ["default contract URL", DEFAULT_SIDEBAND_URL],
+    ["127.0.0.1 with port", "http://127.0.0.1:9092"],
+    ["127.0.0.1 no port", "http://127.0.0.1"],
+    ["127.0.0.0/8 block member", "http://127.0.0.2:9092"],
+    ["127.x high octet", "http://127.255.255.254:9092"],
+    ["localhost", "http://localhost:9092"],
+    ["localhost mixed case", "http://LocalHost:9092"],
+    ["IPv6 ::1 bracketed", "http://[::1]:9092"],
+    ["IPv6 ::1 no port", "http://[::1]"],
+    ["IPv6 expanded loopback", "http://[0:0:0:0:0:0:0:1]:9092"],
+    ["IPv4-mapped IPv6 loopback", "http://[::ffff:127.0.0.1]:9092"],
+    ["https loopback (reverse proxy)", "https://127.0.0.1:9443"],
+    ["path suffix preserved", "http://127.0.0.1:9092/sideband"],
+  ] as const;
+
+  for (const [label, url] of accepted) {
+    test(`accepts ${label}: ${url}`, () => {
+      const res = checkLoopbackSideband(url);
+      expect(res.ok).toBe(true);
+      expect(isLoopbackSideband(url)).toBe(true);
+    });
+  }
+});
+
+describe("checkLoopbackSideband — reject set (fail closed)", () => {
+  const rejected = [
+    ["unspecified IPv4 bind", "http://0.0.0.0:9092"],
+    ["unspecified IPv6 bind", "http://[::]:9092"],
+    ["LAN private 192.168", "http://192.168.1.50:9092"],
+    ["LAN private 10.x", "http://10.0.0.5:9092"],
+    ["LAN private 172.16", "http://172.16.0.9:9092"],
+    ["public IPv4", "http://203.0.113.7:9092"],
+    ["routable IPv6", "http://[2001:db8::1]:9092"],
+    ["arbitrary hostname", "http://sideband.internal:9092"],
+    ["evil hostname", "http://evil.com:9092"],
+    ["subdomain of localhost (not loopback)", "http://localhost.evil.com:9092"],
+    ["userinfo smuggling", "http://127.0.0.1@evil.com:9092"],
+    ["userinfo on loopback host", "http://user:pass@127.0.0.1:9092"],
+    ["non-http scheme file", "file:///etc/passwd"],
+    ["non-http scheme ws", "ws://127.0.0.1:9092"],
+    ["non-http scheme javascript", "javascript:alert(1)"],
+    ["out-of-range octet", "http://127.0.0.999:9092"],
+    ["not a url", "not-a-url"],
+    ["empty string", ""],
+    ["whitespace only", "   "],
+  ] as const;
+
+  for (const [label, url] of rejected) {
+    test(`refuses ${label}: ${url}`, () => {
+      const res = checkLoopbackSideband(url);
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.reason.length).toBeGreaterThan(0);
+      }
+      expect(isLoopbackSideband(url)).toBe(false);
+    });
+  }
+});
+
+describe("checkLoopbackSideband — returns parsed URL on accept", () => {
+  test("exposes the parsed URL for the proxy to build request URLs from", () => {
+    const res = checkLoopbackSideband("http://127.0.0.1:9092");
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.url.hostname).toBe("127.0.0.1");
+      expect(res.url.port).toBe("9092");
+      expect(res.url.protocol).toBe("http:");
+    }
+  });
+});

--- a/src/common/sideband/__tests__/proxy.test.ts
+++ b/src/common/sideband/__tests__/proxy.test.ts
@@ -1,0 +1,212 @@
+/**
+ * P-14 U0.1 — sideband server-side proxy: routing, error mapping, timeout,
+ * body cap, header hygiene (signal cortex-sideband.md §2/§3/§4/§8).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { proxySideband, type SidebandProxyConfig } from "../proxy";
+
+const BASE = "http://127.0.0.1:9092";
+
+/** Build a fetch stub that records the call and returns a canned Response. */
+interface RecordedCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+function stubFetch(
+  handler: (url: string, init: RequestInit | undefined) => Response | Promise<Response>,
+): { fetchImpl: typeof fetch; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    calls.push({ url, init });
+    return handler(url, init);
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function cfg(over: Partial<SidebandProxyConfig> & { fetchImpl: typeof fetch }): SidebandProxyConfig {
+  return { baseUrl: BASE, ...over };
+}
+
+describe("proxySideband — path allowlist (§2 endpoint surface)", () => {
+  test("forwards /traces with query", async () => {
+    const { fetchImpl, calls } = stubFetch(() =>
+      Response.json({ correlation_id: "abc", backend: "victoria", spans: [] }),
+    );
+    const res = await proxySideband("GET", "/traces", "correlation_id=abcd", cfg({ fetchImpl }));
+    expect(res.status).toBe(200);
+    expect(calls[0]!.url).toBe("http://127.0.0.1:9092/traces?correlation_id=abcd");
+  });
+
+  test("forwards /logs with query", async () => {
+    const { fetchImpl, calls } = stubFetch(() =>
+      Response.json({ correlation_id: "abc", backend: "victoria", logs: [] }),
+    );
+    await proxySideband("GET", "/logs", "correlation_id=abcd", cfg({ fetchImpl }));
+    expect(calls[0]!.url).toBe("http://127.0.0.1:9092/logs?correlation_id=abcd");
+  });
+
+  test("forwards /traces/{id}/timeline", async () => {
+    const id = "0123456789abcdef0123456789abcdef";
+    const { fetchImpl, calls } = stubFetch(() =>
+      Response.json({ correlation_id: id, backend: "victoria", entries: [] }),
+    );
+    const res = await proxySideband("GET", `/traces/${id}/timeline`, "", cfg({ fetchImpl }));
+    expect(res.status).toBe(200);
+    expect(calls[0]!.url).toBe(`http://127.0.0.1:9092/traces/${id}/timeline`);
+  });
+
+  test("forwards /healthz", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({ status: "ok", backend: "victoria" }));
+    await proxySideband("GET", "/healthz", "", cfg({ fetchImpl }));
+    expect(calls[0]!.url).toBe("http://127.0.0.1:9092/healthz");
+  });
+
+  test("refuses an unknown endpoint with structured 404", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({}));
+    const res = await proxySideband("GET", "/admin/secrets", "", cfg({ fetchImpl }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("internal_error");
+    expect(calls.length).toBe(0); // never reached upstream
+  });
+
+  test("refuses a path-traversal timeline id", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({}));
+    const res = await proxySideband("GET", "/traces/..%2f..%2fadmin/timeline", "", cfg({ fetchImpl }));
+    expect(res.status).toBe(404);
+    expect(calls.length).toBe(0);
+  });
+
+  test("refuses non-GET (read-only sideband, §9)", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({}));
+    const res = await proxySideband("POST", "/traces", "", cfg({ fetchImpl }));
+    expect(res.status).toBe(405);
+    expect(calls.length).toBe(0);
+  });
+});
+
+describe("proxySideband — header hygiene (§3 tokenless)", () => {
+  test("sends a bare GET with accept only; no auth headers", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({ spans: [] }));
+    await proxySideband("GET", "/traces", "correlation_id=x", cfg({ fetchImpl }));
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers).toEqual({ accept: "application/json" });
+  });
+});
+
+describe("proxySideband — error mapping (§4 failure semantics)", () => {
+  test("relays the sideband's own SidebandError + deep_link verbatim on 503", async () => {
+    const { fetchImpl } = stubFetch(() =>
+      Response.json(
+        { code: "backend_unavailable", message: "backend down", deep_link: "https://grafana/x" },
+        { status: 503 },
+      ),
+    );
+    const res = await proxySideband("GET", "/traces", "correlation_id=x", cfg({ fetchImpl }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("backend_unavailable");
+    expect(body.deep_link).toBe("https://grafana/x");
+  });
+
+  test("maps connection refusal to structured 503 (not a 500 splat)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:9092");
+    }) as unknown as typeof fetch;
+    const res = await proxySideband("GET", "/traces", "correlation_id=x", cfg({ fetchImpl }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("backend_unavailable");
+    expect(body.message).toContain("interior capture not available");
+  });
+
+  test("maps timeout/abort to 504 with retry_after", async () => {
+    const fetchImpl = (async () => {
+      const e = new Error("timed out");
+      e.name = "TimeoutError";
+      throw e;
+    }) as unknown as typeof fetch;
+    const res = await proxySideband("GET", "/traces", "correlation_id=x", cfg({ fetchImpl }));
+    expect(res.status).toBe(504);
+    const body = await res.json();
+    expect(body.code).toBe("backend_timeout");
+    expect(body.retry_after_seconds).toBeGreaterThan(0);
+    expect(res.headers.get("retry-after")).toBeTruthy();
+  });
+});
+
+describe("proxySideband — loopback re-enforcement at request boundary", () => {
+  test("refuses a non-loopback base URL without ever fetching", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({}));
+    const res = await proxySideband(
+      "GET",
+      "/traces",
+      "correlation_id=x",
+      cfg({ fetchImpl, baseUrl: "http://192.168.1.5:9092" }),
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("backend_unavailable");
+    expect(calls.length).toBe(0);
+  });
+});
+
+describe("proxySideband — body cap", () => {
+  test("refuses an oversized body (Content-Length) with structured 503", async () => {
+    const { fetchImpl } = stubFetch(
+      () =>
+        new Response("x".repeat(100), {
+          status: 200,
+          headers: { "content-type": "application/json", "content-length": "100" },
+        }),
+    );
+    const res = await proxySideband("GET", "/traces", "correlation_id=x", cfg({ fetchImpl, maxBodyBytes: 10 }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("backend_unavailable");
+  });
+
+  test("refuses an oversized streamed body without Content-Length", async () => {
+    const big = "y".repeat(1000);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(big));
+        controller.close();
+      },
+    });
+    const { fetchImpl } = stubFetch(
+      () => new Response(stream, { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    const res = await proxySideband("GET", "/logs", "correlation_id=x", cfg({ fetchImpl, maxBodyBytes: 10 }));
+    expect(res.status).toBe(503);
+  });
+
+  test("passes a small body through unchanged", async () => {
+    const payload = { correlation_id: "x", backend: "victoria", spans: [{ name: "tool.read" }] };
+    const { fetchImpl } = stubFetch(() => Response.json(payload));
+    const res = await proxySideband("GET", "/traces", "correlation_id=x", cfg({ fetchImpl, maxBodyBytes: 1024 }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(payload);
+  });
+});
+
+describe("proxySideband — reverse-proxy base path (§8)", () => {
+  test("preserves a base URL path prefix", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({ spans: [] }));
+    await proxySideband(
+      "GET",
+      "/traces",
+      "correlation_id=x",
+      cfg({ fetchImpl, baseUrl: "http://127.0.0.1:9092/sideband" }),
+    );
+    expect(calls[0]!.url).toBe("http://127.0.0.1:9092/sideband/traces?correlation_id=x");
+  });
+});

--- a/src/common/sideband/loopback.ts
+++ b/src/common/sideband/loopback.ts
@@ -1,0 +1,164 @@
+/**
+ * Sideband loopback enforcement (P-14 U0.1).
+ *
+ * The signal cortex-sideband contract (`signal/docs/contract/cortex-sideband.md`
+ * §3 "Auth model — loopback only" + §8 "Cortex-side consumer") makes the
+ * sideband a LOCAL-ONLY daemon by design: it binds `127.0.0.1`, carries no
+ * token, and the security boundary is the host process boundary, not a network
+ * one. §8 states the cortex-side consumer "MUST refuse to set a non-loopback
+ * host (principals on shared networks could otherwise self-foot-gun)".
+ *
+ * This module is the fail-CLOSED gate that enforces that invariant. It is the
+ * single source of truth for "is this sideband URL loopback?", called BOTH at
+ * config-parse time (so a non-loopback `mc.sideband` value is rejected before
+ * the daemon ever boots) AND at the proxy request boundary (so a config value
+ * that somehow mutated at runtime can never cause MC to proxy off-host). The
+ * invariant: **MC NEVER proxies to a non-loopback sideband.** When in doubt,
+ * REFUSE — never fall open.
+ *
+ * ## Accept set (per §3 — the kernel-enforced loopback boundary)
+ *
+ * - `127.0.0.1` and the whole IPv4 loopback block `127.0.0.0/8` (e.g.
+ *   `127.0.0.2`). The kernel routes the entire `/8` to the loopback device.
+ * - `::1` (IPv6 loopback), in bracketed URL form `[::1]`, including the
+ *   IPv4-mapped form `[::ffff:127.0.0.1]`.
+ * - `localhost` — the conventional loopback hostname. We accept the literal
+ *   token only; we do NOT perform DNS resolution (resolution is mutable and
+ *   spoofable — accepting the literal keeps the gate deterministic and
+ *   fail-closed, matching the "refuse non-loopback HOST" framing of §8 which
+ *   is about the configured value, not a resolved address).
+ *
+ * ## Reject set (everything else — fail closed)
+ *
+ * - `0.0.0.0` / `[::]` — the unspecified "all interfaces" bind; NOT loopback.
+ * - Any LAN / public IP (`192.168.*`, `10.*`, `172.16-31.*`, routable IPv4/6).
+ * - Any non-`localhost` hostname (`evil.com`, `sideband.internal`, …).
+ * - Non-`http:`/`https:` schemes, malformed URLs, userinfo in the URL.
+ */
+
+/** Structured outcome of a loopback check. `ok:false` carries a render-safe reason. */
+export type LoopbackCheck =
+  | { ok: true; url: URL }
+  | { ok: false; reason: string };
+
+/**
+ * The IPv4 loopback block is `127.0.0.0/8` — the kernel routes the entire `/8`
+ * to the loopback device, so `127.0.0.2` is as loopback as `127.0.0.1`.
+ */
+function isIpv4Loopback(host: string): boolean {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!m) return false;
+  const octets = m.slice(1, 5).map((s) => Number(s));
+  // Reject out-of-range octets (e.g. `127.0.0.999`) — a malformed address is
+  // not a valid loopback address; fail closed.
+  if (octets.some((o) => o < 0 || o > 255)) return false;
+  return octets[0] === 127;
+}
+
+/** Parse a 1-2 hextet group into an octet pair. Helper for IPv4-mapped IPv6. */
+function hextetToOctets(hex: string): [number, number] {
+  const v = parseInt(hex, 16);
+  return [(v >> 8) & 0xff, v & 0xff];
+}
+
+/**
+ * IPv6 loopback: `::1`, plus the IPv4-mapped loopback `::ffff:127.0.0.1`.
+ *
+ * `url.hostname` for an IPv6 literal keeps the surrounding brackets AND
+ * normalizes the address (the WHATWG URL parser compresses zero-runs and
+ * lowercases hex): `[0:0:0:0:0:0:0:1]` → `[::1]`, `[::ffff:127.0.0.1]` →
+ * `[::ffff:7f00:1]`. We strip the brackets and accept both the canonical
+ * `::1` and the IPv4-mapped-loopback hex form `::ffff:7f00:1` (== `127.0.0.1`).
+ */
+function isIpv6Loopback(host: string): boolean {
+  let h = host.toLowerCase();
+  if (h.startsWith("[") && h.endsWith("]")) {
+    h = h.slice(1, -1);
+  }
+  if (h === "::1" || h === "0:0:0:0:0:0:0:1") return true;
+  // IPv4-mapped IPv6 dotted form: `::ffff:127.0.0.1`.
+  const mappedDotted = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(h);
+  if (mappedDotted?.[1] !== undefined) return isIpv4Loopback(mappedDotted[1]);
+  // IPv4-mapped IPv6 hex form (post-normalization): `::ffff:7f00:1` where the
+  // last two hextets encode the 32-bit IPv4 address. `7f00:0001` → 127.0.0.1.
+  const mappedHex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(h);
+  if (mappedHex?.[1] !== undefined && mappedHex[2] !== undefined) {
+    const [a, b] = hextetToOctets(mappedHex[1]);
+    const [c, d] = hextetToOctets(mappedHex[2]);
+    return isIpv4Loopback(`${a}.${b}.${c}.${d}`);
+  }
+  return false;
+}
+
+/**
+ * Decide whether a sideband base URL points at a loopback host. Returns a
+ * structured result so callers can surface a render-friendly reason rather
+ * than a bare boolean.
+ *
+ * Fail-closed: any parse failure, unexpected scheme, or non-loopback host is a
+ * REFUSAL. There is no path that returns `ok:true` for a host the kernel would
+ * route off the loopback device.
+ */
+export function checkLoopbackSideband(raw: string): LoopbackCheck {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    return { ok: false, reason: "sideband URL is empty" };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { ok: false, reason: `sideband URL is not a valid URL: ${raw}` };
+  }
+
+  // Only HTTP(S) — the sideband is an HTTP daemon. Reject `file:`, `ws:`,
+  // `javascript:`, etc. up front.
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return {
+      ok: false,
+      reason: `sideband URL must be http(s), got "${url.protocol}"`,
+    };
+  }
+
+  // Never accept embedded credentials — they have no place pointing at a
+  // tokenless loopback daemon, and `user@host` forms are a classic way to
+  // smuggle a different effective host past a naive check.
+  if (url.username !== "" || url.password !== "") {
+    return { ok: false, reason: "sideband URL must not contain userinfo" };
+  }
+
+  const host = url.hostname;
+  if (host === "") {
+    return { ok: false, reason: "sideband URL has no host" };
+  }
+
+  const lowered = host.toLowerCase();
+  const loopback =
+    lowered === "localhost" ||
+    isIpv4Loopback(host) ||
+    isIpv6Loopback(host);
+
+  if (!loopback) {
+    return {
+      ok: false,
+      reason:
+        `sideband host "${host}" is not loopback — MC refuses to proxy to a ` +
+        `non-loopback sideband (the sideband is a local-only daemon; see ` +
+        `cortex-sideband.md §3/§8)`,
+    };
+  }
+
+  return { ok: true, url };
+}
+
+/**
+ * Boolean convenience wrapper for callers that only need yes/no.
+ * Prefer {@link checkLoopbackSideband} where the refusal reason is useful
+ * (config parse error message, proxy refusal body).
+ */
+export function isLoopbackSideband(raw: string): boolean {
+  return checkLoopbackSideband(raw).ok;
+}
+
+/** The contract default — the sideband's loopback bind on its default port (§2, §6.1). */
+export const DEFAULT_SIDEBAND_URL = "http://127.0.0.1:9092";

--- a/src/common/sideband/proxy.ts
+++ b/src/common/sideband/proxy.ts
@@ -1,0 +1,280 @@
+/**
+ * Sideband server-side proxy (P-14 U0.1).
+ *
+ * MC's browser dashboard NEVER talks to the sideband directly — that would
+ * either require a CORS opening on a loopback-only daemon (impossible) or a
+ * non-loopback bind (forbidden, §3/§8). Instead the MC server proxies
+ * `/api/observability/*` → the configured sideband base URL **server-side**.
+ * The browser only ever talks to MC (same origin); MC talks to
+ * `127.0.0.1:9092`.
+ *
+ * Responsibilities:
+ *  - Re-check the loopback invariant at the request boundary (cheap; the config
+ *    value could in theory have mutated since parse). Fail CLOSED.
+ *  - Allowlist the exact endpoint surface the contract defines (§2): the
+ *    `/traces`, `/logs`, `/traces/{id}/timeline`, `/healthz` reads. Anything
+ *    else is refused (the sideband is read-only; never forward an unknown path).
+ *  - Forward GET only (the sideband has no write endpoints — §9 non-goals).
+ *  - Bound the request with a timeout and the response body with a size cap, so
+ *    a slow or chatty sideband can't hang or OOM the MC process.
+ *  - Never forward auth-sensitive headers — the sideband is tokenless (§3); MC
+ *    sends a bare GET. Cookies / Authorization the browser sent to MC stay at
+ *    MC and are NOT relayed.
+ *  - Map every failure to a structured {@link SidebandError} body (NOT a 500
+ *    splat) so the frontend (#933) can render "interior capture not available"
+ *    honestly and surface the `deep_link` when the sideband supplied one.
+ */
+
+import { checkLoopbackSideband } from "./loopback";
+
+/**
+ * Uniform error body for non-2xx responses, mirroring signal's
+ * `SidebandError` (`signal/src/lib/sideband/types.ts`). Cortex renders
+ * `deep_link` as the "Tier 3 unavailable — open in {backend}" affordance
+ * (contract §4). The `code` set is pinned to the contract enum so the #933
+ * renderer can switch on it.
+ */
+export interface SidebandError {
+  code:
+    | "invalid_correlation_id"
+    | "backend_unavailable"
+    | "backend_timeout"
+    | "internal_error";
+  message: string;
+  deep_link?: string;
+  retry_after_seconds?: number;
+}
+
+export interface SidebandProxyConfig {
+  /** Configured sideband base URL (`mc.sideband`). Loopback-enforced. */
+  baseUrl: string;
+  /** Per-request timeout in ms. Mirrors the contract consumer's 8s budget (§8). */
+  timeoutMs?: number;
+  /** Max bytes to read from a sideband response body. Guards against OOM. */
+  maxBodyBytes?: number;
+  /**
+   * Fetch override for tests. Production uses the global `fetch`. Typed loosely
+   * to match the global's signature without dragging in DOM lib types.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+/** Default per-request timeout — the contract consumer pseudocode uses 8s (§8). */
+export const DEFAULT_TIMEOUT_MS = 8_000;
+/** Default response body cap — Tier-3 single-task payloads are small; 8 MiB is generous. */
+export const DEFAULT_MAX_BODY_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Endpoints the proxy is allowed to forward, expressed as the suffix AFTER the
+ * `/api/observability` prefix. The contract's read surface (§2):
+ *   GET /traces?correlation_id=…
+ *   GET /logs?correlation_id=…
+ *   GET /traces/{trace_id}/timeline
+ *   GET /healthz
+ *
+ * `traces` and `logs` are exact (query carries the id); `traces/{id}/timeline`
+ * is a 3-segment shape validated structurally. Everything else is refused.
+ */
+function mapAllowedPath(suffix: string): string | null {
+  // Strip a single leading slash for matching.
+  const s = suffix.startsWith("/") ? suffix.slice(1) : suffix;
+
+  if (s === "traces") return "/traces";
+  if (s === "logs") return "/logs";
+  if (s === "healthz") return "/healthz";
+
+  // traces/{trace_id}/timeline — exactly 3 segments, middle is the id.
+  const segs = s.split("/");
+  if (segs.length === 3 && segs[0] === "traces" && segs[2] === "timeline") {
+    const id = segs[1] ?? "";
+    // The id is reflected into the upstream path; keep it to a hex-ish token so
+    // a hostile suffix can't inject extra path/query. The sideband itself does
+    // full `invalid_correlation_id` validation (§4); this is a cheap shape gate.
+    if (/^[0-9a-fA-F]{1,64}$/.test(id)) {
+      return `/traces/${id}/timeline`;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+function errorResponse(err: SidebandError, status: number): Response {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (typeof err.retry_after_seconds === "number") {
+    headers["retry-after"] = String(err.retry_after_seconds);
+  }
+  return new Response(JSON.stringify(err), { status, headers });
+}
+
+/**
+ * Proxy a `/api/observability/*` request to the configured sideband.
+ *
+ * @param suffix the path AFTER `/api/observability` (e.g. `/traces`,
+ *   `/traces/abc.../timeline`). The caller strips the prefix.
+ * @param search the original query string (without `?`), forwarded verbatim
+ *   for the allowlisted query-carrying endpoints.
+ */
+export async function proxySideband(
+  method: string,
+  suffix: string,
+  search: string,
+  config: SidebandProxyConfig,
+): Promise<Response> {
+  // §9 non-goals: the sideband is read-only. GET only.
+  if (method !== "GET") {
+    return errorResponse(
+      { code: "internal_error", message: `method ${method} not allowed; sideband is read-only` },
+      405,
+    );
+  }
+
+  // Re-enforce loopback at the request boundary — fail closed. Config could in
+  // theory have mutated since parse; the proxy must never reach a non-loopback host.
+  const loopback = checkLoopbackSideband(config.baseUrl);
+  if (!loopback.ok) {
+    return errorResponse(
+      {
+        code: "backend_unavailable",
+        message: `interior capture not available — sideband endpoint refused: ${loopback.reason}`,
+      },
+      503,
+    );
+  }
+
+  const upstreamPath = mapAllowedPath(suffix);
+  if (upstreamPath === null) {
+    return errorResponse(
+      { code: "internal_error", message: `unknown observability endpoint: ${suffix}` },
+      404,
+    );
+  }
+
+  // Build the upstream URL from the validated base + allowlisted path. Preserve
+  // the base URL's own path prefix (a reverse-proxy mount, §8) by joining on it.
+  const base = loopback.url;
+  const basePath = base.pathname.endsWith("/") ? base.pathname.slice(0, -1) : base.pathname;
+  const upstream = new URL(`${basePath}${upstreamPath}`, base.origin);
+  if (search !== "") {
+    upstream.search = search;
+  }
+
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBodyBytes = config.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  const doFetch = config.fetchImpl ?? fetch;
+
+  let upstreamResp: Response;
+  try {
+    upstreamResp = await doFetch(upstream.toString(), {
+      method: "GET",
+      // NEVER forward auth-sensitive headers — the sideband is tokenless (§3).
+      // We send a bare GET; the browser's cookies/Authorization stay at MC.
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    // Distinguish timeout (504, retryable) from connection refusal/down (503).
+    const isTimeout =
+      err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+    if (isTimeout) {
+      return errorResponse(
+        {
+          code: "backend_timeout",
+          message: "interior capture not available — sideband timed out",
+          retry_after_seconds: 5,
+        },
+        504,
+      );
+    }
+    return errorResponse(
+      {
+        code: "backend_unavailable",
+        message:
+          "interior capture not available — sideband unreachable " +
+          "(is the signal sideband daemon running?)",
+      },
+      503,
+    );
+  }
+
+  // Read the body with a hard size cap. We buffer (Tier-3 payloads are small
+  // and bounded — §9 "no pagination; single-task queries return everything")
+  // but refuse to let an unbounded body OOM the daemon.
+  const bodyText = await readCapped(upstreamResp, maxBodyBytes);
+  if (bodyText === null) {
+    return errorResponse(
+      {
+        code: "backend_unavailable",
+        message: `interior capture not available — sideband response exceeded ${maxBodyBytes} bytes`,
+      },
+      503,
+    );
+  }
+
+  // Pass the sideband's own response through. On a non-2xx the body is already
+  // a SidebandError (with `deep_link` when known, §4) — relay it verbatim so the
+  // frontend gets the contract shape + deep-link. On 2xx relay the payload.
+  const passHeaders: Record<string, string> = { "content-type": "application/json" };
+  const retryAfter = upstreamResp.headers.get("retry-after");
+  if (retryAfter !== null) {
+    passHeaders["retry-after"] = retryAfter;
+  }
+  return new Response(bodyText, { status: upstreamResp.status, headers: passHeaders });
+}
+
+/**
+ * Read a response body as text, refusing once it exceeds `maxBytes`. Returns
+ * `null` on overflow. Streams chunk-by-chunk so an oversized body is rejected
+ * without first buffering the whole thing.
+ */
+async function readCapped(resp: Response, maxBytes: number): Promise<string | null> {
+  // Fast reject via Content-Length when the server declares an oversized body.
+  const declared = resp.headers.get("content-length");
+  if (declared !== null) {
+    const n = Number(declared);
+    if (Number.isFinite(n) && n > maxBytes) {
+      // Drain to free the socket, then signal overflow.
+      try {
+        await resp.body?.cancel();
+      } catch {
+        // Best-effort cancel; the socket closes regardless. Safe to ignore.
+      }
+      return null;
+    }
+  }
+
+  if (resp.body === null) {
+    return "";
+  }
+
+  const reader = resp.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      // `value` is a Uint8Array for every non-final read of a byte stream.
+      total += value.byteLength;
+      if (total > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Best-effort; ignore.
+        }
+        return null;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -588,6 +588,8 @@ describe("AgentConfigSchema.mc (MC-I1.S1)", () => {
       configPath: "",
       dbPath: "",
       port: 0,
+      // P-14 U0.1 — sideband defaults to the contract loopback bind.
+      sideband: "http://127.0.0.1:9092",
     });
   });
 
@@ -628,6 +630,103 @@ describe("AgentConfigSchema.mc (MC-I1.S1)", () => {
 
   test("port rejects a non-integer value", () => {
     expect(() => AgentConfigSchema.parse(minAgentConfig({ port: 8767.5 }))).toThrow();
+  });
+});
+
+// =============================================================================
+// P-14 U0.1 — mc.sideband loopback enforcement + shared-schema parity
+// (signal cortex-sideband.md §3/§8; the #877/#879 shared-McSchema lesson)
+// =============================================================================
+
+describe("mc.sideband (P-14 U0.1)", () => {
+  /** Minimal AgentConfig shell with an mc override. */
+  function minAgentConfig(mc?: Record<string, unknown>) {
+    return {
+      agent: { name: "test", displayName: "Test" },
+      discord: [],
+      mattermost: [],
+      claude: { timeoutMs: 1000 },
+      paths: { publishedEventsDir: "/tmp/x" },
+      ...(mc !== undefined && { mc }),
+    };
+  }
+
+  test("absent mc block → sideband defaults to the contract loopback bind", () => {
+    const parsed = AgentConfigSchema.parse(minAgentConfig());
+    expect(parsed.mc.sideband).toBe("http://127.0.0.1:9092");
+  });
+
+  test("empty mc block ({}) → sideband default", () => {
+    const parsed = AgentConfigSchema.parse(minAgentConfig({}));
+    expect(parsed.mc.sideband).toBe("http://127.0.0.1:9092");
+  });
+
+  test("accepts an explicit loopback override (custom port / localhost / IPv6)", () => {
+    for (const sideband of [
+      "http://127.0.0.1:19092",
+      "http://localhost:9092",
+      "http://[::1]:9092",
+    ]) {
+      const parsed = AgentConfigSchema.parse(minAgentConfig({ sideband }));
+      expect(parsed.mc.sideband).toBe(sideband);
+    }
+  });
+
+  test("REJECTS a non-loopback sideband (fail-closed, §8)", () => {
+    for (const sideband of [
+      "http://0.0.0.0:9092",
+      "http://192.168.1.5:9092",
+      "http://10.0.0.9:9092",
+      "http://sideband.evil.com:9092",
+      "ws://127.0.0.1:9092",
+    ]) {
+      expect(() => AgentConfigSchema.parse(minAgentConfig({ sideband }))).toThrow(/mc\.sideband/);
+    }
+  });
+
+  // ---- Shared-schema parity: BOTH config schemas must see mc.sideband ----
+  // The #877/#879 lesson: any new mc.* key MUST live on the SHARED McSchema so
+  // AgentConfigSchema (legacy bot.yaml) AND CortexConfigSchema (config-split)
+  // both parse it. A field defined on only one schema gets silently stripped
+  // for the other shape's deployments.
+
+  describe("shared-schema parity", () => {
+    test("CortexConfigSchema parses mc.sideband (default)", () => {
+      const parsed = CortexConfigSchema.parse(minConfig());
+      expect(parsed.mc.sideband).toBe("http://127.0.0.1:9092");
+    });
+
+    test("CortexConfigSchema accepts a loopback override", () => {
+      const parsed = CortexConfigSchema.parse({
+        ...minConfig(),
+        mc: { enabled: true, sideband: "http://localhost:19092" },
+      });
+      expect(parsed.mc.sideband).toBe("http://localhost:19092");
+    });
+
+    test("CortexConfigSchema REJECTS a non-loopback sideband (parity with AgentConfigSchema)", () => {
+      expect(() =>
+        CortexConfigSchema.parse({
+          ...minConfig(),
+          mc: { enabled: true, sideband: "http://192.168.1.5:9092" },
+        }),
+      ).toThrow(/mc\.sideband/);
+    });
+
+    test("BOTH schemas reject the SAME non-loopback value and accept the SAME loopback value", () => {
+      const bad = "http://0.0.0.0:9092";
+      const good = "http://127.0.0.2:9092";
+      // Agent shape
+      expect(() => AgentConfigSchema.parse(minAgentConfig({ sideband: bad }))).toThrow();
+      expect(AgentConfigSchema.parse(minAgentConfig({ sideband: good })).mc.sideband).toBe(good);
+      // Cortex shape
+      expect(() =>
+        CortexConfigSchema.parse({ ...minConfig(), mc: { sideband: bad } }),
+      ).toThrow();
+      expect(
+        CortexConfigSchema.parse({ ...minConfig(), mc: { sideband: good } }).mc.sideband,
+      ).toBe(good);
+    });
   });
 });
 

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -9,6 +9,7 @@
 import { z } from "zod/v4";
 import { NKEY_PUBKEY_REGEX } from "./nkey";
 import { NatsSubjectsSchema } from "./nats-subjects";
+import { checkLoopbackSideband, DEFAULT_SIDEBAND_URL } from "../sideband/loopback";
 
 // =============================================================================
 // Helper: typed empty default for nested Zod object schemas.
@@ -375,7 +376,38 @@ export const McSchema = z.object({
   dbPath: z.string().default(""),
   /** Listen port. 0 → fall back to the MC yaml's port (default 8767). */
   port: z.number().int().nonnegative().default(0),
-}).default(emptyDefault()).transform((val) => ({
+  /**
+   * P-14 U0.1 — Tier-3 sideband endpoint (signal cortex-sideband.md §2/§3/§8).
+   * MC proxies `/api/observability/*` to this base URL server-side; the
+   * browser only ever talks to MC. Default = the sideband's loopback bind on
+   * its default port.
+   *
+   * LOOPBACK-ENFORCED (§3/§8): the sideband is a local-only daemon (it binds
+   * `127.0.0.1`, carries no token; the security boundary is the host process
+   * boundary). A non-loopback value is REFUSED at parse time — `superRefine`
+   * fails the whole config load fail-closed, so the daemon never boots
+   * pointed at a non-loopback sideband. The accept set (127.0.0.0/8,
+   * `localhost`, `[::1]`, IPv4-mapped loopback) lives in
+   * `src/common/sideband/loopback.ts`, the single source of truth re-checked
+   * at the proxy request boundary too.
+   */
+  sideband: z.string().default(DEFAULT_SIDEBAND_URL),
+}).default(emptyDefault()).superRefine((val, ctx) => {
+  // Loopback enforcement (§8: "Cortex MUST refuse to set a non-loopback host").
+  // Only check when a value is present; the `.default()` supplies a loopback
+  // URL so the all-defaults path is always valid.
+  const raw = val.sideband;
+  if (typeof raw === "string" && raw !== "") {
+    const check = checkLoopbackSideband(raw);
+    if (!check.ok) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["sideband"],
+        message: `mc.sideband: ${check.reason}`,
+      });
+    }
+  }
+}).transform((val) => ({
   // `.default(emptyDefault())` returns `{}` literally rather than re-parsing
   // the inner defaults, so the fields would be undefined. Re-apply the inner
   // defaults so callers get the populated shape. The `??` chains are
@@ -385,6 +417,7 @@ export const McSchema = z.object({
   configPath: val.configPath ?? "",
   dbPath: val.dbPath ?? "",
   port: val.port ?? 0,
+  sideband: val.sideband ?? DEFAULT_SIDEBAND_URL,
   /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 }));
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3564,6 +3564,9 @@ export async function startCortex(
         dbPath,
         port: config.mc.port,
         agentPresence: () => presenceViewForApi,
+        // P-14 U0.1 — Tier-3 sideband proxy. Loopback-enforced at config-parse
+        // time; the embed wires it onto the `/api/observability/*` proxy.
+        sidebandUrl: config.mc.sideband,
       });
       mcDb = mcHandle.db;
       console.log(`cortex: Mission Control embed listening on http://localhost:${mcHandle.port} — db ${dbPath}`);

--- a/src/surface/mc/__tests__/api-observability.test.ts
+++ b/src/surface/mc/__tests__/api-observability.test.ts
@@ -1,0 +1,162 @@
+/**
+ * P-14 U0.1 — server-route integration for `/api/observability/*`.
+ *
+ * Boots the real MC server (with a real loopback "fake sideband" Bun.serve) and
+ * verifies the proxy route: happy-path passthrough, structured error mapping,
+ * and the "no sideband configured" not-available path. The proxy internals are
+ * unit-tested in `src/common/sideband/__tests__/proxy.test.ts`; this asserts the
+ * server wiring (route prefix, dep threading, suffix/query forwarding).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Database } from "bun:sqlite";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+import { startServer, type ServerContext } from "../server";
+import { initDatabase } from "../db/init";
+import { DEFAULT_CONFIG } from "../config";
+import { ProcessManager } from "../session/process-manager";
+
+interface Ctx {
+  db: Database;
+  ctx: ServerContext;
+  pm: ProcessManager;
+  baseUrl: string;
+  tmpDir: string;
+  sideband: { url: string; stop: () => void; lastPath: () => string | null };
+}
+
+/** A loopback fake sideband: records the requested path, returns canned bodies. */
+function startFakeSideband(): { url: string; stop: () => void; lastPath: () => string | null } {
+  let lastPath: string | null = null;
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      const u = new URL(req.url);
+      lastPath = u.pathname + u.search;
+      if (u.pathname === "/traces") {
+        // Simulate a backend-down SidebandError for a sentinel id so the proxy's
+        // verbatim relay (status + body + deep_link) is exercised.
+        if (u.searchParams.get("correlation_id") === "down") {
+          return Response.json(
+            { code: "backend_unavailable", message: "down", deep_link: "https://grafana/x" },
+            { status: 503 },
+          );
+        }
+        return Response.json({ correlation_id: "abc", backend: "victoria", spans: [] });
+      }
+      if (u.pathname.endsWith("/timeline")) {
+        return Response.json({ correlation_id: "abc", backend: "victoria", entries: [] });
+      }
+      if (u.pathname === "/healthz") {
+        return Response.json({ status: "ok", backend: "victoria" });
+      }
+      return Response.json({ code: "internal_error", message: "unknown" }, { status: 404 });
+    },
+  });
+  return {
+    url: `http://127.0.0.1:${server.port}`,
+    stop: () => server.stop(true),
+    lastPath: () => lastPath,
+  };
+}
+
+async function setup(withSideband: boolean): Promise<Ctx> {
+  const tmpDir = join(tmpdir(), `mc-obs-test-${Date.now()}-${Math.random()}`);
+  const db = initDatabase(join(tmpDir, "test.db"));
+  const pm = new ProcessManager();
+  const fake = startFakeSideband();
+  const ctx = startServer(
+    { ...DEFAULT_CONFIG, port: 0 },
+    db,
+    {
+      processManager: pm,
+      ...(withSideband ? { sidebandUrl: fake.url } : {}),
+    },
+  );
+  const port = ctx.server.port;
+  if (port === undefined) throw new Error("server.port unresolved");
+  return {
+    db,
+    ctx,
+    pm,
+    baseUrl: `http://localhost:${port}`,
+    tmpDir,
+    sideband: { url: fake.url, stop: fake.stop, lastPath: fake.lastPath },
+  };
+}
+
+async function teardown(t: Ctx): Promise<void> {
+  await t.pm.closeAll();
+  t.ctx.stop(true);
+  t.db.close();
+  t.sideband.stop();
+  rmSync(t.tmpDir, { recursive: true, force: true });
+}
+
+describe("GET /api/observability/* — proxy wired", () => {
+  let t: Ctx;
+  beforeEach(async () => {
+    t = await setup(true);
+  });
+  afterEach(async () => {
+    await teardown(t);
+  });
+
+  it("proxies /traces and forwards the query string", async () => {
+    const res = await fetch(`${t.baseUrl}/api/observability/traces?correlation_id=abcd`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.backend).toBe("victoria");
+    expect(t.sideband.lastPath()).toBe("/traces?correlation_id=abcd");
+  });
+
+  it("proxies /traces/{id}/timeline", async () => {
+    const id = "0123456789abcdef0123456789abcdef";
+    const res = await fetch(`${t.baseUrl}/api/observability/traces/${id}/timeline`);
+    expect(res.status).toBe(200);
+    expect(t.sideband.lastPath()).toBe(`/traces/${id}/timeline`);
+  });
+
+  it("proxies /healthz", async () => {
+    const res = await fetch(`${t.baseUrl}/api/observability/healthz`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("ok");
+  });
+
+  it("relays a sideband SidebandError + deep_link verbatim", async () => {
+    const res = await fetch(`${t.baseUrl}/api/observability/traces?correlation_id=down`);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("backend_unavailable");
+    expect(body.deep_link).toBe("https://grafana/x");
+  });
+
+  it("refuses an unknown endpoint with a structured 404 (never reaches upstream)", async () => {
+    const res = await fetch(`${t.baseUrl}/api/observability/admin/secrets`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe("internal_error");
+  });
+});
+
+describe("GET /api/observability/* — no sideband configured", () => {
+  let t: Ctx;
+  beforeEach(async () => {
+    t = await setup(false);
+  });
+  afterEach(async () => {
+    await teardown(t);
+  });
+
+  it("returns a structured not-available error (not a 500 splat)", async () => {
+    const res = await fetch(`${t.baseUrl}/api/observability/traces?correlation_id=x`);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("backend_unavailable");
+    expect(body.message).toContain("interior capture not available");
+  });
+});

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -226,6 +226,16 @@ export interface ApiDeps {
    * if ever needed.
    */
   githubWebhookSecret?: string;
+  /**
+   * P-14 U0.1 — Tier-3 sideband base URL (`mc.sideband`). When present, the
+   * `/api/observability/*` routes proxy to it server-side (the browser only
+   * ever talks to MC; no CORS opening on the loopback-only sideband). Already
+   * loopback-enforced at config-parse time; the proxy re-checks at the request
+   * boundary (fail-closed). When absent, the observability routes return a
+   * structured "interior capture not available" error so the frontend (#933)
+   * renders honestly. See `src/common/sideband/`.
+   */
+  sidebandUrl?: string;
 }
 
 const DEFAULT_AGENT_ID = "mc-default-agent";

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -57,6 +57,14 @@ export interface StartMissionControlOptions {
    * the route serves an empty list.
    */
   agentPresence?: () => AgentPresenceView | null;
+  /**
+   * P-14 U0.1 — Tier-3 sideband base URL (`config.mc.sideband`). Loopback-
+   * enforced at config-parse time; forwarded verbatim to `startServer`, which
+   * wires it onto `ApiDeps.sidebandUrl` so the `/api/observability/*` proxy can
+   * reach the local sideband daemon. Omitted → the observability routes return
+   * a structured not-available error.
+   */
+  sidebandUrl?: string;
 }
 
 /**
@@ -100,6 +108,7 @@ export async function startMissionControl(
     serverCtx = startServer(config, db, {
       processManager,
       ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
+      ...(opts.sidebandUrl ? { sidebandUrl: opts.sidebandUrl } : {}),
     });
     const { server, wsRegistry } = serverCtx;
     hookPoller = new HookStreamPoller(db, config.hooks, wsRegistry);

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -46,6 +46,7 @@ import { handleGetPhaseDetail } from "./api/phase-detail";
 import { handleGetWorkItemDetail } from "./api/work-item-detail";
 import { handleListAttention } from "./api/attention";
 import { handleGetGovernance } from "./api/governance";
+import { proxySideband } from "../../common/sideband/proxy";
 import type { ProcessManager } from "./session/process-manager";
 import type { SpawnFn } from "./session/endpoint-resolver";
 import { join, dirname } from "path";
@@ -165,6 +166,14 @@ export interface StartServerOptions {
    * presence registry → the handler serves an empty list gracefully).
    */
   agentPresence?: () => AgentPresenceView | null;
+  /**
+   * P-14 U0.1 — Tier-3 sideband base URL (`mc.sideband`). When present, the
+   * `/api/observability/*` routes proxy to it server-side. Loopback-enforced
+   * at config-parse time; the proxy re-checks at the request boundary.
+   * Forwarded to `ApiDeps.sidebandUrl`. Omitted → the observability routes
+   * return a structured not-available error.
+   */
+  sidebandUrl?: string;
 }
 
 export function startServer(
@@ -191,6 +200,7 @@ export function startServer(
         ...(options.githubWebhookSecret
           ? { githubWebhookSecret: options.githubWebhookSecret }
           : {}),
+        ...(options.sidebandUrl ? { sidebandUrl: options.sidebandUrl } : {}),
       }
     : null;
 
@@ -489,6 +499,33 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleGetGovernance(db);
+  }
+
+  // P-14 U0.1 — GET /api/observability/* — Tier-3 sideband drill-down proxy.
+  // MC proxies to the loopback-only sideband server-side (the browser only ever
+  // talks to MC; no CORS opening). The proxy allowlists the contract's read
+  // surface (/traces, /logs, /traces/{id}/timeline, /healthz), re-checks the
+  // loopback invariant, bounds the request, and maps every failure to a
+  // structured SidebandError (with deep_link) — never a 500 splat. See
+  // `src/common/sideband/`.
+  if (pathname.startsWith("/api/observability/")) {
+    // When no sideband is configured (e.g. cloud worker parity, or MC booted
+    // without the dep), return the structured not-available error so the
+    // frontend (#933) renders "interior capture not available" honestly.
+    if (!deps?.sidebandUrl) {
+      return new Response(
+        JSON.stringify({
+          code: "backend_unavailable",
+          message:
+            "interior capture not available — no sideband endpoint configured for this Mission Control",
+        }),
+        { status: 503, headers: { "content-type": "application/json" } },
+      );
+    }
+    const suffix = pathname.slice("/api/observability".length);
+    return proxySideband(req.method, suffix, url.search.replace(/^\?/, ""), {
+      baseUrl: deps.sidebandUrl,
+    });
   }
 
   if (pathname === "/api/tasks") {

--- a/src/surface/mc/worker/src/__tests__/observability.test.ts
+++ b/src/surface/mc/worker/src/__tests__/observability.test.ts
@@ -1,0 +1,45 @@
+/**
+ * P-14 U0.1 — cloud worker observability parity.
+ *
+ * The worker does NOT proxy to the sideband (local-only daemon, §3). Every
+ * `/api/observability/*` request on the cloud path returns the structured
+ * not-available SidebandError so the frontend (#933) renders the cloud case
+ * honestly. The route has no env dependencies, so we exercise the sub-app
+ * directly.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { observabilityRoutes } from "../routes/observability";
+
+describe("cloud worker /api/observability/* — local-only parity", () => {
+  it("returns structured not-available (503) for /traces", async () => {
+    const res = await observabilityRoutes.request(
+      "http://x/api/observability/traces?correlation_id=abcd",
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("backend_unavailable");
+    expect(body.message).toContain("interior capture not available");
+    expect(body.message).toContain("local-only");
+  });
+
+  it("returns the SAME shape for /traces/{id}/timeline", async () => {
+    const res = await observabilityRoutes.request(
+      "http://x/api/observability/traces/0123456789abcdef/timeline",
+    );
+    expect(res.status).toBe(503);
+    expect((await res.json()).code).toBe("backend_unavailable");
+  });
+
+  it("returns the SAME shape for /healthz", async () => {
+    const res = await observabilityRoutes.request("http://x/api/observability/healthz");
+    expect(res.status).toBe(503);
+    expect((await res.json()).code).toBe("backend_unavailable");
+  });
+
+  it("never emits a deep_link the cloud can't honour", async () => {
+    const res = await observabilityRoutes.request("http://x/api/observability/logs");
+    const body = await res.json();
+    expect(body.deep_link).toBeUndefined();
+  });
+});

--- a/src/surface/mc/worker/src/index.ts
+++ b/src/surface/mc/worker/src/index.ts
@@ -16,6 +16,7 @@ import { githubRoutes } from "./routes/github";
 import { adminRoutes } from "./routes/admin";
 import { syncRoutes } from "./routes/sync";
 import { dashboardRoutes } from "./routes/dashboard";
+import { observabilityRoutes } from "./routes/observability";
 import { DashboardSocket } from "./dashboard-socket";
 
 export interface Env extends AuthBindings {
@@ -126,6 +127,7 @@ app.route("/", githubRoutes);
 app.route("/", adminRoutes);
 app.route("/", syncRoutes);
 app.route("/", dashboardRoutes);
+app.route("/", observabilityRoutes);
 app.route("/", authRoutes);
 
 // ---------------------------------------------------------------------------

--- a/src/surface/mc/worker/src/routes/observability.ts
+++ b/src/surface/mc/worker/src/routes/observability.ts
@@ -1,0 +1,40 @@
+/**
+ * P-14 U0.1 — `/api/observability/*` on the CLOUD worker (parity decision).
+ *
+ * WORKER-PARITY DECISION: the cloud worker does NOT proxy to the sideband. The
+ * sideband is a LOCAL-ONLY daemon by design (signal cortex-sideband.md §3) —
+ * it binds `127.0.0.1` on the principal's host and carries no token; the
+ * security boundary is the host process boundary. The CF worker runs off-host
+ * (in Cloudflare's edge), so it physically cannot — and per §3.2/§3.4 MUST not
+ * — reach a principal's loopback sideband. Tier-3 drill-down is therefore a
+ * LOCAL-MC-ONLY capability.
+ *
+ * On the cloud path we return the SAME structured "interior capture not
+ * available" `SidebandError` the local server returns when no sideband is
+ * configured, so the dashboard (#933) renders the cloud case honestly:
+ * "interior capture not available — open the local Mission Control for Tier-3".
+ * The frontend pins on the contract `SidebandError` shape regardless of which
+ * MC served the request.
+ */
+
+import { Hono } from "hono";
+import type { Env } from "../index";
+
+export const observabilityRoutes = new Hono<{ Bindings: Env }>();
+
+/**
+ * Catch-all for the observability surface on the cloud worker. Always returns
+ * the not-available error — the sideband is unreachable from the edge by design.
+ */
+observabilityRoutes.all("/api/observability/*", (c) => {
+  return c.json(
+    {
+      code: "backend_unavailable",
+      message:
+        "interior capture not available on cloud Mission Control — Tier-3 " +
+        "drill-down is local-only (the signal sideband binds loopback on the " +
+        "principal's host). Open the local Mission Control to view traces/logs.",
+    },
+    503,
+  );
+});


### PR DESCRIPTION
Part of **signal P-14** (the-metafactory/signal#122; plan `signal/docs/plans/2026-p14-mc-observability.md`, row 1). Partial-implements signal#99 (the sideband knob) + the rendering affordance of signal#97 — **closes neither** of those two. Gates U1.1 + U4.2.

`Closes #931`
`refs the-metafactory/signal#122`

## What this delivers

1. **`mc.sideband` config knob** — default `http://127.0.0.1:9092`, on the **shared `McSchema`** const (`src/common/types/config.ts`) so **both** `AgentConfigSchema` (legacy bot.yaml) and `CortexConfigSchema` (config-split) parse it — the #877/#879 shared-schema lesson. A `superRefine` enforces loopback at config-parse time, **fail-closed**: a non-loopback value fails the whole config load so the daemon never boots pointed off-host.
2. **Loopback enforcement** — `src/common/sideband/loopback.ts` is the single source of truth, re-checked at the proxy request boundary too.
3. **Server-side proxy** — `src/common/sideband/proxy.ts` + a `/api/observability/*` route on the MC server. The browser only ever talks to MC (no CORS opening on the loopback-only, tokenless sideband). Path-allowlisted to the contract's read surface, bounded request + response, no auth-header forwarding, structured error mapping.
4. **Error surfacing** — every failure maps to a contract-shaped `SidebandError` (`code`/`message`/`deep_link`/`retry_after_seconds`); the sideband's own error body (incl. `deep_link`) is relayed verbatim. Sideband down/absent → a render-friendly 503 "interior capture not available", never a 500 splat, so #933 can render honestly.
5. **Worker parity** — documented decision below.

## Contract §3/§8 conformance notes

The contract makes the sideband **local-only by design** (§3: binds `127.0.0.1`, tokenless; the security boundary is the host process boundary). §8 states cortex "MUST refuse to set a non-loopback host". This unit enforces that at two layers (parse-time `superRefine` + request-time re-check), both **fail-closed** — there is no code path that proxies to a non-loopback host.

The proxy sends a **bare tokenless GET** with `accept: application/json` only; the browser's cookies / `Authorization` to MC are **not** relayed (§3 — the sideband requires no auth and we forward none). Endpoints are allowlisted to the §2 read surface (`/traces`, `/logs`, `/traces/{id}/timeline`, `/healthz`); GET-only per §9 non-goals (no write endpoints). Request bounded at 8s (matches the §8 consumer pseudocode budget); response body capped at 8 MiB (§9 says single-task queries return everything with no pagination — we cap rather than stream unbounded into memory). A reverse-proxy base path (§8: "under a reverse proxy on the same host") is preserved.

### Loopback accept/reject matrix implemented

**Accept** (per §3 loopback boundary):
- `127.0.0.1` (+ port, + path) and the whole `127.0.0.0/8` block (e.g. `127.0.0.2`, `127.255.255.254`)
- `localhost` (case-insensitive)
- `[::1]` (incl. expanded `[0:0:0:0:0:0:0:1]`) and IPv4-mapped loopback `[::ffff:127.0.0.1]`
- `https://` loopback (same-host reverse proxy)

**Reject** (fail-closed):
- `0.0.0.0`, `[::]` (unspecified "all interfaces" bind — not loopback)
- any LAN IP (`192.168.*`, `10.*`, `172.16-31.*`) and any public/routable IPv4/IPv6
- any non-`localhost` hostname (`evil.com`, `localhost.evil.com`, `sideband.internal`)
- userinfo smuggling (`http://127.0.0.1@evil.com`, `http://user:pass@127.0.0.1`)
- non-http(s) schemes (`ws:`, `file:`, `javascript:`), malformed URLs, out-of-range octets, empty/whitespace

## Worker-parity decision: **LOCAL-MC-ONLY** (cloud worker does NOT proxy)

The sideband binds loopback on the **principal's host** and is unreachable from Cloudflare's edge — and per §3.2/§3.4 cross-host queries are deliberately impossible (would breach sovereignty pre-M4). So Tier-3 drill-down is a **local-MC-only** capability. The CF worker (`src/surface/mc/worker/`) gets a `/api/observability/*` route that returns the **same** structured not-available `SidebandError` (`backend_unavailable`, "Tier-3 is local-only — open the local Mission Control"), so the dashboard pins on one contract shape regardless of which MC served it. No `deep_link` is emitted on the cloud path (the worker can't compute one).

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, none in new files)
- `bun test` — 6256 pass / 0 fail / 2 skip (366 files)
- `scripts/check-carveouts.sh` — PASS

## Tests

- `src/common/sideband/__tests__/loopback.test.ts` — full accept/reject matrix
- `src/common/sideband/__tests__/proxy.test.ts` — routing, error mapping, timeout→504, body cap, header hygiene, loopback re-enforcement, reverse-proxy base path
- `src/common/types/__tests__/cortex-config.test.ts` — loopback enforcement + **shared-schema parity** (both schemas accept/reject the same values) + absent-config default
- `src/surface/mc/__tests__/api-observability.test.ts` — server-route integration (real loopback fake sideband) + no-sideband not-available path
- `src/surface/mc/worker/src/__tests__/observability.test.ts` — cloud worker parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)