### PR TITLE
feat(network): C-1086 — lift registry-roster read into a runtime-callable lib (P1)

### DIFF
--- a/src/bus/agent-network/__tests__/roster-read.test.ts
+++ b/src/bus/agent-network/__tests__/roster-read.test.ts
@@ -1,0 +1,312 @@
+/**
+ * P1 (cortex#1086) — resolveNetworkRoster unit tests.
+ *
+ * Tests the runtime-callable registry-roster read in isolation against a FAKE
+ * registry client (just the two methods the lib consumes). The verified-fetch
+ * + DD-9 signing path is the {@link NetworkRegistryClient}'s own contract
+ * (covered by network-client.test.ts); here we test the LIFTED orchestration:
+ *
+ *   1. resolve — ok fetch → projected peers (local principal excluded, wire +
+ *      config views, nkey re-encode / leave-off).
+ *   2. 0-peers guard (#762) — empty roster → `emptyRoster: true`, `peers: []`,
+ *      `ok: true` (NOT an error: an empty roster is the common early state).
+ *   3. registry-unreachable → cached (DD-10) — `unreachable` fetch falls back
+ *      to `loadCached`; `usedCache: true`. No cache → `unreachable_uncached`.
+ *   4. definitive negatives — `not_found` / `unverified` surface as `ok: false`
+ *      without touching the cache.
+ *
+ * Design: docs/design-roster-driven-federation-wiring.md §4 (signal-optional),
+ * §7 (P1). Umbrella: cortex#1084.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveNetworkRoster,
+  buildRosterPeers,
+  type RosterPeer,
+} from "../roster-read";
+import type { NetworkRegistryClient } from "../../../common/registry/network-client";
+import type {
+  NetworkDescriptor,
+  NetworkRosterResult,
+} from "../../../common/registry/types";
+
+// =============================================================================
+// Fixtures + a fake registry client (only fetchAndCache / loadCached are read).
+// =============================================================================
+
+const NET = "metafactory";
+const LOCAL = "andreas";
+
+/** A structurally-valid base64 Ed25519 pubkey (re-encodable to nkey-U). */
+const VALID_B64_PUBKEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+/** Not base64 / wrong length — `base64PubkeyToNkey` returns undefined. */
+const BAD_B64_PUBKEY = "not-a-pubkey";
+
+function descriptor(networkId: string): NetworkDescriptor {
+  return {
+    network_id: networkId,
+    hub_url: "tls://hub.meta-factory.ai:7422",
+    leaf_port: 7422,
+    members: [LOCAL, "jc"],
+  };
+}
+
+function roster(
+  networkId: string,
+  members: NetworkRosterResult["members"],
+): NetworkRosterResult {
+  return { network_id: networkId, members };
+}
+
+type FetchAndCacheReturn = Awaited<
+  ReturnType<NetworkRegistryClient["fetchAndCache"]>
+>;
+type LoadCachedReturn = ReturnType<NetworkRegistryClient["loadCached"]>;
+
+/** Minimal client the lib accepts (the `Pick<>` it's typed against). */
+interface FakeClient {
+  fetchAndCache: () => Promise<FetchAndCacheReturn>;
+  loadCached: () => LoadCachedReturn;
+}
+
+function fakeClient(opts: {
+  fetch: FetchAndCacheReturn;
+  cached?: LoadCachedReturn;
+}): FakeClient {
+  return {
+    fetchAndCache: () => Promise.resolve(opts.fetch),
+    loadCached: () => opts.cached,
+  };
+}
+
+// =============================================================================
+// 1. resolve — happy path projection
+// =============================================================================
+
+describe("resolveNetworkRoster — resolve (happy path)", () => {
+  test("projects roster members → peers, excluding the local principal", async () => {
+    const client = fakeClient({
+      fetch: {
+        status: "ok",
+        value: {
+          descriptor: descriptor(NET),
+          roster: roster(NET, [
+            // local principal — MUST be excluded (never self in peers[]).
+            { principal_id: LOCAL, stack_id: "andreas/meta-factory", principal_pubkey: VALID_B64_PUBKEY },
+            { principal_id: "jc", stack_id: "jc/sage-host", principal_pubkey: VALID_B64_PUBKEY },
+          ]),
+        },
+      },
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.usedCache).toBe(false);
+    expect(result.emptyRoster).toBe(false);
+    expect(result.peers).toHaveLength(1);
+
+    const jc = result.peers[0]!;
+    // Wire-segment view (reconciler builds `federated.{principal}.{stack}.>`).
+    expect(jc.principal).toBe("jc");
+    expect(jc.stack).toBe("sage-host");
+    // Config view (CLI writes PolicyFederatedPeer).
+    expect(jc.principal_id).toBe("jc");
+    expect(jc.stack_id).toBe("jc/sage-host");
+    // Re-encodable key → filled (nkey-U, 56-char U-prefixed).
+    expect(jc.principal_pubkey).toBeDefined();
+    expect(jc.principal_pubkey!.startsWith("U")).toBe(true);
+  });
+
+  test("defaults stack to `{principal}/default` when the roster omits stack_id", async () => {
+    const client = fakeClient({
+      fetch: {
+        status: "ok",
+        value: {
+          descriptor: descriptor(NET),
+          roster: roster(NET, [
+            { principal_id: "jc", principal_pubkey: VALID_B64_PUBKEY },
+          ]),
+        },
+      },
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const jc = result.peers[0]!;
+    expect(jc.stack_id).toBe("jc/default");
+    expect(jc.stack).toBe("default");
+  });
+
+  test("leaves principal_pubkey OFF when the roster key is not re-encodable (DD-5: declare by id)", async () => {
+    const client = fakeClient({
+      fetch: {
+        status: "ok",
+        value: {
+          descriptor: descriptor(NET),
+          roster: roster(NET, [
+            { principal_id: "jc", stack_id: "jc/sage-host", principal_pubkey: BAD_B64_PUBKEY },
+          ]),
+        },
+      },
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const jc = result.peers[0]!;
+    expect(jc.principal_pubkey).toBeUndefined();
+    // Identity still resolves so the gate can key on principal_id (DD-5).
+    expect(jc.principal_id).toBe("jc");
+    expect(jc.stack).toBe("sage-host");
+  });
+});
+
+// =============================================================================
+// 2. 0-peers guard (#762)
+// =============================================================================
+
+describe("resolveNetworkRoster — 0-peers guard (#762)", () => {
+  test("empty roster → emptyRoster:true, peers:[], ok:true (NOT an error)", async () => {
+    const client = fakeClient({
+      fetch: {
+        status: "ok",
+        value: { descriptor: descriptor(NET), roster: roster(NET, []) },
+      },
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.emptyRoster).toBe(true);
+    expect(result.peers).toEqual([]);
+  });
+
+  test("a roster of ONLY the local principal resolves to 0 peers → emptyRoster:true", async () => {
+    // The registry names the local principal (it IS a member) but no peers yet.
+    const client = fakeClient({
+      fetch: {
+        status: "ok",
+        value: {
+          descriptor: descriptor(NET),
+          roster: roster(NET, [
+            { principal_id: LOCAL, stack_id: "andreas/meta-factory", principal_pubkey: VALID_B64_PUBKEY },
+          ]),
+        },
+      },
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.emptyRoster).toBe(true);
+    expect(result.peers).toEqual([]);
+  });
+});
+
+// =============================================================================
+// 3. registry-unreachable → cached (DD-10)
+// =============================================================================
+
+describe("resolveNetworkRoster — registry-unreachable → cached (DD-10)", () => {
+  test("falls back to the cached roster and flags usedCache:true", async () => {
+    const cachedRoster = roster(NET, [
+      { principal_id: "jc", stack_id: "jc/sage-host", principal_pubkey: VALID_B64_PUBKEY },
+    ]);
+    const client = fakeClient({
+      fetch: { status: "unreachable", reason: "ECONNREFUSED" },
+      cached: { descriptor: descriptor(NET), roster: cachedRoster },
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.usedCache).toBe(true);
+    expect(result.peers).toHaveLength(1);
+    expect(result.peers[0]!.principal).toBe("jc");
+  });
+
+  test("unreachable AND no cache → ok:false, reason unreachable_uncached", async () => {
+    const client = fakeClient({
+      fetch: { status: "unreachable", reason: "ETIMEDOUT" },
+      cached: undefined,
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unreachable_uncached");
+    expect(result.detail).toContain("ETIMEDOUT");
+  });
+
+  test("a cached roster that is empty still resolves ok with emptyRoster:true", async () => {
+    const client = fakeClient({
+      fetch: { status: "unreachable", reason: "ECONNREFUSED" },
+      cached: { descriptor: descriptor(NET), roster: roster(NET, []) },
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.usedCache).toBe(true);
+    expect(result.emptyRoster).toBe(true);
+  });
+});
+
+// =============================================================================
+// 4. definitive negatives — not_found / unverified
+// =============================================================================
+
+describe("resolveNetworkRoster — definitive negatives", () => {
+  test("not_found → ok:false, reason not_found (no cache consult)", async () => {
+    let loadCachedCalled = false;
+    const client: FakeClient = {
+      fetchAndCache: () => Promise.resolve({ status: "not_found" }),
+      loadCached: () => {
+        loadCachedCalled = true;
+        return undefined;
+      },
+    };
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("not_found");
+    // A definitive negative must NOT fall back to cache (that's unreachable-only).
+    expect(loadCachedCalled).toBe(false);
+  });
+
+  test("unverified → ok:false, reason unverified, detail carries the cause", async () => {
+    const client = fakeClient({
+      fetch: { status: "unverified", reason: "bad_signature" },
+    });
+
+    const result = await resolveNetworkRoster(NET, LOCAL, client);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unverified");
+    expect(result.detail).toContain("bad_signature");
+  });
+});
+
+// =============================================================================
+// 5. buildRosterPeers — projection in isolation
+// =============================================================================
+
+describe("buildRosterPeers — projection", () => {
+  test("excludes the local principal and maps every other member", () => {
+    const peers: RosterPeer[] = buildRosterPeers(
+      LOCAL,
+      roster(NET, [
+        { principal_id: LOCAL, stack_id: "andreas/meta-factory", principal_pubkey: VALID_B64_PUBKEY },
+        { principal_id: "jc", stack_id: "jc/sage-host", principal_pubkey: VALID_B64_PUBKEY },
+        { principal_id: "kim", stack_id: "kim/lab", principal_pubkey: VALID_B64_PUBKEY },
+      ]),
+    );
+    expect(peers.map((p) => p.principal)).toEqual(["jc", "kim"]);
+  });
+});

--- a/src/bus/agent-network/roster-read.ts
+++ b/src/bus/agent-network/roster-read.ts
@@ -1,0 +1,264 @@
+/**
+ * P1 (cortex#1086, design-roster-driven-federation-wiring §7) — the
+ * **runtime-callable** registry-roster read.
+ *
+ * Lifts cortex's roster resolution out of the `network` CLI
+ * (`src/cli/cortex/commands/network-lib.ts` `joinNetwork`'s step (b) +
+ * `buildPeers`) into a reusable function the federation roster reconciler (P3,
+ * #1088) can call WITHOUT going through a CLI command. The question it answers
+ * is exactly the umbrella's (#1084): *"who is on network X?"* — resolved from
+ * the registry, the authority for membership (ADR-0003; design §6).
+ *
+ * ## Reuse, do not rebuild (design §3)
+ *
+ * The verified fetch + DD-10 disk cache already live in
+ * `src/common/registry/`:
+ *
+ *   - {@link NetworkRegistryClient.fetchAndCache} — `GET /networks/{id}` +
+ *     `/roster`, pin+verify (DD-9), cache the pair on success (DD-10).
+ *   - {@link NetworkRegistryClient.loadCached} — last-known-good pair when the
+ *     registry is unreachable (DD-10 fallback).
+ *
+ * This module is the small piece the CLI kept private: the
+ * `fetchAndCache → unreachable → loadCached` orchestration plus the
+ * roster-members → peers projection (which excludes the local principal — a
+ * stack is never in its own peers[]) and the #762 "0 resolved peers" signal so
+ * a caller can preserve hand-pins rather than wipe them.
+ *
+ * ## Signal-optional (design §4, hard constraint)
+ *
+ * This module reads the registry **directly** via cortex's own
+ * {@link NetworkRegistryClient}. It has **zero** dependency on the `signal`
+ * package — signal independently reads the same registry behind its own
+ * `RegistryIntentSource` seam (shared *registry*, not shared *package*; the
+ * dependency direction is cortex→registry and signal→registry, never
+ * cortex→signal). Do NOT add a signal import here.
+ *
+ * ## Trust boundary
+ *
+ * `fetchAndCache`/`loadCached` only ever return DD-9-verified payloads (a bad
+ * signature / shape is a definitive negative, never cached). This module
+ * therefore never sees an unverified roster; it does not re-implement
+ * verification. It also does not write any federation policy or accept-list —
+ * deriving `accept_subjects` is P2 (#1087), applying it is P3 (#1088). This is
+ * a READ.
+ */
+
+import type {
+  NetworkRegistryClient,
+  NetworkFetchResult,
+} from "../../common/registry/network-client";
+import type { NetworkRosterResult } from "../../common/registry/types";
+import { base64PubkeyToNkey } from "../../common/registry/encoding";
+
+// =============================================================================
+// Result shapes
+// =============================================================================
+
+/**
+ * One peer on a network's roster, in the runtime caller's shape.
+ *
+ * Carries BOTH the wire-segment view the reconciler needs
+ * (`principal` / `stack` build `federated.{principal}.{stack}.>` — design §5
+ * step 2) AND the config-peer view the CLI writes
+ * (`principal_id` / `stack_id` / optional nkey `principal_pubkey` →
+ * `PolicyFederatedPeer`), so a single resolve serves both consumers losslessly.
+ */
+export interface RosterPeer {
+  /** Peer principal id — the `{principal}` wire segment. Same as `principal_id`. */
+  principal: string;
+  /**
+   * Peer stack slug — the `{stack}` wire segment (the part AFTER the `/` in
+   * `stack_id`). Defaults to `default` when the roster omits the stack id.
+   */
+  stack: string;
+  /** Peer principal id — the `PolicyFederatedPeer.principal_id` field. */
+  principal_id: string;
+  /**
+   * Peer stack id in `{principal_id}/{stack_slug}` form — the
+   * `PolicyFederatedPeer.stack_id` field. Falls back to
+   * `{principal_id}/default` when the roster omits it (mirrors the CLI's
+   * `buildPeers`).
+   */
+  stack_id: string;
+  /**
+   * Peer principal's NKey-U public key, re-encoded from the roster's base64
+   * Ed25519 key (DD-8). LEFT OFF when the roster key is not re-encodable, so
+   * the config-load resolver (S2) fills it from the registry (DD-5: declare by
+   * id). Mirrors the CLI's `buildPeers` exactly.
+   */
+  principal_pubkey?: string;
+}
+
+/**
+ * The outcome of {@link resolveNetworkRoster}. Never throws — every failure is
+ * a discriminated `ok: false` so a long-running reconciler (P3) can branch
+ * without a try/catch and keep ticking across a transient registry outage.
+ */
+export type ResolveNetworkRosterResult =
+  | {
+      ok: true;
+      /** The peers on the network, local principal excluded. */
+      peers: RosterPeer[];
+      /**
+       * True when the roster came from the DD-10 last-known-good disk cache
+       * because the registry was unreachable (the live fetch failed). The
+       * peers are still trustworthy (cached only after DD-9 verification); the
+       * flag lets a caller surface "stale" in its status/UI.
+       */
+      usedCache: boolean;
+      /**
+       * #762 guard signal — true when the registry roster resolved ZERO peers.
+       * The registry roster is populated implicitly (a principal is "in" a
+       * network only if one of its announced capabilities lists that network),
+       * so an empty roster is the COMMON early state, NOT an error. A caller
+       * that already has hand-pinned peers should PRESERVE them rather than
+       * overwrite with `[]` (the CLI join does exactly this). When this is
+       * true, `peers` is `[]`.
+       */
+      emptyRoster: boolean;
+    }
+  | {
+      ok: false;
+      /** Discriminated reason — mirrors the {@link NetworkFetchResult} negatives. */
+      reason:
+        | "not_found"
+        | "unverified"
+        | "unreachable_uncached";
+      /** Human-readable detail for logs / status. */
+      detail: string;
+    };
+
+// =============================================================================
+// resolveNetworkRoster
+// =============================================================================
+
+/**
+ * Resolve "who is on `networkId`" from the registry, runtime-callable.
+ *
+ * Drives the same DD-9/DD-10 path the CLI join does:
+ *   1. {@link NetworkRegistryClient.fetchAndCache} — verified live fetch
+ *      (refreshes the DD-10 cache on success).
+ *   2. On `unreachable`, fall back to {@link NetworkRegistryClient.loadCached}
+ *      (DD-10). No cached pair ⇒ `unreachable_uncached`.
+ *   3. `not_found` / `unverified` ⇒ a definitive negative (do NOT render a
+ *      roster we couldn't verify).
+ *
+ * On success projects the verified roster members → {@link RosterPeer}[],
+ * excluding `localPrincipalId` (a stack is never in its own peers[]), and
+ * flags an `emptyRoster` so the caller can apply the #762 hand-pin guard.
+ *
+ * Pure over its injected client — no filesystem, network, or env access beyond
+ * what the client encapsulates; trivially testable with a fake client.
+ *
+ * @param networkId        Network whose roster to resolve.
+ * @param localPrincipalId The local principal — excluded from the peer set.
+ * @param client           cortex's OWN registry client (no signal; §4).
+ */
+export async function resolveNetworkRoster(
+  networkId: string,
+  localPrincipalId: string,
+  client: Pick<NetworkRegistryClient, "fetchAndCache" | "loadCached">,
+): Promise<ResolveNetworkRosterResult> {
+  let roster: NetworkRosterResult;
+  let usedCache = false;
+
+  const fetched: NetworkFetchResult<{ roster: NetworkRosterResult }> =
+    await client.fetchAndCache(networkId);
+
+  if (fetched.status === "ok") {
+    roster = fetched.value.roster;
+  } else if (fetched.status === "unreachable") {
+    // DD-10 — registry down → fall back to the last-known-good cached roster
+    // so the reconciler keeps resolving peers across a transient outage. The
+    // cache is written only after DD-9 verification, so the pair is trusted.
+    const cached = client.loadCached(networkId);
+    if (cached === undefined) {
+      return {
+        ok: false,
+        reason: "unreachable_uncached",
+        detail:
+          `registry unreachable (${fetched.reason}) and no cached descriptor ` +
+          `for "${networkId}" — cannot resolve roster`,
+      };
+    }
+    roster = cached.roster;
+    usedCache = true;
+  } else {
+    // not_found / unverified — a definitive negative. Do NOT project a roster
+    // we could not verify (a bad-signature roster never reaches here anyway;
+    // fetchAndCache returns the negative without caching).
+    return {
+      ok: false,
+      reason: fetched.status,
+      detail:
+        fetched.status === "unverified"
+          ? `roster/descriptor failed verification (${fetched.reason}) for "${networkId}"`
+          : `network "${networkId}" not found in registry`,
+    };
+  }
+
+  const peers = buildRosterPeers(localPrincipalId, roster);
+  return {
+    ok: true,
+    peers,
+    usedCache,
+    emptyRoster: peers.length === 0,
+  };
+}
+
+// =============================================================================
+// roster members → peers projection (lifted from network-lib.ts buildPeers)
+// =============================================================================
+
+/**
+ * Project verified roster members → {@link RosterPeer}[] (DD-5). Excludes the
+ * LOCAL principal (a stack is never in its own peers[]). Each peer carries the
+ * wire-segment view (`principal`/`stack`) and the config view
+ * (`principal_id`/`stack_id`/optional nkey `principal_pubkey`).
+ *
+ * `principal_pubkey` is filled from the roster's base64 key, re-encoded to
+ * nkey-U (DD-8), ONLY when re-encodable — otherwise LEFT OFF so the S2
+ * config-load resolver fills it (DD-5: declare by id). This mirrors the CLI's
+ * private `buildPeers` exactly, so the lifted lib is behavior-preserving.
+ *
+ * Exported for direct unit testing of the projection in isolation.
+ */
+export function buildRosterPeers(
+  localPrincipalId: string,
+  roster: NetworkRosterResult,
+): RosterPeer[] {
+  const peers: RosterPeer[] = [];
+  for (const member of roster.members) {
+    if (member.principal_id === localPrincipalId) continue; // never self
+    const stackId = member.stack_id ?? `${member.principal_id}/default`;
+    const stackSlug = stackSlugOf(stackId, member.principal_id);
+    const nkey = base64PubkeyToNkey(member.principal_pubkey);
+    const peer: RosterPeer = {
+      principal: member.principal_id,
+      stack: stackSlug,
+      principal_id: member.principal_id,
+      stack_id: stackId,
+      ...(nkey !== undefined && { principal_pubkey: nkey }),
+    };
+    peers.push(peer);
+  }
+  return peers;
+}
+
+/**
+ * The `{stack}` wire segment — the part after the `/` in a `{principal}/{stack}`
+ * stack id. Falls back to the whole id, then to `default`, for a malformed id
+ * (defensive: the roster is registry-shaped, but a missing `/` should not throw
+ * inside a long-running reconciler).
+ */
+function stackSlugOf(stackId: string, principalId: string): string {
+  const slash = stackId.indexOf("/");
+  if (slash >= 0 && slash < stackId.length - 1) {
+    return stackId.slice(slash + 1);
+  }
+  // No usable slash — derive from `{principal}/default` shape if it matches,
+  // else fall back to `default`.
+  if (stackId === principalId || stackId.length === 0) return "default";
+  return stackId;
+}

--- a/src/bus/agent-network/roster-read.ts
+++ b/src/bus/agent-network/roster-read.ts
@@ -12,12 +12,15 @@
  * ## Reuse, do not rebuild (design §3)
  *
  * The verified fetch + DD-10 disk cache already live in
- * `src/common/registry/`:
+ * `src/common/registry/` and are abstracted by the existing
+ * {@link NetworkRosterProvider} interface (the minimal `{fetchAndCache,
+ * loadCached}` slice of `NetworkRegistryClient`, already exported + structurally
+ * satisfied by the concrete client — reused here rather than re-declared):
  *
- *   - {@link NetworkRegistryClient.fetchAndCache} — `GET /networks/{id}` +
- *     `/roster`, pin+verify (DD-9), cache the pair on success (DD-10).
- *   - {@link NetworkRegistryClient.loadCached} — last-known-good pair when the
- *     registry is unreachable (DD-10 fallback).
+ *   - `fetchAndCache` — `GET /networks/{id}` + `/roster`, pin+verify (DD-9),
+ *     cache the pair on success (DD-10).
+ *   - `loadCached` — last-known-good pair when the registry is unreachable
+ *     (DD-10 fallback).
  *
  * This module is the small piece the CLI kept private: the
  * `fetchAndCache → unreachable → loadCached` orchestration plus the
@@ -27,8 +30,8 @@
  *
  * ## Signal-optional (design §4, hard constraint)
  *
- * This module reads the registry **directly** via cortex's own
- * {@link NetworkRegistryClient}. It has **zero** dependency on the `signal`
+ * This module reads the registry **directly** via cortex's own registry client
+ * (the {@link NetworkRosterProvider} slice). It has **zero** dependency on the `signal`
  * package — signal independently reads the same registry behind its own
  * `RegistryIntentSource` seam (shared *registry*, not shared *package*; the
  * dependency direction is cortex→registry and signal→registry, never
@@ -44,10 +47,8 @@
  * a READ.
  */
 
-import type {
-  NetworkRegistryClient,
-  NetworkFetchResult,
-} from "../../common/registry/network-client";
+import type { NetworkFetchResult } from "../../common/registry/network-client";
+import type { NetworkRosterProvider } from "../../common/registry/resolve-federated-peers";
 import type { NetworkRosterResult } from "../../common/registry/types";
 import { base64PubkeyToNkey } from "../../common/registry/encoding";
 
@@ -137,10 +138,10 @@ export type ResolveNetworkRosterResult =
  * Resolve "who is on `networkId`" from the registry, runtime-callable.
  *
  * Drives the same DD-9/DD-10 path the CLI join does:
- *   1. {@link NetworkRegistryClient.fetchAndCache} — verified live fetch
- *      (refreshes the DD-10 cache on success).
- *   2. On `unreachable`, fall back to {@link NetworkRegistryClient.loadCached}
- *      (DD-10). No cached pair ⇒ `unreachable_uncached`.
+ *   1. `client.fetchAndCache` — verified live fetch (refreshes the DD-10 cache
+ *      on success).
+ *   2. On `unreachable`, fall back to `client.loadCached` (DD-10). No cached
+ *      pair ⇒ `unreachable_uncached`.
  *   3. `not_found` / `unverified` ⇒ a definitive negative (do NOT render a
  *      roster we couldn't verify).
  *
@@ -153,12 +154,13 @@ export type ResolveNetworkRosterResult =
  *
  * @param networkId        Network whose roster to resolve.
  * @param localPrincipalId The local principal — excluded from the peer set.
- * @param client           cortex's OWN registry client (no signal; §4).
+ * @param client           cortex's OWN registry client (the
+ *                         {@link NetworkRosterProvider} slice — no signal; §4).
  */
 export async function resolveNetworkRoster(
   networkId: string,
   localPrincipalId: string,
-  client: Pick<NetworkRegistryClient, "fetchAndCache" | "loadCached">,
+  client: NetworkRosterProvider,
 ): Promise<ResolveNetworkRosterResult> {
   let roster: NetworkRosterResult;
   let usedCache = false;

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -34,7 +34,7 @@ import type {
 } from "../../../common/types/cortex-config";
 import type { NetworkRosterResult } from "../../../common/registry/types";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
-import { base64PubkeyToNkey } from "../../../common/registry/encoding";
+import { buildRosterPeers } from "../../../bus/agent-network/roster-read";
 
 import {
   brandVerified,
@@ -568,27 +568,25 @@ export async function joinNetwork(
  * `stack_id`; `principal_pubkey` is filled from the roster (re-encoded to
  * nkey-U, DD-8) when the roster carries a re-encodable key — otherwise it is
  * LEFT OFF so the S2 config-load resolver resolves it (DD-5: declare by id).
+ *
+ * P1 (cortex#1086) — the roster-members → peers projection now lives in the
+ * runtime-callable `buildRosterPeers` (`src/bus/agent-network/roster-read.ts`)
+ * so the federation reconciler (P3) shares the exact same read. This is the
+ * thin config-shape adapter: `RosterPeer` → `PolicyFederatedPeer`
+ * (dropping the wire-segment view the config doesn't carry). Behavior-
+ * preserving — `buildRosterPeers` lifted this loop verbatim.
  */
 function buildPeers(
   localPrincipalId: string,
   roster: NetworkRosterResult,
 ): PolicyFederatedPeer[] {
-  const peers: PolicyFederatedPeer[] = [];
-  for (const member of roster.members) {
-    if (member.principal_id === localPrincipalId) continue; // never self
-    const stackId =
-      member.stack_id ?? `${member.principal_id}/default`;
-    const nkey = base64PubkeyToNkey(member.principal_pubkey);
-    const peer: PolicyFederatedPeer = nkey === undefined
-      ? { principal_id: member.principal_id, stack_id: stackId }
-      : {
-          principal_id: member.principal_id,
-          stack_id: stackId,
-          principal_pubkey: nkey,
-        };
-    peers.push(peer);
-  }
-  return peers;
+  return buildRosterPeers(localPrincipalId, roster).map((p) => ({
+    principal_id: p.principal_id,
+    stack_id: p.stack_id,
+    ...(p.principal_pubkey !== undefined && {
+      principal_pubkey: p.principal_pubkey,
+    }),
+  }));
 }
 
 /**


### PR DESCRIPTION
## P1 of the roster-driven federation auto-wiring umbrella (#1084)

Lifts cortex's **registry-roster read** out of the `network` CLI into a
**runtime-callable** lib so the federation reconciler (P3, #1088) can resolve
*"who is on network X?"* without invoking a CLI command.

**Design:** `docs/design-roster-driven-federation-wiring.md` §4 (signal-optional), §7 (P1) — spec'd in PR #1083.
**Umbrella:** #1084 (wave 1; parallelizable with P2 #1087, P4 #1089).

### What changed

**New `src/bus/agent-network/roster-read.ts`:**
- `resolveNetworkRoster(networkId, localPrincipalId, client)` — drives the same DD-9/DD-10 path the CLI join does:
  1. `NetworkRegistryClient.fetchAndCache` — verified live fetch (refreshes the DD-10 cache).
  2. On `unreachable` → `loadCached` (DD-10 last-known-good). No cache ⇒ `unreachable_uncached`.
  3. `not_found` / `unverified` ⇒ definitive negative (no cache consult).
  - **Never throws** — every failure is a discriminated `ok:false` so a long-running reconciler branches without try/catch.
- `buildRosterPeers` — lifts the CLI's private roster→peers projection **verbatim** (excludes the local principal; re-encodes the roster key to nkey-U per DD-8, or leaves it off so the S2 resolver fills it per DD-5).
- Surfaces the **#762 `emptyRoster`** signal (0 resolved peers is the common early state, **not** an error) so a caller preserves hand-pins rather than overwriting with `[]`.
- Returns **both** views from one resolve: the wire-segment view (`principal`/`stack` → the reconciler's `federated.{principal}.{stack}.>`) and the config view (`principal_id`/`stack_id`/`principal_pubkey` → `PolicyFederatedPeer`).

**CLI behavior-preserving:** `network-lib.ts buildPeers` now delegates to the lifted `buildRosterPeers` (thin `RosterPeer` → `PolicyFederatedPeer` adapter). This is an **extract + expose**, not a redesign.

### Hard constraints honored
- **No `signal` import.** Zero dependency on the `signal` package — reads the registry directly via cortex's own client (shared *registry*, not shared *package*; design §4). Verified: no signal import in the lib or the `agent-network` tree.
- **DD-10 registry-unreachable → cached fallback preserved** (unit-tested).
- **#762 0-peers guard preserved** (surfaced as `emptyRoster`; CLI guard unchanged).
- Does **not** write any accept-list / federation policy — that's P2 (#1087) / P3 (#1088). This is a READ.

### Tests / checks
- 11 new unit tests: resolve (happy path), stack-default, nkey re-encode + leave-off (DD-5), 0-peers guard (empty + local-only roster), unreachable→cached, unreachable-uncached, `not_found`/`unverified` (no-cache-consult), projection in isolation.
- `bun test` — 245 pass (agent-network + registry), 159 pass (incl. CLI network-lib/adapters/client). 0 fail.
- `bunx tsc --noEmit` — clean. `bun run lint:errors` — clean. `bash scripts/check-carveouts.sh` — PASS.

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)