### PR TITLE
fix(cortex): nkey_pub survives agent resolution so non-MC stacks announce presence (#1006, unblocks #989)

### DIFF
--- a/src/__tests__/cortex.agent-presence-boot.test.ts
+++ b/src/__tests__/cortex.agent-presence-boot.test.ts
@@ -108,6 +108,25 @@ function makeAgent(id: string, capabilities: readonly string[]): Agent {
   };
 }
 
+/**
+ * #1006 — the work/halden shape: an agent in the canonical top-level
+ * `agents[]` that does NOT declare its own `nkey_pub`. Its presence identity
+ * must come from the STACK NKey fallback (declared as `stack.nkey_pub` or
+ * derived from the seed) — independent of the signing posture. Mirrors the
+ * live config-split stacks whose per-agent key lives only on
+ * `policy.principals[].nkey_pub`, not on the `agents[]` entry.
+ */
+function makeAgentNoKey(id: string, capabilities: readonly string[]): Agent {
+  const a = makeAgent(id, capabilities);
+  // Strip the per-agent key so resolution must fall back to the stack key.
+  // `nkey_pub` is optional on Agent, so the rest object is already an Agent.
+  const { nkey_pub: _stripped, ...rest } = a;
+  return rest;
+}
+
+/** A valid 56-char U-prefixed base32 NKey-shaped pubkey for tests. */
+const STACK_NKEY_PUB = "UD" + "Q".padEnd(54, "A");
+
 const presenceTypes = (envs: Envelope[]): string[] =>
   envs.map((e) => e.type).filter((t) => t.startsWith("agent."));
 
@@ -277,5 +296,127 @@ describe("startCortex — agent-presence boot/shutdown (G-1114.B.2+B.3)", () => 
     // recording runtime flags any publish that arrives after `stopped` — no
     // agent.offline may appear there.
     expect(runtime.publishedAfterStop).not.toContain("agent.offline");
+  });
+
+  // ===========================================================================
+  // #1006 — the stack-NKey fallback must survive signing: off.
+  //
+  // The work/halden shape: agents in the canonical top-level `agents[]` carry
+  // NO per-agent `nkey_pub` (it lives only on `policy.principals[].nkey_pub`),
+  // the stack declares `stack.nkey_pub`, and `security.signing` is `off` (the
+  // schema default). Pre-#1006 the stack pubkey was resolved ONLY inside the
+  // signing-enabled boot branch, so with signing off the presence producer had
+  // no fallback → every keyless agent was skipped → no `agent.online` → the
+  // #989 multi-bus aggregator rendered nothing.
+  //
+  // Presence identity is a BUS concern, independent of the signing posture
+  // (ADR-0007): a stack whose pubkey is declared in config must announce its
+  // agents whether or not it is signing outbound envelopes.
+  // ===========================================================================
+
+  test("#1006 signing OFF + keyless agents + stack.nkey_pub: producer STILL announces (stack fallback survives signing posture)", async () => {
+    const runtime = createRecordingRuntime();
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-1006-stackfallback-"));
+    const handle = await startCortex(
+      // mc.enabled false is the work/halden shape; security.signing defaults to
+      // `off` (no security block declared) — the exact live posture.
+      minimalConfig({ mc: { enabled: false, configPath: "", dbPath: "", port: 0 } }),
+      {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmp,
+        injectRuntime: runtime,
+        // Agents WITHOUT per-agent nkey_pub — must fall back to the stack key.
+        inlineAgents: [
+          makeAgentNoKey("luna", ["code-review.typescript"]),
+          makeAgentNoKey("echo", ["research"]),
+        ],
+        // The stack declares its pubkey (and a seed path), but signing is off.
+        stack: {
+          id: "andreas/work",
+          nkey_pub: STACK_NKEY_PUB,
+        },
+        principal: { id: "andreas" },
+      },
+    );
+
+    const onlines = runtime.published.filter((e) => e.type === "agent.online");
+    // BOTH keyless agents must be announced via the stack fallback.
+    expect(onlines.length).toBe(2);
+    // Each carries the STACK pubkey as its presence identity (no per-agent key).
+    for (const online of onlines) {
+      const key = (online.payload as { identity: { nkey_public_key: string } })
+        .identity.nkey_public_key;
+      expect(key).toBe(STACK_NKEY_PUB);
+    }
+
+    await handle.stop();
+  });
+
+  test("#1006 meta-factory shape unchanged: per-agent nkey_pub still wins over the stack key", async () => {
+    const runtime = createRecordingRuntime();
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-1006-perAgentWins-"));
+    const handle = await startCortex(
+      minimalConfig({ mc: { enabled: true, configPath: "", dbPath: "", port: 0 } }),
+      {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmp,
+        injectRuntime: runtime,
+        // The meta-factory shape: agents DO declare per-agent nkey_pub.
+        inlineAgents: [
+          makeAgent("luna", ["code-review.typescript"]),
+          makeAgent("echo", ["research"]),
+        ],
+        // A stack key is ALSO present, but per-agent keys must take precedence.
+        stack: {
+          id: "andreas/meta-factory",
+          nkey_pub: STACK_NKEY_PUB,
+        },
+        principal: { id: "andreas" },
+      },
+    );
+
+    const onlines = runtime.published.filter((e) => e.type === "agent.online");
+    expect(onlines.length).toBe(2);
+    const luna = onlines.find(
+      (e) => (e.payload as { identity: { agent_id: string } }).identity.agent_id === "luna",
+    );
+    // Per-agent key wins — NOT the stack fallback.
+    expect(
+      (luna!.payload as { identity: { nkey_public_key: string } }).identity
+        .nkey_public_key,
+    ).toBe("UA" + "LUNA".padEnd(54, "X"));
+    expect(
+      (luna!.payload as { identity: { nkey_public_key: string } }).identity
+        .nkey_public_key,
+    ).not.toBe(STACK_NKEY_PUB);
+
+    await handle.stop();
+  });
+
+  test("#1006 no stack key AND keyless agents: still skipped (the genuine no-key case)", async () => {
+    const runtime = createRecordingRuntime();
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-presence-1006-genuinely-keyless-"));
+    const handle = await startCortex(
+      minimalConfig({ mc: { enabled: false, configPath: "", dbPath: "", port: 0 } }),
+      {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmp,
+        injectRuntime: runtime,
+        inlineAgents: [makeAgentNoKey("luna", ["code-review.typescript"])],
+        // No `stack` option at all ⇒ no stack pubkey to fall back to.
+        principal: { id: "andreas" },
+      },
+    );
+
+    // Genuinely keyless: nothing to announce — the skip is correct here.
+    expect(runtime.published.filter((e) => e.type === "agent.online")).toEqual([]);
+
+    await handle.stop();
   });
 });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -723,6 +723,32 @@ export async function startCortex(
     );
   }
 
+  // #1006 — presence-scoped stack pubkey, resolved INDEPENDENT of the signing
+  // posture.
+  //
+  // `stackNKeyPubForVerifier` (above) is only populated inside the
+  // signing-ENABLED boot branch — it is the key the chain-verifier loads from
+  // the seed when `attachSigner` is true. With `security.signing: off` (the
+  // schema default that the live work/halden config-split stacks run) that
+  // branch is skipped, so the verifier key stays `undefined` even though the
+  // stack pubkey IS declared in config (`stack.nkey_pub`).
+  //
+  // Presence is a BUS identity concern, NOT a signing concern (ADR-0007): the
+  // agent-presence producer stamps the stack's NKey pubkey as the fallback
+  // identity for any hosted agent that hasn't declared its own `nkey_pub`
+  // (the work/halden shape — per-agent keys live on `policy.principals[]`,
+  // not on the canonical `agents[]` entry). A stack whose pubkey is declared
+  // MUST announce its agents whether or not it signs outbound envelopes.
+  //
+  // Resolution order: prefer the seed-loaded verifier key (already validated
+  // against `stack.nkey_pub` for the rotation split-brain check above when
+  // signing is on), else the declared `stack.nkey_pub`. Both pass the same
+  // NKEY_PUBKEY_REGEX at the schema layer, so they are interchangeable as the
+  // presence identity. Stays `undefined` only when the stack declares neither
+  // — the genuine no-key case, where skipping is still correct.
+  const stackNKeyPubForPresence: string | undefined =
+    stackNKeyPubForVerifier ?? options.stack?.nkey_pub;
+
   // S4 (Network Join Control Plane, epic #733; DD-5 wiring) — resolve the
   // federated `peers[]` from the registry roster BEFORE any consumer reads
   // them. Joining a network names the NETWORK, not each principal: a peer may
@@ -3692,10 +3718,13 @@ export async function startCortex(
   // #1003 — build the per-agent presence descriptors ONCE, BEFORE both the
   // MC-gated consumer block and the unconditional producer block, so the
   // producer is constructed exactly once (no double-construct across the two
-  // paths). The stack's own NKey pubkey (captured when the signer was staged) is
-  // the fallback identity for any agent that hasn't declared its own `nkey_pub`.
-  // Agents with no resolvable key are skipped (the presence payload requires a
-  // non-empty key).
+  // paths). The stack's own NKey pubkey is the fallback identity for any agent
+  // that hasn't declared its own `nkey_pub`. #1006: this uses
+  // `stackNKeyPubForPresence` (declared `stack.nkey_pub` OR the seed-loaded
+  // key) rather than `stackNKeyPubForVerifier` (set only when signing is on),
+  // so a `signing: off` stack still announces its keyless agents. Agents with
+  // no resolvable key are skipped (the presence payload requires a non-empty
+  // key).
   const presenceAgents: PresenceAgent[] = [];
   {
     let skippedNoKey = 0;
@@ -3703,7 +3732,7 @@ export async function startCortex(
       const pa = presenceAgentFromAgent(
         a,
         { principal: principalId, stack: derivedStack.stack },
-        stackNKeyPubForVerifier,
+        stackNKeyPubForPresence,
       );
       if (pa === null) {
         skippedNoKey += 1;


### PR DESCRIPTION
## Root cause

**Candidate #2 — the `stackNKeyPubForVerifier` resolution path. NOT schema divergence.**

The agent-presence producer skipped **every** agent on `work` + `halden` (which run `security.signing: off`, the schema default) even though their stack pubkey is declared in config — the symptom in #1006:

```
cortex: agent-presence — 2 agent(s) skipped (no agent.nkey_pub and no stack NKey to fall back to)
```

The stack NKey pubkey was resolved **only inside the signing-ENABLED boot branch**:

- `src/cortex.ts:679` — `stackNKeyPubForVerifier = kp.getPublicKey()` lives in the `else if (options.stack?.nkey_seed_path)` branch, reached only when `signingKnobs.attachSigner` is true.
- `src/cortex.ts:613` — when `security.signing: off` → `resolveSigningKnobs` returns `attachSigner: false` → the FIRST branch fires (`seed present but signing off → don't attach signer`) and **never sets `stackNKeyPubForVerifier`**. It stays `undefined`.

The presence loop (`src/cortex.ts:~3699`) then passes that `undefined` as the stack-key fallback to `presenceAgentFromAgent`. For agents whose own `nkey_pub` is unset — the **work/halden shape**, where the per-agent key lives on `policy.principals[].nkey_pub`, *not* on the canonical top-level `agents[]` entry — `presenceAgentFromAgent` resolves `agent.nkey_pub ?? fallback` to `undefined`, returns `null`, and the agent is skipped.

`meta-factory` (mc.enabled) escaped this only because **its** `agents[]` carry per-agent `nkey_pub` (stacks/meta-factory.yaml lines 552/591/629), so it never needed the stack fallback.

### Schema divergence ruled out (with evidence)

Both candidate schemas were verified to carry `nkey_pub`:
- **Inline agents** (`stacks/*.yaml` top-level `agents[]`) → `loadConfigWithAgents` → `CortexConfigSchema.parse` (`agents: z.array(AgentSchema)`, cortex-config.ts:2426) → `inlineAgents` → `mergedAgents`.
- **Fragment agents** (`agents.d/*.yaml`) → `loadAgentsDirectory` → `loadAgentFromFile` → `AgentSchema.parse` (loader.ts:934).

Both go through the **same shared `AgentSchema`**, which declares `nkey_pub` (cortex-config.ts:672). No second schema, no divergence — so the fix is on the resolution path, not the schema. No parity test needed.

## The fix

Resolve a presence-scoped `stackNKeyPubForPresence` **independent of the signing posture** (`src/cortex.ts`, right after the signing block):

```ts
const stackNKeyPubForPresence: string | undefined =
  stackNKeyPubForVerifier ?? options.stack?.nkey_pub;
```

Prefer the seed-loaded verifier key (already validated against `stack.nkey_pub` for the rotation split-brain check when signing is on), else the declared `stack.nkey_pub`. Both pass the same `NKEY_PUBKEY_REGEX`, so they are interchangeable as the presence identity. The presence loop now uses this instead of `stackNKeyPubForVerifier`.

Presence is a **bus identity** concern, not a signing concern (ADR-0007): a stack whose pubkey is declared MUST announce its agents whether or not it signs outbound envelopes.

## No-regression evidence

- **meta-factory unchanged:** per-agent `nkey_pub` still wins over the stack fallback (`agent.nkey_pub ?? fallback` short-circuits) — pinned by a new regression test asserting the per-agent key, never the stack key.
- **Genuine no-key case still skips:** an agent with no per-agent key AND no stack key declared is still skipped (correct) — pinned by a new test.
- `stackNKeyPubForVerifier` and all signing/verifier behaviour are untouched; the new binding is read-only and presence-scoped.

## TDD

- **RED:** signing off + keyless agents + `stack.nkey_pub` ⇒ `0` `agent.online` (reproduces the skip).
- **GREEN:** after the fix, `2` `agent.online`, each stamped with the stack pubkey.
- Plus meta-factory-shape regression + genuine-no-key regression.

## Gates

- `bunx tsc --noEmit` — clean (exit 0)
- `bun run lint` — 0 errors (28 pre-existing warnings, unchanged)
- `bun test` — 6374 pass / 0 fail / 2 pre-existing skips

Closes #1006
Refs #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)