### PR TITLE
feat(mc): network graph — per-stack color-coding + highlight-subtree on hub select (#1068)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter-transport.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter-transport.test.ts
@@ -86,10 +86,13 @@ function connectRow(principal: string, stack: string, rtt: number): TransportRos
 }
 
 describe("NetworkGraphEdge — base shape unchanged without overlay (U2.3)", () => {
-  it("buildNetworkGraph emits edges with NO data field (pre-U2.3 byte-shape)", () => {
+  it("buildNetworkGraph emits edges with NO transport field (pre-U2.3 byte-shape)", () => {
     const g = buildNetworkGraph([tile({ agent_id: "luna" })]);
     expect(g.edges.length).toBe(1);
-    expect(g.edges[0]!.data).toBeUndefined();
+    // #1068 — the edge carries `data.stackColor` (the per-stack hue) at build
+    // time, but NO `transport` payload without the overlay.
+    expect(g.edges[0]!.data?.transport).toBeUndefined();
+    expect(typeof g.edges[0]!.data?.stackColor).toBe("string");
   });
 });
 
@@ -124,7 +127,10 @@ describe("applyTransportOverlay — additive widening (U2.3)", () => {
     expect((hub.data as StackHubNodeData).transportVerdict).toBeUndefined();
     const agent = g.nodes.find((n) => n.id === "andreas/research/luna")!;
     expect((agent.data as AgentNodeData).transportLeaf).toBeUndefined();
-    expect(g.edges.find((e) => e.target === "andreas/research/luna")!.data).toBeUndefined();
+    // #1068 — the edge keeps its per-stack color but gains NO transport payload.
+    expect(
+      g.edges.find((e) => e.target === "andreas/research/luna")!.data?.transport,
+    ).toBeUndefined();
   });
 
   it("keys a FOREIGN peer's leaf on its ORIGIN stack (not the local hub)", () => {
@@ -157,6 +163,7 @@ describe("applyTransportOverlay — additive widening (U2.3)", () => {
     const g = applyTransportOverlay(base, buildTransportOverlay([]));
     const hub = g.nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
     expect((hub.data as StackHubNodeData).transportVerdict).toBeUndefined();
-    expect(g.edges[0]!.data).toBeUndefined();
+    // #1068 — color survives; no transport payload added by an empty overlay.
+    expect(g.edges[0]!.data?.transport).toBeUndefined();
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   buildNetworkGraph,
+  collectLegendStacks,
   deriveServingPrincipal,
   STACK_HUB_NODE_ID,
   FOREIGN_HUB_ID_PREFIX,
@@ -17,6 +18,7 @@ import {
   type StackHubNodeData,
 } from "../lib/network-graph-adapter";
 import { classifyOrigin } from "../lib/agents-display";
+import { LOCAL_STACK_COLOR } from "../lib/stack-color";
 import type { AgentPresenceTile } from "../hooks/use-agents";
 
 function tile(
@@ -95,6 +97,10 @@ describe("buildNetworkGraph (G-1114.D.2)", () => {
     expect(data.principal).toBe("andreas");
     expect(data.stack).toBe("research");
     expect(data.agentCount).toBe(1);
+    // #1068 — the local hub carries the reserved signature color, and its edge
+    // strokes in the same hue.
+    expect(data.stackColor).toBe(LOCAL_STACK_COLOR);
+    expect(g.edges[0]!.data?.stackColor).toBe(LOCAL_STACK_COLOR);
   });
 
   it("emits one agent node + one hub→agent edge per agent", () => {
@@ -154,7 +160,9 @@ describe("buildNetworkGraph (G-1114.D.2)", () => {
     expect(d.offlineReason).toBeNull();
     expect(d.lastHeartbeatAt).toBe(beat);
     // No session-interior fields leak onto the node (ADR-0007). The data shape
-    // is a fixed allowlist — assert the key set is exactly the presence fields.
+    // is a fixed allowlist — assert the key set is exactly the presence fields
+    // (+ #1068 `stackColor`, a deterministic presentation field derived from the
+    // origin, NOT a session interior).
     expect(Object.keys(d).sort()).toEqual(
       [
         "agentId",
@@ -166,9 +174,13 @@ describe("buildNetworkGraph (G-1114.D.2)", () => {
         "offlineReason",
         "origin",
         "servingPrincipal",
+        "stackColor",
         "state",
       ].sort(),
     );
+    // #1068 — the agent carries its stack's deterministic color (a member of the
+    // palette), shared with its hub. Local agent → the reserved signature hue.
+    expect(d.stackColor).toBe(LOCAL_STACK_COLOR);
     // The local agent carries the bare "local" origin.
     expect(d.origin).toBe("local");
   });
@@ -357,6 +369,18 @@ describe("buildNetworkGraph — local-sibling vs federated classification (#1008
     expect(classifyOrigin(foreignHub.origin, foreignHub.servingPrincipal)).toBe(
       "foreign",
     );
+
+    // #1068 — each stack gets a DISTINCT color: self → signature, the two peers
+    // → their own (different) hues, and each hub's agents + edge share the hub's.
+    expect(selfHub.stackColor).toBe(LOCAL_STACK_COLOR);
+    const hubColors = [selfHub, siblingHub, foreignHub].map((h) => h.stackColor);
+    expect(new Set(hubColors).size).toBe(3);
+    // The sibling agent + its edge carry the SIBLING hub's color, not the local's.
+    const siblingAgent = g.nodes.find((n) => n.id === "andreas/work/echo")!
+      .data as AgentNodeData;
+    expect(siblingAgent.stackColor).toBe(siblingHub.stackColor);
+    const siblingEdge = g.edges.find((e) => e.target === "andreas/work/echo")!;
+    expect(siblingEdge.data?.stackColor).toBe(siblingHub.stackColor);
   });
 
   it("still gives each distinct stack its OWN hub (sibling gets its own, not the local one)", () => {
@@ -505,5 +529,39 @@ describe("buildNetworkGraph — agent node ids namespaced by stack (#1065)", () 
     expect(agentNode.id).toBe("andreas/research/luna");
     expect(g.edges).toHaveLength(1);
     expect(g.edges[0]!.target).toBe("andreas/research/luna");
+  });
+});
+
+describe("collectLegendStacks (#1068)", () => {
+  it("returns no rows for an empty graph", () => {
+    expect(collectLegendStacks({ nodes: [], edges: [] })).toEqual([]);
+  });
+
+  it("one row per stack-hub, local first, with label + matching hub color", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }), // local self
+      siblingTile({ agent_id: "echo", stack: "work" }), // andreas/work
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+    ]);
+    const rows = collectLegendStacks(g);
+    expect(rows).toHaveLength(3);
+
+    // Local first; its label is "local" and its color the reserved signature.
+    expect(rows[0]!.id).toBe(STACK_HUB_NODE_ID);
+    expect(rows[0]!.label).toBe("local");
+    expect(rows[0]!.color).toBe(LOCAL_STACK_COLOR);
+
+    // Peers carry their `{principal}/{stack}` label + their hub's color.
+    const labels = rows.map((r) => r.label);
+    expect(labels).toContain("andreas/work");
+    expect(labels).toContain("jc/research");
+
+    // Each legend color equals its hub node's stackColor (one source of truth).
+    for (const row of rows) {
+      const hub = g.nodes.find((n) => n.id === row.id)!.data as StackHubNodeData;
+      expect(row.color).toBe(hub.stackColor);
+    }
+    // The three colors are distinct.
+    expect(new Set(rows.map((r) => r.color)).size).toBe(3);
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes-transport.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes-transport.test.tsx
@@ -22,6 +22,7 @@ function hub(over: Partial<StackHubNodeData> = {}): StackHubNodeData {
     principal: "andreas",
     stack: "research",
     agentCount: 2,
+    stackColor: "#5b8cd4",
     ...over,
   };
 }
@@ -38,6 +39,7 @@ function agent(over: Partial<AgentNodeData> = {}): AgentNodeData {
     state: "online",
     offlineReason: null,
     lastHeartbeatAt: null,
+    stackColor: "#5b8cd4",
     ...over,
   };
 }

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
@@ -37,6 +37,7 @@ function agentData(over: Partial<AgentNodeData> = {}): AgentNodeData {
     state: "online",
     offlineReason: null,
     lastHeartbeatAt: null,
+    stackColor: "#5b8cd4",
     ...over,
   };
 }
@@ -139,6 +140,7 @@ describe("StackHubCard (G-1114.D.1)", () => {
       principal: null,
       stack: null,
       agentCount: 0,
+      stackColor: "#5b8cd4",
       ...over,
     };
     return renderToStaticMarkup(createElement(StackHubCard, { data }));
@@ -334,5 +336,132 @@ describe("AgentNodeCard — F.2 hover highlight", () => {
     );
     const lit = (html.match(/network-node-cap-highlighted/g) ?? []).length;
     expect(lit).toBe(1);
+  });
+});
+
+describe("#1068 — per-stack color", () => {
+  it("the agent card carries its stack color as --stack-color + data attr", () => {
+    const html = renderAgent(agentData({ stackColor: "#2e8b7a" }));
+    expect(html).toContain("--stack-color:#2e8b7a");
+    expect(html).toContain('data-stack-color="#2e8b7a"');
+  });
+
+  it("the hub card carries its stack color as --stack-color + data attr", () => {
+    const html = renderToStaticMarkup(
+      createElement(StackHubCard, {
+        data: {
+          kind: "stack-hub",
+          origin: "local",
+          servingPrincipal: "andreas",
+          principal: "andreas",
+          stack: "research",
+          agentCount: 1,
+          stackColor: "#d4915b",
+        } satisfies StackHubNodeData,
+      }),
+    );
+    expect(html).toContain("--stack-color:#d4915b");
+    expect(html).toContain('data-stack-color="#d4915b"');
+  });
+
+  it("the legend renders a swatch + label per stack passed in", () => {
+    const html = renderToStaticMarkup(
+      createElement(NetworkLegend, {
+        stacks: [
+          { id: "__stack__", label: "local", color: "#5b8cd4" },
+          { id: "__stack__:jc/research", label: "jc/research", color: "#2e8b7a" },
+        ],
+      }),
+    );
+    expect(html).toContain("network-legend-swatch-stack");
+    expect(html).toContain("local");
+    expect(html).toContain("jc/research");
+    expect(html).toContain("background:#5b8cd4");
+    expect(html).toContain("background:#2e8b7a");
+  });
+});
+
+describe("#1068 — hub-subtree selection (a11y + emphasis/dim)", () => {
+  it("a non-interactive hub (no toggle handler) carries no role/aria-pressed", () => {
+    const html = renderToStaticMarkup(
+      createElement(StackHubCard, {
+        data: {
+          kind: "stack-hub",
+          origin: "local",
+          servingPrincipal: "andreas",
+          principal: "andreas",
+          stack: "research",
+          agentCount: 1,
+          stackColor: "#5b8cd4",
+        } satisfies StackHubNodeData,
+      }),
+    );
+    expect(html).not.toContain('role="button"');
+    expect(html).not.toContain("aria-pressed");
+  });
+
+  it("an interactive selected hub stamps role=button, aria-pressed=true, data-selected", () => {
+    const html = renderToStaticMarkup(
+      createElement(StackHubCard, {
+        data: {
+          kind: "stack-hub",
+          origin: "local",
+          servingPrincipal: "andreas",
+          principal: "andreas",
+          stack: "research",
+          agentCount: 1,
+          stackColor: "#5b8cd4",
+        } satisfies StackHubNodeData,
+        selected: true,
+        onToggleSelect: () => {},
+      }),
+    );
+    expect(html).toContain('role="button"');
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain('data-selected="true"');
+    expect(html).toContain("network-node-selected");
+  });
+
+  it("a dimmed (non-selected, selection active) hub carries data-dimmed + the dim class", () => {
+    const html = renderToStaticMarkup(
+      createElement(StackHubCard, {
+        data: {
+          kind: "stack-hub",
+          origin: "local",
+          servingPrincipal: "andreas",
+          principal: "andreas",
+          stack: "research",
+          agentCount: 1,
+          stackColor: "#5b8cd4",
+        } satisfies StackHubNodeData,
+        dimmed: true,
+        onToggleSelect: () => {},
+      }),
+    );
+    expect(html).toContain('data-dimmed="true"');
+    expect(html).toContain("network-node-dimmed");
+    expect(html).toContain('aria-pressed="false"');
+  });
+
+  it("an emphasized agent (in the selected subtree) carries data-selected + the emphasis class", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentNodeCard, {
+        data: agentData(),
+        subtreeEmphasized: true,
+      }),
+    );
+    expect(html).toContain('data-selected="true"');
+    expect(html).toContain("network-node-selected");
+  });
+
+  it("a dimmed agent (outside the selected subtree) carries data-dimmed + the dim class", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentNodeCard, {
+        data: agentData(),
+        dimmed: true,
+      }),
+    );
+    expect(html).toContain('data-dimmed="true"');
+    expect(html).toContain("network-node-dimmed");
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-subtree-highlight.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-subtree-highlight.test.ts
@@ -1,0 +1,166 @@
+/**
+ * #1068 — highlight-subtree-on-hub-select tests.
+ *
+ * `subtreeHighlightSet(graph, hubId)` must return EXACTLY the hub + its agents +
+ * its hub→agent edges (and nothing from sibling/foreign stacks); the toggle/
+ * clear logic must select a fresh hub, deselect on a re-click of the same hub,
+ * and clear on a `null` (empty-canvas) click; a foreign hub must light only its
+ * OWN subtree.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  buildNetworkGraph,
+  STACK_HUB_NODE_ID,
+  FOREIGN_HUB_ID_PREFIX,
+} from "../lib/network-graph-adapter";
+import {
+  subtreeHighlightSet,
+  toggleHubSelection,
+  isInSubtreeHighlight,
+  hasSubtreeSelection,
+  EMPTY_SUBTREE_SELECTION,
+} from "../lib/network-subtree-highlight";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+
+function base(agent_id: string): Omit<AgentPresenceTile, "key" | "principal" | "stack" | "origin"> {
+  return {
+    agent_id,
+    assistant_name: null,
+    nkey_public_key: `N${agent_id.toUpperCase()}`,
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 1000,
+  };
+}
+
+function tile(over: { agent_id: string }): AgentPresenceTile {
+  return {
+    key: `andreas/research/${over.agent_id}`,
+    principal: "andreas",
+    stack: "research",
+    origin: "local",
+    ...base(over.agent_id),
+  };
+}
+
+function siblingTile(agent_id: string, stack: string): AgentPresenceTile {
+  return {
+    key: `andreas/${stack}/${agent_id}`,
+    principal: "andreas",
+    stack,
+    origin: { principal: "andreas", stack },
+    ...base(agent_id),
+  };
+}
+
+function foreignTile(agent_id: string, principal: string, stack: string): AgentPresenceTile {
+  return {
+    key: `${principal}/${stack}/${agent_id}`,
+    principal,
+    stack,
+    origin: { principal, stack },
+    ...base(agent_id),
+  };
+}
+
+describe("subtreeHighlightSet (#1068)", () => {
+  it("returns exactly the hub + its agents + its edges (local hub)", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      tile({ agent_id: "echo" }),
+    ]);
+    const set = subtreeHighlightSet(g, STACK_HUB_NODE_ID);
+    // hub + 2 agent ids + 2 edge ids = 5
+    expect(set.has(STACK_HUB_NODE_ID)).toBe(true);
+    expect(set.has("andreas/research/luna")).toBe(true);
+    expect(set.has("andreas/research/echo")).toBe(true);
+    expect(set.has("hub-andreas/research/luna")).toBe(true);
+    expect(set.has("hub-andreas/research/echo")).toBe(true);
+    expect(set.size).toBe(5);
+  });
+
+  it("a foreign hub lights ONLY its own subtree, not other stacks'", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }), // local
+      siblingTile("echo", "work"), // andreas/work
+      foreignTile("sage", "jc", "research"), // jc/research
+    ]);
+    const foreignHubId = `${FOREIGN_HUB_ID_PREFIX}jc/research`;
+    const set = subtreeHighlightSet(g, foreignHubId);
+
+    // The foreign hub + its one agent + its one edge.
+    expect(set.has(foreignHubId)).toBe(true);
+    expect(set.has("jc/research/sage")).toBe(true);
+    expect(set.has("hub-jc/research/sage")).toBe(true);
+    expect(set.size).toBe(3);
+
+    // NOTHING from the local or sibling stacks leaks in.
+    expect(set.has(STACK_HUB_NODE_ID)).toBe(false);
+    expect(set.has("andreas/research/luna")).toBe(false);
+    expect(set.has("andreas/work/echo")).toBe(false);
+    expect(set.has(`${FOREIGN_HUB_ID_PREFIX}andreas/work`)).toBe(false);
+  });
+
+  it("a hub with no agents lights only itself", () => {
+    // No graph has a childless hub in practice (the adapter only synthesises a
+    // hub when an agent groups under it), so assert the helper's defensiveness
+    // directly against a hand-built single-node graph.
+    const set = subtreeHighlightSet(
+      { nodes: [{ id: "h", type: "stackHub", position: { x: 0, y: 0 }, data: {} as never }], edges: [] },
+      "h",
+    );
+    expect([...set]).toEqual(["h"]);
+  });
+
+  it("an unknown / non-existent id lights nothing", () => {
+    const g = buildNetworkGraph([tile({ agent_id: "luna" })]);
+    expect(subtreeHighlightSet(g, "no-such-hub").size).toBe(0);
+  });
+});
+
+describe("toggleHubSelection (#1068)", () => {
+  const g = buildNetworkGraph([
+    tile({ agent_id: "luna" }),
+    foreignTile("sage", "jc", "research"),
+  ]);
+  const foreignHubId = `${FOREIGN_HUB_ID_PREFIX}jc/research`;
+
+  it("selects a fresh hub + computes its highlight set", () => {
+    const next = toggleHubSelection(EMPTY_SUBTREE_SELECTION, STACK_HUB_NODE_ID, g);
+    expect(next.selectedHubId).toBe(STACK_HUB_NODE_ID);
+    expect(hasSubtreeSelection(next)).toBe(true);
+    expect(isInSubtreeHighlight(next, "andreas/research/luna")).toBe(true);
+    expect(isInSubtreeHighlight(next, "jc/research/sage")).toBe(false);
+  });
+
+  it("re-clicking the SAME hub clears the selection", () => {
+    const selected = toggleHubSelection(EMPTY_SUBTREE_SELECTION, STACK_HUB_NODE_ID, g);
+    const cleared = toggleHubSelection(selected, STACK_HUB_NODE_ID, g);
+    expect(cleared.selectedHubId).toBeNull();
+    expect(cleared.highlightIds.size).toBe(0);
+    expect(hasSubtreeSelection(cleared)).toBe(false);
+  });
+
+  it("clicking a DIFFERENT hub switches the selection", () => {
+    const first = toggleHubSelection(EMPTY_SUBTREE_SELECTION, STACK_HUB_NODE_ID, g);
+    const second = toggleHubSelection(first, foreignHubId, g);
+    expect(second.selectedHubId).toBe(foreignHubId);
+    expect(isInSubtreeHighlight(second, "jc/research/sage")).toBe(true);
+    expect(isInSubtreeHighlight(second, "andreas/research/luna")).toBe(false);
+  });
+
+  it("a null click (empty canvas) clears the selection", () => {
+    const selected = toggleHubSelection(EMPTY_SUBTREE_SELECTION, STACK_HUB_NODE_ID, g);
+    const cleared = toggleHubSelection(selected, null, g);
+    expect(cleared).toEqual(EMPTY_SUBTREE_SELECTION);
+  });
+
+  it("the resting selection highlights nothing + reports no active selection", () => {
+    expect(hasSubtreeSelection(EMPTY_SUBTREE_SELECTION)).toBe(false);
+    expect(isInSubtreeHighlight(EMPTY_SUBTREE_SELECTION, STACK_HUB_NODE_ID)).toBe(false);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/stack-color.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/stack-color.test.ts
@@ -55,7 +55,7 @@ describe("stackColor (#1068)", () => {
   });
 
   it("gives distinct colors to the distinct stacks present today", () => {
-    // The 4 local stacks the operator runs (meta-factory is the local self) +
+    // The 4 local stacks the principal runs (meta-factory is the local self) +
     // a couple of federated peers — assert no two NON-self stacks collide.
     const stacks: AgentOrigin[] = [
       peer("andreas", "work"),

--- a/src/surface/mc/dashboard-v2/__tests__/stack-color.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/stack-color.test.ts
@@ -1,0 +1,94 @@
+/**
+ * #1068 — per-stack color-coding tests.
+ *
+ * `stackColor(origin)` must be:
+ *   - deterministic + stable: the SAME origin always yields the SAME color;
+ *   - distinct: different stacks generally yield different colors (no collision
+ *     across the small set used in the snapshot);
+ *   - local-distinguished: `"local"` always maps to the reserved signature hue,
+ *     and a foreign stack never steals that signature color;
+ *   - palette-bounded: every output is a member of the fixed palette.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  stackColor,
+  originScopeKey,
+  STACK_PALETTE,
+  LOCAL_STACK_COLOR,
+} from "../lib/stack-color";
+import type { AgentOrigin } from "../hooks/use-agents";
+
+const peer = (principal: string, stack: string): AgentOrigin => ({
+  principal,
+  stack,
+});
+
+describe("stackColor (#1068)", () => {
+  it("maps the local stack to the reserved signature color", () => {
+    expect(stackColor("local")).toBe(LOCAL_STACK_COLOR);
+    expect(LOCAL_STACK_COLOR).toBe(STACK_PALETTE[0]!);
+  });
+
+  it("is deterministic + stable: the same origin always yields the same color", () => {
+    const o = peer("jc", "research");
+    const first = stackColor(o);
+    // Re-resolve from a fresh object with the same scope — color is content-only.
+    const second = stackColor(peer("jc", "research"));
+    expect(first).toBe(second);
+    // And stable across many calls.
+    for (let i = 0; i < 50; i++) expect(stackColor(o)).toBe(first);
+  });
+
+  it("always returns a member of the fixed palette", () => {
+    const origins: AgentOrigin[] = [
+      "local",
+      peer("andreas", "work"),
+      peer("andreas", "halden"),
+      peer("andreas", "community"),
+      peer("jc", "research"),
+      peer("nova", "ops"),
+    ];
+    for (const o of origins) {
+      expect(STACK_PALETTE).toContain(stackColor(o));
+    }
+  });
+
+  it("gives distinct colors to the distinct stacks present today", () => {
+    // The 4 local stacks the operator runs (meta-factory is the local self) +
+    // a couple of federated peers — assert no two NON-self stacks collide.
+    const stacks: AgentOrigin[] = [
+      peer("andreas", "work"),
+      peer("andreas", "halden"),
+      peer("andreas", "community"),
+      peer("jc", "research"),
+    ];
+    const colors = stacks.map(stackColor);
+    expect(new Set(colors).size).toBe(stacks.length);
+  });
+
+  it("never lets a foreign stack steal the local signature color", () => {
+    // Sweep a wide range of peer scopes; none may land on the reserved palette[0].
+    for (let p = 0; p < 40; p++) {
+      for (let s = 0; s < 40; s++) {
+        const c = stackColor(peer(`principal${p}`, `stack${s}`));
+        expect(c).not.toBe(LOCAL_STACK_COLOR);
+      }
+    }
+  });
+
+  it("different stacks of the SAME principal get their own colors", () => {
+    const work = stackColor(peer("andreas", "work"));
+    const halden = stackColor(peer("andreas", "halden"));
+    expect(work).not.toBe(halden);
+  });
+
+  it("originScopeKey distinguishes local from peers and encodes principal/stack", () => {
+    expect(originScopeKey("local")).toBe("local");
+    expect(originScopeKey(peer("jc", "research"))).toBe("jc/research");
+    // Two different stacks → different keys (so different color buckets).
+    expect(originScopeKey(peer("andreas", "work"))).not.toBe(
+      originScopeKey(peer("andreas", "halden")),
+    );
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/network-canvas.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-canvas.tsx
@@ -32,6 +32,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import ELK from "elkjs/lib/elk.bundled.js";
 import {
+  collectLegendStacks,
   type NetworkGraph,
   type NetworkGraphNode,
 } from "../lib/network-graph-adapter";
@@ -45,6 +46,7 @@ import NetworkElkEdge from "./network-elk-edge";
 import { NetworkLegend } from "./network-legend";
 import {
   NetworkHoverContext,
+  useNetworkHover,
   type NetworkHoverContextValue,
 } from "../lib/network-hover-context";
 
@@ -105,6 +107,14 @@ function FlowCanvas({
   // we cast at this single boundary rather than polluting the adapter's data type.
   const rfNodes = nodes as unknown as RfNode[];
 
+  // #1068 — the per-stack legend rows (one swatch per stack-hub), derived from
+  // the positioned nodes. Hub emission order (local first, then peers) is
+  // preserved, so the legend reads in layout order.
+  const legendStacks = useMemo(
+    () => collectLegendStacks({ nodes, edges: [] }),
+    [nodes],
+  );
+
   // #1008 — render the ORIGIN-GROUPED edges from the adapter (each agent wired to
   // ITS OWN stack's hub — local, sibling, or foreign), typed `elk` so the custom
   // edge draws ELK's orthogonal route from `data.elkPoints`. This replaces the
@@ -119,29 +129,45 @@ function FlowCanvas({
         target: e.target,
         type: "elk",
         // The layout payload (elkPoints + face geometry) drives the custom edge.
-        data: e.layout as unknown as Record<string, unknown>,
+        // #1068 — fold in the per-stack `stackColor` (from the adapter's edge
+        // `data`) so the edge can stroke in its hub's hue.
+        data: {
+          ...(e.layout as unknown as Record<string, unknown>),
+          stackColor: e.data?.stackColor,
+        } as Record<string, unknown>,
       })),
     [laidOutEdges],
   );
 
-  // Node click → lift the agent key up (D.4). The pure
-  // `agentKeyFromClickedNode` resolves agent-node→key / hub→null, so this
-  // handler is a thin delegation (the click→lift logic itself is unit-tested
-  // off the helper, since xyflow can't mount in `bun test`).
+  // #1068 — the sticky hub-subtree selection lives in the hover context (set by
+  // the view, broadcast through the provider). The canvas reads the toggle here
+  // so a hub click flips the selection.
+  const { toggleHubSelection } = useNetworkHover();
+
+  // Node click →
+  //   - AGENT node → lift its key up (D.4): open the detail panel.
+  //   - STACK-HUB node → toggle its subtree selection (#1068) and DESELECT any
+  //     open agent panel (the hub isn't an agent). `agentKeyFromClickedNode`
+  //     already resolves agent→key / hub→null, so we branch on the node type.
   const onNodeClick = useCallback(
     (_evt: unknown, node: RfNode) => {
-      if (!onSelectAgent) return;
-      onSelectAgent(
-        agentKeyFromClickedNode(node as unknown as NetworkGraphNode),
-      );
+      const n = node as unknown as NetworkGraphNode;
+      if (n.type === "stackHub") {
+        toggleHubSelection(n.id);
+        onSelectAgent?.(null);
+        return;
+      }
+      onSelectAgent?.(agentKeyFromClickedNode(n));
     },
-    [onSelectAgent],
+    [onSelectAgent, toggleHubSelection],
   );
 
-  // Click on empty canvas → deselect (close the panel).
+  // Click on empty canvas → deselect EVERYTHING: close the panel AND clear the
+  // hub-subtree selection (#1068).
   const onPaneClick = useCallback(() => {
     onSelectAgent?.(null);
-  }, [onSelectAgent]);
+    toggleHubSelection(null);
+  }, [onSelectAgent, toggleHubSelection]);
 
   return (
     <ReactFlow
@@ -160,7 +186,7 @@ function FlowCanvas({
     >
       <Background gap={20} size={1} />
       <Controls position="bottom-left" showInteractive={false} />
-      <NetworkLegend />
+      <NetworkLegend stacks={legendStacks} />
     </ReactFlow>
   );
 }

--- a/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
@@ -14,13 +14,18 @@
  * didn't route them) fall back to a straight line.
  */
 
-import { useMemo } from "react";
+import { useMemo, type CSSProperties } from "react";
 import {
   BaseEdge,
   getSmoothStepPath,
   Position,
   type EdgeProps,
 } from "@xyflow/react";
+import { useNetworkHover } from "../lib/network-hover-context";
+import {
+  hasSubtreeSelection,
+  isInSubtreeHighlight,
+} from "../lib/network-subtree-highlight";
 
 interface Point {
   x: number;
@@ -124,6 +129,8 @@ export default function NetworkElkEdge(props: EdgeProps) {
 
   const edgeData = data as Record<string, unknown> | undefined;
   const elkPoints = edgeData?.["elkPoints"] as Point[] | undefined;
+  // #1068 — the hub→agent connector strokes in its stack's deterministic color.
+  const stackColor = edgeData?.["stackColor"] as string | undefined;
   const layoutSourceX = edgeData?.["layoutSourceX"] as number | undefined;
   const layoutSourceY = edgeData?.["layoutSourceY"] as number | undefined;
   const layoutTargetX = edgeData?.["layoutTargetX"] as number | undefined;
@@ -180,5 +187,32 @@ export default function NetworkElkEdge(props: EdgeProps) {
     targetBottomY,
   ]);
 
-  return <BaseEdge id={id} path={path} style={style} markerEnd={markerEnd} />;
+  // #1068 — the stack's color is the edge stroke (additive: any incoming `style`
+  // still applies; we only set the stroke when a color is present, so an
+  // un-colored edge is unchanged).
+  const baseStyle: Record<string, unknown> =
+    stackColor !== undefined ? { ...style, stroke: stackColor } : { ...style };
+
+  // #1068 — subtree selection: a hub→agent edge in the SELECTED subtree is
+  // EMPHASIZED (thicker, full opacity); when a subtree is selected and this edge
+  // is OUTSIDE it, the edge DIMS (opacity — not hue). Resting (no selection):
+  // unchanged. Read off the shared hover context like the node cards do.
+  const { selection } = useNetworkHover();
+  if (hasSubtreeSelection(selection)) {
+    if (isInSubtreeHighlight(selection, id)) {
+      baseStyle["strokeWidth"] = 2.5;
+      baseStyle["opacity"] = 1;
+    } else {
+      baseStyle["opacity"] = 0.18;
+    }
+  }
+
+  return (
+    <BaseEdge
+      id={id}
+      path={path}
+      style={baseStyle as CSSProperties}
+      markerEnd={markerEnd}
+    />
+  );
 }

--- a/src/surface/mc/dashboard-v2/components/network-legend.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-legend.tsx
@@ -5,9 +5,30 @@
  * offline (graceful), and the distinct TTL-lapse ("no heartbeat" — the agent
  * went silent, possibly crashed) treatment. Pure presentational — no xyflow
  * context — so it renders standalone in tests and inside the canvas alike.
+ *
+ * #1068 — additionally lists the per-stack COLORS present in the snapshot: one
+ * swatch + `{principal}/{stack}` label per stack, using the same deterministic
+ * `stackColor` the hubs/agents/edges carry. So the principal can map a color back
+ * to a stack at a glance. The stack rows are passed in (derived from the graph)
+ * so the legend stays a pure presentational component.
  */
 
-export function NetworkLegend() {
+/** One stack entry in the legend: its color swatch + its `{principal}/{stack}` label. */
+export interface NetworkLegendStack {
+  /** Stable id (the hub node id) — used as the React key. */
+  id: string;
+  /** Display label, e.g. `andreas/work` or `local`. */
+  label: string;
+  /** The stack's deterministic color (from `stackColor`). */
+  color: string;
+}
+
+export interface NetworkLegendProps {
+  /** #1068 — the stacks present in the snapshot (one swatch each). Empty → no stack rows. */
+  stacks?: readonly NetworkLegendStack[];
+}
+
+export function NetworkLegend({ stacks = [] }: NetworkLegendProps) {
   return (
     <div className="network-legend" aria-label="Legend">
       <span className="network-legend-item">
@@ -25,6 +46,20 @@ export function NetworkLegend() {
         />
         no heartbeat
       </span>
+      {stacks.length > 0 && (
+        <span className="network-legend-stacks" aria-label="Stacks">
+          {stacks.map((s) => (
+            <span className="network-legend-item" key={s.id}>
+              <span
+                className="network-legend-swatch network-legend-swatch-stack"
+                style={{ background: s.color }}
+                aria-hidden="true"
+              />
+              {s.label}
+            </span>
+          ))}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -22,6 +22,7 @@
  * state, reason, heartbeat) — NEVER session interiors.
  */
 
+import type { CSSProperties } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import {
   formatRelativeTime,
@@ -38,16 +39,42 @@ import type {
 } from "../lib/network-graph-adapter";
 import { isAgentHighlighted } from "../lib/capability-highlight";
 import { useNetworkHover } from "../lib/network-hover-context";
+import {
+  hasSubtreeSelection,
+  isInSubtreeHighlight,
+} from "../lib/network-subtree-highlight";
 import { verdictBadge, formatRtt } from "../lib/network-transport-overlay";
 
 // --- Stack hub -------------------------------------------------------------
 
 export interface StackHubCardProps {
   data: StackHubNodeData;
+  /**
+   * #1068 — true when THIS hub is the selected one (its subtree is highlighted).
+   * Drives `aria-pressed`/`data-selected` + the emphasis outline. Defaults false.
+   */
+  selected?: boolean;
+  /**
+   * #1068 — true when SOME OTHER hub is selected, so this hub is outside the
+   * active subtree and should DIM. Conveyed by opacity, not hue (a11y). Defaults
+   * false (no selection → no dimming).
+   */
+  dimmed?: boolean;
+  /**
+   * #1068 — toggle this hub's selection on click / Enter / Space. Wired by the
+   * node wrapper to the hover context; omitted in isolation tests (the card then
+   * renders without the interactive affordance).
+   */
+  onToggleSelect?: () => void;
 }
 
 /** Pure presentational stack-hub card (no `Handle`; unit-testable). */
-export function StackHubCard({ data }: StackHubCardProps) {
+export function StackHubCard({
+  data,
+  selected = false,
+  dimmed = false,
+  onToggleSelect,
+}: StackHubCardProps) {
   const label =
     data.principal && data.stack
       ? `${data.principal}/${data.stack}`
@@ -63,17 +90,52 @@ export function StackHubCard({ data }: StackHubCardProps) {
   // transport overlay is on AND signal observed it). Taken verbatim from signal.
   const badge =
     data.transportVerdict !== undefined ? verdictBadge(data.transportVerdict) : null;
+  // #1068 — the hub is a toggle button for its subtree selection. When
+  // interactive (a toggle handler is wired), it's focusable + Enter/Space
+  // activates it; the selected/dimmed state is on `aria-pressed` + `data-*` +
+  // opacity/outline (never hue alone — a11y).
+  const interactive = onToggleSelect !== undefined;
   return (
     <div
       className={
         "network-node network-node-hub" +
         (foreign ? " network-node-hub-foreign" : " network-node-hub-local") +
-        ` network-node-hub-${category}`
+        ` network-node-hub-${category}` +
+        (selected ? " network-node-selected" : "") +
+        (dimmed ? " network-node-dimmed" : "")
       }
+      // #1068 — the stack's deterministic color, exposed as a CSS custom property
+      // the hub styling references for its accent/border. ADDITIVE: the shape
+      // treatments (solid/dashed border, eyebrow) come from the classes above.
+      style={{ "--stack-color": data.stackColor } as CSSProperties}
       data-node-kind="stack-hub"
+      data-stack-color={data.stackColor}
       data-hub-origin={foreign ? "foreign" : "local"}
       data-hub-category={category}
+      data-selected={selected ? "true" : undefined}
+      data-dimmed={dimmed ? "true" : undefined}
       data-transport-verdict={data.transportVerdict ?? undefined}
+      role={interactive ? "button" : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      aria-pressed={interactive ? selected : undefined}
+      aria-label={
+        interactive
+          ? `${label} stack — ${selected ? "selected; activate to clear" : "activate to highlight its agents"}`
+          : undefined
+      }
+      onClick={onToggleSelect}
+      onKeyDown={
+        interactive
+          ? (e) => {
+              // Enter/Space toggles the subtree selection (keyboard a11y). Stop
+              // Space from scrolling the canvas.
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onToggleSelect();
+              }
+            }
+          : undefined
+      }
     >
       <span className="network-hub-eyebrow dim">
         {foreign ? "federated stack" : "stack"}
@@ -96,11 +158,23 @@ export function StackHubCard({ data }: StackHubCardProps) {
   );
 }
 
-/** xyflow node wrapper for the stack hub — adds the source handle. */
-export function StackHubNode({ data }: NodeProps) {
+/** xyflow node wrapper for the stack hub — adds the source handle + #1068 the
+ * subtree-selection wiring (read off the shared hover context, same as the agent
+ * wrapper reads the capability highlight). */
+export function StackHubNode({ id, data }: NodeProps) {
+  const { selection, toggleHubSelection } = useNetworkHover();
+  const selected = selection.selectedHubId === id;
+  // Dim a NON-selected hub only when SOME hub is selected (a selection is active
+  // and this hub isn't in its subtree — a hub is never inside another hub's).
+  const dimmed = hasSubtreeSelection(selection) && !selected;
   return (
     <>
-      <StackHubCard data={data as unknown as StackHubNodeData} />
+      <StackHubCard
+        data={data as unknown as StackHubNodeData}
+        selected={selected}
+        dimmed={dimmed}
+        onToggleSelect={() => toggleHubSelection(id)}
+      />
       <Handle
         type="source"
         position={Position.Bottom}
@@ -128,6 +202,17 @@ export interface AgentNodeCardProps {
   onHoverCapability?: (capability: string | null) => void;
   /** G-1114.F.2 — report an agent hover up (or `null` on leave). */
   onHoverAgent?: (agentKey: string | null) => void;
+  /**
+   * #1068 — true when this agent is in the SELECTED hub's subtree (emphasized).
+   * Distinct from the capability-hover `highlighted`; both end up emphasizing the
+   * card. Defaults false.
+   */
+  subtreeEmphasized?: boolean;
+  /**
+   * #1068 — true when a hub subtree is selected and this agent is OUTSIDE it, so
+   * it DIMS. Conveyed by opacity (a11y — not hue). Defaults false.
+   */
+  dimmed?: boolean;
 }
 
 /** Pure presentational agent card (no `Handle`; unit-testable). */
@@ -138,6 +223,8 @@ export function AgentNodeCard({
   highlightedCapabilities,
   onHoverCapability,
   onHoverAgent,
+  subtreeEmphasized = false,
+  dimmed = false,
 }: AgentNodeCardProps) {
   const offline = data.state === "offline";
   const ttlLapse = offline && isTtlLapse(data.offlineReason);
@@ -159,14 +246,23 @@ export function AgentNodeCard({
         `network-node network-node-agent network-node-${data.state}` +
         (ttlLapse ? " network-node-ttl-lapse" : "") +
         (foreign ? " network-node-foreign" : "") +
-        (highlighted ? " network-node-highlighted" : "")
+        (highlighted ? " network-node-highlighted" : "") +
+        (subtreeEmphasized ? " network-node-selected" : "") +
+        (dimmed ? " network-node-dimmed" : "")
       }
+      // #1068 — the agent shares its stack's color (same as its hub), exposed as
+      // `--stack-color` and applied as a left accent border, grouping the card
+      // with its hub. ADDITIVE over the foreign dashed-border treatment.
+      style={{ "--stack-color": data.stackColor } as CSSProperties}
       data-node-kind="agent"
       data-agent-id={data.agentId}
       data-state={data.state}
+      data-stack-color={data.stackColor}
       data-agent-origin={foreign ? "foreign" : "local"}
       data-agent-category={category}
       data-highlighted={highlighted ? "true" : undefined}
+      data-selected={subtreeEmphasized ? "true" : undefined}
+      data-dimmed={dimmed ? "true" : undefined}
       data-offline-reason={offline ? (data.offlineReason ?? "") : undefined}
       aria-label={
         `${name} — ${offline ? `offline (${reasonLabel})` : "online"}` +
@@ -286,7 +382,11 @@ export function AgentNodeCard({
  * highlight + hover callbacks onto the pure card. */
 export function AgentNode({ data }: NodeProps) {
   const agentData = data as unknown as AgentNodeData;
-  const { highlight, setHoverTarget } = useNetworkHover();
+  const { highlight, setHoverTarget, selection } = useNetworkHover();
+  // #1068 — subtree selection: this agent is EMPHASIZED when it's in the selected
+  // hub's subtree, DIMMED when a hub is selected and this agent is outside it.
+  const inSubtree = isInSubtreeHighlight(selection, agentData.key);
+  const subtreeActive = hasSubtreeSelection(selection);
   return (
     <>
       <Handle type="target" position={Position.Top} isConnectable={false} />
@@ -298,6 +398,8 @@ export function AgentNode({ data }: NodeProps) {
           // doesn't allocate per node.
           highlight.capabilities.size > 0 ? highlight.capabilities : undefined
         }
+        subtreeEmphasized={subtreeActive && inSubtree}
+        dimmed={subtreeActive && !inSubtree}
         onHoverCapability={(cap) =>
           setHoverTarget(cap === null ? null : { kind: "capability", capability: cap })
         }

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -53,6 +53,11 @@ import {
   computeHighlight,
   type HoverTarget,
 } from "../lib/capability-highlight";
+import {
+  EMPTY_SUBTREE_SELECTION,
+  toggleHubSelection as computeToggleHubSelection,
+  type SubtreeSelection,
+} from "../lib/network-subtree-highlight";
 import type { NetworkHoverContextValue } from "../lib/network-hover-context";
 import {
   DEFAULT_NETWORK_FILTER,
@@ -204,9 +209,44 @@ export function NetworkView({
     () => computeHighlight(hoverTarget, matchIndex),
     [hoverTarget, matchIndex],
   );
+
+  // #1068 — the STICKY hub-subtree selection. The view owns the graph, so it
+  // computes the next selection (pure `toggleHubSelection`) when the canvas
+  // reports a hub click. Recomputed against the LIVE graph so the highlight set
+  // tracks presence changes; if the selected hub vanishes (its stack dropped out
+  // of the snapshot) we clear the stale selection (the effect below).
+  const [selection, setSelection] = useState<SubtreeSelection>(
+    EMPTY_SUBTREE_SELECTION,
+  );
+  const onToggleHubSelection = useCallback(
+    (clickedHubId: string | null) =>
+      setSelection((prev) => computeToggleHubSelection(prev, clickedHubId, graph)),
+    [graph],
+  );
+  // Re-derive the highlight set when the graph changes while a hub is selected
+  // (an agent popped in/out of that stack), and clear a selection whose hub no
+  // longer exists.
+  useEffect(() => {
+    setSelection((prev) => {
+      if (prev.selectedHubId === null) return prev;
+      const stillExists = graph.nodes.some((n) => n.id === prev.selectedHubId);
+      if (!stillExists) return EMPTY_SUBTREE_SELECTION;
+      return computeToggleHubSelection(
+        EMPTY_SUBTREE_SELECTION,
+        prev.selectedHubId,
+        graph,
+      );
+    });
+  }, [graph]);
+
   const hover = useMemo<NetworkHoverContextValue>(
-    () => ({ highlight, setHoverTarget }),
-    [highlight],
+    () => ({
+      highlight,
+      setHoverTarget,
+      selection,
+      toggleHubSelection: onToggleHubSelection,
+    }),
+    [highlight, selection, onToggleHubSelection],
   );
 
   // Filter callbacks.

--- a/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
@@ -43,6 +43,7 @@ import type {
   TransportVerdict,
 } from "./network-transport-overlay";
 import { overlayForStack } from "./network-transport-overlay";
+import { stackColor } from "./stack-color";
 
 /** Reserved id for the synthetic LOCAL stack-root hub node (never a valid agent key). */
 export const STACK_HUB_NODE_ID = "__stack__";
@@ -87,6 +88,14 @@ export interface StackHubNodeData {
   /** Count of agents attached to this hub. */
   agentCount: number;
   /**
+   * #1068 — the deterministic per-stack color for this hub, derived from
+   * `origin` via `stackColor` (the LOCAL stack gets the reserved signature hue,
+   * each peer a stable palette color). Used as the hub's accent/border. ADDITIVE:
+   * the local/sibling/foreign shape treatments (solid/dashed border, eyebrow)
+   * stay — color is a legibility aid, never the only signal.
+   */
+  stackColor: string;
+  /**
    * P-14 U2.3 (#935) — signal's intent⋈reality VERDICT for this stack, when the
    * transport overlay is on AND signal observed this `{principal}/{stack}`.
    * Undefined → no overlay / no observation (the hub renders no verdict badge).
@@ -126,6 +135,14 @@ export interface AgentNodeData {
   offlineReason: string | null;
   /** Epoch-ms of the last `agent.heartbeat` observed, or `null`. */
   lastHeartbeatAt: number | null;
+  /**
+   * #1068 — the deterministic per-stack color for THIS agent's stack (the same
+   * `stackColor(origin)` its hub carries — a local agent shares the local
+   * signature hue, a foreign peer shares its stack's color). Drives the agent
+   * card's accent/left-border. ADDITIVE — the foreign dashed-border + provenance
+   * badge stay; color groups the card visually with its hub.
+   */
+  stackColor: string;
   /**
    * P-14 U2.3 (#935) — leaf LIVENESS for this agent's stack, when the transport
    * overlay is on AND signal observed the stack. `present` is the live-link flag,
@@ -175,8 +192,14 @@ export interface NetworkGraphEdge {
   id: string;
   source: string;
   target: string;
-  /** U2.3 — optional transport overlay payload (health/lag), sourced from signal. */
-  data?: { transport?: NetworkEdgeTransportData };
+  /**
+   * Edge `data` payload.
+   *   - `stackColor` (#1068) — the hub's stack color, so the hub→agent connector
+   *     strokes in the stack's hue (set at build time for every edge).
+   *   - `transport` (U2.3) — optional health/lag overlay payload, sourced from
+   *     signal (present only when the transport overlay is on).
+   */
+  data?: { stackColor?: string; transport?: NetworkEdgeTransportData };
 }
 
 /** The adapter's output: nodes + edges, pre-layout. */
@@ -292,6 +315,11 @@ export function buildNetworkGraph(
   const edges: NetworkGraphEdge[] = [];
 
   for (const bucket of orderedBuckets) {
+    // #1068 — the stack's deterministic color, derived from the bucket's verified
+    // origin. The hub, every agent in the bucket, and every hub→agent edge share
+    // it, so a stack reads as one colored cluster. ADDITIVE over the shape/label
+    // treatments — never the only signal.
+    const color = stackColor(bucket.origin);
     nodes.push({
       id: bucket.hubId,
       type: "stackHub",
@@ -303,6 +331,7 @@ export function buildNetworkGraph(
         principal: bucket.principal ?? null,
         stack: bucket.stack ?? null,
         agentCount: bucket.agents.length,
+        stackColor: color,
       },
     });
     for (const a of bucket.agents) {
@@ -321,17 +350,55 @@ export function buildNetworkGraph(
           state: a.state,
           offlineReason: a.offline_reason,
           lastHeartbeatAt: a.last_heartbeat_at,
+          stackColor: color,
         },
       });
       edges.push({
         id: `hub-${a.key}`,
         source: bucket.hubId,
         target: a.key,
+        data: { stackColor: color },
       });
     }
   }
 
   return { nodes, edges };
+}
+
+/** #1068 — one legend entry: a stack's hub id, display label, and color. */
+export interface LegendStack {
+  /** The hub node id (stable React key + identity). */
+  id: string;
+  /** Display label — `{principal}/{stack}`, or `local` for the self stack. */
+  label: string;
+  /** The stack's deterministic color (the hub's `stackColor`). */
+  color: string;
+}
+
+/**
+ * #1068 — collect the per-stack legend entries from a built graph: one row per
+ * stack-hub node, carrying its `{principal}/{stack}` label (or `local` for the
+ * self stack) and its deterministic color. Hub emission order is preserved
+ * (local first, then peers in first-seen order — see {@link buildNetworkGraph}),
+ * so the legend reads in the same order the hubs lay out.
+ *
+ * Pure + DOM-free so it's unit-tested without a browser; the legend component
+ * takes the result and renders swatches.
+ */
+export function collectLegendStacks(graph: NetworkGraph): LegendStack[] {
+  const out: LegendStack[] = [];
+  for (const node of graph.nodes) {
+    if (node.data.kind !== "stack-hub") continue;
+    const d = node.data;
+    const label =
+      d.origin === "local"
+        ? "local"
+        : d.principal && d.stack
+          ? `${d.principal}/${d.stack}`
+          : (d.stack ?? d.principal ?? node.id);
+    out.push({ id: node.id, label, color: d.stackColor });
+  }
+  return out;
 }
 
 /**
@@ -394,6 +461,9 @@ export function applyTransportOverlay(
     return {
       ...edge,
       data: {
+        // Preserve the #1068 per-stack color the base build set; the overlay
+        // only ADDS the transport payload.
+        ...edge.data,
         transport: {
           verdict: peer.verdict,
           present: peer.present,

--- a/src/surface/mc/dashboard-v2/lib/network-hover-context.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-hover-context.ts
@@ -19,17 +19,38 @@
 
 import { createContext, useContext } from "react";
 import { EMPTY_HIGHLIGHT, type HighlightSet, type HoverTarget } from "./capability-highlight";
+import {
+  EMPTY_SUBTREE_SELECTION,
+  type SubtreeSelection,
+} from "./network-subtree-highlight";
 
 export interface NetworkHoverContextValue {
   /** The currently-active highlight set (derived from the hover target). */
   highlight: HighlightSet;
   /** Report a new hover target (or `null` on mouse-leave). */
   setHoverTarget: (target: HoverTarget) => void;
+  /**
+   * #1068 — the STICKY hub-subtree selection (the selected hub id + the set of
+   * hub/agent/edge ids to emphasize; everything else dims). A sibling of `hover`
+   * that persists until the principal re-clicks the hub or clicks empty canvas.
+   * Inert default → nothing selected (no dimming). Read by the node cards (to
+   * emphasize/dim + stamp `aria-pressed`/`data-selected`) and the custom edge
+   * (to emphasize/dim its connector).
+   */
+  selection: SubtreeSelection;
+  /**
+   * #1068 — TOGGLE the hub selection for a clicked hub id (or clear on `null`).
+   * The view owns the graph, so it computes the next selection; the canvas just
+   * reports the clicked hub up through this setter.
+   */
+  toggleHubSelection: (clickedHubId: string | null) => void;
 }
 
 const INERT: NetworkHoverContextValue = {
   highlight: EMPTY_HIGHLIGHT,
   setHoverTarget: () => {},
+  selection: EMPTY_SUBTREE_SELECTION,
+  toggleHubSelection: () => {},
 };
 
 export const NetworkHoverContext =

--- a/src/surface/mc/dashboard-v2/lib/network-subtree-highlight.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-subtree-highlight.ts
@@ -1,0 +1,121 @@
+/**
+ * #1068 — highlight-subtree on stack-hub select (pure logic).
+ *
+ * Selecting a STACK-HUB highlights its whole subtree — the hub, every agent
+ * grouped under it, and the hub→agent edges wiring them — while everything else
+ * dims. This is the DECISION ("given a selected hub, which ids light up?"); the
+ * interaction (click/keyboard → set/toggle selection, the React context that
+ * broadcasts it) is thin wiring. The decision is pure + unit-testable without a
+ * DOM, exactly like the capability-hover highlight (`capability-highlight.ts`)
+ * it sits beside.
+ *
+ * The selection is a STICKY sibling of hover: hover is transient (mouse
+ * enter/leave), selection persists until the principal clicks the hub again or
+ * clicks empty canvas. Both feed the SAME visual machinery (emphasize the lit
+ * set, dim the rest), so a node/edge asks one question — "am I in the active
+ * highlight set?" — regardless of which produced it.
+ *
+ * ## What the set contains
+ *
+ * `subtreeHighlightSet(graph, hubId)` returns the SET of element ids to light:
+ *   - the hub's own node id;
+ *   - every AGENT node id whose hub→agent edge originates at the hub (so the set
+ *     is computed off the EDGES — the adapter wires each agent to ITS OWN stack's
+ *     hub, local/sibling/foreign alike, so a foreign hub lights only ITS agents);
+ *   - every hub→agent EDGE id originating at the hub.
+ *
+ * An unknown / non-hub id → an EMPTY set (nothing to highlight — the caller
+ * treats that as "no selection", so the graph reads normally).
+ */
+
+import type { NetworkGraph } from "./network-graph-adapter";
+
+/**
+ * Compute the set of node + edge ids in `hubId`'s subtree (the hub + its agents
+ * + the hub→agent edges). Deterministic: depends only on the graph's edge wiring.
+ *
+ * Off the EDGES (not the nodes' origin) so it composes with the adapter's
+ * grouping verbatim — whatever agents the adapter wired to this hub are exactly
+ * the subtree, no re-derivation of origin grouping here. A hub with no agents
+ * yields `{hubId}` alone; an id that names no hub→agent edge source yields `∅`.
+ */
+export function subtreeHighlightSet(
+  graph: NetworkGraph,
+  hubId: string,
+): Set<string> {
+  const set = new Set<string>();
+  // Only a real node may anchor a subtree; an unknown id lights nothing.
+  if (!graph.nodes.some((n) => n.id === hubId)) return set;
+  set.add(hubId);
+  for (const edge of graph.edges) {
+    if (edge.source !== hubId) continue;
+    set.add(edge.id); // the hub→agent edge
+    set.add(edge.target); // the agent node it points at
+  }
+  return set;
+}
+
+/**
+ * The view's hub-selection state: the selected hub id (or `null` when nothing is
+ * selected) plus the derived highlight set. Kept together so the canvas can both
+ * stamp `aria-pressed`/`data-selected` on the right hub AND dim/emphasize by id.
+ */
+export interface SubtreeSelection {
+  /** The currently-selected stack-hub id, or `null` when nothing is selected. */
+  selectedHubId: string | null;
+  /**
+   * The ids (hub + its agents + its edges) to EMPHASIZE; everything else dims.
+   * Empty when nothing is selected (the resting state — no dimming).
+   */
+  highlightIds: ReadonlySet<string>;
+}
+
+/** Shared resting-state selection — nothing selected, nothing highlighted. */
+export const EMPTY_SUBTREE_SELECTION: SubtreeSelection = Object.freeze({
+  selectedHubId: null,
+  highlightIds: new Set<string>(),
+});
+
+/**
+ * Toggle hub selection: clicking the ALREADY-selected hub clears it; clicking a
+ * DIFFERENT hub selects that one. Pure — `(prev, clickedHubId, graph) → next`.
+ *
+ * Passing `null` for `clickedHubId` (e.g. empty-canvas click, or a click that
+ * resolved to a non-hub) clears the selection. The next selection's highlight set
+ * is computed eagerly so the canvas reads it directly.
+ */
+export function toggleHubSelection(
+  prev: SubtreeSelection,
+  clickedHubId: string | null,
+  graph: NetworkGraph,
+): SubtreeSelection {
+  if (clickedHubId === null || clickedHubId === prev.selectedHubId) {
+    return EMPTY_SUBTREE_SELECTION;
+  }
+  return {
+    selectedHubId: clickedHubId,
+    highlightIds: subtreeHighlightSet(graph, clickedHubId),
+  };
+}
+
+/**
+ * O(1): is this element (node or edge id) in the active subtree highlight?
+ *
+ * When NOTHING is selected (`highlightIds` empty) returns `false` for everything
+ * — the caller reads that as "no selection", so it neither emphasizes nor dims.
+ */
+export function isInSubtreeHighlight(
+  selection: SubtreeSelection,
+  id: string,
+): boolean {
+  return selection.highlightIds.has(id);
+}
+
+/**
+ * Is a subtree selection ACTIVE (something selected)? Drives the dim-the-rest
+ * behavior: only dim non-highlighted elements when a selection exists, so the
+ * resting graph (no selection) is never dimmed.
+ */
+export function hasSubtreeSelection(selection: SubtreeSelection): boolean {
+  return selection.selectedHubId !== null;
+}

--- a/src/surface/mc/dashboard-v2/lib/stack-color.ts
+++ b/src/surface/mc/dashboard-v2/lib/stack-color.ts
@@ -1,0 +1,103 @@
+/**
+ * #1068 — per-stack deterministic color-coding for the Network graph.
+ *
+ * Each stack-hub + its agents + its hub→agent edges get a DISTINCT, stable color
+ * so the principal can tell the local stacks apart at a glance (meta-factory,
+ * work, halden, community, …). The color is derived PURELY from the agent's
+ * VERIFIED origin scope — the same `{principal}/{stack}` (or `"local"`) the
+ * adapter groups hubs by (`hubIdForOrigin`) — so:
+ *
+ *   - the SAME stack always reads the same color (stable across renders + reloads,
+ *     since the hash is content-only — no `Math.random`, no allocation order);
+ *   - DIFFERENT stacks read different colors (until the palette wraps);
+ *   - YOUR own stack (`"local"`) gets a stable DISTINGUISHED signature hue
+ *     (`palette[0]`), so the anchor stack is recognisable at a glance.
+ *
+ * Color is ADDITIVE, never the only signal: the cards keep their text labels and
+ * the local/sibling/foreign shape treatments (solid/dashed border, eyebrow). A
+ * colorblind principal still reads the graph off shape + label; the hue is a
+ * fast-path legibility aid, not load-bearing for correctness (WCAG-ish: the
+ * palette hues are chosen to read on the dark canvas without relying on hue
+ * discrimination alone).
+ *
+ * Pure + DOM-free, so it's unit-tested without a browser (the lib/wrapper
+ * discipline the rest of the graph follows).
+ */
+
+import type { AgentOrigin } from "../hooks/use-agents";
+
+/**
+ * The fixed, accessible palette. Muted mid-saturation hues that all read on the
+ * dark canvas (background ~`#0f1117`), chosen to be reasonably distinguishable
+ * including for the common colorblind types (no pure red/green adjacency that
+ * collapses under deuteranopia/protanopia; the order interleaves warm/cool).
+ * Index 0 is the SIGNATURE hue reserved for the LOCAL stack (a calm blue — your
+ * anchor). The rest cycle for foreign / sibling stacks.
+ *
+ * Hues borrowed in spirit from Strata's type palette (`arc-library/strata/ui`),
+ * which is tuned for the same dark React-Flow canvas, then widened to 10 so 4+
+ * local stacks (today) plus federated peers don't collide early.
+ */
+export const STACK_PALETTE: readonly string[] = [
+  "#5b8cd4", // 0 — signature blue (LOCAL/self)
+  "#2e8b7a", // 1 — teal
+  "#d4915b", // 2 — amber/orange
+  "#9b6ccf", // 3 — violet
+  "#c26cb0", // 4 — magenta
+  "#5ea0a0", // 5 — cyan-grey
+  "#c4b257", // 6 — gold
+  "#7a9c5e", // 7 — olive
+  "#cf6c6c", // 8 — clay red
+  "#6c8ccf", // 9 — periwinkle
+] as const;
+
+/** The signature color reserved for the LOCAL/self stack (`STACK_PALETTE[0]`). */
+export const LOCAL_STACK_COLOR: string = STACK_PALETTE[0]!;
+
+/**
+ * The grouping KEY an origin resolves to — the same scope the adapter buckets
+ * hubs by. `"local"` for your own stack; `"{principal}/{stack}"` for a peer.
+ * Exported so callers (and tests) can assert two origins share a stack.
+ */
+export function originScopeKey(origin: AgentOrigin): string {
+  return origin === "local"
+    ? "local"
+    : `${origin.principal}/${origin.stack}`;
+}
+
+/**
+ * A small, well-distributed string hash (FNV-1a, 32-bit). Deterministic and
+ * content-only — no global state, no allocation-order dependence — so the same
+ * scope key always hashes to the same value across renders, reloads, and
+ * processes. (FNV-1a is the standard cheap choice for short keys with good
+ * avalanche for our 10-bucket modulo.)
+ */
+function fnv1a(s: string): number {
+  let h = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    // 32-bit FNV prime multiply via shifts (avoids float precision loss).
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * The deterministic color for a stack origin.
+ *
+ *   - `"local"` → the reserved {@link LOCAL_STACK_COLOR} (`palette[0]`), ALWAYS —
+ *     the self stack's signature hue is never hashed into a different bucket.
+ *   - a peer `{principal,stack}` → `palette[1 + (hash(scopeKey) mod (N-1))]` —
+ *     hashed into the NON-signature range `[1, N)` so a foreign/sibling stack
+ *     never steals the local signature color. Same scope → same index → same
+ *     color, every render.
+ *
+ * Pure: `stackColor(o)` depends only on `o`'s scope key.
+ */
+export function stackColor(origin: AgentOrigin): string {
+  if (origin === "local") return LOCAL_STACK_COLOR;
+  const key = originScopeKey(origin);
+  const span = STACK_PALETTE.length - 1; // reserve index 0 for local
+  const idx = 1 + (fnv1a(key) % span);
+  return STACK_PALETTE[idx]!;
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -474,8 +474,17 @@ html, body {
 }
 .network-node-hub {
   align-items: center; text-align: center;
-  border-color: var(--accent);
-  background: var(--accent-soft);
+  /* #1068 — the hub accents in its per-stack color (falls back to the generic
+     accent when no stack color is set). Color is ADDITIVE: the foreign/sibling
+     shape treatments below still set border-style + the eyebrow label. */
+  border-color: var(--stack-color, var(--accent));
+  background: color-mix(in oklch, var(--stack-color, var(--accent)) 14%, var(--panel));
+}
+/* A 2px top accent bar makes the hub's stack color legible even when the border
+   is muted by a shape treatment. */
+.network-node-hub {
+  border-top-width: 2px;
+  border-top-color: var(--stack-color, var(--accent));
 }
 .network-hub-eyebrow {
   font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em;
@@ -483,7 +492,14 @@ html, body {
 .network-hub-label { font-size: 13px; font-weight: 700; font-family: var(--mono); }
 .network-hub-count { font-size: 10.5px; }
 
-.network-node-agent { width: 200px; }
+.network-node-agent {
+  width: 200px;
+  /* #1068 — a left accent bar in the agent's stack color groups it visually with
+     its hub. ADDITIVE: the foreign dashed border + provenance badge still apply;
+     a colorblind reader still distinguishes stacks by the hub label + shape. */
+  border-left-width: 3px;
+  border-left-color: var(--stack-color, var(--line));
+}
 .network-node-offline { opacity: 0.62; }
 .network-node-ttl-lapse {
   border-color: color-mix(in oklch, var(--warn) 50%, var(--line));
@@ -590,6 +606,17 @@ html, body {
 .network-legend-swatch.swatch-online { background: var(--ok); }
 .network-legend-swatch.swatch-offline { background: var(--fg-faint); }
 .network-legend-swatch.swatch-ttl-lapse { background: var(--warn); }
+/* #1068 — per-stack color swatches. Square (vs the round state swatches) so the
+   two legend groups read as distinct keys; the inline background is the stack's
+   deterministic color. The flex-wrap lets the stack list flow when many stacks
+   are present. */
+.network-legend { flex-wrap: wrap; max-width: 60%; }
+.network-legend-stacks {
+  display: inline-flex; flex-wrap: wrap; gap: 10px;
+  padding-left: 10px; margin-left: 2px;
+  border-left: 1px solid var(--line);
+}
+.network-legend-swatch-stack { border-radius: 2px; }
 
 /* G-1114.D.4 — node detail panel (slides in on the right of the canvas).
    Presence + capabilities + a LIGHT dispatch pointer — never session
@@ -690,6 +717,34 @@ html, body {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
   box-shadow: 0 0 12px -2px var(--accent);
+}
+
+/* #1068 — STICKY hub-subtree selection. Selecting a stack-hub emphasizes its
+   subtree (the hub + its agents + edges) and dims everything else. Emphasis +
+   dim are conveyed by OUTLINE + OPACITY, never hue alone (a11y): a colorblind
+   principal still sees the lit subtree pop and the rest recede. The outline uses
+   the stack's own color when present (`--stack-color`) so the emphasis reads as
+   "this stack", falling back to the generic accent. */
+.network-node-selected {
+  outline: 2px solid var(--stack-color, var(--accent));
+  outline-offset: 1px;
+  box-shadow: 0 0 14px -2px var(--stack-color, var(--accent));
+  opacity: 1;
+}
+.network-node-hub.network-node-selected {
+  /* The selected hub gets a slightly stronger ring so it reads as the anchor. */
+  outline-width: 3px;
+}
+.network-node-dimmed {
+  opacity: 0.28;
+  filter: saturate(0.7);
+  transition: opacity 0.2s ease, filter 0.2s ease;
+}
+/* An interactive hub shows a pointer + a focus ring for keyboard a11y. */
+.network-node-hub[role="button"] { cursor: pointer; }
+.network-node-hub[role="button"]:focus-visible {
+  outline: 2px solid var(--stack-color, var(--accent));
+  outline-offset: 2px;
 }
 
 /* G-1114.F.3 — dispatch-direct affordance in the detail panel. */


### PR DESCRIPTION
Two Network-graph UX enhancements Andreas asked for on the now-working multi-stack graph (#1060, v5.18.0). Both PURE helpers live in libs + are unit-tested; the React wiring is thin.

## Part 1 — per-stack color-coding

- **`lib/stack-color.ts`** — pure `stackColor(origin) → color`. **Palette:** a fixed, accessible 10-hue set tuned for the dark canvas (borrowed in spirit from Strata's type palette, then widened): `#5b8cd4` (signature blue, LOCAL), teal, amber, violet, magenta, cyan-grey, gold, olive, clay red, periwinkle. **Determinism:** `"local"`/self always maps to the reserved signature hue (`palette[0]`); each peer `{principal}/{stack}` is **FNV-1a-hashed** into the **non-signature range `[1,N)`**, so a foreign stack can never steal the local color. Hash is content-only (no `Math.random`, no allocation-order dep) → the same stack reads the same color across renders, reloads, and processes.
- Threaded onto **hub + agent node data and the hub→agent edge data** in the adapter (one color per origin bucket). Applied as the **hub top-accent/border**, **agent left-accent border** (via a `--stack-color` CSS custom property), and the **edge stroke** (in `network-elk-edge.tsx`). **ADDITIVE** over the existing local/sibling/foreign shape treatments (solid/dashed border, eyebrow) + text labels — color is never the only signal (colorblind-reasonable; a11y).
- **Legend** shows a swatch + `{principal}/{stack}` per stack present in the snapshot (`local` first, in hub layout order), via the pure `collectLegendStacks`.

## Part 2 — highlight-subtree on stack-hub select

- **`lib/network-subtree-highlight.ts`** — pure `subtreeHighlightSet(graph, hubId)` = `{hub} ∪ {its agents} ∪ {its hub→agent edges}`, computed **off the edge wiring** so a foreign/federated hub lights **only its own** subtree. Plus sticky `toggleHubSelection` (select / re-click-clears / switch / empty-clears).
- **Extended `lib/network-hover-context.ts`** with a sticky `selection` — reusing the **existing G-1114.F hover-highlight visual machinery** (emphasize the lit set, dim the rest). Selection is a **sticky** version of hover; hover still works transiently on top. Clicking (or Enter/Space on a focused) **stack-hub** toggles its subtree; re-clicking the same hub or clicking empty canvas clears.
- Nodes/edges **emphasize** (outline + full opacity) the selected subtree and **dim** (opacity, not hue) everything else.

### a11y
- The selected hub carries `role="button"`, `aria-pressed`, and `data-selected`; keyboard: focus a hub + **Enter/Space** toggles its selection (`:focus-visible` ring).
- Emphasis vs dim is conveyed by **opacity + outline**, never hue alone. Agents/edges carry `data-selected`/`data-dimmed`.

## Gates
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun test` — **6884 pass / 0 fail**
- `bun run build:dashboard` — **lazy split preserved**: entry **1.26 MB**, `network-canvas` chunk **3.51 MB** (separate). The pure helpers stay in the main bundle (engine-free); the canvas/edge/nodes stay in the lazy chunk.
- Vocab carve-out: `principal`, not `operator`.

ADR-0007 honored — the new node fields are deterministic **presentation** (a color derived from origin), never session interiors; the ADR-0007 allowlist guard test is updated accordingly. #1060 ELK layout/routing + the 3-way local/sibling/foreign classification are untouched.

**Browser-QA on `localhost:8767` is the visual gate** (curl/SSR can't confirm the hover/click interactions or the rendered hues).

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)