### PR TITLE
chore: bump to v5.23.0 — cortex creds CLI + accumulated 5.22 work

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.22.0"
+version: "5.23.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Bump 5.22.0 → 5.23.0. Ships everything unreleased since v5.21.0 (the manifest sat at 5.22.0 with no v5.22.0 tag): notably **#1098** (`cortex creds` CLI registration — unblocks the onboarding tender + the dev-loop/tender stack bus creds). GitHub release cut on merge → `arc upgrade` makes `cortex creds` live on the deployed CLI.