### PR TITLE
feat(mc): #1044 — headless MC mode (db+ingestor, no API server) for pane-of-glass producers

### DIFF
--- a/docs/config-layout/stacks/research.yaml
+++ b/docs/config-layout/stacks/research.yaml
@@ -173,16 +173,34 @@ github:
 # -----------------------------------------------------------------------------
 # mc — Mission Control, in-process (ADR-0005). OPTIONAL; off by default.
 # -----------------------------------------------------------------------------
-# When enabled, the cortex runtime starts the MC server (REST+WS+dashboard) as
-# an in-process module and owns mission-control.db. ONE db per stack is
-# REQUIRED: the hook cursor lives beside the db, so two stacks sharing a
-# dbPath would also share cursor state. Leave dbPath empty to get the per-slug
-# default (~/.local/share/cortex/mc/{slug}/mission-control.db).
+# When enabled, the cortex runtime starts the MC embed in-process and owns
+# mission-control.db. ONE db per stack is REQUIRED: the hook cursor lives beside
+# the db, so two stacks sharing a dbPath would also share cursor state. Leave
+# dbPath empty to get the per-slug default
+# (~/.local/share/cortex/mc/{slug}/mission-control.db).
+#
+# #1044 — producer/server split. The embed has two halves:
+#   * the PRODUCER — initDatabase + the ingestor (HookStreamPoller) — always
+#     runs when mc.enabled, populating mission-control.db from this stack's
+#     cc-events.
+#   * the SERVER — the REST+WS HTTP listener + dashboard — gated by
+#     `server.enabled` below.
+# A lean stack (work/halden) runs HEADLESS (server.enabled: false): it WRITES
+# its db cheaply for the pane-of-glass (#1008) to read, but binds no port and
+# serves no dashboard. The ONE pane-serving stack runs FULL (server.enabled:
+# true, the default) and reads every sibling's db.
 mc:
-  enabled: false                   # flip true on the stack that hosts your local pane
+  enabled: false                   # flip true on EVERY stack you want visible on the pane
   dbPath: ""                       # empty = per-slug default; set explicitly to adopt an existing db
   port: 0                          # 0 = MC default (8767); set when running panes for several stacks
   configPath: ""                   # optional MC yaml for hooks/ws/log tuning (db/port ignored when embedded)
+  # #1044 — HTTP/WS server + dashboard. DEFAULT ON (full MC). Set enabled:false
+  # for HEADLESS mode: db + ingestor only, NO port bound, NO dashboard. Use
+  # headless on producer-only stacks (work/halden) so they write their db for
+  # the pane-of-glass without serving a pane; keep it ON (or omit) on the single
+  # stack that hosts your local pane. Only meaningful when mc.enabled is true.
+  server:
+    enabled: true                  # false = headless (db + ingestor, no HTTP server)
   # P-14 U0.1 — Tier-3 sideband endpoint (signal cortex-sideband.md §2/§3/§8).
   # MC proxies /api/observability/* to this base URL SERVER-SIDE; the browser
   # only ever talks to MC. LOOPBACK-ENFORCED: the sideband is a local-only

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -141,7 +141,7 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
       encryption: { payload: "off", at_rest: "off" },
       transport: { mtls: "off" },
     },
-    mc: { enabled: false, configPath: "", dbPath: "", port: 0, sideband: "http://127.0.0.1:9092", aggregateLocalStacks: { enabled: true, dbRead: true, configRoot: "", stacks: [] } },
+    mc: { enabled: false, configPath: "", dbPath: "", port: 0, sideband: "http://127.0.0.1:9092", server: { enabled: true }, aggregateLocalStacks: { enabled: true, dbRead: true, configRoot: "", stacks: [] } },
     cockpit: {
       enabled: false,
       docsDir: "docs",

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -127,6 +127,7 @@ const TEST_CONFIG: AgentConfig = {
     dbPath: "",
     port: 0,
     sideband: "http://127.0.0.1:9092",
+    server: { enabled: true },
     aggregateLocalStacks: { enabled: true, dbRead: true, configRoot: "", stacks: [] },
   },
   networksDir: "./networks",

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -720,6 +720,8 @@ describe("AgentConfigSchema.mc (MC-I1.S1)", () => {
       port: 0,
       // P-14 U0.1 — sideband defaults to the contract loopback bind.
       sideband: "http://127.0.0.1:9092",
+      // #1044 — the HTTP server defaults ON (full MC); headless sets it false.
+      server: { enabled: true },
       // #989 — local-stack aggregation defaults ON; discovery is a no-op on a
       // single-stack box (finds no siblings).
       // #1008 — dbRead pane-of-glass aggregation defaults ON alongside `enabled`.
@@ -898,6 +900,38 @@ describe("mc.sideband (P-14 U0.1)", () => {
       }).mc.aggregateLocalStacks;
       expect(agentParsed).toEqual(block);
       expect(cortexParsed).toEqual(block);
+    });
+
+    // #1044 — mc.server.enabled is on the SHARED McSchema (headless MC mode:
+    // run db+ingestor, skip the HTTP server). BOTH config shapes must parse it
+    // identically (the #877/#879 lesson) or a headless work/halden stack on the
+    // config-split shape would silently keep its server flag stripped.
+    test("BOTH schemas default mc.server.enabled to true (full mode)", () => {
+      const fromAgent = AgentConfigSchema.parse(minAgentConfig()).mc.server;
+      const fromCortex = CortexConfigSchema.parse(minConfig()).mc.server;
+      const expected = { enabled: true };
+      expect(fromAgent).toEqual(expected);
+      expect(fromCortex).toEqual(expected);
+    });
+
+    test("BOTH schemas parse an explicit mc.server.enabled:false (headless) identically", () => {
+      const fromAgent = AgentConfigSchema.parse(
+        minAgentConfig({ server: { enabled: false } }),
+      ).mc.server;
+      const fromCortex = CortexConfigSchema.parse({
+        ...minConfig(),
+        mc: { server: { enabled: false } },
+      }).mc.server;
+      const expected = { enabled: false };
+      expect(fromAgent).toEqual(expected);
+      expect(fromCortex).toEqual(expected);
+    });
+
+    test("empty mc block ({}) → server.enabled defaults true on BOTH schemas", () => {
+      expect(AgentConfigSchema.parse(minAgentConfig({})).mc.server.enabled).toBe(true);
+      expect(
+        CortexConfigSchema.parse({ ...minConfig(), mc: {} }).mc.server.enabled,
+      ).toBe(true);
     });
   });
 });

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -399,6 +399,27 @@ export const McSchema = z.object({
    */
   sideband: z.string().default(DEFAULT_SIDEBAND_URL),
   /**
+   * #1044 — headless MC mode (producer/server split). When `mc.enabled`, the
+   * embed always runs `initDatabase` + the `HookStreamPoller` INGESTOR (so the
+   * stack's `mission-control.db` is populated from its cc-events). This sub-flag
+   * gates ONLY the HTTP/WS server (`startServer`) + the live dashboard surface:
+   *
+   *   - `server.enabled: true`  (DEFAULT) → FULL MC — db + ingestor + HTTP server
+   *     + dashboard, byte-identical to pre-#1044. The ONE pane-serving stack
+   *     (meta-factory) runs this and reads every sibling stack's db (#1008).
+   *   - `server.enabled: false` → HEADLESS MC — db + ingestor only, NO port
+   *     bound, NO dashboard. A lean producer stack (work/halden) runs this so it
+   *     cheaply WRITES its db for the pane-of-glass to read, without serving one.
+   *
+   * Only meaningful when `mc.enabled` is true (an `mc.enabled: false` stack runs
+   * no embed at all). Default ON preserves every existing deployment's behaviour.
+   */
+  server: z
+    .object({
+      enabled: z.boolean().default(true),
+    })
+    .default(emptyDefault()),
+  /**
    * #989 part-1 — LOCAL same-principal stack aggregation on the Network view.
    *
    * When `enabled`, the dashboard-serving daemon auto-discovers the principal's
@@ -493,6 +514,12 @@ export const McSchema = z.object({
   dbPath: val.dbPath ?? "",
   port: val.port ?? 0,
   sideband: val.sideband ?? DEFAULT_SIDEBAND_URL,
+  // #1044 — re-apply the nested default ({} from `.default(emptyDefault())`
+  // would leave `enabled` undefined on the all-defaults parse path). The `??`
+  // chain is load-bearing, same as `aggregateLocalStacks` below.
+  server: {
+    enabled: val.server?.enabled ?? true,
+  },
   // #989 — re-apply the nested default ({} from `.default(emptyDefault())`
   // would otherwise leave the inner fields undefined). The `??` chain is
   // load-bearing for the all-defaults parse path, same as the leaves above.

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -4781,10 +4781,20 @@ export async function startCortex(
       }
     }
     try {
+      // #1044 — headless MC mode (producer/server split). `mc.server.enabled`
+      // false ⇒ run db + ingestor only, SKIP the HTTP/WS server. A lean stack
+      // (work/halden) WRITES its `mission-control.db` for the pane-of-glass
+      // (#1008) to read, without binding a port or serving a dashboard. The
+      // db-read aggregation (which SERVES the pane) is full-mode-only, so the
+      // `localAggregation` getter only resolves a context on a server stack
+      // (`siblingResolveOpts` is computed below under the same `aggCfg` gate,
+      // independent of headless — a headless stack simply doesn't serve).
+      const mcHeadless = !config.mc.server.enabled;
       mcHandle = await startMissionControl({
         configPath: config.mc.configPath || undefined,
         dbPath,
         port: config.mc.port,
+        ...(mcHeadless ? { headless: true } : {}),
         agentPresence: () => presenceViewForApi,
         // #1008 — DB-read pane-of-glass aggregation. The getter returns a context
         // only when discovery produced a resolve-opts (dbRead on); otherwise null
@@ -4798,7 +4808,13 @@ export async function startCortex(
         sidebandUrl: config.mc.sideband,
       });
       mcDb = mcHandle.db;
-      console.log(`cortex: Mission Control embed listening on http://localhost:${mcHandle.port} — db ${dbPath}`);
+      // #1044 — headless mode binds no port (`mcHandle.port === null`); log the
+      // producer-only state honestly instead of an unreachable localhost URL.
+      if (mcHandle.port !== null) {
+        console.log(`cortex: Mission Control embed listening on http://localhost:${mcHandle.port} — db ${dbPath}`);
+      } else {
+        console.log(`cortex: Mission Control embed HEADLESS (db + ingestor, no HTTP server) — db ${dbPath}`);
+      }
 
       // MC-I1.S4/S6 (ADR-0005 §3/§4) — register the bus→MC projection renderer.
       // The seam is a surface-router renderer (§4) with a single project()
@@ -4820,10 +4836,19 @@ export async function startCortex(
       // makes failed_dispatch attention work whenever `mc.enabled`, independent
       // of `cockpit.enabled` (it's event-driven, not state-derived). The
       // deep-link for a session-anchored item is the dashboard drill-down route.
+      // #1044 — headless mode binds no port. Fall back to a non-routable
+      // sentinel so deep-links are well-formed but obviously not a live pane;
+      // an explicit `grove.baseUrl` (the pane-serving host) still wins. A
+      // headless producer's attention items deep-link into the SERVING stack's
+      // pane via `grove.baseUrl`, not its own absent port.
       const mcBaseUrl =
-        config.grove.baseUrl !== "" ? config.grove.baseUrl : `http://localhost:${mcHandle.port}`;
+        config.grove.baseUrl !== ""
+          ? config.grove.baseUrl
+          : mcHandle.port !== null
+            ? `http://localhost:${mcHandle.port}`
+            : "http://localhost";
       router.register(
-        createDispatchProjectionRenderer(mcDb, mcHandle.wsRegistry, {
+        createDispatchProjectionRenderer(mcDb, mcHandle.wsRegistry ?? undefined, {
           stackId: derivedStack.stack,
           publishDelta: async (delta) => {
             await publishReconcileDelta(
@@ -4847,7 +4872,7 @@ export async function startCortex(
       // hub-emitted — on a non-hub stack the renderer simply never receives
       // those subjects, so the tab's federation/transport sections stay honestly
       // empty (no synthesized rows).
-      router.register(createObservabilityProjectionRenderer(mcDb, mcHandle.wsRegistry));
+      router.register(createObservabilityProjectionRenderer(mcDb, mcHandle.wsRegistry ?? undefined));
       console.log("cortex: Mission Control observability projection renderer registered (signal + collector + federation + transport)");
     } catch (err) {
       console.error("cortex: Mission Control embed startup error (non-fatal):", err instanceof Error ? err.message : err);
@@ -4981,7 +5006,12 @@ export async function startCortex(
       // (`mcHandle` non-null); on a registry-without-embed boot the holder stays
       // null and there are no WS clients to notify.
       presenceViewForApi = presenceRegistryHandle.registry;
-      if (mcHandle !== null) {
+      // #1044 — the WS broadcast needs a live registry. In HEADLESS mode the
+      // embed binds no server, so `mcHandle.wsRegistry` is null (no clients to
+      // notify); skip the broadcast subscription entirely. The registry still
+      // CONSUMES presence (feeds `/api/agents` on a server stack), but a
+      // producer-only stack has no pane to push to.
+      if (mcHandle?.wsRegistry != null) {
         const broadcastWsRegistry = mcHandle.wsRegistry;
         presenceBroadcastSub = presenceRegistryHandle.registry.onChange((key, record) => {
           broadcastWsRegistry.broadcast({
@@ -5095,7 +5125,10 @@ export async function startCortex(
       // `mcDb` (the projection target); on the mc.enabled boot it is non-null.
       if (mcDb !== null) {
         const observabilityFoldDb = mcDb;
-        const observabilityFoldWs = mcHandle?.wsRegistry;
+        // #1044 — null in headless mode (no server ⇒ no WS clients). The
+        // projection's broadcast is a no-op on `undefined`; coalesce so the
+        // type matches `WsClientRegistry | undefined`.
+        const observabilityFoldWs = mcHandle?.wsRegistry ?? undefined;
         federatedObservabilityHandle = await startFederatedObservabilityFold({
           runtime,
           // The injected projection write — bus/ never imports surface/mc/, so
@@ -5228,7 +5261,16 @@ export async function startCortex(
     const cockpitDb = mcDb;
     const [repoOwner, repoName] = config.cockpit.repo.split("/");
     const defaultRepo = repoOwner && repoName ? { owner: repoOwner, repo: repoName } : undefined;
-    const baseUrl = config.grove.baseUrl !== "" ? config.grove.baseUrl : `http://localhost:${mcHandle?.port ?? 8767}`;
+    // #1044 — in headless mode `mcHandle.port` is null (no server). An explicit
+    // `grove.baseUrl` (the pane-serving host) wins; otherwise use the bound port
+    // when present, falling back to a portless localhost rather than a
+    // misleading fixed 8767 that nothing is listening on.
+    const baseUrl =
+      config.grove.baseUrl !== ""
+        ? config.grove.baseUrl
+        : mcHandle?.port != null
+          ? `http://localhost:${mcHandle.port}`
+          : "http://localhost";
     // Resolve docsDir to an absolute path so the ingest doesn't depend on the
     // launchd plist's CWD (which isn't guaranteed to be the repo root). Warn
     // once at startup if it's missing rather than only failing every tick.

--- a/src/surface/mc/__tests__/embed.test.ts
+++ b/src/surface/mc/__tests__/embed.test.ts
@@ -82,9 +82,12 @@ describe("startMissionControl (embed)", () => {
     // bus→MC projection renderer can broadcast `mc.projection` refresh signals
     // to live dashboard clients. It must be the SAME registry the server's
     // hooks/API use (broadcast() callable, starts with zero clients).
-    expect(handle.wsRegistry).toBeDefined();
-    expect(typeof handle.wsRegistry.broadcast).toBe("function");
-    expect(handle.wsRegistry.size).toBe(0);
+    // Full mode: the registry is live (non-null). Headless (#1044) sets it null;
+    // the dedicated headless test asserts that path.
+    expect(handle.wsRegistry).not.toBeNull();
+    const wsRegistry = handle.wsRegistry!;
+    expect(typeof wsRegistry.broadcast).toBe("function");
+    expect(wsRegistry.size).toBe(0);
   });
 
   it("releases the port on stop()", async () => {
@@ -117,6 +120,106 @@ describe("startMissionControl (embed)", () => {
       // port omitted → falls back to the yaml's port
     });
     expect(handle.port).toBeGreaterThan(0);
+    expect((await fetch(`http://127.0.0.1:${handle.port}/health`)).ok).toBe(true);
+  });
+
+  // ---- #1044 — headless MC mode (db + ingestor, NO HTTP server) ----
+  // A lean producer stack runs initDatabase + the HookStreamPoller ingestor so
+  // its mission-control.db is populated for the pane-of-glass (#1008) to read,
+  // but binds NO port and serves NO dashboard.
+
+  it("headless: boots db + ingestor with NO server — port is null, no listener bound", async () => {
+    const dbPath = join(tmpDir, "data", "mission-control.db");
+    handle = await startMissionControl({
+      configPath: writeMcYaml(),
+      dbPath,
+      headless: true,
+    });
+
+    // No HTTP listener: port is null headless.
+    expect(handle.port).toBeNull();
+    // No wsRegistry headless (no clients to broadcast to).
+    expect(handle.wsRegistry).toBeNull();
+
+    // The db still lands at the requested path, with the cursor BESIDE it — the
+    // ingestor's home — so the producer writes exactly like a full stack.
+    expect(existsSync(dbPath)).toBe(true);
+    const cursorPath = join(dirname(dbPath), "mc-hook-cursor.json");
+    expect(dirname(cursorPath)).toBe(dirname(dbPath));
+
+    // The handle exposes the live, writable db handle.
+    expect(handle.db).toBeDefined();
+    expect(() => handle!.db.query("SELECT 1").get()).not.toThrow();
+  });
+
+  it("headless: the ingestor populates the db from raw cc-events (same as full mode)", async () => {
+    const dbPath = join(tmpDir, "data", "mission-control.db");
+    const rawEventsDir = join(tmpDir, "events", "raw");
+    mkdirSync(rawEventsDir, { recursive: true });
+    const cfgPath = join(tmpDir, "mc.yaml");
+    // Fast poll so the test doesn't wait long for the ingestor tick.
+    writeFileSync(
+      cfgPath,
+      `port: 0\nhooks:\n  rawEventsDir: ${rawEventsDir}\n  pollInterval: 20\n`,
+    );
+
+    handle = await startMissionControl({ configPath: cfgPath, dbPath, headless: true });
+    expect(handle.port).toBeNull();
+
+    // Emit a hook event for an unknown cc_session_id — the ingestor (#856)
+    // auto-registers it as a `local.observed` session row. Mirror the
+    // RawHookEvent shape the EventLogger writes to ~/.claude/events/raw/.
+    const ccSessionId = "headless-sess-1";
+    const line = JSON.stringify({
+      event_id: "evt-1",
+      event_type: "SessionStart",
+      timestamp: new Date().toISOString(),
+      session_id: ccSessionId,
+      agent_id: "test-agent",
+      agent_name: "Test Agent",
+      source: { hook: "SessionStart" },
+      payload: {},
+    });
+    writeFileSync(join(rawEventsDir, "events.jsonl"), line + "\n");
+
+    // Wait for the ingestor to pick the line up (poll every 20ms). The row is
+    // keyed by cc_session_id (its `id` is generated).
+    let row: unknown = null;
+    for (let i = 0; i < 100; i++) {
+      row = handle.db
+        .query("SELECT id FROM sessions WHERE cc_session_id = ?")
+        .get(ccSessionId);
+      if (row) break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(row).not.toBeNull();
+  });
+
+  it("headless: stop() tears down cleanly (db closed, no port to release)", async () => {
+    const dbPath = join(tmpDir, "data", "mission-control.db");
+    handle = await startMissionControl({
+      configPath: writeMcYaml(),
+      dbPath,
+      headless: true,
+    });
+    await handle.stop();
+    handle = null; // prevent afterEach double-stop
+
+    // The db handle was closed: we can reopen + delete it cleanly.
+    const reopened = new Database(dbPath, { readwrite: true });
+    expect(() => reopened.query("PRAGMA user_version").get()).not.toThrow();
+    reopened.close();
+    expect(() => rmSync(dbPath, { force: true })).not.toThrow();
+  });
+
+  it("full mode is unchanged when headless is omitted (regression — server on, port bound)", async () => {
+    handle = await startMissionControl({
+      configPath: writeMcYaml(),
+      dbPath: join(tmpDir, "data", "mission-control.db"),
+      // headless omitted → full mode (server on)
+    });
+    expect(handle.port).toBeGreaterThan(0);
+    expect(handle.wsRegistry).not.toBeNull();
     expect((await fetch(`http://127.0.0.1:${handle.port}/health`)).ok).toBe(true);
   });
 

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -27,15 +27,25 @@ import type { LocalAggregationProvider } from "./local-aggregation/sibling-db-re
 
 export interface MissionControlHandle {
   db: Database;
-  port: number;
+  /**
+   * The bound HTTP listen port, or `null` in HEADLESS mode (#1044) where no
+   * server is started. Callers that build a dashboard base URL (the cockpit
+   * loop, the projection deep-links) MUST tolerate `null` — a headless
+   * producer stack writes its db but serves no pane.
+   */
+  port: number | null;
   /**
    * The live WebSocket client registry (MC-I1.S6, #848). Exposed so the bus→MC
    * projection renderer can broadcast `mc.projection` refresh signals to live
    * dashboard clients on a projected mutation — closing the S4 "projection
    * writes bypass WS fan-out" gap. The cockpit/API mutation paths reach the
    * SAME registry; the projection reuses the existing broadcast helpers.
+   *
+   * `null` in HEADLESS mode (#1044): no server ⇒ no clients to broadcast to.
+   * The projection renderers already accept an optional/absent registry (their
+   * broadcast becomes a no-op), so downstream wiring passes `?? undefined`.
    */
-  wsRegistry: WsClientRegistry;
+  wsRegistry: WsClientRegistry | null;
   stop(): Promise<void>;
 }
 
@@ -50,6 +60,17 @@ export interface StartMissionControlOptions {
   dbPath: string;
   /** Listen port. `> 0` overrides the MC yaml's port; otherwise the yaml's port (default 8767) wins. */
   port?: number;
+  /**
+   * #1044 — HEADLESS mode (producer/server split). When `true`, the embed runs
+   * `initDatabase` + the `HookStreamPoller` INGESTOR (the db gets populated from
+   * the stack's cc-events) but SKIPS `startServer` — no HTTP/WS listener, no
+   * dashboard, no ProcessManager (which only serves the API's session-control
+   * endpoints, never the ingestor). The returned handle's `port` and
+   * `wsRegistry` are both `null`. A lean producer stack (work/halden) uses this
+   * so the pane-of-glass (#1008) can read its db without it serving a pane.
+   * Default (omitted/false) → FULL mode, byte-identical to pre-#1044.
+   */
+  headless?: boolean;
   /**
    * G-1114.B.4 — lazy accessor for the stack-local agent-presence registry
    * view (serves `GET /api/agents`). A GETTER because the registry boots AFTER
@@ -110,6 +131,38 @@ export async function startMissionControl(
   // unhandled throw here would otherwise leak the db handle — and the bound
   // socket — for the whole daemon lifetime (e.g. EADDRINUSE on a busy fixed port).
   const db = initDatabase(config.db.path);
+
+  // #1044 — HEADLESS path: db + ingestor only, NO server. The ingestor (the
+  // `HookStreamPoller`) is what populates the db from the stack's cc-events, so
+  // a producer stack runs it identically to a full stack — it just doesn't
+  // serve a pane. No ProcessManager (it only backs the API's session-control
+  // endpoints, never the ingestor); no wsRegistry (no clients to broadcast to);
+  // no port (nothing bound). Built with the same incremental-teardown discipline
+  // so a poller-construction failure closes the db rather than leaking it.
+  if (opts.headless === true) {
+    let headlessPoller: HookStreamPoller | null = null;
+    try {
+      // wsRegistry omitted → the ingestor's WS broadcasts are no-ops (the poller
+      // already guards every broadcast on `if (this.wsRegistry)`).
+      headlessPoller = new HookStreamPoller(db, config.hooks);
+      headlessPoller.start();
+
+      const startedPoller = headlessPoller;
+      // require-await: the contract is async (callers `await handle.stop()`);
+      // the headless teardown has nothing to await (no server, no ProcessManager).
+      // eslint-disable-next-line @typescript-eslint/require-await
+      const stop = async (): Promise<void> => {
+        startedPoller.stop();
+        db.close();
+      };
+      return { db, port: null, wsRegistry: null, stop };
+    } catch (err) {
+      headlessPoller?.stop();
+      db.close();
+      throw err;
+    }
+  }
+
   let serverCtx: ReturnType<typeof startServer> | null = null;
   let hookPoller: HookStreamPoller | null = null;
   try {


### PR DESCRIPTION
## The producer/server split

The pane-of-glass (approach C, #1008, deployed) reads each LOCAL stack's `mission-control.db`. But a stack only WRITES a db if it runs the FULL MC embed (`mc.enabled` → `startMissionControl` = initDatabase + ingestor + **HTTP server** + dashboard, all welded together). Lean stacks (work/halden, no dashboard) wrote nothing → invisible on the pane.

This PR decouples the two halves of the embed:

- **PRODUCER** — `initDatabase` + the `HookStreamPoller` INGESTOR. Always runs when `mc.enabled`; populates `mission-control.db` from the stack's cc-events.
- **SERVER** — the REST/WS HTTP listener + dashboard. Now gated behind a config flag.

A lean stack runs **HEADLESS** (producer only): it WRITES its db cheaply for the pane to read, but binds no port and serves no dashboard. The ONE pane-serving stack (meta-factory) runs FULL and reads every sibling's db via approach C — unchanged.

## Config flag shape + default

Chose **`mc.server: { enabled: boolean }`, default `true`** (over `mc.headless`). Rationale: cleanest "full = server on; headless = server off" semantic, mirrors the existing nested-object pattern (`mc.aggregateLocalStacks`), reads naturally (`server.enabled: false` = "don't run the server"), and leaves room for future server-scoped knobs.

- `mc.server.enabled: true` (DEFAULT) → FULL MC — byte-identical to pre-#1044.
- `mc.server.enabled: false` → HEADLESS — db + ingestor only, no port, no dashboard.
- Only meaningful when `mc.enabled` is true.

Lives on the **SHARED `McSchema`** (`src/common/types/config.ts`), so both `AgentConfigSchema` (legacy bot.yaml) and `CortexConfigSchema` (config-split) parse it identically — the #877/#879 P0 parity lesson. Parity asserted by new tests. Documented in `docs/config-layout/stacks/research.yaml`.

## ProcessManager-headless decision

**Headless SKIPS ProcessManager.** Investigated: `ProcessManager` is a registry of CC child processes spawned by the API's session-control endpoints (`/api/sessions`, handoff/abandon/requeue). It is only ever passed into `startServer` (→ `ApiDeps`). The ingestor (`HookStreamPoller`), the db, and `ingestEvents`/`registerOrphanSession` have **zero** dependency on it (verified by grep across `hooks/`, `db/`). With no server there are no session-control endpoints, so headless constructs no ProcessManager.

## Null-safety audit of mcHandle uses

`MissionControlHandle.port` → `number | null`; `.wsRegistry` → `WsClientRegistry | null` (both null headless). Every downstream site made null-safe:

| Site (`src/cortex.ts`) | Treatment |
|---|---|
| `mcHandle.port` "listening on …" boot log | branch: headless logs "HEADLESS (db + ingestor, no HTTP server)" |
| `mcBaseUrl` (failed-dispatch deep-links) | `grove.baseUrl` wins; else port-when-present, else portless `http://localhost` |
| `createDispatchProjectionRenderer(mcDb, mcHandle.wsRegistry, …)` | `?? undefined` (renderer already accepts optional wsRegistry — broadcast no-ops) |
| `createObservabilityProjectionRenderer(mcDb, mcHandle.wsRegistry)` | `?? undefined` |
| presence WS broadcast `if (mcHandle !== null)` | tightened to `if (mcHandle?.wsRegistry != null)` — skips broadcast headless |
| federated observability fold `observabilityFoldWs = mcHandle?.wsRegistry` | `?? undefined` |
| cockpit `baseUrl` (`mcHandle?.port ?? 8767`) | `grove.baseUrl` → port-when-present → portless localhost (no misleading 8767) |
| `mcHandle?.stop()` (drain) | already optional-chained |

The projection renderers + `projectObservability` were ALREADY designed to treat an absent `wsRegistry` as a no-op broadcast ("omitted → broadcast is a no-op for headless/test") — this PR just feeds that path.

## No-regression evidence

- A FULL stack is byte-identical: same port bound, same db, same ingestor, same pane-of-glass aggregation, same projection/presence WS fan-out. Covered by the existing embed `/health` + port-release tests (still green) plus a new explicit "full mode unchanged when headless omitted" regression test.
- A HEADLESS stack: db created + writable, ingestor populates it identically (new test feeds a raw cc-event and asserts the auto-registered session row lands), `port` is null (no listener bound), `wsRegistry` null, clean `stop()`.
- The presence PRODUCER is already decoupled from `mc.enabled` (#1003/#1007), so a headless stack still publishes its presence — independent of this PR.
- Approach C (#1008 sibling-db-reader) needs **no change** — it already reads sibling dbs; this just makes lean stacks HAVE one.

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun test` — **6825 pass, 0 fail** (P0 shared-schema parity green; +7 new tests)
- `scripts/check-carveouts.sh` — PASS (vocab gate: new prose uses "principal", not "operator")

## Rollout

After merge + deploy (`arc upgrade Cortex`): set `mc.enabled: true` + `mc.server: { enabled: false }` on the work/halden stacks → they write their dbs → meta-factory's pane reads them → all local stacks render with sessions. Closes the pane-of-glass saga (#989/#1008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)