### PR TITLE
feat(mattermost): inline file content so the brain can read uploads

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.20.0"
+version: "5.21.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -443,6 +443,7 @@ export class MattermostAdapter implements PlatformAdapter {
       filename: i.originalName,
       contentType: i.contentType,
       size: i.size,
+      ...(i.content !== undefined && { content: i.content }),
     }));
   }
 

--- a/src/adapters/mattermost/poller.ts
+++ b/src/adapters/mattermost/poller.ts
@@ -245,12 +245,36 @@ async function fetchChannelPostsSince(
  * Fetch file metadata from Mattermost for attachment processing.
  * Returns AttachmentInfo-compatible objects.
  */
+type MattermostFileInfo = {
+  originalName: string;
+  url: string;
+  contentType: string;
+  size: number;
+  source: "mattermost";
+  /** Base64 file bytes, INLINED for text-like files under the cap. Mattermost
+   *  file URLs need the bot's Bearer token to download — the brain (and pulse's
+   *  A_INGEST_ATTACHMENT) can't auth, so the adapter (which HAS the token)
+   *  fetches the bytes here and ships them inline. Discord uses public CDN URLs
+   *  and never needs this. */
+  content?: string;
+};
+
+/** Text-like by MIME or extension — only these are worth inlining for IOC work. */
+function isInlineableText(name: string, mime: string): boolean {
+  const m = mime.toLowerCase();
+  if (m.startsWith("text/") || m === "message/rfc822" || m === "application/json") return true;
+  return /\.(eml|txt|csv|log|json|md|ics)$/i.test(name);
+}
+
+/** Cap on inlined file bytes — keeps the brain task envelope well under NATS limits. */
+const MAX_INLINE_BYTES = 512 * 1024;
+
 export async function fetchMattermostFileInfos(
   fileIds: string[],
   apiUrl: string,
   apiToken: string
-): Promise<{ originalName: string; url: string; contentType: string; size: number; source: "mattermost" }[]> {
-  const results: { originalName: string; url: string; contentType: string; size: number; source: "mattermost" }[] = [];
+): Promise<MattermostFileInfo[]> {
+  const results: MattermostFileInfo[] = [];
 
   for (const fileId of fileIds) {
     try {
@@ -260,12 +284,35 @@ export async function fetchMattermostFileInfos(
       if (!res.ok) continue;
 
       const info = await res.json() as { name?: string; mime_type?: string; size?: number };
+      const name = info.name ?? "unknown";
+      const contentType = info.mime_type ?? "application/octet-stream";
+      const size = info.size ?? 0;
+
+      // Inline text-like bytes (authenticated fetch) so the brain doesn't have
+      // to — a failed inline is non-fatal (the URL still travels as a fallback).
+      let content: string | undefined;
+      if (isInlineableText(name, contentType) && size > 0 && size <= MAX_INLINE_BYTES) {
+        try {
+          const fres = await fetch(`${apiUrl}/api/v4/files/${fileId}`, {
+            headers: { Authorization: `Bearer ${apiToken}` },
+          });
+          if (fres.ok) {
+            content = Buffer.from(new Uint8Array(await fres.arrayBuffer())).toString("base64");
+          } else {
+            console.warn(`mattermost-poller: file fetch ${fileId} → HTTP ${fres.status} (will ship URL only)`);
+          }
+        } catch (err) {
+          console.warn("mattermost-poller: file byte fetch failed:", fileId, err instanceof Error ? err.message : err);
+        }
+      }
+
       results.push({
-        originalName: info.name ?? "unknown",
+        originalName: name,
         url: `${apiUrl}/api/v4/files/${fileId}`,
-        contentType: info.mime_type ?? "application/octet-stream",
-        size: info.size ?? 0,
+        contentType,
+        size,
         source: "mattermost",
+        ...(content !== undefined && { content }),
       });
     } catch (err) {
       console.warn("mattermost-poller: failed to fetch file info:", fileId, err instanceof Error ? err.message : err);

--- a/src/adapters/mattermost/poller.ts
+++ b/src/adapters/mattermost/poller.ts
@@ -245,7 +245,7 @@ async function fetchChannelPostsSince(
  * Fetch file metadata from Mattermost for attachment processing.
  * Returns AttachmentInfo-compatible objects.
  */
-type MattermostFileInfo = {
+interface MattermostFileInfo {
   originalName: string;
   url: string;
   contentType: string;
@@ -257,7 +257,7 @@ type MattermostFileInfo = {
    *  fetches the bytes here and ships them inline. Discord uses public CDN URLs
    *  and never needs this. */
   content?: string;
-};
+}
 
 /** Text-like by MIME or extension — only these are worth inlining for IOC work. */
 function isInlineableText(name: string, mime: string): boolean {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -60,6 +60,11 @@ export interface InboundAttachment {
   filename: string;
   contentType?: string;
   size?: number;
+  /** Base64 file bytes, INLINED by the adapter when the surface needs auth to
+   *  download (Mattermost) — lets the brain consume the file without the bot
+   *  token or a host-allowlisted public URL. Absent for public-CDN surfaces
+   *  (Discord), which travel by URL. */
+  content?: string;
 }
 
 /** Result of access control check */

--- a/src/bus/__tests__/brain-consumer.test.ts
+++ b/src/bus/__tests__/brain-consumer.test.ts
@@ -298,6 +298,19 @@ describe("brain-consumer helpers", () => {
     expect(safeAttachmentRefs("mattermost", [{ filename: "x", url: "https://files.mm/x" }])).toEqual([]);
   });
 
+  test("safeAttachmentRefs: inlined content bypasses the host allowlist (no fetch = no SSRF)", () => {
+    // Mattermost: bytes the adapter already fetched (with the bot token) and
+    // base64-inlined are forwarded REGARDLESS of host — the brain reads the
+    // bytes, never fetches the (auth-gated, non-allowlisted) URL.
+    const refs = safeAttachmentRefs("mattermost", [
+      { filename: "phish.eml", contentType: "message/rfc822", url: "https://securechat.example/api/v4/files/abc", content: "YmFzZTY0" },
+      { filename: "nocontent.eml", url: "https://securechat.example/api/v4/files/def" }, // no inline → dropped (off-allowlist)
+    ]);
+    expect(refs).toEqual([
+      { name: "phish.eml", contentType: "message/rfc822", url: "https://securechat.example/api/v4/files/abc", content: "YmFzZTY0" },
+    ]);
+  });
+
   test("brainReasonToDispatchReason: not_now carries retry_after_ms", () => {
     expect(
       brainReasonToDispatchReason({ kind: "not_now", detail: "busy", retry_after_ms: 500 }),

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -1003,6 +1003,11 @@ export interface BrainAttachmentRef {
   name: string;
   contentType?: string;
   url: string;
+  /** Base64 file bytes, inlined by the surface adapter when the file can't be
+   *  fetched by the brain (Mattermost needs auth). When present the brain uses
+   *  it DIRECTLY — no URL fetch — so it is NOT subject to the host allowlist
+   *  (there is no SSRF surface without a fetch). */
+  content?: string;
 }
 
 /**
@@ -1021,15 +1026,31 @@ const ATTACHMENT_HOST_ALLOWLIST: Record<string, readonly string[]> = {
  * default port (443) — a non-default port (e.g. `cdn.discordapp.com:22`) is
  * rejected. Fail-closed: an unknown surface (no allowlist entry) forwards NONE,
  * and a malformed / non-https / off-allowlist / non-default-port URL is dropped.
+ *
+ * INLINE-CONTENT path (Mattermost): an attachment whose bytes the adapter
+ * already fetched (with the bot token) and base64-inlined is forwarded with its
+ * `content` REGARDLESS of host allowlist — the brain consumes the bytes
+ * directly, never fetches the URL, so there is no SSRF surface to guard. The
+ * URL is still carried (audit/fallback) but is not what the brain reads.
  * Normalises `filename` → `name`.
  */
 export function safeAttachmentRefs(
   platform: string,
-  attachments: { filename: string; contentType?: string; url: string }[],
+  attachments: { filename: string; contentType?: string; url: string; content?: string }[],
 ): BrainAttachmentRef[] {
   const allowed = ATTACHMENT_HOST_ALLOWLIST[platform] ?? [];
   const refs: BrainAttachmentRef[] = [];
   for (const a of attachments) {
+    // Inlined bytes → forward directly (no fetch, no SSRF, no allowlist check).
+    if (typeof a.content === "string" && a.content.length > 0) {
+      refs.push({
+        name: a.filename,
+        ...(a.contentType !== undefined && { contentType: a.contentType }),
+        url: a.url,
+        content: a.content,
+      });
+      continue;
+    }
     let host: string;
     try {
       const u = new URL(a.url);


### PR DESCRIPTION
A Mattermost .eml upload never reached the brain — MM file URLs need bot-token auth AND weren't host-allowlisted, so safeAttachmentRefs dropped them fail-closed (flow saw 0 IOCs, guard halted). The adapter now fetches text-like file bytes (authed) at ingestion and ships them base64-inlined; safeAttachmentRefs forwards inline-content attachments regardless of host (no fetch = no SSRF). Discord keeps the URL path. 512KiB cap. Pairs with pulse#68 (A_INGEST decodes inline + parses EML MIME). v5.20.0→v5.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)