### PR TITLE
feat(offer): C-1097 — merge offer-mode dispatch accept_subjects with presence rows (#1084 P2.1)

### DIFF
--- a/src/cli/cortex/commands/__tests__/offer.test.ts
+++ b/src/cli/cortex/commands/__tests__/offer.test.ts
@@ -56,6 +56,7 @@ import {
   applyRevoke,
   buildListRows,
   reconcileLayer,
+  mergeOfferAcceptSubjects,
   resolveTarget,
   dispatchOffer,
 } from "../offer";
@@ -390,6 +391,171 @@ describe("reconcileLayer", () => {
     ]);
     // Defensive: the stack.id principal half must NOT leak onto the wire.
     expect((net[0]?.accept_subjects as string[])[0]).not.toContain("jcfischer");
+  });
+});
+
+// ===========================================================================
+// mergeOfferAcceptSubjects — the pure least-privilege preserve-merge (#1097)
+// ===========================================================================
+
+describe("mergeOfferAcceptSubjects", () => {
+  test("preserves non-offer rows (OWN `.>`, peer `.agent.>`), appends capability rows", () => {
+    const prior = [
+      "federated.andreas.work.>",
+      "federated.jc.sage-host.agent.>",
+    ];
+    const caps = ["federated.andreas.work.tasks.code-review.typescript.>"];
+    expect(mergeOfferAcceptSubjects(prior, caps, "andreas", "work")).toEqual([
+      "federated.andreas.work.>",
+      "federated.jc.sage-host.agent.>",
+      "federated.andreas.work.tasks.code-review.typescript.>",
+    ]);
+  });
+
+  test("regenerates own `…tasks.*.>` rows — a stale capability row is dropped", () => {
+    const prior = [
+      "federated.andreas.work.>",
+      "federated.andreas.work.tasks.old-cap.>", // stale — offer-owned, not in caps
+    ];
+    const caps = ["federated.andreas.work.tasks.new-cap.>"];
+    expect(mergeOfferAcceptSubjects(prior, caps, "andreas", "work")).toEqual([
+      "federated.andreas.work.>",
+      "federated.andreas.work.tasks.new-cap.>",
+    ]);
+  });
+
+  test("does not duplicate a capability row already hand-pinned in prior", () => {
+    const cap = "federated.andreas.work.tasks.code-review.typescript.>";
+    // The hand-pin is an own-`…tasks.` row → the offer writer OWNS it, so it is
+    // dropped from `preserved` and re-added once from caps (no duplicate).
+    expect(mergeOfferAcceptSubjects([cap], [cap], "andreas", "work")).toEqual([cap]);
+  });
+
+  test("empty caps + only presence rows → presence rows survive, no dispatch rows", () => {
+    const prior = ["federated.andreas.work.>", "federated.jc.sage-host.agent.>"];
+    expect(mergeOfferAcceptSubjects(prior, [], "andreas", "work")).toEqual(prior);
+  });
+
+  test("a DIFFERENT principal's `…tasks.` row is NOT offer-owned → preserved", () => {
+    // Defensive: the own-prefix is identity-scoped. A peer's tasks row (should
+    // never appear, but if it does) is not this writer's to regenerate.
+    const prior = ["federated.jc.sage-host.tasks.code-review.>"];
+    const caps = ["federated.andreas.work.tasks.chat.>"];
+    expect(mergeOfferAcceptSubjects(prior, caps, "andreas", "work")).toEqual([
+      "federated.jc.sage-host.tasks.code-review.>",
+      "federated.andreas.work.tasks.chat.>",
+    ]);
+  });
+});
+
+// ===========================================================================
+// reconcileLayer — co-existence with the PRESENCE-wiring accept-list writer
+// (cortex#1097, umbrella #1084 P2.1; least-privilege per #1105)
+//
+// `policy.federated.networks[].accept_subjects` has TWO writers:
+//   - the PRESENCE path (`network join` / reconciler, via `deriveAcceptSubjects`)
+//     writes the OWN `.>` subtree ∪ each roster peer's `.agent.>` presence subtree.
+//   - this offer-mode DISPATCH writer regenerates the capability-dispatch rows
+//     `federated.{me}.{stack}.tasks.{cap}.>` from the offerings.
+// They share ONE array. The offer writer must own ONLY its own-identity
+// `…tasks.*.>` dispatch rows and PRESERVE everything else, or an `offer --apply`
+// silently clobbers the peer presence subtrees and regresses P2/#1105.
+// ===========================================================================
+
+describe("reconcileLayer — preserves presence-wiring accept-subjects (#1097)", () => {
+  const OWN_SUBTREE = "federated.andreas.work.>";
+  const PEER_PRESENCE_JC = "federated.jc.sage-host.agent.>";
+  const PEER_PRESENCE_KZ = "federated.kz.research.agent.>";
+  const CAP_DISPATCH = "federated.andreas.work.tasks.code-review.typescript.>";
+
+  /** A layer whose network already carries the presence-wiring accept-list
+   *  (OWN `.>` ∪ two peer `.agent.>` subtrees), as `network join` would write. */
+  const layerWithPresence = (extraAccept: string[] = []): Rec => ({
+    principal: { id: "andreas" },
+    stack: { id: "andreas/work" },
+    policy: {
+      federated: {
+        networks: [
+          {
+            id: "metafactory-net",
+            leaf_node: "leaf",
+            max_hop: 1,
+            peers: [
+              { principal: "jc", stack: "sage-host" },
+              { principal: "kz", stack: "research" },
+            ],
+            accept_subjects: [OWN_SUBTREE, PEER_PRESENCE_JC, PEER_PRESENCE_KZ, ...extraAccept],
+            announce_capabilities: [],
+          },
+        ],
+        registry: { url: "https://registry.example" },
+      },
+    },
+  });
+
+  test("adding a federated offering PRESERVES the OWN `.>` + peer `.agent.>` presence rows", () => {
+    const { layer } = reconcileLayer(layerWithPresence(), [OFFER_FED_NET]);
+    const net = ((layer.policy as Rec).federated as Rec).networks as Rec[];
+    const accept = net[0]?.accept_subjects as string[];
+    // Presence-wiring rows survive untouched.
+    expect(accept).toContain(OWN_SUBTREE);
+    expect(accept).toContain(PEER_PRESENCE_JC);
+    expect(accept).toContain(PEER_PRESENCE_KZ);
+    // The capability-dispatch row is added alongside them.
+    expect(accept).toContain(CAP_DISPATCH);
+  });
+
+  test("the offer writer never widens to a peer's FULL `.>` subtree (least-privilege #1105)", () => {
+    const { layer } = reconcileLayer(layerWithPresence(), [OFFER_FED_NET]);
+    const net = ((layer.policy as Rec).federated as Rec).networks as Rec[];
+    const accept = net[0]?.accept_subjects as string[];
+    // A peer's full subtree (which would admit peer-DESTINED dispatch) must NOT appear.
+    expect(accept).not.toContain("federated.jc.sage-host.>");
+    expect(accept).not.toContain("federated.kz.research.>");
+  });
+
+  test("revoking the last federated offering drops the stale capability row but KEEPS presence rows", () => {
+    // Seed: presence rows + a stale capability-dispatch row, plus the offering.
+    const seeded = layerWithPresence([CAP_DISPATCH]);
+    (seeded.policy as Rec).offerings = [OFFER_FED_NET];
+    const { layer } = reconcileLayer(seeded, []); // all offerings revoked
+    const net = ((layer.policy as Rec).federated as Rec).networks as Rec[];
+    const accept = net[0]?.accept_subjects as string[];
+    // The offer writer's own stale dispatch row is gone…
+    expect(accept).not.toContain(CAP_DISPATCH);
+    // …but the presence-wiring rows it does NOT own are preserved.
+    expect(accept).toContain(OWN_SUBTREE);
+    expect(accept).toContain(PEER_PRESENCE_JC);
+    expect(accept).toContain(PEER_PRESENCE_KZ);
+  });
+
+  test("regenerating is idempotent — re-running with the same offering does not duplicate rows", () => {
+    const first = reconcileLayer(layerWithPresence(), [OFFER_FED_NET]).layer;
+    const firstNet = ((first.policy as Rec).federated as Rec).networks as Rec[];
+    const second = reconcileLayer(first, [OFFER_FED_NET]).layer;
+    const secondNet = ((second.policy as Rec).federated as Rec).networks as Rec[];
+    expect(secondNet[0]?.accept_subjects).toEqual(firstNet[0]?.accept_subjects);
+    // And exactly one capability-dispatch row.
+    const dispatchRows = (secondNet[0]?.accept_subjects as string[]).filter((s) => s === CAP_DISPATCH);
+    expect(dispatchRows).toHaveLength(1);
+  });
+
+  test("a network with NO prior accept-list (greenfield) still gets the capability dispatch row", () => {
+    // Regression guard: the preserve-merge must not break the empty-prior case
+    // (the existing `reconcileLayer` happy path).
+    const greenfield: Rec = {
+      principal: { id: "andreas" },
+      stack: { id: "andreas/work" },
+      policy: {
+        federated: {
+          networks: [{ id: "metafactory-net", leaf_node: "leaf", max_hop: 1, peers: [] }],
+          registry: { url: "https://registry.example" },
+        },
+      },
+    };
+    const { layer } = reconcileLayer(greenfield, [OFFER_FED_NET]);
+    const net = ((layer.policy as Rec).federated as Rec).networks as Rec[];
+    expect(net[0]?.accept_subjects).toEqual([CAP_DISPATCH]);
   });
 });
 

--- a/src/cli/cortex/commands/offer.ts
+++ b/src/cli/cortex/commands/offer.ts
@@ -203,6 +203,79 @@ function capabilityAcceptSubject(
 }
 
 /**
+ * cortex#1097 (umbrella #1084 P2.1) — the prefix the offer-mode DISPATCH writer
+ * OWNS on `accept_subjects`: this stack's OWN-identity tasks subtree
+ * `federated.{me}.{stack}.tasks.`. Every row beginning with this prefix is a
+ * capability-dispatch accept-subject GENERATED from the offerings; the offer
+ * writer regenerates exactly these and PRESERVES everything else.
+ */
+function ownDispatchPrefix(principal: string, stack: string): string {
+  return `federated.${principal}.${stack}.tasks.`;
+}
+
+/**
+ * cortex#1097 (umbrella #1084 P2.1) — merge the offer-mode capability-DISPATCH
+ * projection into the network's EXISTING `accept_subjects` WITHOUT clobbering
+ * the rows the PRESENCE-wiring writer owns.
+ *
+ * ## Why a merge, not an overwrite (the investigation finding)
+ *
+ * `policy.federated.networks[].accept_subjects` has TWO independent writers that
+ * share ONE array:
+ *
+ *   - the **presence** path (`cortex network join` / the P3 reconciler, via
+ *     `deriveAcceptSubjects`, #1087/#1105) writes the OWN `.>` subtree ∪ each
+ *     roster peer's PRESENCE-only `.agent.>` subtree (source-addressed presence
+ *     FROM peers, ADR-0007).
+ *   - this **offer-mode dispatch** writer regenerates the capability rows
+ *     `federated.{me}.{stack}.tasks.{cap}.>` (receiver-addressed dispatch TO me).
+ *
+ * Offer-mode dispatch is purely RECEIVER-addressed — it never legitimately
+ * RECEIVES a peer-SOURCED subject (the verdict a provider emits is an OUTBOUND
+ * publish to the requester's subtree, not an accept; probe-responder + the
+ * federated review consumer both subscribe the stack's OWN subtree). So the
+ * offer writer's OWN-only `…tasks.{cap}.>` rows are already the least-privilege
+ * accept-list for dispatch — they must NOT widen to a peer's full `.>`. The bug
+ * #1097 fixes is that the old overwrite ALSO erased the presence writer's rows,
+ * silently regressing peer-presence admission (P2/#1105) after any `offer --apply`.
+ *
+ * The merge rule is least-privilege on BOTH sides: the offer writer owns ONLY the
+ * own-identity `…tasks.` dispatch rows (it regenerates exactly those, dropping a
+ * capability that's no longer offered), and preserves every other row verbatim —
+ * the OWN `.>` subtree and the peer `.agent.>` presence subtrees the presence
+ * writer owns. It never invents a peer subtree (it has no roster) and never
+ * widens to `.>`.
+ *
+ * Order: preserved (non-offer) rows first in their original order, then the
+ * regenerated capability-dispatch rows (sorted, as `projectFederationConfig`
+ * already emits them). De-duped — a capability row that also appears in the
+ * preserved set (a hand-pin) is not duplicated.
+ *
+ * PURE.
+ */
+export function mergeOfferAcceptSubjects(
+  priorAccept: readonly string[],
+  capabilityDispatchSubjects: readonly string[],
+  principal: string,
+  stack: string,
+): string[] {
+  const ownPrefix = ownDispatchPrefix(principal, stack);
+  // Preserve every prior row that the offer writer does NOT own (the OWN `.>`
+  // subtree, peer `.agent.>` presence rows, any hand-pin) — i.e. anything that
+  // is not one of THIS stack's own-identity `…tasks.*.>` dispatch rows.
+  const preserved = priorAccept.filter((s) => !s.startsWith(ownPrefix));
+
+  const seen = new Set<string>(preserved);
+  const out = [...preserved];
+  for (const subject of capabilityDispatchSubjects) {
+    if (seen.has(subject)) continue;
+    seen.add(subject);
+    out.push(subject);
+  }
+  return out;
+}
+
+/**
  * Compute the per-network federation-config projection from a stack's
  * offerings — the GENERATE half of DD-CO-2. PURE + total.
  *
@@ -864,9 +937,16 @@ export function reconcileLayer(
     policy.offerings = offerings.map((o) => structuredClone(o));
   }
 
-  // Federation projection — overwrite announce_capabilities + accept_subjects on
-  // each DECLARED network. We never create networks here (that's `cortex network
-  // join`); we only project onto networks the stack already declares.
+  // Federation projection — regenerate announce_capabilities + MERGE the
+  // capability-dispatch accept_subjects on each DECLARED network. We never create
+  // networks here (that's `cortex network join`); we only project onto networks
+  // the stack already declares. `announce_capabilities` is authoritative (the
+  // offer writer is the only writer of the per-network announce list, so an
+  // overwrite is correct); `accept_subjects` is SHARED with the presence-wiring
+  // writer (`network join` / reconciler, #1087/#1105), so we MERGE rather than
+  // overwrite — the offer writer owns only its own-identity `…tasks.{cap}.>`
+  // dispatch rows and must preserve the presence path's OWN `.>` ∪ peer `.agent.>`
+  // rows (cortex#1097). See `mergeOfferAcceptSubjects`.
   const federated = isPlainObject(policy.federated) ? structuredClone(policy.federated) : undefined;
   let dangling: string[];
   if (federated !== undefined && Array.isArray(federated.networks)) {
@@ -888,7 +968,17 @@ export function reconcileLayer(
       const proj = byId.get(id);
       if (proj === undefined) continue;
       network.announce_capabilities = [...proj.announce_capabilities];
-      network.accept_subjects = [...proj.accept_subjects];
+      const priorAccept = Array.isArray(network.accept_subjects)
+        ? (network.accept_subjects as unknown[]).filter(
+            (s): s is string => typeof s === "string",
+          )
+        : [];
+      network.accept_subjects = mergeOfferAcceptSubjects(
+        priorAccept,
+        proj.accept_subjects,
+        wirePrincipal,
+        wireStack,
+      );
     }
     federated.networks = networks;
     policy.federated = federated;


### PR DESCRIPTION
## Investigation finding (the scope decision the umbrella was waiting on)

**Offer-mode federation dispatch is purely RECEIVER-addressed.** It only ever legitimately RECEIVES subjects addressed TO this stack — `federated.{me}.{stack}.tasks.{capability}.>`. Traced end-to-end:

- `src/bus/probe-responder.ts:503` — *"Subscribe our OWN federated tasks subject (FG-2: subject addresses us)"* — `federated.{us}.{stack}.tasks.*.>`.
- `src/cortex.ts:1572` — the federated review consumer subscribes `federated.{ownPrincipal}.{stack}.tasks.code-review.>`.
- `src/bus/review-consumer.ts` (verdict path) — the verdict a provider emits routes to `federated.{requester}.{stack}.review.verdict.*` — an **OUTBOUND publish to the requester's subtree**, not an accept. A provider never *accept-lists* peer-sourced traffic to do its job.
- `src/bus/surface-router.ts:818` `evaluateFederationGate` — already resolves the SOURCE network from `envelope.source`'s principal via `peers[]`; `accept_subjects` is the second gate keyed on the inbound **subject**.

So the OWN-only capability rows (`federated.{me}.{stack}.tasks.{cap}.>`) that `projectFederationConfig` emits are **already the least-privilege accept-list for dispatch** — exactly as #1105 scoped presence to `.agent.>`, dispatch is correctly scoped to `…tasks.{cap}.>`. **Widening to a peer's `.>` (or to `deriveAcceptSubjects`' own ∪ peer union) would be WRONG**: offer.ts has no roster/peer input (it derives from `offerings[]`, not peers), and offer-mode has no business accepting peer-sourced presence.

### The actual bug #1097 is waiting on

`accept_subjects` has **TWO writers** sharing one array:

| Writer | Owns | Wrote |
|---|---|---|
| presence-wiring (`network join` / reconciler, via `deriveAcceptSubjects`, #1087/#1105) | OWN `.>` ∪ each roster peer's `.agent.>` presence subtree | source-addressed presence FROM peers |
| **offer-mode dispatch** (`reconcileLayer`) | `federated.{me}.{stack}.tasks.{cap}.>` | receiver-addressed dispatch TO me |

`reconcileLayer` **overwrote the whole array** (`network.accept_subjects = [...proj.accept_subjects]`). So `cortex offer <cap> --scope federated --apply` **silently clobbered the peer-presence subtrees** the presence path had written — regressing peer-presence admission (P2/#1105) at the gate. (No existing offer test had peers in the network, so the clobber path was untested.)

## The fix — least-privilege preserve-merge

`mergeOfferAcceptSubjects(prior, capabilityDispatchSubjects, principal, stack)`:

- The offer writer owns **ONLY** its own-identity `…tasks.*.>` dispatch rows — it regenerates exactly those (dropping a capability no longer offered) and **preserves every other row verbatim** (the OWN `.>` subtree + peer `.agent.>` presence subtrees + any hand-pin).
- Never invents a peer subtree (no roster available here), **never widens to `.>`** (§6 invariant: "must not open any interior subtree").
- `announce_capabilities` stays an authoritative overwrite — the offer writer is its only writer.

This honours the design §6 invariants and the dual-grammar: dispatch = receiver-addressed (own `…tasks.{cap}.>`), presence = source-addressed (peer `.agent.>`, owned by the other writer). No `signal` import. The #762 hand-pin behaviour is preserved (a hand-pinned non-`…tasks.` row survives; a hand-pinned own-`…tasks.` row is regenerated, de-duped).

## Tests (TDD, RED→GREEN)

- `mergeOfferAcceptSubjects` — pure: preserve presence rows + append caps; regenerate own `…tasks.` (drop stale); de-dup hand-pin; empty-caps keeps presence; a different principal's `…tasks.` row is preserved (identity-scoped prefix).
- `reconcileLayer` co-existence — adding a fed offering preserves OWN `.>` + peer `.agent.>`; never emits a peer's full `.>` (#1105); revoking the last offering drops the stale cap row but KEEPS presence rows; idempotent (no dup); greenfield (no prior list) still gets the cap row.

`bun test src/bus src/cli/cortex` → 1840 pass / 0 fail · `lint:errors` clean · `tsc --noEmit` clean · `check-carveouts.sh` PASS.

Refs: #1084 (umbrella) · #1087 (P2 `deriveAcceptSubjects`) · #1105 (presence-only `.agent.>` tightening).

Closes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)