### PR TITLE
feat(discord): post --file — multipart file attachments

### DIFF
--- a/src/cli/discord/__tests__/attachment-form.test.ts
+++ b/src/cli/discord/__tests__/attachment-form.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the Discord attachment multipart builder.
+ *
+ * `buildAttachmentForm` is the pure half of the file-upload path: it turns a
+ * message + in-memory files into the `multipart/form-data` body Discord v10
+ * expects — a `payload_json` part (message fields + an `attachments` array that
+ * references each file by index) and one `files[n]` part per attachment. Pure
+ * by design (no fs, no token) so the wire format is testable in isolation; the
+ * CLI owns the file read + existence check.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildAttachmentForm, type AttachmentInput } from "../lib/discord";
+
+function file(name: string, body: string): AttachmentInput {
+  return { filename: name, bytes: new TextEncoder().encode(body) };
+}
+
+async function payloadOf(form: FormData): Promise<Record<string, unknown>> {
+  return JSON.parse(form.get("payload_json") as string) as Record<string, unknown>;
+}
+
+describe("buildAttachmentForm", () => {
+  test("payload_json carries content + an attachments array indexed to files[n]", async () => {
+    const form = buildAttachmentForm("here you go", [file("a.md", "alpha"), file("b.json", "{}")]);
+    const payload = await payloadOf(form);
+    expect(payload.content).toBe("here you go");
+    expect(payload.attachments).toEqual([
+      { id: 0, filename: "a.md" },
+      { id: 1, filename: "b.json" },
+    ]);
+  });
+
+  test("one files[n] part per attachment, carrying the bytes + filename", async () => {
+    const form = buildAttachmentForm("", [file("note.md", "the body")]);
+    const part = form.get("files[0]");
+    expect(part).toBeInstanceOf(Blob);
+    const blob = part as Blob;
+    expect((blob as File).name).toBe("note.md");
+    expect(await blob.text()).toBe("the body");
+    // No second file part.
+    expect(form.get("files[1]")).toBeNull();
+  });
+
+  test("empty content is allowed (file-only message)", async () => {
+    const form = buildAttachmentForm("", [file("only.txt", "x")]);
+    const payload = await payloadOf(form);
+    expect(payload.content).toBe("");
+    expect(payload.attachments).toHaveLength(1);
+    expect(form.get("files[0]")).toBeInstanceOf(Blob);
+  });
+
+  test("no files → empty attachments array, no file parts", async () => {
+    const form = buildAttachmentForm("just text", []);
+    const payload = await payloadOf(form);
+    expect(payload.attachments).toEqual([]);
+    expect(form.get("files[0]")).toBeNull();
+  });
+
+  test("byte content round-trips exactly (binary-safe)", async () => {
+    const bytes = new Uint8Array([0, 1, 2, 254, 255]);
+    const form = buildAttachmentForm("", [{ filename: "raw.bin", bytes }]);
+    const blob = form.get("files[0]") as Blob;
+    expect(new Uint8Array(await blob.arrayBuffer())).toEqual(bytes);
+  });
+});

--- a/src/cli/discord/discord.ts
+++ b/src/cli/discord/discord.ts
@@ -12,7 +12,8 @@ import { loadConfig, saveConfig, getConfigPath } from "./lib/config";
 import { resolveServerContext, registerServerProfile, ServerContextError } from "./lib/server-context";
 import type { ResolvedServerContext, ServerContextOptions } from "./lib/server-context";
 import type { DiscordCliConfig } from "./lib/config";
-import { postMessage, createThreadFromMessage, resolveChannelByName, resolveThreadByName, readMessages, listChannels, listThreads } from "./lib/discord";
+import { postMessage, postMessageWithFiles, createThreadFromMessage, resolveChannelByName, resolveThreadByName, readMessages, listChannels, listThreads, type AttachmentInput } from "./lib/discord";
+import { basename } from "node:path";
 
 // Per-command option shapes. Commander's typing is permissive; pinning each
 // `.action((opts) => …)` to the concrete shape lets the typed-checked preset
@@ -22,6 +23,7 @@ interface PostOptions extends ServerContextOptions {
   channel?: string;
   thread?: string;
   createThread?: string;
+  file?: string[];
 }
 interface ReadOptions extends ServerContextOptions {
   channel?: string;
@@ -69,20 +71,41 @@ const program = new Command()
 program
   .command("post")
   .description("Post a message to a Discord channel")
-  .argument("<message...>", "Message text (multiple words joined)")
+  .argument("[message...]", "Message text (optional when --file is given)")
   .option("-c, --channel <name>", "Channel name (default: defaultChannel from config)")
   .option("-t, --thread <name-or-id>", "Thread name or ID to post into")
   .option("-T, --create-thread <name>", "Create a thread from the posted message and print its ID")
+  .option("-f, --file <path>", "Attach a file (repeatable)", (v: string, acc: string[]) => [...acc, v], [])
   .option("-g, --guild <id>", "Guild ID to resolve channel/thread names against (overrides config)")
   .option("-s, --server <name>", "Named server profile from config (layers guildId + overrides)")
   .action(async (messageParts: string[], opts: PostOptions) => {
     const config = loadConfig();
     const ctx = resolveContextOrExit(config, opts);
     const message = messageParts.join(" ");
+    const filePaths = opts.file ?? [];
 
     if (opts.thread && opts.createThread) {
       console.error("--thread and --create-thread are mutually exclusive (a thread cannot contain a thread).");
       process.exit(1);
+    }
+
+    // A post must carry SOMETHING — text or at least one file. An empty post
+    // is rejected before any network call (no dangling empty message).
+    if (message.length === 0 && filePaths.length === 0) {
+      console.error("Nothing to post: provide a message, one or more --file, or both.");
+      process.exit(1);
+    }
+
+    // Read + existence-check every attachment BEFORE resolving the channel or
+    // hitting the API, so a bad path fails cleanly with nothing posted.
+    const attachments: AttachmentInput[] = [];
+    for (const path of filePaths) {
+      const f = Bun.file(path);
+      if (!(await f.exists())) {
+        console.error(`Attachment not found: ${path}`);
+        process.exit(1);
+      }
+      attachments.push({ filename: basename(path), bytes: new Uint8Array(await f.arrayBuffer()) });
     }
 
     if (!ctx.botToken) {
@@ -136,12 +159,15 @@ program
       process.exit(1);
     }
 
-    const result = await postMessage(ctx.botToken, targetId, message);
+    const result = attachments.length > 0
+      ? await postMessageWithFiles(ctx.botToken, targetId, message, attachments)
+      : await postMessage(ctx.botToken, targetId, message);
     if (!result.success) {
       console.error(`Failed: ${result.error}`);
       process.exit(1);
     }
-    console.log(`Posted to #${channelName}${opts.thread ? ` (thread)` : ""}`);
+    const attachNote = attachments.length > 0 ? ` (+${attachments.length} file${attachments.length === 1 ? "" : "s"})` : "";
+    console.log(`Posted to #${channelName}${opts.thread ? ` (thread)` : ""}${attachNote}`);
 
     if (opts.createThread) {
       if (!result.messageId) {

--- a/src/cli/discord/lib/discord.ts
+++ b/src/cli/discord/lib/discord.ts
@@ -107,11 +107,13 @@ export async function postMessage(
  *  pure function (testable without fs or a token). */
 export interface AttachmentInput {
   filename: string;
-  bytes: Uint8Array;
+  /** ArrayBuffer-backed (not Shared) so it appends to a Blob without a copy. */
+  bytes: Uint8Array<ArrayBuffer>;
 }
 
 /**
- * Build the `multipart/form-data` body for an attachment post (Discord v10).
+ * Build the `multipart/form-data` body for an attachment post (Discord v10:
+ * https://discord.com/developers/docs/reference#uploading-files).
  *
  * Pure — no I/O. The form carries a `payload_json` part (message fields plus an
  * `attachments` array that references each file by index) and one `files[n]`
@@ -127,7 +129,8 @@ export function buildAttachmentForm(content: string, files: AttachmentInput[]): 
   };
   form.append("payload_json", JSON.stringify(payload));
   files.forEach((f, i) => {
-    form.append(`files[${i}]`, new Blob([f.bytes.slice().buffer]), f.filename);
+    // Blob accepts the Uint8Array view directly — no copy (sage cortex#1031).
+    form.append(`files[${i}]`, new Blob([f.bytes]), f.filename);
   });
   return form;
 }

--- a/src/cli/discord/lib/discord.ts
+++ b/src/cli/discord/lib/discord.ts
@@ -102,6 +102,63 @@ export async function postMessage(
   return { success: true, messageId: data.id };
 }
 
+/** One attachment, already read into memory. The CLI owns the file read +
+ *  existence check; this module owns the wire format, so the builder stays a
+ *  pure function (testable without fs or a token). */
+export interface AttachmentInput {
+  filename: string;
+  bytes: Uint8Array;
+}
+
+/**
+ * Build the `multipart/form-data` body for an attachment post (Discord v10).
+ *
+ * Pure — no I/O. The form carries a `payload_json` part (message fields plus an
+ * `attachments` array that references each file by index) and one `files[n]`
+ * part per attachment. Do NOT set a Content-Type header when sending this:
+ * fetch derives the multipart boundary from the FormData itself.
+ */
+export function buildAttachmentForm(content: string, files: AttachmentInput[]): FormData {
+  const form = new FormData();
+  const payload = {
+    content,
+    // Discord references uploaded files by the same index used in files[n].
+    attachments: files.map((f, i) => ({ id: i, filename: f.filename })),
+  };
+  form.append("payload_json", JSON.stringify(payload));
+  files.forEach((f, i) => {
+    form.append(`files[${i}]`, new Blob([f.bytes.slice().buffer]), f.filename);
+  });
+  return form;
+}
+
+/**
+ * Post a message with one or more file attachments via bot API.
+ * `content` may be empty when at least one file is present (Discord allows a
+ * file-only message). Same `PostResult` contract as `postMessage`.
+ */
+export async function postMessageWithFiles(
+  botToken: string,
+  channelId: string,
+  content: string,
+  files: AttachmentInput[]
+): Promise<PostResult> {
+  const res = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+    method: "POST",
+    // No Content-Type — fetch sets multipart/form-data + boundary from the body.
+    headers: { Authorization: `Bot ${botToken}` },
+    body: buildAttachmentForm(content, files),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    return { success: false, error: `${res.status}: ${text}` };
+  }
+
+  const data = (await res.json()) as DiscordApiMessageCreated;
+  return { success: true, messageId: data.id };
+}
+
 export interface CreateThreadResult {
   success: boolean;
   threadId?: string;

--- a/src/cli/discord/skill/SKILL.md
+++ b/src/cli/discord/skill/SKILL.md
@@ -85,3 +85,7 @@ servers:
 ```
 
 Config stored at `~/.config/grove/cli.yaml`.
+
+## Attachments
+
+`discord post --file <path>` attaches a local file (repeatable); the message text is optional when a file is present. Files are read + existence-checked before the post, so a bad path posts nothing.

--- a/src/cli/discord/skill/Workflows/Post.md
+++ b/src/cli/discord/skill/Workflows/Post.md
@@ -15,6 +15,9 @@ Post a message to a Discord channel.
    discord post --channel <name> "Your message here"
    # Or into a thread:
    discord post --thread <id> "Your message here"
+   # Attach one or more files (repeatable; message becomes optional):
+   discord post --channel <name> --file ./report.pdf "Monthly report"
+   discord post --file ./a.md --file ./a.envelope.json
    ```
 
 4. **Confirm** — report success or failure to the user.
@@ -38,6 +41,7 @@ top-level config. With no `--server`/`--guild`, posting is exactly as before.
 ## Notes
 
 - For multi-line messages, use quotes and `\n` or write to a temp file first.
+- `--file <path>` attaches a local file (repeatable). The message is optional when at least one file is given. Each path is existence-checked before anything is posted, so a bad path fails cleanly with nothing sent.
 - If posting fails with "Bot token required", run `discord config show` and guide setup.
 - Channel names are resolved automatically on first use and cached (per guild).
 - `--guild` and `--server` must not disagree on the guild — the CLI errors if they do.


### PR DESCRIPTION
Adds `discord post --file <path>` (repeatable) — the discord CLI was text-only. Multipart upload per Discord v10 (payload_json + files[n] + attachments[]).

- pure `buildAttachmentForm` (testable without fs/token) + `postMessageWithFiles`
- message becomes optional when a file is present; empty post rejected; paths existence-checked before any network call (bad path posts nothing); `--create-thread` still works
- 24 discord tests pass (5 new), eslint clean; SKILL.md + Post.md updated

New outbound capability (bot can upload local files) — the reusable mechanism; a pulse `A_NOTIFY_DISCORD` action will call it for internal delivery (NOT the diplomatic pouch — that stays human-relayed by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)