### PR TITLE
feat(brain): cortex-brain/v1 protocol + per-task exec runner (B-1, #1021)

### DIFF
--- a/src/brain/__tests__/exec-brain-runner.test.ts
+++ b/src/brain/__tests__/exec-brain-runner.test.ts
@@ -560,3 +560,21 @@ done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary:
     }
   });
 });
+
+// --- sage round 3: runner-owned env keys -----------------------------------
+
+import { buildEnv as _buildEnvR3 } from "../exec-brain-runner";
+
+describe("round-3: secrets cannot override the sandbox env", () => {
+  test("rejects secret names colliding with runner-owned keys (any case)", () => {
+    for (const k of ["PATH", "TMPDIR", "home", "Lang"]) {
+      expect(() => _buildEnvR3("/tmp/scratch", { [k]: "evil" })).toThrow(/runner-owned/);
+    }
+  });
+
+  test("non-colliding secrets injected verbatim alongside the baseline", () => {
+    const env = _buildEnvR3("/tmp/scratch", { VT_API_KEY: "k" });
+    expect(env.VT_API_KEY).toBe("k");
+    expect(env.TMPDIR).toBe("/tmp/scratch");
+  });
+});

--- a/src/brain/__tests__/exec-brain-runner.test.ts
+++ b/src/brain/__tests__/exec-brain-runner.test.ts
@@ -184,7 +184,9 @@ done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary:
     expect(hooks.posts).toHaveLength(1);
     expect(hooks.posts[0]?.text).toBe("hello from brain");
     expect(out.logs).toContain("did the thing");
-    expect(out.exitCode).toBe(0);
+    // `result` is terminal: the run resolves on the result, BEFORE the process
+    // is reaped, so exitCode is unknown (null) at resolution time (finding 1).
+    expect(out.exitCode).toBeNull();
   });
 });
 
@@ -346,8 +348,182 @@ done({ v: 1, type: "result", task_id: task.task_id, status: "failed", reason: { 
       expect(out.result.reason.kind).toBe("not_now");
       expect(out.result.reason.detail).toContain("retry later");
     }
-    // A typed refusal is a CLEAN exit, not a crash.
-    expect(out.exitCode).toBe(0);
+    // A typed `result: failed` is terminal like any result — the run resolves
+    // on it before the process is reaped, so exitCode is null (finding 1). The
+    // refusal is a clean *result*, not a synthesized crash.
+    expect(out.exitCode).toBeNull();
+  });
+});
+
+describe("exec-brain-runner — result is terminal (finding 1)", () => {
+  test("brain emits result then sleeps forever → runner returns promptly, process reaped", async () => {
+    const fx = writeFixture(
+      "result-then-sleep.ts",
+      `${READ_FIRST_LINE}
+const task = await firstLine();
+emit({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: "fast" });
+// Do NOT exit — sleep forever. The runner must resolve on the result above and
+// reap us in the background, NOT block waiting for our exit.
+await new Promise(() => {});
+`,
+    );
+    const hooks = makeHooks();
+    // A long timeout (10s): if the runner were (incorrectly) waiting for exit,
+    // it would only return at SIGKILL ~ resultGrace+killGrace. We assert it
+    // returns FAR sooner than that.
+    const start = Date.now();
+    const out = await makeExecBrainRunner({
+      run: `bun ${fx}`,
+      packDir: fixtureDir,
+      timeoutMs: 10_000,
+      resultGraceMs: 500,
+      killGraceMs: 500,
+    })(makeTask(), hooks);
+    const elapsed = Date.now() - start;
+
+    expect(out.result.status).toBe("complete");
+    if (out.result.status === "complete") {
+      expect(out.result.summary).toBe("fast");
+    }
+    // Returned promptly — well under the 10s timeout (and under the 2s the
+    // finding cites). bun cold-start dominates; 2s is ample headroom.
+    expect(elapsed).toBeLessThan(2_000);
+    // exitCode is unknown at resolution (the process is reaped afterward).
+    expect(out.exitCode).toBeNull();
+  }, 15_000);
+});
+
+describe("exec-brain-runner — scratch-path confinement (finding 3)", () => {
+  // An inside-scratch path attachment is accepted (reaches the onPost hook).
+  test("post with a path inside scratch is accepted", async () => {
+    const fx = writeFixture(
+      "scratch-inside.ts",
+      `${READ_FIRST_LINE}
+const task = await firstLine();
+// TMPDIR is the scoped scratch dir; a child file is inside it.
+const inside = (process.env.TMPDIR ?? ".") + "/out.png";
+emit({ v: 1, type: "post", task_id: task.task_id, text: "inside", attachment: { filename: "out.png", path: inside } });
+done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: "ok" });
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+    expect(hooks.posts).toHaveLength(1);
+    expect(hooks.posts[0]?.text).toBe("inside");
+    expect(out.result.status).toBe("complete");
+  });
+
+  // A `..` escape is refused with effect_rejected and the post is DROPPED.
+  test("post with a ../escape path is rejected, post dropped", async () => {
+    const fx = writeFixture(
+      "scratch-escape.ts",
+      `${LINE_ITER}
+const it = lines();
+const task = (await it.next()).value;
+const escape = (process.env.TMPDIR ?? ".") + "/../../../etc/passwd";
+emit({ v: 1, type: "post", task_id: task.task_id, text: "escape", attachment: { filename: "passwd", path: escape } });
+for await (const ev of it) {
+  if (ev.type === "effect_rejected") {
+    done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: "rejected:" + ev.effect + ":" + ev.reason.detail });
+  }
+}
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+    // The escaping post never reached the hook.
+    expect(hooks.posts).toHaveLength(0);
+    expect(out.result.status).toBe("complete");
+    if (out.result.status === "complete") {
+      expect(out.result.summary).toContain("rejected:post:");
+      expect(out.result.summary).toContain("outside scratch dir");
+    }
+  });
+
+  // An absolute path elsewhere is refused too.
+  test("post with an absolute path outside scratch is rejected", async () => {
+    const fx = writeFixture(
+      "scratch-abs.ts",
+      `${LINE_ITER}
+const it = lines();
+const task = (await it.next()).value;
+emit({ v: 1, type: "post", task_id: task.task_id, text: "abs", attachment: { filename: "passwd", path: "/etc/passwd" } });
+for await (const ev of it) {
+  if (ev.type === "effect_rejected") {
+    done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: "rejected" });
+  }
+}
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+    expect(hooks.posts).toHaveLength(0);
+    expect(out.result.status).toBe("complete");
+  });
+});
+
+describe("exec-brain-runner — bounded stderr tail (finding 7)", () => {
+  test("a chatty brain's stderr is capped, with a truncation marker", async () => {
+    const fx = writeFixture(
+      "chatty-stderr.ts",
+      `${READ_FIRST_LINE}
+await firstLine();
+// Write ~64 KiB of stderr — far past the 8 KiB cap — then exit WITHOUT a result.
+const blob = "X".repeat(64 * 1024);
+process.stderr.write(blob + "\\nTAIL_SENTINEL\\n");
+process.exit(7);
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+    expect(out.result.status).toBe("failed");
+    // The retained tail is bounded (8 KiB cap + a short truncation marker),
+    // NOT the full 64 KiB the brain emitted.
+    expect(out.stderrTail.length).toBeLessThan(9 * 1024);
+    // The MOST RECENT bytes are kept (ring drops the oldest).
+    expect(out.stderrTail).toContain("TAIL_SENTINEL");
+    expect(out.stderrTail).toContain("stderr truncated");
+  });
+});
+
+describe("exec-brain-runner — pump errors captured (finding 6)", () => {
+  // A stdout stream that throws mid-read must NOT escape the runner; it is
+  // captured (folded into logs + stderr) and the no-result fallback synthesizes
+  // a failed result rather than rejecting.
+  test("a throwing stdout stream is captured, run still resolves failed", async () => {
+    const throwingStdout = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"v":1,"type":"log","level":"info","text":"hi"}\n'));
+        controller.error(new Error("stdout exploded"));
+      },
+    });
+    const emptyStderr = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const fakeSpawn = () => ({
+      stdin: { write: () => 0, flush: () => 0, end: () => {} },
+      stdout: throwingStdout,
+      stderr: emptyStderr,
+      exited: Promise.resolve(9),
+      kill: () => {},
+    });
+    // A throwaway scratch dir the runner may delete in cleanup — NOT the
+    // shared fixtureDir (cleanupScratch rm -rf's its argument).
+    const throwawayScratch = mkdtempSync(join(tmpdir(), "brain-pump-scratch-"));
+    const run = makeExecBrainRunner({
+      run: "irrelevant",
+      packDir: fixtureDir,
+      spawn: fakeSpawn,
+      makeScratchDir: () => throwawayScratch,
+    });
+    const hooks = makeHooks();
+    const out = await run(makeTask(), hooks);
+    // Did not throw; synthesized a failed result.
+    expect(out.result.status).toBe("failed");
+    // The captured pump error is visible in the logs.
+    expect(out.logs.some((l) => l.includes("stdout pump error"))).toBe(true);
   });
 });
 

--- a/src/brain/__tests__/exec-brain-runner.test.ts
+++ b/src/brain/__tests__/exec-brain-runner.test.ts
@@ -1,0 +1,386 @@
+/**
+ * `exec-brain-runner` end-to-end tests (Bot Packs B-1).
+ *
+ * Each test writes a tiny brain fixture (a .ts script) to a temp dir and runs
+ * it through the real runner via `bun`, exercising one protocol path:
+ *   - happy path (task → post → result complete)
+ *   - gate flow (ask_principal → gate_verdict with principal → result)
+ *   - foreign task_id → effect_rejected, dropped
+ *   - dispatch hook rejection → effect_rejected delivered to the brain
+ *   - brain crash → synthesized failed (cant_do)
+ *   - timeout → SIGTERM/KILL → synthesized failed
+ *   - typed refusal (result failed not_now) passes through
+ *
+ * The fixtures speak `cortex-brain/v1` by hand (raw JSON lines on stdout,
+ * reading events off stdin) so the test exercises the wire, not the codec.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  makeExecBrainRunner,
+  type BrainTaskHooks,
+} from "../exec-brain-runner";
+import type {
+  TaskEvent,
+  PostEffect,
+  AskPrincipalEffect,
+  DispatchEffect,
+  LogEffect,
+  GateVerdictValue,
+  BrainReason,
+} from "../protocol";
+
+// ---------------------------------------------------------------------------
+// Fixture harness
+// ---------------------------------------------------------------------------
+
+let fixtureDir: string;
+
+beforeAll(() => {
+  fixtureDir = mkdtempSync(join(tmpdir(), "brain-fixtures-"));
+});
+
+afterAll(() => {
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+/** Write a brain fixture script and return its path. */
+function writeFixture(name: string, body: string): string {
+  const path = join(fixtureDir, name);
+  writeFileSync(path, body, "utf8");
+  return path;
+}
+
+/** A baseline task event. */
+function makeTask(overrides: Partial<TaskEvent> = {}): TaskEvent {
+  return {
+    v: 1,
+    type: "task",
+    task_id: "task-1",
+    capability: "soc.compose.flow",
+    payload: { scenario: "phish" },
+    source: { surface: "mattermost", channel: "c1", thread: "th1", user: "u1" },
+    persona: "You are a test brain.",
+    ...overrides,
+  };
+}
+
+/** Recording hooks with sensible defaults; override per test. */
+function makeHooks(over: Partial<BrainTaskHooks> = {}): BrainTaskHooks & {
+  posts: PostEffect[];
+  asks: AskPrincipalEffect[];
+  dispatches: DispatchEffect[];
+  brainLogs: LogEffect[];
+} {
+  const posts: PostEffect[] = [];
+  const asks: AskPrincipalEffect[] = [];
+  const dispatches: DispatchEffect[] = [];
+  const brainLogs: LogEffect[] = [];
+  return {
+    posts,
+    asks,
+    dispatches,
+    brainLogs,
+    onPost: over.onPost ?? ((p) => void posts.push(p)),
+    onAskPrincipal:
+      over.onAskPrincipal ??
+      (async (a): Promise<{ verdict: GateVerdictValue; principal: string }> => {
+        asks.push(a);
+        return { verdict: "pass", principal: "andreas" };
+      }),
+    onDispatch:
+      over.onDispatch ??
+      ((d) => {
+        dispatches.push(d);
+      }),
+    onLog: over.onLog ?? ((l) => void brainLogs.push(l)),
+  };
+}
+
+/**
+ * A short timeout-friendly runner. `bun` start-up is ~tens of ms; 8 s leaves
+ * ample headroom while keeping the timeout-path test fast.
+ */
+function runner(fixturePath: string, over: { timeoutMs?: number; killGraceMs?: number } = {}) {
+  return makeExecBrainRunner({
+    run: `bun ${fixturePath}`,
+    packDir: fixtureDir,
+    timeoutMs: over.timeoutMs ?? 8_000,
+    killGraceMs: over.killGraceMs ?? 1_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixture prologue — read the task off stdin
+// ---------------------------------------------------------------------------
+//
+// Each brain reads ONE line (the task event) off stdin, then acts. A few also
+// keep reading for follow-up events (gate_verdict / effect_rejected).
+
+//
+// NB: fixtures read stdin via \`node:readline\`, NOT \`Bun.stdin.stream()\`.
+// A spawned child reading \`Bun.stdin.stream()\` does not observe the parent's
+// incremental \`FileSink\` writes under \`bun test\` (the second write never
+// arrives — the child blocks until EOF). \`node:readline\` over
+// \`process.stdin\` delivers lines incrementally and is the portable choice
+// for a line-protocol child. This is a TEST-FIXTURE concern only; the runner
+// drives real packs, which read their own stdin however they like.
+
+const READ_FIRST_LINE = `
+import { createInterface as __ci } from "node:readline";
+const __rl = __ci({ input: process.stdin });
+const __it = __rl[Symbol.asyncIterator]();
+async function firstLine(): Promise<any> {
+  const { value } = await __it.next();
+  return value === undefined ? null : JSON.parse(value);
+}
+function emit(o: unknown) { process.stdout.write(JSON.stringify(o) + "\\n"); }
+// Emit a terminal effect then exit cleanly — node:readline keeps stdin (and
+// thus the event loop) open, so a brain must exit explicitly once done.
+function done(o: unknown) { emit(o); __rl.close(); process.exit(0); }
+`;
+
+// A reader that yields parsed JSON lines (for brains awaiting follow-ups).
+const LINE_ITER = `
+import { createInterface as __ci } from "node:readline";
+const __rl = __ci({ input: process.stdin });
+async function* lines() {
+  for await (const __line of __rl) {
+    const __t = __line.trim();
+    if (__t.length > 0) yield JSON.parse(__t);
+  }
+}
+function emit(o: unknown) { process.stdout.write(JSON.stringify(o) + "\\n"); }
+// Emit a terminal effect then exit cleanly — node:readline keeps stdin (and
+// thus the event loop) open, so a brain must exit explicitly once done.
+function done(o: unknown) { emit(o); __rl.close(); process.exit(0); }
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("exec-brain-runner — happy path", () => {
+  test("task → post → result complete", async () => {
+    const fx = writeFixture(
+      "happy.ts",
+      `${READ_FIRST_LINE}
+const task = await firstLine();
+emit({ v: 1, type: "post", task_id: task.task_id, text: "hello from brain" });
+emit({ v: 1, type: "log", level: "info", text: "did the thing" });
+done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: "ok" });
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+
+    expect(out.result.status).toBe("complete");
+    if (out.result.status === "complete") {
+      expect(out.result.summary).toBe("ok");
+    }
+    expect(hooks.posts).toHaveLength(1);
+    expect(hooks.posts[0]?.text).toBe("hello from brain");
+    expect(out.logs).toContain("did the thing");
+    expect(out.exitCode).toBe(0);
+  });
+});
+
+describe("exec-brain-runner — gate flow", () => {
+  test("ask_principal → gate_verdict with principal → result", async () => {
+    const fx = writeFixture(
+      "gate.ts",
+      `${LINE_ITER}
+let task: any;
+const it = lines();
+const first = await it.next();
+task = first.value;
+emit({ v: 1, type: "ask_principal", task_id: task.task_id, gate: "principal-ack", prompt: "Run it?" });
+// Await the gate_verdict the runner feeds back.
+for await (const ev of it) {
+  if (ev.type === "gate_verdict") {
+    emit({ v: 1, type: "post", task_id: task.task_id, text: "verdict=" + ev.verdict + " principal=" + ev.principal });
+    done({ v: 1, type: "result", task_id: task.task_id, status: ev.verdict === "pass" ? "complete" : "failed", ...(ev.verdict === "pass" ? { summary: "ran" } : { reason: { kind: "wont_do", detail: "denied" } }) });
+  }
+}
+`,
+    );
+    const hooks = makeHooks({
+      onAskPrincipal: async (a) => {
+        expect(a.gate).toBe("principal-ack");
+        return { verdict: "pass", principal: "andreas", notes: "go" };
+      },
+    });
+    const out = await runner(fx)(makeTask(), hooks);
+
+    expect(out.result.status).toBe("complete");
+    expect(hooks.posts[0]?.text).toBe("verdict=pass principal=andreas");
+  });
+});
+
+describe("exec-brain-runner — task_id correlation", () => {
+  test("foreign task_id → effect_rejected, effect dropped (not delivered to hooks)", async () => {
+    const fx = writeFixture(
+      "foreign.ts",
+      `${LINE_ITER}
+const it = lines();
+const task = (await it.next()).value;
+// Emit a post for a DIFFERENT task id — runner must reject + drop it.
+emit({ v: 1, type: "post", task_id: "someone-elses-task", text: "should be dropped" });
+// Await the effect_rejected the runner sends back, then close cleanly.
+for await (const ev of it) {
+  if (ev.type === "effect_rejected") {
+    done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: "rejected=" + ev.reason.kind });
+  }
+}
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+
+    // The foreign post never reached the onPost hook.
+    expect(hooks.posts).toHaveLength(0);
+    expect(out.result.status).toBe("complete");
+    if (out.result.status === "complete") {
+      expect(out.result.summary).toBe("rejected=wont_do");
+    }
+  });
+});
+
+describe("exec-brain-runner — dispatch rejection", () => {
+  test("dispatch hook rejection → effect_rejected delivered to brain", async () => {
+    const fx = writeFixture(
+      "dispatch-reject.ts",
+      `${LINE_ITER}
+const it = lines();
+const task = (await it.next()).value;
+emit({ v: 1, type: "dispatch", task_id: task.task_id, capability: "soc.forbidden", payload: {} });
+for await (const ev of it) {
+  if (ev.type === "effect_rejected") {
+    done({ v: 1, type: "result", task_id: task.task_id, status: "failed", reason: { kind: ev.reason.kind, detail: "host refused: " + ev.reason.detail } });
+  }
+}
+`,
+    );
+    const hooks = makeHooks({
+      onDispatch: (d): { rejected: true; reason: BrainReason } => {
+        expect(d.capability).toBe("soc.forbidden");
+        return { rejected: true, reason: { kind: "wont_do", detail: "capability outside manifest" } };
+      },
+    });
+    const out = await runner(fx)(makeTask(), hooks);
+
+    expect(out.result.status).toBe("failed");
+    if (out.result.status === "failed") {
+      expect(out.result.reason.kind).toBe("wont_do");
+      expect(out.result.reason.detail).toContain("capability outside manifest");
+    }
+  });
+});
+
+describe("exec-brain-runner — brain crash", () => {
+  test("brain exits without result → synthesized failed (cant_do) with stderr tail", async () => {
+    const fx = writeFixture(
+      "crash.ts",
+      `${READ_FIRST_LINE}
+await firstLine();
+process.stderr.write("boom: something broke\\n");
+process.exit(3);
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+
+    expect(out.result.status).toBe("failed");
+    if (out.result.status === "failed") {
+      expect(out.result.reason.kind).toBe("cant_do");
+      expect(out.result.reason.detail).toContain("without result");
+      expect(out.result.reason.detail).toContain("boom");
+    }
+    expect(out.stderrTail).toContain("boom");
+    expect(out.exitCode).toBe(3);
+  });
+});
+
+describe("exec-brain-runner — timeout", () => {
+  test("brain that never returns → SIGTERM/KILL → synthesized failed", async () => {
+    const fx = writeFixture(
+      "hang.ts",
+      `${READ_FIRST_LINE}
+const task = await firstLine();
+if (task !== null) emit({ v: 1, type: "log", level: "info", text: "going to sleep forever" });
+// Never emit a result; sleep past the runner timeout.
+await new Promise(() => {});
+`,
+    );
+    const hooks = makeHooks();
+    // timeoutMs generous enough that the brain reliably reads the task and
+    // emits its log before we trip the timeout (bun cold-start is ~100-300ms),
+    // but short enough to keep the test fast.
+    const out = await runner(fx, { timeoutMs: 1_500, killGraceMs: 400 })(makeTask(), hooks);
+
+    expect(out.result.status).toBe("failed");
+    if (out.result.status === "failed") {
+      expect(out.result.reason.kind).toBe("cant_do");
+      expect(out.result.reason.detail).toContain("timed out");
+    }
+  }, 10_000);
+});
+
+describe("exec-brain-runner — typed refusal passthrough", () => {
+  test("result failed not_now passes through unflattened", async () => {
+    const fx = writeFixture(
+      "refuse.ts",
+      `${READ_FIRST_LINE}
+const task = await firstLine();
+done({ v: 1, type: "result", task_id: task.task_id, status: "failed", reason: { kind: "not_now", detail: "substrate busy, retry later" } });
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+
+    expect(out.result.status).toBe("failed");
+    if (out.result.status === "failed") {
+      expect(out.result.reason.kind).toBe("not_now");
+      expect(out.result.reason.detail).toContain("retry later");
+    }
+    // A typed refusal is a CLEAN exit, not a crash.
+    expect(out.exitCode).toBe(0);
+  });
+});
+
+describe("exec-brain-runner — secrets + env scoping", () => {
+  test("only declared secrets + minimal env reach the brain; no ambient creds", async () => {
+    const fx = writeFixture(
+      "env.ts",
+      `${READ_FIRST_LINE}
+const task = await firstLine();
+done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: JSON.stringify({
+  secret: process.env.VT_API_KEY ?? null,
+  ambient: process.env.SHOULD_NOT_LEAK ?? null,
+  hasTmp: typeof process.env.TMPDIR === "string",
+}) });
+`,
+    );
+    // Set an ambient var that must NOT leak through.
+    process.env.SHOULD_NOT_LEAK = "leaked!";
+    const run = makeExecBrainRunner({
+      run: `bun ${fx}`,
+      packDir: fixtureDir,
+      secrets: { VT_API_KEY: "sekret" },
+      timeoutMs: 8_000,
+    });
+    const out = await run(makeTask(), makeHooks());
+    delete process.env.SHOULD_NOT_LEAK;
+
+    expect(out.result.status).toBe("complete");
+    if (out.result.status === "complete") {
+      const parsed = JSON.parse(out.result.summary ?? "{}");
+      expect(parsed.secret).toBe("sekret");
+      expect(parsed.ambient).toBeNull();
+      expect(parsed.hasTmp).toBe(true);
+    }
+  });
+});

--- a/src/brain/__tests__/protocol.test.ts
+++ b/src/brain/__tests__/protocol.test.ts
@@ -1,0 +1,503 @@
+/**
+ * `cortex-brain/v1` protocol codec tests (Bot Packs B-1).
+ *
+ * Covers: codec round-trips for every event + effect type, unknown-type
+ * tolerance (drop-and-log, never throw), unknown-field tolerance (strip),
+ * the 256 KiB inline-attachment cap, and chunked/partial-line JSONL decoding.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  encodeBrainEvent,
+  parseBrainEvent,
+  encodeBrainEffect,
+  parseBrainEffect,
+  JsonlDecoder,
+  MAX_ATTACHMENT_B64_BYTES,
+  BRAIN_PROTOCOL_VERSION,
+  BRAIN_PROTOCOL_ID,
+  type BrainEvent,
+  type BrainEffect,
+} from "../protocol";
+
+// ---------------------------------------------------------------------------
+// Fixtures — one of every event + effect
+// ---------------------------------------------------------------------------
+
+const events: BrainEvent[] = [
+  {
+    v: 1,
+    type: "task",
+    task_id: "t1",
+    capability: "soc.compose.flow",
+    payload: { scenario: "phish" },
+    source: { surface: "mattermost", channel: "c1", thread: "th1", user: "u1" },
+    persona: "You are Yarrow.",
+  },
+  {
+    v: 1,
+    type: "message",
+    task_id: "t1",
+    text: "follow up",
+    user: "u1",
+  },
+  {
+    v: 1,
+    type: "gate_verdict",
+    task_id: "t1",
+    gate: "principal-ack",
+    verdict: "pass",
+    notes: "run it",
+    principal: "andreas",
+  },
+  { v: 1, type: "cancel", task_id: "t1" },
+  { v: 1, type: "shutdown", deadline_ms: 5000 },
+  {
+    v: 1,
+    type: "effect_rejected",
+    task_id: "t1",
+    effect: "dispatch",
+    reason: { kind: "wont_do", detail: "capability outside manifest" },
+  },
+  {
+    v: 1,
+    type: "hello",
+    persona: "You are Yarrow.",
+    agent: "yarrow",
+    protocol: "cortex-brain/v1",
+  },
+];
+
+const effects: BrainEffect[] = [
+  {
+    v: 1,
+    type: "post",
+    task_id: "t1",
+    text: "here is the flow",
+    attachment: { filename: "flow.png", b64: "aGVsbG8=" },
+  },
+  {
+    v: 1,
+    type: "post",
+    task_id: "t1",
+    text: "big one",
+    attachment: { filename: "flow.png", path: "/scratch/flow.png" },
+  },
+  { v: 1, type: "post", task_id: "t1", text: "no attachment" },
+  {
+    v: 1,
+    type: "ask_principal",
+    task_id: "t1",
+    gate: "principal-ack",
+    prompt: "Run this flow?",
+  },
+  {
+    v: 1,
+    type: "dispatch",
+    task_id: "t1",
+    capability: "soc.triage.email",
+    payload: { id: 7 },
+    sovereignty: { model_class: "local-only" },
+  },
+  {
+    v: 1,
+    type: "dispatch",
+    task_id: "t1",
+    capability: "soc.triage.email",
+    payload: {},
+  },
+  { v: 1, type: "result", task_id: "t1", status: "complete", summary: "done" },
+  { v: 1, type: "result", task_id: "t1", status: "complete" },
+  {
+    v: 1,
+    type: "result",
+    task_id: "t1",
+    status: "failed",
+    reason: { kind: "not_now", detail: "substrate busy" },
+  },
+  { v: 1, type: "log", level: "info", text: "composing" },
+];
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("protocol constants", () => {
+  test("version + id are pinned", () => {
+    expect(BRAIN_PROTOCOL_VERSION).toBe(1);
+    expect(BRAIN_PROTOCOL_ID).toBe("cortex-brain/v1");
+    expect(MAX_ATTACHMENT_B64_BYTES).toBe(256 * 1024);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trips
+// ---------------------------------------------------------------------------
+
+describe("event codec round-trips", () => {
+  for (const ev of events) {
+    test(`event ${ev.type} round-trips`, () => {
+      const line = encodeBrainEvent(ev);
+      expect(line).not.toContain("\n");
+      const parsed = parseBrainEvent(line);
+      expect(parsed.kind).toBe("ok");
+      if (parsed.kind === "ok") {
+        expect(parsed.event).toEqual(ev);
+      }
+    });
+
+    test(`event ${ev.type} carries v:1`, () => {
+      const obj = JSON.parse(encodeBrainEvent(ev));
+      expect(obj.v).toBe(1);
+      expect(obj.type).toBe(ev.type);
+    });
+  }
+});
+
+describe("effect codec round-trips", () => {
+  for (const [i, ef] of effects.entries()) {
+    test(`effect ${ef.type} #${i} round-trips`, () => {
+      const line = encodeBrainEffect(ef);
+      expect(line).not.toContain("\n");
+      const parsed = parseBrainEffect(line);
+      expect(parsed.kind).toBe("ok");
+      if (parsed.kind === "ok") {
+        expect(parsed.effect).toEqual(ef);
+      }
+    });
+
+    test(`effect ${ef.type} #${i} carries v:1`, () => {
+      const obj = JSON.parse(encodeBrainEffect(ef));
+      expect(obj.v).toBe(1);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Unknown-type tolerance
+// ---------------------------------------------------------------------------
+
+describe("unknown-type tolerance (forward-compat §5)", () => {
+  test("unknown effect type → {kind:unknown}, never throws", () => {
+    const line = JSON.stringify({ v: 1, type: "stream_partial", task_id: "t1", chunk: "x" });
+    const parsed = parseBrainEffect(line);
+    expect(parsed.kind).toBe("unknown");
+    if (parsed.kind === "unknown") {
+      expect(parsed.raw["type"]).toBe("stream_partial");
+    }
+  });
+
+  test("unknown event type → {kind:unknown}, never throws", () => {
+    const line = JSON.stringify({ v: 1, type: "pause", task_id: "t1" });
+    const parsed = parseBrainEvent(line);
+    expect(parsed.kind).toBe("unknown");
+  });
+
+  test("malformed JSON → {kind:invalid}, never throws", () => {
+    const parsed = parseBrainEffect("{ not json");
+    expect(parsed.kind).toBe("invalid");
+  });
+
+  test("non-object JSON → invalid", () => {
+    expect(parseBrainEffect("42").kind).toBe("invalid");
+    expect(parseBrainEffect('"a string"').kind).toBe("invalid");
+    expect(parseBrainEffect("[1,2,3]").kind).toBe("invalid");
+    expect(parseBrainEffect("null").kind).toBe("invalid");
+  });
+
+  test("missing type field → invalid", () => {
+    expect(parseBrainEffect(JSON.stringify({ v: 1 })).kind).toBe("invalid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown-field tolerance (strip on known types)
+// ---------------------------------------------------------------------------
+
+describe("unknown-field tolerance", () => {
+  test("extra fields on a known effect are stripped, parse succeeds", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "log",
+      level: "info",
+      text: "hi",
+      future_field: "ignore me",
+    });
+    const parsed = parseBrainEffect(line);
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") {
+      expect(parsed.effect).not.toHaveProperty("future_field");
+    }
+  });
+
+  test("extra fields on a known event are stripped", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "cancel",
+      task_id: "t1",
+      extra: true,
+    });
+    const parsed = parseBrainEvent(line);
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") {
+      expect(parsed.event).not.toHaveProperty("extra");
+    }
+  });
+
+  test("emission strips stray keys before serialization", () => {
+    const dirty = {
+      v: 1,
+      type: "log",
+      level: "info",
+      text: "hi",
+      leaked_secret: "DO NOT EMIT",
+    } as unknown as BrainEffect;
+    const line = encodeBrainEffect(dirty);
+    expect(line).not.toContain("leaked_secret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 256 KiB attachment cap
+// ---------------------------------------------------------------------------
+
+describe("256 KiB inline-attachment cap", () => {
+  test("b64 at the limit parses", () => {
+    const b64 = "a".repeat(MAX_ATTACHMENT_B64_BYTES);
+    const line = JSON.stringify({
+      v: 1,
+      type: "post",
+      task_id: "t1",
+      text: "ok",
+      attachment: { filename: "f.png", b64 },
+    });
+    expect(parseBrainEffect(line).kind).toBe("ok");
+  });
+
+  test("b64 one byte over the limit is rejected as invalid", () => {
+    const b64 = "a".repeat(MAX_ATTACHMENT_B64_BYTES + 1);
+    const line = JSON.stringify({
+      v: 1,
+      type: "post",
+      task_id: "t1",
+      text: "too big",
+      attachment: { filename: "f.png", b64 },
+    });
+    const parsed = parseBrainEffect(line);
+    expect(parsed.kind).toBe("invalid");
+    if (parsed.kind === "invalid") {
+      expect(parsed.detail).toContain("256");
+    }
+  });
+
+  test("a path attachment of any size parses (the escape hatch)", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "post",
+      task_id: "t1",
+      text: "big via path",
+      attachment: { filename: "huge.png", path: "/scratch/huge.png" },
+    });
+    expect(parseBrainEffect(line).kind).toBe("ok");
+  });
+
+  test("an attachment with neither b64 nor path is invalid", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "post",
+      task_id: "t1",
+      text: "bad",
+      attachment: { filename: "f.png" },
+    });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// result discriminated union
+// ---------------------------------------------------------------------------
+
+describe("result status discrimination", () => {
+  test("failed without a reason is invalid", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "result",
+      task_id: "t1",
+      status: "failed",
+    });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
+
+  test("failed reason.kind must be in the taxonomy", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "result",
+      task_id: "t1",
+      status: "failed",
+      reason: { kind: "exploded", detail: "x" },
+    });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
+
+  test("all three reason kinds are accepted", () => {
+    for (const kind of ["cant_do", "not_now", "wont_do"]) {
+      const line = JSON.stringify({
+        v: 1,
+        type: "result",
+        task_id: "t1",
+        status: "failed",
+        reason: { kind, detail: "x" },
+      });
+      expect(parseBrainEffect(line).kind).toBe("ok");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gate_verdict vocabulary
+// ---------------------------------------------------------------------------
+
+describe("gate_verdict vocabulary", () => {
+  test("pass and fail are accepted", () => {
+    for (const verdict of ["pass", "fail"]) {
+      const line = JSON.stringify({
+        v: 1,
+        type: "gate_verdict",
+        task_id: "t1",
+        gate: "principal-ack",
+        verdict,
+        principal: "andreas",
+      });
+      expect(parseBrainEvent(line).kind).toBe("ok");
+    }
+  });
+
+  test("a non-pass/fail verdict is invalid", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "gate_verdict",
+      task_id: "t1",
+      gate: "principal-ack",
+      verdict: "allow",
+      principal: "andreas",
+    });
+    expect(parseBrainEvent(line).kind).toBe("invalid");
+  });
+
+  test("gate_verdict requires a principal", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "gate_verdict",
+      task_id: "t1",
+      gate: "principal-ack",
+      verdict: "pass",
+    });
+    expect(parseBrainEvent(line).kind).toBe("invalid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JsonlDecoder — chunked / partial-line input
+// ---------------------------------------------------------------------------
+
+describe("JsonlDecoder", () => {
+  const enc = (s: string) => new TextEncoder().encode(s);
+
+  test("splits complete lines", () => {
+    const d = new JsonlDecoder();
+    const lines = d.push(enc('{"a":1}\n{"b":2}\n'));
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  test("buffers a partial line across chunks", () => {
+    const d = new JsonlDecoder();
+    expect(d.push(enc('{"a":'))).toEqual([]);
+    expect(d.push(enc("1}\n"))).toEqual(['{"a":1}']);
+  });
+
+  test("reassembles a line split at an arbitrary byte boundary", () => {
+    const d = new JsonlDecoder();
+    const full = '{"type":"log","text":"hello world"}\n';
+    const out: string[] = [];
+    // Feed one byte at a time.
+    const bytes = enc(full);
+    for (const b of bytes) {
+      out.push(...d.push(new Uint8Array([b])));
+    }
+    expect(out).toEqual(['{"type":"log","text":"hello world"}']);
+  });
+
+  test("handles a multibyte codepoint split across chunks", () => {
+    const d = new JsonlDecoder();
+    // "café" — the é is two UTF-8 bytes; split between them.
+    const payload = '{"t":"café"}\n';
+    const bytes = enc(payload);
+    // Find the é bytes and split mid-codepoint.
+    const splitAt = payload.indexOf("é") + 1; // byte index differs but close enough; do real byte split:
+    void splitAt;
+    // Real byte-level split: cut the buffer exactly between the two é bytes.
+    const eIdx = bytes.findIndex((b) => b === 0xc3); // first byte of é
+    const first = bytes.slice(0, eIdx + 1);
+    const second = bytes.slice(eIdx + 1);
+    const out: string[] = [];
+    out.push(...d.push(first));
+    out.push(...d.push(second));
+    expect(out).toEqual(['{"t":"café"}']);
+  });
+
+  test("skips blank lines", () => {
+    const d = new JsonlDecoder();
+    const lines = d.push(enc('{"a":1}\n\n{"b":2}\n'));
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  test("tolerates CRLF line endings", () => {
+    const d = new JsonlDecoder();
+    const lines = d.push(enc('{"a":1}\r\n{"b":2}\r\n'));
+    expect(lines).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  test("flush yields a trailing newline-less line", () => {
+    const d = new JsonlDecoder();
+    expect(d.push(enc('{"a":1}\n{"b":2}'))).toEqual(['{"a":1}']);
+    expect(d.flush()).toEqual(['{"b":2}']);
+  });
+
+  test("flush with no tail yields nothing", () => {
+    const d = new JsonlDecoder();
+    d.push(enc('{"a":1}\n'));
+    expect(d.flush()).toEqual([]);
+  });
+
+  test("accepts string chunks too", () => {
+    const d = new JsonlDecoder();
+    expect(d.push('{"a":1}\n')).toEqual(['{"a":1}']);
+  });
+
+  test("end-to-end: chunked stream parses into effects", () => {
+    const d = new JsonlDecoder();
+    const stream =
+      encodeBrainEffect({ v: 1, type: "log", level: "info", text: "a" }) +
+      "\n" +
+      encodeBrainEffect({
+        v: 1,
+        type: "result",
+        task_id: "t1",
+        status: "complete",
+      }) +
+      "\n";
+    const bytes = enc(stream);
+    // Split into 3 arbitrary chunks.
+    const mid1 = Math.floor(bytes.length / 3);
+    const mid2 = Math.floor((2 * bytes.length) / 3);
+    const parsed = [
+      ...d.push(bytes.slice(0, mid1)),
+      ...d.push(bytes.slice(mid1, mid2)),
+      ...d.push(bytes.slice(mid2)),
+      ...d.flush(),
+    ].map(parseBrainEffect);
+    expect(parsed.map((p) => p.kind)).toEqual(["ok", "ok"]);
+    expect(parsed[0]?.kind === "ok" && parsed[0].effect.type).toBe("log");
+    expect(parsed[1]?.kind === "ok" && parsed[1].effect.type).toBe("result");
+  });
+});

--- a/src/brain/__tests__/protocol.test.ts
+++ b/src/brain/__tests__/protocol.test.ts
@@ -617,3 +617,31 @@ describe("JsonlDecoder", () => {
     expect(parsed[1]?.kind === "ok" && parsed[1].effect.type).toBe("result");
   });
 });
+
+// --- sage round 3 probes ---------------------------------------------------
+
+import { parseBrainEffect as _parseR3 } from "../protocol";
+
+describe("round-3: tolerant attachment extras, strict XOR, complete-reason", () => {
+  const base = { v: 1, type: "post", task_id: "t1", text: "x" };
+
+  test("unknown extra fields on a known attachment are tolerated (stripped)", () => {
+    const r = _parseR3(JSON.stringify({ ...base, attachment: { filename: "a.png", b64: "aGk=", width: 800 } }));
+    expect(r.kind).toBe("ok");
+  });
+
+  test("both b64 and path still rejected (XOR survives tolerance)", () => {
+    const r = _parseR3(JSON.stringify({ ...base, attachment: { filename: "a", b64: "aGk=", path: "x" } }));
+    expect(r.kind).toBe("invalid");
+  });
+
+  test("neither b64 nor path rejected", () => {
+    const r = _parseR3(JSON.stringify({ ...base, attachment: { filename: "a" } }));
+    expect(r.kind).toBe("invalid");
+  });
+
+  test("complete result carrying a reason is rejected, not stripped", () => {
+    const r = _parseR3(JSON.stringify({ v: 1, type: "result", task_id: "t1", status: "complete", reason: { kind: "cant_do", detail: "x" } }));
+    expect(r.kind).toBe("invalid");
+  });
+});

--- a/src/brain/__tests__/protocol.test.ts
+++ b/src/brain/__tests__/protocol.test.ts
@@ -311,6 +311,19 @@ describe("256 KiB inline-attachment cap", () => {
     });
     expect(parseBrainEffect(line).kind).toBe("invalid");
   });
+
+  // Finding 2: the XOR must be genuine — both keys present must FAIL, not
+  // silently bind to the b64 branch and strip `path`.
+  test("an attachment with BOTH b64 and path is invalid (genuine XOR)", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "post",
+      task_id: "t1",
+      text: "both",
+      attachment: { filename: "f.png", b64: "aGk=", path: "/scratch/f.png" },
+    });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -350,6 +363,112 @@ describe("result status discrimination", () => {
       });
       expect(parseBrainEffect(line).kind).toBe("ok");
     }
+  });
+
+  // Finding 4: brain-emitted result.failed stays the 3-kind taxonomy — the
+  // host-only kinds must NOT be accepted from a brain.
+  test("brain result.failed rejects host-only kinds (policy_denied, compliance_block)", () => {
+    for (const kind of ["policy_denied", "compliance_block"]) {
+      const line = JSON.stringify({
+        v: 1,
+        type: "result",
+        task_id: "t1",
+        status: "failed",
+        reason: { kind, detail: "x" },
+      });
+      expect(parseBrainEffect(line).kind).toBe("invalid");
+    }
+  });
+
+  // Finding 4: not_now may carry an optional retry_after_ms hint.
+  test("not_now result.failed may carry retry_after_ms", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "result",
+      task_id: "t1",
+      status: "failed",
+      reason: { kind: "not_now", detail: "busy", retry_after_ms: 5000 },
+    });
+    const parsed = parseBrainEffect(line);
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok" && parsed.effect.type === "result" && parsed.effect.status === "failed") {
+      expect(parsed.effect.reason.retry_after_ms).toBe(5000);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// effect_rejected host taxonomy (finding 4)
+// ---------------------------------------------------------------------------
+
+describe("effect_rejected host taxonomy", () => {
+  // The HOST may emit the brain's 3 kinds PLUS policy_denied / compliance_block,
+  // passed through verbatim (never flattened into a brain kind).
+  test("host effect_rejected accepts all five kinds", () => {
+    for (const kind of [
+      "cant_do",
+      "not_now",
+      "wont_do",
+      "policy_denied",
+      "compliance_block",
+    ]) {
+      const line = JSON.stringify({
+        v: 1,
+        type: "effect_rejected",
+        task_id: "t1",
+        effect: "dispatch",
+        reason: { kind, detail: "host refused" },
+      });
+      expect(parseBrainEvent(line).kind).toBe("ok");
+    }
+  });
+
+  test("a compliance_block reason round-trips verbatim (not flattened)", () => {
+    const ev = {
+      v: 1,
+      type: "effect_rejected",
+      task_id: "t1",
+      effect: "post",
+      reason: { kind: "compliance_block", detail: "PII redaction required" },
+    } as const;
+    const parsed = parseBrainEvent(encodeBrainEvent(ev));
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok" && parsed.event.type === "effect_rejected") {
+      expect(parsed.event.reason.kind).toBe("compliance_block");
+      expect(parsed.event.reason.detail).toBe("PII redaction required");
+    }
+  });
+
+  test("an unknown effect_rejected kind is invalid", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "effect_rejected",
+      task_id: "t1",
+      effect: "post",
+      reason: { kind: "exploded", detail: "x" },
+    });
+    expect(parseBrainEvent(line).kind).toBe("invalid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hello identity is host-authoritative (finding 5)
+// ---------------------------------------------------------------------------
+
+describe("hello identity direction", () => {
+  // `hello` lives in the cortex→brain EVENT union, never the brain→cortex
+  // EFFECT union. A brain emitting `hello` on its stdout (trying to assert its
+  // own agent name) is therefore an UNKNOWN effect — dropped, never trusted.
+  test("a brain-emitted hello is an unknown effect (host owns identity)", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "hello",
+      persona: "I am whoever I say",
+      agent: "impersonator",
+      protocol: "cortex-brain/v1",
+    });
+    const parsed = parseBrainEffect(line);
+    expect(parsed.kind).toBe("unknown");
   });
 });
 
@@ -432,9 +551,6 @@ describe("JsonlDecoder", () => {
     // "café" — the é is two UTF-8 bytes; split between them.
     const payload = '{"t":"café"}\n';
     const bytes = enc(payload);
-    // Find the é bytes and split mid-codepoint.
-    const splitAt = payload.indexOf("é") + 1; // byte index differs but close enough; do real byte split:
-    void splitAt;
     // Real byte-level split: cut the buffer exactly between the two é bytes.
     const eIdx = bytes.findIndex((b) => b === 0xc3); // first byte of é
     const first = bytes.slice(0, eIdx + 1);

--- a/src/brain/exec-brain-runner.ts
+++ b/src/brain/exec-brain-runner.ts
@@ -509,7 +509,7 @@ export function makeExecBrainRunner(
           // and the post is DROPPED — the host owns the filesystem boundary,
           // not the brain. Symlink-escape detection is out of scope for v1; we
           // normalize and prefix-check.
-          if (e.attachment !== undefined && "path" in e.attachment) {
+          if (e.attachment?.path !== undefined) {
             const confined = confineScratchPath(
               scratchReal,
               e.attachment.path,
@@ -703,12 +703,16 @@ export function buildArgv(run: string, packDir: string): string[] {
   return argv;
 }
 
+/** Env keys the runner owns — a secret may never replace them (sage: a
+ * pack-declared secret named PATH/TMPDIR could steer executable lookup or
+ * temp-file behavior outside the sandbox). */
+const RUNNER_OWNED_ENV_KEYS = new Set(["PATH", "HOME", "LANG", "TMPDIR"]);
+
 /**
  * Build the minimal brain env (§8): PATH, HOME, LANG, the scoped TMPDIR, plus
- * the explicit secrets verbatim. NO ambient fleet credentials. The secrets map
- * is spread LAST but env keys it shares with the minimal set would be a
- * manifest author's explicit choice — secrets win, which is the documented
- * "injected verbatim" behavior.
+ * the explicit secrets. NO ambient fleet credentials. Secret names that
+ * collide with the runner-owned baseline are REJECTED (throw) — fail closed
+ * rather than let a manifest redefine the sandbox.
  */
 export function buildEnv(
   scratchDir: string,
@@ -721,6 +725,11 @@ export function buildEnv(
     TMPDIR: scratchDir,
   };
   for (const [k, v] of Object.entries(secrets)) {
+    if (RUNNER_OWNED_ENV_KEYS.has(k.toUpperCase())) {
+      throw new Error(
+        `brain secret "${k}" collides with a runner-owned env key — rename the secret`,
+      );
+    }
     env[k] = v;
   }
   return env;

--- a/src/brain/exec-brain-runner.ts
+++ b/src/brain/exec-brain-runner.ts
@@ -1,0 +1,630 @@
+/**
+ * `cortex-brain/v1` per-task exec runner (Bot Packs B-1;
+ * `docs/design-bot-packs.md` §5, §11 B-1).
+ *
+ * The cortex-side half of the `kind: exec`, `lifecycle: per-task` seam: spawn
+ * the pack's declared command, write the `task` event to its stdin, stream-
+ * parse its stdout effects, route each effect to caller-supplied hooks, and
+ * answer host effects (`gate_verdict`, `effect_rejected`) back on stdin.
+ *
+ * **A NEW sibling to `src/runner/sage-runner.ts`, not a modification of it.**
+ * Sage-runner carries cortex#888/917/920 history and stays untouched (§11:
+ * "sage-runner itself untouched … migrating sage onto the generic runner is a
+ * later option, not a B-1 goal"). This file borrows its precedents — the
+ * narrowed `Bun.spawn` handle, parallel stdout/stderr drain so a large blob
+ * can't deadlock the OS pipe buffer — but the lifecycle is different: a brain
+ * is alive until it emits `result`, emitting many effects in between, whereas
+ * sage is spawn-read-exit.
+ *
+ * ## Lifecycle (per-task — §5 "lifecycle: per-task means alive until result")
+ *
+ *   1. Create a per-task scoped scratch dir (becomes `TMPDIR`).
+ *   2. Spawn the manifest argv with a MINIMAL env: PATH, HOME, LANG, the
+ *      scoped TMPDIR, plus ONLY the explicit `secrets` map (verbatim). No
+ *      ambient fleet credentials (§8 "No ambient fleet credentials").
+ *   3. Write the `task` event as one JSONL line to stdin.
+ *   4. Stream-parse stdout via {@link JsonlDecoder} + {@link parseBrainEffect}.
+ *      Route each effect:
+ *        - `post`          → `hooks.onPost`
+ *        - `ask_principal` → `hooks.onAskPrincipal` → answer `gate_verdict`
+ *        - `dispatch`      → `hooks.onDispatch`; may reject → `effect_rejected`
+ *        - `log`           → `hooks.onLog`
+ *        - `result`        → terminal; resolve.
+ *   5. task_id correlation: any effect whose `task_id` ≠ the spawned task's id
+ *      is refused with `effect_rejected` (`wont_do`) and DROPPED (§5
+ *      "task_id correlation is enforced host-side").
+ *   6. Termination: process stays until `result`. At `timeoutMs` → SIGTERM;
+ *      +5 s grace → SIGKILL (§5/§7 escalation). Brain exit WITHOUT a `result`
+ *      → synthesize `result: failed (cant_do, "brain exited without result")`
+ *      with the captured stderr tail in `reason.detail`.
+ *
+ * The runner returns the final `result` plus the collected log lines and the
+ * stderr tail.
+ */
+
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  encodeBrainEvent,
+  parseBrainEffect,
+  JsonlDecoder,
+  type TaskEvent,
+  type PostEffect,
+  type AskPrincipalEffect,
+  type DispatchEffect,
+  type LogEffect,
+  type ResultEffect,
+  type GateVerdictValue,
+  type BrainReason,
+} from "./protocol";
+
+// ---------------------------------------------------------------------------
+// Spawn-injection types — narrowed surface of `Bun.spawn`
+// ---------------------------------------------------------------------------
+//
+// Same rationale as sage-runner: we don't take `typeof Bun.spawn` (wide,
+// brittle across Bun versions). The runner needs a writable stdin, readable
+// stdout + stderr, `exited`, and a `kill(signal)` handle. Narrowing keeps the
+// test seam trivial (a fake yields a controllable stdin sink + stdout/stderr
+// streams + a settable exit code) and lets internal spawn flags evolve.
+
+/** A writable stdin sink — the subset of Bun's `FileSink` the runner uses. */
+export interface BrainStdinSink {
+  write(chunk: string | Uint8Array): number | Promise<number>;
+  /**
+   * Flush buffered bytes. Bun's `FileSink.flush()` returns the byte count
+   * synchronously or a `Promise<number>` when it must drain — the runner
+   * `await`s it either way (an awaited number is a no-op).
+   */
+  flush?(): number | Promise<number>;
+  end(): void;
+}
+
+/** The handle the runner needs from a spawned brain process. */
+export interface BrainSpawnResult {
+  stdin: BrainStdinSink;
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+  /** Send a POSIX signal to the process (SIGTERM / SIGKILL escalation). */
+  kill(signal?: NodeJS.Signals | number): void;
+}
+
+/**
+ * Spawn function signature. Production wires {@link defaultSpawn} (`Bun.spawn`
+ * with `stdin: "pipe"`); tests inject a deterministic fake.
+ *
+ * `argv` is the fully resolved command (the manifest `run` string, argv-split,
+ * with `{pack}` already substituted). `opts.env` is the minimal env map; `cwd`
+ * is the scoped scratch dir.
+ */
+export type BrainSpawnFn = (
+  argv: string[],
+  opts: { env: Record<string, string>; cwd: string },
+) => BrainSpawnResult;
+
+// ---------------------------------------------------------------------------
+// Hooks — what the caller supplies for each brain effect
+// ---------------------------------------------------------------------------
+
+/**
+ * Effect hooks. The runner routes each validated, correlation-checked effect
+ * to the matching hook. Cortex (the BrainConsumer, B-2 wiring) supplies these
+ * to perform the actual host effects under policy.
+ */
+export interface BrainTaskHooks {
+  /** A `post` effect — cortex posts to the task's surface/thread. */
+  onPost(post: PostEffect): void | Promise<void>;
+
+  /**
+   * An `ask_principal` effect — cortex renders the gate, performs the
+   * host-side principal check, and resolves with the verdict the runner then
+   * forwards to the brain as a `gate_verdict` event (carrying the
+   * host-resolved principal). The brain never infers a verdict from chat text
+   * (the pulse#47 lesson).
+   */
+  onAskPrincipal(
+    ask: AskPrincipalEffect,
+  ): Promise<{
+    verdict: GateVerdictValue;
+    principal: string;
+    notes?: string;
+  }>;
+
+  /**
+   * A `dispatch` effect — cortex publishes the myelin envelope. Resolving with
+   * `{ rejected: true, reason }` (e.g. capability outside the manifest, or
+   * sovereignty refusal) makes the runner send the brain an `effect_rejected`
+   * event so it can degrade. Resolving with `{ rejected: false }` (or void)
+   * accepts the dispatch.
+   */
+  onDispatch(
+    dispatch: DispatchEffect,
+  ):
+    | void
+    | Promise<void>
+    | { rejected: false }
+    | { rejected: true; reason: BrainReason }
+    | Promise<{ rejected: false } | { rejected: true; reason: BrainReason }>;
+
+  /** A `log` effect — diagnostic; not surfaced to the principal. */
+  onLog(log: LogEffect): void | Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory options + result
+// ---------------------------------------------------------------------------
+
+/** Options for {@link makeExecBrainRunner}. */
+export interface MakeExecBrainRunnerOpts {
+  /**
+   * The manifest `run` string, e.g. `"bun {pack}/brain/main.ts"`. Argv-split
+   * on whitespace; `{pack}` is substituted from {@link packDir}.
+   */
+  run: string;
+  /** The arc install dir — substituted for the `{pack}` placeholder in `run`. */
+  packDir: string;
+  /**
+   * Secret env vars (the manifest `brain.secrets` resolved to values),
+   * injected verbatim into the brain env. Principal-approved at install time.
+   * Defaults to `{}`.
+   */
+  secrets?: Record<string, string>;
+  /**
+   * Per-task timeout in ms. On expiry the runner sends SIGTERM, then SIGKILL
+   * after a 5 s grace. Defaults to 120_000 (2 min).
+   */
+  timeoutMs?: number;
+  /**
+   * Grace period between SIGTERM and SIGKILL, in ms. Defaults to 5_000 (§5/§7).
+   */
+  killGraceMs?: number;
+  /**
+   * Spawn function — defaults to {@link defaultSpawn} (`Bun.spawn`). Tests
+   * inject a fake.
+   */
+  spawn?: BrainSpawnFn;
+  /**
+   * Scratch-dir factory — creates a fresh per-task scratch dir and returns its
+   * path. Defaults to {@link defaultMakeScratchDir} (`mkdtempSync` under the
+   * OS temp dir). Tests can stub this.
+   */
+  makeScratchDir?: () => string;
+}
+
+/** What {@link runBrainTask} resolves with. */
+export interface BrainTaskRunResult {
+  /**
+   * The terminal `result` effect — either the brain's own, or a synthesized
+   * `failed` when the brain exited without emitting one / timed out.
+   */
+  result: ResultEffect;
+  /** Every `log` effect's text, in emission order. */
+  logs: string[];
+  /** The captured stderr tail (whole stderr; callers may trim). */
+  stderrTail: string;
+  /** The brain process exit code, or `null` if it was killed before exit. */
+  exitCode: number | null;
+}
+
+/** A `runBrainTask` function bound to a configured runner. */
+export type RunBrainTask = (
+  task: TaskEvent,
+  hooks: BrainTaskHooks,
+) => Promise<BrainTaskRunResult>;
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a per-task brain runner from a manifest's `brain` block.
+ *
+ * No side effects at construction — the factory only closes over `opts`. The
+ * scratch dir, spawn, and stdin write all happen inside {@link runBrainTask}.
+ */
+export function makeExecBrainRunner(
+  opts: MakeExecBrainRunnerOpts,
+): RunBrainTask {
+  const spawn = opts.spawn ?? defaultSpawn;
+  const makeScratchDir = opts.makeScratchDir ?? defaultMakeScratchDir;
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+  const killGraceMs = opts.killGraceMs ?? 5_000;
+  const secrets = opts.secrets ?? {};
+
+  return async (
+    task: TaskEvent,
+    hooks: BrainTaskHooks,
+  ): Promise<BrainTaskRunResult> => {
+    const argv = buildArgv(opts.run, opts.packDir);
+    const scratchDir = makeScratchDir();
+    const env = buildEnv(scratchDir, secrets);
+
+    const logs: string[] = [];
+    // We collect stderr to a single string (drained in parallel below). It
+    // feeds the synthesized-failure reason.detail when the brain exits
+    // without a result.
+    let stderrTail = "";
+
+    // The terminal result. Resolved either by the brain's `result` effect or
+    // by the exit/timeout fallback. We use a manual promise so the stdout
+    // pump can settle it from inside the read loop.
+    let resolveResult!: (r: ResultEffect) => void;
+    const resultPromise = new Promise<ResultEffect>((res) => {
+      resolveResult = res;
+    });
+    let resultSeen = false;
+    const settleResult = (r: ResultEffect): void => {
+      if (!resultSeen) {
+        resultSeen = true;
+        resolveResult(r);
+      }
+    };
+
+    let proc: BrainSpawnResult;
+    try {
+      proc = spawn(argv, { env, cwd: scratchDir });
+    } catch (err) {
+      // Spawn throw (bad argv, sandbox/env bug). Synthesize a cant_do.
+      cleanupScratch(scratchDir);
+      const detail = err instanceof Error ? err.message : String(err);
+      return {
+        result: synthFailed(task.task_id, `brain spawn failed: ${detail}`),
+        logs,
+        stderrTail: "",
+        exitCode: null,
+      };
+    }
+
+    // --- timeout → SIGTERM → (grace) → SIGKILL ----------------------------
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
+    const clearTimers = (): void => {
+      if (killTimer !== undefined) clearTimeout(killTimer);
+      if (graceTimer !== undefined) clearTimeout(graceTimer);
+    };
+    killTimer = setTimeout(() => {
+      timedOut = true;
+      try {
+        proc.kill("SIGTERM");
+      } catch (err) {
+        console.warn(
+          "exec-brain-runner: SIGTERM failed (process likely already exited):",
+          err instanceof Error ? err.message : err,
+        );
+      }
+      graceTimer = setTimeout(() => {
+        try {
+          proc.kill("SIGKILL");
+        } catch (err) {
+          console.warn(
+            "exec-brain-runner: SIGKILL failed (process likely already exited):",
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }, killGraceMs);
+    }, timeoutMs);
+
+    // --- write the task event to stdin ------------------------------------
+    try {
+      proc.stdin.write(encodeBrainEvent(task) + "\n");
+      await proc.stdin.flush?.();
+    } catch (err) {
+      // stdin closed before we could write — treat as a brain that refused
+      // the task. Let the exit fallback below synthesize the failure, but
+      // record why.
+      stderrTail +=
+        (stderrTail ? "\n" : "") +
+        `[runner] stdin write failed: ${err instanceof Error ? err.message : String(err)}`;
+    }
+
+    /**
+     * Send a host event back to the brain on stdin. Best-effort: a closed
+     * stdin (brain already exiting) is logged, not thrown — the exit path
+     * handles overall task resolution.
+     *
+     * The flush is AWAITED. Bun's `FileSink.flush()` returns a Promise; a
+     * fire-and-forget flush can leave the line buffered (the brain then
+     * blocks on `read()` and we deadlock until the timeout). Awaiting it
+     * guarantees the line is on the wire before we return — critical for the
+     * gate round-trip (`ask_principal` → `gate_verdict`).
+     */
+    const sendEvent = async (line: string): Promise<void> => {
+      try {
+        proc.stdin.write(line + "\n");
+        await proc.stdin.flush?.();
+      } catch (err) {
+        console.warn(
+          "exec-brain-runner: failed to write event to brain stdin (likely exiting):",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    };
+
+    // --- route one validated, correlation-checked effect ------------------
+    const routeEffect = async (
+      effect: ReturnType<typeof parseBrainEffect>,
+    ): Promise<void> => {
+      if (effect.kind === "invalid") {
+        // Malformed line / failed validation (e.g. oversized attachment).
+        // Drop-and-log; never throws the pump.
+        logs.push(`[runner] dropped invalid effect: ${effect.detail}`);
+        return;
+      }
+      if (effect.kind === "unknown") {
+        // Forward-compat: unknown effect type — drop and log (§5).
+        logs.push(
+          `[runner] dropped unknown effect type: ${String(effect.raw["type"])}`,
+        );
+        return;
+      }
+
+      const e = effect.effect;
+
+      // `log` is task-agnostic — it carries no `task_id` and is a pure
+      // diagnostic, so it bypasses correlation entirely (running it through
+      // the task_id check below would treat its absent id as "foreign").
+      if (e.type === "log") {
+        logs.push(e.text);
+        await hooks.onLog(e);
+        return;
+      }
+
+      // task_id correlation — host-enforced. Every TASK-SCOPED effect (post,
+      // ask_principal, dispatch, result) must carry THIS brain's task id; a
+      // foreign or absent id is refused with effect_rejected (wont_do) and the
+      // effect is DROPPED (§5 "task_id correlation is enforced host-side").
+      if (e.task_id !== task.task_id) {
+        await sendEvent(
+          encodeBrainEvent({
+            v: 1,
+            type: "effect_rejected",
+            // Echo OUR task id, not the (possibly undefined) foreign one — the
+            // brain correlates the rejection to the task it actually owns.
+            task_id: task.task_id,
+            effect: e.type,
+            reason: {
+              kind: "wont_do",
+              detail: `foreign task_id ${String(e.task_id)} (this brain owns ${task.task_id})`,
+            },
+          }),
+        );
+        return;
+      }
+
+      switch (e.type) {
+        case "post":
+          await hooks.onPost(e);
+          return;
+        case "ask_principal": {
+          const verdict = await hooks.onAskPrincipal(e);
+          await sendEvent(
+            encodeBrainEvent({
+              v: 1,
+              type: "gate_verdict",
+              task_id: task.task_id,
+              gate: e.gate,
+              verdict: verdict.verdict,
+              principal: verdict.principal,
+              ...(verdict.notes !== undefined && { notes: verdict.notes }),
+            }),
+          );
+          return;
+        }
+        case "dispatch": {
+          const outcome = await hooks.onDispatch(e);
+          if (
+            outcome !== undefined &&
+            outcome !== null &&
+            typeof outcome === "object" &&
+            "rejected" in outcome &&
+            outcome.rejected === true
+          ) {
+            await sendEvent(
+              encodeBrainEvent({
+                v: 1,
+                type: "effect_rejected",
+                task_id: task.task_id,
+                effect: "dispatch",
+                reason: outcome.reason,
+              }),
+            );
+          }
+          return;
+        }
+        case "result":
+          settleResult(e);
+          return;
+        default: {
+          // Exhaustiveness guard — a new effect type added to the union but
+          // not handled here trips this at compile time.
+          const _never: never = e;
+          void _never;
+          return;
+        }
+      }
+    };
+
+    // --- stdout pump: stream-parse effects --------------------------------
+    const pumpStdout = async (): Promise<void> => {
+      const decoder = new JsonlDecoder();
+      const reader = proc.stdout.getReader();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value !== undefined) {
+            for (const line of decoder.push(value)) {
+              await routeEffect(parseBrainEffect(line));
+            }
+          }
+        }
+        // Flush any final newline-less line.
+        for (const line of decoder.flush()) {
+          await routeEffect(parseBrainEffect(line));
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    };
+
+    // --- stderr drain (parallel, so a big blob can't deadlock the pipe) ----
+    const pumpStderr = async (): Promise<void> => {
+      try {
+        stderrTail += await new Response(proc.stderr).text();
+      } catch (err) {
+        // Stream error — record it but don't fail the task on stderr alone.
+        stderrTail +=
+          (stderrTail ? "\n" : "") +
+          `[runner] stderr stream error: ${err instanceof Error ? err.message : String(err)}`;
+      }
+    };
+
+    // Run stdout pump, stderr drain, and the exit wait concurrently. The
+    // stdout pump completing (stream closed) and `exited` resolving both bound
+    // the task; we await all so logs/stderr are fully collected.
+    const stdoutDone = pumpStdout();
+    const stderrDone = pumpStderr();
+
+    let exitCode: number | null = null;
+    try {
+      exitCode = await proc.exited;
+    } catch (err) {
+      console.warn(
+        "exec-brain-runner: `exited` rejected:",
+        err instanceof Error ? err.message : err,
+      );
+      exitCode = null;
+    }
+
+    // The process has exited — drain the remaining stdout/stderr then resolve.
+    await Promise.allSettled([stdoutDone, stderrDone]);
+    clearTimers();
+
+    // If the brain exited without emitting a `result`, synthesize one.
+    if (!resultSeen) {
+      const reasonDetail = timedOut
+        ? `brain timed out after ${timeoutMs}ms${
+            stderrTail.trim() ? `; stderr: ${tail(stderrTail)}` : ""
+          }`
+        : `brain exited without result${
+            stderrTail.trim() ? `; stderr: ${tail(stderrTail)}` : ""
+          }`;
+      settleResult(synthFailed(task.task_id, reasonDetail));
+    }
+
+    const result = await resultPromise;
+    cleanupScratch(scratchDir);
+
+    return { result, logs, stderrTail, exitCode };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Split the manifest `run` string into argv and substitute `{pack}`.
+ * Whitespace-split is sufficient for the house style (`bun {pack}/brain/main.ts`);
+ * shell-quoted args are out of scope for v1 (the manifest author controls the
+ * string). Throws on an empty argv — a manifest bug, surfaced before spawn.
+ */
+export function buildArgv(run: string, packDir: string): string[] {
+  const argv = run
+    .trim()
+    .split(/\s+/)
+    .filter((s) => s.length > 0)
+    .map((tok) => tok.replaceAll("{pack}", packDir));
+  if (argv.length === 0) {
+    throw new Error("brain `run` string is empty after substitution");
+  }
+  return argv;
+}
+
+/**
+ * Build the minimal brain env (§8): PATH, HOME, LANG, the scoped TMPDIR, plus
+ * the explicit secrets verbatim. NO ambient fleet credentials. The secrets map
+ * is spread LAST but env keys it shares with the minimal set would be a
+ * manifest author's explicit choice — secrets win, which is the documented
+ * "injected verbatim" behavior.
+ */
+export function buildEnv(
+  scratchDir: string,
+  secrets: Record<string, string>,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    HOME: process.env.HOME ?? scratchDir,
+    LANG: process.env.LANG ?? "en_US.UTF-8",
+    TMPDIR: scratchDir,
+  };
+  for (const [k, v] of Object.entries(secrets)) {
+    env[k] = v;
+  }
+  return env;
+}
+
+/** Production spawn — `Bun.spawn` with a piped stdin. */
+function defaultSpawn(
+  argv: string[],
+  opts: { env: Record<string, string>; cwd: string },
+): BrainSpawnResult {
+  const proc = Bun.spawn(argv, {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: opts.env,
+    cwd: opts.cwd,
+  });
+  return {
+    stdin: proc.stdin,
+    stdout: proc.stdout,
+    stderr: proc.stderr,
+    exited: proc.exited,
+    kill: (signal) => proc.kill(signal as number | NodeJS.Signals | undefined),
+  };
+}
+
+/** Production scratch-dir factory — `mkdtempSync` under the OS temp dir. */
+function defaultMakeScratchDir(): string {
+  return mkdtempSync(join(tmpdir(), "cortex-brain-"));
+}
+
+/** Best-effort scratch-dir removal. A leftover temp dir is non-fatal. */
+function cleanupScratch(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch (err) {
+    // Non-fatal: a leftover scratch dir under the OS temp dir is cleaned by
+    // the OS eventually; we log rather than fail the task on cleanup.
+    console.warn(
+      "exec-brain-runner: scratch-dir cleanup failed:",
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * Synthesize a `result: failed (cant_do)` for the no-result / spawn-fail /
+ * timeout paths. `cant_do` because the brain failed to complete under its own
+ * power — distinct from a `wont_do` policy refusal or a `not_now` transient
+ * the brain would have declared itself.
+ */
+function synthFailed(taskId: string, detail: string): ResultEffect {
+  return {
+    v: 1,
+    type: "result",
+    task_id: taskId,
+    status: "failed",
+    reason: { kind: "cant_do", detail },
+  };
+}
+
+/** Trim a stderr blob to a bounded tail for inclusion in a reason detail. */
+function tail(s: string, max = 1_000): string {
+  const t = s.trim();
+  return t.length <= max ? t : `…${t.slice(t.length - max)}`;
+}

--- a/src/brain/exec-brain-runner.ts
+++ b/src/brain/exec-brain-runner.ts
@@ -33,18 +33,27 @@
  *   5. task_id correlation: any effect whose `task_id` ≠ the spawned task's id
  *      is refused with `effect_rejected` (`wont_do`) and DROPPED (§5
  *      "task_id correlation is enforced host-side").
- *   6. Termination: process stays until `result`. At `timeoutMs` → SIGTERM;
- *      +5 s grace → SIGKILL (§5/§7 escalation). Brain exit WITHOUT a `result`
- *      → synthesize `result: failed (cant_do, "brain exited without result")`
- *      with the captured stderr tail in `reason.detail`.
+ *   6. Scratch confinement: a `post` attachment `path` must resolve within the
+ *      task's realpath'd scratch dir; an escape is refused with
+ *      `effect_rejected` (`wont_do`, "attachment path outside scratch dir") and
+ *      the post DROPPED. The host owns the filesystem boundary, not the brain.
+ *   7. Termination: `result` is TERMINAL — on a schema-valid `result` for the
+ *      owned task the run RESOLVES immediately. Process reaping then happens
+ *      fire-and-forget AFTER resolution (close stdin → `resultGraceMs` self-exit
+ *      grace → SIGTERM → +`killGraceMs` SIGKILL) and can never delay or reject
+ *      the resolved promise. A `timeoutMs` with no result → SIGTERM → grace →
+ *      SIGKILL. Brain exit WITHOUT a `result` → synthesize
+ *      `result: failed (cant_do, "brain exited without result")` with the
+ *      captured (bounded) stderr tail in `reason.detail`.
  *
  * The runner returns the final `result` plus the collected log lines and the
- * stderr tail.
+ * bounded stderr tail.
  */
 
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, realpathSync } from "fs";
+import { rm } from "fs/promises";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, resolve as resolvePath, sep } from "path";
 import {
   encodeBrainEvent,
   parseBrainEffect,
@@ -58,6 +67,13 @@ import {
   type GateVerdictValue,
   type BrainReason,
 } from "./protocol";
+
+/**
+ * Max stderr we retain in memory. A chatty brain must not grow the runner's
+ * heap without bound, so we keep only the last {@link STDERR_TAIL_CAP} bytes as
+ * a ring (older bytes are dropped, a truncation marker is prepended once).
+ */
+const STDERR_TAIL_CAP = 8 * 1024;
 
 // ---------------------------------------------------------------------------
 // Spawn-injection types — narrowed surface of `Bun.spawn`
@@ -181,6 +197,13 @@ export interface MakeExecBrainRunnerOpts {
    */
   killGraceMs?: number;
   /**
+   * Grace period AFTER a terminal `result` is received: how long to let the
+   * brain exit on its own (post stdin-close) before SIGTERM. The run has
+   * ALREADY resolved by this point — this only bounds background reaping.
+   * Defaults to 2_000 (finding 1).
+   */
+  resultGraceMs?: number;
+  /**
    * Spawn function — defaults to {@link defaultSpawn} (`Bun.spawn`). Tests
    * inject a fake.
    */
@@ -231,6 +254,7 @@ export function makeExecBrainRunner(
   const makeScratchDir = opts.makeScratchDir ?? defaultMakeScratchDir;
   const timeoutMs = opts.timeoutMs ?? 120_000;
   const killGraceMs = opts.killGraceMs ?? 5_000;
+  const resultGraceMs = opts.resultGraceMs ?? 2_000;
   const secrets = opts.secrets ?? {};
 
   return async (
@@ -242,32 +266,41 @@ export function makeExecBrainRunner(
     const env = buildEnv(scratchDir, secrets);
 
     const logs: string[] = [];
-    // We collect stderr to a single string (drained in parallel below). It
-    // feeds the synthesized-failure reason.detail when the brain exits
-    // without a result.
-    let stderrTail = "";
+    // We collect stderr into a bounded ring (drained in parallel below). It
+    // feeds the synthesized-failure reason.detail when the brain exits without
+    // a result, and is returned to the caller. A chatty brain cannot grow this
+    // past STDERR_TAIL_CAP — see {@link StderrRing}.
+    const stderrRing = new StderrRing(STDERR_TAIL_CAP);
 
-    // The terminal result. Resolved either by the brain's `result` effect or
-    // by the exit/timeout fallback. We use a manual promise so the stdout
-    // pump can settle it from inside the read loop.
-    let resolveResult!: (r: ResultEffect) => void;
-    const resultPromise = new Promise<ResultEffect>((res) => {
-      resolveResult = res;
+    // Resolve the scratch dir's REAL path once (mkdtemp may hand back a path
+    // through a symlinked temp root, e.g. /var → /private/var on macOS). All
+    // scratch-path confinement checks compare against this realpath prefix.
+    let scratchReal: string;
+    try {
+      scratchReal = realpathSync(scratchDir);
+    } catch {
+      // If realpath fails (dir vanished), fall back to the resolved literal;
+      // confinement still rejects anything outside it.
+      scratchReal = resolvePath(scratchDir);
+    }
+
+    // The terminal run result. The run is RESOLVED on the FIRST of: a
+    // schema-valid `result` effect for the owned task, or process exit without
+    // one. A manual promise lets the stdout pump settle it mid-read-loop. Once
+    // resolved, cleanup (kill escalation + scratch removal) is fire-and-forget
+    // and can never reject this promise (finding 1: `result` is terminal).
+    let resolveRun!: (r: BrainTaskRunResult) => void;
+    const runPromise = new Promise<BrainTaskRunResult>((res) => {
+      resolveRun = res;
     });
-    let resultSeen = false;
-    const settleResult = (r: ResultEffect): void => {
-      if (!resultSeen) {
-        resultSeen = true;
-        resolveResult(r);
-      }
-    };
+    let runSettled = false;
 
     let proc: BrainSpawnResult;
     try {
       proc = spawn(argv, { env, cwd: scratchDir });
     } catch (err) {
       // Spawn throw (bad argv, sandbox/env bug). Synthesize a cant_do.
-      cleanupScratch(scratchDir);
+      void cleanupScratch(scratchDir);
       const detail = err instanceof Error ? err.message : String(err);
       return {
         result: synthFailed(task.task_id, `brain spawn failed: ${detail}`),
@@ -285,8 +318,13 @@ export function makeExecBrainRunner(
       if (killTimer !== undefined) clearTimeout(killTimer);
       if (graceTimer !== undefined) clearTimeout(graceTimer);
     };
-    killTimer = setTimeout(() => {
-      timedOut = true;
+
+    /**
+     * Fire-and-forget kill escalation: SIGTERM now, SIGKILL after the grace.
+     * Used by BOTH the timeout path and the post-`result` cleanup. Wrapped in
+     * try/catch because a process that already exited makes `kill` throw.
+     */
+    const escalateKill = (): void => {
       try {
         proc.kill("SIGTERM");
       } catch (err) {
@@ -305,7 +343,75 @@ export function makeExecBrainRunner(
           );
         }
       }, killGraceMs);
+    };
+
+    killTimer = setTimeout(() => {
+      timedOut = true;
+      escalateKill();
     }, timeoutMs);
+
+    /**
+     * Resolve the run with the brain's terminal `result`, THEN run cleanup
+     * fire-and-forget (finding 1: `result` is terminal — the run returns
+     * promptly; the process is reaped afterward and cannot delay or reject the
+     * resolved promise).
+     *
+     * Cleanup sequence (all AFTER resolution):
+     *   1. close stdin (EOF — most brains exit on it);
+     *   2. give the process `resultGraceMs` to exit on its own;
+     *   3. SIGTERM, then SIGKILL after `killGraceMs`;
+     *   4. remove the scratch dir (async).
+     */
+    const settleWithResult = (result: ResultEffect): void => {
+      if (runSettled) return;
+      runSettled = true;
+      clearTimers();
+      resolveRun({
+        result,
+        logs,
+        stderrTail: stderrRing.value(),
+        // The process has not necessarily exited yet; exit code is unknown at
+        // resolution time. Callers that need the code use the no-result path
+        // (which awaits exit). A terminal result is the brain's own verdict.
+        exitCode: null,
+      });
+      // --- fire-and-forget cleanup (cannot reject the resolved run) --------
+      void reapAfterResult();
+    };
+
+    /**
+     * Best-effort reaping after a terminal result: close stdin, grace, escalate
+     * kill, drop scratch. Every step is guarded; a throw here never surfaces
+     * (the run promise is already resolved).
+     */
+    const reapAfterResult = async (): Promise<void> => {
+      try {
+        proc.stdin.end();
+      } catch (err) {
+        console.warn(
+          "exec-brain-runner: stdin.end() after result failed:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+      // Race the process's own exit against the result grace.
+      const exitedOnOwn = await Promise.race([
+        proc.exited.then(() => true).catch(() => true),
+        new Promise<boolean>((res) =>
+          setTimeout(() => res(false), resultGraceMs),
+        ),
+      ]);
+      if (!exitedOnOwn) {
+        escalateKill();
+        // Let the kill escalation complete in the background, then clear the
+        // grace timer once the process is gone.
+        proc.exited
+          .catch(() => undefined)
+          .finally(() => {
+            if (graceTimer !== undefined) clearTimeout(graceTimer);
+          });
+      }
+      await cleanupScratch(scratchDir);
+    };
 
     // --- write the task event to stdin ------------------------------------
     try {
@@ -315,9 +421,9 @@ export function makeExecBrainRunner(
       // stdin closed before we could write — treat as a brain that refused
       // the task. Let the exit fallback below synthesize the failure, but
       // record why.
-      stderrTail +=
-        (stderrTail ? "\n" : "") +
-        `[runner] stdin write failed: ${err instanceof Error ? err.message : String(err)}`;
+      stderrRing.append(
+        `[runner] stdin write failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     /**
@@ -343,25 +449,34 @@ export function makeExecBrainRunner(
       }
     };
 
+    /**
+     * Send an `effect_rejected` back to the brain and DROP the effect. Shared
+     * by the foreign-task_id and scratch-confinement refusals. `kind` is a
+     * brain-kind (`wont_do`) — a host policy refusal in v1.
+     */
+    const rejectEffect = async (
+      effectType: string,
+      detail: string,
+    ): Promise<void> => {
+      await sendEvent(
+        encodeBrainEvent({
+          v: 1,
+          type: "effect_rejected",
+          task_id: task.task_id,
+          effect: effectType,
+          reason: { kind: "wont_do", detail },
+        }),
+      );
+    };
+
     // --- route one validated, correlation-checked effect ------------------
     const routeEffect = async (
-      effect: ReturnType<typeof parseBrainEffect>,
+      parsed: ReturnType<typeof parseBrainEffect>,
     ): Promise<void> => {
-      if (effect.kind === "invalid") {
-        // Malformed line / failed validation (e.g. oversized attachment).
-        // Drop-and-log; never throws the pump.
-        logs.push(`[runner] dropped invalid effect: ${effect.detail}`);
-        return;
-      }
-      if (effect.kind === "unknown") {
-        // Forward-compat: unknown effect type — drop and log (§5).
-        logs.push(
-          `[runner] dropped unknown effect type: ${String(effect.raw["type"])}`,
-        );
-        return;
-      }
-
-      const e = effect.effect;
+      // Drop-and-log invalid/unknown lines (§5 forward-compat). The type guard
+      // narrows `parsed` to the `ok` variant when it returns false.
+      if (!isOkEffect(parsed, logs)) return;
+      const e = parsed.effect;
 
       // `log` is task-agnostic — it carries no `task_id` and is a pure
       // diagnostic, so it bypasses correlation entirely (running it through
@@ -376,28 +491,40 @@ export function makeExecBrainRunner(
       // ask_principal, dispatch, result) must carry THIS brain's task id; a
       // foreign or absent id is refused with effect_rejected (wont_do) and the
       // effect is DROPPED (§5 "task_id correlation is enforced host-side").
+      // Echo OUR task id, not the foreign one, so the brain correlates the
+      // rejection to the task it actually owns.
       if (e.task_id !== task.task_id) {
-        await sendEvent(
-          encodeBrainEvent({
-            v: 1,
-            type: "effect_rejected",
-            // Echo OUR task id, not the (possibly undefined) foreign one — the
-            // brain correlates the rejection to the task it actually owns.
-            task_id: task.task_id,
-            effect: e.type,
-            reason: {
-              kind: "wont_do",
-              detail: `foreign task_id ${String(e.task_id)} (this brain owns ${task.task_id})`,
-            },
-          }),
+        await rejectEffect(
+          e.type,
+          `foreign task_id ${String(e.task_id)} (this brain owns ${task.task_id})`,
         );
         return;
       }
 
       switch (e.type) {
-        case "post":
+        case "post": {
+          // Scratch-path confinement (finding 3): a `path` attachment must
+          // resolve to WITHIN this task's realpath'd scratch dir. An escape
+          // (`..`, an absolute path elsewhere) is refused with effect_rejected
+          // and the post is DROPPED — the host owns the filesystem boundary,
+          // not the brain. Symlink-escape detection is out of scope for v1; we
+          // normalize and prefix-check.
+          if (e.attachment !== undefined && "path" in e.attachment) {
+            const confined = confineScratchPath(
+              scratchReal,
+              e.attachment.path,
+            );
+            if (!confined.ok) {
+              await rejectEffect(
+                "post",
+                "attachment path outside scratch dir",
+              );
+              return;
+            }
+          }
           await hooks.onPost(e);
           return;
+        }
         case "ask_principal": {
           const verdict = await hooks.onAskPrincipal(e);
           await sendEvent(
@@ -435,7 +562,9 @@ export function makeExecBrainRunner(
           return;
         }
         case "result":
-          settleResult(e);
+          // Terminal: resolve the run NOW, reap the process afterward
+          // (finding 1).
+          settleWithResult(e);
           return;
         default: {
           // Exhaustiveness guard — a new effect type added to the union but
@@ -448,6 +577,9 @@ export function makeExecBrainRunner(
     };
 
     // --- stdout pump: stream-parse effects --------------------------------
+    // Returns nothing; a stream error is CAPTURED (folded into the stderr
+    // ring + logs), never thrown out of the pump (finding 6). An unhandled
+    // rejection here would otherwise escape the resolved run.
     const pumpStdout = async (): Promise<void> => {
       const decoder = new JsonlDecoder();
       const reader = proc.stdout.getReader();
@@ -465,6 +597,10 @@ export function makeExecBrainRunner(
         for (const line of decoder.flush()) {
           await routeEffect(parseBrainEffect(line));
         }
+      } catch (err) {
+        const msg = `[runner] stdout pump error: ${err instanceof Error ? err.message : String(err)}`;
+        logs.push(msg);
+        stderrRing.append(msg);
       } finally {
         reader.releaseLock();
       }
@@ -473,38 +609,57 @@ export function makeExecBrainRunner(
     // --- stderr drain (parallel, so a big blob can't deadlock the pipe) ----
     const pumpStderr = async (): Promise<void> => {
       try {
-        stderrTail += await new Response(proc.stderr).text();
+        const reader = proc.stderr.getReader();
+        const dec = new TextDecoder("utf-8");
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value !== undefined) {
+              stderrRing.append(dec.decode(value, { stream: true }));
+            }
+          }
+          const trailing = dec.decode();
+          if (trailing.length > 0) stderrRing.append(trailing);
+        } finally {
+          reader.releaseLock();
+        }
       } catch (err) {
         // Stream error — record it but don't fail the task on stderr alone.
-        stderrTail +=
-          (stderrTail ? "\n" : "") +
-          `[runner] stderr stream error: ${err instanceof Error ? err.message : String(err)}`;
+        stderrRing.append(
+          `[runner] stderr stream error: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     };
 
-    // Run stdout pump, stderr drain, and the exit wait concurrently. The
-    // stdout pump completing (stream closed) and `exited` resolving both bound
-    // the task; we await all so logs/stderr are fully collected.
+    // Pumps run concurrently with the exit watch. Their rejections are already
+    // captured inside; we still keep their promises so the no-result fallback
+    // can await a full drain before synthesizing the failure detail.
     const stdoutDone = pumpStdout();
     const stderrDone = pumpStderr();
 
-    let exitCode: number | null = null;
-    try {
-      exitCode = await proc.exited;
-    } catch (err) {
-      console.warn(
-        "exec-brain-runner: `exited` rejected:",
-        err instanceof Error ? err.message : err,
-      );
-      exitCode = null;
-    }
-
-    // The process has exited — drain the remaining stdout/stderr then resolve.
-    await Promise.allSettled([stdoutDone, stderrDone]);
-    clearTimers();
-
-    // If the brain exited without emitting a `result`, synthesize one.
-    if (!resultSeen) {
+    // --- exit watcher: the no-result fallback -----------------------------
+    // If the process exits before a terminal `result` settles the run, drain
+    // the pumps and synthesize a failed result. This runs concurrently with
+    // the routeEffect loop; whichever settles the run first wins (settleWith*
+    // is idempotent via runSettled).
+    void (async (): Promise<void> => {
+      let exitCode: number | null = null;
+      try {
+        exitCode = await proc.exited;
+      } catch (err) {
+        console.warn(
+          "exec-brain-runner: `exited` rejected:",
+          err instanceof Error ? err.message : err,
+        );
+        exitCode = null;
+      }
+      // Drain the remaining stdout/stderr — a late `result` on the final chunk
+      // can still settle the run inside routeEffect.
+      await Promise.allSettled([stdoutDone, stderrDone]);
+      if (runSettled) return;
+      clearTimers();
+      const stderrTail = stderrRing.value();
       const reasonDetail = timedOut
         ? `brain timed out after ${timeoutMs}ms${
             stderrTail.trim() ? `; stderr: ${tail(stderrTail)}` : ""
@@ -512,13 +667,17 @@ export function makeExecBrainRunner(
         : `brain exited without result${
             stderrTail.trim() ? `; stderr: ${tail(stderrTail)}` : ""
           }`;
-      settleResult(synthFailed(task.task_id, reasonDetail));
-    }
+      runSettled = true;
+      resolveRun({
+        result: synthFailed(task.task_id, reasonDetail),
+        logs,
+        stderrTail,
+        exitCode,
+      });
+      await cleanupScratch(scratchDir);
+    })();
 
-    const result = await resultPromise;
-    cleanupScratch(scratchDir);
-
-    return { result, logs, stderrTail, exitCode };
+    return runPromise;
   };
 }
 
@@ -593,10 +752,14 @@ function defaultMakeScratchDir(): string {
   return mkdtempSync(join(tmpdir(), "cortex-brain-"));
 }
 
-/** Best-effort scratch-dir removal. A leftover temp dir is non-fatal. */
-function cleanupScratch(dir: string): void {
+/**
+ * Best-effort scratch-dir removal, ASYNC + non-blocking (finding 8). A leftover
+ * temp dir is non-fatal. Never throws — a failed cleanup is logged, not
+ * surfaced (the run is already resolved by the time this is called).
+ */
+async function cleanupScratch(dir: string): Promise<void> {
   try {
-    rmSync(dir, { recursive: true, force: true });
+    await rm(dir, { recursive: true, force: true });
   } catch (err) {
     // Non-fatal: a leftover scratch dir under the OS temp dir is cleaned by
     // the OS eventually; we log rather than fail the task on cleanup.
@@ -604,6 +767,117 @@ function cleanupScratch(dir: string): void {
       "exec-brain-runner: scratch-dir cleanup failed:",
       err instanceof Error ? err.message : err,
     );
+  }
+}
+
+/**
+ * Drop-and-log invalid/unknown parse results (§5 forward-compat), and act as a
+ * type guard that narrows to the `ok` variant. Single tolerant-parse handler
+ * shared by every parse site (finding 8 — was duplicated inline).
+ *
+ * Returns `true` (narrowing `parsed` to `{ kind: "ok"; effect }`) when the line
+ * is a well-formed known effect; `false` when it was dropped.
+ */
+function isOkEffect(
+  parsed: ReturnType<typeof parseBrainEffect>,
+  logs: string[],
+): parsed is Extract<ReturnType<typeof parseBrainEffect>, { kind: "ok" }> {
+  if (parsed.kind === "invalid") {
+    // Malformed line / failed validation (e.g. oversized attachment).
+    logs.push(`[runner] dropped invalid effect: ${parsed.detail}`);
+    return false;
+  }
+  if (parsed.kind === "unknown") {
+    // Forward-compat: unknown effect type — drop and log (§5).
+    logs.push(
+      `[runner] dropped unknown effect type: ${String(parsed.raw["type"])}`,
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Host-side scratch confinement (finding 3). A brain's `path` attachment must
+ * resolve to WITHIN `scratchReal` (the realpath'd per-task scratch dir).
+ *
+ *   - `scratchReal` is already realpath'd by the caller (canonical, symlink-
+ *     free root on the SCRATCH side).
+ *   - The candidate is `path.resolve`d against the scratch root, normalizing
+ *     `..` segments and binding a relative path to the scratch dir.
+ *   - The resolved candidate's NEAREST EXISTING ANCESTOR is realpath'd so the
+ *     comparison is symlink-canonical on both sides — this is what makes a
+ *     legitimate file under a symlinked temp root (macOS `/var` →
+ *     `/private/var`) compare equal instead of false-rejecting. We realpath the
+ *     ancestor (not the file) because the attachment file may not exist yet.
+ *   - A prefix check (`resolved === root || resolved.startsWith(root + sep)`)
+ *     then rejects any path that climbed out, or an absolute path elsewhere.
+ *
+ * Symlink ESCAPES on the candidate side (a real file the brain placed inside
+ * scratch that itself symlinks out, then references by that inner path) are
+ * explicitly out of scope for v1 — we canonicalize the ANCESTOR for the
+ * temp-root case, not chase a maliciously-planted leaf symlink.
+ */
+export function confineScratchPath(
+  scratchReal: string,
+  candidate: string,
+): { ok: true; resolved: string } | { ok: false } {
+  const root = resolvePath(scratchReal);
+  // resolve() binds a relative candidate to the scratch root and collapses
+  // `..`; an absolute candidate is resolved as-is.
+  const resolved = resolvePath(root, candidate);
+  // Canonicalize via the nearest existing ancestor so a symlinked temp root
+  // doesn't cause a false reject. realpathSync throws on a missing leaf, so we
+  // walk up to the first ancestor that exists.
+  const canonical = realpathNearestAncestor(resolved);
+  if (canonical === root || canonical.startsWith(root + sep)) {
+    return { ok: true, resolved };
+  }
+  return { ok: false };
+}
+
+/**
+ * realpath the nearest existing ancestor of `p`, re-appending the non-existent
+ * tail. Lets confinement canonicalize a path whose leaf file does not exist
+ * yet (the common case — the brain is about to write it).
+ */
+function realpathNearestAncestor(p: string): string {
+  let dir = p;
+  const tail: string[] = [];
+  for (;;) {
+    try {
+      const real = realpathSync(dir);
+      return tail.length === 0 ? real : join(real, ...tail.reverse());
+    } catch {
+      const idx = dir.lastIndexOf(sep);
+      if (idx <= 0) return p; // reached the root without a hit; use as-is
+      tail.push(dir.slice(idx + 1));
+      dir = dir.slice(0, idx);
+    }
+  }
+}
+
+/**
+ * Bounded stderr ring (finding 7). Retains at most `cap` bytes; older content
+ * is dropped and a one-time truncation marker is prepended so the caller knows
+ * the tail is partial. Keeps a chatty brain from growing the runner heap.
+ */
+class StderrRing {
+  private buf = "";
+  private truncated = false;
+  constructor(private readonly cap: number) {}
+
+  append(chunk: string): void {
+    if (chunk.length === 0) return;
+    this.buf += chunk;
+    if (this.buf.length > this.cap) {
+      this.buf = this.buf.slice(this.buf.length - this.cap);
+      this.truncated = true;
+    }
+  }
+
+  value(): string {
+    return this.truncated ? `…[stderr truncated]…${this.buf}` : this.buf;
   }
 }
 

--- a/src/brain/protocol.ts
+++ b/src/brain/protocol.ts
@@ -1,0 +1,628 @@
+/**
+ * `cortex-brain/v1` — the wire protocol between cortex and an externally
+ * authored agent brain (Bot Packs B-1; `docs/design-bot-packs.md` §5).
+ *
+ * JSONL, newline-delimited, one JSON object per line. Every line carries
+ * `{ "v": 1, "type": … }`. The grammar is symmetric across both lifecycles
+ * (per-task uses stdin/stdout, daemon uses a socket — B-2); only the
+ * transport differs, never the message shapes.
+ *
+ * ## Two directions
+ *
+ *   - **Cortex → brain (events).** Things the host tells the brain about:
+ *     a `task` to run, a follow-up `message`, a host-resolved `gate_verdict`,
+ *     a `cancel`, a `shutdown` drain signal, an `effect_rejected` (cortex
+ *     refused one of the brain's effects), and the daemon `hello` handshake.
+ *   - **Brain → cortex (effects).** Things the brain asks the host to do:
+ *     `post` to a surface, `ask_principal` (render a gate), `dispatch` fleet
+ *     work, `result` (close the task), and `log`.
+ *
+ * The brain never sees a platform token, a NATS credential, or another
+ * agent's identity (§5 property 1). It *asks* for effects; cortex *performs*
+ * them under policy.
+ *
+ * ## Direction-asymmetric tolerance (§5 "version tolerance")
+ *
+ * The forward-compat rule from §5 is implemented as two codec halves with
+ * opposite strictness:
+ *
+ *   - **Ingest (brain → cortex effects).** Cortex parses what an untrusted
+ *     brain emits, so it is TOLERANT: unknown `type` ⇒ a typed
+ *     `{ kind: "unknown", raw }` result the caller drops-and-logs (NEVER a
+ *     throw); unknown FIELDS on a known type are ignored (Zod default strip
+ *     — extras are dropped, not rejected). A brain on a newer protocol minor
+ *     can add fields/types without breaking an older cortex.
+ *
+ *   - **Emission (cortex → brain events).** Cortex authors these, so they are
+ *     STRICT-by-construction: the encoder builds them from typed inputs and
+ *     Zod strips any stray keys before serialization. The brain side is the
+ *     one expected to tolerate unknown event types (mirror rule), so cortex's
+ *     job is only to emit clean, well-formed lines.
+ *
+ * This is the v1 rule that lets B-2 add events without a protocol bump.
+ *
+ * ## Vocabulary
+ *
+ * Gate/effect names use *principal* (`ask_principal`, `principal-ack`) per
+ * vocabulary migration 0002 R1/R2. `gate_verdict.verdict` reuses the existing
+ * gate vocabulary (`pass | fail`). The `result.failed` / `effect_rejected`
+ * `reason.kind` taxonomy (`cant_do | not_now | wont_do`) is the
+ * brain-protocol subset of the dispatch nak taxonomy
+ * (`src/bus/dispatch-events.ts` `DispatchTaskFailedReason`) — the protocol
+ * deliberately does NOT re-flatten the three kinds into one (§5 property 5).
+ */
+
+import { z } from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Protocol constants
+// ---------------------------------------------------------------------------
+
+/** The protocol version stamped on every line as `v`. */
+export const BRAIN_PROTOCOL_VERSION = 1 as const;
+
+/** The protocol id a manifest declares (`brain.protocol`). */
+export const BRAIN_PROTOCOL_ID = "cortex-brain/v1" as const;
+
+/**
+ * Inline attachment cap — 256 KiB of base64 (`post.attachment.b64`). Anything
+ * larger MUST be written by the brain to its scratch dir and referenced by
+ * path (`attachment: { filename, path }`), which cortex reads and uploads.
+ * Enforced at parse time so an oversized payload is rejected at the seam, not
+ * after a decode. (§5 "Attachments are capped at 256 KiB".)
+ */
+export const MAX_ATTACHMENT_B64_BYTES = 256 * 1024;
+
+// ---------------------------------------------------------------------------
+// Shared sub-schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * The typed refusal taxonomy shared by `result.failed` and `effect_rejected`.
+ * Mirrors the dispatch nak taxonomy 1:1 (a brain refusal maps straight onto
+ * the dispatch failure taxonomy — §5 property 5):
+ *
+ *   - `cant_do` — the brain is structurally unable (missing skill / capability).
+ *   - `not_now` — transient; the same request might succeed later (backpressure).
+ *   - `wont_do` — policy / will refusal; will not succeed on retry.
+ */
+export const BrainReasonKindSchema = z.enum(["cant_do", "not_now", "wont_do"]);
+export type BrainReasonKind = z.infer<typeof BrainReasonKindSchema>;
+
+/** A typed refusal reason: `{ kind, detail }`. */
+export const BrainReasonSchema = z.object({
+  kind: BrainReasonKindSchema,
+  detail: z.string(),
+});
+export type BrainReason = z.infer<typeof BrainReasonSchema>;
+
+/**
+ * Gate verdict vocabulary — reuses the existing gate vocabulary (`pass | fail`)
+ * rather than the governance allow/deny/defer enum. Aligning the two is a
+ * B-1 audit item flagged in §5, NOT a B-1 change.
+ */
+export const GateVerdictValueSchema = z.enum(["pass", "fail"]);
+export type GateVerdictValue = z.infer<typeof GateVerdictValueSchema>;
+
+/**
+ * Where a task originated. The brain sees this only as metadata — it is
+ * surface-agnostic (§5 property 3). Mattermost today, Discord tomorrow, with
+ * zero brain changes; cortex's adapters own the mapping both ways.
+ */
+export const TaskSourceSchema = z.object({
+  surface: z.string(),
+  channel: z.string(),
+  thread: z.string(),
+  user: z.string(),
+});
+export type TaskSource = z.infer<typeof TaskSourceSchema>;
+
+/**
+ * Sovereignty constraint on a `dispatch` effect.
+ *
+ * **Downgrade-only.** The manifest is the ceiling cortex enforces; a brain's
+ * `sovereignty` field may only TIGHTEN it (e.g. request `local-only` although
+ * `any` is allowed), never loosen it. Policy is never the bot's own claim
+ * (§2, §5 property 6). This schema captures the brain's REQUEST; the
+ * downgrade-only enforcement happens host-side against the manifest, not here.
+ */
+export const DispatchSovereigntySchema = z.object({
+  model_class: z.string(),
+});
+export type DispatchSovereignty = z.infer<typeof DispatchSovereigntySchema>;
+
+// ---------------------------------------------------------------------------
+// Cortex → brain events
+// ---------------------------------------------------------------------------
+
+export const BRAIN_EVENT_TASK = "task" as const;
+export const BRAIN_EVENT_MESSAGE = "message" as const;
+export const BRAIN_EVENT_GATE_VERDICT = "gate_verdict" as const;
+export const BRAIN_EVENT_CANCEL = "cancel" as const;
+export const BRAIN_EVENT_SHUTDOWN = "shutdown" as const;
+export const BRAIN_EVENT_EFFECT_REJECTED = "effect_rejected" as const;
+export const BRAIN_EVENT_HELLO = "hello" as const;
+
+/**
+ * `task` — start a unit of work. Per-task brains receive `persona` here (§5
+ * "Persona delivery"); daemons receive it once in `hello` instead, so it is
+ * optional on the task event.
+ */
+export const TaskEventSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EVENT_TASK),
+  task_id: z.string().min(1),
+  capability: z.string().min(1),
+  payload: z.record(z.string(), z.unknown()),
+  source: TaskSourceSchema,
+  /** Per-task lifecycle: the brain's persona text, delivered on the task. */
+  persona: z.string().optional(),
+});
+export type TaskEvent = z.infer<typeof TaskEventSchema>;
+
+/** `message` — a follow-up in an open task's thread. */
+export const MessageEventSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EVENT_MESSAGE),
+  task_id: z.string().min(1),
+  text: z.string(),
+  user: z.string(),
+});
+export type MessageEvent = z.infer<typeof MessageEventSchema>;
+
+/**
+ * `gate_verdict` — the answer to an `ask_principal`.
+ *
+ * Carries the HOST-RESOLVED `principal`, not whatever was typed in a chat
+ * thread. The brain must never infer a verdict from `message` text — the host
+ * performs the principal check (the pulse#47 lesson) and only then forwards
+ * this event. (§5 "Protocol contract details".)
+ */
+export const GateVerdictEventSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EVENT_GATE_VERDICT),
+  task_id: z.string().min(1),
+  gate: z.string().min(1),
+  verdict: GateVerdictValueSchema,
+  notes: z.string().optional(),
+  /** The host-resolved principal id — authoritative, not chat-inferred. */
+  principal: z.string().min(1),
+});
+export type GateVerdictEvent = z.infer<typeof GateVerdictEventSchema>;
+
+/** `cancel` — abandon an in-flight task. */
+export const CancelEventSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EVENT_CANCEL),
+  task_id: z.string().min(1),
+});
+export type CancelEvent = z.infer<typeof CancelEventSchema>;
+
+/**
+ * `shutdown` — drain signal (hot-swap). The brain has `deadline_ms` to finish
+ * in-flight work before SIGTERM; per §7 escalation, deadline → SIGTERM, +5s →
+ * SIGKILL.
+ */
+export const ShutdownEventSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EVENT_SHUTDOWN),
+  deadline_ms: z.number().int().nonnegative(),
+});
+export type ShutdownEvent = z.infer<typeof ShutdownEventSchema>;
+
+/**
+ * `effect_rejected` — cortex refused one of the brain's effects (e.g. a
+ * `dispatch` for a capability outside the manifest, or a foreign `task_id`).
+ * The brain decides how to degrade. Carries the same `reason.kind` taxonomy
+ * as `result.failed` (§5 property 5).
+ */
+export const EffectRejectedEventSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EVENT_EFFECT_REJECTED),
+  task_id: z.string().min(1),
+  /** The effect type cortex refused (e.g. `"dispatch"`, `"post"`). */
+  effect: z.string().min(1),
+  reason: BrainReasonSchema,
+});
+export type EffectRejectedEvent = z.infer<typeof EffectRejectedEventSchema>;
+
+/**
+ * `hello` — daemon handshake, emitted once at start. Carries the persona
+ * (daemon brains do not get it per-task) plus the agent id and protocol
+ * version. (§5 "Persona delivery"; daemon path is B-2 but the shape is fixed
+ * here so the codec is complete.)
+ */
+export const HelloEventSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EVENT_HELLO),
+  persona: z.string(),
+  agent: z.string().min(1),
+  protocol: z.literal(BRAIN_PROTOCOL_ID),
+});
+export type HelloEvent = z.infer<typeof HelloEventSchema>;
+
+/**
+ * Discriminated union of every cortex → brain event. Used for the tolerant
+ * INGEST direction (a brain decoding what cortex sent it) — but cortex itself
+ * only ever ENCODES these, so within cortex this union is the input domain of
+ * {@link encodeBrainEvent}.
+ */
+export const BrainEventSchema = z.discriminatedUnion("type", [
+  TaskEventSchema,
+  MessageEventSchema,
+  GateVerdictEventSchema,
+  CancelEventSchema,
+  ShutdownEventSchema,
+  EffectRejectedEventSchema,
+  HelloEventSchema,
+]);
+export type BrainEvent = z.infer<typeof BrainEventSchema>;
+
+// ---------------------------------------------------------------------------
+// Brain → cortex effects
+// ---------------------------------------------------------------------------
+
+export const BRAIN_EFFECT_POST = "post" as const;
+export const BRAIN_EFFECT_ASK_PRINCIPAL = "ask_principal" as const;
+export const BRAIN_EFFECT_DISPATCH = "dispatch" as const;
+export const BRAIN_EFFECT_RESULT = "result" as const;
+export const BRAIN_EFFECT_LOG = "log" as const;
+
+/**
+ * `post` attachment — inline base64 OR a scratch-dir path, never both.
+ *
+ *   - `{ filename, b64 }` — inline, capped at {@link MAX_ATTACHMENT_B64_BYTES}
+ *     (256 KiB) enforced at parse time.
+ *   - `{ filename, path }` — a path in the brain's scratch dir; cortex reads
+ *     and uploads it. The over-256-KiB escape hatch.
+ *
+ * Modeled as a two-member union so a payload carrying neither (or both
+ * required keys of opposite variants) fails validation.
+ */
+export const PostAttachmentSchema = z.union([
+  z.object({
+    filename: z.string().min(1),
+    b64: z
+      .string()
+      .refine(
+        (s) => Buffer.byteLength(s, "utf8") <= MAX_ATTACHMENT_B64_BYTES,
+        {
+          message: `inline attachment b64 exceeds ${MAX_ATTACHMENT_B64_BYTES} bytes (256 KiB); write it to the scratch dir and use { filename, path } instead`,
+        },
+      ),
+  }),
+  z.object({
+    filename: z.string().min(1),
+    path: z.string().min(1),
+  }),
+]);
+export type PostAttachment = z.infer<typeof PostAttachmentSchema>;
+
+/**
+ * `post` — cortex posts `text` (and optional `attachment`) to the task's
+ * surface/thread. A brain cannot choose the channel — it is bound to the task
+ * source (§5 property 1).
+ */
+export const PostEffectSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EFFECT_POST),
+  task_id: z.string().min(1),
+  text: z.string(),
+  attachment: PostAttachmentSchema.optional(),
+});
+export type PostEffect = z.infer<typeof PostEffectSchema>;
+
+/**
+ * `ask_principal` — render a gate. Cortex enforces the principal check; the
+ * brain only supplies the prompt and the gate name. The answer comes back as
+ * a {@link GateVerdictEvent}.
+ */
+export const AskPrincipalEffectSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EFFECT_ASK_PRINCIPAL),
+  task_id: z.string().min(1),
+  gate: z.string().min(1),
+  prompt: z.string(),
+});
+export type AskPrincipalEffect = z.infer<typeof AskPrincipalEffectSchema>;
+
+/**
+ * `dispatch` — fleet work; cortex publishes the myelin envelope. The optional
+ * `sovereignty` field is DOWNGRADE-ONLY: it may only tighten the manifest
+ * ceiling, never loosen it (enforced host-side — §5 property 6). See
+ * {@link DispatchSovereigntySchema}.
+ */
+export const DispatchEffectSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EFFECT_DISPATCH),
+  task_id: z.string().min(1),
+  capability: z.string().min(1),
+  payload: z.record(z.string(), z.unknown()),
+  sovereignty: DispatchSovereigntySchema.optional(),
+});
+export type DispatchEffect = z.infer<typeof DispatchEffectSchema>;
+
+/**
+ * `result` — closes the task. `complete` carries an optional `summary`;
+ * `failed` carries the typed `reason` (cant_do | not_now | wont_do — §5
+ * property 5). Modeled as a `status`-discriminated union so a `failed` result
+ * MUST carry a reason and a `complete` result must not pretend to.
+ */
+export const ResultEffectSchema = z.discriminatedUnion("status", [
+  z.object({
+    v: z.literal(BRAIN_PROTOCOL_VERSION),
+    type: z.literal(BRAIN_EFFECT_RESULT),
+    task_id: z.string().min(1),
+    status: z.literal("complete"),
+    summary: z.string().optional(),
+  }),
+  z.object({
+    v: z.literal(BRAIN_PROTOCOL_VERSION),
+    type: z.literal(BRAIN_EFFECT_RESULT),
+    task_id: z.string().min(1),
+    status: z.literal("failed"),
+    reason: BrainReasonSchema,
+  }),
+]);
+export type ResultEffect = z.infer<typeof ResultEffectSchema>;
+
+/** `log` — diagnostic line; not surfaced to the principal. */
+export const LogEffectSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EFFECT_LOG),
+  level: z.enum(["debug", "info", "warn", "error"]),
+  text: z.string(),
+});
+export type LogEffect = z.infer<typeof LogEffectSchema>;
+
+/**
+ * Discriminated union of every brain → cortex effect. This is the INGEST
+ * domain within cortex — what {@link parseBrainEffect} validates a single
+ * line against before the tolerant unknown-type fallback.
+ */
+export const BrainEffectSchema = z.discriminatedUnion("type", [
+  PostEffectSchema,
+  AskPrincipalEffectSchema,
+  DispatchEffectSchema,
+  ResultEffectSchema,
+  LogEffectSchema,
+]);
+export type BrainEffect = z.infer<typeof BrainEffectSchema>;
+
+// ---------------------------------------------------------------------------
+// Parse results — tolerant ingest
+// ---------------------------------------------------------------------------
+
+/**
+ * The result of tolerantly parsing one ingest line. Forward-compat (§5
+ * "version tolerance"): an unknown `type` is never a throw — it surfaces as
+ * `{ kind: "unknown", raw }` the caller can drop-and-log.
+ *
+ *   - `ok`       — a well-formed, known effect.
+ *   - `unknown`  — well-formed JSON `{ v, type, … }` but an unrecognised
+ *                  `type`; `raw` is the parsed object for logging.
+ *   - `invalid`  — malformed JSON, or a known type that failed validation
+ *                  (e.g. an oversized attachment, a missing required field).
+ */
+export type ParseBrainEffectResult =
+  | { kind: "ok"; effect: BrainEffect }
+  | { kind: "unknown"; raw: Record<string, unknown> }
+  | { kind: "invalid"; detail: string; raw?: unknown };
+
+/** The known brain → cortex effect `type` literals, for the tolerance gate. */
+const KNOWN_EFFECT_TYPES: ReadonlySet<string> = new Set([
+  BRAIN_EFFECT_POST,
+  BRAIN_EFFECT_ASK_PRINCIPAL,
+  BRAIN_EFFECT_DISPATCH,
+  BRAIN_EFFECT_RESULT,
+  BRAIN_EFFECT_LOG,
+]);
+
+// ---------------------------------------------------------------------------
+// Codec — single JSON lines
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode a cortex → brain event as a single JSONL line (no trailing newline).
+ * STRICT emission: the event is validated and stray keys are stripped (Zod
+ * default) before serialization, so cortex never leaks an internal field onto
+ * the wire. Throws on an event that fails its own schema — that is a cortex
+ * bug, not untrusted input.
+ */
+export function encodeBrainEvent(event: BrainEvent): string {
+  const parsed = BrainEventSchema.parse(event);
+  return JSON.stringify(parsed);
+}
+
+/**
+ * Parse a single JSONL line the brain sent cortex into a tolerant result.
+ * NEVER throws (§5 forward-compat) — malformed JSON, unknown types, and
+ * validation failures all return a typed variant.
+ *
+ * Tolerance order:
+ *   1. JSON parse fails            → `invalid`.
+ *   2. not an object / no `type`   → `invalid`.
+ *   3. `type` not in known set     → `unknown` (drop-and-log).
+ *   4. known `type`, fails schema  → `invalid` (e.g. oversized attachment).
+ *   5. known `type`, valid         → `ok`.
+ *
+ * Unknown FIELDS on a known type are ignored (Zod strips them by default).
+ */
+export function parseBrainEffect(line: string): ParseBrainEffectResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(line);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { kind: "invalid", detail: `malformed JSON: ${detail}`, raw: line };
+  }
+
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      kind: "invalid",
+      detail: "line is not a JSON object",
+      raw,
+    };
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const type = obj["type"];
+  if (typeof type !== "string") {
+    return {
+      kind: "invalid",
+      detail: "missing or non-string `type` field",
+      raw: obj,
+    };
+  }
+
+  // Forward-compat: an unrecognised type is dropped-and-logged, never thrown.
+  if (!KNOWN_EFFECT_TYPES.has(type)) {
+    return { kind: "unknown", raw: obj };
+  }
+
+  const result = BrainEffectSchema.safeParse(obj);
+  if (!result.success) {
+    return {
+      kind: "invalid",
+      detail: result.error.issues
+        .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+        .join("; "),
+      raw: obj,
+    };
+  }
+  return { kind: "ok", effect: result.data };
+}
+
+/**
+ * Encode a brain → cortex effect as a single JSONL line. Provided for symmetry
+ * (and so a TS-authored brain or test fixture can emit effects through the same
+ * schema cortex validates with). Validates + strips before serializing.
+ */
+export function encodeBrainEffect(effect: BrainEffect): string {
+  const parsed = BrainEffectSchema.parse(effect);
+  return JSON.stringify(parsed);
+}
+
+/**
+ * Parse a single JSONL line cortex sent the brain into a tolerant result.
+ * The inverse of {@link parseBrainEffect}, for the brain side / tests: cortex
+ * itself only ever encodes events, but a brain decoding them needs the same
+ * unknown-type tolerance (the mirror of §5's "brains MUST ignore unknown
+ * cortex→brain event types").
+ */
+export type ParseBrainEventResult =
+  | { kind: "ok"; event: BrainEvent }
+  | { kind: "unknown"; raw: Record<string, unknown> }
+  | { kind: "invalid"; detail: string; raw?: unknown };
+
+const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
+  BRAIN_EVENT_TASK,
+  BRAIN_EVENT_MESSAGE,
+  BRAIN_EVENT_GATE_VERDICT,
+  BRAIN_EVENT_CANCEL,
+  BRAIN_EVENT_SHUTDOWN,
+  BRAIN_EVENT_EFFECT_REJECTED,
+  BRAIN_EVENT_HELLO,
+]);
+
+export function parseBrainEvent(line: string): ParseBrainEventResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(line);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { kind: "invalid", detail: `malformed JSON: ${detail}`, raw: line };
+  }
+
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { kind: "invalid", detail: "line is not a JSON object", raw };
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const type = obj["type"];
+  if (typeof type !== "string") {
+    return {
+      kind: "invalid",
+      detail: "missing or non-string `type` field",
+      raw: obj,
+    };
+  }
+
+  if (!KNOWN_EVENT_TYPES.has(type)) {
+    return { kind: "unknown", raw: obj };
+  }
+
+  const result = BrainEventSchema.safeParse(obj);
+  if (!result.success) {
+    return {
+      kind: "invalid",
+      detail: result.error.issues
+        .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+        .join("; "),
+      raw: obj,
+    };
+  }
+  return { kind: "ok", event: result.data };
+}
+
+// ---------------------------------------------------------------------------
+// Incremental decoder — chunked stream input
+// ---------------------------------------------------------------------------
+
+/**
+ * Incremental newline-delimited JSON decoder. Feeds it arbitrary chunks
+ * (which may split a line anywhere, including mid-multibyte) and it yields
+ * complete lines, buffering the partial tail across calls.
+ *
+ * It is transport-agnostic: it does not know about events vs effects — it
+ * only splits on `\n` and hands whole lines back. The runner pairs it with
+ * {@link parseBrainEffect} (cortex reading a brain's stdout); a brain pairs
+ * it with {@link parseBrainEvent}.
+ *
+ * Decoding is UTF-8 streaming (`TextDecoder({ stream: true })`) so a chunk
+ * boundary in the middle of a multibyte codepoint is handled correctly.
+ */
+export class JsonlDecoder {
+  private buffer = "";
+  private readonly decoder = new TextDecoder("utf-8");
+
+  /**
+   * Push a chunk and return every COMPLETE line it produced (without the
+   * trailing `\n`). A trailing partial line is buffered for the next call.
+   * Empty lines (blank `\n\n`) are skipped — they carry no JSON object.
+   */
+  push(chunk: Uint8Array | string): string[] {
+    this.buffer +=
+      typeof chunk === "string"
+        ? chunk
+        : this.decoder.decode(chunk, { stream: true });
+
+    const lines: string[] = [];
+    let newlineIdx = this.buffer.indexOf("\n");
+    while (newlineIdx !== -1) {
+      const line = this.buffer.slice(0, newlineIdx);
+      this.buffer = this.buffer.slice(newlineIdx + 1);
+      // Tolerate CRLF and skip blank lines.
+      const trimmed = line.endsWith("\r") ? line.slice(0, -1) : line;
+      if (trimmed.length > 0) {
+        lines.push(trimmed);
+      }
+      newlineIdx = this.buffer.indexOf("\n");
+    }
+    return lines;
+  }
+
+  /**
+   * Flush any buffered tail at end-of-stream. Returns the final line if the
+   * stream ended without a trailing newline (and it is non-empty), else `[]`.
+   * Also flushes any pending multibyte state from the UTF-8 decoder.
+   */
+  flush(): string[] {
+    // Drain any final bytes held by the streaming UTF-8 decoder.
+    this.buffer += this.decoder.decode();
+    const tail = this.buffer;
+    this.buffer = "";
+    const trimmed = tail.endsWith("\r") ? tail.slice(0, -1) : tail;
+    return trimmed.length > 0 ? [trimmed] : [];
+  }
+}

--- a/src/brain/protocol.ts
+++ b/src/brain/protocol.ts
@@ -45,11 +45,21 @@
  *
  * Gate/effect names use *principal* (`ask_principal`, `principal-ack`) per
  * vocabulary migration 0002 R1/R2. `gate_verdict.verdict` reuses the existing
- * gate vocabulary (`pass | fail`). The `result.failed` / `effect_rejected`
- * `reason.kind` taxonomy (`cant_do | not_now | wont_do`) is the
- * brain-protocol subset of the dispatch nak taxonomy
- * (`src/bus/dispatch-events.ts` `DispatchTaskFailedReason`) — the protocol
- * deliberately does NOT re-flatten the three kinds into one (§5 property 5).
+ * gate vocabulary (`pass | fail`).
+ *
+ * The refusal taxonomy is DIRECTION-ASYMMETRIC, not a 1:1 mirror of the
+ * dispatch nak taxonomy (§5 property 5):
+ *
+ *   - **Brains emit 3 kinds** (`result.failed.reason.kind`):
+ *     `cant_do | not_now | wont_do`. `not_now` may carry `retry_after_ms`.
+ *   - **The host may emit 5 kinds** (`effect_rejected.reason.kind`): those 3
+ *     plus `policy_denied | compliance_block`, which only the host can decide.
+ *
+ * Compliance/policy refusals never silently flatten into a brain kind — the
+ * host passes them through `effect_rejected` verbatim. The brain-side three are
+ * the subset shared with the dispatch nak taxonomy
+ * (`src/bus/dispatch-events.ts` `DispatchTaskFailedReason`); the protocol
+ * deliberately does NOT re-flatten the kinds into one.
  */
 
 import { z } from "zod/v4";
@@ -78,23 +88,65 @@ export const MAX_ATTACHMENT_B64_BYTES = 256 * 1024;
 // ---------------------------------------------------------------------------
 
 /**
- * The typed refusal taxonomy shared by `result.failed` and `effect_rejected`.
- * Mirrors the dispatch nak taxonomy 1:1 (a brain refusal maps straight onto
- * the dispatch failure taxonomy — §5 property 5):
+ * The typed refusal taxonomy. The mapping onto the dispatch nak taxonomy is
+ * NOT 1:1 — it is direction-asymmetric (§5 property 5):
  *
- *   - `cant_do` — the brain is structurally unable (missing skill / capability).
- *   - `not_now` — transient; the same request might succeed later (backpressure).
- *   - `wont_do` — policy / will refusal; will not succeed on retry.
+ *   - **Brains emit 3 kinds** (`result.failed.reason.kind`): a brain can only
+ *     describe its OWN inability or unwillingness.
+ *       - `cant_do` — structurally unable (missing skill / capability).
+ *       - `not_now` — transient; the same request might succeed later
+ *         (backpressure). May carry `retry_after_ms` as a hint.
+ *       - `wont_do` — the brain's own will refusal; will not succeed on retry.
+ *   - **The HOST may emit 5 kinds** (`effect_rejected.reason.kind`): the host
+ *     refuses an effect for the 3 brain reasons PLUS two it alone can decide.
+ *       - `policy_denied` — a policy / sovereignty rule refused the effect.
+ *       - `compliance_block` — a compliance gate blocked the effect.
+ *
+ * Compliance/policy refusals NEVER silently flatten into the brain's 3 kinds:
+ * the host passes them through `effect_rejected` verbatim with their own kind,
+ * so the brain can distinguish "I won't" from "the host's policy won't".
  */
+
+/** Brain-emitted refusal kinds (`result.failed`) — the brain's own 3. */
 export const BrainReasonKindSchema = z.enum(["cant_do", "not_now", "wont_do"]);
 export type BrainReasonKind = z.infer<typeof BrainReasonKindSchema>;
 
-/** A typed refusal reason: `{ kind, detail }`. */
+/**
+ * Host-emitted refusal kinds (`effect_rejected`) — the brain's 3 plus the two
+ * only the host can decide (`policy_denied`, `compliance_block`).
+ */
+export const HostReasonKindSchema = z.enum([
+  "cant_do",
+  "not_now",
+  "wont_do",
+  "policy_denied",
+  "compliance_block",
+]);
+export type HostReasonKind = z.infer<typeof HostReasonKindSchema>;
+
+/**
+ * A brain-emitted refusal reason: `{ kind, detail }`, with an optional
+ * `retry_after_ms` hint that is only meaningful when `kind === "not_now"`.
+ */
 export const BrainReasonSchema = z.object({
   kind: BrainReasonKindSchema,
   detail: z.string(),
+  /** Retry hint (ms); only meaningful for `not_now`. */
+  retry_after_ms: z.number().int().nonnegative().optional(),
 });
 export type BrainReason = z.infer<typeof BrainReasonSchema>;
+
+/**
+ * A host-emitted refusal reason (`effect_rejected`): the wider 5-kind taxonomy.
+ * `retry_after_ms` is likewise only meaningful for `not_now`.
+ */
+export const HostReasonSchema = z.object({
+  kind: HostReasonKindSchema,
+  detail: z.string(),
+  /** Retry hint (ms); only meaningful for `not_now`. */
+  retry_after_ms: z.number().int().nonnegative().optional(),
+});
+export type HostReason = z.infer<typeof HostReasonSchema>;
 
 /**
  * Gate verdict vocabulary — reuses the existing gate vocabulary (`pass | fail`)
@@ -212,9 +264,12 @@ export type ShutdownEvent = z.infer<typeof ShutdownEventSchema>;
 
 /**
  * `effect_rejected` — cortex refused one of the brain's effects (e.g. a
- * `dispatch` for a capability outside the manifest, or a foreign `task_id`).
- * The brain decides how to degrade. Carries the same `reason.kind` taxonomy
- * as `result.failed` (§5 property 5).
+ * `dispatch` for a capability outside the manifest, a foreign `task_id`, or a
+ * scratch-path escape). The brain decides how to degrade. Carries the WIDER
+ * HOST taxonomy ({@link HostReasonSchema}): the brain's 3 kinds plus
+ * `policy_denied | compliance_block`, which only the host can decide (§5
+ * property 5). A policy/compliance refusal is passed through verbatim, never
+ * flattened into a brain kind.
  */
 export const EffectRejectedEventSchema = z.object({
   v: z.literal(BRAIN_PROTOCOL_VERSION),
@@ -222,7 +277,7 @@ export const EffectRejectedEventSchema = z.object({
   task_id: z.string().min(1),
   /** The effect type cortex refused (e.g. `"dispatch"`, `"post"`). */
   effect: z.string().min(1),
-  reason: BrainReasonSchema,
+  reason: HostReasonSchema,
 });
 export type EffectRejectedEvent = z.infer<typeof EffectRejectedEventSchema>;
 
@@ -231,6 +286,14 @@ export type EffectRejectedEvent = z.infer<typeof EffectRejectedEventSchema>;
  * (daemon brains do not get it per-task) plus the agent id and protocol
  * version. (§5 "Persona delivery"; daemon path is B-2 but the shape is fixed
  * here so the codec is complete.)
+ *
+ * **Agent identity is HOST-AUTHORITATIVE.** `hello` is a cortex → brain event:
+ * the host TELLS the brain which agent identity it has been spawned as. It is
+ * NOT a brain-asserted name. The brain never emits `hello` (it lives in the
+ * EVENT union cortex encodes, never the EFFECT union the brain emits), so there
+ * is no codec path by which a brain could assert its own `agent` and have the
+ * host trust it. The identity source is host config, full stop; this field is
+ * informational, host → brain.
  */
 export const HelloEventSchema = z.object({
   v: z.literal(BRAIN_PROTOCOL_VERSION),
@@ -269,18 +332,25 @@ export const BRAIN_EFFECT_RESULT = "result" as const;
 export const BRAIN_EFFECT_LOG = "log" as const;
 
 /**
- * `post` attachment — inline base64 OR a scratch-dir path, never both.
+ * `post` attachment — inline base64 XOR a scratch-dir path, never both.
  *
  *   - `{ filename, b64 }` — inline, capped at {@link MAX_ATTACHMENT_B64_BYTES}
  *     (256 KiB) enforced at parse time.
  *   - `{ filename, path }` — a path in the brain's scratch dir; cortex reads
- *     and uploads it. The over-256-KiB escape hatch.
+ *     and uploads it. The over-256-KiB escape hatch. Host-side scratch
+ *     confinement (the resolved path must stay within THIS task's scratch
+ *     dir) is enforced by the runner, NOT here — the codec only validates
+ *     SHAPE; the runner owns the filesystem boundary (see
+ *     `exec-brain-runner.ts` `confineScratchPath`).
  *
- * Modeled as a two-member union so a payload carrying neither (or both
- * required keys of opposite variants) fails validation.
+ * Modeled as a GENUINELY EXCLUSIVE two-member union: each branch rejects the
+ * other variant's discriminating key. A payload carrying BOTH `b64` and
+ * `path` matches neither branch and fails validation (rather than silently
+ * binding to the b64 branch and stripping `path`). A payload carrying neither
+ * also fails.
  */
 export const PostAttachmentSchema = z.union([
-  z.object({
+  z.strictObject({
     filename: z.string().min(1),
     b64: z
       .string()
@@ -291,7 +361,7 @@ export const PostAttachmentSchema = z.union([
         },
       ),
   }),
-  z.object({
+  z.strictObject({
     filename: z.string().min(1),
     path: z.string().min(1),
   }),

--- a/src/brain/protocol.ts
+++ b/src/brain/protocol.ts
@@ -343,14 +343,17 @@ export const BRAIN_EFFECT_LOG = "log" as const;
  *     SHAPE; the runner owns the filesystem boundary (see
  *     `exec-brain-runner.ts` `confineScratchPath`).
  *
- * Modeled as a GENUINELY EXCLUSIVE two-member union: each branch rejects the
- * other variant's discriminating key. A payload carrying BOTH `b64` and
- * `path` matches neither branch and fails validation (rather than silently
- * binding to the b64 branch and stripping `path`). A payload carrying neither
- * also fails.
+ * EXCLUSIVE on the discriminating keys, TOLERANT on everything else: exactly
+ * one of `b64` / `path` must be present — both (or neither) fails validation,
+ * never silent stripping of the loser. Unknown EXTRA fields (future
+ * attachment metadata) are ignored per the codec's tolerant-ingest rule —
+ * which is why these are NOT strict objects.
  */
-export const PostAttachmentSchema = z.union([
-  z.strictObject({
+const attachmentXor = (a: { b64?: unknown; path?: unknown }) =>
+  (a.b64 !== undefined) !== (a.path !== undefined);
+
+export const PostAttachmentSchema = z
+  .object({
     filename: z.string().min(1),
     b64: z
       .string()
@@ -359,13 +362,13 @@ export const PostAttachmentSchema = z.union([
         {
           message: `inline attachment b64 exceeds ${MAX_ATTACHMENT_B64_BYTES} bytes (256 KiB); write it to the scratch dir and use { filename, path } instead`,
         },
-      ),
-  }),
-  z.strictObject({
-    filename: z.string().min(1),
-    path: z.string().min(1),
-  }),
-]);
+      )
+      .optional(),
+    path: z.string().min(1).optional(),
+  })
+  .refine(attachmentXor, {
+    message: "attachment must carry exactly one of `b64` or `path`",
+  });
 export type PostAttachment = z.infer<typeof PostAttachmentSchema>;
 
 /**
@@ -425,6 +428,9 @@ export const ResultEffectSchema = z.discriminatedUnion("status", [
     task_id: z.string().min(1),
     status: z.literal("complete"),
     summary: z.string().optional(),
+    // A `complete` result carrying a `reason` is ambiguous, not tolerable —
+    // reject it instead of silently stripping (sage round 3).
+    reason: z.undefined().optional(),
   }),
   z.object({
     v: z.literal(BRAIN_PROTOCOL_VERSION),


### PR DESCRIPTION
Phase B-1 (protocol half) of #1021, implementing `docs/design-bot-packs.md` §5 (PR #1019). New files only — no existing file touched (B-0 edits land separately).

## What
- `src/brain/protocol.ts` — cortex-brain/v1 wire types (Zod) + codec: 7 events in (task/message/gate_verdict/cancel/shutdown/effect_rejected/hello), 5 effects out (post/ask_principal/dispatch/result/log); typed refusals `cant_do|not_now|wont_do`; 256 KiB inline-attachment cap at parse time; incremental `JsonlDecoder` (mid-multibyte-safe). Forward-compat is asymmetric by design: tolerant ingest (unknown type → drop-and-log result, never a throw), strict emission.
- `src/brain/exec-brain-runner.ts` — per-task lifecycle: locked-down spawn env (PATH/HOME/LANG + scoped scratch + declared secrets only), task on stdin, effect routing to host hooks, host-side task_id correlation (foreign ids → effect_rejected/wont_do), ask_principal round-trip feeding back the HOST-resolved verdict, alive-until-result, SIGTERM at timeout → SIGKILL +5s, crash → synthesized `failed/cant_do` with stderr tail.

## Spec deviations (documented in code)
1. `task.persona` + `gate_verdict.notes` optional (daemons get persona via `hello`).
2. `effect_rejected` echoes the OWNED task id; the foreign id goes in `reason.detail` (a malformed foreign id can be undefined — rejection must stay schema-valid).
3. `log` is task-agnostic — bypasses correlation (it has no task_id in the §5 grammar).

## Evidence
`bun test src/brain/` 71 pass / 0 fail · full suite 6630 pass / 2 skip / 0 fail · tsc clean · vocab gate PASS. Two real bugs caught by the fixture-brain tests during development (unflushed stdin deadlocking the gate round-trip; log-effect misclassified as foreign) — both fixed with probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)