### PR TITLE
chore: bump to v5.9.0 — Capability Offering (public marketplace + injection hardening)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.8.0"
+version: "5.9.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump v5.8.0 → v5.9.0. Completes the Capability Offering epic (#939): **CO-5 (#982)** public PR-review marketplace + **CO-7 (#980)** injection hardening (CO-1..4/CO-6 shipped in v5.8.0). GitHub release cut on merge.