### PR TITLE
feat(mc): U3.1 — governance pane (denials/refusals/verdicts, 30d) (#936)

### DIFF
--- a/src/surface/mc/__tests__/governance-denial.test.ts
+++ b/src/surface/mc/__tests__/governance-denial.test.ts
@@ -1,0 +1,383 @@
+/**
+ * P-14 U3.1 (#936) — governance access-denial projection + 30d query +
+ * retention + render + API tests.
+ *
+ * Verifies:
+ *   1. Projection: `system.access.denied` (nested reason.kind) and
+ *      `system.access.filtered` (flat reason enum) land as rows with the
+ *      reason-kind extracted, refusal classification correct, principal/stack
+ *      parsed from the subject.
+ *   2. Refusal classification: sovereignty reason kinds → isRefusal; authz /
+ *      chain-verify kinds → generic denial.
+ *   3. Idempotency: a redelivered envelope (same id) is not double-inserted.
+ *   4. Fail-closed filters: non-access types, malformed payloads (no reason
+ *      kind), and missing ids project nothing — and never throw.
+ *   5. Renderer seam: the system.access subjects are in the dispatch adapter
+ *      grammar and match real derived subjects; render() routes a denied
+ *      envelope into a row; garbage never throws.
+ *   6. 30-day window: rows inside 30d are listed/summarized; a row backdated
+ *      past 30d falls out of both.
+ *   7. Retention: governance_denials past the 35d retention window is pruned;
+ *      a row inside the 30d query window survives.
+ *   8. API: empty DB → honest zeros; seeded denials + refusals split correctly
+ *      and combine with verdict denials into the alarm tier.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { SCHEMA_SQL } from "../db/schema";
+import {
+  projectGovernanceDenial,
+  type ProjectableDenialEnvelope,
+} from "../projection/governance-denial";
+import {
+  createDispatchProjectionRenderer,
+  DISPATCH_PROJECTION_SUBJECTS,
+} from "../projection/dispatch-lifecycle-renderer";
+import { subjectMatches } from "../../../bus/surface-router";
+import { getGovernance } from "../api/governance";
+import {
+  insertGovernanceDenial,
+  insertGovernanceVerdict,
+  listRecentDenials,
+  summarizeDenials,
+  isRefusalReason,
+} from "../db/governance";
+import {
+  pruneOldGovernanceDenials,
+  pruneRetention,
+  GOVERNANCE_DENIAL_RETENTION_MS,
+} from "../db/retention";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+const SUBJECT = "local.switch-soc.default.system.access.denied";
+
+function deniedEnvelope(
+  reasonKind: string,
+  extra: Record<string, unknown> = {},
+  id = crypto.randomUUID(),
+): ProjectableDenialEnvelope {
+  return {
+    id,
+    type: "system.access.denied",
+    source: "switch-soc.default.cortex",
+    payload: {
+      principal_id: "switch-soc",
+      capability: "code-review.typescript",
+      envelope_subject: "local.switch-soc.default.dispatch.task.received",
+      reason: { kind: reasonKind, ...extra },
+    },
+  };
+}
+
+function filteredEnvelope(
+  reason: string,
+  id = crypto.randomUUID(),
+): ProjectableDenialEnvelope {
+  return {
+    id,
+    type: "system.access.filtered",
+    source: "switch-soc.default.cortex",
+    payload: {
+      renderer_id: "dashboard",
+      envelope_subject: "local.switch-soc.default.dispatch.task.received",
+      reason,
+    },
+  };
+}
+
+function rowCount(db: Database): number {
+  return (db.query(`SELECT COUNT(*) AS n FROM governance_denials`).get() as { n: number }).n;
+}
+
+/** Backdate a denial row's created_at by `msAgo` (unix-seconds column). */
+function backdateDenial(db: Database, rowId: string, msAgo: number): void {
+  const secAgo = Math.floor(msAgo / 1000);
+  db.query(`UPDATE governance_denials SET created_at = unixepoch() - ? WHERE id = ?`).run(
+    secAgo,
+    rowId,
+  );
+}
+
+describe("projectGovernanceDenial", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("projects a system.access.denied envelope → a denial row with reason kind + identity", () => {
+    const res = projectGovernanceDenial(
+      db,
+      deniedEnvelope("chain_verify_failed", { verify_reason: "stamp_unknown" }),
+      SUBJECT,
+    );
+    expect(res?.kind).toBe("denied");
+    expect(res?.reasonKind).toBe("chain_verify_failed");
+    expect(res?.rowId).not.toBeNull();
+
+    const [row] = listRecentDenials(db, 30, 10);
+    expect(row?.reasonKind).toBe("chain_verify_failed");
+    expect(row?.isRefusal).toBe(false); // chain-verify is a generic denial
+    expect(row?.principalId).toBe("switch-soc");
+    expect(row?.capability).toBe("code-review.typescript");
+    expect(row?.detail).toBe("stamp_unknown"); // verify_reason surfaced as detail
+    // Subject identity parsed (stack-ful local grammar, anchored on `system`).
+    expect(row?.principal).toBe("switch-soc");
+    expect(row?.stack).toBe("default");
+  });
+
+  it("classifies a sovereignty_model_class denial as a REFUSAL", () => {
+    const res = projectGovernanceDenial(
+      db,
+      deniedEnvelope("sovereignty_model_class", { reason: "frontier demanded, local-only class", enforced: true }),
+      SUBJECT,
+    );
+    expect(res?.reasonKind).toBe("sovereignty_model_class");
+    const [row] = listRecentDenials(db, 30, 10);
+    expect(row?.isRefusal).toBe(true);
+    expect(row?.detail).toBe("frontier demanded, local-only class");
+  });
+
+  it("projects a system.access.filtered envelope (flat reason enum) as a refusal", () => {
+    const res = projectGovernanceDenial(db, filteredEnvelope("residency_blocked"), SUBJECT);
+    expect(res?.kind).toBe("filtered");
+    expect(res?.reasonKind).toBe("residency_blocked");
+    const [row] = listRecentDenials(db, 30, 10);
+    expect(row?.kind).toBe("filtered");
+    expect(row?.isRefusal).toBe(true); // a visibility filter is a sovereignty refusal
+    expect(row?.detail).toBe("dashboard"); // renderer_id surfaced as detail
+  });
+
+  it("is idempotent on envelope id — redelivery does not double-insert", () => {
+    const env = deniedEnvelope("insufficient_role");
+    const first = projectGovernanceDenial(db, env, SUBJECT);
+    const second = projectGovernanceDenial(db, env, SUBJECT);
+    expect(first?.rowId).not.toBeNull();
+    expect(second?.rowId).toBeNull(); // recognized redelivery
+    expect(rowCount(db)).toBe(1);
+  });
+
+  it("returns null for non-access types, malformed payloads, and missing ids — never throws", () => {
+    // Wrong type.
+    expect(
+      projectGovernanceDenial(db, { id: "a", type: "dispatch.task.started", payload: { x: 1 } }),
+    ).toBeNull();
+    // denied with NO reason record — malformed.
+    expect(
+      projectGovernanceDenial(db, { id: "b", type: "system.access.denied", payload: { principal_id: "p" } }),
+    ).toBeNull();
+    // denied with reason missing a kind — malformed.
+    expect(
+      projectGovernanceDenial(db, { id: "c", type: "system.access.denied", payload: { reason: {} } }),
+    ).toBeNull();
+    // filtered with no reason enum — malformed.
+    expect(
+      projectGovernanceDenial(db, { id: "d", type: "system.access.filtered", payload: {} }),
+    ).toBeNull();
+    // No envelope id — no idempotency key, refuse to project.
+    expect(
+      projectGovernanceDenial(db, { type: "system.access.denied", payload: { reason: { kind: "x" } } }),
+    ).toBeNull();
+    expect(rowCount(db)).toBe(0);
+  });
+
+  it("parses stack-less local subjects too", () => {
+    const res = projectGovernanceDenial(
+      db,
+      deniedEnvelope("unknown_principal"),
+      "local.jc.system.access.denied",
+    );
+    expect(res).not.toBeNull();
+    const [row] = listRecentDenials(db, 30, 1);
+    expect(row?.principal).toBe("jc");
+    expect(row?.stack).toBeNull();
+  });
+});
+
+describe("refusal classification (isRefusalReason)", () => {
+  it("sovereignty + visibility kinds are refusals; authz/chain kinds are not", () => {
+    expect(isRefusalReason("sovereignty_model_class")).toBe(true);
+    expect(isRefusalReason("sovereignty_mismatch")).toBe(true);
+    expect(isRefusalReason("residency_blocked")).toBe(true);
+    expect(isRefusalReason("model_class_blocked")).toBe(true);
+    expect(isRefusalReason("classification_exceeds_max")).toBe(true);
+    // Generic denials.
+    expect(isRefusalReason("chain_verify_failed")).toBe(false);
+    expect(isRefusalReason("chain_verify_fault")).toBe(false);
+    expect(isRefusalReason("originator_denied")).toBe(false);
+    expect(isRefusalReason("insufficient_role")).toBe(false);
+    expect(isRefusalReason(null)).toBe(false);
+  });
+});
+
+describe("renderer seam (U3.1)", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("the dispatch adapter grammar matches real derived system.access subjects", () => {
+    const derived = [
+      "local.switch-soc.default.system.access.denied",
+      "local.jc.system.access.filtered",
+      "federated.andreas.default.system.access.denied",
+    ];
+    for (const subject of derived) {
+      const matched = DISPATCH_PROJECTION_SUBJECTS.some((p) => subjectMatches(p, subject));
+      expect(matched).toBe(true);
+    }
+  });
+
+  it("render() routes a forced gate-refusal into a row and never throws on garbage", async () => {
+    const adapter = createDispatchProjectionRenderer(db);
+    // The live-oracle shape: a forced gate-refusal (sovereignty_model_class).
+    const env = {
+      id: crypto.randomUUID(),
+      source: "switch-soc.default.cortex",
+      type: "system.access.denied",
+      timestamp: new Date().toISOString(),
+      sovereignty: { classification: "local", data_residency: "CH", max_hop: 0, frontier_ok: false, model_class: "local-only" },
+      payload: {
+        principal_id: "switch-soc",
+        capability: "chat",
+        envelope_subject: "local.switch-soc.default.dispatch.task.received",
+        reason: { kind: "sovereignty_model_class", reason: "frontier demand on local-only class", enforced: true },
+      },
+    } as unknown as Envelope;
+    await adapter.render(env, undefined, SUBJECT);
+    expect(rowCount(db)).toBe(1);
+
+    const [row] = listRecentDenials(db, 30, 1);
+    expect(row?.reasonKind).toBe("sovereignty_model_class");
+    expect(row?.isRefusal).toBe(true);
+
+    // Garbage payload through the same seam — swallowed, not thrown.
+    const garbage = { ...env, id: crypto.randomUUID(), payload: "not-an-object" } as unknown as Envelope;
+    await adapter.render(garbage, undefined, SUBJECT);
+    expect(rowCount(db)).toBe(1);
+  });
+});
+
+describe("30-day window (listRecentDenials / summarizeDenials)", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("includes rows inside 30d and excludes a row backdated past 30d", () => {
+    const inside = projectGovernanceDenial(db, deniedEnvelope("chain_verify_failed"), SUBJECT);
+    const old = projectGovernanceDenial(db, deniedEnvelope("insufficient_role"), SUBJECT);
+    expect(inside?.rowId).not.toBeNull();
+    expect(old?.rowId).not.toBeNull();
+
+    // Backdate the second row to 31 days ago.
+    backdateDenial(db, old!.rowId!, 31 * 24 * 60 * 60 * 1000);
+
+    const rows = listRecentDenials(db, 30, 100);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.reasonKind).toBe("chain_verify_failed");
+
+    const s = summarizeDenials(db, 30);
+    expect(s.total).toBe(1);
+    expect(s.byReasonKind.insufficient_role).toBeUndefined();
+  });
+
+  it("summary splits refusals from generic denials over the window", () => {
+    projectGovernanceDenial(db, deniedEnvelope("sovereignty_model_class"), SUBJECT);
+    projectGovernanceDenial(db, filteredEnvelope("residency_blocked"), SUBJECT);
+    projectGovernanceDenial(db, deniedEnvelope("chain_verify_failed"), SUBJECT);
+    projectGovernanceDenial(db, deniedEnvelope("insufficient_role"), SUBJECT);
+
+    const s = summarizeDenials(db, 30);
+    expect(s.total).toBe(4);
+    expect(s.refusals).toBe(2); // sovereignty_model_class + residency_blocked
+    expect(s.otherDenials).toBe(2); // chain_verify_failed + insufficient_role
+    expect(s.denials24h).toBe(4);
+  });
+});
+
+describe("retention (pruneOldGovernanceDenials)", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("prunes a denial past the 35d retention window, keeps one inside the 30d query window", () => {
+    const fresh = projectGovernanceDenial(db, deniedEnvelope("chain_verify_failed"), SUBJECT);
+    const stale = projectGovernanceDenial(db, deniedEnvelope("insufficient_role"), SUBJECT);
+    backdateDenial(db, fresh!.rowId!, 5 * 24 * 60 * 60 * 1000); // 5d — inside 30d
+    backdateDenial(db, stale!.rowId!, GOVERNANCE_DENIAL_RETENTION_MS + 24 * 60 * 60 * 1000); // 36d
+
+    const res = pruneOldGovernanceDenials(db);
+    expect(res.prunedGovernanceDenials).toBe(1);
+    expect(rowCount(db)).toBe(1);
+    expect(listRecentDenials(db, 30, 10)[0]?.reasonKind).toBe("chain_verify_failed");
+  });
+
+  it("pruneRetention reports the governance-denial prune in its summary", () => {
+    const stale = projectGovernanceDenial(db, deniedEnvelope("originator_denied"), SUBJECT);
+    backdateDenial(db, stale!.rowId!, GOVERNANCE_DENIAL_RETENTION_MS + 24 * 60 * 60 * 1000);
+    const summary = pruneRetention(db);
+    expect(summary.ok).toBe(true);
+    expect(summary.prunedGovernanceDenials).toBe(1);
+  });
+});
+
+describe("GET /api/governance (denials dimension)", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("empty DB → zero denial summary, empty list", () => {
+    const res = getGovernance(db);
+    expect(res.denials).toHaveLength(0);
+    expect(res.denialSummary.total).toBe(0);
+    expect(res.denialSummary.refusals).toBe(0);
+    expect(res.denialSummary.otherDenials).toBe(0);
+  });
+
+  it("surfaces denials + refusals and folds them into the alarm tier with verdict denials", () => {
+    // 3 access denials/refusals in 24h.
+    insertGovernanceDenial(db, { envelopeId: crypto.randomUUID(), kind: "denied", reasonKind: "sovereignty_model_class", payload: {} });
+    insertGovernanceDenial(db, { envelopeId: crypto.randomUUID(), kind: "filtered", reasonKind: "residency_blocked", payload: {} });
+    insertGovernanceDenial(db, { envelopeId: crypto.randomUUID(), kind: "denied", reasonKind: "chain_verify_failed", payload: {} });
+    // 3 governed-action verdict denials in 24h (resolved deny ×2 + l0 deny).
+    insertGovernanceVerdict(db, { envelopeId: crypto.randomUUID(), layer: "resolved", decision: "deny", name: "x", payload: {} });
+    insertGovernanceVerdict(db, { envelopeId: crypto.randomUUID(), layer: "resolved", decision: "deny", name: "x", payload: {} });
+    insertGovernanceVerdict(db, { envelopeId: crypto.randomUUID(), layer: "l0", decision: "deny", name: "x", payload: {} });
+
+    const res = getGovernance(db);
+    expect(res.denialSummary.total).toBe(3);
+    expect(res.denialSummary.refusals).toBe(2); // sovereignty_model_class + residency_blocked
+    expect(res.denialSummary.otherDenials).toBe(1); // chain_verify_failed
+    // alarm combines: 3 verdict denials + 3 access denials = 6/24h → high (≥5).
+    expect(res.alarm.denials24h).toBe(6);
+    expect(res.alarm.tier).toBe("high");
+    expect(res.denials).toHaveLength(3);
+  });
+});

--- a/src/surface/mc/api/governance.ts
+++ b/src/surface/mc/api/governance.ts
@@ -14,8 +14,12 @@ import type { Database } from "bun:sqlite";
 import {
   listRecentVerdicts,
   summarizeGovernance,
+  listRecentDenials,
+  summarizeDenials,
   type GovernanceSummary,
   type GovernanceVerdictRow,
+  type GovernanceDenialRow,
+  type GovernanceDenialSummary,
 } from "../db/governance";
 
 export const GOVERNANCE_WINDOW_DAYS = 30;
@@ -25,14 +29,24 @@ export type GovernanceAlarmTier = "none" | "elevated" | "high";
 
 export interface GovernanceAlarm {
   tier: GovernanceAlarmTier;
-  /** Denials observed in the last 24h — the tier's input, always disclosed. */
+  /**
+   * The tier's input: verdict denials + access denials/refusals observed in the
+   * last 24h, combined. Always disclosed (no opaque tiering).
+   */
   denials24h: number;
   note: string;
 }
 
 export interface GovernanceResponse {
+  /** Governed-action verdict rows (governance.verdict.*). */
   verdicts: GovernanceVerdictRow[];
   summary: GovernanceSummary;
+  /**
+   * P-14 U3.1 (#936) — access-gate denial rows (U0.2's system.access.*), newest
+   * first. Refusals (sovereignty subset) carry `isRefusal: true`.
+   */
+  denials: GovernanceDenialRow[];
+  denialSummary: GovernanceDenialSummary;
   alarm: GovernanceAlarm;
   windowDays: number;
   listCap: number;
@@ -44,16 +58,23 @@ export function alarmFor(denials24h: number): GovernanceAlarm {
   const note =
     tier === "none"
       ? "0 denials in the last 24h (window measured: 24h — absence of denials is not absence of risk)"
-      : `${denials24h} denial${denials24h === 1 ? "" : "s"} in the last 24h`;
+      : `${denials24h} denial${denials24h === 1 ? "" : "s"} in the last 24h (verdict denials + access denials/refusals)`;
   return { tier, denials24h, note };
 }
 
 export function getGovernance(db: Database): GovernanceResponse {
   const summary = summarizeGovernance(db, GOVERNANCE_WINDOW_DAYS);
+  const denialSummary = summarizeDenials(db, GOVERNANCE_WINDOW_DAYS);
+  // The alarm tier combines the governed-action verdict denials with the
+  // access-gate denials/refusals over the SAME 24h window — both are governance
+  // "no" signals, so a spike in either should raise the banner.
+  const combined24h = summary.denials24h + denialSummary.denials24h;
   return {
     verdicts: listRecentVerdicts(db, GOVERNANCE_WINDOW_DAYS, GOVERNANCE_LIST_CAP),
     summary,
-    alarm: alarmFor(summary.denials24h),
+    denials: listRecentDenials(db, GOVERNANCE_WINDOW_DAYS, GOVERNANCE_LIST_CAP),
+    denialSummary,
+    alarm: alarmFor(combined24h),
     windowDays: GOVERNANCE_WINDOW_DAYS,
     listCap: GOVERNANCE_LIST_CAP,
   };

--- a/src/surface/mc/dashboard-v2/components/governance-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/governance-view.tsx
@@ -1,17 +1,26 @@
 /**
- * G-1115 — Governance tab (governance upgrade Stage 5).
+ * G-1115 / P-14 U3.1 (#936) — Governance tab (governance upgrade Stage 5).
  *
- * Read-only audit surface over the governed-action stack's bus verdicts
- * (`governance.verdict.{l0,tribunal,gate,resolved}` — pulse P-702): alarm
- * banner (deterministic tier on 24h denials), window summary, and the 30d
- * verdict list. RavenClaude's Heimdall/Víðarr concept, reading the bus.
+ * Read-only audit surface with TWO dimensions over a 30-day window:
+ *   1. VERDICTS — the governed-action stack's bus verdicts
+ *      (`governance.verdict.{l0,tribunal,gate,resolved}` — pulse P-702).
+ *   2. DENIALS / REFUSALS (#936) — U0.2's access-gate decisions
+ *      (`system.access.{denied,filtered}`). A REFUSAL is the sovereignty subset
+ *      (`sovereignty_model_class` / residency / model-class / classification);
+ *      everything else (authz, chain-verify, originator) is a generic denial.
+ * Plus a deterministic alarm banner (tier on combined 24h denials) + window
+ * summaries. RavenClaude's Heimdall/Víðarr concept, reading the bus.
  *
- * Honest empty state: "no verdicts recorded" means no governed pipelines have
- * run in the window — it is NOT an all-clear, and the copy says so.
+ * Honest empty states: "no verdicts recorded" / "no access denials recorded"
+ * mean nothing reached this stack's projection in the window — NOT an all-clear,
+ * and the copy says so.
  */
 
 import type { GovernanceState } from "../hooks/use-governance";
-import type { GovernanceVerdictRow } from "../../db/governance";
+import type {
+  GovernanceVerdictRow,
+  GovernanceDenialRow,
+} from "../../db/governance";
 
 const LAYER_LABEL: Record<string, string> = {
   l0: "L0 policy",
@@ -38,13 +47,16 @@ export interface GovernanceViewProps {
 export function GovernanceView({ state }: GovernanceViewProps) {
   const { data, loaded, error } = state;
 
+  const hasAnyData =
+    data !== null && (data.summary.total > 0 || data.denialSummary.total > 0);
+
   return (
     <section className="scaffold-section governance-view" aria-label="Governance">
       <h2>
         Governance{" "}
-        {loaded && data && data.summary.total > 0 ? (
+        {loaded && hasAnyData && data ? (
           <span className="dim">
-            ({data.summary.total} verdicts / {data.windowDays}d)
+            ({data.summary.total} verdicts · {data.denialSummary.total} denials / {data.windowDays}d)
           </span>
         ) : null}
       </h2>
@@ -52,29 +64,48 @@ export function GovernanceView({ state }: GovernanceViewProps) {
       {!loaded ? (
         <p className="dim">Loading…</p>
       ) : error ? (
-        <p className="dim">Could not load governance verdicts: {error}</p>
-      ) : !data || data.summary.total === 0 ? (
+        <p className="dim">Could not load governance data: {error}</p>
+      ) : !data ? (
+        <p className="dim">No governance data available.</p>
+      ) : (
+        <>
+          {hasAnyData ? (
+            <p
+              className={`governance-alarm alarm-${data.alarm.tier}`}
+              role={data.alarm.tier === "high" ? "alert" : undefined}
+            >
+              <strong>
+                {data.alarm.tier === "none"
+                  ? "No active alarm"
+                  : data.alarm.tier === "elevated"
+                    ? "Elevated"
+                    : "High"}
+              </strong>{" "}
+              — {data.alarm.note}
+            </p>
+          ) : null}
+
+          <VerdictsSection data={data} />
+          <DenialsSection data={data} />
+        </>
+      )}
+    </section>
+  );
+}
+
+/** Governed-action verdicts (governance.verdict.*) — 30d window. */
+function VerdictsSection({ data }: { data: NonNullable<GovernanceState["data"]> }) {
+  return (
+    <div className="governance-subsection governance-verdicts" aria-label="Verdicts">
+      <h3>Verdicts</h3>
+      {data.summary.total === 0 ? (
         <p className="dim">
-          No governance verdicts recorded in the last {data?.windowDays ?? 30} days. Either no
-          governed pipelines ran, or their verdicts never reached this stack&apos;s projection
-          (bus, validation, or retention). Absence of records is not an all-clear.
+          No governance verdicts recorded in the last {data.windowDays} days. Either no governed
+          pipelines ran, or their verdicts never reached this stack&apos;s projection (bus,
+          validation, or retention). Absence of records is not an all-clear.
         </p>
       ) : (
         <>
-          <p
-            className={`governance-alarm alarm-${data.alarm.tier}`}
-            role={data.alarm.tier === "high" ? "alert" : undefined}
-          >
-            <strong>
-              {data.alarm.tier === "none"
-                ? "No active alarm"
-                : data.alarm.tier === "elevated"
-                  ? "Elevated"
-                  : "High"}
-            </strong>{" "}
-            — {data.alarm.note}
-          </p>
-
           <p className="governance-summary dim">
             outcomes: {data.summary.allows} allow · {data.summary.denials} deny ·{" "}
             {data.summary.defers} defer&ensp;|&ensp;layers: {data.summary.byLayer.l0} L0 ·{" "}
@@ -121,6 +152,72 @@ export function GovernanceView({ state }: GovernanceViewProps) {
           </table>
         </>
       )}
-    </section>
+    </div>
+  );
+}
+
+/**
+ * P-14 U3.1 (#936) — access denials / refusals (U0.2's system.access.*), 30d.
+ * Refusals (sovereignty subset) are badged distinctly from generic denials.
+ */
+function DenialsSection({ data }: { data: NonNullable<GovernanceState["data"]> }) {
+  const s = data.denialSummary;
+  return (
+    <div className="governance-subsection governance-denials" aria-label="Denials and refusals">
+      <h3>Denials &amp; refusals</h3>
+      {s.total === 0 ? (
+        <p className="dim">
+          No access denials recorded in the last {data.windowDays} days. Either nothing was denied
+          or refused, or U0.2&apos;s <code>system.access.*</code> envelopes never reached this
+          stack&apos;s projection (bus, validation, or retention). Absence of records is not an
+          all-clear.
+        </p>
+      ) : (
+        <>
+          <p className="governance-summary dim">
+            {s.refusals} sovereignty refusal{s.refusals === 1 ? "" : "s"} · {s.otherDenials} other
+            denial{s.otherDenials === 1 ? "" : "s"}
+            {data.denials.length < s.total
+              ? ` | showing newest ${data.denials.length} of ${s.total}`
+              : ""}
+          </p>
+
+          <table className="governance-table">
+            <thead>
+              <tr>
+                <th>when (UTC)</th>
+                <th>type</th>
+                <th>reason</th>
+                <th>principal</th>
+                <th>capability</th>
+                <th>origin</th>
+                <th>detail</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.denials.map((d: GovernanceDenialRow) => (
+                <tr key={d.id} className={d.isRefusal ? "verdict-defer" : "verdict-deny"}>
+                  <td className="dim">{when(d.createdAt)}</td>
+                  <td>
+                    <span className={`badge ${d.isRefusal ? "decision-defer" : "decision-deny"}`}>
+                      {d.isRefusal ? "refusal" : "denial"}
+                      {d.kind === "filtered" ? <span className="dim"> (filtered)</span> : null}
+                    </span>
+                  </td>
+                  <td className="governance-reason">{d.reasonKind}</td>
+                  <td className="dim">{d.principalId ?? "—"}</td>
+                  <td className="dim">{d.capability ?? "—"}</td>
+                  <td className="dim">
+                    {d.principal ?? "?"}
+                    {d.stack ? `/${d.stack}` : ""}
+                  </td>
+                  <td className="dim governance-reason">{d.detail ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
   );
 }

--- a/src/surface/mc/dashboard-v2/hooks/use-governance.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-governance.ts
@@ -1,10 +1,11 @@
 /**
  * G-1115 — governance verdicts hook (governance upgrade Stage 5).
  *
- * Fetches `GET /api/governance` (30d verdicts + summary + alarm tier) and
- * keeps it fresh by subscribing to the `mc.projection` WS frame with family
- * `governance.verdict`: every projected verdict broadcasts a refresh signal,
- * which triggers a debounced refetch. The frame is a REFRESH SIGNAL, not
+ * Fetches `GET /api/governance` (30d verdicts + denials/refusals + summary +
+ * alarm tier) and keeps it fresh by subscribing to the `mc.projection` WS frame
+ * with family `governance.verdict` OR `governance.denial` (P-14 U3.1, #936):
+ * every projected verdict or access-denial broadcasts a refresh signal, which
+ * triggers a debounced refetch. The frame is a REFRESH SIGNAL, not
  * authoritative state — the tab always re-reads the API (same discipline as
  * `use-agents` / `use-attention`).
  *
@@ -84,7 +85,9 @@ export function useGovernance(ws: WsClient, enabled: boolean): GovernanceState {
   useEffect(() => {
     function onProjection(msg: WsMessage) {
       const family = (msg as { family?: string }).family;
-      if (family !== "governance.verdict") return;
+      // P-14 U3.1 (#936) — both the verdict and the access-denial projections
+      // refresh this pane (verdicts + denials/refusals share one API + tab).
+      if (family !== "governance.verdict" && family !== "governance.denial") return;
       if (!enabledRef.current || !bootedRef.current) return;
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {

--- a/src/surface/mc/db/governance.ts
+++ b/src/surface/mc/db/governance.ts
@@ -161,3 +161,204 @@ export function summarizeGovernance(db: Database, days: number): GovernanceSumma
     denials24h,
   };
 }
+
+// ===========================================================================
+// P-14 U3.1 (#936) — governance_denials storage.
+//
+// Pipeline-level access-decision rows projected from U0.2's (#932)
+// `system.access.{denied,filtered}` envelopes — the access-gate dimension of
+// the governance pane, sibling to `governance_verdicts` (the governed-action
+// pipeline dimension). SAME discipline: append-only from the projection's
+// view, idempotent on `envelope_id` (at-least-once redelivery-safe), windowed
+// + capped reads, no update/delete surface (retention owns age-out — 30d in
+// db/retention.ts).
+//
+// A REFUSAL is the sovereignty subset of denials — `reason_kind` ===
+// 'sovereignty_model_class' (a consumer-side sovereignty gate refused a task
+// whose model-class demand its own class would violate, U0.2 §reason-kinds),
+// plus the three `system.access.filtered` visibility reasons
+// (`residency_blocked` / `model_class_blocked` / `classification_exceeds_max`).
+// The pane breaks denials into refusals-vs-other so a sovereignty refusal
+// reads distinctly from an authz/chain denial.
+// ===========================================================================
+
+/** The two `system.access.*` access-decision envelope kinds we project. */
+export type GovernanceDenialKind = "denied" | "filtered";
+
+/**
+ * The set of `reason_kind` values that classify a denial row as a sovereignty
+ * REFUSAL (vs. a generic authz/chain denial). Drawn from U0.2's #932
+ * `SystemAccessDeniedReason.kind` extension + the three
+ * `SystemAccessFilteredReason` visibility reasons. Membership is the single
+ * source of truth for `isRefusal` so the projection and the summary agree.
+ */
+export const REFUSAL_REASON_KINDS: ReadonlySet<string> = new Set<string>([
+  // system.access.denied — consumer-side sovereignty gate (#932)
+  "sovereignty_model_class",
+  "sovereignty_mismatch",
+  // system.access.filtered — renderer visibility drops (the three axes)
+  "residency_blocked",
+  "model_class_blocked",
+  "classification_exceeds_max",
+]);
+
+/** True when a denial's `reason_kind` is a sovereignty refusal (see set above). */
+export function isRefusalReason(reasonKind: string | null): boolean {
+  return reasonKind !== null && REFUSAL_REASON_KINDS.has(reasonKind);
+}
+
+export interface GovernanceDenialInsert {
+  envelopeId: string;
+  /** `denied` (access gate) or `filtered` (renderer visibility drop). */
+  kind: GovernanceDenialKind;
+  /** The `reason.kind` discriminator (denied) or the filtered reason enum. */
+  reasonKind: string;
+  /** Principal the gate was evaluating (payload `principal_id`), when known. */
+  principalId?: string | null;
+  /** Capability claim evaluated (denied) — null for filtered drops. */
+  capability?: string | null;
+  /** Subject of the ORIGINATING envelope the decision was about. */
+  envelopeSubject?: string | null;
+  /** Free-form detail (reason text / verify_reason / fault / detail). */
+  detail?: string | null;
+  source?: string | null;
+  subject?: string | null;
+  principal?: string | null;
+  stack?: string | null;
+  payload: Record<string, unknown>;
+}
+
+export interface GovernanceDenialRow {
+  id: string;
+  envelopeId: string;
+  kind: GovernanceDenialKind;
+  reasonKind: string;
+  /** Derived from `reasonKind` — sovereignty refusal vs generic denial. */
+  isRefusal: boolean;
+  principalId: string | null;
+  capability: string | null;
+  envelopeSubject: string | null;
+  detail: string | null;
+  principal: string | null;
+  stack: string | null;
+  createdAt: number;
+}
+
+/** Insert one access-denial row. Returns the row id, or null when the envelope
+ *  was already projected (idempotent redelivery no-op). */
+export function insertGovernanceDenial(
+  db: Database,
+  d: GovernanceDenialInsert,
+): string | null {
+  const id = crypto.randomUUID();
+  const res = db
+    .query(
+      `INSERT INTO governance_denials
+         (id, envelope_id, kind, reason_kind, principal_id, capability,
+          envelope_subject, detail, source, subject, principal, stack, payload)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(envelope_id) DO NOTHING`,
+    )
+    .run(
+      id,
+      d.envelopeId,
+      d.kind,
+      d.reasonKind,
+      d.principalId ?? null,
+      d.capability ?? null,
+      d.envelopeSubject ?? null,
+      d.detail ?? null,
+      d.source ?? null,
+      d.subject ?? null,
+      d.principal ?? null,
+      d.stack ?? null,
+      JSON.stringify(d.payload),
+    );
+  return res.changes > 0 ? id : null;
+}
+
+function mapDenialRow(r: Record<string, unknown>): GovernanceDenialRow {
+  const reasonKind = r.reason_kind as string;
+  return {
+    id: r.id as string,
+    envelopeId: r.envelope_id as string,
+    kind: r.kind as GovernanceDenialKind,
+    reasonKind,
+    isRefusal: isRefusalReason(reasonKind),
+    principalId: (r.principal_id as string | null) ?? null,
+    capability: (r.capability as string | null) ?? null,
+    envelopeSubject: (r.envelope_subject as string | null) ?? null,
+    detail: (r.detail as string | null) ?? null,
+    principal: (r.principal as string | null) ?? null,
+    stack: (r.stack as string | null) ?? null,
+    createdAt: r.created_at as number,
+  };
+}
+
+/** Access denials from the last `days` days, newest first, capped at `limit`. */
+export function listRecentDenials(
+  db: Database,
+  days: number,
+  limit: number,
+): GovernanceDenialRow[] {
+  const rows = db
+    .query(
+      `SELECT id, envelope_id, kind, reason_kind, principal_id, capability,
+              envelope_subject, detail, principal, stack, created_at
+       FROM governance_denials
+       WHERE created_at >= unixepoch() - (? * 86400)
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`,
+    )
+    .all(days, limit) as Record<string, unknown>[];
+  return rows.map(mapDenialRow);
+}
+
+export interface GovernanceDenialSummary {
+  /** All denial rows in the window. */
+  total: number;
+  /** Sovereignty refusals (subset of total — see {@link REFUSAL_REASON_KINDS}). */
+  refusals: number;
+  /** Generic denials (total − refusals): authz / chain-verify / originator. */
+  otherDenials: number;
+  /** Per `reason_kind` counts in the window. */
+  byReasonKind: Record<string, number>;
+  /** All denial rows (refusals included) in the last 24h — the alarm input. */
+  denials24h: number;
+}
+
+export function summarizeDenials(db: Database, days: number): GovernanceDenialSummary {
+  const windowExpr = `created_at >= unixepoch() - (? * 86400)`;
+  const byKindRows = db
+    .query(
+      `SELECT reason_kind, COUNT(*) AS n FROM governance_denials
+       WHERE ${windowExpr} GROUP BY reason_kind`,
+    )
+    .all(days) as { reason_kind: string; n: number }[];
+
+  const byReasonKind: Record<string, number> = {};
+  let total = 0;
+  let refusals = 0;
+  for (const row of byKindRows) {
+    byReasonKind[row.reason_kind] = row.n;
+    total += row.n;
+    if (isRefusalReason(row.reason_kind)) refusals += row.n;
+  }
+
+  const denials24h = (
+    db
+      .query(
+        `SELECT COUNT(*) AS n FROM governance_denials
+         WHERE created_at >= unixepoch() - 86400`,
+      )
+      .get() as { n: number }
+  ).n;
+
+  return {
+    total,
+    refusals,
+    otherDenials: total - refusals,
+    byReasonKind,
+    denials24h,
+  };
+}

--- a/src/surface/mc/db/retention.ts
+++ b/src/surface/mc/db/retention.ts
@@ -117,6 +117,25 @@ export const STUCK_RUNNING_TTL_MS = 30 * MINUTE_MS;
  */
 export const OBSERVABILITY_RETENTION_MS = 14 * DAY_MS;
 
+/**
+ * Governance-denials retention window (P-14 U3.1, #936). The `governance_denials`
+ * table is an append-only projection of U0.2's `system.access.{denied,filtered}`
+ * envelopes — no session FK to CASCADE off, so like `events` / `observability_events`
+ * it needs its own age-based prune or it grows unbounded.
+ *
+ * The governance pane queries a **30-day** window (`GOVERNANCE_WINDOW_DAYS`). The
+ * retention window MUST outlive that query window or the pane would show a
+ * truncated 30d — so this is 35 days (the 30d pane window + a 5-day buffer),
+ * mirroring how {@link EVENTS_RETENTION_MS} (14d) outlives {@link
+ * ORPHAN_RETENTION_MS} (7d). Served by `idx_governance_denials_created`.
+ *
+ * NOTE: `governance_verdicts` is intentionally NOT pruned here — its volume is
+ * pipeline-bounded (one per governed action) and its retention was deferred at
+ * inception (db/governance.ts header). Denials/refusals can be high-volume under
+ * an attack or a misconfig, so they get the bound. Module constant, no config.
+ */
+export const GOVERNANCE_DENIAL_RETENTION_MS = 35 * DAY_MS;
+
 // ORPHAN_TASK_ID is imported from ./sessions — the shared orphan anchor task,
 // preserved by the prune (only its children go). Single source of truth so the
 // DELETE anchor can't drift from the registration site.
@@ -135,6 +154,10 @@ export interface ObservabilityPruneResult {
   prunedObservability: number;
 }
 
+export interface GovernanceDenialPruneResult {
+  prunedGovernanceDenials: number;
+}
+
 export interface StuckReapResult {
   /** Orphan assignments transitioned to terminal by the liveness reaper. */
   reaped: number;
@@ -144,6 +167,7 @@ export interface RetentionSummary
   extends OrphanPruneResult,
     EventsPruneResult,
     ObservabilityPruneResult,
+    GovernanceDenialPruneResult,
     StuckReapResult {
   /** false when the prune failed (e.g. closed db) — best-effort, never throws. */
   ok: boolean;
@@ -426,8 +450,23 @@ export function pruneOldObservability(db: Database): ObservabilityPruneResult {
 }
 
 /**
+ * Prune `governance_denials` older than {@link GOVERNANCE_DENIAL_RETENTION_MS}
+ * (P-14 U3.1, #936). Age-based, mirroring {@link pruneOldObservability} but on
+ * the integer `created_at` (unix seconds) column — a single indexed DELETE
+ * (served by `idx_governance_denials_created`); idempotent. The table has no
+ * session FK, so this prune is its sole growth bound. The 35-day window outlives
+ * the pane's 30-day query window so the pane never shows a truncated 30d.
+ */
+export function pruneOldGovernanceDenials(db: Database): GovernanceDenialPruneResult {
+  const cutoffSec = Math.floor((Date.now() - GOVERNANCE_DENIAL_RETENTION_MS) / 1000);
+  const res = db.query(`DELETE FROM governance_denials WHERE created_at < ?`).run(cutoffSec);
+  return { prunedGovernanceDenials: res.changes };
+}
+
+/**
  * Run the full retention sweep: stuck-running reap → orphan terminal-row prune
- * → events age prune → observability-events age prune (#934).
+ * → events age prune → observability-events age prune (#934) →
+ * governance-denials age prune (#936).
  *
  * Ordering is load-bearing: the reaper (ST-P3) runs FIRST so zombie orphans
  * that have gone quiet past the liveness TTL are driven terminal (stamping
@@ -449,7 +488,8 @@ export function pruneRetention(db: Database): RetentionSummary {
     const orphans = pruneOrphanSessions(db);
     const events = pruneOldEvents(db);
     const observability = pruneOldObservability(db);
-    return { ok: true, ...stuck, ...orphans, ...events, ...observability };
+    const governanceDenials = pruneOldGovernanceDenials(db);
+    return { ok: true, ...stuck, ...orphans, ...events, ...observability, ...governanceDenials };
   } catch (err) {
     return {
       ok: false,
@@ -460,6 +500,7 @@ export function pruneRetention(db: Database): RetentionSummary {
       prunedAgents: 0,
       prunedEvents: 0,
       prunedObservability: 0,
+      prunedGovernanceDenials: 0,
     };
   }
 }

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -544,6 +544,35 @@ export const SCHEMA_SQL: string[] = [
   `CREATE INDEX IF NOT EXISTS idx_governance_created ON governance_verdicts(created_at)`,
   `CREATE INDEX IF NOT EXISTS idx_governance_decision ON governance_verdicts(decision, created_at)`,
 
+  // P-14 U3.1 (#936) — governance access denials. Pipeline-level access-decision
+  // rows projected from U0.2's (#932) `system.access.{denied,filtered}` envelopes
+  // — the access-gate dimension of the governance pane, sibling to
+  // `governance_verdicts` (the governed-action dimension). `kind` distinguishes
+  // a hard access deny from a renderer visibility filter; `reason_kind` carries
+  // the deny/filter discriminator (`sovereignty_model_class`, `chain_verify_failed`,
+  // `chain_verify_fault`, `residency_blocked`, …) — the sovereignty subset is the
+  // pane's REFUSALS. Append-only; `envelope_id` UNIQUE makes redelivery idempotent;
+  // retention ages rows past 30d (db/retention.ts).
+  `CREATE TABLE IF NOT EXISTS governance_denials (
+    id TEXT PRIMARY KEY,
+    envelope_id TEXT NOT NULL UNIQUE,
+    kind TEXT NOT NULL
+      CHECK(kind IN ('denied','filtered')),
+    reason_kind TEXT NOT NULL,
+    principal_id TEXT,
+    capability TEXT,
+    envelope_subject TEXT,
+    detail TEXT,
+    source TEXT,
+    subject TEXT,
+    principal TEXT,
+    stack TEXT,
+    payload TEXT NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_governance_denials_created ON governance_denials(created_at)`,
+  `CREATE INDEX IF NOT EXISTS idx_governance_denials_reason ON governance_denials(reason_kind, created_at)`,
+
   // P-14 U2.1 (#934) — Observability events. Append-only projection rows from
   // signal's four `system.*` envelope families (`system.signal.*`,
   // `system.signal.collector.*`, `system.federation.*`, `system.transport.*`),

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -552,7 +552,7 @@ export const SCHEMA_SQL: string[] = [
   // the deny/filter discriminator (`sovereignty_model_class`, `chain_verify_failed`,
   // `chain_verify_fault`, `residency_blocked`, …) — the sovereignty subset is the
   // pane's REFUSALS. Append-only; `envelope_id` UNIQUE makes redelivery idempotent;
-  // retention ages rows past 30d (db/retention.ts).
+  // retention ages rows past 35d, outliving the 30d query window (db/retention.ts).
   `CREATE TABLE IF NOT EXISTS governance_denials (
     id TEXT PRIMARY KEY,
     envelope_id TEXT NOT NULL UNIQUE,

--- a/src/surface/mc/notifications.ts
+++ b/src/surface/mc/notifications.ts
@@ -199,6 +199,9 @@ export type ProjectionFamily =
   | "attention"
   | "adapter.health"
   | "governance.verdict"
+  // P-14 U3.1 (#936) — access denials/refusals (U0.2's system.access.*) refresh
+  // the governance pane alongside verdicts. Additive; older clients ignore it.
+  | "governance.denial"
   // P-14 U2.1 (#934) — signal's four system.* observability families refreshed
   // the Observability tab. Additive; older clients ignore an unknown family.
   | "observability";

--- a/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
@@ -53,6 +53,7 @@ import { projectHeartbeat } from "./heartbeat";
 import { projectAttention } from "./attention-projection";
 import { projectAdapterLifecycle } from "./adapter-lifecycle";
 import { projectGovernanceVerdict } from "./governance-verdict";
+import { projectGovernanceDenial } from "./governance-denial";
 import {
   produceFailedDispatchAttention,
   type AttentionDelta,
@@ -130,6 +131,12 @@ export const DISPATCH_PROJECTION_SUBJECTS: string[] = [
   "local.*.governance.verdict.*",
   "local.*.*.governance.verdict.*",
   "federated.*.*.governance.verdict.*",
+  // governance denials (P-14 U3.1, #936) — U0.2's system.access.{denied,filtered}.
+  // The access-gate dimension of the governance pane; same broad-subject /
+  // type-filter discipline as the verdict family above.
+  "local.*.system.access.*",
+  "local.*.*.system.access.*",
+  "federated.*.*.system.access.*",
 ];
 
 /** A structural view of an envelope the projections read (kept loose so any
@@ -239,6 +246,17 @@ export function project(
     if (res !== null) {
       // Refresh signal only (the attention pattern) — the tab re-reads the API.
       broadcastProjection(wsRegistry, "governance.verdict");
+    }
+    return;
+  }
+
+  // governance denials (P-14 U3.1 — #936): U0.2's system.access.{denied,filtered}
+  // feed the governance pane's denials/refusals dimension. Same refresh-signal
+  // discipline as verdicts — the tab re-reads /api/governance.
+  if (type === "system.access.denied" || type === "system.access.filtered") {
+    const res = projectGovernanceDenial(db, envelope, subject);
+    if (res !== null) {
+      broadcastProjection(wsRegistry, "governance.denial");
     }
     return;
   }

--- a/src/surface/mc/projection/governance-denial.ts
+++ b/src/surface/mc/projection/governance-denial.ts
@@ -1,0 +1,180 @@
+/**
+ * P-14 U3.1 (#936) — project U0.2's (#932) `system.access.{denied,filtered}`
+ * envelopes into the governance pane's DENIALS dimension.
+ *
+ * U0.2 emits two access-decision envelope shapes (src/bus/system-events.ts):
+ *
+ *   system.access.denied   → {
+ *                              principal_id, capability,
+ *                              reason: { kind: <discriminator>, ...variant },
+ *                              envelope_subject, envelope_id, signed_by[]
+ *                            }
+ *      reason.kind values (U0.2 §reason-kinds): the consumer-side fail-closed
+ *      drops emit `sovereignty_model_class` / `chain_verify_failed` /
+ *      `chain_verify_fault` / `originator_denied`; the C.4 / D.2 gate flavours
+ *      emit `unknown_principal` / `insufficient_role` / `sovereignty_mismatch`
+ *      / `peer_not_in_accept_list` / `peer_deny_list`.
+ *
+ *   system.access.filtered → { renderer_id, envelope_subject, reason: <enum> }
+ *      reason is a flat string enum (NOT a nested record):
+ *      `residency_blocked` | `model_class_blocked` | `classification_exceeds_max`.
+ *
+ * Stored as pipeline-level audit rows in `governance_denials` — sibling to the
+ * `governance.verdict.*` projection (governance-verdict.ts). The sovereignty
+ * subset of `reason_kind` is the pane's REFUSALS (db/governance.ts owns the
+ * classification set so projection + summary can't drift).
+ *
+ * Non-throwing: a malformed payload returns null (no-op) — the renderer's
+ * try/catch is the outer belt. Idempotent on envelope id (UNIQUE on
+ * `envelope_id`) so a JetStream redelivery never double-inserts.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import {
+  insertGovernanceDenial,
+  type GovernanceDenialKind,
+} from "../db/governance";
+
+/** Minimal projectable shape — the renderer hands any validated envelope here. */
+export interface ProjectableDenialEnvelope {
+  id?: string;
+  type: string;
+  source?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface GovernanceDenialProjectionResult {
+  kind: GovernanceDenialKind;
+  reasonKind: string;
+  /** Row id, or null when this envelope was already projected (redelivery). */
+  rowId: string | null;
+}
+
+/**
+ * Project one `system.access.{denied,filtered}` envelope. Returns null for any
+ * other type (the authoritative filter — the renderer subscribes broadly), an
+ * envelope missing an idempotency key, or a payload from which no `reason_kind`
+ * can be extracted (malformed).
+ */
+export function projectGovernanceDenial(
+  db: Database,
+  envelope: ProjectableDenialEnvelope,
+  subject?: string,
+): GovernanceDenialProjectionResult | null {
+  const kind = denialKind(envelope.type);
+  if (kind === null) return null;
+
+  const envelopeId = asString(envelope.id);
+  if (envelopeId === null) return null; // no idempotency key — refuse to project
+
+  const rawPayload: unknown = envelope.payload;
+  const payload =
+    typeof rawPayload === "object" && rawPayload !== null
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+
+  const reasonKind = reasonKindFor(kind, payload);
+  if (reasonKind === null) {
+    process.stderr.write(
+      `[mission-control] governance-denial: ignoring ${envelope.type} — no reason kind\n`,
+    );
+    return null;
+  }
+
+  const { principal, stack } = subjectIdentity(subject);
+
+  const rowId = insertGovernanceDenial(db, {
+    envelopeId,
+    kind,
+    reasonKind,
+    principalId: asString(payload.principal_id),
+    capability: asString(payload.capability),
+    envelopeSubject: asString(payload.envelope_subject),
+    detail: detailFor(kind, payload),
+    source: asString(envelope.source),
+    subject: subject ?? null,
+    principal,
+    stack,
+    payload,
+  });
+
+  return { kind, reasonKind, rowId };
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+function denialKind(type: string): GovernanceDenialKind | null {
+  if (type === "system.access.denied") return "denied";
+  if (type === "system.access.filtered") return "filtered";
+  return null;
+}
+
+/**
+ * `denied` carries a nested `reason: { kind }` record; `filtered` carries a
+ * flat `reason` string enum. Either absence is malformed (→ null, dropped).
+ */
+function reasonKindFor(
+  kind: GovernanceDenialKind,
+  payload: Record<string, unknown>,
+): string | null {
+  if (kind === "filtered") return asString(payload.reason);
+  // denied — reason is the structured PolicyDenyReason record.
+  const reason = payload.reason;
+  if (typeof reason === "object" && reason !== null) {
+    return asString((reason as Record<string, unknown>).kind);
+  }
+  return null;
+}
+
+/**
+ * Best-effort free-form detail for the row, by variant. `denied` reasons carry
+ * variant fields off `reason` (reason text, verify_reason, fault, detail);
+ * `filtered` carries the dropping renderer id.
+ */
+function detailFor(
+  kind: GovernanceDenialKind,
+  payload: Record<string, unknown>,
+): string | null {
+  if (kind === "filtered") return asString(payload.renderer_id);
+  const reason = payload.reason;
+  if (typeof reason === "object" && reason !== null) {
+    const r = reason as Record<string, unknown>;
+    return (
+      asString(r.reason) ??
+      asString(r.verify_reason) ??
+      asString(r.fault) ??
+      asString(r.detail) ??
+      asString(r.missing_capability)
+    );
+  }
+  return null;
+}
+
+/**
+ * Parse `{principal}` + optional `{stack}` from the NATS subject. Mirrors
+ * governance-verdict.ts: the access domain is `system.access.{denied,filtered}`,
+ * so the anchor segment is `system`:
+ *   local.{principal}.system.access.{kind}            (stack-less)
+ *   local.{principal}.{stack}.system.access.{kind}    (stack-ful)
+ *   federated.{principal}.{stack}.system.access.{kind}
+ */
+function subjectIdentity(subject: string | undefined): {
+  principal: string | null;
+  stack: string | null;
+} {
+  if (!subject) return { principal: null, stack: null };
+  const segments = subject.split(".");
+  const sys = segments.indexOf("system");
+  if (sys < 2) return { principal: null, stack: null };
+  return {
+    principal: segments[1] ?? null,
+    stack: sys >= 3 ? (segments[2] ?? null) : null,
+  };
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -106,6 +106,8 @@ export type WsServerMessage =
         | "dispatch.lifecycle"
         | "review.verdict"
         | "governance.verdict"
+        // P-14 U3.1 (#936) — governance pane denials/refresh family. Additive.
+        | "governance.denial"
         | "agent.heartbeat"
         | "attention"
         | "adapter.health"


### PR DESCRIPTION
Closes #936. Part of signal P-14 (plan row 10). Depends on U0.2 (#932, merged) + U2.1 (#934, merged).

## What

Extends the existing governance surface (G-1115) into a Stage-5 pane spanning **three dimensions over a 30-day window**:

- **Verdicts** — existing `governance.verdict.{l0,tribunal,gate,resolved}` (unchanged).
- **Denials** — new projection of U0.2's `system.access.{denied,filtered}` envelopes into a sibling `governance_denials` table.
- **Refusals** — the sovereignty subset of denials (`sovereignty_model_class` / `sovereignty_mismatch` + the three `filtered` visibility reasons `residency_blocked` / `model_class_blocked` / `classification_exceeds_max`), badged distinctly from generic authz/chain denials.

## How U0.2's `system.access.*` denials project into the pane

- New `projection/governance-denial.ts` parses `system.access.denied` (nested `reason.kind` — `sovereignty_model_class` / `chain_verify_failed` / `chain_verify_fault` / `originator_denied` / authz kinds) and `system.access.filtered` (flat `reason` enum) into `governance_denials` rows. Idempotent on `envelope_id`, non-throwing, principal/stack parsed off the subject.
- Refusal classification lives in `db/governance.ts:REFUSAL_REASON_KINDS` — a single source of truth shared by the projection and the summary so they can't drift.
- Wired **additively** into the existing `dispatch-lifecycle-renderer` (NOT a new surface-router renderer — co-located with the verdict projection since both feed one pane): three new `system.access.*` subjects + a `system.access.{denied,filtered}` branch in `project()`, broadcasting a new `governance.denial` `mc.projection` refresh family.

## 30d retention + query

- `listRecentDenials` / `summarizeDenials` query a 30-day window (`GOVERNANCE_WINDOW_DAYS`).
- `db/retention.ts` gains `pruneOldGovernanceDenials` at a **35-day** window — it outlives the 30d pane query (mirroring how `events` retention outlives `orphans`) so the pane never shows a truncated 30d. Wired into `pruneRetention` + its summary. (`governance_verdicts` is intentionally still unpruned — pipeline-bounded volume; denials can spike under attack/misconfig, so they get the bound.)

## API + view

- `GET /api/governance` now returns `denials` + `denialSummary`; the alarm tier folds access denials/refusals into the verdict-denial count over the same 24h window.
- `governance-view.tsx` splits into **Verdicts** + **Denials & refusals** sections, each with its own honest empty state (absence of records != all-clear).
- `use-governance.ts` refetches on `governance.verdict` OR `governance.denial`.

## Gate results

- `bunx tsc --noEmit` → **0 errors**
- `bun test src/surface/mc/` → **1818 pass / 0 fail** (124 files; includes the 15 new U3.1 tests)
- `bunx eslint <changed>` → **0 errors** (`src/surface/mc/dashboard-v2/` is in the project eslint ignore — pre-existing config; the dashboard builds clean via `bun run build:dashboard`)

New tests (`src/surface/mc/__tests__/governance-denial.test.ts`): projection of `system.access.denied`/`filtered` → row; refusal classification; idempotent redelivery; fail-closed filters (no throw); renderer seam (**forced gate-refusal → governance row** — the live-oracle shape); 30d window include/exclude; retention prune (35d) + `pruneRetention` summary; API denial summary + combined alarm tier.

## Collision notes

- `governance-view.tsx` — extended (added two subsections), not rewritten.
- `dispatch-lifecycle-renderer.ts` — additive subjects + one dispatcher branch; shared with concurrent governance/observability work.
- `notifications.ts` / `ws/types.ts` — added the `governance.denial` family to both unions (kept in sync to avoid the TS2322 drift the comments warn about).
- **`app.tsx` untouched** — the governance tab already exists, so no new tab entry / no 4-edit pattern needed.

## Needs the live stack to verify

The acceptance live-oracle (a forced gate-refusal appearing in the pane end-to-end over the bus) can't be fully exercised here (Wave-3). It's covered at the unit level by the renderer-seam test that routes a `sovereignty_model_class` `system.access.denied` envelope through `adapter.render()` into a refusal row. End-to-end bus delivery + WS refresh + render in a browser still wants the live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)