### PR TITLE
fix(render): deliver brain post content — render dispatch.task.post (Yarrow silent fix)

### DIFF
--- a/src/adapters/__tests__/envelope-renderer.test.ts
+++ b/src/adapters/__tests__/envelope-renderer.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
+import { formatEnvelopeAsMarkdown, formatDispatchLifecycle } from "../envelope-renderer";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
 
 function makeEnvelope(overrides: Partial<Envelope> = {}): Envelope {
@@ -135,6 +135,26 @@ describe("formatEnvelopeAsMarkdown — dispatch lifecycle", () => {
       type: "dispatch.task.failed",
       payload: { agent_id: "ivy", error_summary: "claude exited 1" },
     }))).toBe("Ivy failed: claude exited 1");
+  });
+
+  test("renders a brain post's own text verbatim (cortex#1039 follow-up)", () => {
+    // A brain `post` carries its content under payload.text — the composed
+    // flow, the ask_principal prompt, per-step replies. Without rendering it
+    // the sink dropped every brain post on null text, so a bot pack stayed
+    // silent. Empty text → null (nothing to deliver).
+    expect(
+      formatDispatchLifecycle(
+        makeEnvelope({
+          type: "dispatch.task.post",
+          payload: { agent_id: "yarrow", text: "⚖️ Yarrow is frontier-A\n```yaml\nname: F_X\n```" },
+        }),
+      ),
+    ).toBe("⚖️ Yarrow is frontier-A\n```yaml\nname: F_X\n```");
+    expect(
+      formatDispatchLifecycle(
+        makeEnvelope({ type: "dispatch.task.post", payload: { agent_id: "yarrow", text: "  " } }),
+      ),
+    ).toBeNull();
   });
 });
 

--- a/src/adapters/__tests__/envelope-renderer.test.ts
+++ b/src/adapters/__tests__/envelope-renderer.test.ts
@@ -142,14 +142,14 @@ describe("formatEnvelopeAsMarkdown — dispatch lifecycle", () => {
     // flow, the ask_principal prompt, per-step replies. Without rendering it
     // the sink dropped every brain post on null text, so a bot pack stayed
     // silent. Empty text → null (nothing to deliver).
+    // Verbatim — intentional leading/trailing whitespace + final newline are
+    // preserved (sage #1040: trim only gates emptiness, never the output).
+    const body = "  ⚖️ Yarrow is frontier-A\n```yaml\nname: F_X\n```\n";
     expect(
       formatDispatchLifecycle(
-        makeEnvelope({
-          type: "dispatch.task.post",
-          payload: { agent_id: "yarrow", text: "⚖️ Yarrow is frontier-A\n```yaml\nname: F_X\n```" },
-        }),
+        makeEnvelope({ type: "dispatch.task.post", payload: { agent_id: "yarrow", text: body } }),
       ),
-    ).toBe("⚖️ Yarrow is frontier-A\n```yaml\nname: F_X\n```");
+    ).toBe(body);
     expect(
       formatDispatchLifecycle(
         makeEnvelope({ type: "dispatch.task.post", payload: { agent_id: "yarrow", text: "  " } }),

--- a/src/adapters/envelope-renderer.ts
+++ b/src/adapters/envelope-renderer.ts
@@ -75,8 +75,10 @@ export function formatDispatchLifecycle(envelope: Envelope): string | null {
     // Empty text → null (nothing to post). Attachment delivery (the diagram
     // PNG) is a separate sink concern — the flow falls back to fenced mermaid
     // source in `text` when no PNG, so text alone is a complete message.
-    const text = typeof payload.text === "string" ? payload.text.trim() : "";
-    return text.length > 0 ? text : null;
+    // Verbatim: post the brain's text exactly (intentional leading/trailing
+    // whitespace + final newlines preserved); trim ONLY for the empty check.
+    const text = typeof payload.text === "string" ? payload.text : "";
+    return text.trim().length > 0 ? text : null;
   }
 
   if (envelope.type === "dispatch.task.completed") {

--- a/src/adapters/envelope-renderer.ts
+++ b/src/adapters/envelope-renderer.ts
@@ -66,6 +66,19 @@ export function formatDispatchLifecycle(envelope: Envelope): string | null {
     return `${label} is working...`;
   }
 
+  if (envelope.type === "dispatch.task.post") {
+    // cortex#1039 follow-up — a brain `post` carries its OWN content (the
+    // composed flow, the ask_principal prompt, per-step replies) under
+    // `payload.text`. Render that verbatim; without this the sink dropped
+    // every brain post on `text === null` (started/completed/failed were the
+    // only rendered lifecycle types), so a bot pack could never speak.
+    // Empty text → null (nothing to post). Attachment delivery (the diagram
+    // PNG) is a separate sink concern — the flow falls back to fenced mermaid
+    // source in `text` when no PNG, so text alone is a complete message.
+    const text = typeof payload.text === "string" ? payload.text.trim() : "";
+    return text.length > 0 ? text : null;
+  }
+
   if (envelope.type === "dispatch.task.completed") {
     // cortex#491 — full reply when present (chat round-trip), else the
     // dashboard summary label, else a terse default.


### PR DESCRIPTION
## Symptom
Yarrow composed + posted (visible on the bus: `started → post → post → completed`) but **nothing appeared in Discord**, across v5.15.0 (triggering) and v5.15.1 (post routing).

## Diagnosis (live)
1. Direct Discord REST probe with Yarrow's token **posted successfully** → token + channel + Send-Messages permission all fine. Not a Discord problem.
2. Bus capture of the real @-mention showed the post envelope now carries the **correct wire routing** `{ adapter_instance: "yarrow-discord", channel_id, thread_id }` (the v5.15.1 fix works).
3. So routing is right and the bot can post — yet the sink delivers nothing and logs no error.

## Root cause
The dispatch-sink does `const text = formatDispatchLifecycle(envelope); if (text === null) return;`. `formatDispatchLifecycle` renders `started/completed/failed/aborted` but **returns `null` for `dispatch.task.post`** — the brain's actual content post. So every brain post (and the `ask_principal` prompt, per-step replies) was silently dropped on null text. The B-2 surface bridge rendered lifecycle *status*, never the brain's *content*.

## Fix
Render `dispatch.task.post` from `payload.text` verbatim (the composed flow, the gate prompt, etc.). Empty text → null. Diagram-PNG attachment delivery stays a separate sink concern — the composer falls back to fenced mermaid source in `text` when there's no PNG, so text alone is a complete message.

No double-delivery: the dispatch-sink reads wire routing (adapter_instance), the review-sink reads logical routing (surface/channel-name); a brain post carries only the wire shape, so only the dispatch-sink renders it.

## Test
`formatDispatchLifecycle` now returns the post text for `dispatch.task.post` (verbatim; empty → null). renderer + dispatch-sink suites green; tsc + eslint + carve-outs clean.

Completes the brain-triggering chain (#1038 → #1039 → this). Part of #1021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)