### PR TITLE
feat(runner): W5.0 — signed-commit enforcement for the dev-loop (cortex#924 cortex half)

### DIFF
--- a/src/runner/__tests__/commit-signing.test.ts
+++ b/src/runner/__tests__/commit-signing.test.ts
@@ -1,0 +1,151 @@
+/**
+ * W5.0 (cortex#924) — signed-commit enforcement tests.
+ *
+ * The loop's commits MUST be signed; signing is NEVER disabled. These tests
+ * assert the pure policy core:
+ *   - `parseSignatureTrust` reads `git log --format=%G?` output → per-commit
+ *     trust levels.
+ *   - `verifyCommitsSigned` PASSES iff every commit's trust is `G` (a good
+ *     signature); ANYTHING short (`N` unsigned, `B` bad, `E` cannot-check,
+ *     `U`/`X`/`Y`/`R` lower trust) → FAIL, fail-closed.
+ *   - `assertSigningEnabled` refuses an env/config where signing is off or
+ *     where a `--no-gpg-sign` style override is present.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  parseSignatureTrust,
+  verifyCommitsSigned,
+  assertSigningConfig,
+  SigningDisabledError,
+} from "../commit-signing";
+
+describe("parseSignatureTrust", () => {
+  test("parses one trust char per line", () => {
+    expect(parseSignatureTrust("G\nG\nG\n")).toEqual(["G", "G", "G"]);
+  });
+
+  test("trims blank trailing lines", () => {
+    expect(parseSignatureTrust("G\n\n")).toEqual(["G"]);
+  });
+
+  test("an unsigned commit surfaces as N", () => {
+    expect(parseSignatureTrust("G\nN\nG")).toEqual(["G", "N", "G"]);
+  });
+
+  test("empty output → empty list", () => {
+    expect(parseSignatureTrust("")).toEqual([]);
+    expect(parseSignatureTrust("   \n")).toEqual([]);
+  });
+});
+
+describe("verifyCommitsSigned — every commit must be G", () => {
+  test("all G → ok", () => {
+    const r = verifyCommitsSigned(["G", "G", "G"]);
+    expect(r.ok).toBe(true);
+  });
+
+  test("any N (unsigned) → fail, names the bad trust levels", () => {
+    const r = verifyCommitsSigned(["G", "N", "G"]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toMatch(/N/);
+      expect(r.badCount).toBe(1);
+    }
+  });
+
+  test("B (bad signature) → fail", () => {
+    const r = verifyCommitsSigned(["B"]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.badCount).toBe(1);
+  });
+
+  test("E (cannot check) → fail (fail-closed — unknown is not good)", () => {
+    const r = verifyCommitsSigned(["E"]);
+    expect(r.ok).toBe(false);
+  });
+
+  test("U / X / Y / R (good-but-lower trust) → fail (we require full G)", () => {
+    for (const t of ["U", "X", "Y", "R"]) {
+      const r = verifyCommitsSigned([t]);
+      expect(r.ok).toBe(false);
+    }
+  });
+
+  test("empty commit set → fail-closed (nothing verified is not 'all signed')", () => {
+    const r = verifyCommitsSigned([]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/no commits/i);
+  });
+});
+
+describe("assertSigningConfig — never run with signing disabled", () => {
+  test("commit.gpgsign true + format + key + agent socket → ok", () => {
+    expect(() =>
+      assertSigningConfig({
+        gpgSign: "true",
+        gpgFormat: "ssh",
+        signingKey: "/Users/x/.ssh/id_ed25519.pub",
+        sshAuthSock: "/private/tmp/agent.sock",
+      }),
+    ).not.toThrow();
+  });
+
+  test("commit.gpgsign false → throws SigningDisabledError", () => {
+    expect(() =>
+      assertSigningConfig({
+        gpgSign: "false",
+        gpgFormat: "ssh",
+        signingKey: "/k.pub",
+        sshAuthSock: "/s.sock",
+      }),
+    ).toThrow(SigningDisabledError);
+  });
+
+  test("missing signing key → throws", () => {
+    expect(() =>
+      assertSigningConfig({
+        gpgSign: "true",
+        gpgFormat: "ssh",
+        signingKey: undefined,
+        sshAuthSock: "/s.sock",
+      }),
+    ).toThrow(SigningDisabledError);
+  });
+
+  test("ssh format but no SSH_AUTH_SOCK (key not loaded — apple-load-keychain not run) → throws", () => {
+    expect(() =>
+      assertSigningConfig({
+        gpgSign: "true",
+        gpgFormat: "ssh",
+        signingKey: "/k.pub",
+        sshAuthSock: undefined,
+      }),
+    ).toThrow(SigningDisabledError);
+  });
+
+  test("gpg (non-ssh) format does NOT require SSH_AUTH_SOCK", () => {
+    expect(() =>
+      assertSigningConfig({
+        gpgSign: "true",
+        gpgFormat: "openpgp",
+        signingKey: "ABCD1234",
+        sshAuthSock: undefined,
+      }),
+    ).not.toThrow();
+  });
+
+  test("error message names the disabled knob (no empty catch, surfaceable)", () => {
+    try {
+      assertSigningConfig({
+        gpgSign: "false",
+        gpgFormat: "ssh",
+        signingKey: "/k.pub",
+        sshAuthSock: "/s.sock",
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SigningDisabledError);
+      expect((err as Error).message).toMatch(/commit\.gpgsign/);
+    }
+  });
+});

--- a/src/runner/commit-signing.ts
+++ b/src/runner/commit-signing.ts
@@ -1,0 +1,170 @@
+/**
+ * W5.0 (cortex#924) — signed-commit enforcement for the dev-loop.
+ *
+ * ## Policy
+ *
+ * Every commit the loop produces MUST be signed; signing is NEVER disabled.
+ * Two enforcement surfaces, both fail-closed:
+ *
+ *   1. `assertSigningConfig` — a precondition guard. Before a dev/release
+ *      session is allowed to commit, the git signing config must be ON
+ *      (`commit.gpgsign=true`, a `user.signingkey` set, a `gpg.format`), and
+ *      for the SSH signer the agent socket must be present (`SSH_AUTH_SOCK` —
+ *      proof the key was loaded, e.g. via `ssh-add --apple-load-keychain`).
+ *      A missing/false knob throws {@link SigningDisabledError} rather than
+ *      silently producing unsigned commits.
+ *
+ *   2. `verifyCommitsSigned` — a postcondition check at the push boundary
+ *      (`DevForge.openPr` / `ReleaseExecutor.cutRelease`). It reads
+ *      `git log --format=%G?` over the commits about to be pushed and PASSES
+ *      iff EVERY commit's signature trust is `G` (a good, fully-trusted
+ *      signature). Anything short — `N` (unsigned), `B` (bad), `E` (cannot
+ *      check), or the good-but-lower `U`/`X`/`Y`/`R` — fails closed. The push
+ *      is refused; the loop NEVER lands an unsigned commit.
+ *
+ * `%G?` legend (git pretty-format): G=good, B=bad, U=good-untrusted,
+ * X=good-expired, Y=good-expired-key, R=good-revoked-key, E=cannot-check,
+ * N=no-signature. We require the strictest `G` — a dev-loop commit on a
+ * protected branch should carry a fully-trusted signature, not a "good but
+ * unverifiable" one.
+ *
+ * ## What this module does NOT do
+ *
+ * It never *creates* a commit and never passes `--no-gpg-sign` — there is no
+ * code path here that can disable signing. Disabling is the prohibited
+ * operation; this module's only verbs are *assert* and *verify*. The commit
+ * itself is made by the CC session (which inherits the signing config from its
+ * env); the runner enforces the policy around it.
+ *
+ * Pure where it can be: `parseSignatureTrust` + `verifyCommitsSigned` +
+ * `assertSigningConfig` take plain inputs and return values / throw. The
+ * git-spawning wrapper (`readCommitSignatures`) is the thin IO seam.
+ */
+
+/**
+ * A `%G?` signature-trust token. The known git levels are G=good-trusted,
+ * B=bad, U=good-untrusted, X=good-expired, Y=good-expired-key,
+ * R=good-revoked-key, E=cannot-check, N=no-signature. Typed as `string` (not a
+ * literal union) so an unknown/future token parses without a cast and is
+ * treated defensively as not-`G` by {@link verifyCommitsSigned}.
+ */
+export type SignatureTrust = string;
+
+/**
+ * Parse `git log --format=%G?` output into one trust char per commit. Blank
+ * lines are dropped (a trailing newline is normal). Pure.
+ */
+export function parseSignatureTrust(stdout: string): SignatureTrust[] {
+  return stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+/** Result of {@link verifyCommitsSigned}. */
+export type VerifyResult =
+  | { ok: true; count: number }
+  | { ok: false; reason: string; badCount: number };
+
+/**
+ * True iff EVERY commit carries a good, fully-trusted signature (`G`). An
+ * empty set fails closed — "nothing to verify" is not "all signed", and the
+ * caller should never reach the push with zero commits on the branch. Pure.
+ */
+export function verifyCommitsSigned(
+  trusts: readonly SignatureTrust[],
+): VerifyResult {
+  if (trusts.length === 0) {
+    return {
+      ok: false,
+      reason: "no commits to verify — refusing to push (fail-closed)",
+      badCount: 0,
+    };
+  }
+  const bad = trusts.filter((t) => t !== "G");
+  if (bad.length > 0) {
+    // Summarize the distinct offending trust levels for the failure detail.
+    const distinct = [...new Set(bad)].join(",");
+    return {
+      ok: false,
+      reason: `${bad.length} of ${trusts.length} commits not fully-signed (trust levels: ${distinct}; require G)`,
+      badCount: bad.length,
+    };
+  }
+  return { ok: true, count: trusts.length };
+}
+
+/** Thrown when the signing config is off/incomplete — fail-closed precondition. */
+export class SigningDisabledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SigningDisabledError";
+  }
+}
+
+/** The signing-relevant git config + env, as plain strings (caller reads them). */
+export interface SigningConfig {
+  /** `git config commit.gpgsign` — must be "true". */
+  gpgSign: string | undefined;
+  /** `git config gpg.format` — "ssh" or "openpgp". */
+  gpgFormat: string | undefined;
+  /** `git config user.signingkey` — must be non-empty. */
+  signingKey: string | undefined;
+  /** `SSH_AUTH_SOCK` from the env — required for the ssh signer. */
+  sshAuthSock: string | undefined;
+}
+
+/**
+ * Assert the environment is configured to sign commits. Throws
+ * {@link SigningDisabledError} (naming the offending knob) when:
+ *   - `commit.gpgsign` is not "true" (signing is off);
+ *   - `user.signingkey` is unset/empty (no key to sign with);
+ *   - the signer is `ssh` but `SSH_AUTH_SOCK` is absent — the key was never
+ *     loaded into the agent (the `ssh-add --apple-load-keychain` step the
+ *     dev-loop env MUST run; its absence is the "key-reload lesson").
+ *
+ * Never disables anything; the only outcomes are pass (return) or refuse
+ * (throw). Pure.
+ */
+export function assertSigningConfig(cfg: SigningConfig): void {
+  if (cfg.gpgSign?.trim().toLowerCase() !== "true") {
+    throw new SigningDisabledError(
+      `commit signing is disabled: commit.gpgsign=${JSON.stringify(cfg.gpgSign)} (must be "true") — NEVER run the dev-loop with signing off`,
+    );
+  }
+  if (!cfg.signingKey || cfg.signingKey.trim() === "") {
+    throw new SigningDisabledError(
+      "commit signing is misconfigured: user.signingkey is unset — no key to sign commits with",
+    );
+  }
+  const format = cfg.gpgFormat?.trim().toLowerCase();
+  if (format === "ssh" && (!cfg.sshAuthSock || cfg.sshAuthSock.trim() === "")) {
+    throw new SigningDisabledError(
+      "ssh commit signing configured but SSH_AUTH_SOCK is unset — the signing key was not loaded into the agent (run `ssh-add --apple-load-keychain` in the dev-loop env)",
+    );
+  }
+}
+
+/** IO seam — runs `git log --format=%G?` over the commit range. */
+export interface CommitSigningIO {
+  /**
+   * Return the raw stdout of `git -C <cwd> log --format=%G? <range>`. `range`
+   * selects the commits about to be pushed (e.g. `origin/main..HEAD`). Throws
+   * on a non-zero git exit (the caller maps the throw to a refusal).
+   */
+  gitSignatureLog: (cwd: string, range: string) => Promise<string>;
+}
+
+/**
+ * Read + verify the signatures of the commits in `range` at `cwd`. Composes
+ * the IO seam with the two pure functions. Returns the {@link VerifyResult};
+ * the caller refuses the push on `ok: false`.
+ */
+export async function readCommitSignatures(
+  io: CommitSigningIO,
+  cwd: string,
+  range: string,
+): Promise<VerifyResult> {
+  const out = await io.gitSignatureLog(cwd, range);
+  return verifyCommitsSigned(parseSignatureTrust(out));
+}

--- a/src/runner/dev-consumer-boot.ts
+++ b/src/runner/dev-consumer-boot.ts
@@ -64,6 +64,7 @@ import {
   type DevOfferAdmissionGate,
 } from "./dev-consumer";
 import { FileDevSessionStore, type DevSessionStore } from "./dev-session-store";
+import { readCommitSignatures, type CommitSigningIO } from "./commit-signing";
 
 export { DevConsumer } from "./dev-consumer";
 
@@ -458,6 +459,32 @@ function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
       if (opts.scopedToken !== undefined && opts.scopedToken.length > 0) {
         childEnv.GH_TOKEN = opts.scopedToken;
       }
+
+      // W5.0 (cortex#924) — signed-commit enforcement, fail-closed at the push
+      // boundary. Every commit on the branch about to be pushed MUST carry a
+      // good, fully-trusted signature (`%G? == G`). An unsigned/bad commit
+      // refuses the push (throws → consumer maps to `cant_do`), so the loop
+      // NEVER lands an unsigned commit. NEVER `--no-gpg-sign`.
+      const signingIO: CommitSigningIO = {
+        gitSignatureLog: async (logCwd, range) => {
+          const r = await run("git", ["log", "--format=%G?", range], {
+            cwd: logCwd,
+            env: childEnv,
+          });
+          return r.stdout;
+        },
+      };
+      const verify = await readCommitSignatures(
+        signingIO,
+        cwd,
+        `origin/${base}..${branch}`,
+      );
+      if (!verify.ok) {
+        throw new Error(
+          `refusing to push ${branch}: commit-signing check failed — ${verify.reason}`,
+        );
+      }
+
       await run("git", ["push", "-u", "origin", branch], { cwd, env: childEnv });
       const body = issue !== undefined ? `${brief}\n\nCloses #${issue}` : brief;
       const args = [

--- a/src/runner/release-consumer.ts
+++ b/src/runner/release-consumer.ts
@@ -261,6 +261,26 @@ export interface ReleaseExecutor {
   }): Promise<ReleaseCutResult>;
 }
 
+// W5.0 (cortex#924) — SIGNED-COMMIT CONTRACT for any production `ReleaseExecutor`.
+//
+// The `release.cut` bump commit MUST be signed; signing is NEVER disabled.
+// The production executor (deferred — F-4.1 ships dormant, no executor) MUST,
+// before pushing the default branch:
+//   1. `assertSigningConfig(...)` over the release env/git-config — refuse if
+//      `commit.gpgsign != true`, no `user.signingkey`, or (ssh signer) no
+//      `SSH_AUTH_SOCK` (the `ssh-add --apple-load-keychain` step must have run).
+//   2. create the bump commit WITHOUT `--no-gpg-sign` (never disable signing),
+//      then `readCommitSignatures(...)` over the pushed range and refuse the
+//      push on any commit whose `%G?` trust is not `G`.
+// Both verbs live in `./commit-signing.ts` so the dev-loop forge and the
+// release executor enforce signing from ONE source. See
+// `docs/design-merge-policy-w5.0.md` (pilot) §4 for the cross-repo rationale.
+//
+// This is a contract note, not a runtime hook, because F-4.1 has no production
+// executor to instrument yet; the dev.implement forge enforces the SAME policy
+// today (`dev-consumer-boot.ts`). The follow-up that wires the real executor
+// wires these two calls.
+
 /**
  * Construction options. Every dependency is injected — no module-scope
  * singletons, no env-derived defaults (mirrors `ReviewConsumerOpts`).


### PR DESCRIPTION
## What

The cortex half of W5.0 (cortex#924): **the loop's commits MUST be signed; signing is NEVER disabled.** Bake the enforcement into the commit/push seams, fail-closed. The load-bearing policy gate lives in the pilot sibling PR (the-metafactory/pilot#164, `Closes #924`); this PR is the signed-commit slice.

## Files

| File | Role |
|---|---|
| `src/runner/commit-signing.ts` | **The pure policy core.** `assertSigningConfig` (precondition: refuse if `commit.gpgsign != true`, no `user.signingkey`, or — ssh signer — no `SSH_AUTH_SOCK`; the `ssh-add --apple-load-keychain` step must have run; throws `SigningDisabledError`, never disables anything). `verifyCommitsSigned` / `parseSignatureTrust` (postcondition: PASS iff every commit `%G? == G`; `N`/`B`/`E`/`U`/`X`/`Y`/`R` or empty → fail-closed). `readCommitSignatures` (thin `git log --format=%G?` IO seam). |
| `src/runner/dev-consumer-boot.ts` | `DevForge.openPr` now **verifies `origin/<base>..<branch>` signatures BEFORE `git push`** and refuses on any unsigned commit (throws → consumer maps to `cant_do`). Never injects `--no-gpg-sign`. |
| `src/runner/release-consumer.ts` | Signed-commit **contract note** on `ReleaseExecutor` — the deferred production executor (F-4.1 ships dormant) MUST `assertSigningConfig` + `readCommitSignatures` via the SAME module before pushing the bump commit. |

## Why a forge-boundary check (not a commit hook)

The commit itself is made by the CC session, which inherits the signing config from its env (`commit.gpgsign=true`, `gpg.format=ssh`, `user.signingkey`, `SSH_AUTH_SOCK`). The runner can't reach inside the session's individual `git commit` calls — so it enforces the policy at the **push boundary it owns**: every commit about to land MUST be `%G? == G`, else the push is refused. This is fail-closed and can't be bypassed by a session that forgot to sign.

## Constraints honored

- **Never `--no-gpg-sign`** — the module has no code path that can disable signing; its only verbs are *assert* and *verify*.
- **No empty catch blocks** — the verify failure throws a named error; the consumer's existing handler maps it to a typed `cant_do`.
- The agent env must `ssh-add --apple-load-keychain` — `assertSigningConfig` refuses (named error) when `SSH_AUTH_SOCK` is absent under the ssh signer, surfacing exactly that lapse.

## Gates

- ✅ `bun test` — **6309 pass / 0 fail** (+16 new: parse, every-G pass, each non-G fail, empty fail-closed, the config-assertion matrix, surfaceable error)
- ✅ `bunx tsc --noEmit` clean
- ✅ `eslint --quiet .` clean

## Coordination

Sibling to the-metafactory/pilot#164 (the policy gate + approver identity + trust-model note, `Closes #924`). Land the pilot gate first (load-bearing); this signing slice is independent and can land in either order.

Do **not** merge — opened for review.

Refs cortex#924, cortex#835.

🤖 Generated with [Claude Code](https://claude.com/claude-code)