### PR TITLE
chore: bump to v5.19.0 — network graph per-stack colour + highlight (#1070)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.18.0"
+version: "5.19.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release bump to **v5.19.0**.

Ships #1070 (merged to main): Mission Control network graph per-stack colour-coding + highlight-subtree on hub select. Local stack keeps the reserved signature blue; peers get deterministic distinct hues; a11y-safe (opacity + outline, not hue-only).

Frontend-only (dashboard-v2) — backend binary unchanged. Dashboard redeploys via `build:dashboard`.