### PR TITLE
fix(brain): host→brain socket write backpressure (truncated large tasks)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.21.0"
+version: "5.22.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -1247,6 +1247,29 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
   // (socket, data); we expose a write/onData/onClose facade.
   interface BunServerSocket { write(data: string | Uint8Array): number; end(): void }
   let liveSocket: BunServerSocket | null = null;
+  // Outbound backpressure (host → brain). Bun's `socket.write` returns the
+  // number of bytes accepted and does NOT buffer the remainder — a large line
+  // (e.g. a task carrying an inlined attachment) exceeding the send buffer is
+  // PARTIALLY written, the rest dropped, so the brain reads a truncated line,
+  // fails JSON.parse, and silently drops the task (it never runs). Queue the
+  // unwritten bytes and flush them on the socket's `drain` event.
+  let writeQueue: Uint8Array = new Uint8Array(0);
+  const flushWriteQueue = (): void => {
+    if (liveSocket === null || writeQueue.length === 0) return;
+    const n = liveSocket.write(writeQueue);
+    writeQueue = n >= writeQueue.length ? new Uint8Array(0) : writeQueue.subarray(n);
+  };
+  const enqueueWrite = (bytes: Uint8Array): void => {
+    if (writeQueue.length === 0) {
+      writeQueue = bytes;
+    } else {
+      const merged = new Uint8Array(writeQueue.length + bytes.length);
+      merged.set(writeQueue);
+      merged.set(bytes, writeQueue.length);
+      writeQueue = merged;
+    }
+    flushWriteQueue();
+  };
   // Auth state: until the first line proves the token, the connection is NOT
   // resolved and inbound bytes are buffered by the auth pre-reader, never the
   // protocol pump.
@@ -1343,7 +1366,9 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
         const sock = liveSocket;
         resolveConn({
           write(chunk) {
-            sock?.write(chunk);
+            // Byte-accurate, backpressure-safe: queue + flush (a large line is
+            // written across multiple `drain`s rather than truncated).
+            enqueueWrite(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
           },
           onData(handler) {
             dataHandler = handler;
@@ -1369,8 +1394,14 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
           }
         }
       },
+      drain() {
+        // Send buffer has room again — flush any bytes a large line couldn't
+        // fit on its first write (prevents truncated task/effect lines).
+        flushWriteQueue();
+      },
       close() {
         liveSocket = null;
+        writeQueue = new Uint8Array(0);
         if (!authed) {
           // Closed before authenticating — surface as a failed connect.
           failAuth("connector closed before authenticating");

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -1363,7 +1363,6 @@ export const makeBunUnixTransport: DaemonTransport = (opts) => {
         // any bytes that arrived AFTER the auth line into the protocol pump.
         authed = true;
         if (authTimer !== undefined) clearTimeout(authTimer);
-        const sock = liveSocket;
         resolveConn({
           write(chunk) {
             // Byte-accurate, backpressure-safe: queue + flush (a large line is


### PR DESCRIPTION
**Bug:** `daemon-brain-host` wrote task lines with `sock.write(chunk)` and ignored Bun's partial-write return. A task line over the socket send buffer (e.g. one carrying an inlined ~32 KB `.eml` attachment) was **partially written, remainder dropped** → the brain read a truncated line, `JSON.parse` failed, the task was silently dropped (`"dropping unrecognized event line"`) → it never ran, and with `MAX_CONCURRENT=1` it wedged everything behind it. This is the "Yarrow goes silent on .eml attachment" bug chased all session.

**Fix:** a byte-accurate write queue that flushes on the socket `drain` event — a large line delivers across multiple writes instead of truncating. Mirrors the backpressure the brain's outbound writer (`main.ts`) already does.

**Verified live:** a 24 KB `.eml` attachment task now delivers whole; the SOC phishing flow runs end-to-end. Typecheck clean; 112 brain tests pass. v5.21.0→v5.22.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)