### PR TITLE
chore: bump to v5.18.0 — network graph rendering (#1060) + existing-db migration fix (#1056)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.17.0"
+version: "5.18.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release: #1060 (Network graph local-sibling hubs + Strata-style orthogonal edges), #1056 (MC embed existing-db boot crash fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)