### PR TITLE
feat(cli): register 'cortex creds' subcommand (O-2.5 #1061 follow-up)

### DIFF
--- a/src/__tests__/cortex.cli-dispatch.test.ts
+++ b/src/__tests__/cortex.cli-dispatch.test.ts
@@ -117,3 +117,21 @@ describe("#752 — start/stop/status unaffected", () => {
     expect(r.stdout).toContain("provision-stack");
   });
 });
+
+describe("O-2.5 (#1061) — creds passthrough", () => {
+  test("`cortex creds --help` routes to the creds dispatcher", async () => {
+    const r = await runCortex(["creds", "--help"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("cortex creds");
+    expect(r.stdout).toContain("issue");
+    expect(r.stdout).toContain("revoke");
+    expect(r.stdout).toContain("rotate");
+    expect(r.stdout + r.stderr).not.toContain("cortex: starting");
+  });
+
+  test("`cortex --help` lists creds alongside the other subcommands", async () => {
+    const r = await runCortex(["--help"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("creds");
+  });
+});

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -222,6 +222,7 @@ import { dispatchNetwork } from "./cli/cortex/commands/network";
 import { dispatchOffer } from "./cli/cortex/commands/offer";
 import { dispatchProvisionStack } from "./cli/cortex/commands/provision-stack";
 import { dispatchStack } from "./cli/cortex/commands/stack";
+import { dispatchCreds } from "./cli/cortex/commands/creds";
 
 import { CloudPublisher } from "./taps/cc-events/cloud-publisher";
 import {
@@ -6286,6 +6287,27 @@ if (import.meta.main) {
     .helpOption(false)
     .action(async (args: string[]) => {
       const result = await dispatchOffer(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
+    });
+
+  // O-2.5 (#1061) — per-agent NATS user credentials (issue/list/revoke/rotate),
+  // a thin delegator to `arc nats … --json`. Same passthrough shape as
+  // `network` / `stack` / `offer`: `dispatchCreds` owns its own arg parsing
+  // (incl. the `creds issue <agent-id> --account/--pub/--sub` form), so
+  // commander hands it the raw remaining argv untouched. The module landed in
+  // #1061 but was never wired into the CLI here — `cortex creds …` was an
+  // unknown command until this registration.
+  program
+    .command("creds")
+    .description("Manage per-agent NATS user credentials (issue / list / revoke / rotate)")
+    .argument("[args...]", "creds subcommand + flags (see `cortex creds --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const result = await dispatchCreds(args);
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
       process.exit(result.exitCode);


### PR DESCRIPTION
**The gap:** #1061 (O-2.5) landed `creds.ts` (issue/list/revoke/rotate — thin delegator to `arc nats add-bot`) but never registered it in the `src/cortex.ts` dispatcher. So `cortex creds …` was an unknown command (only `bun …/creds.ts` worked) — the 'one-command' UX the spec promised was missing, and the onboarding tender's brain (it shells `cortex creds issue`) + the dev-loop/tender stack bus-cred provisioning were blocked.

**Fix:** add the import + the #752-style passthrough `.command("creds")` block in `src/cortex.ts`, identical to network/stack/offer. `dispatchCreds` already exists; this just wires it.

Verified: `cortex creds --help` + `cortex creds issue …` route; top-level help lists `creds`; +2 dispatch tests; tsc clean; carve-out PASS. Refs cortex#1061, #1050. Unblocks the onboarding-tender + dev-loop last mile.