### PR TITLE
feat(bus): export transport runtime + dispatch/dev builders from ./bus barrel (transport-layering F8)

### DIFF
--- a/docs/design-onboarding-tooling-audit.md
+++ b/docs/design-onboarding-tooling-audit.md
@@ -37,7 +37,7 @@ asserted.
 1. **Federated account-topology — zero tooling (the linchpin).** For `federated.>` to
    cross account/operator boundaries on a hub, someone runs `nsc add export` on the
    leaf-bound account + `nsc add import` on the destination account (or co-locates
-   both in one operator universe by hand-copying `resolver_preload`). **Verified: neither
+   both in one operator-mode universe by hand-copying `resolver_preload`). **Verified: neither
    `cortex` nor `arc` tools this** — it is pure manual `nsc` surgery. This is the edge
    that just cost real debugging time, and it's the least tooled.
 2. **Leaf-creds issuance + delivery (two-party, gating).** O-4a built the *broker*

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -100,3 +100,49 @@ export {
   type PublishFn,
 } from "./capability-registry";
 /* eslint-enable @typescript-eslint/no-deprecated */
+
+// ── Transport runtime (M2) ───────────────────────────────────────────────
+// The connect-with-creds + sign-on-publish primitive. Re-exported so M7 apps
+// (pilot) publish via `startMyelinRuntime(config)` + `runtime.publish(envelope)`
+// — the runtime opens the NatsLink with the stack's `nats.credsPath` and signs
+// each envelope — instead of hand-rolling a raw `connect()` + `signEnvelope()`.
+// The barrel previously surfaced `NatsLink`/`MyelinSubscriber` (so pilot's
+// SUBSCRIBERS were cred-aware) but NOT the runtime, which is exactly why the
+// publishers reinvented the transport (the F8 root cause of the cred-less
+// `Authorization Violation` on the operator-mode bus).
+export {
+  startMyelinRuntime,
+  type MyelinRuntime,
+  type MyelinRuntimeOptions,
+  type MyelinSubscribePullOpts,
+  type BusEnvelopeSigner,
+} from "./myelin/runtime";
+
+// ── Dispatch lifecycle envelope builders (M3) ────────────────────────────
+// Single source of truth for `dispatch.task.{started,completed,failed,aborted}`.
+// Re-exported so producers/reactors NEVER hand-build a dispatch envelope (the
+// schema-drift hazard the audit found in pilot's publish-dispatch-lifecycle).
+export {
+  createDispatchTaskStartedEvent,
+  createDispatchTaskCompletedEvent,
+  createDispatchTaskFailedEvent,
+  createDispatchTaskAbortedEvent,
+  type DispatchTaskCommonOpts,
+  type DispatchTaskStartedOpts,
+  type DispatchTaskCompletedOpts,
+  type DispatchTaskFailedOpts,
+  type DispatchTaskAbortedOpts,
+  type DispatchTaskFailedReason,
+  type DispatchEventSource,
+} from "./dispatch-events";
+
+// ── dev.implement request builder (M3) ───────────────────────────────────
+// The canonical `tasks.dev.implement` Offer builder + payload parser, so the
+// producer (pilot's tick) constructs the envelope via this rather than a local
+// copy, and the round-trip stays byte-identical to the consumer's parse.
+export {
+  createDevImplementRequestEvent,
+  parseDevImplementPayload,
+  type DevImplementPayload,
+  type CreateDevImplementRequestEventOpts,
+} from "./dev-events";


### PR DESCRIPTION
## Why

The dev-loop **transport-layering audit** found that all three pilot bus *publishers* reinvent the transport — raw cred-less `connect()` (→ `Authorization Violation` on the operator-mode bus), hand-rolled `signEnvelope`, hand-built subjects, a 229-line `sign-helper.ts`. Root cause (**F8**): the `@the-metafactory/cortex/bus` barrel surfaced `NatsLink` + `MyelinSubscriber` (so pilot's *subscribers* are cred-aware + clean) but **not** `MyelinRuntime`/`startMyelinRuntime` or the dispatch-event builders — so the publishers literally couldn't reach the delegate-everything primitive and reinvented it on the far side. *(A primitive that isn't exported across the package boundary gets re-implemented.)*

## What

Widen `src/bus/index.ts` (pure re-export, no behavior change):
- **M2 transport** — `startMyelinRuntime`, `MyelinRuntime`, `MyelinRuntimeOptions`, `MyelinSubscribePullOpts`, `BusEnvelopeSigner`
- **M3 dispatch lifecycle SSOT** — `createDispatchTask{Started,Completed,Failed,Aborted}Event` (+ opts/types)
- **canonical Offer** — `createDevImplementRequestEvent`, `parseDevImplementPayload`, `DevImplementPayload`

This unblocks the **pilot publisher re-platform** (the actual fix: publishers shrink to *build envelope → `runtime.publish()`*, deleting `sign-helper.ts` + the raw connects).

## Also

Fixes a **pre-existing broken-main carve-out violation** — `docs/design-onboarding-tooling-audit.md:40` had a bare "operator" (a legit NSC operator-mode reference) that was failing the whole-tree vocab gate on *every* PR. Reworded to the carved `operator-mode` form.

tsc clean; carve-out gate green; smoke-import of the new symbols verified.