### PR TITLE
feat(mc): U4.2 — aggregate metrics panels + >14d history (#938)

### DIFF
--- a/src/common/sideband/__tests__/metrics.test.ts
+++ b/src/common/sideband/__tests__/metrics.test.ts
@@ -1,0 +1,137 @@
+/**
+ * P-14 U4.2 (#938) — cortex-side sideband metrics client (request builders +
+ * validation gates). Pins the cortex types to signal's contract via a
+ * captured `SidebandMetricsSummary` fixture (verbatim from signal's
+ * query-v2.test.ts SUMMARY) and verifies the load-bearing window/since/class
+ * gates mirror signal's server-side gates (DURATION_RE / CLASS_RE / cap).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildMetricsSummaryPath,
+  buildSearchPath,
+  buildSearchQuery,
+  DEFAULT_METRICS_WINDOW,
+  HISTORY_WINDOW,
+  isValidDuration,
+  METRICS_WINDOWS,
+  type MetricsSummaryResponse,
+  type SidebandMetricsSummary,
+} from "../metrics";
+
+// Captured verbatim from signal/src/cli/query-v2.test.ts `SUMMARY` — pins the
+// cortex type to signal's wire shape at compile time (this object must satisfy
+// the cortex SidebandMetricsSummary).
+const SUMMARY_FIXTURE: SidebandMetricsSummary = {
+  window: "5m",
+  toolCallRate: [
+    { labels: { tool: "read" }, value: 0.5 },
+    { labels: { tool: "bash" }, value: 0.25 },
+  ],
+  agentSpawnRate: [{ labels: {}, value: 0.1 }],
+  eventRate: [{ labels: {}, value: 1.0 }],
+  hookLatencyMs: { p50: 30, p95: 100, p99: 100 },
+};
+
+// Captured verbatim from signal's MetricsSummaryResponse wrapper shape.
+const RESPONSE_FIXTURE: MetricsSummaryResponse = {
+  backend: "victoria",
+  window: "5m",
+  summary: SUMMARY_FIXTURE,
+};
+
+describe("metrics client — type pin to signal contract", () => {
+  test("the captured signal fixture satisfies the cortex types", () => {
+    // Compile-time assertion realized at runtime: the objects exist + carry the
+    // contract fields. A drift in signal's shape would fail tsc on this file.
+    expect(RESPONSE_FIXTURE.summary.hookLatencyMs.p95).toBe(100);
+    expect(RESPONSE_FIXTURE.summary.toolCallRate[0]!.labels.tool).toBe("read");
+    expect(RESPONSE_FIXTURE.backend).toBe("victoria");
+  });
+
+  test("nullable percentile / sample shapes are honoured", () => {
+    const empty: SidebandMetricsSummary = {
+      window: "5m",
+      toolCallRate: [],
+      agentSpawnRate: [],
+      eventRate: [{ labels: {}, value: null }],
+      hookLatencyMs: { p50: null, p95: null, p99: null },
+    };
+    expect(empty.hookLatencyMs.p50).toBeNull();
+    expect(empty.eventRate[0]!.value).toBeNull();
+  });
+});
+
+describe("isValidDuration — mirrors signal DURATION_RE", () => {
+  test.each(["5m", "1h", "24h", "30d", "2w", "1h30m", "90d"])(
+    "accepts %s",
+    (w) => {
+      expect(isValidDuration(w)).toBe(true);
+    },
+  );
+  test.each(["", "5", "m", "5x", "5 m", "-5m", "5min", "abc"])(
+    "rejects %s",
+    (w) => {
+      expect(isValidDuration(w)).toBe(false);
+    },
+  );
+});
+
+describe("buildMetricsSummaryPath", () => {
+  test("builds the proxied path with the window query", () => {
+    expect(buildMetricsSummaryPath("5m")).toBe(
+      "/api/observability/metrics/summary?window=5m",
+    );
+  });
+  test("builds the >14d history window path", () => {
+    expect(buildMetricsSummaryPath(HISTORY_WINDOW)).toBe(
+      "/api/observability/metrics/summary?window=30d",
+    );
+  });
+  test("throws on an invalid window (load-bearing client gate)", () => {
+    expect(() => buildMetricsSummaryPath("5 minutes")).toThrow(/invalid metrics window/);
+    expect(() => buildMetricsSummaryPath("")).toThrow();
+  });
+  test("DEFAULT_METRICS_WINDOW + METRICS_WINDOWS are coherent", () => {
+    expect(METRICS_WINDOWS).toContain(DEFAULT_METRICS_WINDOW as never);
+    expect(METRICS_WINDOWS).toContain(HISTORY_WINDOW);
+  });
+});
+
+describe("buildSearchPath — mirrors signal's /search gates", () => {
+  test("builds the default >14d history filter path", () => {
+    expect(buildSearchPath({ since: "30d", limit: 200 })).toBe(
+      "/api/observability/search?since=30d&limit=200",
+    );
+  });
+  test("omits empty query and builds bare path with no fields", () => {
+    expect(buildSearchPath({})).toBe("/api/observability/search");
+    expect(buildSearchPath({ query: "" })).toBe("/api/observability/search");
+  });
+  test("includes class + free-text query when present", () => {
+    const path = buildSearchPath({ since: "1h", class: "dispatch", query: "task" });
+    expect(path).toContain("since=1h");
+    expect(path).toContain("class=dispatch");
+    expect(path).toContain("query=task");
+  });
+  test("rejects a bad since duration", () => {
+    expect(() => buildSearchPath({ since: "yesterday" })).toThrow(/since/);
+  });
+  test("rejects a bad class token (CLASS_RE)", () => {
+    expect(() => buildSearchPath({ class: "Dispatch" })).toThrow(/class/);
+    expect(() => buildSearchPath({ class: "dis patch" })).toThrow(/class/);
+  });
+  test("rejects an over-long query (SEARCH_QUERY_MAX = 1024)", () => {
+    expect(() => buildSearchPath({ query: "x".repeat(1025) })).toThrow(/exceeds/);
+    // exactly 1024 is allowed.
+    expect(buildSearchPath({ query: "x".repeat(1024) })).toContain("query=");
+  });
+  test("rejects a non-positive / non-integer limit", () => {
+    expect(() => buildSearchPath({ limit: 0 })).toThrow(/limit/);
+    expect(() => buildSearchPath({ limit: -5 })).toThrow(/limit/);
+    expect(() => buildSearchPath({ limit: 1.5 })).toThrow(/limit/);
+  });
+  test("buildSearchQuery is an alias of buildSearchPath", () => {
+    expect(buildSearchQuery({ since: "30d" })).toBe(buildSearchPath({ since: "30d" }));
+  });
+});

--- a/src/common/sideband/__tests__/proxy-v2.test.ts
+++ b/src/common/sideband/__tests__/proxy-v2.test.ts
@@ -1,0 +1,160 @@
+/**
+ * P-14 U4.2 (#938) — sideband proxy v2 reads: `/metrics/summary` + `/search`.
+ *
+ * The proxy's path allowlist (`mapAllowedPath`) gains the two v2 endpoints
+ * (signal#127/#147). These tests pin:
+ *   - both v2 paths forward verbatim (query string preserved),
+ *   - the GET-only + loopback-re-enforcement + structured-error guarantees still
+ *     hold for them (they are reads on the same tokenless local daemon),
+ *   - a non-v2 path under the same prefix is still refused.
+ *
+ * Mirrors the U0.1 proxy.test.ts harness.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { proxySideband, type SidebandProxyConfig } from "../proxy";
+
+const BASE = "http://127.0.0.1:9092";
+
+interface RecordedCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+function stubFetch(
+  handler: (url: string, init: RequestInit | undefined) => Response | Promise<Response>,
+): { fetchImpl: typeof fetch; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    calls.push({ url, init });
+    return handler(url, init);
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function cfg(
+  over: Partial<SidebandProxyConfig> & { fetchImpl: typeof fetch },
+): SidebandProxyConfig {
+  return { baseUrl: BASE, ...over };
+}
+
+describe("proxySideband — v2 metrics/summary (#938)", () => {
+  test("forwards /metrics/summary with the window query", async () => {
+    const { fetchImpl, calls } = stubFetch(() =>
+      Response.json({ backend: "victoria", window: "5m", summary: {} }),
+    );
+    const res = await proxySideband(
+      "GET",
+      "/metrics/summary",
+      "window=5m",
+      cfg({ fetchImpl }),
+    );
+    expect(res.status).toBe(200);
+    expect(calls[0]!.url).toBe("http://127.0.0.1:9092/metrics/summary?window=5m");
+  });
+
+  test("forwards a wide >14d window verbatim (history aggregate path)", async () => {
+    const { fetchImpl, calls } = stubFetch(() =>
+      Response.json({ backend: "victoria", window: "30d", summary: {} }),
+    );
+    await proxySideband("GET", "/metrics/summary", "window=30d", cfg({ fetchImpl }));
+    expect(calls[0]!.url).toBe("http://127.0.0.1:9092/metrics/summary?window=30d");
+  });
+
+  test("sends a bare GET with accept only (tokenless §3)", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({ summary: {} }));
+    await proxySideband("GET", "/metrics/summary", "window=1h", cfg({ fetchImpl }));
+    expect(calls[0]!.init?.headers).toEqual({ accept: "application/json" });
+  });
+
+  test("refuses non-GET on the v2 path (read-only §9)", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({}));
+    const res = await proxySideband("POST", "/metrics/summary", "window=5m", cfg({ fetchImpl }));
+    expect(res.status).toBe(405);
+    expect(calls.length).toBe(0);
+  });
+
+  test("re-enforces loopback on the v2 path without fetching", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({}));
+    const res = await proxySideband(
+      "GET",
+      "/metrics/summary",
+      "window=5m",
+      cfg({ fetchImpl, baseUrl: "http://10.0.0.4:9092" }),
+    );
+    expect(res.status).toBe(503);
+    expect(calls.length).toBe(0);
+  });
+
+  test("relays a backend SidebandError (e.g. 501 unsupported backend) verbatim", async () => {
+    const { fetchImpl } = stubFetch(() =>
+      Response.json(
+        {
+          code: "internal_error",
+          message: 'backend "honeycomb" does not support /metrics/summary (PromQL)',
+        },
+        { status: 501 },
+      ),
+    );
+    const res = await proxySideband("GET", "/metrics/summary", "window=5m", cfg({ fetchImpl }));
+    expect(res.status).toBe(501);
+    const body = await res.json();
+    expect(body.code).toBe("internal_error");
+    expect(body.message).toContain("does not support /metrics/summary");
+  });
+});
+
+describe("proxySideband — v2 search (#938)", () => {
+  test("forwards /search with the filter query verbatim", async () => {
+    const { fetchImpl, calls } = stubFetch(() =>
+      Response.json({ backend: "victoria", filter: {}, results: [] }),
+    );
+    const res = await proxySideband(
+      "GET",
+      "/search",
+      "since=30d&class=dispatch&limit=200",
+      cfg({ fetchImpl }),
+    );
+    expect(res.status).toBe(200);
+    expect(calls[0]!.url).toBe(
+      "http://127.0.0.1:9092/search?since=30d&class=dispatch&limit=200",
+    );
+  });
+
+  test("forwards /search with no query (bare path)", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({ results: [] }));
+    await proxySideband("GET", "/search", "", cfg({ fetchImpl }));
+    expect(calls[0]!.url).toBe("http://127.0.0.1:9092/search");
+  });
+
+  test("preserves a reverse-proxy base path prefix on the v2 reads (§8)", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({ summary: {} }));
+    await proxySideband(
+      "GET",
+      "/metrics/summary",
+      "window=5m",
+      cfg({ fetchImpl, baseUrl: "http://127.0.0.1:9092/sideband" }),
+    );
+    expect(calls[0]!.url).toBe(
+      "http://127.0.0.1:9092/sideband/metrics/summary?window=5m",
+    );
+  });
+});
+
+describe("proxySideband — v2 allowlist is exact", () => {
+  test("refuses /metrics (without /summary)", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({}));
+    const res = await proxySideband("GET", "/metrics", "", cfg({ fetchImpl }));
+    expect(res.status).toBe(404);
+    expect(calls.length).toBe(0);
+  });
+
+  test("refuses /search/anything (no sub-paths)", async () => {
+    const { fetchImpl, calls } = stubFetch(() => Response.json({}));
+    const res = await proxySideband("GET", "/search/all", "", cfg({ fetchImpl }));
+    expect(res.status).toBe(404);
+    expect(calls.length).toBe(0);
+  });
+});

--- a/src/common/sideband/metrics.ts
+++ b/src/common/sideband/metrics.ts
@@ -1,0 +1,248 @@
+/**
+ * Cortex-side response types + request helpers for the sideband v2 reads
+ * (P-14 U4.2, cortex#938) — `/metrics/summary` and `/search`.
+ *
+ * These types are PINNED to signal's contract. Signal's authoritative wire
+ * shapes live in `signal/src/lib/sideband/types.ts`:
+ *   - `SidebandMetricSample`        → {@link SidebandMetricSample}
+ *   - `SidebandLatencyPercentiles`  → {@link SidebandLatencyPercentiles}
+ *   - `SidebandMetricsSummary`      → {@link SidebandMetricsSummary}
+ *   - `MetricsSummaryResponse`      → {@link MetricsSummaryResponse}
+ *   - `SidebandSearchFilter`        → {@link SidebandSearchFilter}
+ *   - `SearchResponse`              → {@link SearchResponse}
+ *   - `SidebandLogRecord`           → {@link SidebandLogRecord}
+ *
+ * Signal's `cortex-sideband.md` is a P-9-era doc that predates the v2 reads
+ * (U4.1 added `/metrics/summary` + `/search` to the SERVER under signal#127/#147
+ * but the markdown spec wasn't refreshed); the contract source-of-truth for
+ * these two endpoints is signal's `types.ts` + `server.ts`, which this module
+ * mirrors. The `SidebandError` envelope is shared verbatim with the P-9 reads
+ * (see `proxy.ts`), so a v2 failure renders through the SAME honest
+ * "interior capture not available" + `deep_link` affordance.
+ *
+ * Pure module: no fetch, no DOM. The fetch path lives in the
+ * `use-obs-metrics` hook so this stays unit-testable in isolation and the
+ * type-pin is enforced at compile time against captured signal fixtures.
+ */
+
+// =============================================================================
+// /metrics/summary — aggregate panels (pinned to signal SidebandMetricsSummary)
+// =============================================================================
+
+/**
+ * One evaluated PromQL series point. `value` is `null` when the underlying
+ * series produced a non-finite result (NaN / +Inf — VictoriaMetrics emits
+ * these for empty histograms); cortex renders `null` as an em-dash.
+ *
+ * Mirrors signal `SidebandMetricSample`.
+ */
+export interface SidebandMetricSample {
+  /** Label set the series carried (e.g. `{ tool: "read" }`). */
+  labels: Record<string, string>;
+  /** Evaluated PromQL value; `null` for NaN / Inf. */
+  value: number | null;
+}
+
+/**
+ * Hook-latency p50 / p95 / p99 of `pai_duration_ms`, in milliseconds. A field
+ * is `null` when the histogram had no samples in the window.
+ *
+ * Mirrors signal `SidebandLatencyPercentiles`.
+ */
+export interface SidebandLatencyPercentiles {
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+}
+
+/**
+ * The signal-overview panels as JSON. Rates are per-second over `window`.
+ *
+ * Mirrors signal `SidebandMetricsSummary`. Metric provenance (signal
+ * `architecture.md` §3.2): `pai_tool_calls_total`, `pai_agent_spawns_total`,
+ * `pai_events_total` (counters → rates), `pai_duration_ms` (histogram → p50/95/99).
+ */
+export interface SidebandMetricsSummary {
+  /** The rate window the panels were evaluated over (e.g. `5m`). */
+  window: string;
+  /** Per-second tool-call rate, broken out by `tool` label. */
+  toolCallRate: SidebandMetricSample[];
+  /** Per-second agent-spawn rate (typically a single point). */
+  agentSpawnRate: SidebandMetricSample[];
+  /** Per-second overall event rate. */
+  eventRate: SidebandMetricSample[];
+  /** Hook-latency p50 / p95 / p99 over the window, milliseconds. */
+  hookLatencyMs: SidebandLatencyPercentiles;
+}
+
+/**
+ * Response body for `GET /metrics/summary`. Mirrors signal `MetricsSummaryResponse`.
+ */
+export interface MetricsSummaryResponse {
+  /** Adapter name (`victoria` only — PromQL is victoria-specific today). */
+  backend: string;
+  /** The rate window applied (echo of the request `window`). */
+  window: string;
+  /** The signal-overview panels. */
+  summary: SidebandMetricsSummary;
+}
+
+// =============================================================================
+// /search — generalized LogsQL filter (pinned to signal SidebandSearchFilter)
+// =============================================================================
+
+/**
+ * A log record subset. Mirrors signal `SidebandLogRecord` (`cortex-sideband.md`
+ * §2.2 / signal `types.ts`). Cortex already mirrors this shape in
+ * `dashboard-v2/lib/sideband-timeline.ts`; re-declared here for the v2 search
+ * surface so `common/sideband` is self-contained (no surface→surface import).
+ */
+export interface SidebandLogRecord {
+  /** Unix-nanos timestamp the record was observed. */
+  timeUnixNano: string;
+  /** Body text — for envelope-tail records, the verbatim envelope JSON. */
+  body: string;
+  /** OTel severity: TRACE / DEBUG / INFO / WARN / ERROR / FATAL / "". */
+  severityText: string;
+  /** Flat attribute bag (underscored keys per envelope-tail §3.1). */
+  attributes: Record<string, string | number | boolean | null>;
+}
+
+/**
+ * Filter set for `GET /search`. Mirrors signal `SidebandSearchFilter`.
+ *
+ * SAFETY: every populated field is interpolated into LogsQL on the SERVER side.
+ * The cortex client validates the same gates BEFORE building the query string
+ * (see {@link buildSearchQuery}) so a malformed value is rejected at the cortex
+ * boundary rather than round-tripping to a server 400 — but the server is the
+ * load-bearing gate regardless (defense in depth).
+ */
+export interface SidebandSearchFilter {
+  /** LogsQL relative time range, e.g. `30m` / `1h` / `30d`. */
+  since?: string;
+  /** Envelope class (segment-4 myelin domain: `dispatch` / `review` / …). */
+  class?: string;
+  /** Free-text substring matched across the record body. */
+  query?: string;
+  /** Max records to return. */
+  limit?: number;
+}
+
+/** Response body for `GET /search`. Mirrors signal `SearchResponse`. */
+export interface SearchResponse {
+  /** Adapter name. */
+  backend: string;
+  /** Echo of the applied filter (post-validation). */
+  filter: SidebandSearchFilter;
+  /** Matching log records, sorted ascending by `timeUnixNano`. */
+  results: SidebandLogRecord[];
+}
+
+// =============================================================================
+// Client-side request helpers (pure — mirror signal's server-side gates)
+// =============================================================================
+
+/**
+ * PromQL / LogsQL duration grammar — one or more `<number><unit>`, units
+ * s/m/h/d/w. IDENTICAL to signal's `DURATION_RE` (server.ts) and
+ * `isValidPromWindow` (victoria.ts). The value is interpolated into a PromQL
+ * range selector / LogsQL `_time:` filter on the server, so this gate is
+ * load-bearing; we apply it client-side so a bad window/since is refused before
+ * the round-trip rather than surfacing as a server 400.
+ */
+const DURATION_RE = /^(\d+[smhdw])+$/;
+
+/** Bare lowercase envelope-class token — mirrors signal's `CLASS_RE`. */
+const CLASS_RE = /^[a-z][a-z0-9_-]*$/;
+
+/** Free-text cap — mirrors signal's `SEARCH_QUERY_MAX`. */
+const SEARCH_QUERY_MAX = 1024;
+
+/** Default aggregate window for the live panels (mirrors signal `DEFAULT_METRICS_WINDOW`). */
+export const DEFAULT_METRICS_WINDOW = "5m";
+
+/**
+ * Window options the aggregate panels offer. `5m` / `1h` / `24h` are the
+ * "live" windows; `30d` is the >14d history window — wider than MC's
+ * 14-day local `observability_events` retention, so it is necessarily sourced
+ * from signal's VictoriaMetrics (which retains far longer), NOT the local
+ * projection. See {@link HISTORY_WINDOW}.
+ */
+export const METRICS_WINDOWS = ["5m", "1h", "24h", "30d"] as const;
+export type MetricsWindow = (typeof METRICS_WINDOWS)[number];
+
+/**
+ * The >14d history window. MC's `observability_events` projection prunes at
+ * 14 days (`OBSERVABILITY_RETENTION_MS = 14 * DAY_MS`, db/retention.ts), so any
+ * "history past 14d" view CANNOT be served from the local projection. This
+ * window is honoured against signal's backend instead: VictoriaMetrics
+ * (aggregate panels) + VictoriaLogs (event rows via `/search`), which retain
+ * 30/90d (cortex#938). Sourcing history here is the honest path the issue calls
+ * for — "history past MC's 7/14d retention (VictoriaLogs holds 30/90d)".
+ */
+export const HISTORY_WINDOW: MetricsWindow = "30d";
+
+/** True iff `window` is a valid PromQL/LogsQL duration. */
+export function isValidDuration(window: string): boolean {
+  return DURATION_RE.test(window);
+}
+
+/**
+ * Build the proxied `/api/observability/metrics/summary` request path for a
+ * given window. Throws on an invalid window (caller pre-validated, but this is
+ * the load-bearing client gate before the interpolated value leaves cortex).
+ */
+export function buildMetricsSummaryPath(window: string): string {
+  if (!isValidDuration(window)) {
+    throw new Error(
+      `invalid metrics window "${window}" — must be a PromQL duration like 5m, 1h, 30d`,
+    );
+  }
+  const qs = new URLSearchParams({ window });
+  return `/api/observability/metrics/summary?${qs.toString()}`;
+}
+
+/**
+ * Build the proxied `/api/observability/search` request path from a filter.
+ * Validates every populated field with the same gates signal's server applies
+ * (DURATION_RE / CLASS_RE / SEARCH_QUERY_MAX / positive-int limit) so a bad
+ * value is refused at the cortex boundary. Throws on any invalid field.
+ */
+export function buildSearchPath(filter: SidebandSearchFilter): string {
+  const qs = new URLSearchParams();
+  if (filter.since !== undefined) {
+    if (!DURATION_RE.test(filter.since)) {
+      throw new Error(
+        `invalid search "since" "${filter.since}" — must be a LogsQL duration like 30m, 1h, 30d`,
+      );
+    }
+    qs.set("since", filter.since);
+  }
+  if (filter.class !== undefined) {
+    if (!CLASS_RE.test(filter.class)) {
+      throw new Error(
+        `invalid search "class" "${filter.class}" — must be a bare lowercase token like dispatch`,
+      );
+    }
+    qs.set("class", filter.class);
+  }
+  if (filter.query !== undefined && filter.query.length > 0) {
+    if (filter.query.length > SEARCH_QUERY_MAX) {
+      throw new Error(`search "query" exceeds ${SEARCH_QUERY_MAX} chars`);
+    }
+    qs.set("query", filter.query);
+  }
+  if (filter.limit !== undefined) {
+    if (!Number.isInteger(filter.limit) || filter.limit < 1) {
+      throw new Error(`invalid search "limit" — must be a positive integer`);
+    }
+    qs.set("limit", String(filter.limit));
+  }
+  const query = qs.toString();
+  return query === ""
+    ? "/api/observability/search"
+    : `/api/observability/search?${query}`;
+}
+
+// Re-export the shared `buildSearchQuery` alias used in docs/tests.
+export { buildSearchPath as buildSearchQuery };

--- a/src/common/sideband/proxy.ts
+++ b/src/common/sideband/proxy.ts
@@ -66,14 +66,27 @@ export const DEFAULT_MAX_BODY_BYTES = 8 * 1024 * 1024;
 
 /**
  * Endpoints the proxy is allowed to forward, expressed as the suffix AFTER the
- * `/api/observability` prefix. The contract's read surface (§2):
- *   GET /traces?correlation_id=…
- *   GET /logs?correlation_id=…
- *   GET /traces/{trace_id}/timeline
- *   GET /healthz
+ * `/api/observability` prefix. The contract's read surface:
+ *   GET /traces?correlation_id=…           (P-9 §2.1)
+ *   GET /logs?correlation_id=…             (P-9 §2.2)
+ *   GET /traces/{trace_id}/timeline        (P-9 §2.3)
+ *   GET /healthz                           (P-9 §2.4)
+ *   GET /metrics/summary?window=…          (P-14 U4.1, signal#127/#147)
+ *   GET /search?since=&class=&query=&limit (P-14 U4.1, signal#127/#147)
  *
  * `traces` and `logs` are exact (query carries the id); `traces/{id}/timeline`
- * is a 3-segment shape validated structurally. Everything else is refused.
+ * is a 3-segment shape validated structurally. The two v2 reads
+ * (`metrics/summary`, `search`) are exact prefixes whose query strings carry
+ * pre-validated params — the SIGNAL server re-validates the `window` / `since`
+ * / `class` / `query` / `limit` gates (server.ts `DURATION_RE` / `CLASS_RE` /
+ * `SEARCH_QUERY_MAX`) before any interpolation into PromQL/LogsQL, so the proxy
+ * forwards the search string verbatim and lets the server own input safety
+ * (same posture as `/traces?correlation_id=` — the proxy gates the PATH, the
+ * sideband gates the PARAMS). Everything else is refused.
+ *
+ * v2 endpoints stay loopback-only and GET-only exactly like the P-9 reads:
+ * `/metrics/summary` wraps VictoriaMetrics and `/search` wraps VictoriaLogs,
+ * both reached through the same tokenless local daemon (contract §3).
  */
 function mapAllowedPath(suffix: string): string | null {
   // Strip a single leading slash for matching.
@@ -82,6 +95,8 @@ function mapAllowedPath(suffix: string): string | null {
   if (s === "traces") return "/traces";
   if (s === "logs") return "/logs";
   if (s === "healthz") return "/healthz";
+  if (s === "metrics/summary") return "/metrics/summary";
+  if (s === "search") return "/search";
 
   // traces/{trace_id}/timeline — exactly 3 segments, middle is the id.
   const segs = s.split("/");

--- a/src/surface/mc/dashboard-v2/__tests__/obs-metrics-panels.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/obs-metrics-panels.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * P-14 U4.2 (#938) — ObsMetricsPanels rendering against captured fixtures.
+ *
+ * SSR-renders the aggregate panels (rates + hook-latency percentiles) and the
+ * >14d history view through `renderToStaticMarkup`, using fixtures captured
+ * verbatim from signal's contract types (SidebandMetricsSummary /
+ * SidebandLogRecord). Pins:
+ *   - REAL numbers render (rates as /s, percentiles as compact durations),
+ *   - a genuinely empty window renders honest empty states (not zeros-as-data),
+ *   - a SidebandError renders "interior capture not available" + the deep_link
+ *     (honest degradation — NOT fabricated panels),
+ *   - the >14d history note states the source honestly (VictoriaLogs past 14d).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { ObsMetricsPanels } from "../components/obs-metrics-panels";
+import type { ObsMetricsState } from "../hooks/use-obs-metrics";
+import type {
+  SidebandLogRecord,
+  SidebandMetricsSummary,
+} from "../../../../common/sideband/metrics";
+
+// Verbatim from signal/src/cli/query-v2.test.ts SUMMARY.
+const SUMMARY: SidebandMetricsSummary = {
+  window: "5m",
+  toolCallRate: [
+    { labels: { tool: "read" }, value: 0.5 },
+    { labels: { tool: "bash" }, value: 0.25 },
+  ],
+  agentSpawnRate: [{ labels: {}, value: 0.1 }],
+  eventRate: [{ labels: {}, value: 1.0 }],
+  hookLatencyMs: { p50: 30, p95: 100, p99: 100 },
+};
+
+const EMPTY_SUMMARY: SidebandMetricsSummary = {
+  window: "5m",
+  toolCallRate: [],
+  agentSpawnRate: [],
+  eventRate: [{ labels: {}, value: null }],
+  hookLatencyMs: { p50: null, p95: null, p99: null },
+};
+
+const HISTORY_ROWS: SidebandLogRecord[] = [
+  {
+    // 2026-05-01 00:00 UTC in unix-nanos.
+    timeUnixNano: "1777593600000000000",
+    body: '{"type":"dispatch.task.received"}',
+    severityText: "INFO",
+    attributes: {
+      envelope_class: "dispatch",
+      envelope_entity: "task",
+      envelope_action: "received",
+    },
+  },
+];
+
+function baseState(over: Partial<ObsMetricsState> = {}): ObsMetricsState {
+  return {
+    summary: { phase: "loading" },
+    window: "5m",
+    setWindow: () => {},
+    history: { phase: "loading" },
+    loadHistory: () => {},
+    ...over,
+  };
+}
+
+function render(state: ObsMetricsState): string {
+  return renderToStaticMarkup(createElement(ObsMetricsPanels, { state }));
+}
+
+describe("ObsMetricsPanels — real numbers from /metrics/summary fixture", () => {
+  it("renders tool/spawn/event rates and latency percentiles", () => {
+    const html = render(baseState({ summary: { phase: "ready", data: SUMMARY } }));
+    // Rates: spawn 0.1/s, event 1.00/s. Per-tool rows.
+    expect(html).toContain("/s");
+    expect(html).toContain("0.100/s"); // spawn rate (toPrecision(3) on sub-1/s)
+    expect(html).toContain("1.00/s"); // event rate (>=1 → 2dp)
+    expect(html).toContain("read");
+    expect(html).toContain("bash");
+    // Distinct tools = 2.
+    expect(html).toContain("Distinct tools");
+    // Latency percentiles rendered (30ms / 100ms via formatDurationCompact).
+    expect(html).toContain("p50");
+    expect(html).toContain("p95");
+    expect(html).toContain("p99");
+  });
+
+  it("renders honest empty states for a genuinely empty window (not zeros)", () => {
+    const html = render(baseState({ summary: { phase: "ready", data: EMPTY_SUMMARY } }));
+    expect(html).toContain("No tool-call activity in this window.");
+    expect(html).toContain("No hook-latency samples in this window.");
+  });
+});
+
+describe("ObsMetricsPanels — honest degradation on SidebandError", () => {
+  it("renders 'interior capture not available' + deep_link, not fabricated panels", () => {
+    const html = render(
+      baseState({
+        summary: {
+          phase: "error",
+          message: "interior capture not available — sideband unreachable",
+          deepLink: "https://grafana.example/d/signal-overview",
+        },
+      }),
+    );
+    expect(html).toContain("interior capture not available");
+    expect(html).toContain("https://grafana.example/d/signal-overview");
+    expect(html).toContain("Open in observability backend");
+    // It did NOT render rate rows.
+    expect(html).not.toContain("Distinct tools");
+  });
+
+  it("renders a loading state before data arrives", () => {
+    const html = render(baseState({ summary: { phase: "loading" } }));
+    expect(html).toContain("Loading metrics…");
+  });
+});
+
+describe("ObsMetricsPanels — >14d history view", () => {
+  it("renders the history CTA + honest source note when collapsed", () => {
+    const html = render(baseState({ summary: { phase: "ready", data: SUMMARY } }));
+    expect(html).toContain("Show history");
+    expect(html).toContain("VictoriaLogs");
+    expect(html).toContain("14-day local retention");
+  });
+});

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -41,6 +41,7 @@ import { useAttention } from "./hooks/use-attention";
 import { useAgents } from "./hooks/use-agents";
 import { useGovernance } from "./hooks/use-governance";
 import { useObservability } from "./hooks/use-observability";
+import { useObsMetrics } from "./hooks/use-obs-metrics";
 import type { AgentPresenceTile } from "./hooks/use-agents";
 import { useWorkItemDetail } from "./hooks/use-work-item-detail";
 import { useTheme } from "./hooks/use-theme";
@@ -134,6 +135,11 @@ export function App() {
   // fetched only when the Observability tab is visible; live-refreshed off the
   // `observability` mc.projection family.
   const observability = useObservability(ws, view === "observability");
+  // P-14 U4.2 (#938) — aggregate metrics panels (tool/spawn/event rates +
+  // hook-latency percentiles via the sideband /metrics/summary) and the >14d
+  // history view (events past MC's 14-day local prune, sourced from signal's
+  // VictoriaLogs via /search). Fetched only when the Observability tab is open.
+  const obsMetrics = useObsMetrics(view === "observability");
   // If software mode is toggled OFF while on a software-mode view (Repositories
   // / Plans / phase-detail / work-item-detail / attention), the tab + render
   // both gate off — reset to default so the main area isn't left blank.
@@ -574,7 +580,7 @@ export function App() {
              signal health / federation / transport. Federation + transport are
              hub-emitted; a non-hub stack shows an honest explanatory empty
              state (roster arrives via U3.3), never synthesized data. */
-          <ObservabilityView state={observability} />
+          <ObservabilityView state={observability} metrics={obsMetrics} />
         )}
 
         {view === "network" && (

--- a/src/surface/mc/dashboard-v2/components/obs-metrics-panels.css
+++ b/src/surface/mc/dashboard-v2/components/obs-metrics-panels.css
@@ -1,0 +1,125 @@
+/* P-14 U4.2 (#938) — Observability aggregate-metrics panels + >14d history.
+ *
+ * Layers on metrics-panel.css (shared F-18 tokens: .metrics-section,
+ * .metrics-bignums, .metrics-window, .metrics-empty, .metrics-loading). This
+ * file adds only the obs-specific rules: the header, the rate/history tables,
+ * the honest "unavailable" line, and the 3-up latency grid override.
+ */
+
+.obs-metrics-panels {
+  gap: 14px;
+}
+
+.obs-metrics-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.obs-metrics-header h3 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+
+/* 3-up latency grid (override the F-18 4-up default). */
+.metrics-bignums-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+/* ---- Rate + history tables ---- */
+.obs-metrics-rates,
+.obs-metrics-history {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+  margin-top: 10px;
+}
+.obs-metrics-rates th,
+.obs-metrics-history th {
+  text-align: left;
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--line);
+}
+.obs-metrics-rates td,
+.obs-metrics-history td {
+  padding: 7px 8px;
+  border-bottom: 1px solid var(--line);
+  font-variant-numeric: tabular-nums;
+}
+.obs-metrics-rates tr:last-child td,
+.obs-metrics-history tr:last-child td {
+  border-bottom: 0;
+}
+.obs-metrics-rates .num,
+.obs-metrics-history .num {
+  text-align: right;
+}
+.obs-metrics-rates .mono,
+.obs-metrics-history .mono {
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.obs-metrics-history .dim {
+  color: var(--fg-dim);
+}
+
+/* ---- Honest "interior capture not available" line ---- */
+.obs-metrics-unavailable {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--fg-faint);
+  font-size: 12px;
+  font-style: italic;
+  padding: 8px 0;
+}
+.obs-metrics-unavailable a {
+  color: var(--accent, #4f8cff);
+  font-style: normal;
+  text-decoration: none;
+}
+.obs-metrics-unavailable a:hover {
+  text-decoration: underline;
+}
+
+/* ---- History note + controls ---- */
+.obs-metrics-note {
+  font-size: 11px;
+  color: var(--fg-faint);
+}
+.obs-metrics-note code {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 10.5px;
+}
+
+.obs-metrics-refresh,
+.obs-metrics-open-history {
+  appearance: none;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 11px;
+  color: var(--fg-dim);
+  cursor: pointer;
+}
+.obs-metrics-refresh:hover,
+.obs-metrics-open-history:hover {
+  color: var(--fg);
+}
+
+.obs-metrics-history-cta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}

--- a/src/surface/mc/dashboard-v2/components/obs-metrics-panels.tsx
+++ b/src/surface/mc/dashboard-v2/components/obs-metrics-panels.tsx
@@ -1,0 +1,300 @@
+/**
+ * P-14 U4.2 (#938) — Observability aggregate-metrics panels + >14d history view.
+ *
+ * Renders REAL aggregate numbers sourced via the sideband `/metrics/summary`
+ * (PromQL over VictoriaMetrics), proxied per U0.1:
+ *   1. **Rates** — per-second tool-call rate (by tool), agent-spawn rate, and
+ *      overall event rate, evaluated over the selected window.
+ *   2. **Hook latency** — p50 / p95 / p99 of `pai_duration_ms`, in ms.
+ *   3. **>14d history** — events past MC's 14-day local projection prune, sourced
+ *      from VictoriaLogs via `/search?since=30d`. This is the HONEST source: the
+ *      local `observability_events` table prunes at 14 days
+ *      (`OBSERVABILITY_RETENTION_MS`), so anything older necessarily comes from
+ *      signal's backend (VictoriaLogs holds 30/90d — cortex#938).
+ *
+ * No chart library — flexbox + plain tables, mirroring the F-18 `metrics-panel`
+ * design language (reuses `metrics-panel.css` tokens; this file adds only the
+ * obs-specific rate-table + history-table rules).
+ *
+ * Honest degradation: a `SidebandError` (no running stack, backend down) renders
+ * an "interior capture not available" line + the `deep_link` exit, NOT fabricated
+ * zeros. A genuinely empty window renders real empty panels.
+ */
+
+import { useState } from "react";
+import "./metrics-panel.css";
+import "./obs-metrics-panels.css";
+import { formatDurationCompact } from "../../../../shared/format-utils";
+import {
+  HISTORY_WINDOW,
+  METRICS_WINDOWS,
+  type SidebandLogRecord,
+  type SidebandMetricSample,
+  type SidebandMetricsSummary,
+} from "../../../../common/sideband/metrics";
+import type { ObsMetricsState, ObsMetricsLoad } from "../hooks/use-obs-metrics";
+
+/** Per-second rate → a compact human string. `null` → em-dash. */
+function rate(value: number | null): string {
+  if (value === null) return "—";
+  if (value === 0) return "0/s";
+  // Sub-1/s rates: show 3 sig-figs; ≥1/s: 2 decimals.
+  return value < 1 ? `${value.toPrecision(3)}/s` : `${value.toFixed(2)}/s`;
+}
+
+/** p50/95/99 ms → compact duration (reuses the F-18 formatter). `null` → em-dash. */
+function ms(value: number | null): string {
+  return value === null ? "—" : formatDurationCompact(value);
+}
+
+/** A single labelled metric series → a display label (`tool=read` → `read`). */
+function sampleLabel(s: SidebandMetricSample): string {
+  const keys = Object.keys(s.labels);
+  if (keys.length === 0) return "(all)";
+  return keys.map((k) => s.labels[k]).join(" · ");
+}
+
+function ErrorLine({ message, deepLink }: { message: string; deepLink?: string }) {
+  return (
+    <div className="obs-metrics-unavailable">
+      <span>{message}</span>
+      {deepLink ? (
+        <a href={deepLink} target="_blank" rel="noreferrer noopener">
+          Open in observability backend ↗
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+function WindowSelector({
+  window,
+  setWindow,
+}: {
+  window: string;
+  setWindow: (w: string) => void;
+}) {
+  return (
+    <span className="metrics-window" role="tablist" aria-label="Metrics window">
+      {METRICS_WINDOWS.map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          role="tab"
+          aria-selected={window === opt}
+          className={window === opt ? "active" : ""}
+          onClick={() => setWindow(opt)}
+        >
+          {opt}
+        </button>
+      ))}
+    </span>
+  );
+}
+
+function RatesSection({ summary }: { summary: SidebandMetricsSummary }) {
+  const spawn = summary.agentSpawnRate[0]?.value ?? null;
+  const event = summary.eventRate[0]?.value ?? null;
+  return (
+    <div className="metrics-section">
+      <h2>Rates (per second, over {summary.window})</h2>
+      <div className="metrics-bignums">
+        <div className="metrics-bignum">
+          <div className="label">Agent spawns</div>
+          <div className="value">{rate(spawn)}</div>
+        </div>
+        <div className="metrics-bignum">
+          <div className="label">Events</div>
+          <div className="value">{rate(event)}</div>
+        </div>
+        <div className="metrics-bignum">
+          <div className="label">Tools (total)</div>
+          <div className="value">
+            {rate(
+              summary.toolCallRate.length === 0
+                ? 0
+                : summary.toolCallRate.reduce((acc, s) => acc + (s.value ?? 0), 0),
+            )}
+          </div>
+        </div>
+        <div className="metrics-bignum">
+          <div className="label">Distinct tools</div>
+          <div className="value">{summary.toolCallRate.length}</div>
+        </div>
+      </div>
+
+      {summary.toolCallRate.length === 0 ? (
+        <div className="metrics-empty">No tool-call activity in this window.</div>
+      ) : (
+        <table className="obs-metrics-rates">
+          <thead>
+            <tr>
+              <th>Tool</th>
+              <th className="num">Rate</th>
+            </tr>
+          </thead>
+          <tbody>
+            {summary.toolCallRate
+              .slice()
+              .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
+              .map((s) => (
+                <tr key={sampleLabel(s)}>
+                  <td className="mono">{sampleLabel(s)}</td>
+                  <td className="num">{rate(s.value)}</td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function LatencySection({ summary }: { summary: SidebandMetricsSummary }) {
+  const { p50, p95, p99 } = summary.hookLatencyMs;
+  const allNull = p50 === null && p95 === null && p99 === null;
+  return (
+    <div className="metrics-section">
+      <h2>Hook latency (over {summary.window})</h2>
+      {allNull ? (
+        <div className="metrics-empty">No hook-latency samples in this window.</div>
+      ) : (
+        <div className="metrics-bignums metrics-bignums-3">
+          <div className="metrics-bignum">
+            <div className="label">p50</div>
+            <div className="value">{ms(p50)}</div>
+          </div>
+          <div className="metrics-bignum">
+            <div className="label">p95</div>
+            <div className="value">{ms(p95)}</div>
+          </div>
+          <div className="metrics-bignum">
+            <div className="label">p99</div>
+            <div className="value">{ms(p99)}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function nanoToWhen(timeUnixNano: string): string {
+  // Unix-nanos → 'YYYY-MM-DD HH:MM'. BigInt-safe for the ms division.
+  const ms = Number(BigInt(timeUnixNano) / 1_000_000n);
+  if (!Number.isFinite(ms)) return "—";
+  return new Date(ms).toISOString().replace("T", " ").slice(0, 16);
+}
+
+function envelopeType(r: SidebandLogRecord): string {
+  const cls = r.attributes["envelope_class"];
+  const entity = r.attributes["envelope_entity"];
+  const action = r.attributes["envelope_action"];
+  const parts = [cls, entity, action].filter((p) => typeof p === "string" && p !== "");
+  return parts.length > 0 ? parts.join(".") : (r.severityText || "log");
+}
+
+function HistorySection({
+  history,
+  onLoad,
+}: {
+  history: ObsMetricsLoad<SidebandLogRecord[]>;
+  onLoad: () => void;
+}) {
+  return (
+    <div className="metrics-section">
+      <h2>
+        History (&gt;14d)
+        <button type="button" className="obs-metrics-refresh" onClick={onLoad}>
+          Load {HISTORY_WINDOW}
+        </button>
+      </h2>
+      <p className="obs-metrics-note">
+        MC&rsquo;s local projection retains 14 days; this view sources older
+        events from signal&rsquo;s VictoriaLogs (30/90d) via the sideband
+        <code> /search</code>.
+      </p>
+      {history.phase === "loading" ? (
+        <div className="metrics-loading">Loading history…</div>
+      ) : history.phase === "error" ? (
+        <ErrorLine message={history.message} deepLink={history.deepLink} />
+      ) : history.data.length === 0 ? (
+        <div className="metrics-empty">
+          No events in the history window (nothing retained past 14d, or the
+          window is genuinely empty).
+        </div>
+      ) : (
+        <table className="obs-metrics-history">
+          <thead>
+            <tr>
+              <th>When</th>
+              <th>Type</th>
+              <th>Severity</th>
+            </tr>
+          </thead>
+          <tbody>
+            {history.data.map((r, i) => (
+              <tr key={`${r.timeUnixNano}-${i}`}>
+                <td className="mono dim">{nanoToWhen(r.timeUnixNano)}</td>
+                <td className="mono">{envelopeType(r)}</td>
+                <td className="dim">{r.severityText || "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export interface ObsMetricsPanelsProps {
+  state: ObsMetricsState;
+}
+
+export function ObsMetricsPanels({ state }: ObsMetricsPanelsProps) {
+  const { summary, window, setWindow, history, loadHistory } = state;
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  return (
+    <div className="metrics-panel obs-metrics-panels">
+      <div className="obs-metrics-header">
+        <h3>Aggregate metrics</h3>
+        <WindowSelector window={window} setWindow={setWindow} />
+      </div>
+
+      {summary.phase === "loading" ? (
+        <div className="metrics-loading">Loading metrics…</div>
+      ) : summary.phase === "error" ? (
+        <ErrorLine message={summary.message} deepLink={summary.deepLink} />
+      ) : (
+        <>
+          <RatesSection summary={summary.data} />
+          <LatencySection summary={summary.data} />
+        </>
+      )}
+
+      {historyOpen ? (
+        <HistorySection
+          history={history}
+          onLoad={() => loadHistory()}
+        />
+      ) : (
+        <div className="metrics-section obs-metrics-history-cta">
+          <button
+            type="button"
+            className="obs-metrics-open-history"
+            onClick={() => {
+              setHistoryOpen(true);
+              loadHistory();
+            }}
+          >
+            Show history &gt;14d
+          </button>
+          <span className="obs-metrics-note">
+            Sourced from signal&rsquo;s backend (VictoriaLogs/VictoriaMetrics),
+            beyond MC&rsquo;s 14-day local retention.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/observability-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/observability-view.tsx
@@ -18,6 +18,8 @@
  */
 
 import type { ObservabilityState } from "../hooks/use-observability";
+import type { ObsMetricsState } from "../hooks/use-obs-metrics";
+import { ObsMetricsPanels } from "./obs-metrics-panels";
 import type { ObservabilityEventRow } from "../../db/observability";
 
 function when(ts: string): string {
@@ -72,15 +74,29 @@ function Section({ title, rows, count, emptyNote }: SectionProps) {
 
 export interface ObservabilityViewProps {
   state: ObservabilityState;
+  /**
+   * Aggregate-metrics + >14d-history state (P-14 U4.2, #938). Optional so the
+   * tab still renders its U2.1 event sections if the panels aren't wired (e.g.
+   * a test that only exercises the event projection).
+   */
+  metrics?: ObsMetricsState;
 }
 
-export function ObservabilityView({ state }: ObservabilityViewProps) {
+export function ObservabilityView({ state, metrics }: ObservabilityViewProps) {
   const { data, loaded, error } = state;
+
+  // Aggregate panels + >14d history are sourced INDEPENDENTLY of the event
+  // projection (sideband /metrics/summary + /search vs the local
+  // observability_events table). Render them whenever wired, even if the event
+  // sections below are still loading or errored — the two have distinct
+  // sources and distinct failure modes (P-14 U4.2, #938).
+  const panels = metrics ? <ObsMetricsPanels state={metrics} /> : null;
 
   if (!loaded) {
     return (
       <section className="scaffold-section observability-view" aria-label="Observability">
         <h2>Observability</h2>
+        {panels}
         <p className="dim">Loading…</p>
       </section>
     );
@@ -90,6 +106,7 @@ export function ObservabilityView({ state }: ObservabilityViewProps) {
     return (
       <section className="scaffold-section observability-view" aria-label="Observability">
         <h2>Observability</h2>
+        {panels}
         <p className="dim">Could not load observability events: {error ?? "no data"}.</p>
       </section>
     );
@@ -104,6 +121,8 @@ export function ObservabilityView({ state }: ObservabilityViewProps) {
   return (
     <section className="scaffold-section observability-view" aria-label="Observability">
       <h2>Observability</h2>
+
+      {panels}
 
       <Section
         title="Signal health"

--- a/src/surface/mc/dashboard-v2/hooks/use-obs-metrics.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-obs-metrics.ts
@@ -1,0 +1,199 @@
+/**
+ * P-14 U4.2 (#938) — Observability aggregate-metrics hook.
+ *
+ * Fetches the sideband v2 reads through U0.1's server-side proxy:
+ *   - `GET /api/observability/metrics/summary?window=…`  → aggregate panels
+ *     (tool/spawn/event rates + hook-latency p50/p95/p99) from VictoriaMetrics.
+ *   - `GET /api/observability/search?since=30d&…`        → >14d event history
+ *     from VictoriaLogs (past MC's 14-day local projection prune).
+ *
+ * Both paths degrade HONESTLY on a `SidebandError`: the same envelope (with its
+ * optional `deep_link`) the P-9 reads carry, surfaced as "interior capture not
+ * available" rather than fabricated zeros — distinct from a genuinely empty
+ * window, which renders real empty panels. The browser only ever talks to MC
+ * (same origin); MC proxies to the loopback sideband (`127.0.0.1:9092`).
+ *
+ * Only fetches when `enabled` (the Observability tab is visible). Changing the
+ * `window` refetches the aggregate panels; the history view refetches on its
+ * own toggle. Mirrors the boot/gen/alive discipline of `use-observability`.
+ *
+ * Live-oracle note: the real values come from a running signal stack
+ * (VictoriaMetrics + VictoriaLogs reached via the sideband). Without the live
+ * stack the proxy returns a `backend_unavailable` SidebandError, which this
+ * hook renders honestly. The client→proxy wiring + panel rendering are unit-
+ * tested against captured fixtures; the live path is wired end-to-end.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  buildMetricsSummaryPath,
+  buildSearchPath,
+  DEFAULT_METRICS_WINDOW,
+  type MetricsSummaryResponse,
+  type SearchResponse,
+  type SidebandLogRecord,
+  type SidebandMetricsSummary,
+  type SidebandSearchFilter,
+} from "../../../../common/sideband/metrics";
+import type { SidebandError } from "../../../../common/sideband/proxy";
+
+/** A loaded-or-failed result, preserving the SidebandError for honest rendering. */
+export type ObsMetricsLoad<T> =
+  | { phase: "loading" }
+  | { phase: "ready"; data: T }
+  | { phase: "error"; message: string; deepLink?: string };
+
+export interface ObsMetricsState {
+  /** Aggregate panels for the currently-selected `window`. */
+  summary: ObsMetricsLoad<SidebandMetricsSummary>;
+  /** The selected aggregate window. */
+  window: string;
+  setWindow: (w: string) => void;
+  /** >14d event history (lazy — only loaded once the history view is opened). */
+  history: ObsMetricsLoad<SidebandLogRecord[]>;
+  /** Open/refresh the >14d history view (sourced from VictoriaLogs via /search). */
+  loadHistory: (filter?: SidebandSearchFilter) => void;
+}
+
+/** Default history filter — events past the 14-day local prune, capped. */
+const DEFAULT_HISTORY_FILTER: SidebandSearchFilter = { since: "30d", limit: 200 };
+
+/**
+ * Parse a non-2xx proxy response into a `SidebandError`. The proxy always
+ * returns the contract error shape (never a 500 splat), but a transport-level
+ * failure reaching MC itself can still happen — fall back to a generic honest
+ * label in that case.
+ */
+async function readSidebandError(resp: Response): Promise<SidebandError> {
+  try {
+    const body = (await resp.json()) as Partial<SidebandError>;
+    if (body && typeof body.code === "string" && typeof body.message === "string") {
+      return body as SidebandError;
+    }
+  } catch {
+    // fall through
+  }
+  return {
+    code: "backend_unavailable",
+    message: "interior capture not available — sideband returned an unexpected response",
+  };
+}
+
+function errorLoad<T>(err: SidebandError): ObsMetricsLoad<T> {
+  const next: ObsMetricsLoad<T> = { phase: "error", message: err.message };
+  if (err.deep_link) (next as { deepLink?: string }).deepLink = err.deep_link;
+  return next;
+}
+
+export function useObsMetrics(enabled: boolean): ObsMetricsState {
+  const [summary, setSummary] = useState<ObsMetricsLoad<SidebandMetricsSummary>>({
+    phase: "loading",
+  });
+  const [window, setWindowState] = useState<string>(DEFAULT_METRICS_WINDOW);
+  const [history, setHistory] = useState<ObsMetricsLoad<SidebandLogRecord[]>>({
+    phase: "loading",
+  });
+
+  const aliveRef = useRef(true);
+  const summaryGenRef = useRef(0);
+  const historyGenRef = useRef(0);
+  const historyRequestedRef = useRef(false);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const fetchSummary = useCallback(async (w: string) => {
+    const gen = ++summaryGenRef.current;
+    setSummary({ phase: "loading" });
+    let path: string;
+    try {
+      path = buildMetricsSummaryPath(w);
+    } catch (e) {
+      if (!aliveRef.current || gen !== summaryGenRef.current) return;
+      setSummary({ phase: "error", message: e instanceof Error ? e.message : String(e) });
+      return;
+    }
+    try {
+      const resp = await fetch(path, { headers: { accept: "application/json" } });
+      if (!aliveRef.current || gen !== summaryGenRef.current) return;
+      if (!resp.ok) {
+        setSummary(errorLoad(await readSidebandError(resp)));
+        return;
+      }
+      const body = (await resp.json()) as MetricsSummaryResponse;
+      if (!aliveRef.current || gen !== summaryGenRef.current) return;
+      setSummary({ phase: "ready", data: body.summary });
+    } catch {
+      if (!aliveRef.current || gen !== summaryGenRef.current) return;
+      setSummary(
+        errorLoad({
+          code: "backend_unavailable",
+          message:
+            "interior capture not available — could not reach Mission Control for metrics",
+        }),
+      );
+    }
+  }, []);
+
+  const fetchHistory = useCallback(async (filter: SidebandSearchFilter) => {
+    const gen = ++historyGenRef.current;
+    setHistory({ phase: "loading" });
+    let path: string;
+    try {
+      path = buildSearchPath(filter);
+    } catch (e) {
+      if (!aliveRef.current || gen !== historyGenRef.current) return;
+      setHistory({ phase: "error", message: e instanceof Error ? e.message : String(e) });
+      return;
+    }
+    try {
+      const resp = await fetch(path, { headers: { accept: "application/json" } });
+      if (!aliveRef.current || gen !== historyGenRef.current) return;
+      if (!resp.ok) {
+        setHistory(errorLoad(await readSidebandError(resp)));
+        return;
+      }
+      const body = (await resp.json()) as SearchResponse;
+      if (!aliveRef.current || gen !== historyGenRef.current) return;
+      setHistory({ phase: "ready", data: body.results });
+    } catch {
+      if (!aliveRef.current || gen !== historyGenRef.current) return;
+      setHistory(
+        errorLoad({
+          code: "backend_unavailable",
+          message:
+            "interior capture not available — could not reach Mission Control for history",
+        }),
+      );
+    }
+  }, []);
+
+  // Aggregate panels: fetch on enable + whenever the window changes.
+  useEffect(() => {
+    if (!enabled) return;
+    void fetchSummary(window);
+  }, [enabled, window, fetchSummary]);
+
+  // History is lazy: only fetch once the operator opens the >14d view, and
+  // refetch on enable thereafter (so reopening the tab re-reads it).
+  useEffect(() => {
+    if (!enabled || !historyRequestedRef.current) return;
+    void fetchHistory(DEFAULT_HISTORY_FILTER);
+  }, [enabled, fetchHistory]);
+
+  const setWindow = useCallback((w: string) => setWindowState(w), []);
+
+  const loadHistory = useCallback(
+    (filter?: SidebandSearchFilter) => {
+      historyRequestedRef.current = true;
+      void fetchHistory(filter ?? DEFAULT_HISTORY_FILTER);
+    },
+    [fetchHistory],
+  );
+
+  return { summary, window, setWindow, history, loadHistory };
+}

--- a/src/surface/mc/worker/src/__tests__/observability.test.ts
+++ b/src/surface/mc/worker/src/__tests__/observability.test.ts
@@ -42,4 +42,27 @@ describe("cloud worker /api/observability/* — local-only parity", () => {
     const body = await res.json();
     expect(body.deep_link).toBeUndefined();
   });
+
+  // P-14 U4.2 (#938) — the v2 reads (/metrics/summary, /search) wrap the SAME
+  // loopback-only daemon (VictoriaMetrics / VictoriaLogs), so the cloud worker
+  // is just as unable to reach them; the catch-all returns the honest
+  // not-available shape for these too (no fabricated aggregate panels on cloud).
+  it("returns the SAME shape for /metrics/summary (v2 aggregate panels)", async () => {
+    const res = await observabilityRoutes.request(
+      "http://x/api/observability/metrics/summary?window=5m",
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe("backend_unavailable");
+    expect(body.message).toContain("local-only");
+    expect(body.deep_link).toBeUndefined();
+  });
+
+  it("returns the SAME shape for /search (v2 >14d history)", async () => {
+    const res = await observabilityRoutes.request(
+      "http://x/api/observability/search?since=30d",
+    );
+    expect(res.status).toBe(503);
+    expect((await res.json()).code).toBe("backend_unavailable");
+  });
 });


### PR DESCRIPTION
## What

Extends the just-merged U2.1 Observability tab (#934) with **(a) aggregate metrics panels** and **(b) a >14d history view**, sourced via signal's sideband v2 reads (`/metrics/summary` + `/search`, signal U4.1 #147), proxied per U0.1 (#931).

### Panels (`obs-metrics-panels.tsx`)
- **Rates** — per-second tool-call rate (broken out by tool), agent-spawn rate, overall event rate, over a selectable window (`5m` / `1h` / `24h` / `30d`).
- **Hook latency** — p50 / p95 / p99 of `pai_duration_ms`, in ms.
- **>14d history** — events past MC's 14-day local prune, from VictoriaLogs via `/search?since=30d`.

All numbers are REAL — sourced from VictoriaMetrics/VictoriaLogs through the sideband. A genuinely empty window renders honest empty states; a `SidebandError` (no running stack, backend down) renders "interior capture not available" + the backend `deep_link`, never fabricated zeros.

## Sideband client + proxy extension for `/metrics/summary`
- **Proxy** (`src/common/sideband/proxy.ts`): `mapAllowedPath` now allowlists the two v2 reads (`/metrics/summary`, `/search`). Loopback re-enforcement, GET-only, tokenless-header hygiene, structured-error relay, body cap, and reverse-proxy-prefix preservation all carry over unchanged (they are reads on the same loopback daemon).
- **Response type pinned to signal's contract** (`src/common/sideband/metrics.ts`): cortex-side `SidebandMetricsSummary` / `MetricsSummaryResponse` / `SidebandSearchFilter` / `SearchResponse` / `SidebandLogRecord`, mirrored from signal's authoritative `src/lib/sideband/types.ts` + `server.ts`. (Note: signal's `cortex-sideband.md` is a P-9-era doc that predates these v2 endpoints — U4.1 added them to the *server* under signal#127/#147 but the markdown spec wasn't refreshed, so the type-pin tracks signal's `types.ts`, verified by a captured-fixture test.) Client request builders re-apply signal's server-side gates client-side (DURATION_RE / CLASS_RE / SEARCH_QUERY_MAX / positive-int limit).

## How >14d history is actually sourced
MC's local `observability_events` projection prunes at **exactly 14 days** (`OBSERVABILITY_RETENTION_MS = 14 * DAY_MS`, `db/retention.ts`). A >14d history view therefore **cannot** be served from the local projection — it is sourced from signal's backend, which retains 30/90d (per #938):
- **Event rows** past 14d → VictoriaLogs via `/search?since=30d`.
- **Wide-window aggregates** → VictoriaMetrics via `/metrics/summary?window=30d` (a rate/percentile computed over a 30-day window, not a per-row time series).

This is stated honestly in the UI (the history section names VictoriaLogs/VictoriaMetrics as the source and notes the 14-day local boundary).

## Cloud worker parity
The cloud worker's `/api/observability/*` catch-all already returns the honest not-available `SidebandError` (the sideband is loopback-only and unreachable from the edge). The v2 reads inherit that; added parity tests pinning `/metrics/summary` + `/search` to the same shape.

## Files touched
- `src/common/sideband/proxy.ts` (M) — v2 allowlist
- `src/common/sideband/metrics.ts` (NEW) — types + builders pinned to signal
- `src/common/sideband/__tests__/proxy-v2.test.ts` (NEW)
- `src/common/sideband/__tests__/metrics.test.ts` (NEW)
- `src/surface/mc/dashboard-v2/hooks/use-obs-metrics.ts` (NEW)
- `src/surface/mc/dashboard-v2/components/obs-metrics-panels.tsx` + `.css` (NEW)
- `src/surface/mc/dashboard-v2/components/observability-view.tsx` (M) — **collision point with U2.3 + Session A**
- `src/surface/mc/dashboard-v2/app.tsx` (M) — **collision point with U2.3 + Session A** (added `useObsMetrics` + passes `metrics` into `ObservabilityView`)
- `src/surface/mc/dashboard-v2/__tests__/obs-metrics-panels.test.tsx` (NEW)
- `src/surface/mc/worker/src/__tests__/observability.test.ts` (M) — v2 cloud parity tests

## Gate
- `bunx tsc --noEmit` → **0 errors**
- `bun test src/surface/mc/ src/common/sideband/` → **1899 pass / 0 fail / 1 skip**
- `eslint .` → **0 errors** (changed lintable files clean; dashboard-v2 surface is project-eslint-ignored by design, covered by tsc)

## Honest gaps (stretch unit)
The live oracle (panels showing real VictoriaMetrics values end-to-end) needs the live signal stack (VictoriaMetrics + VictoriaLogs + sideband daemon), which can't run here. The client→proxy wiring and panel rendering are unit-tested against fixtures captured verbatim from signal's contract tests, and the real path is wired through `/api/observability/metrics/summary` + `/search`. Without the stack the proxy returns a `backend_unavailable` SidebandError, which the panels render honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)