### PR TITLE
fix(config-merge): write timestamped backup atomically at mode 0o600 (#883)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c"],
+    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c", "sha512-PlffOgC1qoiqomRUVIM3nSE61q0VigytzlOMNcyKlmZT8r7cAgR7+vLQgSbVxNfrFoZVAmx0kgKF6TQnT5UNag=="],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
@@ -124,7 +124,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#f5ec865", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-f5ec865"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#f5ec865", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-f5ec865", "sha512-Uu/giX/FcCwBPrVce/MYWqcx5y7wWK11trpi2wc+a7Jl52hd93vzoluEJlcpqmtQqIPRXMVPtRjlcMnUBuhWcw=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/src/cli/cortex/commands/__tests__/config-merge.test.ts
+++ b/src/cli/cortex/commands/__tests__/config-merge.test.ts
@@ -28,7 +28,7 @@
  */
 
 import { describe, expect, test, beforeEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, chmodSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync, chmodSync, statSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import YAML from "yaml";
@@ -339,6 +339,22 @@ describe("runConfigMerge — CLI", () => {
 
     const backups = readdirSync(join(dir, "stacks")).filter((f) => f.includes(".pre-config-merge-"));
     expect(backups.length).toBe(1);
+  });
+
+  test("#883 backup file is created with mode 0o600 (secret-at-rest)", async () => {
+    // The backup can carry platform tokens (Discord/Slack/Mattermost) from
+    // the source cortex.yaml. It must not be world-readable. Mirrors the
+    // chmod-600 enforcement on cortex.yaml itself (#644 / TC-4a).
+    const dir = makeSplitDir({ research: stackLayer() });
+    const frag = writeFragment("frag.yaml", { capabilities: [CAP_DEV] });
+
+    const code = await runConfigMerge(["--config", dir, "--fragment", frag]);
+    expect(code).toBe(0);
+
+    const backups = readdirSync(join(dir, "stacks")).filter((f) => f.includes(".pre-config-merge-"));
+    expect(backups.length).toBe(1);
+    const backupPath = join(dir, "stacks", backups[0]!);
+    expect(statSync(backupPath).mode & 0o777).toBe(0o600);
   });
 
   test("idempotent — second run writes nothing (no second backup)", async () => {

--- a/src/cli/cortex/commands/config-merge.ts
+++ b/src/cli/cortex/commands/config-merge.ts
@@ -722,9 +722,14 @@ export async function runConfigMerge(argv: string[]): Promise<number> {
   }
 
   // 8. Timestamped backup, then in-place write.
+  // The backup can carry platform tokens (Discord/Slack/Mattermost) lifted
+  // from the original cortex.yaml — write with mode 0o600 atomically so the
+  // file never exists at the default umask between create and chmod. Matches
+  // the cortex.yaml chmod-600 enforcement (#644 / TC-4a) and the cloud.ts
+  // credential-write pattern. Closes #883.
   const backupPath = buildBackupPath(target.filePath);
   try {
-    writeFileSync(backupPath, originalText, "utf-8");
+    writeFileSync(backupPath, originalText, { encoding: "utf-8", mode: 0o600 });
     process.stderr.write(`config ${verb}: backup saved to ${backupPath}\n`);
   } catch (err) {
     process.stderr.write(


### PR DESCRIPTION
Closes #883. (Supersedes #919, whose head branch was deleted and detached from the rebased commit.)

The `cortex config merge` backup can carry platform tokens (Discord/Slack/Mattermost) lifted from the original config. Write it **atomically at mode 0o600** (`writeFileSync(..., { mode: 0o600 })`) so it never exists world-readable at the default umask between create and chmod — matching the cortex.yaml chmod-600 enforcement (#644/TC-4a). The F-6a security follow-up.

Rebased onto green main (post-#991). tsc clean; config-merge suite 36 pass.