### PR TITLE
feat(brain): B-1 wiring — brain: schema + BrainConsumer + hot-reload integration (#1021)

### DIFF
--- a/src/__tests__/cortex.agents-reload.test.ts
+++ b/src/__tests__/cortex.agents-reload.test.ts
@@ -22,7 +22,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -136,6 +136,7 @@ function removeFragment(id: string): void {
 
 async function bootWatcherless(
   runtime: RecordingRuntime,
+  opts: { brainPackBaseDir?: string } = {},
 ): Promise<CortexHandle> {
   const handle = await startCortex(minimalConfig(), {
     disableConfigWatcher: true,
@@ -146,9 +147,36 @@ async function bootWatcherless(
     configPath: join(tmpAgentsDir, "cortex.yaml"), // so agentsDir resolution + pid path are coherent
     injectRuntime: runtime,
     principal: { id: "test-op" },
+    ...(opts.brainPackBaseDir !== undefined && {
+      brainPackBaseDir: opts.brainPackBaseDir,
+    }),
   });
   handles.push(handle);
   return handle;
+}
+
+/**
+ * Bot Packs B-1 — write an exec-brain agent fragment. Declares a `brain:` block
+ * with `kind: exec` + a `run` pointing at the pack's `brain/main.ts` (`{pack}`
+ * expands to `{brainPackBaseDir}/{id}`).
+ */
+function writeBrainFragment(id: string, capabilities: string[]): void {
+  const personaPath = join(tmpPersonasDir, `${id}.md`);
+  writeFileSync(personaPath, `# ${id} persona\n`);
+  const caps = capabilities.map((c) => `    - "${c}"`).join("\n");
+  const yaml = `id: ${id}
+displayName: ${id.charAt(0).toUpperCase() + id.slice(1)}
+persona: "${personaPath}"
+presence: {}
+runtime:
+  mode: in-process
+  capabilities:
+${caps}
+  brain:
+    kind: exec
+    run: "bun {pack}/brain/main.ts"
+`;
+  writeFileSync(join(tmpAgentsDir, `${id}.yaml`), yaml);
 }
 
 // Capability-registration envelopes carry the per-agent payload.
@@ -469,5 +497,116 @@ describe("startCortex — agents.d/ fs.watch reconcile (B-0, cortex#1021)", () =
       "luna",
     ]);
     expect(reloaded.some((added) => added.includes("luna"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — Bot Packs B-1 brain consumers (hot add/remove/change)
+// ---------------------------------------------------------------------------
+
+describe("startCortex — exec-brain consumers hot reload (B-1, cortex#1021)", () => {
+  let packBase: string;
+
+  beforeEach(() => {
+    packBase = mkdtempSync(join(tmpdir(), "cortex-reload-packs-"));
+  });
+  afterEach(() => {
+    rmSync(packBase, { recursive: true, force: true });
+  });
+
+  /** Drop a fixture brain at `{packBase}/{id}/brain/main.ts`. */
+  function writeBrainPack(id: string): void {
+    const dir = join(packBase, id, "brain");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "main.ts"),
+      `import { createInterface } from "node:readline";
+const rl = createInterface({ input: process.stdin });
+const it = rl[Symbol.asyncIterator]();
+const { value } = await it.next();
+const task = JSON.parse(value);
+process.stdout.write(JSON.stringify({ v: 1, type: "result", task_id: task.task_id, status: "complete" }) + "\\n");
+rl.close();
+process.exit(0);
+`,
+      "utf8",
+    );
+  }
+
+  /** Brain-consumer durables carry the `cortex-brain-consumer-` prefix. */
+  function brainDurables(runtime: RecordingRuntime): string[] {
+    return runtime.subscribePullCalls
+      .map((c) => c.durable ?? "")
+      .filter((d) => d.includes("cortex-brain-consumer-"));
+  }
+
+  test("ADD an exec-brain fragment → brain consumer subscribes per capability", async () => {
+    const runtime = createRecordingRuntime();
+    const handle = await bootWatcherless(runtime, { brainPackBaseDir: packBase });
+    expect(brainDurables(runtime).length).toBe(0);
+
+    writeBrainPack("yarrow");
+    writeBrainFragment("yarrow", ["soc.compose.flow"]);
+    await handle.reloadAgents("cli");
+
+    expect(handle.agentRegistry.getById("yarrow").id).toBe("yarrow");
+    // A brain consumer bound a durable for the declared capability — NOT a
+    // review consumer (the agent declares no code-review capability anyway).
+    const durables = brainDurables(runtime);
+    expect(durables.some((d) => d.includes("yarrow"))).toBe(true);
+    expect(durables.some((d) => d.includes("soc-compose-flow"))).toBe(true);
+  });
+
+  test("exec-brain agent is NOT hosted by a review consumer", async () => {
+    const runtime = createRecordingRuntime();
+    // Declare an exec brain that ALSO lists a code-review capability — the brain
+    // path wins; no review consumer is created for it.
+    writeBrainPack("hybrid");
+    writeBrainFragment("hybrid", ["code-review.typescript", "soc.compose.flow"]);
+    const handle = await bootWatcherless(runtime, { brainPackBaseDir: packBase });
+
+    const reviewDurables = runtime.subscribePullCalls
+      .map((c) => c.durable ?? "")
+      .filter((d) => d.includes("cortex-review-consumer-"));
+    expect(reviewDurables.some((d) => d.includes("hybrid"))).toBe(false);
+    // But a brain consumer IS bound.
+    expect(brainDurables(runtime).some((d) => d.includes("hybrid"))).toBe(true);
+    expect(handle.agentRegistry.getById("hybrid").id).toBe("hybrid");
+  });
+
+  test("REMOVE an exec-brain fragment → brain consumer drained", async () => {
+    const runtime = createRecordingRuntime();
+    writeBrainPack("yarrow");
+    writeBrainFragment("yarrow", ["soc.compose.flow"]);
+    const handle = await bootWatcherless(runtime, { brainPackBaseDir: packBase });
+    expect(brainDurables(runtime).some((d) => d.includes("yarrow"))).toBe(true);
+
+    removeFragment("yarrow");
+    await handle.reloadAgents("cli");
+
+    // The brain consumer's subscriber was stopped (drained).
+    expect(
+      runtime.stoppedSubscribers.some((d) => d.includes("yarrow")),
+    ).toBe(true);
+    expect(handle.agentRegistry.getAll().map((a) => a.id)).not.toContain("yarrow");
+  });
+
+  test("CHANGE an exec-brain fragment (new capability) → remove+add brain consumer", async () => {
+    const runtime = createRecordingRuntime();
+    writeBrainPack("yarrow");
+    writeBrainFragment("yarrow", ["soc.compose.flow"]);
+    const handle = await bootWatcherless(runtime, { brainPackBaseDir: packBase });
+    const before = runtime.subscribePullCalls.length;
+
+    writeBrainFragment("yarrow", ["soc.compose.flow", "soc.triage.email"]);
+    await handle.reloadAgents("cli");
+
+    // Old brain consumer drained, new one started → a fresh subscribe happened
+    // (now two capabilities → two durables on the new consumer).
+    expect(runtime.stoppedSubscribers.some((d) => d.includes("yarrow"))).toBe(true);
+    expect(runtime.subscribePullCalls.length).toBeGreaterThan(before);
+    expect(
+      brainDurables(runtime).some((d) => d.includes("soc-triage-email")),
+    ).toBe(true);
   });
 });

--- a/src/bus/__tests__/brain-consumer.test.ts
+++ b/src/bus/__tests__/brain-consumer.test.ts
@@ -294,14 +294,14 @@ describe("BrainConsumer — happy path", () => {
 
     const posts = published(runtime, "dispatch.task.post");
     expect(posts.length).toBe(1);
-    const p = posts[0]?.payload as { text?: string; task_source?: unknown };
+    const p = posts[0]?.payload as { text?: string; response_routing?: unknown; triggered_by?: string };
     expect(p.text).toBe("Composed the flow.");
-    expect(p.task_source).toEqual({
+    expect(p.response_routing).toEqual({
       surface: "mattermost",
       channel: "c9",
       thread: "t9",
-      user: "alice",
     });
+    expect(p.triggered_by).toBe("alice");
   });
 });
 

--- a/src/bus/__tests__/brain-consumer.test.ts
+++ b/src/bus/__tests__/brain-consumer.test.ts
@@ -1,0 +1,610 @@
+/**
+ * `brain-consumer` unit tests (Bot Packs B-1).
+ *
+ * Two layers:
+ *   1. Stubbed `runBrainTask` — drives the consumer's POLICY + LIFECYCLE paths
+ *      deterministically (backpressure, sovereignty ceiling, dispatch allow-list,
+ *      ask_principal gate, terminal envelope publication, ack/nak/term mapping).
+ *   2. Real fixture brain via `makeExecBrainRunner` — one end-to-end happy path
+ *      (bus task → brain → post published → completed envelope), reusing the
+ *      test-brain fixture pattern from `src/brain/__tests__`.
+ *
+ * No real NATS — a recording runtime captures publishes. No real `claude`.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  BrainConsumer,
+  DenyAllPrincipalGate,
+  checkDowngradeOnly,
+  deriveTaskSource,
+  brainReasonToDispatchReason,
+  buildDispatchTaskEnvelope,
+  type BrainConsumerAgent,
+  type BrainConsumerOpts,
+  type PrincipalGate,
+} from "../brain-consumer";
+import type { Envelope } from "../myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../myelin/runtime";
+import type { SystemEventSource } from "../system-events";
+import type {
+  RunBrainTask,
+  BrainTaskHooks,
+  BrainTaskRunResult,
+} from "../../brain/exec-brain-runner";
+import { makeExecBrainRunner } from "../../brain/exec-brain-runner";
+import type { TaskEvent, ResultEffect } from "../../brain/protocol";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SOURCE: SystemEventSource = {
+  principal: "jc",
+  agent: "cortex",
+  instance: "local",
+};
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const published: Envelope[] = [];
+  const handlers = new Set<EnvelopeHandler>();
+  return {
+    enabled: false,
+    published,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    stop: async () => {},
+  };
+}
+
+function buildAgent(over: Partial<BrainConsumerAgent> = {}): BrainConsumerAgent {
+  return {
+    id: "yarrow",
+    capabilities: ["soc.compose.flow"],
+    dispatchCapabilities: [],
+    modelClass: "local-only",
+    ...over,
+  };
+}
+
+/** A bus task envelope carrying a brain payload. `model_class` defaults local. */
+function makeTaskEnvelope(
+  over: Partial<Envelope["sovereignty"]> = {},
+  payload: Record<string, unknown> = { scenario: "phish" },
+): Envelope {
+  return {
+    id: crypto.randomUUID(),
+    source: "jc.metafactory.pilot",
+    type: "tasks.soc.compose.flow",
+    timestamp: new Date().toISOString(),
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+      ...over,
+    },
+    payload,
+  };
+}
+
+/** A `runBrainTask` stub resolving a fixed result; optionally drives hooks. */
+function stubRunner(
+  result: ResultEffect,
+  driveHooks?: (hooks: BrainTaskHooks, task: TaskEvent) => Promise<void>,
+): RunBrainTask {
+  return async (task, hooks): Promise<BrainTaskRunResult> => {
+    if (driveHooks) await driveHooks(hooks, task);
+    return { result, logs: [], stderrTail: "", exitCode: 0 };
+  };
+}
+
+function completeResult(taskId: string, summary?: string): ResultEffect {
+  return {
+    v: 1,
+    type: "result",
+    task_id: taskId,
+    status: "complete",
+    ...(summary !== undefined && { summary }),
+  };
+}
+
+function baseOpts(over: Partial<BrainConsumerOpts> = {}): BrainConsumerOpts {
+  return {
+    agent: buildAgent(),
+    source: SOURCE,
+    runtime: over.runtime ?? createRecordingRuntime(),
+    runBrainTask: over.runBrainTask ?? stubRunner(completeResult("x")),
+    ...over,
+  };
+}
+
+function published(runtime: RecordingRuntime, type: string): Envelope[] {
+  return runtime.published.filter((e) => e.type === type);
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("brain-consumer helpers", () => {
+  test("checkDowngradeOnly: undefined request always OK (inherits ceiling)", () => {
+    expect(checkDowngradeOnly(undefined, "local-only")).toEqual({ ok: true });
+    expect(checkDowngradeOnly(undefined, undefined)).toEqual({ ok: true });
+  });
+
+  test("checkDowngradeOnly: tighten is allowed, loosen is refused", () => {
+    // ceiling = any → request frontier (tighter) OK; request any (equal) OK.
+    expect(checkDowngradeOnly("frontier", "any").ok).toBe(true);
+    expect(checkDowngradeOnly("any", "any").ok).toBe(true);
+    // ceiling = local-only → request frontier (looser) REFUSED.
+    const refused = checkDowngradeOnly("frontier", "local-only");
+    expect(refused.ok).toBe(false);
+    // ceiling = frontier → request any (looser) REFUSED.
+    expect(checkDowngradeOnly("any", "frontier").ok).toBe(false);
+    // ceiling = frontier → request local-only (tighter) OK.
+    expect(checkDowngradeOnly("local-only", "frontier").ok).toBe(true);
+  });
+
+  test("checkDowngradeOnly: class-less agent ceiling is the loosest (any)", () => {
+    expect(checkDowngradeOnly("local-only", undefined).ok).toBe(true);
+    expect(checkDowngradeOnly("frontier", undefined).ok).toBe(true);
+  });
+
+  test("checkDowngradeOnly: unknown requested class is refused", () => {
+    const r = checkDowngradeOnly("bogus", "any");
+    expect(r.ok).toBe(false);
+  });
+
+  test("deriveTaskSource: bus-originated default + response_routing read", () => {
+    expect(deriveTaskSource(makeTaskEnvelope())).toEqual({
+      surface: "bus",
+      channel: "",
+      thread: "",
+      user: "",
+    });
+    const withRouting = makeTaskEnvelope({}, {
+      response_routing: { surface: "mattermost", channel: "c1", thread: "t1" },
+      user: "u1",
+    });
+    expect(deriveTaskSource(withRouting)).toEqual({
+      surface: "mattermost",
+      channel: "c1",
+      thread: "t1",
+      user: "u1",
+    });
+  });
+
+  test("brainReasonToDispatchReason: not_now carries retry_after_ms", () => {
+    expect(
+      brainReasonToDispatchReason({ kind: "not_now", detail: "busy", retry_after_ms: 500 }),
+    ).toEqual({ kind: "not_now", detail: "busy", retry_after_ms: 500 });
+    expect(brainReasonToDispatchReason({ kind: "cant_do", detail: "x" })).toEqual({
+      kind: "cant_do",
+      detail: "x",
+    });
+  });
+
+  test("buildDispatchTaskEnvelope: type=tasks.{cap}, local-only ⇒ frontier_ok=false", () => {
+    const env = buildDispatchTaskEnvelope({
+      source: SOURCE,
+      capability: "soc.triage.email",
+      payload: { a: 1 },
+      modelClass: "local-only",
+    });
+    expect(env.type).toBe("tasks.soc.triage.email");
+    expect(env.sovereignty.model_class).toBe("local-only");
+    expect(env.sovereignty.frontier_ok).toBe(false);
+    expect(env.source).toBe("jc.cortex.local");
+    expect(env.payload).toEqual({ a: 1 });
+  });
+
+  test("DenyAllPrincipalGate fails closed with the B-2 reason", async () => {
+    const v = await new DenyAllPrincipalGate().resolve();
+    expect(v.verdict).toBe("fail");
+    expect(v.principal).toBe("");
+    expect(v.notes).toContain("B-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle — happy path (stubbed runner)
+// ---------------------------------------------------------------------------
+
+describe("BrainConsumer — happy path", () => {
+  test("bus task → started + completed lifecycle envelopes; ack", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        runBrainTask: stubRunner(completeResult(env.id, "done")),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    expect(decision).toEqual({ kind: "ack" });
+    expect(published(runtime, "dispatch.task.started").length).toBe(1);
+    const completed = published(runtime, "dispatch.task.completed");
+    expect(completed.length).toBe(1);
+    expect(completed[0]?.correlation_id).toBe(env.id);
+    expect((completed[0]?.payload as { result_summary?: string }).result_summary).toBe("done");
+  });
+
+  test("brain post effect → brain.post lifecycle envelope with task source + text", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope({}, {
+      response_routing: { surface: "mattermost", channel: "c9", thread: "t9" },
+      user: "alice",
+    });
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
+          await hooks.onPost({
+            v: 1,
+            type: "post",
+            task_id: env.id,
+            text: "Composed the flow.",
+          });
+        }),
+      }),
+    );
+
+    await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    const posts = published(runtime, "brain.post");
+    expect(posts.length).toBe(1);
+    const p = posts[0]?.payload as { text?: string; task_source?: unknown };
+    expect(p.text).toBe("Composed the flow.");
+    expect(p.task_source).toEqual({
+      surface: "mattermost",
+      channel: "c9",
+      thread: "t9",
+      user: "alice",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sovereignty ceiling
+// ---------------------------------------------------------------------------
+
+describe("BrainConsumer — sovereignty ceiling", () => {
+  test("frontier agent + local-only task → enforce deny (term + failed wont_do)", async () => {
+    const runtime = createRecordingRuntime();
+    // Task demands a local model; the agent is frontier-capable → breach.
+    const env = makeTaskEnvelope({ model_class: "local-only", frontier_ok: false });
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        agent: buildAgent({ modelClass: "frontier" }),
+        sovereigntyEnforce: true,
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    expect(decision.kind).toBe("term");
+    const failed = published(runtime, "dispatch.task.failed");
+    expect(failed.length).toBe(1);
+    expect((failed[0]?.payload as { reason?: { kind?: string } }).reason?.kind).toBe("wont_do");
+    // The brain was never run — no started envelope on the deny path.
+    expect(published(runtime, "dispatch.task.started").length).toBe(0);
+  });
+
+  test("frontier agent + local-only task → audit-parity proceeds (no deny)", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope({ model_class: "local-only", frontier_ok: false });
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        agent: buildAgent({ modelClass: "frontier" }),
+        sovereigntyEnforce: false, // audit-parity
+        runBrainTask: stubRunner(completeResult(env.id)),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    expect(decision.kind).toBe("ack");
+    expect(published(runtime, "dispatch.task.started").length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch allow-list + downgrade-only sovereignty
+// ---------------------------------------------------------------------------
+
+describe("BrainConsumer — dispatch effect enforcement", () => {
+  test("dispatch outside allow-list → effect_rejected (wont_do) reaches the brain", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    let rejection: { rejected: boolean; reason?: { kind: string; detail: string } } | undefined;
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        // allow-list is EMPTY — any dispatch is refused.
+        agent: buildAgent({ dispatchCapabilities: [] }),
+        runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
+          const outcome = await hooks.onDispatch({
+            v: 1,
+            type: "dispatch",
+            task_id: env.id,
+            capability: "soc.triage.email",
+            payload: {},
+          });
+          rejection = outcome as typeof rejection;
+        }),
+      }),
+    );
+
+    await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    expect(rejection?.rejected).toBe(true);
+    expect(rejection?.reason?.kind).toBe("wont_do");
+    // No fleet dispatch envelope was published.
+    expect(published(runtime, "tasks.soc.triage.email").length).toBe(0);
+  });
+
+  test("dispatch in allow-list → fleet task envelope published, accepted", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    let outcome: { rejected: boolean } | undefined;
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        agent: buildAgent({ dispatchCapabilities: ["soc.triage.email"] }),
+        runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
+          outcome = (await hooks.onDispatch({
+            v: 1,
+            type: "dispatch",
+            task_id: env.id,
+            capability: "soc.triage.email",
+            payload: { msg: "x" },
+          })) as typeof outcome;
+        }),
+      }),
+    );
+
+    await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    expect(outcome?.rejected).toBe(false);
+    const dispatched = published(runtime, "tasks.soc.triage.email");
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0]?.payload).toEqual({ msg: "x" });
+  });
+
+  test("dispatch loosening sovereignty → refused (downgrade-only)", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    let outcome: { rejected: boolean; reason?: { detail: string } } | undefined;
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        // Agent ceiling local-only; the brain requests frontier (looser).
+        agent: buildAgent({
+          dispatchCapabilities: ["soc.triage.email"],
+          modelClass: "local-only",
+        }),
+        runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
+          outcome = (await hooks.onDispatch({
+            v: 1,
+            type: "dispatch",
+            task_id: env.id,
+            capability: "soc.triage.email",
+            payload: {},
+            sovereignty: { model_class: "frontier" },
+          })) as typeof outcome;
+        }),
+      }),
+    );
+
+    await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    expect(outcome?.rejected).toBe(true);
+    expect(outcome?.reason?.detail).toContain("tighten");
+    expect(published(runtime, "tasks.soc.triage.email").length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ask_principal gate
+// ---------------------------------------------------------------------------
+
+describe("BrainConsumer — ask_principal gate", () => {
+  test("DenyAll gate (default) → brain receives fail + empty principal", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    let verdict: { verdict: string; principal: string } | undefined;
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        // no principalGate ⇒ DenyAllPrincipalGate
+        runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
+          verdict = await hooks.onAskPrincipal({
+            v: 1,
+            type: "ask_principal",
+            task_id: env.id,
+            gate: "principal-ack",
+            prompt: "Run this flow?",
+          });
+        }),
+      }),
+    );
+
+    await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    expect(verdict?.verdict).toBe("fail");
+    expect(verdict?.principal).toBe("");
+  });
+
+  test("stub gate that passes → brain receives pass + resolved principal", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    const passGate: PrincipalGate = {
+      resolve: async () => ({ verdict: "pass", principal: "jc", notes: "run it" }),
+    };
+    let verdict: { verdict: string; principal: string } | undefined;
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        principalGate: passGate,
+        runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
+          verdict = await hooks.onAskPrincipal({
+            v: 1,
+            type: "ask_principal",
+            task_id: env.id,
+            gate: "principal-ack",
+            prompt: "Run this flow?",
+          });
+        }),
+      }),
+    );
+
+    await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    expect(verdict?.verdict).toBe("pass");
+    expect(verdict?.principal).toBe("jc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backpressure + failed terminal
+// ---------------------------------------------------------------------------
+
+describe("BrainConsumer — backpressure + failure", () => {
+  test("over maxConcurrent → nak not_now + failed envelope", async () => {
+    const runtime = createRecordingRuntime();
+    // A runner that blocks until we release it, to hold a slot in-flight.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const env1 = makeTaskEnvelope();
+    const env2 = makeTaskEnvelope();
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        agent: buildAgent({ maxConcurrent: 1 }),
+        runBrainTask: async (task): Promise<BrainTaskRunResult> => {
+          await gate;
+          return { result: completeResult(task.task_id), logs: [], stderrTail: "", exitCode: 0 };
+        },
+      }),
+    );
+
+    // First task occupies the only slot (don't await — it blocks on `gate`).
+    const first = consumer.processEnvelope(env1, "s", null, "soc.compose.flow");
+    // Let `first` register itself in the in-flight set (it yields on the
+    // `dispatch.task.started` publish + the blocked runner before the slot is
+    // claimed). A couple of macrotask ticks is ample and deterministic.
+    await new Promise((r) => setTimeout(r, 20));
+    // Second task hits the ceiling.
+    const second = await consumer.processEnvelope(env2, "s", null, "soc.compose.flow");
+
+    expect(second.kind).toBe("nak");
+    const failed = published(runtime, "dispatch.task.failed");
+    expect(failed.some((e) => (e.payload as { reason?: { kind?: string } }).reason?.kind === "not_now")).toBe(true);
+
+    release();
+    await first;
+  });
+
+  test("brain result failed (not_now) → failed envelope + nak", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        runBrainTask: stubRunner({
+          v: 1,
+          type: "result",
+          task_id: env.id,
+          status: "failed",
+          reason: { kind: "not_now", detail: "transient", retry_after_ms: 250 },
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(env, "s", null, "soc.compose.flow");
+
+    expect(decision.kind).toBe("nak");
+    expect((decision as { delayMs?: number }).delayMs).toBe(250);
+    const failed = published(runtime, "dispatch.task.failed");
+    expect(failed.length).toBe(1);
+    expect((failed[0]?.payload as { reason?: { kind?: string } }).reason?.kind).toBe("not_now");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end with a real fixture brain
+// ---------------------------------------------------------------------------
+
+describe("BrainConsumer — real fixture brain (end-to-end)", () => {
+  let fixtureDir: string;
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "brain-consumer-fixtures-"));
+  });
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  test(
+    "bus task → real brain posts + completes → brain.post + completed published",
+    async () => {
+      // A brain that reads the task off stdin (node:readline — incremental, the
+      // portable line-protocol reader the runner tests use), posts a line, then
+      // completes.
+      const brainPath = join(fixtureDir, "happy-brain.ts");
+      writeFileSync(
+        brainPath,
+        `import { createInterface } from "node:readline";
+const rl = createInterface({ input: process.stdin });
+const it = rl[Symbol.asyncIterator]();
+function emit(o) { process.stdout.write(JSON.stringify(o) + "\\n"); }
+const { value } = await it.next();
+const task = JSON.parse(value);
+emit({ v: 1, type: "post", task_id: task.task_id, text: "hello from brain" });
+emit({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: "ok" });
+rl.close();
+process.exit(0);
+`,
+        "utf8",
+      );
+
+      const runtime = createRecordingRuntime();
+      const runBrainTask = makeExecBrainRunner({
+        run: `bun ${brainPath}`,
+        packDir: fixtureDir,
+        timeoutMs: 8_000,
+        killGraceMs: 1_000,
+      });
+      const env = makeTaskEnvelope();
+      const consumer = new BrainConsumer(baseOpts({ runtime, runBrainTask }));
+
+      const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+      expect(decision).toEqual({ kind: "ack" });
+      expect(published(runtime, "brain.post").length).toBe(1);
+      expect(published(runtime, "dispatch.task.completed").length).toBe(1);
+    },
+    15_000,
+  );
+});

--- a/src/bus/__tests__/brain-consumer.test.ts
+++ b/src/bus/__tests__/brain-consumer.test.ts
@@ -70,6 +70,30 @@ function createRecordingRuntime(): RecordingRuntime {
   };
 }
 
+/**
+ * A runtime whose `publish` throws for envelope types matching `failTypes`
+ * (cortex#1033 §HonestOracle probe). Other publishes record normally.
+ */
+function createPublishFailingRuntime(failTypes: string[]): RecordingRuntime {
+  const published: Envelope[] = [];
+  const handlers = new Set<EnvelopeHandler>();
+  return {
+    enabled: false,
+    published,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: async (envelope: Envelope) => {
+      if (failTypes.includes(envelope.type)) {
+        throw new Error(`publish failed for ${envelope.type}`);
+      }
+      published.push(envelope);
+    },
+    stop: async () => {},
+  };
+}
+
 function buildAgent(over: Partial<BrainConsumerAgent> = {}): BrainConsumerAgent {
   return {
     id: "yarrow",
@@ -246,7 +270,7 @@ describe("BrainConsumer — happy path", () => {
     expect((completed[0]?.payload as { result_summary?: string }).result_summary).toBe("done");
   });
 
-  test("brain post effect → brain.post lifecycle envelope with task source + text", async () => {
+  test("brain post effect → dispatch.task.post lifecycle envelope with task source + text", async () => {
     const runtime = createRecordingRuntime();
     const env = makeTaskEnvelope({}, {
       response_routing: { surface: "mattermost", channel: "c9", thread: "t9" },
@@ -268,7 +292,7 @@ describe("BrainConsumer — happy path", () => {
 
     await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
 
-    const posts = published(runtime, "brain.post");
+    const posts = published(runtime, "dispatch.task.post");
     expect(posts.length).toBe(1);
     const p = posts[0]?.payload as { text?: string; task_source?: unknown };
     expect(p.text).toBe("Composed the flow.");
@@ -279,6 +303,89 @@ describe("BrainConsumer — happy path", () => {
       user: "alice",
     });
   });
+});
+
+// ---------------------------------------------------------------------------
+// Terminal publish failure — must NOT silently ack (cortex#1033 §HonestOracle)
+// ---------------------------------------------------------------------------
+
+describe("BrainConsumer — terminal publish failure", () => {
+  test(
+    "completed publish throws → nak-with-redelivery, NOT ack (result not stranded)",
+    async () => {
+      const runtime = createPublishFailingRuntime(["dispatch.task.completed"]);
+      const env = makeTaskEnvelope();
+      const consumer = new BrainConsumer(
+        baseOpts({
+          runtime,
+          runBrainTask: stubRunner(completeResult(env.id, "done")),
+        }),
+      );
+
+      const decision = await consumer.processEnvelope(
+        env,
+        "subj",
+        null,
+        "soc.compose.flow",
+      );
+
+      // A dropped terminal must redeliver, never ack into the void.
+      expect(decision).toEqual({ kind: "nak", delayMs: 0 });
+      // The completed envelope did NOT land (publish threw).
+      expect(published(runtime, "dispatch.task.completed").length).toBe(0);
+    },
+  );
+
+  test(
+    "failed publish throws → nak-with-redelivery, NOT the mapped failure ack",
+    async () => {
+      const runtime = createPublishFailingRuntime(["dispatch.task.failed"]);
+      const env = makeTaskEnvelope();
+      const consumer = new BrainConsumer(
+        baseOpts({
+          runtime,
+          runBrainTask: stubRunner({
+            v: 1,
+            type: "result",
+            task_id: env.id,
+            status: "failed",
+            reason: { kind: "cant_do", detail: "nope" },
+          }),
+        }),
+      );
+
+      const decision = await consumer.processEnvelope(
+        env,
+        "subj",
+        null,
+        "soc.compose.flow",
+      );
+
+      expect(decision).toEqual({ kind: "nak", delayMs: 0 });
+      expect(published(runtime, "dispatch.task.failed").length).toBe(0);
+    },
+  );
+
+  test(
+    "clean terminal publish still acks (no false-positive redelivery)",
+    async () => {
+      const runtime = createRecordingRuntime();
+      const env = makeTaskEnvelope();
+      const consumer = new BrainConsumer(
+        baseOpts({ runtime, runBrainTask: stubRunner(completeResult(env.id)) }),
+      );
+
+      const decision = await consumer.processEnvelope(
+        env,
+        "subj",
+        null,
+        "soc.compose.flow",
+      );
+
+      expect(decision).toEqual({ kind: "ack" });
+      expect(published(runtime, "dispatch.task.completed").length).toBe(1);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -421,6 +528,80 @@ describe("BrainConsumer — dispatch effect enforcement", () => {
     expect(outcome?.reason?.detail).toContain("tighten");
     expect(published(runtime, "tasks.soc.triage.email").length).toBe(0);
   });
+
+  test(
+    "cortex#1033 §Security — dispatch with OMITTED sovereignty inherits the " +
+      "agent ceiling, NOT 'any' (no frontier loosening)",
+    async () => {
+      const runtime = createRecordingRuntime();
+      const env = makeTaskEnvelope();
+      const consumer = new BrainConsumer(
+        baseOpts({
+          runtime,
+          // local-only brain dispatches WITHOUT a sovereignty block. The
+          // downgrade-only check passes (omitted ⇒ inherit), but the published
+          // envelope must carry the agent's local-only ceiling — never default
+          // to `any`/frontier-ok, which would let a local-only brain publish a
+          // frontier-allowed downstream task.
+          agent: buildAgent({
+            dispatchCapabilities: ["soc.triage.email"],
+            modelClass: "local-only",
+          }),
+          runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
+            await hooks.onDispatch({
+              v: 1,
+              type: "dispatch",
+              task_id: env.id,
+              capability: "soc.triage.email",
+              payload: {},
+              // no `sovereignty` — the regression vector.
+            });
+          }),
+        }),
+      );
+
+      await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+      const dispatched = published(runtime, "tasks.soc.triage.email");
+      expect(dispatched.length).toBe(1);
+      expect(dispatched[0]?.sovereignty.model_class).toBe("local-only");
+      expect(dispatched[0]?.sovereignty.frontier_ok).toBe(false);
+    },
+  );
+
+  test(
+    "cortex#1033 §Security — class-less agent (undefined ceiling) omitting " +
+      "sovereignty still falls through to 'any' (documented loosest default)",
+    async () => {
+      const runtime = createRecordingRuntime();
+      const env = makeTaskEnvelope();
+      const consumer = new BrainConsumer(
+        baseOpts({
+          runtime,
+          agent: buildAgent({
+            dispatchCapabilities: ["soc.triage.email"],
+            modelClass: undefined,
+          }),
+          runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
+            await hooks.onDispatch({
+              v: 1,
+              type: "dispatch",
+              task_id: env.id,
+              capability: "soc.triage.email",
+              payload: {},
+            });
+          }),
+        }),
+      );
+
+      await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+      const dispatched = published(runtime, "tasks.soc.triage.email");
+      expect(dispatched.length).toBe(1);
+      expect(dispatched[0]?.sovereignty.model_class).toBe("any");
+      expect(dispatched[0]?.sovereignty.frontier_ok).toBe(true);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -567,7 +748,7 @@ describe("BrainConsumer — real fixture brain (end-to-end)", () => {
   });
 
   test(
-    "bus task → real brain posts + completes → brain.post + completed published",
+    "bus task → real brain posts + completes → dispatch.task.post + completed published",
     async () => {
       // A brain that reads the task off stdin (node:readline — incremental, the
       // portable line-protocol reader the runner tests use), posts a line, then
@@ -602,7 +783,7 @@ process.exit(0);
       const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
 
       expect(decision).toEqual({ kind: "ack" });
-      expect(published(runtime, "brain.post").length).toBe(1);
+      expect(published(runtime, "dispatch.task.post").length).toBe(1);
       expect(published(runtime, "dispatch.task.completed").length).toBe(1);
     },
     15_000,

--- a/src/bus/__tests__/dispatch-events.test.ts
+++ b/src/bus/__tests__/dispatch-events.test.ts
@@ -358,7 +358,8 @@ describe("createDispatchTaskPostEvent", () => {
         task_id: TASK_ID,
         agent_id: "yarrow",
         text: "Composed the flow.",
-        task_source: { surface: "mattermost", channel: "c1", thread: "t1", user: "u1" },
+        response_routing: { surface: "mattermost", channel: "c1", thread: "t1" },
+        triggered_by: "u1",
       });
       expect(env.correlation_id).toBe(TASK_ID);
       expect(validateEnvelope(env).ok).toBe(true);

--- a/src/bus/__tests__/dispatch-events.test.ts
+++ b/src/bus/__tests__/dispatch-events.test.ts
@@ -21,6 +21,7 @@ import {
   createDispatchTaskCompletedEvent,
   createDispatchTaskFailedEvent,
   createDispatchTaskStartedEvent,
+  createDispatchTaskPostEvent,
   type DispatchEventSource,
 } from "../dispatch-events";
 
@@ -331,6 +332,62 @@ describe("createDispatchTaskAbortedEvent", () => {
       "principal-cancel: SIGINT received during shutdown drain",
     );
     expect(validateEnvelope(env).ok).toBe(true);
+  });
+});
+
+describe("createDispatchTaskPostEvent", () => {
+  test(
+    "cortex#1033 §Architecture — post rides the dispatch domain as " +
+      "dispatch.task.post (NOT a brain.* top-level domain); passes schema",
+    () => {
+      const env = createDispatchTaskPostEvent({
+        source: SOURCE,
+        taskId: TASK_ID,
+        agentId: "yarrow",
+        text: "Composed the flow.",
+        taskSource: {
+          surface: "mattermost",
+          channel: "c1",
+          thread: "t1",
+          user: "u1",
+        },
+      });
+      expect(env.type).toBe("dispatch.task.post");
+      expect(env.type.startsWith("dispatch.")).toBe(true);
+      expect(env.payload).toMatchObject({
+        task_id: TASK_ID,
+        agent_id: "yarrow",
+        text: "Composed the flow.",
+        task_source: { surface: "mattermost", channel: "c1", thread: "t1", user: "u1" },
+      });
+      expect(env.correlation_id).toBe(TASK_ID);
+      expect(validateEnvelope(env).ok).toBe(true);
+    },
+  );
+
+  test("attachment reference is carried when present, omitted otherwise", () => {
+    const withAtt = createDispatchTaskPostEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "yarrow",
+      text: "see attached",
+      taskSource: { surface: "bus", channel: "", thread: "", user: "" },
+      attachment: { filename: "report.md", path: "/scratch/report.md" },
+    });
+    expect((withAtt.payload as { attachment?: unknown }).attachment).toEqual({
+      filename: "report.md",
+      path: "/scratch/report.md",
+    });
+    expect(validateEnvelope(withAtt).ok).toBe(true);
+
+    const noAtt = createDispatchTaskPostEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "yarrow",
+      text: "no attachment",
+      taskSource: { surface: "bus", channel: "", thread: "", user: "" },
+    });
+    expect("attachment" in (noAtt.payload as object)).toBe(false);
   });
 });
 

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -435,6 +435,18 @@ export class BrainConsumer {
       );
     }
 
+    // 2b. Shutdown guard BEFORE `started` (sage cortex#1033 round 2): a task
+    // refused because the consumer is draining must never be recorded as
+    // started — publish the not_now failure and nak for the next boot.
+    if (this.stopped) {
+      await this.publishFailed(correlationId, {
+        kind: "not_now",
+        detail: "brain consumer is shutting down",
+        retry_after_ms: 0,
+      });
+      return { kind: "nak", delayMs: 0 };
+    }
+
     // 3. Emit dispatch.task.started — paired with the terminal via correlation.
     const startedAt = this.clock();
     await this.safePublish(
@@ -472,16 +484,18 @@ export class BrainConsumer {
     if (this.stopPromise) return this.stopPromise;
     this.stopPromise = (async () => {
       this.stopped = true;
-      for (const sub of this.subscribers) {
-        try {
-          await sub.stop();
-        } catch (err) {
+      // One subscriber per capability — stop them in one parallel wave
+      // (sage cortex#1033 round 2): shutdown latency is the slowest broker
+      // stop, not the sum.
+      const stops = await Promise.allSettled(this.subscribers.map((sub) => sub.stop()));
+      stops.forEach((res) => {
+        if (res.status === "rejected") {
           process.stderr.write(
             `brain-consumer: subscriber stop failed for agent=${this.agent.id}: ` +
-              `${err instanceof Error ? err.message : String(err)}\n`,
+              `${res.reason instanceof Error ? res.reason.message : String(res.reason)}\n`,
           );
         }
-      }
+      });
       if (this.inFlight.size > 0) {
         await Promise.allSettled(Array.from(this.inFlight));
       }

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -26,7 +26,7 @@
  *
  *   - **`onPost`** — B-1 is BUS-ORIGINATED: there is no live surface session to
  *     post into (the adapter/surface bridge is B-2). So a brain's `post` effect
- *     is published as a `brain.post` lifecycle envelope carrying the
+ *     is published as a `dispatch.task.post` lifecycle envelope carrying the
  *     text/attachment-ref + the task's source triple. We do NOT fake a
  *     `PlatformAdapter` wiring that can't be reached from a bus task — the
  *     honest B-1 behaviour is "publish the post intent onto the bus; B-2 renders
@@ -68,7 +68,7 @@
  *
  *   - NOT the daemon lifecycle — socket transport, supervision, drain-on-reload
  *     of a long-lived brain are B-2. This consumer is per-task only.
- *   - NOT the surface bridge — `onPost` publishes a `brain.post` envelope; the
+ *   - NOT the surface bridge — `onPost` publishes a `dispatch.task.post` envelope; the
  *     adapter that renders it is B-2.
  *   - NOT federation — B-1 binds `local.` only; cross-principal brain dispatch
  *     is out of scope.
@@ -88,7 +88,7 @@ import {
   createDispatchTaskStartedEvent,
   createDispatchTaskCompletedEvent,
   createDispatchTaskFailedEvent,
-  createBrainPostEvent,
+  createDispatchTaskPostEvent,
   type DispatchTaskFailedReason,
   type BrainPostSource,
 } from "./dispatch-events";
@@ -543,8 +543,20 @@ export class BrainConsumer {
     }
 
     // Terminal: publish completed/failed + map the JetStream control.
+    //
+    // cortex#1033 §HonestOracle blocker — the terminal envelope IS the task
+    // result; downstream waiters join on `dispatch.task.completed`/`…failed` via
+    // correlation_id. If that publish fails we must NOT ack: acking a dropped
+    // terminal strands the waiter (the result vanishes while the broker believes
+    // the task is done). ReviewConsumer's verdict path acks-after-swallow today
+    // (its `safePublish` logs-and-returns); rather than copy that latent bug, the
+    // brain path naks-with-redelivery so JetStream re-delivers and the per-task
+    // brain re-runs cleanly (idempotent — `processEnvelope` re-runs the brain on
+    // redelivery, see the §"NOT redelivery branch" note above). The review path
+    // retains its pre-existing behaviour (out of scope for this PR — noted in the
+    // disposition report).
     if (result.status === "complete") {
-      await this.safePublish(
+      const ok = await this.safePublish(
         createDispatchTaskCompletedEvent({
           source: this.source,
           taskId: crypto.randomUUID(),
@@ -556,12 +568,23 @@ export class BrainConsumer {
         }),
         "dispatch.task.completed",
       );
+      if (!ok) {
+        // Terminal publish lost — redeliver so the result is not silently
+        // dropped. `delayMs: 0` lets JetStream re-deliver on its own cadence.
+        return { kind: "nak", delayMs: 0 };
+      }
       return { kind: "ack" };
     }
 
     // status === "failed" — carry the brain's typed reason verbatim.
     const reason = brainReasonToDispatchReason(result.reason);
-    await this.publishFailed(correlationId, reason);
+    const failedOk = await this.publishFailed(correlationId, reason);
+    if (!failedOk) {
+      // Same rule as the completed path: a dropped `dispatch.task.failed` is a
+      // lost terminal result — nak-with-redelivery rather than ack the failure
+      // into the void.
+      return { kind: "nak", delayMs: 0 };
+    }
     return failedReasonToAckDecision(reason);
   }
 
@@ -578,12 +601,14 @@ export class BrainConsumer {
       user: source.user,
     };
     return {
-      // `post` — B-1 publishes a `brain.post` lifecycle envelope (no live
-      // surface session; the adapter bridge is B-2). The runner has already
-      // validated the attachment SHAPE + scratch confinement.
+      // `post` — B-1 publishes a `dispatch.task.post` lifecycle envelope (no
+      // live surface session; the adapter bridge is B-2). The runner has already
+      // validated the attachment SHAPE + scratch confinement. NON-TERMINAL: a
+      // lost post is a breadcrumb, not a stranded result, so the `safePublish`
+      // success flag is intentionally ignored here.
       onPost: async (post: PostEffect): Promise<void> => {
         await this.safePublish(
-          createBrainPostEvent({
+          createDispatchTaskPostEvent({
             source: this.source,
             taskId: crypto.randomUUID(),
             agentId: this.agent.id,
@@ -594,7 +619,7 @@ export class BrainConsumer {
               attachment: post.attachment,
             }),
           }),
-          "brain.post",
+          "dispatch.task.post",
         );
       },
 
@@ -645,12 +670,22 @@ export class BrainConsumer {
           };
         }
         // Allowed — publish a fleet task envelope under the agent's identity.
+        // SECURITY (cortex#1033 §Security blocker): an OMITTED dispatch
+        // sovereignty must inherit the AGENT's manifest ceiling, never default
+        // to the loosest class. `checkDowngradeOnly(undefined, …)` above passes
+        // (inherit), but the downstream envelope would otherwise be stamped
+        // `any`/frontier-ok by `buildDispatchTaskEnvelope`'s fallback — letting a
+        // `local-only` brain publish a frontier-allowed task. Resolve the
+        // effective class HERE (request ?? agent ceiling) so the published
+        // envelope carries the tightened ceiling the downgrade-only check
+        // promised. A class-less agent (undefined ceiling) still falls through to
+        // `any` inside the builder — that is the documented loosest default.
         await this.safePublish(
           buildDispatchTaskEnvelope({
             source: this.source,
             capability: dispatch.capability,
             payload: dispatch.payload,
-            modelClass: dispatch.sovereignty?.model_class,
+            modelClass: dispatch.sovereignty?.model_class ?? this.agent.modelClass,
           }),
           `dispatch:${dispatch.capability}`,
         );
@@ -666,13 +701,22 @@ export class BrainConsumer {
     };
   }
 
-  /** Publish a `dispatch.task.failed` envelope for a terminal failure. */
+  /**
+   * Publish a `dispatch.task.failed` envelope for a terminal failure. Returns
+   * the underlying `safePublish` success flag so the terminal caller in
+   * {@link runOne} can nak-with-redelivery on a dropped terminal (cortex#1033
+   * §HonestOracle). The PRE-SPAWN refusal callers in `processEnvelope`
+   * (backpressure / sovereignty-deny / shutdown) intentionally ignore the flag:
+   * they already carry their own nak/term AckDecision and a lost
+   * refusal-breadcrumb does not strand a result the way a dropped post-run
+   * terminal does.
+   */
   private async publishFailed(
     correlationId: string,
     reason: DispatchTaskFailedReason,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const now = this.clock();
-    await this.safePublish(
+    return this.safePublish(
       createDispatchTaskFailedEvent({
         source: this.source,
         taskId: crypto.randomUUID(),
@@ -692,15 +736,24 @@ export class BrainConsumer {
    * catch blocks"). A failed publish is noisy but must not crash the consumer
    * or prevent `processEnvelope` from returning an `AckDecision`. Mirrors
    * ReviewConsumer's `safePublish` (local-only — B-1 has no federated routing).
+   *
+   * Returns `true` on a clean publish, `false` when the publish threw (and was
+   * logged). NON-TERMINAL callers (`dispatch.task.started`, `dispatch.task.post`)
+   * ignore the result — a lost lifecycle breadcrumb is noise, not a correctness
+   * breach. The TERMINAL callers (`completed`/`failed`) inspect it: a lost
+   * terminal envelope IS a correctness breach (a waiter never sees the result),
+   * so they must NOT ack a dropped terminal — see {@link runOne}.
    */
-  private async safePublish(envelope: Envelope, label: string): Promise<void> {
+  private async safePublish(envelope: Envelope, label: string): Promise<boolean> {
     try {
       await this.runtime.publish(envelope);
+      return true;
     } catch (err) {
       process.stderr.write(
         `brain-consumer: publish failed for ${label} (agent=${this.agent.id}): ` +
           `${err instanceof Error ? err.message : String(err)}\n`,
       );
+      return false;
     }
   }
 }
@@ -716,7 +769,7 @@ export class BrainConsumer {
  * `payload.response_routing` / `payload.source` when present, else empty.
  *
  * The brain sees this only as metadata (§5 property 3); the B-2 surface bridge
- * is what turns a `brain.post` carrying it into a real thread reply.
+ * is what turns a `dispatch.task.post` carrying it into a real thread reply.
  */
 export function deriveTaskSource(envelope: Envelope): TaskSource {
   const p = envelope.payload as Record<string, unknown> | undefined;

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -166,6 +166,12 @@ export class DenyAllPrincipalGate implements PrincipalGate {
  * Minimal snapshot of an agent's runtime the BrainConsumer needs. Kept narrow
  * so tests build a fixture without the full Zod-validated `Agent`.
  */
+/**
+ * Finite default concurrency for exec brains (sage cortex#1033 round 3):
+ * one subprocess at a time unless the manifest raises it explicitly.
+ */
+export const DEFAULT_BRAIN_MAX_CONCURRENT = 1;
+
 export interface BrainConsumerAgent {
   /** Logical agent id — stamped onto every emitted envelope. */
   id: string;
@@ -396,15 +402,16 @@ export class BrainConsumer {
     const correlationId = envelope.id;
 
     // 1. Backpressure (§5 "Backpressure is host-side"). Over the ceiling →
-    //    publish a `not_now` failed envelope + nak with a retry hint.
-    if (
-      this.agent.maxConcurrent !== undefined &&
-      this.inFlight.size >= this.agent.maxConcurrent
-    ) {
+    //    publish a `not_now` failed envelope + nak with a retry hint. An
+    //    OMITTED maxConcurrent defaults to a FINITE cap (sage cortex#1033
+    //    round 3): every accepted task spawns a subprocess, so an unbounded
+    //    default would let a task burst grow processes without limit.
+    const concurrencyCap = this.agent.maxConcurrent ?? DEFAULT_BRAIN_MAX_CONCURRENT;
+    if (this.inFlight.size >= concurrencyCap) {
       const retryAfterMs = 1000;
       await this.publishFailed(correlationId, {
         kind: "not_now",
-        detail: `agent at maxConcurrent (${this.agent.maxConcurrent}) — try again`,
+        detail: `agent at maxConcurrent (${concurrencyCap}) — try again`,
         retry_after_ms: retryAfterMs,
       });
       return { kind: "nak", delayMs: retryAfterMs };

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -1,0 +1,846 @@
+/**
+ * `brain-consumer.ts` — Bot Packs B-1 (`docs/design-bot-packs.md` §5, §6, §8).
+ *
+ * The GENERAL capability-dispatch consumer for `kind: exec` brains. It is the
+ * bus-side half of the `cortex-brain/v1` per-task seam: it pull-subscribes to
+ * the agent's declared (non-code-review) capability task subjects, enforces
+ * backpressure + sovereignty BEFORE spawning, runs the brain via
+ * {@link RunBrainTask} (`exec-brain-runner.ts`), and routes each brain effect to
+ * a host action under policy.
+ *
+ * ## Relationship to ReviewConsumer
+ *
+ * Modeled on `review-consumer.ts`'s skeleton (pull subscription per capability,
+ * `maxConcurrent` backpressure, sovereignty enforcement, lifecycle envelope
+ * publication, drain-on-stop) but GENERAL: where ReviewConsumer hard-codes the
+ * `tasks.code-review.<flavor>` subject + the CC review pipeline, BrainConsumer
+ * derives `local.{principal}.{stack}.tasks.{capability}` for each of the
+ * agent's declared capabilities and runs the brain protocol bridge instead.
+ *
+ * It reuses the SHARED dispatch lifecycle builders
+ * (`createDispatchTaskStartedEvent` / `…CompletedEvent` / `…FailedEvent`) so a
+ * brain task's lifecycle stitches onto the dashboard exactly like a review's —
+ * no copy-pasted envelope assembly.
+ *
+ * ## The four brain effect hooks (this consumer's policy seam)
+ *
+ *   - **`onPost`** — B-1 is BUS-ORIGINATED: there is no live surface session to
+ *     post into (the adapter/surface bridge is B-2). So a brain's `post` effect
+ *     is published as a `brain.post` lifecycle envelope carrying the
+ *     text/attachment-ref + the task's source triple. We do NOT fake a
+ *     `PlatformAdapter` wiring that can't be reached from a bus task — the
+ *     honest B-1 behaviour is "publish the post intent onto the bus; B-2 renders
+ *     it to the thread".
+ *
+ *   - **`onAskPrincipal`** — resolved through a pluggable {@link PrincipalGate}.
+ *     B-1 ships ONE implementation: {@link DenyAllPrincipalGate}, a fail-closed
+ *     placeholder returning `fail` with reason "no principal gate configured
+ *     (B-2)". The typed seam is where B-2's real surface gate (the host-side
+ *     principal check — the pulse#47 lesson) lands. Tests inject a stub gate
+ *     that resolves a real principal + `pass`.
+ *
+ *   - **`onDispatch`** — enforces TWO host-side ceilings before publishing the
+ *     fleet task (§8):
+ *       1. the capability MUST be in the manifest's
+ *          `brain.dispatch_capabilities[]` allow-list — a brain may dispatch
+ *          only what its manifest allows; a violation is `effect_rejected`
+ *          (`wont_do`), which the runner delivers back to the brain.
+ *       2. sovereignty is DOWNGRADE-ONLY (§5 property 6): the brain's requested
+ *          `model_class` may only TIGHTEN the agent's manifest ceiling, never
+ *          loosen it. A loosening request is refused the same way.
+ *     An allowed dispatch publishes a task envelope on the bus under the
+ *     agent's own source identity.
+ *
+ *   - **`result`** — publishes `dispatch.task.completed` / `dispatch.task.failed`
+ *     lifecycle envelopes exactly like ReviewConsumer does, via the shared
+ *     builders + the `failedReasonToAckDecision` mapping the JetStream control.
+ *
+ * ## Lifecycle
+ *
+ *   1. `new BrainConsumer(opts)` — registers; does NOT subscribe.
+ *   2. `await consumer.start(opts)` — opens ONE pull subscription PER declared
+ *      capability. `processEnvelope` is the testability seam (drive an envelope
+ *      without a real broker).
+ *   3. `await consumer.stop()` — drains in-flight brain tasks, stops every
+ *      subscription. Idempotent.
+ *
+ * ## Anti-scope (B-1)
+ *
+ *   - NOT the daemon lifecycle — socket transport, supervision, drain-on-reload
+ *     of a long-lived brain are B-2. This consumer is per-task only.
+ *   - NOT the surface bridge — `onPost` publishes a `brain.post` envelope; the
+ *     adapter that renders it is B-2.
+ *   - NOT federation — B-1 binds `local.` only; cross-principal brain dispatch
+ *     is out of scope.
+ */
+
+import type { JsMsg } from "nats";
+import type { MyelinRuntime } from "./myelin/runtime";
+import type { Envelope } from "./myelin/envelope-validator";
+import type { MyelinSubscriber, AckDecision } from "./myelin/subscriber";
+import {
+  evaluateSovereignty,
+  type AgentModelClass,
+  type EnvelopeSovereignty,
+} from "./sovereignty-gate";
+import { buildSource, type SystemEventSource } from "./system-events";
+import {
+  createDispatchTaskStartedEvent,
+  createDispatchTaskCompletedEvent,
+  createDispatchTaskFailedEvent,
+  createBrainPostEvent,
+  type DispatchTaskFailedReason,
+  type BrainPostSource,
+} from "./dispatch-events";
+import { failedReasonToAckDecision } from "./review-consumer";
+import type {
+  RunBrainTask,
+  BrainTaskHooks,
+} from "../brain/exec-brain-runner";
+import type {
+  TaskEvent,
+  TaskSource,
+  PostEffect,
+  AskPrincipalEffect,
+  DispatchEffect,
+  ResultEffect,
+  GateVerdictValue,
+  BrainReason,
+} from "../brain/protocol";
+
+// ---------------------------------------------------------------------------
+// Principal gate — the ask_principal seam
+// ---------------------------------------------------------------------------
+
+/**
+ * The host-side principal gate that answers a brain's `ask_principal` effect.
+ *
+ * The brain NEVER infers a verdict from chat text — the host performs the
+ * principal check and forwards a {@link GateVerdictValue} carrying the
+ * HOST-RESOLVED principal (the pulse#47 lesson; §5 "Protocol contract
+ * details"). This is the typed seam B-2's surface gate plugs into; B-1 ships
+ * only {@link DenyAllPrincipalGate}.
+ */
+export interface PrincipalGate {
+  /**
+   * Resolve a gate. Returns the verdict + the host-resolved principal id (+
+   * optional notes). A `fail` verdict closes the gate negatively; the brain
+   * decides how to degrade.
+   */
+  resolve(input: {
+    agentId: string;
+    taskId: string;
+    gate: string;
+    prompt: string;
+    source: TaskSource;
+  }): Promise<{ verdict: GateVerdictValue; principal: string; notes?: string }>;
+}
+
+/**
+ * The B-1 fail-closed principal gate. There is no host-side surface gate in
+ * B-1 (it lands in B-2), so every `ask_principal` resolves to `fail` with a
+ * legible reason. A brain that needs a principal verdict in B-1 must degrade;
+ * it can never get a `pass` it wasn't entitled to. The resolved principal is
+ * empty because none was checked — paired with `fail`, the brain treats the
+ * gate as denied.
+ */
+export class DenyAllPrincipalGate implements PrincipalGate {
+  async resolve(): Promise<{
+    verdict: GateVerdictValue;
+    principal: string;
+    notes?: string;
+  }> {
+    return {
+      verdict: "fail",
+      principal: "",
+      notes: "no principal gate configured (B-2)",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal snapshot of an agent's runtime the BrainConsumer needs. Kept narrow
+ * so tests build a fixture without the full Zod-validated `Agent`.
+ */
+export interface BrainConsumerAgent {
+  /** Logical agent id — stamped onto every emitted envelope. */
+  id: string;
+  /**
+   * The capabilities this brain OFFERS the fleet (`runtime.capabilities`).
+   * The consumer binds one subscription per capability and routes inbound
+   * `tasks.{capability}` envelopes to the brain.
+   */
+  capabilities: readonly string[];
+  /**
+   * The manifest ALLOW-LIST for `dispatch` effects (`brain.dispatch_capabilities`).
+   * A brain `dispatch` for a capability NOT in this list is refused host-side
+   * (§8). Empty = a brain that may dispatch nothing.
+   */
+  dispatchCapabilities: readonly string[];
+  /** Optional `maxConcurrent` — admit at most this many in-flight tasks. */
+  maxConcurrent?: number;
+  /**
+   * The agent's declared model class — the manifest ceiling for the
+   * consumer-side sovereignty gate AND the downgrade-only `dispatch`
+   * sovereignty check. Absent → the gate fails closed for local-only tasks.
+   */
+  modelClass?: AgentModelClass;
+}
+
+/**
+ * Construction options. Every dependency is injected — no module-scope
+ * singletons. Production wires the real `runtime` + `runBrainTask`; tests
+ * inject doubles.
+ */
+export interface BrainConsumerOpts {
+  /** The agent this consumer serves. */
+  agent: BrainConsumerAgent;
+  /** Envelope source `{principal}.{agent}.{instance}` for emitted lifecycle envelopes. */
+  source: SystemEventSource;
+  /** The myelin runtime — used for `publish` + `subscribePull`. */
+  runtime: MyelinRuntime;
+  /**
+   * The configured per-task brain runner (from `makeExecBrainRunner` over the
+   * manifest's `brain` block). Injected so the consumer never owns spawn
+   * policy; tests pass a stub that resolves a deterministic result.
+   */
+  runBrainTask: RunBrainTask;
+  /**
+   * Optional persona text delivered to the brain on each `task` event (per-task
+   * brains receive persona on the task; §5 "Persona delivery"). Omitted → no
+   * persona field on the wire.
+   */
+  persona?: string;
+  /**
+   * The principal gate answering `ask_principal` effects. Defaults to
+   * {@link DenyAllPrincipalGate} (B-1 fail-closed). B-2 injects the surface gate.
+   */
+  principalGate?: PrincipalGate;
+  /**
+   * When `true`, the consumer-side sovereignty gate HARD-DENIES a task whose
+   * envelope demands a model class the agent's class would violate. When
+   * `false`/absent it runs in audit-parity (evaluate + log, but proceed) —
+   * mirrors ReviewConsumer's `sovereigntyEnforce` default rationale (a
+   * self-declared class is spoofable until bound to the signing identity).
+   */
+  sovereigntyEnforce?: boolean;
+  /** Test seam — clock. Defaults to `() => new Date()`. */
+  clock?: () => Date;
+}
+
+/**
+ * Options for {@link BrainConsumer.start} when binding real JetStream pull
+ * consumers. ONE subscription opens per declared capability; the caller
+ * supplies a per-capability `(capability) => { pattern, stream, durable }`
+ * resolver so the boot wiring owns the subject grammar + durable naming.
+ */
+export interface BrainConsumerStartOpts {
+  /**
+   * Resolve the pull-subscription parameters for one capability. Returning
+   * `null` skips binding that capability (e.g. a capability with no provisioned
+   * stream). The boot path derives
+   * `local.{principal}.{stack}.tasks.{capability}` + a per-(agent,capability)
+   * durable.
+   */
+  resolve(capability: string): {
+    pattern: string;
+    stream: string;
+    durable: string;
+    maxMessages?: number;
+    expiresMs?: number;
+    thresholdMessages?: number;
+  } | null;
+}
+
+/** Boot/log info per the consumer's `start()` outcome. */
+export interface BrainConsumerStartedInfo {
+  agentId: string;
+  capabilities: readonly string[];
+  /** Capabilities whose pull subscription actually opened on the broker. */
+  subscribedCapabilities: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Class
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-agent, capability-addressed brain consumer (Bot Packs B-1).
+ */
+export class BrainConsumer {
+  readonly agent: BrainConsumerAgent;
+
+  private readonly source: SystemEventSource;
+  private readonly runtime: MyelinRuntime;
+  private readonly runBrainTask: RunBrainTask;
+  private readonly persona: string | undefined;
+  private readonly principalGate: PrincipalGate;
+  private readonly sovereigntyEnforce: boolean;
+  private readonly clock: () => Date;
+
+  /** The manifest dispatch allow-list, as a Set for O(1) membership. */
+  private readonly dispatchAllow: Set<string>;
+  /** Promises for in-flight brain tasks so `stop()` can drain. */
+  private readonly inFlight = new Set<Promise<void>>();
+  /** Open pull subscriptions (one per bound capability). */
+  private readonly subscribers: MyelinSubscriber[] = [];
+
+  private started = false;
+  private stopped = false;
+  private stopPromise: Promise<void> | null = null;
+
+  constructor(opts: BrainConsumerOpts) {
+    this.agent = opts.agent;
+    this.source = opts.source;
+    this.runtime = opts.runtime;
+    this.runBrainTask = opts.runBrainTask;
+    this.persona = opts.persona;
+    this.principalGate = opts.principalGate ?? new DenyAllPrincipalGate();
+    this.sovereigntyEnforce = opts.sovereigntyEnforce ?? false;
+    this.clock = opts.clock ?? (() => new Date());
+    this.dispatchAllow = new Set(opts.agent.dispatchCapabilities);
+  }
+
+  /**
+   * Bind one pull subscription per declared capability. Idempotent-guarded
+   * (throws if already started). A capability whose `resolve` returns null —
+   * or whose `subscribePull` returns null (runtime dormant) — is skipped and
+   * NOT counted as subscribed, so the boot log can be honest.
+   */
+  async start(opts: BrainConsumerStartOpts): Promise<BrainConsumerStartedInfo> {
+    if (this.started) {
+      throw new Error(
+        `brain-consumer: already started for agent="${this.agent.id}"`,
+      );
+    }
+    this.started = true;
+    const subscribedCapabilities: string[] = [];
+
+    for (const capability of this.agent.capabilities) {
+      const resolved = opts.resolve(capability);
+      if (resolved === null) continue;
+
+      const subscribePullOpts: {
+        pattern: string;
+        stream: string;
+        durable: string;
+        onEnvelope: (envelope: Envelope, subject: string) => Promise<AckDecision>;
+        maxMessages?: number;
+        expiresMs?: number;
+        thresholdMessages?: number;
+      } = {
+        pattern: resolved.pattern,
+        stream: resolved.stream,
+        durable: resolved.durable,
+        // Capture THIS capability so the routed task carries the right id even
+        // though one consumer serves several capabilities.
+        onEnvelope: async (envelope, subject) =>
+          this.processEnvelope(envelope, subject, null, capability),
+      };
+      if (resolved.maxMessages !== undefined) {
+        subscribePullOpts.maxMessages = resolved.maxMessages;
+      }
+      if (resolved.expiresMs !== undefined) {
+        subscribePullOpts.expiresMs = resolved.expiresMs;
+      }
+      if (resolved.thresholdMessages !== undefined) {
+        subscribePullOpts.thresholdMessages = resolved.thresholdMessages;
+      }
+
+      // `subscribePull` is OPTIONAL on MyelinRuntime (the additivity constraint
+      // ReviewConsumer also honours). An undefined property or a null return
+      // means the runtime is disabled — skip, leave the capability unsubscribed.
+      const sub = this.runtime.subscribePull
+        ? this.runtime.subscribePull(subscribePullOpts)
+        : null;
+      if (sub === null) continue;
+      this.subscribers.push(sub);
+      await sub.ready;
+      subscribedCapabilities.push(capability);
+    }
+
+    return {
+      agentId: this.agent.id,
+      capabilities: this.agent.capabilities,
+      subscribedCapabilities,
+    };
+  }
+
+  /**
+   * Drive one envelope through the brain. Public for tests (which call this
+   * directly without a broker). Always returns an `AckDecision` so the
+   * subscriber can drive ack/nak/term without exception handling.
+   *
+   * Pipeline:
+   *   1. backpressure gate (over `maxConcurrent` → nak `not_now`);
+   *   2. sovereignty gate (envelope demand vs. agent model class);
+   *   3. emit `dispatch.task.started`;
+   *   4. run the brain (effects routed to host hooks);
+   *   5. publish the terminal `dispatch.task.completed`/`failed` + map the ack.
+   */
+  async processEnvelope(
+    envelope: Envelope,
+    _subject: string,
+    msg: JsMsg | null,
+    capability: string,
+  ): Promise<AckDecision> {
+    // Avoid an unused-parameter lint on the JsMsg handle: B-1 has no redelivery
+    // branch (unlike ReviewConsumer's §2.3 aborted-emit) — the per-task brain
+    // re-runs cleanly on redelivery. Kept in the signature for parity + B-2.
+    void msg;
+
+    const correlationId = envelope.id;
+
+    // 1. Backpressure (§5 "Backpressure is host-side"). Over the ceiling →
+    //    publish a `not_now` failed envelope + nak with a retry hint.
+    if (
+      this.agent.maxConcurrent !== undefined &&
+      this.inFlight.size >= this.agent.maxConcurrent
+    ) {
+      const retryAfterMs = 1000;
+      await this.publishFailed(correlationId, {
+        kind: "not_now",
+        detail: `agent at maxConcurrent (${this.agent.maxConcurrent}) — try again`,
+        retry_after_ms: retryAfterMs,
+      });
+      return { kind: "nak", delayMs: retryAfterMs };
+    }
+
+    // 2. Sovereignty ceiling — BEFORE spawn (the manifest is the ceiling; this
+    //    is where it bites). Audit-parity by default; hard-deny under enforce.
+    const sov = evaluateSovereignty(
+      toEnvelopeSovereignty(envelope),
+      this.agent.modelClass,
+    );
+    if (sov.decision === "deny") {
+      if (this.sovereigntyEnforce) {
+        process.stderr.write(
+          `cortex/brain-consumer: sovereignty DENIED (enforce) for ` +
+            `agent="${this.agent.id}" capability=${capability} envelope=${envelope.id} — ${sov.reason}\n`,
+        );
+        await this.publishFailed(correlationId, {
+          kind: "wont_do",
+          detail: sov.reason,
+        });
+        return { kind: "term", reason: `wont_do: ${sov.reason}` };
+      }
+      // Audit-parity: observable, does not yet bite.
+      process.stderr.write(
+        `cortex/brain-consumer: sovereignty would DENY (audit-parity) for ` +
+          `agent="${this.agent.id}" capability=${capability} envelope=${envelope.id} — ${sov.reason}\n`,
+      );
+    }
+
+    // 3. Emit dispatch.task.started — paired with the terminal via correlation.
+    const startedAt = this.clock();
+    await this.safePublish(
+      createDispatchTaskStartedEvent({
+        source: this.source,
+        taskId: crypto.randomUUID(),
+        agentId: this.agent.id,
+        correlationId,
+        startedAt,
+      }),
+      "dispatch.task.started",
+    );
+
+    // 4+5. Run the brain, then publish the terminal envelope + map the ack.
+    const taskPromise = this.runOne(
+      envelope,
+      capability,
+      startedAt,
+      correlationId,
+    );
+    const drainSentinel = taskPromise.then(() => undefined);
+    this.inFlight.add(drainSentinel);
+    try {
+      return await taskPromise;
+    } finally {
+      this.inFlight.delete(drainSentinel);
+    }
+  }
+
+  /**
+   * Stop accepting new envelopes + drain in-flight brain tasks. Idempotent;
+   * concurrent callers share one Promise.
+   */
+  async stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise;
+    this.stopPromise = (async () => {
+      this.stopped = true;
+      for (const sub of this.subscribers) {
+        try {
+          await sub.stop();
+        } catch (err) {
+          process.stderr.write(
+            `brain-consumer: subscriber stop failed for agent=${this.agent.id}: ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
+      }
+      if (this.inFlight.size > 0) {
+        await Promise.allSettled(Array.from(this.inFlight));
+      }
+    })();
+    return this.stopPromise;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /**
+   * Build the `task` event, run the brain with the host hooks, then publish the
+   * terminal lifecycle envelope and return the `AckDecision`.
+   */
+  private async runOne(
+    envelope: Envelope,
+    capability: string,
+    startedAt: Date,
+    correlationId: string,
+  ): Promise<AckDecision> {
+    if (this.stopped) {
+      // Mid-shutdown: don't start new brain runs. Publish a failed envelope so
+      // a waiter doesn't hang, and nak so the next boot picks it up.
+      await this.publishFailed(correlationId, {
+        kind: "not_now",
+        detail: "brain consumer is shutting down",
+        retry_after_ms: 0,
+      });
+      return { kind: "nak", delayMs: 0 };
+    }
+
+    const source = deriveTaskSource(envelope);
+    const task: TaskEvent = {
+      v: 1,
+      type: "task",
+      task_id: correlationId,
+      capability,
+      payload: envelope.payload,
+      source,
+      ...(this.persona !== undefined && { persona: this.persona }),
+    };
+
+    let result: ResultEffect;
+    try {
+      const run = await this.runBrainTask(task, this.makeHooks(source));
+      result = run.result;
+    } catch (err) {
+      // The runner has a non-throwing contract (it synthesizes a failed result
+      // on spawn failure / no-result / timeout), but a future regression could
+      // throw. Map to a transient failure so a waiter gets a retry signal.
+      const detail = err instanceof Error ? err.message : String(err);
+      await this.publishFailed(correlationId, {
+        kind: "not_now",
+        detail: `brain runner threw unexpectedly: ${detail}`,
+        retry_after_ms: 0,
+      });
+      return { kind: "nak", delayMs: 0 };
+    }
+
+    // Terminal: publish completed/failed + map the JetStream control.
+    if (result.status === "complete") {
+      await this.safePublish(
+        createDispatchTaskCompletedEvent({
+          source: this.source,
+          taskId: crypto.randomUUID(),
+          agentId: this.agent.id,
+          correlationId,
+          startedAt,
+          completedAt: this.clock(),
+          ...(result.summary !== undefined && { resultSummary: result.summary }),
+        }),
+        "dispatch.task.completed",
+      );
+      return { kind: "ack" };
+    }
+
+    // status === "failed" — carry the brain's typed reason verbatim.
+    const reason = brainReasonToDispatchReason(result.reason);
+    await this.publishFailed(correlationId, reason);
+    return failedReasonToAckDecision(reason);
+  }
+
+  /**
+   * Build the {@link BrainTaskHooks} the runner routes brain effects through.
+   * Each hook performs the host action under policy; the runner owns
+   * task_id correlation + scratch confinement BEFORE these are called.
+   */
+  private makeHooks(source: TaskSource): BrainTaskHooks {
+    const brainPostSource: BrainPostSource = {
+      surface: source.surface,
+      channel: source.channel,
+      thread: source.thread,
+      user: source.user,
+    };
+    return {
+      // `post` — B-1 publishes a `brain.post` lifecycle envelope (no live
+      // surface session; the adapter bridge is B-2). The runner has already
+      // validated the attachment SHAPE + scratch confinement.
+      onPost: async (post: PostEffect): Promise<void> => {
+        await this.safePublish(
+          createBrainPostEvent({
+            source: this.source,
+            taskId: crypto.randomUUID(),
+            agentId: this.agent.id,
+            correlationId: post.task_id,
+            text: post.text,
+            taskSource: brainPostSource,
+            ...(post.attachment !== undefined && {
+              attachment: post.attachment,
+            }),
+          }),
+          "brain.post",
+        );
+      },
+
+      // `ask_principal` — resolve through the pluggable principal gate. B-1's
+      // DenyAllPrincipalGate fails closed; a stub gate (tests / B-2) may pass.
+      onAskPrincipal: async (
+        ask: AskPrincipalEffect,
+      ): Promise<{
+        verdict: GateVerdictValue;
+        principal: string;
+        notes?: string;
+      }> => {
+        const verdict = await this.principalGate.resolve({
+          agentId: this.agent.id,
+          taskId: ask.task_id,
+          gate: ask.gate,
+          prompt: ask.prompt,
+          source,
+        });
+        return verdict;
+      },
+
+      // `dispatch` — enforce the manifest allow-list + downgrade-only
+      // sovereignty BEFORE publishing the fleet task (§8).
+      onDispatch: async (
+        dispatch: DispatchEffect,
+      ): Promise<{ rejected: false } | { rejected: true; reason: BrainReason }> => {
+        // Ceiling 1 — capability must be in the manifest dispatch allow-list.
+        if (!this.dispatchAllow.has(dispatch.capability)) {
+          return {
+            rejected: true,
+            reason: {
+              kind: "wont_do",
+              detail: `capability "${dispatch.capability}" is not in the brain's dispatch allow-list`,
+            },
+          };
+        }
+        // Ceiling 2 — sovereignty is downgrade-only: the brain may TIGHTEN the
+        // agent's manifest model-class ceiling, never loosen it.
+        const downgradeCheck = checkDowngradeOnly(
+          dispatch.sovereignty?.model_class,
+          this.agent.modelClass,
+        );
+        if (!downgradeCheck.ok) {
+          return {
+            rejected: true,
+            reason: { kind: "wont_do", detail: downgradeCheck.detail },
+          };
+        }
+        // Allowed — publish a fleet task envelope under the agent's identity.
+        await this.safePublish(
+          buildDispatchTaskEnvelope({
+            source: this.source,
+            capability: dispatch.capability,
+            payload: dispatch.payload,
+            modelClass: dispatch.sovereignty?.model_class,
+          }),
+          `dispatch:${dispatch.capability}`,
+        );
+        return { rejected: false };
+      },
+
+      // `log` — diagnostic; forwarded to stderr, not surfaced to the principal.
+      onLog: (log): void => {
+        process.stderr.write(
+          `cortex/brain-consumer: [${log.level}] agent=${this.agent.id}: ${log.text}\n`,
+        );
+      },
+    };
+  }
+
+  /** Publish a `dispatch.task.failed` envelope for a terminal failure. */
+  private async publishFailed(
+    correlationId: string,
+    reason: DispatchTaskFailedReason,
+  ): Promise<void> {
+    const now = this.clock();
+    await this.safePublish(
+      createDispatchTaskFailedEvent({
+        source: this.source,
+        taskId: crypto.randomUUID(),
+        agentId: this.agent.id,
+        correlationId,
+        startedAt: now,
+        failedAt: now,
+        errorSummary: failedSummary(reason),
+        reason,
+      }),
+      "dispatch.task.failed",
+    );
+  }
+
+  /**
+   * Single publish path — traps + logs publish errors (CLAUDE.md "no empty
+   * catch blocks"). A failed publish is noisy but must not crash the consumer
+   * or prevent `processEnvelope` from returning an `AckDecision`. Mirrors
+   * ReviewConsumer's `safePublish` (local-only — B-1 has no federated routing).
+   */
+  private async safePublish(envelope: Envelope, label: string): Promise<void> {
+    try {
+      await this.runtime.publish(envelope);
+    } catch (err) {
+      process.stderr.write(
+        `brain-consumer: publish failed for ${label} (agent=${this.agent.id}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the brain's `task.source` triple from an inbound envelope. B-1 tasks
+ * are bus-originated, so there is no native surface session: `surface` is
+ * `"bus"` and the channel/thread/user are read from the envelope's
+ * `payload.response_routing` / `payload.source` when present, else empty.
+ *
+ * The brain sees this only as metadata (§5 property 3); the B-2 surface bridge
+ * is what turns a `brain.post` carrying it into a real thread reply.
+ */
+export function deriveTaskSource(envelope: Envelope): TaskSource {
+  const p = envelope.payload as Record<string, unknown> | undefined;
+  const routing =
+    p && typeof p.response_routing === "object" && p.response_routing !== null
+      ? (p.response_routing as Record<string, unknown>)
+      : undefined;
+  const str = (v: unknown): string => (typeof v === "string" ? v : "");
+  return {
+    surface: routing && typeof routing.surface === "string" ? routing.surface : "bus",
+    channel: routing ? str(routing.channel) : "",
+    thread: routing ? str(routing.thread) : "",
+    user: p ? str(p.user) : "",
+  };
+}
+
+/** Narrow an `Envelope.sovereignty` to the gate's `EnvelopeSovereignty` shape. */
+function toEnvelopeSovereignty(envelope: Envelope): EnvelopeSovereignty {
+  return {
+    model_class: envelope.sovereignty.model_class,
+    frontier_ok: envelope.sovereignty.frontier_ok,
+  };
+}
+
+/**
+ * Downgrade-only check for a `dispatch` effect's requested model class (§5
+ * property 6). The agent's manifest class is the CEILING; the brain may request
+ * an EQUAL or TIGHTER class, never a looser one.
+ *
+ * Strictness ordering (tighter → looser): `local-only` < `frontier` < `any`.
+ * A request to move toward `any` from a tighter ceiling is a LOOSENING and is
+ * refused. Requesting nothing (undefined) is always fine — it inherits the
+ * ceiling. A class-less agent (undefined ceiling) is treated as the loosest
+ * (`any`), so any explicit request is a valid tighten.
+ */
+export function checkDowngradeOnly(
+  requested: string | undefined,
+  ceiling: AgentModelClass | undefined,
+): { ok: true } | { ok: false; detail: string } {
+  if (requested === undefined) return { ok: true };
+  const rank: Record<string, number> = {
+    "local-only": 0,
+    frontier: 1,
+    any: 2,
+  };
+  const reqRank = rank[requested];
+  if (reqRank === undefined) {
+    return {
+      ok: false,
+      detail: `unknown requested model_class "${requested}"`,
+    };
+  }
+  // A class-less agent has the loosest ceiling (any).
+  const ceilRank = ceiling !== undefined ? rank[ceiling] ?? 2 : 2;
+  if (reqRank > ceilRank) {
+    return {
+      ok: false,
+      detail: `dispatch sovereignty may only tighten the manifest ceiling: requested "${requested}" is looser than the agent's "${ceiling ?? "any"}"`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Build a fleet `dispatch` task envelope for an ALLOWED brain dispatch. The
+ * envelope type is `tasks.{capability}` and carries the brain's payload under
+ * the agent's own source identity. The optional `modelClass` (the brain's
+ * downgrade request) stamps the envelope sovereignty so the downstream consumer
+ * honours the tightened class.
+ */
+export function buildDispatchTaskEnvelope(opts: {
+  source: SystemEventSource;
+  capability: string;
+  payload: Record<string, unknown>;
+  modelClass?: string;
+}): Envelope {
+  const now = new Date().toISOString();
+  const modelClass = isModelClass(opts.modelClass) ? opts.modelClass : "any";
+  return {
+    id: crypto.randomUUID(),
+    source: buildSource(opts.source),
+    type: `tasks.${opts.capability}`,
+    timestamp: now,
+    sovereignty: {
+      classification: "local",
+      data_residency: opts.source.dataResidency ?? "NZ",
+      max_hop: 0,
+      // A tightened class implies frontier is NOT permitted; only an explicit
+      // `any`/`frontier` clears frontier.
+      frontier_ok: modelClass !== "local-only",
+      model_class: modelClass,
+    },
+    payload: opts.payload,
+  };
+}
+
+function isModelClass(v: string | undefined): v is "local-only" | "frontier" | "any" {
+  return v === "local-only" || v === "frontier" || v === "any";
+}
+
+/** Map a brain-emitted `result.failed.reason` onto a dispatch failed reason. */
+export function brainReasonToDispatchReason(
+  reason: BrainReason,
+): DispatchTaskFailedReason {
+  switch (reason.kind) {
+    case "not_now":
+      return {
+        kind: "not_now",
+        detail: reason.detail,
+        ...(reason.retry_after_ms !== undefined && {
+          retry_after_ms: reason.retry_after_ms,
+        }),
+      };
+    case "cant_do":
+      return { kind: "cant_do", detail: reason.detail };
+    case "wont_do":
+      return { kind: "wont_do", detail: reason.detail };
+  }
+}
+
+/** A short error summary for the `dispatch.task.failed` envelope. */
+function failedSummary(reason: DispatchTaskFailedReason): string {
+  if (reason.kind === "policy_denied") {
+    return `policy_denied: ${Object.keys(reason.deny).join(",") || "(no detail)"}`;
+  }
+  return `${reason.kind}: ${reason.detail}`;
+}

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -603,11 +603,11 @@ export interface BrainPostOpts extends DispatchTaskCommonOpts {
  * task is BUS-ORIGINATED — there is no live surface session the BrainConsumer
  * can post into. So a brain's `post` effect is published as a
  * `dispatch.task.post` lifecycle envelope carrying the text/attachment-ref + the
- * task's source triple; the adapter/surface bridge that reads it and renders to
- * the thread is B-2. The BrainConsumer header documents this honestly. This
- * keeps the brain protocol's "post to the task's surface/thread" semantics
- * intact while the live-surface bridge is deferred — the brain still cannot
- * choose a channel (the source triple is host-supplied, §5 property 1).
+ * task's source as canonical `response_routing`; the adapter/surface bridge
+ * (dispatch sink) that reads it and renders to the thread is B-2 — in B-1 this
+ * is an INTENT envelope, not an actual thread post. What B-1 does preserve:
+ * the brain still cannot choose a channel (the routing is host-supplied, §5
+ * property 1), and the sink will need no second routing vocabulary.
  *
  * **Why `dispatch.task.post` and not `brain.post`** (cortex#1033 §Architecture):
  * the post is a dispatch-lifecycle moment, a sibling of started/completed/failed
@@ -618,9 +618,19 @@ export interface BrainPostOpts extends DispatchTaskCommonOpts {
 export function createDispatchTaskPostEvent(
   opts: BrainPostOpts & { taskSource: BrainPostSource },
 ): Envelope {
+  // Canonical response routing (CONTEXT.md §Response-routing, logical shape):
+  // the SAME payload field every dispatch.task.* lifecycle envelope carries,
+  // so the B-2 dispatch sink reads one vocabulary — never a parallel
+  // `task_source` (sage cortex#1033 round 3). The triggering user is not part
+  // of routing; it rides as its own field.
   return buildBaseEnvelope("dispatch.task.post", opts, {
     text: opts.text,
-    task_source: opts.taskSource,
+    response_routing: {
+      surface: opts.taskSource.surface,
+      channel: opts.taskSource.channel,
+      ...(opts.taskSource.thread !== "" && { thread: opts.taskSource.thread }),
+    },
+    triggered_by: opts.taskSource.user,
     ...(opts.attachment !== undefined && { attachment: opts.attachment }),
   });
 }

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -4,8 +4,10 @@
  * Per G-1111 §3.4 the `dispatch.task` domain captures the lifecycle of a
  * task that a principal (or a sibling agent) dispatched to a runner-style
  * agent: `dispatched`, `accepted`, `rejected`, `started`, `completed`,
- * `failed`. This file ships the four lifecycle helpers cortex's runner
- * needs end-to-end (`started`, `completed`, `failed`, `aborted`).
+ * `failed`. This file ships the lifecycle helpers cortex's runner needs
+ * end-to-end (`started`, `completed`, `failed`, `aborted`) plus the Bot Packs
+ * B-1 `post` sibling (`dispatch.task.post` — a brain's surface-post intent,
+ * cortex#1033 §Architecture).
  *
  * Note on §3.4 vs §6: the spec's §3.4 summary table omits `aborted`
  * (only lists `failed`) but the natural runtime distinction between
@@ -548,12 +550,19 @@ export function createDispatchTaskAbortedEvent(
 }
 
 // ---------------------------------------------------------------------------
-// brain.post  (Bot Packs B-1 — docs/design-bot-packs.md §5, §11 B-1)
+// dispatch.task.post  (Bot Packs B-1 — docs/design-bot-packs.md §5, §11 B-1)
+//
+// cortex#1033 §Architecture — a brain's `post` effect is a DISPATCH-lifecycle
+// event (a sibling of started/completed/failed), so it rides the declared
+// `dispatch` domain as `dispatch.task.post`, NOT a new `brain.*` top-level
+// domain. CONTEXT.md §Language → Domain enumerates the legal domains
+// (tasks/agent/system/code/review/dispatch/governance); introducing `brain` as
+// a public wire surface B-2 adapters consume would lock in an undeclared shape.
 // ---------------------------------------------------------------------------
 
 /**
  * Where a brain task originated — the source triple cortex hands the brain on
- * the `task` event and the BrainConsumer echoes onto every `brain.post`
+ * the `task` event and the BrainConsumer echoes onto every `dispatch.task.post`
  * lifecycle envelope. Surface-agnostic (the brain sees it only as metadata,
  * §5 property 3); the adapter/surface bridge (B-2) reads it to deliver the
  * post to the right thread.
@@ -588,22 +597,28 @@ export interface BrainPostOpts extends DispatchTaskCommonOpts {
 }
 
 /**
- * Construct a `brain.post` lifecycle envelope (Bot Packs B-1).
+ * Construct a `dispatch.task.post` lifecycle envelope (Bot Packs B-1).
  *
  * **Why a lifecycle envelope and not a direct surface post.** In B-1 a brain
  * task is BUS-ORIGINATED — there is no live surface session the BrainConsumer
- * can post into. So a brain's `post` effect is published as a `brain.post`
- * lifecycle envelope carrying the text/attachment-ref + the task's source
- * triple; the adapter/surface bridge that reads it and renders to the thread
- * is B-2. The BrainConsumer header documents this honestly. This keeps the
- * brain protocol's "post to the task's surface/thread" semantics intact while
- * the live-surface bridge is deferred — the brain still cannot choose a
- * channel (the source triple is host-supplied, §5 property 1).
+ * can post into. So a brain's `post` effect is published as a
+ * `dispatch.task.post` lifecycle envelope carrying the text/attachment-ref + the
+ * task's source triple; the adapter/surface bridge that reads it and renders to
+ * the thread is B-2. The BrainConsumer header documents this honestly. This
+ * keeps the brain protocol's "post to the task's surface/thread" semantics
+ * intact while the live-surface bridge is deferred — the brain still cannot
+ * choose a channel (the source triple is host-supplied, §5 property 1).
+ *
+ * **Why `dispatch.task.post` and not `brain.post`** (cortex#1033 §Architecture):
+ * the post is a dispatch-lifecycle moment, a sibling of started/completed/failed
+ * under the already-declared `dispatch` domain. A `brain.*` top-level domain is
+ * not in CONTEXT.md §Language → Domain's enumerated values and would lock an
+ * undocumented public wire shape that B-2 adapters consume.
  */
-export function createBrainPostEvent(
+export function createDispatchTaskPostEvent(
   opts: BrainPostOpts & { taskSource: BrainPostSource },
 ): Envelope {
-  return buildBaseEnvelope("brain.post", opts, {
+  return buildBaseEnvelope("dispatch.task.post", opts, {
     text: opts.text,
     task_source: opts.taskSource,
     ...(opts.attachment !== undefined && { attachment: opts.attachment }),

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -546,3 +546,66 @@ export function createDispatchTaskAbortedEvent(
     reason: opts.reason,
   });
 }
+
+// ---------------------------------------------------------------------------
+// brain.post  (Bot Packs B-1 — docs/design-bot-packs.md §5, §11 B-1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Where a brain task originated — the source triple cortex hands the brain on
+ * the `task` event and the BrainConsumer echoes onto every `brain.post`
+ * lifecycle envelope. Surface-agnostic (the brain sees it only as metadata,
+ * §5 property 3); the adapter/surface bridge (B-2) reads it to deliver the
+ * post to the right thread.
+ */
+export interface BrainPostSource {
+  /** Platform identity, e.g. `"mattermost"` | `"discord"` | `"bus"`. */
+  surface: string;
+  /** Native channel id the task arrived on. */
+  channel: string;
+  /** Native thread id (may be empty for channel-scope). */
+  thread: string;
+  /** The user who triggered the task. */
+  user: string;
+}
+
+export interface BrainPostOpts extends DispatchTaskCommonOpts {
+  /** The brain's whole-message text (§12.3 — whole-message posts in v1). */
+  text: string;
+  /**
+   * Optional attachment reference. B-1 is bus-originated (no live surface
+   * session to upload to), so the post carries the REFERENCE — inline base64
+   * XOR a scratch-dir path — and the B-2 adapter/surface bridge performs the
+   * actual upload. Exactly one of `b64` / `path` per the protocol's attachment
+   * XOR; the runner already validated SHAPE + scratch confinement before the
+   * BrainConsumer builds this.
+   */
+  attachment?: {
+    filename: string;
+    b64?: string;
+    path?: string;
+  };
+}
+
+/**
+ * Construct a `brain.post` lifecycle envelope (Bot Packs B-1).
+ *
+ * **Why a lifecycle envelope and not a direct surface post.** In B-1 a brain
+ * task is BUS-ORIGINATED — there is no live surface session the BrainConsumer
+ * can post into. So a brain's `post` effect is published as a `brain.post`
+ * lifecycle envelope carrying the text/attachment-ref + the task's source
+ * triple; the adapter/surface bridge that reads it and renders to the thread
+ * is B-2. The BrainConsumer header documents this honestly. This keeps the
+ * brain protocol's "post to the task's surface/thread" semantics intact while
+ * the live-surface bridge is deferred — the brain still cannot choose a
+ * channel (the source triple is host-supplied, §5 property 1).
+ */
+export function createBrainPostEvent(
+  opts: BrainPostOpts & { taskSource: BrainPostSource },
+): Envelope {
+  return buildBaseEnvelope("brain.post", opts, {
+    text: opts.text,
+    task_source: opts.taskSource,
+    ...(opts.attachment !== undefined && { attachment: opts.attachment }),
+  });
+}

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -17,6 +17,7 @@ import { describe, test, expect } from "bun:test";
 import { AgentConfigSchema } from "../config";
 import {
   AgentDetectionSchema,
+  AgentRuntimeSchema,
   AgentSchema,
   AttachmentsConfigSchema,
   BusConfigSchema,
@@ -344,6 +345,115 @@ describe("AgentSchema", () => {
       presence: { discord: { ...minDiscordPresence(), guildId: 1487 } },
     }));
     expect(parsed.presence.discord?.guildId).toBe("1487");
+  });
+});
+
+// =============================================================================
+// Bot Packs B-1 — AgentRuntime.brain block (docs/design-bot-packs.md §4)
+// =============================================================================
+
+describe("AgentRuntimeSchema.brain (Bot Packs B-1)", () => {
+  function minRuntime(brain?: Record<string, unknown>) {
+    return {
+      mode: "in-process" as const,
+      capabilities: ["soc.compose.flow"],
+      ...(brain !== undefined && { brain }),
+    };
+  }
+
+  test("brain absent ⇒ builtin ⇒ existing runtime parses with no brain key", () => {
+    // The zero-migration contract: a runtime that omits `brain` parses with an
+    // UNDEFINED `brain` field — no synthetic default object, so downstream
+    // engine resolution stays untouched.
+    const parsed = AgentRuntimeSchema.parse(minRuntime());
+    expect(parsed.brain).toBeUndefined();
+  });
+
+  test("every existing fixture config parses IDENTICALLY (no brain drift)", () => {
+    // Prove the schema addition is purely additive: a representative spread of
+    // pre-B-1 runtime shapes round-trips byte-identical, with `brain` absent.
+    const fixtures: Record<string, unknown>[] = [
+      { mode: "in-process", capabilities: [] },
+      { mode: "in-process", capabilities: ["code-review.typescript"], engine: "assistant" },
+      { mode: "standalone", capabilities: ["research"], substrate: "claude-code" },
+      { mode: "in-process", capabilities: ["code-review"], engine: "sage", model: "pi" },
+      { mode: "in-process", capabilities: ["x"], maxConcurrent: 3, modelClass: "frontier", sovereignty: "selective" },
+    ];
+    for (const fx of fixtures) {
+      const parsed = AgentRuntimeSchema.parse(fx);
+      expect(parsed.brain).toBeUndefined();
+      // The non-brain fields survive verbatim (a sample of each).
+      expect(parsed.mode).toBe(fx.mode);
+      expect(parsed.capabilities).toEqual(fx.capabilities as string[]);
+    }
+  });
+
+  test("brain defaults: kind=builtin, protocol=cortex-brain/v1, lifecycle=per-task, secrets=[], dispatch_capabilities=[], maxRestarts=3", () => {
+    const parsed = AgentRuntimeSchema.parse(minRuntime({}));
+    expect(parsed.brain).toEqual({
+      kind: "builtin",
+      protocol: "cortex-brain/v1",
+      lifecycle: "per-task",
+      secrets: [],
+      dispatch_capabilities: [],
+      maxRestarts: 3,
+    });
+  });
+
+  test("kind=exec requires run", () => {
+    expect(() => AgentRuntimeSchema.parse(minRuntime({ kind: "exec" }))).toThrow(
+      /brain\.run is required when brain\.kind is 'exec'/,
+    );
+  });
+
+  test("kind=exec with run parses + carries the run/secrets/dispatch allow-list", () => {
+    const parsed = AgentRuntimeSchema.parse(
+      minRuntime({
+        kind: "exec",
+        run: "bun {pack}/brain/main.ts",
+        secrets: ["VT_API_KEY"],
+        dispatch_capabilities: ["soc.triage.email"],
+      }),
+    );
+    expect(parsed.brain?.kind).toBe("exec");
+    expect(parsed.brain?.run).toBe("bun {pack}/brain/main.ts");
+    expect(parsed.brain?.secrets).toEqual(["VT_API_KEY"]);
+    expect(parsed.brain?.dispatch_capabilities).toEqual(["soc.triage.email"]);
+  });
+
+  test("lifecycle=daemon is REJECTED at load (lands in B-2)", () => {
+    expect(() =>
+      AgentRuntimeSchema.parse(
+        minRuntime({ kind: "exec", run: "bun x.ts", lifecycle: "daemon" }),
+      ),
+    ).toThrow(/daemon[\s\S]*B-2/);
+  });
+
+  test("protocol pinned to cortex-brain/v1 — a wrong protocol fails", () => {
+    expect(() =>
+      AgentRuntimeSchema.parse(
+        minRuntime({ kind: "exec", run: "bun x.ts", protocol: "cortex-brain/v2" }),
+      ),
+    ).toThrow();
+  });
+
+  test("maxRestarts must be a non-negative integer", () => {
+    expect(() =>
+      AgentRuntimeSchema.parse(minRuntime({ maxRestarts: -1 })),
+    ).toThrow(/maxRestarts must be >= 0/);
+    expect(() =>
+      AgentRuntimeSchema.parse(minRuntime({ maxRestarts: 1.5 })),
+    ).toThrow(/maxRestarts must be an integer/);
+    // 0 is valid (no restarts).
+    expect(
+      AgentRuntimeSchema.parse(minRuntime({ maxRestarts: 0 })).brain?.maxRestarts,
+    ).toBe(0);
+  });
+
+  test("builtin brain accepts an explicit kind without requiring run", () => {
+    const parsed = AgentRuntimeSchema.parse(minRuntime({ kind: "builtin" }));
+    expect(parsed.brain?.kind).toBe("builtin");
+    expect(parsed.brain?.run).toBeUndefined();
   });
 });
 

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -369,7 +369,7 @@ describe("AgentRuntimeSchema.brain (Bot Packs B-1)", () => {
     expect(parsed.brain).toBeUndefined();
   });
 
-  test("every existing fixture config parses IDENTICALLY (no brain drift)", () => {
+  test("representative existing config shapes parse identically (builtin-absent equivalence spread) (no brain drift)", () => {
     // Prove the schema addition is purely additive: a representative spread of
     // pre-B-1 runtime shapes round-trips byte-identical, with `brain` absent.
     const fixtures: Record<string, unknown>[] = [
@@ -1743,5 +1743,40 @@ describe("CortexConfigSchema — federated accept/deny subject scope (ADR 0001)"
       },
     });
     expect(parsed.policy?.federated?.networks[0]?.accept_subjects).toHaveLength(1);
+  });
+});
+
+// sage cortex#1033 round 2 (blocker) — exec-brain capability ids are exact
+// NATS subject segments; wildcards must fail at LOAD.
+describe("round-2: exec-brain capability wildcard rejection", () => {
+  const base = {
+    mode: "in-process",
+    capabilities: ["soc.compose.flow"],
+    brain: { kind: "exec", run: "bun {pack}/brain/main.ts" },
+  };
+
+  test("wildcard '>' in capabilities rejected for exec brains", () => {
+    const r = AgentRuntimeSchema.safeParse({ ...base, capabilities: [">"] });
+    expect(r.success).toBe(false);
+  });
+
+  test("'soc.>' rejected; '*' rejected", () => {
+    expect(AgentRuntimeSchema.safeParse({ ...base, capabilities: ["soc.>"] }).success).toBe(false);
+    expect(AgentRuntimeSchema.safeParse({ ...base, capabilities: ["*"] }).success).toBe(false);
+  });
+
+  test("wildcard in dispatch_capabilities rejected", () => {
+    const r = AgentRuntimeSchema.safeParse({
+      ...base,
+      brain: { ...base.brain, dispatch_capabilities: ["soc.>"] },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  test("valid ids still pass; builtin agents unaffected by the grammar gate", () => {
+    expect(AgentRuntimeSchema.safeParse(base).success).toBe(true);
+    expect(
+      AgentRuntimeSchema.safeParse({ mode: "in-process", capabilities: ["WEIRD CAPS"] }).success,
+    ).toBe(true); // builtin: legacy looseness preserved
   });
 });

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -383,7 +383,7 @@ describe("AgentRuntimeSchema.brain (Bot Packs B-1)", () => {
       const parsed = AgentRuntimeSchema.parse(fx);
       expect(parsed.brain).toBeUndefined();
       // The non-brain fields survive verbatim (a sample of each).
-      expect(parsed.mode).toBe(fx.mode);
+      expect(parsed.mode).toBe(fx.mode as "in-process" | "standalone");
       expect(parsed.capabilities).toEqual(fx.capabilities as string[]);
     }
   });

--- a/src/common/types/capability.ts
+++ b/src/common/types/capability.ts
@@ -163,11 +163,19 @@ export type CapabilityCost = z.infer<typeof CapabilityCostSchema>;
  * for natural readability (`code-review` vs `code_review` is a style
  * choice, not a structural one).
  */
+/**
+ * Exported for structural reuse (cortex#1033 §Security): brain-hosted agents'
+ * `runtime.capabilities` become EXACT NATS subject segments — they must match
+ * this grammar so a fragment can never smuggle a `>`/`*` wildcard into a pull
+ * filter and claim tasks beyond its declared capability.
+ */
+export const CAPABILITY_ID_REGEX = /^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)*$/;
+
 const CapabilityIdSchema = z
   .string()
   .min(1, "capability id is required and must be non-empty")
   .regex(
-    /^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)*$/,
+    CAPABILITY_ID_REGEX,
     "capability id must be dot-separated lowercase segments, each starting with a letter and containing only lowercase alphanumeric + hyphen/underscore (e.g. 'code-review.typescript', 'literature-search.medline'); reject uppercase, whitespace, digit-prefix segments, and leading/trailing/consecutive dots",
   );
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -34,6 +34,7 @@
 
 import { z } from "zod/v4";
 
+import { BRAIN_PROTOCOL_ID } from "../../brain/protocol";
 import { CapabilitySchema } from "./capability";
 import {
   CockpitSchema,
@@ -459,6 +460,128 @@ export type Presence = z.infer<typeof PresenceSchema>;
  *   - `roles` is the maximum capability set; presences may restrict, never widen
  */
 /**
+ * Bot Packs B-1 (`docs/design-bot-packs.md` §4) — the `brain:` block on an
+ * agent's `runtime`. Declares WHO computes the function from inbound events to
+ * effects (§2 "Brain" row): a first-party in-process engine (`kind: builtin`)
+ * or an externally-authored subprocess speaking `cortex-brain/v1`
+ * (`kind: exec`).
+ *
+ * **Absent ⇒ builtin ⇒ existing engine resolution untouched.** The whole block
+ * is optional; an agent that omits `brain` keeps today's
+ * `resolveReviewEngine(runtime)` behaviour byte-for-byte (the zero-migration
+ * contract — every existing fixture config parses identically). `kind: exec`
+ * is the new seam; the per-task exec path is B-1, the daemon lifecycle is B-2.
+ *
+ * The fields the schema carries (and what is LIVE vs. accepted-for-B-2):
+ *   - `kind`       — `builtin` (default) | `exec`. LIVE.
+ *   - `run`        — argv template (e.g. `"bun {pack}/brain/main.ts"`).
+ *                    Required IFF `kind: exec` (a builtin has no command to
+ *                    spawn). `{pack}` expands to the arc install dir at spawn.
+ *   - `protocol`   — pinned to `cortex-brain/v1` (the only protocol B-1 speaks).
+ *   - `lifecycle`  — `per-task` (default) | `daemon`. `per-task` is LIVE (B-1);
+ *                    `daemon` is REJECTED at load time (B-2) so nobody
+ *                    half-uses the socket transport before it exists.
+ *   - `secrets`    — env var NAMES only (values resolve from the runtime env at
+ *                    spawn). Install-time principal consent is the arc-side gate
+ *                    (§8). Defaults to `[]`.
+ *   - `dispatch_capabilities` — the manifest ALLOW-LIST for `dispatch` effects
+ *                    (§8: "a brain may dispatch only what its manifest allows").
+ *                    The BrainConsumer enforces it host-side. Defaults to `[]`
+ *                    (a brain that dispatches nothing).
+ *   - `maxRestarts` — daemon supervision restart cap. Accepted + documented;
+ *                    unused until B-2 (per-task brains never restart).
+ */
+export const BrainConfigSchema = z
+  .object({
+    /**
+     * `builtin` — the first-party in-process engine path (`engine: sage |
+     * assistant`); cortex's process holds the code, a trust statement about
+     * first-party code (§3). `exec` — the externally-authored subprocess seam
+     * (process isolation IS the sovereignty story). Defaults to `builtin` so an
+     * omitted/partial block preserves today's behaviour.
+     */
+    kind: z.enum(["builtin", "exec"]).default("builtin"),
+    /**
+     * The argv template cortex spawns for an `exec` brain, e.g.
+     * `"bun {pack}/brain/main.ts"`. `{pack}` expands to the arc install dir.
+     * Required IFF `kind: exec` (enforced by the superRefine below); ignored
+     * for `builtin`.
+     */
+    run: z.string().min(1).optional(),
+    /**
+     * The wire protocol the brain speaks. Pinned to `cortex-brain/v1` — the
+     * only protocol B-1 implements. A `z.literal` so a typo (or a future
+     * `/v2` config used against a B-1 cortex) fails at load rather than at
+     * the first spawn.
+     */
+    protocol: z.literal(BRAIN_PROTOCOL_ID).default(BRAIN_PROTOCOL_ID),
+    /**
+     * `per-task` — spawn the brain per inbound task, alive until it emits
+     * `result` (B-1, LIVE). `daemon` — supervise a long-lived process on a
+     * socket transport (B-2). Daemon is REJECTED at load time (superRefine
+     * below) with a clear "lands in B-2" message so a config can't half-use a
+     * transport that does not exist yet. Defaults to `per-task`.
+     */
+    lifecycle: z.enum(["per-task", "daemon"]).default("per-task"),
+    /**
+     * Names of secret env vars to inject into the brain process (§8, §12.2:
+     * env injection with install-time consent). NAMES only — the values resolve
+     * from the runtime env at spawn; cortex never stores secret material in the
+     * manifest. The principal approves these at arc-install time (the same
+     * consent shape as arc hook installation). Defaults to `[]`.
+     */
+    secrets: z.array(z.string().min(1)).default([]),
+    /**
+     * The manifest ALLOW-LIST for `dispatch` effects (§8). A brain emitting a
+     * `dispatch` for a capability NOT in this list is refused host-side with
+     * `effect_rejected` (`wont_do`) — fail-closed, the same posture as pulse's
+     * enforcement gate. Defaults to `[]` (a brain that may dispatch nothing).
+     * Distinct from `runtime.capabilities` (what the agent OFFERS the fleet);
+     * this is what the brain may REQUEST of the fleet.
+     */
+    dispatch_capabilities: z.array(z.string().min(1)).default([]),
+    /**
+     * Daemon supervision restart cap (§7.4): cortex restarts a crashed daemon
+     * brain up to this many times, then marks the agent degraded. Accepted +
+     * documented now; UNUSED until B-2 (a `per-task` brain is spawned fresh per
+     * task and never restarted). Non-negative integer; defaults to 3.
+     */
+    maxRestarts: z
+      .number()
+      .int("agent.runtime.brain.maxRestarts must be an integer")
+      .nonnegative("agent.runtime.brain.maxRestarts must be >= 0")
+      .default(3),
+  })
+  .superRefine((brain, ctx) => {
+    // `daemon` lifecycle is B-2 — REJECT it at load so a config can't half-use
+    // the socket transport / supervision machinery before they exist. A clear,
+    // actionable message rather than a silent partial-feature.
+    if (brain.lifecycle === "daemon") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "agent.runtime.brain.lifecycle 'daemon' is not yet supported — daemon " +
+          "lifecycle (socket transport + supervision) lands in B-2; use " +
+          "'per-task' (the default) for now",
+        path: ["lifecycle"],
+      });
+    }
+    // An `exec` brain has no behaviour without a command to spawn. Require
+    // `run` so a half-declared exec brain fails at load, not at the first task.
+    if (brain.kind === "exec" && (brain.run === undefined || brain.run.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "agent.runtime.brain.run is required when brain.kind is 'exec' " +
+          "(the argv cortex spawns, e.g. 'bun {pack}/brain/main.ts')",
+        path: ["run"],
+      });
+    }
+  });
+
+export type BrainConfig = z.infer<typeof BrainConfigSchema>;
+
+/**
  * Optional `runtime` block on an agent — declares the substrate harness and
  * dispatch mode for arc-installable sub-bots (cortex#60 D4 + design-arc-agent-
  * bots.md §5). Optional in v1: inline agents in cortex.yaml may omit it
@@ -576,6 +699,14 @@ export const AgentRuntimeSchema = z.object({
    * drop).
    */
   modelClass: z.enum(["local-only", "frontier", "any"]).optional(),
+  /**
+   * Bot Packs B-1 (`docs/design-bot-packs.md` §4) — the brain block. Declares
+   * whether this agent's behaviour is a first-party in-process engine
+   * (`kind: builtin`, the default) or an externally-authored `cortex-brain/v1`
+   * subprocess (`kind: exec`). ABSENT ⇒ builtin ⇒ `resolveReviewEngine`
+   * untouched (zero-migration). See {@link BrainConfigSchema}.
+   */
+  brain: BrainConfigSchema.optional(),
 }).refine(
   // Echo M2 on cortex#62 — a `standalone` agent with zero capabilities parses
   // fine but routes zero work. The daemon connects to NATS, publishes nothing

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -49,6 +49,7 @@ import { NKEY_PUBKEY_REGEX } from "./nkey";
 import { NatsSubjectsSchema } from "./nats-subjects";
 import { LETTER_PREFIX_ID_REGEX } from "./id";
 import { OfferingSchema, superRefineOfferings } from "./offering";
+import { CAPABILITY_ID_REGEX } from "./capability";
 import { checkPublicOfferingBackendGate } from "./public-offering-backend-gate";
 import { StackConfigSchema, deriveStackId } from "./stack";
 
@@ -721,7 +722,39 @@ export const AgentRuntimeSchema = z.object({
       "subjects and silently fails to receive tasks)",
     path: ["capabilities"],
   },
-);
+).superRefine((rt, ctx) => {
+  // Sage cortex#1033 (blocker) — an exec brain's capability ids become EXACT
+  // NATS subject segments in the BrainConsumer pull filter. Free text here
+  // would let a fragment declare `>` or `soc.>` and claim tasks far beyond
+  // its capability. Enforce the capability-id grammar at LOAD time for both
+  // the subscription list and the dispatch allow-list. Builtin agents keep
+  // the legacy looseness (their subjects are built by the review path's own
+  // fixed taxonomy, not raw manifest text).
+  if (rt.brain?.kind !== "exec") return;
+  rt.capabilities.forEach((cap, i) => {
+    if (!CAPABILITY_ID_REGEX.test(cap)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `agent.runtime.capabilities[${i}] ("${cap}") is not a valid capability id — ` +
+          "exec-brain capabilities become exact NATS subject segments and must match " +
+          "the capability grammar (dot-separated lowercase segments; no wildcards)",
+        path: ["capabilities", i],
+      });
+    }
+  });
+  (rt.brain.dispatch_capabilities ?? []).forEach((cap, i) => {
+    if (!CAPABILITY_ID_REGEX.test(cap)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `agent.runtime.brain.dispatch_capabilities[${i}] ("${cap}") is not a valid ` +
+          "capability id (no wildcards)",
+        path: ["brain", "dispatch_capabilities", i],
+      });
+    }
+  });
+});
 
 export type AgentRuntime = z.infer<typeof AgentRuntimeSchema>;
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -603,6 +603,56 @@ function targetAgentForDispatch(
 }
 
 /**
+ * Bot Packs B-1 (cortex#1033 §Maintainability) — collect the declared brain
+ * secrets from THIS process's env. Only named keys are forwarded into the
+ * brain's minimal env (the runner enforces the minimal-env policy; §8). A
+ * named-but-unset secret is simply absent (logged once for visibility — the
+ * install-time consent is the arc-side gate). Pure except for the stderr log.
+ */
+function collectBrainSecrets(
+  agentId: string,
+  declared: readonly string[],
+): Record<string, string> {
+  const secrets: Record<string, string> = {};
+  const missing: string[] = [];
+  for (const name of declared) {
+    const value = process.env[name];
+    if (value !== undefined) secrets[name] = value;
+    else missing.push(name);
+  }
+  if (missing.length > 0) {
+    process.stderr.write(
+      `cortex: brain agent=${agentId} declares secrets not present in the ` +
+        `environment: [${missing.join(",")}] — they will be absent from ` +
+        `the brain process (install-time consent is the arc-side gate)\n`,
+    );
+  }
+  return secrets;
+}
+
+/**
+ * Bot Packs B-1 (cortex#1033 §Maintainability) — read the persona text once at
+ * brain start. `personaPath` is the loader-resolved file PATH. A
+ * missing/unreadable persona is non-fatal: returns `undefined` (the brain
+ * receives no persona) and logs once.
+ */
+function loadBrainPersona(
+  agentId: string,
+  personaPath: string,
+): string | undefined {
+  try {
+    return readFileSync(personaPath, "utf-8");
+  } catch (personaErr) {
+    process.stderr.write(
+      `cortex: brain agent=${agentId} persona unreadable at "${personaPath}": ` +
+        `${personaErr instanceof Error ? personaErr.message : String(personaErr)} — ` +
+        `proceeding without persona\n`,
+    );
+    return undefined;
+  }
+}
+
+/**
  * Construct the full cortex stack and start it. Returns a stop handle.
  *
  * Order: runtime → router → dispatch-handler → adapters → dispatch-listener
@@ -1293,6 +1343,13 @@ export async function startCortex(
   // builtin ⇒ the existing review path, byte-for-byte unchanged.
   const isExecBrainAgent = (a: Agent): boolean =>
     a.runtime?.brain?.kind === "exec";
+  // Bot Packs B-1 — the SINGLE brain-hosting predicate (cortex#1033
+  // §Maintainability): an exec-brain agent that declares at least one capability
+  // (the subjects the consumer binds) is hosted by a BrainConsumer. Used by both
+  // the boot-time `brainAgents` filter AND the hot-reload `isBrainHosted` path so
+  // a B-2 change to the hosting criteria can't drift between them.
+  const isBrainHosted = (a: Agent): boolean =>
+    isExecBrainAgent(a) && (a.runtime?.capabilities?.length ?? 0) > 0;
   const brainConsumers: BrainConsumer[] = [];
   const reviewCapableAgents = mergedAgents.filter((a) => {
     // An exec-brain agent is hosted by the brain path even if it happens to
@@ -1304,11 +1361,8 @@ export async function startCortex(
       (c) => c === "code-review" || c.startsWith("code-review."),
     );
   });
-  // Bot Packs B-1 — agents hosted by a BrainConsumer: exec-brain agents that
-  // declare at least one capability (the subjects the consumer binds).
-  const brainAgents = mergedAgents.filter(
-    (a) => isExecBrainAgent(a) && (a.runtime?.capabilities?.length ?? 0) > 0,
-  );
+  // Bot Packs B-1 — agents hosted by a BrainConsumer (the shared predicate).
+  const brainAgents = mergedAgents.filter(isBrainHosted);
   // Stable identity inputs for the per-agent durable consumer name.
   // cortex#427 — `reviewPrincipalId` is the same `{principal}` segment the
   // surface-router and capability-registry boot paths use; reading the
@@ -2262,22 +2316,12 @@ export async function startCortex(
       // declared secrets resolve from THIS process's env at spawn — only the
       // named keys are forwarded into the brain's minimal env (the runner
       // enforces the minimal-env policy; §8). A named-but-unset secret is
-      // simply absent in the env (logged once below for visibility).
+      // simply absent in the env (logged once for visibility). cortex#1033
+      // §Maintainability — secret collection + persona load are extracted to the
+      // module-level `collectBrainSecrets` / `loadBrainPersona` helpers so this
+      // startup closure reads as a sequence of named steps.
       const packDir = join(brainPackBaseDir, agent.id);
-      const secrets: Record<string, string> = {};
-      const missingSecrets: string[] = [];
-      for (const name of brain.secrets) {
-        const value = process.env[name];
-        if (value !== undefined) secrets[name] = value;
-        else missingSecrets.push(name);
-      }
-      if (missingSecrets.length > 0) {
-        process.stderr.write(
-          `cortex: brain agent=${agent.id} declares secrets not present in the ` +
-            `environment: [${missingSecrets.join(",")}] — they will be absent from ` +
-            `the brain process (install-time consent is the arc-side gate)\n`,
-        );
-      }
+      const secrets = collectBrainSecrets(agent.id, brain.secrets);
 
       const runBrainTask = makeExecBrainRunner({
         run: brain.run,
@@ -2286,19 +2330,9 @@ export async function startCortex(
       });
 
       // Persona delivered to the brain on each task event (§5 "Persona
-      // delivery"). `agent.persona` is the loader-resolved file PATH; read its
-      // text once at start. A missing/unreadable persona is non-fatal — the
-      // brain simply receives no persona (logged once).
-      let personaText: string | undefined;
-      try {
-        personaText = readFileSync(agent.persona, "utf-8");
-      } catch (personaErr) {
-        process.stderr.write(
-          `cortex: brain agent=${agent.id} persona unreadable at "${agent.persona}": ` +
-            `${personaErr instanceof Error ? personaErr.message : String(personaErr)} — ` +
-            `proceeding without persona\n`,
-        );
-      }
+      // delivery"). A missing/unreadable persona is non-fatal — the brain simply
+      // receives no persona (logged once inside the helper).
+      const personaText = loadBrainPersona(agent.id, agent.persona);
 
       const consumer = new BrainConsumer({
         agent: consumerAgent,
@@ -2320,29 +2354,50 @@ export async function startCortex(
       // capability is a literal trailing segment, no `>` wildcard since a brain
       // task subject is exact per capability). Durable name is unique per
       // (principal, agent, capability).
-      const started = await consumer.start({
-        resolve: (capability) => {
-          const pattern = `local.${reviewPrincipalId}.${derivedStack.stack}.tasks.${capability}`;
-          const durable = `cortex-brain-consumer-${reviewPrincipalId}-${agent.id}-${capability.replaceAll(".", "-")}`;
-          // Provision the durable up-front (idempotent) so the bind below
-          // succeeds against a virgin broker. Skipped when JSM is unavailable
-          // (runtime dormant) — start() then stays dormant for this capability.
-          if (reviewJsm !== null) {
-            void provisionReviewConsumer({
+      //
+      // cortex#1033 §Architecture/§HonestOracle — provision ALL capability
+      // durables UP-FRONT and AWAIT them BEFORE calling `consumer.start()`, so
+      // the bind inside `start()` cannot race ahead of a not-yet-created durable
+      // on a virgin broker. This mirrors the review path (which awaits
+      // `provisionReviewConsumer` before `consumer.start()`); the brain path
+      // previously fired `void provisionReviewConsumer(...)` from inside the
+      // synchronous `resolve` callback, which returned the subscription params
+      // immediately while provisioning was still in flight. `resolve` is now a
+      // pure subject/durable resolver with no side effect.
+      const brainCapabilities = consumerAgent.capabilities;
+      const brainDurableFor = (capability: string): string =>
+        `cortex-brain-consumer-${reviewPrincipalId}-${agent.id}-${capability.replaceAll(".", "-")}`;
+      const brainPatternFor = (capability: string): string =>
+        `local.${reviewPrincipalId}.${derivedStack.stack}.tasks.${capability}`;
+
+      if (reviewJsm !== null) {
+        for (const capability of brainCapabilities) {
+          const durable = brainDurableFor(capability);
+          try {
+            await provisionReviewConsumer({
               jsm: reviewJsm,
               stream: reviewStream,
               durable,
-              filterSubject: pattern,
+              filterSubject: brainPatternFor(capability),
               maxDeliver: reviewConsumerMaxDeliver,
-            }).catch((provisionErr) => {
-              process.stderr.write(
-                `cortex: provisionReviewConsumer (brain) failed for "${durable}": ` +
-                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
-              );
             });
+          } catch (provisionErr) {
+            // Don't abort — let `consumer.start()` surface the bind failure
+            // through its own dormant/skip path (mirrors the review path).
+            process.stderr.write(
+              `cortex: provisionReviewConsumer (brain) failed for "${durable}": ` +
+                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+            );
           }
-          return { pattern, stream: reviewStream, durable };
-        },
+        }
+      }
+
+      const started = await consumer.start({
+        resolve: (capability) => ({
+          pattern: brainPatternFor(capability),
+          stream: reviewStream,
+          durable: brainDurableFor(capability),
+        }),
       });
 
       const capSummary =
@@ -3972,10 +4027,10 @@ export async function startCortex(
     const caps = a.runtime?.capabilities ?? [];
     return caps.some((c) => c === "code-review" || c.startsWith("code-review."));
   };
-  // Bot Packs B-1 — mirrors the boot-time `brainAgents` filter so a hot-added
-  // exec-brain agent is started iff it would have been started at boot.
-  const isBrainHosted = (a: Agent): boolean =>
-    isExecBrainAgent(a) && (a.runtime?.capabilities?.length ?? 0) > 0;
+  // Bot Packs B-1 — the hot-reload path reuses the SINGLE `isBrainHosted`
+  // predicate defined at boot setup (cortex#1033 §Maintainability) so a hot-added
+  // exec-brain agent is started iff it would have been started at boot, with no
+  // chance of the two filters drifting.
 
   // Drain + remove every review consumer owned by `agentId` from
   // `reviewConsumers[]`. `ReviewConsumer.stop()` is idempotent and awaits the

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -64,6 +64,11 @@ import {
   type ReviewConsumerAgent,
   type SignatureVerifier,
 } from "./bus/review-consumer";
+import {
+  BrainConsumer,
+  type BrainConsumerAgent,
+} from "./bus/brain-consumer";
+import { makeExecBrainRunner } from "./brain/exec-brain-runner";
 import { wireDevConsumers } from "./runner/dev-consumer-boot";
 import {
   ReleaseConsumer,
@@ -432,6 +437,16 @@ export interface StartCortexOptions {
    * own 200ms — the same window the main ConfigWatcher uses.
    */
   agentsWatcherDebounceMs?: number;
+  /**
+   * Bot Packs B-1 (cortex#1021) — base directory under which an `exec` brain's
+   * pack is resolved: `{brainPackBaseDir}/{agentId}` substitutes for the
+   * `{pack}` placeholder in `brain.run`. Defaults to
+   * `~/.config/metafactory/pkg/repos/` (the arc install path per
+   * design-bot-packs.md §7.1). Tests point it at a tmp dir holding fixture
+   * brains. arc#117's HostAdapter will own this resolution end-to-end (B-3);
+   * until then a pack can be hand-dropped under this base.
+   */
+  brainPackBaseDir?: string;
   /**
    * B-0 (cortex#1021) — test-only observation hook fired after EVERY
    * agents.d/ reload attempt (watcher-, cli-, or sighup-sourced), including
@@ -1272,12 +1287,28 @@ export async function startCortex(
   // on each, allowing in-flight pipelines to finish per the consumer's
   // own drain contract.
   const reviewConsumers: ReviewConsumer[] = [];
+  // Bot Packs B-1 (design-bot-packs.md §4, §6) — an agent whose
+  // `runtime.brain.kind === "exec"` is hosted by a BrainConsumer for its
+  // declared capabilities, NOT a builtin ReviewConsumer. `brain` absent / kind
+  // builtin ⇒ the existing review path, byte-for-byte unchanged.
+  const isExecBrainAgent = (a: Agent): boolean =>
+    a.runtime?.brain?.kind === "exec";
+  const brainConsumers: BrainConsumer[] = [];
   const reviewCapableAgents = mergedAgents.filter((a) => {
+    // An exec-brain agent is hosted by the brain path even if it happens to
+    // declare a code-review capability — the two consumers are mutually
+    // exclusive per agent (§6: "instead of, not in addition to").
+    if (isExecBrainAgent(a)) return false;
     const caps = a.runtime?.capabilities ?? [];
     return caps.some(
       (c) => c === "code-review" || c.startsWith("code-review."),
     );
   });
+  // Bot Packs B-1 — agents hosted by a BrainConsumer: exec-brain agents that
+  // declare at least one capability (the subjects the consumer binds).
+  const brainAgents = mergedAgents.filter(
+    (a) => isExecBrainAgent(a) && (a.runtime?.capabilities?.length ?? 0) > 0,
+  );
   // Stable identity inputs for the per-agent durable consumer name.
   // cortex#427 — `reviewPrincipalId` is the same `{principal}` segment the
   // surface-router and capability-registry boot paths use; reading the
@@ -2197,10 +2228,157 @@ export async function startCortex(
     }
   };
 
+  // Bot Packs B-1 (design-bot-packs.md §4, §6, §8) — start a BrainConsumer for
+  // an `exec`-brain agent. Mirrors `startReviewConsumersForAgent`'s shape: reads
+  // the closure-captured boot state (runtime, systemEventSource, the
+  // brainConsumers[] array the shutdown drain + reconcile walk), provisions the
+  // per-capability JetStream durables, and binds the consumer. NEVER throws —
+  // one brain's wiring failure does not abort boot.
+  const brainPackBaseDir =
+    options.brainPackBaseDir ?? expandTilde("~/.config/metafactory/pkg/repos/");
+  const startBrainConsumersForAgent = async (agent: Agent): Promise<void> => {
+    try {
+      const brain = agent.runtime?.brain;
+      if (brain === undefined || brain.kind !== "exec" || brain.run === undefined) {
+        // Defensive: the caller filters to exec brains with a `run`; a
+        // mis-routed builtin/absent brain is a no-op, not a crash.
+        return;
+      }
+      const caps = agent.runtime?.capabilities ?? [];
+      const consumerAgent: BrainConsumerAgent = {
+        id: agent.id,
+        capabilities: caps,
+        dispatchCapabilities: brain.dispatch_capabilities,
+        ...(agent.runtime?.maxConcurrent !== undefined && {
+          maxConcurrent: agent.runtime.maxConcurrent,
+        }),
+        ...(agent.runtime?.modelClass !== undefined && {
+          modelClass: agent.runtime.modelClass,
+        }),
+      };
+
+      // Resolve the per-task runner over the manifest `brain` block. `{pack}`
+      // expands to `{base}/{agentId}` (the arc install dir; design §7.1). The
+      // declared secrets resolve from THIS process's env at spawn — only the
+      // named keys are forwarded into the brain's minimal env (the runner
+      // enforces the minimal-env policy; §8). A named-but-unset secret is
+      // simply absent in the env (logged once below for visibility).
+      const packDir = join(brainPackBaseDir, agent.id);
+      const secrets: Record<string, string> = {};
+      const missingSecrets: string[] = [];
+      for (const name of brain.secrets) {
+        const value = process.env[name];
+        if (value !== undefined) secrets[name] = value;
+        else missingSecrets.push(name);
+      }
+      if (missingSecrets.length > 0) {
+        process.stderr.write(
+          `cortex: brain agent=${agent.id} declares secrets not present in the ` +
+            `environment: [${missingSecrets.join(",")}] — they will be absent from ` +
+            `the brain process (install-time consent is the arc-side gate)\n`,
+        );
+      }
+
+      const runBrainTask = makeExecBrainRunner({
+        run: brain.run,
+        packDir,
+        secrets,
+      });
+
+      // Persona delivered to the brain on each task event (§5 "Persona
+      // delivery"). `agent.persona` is the loader-resolved file PATH; read its
+      // text once at start. A missing/unreadable persona is non-fatal — the
+      // brain simply receives no persona (logged once).
+      let personaText: string | undefined;
+      try {
+        personaText = readFileSync(agent.persona, "utf-8");
+      } catch (personaErr) {
+        process.stderr.write(
+          `cortex: brain agent=${agent.id} persona unreadable at "${agent.persona}": ` +
+            `${personaErr instanceof Error ? personaErr.message : String(personaErr)} — ` +
+            `proceeding without persona\n`,
+        );
+      }
+
+      const consumer = new BrainConsumer({
+        agent: consumerAgent,
+        source: systemEventSource,
+        runtime,
+        runBrainTask,
+        ...(personaText !== undefined && { persona: personaText }),
+        // onAskPrincipal defaults to DenyAllPrincipalGate (B-1 fail-closed —
+        // the surface gate lands in B-2).
+        // Sovereignty audit-parity by default, mirroring ReviewConsumer (a
+        // self-declared modelClass is spoofable until bound to the signing
+        // identity, cortex#327).
+      });
+      brainConsumers.push(consumer);
+
+      // Provision + bind one durable pull consumer per declared capability.
+      // Subject grammar: `local.{principal}.{stack}.tasks.{capability}` (the
+      // myelin task-envelope grammar the design + agent envelopes use — the
+      // capability is a literal trailing segment, no `>` wildcard since a brain
+      // task subject is exact per capability). Durable name is unique per
+      // (principal, agent, capability).
+      const started = await consumer.start({
+        resolve: (capability) => {
+          const pattern = `local.${reviewPrincipalId}.${derivedStack.stack}.tasks.${capability}`;
+          const durable = `cortex-brain-consumer-${reviewPrincipalId}-${agent.id}-${capability.replaceAll(".", "-")}`;
+          // Provision the durable up-front (idempotent) so the bind below
+          // succeeds against a virgin broker. Skipped when JSM is unavailable
+          // (runtime dormant) — start() then stays dormant for this capability.
+          if (reviewJsm !== null) {
+            void provisionReviewConsumer({
+              jsm: reviewJsm,
+              stream: reviewStream,
+              durable,
+              filterSubject: pattern,
+              maxDeliver: reviewConsumerMaxDeliver,
+            }).catch((provisionErr) => {
+              process.stderr.write(
+                `cortex: provisionReviewConsumer (brain) failed for "${durable}": ` +
+                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+              );
+            });
+          }
+          return { pattern, stream: reviewStream, durable };
+        },
+      });
+
+      const capSummary =
+        started.capabilities.length > 0 ? started.capabilities.join(",") : "(none)";
+      if (started.subscribedCapabilities.length > 0) {
+        console.log(
+          `cortex: brain consumer ready for agent=${agent.id} kind=exec ` +
+            `capabilities=[${capSummary}] subscribed=[${started.subscribedCapabilities.join(",")}]`,
+        );
+      } else {
+        console.log(
+          `cortex: brain consumer DORMANT for agent=${agent.id} kind=exec ` +
+            `capabilities=[${capSummary}] — cortex MyelinRuntime subscriptions disabled ` +
+            `(G-1111 pending; tasks.{capability} envelopes will not be claimed by this brain)`,
+        );
+      }
+    } catch (err) {
+      // Per CLAUDE.md: log every error. One brain's wiring failure does NOT
+      // abort boot; the consumer (if pushed) stays in `brainConsumers[]` so the
+      // shutdown drain still calls `.stop()` (idempotent).
+      process.stderr.write(
+        `cortex: brain consumer init failed for agent=${agent.id}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  };
+
   // Boot: start review consumers for every code-review-capable agent. Same
   // closure the hot-reload path calls for a newly-added agent.
   for (const agent of reviewCapableAgents) {
     await startReviewConsumersForAgent(agent);
+  }
+  // Boot: start brain consumers for every exec-brain agent (B-1). Same closure
+  // the hot-reload path calls for a newly-added exec-brain agent.
+  for (const agent of brainAgents) {
+    await startBrainConsumersForAgent(agent);
   }
   if (reviewConsumers.length === 0) {
     // cortex#314 — same first-install-safety promotion as the
@@ -3787,11 +3965,17 @@ export async function startCortex(
   let reloadInFlight: Promise<void> = Promise.resolve();
 
   // Predicate mirrors the boot-time `reviewCapableAgents` filter so a
-  // hot-added agent is started iff it would have been started at boot.
+  // hot-added agent is started iff it would have been started at boot — an
+  // exec-brain agent is hosted by the BRAIN path, never the review path.
   const isReviewCapable = (a: Agent): boolean => {
+    if (isExecBrainAgent(a)) return false;
     const caps = a.runtime?.capabilities ?? [];
     return caps.some((c) => c === "code-review" || c.startsWith("code-review."));
   };
+  // Bot Packs B-1 — mirrors the boot-time `brainAgents` filter so a hot-added
+  // exec-brain agent is started iff it would have been started at boot.
+  const isBrainHosted = (a: Agent): boolean =>
+    isExecBrainAgent(a) && (a.runtime?.capabilities?.length ?? 0) > 0;
 
   // Drain + remove every review consumer owned by `agentId` from
   // `reviewConsumers[]`. `ReviewConsumer.stop()` is idempotent and awaits the
@@ -3801,24 +3985,38 @@ export async function startCortex(
     // Iterate a snapshot of the indices to remove (consumers can appear more
     // than once per agent: local + offer-scope + federated offer/direct).
     const toStop = reviewConsumers.filter((c) => c.agent.id === agentId);
+    // Bot Packs B-1 — the agent's brain consumer (if any) drains on the SAME
+    // path. A reload that removes/changes an exec-brain agent must stop its
+    // BrainConsumer (which drains its in-flight brain tasks per its own
+    // contract) just like a review agent's consumers.
+    const brainToStop = brainConsumers.filter((c) => c.agent.id === agentId);
     // Sage cortex#1027 — drain this agent's consumers CONCURRENTLY. Each
     // `stop()` drains in-flight work; serializing them made one agent's reload
     // latency the SUM of its consumers' drains. `allSettled` so one failing
     // stop doesn't abort the siblings; we log each rejection by index.
-    const outcomes = await Promise.allSettled(toStop.map((c) => c.stop()));
+    const outcomes = await Promise.allSettled([
+      ...toStop.map((c) => c.stop()),
+      ...brainToStop.map((c) => c.stop()),
+    ]);
     outcomes.forEach((outcome, i) => {
       if (outcome.status === "rejected") {
         const err = outcome.reason;
         process.stderr.write(
-          `cortex: agents-reload — review-consumer drain failed for agent=${agentId} ` +
+          `cortex: agents-reload — consumer drain failed for agent=${agentId} ` +
             `(consumer ${i}): ${err instanceof Error ? err.message : String(err)}\n`,
         );
       }
     });
-    // Compact `reviewConsumers[]` in place, preserving order of survivors.
+    // Compact `reviewConsumers[]` + `brainConsumers[]` in place, preserving
+    // order of survivors.
     for (let i = reviewConsumers.length - 1; i >= 0; i--) {
       if (reviewConsumers[i]?.agent.id === agentId) {
         reviewConsumers.splice(i, 1);
+      }
+    }
+    for (let i = brainConsumers.length - 1; i >= 0; i--) {
+      if (brainConsumers[i]?.agent.id === agentId) {
+        brainConsumers.splice(i, 1);
       }
     }
   };
@@ -3911,14 +4109,19 @@ export async function startCortex(
     agentRegistry = AgentRegistry.fromAgents(freshMerged);
     agentGeneration += 1;
 
-    // ── Start consumers for added + changed (new definition) review-capable
-    //    agents via the SAME construction path boot uses — concurrently
-    //    (sage round 2), mirroring the parallel drain wave above. ──
+    // ── Start consumers for added + changed (new definition) agents via the
+    //    SAME construction path boot uses — concurrently (sage round 2),
+    //    mirroring the parallel drain wave above. A review-capable agent starts
+    //    a ReviewConsumer; an exec-brain agent starts a BrainConsumer (the two
+    //    are mutually exclusive per agent, §6). ──
     await Promise.all(
       [...added, ...changed].map(async (id) => {
         const agent = freshById.get(id);
-        if (agent !== undefined && isReviewCapable(agent)) {
+        if (agent === undefined) return;
+        if (isReviewCapable(agent)) {
           await startReviewConsumersForAgent(agent);
+        } else if (isBrainHosted(agent)) {
+          await startBrainConsumersForAgent(agent);
         }
       }),
     );
@@ -4825,6 +5028,7 @@ export async function startCortex(
       "github webhook receiver stop",
       ...adapterCleanup.map((_, i) => `outbound poller stop[${i}]`),
       ...reviewConsumers.map((c, i) => `review-consumer stop[${i}] (agent=${c.agent.id})`),
+      ...brainConsumers.map((c, i) => `brain-consumer stop[${i}] (agent=${c.agent.id})`),
       ...releaseConsumers.map((c, i) => `release-consumer stop[${i}] (agent=${c.agent.id})`),
       ...devConsumers.map((c, i) => `dev-consumer stop[${i}] (agent=${c.agent.id})`),
       "dispatch-listener stop",
@@ -4939,6 +5143,20 @@ export async function startCortex(
         if (consumer) {
           await completeAsync(
             `review-consumer stop[${i}] (agent=${consumer.agent.id})`,
+            consumer.stop(),
+          );
+        }
+      }
+      // Bot Packs B-1 — drain brain consumers on the SAME boundary as the
+      // review consumers so an in-flight brain task publishes its terminal
+      // envelope before the runtime closes. `BrainConsumer.stop()` is
+      // idempotent and awaits its in-flight set (dormant / never-subscribed is
+      // a no-op). Empty on every stack with no exec-brain agents.
+      for (let i = 0; i < brainConsumers.length; i++) {
+        const consumer = brainConsumers[i];
+        if (consumer) {
+          await completeAsync(
+            `brain-consumer stop[${i}] (agent=${consumer.agent.id})`,
             consumer.stop(),
           );
         }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2371,25 +2371,29 @@ export async function startCortex(
         `local.${reviewPrincipalId}.${derivedStack.stack}.tasks.${capability}`;
 
       if (reviewJsm !== null) {
-        for (const capability of brainCapabilities) {
-          const durable = brainDurableFor(capability);
-          try {
-            await provisionReviewConsumer({
-              jsm: reviewJsm,
-              stream: reviewStream,
-              durable,
-              filterSubject: brainPatternFor(capability),
-              maxDeliver: reviewConsumerMaxDeliver,
-            });
-          } catch (provisionErr) {
-            // Don't abort — let `consumer.start()` surface the bind failure
-            // through its own dormant/skip path (mirrors the review path).
-            process.stderr.write(
-              `cortex: provisionReviewConsumer (brain) failed for "${durable}": ` +
-                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
-            );
-          }
-        }
+        // Independent durables — provision in one parallel wave (sage
+        // cortex#1033 round 2); still awaited as a whole BEFORE start().
+        await Promise.all(
+          brainCapabilities.map(async (capability) => {
+            const durable = brainDurableFor(capability);
+            try {
+              await provisionReviewConsumer({
+                jsm: reviewJsm,
+                stream: reviewStream,
+                durable,
+                filterSubject: brainPatternFor(capability),
+                maxDeliver: reviewConsumerMaxDeliver,
+              });
+            } catch (provisionErr) {
+              // Don't abort — let `consumer.start()` surface the bind failure
+              // through its own dormant/skip path (mirrors the review path).
+              process.stderr.write(
+                `cortex: provisionReviewConsumer (brain) failed for "${durable}": ` +
+                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+              );
+            }
+          }),
+        );
       }
 
       const started = await consumer.start({


### PR DESCRIPTION
Completes phase B-1 of #1021 (design: `docs/design-bot-packs.md` §4/§6/§8). Builds on the merged protocol half (#1024) and B-0 hot reload (#1027).

## What
- **`brain:` block on AgentRuntime** — `kind: builtin|exec` (absent ⇒ builtin ⇒ existing engine resolution, zero migration — probed), `run` (required iff exec), `protocol: cortex-brain/v1`, `lifecycle` (per-task; `daemon` REJECTED at load with "lands in B-2"), `secrets` (names only), `maxRestarts`, `dispatch_capabilities` (allow-list for brain-initiated fleet work, default []).
- **`BrainConsumer`** (`src/bus/brain-consumer.ts`) — ReviewConsumer-skeleton general consumer: exact-subject pull consumers per capability (`local.{principal}.{stack}.tasks.{capability}`), maxConcurrent backpressure, sovereignty audit-parity/enforce mirroring ReviewConsumer's rationale, runBrainTask hook wiring: post → `dispatch.task.post` lifecycle envelope (dispatch domain — sibling of started/completed/failed) carrying the task source triple (honest B-1 — no faked adapter; surface bridge is B-2), ask_principal → pluggable `PrincipalGate` shipping `DenyAllPrincipalGate` (fail-closed placeholder, typed seam for B-2), dispatch → manifest allow-list + downgrade-only sovereignty before a real task envelope publishes, result → `dispatch.task.completed/failed`.
- **Boot + hot reload** — `startBrainConsumersForAgent`: exec-brain agents get BrainConsumers INSTEAD of ReviewConsumers; agents.d reconcile starts/drains them live (4 new reload tests).

## Evidence
Changed-area 266 pass (schema 11, consumer 20, reload+brain suites) · full suite 6735 pass / 1 rotating pre-existing flake (#1028-class; both candidates pass 100% in isolation, verified against stashed baseline) · tsc clean · vocab PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)