### PR TITLE
feat(config): GV-1 — migrate ~/.config/grove → ~/.config/cortex config paths (grove-fallback)

### DIFF
--- a/src/cli/cldyo-live
+++ b/src/cli/cldyo-live
@@ -7,8 +7,9 @@
 # events are bucketed under that repo on the dashboard.
 # Defaults to operator name if no repo given.
 #
-# Agent identity is read from ~/.config/grove/bot.yaml (agent.name, agent.displayName).
-# If bot.yaml is missing, falls back to system username.
+# Agent identity is read from ~/.config/cortex/bot.yaml (agent.name, agent.displayName),
+# falling back to ~/.config/grove/bot.yaml during the GV-1 config-path transition
+# (cortex#1076). If neither exists, falls back to the system username.
 #
 # Examples:
 #   cldyo-live grove              # Work on grove, visible on dashboard
@@ -16,8 +17,14 @@
 #   cldyo-live                    # Default session
 #   cldyo-live grove --resume abc # Pass extra args to claude
 
-# Read agent identity from bot.yaml
-CONFIG_FILE="${HOME}/.config/grove/bot.yaml"
+# Read agent identity from bot.yaml — cortex-first, grove-fallback (GV-1).
+CORTEX_CONFIG_FILE="${HOME}/.config/cortex/bot.yaml"
+GROVE_CONFIG_FILE="${HOME}/.config/grove/bot.yaml"
+if [ -f "${CORTEX_CONFIG_FILE}" ]; then
+  CONFIG_FILE="${CORTEX_CONFIG_FILE}"
+else
+  CONFIG_FILE="${GROVE_CONFIG_FILE}"
+fi
 if [ -f "${CONFIG_FILE}" ]; then
   AGENT_NAME=$(grep -A2 '^agent:' "${CONFIG_FILE}" | grep 'name:' | head -1 | sed 's/.*name:\s*//' | sed 's/#.*//' | tr -d '"' | tr -d "'" | xargs)
   DISPLAY_NAME=$(grep -A3 '^agent:' "${CONFIG_FILE}" | grep 'displayName:' | head -1 | sed 's/.*displayName:\s*//' | sed 's/#.*//' | tr -d '"' | tr -d "'" | xargs)

--- a/src/cli/cortex/commands/cloud.ts
+++ b/src/cli/cortex/commands/cloud.ts
@@ -498,9 +498,10 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
   // --- Step 11: Print summary & save credentials ---
   step(11, TOTAL_STEPS, "Saving credentials and printing summary...");
 
-  // GV-1: write credentials cortex-side. Relocate any legacy grove copy first
-  // (mode-preserving) so we never leave a stale secret behind, then write the
-  // fresh credentials to the canonical cortex path.
+  // GV-1: write credentials cortex-side. Copy any legacy grove copy to the
+  // cortex path first (mode-preserving — the grove original is intentionally
+  // KEPT so the grove-fallback resolver still works during transition), then
+  // write the fresh credentials to the canonical cortex path.
   migrateGroveConfigFile("cloud-credentials.txt");
   const credPath = cortexConfigPath("cloud-credentials.txt");
   mkdirSync(dirname(credPath), { recursive: true });

--- a/src/cli/cortex/commands/cloud.ts
+++ b/src/cli/cortex/commands/cloud.ts
@@ -17,6 +17,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join, dirname } from "path";
 import YAML from "yaml";
+import {
+  cortexConfigPath,
+  migrateGroveConfigFile,
+  resolveConfigFilePath,
+} from "../../../common/config/config-path";
 
 // =============================================================================
 // Pure functions (testable, no side effects)
@@ -389,7 +394,7 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
   // Try to read repos from bot.yaml if available
   let repos = defaultRepos;
   try {
-    const configPath = join(process.env.HOME ?? "~", ".config", "grove", "bot.yaml");
+    const configPath = resolveConfigFilePath("bot.yaml"); // cortex-first, grove-fallback (GV-1)
     if (existsSync(configPath)) {
       const configContent = readFileSync(configPath, "utf-8");
       // Simple yaml parsing — look for repos array under github:
@@ -493,9 +498,12 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
   // --- Step 11: Print summary & save credentials ---
   step(11, TOTAL_STEPS, "Saving credentials and printing summary...");
 
-  const credDir = join(process.env.HOME ?? "~", ".config", "grove");
-  mkdirSync(credDir, { recursive: true });
-  const credPath = join(credDir, "cloud-credentials.txt");
+  // GV-1: write credentials cortex-side. Relocate any legacy grove copy first
+  // (mode-preserving) so we never leave a stale secret behind, then write the
+  // fresh credentials to the canonical cortex path.
+  migrateGroveConfigFile("cloud-credentials.txt");
+  const credPath = cortexConfigPath("cloud-credentials.txt");
+  mkdirSync(dirname(credPath), { recursive: true });
 
   const summary = buildCredentialsSummary({
     workerUrl,
@@ -535,7 +543,7 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
   }
 
   console.log("\nNext steps:");
-  console.log("  1. Add the bot.yaml snippet above to ~/.config/grove/bot.yaml");
+  console.log("  1. Add the bot.yaml snippet above to ~/.config/cortex/bot.yaml");
   console.log("  2. Restart cortex: cortex stop && cortex start");
   console.log("  3. Add more principals: cortex cloud add-principal --name JC --agent-name Ivy --endpoint URL --admin-key SECRET");
 }
@@ -675,7 +683,9 @@ async function cloudStatus(flags: Record<string, string>): Promise<void> {
 // cloud repos — Repo management (bot.yaml + Worker secret + D1)
 // =============================================================================
 
-const DEFAULT_CONFIG_PATH = join(process.env.HOME ?? "~", ".config", "grove", "bot.yaml");
+// GV-1: cortex-first, grove-fallback. Resolved at module load; the daemon and
+// `cortex cloud repos` both read (never write) bot.yaml here.
+const DEFAULT_CONFIG_PATH = resolveConfigFilePath("bot.yaml");
 
 interface BotYamlGithub {
   repos?: string[];
@@ -712,7 +722,7 @@ function loadBotYaml(configPath: string): { raw: string; parsed: BotYaml } {
 }
 
 function readAdminSecret(): string | null {
-  const credPath = join(process.env.HOME ?? "~", ".config", "grove", "cloud-credentials.txt");
+  const credPath = resolveConfigFilePath("cloud-credentials.txt"); // cortex-first, grove-fallback (GV-1)
   if (!existsSync(credPath)) return null;
   const content = readFileSync(credPath, "utf-8");
   const match = /Admin Secret:\s+(\S+)/.exec(content);
@@ -745,7 +755,7 @@ async function cloudRepos(subcommand: string, flags: Record<string, string>, ext
       console.log("  add <repo>      Add a repo (updates bot.yaml + Worker secret + triggers sync)");
       console.log("  remove <repo>   Remove a repo (updates bot.yaml + Worker secret + prunes D1)\n");
       console.log("Options:");
-      console.log("  --config PATH   Path to bot.yaml (default: ~/.config/grove/bot.yaml)");
+      console.log("  --config PATH   Path to bot.yaml (default: ~/.config/cortex/bot.yaml, falls back to ~/.config/grove/bot.yaml)");
       console.log("  --cf-api-token  Cloudflare API token (for updating Worker secret)");
       console.log("  --admin-key     Admin secret (for D1 prune; auto-detected from credentials)\n");
       console.log("Examples:");
@@ -907,7 +917,7 @@ async function pruneRepoFromD1(repo: string, config: BotYaml, flags: Record<stri
 
   if (!endpoint || !adminKey) {
     warn("No endpoint or admin key — skipping D1 prune");
-    console.log("    Pass --admin-key or ensure ~/.config/grove/cloud-credentials.txt exists");
+    console.log("    Pass --admin-key or ensure ~/.config/cortex/cloud-credentials.txt exists");
     return;
   }
 

--- a/src/cli/discord/lib/config.ts
+++ b/src/cli/discord/lib/config.ts
@@ -1,16 +1,16 @@
 /**
- * Discord CLI configuration — stored at ~/.config/grove/cli.yaml.
+ * Discord CLI configuration — stored at ~/.config/cortex/cli.yaml.
  *
- * Path is intentionally `~/.config/grove/` for byte-identical parity with
- * grove-v2 (plan §1.3 non-goal: behaviour parity). The rename to
- * `~/.config/cortex/cli.yaml` lands at MIG-7 alongside the broader
- * bot.yaml → cortex.yaml move; doing it now would create an intermediate
- * config-fork state for the principal. Tracked at plan §4 MIG-7.
+ * GV-1 (cortex#1076): the canonical location is `~/.config/cortex/cli.yaml`.
+ * Reads are cortex-first with a `~/.config/grove/cli.yaml` fallback during the
+ * transition window; the first write migrates the legacy grove copy to cortex
+ * (mode-preserving) and persists cortex-side thereafter.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join, dirname } from "path";
+import { dirname } from "path";
 import YAML from "yaml";
+import { cortexConfigPath, migrateGroveConfigFile, resolveConfigFilePath } from "../../../common/config/config-path";
 
 export interface ChannelConfig {
   /** Discord channel ID */
@@ -50,21 +50,29 @@ export interface DiscordCliConfig {
   servers?: Record<string, ServerProfile>;
 }
 
-const CONFIG_PATH = join(process.env.HOME ?? "~", ".config", "grove", "cli.yaml");
+const CONFIG_FILENAME = "cli.yaml";
 
 export function loadConfig(): DiscordCliConfig {
-  if (!existsSync(CONFIG_PATH)) return {};
-  const text = readFileSync(CONFIG_PATH, "utf-8");
+  // cortex-first, grove-fallback (GV-1).
+  const path = resolveConfigFilePath(CONFIG_FILENAME);
+  if (!existsSync(path)) return {};
+  const text = readFileSync(path, "utf-8");
   return (YAML.parse(text) as DiscordCliConfig | undefined) ?? {};
 }
 
 export function saveConfig(config: DiscordCliConfig): void {
-  mkdirSync(dirname(CONFIG_PATH), { recursive: true });
-  writeFileSync(CONFIG_PATH, YAML.stringify(config));
+  // On first write, migrate any legacy grove copy to cortex (mode-preserving),
+  // then always persist to the canonical cortex path.
+  migrateGroveConfigFile(CONFIG_FILENAME);
+  const path = cortexConfigPath(CONFIG_FILENAME);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, YAML.stringify(config));
 }
 
 export function getConfigPath(): string {
-  return CONFIG_PATH;
+  // The path a reader would resolve right now (cortex if present/default,
+  // grove only as the legacy fallback).
+  return resolveConfigFilePath(CONFIG_FILENAME);
 }
 
 /**

--- a/src/cli/discord/skill/SKILL.md
+++ b/src/cli/discord/skill/SKILL.md
@@ -85,7 +85,7 @@ servers:
     # botToken / channels optional — omitted fields fall back to top-level
 ```
 
-Config stored at `~/.config/grove/cli.yaml`.
+Config stored at `~/.config/cortex/cli.yaml` (read cortex-first with a `~/.config/grove/cli.yaml` fallback during the GV-1 transition; first write migrates the legacy copy).
 
 ## Attachments
 

--- a/src/common/config/__tests__/config-path.test.ts
+++ b/src/common/config/__tests__/config-path.test.ts
@@ -1,0 +1,127 @@
+/**
+ * GV-1 (cortex#1076) — config-path resolver tests.
+ *
+ * The resolver is cortex-first with a grove fallback during the
+ * ~/.config/grove → ~/.config/cortex transition (EPIC cortex#1075). It must:
+ *   - resolve ~/.config/cortex/<file> when it exists
+ *   - fall back to ~/.config/grove/<file> when only the grove copy exists
+ *   - target the cortex path (for writes / defaults) when neither exists
+ *   - auto-migrate a grove-only file to cortex preserving the file mode
+ *     (cloud-credentials.txt is a secret, chmod 600 — never widen it)
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  cortexConfigPath,
+  groveConfigPath,
+  migrateGroveConfigFile,
+  resolveConfigFile,
+} from "../config-path";
+
+let home: string;
+const FILE = "cli.yaml";
+
+function cortexFile() {
+  return join(home, ".config", "cortex", FILE);
+}
+function groveFile() {
+  return join(home, ".config", "grove", FILE);
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "gv1-home-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("path builders", () => {
+  test("cortexConfigPath builds ~/.config/cortex/<file>", () => {
+    expect(cortexConfigPath(FILE, home)).toBe(cortexFile());
+  });
+  test("groveConfigPath builds ~/.config/grove/<file>", () => {
+    expect(groveConfigPath(FILE, home)).toBe(groveFile());
+  });
+});
+
+describe("resolveConfigFile — cortex-first, grove-fallback", () => {
+  test("returns cortex path + source=cortex when cortex file exists", () => {
+    mkdirSync(join(home, ".config", "cortex"), { recursive: true });
+    writeFileSync(cortexFile(), "from-cortex");
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(cortexFile());
+    expect(r.source).toBe("cortex");
+  });
+
+  test("falls back to grove path + source=grove when only grove exists", () => {
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(groveFile(), "from-grove");
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(groveFile());
+    expect(r.source).toBe("grove");
+  });
+
+  test("cortex wins when BOTH exist (cortex-first precedence)", () => {
+    mkdirSync(join(home, ".config", "cortex"), { recursive: true });
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(cortexFile(), "from-cortex");
+    writeFileSync(groveFile(), "from-grove");
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(cortexFile());
+    expect(r.source).toBe("cortex");
+  });
+
+  test("targets cortex path + source=default when neither exists (write target)", () => {
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(cortexFile());
+    expect(r.source).toBe("default");
+  });
+});
+
+describe("migrateGroveConfigFile — auto-migrate preserving mode", () => {
+  test("copies grove → cortex when only grove exists, preserving 0o600", () => {
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(groveFile(), "secret-bytes", { mode: 0o600 });
+    chmodSync(groveFile(), 0o600); // umask-proof the fixture
+
+    const migrated = migrateGroveConfigFile(FILE, home);
+
+    expect(migrated).toBe(true);
+    expect(existsSync(cortexFile())).toBe(true);
+    expect(readFileSync(cortexFile(), "utf-8")).toBe("secret-bytes");
+    const mode = statSync(cortexFile()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("preserves a non-secret 0o644 mode too", () => {
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(groveFile(), "plain", { mode: 0o644 });
+    chmodSync(groveFile(), 0o644);
+
+    migrateGroveConfigFile(FILE, home);
+
+    const mode = statSync(cortexFile()).mode & 0o777;
+    expect(mode).toBe(0o644);
+  });
+
+  test("no-op (returns false) when cortex already exists — never clobbers", () => {
+    mkdirSync(join(home, ".config", "cortex"), { recursive: true });
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(cortexFile(), "cortex-canonical");
+    writeFileSync(groveFile(), "grove-stale");
+
+    const migrated = migrateGroveConfigFile(FILE, home);
+
+    expect(migrated).toBe(false);
+    expect(readFileSync(cortexFile(), "utf-8")).toBe("cortex-canonical");
+  });
+
+  test("no-op (returns false) when neither exists", () => {
+    expect(migrateGroveConfigFile(FILE, home)).toBe(false);
+    expect(existsSync(cortexFile())).toBe(false);
+  });
+});

--- a/src/common/config/__tests__/config-path.test.ts
+++ b/src/common/config/__tests__/config-path.test.ts
@@ -108,6 +108,23 @@ describe("migrateGroveConfigFile — auto-migrate preserving mode", () => {
     expect(mode).toBe(0o644);
   });
 
+  // The secret-at-rest contract, named explicitly: cloud-credentials.txt MUST
+  // land 0o600 on the cortex side — copyFileSync applies the umask, so the
+  // chmod re-assertion is what keeps the secret from being widened on migrate.
+  test("cloud-credentials.txt (a secret) stays 0o600 across the grove→cortex migrate", () => {
+    const SECRET = "cloud-credentials.txt";
+    const groveSecret = join(home, ".config", "grove", SECRET);
+    const cortexSecret = join(home, ".config", "cortex", SECRET);
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(groveSecret, "TOKEN=redacted", { mode: 0o600 });
+    chmodSync(groveSecret, 0o600); // umask-proof the fixture
+
+    migrateGroveConfigFile(SECRET, home);
+
+    expect(existsSync(cortexSecret)).toBe(true);
+    expect(statSync(cortexSecret).mode & 0o777).toBe(0o600);
+  });
+
   test("no-op (returns false) when cortex already exists — never clobbers", () => {
     mkdirSync(join(home, ".config", "cortex"), { recursive: true });
     mkdirSync(join(home, ".config", "grove"), { recursive: true });

--- a/src/common/config/config-path.ts
+++ b/src/common/config/config-path.ts
@@ -1,0 +1,124 @@
+/**
+ * GV-1 (cortex#1076, EPIC cortex#1075 Phase 1) — config-FILE path resolver.
+ *
+ * The metafactory config directory is migrating from `~/.config/grove/` to
+ * `~/.config/cortex/`. This module is the single, shared place that resolves a
+ * config FILE (cli.yaml, bot.yaml, cloud-credentials.txt, mission-control.yaml,
+ * …) under that directory with **cortex-first / grove-fallback** precedence
+ * during the transition window.
+ *
+ * Precedence (read):
+ *   1. `~/.config/cortex/<file>`  — canonical; used if it exists.
+ *   2. `~/.config/grove/<file>`   — legacy fallback; used only if the cortex
+ *      copy is absent AND the grove copy exists.
+ *   3. `~/.config/cortex/<file>`  — the write/default target when NEITHER
+ *      exists (a fresh install writes cortex-side, never grove-side).
+ *
+ * SCOPE — this owns config FILES ONLY. It deliberately does NOT touch the live
+ * runtime state the same directory also holds (`state/`, `networks/`, `logs/`,
+ * `personas/`). Renaming those is a later, separately-sequenced step (the
+ * running daemon reads/writes them live); doing it here would disrupt a
+ * running stack. See cortex#1075.
+ *
+ * Also out of scope: the `GROVE_*` → `CORTEX_*` ENV-VAR tier (separate shim,
+ * cortex#774) and any `grove`-as-guild-name / `the-metafactory/grove` repo refs.
+ */
+
+import { copyFileSync, existsSync, mkdirSync, statSync, chmodSync } from "fs";
+import { dirname, join } from "path";
+
+/** The canonical config directory name. */
+export const CORTEX_CONFIG_DIRNAME = "cortex";
+/** The legacy config directory name (read-fallback only during transition). */
+export const GROVE_CONFIG_DIRNAME = "grove";
+
+/** Which directory a resolved path came from. */
+export type ConfigSource = "cortex" | "grove" | "default";
+
+export interface ResolvedConfigFile {
+  /** Absolute path to use. */
+  path: string;
+  /**
+   * Where it resolved:
+   *  - `cortex`  — the canonical file exists.
+   *  - `grove`   — only the legacy file exists (fallback in effect).
+   *  - `default` — neither exists; `path` is the cortex write target.
+   */
+  source: ConfigSource;
+}
+
+function homeDir(home?: string): string {
+  return home ?? process.env.HOME ?? "~";
+}
+
+/** Build `~/.config/cortex/<filename>` (canonical). */
+export function cortexConfigPath(filename: string, home?: string): string {
+  return join(homeDir(home), ".config", CORTEX_CONFIG_DIRNAME, filename);
+}
+
+/** Build `~/.config/grove/<filename>` (legacy / fallback). */
+export function groveConfigPath(filename: string, home?: string): string {
+  return join(homeDir(home), ".config", GROVE_CONFIG_DIRNAME, filename);
+}
+
+/**
+ * Resolve a config FILE with cortex-first / grove-fallback precedence.
+ *
+ * Never throws on a missing file: when neither copy exists it returns the
+ * cortex path with `source: "default"` so a caller writing a fresh config
+ * lands it cortex-side.
+ *
+ * @param filename Bare filename under the config dir, e.g. `"cli.yaml"`.
+ * @param home Override for `$HOME` (tests). Defaults to `process.env.HOME`.
+ */
+export function resolveConfigFile(filename: string, home?: string): ResolvedConfigFile {
+  const cortex = cortexConfigPath(filename, home);
+  if (existsSync(cortex)) return { path: cortex, source: "cortex" };
+
+  const grove = groveConfigPath(filename, home);
+  if (existsSync(grove)) return { path: grove, source: "grove" };
+
+  return { path: cortex, source: "default" };
+}
+
+/**
+ * Convenience: the path to READ a config file from (cortex if present, else
+ * grove if present, else the cortex path which a caller will find absent).
+ */
+export function resolveConfigFilePath(filename: string, home?: string): string {
+  return resolveConfigFile(filename, home).path;
+}
+
+/**
+ * Auto-migrate a legacy grove-side config FILE to its cortex location,
+ * **preserving the file mode**.
+ *
+ * Idempotent and non-destructive:
+ *   - if the cortex copy already exists → no-op, returns `false` (the cortex
+ *     copy is canonical; we never clobber it with a stale grove copy);
+ *   - if only the grove copy exists → copies it to cortex with the SAME mode
+ *     (so a `chmod 600` secret such as `cloud-credentials.txt` stays 600 and
+ *     is never widened), returns `true`;
+ *   - if neither exists → no-op, returns `false`.
+ *
+ * Mode preservation is explicit: `copyFileSync` does NOT preserve mode (the
+ * destination is created with the process umask), so we re-apply the source
+ * mode bits with `chmodSync`.
+ *
+ * @returns whether a migration copy was performed.
+ */
+export function migrateGroveConfigFile(filename: string, home?: string): boolean {
+  const cortex = cortexConfigPath(filename, home);
+  if (existsSync(cortex)) return false; // cortex copy is canonical — never clobber
+
+  const grove = groveConfigPath(filename, home);
+  if (!existsSync(grove)) return false; // nothing to migrate
+
+  const mode = statSync(grove).mode & 0o777;
+  mkdirSync(dirname(cortex), { recursive: true });
+  copyFileSync(grove, cortex);
+  // copyFileSync applies the umask, not the source mode — re-assert it so a
+  // 0o600 secret is preserved exactly (and never widened) on the cortex copy.
+  if (process.platform !== "win32") chmodSync(cortex, mode);
+  return true;
+}

--- a/src/runner/__tests__/security-preamble.test.ts
+++ b/src/runner/__tests__/security-preamble.test.ts
@@ -48,9 +48,10 @@ describe("buildSecurityPreamble", () => {
     expect(preamble).toContain("/home/user/.config/cortex");
   });
 
-  test("defaults to ~/.config/grove when no configPath (pre-MIG-8 cascade — GROVE_* → CORTEX_* namespace migration owns this)", () => {
+  test("defaults to ~/.config/cortex when no configPath (GV-1 cortex#1076 — config-path migration)", () => {
     const preamble = buildSecurityPreamble(makeConfig());
-    expect(preamble).toContain("~/.config/grove");
+    expect(preamble).toContain("~/.config/cortex");
+    expect(preamble).not.toContain("~/.config/grove");
   });
 
   test("includes filesystem restriction when allowedDirs configured", () => {

--- a/src/runner/security-preamble.ts
+++ b/src/runner/security-preamble.ts
@@ -99,12 +99,13 @@ export function buildSecurityPreamble(config: AgentConfig, configPath?: string, 
 
   // Config immutability — the agent must never modify its own configuration.
   // This is a trust boundary: the entity being constrained must not control its own constraints.
-  // Note: the `~/.config/grove` default path is owned by the separate GROVE_* → CORTEX_*
-  // namespace migration (retires at MIG-8); in practice the runtime always passes a
-  // resolved `configPath` so the default is only seen by tests.
+  // Note: in practice the runtime always passes a resolved `configPath` so this
+  // default is only seen by tests; GV-1 (cortex#1076) points it at the canonical
+  // cortex config dir. (Distinct from the GROVE_* → CORTEX_* env-var migration,
+  // cortex#774.)
   const configDir = configPath
     ? configPath.replace(/\/[^/]+$/, "")
-    : "~/.config/grove";
+    : "~/.config/cortex";
   rules.push(
     `CONFIG IMMUTABILITY: You MUST NOT read, write, edit, or delete cortex.yaml or any file in the cortex config directory (${configDir}). ` +
     `This includes using any tool (Write, Edit, Bash, etc.) to modify, overwrite, move, copy, or remove cortex.yaml or files in ${configDir}. ` +

--- a/src/statusline/__tests__/cortex-status-config-path.test.ts
+++ b/src/statusline/__tests__/cortex-status-config-path.test.ts
@@ -1,0 +1,69 @@
+/**
+ * GV-1 (cortex#1076) — cortex-status.sh config-path precedence.
+ *
+ * The statusline helper reads bot.yaml cortex-first with a grove fallback. We
+ * drive the script with a controlled $HOME and a distinguishing `api.mode`
+ * (cloud vs local) in each candidate bot.yaml, then assert which one the
+ * rendered Mode/Network reflects.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const SCRIPT = join(import.meta.dir, "..", "cortex-status.sh");
+let home: string;
+
+function writeBotYaml(dir: "cortex" | "grove", mode: "cloud" | "local") {
+  const d = join(home, ".config", dir);
+  mkdirSync(d, { recursive: true });
+  // `api.mode` drives the rendered Mode/Network — a clean, non-deprecated
+  // discriminator for WHICH bot.yaml the script read.
+  writeFileSync(join(d, "bot.yaml"), `api:\n  mode: ${mode}\n`);
+}
+
+/** Source the script in `normal` MODE with GROVE_CHANNEL set, capture stdout. */
+async function runStatus(): Promise<string> {
+  // Strip any GROVE_* inherited from the runner's shell — the render prefers
+  // GROVE_AGENT_NAME over the bot.yaml operatorId, which would mask the field
+  // we're using to detect WHICH bot.yaml was read.
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GROVE_") && !k.startsWith("CORTEX_") && v !== undefined) env[k] = v;
+  }
+  env.HOME = home;
+  env.GROVE_CHANNEL = "ch";
+  env.MODE = "normal";
+  const proc = Bun.spawn(["bash", "-c", `source "${SCRIPT}"`], {
+    env,
+    stdout: "pipe",
+  });
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  return out;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "gv1-status-"));
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("cortex-status.sh — cortex-first, grove-fallback", () => {
+  test("reads grove bot.yaml when only grove exists (mode: cloud → Network: metafactory)", async () => {
+    writeBotYaml("grove", "cloud");
+    const out = await runStatus();
+    expect(out).toContain("metafactory");
+  });
+
+  test("reads cortex bot.yaml when both exist — cortex-first (cortex: local, grove: cloud)", async () => {
+    writeBotYaml("grove", "cloud"); // would render Network: metafactory if read
+    writeBotYaml("cortex", "local"); // cortex wins → Network: local
+    const out = await runStatus();
+    expect(out).toContain("Network:");
+    expect(out).toContain("local");
+    expect(out).not.toContain("metafactory");
+  });
+});

--- a/src/statusline/cortex-status.sh
+++ b/src/statusline/cortex-status.sh
@@ -11,10 +11,10 @@
 # Requires: GROVE_CHANNEL set (e.g., via cldyo-live).
 # Without GROVE_CHANNEL, this extension is a no-op (returns silently).
 #
-# NOTE: env-var and config-path names are intentionally left as `GROVE_*` /
-# `~/.config/grove/` to preserve 1:1 behaviour with grove's installed helper
-# during the MIG-7 cutover window. A follow-up will rename them to `CORTEX_*`
-# once cldyo-live and the bot are emitting the new contract.
+# NOTE: the bot.yaml config path is read cortex-first with a `~/.config/grove/`
+# fallback during the GV-1 transition (cortex#1076). The `GROVE_*` ENV VARS are
+# left as-is — they are owned by the separate GROVE_* → CORTEX_* env-var shim
+# (cortex#774) and are out of scope for GV-1.
 #
 # Install: arc lays this file down at $PAI_DIR/cortex-status.sh; the cortex
 # statusline-command.sh sources it explicitly.
@@ -34,8 +34,12 @@ CORTEX_LOCAL='\033[38;2;251;191;36m'    # Amber-400
 CORTEX_RESET='\033[0m'
 
 # ─── Read bot config ──────────────────────────────────────────────────────────
-# Path stays `~/.config/grove/` during cutover (see header note).
-CORTEX_CONFIG="${HOME}/.config/grove/bot.yaml"
+# cortex-first, grove-fallback (GV-1, cortex#1076 — see header note).
+if [ -f "${HOME}/.config/cortex/bot.yaml" ]; then
+    CORTEX_CONFIG="${HOME}/.config/cortex/bot.yaml"
+else
+    CORTEX_CONFIG="${HOME}/.config/grove/bot.yaml"
+fi
 cortex_mode=""
 cortex_network=""
 cortex_operator=""

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -7,6 +7,7 @@ import { parse as parseYaml } from "yaml";
 import { join } from "path";
 import { homedir } from "os";
 import type { Config, LogLevel } from "./types";
+import { resolveConfigFilePath } from "../../common/config/config-path";
 
 const VALID_LOG_LEVELS: ReadonlySet<LogLevel> = new Set([
   "debug",
@@ -51,9 +52,10 @@ export const DEFAULT_CONFIG: Config = {
  * - If the file is malformed YAML, throws with a clear message.
  */
 export function loadConfig(configPath?: string): Readonly<Config> {
+  // GV-1: cortex-first, grove-fallback for the default mission-control.yaml.
   const resolvedPath =
     configPath ??
-    join(homedir(), ".config", "grove", "mission-control.yaml");
+    resolveConfigFilePath("mission-control.yaml");
 
   if (!existsSync(resolvedPath)) {
     return Object.freeze({ ...DEFAULT_CONFIG });


### PR DESCRIPTION
## GV-1 — config-path migration (EPIC #1075 Phase 1)

Migrate every code-hardcoded `~/.config/grove/` **config FILE** path to `~/.config/cortex/`, read **cortex-first with a grove fallback** during the transition, and **auto-migrate on write preserving file mode**.

### Resolver shape (cortex-first / grove-fallback)
New shared module `src/common/config/config-path.ts`:

- `resolveConfigFile(name)` → `{ path, source }` where precedence is:
  1. `~/.config/cortex/<name>` if it exists (`source: cortex`)
  2. else `~/.config/grove/<name>` if it exists (`source: grove`)
  3. else `~/.config/cortex/<name>` as the write/default target (`source: default`)
- `resolveConfigFilePath(name)` — convenience returning just the path.
- `cortexConfigPath(name)` / `groveConfigPath(name)` — path builders.

### Auto-migrate + mode preservation
`migrateGroveConfigFile(name)`:
- no-op (returns `false`) if the cortex copy already exists — **never clobbers** the canonical copy with a stale grove one;
- if only the grove copy exists, copies grove→cortex and **re-applies the source mode** with `chmodSync` (because `copyFileSync` applies the umask, not the source mode) — a `chmod 600` secret like `cloud-credentials.txt` stays **600 and is never widened**;
- idempotent; skips the chmod on win32 (NTFS ACLs).

### Sites changed
| File | Change |
|------|--------|
| `src/cli/discord/lib/config.ts` | `cli.yaml`: read cortex-first/grove-fallback; `saveConfig` migrates legacy copy then writes cortex-side |
| `src/cli/cortex/commands/cloud.ts` | `bot.yaml` read + `DEFAULT_CONFIG_PATH` (resolver); `cloud-credentials.txt` write migrates+writes cortex-side `@600`; cred read (resolver); help/prompt strings |
| `src/surface/mc/config.ts` | `mission-control.yaml` default path (resolver) |
| `src/runner/security-preamble.ts` | config-immutability default dir `~/.config/grove` → `~/.config/cortex` |
| `src/cli/cldyo-live` | bash cortex-first/grove-fallback for `bot.yaml` |
| `src/statusline/cortex-status.sh` | bash cortex-first/grove-fallback for `bot.yaml` |
| `src/cli/discord/skill/SKILL.md` | doc updated |

### Deferred (NOT in this PR — would disrupt the running daemon)
GV-1 is the config **FILES** only. The live **state dirs** the same config directory also holds — `state/`, `networks/`, `logs/`, `personas/` — and the `~/.local/share/grove/mission-control.db` are **deliberately untouched**: the running daemon reads/writes them live, so relocating them is a later, separately-sequenced step.

Also out of scope by design: the `GROVE_*` → `CORTEX_*` **env-var** shim (#774) and any `grove`-as-guild-name / `the-metafactory/grove` repo references.

### Tests (TDD)
- `src/common/config/__tests__/config-path.test.ts` — 10 cases: path builders; cortex-path read; grove-fallback; cortex-wins-when-both; cortex default-target when neither; auto-migrate preserving `0o600` and `0o644`; no-clobber when cortex exists; no-op when neither exists.
- `src/statusline/__tests__/cortex-status-config-path.test.ts` — 2 cases: bash precedence (grove-only read; cortex-first when both).
- Updated `security-preamble.test.ts` to assert the cortex default.
- **12 new test cases.**

### Gates
- `tsc --noEmit` — clean
- `eslint --quiet src/` — clean
- `bun test src/` — **6910 pass / 0 fail** (2 skip)
- `check-carveouts.sh` — PASS (grove-path strings are not deprecated-vocab terms; the gate flags `operator`/`BotConfig`/`broadcast`/`persona` only)

Closes #1076
Refs #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)