### PR TITLE
fix(dispatch): deliver brain posts — adapter_instance in the post wire routing (#1038 follow-up)

### DIFF
--- a/src/brain/protocol.ts
+++ b/src/brain/protocol.ts
@@ -166,6 +166,15 @@ export const TaskSourceSchema = z.object({
   channel: z.string(),
   thread: z.string(),
   user: z.string(),
+  /**
+   * Host-routing metadata (cortex#1038): the adapter instance id the task
+   * arrived on, when the source is a live surface. The brain treats it as
+   * opaque (it never chooses a channel — §5 property 1); cortex uses it to
+   * route a brain `post` back to the originating adapter via the chat
+   * dispatch-sink's `adapter_instance` filter (a bus-originated task has no
+   * adapter, so it is absent then). Optional + ignored by the brain.
+   */
+  adapter_instance: z.string().optional(),
 });
 export type TaskSource = z.infer<typeof TaskSourceSchema>;
 

--- a/src/bus/__tests__/dispatch-events.test.ts
+++ b/src/bus/__tests__/dispatch-events.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { validateEnvelope } from "../myelin/envelope-validator";
+import { readResponseRouting } from "../../adapters/response-routing-delivery";
 import {
   createDispatchTaskAbortedEvent,
   createDispatchTaskCompletedEvent,
@@ -365,6 +366,54 @@ describe("createDispatchTaskPostEvent", () => {
       expect(validateEnvelope(env).ok).toBe(true);
     },
   );
+
+  test("cortex#1038 — adapter_instance source ⇒ WIRE routing the chat sink delivers; absent ⇒ logical shape", () => {
+    // The bug: a brain post's logical {surface,channel,thread} routing is
+    // null to `readResponseRouting` (the chat dispatch-sink's gate), so every
+    // post was dropped. With adapter_instance the post must carry the wire
+    // shape the sink accepts.
+    const live = createDispatchTaskPostEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "yarrow",
+      text: "Composed the flow.",
+      taskSource: {
+        surface: "discord",
+        channel: "chan-snowflake",
+        thread: "thread-snowflake",
+        user: "u1",
+        adapter_instance: "discord-yarrow",
+      },
+    });
+    expect(live.payload).toMatchObject({
+      response_routing: {
+        adapter_instance: "discord-yarrow",
+        channel_id: "chan-snowflake",
+        thread_id: "thread-snowflake",
+      },
+    });
+    // The sink's gate now ACCEPTS it (was null before this fix).
+    expect(readResponseRouting(live)).toEqual({
+      adapter_instance: "discord-yarrow",
+      channel_id: "chan-snowflake",
+      thread_id: "thread-snowflake",
+    });
+    expect(validateEnvelope(live).ok).toBe(true);
+
+    // Bus-originated (no adapter_instance) keeps the logical shape — the
+    // review-sink path — back-compat unchanged.
+    const bus = createDispatchTaskPostEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "yarrow",
+      text: "x",
+      taskSource: { surface: "bus", channel: "c1", thread: "t1", user: "u1" },
+    });
+    expect(bus.payload).toMatchObject({
+      response_routing: { surface: "bus", channel: "c1", thread: "t1" },
+    });
+    expect(readResponseRouting(bus)).toBeNull();
+  });
 
   test("attachment reference is carried when present, omitted otherwise", () => {
     const withAtt = createDispatchTaskPostEvent({

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -695,6 +695,9 @@ export class BrainConsumer {
       channel: source.channel,
       thread: source.thread,
       user: source.user,
+      ...(source.adapter_instance !== undefined && {
+        adapter_instance: source.adapter_instance,
+      }),
     };
     return {
       // `post` — B-1 publishes a `dispatch.task.post` lifecycle envelope (no
@@ -874,11 +877,19 @@ export function deriveTaskSource(envelope: Envelope): TaskSource {
       ? (p.response_routing as Record<string, unknown>)
       : undefined;
   const str = (v: unknown): string => (typeof v === "string" ? v : "");
+  // cortex#1038: a live-surface inbound task carries the adapter instance id
+  // so a brain `post` can route back through the chat dispatch-sink's
+  // `adapter_instance` filter. Absent for bus-originated tasks.
+  const adapterInstance =
+    routing && typeof routing.adapter_instance === "string"
+      ? routing.adapter_instance
+      : undefined;
   return {
     surface: routing && typeof routing.surface === "string" ? routing.surface : "bus",
     channel: routing ? str(routing.channel) : "",
     thread: routing ? str(routing.thread) : "",
     user: p ? str(p.user) : "",
+    ...(adapterInstance !== undefined && { adapter_instance: adapterInstance }),
   };
 }
 
@@ -947,6 +958,12 @@ export function buildBrainTaskPayload(opts: {
   surface: string;
   channel: string;
   thread: string;
+  /**
+   * cortex#1038 — the live-surface adapter instance id. Rides in
+   * `response_routing` so it survives `deriveTaskSource` → the brain `post`,
+   * letting the post reach the originating adapter via the chat dispatch-sink.
+   */
+  adapterInstance?: string;
 }): Record<string, unknown> {
   return {
     text: opts.text,
@@ -956,6 +973,9 @@ export function buildBrainTaskPayload(opts: {
       surface: opts.surface,
       channel: opts.channel,
       thread: opts.thread,
+      ...(opts.adapterInstance !== undefined && {
+        adapter_instance: opts.adapterInstance,
+      }),
     },
   };
 }

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -576,6 +576,15 @@ export interface BrainPostSource {
   thread: string;
   /** The user who triggered the task. */
   user: string;
+  /**
+   * cortex#1038 — the adapter instance id, when the task arrived on a LIVE
+   * surface. Present ⇒ the post emits the WIRE `response_routing`
+   * (`{ adapter_instance, channel_id, thread_id }`) the chat dispatch-sink
+   * routes on, so a brain reply reaches the originating adapter directly.
+   * Absent (bus-originated) ⇒ the logical `{ surface, channel, thread }`
+   * shape (review-sink path) — back-compat unchanged.
+   */
+  adapter_instance?: string;
 }
 
 export interface BrainPostOpts extends DispatchTaskCommonOpts {
@@ -623,13 +632,27 @@ export function createDispatchTaskPostEvent(
   // so the B-2 dispatch sink reads one vocabulary — never a parallel
   // `task_source` (sage cortex#1033 round 3). The triggering user is not part
   // of routing; it rides as its own field.
+  // cortex#1038 — when the task came from a LIVE surface (adapter_instance
+  // present), emit the WIRE routing shape the chat dispatch-sink consumes
+  // (`readResponseRouting` requires `adapter_instance` + `channel_id`); a
+  // brain `post` then reaches the originating adapter directly. Without it
+  // (bus-originated), keep the logical `{ surface, channel, thread }` shape
+  // the review-sink resolves — back-compat unchanged.
+  const responseRouting =
+    opts.taskSource.adapter_instance !== undefined
+      ? {
+          adapter_instance: opts.taskSource.adapter_instance,
+          channel_id: opts.taskSource.channel,
+          ...(opts.taskSource.thread !== "" && { thread_id: opts.taskSource.thread }),
+        }
+      : {
+          surface: opts.taskSource.surface,
+          channel: opts.taskSource.channel,
+          ...(opts.taskSource.thread !== "" && { thread: opts.taskSource.thread }),
+        };
   return buildBaseEnvelope("dispatch.task.post", opts, {
     text: opts.text,
-    response_routing: {
-      surface: opts.taskSource.surface,
-      channel: opts.taskSource.channel,
-      ...(opts.taskSource.thread !== "" && { thread: opts.taskSource.thread }),
-    },
+    response_routing: responseRouting,
     triggered_by: opts.taskSource.user,
     ...(opts.attachment !== undefined && { attachment: opts.attachment }),
   });

--- a/src/bus/surface-principal-gate.ts
+++ b/src/bus/surface-principal-gate.ts
@@ -358,6 +358,12 @@ export function makeDispatchPostRenderer(opts: {
             channel: r.source.channel,
             thread: r.source.thread,
             user: r.source.user,
+            // cortex#1038 — carry the adapter instance so the gate PROMPT
+            // (ask_principal) reaches the originating adapter via the chat
+            // dispatch-sink, same as the brain's own posts.
+            ...(r.source.adapter_instance !== undefined && {
+              adapter_instance: r.source.adapter_instance,
+            }),
           },
         }),
       );

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2518,6 +2518,10 @@ export async function startCortex(
         surface: msg.platform,
         channel: msg.channelId,
         thread,
+        // cortex#1038 — the adapter instance the @-mention arrived on, so the
+        // brain's posts + the gate prompt route back to THIS adapter via the
+        // chat dispatch-sink (which filters on adapter_instance).
+        adapterInstance: msg.instanceId,
       }),
       ...(agent.runtime?.modelClass !== undefined && { modelClass: agent.runtime.modelClass }),
     });


### PR DESCRIPTION
## Symptom
Yarrow (the first bot pack) composed a flow and posted — visible on the bus as `dispatch.task.started → post → post → completed` — but **nothing reached Discord**.

## Root cause
A brain `post` builds `response_routing` in the **logical** shape `{ surface, channel, thread }`. But the chat **dispatch-sink**'s `readResponseRouting` accepts ONLY the **wire** shape `{ adapter_instance, channel_id, thread_id }` — it returns `null` for the logical shape, so every brain post (and the `ask_principal` gate prompt) was silently dropped before the surface. The other sink (review-sink) resolves the logical shape by channel **name** via `resolveLogicalTarget`, but the inbound channel is a Discord **snowflake**, not a name — so that path can't deliver it either. The B-1/B-2 brain-post path was never exercised against a live surface.

## Fix
Thread the originating adapter instance id through and emit the wire shape when present:
- inbound `buildBrainTaskPayload` carries `adapter_instance = msg.instanceId` in `response_routing`.
- `deriveTaskSource` extracts it into `TaskSource.adapter_instance` (optional; the brain treats source as opaque metadata — §5 property 1 preserved, the brain still can't choose a channel).
- `createDispatchTaskPostEvent` emits `{ adapter_instance, channel_id, thread_id }` when present (the dispatch-sink's shape) → the sink delivers; else the logical shape (bus-originated → review-sink path, **back-compat unchanged**).
- the `SurfacePrincipalGate` prompt renderer carries it too, so `ask_principal` reaches the channel.

Gate correlation is unaffected — the `GateReplyRouter` still keys on `(surface, channel, thread)` snowflakes on both the offer and await sides.

## Test
`createDispatchTaskPostEvent` with `adapter_instance` now yields a `response_routing` that `readResponseRouting` **accepts** (was `null` — the dropped-post contract); without it stays logical (`readResponseRouting` null → review-sink path). Full suite 6811 pass / 0 fail; tsc + eslint + carve-outs clean.

## Live / verification scope
What is PROVEN here: the unit test shows `readResponseRouting` now ACCEPTS the post routing (it returned `null` before — the exact reason posts were dropped). What is NOT shown in this diff: a live Discord delivery transcript. The end-to-end proof (composed flow + gate prompt appearing in the channel, then "run it" → run) is the post-deploy acceptance step — it needs the principal to @-mention Yarrow (I cannot post as the principal). Pre-fix live state already confirmed: brain composed + posted to the bus (`dispatch.task.started → post → post → completed`) but nothing reached Discord — consistent with the dropped-routing root cause this fixes.

Follows #1038 (triggering), part of #1021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
