### PR TITLE
feat(creds): G2 — cortex creds grant, one-command admin grant act

### DIFF
--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -186,6 +186,19 @@ async function signWithNKey(kp: KeyPair, message: Uint8Array): Promise<string> {
   return bytesToBase64(new Uint8Array(sig));
 }
 
+/**
+ * Sign `message` using an NKey seed string (`SU…`). Public API for callers
+ * that hold a seed string (e.g. the `creds grant` command) without needing to
+ * reconstruct the full PKCS#8 bridge inline — divergent prefix bytes between
+ * callers would produce silent signature mismatches. Single source of truth.
+ *
+ * Returns a base64 raw 64-byte ed25519 signature over `message`.
+ */
+export async function signClaimWithSeed(seed: string, message: Uint8Array): Promise<string> {
+  const kp = fromSeed(new TextEncoder().encode(seed.trim()));
+  return signWithNKey(kp, message);
+}
+
 // =============================================================================
 // Identity generation + seed-file write
 // =============================================================================

--- a/src/cli/cortex/commands/__tests__/creds-grant.test.ts
+++ b/src/cli/cortex/commands/__tests__/creds-grant.test.ts
@@ -18,9 +18,9 @@ import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { dispatchCreds, __setArcRunnerForTests } from "../creds";
+import { dispatchCreds, __setArcRunnerForTests, __setDiscordGrantClientForTests } from "../creds";
 import { dispatchProvisionStack } from "../provision-stack";
-import type { ArcRunner, ArcRunResult } from "../creds";
+import type { ArcRunner, ArcRunResult, DiscordGrantClient } from "../creds";
 
 /** Type-safe helper to assign a mock to globalThis.fetch without hitting Bun's
  *  `preconnect` property requirement. Mirrors the pattern in network-create.test.ts. */
@@ -41,6 +41,7 @@ function freshDir(): string {
 
 afterEach(() => {
   __setArcRunnerForTests(null);
+  __setDiscordGrantClientForTests(null);
   // Restore real fetch
   globalThis.fetch = realFetch;
   while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
@@ -542,11 +543,24 @@ describe("creds grant --apply — Discord role assignment", () => {
     const discordGuildId = "987654321098765432";
     const discordRoleId = "111111111111111111";
 
-    const { fetch: mockFetch, calls } = buildMockFetch({
+    // Track Discord client calls via the injected seam — no real fetch,
+    // no filesystem config required. This is what was missing on CI.
+    const discordCalls: { method: string; userId?: string; guildId?: string; roleId?: string }[] = [];
+    const mockDiscordClient: DiscordGrantClient = {
+      async resolveRoleId(_token, guildId, _roleName) {
+        discordCalls.push({ method: "resolveRoleId", guildId });
+        return discordRoleId;
+      },
+      async assignRole(_token, guildId, userId, roleId) {
+        discordCalls.push({ method: "assignRole", guildId, userId, roleId });
+        return { success: true };
+      },
+    };
+    __setDiscordGrantClientForTests(mockDiscordClient);
+
+    const { fetch: mockFetch } = buildMockFetch({
       requestId,
       requestFixture: fixture,
-      discordGuildId,
-      discordRoleId,
     });
     setMockFetch(mockFetch);
 
@@ -561,11 +575,14 @@ describe("creds grant --apply — Discord role assignment", () => {
 
     expect(res.exitCode).toBe(0);
 
-    // Discord PUT role call made
-    const rolePut = calls.find((c) => c.method === "PUT" && c.url.includes("/roles/"));
-    expect(rolePut).toBeTruthy();
-    expect(rolePut!.url).toContain(discordGuildId);
-    expect(rolePut!.url).toContain(discordMemberId);
+    // Injected client was called for role resolution and assignment
+    const resolveCall = discordCalls.find((c) => c.method === "resolveRoleId");
+    expect(resolveCall).toBeTruthy();
+    const assignCall = discordCalls.find((c) => c.method === "assignRole");
+    expect(assignCall).toBeTruthy();
+    expect(assignCall!.userId).toBe(discordMemberId);
+    expect(assignCall!.guildId).toBe(discordGuildId);
+    expect(assignCall!.roleId).toBe(discordRoleId);
 
     // Output mentions role assignment
     expect(res.stdout).toMatch(/role|discord/i);
@@ -582,11 +599,20 @@ describe("creds grant --apply — Discord role assignment", () => {
       stderr: "",
     }));
 
+    // Inject a Discord client that fails on assignRole
+    const mockDiscordClient: DiscordGrantClient = {
+      async resolveRoleId(_token, _guildId, _roleName) {
+        return "roleId-fake";
+      },
+      async assignRole(_token, _guildId, _userId, _roleId) {
+        return { success: false, error: "Missing Permissions" };
+      },
+    };
+    __setDiscordGrantClientForTests(mockDiscordClient);
+
     const { fetch: mockFetch } = buildMockFetch({
       requestId,
       requestFixture: fixture,
-      discordGuildId: "999999999999999999",
-      discordPutStatus: 403, // Discord fails
     });
     setMockFetch(mockFetch);
 
@@ -679,7 +705,7 @@ describe("creds grant — scope flag", () => {
 // =============================================================================
 
 describe("creds grant --apply --json", () => {
-  test("success emits structured envelope with creds_path and grant details", async () => {
+  test("success emits structured envelope with local_creds_path and grant details", async () => {
     const { seedPath } = await mintAdminSeed();
     const requestId = "req-json-001";
     const fixture = pendingRequestFixture(requestId);
@@ -709,7 +735,7 @@ describe("creds grant --apply --json", () => {
     expect(env.status).toBe("ok");
     expect(env.data.applied).toBe("true");
     expect(env.data.request_id).toBe(requestId);
-    // credsPath is surfaced as local context for the admin, NOT sent to registry
-    expect(env.data.creds_path).toBe("/home/admin/.nats/echo.creds");
+    // local_creds_path is surfaced as local context for the admin, NOT sent to registry
+    expect(env.data.local_creds_path).toBe("/home/admin/.nats/echo.creds");
   });
 });

--- a/src/cli/cortex/commands/__tests__/creds-grant.test.ts
+++ b/src/cli/cortex/commands/__tests__/creds-grant.test.ts
@@ -1,0 +1,715 @@
+/**
+ * G2 — `cortex creds grant <request-id>` CLI tests.
+ *
+ * Orchestration flow under test:
+ *   1. Fetch PENDING request via admin-signed GET (mock registry)
+ *   2. Issue scoped creds via arc (injected ArcRunner)
+ *   3. Assemble PUBLIC leaf package (no credsPath/secret)
+ *   4. Sign + POST the IssuanceDecisionClaimWithPackage (mock registry)
+ *   5. Assign Discord role (injected fetch) when --discord-member is given
+ *
+ * All live surfaces (registry HTTP, arc binary, Discord API) are mocked.
+ * Tests exercise the wiring, the no-secret guarantee, dry-run default,
+ * partial-success on Discord failure, and error paths.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { dispatchCreds, __setArcRunnerForTests } from "../creds";
+import { dispatchProvisionStack } from "../provision-stack";
+import type { ArcRunner, ArcRunResult } from "../creds";
+
+/** Type-safe helper to assign a mock to globalThis.fetch without hitting Bun's
+ *  `preconnect` property requirement. Mirrors the pattern in network-create.test.ts. */
+function setMockFetch(fn: (input: RequestInfo | URL, init?: RequestInit | BunFetchRequestInit) => Promise<Response>): void {
+  globalThis.fetch = fn as unknown as typeof globalThis.fetch;
+}
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "g2-creds-grant-"));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  __setArcRunnerForTests(null);
+  // Restore real fetch
+  globalThis.fetch = realFetch;
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+const realFetch = globalThis.fetch;
+
+/**
+ * Mint a real admin nkey seed file (chmod 600) via provision-stack and return
+ * its path + the derived base64 pubkey. Reuses the same helper pattern as
+ * network-create tests.
+ */
+async function mintAdminSeed(): Promise<{ seedPath: string; adminPubkey: string }> {
+  const seedPath = join(freshDir(), "admin.nk");
+  const res = await dispatchProvisionStack([
+    "generate", "andreas",
+    "--seed-path", seedPath,
+    "--json",
+  ]);
+  expect(res.exitCode).toBe(0);
+  const env = JSON.parse(res.stdout) as { data: { pubkey_b64: string } };
+  return { seedPath, adminPubkey: env.data.pubkey_b64 };
+}
+
+/**
+ * Build a valid IssuanceRequest fixture in PENDING state. `peer_pubkey` is a
+ * placeholder base64 string — the tests don't verify it, the registry mock owns
+ * the state machine.
+ */
+function pendingRequestFixture(requestId: string, opts: { scope?: string } = {}) {
+  return {
+    request_id: requestId,
+    principal_id: "echo",
+    peer_pubkey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    requested_scope: opts.scope ?? "federated.echo.>",
+    status: "PENDING",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    granted_by: null,
+    leaf_package: null,
+  };
+}
+
+/** Build an arc.nats.v1 add-bot success envelope. */
+function arcAddBotOk(opts: {
+  bot: string;
+  account?: string;
+  credsPath?: string;
+  pubKey?: string;
+  jwt?: string;
+}): string {
+  return JSON.stringify({
+    schema: "arc.nats.v1",
+    ok: true,
+    bot: opts.bot,
+    account: opts.account ?? "OP_TEST",
+    credsPath: opts.credsPath ?? `/tmp/${opts.bot}.creds`,
+    jwt: opts.jwt ?? "eyJ-fake-account-jwt",
+    pubKey: opts.pubKey ?? "UAFAKEPUBKEY",
+  });
+}
+
+/** Minimal operator JWT (base64url encoded — not cryptographically valid, just structurally shaped). */
+const FAKE_OPERATOR_JWT = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJvcCJ9.fakesig";
+/** Minimal account JWT. */
+const FAKE_ACCOUNT_JWT = "eyJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJhY2MifQ.fakesig2";
+
+/**
+ * Build a mock fetch that handles:
+ *   - GET  /issuance-requests/{id}  → returns the fixture (admin-signed header OK)
+ *   - POST /issuance-requests/{id}/grant → 200 granted
+ *   - GET  /guilds/{gid}/roles → discord role list
+ *   - PUT  /guilds/{gid}/members/{uid}/roles/{rid} → 204
+ */
+interface MockFetchCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+function buildMockFetch(opts: {
+  requestId: string;
+  requestFixture: ReturnType<typeof pendingRequestFixture>;
+  grantedFixture?: object;
+  discordGuildId?: string;
+  discordRoleId?: string;
+  /** If set, POST /grant returns this status (defaults to 200) */
+  grantStatus?: number;
+  /** If set, Discord PUT returns this status (defaults to 204) */
+  discordPutStatus?: number;
+}): { fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>; calls: MockFetchCall[] } {
+  const calls: MockFetchCall[] = [];
+  const mockFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const rawHeaders = init?.headers ?? {};
+    const headers: Record<string, string> = {};
+    if (rawHeaders instanceof Headers) {
+      rawHeaders.forEach((v, k) => (headers[k] = v));
+    } else if (Array.isArray(rawHeaders)) {
+      for (const [k, v] of rawHeaders) headers[k] = v;
+    } else {
+      Object.assign(headers, rawHeaders);
+    }
+
+    let body: unknown;
+    try {
+      if (init?.body) body = JSON.parse(init.body as string);
+    } catch (_err) {
+      // ignore parse errors — body may not be JSON
+    }
+
+    calls.push({ url, method, headers, body });
+
+    // Registry GET /issuance-requests/{id}
+    if (method === "GET" && url.includes(`/issuance-requests/${opts.requestId}`) && !url.includes("/package")) {
+      return new Response(JSON.stringify(opts.requestFixture), { status: 200 });
+    }
+
+    // Registry POST /issuance-requests/{id}/grant
+    if (method === "POST" && url.includes(`/issuance-requests/${opts.requestId}/grant`)) {
+      const status = opts.grantStatus ?? 200;
+      const body = status === 200
+        ? JSON.stringify(opts.grantedFixture ?? { ...opts.requestFixture, status: "GRANTED", granted_by: "admin-pubkey" })
+        : JSON.stringify({ error: "already_decided" });
+      return new Response(body, { status });
+    }
+
+    // Discord GET /guilds/{gid}/roles
+    if (method === "GET" && url.includes("/guilds/") && url.endsWith("/roles") && opts.discordGuildId) {
+      return new Response(
+        JSON.stringify([{ id: opts.discordRoleId ?? "99999", name: "community-fleet" }]),
+        { status: 200 },
+      );
+    }
+
+    // Discord PUT /guilds/{gid}/members/{uid}/roles/{rid}
+    if (method === "PUT" && url.includes("/guilds/") && url.includes("/roles/") && opts.discordGuildId) {
+      return new Response(null, { status: opts.discordPutStatus ?? 204 });
+    }
+
+    // Fallthrough — should not happen in well-formed tests
+    return new Response(JSON.stringify({ error: "unexpected call" }), { status: 500 });
+  };
+
+  return { fetch: mockFetch, calls };
+}
+
+// =============================================================================
+// Usage validation (exit 2)
+// =============================================================================
+
+describe("creds grant — usage validation", () => {
+  test("missing request-id (exit 2)", async () => {
+    const res = await dispatchCreds(["grant"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("request-id");
+  });
+
+  test("missing --admin-seed (exit 2)", async () => {
+    const res = await dispatchCreds(["grant", "req-abc123"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--admin-seed");
+  });
+
+  test("--admin-seed file not found (exit 1)", async () => {
+    const res = await dispatchCreds([
+      "grant", "req-abc123",
+      "--admin-seed", "/tmp/no-such-seed-file-g2.nk",
+    ]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("not found");
+  });
+
+  test("--apply and --dry-run together is a usage error (exit 2)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const res = await dispatchCreds([
+      "grant", "req-abc123",
+      "--admin-seed", seedPath,
+      "--apply",
+      "--dry-run",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toMatch(/mutually exclusive/i);
+  });
+});
+
+// =============================================================================
+// Dry-run (DEFAULT) — no registry writes, no arc calls, no Discord calls
+// =============================================================================
+
+describe("creds grant — dry-run (default)", () => {
+  test("dry-run prints what WOULD happen without contacting registry", async () => {
+    const { seedPath } = await mintAdminSeed();
+
+    // arc should NOT be called in dry-run
+    let arcCalled = false;
+    __setArcRunnerForTests(async () => {
+      arcCalled = true;
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+
+    // Registry should NOT be fetched in dry-run
+    let fetchCalled = false;
+    setMockFetch(async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    });
+
+    const res = await dispatchCreds([
+      "grant", "req-dryrun01",
+      "--admin-seed", seedPath,
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    expect(arcCalled).toBe(false);
+    expect(fetchCalled).toBe(false);
+    // Should mention dry-run
+    expect(res.stdout).toMatch(/dry.run/i);
+    // Should mention the request id
+    expect(res.stdout).toContain("req-dryrun01");
+  });
+
+  test("dry-run with --json emits structured envelope with applied:false", async () => {
+    const { seedPath } = await mintAdminSeed();
+    __setArcRunnerForTests(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
+    setMockFetch(async () => new Response("{}", { status: 200 }));
+
+    const res = await dispatchCreds([
+      "grant", "req-dryrun02",
+      "--admin-seed", seedPath,
+      "--json",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { status: string; data: Record<string, string> };
+    expect(env.status).toBe("ok");
+    expect(env.data.applied).toBe("false");
+    expect(env.data.request_id).toBe("req-dryrun02");
+  });
+});
+
+// =============================================================================
+// --apply: full orchestration (fetch → arc → assemble package → POST → Discord)
+// =============================================================================
+
+describe("creds grant --apply — full orchestration", () => {
+  test("fetches PENDING request, issues creds, posts grant with PUBLIC leaf package", async () => {
+    const { seedPath, adminPubkey } = await mintAdminSeed();
+    const requestId = "req-apply-001";
+    const fixture = pendingRequestFixture(requestId, { scope: "federated.echo.>" });
+
+    // Arc returns a valid add-bot result
+    const arcArgvLog: (readonly string[])[] = [];
+    __setArcRunnerForTests(async (argv) => {
+      arcArgvLog.push(argv);
+      return {
+        exitCode: 0,
+        stdout: arcAddBotOk({
+          bot: "echo",
+          credsPath: "/tmp/echo.creds",
+          jwt: FAKE_ACCOUNT_JWT,
+          pubKey: "UECHOPUBKEY",
+        }),
+        stderr: "",
+      };
+    });
+
+    const { fetch: mockFetch, calls } = buildMockFetch({
+      requestId,
+      requestFixture: fixture,
+      discordGuildId: undefined, // no Discord in this test
+    });
+    setMockFetch(mockFetch);
+
+    const res = await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--apply",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+
+    // Arc was called
+    expect(arcArgvLog.length).toBe(1);
+    const arcArgv = arcArgvLog[0]!;
+    expect(arcArgv).toContain("nats");
+    expect(arcArgv).toContain("add-bot");
+
+    // Registry GET was called (admin read)
+    const getCall = calls.find((c) => c.method === "GET" && c.url.includes("/issuance-requests/"));
+    expect(getCall).toBeTruthy();
+    expect(getCall!.headers["x-admin-signed"]).toBeTruthy();
+
+    // Registry POST /grant was called
+    const postCall = calls.find((c) => c.method === "POST" && c.url.includes("/grant"));
+    expect(postCall).toBeTruthy();
+    const postBody = postCall!.body as { claim: { request_id: string; decision: string; admin_pubkey: string; leaf_package?: { operatorJwt: string; account: string; accountJwt: string } }; signature: string };
+    expect(postBody.claim.request_id).toBe(requestId);
+    expect(postBody.claim.decision).toBe("grant");
+    expect(postBody.claim.admin_pubkey).toBe(adminPubkey);
+    // Leaf package MUST be present
+    expect(postBody.claim.leaf_package).toBeTruthy();
+    // Leaf package MUST have operatorJwt, account, accountJwt
+    expect(postBody.claim.leaf_package!.operatorJwt).toBe(FAKE_OPERATOR_JWT);
+    expect(postBody.claim.leaf_package!.account).toBe("OP_TEST");
+    expect(postBody.claim.leaf_package!.accountJwt).toBe(FAKE_ACCOUNT_JWT);
+    // Signature over canonical-JSON(claim) must be present
+    expect(typeof postBody.signature).toBe("string");
+    expect(postBody.signature.length).toBeGreaterThan(10);
+
+    // Summary output
+    expect(res.stdout).toMatch(/granted/i);
+    expect(res.stdout).toContain(requestId);
+  });
+
+  test("no-secrets guarantee: credsPath NEVER appears in the POST body", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-no-secret-001";
+    const fixture = pendingRequestFixture(requestId);
+    const SECRET_CREDS_PATH = "/home/admin/.config/nats/creds/echo.creds";
+
+    __setArcRunnerForTests(async () => ({
+      exitCode: 0,
+      stdout: arcAddBotOk({ bot: "echo", credsPath: SECRET_CREDS_PATH }),
+      stderr: "",
+    }));
+
+    const { fetch: mockFetch, calls } = buildMockFetch({
+      requestId,
+      requestFixture: fixture,
+    });
+    setMockFetch(mockFetch);
+
+    await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--apply",
+    ]);
+
+    // The POST body must NOT contain the local creds path
+    const postCall = calls.find((c) => c.method === "POST" && c.url.includes("/grant"));
+    expect(postCall).toBeTruthy();
+    const postBodyStr = JSON.stringify(postCall!.body);
+    expect(postBodyStr).not.toContain("credsPath");
+    expect(postBodyStr).not.toContain(SECRET_CREDS_PATH);
+    expect(postBodyStr).not.toContain(".creds");
+  });
+
+  test("leaf package missing required field fails before POST (exit 1)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-badpkg-001";
+    const fixture = pendingRequestFixture(requestId);
+
+    // Arc returns a result missing the JWT
+    __setArcRunnerForTests(async () => ({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        schema: "arc.nats.v1",
+        ok: true,
+        bot: "echo",
+        account: "OP_TEST",
+        credsPath: "/tmp/echo.creds",
+        jwt: "", // empty — invalid
+        pubKey: "UAFAKEPUBKEY",
+      }),
+      stderr: "",
+    }));
+
+    let postCalled = false;
+    const { fetch: mockFetch } = buildMockFetch({
+      requestId,
+      requestFixture: fixture,
+    });
+    setMockFetch(async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input).url;
+      if ((init?.method ?? "GET").toUpperCase() === "POST" && url.includes("/grant")) {
+        postCalled = true;
+      }
+      return mockFetch(input, init);
+    });
+
+    const res = await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--apply",
+    ]);
+
+    // Should fail before POSTing an invalid package
+    expect(res.exitCode).toBe(1);
+    expect(postCalled).toBe(false);
+    expect(res.stderr).toMatch(/accountJwt|jwt|leaf.package/i);
+  });
+
+  test("non-PENDING request fails with clear error (exit 1)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-already-granted";
+    const grantedFixture = { ...pendingRequestFixture(requestId), status: "GRANTED" };
+
+    __setArcRunnerForTests(async () => ({ exitCode: 0, stdout: arcAddBotOk({ bot: "echo" }), stderr: "" }));
+
+    setMockFetch(async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input).url;
+      if ((init?.method ?? "GET").toUpperCase() === "GET" && url.includes("/issuance-requests/")) {
+        return new Response(JSON.stringify(grantedFixture), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const res = await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--apply",
+    ]);
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/not PENDING|already.*granted|status.*GRANTED/i);
+  });
+
+  test("registry returns 404 for unknown request-id (exit 1)", async () => {
+    const { seedPath } = await mintAdminSeed();
+
+    setMockFetch(async () => new Response(JSON.stringify({ error: "not_found" }), { status: 404 }));
+
+    const res = await dispatchCreds([
+      "grant", "req-nonexistent",
+      "--admin-seed", seedPath,
+      "--apply",
+    ]);
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/not.found|404/i);
+  });
+
+  test("arc failure exits 1 with clear message, no POST", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-arc-fail";
+    const fixture = pendingRequestFixture(requestId);
+
+    __setArcRunnerForTests(async () => ({
+      exitCode: 1,
+      stdout: JSON.stringify({
+        schema: "arc.nats.v1",
+        ok: false,
+        error: { code: "NSC_NOT_INSTALLED", message: "nsc binary not found" },
+      }),
+      stderr: "",
+    }));
+
+    let postCalled = false;
+    setMockFetch(async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/issuance-requests/")) {
+        return new Response(JSON.stringify(fixture), { status: 200 });
+      }
+      if (method === "POST" && url.includes("/grant")) {
+        postCalled = true;
+        return new Response("{}", { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const res = await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--apply",
+    ]);
+
+    expect(res.exitCode).toBe(1);
+    expect(postCalled).toBe(false);
+    expect(res.stderr).toMatch(/arc|creds|issue/i);
+  });
+});
+
+// =============================================================================
+// Discord role assignment (O-5)
+// =============================================================================
+
+describe("creds grant --apply — Discord role assignment", () => {
+  test("assigns community-fleet role when --discord-member is given", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-discord-001";
+    const fixture = pendingRequestFixture(requestId);
+
+    __setArcRunnerForTests(async () => ({
+      exitCode: 0,
+      stdout: arcAddBotOk({ bot: "echo", jwt: FAKE_ACCOUNT_JWT }),
+      stderr: "",
+    }));
+
+    const discordMemberId = "123456789012345678";
+    const discordGuildId = "987654321098765432";
+    const discordRoleId = "111111111111111111";
+
+    const { fetch: mockFetch, calls } = buildMockFetch({
+      requestId,
+      requestFixture: fixture,
+      discordGuildId,
+      discordRoleId,
+    });
+    setMockFetch(mockFetch);
+
+    const res = await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--discord-member", discordMemberId,
+      "--discord-guild", discordGuildId,
+      "--apply",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+
+    // Discord PUT role call made
+    const rolePut = calls.find((c) => c.method === "PUT" && c.url.includes("/roles/"));
+    expect(rolePut).toBeTruthy();
+    expect(rolePut!.url).toContain(discordGuildId);
+    expect(rolePut!.url).toContain(discordMemberId);
+
+    // Output mentions role assignment
+    expect(res.stdout).toMatch(/role|discord/i);
+  });
+
+  test("partial success: grant OK but Discord fails → exit 0 with warning", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-partial-001";
+    const fixture = pendingRequestFixture(requestId);
+
+    __setArcRunnerForTests(async () => ({
+      exitCode: 0,
+      stdout: arcAddBotOk({ bot: "echo", jwt: FAKE_ACCOUNT_JWT }),
+      stderr: "",
+    }));
+
+    const { fetch: mockFetch } = buildMockFetch({
+      requestId,
+      requestFixture: fixture,
+      discordGuildId: "999999999999999999",
+      discordPutStatus: 403, // Discord fails
+    });
+    setMockFetch(mockFetch);
+
+    const res = await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--discord-member", "111122223333444455",
+      "--discord-guild", "999999999999999999",
+      "--apply",
+    ]);
+
+    // Grant succeeded; Discord failed → partial success
+    expect(res.exitCode).toBe(0);
+    // Must warn about Discord failure
+    expect(res.stdout).toMatch(/discord.*fail|role.*fail|assign.*manual|partial/i);
+    // Must indicate grant was committed (don't roll back)
+    expect(res.stdout).toMatch(/granted/i);
+  });
+
+  test("no Discord calls when --discord-member is absent", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-no-discord-001";
+    const fixture = pendingRequestFixture(requestId);
+
+    __setArcRunnerForTests(async () => ({
+      exitCode: 0,
+      stdout: arcAddBotOk({ bot: "echo", jwt: FAKE_ACCOUNT_JWT }),
+      stderr: "",
+    }));
+
+    const { fetch: mockFetch, calls } = buildMockFetch({
+      requestId,
+      requestFixture: fixture,
+    });
+    setMockFetch(mockFetch);
+
+    const res = await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--apply",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    const discordCall = calls.find((c) => c.url.includes("discord.com"));
+    expect(discordCall).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// --scope flag
+// =============================================================================
+
+describe("creds grant — scope flag", () => {
+  test("--scope overrides the inferred scope passed to arc", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-scope-001";
+    const fixture = pendingRequestFixture(requestId);
+
+    const arcArgvLog: (readonly string[])[] = [];
+    __setArcRunnerForTests(async (argv) => {
+      arcArgvLog.push(argv);
+      return {
+        exitCode: 0,
+        stdout: arcAddBotOk({ bot: "echo", jwt: FAKE_ACCOUNT_JWT }),
+        stderr: "",
+      };
+    });
+
+    const { fetch: mockFetch } = buildMockFetch({ requestId, requestFixture: fixture });
+    setMockFetch(mockFetch);
+
+    await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--scope", "federated.echo.> _INBOX.>",
+      "--apply",
+    ]);
+
+    expect(arcArgvLog.length).toBe(1);
+    const arcArgv = arcArgvLog[0]!;
+    expect(arcArgv.join(" ")).toContain("federated.echo.>");
+  });
+});
+
+// =============================================================================
+// --json output
+// =============================================================================
+
+describe("creds grant --apply --json", () => {
+  test("success emits structured envelope with creds_path and grant details", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const requestId = "req-json-001";
+    const fixture = pendingRequestFixture(requestId);
+
+    __setArcRunnerForTests(async () => ({
+      exitCode: 0,
+      stdout: arcAddBotOk({ bot: "echo", credsPath: "/home/admin/.nats/echo.creds", jwt: FAKE_ACCOUNT_JWT }),
+      stderr: "",
+    }));
+
+    const { fetch: mockFetch } = buildMockFetch({ requestId, requestFixture: fixture });
+    setMockFetch(mockFetch);
+
+    const res = await dispatchCreds([
+      "grant", requestId,
+      "--admin-seed", seedPath,
+      "--operator-jwt", FAKE_OPERATOR_JWT,
+      "--apply",
+      "--json",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as {
+      status: string;
+      data: Record<string, string>;
+    };
+    expect(env.status).toBe("ok");
+    expect(env.data.applied).toBe("true");
+    expect(env.data.request_id).toBe(requestId);
+    // credsPath is surfaced as local context for the admin, NOT sent to registry
+    expect(env.data.creds_path).toBe("/home/admin/.nats/echo.creds");
+  });
+});

--- a/src/cli/cortex/commands/creds.ts
+++ b/src/cli/cortex/commands/creds.ts
@@ -37,6 +37,7 @@ import { enforceChmod600 } from "../../../common/config/file-permissions";
 import {
   materialFromSeedString,
   randomNonce,
+  signClaimWithSeed,
   type StackIdentityMaterial,
 } from "../../../bus/stack-provisioning";
 import { canonicalJSON } from "../../../common/registry/signing";
@@ -780,6 +781,30 @@ function errorEnvelopeForSubcommand(
 }
 
 // =============================================================================
+// G2 — Discord client injection seam (mirrors ArcRunner pattern)
+// =============================================================================
+
+/** Minimal Discord client surface used by runCredsGrant — injectable for tests. */
+export interface DiscordGrantClient {
+  resolveRoleId(botToken: string, guildId: string, roleName: string): Promise<string>;
+  assignRole(botToken: string, guildId: string, userId: string, roleId: string): Promise<{ success: boolean; error?: string }>;
+}
+
+let discordGrantClientOverride: DiscordGrantClient | null = null;
+
+/** Test-only setter. Production callers never touch this. Passing `null`
+ *  restores the real discord-lib default. */
+export function __setDiscordGrantClientForTests(client: DiscordGrantClient | null): void {
+  discordGrantClientOverride = client;
+}
+
+/** Default production client — thin wrappers over the real discord lib. */
+const defaultDiscordGrantClient: DiscordGrantClient = {
+  resolveRoleId,
+  assignRole,
+};
+
+// =============================================================================
 // G2 — runCredsGrant: one-command admin grant act (cortex#1118)
 // =============================================================================
 
@@ -856,10 +881,9 @@ async function adminMaterialFromSeedPath(
 
 /**
  * Build an admin-signed issuance decision body. The claim is canonicalJSON'd
- * and signed with the admin nkey — exactly the same path as network-create.
- * The `fromSeed` call is inlined here because `signWithNKey` is not exported;
- * instead we re-derive the KeyPair from the in-memory seed string, matching
- * the pattern in `buildNetworkCreateClaim`.
+ * and signed with the admin nkey via the shared `signClaimWithSeed` primitive
+ * from stack-provisioning.ts — one source of truth for the PKCS#8 bridge so
+ * divergent prefix bytes cannot silently break signatures.
  */
 async function buildGrantDecisionBody(
   requestId: string,
@@ -867,28 +891,6 @@ async function buildGrantDecisionBody(
   leafPackage: GrantLeafPackageClient | undefined,
   opts: { issuedAt?: string; nonce?: string } = {},
 ): Promise<{ claim: IssuanceDecisionClaimWithPackageClient; signature: string }> {
-  const { fromSeed } = await import("nkeys.js");
-
-  // PKCS#8 bridge (mirrors stack-provisioning.ts — same approach, same key shape)
-  const PKCS8_ED25519_PREFIX = Uint8Array.from([
-    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
-    0x22, 0x04, 0x20,
-  ]);
-
-  const kp = fromSeed(new TextEncoder().encode(material.seed.trim()));
-  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
-  const pkcs8 = new Uint8Array(PKCS8_ED25519_PREFIX.length + 32);
-  pkcs8.set(PKCS8_ED25519_PREFIX, 0);
-  pkcs8.set(rawSeed, PKCS8_ED25519_PREFIX.length);
-
-  const cryptoKey = await crypto.subtle.importKey(
-    "pkcs8",
-    pkcs8 as BufferSource,
-    { name: "Ed25519" },
-    false,
-    ["sign"],
-  );
-
   const claim: IssuanceDecisionClaimWithPackageClient = {
     request_id: requestId,
     decision: "grant",
@@ -899,12 +901,8 @@ async function buildGrantDecisionBody(
   };
 
   // Bytes to be signed: canonical-JSON(claim) — same as the registry verifies.
-  let bin = "";
   const msgBytes = new TextEncoder().encode(canonicalJSON(claim));
-  const sig = await crypto.subtle.sign({ name: "Ed25519" }, cryptoKey, msgBytes);
-  const sigBytes = new Uint8Array(sig);
-  for (const b of sigBytes) bin += String.fromCharCode(b);
-  const signature = btoa(bin);
+  const signature = await signClaimWithSeed(material.seed, msgBytes);
 
   return { claim, signature };
 }
@@ -912,43 +910,19 @@ async function buildGrantDecisionBody(
 /**
  * Build an admin-signed read claim for the `x-admin-signed` header used on
  * GET /issuance-requests/{id}. No nonce (reads are idempotent). Clock-skew
- * applies on the registry side.
+ * applies on the registry side. Uses `signClaimWithSeed` — the same PKCS#8
+ * bridge as buildGrantDecisionBody, single source of truth.
  */
 async function buildAdminReadHeader(
   material: StackIdentityMaterial,
 ): Promise<string> {
-  const { fromSeed } = await import("nkeys.js");
-
-  const PKCS8_ED25519_PREFIX = Uint8Array.from([
-    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
-    0x22, 0x04, 0x20,
-  ]);
-
-  const kp = fromSeed(new TextEncoder().encode(material.seed.trim()));
-  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
-  const pkcs8 = new Uint8Array(PKCS8_ED25519_PREFIX.length + 32);
-  pkcs8.set(PKCS8_ED25519_PREFIX, 0);
-  pkcs8.set(rawSeed, PKCS8_ED25519_PREFIX.length);
-
-  const cryptoKey = await crypto.subtle.importKey(
-    "pkcs8",
-    pkcs8 as BufferSource,
-    { name: "Ed25519" },
-    false,
-    ["sign"],
-  );
-
   const claim = {
     admin_pubkey: material.pubkeyB64,
     issued_at: new Date().toISOString(),
   };
 
-  let bin = "";
   const msgBytes = new TextEncoder().encode(canonicalJSON(claim));
-  const sig = await crypto.subtle.sign({ name: "Ed25519" }, cryptoKey, msgBytes);
-  const sigBytes = new Uint8Array(sig);
-  for (const b of sigBytes) bin += String.fromCharCode(b);
-  const signature = btoa(bin);
+  const signature = await signClaimWithSeed(material.seed, msgBytes);
 
   return JSON.stringify({ claim, signature });
 }
@@ -1183,18 +1157,6 @@ export async function runCredsGrant(args: ParsedCredsArgs): Promise<ExitResult> 
     }
   }
 
-  // Safety: verify the package carries no secret material (belt-and-suspenders;
-  // the shape only has public fields, but if there's ever a future bug where
-  // credsPath bleeds in, catch it here).
-  if (leafPackage !== undefined) {
-    const pkgStr = JSON.stringify(leafPackage);
-    if (pkgStr.includes("credsPath") || pkgStr.includes(".creds")) {
-      const reason = "internal: leaf package contains secret field (credsPath) — refusing to POST";
-      process.stderr.write(`cortex creds grant: ${reason}\n`);
-      return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
-    }
-  }
-
   // 4. Sign + POST the grant
   let grantBody: { claim: IssuanceDecisionClaimWithPackageClient; signature: string };
   try {
@@ -1205,6 +1167,18 @@ export async function runCredsGrant(args: ParsedCredsArgs): Promise<ExitResult> 
       return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant" })), stderr: "" };
     }
     return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+
+  // Safety: verify the ACTUAL WIRE PAYLOAD carries no secret material
+  // (belt-and-suspenders on the full POST body — not just the leaf package —
+  // so any future field that bleeds credsPath/seed is caught on the actual bytes).
+  {
+    const wireStr = JSON.stringify(grantBody);
+    if (wireStr.includes("credsPath") || wireStr.includes(".creds")) {
+      const reason = "internal: grant body contains secret field (credsPath/.creds) — refusing to POST";
+      process.stderr.write(`cortex creds grant: ${reason}\n`);
+      return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+    }
   }
 
   let grantResponse: unknown;
@@ -1236,6 +1210,10 @@ export async function runCredsGrant(args: ParsedCredsArgs): Promise<ExitResult> 
   let discordWarning = "";
 
   if (args.discordMember) {
+    // Use the injected client when running under tests; fall back to the
+    // real discord lib for production (which reads from loadDiscordConfig()).
+    const discordClient = discordGrantClientOverride;
+
     try {
       // Resolve bot token + guild id from config/flags — mirrors discord.ts role add
       const discordConfig = loadDiscordConfig();
@@ -1244,20 +1222,21 @@ export async function runCredsGrant(args: ParsedCredsArgs): Promise<ExitResult> 
         guild: args.discordGuild,
       });
 
-      const botToken = ctx.botToken;
-      const guildId = ctx.guildId;
+      const botToken = discordClient ? "injected" : ctx.botToken;
+      const guildId = discordClient ? (args.discordGuild ?? ctx.guildId) : ctx.guildId;
 
-      if (!botToken) {
+      if (!discordClient && !botToken) {
         discordWarning = "Discord role not assigned: no bot token configured (run: discord config set botToken <token>)";
         discordStatus = "skipped_no_token";
       } else if (!guildId) {
         discordWarning = "Discord role not assigned: no guild id configured — pass --discord-guild <id> or run: discord config set guildId <id>";
         discordStatus = "skipped_no_guild";
       } else {
+        const client = discordClient ?? defaultDiscordGrantClient;
         const roleName = args.discordRole ?? DEFAULT_DISCORD_ROLE;
         let roleId: string;
         try {
-          roleId = await resolveRoleId(botToken, guildId, roleName);
+          roleId = await client.resolveRoleId(botToken ?? "", guildId, roleName);
         } catch (err) {
           discordWarning = `Discord role not assigned: ${err instanceof Error ? err.message : String(err)} — assign manually`;
           discordStatus = "failed";
@@ -1265,7 +1244,7 @@ export async function runCredsGrant(args: ParsedCredsArgs): Promise<ExitResult> 
         }
 
         if (roleId) {
-          const roleResult = await assignRole(botToken, guildId, args.discordMember, roleId);
+          const roleResult = await client.assignRole(botToken ?? "", guildId, args.discordMember, roleId);
           if (roleResult.success) {
             discordStatus = "assigned";
           } else {
@@ -1288,7 +1267,7 @@ export async function runCredsGrant(args: ParsedCredsArgs): Promise<ExitResult> 
       request_id: args.requestId,
       principal_id: request.principal_id,
       scope: scopeStr,
-      creds_path: localCredsPath,
+      local_creds_path: localCredsPath,
       admin_fingerprint: material.fingerprint,
       ...(discordStatus !== "skipped" && { discord_status: discordStatus }),
     };

--- a/src/cli/cortex/commands/creds.ts
+++ b/src/cli/cortex/commands/creds.ts
@@ -29,9 +29,20 @@
  */
 
 import { existsSync, lstatSync, readdirSync } from "fs";
+import { readFile } from "fs/promises";
 import { join } from "path";
 
 import { expandTilde } from "../../../common/config/loader";
+import { enforceChmod600 } from "../../../common/config/file-permissions";
+import {
+  materialFromSeedString,
+  randomNonce,
+  type StackIdentityMaterial,
+} from "../../../bus/stack-provisioning";
+import { canonicalJSON } from "../../../common/registry/signing";
+import { assignRole, resolveRoleId } from "../../discord/lib/discord";
+import { loadConfig as loadDiscordConfig } from "../../discord/lib/config";
+import { resolveServerContext } from "../../discord/lib/server-context";
 import { CliArgsError, MissingPositionalError } from "./_shared/arg-error";
 import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
 import { assertExhaustive } from "./_shared/assert-exhaustive";
@@ -44,7 +55,7 @@ import { boolFlag, listFlag, valueFlag } from "./_shared/hydrate";
 // =============================================================================
 
 export interface ParsedCredsArgs {
-  subcommand: "list" | "issue" | "revoke" | "rotate" | "help" | "unknown";
+  subcommand: "list" | "issue" | "revoke" | "rotate" | "grant" | "help" | "unknown";
   rawSubcommand: string;
   agentId: string | undefined;
   credsDir: string | undefined;
@@ -61,6 +72,30 @@ export interface ParsedCredsArgs {
   sub: string[];
   json: boolean;
   help: boolean;
+  // G2 — grant subcommand fields (optional so existing partial-args tests keep compiling)
+  /** G2: request-id positional for `grant`. */
+  requestId?: string | undefined;
+  /** G2: path to admin nkey seed file (chmod-600 gated). */
+  adminSeed?: string | undefined;
+  /** G2: registry base URL (defaults to prod). */
+  registryUrl?: string | undefined;
+  /** G2: NATS subject scope override (e.g. "federated.echo.>"). Space-separated
+   *  multi-subject is accepted; defaults to the request's requested_scope. */
+  scope?: string | undefined;
+  /** G2: NSC operator JWT (for assembling the leaf package). */
+  operatorJwt?: string | undefined;
+  /** G2: Discord member id (snowflake) for the O-5 role admit. Optional. */
+  discordMember?: string | undefined;
+  /** G2: Discord server profile name (from discord cli.yaml) for role resolution. */
+  discordServer?: string | undefined;
+  /** G2: Discord guild id override (wins over profile). */
+  discordGuild?: string | undefined;
+  /** G2: Discord role name to assign (default: community-fleet). */
+  discordRole?: string | undefined;
+  /** G2: dry-run flag (default true — pass --apply to mutate). */
+  dryRun?: boolean;
+  /** G2: explicit --apply flag. */
+  apply?: boolean;
 }
 
 export { type ExitResult } from "./_shared/exit-result";
@@ -179,7 +214,7 @@ type ArcEnvelope =
 // parseCredsArgs
 // =============================================================================
 
-const CREDS_SPEC: SubcommandSpec<"list" | "issue" | "revoke" | "rotate"> = {
+const CREDS_SPEC: SubcommandSpec<"list" | "issue" | "revoke" | "rotate" | "grant"> = {
   cliName: "creds",
   subcommands: {
     list: { flags: { "--creds-dir": "value" } },
@@ -195,6 +230,23 @@ const CREDS_SPEC: SubcommandSpec<"list" | "issue" | "revoke" | "rotate"> = {
     },
     revoke: { positionals: ["agent-id"], flags: { "--account": "value" } },
     rotate: { positionals: ["agent-id"], flags: { "--account": "value" } },
+    // G2 — one-command admin grant act (cortex#1118)
+    grant: {
+      positionals: ["request-id"],
+      flags: {
+        "--admin-seed": "value",
+        "--registry-url": "value",
+        "--scope": "value",
+        "--operator-jwt": "value",
+        "--discord-member": "value",
+        "--discord-server": "value",
+        "--discord-guild": "value",
+        "--discord-role": "value",
+        "--apply": "bool",
+        "--dry-run": "bool",
+        "--account": "value",
+      },
+    },
   },
   universal: { "--help": "bool", "-h": "bool", "--json": "bool" },
 };
@@ -204,13 +256,10 @@ export function parseCredsArgs(argv: string[]): ParsedCredsArgs {
   try {
     parsed = parseSubcommandArgs(CREDS_SPEC, argv);
   } catch (err) {
-    if (
-      err instanceof MissingPositionalError &&
-      err.positionalName === "agent-id"
-    ) {
+    if (err instanceof MissingPositionalError) {
       const sub = err.rawSubcommand;
       const known =
-        sub === "list" || sub === "issue" || sub === "revoke" || sub === "rotate"
+        sub === "list" || sub === "issue" || sub === "revoke" || sub === "rotate" || sub === "grant"
           ? sub
           : "unknown";
       return {
@@ -223,6 +272,17 @@ export function parseCredsArgs(argv: string[]): ParsedCredsArgs {
         sub: [],
         json: false,
         help: false,
+        requestId: undefined,
+        adminSeed: undefined,
+        registryUrl: undefined,
+        scope: undefined,
+        operatorJwt: undefined,
+        discordMember: undefined,
+        discordServer: undefined,
+        discordGuild: undefined,
+        discordRole: undefined,
+        dryRun: true,
+        apply: false,
       };
     }
     throw err;
@@ -238,6 +298,18 @@ export function parseCredsArgs(argv: string[]): ParsedCredsArgs {
     sub: listFlag(parsed.flags, "--sub"),
     json: boolFlag(parsed.flags, "--json"),
     help: parsed.help,
+    // G2 grant fields
+    requestId: parsed.positionals["request-id"],
+    adminSeed: valueFlag(parsed.flags, "--admin-seed"),
+    registryUrl: valueFlag(parsed.flags, "--registry-url"),
+    scope: valueFlag(parsed.flags, "--scope"),
+    operatorJwt: valueFlag(parsed.flags, "--operator-jwt"),
+    discordMember: valueFlag(parsed.flags, "--discord-member"),
+    discordServer: valueFlag(parsed.flags, "--discord-server"),
+    discordGuild: valueFlag(parsed.flags, "--discord-guild"),
+    discordRole: valueFlag(parsed.flags, "--discord-role"),
+    apply: boolFlag(parsed.flags, "--apply"),
+    dryRun: boolFlag(parsed.flags, "--dry-run") || !boolFlag(parsed.flags, "--apply"),
   };
 }
 
@@ -708,6 +780,542 @@ function errorEnvelopeForSubcommand(
 }
 
 // =============================================================================
+// G2 — runCredsGrant: one-command admin grant act (cortex#1118)
+// =============================================================================
+
+/** Default registry URL — mirrors network create / join constants. */
+const DEFAULT_GRANT_REGISTRY_URL = "https://network.meta-factory.ai";
+
+/** Default Discord role for O-5 community-fleet admission. */
+const DEFAULT_DISCORD_ROLE = "community-fleet";
+
+/**
+ * Mirror of the registry's `IssuanceRequest` shape used on the client side.
+ * Reproduced rather than imported (registry is a separately-bundled CF Worker).
+ */
+interface IssuanceRequestClient {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  requested_scope: string;
+  status: "PENDING" | "GRANTED" | "REJECTED";
+  created_at: string;
+  updated_at: string;
+  granted_by: string | null;
+  leaf_package: string | null;
+}
+
+/**
+ * On-wire shape for the grant claim. Mirrors `IssuanceDecisionClaimWithPackage`
+ * from the registry types — reproduced on the client side (same CF Worker
+ * boundary isolation as the rest of the CLI).
+ */
+interface GrantLeafPackageClient {
+  operatorJwt: string;
+  account: string;
+  accountJwt: string;
+  systemAccount?: string;
+  systemAccountJwt?: string;
+  endpoint?: string;
+}
+
+interface IssuanceDecisionClaimWithPackageClient {
+  request_id: string;
+  decision: "grant";
+  admin_pubkey: string;
+  issued_at: string;
+  nonce: string;
+  leaf_package?: GrantLeafPackageClient;
+}
+
+/** Load + derive admin material from a seed file (chmod-600 gated). */
+async function adminMaterialFromSeedPath(
+  seedPath: string,
+): Promise<{ ok: true; material: StackIdentityMaterial } | { ok: false; reason: string }> {
+  const expanded = expandTilde(seedPath);
+  if (!existsSync(expanded)) {
+    return { ok: false, reason: `--admin-seed file not found at ${expanded}` };
+  }
+  try {
+    enforceChmod600(expanded);
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  let seed: string;
+  try {
+    seed = await readFile(expanded, "utf-8");
+  } catch (err) {
+    return { ok: false, reason: `failed to read --admin-seed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  try {
+    return { ok: true, material: materialFromSeedString(seed) };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Build an admin-signed issuance decision body. The claim is canonicalJSON'd
+ * and signed with the admin nkey — exactly the same path as network-create.
+ * The `fromSeed` call is inlined here because `signWithNKey` is not exported;
+ * instead we re-derive the KeyPair from the in-memory seed string, matching
+ * the pattern in `buildNetworkCreateClaim`.
+ */
+async function buildGrantDecisionBody(
+  requestId: string,
+  material: StackIdentityMaterial,
+  leafPackage: GrantLeafPackageClient | undefined,
+  opts: { issuedAt?: string; nonce?: string } = {},
+): Promise<{ claim: IssuanceDecisionClaimWithPackageClient; signature: string }> {
+  const { fromSeed } = await import("nkeys.js");
+
+  // PKCS#8 bridge (mirrors stack-provisioning.ts — same approach, same key shape)
+  const PKCS8_ED25519_PREFIX = Uint8Array.from([
+    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
+    0x22, 0x04, 0x20,
+  ]);
+
+  const kp = fromSeed(new TextEncoder().encode(material.seed.trim()));
+  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
+  const pkcs8 = new Uint8Array(PKCS8_ED25519_PREFIX.length + 32);
+  pkcs8.set(PKCS8_ED25519_PREFIX, 0);
+  pkcs8.set(rawSeed, PKCS8_ED25519_PREFIX.length);
+
+  const cryptoKey = await crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8 as BufferSource,
+    { name: "Ed25519" },
+    false,
+    ["sign"],
+  );
+
+  const claim: IssuanceDecisionClaimWithPackageClient = {
+    request_id: requestId,
+    decision: "grant",
+    admin_pubkey: material.pubkeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+    ...(leafPackage !== undefined && { leaf_package: leafPackage }),
+  };
+
+  // Bytes to be signed: canonical-JSON(claim) — same as the registry verifies.
+  let bin = "";
+  const msgBytes = new TextEncoder().encode(canonicalJSON(claim));
+  const sig = await crypto.subtle.sign({ name: "Ed25519" }, cryptoKey, msgBytes);
+  const sigBytes = new Uint8Array(sig);
+  for (const b of sigBytes) bin += String.fromCharCode(b);
+  const signature = btoa(bin);
+
+  return { claim, signature };
+}
+
+/**
+ * Build an admin-signed read claim for the `x-admin-signed` header used on
+ * GET /issuance-requests/{id}. No nonce (reads are idempotent). Clock-skew
+ * applies on the registry side.
+ */
+async function buildAdminReadHeader(
+  material: StackIdentityMaterial,
+): Promise<string> {
+  const { fromSeed } = await import("nkeys.js");
+
+  const PKCS8_ED25519_PREFIX = Uint8Array.from([
+    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
+    0x22, 0x04, 0x20,
+  ]);
+
+  const kp = fromSeed(new TextEncoder().encode(material.seed.trim()));
+  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
+  const pkcs8 = new Uint8Array(PKCS8_ED25519_PREFIX.length + 32);
+  pkcs8.set(PKCS8_ED25519_PREFIX, 0);
+  pkcs8.set(rawSeed, PKCS8_ED25519_PREFIX.length);
+
+  const cryptoKey = await crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8 as BufferSource,
+    { name: "Ed25519" },
+    false,
+    ["sign"],
+  );
+
+  const claim = {
+    admin_pubkey: material.pubkeyB64,
+    issued_at: new Date().toISOString(),
+  };
+
+  let bin = "";
+  const msgBytes = new TextEncoder().encode(canonicalJSON(claim));
+  const sig = await crypto.subtle.sign({ name: "Ed25519" }, cryptoKey, msgBytes);
+  const sigBytes = new Uint8Array(sig);
+  for (const b of sigBytes) bin += String.fromCharCode(b);
+  const signature = btoa(bin);
+
+  return JSON.stringify({ claim, signature });
+}
+
+/**
+ * Validate a GrantLeafPackage shape — checks that required JWT-shaped and
+ * nkey-U-shaped fields are non-empty, and that `systemAccount`/`systemAccountJwt`
+ * are either both present or both absent (half-specified is rejected).
+ *
+ * Returns null on success, a reason string on failure.
+ */
+function validateLeafPackage(pkg: GrantLeafPackageClient): string | null {
+  if (!pkg.operatorJwt.startsWith("eyJ")) {
+    return "leaf package: operatorJwt must be a non-empty JWT (eyJ…)";
+  }
+  if (!pkg.account || pkg.account.length < 4) {
+    return "leaf package: account must be a non-empty nkey-A public key";
+  }
+  if (!pkg.accountJwt.startsWith("eyJ")) {
+    return "leaf package: accountJwt must be a non-empty JWT (eyJ…)";
+  }
+  const hasSysAccount = pkg.systemAccount !== undefined && pkg.systemAccount.length > 0;
+  const hasSysJwt = pkg.systemAccountJwt !== undefined && pkg.systemAccountJwt.length > 0;
+  if (hasSysAccount !== hasSysJwt) {
+    return "leaf package: systemAccount and systemAccountJwt must both be present or both absent";
+  }
+  return null;
+}
+
+export async function runCredsGrant(args: ParsedCredsArgs): Promise<ExitResult> {
+  if (args.help) {
+    return { exitCode: 0, stdout: grantHelp(), stderr: "" };
+  }
+
+  // --- Usage validation ---
+
+  if (!args.requestId) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: "cortex creds grant: missing request-id (usage: cortex creds grant <request-id> --admin-seed <path>)\n",
+    };
+  }
+
+  if (!args.adminSeed) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: "cortex creds grant: --admin-seed <path> is required\n",
+    };
+  }
+
+  const applyFlag = args.apply ?? false;
+  const dryRunFlag = args.dryRun ?? !applyFlag;
+
+  // --apply and --dry-run together is a usage error:
+  // dryRun=true AND apply=true means both were explicitly passed
+  if (applyFlag && dryRunFlag) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: "cortex creds grant: --apply and --dry-run are mutually exclusive\n",
+    };
+  }
+
+  const registryUrl = args.registryUrl ?? DEFAULT_GRANT_REGISTRY_URL;
+
+  // Load the admin seed (chmod-600 gated) — exit 1 on any failure
+  const matRes = await adminMaterialFromSeedPath(args.adminSeed);
+  if (!matRes.ok) {
+    const reason = matRes.reason;
+    if (args.json) {
+      return {
+        exitCode: 1,
+        stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant" })),
+        stderr: "",
+      };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+  const material = matRes.material;
+
+  // --- Dry-run: print plan, touch nothing ---
+
+  if (!applyFlag) {
+    if (args.json) {
+      return {
+        exitCode: 0,
+        stdout: renderJson(
+          envelopeOk<CredsItem>([], {
+            subcommand: "grant",
+            request_id: args.requestId,
+            registry_url: registryUrl,
+            admin_fingerprint: material.fingerprint,
+            applied: "false",
+          }),
+        ),
+        stderr: "",
+      };
+    }
+    const lines = [
+      `cortex creds grant ${args.requestId}: dry-run (no registry write; pass --apply to execute)`,
+      `  registry:         ${registryUrl}`,
+      `  admin_fingerprint: ${material.fingerprint}`,
+      `  scope:            ${args.scope ?? "(from request's requested_scope)"}`,
+      `  operator_jwt:     ${args.operatorJwt ? `${args.operatorJwt.slice(0, 20)}…` : "(none — leaf package will be absent)"}`,
+      ...(args.discordMember ? [`  discord_member:   ${args.discordMember}`] : []),
+      ``,
+    ];
+    return { exitCode: 0, stdout: lines.join("\n"), stderr: "" };
+  }
+
+  // --- APPLY path ---
+
+  // 1. Fetch the PENDING request (admin-signed GET)
+  let request: IssuanceRequestClient;
+  try {
+    const adminReadHeader = await buildAdminReadHeader(material);
+    const getUrl = `${registryUrl.replace(/\/+$/, "")}/issuance-requests/${encodeURIComponent(args.requestId)}`;
+    const getResp = await globalThis.fetch(getUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "x-admin-signed": adminReadHeader,
+      },
+    });
+    if (getResp.status === 404) {
+      const reason = `request-id "${args.requestId}" not found in registry (HTTP 404)`;
+      if (args.json) {
+        return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant", request_id: args.requestId })), stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+    }
+    if (!getResp.ok) {
+      const body = await getResp.text();
+      const reason = `registry GET failed (HTTP ${getResp.status.toString()}): ${body}`;
+      if (args.json) {
+        return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant", request_id: args.requestId })), stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+    }
+    request = (await getResp.json()) as IssuanceRequestClient;
+  } catch (err) {
+    const reason = `failed to fetch request from registry: ${err instanceof Error ? err.message : String(err)}`;
+    if (args.json) {
+      return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant" })), stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+
+  // Validate request is PENDING — fail clearly if not
+  if (request.status !== "PENDING") {
+    const reason = `request "${args.requestId}" is not PENDING (status: ${request.status}) — cannot grant an already-decided request`;
+    if (args.json) {
+      return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant", request_id: args.requestId, status: request.status })), stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+
+  // 2. Issue scoped creds via arc (the existing creds-issue path)
+  // Resolve scope: explicit --scope flag > request's requested_scope
+  const rawScope = args.scope ?? request.requested_scope;
+  // Split on whitespace to support multiple subjects in --scope "sub1 sub2"
+  const scopeParts = rawScope.split(/\s+/).filter((s) => s.length > 0);
+  const scopeStr = scopeParts.join(",");
+
+  // Derive a usable agent-id from the principal_id for `arc nats add-bot`
+  // The principal_id is already a valid lower-kebab identifier.
+  const agentId = request.principal_id;
+
+  // Build arc argv — same pattern as runArcSubcommand
+  const arcArgv: string[] = [
+    "nats", "add-bot", agentId,
+    "--pub", scopeStr,
+    "--sub", scopeStr,
+  ];
+  if (args.account) arcArgv.push("--account", args.account);
+  arcArgv.push("--json");
+
+  const arcCall = await callArcNats(arcArgv);
+
+  if (arcCall.spawnError) {
+    const reason = `failed to invoke 'arc nats add-bot' — ${arcCall.spawnError}. Ensure arc (>= ${MIN_ARC_VERSION}) is installed and on PATH.`;
+    if (args.json) {
+      return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant" })), stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+
+  if (!arcCall.envelope) {
+    const reason = `arc returned no valid '${ARC_NATS_SCHEMA_V1}' envelope. Confirm arc >= ${MIN_ARC_VERSION} is installed and supports --json.`;
+    if (args.json) {
+      return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant" })), stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+
+  if (!arcCall.envelope.ok) {
+    const arcErr = arcCall.envelope as { ok: false; error: { code: string; message: string } };
+    const reason = `arc creds issue failed: ${arcErr.error.code}: ${arcErr.error.message}`;
+    if (args.json) {
+      return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant", arc_code: arcErr.error.code })), stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+
+  // Extract PUBLIC fields from the arc envelope — the secret .creds stays local
+  const arcSuccess = arcCall.envelope as { ok: true; bot: string; account: string; credsPath: string; jwt: string; pubKey: string };
+  const localCredsPath = arcSuccess.credsPath;
+  const issuedAccount = arcSuccess.account;
+  const issuedAccountJwt = arcSuccess.jwt;
+
+  // 3. Assemble the PUBLIC leaf package
+  // operatorJwt comes from --operator-jwt flag. Without it, leaf_package is absent
+  // (grant without a package is valid per O-4a.2 — leaf_package column stays null).
+  let leafPackage: GrantLeafPackageClient | undefined;
+  if (args.operatorJwt) {
+    leafPackage = {
+      operatorJwt: args.operatorJwt,
+      account: issuedAccount,
+      accountJwt: issuedAccountJwt,
+    };
+
+    // Validate before sending
+    const pkgErr = validateLeafPackage(leafPackage);
+    if (pkgErr) {
+      const reason = pkgErr;
+      if (args.json) {
+        return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant" })), stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+    }
+  }
+
+  // Safety: verify the package carries no secret material (belt-and-suspenders;
+  // the shape only has public fields, but if there's ever a future bug where
+  // credsPath bleeds in, catch it here).
+  if (leafPackage !== undefined) {
+    const pkgStr = JSON.stringify(leafPackage);
+    if (pkgStr.includes("credsPath") || pkgStr.includes(".creds")) {
+      const reason = "internal: leaf package contains secret field (credsPath) — refusing to POST";
+      process.stderr.write(`cortex creds grant: ${reason}\n`);
+      return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+    }
+  }
+
+  // 4. Sign + POST the grant
+  let grantBody: { claim: IssuanceDecisionClaimWithPackageClient; signature: string };
+  try {
+    grantBody = await buildGrantDecisionBody(args.requestId, material, leafPackage);
+  } catch (err) {
+    const reason = `failed to build grant decision claim: ${err instanceof Error ? err.message : String(err)}`;
+    if (args.json) {
+      return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant" })), stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+
+  let grantResponse: unknown;
+  try {
+    const postUrl = `${registryUrl.replace(/\/+$/, "")}/issuance-requests/${encodeURIComponent(args.requestId)}/grant`;
+    const postResp = await globalThis.fetch(postUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(grantBody),
+    });
+    grantResponse = await postResp.json();
+    if (!postResp.ok) {
+      const reason = `registry rejected grant (HTTP ${postResp.status.toString()}): ${JSON.stringify(grantResponse)}`;
+      if (args.json) {
+        return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant", request_id: args.requestId })), stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+    }
+  } catch (err) {
+    const reason = `registry POST failed: ${err instanceof Error ? err.message : String(err)}`;
+    if (args.json) {
+      return { exitCode: 1, stdout: renderJson(envelopeError<CredsItem>(reason, { subcommand: "grant" })), stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex creds grant: ${reason}\n` };
+  }
+
+  // 5. Assign Discord role (O-5) — when --discord-member is given
+  let discordStatus = "skipped";
+  let discordWarning = "";
+
+  if (args.discordMember) {
+    try {
+      // Resolve bot token + guild id from config/flags — mirrors discord.ts role add
+      const discordConfig = loadDiscordConfig();
+      const ctx = resolveServerContext(discordConfig, {
+        server: args.discordServer,
+        guild: args.discordGuild,
+      });
+
+      const botToken = ctx.botToken;
+      const guildId = ctx.guildId;
+
+      if (!botToken) {
+        discordWarning = "Discord role not assigned: no bot token configured (run: discord config set botToken <token>)";
+        discordStatus = "skipped_no_token";
+      } else if (!guildId) {
+        discordWarning = "Discord role not assigned: no guild id configured — pass --discord-guild <id> or run: discord config set guildId <id>";
+        discordStatus = "skipped_no_guild";
+      } else {
+        const roleName = args.discordRole ?? DEFAULT_DISCORD_ROLE;
+        let roleId: string;
+        try {
+          roleId = await resolveRoleId(botToken, guildId, roleName);
+        } catch (err) {
+          discordWarning = `Discord role not assigned: ${err instanceof Error ? err.message : String(err)} — assign manually`;
+          discordStatus = "failed";
+          roleId = "";
+        }
+
+        if (roleId) {
+          const roleResult = await assignRole(botToken, guildId, args.discordMember, roleId);
+          if (roleResult.success) {
+            discordStatus = "assigned";
+          } else {
+            discordWarning = `Discord role assignment failed: ${roleResult.error ?? "unknown error"} — grant already committed, assign role manually`;
+            discordStatus = "failed";
+          }
+        }
+      }
+    } catch (err) {
+      discordWarning = `Discord role assignment error: ${err instanceof Error ? err.message : String(err)} — grant already committed, assign role manually`;
+      discordStatus = "failed";
+    }
+  }
+
+  // 6. Output summary
+  if (args.json) {
+    const data: Record<string, string> = {
+      subcommand: "grant",
+      applied: "true",
+      request_id: args.requestId,
+      principal_id: request.principal_id,
+      scope: scopeStr,
+      creds_path: localCredsPath,
+      admin_fingerprint: material.fingerprint,
+      ...(discordStatus !== "skipped" && { discord_status: discordStatus }),
+    };
+    if (discordWarning) data.discord_warning = discordWarning;
+    return { exitCode: 0, stdout: renderJson(envelopeOk<CredsItem>([], data)), stderr: "" };
+  }
+
+  const lines: string[] = [
+    `cortex creds grant ${args.requestId}: granted`,
+    `  principal:       ${request.principal_id}`,
+    `  scope:           ${scopeStr}`,
+    `  creds_path:      ${localCredsPath}  (local — NOT sent to registry)`,
+    `  leaf_package:    ${leafPackage ? "posted to registry" : "none (no --operator-jwt)"}`,
+    `  admin:           ${material.fingerprint}`,
+  ];
+  if (args.discordMember) {
+    if (discordStatus === "assigned") {
+      lines.push(`  discord:         role "${args.discordRole ?? DEFAULT_DISCORD_ROLE}" assigned to member ${args.discordMember}`);
+    } else {
+      lines.push(`  discord:         ${discordWarning}`);
+    }
+  }
+  lines.push("");
+  return { exitCode: 0, stdout: lines.join("\n"), stderr: "" };
+}
+
+// =============================================================================
 // dispatchCreds
 // =============================================================================
 
@@ -735,6 +1343,8 @@ export async function dispatchCreds(argv: string[]): Promise<ExitResult> {
       return await runCredsRevoke(args);
     case "rotate":
       return await runCredsRotate(args);
+    case "grant":
+      return await runCredsGrant(args);
     case "help":
       return { exitCode: 0, stdout: topLevelHelp(), stderr: "" };
     case "unknown":
@@ -780,6 +1390,11 @@ Usage:
   cortex creds issue  <agent-id> [--account <name>] [--pub <subject>]... [--sub <subject>]... [--json]
   cortex creds revoke <agent-id> [--account <name>] [--json]
   cortex creds rotate <agent-id> [--account <name>] [--json]
+  cortex creds grant  <request-id> --admin-seed <path> [--operator-jwt <jwt>]
+                      [--scope <subjects>] [--registry-url <url>]
+                      [--discord-member <id>] [--discord-guild <id>]
+                      [--discord-server <profile>] [--discord-role <name>]
+                      [--apply] [--dry-run] [--json]
   cortex creds --help
 
 Subcommands:
@@ -787,6 +1402,10 @@ Subcommands:
   issue    Mint creds for an agent — shells out to \`arc nats add-bot\`
   revoke   Revoke creds — shells out to \`arc nats remove-bot --delete-creds\`
   rotate   Rotate creds — shells out to \`arc nats reissue-bot\`
+  grant    One-command admin grant act (G2, cortex#1118): fetch pending request,
+           issue scoped creds via arc, post the signed grant + public leaf package
+           to the registry, optionally assign the Discord community-fleet role.
+           DRY-RUN by default (pass --apply to execute).
 
 Per-subcommand options:
   list:    --creds-dir <path>   Directory containing .creds files (default: ~/.config/nats/creds)
@@ -810,6 +1429,57 @@ Exit codes:
   2    usage error (bad flag, bad agent id, missing positional)
 
 Requires: arc >= ${MIN_ARC_VERSION} on PATH.
+`;
+}
+
+function grantHelp(): string {
+  return `cortex creds grant — one-command admin grant act (G2, cortex#1118)
+
+Scripted form of the human grant: fetch the PENDING issuance request,
+issue scoped NATS credentials via arc, assemble the PUBLIC leaf package
+(no creds path or secret), sign + POST the grant to the registry, and
+optionally admit the peer to Discord (O-5 community-fleet role).
+
+Usage:
+  cortex creds grant <request-id> --admin-seed <path> [options]
+
+Required:
+  <request-id>                   Hex issuance request id (from the registry)
+  --admin-seed <path>            Path to the admin nkey seed file (SU…, chmod 600)
+
+Options:
+  --operator-jwt <jwt>           NSC operator JWT — included in the public leaf
+                                 package POSTed to the registry. Omit if you don't
+                                 want to supply the NSC operator JWT hint.
+  --scope <subjects>             Space-separated NATS subjects for pub/sub scope.
+                                 Defaults to the request's requested_scope.
+  --registry-url <url>           Registry base URL (default: https://network.meta-factory.ai)
+  --account <name>               NSC operator account name (passed to arc)
+  --discord-member <snowflake>   Discord user id to assign the community-fleet role
+  --discord-guild <id>           Discord guild id override
+  --discord-server <profile>     Named server profile from discord cli.yaml
+  --discord-role <name>          Role to assign (default: community-fleet)
+  --apply                        Execute the grant (default: dry-run)
+  --dry-run                      Force dry-run (default; mutually exclusive with --apply)
+  --json                         Emit structured JSON envelope
+
+Security guarantees:
+  - The .creds file produced by arc is LOCAL ONLY — it is NEVER sent to the
+    registry. Only public leaf package fields (JWTs, nkey-A account keys) go up.
+  - The admin seed is chmod-600 gated before any I/O.
+  - Dry-run (default) touches no registry and calls no arc.
+
+Partial success:
+  If the grant POST succeeds but the Discord role assignment fails, the command
+  exits 0 with a warning — the grant is already committed and CANNOT be rolled
+  back from here. The admin must assign the role manually.
+
+Exit codes:
+  0    success (or dry-run)
+  1    operational failure (registry error, arc failure, seed not readable)
+  2    usage error (missing positional, bad flags)
+
+Requires: arc >= ${MIN_ARC_VERSION} on PATH (for --apply).
 `;
 }
 


### PR DESCRIPTION
## Summary

- Adds `cortex creds grant <request-id>` — the admin one-command grant act for the O-4 onboarding pipeline
- 5-step orchestration: fetch PENDING request (admin-signed GET) → issue creds via arc → assemble PUBLIC leaf package → sign + POST `IssuanceDecisionClaimWithPackage` → optionally assign Discord `community-fleet` role
- Belt-and-suspenders no-secrets guarantee: `.creds` file stays local; a string-scan on the assembled payload blocks any `credsPath` or `.creds` from being POSTed
- Dry-run by default (`--apply` required to mutate); `--apply + --dry-run` is a usage error (exit 2)
- Partial-success on Discord role failure: exits 0 with warning (grant is already committed, cannot roll back)
- Admin seed loaded with `enforceChmod600` gate; PKCS#8 bridge reused from `stack-provisioning.ts`; Discord `resolveRoleId` + `assignRole` reused from `discord/lib/discord.ts`

## Test plan

- [x] 17 unit tests (TDD: RED → GREEN) — all mock registry HTTP, arc runner, Discord API
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/cli/cortex/` — 800 pass, 0 fail
- [x] `bun test src/` — 7244 pass, 0 fail
- [x] Carve-out check — PASS (two prose `operator` hits renamed to `admin` / `NSC operator JWT hint`)
- [x] `bunx eslint --quiet` — clean on touched files

Closes #1118
Refs #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)