### PR TITLE
fix(discord): scope channel cache by guild

### DIFF
--- a/src/bus/__tests__/brain-consumer.test.ts
+++ b/src/bus/__tests__/brain-consumer.test.ts
@@ -456,7 +456,7 @@ describe("BrainConsumer — dispatch effect enforcement", () => {
             capability: "soc.triage.email",
             payload: {},
           });
-          rejection = outcome as typeof rejection;
+          rejection = outcome;
         }),
       }),
     );
@@ -478,13 +478,13 @@ describe("BrainConsumer — dispatch effect enforcement", () => {
         runtime,
         agent: buildAgent({ dispatchCapabilities: ["soc.triage.email"] }),
         runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
-          outcome = (await hooks.onDispatch({
+          outcome = await hooks.onDispatch({
             v: 1,
             type: "dispatch",
             task_id: env.id,
             capability: "soc.triage.email",
             payload: { msg: "x" },
-          })) as typeof outcome;
+          });
         }),
       }),
     );
@@ -510,14 +510,14 @@ describe("BrainConsumer — dispatch effect enforcement", () => {
           modelClass: "local-only",
         }),
         runBrainTask: stubRunner(completeResult(env.id), async (hooks) => {
-          outcome = (await hooks.onDispatch({
+          outcome = await hooks.onDispatch({
             v: 1,
             type: "dispatch",
             task_id: env.id,
             capability: "soc.triage.email",
             payload: {},
             sovereignty: { model_class: "frontier" },
-          })) as typeof outcome;
+          });
         }),
       }),
     );

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -145,16 +145,16 @@ export interface PrincipalGate {
  * gate as denied.
  */
 export class DenyAllPrincipalGate implements PrincipalGate {
-  async resolve(): Promise<{
+  resolve(): Promise<{
     verdict: GateVerdictValue;
     principal: string;
     notes?: string;
   }> {
-    return {
+    return Promise.resolve({
       verdict: "fail",
       principal: "",
       notes: "no principal gate configured (B-2)",
-    };
+    });
   }
 }
 

--- a/src/cli/discord/__tests__/server-context.test.ts
+++ b/src/cli/discord/__tests__/server-context.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, test } from "bun:test";
 import type { DiscordCliConfig } from "../lib/config";
 import {
+  cachedChannelId,
   resolveServerContext,
   registerServerProfile,
   ServerContextError,
@@ -47,6 +48,7 @@ describe("resolveServerContext — back-compat (no flags)", () => {
     expect(ctx.botToken).toBe("grove-token");
     expect(ctx.defaultChannel).toBe("cortex");
     expect(ctx.channels).toEqual({ cortex: { id: "111" } });
+    expect(ctx.channelsGuildId).toBe(GROVE_GUILD);
     expect(ctx.serverName).toBeUndefined();
   });
 
@@ -60,6 +62,7 @@ describe("resolveServerContext — back-compat (no flags)", () => {
     expect(ctx.guildId).toBe(GROVE_GUILD);
     expect(ctx.botToken).toBe("t");
     expect(ctx.defaultChannel).toBe("cortex");
+    expect(ctx.channelsGuildId).toBeUndefined();
   });
 });
 
@@ -67,12 +70,14 @@ describe("resolveServerContext — --guild flag (ISC-C2/C3)", () => {
   test("--guild overrides guildId for name resolution", () => {
     const ctx = resolveServerContext(baseConfig(), { guild: HALDEN_GUILD });
     expect(ctx.guildId).toBe(HALDEN_GUILD);
+    expect(ctx.channelsGuildId).toBe(GROVE_GUILD);
   });
 
-  test("--guild keeps the top-level token and channels (token guild-agnostic)", () => {
+  test("--guild keeps the top-level token and channels but marks their owner", () => {
     const ctx = resolveServerContext(baseConfig(), { guild: HALDEN_GUILD });
     expect(ctx.botToken).toBe("grove-token");
     expect(ctx.channels).toEqual({ cortex: { id: "111" } });
+    expect(ctx.channelsGuildId).toBe(GROVE_GUILD);
     expect(ctx.serverName).toBeUndefined();
   });
 });
@@ -88,9 +93,10 @@ describe("resolveServerContext — --server profile (ISC-C7/C8)", () => {
     const ctx = resolveServerContext(baseConfig(), { server: "halden" });
     expect(ctx.defaultChannel).toBe("general");
     expect(ctx.channels).toEqual({ general: { id: "1512054429480648837" } });
+    expect(ctx.channelsGuildId).toBe(HALDEN_GUILD);
   });
 
-  test("--server falls back to top-level token/channel when profile omits them", () => {
+  test("--server falls back to top-level token/channel and preserves channel owner", () => {
     const config = baseConfig();
     config.servers = { halden: { guildId: HALDEN_GUILD } };
     const ctx = resolveServerContext(config, { server: "halden" });
@@ -98,6 +104,7 @@ describe("resolveServerContext — --server profile (ISC-C7/C8)", () => {
     expect(ctx.botToken).toBe("grove-token"); // fell back to top-level
     expect(ctx.defaultChannel).toBe("cortex"); // fell back to top-level
     expect(ctx.channels).toEqual({ cortex: { id: "111" } });
+    expect(ctx.channelsGuildId).toBe(GROVE_GUILD);
   });
 
   test("--server uses the profile's own token when present", () => {
@@ -116,6 +123,49 @@ describe("resolveServerContext — precedence (ISC-C9)", () => {
     expect(ctx.guildId).toBe(HALDEN_GUILD);
     // profile's channels/defaultChannel still layered in.
     expect(ctx.defaultChannel).toBe("general");
+    expect(ctx.channelsGuildId).toBe(HALDEN_GUILD);
+  });
+});
+
+describe("cachedChannelId — guild-scoped channel cache (cortex#1030)", () => {
+  test("no flags can use the top-level channel cache", () => {
+    const ctx = resolveServerContext(baseConfig(), {});
+    expect(cachedChannelId(ctx, "cortex")).toBe("111");
+  });
+
+  test("--guild cannot use a top-level cache owned by another guild", () => {
+    const ctx = resolveServerContext(baseConfig(), { guild: HALDEN_GUILD });
+    expect(cachedChannelId(ctx, "cortex")).toBeUndefined();
+  });
+
+  test("--guild can use the top-level cache when the guild still matches", () => {
+    const ctx = resolveServerContext(baseConfig(), { guild: GROVE_GUILD });
+    expect(cachedChannelId(ctx, "cortex")).toBe("111");
+  });
+
+  test("--server can use its own profile channel cache", () => {
+    const ctx = resolveServerContext(baseConfig(), { server: "halden" });
+    expect(cachedChannelId(ctx, "general")).toBe("1512054429480648837");
+  });
+
+  test("--server without profile channels cannot use inherited top-level cache", () => {
+    const config = baseConfig();
+    config.servers = { halden: { guildId: HALDEN_GUILD } };
+    const ctx = resolveServerContext(config, { server: "halden" });
+    expect(cachedChannelId(ctx, "cortex")).toBeUndefined();
+  });
+
+  test("matching --server and --guild can still use the profile cache", () => {
+    const ctx = resolveServerContext(baseConfig(), {
+      server: "halden",
+      guild: HALDEN_GUILD,
+    });
+    expect(cachedChannelId(ctx, "general")).toBe("1512054429480648837");
+  });
+
+  test("unknown channel names miss the cache", () => {
+    const ctx = resolveServerContext(baseConfig(), {});
+    expect(cachedChannelId(ctx, "unknown")).toBeUndefined();
   });
 });
 

--- a/src/cli/discord/discord.ts
+++ b/src/cli/discord/discord.ts
@@ -9,7 +9,7 @@
 import { Command } from "commander";
 import YAML from "yaml";
 import { loadConfig, saveConfig, getConfigPath } from "./lib/config";
-import { resolveServerContext, registerServerProfile, ServerContextError } from "./lib/server-context";
+import { cachedChannelId, resolveServerContext, registerServerProfile, ServerContextError } from "./lib/server-context";
 import type { ResolvedServerContext, ServerContextOptions } from "./lib/server-context";
 import type { DiscordCliConfig } from "./lib/config";
 import { postMessage, postMessageWithFiles, createThreadFromMessage, resolveChannelByName, resolveThreadByName, readMessages, listChannels, listThreads, type AttachmentInput } from "./lib/discord";
@@ -135,21 +135,14 @@ program
       process.exit(1);
     }
 
-    // Resolve channel name → ID (cached in context, or looked up via API).
-    // A cached id posts directly and is guild-agnostic — no resolution needed.
+    // Resolve channel name → ID. Cached ids and raw ids are only trusted when
+    // they belong to this command's effective guild.
     let channelId: string | undefined;
     if (channelName) {
-      channelId = ctx.channels?.[channelName]?.id;
-      if (!channelId) {
-        channelId = await resolveChannelByName(ctx.botToken, ctx.guildId, channelName) ?? undefined;
-        if (!channelId && !threadId) {
-          console.error(`Channel "#${channelName}" not found. Run: discord channels`);
-          process.exit(1);
-        }
-        if (channelId) {
-          cacheChannelId(config, ctx, channelName, channelId);
-          saveConfig(config);
-        }
+      channelId = await resolveChannelId(config, ctx, ctx.botToken, ctx.guildId, channelName);
+      if (!channelId && !threadId) {
+        console.error(`Channel "#${channelName}" not found. Run: discord channels`);
+        process.exit(1);
       }
     }
 
@@ -229,15 +222,10 @@ program
         process.exit(1);
       }
 
-      let channelId = ctx.channels?.[channelName]?.id;
+      const channelId = await resolveChannelId(config, ctx, ctx.botToken, ctx.guildId, channelName);
       if (!channelId) {
-        channelId = await resolveChannelByName(ctx.botToken, ctx.guildId, channelName) ?? undefined;
-        if (!channelId) {
-          console.error(`Channel "#${channelName}" not found.`);
-          process.exit(1);
-        }
-        cacheChannelId(config, ctx, channelName, channelId);
-        saveConfig(config);
+        console.error(`Channel "#${channelName}" not found.`);
+        process.exit(1);
       }
       readTargetId = channelId;
     }
@@ -389,6 +377,33 @@ function cacheChannelId(
     config.channels ??= {};
     config.channels[channelName] = { id: channelId };
   }
+}
+
+async function resolveChannelId(
+  config: DiscordCliConfig,
+  ctx: ResolvedServerContext,
+  botToken: string,
+  guildId: string,
+  channelName: string
+): Promise<string | undefined> {
+  if (isDiscordId(channelName)) {
+    const channels = await listChannels(botToken, guildId);
+    return channels.some((channel) => channel.id === channelName) ? channelName : undefined;
+  }
+
+  const cached = cachedChannelId(ctx, channelName);
+  if (cached) return cached;
+
+  const resolved = await resolveChannelByName(botToken, guildId, channelName) ?? undefined;
+  if (resolved) {
+    cacheChannelId(config, ctx, channelName, resolved);
+    saveConfig(config);
+  }
+  return resolved;
+}
+
+function isDiscordId(value: string): boolean {
+  return /^\d{17,20}$/.test(value);
 }
 
 function setNestedValue(obj: ConfigObject, key: string, value: string): void {

--- a/src/cli/discord/lib/server-context.ts
+++ b/src/cli/discord/lib/server-context.ts
@@ -47,6 +47,8 @@ export interface ResolvedServerContext {
   defaultChannel?: string;
   /** Cached channel name→id map for guild-agnostic id posting. */
   channels?: Record<string, ChannelConfig>;
+  /** Guild that owns the resolved cached channel map, when known. */
+  channelsGuildId?: string;
   /** Name of the profile applied, when `--server` was used. */
   serverName?: string;
 }
@@ -76,6 +78,7 @@ export function resolveServerContext(
   let botToken = config.botToken;
   let defaultChannel = config.defaultChannel;
   let channels = config.channels;
+  let channelsGuildId = config.channels ? config.guildId : undefined;
   let serverName: string | undefined;
 
   // ── Layer 1: named server profile ────────────────────────────────────────
@@ -98,7 +101,10 @@ export function resolveServerContext(
     // Optional overrides fall back to the top-level values when absent.
     if (profile.botToken) botToken = profile.botToken;
     if (profile.defaultChannel) defaultChannel = profile.defaultChannel;
-    if (profile.channels) channels = profile.channels;
+    if (profile.channels) {
+      channels = profile.channels;
+      channelsGuildId = profile.guildId;
+    }
   }
 
   // ── Layer 2: explicit --guild flag (highest precedence for guildId) ───────
@@ -114,7 +120,20 @@ export function resolveServerContext(
     guildId = opts.guild;
   }
 
-  return { guildId, botToken, defaultChannel, channels, serverName };
+  return { guildId, botToken, defaultChannel, channels, channelsGuildId, serverName };
+}
+
+/**
+ * Return a cached channel id only when the cache belongs to the same guild the
+ * command is currently resolving names in. This keeps a top-level `channels:`
+ * map from silently targeting another guild after `--guild`/`--server`.
+ */
+export function cachedChannelId(
+  ctx: ResolvedServerContext,
+  channelName: string
+): string | undefined {
+  if (!ctx.guildId || ctx.channelsGuildId !== ctx.guildId) return undefined;
+  return ctx.channels?.[channelName]?.id;
 }
 
 /**

--- a/src/cli/discord/skill/SKILL.md
+++ b/src/cli/discord/skill/SKILL.md
@@ -44,8 +44,9 @@ discord read  --server halden
 
 Precedence: explicit `--guild`/`--channel` flags  >  `--server` profile  >
 top-level config. With neither flag, behaviour is identical to single-guild.
-A cached `channels.<name>.id` posts by id directly and is guild-agnostic; the
-`--guild`/`--server` override only changes how a channel *name* is resolved.
+Cached `channels.<name>.id` entries are used only when their owning guild
+matches the selected `--guild`/`--server` context; otherwise the CLI resolves
+the name inside the selected guild or fails loudly.
 
 ---
 

--- a/src/cli/discord/skill/Workflows/Post.md
+++ b/src/cli/discord/skill/Workflows/Post.md
@@ -43,5 +43,5 @@ top-level config. With no `--server`/`--guild`, posting is exactly as before.
 - For multi-line messages, use quotes and `\n` or write to a temp file first.
 - `--file <path>` attaches a local file (repeatable). The message is optional when at least one file is given. Each path is existence-checked before anything is posted, so a bad path fails cleanly with nothing sent.
 - If posting fails with "Bot token required", run `discord config show` and guide setup.
-- Channel names are resolved automatically on first use and cached (per guild).
+- Channel names are resolved automatically on first use and cached per guild. Raw channel IDs are accepted only after the bot sees that ID in the selected guild channel list.
 - `--guild` and `--server` must not disagree on the guild — the CLI errors if they do.

--- a/src/cli/discord/skill/Workflows/Read.md
+++ b/src/cli/discord/skill/Workflows/Read.md
@@ -23,3 +23,4 @@ Read recent messages from a Discord channel.
 - Format: `[HH:MM] Author: Content`
 - To list available channels: `discord channels`
 - To list active threads: `discord threads`
+- Cached channel names are used only when the cache owner matches the selected guild; raw channel IDs must be visible in the selected guild.

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -559,7 +559,7 @@ export const BrainConfigSchema = z
     // actionable message rather than a silent partial-feature.
     if (brain.lifecycle === "daemon") {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message:
           "agent.runtime.brain.lifecycle 'daemon' is not yet supported — daemon " +
           "lifecycle (socket transport + supervision) lands in B-2; use " +
@@ -571,7 +571,7 @@ export const BrainConfigSchema = z
     // `run` so a half-declared exec brain fails at load, not at the first task.
     if (brain.kind === "exec" && (brain.run === undefined || brain.run.length === 0)) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message:
           "agent.runtime.brain.run is required when brain.kind is 'exec' " +
           "(the argv cortex spawns, e.g. 'bun {pack}/brain/main.ts')",
@@ -730,11 +730,12 @@ export const AgentRuntimeSchema = z.object({
   // the subscription list and the dispatch allow-list. Builtin agents keep
   // the legacy looseness (their subjects are built by the review path's own
   // fixed taxonomy, not raw manifest text).
-  if (rt.brain?.kind !== "exec") return;
+  const brain = rt.brain;
+  if (brain?.kind !== "exec") return;
   rt.capabilities.forEach((cap, i) => {
     if (!CAPABILITY_ID_REGEX.test(cap)) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message:
           `agent.runtime.capabilities[${i}] ("${cap}") is not a valid capability id — ` +
           "exec-brain capabilities become exact NATS subject segments and must match " +
@@ -743,10 +744,11 @@ export const AgentRuntimeSchema = z.object({
       });
     }
   });
-  (rt.brain.dispatch_capabilities ?? []).forEach((cap, i) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Zod superRefine still sees hand-written configs while defaults are being applied.
+  (brain.dispatch_capabilities ?? []).forEach((cap, i) => {
     if (!CAPABILITY_ID_REGEX.test(cap)) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         message:
           `agent.runtime.brain.dispatch_capabilities[${i}] ("${cap}") is not a valid ` +
           "capability id (no wildcards)",

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1349,8 +1349,10 @@ export async function startCortex(
   // (the subjects the consumer binds) is hosted by a BrainConsumer. Used by both
   // the boot-time `brainAgents` filter AND the hot-reload `isBrainHosted` path so
   // a B-2 change to the hosting criteria can't drift between them.
-  const isBrainHosted = (a: Agent): boolean =>
-    isExecBrainAgent(a) && (a.runtime?.capabilities?.length ?? 0) > 0;
+  const isBrainHosted = (a: Agent): boolean => {
+    const runtime = a.runtime;
+    return runtime?.brain?.kind === "exec" && runtime.capabilities.length > 0;
+  };
   const brainConsumers: BrainConsumer[] = [];
   const reviewCapableAgents = mergedAgents.filter((a) => {
     // An exec-brain agent is hosted by the brain path even if it happens to
@@ -2294,7 +2296,7 @@ export async function startCortex(
   const startBrainConsumersForAgent = async (agent: Agent): Promise<void> => {
     try {
       const brain = agent.runtime?.brain;
-      if (brain === undefined || brain.kind !== "exec" || brain.run === undefined) {
+      if (brain?.kind !== "exec" || brain.run === undefined) {
         // Defensive: the caller filters to exec brains with a `run`; a
         // mis-routed builtin/absent brain is a no-op, not a crash.
         return;


### PR DESCRIPTION
## Summary
- track which guild owns a resolved Discord channel cache
- refuse cached channel ids when --guild/--server resolves against a different guild
- accept raw numeric channel ids for post/read and keep resolved cache writes profile-scoped
- clean current main lint errors so the PR gates stay green

Closes #1030

## Verification
- rtk bun test src/cli/discord/__tests__/server-context.test.ts
- rtk bun test src/cli/discord
- rtk bun run lint:errors
- rtk bunx tsc --noEmit
- rtk git diff --check
- rtk bun test