### PR TITLE
feat(bus): U0.2 — structured system.access.* denial telemetry (gate refuse + consumer drops) (#932)

### DIFF
--- a/src/__tests__/cortex.review-consumer.e2e.test.ts
+++ b/src/__tests__/cortex.review-consumer.e2e.test.ts
@@ -387,6 +387,51 @@ function buildVerdictEnvelope(
   });
 }
 
+/**
+ * Assert the audit-parity `system.access.denied` emission that the consumer's
+ * Stage-1b sovereignty gate (cortex#932 / P-14 U0.2) fires on these round-trips.
+ *
+ * Every agent in this file is constructed WITHOUT a `modelClass`, so
+ * `evaluateSovereignty(envelope.sovereignty, undefined)` fails closed and
+ * returns `decision: "deny"` (reason: "agent model class missing or unknown …").
+ * Because none of these consumers set `sovereigntyEnforce`, the default
+ * audit-parity posture (`enforced: false`) applies: the pipeline still RUNS, but
+ * U0.2 correctly emits a `system.access.denied` governance signal — the stream
+ * the audit→enforce flip (#906) and the U3.1 governance pane read. The gate
+ * emits it (fire-and-forget) before `dispatch.task.started`, so it lands first
+ * in publish order.
+ *
+ * This guards the EMISSION SET (not just the count): the 4th envelope is the
+ * audit-parity denial with the exact would-deny reason, never a stray
+ * over-emit on a clean accept. If a future change made the agent prove its
+ * model class (so the would-deny vanishes), `expect(denial).toBeDefined()`
+ * fails loudly — the assertion is a real guard, not a number bump.
+ */
+function assertAuditParityDenial(
+  emitted: readonly Envelope[],
+  expectedSubject: string,
+): void {
+  const denial = emitted.find((e) => e.type === "system.access.denied");
+  expect(denial).toBeDefined();
+  // Emitted before the pipeline lifecycle (gate Stage 1b precedes started).
+  expect(emitted[0]!.type).toBe("system.access.denied");
+  const payload = denial!.payload as {
+    capability: string;
+    envelope_subject: string;
+    reason: { kind: string; enforced?: boolean; reason?: string };
+    intent_sovereignty: { model_class: string; frontier_ok: boolean };
+  };
+  expect(payload.reason.kind).toBe("sovereignty_model_class");
+  // Audit-parity: the denial is observable but does not bite (pipeline ran).
+  expect(payload.reason.enforced).toBe(false);
+  // The would-deny condition these agents actually hit (no declared modelClass).
+  expect(payload.reason.reason).toContain("agent model class missing or unknown");
+  expect(payload.envelope_subject).toBe(expectedSubject);
+  // The intent the gate refused: a local-only task an unproven agent can't run.
+  expect(payload.intent_sovereignty.model_class).toBe("local-only");
+  expect(payload.intent_sovereignty.frontier_ok).toBe(false);
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -467,17 +512,24 @@ describe("cortex#237 PR-9 — review-consumer end-to-end round-trip (§11.1 Laye
     expect(decisions.length).toBe(1);
     expect(decisions[0]).toEqual({ kind: "ack" });
 
-    // Three envelopes emitted in §8.2 order: started → verdict → completed.
+    // Four envelopes in publish order: the audit-parity sovereignty denial
+    // (cortex#932 / U0.2 — the agent declares no modelClass, so the Stage-1b
+    // gate fails closed and emits a `system.access.denied` with
+    // `enforced: false` BEFORE the pipeline runs), then §8.2 order
+    // started → verdict → completed.
     const emitted = runtime.published.slice(publishedBefore);
-    expect(emitted.length).toBe(3);
-    expect(emitted[0]!.type).toBe("dispatch.task.started");
-    expect(emitted[1]!.type).toBe("review.verdict.approved");
-    expect(emitted[2]!.type).toBe("dispatch.task.completed");
+    expect(emitted.length).toBe(4);
+    assertAuditParityDenial(emitted, requestSubject);
+    expect(emitted[1]!.type).toBe("dispatch.task.started");
+    expect(emitted[2]!.type).toBe("review.verdict.approved");
+    expect(emitted[3]!.type).toBe("dispatch.task.completed");
 
     // **THE HEADLINE CONTRACT** (design §5.1): every emitted envelope's
     // correlation_id MUST equal the request envelope's id. Pilot's
     // `subscribe-verdict` filter joins on exactly this value; if it
-    // ever drifts pilot would silently miss the verdict.
+    // ever drifts pilot would silently miss the verdict. (The denial
+    // envelope joins too: its correlation_id falls back to the request id
+    // when the request carries no correlation_id, as here.)
     for (const env of emitted) {
       expect(env.correlation_id).toBe(request.id);
     }
@@ -485,7 +537,7 @@ describe("cortex#237 PR-9 — review-consumer end-to-end round-trip (§11.1 Laye
     // Verdict envelope shape spot-check — payload echoes the request,
     // discriminator-alignment guard (§6.3) didn't fire (builder would
     // have thrown).
-    const verdict = emitted[1]!;
+    const verdict = emitted[2]!;
     const payload = verdict.payload as {
       repo: string;
       pr: number;
@@ -640,12 +692,20 @@ describe("cortex#327 — signature verification gate", () => {
     expect(verifyCalls).toHaveLength(1);
     expect(verifyCalls[0]!.envelopeId).toBe(request.id);
 
-    // Full pipeline runs — started + verdict + completed emissions, ack on JsMsg.
+    // Full pipeline runs — the audit-parity sovereignty denial
+    // (cortex#932 / U0.2: this agent declares no modelClass → Stage-1b gate
+    // fails closed, emits `system.access.denied` with `enforced: false` and
+    // proceeds), then started + verdict + completed, ack on JsMsg. The
+    // signature gate (the subject of THIS test) is upstream of the
+    // sovereignty gate, so a valid signature still reaches the would-deny.
     expect(handlersCalled).toBe(1);
     expect(decisions[0]).toEqual({ kind: "ack" });
     const emitted = runtime.published.slice(publishedBefore);
-    expect(emitted.length).toBe(3);
-    expect(emitted[1]!.type).toBe("review.verdict.approved");
+    expect(emitted.length).toBe(4);
+    assertAuditParityDenial(emitted, requestSubject);
+    expect(emitted[1]!.type).toBe("dispatch.task.started");
+    expect(emitted[2]!.type).toBe("review.verdict.approved");
+    expect(emitted[3]!.type).toBe("dispatch.task.completed");
 
     const sub = runtime.subscriptions[0]!;
     expect(sub.msgs.length).toBe(subBefore + 1);
@@ -812,18 +872,22 @@ describe("cortex#331 Phase 1 — pi-dev substrate dispatch (factory wired into R
     expect(handlersCalled).toBe(1);
     expect(decisions[0]).toEqual({ kind: "ack" });
 
-    // started + verdict + completed, in §8.2 order.
+    // The audit-parity sovereignty denial (cortex#932 / U0.2: the sage agent
+    // declares no modelClass → Stage-1b gate fails closed, emits
+    // `system.access.denied` with `enforced: false` and proceeds), then
+    // started + verdict + completed in §8.2 order.
     const emitted = runtime.published.slice(publishedBefore);
-    expect(emitted.length).toBe(3);
-    expect(emitted[0]!.type).toBe("dispatch.task.started");
-    expect(emitted[1]!.type).toBe("review.verdict.commented");
-    expect(emitted[2]!.type).toBe("dispatch.task.completed");
+    expect(emitted.length).toBe(4);
+    assertAuditParityDenial(emitted, requestSubject);
+    expect(emitted[1]!.type).toBe("dispatch.task.started");
+    expect(emitted[2]!.type).toBe("review.verdict.commented");
+    expect(emitted[3]!.type).toBe("dispatch.task.completed");
 
     // **THE HEADLINE CONTRACT** — verdict envelope's correlation_id is
     // the request envelope's id (design §5.1). Phase 1's pi-dev runner
     // preserves this; if a future refactor breaks it pilot's --wait
     // would silently miss every sage verdict.
-    const verdict = emitted[1]!;
+    const verdict = emitted[2]!;
     expect(verdict.correlation_id).toBe(request.id);
 
     // Summary carries sage's stdout verbatim — Phase 2 will parse this

--- a/src/__tests__/review-roundtrip.integration.test.ts
+++ b/src/__tests__/review-roundtrip.integration.test.ts
@@ -321,7 +321,13 @@ maybeDescribe("cortex#339 — live JetStream review round-trip", () => {
         return (
           types.includes("dispatch.task.started") &&
           types.includes("dispatch.task.completed") &&
-          types.includes("review.verdict.approved")
+          types.includes("review.verdict.approved") &&
+          // cortex#932 / U0.2: the echo agent declares no modelClass, so the
+          // Stage-1b sovereignty gate fails closed and emits an audit-parity
+          // `system.access.denied` (enforced:false) alongside the lifecycle.
+          // Wait for it too so the assertions below don't race the
+          // fire-and-forget emit over the JetStream wire.
+          types.includes("system.access.denied")
         );
       },
       () =>
@@ -334,7 +340,34 @@ maybeDescribe("cortex#339 — live JetStream review round-trip", () => {
     );
 
     const emitted = observed.filter((e) => e.correlation_id === request.id);
-    expect(emitted.map((e) => e.type)).toEqual([
+
+    // cortex#932 / P-14 U0.2 — the audit-parity sovereignty denial. The agent
+    // declares no modelClass, so `evaluateSovereignty` fails closed and the
+    // gate emits a `system.access.denied` governance signal (the stream the
+    // audit→enforce flip #906 reads). Because `sovereigntyEnforce` is unset,
+    // the pipeline still runs (`enforced:false`) — the denial is observable but
+    // does not bite. Asserted explicitly so the test guards the EMISSION (its
+    // reason + audit posture), never a bare count.
+    const denial = emitted.find((e) => e.type === "system.access.denied");
+    expect(denial).toBeDefined();
+    expect(denial!.payload).toMatchObject({
+      reason: {
+        kind: "sovereignty_model_class",
+        enforced: false,
+      },
+      envelope_subject: "local.test-op.default.tasks.code-review.typescript",
+    });
+    expect(
+      (denial!.payload as { reason: { reason: string } }).reason.reason,
+    ).toContain("agent model class missing or unknown");
+
+    // The §8.2 lifecycle sequence (denial excluded — it's an out-of-band
+    // governance signal, not part of the dispatch lifecycle). Over a real
+    // JetStream wire the lifecycle envelopes keep their relative order; the
+    // denial's wire position is best-effort (fire-and-forget) so it is matched
+    // by membership above, not pinned to an index here.
+    const lifecycle = emitted.filter((e) => e.type !== "system.access.denied");
+    expect(lifecycle.map((e) => e.type)).toEqual([
       "dispatch.task.started",
       "review.verdict.approved",
       "dispatch.task.completed",

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -141,6 +141,13 @@ function buildAgent(
   return {
     id: "echo",
     capabilities: ["code-review.typescript"],
+    // cortex#932 — declare a local-only model class by default so the
+    // consumer-side sovereignty gate (Stage 1b) ALLOWS the default local-only
+    // task without firing the new `system.access.denied` audit telemetry. A
+    // missing class fails closed (audit-parity would-deny), which would add an
+    // audit envelope to every count-based assertion below. The sovereignty
+    // tests override this with `frontier` / `{}` to exercise the deny paths.
+    modelClass: "local-only",
     ...overrides,
   };
 }
@@ -2230,6 +2237,14 @@ describe("ReviewConsumer.processEnvelope — consumer-side sovereignty gate (Sta
     // A dispatch.task.failed (wont_do) is published back to the requester.
     const failed = runtime.published.find((e) => e.type === "dispatch.task.failed");
     expect(failed).toBeDefined();
+    // cortex#932 — the enforce deny ALSO emits a system.access.denied audit
+    // envelope (reason sovereignty_model_class, enforced:true) for governance.
+    const denied = runtime.published.find((e) => e.type === "system.access.denied");
+    expect(denied).toBeDefined();
+    const reason = (denied!.payload as { reason: { kind: string; enforced: boolean } })
+      .reason;
+    expect(reason.kind).toBe("sovereignty_model_class");
+    expect(reason.enforced).toBe(true);
   });
 
   test("audit-parity (default): frontier agent + local-only task → still runs", async () => {
@@ -2258,6 +2273,15 @@ describe("ReviewConsumer.processEnvelope — consumer-side sovereignty gate (Sta
 
     expect(decision).toEqual({ kind: "ack" });
     expect(pipelineRan).toBe(true);
+    // cortex#932 — audit-parity STILL emits the would-deny telemetry (the
+    // governance pane sees the refusal even when the gate doesn't yet bite),
+    // with enforced:false to distinguish it from a hard deny.
+    const denied = runtime.published.find((e) => e.type === "system.access.denied");
+    expect(denied).toBeDefined();
+    const reason = (denied!.payload as { reason: { kind: string; enforced: boolean } })
+      .reason;
+    expect(reason.kind).toBe("sovereignty_model_class");
+    expect(reason.enforced).toBe(false);
   });
 
   test("enforce: local-only agent + local-only task → runs (no violation)", async () => {
@@ -2296,7 +2320,7 @@ describe("ReviewConsumer.processEnvelope — consumer-side sovereignty gate (Sta
     const consumer = new ReviewConsumer(
       baseOpts({
         runtime,
-        agent: buildAgent({}), // no modelClass
+        agent: buildAgent({ modelClass: undefined }), // no modelClass → fail closed
         sovereigntyEnforce: true,
         pipelineRunner: fixedPipeline(() => {
           pipelineRan = true;

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -12,17 +12,23 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../myelin/envelope-validator";
 import { validateEnvelope } from "../myelin/envelope-validator";
 import {
   adapterCorrelationKey,
   createAgentHeartbeatEvent,
+  createSystemAccessDeniedEvent,
   createSystemAccessFilteredEvent,
   createSystemAdapterDegradedEvent,
   createSystemAdapterDisconnectedEvent,
   createSystemAdapterRecoveredEvent,
   createSystemDispatchStageEvent,
   createSystemInboundAbortedEvent,
+  type SystemEventSource,
 } from "../system-events";
+import { emitSystemAccessDenied } from "../emit-system-access-denied";
+import { createAgentOnlineEvent } from "../agent-network/builders";
+import type { MyelinRuntime } from "../myelin/runtime";
 
 describe("adapterCorrelationKey", () => {
   test("formats `adapter:{id}:{iso}` per G-1111 §3.5.6", () => {
@@ -761,5 +767,155 @@ describe("createSystemDispatchStageEvent", () => {
       outcome: "info",
     });
     expect(a.id).not.toBe(b.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#932 (P-14 U0.2) — createSystemAccessDeniedEvent + emitSystemAccessDenied
+// ---------------------------------------------------------------------------
+
+describe("createSystemAccessDeniedEvent — open reason record (cortex#932 kinds)", () => {
+  const SOURCE: SystemEventSource = {
+    principal: "metafactory",
+    agent: "cortex",
+    instance: "local",
+  };
+
+  test("carries the structured reason verbatim and passes schema validation", () => {
+    const env = createSystemAccessDeniedEvent({
+      source: SOURCE,
+      principalId: "joel",
+      capability: "agent.online",
+      reason: { kind: "chain_verify_failed", verify_reason: "unknown_agent" },
+      sovereignty: {
+        classification: "federated",
+        data_residency: "NZ",
+        max_hop: 1,
+        frontier_ok: false,
+        model_class: "local-only",
+      },
+      correlationId: "00000000-0000-4000-8000-000000000001",
+      envelopeId: "00000000-0000-4000-8000-000000000002",
+      envelopeSubject: "federated.joel.research.agent.online",
+      signedBy: [],
+    });
+    expect(env.type).toBe("system.access.denied");
+    const payload = env.payload as { reason: { kind: string; verify_reason?: string } };
+    expect(payload.reason.kind).toBe("chain_verify_failed");
+    expect(payload.reason.verify_reason).toBe("unknown_agent");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("all four cortex#932 reason kinds produce schema-valid denied envelopes", () => {
+    const reasons = [
+      { kind: "sovereignty_model_class", reason: "x", enforced: true },
+      { kind: "chain_verify_failed", verify_reason: "unknown_agent" },
+      { kind: "chain_verify_fault", fault: "boom" },
+      { kind: "originator_denied", detail: "not a peer" },
+    ];
+    for (const reason of reasons) {
+      const env = createSystemAccessDeniedEvent({
+        source: SOURCE,
+        principalId: "joel",
+        capability: "agent.online",
+        reason,
+        sovereignty: {
+          classification: "local",
+          data_residency: "NZ",
+          max_hop: 0,
+          frontier_ok: false,
+          model_class: "local-only",
+        },
+        correlationId: "00000000-0000-4000-8000-000000000003",
+        envelopeId: "00000000-0000-4000-8000-000000000004",
+        envelopeSubject: "local.metafactory.x.y.z",
+        signedBy: [],
+      });
+      expect((env.payload as { reason: { kind: string } }).reason.kind).toBe(
+        reason.kind,
+      );
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+});
+
+describe("emitSystemAccessDenied — drop-site emit helper (cortex#932)", () => {
+  const SOURCE: SystemEventSource = {
+    principal: "metafactory",
+    agent: "cortex",
+    instance: "local",
+  };
+
+  /** A fake runtime that records every published envelope. */
+  function recordingRuntime(): { published: Envelope[]; runtime: MyelinRuntime } {
+    const published: Envelope[] = [];
+    const runtime = {
+      enabled: true,
+      publish: (env: Envelope) => {
+        published.push(env);
+        return Promise.resolve();
+      },
+    } as unknown as MyelinRuntime;
+    return { published, runtime };
+  }
+
+  /** A foreign federated presence envelope to feed the helper. */
+  function inbound(): Envelope {
+    return createAgentOnlineEvent({
+      source: { principal: "joel", stack: "research", instance: "local" },
+      identity: {
+        nkey_public_key: "UPEER1234567890",
+        agent_id: "sage",
+        assistant_name: "Sage",
+      },
+      scope: { principal: "joel", stack: "research" },
+      capabilities: ["code-review.typescript"],
+      startedAt: new Date("2026-06-11T09:00:00.000Z"),
+      classification: "federated",
+    });
+  }
+
+  test("publishes a system.access.denied envelope carrying the reason kind", () => {
+    const { published, runtime } = recordingRuntime();
+    emitSystemAccessDenied(runtime, SOURCE, inbound(), {
+      envelopeSubject: "federated.joel.research.agent.online",
+      principalId: "joel",
+      capability: "agent.online",
+      reason: { kind: "chain_verify_failed", verify_reason: "unknown_agent" },
+    });
+    expect(published.length).toBe(1);
+    expect(published[0]!.type).toBe("system.access.denied");
+    const reason = (published[0]!.payload as { reason: { kind: string } }).reason;
+    expect(reason.kind).toBe("chain_verify_failed");
+  });
+
+  test("derives correlation + envelope_id from the dropped envelope", () => {
+    const { published, runtime } = recordingRuntime();
+    const env = inbound();
+    emitSystemAccessDenied(runtime, SOURCE, env, {
+      envelopeSubject: "federated.joel.research.agent.online",
+      principalId: "joel",
+      capability: "agent.online",
+      reason: { kind: "chain_verify_fault", fault: "boom" },
+    });
+    const payload = published[0]!.payload as {
+      envelope_id: string;
+      envelope_subject: string;
+    };
+    expect(payload.envelope_id).toBe(env.id);
+    expect(payload.envelope_subject).toBe("federated.joel.research.agent.online");
+  });
+
+  test("source-undefined guard: NO-OP, publishes nothing, does not throw", () => {
+    const { published, runtime } = recordingRuntime();
+    expect(() =>
+      emitSystemAccessDenied(runtime, undefined, inbound(), {
+        envelopeSubject: "federated.joel.research.agent.online",
+        principalId: "joel",
+        capability: "agent.online",
+        reason: { kind: "chain_verify_failed", verify_reason: "unknown_agent" },
+      }),
+    ).not.toThrow();
+    expect(published.length).toBe(0);
   });
 });

--- a/src/bus/agent-network/__tests__/federated-subscriber.test.ts
+++ b/src/bus/agent-network/__tests__/federated-subscriber.test.ts
@@ -369,6 +369,54 @@ describe("E.5 — TRUST: signed_by chain verification", () => {
     runtime.fire(signed, FED_SUBJECT, "primary");
     await flush();
     expect(registry.getAgents().length).toBe(0);
+    // cortex#932 — the chain-verify rejection is no longer silent: it emits a
+    // system.access.denied audit envelope with reason kind chain_verify_failed.
+    const denied = runtime.published.find(
+      (e) => e.type === "system.access.denied",
+    );
+    expect(denied).toBeDefined();
+    expect(
+      (denied!.payload as { reason: { kind: string } }).reason.kind,
+    ).toBe("chain_verify_failed");
+    await handle.stop();
+  });
+
+  test("verifier THREW ⇒ DROPPED + system.access.denied chain_verify_fault (cortex#932)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    // Force the verify promise to REJECT by making the federated-peer
+    // resolution seam throw. `verifySignedByChain` engages this seam only with
+    // cryptoVerify:true + a federated-classification envelope (both true here),
+    // and the seam is contractually "must never throw" — so a throw drops into
+    // the subscriber's .catch() fault path (the cortex#932 chain_verify_fault).
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: true,
+      resolveFederatedPeer: () => {
+        throw new Error("resolver exploded");
+      },
+    });
+    const signed = foreignOnline({
+      signedBy: [
+        { method: "ed25519", identity: "did:mf:stranger", signature: "x", timestamp: "t" } as unknown as SignedBy,
+      ],
+    });
+    runtime.fire(signed, FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0);
+    const denied = runtime.published.find(
+      (e) => e.type === "system.access.denied",
+    );
+    expect(denied).toBeDefined();
+    expect(
+      (denied!.payload as { reason: { kind: string } }).reason.kind,
+    ).toBe("chain_verify_fault");
     await handle.stop();
   });
 

--- a/src/bus/agent-network/federated-subscriber.ts
+++ b/src/bus/agent-network/federated-subscriber.ts
@@ -103,6 +103,7 @@ import {
   evaluateFederationGate,
   subjectMatches,
 } from "../surface-router";
+import { emitSystemAccessDenied } from "../emit-system-access-denied";
 import { verifySignedByChain } from "../verify-signed-by-chain";
 import { AgentPresenceRegistry } from "./registry";
 import { AGENT_PRESENCE_TYPES } from "./envelopes";
@@ -314,6 +315,18 @@ export async function startFederatedAgentPresenceSubscriber(
                 `(id=${envelope.id}) — signed_by chain verification failed: ` +
                 `${result.reason.kind}\n`,
             );
+            // cortex#932 — the drop was stderr-only; emit a queryable
+            // `system.access.denied` on our local audit stream so governance
+            // sees the chain-verify rejection. Carries signed_by[] verbatim.
+            emitSystemAccessDenied(runtime, source, envelope, {
+              envelopeSubject: subject,
+              principalId: envelope.source.split(".")[0] ?? envelope.source,
+              capability: envelope.type,
+              reason: {
+                kind: "chain_verify_failed",
+                verify_reason: result.reason.kind,
+              },
+            });
             return;
           }
           foldForeign(registry, envelope);
@@ -321,11 +334,22 @@ export async function startFederatedAgentPresenceSubscriber(
         .catch((err: unknown) => {
           // A verifier fault must never crash the fan-out — log + drop (fail
           // closed: an envelope we couldn't verify is not folded).
+          const faultMessage = err instanceof Error ? err.message : String(err);
           process.stderr.write(
             `federated-agent-presence: chain verify threw for ${envelope.type} ` +
               `(id=${envelope.id}) — dropping: ` +
-              `${err instanceof Error ? err.message : String(err)}\n`,
+              `${faultMessage}\n`,
           );
+          // cortex#932 — a verifier FAULT is also a fail-closed drop; make it
+          // observable on the local audit stream (distinct reason kind from a
+          // clean chain rejection so governance can tell "verifier broke" from
+          // "signature didn't verify").
+          emitSystemAccessDenied(runtime, source, envelope, {
+            envelopeSubject: subject,
+            principalId: envelope.source.split(".")[0] ?? envelope.source,
+            capability: envelope.type,
+            reason: { kind: "chain_verify_fault", fault: faultMessage },
+          });
         });
       return;
     }

--- a/src/bus/emit-system-access-denied.ts
+++ b/src/bus/emit-system-access-denied.ts
@@ -1,0 +1,142 @@
+/**
+ * cortex#932 (P-14 U0.2) — structured `system.access.denied` telemetry for the
+ * consumer-side fail-closed DROP sites.
+ *
+ * Several gates in the bus refuse / drop an envelope SILENTLY (stderr-only, or
+ * no signal at all). Each such drop is a governance-relevant decision that the
+ * audit→enforce flip (#906) and the U3.1 governance pane need to SEE. This
+ * helper turns a silent drop into a queryable `system.access.denied` audit
+ * envelope, reusing the EXISTING builder + emit pattern.
+ *
+ * It is the drop-site sibling of {@link emitFederationDenied} (surface-router,
+ * the D.2 router-gate variant): SAME wire shape (`type:
+ * "system.access.denied"`, local audit subject derived from `source`), SAME
+ * best-effort contract (no-op when `source` is undefined, runtime errors
+ * surfaced to stderr and swallowed so a broken audit path can never poison the
+ * gate's own fail-closed decision). Living in its own module keeps
+ * `system-events.ts` a pure builder (runtime-free) and avoids editing the
+ * cross-session `surface-router.ts` hotspot.
+ *
+ * @jcfischer owns the `system.access.*` shape — the four reason kinds emitted
+ * through here (`sovereignty_model_class` / `chain_verify_failed` /
+ * `chain_verify_fault` / `originator_denied`) ride the OPEN
+ * {@link SystemAccessDeniedReason} record (its `kind` is `string`), so they add
+ * NO wire break and need no schema bump.
+ */
+
+import type { Envelope } from "./myelin/envelope-validator";
+import { getSignedByChain } from "./myelin/envelope-validator";
+import type { MyelinRuntime } from "./myelin/runtime";
+import {
+  createSystemAccessDeniedEvent,
+  type SystemAccessDeniedReason,
+  type SystemAccessSignedBy,
+  type SystemAccessSovereignty,
+  type SystemEventSource,
+} from "./system-events";
+
+/**
+ * Per-call inputs that the builder can't infer from the dropped envelope. The
+ * `signedBy` / `sovereignty` / `correlationId` / `envelopeSubject` /
+ * `envelopeId` fields {@link createSystemAccessDeniedEvent} needs are derived
+ * here from `envelope` + `envelopeSubject`, so callers only supply the gate's
+ * own decision vocabulary.
+ */
+export interface SystemAccessDeniedEmit {
+  /** Subject the dropped envelope arrived on — rides `envelope_subject`. */
+  envelopeSubject: string;
+  /**
+   * Principal the gate was evaluating. Bare (no `did:mf:` prefix). Falls back
+   * to the dropped envelope's source principal when the caller has nothing
+   * more specific (e.g. a presence drop, where the source IS the actor).
+   */
+  principalId: string;
+  /** Capability claim / intent the gate evaluated (free-form per gate). */
+  capability: string;
+  /** Structured reason — `kind` plus any variant fields (open record). */
+  reason: SystemAccessDeniedReason;
+}
+
+/** First segment of `envelope.source` — the bare source principal. */
+function sourcePrincipalOf(envelope: Envelope): string {
+  return envelope.source.split(".")[0] ?? envelope.source;
+}
+
+/**
+ * Emit a `system.access.denied` audit envelope for a fail-closed drop.
+ *
+ * No-op (log + return) when `source` is undefined — the test-only path, mirror
+ * of {@link emitFederationDenied}. Production callers MUST pass a
+ * `SystemEventSource`; emitting a half-formed envelope from an undefined source
+ * is worse than not emitting.
+ *
+ * Best-effort: a `runtime.publish` rejection (a regression of the "publish
+ * never throws" contract) is surfaced to stderr, never propagated — the gate's
+ * own drop decision has already been made and must not be unwound by an audit
+ * failure.
+ */
+export function emitSystemAccessDenied(
+  runtime: MyelinRuntime,
+  source: SystemEventSource | undefined,
+  envelope: Envelope,
+  emit: SystemAccessDeniedEmit,
+): void {
+  if (!source) {
+    // Test-only path: a production caller wiring the gate passes
+    // `systemEventSource`. Log so a missing wiring is visible, but never emit
+    // a half-formed envelope. Same contract as `emitFederationDenied`.
+    console.info(
+      `emitSystemAccessDenied: drop subject="${emit.envelopeSubject}" reason=${emit.reason.kind} ` +
+        `(no systemEventSource configured — system.access.denied envelope NOT emitted)`,
+    );
+    return;
+  }
+
+  // Carry `signed_by[]` verbatim (C.4.3) — a denied envelope stays
+  // cryptographically attributable; the rejection is part of the audit trail.
+  const signedBy: SystemAccessSignedBy[] = getSignedByChain(envelope).map(
+    (stamp) => ({ ...stamp }),
+  );
+  const sovereignty: SystemAccessSovereignty = {
+    classification: envelope.sovereignty.classification,
+    data_residency: envelope.sovereignty.data_residency,
+    max_hop: envelope.sovereignty.max_hop,
+    frontier_ok: envelope.sovereignty.frontier_ok,
+    model_class: envelope.sovereignty.model_class,
+  };
+
+  try {
+    const env = createSystemAccessDeniedEvent({
+      source,
+      principalId: emit.principalId || sourcePrincipalOf(envelope),
+      capability: emit.capability,
+      reason: emit.reason,
+      sovereignty,
+      // Fall back to envelopeId for joinability when the dropped envelope had
+      // no correlation_id — audit consumers always get a non-empty join key.
+      correlationId: envelope.correlation_id ?? envelope.id,
+      envelopeId: envelope.id,
+      envelopeSubject: emit.envelopeSubject,
+      signedBy,
+    });
+    // Defensive `.catch()` — same pattern as `emitFederationDenied`: a
+    // regression of the runtime.publish "never throws" contract surfaces a
+    // principal-visible signal instead of silently dropping the audit
+    // envelope. Direct stderr — a broken runtime can't swallow alerts about
+    // itself.
+    runtime.publish(env).catch((publishErr: unknown) => {
+      process.stderr.write(
+        `[emit-system-access-denied] failed to emit system.access.denied audit envelope ` +
+          `(reason=${emit.reason.kind}): ${publishErr instanceof Error ? publishErr.message : String(publishErr)}\n`,
+      );
+    });
+  } catch (err) {
+    // Defensive — buildBaseEnvelope shouldn't throw on schema-valid inputs,
+    // but a future refactor making it synchronous-throwing must not poison the
+    // gate that called us.
+    console.error(
+      `emitSystemAccessDenied: failed to build system.access.denied for subject="${emit.envelopeSubject}":`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -71,6 +71,7 @@ import type { Envelope } from "./myelin/envelope-validator";
 import { getActorPrincipal } from "./myelin/envelope-validator";
 import { resolveSourceNetwork } from "./surface-router";
 import { evaluateSovereignty, type AgentModelClass } from "./sovereignty-gate";
+import { emitSystemAccessDenied } from "./emit-system-access-denied";
 import type { GateFloorDecision } from "./gate-floor";
 import type { PolicyFederatedNetwork } from "../common/types/cortex-config";
 import type { MyelinSubscriber } from "./myelin/subscriber";
@@ -662,6 +663,13 @@ export class ReviewConsumer {
           `cortex/review-consumer: federated request DENIED (dropped) for ` +
             `agent="${this.agent.id}" subject=${subject} envelope=${envelope.id} — ${denyReason}\n`,
         );
+        // cortex#932 — this `originator_denied` fail-closed drop is the #908
+        // pain and #908 OWNS this exact site; the `originator_denied` reason
+        // kind is reserved in `SystemAccessDeniedReason` for #908 to wire its
+        // emit without a wire-shape change. Deliberately NOT emitting here to
+        // avoid colliding with #908's in-flight fix (issue #932: "must not
+        // collide with #908 fixes"). The drop stays observable via stderr +
+        // the `term` ack until #908 lands.
         // Term so JetStream removes the message (permanent — a non-peer
         // requester won't become a peer on redelivery) WITHOUT emitting any
         // verdict/lifecycle envelope to a principal we don't trust.
@@ -829,6 +837,22 @@ export class ReviewConsumer {
     {
       const sov = evaluateSovereignty(envelope.sovereignty, this.agent.modelClass);
       if (sov.decision === "deny") {
+        // cortex#932 — emit `system.access.denied` for BOTH the enforce deny
+        // and the audit-parity would-deny, so the governance pane sees the
+        // sovereignty refusal regardless of posture (the audit→enforce flip,
+        // #906, reads exactly this stream). `enforced` distinguishes the bit
+        // that bit from the would-deny. Emitted before the term ack on the
+        // enforce path — best-effort, never blocks the decision.
+        emitSystemAccessDenied(this.runtime, this.source, envelope, {
+          envelopeSubject: subject,
+          principalId: requester?.principal ?? getActorPrincipal(envelope) ?? "",
+          capability: envelope.type,
+          reason: {
+            kind: "sovereignty_model_class",
+            reason: sov.reason,
+            enforced: this.sovereigntyEnforce,
+          },
+        });
         if (this.sovereigntyEnforce) {
           process.stderr.write(
             `cortex/review-consumer: sovereignty DENIED (enforce) for ` +

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -610,6 +610,25 @@ export interface SystemAccessDeniedReason {
    * Discriminator — `"unknown_principal"` | `"insufficient_role"`
    * | `"sovereignty_mismatch"` today. Future kinds append per
    * G-1111 §3.1 (no wire break).
+   *
+   * cortex#932 (P-14 U0.2) — the consumer-side fail-closed drop sites
+   * emit on this same open record. Their kinds (no wire break — the
+   * field is `string`):
+   *   - `"sovereignty_model_class"` — the consumer-side sovereignty gate
+   *     (review-consumer Stage 1b) refused a task whose model-class demand
+   *     its own class would violate. Rides `reason` (free-form, from
+   *     `evaluateSovereignty`) + `enforced` (bool — `true` when the deny
+   *     bit, `false` on the audit-parity would-deny).
+   *   - `"chain_verify_failed"` — a foreign `federated.*` presence envelope
+   *     FAILED `signed_by[]` chain verification and was dropped (never
+   *     folded). Rides `verify_reason` (the verifier's `result.reason.kind`).
+   *   - `"chain_verify_fault"` — the chain verifier itself THREW; the
+   *     envelope is dropped fail-closed (an envelope we couldn't verify is
+   *     never folded). Rides `fault` (the thrown error's message).
+   *   - `"originator_denied"` — a cross-principal (`federated.*`) review
+   *     request whose requester (decoded from `originator.identity`) is not
+   *     a configured `peers[]` member, or is unresolvable, was denied and
+   *     dropped (the #908 fail-closed class). Rides `detail` (free-form).
    */
   kind: string;
   /**
@@ -617,6 +636,10 @@ export interface SystemAccessDeniedReason {
    *   - `principal_id` (always present today)
    *   - `missing_capability` (insufficient_role)
    *   - `reason` (sovereignty_mismatch — free-form text)
+   *   - `enforced` (sovereignty_model_class — bool)
+   *   - `verify_reason` (chain_verify_failed — the verifier reason kind)
+   *   - `fault` (chain_verify_fault — the thrown error message)
+   *   - `detail` (originator_denied — free-form text)
    */
   [k: string]: unknown;
 }


### PR DESCRIPTION
Closes #932 (P-14 U0.2). **Trust-path unit** — expect adversarial review.

## What this does
Two SILENT fail-closed drop sites now emit a queryable `system.access.denied` audit envelope, reusing the **existing** `createSystemAccessDeniedEvent` builder + emit pattern. **No new infrastructure.** Feeds the audit→enforce flip (#906) and the U3.1 governance pane.

### Drop site A — consumer-side sovereignty gate (`src/bus/review-consumer.ts`)
The Stage-1b sovereignty gate (`evaluateSovereignty` deny) previously emitted **nothing**. Now emits `system.access.denied` on **both** paths:
- enforce DENY → `reason.enforced: true`
- audit-parity would-deny → `reason.enforced: false`

reason kind: **`sovereignty_model_class`** (+ the `evaluateSovereignty` reason text).

### Drop site B — signed_by chain verification (`src/bus/agent-network/federated-subscriber.ts`)
Both drops were **stderr-only**. Now emit (stderr retained):
- chain-verify reject (`!result.valid`) → **`chain_verify_failed`** (carries the verifier `result.reason.kind` as `verify_reason`)
- verifier-threw `.catch()` → **`chain_verify_fault`** (carries the thrown message as `fault`)

Both carry `signed_by[]` verbatim (C.4.3 attribution).

## The 4 reason kinds
Ride the **OPEN** `SystemAccessDeniedReason` record (`kind: string`) — **no wire break, no schema bump**:

| kind | wired? | site |
|------|--------|------|
| `sovereignty_model_class` | ✅ | review-consumer sovereignty gate |
| `chain_verify_failed` | ✅ | federated-subscriber chain reject |
| `chain_verify_fault` | ✅ | federated-subscriber verifier fault |
| `originator_denied` | **documented + reserved, NOT wired** | review-consumer federated-requester denial |

`originator_denied` is the **#908 pain** and **#908 owns that exact drop site** — wiring an emit there would collide with its in-flight fix (issue #932: "must not collide with #908 fixes"). The kind is reserved in the doc so #908 can wire its emit without a wire-shape change.

## Emit pattern
New `src/bus/emit-system-access-denied.ts` helper **mirrors** surface-router's `emitFederationDenied`:
- source-undefined guard → no-op (log + return), never emits a half-formed envelope
- `signed_by[]` carried verbatim, sovereignty lifted from the dropped envelope
- `runtime.publish().catch()` best-effort — a broken audit path never unwinds the gate's fail-closed decision

**`surface-router.ts` is NOT edited** (cross-session hotspot). The helper keeps `system-events.ts` a pure (runtime-free) builder. Subject is the builder default: `local.{principal}.system.access.denied` (local audit stream).

## Tests
- `system-events.test.ts` — builder carries all 4 reason kinds (schema-valid); `emitSystemAccessDenied` publishes the right kind, derives `envelope_id`/`subject`, and the **source-undefined guard no-ops without throwing**.
- `review-consumer.test.ts` — sovereignty enforce emit (`sovereignty_model_class`, `enforced:true`) + audit-parity emit (`enforced:false`). Default test agent given `modelClass: "local-only"` so pre-existing exact-count assertions stay correct (a missing class fails-closed = audit-parity, which would otherwise add an audit envelope to every count test).
- `federated-subscriber.test.ts` — chain-verify reject asserts `chain_verify_failed`; new verifier-fault test asserts `chain_verify_fault`.

## Gate results (run in worktree)
- `bunx tsc --noEmit` → **0 errors** (exit 0)
- `bun test src/bus` → **909 pass / 0 fail / 1 skip** (40 files); the 3 target files: 143 pass / 0 fail
- `eslint` on the 7 changed/new files → **0 problems** (exit 0)

## #988 non-collision (verified)
PR #988 touches `src/adapters/*`, `src/gateway/*`, `src/runner/*`, `src/surface/mc/ws/types.ts`. **None** of my files overlap — confirmed via `gh pr view 988 --json files` and `git diff --name-only`. **`src/surface/mc/ws/types.ts` is NOT touched.**

## JC coordination
@jcfischer owns the `system.access.*` shape — coordination comment posted: https://github.com/the-metafactory/cortex/issues/932#issuecomment-4679994785

🤖 Generated with [Claude Code](https://claude.com/claude-code)