### PR TITLE
fix(mc): network graph hub-select highlight was inert — double-toggle (#1070)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-subtree-highlight.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-subtree-highlight.test.ts
@@ -145,6 +145,22 @@ describe("toggleHubSelection (#1068)", () => {
     expect(hasSubtreeSelection(cleared)).toBe(false);
   });
 
+  it("#1070 regression — toggling the SAME hub TWICE in one click cancels to EMPTY", () => {
+    // The shipped-but-inert bug: a hub click fired the toggle from BOTH the hub
+    // card's own `onClick` AND React Flow's bubbling `onNodeClick`, so the
+    // selection went EMPTY → selected → EMPTY within one event tick and the
+    // highlight never stuck. This pins WHY exactly ONE handler may toggle: a
+    // double application of the same-id toggle is a no-op. The fix removes the
+    // second (onNodeClick) toggle so a single click lands on `selected`.
+    const once = toggleHubSelection(EMPTY_SUBTREE_SELECTION, STACK_HUB_NODE_ID, g);
+    const twice = toggleHubSelection(once, STACK_HUB_NODE_ID, g);
+    expect(once.selectedHubId).toBe(STACK_HUB_NODE_ID); // single click → selected
+    expect(hasSubtreeSelection(once)).toBe(true);
+    expect(twice.selectedHubId).toBeNull(); // double toggle → back to nothing
+    expect(hasSubtreeSelection(twice)).toBe(false);
+    expect(twice).toEqual(EMPTY_SUBTREE_SELECTION);
+  });
+
   it("clicking a DIFFERENT hub switches the selection", () => {
     const first = toggleHubSelection(EMPTY_SUBTREE_SELECTION, STACK_HUB_NODE_ID, g);
     const second = toggleHubSelection(first, foreignHubId, g);

--- a/src/surface/mc/dashboard-v2/components/network-canvas.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-canvas.tsx
@@ -146,20 +146,25 @@ function FlowCanvas({
 
   // Node click →
   //   - AGENT node → lift its key up (D.4): open the detail panel.
-  //   - STACK-HUB node → toggle its subtree selection (#1068) and DESELECT any
-  //     open agent panel (the hub isn't an agent). `agentKeyFromClickedNode`
-  //     already resolves agent→key / hub→null, so we branch on the node type.
+  //   - STACK-HUB node → DESELECT any open agent panel (the hub isn't an agent).
+  //     The subtree-selection TOGGLE is owned by the hub card's own
+  //     `onClick`/`onKeyDown` (network-nodes.tsx — the a11y `role=button` control
+  //     with `aria-pressed` + keyboard activation). The hub card does NOT stop
+  //     propagation, so this `onNodeClick` ALSO fires on a hub click; it must NOT
+  //     toggle here too, or the two functional `setSelection` calls in the same
+  //     event tick cancel out (EMPTY→selected→EMPTY) and the highlight never
+  //     sticks (#1070 regression — caught in browser-QA, invisible to the pure-
+  //     function unit tests). `agentKeyFromClickedNode` resolves hub→null anyway.
   const onNodeClick = useCallback(
     (_evt: unknown, node: RfNode) => {
       const n = node as unknown as NetworkGraphNode;
       if (n.type === "stackHub") {
-        toggleHubSelection(n.id);
         onSelectAgent?.(null);
         return;
       }
       onSelectAgent?.(agentKeyFromClickedNode(n));
     },
-    [onSelectAgent, toggleHubSelection],
+    [onSelectAgent],
   );
 
   // Click on empty canvas → deselect EVERYTHING: close the panel AND clear the


### PR DESCRIPTION
## Problem
The #1070 highlight-subtree-on-hub-click (v5.19.0) shipped but was **inert at runtime** — clicking a stack hub never flipped `aria-pressed` and never dimmed other stacks. Browser-QA caught it; the pure-function unit tests + logic-only review could not (integration defect, not logic).

## Root cause — double-toggle
A hub click toggled the subtree selection **twice** in one event tick:
1. the hub card is an a11y `role=button` with its own `onClick → toggleHubSelection(id)` (network-nodes.tsx), and it does **not** `stopPropagation`, so
2. the click also bubbled to React Flow's `onNodeClick`, which called `toggleHubSelection(n.id)` **again**.

Two functional `setSelection` toggles of the same id cancel: `EMPTY → selected → EMPTY`. The selection never stuck.

## Fix
The hub card's own click/keyboard handler is the canonical (a11y-correct) toggler. `onNodeClick` no longer toggles for a `stackHub` — it keeps only its panel-close side-effect (`onSelectAgent(null)`). **One toggle per click.**

Adds a regression test pinning the invariant that a double same-id toggle is a no-op.

## Verification
Verified live in-browser on the patched bundle: select / toggle-off / switch-hub / empty-canvas-clear all work; non-selected stacks dim to opacity 0.28; `aria-pressed` flips correctly; console clean (zero dup-key warnings). 795/795 dashboard tests pass; lint + tsc + vocab gate clean.

Follow-up to #1070 (v5.19.0).