### PR TITLE
feat(brain): B-2 — daemon lifecycle, supervision, surface principal gate (#1021)

### DIFF
--- a/src/brain/__tests__/attachment-budget.test.ts
+++ b/src/brain/__tests__/attachment-budget.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `attachment-budget` unit tests (Bot Packs B-2; §12.5 — 4 MiB per-task cap).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  AttachmentBudget,
+  attachmentByteSize,
+  MAX_TASK_ATTACHMENT_BYTES,
+} from "../attachment-budget";
+import type { PostAttachment } from "../protocol";
+
+let dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs = [];
+});
+
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "att-budget-"));
+  dirs.push(d);
+  return d;
+}
+
+describe("attachmentByteSize", () => {
+  test("inline b64 charges the DECODED size, not the base64 envelope", () => {
+    const decoded = Buffer.alloc(1000, 0x41);
+    const att: PostAttachment = { filename: "a.bin", b64: decoded.toString("base64") };
+    expect(attachmentByteSize(att)).toBe(1000);
+  });
+
+  test("scratch path charges the on-disk file size", () => {
+    const dir = tmp();
+    const file = join(dir, "out.png");
+    writeFileSync(file, Buffer.alloc(2048, 0));
+    const att: PostAttachment = { filename: "out.png", path: file };
+    expect(attachmentByteSize(att, file)).toBe(2048);
+  });
+
+  test("a missing scratch file charges 0 (post fails downstream, not here)", () => {
+    const att: PostAttachment = { filename: "gone.png", path: "/nope/missing.png" };
+    expect(attachmentByteSize(att, "/nope/missing.png")).toBe(0);
+  });
+});
+
+describe("AttachmentBudget", () => {
+  test("charges accumulate and stay within the cap", () => {
+    const b = new AttachmentBudget(1000);
+    const att = (n: number): PostAttachment => ({
+      filename: "x",
+      b64: Buffer.alloc(n, 0).toString("base64"),
+    });
+    expect(b.charge(att(400)).ok).toBe(true);
+    expect(b.charge(att(400)).ok).toBe(true);
+    expect(b.totalBytes).toBe(800);
+    expect(b.remainingBytes).toBe(200);
+  });
+
+  test("over-budget charge is refused and consumes NOTHING", () => {
+    const b = new AttachmentBudget(1000);
+    const att = (n: number): PostAttachment => ({
+      filename: "x",
+      b64: Buffer.alloc(n, 0).toString("base64"),
+    });
+    expect(b.charge(att(900)).ok).toBe(true);
+    const refused = b.charge(att(200));
+    expect(refused.ok).toBe(false);
+    if (!refused.ok) {
+      expect(refused.detail).toMatch(/budget exceeded/i);
+    }
+    // The refused bytes were NOT consumed — a smaller attachment still fits.
+    expect(b.totalBytes).toBe(900);
+    expect(b.charge(att(100)).ok).toBe(true);
+  });
+
+  test("default cap is 4 MiB", () => {
+    expect(MAX_TASK_ATTACHMENT_BYTES).toBe(4 * 1024 * 1024);
+    const b = new AttachmentBudget();
+    const justUnder: PostAttachment = {
+      filename: "x",
+      // a path attachment lets us exceed the 256 KiB inline cap conceptually,
+      // but here we just assert the cap value via a single over-cap inline-equiv
+      // by charging a path-sized stat is covered elsewhere; use remaining.
+      b64: "",
+    };
+    void justUnder;
+    expect(b.remainingBytes).toBe(MAX_TASK_ATTACHMENT_BYTES);
+  });
+});

--- a/src/brain/__tests__/daemon-brain-host.test.ts
+++ b/src/brain/__tests__/daemon-brain-host.test.ts
@@ -1,0 +1,538 @@
+/**
+ * `daemon-brain-host` tests (Bot Packs B-2; `docs/design-bot-packs.md` §5/§7/§12).
+ *
+ * Drives the host through an IN-MEMORY transport double — a controllable "brain"
+ * that the test scripts to emit effects, crash, or stall. No real socket / no
+ * real subprocess; the protocol multiplexing, supervision, drain, attachment
+ * budget, and scratch confinement are all exercised deterministically.
+ *
+ * Covered (task deliverable 7):
+ *   - daemon round-trip: hello → task → post → result (over the transport)
+ *   - multiplexed two concurrent tasks (interleaved effects, correlated by id)
+ *   - crash → restart → maxRestarts → degraded presence emit
+ *   - in-flight tasks fail (cant_do, "brain crashed") on crash
+ *   - drain with an open ask_principal gate → cancellation notice + not_now
+ *   - 4 MiB attachment budget → effect_rejected wont_do
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  DaemonBrainHost,
+  type DaemonTransport,
+  type DaemonBrainConnection,
+  type DaemonBrainProcess,
+} from "../daemon-brain-host";
+import { MAX_TASK_ATTACHMENT_BYTES } from "../attachment-budget";
+import {
+  parseBrainEvent,
+  type BrainEvent,
+  type TaskEvent,
+  type GateVerdictValue,
+} from "../protocol";
+import type { BrainTaskHooks } from "../exec-brain-runner";
+
+// ---------------------------------------------------------------------------
+// In-memory transport double
+// ---------------------------------------------------------------------------
+
+/**
+ * A scripted brain on the other side of the socket. The host writes events
+ * (lines) to `write`; the test reads them via `events` and replies by calling
+ * `emit(line)`. `crash()` fires the close handler; `exit()` resolves `exited`.
+ */
+class FakeBrain {
+  private dataHandler: ((chunk: string) => void) | null = null;
+  private closeHandler: (() => void) | null = null;
+  /** Every cortex → brain event the host wrote, parsed. */
+  readonly received: BrainEvent[] = [];
+  /** Raw lines (for assertions on shape). */
+  readonly receivedLines: string[] = [];
+  killed: NodeJS.Signals | number | undefined;
+  private exitResolve!: (code: number | null) => void;
+  readonly exited: Promise<number | null>;
+
+  readonly connection: DaemonBrainConnection;
+
+  constructor() {
+    this.exited = new Promise((res) => {
+      this.exitResolve = res;
+    });
+    this.connection = {
+      write: (chunk: string) => {
+        for (const line of chunk.split("\n")) {
+          if (line.trim().length === 0) continue;
+          this.receivedLines.push(line);
+          const parsed = parseBrainEvent(line);
+          if (parsed.kind === "ok") this.received.push(parsed.event);
+        }
+      },
+      onData: (handler) => {
+        this.dataHandler = handler as (c: string) => void;
+      },
+      onClose: (handler) => {
+        this.closeHandler = handler;
+      },
+    };
+  }
+
+  /** Brain → host: emit one effect line. */
+  emit(line: string): void {
+    this.dataHandler?.(line + "\n");
+  }
+
+  /** Simulate a crash — fire the connection close handler. */
+  crash(): void {
+    this.closeHandler?.();
+    this.exitResolve(1);
+  }
+
+  /** Simulate a clean exit. */
+  exit(code = 0): void {
+    this.exitResolve(code);
+  }
+
+  /** Did the host write an event of this type? */
+  hasEvent(type: BrainEvent["type"]): boolean {
+    return this.received.some((e) => e.type === type);
+  }
+
+  lastTask(): TaskEvent | undefined {
+    const tasks = this.received.filter((e): e is TaskEvent => e.type === "task");
+    return tasks[tasks.length - 1];
+  }
+}
+
+/**
+ * Build a transport that hands out a sequence of FakeBrains (one per spawn —
+ * generation 0, then restarts). The test pre-seeds the list; each spawn pops the
+ * next. `connectDelayMs` lets a generation defer connecting.
+ */
+function makeFakeTransport(brains: FakeBrain[]): {
+  transport: DaemonTransport;
+  spawns: number;
+} {
+  const state = { spawns: 0 };
+  const transport: DaemonTransport = () => {
+    const brain = brains[state.spawns];
+    state.spawns += 1;
+    if (brain === undefined) {
+      throw new Error(`fake transport: no brain seeded for spawn #${state.spawns - 1}`);
+    }
+    const proc: DaemonBrainProcess = {
+      connection: Promise.resolve(brain.connection),
+      exited: brain.exited,
+      kill: (signal) => {
+        brain.killed = signal;
+        brain.exit(137);
+      },
+    };
+    return proc;
+  };
+  return {
+    transport,
+    get spawns() {
+      return state.spawns;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let scratchDirs: string[] = [];
+function scratchFactory(): string {
+  const d = mkdtempSync(join(tmpdir(), "daemon-test-scratch-"));
+  scratchDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of scratchDirs) rmSync(d, { recursive: true, force: true });
+  scratchDirs = [];
+});
+
+function makeTask(over: Partial<TaskEvent> = {}): TaskEvent {
+  return {
+    v: 1,
+    type: "task",
+    task_id: "t-1",
+    capability: "soc.compose.flow",
+    payload: { scenario: "phish" },
+    source: { surface: "mattermost", channel: "c1", thread: "th1", user: "u1" },
+    ...over,
+  };
+}
+
+function makeHooks(over: Partial<BrainTaskHooks> = {}): BrainTaskHooks & {
+  posts: unknown[];
+  asks: unknown[];
+  dispatches: unknown[];
+} {
+  const posts: unknown[] = [];
+  const asks: unknown[] = [];
+  const dispatches: unknown[] = [];
+  return {
+    posts,
+    asks,
+    dispatches,
+    onPost: over.onPost ?? ((p) => void posts.push(p)),
+    onAskPrincipal:
+      over.onAskPrincipal ??
+      (async (a): Promise<{ verdict: GateVerdictValue; principal: string }> => {
+        asks.push(a);
+        return { verdict: "pass", principal: "andreas" };
+      }),
+    onDispatch: over.onDispatch ?? ((d) => void dispatches.push(d)),
+    onLog: over.onLog ?? (() => {}),
+  };
+}
+
+/** Wait until `cond()` is true (poll), or throw after `timeoutMs`. */
+async function until(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("until() timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DaemonBrainHost — round-trip", () => {
+  test("hello handshake on start, then task → post → result", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun brain.ts",
+      packDir: "/packs/yarrow",
+      persona: "You are Yarrow.",
+      transport,
+      makeScratchDir: scratchFactory,
+    });
+    await host.start();
+
+    // hello sent at connect (host-authoritative identity + persona).
+    expect(brain.hasEvent("hello")).toBe(true);
+    const hello = brain.received.find((e) => e.type === "hello");
+    expect(hello).toMatchObject({
+      type: "hello",
+      agent: "yarrow",
+      persona: "You are Yarrow.",
+      protocol: "cortex-brain/v1",
+    });
+
+    const hooks = makeHooks();
+    const runP = host.runTask(makeTask({ task_id: "t-1" }), hooks);
+
+    await until(() => brain.lastTask()?.task_id === "t-1");
+    // Daemon task carries NO persona (persona was delivered via hello).
+    expect(brain.lastTask()?.persona).toBeUndefined();
+
+    // Brain posts, then completes.
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: "t-1", text: "flow ready" }));
+    brain.emit(
+      JSON.stringify({ v: 1, type: "result", task_id: "t-1", status: "complete", summary: "done" }),
+    );
+
+    const result = await runP;
+    expect(result.result.status).toBe("complete");
+    expect(hooks.posts.length).toBe(1);
+    await host.stop();
+  });
+
+  test("multiplexes two concurrent tasks correlated by task_id", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun brain.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+    });
+    await host.start();
+
+    const hooksA = makeHooks();
+    const hooksB = makeHooks();
+    const runA = host.runTask(makeTask({ task_id: "A" }), hooksA);
+    const runB = host.runTask(makeTask({ task_id: "B" }), hooksB);
+
+    await until(
+      () => brain.received.filter((e) => e.type === "task").length === 2,
+    );
+
+    // Interleave effects across the two tasks.
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: "B", text: "B1" }));
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: "A", text: "A1" }));
+    brain.emit(
+      JSON.stringify({ v: 1, type: "result", task_id: "A", status: "complete" }),
+    );
+    brain.emit(
+      JSON.stringify({ v: 1, type: "result", task_id: "B", status: "complete" }),
+    );
+
+    const [resA, resB] = await Promise.all([runA, runB]);
+    expect(resA.result.task_id).toBe("A");
+    expect(resB.result.task_id).toBe("B");
+    expect((hooksA.posts[0] as { text: string }).text).toBe("A1");
+    expect((hooksB.posts[0] as { text: string }).text).toBe("B1");
+    await host.stop();
+  });
+
+  test("an effect for an unknown task_id is refused with effect_rejected", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+    });
+    await host.start();
+
+    // No task in flight — a post for a ghost task_id is rejected.
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: "ghost", text: "x" }));
+    await until(() => brain.hasEvent("effect_rejected"));
+    const rej = brain.received.find((e) => e.type === "effect_rejected");
+    expect(rej).toMatchObject({ type: "effect_rejected", effect: "post" });
+    await host.stop();
+  });
+});
+
+describe("DaemonBrainHost — supervision", () => {
+  test("crash restarts up to maxRestarts then marks degraded + emits presence", async () => {
+    // 1 original + maxRestarts(2) restarts = 3 brains; the 3rd crash exhausts.
+    const brains = [new FakeBrain(), new FakeBrain(), new FakeBrain()];
+    const { transport } = makeFakeTransport(brains);
+    const degraded: string[] = [];
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      maxRestarts: 2,
+      makeScratchDir: scratchFactory,
+      onDegraded: (id) => degraded.push(id),
+    });
+    await host.start();
+    expect(brains[0]?.hasEvent("hello")).toBe(true);
+
+    // Crash gen 0 → restart to gen 1.
+    brains[0]?.crash();
+    await until(() => brains[1]?.hasEvent("hello") === true);
+    expect(host.isDegraded).toBe(false);
+
+    // Crash gen 1 → restart to gen 2.
+    brains[1]?.crash();
+    await until(() => brains[2]?.hasEvent("hello") === true);
+    expect(host.isDegraded).toBe(false);
+
+    // Crash gen 2 → budget (2) exhausted → degraded + presence signal.
+    brains[2]?.crash();
+    await until(() => host.isDegraded);
+    expect(degraded).toEqual(["yarrow"]);
+
+    // A degraded host fast-fails new tasks not_now.
+    const res = await host.runTask(makeTask(), makeHooks());
+    expect(res.result.status).toBe("failed");
+    if (res.result.status === "failed") {
+      expect(res.result.reason.kind).toBe("not_now");
+    }
+    await host.stop();
+  });
+
+  test("in-flight tasks fail cant_do 'brain crashed' on a crash", async () => {
+    const brains = [new FakeBrain(), new FakeBrain()];
+    const { transport } = makeFakeTransport(brains);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      maxRestarts: 1,
+      makeScratchDir: scratchFactory,
+    });
+    await host.start();
+
+    const runP = host.runTask(makeTask({ task_id: "live" }), makeHooks());
+    await until(() => brains[0]?.lastTask()?.task_id === "live");
+
+    brains[0]?.crash();
+    const res = await runP;
+    expect(res.result.status).toBe("failed");
+    if (res.result.status === "failed") {
+      expect(res.result.reason.kind).toBe("cant_do");
+      expect(res.result.reason.detail).toContain("brain crashed");
+    }
+    await host.stop();
+  });
+
+  test("healthy uptime resets the restart counter", async () => {
+    const brains = [new FakeBrain(), new FakeBrain(), new FakeBrain(), new FakeBrain()];
+    const { transport } = makeFakeTransport(brains);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      maxRestarts: 1,
+      healthyResetMs: 10, // reset almost immediately
+      makeScratchDir: scratchFactory,
+    });
+    await host.start();
+
+    brains[0]?.crash(); // restart 1/1
+    await until(() => brains[1]?.hasEvent("hello") === true);
+    // Let the healthy-reset timer fire (10ms) so the counter resets.
+    await new Promise((r) => setTimeout(r, 40));
+    brains[1]?.crash(); // would be 2/1 without reset → but reset → 1/1 again
+    await until(() => brains[2]?.hasEvent("hello") === true);
+    expect(host.isDegraded).toBe(false);
+    await host.stop();
+  });
+});
+
+describe("DaemonBrainHost — drain (hot-swap §7)", () => {
+  test("drain with an open gate cancels with a re-trigger notice + not_now", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      killGraceMs: 50,
+      makeScratchDir: scratchFactory,
+    });
+    await host.start();
+
+    // The gate hook never resolves (principal never answers) — so the gate stays
+    // open across the drain deadline.
+    const posts: { text: string }[] = [];
+    let gateResolve: (() => void) | null = null;
+    const hooks = makeHooks({
+      onPost: (p) => void posts.push(p as { text: string }),
+      onAskPrincipal: () =>
+        new Promise(() => {
+          gateResolve = () => {};
+        }),
+    });
+    const runP = host.runTask(makeTask({ task_id: "g" }), hooks);
+    await until(() => brain.lastTask()?.task_id === "g");
+
+    // Brain opens a gate; the hook hangs (open gate).
+    brain.emit(
+      JSON.stringify({ v: 1, type: "post", task_id: "g", text: "composing…" }),
+    );
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "ask_principal",
+        task_id: "g",
+        gate: "principal-ack",
+        prompt: "Run it?",
+      }),
+    );
+    await until(() => posts.length === 1);
+
+    // Drain with a short deadline — the gate is still open, so it must be
+    // cancelled: a re-trigger notice posted + the task closed not_now.
+    await host.drain(30);
+
+    const res = await runP;
+    expect(res.result.status).toBe("failed");
+    if (res.result.status === "failed") {
+      expect(res.result.reason.kind).toBe("not_now");
+    }
+    // The upgrade notice was posted into the thread.
+    expect(posts.some((p) => /upgraded/i.test(p.text))).toBe(true);
+    // shutdown was sent to the brain with the deadline.
+    expect(brain.hasEvent("shutdown")).toBe(true);
+    void gateResolve;
+  });
+
+  test("drain lets an in-flight task finish if it completes before the deadline", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+    });
+    await host.start();
+
+    const runP = host.runTask(makeTask({ task_id: "fin" }), makeHooks());
+    await until(() => brain.lastTask()?.task_id === "fin");
+
+    // Complete shortly after drain begins, within the deadline.
+    const drainP = host.drain(500);
+    brain.emit(
+      JSON.stringify({ v: 1, type: "result", task_id: "fin", status: "complete" }),
+    );
+    const res = await runP;
+    await drainP;
+    expect(res.result.status).toBe("complete");
+  });
+});
+
+describe("DaemonBrainHost — attachment budget (§12.5)", () => {
+  test("an over-budget inline attachment is refused effect_rejected wont_do", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+    });
+    await host.start();
+
+    const hooks = makeHooks();
+    const runP = host.runTask(makeTask({ task_id: "big" }), hooks);
+    await until(() => brain.lastTask()?.task_id === "big");
+
+    // Build a base64 payload that DECODES to just over 4 MiB. The protocol's
+    // 256 KiB INLINE cap would reject a single huge b64 — so instead we post
+    // many under-256-KiB attachments until the per-TASK 4 MiB budget trips.
+    // One ~192 KiB-decoded attachment, posted ceil(4MiB/192KiB)+1 times.
+    const chunkDecodedBytes = 192 * 1024;
+    const b64 = Buffer.alloc(chunkDecodedBytes, 0x41).toString("base64");
+    const postsToOverflow = Math.ceil(MAX_TASK_ATTACHMENT_BYTES / chunkDecodedBytes) + 1;
+    for (let i = 0; i < postsToOverflow; i++) {
+      brain.emit(
+        JSON.stringify({
+          v: 1,
+          type: "post",
+          task_id: "big",
+          text: `chunk ${i}`,
+          attachment: { filename: `c${i}.bin`, b64 },
+        }),
+      );
+    }
+    // The budget overflow surfaces as an effect_rejected wont_do to the brain.
+    await until(() => brain.hasEvent("effect_rejected"));
+    const rej = brain.received.find((e) => e.type === "effect_rejected");
+    expect(rej).toMatchObject({ type: "effect_rejected", effect: "post" });
+    if (rej?.type === "effect_rejected") {
+      expect(rej.reason.kind).toBe("wont_do");
+      expect(rej.reason.detail).toMatch(/budget/i);
+    }
+
+    brain.emit(
+      JSON.stringify({ v: 1, type: "result", task_id: "big", status: "complete" }),
+    );
+    await runP;
+    await host.stop();
+  });
+});

--- a/src/brain/__tests__/daemon-brain-host.test.ts
+++ b/src/brain/__tests__/daemon-brain-host.test.ts
@@ -22,122 +22,20 @@ import { join } from "path";
 import {
   DaemonBrainHost,
   type DaemonTransport,
-  type DaemonBrainConnection,
   type DaemonBrainProcess,
 } from "../daemon-brain-host";
 import { MAX_TASK_ATTACHMENT_BYTES } from "../attachment-budget";
-import {
-  parseBrainEvent,
-  type BrainEvent,
-  type TaskEvent,
-  type GateVerdictValue,
-} from "../protocol";
+import { type TaskEvent, type GateVerdictValue } from "../protocol";
 import type { BrainTaskHooks } from "../exec-brain-runner";
+import {
+  FakeDaemonBrain,
+  makeFakeDaemonTransport,
+} from "./fake-daemon-brain";
 
-// ---------------------------------------------------------------------------
-// In-memory transport double
-// ---------------------------------------------------------------------------
-
-/**
- * A scripted brain on the other side of the socket. The host writes events
- * (lines) to `write`; the test reads them via `events` and replies by calling
- * `emit(line)`. `crash()` fires the close handler; `exit()` resolves `exited`.
- */
-class FakeBrain {
-  private dataHandler: ((chunk: string) => void) | null = null;
-  private closeHandler: (() => void) | null = null;
-  /** Every cortex → brain event the host wrote, parsed. */
-  readonly received: BrainEvent[] = [];
-  /** Raw lines (for assertions on shape). */
-  readonly receivedLines: string[] = [];
-  killed: NodeJS.Signals | number | undefined;
-  private exitResolve!: (code: number | null) => void;
-  readonly exited: Promise<number | null>;
-
-  readonly connection: DaemonBrainConnection;
-
-  constructor() {
-    this.exited = new Promise((res) => {
-      this.exitResolve = res;
-    });
-    this.connection = {
-      write: (chunk: string) => {
-        for (const line of chunk.split("\n")) {
-          if (line.trim().length === 0) continue;
-          this.receivedLines.push(line);
-          const parsed = parseBrainEvent(line);
-          if (parsed.kind === "ok") this.received.push(parsed.event);
-        }
-      },
-      onData: (handler) => {
-        this.dataHandler = handler as (c: string) => void;
-      },
-      onClose: (handler) => {
-        this.closeHandler = handler;
-      },
-    };
-  }
-
-  /** Brain → host: emit one effect line. */
-  emit(line: string): void {
-    this.dataHandler?.(line + "\n");
-  }
-
-  /** Simulate a crash — fire the connection close handler. */
-  crash(): void {
-    this.closeHandler?.();
-    this.exitResolve(1);
-  }
-
-  /** Simulate a clean exit. */
-  exit(code = 0): void {
-    this.exitResolve(code);
-  }
-
-  /** Did the host write an event of this type? */
-  hasEvent(type: BrainEvent["type"]): boolean {
-    return this.received.some((e) => e.type === type);
-  }
-
-  lastTask(): TaskEvent | undefined {
-    const tasks = this.received.filter((e): e is TaskEvent => e.type === "task");
-    return tasks[tasks.length - 1];
-  }
-}
-
-/**
- * Build a transport that hands out a sequence of FakeBrains (one per spawn —
- * generation 0, then restarts). The test pre-seeds the list; each spawn pops the
- * next. `connectDelayMs` lets a generation defer connecting.
- */
-function makeFakeTransport(brains: FakeBrain[]): {
-  transport: DaemonTransport;
-  spawns: number;
-} {
-  const state = { spawns: 0 };
-  const transport: DaemonTransport = () => {
-    const brain = brains[state.spawns];
-    state.spawns += 1;
-    if (brain === undefined) {
-      throw new Error(`fake transport: no brain seeded for spawn #${state.spawns - 1}`);
-    }
-    const proc: DaemonBrainProcess = {
-      connection: Promise.resolve(brain.connection),
-      exited: brain.exited,
-      kill: (signal) => {
-        brain.killed = signal;
-        brain.exit(137);
-      },
-    };
-    return proc;
-  };
-  return {
-    transport,
-    get spawns() {
-      return state.spawns;
-    },
-  };
-}
+// The in-memory daemon-brain double + sequencing transport are shared with the
+// consumer integration tests; see `./fake-daemon-brain.ts`.
+const FakeBrain = FakeDaemonBrain;
+const makeFakeTransport = makeFakeDaemonTransport;
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -396,6 +294,67 @@ describe("DaemonBrainHost — supervision", () => {
     brains[1]?.crash(); // would be 2/1 without reset → but reset → 1/1 again
     await until(() => brains[2]?.hasEvent("hello") === true);
     expect(host.isDegraded).toBe(false);
+    await host.stop();
+  });
+
+  // Finding 2 (sage cortex#1035): a restart whose CONNECT always fails must
+  // count against the restart budget and degrade — not recurse, not leave a
+  // stale proc installed.
+  test("a restart that always fails to connect degrades after maxRestarts (no recursion, no stale proc)", async () => {
+    const gen0 = new FakeDaemonBrain();
+    // gen 0 connects fine; every restart spawn rejects its connection promise.
+    let spawnIdx = 0;
+    const killedProcs: DaemonBrainProcess[] = [];
+    const transport: DaemonTransport = () => {
+      const idx = spawnIdx++;
+      if (idx === 0) {
+        return {
+          connection: Promise.resolve(gen0.connection),
+          exited: gen0.exited,
+          kill: () => gen0.killed(),
+        };
+      }
+      // A failed-connect restart: connection rejects, process already exited.
+      const proc: DaemonBrainProcess = {
+        connection: Promise.reject(
+          new Error(`connect failed for restart spawn #${idx}`),
+        ),
+        exited: Promise.resolve(1),
+        kill: () => {},
+      };
+      killedProcs.push(proc);
+      return proc;
+    };
+
+    const degraded: string[] = [];
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      maxRestarts: 2,
+      makeScratchDir: scratchFactory,
+      onDegraded: (id) => degraded.push(id),
+    });
+    await host.start();
+    expect(gen0.hasEvent("hello")).toBe(true);
+
+    // Crash gen 0 → restart 1 (fails connect) → restart 2 (fails connect) →
+    // budget (2) exhausted → degraded. No infinite recursion.
+    gen0.crash();
+    await until(() => host.isDegraded, 3000);
+    expect(degraded).toEqual(["yarrow"]);
+    // Exactly 1 original + 2 restart spawns were attempted (budget == 2); a
+    // recursion bug would keep spawning well past this.
+    expect(spawnIdx).toBe(3);
+
+    // No stale proc installed: a new task fast-fails not_now (degraded), and the
+    // host did not silently keep a dead connection.
+    const res = await host.runTask(makeTask(), makeHooks());
+    expect(res.result.status).toBe("failed");
+    if (res.result.status === "failed") {
+      expect(res.result.reason.kind).toBe("not_now");
+    }
     await host.stop();
   });
 });

--- a/src/brain/__tests__/daemon-socket-auth.test.ts
+++ b/src/brain/__tests__/daemon-socket-auth.test.ts
@@ -192,3 +192,25 @@ describe("makeBunUnixTransport — socket auth (finding 1)", () => {
     first.close();
   });
 });
+
+// sage cortex#1035 round 2 — bytes in the SAME chunk as the auth line must
+// reach the protocol layer once onData registers (no silent drop).
+describe("round-2: post-auth bytes in the auth chunk", () => {
+  test("protocol bytes appended to the auth line are delivered, not dropped", async () => {
+    const token = crypto.randomUUID();
+    const { proc, socketPath } = startTransport(token);
+    const brain = await connectRaw(socketPath);
+    // Auth line + a protocol line in ONE write (one socket chunk).
+    brain.write(
+      `{"v":1,"type":"auth","token":"${token}"}\n` +
+        `{"v":1,"type":"log","level":"info","text":"same-chunk"}\n`,
+    );
+    const conn = await proc.connection;
+    const received: string[] = [];
+    conn.onData((chunk) =>
+      received.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk)),
+    );
+    await until(() => received.join("").includes("same-chunk"));
+    brain.close();
+  });
+});

--- a/src/brain/__tests__/daemon-socket-auth.test.ts
+++ b/src/brain/__tests__/daemon-socket-auth.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Socket-auth probes for the production Bun Unix-socket transport
+ * (`makeBunUnixTransport`) — finding 1, sage cortex#1035.
+ *
+ * The transport binds a real Unix socket and requires the FIRST line from the
+ * connector to prove a per-spawn token before it resolves `connection` and
+ * before any effect is routed. These probes drive a REAL socket: the transport
+ * spawns a long-lived no-op process (so it does not reject on early exit) and
+ * the TEST plays the brain by connecting to the socket directly via
+ * `Bun.connect({ unix })`.
+ *
+ *   - wrong-token connector is rejected (connection never resolves)
+ *   - no effect is accepted pre-auth (no data reaches the host's onData pump)
+ *   - the correct token proceeds (connection resolves, post-auth bytes flow)
+ *   - a second connector while one is live is rejected
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "os";
+import { join } from "path";
+import { makeBunUnixTransport, SOCKET_AUTH_TIMEOUT_MS } from "../daemon-brain-host";
+import type { DaemonBrainProcess } from "../daemon-brain-host";
+
+/** A long-lived no-op argv so the transport does not reject on early exit. */
+const SLEEP_ARGV = ["sleep", "30"];
+
+let spawned: DaemonBrainProcess[] = [];
+
+function startTransport(token: string): { proc: DaemonBrainProcess; socketPath: string } {
+  const socketPath = join(
+    tmpdir(),
+    `cortex-brain-auth-test-${process.pid}-${crypto.randomUUID().slice(0, 8)}.sock`,
+  );
+  const proc = makeBunUnixTransport({
+    argv: SLEEP_ARGV,
+    env: {},
+    cwd: tmpdir(),
+    socketPath,
+    socketToken: token,
+  });
+  spawned.push(proc);
+  return { proc, socketPath };
+}
+
+/** Connect to the unix socket as a raw brain. */
+async function connectRaw(socketPath: string): Promise<{
+  write: (s: string) => void;
+  received: () => string;
+  close: () => void;
+}> {
+  let buf = "";
+  const sock = await Bun.connect({
+    unix: socketPath,
+    socket: {
+      data(_s, data: Uint8Array) {
+        buf += new TextDecoder().decode(data);
+      },
+      error() {},
+      close() {},
+    },
+  });
+  return {
+    write: (s: string) => void sock.write(s),
+    received: () => buf,
+    close: () => sock.end(),
+  };
+}
+
+/** Wait until `cond()` or throw after `timeoutMs`. */
+async function until(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("until() timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/** Race a promise against a timeout, resolving to a discriminated outcome. */
+async function settleWithin<T>(
+  p: Promise<T>,
+  ms: number,
+): Promise<{ state: "resolved"; value: T } | { state: "rejected" } | { state: "pending" }> {
+  return Promise.race([
+    p.then(
+      (value) => ({ state: "resolved" as const, value }),
+      () => ({ state: "rejected" as const }),
+    ),
+    new Promise<{ state: "pending" }>((r) =>
+      setTimeout(() => r({ state: "pending" }), ms),
+    ),
+  ]);
+}
+
+afterEach(() => {
+  for (const p of spawned) {
+    try {
+      p.kill("SIGKILL");
+    } catch {
+      // already gone
+    }
+  }
+  spawned = [];
+});
+
+describe("makeBunUnixTransport — socket auth (finding 1)", () => {
+  test("the correct token proceeds: connection resolves and post-auth bytes reach onData", async () => {
+    const token = crypto.randomUUID();
+    const { proc, socketPath } = startTransport(token);
+    const brain = await connectRaw(socketPath);
+
+    // Send the auth proof, then a protocol line.
+    brain.write(JSON.stringify({ v: 1, type: "auth", token }) + "\n");
+
+    const conn = await proc.connection; // resolves only on a valid auth proof
+    const seen: string[] = [];
+    conn.onData((chunk) => {
+      seen.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+    });
+
+    // A post-auth protocol line must flow to the host's pump.
+    brain.write(JSON.stringify({ v: 1, type: "log", level: "info", text: "hi" }) + "\n");
+    await until(() => seen.join("").includes("hi"));
+    expect(seen.join("")).toContain("hi");
+    brain.close();
+  });
+
+  test("a wrong-token connector is rejected: connection never resolves and no effect is accepted", async () => {
+    const { proc, socketPath } = startTransport(crypto.randomUUID());
+    const brain = await connectRaw(socketPath);
+
+    let onDataFired = false;
+    // Wire onData BEFORE auth would resolve — it must never fire pre-auth. Also
+    // attach a rejection handler so the expected auth-failure rejection is not
+    // reported as unhandled.
+    void proc.connection.then(
+      (conn) => {
+        conn.onData(() => {
+          onDataFired = true;
+        });
+      },
+      () => {
+        // Expected: auth failed → connection rejected. Swallowed here; the
+        // assertion below verifies the rejection via settleWithin.
+      },
+    );
+
+    // Wrong token, then an effect the host must NOT route.
+    brain.write(JSON.stringify({ v: 1, type: "auth", token: "WRONG" }) + "\n");
+    brain.write(JSON.stringify({ v: 1, type: "post", task_id: "t", text: "x" }) + "\n");
+
+    const outcome = await settleWithin(proc.connection, 500);
+    expect(outcome.state).toBe("rejected");
+    expect(onDataFired).toBe(false);
+    brain.close();
+  });
+
+  test("no auth line within the timeout rejects the connection", async () => {
+    const { proc, socketPath } = startTransport(crypto.randomUUID());
+    const brain = await connectRaw(socketPath);
+    // Send nothing. The transport's auth deadline must reject.
+    const outcome = await settleWithin(proc.connection, SOCKET_AUTH_TIMEOUT_MS + 1000);
+    expect(outcome.state).toBe("rejected");
+    brain.close();
+  });
+
+  test("a second connector while one is live is rejected", async () => {
+    const token = crypto.randomUUID();
+    const { proc, socketPath } = startTransport(token);
+
+    // First connector authenticates and owns the connection.
+    const first = await connectRaw(socketPath);
+    first.write(JSON.stringify({ v: 1, type: "auth", token }) + "\n");
+    await proc.connection;
+
+    // A second connector — even with the correct token — must be closed; it
+    // cannot race in as the brain. Its socket closes without ever taking over.
+    let secondClosed = false;
+    const second = await Bun.connect({
+      unix: socketPath,
+      socket: {
+        data() {},
+        error() {},
+        close() {
+          secondClosed = true;
+        },
+      },
+    });
+    second.write(JSON.stringify({ v: 1, type: "auth", token }) + "\n");
+    await until(() => secondClosed, 2000);
+    expect(secondClosed).toBe(true);
+
+    first.close();
+  });
+});

--- a/src/brain/__tests__/fake-daemon-brain.ts
+++ b/src/brain/__tests__/fake-daemon-brain.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared in-memory daemon-brain test double (Bot Packs B-2).
+ *
+ * A scripted "brain" on the other side of the {@link DaemonBrainHost} transport
+ * seam — no real socket, no real subprocess. The host writes cortex → brain
+ * events to the connection's `write`; the test inspects them via `received` and
+ * replies by calling `emit(line)` (brain → cortex effects). `crash()` fires the
+ * close handler; `exit(code)` / `kill` resolve `exited`.
+ *
+ * Both the host's own unit tests (`daemon-brain-host.test.ts`) and the
+ * consumer↔host integration tests (`brain-consumer.test.ts`) drive this same
+ * double, so a protocol-shape change updates ONE place instead of fanning out
+ * across two near-identical copies (sage cortex#1035 round 1).
+ *
+ * NOT a `.test.ts` file on purpose — it defines no suite; it is imported by the
+ * suites that need it.
+ */
+
+import {
+  parseBrainEvent,
+  type BrainEvent,
+  type TaskEvent,
+} from "../protocol";
+import type {
+  DaemonBrainConnection,
+  DaemonBrainProcess,
+  DaemonTransport,
+} from "../daemon-brain-host";
+
+/** A scripted brain the host talks to over an in-memory connection. */
+export class FakeDaemonBrain {
+  private dataHandler: ((chunk: string) => void) | null = null;
+  private closeHandler: (() => void) | null = null;
+
+  /** Every cortex → brain event the host wrote, parsed. */
+  readonly received: BrainEvent[] = [];
+  /** Raw lines (for assertions on wire shape). */
+  readonly receivedLines: string[] = [];
+  /** The signal the host killed the process with (if any). */
+  killedWith: NodeJS.Signals | number | undefined;
+
+  private exitResolve!: (code: number | null) => void;
+  readonly exited: Promise<number | null>;
+  readonly connection: DaemonBrainConnection;
+
+  constructor() {
+    this.exited = new Promise((res) => {
+      this.exitResolve = res;
+    });
+    this.connection = {
+      write: (chunk: string) => {
+        for (const line of chunk.split("\n")) {
+          if (line.trim().length === 0) continue;
+          this.receivedLines.push(line);
+          const parsed = parseBrainEvent(line);
+          if (parsed.kind === "ok") this.received.push(parsed.event);
+        }
+      },
+      onData: (handler) => {
+        this.dataHandler = handler as (c: string) => void;
+      },
+      onClose: (handler) => {
+        this.closeHandler = handler;
+      },
+    };
+  }
+
+  /** Brain → host: emit one effect line. */
+  emit(line: string): void {
+    this.dataHandler?.(line + "\n");
+  }
+
+  /** Simulate a crash — fire the connection close handler + resolve `exited`. */
+  crash(): void {
+    this.closeHandler?.();
+    this.exitResolve(1);
+  }
+
+  /** Simulate a clean exit. */
+  exit(code = 0): void {
+    this.exitResolve(code);
+  }
+
+  /** A killed process exits — resolve `exited` so teardown settles promptly. */
+  killed(): void {
+    this.exitResolve(137);
+  }
+
+  /** Did the host write an event of this type? */
+  hasEvent(type: BrainEvent["type"]): boolean {
+    return this.received.some((e) => e.type === type);
+  }
+
+  /** Did the host write at least one `task` event? */
+  hasTask(): boolean {
+    return this.hasEvent("task");
+  }
+
+  /** The FIRST task's id (consumer integration tests dispatch one task). */
+  taskId(): string | undefined {
+    const t = this.received.find((e) => e.type === "task");
+    return t?.type === "task" ? t.task_id : undefined;
+  }
+
+  /** The LAST task the host wrote (multiplex tests dispatch several). */
+  lastTask(): TaskEvent | undefined {
+    const tasks = this.received.filter((e): e is TaskEvent => e.type === "task");
+    return tasks[tasks.length - 1];
+  }
+}
+
+/**
+ * A transport that hands out a fixed SEQUENCE of brains — one per spawn
+ * (generation 0, then restarts). The test pre-seeds the list; each spawn pops
+ * the next. Exposes a live `spawns` count.
+ */
+export function makeFakeDaemonTransport(brains: FakeDaemonBrain[]): {
+  transport: DaemonTransport;
+  readonly spawns: number;
+} {
+  const state = { spawns: 0 };
+  const transport: DaemonTransport = () => {
+    const brain = brains[state.spawns];
+    state.spawns += 1;
+    if (brain === undefined) {
+      throw new Error(
+        `fake transport: no brain seeded for spawn #${state.spawns - 1}`,
+      );
+    }
+    const proc: DaemonBrainProcess = {
+      connection: Promise.resolve(brain.connection),
+      exited: brain.exited,
+      kill: (signal) => {
+        brain.killedWith = signal;
+        brain.exit(137);
+      },
+    };
+    return proc;
+  };
+  return {
+    transport,
+    get spawns() {
+      return state.spawns;
+    },
+  };
+}
+
+/**
+ * A single-brain transport (the common case for the consumer integration
+ * tests). On `kill`, resolves the brain's `exited` so the host's
+ * SIGTERM→grace race settles promptly rather than waiting the full grace.
+ */
+export function singleFakeDaemonTransport(brain: FakeDaemonBrain): DaemonTransport {
+  return () => ({
+    connection: Promise.resolve(brain.connection),
+    exited: brain.exited,
+    kill: () => brain.killed(),
+  });
+}

--- a/src/brain/attachment-budget.ts
+++ b/src/brain/attachment-budget.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-task attachment budget (Bot Packs B-2; `docs/design-bot-packs.md` §12.5).
+ *
+ * §12.5 (JC decision, 2026-06-11): **4 MiB total per task** — cumulative
+ * inline-base64 (`post.attachment.b64`) PLUS scratch-path uploads
+ * (`post.attachment.path`) combined. Over budget → `effect_rejected` with
+ * `wont_do` (PERMANENT for that task — the brain must summarise or link instead
+ * of re-trying the same payload).
+ *
+ * This is the HOST-side cap (§8 "Resource caps are host-side manifest fields"),
+ * SEPARATE from and STRICTER-in-aggregate than the per-attachment 256 KiB inline
+ * cap (`protocol.ts` `MAX_ATTACHMENT_B64_BYTES`): a brain can stay under 256 KiB
+ * per `post` yet blow the per-TASK ceiling across many posts. The inline cap is
+ * a single-message shape limit enforced at PARSE time; this budget is a running
+ * TASK total enforced after parse, at the host effect boundary.
+ *
+ * ## Why a shared module
+ *
+ * BOTH lifecycles enforce it: the per-task `exec-brain-runner` (one budget per
+ * spawned task) and the daemon `daemon-brain-host` (one budget per multiplexed
+ * task_id). Sharing the accounting keeps the rule in one place — a brain that
+ * posts 20 × 250 KiB attachments hits the same `wont_do` whether it is per-task
+ * or daemon-hosted.
+ *
+ * ## Sizing rule
+ *
+ *   - **inline** — the budget charges the DECODED byte length of the base64
+ *     payload (`Buffer.byteLength(b64, "base64")`), i.e. what the upload will
+ *     actually weigh on the surface, NOT the ~33%-larger base64 envelope. A
+ *     brain that base64s a 250 KiB PNG is charged ~250 KiB, not ~333 KiB.
+ *   - **scratch path** — the on-disk size of the referenced file
+ *     (`statSync(...).size`). The runner has ALREADY confined the path to the
+ *     task's scratch dir before this is called, so the stat is on a host-owned,
+ *     in-bounds file. A vanished/unreadable file is charged 0 (the post will
+ *     fail downstream at upload; the budget does not punish a stat miss).
+ */
+
+import { statSync } from "fs";
+import type { PostAttachment } from "./protocol";
+
+/**
+ * The per-task attachment ceiling — 4 MiB (`docs/design-bot-packs.md` §12.5).
+ * Cumulative inline + scratch bytes; exported so the host/runner share ONE
+ * constant and tests assert against it directly.
+ */
+export const MAX_TASK_ATTACHMENT_BYTES = 4 * 1024 * 1024;
+
+/** What {@link AttachmentBudget.charge} returns. */
+export type AttachmentChargeResult =
+  | { ok: true; chargedBytes: number; totalBytes: number }
+  | { ok: false; detail: string; attemptedBytes: number; totalBytes: number };
+
+/**
+ * Compute the byte weight an attachment adds to a task's running total.
+ *
+ * Exported (not just used by {@link AttachmentBudget}) so a host can probe an
+ * attachment's size without mutating a budget — e.g. for a log line. The
+ * `confinedPath` argument lets the caller pass the HOST-RESOLVED, confined path
+ * (the runner resolves `attachment.path` against the realpath'd scratch dir);
+ * when omitted, the attachment's own `path` is stat'd as-is (the daemon host
+ * passes the resolved path explicitly).
+ */
+export function attachmentByteSize(
+  attachment: PostAttachment,
+  confinedPath?: string,
+): number {
+  if (attachment.b64 !== undefined) {
+    // Charge the DECODED size — what the surface upload actually weighs.
+    return Buffer.byteLength(attachment.b64, "base64");
+  }
+  // Scratch-path reference. The caller has already confined the path; stat the
+  // host-owned file. A stat failure (vanished/unreadable) charges 0 — the post
+  // fails downstream at upload, not here.
+  const pathToStat = confinedPath ?? attachment.path;
+  if (pathToStat === undefined) return 0;
+  try {
+    return statSync(pathToStat).size;
+  } catch (err) {
+    // Non-fatal: a missing/unreadable scratch file is charged 0 (the post will
+    // fail at upload). Logged so a silently-dropped charge is observable.
+    process.stderr.write(
+      `attachment-budget: could not stat scratch attachment "${pathToStat}" ` +
+        `(charging 0 bytes): ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * A per-task running attachment-byte accumulator. One instance per task (the
+ * runner makes one per spawned task; the daemon host makes one per task_id and
+ * disposes it when the task closes). NOT thread-safe across tasks by design —
+ * each task has its OWN budget; that is the §12.5 semantics ("4 MiB total per
+ * task").
+ *
+ * The budget is CONSUMED on a successful charge: once 4 MiB is spent, every
+ * subsequent attachment over the remainder is rejected `wont_do`. A rejected
+ * charge does NOT consume budget (the attachment was refused, so its bytes never
+ * counted) — the brain may still post a SMALLER attachment that fits the
+ * remainder, or post text without an attachment.
+ */
+export class AttachmentBudget {
+  private spent = 0;
+
+  constructor(private readonly cap: number = MAX_TASK_ATTACHMENT_BYTES) {}
+
+  /** Bytes already charged against this task. */
+  get totalBytes(): number {
+    return this.spent;
+  }
+
+  /** Remaining budget before the cap (never negative). */
+  get remainingBytes(): number {
+    return Math.max(0, this.cap - this.spent);
+  }
+
+  /**
+   * Charge an attachment against the budget.
+   *
+   *   - WITHIN budget → consume the bytes, return `{ ok: true, chargedBytes,
+   *     totalBytes }`.
+   *   - OVER budget → consume NOTHING, return `{ ok: false, detail, … }` with a
+   *     legible reason the caller turns into an `effect_rejected` (`wont_do`).
+   *
+   * `confinedPath` is the host-resolved, confined scratch path for a
+   * path-attachment (the runner/host has already validated it stays inside the
+   * task scratch dir). For an inline attachment it is ignored.
+   */
+  charge(
+    attachment: PostAttachment,
+    confinedPath?: string,
+  ): AttachmentChargeResult {
+    const bytes = attachmentByteSize(attachment, confinedPath);
+    if (this.spent + bytes > this.cap) {
+      return {
+        ok: false,
+        detail:
+          `per-task attachment budget exceeded: this attachment is ${bytes} bytes, ` +
+          `${this.spent} already used of ${this.cap} (${MAX_TASK_ATTACHMENT_BYTES / (1024 * 1024)} MiB) — ` +
+          `summarise or link instead of attaching`,
+        attemptedBytes: bytes,
+        totalBytes: this.spent,
+      };
+    }
+    this.spent += bytes;
+    return { ok: true, chargedBytes: bytes, totalBytes: this.spent };
+  }
+}

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -1,0 +1,1053 @@
+/**
+ * `cortex-brain/v1` daemon host (Bot Packs B-2; `docs/design-bot-packs.md`
+ * §5, §7, §12.1).
+ *
+ * The cortex-side half of the `kind: exec`, `lifecycle: daemon` seam: a
+ * LONG-LIVED brain process per agent, spawned ONCE, speaking the protocol over a
+ * cortex-assigned **Unix domain socket** (§12.1: socket for protocol, stdio for
+ * logs). Per-task events MULTIPLEX over the one socket — every event/effect
+ * already carries `task_id` (protocol.ts), so a single connection serves many
+ * concurrent tasks. The host:
+ *
+ *   1. spawns the brain with a MINIMAL env (PATH/HOME/LANG/TMPDIR + the
+ *      manifest secrets, same discipline as `exec-brain-runner`) plus the
+ *      `CORTEX_BRAIN_SOCKET` env naming the socket to connect back on, and
+ *      `lifecycle: daemon`-marking `CORTEX_BRAIN_LIFECYCLE=daemon`;
+ *   2. waits for the brain to connect, then sends the `hello` handshake
+ *      (host → brain: agent id, persona, protocol version — §5 "Persona
+ *      delivery"; identity is HOST-AUTHORITATIVE);
+ *   3. accepts `runTask(task, hooks)` calls — writes the `task` event, routes
+ *      the brain's effects (post / ask_principal / dispatch / log / result) to
+ *      the per-task hooks, and resolves when that task's `result` arrives;
+ *   4. enforces, PER TASK (not per process): task_id correlation, scratch
+ *      confinement, and the 4 MiB attachment budget (§12.5). Scratch dirs are
+ *      created per TASK and removed when the task closes — confinement stays
+ *      task-scoped even though the process is shared (the task brief: "scratch
+ *      dir per TASK, not per process");
+ *   5. SUPERVISES the process: a crash restarts it up to `maxRestarts`, then
+ *      marks the agent DEGRADED; the restart counter RESETS after a healthy
+ *      uptime interval. All in-flight tasks of a crashed brain fail
+ *      (`cant_do`, "brain crashed") — the consumer maps that to
+ *      `dispatch.task.failed` + nak;
+ *   6. DRAINS on hot-swap (`drain(deadlineMs)`): sends `shutdown` with the
+ *      deadline, waits for in-flight tasks (and open `ask_principal` gates) up
+ *      to the deadline, CANCELS anything still open past it, then SIGTERM →
+ *      +killGraceMs SIGKILL.
+ *
+ * ## Relationship to `exec-brain-runner`
+ *
+ * The per-task runner spawns-per-task; this host spawns-once and multiplexes.
+ * They SHARE the protocol codec, the scratch-confinement helper
+ * (`confineScratchPath`), the minimal-env builder (`buildEnv`), the argv
+ * builder (`buildArgv`), and the attachment budget — so the security discipline
+ * is identical at both lifecycles; only the process lifecycle differs.
+ *
+ * ## Transport injection
+ *
+ * The socket is behind a {@link DaemonTransport} seam (mirroring the runner's
+ * injectable `BrainSpawnFn`). Production wires {@link makeBunUnixTransport}
+ * (`Bun.listen({ unix })` + `Bun.spawn` with the socket env); tests inject an
+ * in-memory transport that drives the brain side directly — the protocol,
+ * multiplexing, supervision, drain, budget, and confinement logic are all
+ * exercised without a real socket or subprocess.
+ */
+
+import { mkdtempSync, realpathSync } from "fs";
+import { rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join, resolve as resolvePath } from "path";
+import {
+  encodeBrainEvent,
+  parseBrainEffect,
+  JsonlDecoder,
+  type TaskEvent,
+  type ResultEffect,
+} from "./protocol";
+import {
+  buildArgv,
+  buildEnv,
+  confineScratchPath,
+  type BrainTaskHooks,
+  type BrainTaskRunResult,
+} from "./exec-brain-runner";
+import { AttachmentBudget } from "./attachment-budget";
+
+// ---------------------------------------------------------------------------
+// Transport seam
+// ---------------------------------------------------------------------------
+
+/**
+ * A connected brain socket — the bytes-in / bytes-out + close handle the host
+ * speaks the protocol over. Production is a Bun Unix-socket connection; tests
+ * supply an in-memory double. The host owns framing (JsonlDecoder); the
+ * transport only moves bytes.
+ */
+export interface DaemonBrainConnection {
+  /** Write a raw chunk (one or more newline-delimited JSON lines) to the brain. */
+  write(chunk: string): void | Promise<void>;
+  /** Register the byte sink for inbound brain → host bytes. Called once. */
+  onData(handler: (chunk: Uint8Array | string) => void): void;
+  /** Register the connection-closed handler (brain disconnected / crashed). */
+  onClose(handler: () => void): void;
+}
+
+/**
+ * The spawned-and-connected brain. The transport spawns the process, listens on
+ * the assigned socket, and resolves `connection` once the brain connects back.
+ * `exited` resolves with the process exit code (or null if killed). `kill`
+ * escalates termination.
+ */
+export interface DaemonBrainProcess {
+  /** Resolves once the brain has connected on the socket + is ready for `hello`. */
+  connection: Promise<DaemonBrainConnection>;
+  /** Resolves with the exit code when the process exits (null if killed pre-exit). */
+  exited: Promise<number | null>;
+  /** Send a POSIX signal (SIGTERM / SIGKILL escalation). */
+  kill(signal?: NodeJS.Signals | number): void;
+}
+
+/**
+ * Spawn-and-listen transport. Given the resolved argv + env + a socket path,
+ * it must: bind/listen on the socket, spawn the process (with the socket env
+ * already injected by the host into `env`), and resolve `connection` when the
+ * brain connects. Tests inject a fake that wires an in-memory pipe.
+ */
+export type DaemonTransport = (opts: {
+  argv: string[];
+  env: Record<string, string>;
+  cwd: string;
+  socketPath: string;
+}) => DaemonBrainProcess;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/** Construction options for {@link DaemonBrainHost}. */
+export interface DaemonBrainHostOpts {
+  /** Logical agent id — sent in `hello`, used in logs. */
+  agentId: string;
+  /** The manifest `run` string (`bun {pack}/brain/main.ts`); `{pack}` → packDir. */
+  run: string;
+  /** The arc install dir — substituted for `{pack}`. */
+  packDir: string;
+  /** Persona text — delivered ONCE in the `hello` handshake (daemon §5). */
+  persona?: string;
+  /** Secret env vars (resolved values), injected verbatim. Defaults to `{}`. */
+  secrets?: Record<string, string>;
+  /**
+   * Daemon supervision restart cap (§7.4): restart a crashed brain up to this
+   * many times, then mark the agent degraded. Defaults to 3.
+   */
+  maxRestarts?: number;
+  /**
+   * Healthy-uptime interval after which the restart counter RESETS (§7.4: "restarts
+   * reset on a healthy interval (e.g. 10 min uptime)"). A brain that runs this
+   * long without crashing is considered recovered. Defaults to 600_000 (10 min).
+   */
+  healthyResetMs?: number;
+  /**
+   * Per-task timeout (ms). A task with no `result` by this point fails
+   * (`cant_do`, timeout) — but does NOT kill the shared process (other tasks
+   * keep running). Defaults to 120_000 (2 min).
+   */
+  taskTimeoutMs?: number;
+  /** SIGTERM → SIGKILL grace on drain/shutdown. Defaults to 5_000 (§7.6). */
+  killGraceMs?: number;
+  /** Injected transport. Defaults to {@link makeBunUnixTransport}. */
+  transport?: DaemonTransport;
+  /** Scratch-dir factory (per TASK). Defaults to `mkdtempSync` under OS temp. */
+  makeScratchDir?: () => string;
+  /** Socket-path factory. Defaults to a unique path under OS temp. */
+  makeSocketPath?: (agentId: string) => string;
+  /**
+   * Called when the brain is marked DEGRADED (restart budget exhausted). The
+   * consumer/boot wiring routes this to the presence producer
+   * (`publishCapabilitiesChanged(agentId, [])`) — the existing capability-change
+   * presence signal (§7.4: "surface it (agent.online presence envelope already
+   * exists for exactly this)"). Best-effort; a throw here is logged, not fatal.
+   */
+  onDegraded?: (agentId: string) => void;
+  /** Test seam — clock for uptime accounting. Defaults to `() => Date.now()`. */
+  now?: () => number;
+}
+
+/** Per-task tracking record (one per multiplexed task_id). */
+interface TaskRecord {
+  task: TaskEvent;
+  hooks: BrainTaskHooks;
+  scratchReal: string;
+  scratchDir: string;
+  budget: AttachmentBudget;
+  logs: string[];
+  resolve: (r: BrainTaskRunResult) => void;
+  settled: boolean;
+  /** Open `ask_principal` gate count — drain waits on these up to the deadline. */
+  openGates: number;
+  timeoutTimer?: ReturnType<typeof setTimeout>;
+}
+
+/** A reason the host fails an in-flight task it could not let the brain finish. */
+type HostTaskFailKind = "crashed" | "drained" | "timeout";
+
+// ---------------------------------------------------------------------------
+// Host
+// ---------------------------------------------------------------------------
+
+/**
+ * One long-lived daemon brain, supervised. Construct it, `await start()` (spawn
+ * + connect + hello), then `runTask(...)` per inbound task. `drain(deadlineMs)`
+ * on hot-swap; `stop()` for an unconditional teardown.
+ */
+export class DaemonBrainHost {
+  readonly agentId: string;
+
+  private readonly run: string;
+  private readonly packDir: string;
+  private readonly persona: string | undefined;
+  private readonly secrets: Record<string, string>;
+  private readonly maxRestarts: number;
+  private readonly healthyResetMs: number;
+  private readonly taskTimeoutMs: number;
+  private readonly killGraceMs: number;
+  private readonly transport: DaemonTransport;
+  private readonly makeScratchDir: () => string;
+  private readonly makeSocketPath: (agentId: string) => string;
+  private readonly onDegraded: ((agentId: string) => void) | undefined;
+  private readonly now: () => number;
+
+  /** Live process + connection for the CURRENT generation. */
+  private proc: DaemonBrainProcess | null = null;
+  private connection: DaemonBrainConnection | null = null;
+  private decoder = new JsonlDecoder();
+
+  /** In-flight tasks keyed by task_id (multiplexed over the one socket). */
+  private readonly tasks = new Map<string, TaskRecord>();
+
+  /** Restart accounting (§7.4). */
+  private restartCount = 0;
+  private spawnAt = 0;
+  private healthyResetTimer: ReturnType<typeof setTimeout> | undefined;
+  /**
+   * Monotonic generation token. Incremented on every spawn. The close/exit
+   * watchers capture the generation they were wired for and IGNORE a disconnect
+   * that arrives for a STALE generation — a crashed process's `exited` and its
+   * socket `close` both fire, and a restart may already have advanced the live
+   * generation by the time the second signal lands; without this, a single
+   * crash could be counted twice (or a restart's fresh process mistaken for the
+   * crashed one).
+   */
+  private generation = 0;
+
+  private started = false;
+  private degraded = false;
+  private draining = false;
+  private stopped = false;
+
+  constructor(opts: DaemonBrainHostOpts) {
+    this.agentId = opts.agentId;
+    this.run = opts.run;
+    this.packDir = opts.packDir;
+    this.persona = opts.persona;
+    this.secrets = opts.secrets ?? {};
+    this.maxRestarts = opts.maxRestarts ?? 3;
+    this.healthyResetMs = opts.healthyResetMs ?? 600_000;
+    this.taskTimeoutMs = opts.taskTimeoutMs ?? 120_000;
+    this.killGraceMs = opts.killGraceMs ?? 5_000;
+    this.transport = opts.transport ?? makeBunUnixTransport;
+    this.makeScratchDir =
+      opts.makeScratchDir ??
+      (() => mkdtempSync(join(tmpdir(), "cortex-brain-daemon-")));
+    this.makeSocketPath =
+      opts.makeSocketPath ??
+      ((id) =>
+        join(
+          tmpdir(),
+          `cortex-brain-${id}-${process.pid}-${crypto.randomUUID().slice(0, 8)}.sock`,
+        ));
+    this.onDegraded = opts.onDegraded;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  /** True once the restart budget is exhausted — the consumer stops dispatching. */
+  get isDegraded(): boolean {
+    return this.degraded;
+  }
+
+  /**
+   * Spawn the brain, wait for it to connect, send `hello`. Idempotent-guarded.
+   * Throws if the brain never connects (a manifest/transport fault) — boot logs
+   * + skips, same as the per-task runner's spawn-fail synthesis.
+   */
+  async start(): Promise<void> {
+    if (this.started) {
+      throw new Error(`daemon-brain-host: already started for "${this.agentId}"`);
+    }
+    this.started = true;
+    await this.spawnGeneration();
+  }
+
+  /**
+   * Run one task. Writes the `task` event over the socket and resolves with the
+   * terminal result. Multiplexed: many `runTask` calls share the one process,
+   * correlated by `task_id`. A degraded/stopped/draining host fails fast with a
+   * synthesized `not_now` (the consumer naks for the next boot).
+   */
+  async runTask(
+    task: TaskEvent,
+    hooks: BrainTaskHooks,
+  ): Promise<BrainTaskRunResult> {
+    if (this.degraded || this.stopped) {
+      return synthHostFail(
+        task.task_id,
+        "not_now",
+        `daemon brain "${this.agentId}" is ${this.degraded ? "degraded" : "stopped"}`,
+      );
+    }
+    if (this.draining) {
+      return synthHostFail(
+        task.task_id,
+        "not_now",
+        `daemon brain "${this.agentId}" is draining (hot-swap)`,
+      );
+    }
+    const conn = this.connection;
+    if (conn === null) {
+      return synthHostFail(
+        task.task_id,
+        "not_now",
+        `daemon brain "${this.agentId}" not connected`,
+      );
+    }
+    if (this.tasks.has(task.task_id)) {
+      // task_id collision — a host bug (correlation ids must be unique). Refuse
+      // rather than clobber the existing record.
+      return synthHostFail(
+        task.task_id,
+        "cant_do",
+        `duplicate task_id ${task.task_id} already in flight`,
+      );
+    }
+
+    const scratchDir = this.makeScratchDir();
+    let scratchReal: string;
+    try {
+      scratchReal = realpathSync(scratchDir);
+    } catch {
+      scratchReal = resolvePath(scratchDir);
+    }
+
+    const runPromise = new Promise<BrainTaskRunResult>((resolve) => {
+      const record: TaskRecord = {
+        task,
+        hooks,
+        scratchReal,
+        scratchDir,
+        budget: new AttachmentBudget(),
+        logs: [],
+        resolve,
+        settled: false,
+        openGates: 0,
+      };
+      // Per-task timeout: fail the task (does NOT kill the shared process).
+      record.timeoutTimer = setTimeout(() => {
+        void this.failTask(record, "timeout");
+      }, this.taskTimeoutMs);
+      this.tasks.set(task.task_id, record);
+    });
+
+    // Send the task over the socket. The daemon receives persona via `hello`,
+    // so the per-task event carries no persona (strip it if a caller set one).
+    const taskEvent: TaskEvent = { ...task };
+    delete (taskEvent as { persona?: string }).persona;
+    try {
+      await conn.write(encodeBrainEvent(taskEvent) + "\n");
+    } catch (err) {
+      const record = this.tasks.get(task.task_id);
+      if (record) {
+        await this.failTask(
+          record,
+          "crashed",
+          `task write failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    return runPromise;
+  }
+
+  /**
+   * Hot-swap drain (§7.3/§7.5/§7.6). Send `shutdown` with the deadline; wait for
+   * in-flight tasks to finish up to `deadlineMs`. Past the deadline, every still-
+   * open task is CANCELLED — an open `ask_principal` gate gets a visible
+   * "brain was upgraded; re-trigger" notice and the task closes `failed/not_now`
+   * (no verdict is ever forwarded to a replaced generation). Then SIGTERM, +grace
+   * SIGKILL. Idempotent.
+   */
+  async drain(deadlineMs: number): Promise<void> {
+    if (this.stopped) return;
+    if (this.draining) return;
+    this.draining = true;
+
+    // Tell the brain to wind down. Best-effort — a dead socket just means the
+    // brain already gone.
+    const conn = this.connection;
+    if (conn !== null) {
+      try {
+        await conn.write(
+          encodeBrainEvent({
+            v: 1,
+            type: "shutdown",
+            deadline_ms: deadlineMs,
+          }) + "\n",
+        );
+      } catch (err) {
+        process.stderr.write(
+          `daemon-brain-host: shutdown write failed for "${this.agentId}" ` +
+            `(brain likely gone): ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+
+    // Wait for in-flight tasks up to the deadline.
+    const deadline = this.now() + deadlineMs;
+    while (this.tasks.size > 0 && this.now() < deadline) {
+      await sleep(Math.min(25, Math.max(0, deadline - this.now())));
+    }
+
+    // Past the deadline — CANCEL whatever is still open. Snapshot first (failTask
+    // mutates the map). Open gates get the upgrade notice via the post hook.
+    const stragglers = Array.from(this.tasks.values());
+    for (const record of stragglers) {
+      if (record.openGates > 0) {
+        await this.postUpgradeNotice(record);
+      }
+      await this.failTask(record, "drained");
+    }
+
+    // SIGTERM → SIGKILL escalation.
+    await this.terminateProcess();
+    await this.cleanupSocket();
+  }
+
+  /**
+   * Unconditional teardown — fail every in-flight task (`drained`), kill the
+   * process, drop the socket. Idempotent. Used by the consumer's `stop()` when
+   * not a graceful hot-swap (e.g. process shutdown).
+   */
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.draining = true;
+    if (this.healthyResetTimer !== undefined) {
+      clearTimeout(this.healthyResetTimer);
+      this.healthyResetTimer = undefined;
+    }
+    const stragglers = Array.from(this.tasks.values());
+    for (const record of stragglers) {
+      await this.failTask(record, "drained");
+    }
+    await this.terminateProcess();
+    await this.cleanupSocket();
+  }
+
+  // -------------------------------------------------------------------------
+  // Generation lifecycle
+  // -------------------------------------------------------------------------
+
+  private currentSocketPath: string | null = null;
+
+  /** Spawn a fresh brain generation, connect, hello, wire the data/close pumps. */
+  private async spawnGeneration(): Promise<void> {
+    const argv = buildArgv(this.run, this.packDir);
+    const socketPath = this.makeSocketPath(this.agentId);
+    this.currentSocketPath = socketPath;
+    // Minimal env (shared discipline with the per-task runner) PLUS the socket
+    // env naming where the brain connects back, and the daemon lifecycle marker.
+    const baseScratch = this.makeScratchDir();
+    const env = {
+      ...buildEnv(baseScratch, this.secrets),
+      CORTEX_BRAIN_SOCKET: socketPath,
+      CORTEX_BRAIN_LIFECYCLE: "daemon",
+    };
+    // The process-level scratch (env TMPDIR baseline) is removed on teardown; per
+    // TASK scratch dirs are separate (created in runTask, removed on task close).
+    this.processScratch = baseScratch;
+
+    // This generation's token — captured by the close/exit watchers so a stale
+    // disconnect (an old crashed process's exit landing after a restart) is
+    // ignored.
+    this.generation += 1;
+    const myGeneration = this.generation;
+
+    this.spawnAt = this.now();
+    this.decoder = new JsonlDecoder();
+    const proc = this.transport({ argv, env, cwd: baseScratch, socketPath });
+    this.proc = proc;
+
+    const connection = await proc.connection;
+    this.connection = connection;
+
+    connection.onData((chunk) => {
+      for (const line of this.decoder.push(chunk)) {
+        void this.routeLine(line);
+      }
+    });
+    connection.onClose(() => {
+      this.handleDisconnect(myGeneration);
+    });
+
+    // Watch the process exit too (covers a crash that doesn't emit a socket
+    // close first, e.g. SIGKILL). Both signals carry the SAME generation token,
+    // so whichever lands first handles the crash and the second is a no-op.
+    void proc.exited.then(() => {
+      this.handleDisconnect(myGeneration);
+    });
+
+    // Send the hello handshake (host → brain): host-authoritative identity +
+    // persona (daemon brains get persona once, here — §5).
+    try {
+      await connection.write(
+        encodeBrainEvent({
+          v: 1,
+          type: "hello",
+          agent: this.agentId,
+          persona: this.persona ?? "",
+          protocol: "cortex-brain/v1",
+        }) + "\n",
+      );
+    } catch (err) {
+      process.stderr.write(
+        `daemon-brain-host: hello write failed for "${this.agentId}": ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+
+    // Schedule the healthy-uptime reset: if THIS generation lives healthyResetMs
+    // without crashing, the restart counter resets (§7.4).
+    this.scheduleHealthyReset();
+  }
+
+  private processScratch: string | null = null;
+
+  /** Reset the restart counter after a healthy uptime window (§7.4). */
+  private scheduleHealthyReset(): void {
+    if (this.healthyResetTimer !== undefined) {
+      clearTimeout(this.healthyResetTimer);
+    }
+    this.healthyResetTimer = setTimeout(() => {
+      this.restartCount = 0;
+    }, this.healthyResetMs);
+    // Don't keep the event loop alive solely for the reset timer.
+    (this.healthyResetTimer as { unref?: () => void }).unref?.();
+  }
+
+  /**
+   * The brain disconnected / the process exited. If this was an intentional
+   * drain/stop, ignore. Otherwise it is a CRASH: fail every in-flight task
+   * (`crashed`), then restart-or-degrade per §7.4.
+   */
+  private handleDisconnect(forGeneration: number): void {
+    if (this.stopped || this.draining) return;
+    // Ignore a disconnect from a STALE generation — a restart has already
+    // advanced past it (the old process's exit landed after the new one
+    // spawned). Only the LIVE generation's disconnect is a real crash.
+    if (forGeneration !== this.generation) return;
+    // Guard re-entry (socket close + process exit can both fire for the same
+    // generation).
+    if (this.connection === null && this.proc === null) return;
+    this.connection = null;
+    const crashedProc = this.proc;
+    this.proc = null;
+
+    // Fail every in-flight task of the crashed generation.
+    const inFlight = Array.from(this.tasks.values());
+    for (const record of inFlight) {
+      void this.failTask(record, "crashed");
+    }
+
+    void crashedProc?.exited.catch(() => undefined);
+
+    // Restart-or-degrade.
+    if (this.restartCount < this.maxRestarts) {
+      this.restartCount += 1;
+      process.stderr.write(
+        `daemon-brain-host: brain "${this.agentId}" crashed — restarting ` +
+          `(${this.restartCount}/${this.maxRestarts})\n`,
+      );
+      void this.spawnGeneration().catch((err: unknown) => {
+        process.stderr.write(
+          `daemon-brain-host: restart spawn failed for "${this.agentId}": ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        // A failed restart spawn counts as another crash toward the budget. The
+        // failed spawn already advanced `this.generation`; treat it as that
+        // generation's disconnect so the budget advances (or degrades).
+        this.handleDisconnect(this.generation);
+      });
+    } else {
+      this.markDegraded();
+    }
+  }
+
+  /** Mark the agent degraded + surface it via the injected presence callback. */
+  private markDegraded(): void {
+    if (this.degraded) return;
+    this.degraded = true;
+    if (this.healthyResetTimer !== undefined) {
+      clearTimeout(this.healthyResetTimer);
+      this.healthyResetTimer = undefined;
+    }
+    process.stderr.write(
+      `daemon-brain-host: brain "${this.agentId}" DEGRADED — restart budget ` +
+        `(${this.maxRestarts}) exhausted\n`,
+    );
+    try {
+      this.onDegraded?.(this.agentId);
+    } catch (err) {
+      process.stderr.write(
+        `daemon-brain-host: onDegraded callback threw for "${this.agentId}": ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Effect routing (per multiplexed task)
+  // -------------------------------------------------------------------------
+
+  /** Route one decoded JSONL line (a brain effect) to its task. */
+  private async routeLine(line: string): Promise<void> {
+    const parsed = parseBrainEffect(line);
+    if (parsed.kind === "invalid") {
+      process.stderr.write(
+        `daemon-brain-host: dropped invalid effect from "${this.agentId}": ${parsed.detail}\n`,
+      );
+      return;
+    }
+    if (parsed.kind === "unknown") {
+      // Forward-compat (§5): unknown effect type — drop and log.
+      process.stderr.write(
+        `daemon-brain-host: dropped unknown effect type from "${this.agentId}": ${String(parsed.raw.type)}\n`,
+      );
+      return;
+    }
+    const e = parsed.effect;
+
+    // `log` is task-agnostic — no task_id correlation.
+    if (e.type === "log") {
+      // Route to whichever task's hooks if it correlates, else process stderr.
+      process.stderr.write(
+        `daemon-brain-host: [${e.level}] agent=${this.agentId}: ${e.text}\n`,
+      );
+      return;
+    }
+
+    const record = this.tasks.get(e.task_id);
+    // task_id correlation (§5): an effect for a task this host does not own (or
+    // already closed) is refused with effect_rejected (wont_do) and dropped.
+    if (record === undefined) {
+      await this.rejectEffect(e.task_id, e.type, "wont_do",
+        `unknown or closed task_id ${e.task_id} for agent ${this.agentId}`);
+      return;
+    }
+
+    switch (e.type) {
+      case "post": {
+        let confinedPath: string | undefined;
+        if (e.attachment?.path !== undefined) {
+          const confined = confineScratchPath(record.scratchReal, e.attachment.path);
+          if (!confined.ok) {
+            await this.rejectEffect(e.task_id, "post", "wont_do",
+              "attachment path outside scratch dir");
+            return;
+          }
+          confinedPath = confined.resolved;
+        }
+        if (e.attachment !== undefined) {
+          const charge = record.budget.charge(e.attachment, confinedPath);
+          if (!charge.ok) {
+            await this.rejectEffect(e.task_id, "post", "wont_do", charge.detail);
+            return;
+          }
+        }
+        await record.hooks.onPost(e);
+        return;
+      }
+      case "ask_principal": {
+        record.openGates += 1;
+        try {
+          const verdict = await record.hooks.onAskPrincipal(e);
+          // The task may have been drained/cancelled while the gate was open —
+          // never forward a verdict to a closed/replaced task (§7.5).
+          if (record.settled) return;
+          await this.sendToConn(
+            encodeBrainEvent({
+              v: 1,
+              type: "gate_verdict",
+              task_id: e.task_id,
+              gate: e.gate,
+              verdict: verdict.verdict,
+              principal: verdict.principal,
+              ...(verdict.notes !== undefined && { notes: verdict.notes }),
+            }) + "\n",
+          );
+        } finally {
+          record.openGates = Math.max(0, record.openGates - 1);
+        }
+        return;
+      }
+      case "dispatch": {
+        const outcome = await record.hooks.onDispatch(e);
+        if (outcome?.rejected) {
+          await this.sendToConn(
+            encodeBrainEvent({
+              v: 1,
+              type: "effect_rejected",
+              task_id: e.task_id,
+              effect: "dispatch",
+              reason: outcome.reason,
+            }) + "\n",
+          );
+        }
+        return;
+      }
+      case "result":
+        this.settleTask(record, e);
+        return;
+      default: {
+        const _never: never = e;
+        void _never;
+        return;
+      }
+    }
+  }
+
+  /** Resolve a task with the brain's terminal `result`; clean up its scratch. */
+  private settleTask(record: TaskRecord, result: ResultEffect): void {
+    if (record.settled) return;
+    record.settled = true;
+    if (record.timeoutTimer !== undefined) clearTimeout(record.timeoutTimer);
+    this.tasks.delete(record.task.task_id);
+    record.resolve({
+      result,
+      logs: record.logs,
+      stderrTail: "",
+      exitCode: null,
+    });
+    void this.cleanupTaskScratch(record);
+  }
+
+  /**
+   * Fail an in-flight task the host could not let the brain finish (crash /
+   * drain / timeout). Synthesizes a `result: failed` and resolves the run.
+   */
+  private async failTask(
+    record: TaskRecord,
+    kind: HostTaskFailKind,
+    extra?: string,
+  ): Promise<void> {
+    if (record.settled) return;
+    record.settled = true;
+    if (record.timeoutTimer !== undefined) clearTimeout(record.timeoutTimer);
+    this.tasks.delete(record.task.task_id);
+    const { reasonKind, detail } = hostFailReason(kind, this.agentId, extra);
+    record.resolve({
+      result: {
+        v: 1,
+        type: "result",
+        task_id: record.task.task_id,
+        status: "failed",
+        reason: { kind: reasonKind, detail },
+      },
+      logs: record.logs,
+      stderrTail: "",
+      exitCode: null,
+    });
+    await this.cleanupTaskScratch(record);
+  }
+
+  /**
+   * Post the "brain was upgraded; re-trigger the request" notice into a task's
+   * thread before cancelling an open gate (§7.5). Reuses the task's own `onPost`
+   * hook so it rides the normal `dispatch.task.post` path to the right surface.
+   */
+  private async postUpgradeNotice(record: TaskRecord): Promise<void> {
+    try {
+      await record.hooks.onPost({
+        v: 1,
+        type: "post",
+        task_id: record.task.task_id,
+        text:
+          "The brain was upgraded while this request was awaiting your approval. " +
+          "The pending request was cancelled — please re-trigger it.",
+      });
+    } catch (err) {
+      process.stderr.write(
+        `daemon-brain-host: upgrade-notice post failed for task ` +
+          `${record.task.task_id} (agent ${this.agentId}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  /** Send an `effect_rejected` for a refused effect. Best-effort. */
+  private async rejectEffect(
+    taskId: string,
+    effect: string,
+    kind: "cant_do" | "not_now" | "wont_do",
+    detail: string,
+  ): Promise<void> {
+    await this.sendToConn(
+      encodeBrainEvent({
+        v: 1,
+        type: "effect_rejected",
+        task_id: taskId,
+        effect,
+        reason: { kind, detail },
+      }) + "\n",
+    );
+  }
+
+  /** Write a line to the live connection, swallowing a closed-socket error. */
+  private async sendToConn(line: string): Promise<void> {
+    const conn = this.connection;
+    if (conn === null) return;
+    try {
+      await conn.write(line);
+    } catch (err) {
+      process.stderr.write(
+        `daemon-brain-host: write failed for "${this.agentId}" (socket likely closed): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Teardown helpers
+  // -------------------------------------------------------------------------
+
+  /** SIGTERM → +killGraceMs SIGKILL the current process. Best-effort. */
+  private async terminateProcess(): Promise<void> {
+    const proc = this.proc;
+    this.proc = null;
+    this.connection = null;
+    if (this.healthyResetTimer !== undefined) {
+      clearTimeout(this.healthyResetTimer);
+      this.healthyResetTimer = undefined;
+    }
+    if (proc === null) return;
+    try {
+      proc.kill("SIGTERM");
+    } catch (err) {
+      process.stderr.write(
+        `daemon-brain-host: SIGTERM failed for "${this.agentId}" (likely exited): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    const exitedOnOwn = await Promise.race([
+      proc.exited.then(() => true).catch(() => true),
+      sleep(this.killGraceMs).then(() => false),
+    ]);
+    if (!exitedOnOwn) {
+      try {
+        proc.kill("SIGKILL");
+      } catch (err) {
+        process.stderr.write(
+          `daemon-brain-host: SIGKILL failed for "${this.agentId}" (likely exited): ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+  }
+
+  /** Remove the process-level scratch dir + the socket file. Best-effort. */
+  private async cleanupSocket(): Promise<void> {
+    if (this.processScratch !== null) {
+      await cleanupDir(this.processScratch);
+      this.processScratch = null;
+    }
+    if (this.currentSocketPath !== null) {
+      await cleanupDir(this.currentSocketPath);
+      this.currentSocketPath = null;
+    }
+  }
+
+  /** Remove one task's scratch dir. Best-effort. */
+  private async cleanupTaskScratch(record: TaskRecord): Promise<void> {
+    await cleanupDir(record.scratchDir);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Map a host-side task failure to a brain reason kind + detail. */
+function hostFailReason(
+  kind: HostTaskFailKind,
+  agentId: string,
+  extra?: string,
+): { reasonKind: "cant_do" | "not_now"; detail: string } {
+  switch (kind) {
+    case "crashed":
+      return {
+        reasonKind: "cant_do",
+        detail: `brain crashed${extra ? `: ${extra}` : ""}`,
+      };
+    case "timeout":
+      return {
+        reasonKind: "cant_do",
+        detail: `brain task timed out (agent ${agentId})`,
+      };
+    case "drained":
+      return {
+        reasonKind: "not_now",
+        detail: `brain was upgraded (hot-swap) — re-trigger the request`,
+      };
+  }
+}
+
+/** Synthesize a terminal `failed` result for a fast-fail in `runTask`. */
+function synthHostFail(
+  taskId: string,
+  kind: "cant_do" | "not_now",
+  detail: string,
+): BrainTaskRunResult {
+  return {
+    result: {
+      v: 1,
+      type: "result",
+      task_id: taskId,
+      status: "failed",
+      reason: { kind, detail },
+    },
+    logs: [],
+    stderrTail: "",
+    exitCode: null,
+  };
+}
+
+/** Best-effort recursive removal of a dir or file. Never throws. */
+async function cleanupDir(path: string): Promise<void> {
+  try {
+    await rm(path, { recursive: true, force: true });
+  } catch (err) {
+    process.stderr.write(
+      `daemon-brain-host: cleanup of "${path}" failed: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+/** Promise-based sleep. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Default Bun Unix-socket transport
+// ---------------------------------------------------------------------------
+
+/**
+ * Production transport: bind a Unix domain socket, spawn the brain (with
+ * `CORTEX_BRAIN_SOCKET` already in `env`), resolve `connection` when the brain
+ * connects. Logs ride stdio (§12.1); the protocol rides the socket.
+ *
+ * Wrapped in a factory so the host's default is a stable reference; tests pass
+ * their own `transport`.
+ */
+export const makeBunUnixTransport: DaemonTransport = (opts) => {
+  let resolveConn!: (c: DaemonBrainConnection) => void;
+  let rejectConn!: (e: unknown) => void;
+  const connection = new Promise<DaemonBrainConnection>((res, rej) => {
+    resolveConn = res;
+    rejectConn = rej;
+  });
+
+  let dataHandler: ((chunk: Uint8Array | string) => void) | null = null;
+  let closeHandler: (() => void) | null = null;
+  // The bound socket the brain connects on. Bun's socket data callback is
+  // (socket, data); we expose a write/onData/onClose facade.
+  type BunServerSocket = { write(data: string | Uint8Array): number; end(): void };
+  let liveSocket: BunServerSocket | null = null;
+
+  // `Bun.listen` with a `unix` path. The brain process connects via
+  // `Bun.connect({ unix })`. Typed loosely because the Bun socket types vary
+  // across versions; the host only needs write/onData/onClose.
+  const bun = globalThis.Bun as unknown as {
+    listen: (cfg: unknown) => { stop: (closeActive?: boolean) => void };
+    spawn: (argv: string[], cfg: unknown) => {
+      exited: Promise<number>;
+      kill: (signal?: NodeJS.Signals | number) => void;
+    };
+  };
+
+  const server = bun.listen({
+    unix: opts.socketPath,
+    socket: {
+      open(socket: BunServerSocket) {
+        liveSocket = socket;
+        resolveConn({
+          write(chunk) {
+            socket.write(chunk);
+          },
+          onData(handler) {
+            dataHandler = handler;
+          },
+          onClose(handler) {
+            closeHandler = handler;
+          },
+        });
+      },
+      data(_socket: BunServerSocket, data: Uint8Array) {
+        dataHandler?.(data);
+      },
+      close() {
+        liveSocket = null;
+        closeHandler?.();
+      },
+      error(_socket: BunServerSocket, err: unknown) {
+        process.stderr.write(
+          `daemon-brain-host(transport): socket error: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      },
+    },
+  });
+
+  const proc = bun.spawn(opts.argv, {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+    env: opts.env,
+    cwd: opts.cwd,
+  });
+
+  // If the process exits before connecting, reject the connection promise so
+  // `start()` surfaces the spawn failure.
+  void proc.exited.then((code) => {
+    if (liveSocket === null) {
+      rejectConn(
+        new Error(`brain process exited (code ${code}) before connecting on socket`),
+      );
+    }
+  });
+
+  return {
+    connection,
+    exited: proc.exited.then((c) => c).catch(() => null),
+    kill(signal) {
+      try {
+        proc.kill(signal);
+      } finally {
+        try {
+          server.stop(true);
+        } catch (err) {
+          process.stderr.write(
+            `daemon-brain-host(transport): server.stop failed: ${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
+      }
+    },
+  };
+};

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -727,9 +727,15 @@ export class DaemonBrainHost {
       // guard — the budget advances on every failed spawn. The `.catch` is a
       // safety net for an UNEXPECTED throw (e.g. argv/env build) so the budget
       // still advances rather than the failure floating unhandled.
-      const gen = this.generation;
+      // Sage cortex#1035 round 3: capture the generation AFTER spawnGeneration
+      // increments it, not before — a throw after the increment would
+      // otherwise carry a stale generation and be discarded by
+      // handleSpawnFailure's staleness guard, never counting toward the
+      // budget. spawnGeneration is async; by the time .catch runs the
+      // increment has happened, so read the live value at catch time and
+      // attribute the failure to it.
       void this.spawnGeneration(/* isRestart */ true).catch((err: unknown) => {
-        this.handleSpawnFailure(gen, err);
+        this.handleSpawnFailure(this.generation, err);
       });
     } else {
       this.markDegraded();

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -58,6 +58,7 @@
 
 import { timingSafeEqual } from "crypto";
 import { chmodSync, mkdtempSync, realpathSync } from "fs";
+import { realpath } from "fs/promises";
 import { rm } from "fs/promises";
 import { tmpdir } from "os";
 import { basename, dirname, join, resolve as resolvePath } from "path";
@@ -354,11 +355,16 @@ export class DaemonBrainHost {
       );
     }
 
+    // Async scratch setup (sage cortex#1035 round 2): per-task filesystem work
+    // must not stall the event loop the multiplexed socket shares with every
+    // other in-flight task.
     const scratchDir = this.makeScratchDir();
     let scratchReal: string;
     try {
-      scratchReal = realpathSync(scratchDir);
-    } catch {
+      scratchReal = await realpath(scratchDir);
+    } catch (_err) {
+      // Path not resolvable (yet) — fall back to a normalized absolute path;
+      // confinement still prefix-checks against this base.
       scratchReal = resolvePath(scratchDir);
     }
 
@@ -640,7 +646,9 @@ export class DaemonBrainHost {
       void this.failTask(record, "crashed");
     }
 
-    void crashedProc?.exited.catch(() => undefined);
+    // Crash path: usually already dead, but a socket-close without process
+    // exit (e.g. brain closed its socket and hung) must not leak the process.
+    this.reapFailedProc(crashedProc);
 
     this.restartOrDegrade();
   }
@@ -667,12 +675,38 @@ export class DaemonBrainHost {
     this.connection = null;
     const failedProc = this.proc;
     this.proc = null;
-    void failedProc?.exited.catch(() => undefined);
+    this.reapFailedProc(failedProc);
     process.stderr.write(
       `daemon-brain-host: restart spawn failed to connect for "${this.agentId}": ` +
         `${err instanceof Error ? err.message : String(err)}\n`,
     );
     this.restartOrDegrade();
+  }
+
+
+  /**
+   * Reap a process whose generation FAILED (connect failure / auth timeout) or
+   * crashed: SIGTERM immediately, SIGKILL after killGraceMs if it lingers
+   * (sage cortex#1035 round 2 — a failed spawn must never be left running
+   * while the next generation starts).
+   */
+  private reapFailedProc(proc: DaemonBrainProcess | null): void {
+    if (proc === null) return;
+    try {
+      proc.kill("SIGTERM");
+    } catch (_err) {
+      // already exited — nothing to reap
+    }
+    const killTimer = setTimeout(() => {
+      try {
+        proc.kill("SIGKILL");
+      } catch (_err) {
+        // already exited
+      }
+    }, this.killGraceMs);
+    void proc.exited
+      .catch(() => undefined)
+      .finally(() => clearTimeout(killTimer));
   }
 
   /**
@@ -1173,6 +1207,7 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
   });
 
   let dataHandler: ((chunk: Uint8Array | string) => void) | null = null;
+    const pendingPostAuth: Uint8Array[] = [];
   let closeHandler: (() => void) | null = null;
   // The bound socket the brain connects on. Bun's socket data callback is
   // (socket, data); we expose a write/onData/onClose facade.
@@ -1278,13 +1313,26 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
           },
           onData(handler) {
             dataHandler = handler;
+            // Flush bytes that arrived in the SAME chunk as the auth line
+            // (sage cortex#1035 round 2): the host registers onData only
+            // after the connection resolves; without buffering, protocol
+            // bytes replayed before registration are silently dropped.
+            if (pendingPostAuth.length > 0) {
+              const flush = pendingPostAuth.splice(0, pendingPostAuth.length);
+              for (const chunk of flush) handler(chunk);
+            }
           },
           onClose(handler) {
             closeHandler = handler;
           },
         });
         if (rest.length > 0) {
-          dataHandler?.(rest);
+          const restBytes = new TextEncoder().encode(rest);
+          if (dataHandler !== null) {
+            dataHandler(restBytes);
+          } else {
+            pendingPostAuth.push(restBytes);
+          }
         }
       },
       close() {

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -11,9 +11,13 @@
  *
  *   1. spawns the brain with a MINIMAL env (PATH/HOME/LANG/TMPDIR + the
  *      manifest secrets, same discipline as `exec-brain-runner`) plus the
- *      `CORTEX_BRAIN_SOCKET` env naming the socket to connect back on, and
- *      `lifecycle: daemon`-marking `CORTEX_BRAIN_LIFECYCLE=daemon`;
- *   2. waits for the brain to connect, then sends the `hello` handshake
+ *      `CORTEX_BRAIN_SOCKET` env naming the socket to connect back on, a
+ *      per-spawn `CORTEX_BRAIN_SOCKET_TOKEN` the brain MUST echo as its first
+ *      socket line to authenticate (`{ v:1, type:"auth", token }` — see
+ *      {@link DaemonTransport}), and the `lifecycle: daemon`-marking
+ *      `CORTEX_BRAIN_LIFECYCLE=daemon`;
+ *   2. waits for the brain to connect + AUTHENTICATE, then sends the `hello`
+ *      handshake
  *      (host → brain: agent id, persona, protocol version — §5 "Persona
  *      delivery"; identity is HOST-AUTHORITATIVE);
  *   3. accepts `runTask(task, hooks)` calls — writes the `task` event, routes
@@ -52,10 +56,11 @@
  * exercised without a real socket or subprocess.
  */
 
-import { mkdtempSync, realpathSync } from "fs";
+import { timingSafeEqual } from "crypto";
+import { chmodSync, mkdtempSync, realpathSync } from "fs";
 import { rm } from "fs/promises";
 import { tmpdir } from "os";
-import { join, resolve as resolvePath } from "path";
+import { basename, dirname, join, resolve as resolvePath } from "path";
 import {
   encodeBrainEvent,
   parseBrainEffect,
@@ -111,13 +116,39 @@ export interface DaemonBrainProcess {
  * it must: bind/listen on the socket, spawn the process (with the socket env
  * already injected by the host into `env`), and resolve `connection` when the
  * brain connects. Tests inject a fake that wires an in-memory pipe.
+ *
+ * ## Connection authentication (`socketToken`)
+ *
+ * A Unix socket under `tmpdir()` is reachable by any local process; the first
+ * connector wins. Without a proof, a local process racing the real brain could
+ * connect first and impersonate it (emit posts / dispatches / gate requests).
+ * So the host mints a per-spawn `socketToken`, injects it into the brain's env
+ * (`CORTEX_BRAIN_SOCKET_TOKEN`), and the transport REQUIRES the brain's FIRST
+ * line on the socket to be a matching auth proof
+ * (`{ "v": 1, "type": "auth", "token": "…" }`) BEFORE it resolves `connection`.
+ * This auth line is consumed by the TRANSPORT layer (raw bytes), NOT the
+ * protocol codec — it is pre-protocol, so `protocol.ts` is untouched and the
+ * tolerant ingest never sees it. Mismatch / malformed / no line within
+ * {@link SOCKET_AUTH_TIMEOUT_MS} → the socket is closed and `connection`
+ * rejects; the host treats that as a failed spawn (counts against the restart
+ * budget). A second connector arriving while one is already live is closed
+ * immediately (single-connection socket).
  */
 export type DaemonTransport = (opts: {
   argv: string[];
   env: Record<string, string>;
   cwd: string;
   socketPath: string;
+  /**
+   * Per-spawn auth token. The transport must require the brain's first socket
+   * line to be `{ v: 1, type: "auth", token }` matching this value before
+   * resolving `connection`. Always set by the host.
+   */
+  socketToken: string;
 }) => DaemonBrainProcess;
+
+/** How long the transport waits for the brain's auth line before rejecting. */
+export const SOCKET_AUTH_TIMEOUT_MS = 2_000;
 
 // ---------------------------------------------------------------------------
 // Options
@@ -258,13 +289,7 @@ export class DaemonBrainHost {
     this.makeScratchDir =
       opts.makeScratchDir ??
       (() => mkdtempSync(join(tmpdir(), "cortex-brain-daemon-")));
-    this.makeSocketPath =
-      opts.makeSocketPath ??
-      ((id) =>
-        join(
-          tmpdir(),
-          `cortex-brain-${id}-${process.pid}-${crypto.randomUUID().slice(0, 8)}.sock`,
-        ));
+    this.makeSocketPath = opts.makeSocketPath ?? defaultMakeSocketPath;
     this.onDegraded = opts.onDegraded;
     this.now = opts.now ?? (() => Date.now());
   }
@@ -284,7 +309,7 @@ export class DaemonBrainHost {
       throw new Error(`daemon-brain-host: already started for "${this.agentId}"`);
     }
     this.started = true;
-    await this.spawnGeneration();
+    await this.spawnGeneration(/* isRestart */ false);
   }
 
   /**
@@ -457,17 +482,35 @@ export class DaemonBrainHost {
 
   private currentSocketPath: string | null = null;
 
-  /** Spawn a fresh brain generation, connect, hello, wire the data/close pumps. */
-  private async spawnGeneration(): Promise<void> {
+  /**
+   * Spawn a fresh brain generation, connect, hello, wire the data/close pumps.
+   *
+   * `isRestart` distinguishes the two failure modes of a connect failure:
+   *   - initial `start()` (`isRestart=false`): re-throw so the boot path logs
+   *     and skips (the manifest/transport-fault contract); no live proc is left.
+   *   - supervised restart (`isRestart=true`): a connect failure is a failed
+   *     spawn — it must count against the restart budget (degrade if exhausted),
+   *     NOT throw into the floating `.catch` and recurse. {@link handleSpawnFailure}
+   *     owns that.
+   */
+  private async spawnGeneration(isRestart: boolean): Promise<void> {
     const argv = buildArgv(this.run, this.packDir);
     const socketPath = this.makeSocketPath(this.agentId);
     this.currentSocketPath = socketPath;
+    // Per-spawn socket auth token: a local process racing the brain to the
+    // tmpdir socket cannot impersonate it without this secret. The transport
+    // requires the brain's first line to prove it before accepting effects
+    // (see `DaemonTransport`). Fresh per generation — a restart re-mints it so
+    // a leaked token from a crashed generation is useless.
+    const socketToken = crypto.randomUUID();
     // Minimal env (shared discipline with the per-task runner) PLUS the socket
-    // env naming where the brain connects back, and the daemon lifecycle marker.
+    // env naming where the brain connects back, the per-spawn auth token, and
+    // the daemon lifecycle marker.
     const baseScratch = this.makeScratchDir();
     const env = {
       ...buildEnv(baseScratch, this.secrets),
       CORTEX_BRAIN_SOCKET: socketPath,
+      CORTEX_BRAIN_SOCKET_TOKEN: socketToken,
       CORTEX_BRAIN_LIFECYCLE: "daemon",
     };
     // The process-level scratch (env TMPDIR baseline) is removed on teardown; per
@@ -482,10 +525,41 @@ export class DaemonBrainHost {
 
     this.spawnAt = this.now();
     this.decoder = new JsonlDecoder();
-    const proc = this.transport({ argv, env, cwd: baseScratch, socketPath });
+    const proc = this.transport({ argv, env, cwd: baseScratch, socketPath, socketToken });
     this.proc = proc;
 
-    const connection = await proc.connection;
+    // Await the AUTHENTICATED connection. The transport rejects this promise on
+    // a wrong/missing auth proof or connect failure; a rejection here is a
+    // failed spawn — clear the live process/connection and count it against the
+    // restart budget (degrade if exhausted) rather than installing a stale proc
+    // or recursing. See finding 2 (failed-restart-does-not-degrade).
+    let connection: DaemonBrainConnection;
+    try {
+      connection = await proc.connection;
+    } catch (err) {
+      if (!isRestart) {
+        // Initial start() — clear the stale proc and re-throw so the boot path
+        // logs + skips (the documented manifest/transport-fault contract).
+        if (this.generation === myGeneration) {
+          this.proc = null;
+          this.connection = null;
+        }
+        throw err;
+      }
+      // Supervised restart — route through the budget (degrade if exhausted).
+      this.handleSpawnFailure(myGeneration, err);
+      return;
+    }
+    // A drain/stop (or a newer generation) may have superseded this spawn while
+    // we awaited the connection — don't install a connection nobody owns.
+    if (this.stopped || this.draining || myGeneration !== this.generation) {
+      try {
+        void connection;
+      } finally {
+        proc.kill("SIGKILL");
+      }
+      return;
+    }
     this.connection = connection;
 
     connection.onData((chunk) => {
@@ -568,22 +642,60 @@ export class DaemonBrainHost {
 
     void crashedProc?.exited.catch(() => undefined);
 
-    // Restart-or-degrade.
+    this.restartOrDegrade();
+  }
+
+  /**
+   * A supervised restart spawn FAILED to connect (wrong/missing auth, transport
+   * fault, or the process exited before connecting). Distinct from
+   * {@link handleDisconnect}: there is no live proc/connection to tear down — the
+   * connect never completed — so we must NOT re-enter the disconnect path (which
+   * would no-op on the `proc === null` re-entry guard and silently swallow the
+   * failure, leaving the budget unmoved). Clear any partial state for this
+   * generation and count the failed spawn directly against the budget.
+   */
+  private handleSpawnFailure(forGeneration: number, err: unknown): void {
+    if (this.stopped || this.draining) return;
+    if (forGeneration !== this.generation) return;
+    // Re-entry guard: if both are already cleared, this generation's failure was
+    // handled (the internal connect-failure path and the `.catch` safety net can
+    // both fire for the same generation). Don't double-count the budget.
+    if (this.connection === null && this.proc === null) return;
+    // The connect never resolved: no connection installed, and `this.proc` was
+    // set to the failed proc in spawnGeneration. Clear both so no stale process
+    // is left installed.
+    this.connection = null;
+    const failedProc = this.proc;
+    this.proc = null;
+    void failedProc?.exited.catch(() => undefined);
+    process.stderr.write(
+      `daemon-brain-host: restart spawn failed to connect for "${this.agentId}": ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    this.restartOrDegrade();
+  }
+
+  /**
+   * Restart the brain if the budget allows, else mark degraded (§7.4). Shared by
+   * the live-disconnect path ({@link handleDisconnect}) and the failed-connect
+   * path ({@link handleSpawnFailure}) so every kind of failed generation — crash
+   * OR failed restart spawn — advances the SAME budget toward degradation.
+   */
+  private restartOrDegrade(): void {
     if (this.restartCount < this.maxRestarts) {
       this.restartCount += 1;
       process.stderr.write(
         `daemon-brain-host: brain "${this.agentId}" crashed — restarting ` +
           `(${this.restartCount}/${this.maxRestarts})\n`,
       );
-      void this.spawnGeneration().catch((err: unknown) => {
-        process.stderr.write(
-          `daemon-brain-host: restart spawn failed for "${this.agentId}": ` +
-            `${err instanceof Error ? err.message : String(err)}\n`,
-        );
-        // A failed restart spawn counts as another crash toward the budget. The
-        // failed spawn already advanced `this.generation`; treat it as that
-        // generation's disconnect so the budget advances (or degrades).
-        this.handleDisconnect(this.generation);
+      // A failed restart CONNECT routes through handleSpawnFailure internally
+      // (NOT a throw), so there is no recursion through the disconnect re-entry
+      // guard — the budget advances on every failed spawn. The `.catch` is a
+      // safety net for an UNEXPECTED throw (e.g. argv/env build) so the budget
+      // still advances rather than the failure floating unhandled.
+      const gen = this.generation;
+      void this.spawnGeneration(/* isRestart */ true).catch((err: unknown) => {
+        this.handleSpawnFailure(gen, err);
       });
     } else {
       this.markDegraded();
@@ -861,14 +973,26 @@ export class DaemonBrainHost {
     }
   }
 
-  /** Remove the process-level scratch dir + the socket file. Best-effort. */
+  /**
+   * Remove the process-level scratch dir + the socket file (and the per-spawn
+   * restricted dir the default factory created to hold it). Best-effort.
+   */
   private async cleanupSocket(): Promise<void> {
     if (this.processScratch !== null) {
       await cleanupDir(this.processScratch);
       this.processScratch = null;
     }
     if (this.currentSocketPath !== null) {
-      await cleanupDir(this.currentSocketPath);
+      const sockPath = this.currentSocketPath;
+      await cleanupDir(sockPath);
+      // The default factory nests the socket in a per-spawn 0700 dir
+      // (`…/cortex-brain-sock-XXXX/{agent}.sock`); remove that dir too so we do
+      // not leak an empty restricted dir per spawn. Guarded to our own naming
+      // so an injected `makeSocketPath` (e.g. a bare path) is never over-swept.
+      const parent = dirname(sockPath);
+      if (basename(parent).startsWith("cortex-brain-sock-")) {
+        await cleanupDir(parent);
+      }
       this.currentSocketPath = null;
     }
   }
@@ -945,14 +1069,97 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Default socket-path factory. Puts the socket inside a per-spawn directory
+ * created mode-0700 (owner-only) under the OS temp dir, so the socket file is
+ * not even traversable by other local users — a second, file-permission layer
+ * under the per-spawn auth token. Belt-and-braces: the token authenticates the
+ * connector; the 0700 dir narrows who can reach the socket at all. Falls back
+ * to a bare tmpdir path if the restricted-dir create fails (the auth token
+ * still protects the seam).
+ */
+function defaultMakeSocketPath(agentId: string): string {
+  const unique = `${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
+  try {
+    const dir = mkdtempSync(join(tmpdir(), `cortex-brain-sock-`));
+    // mkdtempSync creates 0700 on POSIX already, but set it explicitly so the
+    // guarantee does not depend on the platform umask.
+    try {
+      chmodSync(dir, 0o700);
+    } catch (err) {
+      process.stderr.write(
+        `daemon-brain-host: chmod 0700 on socket dir "${dir}" failed ` +
+          `(continuing; auth token still protects the seam): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    return join(dir, `${agentId}.sock`);
+  } catch (err) {
+    process.stderr.write(
+      `daemon-brain-host: restricted socket-dir create failed ` +
+        `(falling back to bare tmpdir; auth token still protects the seam): ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return join(tmpdir(), `cortex-brain-${agentId}-${unique}.sock`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Default Bun Unix-socket transport
 // ---------------------------------------------------------------------------
 
 /**
+ * Verify a raw pre-protocol auth line against the expected token. The line is
+ * `{ "v": 1, "type": "auth", "token": "…" }`. Tolerant of unknown extra fields
+ * (forward-compat), strict on the token match. Returns true only on an exact,
+ * constant-time-ish token match. Never throws.
+ */
+function verifyAuthLine(line: string, expected: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    // Malformed first line — not a valid auth proof.
+    return false;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return false;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.type !== "auth" || typeof obj.token !== "string") return false;
+  return timingSafeEqualStr(obj.token, expected);
+}
+
+/**
+ * Constant-time-ish token equality. Compares the UTF-8 bytes via
+ * `crypto.timingSafeEqual` when lengths match; a length mismatch is an
+ * immediate false — the token is a fixed-length UUID, so length is not a
+ * secret. Avoids leaking match progress through early-return timing on the
+ * byte comparison itself. Never throws.
+ */
+function timingSafeEqualStr(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  try {
+    return timingSafeEqual(ab, bb);
+  } catch {
+    // timingSafeEqual only throws on length mismatch (already guarded); any
+    // other failure is treated as a non-match — fail closed.
+    return false;
+  }
+}
+
+/**
  * Production transport: bind a Unix domain socket, spawn the brain (with
- * `CORTEX_BRAIN_SOCKET` already in `env`), resolve `connection` when the brain
- * connects. Logs ride stdio (§12.1); the protocol rides the socket.
+ * `CORTEX_BRAIN_SOCKET` + `CORTEX_BRAIN_SOCKET_TOKEN` already in `env`), and
+ * resolve `connection` ONLY after the brain proves the per-spawn token on its
+ * first line. Logs ride stdio (§12.1); the protocol rides the socket.
+ *
+ * The auth line is consumed HERE, in the transport — before any protocol byte
+ * reaches the host's codec. The host's `onData` pump (the protocol decoder) is
+ * only wired AFTER `connection` resolves, so an unauthenticated connector never
+ * gets an effect routed.
  *
  * Wrapped in a factory so the host's default is a stable reference; tests pass
  * their own `transport`.
@@ -971,6 +1178,14 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
   // (socket, data); we expose a write/onData/onClose facade.
   type BunServerSocket = { write(data: string | Uint8Array): number; end(): void };
   let liveSocket: BunServerSocket | null = null;
+  // Auth state: until the first line proves the token, the connection is NOT
+  // resolved and inbound bytes are buffered by the auth pre-reader, never the
+  // protocol pump.
+  let authed = false;
+  let authClosed = false;
+  let authBuffer = "";
+  const authDecoder = new TextDecoder("utf-8");
+  let authTimer: ReturnType<typeof setTimeout> | undefined;
 
   // `Bun.listen` with a `unix` path. The brain process connects via
   // `Bun.connect({ unix })`. Typed loosely because the Bun socket types vary
@@ -983,14 +1198,83 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
     };
   };
 
+  /** Reject + tear down on a failed/timed-out auth. Idempotent. */
+  const failAuth = (reason: string): void => {
+    if (authClosed) return;
+    authClosed = true;
+    if (authTimer !== undefined) clearTimeout(authTimer);
+    process.stderr.write(
+      `daemon-brain-host(transport): rejecting unauthenticated connector on ` +
+        `${opts.socketPath}: ${reason}\n`,
+    );
+    try {
+      liveSocket?.end();
+    } catch {
+      // Socket already gone — nothing to close.
+    }
+    rejectConn(new Error(`brain socket auth failed: ${reason}`));
+  };
+
   const server = bun.listen({
     unix: opts.socketPath,
     socket: {
       open(socket: BunServerSocket) {
+        // SINGLE-CONNECTION socket: the first connector owns the auth attempt.
+        // A second connector arriving while one is live (authed OR mid-auth) is
+        // closed immediately — it cannot race in as the brain.
+        if (liveSocket !== null) {
+          process.stderr.write(
+            `daemon-brain-host(transport): rejecting second connector on ` +
+              `${opts.socketPath} (one already connected)\n`,
+          );
+          try {
+            socket.end();
+          } catch {
+            // Already closing.
+          }
+          return;
+        }
         liveSocket = socket;
+        // Start the auth deadline: no valid proof within the window → reject.
+        authTimer = setTimeout(
+          () => failAuth(`no auth line within ${SOCKET_AUTH_TIMEOUT_MS}ms`),
+          SOCKET_AUTH_TIMEOUT_MS,
+        );
+        (authTimer as { unref?: () => void }).unref?.();
+      },
+      data(_socket: BunServerSocket, data: Uint8Array) {
+        if (authed) {
+          // Post-auth: ordinary protocol bytes go to the host's decoder pump.
+          dataHandler?.(data);
+          return;
+        }
+        if (authClosed) return;
+        // Pre-auth: buffer until the first newline, then verify the auth proof.
+        authBuffer += authDecoder.decode(data, { stream: true });
+        const nl = authBuffer.indexOf("\n");
+        if (nl === -1) {
+          // Bound the pre-auth buffer so a connector cannot stream unbounded
+          // bytes without ever sending a newline.
+          if (authBuffer.length > 64 * 1024) {
+            failAuth("auth line exceeded 64 KiB without a newline");
+          }
+          return;
+        }
+        const rawLine = authBuffer.slice(0, nl);
+        const rest = authBuffer.slice(nl + 1);
+        const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+        if (!verifyAuthLine(line, opts.socketToken)) {
+          failAuth("auth token mismatch or malformed auth line");
+          return;
+        }
+        // Authenticated. Stop the deadline, resolve the connection, and replay
+        // any bytes that arrived AFTER the auth line into the protocol pump.
+        authed = true;
+        if (authTimer !== undefined) clearTimeout(authTimer);
+        const sock = liveSocket;
         resolveConn({
           write(chunk) {
-            socket.write(chunk);
+            sock?.write(chunk);
           },
           onData(handler) {
             dataHandler = handler;
@@ -999,12 +1283,17 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
             closeHandler = handler;
           },
         });
-      },
-      data(_socket: BunServerSocket, data: Uint8Array) {
-        dataHandler?.(data);
+        if (rest.length > 0) {
+          dataHandler?.(rest);
+        }
       },
       close() {
         liveSocket = null;
+        if (!authed) {
+          // Closed before authenticating — surface as a failed connect.
+          failAuth("connector closed before authenticating");
+          return;
+        }
         closeHandler?.();
       },
       error(_socket: BunServerSocket, err: unknown) {

--- a/src/brain/exec-brain-runner.ts
+++ b/src/brain/exec-brain-runner.ts
@@ -67,6 +67,7 @@ import {
   type GateVerdictValue,
   type BrainReason,
 } from "./protocol";
+import { AttachmentBudget } from "./attachment-budget";
 
 /**
  * Max stderr we retain in memory. A chatty brain must not grow the runner's
@@ -269,6 +270,12 @@ export function makeExecBrainRunner(
     // a result, and is returned to the caller. A chatty brain cannot grow this
     // past STDERR_TAIL_CAP — see {@link StderrRing}.
     const stderrRing = new StderrRing(STDERR_TAIL_CAP);
+
+    // Per-task attachment budget (§12.5) — 4 MiB cumulative inline + scratch
+    // bytes across every `post` this task emits. Over budget → effect_rejected
+    // (wont_do) and the post is DROPPED. One budget per spawned task (per-task
+    // lifecycle = one task per process).
+    const attachmentBudget = new AttachmentBudget();
 
     // Resolve the scratch dir's REAL path once (mkdtemp may hand back a path
     // through a symlinked temp root, e.g. /var → /private/var on macOS). All
@@ -506,6 +513,7 @@ export function makeExecBrainRunner(
           // and the post is DROPPED — the host owns the filesystem boundary,
           // not the brain. Symlink-escape detection is out of scope for v1; we
           // normalize and prefix-check.
+          let confinedPath: string | undefined;
           if (e.attachment?.path !== undefined) {
             const confined = confineScratchPath(
               scratchReal,
@@ -516,6 +524,20 @@ export function makeExecBrainRunner(
                 "post",
                 "attachment path outside scratch dir",
               );
+              return;
+            }
+            confinedPath = confined.resolved;
+          }
+          // Per-task attachment budget (§12.5): charge the attachment's bytes
+          // (decoded inline b64 OR confined scratch-file size) against the 4 MiB
+          // task ceiling. Over budget → effect_rejected (wont_do, PERMANENT for
+          // this task) and the post is DROPPED — the brain must summarise/link.
+          // A budget charge runs AFTER confinement so we only stat in-bounds
+          // files. A text-only post (no attachment) never touches the budget.
+          if (e.attachment !== undefined) {
+            const charge = attachmentBudget.charge(e.attachment, confinedPath);
+            if (!charge.ok) {
+              await rejectEffect("post", charge.detail);
               return;
             }
           }

--- a/src/bus/__tests__/brain-consumer.test.ts
+++ b/src/bus/__tests__/brain-consumer.test.ts
@@ -148,13 +148,20 @@ function completeResult(taskId: string, summary?: string): ResultEffect {
 }
 
 function baseOpts(over: Partial<BrainConsumerOpts> = {}): BrainConsumerOpts {
-  return {
+  const { runBrainTask, daemonHost, ...rest } = over;
+  const base = {
     agent: buildAgent(),
     source: SOURCE,
     runtime: over.runtime ?? createRecordingRuntime(),
-    runBrainTask: over.runBrainTask ?? stubRunner(completeResult("x")),
-    ...over,
+    ...rest,
   };
+  // The opts type is a discriminated union: a daemon agent passes `daemonHost`
+  // (no per-task runner), a per-task agent passes `runBrainTask`. Build the
+  // correct variant so neither field leaks onto the other path.
+  if (daemonHost !== undefined) {
+    return { ...base, daemonHost };
+  }
+  return { ...base, runBrainTask: runBrainTask ?? stubRunner(completeResult("x")) };
 }
 
 function published(runtime: RecordingRuntime, type: string): Envelope[] {
@@ -800,53 +807,15 @@ process.exit(0);
 // is needed — the consumer↔host↔(fake brain) round-trip is fully driven.
 
 import { DaemonBrainHost } from "../../brain/daemon-brain-host";
-import type {
-  DaemonTransport,
-  DaemonBrainConnection,
-} from "../../brain/daemon-brain-host";
-import { parseBrainEvent, type BrainEvent } from "../../brain/protocol";
+import {
+  FakeDaemonBrain,
+  singleFakeDaemonTransport,
+} from "../../brain/__tests__/fake-daemon-brain";
 
-class DaemonFakeBrain {
-  private dataHandler: ((c: string) => void) | null = null;
-  private closeHandler: (() => void) | null = null;
-  readonly received: BrainEvent[] = [];
-  private exitResolve!: (code: number | null) => void;
-  readonly exited: Promise<number | null>;
-  readonly connection: DaemonBrainConnection;
-  constructor() {
-    this.exited = new Promise((res) => { this.exitResolve = res; });
-    this.connection = {
-      write: (chunk: string) => {
-        for (const line of chunk.split("\n")) {
-          if (line.trim().length === 0) continue;
-          const p = parseBrainEvent(line);
-          if (p.kind === "ok") this.received.push(p.event);
-        }
-      },
-      onData: (h) => { this.dataHandler = h as (c: string) => void; },
-      onClose: (h) => { this.closeHandler = h; },
-    };
-  }
-  emit(line: string): void { this.dataHandler?.(line + "\n"); }
-  crash(): void { this.closeHandler?.(); this.exitResolve(1); }
-  /** A real process exits when killed — resolve `exited` so teardown is prompt. */
-  killed(): void { this.exitResolve(137); }
-  hasTask(): boolean { return this.received.some((e) => e.type === "task"); }
-  taskId(): string | undefined {
-    const t = this.received.find((e) => e.type === "task");
-    return t?.type === "task" ? t.task_id : undefined;
-  }
-}
-
-function daemonTransport(brain: DaemonFakeBrain): DaemonTransport {
-  return () => ({
-    connection: Promise.resolve(brain.connection),
-    exited: brain.exited,
-    // A killed process exits — resolve `exited` so the host's SIGTERM→grace
-    // race settles promptly (otherwise teardown waits the full killGrace).
-    kill: () => brain.killed(),
-  });
-}
+// The daemon-brain double + single-brain transport are shared with the host's
+// own unit tests; see `src/brain/__tests__/fake-daemon-brain.ts`.
+const DaemonFakeBrain = FakeDaemonBrain;
+const daemonTransport = singleFakeDaemonTransport;
 
 async function tick(): Promise<void> {
   for (let i = 0; i < 50; i++) await new Promise((r) => setTimeout(r, 2));

--- a/src/bus/__tests__/brain-consumer.test.ts
+++ b/src/bus/__tests__/brain-consumer.test.ts
@@ -789,3 +789,143 @@ process.exit(0);
     15_000,
   );
 });
+
+// ---------------------------------------------------------------------------
+// B-2 — daemon host integration
+// ---------------------------------------------------------------------------
+//
+// The consumer is lifecycle-agnostic: given a DaemonBrainHost, it multiplexes
+// tasks through the host's `runTask` and DRAINS the host on `stop()`. These
+// tests use a minimal in-memory transport double so no real socket/subprocess
+// is needed — the consumer↔host↔(fake brain) round-trip is fully driven.
+
+import { DaemonBrainHost } from "../../brain/daemon-brain-host";
+import type {
+  DaemonTransport,
+  DaemonBrainConnection,
+} from "../../brain/daemon-brain-host";
+import { parseBrainEvent, type BrainEvent } from "../../brain/protocol";
+
+class DaemonFakeBrain {
+  private dataHandler: ((c: string) => void) | null = null;
+  private closeHandler: (() => void) | null = null;
+  readonly received: BrainEvent[] = [];
+  private exitResolve!: (code: number | null) => void;
+  readonly exited: Promise<number | null>;
+  readonly connection: DaemonBrainConnection;
+  constructor() {
+    this.exited = new Promise((res) => { this.exitResolve = res; });
+    this.connection = {
+      write: (chunk: string) => {
+        for (const line of chunk.split("\n")) {
+          if (line.trim().length === 0) continue;
+          const p = parseBrainEvent(line);
+          if (p.kind === "ok") this.received.push(p.event);
+        }
+      },
+      onData: (h) => { this.dataHandler = h as (c: string) => void; },
+      onClose: (h) => { this.closeHandler = h; },
+    };
+  }
+  emit(line: string): void { this.dataHandler?.(line + "\n"); }
+  crash(): void { this.closeHandler?.(); this.exitResolve(1); }
+  /** A real process exits when killed — resolve `exited` so teardown is prompt. */
+  killed(): void { this.exitResolve(137); }
+  hasTask(): boolean { return this.received.some((e) => e.type === "task"); }
+  taskId(): string | undefined {
+    const t = this.received.find((e) => e.type === "task");
+    return t?.type === "task" ? t.task_id : undefined;
+  }
+}
+
+function daemonTransport(brain: DaemonFakeBrain): DaemonTransport {
+  return () => ({
+    connection: Promise.resolve(brain.connection),
+    exited: brain.exited,
+    // A killed process exits — resolve `exited` so the host's SIGTERM→grace
+    // race settles promptly (otherwise teardown waits the full killGrace).
+    kill: () => brain.killed(),
+  });
+}
+
+async function tick(): Promise<void> {
+  for (let i = 0; i < 50; i++) await new Promise((r) => setTimeout(r, 2));
+}
+
+describe("brain-consumer — daemon host (B-2)", () => {
+  test("routes a task through the daemon host to a completed envelope", async () => {
+    const runtime = createRecordingRuntime();
+    const brain = new DaemonFakeBrain();
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport: daemonTransport(brain),
+    });
+    await host.start();
+    const consumer = new BrainConsumer(baseOpts({ runtime, daemonHost: host }));
+
+    const env = makeTaskEnvelope();
+    const decisionP = consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    // Wait for the task to reach the fake brain, then complete it.
+    await tick();
+    expect(brain.hasTask()).toBe(true);
+    const tid = brain.taskId();
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: tid, text: "hi" }));
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: tid, status: "complete" }));
+
+    const decision = await decisionP;
+    expect(decision).toEqual({ kind: "ack" });
+    expect(published(runtime, "dispatch.task.post").length).toBe(1);
+    expect(published(runtime, "dispatch.task.completed").length).toBe(1);
+    await consumer.stop();
+  });
+
+  test("stop() drains the daemon host (sends shutdown)", async () => {
+    const runtime = createRecordingRuntime();
+    const brain = new DaemonFakeBrain();
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport: daemonTransport(brain),
+      killGraceMs: 20,
+    });
+    await host.start();
+    const consumer = new BrainConsumer(
+      baseOpts({ runtime, daemonHost: host, drainDeadlineMs: 20 }),
+    );
+    await consumer.stop();
+    expect(brain.received.some((e) => e.type === "shutdown")).toBe(true);
+  });
+
+  test("a crashed daemon's in-flight task fails → dispatch.task.failed + nak", async () => {
+    const runtime = createRecordingRuntime();
+    const brain = new DaemonFakeBrain();
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport: daemonTransport(brain),
+      maxRestarts: 0, // crash → straight to degraded; task fails cant_do
+    });
+    await host.start();
+    const consumer = new BrainConsumer(baseOpts({ runtime, daemonHost: host }));
+
+    const env = makeTaskEnvelope();
+    const decisionP = consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+    await tick();
+    expect(brain.hasTask()).toBe(true);
+    brain.crash();
+
+    const decision = await decisionP;
+    // cant_do maps to a terminal failure; the consumer publishes failed + maps
+    // the ack per failedReasonToAckDecision.
+    expect(published(runtime, "dispatch.task.failed").length).toBeGreaterThanOrEqual(1);
+    const failed = published(runtime, "dispatch.task.failed")[0];
+    expect(JSON.stringify(failed?.payload)).toMatch(/brain crashed/);
+    void decision;
+    await consumer.stop();
+  });
+});

--- a/src/bus/__tests__/surface-principal-gate.test.ts
+++ b/src/bus/__tests__/surface-principal-gate.test.ts
@@ -1,0 +1,266 @@
+/**
+ * `surface-principal-gate` tests (Bot Packs B-2; `docs/design-bot-packs.md`
+ * §5/§7/§8; the pulse#47 lesson).
+ *
+ * The gate's SECURITY-bearing logic — render to surface, identity-checked await,
+ * pass/fail mapping, timeout, fail-closed routing — is fully exercised with a
+ * stub renderer + reply source. The live adapter-inbound bridge is the one
+ * injected seam (`PrincipalReplySource`); everything else is real here.
+ *
+ * Covered (task deliverable 7):
+ *   - surface gate PASS (rendered prompt captured + injected principal reply)
+ *   - wrong-user reply IGNORED (the pulse#47 structural fix)
+ *   - timeout → fail
+ *   - bus-only task → DenyAll fail-closed
+ *   - non-hosted surface → fail-closed
+ *   - no configured principal id for the surface → fail-closed
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  SurfacePrincipalGate,
+  replyToVerdict,
+  principalIdForSurface,
+  type PrincipalReply,
+  type PrincipalReplySource,
+  type GatePromptRenderer,
+} from "../surface-principal-gate";
+import type { TaskSource } from "../../brain/protocol";
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+interface RenderedPrompt {
+  agentId: string;
+  taskId: string;
+  gate: string;
+  prompt: string;
+  source: TaskSource;
+}
+
+function recordingRenderer(): GatePromptRenderer & { rendered: RenderedPrompt[] } {
+  const rendered: RenderedPrompt[] = [];
+  return {
+    rendered,
+    render: (r) => void rendered.push(r),
+  };
+}
+
+/** A reply source that yields a SCRIPTED queue of replies, then null (timeout). */
+function scriptedReplies(replies: PrincipalReply[]): PrincipalReplySource {
+  let i = 0;
+  return {
+    awaitReply: async () => {
+      const next = replies[i];
+      i += 1;
+      return next ?? null;
+    },
+  };
+}
+
+function source(over: Partial<TaskSource> = {}): TaskSource {
+  return {
+    surface: "mattermost",
+    channel: "c1",
+    thread: "th1",
+    user: "u1",
+    ...over,
+  };
+}
+
+const PRINCIPAL_MM = "mm-principal-123";
+
+function makeGate(opts: {
+  replies?: PrincipalReply[];
+  replySource?: PrincipalReplySource;
+  liveSurfaces?: string[];
+  mattermostId?: string;
+  timeoutMs?: number;
+}): { gate: SurfacePrincipalGate; renderer: ReturnType<typeof recordingRenderer> } {
+  const renderer = recordingRenderer();
+  const gate = new SurfacePrincipalGate({
+    principalIdentity: { mattermostId: opts.mattermostId ?? PRINCIPAL_MM },
+    liveSurfaces: new Set(opts.liveSurfaces ?? ["mattermost"]),
+    renderer,
+    replySource: opts.replySource ?? scriptedReplies(opts.replies ?? []),
+    timeoutMs: opts.timeoutMs ?? 5_000,
+  });
+  return { gate, renderer };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("replyToVerdict", () => {
+  test("affirmatives map to pass", () => {
+    for (const t of ["yes", "Y", " run it ", "approve", "GO", "ok"]) {
+      expect(replyToVerdict(t)).toBe("pass");
+    }
+  });
+  test("negatives and unrecognised map to fail (fail-closed)", () => {
+    for (const t of ["no", "deny", "stop", "maybe", "", "what?"]) {
+      expect(replyToVerdict(t)).toBe("fail");
+    }
+  });
+});
+
+describe("principalIdForSurface", () => {
+  test("resolves per-surface, undefined for unknown/unconfigured", () => {
+    const id = { mattermostId: "m", discordId: "d" };
+    expect(principalIdForSurface(id, "mattermost")).toBe("m");
+    expect(principalIdForSurface(id, "discord")).toBe("d");
+    expect(principalIdForSurface(id, "slack")).toBeUndefined();
+    expect(principalIdForSurface(id, "bus")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gate behaviour
+// ---------------------------------------------------------------------------
+
+describe("SurfacePrincipalGate", () => {
+  test("PASS — renders the prompt and accepts the configured principal's reply", async () => {
+    const { gate, renderer } = makeGate({
+      replies: [{ authorId: PRINCIPAL_MM, text: "run it" }],
+    });
+    const verdict = await gate.resolve({
+      agentId: "yarrow",
+      taskId: "t-1",
+      gate: "principal-ack",
+      prompt: "Run this flow?",
+      source: source(),
+    });
+    expect(verdict.verdict).toBe("pass");
+    expect(verdict.principal).toBe(PRINCIPAL_MM);
+    // The prompt was rendered to the surface.
+    expect(renderer.rendered.length).toBe(1);
+    expect(renderer.rendered[0]?.prompt).toBe("Run this flow?");
+    expect(renderer.rendered[0]?.source.surface).toBe("mattermost");
+  });
+
+  test("wrong-user reply is IGNORED, then the principal's reply decides (pulse#47)", async () => {
+    // A non-principal says "run it" first — it MUST be ignored. Then the
+    // principal says "no" — the gate fails (deny), proving the impostor never
+    // counted.
+    const { gate } = makeGate({
+      replies: [
+        { authorId: "someone-else", text: "run it" },
+        { authorId: PRINCIPAL_MM, text: "no" },
+      ],
+    });
+    const verdict = await gate.resolve({
+      agentId: "yarrow",
+      taskId: "t-1",
+      gate: "principal-ack",
+      prompt: "Run?",
+      source: source(),
+    });
+    expect(verdict.verdict).toBe("fail");
+    expect(verdict.principal).toBe(PRINCIPAL_MM);
+  });
+
+  test("an impostor 'run it' alone never passes — it's ignored to timeout", async () => {
+    // Only an impostor replies; the source then yields null (timeout). The gate
+    // must NOT pass — the structural pulse#47 fix.
+    const { gate } = makeGate({
+      replies: [{ authorId: "impostor", text: "run it" }],
+    });
+    const verdict = await gate.resolve({
+      agentId: "yarrow",
+      taskId: "t-1",
+      gate: "principal-ack",
+      prompt: "Run?",
+      source: source(),
+    });
+    expect(verdict.verdict).toBe("fail");
+    expect(verdict.notes).toMatch(/no reply from principal/i);
+  });
+
+  test("timeout (no reply) fails closed", async () => {
+    const { gate } = makeGate({ replies: [] });
+    const verdict = await gate.resolve({
+      agentId: "yarrow",
+      taskId: "t-1",
+      gate: "principal-ack",
+      prompt: "Run?",
+      source: source(),
+    });
+    expect(verdict.verdict).toBe("fail");
+  });
+
+  test("a bus-only task never reaches the gate — DenyAll fail-closed", async () => {
+    const { gate, renderer } = makeGate({
+      replies: [{ authorId: PRINCIPAL_MM, text: "yes" }],
+    });
+    const verdict = await gate.resolve({
+      agentId: "yarrow",
+      taskId: "t-1",
+      gate: "principal-ack",
+      prompt: "Run?",
+      source: source({ surface: "bus" }),
+    });
+    expect(verdict.verdict).toBe("fail");
+    // Never rendered — bus tasks don't get a surface gate.
+    expect(renderer.rendered.length).toBe(0);
+  });
+
+  test("a surface this instance does not host fails closed", async () => {
+    const { gate, renderer } = makeGate({
+      liveSurfaces: ["mattermost"],
+      replies: [{ authorId: PRINCIPAL_MM, text: "yes" }],
+    });
+    const verdict = await gate.resolve({
+      agentId: "yarrow",
+      taskId: "t-1",
+      gate: "principal-ack",
+      prompt: "Run?",
+      source: source({ surface: "discord" }), // not hosted
+    });
+    expect(verdict.verdict).toBe("fail");
+    expect(renderer.rendered.length).toBe(0);
+  });
+
+  test("no configured principal id for the surface fails closed", async () => {
+    const renderer = recordingRenderer();
+    const gate = new SurfacePrincipalGate({
+      principalIdentity: {}, // no ids configured
+      liveSurfaces: new Set(["mattermost"]),
+      renderer,
+      replySource: scriptedReplies([{ authorId: "anyone", text: "yes" }]),
+    });
+    const verdict = await gate.resolve({
+      agentId: "yarrow",
+      taskId: "t-1",
+      gate: "principal-ack",
+      prompt: "Run?",
+      source: source(),
+    });
+    expect(verdict.verdict).toBe("fail");
+    expect(verdict.notes).toMatch(/no configured principal id/i);
+    expect(renderer.rendered.length).toBe(0);
+  });
+
+  test("a render failure fails closed (principal never saw the prompt)", async () => {
+    const gate = new SurfacePrincipalGate({
+      principalIdentity: { mattermostId: PRINCIPAL_MM },
+      liveSurfaces: new Set(["mattermost"]),
+      renderer: {
+        render: () => {
+          throw new Error("publish blew up");
+        },
+      },
+      replySource: scriptedReplies([{ authorId: PRINCIPAL_MM, text: "yes" }]),
+    });
+    const verdict = await gate.resolve({
+      agentId: "yarrow",
+      taskId: "t-1",
+      gate: "principal-ack",
+      prompt: "Run?",
+      source: source(),
+    });
+    expect(verdict.verdict).toBe("fail");
+    expect(verdict.notes).toMatch(/failed to render/i);
+  });
+});

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -97,6 +97,7 @@ import type {
   RunBrainTask,
   BrainTaskHooks,
 } from "../brain/exec-brain-runner";
+import type { DaemonBrainHost } from "../brain/daemon-brain-host";
 import type {
   TaskEvent,
   TaskSource,
@@ -213,8 +214,28 @@ export interface BrainConsumerOpts {
    * The configured per-task brain runner (from `makeExecBrainRunner` over the
    * manifest's `brain` block). Injected so the consumer never owns spawn
    * policy; tests pass a stub that resolves a deterministic result.
+   *
+   * For a `lifecycle: daemon` agent (B-2) pass {@link daemonHost} instead — the
+   * consumer derives the runner from the host's `runTask` and routes
+   * drain/teardown through the host. Exactly one of `runBrainTask` / `daemonHost`
+   * is used; when both are present `daemonHost` wins (B-2 daemon path).
    */
   runBrainTask: RunBrainTask;
+  /**
+   * Bot Packs B-2 — the daemon brain host (`lifecycle: daemon`). When provided,
+   * the consumer multiplexes tasks over the long-lived host (its `runTask` is
+   * the runner) and a `stop()` DRAINS the host (hot-swap or shutdown). A degraded
+   * host (restart budget exhausted) is surfaced through the host's own
+   * `onDegraded` callback the boot wiring supplies. Omitted ⇒ per-task lifecycle
+   * (B-1) via {@link runBrainTask}.
+   */
+  daemonHost?: DaemonBrainHost;
+  /**
+   * Hot-swap drain deadline (ms) handed to {@link daemonHost.drain} on `stop()`.
+   * Past it, open `ask_principal` gates are cancelled with a re-trigger notice
+   * (§7.5). Ignored for the per-task lifecycle. Defaults to 5_000.
+   */
+  drainDeadlineMs?: number;
   /**
    * Optional persona text delivered to the brain on each `task` event (per-task
    * brains receive persona on the task; §5 "Persona delivery"). Omitted → no
@@ -283,6 +304,9 @@ export class BrainConsumer {
   private readonly source: SystemEventSource;
   private readonly runtime: MyelinRuntime;
   private readonly runBrainTask: RunBrainTask;
+  /** B-2 — the daemon host (when `lifecycle: daemon`), else undefined. */
+  private readonly daemonHost: DaemonBrainHost | undefined;
+  private readonly drainDeadlineMs: number;
   private readonly persona: string | undefined;
   private readonly principalGate: PrincipalGate;
   private readonly sovereigntyEnforce: boolean;
@@ -303,7 +327,15 @@ export class BrainConsumer {
     this.agent = opts.agent;
     this.source = opts.source;
     this.runtime = opts.runtime;
-    this.runBrainTask = opts.runBrainTask;
+    this.daemonHost = opts.daemonHost;
+    this.drainDeadlineMs = opts.drainDeadlineMs ?? 5_000;
+    // B-2: when a daemon host is provided, the runner IS the host's multiplexed
+    // `runTask` (one long-lived process). Otherwise the injected per-task runner
+    // (B-1). Binding here keeps `runOne` lifecycle-agnostic — it just calls
+    // `this.runBrainTask(task, hooks)` either way.
+    this.runBrainTask = opts.daemonHost
+      ? (task, hooks) => opts.daemonHost!.runTask(task, hooks)
+      : opts.runBrainTask;
     this.persona = opts.persona;
     this.principalGate = opts.principalGate ?? new DenyAllPrincipalGate();
     this.sovereigntyEnforce = opts.sovereigntyEnforce ?? false;
@@ -505,6 +537,21 @@ export class BrainConsumer {
       });
       if (this.inFlight.size > 0) {
         await Promise.allSettled(Array.from(this.inFlight));
+      }
+      // B-2 — drain the daemon host on the SAME stop path (hot-swap or shutdown).
+      // `drain(deadline)` sends `shutdown`, waits for in-flight tasks + open
+      // gates up to the deadline, cancels stragglers with the re-trigger notice
+      // (§7.5), then SIGTERM/SIGKILL. The per-task lifecycle has no host to
+      // drain — its in-flight runs already settled in the `inFlight` await above.
+      if (this.daemonHost !== undefined) {
+        try {
+          await this.daemonHost.drain(this.drainDeadlineMs);
+        } catch (err) {
+          process.stderr.write(
+            `brain-consumer: daemon host drain failed for agent=${this.agent.id}: ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
       }
     })();
     return this.stopPromise;

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -199,11 +199,14 @@ export interface BrainConsumerAgent {
 }
 
 /**
- * Construction options. Every dependency is injected — no module-scope
- * singletons. Production wires the real `runtime` + `runBrainTask`; tests
- * inject doubles.
+ * Construction options shared by both lifecycles. The lifecycle-specific
+ * `runBrainTask` (per-task / B-1) vs `daemonHost` (daemon / B-2) split is
+ * layered on as a discriminated union below ({@link BrainConsumerOpts}) so the
+ * two are MUTUALLY EXCLUSIVE at the type level — a caller cannot construct an
+ * inert runner alongside a daemon host (sage cortex#1035: one lifecycle path
+ * should be impossible, not merely "daemonHost wins").
  */
-export interface BrainConsumerOpts {
+export interface BrainConsumerBaseOpts {
   /** The agent this consumer serves. */
   agent: BrainConsumerAgent;
   /** Envelope source `{principal}.{agent}.{instance}` for emitted lifecycle envelopes. */
@@ -211,29 +214,10 @@ export interface BrainConsumerOpts {
   /** The myelin runtime — used for `publish` + `subscribePull`. */
   runtime: MyelinRuntime;
   /**
-   * The configured per-task brain runner (from `makeExecBrainRunner` over the
-   * manifest's `brain` block). Injected so the consumer never owns spawn
-   * policy; tests pass a stub that resolves a deterministic result.
-   *
-   * For a `lifecycle: daemon` agent (B-2) pass {@link daemonHost} instead — the
-   * consumer derives the runner from the host's `runTask` and routes
-   * drain/teardown through the host. Exactly one of `runBrainTask` / `daemonHost`
-   * is used; when both are present `daemonHost` wins (B-2 daemon path).
-   */
-  runBrainTask: RunBrainTask;
-  /**
-   * Bot Packs B-2 — the daemon brain host (`lifecycle: daemon`). When provided,
-   * the consumer multiplexes tasks over the long-lived host (its `runTask` is
-   * the runner) and a `stop()` DRAINS the host (hot-swap or shutdown). A degraded
-   * host (restart budget exhausted) is surfaced through the host's own
-   * `onDegraded` callback the boot wiring supplies. Omitted ⇒ per-task lifecycle
-   * (B-1) via {@link runBrainTask}.
-   */
-  daemonHost?: DaemonBrainHost;
-  /**
-   * Hot-swap drain deadline (ms) handed to {@link daemonHost.drain} on `stop()`.
-   * Past it, open `ask_principal` gates are cancelled with a re-trigger notice
-   * (§7.5). Ignored for the per-task lifecycle. Defaults to 5_000.
+   * Hot-swap drain deadline (ms) handed to {@link DaemonBrainHost.drain} on
+   * `stop()`. Past it, open `ask_principal` gates are cancelled with a
+   * re-trigger notice (§7.5). Ignored for the per-task lifecycle. Defaults to
+   * 5_000.
    */
   drainDeadlineMs?: number;
   /**
@@ -258,6 +242,47 @@ export interface BrainConsumerOpts {
   /** Test seam — clock. Defaults to `() => new Date()`. */
   clock?: () => Date;
 }
+
+/**
+ * Per-task lifecycle (B-1): the consumer owns an injected per-task runner and
+ * NO daemon host. `daemonHost` is statically forbidden here.
+ */
+export interface BrainConsumerPerTaskOpts extends BrainConsumerBaseOpts {
+  /**
+   * The configured per-task brain runner (from `makeExecBrainRunner` over the
+   * manifest's `brain` block). Injected so the consumer never owns spawn
+   * policy; tests pass a stub that resolves a deterministic result.
+   */
+  runBrainTask: RunBrainTask;
+  /** Forbidden on the per-task path — use {@link BrainConsumerDaemonOpts}. */
+  daemonHost?: never;
+}
+
+/**
+ * Daemon lifecycle (B-2): the consumer multiplexes tasks over a long-lived
+ * {@link DaemonBrainHost} (its `runTask` IS the runner) and `stop()` DRAINS the
+ * host (hot-swap or shutdown). A degraded host (restart budget exhausted) is
+ * surfaced through the host's own `onDegraded` callback the boot wiring
+ * supplies. `runBrainTask` is statically forbidden here — there is no inert
+ * per-task runner to construct alongside the host.
+ */
+export interface BrainConsumerDaemonOpts extends BrainConsumerBaseOpts {
+  /** The daemon brain host (`lifecycle: daemon`). */
+  daemonHost: DaemonBrainHost;
+  /** Forbidden on the daemon path — the host's `runTask` is the runner. */
+  runBrainTask?: never;
+}
+
+/**
+ * Construction options. A discriminated union over the two lifecycles so
+ * exactly ONE of `runBrainTask` (per-task / B-1) and `daemonHost` (daemon /
+ * B-2) is constructible — never both, never neither. Every dependency is
+ * injected — no module-scope singletons. Production wires the real `runtime`
+ * plus the lifecycle's runner; tests inject doubles.
+ */
+export type BrainConsumerOpts =
+  | BrainConsumerPerTaskOpts
+  | BrainConsumerDaemonOpts;
 
 /**
  * Options for {@link BrainConsumer.start} when binding real JetStream pull
@@ -333,9 +358,12 @@ export class BrainConsumer {
     // `runTask` (one long-lived process). Otherwise the injected per-task runner
     // (B-1). Binding here keeps `runOne` lifecycle-agnostic — it just calls
     // `this.runBrainTask(task, hooks)` either way.
-    this.runBrainTask = opts.daemonHost
-      ? (task, hooks) => opts.daemonHost!.runTask(task, hooks)
-      : opts.runBrainTask;
+    if (opts.daemonHost !== undefined) {
+      const host = opts.daemonHost;
+      this.runBrainTask = (task, hooks) => host.runTask(task, hooks);
+    } else {
+      this.runBrainTask = opts.runBrainTask;
+    }
     this.persona = opts.persona;
     this.principalGate = opts.principalGate ?? new DenyAllPrincipalGate();
     this.sovereigntyEnforce = opts.sovereigntyEnforce ?? false;

--- a/src/bus/surface-principal-gate.ts
+++ b/src/bus/surface-principal-gate.ts
@@ -1,0 +1,380 @@
+/**
+ * `surface-principal-gate.ts` — the Bot Packs B-2 surface gate
+ * (`docs/design-bot-packs.md` §5, §7, §8; pulse#47 lesson).
+ *
+ * This is the bridge that finally makes `ask_principal` REAL. B-1 shipped only
+ * {@link DenyAllPrincipalGate} (fail-closed) because there was no live surface to
+ * render a gate to and no host-side principal check. B-2 adds the surface gate:
+ * when a brain task's `response_routing` names a LIVE surface the cortex instance
+ * hosts, this gate:
+ *
+ *   1. RENDERS the gate prompt to the task's surface/thread via the
+ *      dispatch-sink/post path (a `dispatch.task.post` envelope — the SAME path
+ *      a brain `post` rides; §5 property 1: the brain cannot choose the channel,
+ *      the host-supplied routing does);
+ *   2. AWAITS a reply from the CONFIGURED PRINCIPAL — resolved by IDENTITY
+ *      (platform user id: `principal.mattermostId` / `discordId` / `slackId`),
+ *      NEVER by message-text inference. This is the pulse#47 lesson made
+ *      structural: "any channel member could say 'run it'" is impossible here
+ *      because a reply from anyone but the configured principal id is IGNORED;
+ *   3. MAPS the principal's reply to the gate vocabulary (`pass` / `fail`) and
+ *      returns the HOST-RESOLVED principal id on the verdict (so the brain
+ *      receives an authoritative principal, never a chat-inferred one);
+ *   4. TIMES OUT to `fail` — a gate with no principal reply within the window is
+ *      denied, fail-closed.
+ *
+ * ## What is host-real vs. what is the injected seam
+ *
+ * The IDENTITY CHECK, the pass/fail mapping, the timeout, the host-resolved
+ * principal, and the prompt RENDER are all fully implemented here. The one
+ * deliberately-injected seam is {@link PrincipalReplySource} — how a live
+ * principal reply in a thread is OBSERVED. Wiring that to the live adapter
+ * inbound (a DM/@mention correlated back to the open gate) is the deepest part
+ * of the adapter integration; isolating it behind a typed source keeps this
+ * gate's decision logic — the security-bearing part — fully tested with a stub,
+ * and lets the live inbound bridge land without touching the decision logic.
+ *
+ * ## Fail-closed routing
+ *
+ * A BUS-ONLY task (no live surface in `response_routing`, or the named surface
+ * is not one this instance hosts) NEVER reaches the await — it returns
+ * {@link DenyAllPrincipalGate}'s `fail` verbatim. Only a task whose routing
+ * names a live, hosted surface AND a configured principal identity gets a real
+ * gate. Everything else is denied. (§8: policy stays in cortex; the brain's own
+ * claim is never trusted.)
+ */
+
+import type { TaskSource } from "../brain/protocol";
+import {
+  DenyAllPrincipalGate,
+  type PrincipalGate,
+} from "./brain-consumer";
+import type { GateVerdictValue } from "../brain/protocol";
+import type { MyelinRuntime } from "./myelin/runtime";
+import type { SystemEventSource } from "./system-events";
+import { createDispatchTaskPostEvent } from "./dispatch-events";
+
+// ---------------------------------------------------------------------------
+// Principal identity + reply seams
+// ---------------------------------------------------------------------------
+
+/**
+ * The platform user ids of the configured principal, per surface. Resolved from
+ * `principal.mattermostId` / `discordId` / `slackId` at boot (see
+ * `PrincipalConfig`). A surface with NO configured id cannot run a real gate —
+ * the gate cannot verify identity, so it fails closed for that surface.
+ */
+export interface PrincipalIdentity {
+  mattermostId?: string;
+  discordId?: string;
+  slackId?: string;
+}
+
+/**
+ * Resolve the configured principal's platform user id FOR A GIVEN SURFACE. The
+ * gate compares an inbound reply's author id against THIS — the structural
+ * pulse#47 fix. Returns `undefined` when the principal has no id on that surface
+ * (gate fails closed — identity unverifiable).
+ */
+export function principalIdForSurface(
+  identity: PrincipalIdentity,
+  surface: string,
+): string | undefined {
+  switch (surface) {
+    case "mattermost":
+      return identity.mattermostId;
+    case "discord":
+      return identity.discordId;
+    case "slack":
+      return identity.slackId;
+    default:
+      return undefined;
+  }
+}
+
+/** A single inbound reply observed in a gate's thread. */
+export interface PrincipalReply {
+  /** The platform user id of the replier — the IDENTITY the gate checks. */
+  authorId: string;
+  /** The reply text — used ONLY for pass/fail wording, NEVER for identity. */
+  text: string;
+}
+
+/**
+ * How the gate observes a principal reply in the task's thread. The live
+ * implementation correlates an inbound adapter message (DM/@mention in the
+ * gate's channel+thread) back to the open gate; the test stub resolves a
+ * scripted reply.
+ *
+ * Contract: `awaitReply` resolves with the NEXT reply in the named
+ * channel/thread (from ANY author — the gate filters by identity), or `null` on
+ * timeout / no live source. The source does NOT itself filter by author — that
+ * is the gate's job, so the gate's identity check is the single source of truth
+ * (a source that pre-filtered could silently let a mis-configured identity
+ * through).
+ */
+export interface PrincipalReplySource {
+  awaitReply(opts: {
+    surface: string;
+    channel: string;
+    thread: string;
+    timeoutMs: number;
+  }): Promise<PrincipalReply | null>;
+}
+
+/**
+ * How the gate RENDERS its prompt to the surface. The live implementation
+ * publishes a `dispatch.task.post` envelope (the same path a brain `post`
+ * rides), letting the dispatch sink deliver it to the thread. Injected so the
+ * gate doesn't own the publish path + tests assert the rendered prompt.
+ */
+export interface GatePromptRenderer {
+  render(opts: {
+    agentId: string;
+    taskId: string;
+    gate: string;
+    prompt: string;
+    source: TaskSource;
+  }): Promise<void> | void;
+}
+
+// ---------------------------------------------------------------------------
+// Pass/fail mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Default affirmative replies. Deliberately a small, explicit allow-list rather
+ * than fuzzy NLP — a gate verdict is a security decision; an unrecognised reply
+ * is NOT a pass. The text is matched ONLY after the identity check passes, so it
+ * never carries identity weight (pulse#47).
+ */
+const AFFIRMATIVE = new Set([
+  "yes",
+  "y",
+  "approve",
+  "approved",
+  "run it",
+  "run",
+  "go",
+  "ok",
+  "okay",
+  "pass",
+  "confirm",
+  "confirmed",
+]);
+
+/** Default negative replies — an explicit deny. */
+const NEGATIVE = new Set([
+  "no",
+  "n",
+  "deny",
+  "denied",
+  "reject",
+  "rejected",
+  "stop",
+  "cancel",
+  "fail",
+  "abort",
+]);
+
+/**
+ * Map a principal's reply text to a gate verdict. Affirmative → `pass`; anything
+ * else (explicit negative OR unrecognised) → `fail`. FAIL-CLOSED on ambiguity:
+ * an unrecognised reply is a `fail`, not a retry — a verdict must be an explicit
+ * yes. Normalises case + surrounding whitespace; never parses identity.
+ */
+export function replyToVerdict(text: string): GateVerdictValue {
+  const normalized = text.trim().toLowerCase();
+  if (AFFIRMATIVE.has(normalized)) return "pass";
+  // Explicit negatives and everything unrecognised both fail closed.
+  void NEGATIVE; // exported intent: a negative is a fail, same as unknown.
+  return "fail";
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+/** Construction options for {@link SurfacePrincipalGate}. */
+export interface SurfacePrincipalGateOpts {
+  /** The configured principal's per-surface platform ids. */
+  principalIdentity: PrincipalIdentity;
+  /** Which surfaces this cortex instance actually hosts a live adapter for. */
+  liveSurfaces: ReadonlySet<string>;
+  /** Renders the gate prompt to the surface (the dispatch.task.post path). */
+  renderer: GatePromptRenderer;
+  /** Observes the principal's reply in the thread. */
+  replySource: PrincipalReplySource;
+  /** Gate timeout (ms) — no principal reply by then → fail. Defaults to 300_000 (5 min). */
+  timeoutMs?: number;
+}
+
+/**
+ * The B-2 surface gate. Implements {@link PrincipalGate} so it drops straight
+ * into the BrainConsumer's `principalGate` seam, replacing
+ * {@link DenyAllPrincipalGate} for tasks routed to a live surface.
+ */
+export class SurfacePrincipalGate implements PrincipalGate {
+  private readonly principalIdentity: PrincipalIdentity;
+  private readonly liveSurfaces: ReadonlySet<string>;
+  private readonly renderer: GatePromptRenderer;
+  private readonly replySource: PrincipalReplySource;
+  private readonly timeoutMs: number;
+  /** Fallback for bus-only / non-hosted-surface tasks — fail-closed. */
+  private readonly denyAll = new DenyAllPrincipalGate();
+
+  constructor(opts: SurfacePrincipalGateOpts) {
+    this.principalIdentity = opts.principalIdentity;
+    this.liveSurfaces = opts.liveSurfaces;
+    this.renderer = opts.renderer;
+    this.replySource = opts.replySource;
+    this.timeoutMs = opts.timeoutMs ?? 300_000;
+  }
+
+  async resolve(input: {
+    agentId: string;
+    taskId: string;
+    gate: string;
+    prompt: string;
+    source: TaskSource;
+  }): Promise<{ verdict: GateVerdictValue; principal: string; notes?: string }> {
+    const { surface, channel, thread } = input.source;
+
+    // Fail-closed routing: a bus-only task, or a task routed to a surface this
+    // instance does not host, never gets a real gate. DenyAll handles it.
+    if (surface === "bus" || !this.liveSurfaces.has(surface)) {
+      return this.denyAll.resolve();
+    }
+
+    // Resolve the configured principal's id for THIS surface. No configured id
+    // ⇒ identity unverifiable ⇒ fail closed (we will not run a gate we cannot
+    // attribute to the principal).
+    const principalId = principalIdForSurface(this.principalIdentity, surface);
+    if (principalId === undefined || principalId.length === 0) {
+      return {
+        verdict: "fail",
+        principal: "",
+        notes: `no configured principal id for surface "${surface}" — cannot verify identity`,
+      };
+    }
+
+    // A channel/thread is required to both render and observe the reply. A task
+    // with a live surface but no channel can't host a thread gate — fail closed.
+    if (channel.length === 0) {
+      return {
+        verdict: "fail",
+        principal: "",
+        notes: `surface "${surface}" task has no channel to render the gate into`,
+      };
+    }
+
+    // 1. Render the prompt to the surface/thread (host-supplied routing — the
+    //    brain cannot choose the channel).
+    try {
+      await this.renderer.render({
+        agentId: input.agentId,
+        taskId: input.taskId,
+        gate: input.gate,
+        prompt: input.prompt,
+        source: input.source,
+      });
+    } catch (err) {
+      // A render failure means the principal never saw the prompt — fail closed.
+      return {
+        verdict: "fail",
+        principal: "",
+        notes: `failed to render gate prompt to surface: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    // 2. Await a reply, filtering by IDENTITY (the pulse#47 fix). A reply from
+    //    anyone but the configured principal id is IGNORED — we keep waiting
+    //    until the deadline. The text is used ONLY for the pass/fail mapping,
+    //    never for identity.
+    const deadline = Date.now() + this.timeoutMs;
+    for (;;) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      let reply: PrincipalReply | null;
+      try {
+        reply = await this.replySource.awaitReply({
+          surface,
+          channel,
+          thread,
+          timeoutMs: remaining,
+        });
+      } catch (err) {
+        return {
+          verdict: "fail",
+          principal: "",
+          notes: `reply source error: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+      if (reply === null) break; // source timed out / no live source
+      if (reply.authorId !== principalId) {
+        // NOT the principal — ignore and keep waiting (someone else in the
+        // thread said "run it"; that is exactly the pulse#47 case we refuse).
+        continue;
+      }
+      // 3. The configured principal replied — map text → verdict, return the
+      //    HOST-RESOLVED principal id (authoritative, not chat-inferred).
+      return {
+        verdict: replyToVerdict(reply.text),
+        principal: principalId,
+        notes: `principal ${principalId} on ${surface} replied: ${truncate(reply.text)}`,
+      };
+    }
+
+    // 4. Timeout — no principal reply within the window. Fail closed.
+    return {
+      verdict: "fail",
+      principal: "",
+      notes: `no reply from principal ${principalId} on ${surface} within ${this.timeoutMs}ms`,
+    };
+  }
+}
+
+/** Trim a reply to a bounded length for the verdict notes. */
+function truncate(s: string, max = 120): string {
+  const t = s.trim();
+  return t.length <= max ? t : `${t.slice(0, max)}…`;
+}
+
+// ---------------------------------------------------------------------------
+// Default dispatch-post renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * The production {@link GatePromptRenderer}: render the gate prompt by
+ * publishing a `dispatch.task.post` envelope (the SAME path a brain `post`
+ * rides), so the dispatch sink delivers it to the task's surface/thread. The
+ * routing comes from the task source — the brain never chooses the channel
+ * (§5 property 1).
+ *
+ * Best-effort publish: a publish failure rejects so the gate's render-failure
+ * branch fails the gate closed (the principal never saw the prompt).
+ */
+export function makeDispatchPostRenderer(opts: {
+  runtime: MyelinRuntime;
+  source: SystemEventSource;
+}): GatePromptRenderer {
+  return {
+    async render(r): Promise<void> {
+      await opts.runtime.publish(
+        createDispatchTaskPostEvent({
+          source: opts.source,
+          taskId: crypto.randomUUID(),
+          agentId: r.agentId,
+          correlationId: r.taskId,
+          text: r.prompt,
+          taskSource: {
+            surface: r.source.surface,
+            channel: r.source.channel,
+            thread: r.source.thread,
+            user: r.source.user,
+          },
+        }),
+      );
+    },
+  };
+}

--- a/src/bus/surface-principal-gate.ts
+++ b/src/bus/surface-principal-gate.ts
@@ -163,31 +163,17 @@ const AFFIRMATIVE = new Set([
   "confirmed",
 ]);
 
-/** Default negative replies — an explicit deny. */
-const NEGATIVE = new Set([
-  "no",
-  "n",
-  "deny",
-  "denied",
-  "reject",
-  "rejected",
-  "stop",
-  "cancel",
-  "fail",
-  "abort",
-]);
-
 /**
  * Map a principal's reply text to a gate verdict. Affirmative → `pass`; anything
- * else (explicit negative OR unrecognised) → `fail`. FAIL-CLOSED on ambiguity:
- * an unrecognised reply is a `fail`, not a retry — a verdict must be an explicit
- * yes. Normalises case + surrounding whitespace; never parses identity.
+ * else → `fail`. FAIL-CLOSED on ambiguity: an explicit negative ("no", "deny")
+ * and an unrecognised reply both fail the same way — a verdict must be an
+ * explicit affirmative. There is therefore no separate negative allow-list to
+ * maintain (the absence of a `pass` IS the deny). Normalises case + surrounding
+ * whitespace; never parses identity.
  */
 export function replyToVerdict(text: string): GateVerdictValue {
   const normalized = text.trim().toLowerCase();
   if (AFFIRMATIVE.has(normalized)) return "pass";
-  // Explicit negatives and everything unrecognised both fail closed.
-  void NEGATIVE; // exported intent: a negative is a fail, same as unknown.
   return "fail";
 }
 

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -421,12 +421,32 @@ describe("AgentRuntimeSchema.brain (Bot Packs B-1)", () => {
     expect(parsed.brain?.dispatch_capabilities).toEqual(["soc.triage.email"]);
   });
 
-  test("lifecycle=daemon is REJECTED at load (lands in B-2)", () => {
+  test("lifecycle=daemon is now ACCEPTED at load (B-2 daemon host is live)", () => {
+    const parsed = AgentRuntimeSchema.parse(
+      minRuntime({
+        kind: "exec",
+        run: "bun x.ts",
+        lifecycle: "daemon",
+        maxRestarts: 5,
+      }),
+    );
+    expect(parsed.brain?.lifecycle).toBe("daemon");
+    expect(parsed.brain?.maxRestarts).toBe(5);
+  });
+
+  test("lifecycle defaults to per-task when omitted", () => {
+    const parsed = AgentRuntimeSchema.parse(
+      minRuntime({ kind: "exec", run: "bun x.ts" }),
+    );
+    expect(parsed.brain?.lifecycle).toBe("per-task");
+  });
+
+  test("daemon still requires run when kind=exec", () => {
     expect(() =>
       AgentRuntimeSchema.parse(
-        minRuntime({ kind: "exec", run: "bun x.ts", lifecycle: "daemon" }),
+        minRuntime({ kind: "exec", lifecycle: "daemon" }),
       ),
-    ).toThrow(/daemon[\s\S]*B-2/);
+    ).toThrow(/brain\.run is required when brain\.kind is 'exec'/);
   });
 
   test("protocol pinned to cortex-brain/v1 — a wrong protocol fails", () => {

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -479,9 +479,9 @@ export type Presence = z.infer<typeof PresenceSchema>;
  *                    Required IFF `kind: exec` (a builtin has no command to
  *                    spawn). `{pack}` expands to the arc install dir at spawn.
  *   - `protocol`   — pinned to `cortex-brain/v1` (the only protocol B-1 speaks).
- *   - `lifecycle`  — `per-task` (default) | `daemon`. `per-task` is LIVE (B-1);
- *                    `daemon` is REJECTED at load time (B-2) so nobody
- *                    half-uses the socket transport before it exists.
+ *   - `lifecycle`  — `per-task` (default) | `daemon`. Both LIVE: `per-task`
+ *                    (B-1) spawns per inbound task; `daemon` (B-2) supervises a
+ *                    long-lived socket-multiplexed process.
  *   - `secrets`    — env var NAMES only (values resolve from the runtime env at
  *                    spawn). Install-time principal consent is the arc-side gate
  *                    (§8). Defaults to `[]`.
@@ -519,9 +519,10 @@ export const BrainConfigSchema = z
     /**
      * `per-task` — spawn the brain per inbound task, alive until it emits
      * `result` (B-1, LIVE). `daemon` — supervise a long-lived process on a
-     * socket transport (B-2). Daemon is REJECTED at load time (superRefine
-     * below) with a clear "lands in B-2" message so a config can't half-use a
-     * transport that does not exist yet. Defaults to `per-task`.
+     * Unix-socket transport, multiplexing tasks by `task_id`, with crash
+     * supervision (`maxRestarts`) and hot-swap drain (B-2, LIVE —
+     * `src/brain/daemon-brain-host.ts`). Both are accepted at load. Defaults to
+     * `per-task`.
      */
     lifecycle: z.enum(["per-task", "daemon"]).default("per-task"),
     /**
@@ -543,9 +544,11 @@ export const BrainConfigSchema = z
     dispatch_capabilities: z.array(z.string().min(1)).default([]),
     /**
      * Daemon supervision restart cap (§7.4): cortex restarts a crashed daemon
-     * brain up to this many times, then marks the agent degraded. Accepted +
-     * documented now; UNUSED until B-2 (a `per-task` brain is spawned fresh per
-     * task and never restarted). Non-negative integer; defaults to 3.
+     * brain up to this many times, then marks the agent degraded (the restart
+     * counter resets after a healthy uptime window). LIVE for `lifecycle: daemon`
+     * as of B-2 (`DaemonBrainHost`); a `per-task` brain is spawned fresh per task
+     * and never restarted, so the field is inert there. Non-negative integer;
+     * defaults to 3.
      */
     maxRestarts: z
       .number()
@@ -554,19 +557,12 @@ export const BrainConfigSchema = z
       .default(3),
   })
   .superRefine((brain, ctx) => {
-    // `daemon` lifecycle is B-2 — REJECT it at load so a config can't half-use
-    // the socket transport / supervision machinery before they exist. A clear,
-    // actionable message rather than a silent partial-feature.
-    if (brain.lifecycle === "daemon") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          "agent.runtime.brain.lifecycle 'daemon' is not yet supported — daemon " +
-          "lifecycle (socket transport + supervision) lands in B-2; use " +
-          "'per-task' (the default) for now",
-        path: ["lifecycle"],
-      });
-    }
+    // `daemon` lifecycle is LIVE as of B-2 (socket transport + supervision +
+    // hot-swap drain — `src/brain/daemon-brain-host.ts`). The B-1 load-time
+    // rejection is removed; a `daemon` brain is now spawned once and supervised
+    // (the BrainConsumer routes its tasks through the DaemonBrainHost). The
+    // `exec`-with-`run` requirement below still applies to both lifecycles.
+
     // An `exec` brain has no behaviour without a command to spawn. Require
     // `run` so a half-declared exec brain fails at load, not at the first task.
     if (brain.kind === "exec" && (brain.run === undefined || brain.run.length === 0)) {

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -69,6 +69,7 @@ import {
   type BrainConsumerAgent,
 } from "./bus/brain-consumer";
 import { makeExecBrainRunner } from "./brain/exec-brain-runner";
+import { DaemonBrainHost } from "./brain/daemon-brain-host";
 import { wireDevConsumers } from "./runner/dev-consumer-boot";
 import {
   ReleaseConsumer,
@@ -1352,6 +1353,20 @@ export async function startCortex(
   const isBrainHosted = (a: Agent): boolean =>
     isExecBrainAgent(a) && (a.runtime?.capabilities?.length ?? 0) > 0;
   const brainConsumers: BrainConsumer[] = [];
+  // Bot Packs B-2 — the long-lived daemon brain hosts (one per `lifecycle:
+  // daemon` agent). Tracked so the shutdown drain + reconcile teardown can stop
+  // them; the BrainConsumer already routes per-task drain through `stop()`, but
+  // a host also needs an unconditional teardown on process shutdown.
+  const daemonBrainHosts: DaemonBrainHost[] = [];
+  // Bot Packs B-2 — a mutable holder for the presence producer so the daemon
+  // host's `onDegraded` callback (which fires at RUNTIME, long after boot) can
+  // surface a degraded agent via `publishCapabilitiesChanged(agentId, [])` —
+  // the same capability-change presence signal the reconcile path uses. The
+  // producer is constructed later (the MC-registry block); this holder is
+  // assigned there and read lazily inside the callback.
+  const brainPresenceHolder: { producer: AgentPresenceProducer | null } = {
+    producer: null,
+  };
   const reviewCapableAgents = mergedAgents.filter((a) => {
     // An exec-brain agent is hosted by the brain path even if it happens to
     // declare a code-review capability — the two consumers are mutually
@@ -2324,25 +2339,72 @@ export async function startCortex(
       const packDir = join(brainPackBaseDir, agent.id);
       const secrets = collectBrainSecrets(agent.id, brain.secrets);
 
-      const runBrainTask = makeExecBrainRunner({
-        run: brain.run,
-        packDir,
-        secrets,
-      });
-
-      // Persona delivered to the brain on each task event (§5 "Persona
-      // delivery"). A missing/unreadable persona is non-fatal — the brain simply
-      // receives no persona (logged once inside the helper).
+      // Persona delivered to the brain — per-task brains receive it on each task
+      // event; daemon brains receive it ONCE in the `hello` handshake (§5
+      // "Persona delivery"). A missing/unreadable persona is non-fatal.
       const personaText = loadBrainPersona(agent.id, agent.persona);
+
+      // Bot Packs B-2 — `lifecycle: daemon` is hosted by a long-lived
+      // DaemonBrainHost (spawn once, socket-multiplex tasks, supervise + drain);
+      // `per-task` (default) keeps the B-1 per-spawn runner. Both feed the SAME
+      // BrainConsumer policy seam (the consumer is lifecycle-agnostic — it routes
+      // brain effects through the host hooks identically).
+      let daemonHost: DaemonBrainHost | undefined;
+      let runBrainTask: ReturnType<typeof makeExecBrainRunner>;
+      if (brain.lifecycle === "daemon") {
+        daemonHost = new DaemonBrainHost({
+          agentId: agent.id,
+          run: brain.run,
+          packDir,
+          secrets,
+          maxRestarts: brain.maxRestarts,
+          ...(personaText !== undefined && { persona: personaText }),
+          // On degradation (restart budget exhausted) surface the agent via the
+          // presence producer's capability-change signal (drop to empty caps),
+          // the same path the reconcile uses (§7.4). Read the holder lazily —
+          // the producer is constructed after this boot closure runs.
+          onDegraded: (degradedId: string): void => {
+            const producer = brainPresenceHolder.producer;
+            if (producer !== null) {
+              producer.publishCapabilitiesChanged(degradedId, []);
+            }
+            process.stderr.write(
+              `cortex: daemon brain agent=${degradedId} marked DEGRADED — ` +
+                `restart budget exhausted; presence signalled\n`,
+            );
+          },
+        });
+        // Spawn + connect + hello. A spawn/connect failure is logged; the
+        // consumer still registers so a later reload can replace it. The
+        // consumer's runner (the host's runTask) fast-fails not_now until the
+        // host connects, so no task is silently lost.
+        try {
+          await daemonHost.start();
+        } catch (startErr) {
+          process.stderr.write(
+            `cortex: daemon brain host start failed for agent=${agent.id}: ` +
+              `${startErr instanceof Error ? startErr.message : String(startErr)}\n`,
+          );
+        }
+        daemonBrainHosts.push(daemonHost);
+        // `runBrainTask` is unused when daemonHost is set (the consumer binds the
+        // host's runTask), but the field is required — supply the per-task runner
+        // as an inert fallback so the type is satisfied.
+        runBrainTask = makeExecBrainRunner({ run: brain.run, packDir, secrets });
+      } else {
+        runBrainTask = makeExecBrainRunner({ run: brain.run, packDir, secrets });
+      }
 
       const consumer = new BrainConsumer({
         agent: consumerAgent,
         source: systemEventSource,
         runtime,
         runBrainTask,
+        ...(daemonHost !== undefined && { daemonHost }),
         ...(personaText !== undefined && { persona: personaText }),
-        // onAskPrincipal defaults to DenyAllPrincipalGate (B-1 fail-closed —
-        // the surface gate lands in B-2).
+        // onAskPrincipal defaults to DenyAllPrincipalGate (fail-closed). The B-2
+        // SurfacePrincipalGate is wired by the boot path when a live surface +
+        // configured principal identity exist (see the surface-gate wiring).
         // Sovereignty audit-parity by default, mirroring ReviewConsumer (a
         // self-declared modelClass is spoofable until bound to the signing
         // identity, cortex#327).
@@ -4079,6 +4141,16 @@ export async function startCortex(
         brainConsumers.splice(i, 1);
       }
     }
+    // Bot Packs B-2 — the removed/changed agent's daemon brain host (if any) was
+    // already drained by its BrainConsumer.stop() above (which calls
+    // host.drain()); compact it out of the tracking array so a subsequent
+    // shutdown doesn't re-stop a host whose generation is gone. stop() is
+    // idempotent regardless, so this is bookkeeping, not correctness.
+    for (let i = daemonBrainHosts.length - 1; i >= 0; i--) {
+      if (daemonBrainHosts[i]?.agentId === agentId) {
+        daemonBrainHosts.splice(i, 1);
+      }
+    }
   };
 
   // The single reconcile path. Both the fs.watch callback and the handle's
@@ -4682,6 +4754,10 @@ export async function startCortex(
       // defensive emit side). Wired regardless of `mc.enabled` so capability
       // hot-reload tracks presence even on a non-dashboard stack.
       presenceProducerForReload = presenceProducer;
+      // Bot Packs B-2 — publish the producer to the daemon-brain degrade holder
+      // so a `DaemonBrainHost.onDegraded` (restart budget exhausted, at runtime)
+      // can surface the agent via `publishCapabilitiesChanged(agentId, [])`.
+      brainPresenceHolder.producer = presenceProducer;
       console.log(
         `cortex: agent-presence producer started — ${presenceAgents.length} agent(s) announced ` +
           `(stack-local${config.mc.enabled ? " + local registry" : ", mc disabled"}; ` +
@@ -5091,6 +5167,9 @@ export async function startCortex(
       ...adapterCleanup.map((_, i) => `outbound poller stop[${i}]`),
       ...reviewConsumers.map((c, i) => `review-consumer stop[${i}] (agent=${c.agent.id})`),
       ...brainConsumers.map((c, i) => `brain-consumer stop[${i}] (agent=${c.agent.id})`),
+      // Bot Packs B-2 — daemon brain host teardown slots (belt-and-braces; the
+      // consumer drain already drains the host, these are idempotent).
+      ...daemonBrainHosts.map((h, i) => `daemon-brain-host stop[${i}] (agent=${h.agentId})`),
       ...releaseConsumers.map((c, i) => `release-consumer stop[${i}] (agent=${c.agent.id})`),
       ...devConsumers.map((c, i) => `dev-consumer stop[${i}] (agent=${c.agent.id})`),
       "dispatch-listener stop",
@@ -5220,6 +5299,19 @@ export async function startCortex(
           await completeAsync(
             `brain-consumer stop[${i}] (agent=${consumer.agent.id})`,
             consumer.stop(),
+          );
+        }
+      }
+      // Bot Packs B-2 — belt-and-braces: ensure every daemon brain host is torn
+      // down even if its consumer's stop() did not reach the drain (e.g. a host
+      // whose consumer init threw after the host spawned). `stop()` is idempotent
+      // — a host already drained by its consumer above is a no-op.
+      for (let i = 0; i < daemonBrainHosts.length; i++) {
+        const host = daemonBrainHosts[i];
+        if (host) {
+          await completeAsync(
+            `daemon-brain-host stop[${i}] (agent=${host.agentId})`,
+            host.stop(),
           );
         }
       }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2397,14 +2397,18 @@ export async function startCortex(
         // consumer still registers so a later reload can replace it. The
         // consumer's runner (the host's runTask) fast-fails not_now until the
         // host connects, so no task is silently lost.
-        try {
-          await daemonHost.start();
-        } catch (startErr) {
+        // Non-blocking start (sage cortex#1035 round 3): start() resolves on
+        // the socket handshake, so awaiting here would make cortex boot
+        // latency the SUM of every daemon's spawn+auth. The consumer's
+        // runner fast-fails not_now until the host connects (documented
+        // above), so registering the consumer before the handshake settles
+        // loses nothing — failures land in the same stderr path.
+        void daemonHost.start().catch((startErr: unknown) => {
           process.stderr.write(
             `cortex: daemon brain host start failed for agent=${agent.id}: ` +
               `${startErr instanceof Error ? startErr.message : String(startErr)}\n`,
           );
-        }
+        });
         daemonBrainHosts.push(daemonHost);
         consumer = new BrainConsumer({ ...baseConsumerOpts, daemonHost });
       } else {

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2348,9 +2348,28 @@ export async function startCortex(
       // DaemonBrainHost (spawn once, socket-multiplex tasks, supervise + drain);
       // `per-task` (default) keeps the B-1 per-spawn runner. Both feed the SAME
       // BrainConsumer policy seam (the consumer is lifecycle-agnostic — it routes
-      // brain effects through the host hooks identically).
+      // brain effects through the host hooks identically). The lifecycle-specific
+      // runner is mutually exclusive: a daemon agent passes `daemonHost` (no
+      // per-task runner constructed), a per-task agent passes `runBrainTask`.
+      // The `principalGate` is left to the consumer default on BOTH paths:
+      // DenyAllPrincipalGate (B-1 fail-closed — every `ask_principal` denied).
+      // SurfacePrincipalGate (B-2) is IMPLEMENTED + unit-tested but NOT booted
+      // here yet: it needs an adapter inbound reply-bridge (a
+      // PrincipalReplySource fed by a live surface adapter) to observe the
+      // principal's reply, which lands in B-3. Until that bridge exists there is
+      // nothing to construct the gate from, so the boot path leaves the
+      // fail-closed default in place — identity-based approval is NOT live.
+      // Sovereignty audit-parity by default, mirroring ReviewConsumer (a
+      // self-declared modelClass is spoofable until bound to the signing
+      // identity, cortex#327).
+      const baseConsumerOpts = {
+        agent: consumerAgent,
+        source: systemEventSource,
+        runtime,
+        ...(personaText !== undefined && { persona: personaText }),
+      };
       let daemonHost: DaemonBrainHost | undefined;
-      let runBrainTask: ReturnType<typeof makeExecBrainRunner>;
+      let consumer: BrainConsumer;
       if (brain.lifecycle === "daemon") {
         daemonHost = new DaemonBrainHost({
           agentId: agent.id,
@@ -2387,28 +2406,11 @@ export async function startCortex(
           );
         }
         daemonBrainHosts.push(daemonHost);
-        // `runBrainTask` is unused when daemonHost is set (the consumer binds the
-        // host's runTask), but the field is required — supply the per-task runner
-        // as an inert fallback so the type is satisfied.
-        runBrainTask = makeExecBrainRunner({ run: brain.run, packDir, secrets });
+        consumer = new BrainConsumer({ ...baseConsumerOpts, daemonHost });
       } else {
-        runBrainTask = makeExecBrainRunner({ run: brain.run, packDir, secrets });
+        const runBrainTask = makeExecBrainRunner({ run: brain.run, packDir, secrets });
+        consumer = new BrainConsumer({ ...baseConsumerOpts, runBrainTask });
       }
-
-      const consumer = new BrainConsumer({
-        agent: consumerAgent,
-        source: systemEventSource,
-        runtime,
-        runBrainTask,
-        ...(daemonHost !== undefined && { daemonHost }),
-        ...(personaText !== undefined && { persona: personaText }),
-        // onAskPrincipal defaults to DenyAllPrincipalGate (fail-closed). The B-2
-        // SurfacePrincipalGate is wired by the boot path when a live surface +
-        // configured principal identity exist (see the surface-gate wiring).
-        // Sovereignty audit-parity by default, mirroring ReviewConsumer (a
-        // self-declared modelClass is spoofable until bound to the signing
-        // identity, cortex#327).
-      });
       brainConsumers.push(consumer);
 
       // Provision + bind one durable pull consumer per declared capability.


### PR DESCRIPTION
Phase B-2 of #1021 (design `docs/design-bot-packs.md` §5 hello/daemon, §7 hot-swap, §8, §12 decisions). Completes the bot-packs runtime short of arc packaging (B-3) and the Yarrow migration (B-4).

## What
- **`lifecycle: daemon` un-rejected** — long-lived brain per agent via `daemon-brain-host.ts`: Unix-socket protocol transport (logs stay on stdio, §12.1), host→brain `hello` handshake (agent id, persona, protocol version), per-task multiplexing over the existing task_id correlation, task-scoped scratch/secrets discipline unchanged.
- **Supervision** — crash → restart up to `maxRestarts` (healthy-uptime reset), then degraded presence via the existing capability-change presence path; in-flight tasks of a crashed brain → `dispatch.task.failed` (cant_do) under B-1's terminal-publish rules. Generation token prevents a fresh process being mistaken for the crashed one (real bug found+fixed in testing).
- **Hot-swap drain** (§7) — reload of a daemon-brain agent: `shutdown` with deadline, open `ask_principal` gates cancelled past the deadline with a visible `dispatch.task.post` notice + not_now close, SIGTERM → SIGKILL+5s.
- **4 MiB per-task attachment budget** (§12.5) — cumulative inline+scratch, host-enforced for BOTH lifecycles; over → effect_rejected wont_do.
- **`SurfacePrincipalGate`** — identity-based ask_principal: renders the prompt to the task's surface via `dispatch.task.post`, accepts pass/fail ONLY from the configured principal's platform user id (never message-text inference — the pulse#47 class fixed at the host), timeout → fail; bus-only/non-hosted surfaces stay DenyAll fail-closed.

## Honest seams (documented in code)
1. Daemon transport is injectable; tests drive an in-memory `DaemonTransport` double covering protocol/multiplex/supervision/drain — the Bun `listen({unix})` glue sits behind the same seam B-1 uses for spawning. Round-1 fixes later ADDED real-socket auth probes (daemon-socket-auth.test.ts) — the in-memory double covers protocol/supervision/drain; the auth handshake is probed against a real Bun unix socket.
2. `SurfacePrincipalGate` is implemented and tested but NOT booted: cortex.ts constructs DenyAll (fail-closed) unconditionally in B-2 — flipping it on needs the adapter inbound reply-bridge (`PrincipalReplySource`), which is the B-2→B-3 boundary item.

## Evidence
```
bun test (full)   6778 pass / 2 skip / 0 fail (396 files; one mid-session rotation flake cleared on rerun + 5× isolation)
changed-area      144 pass / 0 fail (daemon host, budget, surface gate, brain-consumer, config)
bunx tsc --noEmit clean · vocab gate PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)