### PR TITLE
feat(cortex): B-0 — hot agents.d reload + derived provided_by (#1021)

### DIFF
--- a/src/__tests__/cortex.agents-reload.test.ts
+++ b/src/__tests__/cortex.agents-reload.test.ts
@@ -158,6 +158,29 @@ function capRegAgentIds(published: Envelope[]): string[] {
     .map((e) => (e.payload as { agent_id?: string }).agent_id ?? "?");
 }
 
+// Capability registrations as (agent_id, capability-count) pairs — lets a test
+// tell a real registration (caps > 0) apart from a TOMBSTONE (caps === 0).
+function capRegEvents(
+  published: Envelope[],
+): Array<{ agentId: string; capCount: number }> {
+  return published
+    .filter((e) => e.type === "agents.capabilities.registered")
+    .map((e) => {
+      const p = e.payload as { agent_id?: string; capabilities?: unknown[] };
+      return {
+        agentId: p.agent_id ?? "?",
+        capCount: Array.isArray(p.capabilities) ? p.capabilities.length : -1,
+      };
+    });
+}
+
+// Tombstones are capability registrations with an EMPTY capabilities array.
+function tombstonedAgentIds(published: Envelope[]): string[] {
+  return capRegEvents(published)
+    .filter((e) => e.capCount === 0)
+    .map((e) => e.agentId);
+}
+
 // ---------------------------------------------------------------------------
 // Tests — handle.reloadAgents() (deterministic)
 // ---------------------------------------------------------------------------
@@ -244,6 +267,70 @@ describe("startCortex — agents.d/ hot reload (B-0, cortex#1021)", () => {
 
     // Re-publish fired: luna now appears among the capability registrations.
     expect(capRegAgentIds(runtime.published)).toContain("luna");
+  });
+
+  test("REMOVE a fragment → capability registration is TOMBSTONED (Sage cortex#1027)", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    writeFragment("luna", ["code-review.security"]);
+    const handle = await bootWatcherless(runtime);
+    const before = runtime.published.length;
+
+    removeFragment("luna");
+    await handle.reloadAgents("cli");
+
+    // A tombstone (empty-capability registration) was published for luna so its
+    // prior registration is OVERWRITTEN — it no longer registers as a provider.
+    const tombstoned = tombstonedAgentIds(runtime.published.slice(before));
+    expect(tombstoned).toContain("luna");
+    // echo, unchanged, is NOT tombstoned.
+    expect(tombstoned).not.toContain("echo");
+  });
+
+  test("diff-only republish — an unchanged agent is NOT re-published on an unrelated add (Sage cortex#1027)", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    const handle = await bootWatcherless(runtime);
+    const before = runtime.published.length;
+
+    // Add luna; echo is untouched.
+    writeFragment("luna", ["code-review.security"]);
+    await handle.reloadAgents("cli");
+
+    const reloadRegs = capRegEvents(runtime.published.slice(before));
+    // luna (the added agent) is republished…
+    expect(reloadRegs.some((e) => e.agentId === "luna" && e.capCount > 0)).toBe(true);
+    // …but echo (unchanged) is NOT re-published (no O(total agents) churn).
+    expect(reloadRegs.some((e) => e.agentId === "echo")).toBe(false);
+  });
+
+  test("CHANGE an agent to zero capabilities → tombstoned (Sage cortex#1027)", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    // nova starts WITH a (non-review) capability so it's a registered provider.
+    writeFragment("nova", ["deploy.k8s"]);
+    const handle = await bootWatcherless(runtime);
+    const before = runtime.published.length;
+
+    // Rewrite nova with an empty capability set.
+    const personaPath = join(tmpPersonasDir, "nova.md");
+    writeFileSync(personaPath, "# nova persona\n");
+    writeFileSync(
+      join(tmpAgentsDir, "nova.yaml"),
+      `id: nova
+displayName: Nova
+persona: "${personaPath}"
+presence: {}
+runtime:
+  substrate: claude-code
+  mode: in-process
+  capabilities: []
+`,
+    );
+    await handle.reloadAgents("cli");
+
+    // nova dropped to zero caps → tombstoned so its stale registration clears.
+    expect(tombstonedAgentIds(runtime.published.slice(before))).toContain("nova");
   });
 
   test("derived provided_by — a declaration-only capability needs no catalog edit", async () => {

--- a/src/__tests__/cortex.agents-reload.test.ts
+++ b/src/__tests__/cortex.agents-reload.test.ts
@@ -1,0 +1,386 @@
+/**
+ * B-0 (cortex#1021, design-bot-packs §7 + §11) — daemon-level agents.d/ hot
+ * reload tests.
+ *
+ * Drives `startCortex` with a real `agents.d/` tmp dir + injected recording
+ * runtime, then exercises the reconcile path through the handle's
+ * `reloadAgents()` (deterministic — no fs.watch timing) AND through the live
+ * fs.watch watcher (debounce overridden short). Asserts:
+ *
+ *   - a fragment ADD starts the new agent's review consumer + bumps generation
+ *   - a fragment REMOVE drains the agent's consumer + bumps generation
+ *   - a fragment CHANGE is remove+add
+ *   - capability registry is re-published on reload (deliverable 3)
+ *   - derived provided_by: a declaration-only capability needs no catalog edit
+ *   - an invalid fragment is rejected without killing the daemon (old
+ *     generation retained, prior consumers intact)
+ *   - a no-op reload does not bump the generation
+ *   - the live fs.watch path fires the same reconcile
+ *
+ * No real NATS, Discord, or `claude` spawning. Persona files are real tmp
+ * files (the loader stats them).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import { startCortex, type CortexHandle } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+  MyelinSubscribePullOpts,
+} from "../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+
+// ---------------------------------------------------------------------------
+// Harness (mirrors cortex.review-consumer-boot.test.ts)
+// ---------------------------------------------------------------------------
+
+function minimalConfig(): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-reload-test-published" },
+  });
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+  subscribePullCalls: MyelinSubscribePullOpts[];
+  stoppedSubscribers: string[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+  const stoppedSubscribers: string[] = [];
+  return {
+    enabled: false,
+    published,
+    subscribePullCalls,
+    stoppedSubscribers,
+    onEnvelope(handler) {
+      onEnvelopeHandlers.add(handler);
+      return { unregister: () => onEnvelopeHandlers.delete(handler) };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    subscribePull: (opts: MyelinSubscribePullOpts): MyelinSubscriber => {
+      subscribePullCalls.push(opts);
+      return {
+        pattern: opts.pattern,
+        ready: Promise.resolve(),
+        stop: async () => {
+          stoppedSubscribers.push(opts.durable ?? opts.pattern);
+        },
+      } as unknown as MyelinSubscriber;
+    },
+    stop: async () => {},
+  };
+}
+
+let tmpAgentsDir: string;
+let tmpPersonasDir: string;
+const handles: CortexHandle[] = [];
+
+beforeEach(() => {
+  tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-reload-agentsd-"));
+  tmpPersonasDir = mkdtempSync(join(tmpdir(), "cortex-reload-personas-"));
+});
+
+afterEach(async () => {
+  for (const h of handles.splice(0)) {
+    await h.stop();
+  }
+  rmSync(tmpAgentsDir, { recursive: true, force: true });
+  rmSync(tmpPersonasDir, { recursive: true, force: true });
+});
+
+/** Write a fragment YAML for `id` declaring the given capabilities. */
+function writeFragment(
+  id: string,
+  capabilities: string[],
+  opts: { broken?: boolean } = {},
+): void {
+  if (opts.broken) {
+    writeFileSync(join(tmpAgentsDir, `${id}.yaml`), `id: "${id}\n`); // unterminated quote
+    return;
+  }
+  const personaPath = join(tmpPersonasDir, `${id}.md`);
+  writeFileSync(personaPath, `# ${id} persona\n`);
+  const caps = capabilities.map((c) => `    - "${c}"`).join("\n");
+  const yaml = `id: ${id}
+displayName: ${id.charAt(0).toUpperCase() + id.slice(1)}
+persona: "${personaPath}"
+presence: {}
+runtime:
+  substrate: claude-code
+  mode: in-process
+  capabilities:
+${caps}
+`;
+  writeFileSync(join(tmpAgentsDir, `${id}.yaml`), yaml);
+}
+
+function removeFragment(id: string): void {
+  unlinkSync(join(tmpAgentsDir, `${id}.yaml`));
+}
+
+async function bootWatcherless(
+  runtime: RecordingRuntime,
+): Promise<CortexHandle> {
+  const handle = await startCortex(minimalConfig(), {
+    disableConfigWatcher: true,
+    disableDashboard: true,
+    disableOutboundPoller: true,
+    disableAgentsWatcher: true, // drive reloads through handle.reloadAgents()
+    agentsDir: tmpAgentsDir,
+    configPath: join(tmpAgentsDir, "cortex.yaml"), // so agentsDir resolution + pid path are coherent
+    injectRuntime: runtime,
+    principal: { id: "test-op" },
+  });
+  handles.push(handle);
+  return handle;
+}
+
+// Capability-registration envelopes carry the per-agent payload.
+function capRegAgentIds(published: Envelope[]): string[] {
+  return published
+    .filter((e) => e.type === "agents.capabilities.registered")
+    .map((e) => (e.payload as { agent_id?: string }).agent_id ?? "?");
+}
+
+// ---------------------------------------------------------------------------
+// Tests — handle.reloadAgents() (deterministic)
+// ---------------------------------------------------------------------------
+
+describe("startCortex — agents.d/ hot reload (B-0, cortex#1021)", () => {
+  test("ADD a fragment → new review consumer started + generation bumped", async () => {
+    const runtime = createRecordingRuntime();
+    // Boot with one fragment already present.
+    writeFragment("echo", ["code-review.typescript"]);
+    const handle = await bootWatcherless(runtime);
+
+    expect(handle.agentGeneration).toBe(0);
+    expect(handle.agentRegistry.getAll().map((a) => a.id)).toEqual(["echo"]);
+    expect(runtime.subscribePullCalls.length).toBe(1); // echo
+
+    // Drop a second fragment, reload.
+    writeFragment("luna", ["code-review.security"]);
+    await handle.reloadAgents("cli");
+
+    expect(handle.agentGeneration).toBe(1);
+    expect(handle.agentRegistry.getAll().map((a) => a.id).sort()).toEqual([
+      "echo",
+      "luna",
+    ]);
+    // Luna's consumer subscribed (echo's was already subscribed at boot).
+    const lunaDurable = runtime.subscribePullCalls.find((c) =>
+      (c.durable ?? "").includes("luna"),
+    );
+    expect(lunaDurable).toBeDefined();
+  });
+
+  test("REMOVE a fragment → consumer drained + generation bumped", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    writeFragment("luna", ["code-review.security"]);
+    const handle = await bootWatcherless(runtime);
+    expect(handle.agentRegistry.getAll().length).toBe(2);
+    const subsBefore = runtime.subscribePullCalls.length;
+
+    removeFragment("luna");
+    await handle.reloadAgents("cli");
+
+    expect(handle.agentGeneration).toBe(1);
+    expect(handle.agentRegistry.getAll().map((a) => a.id)).toEqual(["echo"]);
+    // Luna's subscriber was stopped (drained).
+    expect(
+      runtime.stoppedSubscribers.some((d) => d.includes("luna")),
+    ).toBe(true);
+    // No new subscriptions opened by a pure removal.
+    expect(runtime.subscribePullCalls.length).toBe(subsBefore);
+  });
+
+  test("CHANGE a fragment (new capability) → remove+add, generation bumped", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    const handle = await bootWatcherless(runtime);
+    const subsBefore = runtime.subscribePullCalls.length;
+
+    // Rewrite echo with an extra flavor.
+    writeFragment("echo", ["code-review.typescript", "code-review.security"]);
+    await handle.reloadAgents("cli");
+
+    expect(handle.agentGeneration).toBe(1);
+    // Old consumer drained, new consumer started → a fresh subscribe happened.
+    expect(runtime.stoppedSubscribers.some((d) => d.includes("echo"))).toBe(true);
+    expect(runtime.subscribePullCalls.length).toBeGreaterThan(subsBefore);
+    // The flavor set reflects the change.
+    const echo = handle.agentRegistry.getById("echo");
+    expect(echo.runtime?.capabilities).toEqual([
+      "code-review.typescript",
+      "code-review.security",
+    ]);
+  });
+
+  test("reload re-publishes the capability registry (deliverable 3)", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    const handle = await bootWatcherless(runtime);
+    const bootCount = capRegAgentIds(runtime.published).length;
+    expect(bootCount).toBeGreaterThanOrEqual(1);
+
+    writeFragment("luna", ["code-review.security"]);
+    await handle.reloadAgents("cli");
+
+    // Re-publish fired: luna now appears among the capability registrations.
+    expect(capRegAgentIds(runtime.published)).toContain("luna");
+  });
+
+  test("derived provided_by — a declaration-only capability needs no catalog edit", async () => {
+    // The agent declares a capability that exists in NO top-level catalog;
+    // boot + reload accept it and publish it. (deliverable 4 end-to-end)
+    const runtime = createRecordingRuntime();
+    writeFragment("nova", ["deploy.k8s"]); // not code-review; not catalogued
+    const handle = await bootWatcherless(runtime);
+
+    expect(handle.agentRegistry.getById("nova").runtime?.capabilities).toEqual([
+      "deploy.k8s",
+    ]);
+    // The capability registry published nova's declared capability.
+    expect(capRegAgentIds(runtime.published)).toContain("nova");
+
+    // Reload still accepts it and re-publishes.
+    writeFragment("nova", ["deploy.k8s", "deploy.fly"]);
+    await handle.reloadAgents("cli");
+    expect(handle.agentGeneration).toBe(1);
+    expect(handle.agentRegistry.getById("nova").runtime?.capabilities).toEqual([
+      "deploy.k8s",
+      "deploy.fly",
+    ]);
+  });
+
+  test("invalid fragment → rejected, old generation retained, daemon survives", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    const handle = await bootWatcherless(runtime);
+    expect(handle.agentGeneration).toBe(0);
+
+    // Drop a malformed fragment + reload.
+    writeFragment("broken", [], { broken: true });
+    await handle.reloadAgents("cli");
+
+    // Generation NOT bumped; echo's consumer is intact; the daemon is alive.
+    expect(handle.agentGeneration).toBe(0);
+    expect(handle.agentRegistry.getAll().map((a) => a.id)).toEqual(["echo"]);
+  });
+
+  test("no-op reload (nothing changed) does not bump the generation", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    const handle = await bootWatcherless(runtime);
+    expect(handle.agentGeneration).toBe(0);
+
+    // Reload with no on-disk change.
+    await handle.reloadAgents("cli");
+    expect(handle.agentGeneration).toBe(0);
+    expect(handle.agentRegistry.getAll().map((a) => a.id)).toEqual(["echo"]);
+  });
+
+  test("onAgentsReloaded hook reports add/remove/change sets + generation", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    const events: Array<{
+      generation: number;
+      added: string[];
+      removed: string[];
+      changed: string[];
+      failed: boolean;
+    }> = [];
+    const handle = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      disableAgentsWatcher: true,
+      agentsDir: tmpAgentsDir,
+      configPath: join(tmpAgentsDir, "cortex.yaml"),
+      injectRuntime: runtime,
+      principal: { id: "test-op" },
+      onAgentsReloaded: (info) => {
+        events.push({
+          generation: info.generation,
+          added: info.added,
+          removed: info.removed,
+          changed: info.changed,
+          failed: info.failed,
+        });
+      },
+    });
+    handles.push(handle);
+
+    writeFragment("luna", ["code-review.security"]);
+    await handle.reloadAgents("cli");
+
+    expect(events.length).toBe(1);
+    expect(events[0]).toMatchObject({
+      generation: 1,
+      added: ["luna"],
+      removed: [],
+      changed: [],
+      failed: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — live fs.watch path
+// ---------------------------------------------------------------------------
+
+describe("startCortex — agents.d/ fs.watch reconcile (B-0, cortex#1021)", () => {
+  test("fs.watch fires the reconcile on a fragment add", async () => {
+    const runtime = createRecordingRuntime();
+    writeFragment("echo", ["code-review.typescript"]);
+    let lastGeneration = -1;
+    const reloaded: string[][] = [];
+    const handle = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      // watcher ENABLED with a short debounce
+      agentsWatcherDebounceMs: 30,
+      agentsDir: tmpAgentsDir,
+      configPath: join(tmpAgentsDir, "cortex.yaml"),
+      injectRuntime: runtime,
+      principal: { id: "test-op" },
+      onAgentsReloaded: (info) => {
+        lastGeneration = info.generation;
+        reloaded.push(info.added);
+      },
+    });
+    handles.push(handle);
+
+    // Drop a fragment; the fs.watch + debounce should fire the reconcile.
+    writeFragment("luna", ["code-review.security"]);
+
+    const deadline = Date.now() + 4000;
+    while (Date.now() < deadline && lastGeneration < 1) {
+      await new Promise<void>((r) => setTimeout(r, 30));
+    }
+
+    expect(handle.agentGeneration).toBeGreaterThanOrEqual(1);
+    expect(handle.agentRegistry.getAll().map((a) => a.id).sort()).toEqual([
+      "echo",
+      "luna",
+    ]);
+    expect(reloaded.some((added) => added.includes("luna"))).toBe(true);
+  });
+});

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -23,9 +23,9 @@
  *     option) keep the test deterministic and avoid filesystem churn.
  */
 
-import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "fs";
-import { join } from "path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, symlinkSync } from "fs";
+import { join, basename } from "path";
 import { tmpdir } from "os";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
@@ -889,5 +889,53 @@ describe("pidFileFor — per-config PID file derivation", () => {
     const rel = pidFileFor("./cortex.work.yaml");
     const abs = pidFileFor("/Users/andreas/.config/cortex/cortex.work.yaml");
     expect(rel).toBe(abs);
+  });
+
+  // Sage cortex#1027 — different SPELLINGS of the same on-disk config must
+  // resolve to one PID identity (otherwise `cortex agents reload` signals the
+  // wrong/no daemon). These probes use a real tmp file + a symlink so
+  // realpathSync actually canonicalizes.
+  describe("spelling stability (Sage cortex#1027)", () => {
+    let dir: string;
+    let configPath: string;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "cortex-pidfile-spelling-"));
+      configPath = join(dir, "stack.yaml");
+      writeFileSync(configPath, "agent:\n  name: x\n");
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("trailing slash + plain spelling resolve to the same PID file", () => {
+      expect(pidFileFor(`${configPath}/`)).toBe(pidFileFor(configPath));
+    });
+
+    test("'.' / '..' detour resolves to the same PID file", () => {
+      const detour = join(dir, ".", "..", basename(dir), "stack.yaml");
+      expect(pidFileFor(detour)).toBe(pidFileFor(configPath));
+    });
+
+    test("symlink to the config resolves to the same PID file as the target", () => {
+      const link = join(dir, "alias.yaml");
+      symlinkSync(configPath, link);
+      // Without canonicalization these would key two daemons (stack.pid vs
+      // alias.pid); realpathSync collapses the symlink onto its target.
+      expect(pidFileFor(link)).toBe(pidFileFor(configPath));
+    });
+
+    test("non-existent config still derives a stable basename PID (fallback path)", () => {
+      const ghost = join(dir, "never-created.yaml");
+      const expected = join(
+        process.env.HOME ?? "~",
+        ".config",
+        "grove",
+        "state",
+        "cortex-never-created.pid",
+      );
+      expect(pidFileFor(ghost)).toBe(expected);
+    });
   });
 });

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -320,6 +320,22 @@ presence:
     }
   });
 
+  test("round-2: partial-numeric PID file is malformed — never signals PID prefix", () => {
+    // parseInt("123abc") === 123 would SIGHUP an unintended process; the
+    // full-string check must classify the file as malformed instead.
+    const { configPath, restore } = seedConfigWithPidFile(1);
+    try {
+      writeFileSync(pidFileFor(configPath), "123abc\n");
+      const r = runAgentsReload(
+        parseAgentsArgs(["reload", "--config", configPath]),
+      );
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toContain("malformed");
+    } finally {
+      restore();
+    }
+  });
+
   test("Sage cortex#1027: a FAILED signal (stale PID) exits non-zero and reports the failure", () => {
     // A PID that is (almost certainly) not a live process → process.kill throws
     // ESRCH → attempted-but-failed → non-zero exit.

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -588,3 +588,19 @@ function seedConfigWithPidFile(pid: number): {
     },
   };
 }
+
+// sage round 3 — tilde spelling converges for on-disk configs
+describe("round-3: pidFileFor tilde expansion", () => {
+  test("~ and absolute spellings of the same existing config derive one PID file", () => {
+    const home = process.env.HOME!;
+    const dir = mkdtempSync(join(home, ".pidfile-tilde-test-"));
+    try {
+      const abs = join(dir, "stack.yaml");
+      writeFileSync(abs, "x: 1\n");
+      const viaTilde = `~/${abs.slice(home.length + 1)}`;
+      expect(pidFileFor(viaTilde)).toBe(pidFileFor(abs));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -266,14 +266,34 @@ presence:
     expect(r.stderr).toMatch(/displayName/i);
   });
 
-  test("success text includes the validation-only caveat (Echo M3)", () => {
+  test("B-0: --validate-only keeps the validation-only caveat (no daemon signal)", () => {
     const cfg = mkdtempSync(join(tmpdir(), "f3-validation-note-"));
+    seedConfigDir(cfg, VALID_DIR);
+    const r = runAgentsReload(
+      parseAgentsArgs([
+        "reload",
+        "--validate-only",
+        "--config",
+        join(cfg, "cortex.yaml"),
+      ]),
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("validation-only");
+    // No daemon-signal language on the validate-only path.
+    expect(r.stdout).not.toContain("signalled running daemon");
+  });
+
+  test("B-0: default reload reports 'daemon NOT signalled' when no daemon is running", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-no-daemon-"));
     seedConfigDir(cfg, VALID_DIR);
     const r = runAgentsReload(
       parseAgentsArgs(["reload", "--config", join(cfg, "cortex.yaml")]),
     );
+    // Validation passed; with no PID file the daemon is not signalled, but the
+    // command still exits 0 (validation is the failure surface, not liveness).
     expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain("validation-only");
+    expect(r.stdout).toContain("daemon NOT signalled");
+    expect(r.stdout).toContain("no running daemon");
   });
 
   test("--fragment 1 MiB cap applies (Echo M2 hardening parity)", () => {

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -1,9 +1,10 @@
 // F-3 — cortex agents reload/list CLI tests.
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync, copyFileSync, mkdirSync, readdirSync, readFileSync, rmSync } from "fs";
+import { mkdtempSync, writeFileSync, copyFileSync, mkdirSync, readdirSync, readFileSync, rmSync, existsSync, unlinkSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { spawn, type ChildProcess } from "child_process";
 
 import {
   parseAgentsArgs,
@@ -12,6 +13,7 @@ import {
   dispatchAgents,
   AgentsArgsError,
 } from "../agents";
+import { pidFileFor } from "../../../../common/pidfile";
 
 const FIXTURES = join(import.meta.dir, "fixtures");
 const VALID_DIR = join(FIXTURES, "agents.d-valid");
@@ -279,21 +281,93 @@ presence:
     );
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toContain("validation-only");
-    // No daemon-signal language on the validate-only path.
-    expect(r.stdout).not.toContain("signalled running daemon");
+    // No signal language on the validate-only path.
+    expect(r.stdout).not.toContain("reload signal delivered");
   });
 
-  test("B-0: default reload reports 'daemon NOT signalled' when no daemon is running", () => {
-    const cfg = mkdtempSync(join(tmpdir(), "f3-no-daemon-"));
+  test("B-0: default reload reports no signal sent when no runtime is running", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-no-runtime-"));
     seedConfigDir(cfg, VALID_DIR);
     const r = runAgentsReload(
       parseAgentsArgs(["reload", "--config", join(cfg, "cortex.yaml")]),
     );
-    // Validation passed; with no PID file the daemon is not signalled, but the
-    // command still exits 0 (validation is the failure surface, not liveness).
+    // Validation passed; with no PID file there's no runtime to signal — benign,
+    // so the command still exits 0 (validation is the failure surface).
     expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain("daemon NOT signalled");
-    expect(r.stdout).toContain("no running daemon");
+    expect(r.stdout).toContain("no reload signal sent");
+    expect(r.stdout).toContain("no running cortex runtime");
+  });
+
+  // Sage cortex#1027 — honesty: a delivered SIGHUP is reported as "signal
+  // delivered", NOT "reload applied". Drive a real signalable PID (this test
+  // process) through a config whose PID file we write ourselves.
+  test("Sage cortex#1027: delivered signal is reported as 'signal delivered', not 'reload applied'", () => {
+    const target = spawnSignalTarget();
+    const { configPath, restore } = seedConfigWithPidFile(target.pid);
+    try {
+      const r = runAgentsReload(
+        parseAgentsArgs(["reload", "--config", configPath]),
+      );
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("reload signal delivered");
+      // Honest scope: never claims the async reload finished.
+      expect(r.stdout).not.toMatch(/reload live|reload applied/);
+      // Tells the principal where to confirm.
+      expect(r.stdout).toContain("runtime logs");
+    } finally {
+      target.kill();
+      restore();
+    }
+  });
+
+  test("Sage cortex#1027: a FAILED signal (stale PID) exits non-zero and reports the failure", () => {
+    // A PID that is (almost certainly) not a live process → process.kill throws
+    // ESRCH → attempted-but-failed → non-zero exit.
+    const { configPath, restore } = seedConfigWithPidFile(2_147_483_646);
+    try {
+      const r = runAgentsReload(
+        parseAgentsArgs(["reload", "--config", configPath]),
+      );
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toContain("reload signal FAILED");
+    } finally {
+      restore();
+    }
+  });
+
+  test("Sage cortex#1027: --json carries a FAILED signal as an error + non-zero exit", () => {
+    const { configPath, restore } = seedConfigWithPidFile(2_147_483_646);
+    try {
+      const r = runAgentsReload(
+        parseAgentsArgs(["reload", "--config", configPath, "--json"]),
+      );
+      expect(r.exitCode).toBe(1);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.status).toBe("error");
+      expect(parsed.error.reason).toContain("reload signal failed");
+      // Validation itself passed — the error context records that distinction.
+      expect(parsed.error.context.validation).toBe("ok");
+    } finally {
+      restore();
+    }
+  });
+
+  test("Sage cortex#1027: --json on a delivered signal records signalled=true in data (success)", () => {
+    const target = spawnSignalTarget();
+    const { configPath, restore } = seedConfigWithPidFile(target.pid);
+    try {
+      const r = runAgentsReload(
+        parseAgentsArgs(["reload", "--config", configPath, "--json"]),
+      );
+      expect(r.exitCode).toBe(0);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.status).toBe("ok");
+      expect(parsed.data.signalled).toBe("true");
+      expect(parsed.data.pid).toBe(String(target.pid));
+    } finally {
+      target.kill();
+      restore();
+    }
   });
 
   test("--fragment 1 MiB cap applies (Echo M2 hardening parity)", () => {
@@ -432,4 +506,69 @@ function seedConfigDir(cfg: string, srcAgentsDir: string): void {
     const content = readFileSync(join(srcAgentsDir, filename), "utf-8");
     writeFileSync(join(agentsD, filename), content);
   }
+}
+
+/**
+ * Sage cortex#1027 — seed a valid config dir AND write a PID file (containing
+ * `pid`) at the exact location `signalDaemonReload` resolves it to, so a `reload`
+ * actually attempts `process.kill(pid, SIGHUP)`. Each test gets a UNIQUE config
+ * basename (so its PID file path is unique) and `restore()` removes the PID file.
+ *
+ * The config basename must be unique per test because `pidFileFor` keys on the
+ * (canonicalized) config basename — two tests sharing a basename would collide on
+ * the same PID file under `~/.config/grove/state/`.
+ */
+/**
+ * Spawn a harmless long-lived child (`sleep 300`) and return its PID + a killer.
+ * Used as a REAL, signalable target so the "delivered signal" path runs
+ * `process.kill(childPid, SIGHUP)` against a live process that is NOT the test
+ * runner (signalling `process.pid` would SIGHUP-kill the test process itself).
+ * The child's default SIGHUP action terminates it — fine; `process.kill` still
+ * returns success because the process existed at signal time.
+ */
+function spawnSignalTarget(): { pid: number; kill: () => void } {
+  const child: ChildProcess = spawn("sleep", ["300"], { stdio: "ignore" });
+  const pid = child.pid;
+  if (pid === undefined) throw new Error("failed to spawn signal target");
+  return {
+    pid,
+    kill: () => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already gone (e.g. our SIGHUP terminated it) — nothing to clean up.
+      }
+    },
+  };
+}
+
+let pidConfigCounter = 0;
+function seedConfigWithPidFile(pid: number): {
+  cfg: string;
+  configPath: string;
+  restore: () => void;
+} {
+  const cfg = mkdtempSync(join(tmpdir(), "f3-pid-"));
+  // UNIQUE config basename per call — `pidFileFor` keys on the (canonicalized)
+  // basename, so a shared name would collide on one PID file across tests AND
+  // could clash with a real daemon's `cortex-cortex.pid`. The agents.d/ dir is
+  // resolved from the config DIRECTORY, so the filename is free to vary.
+  const base = `cortex-pidtest-${process.pid}-${pidConfigCounter++}`;
+  const configPath = join(cfg, `${base}.yaml`);
+  // seedConfigDir writes its own cortex.yaml placeholder + agents.d/; we only
+  // need the agents.d/ tree (resolved from the config dir), so reuse it then
+  // point --config at our uniquely-named file (same dir).
+  seedConfigDir(cfg, VALID_DIR);
+  writeFileSync(configPath, "agents: []\n");
+  const pidFile = pidFileFor(configPath);
+  mkdirSync(join(pidFile, ".."), { recursive: true });
+  writeFileSync(pidFile, String(pid));
+  return {
+    cfg,
+    configPath,
+    restore: () => {
+      if (existsSync(pidFile)) unlinkSync(pidFile);
+      rmSync(cfg, { recursive: true, force: true });
+    },
+  };
 }

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -2,13 +2,17 @@
 /**
  * F-3 — `cortex agents <subcommand>` CLI.
  *
- * Validation-only CLI for inspecting and validating `agents.d/` fragments
- * against the cortex schema. Wraps F-2's `loadAgentsDirectory()`. Does NOT
- * talk to a running cortex daemon in v1 — daemon-IPC is a follow-up that
- * waits for cortex.ts integration of `AgentsDirectoryWatcher`.
+ * Inspects + validates `agents.d/` fragments against the cortex schema (wraps
+ * F-2's `loadAgentsDirectory()`), and — B-0 (cortex#1021) — SIGNALS the running
+ * daemon to reload after a successful validation. `reload` resolves the daemon
+ * PID file from `--config` and sends SIGHUP, which the daemon routes to the
+ * same agents.d/ reconcile its fs.watch watcher uses (registry swap + review-
+ * consumer reconcile + capability re-publish). `--validate-only` keeps the
+ * legacy validation-only behaviour; `--fragment` (single-file) is always
+ * validation-only. Presence adapters are restart-only (documented limitation).
  *
  * Usage:
- *   bun src/cli/cortex/commands/agents.ts reload [--config <path>] [--fragment <path>] [--json]
+ *   bun src/cli/cortex/commands/agents.ts reload [--config <path>] [--fragment <path>] [--validate-only] [--json]
  *   bun src/cli/cortex/commands/agents.ts list   [--config <path>] [--json]
  *   bun src/cli/cortex/commands/agents.ts --help
  *
@@ -18,9 +22,10 @@
  *   2  — usage error (bad flags, missing files, unknown subcommand)
  */
 
-import { existsSync, statSync } from "fs";
+import { existsSync, statSync, readFileSync } from "fs";
 import { dirname } from "path";
 
+import { pidFileFor } from "../../../common/pidfile";
 import { CliArgsError } from "./_shared/arg-error";
 import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
 import { type ExitResult } from "./_shared/exit-result";
@@ -45,6 +50,14 @@ export interface ParsedAgentsArgs {
   fragment: string | undefined;
   json: boolean;
   help: boolean;
+  /**
+   * B-0 (cortex#1021) — when set, `reload` only VALIDATES the fragments and
+   * does NOT signal the running daemon. Default behaviour now validates AND
+   * sends SIGHUP to the daemon (resolved from the `--config` PID file) so the
+   * live registry / review consumers / capability registry reload — the same
+   * path the daemon's fs.watch + `reloadAgents()` use.
+   */
+  validateOnly: boolean;
 }
 
 // ExitResult moved to `_shared/exit-result.ts` (cortex#65). Importing
@@ -71,7 +84,13 @@ export const AgentsArgsError = CliArgsError;
 const AGENTS_SPEC: SubcommandSpec<"reload" | "list"> = {
   cliName: "agents",
   subcommands: {
-    reload: { flags: { "--config": "value", "--fragment": "value" } },
+    reload: {
+      flags: {
+        "--config": "value",
+        "--fragment": "value",
+        "--validate-only": "bool",
+      },
+    },
     list: { flags: { "--config": "value" } },
   },
   universal: { "--help": "bool", "-h": "bool", "--json": "bool" },
@@ -97,6 +116,7 @@ export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
     fragment: valueFlag(parsed.flags, "--fragment"),
     json: boolFlag(parsed.flags, "--json"),
     help: parsed.help,
+    validateOnly: boolFlag(parsed.flags, "--validate-only"),
   };
 }
 
@@ -121,20 +141,27 @@ export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
 
   try {
     const agents = loadAgentsDirectory(agentsDir);
+    // B-0 (cortex#1021) — validation succeeded. Unless `--validate-only`, signal
+    // the running daemon (SIGHUP) so it reloads the live registry / review
+    // consumers / capability registry via the SAME reconcile path its fs.watch
+    // and `reloadAgents()` use. A missing PID file means no daemon is running —
+    // we report that but keep exit 0 (validation passed; nothing to signal).
+    const signal = args.validateOnly ? null : signalDaemonReload(args.config);
+
     if (args.json) {
       return { exitCode: 0, stdout: jsonOk(agents), stderr: "" };
     }
+    const footer = reloadFooter(agents.length, signal);
     if (agents.length === 0) {
       return {
         exitCode: 0,
-        stdout: `0 fragments in ${agentsDir} — nothing to load (OK)\n\n${VALIDATION_ONLY_NOTE}\n`,
+        stdout: `0 fragments in ${agentsDir} — nothing to load (OK)\n\n${footer}\n`,
         stderr: "",
       };
     }
     return {
       exitCode: 0,
-      stdout:
-        agents.map(formatAgentLine).join("\n") + "\n\n" + successFooter(agents.length),
+      stdout: agents.map(formatAgentLine).join("\n") + "\n\n" + footer + "\n",
       stderr: "",
     };
   } catch (err) {
@@ -147,6 +174,65 @@ export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
       stderr: `cortex agents reload: unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
     };
   }
+}
+
+/**
+ * B-0 (cortex#1021) — outcome of attempting to signal the running daemon.
+ *   - `{ signalled: true, pid }`   — SIGHUP delivered; the daemon will reload.
+ *   - `{ signalled: false, reason }`— no daemon (missing/stale PID file) or the
+ *                                     signal failed; validation still passed.
+ */
+type SignalOutcome =
+  | { signalled: true; pid: number }
+  | { signalled: false; reason: string };
+
+/**
+ * Resolve the daemon PID file for `configPath` and send SIGHUP, which the
+ * daemon routes to its agents.d/ reload reconcile. The agents CLI's default
+ * config is `~/.config/cortex/cortex.yaml` (NOT the legacy grove default
+ * `pidFileFor` collapses to), so when `--config` is absent we resolve the PID
+ * file against the explicit cortex default path rather than the unspecified
+ * branch — this keeps the CLI pointed at the cortex-shaped daemon.
+ */
+function signalDaemonReload(configPath: string | undefined): SignalOutcome {
+  const resolvedConfig = expandTilde(configPath ?? DEFAULT_CONFIG_PATH);
+  const pidFile = pidFileFor(resolvedConfig);
+  if (!existsSync(pidFile)) {
+    return { signalled: false, reason: `no running daemon (no PID file at ${pidFile})` };
+  }
+  const raw = readFileSync(pidFile, "utf-8").trim();
+  const pid = Number.parseInt(raw, 10);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return { signalled: false, reason: `PID file ${pidFile} is malformed ("${raw}")` };
+  }
+  try {
+    process.kill(pid, "SIGHUP");
+    return { signalled: true, pid };
+  } catch (err) {
+    // ESRCH (process gone) or EPERM — surface but don't fail the validation.
+    return {
+      signalled: false,
+      reason: `could not signal PID ${pid}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/** Compose the reload footer reflecting validation + the daemon-signal result. */
+function reloadFooter(n: number, signal: SignalOutcome | null): string {
+  const summary = `${n} fragment${n === 1 ? "" : "s"} loaded OK`;
+  if (signal === null) {
+    // --validate-only
+    return `${summary}\n${VALIDATION_ONLY_NOTE}`;
+  }
+  if (signal.signalled) {
+    return (
+      `${summary}\n` +
+      `signalled running daemon (PID ${signal.pid}, SIGHUP) — registry, review consumers, ` +
+      `and capability registry reload live.\n` +
+      `note: presence (Discord/Mattermost/Slack) changes for added/removed agents require a daemon restart.`
+    );
+  }
+  return `${summary}\nvalidation OK; daemon NOT signalled — ${signal.reason}`;
 }
 
 /**
@@ -314,12 +400,12 @@ export function dispatchAgents(argv: string[]): ExitResult {
 // =============================================================================
 
 /**
- * Validation-only caveat appended to success output so arc lifecycle scripts
- * (and principals reading stdout) don't infer "the running daemon reloaded."
- * Echo M3 on cortex#63.
+ * Validation-only caveat appended to success output for paths that do NOT
+ * signal the daemon — `--validate-only` and the single-file `--fragment`
+ * check. The default `reload` path DOES signal (SIGHUP) and uses `reloadFooter`.
  */
 const VALIDATION_ONLY_NOTE =
-  "note: validation-only — this CLI does NOT signal a running cortex daemon to reload (v1).";
+  "note: validation-only — the running cortex daemon was NOT signalled to reload.";
 
 function successFooter(n: number): string {
   const summary = `${n} fragment${n === 1 ? "" : "s"} loaded OK`;
@@ -451,20 +537,26 @@ Exit codes:
 }
 
 function reloadHelp(): string {
-  return `cortex agents reload — validate agents.d/ fragments
+  return `cortex agents reload — validate agents.d/ fragments + reload the daemon
 
 Usage:
-  cortex agents reload [--config <path>] [--fragment <path>] [--json]
+  cortex agents reload [--config <path>] [--fragment <path>] [--validate-only] [--json]
 
 Options:
   --config <path>      cortex.yaml path (default: ~/.config/cortex/cortex.yaml)
-                       The agents.d/ directory next to this file is loaded.
-  --fragment <path>    Validate a single fragment file (overrides --config dir mode)
+                       The agents.d/ directory next to this file is loaded; the
+                       daemon's PID file is resolved from the same path.
+  --fragment <path>    Validate a single fragment file (overrides --config dir mode).
+                       Validation-only — does not signal the daemon.
+  --validate-only      Validate the agents.d/ directory but do NOT signal the daemon.
   --json               Emit structured JSON
 
-In v1, this command is validation-only. It does NOT signal a running cortex
-daemon to reload — that wiring lands when cortex.ts integrates the
-AgentsDirectoryWatcher (separate follow-up).
+By default this validates the agents.d/ fragments and then sends SIGHUP to the
+running cortex daemon (resolved from the --config PID file), which reloads the
+live agent registry, review consumers, and capability registry via the same
+reconcile path the daemon's fs.watch + 'reloadAgents()' use. Presence adapter
+(Discord/Mattermost/Slack) changes for added/removed agents require a daemon
+restart (registry + review + capabilities reload live; presence is restart-only).
 `;
 }
 

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -535,9 +535,9 @@ function jsonOk(agents: Agent[], data?: Record<string, string>): string {
 /**
  * Sage cortex#1027 — success-side `data` describing the runtime-signal outcome,
  * so JSON consumers can tell apart "reload signal delivered" from "no runtime to
- * signal" from "validation-only". Returns undefined for `--validate-only` (no
- * signal attempted), keeping the envelope free of signal fields when there was
- * nothing to report.
+ * signal" from "validation-only". For `--validate-only` (signal === null, no
+ * signal attempted) returns `{ signalled: "false", reason: "validate-only" }`
+ * so the JSON contract always carries an explicit signal outcome.
  */
 function signalData(
   signal: SignalOutcome | null,

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -4,10 +4,12 @@
  *
  * Inspects + validates `agents.d/` fragments against the cortex schema (wraps
  * F-2's `loadAgentsDirectory()`), and — B-0 (cortex#1021) — SIGNALS the running
- * daemon to reload after a successful validation. `reload` resolves the daemon
- * PID file from `--config` and sends SIGHUP, which the daemon routes to the
- * same agents.d/ reconcile its fs.watch watcher uses (registry swap + review-
- * consumer reconcile + capability re-publish). `--validate-only` keeps the
+ * cortex runtime to reload after a successful validation. `reload` resolves the
+ * runtime's PID file from `--config` and sends SIGHUP, which the runtime routes
+ * to the same agents.d/ reconcile its fs.watch watcher uses (registry swap +
+ * review-consumer reconcile + capability re-publish). The signal is delivered
+ * synchronously; the reload is applied asynchronously (Sage cortex#1027 — the CLI
+ * reports "signal delivered", not "reload applied"). `--validate-only` keeps the
  * legacy validation-only behaviour; `--fragment` (single-file) is always
  * validation-only. Presence adapters are restart-only (documented limitation).
  *
@@ -52,10 +54,10 @@ export interface ParsedAgentsArgs {
   help: boolean;
   /**
    * B-0 (cortex#1021) — when set, `reload` only VALIDATES the fragments and
-   * does NOT signal the running daemon. Default behaviour now validates AND
-   * sends SIGHUP to the daemon (resolved from the `--config` PID file) so the
-   * live registry / review consumers / capability registry reload — the same
-   * path the daemon's fs.watch + `reloadAgents()` use.
+   * does NOT signal the running cortex runtime. Default behaviour now validates
+   * AND sends SIGHUP to the runtime (resolved from the `--config` PID file) so
+   * the live registry / review consumers / capability registry reload — the same
+   * path the runtime's fs.watch + `reloadAgents()` use.
    */
   validateOnly: boolean;
 }
@@ -142,25 +144,56 @@ export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
   try {
     const agents = loadAgentsDirectory(agentsDir);
     // B-0 (cortex#1021) — validation succeeded. Unless `--validate-only`, signal
-    // the running daemon (SIGHUP) so it reloads the live registry / review
+    // the running runtime (SIGHUP) so it reloads the live registry / review
     // consumers / capability registry via the SAME reconcile path its fs.watch
-    // and `reloadAgents()` use. A missing PID file means no daemon is running —
-    // we report that but keep exit 0 (validation passed; nothing to signal).
+    // and `reloadAgents()` use. Sage cortex#1027 — three outcomes, handled below:
+    // a missing PID file is benign (no runtime; exit 0); a DELIVERED signal is
+    // reported as "delivered", NOT "reload applied" (we can't prove the async
+    // reload finished); an ATTEMPTED-but-FAILED signal (stale/malformed PID,
+    // ESRCH/EPERM) is an error → non-zero exit + JSON error.
     const signal = args.validateOnly ? null : signalDaemonReload(args.config);
 
+    // Sage cortex#1027 — a signal that was ATTEMPTED but FAILED is an error for
+    // machine consumers: the reload the caller asked for did NOT happen. Exit
+    // non-zero and emit a JSON error (validation passed, but the operation as a
+    // whole did not). A BENIGN miss (no runtime to signal) or a delivered signal
+    // stays exit 0.
+    const signalFailed = signal !== null && !signal.signalled && !signal.benign;
+
     if (args.json) {
-      return { exitCode: 0, stdout: jsonOk(agents), stderr: "" };
-    }
-    const footer = reloadFooter(agents.length, signal);
-    if (agents.length === 0) {
+      if (signalFailed) {
+        return {
+          exitCode: 1,
+          stdout: renderJson(
+            envelopeError<AgentSummary>(
+              `reload signal failed: ${signal.reason}`,
+              { signalled: "false", validation: "ok" },
+            ),
+          ),
+          stderr: "",
+        };
+      }
+      // Success: carry the signal outcome in `data` so machine consumers can
+      // distinguish "signal delivered" from "no runtime to signal" — and so they
+      // never mistake validation-only success for a completed reload.
       return {
         exitCode: 0,
+        stdout: jsonOk(agents, signalData(signal)),
+        stderr: "",
+      };
+    }
+
+    const footer = reloadFooter(agents.length, signal);
+    const exitCode = signalFailed ? 1 : 0;
+    if (agents.length === 0) {
+      return {
+        exitCode,
         stdout: `0 fragments in ${agentsDir} — nothing to load (OK)\n\n${footer}\n`,
         stderr: "",
       };
     }
     return {
-      exitCode: 0,
+      exitCode,
       stdout: agents.map(formatAgentLine).join("\n") + "\n\n" + footer + "\n",
       stderr: "",
     };
@@ -177,47 +210,96 @@ export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
 }
 
 /**
- * B-0 (cortex#1021) — outcome of attempting to signal the running daemon.
- *   - `{ signalled: true, pid }`   — SIGHUP delivered; the daemon will reload.
- *   - `{ signalled: false, reason }`— no daemon (missing/stale PID file) or the
- *                                     signal failed; validation still passed.
+ * B-0 (cortex#1021; Sage cortex#1027 honesty fix) — outcome of attempting to
+ * signal the running runtime.
+ *
+ * Three distinct states (the middle two are NOT the same — Sage cortex#1027):
+ *   - `signalled: true`            — SIGHUP DELIVERED to a live PID. This proves
+ *                                    the signal was SENT, NOT that the runtime
+ *                                    finished (or even began) reloading. We never
+ *                                    claim "reload applied" — only "signal
+ *                                    delivered; reload happens asynchronously".
+ *   - `signalled: false, benign`   — no runtime to signal (no PID file). Nothing
+ *                                    was attempted; validation passed → exit 0.
+ *   - `signalled: false, failed`   — we ATTEMPTED to signal but it failed (stale
+ *                                    PID file vanished mid-read, malformed PID,
+ *                                    ESRCH/EPERM from kill). This is an ERROR for
+ *                                    machine consumers → non-zero exit + JSON
+ *                                    error. The validation still passed, but the
+ *                                    reload the caller asked for did NOT happen.
  */
 type SignalOutcome =
   | { signalled: true; pid: number }
-  | { signalled: false; reason: string };
+  | { signalled: false; benign: true; reason: string }
+  | { signalled: false; benign: false; reason: string };
 
 /**
- * Resolve the daemon PID file for `configPath` and send SIGHUP, which the
- * daemon routes to its agents.d/ reload reconcile. The agents CLI's default
- * config is `~/.config/cortex/cortex.yaml` (NOT the legacy grove default
- * `pidFileFor` collapses to), so when `--config` is absent we resolve the PID
- * file against the explicit cortex default path rather than the unspecified
- * branch — this keeps the CLI pointed at the cortex-shaped daemon.
+ * Resolve the runtime PID file for `configPath` and send SIGHUP, which the
+ * running cortex runtime routes to its agents.d/ reload reconcile. The agents
+ * CLI's default config is `~/.config/cortex/cortex.yaml` (NOT the legacy grove
+ * default `pidFileFor` collapses to), so when `--config` is absent we resolve the
+ * PID file against the explicit cortex default path rather than the unspecified
+ * branch — this keeps the CLI pointed at the cortex-shaped runtime.
+ *
+ * Sage cortex#1027 — the PID-file READ is inside the same non-fatal outcome path
+ * as the signal: if the file disappears or becomes unreadable between the
+ * existence check and the read, we report `signalled: false, failed` rather than
+ * letting `readFileSync` throw out of the reload command as an unexpected error.
  */
 function signalDaemonReload(configPath: string | undefined): SignalOutcome {
   const resolvedConfig = expandTilde(configPath ?? DEFAULT_CONFIG_PATH);
   const pidFile = pidFileFor(resolvedConfig);
   if (!existsSync(pidFile)) {
-    return { signalled: false, reason: `no running daemon (no PID file at ${pidFile})` };
+    // No runtime to signal — benign. Validation passed; nothing to reload.
+    return {
+      signalled: false,
+      benign: true,
+      reason: `no running cortex runtime (no PID file at ${pidFile})`,
+    };
   }
-  const raw = readFileSync(pidFile, "utf-8").trim();
+  let raw: string;
+  try {
+    raw = readFileSync(pidFile, "utf-8").trim();
+  } catch (err) {
+    // Sage cortex#1027 — the PID file vanished or became unreadable between the
+    // existsSync check and this read (a stale/racing runtime shutdown). Treat as
+    // an ATTEMPTED-but-FAILED signal, not an unexpected crash of the command.
+    return {
+      signalled: false,
+      benign: false,
+      reason: `could not read PID file ${pidFile}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
   const pid = Number.parseInt(raw, 10);
   if (!Number.isInteger(pid) || pid <= 0) {
-    return { signalled: false, reason: `PID file ${pidFile} is malformed ("${raw}")` };
+    return {
+      signalled: false,
+      benign: false,
+      reason: `PID file ${pidFile} is malformed ("${raw}")`,
+    };
   }
   try {
     process.kill(pid, "SIGHUP");
     return { signalled: true, pid };
   } catch (err) {
-    // ESRCH (process gone) or EPERM — surface but don't fail the validation.
+    // ESRCH (process gone — stale PID) or EPERM (not ours). We attempted the
+    // signal and it failed → non-benign. The reload did NOT happen.
     return {
       signalled: false,
+      benign: false,
       reason: `could not signal PID ${pid}: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
 }
 
-/** Compose the reload footer reflecting validation + the daemon-signal result. */
+/**
+ * Compose the reload footer reflecting validation + the runtime-signal result.
+ *
+ * Sage cortex#1027 — HONEST wording. A delivered SIGHUP proves the signal was
+ * SENT, not that the runtime reloaded. We say "reload signal delivered" and tell
+ * the principal where to confirm the reload actually applied (runtime logs /
+ * generation bump), instead of asserting "reload live".
+ */
 function reloadFooter(n: number, signal: SignalOutcome | null): string {
   const summary = `${n} fragment${n === 1 ? "" : "s"} loaded OK`;
   if (signal === null) {
@@ -227,12 +309,18 @@ function reloadFooter(n: number, signal: SignalOutcome | null): string {
   if (signal.signalled) {
     return (
       `${summary}\n` +
-      `signalled running daemon (PID ${signal.pid}, SIGHUP) — registry, review consumers, ` +
-      `and capability registry reload live.\n` +
-      `note: presence (Discord/Mattermost/Slack) changes for added/removed agents require a daemon restart.`
+      `reload signal delivered to running cortex runtime (PID ${signal.pid}, SIGHUP). ` +
+      `The runtime applies the reload asynchronously — confirm via the runtime logs ` +
+      `(look for "agents-reload … generation N").\n` +
+      `note: presence (Discord/Mattermost/Slack) changes for added/removed agents require a runtime restart.`
     );
   }
-  return `${summary}\nvalidation OK; daemon NOT signalled — ${signal.reason}`;
+  if (signal.benign) {
+    // No runtime present — nothing to signal. Validation still passed.
+    return `${summary}\nvalidation OK; no reload signal sent — ${signal.reason}`;
+  }
+  // Attempted-but-failed signal — surface as a problem the principal must act on.
+  return `${summary}\nvalidation OK, but the reload signal FAILED — ${signal.reason}`;
 }
 
 /**
@@ -401,11 +489,11 @@ export function dispatchAgents(argv: string[]): ExitResult {
 
 /**
  * Validation-only caveat appended to success output for paths that do NOT
- * signal the daemon — `--validate-only` and the single-file `--fragment`
+ * signal the cortex runtime — `--validate-only` and the single-file `--fragment`
  * check. The default `reload` path DOES signal (SIGHUP) and uses `reloadFooter`.
  */
 const VALIDATION_ONLY_NOTE =
-  "note: validation-only — the running cortex daemon was NOT signalled to reload.";
+  "note: validation-only — the running cortex runtime was NOT signalled to reload.";
 
 function successFooter(n: number): string {
   const summary = `${n} fragment${n === 1 ? "" : "s"} loaded OK`;
@@ -430,8 +518,29 @@ function successFooter(n: number): string {
  */
 export type AgentSummary = ReturnType<typeof summarizeAgent>;
 
-function jsonOk(agents: Agent[]): string {
-  return renderJson(envelopeOk<AgentSummary>(agents.map(summarizeAgent)));
+function jsonOk(agents: Agent[], data?: Record<string, string>): string {
+  return renderJson(envelopeOk<AgentSummary>(agents.map(summarizeAgent), data));
+}
+
+/**
+ * Sage cortex#1027 — success-side `data` describing the runtime-signal outcome,
+ * so JSON consumers can tell apart "reload signal delivered" from "no runtime to
+ * signal" from "validation-only". Returns undefined for `--validate-only` (no
+ * signal attempted), keeping the envelope free of signal fields when there was
+ * nothing to report.
+ */
+function signalData(
+  signal: SignalOutcome | null,
+): Record<string, string> | undefined {
+  if (signal === null) {
+    return { signalled: "false", reason: "validate-only" };
+  }
+  if (signal.signalled) {
+    // "signalled" — the SIGHUP was delivered. NOT a reload-applied claim.
+    return { signalled: "true", pid: String(signal.pid) };
+  }
+  // benign miss (no runtime present)
+  return { signalled: "false", reason: signal.reason };
 }
 
 function jsonOrTextError(
@@ -537,7 +646,7 @@ Exit codes:
 }
 
 function reloadHelp(): string {
-  return `cortex agents reload — validate agents.d/ fragments + reload the daemon
+  return `cortex agents reload — validate agents.d/ fragments + reload the cortex runtime
 
 Usage:
   cortex agents reload [--config <path>] [--fragment <path>] [--validate-only] [--json]
@@ -545,18 +654,20 @@ Usage:
 Options:
   --config <path>      cortex.yaml path (default: ~/.config/cortex/cortex.yaml)
                        The agents.d/ directory next to this file is loaded; the
-                       daemon's PID file is resolved from the same path.
+                       runtime's PID file is resolved from the same path.
   --fragment <path>    Validate a single fragment file (overrides --config dir mode).
-                       Validation-only — does not signal the daemon.
-  --validate-only      Validate the agents.d/ directory but do NOT signal the daemon.
+                       Validation-only — does not signal the cortex runtime.
+  --validate-only      Validate the agents.d/ directory but do NOT signal the cortex runtime.
   --json               Emit structured JSON
 
 By default this validates the agents.d/ fragments and then sends SIGHUP to the
-running cortex daemon (resolved from the --config PID file), which reloads the
-live agent registry, review consumers, and capability registry via the same
-reconcile path the daemon's fs.watch + 'reloadAgents()' use. Presence adapter
-(Discord/Mattermost/Slack) changes for added/removed agents require a daemon
-restart (registry + review + capabilities reload live; presence is restart-only).
+running cortex runtime (resolved from the --config PID file). The runtime then
+reloads its live agent registry, review consumers, and capability registry via
+the same reconcile path its fs.watch + 'reloadAgents()' use. The signal is
+delivered synchronously; the reload itself is applied asynchronously — confirm
+it landed via the runtime logs. Presence adapter (Discord/Mattermost/Slack)
+changes for added/removed agents require a runtime restart (registry + review +
+capabilities reload live; presence is restart-only).
 `;
 }
 

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -270,8 +270,18 @@ function signalDaemonReload(configPath: string | undefined): SignalOutcome {
       reason: `could not read PID file ${pidFile}: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
-  const pid = Number.parseInt(raw, 10);
-  if (!Number.isInteger(pid) || pid <= 0) {
+  // Full-string numeric check (sage round 2): parseInt("123abc") === 123
+  // would SIGHUP an unintended process instead of flagging the file.
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return {
+      signalled: false,
+      benign: false,
+      reason: `PID file ${pidFile} is malformed ("${raw}")`,
+    };
+  }
+  const pid = Number(trimmed);
+  if (pid <= 0) {
     return {
       signalled: false,
       benign: false,

--- a/src/cli/cortex/commands/offer.ts
+++ b/src/cli/cortex/commands/offer.ts
@@ -81,6 +81,7 @@ import { homedir } from "os";
 import YAML from "yaml";
 
 import { composeRawConfig } from "../../../common/config/loader";
+import { deriveEffectiveCapabilityCatalog } from "../../../common/agents/capability-catalog";
 import {
   type AcceptPolicy,
   type Offering,
@@ -1336,8 +1337,15 @@ function runList(
     return opError("list", `config failed CortexConfigSchema — cannot list offerings.\n  ${parsed.error.message}`, json);
   }
   const cfg = parsed.data;
+  // EFFECTIVE catalog: explicit entries pass through authoritative; agents
+  // declaring capabilities nobody catalogued get synthesized entries
+  // (cortex#1021 B-0 — kills the manual capabilities[] cross-edit).
+  const effectiveCatalog = deriveEffectiveCapabilityCatalog(
+    cfg.capabilities,
+    cfg.agents ?? [],
+  );
   const rows = buildListRows(
-    cfg.capabilities.map((c) => ({ id: c.id, provided_by: c.provided_by })),
+    effectiveCatalog.map((c) => ({ id: c.id, provided_by: c.provided_by })),
     cfg.policy?.offerings,
   );
 

--- a/src/common/agents/__tests__/capability-catalog.test.ts
+++ b/src/common/agents/__tests__/capability-catalog.test.ts
@@ -2,7 +2,9 @@
  * B-0 (cortex#1021) — effective capability catalog derivation tests.
  *
  * Covers `deriveEffectiveCapabilityCatalog`:
- *   - explicit entries augmented with derived providers (union, stable order)
+ *   - explicit entries are AUTHORITATIVE — passed through unchanged; a fragment
+ *     declaring a catalogued capability does NOT self-grant into provided_by[]
+ *     (Sage cortex#1027 authorization fix)
  *   - declaration-only capabilities synthesized (id + providers, empty desc)
  *   - backwards compat: a complete catalog derives byte-identically (no-op)
  *   - dedup of repeated providers; multi-agent providers ordered by declaration
@@ -72,9 +74,12 @@ describe("deriveEffectiveCapabilityCatalog", () => {
     ]);
   });
 
-  test("explicit entry is augmented with a derived provider not already listed", () => {
-    // Explicit entry lists luna; echo ALSO declares the capability → echo is
-    // appended to provided_by (union, explicit first).
+  test("SECURITY (Sage cortex#1027) — a fragment declaring a catalogued capability does NOT self-grant into provided_by[]", () => {
+    // Explicit entry lists ONLY luna as an authorized provider. echo declares
+    // the same capability in its runtime.capabilities[] — but the explicit
+    // catalog is an authoritative allow-list, so echo MUST NOT appear. Letting
+    // it would be a capability-authorization bypass: any agents.d fragment could
+    // self-grant a restricted capability by merely declaring it.
     const explicit = [cap("code-review.typescript", ["luna"])];
     const agents = [
       agentFixture("luna", ["code-review.typescript"]),
@@ -83,22 +88,33 @@ describe("deriveEffectiveCapabilityCatalog", () => {
     const result = deriveEffectiveCapabilityCatalog(explicit, agents);
     expect(result).toHaveLength(1);
     expect(result[0]?.id).toBe("code-review.typescript");
-    expect(result[0]?.provided_by).toEqual(["luna", "echo"]);
+    // echo is REJECTED — only the explicitly-granted luna provides it.
+    expect(result[0]?.provided_by).toEqual(["luna"]);
+    // The explicit entry is passed through unchanged (reference-equal).
+    expect(result[0]).toBe(explicit[0]);
     // Description/tags from the explicit entry are preserved.
     expect(result[0]?.description).toBe("explicit");
+  });
+
+  test("explicit entry is authoritative — passed through unchanged even when no agent declares it", () => {
+    // An explicit grant stands on its own; derivation never rewrites it.
+    const explicit = [cap("code-review.typescript", ["luna", "echo"])];
+    const agents = [agentFixture("luna", ["code-review.typescript"])];
+    const result = deriveEffectiveCapabilityCatalog(explicit, agents);
+    expect(result).toEqual(explicit);
+    expect(result[0]).toBe(explicit[0]);
   });
 
   test("backwards compat — a catalog that already lists every provider derives identically (no-op)", () => {
     const explicit = [cap("code-review.typescript", ["luna"])];
     const agents = [agentFixture("luna", ["code-review.typescript"])];
     const result = deriveEffectiveCapabilityCatalog(explicit, agents);
-    // Same shape; the entry object is returned unchanged (reference-equal) when
-    // the provider list didn't grow.
+    // Same shape; the entry object is returned unchanged (reference-equal).
     expect(result).toEqual(explicit);
     expect(result[0]).toBe(explicit[0]);
   });
 
-  test("mixed: explicit (augmented) + declaration-only (synthesized) in stable order", () => {
+  test("mixed: explicit (authoritative) + declaration-only (synthesized) in stable order", () => {
     const explicit = [cap("code-review.typescript", ["luna"], "review TS")];
     const agents = [
       agentFixture("luna", ["code-review.typescript", "deploy.k8s"]),
@@ -110,10 +126,12 @@ describe("deriveEffectiveCapabilityCatalog", () => {
       "code-review.typescript",
       "deploy.k8s",
     ]);
-    // code-review.typescript: explicit luna, no new derived (luna already there)
+    // code-review.typescript: explicit and authoritative — luna only, unchanged.
     expect(result[0]?.provided_by).toEqual(["luna"]);
     expect(result[0]?.description).toBe("review TS");
-    // deploy.k8s: synthesized; providers in agent-declaration order (luna, echo)
+    // deploy.k8s: UNCATALOGUED → synthesized; providers in agent-declaration
+    // order (luna, echo). Derivation only adds providers where there is no
+    // explicit grant to honor.
     expect(result[1]?.provided_by).toEqual(["luna", "echo"]);
     expect(result[1]?.description).toBe("");
   });

--- a/src/common/agents/__tests__/capability-catalog.test.ts
+++ b/src/common/agents/__tests__/capability-catalog.test.ts
@@ -1,0 +1,148 @@
+/**
+ * B-0 (cortex#1021) — effective capability catalog derivation tests.
+ *
+ * Covers `deriveEffectiveCapabilityCatalog`:
+ *   - explicit entries augmented with derived providers (union, stable order)
+ *   - declaration-only capabilities synthesized (id + providers, empty desc)
+ *   - backwards compat: a complete catalog derives byte-identically (no-op)
+ *   - dedup of repeated providers; multi-agent providers ordered by declaration
+ *   - inputs are never mutated
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import { deriveEffectiveCapabilityCatalog } from "../capability-catalog";
+import type { Agent } from "../../types/cortex-config";
+import type { Capability } from "../../types/capability";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function agentFixture(
+  id: string,
+  capabilities: string[] = [],
+): Agent {
+  return {
+    id,
+    displayName: id,
+    persona: `./personas/${id}.md`,
+    trust: [],
+    presence: {},
+    ...(capabilities.length > 0 && {
+      runtime: {
+        substrate: "claude-code",
+        mode: "in-process",
+        capabilities,
+      },
+    }),
+  } as Agent;
+}
+
+function cap(
+  id: string,
+  provided_by: string[],
+  description = "explicit",
+): Capability {
+  return { id, description, tags: [], provided_by };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("deriveEffectiveCapabilityCatalog", () => {
+  test("empty catalog + no agent capabilities → empty result", () => {
+    expect(deriveEffectiveCapabilityCatalog([], [])).toEqual([]);
+    expect(deriveEffectiveCapabilityCatalog([], [agentFixture("luna")])).toEqual(
+      [],
+    );
+  });
+
+  test("declaration-only capability is synthesized with the declaring agent as provider", () => {
+    const agents = [agentFixture("luna", ["code-review.typescript"])];
+    const result = deriveEffectiveCapabilityCatalog([], agents);
+    expect(result).toEqual([
+      {
+        id: "code-review.typescript",
+        description: "",
+        tags: [],
+        provided_by: ["luna"],
+      },
+    ]);
+  });
+
+  test("explicit entry is augmented with a derived provider not already listed", () => {
+    // Explicit entry lists luna; echo ALSO declares the capability → echo is
+    // appended to provided_by (union, explicit first).
+    const explicit = [cap("code-review.typescript", ["luna"])];
+    const agents = [
+      agentFixture("luna", ["code-review.typescript"]),
+      agentFixture("echo", ["code-review.typescript"]),
+    ];
+    const result = deriveEffectiveCapabilityCatalog(explicit, agents);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("code-review.typescript");
+    expect(result[0]?.provided_by).toEqual(["luna", "echo"]);
+    // Description/tags from the explicit entry are preserved.
+    expect(result[0]?.description).toBe("explicit");
+  });
+
+  test("backwards compat — a catalog that already lists every provider derives identically (no-op)", () => {
+    const explicit = [cap("code-review.typescript", ["luna"])];
+    const agents = [agentFixture("luna", ["code-review.typescript"])];
+    const result = deriveEffectiveCapabilityCatalog(explicit, agents);
+    // Same shape; the entry object is returned unchanged (reference-equal) when
+    // the provider list didn't grow.
+    expect(result).toEqual(explicit);
+    expect(result[0]).toBe(explicit[0]);
+  });
+
+  test("mixed: explicit (augmented) + declaration-only (synthesized) in stable order", () => {
+    const explicit = [cap("code-review.typescript", ["luna"], "review TS")];
+    const agents = [
+      agentFixture("luna", ["code-review.typescript", "deploy.k8s"]),
+      agentFixture("echo", ["deploy.k8s"]),
+    ];
+    const result = deriveEffectiveCapabilityCatalog(explicit, agents);
+    // Explicit entries first (in declared order), then synthesized.
+    expect(result.map((c) => c.id)).toEqual([
+      "code-review.typescript",
+      "deploy.k8s",
+    ]);
+    // code-review.typescript: explicit luna, no new derived (luna already there)
+    expect(result[0]?.provided_by).toEqual(["luna"]);
+    expect(result[0]?.description).toBe("review TS");
+    // deploy.k8s: synthesized; providers in agent-declaration order (luna, echo)
+    expect(result[1]?.provided_by).toEqual(["luna", "echo"]);
+    expect(result[1]?.description).toBe("");
+  });
+
+  test("duplicate declarations of the same capability by one agent dedup to a single provider entry", () => {
+    const agents = [agentFixture("luna", ["x.cap", "x.cap"])];
+    const result = deriveEffectiveCapabilityCatalog([], agents);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.provided_by).toEqual(["luna"]);
+  });
+
+  test("multi-agent providers for one synthesized capability are ordered by first-seen agent", () => {
+    const agents = [
+      agentFixture("zeta", ["shared.cap"]),
+      agentFixture("alpha", ["shared.cap"]),
+    ];
+    const result = deriveEffectiveCapabilityCatalog([], agents);
+    expect(result[0]?.provided_by).toEqual(["zeta", "alpha"]);
+  });
+
+  test("does not mutate the inputs", () => {
+    const explicit = [cap("code-review.typescript", ["luna"])];
+    const explicitSnapshot = JSON.parse(JSON.stringify(explicit));
+    const agents = [
+      agentFixture("luna", ["code-review.typescript"]),
+      agentFixture("echo", ["code-review.typescript"]),
+    ];
+    deriveEffectiveCapabilityCatalog(explicit, agents);
+    expect(explicit).toEqual(explicitSnapshot);
+    expect(explicit[0]?.provided_by).toEqual(["luna"]);
+  });
+});

--- a/src/common/agents/capability-catalog.ts
+++ b/src/common/agents/capability-catalog.ts
@@ -1,0 +1,136 @@
+/**
+ * B-0 (cortex#1021, design-bot-packs §7 + §11) — effective capability catalog.
+ *
+ * Today a principal who adds an agent declaring `runtime.capabilities: [X]`
+ * must ALSO hand-edit the top-level `capabilities[]` block to add an entry for
+ * `X` listing that agent in `provided_by[]`. That manual cross-edit is the
+ * "step 3" the bot-packs design kills: an agent declaring a capability IS, by
+ * declaration, a provider of it.
+ *
+ * This module derives the EFFECTIVE catalog from two inputs:
+ *
+ *   1. the explicit top-level `capabilities[]` entries (authored for their
+ *      description / tags / rate / cost / explicit provider lists), and
+ *   2. the per-agent `runtime.capabilities[]` declarations (each declaring
+ *      its owning agent as a provider of that capability id).
+ *
+ * The derivation:
+ *   - augments each explicit entry's `provided_by[]` with every agent that
+ *     declares the capability (union, dedup, stable order: explicit providers
+ *     first in their declared order, then newly-derived providers in agent
+ *     declaration order);
+ *   - synthesizes a catalog entry for any capability id that ONLY exists via
+ *     agent declaration (no explicit entry) — id + derived `provided_by[]` +
+ *     empty description + empty tags, no rate/cost.
+ *
+ * Backwards compatibility: a config whose explicit `capabilities[]` already
+ * lists every provider derives an IDENTICAL catalog (the derived providers are
+ * already present, so the union is a no-op). Existing configs stay valid and
+ * equivalent.
+ *
+ * This is pure derivation over already-parsed structures — it performs NO
+ * validation. The cross-validator on `CortexConfigSchema` still rejects an
+ * EXPLICIT `provided_by[]` entry that names a nonexistent agent (a typo guard);
+ * derived providers can only ever be real agent ids because they come from the
+ * agent list itself.
+ */
+
+import type { Agent } from "../types/cortex-config";
+import type { Capability } from "../types/capability";
+
+/**
+ * Derive the effective capability catalog from the explicit catalog plus the
+ * agents' `runtime.capabilities[]` declarations.
+ *
+ * @param explicit  the top-level `capabilities[]` block (may be empty).
+ * @param agents    the merged agent set (inline + fragments).
+ * @returns a new array; inputs are not mutated. Order: explicit entries first
+ *          (in their declared order, each with an augmented `provided_by[]`),
+ *          then synthesized entries for capabilities that exist only via agent
+ *          declaration (in first-seen agent-declaration order).
+ */
+export function deriveEffectiveCapabilityCatalog(
+  explicit: readonly Capability[],
+  agents: readonly Agent[],
+): Capability[] {
+  // capability id -> ordered, de-duplicated list of agent ids that declare it
+  // via runtime.capabilities[]. First-seen order across the agent list.
+  const derivedProvidersByCap = new Map<string, string[]>();
+  // Track first-seen order of capability ids that appear ONLY via declaration
+  // (used to order synthesized entries deterministically).
+  const declaredCapOrder: string[] = [];
+
+  for (const agent of agents) {
+    const caps = agent.runtime?.capabilities ?? [];
+    for (const capId of caps) {
+      let providers = derivedProvidersByCap.get(capId);
+      if (providers === undefined) {
+        providers = [];
+        derivedProvidersByCap.set(capId, providers);
+        declaredCapOrder.push(capId);
+      }
+      if (!providers.includes(agent.id)) {
+        providers.push(agent.id);
+      }
+    }
+  }
+
+  const explicitIds = new Set(explicit.map((c) => c.id));
+
+  // 1. Augment each explicit entry with derived providers (union, stable).
+  const augmented: Capability[] = explicit.map((cap) => {
+    const derived = derivedProvidersByCap.get(cap.id) ?? [];
+    const merged = unionPreserveOrder(cap.provided_by, derived);
+    // Only allocate a new object when the provider list actually changed —
+    // keeps the no-op (already-complete) config byte-identical.
+    if (merged.length === cap.provided_by.length) {
+      return cap;
+    }
+    return { ...cap, provided_by: merged };
+  });
+
+  // 2. Synthesize entries for declaration-only capabilities.
+  const synthesized: Capability[] = [];
+  for (const capId of declaredCapOrder) {
+    if (explicitIds.has(capId)) continue;
+    const providers = derivedProvidersByCap.get(capId) ?? [];
+    synthesized.push({
+      id: capId,
+      // Synthesized entries carry an empty description (design §11 B-0). The
+      // catalog is still queryable by id + providers; a principal who wants a
+      // human-readable description authors an explicit entry, which then wins
+      // for description/tags while still being augmented with derived providers.
+      description: "",
+      tags: [],
+      provided_by: providers,
+    });
+  }
+
+  return [...augmented, ...synthesized];
+}
+
+/**
+ * Union two ordered string lists, preserving order: every element of `first`
+ * in its order, then every element of `second` not already present, in its
+ * order. De-duplicates within and across both lists.
+ */
+function unionPreserveOrder(
+  first: readonly string[],
+  second: readonly string[],
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of first) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  for (const x of second) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}

--- a/src/common/agents/capability-catalog.ts
+++ b/src/common/agents/capability-catalog.ts
@@ -14,19 +14,30 @@
  *   2. the per-agent `runtime.capabilities[]` declarations (each declaring
  *      its owning agent as a provider of that capability id).
  *
- * The derivation:
- *   - augments each explicit entry's `provided_by[]` with every agent that
- *     declares the capability (union, dedup, stable order: explicit providers
- *     first in their declared order, then newly-derived providers in agent
- *     declaration order);
+ * The derivation (Sage cortex#1027 — explicit `provided_by[]` is AUTHORITATIVE):
+ *   - an EXPLICIT catalog entry's `provided_by[]` is the authoritative grant
+ *     list and is passed through UNCHANGED. A config that catalogues a
+ *     capability has deliberately scoped who may provide it; an agents.d
+ *     fragment MUST NOT self-grant itself into that list by merely declaring
+ *     `runtime.capabilities: [X]`. Letting it would turn `provided_by[]` from an
+ *     explicit allow-list into a self-asserted union before dispatch selects a
+ *     provider — a capability-authorization bypass. So derivation only ever
+ *     ADDS providers where the principal expressed NO explicit grant list:
  *   - synthesizes a catalog entry for any capability id that ONLY exists via
- *     agent declaration (no explicit entry) — id + derived `provided_by[]` +
- *     empty description + empty tags, no rate/cost.
+ *     agent declaration (NO explicit entry) — id + derived `provided_by[]` +
+ *     empty description + empty tags, no rate/cost. This is the "step 3"
+ *     convenience: a brand-new capability nobody catalogued is provided by the
+ *     agents that declare it, because there is no explicit grant to honor.
+ *
+ * Conservative rule, stated once: explicit entry present → derived agents are
+ * IGNORED for that capability (the catalog wins, full stop). Explicit entry
+ * absent → derived agents synthesize the entry. There is no middle "augment an
+ * explicit entry" path — that was the bypass.
  *
  * Backwards compatibility: a config whose explicit `capabilities[]` already
- * lists every provider derives an IDENTICAL catalog (the derived providers are
- * already present, so the union is a no-op). Existing configs stay valid and
- * equivalent.
+ * lists every provider derives an IDENTICAL catalog (explicit entries pass
+ * through unchanged; only declaration-only capabilities synthesize). Existing
+ * configs stay valid and equivalent.
  *
  * This is pure derivation over already-parsed structures — it performs NO
  * validation. The cross-validator on `CortexConfigSchema` still rejects an
@@ -45,9 +56,10 @@ import type { Capability } from "../types/capability";
  * @param explicit  the top-level `capabilities[]` block (may be empty).
  * @param agents    the merged agent set (inline + fragments).
  * @returns a new array; inputs are not mutated. Order: explicit entries first
- *          (in their declared order, each with an augmented `provided_by[]`),
- *          then synthesized entries for capabilities that exist only via agent
- *          declaration (in first-seen agent-declaration order).
+ *          (in their declared order, each with its authoritative `provided_by[]`
+ *          passed through UNCHANGED — Sage cortex#1027), then synthesized
+ *          entries for capabilities that exist only via agent declaration (in
+ *          first-seen agent-declaration order).
  */
 export function deriveEffectiveCapabilityCatalog(
   explicit: readonly Capability[],
@@ -77,17 +89,14 @@ export function deriveEffectiveCapabilityCatalog(
 
   const explicitIds = new Set(explicit.map((c) => c.id));
 
-  // 1. Augment each explicit entry with derived providers (union, stable).
-  const augmented: Capability[] = explicit.map((cap) => {
-    const derived = derivedProvidersByCap.get(cap.id) ?? [];
-    const merged = unionPreserveOrder(cap.provided_by, derived);
-    // Only allocate a new object when the provider list actually changed —
-    // keeps the no-op (already-complete) config byte-identical.
-    if (merged.length === cap.provided_by.length) {
-      return cap;
-    }
-    return { ...cap, provided_by: merged };
-  });
+  // 1. Explicit entries pass through UNCHANGED (Sage cortex#1027 — authorization
+  //    fix). An explicit `provided_by[]` is the principal's authoritative grant
+  //    list; an agents.d fragment must NOT self-grant into it by declaring the
+  //    capability. We deliberately do NOT union derived providers here — doing so
+  //    let a fragment widen an explicit allow-list it was never granted into.
+  //    The explicit catalog is the source of truth for catalogued capabilities;
+  //    derivation only synthesizes entries for UNCATALOGUED ones (step 2 below).
+  const authoritative: Capability[] = [...explicit];
 
   // 2. Synthesize entries for declaration-only capabilities.
   const synthesized: Capability[] = [];
@@ -106,31 +115,5 @@ export function deriveEffectiveCapabilityCatalog(
     });
   }
 
-  return [...augmented, ...synthesized];
-}
-
-/**
- * Union two ordered string lists, preserving order: every element of `first`
- * in its order, then every element of `second` not already present, in its
- * order. De-duplicates within and across both lists.
- */
-function unionPreserveOrder(
-  first: readonly string[],
-  second: readonly string[],
-): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const x of first) {
-    if (!seen.has(x)) {
-      seen.add(x);
-      out.push(x);
-    }
-  }
-  for (const x of second) {
-    if (!seen.has(x)) {
-      seen.add(x);
-      out.push(x);
-    }
-  }
-  return out;
+  return [...authoritative, ...synthesized];
 }

--- a/src/common/agents/capability-catalog.ts
+++ b/src/common/agents/capability-catalog.ts
@@ -107,8 +107,7 @@ export function deriveEffectiveCapabilityCatalog(
       id: capId,
       // Synthesized entries carry an empty description (design §11 B-0). The
       // catalog is still queryable by id + providers; a principal who wants a
-      // human-readable description authors an explicit entry, which then wins
-      // for description/tags while still being augmented with derived providers.
+      // human-readable description authors an explicit entry,       // for description/tags while still being augmented with derived providers.
       description: "",
       tags: [],
       provided_by: providers,

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -12,6 +12,7 @@
  */
 
 import { join, basename } from "path";
+import { realpathSync } from "fs";
 
 export const STATE_DIR = join(
   process.env.HOME ?? "~",
@@ -35,14 +36,52 @@ export const DEFAULT_CONFIG = join(
  *     backward compat).
  *   - Custom config → `cortex-<config-basename>.pid` (config filename without
  *     the `.yaml`/`.yml` extension). Two stacks with different `--config`
- *     paths get distinct PID files. Directory portion is omitted so a config
- *     that moves on disk still maps to the same PID file.
+ *     paths get distinct PID files.
+ *
+ * Sage cortex#1027 — **stable against config-path spelling.** The PID file is a
+ * lifecycle identity: `cortex start --config X` (writer) and `cortex agents
+ * reload --config X` / `cortex stop --config X` (readers) MUST resolve the same
+ * file even when `X` is spelled differently (trailing slash, `./`, `..`,
+ * symlink, relative vs absolute). We `realpathSync` the config path first so two
+ * spellings of the SAME file canonicalize to one identity before we take the
+ * basename — otherwise `~/.config/cortex/work.yaml` and a symlink to it would
+ * key two different daemons and a reload would signal the wrong (or no) process.
+ *
+ * Keying on `stack.id` would be stricter still (the slug is the real authority
+ * per CONTEXT.md §"Stack slug"), but parsing the config here would pull the full
+ * schema graph into this deliberately-tiny module that the lightweight `agents`
+ * CLI imports. Canonicalizing the locator is the conservative fix that keeps the
+ * module dependency-free while killing the spelling-collision class.
  */
 export function pidFileFor(configPath: string | undefined): string {
   if (configPath === undefined || configPath === DEFAULT_CONFIG) {
     return PID_FILE;
   }
-  const base = basename(configPath).replace(/\.ya?ml$/i, "");
+  const canonical = canonicalizeConfigPath(configPath);
+  if (canonical === DEFAULT_CONFIG) {
+    return PID_FILE;
+  }
+  const base = basename(canonical).replace(/\.ya?ml$/i, "");
   if (base.length === 0) return PID_FILE;
   return join(STATE_DIR, `cortex-${base}.pid`);
+}
+
+/**
+ * Canonicalize a config locator so different spellings of the same file map to
+ * one identity. Resolves symlinks + `.`/`..` via `realpathSync`; when the path
+ * does not exist on disk yet (e.g. resolving the PID file before the config is
+ * created), falls back to the raw path so the previous basename behaviour is
+ * preserved. Always strips a single trailing slash so a directory-style spelling
+ * of a file path does not skew the basename.
+ */
+function canonicalizeConfigPath(configPath: string): string {
+  const trimmed = configPath.replace(/\/+$/, "");
+  try {
+    return realpathSync(trimmed);
+  } catch {
+    // Path not on disk (yet) or unreadable — realpath can't canonicalize it.
+    // Fall back to the trimmed literal so the basename derivation still runs;
+    // two on-disk spellings of an EXISTING file still converge via the try-path.
+    return trimmed;
+  }
 }

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -1,10 +1,10 @@
 /**
  * Daemon PID-file path resolution — single source of truth shared by the
  * `cortex start/stop/status` lifecycle (in `cortex.ts`) and the
- * `cortex agents reload` daemon-signal path (in `cli/cortex/commands/agents.ts`).
+ * `cortex agents reload` runtime-signal path (in `cli/cortex/commands/agents.ts`).
  *
  * Lives in its own tiny module (no heavy import graph) so the lightweight
- * `agents` CLI can resolve the running daemon's PID without pulling the whole
+ * `agents` CLI can resolve the running runtime's PID without pulling the whole
  * `cortex.ts` module graph in just for `pidFileFor`.
  *
  * MIG-7.9 (deferred) flips these to `~/.config/cortex/`. Keeping grove-shaped

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -1,0 +1,48 @@
+/**
+ * Daemon PID-file path resolution — single source of truth shared by the
+ * `cortex start/stop/status` lifecycle (in `cortex.ts`) and the
+ * `cortex agents reload` daemon-signal path (in `cli/cortex/commands/agents.ts`).
+ *
+ * Lives in its own tiny module (no heavy import graph) so the lightweight
+ * `agents` CLI can resolve the running daemon's PID without pulling the whole
+ * `cortex.ts` module graph in just for `pidFileFor`.
+ *
+ * MIG-7.9 (deferred) flips these to `~/.config/cortex/`. Keeping grove-shaped
+ * paths for now so the principal's existing `bot.yaml` continues to work.
+ */
+
+import { join, basename } from "path";
+
+export const STATE_DIR = join(
+  process.env.HOME ?? "~",
+  ".config",
+  "grove",
+  "state",
+);
+export const PID_FILE = join(STATE_DIR, "cortex.pid");
+export const DEFAULT_CONFIG = join(
+  process.env.HOME ?? "~",
+  ".config",
+  "grove",
+  "bot.yaml",
+);
+
+/**
+ * Resolve the PID file path for a given `--config` value.
+ *
+ * Resolution:
+ *   - Default config (or unspecified) → legacy `cortex.pid` (single-instance
+ *     backward compat).
+ *   - Custom config → `cortex-<config-basename>.pid` (config filename without
+ *     the `.yaml`/`.yml` extension). Two stacks with different `--config`
+ *     paths get distinct PID files. Directory portion is omitted so a config
+ *     that moves on disk still maps to the same PID file.
+ */
+export function pidFileFor(configPath: string | undefined): string {
+  if (configPath === undefined || configPath === DEFAULT_CONFIG) {
+    return PID_FILE;
+  }
+  const base = basename(configPath).replace(/\.ya?ml$/i, "");
+  if (base.length === 0) return PID_FILE;
+  return join(STATE_DIR, `cortex-${base}.pid`);
+}

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -11,6 +11,7 @@
  * paths for now so the principal's existing `bot.yaml` continues to work.
  */
 
+import { homedir } from "node:os";
 import { join, basename } from "path";
 import { realpathSync } from "fs";
 
@@ -38,14 +39,16 @@ export const DEFAULT_CONFIG = join(
  *     the `.yaml`/`.yml` extension). Two stacks with different `--config`
  *     paths get distinct PID files.
  *
- * Sage cortex#1027 — **stable against config-path spelling.** The PID file is a
- * lifecycle identity: `cortex start --config X` (writer) and `cortex agents
- * reload --config X` / `cortex stop --config X` (readers) MUST resolve the same
- * file even when `X` is spelled differently (trailing slash, `./`, `..`,
- * symlink, relative vs absolute). We `realpathSync` the config path first so two
- * spellings of the SAME file canonicalize to one identity before we take the
- * basename — otherwise `~/.config/cortex/work.yaml` and a symlink to it would
- * key two different daemons and a reload would signal the wrong (or no) process.
+ * Sage cortex#1027 — **canonicalized against config-path spelling.** The PID
+ * file is a lifecycle identity: `cortex start --config X` (writer) and
+ * `cortex agents reload --config X` / `cortex stop --config X` (readers) must
+ * resolve the same file across spellings. Covered: trailing slash, `./`/`..`
+ * detours, symlinks, relative-vs-absolute, and `~` (expanded here) — for
+ * configs that EXIST on disk, via `realpathSync`. Honest limit: when the path
+ * does not resolve (file missing/unreadable) we fall back to the trimmed
+ * literal, so two never-on-disk spellings of the same intended file can still
+ * derive different PID files — callers get convergence for real configs, not
+ * for hypothetical ones.
  *
  * Keying on `stack.id` would be stricter still (the slug is the real authority
  * per CONTEXT.md §"Stack slug"), but parsing the config here would pull the full
@@ -75,7 +78,12 @@ export function pidFileFor(configPath: string | undefined): string {
  * of a file path does not skew the basename.
  */
 function canonicalizeConfigPath(configPath: string): string {
-  const trimmed = configPath.replace(/\/+$/, "");
+  let trimmed = configPath.replace(/\/+$/, "");
+  // `~` never reaches realpath (shells expand it, but config values passed
+  // programmatically may carry it verbatim).
+  if (trimmed === "~" || trimmed.startsWith("~/")) {
+    trimmed = join(homedir(), trimmed.slice(1));
+  }
   try {
     return realpathSync(trimmed);
   } catch {

--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -544,111 +544,82 @@ describe("CortexConfigSchema — agents[].runtime.capabilities → catalog (A.6.
     ]);
   });
 
-  test("agent claiming undeclared capability is rejected (dangling reference)", () => {
+  test("B-0 (cortex#1021) — agent declaring an uncatalogued capability now parses cleanly", () => {
+    // The former check #3 (every runtime.capabilities[] entry must exist in
+    // the top-level catalog) is RETIRED per design-bot-packs §7 + §11. An
+    // agent declaring `runtime.capabilities: [X]` IS a provider of X; the
+    // effective catalog synthesizes the entry. So this no longer throws.
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: ["code-review.typescript"], // not in empty catalog
+            },
+          }),
+        ],
+        // capabilities: omitted → defaults to []
+      }),
+    );
+    expect(parsed.agents[0]?.runtime?.capabilities).toEqual([
+      "code-review.typescript",
+    ]);
+    // The explicit catalog is still empty — derivation happens at boot/reload
+    // (`deriveEffectiveCapabilityCatalog`), NOT inside the parsed config.
+    expect(parsed.capabilities).toEqual([]);
+  });
+
+  test("B-0 (cortex#1021) — mixed catalogued + declaration-only capabilities both parse", () => {
+    // One capability has an explicit catalog entry; another exists ONLY via
+    // the agent's declaration. Both are accepted; the explicit one is
+    // unchanged in the parsed config, the declaration-only one is NOT injected
+    // into `config.capabilities` (it surfaces only in the derived catalog).
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "echo",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: ["code-review.typescript", "deploy.k8s"],
+            },
+          }),
+        ],
+        capabilities: [
+          minCapability({ id: "code-review.typescript", provided_by: ["echo"] }),
+        ],
+      }),
+    );
+    expect(parsed.capabilities.map((c) => c.id)).toEqual([
+      "code-review.typescript",
+    ]);
+    expect(parsed.agents[0]?.runtime?.capabilities).toEqual([
+      "code-review.typescript",
+      "deploy.k8s",
+    ]);
+  });
+
+  test("B-0 (cortex#1021) — an EXPLICIT provided_by naming a nonexistent agent is STILL rejected", () => {
+    // The typo guard (check #2) is preserved: a hand-authored provided_by[]
+    // that names a phantom agent is still a config error. Only the agent-side
+    // reference check (former check #3) was retired.
     expect(() =>
       CortexConfigSchema.parse(
         minConfig({
-          agents: [
-            minAgent({
-              id: "luna",
-              runtime: {
-                substrate: "claude-code",
-                mode: "in-process",
-                capabilities: ["code-review.typescript"], // not in empty catalog
-              },
+          agents: [minAgent({ id: "echo" })],
+          capabilities: [
+            minCapability({
+              id: "code-review.typescript",
+              provided_by: ["nonexistent-agent"],
             }),
           ],
-          // capabilities: omitted → defaults to []
         }),
       ),
-    ).toThrow(/claims capability .*code-review\.typescript/);
-  });
-
-  test("error message names the agent, the capability id, and the catalog state", () => {
-    try {
-      CortexConfigSchema.parse(
-        minConfig({
-          agents: [
-            minAgent({
-              id: "echo",
-              runtime: {
-                substrate: "claude-code",
-                mode: "in-process",
-                capabilities: ["deploy.k8s"],
-              },
-            }),
-          ],
-          capabilities: [
-            minCapability({ id: "code-review.typescript", provided_by: ["echo"] }),
-          ],
-        }),
-      );
-      throw new Error("expected parse to throw");
-    } catch (e) {
-      // ZodError.message is JSON-encoded; we assert on bare identifiers
-      // rather than the surrounding quote character so the test doesn't
-      // brittle-couple to JSON escaping.
-      const msg = (e as Error).message;
-      expect(msg).toContain("echo");
-      expect(msg).toContain("deploy.k8s");
-      expect(msg).toContain("code-review.typescript"); // the declared catalog id
-    }
-  });
-
-  test("cortex#314 — error message points at 'Fix:' add-to-catalog asymmetry, not symmetric 'Either…or…' framing", () => {
-    // First-install safety regression guard. The previous error wording
-    // was "Either add ... or remove ..." which implied symmetric choice.
-    // In practice the right fix (especially for code-review.* flavors
-    // pilot dispatches against) is almost always to add the capability
-    // to the top-level catalog — the catalog is the source of truth.
-    //
-    // The reworded message:
-    //   - Leads with the verb "Fix:" so a principal scanning the error
-    //     finds the actionable line immediately.
-    //   - Spells out the asymmetry between catalog (registry consumed
-    //     by the dispatch consumer) and runtime.capabilities[] (agent
-    //     declaration of intent).
-    //   - Includes a copy-pasteable minimal capability entry naming
-    //     the offending capability id AND the offending agent id (the
-    //     agent becomes the catalog entry's provided_by[]).
-    //   - Keeps a parenthetical pointing at the remove-from-agent
-    //     escape hatch as the rarer fix.
-    try {
-      CortexConfigSchema.parse(
-        minConfig({
-          agents: [
-            minAgent({
-              id: "echo",
-              runtime: {
-                substrate: "claude-code",
-                mode: "in-process",
-                capabilities: ["code-review.typescript"],
-              },
-            }),
-          ],
-          // capabilities: omitted → defaults to []
-        }),
-      );
-      throw new Error("expected parse to throw");
-    } catch (e) {
-      const msg = (e as Error).message;
-      // Leads with the actionable verb + the catalog as target.
-      expect(msg).toContain("Fix:");
-      expect(msg).toContain("add a");
-      expect(msg).toContain("entry to capabilities[] at the top level of cortex.yaml");
-      // Spells out the asymmetry rather than the previous "Either…or…".
-      expect(msg).toContain("source of truth");
-      expect(msg).toContain("declaration of intent");
-      // Carries the copy-pasteable example block naming the offender +
-      // provider in their canonical YAML shape.
-      expect(msg).toContain("Example minimal entry");
-      expect(msg).toContain("- id: code-review.typescript");
-      expect(msg).toContain("provided_by: [echo]");
-      // Keeps the remove-from-agent escape hatch as the rarer fix.
-      expect(msg).toContain("Only remove from agent");
-      // Does NOT carry the old symmetric "Either…or…" framing.
-      expect(msg).not.toContain("Either add");
-    }
+    ).toThrow(/provider agent .*nonexistent-agent/);
   });
 
   test("empty catalog + empty agent runtime.capabilities parses cleanly", () => {
@@ -714,28 +685,30 @@ describe("CortexConfigSchema — agents[].runtime.capabilities → catalog (A.6.
     ]);
   });
 
-  test("multiple dangling agent references are all reported", () => {
-    try {
-      CortexConfigSchema.parse(
-        minConfig({
-          agents: [
-            minAgent({
-              id: "luna",
-              runtime: {
-                substrate: "claude-code",
-                mode: "in-process",
-                capabilities: ["missing-a", "missing-b"],
-              },
-            }),
-          ],
-        }),
-      );
-      throw new Error("expected parse to throw");
-    } catch (e) {
-      const msg = (e as Error).message;
-      expect(msg).toContain("missing-a");
-      expect(msg).toContain("missing-b");
-    }
+  test("B-0 (cortex#1021) — multiple declaration-only capabilities all parse (former dangling-ref check retired)", () => {
+    // Pre-B-0 this asserted that an agent claiming multiple uncatalogued
+    // capabilities surfaced a dangling-reference error per capability. Under
+    // B-0 those declarations are valid: each becomes a derived/synthesized
+    // catalog entry. Assert the config now parses and preserves the claims.
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: ["missing-a", "missing-b"],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(parsed.agents[0]?.runtime?.capabilities).toEqual([
+      "missing-a",
+      "missing-b",
+    ]);
+    expect(parsed.capabilities).toEqual([]);
   });
 });
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -2560,45 +2560,31 @@ export const CortexConfigSchema = z.object({
       }
     }
   })
-  .superRefine((config, ctx) => {
-    const catalogIds = new Set(config.capabilities.map((c) => c.id));
-    const declaredCatalog = [...catalogIds].sort().join(", ") || "(none)";
-    for (let agentIdx = 0; agentIdx < config.agents.length; agentIdx++) {
-      const agent = config.agents[agentIdx];
-      if (!agent) continue;
-      const claimed = agent.runtime?.capabilities ?? [];
-      for (let claimIdx = 0; claimIdx < claimed.length; claimIdx++) {
-        const capId = claimed[claimIdx];
-        if (capId !== undefined && !catalogIds.has(capId)) {
-          // cortex#314 — reworded for first-install safety. The previous
-          // "Either add ... or remove ..." framing implied symmetric
-          // choice; in practice (especially for code-review.* flavors)
-          // the right fix is almost always to add the capability to the
-          // top-level catalog. The catalog is the source of truth that
-          // the dispatch consumer + future network registry consult;
-          // the agent's runtime.capabilities[] is the agent's
-          // declaration of intent. Spell that asymmetry out so a fresh
-          // principal hitting this error knows which surface to edit.
-          ctx.addIssue({
-            code: "custom",
-            message:
-              `agent "${agent.id}" claims capability "${capId}" in runtime.capabilities[], ` +
-              `but no matching entry exists in the top-level capabilities[] catalog ` +
-              `(declared capability ids: ${declaredCatalog}).\n\n` +
-              `Fix: add a "${capId}" entry to capabilities[] at the top level of cortex.yaml. ` +
-              `The top-level capabilities[] is the source of truth that the dispatch consumer ` +
-              `consults; the agent's runtime.capabilities[] is the agent's declaration of intent.\n\n` +
-              `Example minimal entry:\n` +
-              `  - id: ${capId}\n` +
-              `    description: <one-line description>\n` +
-              `    provided_by: [${agent.id}]\n\n` +
-              `(Only remove from agent "${agent.id}" runtime.capabilities[] if the agent should NOT ` +
-              `actually provide that capability.)`,
-            path: ["agents", agentIdx, "runtime", "capabilities", claimIdx],
-          });
-        }
-      }
-    }
+  // B-0 (cortex#1021, design-bot-packs §7 + §11) — the per-agent
+  // capability-reference check (formerly check #3) is RETIRED.
+  //
+  // It used to require every `agents[].runtime.capabilities[]` entry to exist
+  // in the top-level `capabilities[]` catalog, forcing a principal who adds an
+  // agent to ALSO hand-edit the catalog. That manual cross-edit is exactly the
+  // step the bot-packs design removes: an agent declaring `runtime.capabilities:
+  // [X]` IS, by declaration, a provider of X, and
+  // `deriveEffectiveCapabilityCatalog` (`src/common/agents/capability-catalog.ts`)
+  // synthesizes a catalog entry for a declaration-only capability at boot/reload.
+  //
+  // What is INTENTIONALLY preserved (checks #1 + #2 above, untouched):
+  //   - top-level capability ids stay unique;
+  //   - an EXPLICIT `provided_by[]` entry that names a nonexistent agent is
+  //     still rejected (the typo guard) — derived providers can only ever be
+  //     real agent ids because they come from the agent list itself.
+  //
+  // Backwards compatibility: a config whose catalog already lists every
+  // declared capability validates EXACTLY as before (the derivation is a no-op
+  // for it). Only the previously-rejected "declared but uncatalogued" shape
+  // changes — it now validates and derives.
+  .superRefine(() => {
+    // No-op: see the B-0 rationale block above. Retained as an explicit
+    // refine so the removal is auditable in `git blame` rather than a silent
+    // deletion, and so re-tightening (if ever needed) has an obvious home.
   })
   // ADR 0001 (supersedes cortex#661) — federated accept/deny subject scope.
   //

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -2581,11 +2581,14 @@ export const CortexConfigSchema = z.object({
   // declared capability validates EXACTLY as before (the derivation is a no-op
   // for it). Only the previously-rejected "declared but uncatalogued" shape
   // changes — it now validates and derives.
-  .superRefine(() => {
-    // No-op: see the B-0 rationale block above. Retained as an explicit
-    // refine so the removal is auditable in `git blame` rather than a silent
-    // deletion, and so re-tightening (if ever needed) has an obvious home.
-  })
+  //
+  // Sage cortex#1027 — the retired check #3 left an empty `.superRefine(() => {})`
+  // in the chain as a "where re-tightening would go" marker. That is dead code
+  // that runs on every parse and an attractive-but-misleading home for future
+  // validation logic, so it is removed. If the per-agent capability-reference
+  // check ever needs re-introducing, it belongs as a NEW named `.superRefine`
+  // here with its own rationale — not resurrected from a no-op stub.
+  //
   // ADR 0001 (supersedes cortex#661) — federated accept/deny subject scope.
   //
   // Every `policy.federated.networks[].accept_subjects[]` / `deny_subjects[]`

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -25,7 +25,11 @@ import { parse as parseYaml } from "yaml";
 import type { TextChannel } from "discord.js";
 
 import { loadConfigWithAgents, loadAgentsDirectory, expandTilde, FragmentLoadError } from "./common/config/loader";
-import { ConfigWatcher } from "./common/config/watcher";
+import {
+  ConfigWatcher,
+  AgentsDirectoryWatcher,
+  type AgentsChangeEvent,
+} from "./common/config/watcher";
 import { type AgentConfig } from "./common/types/config";
 import { resolveSigningKnobs } from "./common/security-posture";
 import { buildHttpsMtlsMaterial } from "./common/config/transport-mtls";
@@ -223,9 +227,11 @@ import {
 
 // MIG-7.9 (deferred) flips these to `~/.config/cortex/`. Keeping grove-shaped
 // paths for now so the principal's existing `bot.yaml` continues to work.
-const STATE_DIR = join(process.env.HOME ?? "~", ".config", "grove", "state");
-const PID_FILE = join(STATE_DIR, "cortex.pid");
-const DEFAULT_CONFIG = join(process.env.HOME ?? "~", ".config", "grove", "bot.yaml");
+// B-0 (cortex#1021) — the PID-file resolution moved to `./common/pidfile` so
+// the lightweight `cortex agents reload` CLI can resolve the running daemon's
+// PID (to signal a reload) without importing this whole module graph. Re-import
+// here so cortex.ts's lifecycle paths stay on the single source of truth.
+import { STATE_DIR, PID_FILE, DEFAULT_CONFIG, pidFileFor } from "./common/pidfile";
 
 /**
  * Resolve the PID file path for a given `--config` value.
@@ -249,14 +255,11 @@ const DEFAULT_CONFIG = join(process.env.HOME ?? "~", ".config", "grove", "bot.ya
  * to the same PID file — moving a config doesn't accidentally orphan
  * the prior PID file.
  */
-export function pidFileFor(configPath: string | undefined): string {
-  if (configPath === undefined || configPath === DEFAULT_CONFIG) {
-    return PID_FILE;
-  }
-  const base = basename(configPath).replace(/\.ya?ml$/i, "");
-  if (base.length === 0) return PID_FILE;
-  return join(STATE_DIR, `cortex-${base}.pid`);
-}
+// B-0 (cortex#1021) — `pidFileFor` is imported from `./common/pidfile` (single
+// source of truth shared with the `cortex agents reload` daemon-signal path)
+// and re-exported here so existing importers of `pidFileFor` from `cortex.ts`
+// (tests, the lifecycle commands below) are unaffected.
+export { pidFileFor };
 
 /**
  * cortex#400 — derive the per-agent CC session opts handed to the
@@ -328,6 +331,24 @@ export interface CortexHandle {
    */
   readonly agentRegistry: AgentRegistry;
   /**
+   * B-0 (cortex#1021) — the live agent-registry generation. 0 at boot; each
+   * successful agents.d/ reload that CHANGES the agent set increments it. A
+   * no-op reload (no add/remove/change) does not advance it. Read it after a
+   * `reloadAgents()` (or a fs.watch-driven reload) to confirm a swap happened.
+   */
+  readonly agentGeneration: number;
+  /**
+   * B-0 (cortex#1021) — trigger an agents.d/ reload on the SAME path the
+   * fs.watch callback uses: revalidate fragments, rebuild the merged set
+   * (inline cortex.yaml agents still win on id conflict), swap the registry,
+   * reconcile review consumers (add → start, remove → drain, change →
+   * remove+add), and re-publish the capability registry. `cortex agents
+   * reload` and SIGHUP route here. `source` tags the reload's origin for
+   * logging/observation. Resolves once the reconcile completes (consumers
+   * drained/started). A no-op when no `agents.d/` directory is in play.
+   */
+  reloadAgents(source?: "cli" | "sighup"): Promise<void>;
+  /**
    * IAW Phase D.4.3 — registry-resolved peer pubkey reader. Exposed
    * read-only so D.6 integration tests + future consumers can verify
    * that the federation roster gets populated from the registry.
@@ -397,6 +418,34 @@ export interface StartCortexOptions {
    * @internal — not part of the public API; semver does not apply.
    */
   agentsDir?: string;
+  /**
+   * B-0 (cortex#1021) — skip the daemon-level `agents.d/` fragment watcher
+   * (tests that don't want a live fs.watch, or that drive reloads through the
+   * handle's `reloadAgents()` directly). Production omits this; the watcher
+   * starts whenever `agentsDir` exists.
+   */
+  disableAgentsWatcher?: boolean;
+  /**
+   * B-0 (cortex#1021) — override the `agents.d/` watcher debounce (tests use a
+   * short window to keep fs.watch assertions fast). Defaults to the watcher's
+   * own 200ms — the same window the main ConfigWatcher uses.
+   */
+  agentsWatcherDebounceMs?: number;
+  /**
+   * B-0 (cortex#1021) — test-only observation hook fired after EVERY
+   * agents.d/ reload attempt (watcher-, cli-, or sighup-sourced), including
+   * failed ones. Surfaces the post-reload generation + the add/remove/change
+   * sets so tests can assert reconcile behaviour without scraping logs.
+   */
+  onAgentsReloaded?: (info: {
+    generation: number;
+    source: AgentsChangeEvent["source"];
+    failed: boolean;
+    added: string[];
+    removed: string[];
+    changed: string[];
+    consumerAgentIds: string[];
+  }) => void;
   /**
    * Inline `Agent[]` to merge with the fragment-loaded list when building
    * the registry. Mirrors the cortex.yaml `agents[]` block (design §6.1):
@@ -921,7 +970,19 @@ export async function startCortex(
     ...inlineAgents,
     ...fragmentAgents.filter((a) => !inlineIds.has(a.id)),
   ];
-  const agentRegistry = AgentRegistry.fromAgents(mergedAgents);
+  // B-0 (cortex#1021) — `agentRegistry` is the live, swappable snapshot. The
+  // agents.d/ hot-reload path (below) rebuilds the merged set and reassigns
+  // this binding under a bumped generation counter; the handle's
+  // `agentRegistry` getter reads the live binding so callers always see the
+  // current generation. `mergedAgents` stays the BOOT snapshot (it is consumed
+  // structurally by the boot-time adapter / presence / dispatch wiring); the
+  // reload path tracks its own current view in `liveFragmentAgents` below.
+  let agentRegistry = AgentRegistry.fromAgents(mergedAgents);
+  // The registry generation. Starts at 0 (boot); each successful agents.d/
+  // reload that changes the agent set increments it. Surfaced for tests +
+  // observability — a generation that doesn't advance on a no-op reload is the
+  // signal that nothing structurally changed.
+  let agentGeneration = 0;
   if (mergedAgents.length > 0) {
     console.log(
       `cortex: agent registry assembled — ${mergedAgents.length} agent(s) `
@@ -1018,24 +1079,38 @@ export async function startCortex(
   //
   // **Scope (per §10.1 PR-7).** Publish-only. No subscriber wiring here —
   // the consumer is principal-dashboard side and lands in a future PR.
-  const capabilityEntries: CapabilityRegistryEntry[] = mergedAgents
-    .filter((a): a is Agent & { runtime: { capabilities: readonly string[] } } =>
-      (a.runtime?.capabilities.length ?? 0) > 0,
-    )
-    .map((a) => ({
-      agentId: a.id,
-      capabilities: a.runtime.capabilities,
-    }));
-  if (capabilityEntries.length > 0) {
+  // B-0 (cortex#1021) — the idempotent capability-registry publish, lifted into
+  // a reusable closure so the agents.d/ hot-reload path (below) re-publishes
+  // through the SAME code at boot. This CLOSES the long-standing TODO in this
+  // block's preamble ("we do NOT wire a re-publish into the hot-reload path …
+  // when [a fragment watcher] is wired, the re-publish belongs in its
+  // callback"): the watcher's reload callback now calls `publishCapabilitiesFor`
+  // after swapping the registry. The publisher keys the bucket on `agent_id`
+  // and overwrites, so a re-publish reconciles a changed/added agent's caps and
+  // is a harmless no-op for unchanged ones. Returns the number of agents whose
+  // registrations were attempted (0 when no agent declares capabilities).
+  const publishCapabilitiesFor = async (
+    agents: readonly Agent[],
+    context: "boot" | "reload",
+  ): Promise<number> => {
+    const entries: CapabilityRegistryEntry[] = agents
+      .filter((a): a is Agent & { runtime: { capabilities: readonly string[] } } =>
+        (a.runtime?.capabilities.length ?? 0) > 0,
+      )
+      .map((a) => ({
+        agentId: a.id,
+        capabilities: a.runtime.capabilities,
+      }));
+    if (entries.length === 0) return 0;
     // cortex#288 follow-up — closure-scoped success/failure counters.
     //
     // `publishCapabilityRegistry`'s contract is "I called publish() for each
     // envelope" — it pushes to its returned `published[]` *after* awaiting
-    // publish(), regardless of whether the boot site swallows the rejection.
+    // publish(), regardless of whether the call site swallows the rejection.
     // Our `wrappedPublish` below DOES swallow per-envelope failures (so one
     // bad publish doesn't abort the loop), which means `published.length` is
     // really "publishes that returned without throwing into the publisher",
-    // not "publishes that actually landed on the wire". The boot log should
+    // not "publishes that actually landed on the wire". The log should
     // report wire-side reality. We count outcomes locally here; the publisher
     // contract stays correct and unchanged.
     let successfulPublishes = 0;
@@ -1061,25 +1136,33 @@ export async function startCortex(
     try {
       await publishCapabilityRegistry({
         source: systemEventSource,
-        entries: capabilityEntries,
+        entries,
         publish: wrappedPublish,
       });
       const failureSuffix = failedPublishes > 0 ? ` (${failedPublishes} failure(s))` : "";
       console.log(
         `cortex: published ${successfulPublishes} capability registration(s)${failureSuffix} ` +
-          `for ${capabilityEntries.length} agent(s)`,
+          `for ${entries.length} agent(s) (${context})`,
       );
     } catch (err) {
       // Defensive — `publishCapabilityRegistry` is pure orchestration and
       // shouldn't throw once `wrappedPublish` traps per-envelope failures,
       // but a `clock()` or `buildBaseEnvelope` throw would still surface
-      // here. Boot continues; the bucket simply stays unpopulated until
-      // the next restart.
+      // here. Boot/reload continues; the bucket simply stays unpopulated
+      // until the next publish.
       console.error(
-        "cortex: capability-registry boot wiring failed (non-fatal — boot continues):",
+        `cortex: capability-registry ${context} wiring failed (non-fatal — continues):`,
         err instanceof Error ? err.message : String(err),
       );
     }
+    return entries.length;
+  };
+
+  const capabilityEntryCount = mergedAgents.filter(
+    (a) => (a.runtime?.capabilities.length ?? 0) > 0,
+  ).length;
+  if (capabilityEntryCount > 0) {
+    await publishCapabilitiesFor(mergedAgents, "boot");
   } else {
     // cortex#314 — promote skipped notice to stderr WARNING with
     // principal-actionable text. The capability-dispatch consumer rejects
@@ -1601,7 +1684,17 @@ export async function startCortex(
     // ── /F-2.2 provision DEV_IMPLEMENT ──────────────────────────────────────
   }
 
-  for (const agent of reviewCapableAgents) {
+  // B-0 (cortex#1021) — the per-agent review-consumer construction, lifted out
+  // of the boot loop into a reusable closure so the agents.d/ hot-reload path
+  // (below) can START a newly-ADDED agent's consumers through the SAME
+  // construction it uses at boot — no duplicated wiring. It captures every
+  // boot-scoped dependency it needs (trustResolver, signingKnobs, signer,
+  // resolvedPolicy, derivedStack, reviewJsm, the offering/federation patterns,
+  // systemEventSource, the reviewConsumers array, …) by closure; nothing new is
+  // threaded as a parameter. Pushes the consumers it creates onto
+  // `reviewConsumers[]` (the same array the shutdown drain walks), so a
+  // hot-added agent's consumers drain on shutdown identically to a boot agent's.
+  const startReviewConsumersForAgent = async (agent: Agent): Promise<void> => {
     try {
       const caps = agent.runtime?.capabilities ?? [];
       const consumerAgent: ReviewConsumerAgent = {
@@ -2055,6 +2148,12 @@ export async function startCortex(
           `${err instanceof Error ? err.message : String(err)}\n`,
       );
     }
+  };
+
+  // Boot: start review consumers for every code-review-capable agent. Same
+  // closure the hot-reload path calls for a newly-added agent.
+  for (const agent of reviewCapableAgents) {
+    await startReviewConsumersForAgent(agent);
   }
   if (reviewConsumers.length === 0) {
     // cortex#314 — same first-install-safety promotion as the
@@ -3595,6 +3694,304 @@ export async function startCortex(
     configWatcher.start();
   }
 
+  // ===========================================================================
+  // B-0 (cortex#1021, design-bot-packs §7 + §11) — daemon-level agents.d/
+  // fragment watcher + hot reload.
+  // ===========================================================================
+  //
+  // This wires the in-tree `AgentsDirectoryWatcher` (cortex#60 A.1, which until
+  // now was unit-tested but UNWIRED at the daemon level — see the historical
+  // TODO this section closes) into the running daemon, EXTENDING the existing
+  // reload machinery (the ConfigWatcher above) rather than inventing a parallel
+  // one. On a fragment add/change/remove (debounced), or an explicit
+  // `cortex agents reload` / SIGHUP, it:
+  //
+  //   1. revalidates fragments + rebuilds the merged agent set (inline
+  //      cortex.yaml agents still WIN on id conflict — design §6.1);
+  //   2. swaps `agentRegistry` under a bumped `agentGeneration`;
+  //   3. reconciles REVIEW CONSUMERS — an ADDED agent's consumers START via the
+  //      same `startReviewConsumersForAgent` boot uses; a REMOVED agent's
+  //      consumers DRAIN (`.stop()` lets in-flight finish) and leave
+  //      `reviewConsumers[]`; a CHANGED agent is remove-then-add;
+  //   4. re-publishes the capability registry (`publishCapabilitiesFor`), which
+  //      is idempotent (keyed on agent_id);
+  //   5. an invalid fragment is REJECTED without killing the daemon — the old
+  //      generation is retained and a warning is logged.
+  //
+  // HONEST SCOPE — PRESENCE ADAPTERS ARE RESTART-ONLY (documented limitation).
+  // Live presence-adapter (Discord/Mattermost/Slack) start/stop on reload is
+  // deeply entangled with boot: the two-pass cross-adapter trust resolution
+  // (cortex#98 part B) and the surface-router registration both run once over
+  // the full roster at boot. Hot-swapping a single adapter would have to
+  // re-run those shared passes safely mid-flight. Per the task's honest-scope
+  // rule we DO NOT half-implement that — the registry + review-consumer +
+  // capability hot path is fully live; presence changes for a hot-added/removed
+  // agent require a daemon restart. The reconcile logs a warning and
+  // `reloadAgents()` callers (the CLI) surface the same notice.
+  //
+  // The reconcile is SERIALIZED behind `reloadInFlight` so overlapping triggers
+  // (a fast double fs.watch event, or a CLI reload racing a watcher reload)
+  // don't interleave consumer start/stop. Each trigger awaits the prior one.
+  let liveFragmentAgents: Agent[] = fragmentAgents;
+  let liveMergedAgents: Agent[] = mergedAgents;
+  let reloadInFlight: Promise<void> = Promise.resolve();
+
+  // Predicate mirrors the boot-time `reviewCapableAgents` filter so a
+  // hot-added agent is started iff it would have been started at boot.
+  const isReviewCapable = (a: Agent): boolean => {
+    const caps = a.runtime?.capabilities ?? [];
+    return caps.some((c) => c === "code-review" || c.startsWith("code-review."));
+  };
+
+  // Drain + remove every review consumer owned by `agentId` from
+  // `reviewConsumers[]`. `ReviewConsumer.stop()` is idempotent and awaits the
+  // in-flight set per its own drain contract (cortex#237 PR-6), so a removed
+  // agent's in-flight reviews publish their terminal envelope before teardown.
+  const drainConsumersForAgent = async (agentId: string): Promise<void> => {
+    // Iterate a snapshot of the indices to remove (consumers can appear more
+    // than once per agent: local + offer-scope + federated offer/direct).
+    const toStop = reviewConsumers.filter((c) => c.agent.id === agentId);
+    for (const consumer of toStop) {
+      try {
+        await consumer.stop();
+      } catch (err) {
+        process.stderr.write(
+          `cortex: agents-reload — review-consumer drain failed for agent=${agentId}: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+    // Compact `reviewConsumers[]` in place, preserving order of survivors.
+    for (let i = reviewConsumers.length - 1; i >= 0; i--) {
+      if (reviewConsumers[i]?.agent.id === agentId) {
+        reviewConsumers.splice(i, 1);
+      }
+    }
+  };
+
+  // The single reconcile path. Both the fs.watch callback and the handle's
+  // `reloadAgents()` route here through `runReconcile`. Computes the merged
+  // diff (inline wins), drains removed/changed-old consumers, starts
+  // added/changed-new consumers, swaps the registry, re-publishes caps.
+  const reconcileFromEvent = async (event: AgentsChangeEvent): Promise<void> => {
+    if (event.failed) {
+      // Invalid fragment mid-run: keep the old generation alive. The watcher
+      // already retained the prior valid agent set; we don't swap anything.
+      console.warn(
+        `cortex: agents-reload (${event.source}) REJECTED — invalid fragment ${event.error?.file ?? "?"}: ` +
+          `${event.error?.reason ?? "unknown"} — keeping generation ${agentGeneration}`,
+      );
+      options.onAgentsReloaded?.({
+        generation: agentGeneration,
+        source: event.source,
+        failed: true,
+        added: [],
+        removed: [],
+        changed: [],
+        consumerAgentIds: reviewConsumers.map((c) => c.agent.id),
+      });
+      return;
+    }
+
+    // `event.agents` is the fresh FRAGMENT set. Re-apply the inline-wins merge
+    // (design §6.1) so an inline cortex.yaml agent still shadows a fragment of
+    // the same id after the reload.
+    const freshFragments = event.agents;
+    const freshMerged: Agent[] = [
+      ...inlineAgents,
+      ...freshFragments.filter((a) => !inlineIds.has(a.id)),
+    ];
+
+    // Diff the MERGED view (not the raw fragment view) so a fragment change to
+    // an inline-shadowed id is a no-op, and removing a fragment that an inline
+    // entry shadows does not tear down the inline agent's consumers.
+    const priorById = new Map(liveMergedAgents.map((a) => [a.id, a]));
+    const freshById = new Map(freshMerged.map((a) => [a.id, a]));
+    const added: string[] = [];
+    const removed: string[] = [];
+    const changed: string[] = [];
+    for (const [id, fresh] of freshById) {
+      const prior = priorById.get(id);
+      if (prior === undefined) added.push(id);
+      else if (!agentsEqual(prior, fresh)) changed.push(id);
+    }
+    for (const id of priorById.keys()) {
+      if (!freshById.has(id)) removed.push(id);
+    }
+    added.sort();
+    removed.sort();
+    changed.sort();
+
+    if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+      // Nothing structurally changed in the merged view — do not bump the
+      // generation, do not churn consumers. (e.g. a fragment touched but its
+      // content is byte-identical, or only inline-shadowed ids moved.)
+      console.log(
+        `cortex: agents-reload (${event.source}) — no effective change (generation ${agentGeneration})`,
+      );
+      options.onAgentsReloaded?.({
+        generation: agentGeneration,
+        source: event.source,
+        failed: false,
+        added: [],
+        removed: [],
+        changed: [],
+        consumerAgentIds: reviewConsumers.map((c) => c.agent.id),
+      });
+      return;
+    }
+
+    // ── Drain consumers for removed + changed (old definition) agents first ──
+    for (const id of [...removed, ...changed]) {
+      await drainConsumersForAgent(id);
+    }
+
+    // ── Swap the registry + bump the generation BEFORE starting new consumers,
+    //    so a started consumer reads the new registry generation. ──
+    liveFragmentAgents = [...freshFragments];
+    liveMergedAgents = freshMerged;
+    agentRegistry = AgentRegistry.fromAgents(freshMerged);
+    agentGeneration += 1;
+
+    // ── Start consumers for added + changed (new definition) review-capable
+    //    agents via the SAME construction path boot uses. ──
+    for (const id of [...added, ...changed]) {
+      const agent = freshById.get(id);
+      if (agent !== undefined && isReviewCapable(agent)) {
+        await startReviewConsumersForAgent(agent);
+      }
+    }
+
+    // ── Re-publish the capability registry (deliverable 3 — idempotent). ──
+    await publishCapabilitiesFor(freshMerged, "reload");
+
+    // ── Honest-scope: presence-adapter changes are restart-only. Warn when a
+    //    reload added/removed an agent that declares a presence binding (the
+    //    case where a restart is actually needed to (dis)connect a bot). ──
+    const presenceAffected = [...added, ...removed, ...changed].filter((id) => {
+      const a = freshById.get(id) ?? priorById.get(id);
+      return (
+        a?.presence.discord !== undefined ||
+        a?.presence.mattermost !== undefined ||
+        a?.presence.slack !== undefined
+      );
+    });
+    if (presenceAffected.length > 0) {
+      process.stderr.write(
+        `cortex: agents-reload (${event.source}) — presence changes for ${presenceAffected.join(", ")} ` +
+          `require a daemon restart (registry + review consumers + capabilities updated live; ` +
+          `presence adapters are restart-only — see B-0 honest-scope note).\n`,
+      );
+    }
+
+    console.log(
+      `cortex: agents-reload (${event.source}) — generation ${agentGeneration} ` +
+        `(added: [${added.join(",")}], removed: [${removed.join(",")}], changed: [${changed.join(",")}])`,
+    );
+    options.onAgentsReloaded?.({
+      generation: agentGeneration,
+      source: event.source,
+      failed: false,
+      added,
+      removed,
+      changed,
+      consumerAgentIds: reviewConsumers.map((c) => c.agent.id),
+    });
+  };
+
+  // Serialize every reconcile behind `reloadInFlight` so triggers can't
+  // interleave consumer start/stop. Returns the chained promise so callers
+  // (the CLI handle path) can await completion.
+  const runReconcile = (event: AgentsChangeEvent): Promise<void> => {
+    const next = reloadInFlight.then(() => reconcileFromEvent(event));
+    // Swallow the rejection on the CHAIN (not on `next`) so one failed
+    // reconcile doesn't poison every subsequent trigger; the per-reconcile
+    // body already logs its own errors.
+    reloadInFlight = next.catch((err) => {
+      process.stderr.write(
+        `cortex: agents-reload reconcile error (non-fatal): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    });
+    return next;
+  };
+
+  // The watcher itself. Constructed with the BOOT fragment set as its baseline
+  // so the first fs.watch diff is computed against what boot actually loaded.
+  // `null` when disabled (tests) or when the daemon has no agents.d/ in play.
+  let agentsWatcher: AgentsDirectoryWatcher | null = null;
+  if (!options.disableAgentsWatcher) {
+    agentsWatcher = new AgentsDirectoryWatcher(
+      agentsDir,
+      fragmentAgents,
+      (event) => {
+        void runReconcile(event);
+      },
+      {
+        ...(options.agentsWatcherDebounceMs !== undefined && {
+          debounceMs: options.agentsWatcherDebounceMs,
+        }),
+      },
+    );
+    agentsWatcher.start();
+  }
+
+  // `reloadAgents()` (handle) + SIGHUP both call this. When the watcher exists
+  // we route through its `triggerReload` (which loads the dir + emits the same
+  // AgentsChangeEvent the fs.watch path emits) so there is ONE reconcile path.
+  // When the watcher is disabled, we load the directory directly and synthesize
+  // the event so the CLI/SIGHUP still works in watcher-less deployments/tests.
+  const reloadAgentsViaTrigger = async (
+    source: "cli" | "sighup",
+  ): Promise<void> => {
+    if (agentsWatcher !== null) {
+      // Capture the reconcile promise: triggerReload fires the handler
+      // synchronously (no debounce for explicit triggers), which calls
+      // runReconcile and assigns reloadInFlight. Await that.
+      agentsWatcher.triggerReload(source);
+      await reloadInFlight;
+      return;
+    }
+    // Watcher-less path: load + reconcile directly.
+    let event: AgentsChangeEvent;
+    try {
+      const fresh = loadAgentsDirectory(agentsDir);
+      event = {
+        source,
+        failed: false,
+        agents: fresh,
+        // The diff sets are recomputed inside reconcileFromEvent against the
+        // live merged view; these fragment-level sets are unused there.
+        agentsAdded: [],
+        agentsRemoved: [],
+        agentsChanged: [],
+      };
+    } catch (err) {
+      const isFragErr = err instanceof FragmentLoadError;
+      event = {
+        source,
+        failed: true,
+        error: {
+          file: isFragErr ? err.file : agentsDir,
+          reason: err instanceof Error ? err.message : String(err),
+        },
+        agents: liveFragmentAgents,
+        agentsAdded: [],
+        agentsRemoved: [],
+        agentsChanged: [],
+      };
+    }
+    await runReconcile(event);
+  };
+
+  // SIGHUP → agents reload, on the SAME path the watcher + CLI use. Registered
+  // once; harmless when the watcher is disabled (the trigger still revalidates
+  // + reconciles by reloading the dir directly). Deregistered in `drain()`.
+  const sighupHandler = (): void => {
+    void reloadAgentsViaTrigger("sighup");
+  };
+  process.on("SIGHUP", sighupHandler);
+
   // MC-I1.S1 (ADR-0005): in-process Mission Control embed — opt-in via `config.mc.enabled`.
   // The legacy `api.*` embedded-dashboard path (G-201) was retired per ADR-0005 /
   // #712 (its dynamic import never migrated from grove-v2 and threw on every
@@ -4363,6 +4760,16 @@ export async function startCortex(
 
     const drain = async (): Promise<void> => {
       completeSync("config-watcher stop", () => configWatcher?.stop());
+      // B-0 (cortex#1021) — stop the agents.d/ watcher + deregister the SIGHUP
+      // handler so no reload fires mid-shutdown. Await any in-flight reconcile
+      // first so a reload racing shutdown finishes its consumer start/stop
+      // before the runtime closes (the started consumers then drain below with
+      // the rest of `reviewConsumers[]`).
+      completeSync("agents-watcher stop", () => agentsWatcher?.stop());
+      completeSync("agents-sighup deregister", () =>
+        process.removeListener("SIGHUP", sighupHandler),
+      );
+      await completeAsync("agents-reload in-flight drain", reloadInFlight);
       // G-1114.B.2 — publish agent.offline (reason: shutdown) for every hosted
       // agent FIRST, while the runtime/bus is still up. `stop()` awaits the
       // offline publishes so they go out before any later step (and well before
@@ -4551,10 +4958,63 @@ export async function startCortex(
     get agentRegistry() {
       return agentRegistry;
     },
+    get agentGeneration() {
+      return agentGeneration;
+    },
+    // B-0 (cortex#1021) — manual reload entrypoint. `cortex agents reload`
+    // (via the CLI's daemon-signal path) and SIGHUP both reach the same
+    // reconcile through here.
+    reloadAgents(source: "cli" | "sighup" = "cli") {
+      return reloadAgentsViaTrigger(source);
+    },
     get registryClient() {
       return registryClient;
     },
   };
+}
+
+/**
+ * B-0 (cortex#1021) — order-independent structural equality for two `Agent`
+ * shapes, used by the agents.d/ hot-reload diff to decide whether an agent
+ * CHANGED (vs. an untouched fragment touch that produced a byte-identical
+ * reload). Mirrors the watcher's private `deepEqual` (it can't be imported
+ * without widening the watcher's public surface) but is scoped to the Agent
+ * shapes the reconcile actually compares: plain objects, arrays, scalars.
+ * No Date/Map/Set handling — Agent values don't inhabit those.
+ */
+function agentsEqual(a: Agent, b: Agent): boolean {
+  return structuralEqual(a, b);
+}
+
+function structuralEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!structuralEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (Array.isArray(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b as object);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+    if (
+      !structuralEqual(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key],
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3946,6 +3946,29 @@ export async function startCortex(
     });
     await publishCapabilityTombstones([...removed, ...changedToEmpty]);
 
+    // ── Canonical presence envelope (sage round 3): the legacy registry write
+    //    above is the migration-period dual-emit; `agent.capabilities-changed`
+    //    is the canonical signal presence consumers follow (CONTEXT.md §Agent
+    //    presence). Diff-based: the producer only emits on a real delta.
+    const presenceProducer = presenceProducerForReload;
+    if (presenceProducer !== null) {
+      let emitted = 0;
+      for (const id of [...added, ...changed]) {
+        const fresh = freshById.get(id);
+        if (fresh === undefined) continue;
+        const caps = fresh.runtime?.capabilities ?? [];
+        if (presenceProducer.publishCapabilitiesChanged(id, caps)) emitted += 1;
+      }
+      for (const id of removed) {
+        if (presenceProducer.publishCapabilitiesChanged(id, [])) emitted += 1;
+      }
+      if (emitted > 0) {
+        console.log(
+          `cortex: agents-reload — emitted ${emitted} agent.capabilities-changed`,
+        );
+      }
+    }
+
     // ── Honest-scope: presence-adapter changes are restart-only. Warn when a
     //    reload added/removed an agent that declares a presence binding (the
     //    case where a restart is actually needed to (dis)connect a bot). ──

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -56,6 +56,7 @@ import { createNetworkResolver } from "./bus/network-resolver";
 import type { SystemEventSource } from "./bus/system-events";
 import {
   publishCapabilityRegistry,
+  buildCapabilityRegisteredEnvelope,
   type CapabilityRegistryEntry,
 } from "./bus";
 import {
@@ -1156,6 +1157,51 @@ export async function startCortex(
       );
     }
     return entries.length;
+  };
+
+  // B-0 (Sage cortex#1027) — capability TOMBSTONE publish for REMOVED agents.
+  //
+  // The bucket consumer keys on `agent_id` and overwrites; an agent that is
+  // removed on reload must have its prior registration OVERWRITTEN, not merely
+  // omitted from the next republish (omission leaves the stale registration
+  // live — the agent stays a "provider" of capabilities it no longer hosts).
+  // `publishCapabilityRegistry` deliberately SKIPS empty-capability entries
+  // (spec §3.4), so we cannot tombstone through it. We build the empty-capability
+  // envelope directly: same `agents.capabilities.registered` type + `agent_id`,
+  // `capabilities: []` — which a keyed consumer interprets as "this agent now
+  // provides nothing", i.e. an unregister. Errors are trapped per-envelope so one
+  // failure doesn't abort the reload.
+  const publishCapabilityTombstones = async (
+    removedAgentIds: readonly string[],
+  ): Promise<number> => {
+    if (removedAgentIds.length === 0) return 0;
+    let tombstoned = 0;
+    for (const agentId of removedAgentIds) {
+      try {
+        const envelope = buildCapabilityRegisteredEnvelope({
+          source: systemEventSource,
+          agentId,
+          capabilities: [],
+          registeredAt: new Date(),
+          instance: systemEventSource.instance,
+        });
+        await runtime.publish(envelope);
+        tombstoned++;
+      } catch (err) {
+        // Per CLAUDE.md "no empty catch blocks": log, continue. stderr (not the
+        // system-events pipeline) for the same reason as publishCapabilitiesFor.
+        process.stderr.write(
+          `cortex: capability-registry tombstone publish failed for agent_id=${agentId}: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+    if (tombstoned > 0) {
+      console.log(
+        `cortex: published ${tombstoned} capability tombstone(s) for removed agent(s) (reload)`,
+      );
+    }
+    return tombstoned;
   };
 
   const capabilityEntryCount = mergedAgents.filter(
@@ -3713,8 +3759,11 @@ export async function startCortex(
   //      same `startReviewConsumersForAgent` boot uses; a REMOVED agent's
   //      consumers DRAIN (`.stop()` lets in-flight finish) and leave
   //      `reviewConsumers[]`; a CHANGED agent is remove-then-add;
-  //   4. re-publishes the capability registry (`publishCapabilitiesFor`), which
-  //      is idempotent (keyed on agent_id);
+  //   4. reconciles the capability registry (Sage cortex#1027): re-publishes
+  //      registrations for ADDED + CHANGED agents only (diff-only, not the whole
+  //      roster), and TOMBSTONES removed agents (and changed-to-empty agents) with
+  //      an empty-capability registration so a removed agent stops being a
+  //      registered provider — both keyed on agent_id;
   //   5. an invalid fragment is REJECTED without killing the daemon — the old
   //      generation is retained and a warning is logged.
   //
@@ -3751,16 +3800,20 @@ export async function startCortex(
     // Iterate a snapshot of the indices to remove (consumers can appear more
     // than once per agent: local + offer-scope + federated offer/direct).
     const toStop = reviewConsumers.filter((c) => c.agent.id === agentId);
-    for (const consumer of toStop) {
-      try {
-        await consumer.stop();
-      } catch (err) {
+    // Sage cortex#1027 — drain this agent's consumers CONCURRENTLY. Each
+    // `stop()` drains in-flight work; serializing them made one agent's reload
+    // latency the SUM of its consumers' drains. `allSettled` so one failing
+    // stop doesn't abort the siblings; we log each rejection by index.
+    const outcomes = await Promise.allSettled(toStop.map((c) => c.stop()));
+    outcomes.forEach((outcome, i) => {
+      if (outcome.status === "rejected") {
+        const err = outcome.reason;
         process.stderr.write(
-          `cortex: agents-reload — review-consumer drain failed for agent=${agentId}: ` +
-            `${err instanceof Error ? err.message : String(err)}\n`,
+          `cortex: agents-reload — review-consumer drain failed for agent=${agentId} ` +
+            `(consumer ${i}): ${err instanceof Error ? err.message : String(err)}\n`,
         );
       }
-    }
+    });
     // Compact `reviewConsumers[]` in place, preserving order of survivors.
     for (let i = reviewConsumers.length - 1; i >= 0; i--) {
       if (reviewConsumers[i]?.agent.id === agentId) {
@@ -3842,9 +3895,13 @@ export async function startCortex(
     }
 
     // ── Drain consumers for removed + changed (old definition) agents first ──
-    for (const id of [...removed, ...changed]) {
-      await drainConsumersForAgent(id);
-    }
+    //    Sage cortex#1027 — drain all affected agents CONCURRENTLY; each
+    //    `drainConsumersForAgent` already settles its own consumers in parallel
+    //    and logs failures, so the whole drain is one parallel wave rather than
+    //    a per-agent serial chain.
+    await Promise.all(
+      [...removed, ...changed].map((id) => drainConsumersForAgent(id)),
+    );
 
     // ── Swap the registry + bump the generation BEFORE starting new consumers,
     //    so a started consumer reads the new registry generation. ──
@@ -3862,8 +3919,29 @@ export async function startCortex(
       }
     }
 
-    // ── Re-publish the capability registry (deliverable 3 — idempotent). ──
-    await publishCapabilitiesFor(freshMerged, "reload");
+    // ── Re-publish the capability registry (deliverable 3). ──
+    //    Sage cortex#1027:
+    //    (a) DIFF-ONLY republish — only re-emit registrations for added + changed
+    //        agents. Unchanged agents' registrations are already live and keyed by
+    //        agent_id; re-emitting all of them made a one-fragment edit cost
+    //        O(total agents) bus publishes. We republish O(changed agents).
+    //    (b) TOMBSTONE removed agents — a removed agent must have its prior
+    //        registration OVERWRITTEN with an empty-capability registration, else
+    //        it stays registered as a provider of capabilities it no longer hosts.
+    const republishIds = new Set([...added, ...changed]);
+    const republishAgents = freshMerged.filter((a) => republishIds.has(a.id));
+    if (republishAgents.length > 0) {
+      await publishCapabilitiesFor(republishAgents, "reload");
+    }
+    // Tombstone every agent whose registration must be CLEARED: removed agents,
+    // plus CHANGED agents that dropped to zero capabilities (publishCapabilities-
+    // For skips empty-capability entries, so without an explicit tombstone such an
+    // agent would keep its stale prior registration).
+    const changedToEmpty = changed.filter((id) => {
+      const a = freshById.get(id);
+      return (a?.runtime?.capabilities?.length ?? 0) === 0;
+    });
+    await publishCapabilityTombstones([...removed, ...changedToEmpty]);
 
     // ── Honest-scope: presence-adapter changes are restart-only. Warn when a
     //    reload added/removed an agent that declares a presence binding (the

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3911,13 +3911,16 @@ export async function startCortex(
     agentGeneration += 1;
 
     // ── Start consumers for added + changed (new definition) review-capable
-    //    agents via the SAME construction path boot uses. ──
-    for (const id of [...added, ...changed]) {
-      const agent = freshById.get(id);
-      if (agent !== undefined && isReviewCapable(agent)) {
-        await startReviewConsumersForAgent(agent);
-      }
-    }
+    //    agents via the SAME construction path boot uses — concurrently
+    //    (sage round 2), mirroring the parallel drain wave above. ──
+    await Promise.all(
+      [...added, ...changed].map(async (id) => {
+        const agent = freshById.get(id);
+        if (agent !== undefined && isReviewCapable(agent)) {
+          await startReviewConsumersForAgent(agent);
+        }
+      }),
+    );
 
     // ── Re-publish the capability registry (deliverable 3). ──
     //    Sage cortex#1027:


### PR DESCRIPTION
Phase B-0 of #1021 (design: PR #1019 §7/§11). Makes agent declaration hot — the prerequisite for installable bot packs.

## What
- **Daemon-level agents.d watcher** (`AgentsDirectoryWatcher` wired in cortex.ts): fragment add/change/remove → revalidate → rebuild merged registry (inline still wins on id conflict, recomputed per reload) → generation bump. Invalid fragment survives without killing the daemon or bumping the generation.
- **Reload semantics**: added agent → ReviewConsumer started via the SAME extracted path boot uses (`startReviewConsumersForAgent`); removed → drain; changed → remove+add. `cortex agents reload` now SIGHUPs the daemon (PID-file single-source in new `src/common/pidfile.ts`); `--validate-only` keeps the old behavior. Reconciles serialized behind `reloadInFlight`; in-flight reload drained on shutdown.
- **Capability re-publish on reload** — closes the cortex.ts TODO ("when one is wired, the re-publish belongs in its callback"); publisher idempotency already documented.
- **Derived provided_by** (`deriveEffectiveCapabilityCatalog`): agents declaring `runtime.capabilities` auto-register as providers; declaration-only capabilities get synthesized catalog entries; explicit entries keep descriptions/tags and the explicit-provider typo guard stays. Kills manual step 3 of agent addition. Former cross-validator check #3 retired accordingly (3 rejection tests inverted deliberately).

## Honest scope
Presence adapters (Discord/MM/Slack) are **restart-only** in B-0 — their boot is a two-pass cross-adapter trust resolution (cortex#98 B) over the full roster; hot-swapping one adapter mid-flight would require re-running shared passes. The reconcile warn-logs it and the CLI says so. The capability-dispatch path (the part bot packs need) is fully hot.

## Evidence
Reconcile suite 9 pass (add/drain/change, re-publish fires, derived catalog e2e, invalid-fragment survival, no-op no-bump, live fs.watch) + capability-catalog 8 pass · full suite 6577 pass / 2 skip / 0 fail · tsc clean · vocab gate PASS.

Pre-existing flake noted, untouched: `cortex.review-consumer-boot.test.ts` CO-2 does a live TOFU fetch to network.meta-factory.ai and times out under slow network (verified 4/4 at baseline without these changes) — needs an injected registry in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)