### PR TITLE
fix(mc): idle local stacks vanished from Network view — presence via bus, sessions via db

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -4729,12 +4729,13 @@ export async function startCortex(
   // registry boots AFTER this embed (below), so the getter returns `null` until
   // we assign it post-registry-start. The MC server resolves it per request.
   let presenceViewForApi: AgentPresenceView | null = null;
-  // #1008 — discovered LOCAL sibling stacks, computed ONCE here and shared by
-  // BOTH the DB-read pane-of-glass aggregation (the embed's `localAggregation`
-  // getter, below) AND the #989 bus sibling-presence aggregator (later) — so the
-  // two paths agree on the same roster and the dbRead-supersedes-bus gate is
-  // coherent. Empty until the aggregation block computes it; the getter reads
-  // this holder lazily (the embed starts before discovery runs).
+  // #1008/#989 — discovered LOCAL sibling stacks, used by BOTH the DB-read
+  // pane-of-glass aggregation (the embed's `localAggregation` getter, below, for
+  // session trees) AND the #989 bus sibling-presence aggregator (later, for
+  // idle-or-active liveness). The two paths COMPOSE (presence via bus, sessions
+  // via db) — they are no longer mutually exclusive; `aggregateAgentTiles` dedups
+  // the overlap by key. Empty until the aggregation block computes it; the getter
+  // reads this holder lazily (the embed starts before discovery runs).
   const aggCfg = config.mc.aggregateLocalStacks;
   let discoveredSiblings: readonly SiblingStackDescriptor[] = [];
   let siblingResolveOpts: SiblingDbResolveOptions | null = null;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -5186,19 +5186,29 @@ export async function startCortex(
       // sibling that can't be reached / authed degrades to absent — it never
       // blocks this boot or perturbs the serving stack's own presence.
       //
-      // #1008 RECONCILIATION (DB-read OWNS local siblings): when `dbRead` is on
-      // (default), the DB-read pane-of-glass aggregation already merges every
-      // LOCAL sibling's agents (+ session trees) straight off its db into the
-      // /api/agents + /api/working-agents feeds. Running this BUS sibling-presence
-      // aggregator too would DOUBLE-COUNT the same local agents (db + bus). So the
-      // bus path is gated OFF for local siblings whenever DB-read aggregation is
-      // on. The bus sibling path remains the mechanism for FEDERATED / cross-
-      // principal peers (whose dbs live on another machine/principal and cannot be
-      // read here) — that is the separate `startFederatedAgentPresenceSubscriber`
-      // above, NOT this local-sibling aggregator. Clean reach/depth split: DB-read
-      // = my own local stacks; bus = remote peers. Set `dbRead: false` to restore
-      // the bus path for local siblings (agents only, no session trees).
-      const runBusSiblingPresence = aggCfg.enabled && !aggCfg.dbRead;
+      // #1008/#989 RECONCILIATION — PRESENCE via bus, SESSIONS via db (they
+      // COMPOSE, they are not mutually exclusive). Agent PRESENCE (the liveness
+      // a hub renders: "this agent is up, idle or not") lives ONLY in the
+      // in-memory registry, fed by the `agent.{online,heartbeat,offline}` bus
+      // stream — it is NEVER persisted to a sibling's db. So the DB-read path can
+      // only project a sibling agent that "owns a LIVE SESSION" (sibling-db-reader
+      // `siblingAgentTiles`); an IDLE local sibling has no live session and thus
+      // vanished from the Network view whenever the bus path was gated off (the
+      // "only one stack" regression). The earlier "DB-read OWNS local siblings,
+      // gate the bus path off to avoid double-count" framing was wrong: db-read
+      // owns SESSION TREES (/api/working-agents), not idle PRESENCE.
+      //
+      // Corrected split: the BUS sibling-presence aggregator owns local-sibling
+      // PRESENCE (folds idle-or-active `agent.*` into the registry, origin-tagged)
+      // and runs whenever aggregation is enabled — NOT gated by dbRead. The
+      // DB-read path keeps the session trees (working-agents) AND a deduped
+      // live-session fallback into /api/agents: `aggregateAgentTiles` skips any
+      // sibling tile whose key is already live in the registry (the bus fold), so
+      // an active sibling present on BOTH paths is counted ONCE (registry wins),
+      // and a sibling the bus couldn't reach still surfaces from its db. The
+      // separate `startFederatedAgentPresenceSubscriber` above stays the path for
+      // FEDERATED / cross-principal peers (remote dbs, unreadable here).
+      const runBusSiblingPresence = aggCfg.enabled;
       if (runBusSiblingPresence) {
         try {
           // Precedence: explicit `stacks[]` overrides discovery. Empty ⇒ scan

--- a/src/surface/mc/local-aggregation/__tests__/sibling-db-reader.test.ts
+++ b/src/surface/mc/local-aggregation/__tests__/sibling-db-reader.test.ts
@@ -301,6 +301,53 @@ describe("aggregateAgentTiles (/api/agents union)", () => {
     // nkey, which the db live-session projection leaves empty.
     expect(lunas[0]!.capabilities).toEqual(["chat"]);
     expect(lunas[0]!.nkey_public_key).toBe("NKEYLUNA");
+    // Both paths agree online → stays online.
+    expect(lunas[0]!.state).toBe("online");
+  });
+
+  test("#989 dedup is state-aware — a live db session revives an offline-by-TTL registry tile", () => {
+    // The degraded-bus case: the sibling's bus went quiet so the TTL reaper marked
+    // its registry record `offline` (the reaper keeps the record, never deletes),
+    // BUT the sibling still has a LIVE SESSION in its db. The db fallback exists
+    // for exactly this — so the agent must read ONLINE, not offline. The registry's
+    // richer fields (capabilities/nkey) are still preserved.
+    const root = freshTmp();
+    const share = freshTmp();
+    seedDb(join(share, "work", "mission-control.db"), {
+      agentId: "luna",
+      agentName: "Luna",
+      taskTitle: "still working",
+    });
+
+    const localRecords: AgentPresenceSnapshotRecord[] = [
+      {
+        key: "andreas/work/luna",
+        origin: { kind: "foreign", principal: "andreas", stack: "work" },
+        agentId: "luna",
+        nkeyPublicKey: "NKEYLUNA",
+        assistantName: "Luna",
+        principal: "andreas",
+        stack: "work",
+        capabilities: ["chat"],
+        state: "offline", // heartbeat lapsed — but a session is still live in the db
+        offlineReason: "ttl_lapse",
+        lastSeenAt: 1,
+      },
+    ];
+
+    const tiles = aggregateAgentTiles(
+      localRecords,
+      [sibling("work")],
+      { configRoot: root, homeShareDir: share },
+    );
+
+    const lunas = tiles.filter((t) => t.key === "andreas/work/luna");
+    expect(lunas).toHaveLength(1); // still one tile
+    expect(lunas[0]!.state).toBe("online"); // live db session revived liveness
+    expect(lunas[0]!.offline_reason).toBeNull();
+    // Richer registry fields are preserved through the liveness upgrade.
+    expect(lunas[0]!.capabilities).toEqual(["chat"]);
+    expect(lunas[0]!.nkey_public_key).toBe("NKEYLUNA");
   });
 });
 

--- a/src/surface/mc/local-aggregation/__tests__/sibling-db-reader.test.ts
+++ b/src/surface/mc/local-aggregation/__tests__/sibling-db-reader.test.ts
@@ -257,6 +257,51 @@ describe("aggregateAgentTiles (/api/agents union)", () => {
     expect(luna).toBeDefined();
     expect(luna!.origin).toEqual({ principal: "andreas", stack: "work" });
   });
+
+  test("#989 dedup — a sibling already live in the registry (bus fold) is NOT double-counted from its db", () => {
+    // The reconciliation: the bus aggregator folds a local sibling's LIVE
+    // presence into the registry (`localRecords`), AND the same sibling has a
+    // live session in its db. Both paths produce the SAME key
+    // (`andreas/work/luna`) — `aggregateAgentTiles` must emit ONE tile (the
+    // bus-folded record wins, carrying real liveness), never two (which would be
+    // a duplicate React key in the Network view).
+    const root = freshTmp();
+    const share = freshTmp();
+    seedDb(join(share, "work", "mission-control.db"), {
+      agentId: "luna",
+      agentName: "Luna",
+      taskTitle: "work task",
+    });
+
+    const localRecords: AgentPresenceSnapshotRecord[] = [
+      {
+        // The SAME sibling agent, already folded into the registry via the bus.
+        key: "andreas/work/luna",
+        origin: { kind: "foreign", principal: "andreas", stack: "work" },
+        agentId: "luna",
+        nkeyPublicKey: "NKEYLUNA",
+        assistantName: "Luna",
+        principal: "andreas",
+        stack: "work",
+        capabilities: ["chat"],
+        state: "online",
+        lastSeenAt: 42,
+      },
+    ];
+
+    const tiles = aggregateAgentTiles(
+      localRecords,
+      [sibling("work")],
+      { configRoot: root, homeShareDir: share },
+    );
+
+    const lunas = tiles.filter((t) => t.key === "andreas/work/luna");
+    expect(lunas).toHaveLength(1); // deduped — not two
+    // The registry (bus-folded) record wins: it carries the real capabilities +
+    // nkey, which the db live-session projection leaves empty.
+    expect(lunas[0]!.capabilities).toEqual(["chat"]);
+    expect(lunas[0]!.nkey_public_key).toBe("NKEYLUNA");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/surface/mc/local-aggregation/sibling-db-reader.ts
+++ b/src/surface/mc/local-aggregation/sibling-db-reader.ts
@@ -394,11 +394,23 @@ export function aggregateAgentTiles(
   opts: SiblingDbResolveOptions,
 ): AgentPresenceTile[] {
   const out: AgentPresenceTile[] = localRecords.map(recordToTile);
+  // #989/#1008 — the registry (`localRecords`) now folds local siblings' LIVE
+  // bus presence (idle-or-active) via the bus aggregator. The db-derived sibling
+  // tiles below are a live-SESSION fallback for the same agents, so dedup by key
+  // (`{principal}/{stack}/{agent_id}` — identical on both paths): the bus-folded
+  // record WINS (it carries real liveness/capabilities), and a sibling the bus
+  // couldn't reach still surfaces from its db. Without this, an active sibling
+  // present on BOTH paths would double-count (two tiles, same key → dup React key).
+  const seen = new Set(out.map((t) => t.key));
 
   const { handles } = openReadableSiblingDbs(siblings, opts);
   try {
     for (const h of handles) {
-      out.push(...siblingAgentTiles(h.db, h.origin));
+      for (const tile of siblingAgentTiles(h.db, h.origin)) {
+        if (seen.has(tile.key)) continue;
+        seen.add(tile.key);
+        out.push(tile);
+      }
     }
   } finally {
     for (const h of handles) h.db.close();

--- a/src/surface/mc/local-aggregation/sibling-db-reader.ts
+++ b/src/surface/mc/local-aggregation/sibling-db-reader.ts
@@ -396,20 +396,41 @@ export function aggregateAgentTiles(
   const out: AgentPresenceTile[] = localRecords.map(recordToTile);
   // #989/#1008 — the registry (`localRecords`) now folds local siblings' LIVE
   // bus presence (idle-or-active) via the bus aggregator. The db-derived sibling
-  // tiles below are a live-SESSION fallback for the same agents, so dedup by key
-  // (`{principal}/{stack}/{agent_id}` — identical on both paths): the bus-folded
-  // record WINS (it carries real liveness/capabilities), and a sibling the bus
-  // couldn't reach still surfaces from its db. Without this, an active sibling
-  // present on BOTH paths would double-count (two tiles, same key → dup React key).
-  const seen = new Set(out.map((t) => t.key));
+  // tiles below are a live-SESSION fallback for the same agents, deduped by key
+  // (`{principal}/{stack}/{agent_id}` — identical on both paths) so an active
+  // sibling on BOTH paths is ONE tile (no dup React key).
+  //
+  // The registry record wins on its RICHER fields (capabilities/nkey, which the
+  // db projection leaves empty) — BUT liveness is state-aware: the TTL reaper
+  // keeps a record as `state:offline` after a heartbeat lapse (it never deletes),
+  // so a sibling whose bus went quiet WHILE a session is still live would read
+  // `offline` from the registry yet `online` from its db. That is the exact
+  // degraded-bus case the db fallback exists for, so an `online` db tile upgrades
+  // an `offline` registry tile's liveness (keeping the registry's richer fields).
+  const idxByKey = new Map<string, number>();
+  out.forEach((t, i) => idxByKey.set(t.key, i));
 
   const { handles } = openReadableSiblingDbs(siblings, opts);
   try {
     for (const h of handles) {
       for (const tile of siblingAgentTiles(h.db, h.origin)) {
-        if (seen.has(tile.key)) continue;
-        seen.add(tile.key);
-        out.push(tile);
+        const existingIdx = idxByKey.get(tile.key);
+        if (existingIdx === undefined) {
+          idxByKey.set(tile.key, out.length);
+          out.push(tile);
+          continue;
+        }
+        // Collision with a bus-folded registry tile: keep it, but let a live db
+        // session revive an offline-by-TTL liveness (bus quiet, work ongoing).
+        const existing = out[existingIdx];
+        if (existing?.state === "offline" && tile.state === "online") {
+          out[existingIdx] = {
+            ...existing,
+            state: "online",
+            offline_reason: null,
+            last_seen_at: Math.max(existing.last_seen_at, tile.last_seen_at),
+          };
+        }
       }
     }
   } finally {


### PR DESCRIPTION
## Problem
The localhost Mission Control **Network view** dropped to showing only the serving stack (`andreas/meta-factory`) — the principal's other idle local stacks (work, halden, community) vanished as hubs.

## Root cause
A wrong reconciliation between the **#1008 DB-read** pane-of-glass aggregation and the **#989 bus** sibling-presence aggregator: they were made **mutually exclusive** (`aggregateLocalStacks.dbRead` toggled between them), with the bus path gated OFF by default (`runBusSiblingPresence = enabled && !dbRead`) on the assumption *"DB-read owns local siblings."*

But agent **presence** — the liveness a hub renders (*"agent up, idle or not"*, ADR-0007) — lives **only in the in-memory registry**, fed by the `agent.{online,heartbeat,offline}` bus stream. It is **never persisted to a sibling's db**. So the DB-read path can only project a sibling that *"owns a live session"* (`siblingAgentTiles`). An **idle** local sibling has no live session → it vanished from the Network view whenever the bus path was gated off. (It appeared during earlier QA only because those stacks had live CC sessions running at the time.)

## Fix — compose the two paths (presence via bus, sessions via db)
- **Un-gate** the bus sibling-presence aggregator — it runs whenever local-stack aggregation is enabled (dropped `&& !dbRead`), folding idle-or-active sibling `agent.*` into the registry, origin-tagged.
- **DB-read keeps** the session trees (`/api/working-agents`) **and** a deduped live-session fallback into `/api/agents`: `aggregateAgentTiles` now **dedups by key** (`{principal}/{stack}/{agent_id}`, identical on both paths) — the bus-folded record wins (real liveness/capabilities), and a sibling the bus couldn't reach still surfaces from its db. No double-count (was a dup React key risk).

Implements the chosen design: **presence via bus, sessions via db** — keeps both the Network-view hubs for idle stacks AND the working-grid session trees.

## Verification
2084/2085 surface-mc + bus tests pass (1 skip); new dedup regression test; tsc + lint + vocab gate clean. Browser-QA after deploy: all 4 local stacks render as hubs when idle.