### PR TITLE
refactor(config): rename engine value persona → assistant — closes #921

### DIFF
--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -477,8 +477,9 @@ export const AgentRuntimeSchema = z.object({
    * Distinct from `substrate` (the M6 execution harness) and `model` (sage's
    * lens LLM). **Optional** for back-compat: when unset, `resolveReviewEngine`
    * derives it from the legacy `substrate` value (`pi-dev` → sage; everything
-   * else → assistant), preserving pre-split routing byte-for-byte. New configs
-   * SHOULD set it explicitly.
+   * else → assistant), preserving pre-split routing (the engine value was
+   * renamed `persona`→`assistant` in cortex#921 — routing-equivalent). New
+   * configs SHOULD set it explicitly.
    */
   engine: z.enum(["sage", "assistant"]).optional(),
   /**

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -471,16 +471,16 @@ export const AgentRuntimeSchema = z.object({
    *   - `sage`    — the standalone sage lens-CLI (deterministic pipeline:
    *                 fixed lens registry + pure `decideVerdict`). Run via the
    *                 sage runner; the LLM it runs lenses through is `model`.
-   *   - `persona` — a Claude-Code session that reads the CodeReview SKILL.md +
-   *                 the agent persona and reviews in-session (Echo/Luna/Holly).
+   *   - `assistant` — a Claude-Code session that reads the CodeReview SKILL.md
+   *                 + the agent persona and reviews in-session (Echo/Luna/Holly).
    *
    * Distinct from `substrate` (the M6 execution harness) and `model` (sage's
    * lens LLM). **Optional** for back-compat: when unset, `resolveReviewEngine`
    * derives it from the legacy `substrate` value (`pi-dev` → sage; everything
-   * else → persona), preserving pre-split routing byte-for-byte. New configs
+   * else → assistant), preserving pre-split routing byte-for-byte. New configs
    * SHOULD set it explicitly.
    */
-  engine: z.enum(["sage", "persona"]).optional(),
+  engine: z.enum(["sage", "assistant"]).optional(),
   /**
    * cortex#917 — the LLM `engine: sage` runs its lenses through, forwarded to
    * `sage review --substrate <model>`. Closed enum so an unsupported value is
@@ -491,7 +491,7 @@ export const AgentRuntimeSchema = z.object({
    */
   model: z.enum(["claude", "codex", "pi"]).optional(),
   /** Execution substrate — the M6 harness (cortex#113 `HarnessId`). For
-   *  `engine: persona` this is the in-session harness (`claude-code`). Optional:
+   *  `engine: assistant` this is the in-session harness (`claude-code`). Optional:
    *  `engine: sage` agents run through the sage CLI (no HarnessId) and omit it;
    *  the legacy `pi-dev` value is the back-compat shim that `resolveReviewEngine`
    *  maps to `engine: sage`. */

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1630,10 +1630,10 @@ export async function startCortex(
       // sole receiver for sage-owned review flavors.
       //
       // cortex#917 — the engine/model split. `resolveReviewEngine` reads
-      // `runtime.engine` (`sage` | `persona`); the sage lens LLM is the
+      // `runtime.engine` (`sage` | `assistant`); the sage lens LLM is the
       // orthogonal `runtime.model` (claude|codex|pi), NOT `substrate` (which is
       // the M6 harness). `engine: sage` wires the sage lens-CLI runner,
-      // forwarding `model` to `sage review --substrate <model>`; `persona`
+      // forwarding `model` to `sage review --substrate <model>`; `assistant`
       // (and the legacy default) leaves `pipelineRunner` undefined so the
       // ReviewConsumer falls through to `runReviewPipeline` → the Claude-Code
       // SKILL.md path (`ccSessionFactory` stays wired for it). The resolver's

--- a/src/runner/__tests__/review-engine.test.ts
+++ b/src/runner/__tests__/review-engine.test.ts
@@ -20,9 +20,9 @@ describe("resolveReviewEngine — explicit engine", () => {
     expect(resolveReviewEngine({ engine: "sage" })).toEqual({ engine: "sage" });
   });
 
-  test("engine: persona → persona, no model regardless of any model field", () => {
-    expect(resolveReviewEngine({ engine: "persona", model: "codex" })).toEqual({
-      engine: "persona",
+  test("engine: assistant → assistant, no model regardless of any model field", () => {
+    expect(resolveReviewEngine({ engine: "assistant", model: "codex" })).toEqual({
+      engine: "assistant",
     });
   });
 });
@@ -35,17 +35,17 @@ describe("resolveReviewEngine — legacy migration (no engine field)", () => {
     expect(resolveReviewEngine({ substrate: "pi-dev" })).toEqual({ engine: "sage" });
   });
 
-  test("legacy substrate: claude-code → persona (unchanged)", () => {
-    expect(resolveReviewEngine({ substrate: "claude-code" })).toEqual({ engine: "persona" });
+  test("legacy substrate: claude-code → assistant (unchanged)", () => {
+    expect(resolveReviewEngine({ substrate: "claude-code" })).toEqual({ engine: "assistant" });
   });
 
-  test("legacy substrate: codex → persona (unchanged — this was the silent-fallthrough bug)", () => {
-    expect(resolveReviewEngine({ substrate: "codex" })).toEqual({ engine: "persona" });
+  test("legacy substrate: codex → assistant (unchanged — this was the silent-fallthrough bug)", () => {
+    expect(resolveReviewEngine({ substrate: "codex" })).toEqual({ engine: "assistant" });
   });
 
-  test("no runtime → persona (the default CC path)", () => {
-    expect(resolveReviewEngine(undefined)).toEqual({ engine: "persona" });
-    expect(resolveReviewEngine({})).toEqual({ engine: "persona" });
+  test("no runtime → assistant (the default CC path)", () => {
+    expect(resolveReviewEngine(undefined)).toEqual({ engine: "assistant" });
+    expect(resolveReviewEngine({})).toEqual({ engine: "assistant" });
   });
 });
 

--- a/src/runner/review-engine.ts
+++ b/src/runner/review-engine.ts
@@ -8,7 +8,7 @@
  *   - WHICH LLM the sage engine runs its lenses through (`claude` | `codex` | `pi`).
  *
  * `substrate === "pi-dev"` used to mean "use the sage runner", so a sage agent
- * configured `substrate: codex` silently fell through to the persona path —
+ * configured `substrate: codex` silently fell through to the assistant path —
  * "codex" only names a harness, never the engine. This module splits the axes:
  * `runtime.engine` selects the engine; `runtime.model` is the LLM the sage CLI
  * runs lenses through (forwarded to `sage review --substrate <model>`);
@@ -17,11 +17,11 @@
  * Pure + deterministic — unit-tested in `review-engine.test.ts`.
  */
 
-export type ReviewEngine = "sage" | "persona";
+export type ReviewEngine = "sage" | "assistant";
 export type SageModel = "claude" | "codex" | "pi";
 
 export interface ResolvedReviewEngine {
-  /** sage = standalone lens CLI; persona = Claude-Code session + CodeReview skill. */
+  /** sage = standalone lens CLI; assistant = Claude-Code session + CodeReview skill. */
   engine: ReviewEngine;
   /**
    * The LLM the sage CLI runs its lenses through (`sage review --substrate
@@ -47,7 +47,7 @@ export interface ReviewEngineInput {
  *   2. Legacy (no `engine`): only `substrate === "pi-dev"` selected the sage
  *      runner before, so it maps to `{engine: sage}` with NO model (runner uses SAGE_SUBSTRATE env, else pi — true parity); legacy
  *      backend). EVERY other legacy substrate (`claude-code`, `codex`, `cursor`,
- *      `custom`, unset) kept the Claude-Code path → `{engine: persona}`. This
+ *      `custom`, unset) kept the Claude-Code path → `{engine: assistant}`. This
  *      preserves pre-split behaviour byte-for-byte for un-migrated configs.
  *
  * No coercion of unknown values — `model` is constrained to `SageModel` by the
@@ -60,8 +60,8 @@ export function resolveReviewEngine(runtime?: ReviewEngineInput): ResolvedReview
       ? { engine: "sage", model: runtime.model }
       : { engine: "sage" };
   }
-  if (runtime?.engine === "persona") {
-    return { engine: "persona" };
+  if (runtime?.engine === "assistant") {
+    return { engine: "assistant" };
   }
   // Legacy migration — engine unset. NO `model`: the runner falls back to
   // SAGE_SUBSTRATE env (else pi), exactly as pre-split `makePiDevPipelineRunner({})`
@@ -70,5 +70,5 @@ export function resolveReviewEngine(runtime?: ReviewEngineInput): ResolvedReview
   if (runtime?.substrate === "pi-dev") {
     return { engine: "sage" };
   }
-  return { engine: "persona" };
+  return { engine: "assistant" };
 }

--- a/src/runner/review-engine.ts
+++ b/src/runner/review-engine.ts
@@ -48,7 +48,9 @@ export interface ReviewEngineInput {
  *      runner before, so it maps to `{engine: sage}` with NO model (runner uses SAGE_SUBSTRATE env, else pi — true parity); legacy
  *      backend). EVERY other legacy substrate (`claude-code`, `codex`, `cursor`,
  *      `custom`, unset) kept the Claude-Code path → `{engine: assistant}`. This
- *      preserves pre-split behaviour byte-for-byte for un-migrated configs.
+ *      preserves pre-split ROUTING for un-migrated configs — the resolved
+ *      engine string is `assistant` (renamed from `persona` in cortex#921), so
+ *      it is routing-equivalent, not byte-identical, to the pre-split value.
  *
  * No coercion of unknown values — `model` is constrained to `SageModel` by the
  * schema's `z.enum`, so an unsupported LLM is rejected at config load rather


### PR DESCRIPTION
## What
Renames the review-engine config value `persona` → `assistant`. Closes #921.

## Why
cortex#920's review flagged `engine: "persona"`: CONTEXT.md §Flagged ambiguities maps `persona` → `assistant` ("persona is not a domain entity"). `runtime.engine` is a versioned config surface, so rename before it has users.

## Changes
- `engine: z.enum(["sage", "persona"])` → `["sage", "assistant"]` (`cortex-config.ts`)
- `ReviewEngine` type + `resolveReviewEngine` returns + docstrings (`review-engine.ts`)
- routing comment in `cortex.ts`; tests

The agent **persona.md file** field (`persona: z.string()`) is UNCHANGED — only the engine *value* is renamed. The assistant engine still reads the agent's `persona` markdown; it's the value naming that aligns with CONTEXT.md.

## Migration
None — no agent declares `engine: persona` (sage uses `engine: sage`; the assistant path is the unset/legacy default, derived by `resolveReviewEngine`).

## Testing
373 pass across runner/boot/config; `tsc --noEmit` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Migration evidence
```
$ grep -rn "engine: persona" <repo>/src <repo>/*.yaml ~/.config/cortex
# → zero matches (only hit: .git/COMMIT_EDITMSG)
```
No agent config — repo fixtures or the live `~/.config/cortex` stack — declares `engine: persona`, so the enum-reject of the old value is safe.
