### PR TITLE
fix(mc): drop deprecated "operator" from a comment — unblock whole-tree vocab gate

### DIFF
--- a/src/surface/mc/dashboard-v2/hooks/use-obs-metrics.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-obs-metrics.ts
@@ -178,7 +178,7 @@ export function useObsMetrics(enabled: boolean): ObsMetricsState {
     void fetchSummary(window);
   }, [enabled, window, fetchSummary]);
 
-  // History is lazy: only fetch once the operator opens the >14d view, and
+  // History is lazy: only fetch once the >14d view is opened, and
   // refetch on enable thereafter (so reopening the tab re-reads it).
   useEffect(() => {
     if (!enabled || !historyRequestedRef.current) return;


### PR DESCRIPTION
U4.2 (#1011) merged a comment using the deprecated term `operator` in `use-obs-metrics.ts:181`. The carve-out gate is **whole-tree**, so this turns the vocab check red for every in-flight cortex PR. Reworded to neutral phrasing. Comment-only, zero behavior change. (Process note: this slipped in because #1011 was admin-merged while its vocab check was red — gating strictly on all-checks-green going forward.)