### PR TITLE
feat(mc): U2.1 — Observability tab v1, four system.* family renderer (#934)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -130,6 +130,10 @@ import { startMissionControl, type MissionControlHandle } from "./surface/mc/emb
 import type { AgentPresenceView } from "./surface/mc/api/agents";
 // MC-I1.S4 (ADR-0005 §4) — bus→MC dispatch-lifecycle projection renderer.
 import { createDispatchProjectionRenderer } from "./surface/mc/projection/dispatch-lifecycle-renderer";
+// P-14 U2.1 (#934) — bus→MC observability projection renderer (signal's four
+// system.* families). Own renderer, own subjects; registered beside the dispatch
+// renderer, no edit to surface-router.ts.
+import { createObservabilityProjectionRenderer } from "./surface/mc/projection/observability-renderer";
 // MC-I1.S7 (#849) — funnel the event-driven failed_dispatch attention delta
 // onto the same system.attention.* bus path the cockpit loop publishes on.
 import { publishReconcileDelta } from "./surface/mc/attention-notify";
@@ -3610,6 +3614,16 @@ export async function startCortex(
         }),
       );
       console.log("cortex: Mission Control bus→MC projection renderer registered (dispatch + verdicts + heartbeats + attention + adapter health + failed-dispatch)");
+      // P-14 U2.1 (#934) — the observability projection renderer for signal's
+      // four system.* families. Its OWN surface-router renderer (own id +
+      // subjects); shares the embed's db + wsRegistry so its rows + att:adapter:
+      // attention items push the `observability` / `attention` mc.projection
+      // refresh families to live dashboard clients. Federation/transport are
+      // hub-emitted — on a non-hub stack the renderer simply never receives
+      // those subjects, so the tab's federation/transport sections stay honestly
+      // empty (no synthesized rows).
+      router.register(createObservabilityProjectionRenderer(mcDb, mcHandle.wsRegistry));
+      console.log("cortex: Mission Control observability projection renderer registered (signal + collector + federation + transport)");
     } catch (err) {
       console.error("cortex: Mission Control embed startup error (non-fatal):", err instanceof Error ? err.message : err);
     }

--- a/src/surface/mc/__tests__/observability-db.test.ts
+++ b/src/surface/mc/__tests__/observability-db.test.ts
@@ -1,0 +1,108 @@
+/**
+ * P-14 U2.1 (#934) — observability_events storage + retention prune.
+ *
+ * Coverage:
+ *   - insert returns an id, idempotent on envelope_id (redelivery → null, one row).
+ *   - list by family (newest first) + overall, capped.
+ *   - countByFamily omits zero-row families.
+ *   - pruneOldObservability deletes rows older than the window, keeps recent.
+ *   - pruneRetention includes the observability prune in its summary.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { SCHEMA_SQL } from "../db/schema";
+import {
+  insertObservabilityEvent,
+  listObservabilityEvents,
+  countObservabilityByFamily,
+} from "../db/observability";
+import {
+  pruneOldObservability,
+  pruneRetention,
+  OBSERVABILITY_RETENTION_MS,
+} from "../db/retention";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+describe("observability_events storage", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("inserts and returns an id", () => {
+    const id = insertObservabilityEvent(db, {
+      envelopeId: "env-1",
+      family: "signal",
+      type: "system.signal.received",
+      payload: { n: 1 },
+    });
+    expect(id).not.toBeNull();
+    expect(listObservabilityEvents(db, 10).length).toBe(1);
+  });
+
+  it("is idempotent on envelope_id (redelivery → null, one row)", () => {
+    expect(insertObservabilityEvent(db, { envelopeId: "dup", family: "federation", type: "system.federation.peer.added", payload: {} })).not.toBeNull();
+    expect(insertObservabilityEvent(db, { envelopeId: "dup", family: "federation", type: "system.federation.peer.added", payload: {} })).toBeNull();
+    expect(countObservabilityByFamily(db).federation).toBe(1);
+  });
+
+  it("lists by family, newest first, and overall", () => {
+    insertObservabilityEvent(db, { envelopeId: "a", family: "signal", type: "system.signal.received", payload: {}, timestamp: "2026-06-01T00:00:00.000Z" });
+    insertObservabilityEvent(db, { envelopeId: "b", family: "signal", type: "system.signal.dropped", payload: {}, timestamp: "2026-06-02T00:00:00.000Z" });
+    insertObservabilityEvent(db, { envelopeId: "c", family: "transport", type: "system.transport.leaf_connect", payload: {}, timestamp: "2026-06-03T00:00:00.000Z" });
+
+    const sig = listObservabilityEvents(db, 10, "signal");
+    expect(sig.map((r) => r.envelopeId)).toEqual(["b", "a"]); // newest first
+    expect(listObservabilityEvents(db, 10).length).toBe(3);
+    expect(listObservabilityEvents(db, 1).length).toBe(1); // cap honoured
+  });
+
+  it("countByFamily omits zero-row families", () => {
+    insertObservabilityEvent(db, { envelopeId: "x", family: "collector", type: "system.signal.collector.degraded", payload: {} });
+    const counts = countObservabilityByFamily(db);
+    expect(counts.collector).toBe(1);
+    expect(counts.signal).toBeUndefined();
+    expect(counts.federation).toBeUndefined();
+    expect(counts.transport).toBeUndefined();
+  });
+});
+
+describe("pruneOldObservability — age-based retention", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("deletes rows older than the window, keeps recent", () => {
+    const old = new Date(Date.now() - OBSERVABILITY_RETENTION_MS - 60_000).toISOString();
+    const fresh = new Date().toISOString();
+    insertObservabilityEvent(db, { envelopeId: "old", family: "signal", type: "system.signal.received", payload: {}, timestamp: old });
+    insertObservabilityEvent(db, { envelopeId: "fresh", family: "signal", type: "system.signal.received", payload: {}, timestamp: fresh });
+
+    const res = pruneOldObservability(db);
+    expect(res.prunedObservability).toBe(1);
+    const remaining = listObservabilityEvents(db, 10);
+    expect(remaining.length).toBe(1);
+    expect(remaining[0]?.envelopeId).toBe("fresh");
+  });
+
+  it("is a no-op when nothing is old", () => {
+    insertObservabilityEvent(db, { envelopeId: "fresh", family: "signal", type: "system.signal.received", payload: {} });
+    expect(pruneOldObservability(db).prunedObservability).toBe(0);
+  });
+
+  it("pruneRetention reports prunedObservability in its summary", () => {
+    const old = new Date(Date.now() - OBSERVABILITY_RETENTION_MS - 60_000).toISOString();
+    insertObservabilityEvent(db, { envelopeId: "old", family: "transport", type: "system.transport.leaf_disconnect", payload: {}, timestamp: old });
+    const summary = pruneRetention(db);
+    expect(summary.ok).toBe(true);
+    expect(summary.prunedObservability).toBe(1);
+  });
+});

--- a/src/surface/mc/__tests__/observability-renderer.test.ts
+++ b/src/surface/mc/__tests__/observability-renderer.test.ts
@@ -1,0 +1,260 @@
+/**
+ * P-14 U2.1 (#934) — tests for the observability projection renderer + its
+ * attention producer.
+ *
+ * Coverage axes:
+ *   - familyForType maps each of the four families (collector-before-signal).
+ *   - projectObservability writes an observability_events row per family + a
+ *     validated envelope carrying a body `signed_by` is parsed structurally.
+ *   - WS `observability` (+ `attention`) family broadcast on a projected mutation.
+ *   - the att:adapter: attention producer opens/resolves on the six health
+ *     signals (collector degraded/recovered, transport backend un/reachable,
+ *     leaf dis/connect) and is idempotent under redelivery.
+ *   - non-matching types are ignored; idempotent row insert on envelope id.
+ *   - the renderer's render() is non-throwing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { SCHEMA_SQL } from "../db/schema";
+import {
+  createObservabilityProjectionRenderer,
+  projectObservability,
+  familyForType,
+} from "../projection/observability-renderer";
+import { produceObservabilityAttention } from "../projection/observability-attention";
+import { ADAPTER_ATTENTION_PREFIX } from "../projection/adapter-lifecycle";
+import {
+  listObservabilityEvents,
+  countObservabilityByFamily,
+} from "../db/observability";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { WsClientRegistry } from "../ws/client-registry";
+import type { WsServerMessage } from "../ws/types";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+/**
+ * A canonical-myelin-shaped envelope carrying a body `signed_by` chain — proving
+ * the renderer parses a validated U0.4/#124 envelope structurally (it reads
+ * type + payload; signed_by/sovereignty ride along untouched).
+ */
+function envelope(type: string, payload: Record<string, unknown>, id?: string): Envelope {
+  return {
+    id: id ?? crypto.randomUUID(),
+    source: "andreas.work.luna",
+    type,
+    timestamp: "2026-06-11T00:00:00.000Z",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: true,
+      model_class: "any",
+    },
+    payload,
+    signed_by: [
+      {
+        identity: "andreas-work",
+        algo: "ed25519",
+        public_key: "pk",
+        signature: "sig",
+        signed_at: "2026-06-11T00:00:00.000Z",
+      },
+    ],
+  } as unknown as Envelope;
+}
+
+function attentionRow(db: Database, id: string): { status: string } | null {
+  return db
+    .query(`SELECT status FROM attention_items WHERE id = ?`)
+    .get(id) as { status: string } | null;
+}
+
+// ---------------------------------------------------------------------------
+// familyForType
+// ---------------------------------------------------------------------------
+
+describe("familyForType — four-family routing", () => {
+  it("routes collector BEFORE signal (more specific prefix wins)", () => {
+    expect(familyForType("system.signal.collector.degraded")).toBe("collector");
+    expect(familyForType("system.signal.received")).toBe("signal");
+  });
+
+  it("routes federation and transport", () => {
+    expect(familyForType("system.federation.peer.added")).toBe("federation");
+    expect(familyForType("system.transport.leaf_disconnect")).toBe("transport");
+  });
+
+  it("returns null for an unrelated type", () => {
+    expect(familyForType("dispatch.task.started")).toBeNull();
+    expect(familyForType("system.agent.heartbeat")).toBeNull();
+    expect(familyForType("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projectObservability — rows + WS broadcast
+// ---------------------------------------------------------------------------
+
+describe("projectObservability — projection rows", () => {
+  let db: Database;
+  let broadcasts: WsServerMessage[];
+  let fakeRegistry: WsClientRegistry;
+
+  beforeEach(() => {
+    db = setupDb();
+    broadcasts = [];
+    fakeRegistry = {
+      broadcast: (msg: WsServerMessage) => {
+        broadcasts.push(msg);
+      },
+    } as unknown as WsClientRegistry;
+  });
+  afterEach(() => db.close());
+
+  it("writes a row per family and parses a signed_by-carrying envelope", () => {
+    expect(projectObservability(db, envelope("system.signal.received", { summary: "ok" }), fakeRegistry)).toBe("signal");
+    expect(projectObservability(db, envelope("system.signal.collector.degraded", { collector_id: "relay-1" }), fakeRegistry)).toBe("collector");
+    expect(projectObservability(db, envelope("system.federation.peer.added", { peer: "jc" }), fakeRegistry)).toBe("federation");
+    expect(projectObservability(db, envelope("system.transport.leaf_connect", { leaf: "leaf-a" }), fakeRegistry)).toBe("transport");
+
+    const counts = countObservabilityByFamily(db);
+    expect(counts).toEqual({ signal: 1, collector: 1, federation: 1, transport: 1 });
+    expect(listObservabilityEvents(db, 10, "signal")[0]?.summary).toBe("ok");
+  });
+
+  it("broadcasts the observability mc.projection family on a row mutation", () => {
+    projectObservability(db, envelope("system.signal.received", {}), fakeRegistry);
+    expect(broadcasts.some((m) => m.type === "mc.projection" && m.family === "observability")).toBe(true);
+  });
+
+  it("is idempotent on redelivery (same envelope id → one row)", () => {
+    const env = envelope("system.federation.peer.added", { peer: "jc" }, "fixed-id-1");
+    projectObservability(db, env, fakeRegistry);
+    projectObservability(db, env, fakeRegistry);
+    expect(countObservabilityByFamily(db).federation).toBe(1);
+  });
+
+  it("ignores a non-observability type (no row, no broadcast)", () => {
+    expect(projectObservability(db, envelope("dispatch.task.started", {}), fakeRegistry)).toBeNull();
+    expect(countObservabilityByFamily(db)).toEqual({});
+    expect(broadcasts.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attention producer — the live-oracle path
+// ---------------------------------------------------------------------------
+
+describe("produceObservabilityAttention — att:adapter: open/resolve", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("opens an att:adapter: item on collector.degraded and resolves on recovered", () => {
+    const open = produceObservabilityAttention(db, {
+      type: "system.signal.collector.degraded",
+      payload: { collector_id: "relay-1" },
+    });
+    expect(open).toMatchObject({ action: "opened" });
+    expect(open?.itemId.startsWith(`${ADAPTER_ATTENTION_PREFIX}collector:`)).toBe(true);
+    expect(attentionRow(db, open!.itemId)?.status).toBe("open");
+
+    const resolved = produceObservabilityAttention(db, {
+      type: "system.signal.collector.recovered",
+      payload: { collector_id: "relay-1" },
+    });
+    expect(resolved).toMatchObject({ action: "resolved" });
+    expect(attentionRow(db, open!.itemId)?.status).toBe("resolved");
+  });
+
+  it("opens on transport backend.unreachable and on leaf_disconnect", () => {
+    const backend = produceObservabilityAttention(db, {
+      type: "system.transport.backend.unreachable",
+      payload: { backend: "victoria" },
+    });
+    expect(backend).toMatchObject({ action: "opened" });
+    expect(attentionRow(db, backend!.itemId)?.status).toBe("open");
+
+    const leaf = produceObservabilityAttention(db, {
+      type: "system.transport.leaf_disconnect",
+      payload: { leaf: "leaf-a" },
+    });
+    expect(leaf).toMatchObject({ action: "opened" });
+    expect(attentionRow(db, leaf!.itemId)?.status).toBe("open");
+  });
+
+  it("is idempotent: re-opening the same degraded keeps one open item", () => {
+    const a = produceObservabilityAttention(db, { type: "system.signal.collector.degraded", payload: { collector_id: "relay-1" } });
+    const b = produceObservabilityAttention(db, { type: "system.signal.collector.degraded", payload: { collector_id: "relay-1" } });
+    expect(a?.itemId).toBe(b?.itemId);
+    const n = (db.query(`SELECT COUNT(*) AS n FROM attention_items WHERE id = ?`).get(a!.itemId) as { n: number }).n;
+    expect(n).toBe(1);
+  });
+
+  it("returns null for a non-health observability type (history-only)", () => {
+    expect(produceObservabilityAttention(db, { type: "system.signal.received", payload: {} })).toBeNull();
+    expect(produceObservabilityAttention(db, { type: "system.federation.peer.added", payload: {} })).toBeNull();
+  });
+
+  it("falls back to the namespace id when the origin id is absent", () => {
+    const res = produceObservabilityAttention(db, { type: "system.transport.backend.unreachable", payload: {} });
+    expect(res?.itemId).toBe(`${ADAPTER_ATTENTION_PREFIX}transport:transport`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Renderer integration — the oracle path + non-throwing contract
+// ---------------------------------------------------------------------------
+
+describe("createObservabilityProjectionRenderer", () => {
+  let db: Database;
+  let broadcasts: WsServerMessage[];
+  let fakeRegistry: WsClientRegistry;
+
+  beforeEach(() => {
+    db = setupDb();
+    broadcasts = [];
+    fakeRegistry = {
+      broadcast: (msg: WsServerMessage) => broadcasts.push(msg),
+    } as unknown as WsClientRegistry;
+  });
+  afterEach(() => db.close());
+
+  it("exposes a stable id and the four-family subject set", () => {
+    const r = createObservabilityProjectionRenderer(db, fakeRegistry);
+    expect(r.id).toBe("mc-observability-projection");
+    expect(r.subjects.some((s) => s.includes("system.signal"))).toBe(true);
+    expect(r.subjects.some((s) => s.includes("system.federation"))).toBe(true);
+    expect(r.subjects.some((s) => s.includes("system.transport"))).toBe(true);
+  });
+
+  it("collector.degraded projects a row AND opens an attention item (oracle path)", async () => {
+    const r = createObservabilityProjectionRenderer(db, fakeRegistry);
+    await r.render(envelope("system.signal.collector.degraded", { collector_id: "relay-1" }), undefined, "local.andreas.work.system.signal.collector.degraded");
+    expect(countObservabilityByFamily(db).collector).toBe(1);
+    expect(attentionRow(db, `${ADAPTER_ATTENTION_PREFIX}collector:relay-1`)?.status).toBe("open");
+    expect(broadcasts.some((m) => m.type === "mc.projection" && m.family === "observability")).toBe(true);
+    expect(broadcasts.some((m) => m.type === "mc.projection" && m.family === "attention")).toBe(true);
+  });
+
+  it("render() never throws on a malformed envelope", async () => {
+    const r = createObservabilityProjectionRenderer(db, fakeRegistry);
+    const bad = { id: "x", type: "system.signal.received", payload: null } as unknown as Envelope;
+    await expect(r.render(bad, undefined, "local.andreas.work.system.signal.received")).resolves.toBeUndefined();
+  });
+
+  it("works headless (no wsRegistry) — row still written, no broadcast crash", async () => {
+    const r = createObservabilityProjectionRenderer(db);
+    await r.render(envelope("system.signal.received", {}), undefined, "local.andreas.work.system.signal.received");
+    expect(countObservabilityByFamily(db).signal).toBe(1);
+  });
+});

--- a/src/surface/mc/api/observability-tab.ts
+++ b/src/surface/mc/api/observability-tab.ts
@@ -1,0 +1,54 @@
+/**
+ * P-14 U2.1 (#934) — GET /api/observability-events.
+ *
+ * Read-only surface over `observability_events` (the projection of signal's four
+ * `system.*` families) for the MC Observability tab. Returns each section's
+ * recent rows + per-family counts. NOT to be confused with `/api/observability/*`
+ * (U0.1's Tier-3 sideband trace/timeline proxy) — distinct path, distinct concern.
+ *
+ * The hub-scope caveat is the CONSUMER's to render honestly: a non-hub stack has
+ * zero `federation` / `transport` rows, and the response simply reflects that
+ * (empty arrays, zero counts). This handler NEVER synthesizes rows to paper over
+ * an empty family — an empty section is the truth, not a defect.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import {
+  listObservabilityEvents,
+  countObservabilityByFamily,
+  OBSERVABILITY_FAMILIES,
+  type ObservabilityEventRow,
+  type ObservabilityCounts,
+  type ObservabilityFamily,
+} from "../db/observability";
+
+/** Per-family cap on rows returned to the tab. */
+export const OBSERVABILITY_LIST_CAP = 200;
+
+export interface ObservabilityResponse {
+  /** Recent rows per family, newest first (each capped at {@link OBSERVABILITY_LIST_CAP}). */
+  byFamily: Record<ObservabilityFamily, ObservabilityEventRow[]>;
+  /** Per-family total row counts (a zero-row family is present with 0). */
+  counts: Record<ObservabilityFamily, number>;
+  listCap: number;
+}
+
+export function getObservability(db: Database): ObservabilityResponse {
+  const rawCounts: ObservabilityCounts = countObservabilityByFamily(db);
+  const byFamily = {} as Record<ObservabilityFamily, ObservabilityEventRow[]>;
+  const counts = {} as Record<ObservabilityFamily, number>;
+  for (const family of OBSERVABILITY_FAMILIES) {
+    byFamily[family] = listObservabilityEvents(db, OBSERVABILITY_LIST_CAP, family);
+    counts[family] = rawCounts[family] ?? 0;
+  }
+  return { byFamily, counts, listCap: OBSERVABILITY_LIST_CAP };
+}
+
+/** GET /api/observability-events — per-section rows + counts for the tab. */
+export function handleGetObservability(db: Database): Response {
+  return new Response(JSON.stringify(getObservability(db)), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/surface/mc/dashboard-v2/__tests__/projection-refetch.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/projection-refetch.test.ts
@@ -109,6 +109,10 @@ describe("routeProjectionFamily — S6 family → live-view policy", () => {
     expect(routeProjectionFamily("adapter.health")).toEqual([]);
   });
 
+  it("observability (#934) routes only to the Observability view", () => {
+    expect(routeProjectionFamily("observability")).toEqual(["observability"]);
+  });
+
   it("an unknown family routes to nothing (defensive against future server families)", () => {
     expect(routeProjectionFamily("future.thing")).toEqual([]);
     expect(routeProjectionFamily("")).toEqual([]);
@@ -125,6 +129,8 @@ describe("routeProjectionFamily — S6 family → live-view policy", () => {
     expect(projectionAffectsView("dispatch.lifecycle", "attention")).toBe(false);
     expect(projectionAffectsView("attention", "attention")).toBe(true);
     expect(projectionAffectsView("adapter.health", "working-agents")).toBe(false);
+    expect(projectionAffectsView("observability", "observability")).toBe(true);
+    expect(projectionAffectsView("observability", "attention")).toBe(false);
   });
 });
 

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -27,6 +27,7 @@ import { WorkItemDetailView } from "./components/work-item-detail-view";
 import { AttentionView } from "./components/attention-view";
 import { NetworkView } from "./components/network-view";
 import { GovernanceView } from "./components/governance-view";
+import { ObservabilityView } from "./components/observability-view";
 import { Toast } from "./components/toast";
 import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
@@ -39,6 +40,7 @@ import { usePhaseDetail } from "./hooks/use-phase-detail";
 import { useAttention } from "./hooks/use-attention";
 import { useAgents } from "./hooks/use-agents";
 import { useGovernance } from "./hooks/use-governance";
+import { useObservability } from "./hooks/use-observability";
 import type { AgentPresenceTile } from "./hooks/use-agents";
 import { useWorkItemDetail } from "./hooks/use-work-item-detail";
 import { useTheme } from "./hooks/use-theme";
@@ -63,7 +65,7 @@ import type { Command } from "./components/command-palette";
  * may upgrade to a hash route if deep-linking turns out to be
  * principal-requested; for now the in-memory view is sufficient.
  */
-type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "work-item-detail" | "attention" | "kanban-detail" | "network" | "governance";
+type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "work-item-detail" | "attention" | "kanban-detail" | "network" | "governance" | "observability";
 
 export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
@@ -128,6 +130,10 @@ export function App() {
   const agents = useAgents(ws, view === "network");
   // G-1115 — governance verdicts, fetched only when the tab is visible.
   const governance = useGovernance(ws, view === "governance");
+  // P-14 U2.1 (#934) — observability events (signal's four system.* families),
+  // fetched only when the Observability tab is visible; live-refreshed off the
+  // `observability` mc.projection family.
+  const observability = useObservability(ws, view === "observability");
   // If software mode is toggled OFF while on a software-mode view (Repositories
   // / Plans / phase-detail / work-item-detail / attention), the tab + render
   // both gate off — reset to default so the main area isn't left blank.
@@ -364,6 +370,15 @@ export function App() {
         >
           Governance
         </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "observability"}
+          className={`tab${view === "observability" ? " active" : ""}`}
+          onClick={() => setView("observability")}
+        >
+          Observability
+        </button>
         {softwareMode && (
           <button
             type="button"
@@ -552,6 +567,14 @@ export function App() {
           /* G-1115 — read-only governance audit surface: verdicts from the
              governed-action stack (pulse P-702) read back off the bus. */
           <GovernanceView state={governance} />
+        )}
+
+        {view === "observability" && (
+          /* P-14 U2.1 (#934) — signal's four system.* observability families:
+             signal health / federation / transport. Federation + transport are
+             hub-emitted; a non-hub stack shows an honest explanatory empty
+             state (roster arrives via U3.3), never synthesized data. */
+          <ObservabilityView state={observability} />
         )}
 
         {view === "network" && (

--- a/src/surface/mc/dashboard-v2/components/observability-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/observability-view.tsx
@@ -1,0 +1,130 @@
+/**
+ * P-14 U2.1 (#934) — Observability tab.
+ *
+ * Read-only surface over the projection of signal's four canonical myelin
+ * `system.*` envelope families, grouped into three sections:
+ *
+ *   1. **Signal health** — `system.signal.*` + `system.signal.collector.*`.
+ *   2. **Federation**    — `system.federation.*`.
+ *   3. **Transport**     — `system.transport.*`.
+ *
+ * ## Hub-scope caveat (stated honestly, not faked)
+ * Federation and transport envelopes are HUB-emitted: a non-hub stack legitimately
+ * never sees them, so those sections render zero rows on a leaf. We do NOT
+ * synthesize placeholder data — an empty federation/transport section shows an
+ * EXPLANATORY empty state ("hub-emitted; this stack is not a hub / the roster
+ * arrives via U3.3"), distinct from the signal-health empty state ("no signal
+ * activity yet"). Absence of rows is the truth, surfaced as such.
+ */
+
+import type { ObservabilityState } from "../hooks/use-observability";
+import type { ObservabilityEventRow } from "../../db/observability";
+
+function when(ts: string): string {
+  // ISO-8601 (or SQLite 'YYYY-MM-DD HH:MM:SS') → compact 'YYYY-MM-DD HH:MM'.
+  return ts.replace("T", " ").slice(0, 16);
+}
+
+function EventTable({ rows }: { rows: ObservabilityEventRow[] }) {
+  return (
+    <table className="observability-events">
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Type</th>
+          <th>Origin</th>
+          <th>Detail</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr key={r.id}>
+            <td className="mono dim">{when(r.timestamp)}</td>
+            <td className="mono">{r.type}</td>
+            <td className="mono dim">{r.stackId ?? "—"}</td>
+            <td>{r.summary ?? "—"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  rows: ObservabilityEventRow[];
+  count: number;
+  /** Copy shown when the section has zero rows. */
+  emptyNote: string;
+}
+
+function Section({ title, rows, count, emptyNote }: SectionProps) {
+  return (
+    <div className="observability-section">
+      <h3>
+        {title}{" "}
+        {count > 0 ? <span className="dim">({count})</span> : null}
+      </h3>
+      {rows.length === 0 ? <p className="dim">{emptyNote}</p> : <EventTable rows={rows} />}
+    </div>
+  );
+}
+
+export interface ObservabilityViewProps {
+  state: ObservabilityState;
+}
+
+export function ObservabilityView({ state }: ObservabilityViewProps) {
+  const { data, loaded, error } = state;
+
+  if (!loaded) {
+    return (
+      <section className="scaffold-section observability-view" aria-label="Observability">
+        <h2>Observability</h2>
+        <p className="dim">Loading…</p>
+      </section>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <section className="scaffold-section observability-view" aria-label="Observability">
+        <h2>Observability</h2>
+        <p className="dim">Could not load observability events: {error ?? "no data"}.</p>
+      </section>
+    );
+  }
+
+  // Signal health groups the signal + collector families.
+  const signalRows = [...data.byFamily.signal, ...data.byFamily.collector].sort((a, b) =>
+    a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0,
+  );
+  const signalCount = data.counts.signal + data.counts.collector;
+
+  return (
+    <section className="scaffold-section observability-view" aria-label="Observability">
+      <h2>Observability</h2>
+
+      <Section
+        title="Signal health"
+        rows={signalRows}
+        count={signalCount}
+        emptyNote="No signal or collector activity recorded yet. Once signal is emitting on this stack, its health envelopes appear here."
+      />
+
+      <Section
+        title="Federation"
+        rows={data.byFamily.federation}
+        count={data.counts.federation}
+        emptyNote="No federation events. These are hub-emitted — a non-hub stack does not see federation envelopes until it joins a network and a roster arrives (U3.3). This empty state is expected on a leaf, not a fault."
+      />
+
+      <Section
+        title="Transport"
+        rows={data.byFamily.transport}
+        count={data.counts.transport}
+        emptyNote="No transport events. Transport envelopes (leaf connect/disconnect, backend reachability) are hub-emitted — a non-hub stack does not observe them until the roster arrives via U3.3. Empty here is honest, not synthetic."
+      />
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/hooks/use-observability.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-observability.ts
@@ -1,0 +1,106 @@
+/**
+ * P-14 U2.1 (#934) — observability tab hook.
+ *
+ * Fetches `GET /api/observability-events` (per-section rows + counts over the
+ * projection of signal's four `system.*` families) and keeps it fresh by
+ * subscribing to the `mc.projection` WS frame with family `observability`: every
+ * projected observability envelope broadcasts a refresh signal, which triggers a
+ * debounced refetch. The frame is a REFRESH SIGNAL, not authoritative state — the
+ * tab always re-reads the API (same discipline as `use-governance` / `use-attention`).
+ *
+ * Only fetches when `enabled` (the Observability tab is visible). Frames arriving
+ * while the tab is closed are discarded, so every tab OPEN refetches, and a failed
+ * boot fetch retries on the next open rather than wedging the tab.
+ *
+ * Live-oracle path: stopping the relay / a leaf publishes
+ * `system.signal.collector.degraded` / `system.transport.leaf_disconnect`, the
+ * renderer projects them (+ opens an `att:adapter:` attention item) and broadcasts
+ * the `observability` family — which lands here within one poll's debounce.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiFailure, getJson } from "../lib/api";
+import { projectionAffectsView } from "../lib/projection-routing";
+import type { ObservabilityResponse } from "../../api/observability-tab";
+import type { WsClient, WsMessage } from "./use-websocket";
+
+export interface ObservabilityState {
+  data: ObservabilityResponse | null;
+  loaded: boolean;
+  /** Boot error only — refetch failures are swallowed (warn-only). */
+  error: string | null;
+}
+
+const REFETCH_DEBOUNCE_MS = 150;
+
+export function useObservability(ws: WsClient, enabled: boolean): ObservabilityState {
+  const [data, setData] = useState<ObservabilityResponse | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const genRef = useRef(0);
+  const aliveRef = useRef(true);
+  const bootedRef = useRef(false);
+  const enabledRef = useRef(enabled);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const fetchObservability = useCallback(async (isBoot: boolean) => {
+    const gen = ++genRef.current;
+    try {
+      const res = await getJson<ObservabilityResponse>("/api/observability-events");
+      if (!aliveRef.current || gen !== genRef.current) return;
+      bootedRef.current = true; // freshness achieved — frame refetches engage
+      setData(res);
+      setLoaded(true);
+      setError(null);
+    } catch (err) {
+      if (!aliveRef.current || gen !== genRef.current) return;
+      if (isBoot) {
+        setLoaded(true);
+        setError(err instanceof ApiFailure ? err.message : String(err));
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn("[mc] observability refetch failed", err);
+      }
+    }
+  }, []);
+
+  // Fetch on EVERY tab open (closed-tab frames are discarded, so reopening must
+  // re-read). The first successful fetch flips bootedRef so frame refetches engage.
+  useEffect(() => {
+    if (!enabled) return;
+    void fetchObservability(!bootedRef.current);
+  }, [enabled, fetchObservability]);
+
+  // Live refresh on projected observability envelopes (family-gated via the
+  // shared routing policy, so a future server family this client doesn't know
+  // about can't trigger a spurious refetch).
+  const subscribe = ws.subscribe;
+  useEffect(() => {
+    function onProjection(msg: WsMessage) {
+      const family = (msg as { family?: string }).family;
+      if (family === undefined || !projectionAffectsView(family, "observability")) return;
+      if (!enabledRef.current || !bootedRef.current) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        debounceRef.current = null;
+        void fetchObservability(false);
+      }, REFETCH_DEBOUNCE_MS);
+    }
+    return subscribe("mc.projection", onProjection);
+  }, [subscribe, fetchObservability]);
+
+  return { data, loaded, error };
+}

--- a/src/surface/mc/dashboard-v2/lib/projection-routing.ts
+++ b/src/surface/mc/dashboard-v2/lib/projection-routing.ts
@@ -25,6 +25,8 @@ export const PROJECTION_FAMILIES = [
   "agent.heartbeat",
   "attention",
   "adapter.health",
+  // P-14 U2.1 (#934) — signal's four system.* families refresh the Observability tab.
+  "observability",
 ] as const;
 
 export type ProjectionFamily = (typeof PROJECTION_FAMILIES)[number];
@@ -33,7 +35,7 @@ export type ProjectionFamily = (typeof PROJECTION_FAMILIES)[number];
  * The live views a `mc.projection` refetch can target. These are the
  * data hooks whose REST payload a projection write can invalidate.
  */
-export type ProjectionView = "working-agents" | "tasks" | "attention";
+export type ProjectionView = "working-agents" | "tasks" | "attention" | "observability";
 
 /**
  * Map a projection `family` → the live views it can invalidate.
@@ -64,6 +66,13 @@ export function routeProjectionFamily(family: string): readonly ProjectionView[]
       return ["attention"];
     case "adapter.health":
       return [];
+    case "observability":
+      // The Observability tab is the sole reader of this family (the four
+      // signal system.* families). It can also touch the attention queue (a
+      // collector.degraded / backend.unreachable opens an att:adapter: item),
+      // but the renderer broadcasts a separate `attention` family for that, so
+      // here `observability` routes only to its own view.
+      return ["observability"];
     default:
       return [];
   }

--- a/src/surface/mc/db/observability.ts
+++ b/src/surface/mc/db/observability.ts
@@ -1,0 +1,132 @@
+/**
+ * P-14 U2.1 (#934) — observability_events storage.
+ *
+ * Append-only projection rows from signal's four `system.*` envelope families,
+ * surfaced on the MC Observability tab. Modelled on `db/governance.ts`: insert is
+ * idempotent on `envelope_id` (at-least-once redelivery-safe), reads are windowed
+ * + capped, no update surface. Retention (age-based prune) lives in db/retention.ts
+ * (the established owner of that pattern).
+ *
+ * `family` is the tab's section discriminator (signal-health groups `signal` +
+ * `collector`; `federation` and `transport` are their own sections). `type` is the
+ * full envelope `domain.entity.action`. Hub-scope (federation/transport) is a DATA
+ * property — a non-hub stack simply has zero rows of those families, which the tab
+ * renders as an honest explanatory empty state (never synthesized).
+ */
+
+import type { Database } from "bun:sqlite";
+
+/** The four section families. `signal` + `collector` together are "signal health". */
+export type ObservabilityFamily = "signal" | "collector" | "federation" | "transport";
+
+export const OBSERVABILITY_FAMILIES: readonly ObservabilityFamily[] = [
+  "signal",
+  "collector",
+  "federation",
+  "transport",
+] as const;
+
+export interface ObservabilityEventInsert {
+  envelopeId: string;
+  family: ObservabilityFamily;
+  /** Full envelope `domain.entity.action`. */
+  type: string;
+  /** Origin stack id (or other origin segment), when known. */
+  stackId?: string | null;
+  /** A short human-readable line for the row (optional). */
+  summary?: string | null;
+  payload: Record<string, unknown>;
+  /** ISO-8601; defaults to now when omitted. */
+  timestamp?: string;
+}
+
+export interface ObservabilityEventRow {
+  id: string;
+  envelopeId: string;
+  family: ObservabilityFamily;
+  type: string;
+  stackId: string | null;
+  summary: string | null;
+  timestamp: string;
+}
+
+/**
+ * Insert one observability event. Returns the row id, or null when the envelope
+ * was already projected (idempotent redelivery no-op via `ON CONFLICT(envelope_id)`).
+ */
+export function insertObservabilityEvent(
+  db: Database,
+  e: ObservabilityEventInsert,
+): string | null {
+  const id = crypto.randomUUID();
+  const res = db
+    .query(
+      `INSERT INTO observability_events
+         (id, envelope_id, family, type, stack_id, summary, payload, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))
+       ON CONFLICT(envelope_id) DO NOTHING`,
+    )
+    .run(
+      id,
+      e.envelopeId,
+      e.family,
+      e.type,
+      e.stackId ?? null,
+      e.summary ?? null,
+      JSON.stringify(e.payload),
+      e.timestamp ?? null,
+    );
+  return res.changes > 0 ? id : null;
+}
+
+/**
+ * Recent events, newest first, capped at `limit`. When `family` is given, only
+ * that family's rows are returned (the tab reads per-section).
+ */
+export function listObservabilityEvents(
+  db: Database,
+  limit: number,
+  family?: ObservabilityFamily,
+): ObservabilityEventRow[] {
+  const rows = (
+    family === undefined
+      ? db
+          .query(
+            `SELECT id, envelope_id, family, type, stack_id, summary, timestamp
+             FROM observability_events
+             ORDER BY timestamp DESC, id DESC
+             LIMIT ?`,
+          )
+          .all(limit)
+      : db
+          .query(
+            `SELECT id, envelope_id, family, type, stack_id, summary, timestamp
+             FROM observability_events
+             WHERE family = ?
+             ORDER BY timestamp DESC, id DESC
+             LIMIT ?`,
+          )
+          .all(family, limit)
+  ) as Record<string, unknown>[];
+  return rows.map((r) => ({
+    id: r.id as string,
+    envelopeId: r.envelope_id as string,
+    family: r.family as ObservabilityFamily,
+    type: r.type as string,
+    stackId: (r.stack_id as string | null) ?? null,
+    summary: (r.summary as string | null) ?? null,
+    timestamp: r.timestamp as string,
+  }));
+}
+
+/** Per-family row counts. A family with zero rows is absent from the result map. */
+export type ObservabilityCounts = Partial<Record<ObservabilityFamily, number>>;
+
+export function countObservabilityByFamily(db: Database): ObservabilityCounts {
+  const rows = db
+    .query(`SELECT family, COUNT(*) AS n FROM observability_events GROUP BY family`)
+    .all() as { family: ObservabilityFamily; n: number }[];
+  const out: ObservabilityCounts = {};
+  for (const row of rows) out[row.family] = row.n;
+  return out;
+}

--- a/src/surface/mc/db/retention.ts
+++ b/src/surface/mc/db/retention.ts
@@ -106,6 +106,17 @@ export const EVENTS_RETENTION_MS = 14 * DAY_MS;
  */
 export const STUCK_RUNNING_TTL_MS = 30 * MINUTE_MS;
 
+/**
+ * Observability-events retention window (P-14 U2.1, #934). The
+ * `observability_events` table is an append-only projection of signal's four
+ * `system.*` families, with no session FK to CASCADE off — so, like `events`, it
+ * needs its own age-based prune or it grows unbounded. 14 days mirrors
+ * {@link EVENTS_RETENTION_MS}: a fortnight of observability history on the glass,
+ * then aged out by a single indexed DELETE (served by `idx_observability_timestamp`).
+ * Module constant, no config — minimal blast radius, same as the other windows.
+ */
+export const OBSERVABILITY_RETENTION_MS = 14 * DAY_MS;
+
 // ORPHAN_TASK_ID is imported from ./sessions — the shared orphan anchor task,
 // preserved by the prune (only its children go). Single source of truth so the
 // DELETE anchor can't drift from the registration site.
@@ -120,6 +131,10 @@ export interface EventsPruneResult {
   prunedEvents: number;
 }
 
+export interface ObservabilityPruneResult {
+  prunedObservability: number;
+}
+
 export interface StuckReapResult {
   /** Orphan assignments transitioned to terminal by the liveness reaper. */
   reaped: number;
@@ -128,6 +143,7 @@ export interface StuckReapResult {
 export interface RetentionSummary
   extends OrphanPruneResult,
     EventsPruneResult,
+    ObservabilityPruneResult,
     StuckReapResult {
   /** false when the prune failed (e.g. closed db) — best-effort, never throws. */
   ok: boolean;
@@ -397,8 +413,21 @@ export function pruneOldEvents(db: Database): EventsPruneResult {
 }
 
 /**
+ * Prune `observability_events` older than {@link OBSERVABILITY_RETENTION_MS}
+ * (P-14 U2.1, #934). Age-based, mirroring {@link pruneOldEvents}: a single
+ * indexed DELETE (served by `idx_observability_timestamp`); idempotent. The table
+ * has no session FK, so unlike orphan events these rows never CASCADE-drop with a
+ * session — this prune is their sole bound.
+ */
+export function pruneOldObservability(db: Database): ObservabilityPruneResult {
+  const cutoffIso = new Date(Date.now() - OBSERVABILITY_RETENTION_MS).toISOString();
+  const res = db.query(`DELETE FROM observability_events WHERE timestamp < ?`).run(cutoffIso);
+  return { prunedObservability: res.changes };
+}
+
+/**
  * Run the full retention sweep: stuck-running reap → orphan terminal-row prune
- * → events age prune.
+ * → events age prune → observability-events age prune (#934).
  *
  * Ordering is load-bearing: the reaper (ST-P3) runs FIRST so zombie orphans
  * that have gone quiet past the liveness TTL are driven terminal (stamping
@@ -419,7 +448,8 @@ export function pruneRetention(db: Database): RetentionSummary {
     const stuck = reapStuckRunningOrphans(db);
     const orphans = pruneOrphanSessions(db);
     const events = pruneOldEvents(db);
-    return { ok: true, ...stuck, ...orphans, ...events };
+    const observability = pruneOldObservability(db);
+    return { ok: true, ...stuck, ...orphans, ...events, ...observability };
   } catch (err) {
     return {
       ok: false,
@@ -429,6 +459,7 @@ export function pruneRetention(db: Database): RetentionSummary {
       prunedAssignments: 0,
       prunedAgents: 0,
       prunedEvents: 0,
+      prunedObservability: 0,
     };
   }
 }

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -26,6 +26,7 @@ export const TABLE_NAMES = [
   "plan_phases",
   "work_items",
   "attention_items",
+  "observability_events",
 ] as const;
 
 export const SCHEMA_SQL: string[] = [
@@ -542,6 +543,30 @@ export const SCHEMA_SQL: string[] = [
   )`,
   `CREATE INDEX IF NOT EXISTS idx_governance_created ON governance_verdicts(created_at)`,
   `CREATE INDEX IF NOT EXISTS idx_governance_decision ON governance_verdicts(decision, created_at)`,
+
+  // P-14 U2.1 (#934) — Observability events. Append-only projection rows from
+  // signal's four `system.*` envelope families (`system.signal.*`,
+  // `system.signal.collector.*`, `system.federation.*`, `system.transport.*`),
+  // surfaced on the MC Observability tab. NOT session-joined: the tab queries
+  // by `family` (signal-health / federation / transport sections) and time, not
+  // session feeds — modelled on `governance_verdicts`. `envelope_id` UNIQUE makes
+  // at-least-once redelivery idempotent. `family` is the section discriminator;
+  // `type` is the full `domain.entity.action`. Hub-scope (federation/transport)
+  // is a DATA property — non-hub stacks simply have zero rows of those families,
+  // which the tab renders as an honest empty state (never synthesized).
+  `CREATE TABLE IF NOT EXISTS observability_events (
+    id TEXT PRIMARY KEY,
+    envelope_id TEXT NOT NULL UNIQUE,
+    family TEXT NOT NULL
+      CHECK(family IN ('signal','collector','federation','transport')),
+    type TEXT NOT NULL,
+    stack_id TEXT,
+    summary TEXT,
+    payload TEXT NOT NULL DEFAULT '{}',
+    timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_observability_timestamp ON observability_events(timestamp)`,
+  `CREATE INDEX IF NOT EXISTS idx_observability_family ON observability_events(family, timestamp DESC)`,
 ];
 
 /**

--- a/src/surface/mc/notifications.ts
+++ b/src/surface/mc/notifications.ts
@@ -198,7 +198,10 @@ export type ProjectionFamily =
   | "agent.heartbeat"
   | "attention"
   | "adapter.health"
-  | "governance.verdict";
+  | "governance.verdict"
+  // P-14 U2.1 (#934) — signal's four system.* observability families refreshed
+  // the Observability tab. Additive; older clients ignore an unknown family.
+  | "observability";
 
 /**
  * MC-I1.S6 (#848) — broadcast an `mc.projection` refresh signal to all connected

--- a/src/surface/mc/projection/observability-attention.ts
+++ b/src/surface/mc/projection/observability-attention.ts
@@ -1,0 +1,126 @@
+/**
+ * P-14 U2.1 (#934) — observability attention producer.
+ *
+ * Two of signal's observability conditions are not just history to chart — they
+ * are surface-health outages the cockpit should raise: a degraded collector
+ * (`system.signal.collector.degraded`) and an unreachable transport backend
+ * (`system.transport.backend.unreachable`). Both are the SAME class of signal as
+ * the existing adapter-health producer (`projectAdapterLifecycle`), so they reuse
+ * its `att:adapter:` namespace (db/adapter-lifecycle.ts `ADAPTER_ATTENTION_PREFIX`)
+ * and the same upsert/resolve lifecycle — one open item per origin, idempotent
+ * under redelivery, resolved by the matching recovered/reachable signal.
+ *
+ *   - `system.signal.collector.degraded`           → OPEN  att:adapter:collector:{id}
+ *   - `system.signal.collector.recovered`          → RESOLVE it
+ *   - `system.transport.backend.unreachable`       → OPEN  att:adapter:transport:{id}
+ *   - `system.transport.backend.reachable`         → RESOLVE it
+ *   - `system.transport.leaf_disconnect`           → OPEN  att:adapter:transport:{id}
+ *   - `system.transport.leaf_connect`              → RESOLVE it
+ *
+ * The origin id keys the item: `collector_id` (collector family) or `backend` /
+ * `leaf` / `node` (transport family), falling back to the family name so a
+ * payload missing its id still produces a deterministic, resolvable item rather
+ * than dropping the outage silently.
+ *
+ * Non-throwing: a non-matching type or malformed payload returns null. Mirrors
+ * `projectAdapterLifecycle`'s contract so the renderer can treat both uniformly.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import { upsertAttentionItem, resolveAttentionItem } from "../db/attention";
+import { ADAPTER_ATTENTION_PREFIX } from "./adapter-lifecycle";
+import type { AttentionItem } from "../types";
+
+export interface ProjectableObservabilityEnvelope {
+  id?: string;
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+export interface ObservabilityAttentionResult {
+  action: "opened" | "resolved";
+  /** The `att:adapter:`-prefixed MC attention item id. */
+  itemId: string;
+}
+
+interface Mapping {
+  /** Whether this type opens an outage or resolves one. */
+  opens: boolean;
+  /** Id-namespace segment after the shared adapter prefix (`collector:` / `transport:`). */
+  ns: "collector" | "transport";
+  /** Payload keys to try, in order, for the origin id. */
+  idKeys: string[];
+}
+
+function classify(type: string): Mapping | null {
+  switch (type) {
+    case "system.signal.collector.degraded":
+      return { opens: true, ns: "collector", idKeys: ["collector_id", "collector", "id"] };
+    case "system.signal.collector.recovered":
+      return { opens: false, ns: "collector", idKeys: ["collector_id", "collector", "id"] };
+    case "system.transport.backend.unreachable":
+      return { opens: true, ns: "transport", idKeys: ["backend", "backend_id", "id"] };
+    case "system.transport.backend.reachable":
+      return { opens: false, ns: "transport", idKeys: ["backend", "backend_id", "id"] };
+    case "system.transport.leaf_disconnect":
+      return { opens: true, ns: "transport", idKeys: ["leaf", "node", "peer", "id"] };
+    case "system.transport.leaf_connect":
+      return { opens: false, ns: "transport", idKeys: ["leaf", "node", "peer", "id"] };
+    default:
+      return null;
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Produce the observability attention transition for ONE envelope, or null when
+ * the type isn't one of the six health signals above. Idempotent: re-opening an
+ * already-open item upserts in place; resolving an absent item is a harmless
+ * no-op.
+ */
+export function produceObservabilityAttention(
+  db: Database,
+  envelope: ProjectableObservabilityEnvelope,
+): ObservabilityAttentionResult | null {
+  const mapping = classify(envelope.type);
+  if (mapping === null) return null;
+
+  const rawPayload: unknown = envelope.payload;
+  const payload: Record<string, unknown> =
+    typeof rawPayload === "object" && rawPayload !== null
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+
+  let originId: string | null = null;
+  for (const key of mapping.idKeys) {
+    originId = asString(payload[key]);
+    if (originId !== null) break;
+  }
+  // Fall back to the namespace itself so a payload missing its id still yields a
+  // deterministic, resolvable item rather than dropping the outage silently.
+  const id = originId ?? mapping.ns;
+  const itemId = `${ADAPTER_ATTENTION_PREFIX}${mapping.ns}:${id}`;
+
+  if (!mapping.opens) {
+    resolveAttentionItem(db, itemId);
+    return { action: "resolved", itemId };
+  }
+
+  const item: AttentionItem = {
+    id: itemId,
+    // The origin id segment groups a multi-stack view by source, same as the
+    // adapter-health producer stamps `stackId` with the adapter id.
+    stackId: `${mapping.ns}:${id}`,
+    workItemId: null,
+    sessionId: null,
+    kind: "blocked",
+    severity: "high",
+    status: "open",
+  };
+  upsertAttentionItem(db, item);
+  return { action: "opened", itemId };
+}

--- a/src/surface/mc/projection/observability-renderer.ts
+++ b/src/surface/mc/projection/observability-renderer.ts
@@ -1,0 +1,202 @@
+/**
+ * P-14 U2.1 (#934) — the bus→MC projection renderer for signal's four
+ * observability families.
+ *
+ * Analogous to `createDispatchProjectionRenderer` (dispatch-lifecycle-renderer.ts)
+ * but for the four canonical myelin envelope families signal emits:
+ *
+ *   | envelope.type prefix              | section / family   |
+ *   |-----------------------------------|--------------------|
+ *   | `system.signal.collector.`        | collector          |  ← checked FIRST
+ *   | `system.signal.`                  | signal             |    (more specific
+ *   | `system.federation.`              | federation         |     prefix wins)
+ *   | `system.transport.`               | transport          |
+ *
+ * cortex has NO local producers for these families — they originate in the
+ * **signal** repo and arrive over the bus as canonical, AJV-validated myelin
+ * envelopes (signal U0.4 / #124 merged: they pass the myelin schema + carry a
+ * body `signed_by`). So this renderer parses the generic validated `Envelope`
+ * STRUCTURALLY by `type` + `payload` — exactly like the dispatch renderer's
+ * `ProjectableEnvelope` — rather than via any cortex-side typed builder.
+ *
+ * It is its OWN surface-router renderer (own id + subjects), registered alongside
+ * the dispatch renderer in cortex.ts. It does NOT touch surface-router.ts and does
+ * NOT extend the dispatch renderer's dispatcher — separate family, separate file.
+ *
+ * ## Two writes per envelope
+ *   1. An append-only `observability_events` row (db/observability.ts) — the tab's
+ *      history, retained by db/retention.ts.
+ *   2. For the six health signals (collector degraded/recovered, transport
+ *      backend reachable/unreachable, leaf connect/disconnect) an `att:adapter:`
+ *      attention item via the observability-attention producer — the live oracle
+ *      path (stopping the relay / a leaf surfaces `collector.degraded` /
+ *      `leaf_disconnect` on the tab AND the attention queue).
+ * Either write broadcasts the matching `mc.projection` refresh family.
+ *
+ * ## Non-throwing contract
+ * Like the dispatch renderer, `render()` catches every error and routes it to
+ * stderr so a malformed envelope can't poison the surface-router's dispatch loop
+ * (Renderer contract §2 — belt to the router's `renderWithIsolation` braces).
+ *
+ * ## WS push
+ * Each projected mutation emits an `mc.projection` refresh signal (family
+ * `"observability"`) via {@link broadcastProjection}, reusing the existing helper
+ * — NO new WS message type. `wsRegistry` is optional (headless/test → no-op).
+ */
+
+import type { Database } from "bun:sqlite";
+
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { SurfaceAdapter } from "../../../bus/surface-router";
+import type { WsClientRegistry } from "../ws/client-registry";
+import { broadcastProjection } from "../notifications";
+import {
+  insertObservabilityEvent,
+  type ObservabilityFamily,
+} from "../db/observability";
+import { produceObservabilityAttention } from "./observability-attention";
+
+/** Stable surface-router id for the observability projection renderer. */
+export const OBSERVABILITY_PROJECTION_RENDERER_ID = "mc-observability-projection";
+
+/**
+ * NATS subject patterns the renderer subscribes to — the stack-ful
+ * (`local.{principal}.{stack}.…`), stack-less (`local.{principal}.…`) LOCAL and
+ * the federated (`federated.{principal}.{stack}.…`) grammars for each family.
+ * Intentionally broad; the authoritative filter is the renderer's own `type`
+ * prefix check (an over-matching subject costs only a cheap compare).
+ *
+ * `*` matches exactly one segment, `>` one-or-more trailing segments.
+ */
+export const OBSERVABILITY_PROJECTION_SUBJECTS: string[] = [
+  // signal (covers signal.collector.* too — the prefix check splits them)
+  "local.*.system.signal.>",
+  "local.*.*.system.signal.>",
+  "federated.*.*.system.signal.>",
+  // federation
+  "local.*.system.federation.>",
+  "local.*.*.system.federation.>",
+  "federated.*.*.system.federation.>",
+  // transport (hub-emitted; non-hub stacks just never see these)
+  "local.*.system.transport.>",
+  "local.*.*.system.transport.>",
+  "federated.*.*.system.transport.>",
+];
+
+/** A structural view of an envelope the projection reads. */
+interface ProjectableEnvelope {
+  id?: string;
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Map an `envelope.type` to its tab family, or null when it's none of the four.
+ * `system.signal.collector.` is checked BEFORE `system.signal.` so the more
+ * specific collector prefix wins (a collector type also starts with the signal
+ * prefix).
+ */
+export function familyForType(type: string): ObservabilityFamily | null {
+  if (type.startsWith("system.signal.collector.")) return "collector";
+  if (type.startsWith("system.signal.")) return "signal";
+  if (type.startsWith("system.federation.")) return "federation";
+  if (type.startsWith("system.transport.")) return "transport";
+  return null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/** Best-effort origin-stack id off the payload, for grouping in a multi-stack view. */
+function originStackId(payload: Record<string, unknown>): string | null {
+  return (
+    asString(payload.stack_id) ??
+    asString(payload.stack) ??
+    asString(payload.origin) ??
+    null
+  );
+}
+
+/**
+ * The single `project(envelope)` dispatcher. Routes on the family prefix to an
+ * `observability_events` insert (+ the attention producer for health signals),
+ * broadcasting an `mc.projection` refresh on any mutation. Returns the projected
+ * family (or null when the type matched no family / the row was a redelivery
+ * no-op) so callers/tests can assert routing without the surface-router.
+ *
+ * Exported for direct unit testing.
+ */
+export function projectObservability(
+  db: Database,
+  envelope: ProjectableEnvelope,
+  wsRegistry: WsClientRegistry | undefined,
+): ObservabilityFamily | null {
+  const family = familyForType(envelope.type);
+  if (family === null) return null;
+
+  const rawPayload: unknown = envelope.payload;
+  const payload: Record<string, unknown> =
+    typeof rawPayload === "object" && rawPayload !== null
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+
+  // The envelope id anchors idempotent redelivery. A validated bus envelope
+  // always carries one; fall back to a random id only for the unvalidated test
+  // shape (which then can't dedup, but never collides).
+  const envelopeId = asString(envelope.id) ?? crypto.randomUUID();
+
+  const rowId = insertObservabilityEvent(db, {
+    envelopeId,
+    family,
+    type: envelope.type,
+    stackId: originStackId(payload),
+    summary: asString(payload.summary) ?? asString(payload.message),
+    payload,
+  });
+
+  // The attention producer rides the SAME seam — every observability envelope is
+  // offered to it; only the six health signals (collector/transport up/down)
+  // open or resolve an `att:adapter:` item. It runs independently of the row
+  // insert's idempotent no-op (a redelivered degraded must still keep the item
+  // open / resolvable), so it is NOT gated on `rowId`.
+  const attn = produceObservabilityAttention(db, { id: envelope.id, type: envelope.type, payload });
+
+  let mutated = rowId !== null;
+  if (attn !== null) {
+    broadcastProjection(wsRegistry, "attention");
+    mutated = true;
+  }
+  if (mutated) {
+    broadcastProjection(wsRegistry, "observability");
+  }
+  return family;
+}
+
+/**
+ * Build the `SurfaceAdapter` the surface-router consumes for the observability
+ * projection. `render()` is non-throwing (every projection error caught + logged)
+ * so a malformed envelope can't poison the router's dispatch loop. `db` is the
+ * in-process MC handle; `wsRegistry` is the embed's live registry (omitted →
+ * broadcast is a no-op for headless/test). cortex.ts wires both only when
+ * `mc.enabled`.
+ */
+export function createObservabilityProjectionRenderer(
+  db: Database,
+  wsRegistry?: WsClientRegistry,
+): SurfaceAdapter {
+  return {
+    id: OBSERVABILITY_PROJECTION_RENDERER_ID,
+    subjects: OBSERVABILITY_PROJECTION_SUBJECTS,
+    // eslint-disable-next-line @typescript-eslint/require-await
+    render: async (envelope: Envelope): Promise<void> => {
+      try {
+        projectObservability(db, envelope, wsRegistry);
+      } catch (err) {
+        process.stderr.write(
+          `[mission-control] observability renderer: render() swallowed an error for envelope ${envelope.id} (${envelope.type}): ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    },
+  };
+}

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -46,6 +46,7 @@ import { handleGetPhaseDetail } from "./api/phase-detail";
 import { handleGetWorkItemDetail } from "./api/work-item-detail";
 import { handleListAttention } from "./api/attention";
 import { handleGetGovernance } from "./api/governance";
+import { handleGetObservability } from "./api/observability-tab";
 import { proxySideband } from "../../common/sideband/proxy";
 import type { ProcessManager } from "./session/process-manager";
 import type { SpawnFn } from "./session/endpoint-resolver";
@@ -499,6 +500,19 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleGetGovernance(db);
+  }
+
+  // P-14 U2.1 (#934) — GET /api/observability-events — the Observability tab's
+  // per-section rows + counts over `observability_events`. Registered BEFORE the
+  // U0.1 `/api/observability/*` proxy below: the proxy matches the trailing-slash
+  // prefix `/api/observability/`, which `/api/observability-events` does NOT
+  // start with (the next char is `-`, not `/`), so the two never collide — but
+  // ordering this first makes the disjointness explicit and robust to refactors.
+  if (pathname === "/api/observability-events") {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    return handleGetObservability(db);
   }
 
   // P-14 U0.1 — GET /api/observability/* — Tier-3 sideband drill-down proxy.

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -108,7 +108,9 @@ export type WsServerMessage =
         | "governance.verdict"
         | "agent.heartbeat"
         | "attention"
-        | "adapter.health";
+        | "adapter.health"
+        // P-14 U2.1 (#934) — Observability tab refresh family. Additive.
+        | "observability";
       sessionId?: string;
       assignmentId?: string;
     }


### PR DESCRIPTION
Closes #934 (P-14 U2.1). Surfaces signal's four canonical myelin envelope families on a new Mission Control **Observability** tab.

## What's here

**Renderer** — `src/surface/mc/projection/observability-renderer.ts` (own new file), analogous to `createDispatchProjectionRenderer`: own id + subjects, non-throwing `render()`, a `project()` dispatcher keyed on the four family prefixes (`system.signal.collector.` checked before `system.signal.`, then `system.federation.`, `system.transport.`). cortex has no local producers for these families — they arrive from signal over the bus (U0.4/#124 merged), so the renderer parses the validated `Envelope` **structurally** (type + payload), exactly like the dispatch renderer. It **self-registers** via `router.register()` in `cortex.ts` (+14 lines, additive) — `surface-router.ts` is **untouched**.

**Projection rows + retention** — new `observability_events` table (modelled on `governance_verdicts`) in `schema.ts`; `db/observability.ts` (insert/list/count, idempotent on `envelope_id`); `OBSERVABILITY_RETENTION_MS` + `pruneOldObservability` in `db/retention.ts`, wired into the existing `pruneRetention` sweep.

**WS refresh** — reuses the existing `mc.projection` message. Adds an additive `"observability"` family to `ProjectionFamily` (notifications.ts) + the drift-locked inline union (ws/types.ts) + `projection-routing.ts`. **No new WS message type.**

**Tab (4-edit pattern in app.tsx)** — (1) `DashboardView` union; (2) nav `<button>` after Metrics; (3) `{view === "observability" && <ObservabilityView/>}`; (4) `useObservability` hook call. Plus `hooks/use-observability.ts` (mirrors use-governance), `components/observability-view.tsx` (three sections: **signal health / federation / transport**), and `GET /api/observability-events` (distinct from U0.1's `/api/observability/*` sideband proxy).

**Attention producers** — `system.signal.collector.degraded` and transport `backend.unreachable` / `leaf_disconnect` open `att:adapter:`-namespaced items (reuse `ADAPTER_ATTENTION_PREFIX`), resolved by their `recovered`/`reachable`/`connect` twins. This makes the live-oracle path real: stopping the relay / a leaf surfaces `collector.degraded` / `leaf_disconnect` on the tab **and** the attention queue within one poll.

## Hub-scope caveat (honest, not faked)

`system.federation.*` and `system.transport.*` are **hub-emitted**. A non-hub stack simply never receives those subjects, so the federation/transport sections render **explanatory empty states** ("hub-emitted; this stack is not a hub / the roster arrives via U3.3") — distinct from the signal-health empty state, and **never synthesized data**. Verified by anti-criterion test + Read.

## Gate

- `bunx tsc --noEmit` → **0 errors** (exit 0)
- `bun test src/surface/mc/` → **1756 pass / 0 fail / 1 skip** (skip = pre-existing dashboard-SPA build skip)
- New/extended tests (`observability-renderer.test.ts`, `observability-db.test.ts`, `projection-refetch.test.ts`) → **40 pass / 0 fail**
- `eslint .` → **0 errors** (28 pre-existing warnings, none in changed files)

## Collision notes vs U1.1 / #988

- **`app.tsx`** (U1.1) — edits are exactly the 4-edit pattern (+24/-1), localized; appended after the Governance tab so they're unlikely to conflict.
- **`ws/types.ts`** (#988) — only a `| "observability"` family-union addition (+3/-1); the inline union MUST stay in sync with `ProjectionFamily` (notifications.ts) or tsc goes red — both updated together.
- **`surface-router.ts`** — **0 changes** (renderer self-registers from cortex.ts).
- **`cortex.ts`** — +14 additive lines (import + register + log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)