### PR TITLE
fix(adapters,runner): context-poisoning defences + dispatch-sink render idempotency (#987)

### DIFF
--- a/src/adapters/__tests__/dispatch-sink.test.ts
+++ b/src/adapters/__tests__/dispatch-sink.test.ts
@@ -61,13 +61,18 @@ function fakeRuntime(): {
   };
 }
 
+// cortex#987 — unique id per fixture envelope: the sink now dedupes renders by
+// `envelope.id`, so a shared hardcoded id would make distinct test envelopes
+// look like duplicate deliveries of one envelope.
+let envelopeSeq = 0;
 function lifecycleEnvelope(
   type: string,
   payload: Record<string, unknown>,
   correlationId = "task-1",
 ): Envelope {
+  envelopeSeq += 1;
   return {
-    id: "00000000-0000-4000-8000-000000000099",
+    id: `00000000-0000-4000-8000-${String(envelopeSeq).padStart(12, "0")}`,
     source: "metafactory.runner.local",
     type,
     timestamp: "2026-05-09T12:00:00Z",
@@ -493,6 +498,58 @@ describe("dispatch-sink — no-routing and non-lifecycle envelopes", () => {
 
     // The sink is the ONLY thing posting — never doubles a single envelope.
     expect(adapter.sentMessages).toHaveLength(1);
+  });
+
+  test("cortex#987 — double-delivery of the SAME envelope posts exactly once", async () => {
+    // `onEnvelope` is a global per-delivery fan-out: an EXTERNAL overlapping
+    // subscription (e.g. a `nats.subjects[]` wildcard that also matches
+    // `dispatch.task.>`) makes the runtime receive the envelope twice and
+    // invoke the sink's handler twice. Observed live as every chat reply
+    // posting twice. The render-dedupe guard makes the second delivery a
+    // no-op.
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("sage-mattermost");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "jc", stack: "switch" });
+    await sink.start();
+
+    const env = lifecycleEnvelope("dispatch.task.completed", {
+      agent_id: "sage",
+      chat_response: "Hello! I'm Sage.",
+      response_routing: routing("sage-mattermost", "C123"),
+    });
+    trigger(env);
+    trigger(env); // second delivery of the SAME envelope (same id)
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+  });
+
+  test("cortex#987 — distinct envelopes still post independently after dedupe", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("sage-mattermost");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "jc", stack: "switch" });
+    await sink.start();
+
+    const a = lifecycleEnvelope("dispatch.task.completed", {
+      agent_id: "sage",
+      chat_response: "first",
+      response_routing: routing("sage-mattermost", "C123"),
+    });
+    const b = {
+      ...lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "sage",
+        chat_response: "second",
+        response_routing: routing("sage-mattermost", "C123"),
+      }),
+      id: "00000000-0000-4000-8000-0000000000aa",
+    };
+    trigger(a);
+    trigger(b);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(2);
   });
 });
 

--- a/src/adapters/__tests__/dispatch-sink.test.ts
+++ b/src/adapters/__tests__/dispatch-sink.test.ts
@@ -525,6 +525,39 @@ describe("dispatch-sink — no-routing and non-lifecycle envelopes", () => {
     expect(adapter.sentMessages).toHaveLength(1);
   });
 
+  test("cortex#988 — a FAILED post releases the claim so redelivery retries", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("sage-mattermost");
+    // First post attempt throws (rate limit etc.); subsequent attempts succeed.
+    const realPost = adapter.postResponse.bind(adapter);
+    let failures = 1;
+    adapter.postResponse = async (target, text, files) => {
+      if (failures > 0) {
+        failures -= 1;
+        throw new Error("rate limited");
+      }
+      return realPost(target, text, files);
+    };
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "jc", stack: "switch" });
+    await sink.start();
+
+    const env = lifecycleEnvelope("dispatch.task.completed", {
+      agent_id: "sage",
+      chat_response: "retry me",
+      response_routing: routing("sage-mattermost", "C123"),
+    });
+    trigger(env); // fails — claim must be released
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(adapter.sentMessages).toHaveLength(0);
+
+    trigger(env); // redelivery of the SAME envelope — retries and succeeds
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.text).toBe("retry me");
+  });
+
   test("cortex#987 — distinct envelopes still post independently after dedupe", async () => {
     const { runtime, trigger } = fakeRuntime();
     const adapter = new MockAdapter("sage-mattermost");

--- a/src/adapters/dispatch-sink.ts
+++ b/src/adapters/dispatch-sink.ts
@@ -38,6 +38,7 @@ import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { MyelinSubscriber } from "../bus/myelin/subscriber";
 import { formatDispatchLifecycle } from "./envelope-renderer";
 import {
+  createRenderDedupe,
   deliverRoutedResponse,
   LIFECYCLE_TYPE_PREFIX,
   readResponseRouting,
@@ -205,6 +206,14 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
   let registration: { unregister: () => void } | null = null;
   let subscribers: MyelinSubscriber[] = [];
 
+  // cortex#987 — at-most-once render per envelope.id. `onEnvelope` is a
+  // global per-delivery fan-out: an external overlapping subscription (a
+  // `nats.subjects[]` wildcard that also matches `dispatch.task.>`) delivers
+  // the same envelope twice and this handler runs twice — observed live as
+  // every chat reply posting twice. Same belt-and-braces the review sink
+  // carries.
+  const alreadyRendered = createRenderDedupe();
+
   /**
    * Deliver one lifecycle envelope. Pure routing + render + post; never
    * throws (the runtime `onEnvelope` fan-out must not see a throw, and a
@@ -225,6 +234,11 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
 
     const text = formatDispatchLifecycle(envelope);
     if (text === null || text.length === 0) return;
+
+    // Mark seen only once we know this envelope WOULD post (routing present,
+    // instance matched, text non-empty) so non-actionable envelopes don't
+    // consume window slots. A second delivery of the same id is a no-op.
+    if (alreadyRendered(envelope.id)) return;
 
     const target: ResponseTarget = {
       instanceId: routing.adapter_instance,

--- a/src/adapters/dispatch-sink.ts
+++ b/src/adapters/dispatch-sink.ts
@@ -211,8 +211,9 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
   // `nats.subjects[]` wildcard that also matches `dispatch.task.>`) delivers
   // the same envelope twice and this handler runs twice — observed live as
   // every chat reply posting twice. Same belt-and-braces the review sink
-  // carries.
-  const alreadyRendered = createRenderDedupe();
+  // carries. Claimed BEFORE the post (duplicate deliveries land in the same
+  // tick); RELEASED on a failed post so redelivery can retry.
+  const dedupe = createRenderDedupe();
 
   /**
    * Deliver one lifecycle envelope. Pure routing + render + post; never
@@ -235,10 +236,10 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
     const text = formatDispatchLifecycle(envelope);
     if (text === null || text.length === 0) return;
 
-    // Mark seen only once we know this envelope WOULD post (routing present,
+    // Claim only once we know this envelope WOULD post (routing present,
     // instance matched, text non-empty) so non-actionable envelopes don't
     // consume window slots. A second delivery of the same id is a no-op.
-    if (alreadyRendered(envelope.id)) return;
+    if (!dedupe.claim(envelope.id)) return;
 
     const target: ResponseTarget = {
       instanceId: routing.adapter_instance,
@@ -255,7 +256,11 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
         // A platform post failure must not crash the fan-out. Log to
         // stderr (per CLAUDE.md no-empty-catch rule) and move on; the
         // dispatch already completed on the bus, only the surface delivery
-        // failed (rate limit, deleted channel, etc.).
+        // failed (rate limit, deleted channel, etc.). Release the dedupe
+        // claim so a redelivery of this envelope can retry the render
+        // (sage finding on cortex#988 — a claim that produced no render
+        // must not suppress the retry).
+        dedupe.release(envelope.id);
         process.stderr.write(
           `cortex: dispatch-sink postResponse failed (instance=${routing.adapter_instance}, ` +
             `channel=${routing.channel_id}, type=${envelope.type}): ` +

--- a/src/adapters/response-routing-delivery.ts
+++ b/src/adapters/response-routing-delivery.ts
@@ -90,17 +90,40 @@ export function dispatchCorrelationKey(envelope: Envelope): string | undefined {
  * (envelopes arrive in roughly-temporal order, so a genuine duplicate lands
  * well within the window).
  */
-export function createRenderDedupe(window = 4096): (id: string) => boolean {
+export interface RenderDedupe {
+  /**
+   * Atomically claim `id`. Returns `true` when this caller owns the render
+   * (first claim); `false` when the id was already claimed (duplicate
+   * delivery — skip). Claiming BEFORE the async post (rather than marking
+   * after success) is load-bearing: duplicate deliveries arrive in the same
+   * fan-out tick, so a check-then-mark-after-await pattern would let both
+   * pass the check before either marks.
+   */
+  claim(id: string): boolean;
+  /**
+   * Release a claimed id after a FAILED delivery, so a later redelivery of
+   * the same envelope can retry instead of being suppressed by a claim that
+   * never produced a render (sage finding on cortex#988).
+   */
+  release(id: string): void;
+}
+
+export function createRenderDedupe(window = 4096): RenderDedupe {
   const seenIds = new Set<string>();
-  return function alreadyRendered(id: string): boolean {
-    if (seenIds.has(id)) return true;
-    seenIds.add(id);
-    if (seenIds.size > window) {
-      // Evict the oldest entry (insertion order — Set preserves it).
-      const oldest = seenIds.values().next().value;
-      if (oldest !== undefined) seenIds.delete(oldest);
-    }
-    return false;
+  return {
+    claim(id: string): boolean {
+      if (seenIds.has(id)) return false;
+      seenIds.add(id);
+      if (seenIds.size > window) {
+        // Evict the oldest entry (insertion order — Set preserves it).
+        const oldest = seenIds.values().next().value;
+        if (oldest !== undefined) seenIds.delete(oldest);
+      }
+      return true;
+    },
+    release(id: string): void {
+      seenIds.delete(id);
+    },
   };
 }
 

--- a/src/adapters/response-routing-delivery.ts
+++ b/src/adapters/response-routing-delivery.ts
@@ -76,6 +76,34 @@ export function dispatchCorrelationKey(envelope: Envelope): string | undefined {
   return undefined;
 }
 
+
+/**
+ * cortex#987 — bounded at-most-once render guard, shared by the dispatch and
+ * review sinks. The runtime-level subscribe dedupe (cortex#491 in
+ * `runtime.ts`) deduplicates each consumer's OWN patterns, but `onEnvelope`
+ * is a global per-delivery fan-out: any EXTERNAL overlapping subscription
+ * (e.g. a `nats.subjects[]` wildcard in `system/system.yaml` that also
+ * matches `dispatch.task.>`) makes the runtime receive the envelope twice and
+ * invoke every handler twice. This guard makes a sink idempotent per
+ * `envelope.id` regardless of how many deliveries occur. Bounded so a
+ * long-lived sink can't leak: oldest ids evict once the window fills
+ * (envelopes arrive in roughly-temporal order, so a genuine duplicate lands
+ * well within the window).
+ */
+export function createRenderDedupe(window = 4096): (id: string) => boolean {
+  const seenIds = new Set<string>();
+  return function alreadyRendered(id: string): boolean {
+    if (seenIds.has(id)) return true;
+    seenIds.add(id);
+    if (seenIds.size > window) {
+      // Evict the oldest entry (insertion order — Set preserves it).
+      const oldest = seenIds.values().next().value;
+      if (oldest !== undefined) seenIds.delete(oldest);
+    }
+    return false;
+  };
+}
+
 interface ReplyAdapter {
   sendProgress: (target: ResponseTarget, text: string) => Promise<void>;
   clearProgress: (target: ResponseTarget) => Promise<void>;

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -224,7 +224,7 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
   // cortex#491 belt-and-braces — render idempotency keyed by `envelope.id`.
   // Shared with the dispatch sink since cortex#987 (which hit the
   // overlapping-pattern double-delivery this guards against, live).
-  const alreadyRendered = createRenderDedupe();
+  const dedupe = createRenderDedupe();
 
   /**
    * Resolve a native target for the logical address, PREFERRING the reviewing
@@ -286,14 +286,16 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
     // mark seen only once we know this envelope WOULD post (routing present,
     // text non-empty) so a non-actionable envelope doesn't consume a window
     // slot. A second delivery of the same id is a silent no-op.
-    if (alreadyRendered(envelope.id)) return;
+    if (!dedupe.claim(envelope.id)) return;
 
     let target: ResponseTarget | null;
     try {
       target = await resolveTarget(routing, reviewingAgentId(envelope));
     } catch (err) {
       // A resolve failure (e.g. a thread-create API error) must not crash
-      // the fan-out. Log and drop this delivery.
+      // the fan-out. Log and drop this delivery — releasing the dedupe
+      // claim so a redelivery can retry (no render happened).
+      dedupe.release(envelope.id);
       process.stderr.write(
         `cortex: review-sink resolveLogicalTarget failed (surface=${routing.surface}, ` +
           `channel=${routing.channel}, type=${envelope.type}): ` +
@@ -318,7 +320,9 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
         // no-empty-catch rule). The review already completed on the bus;
         // only the surface delivery failed (rate limit, deleted channel,
         // etc.). The authoritative verdict still reached pilot via
-        // correlation_id.
+        // correlation_id. Release the dedupe claim so a redelivery can
+        // retry the render (sage finding on cortex#988).
+        dedupe.release(envelope.id);
         process.stderr.write(
           `cortex: review-sink postResponse failed (surface=${routing.surface}, ` +
             `channel=${routing.channel}, type=${envelope.type}): ` +

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -61,6 +61,7 @@ import {
   formatReviewVerdict,
 } from "./envelope-renderer";
 import {
+  createRenderDedupe,
   deliverRoutedResponse,
   LIFECYCLE_TYPE_PREFIX,
   readLogicalRouting,
@@ -221,25 +222,9 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
   let subscribers: MyelinSubscriber[] = [];
 
   // cortex#491 belt-and-braces — render idempotency keyed by `envelope.id`.
-  // The runtime-level subscribe dedupe (cortex#491 in `runtime.ts`) is the
-  // primary defence against double-delivery; this second layer guarantees
-  // that even an accidental double-delivery from a misconfig (or a future
-  // overlapping-pattern path) cannot produce TWO GitHub/Discord renders for
-  // one envelope. Bounded so a long-lived sink can't leak: oldest ids evict
-  // once the window fills (envelopes arrive in roughly-temporal order, so a
-  // genuine duplicate lands well within the window).
-  const seenIds = new Set<string>();
-  const SEEN_WINDOW = 4096;
-  function alreadyRendered(id: string): boolean {
-    if (seenIds.has(id)) return true;
-    seenIds.add(id);
-    if (seenIds.size > SEEN_WINDOW) {
-      // Evict the oldest entry (insertion order — Set preserves it).
-      const oldest = seenIds.values().next().value;
-      if (oldest !== undefined) seenIds.delete(oldest);
-    }
-    return false;
-  }
+  // Shared with the dispatch sink since cortex#987 (which hit the
+  // overlapping-pattern double-delivery this guards against, live).
+  const alreadyRendered = createRenderDedupe();
 
   /**
    * Resolve a native target for the logical address, PREFERRING the reviewing

--- a/src/gateway/__tests__/cross-principal-routing.integration.test.ts
+++ b/src/gateway/__tests__/cross-principal-routing.integration.test.ts
@@ -201,13 +201,18 @@ function inbound(overrides: Partial<InboundMessage>): InboundMessage {
 }
 
 /** A `dispatch.task.completed` lifecycle envelope echoing a response routing. */
+// cortex#987 — unique id per fixture envelope: the dispatch sink dedupes
+// renders by `envelope.id`, so a shared hardcoded id would make distinct
+// replies look like duplicate deliveries of one envelope.
+let completedSeq = 0;
 function completedEnvelope(routing: {
   adapter_instance: string;
   channel_id: string;
   thread_id?: string;
 }, chatResponse: string): Envelope {
+  completedSeq += 1;
   return {
-    id: "00000000-0000-4000-8000-0000000000aa",
+    id: `00000000-0000-4000-8000-${String(completedSeq).padStart(10, "0")}aa`,
     source: "any.runner.local",
     type: "dispatch.task.completed",
     timestamp: "2026-06-03T00:01:00Z",

--- a/src/runner/__tests__/prompt-builder.test.ts
+++ b/src/runner/__tests__/prompt-builder.test.ts
@@ -239,5 +239,16 @@ describe("buildPrompt", () => {
       });
       expect(result).not.toContain("Never repeat or imitate them");
     });
+
+    test("bare mention without context carries no guard either (sage cycle-4)", () => {
+      const result = buildPrompt({
+        msg: makeMsg({ content: "" }),
+        context: [],
+        isResume: false,
+        attachmentPrompt: "",
+        securityPreamble: "",
+      });
+      expect(result).not.toContain("Never repeat or imitate them");
+    });
   });
 });

--- a/src/runner/__tests__/prompt-builder.test.ts
+++ b/src/runner/__tests__/prompt-builder.test.ts
@@ -159,4 +159,63 @@ describe("buildPrompt", () => {
       expect(result.endsWith("[file]")).toBe(true);
     });
   });
+
+  // cortex#987 — principal attribution + anti-imitation guard
+  describe("context poisoning defences (cortex#987)", () => {
+    test("authorIsPrincipal stamps the principal attribution on a new conversation", () => {
+      const result = buildPrompt({
+        msg: makeMsg({ authorName: "admin-test", authorIsPrincipal: true, content: "who are you?" }),
+        context: sampleContext,
+        isResume: false,
+        attachmentPrompt: "",
+        securityPreamble: "",
+      });
+      expect(result).toContain("admin-test (your principal — already authorized by the policy gate)");
+    });
+
+    test("authorIsPrincipal stamps the attribution on the resume path", () => {
+      const result = buildPrompt({
+        msg: makeMsg({ authorName: "admin-test", authorIsPrincipal: true, content: "hello" }),
+        context: [],
+        isResume: true,
+        attachmentPrompt: "",
+        securityPreamble: "",
+      });
+      expect(result).toContain("[Message from admin-test (your principal — already authorized by the policy gate)]");
+    });
+
+    test("non-principal authors keep the bare author name", () => {
+      const result = buildPrompt({
+        msg: makeMsg({ authorName: "stranger", content: "hi" }),
+        context: sampleContext,
+        isResume: false,
+        attachmentPrompt: "",
+        securityPreamble: "",
+      });
+      expect(result).toContain("Latest message from stranger:");
+      expect(result).not.toContain("your principal");
+    });
+
+    test("anti-imitation guard accompanies any non-empty context", () => {
+      const result = buildPrompt({
+        msg: makeMsg({ content: "hello" }),
+        context: sampleContext,
+        isResume: false,
+        attachmentPrompt: "",
+        securityPreamble: "",
+      });
+      expect(result).toContain("Never repeat or imitate them");
+    });
+
+    test("no guard without context (nothing to imitate)", () => {
+      const result = buildPrompt({
+        msg: makeMsg({ content: "hello" }),
+        context: [],
+        isResume: false,
+        attachmentPrompt: "",
+        securityPreamble: "",
+      });
+      expect(result).not.toContain("Never repeat or imitate them");
+    });
+  });
 });

--- a/src/runner/__tests__/prompt-builder.test.ts
+++ b/src/runner/__tests__/prompt-builder.test.ts
@@ -184,6 +184,28 @@ describe("buildPrompt", () => {
       expect(result).toContain("[Message from admin-test (your principal — already authorized by the policy gate)]");
     });
 
+    test("principal attribution applies on the context-less new-conversation path too", () => {
+      const result = buildPrompt({
+        msg: makeMsg({ authorName: "admin-test", authorIsPrincipal: true, content: "hello" }),
+        context: [],
+        isResume: false,
+        attachmentPrompt: "",
+        securityPreamble: "",
+      });
+      expect(result).toContain("[Message from admin-test (your principal — already authorized by the policy gate)]: hello");
+    });
+
+    test("non-principal context-less messages stay bare content", () => {
+      const result = buildPrompt({
+        msg: makeMsg({ authorName: "stranger", content: "hi there" }),
+        context: [],
+        isResume: false,
+        attachmentPrompt: "",
+        securityPreamble: "",
+      });
+      expect(result).toBe("hi there");
+    });
+
     test("non-principal authors keep the bare author name", () => {
       const result = buildPrompt({
         msg: makeMsg({ authorName: "stranger", content: "hi" }),

--- a/src/runner/prompt-builder.ts
+++ b/src/runner/prompt-builder.ts
@@ -35,21 +35,43 @@ export function buildPrompt(opts: PromptBuildOpts): string {
   const formatted = formatContextForClaude(context);
   const isThread = !!msg.threadId;
 
+  // cortex#987 — principal attribution. `authorIsPrincipal` is the
+  // non-spoofable trust signal the adapter stamps from the PolicyEngine
+  // (cortex#729); surfacing it in the prompt lets the session KNOW the
+  // platform username it sees is its principal. Without this, a session on a
+  // platform where the principal's username is unfamiliar (e.g. a corporate
+  // Mattermost handle) cannot tell the principal from a stranger and may
+  // refuse or hedge incorrectly.
+  const author = msg.authorIsPrincipal === true
+    ? `${msg.authorName} (your principal — already authorized by the policy gate)`
+    : msg.authorName;
+
+  // cortex#987 — anti-imitation guard. Channel context can contain the
+  // assistant's OWN past infrastructure posts (policy denials, error
+  // notices). Without this guard a session has imitated a historical denial
+  // template verbatim instead of answering (the context-poisoning parrot).
+  // Authorization is enforced BEFORE the session spawns, so the session must
+  // never re-litigate it from context.
+  const contextGuard =
+    "\n\nNote: messages tagged assistant_message are your own previous posts and may " +
+    "include automated system or error notices. Never repeat or imitate them — " +
+    "authorization was already enforced before this session started; compose a fresh reply.";
+
   let prompt: string;
 
   if (isResume) {
     // Resuming a thread session — CC already has context
     prompt = msg.content
-      ? `[Message from ${msg.authorName}]: ${msg.content}`
-      : `The user ${msg.authorName} mentioned you again in this thread. Please respond to the latest messages.`;
+      ? `[Message from ${author}]: ${msg.content}`
+      : `The user ${author} mentioned you again in this thread. Please respond to the latest messages.`;
   } else if (msg.content) {
     // New conversation with content
     prompt = formatted
-      ? `You are responding in a ${msg.platform === "discord" ? "Discord" : msg.platform === "mattermost" ? "Mattermost" : msg.platform} ${isThread ? "thread" : "channel"}. Here's the recent conversation:\n${formatted}\n\nLatest message from ${msg.authorName}:\n${msg.content}`
+      ? `You are responding in a ${msg.platform === "discord" ? "Discord" : msg.platform === "mattermost" ? "Mattermost" : msg.platform} ${isThread ? "thread" : "channel"}. Here's the recent conversation:\n${formatted}${contextGuard}\n\nLatest message from ${author}:\n${msg.content}`
       : msg.content;
   } else {
     // Bare mention — no content
-    prompt = `You are responding in a ${msg.platform === "discord" ? "Discord" : msg.platform === "mattermost" ? "Mattermost" : msg.platform} ${isThread ? "thread" : "channel"}. A user mentioned you to get your input on the conversation. Here's the recent conversation:\n${formatted}\n\nPlease respond to the conversation above. The user who mentioned you is ${msg.authorName}.`;
+    prompt = `You are responding in a ${msg.platform === "discord" ? "Discord" : msg.platform === "mattermost" ? "Mattermost" : msg.platform} ${isThread ? "thread" : "channel"}. A user mentioned you to get your input on the conversation. Here's the recent conversation:\n${formatted}${contextGuard}\n\nPlease respond to the conversation above. The user who mentioned you is ${author}.`;
   }
 
   // Append attachment context

--- a/src/runner/prompt-builder.ts
+++ b/src/runner/prompt-builder.ts
@@ -76,7 +76,7 @@ export function buildPrompt(opts: PromptBuildOpts): string {
         : msg.content;
   } else {
     // Bare mention — no content
-    prompt = `You are responding in a ${msg.platform === "discord" ? "Discord" : msg.platform === "mattermost" ? "Mattermost" : msg.platform} ${isThread ? "thread" : "channel"}. A user mentioned you to get your input on the conversation. Here's the recent conversation:\n${formatted}${contextGuard}\n\nPlease respond to the conversation above. The user who mentioned you is ${author}.`;
+    prompt = `You are responding in a ${msg.platform === "discord" ? "Discord" : msg.platform === "mattermost" ? "Mattermost" : msg.platform} ${isThread ? "thread" : "channel"}. A user mentioned you to get your input on the conversation. Here's the recent conversation:\n${formatted}${formatted ? contextGuard : ""}\n\nPlease respond to the conversation above. The user who mentioned you is ${author}.`;
   }
 
   // Append attachment context

--- a/src/runner/prompt-builder.ts
+++ b/src/runner/prompt-builder.ts
@@ -65,10 +65,15 @@ export function buildPrompt(opts: PromptBuildOpts): string {
       ? `[Message from ${author}]: ${msg.content}`
       : `The user ${author} mentioned you again in this thread. Please respond to the latest messages.`;
   } else if (msg.content) {
-    // New conversation with content
+    // New conversation with content. Without context the prompt stays close
+    // to the bare content, but a principal's message still carries the
+    // attribution (cortex#987 — the trust signal must reach EVERY path, not
+    // only the context-bearing branch).
     prompt = formatted
       ? `You are responding in a ${msg.platform === "discord" ? "Discord" : msg.platform === "mattermost" ? "Mattermost" : msg.platform} ${isThread ? "thread" : "channel"}. Here's the recent conversation:\n${formatted}${contextGuard}\n\nLatest message from ${author}:\n${msg.content}`
-      : msg.content;
+      : msg.authorIsPrincipal === true
+        ? `[Message from ${author}]: ${msg.content}`
+        : msg.content;
   } else {
     // Bare mention — no content
     prompt = `You are responding in a ${msg.platform === "discord" ? "Discord" : msg.platform === "mattermost" ? "Mattermost" : msg.platform} ${isThread ? "thread" : "channel"}. A user mentioned you to get your input on the conversation. Here's the recent conversation:\n${formatted}${contextGuard}\n\nPlease respond to the conversation above. The user who mentioned you is ${author}.`;

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -98,6 +98,10 @@ export type WsServerMessage =
   // "projection writes bypass WS fan-out" gap.
   | {
       type: "mc.projection";
+      // This union MIRRORS `ProjectionFamily` in `surface/mc/notifications.ts`
+      // (whose doc comment declares the mirror); keep the two in sync.
+      // `governance.verdict` added here because the family gained it while the
+      // frame didn't — the drift tsc caught on cortex#988.
       family:
         | "dispatch.lifecycle"
         | "review.verdict"

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -101,6 +101,7 @@ export type WsServerMessage =
       family:
         | "dispatch.lifecycle"
         | "review.verdict"
+        | "governance.verdict"
         | "agent.heartbeat"
         | "attention"
         | "adapter.health";


### PR DESCRIPTION
## Summary

Fixes the two user-visible defects from the cortex#987 investigation (jc/switch SecureChat):

### 1. Context poisoning — the parrot
A live chat session imitated a historical policy-denial template verbatim from fetched channel context instead of answering (full forensics in #987). Two prompt-builder defences:
- **Principal attribution**: the adapter's non-spoofable `authorIsPrincipal` signal (cortex#729) now reaches the prompt — the author is rendered as `<name> (your principal — already authorized by the policy gate)` on all three prompt paths (resume / new-with-content / bare-mention).
- **Anti-imitation guard**: whenever context is included, the prompt states that `assistant_message` entries are the session's own past posts (possibly automated infra notices), never to be repeated or imitated, and that authorization was enforced before the session started.

### 2. Dispatch-sink double-posting
`runtime.onEnvelope` is a global per-delivery fan-out. An external overlapping subscription — live case: `nats.subjects[]` wildcards in `system/system.yaml` that also matched `dispatch.task.>` — makes the runtime receive each envelope twice and the dispatch-sink posted every reply twice. The review-sink already carried the cortex#491 belt-and-braces render-dedupe for exactly this scenario; this PR extracts it as `createRenderDedupe()` (shared, bounded 4096-id window, **claim/release** semantics) and wires it into the dispatch-sink. The review-sink moves onto the shared helper with one deliberate behavior change (sage cycle-2 finding): a claim is now **released** when the render fails (resolve failure or post failure), so a redelivery of an envelope that never rendered can retry instead of being suppressed; successful renders dedupe exactly as before.

### Drive-by (repo rule: fix all errors found)
- Pre-existing `tsc` error: `mc.projection` WS frame union missing `governance.verdict` (notifications.ts `ProjectionFamily` and `ws/types.ts` are documented mirrors).
- Test fixtures hardcoding one envelope id now generate unique ids — the dedupe correctly flags a repeated id as a duplicate delivery.

## Tests
- New: double-delivery → exactly one post; distinct envelopes unaffected; principal attribution (all paths); guard present with context / absent without; non-principal unchanged.
- Full suite: **6235 pass / 0 fail**, lint clean, tsc clean.

## Out of scope (tracked in #987)
- Poller re-processing after channel deletions; misleading `check apiToken` diagnostic; missing log timestamps; cross-stack redelivery loop; the NetSec-demo `nats.subjects` wildcards themselves (config — already scoped on the live stack); content-filter watermarking of infra posts (the stronger long-term fix).

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
