### PR TITLE
fix(cortex): announce agent presence independent of mc.enabled (#1003, unblocks #989)

### DIFF
--- a/src/__tests__/cortex.agent-presence-boot.test.ts
+++ b/src/__tests__/cortex.agent-presence-boot.test.ts
@@ -3,13 +3,21 @@
  *
  * Asserts the boot lifecycle integration in `startCortex`:
  *
- *   1. Gated ON (`config.mc.enabled: true`) → one `agent.online` per hosted
+ *   1. MC ON (`config.mc.enabled: true`) → one `agent.online` per hosted
  *      agent goes out on boot, carrying that agent's capabilities; the registry
  *      subscriber self-subscribes to the stack-local `agent.>` pattern.
- *   2. Gated OFF (`config.mc.enabled: false`) → NO `agent.*` envelopes.
- *   3. Shutdown → `agent.offline` (reason: shutdown) publishes for every agent
+ *   2. (#1003) MC OFF (`config.mc.enabled: false`) WITH agents → the presence
+ *      PRODUCER still announces (`agent.online` per agent + `agent.offline` on
+ *      shutdown), because presence is a BUS concern independent of the MC
+ *      dashboard (ADR-0007). But the consuming REGISTRY stays MC-gated: a
+ *      non-dashboard stack only PUBLISHES its own presence, it does not CONSUME
+ *      others' — so it does NOT subscribe to `agent.>`.
+ *   3. No agents (empty roster) → NO producer, NO `agent.*` envelopes, even with
+ *      a bus — nothing to announce.
+ *   4. Shutdown → `agent.offline` (reason: shutdown) publishes for every agent
  *      BEFORE the runtime closes (ordering: offline lands while the recording
- *      runtime is still accepting publishes, i.e. before `runtime.stop`).
+ *      runtime is still accepting publishes, i.e. before `runtime.stop`) — and
+ *      this holds whether or not MC is enabled.
  *
  * Mirrors the `cortex.capability-boot.test.ts` harness (NATS-absent recording
  * runtime, inline agents, headless presence). The recording runtime records the
@@ -140,7 +148,7 @@ describe("startCortex — agent-presence boot/shutdown (G-1114.B.2+B.3)", () => 
     await handle.stop();
   });
 
-  test("gated OFF: no agent.* envelopes when mc.enabled is false", async () => {
+  test("#1003 MC OFF with agents: producer STILL announces agent.online per agent (presence is a bus concern)", async () => {
     const runtime = createRecordingRuntime();
     const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-off-"));
     const handle = await startCortex(
@@ -151,13 +159,92 @@ describe("startCortex — agent-presence boot/shutdown (G-1114.B.2+B.3)", () => 
         disableOutboundPoller: true,
         agentsDir: tmp,
         injectRuntime: runtime,
-        inlineAgents: [makeAgent("luna", ["code-review.typescript"])],
+        inlineAgents: [
+          makeAgent("luna", ["code-review.typescript"]),
+          makeAgent("echo", ["research"]),
+        ],
         principal: { id: "andreas" },
       },
     );
-    expect(presenceTypes(runtime.published)).toEqual([]);
-    expect(runtime.subscribedPatterns).not.toContain("local.andreas.default.agent.>");
+
+    // The PRODUCER runs regardless of mc.enabled — the core #1003 fix. Each
+    // hosted agent announces presence on the stack-local bus so #989's
+    // multi-bus aggregator has something to render.
+    const onlines = runtime.published.filter((e) => e.type === "agent.online");
+    expect(onlines.length).toBe(2);
+    const luna = onlines.find(
+      (e) => (e.payload as { identity: { agent_id: string } }).identity.agent_id === "luna",
+    );
+    expect((luna!.payload as { capabilities: string[] }).capabilities).toEqual([
+      "code-review.typescript",
+    ]);
+    expect(luna!.sovereignty.classification).toBe("local");
+
+    // The CONSUMING registry stays MC-gated: a non-dashboard stack publishes its
+    // own presence but does not consume others' — so NO `agent.>` subscription.
+    expect(runtime.subscribedPatterns).not.toContain(
+      "local.andreas.default.agent.>",
+    );
+
     await handle.stop();
+  });
+
+  test("#1003 MC OFF: agent.offline still publishes on shutdown for every agent", async () => {
+    const runtime = createRecordingRuntime();
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-off-shutdown-"));
+    const handle = await startCortex(
+      minimalConfig({ mc: { enabled: false, configPath: "", dbPath: "", port: 0 } }),
+      {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmp,
+        injectRuntime: runtime,
+        inlineAgents: [
+          makeAgent("luna", ["code-review.typescript"]),
+          makeAgent("echo", ["research"]),
+        ],
+        principal: { id: "andreas" },
+      },
+    );
+
+    await handle.stop();
+
+    const offlines = runtime.published.filter((e) => e.type === "agent.offline");
+    expect(offlines.length).toBe(2);
+    for (const off of offlines) {
+      expect((off.payload as { reason: string }).reason).toBe("shutdown");
+    }
+    // Still ordered before the runtime close even on the MC-off path.
+    expect(runtime.publishedAfterStop).not.toContain("agent.offline");
+  });
+
+  test("#1003 no agents: no producer, no agent.* envelopes (even with a bus)", async () => {
+    const runtime = createRecordingRuntime();
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-no-agents-"));
+    const handle = await startCortex(
+      // mc.enabled true to prove the gate is "has agents", not "mc off": even
+      // with MC on, an empty roster announces nothing.
+      minimalConfig({ mc: { enabled: true, configPath: "", dbPath: "", port: 0 } }),
+      {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmp,
+        injectRuntime: runtime,
+        inlineAgents: [],
+        principal: { id: "andreas" },
+      },
+    );
+    // No hosted agents ⇒ no presence producer ⇒ no agent.online/heartbeat.
+    expect(runtime.published.filter((e) => e.type === "agent.online")).toEqual(
+      [],
+    );
+    await handle.stop();
+    // …and none on shutdown either.
+    expect(runtime.published.filter((e) => e.type === "agent.offline")).toEqual(
+      [],
+    );
   });
 
   test("shutdown: agent.offline publishes for every agent BEFORE runtime close", async () => {

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3625,26 +3625,38 @@ export async function startCortex(
   // G-1114.B.2 + B.3 — live agent-presence producer + runtime registry
   // subscriber (STACK-LOCAL ONLY — no federation; that is Phase E).
   //
-  // Gated on `config.mc.enabled` — presence is the data the B.4 agents panel +
-  // the MC API render, so it only runs when MC is wanted. The producer and
-  // subscriber share this gate so they stay consistent (a stack that records
-  // presence also emits it, and vice-versa). Both are best-effort: a fault
-  // logs + boot continues.
+  // #1003 — the PRODUCER (publish side) is DECOUPLED from `config.mc.enabled`;
+  // the consuming REGISTRY (+ federated/sibling subscribers + WS broadcast) stay
+  // MC-gated. The split follows ADR-0007: presence is a BUS concern — "this
+  // agent process is up and consuming" — independent of whether this stack ALSO
+  // serves an MC dashboard. So:
   //
-  // Independent of `disableDashboard`: the producer + registry are pure bus
-  // wiring (no MC DB / no HTTP port), so they run on the same `mc.enabled`
-  // signal even when the embed itself is skipped (e.g. tests that disable the
-  // HTTP embed but still want the presence roundtrip).
+  //   - The PRODUCER runs whenever the stack hosts ≥1 agent on the bus,
+  //     REGARDLESS of `mc.enabled`. A non-dashboard stack (work/halden) must
+  //     still PUBLISH `local.{principal}.{stack}.agent.{online,heartbeat,offline}`
+  //     so #989's multi-bus aggregator (running on the dashboard stack) has
+  //     something to render. The producer's only deps are the bus runtime
+  //     (`runtime.publish`) + the hosted-agent roster + heartbeat config — NOT
+  //     the MC db / dashboard / registry. (No agents ⇒ no producer: nothing to
+  //     announce, so an empty roster constructs nothing.)
+  //   - The REGISTRY + federated/sibling subscribers + the WS broadcast stay
+  //     gated on `config.mc.enabled`: they CONSUME presence to render the B.4
+  //     agents panel + Network view. A non-dashboard stack only needs to PUBLISH
+  //     its own presence, not CONSUME others' — so it does not subscribe.
   //
-  //   - The REGISTRY subscriber starts FIRST so it's listening before the
-  //     producer's own `agent.online` envelopes go out (the roundtrip lands the
-  //     hosted agents in the registry immediately).
-  //   - The PRODUCER then publishes one `agent.online` per hosted agent
-  //     (carrying its capabilities) + starts the heartbeat ticker.
+  // Both halves are best-effort: a fault logs + boot continues. Independent of
+  // `disableDashboard`: the registry is pure bus wiring (no MC DB / no HTTP
+  // port), so the MC-gated consumer half runs on `mc.enabled` even when the HTTP
+  // embed is skipped (tests that disable the embed but still want the roundtrip).
+  //
+  // Ordering when MC is on: the REGISTRY subscriber starts FIRST (in the MC
+  // block) so it's listening before the producer's `agent.online` envelopes go
+  // out below — the roundtrip lands the hosted agents in the registry
+  // immediately. With MC off, the producer simply publishes onto the bus with no
+  // local consumer.
   //
   // `runtime.publish` is a no-op when the runtime is dormant (no NATS), so this
-  // is safe to run without a bus — the producer simply emits into the void and
-  // the registry stays empty.
+  // is safe to run without a bus — the producer emits into the void.
   //
   // Liveness FSM (G-1114.C.3): `startAgentPresenceRegistry` starts the 5-min
   // TTL reaper by default — an `online` record whose `agent.heartbeat` stops for
@@ -3676,6 +3688,41 @@ export async function startCortex(
   // unsubscribe it explicitly — making teardown order-independent rather than
   // relying on the registry stop severing the envelope feed first (#899 review).
   let presenceBroadcastSub: { unsubscribe: () => void } | null = null;
+
+  // #1003 — build the per-agent presence descriptors ONCE, BEFORE both the
+  // MC-gated consumer block and the unconditional producer block, so the
+  // producer is constructed exactly once (no double-construct across the two
+  // paths). The stack's own NKey pubkey (captured when the signer was staged) is
+  // the fallback identity for any agent that hasn't declared its own `nkey_pub`.
+  // Agents with no resolvable key are skipped (the presence payload requires a
+  // non-empty key).
+  const presenceAgents: PresenceAgent[] = [];
+  {
+    let skippedNoKey = 0;
+    for (const a of mergedAgents) {
+      const pa = presenceAgentFromAgent(
+        a,
+        { principal: principalId, stack: derivedStack.stack },
+        stackNKeyPubForVerifier,
+      );
+      if (pa === null) {
+        skippedNoKey += 1;
+        continue;
+      }
+      presenceAgents.push(pa);
+    }
+    if (skippedNoKey > 0) {
+      console.warn(
+        `cortex: agent-presence — ${skippedNoKey} agent(s) skipped (no agent.nkey_pub ` +
+          `and no stack NKey to fall back to); they will not appear in the presence registry`,
+      );
+    }
+  }
+
+  // MC-gated CONSUMER half — the registry subscriber + WS broadcast. Starts
+  // FIRST (before the producer below) so it's listening before the producer's
+  // own `agent.online` envelopes go out, landing the hosted agents in the
+  // registry immediately on the local roundtrip.
   if (config.mc.enabled) {
     try {
       presenceRegistryHandle = await startAgentPresenceRegistry({
@@ -3705,30 +3752,24 @@ export async function startCortex(
           });
         });
       }
-      // Build the per-agent presence descriptors. The stack's own NKey pubkey
-      // (captured when the signer was staged) is the fallback identity for any
-      // agent that hasn't declared its own `nkey_pub`. Agents with no resolvable
-      // key are skipped (the presence payload requires a non-empty key).
-      const presenceAgents: PresenceAgent[] = [];
-      let skippedNoKey = 0;
-      for (const a of mergedAgents) {
-        const pa = presenceAgentFromAgent(
-          a,
-          { principal: principalId, stack: derivedStack.stack },
-          stackNKeyPubForVerifier,
-        );
-        if (pa === null) {
-          skippedNoKey += 1;
-          continue;
-        }
-        presenceAgents.push(pa);
-      }
-      if (skippedNoKey > 0) {
-        console.warn(
-          `cortex: agent-presence — ${skippedNoKey} agent(s) skipped (no agent.nkey_pub ` +
-            `and no stack NKey to fall back to); they will not appear in the presence registry`,
-        );
-      }
+    } catch (err) {
+      console.error(
+        "cortex: agent-presence registry/WS startup error (non-fatal):",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  // #1003 — PRODUCER half — DECOUPLED from `config.mc.enabled`. Constructed +
+  // started whenever the stack hosts ≥1 agent on the bus, so a non-dashboard
+  // stack (work/halden) still publishes `agent.{online,heartbeat,offline}` for
+  // #989's aggregator to render. Its only deps are the bus runtime + the agent
+  // roster + heartbeat config — NOT the MC db/dashboard/registry (see
+  // agent-presence-producer.ts: "safe to run unconditionally"). Constructed ONCE
+  // here (the roster was built above), never in the MC block — no
+  // double-construct. No agents ⇒ no producer (nothing to announce).
+  if (presenceAgents.length > 0) {
+    try {
       presenceProducer = new AgentPresenceProducer({
         runtime,
         source: {
@@ -3744,7 +3785,33 @@ export async function startCortex(
         federate: federatePresence,
       });
       presenceProducer.start();
+      // G-1114.C.1 — publish the now-started producer to the config-reload
+      // onChange handler so a mid-life capability drift can emit
+      // `agent.capabilities-changed` without restart (see that handler's block
+      // for THE FINDING — restart-only in the common case, this is the
+      // defensive emit side). Wired regardless of `mc.enabled` so capability
+      // hot-reload tracks presence even on a non-dashboard stack.
+      presenceProducerForReload = presenceProducer;
+      console.log(
+        `cortex: agent-presence producer started — ${presenceAgents.length} agent(s) announced ` +
+          `(stack-local${config.mc.enabled ? " + local registry" : ", mc disabled"}; ` +
+          `heartbeat every ${DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS}ms)`,
+      );
+    } catch (err) {
+      console.error(
+        "cortex: agent-presence producer startup error (non-fatal):",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
 
+  // MC-gated CONSUMER half (cont.) — federated + sibling presence subscribers
+  // fold OTHER stacks' agents into the local registry that backs the Network
+  // view. A non-dashboard stack has no registry to fold into and does not
+  // consume others' presence, so these stay gated on `mc.enabled` and require
+  // the registry the MC block above started.
+  if (config.mc.enabled && presenceRegistryHandle !== null) {
+    try {
       // G-1114.E.2 + E.5 — start the trust-verified federated presence
       // subscriber. INERT (no NATS subscription, no folds) when the stack hasn't
       // opted into federation. When opted in, it folds peers' accept-listed +
@@ -3770,16 +3837,6 @@ export async function startCortex(
         }),
         ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
       });
-      // G-1114.C.1 — publish the now-started producer to the config-reload
-      // onChange handler so a mid-life capability drift can emit
-      // `agent.capabilities-changed` without restart (see that handler's block
-      // for THE FINDING — restart-only in the common case, this is the
-      // defensive emit side).
-      presenceProducerForReload = presenceProducer;
-      console.log(
-        `cortex: agent-presence producer + registry started — ${presenceAgents.length} agent(s) announced ` +
-          `(stack-local; heartbeat every ${DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS}ms)`,
-      );
 
       // #989 part-1 — LOCAL same-principal sibling-stack presence aggregation.
       // When enabled (default ON), auto-discover the principal's OTHER local
@@ -3845,7 +3902,7 @@ export async function startCortex(
       }
     } catch (err) {
       console.error(
-        "cortex: agent-presence producer/registry startup error (non-fatal):",
+        "cortex: federated/sibling agent-presence startup error (non-fatal):",
         err instanceof Error ? err.message : err,
       );
     }


### PR DESCRIPTION
## What & why

The agent-presence **producer** (the publish side — `agent.{online,heartbeat,offline}` on `local.{principal}.{stack}.agent.*`) was constructed + started **inside** the `if (config.mc.enabled)` boot block in `src/cortex.ts`. So a stack that doesn't serve its OWN MC dashboard — `work`, `halden` — **never started the producer** → published **zero** presence.

That's the gap blocking the visible outcome of #989: its multi-bus aggregator connects to the sibling stacks' buses (confirmed pinging live) but sees nothing to render, because the sibling stacks are silent at the source.

Per **ADR-0007**, presence is a **BUS concern** — "this agent process is up and consuming" — *independent* of whether the stack ALSO serves an MC dashboard. The old coupling conflated "I render a dashboard" with "I exist on the network".

## The decoupling

The producer's real dependency is **bus-level only**: `runtime` (`MyelinRuntime.publish`) + the hosted-agent roster (`PresenceAgent[]`, derived from `mergedAgents`) + heartbeat config + the federate flag. It takes **no** MC db / dashboard / registry dependency (the producer's own docstring: *"safe to run unconditionally"*). So the publish side can run on any stack with a bus + agents.

Restructure of the boot block (`src/cortex.ts`):

1. **Build the presence-agent roster ONCE**, before both blocks → the producer is constructed exactly **once** (no double-construct across an mc-on / mc-off path).
2. **Producer (publish side) — DECOUPLED.** Constructed + `.start()`ed whenever the stack hosts **≥1 agent**, regardless of `mc.enabled`. No agents ⇒ no producer (nothing to announce).
3. **Consumer side — stays MC-gated.** The registry subscriber, the federated + sibling presence subscribers (which fold OTHER stacks' agents into the local Network-view registry), and the WS broadcast remain behind `config.mc.enabled`. A non-dashboard stack only needs to **PUBLISH** its own presence, not **CONSUME** others' — so it does not subscribe to `agent.>`.
4. **Lifecycle preserved.** `presenceProducerForReload` (the config-reload capability re-emit) is now assigned regardless of `mc.enabled`; the shutdown drain's `presenceProducer?.stop("shutdown")` is null-safe and unchanged.

Net: a stack with agents + a bus but **no `mc.enabled`** now publishes `local.{principal}.{stack}.agent.{online,heartbeat,offline}` → #989's aggregator surfaces it.

## No regression (meta-factory, `mc.enabled: true`)

- Registry still starts **first** (before the producer's `agent.online` goes out) — the local roundtrip still lands hosted agents immediately.
- Producer still announces exactly as before; federated + sibling subscribers + WS broadcast unchanged.
- Producer constructed **once** (grep-verified: one `new AgentPresenceProducer`, one `.start()`, one `presenceProducerForReload =`).

## Tests (TDD — RED→GREEN)

Extended `src/__tests__/cortex.agent-presence-boot.test.ts` (the existing NATS-absent recording-runtime harness):

- **#1003 MC OFF + agents →** producer STILL announces `agent.online` per agent (with capabilities, `classification: local`); registry does NOT subscribe to `agent.>` (consumer stays gated). *(the core fix — was RED before)*
- **#1003 MC OFF →** `agent.offline` still publishes for every agent on shutdown, before the runtime closes. *(was RED before)*
- **#1003 no agents (even MC ON) →** no producer, no `agent.*` envelopes on boot or shutdown.
- **MC ON →** unchanged: `agent.online` per agent + registry self-subscribes (regression guard).
- **Shutdown (MC ON) →** `agent.offline` before runtime close (regression guard).

## Gates

- `bunx tsc --noEmit` → clean (exit 0)
- `bun run lint` → 0 errors, 28 warnings (identical count on clean `main` — all pre-existing, none introduced)
- `bun test` → **6371 pass, 0 fail, 2 skip** (6373 across 374 files)

Closes #1003
Refs #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)