### PR TITLE
fix(mc): #1048 — move idx_observability_origin out of SCHEMA_SQL (existing-DB boot crash, #961 class)

### DIFF
--- a/src/surface/mc/__tests__/u3-3-observability-origin-migration.test.ts
+++ b/src/surface/mc/__tests__/u3-3-observability-origin-migration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * P-14 U3.3 (#937) — existing pre-U3.3 observability DB migration regression.
+ *
+ * The origin-badge columns (`origin_kind` / `origin_peer`) are ADDED to an
+ * already-initialised local DB by COLUMN_ADD_MIGRATIONS. This test proves
+ * `initDatabase` survives a faithful PRE-U3.3 `observability_events` table --
+ * the shape the running U2.1 stacks carry (no origin_kind/origin_peer yet).
+ *
+ * REGRESSION GUARD (#1048, the #961/ST-P0 bug class reintroduced by U3.3): the
+ * `CREATE INDEX idx_observability_origin ON observability_events(origin_kind,
+ * origin_peer)` statement must NOT live in SCHEMA_SQL -- init.ts runs the full
+ * SCHEMA_SQL loop BEFORE COLUMN_ADD_MIGRATIONS adds those columns, so on an
+ * existing DB it references columns that do not yet exist (`no such column:
+ * origin_kind`), and initDatabase aborts so the MC embed cannot open its DB
+ * ("Mission Control embed startup error (non-fatal): no such column:
+ * origin_kind"). The index belongs ONLY in the COLUMN_ADD_MIGRATIONS post[]
+ * arrays (which run AFTER the ALTERs and unconditionally, so fresh DBs stay
+ * covered too). CI was green only because every other test uses a FRESH DB
+ * where the columns exist from CREATE TABLE.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { SCHEMA_SQL } from "../db/schema";
+import { initDatabase } from "../db/init";
+
+// The pre-U3.3 observability_events shape: exactly the U2.1 columns the running
+// stacks carry, BEFORE the U3.3 origin-badge columns were added. Mirrors the
+// observability_events CREATE TABLE in SCHEMA_SQL minus origin_kind/origin_peer.
+const OLD_OBSERVABILITY = `CREATE TABLE IF NOT EXISTS observability_events (
+  id TEXT PRIMARY KEY,
+  envelope_id TEXT NOT NULL UNIQUE,
+  family TEXT NOT NULL
+    CHECK(family IN ('signal','collector','federation','transport')),
+  type TEXT NOT NULL,
+  stack_id TEXT,
+  summary TEXT,
+  payload TEXT NOT NULL DEFAULT '{}',
+  timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+)`;
+
+/**
+ * Build a faithful pre-U3.3 DB: every table from SCHEMA_SQL EXCEPT
+ * `observability_events` (replaced by its OLD shape), and crucially WITHOUT
+ * applying any COLUMN_ADD_MIGRATIONS — so the origin-badge columns are
+ * genuinely absent, the way an already-running U2.1 stack's DB is before this
+ * PR lands.
+ *
+ * The SCHEMA_SQL index statement that references the not-yet-existing origin
+ * columns is the very thing under test — so when building the seed we skip any
+ * index that targets origin_kind/origin_peer (if it is still wrongly in
+ * SCHEMA_SQL); the regression is what happens when `initDatabase` re-runs the
+ * FULL SCHEMA_SQL over this old DB.
+ */
+function buildPreU33Db(path: string): Database {
+  const db = new Database(path, { create: true });
+  db.run("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) {
+    if (sql.includes("CREATE TABLE IF NOT EXISTS observability_events (")) {
+      db.run(OLD_OBSERVABILITY);
+      continue;
+    }
+    // Skip any index that targets the origin-badge columns that don't exist on
+    // the pre-U3.3 table — building the seed must not depend on the bug we test.
+    if (/ON observability_events\s*\(\s*(origin_kind|origin_peer)\b/.test(sql)) continue;
+    db.run(sql);
+  }
+  return db;
+}
+
+describe("U3.3 — existing pre-U3.3 observability DB origin-badge migration (#1048)", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) {
+      for (const suffix of ["", "-wal", "-shm"]) if (existsSync(p + suffix)) rmSync(p + suffix);
+    }
+    paths.length = 0;
+  });
+  function freshPath() {
+    const p = join(tmpdir(), `u3-3-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return p;
+  }
+
+  it("initDatabase succeeds on a pre-U3.3 observability table and backfills origin columns + index", () => {
+    const path = freshPath();
+
+    // --- seed: a pre-U3.3 DB with a real observability row.
+    const old = buildPreU33Db(path);
+    old.run(
+      `INSERT INTO observability_events (id, envelope_id, family, type, summary)
+       VALUES ('o-1', 'env-1', 'signal', 'system.signal.heartbeat', 'heartbeat')`
+    );
+    // Sanity: the pre-U3.3 table genuinely lacks the origin-badge columns.
+    const preNames = (old
+      .query(`SELECT name FROM pragma_table_info('observability_events')`)
+      .all() as { name: string }[]).map((c) => c.name);
+    expect(preNames).not.toContain("origin_kind");
+    expect(preNames).not.toContain("origin_peer");
+    old.close();
+
+    // --- reopen via initDatabase → MUST NOT throw `no such column: origin_kind`.
+    const db = initDatabase(path);
+
+    // Origin-badge columns now exist on the migrated table.
+    const names = (db
+      .query(`SELECT name FROM pragma_table_info('observability_events')`)
+      .all() as { name: string }[]).map((c) => c.name);
+    expect(names).toContain("origin_kind");
+    expect(names).toContain("origin_peer");
+
+    // The existing row survived: origin_kind backfilled to the NOT NULL default
+    // ('local' — its true origin: U2.1 only ever folded local rows),
+    // origin_peer left NULL, original data intact.
+    const row = db
+      .query(`SELECT * FROM observability_events WHERE id='o-1'`)
+      .get() as Record<string, unknown>;
+    expect(row.origin_kind).toBe("local");
+    expect(row.origin_peer).toBeNull();
+    expect(row.family).toBe("signal");
+    expect(row.envelope_id).toBe("env-1");
+
+    // The origin index was created (by the COLUMN_ADD_MIGRATIONS post[]).
+    const idxNames = (db
+      .query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='observability_events'`)
+      .all() as { name: string }[]).map((r) => r.name);
+    expect(idxNames).toContain("idx_observability_origin");
+
+    db.close();
+  });
+
+  it("is idempotent — a second init over the migrated DB does not error, columns + index intact", () => {
+    const path = freshPath();
+    const old = buildPreU33Db(path);
+    old.run(
+      `INSERT INTO observability_events (id, envelope_id, family, type) VALUES ('o-1', 'env-1', 'transport', 'system.transport.up')`
+    );
+    old.close();
+
+    const db1 = initDatabase(path);
+    db1.close();
+    const db2 = initDatabase(path);
+    const names = (db2
+      .query(`SELECT name FROM pragma_table_info('observability_events')`)
+      .all() as { name: string }[]).map((c) => c.name);
+    expect(names).toContain("origin_kind");
+    expect(names).toContain("origin_peer");
+    const idxNames = (db2
+      .query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='observability_events'`)
+      .all() as { name: string }[]).map((r) => r.name);
+    expect(idxNames).toContain("idx_observability_origin");
+    db2.close();
+  });
+
+  it("a fresh DB still gets the origin columns + index (post[] runs unconditionally)", () => {
+    const path = freshPath();
+    const db = initDatabase(path);
+    const names = (db
+      .query(`SELECT name FROM pragma_table_info('observability_events')`)
+      .all() as { name: string }[]).map((c) => c.name);
+    expect(names).toContain("origin_kind");
+    expect(names).toContain("origin_peer");
+    const idxNames = (db
+      .query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='observability_events'`)
+      .all() as { name: string }[]).map((r) => r.name);
+    expect(idxNames).toContain("idx_observability_origin");
+    db.close();
+  });
+});

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -608,7 +608,17 @@ export const SCHEMA_SQL: string[] = [
   )`,
   `CREATE INDEX IF NOT EXISTS idx_observability_timestamp ON observability_events(timestamp)`,
   `CREATE INDEX IF NOT EXISTS idx_observability_family ON observability_events(family, timestamp DESC)`,
-  `CREATE INDEX IF NOT EXISTS idx_observability_origin ON observability_events(origin_kind, origin_peer)`,
+  // ST-P0 / #1048: the origin-badge lookup index (idx_observability_origin on
+  // origin_kind, origin_peer) is DELIBERATELY NOT declared here. It indexes
+  // origin_kind / origin_peer, columns that an existing pre-U3.3 DB does not yet
+  // carry when init.ts runs this SCHEMA_SQL loop (which precedes the
+  // COLUMN_ADD_MIGRATIONS loop). Declaring it here crashes initDatabase on those
+  // DBs with `no such column: origin_kind` (the #961 bug class, reintroduced by
+  // U3.3 / #937, and the cause of the MC embed boot crash in #1048). It is
+  // created instead by the origin_kind / origin_peer COLUMN_ADD_MIGRATIONS
+  // `post[]` arrays below — which run AFTER the column ALTERs AND unconditionally
+  // (init.ts always runs `post[]`, even when the ALTER is skipped on a fresh DB
+  // whose columns came from CREATE TABLE).
 ];
 
 /**
@@ -700,14 +710,20 @@ export const COLUMN_ADD_MIGRATIONS: ColumnAddMigration[] = [
     table: "observability_events",
     column: "origin_kind",
     ddl: `ALTER TABLE observability_events ADD COLUMN origin_kind TEXT NOT NULL DEFAULT 'local'`,
-    post: [
-      `CREATE INDEX IF NOT EXISTS idx_observability_origin ON observability_events(origin_kind, origin_peer)`,
-    ],
+    // NOTE: the partner index idx_observability_origin spans BOTH origin_kind
+    // AND origin_peer. It is created in the origin_peer entry's post[] below —
+    // NOT here — because at this point origin_peer has not yet been ALTERed in
+    // (this entry runs first), so a `CREATE INDEX ... (origin_kind, origin_peer)`
+    // here throws `no such column: origin_peer` on an existing DB (#1048).
   },
   {
     table: "observability_events",
     column: "origin_peer",
     ddl: `ALTER TABLE observability_events ADD COLUMN origin_peer TEXT`,
+    // Both origin columns now exist (origin_kind added by the entry above,
+    // origin_peer by this one), so the composite index is safe to create here.
+    // Runs unconditionally (init.ts always runs post[]) so fresh DBs — whose
+    // columns came from CREATE TABLE — get the index too.
     post: [
       `CREATE INDEX IF NOT EXISTS idx_observability_origin ON observability_events(origin_kind, origin_peer)`,
     ],


### PR DESCRIPTION
## Root cause

The MC embed crashed on every **EXISTING** (pre-U3.3) `mission-control.db` with `cortex: Mission Control embed startup error (non-fatal): no such column: origin_kind` → the whole Observability pane went down. Fresh DBs were fine, which is why CI (fresh-db-blind) shipped it.

This is the **#961 / ST-P0 bug class, reintroduced by U3.3 (#937)**. `init.ts` runs the full `SCHEMA_SQL` loop **before** `COLUMN_ADD_MIGRATIONS`. `schema.ts:611` put `CREATE INDEX idx_observability_origin ON observability_events(origin_kind, origin_peer)` in `SCHEMA_SQL`, but those two columns are `ALTER`ed in by `COLUMN_ADD_MIGRATIONS`. On an existing DB, `CREATE TABLE IF NOT EXISTS observability_events` no-ops (the table already exists, without the new columns) → the line-611 index references columns that don't exist yet → throws → the embed aborts before the migration can add them.

## The fix

1. **Removed** `idx_observability_origin` from `SCHEMA_SQL`. The `COLUMN_ADD_MIGRATIONS` `post[]` already creates it *after* the `ALTER`s — so fresh DBs (CREATE TABLE has the columns, post[] creates the index) and existing DBs (ALTER adds columns, then post[] creates the index) both work. `init.ts` runs `post[]` unconditionally on both paths. This mirrors the #961 fix for the sessions indices exactly.

2. **Second latent ordering bug found + fixed.** Once the SCHEMA_SQL crash was removed, the test surfaced a second bug *inside* `COLUMN_ADD_MIGRATIONS`: the composite index lived in **both** the `origin_kind` **and** `origin_peer` migration `post[]` arrays. The `origin_kind` entry runs **first**, so its `post[]` `CREATE INDEX (origin_kind, origin_peer)` threw `no such column: origin_peer` (added only by the next entry). The index now lives **only** in the `origin_peer` entry's `post[]` — the second to run, where both columns exist. This was previously masked on fresh DBs because the SCHEMA_SQL index satisfied the `IF NOT EXISTS` before the post[] ran.

## SCHEMA_SQL audit result

Cross-checked **every** `SCHEMA_SQL` `CREATE INDEX` against the columns added via `COLUMN_ADD_MIGRATIONS`. **`idx_observability_origin` was the ONLY at-risk index.** Specifically:
- `idx_ata_agent_id` references `agent_task_assignment.agent_id` — a **base CREATE TABLE** column (line 71), **not** the migration-added `sessions.agent_id`. Safe.
- The sessions-tree indices (`idx_sessions_parent_session_id`, `idx_sessions_substrate`) were already correctly moved to `post[]` by the #961/ST-P0 fix.
- No other SCHEMA_SQL index references a migration-added column.

## Regression test (RED → GREEN)

New `src/surface/mc/__tests__/u3-3-observability-origin-migration.test.ts` (sibling of `st-p0-existing-db-migration.test.ts`): builds a faithful **pre-U3.3** `observability_events` table (the U2.1 shape, no `origin_kind`/`origin_peer`) in a temp DB, runs `initDatabase`, and asserts it **succeeds** with both columns + `idx_observability_origin` present after, the existing row backfilled (`origin_kind='local'`, `origin_peer=NULL`), plus idempotency and fresh-DB coverage.

- **RED confirmed** on unfixed code: `no such column: origin_kind` at the SCHEMA_SQL index step (`init.ts:33`), failing the two existing-DB cases; the fresh-DB case passed (proving it's specifically the existing-DB path).
- **GREEN** after the fix: 3/3 pass.

## Gates

- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun test` — **6828 pass, 2 skip, 0 fail** (399 files)

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)