### PR TITLE
chore: bump to v5.11.0 — P-14 lane (sideband proxy, transcript drill-down, multi-bus aggregation)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.10.0"
+version: "5.11.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump for the v5.11.0 release. 7 commits since v5.10.0: U0.1 sideband proxy (#983), U1.1 transcript drill-down (#996), #989 part-1 multi-bus local-stack presence aggregation (#1001), + the red-main/vocab fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)