### PR TITLE
feat(network): O-3 — cortex network join auto-converts an anonymous bus to operator-mode

### DIFF
--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -233,6 +233,32 @@ CARVEOUT_LINE_PATTERNS=(
   'operator_pubkey'
   'operator-mode'
   '[Oo]peratorRecord'
+  # O-3 (cortex#1053) — the NSC operator-JWT / operator-mode-conversion vocabulary
+  # that `cortex network join` auto-converts an anonymous bus with. ALL the NSC
+  # account-tree sense (the operator JWT the leaf binds under), NEVER the
+  # principal. Class: NSC (the permanent qualified survivor). Covers:
+  #   - the `OperatorMode*` renderer type/symbol prefix (OperatorModeLeafPackage,
+  #     OperatorModeConversion, renderOperatorModeBlocks, convertToOperatorMode);
+  #   - the `operatorJwt` field + the `operator_jwt` config key + `--operator-jwt`
+  #     flag (the operator JWT, an NSC artifact);
+  #   - a rendered `operator:` config line (the operator-mode block this writes).
+  '[Oo]peratorMode'
+  'operatorJwt'
+  'operator_jwt'
+  '--operator-jwt'
+  'operator:[[:space:]]*\$\{?operatorJwt'
+  '`operator:'
+  'operator[[:space:]]+(JWT|that owns)'
+  # O-3 test fixtures — the operator-mode-conversion suite's NSC vocabulary:
+  #   - `foreign-operator` — the bus-type fixture modelling a bus already
+  #     operator-mode under a DIFFERENT operator JWT (the never-clobber case);
+  #   - a rendered `operator: eyJ…` block line + its `A_DIFFERENT_OPERATOR` fake;
+  #   - the design-doc filename `…-operator-onboarding.md`.
+  # All the NSC account-tree sense, never the principal. Class: NSC.
+  'foreign-operator'
+  'operator: eyJ'
+  'A_DIFFERENT_OPERATOR'
+  'operator-onboarding'
   # NSC operator-account signing seed/nkey file paths (`operator.nk`, `operator.nkey`,
   # `operator.creds`). The NATS account-tree root seed (CONTEXT.md → NSC operator);
   # a filesystem path to the operator-account key, never the principal. Class: NSC.

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync, chmodSync } from "fs";
 import { tmpdir, homedir } from "os";
 import { join } from "path";
 
@@ -385,6 +385,70 @@ describe("O-3 live convertToOperatorMode — round-trip a real temp nats config"
     expect(result.status).toBe("converted");
     // ...but nothing was written.
     expect(readFileSync(conf, "utf-8")).toBe(original);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Security-review MAJOR (#1058) — the converting write is ATOMIC (tmp+rename),
+  // so a SIGKILL/OOM mid-write can never leave nats-server a truncated config.
+  // ---------------------------------------------------------------------------
+  test("the converting write goes via a tmp file + rename (no .tmp left behind)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "community.conf");
+    writeFileSync(conf, anonLocalConf(), "utf-8");
+
+    const ports = buildLivePorts(cfgWithConfig(conf));
+    const result = ports.leafFile.convertToOperatorMode(FAKE_PACKAGE);
+    expect(result.status).toBe("converted");
+
+    // The rename CONSUMED the tmp file — none is left in the dir, and the final
+    // config carries the full converted bytes (atomic: old-or-new, never partial).
+    expect(existsSync(`${conf}.tmp`)).toBe(false);
+    expect(readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+    if (result.status !== "converted") throw new Error("expected converted");
+    expect(readFileSync(conf, "utf-8")).toBe(result.conf);
+  });
+
+  test("a FAILED converting write leaves the original config intact (atomic, never truncated)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "community.conf");
+    const original = anonLocalConf();
+    writeFileSync(conf, original, "utf-8");
+
+    // Make the config's directory read-only so the `.tmp` write throws EACCES
+    // BEFORE the rename — the original file's bytes must be untouched (the whole
+    // point of tmp+rename: the target is only ever swapped atomically, never
+    // opened for truncation in place).
+    chmodSync(dir, 0o500);
+    try {
+      const ports = buildLivePorts(cfgWithConfig(conf));
+      expect(() => ports.leafFile.convertToOperatorMode(FAKE_PACKAGE)).toThrow();
+    } finally {
+      chmodSync(dir, 0o700); // restore so afterEach can clean up
+    }
+    // The original config survived verbatim — no partial/corrupt write.
+    expect(readFileSync(conf, "utf-8")).toBe(original);
+    expect(existsSync(`${conf}.tmp`)).toBe(false);
+  });
+
+  test("restoreLeafState's base-config rewrite is ALSO atomic (no .tmp left behind)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    // A base config WITHOUT the leaf include directive — restoring a snapshot
+    // that records "directive-present" makes restoreLeafState rewrite the base
+    // config (the path the MAJOR flagged). Assert it goes atomic.
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    ports.leafFile.restoreLeafState({
+      networkId: "metafactory",
+      includeFile: undefined,
+      natsConfig: "directive-present", // → ensureLeafInclude rewrites the base config
+    });
+
+    expect(existsSync(`${conf}.tmp`)).toBe(false);
+    expect(readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+    // The directive was added (the rewrite happened, atomically).
+    expect(readFileSync(conf, "utf-8")).toContain('include "leafnodes-metafactory.conf"');
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -266,6 +266,129 @@ describe("#754 live leaf-include wiring", () => {
 });
 
 // =============================================================================
+// O-3 (cortex#1053) — the LIVE convertToOperatorMode adapter round-trips a real
+// temp nats config: an anonymous bus + a leaf package → the on-disk config gains
+// the operator-mode blocks, keeps its own identity, and adds NO leaf include.
+// =============================================================================
+
+/** The anonymous / hard-isolated bus shape (sop-stack-onboarding §Step 2). */
+function anonLocalConf(): string {
+  return [
+    "server_name: community-andreas",
+    "listen: 127.0.0.1:4224",
+    "http: 127.0.0.1:8224",
+    "jetstream {",
+    "  store_dir: /Users/andreas/.config/nats/community-jetstream",
+    "  domain: community-andreas",
+    "}",
+    "",
+  ].join("\n");
+}
+
+// Public-repo-safe fake leaf package (obvious `eyJ…` / `A…`-shaped fixtures).
+const FAKE_PACKAGE = {
+  operatorJwt:
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_OPERATOR.sig",
+  account: "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+  accountJwt:
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_ACCOUNT.sig",
+};
+
+describe("O-3 live convertToOperatorMode — round-trip a real temp nats config", () => {
+  test("anonymous bus + leaf package → conf gains operator-mode blocks, keeps identity, no leaf include", () => {
+    const dir = freshDir();
+    const conf = join(dir, "community.conf");
+    writeFileSync(conf, anonLocalConf(), "utf-8");
+
+    const ports = buildLivePorts(cfgWithConfig(conf));
+    const result = ports.leafFile.convertToOperatorMode(FAKE_PACKAGE);
+
+    expect(result.status).toBe("converted");
+    const after = readFileSync(conf, "utf-8");
+    // operator-mode blocks rendered
+    expect(after).toContain(`operator: ${FAKE_PACKAGE.operatorJwt}`);
+    expect(after).toContain("resolver: MEMORY");
+    expect(after).toContain(`${FAKE_PACKAGE.account}: ${FAKE_PACKAGE.accountJwt}`);
+    // the stack's own identity/ports/JS domain preserved
+    expect(after).toContain("server_name: community-andreas");
+    expect(after).toContain("listen: 127.0.0.1:4224");
+    expect(after).toContain("domain: community-andreas");
+    // NO leaf include — join renders its own
+    expect(after).not.toMatch(/include[ \t]+["']leafnodes-/);
+  });
+
+  test("already-operator-mode bus under the SAME operator → 'already', file unchanged + leaf can be added", () => {
+    const dir = freshDir();
+    const conf = join(dir, "community.conf");
+    writeFileSync(conf, anonLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    // First convert, then re-convert: byte-stable no-op.
+    ports.leafFile.convertToOperatorMode(FAKE_PACKAGE);
+    const afterFirst = readFileSync(conf, "utf-8");
+    const second = ports.leafFile.convertToOperatorMode(FAKE_PACKAGE);
+    expect(second.status).toBe("already");
+    expect(readFileSync(conf, "utf-8")).toBe(afterFirst);
+
+    // And the converted bus can now take a leaf include (the join's next step).
+    ports.leafFile.ensureInclude("metafactory");
+    const withLeaf = readFileSync(conf, "utf-8");
+    expect(withLeaf).toContain('include "leafnodes-metafactory.conf"');
+    // still operator-mode + identity intact
+    expect(withLeaf).toContain(`operator: ${FAKE_PACKAGE.operatorJwt}`);
+    expect(withLeaf).toContain("server_name: community-andreas");
+  });
+
+  test("missing operator JWT → refuse, the on-disk config is untouched (fail-fast preserved)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "community.conf");
+    const original = anonLocalConf();
+    writeFileSync(conf, original, "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    const result = ports.leafFile.convertToOperatorMode({
+      ...FAKE_PACKAGE,
+      operatorJwt: "",
+    });
+    expect(result.status).toBe("refuse");
+    // nothing written
+    expect(readFileSync(conf, "utf-8")).toBe(original);
+  });
+
+  test("an already-operator-mode bus under a DIFFERENT operator → refuse (never clobber)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const original = bareLocalConf(); // carries system_account → operator-mode-ish
+    const foreign = [
+      original.trimEnd(),
+      "operator: eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.A_DIFFERENT_OPERATOR.sig",
+      "",
+    ].join("\n");
+    writeFileSync(conf, foreign, "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    const result = ports.leafFile.convertToOperatorMode(FAKE_PACKAGE);
+    expect(result.status).toBe("refuse");
+    // the foreign config is left exactly as-is.
+    expect(readFileSync(conf, "utf-8")).toBe(foreign);
+  });
+
+  test("dry-run convertToOperatorMode surfaces the decision but writes NOTHING", () => {
+    const dir = freshDir();
+    const conf = join(dir, "community.conf");
+    const original = anonLocalConf();
+    writeFileSync(conf, original, "utf-8");
+
+    const ports = buildDryRunPorts(cfgWithConfig(conf));
+    const result = ports.leafFile.convertToOperatorMode(FAKE_PACKAGE);
+    // The decision is a READ — identical to live: it WOULD convert.
+    expect(result.status).toBe("converted");
+    // ...but nothing was written.
+    expect(readFileSync(conf, "utf-8")).toBe(original);
+  });
+});
+
+// =============================================================================
 // #756 — the config-store port is CONFIG-SPLIT-AWARE: it writes
 // policy.federated.networks[] to the per-stack split path
 // (~/.config/cortex/<slug>/stacks/<slug>.yaml) when the per-stack dir exists,

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -506,3 +506,148 @@ describe("#763 — deriveLeaveInputs platform-aware descriptor", () => {
     expect(res.inputs?.platform).toBe("linux");
   });
 });
+
+// =============================================================================
+// O-3 (cortex#1053) — assemble the operator-mode leaf package from config/flags.
+// =============================================================================
+
+describe("deriveJoinInputs — O-3 operator-mode leaf package", () => {
+  const OP_JWT = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.FAKE_OP.sig";
+  const ACC_JWT = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.FAKE_ACC.sig";
+
+  test("config-supplied package (operator_jwt + account + account_jwt) materialises", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/community",
+        nkey_seed_path: "~/seed.nk",
+        nats_infra: {
+          config_path: "~/community.conf",
+          plist_path: "~/nats.plist",
+          account: "A" + "B".repeat(55),
+          operator_jwt: OP_JWT,
+          account_jwt: ACC_JWT,
+        },
+      },
+      policy: {
+        principals: [],
+        roles: [],
+        federated: {
+          networks: [],
+          registry: { url: "https://r", pubkey: "A".repeat(43) + "=" },
+        },
+      },
+    });
+    const res = deriveJoinInputs("metafactory-community", {}, "/cfg", reader(cfg), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toEqual({
+      operatorJwt: OP_JWT,
+      account: "A" + "B".repeat(55),
+      accountJwt: ACC_JWT,
+    });
+  });
+
+  test("flags override config for the package fields", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/community",
+        nkey_seed_path: "~/seed.nk",
+        nats_infra: {
+          config_path: "~/community.conf",
+          plist_path: "~/nats.plist",
+          account: "A" + "B".repeat(55),
+          operator_jwt: "eyJ.CONFIG_OP.sig",
+          account_jwt: "eyJ.CONFIG_ACC.sig",
+        },
+      },
+      policy: {
+        principals: [],
+        roles: [],
+        federated: {
+          networks: [],
+          registry: { url: "https://r", pubkey: "A".repeat(43) + "=" },
+        },
+      },
+    });
+    const res = deriveJoinInputs(
+      "metafactory-community",
+      { operatorJwt: OP_JWT, accountJwt: ACC_JWT, account: "A" + "C".repeat(55) },
+      "/cfg",
+      reader(cfg),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toEqual({
+      operatorJwt: OP_JWT,
+      account: "A" + "C".repeat(55),
+      accountJwt: ACC_JWT,
+    });
+  });
+
+  test("a SYS account (+ jwt) is carried through when present", () => {
+    const res = deriveJoinInputs(
+      "metafactory-community",
+      {
+        operatorJwt: OP_JWT,
+        accountJwt: ACC_JWT,
+        account: "A" + "B".repeat(55),
+        systemAccount: "A" + "D".repeat(55),
+        systemAccountJwt: "eyJ.SYS.sig",
+      },
+      "/cfg",
+      reader(loaded({
+        principal: { id: "andreas" },
+        stack: {
+          id: "andreas/community",
+          nkey_seed_path: "~/seed.nk",
+          nats_infra: { config_path: "~/c.conf", plist_path: "~/p.plist" },
+        },
+        policy: {
+          principals: [],
+          roles: [],
+          federated: { networks: [], registry: { url: "https://r", pubkey: "A".repeat(43) + "=" } },
+        },
+      })),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toEqual({
+      operatorJwt: OP_JWT,
+      account: "A" + "B".repeat(55),
+      accountJwt: ACC_JWT,
+      systemAccount: "A" + "D".repeat(55),
+      systemAccountJwt: "eyJ.SYS.sig",
+    });
+  });
+
+  test("a PARTIAL package (operator_jwt but no account_jwt) → no package (fail-fast preserved)", () => {
+    const res = deriveJoinInputs(
+      "metafactory-community",
+      { operatorJwt: OP_JWT, account: "A" + "B".repeat(55) }, // no accountJwt
+      "/cfg",
+      reader(loaded({
+        principal: { id: "andreas" },
+        stack: {
+          id: "andreas/community",
+          nkey_seed_path: "~/seed.nk",
+          nats_infra: { config_path: "~/c.conf", plist_path: "~/p.plist" },
+        },
+        policy: {
+          principals: [],
+          roles: [],
+          federated: { networks: [], registry: { url: "https://r", pubkey: "A".repeat(43) + "=" } },
+        },
+      })),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toBeUndefined();
+  });
+
+  test("no package material at all → operatorModePackage undefined (the common case)", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg/cortex.yaml", reader(FULL), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toBeUndefined();
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -42,8 +42,22 @@ import type {
 } from "../../../../common/registry/types";
 import type { NetworkFetchResult } from "../../../../common/registry/network-client";
 import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
-import { renderLeafIncludeFile } from "../../../../common/nats/leaf-remote-renderer";
+import {
+  renderLeafIncludeFile,
+  type OperatorModeLeafPackage,
+} from "../../../../common/nats/leaf-remote-renderer";
 import { nkeyToBase64Pubkey } from "../../../../common/registry/encoding";
+
+// O-3 (cortex#1053) — a public-repo-safe fake leaf package: the operator-mode
+// material `cortex network join` renders to convert an anonymous bus. O-4
+// supplies this for real via the register→issue handshake.
+const LOCAL_PACKAGE: OperatorModeLeafPackage = {
+  operatorJwt:
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_OPERATOR.sig",
+  account: "A" + "B".repeat(55),
+  accountJwt:
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_ACCOUNT.sig",
+};
 
 // =============================================================================
 // Fixtures
@@ -127,6 +141,8 @@ interface Recorder {
   healthProbes: number;
   /** #821 MAJOR-1 — count of `nats-server -c <cfg> -t` validation gate runs. */
   validateConfigs: number;
+  /** O-3 (#1053) — leaf packages the orchestrator asked to convert with. */
+  conversions: OperatorModeLeafPackage[];
 }
 
 function makeFakes(opts: {
@@ -150,7 +166,7 @@ function makeFakes(opts: {
    *   - "default-g"               → $G/default-account bus (no account tree).
    * The fake's `resolveBindMode` mirrors the real `resolveLeafBindMode` decision.
    */
-  busType?: "operator-mode" | "default-g";
+  busType?: "operator-mode" | "default-g" | "anonymous" | "foreign-operator";
   /** #821 — model the leaf creds file as MISSING (pre-flight refuses). */
   credsMissing?: boolean;
   /**
@@ -195,8 +211,14 @@ function makeFakes(opts: {
     restores: [],
     healthProbes: 0,
     validateConfigs: 0,
+    conversions: [],
   };
   const storeRef = { networks: opts.initialNetworks ?? [] };
+  // O-3 (#1053) — the fake's mutable view of the bus type. An "anonymous" bus
+  // that convertToOperatorMode() successfully converts FLIPS to operator-mode,
+  // so the subsequent resolveBindMode() returns account-bound (mirroring how the
+  // real renderOperatorModeBlocks rewrites the on-disk config the next read sees).
+  let busType = opts.busType ?? "operator-mode";
   const leafFilesPresent = new Set<string>(
     (opts.initialNetworks ?? []).map((n) => n.id),
   );
@@ -267,7 +289,16 @@ function makeFakes(opts: {
       if (!hasCreds) {
         return { mode: "refuse", reason: "no leaf creds available" };
       }
-      const busType = opts.busType ?? "operator-mode";
+      // O-3 (#1053) — an anonymous / foreign-operator bus refuses (the #794
+      // fail-fast input). A successful conversion flips `busType` to operator-mode
+      // BEFORE the orchestrator re-resolves, so this branch only fires pre-convert.
+      if (busType === "anonymous" || busType === "foreign-operator") {
+        return {
+          mode: "refuse",
+          reason:
+            "config is anonymous/hard-isolated (no operator-mode account tree)",
+        };
+      }
       if (busType === "default-g") {
         // $G/default-account bus + creds → no-account remote (creds JWT binds).
         return { mode: "creds-only" };
@@ -294,6 +325,35 @@ function makeFakes(opts: {
           "operator-mode bus requires the leaf remote to declare an account nkey, " +
           "but none was offered",
       };
+    },
+    convertToOperatorMode(pkg) {
+      rec.conversions.push(pkg);
+      // O-3 (#1053) — model the real adapter's outcomes over the bus type:
+      //   - foreign-operator bus → REFUSE (never clobber someone else's tree).
+      //   - already operator-mode (any operator-binding type) → 'already' no-op.
+      //   - anonymous bus + a valid package → 'converted'; FLIP busType to
+      //     operator-mode so the orchestrator's re-resolve binds the account.
+      //   - anonymous bus + an INVALID package → refuse (the preserved fail-fast).
+      if (busType === "foreign-operator") {
+        return {
+          status: "refuse",
+          reason:
+            "the nats config is ALREADY operator-mode under a different operator",
+        };
+      }
+      if (busType !== "anonymous") {
+        return { status: "already", conf: "ALREADY-OPERATOR-MODE" };
+      }
+      // Anonymous bus. Validate the package the way the real renderer does (only
+      // the fields the orchestrator depends on): operator JWT + account present.
+      if (pkg.operatorJwt.trim().length === 0 || pkg.account.trim().length === 0) {
+        return {
+          status: "refuse",
+          reason: "leaf package is missing the operator JWT or account",
+        };
+      }
+      busType = "operator-mode"; // the conversion stuck — the bus is now operator-mode.
+      return { status: "converted", conf: "CONVERTED-OPERATOR-MODE-CONF" };
     },
     credsExist(path) {
       rec.credsChecks.push(path);
@@ -604,6 +664,107 @@ describe("join", () => {
       expect(rec.writes.length).toBe(0);
       expect(storeRef.networks.length).toBe(0);
       expect(rec.bindModeChecks).toEqual([{ account: undefined, hasCreds: false }]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // O-3 (cortex#1053, epic #1050, spec §4-D2) — auto-convert an anonymous bus to
+  // operator-mode instead of fail-fasting (#794). The orchestrator, given a leaf
+  // package on the joining stack, converts the bus THEN proceeds with the
+  // existing leaf render + policy write + restart.
+  // ---------------------------------------------------------------------------
+  describe("O-3 auto-convert an anonymous bus to operator-mode", () => {
+    test("anonymous bus + leaf package → converts, then joins account-bound", async () => {
+      const STACK: JoiningStack = {
+        principalId: "andreas",
+        stackSlug: "community",
+        credentials: "/Users/andreas/.config/nats/andreas.creds",
+        account: LOCAL_PACKAGE.account,
+        operatorModePackage: LOCAL_PACKAGE,
+      };
+      const { ports, rec, storeRef } = makeFakes({ busType: "anonymous" });
+      const res = await joinNetwork("metafactory-community", STACK, ports);
+
+      expect(res.ok).toBe(true);
+      // The conversion ran with the supplied package...
+      expect(rec.conversions).toEqual([LOCAL_PACKAGE]);
+      // ...and the join then proceeded account-bound (the converted bus is now
+      // operator-mode, so resolveBindMode bound the account on the re-resolve).
+      expect(rec.writes.length).toBe(1);
+      expect(rec.writes[0]!.binding.account).toBe(LOCAL_PACKAGE.account);
+      expect(storeRef.networks.length).toBe(1);
+      expect(rec.restarts).toBe(1);
+      // A step records the conversion so the CLI can surface it.
+      expect(res.steps.some((s) => /operator-mode/i.test(s))).toBe(true);
+    });
+
+    test("an already-operator-mode bus is NOT converted (no package needed)", async () => {
+      // The pre-O-3 happy path: operator-mode bus that binds the account → join
+      // proceeds WITHOUT any conversion attempt.
+      const { ports, rec } = makeFakes({ busType: "operator-mode" });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+      expect(res.ok).toBe(true);
+      expect(rec.conversions).toEqual([]); // no conversion attempted
+      expect(rec.writes.length).toBe(1);
+    });
+
+    test("anonymous bus with NO leaf package → STILL fail-fasts (#794 preserved)", async () => {
+      // The conversion seam only engages when a package is present. Without one,
+      // an anonymous bus is still un-joinable → the #794 refusal stands.
+      const STACK: JoiningStack = {
+        principalId: "andreas",
+        stackSlug: "community",
+        credentials: "/Users/andreas/.config/nats/andreas.creds",
+        account: LOCAL_PACKAGE.account,
+        // no operatorModePackage
+      };
+      const { ports, rec, storeRef } = makeFakes({ busType: "anonymous" });
+      const res = await joinNetwork("metafactory-community", STACK, ports);
+
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("cortex#794/#799");
+      expect(rec.conversions).toEqual([]); // never attempted (no package)
+      // NOTHING mutated.
+      expect(rec.writes.length).toBe(0);
+      expect(storeRef.networks.length).toBe(0);
+      expect(rec.restarts).toBe(0);
+    });
+
+    test("conversion REFUSE (foreign-operator bus) aborts the join, touches nothing", async () => {
+      const STACK: JoiningStack = {
+        principalId: "andreas",
+        stackSlug: "community",
+        credentials: "/Users/andreas/.config/nats/andreas.creds",
+        account: LOCAL_PACKAGE.account,
+        operatorModePackage: LOCAL_PACKAGE,
+      };
+      const { ports, rec, storeRef } = makeFakes({ busType: "foreign-operator" });
+      const res = await joinNetwork("metafactory-community", STACK, ports);
+
+      expect(res.ok).toBe(false);
+      expect(res.reason).toMatch(/different operator|operator-mode/i);
+      // Conversion was attempted (and refused) — but NOTHING was mutated.
+      expect(rec.conversions).toEqual([LOCAL_PACKAGE]);
+      expect(rec.writes.length).toBe(0);
+      expect(storeRef.networks.length).toBe(0);
+      expect(rec.restarts).toBe(0);
+    });
+
+    test("conversion REFUSE (incomplete package) aborts the join", async () => {
+      const STACK: JoiningStack = {
+        principalId: "andreas",
+        stackSlug: "community",
+        credentials: "/Users/andreas/.config/nats/andreas.creds",
+        account: LOCAL_PACKAGE.account,
+        operatorModePackage: { ...LOCAL_PACKAGE, operatorJwt: "" },
+      };
+      const { ports, rec, storeRef } = makeFakes({ busType: "anonymous" });
+      const res = await joinNetwork("metafactory-community", STACK, ports);
+
+      expect(res.ok).toBe(false);
+      expect(rec.conversions.length).toBe(1);
+      expect(rec.writes.length).toBe(0);
+      expect(storeRef.networks.length).toBe(0);
     });
   });
 

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -42,6 +42,7 @@ import {
   natsConfigMonitorUrl,
   removeLeafInclude,
   renderLeafIncludeFile,
+  renderOperatorModeBlocks,
   resolveLeafBindMode,
 } from "../../../common/nats/leaf-remote-renderer";
 import {
@@ -497,6 +498,26 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
         ? readFileSync(configPath, "utf-8")
         : "";
       return resolveLeafBindMode(text, account, hasCreds);
+    },
+    convertToOperatorMode(pkg) {
+      // O-3 (cortex#1053) — render the SOP §B0.1 operator-mode blocks into the
+      // stack's nats config from the leaf package. The DECISION (convert /
+      // already / refuse) is a PURE read (identical in live + dry-run); only the
+      // WRITE-BACK is gated on `mutate`. An absent/empty config file reads as
+      // anonymous (a brand-new stack), so renderOperatorModeBlocks converts it.
+      const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      const current = existsSync(configPath)
+        ? readFileSync(configPath, "utf-8")
+        : "";
+      const result = renderOperatorModeBlocks(current, pkg);
+      // Only a genuine `converted` mutates the on-disk config. `already` is a
+      // byte-stable no-op (skip the write); `refuse` writes nothing. Dry-run is
+      // inert — it surfaces the decision in the step log without touching disk.
+      if (result.status === "converted" && mutate) {
+        mkdirSync(dirname(configPath), { recursive: true });
+        writeFileSync(configPath, result.conf, "utf-8");
+      }
+      return result;
     },
     credsExist(path) {
       // #821 — pure READ (identical in live + dry-run): does the leaf creds file

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -25,6 +25,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -424,6 +425,25 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
 // Leaf-file port — S3 renderer output written to the nats config dir.
 // =============================================================================
 
+/**
+ * O-3 (cortex#1053 security-review MAJOR) — write `contents` to `path`
+ * ATOMICALLY: write a sibling `<path>.tmp` first, then `renameSync` it over the
+ * target. `rename(2)` is POSIX-atomic within a filesystem — a reader (here:
+ * nats-server on its next launchd/systemd restart) sees EITHER the old bytes OR
+ * the complete new bytes, NEVER a partial/truncated file.
+ *
+ * A plain `writeFileSync` is NOT atomic: a SIGKILL/OOM mid-write truncates the
+ * file, and nats-server then reads corrupt HOCON and REFUSES to start → the bus
+ * goes DOWN — the exact #794 hazard this slice exists to prevent (and which the
+ * snapshot/rollback can't recover, since it runs AFTER the write+restart). The
+ * `.tmp` sits beside the target so the rename stays same-filesystem (atomic).
+ */
+function atomicWriteFileSync(path: string, contents: string): void {
+  const tmpPath = `${path}.tmp`;
+  writeFileSync(tmpPath, contents, "utf-8");
+  renameSync(tmpPath, path); // POSIX-atomic: old-or-new, never partial.
+}
+
 /** Directory the per-network leaf include files live in (beside nats config). */
 function leafDir(cfg: LivePortsConfig): string {
   const natsConfig = expandTilde(cfg.natsConfigPath ?? "");
@@ -515,7 +535,11 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
       // inert — it surfaces the decision in the step log without touching disk.
       if (result.status === "converted" && mutate) {
         mkdirSync(dirname(configPath), { recursive: true });
-        writeFileSync(configPath, result.conf, "utf-8");
+        // Security-review MAJOR (#1058) — ATOMIC write (tmp + rename). A
+        // non-atomic writeFileSync truncated by a SIGKILL/OOM mid-write would
+        // leave corrupt HOCON that crashes nats-server on its next restart →
+        // bus DOWN, with no recovery (the snapshot runs after write+restart).
+        atomicWriteFileSync(configPath, result.conf);
       }
       return result;
     },
@@ -587,7 +611,9 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
         rmSync(includePath, { force: true });
       } else {
         mkdirSync(dir, { recursive: true });
-        writeFileSync(includePath, snapshot.includeFile, "utf-8");
+        // Security-review MAJOR (#1058) — atomic, same as the base config below:
+        // a crash mid-rollback must never leave a truncated include file either.
+        atomicWriteFileSync(includePath, snapshot.includeFile);
       }
 
       // Restore the include DIRECTIVE in the base config to its pre-join presence.
@@ -598,7 +624,10 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
       const next = directiveWasPresent
         ? ensureLeafInclude(current, snapshot.networkId) // it was there → keep it
         : removeLeafInclude(current, snapshot.networkId); // join added it → drop it
-      if (next !== current) writeFileSync(configPath, next, "utf-8");
+      // Security-review MAJOR (#1058) — ATOMIC write (tmp + rename). The rollback
+      // path has the identical non-atomicity hazard: a crash mid-rollback would
+      // corrupt the very base config it is trying to restore → bus DOWN.
+      if (next !== current) atomicWriteFileSync(configPath, next);
     },
   };
 }

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -38,6 +38,7 @@
 
 import type { LoadedConfig } from "../../../common/config/loader";
 import type { ServicePlatform } from "../../../common/nats/nats-service-manager";
+import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 
 // =============================================================================
 // Types
@@ -74,6 +75,15 @@ export interface DerivedJoinInputs {
    */
   account?: string;
   credsPath: string;
+  /**
+   * O-3 (cortex#1053) — the operator-mode leaf package, assembled from
+   * `--operator-jwt` / `--account-jwt` / `--account` (+ optional
+   * `--system-account` / `--system-account-jwt`) flags or the matching
+   * `stack.nats_infra.*` fields. Present ONLY when at least the operator JWT +
+   * account + account JWT all resolve — the minimum to convert an anonymous bus.
+   * Absent ⇒ join falls back to the #794 fail-fast on an anonymous bus.
+   */
+  operatorModePackage?: OperatorModeLeafPackage;
   /**
    * #762 — the capability ids this stack announces INTO the network, read from
    * the matching `policy.federated.networks[].announce_capabilities[]` block in
@@ -122,6 +132,14 @@ export interface JoinOverrides {
   unitPath?: string;
   account?: string;
   credsPath?: string;
+  /** O-3 (#1053) — `--operator-jwt`. */
+  operatorJwt?: string;
+  /** O-3 (#1053) — `--account-jwt`. */
+  accountJwt?: string;
+  /** O-3 (#1053) — `--system-account`. */
+  systemAccount?: string;
+  /** O-3 (#1053) — `--system-account-jwt`. */
+  systemAccountJwt?: string;
 }
 
 /** A reader that loads + validates the cortex config from a path. */
@@ -357,6 +375,35 @@ export function deriveJoinInputs(
   const credsPath =
     overrides.credsPath ?? natsInfra?.creds_path ?? defaultCredsPath(networkId);
 
+  // O-3 (cortex#1053) — assemble the operator-mode leaf package. Flag wins over
+  // config (`stack.nats_infra.{operator_jwt,account_jwt,system_account,…}`). The
+  // package materialises ONLY when its minimum (operator JWT + account + account
+  // JWT) all resolve; a partial set is treated as "no package" so join falls back
+  // to the #794 fail-fast rather than handing a half-formed package to the
+  // renderer (which would refuse anyway, but with a less obvious cause). O-4
+  // supplies these via the handshake; here they come from flags/config.
+  const operatorJwt = overrides.operatorJwt ?? natsInfra?.operator_jwt;
+  const accountJwt = overrides.accountJwt ?? natsInfra?.account_jwt;
+  const systemAccount = overrides.systemAccount ?? natsInfra?.system_account;
+  const systemAccountJwt =
+    overrides.systemAccountJwt ?? natsInfra?.system_account_jwt;
+  const operatorModePackage: OperatorModeLeafPackage | undefined =
+    operatorJwt !== undefined &&
+    operatorJwt !== "" &&
+    account !== undefined &&
+    accountJwt !== undefined &&
+    accountJwt !== ""
+      ? {
+          operatorJwt,
+          account,
+          accountJwt,
+          ...(systemAccount !== undefined &&
+            systemAccount !== "" && { systemAccount }),
+          ...(systemAccountJwt !== undefined &&
+            systemAccountJwt !== "" && { systemAccountJwt }),
+        }
+      : undefined;
+
   // #762 — announce_capabilities for THIS network, read from the matching
   // policy.federated.networks[] block. The join announces these to the registry
   // with networks:[networkId] so the principal joins the roster. Absent network
@@ -380,6 +427,7 @@ export function deriveJoinInputs(
       platform: descriptor.platform,
       ...(account !== undefined && { account }),
       credsPath,
+      ...(operatorModePackage !== undefined && { operatorModePackage }),
       announceCapabilities,
     },
   };

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -33,6 +33,7 @@ import type {
   PolicyFederatedPeer,
 } from "../../../common/types/cortex-config";
 import type { NetworkRosterResult } from "../../../common/registry/types";
+import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 import { base64PubkeyToNkey } from "../../../common/registry/encoding";
 
 import {
@@ -70,6 +71,15 @@ export interface JoiningStack {
   leafNode?: string;
   /** max_hop to write (schema has no default). Conservative default: 1. */
   maxHop?: number;
+  /**
+   * O-3 (cortex#1053) — the operator-mode "leaf package" (operator JWT + issued
+   * account + account JWT, optional SYS account). Present ⇒ when the stack's bus
+   * is anonymous/hard-isolated (the #794 fail-fast input), `joinNetwork` CONVERTS
+   * it to operator-mode (renders the SOP §B0.1 blocks) instead of refusing, then
+   * proceeds with the existing leaf render. Absent ⇒ the #794 fail-fast stands.
+   * O-4 (the register→issue handshake) SUPPLIES this; O-3 only consumes it.
+   */
+  operatorModePackage?: OperatorModeLeafPackage;
 }
 
 // =============================================================================
@@ -214,7 +224,44 @@ export async function joinNetwork(
   // This is a READ (no mutation), so dry-run surfaces the same decision.
   const hasCreds =
     typeof stack.credentials === "string" && stack.credentials.trim().length > 0;
-  const bindMode = ports.leafFile.resolveBindMode(stack.account, hasCreds);
+  let bindMode = ports.leafFile.resolveBindMode(stack.account, hasCreds);
+
+  // (b.5.1) O-3 (cortex#1053, spec §4-D2) — AUTO-CONVERT an anonymous bus.
+  //
+  // When the bind-mode pre-flight REFUSES (the #794 fail-fast: an anonymous /
+  // hard-isolated bus has no operator-mode account tree, so the account the leaf
+  // binds can never resolve) AND the joining stack carries a leaf package (O-4's
+  // register→issue handshake supplies it), render the SOP §B0.1 operator-mode
+  // blocks into the bus's nats config — KEEPING its own identity/ports/JS domain,
+  // adding NO leaf include — THEN re-resolve. The converted bus is operator-mode,
+  // so the re-resolve binds the account and the existing join flow proceeds.
+  //
+  // The conversion port is the single writer (live writes the rendered config;
+  // dry-run is inert). `already`/`converted` both let the join continue; a
+  // conversion `refuse` (incomplete package, or a bus already operator-mode under
+  // a DIFFERENT operator JWT — never clobber it) ABORTS before any further mutation.
+  if (bindMode.mode === "refuse" && stack.operatorModePackage !== undefined) {
+    const conversion = ports.leafFile.convertToOperatorMode(
+      stack.operatorModePackage,
+    );
+    if (conversion.status === "refuse") {
+      return {
+        ok: false,
+        steps,
+        reason:
+          `cannot auto-convert the bus to operator-mode (${conversion.reason}). ` +
+          `Refusing to render a leaf that would crash nats-server (cortex#794/#1053).`,
+      };
+    }
+    steps.push(
+      conversion.status === "converted"
+        ? `converted the anonymous bus to operator-mode (rendered the operator/account/resolver blocks — O-3, #1053)`
+        : `bus already operator-mode under this operator — no conversion needed (O-3, #1053)`,
+    );
+    // Re-resolve against the now-operator-mode bus.
+    bindMode = ports.leafFile.resolveBindMode(stack.account, hasCreds);
+  }
+
   if (bindMode.mode === "refuse") {
     const configPath = ports.leafFile.natsConfigPath();
     return {
@@ -223,7 +270,8 @@ export async function joinNetwork(
       reason:
         `nats config ${configPath} cannot federate (${bindMode.reason}). ` +
         `An operator-mode bus must DEFINE the leaf account (convert it — see ` +
-        `docs/sop-stack-onboarding.md §Part 2 — or pass a config that does via ` +
+        `docs/sop-stack-onboarding.md §Part 2, or supply a leaf package so join ` +
+        `auto-converts — O-3/#1053 — or pass a config that does via ` +
         `--nats-config); a $G/default bus needs valid leaf creds. Refusing to ` +
         `render a leaf that would crash nats-server (cortex#794/#799).`,
     };

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -34,6 +34,8 @@ import type { NetworkFetchResult } from "../../../common/registry/network-client
 import type {
   AccountBindCheck,
   LeafBindMode,
+  OperatorModeConversion,
+  OperatorModeLeafPackage,
   StackLeafBinding,
 } from "../../../common/nats/leaf-remote-renderer";
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
@@ -189,6 +191,28 @@ export interface LeafFilePort {
    * creds path; `account` is the candidate nkey-U (or `undefined`).
    */
   resolveBindMode(account: string | undefined, hasCreds: boolean): LeafBindMode;
+  /**
+   * O-3 (cortex#1053) — CONVERT an anonymous/hard-isolated bus to operator-mode
+   * by rendering the SOP §B0.1 operator-mode blocks (operator JWT +
+   * system_account + `resolver: MEMORY` + `resolver_preload`) from a leaf
+   * package, KEEPING the stack's own identity/ports/JS domain and adding NO leaf
+   * include (the join renders its own). Replaces the #794 "fail-fast and tell a
+   * human to hand-edit `<slug>.conf`" with a one-command conversion.
+   *
+   *   - `converted` — the bus was anonymous; the live adapter WROTE the rendered
+   *     operator-mode config back to `natsConfigPath()` (dry-run is inert).
+   *   - `already` — the bus was already operator-mode under THIS package's
+   *     operator JWT; a byte-stable no-op (no write).
+   *   - `refuse` — material absent/malformed (the preserved #794 fail-fast), OR
+   *     the bus is already operator-mode under a DIFFERENT operator (never
+   *     clobber it).
+   *
+   * Delegates the rendering to {@link renderOperatorModeBlocks} (pure). The
+   * orchestrator calls this ONLY when `resolveBindMode` would refuse an anonymous
+   * bus AND a leaf package is present, then re-resolves the (now operator-mode)
+   * bus. An absent config file reads as anonymous (a brand-new stack).
+   */
+  convertToOperatorMode(pkg: OperatorModeLeafPackage): OperatorModeConversion;
   /**
    * #821 — pre-flight: does the leaf `.creds` file at `path` actually EXIST on
    * disk? `nats-server -c <cfg> -t` only validates HOCON syntax — it does NOT

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -169,6 +169,17 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--principal-seed": "value",
         "--creds": "value",
         "--account": "value",
+        // O-3 (cortex#1053) — the operator-mode "leaf package" flags. When the
+        // stack's bus is anonymous/hard-isolated (the #794 fail-fast input),
+        // these let `cortex network join` AUTO-CONVERT it to operator-mode
+        // (render the SOP §B0.1 blocks) instead of refusing. Map to
+        // stack.nats_infra.{operator_jwt,account_jwt,system_account,
+        // system_account_jwt}. O-4 supplies them via the register→issue
+        // handshake; these flags/config fields are the manual/interim path.
+        "--operator-jwt": "value",
+        "--account-jwt": "value",
+        "--system-account": "value",
+        "--system-account-jwt": "value",
         "--nats-config": "value",
         "--plist": "value",
         // #763 — Linux/systemd: the nats-server systemd unit path (the
@@ -452,6 +463,11 @@ async function runJoin(
         ...readOverride(flags, "--unit", "unitPath"),
         ...readOverride(flags, "--account", "account"),
         ...readOverride(flags, "--creds", "credsPath"),
+        // O-3 (cortex#1053) — operator-mode leaf-package overrides.
+        ...readOverride(flags, "--operator-jwt", "operatorJwt"),
+        ...readOverride(flags, "--account-jwt", "accountJwt"),
+        ...readOverride(flags, "--system-account", "systemAccount"),
+        ...readOverride(flags, "--system-account-jwt", "systemAccountJwt"),
       },
       expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
       load,
@@ -490,6 +506,11 @@ async function runJoin(
     account: inputs.account,
     leafNode: optionalValueFlag(flags, "--leaf-node"),
     maxHop,
+    // O-3 (cortex#1053) — pass the operator-mode leaf package (when resolved)
+    // so join auto-converts an anonymous bus instead of fail-fasting (#794).
+    ...(inputs.operatorModePackage !== undefined && {
+      operatorModePackage: inputs.operatorModePackage,
+    }),
   };
 
   const cfg = portsConfigFromInputs(networkId, inputs, slugRes.slug, flags);
@@ -1320,6 +1341,17 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
                           2nd stack — not to re-run a converged one.
   --creds <p>             Override stack.nats_infra.creds_path (default: ~/.config/nats/<network>.creds).
   --account <nkey-U>      Override stack.nats_infra.account (A… nkey-U the leaf binds to).
+  --operator-jwt <eyJ…>   (O-3, #1053) NSC operator JWT. With --account-jwt + --account, lets join
+                          AUTO-CONVERT an anonymous/hard-isolated bus to operator-mode (render the
+                          SOP §B0.1 blocks) instead of fail-fasting (#794). Maps to
+                          stack.nats_infra.operator_jwt. O-4 supplies it via the register→issue
+                          handshake; this flag/config is the manual/interim path.
+  --account-jwt <eyJ…>    (O-3, #1053) The issued account JWT (preloaded under resolver_preload).
+                          Maps to stack.nats_infra.account_jwt.
+  --system-account <A…>   (O-3, #1053) OPTIONAL system account nkey-U (sets system_account). Maps
+                          to stack.nats_infra.system_account.
+  --system-account-jwt <eyJ…> (O-3, #1053) OPTIONAL system account JWT. Maps to
+                          stack.nats_infra.system_account_jwt.
   --nats-config <p>       Override stack.nats_infra.config_path (nats-server -c config).
   --plist <p>             Override stack.nats_infra.plist_path (macOS nats-server launchd plist).
   --unit <p>              Override stack.nats_infra.unit_path (Linux nats-server systemd unit; #763).

--- a/src/common/nats/__tests__/operator-mode-conversion.test.ts
+++ b/src/common/nats/__tests__/operator-mode-conversion.test.ts
@@ -209,6 +209,33 @@ describe("renderOperatorModeBlocks — fail-fast on missing material", () => {
     if (result.status !== "refuse") throw new Error("expected refuse");
     expect(result.reason).toMatch(/nkey|account/i);
   });
+
+  // Security-review NIT-1 (#1058) — JWT_SHAPE requires EXACTLY 3 segments.
+  test("a 2-segment operatorJwt → refuse (not a valid NSC JWT — fail fast here)", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, {
+      ...PACKAGE,
+      operatorJwt: "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.ONLY_TWO_SEGMENTS",
+    });
+    expect(result.status).toBe("refuse");
+    if (result.status !== "refuse") throw new Error("expected refuse");
+    expect(result.reason).toMatch(/JWT/i);
+  });
+
+  test("a 2-segment account 'JWT' → refuse", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, {
+      ...PACKAGE,
+      accountJwt: "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.ONLY_TWO",
+    });
+    expect(result.status).toBe("refuse");
+  });
+
+  test("a canonical 3-segment JWT is accepted (header.payload.signature)", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, {
+      ...PACKAGE,
+      operatorJwt: "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.PAYLOAD.SIGNATURE",
+    });
+    expect(result.status).toBe("converted");
+  });
 });
 
 // =============================================================================

--- a/src/common/nats/__tests__/operator-mode-conversion.test.ts
+++ b/src/common/nats/__tests__/operator-mode-conversion.test.ts
@@ -1,0 +1,246 @@
+/**
+ * O-3 (cortex#1053, epic #1050, operator-mode conversion; spec
+ * `docs/design-automated-operator-onboarding.md` §4-D2) — `cortex network join`
+ * auto-converts an anonymous/default bus to operator-mode instead of
+ * fail-fasting (#794) and telling a human to hand-edit `<slug>.conf`.
+ *
+ * This file is the RED-first spec for the PURE renderer half of O-3:
+ * {@link renderOperatorModeBlocks}. Given the stack's CURRENT (anonymous /
+ * hard-isolated) nats config text + a "leaf package" (operator JWT + the issued
+ * account pubkey `A…` + account JWT, optional system account), it renders the
+ * SOP §B0.1 operator-mode blocks INTO the config — `operator:`, `system_account`,
+ * `resolver: MEMORY`, `resolver_preload { <account>: <jwt> }` — while KEEPING the
+ * stack's own `server_name` / `listen` / `http` / `jetstream.domain` and WITHOUT
+ * adding a meta-factory leaf include (the join renders its own).
+ *
+ * It is a PURE function (text in, text out) — no filesystem, no daemon. The
+ * orchestrator (network-lib joinNetwork) calls it through the LeafFilePort.
+ *
+ * Fail-fast remains ONLY when the package is genuinely absent (no operator JWT /
+ * no account). Idempotent: re-running on an already-converted bus is a byte-stable
+ * no-op (status "already"). NEVER clobber a bus that's ALREADY operator-mode under
+ * a DIFFERENT operator JWT — detect + refuse with a clear error.
+ *
+ * Public repo — key material here is obvious fake `eyJ…` / `A…`-shaped fixtures.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  renderOperatorModeBlocks,
+  natsConfigHasAccountTree,
+  type OperatorModeConversion,
+  type OperatorModeLeafPackage,
+} from "../leaf-remote-renderer";
+
+/** Narrow to the converted config, failing the test with the reason otherwise. */
+function mustConvert(result: OperatorModeConversion): string {
+  if (result.status !== "converted") {
+    throw new Error(
+      `expected converted, got ${result.status}` +
+        (result.status === "refuse" ? `: ${result.reason}` : ""),
+    );
+  }
+  return result.conf;
+}
+
+// =============================================================================
+// Fixtures — an anonymous bus (the Part-1 hard-isolated shape) + a leaf package.
+// =============================================================================
+
+/**
+ * The anonymous / hard-isolated bus shape from sop-stack-onboarding.md Step 2:
+ * server identity + ports + jetstream domain, NO leafnodes/cluster/gateway,
+ * NO operator-mode account tree. This is what Part-1 stands a stack up on.
+ */
+const ANON_CONF = [
+  "server_name: community-andreas",
+  "listen: 127.0.0.1:4224",
+  "http: 127.0.0.1:8224",
+  "jetstream {",
+  "  store_dir: /Users/andreas/.config/nats/community-jetstream",
+  "  max_mem: 64mb",
+  "  max_file: 1gb",
+  "  domain: community-andreas",
+  "}",
+  "",
+].join("\n");
+
+// Obvious fake operator-mode material (a public-repo-safe leaf package).
+const OPERATOR_JWT =
+  "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_OPERATOR_JWT_BODY.sig";
+const ACCOUNT = "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX";
+const ACCOUNT_JWT =
+  "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_ACCOUNT_JWT_BODY.sig";
+const SYS_ACCOUNT = "ADSYS6VXCEEKH62BYKGBHXQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVM";
+const SYS_ACCOUNT_JWT =
+  "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_SYS_JWT_BODY.sig";
+
+const PACKAGE: OperatorModeLeafPackage = {
+  operatorJwt: OPERATOR_JWT,
+  account: ACCOUNT,
+  accountJwt: ACCOUNT_JWT,
+};
+
+const PACKAGE_WITH_SYS: OperatorModeLeafPackage = {
+  ...PACKAGE,
+  systemAccount: SYS_ACCOUNT,
+  systemAccountJwt: SYS_ACCOUNT_JWT,
+};
+
+// =============================================================================
+// Happy path — anonymous bus + leaf package → operator-mode blocks added.
+// =============================================================================
+
+describe("renderOperatorModeBlocks — convert an anonymous bus (O-3 D2)", () => {
+  test("an anonymous bus is NOT operator-mode to start (the #794 fail-fast input)", () => {
+    expect(natsConfigHasAccountTree(ANON_CONF)).toBe(false);
+  });
+
+  test("renders the four SOP §B0.1 operator-mode blocks", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, PACKAGE);
+    expect(result.status).toBe("converted");
+    const conf = mustConvert(result);
+
+    expect(conf).toContain(`operator: ${OPERATOR_JWT}`);
+    expect(conf).toContain("resolver: MEMORY");
+    expect(conf).toContain("resolver_preload");
+    // the issued account is preloaded with its JWT
+    expect(conf).toContain(`${ACCOUNT}: ${ACCOUNT_JWT}`);
+  });
+
+  test("the converted config IS operator-mode (the bind check now passes)", () => {
+    const conf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    expect(natsConfigHasAccountTree(conf)).toBe(true);
+  });
+
+  test("KEEPS the stack's own server_name / listen / http / jetstream domain", () => {
+    const conf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    expect(conf).toContain("server_name: community-andreas");
+    expect(conf).toContain("listen: 127.0.0.1:4224");
+    expect(conf).toContain("http: 127.0.0.1:8224");
+    expect(conf).toContain("domain: community-andreas");
+    expect(conf).toContain(
+      "store_dir: /Users/andreas/.config/nats/community-jetstream",
+    );
+  });
+
+  test("does NOT add a meta-factory leaf include (the join renders its own)", () => {
+    const conf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    // No leafnodes block and no `include "leafnodes-…"` — that is join's job.
+    expect(conf).not.toContain("leafnodes-metafactory");
+    expect(conf).not.toMatch(/^[ \t]*leafnodes[ \t]*\{/m);
+    expect(conf).not.toMatch(/include[ \t]+["']leafnodes-/);
+  });
+
+  test("renders system_account when the package carries a SYS account", () => {
+    const conf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE_WITH_SYS));
+    expect(conf).toContain(`system_account: ${SYS_ACCOUNT}`);
+    // and the SYS account is preloaded too
+    expect(conf).toContain(`${SYS_ACCOUNT}: ${SYS_ACCOUNT_JWT}`);
+  });
+});
+
+// =============================================================================
+// Idempotency — re-running on a converted bus is a byte-stable no-op.
+// =============================================================================
+
+describe("renderOperatorModeBlocks — idempotent", () => {
+  test("re-running on a bus this package already converted is status 'already'", () => {
+    const firstConf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    const second = renderOperatorModeBlocks(firstConf, PACKAGE);
+    expect(second.status).toBe("already");
+  });
+
+  test("re-render produces byte-identical config (no drift, no duplicate blocks)", () => {
+    const firstConf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    const second = renderOperatorModeBlocks(firstConf, PACKAGE);
+    // 'already' carries the unchanged conf so the orchestrator can write it
+    // byte-stably (or skip the write).
+    if (second.status !== "already") throw new Error("expected already");
+    expect(second.conf).toBe(firstConf);
+    // exactly ONE operator-mode `operator:` line — no duplicate splice.
+    const operatorModeLines = firstConf
+      .split("\n")
+      .filter((l) => /^[ \t]*operator[ \t]*:/.test(l)); // operator-mode block
+    expect(operatorModeLines).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// Fail-fast — material genuinely absent → cannot convert.
+// =============================================================================
+
+describe("renderOperatorModeBlocks — fail-fast on missing material", () => {
+  test("missing operator JWT → refuse with an actionable reason", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, {
+      ...PACKAGE,
+      operatorJwt: "",
+    });
+    expect(result.status).toBe("refuse");
+    if (result.status !== "refuse") throw new Error("expected refuse");
+    expect(result.reason).toMatch(/operator/i); // operator-mode material
+  });
+
+  test("missing account → refuse", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, {
+      ...PACKAGE,
+      account: "",
+    });
+    expect(result.status).toBe("refuse");
+    if (result.status !== "refuse") throw new Error("expected refuse");
+    expect(result.reason).toMatch(/account/i);
+  });
+
+  test("missing account JWT → refuse (resolver_preload needs the JWT)", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, {
+      ...PACKAGE,
+      accountJwt: "",
+    });
+    expect(result.status).toBe("refuse");
+  });
+
+  test("a non-nkey-U account → refuse (HOCON-injection guard)", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, {
+      ...PACKAGE,
+      account: "not-an-nkey",
+    });
+    expect(result.status).toBe("refuse");
+    if (result.status !== "refuse") throw new Error("expected refuse");
+    expect(result.reason).toMatch(/nkey|account/i);
+  });
+});
+
+// =============================================================================
+// Never clobber — already operator-mode under a DIFFERENT operator → refuse.
+// =============================================================================
+
+describe("renderOperatorModeBlocks — never clobber a foreign operator", () => {
+  const FOREIGN_OPERATOR_JWT =
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.A_DIFFERENT_OPERATOR.sig";
+  const ALREADY_OPERATOR_CONF = [
+    "server_name: community-andreas",
+    "listen: 127.0.0.1:4224",
+    `operator: ${FOREIGN_OPERATOR_JWT}`,
+    "system_account: ADSYSACCOUNT0000000000000000000000000000000000000000000",
+    "resolver: MEMORY",
+    "resolver_preload: {",
+    "  ABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB: eyJ.OTHER.sig",
+    "}",
+    "",
+  ].join("\n");
+
+  test("converting onto a config already operator-mode under a DIFFERENT operator refuses", () => {
+    const result = renderOperatorModeBlocks(ALREADY_OPERATOR_CONF, PACKAGE);
+    expect(result.status).toBe("refuse");
+    if (result.status !== "refuse") throw new Error("expected refuse");
+    expect(result.reason).toMatch(/operator|already/i); // operator-mode
+  });
+
+  test("converting onto a config already operator-mode under the SAME operator + account is 'already'", () => {
+    // Build the exact converted shape this package would produce, then re-run.
+    const convertedConf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    const again = renderOperatorModeBlocks(convertedConf, PACKAGE);
+    expect(again.status).toBe("already");
+  });
+});

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -721,6 +721,217 @@ function hasNonLeafInclude(text: string): boolean {
   return false;
 }
 
+// =============================================================================
+// O-3 (cortex#1053, epic #1050, spec docs/design-automated-operator-onboarding.md  // operator-mode
+// §4-D2) — CONVERT an anonymous/hard-isolated bus to operator-mode, in place,
+// instead of fail-fasting (#794) and telling a human to hand-edit `<slug>.conf`.
+//
+// #794 made `cortex network join` REFUSE on an anonymous bus (rendering an
+// account-bound leaf there crashes nats-server). That refusal is the right
+// last-resort, but it blocks automation: the human had to copy the four
+// operator-mode blocks out of `~/.config/nats/local.conf` by hand (SOP §B0.1).
+//
+// O-3 makes join render those blocks itself FROM THE LEAF PACKAGE (the
+// register→issue handshake of O-4 supplies it; O-3 is the renderer + the
+// conversion seam). The blocks are exactly SOP §B0.1's four:
+//   - `operator: <JWT>`        — the NSC operator JWT
+//   - `system_account: <A…>`   — OPTIONAL (only when the package carries a SYS)
+//   - `resolver: MEMORY`
+//   - `resolver_preload { <account>: <JWT> [, <sys>: <JWT>] }`
+// while KEEPING the stack's own `server_name`/`listen`/`http`/`jetstream` and
+// NOT adding a meta-factory leaf include (join renders its own per-network one).
+// =============================================================================
+
+/**
+ * The "leaf package" — the operator-mode material join needs to convert an
+ * anonymous bus. O-4 (the register→issue handshake) SUPPLIES this; O-3 only
+ * consumes + renders it. Public-repo-safe: it is JWT + nkey-U text, never a
+ * seed.
+ */
+export interface OperatorModeLeafPackage {
+  /** The NSC operator JWT (`eyJ…`) — the root of the local account tree. */
+  operatorJwt: string;
+  /** The issued account public key (nkey-U, `A…`) the leaf binds to. */
+  account: string;
+  /** The issued account's JWT (`eyJ…`) — preloaded under `resolver_preload`. */
+  accountJwt: string;
+  /** OPTIONAL system account public key (nkey-U). Sets `system_account`. */
+  systemAccount?: string;
+  /** OPTIONAL system account JWT — preloaded alongside the issued account. */
+  systemAccountJwt?: string;
+}
+
+/**
+ * The outcome of {@link renderOperatorModeBlocks}:
+ *   - `converted` — the config was anonymous; the rendered operator-mode config
+ *     is in `conf` (the orchestrator writes it).
+ *   - `already` — the config is ALREADY operator-mode under THIS package's
+ *     operator JWT; `conf` is the unchanged bytes (a byte-stable no-op).
+ *   - `refuse` — cannot convert: material absent/malformed, OR the config is
+ *     already operator-mode under a DIFFERENT operator (never clobber it).
+ */
+export type OperatorModeConversion =
+  | { status: "converted"; conf: string }
+  | { status: "already"; conf: string }
+  | { status: "refuse"; reason: string };
+
+/** A marker line so a human reading the converted config knows join wrote it. */
+const OPERATOR_MODE_MARKER =
+  "// --- operator-mode blocks rendered by cortex network join (O-3, #1053) ---";
+const OPERATOR_MODE_MARKER_END =
+  "// --- end operator-mode blocks ---";
+
+/**
+ * Render the SOP §B0.1 operator-mode blocks INTO `currentConf` from a leaf
+ * package. PURE (text in, text out): no filesystem, no daemon. The orchestrator
+ * (network-lib joinNetwork) calls this through the LeafFilePort, decides whether
+ * to write the result, then proceeds with the existing leaf-remote render.
+ *
+ * Conversion rules:
+ *   - **anonymous bus + complete package** → `converted`: append the four blocks,
+ *     KEEPING the stack's own identity/ports/JS domain verbatim, NOT touching
+ *     any `leafnodes`/`include` (the join renders its own per-network leaf).
+ *   - **already operator-mode under THIS operator** → `already` (idempotent
+ *     no-op: re-running a converted bus must not duplicate or drift).
+ *   - **already operator-mode under a DIFFERENT operator** → `refuse`: never
+ *     clobber a bus standing on someone else's account tree.
+ *   - **material absent/malformed** → `refuse` with an actionable reason (this
+ *     is the #794 fail-fast, preserved for the genuinely-unconvertible case).
+ *
+ * The account nkey-U is validated against {@link NKEY_ACCOUNT} before it is
+ * emitted, and the operator JWT + account JWTs are emitted ONLY as bare `eyJ…` tokens
+ * matching the live `local.conf` shape — both guards prevent HOCON injection
+ * (a value carrying whitespace/braces/newlines would break out of the block).
+ */
+export function renderOperatorModeBlocks(
+  currentConf: string,
+  pkg: OperatorModeLeafPackage,
+): OperatorModeConversion {
+  // 1) Validate the package — the genuinely-unconvertible cases fail fast (#794).
+  const operatorJwt = pkg.operatorJwt.trim();
+  const account = pkg.account.trim();
+  const accountJwt = pkg.accountJwt.trim();
+  const systemAccount = pkg.systemAccount?.trim();
+  const systemAccountJwt = pkg.systemAccountJwt?.trim();
+
+  if (operatorJwt.length === 0) {
+    return {
+      status: "refuse",
+      reason:
+        "leaf package is missing the operator JWT — cannot render operator-mode " +
+        "(pass --operator-jwt or set stack.nats_infra.operator_jwt; O-4 supplies it " +
+        "via the register→issue handshake).",
+    };
+  }
+  if (!JWT_SHAPE.test(operatorJwt)) {
+    return {
+      status: "refuse",
+      reason: `operator JWT ${JSON.stringify(pkg.operatorJwt)} is not a JWT (expected an \`eyJ…\` token)`,
+    };
+  }
+  if (account.length === 0) {
+    return {
+      status: "refuse",
+      reason:
+        "leaf package is missing the issued account public key — cannot bind the " +
+        "leaf (pass --account or set stack.nats_infra.account).",
+    };
+  }
+  if (!NKEY_ACCOUNT.test(account)) {
+    return {
+      status: "refuse",
+      reason: `account ${JSON.stringify(pkg.account)} is not an nkey-U account public key (\`A…\`)`,
+    };
+  }
+  if (accountJwt.length === 0 || !JWT_SHAPE.test(accountJwt)) {
+    return {
+      status: "refuse",
+      reason:
+        "leaf package is missing a valid account JWT — `resolver_preload` needs the " +
+        "issued account's JWT (pass --account-jwt or set stack.nats_infra.account_jwt).",
+    };
+  }
+  // A SYS account is OPTIONAL, but if one is offered it must be well-formed
+  // AND paired with its JWT (a half-specified SYS account would emit a
+  // `system_account` line with no preload → nats-server can't resolve it).
+  if (systemAccount !== undefined && systemAccount.length > 0) {
+    if (!NKEY_ACCOUNT.test(systemAccount)) {
+      return {
+        status: "refuse",
+        reason: `system account ${JSON.stringify(pkg.systemAccount)} is not an nkey-U account public key`,
+      };
+    }
+    if (
+      systemAccountJwt === undefined ||
+      systemAccountJwt.length === 0 ||
+      !JWT_SHAPE.test(systemAccountJwt)
+    ) {
+      return {
+        status: "refuse",
+        reason:
+          "a system account was offered without a valid system account JWT — " +
+          "`resolver_preload` must carry the SYS account's JWT too.",
+      };
+    }
+  }
+
+  // 2) Already operator-mode? Decide between idempotent no-op and clobber-refuse.
+  if (natsConfigHasAccountTree(currentConf)) {
+    const stripped = stripConfigComments(currentConf);
+    const existingOperatorJwt = /^[ \t]*operator[ \t]*[:=][ \t]*(\S+)/m.exec( // operator-mode block line
+      stripped,
+    );
+    // SAME operator JWT already present → this package already converted it.
+    // Byte-stable no-op (the orchestrator may skip the write).
+    if (existingOperatorJwt?.[1] === operatorJwt) {
+      return { status: "already", conf: currentConf };
+    }
+    // Operator-mode under a DIFFERENT (or unreadable) operator JWT — NEVER clobber.
+    return {
+      status: "refuse",
+      reason:
+        "the nats config is ALREADY operator-mode under a different operator — " +
+        "refusing to overwrite its account tree. Convert/clean the bus by hand " +
+        "or join with the operator that owns this bus (cortex#1053).",
+    };
+  }
+
+  // 3) Anonymous bus + complete package → render the four §B0.1 blocks.
+  // We APPEND them (KEEPING the stack's own identity/ports/JS domain verbatim,
+  // and never touching any leafnodes/include). The trailing newline of the
+  // source config is normalised so the appended block sits on its own lines.
+  const preload: string[] = [
+    `  ${account}: ${accountJwt}`,
+  ];
+  if (systemAccount !== undefined && systemAccount.length > 0) {
+    preload.push(`  ${systemAccount}: ${systemAccountJwt ?? ""}`);
+  }
+
+  const blocks: string[] = [
+    OPERATOR_MODE_MARKER,
+    `operator: ${operatorJwt}`,
+  ];
+  if (systemAccount !== undefined && systemAccount.length > 0) {
+    blocks.push(`system_account: ${systemAccount}`);
+  }
+  blocks.push("resolver: MEMORY", "resolver_preload: {", ...preload, "}");
+  blocks.push(OPERATOR_MODE_MARKER_END);
+
+  const base = currentConf.replace(/\n+$/, "");
+  const conf = `${base}\n\n${blocks.join("\n")}\n`;
+  return { status: "converted", conf };
+}
+
+/**
+ * A JWT shape guard for the operator JWT + account JWTs emitted bare into the config.
+ * NSC JWTs are `eyJ…` (a base64url-encoded `{"alg":…}` header) — three
+ * base64url segments joined by `.`. We require the `eyJ` prefix + a
+ * dot-separated base64url body (no whitespace/braces/newlines) so a hostile or
+ * malformed value cannot break out of the rendered block. (Validated, never
+ * cryptographically verified — verification is O-4's handshake.)
+ */
+const JWT_SHAPE = /^eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){1,2}$/;
+
 /**
  * #821 MAJOR (code-review) — derive the nats-server HTTP MONITOR url from its
  * config, so the post-restart health probe targets THIS bus's monitor port (the

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -914,6 +914,11 @@ export function renderOperatorModeBlocks(
   if (systemAccount !== undefined && systemAccount.length > 0) {
     blocks.push(`system_account: ${systemAccount}`);
   }
+  // Security-review NIT-2 (#1058) — `resolver_preload:` with the COLON form
+  // (not the brace-only `resolver_preload {`): this matches the production hub's
+  // `~/.config/nats/local.conf` shape (which uses the colon form), so a converted
+  // bus looks identical to a hand-built operator-mode one. Both forms are valid
+  // HOCON; we pick the colon form deliberately to match local.conf.
   blocks.push("resolver: MEMORY", "resolver_preload: {", ...preload, "}");
   blocks.push(OPERATOR_MODE_MARKER_END);
 
@@ -924,13 +929,18 @@ export function renderOperatorModeBlocks(
 
 /**
  * A JWT shape guard for the operator JWT + account JWTs emitted bare into the config.
- * NSC JWTs are `eyJ…` (a base64url-encoded `{"alg":…}` header) — three
- * base64url segments joined by `.`. We require the `eyJ` prefix + a
- * dot-separated base64url body (no whitespace/braces/newlines) so a hostile or
- * malformed value cannot break out of the rendered block. (Validated, never
- * cryptographically verified — verification is O-4's handshake.)
+ * NSC JWTs are `eyJ…` (a base64url-encoded `{"alg":…}` header) — EXACTLY three
+ * base64url segments joined by `.` (header.payload.signature). We require the
+ * `eyJ` prefix + exactly two more dot-separated base64url segments (no
+ * whitespace/braces/newlines) so a hostile or malformed value cannot break out
+ * of the rendered block. (Validated, never cryptographically verified —
+ * verification is O-4's handshake.)
+ *
+ * Security-review NIT-1 (#1058) — `{2}` (exactly two trailing segments), not
+ * `{1,2}`: a 2-segment value is not a valid NSC JWT, and accepting one would let
+ * nats-server reject it at RUNTIME (bus restart) instead of failing fast here.
  */
-const JWT_SHAPE = /^eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){1,2}$/;
+const JWT_SHAPE = /^eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2}$/;
 
 /**
  * #821 MAJOR (code-review) — derive the nats-server HTTP MONITOR url from its

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -110,6 +110,27 @@ export const StackNatsInfraSchema = z.object({
    * (per-network creds file). Declare here only to override the convention.
    */
   creds_path: z.string().min(1).optional(),
+  /**
+   * O-3 (cortex#1053) — the operator-mode "leaf package": the material
+   * `cortex network join` needs to AUTO-CONVERT an anonymous/hard-isolated bus
+   * to operator-mode (rendering the SOP §B0.1 blocks) instead of fail-fasting
+   * (#794). All OPTIONAL — a stack standing on an already-operator-mode bus, or
+   * one that never federates, omits them. O-4 (the register→issue handshake)
+   * SUPPLIES these at join time; declaring them in config is the manual /
+   * interim path. These are JWTs + an account pubkey — public-key material, not
+   * seeds — but a federating stack's config still carries the bot token, so keep
+   * the stack file chmod 600.
+   *
+   * `operator_jwt` + `account` + `account_jwt` are the minimum to convert; a
+   * `system_account` (+ its `system_account_jwt`) is rendered only when present.
+   */
+  operator_jwt: z.string().min(1).optional(),
+  account_jwt: z.string().min(1).optional(),
+  system_account: z.string().regex(
+    /^A[A-Z0-9]{55}$/,
+    "stack.nats_infra.system_account must be an account-class NKey (A-prefixed, 56 chars total)",
+  ).optional(),
+  system_account_jwt: z.string().min(1).optional(),
 }).strict();
 
 export type StackNatsInfra = z.infer<typeof StackNatsInfraSchema>;


### PR DESCRIPTION
Closes #1053 · refs #1050 (epic) · refs #1049 (spec)

## What

Per the automated-operator-onboarding spec `docs/design-automated-operator-onboarding.md` §4-D2: today `cortex network join` FAIL-FASTS on an anonymous/hard-isolated bus (the #794 guard) and tells a human to hand-edit `<slug>.conf` with the four operator-mode blocks. Error-prone, blocks automation.

O-3 makes join **render those blocks itself** from a "leaf package", then proceed with the existing leaf-remote render + `policy.federated.networks[]` write + restart.

## The conversion seam

- **`renderOperatorModeBlocks(currentConf, pkg)`** — pure (text in, text out), in `src/common/nats/leaf-remote-renderer.ts`. Appends the SOP §B0.1 blocks (`operator:` JWT, optional `system_account`, `resolver: MEMORY`, `resolver_preload { account: jwt[, sys: jwt] }`) while KEEPING the stack's own `server_name`/`listen`/`http`/`jetstream.domain` and adding NO meta-factory leaf include (join renders its own per-network one).
- **`LeafFilePort.convertToOperatorMode`** — live adapter writes the rendered config back to the nats config path; dry-run is inert but surfaces the decision (it's a READ).
- **`joinNetwork`** — calls the conversion ONLY when `resolveBindMode` refuses (the #794 anonymous-bus input) AND the joining stack carries a leaf package, then re-resolves the now-operator-mode bus and proceeds.
- **Material flows in** via `--operator-jwt`/`--account-jwt`/`--account` (+ optional `--system-account`/`--system-account-jwt`) flags, or `stack.nats_infra.{operator_jwt,account_jwt,system_account,system_account_jwt}` config.

## Fail-fast / refuse conditions (preserved)

- Missing operator JWT / account / account JWT (or a partial package) → **refuse** (the #794 fail-fast preserved for the genuinely-unconvertible case).
- A bus already operator-mode under a **DIFFERENT** operator → **refuse** (never clobber someone else's account tree).
- Already operator-mode under the SAME operator → **`already`** (idempotent, byte-stable no-op).

## Out of scope (O-4)

The register→issue handshake that SUPPLIES the leaf package is **O-4**. O-3 is the renderer + conversion seam; the package arrives via flags/config in the interim.

## Gates

- `bunx tsc --noEmit` — clean
- `bunx eslint --quiet src/` — clean
- `bun test src/` — 6854 pass / 0 fail (30 new O-3 tests: 14 renderer + 6 orchestrator + 5 live-adapter round-trip + 5 derive)
- `bash scripts/check-carveouts.sh` — PASS (added NSC operator-JWT / operator-mode-conversion carve patterns; all the NSC account-tree sense, never the principal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)