### PR TITLE
fix(mattermost): collapse top-level posts to channel key so gate replies correlate

### DIFF
--- a/src/adapters/mattermost/__tests__/thread-collapse.test.ts
+++ b/src/adapters/mattermost/__tests__/thread-collapse.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression: the Mattermost gate-orphan bug.
+ *
+ * The poller sets `rootId = post.root_id || post.id`, so a top-level post's
+ * "rootId" is its OWN id. If that flows through as `InboundMessage.threadId`,
+ * cortex's `threadId ?? channelId` collapse never fires and every top-level
+ * post becomes its own phantom thread — a gate prompt and the principal's
+ * separate top-level reply then key on different ids and never correlate, so
+ * the reply spawns a NEW task instead of resolving the open gate.
+ *
+ * These tests lock the collapse: top-level → channel key (undefined threadId);
+ * genuine thread → its root; and the outbound side never posts root_id=channel.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { inboundThreadId, outboundRootId } from "../index";
+
+describe("inboundThreadId — top-level collapses, threads keep their root", () => {
+  it("top-level post (rootId === postId) → undefined (collapses to channel)", () => {
+    expect(inboundThreadId("post-1", "post-1")).toBeUndefined();
+  });
+
+  it("genuinely-threaded post (rootId !== postId) → the thread root", () => {
+    expect(inboundThreadId("root-9", "post-2")).toBe("root-9");
+  });
+
+  it("two distinct top-level posts both collapse — so they share a key", () => {
+    // The run command (P1) and the principal's separate 'yes' (P2): both
+    // top-level, both → undefined → cortex keys both on channelId → MATCH.
+    expect(inboundThreadId("P1", "P1")).toBeUndefined();
+    expect(inboundThreadId("P2", "P2")).toBeUndefined();
+  });
+});
+
+describe("outboundRootId — never post root_id=channel", () => {
+  it("thread === channel (cortex's no-thread key) → undefined (top-level post)", () => {
+    expect(outboundRootId("chan-1", "chan-1")).toBeUndefined();
+  });
+
+  it("undefined thread → undefined (top-level post)", () => {
+    expect(outboundRootId(undefined, "chan-1")).toBeUndefined();
+  });
+
+  it("genuine thread root (≠ channel) → threads as usual", () => {
+    expect(outboundRootId("root-9", "chan-1")).toBe("root-9");
+  });
+});

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -90,6 +90,33 @@ export interface MattermostAdapterInfra {
   policyRegistry?: PrincipalRegistry;
 }
 
+/**
+ * Inbound thread key for a Mattermost post. The poller sets
+ * `rootId = post.root_id || post.id`, so a TOP-LEVEL post has
+ * `rootId === postId` — that is the message's own id, not a thread it belongs
+ * to. Returning `undefined` there lets cortex's `threadId ?? channelId`
+ * collapse (cortex.ts:2450) key top-level conversations on the CHANNEL, so a
+ * gate prompt and the principal's separate top-level reply correlate. A
+ * genuinely-threaded post (`rootId !== postId`) keeps its thread root.
+ */
+export function inboundThreadId(rootId: string, postId: string): string | undefined {
+  return rootId !== postId ? rootId : undefined;
+}
+
+/**
+ * Outbound Mattermost `root_id`. cortex routes a non-threaded conversation
+ * with `thread === channelId` (the collapse above); Mattermost rejects a post
+ * whose `root_id` is a channel id, so that case posts TOP-LEVEL (`undefined`).
+ * A genuine thread root (≠ channelId) threads as usual; `undefined` stays
+ * top-level.
+ */
+export function outboundRootId(
+  threadId: string | undefined,
+  channelId: string,
+): string | undefined {
+  return threadId !== undefined && threadId !== channelId ? threadId : undefined;
+}
+
 export class MattermostAdapter implements PlatformAdapter {
   readonly platform = "mattermost";
   readonly instanceId: string;
@@ -156,7 +183,9 @@ export class MattermostAdapter implements PlatformAdapter {
           authorName: mmMsg.userName,
           content: mmMsg.content,
           channelId: mmMsg.channelId,
-          threadId: mmMsg.rootId, // Thread to original message for proper reply threading
+          // Top-level posts collapse to the channel key so gate prompt + reply
+          // correlate; only genuine threads carry a thread id (see helper).
+          threadId: inboundThreadId(mmMsg.rootId, mmMsg.postId),
           // cortex#729 — stamp the home-principal trust signal for parity with
           // the Discord adapter, so the dispatch-handler's prompt-filter
           // trust-scope bypasses the hard-block for the home principal's
@@ -290,7 +319,9 @@ export class MattermostAdapter implements PlatformAdapter {
   async postResponse(target: ResponseTarget, text: string, files?: OutboundFile[]): Promise<void> {
     const apiUrl = this.apiUrl;
     const apiToken = this.apiToken;
-    const rootId = target.threadId;
+    // thread === channel is cortex's "no native thread" key — post top-level
+    // (root_id=channelId is invalid in MM); a genuine root still threads.
+    const rootId = outboundRootId(target.threadId, target.channelId);
 
     if (files && files.length > 0) {
       // Write files to temp paths for upload
@@ -317,10 +348,12 @@ export class MattermostAdapter implements PlatformAdapter {
     // Mattermost can't edit posts easily — just send once, skip subsequent
     if (this.progressSent.has(key)) return;
     this.progressSent.add(key);
+    // Same channel-collapse rule as postResponse.
+    const rootId = outboundRootId(target.threadId, target.channelId);
     await postReply(
       target.channelId,
       `> ${text}`,
-      target.threadId,
+      rootId,
       this.apiUrl,
       this.apiToken,
     );


### PR DESCRIPTION
## The bug (live Mattermost gate-orphan)

`@Yarrow run F_IP_INVESTIGATE_ENRICH <ip>` ran through all steps and opened the internal analyst-approve gate ("Approve opening a tracker ticket?"). `@Yarrow yes` then **spawned a brand-new brain task** instead of resolving the open gate — the gate was orphaned and the run task failed.

## Root cause

The MM poller sets `rootId = post.root_id || post.id`, so a **top-level** post's `rootId` is its **own** post id. That flowed straight into `InboundMessage.threadId` (`index.ts:159`), defeating cortex's `threadId ?? channelId` collapse (`cortex.ts:2450`). Every top-level post became its own phantom thread, so the `run` command (key = P1) and the separate `yes` (key = P2) keyed on **different** ids — the gate awaited on P1, `yes` was offered on P2, no match → new task. Discord is immune because its top-level messages carry `threadId=undefined` and both sides collapse to `channelId`.

## Fix

Honor cortex's documented channel-collapse on Mattermost:
- **inbound**: top-level post (`rootId === postId`) → `threadId` undefined; a genuine thread (`rootId !== postId`) keeps its root.
- **outbound**: a routing thread equal to the channel id is the "no native thread" key → post top-level (MM rejects `root_id=channelId`); a genuine root threads as usual.

Extracted `inboundThreadId()` / `outboundRootId()` as pure helpers with regression tests.

## Behavior change

Non-threaded MM conversations (incl. sage chat) now post replies **top-level** instead of threaded under each message — this is exactly cortex's intended channel-level model for non-threaded surfaces, and is required for gate correlation.

## Tests

Full suite green: **1549 pass, 0 fail**. 6 new regression tests in `thread-collapse.test.ts`.

## Follow-up (separate, not in this PR)

`daemon-brain-host` per-task `taskTimeoutMs` (300s) fires `failTask` even while a human gate is open (`openGates` tracked but not consulted) — a SOC gate that legitimately takes >5 min would be killed mid-wait. Did not cause this incident (reply was prompt) but should be fixed (pause the timeout while `openGates > 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)