### PR TITLE
fix(provision): extract only the seed line from nsc nkey output (cortex#1106)

### DIFF
--- a/scripts/__tests__/stack-identity-provision.sh
+++ b/scripts/__tests__/stack-identity-provision.sh
@@ -90,6 +90,10 @@ if [ -f "${SEED3}" ]; then
     else
       fail "generated seed does NOT parse via fromSeed — cortex#1106 regression"
     fi
+  else
+    # bun is a hard cortex dep, so this should not happen — make the degraded
+    # guard VISIBLE rather than silently skipping the strongest assertion.
+    printf '  ⓘ skip: bun not on PATH — fromSeed round-trip assertion not run\n'
   fi
 else
   fail "generate_nkey_seed produced no seed file (neither nsc nor bun available?)"

--- a/scripts/__tests__/stack-identity-provision.sh
+++ b/scripts/__tests__/stack-identity-provision.sh
@@ -63,5 +63,38 @@ after="$(cat "${TH2}/.config/nats/cortex-x-test.nk")"
 [ "${before}" = "${after}" ] && pass "declared path + existing seed → not regenerated (idempotent)" || fail "existing seed was clobbered"
 rm -rf "${TH2}"
 
+# ─── Case 3: generated seed is a SINGLE bare nkey, not nsc's multi-line dump (cortex#1106) ──
+# `nsc generate nkey -u` prints seed + pubkey + blank (3 lines); writing all of
+# them makes cortex's `fromSeed(content.trim())` fail ("invalid encoded key").
+# The seed must be one bare S-prefixed token that round-trips through fromSeed.
+TH3="$(mktemp -d)"
+mkdir -p "${TH3}/.config/nats"
+HOME="${TH3}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; generate_nkey_seed \"\${HOME}/.config/nats/seed.nk\"" \
+  >/dev/null 2>&1 || true
+SEED3="${TH3}/.config/nats/seed.nk"
+if [ -f "${SEED3}" ]; then
+  # Newline count: 0 (bare, no trailing) or 1 (trailing) for a valid single
+  # seed; nsc's unfixed 3-line dump yields 2 → this is the core regression guard.
+  nl="$(wc -l < "${SEED3}" | tr -d ' ')"
+  tok="$(tr -d '[:space:]' < "${SEED3}")"
+  if [ "${nl}" -le 1 ] && printf '%s' "${tok}" | grep -qE '^S[A-Z2-7]+$'; then
+    pass "generated seed is a single bare S-prefixed line, not nsc's 3-line dump (cortex#1106)"
+  else
+    fail "generated seed is multi-line / malformed (${nl} newline(s)) — cortex#1106 regression"
+  fi
+  # The exact parse cortex's stack-signing loader performs.
+  if command -v bun >/dev/null 2>&1; then
+    if bun -e "import {fromSeed} from 'nkeys.js'; import {readFileSync} from 'fs'; fromSeed(new TextEncoder().encode(readFileSync('${SEED3}','utf-8').trim())).getPublicKey();" >/dev/null 2>&1; then
+      pass "generated seed parses via nkeys.js fromSeed (cortex#1106)"
+    else
+      fail "generated seed does NOT parse via fromSeed — cortex#1106 regression"
+    fi
+  fi
+else
+  fail "generate_nkey_seed produced no seed file (neither nsc nor bun available?)"
+fi
+rm -rf "${TH3}"
+
 printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" -eq 0 ]

--- a/scripts/lib/stack-identity-provision.sh
+++ b/scripts/lib/stack-identity-provision.sh
@@ -117,8 +117,18 @@ generate_nkey_seed() {
     return 0
   fi
   mkdir -p "$(dirname "${seed_path}")"
-  # nsc generate nkey -u prints the seed on stdout.
-  "${nsc_path}" generate nkey -u > "${seed_path}" 2>/dev/null || return 1
+  # cortex#1106 — `nsc generate nkey -u` prints THREE lines: the seed (`SU…`),
+  # the public key (`U…`), and a trailing blank. Writing all three breaks the
+  # stack signing loader: cortex does `fromSeed(content.trim())`, and trim()
+  # cannot strip the INTERIOR pubkey line, so the file fails to parse
+  # ("nkeys: invalid encoded key") and the stack boots unsigned (seen on the
+  # dev-loop + tender stacks). Extract ONLY the seed line (the `S`-prefixed
+  # one) and write it bare (no trailing newline), matching the bun fallback
+  # above and the single-token format `derive_pubkey_from_seed` + cortex expect.
+  local nsc_seed
+  nsc_seed="$("${nsc_path}" generate nkey -u 2>/dev/null | awk '/^S/ { print; exit }')"
+  [ -n "${nsc_seed}" ] || return 1
+  printf '%s' "${nsc_seed}" > "${seed_path}" || return 1
   chmod 600 "${seed_path}" 2>/dev/null
   return 0
 }

--- a/scripts/lib/stack-identity-provision.sh
+++ b/scripts/lib/stack-identity-provision.sh
@@ -128,7 +128,10 @@ generate_nkey_seed() {
   local nsc_seed
   nsc_seed="$("${nsc_path}" generate nkey -u 2>/dev/null | awk '/^S/ { print; exit }')"
   [ -n "${nsc_seed}" ] || return 1
-  printf '%s' "${nsc_seed}" > "${seed_path}" || return 1
+  # umask 077 so the seed file is born 600 — no world-readable window between
+  # create and the chmod below (it IS signing-key material). chmod stays as
+  # belt-and-suspenders for an inherited-odd-umask environment.
+  ( umask 077; printf '%s' "${nsc_seed}" > "${seed_path}" ) || return 1
   chmod 600 "${seed_path}" 2>/dev/null
   return 0
 }


### PR DESCRIPTION
## Problem

`nsc generate nkey -u` prints **three lines** — the seed (`SU…`), the public key (`U…`), and a trailing blank. `generate_nkey_seed` (scripts/lib/stack-identity-provision.sh) wrote **all three** to the stack signing seed file. cortex's stack-signing loader does `fromSeed(content.trim())`, and `trim()` can't strip the *interior* pubkey line — so the file failed to parse (`nkeys: invalid encoded key`) and the stack booted **unsigned**.

Observed on `andreas/dev-loop` + `andreas/tender`: the generated `.nk` was **117 bytes** (3 lines) vs a valid bare seed's **58 bytes**.

The bun fallback (used when `nsc` is absent) was already correct — it writes just the 58-byte seed. Only the nsc path was broken.

## Fix

Extract **only** the `S`-prefixed seed line from nsc's output and write it bare (no trailing newline), matching the bun fallback and the working stacks' seeds:

```sh
nsc_seed="$("${nsc_path}" generate nkey -u 2>/dev/null | awk '/^S/ { print; exit }')"
[ -n "${nsc_seed}" ] || return 1
printf '%s' "${nsc_seed}" > "${seed_path}" || return 1
```

Bonus: `derive_pubkey_from_seed` now succeeds on the single-token file, so the provisioner can also pin `nkey_pub` automatically.

## Tests

New `scripts/__tests__/stack-identity-provision.sh` cases (#1106): the generated seed is a **single bare `S`-prefixed line** (not nsc's 3-line dump) and **round-trips through `nkeys.js` `fromSeed`** (the exact parse cortex's loader performs). 5/5 pass locally — where `nsc` is present, so this exercises the fixed nsc path.

> ⚠️ **Follow-up (needs `workflow` scope):** these bash suites under `scripts/__tests__/` aren't run in CI — `bun test` only discovers `*.test.ts`, so the #1101 + #1106 guards are inert in CI. A `shell-tests` CI job is ready but the OAuth push token lacks `workflow` scope; will apply separately.

Refs the dev-loop make-it-live work (#887/#925). Closes #1106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)