### PR TITLE
chore: bump to v5.17.0 — headless MC mode (#1044)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.16.0"
+version: "5.17.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release for headless MC (#1046) — the producer/server split that lets lean stacks write a mission-control.db for the pane-of-glass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)