### PR TITLE
feat(mc): U3.3 — federated observability fold (Option-D trust path for system.{transport,federation}) (#937)

### DIFF
--- a/src/bus/agent-network/__tests__/federated-observability-curation.test.ts
+++ b/src/bus/agent-network/__tests__/federated-observability-curation.test.ts
@@ -1,0 +1,87 @@
+/**
+ * P-14 U3.3 (#937) — curation gate tests (the NEGATIVE CONTROL, pure-function half).
+ *
+ * The curation gate is cortex's OWN, code-fixed mirror of signal's U3.2 recipe
+ * (signal#141): ALLOW `system.{transport,federation}.>`; DENY everything else
+ * (`trace.>`, `metric.>`, `log.>`, `session.>`, `system.signal.*`, any novel
+ * class). This file pins the class matrix exhaustively — it is where the
+ * negative control is proven at the gate level, BEFORE the integration test
+ * proves a denied class never reaches the projection.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  evaluateObservabilityCuration,
+  isFoldableObservabilityClass,
+  FOLDED_OBSERVABILITY_PREFIXES,
+  DENIED_OBSERVABILITY_PREFIXES,
+} from "../federated-observability-curation";
+
+describe("evaluateObservabilityCuration — ALLOW-list (the folded classes)", () => {
+  test.each([
+    "system.transport.leaf_connect",
+    "system.transport.leaf_disconnect",
+    "system.transport.liveness_drift",
+    "system.transport.roster_snapshot",
+    "system.transport.backend.reachable",
+    "system.federation.peer.added",
+    "system.federation.peer.removed",
+  ])("ALLOWS the curated class %s", (type) => {
+    expect(evaluateObservabilityCuration(type)).toEqual({ kind: "allow" });
+    expect(isFoldableObservabilityClass(type)).toBe(true);
+  });
+});
+
+describe("evaluateObservabilityCuration — DENY (the NEGATIVE CONTROL)", () => {
+  test.each([
+    // The session interior — NEVER folded cross-principal (ADR-0005).
+    "trace.span.start",
+    "trace.span.end",
+    // Telemetry streams — signal's bounded context, not cortex's.
+    "metric.gauge.observed",
+    "log.record.emitted",
+    "session.lifecycle.started",
+    // A peer's collector substrate health — `system.signal.*` is DENIED while
+    // its `system.federation.`/`system.transport.` siblings ALLOW. This is the
+    // case the allow-list (not a `system.>` blanket) exists to catch.
+    "system.signal.received",
+    "system.signal.collector.degraded",
+    "system.signal.collector.recovered",
+  ])("DENIES the non-exported class %s (negative control)", (type) => {
+    expect(evaluateObservabilityCuration(type)).toEqual({
+      kind: "deny_not_curated",
+      type,
+    });
+    expect(isFoldableObservabilityClass(type)).toBe(false);
+  });
+
+  test("DENIES an unanticipated novel class (fail-closed default-deny)", () => {
+    // A peer cannot widen the fold by inventing a new class — deny is the default.
+    expect(isFoldableObservabilityClass("system.exfiltrate.everything")).toBe(false);
+    expect(isFoldableObservabilityClass("dispatch.task.started")).toBe(false);
+    expect(isFoldableObservabilityClass("")).toBe(false);
+    // A near-miss that merely STARTS like an allow prefix but isn't (no dot
+    // boundary) must not slip through.
+    expect(isFoldableObservabilityClass("system.transportx.evil")).toBe(false);
+    expect(isFoldableObservabilityClass("system.federationx.evil")).toBe(false);
+  });
+});
+
+describe("recipe correspondence — the allow/deny lists match signal#141", () => {
+  test("the ALLOW prefixes are exactly transport + federation", () => {
+    expect([...FOLDED_OBSERVABILITY_PREFIXES].sort()).toEqual([
+      "system.federation.",
+      "system.transport.",
+    ]);
+  });
+
+  test("every documented DENY prefix is in fact denied by the gate", () => {
+    // Belt-and-braces: the gate is allow-list-driven (deny is the default), so
+    // every entry on the documented DENY list must evaluate to a deny when
+    // exercised with a representative child class.
+    for (const prefix of DENIED_OBSERVABILITY_PREFIXES) {
+      const type = `${prefix}example.child`;
+      expect(isFoldableObservabilityClass(type)).toBe(false);
+    }
+  });
+});

--- a/src/bus/agent-network/__tests__/federated-observability-fold.test.ts
+++ b/src/bus/agent-network/__tests__/federated-observability-fold.test.ts
@@ -1,0 +1,442 @@
+/**
+ * P-14 U3.3 (#937) — TRUST-VERIFIED federated observability fold tests.
+ *
+ * The SECURITY-FOCUSED slice — the trust-path FINALE. Coverage axes mirror the
+ * federated-subscriber test (same Option-D path) PLUS the curation gate:
+ *
+ *   1. Opt-in — no `policy.federated.networks[]` ⇒ fold INERT.
+ *   2. Fold — an ALLOW-listed (curation) + accept-listed (federation) peer's
+ *      `system.transport.*` ⇒ projected, ORIGIN-BADGED foreign (chain-verified
+ *      `{principal}/{stack}`), never local. (acceptance: origin attribution)
+ *   3. NEGATIVE CONTROL (critical) — a peer's NON-exported class
+ *      (`system.signal.*`, `trace.*`) provably does NOT fold — excluded at the
+ *      curation gate. (load-bearing)
+ *   4. TRUST gate (accept-list) — a non-allowlisted peer is DROPPED + denial.
+ *   5. TRUST gate (chain) — an unsigned/bad-chain envelope is DROPPED FAIL-CLOSED
+ *      + emits `system.access.denied (chain_verify_failed)`. (load-bearing)
+ *   6. Source-bound origin — the badge derives from the verified SOURCE, never
+ *      the attacker-controlled payload.
+ *   7. Subject filter — a `local.*` system envelope is ignored (U2.1 owns local).
+ */
+
+import { describe, expect, test, mock } from "bun:test";
+import {
+  startFederatedObservabilityFold,
+  federatedObservabilitySubject,
+  foldVerifiedObservability,
+  type FoldedObservability,
+} from "../federated-observability-fold";
+import type { Envelope, SignedBy } from "../../myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../../myelin/runtime";
+import type { MyelinSubscriber } from "../../myelin/subscriber";
+import type { SystemEventSource } from "../../system-events";
+import type {
+  PolicyFederated,
+  PolicyFederatedNetwork,
+} from "../../../common/types/cortex-config";
+import { TrustResolver } from "../../../common/agents/trust-resolver";
+import { AgentRegistry } from "../../../common/agents/registry";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SYSTEM_SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+
+/**
+ * A foreign (peer `joel/research`) observability envelope of `type`, carrying a
+ * canonical-myelin shape with the verified SOURCE `joel.research.local`. The
+ * payload can claim anything — the fold derives the origin from `source`, never
+ * the payload (the spoof-resistance check).
+ */
+function foreignObs(
+  type: string,
+  payload: Record<string, unknown> = {},
+  opts: { signedBy?: SignedBy[]; source?: string } = {},
+): Envelope {
+  return {
+    id: crypto.randomUUID(),
+    source: opts.source ?? "joel.research.local",
+    type,
+    timestamp: "2026-06-12T00:00:00.000Z",
+    sovereignty: {
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 3,
+      frontier_ok: true,
+      model_class: "any",
+    },
+    payload,
+    signed_by: opts.signedBy ?? [],
+  } as unknown as Envelope;
+}
+
+/** A network that accept-lists joel + accepts its system observability subtree. */
+function networkWithJoel(): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "primary",
+    peers: [{ principal_id: "joel", stack_id: "joel/research" }],
+    accept_subjects: ["federated.joel.research.system.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+/** A network that does NOT list joel (no peer) — joel is unknown/untrusted. */
+function networkWithoutJoel(): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "primary",
+    peers: [],
+    accept_subjects: ["federated.joel.research.system.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+function federatedPolicy(networks: PolicyFederatedNetwork[]): PolicyFederated {
+  return { networks };
+}
+
+// ---------------------------------------------------------------------------
+// Fake runtime + recording fold callback
+// ---------------------------------------------------------------------------
+
+interface FakeRuntime extends MyelinRuntime {
+  fire(envelope: Envelope, subject: string, sourceLink?: string): void;
+  subscribedPatterns: string[];
+  published: Envelope[];
+}
+
+function makeFakeRuntime(opts: { canSubscribe?: boolean } = {}): FakeRuntime {
+  const canSubscribe = opts.canSubscribe ?? true;
+  const handlers = new Set<EnvelopeHandler>();
+  const subscribedPatterns: string[] = [];
+  const published: Envelope[] = [];
+  const subscriberStop = mock(() => Promise.resolve());
+  const fakeSubscriber = { stop: subscriberStop } as unknown as MyelinSubscriber;
+  return {
+    enabled: true,
+    subscribedPatterns,
+    published,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: (env: Envelope) => {
+      published.push(env);
+      return Promise.resolve();
+    },
+    stop: () => Promise.resolve(),
+    subscribe: (pattern: string) => {
+      subscribedPatterns.push(pattern);
+      return Promise.resolve(canSubscribe ? fakeSubscriber : null);
+    },
+    fire(envelope, subject, sourceLink) {
+      for (const h of handlers) h(envelope, subject, sourceLink);
+    },
+  };
+}
+
+/** A recording fold callback + the rows it received. */
+function recordingFold(): { fn: (f: FoldedObservability) => void; folded: FoldedObservability[] } {
+  const folded: FoldedObservability[] = [];
+  return { fn: (f) => folded.push(f), folded };
+}
+
+function emptyTrustResolver(): TrustResolver {
+  return new TrustResolver(AgentRegistry.fromAgents([]));
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+const TRANSPORT_TYPE = "system.transport.leaf_connect";
+const TRANSPORT_SUBJECT = "federated.joel.research.system.transport.leaf_connect";
+
+// ===========================================================================
+// 1. Opt-in
+// ===========================================================================
+
+describe("U3.3 — federation opt-in", () => {
+  test("no networks ⇒ fold INERT (binds nothing, folds nothing)", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: undefined,
+      source: SYSTEM_SOURCE,
+    });
+    expect(runtime.subscribedPatterns).toEqual([]);
+    runtime.fire(foreignObs(TRANSPORT_TYPE), TRANSPORT_SUBJECT, "primary");
+    await flush();
+    expect(fold.folded.length).toBe(0);
+    await handle.stop();
+  });
+
+  test("networks present ⇒ subscribes the federated system firehose", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    expect(runtime.subscribedPatterns).toEqual([federatedObservabilitySubject()]);
+    expect(federatedObservabilitySubject()).toBe("federated.*.*.system.>");
+    await handle.stop();
+  });
+});
+
+// ===========================================================================
+// 2. Fold (curated + accept-listed) + origin attribution
+// ===========================================================================
+
+describe("U3.3 — fold curated + accept-listed foreign observability", () => {
+  test("allow-listed peer's system.transport.* ⇒ folded, ORIGIN-BADGED foreign", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      // No trustResolver ⇒ chain check skipped; curation + accept-list gates
+      // bound admissible classes + peers (production adds the chain check).
+    });
+    runtime.fire(
+      foreignObs(TRANSPORT_TYPE, { network: "metafactory", leaf: { principal: "joel", stack: "research" } }),
+      TRANSPORT_SUBJECT,
+      "primary",
+    );
+    await flush();
+    expect(fold.folded.length).toBe(1);
+    // The origin badge is the CHAIN-VERIFIED source `{principal}/{stack}`.
+    expect(fold.folded[0]?.peer).toBe("joel/research");
+    expect(fold.folded[0]?.envelope.type).toBe(TRANSPORT_TYPE);
+    await handle.stop();
+  });
+
+  test("folds system.federation.* too (the other curated class)", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    runtime.fire(
+      foreignObs("system.federation.peer.added", { peer: "joel" }),
+      "federated.joel.research.system.federation.peer.added",
+      "primary",
+    );
+    await flush();
+    expect(fold.folded.length).toBe(1);
+    expect(fold.folded[0]?.peer).toBe("joel/research");
+    await handle.stop();
+  });
+});
+
+// ===========================================================================
+// 3. NEGATIVE CONTROL (critical) — a peer's non-exported class never folds
+// ===========================================================================
+
+describe("U3.3 — NEGATIVE CONTROL: non-exported class excluded at the curation gate", () => {
+  test("a peer's system.signal.* is DROPPED — never folded (no row)", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      // The peer IS accept-listed at the federation tier — proving the curation
+      // gate is an INDEPENDENT exclusion, not piggybacking on the accept-list.
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    runtime.fire(
+      foreignObs("system.signal.collector.degraded", { collector_id: "relay-1" }),
+      "federated.joel.research.system.signal.collector.degraded",
+      "primary",
+    );
+    await flush();
+    expect(fold.folded.length).toBe(0);
+    await handle.stop();
+  });
+
+  test("a peer's trace.* (session interior) is DROPPED — never folded", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    // Even if it somehow rode the `system.>` bind (it wouldn't — trace.* isn't
+    // under system.), the curation gate denies it. Fire it on a system subject
+    // to prove the gate decides on the TYPE, not just the subject.
+    runtime.fire(
+      foreignObs("trace.span.start", { span: "x" }),
+      "federated.joel.research.system.transport.leaf_connect",
+      "primary",
+    );
+    await flush();
+    expect(fold.folded.length).toBe(0);
+    await handle.stop();
+  });
+});
+
+// ===========================================================================
+// 4. TRUST gate — federation accept-list (load-bearing)
+// ===========================================================================
+
+describe("U3.3 — TRUST: federation accept-list gate", () => {
+  test("peer NOT in any network's peers[] ⇒ DROPPED + denial emitted", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    runtime.fire(foreignObs(TRANSPORT_TYPE), TRANSPORT_SUBJECT, "primary");
+    await flush();
+    expect(fold.folded.length).toBe(0);
+    // The drop is observable as a system.access.denied audit envelope.
+    const denied = runtime.published.find(
+      (e) => e.type.includes("access") && e.type.includes("denied"),
+    );
+    expect(denied).toBeDefined();
+    await handle.stop();
+  });
+});
+
+// ===========================================================================
+// 5. TRUST gate — chain verification (load-bearing: unsigned/bad-chain drop)
+// ===========================================================================
+
+describe("U3.3 — TRUST: signed_by chain verification (fail-closed)", () => {
+  test("UNSIGNED foreign envelope under enforce ⇒ DROPPED + chain_verify_failed denial", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: false,
+      // enforce posture: an empty chain is rejected.
+      rejectEmpty: true,
+    });
+    // An UNSIGNED envelope (empty signed_by): passes curation + accept-list,
+    // then FAILS chain verification (empty_chain under rejectEmpty) ⇒ dropped.
+    runtime.fire(foreignObs(TRANSPORT_TYPE, {}, { signedBy: [] }), TRANSPORT_SUBJECT, "primary");
+    await flush();
+    expect(fold.folded.length).toBe(0);
+    const denied = runtime.published.find((e) => e.type === "system.access.denied");
+    expect(denied).toBeDefined();
+    expect((denied!.payload as { reason: { kind: string } }).reason.kind).toBe(
+      "chain_verify_failed",
+    );
+    await handle.stop();
+  });
+
+  test("BAD-CHAIN foreign envelope (unresolvable signer) ⇒ DROPPED + denial", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: false,
+    });
+    // A signed-but-untrusted foreign envelope: passes curation + accept-list,
+    // then FAILS chain verification (unknown_agent) ⇒ dropped.
+    const signed = foreignObs(TRANSPORT_TYPE, {}, {
+      signedBy: [
+        { method: "ed25519", identity: "did:mf:stranger", signature: "x", timestamp: "t" } as unknown as SignedBy,
+      ],
+    });
+    runtime.fire(signed, TRANSPORT_SUBJECT, "primary");
+    await flush();
+    expect(fold.folded.length).toBe(0);
+    const denied = runtime.published.find((e) => e.type === "system.access.denied");
+    expect(denied).toBeDefined();
+    expect((denied!.payload as { reason: { kind: string } }).reason.kind).toBe(
+      "chain_verify_failed",
+    );
+    await handle.stop();
+  });
+});
+
+// ===========================================================================
+// 6. Source-bound origin (spoof-resistance)
+// ===========================================================================
+
+describe("U3.3 — source-bound origin (the #914 spoof-resistance pattern)", () => {
+  test("origin badge derives from the verified SOURCE, NOT the payload", () => {
+    const fold = recordingFold();
+    // Payload tries to claim a DIFFERENT, local-looking origin; the source is the
+    // verified peer. foldVerifiedObservability must badge by source.
+    const env = foreignObs(
+      TRANSPORT_TYPE,
+      { stack_id: "andreas/meta-factory", origin: "andreas" },
+      { source: "joel.research.local" },
+    );
+    foldVerifiedObservability(fold.fn, env, TRANSPORT_SUBJECT);
+    expect(fold.folded.length).toBe(1);
+    expect(fold.folded[0]?.peer).toBe("joel/research");
+  });
+
+  test("a source with < 2 segments is DROPPED (originless rows forbidden)", () => {
+    const fold = recordingFold();
+    const env = foreignObs(TRANSPORT_TYPE, {}, { source: "joel" });
+    foldVerifiedObservability(fold.fn, env, TRANSPORT_SUBJECT);
+    expect(fold.folded.length).toBe(0);
+  });
+});
+
+// ===========================================================================
+// 7. Subject filter — local.* is ignored (U2.1 owns local)
+// ===========================================================================
+
+describe("U3.3 — subject filter", () => {
+  test("a local.* system envelope is IGNORED by the federated fold", async () => {
+    const runtime = makeFakeRuntime();
+    const fold = recordingFold();
+    const handle = await startFederatedObservabilityFold({
+      runtime,
+      foldObservability: fold.fn,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+    });
+    runtime.fire(
+      foreignObs(TRANSPORT_TYPE, {}, { source: "andreas.meta-factory.local" }),
+      "local.andreas.meta-factory.system.transport.leaf_connect",
+      "primary",
+    );
+    await flush();
+    // local.* is U2.1's; the federated fold's subject filter rejects it.
+    expect(fold.folded.length).toBe(0);
+    await handle.stop();
+  });
+});

--- a/src/bus/agent-network/federated-observability-curation.ts
+++ b/src/bus/agent-network/federated-observability-curation.ts
@@ -1,0 +1,100 @@
+/**
+ * P-14 U3.3 (#937) — the CURATION GATE for folded federated observability.
+ *
+ * This is cortex's OWN, code-enforced mirror of signal's U3.2 curation recipe
+ * (signal#141, merged): the closed set of observability classes a peer may have
+ * curated+exported and that this stack will therefore FOLD into Mission Control.
+ *
+ *   ALLOW — fold these `system.*` families:
+ *     - `system.transport.>`   (leaf liveness / RTT / intent⋈reality verdicts)
+ *     - `system.federation.>`  (peer roster lifecycle)
+ *
+ *   DENY — NEVER fold (a peer's interior / forensic / session-scoped streams):
+ *     - `trace.>`              (OTLP spans — the session interior, ADR-0005)
+ *     - `metric.>`
+ *     - `log.>`
+ *     - `session.>`
+ *     - `system.signal.*`      (signal-collector health — a peer's substrate
+ *                               interior, NOT folded cross-principal)
+ *
+ * ## Why a cortex-side gate AND the surface-router accept-list?
+ *
+ * The surface-router's `evaluateFederationGate` enforces the PER-NETWORK
+ * `accept_subjects` / `deny_subjects` a principal configured for a peer — a
+ * deployment-topology decision. THIS gate is a separate, code-fixed invariant:
+ * regardless of how a peer's network is configured (or misconfigured), cortex
+ * folds ONLY the curated observability classes. The recipe is not a config knob
+ * a lax peer or a fat-fingered `accept_subjects: ["system.>"]` can widen — it is
+ * the bounded context boundary between *work consolidation* (cortex, #21) and
+ * *observability consolidation* (signal), enforced here in code.
+ *
+ * So a peer envelope must clear BOTH: the network accept-list (is this peer
+ * allowed at all, on a subject its network permits) AND this curation gate (is
+ * this an observability CLASS cortex folds). The curation gate is the load-
+ * bearing NEGATIVE CONTROL: a peer's non-exported class (`trace.>`,
+ * `system.signal.*`) is excluded HERE even if it somehow passed the network
+ * accept-list — it can never appear in MC.
+ *
+ * Pure + dependency-free → exhaustively unit-testable against the class matrix.
+ * The decision is taken on the envelope `type` (`domain.entity.action`), the
+ * canonical class identifier — NOT the wire subject, which a peer cannot forge
+ * past the source-bound identity but which carries the `federated.{principal}.
+ * {stack}.` routing prefix the class check would have to strip anyway.
+ */
+
+/**
+ * The closed ALLOW-list of folded observability class prefixes. A type folds
+ * IFF it starts with one of these. Ordered most-specific-first is unnecessary
+ * here (the two prefixes are disjoint), but kept explicit for the recipe's
+ * one-to-one correspondence with signal#141.
+ */
+export const FOLDED_OBSERVABILITY_PREFIXES: readonly string[] = [
+  "system.transport.",
+  "system.federation.",
+] as const;
+
+/**
+ * The DENY-list — classes that must NEVER fold, listed for the negative-control
+ * test's explicitness and for an auditable record of the recipe. The gate's
+ * decision is ALLOW-list-driven (anything not on the allow-list is denied), so
+ * this list is documentation + a belt-and-braces guard the test pins; a class
+ * that is BOTH (impossible by construction — the prefixes are disjoint) would
+ * deny, since deny is the default.
+ */
+export const DENIED_OBSERVABILITY_PREFIXES: readonly string[] = [
+  "trace.",
+  "metric.",
+  "log.",
+  "session.",
+  "system.signal.",
+] as const;
+
+/** Structured curation outcome — `allow`, or a deny carrying the rejected class. */
+export type CurationDecision =
+  | { kind: "allow" }
+  | { kind: "deny_not_curated"; type: string };
+
+/**
+ * Decide whether a federated observability envelope of `type` may be folded.
+ *
+ * ALLOW-list semantics (fail-closed): a type folds IFF it matches a
+ * {@link FOLDED_OBSERVABILITY_PREFIXES} entry. Everything else — including every
+ * {@link DENIED_OBSERVABILITY_PREFIXES} class and any unanticipated class — is
+ * `deny_not_curated`. A peer cannot widen this by emitting a novel class: the
+ * default is deny.
+ *
+ * Note `system.signal.` is denied while `system.federation.`/`system.transport.`
+ * allow — the curation boundary runs THROUGH the `system.` domain, not around
+ * it, which is exactly why an allow-list (not a `system.>` blanket) is required.
+ */
+export function evaluateObservabilityCuration(type: string): CurationDecision {
+  for (const prefix of FOLDED_OBSERVABILITY_PREFIXES) {
+    if (type.startsWith(prefix)) return { kind: "allow" };
+  }
+  return { kind: "deny_not_curated", type };
+}
+
+/** Convenience boolean form for hot-path call sites. */
+export function isFoldableObservabilityClass(type: string): boolean {
+  return evaluateObservabilityCuration(type).kind === "allow";
+}

--- a/src/bus/agent-network/federated-observability-fold.ts
+++ b/src/bus/agent-network/federated-observability-fold.ts
@@ -1,0 +1,417 @@
+/**
+ * P-14 U3.3 (#937) — TRUST-VERIFIED federated OBSERVABILITY fold (the TRUST-PATH
+ * FINALE of the P-14 federated-fold line).
+ *
+ * The observability sibling of {@link startFederatedAgentPresenceSubscriber}.
+ * Where that subscriber folds TRUST-VERIFIED FOREIGN agent PRESENCE
+ * (`federated.{principal}.{stack}.agent.>`) into the shared presence registry,
+ * THIS module folds TRUST-VERIFIED FOREIGN OBSERVABILITY
+ * (`federated.{principal}.{stack}.system.{transport,federation}.>`) into the MC
+ * observability projection — ORIGIN-BADGED by peer `{principal}/{stack}`, through
+ * the SAME Option-D trust path. It serves cortex#21 (network-wide consolidation):
+ * a peer's curated substrate-health observability appears on the principal's
+ * Observability tab + Network-view transport overlay, attributed to the peer.
+ *
+ * ## THE DESIGN QUESTION (resolved against the existing U2.1 path)
+ *
+ * **Doesn't the U2.1 observability renderer ALREADY fold `federated.*` rows?**
+ * It subscribes to `federated.*.*.system.{signal,federation,transport}.>` and is
+ * a `SurfaceAdapter`, so the surface-router's `evaluateFederationGate` DOES run
+ * on its inbound. So why a second path?
+ *
+ * Because the SurfaceAdapter path has THREE trust gaps for a CROSS-PRINCIPAL
+ * fold that this module closes:
+ *
+ *   1. **No chain verification.** The surface-router gate is accept-list /
+ *      deny-list / hop-budget / anti-spoof ONLY — it does NOT run
+ *      `verifySignedByChain`. A peer envelope with forged BYTES that happens to
+ *      pass the accept-list would fold. U3.3 requires cryptographic
+ *      verification before fold (the #914 precedent).
+ *   2. **No origin binding.** U2.1's `originStackId()` reads `payload.stack_id` —
+ *      ATTACKER-CONTROLLED. A peer could paint a local-looking origin. U3.3
+ *      requires the origin be derived from the CHAIN-VERIFIED `source`.
+ *   3. **No curation gate.** U2.1 subscribes to `federated.*.*.system.signal.>` —
+ *      which would fold the DENIED `system.signal.*` class if a peer's network
+ *      `accept_subjects` permitted it. U3.3 requires cortex's OWN curation gate
+ *      (signal#141 recipe — ALLOW `system.{transport,federation}.>` only).
+ *
+ * So at U3.3 the U2.1 renderer is NARROWED to LOCAL subjects only
+ * (`local.*.…`), and ALL `federated.*` observability flows through THIS
+ * trust-verified path. This MIRRORS the federated-subscriber's resolution of the
+ * identical question (cortex#484 / #914): a cross-principal consumer that needs
+ * chain verification + source-bound identity grows its OWN inline trust path; it
+ * does NOT rely on the surface-router gate (which covers neither).
+ *
+ * ## The trust path (mirrors federated-subscriber.ts EXACTLY, + the curation gate)
+ *
+ * For every inbound `federated.*.*.system.>` envelope, in order:
+ *
+ *   0. **Curation gate** — {@link evaluateObservabilityCuration} on the envelope
+ *      TYPE. ALLOW `system.{transport,federation}.>`; everything else
+ *      (`trace.>`, `metric.>`, `log.>`, `session.>`, `system.signal.*`, any
+ *      novel class) is DROPPED, fail-closed. This is the load-bearing NEGATIVE
+ *      CONTROL: a peer's non-exported class never reaches the fold. (No denial
+ *      envelope here — a non-curated class is not a TRUST failure, it's simply
+ *      out of cortex's bounded context; emitting `system.access.denied` for
+ *      every peer `trace.>` tick would be noise. The trust-failure denials below
+ *      are reserved for accept-list / chain-verify drops.)
+ *   1. **Federation accept-list gate** — {@link evaluateFederationGate} on the
+ *      wire subject + envelope, against the principal's `policy.federated`. A
+ *      non-allowlisted peer / denied subject / over-budget hop / cross-network
+ *      spoof is DROPPED + emits `emitFederationDenied` (the same audit path the
+ *      router + presence subscriber use).
+ *   2. **`signed_by[]` chain verification** — {@link verifySignedByChain} with
+ *      the SAME `resolveFederatedPeer` seam (wired only under
+ *      `signing === "enforce"`). A chain failure DROPS the envelope + emits
+ *      `system.access.denied (chain_verify_failed)` via the U0.2 path
+ *      ({@link emitSystemAccessDenied}). A verifier FAULT drops + emits
+ *      `chain_verify_fault`. Posture-gated empty-chain handling via `rejectEmpty`
+ *      — identical to the presence subscriber + #484 dispatch-listener.
+ *
+ * Only an envelope that clears ALL of curation + accept-list + chain is folded.
+ *
+ * ## SOURCE-BOUND ORIGIN (the #914 BLOCKER pattern, applied to observability)
+ *
+ * The folded row's ORIGIN BADGE — the peer `{principal}/{stack}` — is derived
+ * from the CHAIN-VERIFIED `envelope.source`, NEVER from the attacker-controlled
+ * payload. {@link foldVerifiedObservability} splits `source` into
+ * `{principal}/{stack}` and passes it as the row's `origin: { kind: "foreign";
+ * peer }`. So an accept-listed peer's observability can be badged ONLY under its
+ * OWN verified identity — it can NEVER be shown as local, and a foreign row can
+ * never masquerade as this principal's substrate health. This is the
+ * negative-control's identity half.
+ *
+ * ## Sovereignty (ADR-0005)
+ *
+ * The curation gate's ALLOW-list is exactly the substrate-health classes
+ * (transport liveness/verdicts, federation roster) — NEVER the session interior
+ * (`trace.>` = OTLP spans = tool calls/prompts/diffs, always `local` scope per
+ * CONTEXT.md §Session interior). Interior leakage is structurally impossible:
+ * `trace.>` is denied at gate 0, and the interior never publishes `federated.`
+ * in the first place. cortex consumes ONLY the curated exterior.
+ *
+ * ## /wire-check posture — this is a CONSUMER, not a dispatcher
+ *
+ * This module INGESTS curated+signed peer observability. It NEVER publishes onto
+ * `federated.*` (the only thing it emits is LOCAL `system.access.denied` audit
+ * envelopes on a trust drop, via the U0.2 path — those ride the local audit
+ * subject derived from `source`, never the wire). The load-bearing wire-check
+ * invariant (never leak LOCAL interiors back onto the wire) holds by
+ * construction: there is no publish-to-federation path here at all.
+ *
+ * ## Dependency direction
+ *
+ * `bus/` never imports `surface/mc/` (layering: surface → bus). So the
+ * projection write is an INJECTED `foldObservability` callback (wired in
+ * cortex.ts to the observability projection + WS broadcast). This module owns the
+ * TRUST PATH; the callback owns the DB write. Clean seam, testable in isolation
+ * with a recording fake.
+ */
+
+import type { Envelope } from "../myelin/envelope-validator";
+import { getSignedByChain } from "../myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../myelin/runtime";
+import type { MyelinSubscriber } from "../myelin/subscriber";
+import type { TrustResolver } from "../../common/agents/trust-resolver";
+import type { FederatedPeerResolution } from "../../common/registry";
+import type {
+  PolicyFederated,
+  PolicyFederatedNetwork,
+} from "../../common/types/cortex-config";
+import type { SystemEventSource } from "../system-events";
+import {
+  emitFederationDenied,
+  evaluateFederationGate,
+  subjectMatches,
+} from "../surface-router";
+import { emitSystemAccessDenied } from "../emit-system-access-denied";
+import { verifySignedByChain } from "../verify-signed-by-chain";
+import { evaluateObservabilityCuration } from "./federated-observability-curation";
+
+/**
+ * Subject pattern the FEDERATED observability subscriber binds — every peer
+ * principal/stack's `system.>` subtree. `federated.*.*.system.>`: segment[1]
+ * (`*`) = any peer PRINCIPAL, segment[2] (`*`) = any peer STACK, `system.>` =
+ * any system observability action. Intentionally broad at the bind; the
+ * authoritative narrowing is the CURATION gate at fold time (`system.signal.*`
+ * matches `system.>` on the wire but is denied at the gate) — mirroring the
+ * presence subscriber's "subscription is the firehose, the gate is the trust
+ * boundary" stance.
+ */
+export function federatedObservabilitySubject(): string {
+  return "federated.*.*.system.>";
+}
+
+/**
+ * The CHAIN-VERIFIED, CURATED foreign observability envelope handed to the
+ * injected projection callback. Carries the source-bound peer identity so the
+ * projection writes the origin badge from a VERIFIED value, never the payload.
+ */
+export interface FoldedObservability {
+  envelope: Envelope;
+  /** The wire subject the envelope arrived on. */
+  subject: string;
+  /** CHAIN-VERIFIED peer `{principal}/{stack}` (the origin badge). */
+  peer: string;
+}
+
+/**
+ * Injected projection write. cortex.ts wires this to the observability
+ * projection (insert the row with `origin: { kind: "foreign"; peer }` + WS
+ * broadcast). Returns nothing — fire-and-forget; a projection error is the
+ * callback's own to swallow (the projection layer is non-throwing by contract).
+ */
+export type FoldObservabilityFn = (folded: FoldedObservability) => void;
+
+/** Lifecycle handle for the federated observability fold. */
+export interface FederatedObservabilityFoldHandle {
+  /**
+   * Stop the fold: unregister the fan-out handler + drain the push subscriber.
+   * Idempotent. (Unlike presence, projected observability ROWS are an
+   * append-only history retained by db/retention.ts — disabling federation
+   * stops folding NEW peer rows but does not retro-delete projected history;
+   * that is retention's job, identical to how local rows age out.)
+   */
+  stop(): Promise<void>;
+}
+
+/** Options for {@link startFederatedObservabilityFold}. */
+export interface StartFederatedObservabilityFoldOptions {
+  runtime: MyelinRuntime;
+  /**
+   * The projection write — wired in cortex.ts to insert the origin-badged row.
+   * MUST be supplied; without it the fold is pointless (and the subscriber stays
+   * inert rather than verifying envelopes it then drops on the floor).
+   */
+  foldObservability: FoldObservabilityFn;
+  /**
+   * Federation policy — the OPT-IN switch. When `undefined` or `networks[]` is
+   * empty, the fold is INERT (no subscription, no folds), byte-identical to
+   * pre-U3.3 behaviour. Mirrors the presence subscriber's opt-in default.
+   */
+  federated: PolicyFederated | undefined;
+  /** Source identity for the `system.access.denied` / federation-denied audit envelopes. */
+  source: SystemEventSource;
+  /** Chain-verification trust resolver (mirrors the presence subscriber). */
+  trustResolver?: TrustResolver;
+  /** Receiving agent id whose `trust:` list governs admitted signers. */
+  receivingAgentId?: string;
+  /** Principal id — threaded to the crypto-verify pass. */
+  principalId?: string;
+  /** Whether the chain verifier runs ed25519 crypto verification. Default `true`. */
+  cryptoVerify?: boolean;
+  /** Posture-gated empty-chain rejection (off/permissive → false; enforce → true). */
+  rejectEmpty?: boolean;
+  /** Receiving stack's signing DID (own-stack short-circuit in the verifier). */
+  stackIdentity?: string;
+  /** Receiving stack's NKey pubkey (crypto-verify pass for own-stack stamps). */
+  stackNKeyPub?: string;
+  /** Federated peer-pubkey resolution seam (wired only under `signing === "enforce"`). */
+  resolveFederatedPeer?: (
+    peerPrincipal: string,
+  ) => Promise<FederatedPeerResolution>;
+}
+
+/**
+ * Wire the trust-verified federated observability fold into the running cortex.
+ * OPT-IN: inert when `federated` is absent / has no networks.
+ *
+ * NON-THROWING / best-effort, matching every other capability-side boot feature.
+ */
+export async function startFederatedObservabilityFold(
+  opts: StartFederatedObservabilityFoldOptions,
+): Promise<FederatedObservabilityFoldHandle> {
+  const {
+    runtime,
+    foldObservability,
+    federated,
+    source,
+    trustResolver,
+    receivingAgentId,
+    principalId,
+    stackIdentity,
+    stackNKeyPub,
+    resolveFederatedPeer,
+  } = opts;
+  const cryptoVerify = opts.cryptoVerify ?? true;
+  // Posture-gated, matching the presence subscriber + #484 dispatch-listener.
+  const rejectEmpty = opts.rejectEmpty ?? false;
+
+  // OPT-IN gate — no networks ⇒ inert (no firehose, no folds).
+  const networks = federated?.networks ?? [];
+  if (networks.length === 0) {
+    return { stop: (): Promise<void> => Promise.resolve() };
+  }
+
+  const federatedNetworksById = new Map<string, PolicyFederatedNetwork>();
+  for (const network of networks) {
+    federatedNetworksById.set(network.id, network);
+  }
+
+  const pattern = federatedObservabilitySubject();
+
+  const handler: EnvelopeHandler = (envelope, subject, sourceLink) => {
+    // Subject filter — only the federated `system.>` subtree (the runtime fans
+    // EVERY envelope to EVERY handler, so reject everything else, incl. local
+    // `system.*` which the U2.1 renderer owns).
+    if (!subjectMatches(pattern, subject)) return;
+
+    // === GATE 0 — CURATION (signal#141 recipe; the NEGATIVE CONTROL) =========
+    // ALLOW only `system.{transport,federation}.>`. A peer's non-exported class
+    // (`system.signal.*`, or — if a misconfigured peer somehow routed them onto
+    // `system.>` — anything else) is DROPPED here, BEFORE any trust work. This
+    // is the load-bearing exclusion: a denied class can NEVER appear in MC.
+    if (evaluateObservabilityCuration(envelope.type).kind !== "allow") {
+      // Out-of-context, not a trust failure → no audit envelope (would be noise).
+      return;
+    }
+
+    // === GATE 1 — FEDERATION ACCEPT-LIST =====================================
+    const decision = evaluateFederationGate(
+      subject,
+      envelope,
+      federatedNetworksById,
+      sourceLink,
+    );
+    if (decision !== "allow") {
+      emitFederationDenied(runtime, source, envelope, subject, decision);
+      return;
+    }
+
+    // === GATE 2 — signed_by[] CHAIN VERIFICATION =============================
+    if (trustResolver !== undefined && receivingAgentId !== undefined) {
+      void verifySignedByChain(envelope, {
+        resolver: trustResolver,
+        receivingAgentId,
+        rejectEmpty,
+        cryptoVerify,
+        ...(principalId !== undefined && { principalId }),
+        ...(stackIdentity !== undefined && { stackIdentity }),
+        ...(stackNKeyPub !== undefined && { stackNKeyPub }),
+        ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
+      })
+        .then((result) => {
+          if (!result.valid) {
+            // Chain failed — DROP. A foreign observability envelope that can't
+            // be cryptographically attributed never appears in the view.
+            process.stderr.write(
+              `federated-observability: dropping foreign observability ${envelope.type} ` +
+                `(id=${envelope.id}) — signed_by chain verification failed: ` +
+                `${result.reason.kind}\n`,
+            );
+            // cortex#932 (U0.2) — make the chain-verify drop queryable on the
+            // local audit stream. Carries signed_by[] verbatim. REUSES the
+            // exact emit path the presence subscriber uses.
+            emitSystemAccessDenied(runtime, source, envelope, {
+              envelopeSubject: subject,
+              principalId: envelope.source.split(".")[0] ?? envelope.source,
+              capability: envelope.type,
+              reason: {
+                kind: "chain_verify_failed",
+                verify_reason: result.reason.kind,
+              },
+            });
+            return;
+          }
+          foldVerifiedObservability(foldObservability, envelope, subject);
+        })
+        .catch((err: unknown) => {
+          // A verifier FAULT must never crash the fan-out — log + drop (fail
+          // closed). Distinct reason kind so governance tells "verifier broke"
+          // from "signature didn't verify".
+          const faultMessage = err instanceof Error ? err.message : String(err);
+          process.stderr.write(
+            `federated-observability: chain verify threw for ${envelope.type} ` +
+              `(id=${envelope.id}) — dropping: ${faultMessage}\n`,
+          );
+          emitSystemAccessDenied(runtime, source, envelope, {
+            envelopeSubject: subject,
+            principalId: envelope.source.split(".")[0] ?? envelope.source,
+            capability: envelope.type,
+            reason: { kind: "chain_verify_fault", fault: faultMessage },
+          });
+        });
+      return;
+    }
+
+    // No chain verifier wired — fold directly (the accept-list + curation gates
+    // already bounded the admissible peers + classes). Matches the presence
+    // subscriber's no-resolver branch.
+    foldVerifiedObservability(foldObservability, envelope, subject);
+  };
+
+  const registration = runtime.onEnvelope(handler);
+
+  // Self-subscribe to the federated observability firehose. Best-effort.
+  let subscriber: MyelinSubscriber | null = null;
+  try {
+    subscriber = (await runtime.subscribe?.(pattern)) ?? null;
+    if (runtime.enabled && subscriber === null) {
+      process.stderr.write(
+        `federated-observability: runtime.subscribe(${pattern}) returned null — ` +
+          `fold will only see envelopes from other static subscriptions\n`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write(
+      `federated-observability: subscribe(${pattern}) failed (non-fatal — dormant): ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+
+  let stopped = false;
+  return {
+    stop: async (): Promise<void> => {
+      if (stopped) return;
+      stopped = true;
+      registration.unregister();
+      if (subscriber) {
+        await subscriber.stop();
+      }
+    },
+  };
+}
+
+/**
+ * Fold a TRUST-VERIFIED, CURATED foreign observability envelope by deriving the
+ * source-bound peer `{principal}/{stack}` from the CHAIN-VERIFIED
+ * `envelope.source` (segment[0]/segment[1]) and handing it to the injected
+ * projection callback as the `peer` origin badge.
+ *
+ * `envelope.source` is `{principal}.{stack}.{instance}[...]`. A source with
+ * fewer than two segments (defensive — the schema forbids it) is dropped rather
+ * than folded as an originless row, so a foreign row is ALWAYS attributable.
+ *
+ * Exported for direct unit testing of the source-binding.
+ */
+export function foldVerifiedObservability(
+  foldObservability: FoldObservabilityFn,
+  envelope: Envelope,
+  subject: string,
+): void {
+  const segments = envelope.source.split(".");
+  const principal = segments[0];
+  const stack = segments[1];
+  if (
+    principal === undefined ||
+    principal.length === 0 ||
+    stack === undefined ||
+    stack.length === 0
+  ) {
+    process.stderr.write(
+      `federated-observability: dropping foreign observability ${envelope.type} ` +
+        `(id=${envelope.id}) — could not derive {principal}/{stack} provenance ` +
+        `from source "${envelope.source}"\n`,
+    );
+    return;
+  }
+  foldObservability({ envelope, subject, peer: `${principal}/${stack}` });
+}
+
+/**
+ * Re-export for the boot wiring's hop-budget sanity (mirror of the presence
+ * subscriber's helper).
+ */
+export function observedHops(envelope: Envelope): number {
+  return getSignedByChain(envelope).length;
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -133,7 +133,12 @@ import { createDispatchProjectionRenderer } from "./surface/mc/projection/dispat
 // P-14 U2.1 (#934) — bus→MC observability projection renderer (signal's four
 // system.* families). Own renderer, own subjects; registered beside the dispatch
 // renderer, no edit to surface-router.ts.
-import { createObservabilityProjectionRenderer } from "./surface/mc/projection/observability-renderer";
+// P-14 U3.3 (#937) — projectForeignObservability: the foreign-origin projection
+// entry the federated observability fold's callback writes through.
+import {
+  createObservabilityProjectionRenderer,
+  projectForeignObservability,
+} from "./surface/mc/projection/observability-renderer";
 // MC-I1.S7 (#849) — funnel the event-driven failed_dispatch attention delta
 // onto the same system.attention.* bus path the cockpit loop publishes on.
 import { publishReconcileDelta } from "./surface/mc/attention-notify";
@@ -164,6 +169,13 @@ import {
   startFederatedAgentPresenceSubscriber,
   type FederatedAgentPresenceSubscriberHandle,
 } from "./bus/agent-network/federated-subscriber";
+// P-14 U3.3 (#937) — trust-verified federated OBSERVABILITY fold (the
+// observability sibling of the presence subscriber; same Option-D trust path +
+// the curation gate, origin-badged).
+import {
+  startFederatedObservabilityFold,
+  type FederatedObservabilityFoldHandle,
+} from "./bus/agent-network/federated-observability-fold";
 // #989 part-1 — LOCAL same-principal multi-bus presence aggregation.
 import { discoverSiblingStacks } from "./surface/mc/local-aggregation/sibling-discovery";
 import {
@@ -3775,6 +3787,10 @@ export async function startCortex(
   // G-1114.E.2 — trust-verified federated presence subscriber (folds peers'
   // agents into the SAME registry, tagged with foreign provenance).
   let federatedPresenceHandle: FederatedAgentPresenceSubscriberHandle | null = null;
+  // P-14 U3.3 (#937) — trust-verified federated OBSERVABILITY fold (folds peers'
+  // curated+signed system.{transport,federation}.* into the observability
+  // projection, ORIGIN-BADGED — the Option-D sibling of the presence subscriber).
+  let federatedObservabilityHandle: FederatedObservabilityFoldHandle | null = null;
   // #989 part-1 — LOCAL same-principal sibling-stack presence aggregator (folds
   // the principal's OTHER local stacks' agents into the SAME registry, tagged by
   // sibling origin, so the Network view shows every local stack as its own hub).
@@ -3944,6 +3960,61 @@ export async function startCortex(
         }),
         ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
       });
+
+      // P-14 U3.3 (#937) — the trust-verified federated OBSERVABILITY fold, the
+      // observability sibling of the presence subscriber above. Reuses the EXACT
+      // same trust config (federation gate + `verifySignedByChain` + the
+      // `resolveFederatedPeer` seam) PLUS cortex's curation gate (ALLOW
+      // system.{transport,federation}.>; DENY trace/metric/log/session/
+      // system.signal — signal#141). Folds peers' curated+signed substrate
+      // observability into the SAME observability projection the U2.1 renderer
+      // writes, but ORIGIN-BADGED foreign (chain-verified `{principal}/{stack}`),
+      // and NEVER opening a local attention item. The U2.1 renderer was narrowed
+      // to `local.*` at U3.3, so the federated path is exclusively this verified
+      // fold — no double-fold. INERT when federation isn't opted into. Needs
+      // `mcDb` (the projection target); on the mc.enabled boot it is non-null.
+      if (mcDb !== null) {
+        const observabilityFoldDb = mcDb;
+        const observabilityFoldWs = mcHandle?.wsRegistry;
+        federatedObservabilityHandle = await startFederatedObservabilityFold({
+          runtime,
+          // The injected projection write — bus/ never imports surface/mc/, so
+          // the DB write is wired here. Non-throwing: projectForeignObservability
+          // never throws on a valid envelope; a defensive guard keeps a poison
+          // peer envelope from perturbing the verify fan-out.
+          foldObservability: ({ envelope, peer }) => {
+            try {
+              projectForeignObservability(
+                observabilityFoldDb,
+                { id: envelope.id, type: envelope.type, payload: envelope.payload },
+                peer,
+                observabilityFoldWs,
+              );
+            } catch (err) {
+              process.stderr.write(
+                `cortex: federated observability fold projection error (non-fatal) ` +
+                  `for ${envelope.type} (id=${envelope.id}): ` +
+                  `${err instanceof Error ? err.message : String(err)}\n`,
+              );
+            }
+          },
+          federated: resolvedPolicy?.federated,
+          source: systemEventSource,
+          trustResolver,
+          receivingAgentId: mergedAgents[0]?.id,
+          principalId,
+          cryptoVerify: signingKnobs.cryptoVerify,
+          rejectEmpty: signingKnobs.rejectEmpty,
+          ...(signer !== undefined && { stackIdentity: signer.principal }),
+          ...(stackNKeyPubForVerifier !== undefined && {
+            stackNKeyPub: stackNKeyPubForVerifier,
+          }),
+          ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
+        });
+        console.log(
+          "cortex: federated observability fold started (Option-D trust path: curation gate + accept-list + chain-verify; origin-badged)",
+        );
+      }
 
       // #989 part-1 — LOCAL same-principal sibling-stack presence aggregation.
       // When enabled (default ON), auto-discover the principal's OTHER local
@@ -4312,6 +4383,15 @@ export async function startCortex(
       await completeAsync(
         "federated agent-presence subscriber stop",
         federatedPresenceHandle?.stop(),
+      );
+      // P-14 U3.3 — stop the federated observability fold (drains its push
+      // subscriber + unregisters its fan-out handler). Projected observability
+      // ROWS are append-only history retained by db/retention.ts — stopping the
+      // fold stops NEW peer rows; it does not retro-delete (identical to local
+      // rows). Order-independent vs. the registry/db teardown.
+      await completeAsync(
+        "federated observability fold stop",
+        federatedObservabilityHandle?.stop(),
       );
       // #989 part-1 — stop the LOCAL sibling-stack aggregator alongside the
       // federated one (both before the registry stop). It closes every sibling

--- a/src/surface/mc/__tests__/observability-db.test.ts
+++ b/src/surface/mc/__tests__/observability-db.test.ts
@@ -154,3 +154,56 @@ describe("listTransportRosterEvents (P-14 U2.3) — payload-bearing transport re
     expect(listTransportRosterEvents(db, 10)).toEqual([]);
   });
 });
+
+describe("observability origin badge (P-14 U3.3)", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("defaults a row's origin to local when no origin is supplied (U2.1 contract)", () => {
+    insertObservabilityEvent(db, {
+      envelopeId: "local-1", family: "transport", type: "system.transport.leaf_connect", payload: {},
+    });
+    expect(listObservabilityEvents(db, 10, "transport")[0]?.origin).toBe("local");
+    expect(listTransportRosterEvents(db, 10)[0]?.origin).toBe("local");
+  });
+
+  it("persists + round-trips a FOREIGN origin badge (chain-verified peer)", () => {
+    insertObservabilityEvent(db, {
+      envelopeId: "fed-1",
+      family: "transport",
+      type: "system.transport.liveness_drift",
+      payload: { action: "liveness_drift", network: "net", attributes: { peer: "joel/research", to: "connected" } },
+      origin: { kind: "foreign", peer: "joel/research" },
+    });
+    const tabRow = listObservabilityEvents(db, 10, "transport")[0];
+    expect(tabRow?.origin).toEqual({ kind: "foreign", peer: "joel/research" });
+    const rosterRow = listTransportRosterEvents(db, 10)[0];
+    expect(rosterRow?.origin).toEqual({ kind: "foreign", peer: "joel/research" });
+  });
+
+  it("a foreign row with a missing peer degrades to local (never an originless foreign badge)", () => {
+    // Defensive: a writer always pairs origin_kind=foreign with a non-empty
+    // origin_peer; an inconsistent row must not surface an un-attributed foreign.
+    db.query(
+      `INSERT INTO observability_events (id, envelope_id, family, type, payload, origin_kind, origin_peer, timestamp)
+       VALUES (?, ?, 'transport', 'system.transport.leaf_connect', '{}', 'foreign', NULL, datetime('now'))`,
+    ).run(crypto.randomUUID(), "broken-foreign");
+    expect(listObservabilityEvents(db, 10, "transport")[0]?.origin).toBe("local");
+  });
+
+  it("local and foreign rows coexist, each carrying its own badge", () => {
+    insertObservabilityEvent(db, {
+      envelopeId: "loc", family: "transport", type: "system.transport.leaf_connect",
+      payload: {}, origin: "local", timestamp: "2026-06-01T00:00:00.000Z",
+    });
+    insertObservabilityEvent(db, {
+      envelopeId: "fed", family: "transport", type: "system.transport.leaf_connect",
+      payload: {}, origin: { kind: "foreign", peer: "joel/research" }, timestamp: "2026-06-02T00:00:00.000Z",
+    });
+    const rows = listTransportRosterEvents(db, 10);
+    expect(rows.find((r) => r.id && (r.payload, true) && r.origin !== "local")).toBeDefined();
+    const byOrigin = rows.map((r) => (r.origin === "local" ? "local" : r.origin.peer));
+    expect(byOrigin.sort()).toEqual(["joel/research", "local"]);
+  });
+});

--- a/src/surface/mc/__tests__/observability-renderer.test.ts
+++ b/src/surface/mc/__tests__/observability-renderer.test.ts
@@ -21,6 +21,7 @@ import { SCHEMA_SQL } from "../db/schema";
 import {
   createObservabilityProjectionRenderer,
   projectObservability,
+  projectForeignObservability,
   familyForType,
 } from "../projection/observability-renderer";
 import { produceObservabilityAttention } from "../projection/observability-attention";
@@ -151,6 +152,58 @@ describe("projectObservability — projection rows", () => {
 });
 
 // ---------------------------------------------------------------------------
+// P-14 U3.3 — foreign-origin projection + the narrowed (local-only) subjects
+// ---------------------------------------------------------------------------
+
+describe("projectForeignObservability — origin-badged peer rows (U3.3)", () => {
+  let db: Database;
+  let broadcasts: WsServerMessage[];
+  let fakeRegistry: WsClientRegistry;
+
+  beforeEach(() => {
+    db = setupDb();
+    broadcasts = [];
+    fakeRegistry = {
+      broadcast: (msg: WsServerMessage) => broadcasts.push(msg),
+    } as unknown as WsClientRegistry;
+  });
+  afterEach(() => db.close());
+
+  it("writes a FOREIGN-origin row + broadcasts, never local", () => {
+    const fam = projectForeignObservability(
+      db,
+      envelope("system.transport.leaf_connect", { leaf: "leaf-a" }),
+      "joel/research",
+      fakeRegistry,
+    );
+    expect(fam).toBe("transport");
+    const row = listObservabilityEvents(db, 10, "transport")[0];
+    expect(row?.origin).toEqual({ kind: "foreign", peer: "joel/research" });
+    expect(broadcasts.some((m) => m.type === "mc.projection" && m.family === "observability")).toBe(true);
+  });
+
+  it("a FOREIGN row never opens a local attention item (peer health is not the principal's adapter)", () => {
+    // A peer's leaf_disconnect WOULD open an att:adapter: item if treated as
+    // local. As a foreign row it must NOT — no attention broadcast, no item.
+    projectForeignObservability(
+      db,
+      envelope("system.transport.leaf_disconnect", { leaf: "leaf-a" }),
+      "joel/research",
+      fakeRegistry,
+    );
+    expect(broadcasts.some((m) => m.type === "mc.projection" && m.family === "attention")).toBe(false);
+    const attnCount = (db.query(`SELECT COUNT(*) AS n FROM attention_items`).get() as { n: number }).n;
+    expect(attnCount).toBe(0);
+  });
+
+  it("a LOCAL transport health signal STILL opens an attention item (regression guard)", () => {
+    // Contrast: the same disconnect via the LOCAL path opens the att:adapter: item.
+    projectObservability(db, envelope("system.transport.leaf_disconnect", { leaf: "leaf-a" }), fakeRegistry);
+    expect(broadcasts.some((m) => m.type === "mc.projection" && m.family === "attention")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Attention producer — the live-oracle path
 // ---------------------------------------------------------------------------
 
@@ -235,6 +288,16 @@ describe("createObservabilityProjectionRenderer", () => {
     expect(r.subjects.some((s) => s.includes("system.signal"))).toBe(true);
     expect(r.subjects.some((s) => s.includes("system.federation"))).toBe(true);
     expect(r.subjects.some((s) => s.includes("system.transport"))).toBe(true);
+  });
+
+  it("U3.3 — subjects are LOCAL-ONLY: no federated.* (the trust-verified fold owns federation)", () => {
+    // At U3.3 this renderer no longer subscribes to federated.* — ALL federated
+    // observability flows through the chain-verifying, curation-gated fold. This
+    // narrowing is load-bearing: it prevents an UN-verified, UN-badged, UN-curated
+    // double-fold of peer rows (which would have folded the DENIED system.signal.*).
+    const r = createObservabilityProjectionRenderer(db, fakeRegistry);
+    expect(r.subjects.every((s) => s.startsWith("local."))).toBe(true);
+    expect(r.subjects.some((s) => s.startsWith("federated."))).toBe(false);
   });
 
   it("collector.degraded projects a row AND opens an attention item (oracle path)", async () => {

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter-transport.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter-transport.test.ts
@@ -65,6 +65,8 @@ function driftRow(principal: string, stack: string, to: string): TransportRoster
       reason: "x",
       attributes: { peer: `${principal}/${stack}`, principal, stack, from: null, to },
     },
+    // P-14 U3.3 — local origin (these are this stack's own hub fixtures).
+    origin: "local",
   };
 }
 
@@ -79,6 +81,7 @@ function connectRow(principal: string, stack: string, rtt: number): TransportRos
       network: "net",
       leaf: { principal, stack, network: "net", rtt_ms: rtt, frames: { in_msgs: 0, out_msgs: 0, in_bytes: 0, out_bytes: 0 } },
     },
+    origin: "local",
   };
 }
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-transport-overlay.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-transport-overlay.test.ts
@@ -32,6 +32,9 @@ function row(over: Partial<TransportRosterEventRow> & { type: string }): Transpo
     stackId: NET,
     timestamp: "2026-06-12T00:00:00.000Z",
     payload: {},
+    // P-14 U3.3 — default to a LOCAL origin (these U2.3 fixtures predate the
+    // federated fold). Foreign-origin fixtures pass `origin` explicitly.
+    origin: "local",
     ...over,
   };
 }
@@ -323,5 +326,58 @@ describe("formatRtt + isTransportVerdict (U2.3)", () => {
     expect(isTransportVerdict("unregistered-present")).toBe(true);
     expect(isTransportVerdict("flapping")).toBe(false);
     expect(isTransportVerdict(null)).toBe(false);
+  });
+});
+
+describe("buildTransportOverlay — ORIGIN BADGE (P-14 U3.3)", () => {
+  it("carries a local row's origin through to the overlay (default)", () => {
+    const o = buildTransportOverlay([drift("jc", "default", "connected")]);
+    expect(overlayForStack(o, "jc", "default")!.origin).toBe("local");
+  });
+
+  it("carries a FOREIGN peer's origin badge through to the overlay", () => {
+    const o = buildTransportOverlay([
+      drift("joel", "research", "connected", { origin: { kind: "foreign", peer: "joel/research" } }),
+      leafConnect("joel", "research", 11.2, { origin: { kind: "foreign", peer: "joel/research" } }),
+    ]);
+    const joel = overlayForStack(o, "joel", "research")!;
+    expect(joel.origin).toEqual({ kind: "foreign", peer: "joel/research" });
+    // The verdict + RTT still fold normally — origin is additive attribution.
+    expect(joel.verdict).toBe("connected");
+    expect(joel.rttMs).toBe(11.2);
+  });
+
+  it("a foreign verdict is NEVER downgraded to local (foreign badge is monotonic)", () => {
+    // Defensive: even if a local-origin candidate for the same key arrived after
+    // a foreign one (subject-disjoint paths make this unreachable in prod), the
+    // overlay must keep the foreign attribution — a peer verdict shown as local
+    // substrate health is the exact failure the badge exists to prevent.
+    const o = buildTransportOverlay([
+      // newest-first: foreign drift, then an older same-key local connect
+      drift("joel", "research", "connected", {
+        origin: { kind: "foreign", peer: "joel/research" },
+        timestamp: "2026-06-12T00:00:02.000Z",
+      }),
+      leafConnect("joel", "research", 9.0, {
+        origin: "local",
+        timestamp: "2026-06-12T00:00:01.000Z",
+      }),
+    ]);
+    expect(overlayForStack(o, "joel", "research")!.origin).toEqual({
+      kind: "foreign",
+      peer: "joel/research",
+    });
+  });
+
+  it("local and foreign peers in the same roster keep distinct badges", () => {
+    const o = buildTransportOverlay([
+      drift("andreas", "meta-factory", "connected", { origin: "local" }),
+      drift("joel", "research", "connected", { origin: { kind: "foreign", peer: "joel/research" } }),
+    ]);
+    expect(overlayForStack(o, "andreas", "meta-factory")!.origin).toBe("local");
+    expect(overlayForStack(o, "joel", "research")!.origin).toEqual({
+      kind: "foreign",
+      peer: "joel/research",
+    });
   });
 });

--- a/src/surface/mc/dashboard-v2/lib/network-transport-overlay.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-transport-overlay.ts
@@ -39,6 +39,7 @@
  */
 
 import type { TransportRosterEventRow } from "../../api/observability-tab";
+import type { ObservabilityOrigin } from "../../db/observability";
 
 /**
  * The three deterministic liveness verdicts — signal's P-13.B vocabulary,
@@ -79,6 +80,16 @@ export interface TransportPeerOverlay {
   present: boolean;
   /** Round-trip time in ms from signal's leaf roster, or null when absent/unreported. */
   rttMs: number | null;
+  /**
+   * P-14 U3.3 (#937) — the ORIGIN BADGE for this peer-stack's transport
+   * observation. `"local"` when folded from this principal's own hub rows;
+   * `{ kind: "foreign"; peer }` when folded from a TRUST-VERIFIED federated
+   * peer's curated transport observability. The Network view badges a foreign
+   * observation distinctly so a peer's substrate verdict is NEVER shown as local
+   * substrate health. Derived from the row's chain-verified origin, never the
+   * payload.
+   */
+  origin: ObservabilityOrigin;
 }
 
 /**
@@ -130,6 +141,8 @@ interface Candidate {
   rttMs: number | null;
   /** `liveness_drift` is authoritative; edges/snapshots only seed when no drift seen. */
   authoritative: boolean;
+  /** P-14 U3.3 — the row's origin badge, carried through to the overlay. */
+  origin: ObservabilityOrigin;
 }
 
 /** Extract the leaf liveness/RTT off a `leaf` / `leaves[]` entry body. */
@@ -143,6 +156,8 @@ function leafLiveness(leaf: Record<string, unknown>): { present: boolean; rttMs:
 function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
   const payload = row.payload;
   const network = asString(payload.network) ?? asString(row.stackId);
+  // P-14 U3.3 — the row's origin badge rides every candidate it contributes.
+  const origin = row.origin;
 
   switch (row.type) {
     case "system.transport.liveness_drift": {
@@ -179,6 +194,7 @@ function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
           present: to === "connected" || to === "unregistered-present",
           rttMs: null,
           authoritative: true,
+          origin,
         },
       ];
     }
@@ -203,6 +219,7 @@ function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
           present: connect ? live.present : false,
           rttMs: connect ? live.rttMs : null,
           authoritative: false,
+          origin,
         },
       ];
     }
@@ -226,6 +243,7 @@ function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
           present: live.present,
           rttMs: live.rttMs,
           authoritative: false,
+          origin,
         });
       }
       return out;
@@ -281,6 +299,7 @@ export function buildTransportOverlay(
           verdict: c.verdict,
           present: c.present,
           rttMs: c.rttMs,
+          origin: c.origin,
         });
         if (c.authoritative) lockedByDrift.add(c.key);
         // If the NEWEST event for this key asserts absence (a `registered-absent`
@@ -311,6 +330,16 @@ export function buildTransportOverlay(
         }
       }
       if (existing.network === null && c.network !== null) existing.network = c.network;
+      // P-14 U3.3 — origin is source-bound (a key is one `{principal}/{stack}`),
+      // so every candidate for a key SHOULD agree. Defensively, a FOREIGN badge
+      // wins: once any row for a key is peer-attributed, the overlay never
+      // downgrades it to `local` (a foreign verdict must never be shown as local
+      // substrate health). A foreign-then-local mix for one key shouldn't occur
+      // — the two fold paths are subject-disjoint — but the guard makes the
+      // origin badge monotonic toward attribution regardless of row order.
+      if (existing.origin === "local" && c.origin !== "local") {
+        existing.origin = c.origin;
+      }
     }
   }
 

--- a/src/surface/mc/db/observability.ts
+++ b/src/surface/mc/db/observability.ts
@@ -26,6 +26,24 @@ export const OBSERVABILITY_FAMILIES: readonly ObservabilityFamily[] = [
   "transport",
 ] as const;
 
+/**
+ * P-14 U3.3 (#937) — the ORIGIN-BADGE for a projected observability row.
+ *
+ *   - `"local"` — this principal's own (or local-sibling) row, the U2.1 default.
+ *   - `{ kind: "foreign"; peer }` — a TRUST-VERIFIED federated peer's row, where
+ *     `peer` is the CHAIN-VERIFIED `{principal}/{stack}` derived from the
+ *     envelope SOURCE (never from the attacker-controlled payload). Mirrors the
+ *     agent-presence registry's `AgentRecordOrigin` vocabulary so the Network
+ *     view badges peer observability the same way it badges peer agents.
+ *
+ * A foreign row can NEVER be stored as local: the fold path supplies the
+ * source-bound `peer` and this module persists `origin_kind = 'foreign'` +
+ * `origin_peer = peer`. The negative-control's identity half.
+ */
+export type ObservabilityOrigin =
+  | "local"
+  | { kind: "foreign"; peer: string };
+
 export interface ObservabilityEventInsert {
   envelopeId: string;
   family: ObservabilityFamily;
@@ -36,6 +54,12 @@ export interface ObservabilityEventInsert {
   /** A short human-readable line for the row (optional). */
   summary?: string | null;
   payload: Record<string, unknown>;
+  /**
+   * P-14 U3.3 — origin badge. Defaults to `"local"` (the U2.1 contract: every
+   * caller that doesn't set it is folding a local row). The federated fold path
+   * passes `{ kind: "foreign"; peer }` with the chain-verified `{principal}/{stack}`.
+   */
+  origin?: ObservabilityOrigin;
   /** ISO-8601; defaults to now when omitted. */
   timestamp?: string;
 }
@@ -47,7 +71,22 @@ export interface ObservabilityEventRow {
   type: string;
   stackId: string | null;
   summary: string | null;
+  /** P-14 U3.3 — the row's origin badge (`"local"` or a foreign peer). */
+  origin: ObservabilityOrigin;
   timestamp: string;
+}
+
+/**
+ * Re-hydrate the `origin_kind`/`origin_peer` columns into an
+ * {@link ObservabilityOrigin}. A `foreign` row with a missing/empty `origin_peer`
+ * (defensive — the writer always pairs them) degrades to `local` rather than an
+ * originless foreign badge, so the view never shows an un-attributed peer.
+ */
+function rowOrigin(originKind: unknown, originPeer: unknown): ObservabilityOrigin {
+  if (originKind === "foreign" && typeof originPeer === "string" && originPeer.length > 0) {
+    return { kind: "foreign", peer: originPeer };
+  }
+  return "local";
 }
 
 /**
@@ -59,11 +98,14 @@ export function insertObservabilityEvent(
   e: ObservabilityEventInsert,
 ): string | null {
   const id = crypto.randomUUID();
+  const origin = e.origin ?? "local";
+  const originKind = origin === "local" ? "local" : "foreign";
+  const originPeer = origin === "local" ? null : origin.peer;
   const res = db
     .query(
       `INSERT INTO observability_events
-         (id, envelope_id, family, type, stack_id, summary, payload, timestamp)
-       VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))
+         (id, envelope_id, family, type, stack_id, summary, payload, origin_kind, origin_peer, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))
        ON CONFLICT(envelope_id) DO NOTHING`,
     )
     .run(
@@ -74,6 +116,8 @@ export function insertObservabilityEvent(
       e.stackId ?? null,
       e.summary ?? null,
       JSON.stringify(e.payload),
+      originKind,
+      originPeer,
       e.timestamp ?? null,
     );
   return res.changes > 0 ? id : null;
@@ -92,7 +136,7 @@ export function listObservabilityEvents(
     family === undefined
       ? db
           .query(
-            `SELECT id, envelope_id, family, type, stack_id, summary, timestamp
+            `SELECT id, envelope_id, family, type, stack_id, summary, origin_kind, origin_peer, timestamp
              FROM observability_events
              ORDER BY timestamp DESC, id DESC
              LIMIT ?`,
@@ -100,7 +144,7 @@ export function listObservabilityEvents(
           .all(limit)
       : db
           .query(
-            `SELECT id, envelope_id, family, type, stack_id, summary, timestamp
+            `SELECT id, envelope_id, family, type, stack_id, summary, origin_kind, origin_peer, timestamp
              FROM observability_events
              WHERE family = ?
              ORDER BY timestamp DESC, id DESC
@@ -115,6 +159,7 @@ export function listObservabilityEvents(
     type: r.type as string,
     stackId: (r.stack_id as string | null) ?? null,
     summary: (r.summary as string | null) ?? null,
+    origin: rowOrigin(r.origin_kind, r.origin_peer),
     timestamp: r.timestamp as string,
   }));
 }
@@ -138,6 +183,14 @@ export interface TransportRosterEventRow {
   stackId: string | null;
   /** The parsed envelope BODY signal published (`{ action, network, leaf?, leaves?, attributes? }`). */
   payload: Record<string, unknown>;
+  /**
+   * P-14 U3.3 (#937) — origin badge. `"local"` for this principal's own hub
+   * transport rows; `{ kind: "foreign"; peer }` for a TRUST-VERIFIED federated
+   * peer's. The Network-view overlay carries this onto each peer-stack so a
+   * folded foreign verdict is visually attributed to its peer, never shown as
+   * local substrate health.
+   */
+  origin: ObservabilityOrigin;
   timestamp: string;
 }
 
@@ -155,7 +208,7 @@ export function listTransportRosterEvents(
 ): TransportRosterEventRow[] {
   const rows = db
     .query(
-      `SELECT id, type, stack_id, payload, timestamp
+      `SELECT id, type, stack_id, payload, origin_kind, origin_peer, timestamp
        FROM observability_events
        WHERE family = 'transport'
        ORDER BY timestamp DESC, id DESC
@@ -181,6 +234,7 @@ export function listTransportRosterEvents(
       type: r.type as string,
       stackId: (r.stack_id as string | null) ?? null,
       payload,
+      origin: rowOrigin(r.origin_kind, r.origin_peer),
       timestamp: r.timestamp as string,
     };
   });

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -583,6 +583,15 @@ export const SCHEMA_SQL: string[] = [
   // `type` is the full `domain.entity.action`. Hub-scope (federation/transport)
   // is a DATA property — non-hub stacks simply have zero rows of those families,
   // which the tab renders as an honest empty state (never synthesized).
+  // P-14 U3.3 (#937) — `origin_kind` / `origin_peer` carry the ORIGIN-BADGE.
+  //   - `origin_kind` is `'local'` (this principal's own / sibling-stack rows,
+  //     the U2.1 default) or `'foreign'` (a TRUST-VERIFIED federated peer's row,
+  //     folded via the Option-D `federated-observability-fold.ts` path).
+  //   - `origin_peer` is the CHAIN-VERIFIED `{principal}/{stack}` for a foreign
+  //     row (NULL for local). It is derived from the verified envelope SOURCE,
+  //     never from the attacker-controlled payload — so a peer row can NEVER be
+  //     shown as local (the negative control's identity half).
+  // Fresh DBs get them here; existing DBs backfill via COLUMN_ADD_MIGRATIONS.
   `CREATE TABLE IF NOT EXISTS observability_events (
     id TEXT PRIMARY KEY,
     envelope_id TEXT NOT NULL UNIQUE,
@@ -592,10 +601,14 @@ export const SCHEMA_SQL: string[] = [
     stack_id TEXT,
     summary TEXT,
     payload TEXT NOT NULL DEFAULT '{}',
+    origin_kind TEXT NOT NULL DEFAULT 'local'
+      CHECK(origin_kind IN ('local','foreign')),
+    origin_peer TEXT,
     timestamp TEXT NOT NULL DEFAULT (datetime('now'))
   )`,
   `CREATE INDEX IF NOT EXISTS idx_observability_timestamp ON observability_events(timestamp)`,
   `CREATE INDEX IF NOT EXISTS idx_observability_family ON observability_events(family, timestamp DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_observability_origin ON observability_events(origin_kind, origin_peer)`,
 ];
 
 /**
@@ -674,6 +687,31 @@ export const COLUMN_ADD_MIGRATIONS: ColumnAddMigration[] = [
   { table: "sessions", column: "classification", ddl: `ALTER TABLE sessions ADD COLUMN classification TEXT` },
   { table: "sessions", column: "data_residency", ddl: `ALTER TABLE sessions ADD COLUMN data_residency TEXT` },
   { table: "sessions", column: "home_principal", ddl: `ALTER TABLE sessions ADD COLUMN home_principal TEXT` },
+
+  // P-14 U3.3 (#937) — origin-badge columns for EXISTING observability DBs.
+  // Fresh DBs get these from the observability_events CREATE TABLE above; an
+  // already-initialised DB (the running U2.1 stacks) backfills them here.
+  // `origin_kind` is NOT NULL with a constant DEFAULT 'local' (SQLite ALTER ADD
+  // requires a constant default for NOT NULL) — so every pre-U3.3 row reads as
+  // `local`, exactly its true origin (U2.1 only ever folded local rows safely;
+  // the federated path is what U3.3 adds). `origin_peer` is nullable (NULL for
+  // local). The partner index is idempotent via CREATE INDEX IF NOT EXISTS.
+  {
+    table: "observability_events",
+    column: "origin_kind",
+    ddl: `ALTER TABLE observability_events ADD COLUMN origin_kind TEXT NOT NULL DEFAULT 'local'`,
+    post: [
+      `CREATE INDEX IF NOT EXISTS idx_observability_origin ON observability_events(origin_kind, origin_peer)`,
+    ],
+  },
+  {
+    table: "observability_events",
+    column: "origin_peer",
+    ddl: `ALTER TABLE observability_events ADD COLUMN origin_peer TEXT`,
+    post: [
+      `CREATE INDEX IF NOT EXISTS idx_observability_origin ON observability_events(origin_kind, origin_peer)`,
+    ],
+  },
 ];
 
 /**

--- a/src/surface/mc/projection/observability-renderer.ts
+++ b/src/surface/mc/projection/observability-renderer.ts
@@ -53,6 +53,7 @@ import { broadcastProjection } from "../notifications";
 import {
   insertObservabilityEvent,
   type ObservabilityFamily,
+  type ObservabilityOrigin,
 } from "../db/observability";
 import { produceObservabilityAttention } from "./observability-attention";
 
@@ -61,26 +62,36 @@ export const OBSERVABILITY_PROJECTION_RENDERER_ID = "mc-observability-projection
 
 /**
  * NATS subject patterns the renderer subscribes to — the stack-ful
- * (`local.{principal}.{stack}.…`), stack-less (`local.{principal}.…`) LOCAL and
- * the federated (`federated.{principal}.{stack}.…`) grammars for each family.
- * Intentionally broad; the authoritative filter is the renderer's own `type`
- * prefix check (an over-matching subject costs only a cheap compare).
+ * (`local.{principal}.{stack}.…`) + stack-less (`local.{principal}.…`) LOCAL
+ * grammars for each family. Intentionally broad WITHIN the local scope; the
+ * authoritative filter is the renderer's own `type` prefix check (an
+ * over-matching subject costs only a cheap compare).
  *
  * `*` matches exactly one segment, `>` one-or-more trailing segments.
+ *
+ * ## P-14 U3.3 (#937) — LOCAL-ONLY. The `federated.*` grammars were REMOVED.
+ *
+ * Pre-U3.3 this renderer also subscribed to `federated.*.*.system.{signal,
+ * federation,transport}.>` and folded peer rows UN-origin-badged, WITHOUT chain
+ * verification, and WITHOUT cortex's curation gate (so it would have folded the
+ * DENIED `system.signal.*` class from a peer). That was a trust gap for a
+ * cross-principal fold. At U3.3 ALL `federated.*` observability flows through
+ * the dedicated TRUST-VERIFIED path (`bus/agent-network/federated-observability-
+ * fold.ts`): curation gate + federation accept-list + `verifySignedByChain` +
+ * source-bound origin badge. This renderer now folds ONLY this principal's own
+ * (and local-sibling) observability, every row `origin: "local"` (the default).
+ * The two paths are disjoint by subject scope — no double-fold.
  */
 export const OBSERVABILITY_PROJECTION_SUBJECTS: string[] = [
   // signal (covers signal.collector.* too — the prefix check splits them)
   "local.*.system.signal.>",
   "local.*.*.system.signal.>",
-  "federated.*.*.system.signal.>",
   // federation
   "local.*.system.federation.>",
   "local.*.*.system.federation.>",
-  "federated.*.*.system.federation.>",
   // transport (hub-emitted; non-hub stacks just never see these)
   "local.*.system.transport.>",
   "local.*.*.system.transport.>",
-  "federated.*.*.system.transport.>",
 ];
 
 /** A structural view of an envelope the projection reads. */
@@ -125,12 +136,18 @@ function originStackId(payload: Record<string, unknown>): string | null {
  * family (or null when the type matched no family / the row was a redelivery
  * no-op) so callers/tests can assert routing without the surface-router.
  *
+ * `origin` defaults to `"local"` — the U2.1 contract (this renderer + every
+ * local caller folds local rows). P-14 U3.3's federated fold path passes
+ * `{ kind: "foreign"; peer }` via {@link projectForeignObservability} so the row
+ * carries the chain-verified peer origin badge.
+ *
  * Exported for direct unit testing.
  */
 export function projectObservability(
   db: Database,
   envelope: ProjectableEnvelope,
   wsRegistry: WsClientRegistry | undefined,
+  origin: ObservabilityOrigin = "local",
 ): ObservabilityFamily | null {
   const family = familyForType(envelope.type);
   if (family === null) return null;
@@ -146,6 +163,9 @@ export function projectObservability(
   // shape (which then can't dedup, but never collides).
   const envelopeId = asString(envelope.id) ?? crypto.randomUUID();
 
+  // Origin-stack id is a best-effort GROUPING hint off the payload. For a
+  // FOREIGN row the authoritative ATTRIBUTION is the `origin.peer` (chain-
+  // verified source), persisted via the `origin` column — never the payload.
   const rowId = insertObservabilityEvent(db, {
     envelopeId,
     family,
@@ -153,6 +173,7 @@ export function projectObservability(
     stackId: originStackId(payload),
     summary: asString(payload.summary) ?? asString(payload.message),
     payload,
+    origin,
   });
 
   // The attention producer rides the SAME seam — every observability envelope is
@@ -160,7 +181,17 @@ export function projectObservability(
   // open or resolve an `att:adapter:` item. It runs independently of the row
   // insert's idempotent no-op (a redelivered degraded must still keep the item
   // open / resolvable), so it is NOT gated on `rowId`.
-  const attn = produceObservabilityAttention(db, { id: envelope.id, type: envelope.type, payload });
+  //
+  // P-14 U3.3 — only LOCAL observability opens the principal's actionable
+  // `att:adapter:` attention items. A FOREIGN peer's substrate health is
+  // origin-badged HISTORY (+ Network-view overlay), NOT the principal's own
+  // adapter to action — and `att:adapter:` items are keyed by leaf/backend id
+  // alone, so a peer's leaf would collide with a local one. Foreign rows project
+  // history + broadcast only; the attention queue stays the principal's own.
+  const attn =
+    origin === "local"
+      ? produceObservabilityAttention(db, { id: envelope.id, type: envelope.type, payload })
+      : null;
 
   let mutated = rowId !== null;
   if (attn !== null) {
@@ -171,6 +202,30 @@ export function projectObservability(
     broadcastProjection(wsRegistry, "observability");
   }
   return family;
+}
+
+/**
+ * P-14 U3.3 (#937) — the projection entry point for the TRUST-VERIFIED federated
+ * observability fold (`bus/agent-network/federated-observability-fold.ts`).
+ *
+ * Writes the curated, chain-verified peer envelope as an ORIGIN-BADGED row
+ * (`origin: { kind: "foreign"; peer }`), where `peer` is the chain-verified
+ * `{principal}/{stack}` the fold derived from the envelope SOURCE (never the
+ * payload). Thin wrapper over {@link projectObservability} with the foreign
+ * origin — so a foreign row gets the SAME idempotent-redelivery + WS-broadcast
+ * treatment as a local one, while being durably attributed to its peer and
+ * NEVER opening a local attention item.
+ *
+ * Non-throwing is the CALLER's contract here (the fold callback swallows), but
+ * the underlying inserts/broadcasts already never throw on valid inputs.
+ */
+export function projectForeignObservability(
+  db: Database,
+  envelope: ProjectableEnvelope,
+  peer: string,
+  wsRegistry: WsClientRegistry | undefined,
+): ObservabilityFamily | null {
+  return projectObservability(db, envelope, wsRegistry, { kind: "foreign", peer });
 }
 
 /**


### PR DESCRIPTION
**TRUST-PATH** — expect adversarial + /wire-check review. Closes #937. First concrete consumer slice of #21 (cortex = network-wide work consolidator).

## What
Fold federated peers' curated+signed `federated.{peer}.{stack}.system.{transport,federation}.*` observability into the U2.1 Observability tab + U2.3 Network-view transport overlay, **ORIGIN-BADGED** by peer `{principal}/{stack}`, through the **Option-D trust path** (the presence-subscriber pattern, applied to observability, + a curation gate).

## The gate (allow/deny) + verify wiring
New `src/bus/agent-network/federated-observability-fold.ts` runs, per inbound `federated.*.*.system.>` envelope, in order:

0. **CURATION GATE** — cortex's OWN code-fixed mirror of signal's U3.2 recipe (signal#141): **ALLOW** `{system.transport.>, system.federation.>}`; **DENY** `{trace.>, metric.>, log.>, session.>, system.signal.*}` (`federated-observability-curation.ts`, allow-list / fail-closed default-deny). This is the load-bearing **negative control** — a peer's non-exported class never reaches MC, independent of how the peer's network `accept_subjects` is configured.
1. **Federation accept-list** — `evaluateFederationGate` (resolves source network from source principal's `peers[]`; deny/hop/anti-spoof). Drop ⇒ `emitFederationDenied`.
2. **`verifySignedByChain`** — unsigned / bad-chain DROPPED **fail-closed** + emits `system.access.denied(chain_verify_failed)` via **U0.2's** `emit-system-access-denied.ts` (reused, not reinvented). Verifier fault ⇒ `chain_verify_fault`. Posture-gated empty-chain (`rejectEmpty`) identical to the presence subscriber / #484 dispatch-listener.

Only an envelope clearing **curation + accept-list + chain** is folded.

## Origin-badging
The badge derives from the **chain-verified `envelope.source`** `{principal}/{stack}` — NEVER the attacker-controlled payload (the #914 source-bound pattern). `observability_events` gains `origin_kind ('local'|'foreign')` + `origin_peer` (CREATE TABLE for fresh DBs + `COLUMN_ADD_MIGRATIONS` for existing — pre-U3.3 rows default to `local`, their true origin). The transport overlay carries the badge per peer-stack (foreign-monotonic: a foreign verdict is never downgraded to local). A foreign row projects history + WS broadcast but **never opens a local attention item** (peer substrate health ≠ the principal's actionable adapter).

The U2.1 renderer was **narrowed to `local.*`** — pre-U3.3 it also folded `federated.*` un-verified, un-badged, un-curated (it would have folded the DENIED `system.signal.*`). All federated observability now flows exclusively through the trust-verified fold; the two paths are subject-disjoint (no double-fold). `bus/` never imports `surface/mc/`, so the projection write is an injected callback wired in `cortex.ts` (`projectForeignObservability`).

## Negative control + unsigned-drop tests
- **Negative control** (`federated-observability-curation.test.ts` + `federated-observability-fold.test.ts`): a peer's `system.signal.collector.degraded` and `trace.span.start` provably do NOT fold (excluded at the curation gate) — asserted even while the peer is federation-accept-listed, proving the curation gate is an independent exclusion.
- **Unsigned/bad-chain → denial**: unsigned (empty chain under enforce) and bad-chain (unresolvable signer) envelopes are DROPPED + emit `system.access.denied` with `reason.kind === "chain_verify_failed"`.
- **Origin attribution**: an allow-listed + (no-resolver / verified) peer's `system.transport.*` folds with `peer: "joel/research"`; the badge derives from source even when the payload claims a local-looking `stack_id` (spoof-resistance).

## /wire-check — 5/5 PASS (CONSUMER, not dispatcher)
1. **No network on wire** — PASS. Subscribe pattern carries no `network_id`; admissibility resolves source network from source principal via `peers[]`. Audit envelope rides `local.{principal}.system.access.denied`.
2. **Subject addresses target** — PASS. Subscribes peers' `federated.{peer-principal}.{peer-stack}.system.>` (ADR-0001 `{principal}.{stack}` segments). No federated re-publish.
3. **Requester-in-originator** — **N/A (self-consume).** Not a dispatch/request-reply; no `originator` read or written. Peer identity for badge + chain-verify comes from chain-verified `source` (correct for attribution), not `originator` (there is none).
4. **Reply-keyed-on-requester** — **N/A (no reply).** Cortex consumes observability for display; emits no verdict/lifecycle back to the peer. Only emits LOCAL `system.access.denied` on drop, keyed on this principal's own audit stream, never on `federated.*`.
5. **Scope correct (federated tier)** — PASS, load-bearing. Ingests only `federated.*`, folds only curated exterior classes; `trace.>`/`system.signal.*` denied at the curation gate. **No publish-to-federation path exists** — a LOCAL interior cannot leak back onto the wire by construction.

## Collision notes (Session-B)
`src/bus/agent-network/federated-subscriber.ts` is the capability-offering epic's hotspot. This change ADDS sibling modules (`federated-observability-fold.ts` + `federated-observability-curation.ts`) rather than editing `federated-subscriber.ts`, keeping the seam conflict-light. Shared touch points: it reuses (does not modify) `evaluateFederationGate`/`emitFederationDenied`/`subjectMatches` from `surface-router.ts`, `verifySignedByChain`, and `emit-system-access-denied.ts`. `cortex.ts` wiring sits in the same `mc.enabled && presenceRegistryHandle` block as the presence subscriber.

## Gate results
- `bunx tsc --noEmit` → **0 errors**
- `bun test src/surface/mc/ src/bus/` → **2827 pass, 1 skip (pre-existing), 0 fail**
- `bun run lint` → **0 errors** (28 pre-existing warnings, untouched files)
- `bun run build:dashboard` → **ok**

## Needs 2-principal live verification (honest flag)
The Wave-3 live oracle (two real federated principals exchanging signed observability over a hub) is NOT exercised here — the trust LOGIC is unit-tested thoroughly instead (curation matrix, accept-list, chain-verify drop→denial, source-binding, origin round-trip, overlay badge, attention-skip). End-to-end signed-envelope flow across a real leaf link, and the curated export actually originating from a peer's signal U3.2 recipe, still need a 2-principal deployment to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)