### PR TITLE
chore: bump to v5.12.0 — pane-of-glass sibling MC-DB aggregation (#1008) + presence fixes

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.11.1"
+version: "5.12.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release: #1016 (direct MC-DB pane-of-glass over all local stacks), #1007 (presence survives signing-off), #1004 (presence decoupled from mc.enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)