### PR TITLE
feat(mc): U2.3 — Network-view transport overlay (leaf liveness/RTT/verdicts) (#935)

### DIFF
--- a/src/surface/mc/__tests__/observability-db.test.ts
+++ b/src/surface/mc/__tests__/observability-db.test.ts
@@ -16,6 +16,7 @@ import { SCHEMA_SQL } from "../db/schema";
 import {
   insertObservabilityEvent,
   listObservabilityEvents,
+  listTransportRosterEvents,
   countObservabilityByFamily,
 } from "../db/observability";
 import {
@@ -104,5 +105,52 @@ describe("pruneOldObservability — age-based retention", () => {
     const summary = pruneRetention(db);
     expect(summary.ok).toBe(true);
     expect(summary.prunedObservability).toBe(1);
+  });
+});
+
+describe("listTransportRosterEvents (P-14 U2.3) — payload-bearing transport read", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("returns ONLY transport-family rows, newest first, WITH parsed payload", () => {
+    insertObservabilityEvent(db, {
+      envelopeId: "sig", family: "signal", type: "system.signal.received",
+      payload: { n: 1 }, timestamp: "2026-06-01T00:00:00.000Z",
+    });
+    insertObservabilityEvent(db, {
+      envelopeId: "t1", family: "transport", type: "system.transport.liveness_drift",
+      payload: { action: "liveness_drift", network: "net", attributes: { peer: "jc/default", to: "connected" } },
+      timestamp: "2026-06-02T00:00:00.000Z",
+    });
+    insertObservabilityEvent(db, {
+      envelopeId: "t2", family: "transport", type: "system.transport.leaf_connect",
+      payload: { action: "leaf_connect", network: "net", leaf: { principal: "jc", stack: "default", network: "net", rtt_ms: 8.4 } },
+      timestamp: "2026-06-03T00:00:00.000Z",
+    });
+
+    const rows = listTransportRosterEvents(db, 50);
+    expect(rows.length).toBe(2); // signal row excluded
+    expect(rows[0]!.type).toBe("system.transport.leaf_connect"); // newest first
+    // The payload round-trips back to an object (NOT stripped like the tab read).
+    expect((rows[0]!.payload.leaf as Record<string, unknown>).rtt_ms).toBe(8.4);
+    expect((rows[1]!.payload.attributes as Record<string, unknown>).to).toBe("connected");
+  });
+
+  it("degrades a poison payload to {} without throwing", () => {
+    // Force a non-JSON payload directly (the insert path always JSON-stringifies,
+    // so write a raw bad value to exercise the parse guard).
+    db.query(
+      `INSERT INTO observability_events (id, envelope_id, family, type, payload, timestamp)
+       VALUES (?, ?, 'transport', 'system.transport.roster_snapshot', '{not json', datetime('now'))`,
+    ).run(crypto.randomUUID(), "poison");
+    const rows = listTransportRosterEvents(db, 10);
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.payload).toEqual({});
+  });
+
+  it("is empty on a non-hub stack (no transport rows)", () => {
+    insertObservabilityEvent(db, { envelopeId: "sig", family: "signal", type: "system.signal.received", payload: {} });
+    expect(listTransportRosterEvents(db, 10)).toEqual([]);
   });
 });

--- a/src/surface/mc/api/observability-tab.ts
+++ b/src/surface/mc/api/observability-tab.ts
@@ -16,12 +16,18 @@ import type { Database } from "bun:sqlite";
 
 import {
   listObservabilityEvents,
+  listTransportRosterEvents,
   countObservabilityByFamily,
   OBSERVABILITY_FAMILIES,
   type ObservabilityEventRow,
+  type TransportRosterEventRow,
   type ObservabilityCounts,
   type ObservabilityFamily,
 } from "../db/observability";
+
+// Re-export so consumers (the Network-view transport overlay) can name the row
+// type off the API response module without reaching into db/observability.ts.
+export type { TransportRosterEventRow } from "../db/observability";
 
 /** Per-family cap on rows returned to the tab. */
 export const OBSERVABILITY_LIST_CAP = 200;
@@ -31,6 +37,14 @@ export interface ObservabilityResponse {
   byFamily: Record<ObservabilityFamily, ObservabilityEventRow[]>;
   /** Per-family total row counts (a zero-row family is present with 0). */
   counts: Record<ObservabilityFamily, number>;
+  /**
+   * P-14 U2.3 (#935) — the transport-family rows WITH parsed payloads, for the
+   * Network-view transport overlay (leaf liveness/RTT + intent⋈reality verdicts).
+   * The summary table above carries the same rows payload-stripped; this is the
+   * verdict-bearing projection the overlay folds. Empty on a non-hub stack (no
+   * transport rows), which the overlay renders as "no transport observations".
+   */
+  transportRoster: TransportRosterEventRow[];
   listCap: number;
 }
 
@@ -42,7 +56,8 @@ export function getObservability(db: Database): ObservabilityResponse {
     byFamily[family] = listObservabilityEvents(db, OBSERVABILITY_LIST_CAP, family);
     counts[family] = rawCounts[family] ?? 0;
   }
-  return { byFamily, counts, listCap: OBSERVABILITY_LIST_CAP };
+  const transportRoster = listTransportRosterEvents(db, OBSERVABILITY_LIST_CAP);
+  return { byFamily, counts, transportRoster, listCap: OBSERVABILITY_LIST_CAP };
 }
 
 /** GET /api/observability-events — per-section rows + counts for the tab. */

--- a/src/surface/mc/dashboard-v2/__tests__/network-filter-bar.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-filter-bar.test.tsx
@@ -22,6 +22,7 @@ function render(over: Partial<NetworkFilterBarProps> = {}): string {
     onStateChange: () => {},
     onCapabilityChange: () => {},
     onScopeChange: () => {},
+    onTransportOverlayChange: () => {},
     onClear: () => {},
     onOpenSpotlight: () => {},
     ...over,
@@ -117,6 +118,32 @@ describe("NetworkFilterBar — clear affordance (G-1114.D.5)", () => {
   it("shows Clear when a capability filter is active", () => {
     const html = render({ filter: { state: "all", capability: "moderate", scope: "include-federated" } });
     expect(html).toContain("network-filter-clear");
+  });
+});
+
+describe("NetworkFilterBar — transport overlay toggle (P-14 U2.3)", () => {
+  it("renders the toggle, off by default", () => {
+    const html = render();
+    expect(html).toContain('data-transport-overlay="off"');
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain("Overlay off");
+  });
+
+  it("marks the toggle pressed + on when the overlay is enabled", () => {
+    const html = render({
+      filter: { state: "all", capability: null, scope: "include-federated", transportOverlay: true },
+    });
+    expect(html).toContain('aria-pressed="true" data-transport-overlay="on"');
+    expect(html).toContain("Overlay on");
+  });
+
+  it("does NOT count the overlay toggle as an agent filter (no Clear from it alone)", () => {
+    // The overlay is a render lens, not an agent predicate — toggling it on must
+    // not surface the Clear affordance (which is for agent-narrowing filters).
+    const html = render({
+      filter: { state: "all", capability: null, scope: "include-federated", transportOverlay: true },
+    });
+    expect(html).not.toContain("network-filter-clear");
   });
 });
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter-transport.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter-transport.test.ts
@@ -1,0 +1,159 @@
+/**
+ * P-14 U2.3 (#935) — NetworkGraphEdge transport widening tests.
+ *
+ * Asserts `applyTransportOverlay` folds signal's transport overlay onto a built
+ * graph ADDITIVELY: stack-hub nodes gain `transportVerdict`, agent nodes gain
+ * `transportLeaf` liveness/RTT, hub→agent edges gain `data.transport` — all keyed
+ * by `{principal}/{stack}` and taken verbatim from the overlay (sourced from
+ * signal). A stack signal didn't observe is left UNCHANGED. The base
+ * `buildNetworkGraph` shape is untouched (the widening is opt-in).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  buildNetworkGraph,
+  applyTransportOverlay,
+  STACK_HUB_NODE_ID,
+  type AgentNodeData,
+  type StackHubNodeData,
+} from "../lib/network-graph-adapter";
+import { buildTransportOverlay } from "../lib/network-transport-overlay";
+import type { TransportRosterEventRow } from "../../api/observability-tab";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+function tile(over: Partial<AgentPresenceTile> & { agent_id: string }): AgentPresenceTile {
+  const { agent_id } = over;
+  return {
+    key: `andreas/research/${agent_id}`,
+    origin: "local",
+    assistant_name: null,
+    nkey_public_key: `N${agent_id.toUpperCase()}`,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+    ...over,
+  };
+}
+
+function foreignTile(
+  over: Partial<AgentPresenceTile> & { agent_id: string; principal: string; stack: string },
+): AgentPresenceTile {
+  const { agent_id, principal, stack } = over;
+  return tile({
+    ...over,
+    key: `${principal}/${stack}/${agent_id}`,
+    principal,
+    stack,
+    origin: { principal, stack },
+  });
+}
+
+function driftRow(principal: string, stack: string, to: string): TransportRosterEventRow {
+  return {
+    id: crypto.randomUUID(),
+    type: "system.transport.liveness_drift",
+    stackId: "net",
+    timestamp: "2026-06-12T00:00:00.000Z",
+    payload: {
+      action: "liveness_drift",
+      network: "net",
+      reason: "x",
+      attributes: { peer: `${principal}/${stack}`, principal, stack, from: null, to },
+    },
+  };
+}
+
+function connectRow(principal: string, stack: string, rtt: number): TransportRosterEventRow {
+  return {
+    id: crypto.randomUUID(),
+    type: "system.transport.leaf_connect",
+    stackId: "net",
+    timestamp: "2026-06-12T00:00:00.000Z",
+    payload: {
+      action: "leaf_connect",
+      network: "net",
+      leaf: { principal, stack, network: "net", rtt_ms: rtt, frames: { in_msgs: 0, out_msgs: 0, in_bytes: 0, out_bytes: 0 } },
+    },
+  };
+}
+
+describe("NetworkGraphEdge — base shape unchanged without overlay (U2.3)", () => {
+  it("buildNetworkGraph emits edges with NO data field (pre-U2.3 byte-shape)", () => {
+    const g = buildNetworkGraph([tile({ agent_id: "luna" })]);
+    expect(g.edges.length).toBe(1);
+    expect(g.edges[0]!.data).toBeUndefined();
+  });
+});
+
+describe("applyTransportOverlay — additive widening (U2.3)", () => {
+  it("widens the LOCAL hub node with signal's verdict + the agent with leaf liveness/RTT", () => {
+    const base = buildNetworkGraph([tile({ agent_id: "luna" })]);
+    // andreas/research is connected @8.4ms per signal.
+    const overlay = buildTransportOverlay([
+      driftRow("andreas", "research", "connected"),
+      connectRow("andreas", "research", 8.4),
+    ]);
+    const g = applyTransportOverlay(base, overlay);
+
+    const hub = g.nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    expect((hub.data as StackHubNodeData).transportVerdict).toBe("connected");
+
+    const agent = g.nodes.find((n) => n.id === "andreas/research/luna")!;
+    const leaf = (agent.data as AgentNodeData).transportLeaf;
+    expect(leaf).toEqual({ present: true, rttMs: 8.4 });
+
+    const edge = g.edges.find((e) => e.target === "andreas/research/luna")!;
+    expect(edge.data?.transport).toEqual({ verdict: "connected", present: true, rttMs: 8.4 });
+  });
+
+  it("leaves a node/edge UNCHANGED when signal did not observe its stack", () => {
+    const base = buildNetworkGraph([tile({ agent_id: "luna" })]);
+    // Overlay observes a DIFFERENT stack — nothing to paint onto andreas/research.
+    const overlay = buildTransportOverlay([driftRow("jc", "default", "connected")]);
+    const g = applyTransportOverlay(base, overlay);
+
+    const hub = g.nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    expect((hub.data as StackHubNodeData).transportVerdict).toBeUndefined();
+    const agent = g.nodes.find((n) => n.id === "andreas/research/luna")!;
+    expect((agent.data as AgentNodeData).transportLeaf).toBeUndefined();
+    expect(g.edges.find((e) => e.target === "andreas/research/luna")!.data).toBeUndefined();
+  });
+
+  it("keys a FOREIGN peer's leaf on its ORIGIN stack (not the local hub)", () => {
+    const base = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "default" }),
+    ]);
+    const overlay = buildTransportOverlay([
+      driftRow("jc", "default", "unregistered-present"),
+    ]);
+    const g = applyTransportOverlay(base, overlay);
+
+    // The foreign hub (jc/default) carries the anomaly verdict.
+    const foreignHub = g.nodes.find(
+      (n) => n.data.kind === "stack-hub" && (n.data as StackHubNodeData).stack === "default",
+    )!;
+    expect((foreignHub.data as StackHubNodeData).transportVerdict).toBe("unregistered-present");
+
+    // The foreign agent's edge carries the foreign stack's verdict.
+    const sageEdge = g.edges.find((e) => e.target === "jc/default/sage")!;
+    expect(sageEdge.data?.transport?.verdict).toBe("unregistered-present");
+
+    // The LOCAL hub (andreas/research) is untouched — signal didn't observe it.
+    const localHub = g.nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    expect((localHub.data as StackHubNodeData).transportVerdict).toBeUndefined();
+  });
+
+  it("an empty overlay returns the graph functionally unchanged (no transport fields)", () => {
+    const base = buildNetworkGraph([tile({ agent_id: "luna" })]);
+    const g = applyTransportOverlay(base, buildTransportOverlay([]));
+    const hub = g.nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    expect((hub.data as StackHubNodeData).transportVerdict).toBeUndefined();
+    expect(g.edges[0]!.data).toBeUndefined();
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes-transport.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes-transport.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * P-14 U2.3 (#935) — transport-overlay node render tests.
+ *
+ * The pure card inners (`StackHubCard`, `AgentNodeCard`) render under
+ * `renderToStaticMarkup` (no xyflow provider). Asserts the verdict badge appears
+ * on a hub carrying `transportVerdict` (with the right severity class + label),
+ * leaf liveness/RTT appears on an agent carrying `transportLeaf`, and BOTH are
+ * absent when the overlay fields are undefined (overlay off / unobserved stack).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { AgentNodeCard, StackHubCard } from "../components/network-nodes";
+import type { AgentNodeData, StackHubNodeData } from "../lib/network-graph-adapter";
+
+function hub(over: Partial<StackHubNodeData> = {}): StackHubNodeData {
+  return {
+    kind: "stack-hub",
+    origin: "local",
+    principal: "andreas",
+    stack: "research",
+    agentCount: 2,
+    ...over,
+  };
+}
+
+function agent(over: Partial<AgentNodeData> = {}): AgentNodeData {
+  return {
+    kind: "agent",
+    key: "andreas/research/luna",
+    origin: "local",
+    agentId: "luna",
+    assistantName: "Luna",
+    capabilities: [],
+    state: "online",
+    offlineReason: null,
+    lastHeartbeatAt: null,
+    ...over,
+  };
+}
+
+const renderHub = (d: StackHubNodeData) => renderToStaticMarkup(createElement(StackHubCard, { data: d }));
+const renderAgent = (d: AgentNodeData) =>
+  renderToStaticMarkup(createElement(AgentNodeCard, { data: d, now: Date.now() }));
+
+describe("StackHubCard — verdict badge (U2.3)", () => {
+  it("renders NO verdict badge when the overlay is off (undefined verdict)", () => {
+    const html = renderHub(hub());
+    expect(html).not.toContain("network-verdict-badge");
+    expect(html).not.toContain("data-transport-verdict");
+  });
+
+  it("renders a connected badge (ok severity) when signal reports connected", () => {
+    const html = renderHub(hub({ transportVerdict: "connected" }));
+    expect(html).toContain("network-verdict-connected");
+    expect(html).toContain('data-verdict="connected"');
+    expect(html).toContain('data-severity="ok"');
+    expect(html).toContain('data-transport-verdict="connected"');
+    expect(html).toContain("connected");
+  });
+
+  it("renders a registered-absent badge (warn severity)", () => {
+    const html = renderHub(hub({ transportVerdict: "registered-absent" }));
+    expect(html).toContain("network-verdict-registered-absent");
+    expect(html).toContain('data-severity="warn"');
+  });
+
+  it("renders an unregistered-present badge (alert severity, the anomaly)", () => {
+    const html = renderHub(hub({ transportVerdict: "unregistered-present" }));
+    expect(html).toContain("network-verdict-unregistered-present");
+    expect(html).toContain('data-severity="alert"');
+  });
+});
+
+describe("AgentNodeCard — leaf liveness/RTT (U2.3)", () => {
+  it("renders NO leaf row when the overlay is off (undefined transportLeaf)", () => {
+    const html = renderAgent(agent());
+    expect(html).not.toContain("network-node-leaf");
+  });
+
+  it("renders a live leaf with RTT when signal reports it present", () => {
+    const html = renderAgent(agent({ transportLeaf: { present: true, rttMs: 8.4 } }));
+    expect(html).toContain("network-node-leaf-present");
+    expect(html).toContain('data-leaf-present="true"');
+    expect(html).toContain("leaf 8.4ms");
+  });
+
+  it("renders 'no leaf' for an absent leaf (registered-absent peer)", () => {
+    const html = renderAgent(agent({ transportLeaf: { present: false, rttMs: null } }));
+    expect(html).toContain("network-node-leaf-absent");
+    expect(html).toContain('data-leaf-present="false"');
+    expect(html).toContain("no leaf");
+  });
+
+  it("shows a — RTT when the leaf is present but RTT unreported", () => {
+    const html = renderAgent(agent({ transportLeaf: { present: true, rttMs: null } }));
+    expect(html).toContain("network-node-leaf-present");
+    expect(html).toContain("leaf —");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-transport-overlay.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-transport-overlay.test.ts
@@ -1,0 +1,242 @@
+/**
+ * P-14 U2.3 (#935) — transport overlay fold + verdict→badge mapping tests.
+ *
+ * The overlay folds signal's projected `system.transport.*` rows into a per-stack
+ * verdict + leaf liveness/RTT model, then maps each verdict to its badge. The
+ * fixtures mirror signal's OWN roster oracle (`signal transport roster`,
+ * src/cli/transport-roster.test.ts): jc/default connected @8.4ms,
+ * andreas/macbook-pro registered-absent, intruder/ghost unregistered-present.
+ * That cross-repo fidelity is the acceptance criterion — the MC overlay verdicts
+ * must match the CLI's. cortex SOURCES these verdicts from signal; it never
+ * re-derives them (proven here: a drift's `to` is carried through verbatim).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  buildTransportOverlay,
+  overlayForStack,
+  verdictBadge,
+  formatRtt,
+  isTransportVerdict,
+  EMPTY_TRANSPORT_OVERLAY,
+  TRANSPORT_VERDICTS,
+} from "../lib/network-transport-overlay";
+import type { TransportRosterEventRow } from "../../api/observability-tab";
+
+const NET = "metafactory-community";
+
+/** A transport row with a sane default timestamp (newer rows have larger ts). */
+function row(over: Partial<TransportRosterEventRow> & { type: string }): TransportRosterEventRow {
+  return {
+    id: crypto.randomUUID(),
+    stackId: NET,
+    timestamp: "2026-06-12T00:00:00.000Z",
+    payload: {},
+    ...over,
+  };
+}
+
+/** A `liveness_drift` row asserting `to` for a peer (signal's authoritative verdict). */
+function drift(
+  principal: string,
+  stack: string,
+  to: string,
+  over: Partial<TransportRosterEventRow> = {},
+): TransportRosterEventRow {
+  return row({
+    type: "system.transport.liveness_drift",
+    payload: {
+      action: "liveness_drift",
+      network: NET,
+      reason: `peer ${principal}/${stack} → ${to}`,
+      attributes: { peer: `${principal}/${stack}`, principal, stack, from: null, to },
+    },
+    ...over,
+  });
+}
+
+/** A `leaf_connect` row carrying a live leaf with RTT. */
+function leafConnect(
+  principal: string,
+  stack: string,
+  rtt_ms: number | null,
+  over: Partial<TransportRosterEventRow> = {},
+): TransportRosterEventRow {
+  return row({
+    type: "system.transport.leaf_connect",
+    payload: {
+      action: "leaf_connect",
+      network: NET,
+      leaf: { principal, stack, network: NET, rtt_ms, frames: { in_msgs: 0, out_msgs: 0, in_bytes: 0, out_bytes: 0 } },
+    },
+    ...over,
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+describe("buildTransportOverlay — fold (U2.3)", () => {
+  it("returns the empty overlay for no rows", () => {
+    const o = buildTransportOverlay([]);
+    expect(o.byKey.size).toBe(0);
+    expect(o.networks).toEqual([]);
+  });
+
+  it("matches signal's roster oracle: connected/registered-absent/unregistered-present", () => {
+    // The drift envelopes carry signal's reconciled verdicts; the connect carries
+    // jc's live RTT — exactly the roster CLI's three-peer fixture.
+    const o = buildTransportOverlay([
+      drift("jc", "default", "connected"),
+      leafConnect("jc", "default", 8.4),
+      drift("andreas", "macbook-pro", "registered-absent"),
+      drift("intruder", "ghost", "unregistered-present"),
+    ]);
+
+    expect(
+      Object.fromEntries([...o.byKey.values()].map((p) => [p.key, p.verdict])),
+    ).toEqual({
+      "jc/default": "connected",
+      "andreas/macbook-pro": "registered-absent",
+      "intruder/ghost": "unregistered-present",
+    });
+
+    // The connected peer carries the live RTT (sourced from the leaf body).
+    const jc = overlayForStack(o, "jc", "default");
+    expect(jc).not.toBeNull();
+    expect(jc!.present).toBe(true);
+    expect(jc!.rttMs).toBe(8.4);
+    expect(jc!.network).toBe(NET);
+
+    // The registered-absent peer has no live leaf.
+    const andreas = overlayForStack(o, "andreas", "macbook-pro");
+    expect(andreas!.present).toBe(false);
+    expect(andreas!.rttMs).toBeNull();
+
+    expect(o.networks).toEqual([NET]);
+  });
+
+  it("a liveness_drift's verdict is taken VERBATIM (never re-derived)", () => {
+    // Even with a contradicting leaf_connect present, the newest drift wins —
+    // proving the overlay carries signal's verdict, it doesn't recompute one.
+    const o = buildTransportOverlay([
+      drift("jc", "default", "registered-absent", { timestamp: "2026-06-12T00:00:02.000Z" }),
+      leafConnect("jc", "default", 5.0, { timestamp: "2026-06-12T00:00:01.000Z" }),
+    ]);
+    const jc = overlayForStack(o, "jc", "default");
+    // Drift (authoritative) holds registered-absent despite a connect row existing.
+    expect(jc!.verdict).toBe("registered-absent");
+  });
+
+  it("newest drift wins over an older drift for the same key (newest-first pass)", () => {
+    const o = buildTransportOverlay([
+      drift("jc", "default", "connected", { timestamp: "2026-06-12T00:00:05.000Z" }),
+      drift("jc", "default", "registered-absent", { timestamp: "2026-06-12T00:00:01.000Z" }),
+    ]);
+    expect(overlayForStack(o, "jc", "default")!.verdict).toBe("connected");
+  });
+
+  it("folds a roster_snapshot's leaves into connected verdicts with RTT", () => {
+    const o = buildTransportOverlay([
+      row({
+        type: "system.transport.roster_snapshot",
+        payload: {
+          action: "roster_snapshot",
+          network: NET,
+          leaves: [
+            { principal: "jc", stack: "default", network: NET, rtt_ms: 8.4, frames: { in_msgs: 1, out_msgs: 1, in_bytes: 1, out_bytes: 1 } },
+            { principal: "echo", stack: "research", network: NET, rtt_ms: null, frames: { in_msgs: 0, out_msgs: 0, in_bytes: 0, out_bytes: 0 } },
+          ],
+        },
+      }),
+    ]);
+    expect(overlayForStack(o, "jc", "default")!.verdict).toBe("connected");
+    expect(overlayForStack(o, "jc", "default")!.rttMs).toBe(8.4);
+    expect(overlayForStack(o, "echo", "research")!.present).toBe(true);
+    expect(overlayForStack(o, "echo", "research")!.rttMs).toBeNull();
+  });
+
+  it("a leaf_disconnect seeds registered-absent (a leaf vanished)", () => {
+    const o = buildTransportOverlay([
+      row({
+        type: "system.transport.leaf_disconnect",
+        payload: {
+          action: "leaf_disconnect",
+          network: NET,
+          leaf: { principal: "jc", stack: "default", network: NET, rtt_ms: null, frames: { in_msgs: 0, out_msgs: 0, in_bytes: 0, out_bytes: 0 } },
+        },
+      }),
+    ]);
+    const jc = overlayForStack(o, "jc", "default");
+    expect(jc!.verdict).toBe("registered-absent");
+    expect(jc!.present).toBe(false);
+  });
+
+  it("skips unreadable rows (poison payload / unknown type) without throwing", () => {
+    const o = buildTransportOverlay([
+      row({ type: "system.transport.liveness_drift", payload: {} }), // no attributes
+      row({ type: "system.transport.something_else", payload: { foo: 1 } }),
+      drift("jc", "default", "connected"),
+    ]);
+    expect(o.byKey.size).toBe(1);
+    expect(overlayForStack(o, "jc", "default")!.verdict).toBe("connected");
+  });
+
+  it("overlayForStack returns null for a never-observed stack", () => {
+    const o = buildTransportOverlay([drift("jc", "default", "connected")]);
+    expect(overlayForStack(o, "nobody", "nowhere")).toBeNull();
+    expect(overlayForStack(o, null, "default")).toBeNull();
+  });
+
+  it("EMPTY_TRANSPORT_OVERLAY is shape-compatible (empty map + networks)", () => {
+    expect(EMPTY_TRANSPORT_OVERLAY.byKey.size).toBe(0);
+    expect(EMPTY_TRANSPORT_OVERLAY.networks).toEqual([]);
+  });
+});
+
+describe("verdictBadge — verdict→badge mapping (U2.3)", () => {
+  it("maps connected → ok / connected label / class", () => {
+    const b = verdictBadge("connected");
+    expect(b.severity).toBe("ok");
+    expect(b.label).toBe("connected");
+    expect(b.className).toContain("network-verdict-connected");
+    expect(b.title).toContain("intent ∩ reality");
+  });
+
+  it("maps registered-absent → warn", () => {
+    const b = verdictBadge("registered-absent");
+    expect(b.severity).toBe("warn");
+    expect(b.className).toContain("network-verdict-registered-absent");
+    expect(b.title).toContain("no live leaf");
+  });
+
+  it("maps unregistered-present → alert (the security anomaly)", () => {
+    const b = verdictBadge("unregistered-present");
+    expect(b.severity).toBe("alert");
+    expect(b.className).toContain("network-verdict-unregistered-present");
+    expect(b.title.toLowerCase()).toContain("anomaly");
+  });
+
+  it("is total over every verdict in TRANSPORT_VERDICTS", () => {
+    for (const v of TRANSPORT_VERDICTS) {
+      const b = verdictBadge(v);
+      expect(b.verdict).toBe(v);
+      expect(["ok", "warn", "alert"]).toContain(b.severity);
+    }
+  });
+});
+
+describe("formatRtt + isTransportVerdict (U2.3)", () => {
+  it("formats RTT to one decimal with an ms suffix, — when null", () => {
+    expect(formatRtt(8.4)).toBe("8.4ms");
+    expect(formatRtt(12)).toBe("12ms");
+    expect(formatRtt(null)).toBe("—");
+  });
+
+  it("guards signal's three verdict strings, rejects junk", () => {
+    expect(isTransportVerdict("connected")).toBe(true);
+    expect(isTransportVerdict("registered-absent")).toBe(true);
+    expect(isTransportVerdict("unregistered-present")).toBe(true);
+    expect(isTransportVerdict("flapping")).toBe(false);
+    expect(isTransportVerdict(null)).toBe(false);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-transport-overlay.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-transport-overlay.test.ts
@@ -73,6 +73,23 @@ function leafConnect(
   });
 }
 
+/** A `leaf_disconnect` row (a leaf vanished — carries no live RTT). */
+function leafDisconnect(
+  principal: string,
+  stack: string,
+  over: Partial<TransportRosterEventRow> = {},
+): TransportRosterEventRow {
+  return row({
+    type: "system.transport.leaf_disconnect",
+    payload: {
+      action: "leaf_disconnect",
+      network: NET,
+      leaf: { principal, stack, network: NET, rtt_ms: null, frames: { in_msgs: 0, out_msgs: 0, in_bytes: 0, out_bytes: 0 } },
+    },
+    ...over,
+  });
+}
+
 // ---------------------------------------------------------------------------
 
 describe("buildTransportOverlay — fold (U2.3)", () => {
@@ -125,6 +142,74 @@ describe("buildTransportOverlay — fold (U2.3)", () => {
     const jc = overlayForStack(o, "jc", "default");
     // Drift (authoritative) holds registered-absent despite a connect row existing.
     expect(jc!.verdict).toBe("registered-absent");
+  });
+
+  it("newest registered-absent drift suppresses an older connect's leaf (no resurrection)", () => {
+    // A peer just drifted registered-absent; its prior leaf_connect row is still
+    // in the 200-row window. The stale connect must NOT flip presence back on or
+    // backfill RTT — the newest authoritative event (the drift) wins.
+    const o = buildTransportOverlay([
+      drift("jc", "default", "registered-absent", { timestamp: "2026-06-12T00:00:02.000Z" }),
+      leafConnect("jc", "default", 5.0, { timestamp: "2026-06-12T00:00:01.000Z" }),
+    ]);
+    const jc = overlayForStack(o, "jc", "default")!;
+    expect(jc.verdict).toBe("registered-absent");
+    expect(jc.present).toBe(false);
+    expect(jc.rttMs).toBeNull();
+  });
+
+  it("newest leaf_disconnect suppresses an older connect's leaf (no resurrection)", () => {
+    // A leaf vanished (disconnect newest); its earlier connect row lingers in the
+    // window. Presence stays false and RTT stays null — the disconnect wins.
+    const o = buildTransportOverlay([
+      leafDisconnect("jc", "default", { timestamp: "2026-06-12T00:00:02.000Z" }),
+      leafConnect("jc", "default", 5.0, { timestamp: "2026-06-12T00:00:01.000Z" }),
+    ]);
+    const jc = overlayForStack(o, "jc", "default")!;
+    expect(jc.verdict).toBe("registered-absent");
+    expect(jc.present).toBe(false);
+    expect(jc.rttMs).toBeNull();
+  });
+
+  it("newest registered-absent drift + empty roster_snapshot still suppresses a stale connect", () => {
+    // Drift newest, then an empty snapshot (peer not listed), then a stale connect.
+    // The connect must still not resurrect presence/RTT.
+    const o = buildTransportOverlay([
+      drift("jc", "default", "registered-absent", { timestamp: "2026-06-12T00:00:03.000Z" }),
+      row({
+        type: "system.transport.roster_snapshot",
+        timestamp: "2026-06-12T00:00:02.000Z",
+        payload: { action: "roster_snapshot", network: NET, leaves: [] },
+      }),
+      leafConnect("jc", "default", 7.2, { timestamp: "2026-06-12T00:00:01.000Z" }),
+    ]);
+    const jc = overlayForStack(o, "jc", "default")!;
+    expect(jc.verdict).toBe("registered-absent");
+    expect(jc.present).toBe(false);
+    expect(jc.rttMs).toBeNull();
+  });
+
+  it("a genuine newest leaf_connect still shows present + RTT (not over-suppressed)", () => {
+    // No absent verdict is newer; the live connect must keep present:true + its RTT.
+    const o = buildTransportOverlay([
+      leafConnect("jc", "default", 6.1, { timestamp: "2026-06-12T00:00:02.000Z" }),
+    ]);
+    const jc = overlayForStack(o, "jc", "default")!;
+    expect(jc.present).toBe(true);
+    expect(jc.rttMs).toBe(6.1);
+  });
+
+  it("a newest connected drift still backfills RTT from its older connect row", () => {
+    // The connected verdict is present:true; its accompanying (older) connect row
+    // must still backfill the live RTT — presence-resolution only locks ABSENCE.
+    const o = buildTransportOverlay([
+      drift("jc", "default", "connected", { timestamp: "2026-06-12T00:00:02.000Z" }),
+      leafConnect("jc", "default", 8.4, { timestamp: "2026-06-12T00:00:01.000Z" }),
+    ]);
+    const jc = overlayForStack(o, "jc", "default")!;
+    expect(jc.verdict).toBe("connected");
+    expect(jc.present).toBe(true);
+    expect(jc.rttMs).toBe(8.4);
   });
 
   it("newest drift wins over an older drift for the same key (newest-first pass)", () => {

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -132,9 +132,15 @@ export function App() {
   // G-1115 — governance verdicts, fetched only when the tab is visible.
   const governance = useGovernance(ws, view === "governance");
   // P-14 U2.1 (#934) — observability events (signal's four system.* families),
-  // fetched only when the Observability tab is visible; live-refreshed off the
+  // fetched when the Observability tab is visible; live-refreshed off the
   // `observability` mc.projection family.
-  const observability = useObservability(ws, view === "observability");
+  // P-14 U2.3 (#935) — ALSO fetched on the Network tab: its transport overlay
+  // folds signal's `transportRoster` (the verdict-bearing transport family) onto
+  // the graph, so the same projection feeds both tabs.
+  const observability = useObservability(
+    ws,
+    view === "observability" || view === "network",
+  );
   // P-14 U4.2 (#938) — aggregate metrics panels (tool/spawn/event rates +
   // hook-latency percentiles via the sideband /metrics/summary) and the >14d
   // history view (events past MC's 14-day local prune, sourced from signal's
@@ -592,6 +598,10 @@ export function App() {
           <NetworkView
             state={agents}
             workingAgents={working.agents}
+            // U2.3 — signal's projected transport roster (verdict-bearing) feeds
+            // the Network view's transport overlay. Empty until the obs fetch
+            // lands / on a non-hub stack; the overlay paints nothing then.
+            transportRoster={observability.data?.transportRoster ?? []}
             onViewInWorkingGrid={() => setView("default")}
             // G-1114.F.3 — dispatch-direct to a LOCAL agent, REUSING the
             // existing dispatch path (`POST /api/sessions` with `agentId`). The

--- a/src/surface/mc/dashboard-v2/components/network-filter-bar.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-filter-bar.tsx
@@ -44,6 +44,8 @@ export interface NetworkFilterBarProps {
   onCapabilityChange: (capability: string | null) => void;
   /** E.4 — flip federation scope (include foreign peers vs this stack only). */
   onScopeChange: (scope: NetworkScopeFilter) => void;
+  /** U2.3 — flip the transport overlay (signal's verdicts + leaf liveness/RTT). */
+  onTransportOverlayChange: (on: boolean) => void;
   onClear: () => void;
   /** Open the Cmd+K spotlight (the hint button is also a click target). */
   onOpenSpotlight: () => void;
@@ -55,6 +57,7 @@ export function NetworkFilterBar({
   onStateChange,
   onCapabilityChange,
   onScopeChange,
+  onTransportOverlayChange,
   onClear,
   onOpenSpotlight,
 }: NetworkFilterBarProps) {
@@ -97,6 +100,20 @@ export function NetworkFilterBar({
             </button>
           );
         })}
+      </div>
+
+      <div className="network-filter-group" role="group" aria-label="Transport overlay toggle">
+        <span className="network-filter-label">Transport</span>
+        <button
+          type="button"
+          className={`network-filter-transport-btn${filter.transportOverlay ? " on" : ""}`}
+          aria-pressed={filter.transportOverlay}
+          data-transport-overlay={filter.transportOverlay ? "on" : "off"}
+          title="Overlay signal's transport verdicts + leaf liveness/RTT onto the graph"
+          onClick={() => onTransportOverlayChange(!filter.transportOverlay)}
+        >
+          {filter.transportOverlay ? "Overlay on" : "Overlay off"}
+        </button>
       </div>
 
       <div className="network-filter-group">

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -37,6 +37,7 @@ import type {
 } from "../lib/network-graph-adapter";
 import { isAgentHighlighted } from "../lib/capability-highlight";
 import { useNetworkHover } from "../lib/network-hover-context";
+import { verdictBadge, formatRtt } from "../lib/network-transport-overlay";
 
 // --- Stack hub -------------------------------------------------------------
 
@@ -53,6 +54,10 @@ export function StackHubCard({ data }: StackHubCardProps) {
   // E.4: a FOREIGN (federated peer) hub renders distinctly from YOUR local hub —
   // a "federated" eyebrow + a dimmer/bordered treatment via the modifier class.
   const foreign = isForeignOrigin(data.origin);
+  // U2.3 — signal's intent⋈reality verdict for this stack (present only when the
+  // transport overlay is on AND signal observed it). Taken verbatim from signal.
+  const badge =
+    data.transportVerdict !== undefined ? verdictBadge(data.transportVerdict) : null;
   return (
     <div
       className={
@@ -61,11 +66,22 @@ export function StackHubCard({ data }: StackHubCardProps) {
       }
       data-node-kind="stack-hub"
       data-hub-origin={foreign ? "foreign" : "local"}
+      data-transport-verdict={data.transportVerdict ?? undefined}
     >
       <span className="network-hub-eyebrow dim">
         {foreign ? "federated stack" : "stack"}
       </span>
       <span className="network-hub-label">{label}</span>
+      {badge && (
+        <span
+          className={badge.className}
+          data-verdict={badge.verdict}
+          data-severity={badge.severity}
+          title={badge.title}
+        >
+          {badge.label}
+        </span>
+      )}
       <span className="network-hub-count dim">
         {data.agentCount} agent{data.agentCount === 1 ? "" : "s"}
       </span>
@@ -223,6 +239,29 @@ export function AgentNodeCard({
           {ttlLapse ? "last seen " : ""}
           {formatRelativeTime(data.lastHeartbeatAt, now)}
         </span>
+        {/* U2.3 — leaf liveness + RTT from signal's transport roster (overlay on
+            + signal observed this stack). Sourced from signal, never re-derived. */}
+        {data.transportLeaf !== undefined && (
+          <span
+            className={
+              "network-node-leaf" +
+              (data.transportLeaf.present
+                ? " network-node-leaf-present"
+                : " network-node-leaf-absent")
+            }
+            data-leaf-present={data.transportLeaf.present ? "true" : "false"}
+            data-leaf-rtt={data.transportLeaf.rttMs ?? undefined}
+            title={
+              data.transportLeaf.present
+                ? `leaf live — RTT ${formatRtt(data.transportLeaf.rttMs)}`
+                : "leaf not present"
+            }
+          >
+            {data.transportLeaf.present
+              ? `leaf ${formatRtt(data.transportLeaf.rttMs)}`
+              : "no leaf"}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -31,7 +31,15 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react
 import type { AgentPresenceTile, AgentsState } from "../hooks/use-agents";
 import type { WorkingAgentTile } from "../hooks/use-working-agents";
 import { pickAgentsPanelMode } from "../lib/agents-display";
-import { buildNetworkGraph } from "../lib/network-graph-adapter";
+import {
+  buildNetworkGraph,
+  applyTransportOverlay,
+} from "../lib/network-graph-adapter";
+import {
+  buildTransportOverlay,
+  EMPTY_TRANSPORT_OVERLAY,
+} from "../lib/network-transport-overlay";
+import type { TransportRosterEventRow } from "../../api/observability-tab";
 import {
   resolveSelectedAgent,
   selectAgentDispatchActivity,
@@ -97,6 +105,15 @@ export interface NetworkViewProps {
    * caller projects them here and the index lights up task↔agent matches.
    */
   matchTasks?: readonly MatchTask[];
+  /**
+   * P-14 U2.3 (#935) — signal's projected `system.transport.*` roster (the
+   * payload-bearing `transportRoster` from `/api/observability-events`, via
+   * `useObservability`). When the principal flips the transport-overlay toggle,
+   * the view folds these into per-stack verdict badges + leaf liveness/RTT. Empty
+   * default → the overlay has nothing to paint (a non-hub stack, or signal not
+   * emitting yet). SOURCED FROM SIGNAL — the view never re-derives substrate health.
+   */
+  transportRoster?: readonly TransportRosterEventRow[];
 }
 
 export function NetworkView({
@@ -106,6 +123,7 @@ export function NetworkView({
   onDispatchDirect,
   dispatchingAgentKeys,
   matchTasks = [],
+  transportRoster = [],
 }: NetworkViewProps) {
   const mode = pickAgentsPanelMode(state);
 
@@ -126,7 +144,29 @@ export function NetworkView({
   // Pure: filtered snapshot → React-Flow graph (re-derived when agents OR the
   // filter change). Tiny + engine-free, so it stays in the main bundle; the lazy
   // canvas takes the built graph and runs ELK over it.
-  const graph = useMemo(() => buildNetworkGraph(filteredAgents), [filteredAgents]);
+  const baseGraph = useMemo(() => buildNetworkGraph(filteredAgents), [filteredAgents]);
+
+  // U2.3 — fold signal's transport verdicts + leaf liveness/RTT into the overlay
+  // model, then onto the base graph WHEN the overlay toggle is on. Built off the
+  // FULL roster (the verdict for a stack is the verdict regardless of agent
+  // filters), but applied to the SCOPE-FILTERED graph — so `local-only` cleanly
+  // hides foreign verdicts (those hubs/nodes aren't in the graph to paint onto).
+  // SOURCED FROM SIGNAL: `buildTransportOverlay` carries signal's verdict strings
+  // verbatim; cortex never re-derives them.
+  const transportOverlay = useMemo(
+    () =>
+      filter.transportOverlay
+        ? buildTransportOverlay(transportRoster)
+        : EMPTY_TRANSPORT_OVERLAY,
+    [filter.transportOverlay, transportRoster],
+  );
+  const graph = useMemo(
+    () =>
+      filter.transportOverlay
+        ? applyTransportOverlay(baseGraph, transportOverlay)
+        : baseGraph,
+    [baseGraph, transportOverlay, filter.transportOverlay],
+  );
 
   // F.1 — the capability-match index, built off the FULL snapshot (not the
   // filtered one) so a hovered capability lights every declaring agent
@@ -173,6 +213,11 @@ export function NetworkView({
   // spotlight read, so flipping it cleanly removes/restores foreign agents.
   const onScopeChange = useCallback(
     (scope: NetworkScopeFilter) => setFilter((f) => ({ ...f, scope })),
+    [],
+  );
+  // U2.3 — flip the transport overlay (a render lens, not an agent predicate).
+  const onTransportOverlayChange = useCallback(
+    (on: boolean) => setFilter((f) => ({ ...f, transportOverlay: on })),
     [],
   );
   const onClearFilters = useCallback(() => setFilter(DEFAULT_NETWORK_FILTER), []);
@@ -282,6 +327,7 @@ export function NetworkView({
             onStateChange={onStateChange}
             onCapabilityChange={onCapabilityChange}
             onScopeChange={onScopeChange}
+            onTransportOverlayChange={onTransportOverlayChange}
             onClear={onClearFilters}
             onOpenSpotlight={openSpotlight}
           />

--- a/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
@@ -38,6 +38,11 @@
  */
 
 import type { AgentPresenceTile, AgentOrigin } from "../hooks/use-agents";
+import type {
+  TransportOverlay,
+  TransportVerdict,
+} from "./network-transport-overlay";
+import { overlayForStack } from "./network-transport-overlay";
 
 /** Reserved id for the synthetic LOCAL stack-root hub node (never a valid agent key). */
 export const STACK_HUB_NODE_ID = "__stack__";
@@ -72,6 +77,13 @@ export interface StackHubNodeData {
   stack: string | null;
   /** Count of agents attached to this hub. */
   agentCount: number;
+  /**
+   * P-14 U2.3 (#935) — signal's intent⋈reality VERDICT for this stack, when the
+   * transport overlay is on AND signal observed this `{principal}/{stack}`.
+   * Undefined → no overlay / no observation (the hub renders no verdict badge).
+   * SOURCED FROM SIGNAL — never re-derived (the badge mapping keys off this).
+   */
+  transportVerdict?: TransportVerdict;
 }
 
 /** React Flow node `data` payload for one agent. */
@@ -98,6 +110,13 @@ export interface AgentNodeData {
   offlineReason: string | null;
   /** Epoch-ms of the last `agent.heartbeat` observed, or `null`. */
   lastHeartbeatAt: number | null;
+  /**
+   * P-14 U2.3 (#935) — leaf LIVENESS for this agent's stack, when the transport
+   * overlay is on AND signal observed the stack. `present` is the live-link flag,
+   * `rttMs` the round-trip from signal's leaf roster (null when unreported).
+   * Undefined → no overlay / no observation. SOURCED FROM SIGNAL — never re-derived.
+   */
+  transportLeaf?: { present: boolean; rttMs: number | null };
 }
 
 /** Discriminated union of every node `data` shape in the graph. */
@@ -112,11 +131,36 @@ export interface NetworkGraphNode {
   position: { x: number; y: number };
 }
 
-/** A React-Flow-shaped edge (hub → agent for the stack-local cut). */
+/**
+ * P-14 U2.3 (#935) — transport health/lag an edge can carry when the Network
+ * view's transport overlay is on. SOURCED FROM SIGNAL (the projected
+ * `system.transport.*` family — signal's P-13.B verdicts), never re-derived
+ * here. Additive + optional, so a graph built without the overlay is
+ * byte-identical to the pre-U2.3 shape.
+ */
+export interface NetworkEdgeTransportData {
+  /** Signal's intent⋈reality verdict for the target leaf's stack. */
+  verdict: "connected" | "registered-absent" | "unregistered-present";
+  /** Leaf liveness (true when signal reports the leaf present). */
+  present: boolean;
+  /** Round-trip time (ms) from signal's leaf roster, or null when unreported. */
+  rttMs: number | null;
+}
+
+/**
+ * A React-Flow-shaped edge (hub → agent for the stack-local cut).
+ *
+ * G-1114.E.3 grew this to federated multi-hub edges; U2.3 widens it additively
+ * with an OPTIONAL `data.transport` health/lag payload (present only when the
+ * transport overlay is on AND signal observed the target's stack). The base
+ * `{id,source,target}` is unchanged — a no-overlay build never sets `data`.
+ */
 export interface NetworkGraphEdge {
   id: string;
   source: string;
   target: string;
+  /** U2.3 — optional transport overlay payload (health/lag), sourced from signal. */
+  data?: { transport?: NetworkEdgeTransportData };
 }
 
 /** The adapter's output: nodes + edges, pre-layout. */
@@ -237,6 +281,78 @@ export function buildNetworkGraph(
       });
     }
   }
+
+  return { nodes, edges };
+}
+
+/**
+ * P-14 U2.3 (#935) — overlay signal's transport health onto a built graph.
+ *
+ * A PURE, additive widening: returns a NEW graph whose stack-hub nodes carry the
+ * `transportVerdict`, agent nodes carry `transportLeaf` liveness/RTT, and
+ * hub→agent edges carry `data.transport` — all keyed by `{principal}/{stack}` and
+ * taken VERBATIM from the {@link TransportOverlay} (signal's projected verdicts;
+ * never re-derived here). A node/edge whose stack signal did not observe is
+ * returned UNCHANGED (no `transport*` fields), so a non-hub stack — or any leaf
+ * signal didn't report — reads exactly as the un-overlaid graph.
+ *
+ * Kept separate from {@link buildNetworkGraph} so the base projection stays
+ * overlay-free + byte-identical to pre-U2.3, and the fold is independently
+ * unit-testable against fixtures.
+ */
+export function applyTransportOverlay(
+  graph: NetworkGraph,
+  overlay: TransportOverlay,
+): NetworkGraph {
+  const nodes = graph.nodes.map((node): NetworkGraphNode => {
+    if (node.data.kind === "stack-hub") {
+      const peer = overlayForStack(overlay, node.data.principal, node.data.stack);
+      if (peer === null) return node;
+      return {
+        ...node,
+        data: { ...node.data, transportVerdict: peer.verdict },
+      };
+    }
+    // An agent node's leaf liveness keys on the agent's ORIGIN stack (a foreign
+    // peer's leaf lives on ITS stack, exactly like its hub grouping). originScope
+    // resolves a foreign origin's {principal,stack}; a local agent's own.
+    const origin = node.data.origin;
+    const principal = origin === "local" ? node.data.key.split("/")[0]! : origin.principal;
+    const stack = origin === "local" ? node.data.key.split("/")[1]! : origin.stack;
+    const peer = overlayForStack(overlay, principal, stack);
+    if (peer === null) return node;
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        transportLeaf: { present: peer.present, rttMs: peer.rttMs },
+      },
+    };
+  });
+
+  const edges = graph.edges.map((edge): NetworkGraphEdge => {
+    // The edge target is the agent key (`{principal}/{stack}/{agent_id}`); the
+    // overlay keys on `{principal}/{stack}`. Resolve via the target node's data.
+    const targetNode = graph.nodes.find((n) => n.id === edge.target);
+    if (targetNode === undefined || targetNode.data.kind !== "agent") return edge;
+    const origin = targetNode.data.origin;
+    const principal =
+      origin === "local" ? targetNode.data.key.split("/")[0]! : origin.principal;
+    const stack =
+      origin === "local" ? targetNode.data.key.split("/")[1]! : origin.stack;
+    const peer = overlayForStack(overlay, principal, stack);
+    if (peer === null) return edge;
+    return {
+      ...edge,
+      data: {
+        transport: {
+          verdict: peer.verdict,
+          present: peer.present,
+          rttMs: peer.rttMs,
+        },
+      },
+    };
+  });
 
   return { nodes, edges };
 }

--- a/src/surface/mc/dashboard-v2/lib/network-graph-filter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-filter.ts
@@ -58,6 +58,19 @@ export interface NetworkFilterState {
    * drops every foreign agent. Defaults to `include-federated`.
    */
   scope: NetworkScopeFilter;
+  /**
+   * P-14 U2.3 (#935) — TRANSPORT OVERLAY toggle. When true, the view folds
+   * signal's projected `system.transport.*` verdicts + leaf liveness/RTT onto the
+   * graph (hub verdict badges + agent leaf liveness/RTT). Off by default — the
+   * overlay is an opt-in lens, not the graph's baseline. This is a RENDER toggle,
+   * not an agent predicate: unlike `state`/`capability`/`scope` it never filters
+   * the agent set (see {@link isFilterActive} — it doesn't count it as "active").
+   *
+   * OPTIONAL (additive over the pre-U2.3 shape): `undefined` reads as "off", so a
+   * partial filter literal (e.g. a pre-existing test fixture) is still valid and
+   * the overlay simply stays off. `DEFAULT_NETWORK_FILTER` sets it explicitly.
+   */
+  transportOverlay?: boolean;
 }
 
 /** The no-op filter: every agent passes. The view's initial filter state. */
@@ -65,6 +78,7 @@ export const DEFAULT_NETWORK_FILTER: NetworkFilterState = {
   state: "all",
   capability: null,
   scope: "include-federated",
+  transportOverlay: false,
 };
 
 /**

--- a/src/surface/mc/dashboard-v2/lib/network-transport-overlay.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-transport-overlay.ts
@@ -1,0 +1,368 @@
+/**
+ * P-14 U2.3 (#935) — Network-view TRANSPORT OVERLAY (pure fold).
+ *
+ * Folds signal's projected `system.transport.*` rows (U2.1's observability
+ * projection, exposed payload-bearing via `transportRoster` on
+ * `/api/observability-events`) into a per-peer-stack overlay the Network view
+ * paints onto the graph:
+ *
+ *   - a stack-hub VERDICT badge (connected / registered-absent / unregistered-present)
+ *     keyed by `{principal}/{stack}` — the intent⋈reality verdict signal computed
+ *     in its P-13.B reconciler; and
+ *   - leaf LIVENESS + RTT for the same key (present + rtt_ms, when the leaf is live).
+ *
+ * ## SOURCED FROM SIGNAL — never re-derived (CONTEXT.md §Sourced-from-signal)
+ *
+ * cortex does NOT reconcile intent against reality here. The verdict string is
+ * taken VERBATIM from signal's envelopes:
+ *
+ *   | signal envelope `type`                | overlay verdict it asserts                |
+ *   |---------------------------------------|-------------------------------------------|
+ *   | `system.transport.liveness_drift`     | `payload.attributes.to` (the drift target)|
+ *   | `system.transport.leaf_connect`       | `connected` (a leaf appeared)             |
+ *   | `system.transport.leaf_disconnect`    | `registered-absent` (a leaf vanished)     |
+ *   | `system.transport.roster_snapshot`    | each `leaves[]` entry → `connected`        |
+ *
+ * `liveness_drift` is authoritative for a peer (it's signal's reconciled verdict,
+ * including the `unregistered-present` anomaly + `registered-absent` that the
+ * edge events alone can't express); the edge / snapshot events only seed a
+ * verdict when no drift has been seen for that key. Leaf RTT / liveness come from
+ * the `leaf` / `leaves[]` body (`rtt_ms`, presence), which only `connected` peers
+ * carry — exactly as signal's reconciler stamps them.
+ *
+ * Rows arrive newest-first (the DB read's `ORDER BY timestamp DESC`); the fold is
+ * a single pass that keeps the FIRST (newest) authoritative signal per key, so a
+ * later poll's verdict wins over an earlier one without any clock comparison.
+ *
+ * Pure + DOM-free → unit-testable against fixtures (the live oracle:
+ * `signal transport roster <network>` verdicts must match this overlay).
+ */
+
+import type { TransportRosterEventRow } from "../../api/observability-tab";
+
+/**
+ * The three deterministic liveness verdicts — signal's P-13.B vocabulary,
+ * mirrored here so the badge mapping is typed. NOT re-computed; signal emits
+ * these strings, the overlay carries them through.
+ */
+export type TransportVerdict =
+  | "connected"
+  | "registered-absent"
+  | "unregistered-present";
+
+export const TRANSPORT_VERDICTS: readonly TransportVerdict[] = [
+  "connected",
+  "registered-absent",
+  "unregistered-present",
+] as const;
+
+/** True when `v` is one of signal's three verdict strings (a wire-value guard). */
+export function isTransportVerdict(v: unknown): v is TransportVerdict {
+  return (
+    v === "connected" ||
+    v === "registered-absent" ||
+    v === "unregistered-present"
+  );
+}
+
+/** One peer-stack's overlay state, keyed by `{principal}/{stack}`. */
+export interface TransportPeerOverlay {
+  /** `{principal}/{stack}` — the join key against the stack-hub + agent origin. */
+  key: string;
+  principal: string;
+  stack: string;
+  /** The network this observation is scoped to (from the envelope payload). */
+  network: string | null;
+  /** Signal's verdict — taken verbatim, never re-derived. */
+  verdict: TransportVerdict;
+  /** Leaf liveness: true when signal reports the leaf present (a live link). */
+  present: boolean;
+  /** Round-trip time in ms from signal's leaf roster, or null when absent/unreported. */
+  rttMs: number | null;
+}
+
+/**
+ * The overlay model the Network view threads onto the graph: a lookup keyed by
+ * `{principal}/{stack}` plus the network label (for the legend). `byKey` is a
+ * Map for O(1) node-render lookups.
+ */
+export interface TransportOverlay {
+  byKey: Map<string, TransportPeerOverlay>;
+  /** The distinct network(s) observed in this roster (sorted), for a legend line. */
+  networks: string[];
+}
+
+/** The empty overlay — no transport observations (e.g. a non-hub stack). */
+export const EMPTY_TRANSPORT_OVERLAY: TransportOverlay = {
+  byKey: new Map(),
+  networks: [],
+};
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function asNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return typeof v === "object" && v !== null ? (v as Record<string, unknown>) : {};
+}
+
+/** `{principal}/{stack}` join key, or null when either half is missing. */
+function peerKey(principal: string | null, stack: string | null): string | null {
+  return principal !== null && stack !== null ? `${principal}/${stack}` : null;
+}
+
+/**
+ * A single fold candidate extracted from one row — the verdict signal asserts for
+ * one peer-stack, plus that row's leaf liveness/RTT, plus whether it is the
+ * AUTHORITATIVE source (a `liveness_drift`) or merely a seed (edge / snapshot).
+ */
+interface Candidate {
+  key: string;
+  principal: string;
+  stack: string;
+  network: string | null;
+  verdict: TransportVerdict;
+  present: boolean;
+  rttMs: number | null;
+  /** `liveness_drift` is authoritative; edges/snapshots only seed when no drift seen. */
+  authoritative: boolean;
+}
+
+/** Extract the leaf liveness/RTT off a `leaf` / `leaves[]` entry body. */
+function leafLiveness(leaf: Record<string, unknown>): { present: boolean; rttMs: number | null } {
+  // A leaf entry present in a connect/snapshot body IS a live link; RTT may be
+  // null (the hub didn't report it) — mirror signal's ObservedLeaf nullable rtt_ms.
+  return { present: true, rttMs: asNumber(leaf.rtt_ms) };
+}
+
+/** Pull the candidate(s) one transport row contributes, or `[]` when unreadable. */
+function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
+  const payload = row.payload;
+  const network = asString(payload.network) ?? asString(row.stackId);
+
+  switch (row.type) {
+    case "system.transport.liveness_drift": {
+      // Authoritative: signal's reconciled verdict. The peer + verdict ride
+      // `attributes` (reconciler: { peer, principal, stack, from, to }).
+      const attrs = asRecord(payload.attributes);
+      const to = attrs.to;
+      if (!isTransportVerdict(to)) return [];
+      const principal = asString(attrs.principal);
+      const stack = asString(attrs.stack);
+      // Prefer the explicit attribute key, else split `peer` ("principal/stack").
+      let key = peerKey(principal, stack);
+      let p = principal;
+      let s = stack;
+      if (key === null) {
+        const peer = asString(attrs.peer);
+        const slash = peer?.indexOf("/") ?? -1;
+        if (peer !== null && slash > 0) {
+          p = peer.slice(0, slash);
+          s = peer.slice(slash + 1);
+          key = peer;
+        }
+      }
+      if (key === null || p === null || s === null) return [];
+      // A drift carries no leaf body; liveness/RTT only exist for a connected
+      // peer and arrive via the connect/snapshot rows folded alongside.
+      return [
+        {
+          key,
+          principal: p,
+          stack: s,
+          network,
+          verdict: to,
+          present: to === "connected" || to === "unregistered-present",
+          rttMs: null,
+          authoritative: true,
+        },
+      ];
+    }
+    case "system.transport.leaf_connect":
+    case "system.transport.leaf_disconnect": {
+      const leaf = asRecord(payload.leaf);
+      const principal = asString(leaf.principal);
+      const stack = asString(leaf.stack);
+      const key = peerKey(principal, stack);
+      if (key === null || principal === null || stack === null) return [];
+      const connect = row.type === "system.transport.leaf_connect";
+      const live = leafLiveness(leaf);
+      return [
+        {
+          key,
+          principal,
+          stack,
+          network: asString(leaf.network) ?? network,
+          // An edge seeds a verdict only when no drift dominates: a connect leaf
+          // is `connected`; a disconnect leaves the peer registered-absent.
+          verdict: connect ? "connected" : "registered-absent",
+          present: connect ? live.present : false,
+          rttMs: connect ? live.rttMs : null,
+          authoritative: false,
+        },
+      ];
+    }
+    case "system.transport.roster_snapshot": {
+      const leaves = Array.isArray(payload.leaves) ? payload.leaves : [];
+      const out: Candidate[] = [];
+      for (const raw of leaves) {
+        const leaf = asRecord(raw);
+        const principal = asString(leaf.principal);
+        const stack = asString(leaf.stack);
+        const key = peerKey(principal, stack);
+        if (key === null || principal === null || stack === null) continue;
+        const live = leafLiveness(leaf);
+        out.push({
+          key,
+          principal,
+          stack,
+          network: asString(leaf.network) ?? network,
+          // A leaf in the permitted roster snapshot is present → connected.
+          verdict: "connected",
+          present: live.present,
+          rttMs: live.rttMs,
+          authoritative: false,
+        });
+      }
+      return out;
+    }
+    default:
+      return [];
+  }
+}
+
+/**
+ * Fold the transport-family rows (newest-first) into the per-peer-stack overlay.
+ *
+ * Precedence, resolved in one newest-first pass:
+ *   1. the FIRST (newest) `liveness_drift` for a key wins its verdict outright;
+ *   2. otherwise the FIRST (newest) edge/snapshot seeds it;
+ *   3. leaf liveness/RTT is taken from the first row for the key that carries a
+ *      leaf body (drifts carry none), so a `connected` verdict still shows RTT
+ *      from its accompanying connect/snapshot row.
+ *
+ * Empty / unreadable input → {@link EMPTY_TRANSPORT_OVERLAY} (shape-compatible).
+ */
+export function buildTransportOverlay(
+  rows: readonly TransportRosterEventRow[],
+): TransportOverlay {
+  if (rows.length === 0) return { byKey: new Map(), networks: [] };
+
+  const byKey = new Map<string, TransportPeerOverlay>();
+  /** Track whether a key's verdict was set by an authoritative drift (locks it). */
+  const lockedByDrift = new Set<string>();
+  const networks = new Set<string>();
+
+  for (const row of rows) {
+    for (const c of candidatesForRow(row)) {
+      if (c.network !== null) networks.add(c.network);
+      const existing = byKey.get(c.key);
+      if (existing === undefined) {
+        byKey.set(c.key, {
+          key: c.key,
+          principal: c.principal,
+          stack: c.stack,
+          network: c.network,
+          verdict: c.verdict,
+          present: c.present,
+          rttMs: c.rttMs,
+        });
+        if (c.authoritative) lockedByDrift.add(c.key);
+        continue;
+      }
+      // Verdict precedence: a drift locks the key (newest drift already won, since
+      // we walk newest-first); a non-drift never overrides a drift-locked verdict.
+      if (c.authoritative && !lockedByDrift.has(c.key)) {
+        existing.verdict = c.verdict;
+        existing.present = c.present;
+        lockedByDrift.add(c.key);
+        if (existing.network === null) existing.network = c.network;
+      }
+      // Leaf liveness/RTT: backfill from the first row carrying a real leaf body,
+      // regardless of which row set the verdict (a drift has no leaf body).
+      if (existing.rttMs === null && c.rttMs !== null) existing.rttMs = c.rttMs;
+      if (!existing.present && c.present && c.rttMs !== null) {
+        // Only let a leaf-bearing row flip presence on (a connect/snapshot),
+        // never a verdict-only drift that asserted absence.
+        existing.present = true;
+      }
+      if (existing.network === null && c.network !== null) existing.network = c.network;
+    }
+  }
+
+  return { byKey, networks: [...networks].sort() };
+}
+
+/** Look up one peer-stack's overlay by `{principal}/{stack}` (null when absent). */
+export function overlayForStack(
+  overlay: TransportOverlay,
+  principal: string | null,
+  stack: string | null,
+): TransportPeerOverlay | null {
+  const key = peerKey(principal, stack);
+  return key === null ? null : (overlay.byKey.get(key) ?? null);
+}
+
+// =============================================================================
+// Verdict → badge mapping (pure; the single source of truth for the UI label,
+// severity class + tooltip, shared by the hub badge + any legend).
+// =============================================================================
+
+/** Severity tier driving the badge's colour class (CSS keys off `data-verdict`). */
+export type VerdictSeverity = "ok" | "warn" | "alert";
+
+export interface VerdictBadge {
+  verdict: TransportVerdict;
+  /** Short label shown in the badge pill. */
+  label: string;
+  /** Severity class suffix (`ok` / `warn` / `alert`). */
+  severity: VerdictSeverity;
+  /** The full class name for the badge pill. */
+  className: string;
+  /** Hover title explaining the intent⋈reality meaning (signal's P-13.B vocab). */
+  title: string;
+}
+
+const VERDICT_BADGES: Record<TransportVerdict, Omit<VerdictBadge, "verdict">> = {
+  connected: {
+    label: "connected",
+    severity: "ok",
+    className: "network-verdict-badge network-verdict-connected",
+    title: "Connected — registered AND a live leaf is present (intent ∩ reality).",
+  },
+  "registered-absent": {
+    label: "registered-absent",
+    severity: "warn",
+    className: "network-verdict-badge network-verdict-registered-absent",
+    title:
+      "Registered-absent — a registered peer with no live leaf (intent \\ reality).",
+  },
+  "unregistered-present": {
+    label: "unregistered-present",
+    severity: "alert",
+    className:
+      "network-verdict-badge network-verdict-unregistered-present",
+    title:
+      "Unregistered-present — a live leaf with no registry entry, the security anomaly (reality \\ intent).",
+  },
+};
+
+/**
+ * Map one of signal's verdict strings to its badge descriptor (label + severity
+ * + class + tooltip). The mapping is total over {@link TransportVerdict}, so the
+ * Network view never renders an unmapped verdict.
+ */
+export function verdictBadge(verdict: TransportVerdict): VerdictBadge {
+  return { verdict, ...VERDICT_BADGES[verdict] };
+}
+
+/** Format a leaf RTT for display (e.g. `8.4ms`), or `—` when unreported. */
+export function formatRtt(rttMs: number | null): string {
+  if (rttMs === null) return "—";
+  // One decimal place, matching `signal transport roster` output (`8.4ms`).
+  return `${Math.round(rttMs * 10) / 10}ms`;
+}

--- a/src/surface/mc/dashboard-v2/lib/network-transport-overlay.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-transport-overlay.ts
@@ -243,7 +243,11 @@ function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
  *   2. otherwise the FIRST (newest) edge/snapshot seeds it;
  *   3. leaf liveness/RTT is taken from the first row for the key that carries a
  *      leaf body (drifts carry none), so a `connected` verdict still shows RTT
- *      from its accompanying connect/snapshot row.
+ *      from its accompanying connect/snapshot row — UNLESS the key's newest
+ *      authoritative event already resolved presence ABSENT (a `registered-absent`
+ *      drift or a `leaf_disconnect`), in which case an older connect/snapshot
+ *      row must NOT resurrect presence/RTT (the just-disconnected peer's stale
+ *      connect row is still in the 200-row window; newest authoritative wins).
  *
  * Empty / unreadable input → {@link EMPTY_TRANSPORT_OVERLAY} (shape-compatible).
  */
@@ -255,6 +259,13 @@ export function buildTransportOverlay(
   const byKey = new Map<string, TransportPeerOverlay>();
   /** Track whether a key's verdict was set by an authoritative drift (locks it). */
   const lockedByDrift = new Set<string>();
+  /**
+   * Keys whose presence was RESOLVED-ABSENT by their newest authoritative event
+   * (a `registered-absent` drift, or a `leaf_disconnect`). Once a key is in here,
+   * an OLDER leaf-bearing row (connect / snapshot) must NOT resurrect presence or
+   * backfill RTT — the newest authoritative event wins, so the absence stands.
+   */
+  const presenceResolved = new Set<string>();
   const networks = new Set<string>();
 
   for (const row of rows) {
@@ -272,6 +283,10 @@ export function buildTransportOverlay(
           rttMs: c.rttMs,
         });
         if (c.authoritative) lockedByDrift.add(c.key);
+        // If the NEWEST event for this key asserts absence (a `registered-absent`
+        // drift or a `leaf_disconnect` — the only candidates with present:false),
+        // lock presence absent: a later (older) connect/snapshot must not flip it.
+        if (!c.present) presenceResolved.add(c.key);
         continue;
       }
       // Verdict precedence: a drift locks the key (newest drift already won, since
@@ -282,13 +297,18 @@ export function buildTransportOverlay(
         lockedByDrift.add(c.key);
         if (existing.network === null) existing.network = c.network;
       }
-      // Leaf liveness/RTT: backfill from the first row carrying a real leaf body,
-      // regardless of which row set the verdict (a drift has no leaf body).
-      if (existing.rttMs === null && c.rttMs !== null) existing.rttMs = c.rttMs;
-      if (!existing.present && c.present && c.rttMs !== null) {
-        // Only let a leaf-bearing row flip presence on (a connect/snapshot),
-        // never a verdict-only drift that asserted absence.
-        existing.present = true;
+      // Leaf liveness/RTT: backfill from the first row carrying a real leaf body —
+      // UNLESS the key's newest authoritative event already resolved it absent, in
+      // which case an older connect/snapshot must NOT resurrect presence or RTT
+      // (newest authoritative event wins; the stale connect row just hasn't aged
+      // out of the 200-row window yet).
+      if (!presenceResolved.has(c.key)) {
+        if (existing.rttMs === null && c.rttMs !== null) existing.rttMs = c.rttMs;
+        if (!existing.present && c.present && c.rttMs !== null) {
+          // A leaf-bearing row (connect / snapshot) flips presence on; this only
+          // runs for keys NOT resolved-absent by a newer drift / disconnect.
+          existing.present = true;
+        }
       }
       if (existing.network === null && c.network !== null) existing.network = c.network;
     }

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -428,15 +428,18 @@ html, body {
   text-transform: uppercase; letter-spacing: 0.04em;
 }
 .network-filter-state-btn,
-.network-filter-scope-btn {
+.network-filter-scope-btn,
+.network-filter-transport-btn {
   appearance: none; cursor: pointer; font: inherit; font-size: 12px;
   padding: 3px 9px; border-radius: 6px;
   border: 1px solid var(--line); background: var(--bg); color: var(--fg-faint);
 }
 .network-filter-state-btn:hover,
-.network-filter-scope-btn:hover { color: var(--fg); }
+.network-filter-scope-btn:hover,
+.network-filter-transport-btn:hover { color: var(--fg); }
 .network-filter-state-btn.on,
-.network-filter-scope-btn.on {
+.network-filter-scope-btn.on,
+.network-filter-transport-btn.on {
   background: var(--accent-soft); color: var(--fg);
   border-color: color-mix(in oklch, var(--accent) 50%, transparent);
 }
@@ -524,6 +527,43 @@ html, body {
 .network-node-reason { font-size: 10px; }
 .network-node-reason-ttl-lapse { color: var(--warn); }
 .network-node-heartbeat { font-size: 10px; margin-left: auto; }
+
+/* P-14 U2.3 — transport overlay: hub verdict badge + agent leaf liveness/RTT.
+   Sourced from signal's projected transport family; severity keys the colour. */
+.network-verdict-badge {
+  font-size: 9px; font-weight: 600; font-family: var(--mono);
+  text-transform: uppercase; letter-spacing: 0.03em;
+  padding: 1px 6px; border-radius: 4px;
+  border: 1px solid var(--line);
+}
+.network-verdict-connected {
+  color: var(--ok);
+  border-color: color-mix(in oklch, var(--ok) 55%, transparent);
+  background: color-mix(in oklch, var(--ok) 14%, transparent);
+}
+.network-verdict-registered-absent {
+  color: var(--warn);
+  border-color: color-mix(in oklch, var(--warn) 55%, transparent);
+  background: color-mix(in oklch, var(--warn) 14%, transparent);
+}
+.network-verdict-unregistered-present {
+  color: var(--danger, var(--warn));
+  border-color: color-mix(in oklch, var(--danger, var(--warn)) 60%, transparent);
+  background: color-mix(in oklch, var(--danger, var(--warn)) 16%, transparent);
+  font-weight: 700;
+}
+.network-node-leaf {
+  font-size: 9.5px; font-family: var(--mono);
+  padding: 1px 5px; border-radius: 4px; border: 1px solid var(--line);
+}
+.network-node-leaf-present {
+  color: var(--ok);
+  border-color: color-mix(in oklch, var(--ok) 45%, transparent);
+}
+.network-node-leaf-absent {
+  color: var(--fg-faint);
+  border-style: dashed;
+}
 
 /* Legend overlay (bottom-right of the canvas). */
 .network-legend {

--- a/src/surface/mc/db/observability.ts
+++ b/src/surface/mc/db/observability.ts
@@ -119,6 +119,73 @@ export function listObservabilityEvents(
   }));
 }
 
+/**
+ * P-14 U2.3 (#935) — a transport-family row WITH its parsed `payload`.
+ *
+ * The generic {@link listObservabilityEvents} read deliberately strips `payload`
+ * (the tab only needs `type`/`summary`/`stackId`). The Network-view transport
+ * overlay, by contrast, needs the per-leaf verdict + RTT that signal stamps into
+ * the envelope BODY (`system.transport.*` payload — `leaf`/`leaves`/`attributes`,
+ * see signal P-13.B reconciler). This narrow read returns those rows WITH the
+ * payload re-parsed, so the overlay folds signal's OWN verdicts onto the graph
+ * (CONTEXT.md §Sourced-from-signal — cortex never re-derives substrate health).
+ *
+ * Additive: a new query alongside the existing reads; nothing else changes.
+ */
+export interface TransportRosterEventRow {
+  id: string;
+  type: string;
+  stackId: string | null;
+  /** The parsed envelope BODY signal published (`{ action, network, leaf?, leaves?, attributes? }`). */
+  payload: Record<string, unknown>;
+  timestamp: string;
+}
+
+/**
+ * Recent `transport`-family rows (newest first, capped at `limit`) WITH their
+ * stored `payload` parsed back to an object. Malformed/empty payloads parse to
+ * `{}` (never throws — a poison row degrades to an empty body, not a crash).
+ *
+ * Sourced verbatim from the projected `system.transport.*` envelopes signal
+ * emitted; this read does no reconciliation of its own.
+ */
+export function listTransportRosterEvents(
+  db: Database,
+  limit: number,
+): TransportRosterEventRow[] {
+  const rows = db
+    .query(
+      `SELECT id, type, stack_id, payload, timestamp
+       FROM observability_events
+       WHERE family = 'transport'
+       ORDER BY timestamp DESC, id DESC
+       LIMIT ?`,
+    )
+    .all(limit) as Record<string, unknown>[];
+  return rows.map((r) => {
+    let payload: Record<string, unknown> = {};
+    const raw = r.payload;
+    if (typeof raw === "string" && raw.length > 0) {
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        if (typeof parsed === "object" && parsed !== null) {
+          payload = parsed as Record<string, unknown>;
+        }
+      } catch {
+        // A poison payload degrades to {} — the overlay folder skips a body it
+        // can't read rather than failing the whole roster read.
+      }
+    }
+    return {
+      id: r.id as string,
+      type: r.type as string,
+      stackId: (r.stack_id as string | null) ?? null,
+      payload,
+      timestamp: r.timestamp as string,
+    };
+  });
+}
+
 /** Per-family row counts. A family with zero rows is absent from the result map. */
 export type ObservabilityCounts = Partial<Record<ObservabilityFamily, number>>;
 


### PR DESCRIPTION
Cortex half of signal#117 (the Grafana-panel half stays in signal#117). Overlays signal's projected `system.transport.*` family onto the MC **Network** view: stack-hub intent⋈reality **verdict badges**, **leaf liveness + RTT** on agent nodes, behind a **transport-overlay toggle**, **scope-filter aware**. Closes #935.

## Sourced from signal — never re-derived (CONTEXT.md §Sourced-from-signal)
cortex does NOT reconcile intent⋈reality here. The verdict string is taken **verbatim** from signal's P-13.B reconciler output as projected by U2.1:

| signal envelope `type` | overlay verdict it asserts |
|---|---|
| `system.transport.liveness_drift` | `payload.attributes.to` (authoritative — locks the key) |
| `system.transport.leaf_connect` | `connected` (seed) |
| `system.transport.leaf_disconnect` | `registered-absent` (seed) |
| `system.transport.roster_snapshot` | each `leaves[]` → `connected` (seed) |

Leaf RTT / liveness come from signal's `leaf` / `leaves[]` body (`rtt_ms`, presence). A drift is authoritative; edges/snapshots only seed a verdict when no drift dominates. The fold is one newest-first pass (no clock math).

## Verdict → badge mapping
| verdict | severity | class |
|---|---|---|
| `connected` | ok | `network-verdict-connected` |
| `registered-absent` | warn | `network-verdict-registered-absent` |
| `unregistered-present` | alert | `network-verdict-unregistered-present` |

## Adapter widening (additive, on top of G-1114.E.3 federated topology)
- `NetworkGraphEdge` gains optional `data.transport` (`{ verdict, present, rttMs }`). A no-overlay build is byte-identical to pre-U2.3 (`data` unset).
- `StackHubNodeData` gains optional `transportVerdict`; `AgentNodeData` gains optional `transportLeaf`.
- New pure `applyTransportOverlay(graph, overlay)` folds the overlay onto a built graph; an unobserved stack is left **unchanged**. A foreign peer's leaf keys on its **origin** stack.

## Sourcing path
`db/observability.ts` `+ listTransportRosterEvents` (narrow payload-bearing read of the transport family — the generic tab read strips `payload`) → `transportRoster` on `/api/observability-events` → `useObservability` (now also fetched on the Network tab) → `buildTransportOverlay` → `applyTransportOverlay`.

## Scope-filter awareness
The overlay folds onto the **scope-filtered** graph, so `local-only` cleanly hides foreign verdicts (those hubs/nodes aren't in the graph to paint onto). The toggle is a render lens, not an agent predicate — it never narrows the agent set and never triggers "Clear".

## ⚠ Collision points (active concurrent dev)
- `lib/network-graph-adapter.ts` — known hotspot (grew federated multi-hub topology in G-1114.E.3). Kept **strictly additive**: base `buildNetworkGraph` untouched; widening is a separate optional field + a separate `applyTransportOverlay` function.
- `components/network-view.tsx` — added a prop + a memo + a callback; left existing flows intact.

## Gate
- `bunx tsc --noEmit` → **0**
- `bun test src/surface/mc/` → **1836 pass / 1 skip / 0 fail**
- `eslint` (in-scope changed files) → **0 errors** (`dashboard-v2/` is repo-eslint-ignored by `eslint.config.js`; tsc is its gate)

Live oracle (deferred — can't run signal hub here): `signal transport roster <network>` verdicts must match the overlay. Unit-tested against signal's own oracle fixture (jc/default connected @8.4ms, andreas/macbook-pro registered-absent, intruder/ghost unregistered-present).

## Tests
- `network-transport-overlay.test.ts` — fold matches signal's roster oracle; drift verdict carried verbatim (wins over contradicting connect); newest drift wins; snapshot/edge folds; poison/unknown rows skipped; badge mapping total over verdicts; `formatRtt` / `isTransportVerdict`.
- `network-graph-adapter-transport.test.ts` — base edges carry no `data`; hub verdict + agent leaf + edge `data.transport` widened; unobserved stack untouched; foreign peer keyed on origin stack; empty overlay no-op.
- `network-nodes-transport.test.tsx` — verdict badge (3 severities) + leaf chip render; absent when overlay off.
- `network-filter-bar.test.tsx` — overlay toggle off-by-default / pressed-on / doesn't surface Clear.
- `observability-db.test.ts` — `listTransportRosterEvents` (transport-only, newest-first, payload round-trips, poison→{}, empty on non-hub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)