### PR TITLE
fix(security): sovereignty gate — demand-first; missing agent class denies only when task demands local (#1023)

### DIFF
--- a/src/bus/__tests__/sovereignty-gate.test.ts
+++ b/src/bus/__tests__/sovereignty-gate.test.ts
@@ -48,12 +48,27 @@ describe("evaluateSovereignty — the breach is guarded", () => {
 });
 
 describe("evaluateSovereignty — fail-closed invariants", () => {
-  it("denies when the agent class is missing", () => {
-    expect(evaluateSovereignty({ model_class: "any", frontier_ok: true }, undefined).decision).toBe("deny");
+  // cortex#1023 — DEMAND-FIRST: a missing/unknown agent class fails closed
+  // ONLY when the task demands a local model. A task whose sovereignty
+  // explicitly permits frontier carries nothing the class could breach.
+  it("allows a class-less agent a task that explicitly permits frontier (cortex#1023)", () => {
+    const d = evaluateSovereignty({ model_class: "any", frontier_ok: true }, undefined);
+    expect(d.decision).toBe("allow");
+    expect(d.reason).toContain("permits any model class");
   });
 
-  it("denies when the agent class is unknown", () => {
+  it("denies a class-less agent when the task demands local (missing class)", () => {
+    // frontier_ok missing → demands local → class-less fails closed.
+    expect(evaluateSovereignty({ model_class: "any" }, undefined).decision).toBe("deny");
+  });
+
+  it("denies when the agent class is unknown and the task demands local", () => {
     expect(evaluateSovereignty({ model_class: "any" }, "gpu" as never).decision).toBe("deny");
+  });
+
+  it("allows an unknown-class agent a task that explicitly permits frontier (cortex#1023)", () => {
+    // Same demand-first rule for unknown (not just missing) class values.
+    expect(evaluateSovereignty({ model_class: "any", frontier_ok: true }, "gpu" as never).decision).toBe("allow");
   });
 
   it("denies when the envelope has no sovereignty block", () => {
@@ -62,6 +77,12 @@ describe("evaluateSovereignty — fail-closed invariants", () => {
   });
 
   it("a local-only task with no agent class denies (cannot prove compliance)", () => {
-    expect(evaluateSovereignty({ model_class: "local-only" }, undefined).decision).toBe("deny");
+    const d = evaluateSovereignty({ model_class: "local-only" }, undefined);
+    expect(d.decision).toBe("deny");
+    expect(d.reason).toContain("missing or unknown");
+  });
+
+  it("a frontier_ok:false task with no agent class denies", () => {
+    expect(evaluateSovereignty({ model_class: "any", frontier_ok: false }, undefined).decision).toBe("deny");
   });
 });

--- a/src/bus/sovereignty-gate.ts
+++ b/src/bus/sovereignty-gate.ts
@@ -41,8 +41,9 @@ export interface SovereigntyDecision {
 
 /**
  * Decide whether an agent of `agentClass` may execute a task carrying
- * `sovereignty`. Fail-closed: a missing/unknown agent class, or a missing
- * sovereignty block, denies.
+ * `sovereignty`. Fail-closed where the BREACH is possible: a missing
+ * sovereignty block denies; a missing/unknown agent class denies WHEN the
+ * task demands a local model.
  *
  * The breach guarded: a task that demands a local model must NOT be executed
  * by a frontier-capable agent (class "frontier" or "any"). A task "demands
@@ -52,15 +53,23 @@ export interface SovereigntyDecision {
  * Envelope frontier_ok is required so this only bites callers outside the
  * pipeline; the conservative default keeps the gate safe for them too.
  * Everything the demand explicitly permits is allowed.
+ *
+ * cortex#1023 — DEMAND-FIRST evaluation. The agent class is examined only
+ * when the task demands a local model. A task whose sovereignty explicitly
+ * permits frontier (`frontier_ok: true`) carries nothing to protect from a
+ * frontier model — the agent's class is irrelevant to the breach, so a
+ * class-less agent is allowed. This matches the `modelClass` schema contract
+ * ("When unset the sovereignty gate fails closed for tasks that demand a
+ * local model ... tasks that permit any model are unaffected") which the
+ * pre-#1023 implementation violated by denying class-less agents
+ * unconditionally — under the audit→enforce flip (#906/#327) that would
+ * have DoS'd every dispatch to a class-less agent regardless of the task's
+ * sovereignty demand.
  */
 export function evaluateSovereignty(
   sovereignty: EnvelopeSovereignty | null | undefined,
   agentClass: AgentModelClass | undefined,
 ): SovereigntyDecision {
-  // Fail closed: an agent that can't prove its class can't prove compliance.
-  if (agentClass !== "local-only" && agentClass !== "frontier" && agentClass !== "any") {
-    return { decision: "deny", reason: `agent model class missing or unknown (got ${String(agentClass)}) — failing closed` };
-  }
   // Fail closed: an envelope with no sovereignty block carries no permission to read.
   if (!sovereignty || typeof sovereignty !== "object") {
     return { decision: "deny", reason: "envelope carries no sovereignty block — failing closed" };
@@ -70,7 +79,24 @@ export function evaluateSovereignty(
   // demands local — fail closed for callers that omit the field.
   const demandsLocal = sovereignty.model_class === "local-only" || sovereignty.frontier_ok !== true;
 
-  if (demandsLocal && (agentClass === "frontier" || agentClass === "any")) {
+  // cortex#1023 — the task explicitly permits frontier: no confidential
+  // payload to protect from a frontier model, agent class irrelevant.
+  if (!demandsLocal) {
+    return { decision: "allow", reason: "task sovereignty permits any model class" };
+  }
+
+  // The task demands a local model — fail closed: an agent that can't prove
+  // its class can't prove compliance with the demand.
+  if (agentClass !== "local-only" && agentClass !== "frontier" && agentClass !== "any") {
+    return {
+      decision: "deny",
+      reason:
+        `task requires a local model but agent model class missing or unknown ` +
+        `(got ${String(agentClass)}) — failing closed`,
+    };
+  }
+
+  if (agentClass === "frontier" || agentClass === "any") {
     return {
       decision: "deny",
       reason:
@@ -80,7 +106,6 @@ export function evaluateSovereignty(
     };
   }
 
-  // A local-only agent may always execute (it cannot leak to a frontier model);
-  // a frontier/any agent may execute anything the demand does not restrict.
+  // A local-only agent may always execute (it cannot leak to a frontier model).
   return { decision: "allow", reason: "agent model class satisfies the task sovereignty demand" };
 }


### PR DESCRIPTION
Closes #1023.

## Summary

`evaluateSovereignty` denied on a missing/unknown agent `modelClass` BEFORE examining the task's sovereignty demand — an envelope explicitly permitting frontier (`frontier_ok: true`) still produced a deny for every class-less agent. The `modelClass` schema docblock promises the opposite ("When unset the sovereignty gate fails closed for tasks that demand a local model ... tasks that permit any model are unaffected"). Today: audit-parity log noise on every dispatch to a class-less agent (observed on every sage dispatch). Post audit→enforce flip (#906/#327): hard DoS on all dispatches to class-less agents regardless of task sovereignty.

## Change

Demand-first ordering in `src/bus/sovereignty-gate.ts`:

1. no sovereignty block → **deny** (unchanged)
2. task explicitly permits frontier (`frontier_ok: true` and not `model_class: local-only`) → **allow** — class irrelevant to the guarded breach
3. task demands local + class missing/unknown → **deny** (unchanged, fail closed)
4. task demands local + frontier-capable class → **deny** (unchanged)
5. local-only agent → **allow** (unchanged)

The guarded breach — confidential payload reaching a frontier model — is untouched: every demands-local path fails closed exactly as before. `frontier_ok` missing still demands local (conservative default unchanged).

## Tests

Updated to the documented contract: class-less/unknown + `frontier_ok: true` → allow (2 new); class-less/unknown + demands-local → deny pinned (3 cases incl. `frontier_ok: false`). Full suite 6562 pass / 0 fail.

## Deployment note

Companion config change (not in this PR — deployment-side): `sage` on the jc/meta-factory stack gains `runtime.modelClass: frontier` (truthful — sage lenses run through codex), so demands-local tasks correctly deny for sage once enforcement lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)