### PR TITLE
fix(network): peer accept-list is presence-only (.agent.>) — least-privilege

### DIFF
--- a/src/bus/agent-network/__tests__/accept-subjects.test.ts
+++ b/src/bus/agent-network/__tests__/accept-subjects.test.ts
@@ -52,7 +52,7 @@ describe("deriveAcceptSubjects — dual-grammar union", () => {
     const subjects = deriveAcceptSubjects(SELF, [peer("jc", "default")]);
     expect(subjects).toEqual([
       OWN_SUBTREE, // dispatch addressed TO me (RECEIVER-addressed)
-      "federated.jc.default.>", // presence sourced FROM jc (SOURCE-addressed)
+      "federated.jc.default.agent.>", // presence sourced FROM jc (SOURCE-addressed, presence-only)
     ]);
   });
 
@@ -63,14 +63,14 @@ describe("deriveAcceptSubjects — dual-grammar union", () => {
     ]);
     expect(subjects).toEqual([
       OWN_SUBTREE,
-      "federated.jc.sage-host.>",
-      "federated.dana.default.>",
+      "federated.jc.sage-host.agent.>",
+      "federated.dana.default.agent.>",
     ]);
   });
 
   test("a peer with a non-default stack slug uses that slug, not 'default'", () => {
     const subjects = deriveAcceptSubjects(SELF, [peer("jc", "research")]);
-    expect(subjects).toContain("federated.jc.research.>");
+    expect(subjects).toContain("federated.jc.research.agent.>");
   });
 });
 
@@ -114,7 +114,7 @@ describe("deriveAcceptSubjects — ordering + de-dupe", () => {
       peer("jc", "default"),
       peer("jc", "default"),
     ]);
-    expect(subjects).toEqual([OWN_SUBTREE, "federated.jc.default.>"]);
+    expect(subjects).toEqual([OWN_SUBTREE, "federated.jc.default.agent.>"]);
   });
 
   test("same principal, different stacks → two distinct subtrees", () => {
@@ -124,8 +124,8 @@ describe("deriveAcceptSubjects — ordering + de-dupe", () => {
     ]);
     expect(subjects).toEqual([
       OWN_SUBTREE,
-      "federated.jc.default.>",
-      "federated.jc.sage-host.>",
+      "federated.jc.default.agent.>",
+      "federated.jc.sage-host.agent.>",
     ]);
   });
 
@@ -164,5 +164,22 @@ describe("deriveAcceptSubjects — derived patterns match real wire subjects", (
       subjectMatches(p, "federated.stranger.default.agent.online"),
     );
     expect(hit).toBe(false);
+  });
+
+  test("least-privilege — a PEER's NON-presence subject (dispatch destined for the peer) is NOT admitted", () => {
+    // The peer accept-list is presence-only (`…agent.>`), so traffic on the
+    // peer's subtree that is NOT presence — e.g. dispatch addressed TO the peer
+    // (receiver-addressed, the peer's business, not mine) — must NOT match. This
+    // is the design §6 invariant: the auto-wiring widens PRESENCE acceptance only.
+    const dispatchToPeer = subjects.some((p) =>
+      subjectMatches(p, "federated.jc.default.tasks.code-review.ts"),
+    );
+    expect(dispatchToPeer).toBe(false);
+    const dispatchLifecycleToPeer = subjects.some((p) =>
+      subjectMatches(p, "federated.jc.default.dispatch.task.started"),
+    );
+    expect(dispatchLifecycleToPeer).toBe(false);
+    // And the own subtree (`.>`) must NOT accidentally cover the peer's subjects.
+    expect(subjectMatches(OWN_SUBTREE, "federated.jc.default.agent.online")).toBe(false);
   });
 });

--- a/src/bus/agent-network/accept-subjects.ts
+++ b/src/bus/agent-network/accept-subjects.ts
@@ -109,14 +109,29 @@ export function deriveAcceptSubjects(
   self: AcceptSubjectsSelf,
   peers: readonly FederatedWireIdentity[],
 ): string[] {
+  // OWN subtree is the FULL `federated.{me}.{stack}.>` — I must accept every
+  // inbound federated subject addressed TO me (dispatch is RECEIVER-addressed, so
+  // a peer dispatching to me publishes onto MY subtree).
   const ownSubtree = federatedSubtree(self.principal, self.stack);
 
-  // Insertion-ordered de-dupe: own subtree first, then each peer's subtree.
+  // Insertion-ordered de-dupe: own subtree first, then each peer's PRESENCE subtree.
   const seen = new Set<string>([ownSubtree]);
   const out: string[] = [ownSubtree];
 
   for (const peer of peers) {
-    const subtree = federatedSubtree(peer.principal, peer.stack);
+    // A self-shaped peer (P1 excludes self, but defensive) is fully covered by
+    // the own `.>` subtree above — skip it rather than emit a redundant
+    // `federated.{me}.{stack}.agent.>` row the own subtree already subsumes.
+    if (peer.principal === self.principal && peer.stack === self.stack) continue;
+    // PEER subtree is PRESENCE-ONLY (`…agent.>`), NOT the full `.>` — least
+    // privilege + the design §6 invariant ("only widens PRESENCE acceptance").
+    // The only source-addressed traffic I legitimately receive from a peer is its
+    // presence (`federated.{peer}.{stack}.agent.*`, ADR-0007). A peer's full
+    // subtree ALSO carries dispatch addressed TO that peer (receiver-addressed) —
+    // traffic destined for the peer, not me; I must not ingest it. Federated
+    // DISPATCH admission is a separate accept-list path (offer-mode, #1097), not
+    // this presence-wiring derivation.
+    const subtree = federatedPresenceSubtree(peer.principal, peer.stack);
     if (seen.has(subtree)) continue;
     seen.add(subtree);
     out.push(subtree);
@@ -126,12 +141,22 @@ export function deriveAcceptSubjects(
 }
 
 /**
- * The `federated.{principal}.{stack}.>` subtree wildcard for one wire identity —
- * the single accept-list pattern that admits every federated subject addressed
- * to (dispatch) or sourced from (presence) `{principal}/{stack}`. The terminal
- * `>` matches one-or-more trailing segments (`subjectMatches`, surface-router),
- * covering `…agent.online`, `…tasks.code-review.ts`, and every other action.
+ * The FULL `federated.{principal}.{stack}.>` subtree wildcard — admits every
+ * federated subject addressed to (dispatch) or sourced from (presence)
+ * `{principal}/{stack}`. Used for the OWN subtree only (I accept all traffic
+ * addressed to me). The terminal `>` matches one-or-more trailing segments.
  */
 function federatedSubtree(principal: string, stack: string): string {
   return `federated.${principal}.${stack}.>`;
+}
+
+/**
+ * The PRESENCE-ONLY `federated.{principal}.{stack}.agent.>` subtree — admits a
+ * peer's source-addressed presence stream (`agent.online|heartbeat|offline|
+ * capabilities-changed`) and NOTHING ELSE on the peer's subtree. Used for ROSTER
+ * PEERS, so the auto-wiring widens presence acceptance without admitting
+ * peer-destined dispatch (least privilege; design §6 invariant).
+ */
+function federatedPresenceSubtree(principal: string, stack: string): string {
+  return `federated.${principal}.${stack}.agent.>`;
 }

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -1027,7 +1027,7 @@ describe("join", () => {
     // FROM peers). rosterFor() resolves one peer, jc/sage-host.
     expect(net.accept_subjects).toEqual([
       "federated.andreas.meta-factory.>",
-      "federated.jc.sage-host.>",
+      "federated.jc.sage-host.agent.>", // peer = PRESENCE-ONLY (least privilege)
     ]);
     // The wire contract STILL holds: subjects gate by principal/stack segments,
     // never the network id `metafactory` (note `meta-factory` is the stack SLUG,
@@ -1386,8 +1386,8 @@ describe("P2 #1087 accept_subjects derivation", () => {
     expect(res.ok).toBe(true);
     const net = storeRef.networks.find((n) => n.id === "metafactory")!;
     expect(net.accept_subjects).toEqual([
-      "federated.andreas.meta-factory.>", // dispatch addressed TO me
-      "federated.jc.sage-host.>", // jc's presence, SOURCE-addressed
+      "federated.andreas.meta-factory.>", // dispatch addressed TO me (full subtree)
+      "federated.jc.sage-host.agent.>", // jc's presence, SOURCE-addressed (presence-only)
     ]);
   });
 
@@ -1400,7 +1400,7 @@ describe("P2 #1087 accept_subjects derivation", () => {
       res.steps.some(
         (s) =>
           s.includes("federated.andreas.meta-factory.>") &&
-          s.includes("federated.jc.sage-host.>"),
+          s.includes("federated.jc.sage-host.agent.>"),
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
Follow-up to #1087 (P2 of #1084). `deriveAcceptSubjects` granted each roster peer the FULL `federated.{peer}.{stack}.>` subtree, which also admits dispatch addressed TO the peer — exceeding the design §6 invariant (*'only widens PRESENCE acceptance'*) and least-privilege.

**Fix:** peer subtree → presence-only `federated.{peer}.{stack}.agent.>`; OWN subtree stays full `.>` (dispatch addressed to me). Self-shaped-peer skip added. New least-privilege regression test: a peer's dispatch subject (`federated.{peer}.{stack}.tasks.*` / `.dispatch.*`) is NOT admitted; presence (`.agent.*`) still is.

Federated DISPATCH admission remains the separate offer-mode accept-list path (#1097).

338 tests pass; lint + tsc + vocab clean. Caught in the P3 #1102 trust-gate review before merging the reconciler.