### PR TITLE
feat(registry): O-4a.2 — record + serve granted leaf package (PoP peer read); register handles PENDING

### DIFF
--- a/src/__tests__/o4a2-provision-stack-pending.test.ts
+++ b/src/__tests__/o4a2-provision-stack-pending.test.ts
@@ -1,0 +1,130 @@
+/**
+ * O-4a.2 — provision-stack register handles PENDING gracefully.
+ *
+ * After a successful registration (2xx), the issuance request is PENDING.
+ * The CLI must not exit with an error; it must surface a clear message
+ * telling the principal that the credential is awaiting admin grant.
+ *
+ * Test strategy:
+ *   1. Generate a temp NKey seed via `dispatchProvisionStack generate`.
+ *   2. Call `dispatchProvisionStack register` with a mock fetch that returns
+ *      HTTP 201 with a minimal signed-assertion body.
+ *   3. Assert exit code 0 and stdout contains the PENDING message.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { unlinkSync, existsSync } from "fs";
+import { dispatchProvisionStack } from "../cli/cortex/commands/provision-stack";
+
+const MOCK_PRINCIPAL_RECORD = {
+  payload: {
+    principal_id: "testprincipal",
+    stacks: [],
+    capabilities: [],
+    updated_at: new Date().toISOString(),
+  },
+  issued_at: new Date().toISOString(),
+  registry: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+  signature: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+};
+
+describe("provision-stack register — PENDING note (O-4a.2)", () => {
+  test("successful register outputs 'awaiting admin grant' message and exits 0", async () => {
+    const tmpSeedPath = `/tmp/o4a2-pending-test-seed-${Date.now().toString()}.nk`;
+    let capturedUrl = "";
+
+    try {
+      // Step 1: generate a fresh seed.
+      const genResult = await dispatchProvisionStack([
+        "generate",
+        "testprincipal",
+        "--seed-path",
+        tmpSeedPath,
+      ]);
+      expect(genResult.exitCode).toBe(0);
+      expect(existsSync(tmpSeedPath)).toBe(true);
+
+      // Step 2: register with a mock fetch returning 201.
+      // Cast to globalThis.fetch type: the Bun type requires `preconnect` on the
+      // function object, which a plain async arrow doesn't have. The cast is safe
+      // here — the mock only exercises the fetch(url, init) call path.
+      const mockFetch = (async (input: URL | RequestInfo, _init?: RequestInit | BunFetchRequestInit) => {
+        capturedUrl = typeof input === "string" ? input : (input as Request).url;
+        return new Response(JSON.stringify(MOCK_PRINCIPAL_RECORD), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        });
+      }) as unknown as typeof globalThis.fetch;
+
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch;
+      try {
+        const regResult = await dispatchProvisionStack([
+          "register",
+          "testprincipal",
+          "--seed-path",
+          tmpSeedPath,
+          "--registry-url",
+          "https://registry.test",
+        ]);
+
+        // Step 3: assert PENDING note + clean exit.
+        expect(regResult.exitCode).toBe(0);
+        expect(regResult.stdout).toContain("awaiting admin grant");
+        expect(regResult.stderr).toBe("");
+        expect(capturedUrl).toContain("testprincipal");
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    } finally {
+      if (existsSync(tmpSeedPath)) {
+        unlinkSync(tmpSeedPath);
+      }
+    }
+  });
+
+  test("failed register (4xx) still exits with error code 1", async () => {
+    const tmpSeedPath = `/tmp/o4a2-pending-test-seed-fail-${Date.now().toString()}.nk`;
+    try {
+      const genResult = await dispatchProvisionStack([
+        "generate",
+        "testprincipal",
+        "--seed-path",
+        tmpSeedPath,
+      ]);
+      expect(genResult.exitCode).toBe(0);
+
+      const mockFetch = (async (_input: URL | RequestInfo, _init?: RequestInit | BunFetchRequestInit) => {
+        return new Response(
+          JSON.stringify({ error: "admin_not_configured" }),
+          {
+            status: 503,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }) as unknown as typeof globalThis.fetch;
+
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch;
+      try {
+        const regResult = await dispatchProvisionStack([
+          "register",
+          "testprincipal",
+          "--seed-path",
+          tmpSeedPath,
+          "--registry-url",
+          "https://registry.test",
+        ]);
+        // A 503 (ok:false) is a real failure — must exit 1.
+        expect(regResult.exitCode).toBe(1);
+        expect(regResult.stderr).toContain("503");
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    } finally {
+      if (existsSync(tmpSeedPath)) {
+        unlinkSync(tmpSeedPath);
+      }
+    }
+  });
+});

--- a/src/__tests__/o4b-grammar-mirror.test.ts
+++ b/src/__tests__/o4b-grammar-mirror.test.ts
@@ -1,0 +1,123 @@
+/**
+ * O-4a.2 / O-4b grammar anti-drift test.
+ *
+ * The registry package (`src/services/network-registry`) mirrors two regex
+ * predicates from `src/common/nats/leaf-remote-renderer.ts` so it can
+ * validate leaf packages without a cross-package import:
+ *
+ *   isNkeyAccountPubkeyRegistry  ↔  isNkeyAccountPubkey
+ *     (NATS nkey-U account pubkey grammar: /^A[A-Z2-7]{55}$/)
+ *
+ *   isNscJwtShapeRegistry  ↔  isNscJwtShape
+ *     (NSC JWT shape: /^eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2}$/)
+ *
+ * This test imports BOTH sides and asserts identical results for a shared
+ * set of known-good and known-bad vectors. A regex change in either module
+ * that isn't reflected in the other will break this test before it causes
+ * a silent validation mismatch in production.
+ *
+ * Test vectors are the SAME as in:
+ *   src/services/network-registry/__tests__/o4a2-package.test.ts
+ */
+
+import { describe, test, expect } from "bun:test";
+// O-4b canonical source (leaf-remote-renderer.ts) — the reference grammar.
+import { isNkeyAccountPubkey, isNscJwtShape } from "../common/nats/leaf-remote-renderer";
+// Registry mirror — must produce identical results for every vector.
+import {
+  isNkeyAccountPubkeyRegistry,
+  isNscJwtShapeRegistry,
+} from "../services/network-registry/src/validate";
+
+// =============================================================================
+// Shared test vectors (same set as o4a2-package.test.ts)
+// =============================================================================
+
+const NKEY_VECTORS: { label: string; value: string; expected: boolean }[] = [
+  {
+    // A prefix + 55 base32 chars = 56 total — matches /^A[A-Z2-7]{55}$/
+    label: "known-good nkey-U (56 chars, A prefix, base32)",
+    value: "AABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
+    expected: true,
+  },
+  {
+    label: "too short (6 chars)",
+    value: "ABCDEF",
+    expected: false,
+  },
+  {
+    label: "wrong prefix (starts with B)",
+    value: "BABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
+    expected: false,
+  },
+  {
+    label: "lowercase (invalid base32 for nkey)",
+    value: "aabcdefghijklmnopqrstuvwxyz234567abcdefghijklmnopqrstuvw",
+    expected: false,
+  },
+  {
+    label: "empty string",
+    value: "",
+    expected: false,
+  },
+  {
+    label: "too long (57 chars)",
+    value: "AABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX",
+    expected: false,
+  },
+];
+
+const JWT_VECTORS: { label: string; value: string; expected: boolean }[] = [
+  {
+    label: "known-good 3-segment base64url JWT starting with eyJ",
+    value: "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJhY2NvdW50In0.c2lnbmF0dXJl",
+    expected: true,
+  },
+  {
+    label: "only one segment (no dots)",
+    value: "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ",
+    expected: false,
+  },
+  {
+    label: "too many segments (4 parts)",
+    value: "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJhY2NvdW50In0.c2lnbmF0dXJl.extra",
+    expected: false,
+  },
+  {
+    label: "does not start with eyJ",
+    value: "BAAAAD.eyJzdWIiOiJhY2NvdW50In0.c2lnbmF0dXJl",
+    expected: false,
+  },
+  {
+    label: "empty string",
+    value: "",
+    expected: false,
+  },
+  {
+    label: "plain ASCII text (not a JWT)",
+    value: "not-a-jwt",
+    expected: false,
+  },
+];
+
+// =============================================================================
+// Cross-module anti-drift assertions
+// =============================================================================
+
+describe("isNkeyAccountPubkey ↔ isNkeyAccountPubkeyRegistry — grammar anti-drift", () => {
+  for (const { label, value, expected } of NKEY_VECTORS) {
+    test(`${label} → ${expected.toString()}`, () => {
+      expect(isNkeyAccountPubkey(value)).toBe(expected);
+      expect(isNkeyAccountPubkeyRegistry(value)).toBe(expected);
+    });
+  }
+});
+
+describe("isNscJwtShape ↔ isNscJwtShapeRegistry — grammar anti-drift", () => {
+  for (const { label, value, expected } of JWT_VECTORS) {
+    test(`${label} → ${expected.toString()}`, () => {
+      expect(isNscJwtShape(value)).toBe(expected);
+      expect(isNscJwtShapeRegistry(value)).toBe(expected);
+    });
+  }
+});

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -446,7 +446,14 @@ async function doRegister(
       reason: `registry rejected registration (HTTP ${result.status.toString()}): ${detail}`,
     };
   }
-  return { ok: true, note: `registered pubkey ${material.fingerprint}… at ${registryUrl} (HTTP ${result.status.toString()})` };
+  // O-4a.2 — a successful registration (2xx) triggers an issuance request that
+  // starts PENDING. The leaf credential package is issued only after an admin
+  // grants the request. Always surface this so the principal knows to expect
+  // the admin-grant step before the stack can join the federation.
+  return {
+    ok: true,
+    note: `registration recorded; awaiting admin grant — your credential will be issued on approval (HTTP ${result.status.toString()}, registry: ${registryUrl})`,
+  };
 }
 
 // =============================================================================

--- a/src/services/network-registry/__tests__/d1-mock.ts
+++ b/src/services/network-registry/__tests__/d1-mock.ts
@@ -226,13 +226,27 @@ export class MockD1 {
     }
 
     // issuance_requests: UPDATE (transitionIssuanceRequest — CAS on status='PENDING')
+    // O-4a.2: args are [newStatus, grantedBy, updatedAt, leafPackageJson, requestId]
+    // (leaf_package added in O-4a.2 — the 4th bind value is the package JSON or null)
     if (sql.startsWith("UPDATE issuance_requests SET status")) {
-      const [newStatus, grantedBy, updatedAt, requestId] = args as [string, string, string, string];
+      const [newStatus, grantedBy, updatedAt, leafPackageJson, requestId] = args as [
+        string,
+        string,
+        string,
+        string | null,
+        string,
+      ];
       const existing = this.issuanceRequests.get(requestId);
       if (!existing || existing.status !== "PENDING") {
         return { meta: { changes: 0 } };
       }
-      const updated: IssuanceRequestRow = { ...existing, status: newStatus, granted_by: grantedBy, updated_at: updatedAt };
+      const updated: IssuanceRequestRow = {
+        ...existing,
+        status: newStatus,
+        granted_by: grantedBy,
+        updated_at: updatedAt,
+        leaf_package: leafPackageJson,
+      };
       this.issuanceRequests.set(requestId, updated);
       return { meta: { changes: 1 } };
     }

--- a/src/services/network-registry/__tests__/o4a2-package.test.ts
+++ b/src/services/network-registry/__tests__/o4a2-package.test.ts
@@ -138,13 +138,24 @@ async function get(
   return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
 }
 
-/** Build a peer PoP header for the given peer key. */
+/**
+ * Build a peer PoP header for the given peer key.
+ *
+ * N2 — `requestId` is now required: the signed claim includes `request_id`
+ * so the token is bound to a specific issuance request and cannot be replayed
+ * against a different request for the same peer key.
+ *
+ * `opts.requestIdOverride` lets tests sign a claim with a DIFFERENT request_id
+ * than the path to exercise the mismatch rejection.
+ */
 async function makePeerPoP(
   peerKey: PrincipalKey,
-  opts: { issuedAt?: string; signWith?: PrincipalKey } = {},
+  requestId: string,
+  opts: { issuedAt?: string; signWith?: PrincipalKey; requestIdOverride?: string } = {},
 ): Promise<string> {
   const claim: IssuancePackageReadClaim = {
     peer_pubkey: peerKey.publicKeyB64,
+    request_id: opts.requestIdOverride ?? requestId,
     issued_at: opts.issuedAt ?? new Date().toISOString(),
   };
   const message = new TextEncoder().encode(canonicalJSON(claim));
@@ -499,7 +510,7 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
     expect(grantRes.status).toBe(200);
 
     // Peer fetches their package.
-    const peerHeader = await makePeerPoP(principal);
+    const peerHeader = await makePeerPoP(principal, req.request_id);
     const res = await get(
       `/issuance-requests/${req.request_id}/package`,
       env,
@@ -516,7 +527,7 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
     const req = await registerAndGetRequest("pop-bob");
     // Do NOT grant.
 
-    const peerHeader = await makePeerPoP(principal);
+    const peerHeader = await makePeerPoP(principal, req.request_id);
     const res = await get(
       `/issuance-requests/${req.request_id}/package`,
       env,
@@ -533,7 +544,7 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
     const decision = await makeSignedAdminDecision(req.request_id, "reject", admin);
     await post(`/issuance-requests/${req.request_id}/reject`, decision);
 
-    const peerHeader = await makePeerPoP(principal);
+    const peerHeader = await makePeerPoP(principal, req.request_id);
     const res = await get(
       `/issuance-requests/${req.request_id}/package`,
       env,
@@ -552,7 +563,7 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
 
     // A different peer key signs the PoP.
     const otherKey = await makePrincipalKey();
-    const peerHeader = await makePeerPoP(otherKey);
+    const peerHeader = await makePeerPoP(otherKey, req.request_id);
     const res = await get(
       `/issuance-requests/${req.request_id}/package`,
       env,
@@ -571,7 +582,7 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
 
     // Build a PoP that claims principal.publicKeyB64 but is signed by another key.
     const otherKey = await makePrincipalKey();
-    const peerHeader = await makePeerPoP(principal, { signWith: otherKey });
+    const peerHeader = await makePeerPoP(principal, req.request_id, { signWith: otherKey });
     const res = await get(
       `/issuance-requests/${req.request_id}/package`,
       env,
@@ -582,9 +593,10 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
   });
 
   test("peer request on nonexistent request_id → 404 not_found", async () => {
-    const peerHeader = await makePeerPoP(principal);
+    const knownId = "0000000000000000000000000000cafe";
+    const peerHeader = await makePeerPoP(principal, knownId);
     const res = await get(
-      "/issuance-requests/0000000000000000000000000000cafe/package",
+      `/issuance-requests/${knownId}/package`,
       env,
       { "x-peer-signed": peerHeader },
     );
@@ -599,7 +611,7 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
     const decision = await makeSignedAdminDecision(req.request_id, "grant", admin);
     await post(`/issuance-requests/${req.request_id}/grant`, decision);
 
-    const peerHeader = await makePeerPoP(principal);
+    const peerHeader = await makePeerPoP(principal, req.request_id);
     const res = await get(
       `/issuance-requests/${req.request_id}/package`,
       env,
@@ -622,7 +634,10 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
   });
 
   test("invalid request_id on /package route → 400 invalid_request_id", async () => {
-    const peerHeader = await makePeerPoP(principal);
+    // For an invalid path param we use a placeholder known-good id in the claim
+    // (the path validation fires before the claim is parsed, so the claim
+    // request_id value doesn't matter here — the path param is rejected first).
+    const peerHeader = await makePeerPoP(principal, "0000000000000000000000000000cafe");
     const res = await get(
       "/issuance-requests/not-valid-hex/package",
       env,
@@ -640,7 +655,7 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
 
     // PoP with a stale issued_at (30 min ago > 5 min skew window).
     const staleAt = new Date(Date.now() - 30 * 60 * 1000).toISOString();
-    const peerHeader = await makePeerPoP(principal, { issuedAt: staleAt });
+    const peerHeader = await makePeerPoP(principal, req.request_id, { issuedAt: staleAt });
     const res = await get(
       `/issuance-requests/${req.request_id}/package`,
       env,
@@ -659,7 +674,7 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
     await post(`/issuance-requests/${req.request_id}/grant`, decision);
 
     // Admin tries to fetch using admin key as peer — wrong_key since admin ≠ registered peer.
-    const adminPoP = await makePeerPoP(admin);
+    const adminPoP = await makePeerPoP(admin, req.request_id);
     const res = await get(
       `/issuance-requests/${req.request_id}/package`,
       env,
@@ -667,6 +682,89 @@ describe("GET /issuance-requests/:id/package — peer PoP", () => {
     );
     expect(res.status).toBe(403);
     expect(((await res.json()) as { error: string }).error).toBe("wrong_key");
+  });
+
+  // ===========================================================================
+  // M1 — rate-limit: flood of peer GETs trips 429
+  // ===========================================================================
+
+  test("M1 — flood of peer GET /package trips 429 (rate-limit shed)", async () => {
+    const req = await registerAndGetRequest("pop-rate-limit");
+
+    // Grant with package so the request is GRANTED.
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, VALID_PACKAGE);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    // The "read" bucket allows 120 / 60s. Exhaust it with a batch of requests
+    // (each signed with a fresh key so they don't short-circuit on ownership).
+    // We send 121 to guarantee we cross the threshold; the in-memory fallback
+    // will reject the 121st.
+    let tripped = false;
+    for (let i = 0; i <= 120; i++) {
+      const peerHeader = await makePeerPoP(principal, req.request_id);
+      const res = await get(
+        `/issuance-requests/${req.request_id}/package`,
+        env,
+        { "x-peer-signed": peerHeader },
+      );
+      if (res.status === 429) {
+        tripped = true;
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe("rate_limited");
+        break;
+      }
+    }
+    expect(tripped).toBe(true);
+  });
+
+  // ===========================================================================
+  // N2 — request_id binding: token signed for request A rejected at request B
+  // ===========================================================================
+
+  test("N2 — claim.request_id missing from envelope → 400 validation_failed", async () => {
+    // Build a raw header WITHOUT request_id in the claim (old pre-N2 shape).
+    const claim = {
+      peer_pubkey: principal.publicKeyB64,
+      // request_id deliberately omitted
+      issued_at: new Date().toISOString(),
+    };
+    const message = new TextEncoder().encode(canonicalJSON(claim));
+    const signature = await signEd25519(principal.privateKeyB64, message);
+    const header = JSON.stringify({ claim, signature });
+
+    const req = await registerAndGetRequest("n2-missing");
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": header },
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("x-peer-signed validation_failed");
+  });
+
+  test("N2 — claim signed for request A is rejected at request B → 401 request_id_mismatch", async () => {
+    // Register two separate principals so we get two distinct issuance requests.
+    const reqA = await registerAndGetRequest("n2-request-a");
+    const reqB = await registerAndGetRequest("n2-request-b");
+
+    // Grant request B so it reaches the package-serve logic.
+    const decisionB = await makeSignedAdminDecisionWithPackage(reqB.request_id, admin, VALID_PACKAGE);
+    await post(`/issuance-requests/${reqB.request_id}/grant`, decisionB);
+
+    // Build a PoP signed for request A (requestIdOverride = reqA.request_id),
+    // then present it at request B's endpoint.
+    const peerHeader = await makePeerPoP(principal, reqB.request_id, {
+      requestIdOverride: reqA.request_id,
+    });
+    const res = await get(
+      `/issuance-requests/${reqB.request_id}/package`,
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("request_id_mismatch");
   });
 });
 

--- a/src/services/network-registry/__tests__/o4a2-package.test.ts
+++ b/src/services/network-registry/__tests__/o4a2-package.test.ts
@@ -319,7 +319,7 @@ describe("validateGrantLeafPackage", () => {
   });
 
   test("field containing 'seed' → rejected", () => {
-    const pkg = { ...VALID_PACKAGE, operatorSeed: "SOABCDEF" };
+    const pkg = { ...VALID_PACKAGE, accountSeed: "SOABCDEF" };
     const result = validateGrantLeafPackage(pkg);
     expect(result.ok).toBe(false);
   });

--- a/src/services/network-registry/__tests__/o4a2-package.test.ts
+++ b/src/services/network-registry/__tests__/o4a2-package.test.ts
@@ -1,0 +1,675 @@
+/**
+ * O-4a.2 — Leaf package record + serve (PoP peer read) tests.
+ *
+ * Coverage:
+ *
+ * Grammar anti-drift vectors (O-4b mirror check):
+ *   - isNkeyAccountPubkeyRegistry / isNscJwtShapeRegistry use the same
+ *     grammar as O-4b's isNkeyAccountPubkey / isNscJwtShape. This test
+ *     asserts known-good and known-bad vectors against BOTH sides of the
+ *     mirror so a future regex change in either module trips a test failure
+ *     before it causes a silent mismatch.
+ *
+ * validateGrantLeafPackage:
+ *   - valid minimal package (no SYS account)
+ *   - valid package with SYS account
+ *   - valid package with endpoint
+ *   - rejects credsPath (secret field)
+ *   - rejects any field containing "seed" / "secret" / "private"
+ *   - rejects malformed operatorJwt
+ *   - rejects malformed account (not nkey-U)
+ *   - rejects malformed accountJwt
+ *   - rejects half-specified SYS account (systemAccount without systemAccountJwt)
+ *   - rejects half-specified SYS account (systemAccountJwt without systemAccount)
+ *
+ * Grant with package (admin path):
+ *   - POST /issuance-requests/:id/grant with leaf_package stores package
+ *   - returned request carries leaf_package JSON
+ *   - grant without package still works (leaf_package remains null)
+ *   - grant with credsPath in package → 400 validation_failed
+ *   - grant with malformed account → 400 validation_failed
+ *   - existing O-4a.1 grant tests are NOT broken (additive)
+ *
+ * Peer PoP package fetch (GET /issuance-requests/:id/package):
+ *   - peer with correct key fetches package from GRANTED request → 200
+ *   - peer request on PENDING request → 409 not_granted
+ *   - peer request on REJECTED request → 409 not_granted
+ *   - peer request with wrong key → 403 wrong_key
+ *   - peer request with forged signature → 401 signature_invalid
+ *   - peer request on nonexistent request_id → 404 not_found
+ *   - peer request on GRANTED request with no package → 404 package_not_ready
+ *   - missing x-peer-signed header → 400
+ *   - admin pubkey CANNOT fetch via peer PoP route (wrong_key unless it matches)
+ *   - invalid request_id path param → 400 invalid_request_id
+ *
+ * Client: provision-stack register PENDING note:
+ *   - doRegister always returns PENDING note on 2xx
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  makeSignedAdminDecision,
+  makeSignedAdminRead,
+  randomNonce,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import type { IssuanceRequest, GrantLeafPackage, IssuancePackageReadClaim } from "../src/types";
+import {
+  validateGrantLeafPackage,
+  isNkeyAccountPubkeyRegistry,
+  isNscJwtShapeRegistry,
+} from "../src/validate";
+
+// =============================================================================
+// Known test vectors for the anti-drift check.
+//
+// These strings are tested against the registry-local predicates
+// (isNkeyAccountPubkeyRegistry / isNscJwtShapeRegistry) which mirror the
+// O-4b predicates (isNkeyAccountPubkey / isNscJwtShape) from
+// `src/common/nats/leaf-remote-renderer.ts`.
+//
+// The companion test `src/__tests__/o4b-grammar-mirror.test.ts` (root-level)
+// imports BOTH the registry validators AND the O-4b validators and asserts
+// identical results for these vectors — that cross-module check catches any
+// future regex drift between the two independent implementations.
+//
+// If O-4b's grammar ever changes, update BOTH the regexes in validate.ts and
+// these vectors, then verify the root-level companion test still passes.
+// =============================================================================
+
+/**
+ * A NATS nkey-U account pubkey that MUST pass both validators.
+ * Grammar: /^A[A-Z2-7]{55}$/ — A prefix + 55 base32 chars = 56 total.
+ */
+const KNOWN_GOOD_NKEY = "AABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+
+/** A string that MUST fail both validators (too short, wrong format). */
+const KNOWN_BAD_NKEY_SHORT = "ABCDEF";
+
+/** A string that MUST fail both validators (starts with B, not A). */
+const KNOWN_BAD_NKEY_WRONG_PREFIX = "BABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+
+/** A lowercase nkey string that MUST fail both validators. */
+const KNOWN_BAD_NKEY_LOWERCASE = "aabcdefghijklmnopqrstuvwxyz234567abcdefghijklmnopqrstuvw";
+
+/** A minimally valid NSC JWT shape. */
+const KNOWN_GOOD_JWT = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJhY2NvdW50In0.c2lnbmF0dXJl";
+
+/** Not a JWT (no dots). */
+const KNOWN_BAD_JWT_NO_DOTS = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ";
+
+/** Too many segments (4 parts). */
+const KNOWN_BAD_JWT_TOO_MANY = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJhY2NvdW50In0.c2lnbmF0dXJl.extra";
+
+/** Does not start with eyJ. */
+const KNOWN_BAD_JWT_WRONG_START = "BAAAAD.eyJzdWIiOiJhY2NvdW50In0.c2lnbmF0dXJl";
+
+// =============================================================================
+// Test scaffold
+// =============================================================================
+
+let env: Env;
+let admin: PrincipalKey;
+let principal: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(
+  path: string,
+  e: Env = env,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+/** Build a peer PoP header for the given peer key. */
+async function makePeerPoP(
+  peerKey: PrincipalKey,
+  opts: { issuedAt?: string; signWith?: PrincipalKey } = {},
+): Promise<string> {
+  const claim: IssuancePackageReadClaim = {
+    peer_pubkey: peerKey.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signer = opts.signWith ?? peerKey;
+  const signature = await signEd25519(signer.privateKeyB64, message);
+  return JSON.stringify({ claim, signature });
+}
+
+/** Register a principal and return the issuance request created. */
+async function registerAndGetRequest(principalId: string): Promise<IssuanceRequest> {
+  const body = await makeSignedRegistration(principalId, principal, {
+    stacks: [{ stack_id: `${principalId}/main`, stack_pubkey: principal.publicKeyB64 }],
+  });
+  const res = await post(`/principals/${principalId}/register`, body);
+  expect(res.status).toBe(201);
+
+  const signedRead = await makeSignedAdminRead(admin);
+  const listRes = await get(
+    `/issuance-requests?status=PENDING`,
+    env,
+    { "x-admin-signed": JSON.stringify(signedRead) },
+  );
+  expect(listRes.status).toBe(200);
+  const list = (await listRes.json()) as IssuanceRequest[];
+  const found = list.find((r) => r.principal_id === principalId);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+/** A valid minimal GrantLeafPackage. */
+const VALID_PACKAGE: GrantLeafPackage = {
+  operatorJwt: KNOWN_GOOD_JWT,
+  account: KNOWN_GOOD_NKEY,
+  accountJwt: KNOWN_GOOD_JWT,
+};
+
+/** Build a grant decision body WITH a leaf_package. */
+async function makeSignedAdminDecisionWithPackage(
+  requestId: string,
+  adminKey: PrincipalKey,
+  leafPackage: GrantLeafPackage,
+  opts: { issuedAt?: string; nonce?: string } = {},
+): Promise<{ claim: Record<string, unknown>; signature: string }> {
+  const claim: Record<string, unknown> = {
+    request_id: requestId,
+    decision: "grant",
+    admin_pubkey: adminKey.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+    leaf_package: leafPackage,
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signature = await signEd25519(adminKey.privateKeyB64, message);
+  return { claim, signature };
+}
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  principal = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// Registry-local grammar validators (O-4b mirror)
+//
+// The registry is a SEPARATE package from the main cortex tree and cannot
+// import `leaf-remote-renderer.ts`. These tests verify the mirrored regexes
+// against the same vectors the O-4b companion test
+// (src/__tests__/o4b-grammar-mirror.test.ts) also uses. If the vectors ever
+// diverge between here and the companion file, the drift is detectable.
+// =============================================================================
+
+describe("isNkeyAccountPubkeyRegistry (mirrors O-4b /^A[A-Z2-7]{55}$/)", () => {
+  test("known-good nkey passes", () => {
+    expect(isNkeyAccountPubkeyRegistry(KNOWN_GOOD_NKEY)).toBe(true);
+  });
+
+  test("too-short nkey fails", () => {
+    expect(isNkeyAccountPubkeyRegistry(KNOWN_BAD_NKEY_SHORT)).toBe(false);
+  });
+
+  test("wrong-prefix nkey (starts with B) fails", () => {
+    expect(isNkeyAccountPubkeyRegistry(KNOWN_BAD_NKEY_WRONG_PREFIX)).toBe(false);
+  });
+
+  test("lowercase nkey fails", () => {
+    expect(isNkeyAccountPubkeyRegistry(KNOWN_BAD_NKEY_LOWERCASE)).toBe(false);
+  });
+
+  test("empty string fails", () => {
+    expect(isNkeyAccountPubkeyRegistry("")).toBe(false);
+  });
+});
+
+describe("isNscJwtShapeRegistry (mirrors O-4b /^eyJ[A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+){2}$/)", () => {
+  test("known-good JWT passes", () => {
+    expect(isNscJwtShapeRegistry(KNOWN_GOOD_JWT)).toBe(true);
+  });
+
+  test("no-dots JWT (only one segment) fails", () => {
+    expect(isNscJwtShapeRegistry(KNOWN_BAD_JWT_NO_DOTS)).toBe(false);
+  });
+
+  test("too-many-segments JWT (4 parts) fails", () => {
+    expect(isNscJwtShapeRegistry(KNOWN_BAD_JWT_TOO_MANY)).toBe(false);
+  });
+
+  test("wrong-start JWT (not eyJ) fails", () => {
+    expect(isNscJwtShapeRegistry(KNOWN_BAD_JWT_WRONG_START)).toBe(false);
+  });
+
+  test("empty string fails", () => {
+    expect(isNscJwtShapeRegistry("")).toBe(false);
+  });
+});
+
+// =============================================================================
+// validateGrantLeafPackage — unit tests
+// =============================================================================
+
+describe("validateGrantLeafPackage", () => {
+  test("valid minimal package passes", () => {
+    const result = validateGrantLeafPackage(VALID_PACKAGE);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.pkg.operatorJwt).toBe(KNOWN_GOOD_JWT);
+      expect(result.pkg.account).toBe(KNOWN_GOOD_NKEY);
+      expect(result.pkg.accountJwt).toBe(KNOWN_GOOD_JWT);
+      expect(result.pkg.systemAccount).toBeUndefined();
+      expect(result.pkg.systemAccountJwt).toBeUndefined();
+    }
+  });
+
+  test("valid package with SYS account passes", () => {
+    const pkg = {
+      ...VALID_PACKAGE,
+      systemAccount: KNOWN_GOOD_NKEY,
+      systemAccountJwt: KNOWN_GOOD_JWT,
+    };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.pkg.systemAccount).toBe(KNOWN_GOOD_NKEY);
+      expect(result.pkg.systemAccountJwt).toBe(KNOWN_GOOD_JWT);
+    }
+  });
+
+  test("valid package with endpoint passes", () => {
+    const pkg = { ...VALID_PACKAGE, endpoint: "tls://hub.meta-factory.ai:7422" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.pkg.endpoint).toBe("tls://hub.meta-factory.ai:7422");
+    }
+  });
+
+  test("credsPath field → rejected (secret field)", () => {
+    const pkg = { ...VALID_PACKAGE, credsPath: "/home/user/.nkeys/creds/mystack.creds" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]?.field).toContain("credsPath");
+      expect(result.errors[0]?.message).toContain("secret");
+    }
+  });
+
+  test("field containing 'seed' → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, operatorSeed: "SOABCDEF" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+  });
+
+  test("field containing 'secret' → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, secretKey: "XXXXXXXXXXX" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+  });
+
+  test("field containing 'private' → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, privateData: "something" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+  });
+
+  test("malformed operatorJwt → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, operatorJwt: "notajwt" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.field.includes("operatorJwt"))).toBe(true);
+    }
+  });
+
+  test("malformed account (not nkey-U) → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, account: "notannkey" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.field.includes("account"))).toBe(true);
+    }
+  });
+
+  test("malformed accountJwt → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, accountJwt: "badvalue" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.field.includes("accountJwt"))).toBe(true);
+    }
+  });
+
+  test("half-specified SYS account: systemAccount without systemAccountJwt → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, systemAccount: KNOWN_GOOD_NKEY };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.message.includes("both"))).toBe(true);
+    }
+  });
+
+  test("half-specified SYS account: systemAccountJwt without systemAccount → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, systemAccountJwt: KNOWN_GOOD_JWT };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.message.includes("both"))).toBe(true);
+    }
+  });
+
+  test("empty endpoint → rejected", () => {
+    const pkg = { ...VALID_PACKAGE, endpoint: "" };
+    const result = validateGrantLeafPackage(pkg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.field.includes("endpoint"))).toBe(true);
+    }
+  });
+});
+
+// =============================================================================
+// Admin grant WITH leaf_package
+// =============================================================================
+
+describe("POST /issuance-requests/:id/grant WITH leaf_package", () => {
+  test("grant with valid leaf_package stores the package", async () => {
+    const req = await registerAndGetRequest("pkg-alice");
+
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, VALID_PACKAGE);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(200);
+
+    const granted = (await res.json()) as IssuanceRequest;
+    expect(granted.status).toBe("GRANTED");
+    expect(granted.leaf_package).not.toBeNull();
+
+    // The stored JSON must round-trip to the original package shape.
+    const parsed = JSON.parse(granted.leaf_package!) as GrantLeafPackage;
+    expect(parsed.operatorJwt).toBe(VALID_PACKAGE.operatorJwt);
+    expect(parsed.account).toBe(VALID_PACKAGE.account);
+    expect(parsed.accountJwt).toBe(VALID_PACKAGE.accountJwt);
+  });
+
+  test("grant with SYS account stores full package", async () => {
+    const req = await registerAndGetRequest("pkg-bob");
+
+    const pkgWithSys: GrantLeafPackage = {
+      ...VALID_PACKAGE,
+      systemAccount: KNOWN_GOOD_NKEY,
+      systemAccountJwt: KNOWN_GOOD_JWT,
+    };
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, pkgWithSys);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(200);
+
+    const granted = (await res.json()) as IssuanceRequest;
+    const parsed = JSON.parse(granted.leaf_package!) as GrantLeafPackage;
+    expect(parsed.systemAccount).toBe(KNOWN_GOOD_NKEY);
+    expect(parsed.systemAccountJwt).toBe(KNOWN_GOOD_JWT);
+  });
+
+  test("grant without leaf_package still works (leaf_package null)", async () => {
+    const req = await registerAndGetRequest("pkg-carol");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(200);
+
+    const granted = (await res.json()) as IssuanceRequest;
+    expect(granted.status).toBe("GRANTED");
+    expect(granted.leaf_package).toBeNull();
+  });
+
+  test("grant with credsPath in package → 400 validation_failed", async () => {
+    const req = await registerAndGetRequest("pkg-dave");
+
+    const badPkg = { ...VALID_PACKAGE, credsPath: "/home/user/.nkeys/creds/mystack.creds" };
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, badPkg as unknown as GrantLeafPackage);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("validation_failed");
+  });
+
+  test("grant with malformed account nkey → 400 validation_failed", async () => {
+    const req = await registerAndGetRequest("pkg-eve");
+
+    const badPkg: GrantLeafPackage = { ...VALID_PACKAGE, account: "notannkey" };
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, badPkg);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(400);
+  });
+
+  test("grant with half-specified SYS account → 400 validation_failed", async () => {
+    const req = await registerAndGetRequest("pkg-frank");
+
+    const badPkg = { ...VALID_PACKAGE, systemAccount: KNOWN_GOOD_NKEY }; // missing systemAccountJwt
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, badPkg as unknown as GrantLeafPackage);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(400);
+  });
+
+  test("existing O-4a.1 grant (no package) still works after O-4a.2 changes", async () => {
+    const req = await registerAndGetRequest("pkg-grace");
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    const res = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(res.status).toBe(200);
+    const granted = (await res.json()) as IssuanceRequest;
+    expect(granted.status).toBe("GRANTED");
+    expect(granted.granted_by).toBe(admin.publicKeyB64);
+    expect(granted.leaf_package).toBeNull(); // no regression
+  });
+});
+
+// =============================================================================
+// Peer PoP package fetch — GET /issuance-requests/:id/package
+// =============================================================================
+
+describe("GET /issuance-requests/:id/package — peer PoP", () => {
+  test("peer fetches their own package from GRANTED request → 200", async () => {
+    const req = await registerAndGetRequest("pop-alice");
+
+    // Grant with package.
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, VALID_PACKAGE);
+    const grantRes = await post(`/issuance-requests/${req.request_id}/grant`, decision);
+    expect(grantRes.status).toBe(200);
+
+    // Peer fetches their package.
+    const peerHeader = await makePeerPoP(principal);
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { leaf_package: GrantLeafPackage };
+    expect(body.leaf_package.account).toBe(VALID_PACKAGE.account);
+    expect(body.leaf_package.operatorJwt).toBe(VALID_PACKAGE.operatorJwt);
+    expect(body.leaf_package.accountJwt).toBe(VALID_PACKAGE.accountJwt);
+  });
+
+  test("peer request on PENDING request → 409 not_granted", async () => {
+    const req = await registerAndGetRequest("pop-bob");
+    // Do NOT grant.
+
+    const peerHeader = await makePeerPoP(principal);
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("not_granted");
+  });
+
+  test("peer request on REJECTED request → 409 not_granted", async () => {
+    const req = await registerAndGetRequest("pop-carol");
+
+    // Reject the request.
+    const decision = await makeSignedAdminDecision(req.request_id, "reject", admin);
+    await post(`/issuance-requests/${req.request_id}/reject`, decision);
+
+    const peerHeader = await makePeerPoP(principal);
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("not_granted");
+  });
+
+  test("peer with wrong key → 403 wrong_key", async () => {
+    const req = await registerAndGetRequest("pop-dave");
+
+    // Grant with package.
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, VALID_PACKAGE);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    // A different peer key signs the PoP.
+    const otherKey = await makePrincipalKey();
+    const peerHeader = await makePeerPoP(otherKey);
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("wrong_key");
+  });
+
+  test("peer with forged signature → 401 signature_invalid", async () => {
+    const req = await registerAndGetRequest("pop-eve");
+
+    // Grant with package.
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, VALID_PACKAGE);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    // Build a PoP that claims principal.publicKeyB64 but is signed by another key.
+    const otherKey = await makePrincipalKey();
+    const peerHeader = await makePeerPoP(principal, { signWith: otherKey });
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("signature_invalid");
+  });
+
+  test("peer request on nonexistent request_id → 404 not_found", async () => {
+    const peerHeader = await makePeerPoP(principal);
+    const res = await get(
+      "/issuance-requests/0000000000000000000000000000cafe/package",
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: string }).error).toBe("not_found");
+  });
+
+  test("peer request on GRANTED request with no package → 404 package_not_ready", async () => {
+    const req = await registerAndGetRequest("pop-frank");
+
+    // Grant WITHOUT package.
+    const decision = await makeSignedAdminDecision(req.request_id, "grant", admin);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    const peerHeader = await makePeerPoP(principal);
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: string }).error).toBe("package_not_ready");
+  });
+
+  test("missing x-peer-signed header → 400", async () => {
+    const req = await registerAndGetRequest("pop-grace");
+
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, VALID_PACKAGE);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    const res = await get(`/issuance-requests/${req.request_id}/package`);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("x-peer-signed header required");
+  });
+
+  test("invalid request_id on /package route → 400 invalid_request_id", async () => {
+    const peerHeader = await makePeerPoP(principal);
+    const res = await get(
+      "/issuance-requests/not-valid-hex/package",
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid_request_id");
+  });
+
+  test("clock-skew check: issued_at in the past beyond skew window → 400", async () => {
+    const req = await registerAndGetRequest("pop-hank");
+
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, VALID_PACKAGE);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    // PoP with a stale issued_at (30 min ago > 5 min skew window).
+    const staleAt = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const peerHeader = await makePeerPoP(principal, { issuedAt: staleAt });
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": peerHeader },
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("issued_at out of skew window");
+  });
+
+  test("admin key is rejected as peer_pubkey if it doesn't match the registered peer_pubkey", async () => {
+    // Register with `principal` key (not `admin` key).
+    const req = await registerAndGetRequest("pop-ivan");
+
+    const decision = await makeSignedAdminDecisionWithPackage(req.request_id, admin, VALID_PACKAGE);
+    await post(`/issuance-requests/${req.request_id}/grant`, decision);
+
+    // Admin tries to fetch using admin key as peer — wrong_key since admin ≠ registered peer.
+    const adminPoP = await makePeerPoP(admin);
+    const res = await get(
+      `/issuance-requests/${req.request_id}/package`,
+      env,
+      { "x-peer-signed": adminPoP },
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("wrong_key");
+  });
+});
+
+// Note: provision-stack register PENDING note test lives in
+// src/__tests__/o4a2-provision-stack-pending.test.ts (root-level test suite)
+// because the CLI module is outside the registry package boundary.

--- a/src/services/network-registry/src/routes/issuance-requests.ts
+++ b/src/services/network-registry/src/routes/issuance-requests.ts
@@ -176,7 +176,7 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
     // IMPORTANT: The canonical-JSON signed payload includes leaf_package when
     // present — the admin signed the whole claim object (including the package),
     // so the existing signature gate already authenticates the package content.
-    const message = new TextEncoder().encode(canonicalJSON(claim));
+    const message = new TextEncoder().encode(canonicalJSON(claim)) as Uint8Array<ArrayBuffer>;
     const gateResult = await applyAdminGate(
       adminPubkeys,
       claim.admin_pubkey,
@@ -244,6 +244,14 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
       return { error: "admin_not_configured", status: 503 };
     }
 
+    // M1 — rate-limit BEFORE the Ed25519 verify to shed compute-DoS.
+    // Admin reads are keyed by IP only (no entity id in the path to fold in).
+    // Uses the "read" bucket (120/60s) — same class as other admin GET endpoints.
+    const allowed = await checkRateLimit(c.env, "read", clientKey(c.req.raw));
+    if (!allowed) {
+      return { error: "rate_limited", status: 429 };
+    }
+
     // 2. Parse + validate x-admin-signed header.
     const headerVal = c.req.header("x-admin-signed");
     if (!headerVal) {
@@ -272,7 +280,7 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
 
     // 4. Signature + allowlist check (no nonce for reads — idempotent).
     const message = new TextEncoder().encode(canonicalJSON(signed.claim));
-    const valid = await verifyEd25519(signed.claim.admin_pubkey, signed.signature, message);
+    const valid = await verifyEd25519(signed.claim.admin_pubkey, signed.signature, message as Uint8Array<ArrayBuffer>);
     if (!valid) return { error: "signature_invalid", status: 401 };
     if (!adminPubkeys.has(signed.claim.admin_pubkey)) return { error: "admin_not_authorized", status: 403 };
 
@@ -298,7 +306,7 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
   app.get("/issuance-requests", async (c) => {
     const authError = await verifyAdminReadHeader(c);
     if (authError) {
-      return c.json({ error: authError.error }, authError.status as 400 | 401 | 403 | 503);
+      return c.json({ error: authError.error }, authError.status as 400 | 401 | 403 | 429 | 503);
     }
 
     const status = c.req.query("status") as IssuanceStatus | undefined;
@@ -322,7 +330,7 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
   app.get("/issuance-requests/:request_id", async (c) => {
     const authError = await verifyAdminReadHeader(c);
     if (authError) {
-      return c.json({ error: authError.error }, authError.status as 400 | 401 | 403 | 503);
+      return c.json({ error: authError.error }, authError.status as 400 | 401 | 403 | 429 | 503);
     }
 
     const requestId = c.req.param("request_id") ?? "";
@@ -368,6 +376,16 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "invalid_request_id" }, 400);
     }
 
+    // M1 — rate-limit BEFORE the header-parse / Ed25519-verify to shed compute-DoS.
+    // Keyed by (IP, requestId) so a targeted flood against one request doesn't
+    // exhaust the bucket for all requests from that IP, and a distributed flood
+    // can't hide behind a shared egress IP by spreading across request ids.
+    // Uses the "read" bucket (120/60s) — same class as other GET endpoints.
+    const allowed = await checkRateLimit(c.env, "read", clientKey(c.req.raw, requestId));
+    if (!allowed) {
+      return c.json(TOO_MANY_REQUESTS_BODY, 429, { "Retry-After": String(retryAfterSeconds("read")) });
+    }
+
     // 1. Parse + validate x-peer-signed header.
     const headerVal = c.req.header("x-peer-signed");
     if (!headerVal) {
@@ -387,6 +405,13 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
     }
     const { signed } = readCheck;
 
+    // N2 — request_id binding check: the signed token must name this specific
+    // request. Reject 401 if it was signed for a different request_id (same
+    // error class as a bad signature — the token is not valid for this endpoint).
+    if (signed.claim.request_id !== requestId) {
+      return c.json({ error: "request_id_mismatch" }, 401);
+    }
+
     // 2. Clock-skew check.
     const issued = Date.parse(signed.claim.issued_at);
     const now = Date.now();
@@ -396,7 +421,7 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
 
     // 3. Signature verification — peer proves possession of claim.peer_pubkey.
     const message = new TextEncoder().encode(canonicalJSON(signed.claim));
-    const valid = await verifyEd25519(signed.claim.peer_pubkey, signed.signature, message);
+    const valid = await verifyEd25519(signed.claim.peer_pubkey, signed.signature, message as Uint8Array<ArrayBuffer>);
     if (!valid) {
       return c.json({ error: "signature_invalid" }, 401);
     }

--- a/src/services/network-registry/src/routes/issuance-requests.ts
+++ b/src/services/network-registry/src/routes/issuance-requests.ts
@@ -46,7 +46,9 @@ import { getNonceCache, getIssuanceStore, AlreadyDecidedError } from "../store";
 import {
   validateSignedIssuanceDecision,
   validateIssuanceDecisionClaim,
+  validateIssuanceDecisionClaimWithPackage,
   validateSignedIssuanceRead,
+  validateSignedIssuancePackageRead,
   isValidRequestId,
 } from "../validate";
 import { canonicalJSON, verifyEd25519 } from "../signing";
@@ -142,11 +144,20 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
     }
     const { signed } = envelopeCheck;
 
-    const claimCheck = validateIssuanceDecisionClaim(signed.claim, requestId, decision);
-    if (!claimCheck.ok) {
-      return c.json({ error: "validation_failed", details: claimCheck.errors }, 400);
+    // O-4a.2: for grant, use the extended claim validator that allows an
+    // optional leaf_package field. For reject, the base validator is sufficient
+    // (packages are only valid on grant; the extended validator rejects a
+    // leaf_package on a reject claim via the base decision check).
+    let claimResult: ReturnType<typeof validateIssuanceDecisionClaim> | ReturnType<typeof validateIssuanceDecisionClaimWithPackage>;
+    if (decision === "grant") {
+      claimResult = validateIssuanceDecisionClaimWithPackage(signed.claim, requestId);
+    } else {
+      claimResult = validateIssuanceDecisionClaim(signed.claim, requestId, decision);
     }
-    const { claim } = claimCheck;
+    if (!claimResult.ok) {
+      return c.json({ error: "validation_failed", details: claimResult.errors }, 400);
+    }
+    const { claim } = claimResult;
 
     // 3. Clock-skew check.
     const issued = Date.parse(claim.issued_at);
@@ -162,6 +173,9 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
     }
 
     // 4. Signature verification FIRST (before recording nonce — #695 rationale).
+    // IMPORTANT: The canonical-JSON signed payload includes leaf_package when
+    // present — the admin signed the whole claim object (including the package),
+    // so the existing signature gate already authenticates the package content.
     const message = new TextEncoder().encode(canonicalJSON(claim));
     const gateResult = await applyAdminGate(
       adminPubkeys,
@@ -180,7 +194,11 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "nonce_replayed" }, 409);
     }
 
-    // 6. State transition.
+    // 6. State transition (O-4a.2: pass leafPackage for grant when present).
+    const leafPackage =
+      decision === "grant" && "leaf_package" in claim
+        ? (claim as { leaf_package?: import("../types").GrantLeafPackage }).leaf_package
+        : undefined;
     const store = getIssuanceStore(c.env);
     let updated;
     try {
@@ -188,6 +206,7 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
         requestId,
         decision === "grant" ? "GRANTED" : "REJECTED",
         claim.admin_pubkey,
+        leafPackage,
       );
     } catch (err) {
       if (err instanceof AlreadyDecidedError) {
@@ -317,6 +336,110 @@ export function issuanceRequestRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "not_found" }, 404);
     }
     return c.json(request, 200);
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /issuance-requests/:request_id/package — peer proof-of-possession fetch
+  //
+  // O-4a.2 — the joining peer fetches THEIR OWN granted leaf package.
+  //
+  // Trust model (separate from admin gate):
+  //   The peer is NOT an admin. They prove possession of the stack key they
+  //   registered with by signing a read claim with that key. The registry verifies:
+  //     1. x-peer-signed header present + valid shape
+  //     2. clock-skew on claim.issued_at
+  //     3. signature valid over canonical-JSON(claim) for claim.peer_pubkey
+  //     4. claim.peer_pubkey === request.peer_pubkey  ← ownership check
+  //   Only then is leaf_package served.
+  //
+  // Status rules:
+  //   GRANTED + leaf_package populated → 200 { leaf_package }
+  //   GRANTED + leaf_package null      → 404 package_not_ready
+  //   PENDING                          → 409 not_granted
+  //   REJECTED                         → 409 not_granted
+  //   request_id not found             → 404 not_found
+  //   peer_pubkey mismatch             → 403 wrong_key
+  // ---------------------------------------------------------------------------
+
+  app.get("/issuance-requests/:request_id/package", async (c) => {
+    const requestId = c.req.param("request_id") ?? "";
+    // M2 — validate request_id path param first.
+    if (!isValidRequestId(requestId)) {
+      return c.json({ error: "invalid_request_id" }, 400);
+    }
+
+    // 1. Parse + validate x-peer-signed header.
+    const headerVal = c.req.header("x-peer-signed");
+    if (!headerVal) {
+      return c.json({ error: "x-peer-signed header required" }, 400);
+    }
+
+    let parsedHeader: unknown;
+    try {
+      parsedHeader = JSON.parse(headerVal);
+    } catch (_err) {
+      return c.json({ error: "x-peer-signed must be valid JSON" }, 400);
+    }
+
+    const readCheck = validateSignedIssuancePackageRead(parsedHeader);
+    if (!readCheck.ok) {
+      return c.json({ error: "x-peer-signed validation_failed", details: readCheck.errors }, 400);
+    }
+    const { signed } = readCheck;
+
+    // 2. Clock-skew check.
+    const issued = Date.parse(signed.claim.issued_at);
+    const now = Date.now();
+    if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
+      return c.json({ error: "issued_at out of skew window" }, 400);
+    }
+
+    // 3. Signature verification — peer proves possession of claim.peer_pubkey.
+    const message = new TextEncoder().encode(canonicalJSON(signed.claim));
+    const valid = await verifyEd25519(signed.claim.peer_pubkey, signed.signature, message);
+    if (!valid) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
+
+    // 4. Fetch the issuance request.
+    const store = getIssuanceStore(c.env);
+    const request = await store.getIssuanceRequest(requestId);
+    if (!request) {
+      return c.json({ error: "not_found" }, 404);
+    }
+
+    // 5. Ownership check: signer pubkey MUST match the registered peer_pubkey.
+    // A peer can only fetch their own request's package — never another peer's.
+    if (signed.claim.peer_pubkey !== request.peer_pubkey) {
+      return c.json({ error: "wrong_key" }, 403);
+    }
+
+    // 6. Status check: package is only available when GRANTED.
+    if (request.status !== "GRANTED") {
+      return c.json(
+        {
+          error: "not_granted",
+          details: `request ${requestId} is ${request.status}`,
+        },
+        409,
+      );
+    }
+
+    // 7. Return the package — if it exists.
+    if (request.leaf_package === null) {
+      // Granted without a package (admin did not supply one at grant time).
+      return c.json({ error: "package_not_ready" }, 404);
+    }
+
+    let pkg: unknown;
+    try {
+      pkg = JSON.parse(request.leaf_package);
+    } catch (_err) {
+      // Corrupt stored data — surface as 500 rather than hiding the corruption.
+      return c.json({ error: "package_parse_error" }, 500);
+    }
+
+    return c.json({ leaf_package: pkg }, 200);
   });
 
   return app;

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -28,6 +28,7 @@
 import type {
   Capability,
   CapabilityHit,
+  GrantLeafPackage,
   IssuanceRequest,
   IssuanceStatus,
   NetworkRecord,
@@ -203,12 +204,15 @@ export interface IssuanceRequestStore {
    * If the request_id doesn't exist, returns `undefined`.
    *
    * Sets `granted_by` to `adminPubkey` and `updated_at` to now.
-   * `leaf_package` stays null (O-4a.2 populates it).
+   * O-4a.2: when `newStatus === "GRANTED"` and `leafPackage` is provided,
+   * stores it in the `leaf_package` column atomically. On REJECTED the
+   * `leafPackage` argument is ignored (package only flows with grants).
    */
   transitionIssuanceRequest(
     requestId: string,
     newStatus: "GRANTED" | "REJECTED",
     adminPubkey: string,
+    leafPackage?: GrantLeafPackage,
   ): Promise<IssuanceRequest | undefined>;
 }
 
@@ -272,6 +276,7 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
     requestId: string,
     newStatus: "GRANTED" | "REJECTED",
     adminPubkey: string,
+    leafPackage?: GrantLeafPackage,
   ): Promise<IssuanceRequest | undefined> {
     const existing = this.requests.get(requestId);
     if (!existing) return undefined;
@@ -283,6 +288,11 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
       status: newStatus,
       granted_by: adminPubkey,
       updated_at: new Date().toISOString(),
+      // O-4a.2: store the package only when granting and a package was supplied.
+      leaf_package:
+        newStatus === "GRANTED" && leafPackage !== undefined
+          ? JSON.stringify(leafPackage)
+          : null,
     };
     this.requests.set(requestId, updated);
     return updated;
@@ -362,6 +372,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     requestId: string,
     newStatus: "GRANTED" | "REJECTED",
     adminPubkey: string,
+    leafPackage?: GrantLeafPackage,
   ): Promise<IssuanceRequest | undefined> {
     // Re-read current state before mutating — needed for AlreadyDecidedError.
     const existing = await this.getIssuanceRequest(requestId);
@@ -371,16 +382,22 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     }
 
     const now = new Date().toISOString();
+    // O-4a.2: include leaf_package in the SET clause when granting with a package.
+    const leafPackageJson =
+      newStatus === "GRANTED" && leafPackage !== undefined
+        ? JSON.stringify(leafPackage)
+        : null;
+
     // CAS-ish: UPDATE only touches the row when status is still PENDING.
     // If a concurrent grant/reject raced us here, the WHERE status='PENDING'
     // is false, changes === 0, and we read back the decided row to throw.
     const res = await this.db
       .prepare(
         `UPDATE issuance_requests
-         SET status = ?, granted_by = ?, updated_at = ?
+         SET status = ?, granted_by = ?, updated_at = ?, leaf_package = ?
          WHERE request_id = ? AND status = 'PENDING'`,
       )
-      .bind(newStatus, adminPubkey, now, requestId)
+      .bind(newStatus, adminPubkey, now, leafPackageJson, requestId)
       .run();
 
     if ((res.meta?.changes ?? 0) === 0) {
@@ -399,6 +416,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
       status: newStatus,
       granted_by: adminPubkey,
       updated_at: now,
+      leaf_package: leafPackageJson,
     };
   }
 }

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -417,11 +417,20 @@ export interface IssuanceDecisionClaimWithPackage extends IssuanceDecisionClaim 
  * claim with that key. The registry verifies:
  *   1. Signature is valid over canonical-JSON(claim).
  *   2. Signer pubkey === request.peer_pubkey.
+ *   3. claim.request_id === the path :request_id (N2 — token is bound to a
+ *      specific request so it cannot be replayed against a different request
+ *      for the same peer key).
  * No nonce (reads are idempotent). Clock-skew applies.
  */
 export interface IssuancePackageReadClaim {
   /** The peer's own stack pubkey (base64 Ed25519). Verified against the request. */
   peer_pubkey: string;
+  /**
+   * N2 — binds this signed token to a specific issuance request.
+   * Must equal the :request_id path parameter; a mismatch is rejected 401.
+   * 32 lowercase hex chars (the format generateRequestId produces).
+   */
+  request_id: string;
   /** ISO-8601 UTC; within the CLOCK_SKEW_MS window. */
   issued_at: string;
 }

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -352,3 +352,83 @@ export interface SignedIssuanceRead {
   /** Base64 Ed25519 signature over canonical-JSON(claim). */
   signature: string;
 }
+
+// =============================================================================
+// O-4a.2 — Leaf package types
+// =============================================================================
+
+/**
+ * The PUBLIC leaf credential package the admin posts on grant.
+ *
+ * Registry-level shape: JWTs + nkey-U public keys ONLY. This is the
+ * `OperatorModeLeafPackage` shape from O-4b (`leaf-remote-renderer.ts`)
+ * MINUS `credsPath` — the registry NEVER receives a creds path or any
+ * secret. The symmetric `credsPath` is delivered out-of-band (#1012).
+ *
+ * Grammar (mirrors O-4b canonical validators — see validate.ts for the
+ * mirrored regexes and the anti-drift test vectors):
+ *   - `account` / `systemAccount`: nkey-U pubkey — `/^A[A-Z2-7]{55}$/`
+ *   - `operatorJwt` / `accountJwt` / `systemAccountJwt`: NSC JWT shape
+ *     — `/^eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2}$/`
+ *
+ * Half-specified SYS account (one of systemAccount/systemAccountJwt
+ * without the other) is rejected with 400 — same rule as O-4b.
+ */
+export interface GrantLeafPackage {
+  /** The NSC operator JWT (`eyJ…`). */
+  operatorJwt: string;
+  /** The issued account public key (nkey-U, `A…`). */
+  account: string;
+  /** The issued account JWT (`eyJ…`). */
+  accountJwt: string;
+  /** OPTIONAL system account public key (nkey-U). */
+  systemAccount?: string;
+  /** OPTIONAL system account JWT. Must be present when `systemAccount` is. */
+  systemAccountJwt?: string;
+  /**
+   * OPTIONAL network endpoint hint for this leaf credential.
+   * Non-empty string if supplied.
+   */
+  endpoint?: string;
+}
+
+/**
+ * The admin-signed claim carried by
+ * `POST /issuance-requests/{request_id}/grant` (O-4a.2 extension).
+ *
+ * Extends `IssuanceDecisionClaim` by adding the optional `leaf_package`
+ * field. The package is included ONLY on grant (not reject). When present
+ * the package is stored atomically inside the PENDING→GRANTED transition.
+ *
+ * The existing `IssuanceDecisionClaim` stays unchanged so O-4a.1 grant
+ * calls (no package) continue to work — the field is optional.
+ */
+export interface IssuanceDecisionClaimWithPackage extends IssuanceDecisionClaim {
+  /**
+   * O-4a.2: the PUBLIC leaf package to store on grant. Optional — a grant
+   * without a package is still valid (leaf_package column stays null).
+   */
+  leaf_package?: GrantLeafPackage;
+}
+
+/**
+ * Proof-of-possession read claim. The joining peer proves they own the
+ * stack key on record for their issuance request by signing a minimal
+ * claim with that key. The registry verifies:
+ *   1. Signature is valid over canonical-JSON(claim).
+ *   2. Signer pubkey === request.peer_pubkey.
+ * No nonce (reads are idempotent). Clock-skew applies.
+ */
+export interface IssuancePackageReadClaim {
+  /** The peer's own stack pubkey (base64 Ed25519). Verified against the request. */
+  peer_pubkey: string;
+  /** ISO-8601 UTC; within the CLOCK_SKEW_MS window. */
+  issued_at: string;
+}
+
+/** On-wire envelope for a peer proof-of-possession package read. */
+export interface SignedIssuancePackageRead {
+  claim: IssuancePackageReadClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -18,10 +18,14 @@
 
 import type {
   Capability,
+  GrantLeafPackage,
   IssuanceDecisionClaim,
+  IssuanceDecisionClaimWithPackage,
+  IssuancePackageReadClaim,
   IssuanceReadClaim,
   RegistrationClaim,
   SignedIssuanceDecision,
+  SignedIssuancePackageRead,
   SignedIssuanceRead,
   SignedRegistration,
   StackIdentity,
@@ -646,5 +650,242 @@ export function validateSignedRegistration(
   return {
     ok: true,
     signed: { claim: b.claim as RegistrationClaim, signature: b.signature },
+  };
+}
+
+// =============================================================================
+// O-4a.2 — Leaf package + peer PoP validators
+// =============================================================================
+
+/**
+ * O-4b grammar: NATS nkey-U account public key.
+ *
+ * Canonical source: `src/common/nats/leaf-remote-renderer.ts`:
+ *   const NKEY_ACCOUNT = /^A[A-Z2-7]{55}$/;
+ *
+ * ANTI-DRIFT: isNkeyAccountPubkeyRegistry() below is tested against the same
+ * known-good and known-bad vectors used to validate O-4b's isNkeyAccountPubkey.
+ * If O-4b's regex ever changes, the shared test in o4a2-package.test.ts will
+ * catch the drift (it uses the same vector strings on BOTH validators).
+ */
+const NKEY_ACCOUNT_RE = /^A[A-Z2-7]{55}$/;
+
+/**
+ * O-4b grammar: NSC JWT shape (`eyJ…` header + exactly three
+ * dot-separated base64url segments).
+ *
+ * Canonical source: `src/common/nats/leaf-remote-renderer.ts`:
+ *   const JWT_SHAPE = /^eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2}$/;
+ *
+ * ANTI-DRIFT: same cross-validation in o4a2-package.test.ts.
+ */
+const NSC_JWT_SHAPE_RE = /^eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2}$/;
+
+/**
+ * True iff `value` is a NATS nkey-U account public key.
+ * Mirrors O-4b's `isNkeyAccountPubkey` from `leaf-remote-renderer.ts`.
+ * The registry is a SEPARATE package and cannot import that module.
+ */
+export function isNkeyAccountPubkeyRegistry(value: string): boolean {
+  return NKEY_ACCOUNT_RE.test(value);
+}
+
+/**
+ * True iff `value` has the NSC JWT shape.
+ * Mirrors O-4b's `isNscJwtShape` from `leaf-remote-renderer.ts`.
+ */
+export function isNscJwtShapeRegistry(value: string): boolean {
+  return NSC_JWT_SHAPE_RE.test(value);
+}
+
+/**
+ * Validate a `GrantLeafPackage` object (public-material-only).
+ *
+ * Enforces:
+ *   - operatorJwt / accountJwt: NSC JWT shape
+ *   - account: nkey-U pubkey
+ *   - systemAccount (optional): nkey-U pubkey
+ *   - systemAccountJwt (optional): NSC JWT shape
+ *   - half-specified SYS account: one of (systemAccount, systemAccountJwt)
+ *     without the other → rejected
+ *   - credsPath or any unrecognised "secret-looking" field → rejected (400)
+ *
+ * Secret-detection: we explicitly reject `credsPath` and any key that
+ * contains "cred", "seed", "secret", or "private" (case-insensitive). The
+ * registry ONLY stores public JWTs + nkey-U pubkeys. Any field that looks
+ * like a secret is an admin error and should fail loudly.
+ */
+export function validateGrantLeafPackage(
+  pkg: unknown,
+  fieldPrefix = "leaf_package",
+): { ok: true; pkg: GrantLeafPackage } | { ok: false; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+
+  if (typeof pkg !== "object" || pkg === null || Array.isArray(pkg)) {
+    return { ok: false, errors: [{ field: fieldPrefix, message: "must be an object" }] };
+  }
+  const p = pkg as Record<string, unknown>;
+
+  // Reject secret-looking fields. An admin including credsPath or a seed in
+  // the grant body is an admin error — fail loudly rather than silently
+  // ignoring the field (which would hide data-hygiene bugs).
+  const SECRET_FIELD_RE = /cred|seed|secret|private/i;
+  for (const key of Object.keys(p)) {
+    if (SECRET_FIELD_RE.test(key)) {
+      errors.push({
+        field: `${fieldPrefix}.${key}`,
+        message:
+          "the registry only stores public material (JWTs + nkey-U pubkeys); " +
+          `field "${key}" looks like a secret and is rejected`,
+      });
+    }
+  }
+  if (errors.length > 0) return { ok: false, errors };
+
+  // operatorJwt — required, NSC JWT shape.
+  if (typeof p.operatorJwt !== "string" || !NSC_JWT_SHAPE_RE.test(p.operatorJwt)) {
+    errors.push({
+      field: `${fieldPrefix}.operatorJwt`,
+      message: "must be an NSC JWT (eyJ… + three base64url segments)",
+    });
+  }
+
+  // account — required, nkey-U pubkey.
+  if (typeof p.account !== "string" || !NKEY_ACCOUNT_RE.test(p.account)) {
+    errors.push({
+      field: `${fieldPrefix}.account`,
+      message: "must be a NATS nkey-U account pubkey (A + 55 base32 chars)",
+    });
+  }
+
+  // accountJwt — required, NSC JWT shape.
+  if (typeof p.accountJwt !== "string" || !NSC_JWT_SHAPE_RE.test(p.accountJwt)) {
+    errors.push({
+      field: `${fieldPrefix}.accountJwt`,
+      message: "must be an NSC JWT (eyJ… + three base64url segments)",
+    });
+  }
+
+  // Half-specified SYS account: one present without the other → reject.
+  const hasSysAccount = p.systemAccount !== undefined;
+  const hasSysJwt = p.systemAccountJwt !== undefined;
+  if (hasSysAccount !== hasSysJwt) {
+    errors.push({
+      field: `${fieldPrefix}.systemAccount`,
+      message:
+        "systemAccount and systemAccountJwt must both be present or both absent (half-specified SYS account)",
+    });
+  } else {
+    if (hasSysAccount) {
+      if (typeof p.systemAccount !== "string" || !NKEY_ACCOUNT_RE.test(p.systemAccount)) {
+        errors.push({
+          field: `${fieldPrefix}.systemAccount`,
+          message: "must be a NATS nkey-U account pubkey (A + 55 base32 chars)",
+        });
+      }
+    }
+    if (hasSysJwt) {
+      if (typeof p.systemAccountJwt !== "string" || !NSC_JWT_SHAPE_RE.test(p.systemAccountJwt)) {
+        errors.push({
+          field: `${fieldPrefix}.systemAccountJwt`,
+          message: "must be an NSC JWT (eyJ… + three base64url segments)",
+        });
+      }
+    }
+  }
+
+  // endpoint — optional, non-empty string when present.
+  if (p.endpoint !== undefined) {
+    if (typeof p.endpoint !== "string" || p.endpoint.length === 0) {
+      errors.push({
+        field: `${fieldPrefix}.endpoint`,
+        message: "must be a non-empty string when provided",
+      });
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  // Build canonical shape — only include optional keys when defined.
+  const result: GrantLeafPackage = {
+    operatorJwt: p.operatorJwt as string,
+    account: p.account as string,
+    accountJwt: p.accountJwt as string,
+  };
+  if (typeof p.systemAccount === "string") result.systemAccount = p.systemAccount;
+  if (typeof p.systemAccountJwt === "string") result.systemAccountJwt = p.systemAccountJwt;
+  if (typeof p.endpoint === "string") result.endpoint = p.endpoint;
+
+  return { ok: true, pkg: result };
+}
+
+/**
+ * Validate the full grant body WITH optional leaf_package (O-4a.2 extension).
+ *
+ * Returns the base `IssuanceDecisionClaim` + the validated `GrantLeafPackage`
+ * when present. The claim still validates via `validateIssuanceDecisionClaim`;
+ * this function adds the package field on top.
+ */
+export function validateIssuanceDecisionClaimWithPackage(
+  claim: unknown,
+  expectedRequestId: string,
+): { ok: true; claim: IssuanceDecisionClaimWithPackage } | { ok: false; errors: ValidationError[] } {
+  // Validate base claim first.
+  const base = validateIssuanceDecisionClaim(claim, expectedRequestId, "grant");
+  if (!base.ok) return base;
+
+  const c = claim as Record<string, unknown>;
+
+  // leaf_package is optional — only validate when present.
+  if (c.leaf_package === undefined) {
+    return { ok: true, claim: base.claim };
+  }
+
+  const pkgResult = validateGrantLeafPackage(c.leaf_package);
+  if (!pkgResult.ok) return { ok: false, errors: pkgResult.errors };
+
+  return {
+    ok: true,
+    claim: { ...base.claim, leaf_package: pkgResult.pkg },
+  };
+}
+
+/**
+ * Validate the `x-peer-signed` header envelope for peer PoP package reads.
+ * The header value is JSON: { claim: IssuancePackageReadClaim, signature: string }.
+ * No nonce (reads are idempotent). Clock-skew applies.
+ */
+export function validateSignedIssuancePackageRead(
+  body: unknown,
+): { ok: true; signed: SignedIssuancePackageRead } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null) {
+    return { ok: false, errors: [{ field: "claim", message: "missing" }] };
+  }
+  const c = b.claim as Record<string, unknown>;
+  if (typeof c.peer_pubkey !== "string" || !isValidPubkey(c.peer_pubkey)) {
+    return {
+      ok: false,
+      errors: [{ field: "claim.peer_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" }],
+    };
+  }
+  if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
+    return { ok: false, errors: [{ field: "claim.issued_at", message: "must be an ISO-8601 timestamp" }] };
+  }
+  return {
+    ok: true,
+    signed: {
+      claim: { peer_pubkey: c.peer_pubkey, issued_at: c.issued_at },
+      signature: b.signature,
+    },
   };
 }

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -726,9 +726,15 @@ export function validateGrantLeafPackage(
   }
   const p = pkg as Record<string, unknown>;
 
-  // Reject secret-looking fields. An admin including credsPath or a seed in
-  // the grant body is an admin error — fail loudly rather than silently
-  // ignoring the field (which would hide data-hygiene bugs).
+  // Secret-detection (N1 — secondary / belt-and-suspenders control):
+  // The PRIMARY guard is the canonical allow-list build at the bottom of this
+  // function — we reconstruct GrantLeafPackage from only the fields the schema
+  // names, so unknown fields are silently dropped and never reach storage.
+  // This deny-list is a SECONDARY, defense-in-depth layer: it makes the
+  // rejection explicit and loud when an admin accidentally includes a field
+  // whose name looks like a secret (e.g. `credsPath`, `accountSeed`). Failing
+  // early here surfaces the admin error at grant time rather than silently
+  // discarding the value and leaving the admin wondering where it went.
   const SECRET_FIELD_RE = /cred|seed|secret|private/i;
   for (const key of Object.keys(p)) {
     if (SECRET_FIELD_RE.test(key)) {
@@ -854,6 +860,10 @@ export function validateIssuanceDecisionClaimWithPackage(
  * Validate the `x-peer-signed` header envelope for peer PoP package reads.
  * The header value is JSON: { claim: IssuancePackageReadClaim, signature: string }.
  * No nonce (reads are idempotent). Clock-skew applies.
+ *
+ * N2 — `claim.request_id` is required and must be a valid hex32 request id.
+ * The route layer then asserts it equals the :request_id path parameter so
+ * a signed token cannot be replayed against a different request for the same key.
  */
 export function validateSignedIssuancePackageRead(
   body: unknown,
@@ -878,13 +888,20 @@ export function validateSignedIssuancePackageRead(
       errors: [{ field: "claim.peer_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" }],
     };
   }
+  // N2 — request_id binds the token to a specific issuance request.
+  if (typeof c.request_id !== "string" || !isValidRequestId(c.request_id)) {
+    return {
+      ok: false,
+      errors: [{ field: "claim.request_id", message: "must be a 32-char lowercase hex request id" }],
+    };
+  }
   if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
     return { ok: false, errors: [{ field: "claim.issued_at", message: "must be an ISO-8601 timestamp" }] };
   }
   return {
     ok: true,
     signed: {
-      claim: { peer_pubkey: c.peer_pubkey, issued_at: c.issued_at },
+      claim: { peer_pubkey: c.peer_pubkey, request_id: c.request_id, issued_at: c.issued_at },
       signature: b.signature,
     },
   };


### PR DESCRIPTION
Closes #1064
Refs #1050

## Summary

- **Grant carries the leaf package**: `POST /issuance-requests/:id/grant` now accepts an optional `leaf_package` (public JWTs + nkey-U pubkeys only). Stored atomically inside the PENDING→GRANTED transition. Package validated with O-4b mirrored grammar (`/^A[A-Z2-7]{55}$/` nkey-U, `/^eyJ…/` NSC JWT). Secret-field rejection rejects `credsPath`, `seed`, `secret`, `private` fields. Half-specified SYS account → 400.
- **Peer PoP package fetch** (`GET /issuance-requests/:id/package`): the joining peer proves possession of their registered stack key via `x-peer-signed` header. Completely separate from the admin allowlist gate. Auth order: request_id validate → clock-skew → Ed25519 verify → ownership check (`claim.peer_pubkey === request.peer_pubkey`) → status check. Status rules: GRANTED+package → 200; GRANTED+null → 404 `package_not_ready`; PENDING/REJECTED → 409; wrong key → 403; forged sig → 401.
- **Anti-drift grammar test**: `src/__tests__/o4b-grammar-mirror.test.ts` imports both sides (registry + O-4b) and asserts identical results on shared vectors — any future regex drift trips this test.
- **`provision-stack register` handles PENDING**: exits 0 on 2xx with a clear "awaiting admin grant" message. Tested in `src/__tests__/o4a2-provision-stack-pending.test.ts`.
- **D1 mock updated** for the new `leaf_package` bind arg in the UPDATE statement.

## Test plan

- [ ] `bunx tsc --noEmit` — clean (root tsconfig gate)
- [ ] `bun test src/services/network-registry/` — 227 pass, 0 fail
- [ ] `bun test src/` — 7161 pass, 2 skip, 0 fail
- [ ] `bunx eslint --quiet` on all touched files — clean
- [ ] `bash scripts/check-carveouts.sh` — pre-existing baseline (2371→2370, our changes net-neutral or better; `operatorJwt` is NATS NSC carve-out per 0002)
- [ ] Peer PoP route: correct key → 200, wrong key → 403, forged sig → 401, PENDING → 409, no package → 404
- [ ] Grant with `credsPath` → 400; half-specified SYS → 400; valid package → 200 with stored JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)