### PR TITLE
chore: bump to v5.11.1 — presence decoupled from mc.enabled (#1003)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.11.0"
+version: "5.11.1"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Patch release: #1004 decouples the agent-presence producer from mc.enabled so non-dashboard stacks (work/halden) announce presence — the last link making #989 multi-stack aggregation visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)