### PR TITLE
fix(federation): federated presence sovereignty crosses the frontier (#1110)

### DIFF
--- a/src/bus/agent-network/__tests__/builders.test.ts
+++ b/src/bus/agent-network/__tests__/builders.test.ts
@@ -21,6 +21,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { evaluateSovereignty } from "../../sovereignty-gate";
 import {
   validateEnvelope,
   deriveNatsSubject,
@@ -131,6 +132,51 @@ describe("createAgentHeartbeatEvent (presence, not dispatch)", () => {
     expect(env.correlation_id).toBeUndefined();
     expect(validateEnvelope(env).ok).toBe(true);
     AGENT_PRESENCE_PAYLOAD_SCHEMAS[AGENT_HEARTBEAT_TYPE].parse(env.payload);
+  });
+});
+
+describe("#1110 — federated presence sovereignty CROSSES the frontier", () => {
+  test("classification:federated → frontier_ok:true, max_hop:1, model_class:'frontier'", () => {
+    const env = createAgentHeartbeatEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      sentAt: SENT_AT,
+      classification: "federated",
+    });
+    expect(env.sovereignty).toEqual({
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 1,
+      frontier_ok: true,
+      model_class: "frontier",
+    });
+  });
+
+  test("the federated copy PASSES the sovereignty gate (it would never cross before #1110)", () => {
+    const federated = createAgentHeartbeatEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      sentAt: SENT_AT,
+      classification: "federated",
+    });
+    // The gate (sovereignty-gate.ts) holds an envelope local when
+    // model_class==="local-only" OR frontier_ok!==true. The federated copy clears
+    // both → admitted to cross. agentClass undefined is fine (no local demand).
+    expect(evaluateSovereignty(federated.sovereignty, undefined).decision).toBe("allow");
+  });
+
+  test("the LOCAL copy still demands local — does NOT cross (the contrast / no regression)", () => {
+    const local = createAgentHeartbeatEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      sentAt: SENT_AT,
+    });
+    expect(local.sovereignty).toMatchObject({ frontier_ok: false, model_class: "local-only", max_hop: 0 });
+    // local-only + no agent class proof → fail closed (held local).
+    expect(evaluateSovereignty(local.sovereignty, undefined).decision).toBe("deny");
   });
 });
 

--- a/src/bus/agent-network/builders.ts
+++ b/src/bus/agent-network/builders.ts
@@ -104,12 +104,26 @@ function defaultPresenceSovereignty(
   source: AgentPresenceSource,
   classification: Classification = "local",
 ): Envelope["sovereignty"] {
+  // #1110 — a FEDERATED presence copy (G-1114.E) must be cleared to CROSS the
+  // frontier. The pre-#1110 code hardcoded `frontier_ok:false / max_hop:0 /
+  // model_class:"local-only"` regardless of `classification`, so `sovereignty-
+  // gate.ts` (`demandsLocal = model_class==="local-only" || frontier_ok!==true`)
+  // held even a `classification:"federated"` envelope local — a federated-scope/
+  // local-only-sovereignty contradiction, so federated presence NEVER crossed
+  // the leaf. Presence is metadata only (identity + capabilities, never session
+  // interiors — ADR-0005), and CONTEXT.md is explicit that cross-principal
+  // presence metadata IS visible + `federated.` always crosses — so the federated
+  // copy is cleared for the frontier; the LOCAL copy stays principal-private.
+  const federated = classification === "federated";
   return {
     classification,
     data_residency: source.dataResidency ?? "NZ",
-    max_hop: 0,
-    frontier_ok: false,
-    model_class: "local-only",
+    // Single direct hop — matches the direct-peer topology (the metafactory
+    // network's `max_hop: 1`). Deriving max_hop from per-network config is a
+    // follow-up if multi-hop presence federation is ever needed.
+    max_hop: federated ? 1 : 0,
+    frontier_ok: federated,
+    model_class: federated ? "frontier" : "local-only",
   };
 }
 


### PR DESCRIPTION
**SOP: federation-wire-protocol | touches: emit | checklist: 5/5 PASS (grammar conformant — fix is the sovereignty metadata layer, no grammar change)**

Closes #1110.

## Bug
`defaultPresenceSovereignty` (builders.ts) hardcoded `max_hop:0 / frontier_ok:false / model_class:"local-only"` regardless of `classification`. So the federate dual-emit (G-1114.E.1) produced a `classification:"federated"`, `federated.`-scoped envelope carrying **local-only sovereignty** — and `sovereignty-gate.ts:80` (`demandsLocal = model_class==="local-only" || frontier_ok!==true`) held it local. **Federated presence has never crossed the leaf** (observed `in=0 out=0` on an established link while bringing up #1084 E2E). The whole roster-driven federation receive-side was correct but starved.

## Fix
`classification==="federated"` → `frontier_ok:true`, `model_class:"frontier"` (least-privilege federatable, not `"any"`), `max_hop:1` (direct-peer topology; matches the metafactory network's `max_hop:1`). LOCAL copy unchanged. One shared helper → covers all four presence builders.

## Grounding
- CONTEXT.md: *"federation is the default… `federated.` always crosses"*; cross-principal presence **metadata** is visible (interiors never — ADR-0005/0007). So the federated copy SHOULD cross — this aligns the sovereignty with the scope it already declares, not a new grant.
- Wire-protocol checklist: **5/5 PASS on grammar** (no network on wire; source-addressed broadcast subject; `federated.` scope). The defect was strictly the myelin `sovereignty` metadata.

## Tests
Federated presence sovereignty round-trips **PASS** through `evaluateSovereignty`; local still demand-local (deny). 187 agent-network + sovereignty tests green; lint/tsc/vocab clean.

## Sibling (NOT in this PR — bigger trust step)
`defaultDispatchSovereignty` (dispatch-events.ts) has the **identical** hardcoded-local bug → federated *dispatch* also never crosses. Filing separately: enabling federated dispatch crossing lets peers trigger work cross-principal — a larger trust decision than presence (read-only metadata).