### PR TITLE
fix(mc): red main — widen mc.projection WS frame union (governance.verdict)

### DIFF
--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -98,12 +98,17 @@ export type WsServerMessage =
   // "projection writes bypass WS fan-out" gap.
   | {
       type: "mc.projection";
+      // MUST stay in sync with `ProjectionFamily` (notifications.ts). When that
+      // type gains a member and this union doesn't, `broadcastProjection` fails
+      // tsc (TS2322) — which is how main went red after `governance.verdict`
+      // landed. Drift-dedup follow-up: reference ProjectionFamily directly.
       family:
         | "dispatch.lifecycle"
         | "review.verdict"
         | "agent.heartbeat"
         | "attention"
-        | "adapter.health";
+        | "adapter.health"
+        | "governance.verdict";
       sessionId?: string;
       assignmentId?: string;
     }


### PR DESCRIPTION
**Red-main fix (SOP §4, highest priority — blocks every PR's Typecheck gate).**

`origin/main` (b92469e) fails CI Typecheck: `ProjectionFamily` (notifications.ts:195) gained `governance.verdict` but the `mc.projection` `WsServerMessage` frame union (ws/types.ts:103) didn't, so `broadcastProjection` errors TS2322. One-line union widening + a sync-warning comment.

Verified: `bunx tsc --noEmit` → 0 errors; projection/ws tests pass. Follow-up: dedup the two unions (reference ProjectionFamily) so this can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)