### PR TITLE
feat(network): O-4b — network join consumes a leaf package (--from-package)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -183,6 +183,92 @@ describe("join dry-run safety", () => {
 });
 
 // =============================================================================
+// O-4b (cortex#1063) — `--from-package <file>` sources the leaf package.
+// =============================================================================
+
+describe("O-4b — join --from-package", () => {
+  // A public-repo-safe valid package: fake `eyJ…` JWTs + `A…` nkey-U pubkey.
+  const VALID_PACKAGE = {
+    operatorJwt: "eyJhbGciOiJlZDI1NTE5In0.eyJvcCI6ImZha2UifQ.c2lnMQ",
+    account: "A" + "B".repeat(55),
+    accountJwt: "eyJhbGciOiJlZDI1NTE5In0.eyJhYyI6ImZha2UifQ.c2lnMg",
+    credsPath: "~/.config/nats/issued.creds",
+  };
+
+  test("a MALFORMED package file → fail-fast usage error (exit 2), NO write", async () => {
+    const dir = freshDir();
+    const pkgFile = join(dir, "bad-package.json");
+    // operatorJwt present but not a JWT — O-3's reused guard must reject it.
+    writeFileSync(
+      pkgFile,
+      JSON.stringify({ ...VALID_PACKAGE, operatorJwt: "not-a-jwt" }),
+    );
+    const natsConfig = join(dir, "nats", "local.conf");
+    const plist = join(dir, "nats.plist");
+
+    const res = await dispatchNetwork([
+      "join", "metafactory-community",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", join(dir, "seed.nk"),
+      "--nats-config", natsConfig,
+      "--plist", plist,
+      "--from-package", pkgFile,
+    ], EMPTY_READER);
+
+    // Fail-fast at the package boundary: usage error, NEVER feeds the conversion.
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr.toLowerCase()).toContain("package");
+    // Nothing written — the bad package is rejected before any mutation attempt.
+    expect(existsSync(natsConfig)).toBe(false);
+    expect(existsSync(plist)).toBe(false);
+  });
+
+  test("a MISSING package file → usage error (exit 2)", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "metafactory-community",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", join(dir, "seed.nk"),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+      "--from-package", join(dir, "does-not-exist.json"),
+    ], EMPTY_READER);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr.toLowerCase()).toContain("package");
+  });
+
+  test("dry-run with a VALID package writes NOTHING (pure read)", async () => {
+    const dir = freshDir();
+    const pkgFile = join(dir, "package.json");
+    writeFileSync(pkgFile, JSON.stringify(VALID_PACKAGE));
+    const natsConfig = join(dir, "nats", "local.conf");
+    const plist = join(dir, "nats.plist");
+
+    const res = await dispatchNetwork([
+      "join", "metafactory-community",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0", // unreachable → join fails downstream
+      "--seed-path", join(dir, "seed.nk"),
+      "--nats-config", natsConfig,
+      "--plist", plist,
+      "--from-package", pkgFile,
+    ], EMPTY_READER);
+
+    // DRY-RUN SAFETY: the package parsed + flowed in, but the join (default
+    // dry-run) wrote NOTHING. The only file on disk is the package we wrote.
+    expect(existsSync(natsConfig)).toBe(false);
+    expect(existsSync(join(dir, "nats"))).toBe(false);
+    expect(existsSync(plist)).toBe(false);
+    // The package itself is untouched (a pure read).
+    expect(existsSync(pkgFile)).toBe(true);
+    // Banner present (dry-run).
+    expect(res.stderr + res.stdout).toContain("dry-run");
+  });
+});
+
+// =============================================================================
 // #763 — Linux/systemd: `--unit` join is accepted + writes nothing on dry-run
 // =============================================================================
 

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -651,3 +651,185 @@ describe("deriveJoinInputs — O-3 operator-mode leaf package", () => {
     expect(res.inputs?.operatorModePackage).toBeUndefined();
   });
 });
+
+// =============================================================================
+// O-4b (cortex#1063) — `--from-package` sources the operator-mode leaf package.
+// Precedence: explicit flags > package file > config > convention.
+// =============================================================================
+
+describe("deriveJoinInputs — O-4b leaf-package source (--from-package)", () => {
+  const OP_JWT = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.FAKE_OP.sig";
+  const ACC_JWT = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.FAKE_ACC.sig";
+  const PKG_ACCOUNT = "A" + "B".repeat(55);
+
+  // A config with NO operator-mode material — the package supplies everything.
+  const CFG_NO_PKG = loaded({
+    principal: { id: "andreas" },
+    stack: {
+      id: "andreas/community",
+      nkey_seed_path: "~/seed.nk",
+      nats_infra: { config_path: "~/community.conf", plist_path: "~/nats.plist" },
+    },
+    policy: {
+      principals: [],
+      roles: [],
+      federated: {
+        networks: [],
+        registry: { url: "https://r", pubkey: "A".repeat(43) + "=" },
+      },
+    },
+  });
+
+  test("package fields flow into operatorModePackage when config has none", () => {
+    const res = deriveJoinInputs(
+      "metafactory-community",
+      {
+        leafPackage: {
+          operatorJwt: OP_JWT,
+          account: PKG_ACCOUNT,
+          accountJwt: ACC_JWT,
+          credsPath: "~/.config/nats/issued.creds",
+        },
+      },
+      "/cfg",
+      reader(CFG_NO_PKG),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toEqual({
+      operatorJwt: OP_JWT,
+      account: PKG_ACCOUNT,
+      accountJwt: ACC_JWT,
+    });
+  });
+
+  test("package credsPath flows into credsPath (overrides the convention default)", () => {
+    const res = deriveJoinInputs(
+      "metafactory-community",
+      {
+        leafPackage: {
+          operatorJwt: OP_JWT,
+          account: PKG_ACCOUNT,
+          accountJwt: ACC_JWT,
+          credsPath: "~/.config/nats/issued.creds",
+        },
+      },
+      "/cfg",
+      reader(CFG_NO_PKG),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.credsPath).toBe("~/.config/nats/issued.creds");
+  });
+
+  test("package SYS account (+ jwt) is carried through", () => {
+    const res = deriveJoinInputs(
+      "metafactory-community",
+      {
+        leafPackage: {
+          operatorJwt: OP_JWT,
+          account: PKG_ACCOUNT,
+          accountJwt: ACC_JWT,
+          systemAccount: "A" + "D".repeat(55),
+          systemAccountJwt: "eyJ.SYS.sig",
+          credsPath: "~/.config/nats/issued.creds",
+        },
+      },
+      "/cfg",
+      reader(CFG_NO_PKG),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toEqual({
+      operatorJwt: OP_JWT,
+      account: PKG_ACCOUNT,
+      accountJwt: ACC_JWT,
+      systemAccount: "A" + "D".repeat(55),
+      systemAccountJwt: "eyJ.SYS.sig",
+    });
+  });
+
+  test("explicit FLAGS override the package file (flag wins)", () => {
+    const res = deriveJoinInputs(
+      "metafactory-community",
+      {
+        // package supplies one operator JWT + account …
+        leafPackage: {
+          operatorJwt: "eyJ.PKG_OP.sig",
+          account: PKG_ACCOUNT,
+          accountJwt: "eyJ.PKG_ACC.sig",
+          credsPath: "~/.config/nats/pkg.creds",
+        },
+        // … but explicit flags override operatorJwt + account + creds.
+        operatorJwt: OP_JWT,
+        account: "A" + "C".repeat(55),
+        credsPath: "~/.config/nats/flag.creds",
+      },
+      "/cfg",
+      reader(CFG_NO_PKG),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toEqual({
+      operatorJwt: OP_JWT, // flag won
+      account: "A" + "C".repeat(55), // flag won
+      accountJwt: "eyJ.PKG_ACC.sig", // package (no flag)
+    });
+    expect(res.inputs?.credsPath).toBe("~/.config/nats/flag.creds"); // flag won
+  });
+
+  test("package overrides config (package beats config for the package fields)", () => {
+    const cfgWithMaterial = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/community",
+        nkey_seed_path: "~/seed.nk",
+        nats_infra: {
+          config_path: "~/community.conf",
+          plist_path: "~/nats.plist",
+          operator_jwt: "eyJ.CONFIG_OP.sig",
+          account: "A" + "E".repeat(55),
+          account_jwt: "eyJ.CONFIG_ACC.sig",
+          creds_path: "~/.config/nats/config.creds",
+        },
+      },
+      policy: {
+        principals: [],
+        roles: [],
+        federated: {
+          networks: [],
+          registry: { url: "https://r", pubkey: "A".repeat(43) + "=" },
+        },
+      },
+    });
+    const res = deriveJoinInputs(
+      "metafactory-community",
+      {
+        leafPackage: {
+          operatorJwt: OP_JWT,
+          account: PKG_ACCOUNT,
+          accountJwt: ACC_JWT,
+          credsPath: "~/.config/nats/issued.creds",
+        },
+      },
+      "/cfg",
+      reader(cfgWithMaterial),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toEqual({
+      operatorJwt: OP_JWT, // package beats config
+      account: PKG_ACCOUNT, // package beats config
+      accountJwt: ACC_JWT, // package beats config
+    });
+    expect(res.inputs?.credsPath).toBe("~/.config/nats/issued.creds"); // package beats config
+  });
+
+  test("no package + no flags + no config material → operatorModePackage undefined", () => {
+    const res = deriveJoinInputs("metafactory-community", {}, "/cfg", reader(CFG_NO_PKG), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.operatorModePackage).toBeUndefined();
+    // creds still falls through to the convention default.
+    expect(res.inputs?.credsPath).toBe("~/.config/nats/metafactory-community.creds");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-leaf-package.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-leaf-package.test.ts
@@ -1,0 +1,224 @@
+/**
+ * O-4b (cortex#1063, epic #1050, spec
+ * `docs/design-automated-operator-onboarding.md` §3) — `cortex network join`
+ * SOURCES the operator-mode leaf package from a file (`--from-package <file>`)
+ * instead of demanding the four `--operator-jwt`/`--account-jwt`/`--account`/
+ * `--system-account*` flags by hand.
+ *
+ * This file is the RED-first spec for the PURE parser/validator half of O-4b:
+ * {@link parseLeafPackageFile}. It reads the JSON wire shape O-4a's signed
+ * register→issue response will carry ({@link LeafPackageFile}), validates it with
+ * the SAME nkey-U / JWT-shape guards O-3 uses (reused, never re-derived), and
+ * fails fast on a malformed package — so unvalidated key material can never reach
+ * the operator-mode conversion seam.
+ *
+ * Public repo — every value here is an OBVIOUS fake `eyJ…` / `A…`-shaped fixture.
+ * No real key material; no seeds (the package is JWT + nkey-U pubkey text only).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseLeafPackageFile,
+  leafPackageToOperatorMode,
+  type LeafPackageFile,
+  type LeafPackageParseResult,
+} from "../network-leaf-package";
+import {
+  isNkeyAccountPubkey,
+  isNscJwtShape,
+} from "../../../../common/nats/leaf-remote-renderer";
+
+// =============================================================================
+// Fixtures — obvious fakes shaped like the real wire material.
+// =============================================================================
+
+/** A well-formed fake operator JWT (`eyJ…` + three base64url segments). */
+const FAKE_OPERATOR_JWT = "eyJhbGciOiJlZDI1NTE5In0.eyJvcCI6ImZha2UifQ.c2lnbmF0dXJlMQ";
+/** A well-formed fake account JWT. */
+const FAKE_ACCOUNT_JWT = "eyJhbGciOiJlZDI1NTE5In0.eyJhYyI6ImZha2UifQ.c2lnbmF0dXJlMg";
+/** A well-formed fake system-account JWT. */
+const FAKE_SYS_JWT = "eyJhbGciOiJlZDI1NTE5In0.eyJzeXMiOiJmYWtlIn0.c2lnbmF0dXJlMw";
+/** A well-formed fake account nkey-U (`A` + 55 base32 chars). */
+const FAKE_ACCOUNT = "A" + "B".repeat(55);
+/** A well-formed fake system-account nkey-U. */
+const FAKE_SYS_ACCOUNT = "A" + "C".repeat(55);
+
+/** The minimal valid package — operator JWT + account + account JWT + creds. */
+const MINIMAL: LeafPackageFile = {
+  operatorJwt: FAKE_OPERATOR_JWT,
+  account: FAKE_ACCOUNT,
+  accountJwt: FAKE_ACCOUNT_JWT,
+  credsPath: "~/.config/nats/metafactory-community.creds",
+};
+
+/** The full package — adds the optional system account (+ JWT) + endpoint. */
+const FULL: LeafPackageFile = {
+  ...MINIMAL,
+  systemAccount: FAKE_SYS_ACCOUNT,
+  systemAccountJwt: FAKE_SYS_JWT,
+  endpoint: "tls://hub.meta-factory.dev:7422",
+};
+
+/** Narrow to a parsed package, failing the test with the reason otherwise. */
+function mustParse(result: LeafPackageParseResult): LeafPackageFile {
+  if (!result.ok) throw new Error(`expected ok, got refuse: ${result.reason}`);
+  return result.package;
+}
+
+// =============================================================================
+// Reused-guard sanity — the fixtures actually exercise O-3's grammar.
+// =============================================================================
+
+describe("O-4b fixtures exercise the reused O-3 guards", () => {
+  test("the fake account/JWTs pass the exported O-3 predicates", () => {
+    expect(isNkeyAccountPubkey(FAKE_ACCOUNT)).toBe(true);
+    expect(isNkeyAccountPubkey(FAKE_SYS_ACCOUNT)).toBe(true);
+    expect(isNscJwtShape(FAKE_OPERATOR_JWT)).toBe(true);
+    expect(isNscJwtShape(FAKE_ACCOUNT_JWT)).toBe(true);
+    expect(isNscJwtShape(FAKE_SYS_JWT)).toBe(true);
+  });
+});
+
+// =============================================================================
+// Happy path — a valid package parses to the wire shape.
+// =============================================================================
+
+describe("parseLeafPackageFile — valid packages", () => {
+  test("parses a minimal package (operator JWT + account + accountJwt + credsPath)", () => {
+    const pkg = mustParse(parseLeafPackageFile(JSON.stringify(MINIMAL)));
+    expect(pkg).toEqual(MINIMAL);
+  });
+
+  test("parses a full package (system account + JWT + endpoint)", () => {
+    const pkg = mustParse(parseLeafPackageFile(JSON.stringify(FULL)));
+    expect(pkg).toEqual(FULL);
+  });
+
+  test("ignores unknown extra fields (forward-compat with O-4a additions)", () => {
+    const withExtra = { ...MINIMAL, futureField: "ignored", another: 7 };
+    const pkg = mustParse(parseLeafPackageFile(JSON.stringify(withExtra)));
+    // Only the known wire fields survive; extras are dropped, not echoed back.
+    expect(pkg).toEqual(MINIMAL);
+    expect((pkg as unknown as Record<string, unknown>).futureField).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Fail-fast — malformed packages refuse, with an actionable reason.
+// =============================================================================
+
+describe("parseLeafPackageFile — malformed packages fail fast", () => {
+  test("non-JSON → refuse", () => {
+    const res = parseLeafPackageFile("{ not json");
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/parse|json/i);
+  });
+
+  test("non-object JSON (array) → refuse", () => {
+    const res = parseLeafPackageFile("[1,2,3]");
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/object/i);
+  });
+
+  test("missing operatorJwt → refuse naming the field", () => {
+    const { operatorJwt: _drop, ...rest } = MINIMAL;
+    const res = parseLeafPackageFile(JSON.stringify(rest));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/operatorJwt/);
+  });
+
+  test("operatorJwt with bad JWT shape (2 segments) → refuse", () => {
+    const res = parseLeafPackageFile(
+      JSON.stringify({ ...MINIMAL, operatorJwt: "eyJhbGci.payload" }),
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/operatorJwt|JWT/);
+  });
+
+  test("account that is not an nkey-U (wrong prefix) → refuse", () => {
+    const res = parseLeafPackageFile(
+      JSON.stringify({ ...MINIMAL, account: "U" + "B".repeat(55) }),
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/account|nkey/i);
+  });
+
+  test("accountJwt with bad shape → refuse", () => {
+    const res = parseLeafPackageFile(
+      JSON.stringify({ ...MINIMAL, accountJwt: "not-a-jwt" }),
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/accountJwt|JWT/);
+  });
+
+  test("missing credsPath → refuse naming the field", () => {
+    const { credsPath: _drop, ...rest } = MINIMAL;
+    const res = parseLeafPackageFile(JSON.stringify(rest));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/credsPath/);
+  });
+
+  test("empty credsPath → refuse", () => {
+    const res = parseLeafPackageFile(JSON.stringify({ ...MINIMAL, credsPath: "  " }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/credsPath/);
+  });
+
+  test("systemAccount offered without systemAccountJwt → refuse", () => {
+    const res = parseLeafPackageFile(
+      JSON.stringify({ ...MINIMAL, systemAccount: FAKE_SYS_ACCOUNT }),
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/system.?account.?jwt/i);
+  });
+
+  test("systemAccount with bad nkey shape → refuse", () => {
+    const res = parseLeafPackageFile(
+      JSON.stringify({
+        ...MINIMAL,
+        systemAccount: "Z" + "C".repeat(55),
+        systemAccountJwt: FAKE_SYS_JWT,
+      }),
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/system.?account|nkey/i);
+  });
+
+  test("endpoint with wrong type → refuse", () => {
+    const res = parseLeafPackageFile(
+      JSON.stringify({ ...MINIMAL, endpoint: 1234 }),
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/endpoint|string/i);
+  });
+});
+
+// =============================================================================
+// Projection — the package SUPERSET maps onto O-3's render subset.
+// =============================================================================
+
+describe("leafPackageToOperatorMode — drops credsPath/endpoint", () => {
+  test("a full package projects to the OperatorModeLeafPackage render fields only", () => {
+    const om = leafPackageToOperatorMode(FULL);
+    expect(om).toEqual({
+      operatorJwt: FAKE_OPERATOR_JWT,
+      account: FAKE_ACCOUNT,
+      accountJwt: FAKE_ACCOUNT_JWT,
+      systemAccount: FAKE_SYS_ACCOUNT,
+      systemAccountJwt: FAKE_SYS_JWT,
+    });
+    // credsPath + endpoint are NOT operator-mode render material.
+    expect((om as unknown as Record<string, unknown>).credsPath).toBeUndefined();
+    expect((om as unknown as Record<string, unknown>).endpoint).toBeUndefined();
+  });
+
+  test("a minimal package omits the optional SYS fields", () => {
+    const om = leafPackageToOperatorMode(MINIMAL);
+    expect(om).toEqual({
+      operatorJwt: FAKE_OPERATOR_JWT,
+      account: FAKE_ACCOUNT,
+      accountJwt: FAKE_ACCOUNT_JWT,
+    });
+  });
+});

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -39,6 +39,7 @@
 import type { LoadedConfig } from "../../../common/config/loader";
 import type { ServicePlatform } from "../../../common/nats/nats-service-manager";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
+import type { LeafPackageFile } from "./network-leaf-package";
 
 // =============================================================================
 // Types
@@ -140,6 +141,17 @@ export interface JoinOverrides {
   systemAccount?: string;
   /** O-3 (#1053) — `--system-account-jwt`. */
   systemAccountJwt?: string;
+  /**
+   * O-4b (#1063) — the leaf package SOURCED from `--from-package <file>` (parsed
+   * + validated by the CLI before it reaches here). Sits in the precedence chain
+   * BELOW the explicit per-field flags above and ABOVE config: an explicit flag
+   * (`operatorJwt`/`account`/`accountJwt`/`systemAccount*`/`credsPath`) wins, then
+   * the package supplies what it sets, then config, then convention. The package
+   * also carries `credsPath` (the issued leaf creds) which feeds the join's creds
+   * resolution. O-4a will supply the SAME shape over the wire; this is the interim
+   * file source. Absent ⇒ unchanged O-3/#753 behaviour.
+   */
+  leafPackage?: LeafPackageFile;
 }
 
 /** A reader that loads + validates the cortex config from a path. */
@@ -344,6 +356,12 @@ export function deriveJoinInputs(
   // nats-infra — flag wins, else stack.nats_infra.{config_path,plist_path,account}.
   const natsInfra = cfg.stack?.nats_infra;
 
+  // O-4b (#1063) — the leaf package sourced from `--from-package`. Sits ABOVE
+  // config and BELOW the explicit per-field flags in the precedence chain (flag
+  // > package > config > convention). Already parsed + validated by the CLI, so
+  // every field here is well-formed (the renderer re-validates at conversion).
+  const pkg = overrides.leafPackage;
+
   const natsConfigPath = overrides.natsConfigPath ?? natsInfra?.config_path;
   if (natsConfigPath === undefined || natsConfigPath === "") {
     return fail(
@@ -367,26 +385,29 @@ export function deriveJoinInputs(
   // leaf (binding rides in the creds JWT). So an absent account is NOT an
   // error here; the bind-mode decision (resolveLeafBindMode) refuses only the
   // genuinely-unjoinable case (no creds, or operator-mode missing the account).
-  const accountRaw = overrides.account ?? natsInfra?.account;
+  const accountRaw = overrides.account ?? pkg?.account ?? natsInfra?.account;
   const account =
     accountRaw === undefined || accountRaw === "" ? undefined : accountRaw;
 
-  // creds — flag wins, else stack.nats_infra.creds_path, else convention.
+  // creds — flag wins, else the package's issued creds, else
+  // stack.nats_infra.creds_path, else convention.
   const credsPath =
-    overrides.credsPath ?? natsInfra?.creds_path ?? defaultCredsPath(networkId);
+    overrides.credsPath ?? pkg?.credsPath ?? natsInfra?.creds_path ?? defaultCredsPath(networkId);
 
-  // O-3 (cortex#1053) — assemble the operator-mode leaf package. Flag wins over
-  // config (`stack.nats_infra.{operator_jwt,account_jwt,system_account,…}`). The
-  // package materialises ONLY when its minimum (operator JWT + account + account
-  // JWT) all resolve; a partial set is treated as "no package" so join falls back
-  // to the #794 fail-fast rather than handing a half-formed package to the
-  // renderer (which would refuse anyway, but with a less obvious cause). O-4
-  // supplies these via the handshake; here they come from flags/config.
-  const operatorJwt = overrides.operatorJwt ?? natsInfra?.operator_jwt;
-  const accountJwt = overrides.accountJwt ?? natsInfra?.account_jwt;
-  const systemAccount = overrides.systemAccount ?? natsInfra?.system_account;
+  // O-3 (cortex#1053) — assemble the operator-mode leaf package. Precedence per
+  // field: explicit flag > `--from-package` file (O-4b #1063) > config
+  // (`stack.nats_infra.{operator_jwt,account_jwt,system_account,…}`). The package
+  // materialises ONLY when its minimum (operator JWT + account + account JWT) all
+  // resolve; a partial set is treated as "no package" so join falls back to the
+  // #794 fail-fast rather than handing a half-formed package to the renderer
+  // (which would refuse anyway, but with a less obvious cause). O-4a supplies the
+  // file/wire package; flags/config remain the manual path.
+  const operatorJwt = overrides.operatorJwt ?? pkg?.operatorJwt ?? natsInfra?.operator_jwt;
+  const accountJwt = overrides.accountJwt ?? pkg?.accountJwt ?? natsInfra?.account_jwt;
+  const systemAccount =
+    overrides.systemAccount ?? pkg?.systemAccount ?? natsInfra?.system_account;
   const systemAccountJwt =
-    overrides.systemAccountJwt ?? natsInfra?.system_account_jwt;
+    overrides.systemAccountJwt ?? pkg?.systemAccountJwt ?? natsInfra?.system_account_jwt;
   const operatorModePackage: OperatorModeLeafPackage | undefined =
     operatorJwt !== undefined &&
     operatorJwt !== "" &&

--- a/src/cli/cortex/commands/network-leaf-package.ts
+++ b/src/cli/cortex/commands/network-leaf-package.ts
@@ -1,0 +1,268 @@
+/**
+ * O-4b (cortex#1063, epic #1050, spec
+ * `docs/design-automated-operator-onboarding.md` §3) — the LEAF-PACKAGE wire
+ * shape + its parser/validator.
+ *
+ * ## What this is
+ *
+ * O-3 (#1053) made `cortex network join` render the SOP §B0.1 operator-mode
+ * blocks from an {@link OperatorModeLeafPackage}, but a human still had to hand
+ * it the four `--operator-jwt` / `--account-jwt` / `--account` /
+ * `--system-account*` flags. O-4 closes that: the signed register→issue response
+ * carries the leaf package, and join consumes it.
+ *
+ * O-4a (the wire transport) is not built yet. O-4b is the CONSUMER side: it adds
+ * a `--from-package <file>` SOURCE — an interim, on-disk form of the EXACT JSON
+ * shape O-4a's signed response will carry ({@link LeafPackageFile}) — so a
+ * joining principal can already drive the automated-conversion path from a file
+ * the onboarding bot writes, without the four flags.
+ *
+ * ## The single contract
+ *
+ * {@link LeafPackageFile} IS the wire shape O-4a will PRODUCE and O-4b CONSUMES.
+ * It is the operator-mode material O-3's renderer needs ({@link
+ * OperatorModeLeafPackage}: `operatorJwt`, `account`, `accountJwt`, optional
+ * `systemAccount` + `systemAccountJwt`) PLUS the two facts the join already
+ * threads from elsewhere but the bot now supplies in one document:
+ *
+ *   - `credsPath` — the issued leaf `.creds` path (today derived from
+ *     `--creds` / `stack.nats_infra.creds_path` / convention). REQUIRED on the
+ *     package: the issued creds are the whole point of the register→issue
+ *     handshake, so a package that omits them is malformed.
+ *   - `endpoint` — OPTIONAL leaf dial URL hint. The authoritative hub_url comes
+ *     from the SIGNED+VERIFIED network descriptor (DD-12), so this is advisory
+ *     only and the join does NOT bind it into the descriptor; it is carried for
+ *     forward-compat / diagnostics and validated only for shape.
+ *
+ * ## Public-repo safety
+ *
+ * The package is JWT + nkey-U PUBLIC-KEY text — NEVER a seed. The `.creds` it
+ * points at is a secret on disk, but the PATH is not. The parser refuses any
+ * malformed material with a fail-fast (never feeds unvalidated material into the
+ * operator-mode conversion).
+ *
+ * ## Validation — REUSE, don't duplicate
+ *
+ * The nkey-U / JWT-shape guards are O-3's, exported from leaf-remote-renderer as
+ * {@link isNkeyAccountPubkey} / {@link isNscJwtShape}. This module calls them so
+ * the package validator and the renderer share ONE grammar (a second copy could
+ * drift and let a value O-3 rejects slip past the parser, or vice-versa).
+ */
+
+import {
+  isNkeyAccountPubkey,
+  isNscJwtShape,
+  type OperatorModeLeafPackage,
+} from "../../../common/nats/leaf-remote-renderer";
+
+// =============================================================================
+// The wire shape — the single O-4a-produces / O-4b-consumes contract.
+// =============================================================================
+
+/**
+ * The leaf package as it crosses the wire (and, interim, as the `--from-package`
+ * file on disk). The SINGLE contract O-4a's signed register→issue response will
+ * produce and `cortex network join` consumes.
+ *
+ * Superset of {@link OperatorModeLeafPackage} (the operator-mode render material)
+ * + `credsPath` (the issued leaf creds, REQUIRED) + `endpoint` (an OPTIONAL,
+ * advisory dial-URL hint — the authoritative hub_url is the signed descriptor's,
+ * DD-12).
+ *
+ * Every field is PUBLIC material: JWTs (`eyJ…`) and nkey-U account PUBLIC keys
+ * (`A…`) — never a seed. `credsPath` is a filesystem path, not the creds.
+ */
+export interface LeafPackageFile {
+  /** The NSC operator JWT (`eyJ…`) — root of the local account tree. */
+  operatorJwt: string;
+  /** The issued account public key (nkey-U, `A…`) the leaf binds to. */
+  account: string;
+  /** The issued account's JWT (`eyJ…`) — preloaded under `resolver_preload`. */
+  accountJwt: string;
+  /** OPTIONAL system-account public key (nkey-U). Sets `system_account`. */
+  systemAccount?: string;
+  /** OPTIONAL system-account JWT — preloaded alongside the issued account. */
+  systemAccountJwt?: string;
+  /**
+   * The issued leaf `.creds` path. REQUIRED — the issued creds are the point of
+   * the handshake. (The PATH is public; the file it names is the secret.)
+   */
+  credsPath: string;
+  /**
+   * OPTIONAL advisory leaf dial-URL hint (`tls://host:port`). The authoritative
+   * hub_url is the SIGNED+VERIFIED descriptor's (DD-12); this is carried for
+   * forward-compat / diagnostics and is NOT bound into the descriptor.
+   */
+  endpoint?: string;
+}
+
+/** The result of {@link parseLeafPackageFile}: a validated package, or a reason. */
+export type LeafPackageParseResult =
+  | { ok: true; package: LeafPackageFile }
+  | { ok: false; reason: string };
+
+// =============================================================================
+// Parse + validate.
+// =============================================================================
+
+/** Read a non-empty string field; returns `undefined` when absent/empty/wrong-type. */
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : value;
+}
+
+/**
+ * Parse + validate a leaf-package JSON document into a {@link LeafPackageFile}.
+ * PURE (string in, result out): no filesystem, no daemon — the caller reads the
+ * file and passes the text.
+ *
+ * Fail-fast (`{ ok: false, reason }`) on ANY malformed material — never return a
+ * half-formed package that could feed unvalidated key material into the
+ * operator-mode conversion. The grammar guards are O-3's, REUSED:
+ *   - `operatorJwt` / `accountJwt` (+ `systemAccountJwt` when offered) →
+ *     {@link isNscJwtShape};
+ *   - `account` (+ `systemAccount` when offered) → {@link isNkeyAccountPubkey}.
+ *
+ * Validation rules (mirroring O-3's {@link renderOperatorModeBlocks} so the
+ * parser and the renderer agree on what "well-formed" means):
+ *   - the document must be a JSON OBJECT;
+ *   - `operatorJwt`, `account`, `accountJwt`, `credsPath` are REQUIRED;
+ *   - if `systemAccount` is offered it must be a valid nkey-U AND be paired with
+ *     a valid `systemAccountJwt` (a half-specified SYS account is malformed);
+ *   - `endpoint` is optional and, when present, must be a string.
+ *
+ * Unknown extra fields are IGNORED (forward-compat: O-4a may add fields).
+ */
+export function parseLeafPackageFile(jsonText: string): LeafPackageParseResult {
+  // 1) Parse the JSON. A syntax error is a malformed package file handed to us.
+  let raw: unknown;
+  try {
+    raw = JSON.parse(jsonText);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `leaf package is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return {
+      ok: false,
+      reason: "leaf package must be a JSON object (got " + (Array.isArray(raw) ? "an array" : typeof raw) + ")",
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  // 2) Required operator JWT.
+  const operatorJwt = optionalString(obj.operatorJwt)?.trim();
+  if (operatorJwt === undefined) {
+    return { ok: false, reason: "leaf package is missing `operatorJwt` (the NSC operator JWT)" };
+  }
+  if (!isNscJwtShape(operatorJwt)) {
+    return {
+      ok: false,
+      reason: `leaf package \`operatorJwt\` is not a JWT (expected an \`eyJ…\` token with three dot-separated segments)`,
+    };
+  }
+
+  // 3) Required account nkey-U.
+  const account = optionalString(obj.account)?.trim();
+  if (account === undefined) {
+    return { ok: false, reason: "leaf package is missing `account` (the issued account public key)" };
+  }
+  if (!isNkeyAccountPubkey(account)) {
+    return {
+      ok: false,
+      reason: "leaf package `account` is not an nkey-U account public key (`A…`, 56 chars)",
+    };
+  }
+
+  // 4) Required account JWT.
+  const accountJwt = optionalString(obj.accountJwt)?.trim();
+  if (accountJwt === undefined) {
+    return { ok: false, reason: "leaf package is missing `accountJwt` (the issued account JWT)" };
+  }
+  if (!isNscJwtShape(accountJwt)) {
+    return {
+      ok: false,
+      reason: "leaf package `accountJwt` is not a JWT (expected an `eyJ…` token with three dot-separated segments)",
+    };
+  }
+
+  // 5) Required creds path. The PATH (not the creds) — must be a non-empty string.
+  const credsPath = optionalString(obj.credsPath);
+  if (credsPath === undefined) {
+    return {
+      ok: false,
+      reason: "leaf package is missing `credsPath` (the issued leaf .creds path)",
+    };
+  }
+
+  // 6) Optional system account — when offered, it must be a valid nkey-U AND
+  // paired with a valid JWT (a half-specified SYS account is malformed, exactly
+  // as O-3's renderer refuses).
+  const systemAccount = optionalString(obj.systemAccount)?.trim();
+  const systemAccountJwt = optionalString(obj.systemAccountJwt)?.trim();
+  if (systemAccount !== undefined) {
+    if (!isNkeyAccountPubkey(systemAccount)) {
+      return {
+        ok: false,
+        reason: "leaf package `systemAccount` is not an nkey-U account public key (`A…`, 56 chars)",
+      };
+    }
+    if (systemAccountJwt === undefined || !isNscJwtShape(systemAccountJwt)) {
+      return {
+        ok: false,
+        reason:
+          "leaf package offers a `systemAccount` without a valid `systemAccountJwt` — " +
+          "resolver_preload must carry the SYS account's JWT too",
+      };
+    }
+  } else if (systemAccountJwt !== undefined) {
+    // A SYS JWT with no SYS account is malformed (nothing to preload it against).
+    return {
+      ok: false,
+      reason: "leaf package offers a `systemAccountJwt` without a `systemAccount`",
+    };
+  }
+
+  // 7) Optional endpoint — shape only (must be a string when present). The
+  // authoritative hub_url is the signed descriptor's (DD-12); this is advisory.
+  if (obj.endpoint !== undefined && typeof obj.endpoint !== "string") {
+    return { ok: false, reason: "leaf package `endpoint` must be a string (a dial-URL hint) when present" };
+  }
+  const endpoint = optionalString(obj.endpoint);
+
+  return {
+    ok: true,
+    package: {
+      operatorJwt,
+      account,
+      accountJwt,
+      credsPath,
+      ...(systemAccount !== undefined && { systemAccount }),
+      ...(systemAccountJwt !== undefined && { systemAccountJwt }),
+      ...(endpoint !== undefined && { endpoint }),
+    },
+  };
+}
+
+/**
+ * Project a validated {@link LeafPackageFile} onto the {@link
+ * OperatorModeLeafPackage} O-3's renderer consumes. The package is a SUPERSET
+ * (it also carries `credsPath` + `endpoint`, which are NOT operator-mode render
+ * material), so this drops those two and returns only the render fields.
+ */
+export function leafPackageToOperatorMode(
+  pkg: LeafPackageFile,
+): OperatorModeLeafPackage {
+  return {
+    operatorJwt: pkg.operatorJwt,
+    account: pkg.account,
+    accountJwt: pkg.accountJwt,
+    ...(pkg.systemAccount !== undefined && { systemAccount: pkg.systemAccount }),
+    ...(pkg.systemAccountJwt !== undefined && {
+      systemAccountJwt: pkg.systemAccountJwt,
+    }),
+  };
+}

--- a/src/cli/cortex/commands/network-leaf-package.ts
+++ b/src/cli/cortex/commands/network-leaf-package.ts
@@ -105,11 +105,11 @@ export type LeafPackageParseResult =
 // Parse + validate.
 // =============================================================================
 
-/** Read a non-empty string field; returns `undefined` when absent/empty/wrong-type. */
+/** Read a non-empty string field, TRIMMED; returns `undefined` when absent/empty/wrong-type. */
 function optionalString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
-  return trimmed.length === 0 ? undefined : value;
+  return trimmed.length === 0 ? undefined : trimmed;
 }
 
 /**
@@ -154,7 +154,7 @@ export function parseLeafPackageFile(jsonText: string): LeafPackageParseResult {
   const obj = raw as Record<string, unknown>;
 
   // 2) Required operator JWT.
-  const operatorJwt = optionalString(obj.operatorJwt)?.trim();
+  const operatorJwt = optionalString(obj.operatorJwt);
   if (operatorJwt === undefined) {
     return { ok: false, reason: "leaf package is missing `operatorJwt` (the NSC operator JWT)" };
   }
@@ -166,7 +166,7 @@ export function parseLeafPackageFile(jsonText: string): LeafPackageParseResult {
   }
 
   // 3) Required account nkey-U.
-  const account = optionalString(obj.account)?.trim();
+  const account = optionalString(obj.account);
   if (account === undefined) {
     return { ok: false, reason: "leaf package is missing `account` (the issued account public key)" };
   }
@@ -178,7 +178,7 @@ export function parseLeafPackageFile(jsonText: string): LeafPackageParseResult {
   }
 
   // 4) Required account JWT.
-  const accountJwt = optionalString(obj.accountJwt)?.trim();
+  const accountJwt = optionalString(obj.accountJwt);
   if (accountJwt === undefined) {
     return { ok: false, reason: "leaf package is missing `accountJwt` (the issued account JWT)" };
   }
@@ -201,8 +201,8 @@ export function parseLeafPackageFile(jsonText: string): LeafPackageParseResult {
   // 6) Optional system account — when offered, it must be a valid nkey-U AND
   // paired with a valid JWT (a half-specified SYS account is malformed, exactly
   // as O-3's renderer refuses).
-  const systemAccount = optionalString(obj.systemAccount)?.trim();
-  const systemAccountJwt = optionalString(obj.systemAccountJwt)?.trim();
+  const systemAccount = optionalString(obj.systemAccount);
+  const systemAccountJwt = optionalString(obj.systemAccountJwt);
   if (systemAccount !== undefined) {
     if (!isNkeyAccountPubkey(systemAccount)) {
       return {

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -40,7 +40,7 @@
  * Exit codes: 0 success · 1 operational failure · 2 usage error.
  */
 
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { join } from "path";
 
@@ -61,6 +61,10 @@ import {
   tolerantReader,
   type ConfigReader,
 } from "./network-derive";
+import {
+  parseLeafPackageFile,
+  type LeafPackageFile,
+} from "./network-leaf-package";
 
 /**
  * #753 — the production config reader: `loadConfigWithAgents` wrapped so a
@@ -180,6 +184,12 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--account-jwt": "value",
         "--system-account": "value",
         "--system-account-jwt": "value",
+        // O-4b (cortex#1063) — SOURCE the operator-mode leaf package from a JSON
+        // file (the interim form of the shape O-4a's signed register→issue
+        // response will carry) instead of the four flags above. Read + validated
+        // before it reaches deriveJoinInputs; sits BELOW the explicit flags and
+        // ABOVE config in precedence (flag > package > config > convention).
+        "--from-package": "value",
         "--nats-config": "value",
         "--plist": "value",
         // #763 — Linux/systemd: the nats-server systemd unit path (the
@@ -316,6 +326,40 @@ function readOverride(
   return { [resolvedKey]: v };
 }
 
+/**
+ * O-4b (cortex#1063) — read + validate the `--from-package <file>` leaf package.
+ * A PURE READ: it only reads the file (never writes), so it is safe under
+ * dry-run. Returns the parsed {@link LeafPackageFile}, or a usage-error reason on
+ * a missing/unreadable/malformed file — fail-fast so unvalidated key material
+ * never reaches the operator-mode conversion seam. `undefined` when the flag is
+ * absent (the common case: no package source).
+ */
+function readLeafPackageFlag(
+  flags: Record<string, string | true>,
+): { ok: true; package: LeafPackageFile | undefined } | { ok: false; reason: string } {
+  const path = optionalValueFlag(flags, "--from-package");
+  if (path === undefined) return { ok: true, package: undefined };
+
+  const expanded = expandTilde(path);
+  if (!existsSync(expanded)) {
+    return { ok: false, reason: `--from-package file not found at ${expanded}` };
+  }
+  let text: string;
+  try {
+    text = readFileSync(expanded, "utf-8");
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `failed to read --from-package file: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  const parsed = parseLeafPackageFile(text);
+  if (!parsed.ok) {
+    return { ok: false, reason: `invalid --from-package file: ${parsed.reason}` };
+  }
+  return { ok: true, package: parsed.package };
+}
+
 /** Resolve the stack slug from `--stack` (`{principal}/{slug}`) or default. */
 function resolveStackSlug(
   principalId: string,
@@ -443,6 +487,13 @@ async function runJoin(
     return usageError("join", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
   }
 
+  // O-4b (cortex#1063) — read + validate the `--from-package` leaf package FIRST
+  // (a pure read). A malformed/missing package fails fast as a usage error here,
+  // BEFORE any derivation or mutation, so unvalidated key material never reaches
+  // the operator-mode conversion. Absent ⇒ undefined (the common case).
+  const pkgRes = readLeafPackageFlag(flags);
+  if (!pkgRes.ok) return usageError("join", pkgRes.reason, json);
+
   // #753 — derive principal / stack / seed / registry / nats-infra (config +
   // convention), with each flag surviving as an optional override. Config-load
   // errors (bad YAML, schema violations) surface as an op-error with the
@@ -468,6 +519,10 @@ async function runJoin(
         ...readOverride(flags, "--account-jwt", "accountJwt"),
         ...readOverride(flags, "--system-account", "systemAccount"),
         ...readOverride(flags, "--system-account-jwt", "systemAccountJwt"),
+        // O-4b (cortex#1063) — the `--from-package` leaf package (parsed above).
+        // Sits BELOW the explicit per-field flags and ABOVE config in the
+        // deriver's precedence chain (flag > package > config > convention).
+        ...(pkgRes.package !== undefined && { leafPackage: pkgRes.package }),
       },
       expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
       load,
@@ -1352,6 +1407,16 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
                           to stack.nats_infra.system_account.
   --system-account-jwt <eyJ…> (O-3, #1053) OPTIONAL system account JWT. Maps to
                           stack.nats_infra.system_account_jwt.
+  --from-package <file>   (O-4b, #1063) SOURCE the operator-mode leaf package from a
+                          JSON file — the interim form of the shape O-4a's signed
+                          register→issue response will carry:
+                          { operatorJwt, account, accountJwt, systemAccount?,
+                            systemAccountJwt?, credsPath, endpoint? }. Saves passing
+                          the four --operator-jwt/--account-jwt/--account/
+                          --system-account* flags by hand. Validated (nkey-U/JWT
+                          shape) + fail-fast on a malformed package. Precedence:
+                          explicit flags override the package; the package overrides
+                          config; the package sets only what it carries.
   --nats-config <p>       Override stack.nats_infra.config_path (nats-server -c config).
   --plist <p>             Override stack.nats_infra.plist_path (macOS nats-server launchd plist).
   --unit <p>              Override stack.nats_infra.unit_path (Linux nats-server systemd unit; #763).

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -942,6 +942,37 @@ export function renderOperatorModeBlocks(
  */
 const JWT_SHAPE = /^eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2}$/;
 
+// =============================================================================
+// O-4b (cortex#1063) — reusable shape guards for the leaf-package consumer.
+//
+// O-4b's `--from-package` source (network-leaf-package.ts) must fail-fast on a
+// malformed package with EXACTLY the same nkey-U / JWT-shape grammar O-3 uses to
+// validate before rendering — never a second, drifting copy. The two predicates
+// below expose `NKEY_ACCOUNT` / `JWT_SHAPE` (the module-private regexes above)
+// as named functions so the consumer reuses them rather than re-deriving the
+// grammar. Keeping the regexes private (only the predicates are exported)
+// preserves this module as the single source of the grammar.
+// =============================================================================
+
+/**
+ * True iff `value` is a NATS nkey-U account public key (`A` + 55 base32 chars).
+ * The exact grammar {@link renderOperatorModeBlocks} validates the package
+ * account/system-account against before emitting it bare into HOCON. (O-4b reuse)
+ */
+export function isNkeyAccountPubkey(value: string): boolean {
+  return NKEY_ACCOUNT.test(value);
+}
+
+/**
+ * True iff `value` has the NSC JWT shape (`eyJ…` header + exactly three
+ * dot-separated base64url segments) {@link renderOperatorModeBlocks} requires of
+ * the operator JWT and the account JWTs before emitting them. Validated, never
+ * cryptographically verified — verification is O-4's handshake. (O-4b reuse)
+ */
+export function isNscJwtShape(value: string): boolean {
+  return JWT_SHAPE.test(value);
+}
+
 /**
  * #821 MAJOR (code-review) — derive the nats-server HTTP MONITOR url from its
  * config, so the post-restart health probe targets THIS bus's monitor port (the


### PR DESCRIPTION
## What

`cortex network join` now **sources the operator-mode leaf package from a file** (`--from-package <file>`) instead of demanding the four `--operator-jwt` / `--account-jwt` / `--account` / `--system-account*` flags by hand. The package is the interim, on-disk form of the **exact shape O-4a's signed `register→issue` response will carry** — so this is the **consumer half** of O-4's handshake (`#1050` spec §3, D3), landing ahead of the wire transport.

## Wire shape — the single O-4a-produces / O-4b-consumes contract

```ts
interface LeafPackageFile {
  operatorJwt: string;       // NSC operator JWT (eyJ…) — root of the account tree
  account: string;           // issued account pubkey (nkey-U, A…) the leaf binds to
  accountJwt: string;        // issued account JWT (eyJ…) — preloaded under resolver_preload
  systemAccount?: string;    // OPTIONAL SYS account pubkey (nkey-U) → system_account
  systemAccountJwt?: string; // OPTIONAL SYS account JWT (preloaded alongside)
  credsPath: string;         // REQUIRED issued leaf .creds PATH (the file is the secret, not the path)
  endpoint?: string;         // OPTIONAL advisory dial-URL hint; the authoritative hub_url is the SIGNED descriptor's (DD-12)
}
```

Superset of O-3's `OperatorModeLeafPackage` (the render material) + `credsPath` (the issued creds — the point of the handshake) + advisory `endpoint`. All fields are **public** key material (JWTs + nkey-U pubkeys); never a seed.

## Source / precedence / validation

- **Source:** `network-leaf-package.ts` — `parseLeafPackageFile(json)` (pure: string in, result out). `network.ts` reads + parses the file **first**, as a pure read.
- **Precedence:** `explicit flags > --from-package file > config > convention`, per field (`operatorJwt` / `account` / `accountJwt` / `systemAccount*` / `credsPath`). The package sets only what it carries; a flag always wins; the package beats config. Threaded as a `JoinOverrides` layer in `deriveJoinInputs`.
- **Validation — REUSE, not duplicate:** the nkey-U / JWT-shape guards are O-3's, now exported from `leaf-remote-renderer` as `isNkeyAccountPubkey` / `isNscJwtShape` and called by the parser (one grammar, no drift). A malformed package (bad nkey/JWT, missing required field, half-specified SYS account, non-object JSON) **fails fast as a usage error BEFORE any derivation or mutation** — unvalidated material never reaches the operator-mode conversion seam. **Dry-run stays a pure read.**

## Tests (+26)

- **Parser (17):** minimal/full happy path, forward-compat (unknown fields ignored), projection (`leafPackageToOperatorMode` drops `credsPath`/`endpoint`), and fail-fast on every malformed shape.
- **Derive (6):** package fields flow into the conversion; `credsPath` flows; SYS carried; **flags override package**; **package overrides config**; none → undefined.
- **CLI (3):** malformed package → exit 2, **no write**; missing file → exit 2; **dry-run with a valid package writes nothing** (pure read).

All fixtures are obvious fake `eyJ…` / `A…` material — **zero seeds, zero real keys**.

## Gates

- `tsc --noEmit` clean
- `eslint --quiet src/` clean
- `bun test src/` — **6886 pass / 0 fail / 2 skip**
- `check-carveouts.sh` — PASS

## Stacking

**Stacked on O-3 (#1058)** — base is `feat/o3-join-autoconvert`, NOT `main`. O-4b consumes O-3's `OperatorModeLeafPackage` type + the renderer/seam + the atomic-write fix. Merge O-3 first.

Closes #1063
Refs #1050, #1054, #1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)