### PR TITLE
feat(registry): O-4a.1 — issuance-request state machine (register→PENDING, admin-gated grant/reject)

### DIFF
--- a/src/services/network-registry/__tests__/d1-mock.ts
+++ b/src/services/network-registry/__tests__/d1-mock.ts
@@ -39,6 +39,18 @@ interface NetworkRow {
   updated_at: string;
 }
 
+interface IssuanceRequestRow {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  requested_scope: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  granted_by: string | null;
+  leaf_package: string | null;
+}
+
 /** What D1's `.run()` returns — we only populate `meta.changes`. */
 interface RunResult {
   meta: { changes: number };
@@ -83,6 +95,10 @@ export class MockD1 {
   readonly principals = new Map<string, PrincipalRow>();
   readonly networks = new Map<string, NetworkRow>();
   readonly nonces = new Map<string, number>();
+  /** Keyed by request_id */
+  readonly issuanceRequests = new Map<string, IssuanceRequestRow>();
+  /** Maps (principal_id + "\x00" + peer_pubkey) → request_id for the unique constraint */
+  private readonly issuancePeerIndex = new Map<string, string>();
 
   /** Count of writes, exposed so tests can assert query activity if needed. */
   writeCount = 0;
@@ -182,6 +198,52 @@ export class MockD1 {
       return { meta: { changes: n } };
     }
 
+    // issuance_requests: INSERT (upsertPending — no re-insert path; D1IssuanceRequestStore pre-checks)
+    if (sql.startsWith("INSERT INTO issuance_requests")) {
+      const [requestId, principalId, peerPubkey, requestedScope, createdAt, updatedAt] = args as [
+        string, string, string, string, string, string,
+      ];
+      const peerKey = `${principalId}\x00${peerPubkey}`;
+      // Enforce UNIQUE(principal_id, peer_pubkey)
+      if (this.issuancePeerIndex.has(peerKey)) {
+        return { meta: { changes: 0 } }; // conflict — no-op
+      }
+      const row: IssuanceRequestRow = {
+        request_id: requestId,
+        principal_id: principalId,
+        peer_pubkey: peerPubkey,
+        requested_scope: requestedScope,
+        status: "PENDING",
+        created_at: createdAt,
+        updated_at: updatedAt,
+        granted_by: null,
+        leaf_package: null,
+      };
+      this.issuanceRequests.set(requestId, row);
+      this.issuancePeerIndex.set(peerKey, requestId);
+      return { meta: { changes: 1 } };
+    }
+
+    // issuance_requests: UPDATE (transitionIssuanceRequest — CAS on status='PENDING')
+    if (sql.startsWith("UPDATE issuance_requests SET status")) {
+      const [newStatus, grantedBy, updatedAt, requestId] = args as [string, string, string, string];
+      const existing = this.issuanceRequests.get(requestId);
+      if (!existing || existing.status !== "PENDING") {
+        return { meta: { changes: 0 } };
+      }
+      const updated: IssuanceRequestRow = { ...existing, status: newStatus, granted_by: grantedBy, updated_at: updatedAt };
+      this.issuanceRequests.set(requestId, updated);
+      return { meta: { changes: 1 } };
+    }
+
+    // issuance_requests: reset
+    if (sql === "DELETE FROM issuance_requests") {
+      const n = this.issuanceRequests.size;
+      this.issuanceRequests.clear();
+      this.issuancePeerIndex.clear();
+      return { meta: { changes: n } };
+    }
+
     throw new Error(`MockD1: unhandled write statement: ${sql}`);
   }
 
@@ -205,6 +267,31 @@ export class MockD1 {
       const id = args[0] as string;
       const row = this.networks.get(id);
       return row ? [row] : [];
+    }
+
+    // issuance_requests: SELECT by request_id
+    if (sql.includes("FROM issuance_requests WHERE request_id =")) {
+      const id = args[0] as string;
+      const row = this.issuanceRequests.get(id);
+      return row ? [row] : [];
+    }
+
+    // issuance_requests: SELECT by (principal_id, peer_pubkey)
+    if (sql.includes("FROM issuance_requests WHERE principal_id = ? AND peer_pubkey =")) {
+      const [principalId, peerPubkey] = args as [string, string];
+      const key = `${principalId}\x00${peerPubkey}`;
+      const requestId = this.issuancePeerIndex.get(key);
+      if (!requestId) return [];
+      const row = this.issuanceRequests.get(requestId);
+      return row ? [row] : [];
+    }
+
+    // issuance_requests: SELECT by status ORDER BY created_at
+    if (sql.includes("FROM issuance_requests WHERE status =")) {
+      const status = args[0] as string;
+      return [...this.issuanceRequests.values()]
+        .filter((r) => r.status === status)
+        .sort((a, b) => a.created_at.localeCompare(b.created_at));
     }
 
     throw new Error(`MockD1: unhandled read statement: ${sql}`);

--- a/src/services/network-registry/__tests__/d1-mock.ts
+++ b/src/services/network-registry/__tests__/d1-mock.ts
@@ -198,15 +198,16 @@ export class MockD1 {
       return { meta: { changes: n } };
     }
 
-    // issuance_requests: INSERT (upsertPending — no re-insert path; D1IssuanceRequestStore pre-checks)
+    // issuance_requests: INSERT ... ON CONFLICT(principal_id, peer_pubkey) DO NOTHING
+    // (M3 atomic upsert — D1IssuanceRequestStore.upsertPending)
     if (sql.startsWith("INSERT INTO issuance_requests")) {
       const [requestId, principalId, peerPubkey, requestedScope, createdAt, updatedAt] = args as [
         string, string, string, string, string, string,
       ];
       const peerKey = `${principalId}\x00${peerPubkey}`;
-      // Enforce UNIQUE(principal_id, peer_pubkey)
+      // ON CONFLICT(principal_id, peer_pubkey) DO NOTHING — idempotent.
       if (this.issuancePeerIndex.has(peerKey)) {
-        return { meta: { changes: 0 } }; // conflict — no-op
+        return { meta: { changes: 0 } }; // existing row wins, no-op
       }
       const row: IssuanceRequestRow = {
         request_id: requestId,

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -8,8 +8,8 @@
  */
 
 import { canonicalJSON, generateKeypair, signEd25519 } from "../src/signing";
-import type { Capability, RegistrationClaim, StackIdentity } from "../src/types";
-import { _setNonceCacheForTest, _setStoreForTest } from "../src/store";
+import type { Capability, IssuanceDecisionClaim, IssuanceReadClaim, RegistrationClaim, StackIdentity } from "../src/types";
+import { _setNonceCacheForTest, _setStoreForTest, _setIssuanceStoreForTest } from "../src/store";
 import { _resetDerivedPublicKeyForTest } from "../src/index";
 import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
 
@@ -47,6 +47,7 @@ export async function makeRegistryKey(): Promise<{
 export function resetStores(): void {
   _setStoreForTest(undefined);
   _setNonceCacheForTest(undefined);
+  _setIssuanceStoreForTest(undefined);
   _resetDerivedPublicKeyForTest();
   _resetRateLimitBucketsForTest();
 }
@@ -101,6 +102,61 @@ export function randomNonce(): string {
     out += bytes[i]!.toString(16).padStart(2, "0");
   }
   return out;
+}
+
+// =============================================================================
+// O-4a.1 — signed-admin issuance decision + read test rig
+// =============================================================================
+
+/**
+ * Build a signed admin decision body for grant/reject.
+ * Mirrors `makeSignedNetworkCreate` in structure — the admin gate is identical.
+ */
+export async function makeSignedAdminDecision(
+  requestId: string,
+  decision: "grant" | "reject",
+  adminKey: PrincipalKey,
+  opts: {
+    issuedAt?: string;
+    nonce?: string;
+    /** Sign with a DIFFERENT key than the claim declares — forged signature tests. */
+    signWith?: PrincipalKey;
+    adminPubkeyOverride?: string;
+  } = {},
+): Promise<{ claim: IssuanceDecisionClaim; signature: string }> {
+  const claim: IssuanceDecisionClaim = {
+    request_id: requestId,
+    decision,
+    admin_pubkey: opts.adminPubkeyOverride ?? adminKey.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signer = opts.signWith ?? adminKey;
+  const signature = await signEd25519(signer.privateKeyB64, message);
+  return { claim, signature };
+}
+
+/**
+ * Build a signed admin read claim for the x-admin-signed header.
+ * No nonce (reads are idempotent). Clock skew applies.
+ */
+export async function makeSignedAdminRead(
+  adminKey: PrincipalKey,
+  opts: {
+    issuedAt?: string;
+    /** Sign with a DIFFERENT key — forged signature test. */
+    signWith?: PrincipalKey;
+  } = {},
+): Promise<{ claim: IssuanceReadClaim; signature: string }> {
+  const claim: IssuanceReadClaim = {
+    admin_pubkey: adminKey.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signer = opts.signWith ?? adminKey;
+  const signature = await signEd25519(signer.privateKeyB64, message);
+  return { claim, signature };
 }
 
 // =============================================================================

--- a/src/services/network-registry/__tests__/issuance-requests.test.ts
+++ b/src/services/network-registry/__tests__/issuance-requests.test.ts
@@ -1,0 +1,453 @@
+/**
+ * O-4a.1 — Issuance-request state machine tests.
+ *
+ * Drives the full Hono pipeline via `app.fetch(req, env)` so the admin gate,
+ * signing path, clock-skew, nonce-replay, and store transitions are all
+ * exercised end-to-end. Mirrors the network-create.test.ts style exactly.
+ *
+ * Coverage:
+ *   register hook:
+ *     - POST /principals/:id/register creates a PENDING issuance request
+ *     - re-register (same peer_pubkey) is idempotent — returns existing row
+ *   admin grant:
+ *     - POST /issuance-requests/:id/grant (allowlisted admin) → 200 GRANTED
+ *     - grant on already-decided request → 409 already_decided
+ *     - forged signature → 401
+ *     - non-allowlisted admin → 403
+ *     - no admin allowlist → 503 fail-closed
+ *     - replayed nonce → 409
+ *   admin reject:
+ *     - POST /issuance-requests/:id/reject (allowlisted admin) → 200 REJECTED
+ *     - reject on already-decided request → 409 already_decided
+ *   read surface (admin-gated):
+ *     - GET /issuance-requests?status=PENDING lists pending requests
+ *     - GET /issuance-requests/:id returns a specific request
+ *     - GET /issuance-requests/:id → 404 for unknown
+ *     - GET reads require admin signature → 503 / 401 / 403 fail-closed
+ *   additive: existing principal/network register tests not broken
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  makeSignedNetworkCreate,
+  randomNonce,
+  resetStores,
+  makeSignedAdminDecision,
+  makeSignedAdminRead,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import type { IssuanceRequest } from "../src/types";
+
+let env: Env;
+let admin: PrincipalKey;
+let principal: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, e: Env = env, headers: Record<string, string> = {}): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+/** Register a principal and return the issuance request created as a side-effect. */
+async function registerAndGetRequest(principalId: string): Promise<IssuanceRequest> {
+  const body = await makeSignedRegistration(principalId, principal, {
+    stacks: [{ stack_id: `${principalId}/main`, stack_pubkey: principal.publicKeyB64 }],
+  });
+  const res = await post(`/principals/${principalId}/register`, body);
+  expect(res.status).toBe(201);
+
+  // List pending to retrieve the created request.
+  const signedRead = await makeSignedAdminRead(admin);
+  const listRes = await get(
+    `/issuance-requests?status=PENDING`,
+    env,
+    { "x-admin-signed": JSON.stringify(signedRead) },
+  );
+  expect(listRes.status).toBe(200);
+  const list = (await listRes.json()) as IssuanceRequest[];
+  const found = list.find((r) => r.principal_id === principalId);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  principal = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// Register hook — PENDING request created as side-effect
+// =============================================================================
+
+describe("POST /principals/:id/register — issuance request side-effect", () => {
+  test("registration creates a PENDING issuance request for the peer pubkey", async () => {
+    const req = await registerAndGetRequest("alice");
+    expect(req.status).toBe("PENDING");
+    expect(req.principal_id).toBe("alice");
+    expect(req.peer_pubkey).toBe(principal.publicKeyB64);
+    expect(req.request_id).toBeTruthy();
+    expect(req.created_at).toBeTruthy();
+    expect(req.updated_at).toBeTruthy();
+    expect(req.granted_by).toBeNull();
+    expect(req.leaf_package).toBeNull();
+  });
+
+  test("re-registration with same peer_pubkey is idempotent (same request_id returned)", async () => {
+    const req1 = await registerAndGetRequest("bob");
+
+    // Register again — same principal, same peer_pubkey.
+    const body2 = await makeSignedRegistration("bob", principal, {
+      stacks: [{ stack_id: "bob/main", stack_pubkey: principal.publicKeyB64 }],
+    });
+    const res2 = await post("/principals/bob/register", body2);
+    expect(res2.status).toBe(201);
+
+    // List pending — should still be exactly one request for bob.
+    const signedRead = await makeSignedAdminRead(admin);
+    const listRes = await get(
+      `/issuance-requests?status=PENDING`,
+      env,
+      { "x-admin-signed": JSON.stringify(signedRead) },
+    );
+    const list = (await listRes.json()) as IssuanceRequest[];
+    const bobRequests = list.filter((r) => r.principal_id === "bob");
+    expect(bobRequests.length).toBe(1);
+    expect(bobRequests[0]!.request_id).toBe(req1.request_id);
+  });
+
+  test("existing register behaviour is preserved (201, signed assertion returned)", async () => {
+    const body = await makeSignedRegistration("carol", principal);
+    const res = await post("/principals/carol/register", body);
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { payload: { principal_id: string } };
+    expect(json.payload.principal_id).toBe("carol");
+  });
+});
+
+// =============================================================================
+// Admin grant — PENDING → GRANTED
+// =============================================================================
+
+describe("POST /issuance-requests/:id/grant — happy path", () => {
+  test("allowlisted admin can grant a PENDING request", async () => {
+    const req = await registerAndGetRequest("dave");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(200);
+    const granted = (await res.json()) as IssuanceRequest;
+    expect(granted.status).toBe("GRANTED");
+    expect(granted.granted_by).toBe(admin.publicKeyB64);
+    expect(granted.request_id).toBe(req.request_id);
+    expect(granted.leaf_package).toBeNull(); // O-4a.2 populates this
+  });
+
+  test("granted request is retrievable via GET /issuance-requests/:id", async () => {
+    const req = await registerAndGetRequest("eve");
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    // Retrieve via admin-gated GET.
+    const signedRead = await makeSignedAdminRead(admin);
+    const res = await get(
+      `/issuance-requests/${req.request_id}`,
+      env,
+      { "x-admin-signed": JSON.stringify(signedRead) },
+    );
+    expect(res.status).toBe(200);
+    const record = (await res.json()) as IssuanceRequest;
+    expect(record.status).toBe("GRANTED");
+  });
+});
+
+// =============================================================================
+// Admin reject — PENDING → REJECTED
+// =============================================================================
+
+describe("POST /issuance-requests/:id/reject — happy path", () => {
+  test("allowlisted admin can reject a PENDING request", async () => {
+    const req = await registerAndGetRequest("frank");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "reject", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/reject`, decision);
+    expect(res.status).toBe(200);
+    const rejected = (await res.json()) as IssuanceRequest;
+    expect(rejected.status).toBe("REJECTED");
+    expect(rejected.granted_by).toBe(admin.publicKeyB64);
+    expect(rejected.request_id).toBe(req.request_id);
+  });
+});
+
+// =============================================================================
+// CAS guard — already-decided requests cannot be re-decided
+// =============================================================================
+
+describe("grant/reject on already-decided request → 409", () => {
+  test("granting an already-GRANTED request returns 409 already_decided", async () => {
+    const req = await registerAndGetRequest("grace");
+    const d1 = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    await post(`/issuance-requests/${req.request_id}/grant`, d1);
+
+    const d2 = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, d2);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("already_decided");
+  });
+
+  test("rejecting an already-REJECTED request returns 409 already_decided", async () => {
+    const req = await registerAndGetRequest("hank");
+    const d1 = await makeSignedAdminDecision(req.request_id, "reject", admin);
+    await post(`/issuance-requests/${req.request_id}/reject`, d1);
+
+    const d2 = await makeSignedAdminDecision(req.request_id, "reject", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/reject`, d2);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("already_decided");
+  });
+
+  test("granting an already-REJECTED request returns 409 already_decided", async () => {
+    const req = await registerAndGetRequest("ivan");
+    const d1 = await makeSignedAdminDecision(req.request_id, "reject", admin);
+    await post(`/issuance-requests/${req.request_id}/reject`, d1);
+
+    const d2 = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, d2);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("already_decided");
+  });
+});
+
+// =============================================================================
+// Auth failures — same gate as network-create (503 / 401 / 403)
+// =============================================================================
+
+describe("POST /issuance-requests/:id/grant — auth failures", () => {
+  test("no admin allowlist configured → 503 fail-closed", async () => {
+    const req = await registerAndGetRequest("judy");
+    const reg = await makeRegistryKey();
+    const unconfigured: Env = {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision, unconfigured);
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toBe("admin_not_configured");
+  });
+
+  test("forged signature → 401", async () => {
+    const req = await registerAndGetRequest("kyle");
+    const other = await makePrincipalKey();
+    // Claim says admin.publicKeyB64 but signed with other key.
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin, { signWith: other });
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("signature_invalid");
+  });
+
+  test("valid sig from non-allowlisted admin → 403", async () => {
+    const req = await registerAndGetRequest("lena");
+    const rogue = await makePrincipalKey();
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", rogue);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("admin_not_authorized");
+  });
+
+  test("replayed nonce → 409", async () => {
+    const req = await registerAndGetRequest("mike");
+    const nonce = randomNonce();
+    const d1 = await makeSignedAdminDecision(req.request_id, "grant", admin, { nonce });
+    const res1 = await post(`/issuance-requests/${req.request_id}/grant`, d1);
+    expect(res1.status).toBe(200);
+
+    // Second request for a different request_id (so it's not already_decided),
+    // same nonce — must replay-reject.
+    const req2 = await registerAndGetRequest("mike2");
+    const d2 = await makeSignedAdminDecision(req2.request_id, "grant", admin, { nonce });
+    const res2 = await post(`/issuance-requests/${req2.request_id}/grant`, d2);
+    expect(res2.status).toBe(409);
+    expect(((await res2.json()) as { error: string }).error).toBe("nonce_replayed");
+  });
+
+  test("issued_at outside skew window → 400", async () => {
+    const req = await registerAndGetRequest("nina");
+    const old = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin, { issuedAt: old });
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(400);
+  });
+
+  test("unknown request_id → 404", async () => {
+    const decision = await makeSignedAdminDecision("doesnotexist1234", "grant", admin);
+    const res = await post("/issuance-requests/doesnotexist1234/grant", decision);
+    expect(res.status).toBe(404);
+  });
+});
+
+// =============================================================================
+// Auth failures — reject path
+// =============================================================================
+
+describe("POST /issuance-requests/:id/reject — auth failures", () => {
+  test("no admin allowlist configured → 503 fail-closed", async () => {
+    const req = await registerAndGetRequest("oscar");
+    const reg = await makeRegistryKey();
+    const unconfigured: Env = {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+    const decision = await makeSignedAdminDecision(req.request_id, "reject", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/reject`, decision, unconfigured);
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toBe("admin_not_configured");
+  });
+
+  test("forged signature → 401", async () => {
+    const req = await registerAndGetRequest("pat");
+    const other = await makePrincipalKey();
+    const decision = await makeSignedAdminDecision(req.request_id, "reject", admin, { signWith: other });
+    const res = await post(`/issuance-requests/${req.request_id}/reject`, decision);
+    expect(res.status).toBe(401);
+  });
+
+  test("valid sig from non-allowlisted admin → 403", async () => {
+    const req = await registerAndGetRequest("quinn");
+    const rogue = await makePrincipalKey();
+    const decision = await makeSignedAdminDecision(req.request_id, "reject", rogue);
+    const res = await post(`/issuance-requests/${req.request_id}/reject`, decision);
+    expect(res.status).toBe(403);
+  });
+});
+
+// =============================================================================
+// Read surface — admin-gated list + single-fetch
+// =============================================================================
+
+describe("GET /issuance-requests — admin-gated read surface", () => {
+  test("GET ?status=PENDING lists pending requests (admin-gated)", async () => {
+    await registerAndGetRequest("rosa");
+    await registerAndGetRequest("sam");
+
+    const signedRead = await makeSignedAdminRead(admin);
+    const res = await get(
+      `/issuance-requests?status=PENDING`,
+      env,
+      { "x-admin-signed": JSON.stringify(signedRead) },
+    );
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as IssuanceRequest[];
+    expect(list.length).toBeGreaterThanOrEqual(2);
+    expect(list.every((r) => r.status === "PENDING")).toBe(true);
+  });
+
+  test("GET ?status=GRANTED lists only granted requests", async () => {
+    const req = await registerAndGetRequest("tara");
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    const signedRead = await makeSignedAdminRead(admin);
+    const res = await get(
+      `/issuance-requests?status=GRANTED`,
+      env,
+      { "x-admin-signed": JSON.stringify(signedRead) },
+    );
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as IssuanceRequest[];
+    expect(list.some((r) => r.request_id === req.request_id)).toBe(true);
+    expect(list.every((r) => r.status === "GRANTED")).toBe(true);
+  });
+
+  test("GET /issuance-requests/:id returns the specific request (admin-gated)", async () => {
+    const req = await registerAndGetRequest("uma");
+    const signedRead = await makeSignedAdminRead(admin);
+    const res = await get(
+      `/issuance-requests/${req.request_id}`,
+      env,
+      { "x-admin-signed": JSON.stringify(signedRead) },
+    );
+    expect(res.status).toBe(200);
+    const record = (await res.json()) as IssuanceRequest;
+    expect(record.request_id).toBe(req.request_id);
+    expect(record.status).toBe("PENDING");
+  });
+
+  test("GET /issuance-requests/:id → 404 for unknown", async () => {
+    const signedRead = await makeSignedAdminRead(admin);
+    const res = await get(
+      "/issuance-requests/unknownrequest0000",
+      env,
+      { "x-admin-signed": JSON.stringify(signedRead) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("GET without admin signature → 503 fail-closed when no allowlist configured", async () => {
+    const reg = await makeRegistryKey();
+    const unconfigured: Env = {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+    const res = await get("/issuance-requests?status=PENDING", unconfigured);
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toBe("admin_not_configured");
+  });
+
+  test("GET with forged admin signature → 401", async () => {
+    const other = await makePrincipalKey();
+    // Build a read claim signed with `other` but claiming to be admin.
+    const forgedRead = await makeSignedAdminRead(admin, { signWith: other });
+    const res = await get(
+      "/issuance-requests?status=PENDING",
+      env,
+      { "x-admin-signed": JSON.stringify(forgedRead) },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("GET with non-allowlisted admin pubkey → 403", async () => {
+    const rogue = await makePrincipalKey();
+    const rogueRead = await makeSignedAdminRead(rogue);
+    const res = await get(
+      "/issuance-requests?status=PENDING",
+      env,
+      { "x-admin-signed": JSON.stringify(rogueRead) },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("GET /issuance-requests missing admin header → 400", async () => {
+    const res = await get("/issuance-requests?status=PENDING");
+    expect(res.status).toBe(400);
+  });
+});
+
+// =============================================================================
+// Migration 0004 — SQL shape test (bun:sqlite)
+// =============================================================================

--- a/src/services/network-registry/__tests__/issuance-requests.test.ts
+++ b/src/services/network-registry/__tests__/issuance-requests.test.ts
@@ -43,6 +43,9 @@ import {
 } from "./helpers";
 import { canonicalJSON, signEd25519 } from "../src/signing";
 import type { IssuanceRequest } from "../src/types";
+import { D1IssuanceRequestStore } from "../src/store";
+import { MockD1, asD1 } from "./d1-mock";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
 
 let env: Env;
 let admin: PrincipalKey;
@@ -303,8 +306,10 @@ describe("POST /issuance-requests/:id/grant — auth failures", () => {
   });
 
   test("unknown request_id → 404", async () => {
-    const decision = await makeSignedAdminDecision("doesnotexist1234", "grant", admin);
-    const res = await post("/issuance-requests/doesnotexist1234/grant", decision);
+    // Must be a valid 32-hex-char id (passes M2 check) but not in the store.
+    const nonexistent = "0000000000000000000000000000dead";
+    const decision = await makeSignedAdminDecision(nonexistent, "grant", admin);
+    const res = await post(`/issuance-requests/${nonexistent}/grant`, decision);
     expect(res.status).toBe(404);
   });
 });
@@ -398,9 +403,10 @@ describe("GET /issuance-requests — admin-gated read surface", () => {
   });
 
   test("GET /issuance-requests/:id → 404 for unknown", async () => {
+    // Must be a valid 32-hex-char id (passes M2 check) but not in the store.
     const signedRead = await makeSignedAdminRead(admin);
     const res = await get(
-      "/issuance-requests/unknownrequest0000",
+      "/issuance-requests/0000000000000000000000000000cafe",
       env,
       { "x-admin-signed": JSON.stringify(signedRead) },
     );
@@ -445,6 +451,227 @@ describe("GET /issuance-requests — admin-gated read surface", () => {
   test("GET /issuance-requests missing admin header → 400", async () => {
     const res = await get("/issuance-requests?status=PENDING");
     expect(res.status).toBe(400);
+  });
+});
+
+// =============================================================================
+// M1 — rate-limit: flood trips 429 on grant/reject handlers
+// =============================================================================
+
+describe("M1 — rate-limit: decision flood trips 429", () => {
+  test("flooding grant with a valid request_id trips 429 after the register limit", async () => {
+    // The "register" bucket allows 5 requests per 60s window (per RATE_LIMITS).
+    // Exhaust the bucket then assert the next call returns 429.
+    // We use a valid-format but nonexistent request_id so the rate-limit check
+    // runs before any store access (the flood-shed path matters, not the outcome).
+    const targetId = "aaaa0000bbbb1111cccc2222dddd3333";
+
+    // Reset rate-limit bucket state from beforeEach so this test starts clean.
+    _resetRateLimitBucketsForTest();
+
+    // Fire 5 requests (the limit) — all will fail on auth (no valid body) but
+    // the rate-limit consumes a token on each.
+    for (let i = 0; i < 5; i++) {
+      await post(`/issuance-requests/${targetId}/grant`, { claim: {}, signature: "" });
+    }
+
+    // The 6th request must be rate-limited before any body parse.
+    const res = await post(`/issuance-requests/${targetId}/grant`, {
+      claim: {},
+      signature: "aGVsbG8=",
+    });
+    expect(res.status).toBe(429);
+    expect(((await res.json()) as { error: string }).error).toBe("rate_limited");
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  test("flooding reject with a valid request_id trips 429 after the register limit", async () => {
+    const targetId = "eeee4444ffff5555aaaa6666bbbb7777";
+    _resetRateLimitBucketsForTest();
+
+    for (let i = 0; i < 5; i++) {
+      await post(`/issuance-requests/${targetId}/reject`, { claim: {}, signature: "" });
+    }
+
+    const res = await post(`/issuance-requests/${targetId}/reject`, {
+      claim: {},
+      signature: "aGVsbG8=",
+    });
+    expect(res.status).toBe(429);
+    expect(((await res.json()) as { error: string }).error).toBe("rate_limited");
+  });
+});
+
+// =============================================================================
+// M2 — request_id path param validation: 400 before body parse or crypto
+// =============================================================================
+
+describe("M2 — invalid request_id path param → 400 invalid_request_id", () => {
+  test("slug (non-hex) request_id → 400 on grant", async () => {
+    const decision = await makeSignedAdminDecision("not-a-valid-request-id", "grant", admin);
+    const res = await post("/issuance-requests/not-a-valid-request-id/grant", decision);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid_request_id");
+  });
+
+  test("UUID-with-dashes request_id → 400 on grant", async () => {
+    const uuidId = "550e8400-e29b-41d4-a716-446655440000";
+    const decision = await makeSignedAdminDecision(uuidId, "grant", admin);
+    const res = await post(`/issuance-requests/${uuidId}/grant`, decision);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid_request_id");
+  });
+
+  test("empty request_id → 400 on reject", async () => {
+    // Hono maps an empty path segment to "" which fails isValidRequestId.
+    const res = await post("/issuance-requests//reject", { claim: {}, signature: "" });
+    // Hono may 404 on unmatched route; either 400 or 404 is acceptable here
+    // (the important thing is it never reaches the store).
+    expect([400, 404].includes(res.status)).toBe(true);
+  });
+
+  test("too-short hex string → 400 on grant (31 chars)", async () => {
+    const shortId = "0000000000000000000000000000bea"; // 31 chars
+    const decision = await makeSignedAdminDecision(shortId, "grant", admin);
+    const res = await post(`/issuance-requests/${shortId}/grant`, decision);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid_request_id");
+  });
+
+  test("too-long hex string → 400 on grant (33 chars)", async () => {
+    const longId = "0000000000000000000000000000beef0"; // 33 chars
+    const decision = await makeSignedAdminDecision(longId, "grant", admin);
+    const res = await post(`/issuance-requests/${longId}/grant`, decision);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid_request_id");
+  });
+
+  test("invalid request_id on GET /:request_id → 400 invalid_request_id", async () => {
+    const signedRead = await makeSignedAdminRead(admin);
+    const res = await get(
+      "/issuance-requests/not-hex-32chars",
+      env,
+      { "x-admin-signed": JSON.stringify(signedRead) },
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid_request_id");
+  });
+});
+
+// =============================================================================
+// M3 — D1 upsertPending is atomic: concurrent inserts never duplicate
+// =============================================================================
+
+describe("M3 — D1IssuanceRequestStore.upsertPending is atomic", () => {
+  test("concurrent upsertPending calls for the same (principal, peer) return the same row", async () => {
+    const shared = new MockD1();
+    const store = new D1IssuanceRequestStore(asD1(shared));
+
+    // Simulate two concurrent upsertPending calls arriving before either row exists.
+    // In production these race; in the mock the first INSERT wins and the second
+    // hits ON CONFLICT DO NOTHING, then both SELECTs return the same row.
+    const [r1, r2] = await Promise.all([
+      store.upsertPending("principal-x", "pubkeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "scope.leaf"),
+      store.upsertPending("principal-x", "pubkeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "scope.leaf"),
+    ]);
+
+    // Both calls return the same request_id — no duplicate was created.
+    expect(r1.request_id).toBe(r2.request_id);
+    expect(r1.status).toBe("PENDING");
+    expect(r2.status).toBe("PENDING");
+
+    // Only one row exists in the backing store.
+    expect(shared.issuanceRequests.size).toBe(1);
+  });
+
+  test("upsertPending returns existing row regardless of its status (idempotent after grant)", async () => {
+    const shared = new MockD1();
+    const store = new D1IssuanceRequestStore(asD1(shared));
+
+    const original = await store.upsertPending(
+      "principal-y",
+      "pubkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+      "scope.leaf",
+    );
+
+    // Simulate the request being granted by directly mutating the mock.
+    const row = shared.issuanceRequests.get(original.request_id)!;
+    shared.issuanceRequests.set(original.request_id, { ...row, status: "GRANTED", granted_by: "admin-key" });
+
+    // A second upsertPending for the same peer returns the existing (now GRANTED) row.
+    const second = await store.upsertPending(
+      "principal-y",
+      "pubkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+      "scope.leaf",
+    );
+
+    expect(second.request_id).toBe(original.request_id);
+    expect(second.status).toBe("GRANTED");
+    expect(shared.issuanceRequests.size).toBe(1);
+  });
+});
+
+// =============================================================================
+// N1 — envelope validator rejects array claim + missing fields
+// =============================================================================
+
+describe("N1 — validateSignedIssuanceDecision envelope hardening", () => {
+  test("array claim → 400 validation_failed", async () => {
+    const req = await registerAndGetRequest("n1-alice");
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, {
+      claim: [{ decision: "grant" }],
+      signature: "aGVsbG8=",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("missing claim field → 400 validation_failed", async () => {
+    const req = await registerAndGetRequest("n1-bob");
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, {
+      signature: "aGVsbG8=",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("missing signature field → 400 validation_failed", async () => {
+    const req = await registerAndGetRequest("n1-carol");
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, {
+      claim: { decision: "grant" },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// =============================================================================
+// N2 — CAS fallback uses pre-read existing row (no spurious 404 on D1 transient)
+// =============================================================================
+
+describe("N2 — transitionIssuanceRequest CAS uses pre-read row on changes===0", () => {
+  test("concurrent grant/reject: second transition throws AlreadyDecidedError with the existing row", async () => {
+    const shared = new MockD1();
+    const store = new D1IssuanceRequestStore(asD1(shared));
+
+    const row = await store.upsertPending(
+      "principal-z",
+      "pubkeyCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=",
+      "scope.leaf",
+    );
+
+    // Grant it once — changes the status in the mock.
+    await store.transitionIssuanceRequest(row.request_id, "GRANTED", "admin-pub");
+
+    // Second grant attempt — `existing` is fetched as GRANTED, then changes === 0,
+    // so AlreadyDecidedError should be thrown with the existing row (not re-read).
+    let caughtStatus: string | undefined;
+    try {
+      await store.transitionIssuanceRequest(row.request_id, "GRANTED", "admin-pub");
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "AlreadyDecidedError") {
+        const typed = err as { request: { status: string } };
+        caughtStatus = typed.request.status;
+      }
+    }
+    expect(caughtStatus).toBe("GRANTED");
   });
 });
 

--- a/src/services/network-registry/__tests__/migration-0004.test.ts
+++ b/src/services/network-registry/__tests__/migration-0004.test.ts
@@ -1,0 +1,167 @@
+/**
+ * O-4a.1 — migration 0004 (issuance_requests table) shape test.
+ *
+ * Runs the real SQL against `bun:sqlite` (D1 is SQLite under the hood).
+ * Verifies the table DDL, constraints, and indexes match the spec:
+ *   - request_id PRIMARY KEY
+ *   - status CHECK IN ('PENDING','GRANTED','REJECTED') with DEFAULT 'PENDING'
+ *   - nullable granted_by + leaf_package
+ *   - UNIQUE(principal_id, peer_pubkey) — idempotency constraint
+ *   - idx_issuance_requests_status index exists
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "..", "migrations");
+
+let db: Database;
+
+function applyMigrations(): void {
+  db.run(readFileSync(join(migrationsDir, "0001_init.sql"), "utf8"));
+  db.run(readFileSync(join(migrationsDir, "0004_issuance_requests.sql"), "utf8"));
+}
+
+function insertRequest(opts: {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  requested_scope?: string;
+  status?: string;
+  created_at?: string;
+  updated_at?: string;
+  granted_by?: string | null;
+  leaf_package?: string | null;
+}): void {
+  const now = "2026-01-01T00:00:00Z";
+  db.run(
+    `INSERT INTO issuance_requests
+       (request_id, principal_id, peer_pubkey, requested_scope, status, created_at, updated_at, granted_by, leaf_package)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      opts.request_id,
+      opts.principal_id,
+      opts.peer_pubkey,
+      opts.requested_scope ?? "federated.peer.>",
+      opts.status ?? "PENDING",
+      opts.created_at ?? now,
+      opts.updated_at ?? now,
+      opts.granted_by ?? null,
+      opts.leaf_package ?? null,
+    ],
+  );
+}
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  applyMigrations();
+});
+
+describe("migration 0004 — issuance_requests table", () => {
+  test("inserts a PENDING request with nulls for granted_by and leaf_package", () => {
+    insertRequest({ request_id: "req-001", principal_id: "alice", peer_pubkey: "ALICE_PUBKEY".padEnd(44, "A") });
+    const row = db
+      .query("SELECT * FROM issuance_requests WHERE request_id = ?")
+      .get("req-001") as Record<string, unknown>;
+    expect(row.status).toBe("PENDING");
+    expect(row.granted_by).toBeNull();
+    expect(row.leaf_package).toBeNull();
+    expect(row.principal_id).toBe("alice");
+    expect(row.peer_pubkey).toBe("ALICE_PUBKEY".padEnd(44, "A"));
+  });
+
+  test("DEFAULT status is PENDING when not specified", () => {
+    db.run(
+      `INSERT INTO issuance_requests
+         (request_id, principal_id, peer_pubkey, requested_scope, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      ["req-default", "bob", "BOB_PUBKEY00".padEnd(44, "B"), "federated.bob.>", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"],
+    );
+    const row = db
+      .query("SELECT status FROM issuance_requests WHERE request_id = ?")
+      .get("req-default") as { status: string };
+    expect(row.status).toBe("PENDING");
+  });
+
+  test("status CHECK constraint rejects invalid values", () => {
+    expect(() => {
+      insertRequest({ request_id: "req-bad", principal_id: "carol", peer_pubkey: "CAROL_PUBKEY".padEnd(44, "C"), status: "APPROVED" });
+    }).toThrow();
+  });
+
+  test("UNIQUE(principal_id, peer_pubkey) prevents duplicate rows", () => {
+    const pubkey = "DAVE_PUBKEY00".padEnd(44, "D");
+    insertRequest({ request_id: "req-d1", principal_id: "dave", peer_pubkey: pubkey });
+    expect(() => {
+      insertRequest({ request_id: "req-d2", principal_id: "dave", peer_pubkey: pubkey });
+    }).toThrow();
+  });
+
+  test("request_id is the PRIMARY KEY — duplicate request_id fails", () => {
+    insertRequest({ request_id: "req-pk", principal_id: "eve", peer_pubkey: "EVE_PUBKEY000".padEnd(44, "E") });
+    expect(() => {
+      insertRequest({
+        request_id: "req-pk",
+        principal_id: "frank",
+        peer_pubkey: "FRANK_PUBKEY0".padEnd(44, "F"),
+      });
+    }).toThrow();
+  });
+
+  test("granted_by and leaf_package can be set to non-null values", () => {
+    insertRequest({
+      request_id: "req-granted",
+      principal_id: "grace",
+      peer_pubkey: "GRACE_PUBKEY0".padEnd(44, "G"),
+      status: "GRANTED",
+      granted_by: "ADMIN_PUBKEY0".padEnd(44, "X"),
+      leaf_package: JSON.stringify({ token: "test" }),
+    });
+    const row = db
+      .query("SELECT * FROM issuance_requests WHERE request_id = ?")
+      .get("req-granted") as Record<string, unknown>;
+    expect(row.status).toBe("GRANTED");
+    expect(row.granted_by).toBe("ADMIN_PUBKEY0".padEnd(44, "X"));
+    expect(row.leaf_package).toBe(JSON.stringify({ token: "test" }));
+  });
+
+  test("idx_issuance_requests_status index exists", () => {
+    const rows = db
+      .query("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='issuance_requests'")
+      .all() as { name: string }[];
+    const names = rows.map((r) => r.name);
+    expect(names).toContain("idx_issuance_requests_status");
+  });
+
+  test("idx_issuance_requests_peer unique index exists", () => {
+    const rows = db
+      .query("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='issuance_requests'")
+      .all() as { name: string }[];
+    const names = rows.map((r) => r.name);
+    expect(names).toContain("idx_issuance_requests_peer");
+  });
+
+  test("idempotent — applying migration twice is a no-op (CREATE IF NOT EXISTS)", () => {
+    // Should not throw.
+    db.run(readFileSync(join(migrationsDir, "0004_issuance_requests.sql"), "utf8"));
+    const count = (db.query("SELECT COUNT(*) as n FROM issuance_requests").get() as { n: number }).n;
+    expect(count).toBe(0);
+  });
+
+  test("status transition: UPDATE from PENDING to GRANTED succeeds", () => {
+    insertRequest({ request_id: "req-trans", principal_id: "henry", peer_pubkey: "HENRY_PUBKEY0".padEnd(44, "H") });
+    db.run(
+      "UPDATE issuance_requests SET status = ?, granted_by = ?, updated_at = ? WHERE request_id = ? AND status = 'PENDING'",
+      ["GRANTED", "ADMIN_PUBKEY0".padEnd(44, "X"), "2026-01-02T00:00:00Z", "req-trans"],
+    );
+    const row = db
+      .query("SELECT status, granted_by FROM issuance_requests WHERE request_id = ?")
+      .get("req-trans") as { status: string; granted_by: string };
+    expect(row.status).toBe("GRANTED");
+    expect(row.granted_by).toBeDefined();
+  });
+});

--- a/src/services/network-registry/migrations/0004_issuance_requests.sql
+++ b/src/services/network-registry/migrations/0004_issuance_requests.sql
@@ -1,0 +1,54 @@
+-- O-4a.1 — issuance-request state machine.
+--
+-- Background
+-- ──────────
+-- Trust model = human-grant: a verified registration (PoP) creates a PENDING
+-- issuance request; a credential leaf package is issued only on an explicit
+-- admin grant (O-4a.2). This table is the metadata ledger — NO secrets,
+-- NO credentials, NO NSC keys. The nullable `leaf_package` column is the
+-- O-4a.2 seam: it stays NULL in this slice and is populated by the next slice.
+--
+-- Design decisions
+-- ─────────────────
+-- • Idempotent upsert on (principal_id, peer_pubkey): re-registering a peer
+--   returns the existing PENDING row, never duplicates. Unique index enforces
+--   the cardinality invariant at the DB layer.
+-- • CAS guard: grant/reject transitions are gated on status = 'PENDING' at
+--   the SQL level so a concurrent double-grant cannot race to both succeed.
+-- • status index: admin list-by-status queries (GET /issuance-requests?status=PENDING)
+--   scan only the matching partition, not the full table.
+-- • ISO-8601 UTC strings for timestamps (TEXT, same as principals/networks).
+-- • `granted_by` nullable: set to admin_pubkey on GRANTED, NULL on PENDING/REJECTED.
+-- • `leaf_package` TEXT nullable: JSON blob, populated in O-4a.2.
+
+CREATE TABLE IF NOT EXISTS issuance_requests (
+  -- Stable, opaque, URL-safe identifier. Generated as a hex UUID on insert.
+  request_id     TEXT    NOT NULL PRIMARY KEY,
+  -- The principal requesting the credential.
+  principal_id   TEXT    NOT NULL,
+  -- Base64 Ed25519 pubkey for the peer stack being onboarded.
+  peer_pubkey    TEXT    NOT NULL,
+  -- The NATS subject scope the peer is requesting (e.g. `federated.<peer>.>`).
+  requested_scope TEXT   NOT NULL,
+  -- Lifecycle: PENDING → GRANTED or PENDING → REJECTED. No re-transition.
+  status         TEXT    NOT NULL DEFAULT 'PENDING'
+                         CHECK (status IN ('PENDING', 'GRANTED', 'REJECTED')),
+  -- ISO-8601 UTC creation timestamp.
+  created_at     TEXT    NOT NULL,
+  -- ISO-8601 UTC; set to created_at on insert, updated on grant/reject.
+  updated_at     TEXT    NOT NULL,
+  -- Admin pubkey (base64) that approved or rejected this request. NULL while PENDING.
+  granted_by     TEXT    ,
+  -- O-4a.2 seam: JSON blob of the issued leaf credential package. NULL in O-4a.1.
+  leaf_package   TEXT
+);
+
+-- Fast lookup for admin list-by-status queries.
+CREATE INDEX IF NOT EXISTS idx_issuance_requests_status
+  ON issuance_requests (status);
+
+-- Idempotency constraint: one PENDING (or decided) request per (principal, peer).
+-- The upsert path in the register hook uses ON CONFLICT(principal_id, peer_pubkey)
+-- to return the existing row rather than inserting a duplicate.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_issuance_requests_peer
+  ON issuance_requests (principal_id, peer_pubkey);

--- a/src/services/network-registry/src/index.ts
+++ b/src/services/network-registry/src/index.ts
@@ -38,6 +38,7 @@ import { createMiddleware } from "hono/factory";
 import { principalRoutes } from "./routes/principals";
 import { networkRoutes } from "./routes/networks";
 import { capabilityRoutes } from "./routes/capabilities";
+import { issuanceRequestRoutes } from "./routes/issuance-requests";
 import { pubkeyFromPkcs8 } from "./signing";
 import type { RateLimitEnv } from "./rate-limit";
 import type { StoreEnv } from "./store";
@@ -242,6 +243,7 @@ app.use("/capabilities", readLimited);
 app.route("/", principalRoutes());
 app.route("/", networkRoutes());
 app.route("/", capabilityRoutes());
+app.route("/", issuanceRequestRoutes());
 
 // ---------------------------------------------------------------------------
 // 404

--- a/src/services/network-registry/src/routes/issuance-requests.ts
+++ b/src/services/network-registry/src/routes/issuance-requests.ts
@@ -47,8 +47,15 @@ import {
   validateSignedIssuanceDecision,
   validateIssuanceDecisionClaim,
   validateSignedIssuanceRead,
+  isValidRequestId,
 } from "../validate";
 import { canonicalJSON, verifyEd25519 } from "../signing";
+import {
+  checkRateLimit,
+  clientKey,
+  retryAfterSeconds,
+  TOO_MANY_REQUESTS_BODY,
+} from "../rate-limit";
 import type { IssuanceStatus } from "../types";
 
 /** Maximum clock skew for admin decision claims — mirrors the network-create route. */
@@ -89,6 +96,13 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
   ): Promise<Response> {
     const requestId = c.req.param("request_id") ?? "";
 
+    // M2 — validate request_id path param BEFORE body parse or crypto.
+    // Rejects slugs, UUIDs with dashes, empty strings, and injection attempts
+    // before they can reach queries or error bodies. Returns 400 immediately.
+    if (!isValidRequestId(requestId)) {
+      return c.json({ error: "invalid_request_id" }, 400);
+    }
+
     // 1. FAIL-CLOSED, FIRST: admin allowlist must be configured.
     const adminPubkeys = parseAdminPubkeys(c.env);
     if (adminPubkeys.size === 0) {
@@ -101,6 +115,17 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
         },
         503,
       );
+    }
+
+    // M1 — rate-limit BEFORE the expensive Ed25519 verify (mirrors networks.ts:~106).
+    // Keyed by (IP, request_id) so a flood against one request can't hide behind
+    // a shared egress IP, and one IP can't exhaust the limit across requests.
+    // Uses the "register" bucket (mutation + Ed25519 compute — same cost class).
+    const allowed = await checkRateLimit(c.env, "register", clientKey(c.req.raw, requestId));
+    if (!allowed) {
+      return c.json(TOO_MANY_REQUESTS_BODY, 429, {
+        "Retry-After": String(retryAfterSeconds("register")),
+      });
     }
 
     // 2. Parse + validate envelope.
@@ -282,6 +307,10 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
     }
 
     const requestId = c.req.param("request_id") ?? "";
+    // M2 — validate request_id path param before any query.
+    if (!isValidRequestId(requestId)) {
+      return c.json({ error: "invalid_request_id" }, 400);
+    }
     const store = getIssuanceStore(c.env);
     const request = await store.getIssuanceRequest(requestId);
     if (!request) {

--- a/src/services/network-registry/src/routes/issuance-requests.ts
+++ b/src/services/network-registry/src/routes/issuance-requests.ts
@@ -64,11 +64,10 @@ const CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes
  * (caller short-circuits immediately).
  */
 async function applyAdminGate(
-  env: Env,
   adminPubkeys: Set<string>,
   adminPubkey: string,
   signature: string,
-  message: Uint8Array,
+  message: Uint8Array<ArrayBuffer>,
 ): Promise<{ error: string; status: number } | null> {
   // adminPubkeys already checked for empty before calling this helper.
   const valid = await verifyEd25519(adminPubkey, signature, message);
@@ -140,7 +139,6 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
     // 4. Signature verification FIRST (before recording nonce — #695 rationale).
     const message = new TextEncoder().encode(canonicalJSON(claim));
     const gateResult = await applyAdminGate(
-      c.env,
       adminPubkeys,
       claim.admin_pubkey,
       signed.signature,

--- a/src/services/network-registry/src/routes/issuance-requests.ts
+++ b/src/services/network-registry/src/routes/issuance-requests.ts
@@ -1,0 +1,296 @@
+/**
+ * O-4a.1 — Issuance-request state machine endpoints.
+ *
+ *   POST /issuance-requests/{request_id}/grant
+ *     Admin-signed transition: PENDING → GRANTED.
+ *     Reuses the admin-pubkey gate from #747 (network-create) verbatim:
+ *       503 admin_not_configured  — no allowlist set
+ *       401 signature_invalid     — sig doesn't verify
+ *       403 admin_not_authorized  — key not allowlisted
+ *     On success: returns the updated IssuanceRequest (leaf_package still null —
+ *     that's O-4a.2). 409 already_decided if the request is not PENDING.
+ *
+ *   POST /issuance-requests/{request_id}/reject
+ *     Admin-signed transition: PENDING → REJECTED. Same gate as grant.
+ *
+ *   GET /issuance-requests?status=<PENDING|GRANTED|REJECTED>
+ *     Admin-gated list of requests by status. The admin proves allowlisted
+ *     possession via the `x-admin-signed` request header (a signed read
+ *     claim — no nonce, clock-skew applies). 400 if the header is missing
+ *     or malformed.
+ *
+ *   GET /issuance-requests/{request_id}
+ *     Admin-gated single-request fetch. Same auth as the list surface.
+ *     404 when the request_id is not found.
+ *
+ * Trust model
+ * ───────────
+ * All write operations reuse the network-create admin gate EXACTLY:
+ *   1. parseAdminPubkeys → empty set → 503 fail-closed (FIRST, no body parse)
+ *   2. JSON parse → schema validate → clock-skew
+ *   3. verifyEd25519(claim.admin_pubkey, sig, canonicalJSON(claim)) → 401
+ *   4. adminPubkeys.has(claim.admin_pubkey) → 403
+ *   5. nonceCache.recordIfFresh → 409
+ *   6. store.transitionIssuanceRequest → 409 already_decided / 404 / 200
+ *
+ * Read operations use the same gate for the admin_pubkey check but carry
+ * the signed token in a header rather than the request body (reads must
+ * remain GETs for HTTP semantics and cache compatibility). No nonce is
+ * required for reads — they are idempotent and don't mutate state. Clock
+ * skew still applies to prevent stale read-tokens lingering.
+ */
+
+import { Hono, type Context } from "hono";
+import { parseAdminPubkeys, type Env } from "../index";
+import { getNonceCache, getIssuanceStore, AlreadyDecidedError } from "../store";
+import {
+  validateSignedIssuanceDecision,
+  validateIssuanceDecisionClaim,
+  validateSignedIssuanceRead,
+} from "../validate";
+import { canonicalJSON, verifyEd25519 } from "../signing";
+import type { IssuanceStatus } from "../types";
+
+/** Maximum clock skew for admin decision claims — mirrors the network-create route. */
+const CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Shared admin gate used by both write (grant/reject) and read endpoints.
+ * Mirrors the network-create gate order verbatim:
+ *   503 admin_not_configured → 401 signature_invalid → 403 admin_not_authorized
+ *
+ * `adminPubkey` and `signature` are pulled from the validated claim.
+ * Returns null on success (caller continues); returns a Response on failure
+ * (caller short-circuits immediately).
+ */
+async function applyAdminGate(
+  env: Env,
+  adminPubkeys: Set<string>,
+  adminPubkey: string,
+  signature: string,
+  message: Uint8Array,
+): Promise<{ error: string; status: number } | null> {
+  // adminPubkeys already checked for empty before calling this helper.
+  const valid = await verifyEd25519(adminPubkey, signature, message);
+  if (!valid) return { error: "signature_invalid", status: 401 };
+  if (!adminPubkeys.has(adminPubkey)) return { error: "admin_not_authorized", status: 403 };
+  return null; // pass
+}
+
+export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  // ---------------------------------------------------------------------------
+  // Helper: shared decision handler for grant and reject
+  // ---------------------------------------------------------------------------
+
+  async function handleDecision(
+    c: Context<{ Bindings: Env }>,
+    decision: "grant" | "reject",
+  ): Promise<Response> {
+    const requestId = c.req.param("request_id") ?? "";
+
+    // 1. FAIL-CLOSED, FIRST: admin allowlist must be configured.
+    const adminPubkeys = parseAdminPubkeys(c.env);
+    if (adminPubkeys.size === 0) {
+      return c.json(
+        {
+          error: "admin_not_configured",
+          details:
+            "REGISTRY_ADMIN_PUBKEYS not provisioned; issuance decisions are disabled (fail-closed). " +
+            "Set the admin pubkey allowlist via `wrangler secret put` to enable signed-admin writes.",
+        },
+        503,
+      );
+    }
+
+    // 2. Parse + validate envelope.
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (_err) {
+      return c.json({ error: "body must be valid JSON" }, 400);
+    }
+
+    const envelopeCheck = validateSignedIssuanceDecision(body);
+    if (!envelopeCheck.ok) {
+      return c.json({ error: "validation_failed", details: envelopeCheck.errors }, 400);
+    }
+    const { signed } = envelopeCheck;
+
+    const claimCheck = validateIssuanceDecisionClaim(signed.claim, requestId, decision);
+    if (!claimCheck.ok) {
+      return c.json({ error: "validation_failed", details: claimCheck.errors }, 400);
+    }
+    const { claim } = claimCheck;
+
+    // 3. Clock-skew check.
+    const issued = Date.parse(claim.issued_at);
+    const now = Date.now();
+    if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
+      return c.json(
+        {
+          error: "issued_at out of skew window",
+          details: { skew_ms: now - issued, max_ms: CLOCK_SKEW_MS },
+        },
+        400,
+      );
+    }
+
+    // 4. Signature verification FIRST (before recording nonce — #695 rationale).
+    const message = new TextEncoder().encode(canonicalJSON(claim));
+    const gateResult = await applyAdminGate(
+      c.env,
+      adminPubkeys,
+      claim.admin_pubkey,
+      signed.signature,
+      message,
+    );
+    if (gateResult) {
+      return c.json({ error: gateResult.error }, gateResult.status as 401 | 403);
+    }
+
+    // 5. Replay check — only on authentic + authorised path.
+    const nonceCache = getNonceCache(c.env);
+    const fresh = await nonceCache.recordIfFresh(claim.nonce, now);
+    if (!fresh) {
+      return c.json({ error: "nonce_replayed" }, 409);
+    }
+
+    // 6. State transition.
+    const store = getIssuanceStore(c.env);
+    let updated;
+    try {
+      updated = await store.transitionIssuanceRequest(
+        requestId,
+        decision === "grant" ? "GRANTED" : "REJECTED",
+        claim.admin_pubkey,
+      );
+    } catch (err) {
+      if (err instanceof AlreadyDecidedError) {
+        return c.json(
+          {
+            error: "already_decided",
+            details: `request ${requestId} is already ${err.request.status}`,
+            current: err.request,
+          },
+          409,
+        );
+      }
+      // Unexpected error — surface as 500 (caught by global error handler,
+      // but we re-throw so it reaches the onError handler set in index.ts).
+      throw err;
+    }
+
+    if (!updated) {
+      return c.json({ error: "not_found" }, 404);
+    }
+
+    return c.json(updated, 200);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helper: verify admin signature for read endpoints (x-admin-signed header)
+  // ---------------------------------------------------------------------------
+
+  async function verifyAdminReadHeader(
+    c: Context<{ Bindings: Env }>,
+  ): Promise<{ error: string; status: number } | null> {
+    // 1. FAIL-CLOSED: admin allowlist must be configured.
+    const adminPubkeys = parseAdminPubkeys(c.env);
+    if (adminPubkeys.size === 0) {
+      return { error: "admin_not_configured", status: 503 };
+    }
+
+    // 2. Parse + validate x-admin-signed header.
+    const headerVal = c.req.header("x-admin-signed");
+    if (!headerVal) {
+      return { error: "x-admin-signed header required", status: 400 };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(headerVal);
+    } catch (_err) {
+      return { error: "x-admin-signed must be valid JSON", status: 400 };
+    }
+
+    const readCheck = validateSignedIssuanceRead(parsed);
+    if (!readCheck.ok) {
+      return { error: "x-admin-signed validation_failed", status: 400 };
+    }
+    const { signed } = readCheck;
+
+    // 3. Clock-skew check.
+    const issued = Date.parse(signed.claim.issued_at);
+    const now = Date.now();
+    if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
+      return { error: "issued_at out of skew window", status: 400 };
+    }
+
+    // 4. Signature + allowlist check (no nonce for reads — idempotent).
+    const message = new TextEncoder().encode(canonicalJSON(signed.claim));
+    const valid = await verifyEd25519(signed.claim.admin_pubkey, signed.signature, message);
+    if (!valid) return { error: "signature_invalid", status: 401 };
+    if (!adminPubkeys.has(signed.claim.admin_pubkey)) return { error: "admin_not_authorized", status: 403 };
+
+    return null; // pass
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /issuance-requests/:request_id/grant
+  // ---------------------------------------------------------------------------
+
+  app.post("/issuance-requests/:request_id/grant", (c) => handleDecision(c, "grant"));
+
+  // ---------------------------------------------------------------------------
+  // POST /issuance-requests/:request_id/reject
+  // ---------------------------------------------------------------------------
+
+  app.post("/issuance-requests/:request_id/reject", (c) => handleDecision(c, "reject"));
+
+  // ---------------------------------------------------------------------------
+  // GET /issuance-requests?status=<status>
+  // ---------------------------------------------------------------------------
+
+  app.get("/issuance-requests", async (c) => {
+    const authError = await verifyAdminReadHeader(c);
+    if (authError) {
+      return c.json({ error: authError.error }, authError.status as 400 | 401 | 403 | 503);
+    }
+
+    const status = c.req.query("status") as IssuanceStatus | undefined;
+    const validStatuses: IssuanceStatus[] = ["PENDING", "GRANTED", "REJECTED"];
+    if (!status || !validStatuses.includes(status)) {
+      return c.json(
+        { error: "status query param required", details: "must be one of PENDING, GRANTED, REJECTED" },
+        400,
+      );
+    }
+
+    const store = getIssuanceStore(c.env);
+    const requests = await store.listIssuanceRequests(status);
+    return c.json(requests, 200);
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /issuance-requests/:request_id
+  // ---------------------------------------------------------------------------
+
+  app.get("/issuance-requests/:request_id", async (c) => {
+    const authError = await verifyAdminReadHeader(c);
+    if (authError) {
+      return c.json({ error: authError.error }, authError.status as 400 | 401 | 403 | 503);
+    }
+
+    const requestId = c.req.param("request_id") ?? "";
+    const store = getIssuanceStore(c.env);
+    const request = await store.getIssuanceRequest(requestId);
+    if (!request) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    return c.json(request, 200);
+  });
+
+  return app;
+}

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -16,7 +16,7 @@
 import { Hono } from "hono";
 import { getRegistryPublicKey, type Env } from "../index";
 import { signEd25519, verifyEd25519, canonicalJSON } from "../signing";
-import { getNonceCache, getStore, StaleRecordError } from "../store";
+import { getNonceCache, getStore, getIssuanceStore, StaleRecordError } from "../store";
 import {
   checkRateLimit,
   clientKey,
@@ -201,6 +201,34 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
         );
       }
       throw err;
+    }
+
+    // O-4a.1 — issuance-request hook. AFTER successful registration, upsert a
+    // PENDING issuance request for the peer's principal pubkey. This is additive:
+    // it does not change the response body or the principal record. Idempotent:
+    // re-registration of the same peer_pubkey returns the existing request row
+    // without creating a duplicate.
+    //
+    // We use the first stack's stack_pubkey (or the root principal_pubkey when
+    // the claim carries no stacks) as the peer_pubkey on the issuance request.
+    // This is the key that federated envelopes FROM this peer will be verified
+    // against (per C-787). The requested_scope is derived from the principal_id.
+    //
+    // Errors here are logged but NOT propagated to the caller: a failure to
+    // create the issuance request must not reject a valid registration — the
+    // principal record is already committed, and a retry of the issuance upsert
+    // is always safe (idempotent).
+    try {
+      const issuanceStore = getIssuanceStore(c.env);
+      const peerPubkey =
+        stacksWithPubkeys[0]?.stack_pubkey ?? claim.principal_pubkey;
+      const requestedScope = `federated.${principalId}.>`;
+      await issuanceStore.upsertPending(principalId, peerPubkey, requestedScope);
+    } catch (err) {
+      console.error(
+        `[network-registry] issuance upsert failed for principal ${principalId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Intentionally non-fatal: the principal record is committed.
     }
 
     // Sign + return the canonical view so the principal gets the same

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -301,39 +301,43 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     peerPubkey: string,
     requestedScope: string,
   ): Promise<IssuanceRequest> {
-    // Check for an existing row for this (principal_id, peer_pubkey) first.
-    // The UNIQUE index on (principal_id, peer_pubkey) would make an INSERT
-    // conflict; we pre-check to keep the idempotency logic explicit and to
-    // return the existing row without touching it.
-    const existing = await this.db
-      .prepare(
-        "SELECT * FROM issuance_requests WHERE principal_id = ? AND peer_pubkey = ?",
-      )
-      .bind(principalId, peerPubkey)
-      .first<IssuanceRequestRow>();
-    if (existing) return rowToIssuanceRequest(existing);
-
+    // M3 — atomic upsert: INSERT ... ON CONFLICT(principal_id, peer_pubkey) DO NOTHING.
+    // Mirrors the D1NonceCache atomic insert pattern (~line 536): the database
+    // decides atomically whether the row exists; no SELECT-then-INSERT race window
+    // exists where two concurrent registrations could both see "no row" and
+    // attempt a double-insert. After the insert-or-ignore, we unconditionally
+    // SELECT the row (either the one we just inserted or the pre-existing one)
+    // and return it.  Contract: always returns the PENDING (or already-decided)
+    // row for this (principal_id, peer_pubkey) pair; never throws on a concurrent
+    // insert; never creates a duplicate.
     const now = new Date().toISOString();
     const requestId = generateRequestId();
     await this.db
       .prepare(
         `INSERT INTO issuance_requests
            (request_id, principal_id, peer_pubkey, requested_scope, status, created_at, updated_at, granted_by, leaf_package)
-         VALUES (?, ?, ?, ?, 'PENDING', ?, ?, NULL, NULL)`,
+         VALUES (?, ?, ?, ?, 'PENDING', ?, ?, NULL, NULL)
+         ON CONFLICT(principal_id, peer_pubkey) DO NOTHING`,
       )
       .bind(requestId, principalId, peerPubkey, requestedScope, now, now)
       .run();
-    return {
-      request_id: requestId,
-      principal_id: principalId,
-      peer_pubkey: peerPubkey,
-      requested_scope: requestedScope,
-      status: "PENDING",
-      created_at: now,
-      updated_at: now,
-      granted_by: null,
-      leaf_package: null,
-    };
+
+    // Unconditional SELECT — retrieves the winner (our insert or the existing row).
+    const row = await this.db
+      .prepare(
+        "SELECT * FROM issuance_requests WHERE principal_id = ? AND peer_pubkey = ?",
+      )
+      .bind(principalId, peerPubkey)
+      .first<IssuanceRequestRow>();
+
+    // The row MUST exist at this point: either we inserted it or it pre-existed.
+    // A missing row here would indicate a D1 write anomaly outside normal operation.
+    if (!row) {
+      throw new Error(
+        `network-registry: upsertPending invariant violated — no row found for (${principalId}, ${peerPubkey}) after atomic insert`,
+      );
+    }
+    return rowToIssuanceRequest(row);
   }
 
   async getIssuanceRequest(requestId: string): Promise<IssuanceRequest | undefined> {
@@ -380,10 +384,14 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
       .run();
 
     if ((res.meta?.changes ?? 0) === 0) {
-      // Someone else decided it concurrently — re-read and throw.
-      const current = await this.getIssuanceRequest(requestId);
-      if (current) throw new AlreadyDecidedError(current);
-      return undefined; // should not happen
+      // N2 — the pre-UPDATE `existing` row is already in scope and was confirmed
+      // PENDING before the UPDATE ran. `changes === 0` means the
+      // `WHERE status = 'PENDING'` guard flipped false after our read — a
+      // concurrent grant/reject landed between our SELECT and UPDATE. Throw
+      // directly with the row we already have rather than issuing a second
+      // SELECT (which could 404 under a transient D1 error even though the row
+      // exists, causing a spurious 404 vs the correct 409).
+      throw new AlreadyDecidedError(existing);
     }
 
     return {

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -28,6 +28,8 @@
 import type {
   Capability,
   CapabilityHit,
+  IssuanceRequest,
+  IssuanceStatus,
   NetworkRecord,
   NetworkRoster,
   PrincipalRecord,
@@ -149,6 +151,296 @@ export interface RegistryStore {
 
   /** Test/admin helper. Not exposed via HTTP. */
   reset(): Promise<void>;
+}
+
+// =============================================================================
+// O-4a.1 — Issuance-request store
+// =============================================================================
+
+/**
+ * Thrown by `transitionIssuanceRequest` when the request has already been
+ * decided (GRANTED or REJECTED). The route maps this to 409 already_decided.
+ */
+export class AlreadyDecidedError extends Error {
+  constructor(public readonly request: IssuanceRequest) {
+    super(`issuance request ${request.request_id} is already ${request.status}`);
+    this.name = "AlreadyDecidedError";
+  }
+}
+
+export interface IssuanceRequestStore {
+  /**
+   * Upsert a PENDING issuance request for (principal_id, peer_pubkey).
+   *
+   * Idempotency rule: if a row already exists for this (principal_id, peer_pubkey)
+   * pair — regardless of its current status — return that existing row without
+   * inserting a new one. Re-registration of the same peer pubkey never creates a
+   * duplicate; it returns the existing row (PENDING, GRANTED, or REJECTED).
+   *
+   * This is the side-effect of `POST /principals/:id/register` AFTER PoP
+   * verification succeeds.
+   */
+  upsertPending(
+    principalId: string,
+    peerPubkey: string,
+    requestedScope: string,
+  ): Promise<IssuanceRequest>;
+
+  /** Retrieve a single issuance request by its request_id. */
+  getIssuanceRequest(requestId: string): Promise<IssuanceRequest | undefined>;
+
+  /**
+   * List issuance requests filtered by status.
+   * Returns all rows matching the given status, ordered by created_at ascending.
+   */
+  listIssuanceRequests(status: IssuanceStatus): Promise<IssuanceRequest[]>;
+
+  /**
+   * Transition a PENDING request to GRANTED or REJECTED.
+   *
+   * The transition is gated on `status = 'PENDING'` (CAS-ish guard): if the
+   * row is already decided, throws `AlreadyDecidedError`.
+   * If the request_id doesn't exist, returns `undefined`.
+   *
+   * Sets `granted_by` to `adminPubkey` and `updated_at` to now.
+   * `leaf_package` stays null (O-4a.2 populates it).
+   */
+  transitionIssuanceRequest(
+    requestId: string,
+    newStatus: "GRANTED" | "REJECTED",
+    adminPubkey: string,
+  ): Promise<IssuanceRequest | undefined>;
+}
+
+// =============================================================================
+// In-memory IssuanceRequestStore
+// =============================================================================
+
+/** Hex UUID generator — URL-safe, collision-resistant for test-scale traffic. */
+function generateRequestId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
+  private readonly requests = new Map<string, IssuanceRequest>();
+  /** (principal_id + "\x00" + peer_pubkey) → request_id */
+  private readonly byPeer = new Map<string, string>();
+
+  async upsertPending(
+    principalId: string,
+    peerPubkey: string,
+    requestedScope: string,
+  ): Promise<IssuanceRequest> {
+    const peerKey = `${principalId}\x00${peerPubkey}`;
+    const existingId = this.byPeer.get(peerKey);
+    if (existingId !== undefined) {
+      // Idempotent: return the existing row.
+      return this.requests.get(existingId)!;
+    }
+    const now = new Date().toISOString();
+    const request: IssuanceRequest = {
+      request_id: generateRequestId(),
+      principal_id: principalId,
+      peer_pubkey: peerPubkey,
+      requested_scope: requestedScope,
+      status: "PENDING",
+      created_at: now,
+      updated_at: now,
+      granted_by: null,
+      leaf_package: null,
+    };
+    this.requests.set(request.request_id, request);
+    this.byPeer.set(peerKey, request.request_id);
+    return request;
+  }
+
+  async getIssuanceRequest(requestId: string): Promise<IssuanceRequest | undefined> {
+    return this.requests.get(requestId);
+  }
+
+  async listIssuanceRequests(status: IssuanceStatus): Promise<IssuanceRequest[]> {
+    return [...this.requests.values()]
+      .filter((r) => r.status === status)
+      .sort((a, b) => a.created_at.localeCompare(b.created_at));
+  }
+
+  async transitionIssuanceRequest(
+    requestId: string,
+    newStatus: "GRANTED" | "REJECTED",
+    adminPubkey: string,
+  ): Promise<IssuanceRequest | undefined> {
+    const existing = this.requests.get(requestId);
+    if (!existing) return undefined;
+    if (existing.status !== "PENDING") {
+      throw new AlreadyDecidedError(existing);
+    }
+    const updated: IssuanceRequest = {
+      ...existing,
+      status: newStatus,
+      granted_by: adminPubkey,
+      updated_at: new Date().toISOString(),
+    };
+    this.requests.set(requestId, updated);
+    return updated;
+  }
+}
+
+// =============================================================================
+// D1-backed IssuanceRequestStore
+// =============================================================================
+
+export class D1IssuanceRequestStore implements IssuanceRequestStore {
+  constructor(private readonly db: D1Like) {}
+
+  async upsertPending(
+    principalId: string,
+    peerPubkey: string,
+    requestedScope: string,
+  ): Promise<IssuanceRequest> {
+    // Check for an existing row for this (principal_id, peer_pubkey) first.
+    // The UNIQUE index on (principal_id, peer_pubkey) would make an INSERT
+    // conflict; we pre-check to keep the idempotency logic explicit and to
+    // return the existing row without touching it.
+    const existing = await this.db
+      .prepare(
+        "SELECT * FROM issuance_requests WHERE principal_id = ? AND peer_pubkey = ?",
+      )
+      .bind(principalId, peerPubkey)
+      .first<IssuanceRequestRow>();
+    if (existing) return rowToIssuanceRequest(existing);
+
+    const now = new Date().toISOString();
+    const requestId = generateRequestId();
+    await this.db
+      .prepare(
+        `INSERT INTO issuance_requests
+           (request_id, principal_id, peer_pubkey, requested_scope, status, created_at, updated_at, granted_by, leaf_package)
+         VALUES (?, ?, ?, ?, 'PENDING', ?, ?, NULL, NULL)`,
+      )
+      .bind(requestId, principalId, peerPubkey, requestedScope, now, now)
+      .run();
+    return {
+      request_id: requestId,
+      principal_id: principalId,
+      peer_pubkey: peerPubkey,
+      requested_scope: requestedScope,
+      status: "PENDING",
+      created_at: now,
+      updated_at: now,
+      granted_by: null,
+      leaf_package: null,
+    };
+  }
+
+  async getIssuanceRequest(requestId: string): Promise<IssuanceRequest | undefined> {
+    const row = await this.db
+      .prepare("SELECT * FROM issuance_requests WHERE request_id = ?")
+      .bind(requestId)
+      .first<IssuanceRequestRow>();
+    return row ? rowToIssuanceRequest(row) : undefined;
+  }
+
+  async listIssuanceRequests(status: IssuanceStatus): Promise<IssuanceRequest[]> {
+    const res = await this.db
+      .prepare(
+        "SELECT * FROM issuance_requests WHERE status = ? ORDER BY created_at ASC",
+      )
+      .bind(status)
+      .all<IssuanceRequestRow>();
+    return (res.results ?? []).map(rowToIssuanceRequest);
+  }
+
+  async transitionIssuanceRequest(
+    requestId: string,
+    newStatus: "GRANTED" | "REJECTED",
+    adminPubkey: string,
+  ): Promise<IssuanceRequest | undefined> {
+    // Re-read current state before mutating — needed for AlreadyDecidedError.
+    const existing = await this.getIssuanceRequest(requestId);
+    if (!existing) return undefined;
+    if (existing.status !== "PENDING") {
+      throw new AlreadyDecidedError(existing);
+    }
+
+    const now = new Date().toISOString();
+    // CAS-ish: UPDATE only touches the row when status is still PENDING.
+    // If a concurrent grant/reject raced us here, the WHERE status='PENDING'
+    // is false, changes === 0, and we read back the decided row to throw.
+    const res = await this.db
+      .prepare(
+        `UPDATE issuance_requests
+         SET status = ?, granted_by = ?, updated_at = ?
+         WHERE request_id = ? AND status = 'PENDING'`,
+      )
+      .bind(newStatus, adminPubkey, now, requestId)
+      .run();
+
+    if ((res.meta?.changes ?? 0) === 0) {
+      // Someone else decided it concurrently — re-read and throw.
+      const current = await this.getIssuanceRequest(requestId);
+      if (current) throw new AlreadyDecidedError(current);
+      return undefined; // should not happen
+    }
+
+    return {
+      ...existing,
+      status: newStatus,
+      granted_by: adminPubkey,
+      updated_at: now,
+    };
+  }
+}
+
+/** Raw column shape for an issuance_requests row. */
+interface IssuanceRequestRow {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  requested_scope: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  granted_by: string | null;
+  leaf_package: string | null;
+}
+
+function rowToIssuanceRequest(row: IssuanceRequestRow): IssuanceRequest {
+  return {
+    request_id: row.request_id,
+    principal_id: row.principal_id,
+    peer_pubkey: row.peer_pubkey,
+    requested_scope: row.requested_scope,
+    status: row.status as IssuanceStatus,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    granted_by: row.granted_by,
+    leaf_package: row.leaf_package,
+  };
+}
+
+// =============================================================================
+// Singleton accessor
+// =============================================================================
+
+let issuanceStoreSingleton: IssuanceRequestStore | undefined;
+
+export function getIssuanceStore(env: StoreEnv): IssuanceRequestStore {
+  if (!issuanceStoreSingleton) {
+    assertDurableBackendInProd(env);
+    issuanceStoreSingleton = env.DB
+      ? new D1IssuanceRequestStore(env.DB)
+      : new InMemoryIssuanceRequestStore();
+  }
+  return issuanceStoreSingleton;
+}
+
+/** Test-only — swap issuance store between cases. */
+export function _setIssuanceStoreForTest(s: IssuanceRequestStore | undefined): void {
+  issuanceStoreSingleton = s;
 }
 
 // =============================================================================

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -249,3 +249,106 @@ export interface CapabilityHit {
   networks: string[];
   description?: string;
 }
+
+// =============================================================================
+// O-4a.1 — Issuance-request state machine types
+// =============================================================================
+
+/**
+ * The lifecycle status of an issuance request.
+ * Transitions: PENDING → GRANTED (on admin grant)
+ *              PENDING → REJECTED (on admin reject)
+ * Re-transitions are forbidden (409 already_decided).
+ */
+export type IssuanceStatus = "PENDING" | "GRANTED" | "REJECTED";
+
+/**
+ * A persisted issuance request — the metadata record that a verified
+ * registration creates. No secrets; no credentials. The `leaf_package`
+ * column is the O-4a.2 seam (always null in O-4a.1).
+ */
+export interface IssuanceRequest {
+  /** Opaque hex UUID, URL-safe. Primary key. */
+  request_id: string;
+  /** The principal that registered and triggered this request. */
+  principal_id: string;
+  /**
+   * Base64 Ed25519 pubkey of the peer stack being onboarded.
+   * The (principal_id, peer_pubkey) pair is unique — re-registration
+   * returns the existing row rather than inserting a duplicate.
+   */
+  peer_pubkey: string;
+  /**
+   * The NATS subject scope the peer is requesting,
+   * e.g. `federated.<peer_slug>.>`.
+   */
+  requested_scope: string;
+  /** Current lifecycle state. */
+  status: IssuanceStatus;
+  /** ISO-8601 UTC; when the request was first created. */
+  created_at: string;
+  /** ISO-8601 UTC; updated on grant/reject. */
+  updated_at: string;
+  /**
+   * The admin pubkey (base64) that granted or rejected this request.
+   * Null while PENDING.
+   */
+  granted_by: string | null;
+  /**
+   * O-4a.2 seam: JSON blob of the issued leaf credential package.
+   * Always null in O-4a.1; populated by the next slice.
+   */
+  leaf_package: string | null;
+}
+
+/**
+ * The admin-signed claim carried by
+ * `POST /issuance-requests/{request_id}/grant` and `/reject`.
+ *
+ * Mirrors `NetworkCreateClaim` in structure so the admin gate can be
+ * reused verbatim: admin signs canonicalJSON(claim); registry verifies
+ * the signature against claim.admin_pubkey and checks the allowlist.
+ */
+export interface IssuanceDecisionClaim {
+  /** Must equal the URL path parameter. Echoed for canonicalisation. */
+  request_id: string;
+  /** The decision: "grant" or "reject". Part of the signed payload. */
+  decision: "grant" | "reject";
+  /** Base64 Ed25519 pubkey of the admin signing this claim. */
+  admin_pubkey: string;
+  /** ISO-8601 UTC timestamp at which the admin signed this claim. */
+  issued_at: string;
+  /** Random nonce to prevent replay (same replay cache as network-create). */
+  nonce: string;
+}
+
+/** On-wire envelope for a grant/reject decision. */
+export interface SignedIssuanceDecision {
+  claim: IssuanceDecisionClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}
+
+/**
+ * The admin-signed claim carried by GET /issuance-requests reads.
+ * The GET endpoints are operational metadata; we gate them behind
+ * an admin signature sent via `x-admin-signed` header. This prevents
+ * any unauthenticated enumeration of the onboarding queue.
+ *
+ * A lightweight claim (no nonce/replay check — reads are idempotent
+ * and don't mutate state). Clock-skew check applies to prevent stale
+ * tokens lingering. The admin proves allowlisted possession.
+ */
+export interface IssuanceReadClaim {
+  /** The admin's own pubkey — used for allowlist check. */
+  admin_pubkey: string;
+  /** ISO-8601 UTC; within the CLOCK_SKEW_MS window. */
+  issued_at: string;
+}
+
+/** On-wire envelope for an admin read authorisation. */
+export interface SignedIssuanceRead {
+  claim: IssuanceReadClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -18,7 +18,11 @@
 
 import type {
   Capability,
+  IssuanceDecisionClaim,
+  IssuanceReadClaim,
   RegistrationClaim,
+  SignedIssuanceDecision,
+  SignedIssuanceRead,
   SignedRegistration,
   StackIdentity,
 } from "./types";
@@ -462,6 +466,141 @@ export function validateSignedNetworkCreate(
   return {
     ok: true,
     signed: { claim: b.claim as NetworkCreateClaim, signature: b.signature },
+  };
+}
+
+// =============================================================================
+// O-4a.1 — Issuance decision claim validation
+// =============================================================================
+
+/**
+ * Validate the body of `POST /issuance-requests/{id}/grant` and `/reject`.
+ * The envelope is { claim: IssuanceDecisionClaim, signature: string }.
+ * Mirrors `validateSignedNetworkCreate` exactly in structure so the admin gate
+ * can be applied identically (503 / 401 / 403 order).
+ */
+export function validateSignedIssuanceDecision(
+  body: unknown,
+): { ok: true; signed: SignedIssuanceDecision } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null) {
+    return { ok: false, errors: [{ field: "claim", message: "missing" }] };
+  }
+  return {
+    ok: true,
+    signed: { claim: b.claim as IssuanceDecisionClaim, signature: b.signature },
+  };
+}
+
+/**
+ * Validate the `IssuanceDecisionClaim` payload before crypto verification.
+ * Cross-field rule: claim.request_id MUST match the URL path parameter.
+ * claim.decision MUST be "grant" or "reject".
+ */
+export function validateIssuanceDecisionClaim(
+  claim: unknown,
+  expectedRequestId: string,
+  expectedDecision: "grant" | "reject",
+): { ok: true; claim: IssuanceDecisionClaim } | { ok: false; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+
+  if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be an object" }] };
+  }
+  const c = claim as Record<string, unknown>;
+
+  // request_id — must match path param (forged-attribution guard).
+  if (typeof c.request_id !== "string" || c.request_id.length === 0) {
+    errors.push({ field: "request_id", message: "must be a non-empty string" });
+  } else if (c.request_id !== expectedRequestId) {
+    errors.push({
+      field: "request_id",
+      message: `body request_id "${c.request_id}" does not match path "${expectedRequestId}"`,
+    });
+  }
+
+  // decision — must match the route's intended decision.
+  if (c.decision !== "grant" && c.decision !== "reject") {
+    errors.push({ field: "decision", message: 'must be "grant" or "reject"' });
+  } else if (c.decision !== expectedDecision) {
+    errors.push({
+      field: "decision",
+      message: `body decision "${c.decision as string}" does not match route "${expectedDecision}"`,
+    });
+  }
+
+  // admin_pubkey — base64 Ed25519 pubkey.
+  if (typeof c.admin_pubkey !== "string" || !isValidPubkey(c.admin_pubkey)) {
+    errors.push({ field: "admin_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
+  }
+
+  // issued_at — ISO-8601 UTC.
+  if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
+    errors.push({ field: "issued_at", message: "must be an ISO-8601 timestamp" });
+  }
+
+  // nonce — same bounds as registration.
+  if (typeof c.nonce !== "string" || c.nonce.length < 8 || c.nonce.length > 128) {
+    errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    claim: {
+      request_id: c.request_id as string,
+      decision: c.decision as "grant" | "reject",
+      admin_pubkey: c.admin_pubkey as string,
+      issued_at: c.issued_at as string,
+      nonce: c.nonce as string,
+    },
+  };
+}
+
+/**
+ * Validate the `x-admin-signed` header envelope for admin-gated GET reads.
+ * The header value is JSON: { claim: IssuanceReadClaim, signature: string }.
+ * No nonce (reads are idempotent). Clock-skew still applies.
+ */
+export function validateSignedIssuanceRead(
+  body: unknown,
+): { ok: true; signed: SignedIssuanceRead } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null) {
+    return { ok: false, errors: [{ field: "claim", message: "missing" }] };
+  }
+  const c = b.claim as Record<string, unknown>;
+  if (typeof c.admin_pubkey !== "string" || !isValidPubkey(c.admin_pubkey)) {
+    return { ok: false, errors: [{ field: "claim.admin_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" }] };
+  }
+  if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
+    return { ok: false, errors: [{ field: "claim.issued_at", message: "must be an ISO-8601 timestamp" }] };
+  }
+  return {
+    ok: true,
+    signed: {
+      claim: { admin_pubkey: c.admin_pubkey, issued_at: c.issued_at },
+      signature: b.signature,
+    },
   };
 }
 

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -46,6 +46,14 @@ const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 /** Network id — same grammar as principal id. */
 const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
 
+/**
+ * Issuance request id — 32 lowercase hex chars (16 random bytes from
+ * generateRequestId in store.ts). Matching the exact format the store
+ * generates ensures a malformed path param is rejected before it reaches
+ * any query or error body (M2 — request_id path param validation).
+ */
+const REQUEST_ID_RE = /^[0-9a-f]{32}$/;
+
 // =============================================================================
 // Public validators
 // =============================================================================
@@ -64,6 +72,16 @@ export function isValidStackId(id: string): boolean {
 
 export function isValidCapabilityId(id: string): boolean {
   return typeof id === "string" && id.length <= 64 && CAPABILITY_ID_RE.test(id);
+}
+
+/**
+ * Validate an issuance request_id path parameter.
+ * Must be exactly 32 lowercase hex chars — the format generateRequestId in
+ * store.ts produces. Rejects slugs, UUIDs with dashes, and empty strings
+ * before they can reach queries or error bodies (M2 guard).
+ */
+export function isValidRequestId(id: string): boolean {
+  return typeof id === "string" && REQUEST_ID_RE.test(id);
 }
 
 /**
@@ -486,14 +504,19 @@ export function validateSignedIssuanceDecision(
     return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
   }
   const b = body as Record<string, unknown>;
+  // N1 — envelope-level rejection: signature must be a non-empty base64 string.
+  // Explicit check so a future direct caller sees a clear error rather than
+  // reaching validateIssuanceDecisionClaim with an unfiltered raw cast.
   if (typeof b.signature !== "string" || b.signature.length === 0) {
     return { ok: false, errors: [{ field: "signature", message: "missing" }] };
   }
   if (!BASE64_RE.test(b.signature)) {
     return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
   }
-  if (typeof b.claim !== "object" || b.claim === null) {
-    return { ok: false, errors: [{ field: "claim", message: "missing" }] };
+  // N1 — claim must be a plain object (not null, not an array). Arrays pass
+  // the `typeof === "object"` check but are not valid claim shapes.
+  if (typeof b.claim !== "object" || b.claim === null || Array.isArray(b.claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be a non-array object" }] };
   }
   return {
     ok: true,


### PR DESCRIPTION
## Summary

- **O-4a.1** of the automated-operator-onboarding epic (#1050). Pure metadata, zero secrets, fail-closed. Refs #1064.
- Adds the `issuance_requests` table (migration 0004), state machine (PENDING→GRANTED/REJECTED), and admin-gated HTTP surface on the production registry CF Worker.
- The register hook now creates a PENDING request as a non-fatal, idempotent side-effect of every successful `POST /principals/:id/register`.

## Architecture

**Trust model = human-grant** (decided, not re-litigated here):
- Verified registration → PENDING request (PoP already proven by the register handler)
- Admin grant/reject → GRANTED/REJECTED (explicit human approval required)
- `leaf_package` column stays null — that's O-4a.2 (recording the admin-side NSC issuance result)

**Admin gate reused verbatim** from `POST /networks/:id` (#747):
1. `parseAdminPubkeys` → empty → `503 admin_not_configured` (FIRST, before any body parse)
2. `verifyEd25519(claim.admin_pubkey, sig, canonicalJSON(claim))` → `401 signature_invalid`
3. `!adminPubkeys.has(claim.admin_pubkey)` → `403 admin_not_authorized`
4. Nonce replay → `409 nonce_replayed`

Read surface (`GET /issuance-requests?status=` and `GET /issuance-requests/:id`) is also admin-gated via `x-admin-signed` header (no nonce — reads are idempotent). Fail-closed: 503 with no allowlist.

## Files changed

| File | What |
|------|------|
| `migrations/0004_issuance_requests.sql` | New table + 2 indexes |
| `src/types.ts` | `IssuanceRequest`, `IssuanceStatus`, decision/read claim shapes |
| `src/store.ts` | `IssuanceRequestStore` interface + in-memory + D1 impls + singleton |
| `src/validate.ts` | Decision + read claim validators |
| `src/routes/issuance-requests.ts` | New route file (grant, reject, list, get-by-id) |
| `src/routes/principals.ts` | Register hook — upsert PENDING (additive, non-fatal) |
| `src/index.ts` | Mount `issuanceRequestRoutes()` |
| `__tests__/helpers.ts` | `makeSignedAdminDecision`, `makeSignedAdminRead`, reset issuance store |
| `__tests__/d1-mock.ts` | `issuance_requests` table simulation |
| `__tests__/issuance-requests.test.ts` | 26 new integration tests |
| `__tests__/migration-0004.test.ts` | 10 SQL shape tests |

## Test plan

- [x] 172/172 registry tests pass (`bun test src/services/network-registry/`)
- [x] `bunx tsc --noEmit` — only pre-existing `Uint8Array<ArrayBufferLike>` errors (identical in networks.ts + principals.ts, not introduced here)
- [x] `bunx eslint --quiet` on changed files — clean
- [x] `bash scripts/check-carveouts.sh` — pre-existing node_modules violations only; zero new violations in our source files

## What O-4a.2 will add (not in this PR)

- Admin-side script to record the NSC-issued leaf credential package back into `leaf_package`
- The `leaf_package` column is already nullable and forward-compat in this migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)