### PR TITLE
feat(mc): U1.1 — transcript drill-down, best-available source per session (P-14)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/event-rows.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/event-rows.test.ts
@@ -94,6 +94,112 @@ describe("lib/event-rows — eventToRows", () => {
   });
 });
 
+describe("lib/event-rows — observed-session hook events (U1.1 item 1)", () => {
+  it("maps tool.bash.executed → a tool_use row carrying the command + paired output (NOT raw)", () => {
+    const rows = eventToRows(ev("tool.bash.executed", {
+      tool_name: "Bash",
+      tool_input: { command: "bun test", description: "run tests" },
+      command_preview: "bun test",
+      tool_output: "42 pass\n0 fail",
+      duration_ms: 1234,
+    }));
+    expect(rows).toHaveLength(1);
+    const tu = rows[0] as ToolUseRowShape;
+    expect(tu.kind).toBe("tool_use");
+    expect(tu.name).toBe("Bash");
+    // input is preserved so the expand-toggle shows the full args, same as controlled.
+    expect((tu.input as { command?: string }).command).toBe("bun test");
+    // the hook's tool_output is paired into the same row as a nested tool_result.
+    expect(tu.result?.text).toContain("42 pass");
+    expect(tu.durationMs).toBe(1234);
+  });
+
+  it("maps tool.file.changed → a tool_use row (Edit/Write) with the path", () => {
+    const rows = eventToRows(ev("tool.file.changed", {
+      tool_name: "Edit",
+      tool_input: { file_path: "/src/x.ts", old_string: "a", new_string: "b" },
+      path: "/src/x.ts",
+    }));
+    const tu = rows[0] as ToolUseRowShape;
+    expect(tu.kind).toBe("tool_use");
+    expect(tu.name).toBe("Edit");
+    expect((tu.input as { file_path?: string }).file_path).toBe("/src/x.ts");
+  });
+
+  it("maps tool.file.read → a tool_use row (Read) with the path", () => {
+    const rows = eventToRows(ev("tool.file.read", {
+      tool_name: "Read",
+      tool_input: { file_path: "/src/y.ts" },
+      path: "/src/y.ts",
+    }));
+    const tu = rows[0] as ToolUseRowShape;
+    expect(tu.kind).toBe("tool_use");
+    expect(tu.name).toBe("Read");
+  });
+
+  it("maps a generic tool.{name}.used → a tool_use row using the payload tool_name", () => {
+    const rows = eventToRows(ev("tool.grep.used", {
+      tool_name: "Grep",
+      tool_input: { pattern: "foo", path: "src" },
+    }));
+    const tu = rows[0] as ToolUseRowShape;
+    expect(tu.kind).toBe("tool_use");
+    expect(tu.name).toBe("Grep");
+  });
+
+  it("derives the tool name from the event type when tool_name is absent", () => {
+    const rows = eventToRows(ev("tool.websearch.used", { tool_input: { query: "x" } }));
+    const tu = rows[0] as ToolUseRowShape;
+    expect(tu.kind).toBe("tool_use");
+    // capitalised from the type segment when no explicit tool_name.
+    expect(tu.name.toLowerCase()).toBe("websearch");
+  });
+
+  it("maps agent.task.started → a principal.input row carrying the prompt_preview", () => {
+    const rows = eventToRows(ev("agent.task.started", {
+      prompt_preview: "implement the feature",
+    }));
+    expect(rows).toHaveLength(1);
+    const row = rows[0] as { kind: string; text: string };
+    expect(row.kind).toBe("principal.input");
+    expect(row.text).toBe("implement the feature");
+  });
+
+  it("maps tool.agent.spawned → a tool_use row (Agent) carrying the description", () => {
+    const rows = eventToRows(ev("tool.agent.spawned", {
+      tool_name: "Agent",
+      agent_description: "explore the codebase",
+      tool_input: { description: "explore the codebase" },
+    }));
+    const tu = rows[0] as ToolUseRowShape;
+    expect(tu.kind).toBe("tool_use");
+    expect(tu.name).toBe("Agent");
+  });
+
+  it("still raw-rows an observed event with no usable payload (graceful)", () => {
+    const rows = eventToRows(ev("tool.bash.executed", {}));
+    // No command/input at all — keep it as a tool_use shell, not a crash,
+    // and never a bare RawRow JSON crumb.
+    expect(rows[0]?.kind).toBe("tool_use");
+  });
+
+  it("pairs an observed tool.bash.executed even with no inline output (output arrives null)", () => {
+    const rows = eventsToRows([
+      ev("tool.bash.executed", { tool_name: "Bash", tool_input: { command: "ls" } }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kind).toBe("tool_use");
+  });
+});
+
+interface ToolUseRowShape {
+  kind: string;
+  name: string;
+  input: unknown;
+  durationMs?: number;
+  result?: { text: string };
+}
+
 describe("lib/event-rows — eventsToRows pairing", () => {
   it("pairs tool_result back to tool_use via tool_use_id (no standalone tool_result row)", () => {
     const events: McEvent[] = [

--- a/src/surface/mc/dashboard-v2/__tests__/sideband-lazy-chunk.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/sideband-lazy-chunk.test.ts
@@ -1,0 +1,59 @@
+/**
+ * U1.1 item 4 — the sideband source must live behind a LAZY chunk boundary so
+ * its fetch path + the `timelineToRows` mapper never bloat the entry bundle
+ * (#933 item 4; the network-canvas chunk precedent).
+ *
+ * We assert the boundary STRUCTURALLY (no build needed in unit tests): the
+ * drill-down references the sideband source ONLY through a dynamic `import()`
+ * inside a `React.lazy(...)`, never as a static top-level import — and nothing
+ * in the statically-reachable drill-down graph (drill-down, drill-log,
+ * event-rows, source-merge) statically imports `sideband-timeline`. If a future
+ * edit converts the lazy import to a static one, the chunk would fold into the
+ * entry and this test fails. (`bun run build:dashboard` is the runtime oracle
+ * that confirms the actual split — checked in CI/gates.)
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DIR = join(import.meta.dir, "..");
+
+function read(rel: string): string {
+  return readFileSync(join(DIR, rel), "utf8");
+}
+
+describe("sideband lazy-chunk boundary (U1.1 item 4)", () => {
+  it("drill-down loads the sideband source via React.lazy(() => import(...)), not a static import", () => {
+    const src = read("components/drill-down.tsx");
+    // The dynamic import exists.
+    expect(src).toMatch(/lazy\(\s*\(\)\s*=>\s*import\(["']\.\/sideband-source["']\)\s*\)/);
+    // And there is NO static top-level import of the sideband source.
+    expect(src).not.toMatch(/^\s*import\s+SidebandSource\s+from\s+["']\.\/sideband-source["']/m);
+    expect(src).not.toMatch(/^\s*import\s+.*from\s+["']\.\/sideband-source["']/m);
+  });
+
+  it("the statically-reachable drill-down graph never imports sideband-timeline", () => {
+    // These are all reachable from the entry bundle (drill-down is static).
+    for (const f of [
+      "components/drill-down.tsx",
+      "components/drill-log.tsx",
+      "lib/event-rows.ts",
+      "lib/source-merge.ts",
+    ]) {
+      const src = read(f);
+      expect(src).not.toMatch(/from\s+["'].*sideband-timeline["']/);
+    }
+  });
+
+  it("only the lazy sideband-source component imports the timeline mapper", () => {
+    const src = read("components/sideband-source.tsx");
+    expect(src).toMatch(/from\s+["']\.\.\/lib\/sideband-timeline["']/);
+  });
+
+  it("source-merge (entry-reachable) stays a pure module — no React, no fetch", () => {
+    const src = read("lib/source-merge.ts");
+    expect(src).not.toMatch(/from\s+["']react["']/);
+    expect(src).not.toMatch(/\bfetch\(/);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/sideband-timeline.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/sideband-timeline.test.ts
@@ -1,0 +1,141 @@
+/**
+ * U1.1 item 2 — sideband-timeline → LogRow mapping + span pairing.
+ *
+ * The sideband (`/api/observability/traces/{id}/timeline`) returns a sorted
+ * union of spans and log records (signal `docs/contract/cortex-sideband.md`
+ * §2.3). We pair `tool.X` + `tool.X.result` spans on `parentSpanId` into ONE
+ * tool_use row (name, arg_preview/output_preview when present, duration_ms,
+ * ok/fail), interleaved with log entries — same row components, same CSS.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  timelineToRows,
+  type SidebandTimeline,
+  type SidebandSpan,
+  type SidebandTimelineEntry,
+} from "../lib/sideband-timeline";
+import type { ToolUseRow, ToolResultRow } from "../lib/event-rows";
+
+function span(over: Partial<SidebandSpan> & { spanId: string }): SidebandTimelineEntry {
+  const s: SidebandSpan = {
+    traceId: "t1",
+    spanId: over.spanId,
+    parentSpanId: over.parentSpanId ?? "",
+    name: over.name ?? "tool.read",
+    kind: 1,
+    startTimeUnixNano: over.startTimeUnixNano ?? "1000000000",
+    endTimeUnixNano: over.endTimeUnixNano ?? "2000000000",
+    attributes: over.attributes ?? {},
+    statusCode: over.statusCode ?? 1,
+    statusMessage: over.statusMessage ?? "",
+  };
+  return { kind: "span", timeUnixNano: s.startTimeUnixNano, span: s };
+}
+
+function log(body: string, timeUnixNano = "1500000000"): SidebandTimelineEntry {
+  return {
+    kind: "log",
+    timeUnixNano,
+    log: { timeUnixNano, body, severityText: "INFO", attributes: {} },
+  };
+}
+
+describe("timelineToRows — span pairing on parentSpanId", () => {
+  it("pairs a tool span + its result child span into ONE tool_use row", () => {
+    const tl: SidebandTimeline = {
+      correlation_id: "abc",
+      backend: "victoria",
+      entries: [
+        span({
+          spanId: "s1",
+          name: "tool.bash",
+          attributes: {
+            "tool.name": "Bash",
+            "tool.arg_preview": "bun test",
+            "tool.duration_ms": 1234,
+          },
+        }),
+        span({
+          spanId: "s1r",
+          parentSpanId: "s1",
+          name: "tool.bash.result",
+          attributes: { "tool.output_preview": "42 pass" },
+        }),
+      ],
+    };
+    const rows = timelineToRows(tl);
+    expect(rows).toHaveLength(1);
+    const tu = rows[0] as ToolUseRow;
+    expect(tu.kind).toBe("tool_use");
+    expect(tu.name).toBe("Bash");
+    expect(tu.durationMs).toBe(1234);
+    expect(tu.fidelity).toBe("sideband");
+    expect((tu.result as ToolResultRow).text).toContain("42 pass");
+  });
+
+  it("renders one row per tool when there is no result child (output absent)", () => {
+    const tl: SidebandTimeline = {
+      correlation_id: "abc",
+      backend: "victoria",
+      entries: [
+        span({ spanId: "s1", name: "tool.read", attributes: { "tool.name": "Read", "tool.arg_preview": "/x" } }),
+      ],
+    };
+    const rows = timelineToRows(tl);
+    expect(rows).toHaveLength(1);
+    const tu = rows[0] as ToolUseRow;
+    expect(tu.name).toBe("Read");
+    expect(tu.result).toBeUndefined();
+  });
+
+  it("marks a failed span (statusCode 2) so the renderer can show fail", () => {
+    const tl: SidebandTimeline = {
+      correlation_id: "abc",
+      backend: "victoria",
+      entries: [
+        span({ spanId: "s1", name: "tool.bash", statusCode: 2, statusMessage: "boom", attributes: { "tool.name": "Bash" } }),
+      ],
+    };
+    const tu = timelineToRows(tl)[0] as ToolUseRow & { failed?: boolean };
+    expect(tu.failed).toBe(true);
+  });
+
+  it("interleaves log entries with tool rows in timeline order", () => {
+    const tl: SidebandTimeline = {
+      correlation_id: "abc",
+      backend: "victoria",
+      entries: [
+        span({ spanId: "s1", name: "tool.read", startTimeUnixNano: "1000", attributes: { "tool.name": "Read" } }),
+        log("dispatch.task.received", "1200"),
+        span({ spanId: "s2", name: "tool.bash", startTimeUnixNano: "1400", attributes: { "tool.name": "Bash" } }),
+      ],
+    };
+    const rows = timelineToRows(tl);
+    // 2 tool rows + 1 log row, in order.
+    expect(rows.map((r) => r.kind)).toEqual(["tool_use", "raw", "tool_use"]);
+  });
+
+  it("does NOT emit a standalone row for a paired result span (it's nested)", () => {
+    const tl: SidebandTimeline = {
+      correlation_id: "abc",
+      backend: "victoria",
+      entries: [
+        span({ spanId: "s1", name: "tool.bash", attributes: { "tool.name": "Bash" } }),
+        span({ spanId: "s1r", parentSpanId: "s1", name: "tool.bash.result", attributes: { "tool.output_preview": "ok" } }),
+      ],
+    };
+    const rows = timelineToRows(tl);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kind).toBe("tool_use");
+  });
+
+  it("every tool row carries fidelity 'sideband' (honest preview-grade)", () => {
+    const tl: SidebandTimeline = {
+      correlation_id: "abc",
+      backend: "victoria",
+      entries: [span({ spanId: "s1", name: "tool.read", attributes: { "tool.name": "Read" } })],
+    };
+    expect((timelineToRows(tl)[0] as ToolUseRow).fidelity).toBe("sideband");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/source-merge.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/source-merge.test.ts
@@ -1,0 +1,131 @@
+/**
+ * U1.1 item 3 — source-merge policy + honest fidelity labeling.
+ *
+ * ONE transcript panel, best-available source per session:
+ *   controlled    → stream-json (full fidelity, the existing path)
+ *   local-observed → hook events (item 1; ~80% CC feel)
+ *   else (remote/historical) → sideband timeline (item 2; preview-grade)
+ *
+ * Plus: honest fidelity labels — and on a sideband `backend_unavailable`, an
+ * honest "interior capture not available" message, NOT a crash.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  selectTranscriptSource,
+  fidelityLabel,
+  type TranscriptSessionMeta,
+} from "../lib/source-merge";
+
+function meta(over: Partial<TranscriptSessionMeta> = {}): TranscriptSessionMeta {
+  return {
+    sessionId: "s1",
+    origin: "local",
+    dispatchOrigin: "controlled",
+    correlationId: null,
+    ...over,
+  };
+}
+
+describe("selectTranscriptSource — best-available per session", () => {
+  it("controlled local session → stream-json source (full)", () => {
+    const src = selectTranscriptSource(meta({ dispatchOrigin: "controlled" }));
+    expect(src.kind).toBe("stream-json");
+    if (src.kind === "stream-json") expect(src.fidelity).toBe("full");
+  });
+
+  it("local observed session → hook-events source (observed)", () => {
+    const src = selectTranscriptSource(meta({ dispatchOrigin: "observed" }));
+    expect(src.kind).toBe("hook-events");
+    if (src.kind === "hook-events") expect(src.fidelity).toBe("observed");
+  });
+
+  it("remote/foreign session WITH a correlationId → sideband source (preview)", () => {
+    const src = selectTranscriptSource(meta({
+      origin: { principal: "jc", stack: "research" },
+      dispatchOrigin: "observed",
+      correlationId: "0123abcd",
+    }));
+    expect(src.kind).toBe("sideband");
+    if (src.kind === "sideband") {
+      expect(src.fidelity).toBe("preview");
+      expect(src.correlationId).toBe("0123abcd");
+    }
+  });
+
+  it("falls back to sideband for a local session that is neither controlled nor observed, when a correlationId exists", () => {
+    const src = selectTranscriptSource(meta({
+      dispatchOrigin: "historical",
+      correlationId: "deadbeef",
+    }));
+    expect(src.kind).toBe("sideband");
+  });
+
+  it("returns an 'unavailable' source when no interior path exists (no observed, no correlationId)", () => {
+    const src = selectTranscriptSource(meta({
+      origin: { principal: "jc", stack: "research" },
+      dispatchOrigin: "historical",
+      correlationId: null,
+    }));
+    expect(src.kind).toBe("unavailable");
+  });
+
+  it("NEVER picks stream-json or hook-events for a FOREIGN origin (ADR-0007 local-pane only)", () => {
+    // A foreign peer's interior never lands locally; the only path is the
+    // (local) sideband when a correlationId is known, else unavailable.
+    const observed = selectTranscriptSource(meta({
+      origin: { principal: "jc", stack: "research" },
+      dispatchOrigin: "controlled",
+      correlationId: "abc",
+    }));
+    expect(observed.kind).toBe("sideband");
+    const none = selectTranscriptSource(meta({
+      origin: { principal: "jc", stack: "research" },
+      dispatchOrigin: "controlled",
+      correlationId: null,
+    }));
+    expect(none.kind).toBe("unavailable");
+  });
+});
+
+describe("fidelityLabel — honest labeling", () => {
+  it("full fidelity → no label (controlled is the real thing)", () => {
+    expect(fidelityLabel("full")).toBeNull();
+  });
+
+  it("observed → an honest 'reconstructed from observed hook events' note", () => {
+    const label = fidelityLabel("observed");
+    expect(label).not.toBeNull();
+    expect(label!.toLowerCase()).toContain("observed");
+  });
+
+  it("preview → 'preview-grade — full interior on this session's home stack'", () => {
+    const label = fidelityLabel("preview");
+    expect(label).not.toBeNull();
+    expect(label!.toLowerCase()).toContain("preview-grade");
+    expect(label!.toLowerCase()).toContain("home stack");
+  });
+});
+
+describe("sidebandErrorLabel — backend_unavailable is honest, not a crash", () => {
+  it("backend_unavailable → 'interior capture not available for this session'", async () => {
+    const { sidebandErrorLabel } = await import("../lib/source-merge");
+    const label = sidebandErrorLabel({ code: "backend_unavailable", message: "down" });
+    expect(label.toLowerCase()).toContain("interior capture not available");
+    expect(label.toLowerCase()).not.toContain("undefined");
+  });
+
+  it("backend_timeout → an honest retry-flavoured message", async () => {
+    const { sidebandErrorLabel } = await import("../lib/source-merge");
+    const label = sidebandErrorLabel({ code: "backend_timeout", message: "slow", retry_after_seconds: 5 });
+    expect(label.toLowerCase()).toContain("timed out");
+  });
+
+  it("never throws on a malformed error body", async () => {
+    const { sidebandErrorLabel } = await import("../lib/source-merge");
+    // @ts-expect-error — deliberately malformed (missing `code`)
+    expect(() => sidebandErrorLabel({})).not.toThrow();
+    expect(() => sidebandErrorLabel(null)).not.toThrow();
+    expect(() => sidebandErrorLabel(undefined)).not.toThrow();
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/drill-down.css
+++ b/src/surface/mc/dashboard-v2/components/drill-down.css
@@ -124,6 +124,13 @@
 .drill-log-load-older:hover { color: var(--fg); border-color: var(--accent); }
 .drill-log-empty { color: var(--fg-faint); font-size: 12px; padding: 12px; text-align: center; }
 .drill-log-error { color: var(--bad); font-size: 12px; padding: 8px; }
+/* U1.1 — honest preview-grade banner above a reconstructed transcript. */
+.drill-log-fidelity { color: var(--fg-faint); font-size: 11px; padding: 6px 8px; border-bottom: 1px solid var(--border); margin-bottom: 4px; }
+/* U1.1 — deep-link exit when the sideband can't serve locally. */
+.drill-log-deeplink { display: inline-block; color: var(--accent); font-size: 12px; padding: 8px; text-decoration: none; }
+.drill-log-deeplink:hover { text-decoration: underline; }
+/* U1.1 — per-tool preview badge for observed/sideband-reconstructed rows. */
+.drill-row .tool-pair-fidelity { color: var(--fg-faint); }
 
 .drill-row {
   display: grid;

--- a/src/surface/mc/dashboard-v2/components/drill-down.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-down.tsx
@@ -9,15 +9,22 @@
  * passes the selected `assignmentId`; null hides the overlay.
  */
 
-import { useEffect, useRef } from "react";
+import { Suspense, lazy, useEffect, useRef } from "react";
 import "./drill-down.css";
 import { CurationToolbar } from "./curation-toolbar";
 import { DrillHeader } from "./drill-header";
 import { DrillLog } from "./drill-log";
 import { DrillInput } from "./drill-input";
 import { useDrillEvents } from "../hooks/use-drill-events";
+import { selectTranscriptSource, type TranscriptSessionMeta } from "../lib/source-merge";
 import type { WsClient } from "../hooks/use-websocket";
 import type { AssignmentListItem } from "../../db/assignments";
+
+// U1.1 item 4 — lazy: the sideband fetch path + `timelineToRows` mapper load
+// ONLY when a session actually resolves to the sideband source (remote /
+// historical). Mirrors the network-canvas chunk precedent so the entry bundle
+// stays lean — this is the ONLY dynamic import in the drill-down.
+const SidebandSource = lazy(() => import("./sideband-source"));
 
 export interface DrillDownProps {
   /** When null, the overlay is closed and renders nothing. */
@@ -40,6 +47,14 @@ export interface DrillDownProps {
    * owner navigates to the kanban-detail view for that iteration id.
    */
   onOpenIteration?: (iterationId: string) => void;
+  /**
+   * U1.1 — best-available-source metadata for the opened session. When
+   * supplied, the source-merge policy (`selectTranscriptSource`) decides whether
+   * to render the local event stream (controlled / observed — the default path)
+   * or the lazy SIDEBAND source (remote / historical). Omitted ⇒ the legacy
+   * local event path (the existing blocked-assignment drill-down), unchanged.
+   */
+  sessionMeta?: TranscriptSessionMeta;
 }
 
 export function DrillDown({
@@ -53,9 +68,15 @@ export function DrillDown({
   onToggleFocusMode,
   onSendInput,
   onOpenIteration,
+  sessionMeta,
 }: DrillDownProps) {
   const drillEvents = useDrillEvents(ws, assignmentId);
   const overlayRef = useRef<HTMLDivElement | null>(null);
+
+  // U1.1 source-merge: only divert to the lazy sideband path when the policy
+  // resolves a session to it. Controlled + observed local sessions stay on the
+  // existing event stream (now observed-aware via item 1). No meta ⇒ legacy path.
+  const source = sessionMeta ? selectTranscriptSource(sessionMeta) : null;
 
   // Global keyboard. Esc closes; `]`/`[` cycle; `f` focus-mode (when
   // textarea not focused). Always runs in capture phase so Esc here
@@ -108,13 +129,23 @@ export function DrillDown({
           onToggleFocusMode={onToggleFocusMode}
           {...(onOpenIteration ? { onOpenIteration } : {})}
         />
-        <DrillLog
-          events={drillEvents.events}
-          loaded={drillEvents.loaded}
-          hasMore={drillEvents.hasMore}
-          error={drillEvents.error}
-          onLoadOlder={drillEvents.loadOlder}
-        />
+        {source && source.kind === "sideband" ? (
+          <Suspense fallback={<div className="drill-log-wrap"><div className="drill-log-empty">Loading interior…</div></div>}>
+            <SidebandSource correlationId={source.correlationId} />
+          </Suspense>
+        ) : source && source.kind === "unavailable" ? (
+          <div className="drill-log-wrap" role="log" aria-live="polite">
+            <div className="drill-log-empty">Interior capture not available for this session.</div>
+          </div>
+        ) : (
+          <DrillLog
+            events={drillEvents.events}
+            loaded={drillEvents.loaded}
+            hasMore={drillEvents.hasMore}
+            error={drillEvents.error}
+            onLoadOlder={drillEvents.loadOlder}
+          />
+        )}
         {/*
           F-12 curation toolbar — Decision 2 places it between the log
           and the input. Verb enablement is a pure function of

--- a/src/surface/mc/dashboard-v2/components/drill-log.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-log.tsx
@@ -10,6 +10,7 @@
 import { useMemo, useState } from "react";
 import "../components/drill-down.css";
 import { eventsToRows, type LogRow, type ToolResultRow, type ToolUseRow } from "../lib/event-rows";
+export type { LogRow } from "../lib/event-rows";
 import { renderMarkdown } from "../lib/markdown";
 import { formatBytes, trimToBytes, byteSize } from "../lib/drill-input";
 import { ImageLightbox } from "./image-lightbox";
@@ -25,6 +26,46 @@ export interface DrillLogProps {
 
 export function DrillLog({ events, loaded, hasMore, error, onLoadOlder }: DrillLogProps) {
   const rows = useMemo(() => eventsToRows(events), [events]);
+
+  return (
+    <DrillRowList
+      rows={rows}
+      loaded={loaded}
+      hasMore={hasMore}
+      error={error}
+      onLoadOlder={onLoadOlder}
+      emptyText="No events yet."
+      isInitiallyEmpty={events.length === 0}
+    />
+  );
+}
+
+export interface DrillRowListProps {
+  /** Already-expanded render rows (from `eventsToRows` or `timelineToRows`). */
+  rows: LogRow[];
+  loaded: boolean;
+  hasMore: boolean;
+  error: string | null;
+  onLoadOlder?: () => void;
+  /** Copy for the loaded-but-empty state. */
+  emptyText?: string;
+  /** Whether the underlying source is still empty (drives the "Loading…" state). */
+  isInitiallyEmpty: boolean;
+  /**
+   * U1.1 — an optional honest banner above the rows (e.g. "preview-grade — full
+   * interior on this session's home stack"). Rendered when present.
+   */
+  fidelityBanner?: string | null;
+}
+
+/**
+ * Shared row-list renderer — the SAME components + CSS for the controlled,
+ * observed, and sideband sources (U1.1). Owns the expand/lightbox state so the
+ * sideband-source lazy chunk reuses it rather than duplicating the row grammar.
+ */
+export function DrillRowList({
+  rows, loaded, hasMore, error, onLoadOlder, emptyText, isInitiallyEmpty, fidelityBanner,
+}: DrillRowListProps) {
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
 
@@ -38,17 +79,18 @@ export function DrillLog({ events, loaded, hasMore, error, onLoadOlder }: DrillL
 
   return (
     <div className="drill-log-wrap" role="log" aria-live="polite">
-      {hasMore && (
+      {fidelityBanner && <div className="drill-log-fidelity">◷ {fidelityBanner}</div>}
+      {hasMore && onLoadOlder && (
         <button type="button" className="drill-log-load-older" onClick={onLoadOlder}>
           Load older events
         </button>
       )}
       {error && <div className="drill-log-error">⚠ {error}</div>}
-      {!loaded && events.length === 0 && (
+      {!loaded && isInitiallyEmpty && (
         <div className="drill-log-empty">Loading…</div>
       )}
       {loaded && rows.length === 0 && !error && (
-        <div className="drill-log-empty">No events yet.</div>
+        <div className="drill-log-empty">{emptyText ?? "No events yet."}</div>
       )}
       {rows.map((row) => (
         <DrillRow
@@ -228,6 +270,22 @@ function ToolUseBlock({ row, isExpanded, onToggle }: { row: ToolUseRow; isExpand
       <div>
         <span className="tool-pair-name">{row.name}</span>
         {argSummary && <span style={{ color: "var(--fg-faint)" }}> · {argSummary}</span>}
+        {row.durationMs != null && (
+          <span style={{ color: "var(--fg-faint)" }}> · {(row.durationMs / 1000).toFixed(1)}s</span>
+        )}
+        {row.fidelity && (
+          <span
+            className="tool-pair-fidelity"
+            title={
+              row.fidelity === "observed"
+                ? "Reconstructed from observed hook events — full interior on this session's home stack"
+                : "Preview-grade — full interior on this session's home stack"
+            }
+            style={{ color: "var(--fg-faint)", marginLeft: 6, fontSize: 10 }}
+          >
+            ◷ preview
+          </span>
+        )}
         {(row.input || row.result) && (
           <button
             type="button"

--- a/src/surface/mc/dashboard-v2/components/sideband-source.tsx
+++ b/src/surface/mc/dashboard-v2/components/sideband-source.tsx
@@ -1,0 +1,112 @@
+/**
+ * U1.1 item 2 + 4 — the sideband-timeline transcript source, LAZY-loaded.
+ *
+ * For fleet / remote / historical sessions the interior is reconstructed from
+ * the signal sideband via U0.1's server-side proxy
+ * (`GET /api/observability/traces/{id}/timeline`). This component:
+ *   - fetches the timeline (same-origin; MC proxies to loopback `127.0.0.1:9092`),
+ *   - maps it to the SAME `LogRow[]` grammar via `timelineToRows` (pure),
+ *   - renders it through the SHARED `DrillRowList` (same row components + CSS),
+ *   - degrades HONESTLY on a `SidebandError` (no crash): an "interior capture
+ *     not available" line + the backend `deep_link` as the analyst's exit.
+ *
+ * It is `React.lazy`-imported by the drill-down (per the network-canvas chunk
+ * precedent) so the `sideband-timeline` mapper + this fetch path land in a
+ * SPLIT chunk and never bloat the entry bundle (#933 item 4).
+ *
+ * Default export so `React.lazy(() => import("./sideband-source"))` resolves it.
+ */
+
+import { useEffect, useState } from "react";
+import { DrillRowList } from "./drill-log";
+import { timelineToRows, type SidebandTimeline } from "../lib/sideband-timeline";
+import { fidelityLabel, sidebandErrorLabel } from "../lib/source-merge";
+import type { LogRow } from "../lib/event-rows";
+import type { SidebandError } from "../../../../common/sideband/proxy";
+
+export interface SidebandSourceProps {
+  /** W3C trace_id ≡ correlation_id (sideband path key). */
+  correlationId: string;
+}
+
+type LoadState =
+  | { phase: "loading" }
+  | { phase: "rows"; rows: LogRow[] }
+  | { phase: "error"; message: string; deepLink?: string };
+
+export default function SidebandSource({ correlationId }: SidebandSourceProps) {
+  const [state, setState] = useState<LoadState>({ phase: "loading" });
+
+  useEffect(() => {
+    let alive = true;
+    const ac = new AbortController();
+    setState({ phase: "loading" });
+    (async () => {
+      try {
+        const resp = await fetch(
+          `/api/observability/traces/${encodeURIComponent(correlationId)}/timeline`,
+          { signal: ac.signal, headers: { accept: "application/json" } },
+        );
+        if (!alive) return;
+        if (!resp.ok) {
+          let err: SidebandError | null = null;
+          try {
+            err = (await resp.json()) as SidebandError;
+          } catch {
+            // Body wasn't the structured SidebandError — fall through to the
+            // generic honest label rather than crashing on a parse error.
+            err = null;
+          }
+          if (!alive) return;
+          const next: LoadState = { phase: "error", message: sidebandErrorLabel(err) };
+          if (err?.deep_link) next.deepLink = err.deep_link;
+          setState(next);
+          return;
+        }
+        const tl = (await resp.json()) as SidebandTimeline;
+        if (!alive) return;
+        setState({ phase: "rows", rows: timelineToRows(tl) });
+      } catch (e) {
+        if (!alive) return;
+        if ((e as { name?: string })?.name === "AbortError") return;
+        // Network failure reaching MC itself — still honest, still no crash.
+        setState({ phase: "error", message: sidebandErrorLabel(null) });
+      }
+    })();
+    return () => {
+      alive = false;
+      ac.abort();
+    };
+  }, [correlationId]);
+
+  if (state.phase === "error") {
+    return (
+      <div className="drill-log-wrap" role="log" aria-live="polite">
+        <div className="drill-log-empty">{state.message}</div>
+        {state.deepLink && (
+          <a
+            className="drill-log-deeplink"
+            href={state.deepLink}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            Open in observability backend ↗
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  const rows = state.phase === "rows" ? state.rows : [];
+  return (
+    <DrillRowList
+      rows={rows}
+      loaded={state.phase === "rows"}
+      hasMore={false}
+      error={null}
+      isInitiallyEmpty={rows.length === 0}
+      emptyText="No interior recorded for this session."
+      fidelityBanner={fidelityLabel("preview")}
+    />
+  );
+}

--- a/src/surface/mc/dashboard-v2/lib/event-rows.ts
+++ b/src/surface/mc/dashboard-v2/lib/event-rows.ts
@@ -52,7 +52,31 @@ export interface ToolUseRow extends RowBase {
   toolUseId?: string;
   /** Paired tool_result, if found (same event chain). */
   result?: ToolResultRow;
+  /**
+   * Wall-clock duration in ms, when the source carries it. Controlled
+   * stream-json doesn't (it's on `stream-json.result`), but observed hook
+   * events (`duration_ms`) and sideband spans (`tool.duration_ms`) do —
+   * U1.1 surfaces it inline on the tool row.
+   */
+  durationMs?: number;
+  /**
+   * U1.1 — when the row was reconstructed from a lower-fidelity source than
+   * controlled stream-json (observed hook event, or sideband span), the
+   * renderer can badge it honestly. `undefined` ⇒ full-fidelity controlled.
+   */
+  fidelity?: RowFidelity;
+  /**
+   * U1.1 — sideband spans carry an OTel `statusCode`; a `2` (ERROR) marks the
+   * tool call as failed so the renderer can show an ok/fail affordance.
+   */
+  failed?: boolean;
 }
+
+/**
+ * U1.1 fidelity provenance for a reconstructed row. Drives the honest
+ * "preview-grade" badge — full-fidelity controlled rows carry no badge.
+ */
+export type RowFidelity = "observed" | "sideband";
 
 export interface ToolResultRow extends RowBase {
   kind: "tool_result";
@@ -130,9 +154,39 @@ export function eventToRows(ev: McEvent): LogRow[] {
       return [resultRow(ev)];
     case "stream-json.system":
       return [systemRow(ev)];
+    // --- U1.1 item 1: observed-session hook events → the SAME row grammar ---
+    // These come off the cc-events tap (EventLogger.hook.ts) for sessions cortex
+    // OBSERVES but did not dispatch. The data (tool_input, tool_output,
+    // duration_ms, prompt_preview) is already in the events table; we just need
+    // to render it into tool_use / principal.input rows instead of RawRow crumbs.
+    case "agent.task.started":
+      return [observedTaskStartedRow(ev)];
     default:
+      if (isObservedToolEvent(ev.type)) {
+        return [observedToolRow(ev)];
+      }
       return [rawRow(ev)];
   }
+}
+
+/**
+ * True for the cc-events observed-tool taxonomy — `tool.bash.executed`,
+ * `tool.file.changed`, `tool.file.read`, `tool.agent.spawned`,
+ * `tool.todo.updated`, and the generic `tool.{name}.used` fallthrough. Kept as
+ * a prefix/suffix test (not an enum) so a new `tool.*` event type renders as a
+ * tool row automatically rather than regressing to a RawRow.
+ */
+function isObservedToolEvent(type: string): boolean {
+  if (!type.startsWith("tool.")) return false;
+  return (
+    type === "tool.bash.executed" ||
+    type === "tool.bash.blocked" ||
+    type === "tool.file.changed" ||
+    type === "tool.file.read" ||
+    type === "tool.agent.spawned" ||
+    type === "tool.todo.updated" ||
+    type.endsWith(".used")
+  );
 }
 
 /**
@@ -234,6 +288,84 @@ function userToRows(ev: McEvent): LogRow[] {
     // (principal.input is the authoritative H-source).
   }
   return out;
+}
+
+/**
+ * U1.1 — map an observed tool hook event to a `tool_use` row identical in
+ * shape to the controlled stream-json path, so the renderer treats them the
+ * same (name + expandable args + paired output + duration). The hook's
+ * `tool_output`, when present, is folded into a nested tool_result so the
+ * expand-toggle shows input AND output, matching the controlled feel.
+ */
+function observedToolRow(ev: McEvent): ToolUseRow {
+  const p = ev.payload as Record<string, unknown>;
+  const name = observedToolName(ev.type, p);
+  // Prefer the structured tool_input; fall back to the preview crumbs so a
+  // bash event with only `command_preview` still renders its command in args.
+  let input: unknown = p["tool_input"];
+  if (input === undefined || input === null) {
+    const synth: Record<string, unknown> = {};
+    if (typeof p["command_preview"] === "string") synth["command"] = p["command_preview"];
+    if (typeof p["path"] === "string") synth["file_path"] = p["path"];
+    if (typeof p["agent_description"] === "string") synth["description"] = p["agent_description"];
+    input = Object.keys(synth).length > 0 ? synth : undefined;
+  }
+  const row: ToolUseRow = {
+    id: ev.id, ts: ev.timestamp, color: "d", weight: "secondary",
+    kind: "tool_use", name,
+    input: input ?? null,
+    fidelity: "observed",
+  };
+  if (typeof p["duration_ms"] === "number") row.durationMs = p["duration_ms"] as number;
+  const output = observedToolOutput(p);
+  if (output !== null) {
+    const text = output.slice(0, PREVIEW_BYTES * 4);
+    row.result = {
+      id: `${ev.id}:result`, ts: ev.timestamp, color: "d", weight: "secondary",
+      kind: "tool_result", text, byteSize: byteLength(text),
+    };
+  }
+  return row;
+}
+
+/** Resolve a display tool name for an observed event. */
+function observedToolName(type: string, p: Record<string, unknown>): string {
+  if (typeof p["tool_name"] === "string" && p["tool_name"]) return p["tool_name"] as string;
+  // tool.{name}.used / tool.{name}.executed / tool.file.{changed,read} →
+  // pull the middle segment (e.g. "grep", "bash", "file").
+  const segs = type.split(".");
+  const seg = segs[1] ?? "tool";
+  return seg.charAt(0).toUpperCase() + seg.slice(1);
+}
+
+/** Flatten an observed event's `tool_output` to text, or null when absent. */
+function observedToolOutput(p: Record<string, unknown>): string | null {
+  const out = p["tool_output"];
+  if (typeof out === "string") return out;
+  if (out !== undefined && out !== null) {
+    try { return JSON.stringify(out, null, 2); } catch { return String(out); }
+  }
+  // `summary` is the Stop-hook completion text — surface it as output when
+  // there's no tool_output (e.g. a task-completion observed event).
+  if (typeof p["summary"] === "string") return p["summary"] as string;
+  return null;
+}
+
+/**
+ * U1.1 — an observed `agent.task.started` is the user's prompt for that turn.
+ * Render it as a principal.input row (the same H-source row controlled
+ * sessions use) so the observed transcript opens with the prompt, not a crumb.
+ */
+function observedTaskStartedRow(ev: McEvent): LogRow {
+  const p = ev.payload as Record<string, unknown>;
+  const text = typeof p["prompt_preview"] === "string"
+    ? (p["prompt_preview"] as string)
+    : (typeof p["summary"] === "string" ? (p["summary"] as string) : "");
+  if (!text) return rawRow(ev);
+  return {
+    id: ev.id, ts: ev.timestamp, color: "h", weight: "primary",
+    kind: "principal.input", text,
+  };
 }
 
 function principalInputRow(ev: McEvent): PrincipalInputRow {

--- a/src/surface/mc/dashboard-v2/lib/sideband-timeline.ts
+++ b/src/surface/mc/dashboard-v2/lib/sideband-timeline.ts
@@ -1,0 +1,217 @@
+/**
+ * U1.1 item 2 — sideband-timeline source for fleet / remote / historical
+ * sessions.
+ *
+ * Pure mapper: the sideband's combined timeline (signal
+ * `docs/contract/cortex-sideband.md` §2.3 — a sorted union of OTLP-shaped
+ * spans and log records) → the SAME `LogRow[]` grammar controlled + observed
+ * sessions render through. Tool spans pair with their `*.result` child span on
+ * `parentSpanId` into ONE `tool_use` row (name, `tool.arg_preview` /
+ * `tool.output_preview` when present, `tool.duration_ms`, ok/fail); log records
+ * interleave as `raw` rows in timeline order. Every reconstructed row carries
+ * `fidelity: "sideband"` so the renderer badges it honestly as preview-grade.
+ *
+ * Stays a pure function (no DOM, no fetch) so the span-pairing logic is
+ * unit-testable in isolation. The fetch + lazy-chunk wrapper lives in the
+ * sideband-source component (so this module's cost lands in the split chunk).
+ */
+
+import type { LogRow, ToolUseRow, ToolResultRow, RawRow } from "./event-rows";
+
+/** A span subset mirroring the contract's `SidebandSpan` (§2.1). */
+export interface SidebandSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId: string;
+  name: string;
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes: Record<string, unknown>;
+  statusCode: number;
+  statusMessage: string;
+}
+
+/** A log record subset mirroring the contract's `SidebandLogRecord` (§2.2). */
+export interface SidebandLogRecord {
+  timeUnixNano: string;
+  body: string;
+  severityText: string;
+  attributes: Record<string, unknown>;
+}
+
+/** One entry in the combined timeline (§2.3) — discriminated on `kind`. */
+export type SidebandTimelineEntry =
+  | { kind: "span"; timeUnixNano: string; endTimeUnixNano?: string; span: SidebandSpan }
+  | { kind: "log"; timeUnixNano: string; log: SidebandLogRecord };
+
+/** The `/traces/{id}/timeline` response shape (§2.3). */
+export interface SidebandTimeline {
+  correlation_id: string;
+  backend: string;
+  entries: SidebandTimelineEntry[];
+}
+
+const PREVIEW_BYTES = 10 * 1024;
+
+/**
+ * Map a sideband timeline to render rows. Pairs `tool.X` spans with their
+ * `*.result` child span (keyed by `parentSpanId` → parent's `spanId`),
+ * preserving timeline order for the parent rows; result spans are folded into
+ * the parent and never emitted standalone.
+ */
+export function timelineToRows(tl: SidebandTimeline): LogRow[] {
+  const entries = tl.entries ?? [];
+
+  // First pass: index result spans by their parentSpanId so the parent tool
+  // span can fold its output in. A "result" span is any span whose parent is a
+  // tool span in this trace (we detect via the `parentSpanId` edge); we also
+  // accept the `.result` name convention as a hint.
+  const resultByParent = new Map<string, SidebandSpan>();
+  const spanIds = new Set<string>();
+  for (const e of entries) {
+    if (e.kind === "span") spanIds.add(e.span.spanId);
+  }
+  for (const e of entries) {
+    if (e.kind !== "span") continue;
+    const sp = e.span;
+    if (sp.parentSpanId && spanIds.has(sp.parentSpanId) && isResultSpan(sp)) {
+      // Last-writer-wins on the rare double-result; tool calls pair 1:1.
+      resultByParent.set(sp.parentSpanId, sp);
+    }
+  }
+
+  const rows: LogRow[] = [];
+  for (const e of entries) {
+    if (e.kind === "log") {
+      rows.push(logRow(e.log));
+      continue;
+    }
+    const sp = e.span;
+    // Skip result spans — they're folded into their parent tool row.
+    if (sp.parentSpanId && resultByParent.get(sp.parentSpanId) === sp) continue;
+    if (isResultSpan(sp) && sp.parentSpanId && spanIds.has(sp.parentSpanId)) continue;
+    rows.push(toolRow(sp, resultByParent.get(sp.spanId)));
+  }
+  return rows;
+}
+
+/** A span is a result/child of a tool call when its name ends `.result`. */
+function isResultSpan(sp: SidebandSpan): boolean {
+  return sp.name.endsWith(".result") || sp.name.endsWith("/result");
+}
+
+function toolRow(sp: SidebandSpan, result?: SidebandSpan): ToolUseRow {
+  const attrs = sp.attributes ?? {};
+  const name = pickString(attrs["tool.name"]) ?? toolNameFromSpanName(sp.name);
+  const argPreview = pickString(attrs["tool.arg_preview"]);
+  const ts = nanosToIso(sp.startTimeUnixNano);
+  const row: ToolUseRow = {
+    id: sp.spanId,
+    ts,
+    color: "d",
+    weight: "secondary",
+    kind: "tool_use",
+    name,
+    // The sideband gives PREVIEWS, not full args — surface the arg_preview as
+    // the input so the one-liner + expand show what's available, honestly.
+    input: argPreview != null ? { preview: argPreview } : null,
+    fidelity: "sideband",
+  };
+  const durationMs = pickNumber(attrs["tool.duration_ms"]) ?? durationFromSpan(sp);
+  if (durationMs != null) row.durationMs = durationMs;
+  if (sp.statusCode === 2) row.failed = true;
+
+  const outputPreview =
+    pickString((result?.attributes ?? {})["tool.output_preview"]) ??
+    pickString(attrs["tool.output_preview"]);
+  if (outputPreview != null) {
+    const text = outputPreview.slice(0, PREVIEW_BYTES * 4);
+    const r: ToolResultRow = {
+      id: `${sp.spanId}:result`,
+      ts,
+      color: "d",
+      weight: "secondary",
+      kind: "tool_result",
+      text,
+      byteSize: byteLength(text),
+    };
+    row.result = r;
+  }
+  return row;
+}
+
+function logRow(log: SidebandLogRecord): RawRow {
+  const attrs = log.attributes ?? {};
+  // Build a compact label from the envelope_* attributes when present (the
+  // sideband's "Envelope flow" records), else fall back to the raw body.
+  const cls = pickString(attrs["envelope_class"]);
+  const entity = pickString(attrs["envelope_entity"]);
+  const action = pickString(attrs["envelope_action"]);
+  const type = cls && entity && action ? `${cls}.${entity}.${action}` : "log";
+  const preview = (log.body ?? "").slice(0, 240);
+  return {
+    id: `log:${log.timeUnixNano}`,
+    ts: nanosToIso(log.timeUnixNano),
+    color: "none",
+    weight: "tertiary",
+    kind: "raw",
+    type,
+    preview,
+  };
+}
+
+// --- helpers ---
+
+function pickString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function pickNumber(v: unknown): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  // VictoriaTraces v0.8.2 stringifies numeric attributes (contract §5.2 known
+  // limitation) — accept a numeric string too.
+  if (typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v))) {
+    return Number(v);
+  }
+  return undefined;
+}
+
+function toolNameFromSpanName(spanName: string): string {
+  // "tool.bash" → "Bash"; "tool.read" → "Read".
+  const segs = spanName.split(".");
+  const seg = segs[segs.length - 1] ?? "tool";
+  return seg.charAt(0).toUpperCase() + seg.slice(1);
+}
+
+function durationFromSpan(sp: SidebandSpan): number | undefined {
+  const start = BigIntSafe(sp.startTimeUnixNano);
+  const end = BigIntSafe(sp.endTimeUnixNano);
+  if (start === null || end === null || end <= start) return undefined;
+  // nanos → ms.
+  return Number((end - start) / 1_000_000n);
+}
+
+function BigIntSafe(s: string): bigint | null {
+  try {
+    if (!/^\d+$/.test(s)) return null;
+    return BigInt(s);
+  } catch {
+    // Non-numeric nanos string — can't compute a duration; skip it. The row
+    // simply renders without a duration badge.
+    return null;
+  }
+}
+
+function nanosToIso(nanos: string): string {
+  const n = BigIntSafe(nanos);
+  if (n === null) return new Date(0).toISOString();
+  const ms = Number(n / 1_000_000n);
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? new Date(0).toISOString() : d.toISOString();
+}
+
+function byteLength(s: string): number {
+  if (typeof Buffer !== "undefined") return Buffer.byteLength(s, "utf8");
+  return new TextEncoder().encode(s).length;
+}

--- a/src/surface/mc/dashboard-v2/lib/source-merge.ts
+++ b/src/surface/mc/dashboard-v2/lib/source-merge.ts
@@ -1,0 +1,119 @@
+/**
+ * U1.1 item 3 — source-merge policy + honest fidelity labeling.
+ *
+ * ONE transcript panel renders the best-available source for a session:
+ *
+ *   controlled (local, MC-dispatched) → stream-json firehose (FULL fidelity)
+ *   local-observed                    → hook events  (item 1; ~80% CC feel)
+ *   else (remote / historical)        → sideband timeline (item 2; preview)
+ *
+ * Guardrail — ADR-0007: session interiors are strictly LOCAL-PANE. A FOREIGN
+ * origin's stream-json / hook events NEVER land locally, so this policy refuses
+ * to pick them for a foreign session; the only interior path for a foreign
+ * session is the (loopback-only) sideband when a correlation_id is known, else
+ * the panel honestly says "interior capture not available".
+ *
+ * Pure decision function — no fetch, no DOM — so the policy is unit-testable in
+ * isolation and lives in the entry bundle (it's tiny); the heavy sideband fetch
+ * + mapping lives behind the lazy chunk (`sideband-source.tsx`).
+ */
+
+import type { AgentOrigin } from "../hooks/use-agents";
+import type { SidebandError } from "../../../../common/sideband/proxy";
+
+/** How MC came to know about this session — drives the source pick. */
+export type DispatchOrigin =
+  /** MC dispatched it; the full stream-json firehose is in the events table. */
+  | "controlled"
+  /** Cortex observed it locally via the cc-events tap (hook events present). */
+  | "observed"
+  /** Neither — fleet / remote / historical; only the sideband can reconstruct. */
+  | "historical";
+
+/** The minimal session metadata the policy needs. */
+export interface TranscriptSessionMeta {
+  sessionId: string;
+  /** `"local"` or a foreign `{ principal, stack }` (ADR-0007 boundary). */
+  origin: AgentOrigin;
+  dispatchOrigin: DispatchOrigin;
+  /** W3C trace_id ≡ correlation_id for the sideband lookup; null when unknown. */
+  correlationId: string | null;
+}
+
+/** Provenance grade for the WHOLE panel — drives the honest header label. */
+export type SourceFidelity = "full" | "observed" | "preview";
+
+export type TranscriptSource =
+  | { kind: "stream-json"; fidelity: "full" }
+  | { kind: "hook-events"; fidelity: "observed" }
+  | { kind: "sideband"; fidelity: "preview"; correlationId: string }
+  | { kind: "unavailable" };
+
+/** True for a foreign (federated peer) origin — interiors are local-pane only. */
+function isForeign(origin: AgentOrigin): origin is { principal: string; stack: string } {
+  return origin !== "local";
+}
+
+/**
+ * Pick the best-available transcript source for a session, honoring the
+ * ADR-0007 local-pane guardrail.
+ */
+export function selectTranscriptSource(meta: TranscriptSessionMeta): TranscriptSource {
+  // FOREIGN origin: the local stream-json / hook-event paths can't apply (those
+  // interiors never leave the peer's stack). Only the loopback sideband can
+  // reconstruct one, and only with a correlation_id.
+  if (isForeign(meta.origin)) {
+    if (meta.correlationId) {
+      return { kind: "sideband", fidelity: "preview", correlationId: meta.correlationId };
+    }
+    return { kind: "unavailable" };
+  }
+
+  // LOCAL origin: prefer the highest-fidelity local source.
+  if (meta.dispatchOrigin === "controlled") {
+    return { kind: "stream-json", fidelity: "full" };
+  }
+  if (meta.dispatchOrigin === "observed") {
+    return { kind: "hook-events", fidelity: "observed" };
+  }
+  // Local but historical — fall back to the sideband when we can correlate.
+  if (meta.correlationId) {
+    return { kind: "sideband", fidelity: "preview", correlationId: meta.correlationId };
+  }
+  return { kind: "unavailable" };
+}
+
+/**
+ * Honest fidelity label for the panel header. `null` ⇒ full-fidelity
+ * controlled (no badge — it's the real transcript).
+ */
+export function fidelityLabel(fidelity: SourceFidelity): string | null {
+  switch (fidelity) {
+    case "full":
+      return null;
+    case "observed":
+      return "Reconstructed from observed hook events — full interior on this session's home stack";
+    case "preview":
+      return "Preview-grade — full interior on this session's home stack";
+  }
+}
+
+/**
+ * Honest message for a sideband failure. Never throws on a malformed body —
+ * the panel must degrade, not crash. On `backend_unavailable` we say "interior
+ * capture not available for this session" (the issue's exact copy); the
+ * `deep_link`, when present, is surfaced separately as the analyst's exit.
+ */
+export function sidebandErrorLabel(err: SidebandError | null | undefined): string {
+  const code = err && typeof err === "object" ? err.code : undefined;
+  switch (code) {
+    case "backend_timeout":
+      return "Interior capture not available — the sideband timed out. Retry, or open the deep link.";
+    case "invalid_correlation_id":
+      return "Interior capture not available for this session — no valid trace id to correlate.";
+    case "backend_unavailable":
+    case "internal_error":
+    default:
+      return "Interior capture not available for this session.";
+  }
+}


### PR DESCRIPTION
## U1.1 — "View trace tree" transcript drill-down panel

ONE transcript panel, one row grammar, **best-available source per session**. Opening an agent session feels like opening the CC CLI (a chronological transcript), regardless of how MC came to know about the session.

Closes #933 · refs the-metafactory/signal#122 · depends U0.1 (#983, merged) + #952 (merged).

### Source-merge policy (item 3)

`lib/source-merge.ts` — pure decision function:

| Session | Source | Fidelity |
|---|---|---|
| controlled (local, MC-dispatched) | stream-json firehose (existing path, unchanged) | **full** |
| local-observed (cc-events tap) | hook events → row grammar (item 1) | **observed** |
| remote / historical | sideband `/traces/{id}/timeline` (item 2) | **preview** |

**ADR-0007 guardrail enforced in the policy:** a FOREIGN origin never gets the local stream-json / hook-event paths (those interiors never leave the peer's stack). The only interior path for a foreign session is the loopback-only sideband when a `correlation_id` is known — else the panel honestly says "interior capture not available for this session." The Network view's foreign-agent detail is untouched; this panel is the local working-grid drill-down.

### Honest fidelity labeling

- `observed` → "Reconstructed from observed hook events — full interior on this session's home stack"
- `preview` → "Preview-grade — full interior on this session's home stack"
- `backend_unavailable` / parse failure → "Interior capture not available for this session." (degrades, never crashes)
- `deep_link` (Grafana/Honeycomb/Datadog) stays the analyst's exit when the sideband supplies one.

A per-tool `◷ preview` badge tags each reconstructed row so full-fidelity controlled rows stay unbadged.

### Item 1 — observed → existing row grammar (highest value)

`lib/event-rows.ts` `eventToRows` now maps the cc-events observed taxonomy into the SAME paired-tool/input rows controlled sessions already use:

- `tool.bash.executed` / `tool.file.changed` / `tool.file.read` / `tool.agent.spawned` / `tool.todo.updated` / `tool.{name}.used` → `tool_use` (name + expandable args + nested `tool_output` as a tool_result + `duration_ms`)
- `agent.task.started` → `principal.input` (the prompt for the turn)

Pure rendering, **zero new capture** — `tool_input`, `tool_output`, `duration_ms`, `prompt_preview` are already in the events table. Observed sessions go from raw-JSON `RawRow` crumbs to ~80% CC feel. (The drill-down already streams these McEvents through `eventsToRows`; they just hit the `default` → RawRow before.)

### Item 2 — sideband-timeline source

`lib/sideband-timeline.ts` (pure) maps the sideband union to `LogRow[]`, pairing `tool.X` + `*.result` spans on `parentSpanId` into one row (name, `tool.arg_preview`/`tool.output_preview` when present per signal#129, `tool.duration_ms`, ok/fail via OTel `statusCode`), interleaving log records — same row components, same CSS. Tolerates VictoriaTraces v0.8.2 stringified numeric attrs (contract §5.2).

### Item 4 — bundle-split evidence

`components/sideband-source.tsx` is `React.lazy(() => import("./sideband-source"))` from the drill-down (the network-canvas chunk precedent). The shared `DrillRowList` (extracted from `DrillLog`) is reused by all three sources.

```
index-5n6bryzf.js              1.22 MB    (entry point)   ← was 1.26 MB baseline
sideband-source-kwtzd3a7.js    6.86 KB    (chunk)         ← timeline mapper + fetch path, split out
```

The entry shrank vs. baseline (the `DrillRowList` extraction improved boundaries); the sideband path is a dedicated 6.86 KB chunk. A structural unit test (`sideband-lazy-chunk.test.ts`) fails if a future edit converts the lazy import to a static one or pulls `sideband-timeline` into the entry-reachable graph; `build:dashboard` is the runtime oracle.

### Tests (TDD) — the 3-part live oracle

- **(a) controlled** end-to-end → existing `event-rows`/`drill-*` tests (unchanged).
- **(b) observed** → `event-rows.test.ts` new cases: bash/file/tool/task → paired rows, **not** RawRow.
- **(c) sideband preview-grade, honestly labeled** → `sideband-timeline.test.ts` (span-pairing on parentSpanId, ok/fail, interleave) + `source-merge.test.ts` (selection + `backend_unavailable` → honest label, no crash) + `sideband-lazy-chunk.test.ts` (chunk boundary).

### Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (warnings all pre-existing, none in new files)
- `bun test` — 6325 pass / 1 skip / 0 fail
- `bun run build:dashboard` — sideband-source in its own 6.86 KB chunk; entry 1.22 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)