### PR TITLE
feat(mc): #1008 — pane-of-glass via direct sibling MC-DB read aggregation (local stacks)

### DIFF
--- a/docs/config-layout/stacks/research.yaml
+++ b/docs/config-layout/stacks/research.yaml
@@ -196,6 +196,19 @@ mc:
   # A single-stack box is unaffected (discovery finds no siblings = no-op).
   aggregateLocalStacks:
     enabled: true                  # false = pin the pane to THIS stack only
+    # #1008 — DB-read pane-of-glass: the PRIMARY mechanism for LOCAL siblings.
+    # When ON (default), the serving daemon reads each local sibling stack's OWN
+    # mission-control.db READ-ONLY and merges its sessions+agents into the
+    # /api/working-agents + /api/agents feeds, origin-tagged — so the pane shows
+    # ALL local stacks as hubs with their full session TREES (sessions AND
+    # agents), with NO bus / NO presence-publish. It SUPERSEDES the #989 bus-
+    # presence path for local siblings (when dbRead is on, the bus sibling path is
+    # gated OFF for local stacks to avoid double-counting; it stays for FEDERATED
+    # cross-principal peers whose dbs live on another machine). Reads are cheap
+    # (per-request read-only SQLite open of YOUR OWN dbs on YOUR OWN box); a
+    # sibling db that's missing/locked/too-old degrades to absent, never crashing
+    # the feed. Set false to fall back to the #989 bus path (agents only, no trees).
+    dbRead: true
     configRoot: ""                 # empty = the serving config dir's parent (~/.config/cortex)
     # Explicit roster OVERRIDES auto-discovery when non-empty (precedence:
     # explicit > discovery). Use it to add a bus the scan can't see, or to

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -141,7 +141,7 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
       encryption: { payload: "off", at_rest: "off" },
       transport: { mtls: "off" },
     },
-    mc: { enabled: false, configPath: "", dbPath: "", port: 0, sideband: "http://127.0.0.1:9092", aggregateLocalStacks: { enabled: true, configRoot: "", stacks: [] } },
+    mc: { enabled: false, configPath: "", dbPath: "", port: 0, sideband: "http://127.0.0.1:9092", aggregateLocalStacks: { enabled: true, dbRead: true, configRoot: "", stacks: [] } },
     cockpit: {
       enabled: false,
       docsDir: "docs",

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -127,7 +127,7 @@ const TEST_CONFIG: AgentConfig = {
     dbPath: "",
     port: 0,
     sideband: "http://127.0.0.1:9092",
-    aggregateLocalStacks: { enabled: true, configRoot: "", stacks: [] },
+    aggregateLocalStacks: { enabled: true, dbRead: true, configRoot: "", stacks: [] },
   },
   networksDir: "./networks",
   networks: [],

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -592,7 +592,8 @@ describe("AgentConfigSchema.mc (MC-I1.S1)", () => {
       sideband: "http://127.0.0.1:9092",
       // #989 — local-stack aggregation defaults ON; discovery is a no-op on a
       // single-stack box (finds no siblings).
-      aggregateLocalStacks: { enabled: true, configRoot: "", stacks: [] },
+      // #1008 — dbRead pane-of-glass aggregation defaults ON alongside `enabled`.
+      aggregateLocalStacks: { enabled: true, dbRead: true, configRoot: "", stacks: [] },
     });
   });
 
@@ -738,7 +739,7 @@ describe("mc.sideband (P-14 U0.1)", () => {
         .aggregateLocalStacks;
       const fromCortex = CortexConfigSchema.parse(minConfig()).mc
         .aggregateLocalStacks;
-      const expected = { enabled: true, configRoot: "", stacks: [] };
+      const expected = { enabled: true, dbRead: true, configRoot: "", stacks: [] };
       expect(fromAgent).toEqual(expected);
       expect(fromCortex).toEqual(expected);
     });
@@ -746,6 +747,7 @@ describe("mc.sideband (P-14 U0.1)", () => {
     test("BOTH schemas parse an explicit aggregateLocalStacks roster identically", () => {
       const block = {
         enabled: true,
+        dbRead: true,
         configRoot: "~/.config/cortex",
         stacks: [
           {

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -429,7 +429,7 @@ export const McSchema = z.object({
        * shows ALL local stacks as hubs with their session TREES (the full local
        * picture: sessions AND agents), with NO bus / NO presence-publish.
        *
-       * This is the operator-chosen PRIMARY mechanism for LOCAL siblings and
+       * This is the principal-chosen PRIMARY mechanism for LOCAL siblings and
        * SUPERSEDES the bus-presence path (#989) for them: when `dbRead` is on,
        * the #989 sibling-PRESENCE bus aggregator is gated OFF for LOCAL siblings
        * to avoid double-counting (DB-read owns local; the bus path stays for

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -422,6 +422,27 @@ export const McSchema = z.object({
     .object({
       enabled: z.boolean().default(true),
       /**
+       * #1008 — DB-read pane-of-glass aggregation. When ON (default), the
+       * dashboard-serving daemon reads each discovered LOCAL sibling stack's own
+       * `mission-control.db` READ-ONLY and merges its sessions+agents into the
+       * `/api/working-agents` + `/api/agents` feeds, origin-tagged — so the pane
+       * shows ALL local stacks as hubs with their session TREES (the full local
+       * picture: sessions AND agents), with NO bus / NO presence-publish.
+       *
+       * This is the operator-chosen PRIMARY mechanism for LOCAL siblings and
+       * SUPERSEDES the bus-presence path (#989) for them: when `dbRead` is on,
+       * the #989 sibling-PRESENCE bus aggregator is gated OFF for LOCAL siblings
+       * to avoid double-counting (DB-read owns local; the bus path stays for
+       * FEDERATED/cross-principal peers whose dbs live on another machine). Set
+       * `dbRead: false` to fall back to the #989 bus-presence path for local
+       * siblings (agents only, no session trees).
+       *
+       * Default ON. Cheap (per-request read-only SQLite open of the principal's
+       * OWN dbs on their OWN machine — ADR-0005 satisfied); a sibling db that is
+       * missing/locked/too-old degrades to absent, never crashing the feed.
+       */
+      dbRead: z.boolean().default(true),
+      /**
        * Config root to scan for sibling stacks. Empty ⇒ the serving stack's own
        * config dir's parent (the conventional `~/.config/cortex`). Leading `~`
        * is expanded at boot.
@@ -471,6 +492,7 @@ export const McSchema = z.object({
   // load-bearing for the all-defaults parse path, same as the leaves above.
   aggregateLocalStacks: {
     enabled: val.aggregateLocalStacks?.enabled ?? true,
+    dbRead: val.aggregateLocalStacks?.dbRead ?? true,
     configRoot: val.aggregateLocalStacks?.configRoot ?? "",
     stacks: val.aggregateLocalStacks?.stacks ?? [],
   },

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -171,6 +171,12 @@ import {
   type SiblingPresenceAggregatorHandle,
 } from "./surface/mc/local-aggregation/sibling-presence-subscriber";
 import { natsSiblingBusConnector } from "./surface/mc/local-aggregation/nats-sibling-connector";
+// #1008 — direct sibling MC-DB read aggregation (the pane-of-glass mechanism).
+import type {
+  LocalAggregationContext,
+  SiblingDbResolveOptions,
+} from "./surface/mc/local-aggregation/sibling-db-reader";
+import type { SiblingStackDescriptor } from "./surface/mc/local-aggregation/sibling-discovery";
 import { createProbeResponder, type ProbeResponder } from "./bus/probe-responder";
 import { WorklogManager } from "./runner/worklog-manager";
 
@@ -3589,18 +3595,76 @@ export async function startCortex(
   // registry boots AFTER this embed (below), so the getter returns `null` until
   // we assign it post-registry-start. The MC server resolves it per request.
   let presenceViewForApi: AgentPresenceView | null = null;
+  // #1008 — discovered LOCAL sibling stacks, computed ONCE here and shared by
+  // BOTH the DB-read pane-of-glass aggregation (the embed's `localAggregation`
+  // getter, below) AND the #989 bus sibling-presence aggregator (later) — so the
+  // two paths agree on the same roster and the dbRead-supersedes-bus gate is
+  // coherent. Empty until the aggregation block computes it; the getter reads
+  // this holder lazily (the embed starts before discovery runs).
+  const aggCfg = config.mc.aggregateLocalStacks;
+  let discoveredSiblings: readonly SiblingStackDescriptor[] = [];
+  let siblingResolveOpts: SiblingDbResolveOptions | null = null;
   if (config.mc.enabled && !options.disableDashboard) {
     // Per-slug default keeps each stack's MC db isolated; the cursor lands beside it.
     const defaultDbPath = join(
       homedir(), ".local", "share", "cortex", "mc", derivedStack.stack, "mission-control.db",
     );
     const dbPath = config.mc.dbPath !== "" ? expandTilde(config.mc.dbPath) : defaultDbPath;
+
+    // #1008 — discover the principal's LOCAL sibling stacks (reusing #989's
+    // `discoverSiblingStacks` for the stack LIST; the DB-read path needs the
+    // roster, not the bus part). The DB-read aggregation context resolves each
+    // sibling's `mission-control.db` per-request and excludes THIS stack's own
+    // db (`selfDbPath = dbPath`). Built only when `aggregateLocalStacks.enabled`
+    // AND `dbRead` are both on; otherwise the context getter returns null and
+    // the feeds stay single-db.
+    if (aggCfg.enabled && aggCfg.dbRead) {
+      try {
+        const configRoot =
+          aggCfg.configRoot !== ""
+            ? expandTilde(aggCfg.configRoot)
+            : dirname(configDir);
+        const explicit =
+          aggCfg.stacks.length > 0
+            ? aggCfg.stacks.map((s) => ({
+                stack: s.stack,
+                principal: s.principal,
+                url: s.url,
+                credential: { kind: "creds" as const, credsPath: s.credsPath },
+              }))
+            : undefined;
+        discoveredSiblings = discoverSiblingStacks({
+          configRoot,
+          selfPrincipal: principalId,
+          selfStack: derivedStack.stack,
+          ...(explicit !== undefined && { explicit }),
+        });
+        siblingResolveOpts = { configRoot, selfDbPath: dbPath };
+        console.log(
+          `cortex: pane-of-glass DB-read aggregation ON — ${discoveredSiblings.length} local sibling stack(s) ` +
+            `(${discoveredSiblings.map((s) => s.stack).join(", ") || "none"})`,
+        );
+      } catch (err) {
+        // Discovery failure must never block the embed boot — degrade to single-db.
+        console.error(
+          "cortex: pane-of-glass sibling discovery error (non-fatal, single-db feed):",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
     try {
       mcHandle = await startMissionControl({
         configPath: config.mc.configPath || undefined,
         dbPath,
         port: config.mc.port,
         agentPresence: () => presenceViewForApi,
+        // #1008 — DB-read pane-of-glass aggregation. The getter returns a context
+        // only when discovery produced a resolve-opts (dbRead on); otherwise null
+        // ⇒ single-db feeds. Lazy so the roster can be (re)read consistently.
+        localAggregation: (): LocalAggregationContext | null =>
+          siblingResolveOpts === null
+            ? null
+            : { siblings: discoveredSiblings, resolve: siblingResolveOpts },
         // P-14 U0.1 — Tier-3 sideband proxy. Loopback-enforced at config-parse
         // time; the embed wires it onto the `/api/observability/*` proxy.
         sidebandUrl: config.mc.sideband,
@@ -3891,8 +3955,21 @@ export async function startCortex(
       // trust: every bus is the principal's own loopback bus (ADR-0005). Any
       // sibling that can't be reached / authed degrades to absent — it never
       // blocks this boot or perturbs the serving stack's own presence.
-      const aggCfg = config.mc.aggregateLocalStacks;
-      if (aggCfg.enabled) {
+      //
+      // #1008 RECONCILIATION (DB-read OWNS local siblings): when `dbRead` is on
+      // (default), the DB-read pane-of-glass aggregation already merges every
+      // LOCAL sibling's agents (+ session trees) straight off its db into the
+      // /api/agents + /api/working-agents feeds. Running this BUS sibling-presence
+      // aggregator too would DOUBLE-COUNT the same local agents (db + bus). So the
+      // bus path is gated OFF for local siblings whenever DB-read aggregation is
+      // on. The bus sibling path remains the mechanism for FEDERATED / cross-
+      // principal peers (whose dbs live on another machine/principal and cannot be
+      // read here) — that is the separate `startFederatedAgentPresenceSubscriber`
+      // above, NOT this local-sibling aggregator. Clean reach/depth split: DB-read
+      // = my own local stacks; bus = remote peers. Set `dbRead: false` to restore
+      // the bus path for local siblings (agents only, no session trees).
+      const runBusSiblingPresence = aggCfg.enabled && !aggCfg.dbRead;
+      if (runBusSiblingPresence) {
         try {
           // Precedence: explicit `stacks[]` overrides discovery. Empty ⇒ scan
           // the config root (default = the serving config dir's parent, the

--- a/src/surface/mc/__tests__/local-aggregation-api.test.ts
+++ b/src/surface/mc/__tests__/local-aggregation-api.test.ts
@@ -1,0 +1,181 @@
+/**
+ * #1008 — `/api/working-agents` + `/api/agents` DB-read aggregation, end-to-end.
+ *
+ * Drives the real Bun.serve HTTP stack with a `localAggregation` getter that
+ * points at fixture sibling MC dbs. Asserts both feeds return the origin-tagged
+ * UNION across the local db + the sibling dbs, and that omitting the getter
+ * yields the byte-identical single-db feed (no regression).
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mkdtempSync, rmSync } from "fs";
+
+import { startServer, type ServerContext } from "../server";
+import { initDatabase } from "../db/init";
+import { DEFAULT_CONFIG } from "../config";
+import type { Database } from "bun:sqlite";
+import type { SiblingStackDescriptor } from "../local-aggregation/sibling-discovery";
+import type { LocalAggregationContext } from "../local-aggregation/sibling-db-reader";
+import type {
+  AgentPresenceSnapshotRecord,
+  AgentPresenceView,
+} from "../api/agents";
+
+const cleanups: (() => void)[] = [];
+afterEach(() => {
+  for (const c of cleanups.splice(0)) c();
+});
+
+function boundPort(ctx: ServerContext): number {
+  const port = ctx.server.port;
+  if (port === undefined) throw new Error("server.port unresolved");
+  return port;
+}
+
+function seedWorking(
+  db: Database,
+  opts: { agentId: string; agentName: string },
+): void {
+  db.run(`INSERT INTO agents (id,name,type,persistent) VALUES (?,?,'head',1)`, [
+    opts.agentId,
+    opts.agentName,
+  ]);
+  db.run(
+    `INSERT INTO tasks (id,title,priority,principal_id,source_system) VALUES ('t','task',2,'andreas','internal')`,
+  );
+  db.run(
+    `INSERT INTO agent_task_assignment (id,agent_id,task_id,state) VALUES ('asg',?,'t','running')`,
+    [opts.agentId],
+  );
+  db.run(
+    `INSERT INTO sessions (id,assignment_id,endpoint_kind,started_at,substrate,agent_id,agent_name,principal_id,status)
+     VALUES ('s','asg','local.observed','2026-06-12T00:00:00.000Z','claude-code',?,?,'andreas','running')`,
+    [opts.agentId, opts.agentName],
+  );
+}
+
+function sibling(stack: string): SiblingStackDescriptor {
+  return {
+    stack,
+    principal: "andreas",
+    url: "nats://127.0.0.1:4222",
+    credential: { kind: "noauth" },
+  };
+}
+
+interface Harness {
+  ctx: ServerContext;
+  baseUrl: string;
+  db: Database;
+  cleanup: () => void;
+}
+
+function start(opts: {
+  agentPresence?: () => AgentPresenceView | null;
+  localAggregation?: () => LocalAggregationContext | null;
+}): Harness {
+  const root = mkdtempSync(join(tmpdir(), "mc-la-root-"));
+  const db = initDatabase(join(root, "local", "mission-control.db"));
+  const ctx = startServer({ ...DEFAULT_CONFIG, port: 0 }, db, {
+    ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
+    ...(opts.localAggregation ? { localAggregation: opts.localAggregation } : {}),
+  });
+  const cleanup = () => {
+    ctx.stop(true);
+    db.close();
+    rmSync(root, { recursive: true, force: true });
+  };
+  cleanups.push(cleanup);
+  return { ctx, baseUrl: `http://localhost:${boundPort(ctx)}`, db, cleanup, root } as Harness & {
+    root: string;
+  };
+}
+
+describe("#1008 /api/working-agents aggregation", () => {
+  it("returns the origin-tagged union across local + sibling dbs", async () => {
+    const share = mkdtempSync(join(tmpdir(), "mc-la-share-"));
+    cleanups.push(() => rmSync(share, { recursive: true, force: true }));
+    const workDb = initDatabase(join(share, "work", "mission-control.db"));
+    seedWorking(workDb, { agentId: "luna", agentName: "Luna" });
+    workDb.close();
+
+    const root = mkdtempSync(join(tmpdir(), "mc-la-cfg-"));
+    cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+
+    const h = start({
+      localAggregation: (): LocalAggregationContext => ({
+        siblings: [sibling("work")],
+        resolve: { configRoot: root, homeShareDir: share },
+      }),
+    });
+    seedWorking(h.db, { agentId: "echo", agentName: "Echo" });
+
+    const res = await fetch(`${h.baseUrl}/api/working-agents`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const echo = body.agents.find((a: { agent_id: string }) => a.agent_id === "echo");
+    expect(echo.origin).toBe("local");
+    const luna = body.agents.find((a: { agent_id: string }) => a.agent_id === "luna");
+    expect(luna.origin).toEqual({ principal: "andreas", stack: "work" });
+  });
+
+  it("omitting localAggregation yields the single-db feed (no origin field)", async () => {
+    const h = start({});
+    seedWorking(h.db, { agentId: "echo", agentName: "Echo" });
+    const res = await fetch(`${h.baseUrl}/api/working-agents`);
+    const body = await res.json();
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0].origin).toBeUndefined();
+  });
+});
+
+describe("#1008 /api/agents aggregation", () => {
+  it("unions the local registry view with sibling-db agent tiles", async () => {
+    const share = mkdtempSync(join(tmpdir(), "mc-la-share2-"));
+    cleanups.push(() => rmSync(share, { recursive: true, force: true }));
+    const workDb = initDatabase(join(share, "work", "mission-control.db"));
+    seedWorking(workDb, { agentId: "luna", agentName: "Luna" });
+    workDb.close();
+
+    const root = mkdtempSync(join(tmpdir(), "mc-la-cfg2-"));
+    cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+
+    const view: AgentPresenceView = {
+      getAgents: (): AgentPresenceSnapshotRecord[] => [
+        {
+          key: "andreas/meta-factory/echo",
+          origin: "local",
+          agentId: "echo",
+          nkeyPublicKey: "NECHO",
+          assistantName: "Echo",
+          principal: "andreas",
+          stack: "meta-factory",
+          capabilities: [],
+          state: "online",
+          lastSeenAt: 1,
+        },
+      ],
+    };
+
+    const h = start({
+      agentPresence: () => view,
+      localAggregation: (): LocalAggregationContext => ({
+        siblings: [sibling("work")],
+        resolve: { configRoot: root, homeShareDir: share },
+      }),
+    });
+
+    const res = await fetch(`${h.baseUrl}/api/agents`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const echo = body.agents.find((a: { agent_id: string }) => a.agent_id === "echo");
+    expect(echo.origin).toBe("local");
+    const luna = body.agents.find((a: { agent_id: string }) => a.agent_id === "luna");
+    expect(luna.origin).toEqual({ principal: "andreas", stack: "work" });
+    expect(luna.state).toBe("online");
+  });
+});

--- a/src/surface/mc/api/agents.ts
+++ b/src/surface/mc/api/agents.ts
@@ -25,6 +25,10 @@
  */
 
 import type { Database } from "bun:sqlite";
+import {
+  aggregateAgentTiles,
+  type LocalAggregationContext,
+} from "../local-aggregation/sibling-db-reader";
 
 /**
  * The minimal read-only contract the MC server depends on to serve
@@ -158,13 +162,31 @@ function toTile(r: AgentPresenceSnapshotRecord): AgentPresenceTile {
  *
  * `view === null` (MC enabled but no presence registry — a gating mismatch)
  * returns an empty list gracefully rather than erroring.
+ *
+ * #1008 — when a `localAggregation` context is supplied (the serving stack has
+ * DB-read pane-of-glass aggregation on), the response is the UNION of the local
+ * registry view AND each readable LOCAL sibling stack's db-derived agent tiles,
+ * origin-tagged (`{principal, stack}`). The presence registry is bus-liveness-
+ * derived; a sibling db has no bus presence, so its agents are projected from
+ * "owns a live session here" (`state: online`, bus-only fields null/empty — an
+ * honest projection, never synthesized liveness). Without the context, the feed
+ * is byte-identical to the pre-#1008 registry-only snapshot.
  */
 export function handleListAgents(
   _db: Database,
   view: AgentPresenceView | null,
+  localAggregation?: LocalAggregationContext | null,
 ): Response {
   try {
     const records = view ? view.getAgents() : [];
+    if (localAggregation) {
+      const agents = aggregateAgentTiles(
+        records,
+        localAggregation.siblings,
+        localAggregation.resolve,
+      );
+      return Response.json({ agents } satisfies ListAgentsResponse);
+    }
     const body: ListAgentsResponse = { agents: records.map(toTile) };
     return Response.json(body);
   } catch (err) {

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -42,6 +42,10 @@ import {
 import { getTaskById, listTasks } from "../db/tasks";
 import { listWorkingAgents } from "../db/working-agents";
 import {
+  aggregateWorkingAgents,
+  type LocalAggregationContext,
+} from "../local-aggregation/sibling-db-reader";
+import {
   attachTask,
   canTransitionServer,
   createIteration,
@@ -426,10 +430,29 @@ export function handleListInbox(db: Database, url: URL): Response {
  * assignment. Primary assignment picked by rank + updated_at (matches
  * F-8 Decision 5 for drill-down-entry consistency).
  *
+ * #1008 — when a `localAggregation` context is supplied (the serving stack has
+ * DB-read pane-of-glass aggregation on), the result is the origin-tagged UNION
+ * across the local db + each readable LOCAL sibling stack's `mission-control.db`.
+ * Each row carries an `origin` (`"local"` or `{principal, stack}`) so the
+ * dashboard's G-1114 multi-hub grouping renders every local stack as its own
+ * hub. Without the context (or `null`), behaviour is byte-identical to the
+ * pre-#1008 single-db feed (tiles carry no `origin`).
+ *
  * See docs/design-mc-f9-working-grid.md for the decision log.
  */
-export function handleListWorkingAgents(db: Database): Response {
+export function handleListWorkingAgents(
+  db: Database,
+  localAggregation?: LocalAggregationContext | null
+): Response {
   try {
+    if (localAggregation) {
+      const agents = aggregateWorkingAgents(
+        db,
+        localAggregation.siblings,
+        localAggregation.resolve
+      );
+      return json({ agents } satisfies ListWorkingAgentsResponse);
+    }
     const agents = listWorkingAgents(db);
     const body: ListWorkingAgentsResponse = { agents };
     return json(body);

--- a/src/surface/mc/api/types.ts
+++ b/src/surface/mc/api/types.ts
@@ -5,6 +5,7 @@
 import type { AssignmentListItem, MostActiveAgent } from "../db/assignments";
 import type { TaskListItem } from "../db/tasks";
 import type { WorkingAgentTile } from "../db/working-agents";
+import type { AgentOrigin } from "./agents";
 import type {
   InboxItem,
   IterationDetail,
@@ -61,10 +62,17 @@ export interface ListTasksResponse {
  * projection with the current-primary assignment folded in, plus a count
  * of additional active-non-blocked assignments for the `+N` badge.
  *
+ * #1008 — each tile MAY carry an `origin` (`"local"` or `{principal, stack}`)
+ * when the serving stack has pane-of-glass DB-read aggregation on: the feed is
+ * then the origin-tagged UNION across the local db + each readable LOCAL sibling
+ * stack's db. The field is OPTIONAL — the single-db feed omits it (byte-identical
+ * to the pre-#1008 shape), and the dashboard's multi-hub grouping treats a
+ * missing `origin` as `"local"`.
+ *
  * See docs/design-mc-f9-working-grid.md for the full decision log.
  */
 export interface ListWorkingAgentsResponse {
-  agents: WorkingAgentTile[];
+  agents: (WorkingAgentTile & { origin?: AgentOrigin })[];
 }
 
 // --- POST /api/sessions ---

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -23,6 +23,7 @@ import { HookStreamPoller } from "./hooks/poller";
 import type { Config } from "./types";
 import type { WsClientRegistry } from "./ws/client-registry";
 import type { AgentPresenceView } from "./api/agents";
+import type { LocalAggregationProvider } from "./local-aggregation/sibling-db-reader";
 
 export interface MissionControlHandle {
   db: Database;
@@ -57,6 +58,14 @@ export interface StartMissionControlOptions {
    * the route serves an empty list.
    */
   agentPresence?: () => AgentPresenceView | null;
+  /**
+   * #1008 — lazy accessor for the local-stack DB-read aggregation context.
+   * Forwarded verbatim to `startServer` so `/api/working-agents` + `/api/agents`
+   * aggregate across the principal's LOCAL sibling stacks' MC dbs. Omitted →
+   * single-db feeds. A GETTER because the sibling context is built at boot
+   * AFTER the embed starts.
+   */
+  localAggregation?: LocalAggregationProvider;
   /**
    * P-14 U0.1 — Tier-3 sideband base URL (`config.mc.sideband`). Loopback-
    * enforced at config-parse time; forwarded verbatim to `startServer`, which
@@ -108,6 +117,7 @@ export async function startMissionControl(
     serverCtx = startServer(config, db, {
       processManager,
       ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
+      ...(opts.localAggregation ? { localAggregation: opts.localAggregation } : {}),
       ...(opts.sidebandUrl ? { sidebandUrl: opts.sidebandUrl } : {}),
     });
     const { server, wsRegistry } = serverCtx;

--- a/src/surface/mc/local-aggregation/__tests__/sibling-db-reader.test.ts
+++ b/src/surface/mc/local-aggregation/__tests__/sibling-db-reader.test.ts
@@ -1,0 +1,359 @@
+/**
+ * #1008 — direct sibling MC-DB read aggregation tests (TDD, RED-first).
+ *
+ * The pane-of-glass mechanism reads each LOCAL sibling stack's own
+ * `mission-control.db` READ-ONLY and merges its sessions+agents into the
+ * serving daemon's API responses, origin-tagged. ADR-0011 unified the schema
+ * across every stack's MC db, so a cross-db read is byte-safe.
+ *
+ * Coverage axes:
+ *   1. dbPath resolution — per-slug default, the stack's configured `mc.dbPath`,
+ *      and tilde expansion; self-exclusion.
+ *   2. Multi-db open + merge — N fixture dbs (each canonical schema, seeded with
+ *      sessions/agents) → one origin-tagged working-agents union.
+ *   3. Graceful degrade — a MISSING / LOCKED-irrelevant / OLD-SCHEMA sibling db
+ *      is SKIPPED (recorded degraded), the others still returned, NEVER a throw.
+ *   4. /api/agents union — sibling agents projected into origin-tagged tiles.
+ *   5. Read-only — the reader opens `{ readonly: true }`; a write attempt throws
+ *      (proves query_only / readonly is in force), the request path never writes.
+ */
+
+import { describe, expect, test, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { initDatabase } from "../../db/init";
+import type { SiblingStackDescriptor } from "../sibling-discovery";
+import {
+  resolveSiblingDbPath,
+  aggregateWorkingAgents,
+  aggregateAgentTiles,
+  openReadableSiblingDbs,
+} from "../sibling-db-reader";
+import type { AgentPresenceSnapshotRecord } from "../../api/agents";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup; a leaked tmp dir doesn't fail the test.
+    }
+  }
+});
+
+function freshTmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "mc-sibling-db-"));
+  tmpDirs.push(d);
+  return d;
+}
+
+/** Build a canonical MC db at `dbPath` seeded with one working agent + session. */
+function seedDb(
+  dbPath: string,
+  opts: { agentId: string; agentName: string; taskTitle: string },
+): void {
+  const db = initDatabase(dbPath);
+  const ts = "2026-06-12T00:00:00.000Z";
+  db.run(
+    `INSERT INTO agents (id, name, type, persistent) VALUES (?, ?, 'head', 1)`,
+    [opts.agentId, opts.agentName],
+  );
+  db.run(
+    `INSERT INTO tasks (id, title, priority, principal_id, source_system)
+     VALUES ('task-1', ?, 2, 'andreas', 'internal')`,
+    [opts.taskTitle],
+  );
+  db.run(
+    `INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
+     VALUES ('asg-1', ?, 'task-1', 'running')`,
+    [opts.agentId],
+  );
+  db.run(
+    `INSERT INTO sessions
+       (id, assignment_id, endpoint_kind, started_at, substrate, agent_id, agent_name, principal_id, status)
+     VALUES ('sess-1', 'asg-1', 'local.observed', ?, 'claude-code', ?, ?, 'andreas', 'running')`,
+    [ts, opts.agentId, opts.agentName],
+  );
+  db.close();
+}
+
+function sibling(
+  stack: string,
+  overrides: Partial<SiblingStackDescriptor> = {},
+): SiblingStackDescriptor {
+  return {
+    stack,
+    principal: "andreas",
+    url: "nats://127.0.0.1:4222",
+    credential: { kind: "noauth" },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. dbPath resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveSiblingDbPath", () => {
+  test("falls back to the per-slug default under the home share dir", () => {
+    const configRoot = freshTmp();
+    // No stacks/*.yaml mc.dbPath → per-slug default.
+    const path = resolveSiblingDbPath(sibling("work"), {
+      configRoot,
+      homeShareDir: "/home/andreas/.local/share/cortex/mc",
+    });
+    expect(path).toBe("/home/andreas/.local/share/cortex/mc/work/mission-control.db");
+  });
+
+  test("honours the stack's configured mc.dbPath (with tilde expansion)", () => {
+    const configRoot = freshTmp();
+    const stackDir = join(configRoot, "work", "stacks");
+    mkdirSync(stackDir, { recursive: true });
+    writeFileSync(
+      join(stackDir, "work.yaml"),
+      `principal:\n  id: andreas\nstack:\n  id: andreas/work\nmc:\n  dbPath: "~/custom/work.db"\n`,
+    );
+    const path = resolveSiblingDbPath(sibling("work"), {
+      configRoot,
+      homeShareDir: "/home/andreas/.local/share/cortex/mc",
+      home: "/home/andreas",
+    });
+    expect(path).toBe("/home/andreas/custom/work.db");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2 + 4. Multi-db open + merge → origin-tagged unions
+// ---------------------------------------------------------------------------
+
+describe("aggregateWorkingAgents (cross-db merge)", () => {
+  test("merges three stacks' working agents into one origin-tagged list", () => {
+    const root = freshTmp();
+    const share = freshTmp();
+    // Three sibling dbs at the per-slug default path.
+    for (const s of ["alpha", "beta", "gamma"]) {
+      seedDb(join(share, s, "mission-control.db"), {
+        agentId: `agent-${s}`,
+        agentName: `Agent ${s}`,
+        taskTitle: `task in ${s}`,
+      });
+    }
+    // The serving (local) db has its OWN agent.
+    const localDb = initDatabase(join(share, "self", "mission-control.db"));
+    localDb.run(
+      `INSERT INTO agents (id, name, type, persistent) VALUES ('agent-self', 'Self', 'head', 1)`,
+    );
+    localDb.run(
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t','self task',2,'andreas','internal')`,
+    );
+    localDb.run(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('a','agent-self','t','running')`,
+    );
+    localDb.run(
+      `INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at, substrate)
+       VALUES ('s','a','local.observed','2026-06-12T00:00:00.000Z','claude-code')`,
+    );
+
+    const siblings = ["alpha", "beta", "gamma"].map((s) => sibling(s));
+    const tiles = aggregateWorkingAgents(localDb, siblings, {
+      configRoot: root,
+      homeShareDir: share,
+    });
+
+    // Local row is "local"; each sibling carries its own origin.
+    const local = tiles.filter((t) => t.origin === "local");
+    expect(local).toHaveLength(1);
+    expect(local[0]!.agent_id).toBe("agent-self");
+
+    for (const s of ["alpha", "beta", "gamma"]) {
+      const row = tiles.find(
+        (t) =>
+          typeof t.origin === "object" &&
+          t.origin.stack === s &&
+          t.origin.principal === "andreas",
+      );
+      expect(row, `expected an origin-tagged tile for ${s}`).toBeDefined();
+      expect(row!.agent_id).toBe(`agent-${s}`);
+    }
+    localDb.close();
+  });
+
+  test("self-exclusion: a sibling that resolves to the local db path is not double-read", () => {
+    const root = freshTmp();
+    const share = freshTmp();
+    const localPath = join(share, "self", "mission-control.db");
+    const localDb = initDatabase(localPath);
+    localDb.run(
+      `INSERT INTO agents (id, name, type, persistent) VALUES ('a','A','head',1)`,
+    );
+    localDb.run(
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t','x',2,'andreas','internal')`,
+    );
+    localDb.run(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('asg','a','t','running')`,
+    );
+    localDb.run(
+      `INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at, substrate)
+       VALUES ('s','asg','local.observed','2026-06-12T00:00:00.000Z','claude-code')`,
+    );
+
+    // A sibling descriptor that points at the SAME db path as the local db.
+    const tiles = aggregateWorkingAgents(localDb, [sibling("self")], {
+      configRoot: root,
+      homeShareDir: share,
+      selfDbPath: localPath,
+    });
+    // Only ONE tile (no duplicate from the self-pointed sibling).
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0]!.origin).toBe("local");
+    localDb.close();
+  });
+});
+
+describe("aggregateAgentTiles (/api/agents union)", () => {
+  test("merges the local registry view with sibling-db-derived agent tiles", () => {
+    const root = freshTmp();
+    const share = freshTmp();
+    seedDb(join(share, "work", "mission-control.db"), {
+      agentId: "luna",
+      agentName: "Luna",
+      taskTitle: "work task",
+    });
+
+    const localRecords: AgentPresenceSnapshotRecord[] = [
+      {
+        key: "andreas/meta-factory/echo",
+        origin: "local",
+        agentId: "echo",
+        nkeyPublicKey: "NKEYECHO",
+        assistantName: "Echo",
+        principal: "andreas",
+        stack: "meta-factory",
+        capabilities: ["code-review"],
+        state: "online",
+        lastSeenAt: 1,
+      },
+    ];
+
+    const tiles = aggregateAgentTiles(
+      localRecords,
+      [sibling("work")],
+      { configRoot: root, homeShareDir: share },
+    );
+
+    const echo = tiles.find((t) => t.agent_id === "echo");
+    expect(echo).toBeDefined();
+    expect(echo!.origin).toBe("local");
+
+    const luna = tiles.find((t) => t.agent_id === "luna");
+    expect(luna).toBeDefined();
+    expect(luna!.origin).toEqual({ principal: "andreas", stack: "work" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Graceful degrade
+// ---------------------------------------------------------------------------
+
+describe("openReadableSiblingDbs (graceful degrade)", () => {
+  test("a MISSING sibling db is skipped (degraded), others still open", () => {
+    const root = freshTmp();
+    const share = freshTmp();
+    seedDb(join(share, "good", "mission-control.db"), {
+      agentId: "g",
+      agentName: "G",
+      taskTitle: "ok",
+    });
+    // "ghost" has no db file on disk.
+    const { handles, degraded } = openReadableSiblingDbs(
+      [sibling("good"), sibling("ghost")],
+      { configRoot: root, homeShareDir: share },
+    );
+    try {
+      expect(handles.map((h) => h.origin.stack).sort()).toEqual(["good"]);
+      expect(degraded.map((d) => d.stack)).toContain("ghost");
+    } finally {
+      for (const h of handles) h.db.close();
+    }
+  });
+
+  test("an OLD-SCHEMA sibling db (missing canonical session columns) is skipped, not crashed-on", () => {
+    const root = freshTmp();
+    const share = freshTmp();
+    seedDb(join(share, "modern", "mission-control.db"), {
+      agentId: "m",
+      agentName: "M",
+      taskTitle: "ok",
+    });
+    // An ancient db: a sessions table WITHOUT the canonical denormalized columns.
+    const oldPath = join(share, "ancient", "mission-control.db");
+    mkdirSync(join(share, "ancient"), { recursive: true });
+    const old = new Database(oldPath, { create: true });
+    old.run(
+      `CREATE TABLE sessions (id TEXT PRIMARY KEY, assignment_id TEXT, started_at TEXT)`,
+    );
+    old.close();
+
+    const { handles, degraded } = openReadableSiblingDbs(
+      [sibling("modern"), sibling("ancient")],
+      { configRoot: root, homeShareDir: share },
+    );
+    try {
+      expect(handles.map((h) => h.origin.stack)).toEqual(["modern"]);
+      expect(degraded.map((d) => d.stack)).toContain("ancient");
+    } finally {
+      for (const h of handles) h.db.close();
+    }
+  });
+
+  test("a corrupt / non-sqlite sibling file is skipped, never throws", () => {
+    const root = freshTmp();
+    const share = freshTmp();
+    const badPath = join(share, "corrupt", "mission-control.db");
+    mkdirSync(join(share, "corrupt"), { recursive: true });
+    writeFileSync(badPath, "this is not a sqlite database");
+
+    const { handles, degraded } = openReadableSiblingDbs([sibling("corrupt")], {
+      configRoot: root,
+      homeShareDir: share,
+    });
+    try {
+      expect(handles).toHaveLength(0);
+      expect(degraded.map((d) => d.stack)).toContain("corrupt");
+    } finally {
+      for (const h of handles) h.db.close();
+    }
+  });
+
+  test("opened sibling handles are READ-ONLY (a write throws)", () => {
+    const root = freshTmp();
+    const share = freshTmp();
+    seedDb(join(share, "ro", "mission-control.db"), {
+      agentId: "r",
+      agentName: "R",
+      taskTitle: "ok",
+    });
+    const { handles } = openReadableSiblingDbs([sibling("ro")], {
+      configRoot: root,
+      homeShareDir: share,
+    });
+    try {
+      expect(handles).toHaveLength(1);
+      expect(() =>
+        handles[0]!.db.run(
+          `INSERT INTO agents (id,name,type,persistent) VALUES ('x','X','head',1)`,
+        ),
+      ).toThrow();
+    } finally {
+      for (const h of handles) h.db.close();
+    }
+  });
+});

--- a/src/surface/mc/local-aggregation/sibling-db-reader.ts
+++ b/src/surface/mc/local-aggregation/sibling-db-reader.ts
@@ -1,7 +1,7 @@
 /**
  * #1008 — direct sibling MC-DB read aggregation (the pane-of-glass mechanism).
  *
- * The operator-chosen PRIMARY way the localhost Mission Control shows ALL of a
+ * The principal-chosen PRIMARY way the localhost Mission Control shows ALL of a
  * principal's LOCAL stacks. Every stack already runs an MC with a COMPLETE local
  * picture in its OWN `mission-control.db` (sessions + agents). The serving daemon
  * (the one with `mc.enabled`) reads each SIBLING stack's db READ-ONLY and MERGES

--- a/src/surface/mc/local-aggregation/sibling-db-reader.ts
+++ b/src/surface/mc/local-aggregation/sibling-db-reader.ts
@@ -1,0 +1,435 @@
+/**
+ * #1008 — direct sibling MC-DB read aggregation (the pane-of-glass mechanism).
+ *
+ * The operator-chosen PRIMARY way the localhost Mission Control shows ALL of a
+ * principal's LOCAL stacks. Every stack already runs an MC with a COMPLETE local
+ * picture in its OWN `mission-control.db` (sessions + agents). The serving daemon
+ * (the one with `mc.enabled`) reads each SIBLING stack's db READ-ONLY and MERGES
+ * its sessions+agents into the MC API responses, tagged by stack origin — so all
+ * of a principal's local stacks render as distinct hubs with their session trees
+ * on one pane.
+ *
+ * ## Why a cross-db read is safe
+ *
+ * ADR-0011 unified the MC session schema across every stack's db (the canonical
+ * `sessions` columns in `db/canonical-session.ts`, asserted by the parity test).
+ * Every stack's `mission-control.db` is therefore the SAME shape — opening a
+ * sibling's db and running THIS stack's own queries against it is byte-safe.
+ *
+ * ## Why this is NOT a trust-boundary crossing (ADR-0005 / ADR-0007)
+ *
+ * Every sibling db is the PRINCIPAL'S OWN data on the principal's OWN machine —
+ * same principal, same host. The interior-locality rule (ADR-0005) governs
+ * crossing a TRUST boundary (another principal / another machine); reading your
+ * own stacks' dbs on your own box does not cross one. Cross-PRINCIPAL peers
+ * (whose dbs live on another machine, unreadable here) stay on the #989 bus
+ * presence path — the clean reach/depth split this module's `#989 reconciliation`
+ * relies on (see `cortex.ts` boot wiring).
+ *
+ * ## Freshness: per-request open→query→close
+ *
+ * The reader opens each sibling db `{ readonly: true }` PER CALL and closes it
+ * when done. A SQLite open is cheap, this keeps every read always-fresh, and it
+ * sidesteps the stale-handle-after-a-sibling-restart problem (a restarted stack
+ * recreates its db file/inode — a cached handle would point at the old inode).
+ *
+ * ## Graceful degradation (never throw into a request)
+ *
+ * A sibling db that is MISSING / unreadable / locked / corrupt / too-old-schema
+ * is SKIPPED (recorded in `degraded[]`, logged to stderr) — that stack is simply
+ * absent from the pane, never a 5xx. An old-schema sibling is detected via a
+ * cheap `pragma_table_info` canonical-columns check BEFORE any query, so a
+ * pre-ADR-0011 db is skipped rather than crashed on with `no such column`.
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { parse as parseYaml } from "yaml";
+
+import type { SiblingStackDescriptor } from "./sibling-discovery";
+import {
+  listWorkingAgents,
+  type WorkingAgentTile,
+} from "../db/working-agents";
+import type {
+  AgentOrigin,
+  AgentPresenceSnapshotRecord,
+  AgentPresenceTile,
+} from "../api/agents";
+
+/**
+ * The resolved local-aggregation context the MC server reads per request.
+ *
+ * `cortex.ts` builds ONE of these at boot (from the discovered siblings + the
+ * serving stack's config root + its own db path) and hands the MC server a
+ * getter that returns it (or `null` when DB-read aggregation is OFF, mirroring
+ * the `agentPresence` lazy-getter pattern). The working-agents + agents handlers
+ * call into the reader with this context to produce the origin-tagged union.
+ */
+export interface LocalAggregationContext {
+  /** The principal's discovered LOCAL sibling stacks (from `discoverSiblingStacks`). */
+  siblings: readonly SiblingStackDescriptor[];
+  /** Path resolution inputs (config root, share dir, self db path for exclusion). */
+  resolve: SiblingDbResolveOptions;
+}
+
+/** Lazy accessor for the local-aggregation context; `null` ⇒ DB-read OFF. */
+export type LocalAggregationProvider = () => LocalAggregationContext | null;
+
+/** The conventional per-slug MC db root: `~/.local/share/cortex/mc`. */
+function defaultHomeShareDir(home: string): string {
+  return join(home, ".local", "share", "cortex", "mc");
+}
+
+/** Expand a leading `~` to the given home dir (matches the loader's expandTilde). */
+function expandTildeWith(p: string, home: string): string {
+  if (p === "~") return home;
+  if (p.startsWith("~/")) return join(home, p.slice(2));
+  return p;
+}
+
+/** Shared resolution inputs — injectable so tests pin paths deterministically. */
+export interface SiblingDbResolveOptions {
+  /** Config root scanned for sibling stack dirs (`<root>/<slug>/stacks/*.yaml`). */
+  configRoot: string;
+  /**
+   * Root for the per-slug default db path. Defaults to
+   * `~/.local/share/cortex/mc`. Injected by tests; production passes the same
+   * root `cortex.ts` derives the serving stack's `defaultDbPath` from.
+   */
+  homeShareDir?: string;
+  /** Home dir for tilde expansion. Defaults to `os.homedir()`. */
+  home?: string;
+  /**
+   * The SERVING stack's own db path. A sibling whose resolved db path equals
+   * this is EXCLUDED — the local db is already queried directly, never twice.
+   */
+  selfDbPath?: string;
+}
+
+/**
+ * Resolve a sibling stack's `mission-control.db` PATH.
+ *
+ * Mirrors `cortex.ts`'s own resolution exactly: the stack's configured
+ * `mc.dbPath` (read from its `stacks/*.yaml`, tilde-expanded) when set, else the
+ * per-slug default `{homeShareDir}/{stack}/mission-control.db`.
+ */
+export function resolveSiblingDbPath(
+  sibling: SiblingStackDescriptor,
+  opts: SiblingDbResolveOptions,
+): string {
+  const home = opts.home ?? homedir();
+  const shareDir = opts.homeShareDir ?? defaultHomeShareDir(home);
+
+  const configured = readConfiguredDbPath(opts.configRoot, sibling.stack);
+  if (configured !== null && configured !== "") {
+    return expandTildeWith(configured, home);
+  }
+  return join(shareDir, sibling.stack, "mission-control.db");
+}
+
+/**
+ * Read a sibling stack's configured `mc.dbPath` from its `stacks/*.yaml`, if any.
+ * Returns `null` when the dir / file / field is absent or unreadable — the
+ * caller falls back to the per-slug default. Never throws.
+ */
+function readConfiguredDbPath(configRoot: string, stack: string): string | null {
+  const stacksDir = join(configRoot, stack, "stacks");
+  if (!existsSync(stacksDir)) return null;
+  let files: string[];
+  try {
+    files = readdirSync(stacksDir)
+      .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+      .sort();
+  } catch {
+    return null;
+  }
+  for (const f of files) {
+    let parsed: unknown;
+    try {
+      parsed = parseYaml(readFileSync(join(stacksDir, f), "utf8"));
+    } catch {
+      continue; // a malformed stack file is skipped; try the next.
+    }
+    const dbPath = (parsed as { mc?: { dbPath?: unknown } } | null)?.mc?.dbPath;
+    if (typeof dbPath === "string" && dbPath.length > 0) return dbPath;
+  }
+  return null;
+}
+
+/**
+ * The canonical session columns whose presence proves a sibling db is at least
+ * ADR-0011 shape. A pre-ADR-0011 db lacking these is skipped (degraded), not
+ * crashed on. We probe a representative subset (not the full list) — these are
+ * the columns the federated queries actually read.
+ */
+const REQUIRED_SESSION_COLUMNS = [
+  "agent_id",
+  "agent_name",
+  "parent_session_id",
+  "substrate",
+] as const;
+
+/** A degraded sibling — its db could not be read — with the reason. */
+export interface DegradedSiblingDb {
+  stack: string;
+  reason: string;
+}
+
+/** A readable sibling db handle, tagged with its origin. */
+export interface SiblingDbHandle {
+  /** The sibling's origin — `{principal, stack}` (always foreign-shaped). */
+  origin: { principal: string; stack: string };
+  /** Read-only bun:sqlite handle. Caller MUST `.db.close()` when done. */
+  db: Database;
+}
+
+/** Result of {@link openReadableSiblingDbs}. */
+export interface OpenSiblingDbsResult {
+  handles: SiblingDbHandle[];
+  degraded: DegradedSiblingDb[];
+}
+
+/**
+ * Open every readable sibling db READ-ONLY. A sibling that is missing / locked /
+ * corrupt / too-old-schema, or that resolves to the serving stack's OWN db path
+ * (self-exclusion), is SKIPPED — recorded in `degraded[]` (self-exclusion is
+ * silent, not degraded) and logged to stderr. NEVER throws.
+ *
+ * Caller owns the returned handles' lifetime: close every `handles[i].db`.
+ */
+export function openReadableSiblingDbs(
+  siblings: readonly SiblingStackDescriptor[],
+  opts: SiblingDbResolveOptions,
+): OpenSiblingDbsResult {
+  const handles: SiblingDbHandle[] = [];
+  const degraded: DegradedSiblingDb[] = [];
+
+  for (const sibling of siblings) {
+    const dbPath = resolveSiblingDbPath(sibling, opts);
+
+    // Self-exclusion — the serving stack's own db is already queried directly.
+    if (opts.selfDbPath !== undefined && dbPath === opts.selfDbPath) {
+      continue;
+    }
+
+    if (!existsSync(dbPath)) {
+      degraded.push({ stack: sibling.stack, reason: `db not found at ${dbPath}` });
+      process.stderr.write(
+        `sibling-db-reader: "${sibling.stack}" absent — db not found at ${dbPath}\n`,
+      );
+      continue;
+    }
+
+    let db: Database;
+    try {
+      db = new Database(dbPath, { readonly: true });
+      // Belt-and-braces: refuse any write at the connection level too. A
+      // readonly handle already rejects writes; query_only makes the intent
+      // explicit and survives a future open-mode change.
+      db.run("PRAGMA query_only = ON");
+    } catch (err) {
+      degraded.push({
+        stack: sibling.stack,
+        reason: `open failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      process.stderr.write(
+        `sibling-db-reader: "${sibling.stack}" absent — open failed: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      continue;
+    }
+
+    // Schema-shape gate: an old (pre-ADR-0011) db lacking the canonical session
+    // columns is skipped here rather than crashing the query below. The probe is
+    // itself wrapped — a corrupt file that opened but errors on pragma is caught.
+    let okSchema: boolean;
+    try {
+      okSchema = hasCanonicalSessionColumns(db);
+    } catch (err) {
+      db.close();
+      degraded.push({
+        stack: sibling.stack,
+        reason: `schema probe failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      process.stderr.write(
+        `sibling-db-reader: "${sibling.stack}" absent — schema probe failed: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      continue;
+    }
+    if (!okSchema) {
+      db.close();
+      degraded.push({
+        stack: sibling.stack,
+        reason: "schema too old (missing canonical session columns)",
+      });
+      process.stderr.write(
+        `sibling-db-reader: "${sibling.stack}" absent — schema too old (pre-ADR-0011)\n`,
+      );
+      continue;
+    }
+
+    handles.push({
+      origin: { principal: sibling.principal, stack: sibling.stack },
+      db,
+    });
+  }
+
+  return { handles, degraded };
+}
+
+/** Cheap `pragma_table_info` check that the sessions table carries the canonical columns. */
+function hasCanonicalSessionColumns(db: Database): boolean {
+  const rows = db
+    .query(`SELECT name FROM pragma_table_info('sessions')`)
+    .all() as { name: string }[];
+  const present = new Set(rows.map((r) => r.name));
+  return REQUIRED_SESSION_COLUMNS.every((c) => present.has(c));
+}
+
+/**
+ * A {@link WorkingAgentTile} tagged with the stack it came from. The local db's
+ * tiles carry `origin: "local"`; each sibling's carry `{principal, stack}`. The
+ * dashboard's G-1114 multi-hub adapter groups by origin → siblings render as
+ * distinct hubs automatically.
+ */
+export type OriginTaggedWorkingAgentTile = WorkingAgentTile & {
+  origin: AgentOrigin;
+};
+
+/**
+ * `/api/working-agents` federation: the origin-tagged UNION of the local db's
+ * working agents (`origin: "local"`) and each readable sibling db's, by running
+ * the EXISTING `listWorkingAgents` query against each db handle and concatenating.
+ *
+ * Per-request open→query→close: sibling handles are opened, queried, and closed
+ * within this call (always fresh). A sibling that can't be read is simply absent
+ * (logged via `openReadableSiblingDbs`), never a throw.
+ */
+export function aggregateWorkingAgents(
+  localDb: Database,
+  siblings: readonly SiblingStackDescriptor[],
+  opts: SiblingDbResolveOptions,
+): OriginTaggedWorkingAgentTile[] {
+  const out: OriginTaggedWorkingAgentTile[] = listWorkingAgents(localDb).map(
+    (t) => ({ ...t, origin: "local" as const }),
+  );
+
+  const { handles } = openReadableSiblingDbs(siblings, opts);
+  try {
+    for (const h of handles) {
+      const origin: AgentOrigin = {
+        principal: h.origin.principal,
+        stack: h.origin.stack,
+      };
+      // REUSE the existing query — run it per-db, then origin-tag + concat.
+      for (const tile of listWorkingAgents(h.db)) {
+        out.push({ ...tile, origin });
+      }
+    }
+  } finally {
+    for (const h of handles) h.db.close();
+  }
+  return out;
+}
+
+/**
+ * Project a sibling db's agents into the `/api/agents` presence-tile shape.
+ *
+ * The presence registry (`/api/agents`) is bus-liveness-derived (nkey,
+ * capabilities, online/offline, heartbeat). A sibling db carries no bus presence
+ * — its ground truth for "this agent is present in this stack" is "the agent owns
+ * a non-terminal session here." We derive a tile per such agent: `state: online`
+ * (it has live work), `origin: {principal, stack}`. Bus-only fields the db can't
+ * supply are null/empty — an honest projection, not synthesized liveness.
+ */
+function siblingAgentTiles(
+  db: Database,
+  origin: { principal: string; stack: string },
+): AgentPresenceTile[] {
+  const rows = db
+    .query(
+      `SELECT DISTINCT ag.id AS agent_id, ag.name AS agent_name
+         FROM agents ag
+         JOIN agent_task_assignment a ON a.agent_id = ag.id
+         JOIN sessions s ON s.assignment_id = a.id
+        WHERE s.ended_at IS NULL
+          AND ag.id != 'mc-shadow-agent'
+        ORDER BY ag.id ASC`,
+    )
+    .all() as { agent_id: string; agent_name: string | null }[];
+
+  const now = Date.now();
+  return rows.map((r) => ({
+    key: `${origin.principal}/${origin.stack}/${r.agent_id}`,
+    origin: { principal: origin.principal, stack: origin.stack },
+    agent_id: r.agent_id,
+    assistant_name: r.agent_name,
+    nkey_public_key: "",
+    principal: origin.principal,
+    stack: origin.stack,
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: now,
+  }));
+}
+
+/**
+ * `/api/agents` federation: the UNION of the local registry view (projected into
+ * tiles by the caller's existing `toTile`) and each readable sibling db's
+ * db-derived agent tiles, origin-tagged.
+ *
+ * Takes the local presence RECORDS (the registry's `getAgents()` snapshot) so it
+ * can reuse the API's own record→tile projection, then appends the sibling tiles.
+ */
+export function aggregateAgentTiles(
+  localRecords: readonly AgentPresenceSnapshotRecord[],
+  siblings: readonly SiblingStackDescriptor[],
+  opts: SiblingDbResolveOptions,
+): AgentPresenceTile[] {
+  const out: AgentPresenceTile[] = localRecords.map(recordToTile);
+
+  const { handles } = openReadableSiblingDbs(siblings, opts);
+  try {
+    for (const h of handles) {
+      out.push(...siblingAgentTiles(h.db, h.origin));
+    }
+  } finally {
+    for (const h of handles) h.db.close();
+  }
+  return out;
+}
+
+/**
+ * Local registry record → API tile. Mirrors `api/agents.ts#toTile` exactly (the
+ * surface layer's snake_case DTO). Kept here so this module can build the union
+ * without importing the handler's private projector; the shapes are pinned by
+ * the `AgentPresenceTile` type both sides use.
+ */
+function recordToTile(r: AgentPresenceSnapshotRecord): AgentPresenceTile {
+  const origin: AgentOrigin =
+    r.origin === "local"
+      ? "local"
+      : { principal: r.origin.principal, stack: r.origin.stack };
+  return {
+    key: r.key,
+    origin,
+    agent_id: r.agentId,
+    assistant_name: r.assistantName,
+    nkey_public_key: r.nkeyPublicKey,
+    principal: r.principal,
+    stack: r.stack,
+    capabilities: r.capabilities,
+    state: r.state,
+    offline_reason: r.offlineReason ?? null,
+    started_at: r.startedAt ?? null,
+    last_heartbeat_at: r.lastHeartbeatAt ?? null,
+    last_seen_at: r.lastSeenAt,
+  };
+}

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -40,6 +40,10 @@ import {
 } from "./api/handlers";
 import { handleListGitLinks } from "./api/git-links";
 import { handleListAgents, type AgentPresenceView } from "./api/agents";
+import type {
+  LocalAggregationContext,
+  LocalAggregationProvider,
+} from "./local-aggregation/sibling-db-reader";
 import { handleListRepositories } from "./api/git-repos";
 import { handleListPlans } from "./api/plans";
 import { handleGetPhaseDetail } from "./api/phase-detail";
@@ -168,6 +172,16 @@ export interface StartServerOptions {
    */
   agentPresence?: () => AgentPresenceView | null;
   /**
+   * #1008 — lazy accessor for the local-stack DB-read aggregation context (the
+   * pane-of-glass mechanism). When it resolves to a context, `/api/working-agents`
+   * and `/api/agents` return the origin-tagged UNION across the local db + each
+   * readable LOCAL sibling stack's `mission-control.db`. A GETTER (like
+   * `agentPresence`) because the discovered-sibling context is built at boot,
+   * after the embed starts; resolved per request. Returns `null` ⇒ DB-read
+   * aggregation OFF (single-db feed, byte-identical to pre-#1008).
+   */
+  localAggregation?: LocalAggregationProvider;
+  /**
    * P-14 U0.1 — Tier-3 sideband base URL (`mc.sideband`). When present, the
    * `/api/observability/*` routes proxy to it server-side. Loopback-enforced
    * at config-parse time; the proxy re-checks at the request boundary.
@@ -254,7 +268,10 @@ export function startServer(
         // Resolve the agent-presence view lazily per request — the registry
         // may not have booted when the server started (see StartServerOptions).
         const agentPresence = options.agentPresence?.() ?? null;
-        return handleApi(req, url, db, apiDeps, agentPresence);
+        // #1008 — resolve the DB-read aggregation context lazily too; null ⇒
+        // single-db feeds (the pre-#1008 path).
+        const localAggregation = options.localAggregation?.() ?? null;
+        return handleApi(req, url, db, apiDeps, agentPresence, localAggregation);
       }
 
       // --- Dashboard static ---
@@ -408,7 +425,8 @@ async function handleApi(
   url: URL,
   db: Database,
   deps: ApiDeps | null,
-  agentPresence: AgentPresenceView | null
+  agentPresence: AgentPresenceView | null,
+  localAggregation: LocalAggregationContext | null
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -605,7 +623,7 @@ async function handleApi(
     if (req.method !== "GET") {
       return methodNotAllowed(["GET"]);
     }
-    return handleListWorkingAgents(db);
+    return handleListWorkingAgents(db, localAggregation);
   }
 
   // G-1114.B.4 — GET /api/agents — stack-local runtime agent-presence snapshot
@@ -615,7 +633,7 @@ async function handleApi(
     if (req.method !== "GET") {
       return methodNotAllowed(["GET"]);
     }
-    return handleListAgents(db, agentPresence);
+    return handleListAgents(db, agentPresence, localAggregation);
   }
 
   // F-17 — principal-driven GitHub iteration import.


### PR DESCRIPTION
## What

The localhost Mission Control becomes the principal's **pane-of-glass over ALL their LOCAL stacks**. Every stack already runs an MC with a COMPLETE local picture in its own `mission-control.db` (sessions + agents). The serving daemon (the one with `mc.enabled`) now reads each SIBLING stack's db **read-only** and **merges** its sessions+agents into the MC API responses, tagged by stack origin → all local stacks render as distinct hubs with their session trees on one pane.

This is the operator-chosen PRIMARY mechanism for LOCAL siblings (#1008), **superseding the #989 bus-presence path for them**. ADR-0011 unified the MC session schema across every stack's db, so the cross-db read is byte-safe.

Closes #1008. Refs #989.

## The reader design

`src/surface/mc/local-aggregation/sibling-db-reader.ts` (new):

- **`resolveSiblingDbPath`** — resolves each sibling's `mission-control.db` PATH: the stack's configured `mc.dbPath` (read from its `stacks/*.yaml`, tilde-expanded) when set, else the per-slug default `~/.local/share/cortex/mc/{stack}/mission-control.db`. **Matches `cortex.ts`'s own resolution exactly.** Excludes the serving stack's own db (`selfDbPath`).
- **`openReadableSiblingDbs`** — opens each sibling `{ readonly: true }` + `PRAGMA query_only`. A cheap `pragma_table_info` canonical-session-columns probe gates an old-schema (pre-ADR-0011) sibling out **before** any query (skipped, not crashed on with `no such column`). Missing / locked / corrupt / too-old → that sibling **absent + structured stderr log, never a throw** into the request.
- **`aggregateWorkingAgents` / `aggregateAgentTiles`** — REUSE the existing per-db query functions (`listWorkingAgents`; the agents projection) by running them against EACH db handle, then concatenate + origin-tag. No query rewrite.

## Resolve-db-path approach

Reuses #989's `discoverSiblingStacks` for the **stack list only** (the DB-read path needs the roster, not the bus part). The db path is then resolved per the rule above. The same discovered roster is shared by both the DB-read context and the #989 bus aggregator so the supersede gate is coherent.

## The #989 reconciliation decision

**DB-read OWNS local siblings.** When `dbRead` is on (default), the #989 sibling-**presence BUS** aggregator is gated OFF for LOCAL siblings — DB-read already merges every local sibling's agents (+ session trees) straight off its db, so running the bus path too would **double-count** the same local agents (db + bus). The bus sibling path remains the mechanism for **FEDERATED / cross-principal peers** (whose dbs live on another machine/principal and can't be read here — `startFederatedAgentPresenceSubscriber`, untouched). Clean reach/depth split: **DB-read = my own local stacks; bus = remote peers.** Set `dbRead: false` to restore the bus path for local siblings (agents only, no session trees).

## Graceful-degrade behaviour

A sibling db that is missing / locked / corrupt / pre-ADR-0011-schema is SKIPPED (recorded degraded, logged to stderr) — that stack is simply absent from the pane, **never a 5xx**. Self-exclusion (a sibling resolving to the serving db path) is silent. Reads open `{ readonly: true }` + `query_only` — a write attempt throws (proven in tests); the request path never writes.

## Default-on justification

The principal runs several stacks on one box and expects the localhost pane to be the one-pane-over-all-my-stacks surface (#1008/#989). A single-stack deployment is unaffected (discovery finds no siblings → no-op). The cost is bounded: a **per-request read-only SQLite open** of the principal's OWN dbs on their OWN machine (ADR-0005 satisfied — no trust boundary crossed). Per-request open→query→close is chosen over a cached handle: always fresh, and it sidesteps the stale-handle-after-a-sibling-restart problem (a restarted stack recreates its db inode).

## Endpoints that now aggregate

- **`GET /api/working-agents`** — origin-tagged union of working-agent tiles (with session trees) across the local db + each readable local sibling db.
- **`GET /api/agents`** — union of the local presence-registry view + each sibling db's db-derived agent tiles (`state: online` from "owns a live session here"; bus-only fields null/empty — an honest projection, not synthesized liveness).

The dashboard's G-1114 multi-hub adapter groups by `origin` → siblings render as distinct hubs automatically (no dashboard change).

## Config

`mc.aggregateLocalStacks.dbRead` (default ON) on the **SHARED `McSchema`** → both config schemas parse it identically (the #877/P0 parity test stays green). Documented in `docs/config-layout/stacks/research.yaml`.

## Tests (TDD)

- `sibling-db-reader.test.ts` — path resolution (per-slug default, configured `mc.dbPath`, tilde); 3-stack merge → one origin-tagged list; missing / old-schema / corrupt sibling skipped (others still returned, no throw); read-only enforcement; self-exclusion.
- `local-aggregation-api.test.ts` — `/api/working-agents` + `/api/agents` return the origin-tagged union over the real HTTP stack; omitting the context yields the single-db feed (no `origin` field — no regression).

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — 0 errors (pre-existing warnings only, none in touched files)
- `bun test` — **6410 pass, 0 fail** (P0/#877 shared-schema parity green)
- No dashboard change → `build:dashboard` not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)