### PR TITLE
chore: bump to v5.24.0 — roster-driven federation auto-wiring

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.23.0"
+version: "5.24.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release bump to v5.24.0. Ships the roster-driven federation auto-wiring wave (#1084): P1 #1086 runtime roster read, P2 #1087 accept-list derivation, P3 #1088 continuous reconciler, P4 #1089 signal-optional verdict, + #1105 presence-only peer accept (least-privilege). Receive side complete.