### PR TITLE
feat(network): C-1087 — derive accept_subjects own ∪ peer subtrees (P2)

### DIFF
--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../surface-router";
 import type { PolicyPublic } from "../../common/types/cortex-config";
 import type { SystemEventSource } from "../system-events";
+import { deriveAcceptSubjects } from "../agent-network/accept-subjects";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1509,6 +1510,93 @@ describe("evaluateFederationGate — accept-list", () => {
       networksMap([makeNetwork({ accept_subjects: [] })]),
     );
     expect(decision).toMatchObject({ kind: "peer_not_in_accept_list", networkId: "research-collab" });
+  });
+});
+
+describe("evaluateFederationGate — P2 (#1087) derived accept-list admits peer presence", () => {
+  // The OQ2 regression guard: BEFORE P2, an OWN-only accept-list rejected a
+  // peer's SOURCE-addressed presence subject even though the peer was in
+  // `peers[]`. AFTER P2 the accept-list is derived own ∪ peer subtrees, so the
+  // SAME gate ADMITS it. We drive the gate with the EXACT accept-list
+  // `deriveAcceptSubjects` produces (not a hand-written one) to prove the
+  // derivation and the gate agree end-to-end.
+
+  // Self = this stack; peer = jc/default (source of the presence).
+  const SELF = { principal: "andreas", stack: "meta-factory" } as const;
+  const derived = deriveAcceptSubjects(SELF, [
+    { principal: "jc", stack: "default" },
+  ]);
+
+  // The network jc rides in on — jc ∈ peers[] so `resolveSourceNetwork`
+  // resolves the source principal, and the derived accept-list is installed.
+  function networkWithJcPeer(): PolicyFederatedNetwork {
+    return makeNetwork({
+      id: "metafactory",
+      leaf_node: "primary", // skip the F-3d source-link cross-check in this test
+      peers: [
+        {
+          principal_id: "jc",
+          stack_id: "jc/default",
+          principal_pubkey: FED_PEER_PUBKEY,
+        },
+      ],
+      accept_subjects: derived,
+    });
+  }
+
+  test("OWN-only accept-list REJECTS jc's presence (the pre-P2 bug, asserted)", () => {
+    const ownOnly = makeNetwork({
+      id: "metafactory",
+      leaf_node: "primary",
+      peers: [
+        {
+          principal_id: "jc",
+          stack_id: "jc/default",
+          principal_pubkey: FED_PEER_PUBKEY,
+        },
+      ],
+      accept_subjects: ["federated.andreas.meta-factory.>"], // OWN-only
+    });
+    const decision = evaluateFederationGate(
+      "federated.jc.default.agent.online",
+      makeFederatedEnvelope({ source: "jc.default.cortex" }),
+      networksMap([ownOnly]),
+    );
+    // jc IS in peers[] (source resolves) but the subject misses the accept-list.
+    expect(decision).toMatchObject({
+      kind: "peer_not_in_accept_list",
+      networkId: "metafactory",
+    });
+  });
+
+  test("derived accept-list ADMITS jc's SOURCE-addressed presence subject", () => {
+    const decision = evaluateFederationGate(
+      "federated.jc.default.agent.online",
+      makeFederatedEnvelope({ source: "jc.default.cortex" }),
+      networksMap([networkWithJcPeer()]),
+    );
+    expect(decision).toBe("allow");
+  });
+
+  test("derived accept-list still ADMITS dispatch addressed TO me (own subtree retained)", () => {
+    const decision = evaluateFederationGate(
+      "federated.andreas.meta-factory.tasks.code-review.ts",
+      makeFederatedEnvelope({ source: "jc.default.cortex" }),
+      networksMap([networkWithJcPeer()]),
+    );
+    expect(decision).toBe("allow");
+  });
+
+  test("a NON-peer's presence is still denied (source unresolved — no over-admission)", () => {
+    const decision = evaluateFederationGate(
+      "federated.stranger.default.agent.online",
+      makeFederatedEnvelope({ source: "stranger.default.cortex" }),
+      networksMap([networkWithJcPeer()]),
+    );
+    expect(decision).toMatchObject({
+      kind: "peer_not_in_accept_list",
+      unknown_network: true,
+    });
   });
 });
 

--- a/src/bus/agent-network/__tests__/accept-subjects.test.ts
+++ b/src/bus/agent-network/__tests__/accept-subjects.test.ts
@@ -1,0 +1,168 @@
+/**
+ * P2 (cortex#1087) — deriveAcceptSubjects unit tests.
+ *
+ * Tests the PURE roster → accept_subjects derivation in isolation against a
+ * roster-peer fixture (no registry, no runtime; the dual-grammar is string
+ * assembly). Covers:
+ *
+ *   1. dual-grammar — own subtree (dispatch, RECEIVER-addressed) ∪ one subtree
+ *      per peer (presence, SOURCE-addressed). The exact OQ2 union.
+ *   2. empty-roster — 0 peers ⇒ OWN-only, preserving the pre-P2 behaviour
+ *      exactly (#762 guard is the CALLER's; the function never returns []).
+ *   3. ordering + de-dupe — own first, peers in roster order, duplicate / self
+ *      subtrees collapsed.
+ *   4. the gate actually admits the derived patterns (subjectMatches round-trip)
+ *      — proves the derivation produces patterns the gate will honour, the
+ *      property gate-level admission depends on.
+ *
+ * Design: docs/design-roster-driven-federation-wiring.md §7 P2 + §8 OQ2.
+ * Umbrella: cortex#1084.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { deriveAcceptSubjects } from "../accept-subjects";
+import type { RosterPeer } from "../roster-read";
+import { subjectMatches } from "../../surface-router";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const SELF = { principal: "andreas", stack: "meta-factory" } as const;
+
+/** A roster peer in the P1 projection shape. Only the wire view is read here. */
+function peer(principal: string, stack: string): RosterPeer {
+  return {
+    principal,
+    stack,
+    principal_id: principal,
+    stack_id: `${principal}/${stack}`,
+  };
+}
+
+const OWN_SUBTREE = "federated.andreas.meta-factory.>";
+
+// =============================================================================
+// dual-grammar union (the OQ2 fix)
+// =============================================================================
+
+describe("deriveAcceptSubjects — dual-grammar union", () => {
+  test("own subtree ∪ one subtree per peer (the OQ2 union)", () => {
+    const subjects = deriveAcceptSubjects(SELF, [peer("jc", "default")]);
+    expect(subjects).toEqual([
+      OWN_SUBTREE, // dispatch addressed TO me (RECEIVER-addressed)
+      "federated.jc.default.>", // presence sourced FROM jc (SOURCE-addressed)
+    ]);
+  });
+
+  test("multiple peers → own + each peer subtree, in roster order", () => {
+    const subjects = deriveAcceptSubjects(SELF, [
+      peer("jc", "sage-host"),
+      peer("dana", "default"),
+    ]);
+    expect(subjects).toEqual([
+      OWN_SUBTREE,
+      "federated.jc.sage-host.>",
+      "federated.dana.default.>",
+    ]);
+  });
+
+  test("a peer with a non-default stack slug uses that slug, not 'default'", () => {
+    const subjects = deriveAcceptSubjects(SELF, [peer("jc", "research")]);
+    expect(subjects).toContain("federated.jc.research.>");
+  });
+});
+
+// =============================================================================
+// empty roster — OWN-only, pre-P2 behaviour preserved
+// =============================================================================
+
+describe("deriveAcceptSubjects — empty roster (#762-adjacent)", () => {
+  test("0 peers → OWN-only accept-list (exactly the pre-P2 behaviour)", () => {
+    expect(deriveAcceptSubjects(SELF, [])).toEqual([OWN_SUBTREE]);
+  });
+
+  test("never returns [] for a valid self — own subtree is always present", () => {
+    const subjects = deriveAcceptSubjects(SELF, []);
+    expect(subjects.length).toBeGreaterThan(0);
+    expect(subjects[0]).toBe(OWN_SUBTREE);
+  });
+});
+
+// =============================================================================
+// ordering + de-dupe
+// =============================================================================
+
+describe("deriveAcceptSubjects — ordering + de-dupe", () => {
+  test("own subtree comes first", () => {
+    const subjects = deriveAcceptSubjects(SELF, [peer("jc", "default")]);
+    expect(subjects[0]).toBe(OWN_SUBTREE);
+  });
+
+  test("a peer whose subtree equals the self subtree is collapsed (no dup own row)", () => {
+    // Defensive: P1 excludes the local principal, but if a self-shaped peer
+    // slips through, the own row must not appear twice.
+    const subjects = deriveAcceptSubjects(SELF, [
+      peer("andreas", "meta-factory"),
+    ]);
+    expect(subjects).toEqual([OWN_SUBTREE]);
+  });
+
+  test("two roster entries with the same principal/stack contribute the pattern once", () => {
+    const subjects = deriveAcceptSubjects(SELF, [
+      peer("jc", "default"),
+      peer("jc", "default"),
+    ]);
+    expect(subjects).toEqual([OWN_SUBTREE, "federated.jc.default.>"]);
+  });
+
+  test("same principal, different stacks → two distinct subtrees", () => {
+    const subjects = deriveAcceptSubjects(SELF, [
+      peer("jc", "default"),
+      peer("jc", "sage-host"),
+    ]);
+    expect(subjects).toEqual([
+      OWN_SUBTREE,
+      "federated.jc.default.>",
+      "federated.jc.sage-host.>",
+    ]);
+  });
+
+  test("does not mutate the input peers array", () => {
+    const peers = [peer("jc", "default")];
+    const before = JSON.stringify(peers);
+    deriveAcceptSubjects(SELF, peers);
+    expect(JSON.stringify(peers)).toBe(before);
+  });
+});
+
+// =============================================================================
+// the derived patterns are honoured by the gate's matcher (round-trip)
+// =============================================================================
+
+describe("deriveAcceptSubjects — derived patterns match real wire subjects", () => {
+  const subjects = deriveAcceptSubjects(SELF, [peer("jc", "default")]);
+
+  test("own subtree matches an inbound DISPATCH subject addressed to me", () => {
+    const hit = subjects.some((p) =>
+      subjectMatches(p, "federated.andreas.meta-factory.tasks.code-review.ts"),
+    );
+    expect(hit).toBe(true);
+  });
+
+  test("peer subtree matches an inbound PRESENCE subject sourced from the peer", () => {
+    // This is the subject the OWN-only accept-list rejected pre-P2.
+    const hit = subjects.some((p) =>
+      subjectMatches(p, "federated.jc.default.agent.online"),
+    );
+    expect(hit).toBe(true);
+  });
+
+  test("a NON-peer's presence subject still matches NOTHING (no over-admission)", () => {
+    const hit = subjects.some((p) =>
+      subjectMatches(p, "federated.stranger.default.agent.online"),
+    );
+    expect(hit).toBe(false);
+  });
+});

--- a/src/bus/agent-network/accept-subjects.ts
+++ b/src/bus/agent-network/accept-subjects.ts
@@ -1,0 +1,137 @@
+/**
+ * P2 (cortex#1087, design-roster-driven-federation-wiring §7 P2 + §8 OQ2) — the
+ * pure derivation of a network's `accept_subjects` from its roster peer set.
+ *
+ * ## The gap this closes (OQ2, RESOLVED)
+ *
+ * `evaluateFederationGate` (`src/bus/surface-router.ts`) admits an inbound
+ * `federated.*` envelope only when (1) the SOURCE principal resolves via
+ * `peers[]` AND (2) `accept_subjects` contains a pattern matching the SUBJECT.
+ * Those two checks are SEPARATE: being in `peers[]` is necessary but NOT
+ * sufficient — the accept-list is a second, independent gate keyed on the wire
+ * SUBJECT, not on peer membership.
+ *
+ * Before this slice, `network join` wrote an OWN-only accept-list
+ * (`federated.{self.principal}.{self.stack}.>`). That admits inbound DISPATCH
+ * (which is RECEIVER-addressed — a peer dispatching TO me publishes onto MY
+ * subtree) but REJECTS inbound PRESENCE, which is SOURCE-addressed: the
+ * federated presence subscriber binds `federated.*.*.agent.>` where segment[1]
+ * is the SOURCE peer principal (ADR-0007). So `jc`'s
+ * `federated.jc.{stack}.agent.online` never matches an OWN-only
+ * `federated.andreas.meta-factory.>` accept-list — it is denied at gate step 3
+ * even though `jc ∈ peers[]`. The accept-list IS the gate; widening it is the fix.
+ *
+ * ## Dual-grammar (honour BOTH addressing conventions)
+ *
+ * Federated subjects carry the wire grammar `federated.{addressee}.{stack}.…`
+ * where `{addressee}` means different principals for the two traffic classes:
+ *
+ *   - **DISPATCH is RECEIVER-addressed** — a peer dispatching work TO me targets
+ *     `federated.{ME}.{my-stack}.…`. I accept my OWN subtree.
+ *   - **PRESENCE is SOURCE-addressed** — a peer announcing ITS presence publishes
+ *     `federated.{PEER}.{peer-stack}.agent.…`. I accept each PEER's subtree.
+ *
+ * So a correct accept-list legitimately needs BOTH: my own subtree (for inbound
+ * dispatch) ∪ one subtree per roster peer (for inbound presence). That union is
+ * exactly what {@link deriveAcceptSubjects} produces.
+ *
+ * ## Empty-roster (#762) — caller's concern, not this function's
+ *
+ * This is a PURE projection: 0 peers in ⇒ just the own subtree out. It NEVER
+ * returns `[]` for a valid `self` (the own subtree is always present), so the
+ * accept-list is never accidentally emptied. The #762 "0 resolved peers →
+ * preserve hand-pins" guard is a SEPARATE policy decision the `network join`
+ * builder makes about the PEERS list; this function does not entangle with it.
+ * When the join preserves prior hand-pinned peers, it derives the accept-list
+ * from THAT preserved peer set, so the two stay consistent (see network-lib.ts).
+ *
+ * ## Signal-optional (design §4, hard constraint)
+ *
+ * Pure over its inputs — no registry, no filesystem, no `signal` import. It
+ * consumes the minimal `{principal, stack}` wire view (structurally satisfied by
+ * the P1 {@link RosterPeer} projection from the verified roster, and by the
+ * config-peer view the `network join` builder writes); whoever resolved that
+ * roster (the CLI today, the P3 reconciler tomorrow) owns the trust boundary.
+ * This is string assembly.
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * A wire identity — the two segments that build a federated subtree
+ * `federated.{principal}.{stack}.>`. Used for BOTH the local stack (its own
+ * subtree, for inbound dispatch) and each roster peer (its subtree, for inbound
+ * presence). Structurally a subset of the P1 `RosterPeer` shape, so a
+ * `RosterPeer[]` is accepted directly without an adapter.
+ */
+export interface FederatedWireIdentity {
+  /** Principal id — the `{principal}` wire segment. */
+  principal: string;
+  /** Stack slug — the `{stack}` wire segment. */
+  stack: string;
+}
+
+/** The local stack's wire identity — alias for readability at call sites. */
+export type AcceptSubjectsSelf = FederatedWireIdentity;
+
+// =============================================================================
+// deriveAcceptSubjects
+// =============================================================================
+
+/**
+ * Derive a network's `accept_subjects` from the local stack identity + its
+ * roster peer set, honouring the dual-grammar (design §7 P2):
+ *
+ *   `[ federated.{self.principal}.{self.stack}.>,           // dispatch TO me
+ *      ...federated.{peer.principal}.{peer.stack}.> per peer // presence FROM peers
+ *   ]`
+ *
+ * The own subtree comes FIRST (stable, human-readable ordering: "my subtree,
+ * then the peers I accept presence from"), followed by one subtree per peer in
+ * roster order. Duplicates are collapsed (a peer that somehow equals the self,
+ * or two roster entries with the same principal/stack, contribute the pattern
+ * once) so the written accept-list has no redundant rows — `subjectMatches` is
+ * order-/duplicate-insensitive, but a clean list reads better in config and in
+ * the `network status` view.
+ *
+ * Pure: no I/O, no mutation of inputs, deterministic. Never returns `[]` for a
+ * valid `self` — the own subtree is always present, so this function cannot
+ * accidentally empty a stack's accept-list (the OWN-only behaviour it replaces
+ * is the degenerate `peers.length === 0` case, preserved exactly).
+ *
+ * @param self  The local stack's `{principal}`/`{stack}` wire identity.
+ * @param peers The network's roster peers (local principal already excluded by
+ *              the P1 projection; an accidental self-entry is de-duped anyway).
+ */
+export function deriveAcceptSubjects(
+  self: AcceptSubjectsSelf,
+  peers: readonly FederatedWireIdentity[],
+): string[] {
+  const ownSubtree = federatedSubtree(self.principal, self.stack);
+
+  // Insertion-ordered de-dupe: own subtree first, then each peer's subtree.
+  const seen = new Set<string>([ownSubtree]);
+  const out: string[] = [ownSubtree];
+
+  for (const peer of peers) {
+    const subtree = federatedSubtree(peer.principal, peer.stack);
+    if (seen.has(subtree)) continue;
+    seen.add(subtree);
+    out.push(subtree);
+  }
+
+  return out;
+}
+
+/**
+ * The `federated.{principal}.{stack}.>` subtree wildcard for one wire identity —
+ * the single accept-list pattern that admits every federated subject addressed
+ * to (dispatch) or sourced from (presence) `{principal}/{stack}`. The terminal
+ * `>` matches one-or-more trailing segments (`subjectMatches`, surface-router),
+ * covering `…agent.online`, `…tasks.code-review.ts`, and every other action.
+ */
+function federatedSubtree(principal: string, stack: string): string {
+  return `federated.${principal}.${stack}.>`;
+}

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -13,8 +13,10 @@
  *     its own peers[].
  *   - leave reverses exactly + is idempotent.
  *   - status renders joined networks + peers + link state.
- *   - wire contract: accept_subjects = the stack's OWN federated.{me}.{stack}.>
- *     (no network id on the wire).
+ *   - wire contract (P2 #1087): accept_subjects = the stack's OWN
+ *     federated.{me}.{stack}.> (inbound dispatch) ∪ each roster peer's
+ *     federated.{peer}.{peer-stack}.> (inbound presence) — no network id on the
+ *     wire. Empty roster collapses to the OWN-only list.
  */
 
 import { describe, test, expect } from "bun:test";
@@ -1017,13 +1019,19 @@ describe("join", () => {
     });
   });
 
-  test("accept_subjects is the stack's OWN federated.{me}.{stack}.> (wire contract)", async () => {
+  test("accept_subjects = own ∪ peer subtrees, never the network id (wire contract, P2 #1087)", async () => {
     const { ports, storeRef } = makeFakes({});
     await joinNetwork("metafactory", LOCAL, ports);
     const net = storeRef.networks[0]!;
-    // The wire contract: own principal/stack segment, NOT the network id.
-    expect(net.accept_subjects).toEqual(["federated.andreas.meta-factory.>"]);
-    // Network id must NOT appear in any accept subject (no network on the wire).
+    // P2: own subtree (dispatch TO me) ∪ each roster peer's subtree (presence
+    // FROM peers). rosterFor() resolves one peer, jc/sage-host.
+    expect(net.accept_subjects).toEqual([
+      "federated.andreas.meta-factory.>",
+      "federated.jc.sage-host.>",
+    ]);
+    // The wire contract STILL holds: subjects gate by principal/stack segments,
+    // never the network id `metafactory` (note `meta-factory` is the stack SLUG,
+    // a hyphenated segment that does not contain the un-hyphenated network id).
     expect(net.accept_subjects.some((s) => s.includes("metafactory"))).toBe(false);
   });
 
@@ -1362,6 +1370,80 @@ describe("#762 empty roster preserves hand-pins", () => {
     expect(
       b.storeRef.networks.find((n) => n.id === "metafactory")!.announce_capabilities,
     ).toEqual(["chat", "release"]);
+  });
+});
+
+// =============================================================================
+// P2 (#1087) — accept_subjects = own ∪ peer subtrees (dual-grammar, OQ2 fix)
+// =============================================================================
+
+describe("P2 #1087 accept_subjects derivation", () => {
+  test("normal join → OWN subtree ∪ each roster peer's subtree (dual-grammar)", async () => {
+    // rosterFor() yields one real peer: jc/sage-host (andreas is self → excluded).
+    const { ports, storeRef } = makeFakes({});
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    const net = storeRef.networks.find((n) => n.id === "metafactory")!;
+    expect(net.accept_subjects).toEqual([
+      "federated.andreas.meta-factory.>", // dispatch addressed TO me
+      "federated.jc.sage-host.>", // jc's presence, SOURCE-addressed
+    ]);
+  });
+
+  test("the step log records the derived accept-list (not OWN-only)", async () => {
+    const { ports } = makeFakes({});
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    expect(
+      res.steps.some(
+        (s) =>
+          s.includes("federated.andreas.meta-factory.>") &&
+          s.includes("federated.jc.sage-host.>"),
+      ),
+    ).toBe(true);
+  });
+
+  test("empty-roster preserve path → accept-list derived from the PRESERVED peers", async () => {
+    // handPinnedNetwork pins peer `andreas/meta-factory` — which EQUALS the self
+    // subtree, so the derived list collapses to OWN-only (the dedupe). The point:
+    // the accept-list is derived from the FINAL (preserved) peer set, staying
+    // consistent with whatever peers are actually written.
+    const { ports, storeRef } = makeFakes({
+      fetch: {
+        status: "ok",
+        value: {
+          descriptor: descriptorFor("metafactory"),
+          roster: emptyRosterFor("metafactory"),
+        },
+      },
+      initialNetworks: [handPinnedNetwork("metafactory")],
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    const net = storeRef.networks.find((n) => n.id === "metafactory")!;
+    // Preserved peer == self subtree → deduped to OWN-only.
+    expect(net.accept_subjects).toEqual(["federated.andreas.meta-factory.>"]);
+  });
+
+  test("first-join empty roster → OWN-only accept-list (pre-P2 behaviour preserved)", async () => {
+    const { ports, storeRef } = makeFakes({
+      fetch: {
+        status: "ok",
+        value: {
+          descriptor: descriptorFor("metafactory"),
+          roster: emptyRosterFor("metafactory"),
+        },
+      },
+      // No initial networks — first join, 0 peers.
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    const net = storeRef.networks.find((n) => n.id === "metafactory")!;
+    expect(net.accept_subjects).toEqual(["federated.andreas.meta-factory.>"]);
   });
 });
 

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -9,10 +9,13 @@
  *
  * S4 writes the federation config, so it must be on-contract:
  *
- *   - **accept_subjects** = the stack's OWN `federated.{me}.{stack}.>` ONLY.
- *     A network never names itself on the wire; accept-lists gate by the
- *     stack's own principal/stack segment. We NEVER write the network id into
- *     a subject.
+ *   - **accept_subjects** = the stack's OWN `federated.{me}.{stack}.>` (inbound
+ *     dispatch, RECEIVER-addressed) ∪ each roster peer's
+ *     `federated.{peer}.{peer-stack}.>` (inbound presence, SOURCE-addressed) —
+ *     the dual-grammar union derived by `deriveAcceptSubjects` (P2 #1087,
+ *     design §7 P2 / §8 OQ2). A network never names ITSELF on the wire;
+ *     accept-lists gate by principal/stack segments only. We NEVER write the
+ *     network id into a subject.
  *   - **peers[]** declare by `principal_id` (+ `stack_id`), pubkey
  *     registry-resolved (DD-5) — the local principal is never in its own
  *     peers[].
@@ -35,6 +38,10 @@ import type {
 import type { NetworkRosterResult } from "../../../common/registry/types";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 import { buildRosterPeers } from "../../../bus/agent-network/roster-read";
+import {
+  deriveAcceptSubjects,
+  type FederatedWireIdentity,
+} from "../../../bus/agent-network/accept-subjects";
 
 import {
   brandVerified,
@@ -335,7 +342,6 @@ export async function joinNetwork(
   // converges (idempotent). `try` spans both writes so the step log records how
   // far the mutation got before the failure.
   const resolvedPeers = buildPeers(stack.principalId, roster);
-  const acceptSubject = `federated.${stack.principalId}.${stack.stackSlug}.>`;
   const warnings: string[] = [];
 
   // (d-pre) #762 — never clobber a working hand-pin with 0 resolved peers.
@@ -368,11 +374,34 @@ export async function joinNetwork(
     steps.push(`WARN: ${warn}`);
   }
 
+  // (d) P2 (#1087, design §7 P2 / §8 OQ2) — derive `accept_subjects` from the
+  // FINAL peer set (own ∪ peer subtrees), not OWN-only. The gate
+  // (`evaluateFederationGate`) keys gate-step-3 on the inbound SUBJECT, and the
+  // two federated traffic classes are addressed differently (dual-grammar):
+  //
+  //   - DISPATCH is RECEIVER-addressed → admitted by the OWN subtree
+  //     `federated.{me}.{my-stack}.>` (a peer dispatching TO me publishes here).
+  //   - PRESENCE is SOURCE-addressed → admitted by each PEER's subtree
+  //     `federated.{peer}.{peer-stack}.>` (the federated presence subscriber
+  //     binds `federated.*.*.agent.>`, segment[1] = the SOURCE peer; ADR-0007).
+  //
+  // An OWN-only accept-list (the pre-P2 behaviour) rejected every peer's
+  // presence even though the peer was in `peers[]` — peer membership and the
+  // accept-list are SEPARATE gates. We derive over `peers` (the post-#762 set:
+  // registry-resolved, or the preserved hand-pins) so the accept-list stays
+  // consistent with whatever peers are actually written. With 0 peers the
+  // derivation collapses to exactly the prior OWN-only list (behaviour-
+  // preserving for the empty-roster first-join case).
+  const acceptSubjects = deriveAcceptSubjects(
+    { principal: stack.principalId, stack: stack.stackSlug },
+    peers.map(peerToWireIdentity),
+  );
+
   const entry: PolicyFederatedNetwork = {
     id: networkId,
     leaf_node: stack.leafNode ?? networkId,
     peers,
-    accept_subjects: [acceptSubject],
+    accept_subjects: acceptSubjects,
     deny_subjects: [],
     // #762 — PRESERVE the hand-authored announce_capabilities for this network.
     // `deriveJoinInputs` sources the caps the join announces INTO the roster from
@@ -397,12 +426,14 @@ export async function joinNetwork(
     steps.push(`ensured local.conf includes leafnodes-${networkId}.conf`);
 
     // (d) Merge the network into the federation config with registry-resolved
-    // peers (DD-5) + the OWN accept-subject (wire contract). Idempotent: replace
-    // the entry keyed by network id, never append a duplicate.
+    // peers (DD-5) + the derived own ∪ peer accept-subjects (P2 #1087, wire
+    // contract). Idempotent: replace the entry keyed by network id, never append
+    // a duplicate.
     const merged = mergeNetwork(existing, entry);
     ports.configStore.writeNetworks(merged);
     steps.push(
-      `wrote policy.federated.networks["${networkId}"] — ${peers.length.toString()} peer(s), accept ${acceptSubject}`,
+      `wrote policy.federated.networks["${networkId}"] — ${peers.length.toString()} peer(s), ` +
+        `accept ${acceptSubjects.join(", ")}`,
     );
   } catch (err) {
     return {
@@ -587,6 +618,26 @@ function buildPeers(
       principal_pubkey: p.principal_pubkey,
     }),
   }));
+}
+
+/**
+ * Project a written {@link PolicyFederatedPeer} → the `{principal, stack}` wire
+ * view {@link deriveAcceptSubjects} consumes (P2 #1087). The `stack` segment is
+ * the part AFTER the `/` in `stack_id` (`{principal}/{stack}`); a malformed id
+ * with no usable slash falls back to `default` (mirrors `roster-read`'s
+ * `stackSlugOf`, so the accept-list segment matches the leaf-write/peer view).
+ *
+ * Exported for direct unit testing of the projection in isolation.
+ */
+export function peerToWireIdentity(
+  peer: PolicyFederatedPeer,
+): FederatedWireIdentity {
+  const slash = peer.stack_id.indexOf("/");
+  const stack =
+    slash >= 0 && slash < peer.stack_id.length - 1
+      ? peer.stack_id.slice(slash + 1)
+      : "default";
+  return { principal: peer.principal_id, stack };
 }
 
 /**


### PR DESCRIPTION
Closes #1087. Sub-issue of umbrella #1084 (roster-driven federation auto-wiring). Builds on P1 (#1093). Design: `docs/design-roster-driven-federation-wiring.md` §7 P2 + §8 OQ2 (resolved).

## Why (OQ2, resolved)

`evaluateFederationGate` (`src/bus/surface-router.ts`) admits an inbound `federated.*` envelope only when **(1)** the SOURCE principal resolves via `peers[]` **AND (2)** `accept_subjects` contains a pattern matching the **SUBJECT**. Those are two *separate* gates — peer membership is necessary but not sufficient.

`network join` wrote an **OWN-only** accept-list (`federated.{me}.{stack}.>`). Under the dual-grammar:

- **DISPATCH is RECEIVER-addressed** — a peer dispatching TO me publishes onto `federated.{me}.{my-stack}.…` → admitted by the own subtree.
- **PRESENCE is SOURCE-addressed** — a peer announces ITS presence on `federated.{peer}.{peer-stack}.agent.…`; the federated presence subscriber binds `federated.*.*.agent.>` where segment[1] = the SOURCE peer (ADR-0007) → **rejected** by an OWN-only accept-list, even though the peer is in `peers[]`.

The accept-list IS the gate. This slice widens it.

## What changed

1. **New pure fn** `deriveAcceptSubjects(self, peers)` — `src/bus/agent-network/accept-subjects.ts`. Returns `[federated.{self.principal}.{self.stack}.>, ...federated.{peer.principal}.{peer.stack}.> per peer]`, own-first, de-duped. Never returns `[]` for a valid self (empty roster collapses to exactly the prior OWN-only list — behavior-preserving). No registry/fs/`signal` — string assembly over the P1 `RosterPeer` wire view.
2. **Wired into the `network join` policy builder** (`src/cli/cortex/commands/network-lib.ts`). Derives over the **FINAL** peer set (post-#762 preserve guard) so the accept-list stays consistent with whatever peers are actually written. The #762 "0 resolved peers → preserve hand-pins" guard is preserved. Added `peerToWireIdentity` to project the written `PolicyFederatedPeer` → the `{principal, stack}` wire view (schema guarantees `stack_id` is `{principal}/{stack}`).
3. **Gate-level test**: with the derived accept-list installed, `evaluateFederationGate` ADMITS a peer's `federated.{peer}.{stack}.agent.online` (asserted rejected pre-P2), still admits dispatch to me, and still denies a non-peer (no over-admission). Reuses the exported gate fn.

## Tests
- `accept-subjects.test.ts` — 13 unit tests: dual-grammar union, empty-roster OWN-only, ordering + de-dupe (incl. self-collapse), `subjectMatches` round-trip.
- `surface-router.test.ts` — 4 gate-level tests (the OQ2 admit, the pre-P2 reject asserted, dispatch retained, non-peer denied).
- `network-lib.test.ts` — wiring: normal join derives own ∪ peer, preserve-path derives from preserved peers, first-join empty roster → OWN-only; updated the superseded OWN-only wire-contract test.
- Full suite green (7049 pass / 0 fail). `lint:errors`, `tsc --noEmit`, `check-carveouts.sh` all clean.

## Out of scope (noted)
- **Emit side / `in>0` end-to-end** — the producer `federate` flag (default OFF) still gates outbound; flipping it + confirming `cortex network status` shows `in>0` (transport/leaf interest) is **P3 (#1088) / verify**. Not touched here.
- **The continuous reconciler** — P3 (#1088).
- **`offer.ts` `projectFederationConfig`** is a SEPARATE accept_subjects writer (config-load/offer path) still OWN-only; reconciling it to the same dual-grammar is a follow-up outside P2's `network join` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)