### PR TITLE
feat(mc): #989 part-1 — Network view aggregates all local stacks (multi-bus presence)

### DIFF
--- a/docs/config-layout/stacks/research.yaml
+++ b/docs/config-layout/stacks/research.yaml
@@ -184,6 +184,27 @@ mc:
   # IP, a hostname) is REFUSED at config-parse time — the daemon won't boot.
   # Override only to change the port or front it with a same-host reverse proxy.
   sideband: "http://127.0.0.1:9092"
+  # #989 part-1 — LOCAL same-principal stack aggregation on the Network view.
+  # When enabled (DEFAULT ON), the dashboard-serving daemon auto-discovers the
+  # principal's OTHER local stacks (sibling config-split dirs under the config
+  # root), opens a READ-ONLY subscriber to each one's loopback NATS bus using
+  # ITS OWN credential, and folds its agent presence into this pane — so the
+  # Network view shows ALL your local stacks as distinct stack-hubs, not just
+  # this one. NO federation, NO cross-principal trust (every bus is YOUR own
+  # loopback bus). A sibling that can't be reached/authed degrades to absent
+  # (its hub just doesn't appear) — it never blocks boot or perturbs this stack.
+  # A single-stack box is unaffected (discovery finds no siblings = no-op).
+  aggregateLocalStacks:
+    enabled: true                  # false = pin the pane to THIS stack only
+    configRoot: ""                 # empty = the serving config dir's parent (~/.config/cortex)
+    # Explicit roster OVERRIDES auto-discovery when non-empty (precedence:
+    # explicit > discovery). Use it to add a bus the scan can't see, or to
+    # narrow the set. Each entry needs a connectable creds file.
+    stacks: []
+    #  - stack: work
+    #    principal: andreas
+    #    url: "nats://127.0.0.1:4222"
+    #    credsPath: "~/.config/nats/cortex-work.creds"
 
 # -----------------------------------------------------------------------------
 # cockpit — G-1113 live-refresh loop (plan ingest → reconcile → attention).

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -141,7 +141,7 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
       encryption: { payload: "off", at_rest: "off" },
       transport: { mtls: "off" },
     },
-    mc: { enabled: false, configPath: "", dbPath: "", port: 0, sideband: "http://127.0.0.1:9092" },
+    mc: { enabled: false, configPath: "", dbPath: "", port: 0, sideband: "http://127.0.0.1:9092", aggregateLocalStacks: { enabled: true, configRoot: "", stacks: [] } },
     cockpit: {
       enabled: false,
       docsDir: "docs",

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -127,6 +127,7 @@ const TEST_CONFIG: AgentConfig = {
     dbPath: "",
     port: 0,
     sideband: "http://127.0.0.1:9092",
+    aggregateLocalStacks: { enabled: true, configRoot: "", stacks: [] },
   },
   networksDir: "./networks",
   networks: [],

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -590,6 +590,9 @@ describe("AgentConfigSchema.mc (MC-I1.S1)", () => {
       port: 0,
       // P-14 U0.1 — sideband defaults to the contract loopback bind.
       sideband: "http://127.0.0.1:9092",
+      // #989 — local-stack aggregation defaults ON; discovery is a no-op on a
+      // single-stack box (finds no siblings).
+      aggregateLocalStacks: { enabled: true, configRoot: "", stacks: [] },
     });
   });
 
@@ -726,6 +729,43 @@ describe("mc.sideband (P-14 U0.1)", () => {
       expect(
         CortexConfigSchema.parse({ ...minConfig(), mc: { sideband: good } }).mc.sideband,
       ).toBe(good);
+    });
+
+    // #989 — mc.aggregateLocalStacks is on the SHARED McSchema, so BOTH config
+    // shapes must parse it identically (the #877/#879 lesson).
+    test("BOTH schemas default mc.aggregateLocalStacks ON with empty roster", () => {
+      const fromAgent = AgentConfigSchema.parse(minAgentConfig()).mc
+        .aggregateLocalStacks;
+      const fromCortex = CortexConfigSchema.parse(minConfig()).mc
+        .aggregateLocalStacks;
+      const expected = { enabled: true, configRoot: "", stacks: [] };
+      expect(fromAgent).toEqual(expected);
+      expect(fromCortex).toEqual(expected);
+    });
+
+    test("BOTH schemas parse an explicit aggregateLocalStacks roster identically", () => {
+      const block = {
+        enabled: true,
+        configRoot: "~/.config/cortex",
+        stacks: [
+          {
+            stack: "work",
+            principal: "andreas",
+            url: "nats://127.0.0.1:4222",
+            credsPath: "~/.config/nats/cortex-work.creds",
+          },
+        ],
+      };
+      const agentParsed = AgentConfigSchema.parse({
+        ...minAgentConfig(),
+        mc: { aggregateLocalStacks: block },
+      }).mc.aggregateLocalStacks;
+      const cortexParsed = CortexConfigSchema.parse({
+        ...minConfig(),
+        mc: { aggregateLocalStacks: block },
+      }).mc.aggregateLocalStacks;
+      expect(agentParsed).toEqual(block);
+      expect(cortexParsed).toEqual(block);
     });
   });
 });

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -404,7 +404,7 @@ export const McSchema = z.object({
    * LOCAL read-only multi-subscription (same principal, loopback buses the
    * principal owns); NO federation, NO cross-principal trust.
    *
-   * **Default ON.** The operator runs several stacks on one machine and expects
+   * **Default ON.** The principal runs several stacks on one machine and expects
    * the localhost pane to be the one-pane-over-all-my-stacks surface (#989); a
    * single-stack deployment is unaffected because discovery simply finds no
    * siblings (an empty config root ⇒ a no-op). The cost is bounded (one extra

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -392,6 +392,54 @@ export const McSchema = z.object({
    * at the proxy request boundary too.
    */
   sideband: z.string().default(DEFAULT_SIDEBAND_URL),
+  /**
+   * #989 part-1 — LOCAL same-principal stack aggregation on the Network view.
+   *
+   * When `enabled`, the dashboard-serving daemon auto-discovers the principal's
+   * OTHER local stacks (by scanning the config root for sibling config-split
+   * dirs), opens a READ-ONLY subscriber to each one's local loopback NATS bus
+   * using that stack's own credential, and folds its `agent.*` presence into the
+   * shared presence registry — so the Network view shows ALL of a principal's
+   * local stacks as distinct stack-hubs, not just the serving one. This is a
+   * LOCAL read-only multi-subscription (same principal, loopback buses the
+   * principal owns); NO federation, NO cross-principal trust.
+   *
+   * **Default ON.** The operator runs several stacks on one machine and expects
+   * the localhost pane to be the one-pane-over-all-my-stacks surface (#989); a
+   * single-stack deployment is unaffected because discovery simply finds no
+   * siblings (an empty config root ⇒ a no-op). The cost is bounded (one extra
+   * read-only loopback NATS connection per discovered sibling), and any
+   * unreachable sibling degrades to absent rather than affecting the serving
+   * stack. Set `enabled: false` to pin the pane to the serving stack only.
+   *
+   * **`stacks[]` (explicit override).** When non-empty, this EXACT list is the
+   * sibling roster and auto-discovery is skipped (precedence: explicit >
+   * discovery). Each entry pins a sibling's `{stack}`, `{principal}`, bus `url`,
+   * and `credsPath`. Use it to add a bus the scan can't see or to narrow the
+   * roster. Empty (the default) ⇒ auto-discover.
+   */
+  aggregateLocalStacks: z
+    .object({
+      enabled: z.boolean().default(true),
+      /**
+       * Config root to scan for sibling stacks. Empty ⇒ the serving stack's own
+       * config dir's parent (the conventional `~/.config/cortex`). Leading `~`
+       * is expanded at boot.
+       */
+      configRoot: z.string().default(""),
+      /** Explicit sibling roster — OVERRIDES discovery when non-empty. */
+      stacks: z
+        .array(
+          z.object({
+            stack: z.string().min(1),
+            principal: z.string().min(1),
+            url: z.string().min(1),
+            credsPath: z.string().min(1),
+          }),
+        )
+        .default([]),
+    })
+    .default(emptyDefault()),
 }).default(emptyDefault()).superRefine((val, ctx) => {
   // Loopback enforcement (§8: "Cortex MUST refuse to set a non-loopback host").
   // Only check when a value is present; the `.default()` supplies a loopback
@@ -418,6 +466,14 @@ export const McSchema = z.object({
   dbPath: val.dbPath ?? "",
   port: val.port ?? 0,
   sideband: val.sideband ?? DEFAULT_SIDEBAND_URL,
+  // #989 — re-apply the nested default ({} from `.default(emptyDefault())`
+  // would otherwise leave the inner fields undefined). The `??` chain is
+  // load-bearing for the all-defaults parse path, same as the leaves above.
+  aggregateLocalStacks: {
+    enabled: val.aggregateLocalStacks?.enabled ?? true,
+    configRoot: val.aggregateLocalStacks?.configRoot ?? "",
+    stacks: val.aggregateLocalStacks?.stacks ?? [],
+  },
   /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 }));
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -160,6 +160,13 @@ import {
   startFederatedAgentPresenceSubscriber,
   type FederatedAgentPresenceSubscriberHandle,
 } from "./bus/agent-network/federated-subscriber";
+// #989 part-1 — LOCAL same-principal multi-bus presence aggregation.
+import { discoverSiblingStacks } from "./surface/mc/local-aggregation/sibling-discovery";
+import {
+  startSiblingPresenceAggregator,
+  type SiblingPresenceAggregatorHandle,
+} from "./surface/mc/local-aggregation/sibling-presence-subscriber";
+import { natsSiblingBusConnector } from "./surface/mc/local-aggregation/nats-sibling-connector";
 import { createProbeResponder, type ProbeResponder } from "./bus/probe-responder";
 import { WorklogManager } from "./runner/worklog-manager";
 
@@ -3652,6 +3659,10 @@ export async function startCortex(
   // G-1114.E.2 — trust-verified federated presence subscriber (folds peers'
   // agents into the SAME registry, tagged with foreign provenance).
   let federatedPresenceHandle: FederatedAgentPresenceSubscriberHandle | null = null;
+  // #989 part-1 — LOCAL same-principal sibling-stack presence aggregator (folds
+  // the principal's OTHER local stacks' agents into the SAME registry, tagged by
+  // sibling origin, so the Network view shows every local stack as its own hub).
+  let siblingPresenceHandle: SiblingPresenceAggregatorHandle | null = null;
   // G-1114.E.1 — federate presence ONLY when the stack has opted into
   // federation (it declares at least one `policy.federated.networks[]`). This is
   // the SAME opt-in lever the federated subscriber + the dispatch-listener gate
@@ -3769,6 +3780,69 @@ export async function startCortex(
         `cortex: agent-presence producer + registry started — ${presenceAgents.length} agent(s) announced ` +
           `(stack-local; heartbeat every ${DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS}ms)`,
       );
+
+      // #989 part-1 — LOCAL same-principal sibling-stack presence aggregation.
+      // When enabled (default ON), auto-discover the principal's OTHER local
+      // stacks (sibling config-split dirs under the config root), open a
+      // READ-ONLY subscriber to each one's loopback bus using ITS OWN creds, and
+      // fold its `agent.*` presence into the SAME registry tagged with the
+      // sibling's origin — so the Network view renders every local stack as its
+      // own hub (not just this serving stack). NO federation, NO cross-principal
+      // trust: every bus is the principal's own loopback bus (ADR-0005). Any
+      // sibling that can't be reached / authed degrades to absent — it never
+      // blocks this boot or perturbs the serving stack's own presence.
+      const aggCfg = config.mc.aggregateLocalStacks;
+      if (aggCfg.enabled) {
+        try {
+          // Precedence: explicit `stacks[]` overrides discovery. Empty ⇒ scan
+          // the config root (default = the serving config dir's parent, the
+          // conventional `~/.config/cortex`).
+          const configRoot =
+            aggCfg.configRoot !== ""
+              ? expandTilde(aggCfg.configRoot)
+              : dirname(configDir);
+          const explicit =
+            aggCfg.stacks.length > 0
+              ? aggCfg.stacks.map((s) => ({
+                  stack: s.stack,
+                  principal: s.principal,
+                  url: s.url,
+                  credential: {
+                    kind: "creds" as const,
+                    credsPath: s.credsPath,
+                  },
+                }))
+              : undefined;
+          const siblings = discoverSiblingStacks({
+            configRoot,
+            selfPrincipal: principalId,
+            selfStack: derivedStack.stack,
+            ...(explicit !== undefined && { explicit }),
+          });
+          siblingPresenceHandle = await startSiblingPresenceAggregator({
+            registry: presenceRegistryHandle.registry,
+            siblings,
+            connect: natsSiblingBusConnector,
+          });
+          const aggregated = siblings.length - siblingPresenceHandle.degraded.length;
+          console.log(
+            `cortex: local-stack presence aggregation — ${aggregated}/${siblings.length} sibling stack(s) ` +
+              `aggregated` +
+              (siblingPresenceHandle.degraded.length > 0
+                ? ` (degraded: ${siblingPresenceHandle.degraded
+                    .map((d) => d.stack)
+                    .join(", ")})`
+                : ""),
+          );
+        } catch (err) {
+          // Aggregation is additive + best-effort: a fault here must never crash
+          // the serving daemon's boot or its own presence path.
+          console.error(
+            "cortex: local-stack presence aggregation startup error (non-fatal):",
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
     } catch (err) {
       console.error(
         "cortex: agent-presence producer/registry startup error (non-fatal):",
@@ -4061,6 +4135,16 @@ export async function startCortex(
       await completeAsync(
         "federated agent-presence subscriber stop",
         federatedPresenceHandle?.stop(),
+      );
+      // #989 part-1 — stop the LOCAL sibling-stack aggregator alongside the
+      // federated one (both before the registry stop). It closes every sibling
+      // read-only link + prunes the sibling foreign records. Both stops call
+      // `removeForeign()` (idempotent); ordering relative to the federated stop
+      // doesn't matter — by the time the registry stops, all foreign records are
+      // gone.
+      await completeAsync(
+        "local-stack presence aggregator stop",
+        siblingPresenceHandle?.stop(),
       );
       await completeAsync(
         "agent-presence registry stop",

--- a/src/surface/mc/local-aggregation/__tests__/sibling-discovery.test.ts
+++ b/src/surface/mc/local-aggregation/__tests__/sibling-discovery.test.ts
@@ -1,0 +1,306 @@
+/**
+ * #989 part-1 — sibling-bus DISCOVERY tests (TDD, RED-first).
+ *
+ * The aggregator must auto-discover the principal's OTHER local stacks by
+ * scanning a config root (`<root>/<slug>/system/system.yaml` +
+ * `<slug>/stacks/<name>.yaml`), yielding one {stack, bus url, credential}
+ * descriptor per sibling. Coverage axes:
+ *
+ *   1. Happy path — N stack dirs → N descriptors, each carrying url + creds +
+ *      the stack's `{principal}/{stack}` identity.
+ *   2. Self-exclusion — the SERVING stack (by config dir) is never in the result.
+ *   3. Same-principal filter — a stack owned by a DIFFERENT principal is excluded
+ *      (this is a LOCAL same-principal aggregation, never cross-principal).
+ *   4. Loopback filter — a stack whose `nats.url` is NOT a 127.0.0.1 loopback is
+ *      excluded (we only read the principal's own local buses).
+ *   5. No-creds degrade — a stack whose bus needs a credential we can't resolve
+ *      (no `credsPath`, only an account-signing NKey) is surfaced with
+ *      `credential: { kind: "unresolved", … }` so the subscriber can degrade it
+ *      to absent rather than crash.
+ *   6. Malformed / partial dirs — a dir with no `system/system.yaml`, or an
+ *      unparseable yaml, is skipped (logged) — never throws.
+ *   7. Explicit-config override — an explicit stack list takes precedence over
+ *      discovery (precedence is documented + tested here).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  discoverSiblingStacks,
+  type SiblingStackDescriptor,
+} from "../sibling-discovery";
+
+/** Write a minimal config-split stack dir under `root/<slug>/`. */
+function writeStackDir(
+  root: string,
+  slug: string,
+  opts: {
+    principal: string;
+    stackId: string;
+    url: string;
+    credsPath?: string;
+    seedPath?: string;
+  },
+): void {
+  const dir = join(root, slug);
+  mkdirSync(join(dir, "system"), { recursive: true });
+  mkdirSync(join(dir, "stacks"), { recursive: true });
+  const natsLines = [
+    "nats:",
+    `  url: ${opts.url}`,
+    `  name: ${slug}`,
+    ...(opts.credsPath ? [`  credsPath: ${opts.credsPath}`] : []),
+    ...(opts.seedPath
+      ? ["  identity:", `    seedPath: ${opts.seedPath}`]
+      : []),
+  ];
+  writeFileSync(join(dir, "system", "system.yaml"), natsLines.join("\n") + "\n");
+  writeFileSync(
+    join(dir, "stacks", `${slug}.yaml`),
+    [
+      "principal:",
+      `  id: ${opts.principal}`,
+      "stack:",
+      `  id: ${opts.stackId}`,
+      "",
+    ].join("\n"),
+  );
+}
+
+function findStack(
+  list: SiblingStackDescriptor[],
+  stack: string,
+): SiblingStackDescriptor | undefined {
+  return list.find((d) => d.stack === stack);
+}
+
+describe("#989 sibling-discovery", () => {
+  test("discovers sibling stacks (url + creds + identity), excluding self", () => {
+    const root = mkdtempSync(join(tmpdir(), "cortex-disc-"));
+    try {
+      writeStackDir(root, "meta-factory", {
+        principal: "andreas",
+        stackId: "andreas/meta-factory",
+        url: "nats://127.0.0.1:4222",
+        credsPath: "~/.config/nats/cortex.creds",
+      });
+      writeStackDir(root, "work", {
+        principal: "andreas",
+        stackId: "andreas/work",
+        url: "nats://127.0.0.1:4222",
+        credsPath: "~/.config/nats/cortex-work.creds",
+      });
+      writeStackDir(root, "halden", {
+        principal: "andreas",
+        stackId: "andreas/halden",
+        url: "nats://127.0.0.1:4223",
+        credsPath: "~/.config/nats/cortex-halden.creds",
+      });
+
+      const result = discoverSiblingStacks({
+        configRoot: root,
+        selfPrincipal: "andreas",
+        selfStack: "meta-factory",
+      });
+
+      // self (meta-factory) excluded; work + halden present.
+      expect(result.map((d) => d.stack).sort()).toEqual(["halden", "work"]);
+
+      const work = findStack(result, "work");
+      expect(work?.principal).toBe("andreas");
+      expect(work?.url).toBe("nats://127.0.0.1:4222");
+      expect(work?.credential).toEqual({
+        kind: "creds",
+        credsPath: "~/.config/nats/cortex-work.creds",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes a stack owned by a different principal", () => {
+    const root = mkdtempSync(join(tmpdir(), "cortex-disc-"));
+    try {
+      writeStackDir(root, "work", {
+        principal: "andreas",
+        stackId: "andreas/work",
+        url: "nats://127.0.0.1:4222",
+        credsPath: "~/.config/nats/cortex-work.creds",
+      });
+      writeStackDir(root, "jc-default", {
+        principal: "jc",
+        stackId: "jc/default",
+        url: "nats://127.0.0.1:4225",
+        credsPath: "~/.config/nats/jc.creds",
+      });
+
+      const result = discoverSiblingStacks({
+        configRoot: root,
+        selfPrincipal: "andreas",
+        selfStack: "meta-factory",
+      });
+
+      expect(result.map((d) => d.stack)).toEqual(["work"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes a stack whose bus url is not loopback", () => {
+    const root = mkdtempSync(join(tmpdir(), "cortex-disc-"));
+    try {
+      writeStackDir(root, "work", {
+        principal: "andreas",
+        stackId: "andreas/work",
+        url: "nats://127.0.0.1:4222",
+        credsPath: "~/.config/nats/cortex-work.creds",
+      });
+      writeStackDir(root, "remote", {
+        principal: "andreas",
+        stackId: "andreas/remote",
+        url: "nats://10.0.0.5:4222",
+        credsPath: "~/.config/nats/remote.creds",
+      });
+
+      const result = discoverSiblingStacks({
+        configRoot: root,
+        selfPrincipal: "andreas",
+        selfStack: "meta-factory",
+      });
+
+      expect(result.map((d) => d.stack)).toEqual(["work"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("surfaces a creds-less (NKey-only) stack as a noauth credential (try-and-see)", () => {
+    const root = mkdtempSync(join(tmpdir(), "cortex-disc-"));
+    try {
+      writeStackDir(root, "community", {
+        principal: "andreas",
+        stackId: "andreas/community",
+        url: "nats://127.0.0.1:4224",
+        seedPath: "~/.config/nats/cortex-community.nk",
+      });
+
+      const result = discoverSiblingStacks({
+        configRoot: root,
+        selfPrincipal: "andreas",
+        selfStack: "meta-factory",
+      });
+
+      const community = findStack(result, "community");
+      expect(community).toBeDefined();
+      // No declared credsPath ⇒ attempt no-auth; the bus decides at connect time
+      // (an open bus connects, a locked one degrades).
+      expect(community?.credential.kind).toBe("noauth");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("skips a dir with no system.yaml and an unparseable yaml (no throw)", () => {
+    const root = mkdtempSync(join(tmpdir(), "cortex-disc-"));
+    try {
+      // A bare dir with no system/system.yaml — not a stack.
+      mkdirSync(join(root, "logs"), { recursive: true });
+      // A dir whose system.yaml is unparseable.
+      mkdirSync(join(root, "broken", "system"), { recursive: true });
+      writeFileSync(
+        join(root, "broken", "system", "system.yaml"),
+        "nats: : : not valid yaml: [",
+      );
+      writeStackDir(root, "work", {
+        principal: "andreas",
+        stackId: "andreas/work",
+        url: "nats://127.0.0.1:4222",
+        credsPath: "~/.config/nats/cortex-work.creds",
+      });
+
+      const result = discoverSiblingStacks({
+        configRoot: root,
+        selfPrincipal: "andreas",
+        selfStack: "meta-factory",
+      });
+
+      expect(result.map((d) => d.stack)).toEqual(["work"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("explicit stack list overrides discovery (precedence: explicit > discovery)", () => {
+    const root = mkdtempSync(join(tmpdir(), "cortex-disc-"));
+    try {
+      // Discovery would find work + halden, but the explicit list pins ONLY work.
+      writeStackDir(root, "work", {
+        principal: "andreas",
+        stackId: "andreas/work",
+        url: "nats://127.0.0.1:4222",
+        credsPath: "~/.config/nats/cortex-work.creds",
+      });
+      writeStackDir(root, "halden", {
+        principal: "andreas",
+        stackId: "andreas/halden",
+        url: "nats://127.0.0.1:4223",
+        credsPath: "~/.config/nats/cortex-halden.creds",
+      });
+
+      const result = discoverSiblingStacks({
+        configRoot: root,
+        selfPrincipal: "andreas",
+        selfStack: "meta-factory",
+        explicit: [
+          {
+            stack: "work",
+            principal: "andreas",
+            url: "nats://127.0.0.1:4222",
+            credential: {
+              kind: "creds",
+              credsPath: "~/.config/nats/cortex-work.creds",
+            },
+          },
+        ],
+      });
+
+      expect(result.map((d) => d.stack)).toEqual(["work"]);
+      expect(findStack(result, "halden")).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("explicit list still excludes self by stack name", () => {
+    const root = mkdtempSync(join(tmpdir(), "cortex-disc-"));
+    try {
+      const result = discoverSiblingStacks({
+        configRoot: root,
+        selfPrincipal: "andreas",
+        selfStack: "meta-factory",
+        explicit: [
+          {
+            stack: "meta-factory",
+            principal: "andreas",
+            url: "nats://127.0.0.1:4222",
+            credential: { kind: "creds", credsPath: "~/.config/nats/cortex.creds" },
+          },
+          {
+            stack: "work",
+            principal: "andreas",
+            url: "nats://127.0.0.1:4222",
+            credential: {
+              kind: "creds",
+              credsPath: "~/.config/nats/cortex-work.creds",
+            },
+          },
+        ],
+      });
+      expect(result.map((d) => d.stack)).toEqual(["work"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/surface/mc/local-aggregation/__tests__/sibling-presence-subscriber.test.ts
+++ b/src/surface/mc/local-aggregation/__tests__/sibling-presence-subscriber.test.ts
@@ -1,0 +1,308 @@
+/**
+ * #989 part-1 — sibling-bus PRESENCE SUBSCRIBER tests (TDD, RED-first).
+ *
+ * For each discovered sibling, the aggregator opens a read-only NATS connection
+ * to that sibling's bus and subscribes to its
+ * `local.{siblingPrincipal}.{siblingStack}.agent.>` subtree, folding inbound
+ * presence into the SHARED registry tagged with the sibling's
+ * `{principal}/{stack}` origin (so /api/agents groups it under its own hub).
+ *
+ * Coverage axes:
+ *   1. Multi-bus fold — N siblings each delivering an `agent.online` ⇒ the
+ *      shared registry has N agents, each tagged foreign by its origin stack.
+ *   2. Origin tagging — a sibling agent's record carries
+ *      `origin: { kind: "foreign", principal, stack }` matching the SIBLING's
+ *      identity (not the serving stack's).
+ *   3. Subject scoping — the subscriber binds the SIBLING's local subtree
+ *      (`local.{sibPrincipal}.{sibStack}.agent.>`), so a stray non-presence /
+ *      wrong-subject message is ignored.
+ *   4. Graceful degrade — a sibling whose connection FAILS (bus down) is absent
+ *      (no record), logged, and NEVER throws; other siblings still fold.
+ *   5. noauth credential — a sibling with `credential.kind: "noauth"` IS
+ *      connected (no pre-judging); an open bus folds, a locked one degrades via
+ *      the connect-failure path.
+ *   6. Lifecycle — `stop()` closes every sibling link + drains; idempotent.
+ *   7. Malformed bytes on a sibling bus are dropped (not thrown).
+ */
+
+import { describe, expect, test, mock } from "bun:test";
+import {
+  AgentPresenceRegistry,
+  isForeignOrigin,
+} from "../../../../bus/agent-network/registry";
+import {
+  createAgentOnlineEvent,
+  type AgentPresenceSource,
+} from "../../../../bus/agent-network/builders";
+import type { Envelope } from "../../../../bus/myelin/envelope-validator";
+import {
+  startSiblingPresenceAggregator,
+  type SiblingBusConnection,
+  type SiblingBusConnector,
+} from "../sibling-presence-subscriber";
+import type { SiblingStackDescriptor } from "../sibling-discovery";
+
+/** Build an `agent.online` envelope for `{principal}/{stack}` + `agentId`. */
+function onlineEnvelope(
+  principal: string,
+  stack: string,
+  agentId: string,
+): Envelope {
+  const source: AgentPresenceSource = { principal, stack, instance: "local" };
+  return createAgentOnlineEvent({
+    source,
+    identity: {
+      nkey_public_key: `NKEY_${agentId}`,
+      agent_id: agentId,
+      assistant_name: agentId,
+    },
+    scope: { principal, stack },
+    capabilities: ["chat"],
+    startedAt: new Date(),
+  });
+}
+
+/**
+ * A fake sibling bus: records its subscribed pattern, lets the test push
+ * envelopes, and tracks close(). The connector hands one out per sibling.
+ */
+class FakeBus implements SiblingBusConnection {
+  subscribedPattern: string | null = null;
+  closed = false;
+  private handler: ((subject: string, data: Uint8Array) => void) | null = null;
+
+  subscribe(
+    pattern: string,
+    onMessage: (subject: string, data: Uint8Array) => void,
+  ): void {
+    this.subscribedPattern = pattern;
+    this.handler = onMessage;
+  }
+
+  /** Test helper — deliver an envelope on a subject as raw JSON bytes. */
+  deliver(subject: string, envelope: Envelope): void {
+    this.handler?.(subject, new TextEncoder().encode(JSON.stringify(envelope)));
+  }
+
+  /** Test helper — deliver raw (possibly malformed) bytes. */
+  deliverRaw(subject: string, text: string): void {
+    this.handler?.(subject, new TextEncoder().encode(text));
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+function descriptor(
+  stack: string,
+  url: string,
+  principal = "andreas",
+): SiblingStackDescriptor {
+  return {
+    stack,
+    principal,
+    url,
+    credential: { kind: "creds", credsPath: `~/.config/nats/${stack}.creds` },
+  };
+}
+
+describe("#989 sibling-presence-subscriber", () => {
+  test("folds presence from N sibling buses into the shared registry, tagged by origin", async () => {
+    const registry = new AgentPresenceRegistry();
+    const buses = new Map<string, FakeBus>();
+    const connector: SiblingBusConnector = async (sib) => {
+      const bus = new FakeBus();
+      buses.set(sib.stack, bus);
+      return bus;
+    };
+
+    const handle = await startSiblingPresenceAggregator({
+      registry,
+      siblings: [
+        descriptor("work", "nats://127.0.0.1:4222"),
+        descriptor("halden", "nats://127.0.0.1:4223"),
+      ],
+      connect: connector,
+    });
+
+    // Each sibling delivers its own agent.online on its own local subtree.
+    buses
+      .get("work")!
+      .deliver(
+        "local.andreas.work.agent.online",
+        onlineEnvelope("andreas", "work", "luna"),
+      );
+    buses
+      .get("halden")!
+      .deliver(
+        "local.andreas.halden.agent.online",
+        onlineEnvelope("andreas", "halden", "sage"),
+      );
+
+    const agents = registry.getAgents();
+    expect(agents.length).toBe(2);
+    const work = agents.find((a) => a.stack === "work");
+    const halden = agents.find((a) => a.stack === "halden");
+    expect(work?.agentId).toBe("luna");
+    expect(halden?.agentId).toBe("sage");
+    // Origin is foreign (sibling), tagged with the SIBLING's identity.
+    expect(isForeignOrigin(work!.origin)).toBe(true);
+    expect(work!.origin).toEqual({
+      kind: "foreign",
+      principal: "andreas",
+      stack: "work",
+    });
+
+    await handle.stop();
+  });
+
+  test("binds each sibling's own local presence subtree", async () => {
+    const registry = new AgentPresenceRegistry();
+    let captured: FakeBus | null = null;
+    const connector: SiblingBusConnector = async () => {
+      captured = new FakeBus();
+      return captured;
+    };
+    const handle = await startSiblingPresenceAggregator({
+      registry,
+      siblings: [descriptor("work", "nats://127.0.0.1:4222")],
+      connect: connector,
+    });
+    expect(captured!.subscribedPattern).toBe("local.andreas.work.agent.>");
+    await handle.stop();
+  });
+
+  test("a sibling whose connection fails degrades to absent (no throw, logged)", async () => {
+    const registry = new AgentPresenceRegistry();
+    const good = new FakeBus();
+    const connector: SiblingBusConnector = async (sib) => {
+      if (sib.stack === "halden") {
+        throw new Error("ECONNREFUSED 127.0.0.1:4223");
+      }
+      return good;
+    };
+
+    const handle = await startSiblingPresenceAggregator({
+      registry,
+      siblings: [
+        descriptor("work", "nats://127.0.0.1:4222"),
+        descriptor("halden", "nats://127.0.0.1:4223"),
+      ],
+      connect: connector,
+    });
+
+    // work folded; halden absent (connection threw).
+    good.deliver(
+      "local.andreas.work.agent.online",
+      onlineEnvelope("andreas", "work", "luna"),
+    );
+    const agents = registry.getAgents();
+    expect(agents.map((a) => a.stack)).toEqual(["work"]);
+
+    // The failed sibling is reported on the handle for observability.
+    expect(handle.degraded.map((d) => d.stack)).toContain("halden");
+
+    await handle.stop();
+  });
+
+  test("a noauth sibling IS connected (open bus folds)", async () => {
+    const registry = new AgentPresenceRegistry();
+    const bus = new FakeBus();
+    const connect = mock<SiblingBusConnector>(async () => bus);
+
+    const handle = await startSiblingPresenceAggregator({
+      registry,
+      siblings: [
+        {
+          stack: "halden",
+          principal: "andreas",
+          url: "nats://127.0.0.1:4223",
+          credential: { kind: "noauth" },
+        },
+      ],
+      connect,
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(handle.degraded.length).toBe(0);
+    bus.deliver(
+      "local.andreas.halden.agent.online",
+      onlineEnvelope("andreas", "halden", "sage"),
+    );
+    expect(registry.getAgents().map((a) => a.stack)).toEqual(["halden"]);
+    await handle.stop();
+  });
+
+  test("a noauth sibling on a LOCKED bus degrades to absent (connect throws)", async () => {
+    const registry = new AgentPresenceRegistry();
+    const connect = mock<SiblingBusConnector>(async () => {
+      throw new Error("Authorization Violation");
+    });
+
+    const handle = await startSiblingPresenceAggregator({
+      registry,
+      siblings: [
+        {
+          stack: "community",
+          principal: "andreas",
+          url: "nats://127.0.0.1:4224",
+          credential: { kind: "noauth" },
+        },
+      ],
+      connect,
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(handle.degraded.map((d) => d.stack)).toContain("community");
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("malformed bytes on a sibling bus are dropped, not thrown", async () => {
+    const registry = new AgentPresenceRegistry();
+    const bus = new FakeBus();
+    const handle = await startSiblingPresenceAggregator({
+      registry,
+      siblings: [descriptor("work", "nats://127.0.0.1:4222")],
+      connect: async () => bus,
+    });
+    expect(() =>
+      bus.deliverRaw("local.andreas.work.agent.online", "{not json"),
+    ).not.toThrow();
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("stop() closes every sibling link and is idempotent", async () => {
+    const registry = new AgentPresenceRegistry();
+    const buses: FakeBus[] = [];
+    const handle = await startSiblingPresenceAggregator({
+      registry,
+      siblings: [
+        descriptor("work", "nats://127.0.0.1:4222"),
+        descriptor("halden", "nats://127.0.0.1:4223"),
+      ],
+      connect: async () => {
+        const b = new FakeBus();
+        buses.push(b);
+        return b;
+      },
+    });
+    await handle.stop();
+    await handle.stop(); // idempotent
+    expect(buses.every((b) => b.closed)).toBe(true);
+  });
+
+  test("empty sibling list is a no-op (no connects)", async () => {
+    const registry = new AgentPresenceRegistry();
+    const connect = mock<SiblingBusConnector>(async () => new FakeBus());
+    const handle = await startSiblingPresenceAggregator({
+      registry,
+      siblings: [],
+      connect,
+    });
+    expect(connect).not.toHaveBeenCalled();
+    await handle.stop();
+  });
+});

--- a/src/surface/mc/local-aggregation/nats-sibling-connector.ts
+++ b/src/surface/mc/local-aggregation/nats-sibling-connector.ts
@@ -1,0 +1,87 @@
+/**
+ * #989 part-1 — production NATS connector for the sibling-presence aggregator.
+ *
+ * Adapts the bus-layer {@link NatsLink} + {@link NatsSubscription} primitives to
+ * the aggregator's {@link SiblingBusConnection} interface. One {@link NatsLink}
+ * per sibling bus (its OWN loopback url + its OWN `.creds`), one
+ * {@link NatsSubscription} bound to the sibling's `local.{principal}.{stack}.agent.>`
+ * subtree. READ-ONLY: it only subscribes, never publishes.
+ *
+ * Kept SEPARATE from the aggregator core (`sibling-presence-subscriber.ts`) so
+ * the core stays NATS-free + unit-testable (a fake connector), and this thin
+ * adapter is the only place that touches real NATS — mirroring how the rest of
+ * the codebase keeps `NatsLink` wiring at the edges.
+ *
+ * `NatsLink.connect` THROWS when the bus is unreachable / auth fails; the
+ * aggregator catches that and degrades the sibling to absent (never crashes
+ * boot). This connector does NOT swallow — it lets the throw propagate so the
+ * aggregator's single degrade path owns the policy.
+ */
+
+import { NatsLink } from "../../../bus/nats/connection";
+import { NatsSubscription } from "../../../bus/nats/subscription";
+import type {
+  SiblingBusConnection,
+  SiblingBusConnector,
+} from "./sibling-presence-subscriber";
+import type { SiblingStackDescriptor } from "./sibling-discovery";
+
+/** A live NATS-backed sibling connection: one link + one subscription. */
+class NatsSiblingBusConnection implements SiblingBusConnection {
+  private readonly link: NatsLink;
+  private subscription: NatsSubscription | null = null;
+
+  constructor(link: NatsLink) {
+    this.link = link;
+  }
+
+  subscribe(
+    pattern: string,
+    onMessage: (subject: string, data: Uint8Array) => void,
+  ): void {
+    // NatsSubscription auto-resubscribes on reconnect — a sibling bus that
+    // bounces re-binds without losing the aggregator. Handler errors are logged
+    // by the subscription's default error sink; we keep onMessage non-throwing
+    // (the aggregator's parse/fold already swallow), so the sink rarely fires.
+    this.subscription = NatsSubscription.start(this.link, {
+      pattern,
+      onMessage,
+    });
+  }
+
+  async close(): Promise<void> {
+    // Stop the subscription first (drains in-flight), then close the link.
+    if (this.subscription !== null) {
+      await this.subscription.stop();
+    }
+    await this.link.close();
+  }
+}
+
+/**
+ * The production {@link SiblingBusConnector}. Opens a read-only `NatsLink` to the
+ * sibling's bus:
+ *   - `creds`  → connect with the declared `.creds` file (operator-mode auth).
+ *   - `noauth` → connect with NO credential. An OPEN loopback bus (e.g. halden's
+ *     `nats-server -js`) accepts it; a LOCKED NSC bus rejects it with an
+ *     Authorization Violation — `NatsLink.connect` throws, the aggregator
+ *     catches it, and that sibling degrades to absent (logged). The throw is
+ *     intentional — this connector lets the aggregator's single degrade path
+ *     own the policy rather than swallowing here.
+ */
+export const natsSiblingBusConnector: SiblingBusConnector = async (
+  sibling: SiblingStackDescriptor,
+): Promise<SiblingBusConnection> => {
+  const link = await NatsLink.connect({
+    url: sibling.url,
+    // `creds` ⇒ supply the credsPath; `noauth` ⇒ omit it (unauthenticated
+    // connect — the open-bus path).
+    ...(sibling.credential.kind === "creds"
+      ? { credsPath: sibling.credential.credsPath }
+      : {}),
+    // A distinct connection name so the sibling bus's `varz` shows WHO is
+    // observing (the serving stack aggregating that sibling read-only).
+    name: `cortex-mc-aggregator:${sibling.stack}`,
+  });
+  return new NatsSiblingBusConnection(link);
+};

--- a/src/surface/mc/local-aggregation/sibling-discovery.ts
+++ b/src/surface/mc/local-aggregation/sibling-discovery.ts
@@ -29,16 +29,16 @@
  * ## Credential resolution
  *
  * Per-bus auth varies (#989 probe findings on the live machine):
- *   - meta-factory / work → a `nats.credsPath` (operator-mode `.creds`) →
+ *   - meta-factory / work → a `nats.credsPath` (operator-account `.creds`) →
  *     `credential.kind: "creds"`.
- *   - halden → an OPEN bus (`nats-server -js`, no operator/account config) that
+ *   - halden → an OPEN bus (`nats-server -js`, no operator-account config) that
  *     accepts an unauthenticated connection. Its `system.yaml` declares only an
  *     account-signing NKey seed (no `credsPath`), so config alone can't tell it
  *     apart from a locked NSC bus. We surface no-credsPath as
  *     `credential.kind: "noauth"` (try connecting with no credential) — and let
  *     the BUS decide: an open bus connects, a locked one fails the connect and
  *     the aggregator degrades that sibling to absent.
- *   - community → a true NSC-operator bus that REQUIRES a minted user. With only
+ *   - community → a true operator-account (NSC) bus that REQUIRES a minted user. With only
  *     an account-signing NKey (not a connectable user), the `noauth` attempt
  *     fails with an Authorization Violation, so the aggregator degrades it to
  *     absent. Minting a read-only observer user for it is a #989 follow-up.

--- a/src/surface/mc/local-aggregation/sibling-discovery.ts
+++ b/src/surface/mc/local-aggregation/sibling-discovery.ts
@@ -1,0 +1,292 @@
+/**
+ * #989 part-1 — sibling-stack DISCOVERY.
+ *
+ * The principal runs SEVERAL cortex stacks on one machine, each on its own
+ * local loopback NATS bus (e.g. `andreas`: meta-factory + work on :4222,
+ * community on :4224, halden on :4223). The localhost MC pane should show ALL
+ * of them as distinct stack-hubs on the Network view — not just the one whose
+ * daemon serves the dashboard.
+ *
+ * This module finds the OTHER stacks. It scans a config root
+ * (`~/.config/cortex/`) for config-split stack dirs, reads each one's
+ * `system/system.yaml` (bus url + credential) and `stacks/*.yaml`
+ * (`{principal}/{stack}` identity), and yields one {@link SiblingStackDescriptor}
+ * per sibling the serving daemon should subscribe to read-only.
+ *
+ * ## Filters (all must hold for a stack to be a sibling)
+ *
+ *   1. **Same principal** — `principal.id` MUST equal the serving stack's
+ *      principal. This is a LOCAL same-principal aggregation (ADR-0005: the
+ *      principal sees their OWN interiors). A different-principal stack is NEVER
+ *      a sibling — that is federation, out of scope here.
+ *   2. **Local loopback bus** — `nats.url` host MUST be a 127.0.0.1 loopback.
+ *      The principal owns every loopback bus + its auth on this machine; a
+ *      non-loopback url is a remote bus (federation territory) and is excluded.
+ *   3. **Not self** — the SERVING stack (by its `{stack}` slug) is excluded so a
+ *      stack never re-subscribes to its own presence (the B.3 local registry
+ *      already folds that).
+ *
+ * ## Credential resolution
+ *
+ * Per-bus auth varies (#989 probe findings on the live machine):
+ *   - meta-factory / work → a `nats.credsPath` (operator-mode `.creds`) →
+ *     `credential.kind: "creds"`.
+ *   - halden → an OPEN bus (`nats-server -js`, no operator/account config) that
+ *     accepts an unauthenticated connection. Its `system.yaml` declares only an
+ *     account-signing NKey seed (no `credsPath`), so config alone can't tell it
+ *     apart from a locked NSC bus. We surface no-credsPath as
+ *     `credential.kind: "noauth"` (try connecting with no credential) — and let
+ *     the BUS decide: an open bus connects, a locked one fails the connect and
+ *     the aggregator degrades that sibling to absent.
+ *   - community → a true NSC-operator bus that REQUIRES a minted user. With only
+ *     an account-signing NKey (not a connectable user), the `noauth` attempt
+ *     fails with an Authorization Violation, so the aggregator degrades it to
+ *     absent. Minting a read-only observer user for it is a #989 follow-up.
+ *
+ * Rationale for "try no-auth, let the bus decide": config can't reliably
+ * distinguish an open loopback bus from a locked one (both lack `credsPath`),
+ * but the connect attempt itself is the ground truth — and a failed read-only
+ * connect already degrades gracefully (the bus is never harmed). This connects
+ * the buses that CAN be read (halden) without a fragile config heuristic, and
+ * cleanly flags the ones that genuinely need a credential (community).
+ *
+ * ## Discovery vs explicit-config PRECEDENCE
+ *
+ * **Explicit config wins.** When the caller supplies an `explicit` list (from
+ * `mc.aggregateLocalStacks.stacks[]`), that list IS the sibling set — discovery
+ * is skipped entirely. This lets a principal pin an exact roster (e.g. add a bus
+ * the auto-scan can't see, or exclude one) without fighting the scanner.
+ * Discovery is the DEFAULT (no explicit list ⇒ scan the config root). Either
+ * path still excludes self by stack slug.
+ *
+ * Pure + side-effect-free beyond reading the filesystem; never throws on a
+ * malformed dir (logs + skips), so a half-written sibling config can't take down
+ * the serving daemon's boot.
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from "fs";
+import { join } from "path";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * How to authenticate a read-only subscriber to a sibling bus.
+ *
+ *   - `creds` — an operator-mode `.creds` file path (expanded + chmod-gated by
+ *     the NATS connection layer). The declared-credential case (meta-factory /
+ *     work).
+ *   - `noauth` — the stack declares NO `credsPath`. We attempt an
+ *     unauthenticated connect and let the BUS decide: an OPEN loopback bus
+ *     (e.g. halden's `nats-server -js`) connects; a LOCKED NSC bus (e.g.
+ *     community) fails the connect with an Authorization Violation and the
+ *     aggregator degrades it to absent (logged). This avoids a fragile
+ *     config heuristic for "open vs locked" — the connect attempt is the ground
+ *     truth, and a failed read-only connect is already harmless.
+ *
+ * (There is no `unresolved` kind: an undecidable config no longer guesses — it
+ * tries `noauth` and degrades on failure, which is strictly more capable than
+ * pre-judging it un-connectable.)
+ */
+export type SiblingCredential =
+  | { kind: "creds"; credsPath: string }
+  | { kind: "noauth" };
+
+/** One sibling stack the serving daemon should subscribe to read-only. */
+export interface SiblingStackDescriptor {
+  /** The sibling's `{stack}` slug (last segment of `stack.id`, or the dir name). */
+  stack: string;
+  /** The sibling's `{principal}` — always equal to the serving principal. */
+  principal: string;
+  /** The sibling bus url (a 127.0.0.1 loopback). */
+  url: string;
+  /** How to connect read-only. `unresolved` ⇒ degrade to absent. */
+  credential: SiblingCredential;
+}
+
+/** Options for {@link discoverSiblingStacks}. */
+export interface DiscoverSiblingStacksOptions {
+  /** Config root to scan (e.g. `~/.config/cortex`). Already tilde-expanded. */
+  configRoot: string;
+  /** The SERVING stack's principal — the same-principal filter pivot. */
+  selfPrincipal: string;
+  /** The SERVING stack's `{stack}` slug — excluded from the result. */
+  selfStack: string;
+  /**
+   * Explicit sibling list. When supplied + non-empty, it OVERRIDES discovery
+   * (precedence: explicit > discovery). Self is still excluded by stack slug.
+   */
+  explicit?: SiblingStackDescriptor[];
+}
+
+/** Hosts treated as the principal's own local loopback bus. */
+function isLoopbackUrl(url: string): boolean {
+  let host: string;
+  try {
+    // nats:// urls parse fine with the URL constructor (the protocol is opaque).
+    host = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  // IPv6 loopback (`[::1]`) → URL.hostname yields `::1`.
+  if (host === "::1") return true;
+  if (host === "localhost") return true;
+  // 127.0.0.0/8 — any 127.x.y.z is loopback.
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+/** Last `/`-segment of a `stack.id` (`andreas/work` → `work`), else the input. */
+function stackSlugOf(stackId: string): string {
+  const idx = stackId.lastIndexOf("/");
+  return idx >= 0 ? stackId.slice(idx + 1) : stackId;
+}
+
+/**
+ * Read one stack dir's `{principal, stack, url, credential}` from its
+ * `system/system.yaml` + `stacks/*.yaml`. Returns `null` (logged) when the dir
+ * is not a parseable config-split stack — never throws.
+ */
+function readStackDir(
+  configRoot: string,
+  dirName: string,
+): SiblingStackDescriptor | null {
+  const dir = join(configRoot, dirName);
+  const systemPath = join(dir, "system", "system.yaml");
+  if (!existsSync(systemPath)) {
+    // Not a stack dir (logs/, state/, …) — silently skip (no log: these are
+    // expected siblings of stack dirs under the config root).
+    return null;
+  }
+  let systemRaw: unknown;
+  try {
+    systemRaw = parseYaml(readFileSync(systemPath, "utf8"));
+  } catch (err) {
+    process.stderr.write(
+      `sibling-discovery: skipping "${dirName}" — system.yaml parse failed: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return null;
+  }
+  const nats = (systemRaw as { nats?: Record<string, unknown> } | null)?.nats;
+  const url = typeof nats?.url === "string" ? nats.url : undefined;
+  if (url === undefined || url.length === 0) {
+    process.stderr.write(
+      `sibling-discovery: skipping "${dirName}" — no nats.url in system.yaml\n`,
+    );
+    return null;
+  }
+
+  // Identity comes from the first stacks/*.yaml that declares principal + stack.
+  const stacksDir = join(dir, "stacks");
+  let principal: string | undefined;
+  let stackId: string | undefined;
+  if (existsSync(stacksDir)) {
+    let stackFiles: string[];
+    try {
+      stackFiles = readdirSync(stacksDir)
+        .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+        .sort();
+    } catch {
+      stackFiles = [];
+    }
+    for (const f of stackFiles) {
+      let parsed: unknown;
+      try {
+        parsed = parseYaml(readFileSync(join(stacksDir, f), "utf8"));
+      } catch {
+        continue; // a bad stack file is skipped; try the next.
+      }
+      const obj = parsed as
+        | { principal?: { id?: unknown }; stack?: { id?: unknown } }
+        | null;
+      const pid = obj?.principal?.id;
+      const sid = obj?.stack?.id;
+      if (typeof pid === "string" && pid.length > 0) principal = pid;
+      if (typeof sid === "string" && sid.length > 0) stackId = sid;
+      if (principal !== undefined && stackId !== undefined) break;
+    }
+  }
+  if (principal === undefined) {
+    process.stderr.write(
+      `sibling-discovery: skipping "${dirName}" — no principal.id in any stacks/*.yaml\n`,
+    );
+    return null;
+  }
+
+  const stack = stackId !== undefined ? stackSlugOf(stackId) : dirName;
+
+  // Credential: a declared credsPath ⇒ creds auth; otherwise attempt no-auth
+  // (open loopback bus) and let the connect decide (a locked bus degrades).
+  const credsPath = typeof nats?.credsPath === "string" ? nats.credsPath : undefined;
+  const credential: SiblingCredential =
+    credsPath !== undefined && credsPath.length > 0
+      ? { kind: "creds", credsPath }
+      : { kind: "noauth" };
+
+  return { stack, principal, url, credential };
+}
+
+/**
+ * Discover the principal's OTHER local stacks for read-only presence
+ * aggregation. See the module docstring for the filter + precedence rules.
+ *
+ * Returns siblings sorted by stack slug for stable boot logs. Self is excluded
+ * in BOTH the explicit and discovery paths.
+ */
+export function discoverSiblingStacks(
+  opts: DiscoverSiblingStacksOptions,
+): SiblingStackDescriptor[] {
+  const { configRoot, selfPrincipal, selfStack, explicit } = opts;
+
+  // PRECEDENCE: explicit config wins. A non-empty explicit list IS the roster;
+  // discovery is skipped. Self is still excluded by stack slug.
+  if (explicit !== undefined && explicit.length > 0) {
+    return explicit
+      .filter((d) => d.stack !== selfStack)
+      .slice()
+      .sort((a, b) => a.stack.localeCompare(b.stack));
+  }
+
+  // DISCOVERY (default): scan the config root for stack dirs.
+  let entries: string[];
+  try {
+    entries = readdirSync(configRoot);
+  } catch (err) {
+    process.stderr.write(
+      `sibling-discovery: cannot read config root "${configRoot}" — no siblings discovered: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return [];
+  }
+
+  const siblings: SiblingStackDescriptor[] = [];
+  for (const name of entries) {
+    let isDir: boolean;
+    try {
+      isDir = statSync(join(configRoot, name)).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+
+    const desc = readStackDir(configRoot, name);
+    if (desc === null) continue;
+
+    // FILTER 1 — same principal only.
+    if (desc.principal !== selfPrincipal) continue;
+    // FILTER 2 — local loopback bus only.
+    if (!isLoopbackUrl(desc.url)) continue;
+    // FILTER 3 — exclude self.
+    if (desc.stack === selfStack) continue;
+
+    siblings.push(desc);
+  }
+
+  // De-dupe by stack slug (two dirs claiming the same stack — keep the first
+  // by sorted dir order) and sort for stable output.
+  const byStack = new Map<string, SiblingStackDescriptor>();
+  for (const s of siblings) {
+    if (!byStack.has(s.stack)) byStack.set(s.stack, s);
+  }
+  return Array.from(byStack.values()).sort((a, b) =>
+    a.stack.localeCompare(b.stack),
+  );
+}

--- a/src/surface/mc/local-aggregation/sibling-presence-subscriber.ts
+++ b/src/surface/mc/local-aggregation/sibling-presence-subscriber.ts
@@ -1,0 +1,200 @@
+/**
+ * #989 part-1 — sibling-bus PRESENCE aggregator.
+ *
+ * For each discovered sibling stack ({@link SiblingStackDescriptor}), open a
+ * READ-ONLY subscriber to that sibling's OWN local NATS bus and fold its
+ * `local.{siblingPrincipal}.{siblingStack}.agent.>` presence stream into the
+ * SHARED {@link AgentPresenceRegistry} — the same registry the serving stack's
+ * own B.3 path folds its own presence into. Each sibling agent is tagged with
+ * its `{principal}/{stack}` ORIGIN (`origin: { kind: "foreign", … }`), so
+ * `/api/agents` groups it under its own stack-hub and the Network view renders
+ * every local stack as a distinct hub (#989).
+ *
+ * ## Why `applyForeign`, with NO trust machinery
+ *
+ * This MIRRORS the federated subscriber's fold (`federated-subscriber.ts`) —
+ * same registry, same origin-tagged record — but DROPS the cross-principal trust
+ * machinery (accept-list gate + `signed_by[]` chain verification). It is safe to
+ * drop because this is the PRINCIPAL'S OWN bus: the daemon connects with the
+ * principal's own credential to a loopback bus the principal owns end-to-end
+ * (ADR-0005 — the principal sees their own interiors). There is no cross-
+ * principal boundary to defend. We STILL call {@link AgentPresenceRegistry.applyForeign}
+ * (not `apply`) because:
+ *   - it tags the record with the sibling's origin so the view groups by hub, and
+ *   - it source-binds identity to the DISCOVERED `{principal}/{stack}` (the
+ *     `verifiedScope`), so a sibling that somehow emits a mis-scoped payload is
+ *     dropped rather than painting a wrong-hub record — a cheap consistency guard,
+ *     not a trust boundary.
+ *
+ * ## Resilience (the load-bearing contract)
+ *
+ *   - A sibling whose connection FAILS at start (bus down, auth fault) is
+ *     recorded in `degraded[]`, logged to stderr, and SKIPPED — the serving
+ *     daemon's boot is never blocked and no exception escapes. That stack's hub
+ *     simply doesn't appear until the next process start.
+ *   - A sibling with a `noauth` credential is connected WITHOUT a credential
+ *     (an open loopback bus accepts it; a locked NSC bus rejects it and the
+ *     connect-failure path above degrades it to absent + logs why). Minting a
+ *     read-only observer user for a locked bus is a #989 follow-up.
+ *   - Malformed bytes / bad envelopes on a sibling bus are dropped by the
+ *     registry's best-effort fold (logged), never thrown.
+ *   - The serving stack's OWN presence path (B.3 + the producer) is untouched —
+ *     this aggregator only ADDS foreign records to the shared registry.
+ *
+ * ## Liveness
+ *
+ * Sibling records flow through the SAME registry, so the existing 5-minute TTL
+ * reaper ({@link AgentPresenceRegistry.startReaper}, started by the B.3 wiring)
+ * applies to them too: a sibling that goes quiet (its bus drops, or its agents
+ * stop heartbeating) ages out to `offline` exactly like a local agent.
+ */
+
+import { tryParseEnvelope } from "../../../bus/myelin/envelope-validator";
+import type { AgentPresenceRegistry } from "../../../bus/agent-network/registry";
+import type { SiblingStackDescriptor } from "./sibling-discovery";
+
+/**
+ * The read-only handle on ONE sibling bus the aggregator drives. A test passes
+ * a fake; production passes a NATS-backed implementation (see
+ * {@link natsSiblingBusConnector}).
+ */
+export interface SiblingBusConnection {
+  /**
+   * Subscribe to `pattern` on this sibling bus, invoking `onMessage` per raw
+   * message. Called exactly ONCE per connection (the aggregator binds the
+   * sibling's `local.{principal}.{stack}.agent.>` subtree).
+   */
+  subscribe(
+    pattern: string,
+    onMessage: (subject: string, data: Uint8Array) => void,
+  ): void;
+  /** Close the connection + drain. Idempotent on the production side. */
+  close(): Promise<void>;
+}
+
+/**
+ * Open a read-only connection to a sibling bus. THROWS when the bus is
+ * unreachable / auth fails — the aggregator catches it and degrades that
+ * sibling to absent (never crashes boot). Injectable so tests avoid real NATS.
+ */
+export type SiblingBusConnector = (
+  sibling: SiblingStackDescriptor,
+) => Promise<SiblingBusConnection>;
+
+/** A sibling that did NOT aggregate, with the reason (for logs + the handle). */
+export interface DegradedSibling {
+  stack: string;
+  reason: string;
+}
+
+/** Lifecycle handle for the sibling-presence aggregator. */
+export interface SiblingPresenceAggregatorHandle {
+  /**
+   * Siblings that are NOT being aggregated — an unresolved credential, or a
+   * connection that failed at start. Surfaced so the boot log (and a future
+   * `/api/agents` diagnostics field) can show which local stacks are dark and
+   * why. Empty when every sibling connected.
+   */
+  readonly degraded: readonly DegradedSibling[];
+  /** Stop every sibling subscriber + close its link. Idempotent. */
+  stop(): Promise<void>;
+}
+
+/** Options for {@link startSiblingPresenceAggregator}. */
+export interface StartSiblingPresenceAggregatorOptions {
+  /** The SHARED registry — same instance the B.3 local path folds into. */
+  registry: AgentPresenceRegistry;
+  /** Discovered siblings to aggregate (see {@link discoverSiblingStacks}). */
+  siblings: readonly SiblingStackDescriptor[];
+  /** Per-bus connector. Tests inject a fake; production uses the NATS connector. */
+  connect: SiblingBusConnector;
+}
+
+/**
+ * The subject subtree the aggregator binds on a sibling's bus — the sibling's
+ * OWN stack-local presence subtree. `local.{principal}.{stack}.agent.>`.
+ */
+function siblingPresenceSubject(principal: string, stack: string): string {
+  return `local.${principal}.${stack}.agent.>`;
+}
+
+/**
+ * Start the sibling-presence aggregator. Opens one read-only subscriber per
+ * connectable sibling and folds its presence into the shared registry, tagged
+ * with the sibling's origin. NON-THROWING: a sibling that can't connect is
+ * degraded to absent, never an exception.
+ */
+export async function startSiblingPresenceAggregator(
+  opts: StartSiblingPresenceAggregatorOptions,
+): Promise<SiblingPresenceAggregatorHandle> {
+  const { registry, siblings, connect } = opts;
+  const connections: SiblingBusConnection[] = [];
+  const degraded: DegradedSibling[] = [];
+
+  for (const sibling of siblings) {
+    // Every credential kind (`creds` + `noauth`) gets a connect attempt — a
+    // `noauth` open bus connects, a locked one fails the connect below and is
+    // degraded there. No pre-judging.
+    let conn: SiblingBusConnection;
+    try {
+      conn = await connect(sibling);
+    } catch (err) {
+      // GRACEFUL DEGRADE — bus down / auth fault at start. Log + skip; the
+      // serving daemon's boot is never blocked, no exception escapes.
+      const reason = `connect failed: ${err instanceof Error ? err.message : String(err)}`;
+      degraded.push({ stack: sibling.stack, reason });
+      process.stderr.write(
+        `sibling-presence: "${sibling.stack}" (${sibling.url}) not aggregated — ${reason}\n`,
+      );
+      continue;
+    }
+
+    connections.push(conn);
+    const pattern = siblingPresenceSubject(sibling.principal, sibling.stack);
+    // SOURCE-BIND identity to the DISCOVERED sibling — a cheap consistency guard
+    // (a mis-scoped payload is dropped, never paints a wrong-hub record). NOT a
+    // trust boundary: this is the principal's own loopback bus.
+    const verifiedScope = {
+      principal: sibling.principal,
+      stack: sibling.stack,
+    };
+    conn.subscribe(pattern, (_subject, data) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(new TextDecoder().decode(data));
+      } catch (err) {
+        // Malformed bytes — drop (logged), never throw into the bus callback.
+        process.stderr.write(
+          `sibling-presence: "${sibling.stack}" dropping un-JSON message: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        return;
+      }
+      const envelope = tryParseEnvelope(parsed);
+      if (envelope === null) {
+        // Not a valid envelope — drop quietly (the registry's own fold would
+        // also reject it; we stop it earlier to avoid a needless apply call).
+        return;
+      }
+      // Fold with the sibling's origin. `applyForeign` tags the record foreign +
+      // source-binds identity to `verifiedScope`; a payload.scope mismatch is
+      // dropped by the registry (logged there).
+      registry.applyForeign(envelope, verifiedScope);
+    });
+  }
+
+  let stopped = false;
+  return {
+    degraded,
+    stop: async (): Promise<void> => {
+      if (stopped) return;
+      stopped = true;
+      // Close every sibling link. Best-effort: a close fault on one link must
+      // not prevent closing the others.
+      await Promise.allSettled(connections.map((c) => c.close()));
+      // Drop the foreign records this aggregator added so a stop cleanly clears
+      // sibling hubs (mirrors the federated subscriber's removeForeign on stop).
+      registry.removeForeign();
+    },
+  };
+}


### PR DESCRIPTION
## What

Makes the localhost MC **Network view** the one-pane-over-all-my-stacks surface (#989 scope-correction, comment 4679908024). The dashboard-serving daemon now auto-discovers the principal's OTHER local stacks, opens a **read-only subscriber per sibling bus** using that stack's own credential, and folds its `agent.*` presence into the shared presence registry tagged with the sibling's origin — so every local stack renders as its own stack-hub, not just the serving one.

**No federation, no bridge, no cross-principal trust** — every bus is the principal's own loopback bus on one machine; the principal owns all of them and their auth (ADR-0005 satisfied: the principal sees their own interiors).

`refs #989` — **part-1-partial**: 3 of 4 buses aggregate; community needs a follow-up (see below). Part-2 (working-grid / session aggregation) is a separate slice.

## Scope (part-1 = PRESENCE / Network view ONLY)

- ✅ Sibling-bus discovery (scan config root → `{principal, stack, url, credential}`, same-principal + loopback filter, self-exclusion)
- ✅ Per-bus read-only subscriber → fold into the shared registry tagged by sibling origin
- ✅ Config knob `mc.aggregateLocalStacks` on the shared `McSchema` (default ON)
- ✅ Graceful degrade (a sibling down/unreachable → absent, logged, never crashes boot)
- ❌ Working-grid session aggregation (part-2, out of scope)
- ❌ Cross-principal / federated changes; the cloud worker (unchanged)

## Discovery approach

`discoverSiblingStacks` scans the config root (default = the serving config dir's parent, `~/.config/cortex`) for config-split stack dirs, reads each one's `system/system.yaml` (bus url + credential) and `stacks/*.yaml` (`{principal}/{stack}`), and yields one descriptor per sibling. Filters: **same principal**, **loopback bus (127.0.0.0/8 / localhost / ::1)**, **not self**. Malformed/partial dirs are skipped (logged), never thrown.

**Precedence:** an explicit `mc.aggregateLocalStacks.stacks[]` roster **overrides** discovery entirely; empty (the default) ⇒ auto-discover. Self is excluded on both paths.

## Per-bus credential resolution (live-probed on this machine)

The credential model is **"declare creds, else try no-auth and let the bus decide"** — because config alone can't distinguish an open loopback bus from a locked NSC bus (both lack `credsPath`), but the connect attempt is ground truth and a failed read-only connect already degrades harmlessly.

| Bus | Port | Config auth | Result |
|---|---|---|---|
| meta-factory | :4222 | `credsPath: cortex.creds` | self (serving stack) — own B.3 path |
| **work** | :4222 | `credsPath: cortex-work.creds` | ✅ **aggregates** (creds) |
| **halden** | :4223 | NKey seed only (config), but bus is an **open `nats-server -js`** | ✅ **aggregates** (noauth — open bus accepts unauth connect) |
| **community** | :4224 | NSC-operator account, only an account-signing NKey | ❌ **degrades** — `Authorization Violation`; needs a **minted read-only observer user** in the `ANDREAS_AGENTS` account |

So **work + halden aggregate today**; **community needs a follow-up** (mint an observer user / creds for the `ANDREAS_AGENTS` account, then it connects with no further code change). Until then community degrades to absent (logged), never crashing the pane.

## Default ON/OFF decision

**Default ON.** The operator explicitly wants the localhost pane to show all their stacks; a single-stack box is unaffected because discovery simply finds no siblings (no-op). The cost is bounded (one extra read-only loopback connection per discovered sibling) and any unreachable sibling degrades to absent. Set `mc.aggregateLocalStacks.enabled: false` to pin the pane to the serving stack only.

## Graceful-degrade behavior

- Unreachable / auth-failed sibling at start → recorded in `handle.degraded[]`, logged to stderr, **skipped** — boot is never blocked, no exception escapes.
- A `noauth` sibling on a locked bus → the connect throws (`Authorization Violation`), caught by the single degrade path.
- Malformed bytes / bad envelopes on a sibling bus → dropped by the registry's best-effort fold (logged), never thrown.
- The serving stack's OWN presence path (B.3 registry + producer) is untouched — aggregation only ADDS foreign records.
- `stop()` closes every sibling link + prunes the sibling foreign records; idempotent.

## Rendering — fed, not rebuilt

The dashboard `network-graph-adapter` already groups agents into **one hub per distinct `{principal}/{stack}` origin** (G-1114.E.3). Sibling agents arrive with `origin: {kind:"foreign", principal:"andreas", stack:"work"|"halden"}` → hub id `__stack__:andreas/work` etc. — distinct hubs, **no rendering change**. This PR feeds that existing machinery.

## Tests (TDD)

- sibling discovery: same-principal/loopback filter, self-exclusion, noauth-vs-creds credential, malformed-dir skip, explicit-override precedence
- multi-bus subscriber fold → registry has agents from N stacks tagged by origin; subject scoping; noauth-connects + locked-bus-degrades; malformed-bytes drop; `stop()` idempotent + closes links
- config shared-schema parity (both `AgentConfigSchema` + `CortexConfigSchema` parse `mc.aggregateLocalStacks` identically — #877 lesson)

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (28 pre-existing warnings, none in new files)
- `bun test` — **6370 pass / 0 fail**
- `bun run build:dashboard` — clean

## Follow-up

- **community (:4224)** — mint a read-only observer user/creds in the `ANDREAS_AGENTS` NSC account and either declare its `credsPath` in `community/system/system.yaml` or add it to `mc.aggregateLocalStacks.stacks[]`. No further code change needed.
- **part-2** — working-grid / session aggregation across stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)