### PR TITLE
fix(mattermost+brain): chunk long posts; pause task timeout during human gates

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.19.1"
+version: "5.20.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/src/adapters/mattermost/__tests__/post-chunking.test.ts
+++ b/src/adapters/mattermost/__tests__/post-chunking.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression: a long Mattermost post (a composed flow's YAML, a big advisory)
+ * was DROPPED with HTTP 500 "app.post.save.app_error" — the MM save layer 500s
+ * well below the API's MaxPostSize. postReply now chunks under that ceiling, so
+ * the content survives as a thread instead of vanishing (the symptom: Yarrow's
+ * compose ack showed "Run this flow?" with no flow YAML/name above it).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { splitForMattermost, sanitizeForMattermost } from "../poller";
+
+const MM_MAX_CHARS = 3800;
+
+describe("splitForMattermost", () => {
+  test("short message → single chunk, unchanged", () => {
+    expect(splitForMattermost("hello")).toEqual(["hello"]);
+  });
+
+  test("long message → multiple chunks, each under the ceiling", () => {
+    const long = Array.from({ length: 400 }, (_, i) => `line ${i}: ${"x".repeat(40)}`).join("\n");
+    expect(long.length).toBeGreaterThan(MM_MAX_CHARS);
+    const chunks = splitForMattermost(long);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(MM_MAX_CHARS);
+    // No content lost (modulo the \n join boundaries).
+    expect(chunks.join("\n").replace(/\n+/g, "\n")).toContain("line 399");
+  });
+
+  test("a single oversized line (no newlines) is hard-sliced under the ceiling", () => {
+    const oneLine = "y".repeat(MM_MAX_CHARS * 3 + 17);
+    const chunks = splitForMattermost(oneLine);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(MM_MAX_CHARS);
+    expect(chunks.join("").length).toBe(oneLine.length); // nothing dropped
+  });
+});
+
+describe("sanitizeForMattermost", () => {
+  test("strips save-rejected control chars, keeps newlines and tabs", () => {
+    const dirty = "a\u0001b\u0007cde\n\tkeep\u007f";
+    const clean = sanitizeForMattermost(dirty);
+    expect(clean).toBe("abcde\n\tkeep");
+  });
+});

--- a/src/adapters/mattermost/poller.ts
+++ b/src/adapters/mattermost/poller.ts
@@ -114,8 +114,80 @@ async function fetchUserName(
   }
 }
 
+// Mattermost save-layer ceiling: the v4 API validates MaxPostSize (16383) but
+// the DB SAVE 500s ("app.post.save.app_error") well below that — ~4000 chars
+// (binary-searched against securechat-test). A long single post (a composed
+// flow's YAML, a big advisory, multi-line step output) is therefore DROPPED
+// with a 500 unless we chunk under the ceiling. Chunk into a root post + thread
+// replies so the content survives. Mirrors A_FETCH/A_NOTIFY's measured limits.
+const MM_MAX_CHARS = 3800;
+const MM_MAX_BYTES = 15000;
+const utf8Len = (s: string): number => new TextEncoder().encode(s).length;
+
+/** Strip control chars Postgres/Mattermost reject at save time (keep \n, \t). */
+export function sanitizeForMattermost(message: string): string {
+  // eslint-disable-next-line no-control-regex
+  return message.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "");
+}
+
+/** Split a message into chunks under both char and byte ceilings, preferring line boundaries. */
+export function splitForMattermost(message: string): string[] {
+  const fits = (s: string): boolean => s.length <= MM_MAX_CHARS && utf8Len(s) <= MM_MAX_BYTES;
+  if (fits(message)) return [message];
+  const chunks: string[] = [];
+  let current = "";
+  for (const line of message.split("\n")) {
+    // Hard-slice a single oversized line (the byte check keeps multibyte slices safe).
+    const pieces: string[] = [];
+    let rest = line;
+    while (!fits(rest)) {
+      let cut = Math.min(rest.length, MM_MAX_CHARS);
+      while (cut > 1 && !fits(rest.slice(0, cut))) cut = Math.floor(cut / 2);
+      pieces.push(rest.slice(0, cut));
+      rest = rest.slice(cut);
+    }
+    pieces.push(rest);
+    for (const piece of pieces) {
+      const candidate = current ? `${current}\n${piece}` : piece;
+      if (current && !fits(candidate)) {
+        chunks.push(current);
+        current = piece;
+      } else {
+        current = candidate;
+      }
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks.length > 0 ? chunks : [message];
+}
+
+/** POST one chunk; returns the created post id (or null on failure). */
+async function postOne(
+  channelId: string,
+  message: string,
+  rootId: string | undefined,
+  apiUrl: string,
+  apiToken: string,
+): Promise<string | null> {
+  const body: Record<string, string> = { channel_id: channelId, message };
+  if (rootId) body.root_id = rootId;
+  const res = await fetch(`${apiUrl}/api/v4/posts`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    console.error(`mattermost-poller: post failed: ${res.status} ${await res.text()}`);
+    return null;
+  }
+  const created = (await res.json()) as Record<string, unknown>;
+  return typeof created.id === "string" ? created.id : null;
+}
+
 /**
- * Post a reply to a Mattermost channel (or thread).
+ * Post a reply to a Mattermost channel (or thread). A message over the MM
+ * save-layer ceiling is split into a root post + thread replies (so a long
+ * flow YAML / advisory is never dropped with a 500); returns the ROOT post id.
  */
 export async function postReply(
   channelId: string,
@@ -125,27 +197,20 @@ export async function postReply(
   apiToken: string
 ): Promise<string | null> {
   try {
-    const body: Record<string, string> = {
-      channel_id: channelId,
-      message,
-    };
-    if (rootId) body.root_id = rootId;
-
-    const res = await fetch(`${apiUrl}/api/v4/posts`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      console.error(`mattermost-poller: post failed: ${res.status} ${await res.text()}`);
-      return null;
+    const chunks = splitForMattermost(sanitizeForMattermost(message));
+    // The chunks after the first reply into the thread; if the caller gave a
+    // rootId, everything stays in that thread, otherwise the first post becomes
+    // the thread root.
+    let thread = rootId;
+    let firstId: string | null = null;
+    for (const [i, chunk] of chunks.entries()) {
+      const id = await postOne(channelId, chunk, thread, apiUrl, apiToken);
+      if (i === 0) {
+        firstId = id;
+        if (thread === undefined && id) thread = id; // root the thread at chunk 1
+      }
     }
-    const created = await res.json() as Record<string, unknown>;
-    return typeof created.id === "string" ? created.id : null;
+    return firstId;
   } catch (error) {
     console.error("mattermost-poller: post error:", error);
     return null;

--- a/src/brain/__tests__/daemon-brain-host.test.ts
+++ b/src/brain/__tests__/daemon-brain-host.test.ts
@@ -210,7 +210,7 @@ describe("DaemonBrainHost — round-trip", () => {
     await until(() => brain.lastTask()?.task_id === "g1");
 
     // Open a gate; the host must NOT fail the task during the 450ms wait.
-    brain.emit(JSON.stringify({ v: 1, type: "ask_principal", task_id: "g1", gate: "operator-ack", prompt: "Run?" }));
+    brain.emit(JSON.stringify({ v: 1, type: "ask_principal", task_id: "g1", gate: "run-ack", prompt: "Run?" }));
     await until(() => gateResolved, 2000);
     // Gate answered → brain completes the (re-armed) task.
     brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "g1", status: "complete" }));

--- a/src/brain/__tests__/daemon-brain-host.test.ts
+++ b/src/brain/__tests__/daemon-brain-host.test.ts
@@ -184,6 +184,42 @@ describe("DaemonBrainHost — round-trip", () => {
     await host.stop();
   });
 
+  test("an open ask_principal gate PAUSES the per-task timeout — no orphan (cortex#1073)", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const host = new DaemonBrainHost({
+      agentId: "yarrow",
+      run: "bun brain.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      taskTimeoutMs: 150, // deliberately shorter than the gate wait below
+    });
+    await host.start();
+
+    let gateResolved = false;
+    const hooks = makeHooks({
+      onAskPrincipal: async (): Promise<{ verdict: GateVerdictValue; principal: string }> => {
+        // A thinking human holds the gate open far longer than taskTimeoutMs.
+        await new Promise((r) => setTimeout(r, 450));
+        gateResolved = true;
+        return { verdict: "pass", principal: "jc" };
+      },
+    });
+    const runP = host.runTask(makeTask({ task_id: "g1" }), hooks);
+    await until(() => brain.lastTask()?.task_id === "g1");
+
+    // Open a gate; the host must NOT fail the task during the 450ms wait.
+    brain.emit(JSON.stringify({ v: 1, type: "ask_principal", task_id: "g1", gate: "operator-ack", prompt: "Run?" }));
+    await until(() => gateResolved, 2000);
+    // Gate answered → brain completes the (re-armed) task.
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "g1", status: "complete" }));
+
+    const result = await runP;
+    expect(result.result.status).toBe("complete"); // NOT "failed"/timeout
+    await host.stop();
+  });
+
   test("an effect for an unknown task_id is refused with effect_rejected", async () => {
     const brain = new FakeBrain();
     const { transport } = makeFakeTransport([brain]);

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -837,6 +837,17 @@ export class DaemonBrainHost {
         return;
       }
       case "ask_principal": {
+        // PAUSE the per-task liveness timeout while a human gate is open. The
+        // timeout exists to fail a HUNG BRAIN, not a thinking human — an open
+        // `ask_principal` is legitimately unbounded by brain liveness, and the
+        // gate has its own deadline (SurfacePrincipalGate.timeoutMs). Without
+        // this, the host timed the task out mid-gate, dropped the verdict
+        // (record.settled), and the principal's reply orphaned (cortex#1073).
+        // Re-arm for the remaining deterministic work once all gates close.
+        if (record.openGates === 0 && record.timeoutTimer !== undefined) {
+          clearTimeout(record.timeoutTimer);
+          record.timeoutTimer = undefined;
+        }
         record.openGates += 1;
         try {
           const verdict = await record.hooks.onAskPrincipal(e);
@@ -856,6 +867,13 @@ export class DaemonBrainHost {
           );
         } finally {
           record.openGates = Math.max(0, record.openGates - 1);
+          // Last gate closed and the task is still live → re-arm the liveness
+          // timeout for the remaining (deterministic) steps.
+          if (record.openGates === 0 && !record.settled && record.timeoutTimer === undefined) {
+            record.timeoutTimer = setTimeout(() => {
+              void this.failTask(record, "timeout");
+            }, this.taskTimeoutMs);
+          }
         }
         return;
       }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2553,6 +2553,12 @@ export async function startCortex(
         liveSurfaces,
         renderer: makeDispatchPostRenderer({ runtime, source: systemEventSource }),
         replySource: gateReplyRouter,
+        // 10 min to review + approve a gate (e.g. a composed flow's operator-ack
+        // or an analyst gate). The host per-task liveness timeout is PAUSED while
+        // a gate is open (daemon-brain-host ask_principal), so this is the real
+        // human-reply window — not racing the 5-min task timeout that used to
+        // orphan it (cortex#1073).
+        timeoutMs: 600_000,
       })
     : undefined;
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2553,7 +2553,7 @@ export async function startCortex(
         liveSurfaces,
         renderer: makeDispatchPostRenderer({ runtime, source: systemEventSource }),
         replySource: gateReplyRouter,
-        // 10 min to review + approve a gate (e.g. a composed flow's operator-ack
+        // 10 min to review + approve a gate (e.g. a composed flow's run-approval
         // or an analyst gate). The host per-task liveness timeout is PAUSED while
         // a gate is open (daemon-brain-host ask_principal), so this is the real
         // human-reply window — not racing the 5-min task timeout that used to


### PR DESCRIPTION
Two bugs that together broke Yarrow's compose-flow demo (a composed flow's ack showed "Run this flow?" with no flow above it, and the gate then orphaned):

**1. Long MM posts dropped (HTTP 500 `app.post.save.app_error`).** The MM save layer 500s well below the API's MaxPostSize (~4000 chars). A composed flow's YAML / big advisory / multi-line step output was dropped. `postReply` now chunks under the ceiling into a root post + thread replies (the same limits A_NOTIFY_MATTERMOST measured).

**2. Human gates orphaned at 5 min (cortex#1073).** The per-task liveness timeout (300s) fired while an `ask_principal` gate was legitimately open, dropped the verdict, and the principal's reply spawned a new task. The host now **pauses** that timeout while `openGates>0` (it guards a hung brain, not a thinking human) and re-arms it when gates close. `SurfacePrincipalGate` window bumped to 10 min; yarrow brain ceiling → 11 min (outer bound).

## Tests
`post-chunking` (split/sanitize) + a gate-pause regression in `daemon-brain-host.test.ts`. Full suite 1514+ green. v5.19.1→v5.20.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)