### PR TITLE
fix(gate): accept natural-language affirmatives (per-word, negation-aware)

### DIFF
--- a/src/bus/__tests__/surface-principal-gate.test.ts
+++ b/src/bus/__tests__/surface-principal-gate.test.ts
@@ -99,8 +99,31 @@ describe("replyToVerdict", () => {
       expect(replyToVerdict(t)).toBe("pass");
     }
   });
+  test("natural-language affirmatives map to pass (per-word match)", () => {
+    for (const t of [
+      "yes, run the flow",
+      "yes, run it",
+      "approve this reset",
+      "ok go ahead",
+      "Yep — proceed",
+      "confirmed, run it now",
+    ]) {
+      expect(replyToVerdict(t)).toBe("pass");
+    }
+  });
   test("negatives and unrecognised map to fail (fail-closed)", () => {
     for (const t of ["no", "deny", "stop", "maybe", "", "what?"]) {
+      expect(replyToVerdict(t)).toBe("fail");
+    }
+  });
+  test("a negative word anywhere wins, even alongside an affirmative", () => {
+    for (const t of [
+      "no, don't run it", // contains "run"
+      "do not run the flow",
+      "cancel the run",
+      "hold off, don't approve",
+      "yes but not now", // ambiguous → fail-closed
+    ]) {
       expect(replyToVerdict(t)).toBe("fail");
     }
   });

--- a/src/bus/__tests__/surface-principal-gate.test.ts
+++ b/src/bus/__tests__/surface-principal-gate.test.ts
@@ -127,6 +127,20 @@ describe("replyToVerdict", () => {
       expect(replyToVerdict(t)).toBe("fail");
     }
   });
+  test("contracted negatives fail-closed (apostrophe stripped, not split to a bare 't')", () => {
+    // Each contains an affirmative word ("run"/"approve"/"go") — the contraction
+    // MUST still deny, or an explicit refusal would fail-OPEN (sage blocker).
+    for (const t of [
+      "don't run it",
+      "don’t approve", // curly apostrophe
+      "won't run",
+      "can't approve this",
+      "cannot run the flow",
+      "shouldn't go ahead",
+    ]) {
+      expect(replyToVerdict(t)).toBe("fail");
+    }
+  });
 });
 
 describe("principalIdForSurface", () => {

--- a/src/bus/__tests__/surface-principal-gate.test.ts
+++ b/src/bus/__tests__/surface-principal-gate.test.ts
@@ -141,6 +141,16 @@ describe("replyToVerdict", () => {
       expect(replyToVerdict(t)).toBe("fail");
     }
   });
+  test("refusal verbs deny even with an affirmative word present", () => {
+    for (const t of [
+      "refuse to run",
+      "I decline to approve",
+      "veto this run",
+      "dismiss — do not run",
+    ]) {
+      expect(replyToVerdict(t)).toBe("fail");
+    }
+  });
 });
 
 describe("principalIdForSurface", () => {

--- a/src/bus/surface-principal-gate.ts
+++ b/src/bus/surface-principal-gate.ts
@@ -163,6 +163,9 @@ const NEGATIVE = new Set([
   "no", "n", "nope", "nah", "not", "never",
   "deny", "denied", "reject", "rejected", "cancel", "cancelled", "canceled",
   "stop", "abort", "aborted", "halt", "hold", "wait",
+  // Refusal verbs — a reply can negate WITHOUT "no"/"not" ("refuse to run").
+  "refuse", "refused", "refusing", "decline", "declined", "declining",
+  "veto", "vetoed", "nay", "negative", "against", "dismiss", "dismissed",
   // Contraction stems — apostrophes are stripped WITHIN words before tokenizing
   // (don't → dont), so the negation isn't lost as a bare "t".
   "dont", "doesnt", "didnt", "wont", "cant", "cannot",
@@ -170,16 +173,22 @@ const NEGATIVE = new Set([
 ]);
 
 /**
- * Map a principal's reply text to a gate verdict. FAIL-CLOSED: a `pass` requires
- * an affirmative word AND no negative word. An explicit negative ("no", "deny",
- * "don't") fails even alongside an affirmative (ambiguity → deny); an
- * unrecognised reply ("maybe", a question) also fails — the absence of a clear
+ * Map a principal's reply text to a gate verdict. FAIL-CLOSED: `pass` requires a
+ * recognised AFFIRMATIVE word and NO recognised NEGATIVE word. NEGATIVE is
+ * checked first, so a recognised negative in the SAME reply wins over a
+ * co-occurring affirmative ("no, run it" / "refuse to run" → fail). An
+ * unrecognised reply ("maybe", a question) also fails — absence of a clear
  * affirmative IS the deny. Never parses identity.
  *
- * Apostrophes are stripped WITHIN words FIRST (so "don't" → "dont", not "don"
- * + "t") before non-alphanumerics become word separators — otherwise a
- * contracted negative would lose its negation and a phrase like "don't run it"
- * would fail-OPEN on the affirmative "run". This was a real fail-open (sage).
+ * Apostrophes are stripped WITHIN words FIRST ("don't" → "dont", not "don"+"t")
+ * before non-alphanumerics become separators, so a contracted negative keeps
+ * its negation (else "don't run it" would fail-OPEN on the affirmative "run").
+ *
+ * LIMITATION (not exhaustive NLP): both lists are explicit, so an UNLISTED
+ * refusal phrasing that also contains an affirmative word would pass. The
+ * principal is already IDENTITY-verified before this runs (pulse#47), so this
+ * mapping only guards against misreading the PRINCIPAL'S OWN wording, not an
+ * adversary — keep the deny-list current; a bare "yes"/"no" is unambiguous.
  */
 export function replyToVerdict(text: string): GateVerdictValue {
   const words = text
@@ -189,7 +198,7 @@ export function replyToVerdict(text: string): GateVerdictValue {
     .trim()
     .split(/\s+/)
     .filter(Boolean);
-  if (words.some((w) => NEGATIVE.has(w))) return "fail"; // a negative anywhere wins
+  if (words.some((w) => NEGATIVE.has(w))) return "fail"; // recognised negative wins
   if (words.some((w) => AFFIRMATIVE.has(w))) return "pass";
   return "fail";
 }

--- a/src/bus/surface-principal-gate.ts
+++ b/src/bus/surface-principal-gate.ts
@@ -160,8 +160,13 @@ const AFFIRMATIVE = new Set([
   "pass", "confirm", "confirmed", "ack", "proceed", "affirmative",
 ]);
 const NEGATIVE = new Set([
-  "no", "n", "nope", "nah", "not", "dont", "deny", "denied", "reject", "rejected",
-  "cancel", "cancelled", "canceled", "stop", "abort", "aborted", "halt", "hold", "wait", "never",
+  "no", "n", "nope", "nah", "not", "never",
+  "deny", "denied", "reject", "rejected", "cancel", "cancelled", "canceled",
+  "stop", "abort", "aborted", "halt", "hold", "wait",
+  // Contraction stems — apostrophes are stripped WITHIN words before tokenizing
+  // (don't → dont), so the negation isn't lost as a bare "t".
+  "dont", "doesnt", "didnt", "wont", "cant", "cannot",
+  "shouldnt", "wouldnt", "couldnt", "isnt", "arent", "wasnt", "werent", "aint",
 ]);
 
 /**
@@ -169,11 +174,21 @@ const NEGATIVE = new Set([
  * an affirmative word AND no negative word. An explicit negative ("no", "deny",
  * "don't") fails even alongside an affirmative (ambiguity → deny); an
  * unrecognised reply ("maybe", a question) also fails — the absence of a clear
- * affirmative IS the deny. Normalises case, strips punctuation, matches per
- * word; never parses identity.
+ * affirmative IS the deny. Never parses identity.
+ *
+ * Apostrophes are stripped WITHIN words FIRST (so "don't" → "dont", not "don"
+ * + "t") before non-alphanumerics become word separators — otherwise a
+ * contracted negative would lose its negation and a phrase like "don't run it"
+ * would fail-OPEN on the affirmative "run". This was a real fail-open (sage).
  */
 export function replyToVerdict(text: string): GateVerdictValue {
-  const words = text.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().split(/\s+/).filter(Boolean);
+  const words = text
+    .toLowerCase()
+    .replace(/['‘’ʼ`´]/g, "") // strip apostrophes within words: don't → dont
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
   if (words.some((w) => NEGATIVE.has(w))) return "fail"; // a negative anywhere wins
   if (words.some((w) => AFFIRMATIVE.has(w))) return "pass";
   return "fail";

--- a/src/bus/surface-principal-gate.ts
+++ b/src/bus/surface-principal-gate.ts
@@ -143,37 +143,39 @@ export interface GatePromptRenderer {
 // ---------------------------------------------------------------------------
 
 /**
- * Default affirmative replies. Deliberately a small, explicit allow-list rather
- * than fuzzy NLP — a gate verdict is a security decision; an unrecognised reply
- * is NOT a pass. The text is matched ONLY after the identity check passes, so it
- * never carries identity weight (pulse#47).
+ * Affirmative / negative TOKEN allow-lists. Deliberately explicit word lists,
+ * not fuzzy NLP — a gate verdict is a security decision. The text is matched
+ * ONLY after the identity check passes, so it never carries identity weight
+ * (pulse#47).
+ *
+ * Matched per-WORD (not whole-string) so a natural reply like
+ * "yes, run the flow" or "approve this reset" passes, while staying fail-closed:
+ * a negative word ANYWHERE wins, so "no, don't run it" — which contains the
+ * affirmative "run" — still fails.
  */
 const AFFIRMATIVE = new Set([
-  "yes",
-  "y",
-  "approve",
-  "approved",
-  "run it",
-  "run",
-  "go",
-  "ok",
-  "okay",
-  "pass",
-  "confirm",
-  "confirmed",
+  "yes", "y", "yeah", "yep", "yup",
+  "approve", "approved", "approving",
+  "run", "go", "ok", "okay",
+  "pass", "confirm", "confirmed", "ack", "proceed", "affirmative",
+]);
+const NEGATIVE = new Set([
+  "no", "n", "nope", "nah", "not", "dont", "deny", "denied", "reject", "rejected",
+  "cancel", "cancelled", "canceled", "stop", "abort", "aborted", "halt", "hold", "wait", "never",
 ]);
 
 /**
- * Map a principal's reply text to a gate verdict. Affirmative → `pass`; anything
- * else → `fail`. FAIL-CLOSED on ambiguity: an explicit negative ("no", "deny")
- * and an unrecognised reply both fail the same way — a verdict must be an
- * explicit affirmative. There is therefore no separate negative allow-list to
- * maintain (the absence of a `pass` IS the deny). Normalises case + surrounding
- * whitespace; never parses identity.
+ * Map a principal's reply text to a gate verdict. FAIL-CLOSED: a `pass` requires
+ * an affirmative word AND no negative word. An explicit negative ("no", "deny",
+ * "don't") fails even alongside an affirmative (ambiguity → deny); an
+ * unrecognised reply ("maybe", a question) also fails — the absence of a clear
+ * affirmative IS the deny. Normalises case, strips punctuation, matches per
+ * word; never parses identity.
  */
 export function replyToVerdict(text: string): GateVerdictValue {
-  const normalized = text.trim().toLowerCase();
-  if (AFFIRMATIVE.has(normalized)) return "pass";
+  const words = text.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().split(/\s+/).filter(Boolean);
+  if (words.some((w) => NEGATIVE.has(w))) return "fail"; // a negative anywhere wins
+  if (words.some((w) => AFFIRMATIVE.has(w))) return "pass";
   return "fail";
 }
 


### PR DESCRIPTION
## Symptom (live)

```
JC: @Yarrow yes, run the flow
Yarrow: 🛑 Aborted by operator: principal … replied: yes, run the flow
```

The principal approved a composed flow and the gate **aborted** it.

## Cause

`replyToVerdict` matched the reply by **exact whole-string** membership in the affirmative set: `AFFIRMATIVE.has(text.trim().toLowerCase())`. So `"yes, run the flow" !== "yes"` → `fail`. Only a bare "yes"/"run it"/"approve" passed — no natural phrasing.

## Fix

Match **per word**, negation-aware, still fail-closed:
- a `pass` requires an affirmative word **and no negative word**;
- a negative word **anywhere** wins → `"no, don't run it"` (contains the affirmative "run") still fails, `"yes but not now"` fails (ambiguity → deny);
- unrecognised replies still fail (absence of a clear affirmative = deny).

Identity is unchanged and still checked first (pulse#47); the text never carries identity weight.

## Verification

```
$ bun test src/bus 2>&1 | tail -3
 0 fail
Ran 1002 tests across 45 files. [1.67s]

$ bunx tsc --noEmit     # exit 0
$ bunx eslint src/bus/surface-principal-gate.ts src/bus/__tests__/surface-principal-gate.test.ts   # exit 0
```

New tests: natural-language affirmatives pass (`"yes, run the flow"`, `"approve this reset"`, `"confirmed, run it now"`); negation-wins cases fail (`"no, don't run it"`, `"do not run the flow"`, `"cancel the run"`, `"yes but not now"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)