### PR TITLE
feat(cortex): C-1089.P4 — signal-optional transport verdict on federated hubs

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes-transport.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes-transport.test.tsx
@@ -77,6 +77,70 @@ describe("StackHubCard — verdict badge (U2.3)", () => {
   });
 });
 
+describe("StackHubCard — #1089 P4 signal-optional liveness enrichment", () => {
+  // OQ4: a `registered-absent` verdict (registered, no live leaf) renders the
+  // peer hub MUTED — render it, don't omit it: the principal wants to see WHO is
+  // on the network, live or not. Muting is opacity/dim (a11y — never hue alone).
+  // A foreign peer hub fixture: origin + principal/stack agree (as the adapter
+  // builds them), and `servingPrincipal` stays this stack's principal so the hub
+  // classifies cross-principal `foreign`.
+  const peerHub = (over: Partial<StackHubNodeData> = {}): StackHubNodeData =>
+    hub({ origin: { principal: "jc", stack: "research" }, principal: "jc", stack: "research", ...over });
+
+  it("mutes the hub when signal reports registered-absent (no live leaf)", () => {
+    const html = renderHub(peerHub({ transportVerdict: "registered-absent" }));
+    expect(html).toContain("network-node-hub-muted");
+    expect(html).toContain('data-transport-muted="true"');
+    // Still rendered (not omitted) — the warn badge still names the verdict.
+    expect(html).toContain("network-verdict-registered-absent");
+  });
+
+  // The `unregistered-present` anomaly (a live leaf with NO registry entry — the
+  // security-relevant case, reality \ intent) is surfaced as an anomaly on the
+  // hub, beyond the alert-severity badge: an explicit anomaly affordance the
+  // Network view can flag distinctly.
+  it("flags the hub as an anomaly when signal reports unregistered-present", () => {
+    const html = renderHub(peerHub({ transportVerdict: "unregistered-present" }));
+    expect(html).toContain("network-node-hub-anomaly");
+    expect(html).toContain('data-transport-anomaly="true"');
+    expect(html).toContain("network-verdict-unregistered-present");
+  });
+
+  // A `connected` verdict is healthy: neither muted nor flagged anomaly.
+  it("neither mutes nor flags a connected hub", () => {
+    const html = renderHub(hub({ transportVerdict: "connected" }));
+    expect(html).not.toContain("network-node-hub-muted");
+    expect(html).not.toContain("network-node-hub-anomaly");
+    expect(html).not.toContain('data-transport-muted');
+    expect(html).not.toContain('data-transport-anomaly');
+  });
+
+  // LOAD-BEARING (design §4 signal-optional): with signal NOT installed there is
+  // no transport verdict, so a FEDERATED PEER hub must still render from cortex's
+  // own federated presence — no badge, no muted/anomaly treatment, no errors.
+  it("renders a federated peer with NO verdict — no badge, no mute, no anomaly", () => {
+    const html = renderHub(peerHub());
+    // The peer still renders as a federated stack hub.
+    expect(html).toContain("network-node-hub-foreign");
+    expect(html).toContain("federated stack");
+    expect(html).toContain("jc/research");
+    // No signal-sourced treatment whatsoever.
+    expect(html).not.toContain("network-verdict-badge");
+    expect(html).not.toContain("network-node-hub-muted");
+    expect(html).not.toContain("network-node-hub-anomaly");
+    expect(html).not.toContain('data-transport-verdict');
+    expect(html).not.toContain('data-transport-muted');
+    expect(html).not.toContain('data-transport-anomaly');
+  });
+
+  // A muted hub is conveyed accessibly: the muted state is reflected in the hub's
+  // data attributes (a11y/automation can read it), not by colour alone.
+  it("exposes the muted state on a data attribute (a11y, not hue-only)", () => {
+    const html = renderHub(hub({ transportVerdict: "registered-absent" }));
+    expect(html).toContain('data-transport-muted="true"');
+  });
+});
+
 describe("AgentNodeCard — leaf liveness/RTT (U2.3)", () => {
   it("renders NO leaf row when the overlay is off (undefined transportLeaf)", () => {
     const html = renderAgent(agent());

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -90,6 +90,20 @@ export function StackHubCard({
   // transport overlay is on AND signal observed it). Taken verbatim from signal.
   const badge =
     data.transportVerdict !== undefined ? verdictBadge(data.transportVerdict) : null;
+  // #1089 P4 — signal-OPTIONAL liveness enrichment. WHEN signal is present its
+  // folded transport verdict keys two hub treatments (OQ4); when signal is absent
+  // `transportVerdict` is undefined and BOTH stay false, so the hub renders purely
+  // from cortex's own federated presence — strictly additive, no signal dependency.
+  //   - `registered-absent` (registered, no live leaf) → MUTE the hub: render it
+  //     (the principal wants to see WHO is on the network, live or not — OQ4: muted,
+  //     not omitted), but dimmed so a transport-dead peer doesn't read as live.
+  //   - `unregistered-present` (a live leaf with no registry entry — reality \ intent)
+  //     → flag an ANOMALY: the security-relevant case gets an explicit affordance
+  //     beyond the alert badge so the Network view can surface it distinctly.
+  // Muting/anomaly are conveyed by class + `data-*` (opacity/treatment), never hue
+  // alone (a11y). `connected` is healthy → neither.
+  const transportMuted = data.transportVerdict === "registered-absent";
+  const transportAnomaly = data.transportVerdict === "unregistered-present";
   // #1068 — the hub is a toggle button for its subtree selection. When
   // interactive (a toggle handler is wired), it's focusable + Enter/Space
   // activates it; the selected/dimmed state is on `aria-pressed` + `data-*` +
@@ -102,7 +116,11 @@ export function StackHubCard({
         (foreign ? " network-node-hub-foreign" : " network-node-hub-local") +
         ` network-node-hub-${category}` +
         (selected ? " network-node-selected" : "") +
-        (dimmed ? " network-node-dimmed" : "")
+        (dimmed ? " network-node-dimmed" : "") +
+        // #1089 P4 — signal-optional transport treatments (additive; only when a
+        // verdict is folded in). registered-absent → muted, unregistered-present → anomaly.
+        (transportMuted ? " network-node-hub-muted" : "") +
+        (transportAnomaly ? " network-node-hub-anomaly" : "")
       }
       // #1068 — the stack's deterministic color, exposed as a CSS custom property
       // the hub styling references for its accent/border. ADDITIVE: the shape
@@ -115,6 +133,10 @@ export function StackHubCard({
       data-selected={selected ? "true" : undefined}
       data-dimmed={dimmed ? "true" : undefined}
       data-transport-verdict={data.transportVerdict ?? undefined}
+      // #1089 P4 — a11y/automation can read the transport treatment off the hub
+      // without relying on colour. Undefined (no `true`) when signal is absent.
+      data-transport-muted={transportMuted ? "true" : undefined}
+      data-transport-anomaly={transportAnomaly ? "true" : undefined}
       role={interactive ? "button" : undefined}
       tabIndex={interactive ? 0 : undefined}
       aria-pressed={interactive ? selected : undefined}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -590,6 +590,26 @@ html, body {
   border-style: dashed;
 }
 
+/* #1089 P4 — signal-OPTIONAL liveness enrichment on a stack hub. Only present
+   when signal folded a transport verdict for the hub; absent signal = no class,
+   so these rules never affect a signal-less Network view (strictly additive).
+   A registered-absent peer (registered, NO live leaf) is MUTED — rendered, not
+   omitted (OQ4: the principal wants to see who is on the network, live or not),
+   but dimmed so a transport-dead peer doesn't read as live. Conveyed by opacity
+   + a dashed treatment, never hue alone (a11y). */
+.network-node-hub-muted {
+  opacity: 0.5;
+  filter: saturate(0.75);
+}
+/* The unregistered-present anomaly (a live leaf with NO registry entry — the
+   security-relevant reality \ intent case) gets an explicit alert ring beyond
+   the alert-severity badge, so it's hard to miss on the canvas. */
+.network-node-hub-anomaly {
+  outline: 2px dashed color-mix(in oklch, var(--danger, var(--warn)) 70%, transparent);
+  outline-offset: 2px;
+  border-color: color-mix(in oklch, var(--danger, var(--warn)) 60%, var(--line));
+}
+
 /* Legend overlay (bottom-right of the canvas). */
 .network-legend {
   position: absolute; right: 10px; bottom: 10px; z-index: 5;


### PR DESCRIPTION
## What

Slice **P4** of the roster-driven federation auto-wiring umbrella (#1084). When **signal IS present**, key a federated peer hub's rendered liveness off signal's already-folded `system.transport.*` verdict (the U3.3 federated-observability fold cortex already does), building on the existing `verdictBadge` at `network-nodes.tsx`:

- **`registered-absent`** (registered, no live leaf) → render the peer hub **muted** (OQ4: muted, **not** omitted — the principal wants to see *who* is on the network, live or not).
- **`unregistered-present`** (a live leaf with no registry entry — reality \ intent, the security-relevant case) → surfaced as an explicit **anomaly** affordance, beyond the alert-severity badge.

## Hard constraint — signal-optional (design §4, LOAD-BEARING)

**Strictly additive.** With signal **NOT** installed, `transportVerdict` is `undefined`, both treatments stay off, and a federated peer **still renders from cortex's OWN federated presence** — no badge, no mute/anomaly, no errors. **No code dependency on the signal package** — coupling stays bus-only via the already-folded `system.transport.*` verdict (verified: no `signal` import in the touched files). A test proves a federated peer renders with no transport verdict present.

a11y: muting/anomaly conveyed by class + `data-*` (opacity/treatment), never hue alone.

## Tests (TDD)

`network-nodes-transport.test.tsx` (pure-card `renderToStaticMarkup`):
- `registered-absent` → `network-node-hub-muted` + `data-transport-muted="true"`, badge still rendered;
- `unregistered-present` → `network-node-hub-anomaly` + `data-transport-anomaly="true"`;
- `connected` → neither muted nor anomaly;
- **signal-absent federated peer → renders as a federated stack hub, no badge, no mute, no anomaly, no errors** (the §4 guarantee).

## Gates

- `bun test` (4 touched dashboard network test files) — 72 pass
- `bun run lint:errors` — clean
- `bunx tsc --noEmit` — clean
- `bash scripts/check-carveouts.sh` — PASS

Dashboard `build:dashboard` is a deploy step, not required for the PR.

Design: `docs/design-roster-driven-federation-wiring.md` §4 (signal-optional) + §7 P4 + §8 OQ4.
Umbrella: #1084.

Closes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)