### PR TITLE
feat(mc): network graph — local-sibling hubs + Strata-style orthogonal edge routing

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-canvas-lazy-chunk.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-canvas-lazy-chunk.test.ts
@@ -1,0 +1,51 @@
+/**
+ * #1008 (network-graph-rendering) — the network-canvas chunk must stay LAZY.
+ *
+ * The graph engine (`@xyflow/react` + `elkjs`) lives behind a `React.lazy`
+ * boundary so it never bloats the entry bundle (the established precedent). The
+ * #1008 custom ELK edge (`network-elk-edge.tsx`) ALSO imports `@xyflow/react`,
+ * so it must be reachable ONLY through the lazy canvas, never statically from the
+ * entry-reachable view.
+ *
+ * Asserted STRUCTURALLY (no build needed): `network-view` references the canvas
+ * ONLY via `React.lazy(() => import("./network-canvas"))`, and the custom edge is
+ * imported ONLY by the canvas. `bun run build:dashboard` is the runtime oracle
+ * that confirms the actual split (checked in gates).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DIR = join(import.meta.dir, "..");
+
+function read(rel: string): string {
+  return readFileSync(join(DIR, rel), "utf8");
+}
+
+describe("network-canvas lazy-chunk boundary (#1008)", () => {
+  it("network-view loads the canvas via React.lazy(() => import(...)), not a static import", () => {
+    const src = read("components/network-view.tsx");
+    expect(src).toMatch(
+      /lazy\(\s*\(\)\s*=>\s*import\(["']\.\/network-canvas["']\)\s*\)/,
+    );
+    // No static top-level import of the canvas (which would fold it into entry).
+    expect(src).not.toMatch(
+      /^\s*import\s+.*from\s+["']\.\/network-canvas["']/m,
+    );
+  });
+
+  it("the custom ELK edge is imported ONLY by the lazy canvas, not the entry-reachable view", () => {
+    // The view (entry-reachable) must never statically import the edge.
+    const view = read("components/network-view.tsx");
+    expect(view).not.toMatch(/from\s+["']\.\/network-elk-edge["']/);
+    // The canvas (lazy) is the one place it's imported.
+    const canvas = read("components/network-canvas.tsx");
+    expect(canvas).toMatch(/from\s+["']\.\/network-elk-edge["']/);
+  });
+
+  it("the custom ELK edge imports the heavy graph lib (@xyflow/react) — confirming it belongs lazy", () => {
+    const edge = read("components/network-elk-edge.tsx");
+    expect(edge).toMatch(/from\s+["']@xyflow\/react["']/);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-detail-panel.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-detail-panel.test.tsx
@@ -80,6 +80,10 @@ function render(
   over: Partial<NetworkDetailPanelProps> & { agent: AgentPresenceTile },
 ): string {
   const props: NetworkDetailPanelProps = {
+    // Default serving principal `andreas` (matching the local fixtures), so a
+    // `"local"` tile classifies `self` and a `jc/*` tile classifies `foreign`.
+    // The #1008 sibling tests override it explicitly.
+    servingPrincipal: "andreas",
     dispatch: null,
     onClose: () => {},
     now: Date.now(),
@@ -276,6 +280,7 @@ describe("NetworkDetailPanel — F.3 dispatch-direct affordance", () => {
     const calls: AgentPresenceTile[] = [];
     const el = createElement(NetworkDetailPanel, {
       agent,
+      servingPrincipal: "andreas",
       dispatch: null,
       onClose: () => {},
       onDispatchDirect: (a) => {
@@ -316,6 +321,105 @@ describe("NetworkDetailPanel — F.3 dispatch-direct affordance", () => {
     });
     // F-19 DispatchButton renders "…" + a disabled button while busy.
     expect(html).toContain("disabled");
+  });
+});
+
+const SIBLING_ORIGIN = { principal: "andreas", stack: "work" } as const;
+
+function siblingTile(
+  over: Partial<AgentPresenceTile> & { agent_id: string } = { agent_id: "echo" },
+): AgentPresenceTile {
+  return tile({
+    ...over,
+    key: `andreas/work/${over.agent_id}`,
+    principal: "andreas",
+    stack: "work",
+    origin: SIBLING_ORIGIN,
+  });
+}
+
+describe("NetworkDetailPanel — local-sibling vs federated classification (#1008)", () => {
+  it("renders a SAME-PRINCIPAL local SIBLING agent as LOCAL, NOT federated", () => {
+    // The bug: clicking a sibling agent re-showed the "FEDERATED" mislabel the
+    // node fix killed. With the serving principal threaded, the panel classifies
+    // the sibling LOCAL — no federated badge, no foreign provenance, no
+    // "activity not local (federated)" framing.
+    const html = render({
+      agent: siblingTile({ agent_id: "echo", assistant_name: "Echo" }),
+      servingPrincipal: "andreas",
+    });
+    expect(html).toContain('data-agent-origin="local"');
+    // No foreign treatment: not the aside modifier, not the provenance badge,
+    // not the federated-activity class — a sibling reads as one of your own.
+    expect(html).not.toContain("network-detail-panel network-detail-foreign");
+    expect(html).not.toContain("network-detail-foreign-activity");
+    expect(html).not.toContain("network-detail-provenance");
+    expect(html).not.toContain("Federated peer");
+  });
+
+  it("frames a sibling's non-local activity as a SIBLING stack, not a federated peer", () => {
+    const html = render({
+      agent: siblingTile({ agent_id: "echo" }),
+      servingPrincipal: "andreas",
+    });
+    // The activity note distinguishes a sibling (its own LOCAL stack) from a
+    // federated peer — and never mislabels it "Federated".
+    expect(html).toContain('data-activity-origin="sibling"');
+    expect(html).toContain("Local sibling stack");
+    expect(html).toContain("andreas/work");
+    expect(html).not.toContain("Federated peer");
+  });
+
+  it("does NOT show the live Dispatch button for a sibling (dispatch is this-stack-local)", () => {
+    const html = render({
+      agent: siblingTile({ agent_id: "echo" }),
+      servingPrincipal: "andreas",
+      onDispatchDirect: () => {},
+    });
+    expect(html).toContain("network-detail-dispatch-direct");
+    // No live button — a sibling lives on another stack; show the future-state.
+    expect(html).not.toContain("network-detail-dispatch-direct-btn");
+    expect(html).toContain('data-dispatch-direct="sibling-disabled"');
+    expect(html).toContain("Local sibling stack");
+    // and it is NOT mislabeled as a federated peer
+    expect(html).not.toContain("foreign-disabled");
+  });
+
+  it("hides the 'view in working grid' link for a sibling (grid is this stack's surface)", () => {
+    const html = render({
+      agent: siblingTile({ agent_id: "echo" }),
+      servingPrincipal: "andreas",
+      onViewInWorkingGrid: () => {},
+    });
+    expect(html).not.toContain("View in working grid");
+  });
+
+  it("still treats a CROSS-PRINCIPAL peer as foreign even with a same stack name", () => {
+    const html = render({
+      agent: tile({
+        agent_id: "nova",
+        key: "jc/work/nova",
+        principal: "jc",
+        stack: "work",
+        origin: { principal: "jc", stack: "work" },
+      }),
+      servingPrincipal: "andreas",
+      onDispatchDirect: () => {},
+    });
+    expect(html).toContain('data-agent-origin="foreign"');
+    expect(html).toContain("Federated peer");
+    expect(html).toContain("foreign-disabled");
+  });
+
+  it("classifies an object origin as foreign when the serving principal is unknown (null)", () => {
+    // Foreign-only snapshot → null serving principal → an object origin can't be
+    // proven a sibling, so it stays foreign (conservative).
+    const html = render({
+      agent: siblingTile({ agent_id: "echo" }),
+      servingPrincipal: null,
+    });
+    expect(html).toContain('data-agent-origin="foreign"');
+    expect(html).toContain("Federated peer");
   });
 });
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-elk-edge.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-elk-edge.test.ts
@@ -1,0 +1,90 @@
+/**
+ * #1008 (network-graph-rendering) — pure ELK-edge geometry tests.
+ *
+ * The SVG edge component (`NetworkElkEdge`) imports `@xyflow/react` and can't
+ * mount under `renderToStaticMarkup` (no provider), so we unit-test the PURE
+ * geometry helpers it delegates to: `elkPointsToPath` (bend points → rounded SVG
+ * path) and `clampElkPointsToFaces` (snap endpoints to the node faces). The
+ * runtime render is covered by the build gate + manual dashboard QA.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  elkPointsToPath,
+  clampElkPointsToFaces,
+} from "../components/network-elk-edge";
+
+describe("elkPointsToPath (#1008)", () => {
+  it("returns an empty path for fewer than two points", () => {
+    expect(elkPointsToPath([])).toBe("");
+    expect(elkPointsToPath([{ x: 1, y: 2 }])).toBe("");
+  });
+
+  it("draws a straight line for exactly two points", () => {
+    expect(elkPointsToPath([{ x: 0, y: 0 }, { x: 10, y: 20 }])).toBe(
+      "M 0 0 L 10 20",
+    );
+  });
+
+  it("rounds an interior corner with a quadratic bezier through the bend", () => {
+    // An L-shaped route: down then right. The middle bend should round.
+    const path = elkPointsToPath(
+      [
+        { x: 0, y: 0 },
+        { x: 0, y: 100 },
+        { x: 100, y: 100 },
+      ],
+      8,
+    );
+    expect(path.startsWith("M 0 0")).toBe(true);
+    // a quadratic (rounded corner) is emitted through the bend point (0,100)
+    expect(path).toContain("Q 0 100");
+    // and it terminates at the endpoint
+    expect(path.endsWith("L 100 100")).toBe(true);
+  });
+
+  it("falls back to a sharp corner when a segment is too short to round", () => {
+    // The second segment (1px) is shorter than 2*radius → no arc, a plain L.
+    const path = elkPointsToPath(
+      [
+        { x: 0, y: 0 },
+        { x: 0, y: 100 },
+        { x: 0, y: 101 },
+      ],
+      8,
+    );
+    expect(path).toContain("L 0 100");
+    expect(path).not.toContain("Q");
+  });
+});
+
+describe("clampElkPointsToFaces (#1008)", () => {
+  it("snaps a downward-exiting start to the source handle Y (bottom face)", () => {
+    const out = clampElkPointsToFaces(
+      [
+        { x: 5, y: 10 }, // ELK start (slightly off the real face)
+        { x: 5, y: 50 }, // next is below → exits downward
+        { x: 5, y: 90 },
+      ],
+      { sourceY: 12, targetY: 88 },
+    );
+    expect(out[0]).toEqual({ x: 5, y: 12 }); // snapped to sourceY
+  });
+
+  it("snaps a from-above entry to the target handle Y (top face)", () => {
+    const out = clampElkPointsToFaces(
+      [
+        { x: 5, y: 10 },
+        { x: 5, y: 50 },
+        { x: 5, y: 90 }, // prev is above → enters from above
+      ],
+      { sourceY: 10, targetY: 88 },
+    );
+    expect(out[out.length - 1]).toEqual({ x: 5, y: 88 }); // snapped to targetY
+  });
+
+  it("returns the points unchanged for a degenerate (<2) route", () => {
+    const pts = [{ x: 0, y: 0 }];
+    expect(clampElkPointsToFaces(pts, { sourceY: 0, targetY: 0 })).toBe(pts);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
@@ -10,11 +10,13 @@
 import { describe, it, expect } from "bun:test";
 import {
   buildNetworkGraph,
+  deriveServingPrincipal,
   STACK_HUB_NODE_ID,
   FOREIGN_HUB_ID_PREFIX,
   type AgentNodeData,
   type StackHubNodeData,
 } from "../lib/network-graph-adapter";
+import { classifyOrigin } from "../lib/agents-display";
 import type { AgentPresenceTile } from "../hooks/use-agents";
 
 function tile(
@@ -53,6 +55,25 @@ function foreignTile(
     principal,
     stack,
     origin: { principal, stack },
+  });
+}
+
+/**
+ * #1008 — a SAME-PRINCIPAL local SIBLING tile (DB-read aggregation): an OBJECT
+ * origin whose principal is the SERVING principal (`andreas`), a DIFFERENT stack.
+ * Structurally identical on the wire to a foreign peer — the classifier tells
+ * them apart by the serving principal.
+ */
+function siblingTile(
+  over: Partial<AgentPresenceTile> & { agent_id: string; stack: string },
+): AgentPresenceTile {
+  const { agent_id, stack } = over;
+  return tile({
+    ...over,
+    key: `andreas/${stack}/${agent_id}`,
+    principal: "andreas",
+    stack,
+    origin: { principal: "andreas", stack },
   });
 }
 
@@ -144,6 +165,7 @@ describe("buildNetworkGraph (G-1114.D.2)", () => {
         "lastHeartbeatAt",
         "offlineReason",
         "origin",
+        "servingPrincipal",
         "state",
       ].sort(),
     );
@@ -272,5 +294,112 @@ describe("buildNetworkGraph — federated multi-hub grouping (G-1114.E.3)", () =
 
   it("returns an empty graph for an empty snapshot (federated path too)", () => {
     expect(buildNetworkGraph([])).toEqual({ nodes: [], edges: [] });
+  });
+});
+
+describe("deriveServingPrincipal (#1008)", () => {
+  it("reads the serving principal off the first local-origin agent", () => {
+    expect(
+      deriveServingPrincipal([
+        tile({ agent_id: "luna" }),
+        foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+      ]),
+    ).toBe("andreas");
+  });
+
+  it("returns null when no local agent is present (foreign-only snapshot)", () => {
+    expect(
+      deriveServingPrincipal([
+        foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty snapshot", () => {
+    expect(deriveServingPrincipal([])).toBeNull();
+  });
+});
+
+describe("buildNetworkGraph — local-sibling vs federated classification (#1008)", () => {
+  it("threads the serving principal onto every node", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      siblingTile({ agent_id: "echo", stack: "work" }),
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+    ]);
+    for (const n of g.nodes) {
+      const d = n.data as StackHubNodeData | AgentNodeData;
+      expect(d.servingPrincipal).toBe("andreas");
+    }
+  });
+
+  it("classifies a SAME-PRINCIPAL sibling as local (NOT federated), foreign as federated", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }), // self
+      siblingTile({ agent_id: "echo", stack: "work" }), // same-principal sibling
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }), // cross-principal
+    ]);
+
+    const selfHub = g.nodes.find((n) => n.id === STACK_HUB_NODE_ID)!
+      .data as StackHubNodeData;
+    const siblingHub = g.nodes.find(
+      (n) => n.id === `${FOREIGN_HUB_ID_PREFIX}andreas/work`,
+    )!.data as StackHubNodeData;
+    const foreignHub = g.nodes.find(
+      (n) => n.id === `${FOREIGN_HUB_ID_PREFIX}jc/research`,
+    )!.data as StackHubNodeData;
+
+    // Self + sibling are LOCAL categories; only the cross-principal peer is foreign.
+    expect(classifyOrigin(selfHub.origin, selfHub.servingPrincipal)).toBe("self");
+    expect(classifyOrigin(siblingHub.origin, siblingHub.servingPrincipal)).toBe(
+      "sibling",
+    );
+    expect(classifyOrigin(foreignHub.origin, foreignHub.servingPrincipal)).toBe(
+      "foreign",
+    );
+  });
+
+  it("still gives each distinct stack its OWN hub (sibling gets its own, not the local one)", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      siblingTile({ agent_id: "echo", stack: "work" }),
+    ]);
+    const hubs = g.nodes.filter((n) => n.type === "stackHub");
+    // local hub + the sibling's own hub = 2 distinct hubs
+    expect(hubs).toHaveLength(2);
+    expect(hubs.map((h) => h.id)).toContain(STACK_HUB_NODE_ID);
+    expect(hubs.map((h) => h.id)).toContain(
+      `${FOREIGN_HUB_ID_PREFIX}andreas/work`,
+    );
+    // the sibling agent is wired to its OWN hub, not the local one
+    const edge = g.edges.find((e) => e.target === "andreas/work/echo")!;
+    expect(edge.source).toBe(`${FOREIGN_HUB_ID_PREFIX}andreas/work`);
+  });
+
+  it("classifies an object origin as foreign when the serving principal is unknown", () => {
+    // Foreign-only snapshot → no local agent → servingPrincipal null → an object
+    // origin can't be proven a sibling, so it conservatively reads foreign.
+    const g = buildNetworkGraph([
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+    ]);
+    const hub = g.nodes.find((n) => n.type === "stackHub")!
+      .data as StackHubNodeData;
+    expect(hub.servingPrincipal).toBeNull();
+    expect(classifyOrigin(hub.origin, hub.servingPrincipal)).toBe("foreign");
+  });
+
+  it("a local-only snapshot only gains the servingPrincipal field (otherwise unchanged)", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      tile({ agent_id: "echo" }),
+    ]);
+    // one local hub, every node carries servingPrincipal "andreas", origin "local"
+    const hubs = g.nodes.filter((n) => n.type === "stackHub");
+    expect(hubs).toHaveLength(1);
+    for (const n of g.nodes) {
+      const d = n.data as StackHubNodeData | AgentNodeData;
+      expect(d.origin).toBe("local");
+      expect(d.servingPrincipal).toBe("andreas");
+    }
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
@@ -91,11 +91,14 @@ describe("toElkGraph (G-1114.D.3)", () => {
     }
   });
 
-  it("uses the force algorithm with component separation (multi-cluster stars)", () => {
-    // E.3: several disconnected stack-clusters (local + each peer) — force +
-    // separateConnectedComponents lays each out as its own group rather than
-    // forcing a single radial root.
-    expect(NETWORK_ELK_OPTIONS["elk.algorithm"]).toContain("force");
+  it("uses the layered algorithm + orthogonal routing with component separation (#1008)", () => {
+    // #1008: cortex's topology is a SET of hub→agents trees. `layered` (DOWN)
+    // places each hub above its agents (tidy per-stack tree), ORTHOGONAL routing
+    // gives right-angled bend points (rendered as rounded polylines, no diagonal
+    // crossings), and separateConnectedComponents packs each stack-tree apart.
+    expect(NETWORK_ELK_OPTIONS["elk.algorithm"]).toContain("layered");
+    expect(NETWORK_ELK_OPTIONS["elk.direction"]).toBe("DOWN");
+    expect(NETWORK_ELK_OPTIONS["elk.edgeRouting"]).toBe("ORTHOGONAL");
     expect(NETWORK_ELK_OPTIONS["elk.separateConnectedComponents"]).toBe("true");
   });
 
@@ -115,7 +118,11 @@ describe("toElkGraph (G-1114.D.3)", () => {
   });
 });
 
-/** Deterministic ELK stub: lays nodes out on a fixed grid, no WASM. */
+/**
+ * Deterministic ELK stub: lays nodes out on a fixed grid, no WASM, and emits a
+ * simple orthogonal `sections[0]` per edge (start → one bend → end) so the
+ * edge-route extraction has something to read back.
+ */
 function stubElk(): ElkLike {
   return {
     async layout(graph: ElkInputGraph): Promise<ElkLaidOutGraph> {
@@ -126,6 +133,16 @@ function stubElk(): ElkLike {
           y: i * 50,
           width: c.width,
           height: c.height,
+        })),
+        edges: graph.edges.map((e) => ({
+          id: e.id,
+          sections: [
+            {
+              startPoint: { x: 0, y: 0 },
+              bendPoints: [{ x: 0, y: 25 }],
+              endPoint: { x: 0, y: 50 },
+            },
+          ],
         })),
       };
     },
@@ -142,7 +159,7 @@ describe("layoutNetworkGraph (G-1114.D.3)", () => {
       },
     };
     const out = await layoutNetworkGraph(spy, { nodes: [], edges: [] });
-    expect(out).toEqual([]);
+    expect(out).toEqual({ nodes: [], edges: [] });
     expect(called).toBe(false);
   });
 
@@ -151,23 +168,51 @@ describe("layoutNetworkGraph (G-1114.D.3)", () => {
       tile({ agent_id: "luna" }),
       tile({ agent_id: "echo" }),
     ]);
-    const out = await layoutNetworkGraph(stubElk(), graph);
+    const { nodes } = await layoutNetworkGraph(stubElk(), graph);
     // 1 hub + 2 agents
-    expect(out).toHaveLength(3);
+    expect(nodes).toHaveLength(3);
     // The hub is index 0 in the adapter output → stub put it at (0,0).
-    const hub = out.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    const hub = nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
     expect(hub.position).toEqual({ x: 0, y: 0 });
     // The 2nd node got (100,50) from the stub.
-    expect(out[1]!.position).toEqual({ x: 100, y: 50 });
-    expect(out[2]!.position).toEqual({ x: 200, y: 100 });
+    expect(nodes[1]!.position).toEqual({ x: 100, y: 50 });
+    expect(nodes[2]!.position).toEqual({ x: 200, y: 100 });
+  });
+
+  it("extracts ELK's edge bend points into each edge's layout payload (#1008)", async () => {
+    const graph = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      tile({ agent_id: "echo" }),
+    ]);
+    const { edges } = await layoutNetworkGraph(stubElk(), graph);
+    expect(edges).toHaveLength(2);
+    for (const e of edges) {
+      // [startPoint, ...bendPoints, endPoint] — the stub emits 3 points.
+      expect(e.layout.elkPoints).toEqual([
+        { x: 0, y: 0 },
+        { x: 0, y: 25 },
+        { x: 0, y: 50 },
+      ]);
+      // Source/target face geometry is populated (for face-clamping).
+      expect(typeof e.layout.layoutSourceX).toBe("number");
+      expect(typeof e.layout.targetBottomY).toBe("number");
+    }
+  });
+
+  it("preserves the origin-grouped edge id/source/target through layout (#1008)", async () => {
+    const graph = buildNetworkGraph([tile({ agent_id: "luna" })]);
+    const { edges } = await layoutNetworkGraph(stubElk(), graph);
+    expect(edges[0]!.id).toBe(graph.edges[0]!.id);
+    expect(edges[0]!.source).toBe(graph.edges[0]!.source);
+    expect(edges[0]!.target).toBe(graph.edges[0]!.target);
   });
 
   it("preserves node data while only replacing position", async () => {
     const graph = buildNetworkGraph([
       tile({ agent_id: "luna", assistant_name: "Luna" }),
     ]);
-    const out = await layoutNetworkGraph(stubElk(), graph);
-    const agent = out.find((n) => n.type === "agent")!;
+    const { nodes } = await layoutNetworkGraph(stubElk(), graph);
+    const agent = nodes.find((n) => n.type === "agent")!;
     expect(agent.data).toEqual(
       graph.nodes.find((n) => n.type === "agent")!.data,
     );
@@ -181,7 +226,9 @@ describe("layoutNetworkGraph (G-1114.D.3)", () => {
         return { children: [] };
       },
     };
-    const out = await layoutNetworkGraph(partial, graph);
-    for (const n of out) expect(n.position).toEqual({ x: 0, y: 0 });
+    const { nodes, edges } = await layoutNetworkGraph(partial, graph);
+    for (const n of nodes) expect(n.position).toEqual({ x: 0, y: 0 });
+    // An edge ELK didn't route carries no elkPoints (the edge falls back).
+    expect(edges[0]!.layout.elkPoints).toBeUndefined();
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes-transport.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes-transport.test.tsx
@@ -18,6 +18,7 @@ function hub(over: Partial<StackHubNodeData> = {}): StackHubNodeData {
   return {
     kind: "stack-hub",
     origin: "local",
+    servingPrincipal: "andreas",
     principal: "andreas",
     stack: "research",
     agentCount: 2,
@@ -30,6 +31,7 @@ function agent(over: Partial<AgentNodeData> = {}): AgentNodeData {
     kind: "agent",
     key: "andreas/research/luna",
     origin: "local",
+    servingPrincipal: "andreas",
     agentId: "luna",
     assistantName: "Luna",
     capabilities: [],

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
@@ -30,6 +30,7 @@ function agentData(over: Partial<AgentNodeData> = {}): AgentNodeData {
     kind: "agent",
     key: "andreas/research/luna",
     origin: "local",
+    servingPrincipal: "andreas",
     agentId: "luna",
     assistantName: "Luna",
     capabilities: [],
@@ -128,7 +129,18 @@ describe("AgentNodeCard (G-1114.D.1)", () => {
 });
 
 describe("StackHubCard (G-1114.D.1)", () => {
-  function renderHub(data: StackHubNodeData): string {
+  // Default the serving principal to `andreas` (matching the local fixtures), so
+  // `origin: "local"` classifies `self` and a `jc/*` origin classifies `foreign`.
+  // Tests that exercise the #1008 sibling path override it explicitly.
+  function renderHub(over: Partial<StackHubNodeData> & { kind: "stack-hub" }): string {
+    const data: StackHubNodeData = {
+      servingPrincipal: "andreas",
+      origin: "local",
+      principal: null,
+      stack: null,
+      agentCount: 0,
+      ...over,
+    };
     return renderToStaticMarkup(createElement(StackHubCard, { data }));
   }
 
@@ -196,6 +208,40 @@ describe("StackHubCard (G-1114.D.1)", () => {
     expect(html).toContain("federated stack");
     expect(html).toContain("jc/research");
   });
+
+  it("renders a SAME-PRINCIPAL local SIBLING hub as LOCAL, not federated (#1008)", () => {
+    // A sibling stack reached via DB-read aggregation carries an OBJECT origin
+    // whose principal === the serving principal. It must read as a "stack" hub
+    // (local visual), NOT "federated stack" — the bug this fixes.
+    const html = renderHub({
+      kind: "stack-hub",
+      origin: { principal: "andreas", stack: "work" },
+      servingPrincipal: "andreas",
+      principal: "andreas",
+      stack: "work",
+      agentCount: 2,
+    });
+    expect(html).toContain('data-hub-origin="local"');
+    expect(html).toContain('data-hub-category="sibling"');
+    expect(html).toContain("network-node-hub-sibling");
+    expect(html).not.toContain("network-node-hub-foreign");
+    expect(html).not.toContain("federated stack");
+    // still labelled with its own {principal}/{stack}
+    expect(html).toContain("andreas/work");
+  });
+
+  it("classifies a CROSS-PRINCIPAL hub as foreign even with the same stack name (#1008)", () => {
+    const html = renderHub({
+      kind: "stack-hub",
+      origin: { principal: "jc", stack: "work" },
+      servingPrincipal: "andreas",
+      principal: "jc",
+      stack: "work",
+      agentCount: 1,
+    });
+    expect(html).toContain('data-hub-category="foreign"');
+    expect(html).toContain("federated stack");
+  });
 });
 
 describe("AgentNodeCard — federated provenance (G-1114.E.4)", () => {
@@ -221,6 +267,23 @@ describe("AgentNodeCard — federated provenance (G-1114.E.4)", () => {
     expect(html).toContain("jc/research");
     // accessible label names it a federated peer
     expect(html).toContain("federated peer jc/research");
+  });
+
+  it("renders a SAME-PRINCIPAL local SIBLING agent as LOCAL, no federated badge (#1008)", () => {
+    const html = renderAgent(
+      agentData({
+        key: "andreas/work/echo",
+        agentId: "echo",
+        assistantName: "Echo",
+        origin: { principal: "andreas", stack: "work" },
+        servingPrincipal: "andreas",
+      }),
+    );
+    expect(html).toContain('data-agent-origin="local"');
+    expect(html).toContain('data-agent-category="sibling"');
+    expect(html).not.toContain("network-node-foreign");
+    expect(html).not.toContain("network-node-provenance");
+    expect(html).not.toContain("federated peer");
   });
 });
 

--- a/src/surface/mc/dashboard-v2/components/network-canvas.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-canvas.tsx
@@ -27,17 +27,21 @@ import {
   type Node as RfNode,
   type Edge as RfEdge,
   type NodeTypes,
+  type EdgeTypes,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import ELK from "elkjs/lib/elk.bundled.js";
 import {
-  STACK_HUB_NODE_ID,
   type NetworkGraph,
   type NetworkGraphNode,
 } from "../lib/network-graph-adapter";
 import { agentKeyFromClickedNode } from "../lib/network-detail-display";
-import { layoutNetworkGraph } from "../lib/network-graph-layout";
+import {
+  layoutNetworkGraph,
+  type LaidOutNetworkEdge,
+} from "../lib/network-graph-layout";
 import { AgentNode, StackHubNode } from "./network-nodes";
+import NetworkElkEdge from "./network-elk-edge";
 import { NetworkLegend } from "./network-legend";
 import {
   NetworkHoverContext,
@@ -49,6 +53,12 @@ import {
 const nodeTypes: NodeTypes = {
   stackHub: StackHubNode,
   agent: AgentNode,
+};
+
+// #1008 — the custom ELK orthogonal edge (rounded-corner polyline from ELK's
+// bend points). Registered once at module scope, same as `nodeTypes`.
+const edgeTypes: EdgeTypes = {
+  elk: NetworkElkEdge,
 };
 
 // One ELK engine for this chunk's lifetime, instantiated lazily on first layout.
@@ -83,9 +93,11 @@ export interface NetworkCanvasProps {
 /** The React Flow canvas — rendered once ELK has positioned the nodes. */
 function FlowCanvas({
   nodes,
+  laidOutEdges,
   onSelectAgent,
 }: {
   nodes: NetworkGraphNode[];
+  laidOutEdges: LaidOutNetworkEdge[];
   onSelectAgent?: (key: string | null) => void;
 }) {
   // React Flow's node `data` is typed `Record<string, unknown>`; our discriminated
@@ -93,20 +105,23 @@ function FlowCanvas({
   // we cast at this single boundary rather than polluting the adapter's data type.
   const rfNodes = nodes as unknown as RfNode[];
 
-  // The hub→agent edges are derivable, but for the star render we don't need
-  // visible connectors to read the grouping; the radial placement carries it.
-  // We still pass edges so the layout's parent/child relationship is honoured by
-  // React Flow's node ordering. Edges are rebuilt here from node ids.
+  // #1008 — render the ORIGIN-GROUPED edges from the adapter (each agent wired to
+  // ITS OWN stack's hub — local, sibling, or foreign), typed `elk` so the custom
+  // edge draws ELK's orthogonal route from `data.elkPoints`. This replaces the
+  // old code that rebuilt every edge as `STACK_HUB_NODE_ID → agent` (which mis-
+  // wired sibling/foreign agents to the LOCAL hub) and used React Flow's default
+  // crossing-prone renderer.
   const edges = useMemo<RfEdge[]>(
     () =>
-      nodes
-        .filter((n) => n.type === "agent")
-        .map((n) => ({
-          id: `hub-${n.id}`,
-          source: STACK_HUB_NODE_ID,
-          target: n.id,
-        })),
-    [nodes],
+      laidOutEdges.map((e) => ({
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        type: "elk",
+        // The layout payload (elkPoints + face geometry) drives the custom edge.
+        data: e.layout as unknown as Record<string, unknown>,
+      })),
+    [laidOutEdges],
   );
 
   // Node click → lift the agent key up (D.4). The pure
@@ -133,6 +148,7 @@ function FlowCanvas({
       nodes={rfNodes}
       edges={edges}
       nodeTypes={nodeTypes}
+      edgeTypes={edgeTypes}
       fitView
       minZoom={0.2}
       maxZoom={2}
@@ -162,21 +178,24 @@ export default function NetworkCanvas({
   hover,
 }: NetworkCanvasProps) {
   const [positioned, setPositioned] = useState<NetworkGraphNode[]>([]);
+  const [laidOutEdges, setLaidOutEdges] = useState<LaidOutNetworkEdge[]>([]);
   const genRef = useRef(0);
 
   useEffect(() => {
     const myGen = ++genRef.current;
     if (graph.nodes.length === 0) {
       setPositioned([]);
+      setLaidOutEdges([]);
       return;
     }
     let cancelled = false;
     void layoutNetworkGraph(getElk(), graph)
-      .then((nodes) => {
+      .then((result) => {
         // Drop a stale layout: the graph changed (new gen) or the effect was
         // torn down while ELK was mid-flight.
         if (cancelled || genRef.current !== myGen) return;
-        setPositioned(nodes);
+        setPositioned(result.nodes);
+        setLaidOutEdges(result.edges);
       })
       .catch((err: unknown) => {
         if (cancelled || genRef.current !== myGen) return;
@@ -200,7 +219,11 @@ export default function NetworkCanvas({
 
   const canvas = (
     <ReactFlowProvider>
-      <FlowCanvas nodes={positioned} onSelectAgent={onSelectAgent} />
+      <FlowCanvas
+        nodes={positioned}
+        laidOutEdges={laidOutEdges}
+        onSelectAgent={onSelectAgent}
+      />
     </ReactFlowProvider>
   );
 

--- a/src/surface/mc/dashboard-v2/components/network-detail-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-detail-panel.tsx
@@ -34,7 +34,7 @@ import {
   formatCapabilities,
   offlineReasonLabel,
   isTtlLapse,
-  isForeignOrigin,
+  classifyOrigin,
   originProvenanceLabel,
 } from "../lib/agents-display";
 import type { AgentPresenceTile } from "../hooks/use-agents";
@@ -50,6 +50,17 @@ function priorityLabel(p: number): string {
 export interface NetworkDetailPanelProps {
   /** The live, snapshot-resolved agent tile to show. */
   agent: AgentPresenceTile;
+  /**
+   * #1008 — the SERVING stack's principal (derived by the view from the snapshot's
+   * `"local"`-origin agents via `deriveServingPrincipal`). The panel pairs it with
+   * `agent.origin` through `classifyOrigin` to distinguish a SAME-PRINCIPAL local
+   * SIBLING (DB-read aggregation) from a CROSS-PRINCIPAL federated peer — so a
+   * sibling renders LOCAL here, exactly as it does on the graph node, rather than
+   * re-showing the "federated peer" mislabel the binary guard produced. `null`
+   * when the snapshot has no local agent (a foreign-only snapshot) → an object
+   * origin classifies conservatively as foreign.
+   */
+  servingPrincipal: string | null;
   /**
    * The agent's dispatch-lifecycle activity (joined from the working-agents
    * projection), or `null` when the agent isn't actively dispatched (idle).
@@ -97,6 +108,7 @@ export interface NetworkDetailPanelProps {
  */
 export function NetworkDetailPanel({
   agent,
+  servingPrincipal,
   dispatch,
   onClose,
   onViewInWorkingGrid,
@@ -111,10 +123,26 @@ export function NetworkDetailPanel({
   const reasonLabel = offline ? offlineReasonLabel(agent.offline_reason) : null;
   const name = agent.assistant_name ?? agent.agent_id;
   const caps = formatCapabilities(agent.capabilities);
-  // E.4: a FOREIGN (federated peer) agent shows its origin + a "activity not
-  // local" note instead of a dispatch join (#909 — working-agents is local-only).
-  const foreign = isForeignOrigin(agent.origin);
-  const provenance = originProvenanceLabel(agent.origin);
+  // #1008: classify against the serving principal — only a CROSS-PRINCIPAL
+  // `foreign` peer gets the "federated peer" badge + the "activity not local"
+  // treatment. A SAME-PRINCIPAL local `sibling` (DB-read aggregation) renders
+  // LOCAL here, matching its graph node — the fix for siblings re-showing the
+  // "FEDERATED" mislabel on click-through.
+  const category = classifyOrigin(agent.origin, servingPrincipal);
+  const foreign = category === "foreign";
+  // Provenance (`{principal}/{stack}`) is only surfaced for a true foreign peer;
+  // a sibling reads as one of your own agents.
+  const provenance = foreign ? originProvenanceLabel(agent.origin) : null;
+  // #1008: ONLY the serving stack's OWN agents are locally dispatchable + carry a
+  // local working-grid join. A SIBLING agent — though same-principal + LOCAL in
+  // label — lives in ANOTHER stack's DB; the dispatch path writes THIS stack's DB
+  // + spawns a local subprocess, so it can't target a sibling any more than a
+  // foreign peer. So the dispatch-join, working-grid link, and dispatch-direct
+  // button gate on `self`, not merely "not foreign". The sibling's own-stack
+  // provenance label (for the not-local activity note) is computed unconditionally
+  // for the non-self branches.
+  const self = category === "self";
+  const ownStackLabel = originProvenanceLabel(agent.origin);
 
   return (
     <aside
@@ -219,15 +247,24 @@ export function NetworkDetailPanel({
       </section>
 
       {/* Dispatch lifecycle (LIGHT — pointer only, never interiors) ---------
-          E.4 / #909: a FOREIGN peer agent shows NO local dispatch activity —
-          working-agents is the LOCAL stack's projection, never joined for a
-          foreign agent. The principal sees that the activity simply isn't local,
-          not an empty "idle" that would misrepresent a busy peer. */}
+          E.4 / #909 / #1008: only the SERVING stack's OWN agents carry a local
+          working-agents join. A FOREIGN peer OR a same-principal SIBLING agent
+          lives on ANOTHER stack — its activity is not in this stack's projection,
+          so we show an origin-appropriate "not local" note rather than an empty
+          "idle" that would misrepresent a busy peer/sibling. */}
       <section className="network-detail-section network-detail-activity">
         <span className="network-detail-section-label dim">recent activity</span>
-        {foreign ? (
-          <span className="network-detail-foreign-activity dim">
-            Federated peer — activity not local.
+        {!self ? (
+          <span
+            className={
+              "network-detail-nonlocal-activity dim" +
+              (foreign ? " network-detail-foreign-activity" : " network-detail-sibling-activity")
+            }
+            data-activity-origin={foreign ? "foreign" : "sibling"}
+          >
+            {foreign
+              ? "Federated peer — activity not local."
+              : `Local sibling stack — activity lives on its own stack${ownStackLabel ? ` (${ownStackLabel})` : ""}.`}
           </span>
         ) : dispatch ? (
           <div className="network-detail-dispatch">
@@ -258,9 +295,10 @@ export function NetworkDetailPanel({
             No active dispatch.
           </span>
         )}
-        {/* The working grid is the LOCAL stack's dispatch surface — the pointer
-            is meaningless for a foreign peer agent (#909), so it's hidden. */}
-        {!foreign && onViewInWorkingGrid && (
+        {/* The working grid is THIS stack's dispatch surface — the pointer is
+            meaningless for a foreign peer (#909) OR a sibling on another stack
+            (#1008), so it's shown only for the serving stack's own agents. */}
+        {self && onViewInWorkingGrid && (
           <button
             type="button"
             className="network-detail-grid-link"
@@ -272,23 +310,25 @@ export function NetworkDetailPanel({
       </section>
 
       {/* Dispatch direct (F.3) ---------------------------------------------
-          A LOCAL agent gets a confirm-gated "Dispatch to {agent}" button that
-          REUSES the existing dispatch path (`POST /api/sessions` with
+          The SERVING stack's OWN agent gets a confirm-gated "Dispatch to {agent}"
+          button that REUSES the existing dispatch path (`POST /api/sessions` with
           `agentId`) — the same confirmation popover the task-row Dispatch uses,
-          so no auth/confirm step is bypassed. A FOREIGN peer agent CANNOT be
-          dispatched to from here (the dispatch path is LOCAL-only — it writes
-          this stack's DB + spawns a local subprocess), so it shows a disabled
-          future-state rather than a half-working cross-principal dispatch. */}
+          so no auth/confirm step is bypassed. A FOREIGN peer OR a same-principal
+          SIBLING agent CANNOT be dispatched to from here (the dispatch path is
+          LOCAL-to-this-stack — it writes THIS stack's DB + spawns a local
+          subprocess, so it can't target an agent that lives on another stack),
+          so it shows a future-state note rather than a half-working dispatch. */}
       {onDispatchDirect && (
         <section className="network-detail-section network-detail-dispatch-direct">
           <span className="network-detail-section-label dim">dispatch</span>
-          {foreign ? (
+          {!self ? (
             <span
               className="network-detail-dispatch-direct-foreign dim"
-              data-dispatch-direct="foreign-disabled"
+              data-dispatch-direct={foreign ? "foreign-disabled" : "sibling-disabled"}
             >
-              Federated peer — direct dispatch happens on its own stack
-              {provenance ? ` (${provenance})` : ""}.
+              {foreign
+                ? `Federated peer — direct dispatch happens on its own stack${provenance ? ` (${provenance})` : ""}.`
+                : `Local sibling stack — direct dispatch happens on its own stack${ownStackLabel ? ` (${ownStackLabel})` : ""}.`}
             </span>
           ) : (
             <DispatchButton

--- a/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
@@ -1,0 +1,184 @@
+/**
+ * #1008 (network-graph-rendering) — custom React Flow edge that renders ELK's
+ * ORTHOGONAL route as a rounded-corner SVG polyline.
+ *
+ * Adapted from Strata's `ElkEdge.tsx` (`arc-library/strata/ui/src/components/`):
+ * the layout step (`network-graph-layout.ts`) extracts ELK's bend points into
+ * `data.elkPoints`; this edge converts them to a path with rounded corners
+ * (`elkPointsToPath`) and clamps the endpoints to the source/target node faces
+ * so a connector never starts inside a card. This is the key to the
+ * non-crossing edges — ELK already routed the right angles; we just draw them.
+ *
+ * Lives in the LAZY canvas chunk (it imports `@xyflow/react`), registered on the
+ * canvas's `edgeTypes` as `elk`. Edges with no `elkPoints` (defensive — ELK
+ * didn't route them) fall back to a straight line.
+ */
+
+import { useMemo } from "react";
+import {
+  BaseEdge,
+  getSmoothStepPath,
+  Position,
+  type EdgeProps,
+} from "@xyflow/react";
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Convert ELK orthogonal bend points into an SVG path with rounded corners.
+ * Each interior bend becomes a quadratic-bezier arc whose radius is clamped to
+ * half the shorter adjacent segment so tight bends never overshoot.
+ */
+export function elkPointsToPath(points: Point[], radius = 8): string {
+  if (points.length < 2) return "";
+  if (points.length === 2) {
+    return `M ${points[0]!.x} ${points[0]!.y} L ${points[1]!.x} ${points[1]!.y}`;
+  }
+
+  const parts: string[] = [`M ${points[0]!.x} ${points[0]!.y}`];
+
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1]!;
+    const curr = points[i]!;
+    const next = points[i + 1]!;
+
+    const dPrev = Math.hypot(curr.x - prev.x, curr.y - prev.y);
+    const dNext = Math.hypot(next.x - curr.x, next.y - curr.y);
+    const r = Math.min(radius, dPrev / 2, dNext / 2);
+
+    if (r < 1) {
+      parts.push(`L ${curr.x} ${curr.y}`);
+      continue;
+    }
+
+    const dxP = (curr.x - prev.x) / dPrev;
+    const dyP = (curr.y - prev.y) / dPrev;
+    const dxN = (next.x - curr.x) / dNext;
+    const dyN = (next.y - curr.y) / dNext;
+
+    // Line to the start of the rounded corner, then arc through the bend.
+    parts.push(`L ${curr.x - dxP * r} ${curr.y - dyP * r}`);
+    parts.push(`Q ${curr.x} ${curr.y} ${curr.x + dxN * r} ${curr.y + dyN * r}`);
+  }
+
+  const last = points[points.length - 1]!;
+  parts.push(`L ${last.x} ${last.y}`);
+  return parts.join(" ");
+}
+
+/**
+ * Clamp the polyline's first/last point to the correct node face so an edge
+ * never starts/ends inside the box. Pure + exported for unit testing (the SVG
+ * edge component itself can't mount under `renderToStaticMarkup`). Returns the
+ * adjusted point list. Mirrors Strata's face-clamping.
+ */
+export function clampElkPointsToFaces(
+  elkPoints: Point[],
+  faces: {
+    sourceY: number;
+    targetY: number;
+    sourceTopY?: number;
+    targetBottomY?: number;
+  },
+): Point[] {
+  if (elkPoints.length < 2) return elkPoints;
+  const adjusted = [...elkPoints];
+  const first = elkPoints[0]!;
+  const firstNext = elkPoints[1]!;
+  const lastIdx = elkPoints.length - 1;
+  const last = elkPoints[lastIdx]!;
+  const lastPrev = elkPoints[lastIdx - 1]!;
+
+  if (firstNext.y >= first.y) {
+    // Exits downward → snap to the actual bottom (source handle Y).
+    adjusted[0] = { x: first.x, y: faces.sourceY };
+  } else if (faces.sourceTopY !== undefined) {
+    // Exits upward → snap to the top of the source node.
+    adjusted[0] = { x: first.x, y: faces.sourceTopY };
+  }
+
+  if (lastPrev.y <= last.y) {
+    // Enters from above → snap to the actual top (target handle Y).
+    adjusted[lastIdx] = { x: last.x, y: faces.targetY };
+  } else if (faces.targetBottomY !== undefined) {
+    // Enters from below → snap to the bottom of the target node.
+    adjusted[lastIdx] = { x: last.x, y: faces.targetBottomY };
+  }
+
+  return adjusted;
+}
+
+/**
+ * The custom edge. Renders ELK's orthogonal route when present; falls back to a
+ * straight line otherwise. If a node is DRAGGED far from its laid-out position
+ * (the handles drift past a threshold from the ELK-expected face), we drop the
+ * stale ELK route and use a live smoothstep so the edge tracks the moved node —
+ * though cortex's nodes are `nodesDraggable={false}`, this keeps the edge robust.
+ */
+export default function NetworkElkEdge(props: EdgeProps) {
+  const { id, data, style, markerEnd, sourceX, sourceY, targetX, targetY } =
+    props;
+
+  const edgeData = data as Record<string, unknown> | undefined;
+  const elkPoints = edgeData?.["elkPoints"] as Point[] | undefined;
+  const layoutSourceX = edgeData?.["layoutSourceX"] as number | undefined;
+  const layoutSourceY = edgeData?.["layoutSourceY"] as number | undefined;
+  const layoutTargetX = edgeData?.["layoutTargetX"] as number | undefined;
+  const layoutTargetY = edgeData?.["layoutTargetY"] as number | undefined;
+  const sourceTopY = edgeData?.["sourceTopY"] as number | undefined;
+  const targetBottomY = edgeData?.["targetBottomY"] as number | undefined;
+
+  const path = useMemo(() => {
+    if (elkPoints && elkPoints.length >= 2) {
+      // Detect a dragged node: large drift between the live handle and the
+      // ELK-expected face → fall back to a live smoothstep.
+      if (layoutSourceX !== undefined && layoutTargetX !== undefined) {
+        const srcDrift = Math.hypot(
+          sourceX - layoutSourceX,
+          sourceY - (layoutSourceY ?? sourceY),
+        );
+        const tgtDrift = Math.hypot(
+          targetX - layoutTargetX,
+          targetY - (layoutTargetY ?? targetY),
+        );
+        if (srcDrift > 20 || tgtDrift > 20) {
+          const [p] = getSmoothStepPath({
+            sourceX,
+            sourceY,
+            targetX,
+            targetY,
+            sourcePosition: Position.Bottom,
+            targetPosition: Position.Top,
+          });
+          return p;
+        }
+      }
+
+      const adjusted = clampElkPointsToFaces(elkPoints, {
+        sourceY,
+        targetY,
+        sourceTopY,
+        targetBottomY,
+      });
+      return elkPointsToPath(adjusted);
+    }
+    return `M ${sourceX} ${sourceY} L ${targetX} ${targetY}`;
+  }, [
+    elkPoints,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    layoutSourceX,
+    layoutSourceY,
+    layoutTargetX,
+    layoutTargetY,
+    sourceTopY,
+    targetBottomY,
+  ]);
+
+  return <BaseEdge id={id} path={path} style={style} markerEnd={markerEnd} />;
+}

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -28,7 +28,8 @@ import {
   formatCapabilities,
   offlineReasonLabel,
   isTtlLapse,
-  isForeignOrigin,
+  classifyOrigin,
+  isLocalCategory,
   originProvenanceLabel,
 } from "../lib/agents-display";
 import type {
@@ -51,9 +52,13 @@ export function StackHubCard({ data }: StackHubCardProps) {
     data.principal && data.stack
       ? `${data.principal}/${data.stack}`
       : (data.stack ?? data.principal ?? "stack");
-  // E.4: a FOREIGN (federated peer) hub renders distinctly from YOUR local hub —
-  // a "federated" eyebrow + a dimmer/bordered treatment via the modifier class.
-  const foreign = isForeignOrigin(data.origin);
+  // #1008: classify against the serving principal — `self`/`sibling` are LOCAL
+  // (same principal, same box; a sibling reached via DB-read aggregation), only
+  // a CROSS-PRINCIPAL `foreign` peer is "federated". This is the fix for local
+  // siblings mislabeled "FEDERATED STACK": a sibling now renders as a "stack"
+  // hub with the local visual, identical to your own stack's treatment.
+  const category = classifyOrigin(data.origin, data.servingPrincipal);
+  const foreign = !isLocalCategory(category);
   // U2.3 — signal's intent⋈reality verdict for this stack (present only when the
   // transport overlay is on AND signal observed it). Taken verbatim from signal.
   const badge =
@@ -62,10 +67,12 @@ export function StackHubCard({ data }: StackHubCardProps) {
     <div
       className={
         "network-node network-node-hub" +
-        (foreign ? " network-node-hub-foreign" : " network-node-hub-local")
+        (foreign ? " network-node-hub-foreign" : " network-node-hub-local") +
+        ` network-node-hub-${category}`
       }
       data-node-kind="stack-hub"
       data-hub-origin={foreign ? "foreign" : "local"}
+      data-hub-category={category}
       data-transport-verdict={data.transportVerdict ?? undefined}
     >
       <span className="network-hub-eyebrow dim">
@@ -136,11 +143,15 @@ export function AgentNodeCard({
   const ttlLapse = offline && isTtlLapse(data.offlineReason);
   const reasonLabel = offline ? offlineReasonLabel(data.offlineReason) : null;
   const name = data.assistantName ?? data.agentId;
-  // E.4: a FOREIGN agent renders distinctly — a "federated" border/dimmer
-  // treatment (modifier class) + a provenance badge (`jc/research`) showing where
-  // the peer agent actually lives.
-  const foreign = isForeignOrigin(data.origin);
-  const provenance = originProvenanceLabel(data.origin);
+  // #1008: classify against the serving principal. Only a CROSS-PRINCIPAL
+  // `foreign` peer renders distinctly (dashed border + "federated peer" badge);
+  // a SAME-PRINCIPAL local `sibling` (DB-read aggregation) renders LOCAL like
+  // your own agents — it is the principal's own stack, not a federation.
+  const category = classifyOrigin(data.origin, data.servingPrincipal);
+  const foreign = category === "foreign";
+  // The provenance label (`{principal}/{stack}`) is only surfaced for a true
+  // foreign peer — a local sibling reads as one of your own agents.
+  const provenance = foreign ? originProvenanceLabel(data.origin) : null;
 
   return (
     <div
@@ -154,6 +165,7 @@ export function AgentNodeCard({
       data-agent-id={data.agentId}
       data-state={data.state}
       data-agent-origin={foreign ? "foreign" : "local"}
+      data-agent-category={category}
       data-highlighted={highlighted ? "true" : undefined}
       data-offline-reason={offline ? (data.offlineReason ?? "") : undefined}
       aria-label={

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -34,6 +34,7 @@ import { pickAgentsPanelMode } from "../lib/agents-display";
 import {
   buildNetworkGraph,
   applyTransportOverlay,
+  deriveServingPrincipal,
 } from "../lib/network-graph-adapter";
 import {
   buildTransportOverlay,
@@ -134,6 +135,15 @@ export function NetworkView({
   const [filter, setFilter] = useState<NetworkFilterState>(DEFAULT_NETWORK_FILTER);
   const capabilityOptions = useMemo(
     () => collectCapabilityOptions(state.agents),
+    [state.agents],
+  );
+  // #1008 — derive the serving principal from the FULL snapshot (a filter that
+  // hides local agents must not lose it) so BOTH the graph adapter AND the
+  // click-through detail panel classify a same-principal sibling as LOCAL, not
+  // federated. The adapter derives its own copy internally; the panel needs it
+  // threaded as a prop (it's pure — no snapshot access of its own).
+  const servingPrincipal = useMemo(
+    () => deriveServingPrincipal(state.agents),
     [state.agents],
   );
   const filteredAgents = useMemo(
@@ -355,6 +365,7 @@ export function NetworkView({
             {selectedAgent && (
               <NetworkDetailPanel
                 agent={selectedAgent}
+                servingPrincipal={servingPrincipal}
                 dispatch={dispatch}
                 onClose={closePanel}
                 onViewInWorkingGrid={onViewInWorkingGrid}

--- a/src/surface/mc/dashboard-v2/lib/agents-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/agents-display.ts
@@ -8,15 +8,67 @@
 import type { AgentPresenceTile, AgentOrigin } from "../hooks/use-agents";
 
 /**
- * G-1114.E.4 — true when an origin is a FOREIGN (federated peer) provenance.
- * A thin guard so view code reads `isForeignOrigin(origin)` rather than
+ * G-1114.E.4 — true when an origin is NOT the serving stack's own `"local"`
+ * record. A thin guard so view code reads `isForeignOrigin(origin)` rather than
  * re-checking the `"local"`-string-vs-object discriminant. Mirrors the bus-side
  * `isForeignOrigin`, re-declared here so the surface layer stays bus-free.
+ *
+ * ⚠️ NOTE: this is the SERVING-STACK guard (origin is an object), NOT the
+ * "federated peer" guard. A same-principal LOCAL SIBLING (#1008 DB-read
+ * aggregation) also carries an object origin yet is NOT federated — it's the
+ * principal's own stack on the principal's own box. Use {@link classifyOrigin}
+ * (which knows the serving principal) to tell a sibling from a true foreign
+ * peer; only `classifyOrigin(...) === "foreign"` means "federated stack".
  */
 export function isForeignOrigin(
   origin: AgentOrigin,
 ): origin is { principal: string; stack: string } {
   return origin !== "local";
+}
+
+/**
+ * The three origin categories the Network graph distinguishes:
+ *   - `"self"`    — the SERVING stack's own agent (`origin: "local"`).
+ *   - `"sibling"` — a SAME-PRINCIPAL local stack reached via #1008 DB-read
+ *     aggregation (`origin: {principal, stack}` with `principal` === the serving
+ *     principal). Same principal, same machine — a LOCAL stack, NOT federated.
+ *   - `"foreign"` — a CROSS-PRINCIPAL federated peer (`origin.principal` !== the
+ *     serving principal). The only category that is truly "federated".
+ *
+ * `self` + `sibling` both render as LOCAL hubs ("stack"); only `foreign` renders
+ * as a "federated stack". This is the fix for the #1008 mislabel where every
+ * object-origin (including same-principal siblings) read as federated.
+ */
+export type OriginCategory = "self" | "sibling" | "foreign";
+
+/**
+ * Classify an origin against the SERVING principal into {@link OriginCategory}.
+ *
+ *   - `"local"` → `"self"`.
+ *   - `{principal,stack}` with `principal === servingPrincipal` → `"sibling"`
+ *     (a same-principal LOCAL stack — DB-read aggregation, not federation).
+ *   - `{principal,stack}` with `principal !== servingPrincipal` → `"foreign"`
+ *     (a cross-principal federated peer).
+ *
+ * When `servingPrincipal` is unknown (`null` — e.g. a foreign-only snapshot with
+ * no `"local"` agent to derive it from), an object origin can't be proven a
+ * sibling, so it conservatively classifies as `"foreign"`. A `"local"` origin is
+ * always `"self"` regardless.
+ */
+export function classifyOrigin(
+  origin: AgentOrigin,
+  servingPrincipal: string | null,
+): OriginCategory {
+  if (origin === "local") return "self";
+  if (servingPrincipal !== null && origin.principal === servingPrincipal) {
+    return "sibling";
+  }
+  return "foreign";
+}
+
+/** True when a category renders with the LOCAL (non-federated) visual + label. */
+export function isLocalCategory(category: OriginCategory): boolean {
+  return category === "self" || category === "sibling";
 }
 
 /**

--- a/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
@@ -71,6 +71,15 @@ export interface StackHubNodeData {
    * distinctly + carrying the provenance label).
    */
   origin: AgentOrigin;
+  /**
+   * #1008 — the SERVING stack's principal, derived from the snapshot's
+   * `"local"`-origin agents (the serving stack's own identity). `null` when the
+   * snapshot has no local agent to derive it from (a foreign-only snapshot). The
+   * card pairs this with `origin` via `classifyOrigin` to tell a SAME-PRINCIPAL
+   * local sibling (DB-read aggregation) from a CROSS-PRINCIPAL federated peer —
+   * so a sibling renders as a "stack" hub, not a "federated stack".
+   */
+  servingPrincipal: string | null;
   /** `{principal}` the stack belongs to. */
   principal: string | null;
   /** `{stack}` label. */
@@ -98,6 +107,13 @@ export interface AgentNodeData {
    * metadata, never an interior (ADR-0007).
    */
   origin: AgentOrigin;
+  /**
+   * #1008 — the SERVING stack's principal (see {@link StackHubNodeData.servingPrincipal}).
+   * Lets the card classify a same-principal local SIBLING agent apart from a
+   * cross-principal FOREIGN peer via `classifyOrigin` — a sibling renders local,
+   * only a true foreign peer renders federated.
+   */
+  servingPrincipal: string | null;
   /** Logical agent id (`luna`, `echo`, …). */
   agentId: string;
   /** Soma assistant name, or `null` (falls back to `agentId` at render). */
@@ -169,6 +185,27 @@ export interface NetworkGraph {
   edges: NetworkGraphEdge[];
 }
 
+/**
+ * #1008 — derive the SERVING stack's principal from the snapshot.
+ *
+ * A `"local"`-origin agent's tile carries the serving stack's own
+ * principal/stack (it IS a stack-own agent), so the serving principal is the
+ * `principal` of the first `"local"` agent. Returns `null` when no local agent
+ * is present (a foreign-only snapshot) — then no object origin can be proven a
+ * same-principal sibling, so classification falls back to "foreign".
+ *
+ * Derived client-side from the existing DTO rather than widening `/api/agents`
+ * to carry a serving-principal field — the `"local"` tiles already encode it.
+ */
+export function deriveServingPrincipal(
+  agents: readonly AgentPresenceTile[],
+): string | null {
+  for (const a of agents) {
+    if (a.origin === "local") return a.principal;
+  }
+  return null;
+}
+
 /** The `{principal}/{stack}` an agent's origin resolves to (for hub grouping). */
 function originScope(a: AgentPresenceTile): { principal: string; stack: string } {
   // A foreign agent's origin carries the peer's verified {principal,stack}; a
@@ -205,6 +242,16 @@ export function buildNetworkGraph(
   if (agents.length === 0) {
     return { nodes: [], edges: [] };
   }
+
+  // #1008 — derive the SERVING principal from the snapshot's `"local"`-origin
+  // agents: a local agent's tile carries the serving stack's own principal. We
+  // thread it onto every node so the cards can tell a SAME-PRINCIPAL local
+  // sibling (DB-read aggregation, `origin.principal === serving`) from a
+  // CROSS-PRINCIPAL federated peer (`origin.principal !== serving`) — the fix
+  // for siblings mislabeled "federated stack". `null` when the snapshot has no
+  // local agent (a foreign-only snapshot), in which case an object origin can't
+  // be proven a sibling and classifies conservatively as foreign.
+  const servingPrincipal = deriveServingPrincipal(agents);
 
   // First pass: bucket agents by their origin hub id, preserving first-seen order
   // of hubs and snapshot order of agents within each hub.
@@ -252,6 +299,7 @@ export function buildNetworkGraph(
       data: {
         kind: "stack-hub",
         origin: bucket.origin,
+        servingPrincipal,
         principal: bucket.principal ?? null,
         stack: bucket.stack ?? null,
         agentCount: bucket.agents.length,
@@ -266,6 +314,7 @@ export function buildNetworkGraph(
           kind: "agent",
           key: a.key,
           origin: a.origin,
+          servingPrincipal,
           agentId: a.agent_id,
           assistantName: a.assistant_name,
           capabilities: a.capabilities,

--- a/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
@@ -1,21 +1,34 @@
 /**
  * G-1114.D.3 — ELK layout for the Network graph.
  * G-1114.E.3 — + multi-cluster (one star per stack-hub) layout.
+ * #1008 (network-graph-rendering) — Strata-style LAYERED + ORTHOGONAL routing.
  *
  * Positions the stack-hub + agent nodes (from {@link buildNetworkGraph}) using
- * elkjs.
+ * elkjs and returns BOTH the positioned nodes AND ELK's computed edge bend
+ * points (`elkPoints`), so the canvas can render clean orthogonal connectors
+ * (see `network-elk-edge.tsx`) instead of React Flow's default crossing-prone
+ * straight/bezier edges.
  *
- * Phase D's topology was a SINGLE star — one hub with every agent as a spoke —
- * for which ELK's `radial` (root-centred concentric placement) was the natural
- * fit. Phase E adds federated peer stacks, so the graph is now potentially
- * SEVERAL disconnected star-clusters (the local hub + one per foreign
- * `{principal}/{stack}`). `radial` is single-rooted and would have to pick ONE
- * root, scattering the other clusters; the **force** (stress) algorithm instead
- * lays disconnected components out as separate, internally-clustered groups —
- * each hub-and-its-agents stays together, and the clusters separate cleanly.
- * That reads as "your stack here, each peer stack as its own cluster". A
- * single-cluster (local-only) graph still lays out as one tidy group, so the
- * Phase-D experience is preserved.
+ * ## Algorithm choice — `layered` (DOWN), not `force`
+ *
+ * Phase D used `radial`; Phase E switched to `force` to handle several
+ * disconnected stack-clusters. But `force` (stress) is a physics scatter: it has
+ * no notion of "hub above its agents", so clusters drift, overlap edges cross,
+ * and with several stacks the whole thing converges on the densest hub — exactly
+ * the crossing-lines mess #1008 reported.
+ *
+ * cortex's topology is a SET of 2-level trees: each stack-hub PARENTS its agents
+ * (hub → agent edges), one such tree per stack (the serving stack, each local
+ * sibling, each federated peer). `org.eclipse.elk.layered` with `direction: DOWN`
+ * is the natural fit — it places each hub on the top layer and its agents on the
+ * layer below, a tidy top-down cluster per stack. `separateConnectedComponents`
+ * packs the per-stack trees side by side (each stack its own clean column-group),
+ * and `crossingMinimization` + `nodePlacement: NETWORK_SIMPLEX` straighten the
+ * hub→agent edges. With `edgeRouting: ORTHOGONAL`, ELK emits right-angled bend
+ * points we render as rounded-corner polylines — no diagonal crossings.
+ *
+ * A single-cluster (local-only) graph lays out as one tidy hub-over-agents tree,
+ * preserving the Phase-D "your stack, agents fanned below" reading.
  *
  * ELK runs asynchronously (`elk.layout` returns a promise), so the view computes
  * the layout in an effect and stores the positioned nodes in state (see
@@ -24,27 +37,46 @@
  * instead of spinning up the real WASM-backed engine.
  */
 
-import type { NetworkGraph, NetworkGraphNode } from "./network-graph-adapter";
+import type {
+  NetworkGraph,
+  NetworkGraphNode,
+  NetworkGraphEdge,
+} from "./network-graph-adapter";
 
 /** Rendered footprint of each node, fed to ELK so it reserves real space. */
 export const HUB_NODE_SIZE = { width: 180, height: 64 } as const;
 export const AGENT_NODE_SIZE = { width: 200, height: 96 } as const;
 
 /**
- * ELK layout options for the multi-cluster star layout. Tuned for one-or-more
- * hub-and-spoke groups:
- *   - `algorithm: force` (stress) — keeps each hub's agents clustered around it
- *     AND lays disconnected stack-clusters out as separate groups (the local
- *     stack + each federated peer stack), rather than forcing a single root.
- *   - `spacing.nodeNode` keeps agent cards (≤200px) from overlapping.
- *   - `separateConnectedComponents` packs the per-stack clusters side-by-side
- *     instead of overlapping them.
+ * ELK layout options for the multi-cluster LAYERED layout (#1008). Tuned for
+ * one-or-more hub→agents trees laid top-down, adapted from Strata's layered
+ * config (`arc-library/strata/ui/src/constants.ts`):
+ *   - `algorithm: layered` + `direction: DOWN` — each stack-hub on the top layer,
+ *     its agents on the layer below: a tidy top-down cluster per stack (replaces
+ *     the `force` scatter that crossed edges + converged on the densest hub).
+ *   - `edgeRouting: ORTHOGONAL` — right-angled connectors; ELK emits the bend
+ *     points we render as rounded polylines (no diagonal crossings).
+ *   - `crossingMinimization.strategy: LAYER_SWEEP` + `thoroughness` — minimise
+ *     edge crossings within each cluster.
+ *   - `nodePlacement.strategy: NETWORK_SIMPLEX` — straighten hub→agent edges so
+ *     agents sit cleanly under their hub.
+ *   - `separateConnectedComponents` + `spacing.componentComponent` — pack each
+ *     disconnected stack-tree (serving stack + each sibling + each peer) as its
+ *     own side-by-side group, NOT one giant overlapping scatter.
+ *   - `spacing.*` keep agent cards (≤200px) and the per-stack columns apart.
  */
 export const NETWORK_ELK_OPTIONS: Record<string, string> = {
-  "elk.algorithm": "org.eclipse.elk.force",
-  "elk.spacing.nodeNode": "80",
-  "elk.force.repulsion": "5.0",
-  // Pack each disconnected stack-cluster as its own group (local + each peer).
+  "elk.algorithm": "org.eclipse.elk.layered",
+  "elk.direction": "DOWN",
+  "elk.edgeRouting": "ORTHOGONAL",
+  "elk.spacing.nodeNode": "48",
+  "elk.layered.spacing.nodeNodeBetweenLayers": "72",
+  "elk.layered.spacing.edgeNodeBetweenLayers": "32",
+  "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
+  "elk.layered.thoroughness": "7",
+  "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+  // Pack each disconnected stack-tree (serving stack + each sibling + each peer)
+  // as its own side-by-side group rather than overlapping them.
   "elk.separateConnectedComponents": "true",
   "elk.spacing.componentComponent": "120",
 };
@@ -80,9 +112,30 @@ export interface ElkLaidOutNode {
   height?: number;
 }
 
+/** A 2D point in ELK's layout coordinate space. */
+export interface ElkPoint {
+  x: number;
+  y: number;
+}
+
+/**
+ * One routed edge ELK returns. ORTHOGONAL routing populates `sections[0]` with a
+ * `startPoint`, optional `bendPoints`, and an `endPoint` — the right-angled path
+ * we render as a rounded polyline. (Strata reads the same `sections[0]` shape.)
+ */
+export interface ElkLaidOutEdge {
+  id: string;
+  sections?: {
+    startPoint: ElkPoint;
+    bendPoints?: ElkPoint[];
+    endPoint: ElkPoint;
+  }[];
+}
+
 /** The ELK result shape we read back. */
 export interface ElkLaidOutGraph {
   children?: ElkLaidOutNode[];
+  edges?: ElkLaidOutEdge[];
 }
 
 /** The minimal elkjs surface we depend on — injectable for tests. */
@@ -117,29 +170,95 @@ export function toElkGraph(graph: NetworkGraph): ElkInputGraph {
 }
 
 /**
- * Run ELK over the graph and return the input nodes with ELK's computed
- * positions applied. Edges are unchanged (React Flow routes hub→agent edges with
- * its default renderer; the radial layout doesn't need explicit edge bend points
- * for a star).
+ * #1008 — the per-edge layout payload the canvas hands to the custom ELK edge
+ * (`network-elk-edge.tsx`). `elkPoints` is ELK's orthogonal route
+ * (`[startPoint, ...bendPoints, endPoint]`); the `layout*`/`*Y` fields are the
+ * source/target node faces, used by the edge to clamp endpoints to the node
+ * boundary and to detect a dragged node (fall back to a smoothstep then). All
+ * optional — an edge ELK didn't route (defensive) carries no `elkPoints` and the
+ * edge component falls back to a straight line.
+ */
+export interface NetworkEdgeLayout {
+  elkPoints?: ElkPoint[];
+  layoutSourceX?: number;
+  layoutSourceY?: number;
+  layoutTargetX?: number;
+  layoutTargetY?: number;
+  sourceTopY?: number;
+  targetBottomY?: number;
+}
+
+/** One laid-out edge: the base graph edge + its computed ELK route payload. */
+export interface LaidOutNetworkEdge extends NetworkGraphEdge {
+  layout: NetworkEdgeLayout;
+}
+
+/** The layout result: positioned nodes + edges carrying ELK's bend points. */
+export interface LaidOutNetworkGraph {
+  nodes: NetworkGraphNode[];
+  edges: LaidOutNetworkEdge[];
+}
+
+/**
+ * Run ELK over the graph and return the positioned nodes AND the edges carrying
+ * ELK's computed orthogonal bend points (`layout.elkPoints`), so the canvas can
+ * render clean right-angled connectors instead of crossing-prone straight/bezier
+ * edges. The bend points are extracted from each edge's `sections[0]`
+ * (`startPoint` + `bendPoints` + `endPoint`), exactly as Strata's layout does.
  *
- * An empty graph short-circuits (no ELK call) and returns empty nodes. A node
- * ELK didn't position (shouldn't happen, but defensive) keeps its incoming
- * `{0,0}` so it renders at the origin rather than vanishing.
+ * An empty graph short-circuits (no ELK call) and returns empty nodes + edges. A
+ * node ELK didn't position (shouldn't happen, but defensive) keeps its incoming
+ * `{0,0}`; an edge ELK didn't route carries no `elkPoints` (the edge component
+ * falls back to a straight line).
  */
 export async function layoutNetworkGraph(
   elk: ElkLike,
   graph: NetworkGraph,
-): Promise<NetworkGraphNode[]> {
-  if (graph.nodes.length === 0) return [];
+): Promise<LaidOutNetworkGraph> {
+  if (graph.nodes.length === 0) return { nodes: [], edges: [] };
 
   const result = await elk.layout(toElkGraph(graph));
-  const positions = new Map<string, { x: number; y: number }>();
-  for (const c of result.children ?? []) {
-    positions.set(c.id, { x: c.x ?? 0, y: c.y ?? 0 });
+
+  // Index the laid-out nodes by id — for positions AND for the source/target
+  // face geometry the edge clamps to.
+  const laidOut = new Map<string, ElkLaidOutNode>();
+  for (const c of result.children ?? []) laidOut.set(c.id, c);
+
+  const nodes = graph.nodes.map((n) => {
+    const c = laidOut.get(n.id);
+    return c ? { ...n, position: { x: c.x ?? 0, y: c.y ?? 0 } } : n;
+  });
+
+  // Extract each edge's orthogonal route from ELK's `sections[0]`.
+  const routes = new Map<string, ElkPoint[]>();
+  for (const e of result.edges ?? []) {
+    const section = e.sections?.[0];
+    if (section) {
+      routes.set(e.id, [
+        section.startPoint,
+        ...(section.bendPoints ?? []),
+        section.endPoint,
+      ]);
+    }
   }
 
-  return graph.nodes.map((n) => {
-    const pos = positions.get(n.id);
-    return pos ? { ...n, position: pos } : n;
+  const edges = graph.edges.map((e): LaidOutNetworkEdge => {
+    const elkPoints = routes.get(e.id);
+    const src = laidOut.get(e.source);
+    const tgt = laidOut.get(e.target);
+    const layout: NetworkEdgeLayout = elkPoints ? { elkPoints } : {};
+    if (elkPoints && src) {
+      layout.layoutSourceX = (src.x ?? 0) + (src.width ?? 0) / 2;
+      layout.layoutSourceY = (src.y ?? 0) + (src.height ?? 0);
+      layout.sourceTopY = src.y ?? 0;
+    }
+    if (elkPoints && tgt) {
+      layout.layoutTargetX = (tgt.x ?? 0) + (tgt.width ?? 0) / 2;
+      layout.layoutTargetY = tgt.y ?? 0;
+      layout.targetBottomY = (tgt.y ?? 0) + (tgt.height ?? 0);
+    }
+    return { ...e, layout };
   });
+
+  return { nodes, edges };
 }

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -619,7 +619,10 @@ html, body {
   color: color-mix(in oklch, var(--accent) 70%, var(--fg-faint));
 }
 .network-detail-federated-badge { font-size: 12px; line-height: 1; }
-.network-detail-foreign-activity { font-size: 11.5px; font-style: italic; }
+/* #1008 — the "not in this stack's projection" activity note, shared by a FOREIGN
+   peer and a same-principal SIBLING (both live on another stack). The base class
+   carries the styling; the per-origin modifier is a hook for future divergence. */
+.network-detail-nonlocal-activity { font-size: 11.5px; font-style: italic; }
 .network-detail-header {
   display: flex; align-items: flex-start; justify-content: space-between; gap: 8px;
 }

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -501,6 +501,15 @@ html, body {
   border-style: dashed;
   border-color: color-mix(in oklch, var(--accent) 55%, transparent);
 }
+/* #1008 — a SAME-PRINCIPAL local SIBLING stack (DB-read aggregation) is LOCAL,
+   not federated: it keeps the solid local-hub treatment (like your own stack),
+   distinguished only by a slightly softer accent so the pane reads "your stacks"
+   as one family vs the dashed cross-principal foreign peers. Distinction is by
+   border weight + label ("stack" vs "federated stack"), never colour alone. */
+.network-node-hub-sibling {
+  border-style: solid;
+  border-color: color-mix(in oklch, var(--accent) 70%, var(--line));
+}
 .network-node-provenance {
   display: inline-flex; align-items: center; gap: 3px;
   font-size: 10px; font-family: var(--mono);


### PR DESCRIPTION
## Summary

Fixes two Mission Control **Network graph** defects (refs #1059; root cause #1008 pane-of-glass DB-read aggregation). No data-plane / DTO changes — both fixes are client-side in the dashboard.

## Part A — local-sibling vs federated classification (correctness)

Since #1008, a principal's own *local sibling* stacks reach the graph via direct MC-DB read aggregation, tagged with an OBJECT origin `{principal, stack}` that is **structurally identical on the wire to a cross-principal federated peer**. The old renderer used `isForeignOrigin(origin) = (origin !== "local")` and so mislabeled every sibling as a scattered **"FEDERATED STACK"**.

**3-way classification** replaces the binary:

```
classifyOrigin(origin, servingPrincipal) → "self" | "sibling" | "foreign"
  "local"                               → self
  {principal,stack}, principal === serving → sibling   (local, NOT federated)
  {principal,stack}, principal !== serving → foreign   (federated peer)
```

- `self` + `sibling` ⇒ **LOCAL** hub visual + `"stack {principal}/{stack}"` label.
- `foreign` ⇒ the existing **"federated stack"** dashed visual + provenance badge.
- The **serving principal** is derived **client-side** from the snapshot's `"local"`-origin agents (their tile carries the serving stack's principal) and threaded onto every node as `servingPrincipal` — no `api/agents` DTO change.
- Each distinct stack still gets its **own hub** (one per `{principal}/{stack}`); only the **label + visual treatment** changed for same-principal siblings. Hub→agent wiring stays per-origin.
- When `servingPrincipal` is unknown (foreign-only snapshot, no local agent), an object origin can't be proven a sibling and classifies conservatively as `foreign`.

New CSS `network-node-hub-sibling` (solid local treatment, softer accent) + `data-hub-category` / `data-agent-category` attributes. a11y: hub state is conveyed by label + border weight, never colour alone.

## Part B — Strata-style edge routing + cleaner layout (the visual fix)

**Layout algorithm — `layered`, not `force`.** cortex's topology is a *set of hub→agents trees* (the serving stack, each local sibling, each federated peer). `force` is a physics scatter with no notion of "hub above its agents", so clusters drift, edges cross, and several stacks converge on the densest hub — the crossing-lines mess reported.

Switched to **`org.eclipse.elk.layered`** (adapted from Strata's `constants.ts`):

| Option | Value | Why |
|---|---|---|
| `algorithm` | `layered` | each hub on the top layer, its agents below — a tidy top-down tree per stack |
| `direction` | `DOWN` | hub-over-agents reading |
| `edgeRouting` | `ORTHOGONAL` | right-angled bend points (rendered as rounded polylines) |
| `crossingMinimization.strategy` | `LAYER_SWEEP` + `thoroughness 7` | minimise crossings per cluster |
| `nodePlacement.strategy` | `NETWORK_SIMPLEX` | straighten hub→agent edges |
| `separateConnectedComponents` + `spacing.componentComponent` | on / 120 | pack each stack-tree apart, not one scatter |

A local-only graph still lays out as one tidy hub-over-agents tree (the Phase-D reading preserved).

**Custom ELK edge.** New `components/network-elk-edge.tsx` (adapted from Strata's `ElkEdge.tsx`): the layout step extracts ELK's `sections[0]` bend points into `data.elkPoints`; the edge converts them to a rounded-corner SVG polyline (`elkPointsToPath`) and clamps endpoints to the source/target node faces (`clampElkPointsToFaces`). Registered as `edgeTypes = { elk: NetworkElkEdge }`; edges are typed `elk` with the layout payload in `data`. The canvas now renders the adapter's **origin-grouped** edges (each agent wired to ITS OWN hub) instead of the old code that rebuilt every edge as `local-hub → agent` (which mis-wired sibling/foreign agents).

## Gates

| Gate | Result |
|---|---|
| `bunx tsc --noEmit` | clean |
| `bun run lint` | clean |
| `bun test` (full) | **6848 pass / 0 fail** (2 skip) |
| `bun run build:dashboard` | chunk split preserved |

**Bundle sizes** (build oracle confirms the lazy split held — the custom edge folded into the network-canvas chunk, not the entry):

| Artifact | Size |
|---|---|
| `index-*.js` (entry) | **1.27 MB** |
| `network-canvas-*.js` (lazy chunk: xyflow + elkjs + custom edge) | **3.51 MB** |

New structural lazy-chunk test asserts the custom edge is reachable only through the lazy canvas.

## Constraints honoured

- ADR-0007 unchanged — nodes carry presence/provenance only; `servingPrincipal` is presence-level, no interiors.
- No `api/agents` DTO change — serving principal derived client-side.
- a11y: hub category surfaced via label + data attributes + border weight, not colour-only.

## QA note

Visual QA on `localhost:8767` is **recommended** to confirm the per-stack clusters + orthogonal edges read cleanly with live data.

refs #1059, #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)