### PR TITLE
feat(arc-upgrade): G3 — auto write-back nkey_pub to all 3 config sites

### DIFF
--- a/scripts/__tests__/stack-identity-provision-g3.sh
+++ b/scripts/__tests__/stack-identity-provision-g3.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# G3 (cortex#1119) — 3-site nkey_pub write-back tests.
+#
+# Guards the idempotent patching of ALL THREE nkey_pub sites in a stack config
+# after arc upgrade derives the real pubkey from the signing seed:
+#
+#   1. stack.nkey_pub
+#   2. policy.principals[<agent>].nkey_pub  (the agent signing identity, NOT the human)
+#   3. agents[*].nkey_pub
+#
+# Placeholder pattern: UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+# (56 chars, the NKEY_PUB_PLACEHOLDER emitted by `cortex stack create`).
+# Sites holding a REAL pubkey (different U…56 value) MUST NOT be clobbered.
+#
+# Run:
+#   bash scripts/__tests__/stack-identity-provision-g3.sh
+#
+# Exit code: 0 = all pass, non-zero = failure count.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PASS=0
+FAIL=0
+pass() { printf '  ✓ %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  ✗ %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+# The exact placeholder emitted by `cortex stack create` (NKEY_PUB_PLACEHOLDER).
+PLACEHOLDER="UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+# A synthetic real pubkey (different value, same valid format U + 55 base32 chars).
+REAL_PUB="UBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+# count_occurrences <file> <value>
+# Returns the number of nkey_pub lines in the file whose value equals <value>.
+count_nkey_occurrences() {
+  local config="$1"
+  local val="$2"
+  # Match lines of the form:  [whitespace]nkey_pub: VALUE[whitespace or end]
+  # Use grep -c with a fixed string that includes the key and value.
+  grep -c "nkey_pub: ${val}" "${config}" 2>/dev/null || true
+}
+
+# Build a minimal config-split stacks/<slug>.yaml that mirrors `cortex stack create` output.
+# $1 = dir prefix (e.g. /tmp/xxx/.config/cortex/<slug>)
+# $2 = agent id (e.g. ivy)
+# $3 = stack nkey_pub value (placeholder or real)
+# $4 = policy.principals[agent].nkey_pub value
+# $5 = agents[agent].nkey_pub value
+make_stack_config() {
+  local dir="$1" agent="$2" stack_pub="$3" policy_pub="$4" agent_pub="$5"
+  mkdir -p "${dir}/stacks"
+  cat > "${dir}/stacks/${agent}.yaml" <<YAML
+principal:
+  id: tester
+  displayName: Tester
+  discordId: "<REPLACE_ME>"
+
+stack:
+  id: tester/${agent}
+  nkey_seed_path: ~/.config/nats/cortex-${agent}-test.nk
+  nkey_pub: ${stack_pub}  # <REPLACE_ME>
+
+capabilities:
+  - id: chat
+    description: chat
+    provided_by: [${agent}]
+
+policy:
+  principals:
+    - id: ${agent}
+      home_principal: tester
+      home_stack: tester/${agent}
+      nkey_pub: ${policy_pub}  # <REPLACE_ME>
+      role:
+        - principal-role
+      trust: []
+      platform_ids: {}
+    - id: tester
+      home_principal: tester
+      home_stack: tester/${agent}
+      role:
+        - principal-role
+      trust: []
+      platform_ids:
+        discord:
+          - "<REPLACE_ME>"
+  roles:
+    - id: principal-role
+      capabilities:
+        - chat
+
+agents:
+  - id: ${agent}
+    displayName: "${agent}"
+    persona: ./personas/${agent}.md
+    nkey_pub: ${agent_pub}  # <REPLACE_ME>
+    roles: []
+    trust: []
+    runtime:
+      substrate: claude-code
+      mode: in-process
+      capabilities:
+        - chat
+    presence: {}
+YAML
+}
+
+# ─── Case 1: fresh stack — all 3 sites hold placeholder → all 3 get patched ──
+printf '\n=== Case 1: all 3 sites hold placeholder → all 3 patched ===\n'
+TH1="$(mktemp -d)"
+make_stack_config "${TH1}/.config/cortex/ivy" "ivy" \
+  "${PLACEHOLDER}" "${PLACEHOLDER}" "${PLACEHOLDER}"
+
+mkdir -p "${TH1}/.config/nats"
+HOME="${TH1}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; generate_nkey_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  >/dev/null 2>&1
+
+REAL_PUB_1="$(HOME="${TH1}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; derive_pubkey_from_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  2>/dev/null || echo '')"
+
+if [ -z "${REAL_PUB_1}" ]; then
+  printf '  ⓘ skip Case 1: bun/nkeys.js not available — cannot derive pubkey\n'
+else
+  HOME="${TH1}" bash -c \
+    "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; provision_stack_identity \"\${HOME}/.config/cortex/ivy/stacks/ivy.yaml\" cortex-ivy-test" \
+    >/dev/null 2>&1 || true
+
+  CONFIG="${TH1}/.config/cortex/ivy/stacks/ivy.yaml"
+
+  # Verify: all 3 placeholder occurrences should be gone (0 left).
+  placeholder_left="$(count_nkey_occurrences "${CONFIG}" "${PLACEHOLDER}")"
+  if [ "${placeholder_left}" -eq 0 ]; then
+    pass "Case 1: no placeholder values remain in config after patch"
+  else
+    fail "Case 1: ${placeholder_left} placeholder value(s) still present (want 0)"
+  fi
+
+  # Verify: the real pubkey appears exactly 3 times (stack + policy agent + agents[]).
+  real_count="$(count_nkey_occurrences "${CONFIG}" "${REAL_PUB_1}")"
+  if [ "${real_count}" -eq 3 ]; then
+    pass "Case 1: real pubkey appears exactly 3 times (all 3 sites patched)"
+  else
+    fail "Case 1: real pubkey appears ${real_count} time(s) (want 3)"
+  fi
+
+  # Verify: the human principal entry (id: tester) does NOT have nkey_pub inserted.
+  # The config template has no nkey_pub on the human entry — should still be absent.
+  total_nkey_lines="$(grep -c 'nkey_pub:' "${CONFIG}" 2>/dev/null || true)"
+  if [ "${total_nkey_lines}" -eq 3 ]; then
+    pass "Case 1: exactly 3 nkey_pub lines total (human principal not touched)"
+  else
+    fail "Case 1: found ${total_nkey_lines} nkey_pub lines (want 3)"
+  fi
+
+  # Backup was created.
+  backup_count="$(find "${TH1}/.config/cortex/ivy/stacks" -name '*.pre-stack-identity-*' | wc -l | tr -d ' ')"
+  if [ "${backup_count}" -ge 1 ]; then
+    pass "Case 1: backup created before edit"
+  else
+    fail "Case 1: no backup created"
+  fi
+fi
+rm -rf "${TH1}"
+
+# ─── Case 2: real pubkey already in place → not clobbered ──
+printf '\n=== Case 2: real pubkey site not clobbered (mixed-state) ===\n'
+# Mixed-state: stack.nkey_pub = placeholder, policy + agent have real pubkey.
+# Only stack.nkey_pub should be replaced; the other two must survive.
+TH2="$(mktemp -d)"
+make_stack_config "${TH2}/.config/cortex/ivy" "ivy" \
+  "${PLACEHOLDER}" "${REAL_PUB}" "${REAL_PUB}"
+mkdir -p "${TH2}/.config/nats"
+HOME="${TH2}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; generate_nkey_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  >/dev/null 2>&1
+
+REAL_PUB_2="$(HOME="${TH2}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; derive_pubkey_from_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  2>/dev/null || echo '')"
+
+if [ -z "${REAL_PUB_2}" ]; then
+  printf '  ⓘ skip Case 2: bun not available\n'
+else
+  HOME="${TH2}" bash -c \
+    "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; provision_stack_identity \"\${HOME}/.config/cortex/ivy/stacks/ivy.yaml\" cortex-ivy-test" \
+    >/dev/null 2>&1 || true
+
+  CONFIG2="${TH2}/.config/cortex/ivy/stacks/ivy.yaml"
+
+  # No placeholder should remain.
+  placeholder_left2="$(count_nkey_occurrences "${CONFIG2}" "${PLACEHOLDER}")"
+  if [ "${placeholder_left2}" -eq 0 ]; then
+    pass "Case 2: no placeholder values remain (stack.nkey_pub was patched)"
+  else
+    fail "Case 2: ${placeholder_left2} placeholder(s) still present"
+  fi
+
+  # The REAL_PUB (pre-existing) values should still be there — 2 occurrences.
+  real_pre_count="$(count_nkey_occurrences "${CONFIG2}" "${REAL_PUB}")"
+  if [ "${real_pre_count}" -eq 2 ]; then
+    pass "Case 2: pre-existing real pubkey kept in 2 sites (not clobbered)"
+  else
+    fail "Case 2: pre-existing real pubkey count = ${real_pre_count} (want 2)"
+  fi
+
+  # The derived pubkey (for stack.nkey_pub) should appear exactly 1 time.
+  real_new_count="$(count_nkey_occurrences "${CONFIG2}" "${REAL_PUB_2}")"
+  if [ "${real_new_count}" -eq 1 ]; then
+    pass "Case 2: stack.nkey_pub patched to derived pubkey (1 occurrence)"
+  else
+    fail "Case 2: derived pubkey count = ${real_new_count} (want 1)"
+  fi
+fi
+rm -rf "${TH2}"
+
+# ─── Case 3: human principal entry nkey_pub NOT inserted ──
+printf '\n=== Case 3: human principal (no nkey_pub) not touched ===\n'
+TH3="$(mktemp -d)"
+make_stack_config "${TH3}/.config/cortex/ivy" "ivy" \
+  "${PLACEHOLDER}" "${PLACEHOLDER}" "${PLACEHOLDER}"
+mkdir -p "${TH3}/.config/nats"
+HOME="${TH3}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; generate_nkey_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  >/dev/null 2>&1
+
+REAL_PUB_3="$(HOME="${TH3}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; derive_pubkey_from_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  2>/dev/null || echo '')"
+
+if [ -z "${REAL_PUB_3}" ]; then
+  printf '  ⓘ skip Case 3: bun not available\n'
+else
+  HOME="${TH3}" bash -c \
+    "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; provision_stack_identity \"\${HOME}/.config/cortex/ivy/stacks/ivy.yaml\" cortex-ivy-test" \
+    >/dev/null 2>&1 || true
+
+  CONFIG3="${TH3}/.config/cortex/ivy/stacks/ivy.yaml"
+
+  # Count total nkey_pub lines — should be exactly 3 (stack, policy[ivy], agents[ivy]).
+  # The human principal (id: tester) has no nkey_pub field in the template.
+  nkey_pub_count="$(grep -c 'nkey_pub:' "${CONFIG3}" || true)"
+  if [ "${nkey_pub_count}" -eq 3 ]; then
+    pass "Case 3: exactly 3 nkey_pub entries (human principal not touched)"
+  else
+    fail "Case 3: found ${nkey_pub_count} nkey_pub entries (want 3)"
+  fi
+fi
+rm -rf "${TH3}"
+
+# ─── Case 4: config with valid pubkey already — no-op ──
+printf '\n=== Case 4: all 3 sites already hold real pubkey → no-op ===\n'
+TH4="$(mktemp -d)"
+# All 3 sites have the same real pubkey (not the placeholder).
+make_stack_config "${TH4}/.config/cortex/ivy" "ivy" \
+  "${REAL_PUB}" "${REAL_PUB}" "${REAL_PUB}"
+mkdir -p "${TH4}/.config/nats"
+HOME="${TH4}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; generate_nkey_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  >/dev/null 2>&1
+
+REAL_PUB_4="$(HOME="${TH4}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; derive_pubkey_from_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  2>/dev/null || echo '')"
+
+if [ -z "${REAL_PUB_4}" ]; then
+  printf '  ⓘ skip Case 4: bun not available\n'
+else
+  before4="$(cat "${TH4}/.config/cortex/ivy/stacks/ivy.yaml")"
+
+  HOME="${TH4}" bash -c \
+    "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; provision_stack_identity \"\${HOME}/.config/cortex/ivy/stacks/ivy.yaml\" cortex-ivy-test" \
+    >/dev/null 2>&1 || true
+
+  after4="$(cat "${TH4}/.config/cortex/ivy/stacks/ivy.yaml")"
+
+  # All 3 sites hold REAL_PUB (not the placeholder) — no patching should occur.
+  if [ "${before4}" = "${after4}" ]; then
+    pass "Case 4: config unchanged when all sites already hold real pubkey"
+  else
+    fail "Case 4: config was modified even though no placeholders present"
+  fi
+fi
+rm -rf "${TH4}"
+
+# ─── Case 5: re-run after patching → fully idempotent ──
+printf '\n=== Case 5: second run after patch → idempotent ===\n'
+TH5="$(mktemp -d)"
+make_stack_config "${TH5}/.config/cortex/ivy" "ivy" \
+  "${PLACEHOLDER}" "${PLACEHOLDER}" "${PLACEHOLDER}"
+mkdir -p "${TH5}/.config/nats"
+HOME="${TH5}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; generate_nkey_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  >/dev/null 2>&1
+
+REAL_PUB_5="$(HOME="${TH5}" bash -c \
+  "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; derive_pubkey_from_seed \"\${HOME}/.config/nats/cortex-ivy-test.nk\"" \
+  2>/dev/null || echo '')"
+
+if [ -z "${REAL_PUB_5}" ]; then
+  printf '  ⓘ skip Case 5: bun not available\n'
+else
+  # First run.
+  HOME="${TH5}" bash -c \
+    "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; provision_stack_identity \"\${HOME}/.config/cortex/ivy/stacks/ivy.yaml\" cortex-ivy-test" \
+    >/dev/null 2>&1 || true
+
+  config5="${TH5}/.config/cortex/ivy/stacks/ivy.yaml"
+  after_first="$(cat "${config5}")"
+  backup_count_after_first="$(find "${TH5}/.config/cortex/ivy/stacks" -name '*.pre-stack-identity-*' | wc -l | tr -d ' ')"
+
+  # Second run — seed file already exists, declared in config → early-return path.
+  HOME="${TH5}" bash -c \
+    "source '${SCRIPT_DIR}/lib/stack-identity-provision.sh'; provision_stack_identity \"\${HOME}/.config/cortex/ivy/stacks/ivy.yaml\" cortex-ivy-test" \
+    >/dev/null 2>&1 || true
+
+  after_second="$(cat "${config5}")"
+  backup_count_after_second="$(find "${TH5}/.config/cortex/ivy/stacks" -name '*.pre-stack-identity-*' | wc -l | tr -d ' ')"
+
+  if [ "${after_first}" = "${after_second}" ]; then
+    pass "Case 5: second run left config unchanged (idempotent)"
+  else
+    fail "Case 5: second run modified the config"
+  fi
+
+  if [ "${backup_count_after_second}" -eq "${backup_count_after_first}" ]; then
+    pass "Case 5: no extra backup created on second run"
+  else
+    fail "Case 5: backup count grew from ${backup_count_after_first} to ${backup_count_after_second} on second run"
+  fi
+fi
+rm -rf "${TH5}"
+
+printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/scripts/lib/stack-identity-provision.sh
+++ b/scripts/lib/stack-identity-provision.sh
@@ -15,6 +15,14 @@
 #      none exists.
 #   4. Idempotent: skipped entirely if `stack.nkey_seed_path` is already
 #      declared in the file.
+#   5. G3 (cortex#1119): once the real pubkey is derived, idempotently
+#      writes it back to ALL THREE config sites that need it:
+#        a. stack.nkey_pub
+#        b. policy.principals[<agent>].nkey_pub  (the signing identity)
+#        c. agents[*].nkey_pub
+#      Only placeholder values (UAAA…56 chars) are overwritten; a real
+#      pubkey already in place is left untouched. Every patch + skip is
+#      logged explicitly.
 #
 # Backup: before any edit, the script copies the config to
 # `${config}.pre-stack-identity-$(date +%Y%m%dT%H%M%S)`. Principal can roll
@@ -92,6 +100,133 @@ derive_pubkey_from_seed() {
   " 2>/dev/null
 }
 
+# G3 (cortex#1119) — idempotently write the real U-prefixed pubkey back to
+# all three config sites that reference it.
+#
+# Strategy:
+#   • Only patches lines whose nkey_pub value is the all-A placeholder
+#     (UAAAA…56 chars). A different U-prefixed value is treated as a real
+#     key already in place and is left untouched.
+#   • Targets precisely:
+#       1. stack.nkey_pub        (inside the top-level `stack:` block)
+#       2. policy.principals[x].nkey_pub  (agent signing entries — those that
+#          HAVE a nkey_pub line; human principals typically have none)
+#       3. agents[*].nkey_pub   (every agent entry that has an nkey_pub line)
+#   • Backs up the config before any edit (reuses the caller's backup if
+#     already taken; this function creates its own if called independently).
+#   • Logs each patched site AND each skipped site (already real).
+#   • Never writes if pubkey is empty — caller must guard that.
+#
+# Args:
+#   $1 config file path
+#   $2 real U-prefixed pubkey (56-char base32)
+#   $3 backup flag: "backup" (default) or "no-backup" when caller already
+#      created one.
+#
+# Returns 0 always (best-effort; failures are logged, not fatal).
+#
+# The placeholder emitted by `cortex stack create` (NKEY_PUB_PLACEHOLDER):
+#   UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+# It is a valid-FORMAT 56-char all-A nkey that parses at load but is
+# semantically meaningless. Matching this exact value (U + 55 × A) is the
+# safe sentinel: real pubkeys generated from actual seeds will differ.
+readonly _NKEY_PLACEHOLDER="UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+patch_nkey_pub_sites() {
+  local config="$1"
+  local pubkey="$2"
+  local backup_flag="${3:-backup}"
+
+  [ -f "${config}" ] || return 0
+  [ -n "${pubkey}" ] || return 0
+
+  # Validate pubkey format: U + exactly 55 uppercase base32 chars.
+  if ! printf '%s' "${pubkey}" | grep -qE '^U[A-Z2-7]{55}$'; then
+    echo "  ⚠ patch_nkey_pub_sites: pubkey '${pubkey}' does not match U[A-Z2-7]{55} — skipping" >&2
+    return 0
+  fi
+
+  # Check whether any placeholder sites exist at all. If not, nothing to do.
+  local placeholder_count
+  placeholder_count="$(grep -c "${_NKEY_PLACEHOLDER}" "${config}" 2>/dev/null || true)"
+  if [ "${placeholder_count}" -eq 0 ]; then
+    echo "  ⊘ No placeholder nkey_pub values found in ${config##*/} — all sites already set"
+    return 0
+  fi
+
+  # Backup before edit (skip if caller already created one).
+  if [ "${backup_flag}" != "no-backup" ]; then
+    local backup
+    backup="${config}.pre-stack-identity-$(date +%Y%m%dT%H%M%S)"
+    cp "${config}" "${backup}"
+    echo "  ✓ Config backup → ${backup##*/}"
+  fi
+
+  # G3 patch strategy: replace ALL occurrences of the placeholder on `nkey_pub:`
+  # lines. The placeholder is the exact 56-char all-A value emitted by
+  # `cortex stack create` — it is semantically unique and cannot legitimately
+  # appear in any other context (it is an invalid-key-material value used solely
+  # as a FORMAT placeholder so the config file passes schema validation before the
+  # real key is provisioned). Any nkey_pub line carrying a DIFFERENT U-prefixed
+  # value is left untouched (it is either a real key or a legitimately distinct
+  # placeholder the operator supplied).
+  #
+  # Implementation: awk in record-per-line mode. For each line, if it is a
+  # `nkey_pub:` line whose first value token equals the placeholder, swap in
+  # the real pubkey while preserving leading whitespace and any trailing inline
+  # comment. All other lines (including nkey_pub lines with real keys) pass
+  # through unchanged.
+  #
+  # Note: we write the awk program to a tmpfile instead of passing it inline to
+  # avoid bash's heredoc/single-quote parser misidentifying $0 and function-call
+  # syntax as shell constructs when the script is sourced in strict mode.
+  local awkprog
+  awkprog="$(mktemp)"
+  # Write awk program as a separate file — avoids bash single-quote parse issues.
+  printf '%s\n' \
+    'BEGIN { patched = 0; skipped = 0 }' \
+    '/^[[:space:]]*nkey_pub:[[:space:]]/ {' \
+    '  # Extract the value token (first non-whitespace token after "nkey_pub: ").'\
+    '  val = $0' \
+    '  sub(/^[[:space:]]*nkey_pub:[[:space:]]*/, "", val)' \
+    '  # Strip inline comment and trailing whitespace to get the bare value.' \
+    '  gsub(/[[:space:]].*$/, "", val)' \
+    '  if (val == placeholder) {' \
+    '    # Preserve leading whitespace (indent) from the original line.' \
+    '    lead = $0' \
+    '    sub(/nkey_pub:.*$/, "", lead)' \
+    '    # Preserve any trailing inline comment (everything after the value token).' \
+    '    comment = $0' \
+    '    sub(/^[[:space:]]*nkey_pub:[[:space:]]*[^[:space:]]+/, "", comment)' \
+    '    printf "%snkey_pub: %s%s\n", lead, pub, comment' \
+    '    patched++' \
+    '    print "  [G3] patch: nkey_pub " val " patched" | "cat >&2"' \
+    '  } else {' \
+    '    print' \
+    '    skipped++' \
+    '    print "  [G3] skip:  nkey_pub " val " (real key — left untouched)" | "cat >&2"' \
+    '  }' \
+    '  next' \
+    '}' \
+    '{ print }' \
+    'END {' \
+    '  if (patched > 0 || skipped > 0) {' \
+    '    msg = "  [G3] summary: " patched " site(s) patched"' \
+    '    if (skipped > 0) msg = msg ", " skipped " already real (left untouched)"' \
+    '    print msg | "cat >&2"' \
+    '  }' \
+    '}' \
+    > "${awkprog}"
+
+  local tmpfile
+  tmpfile="$(mktemp)"
+  awk -v pub="${pubkey}" -v placeholder="${_NKEY_PLACEHOLDER}" -f "${awkprog}" "${config}" > "${tmpfile}"
+  rm -f "${awkprog}"
+  mv "${tmpfile}" "${config}"
+
+  echo "  ✓ G3 nkey_pub write-back complete (${placeholder_count} placeholder(s) replaced in ${config##*/})"
+}
+
 # Generate a fresh SU-prefixed NKey at the given path, chmod 600.
 # Returns 0 on success, 1 if nsc is not installed (caller skips).
 generate_nkey_seed() {
@@ -160,6 +295,15 @@ provision_stack_identity() {
     declared_seed="$(nkey_path_for "${nkey_basename}")"
     if [ -f "${declared_seed}" ]; then
       echo "  ⊘ Stack identity configured + seed file present in ${config##*/}"
+      # G3 (cortex#1119): seed is present but placeholder nkey_pub values may
+      # still be in the config (e.g. after `cortex stack create` + first arc
+      # upgrade that generated the seed but predates G3). Derive the pubkey and
+      # write it back to any placeholder sites — idempotent if already correct.
+      local existing_pub
+      existing_pub="$(derive_pubkey_from_seed "${declared_seed}" || true)"
+      if [ -n "${existing_pub}" ]; then
+        patch_nkey_pub_sites "${config}" "${existing_pub}"
+      fi
       return 0
     fi
     echo "  ⊕ ${config##*/} declares nkey_seed_path but the seed file is missing — generating at ${declared_seed} (cortex#1101)..."
@@ -171,7 +315,12 @@ provision_stack_identity() {
     local declared_pub
     declared_pub="$(derive_pubkey_from_seed "${declared_seed}" || true)"
     if [ -n "${declared_pub}" ]; then
-      echo "    Pin this into ${config##*/} stack.nkey_pub (replacing the placeholder): ${declared_pub}"
+      # G3 (cortex#1119): write the real pubkey back to all 3 config sites.
+      # The config already carries nkey_seed_path — we only patch nkey_pub
+      # placeholder values; the seed path wiring is already correct.
+      patch_nkey_pub_sites "${config}" "${declared_pub}"
+    else
+      echo "    ⓘ Could not derive pubkey from ${declared_seed##*/}; cortex will log it at boot."
     fi
     return 0
   fi
@@ -270,6 +419,10 @@ provision_stack_identity() {
   mv "${tmpfile}" "${config}"
   if [ -n "${pubkey}" ]; then
     echo "  ✓ Stack identity wired: nkey_seed_path + nkey_pub (${pubkey:0:8}…)"
+    # G3 (cortex#1119): the awk above wired stack.nkey_pub. Now patch the two
+    # remaining sites (policy.principals[].nkey_pub and agents[].nkey_pub).
+    # The backup was already taken above — pass "no-backup" to avoid a second one.
+    patch_nkey_pub_sites "${config}" "${pubkey}" "no-backup"
   else
     echo "  ✓ Stack identity wired: nkey_seed_path (nkey_pub will be logged at next boot)"
   fi


### PR DESCRIPTION
## Summary

- Kills the silent-failure edge in stack identity provisioning: after `arc upgrade` generates the signing seed, the real `U…56` pubkey is now **automatically written back** to all three config sites that need it — `stack.nkey_pub`, `policy.principals[<agent>].nkey_pub`, `agents[*].nkey_pub`
- Previously the pubkey was only logged ("Pin this into…") and required a manual copy-paste to three sites; missing one caused silent envelope signature verification failures
- New function `patch_nkey_pub_sites` handles both provision paths (declared+existing seed, declared+missing seed, legacy monolith path); safe sentinel — only the all-A `UAAA…` placeholder is replaced, real pubkeys are never touched

## Design

**3-site write-back (`patch_nkey_pub_sites`)**
- Detects placeholder via exact match on `UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA` (56 chars) — the `NKEY_PUB_PLACEHOLDER` emitted by `cortex stack create`
- Replaces ALL matching `nkey_pub:` lines in one awk pass, preserving indent + inline comment
- Backed by tmpfile awk invocation to avoid bash single-quote parser misidentification of `$0` in strict-source mode
- Idempotent: `grep -c` pre-check skips files with no placeholders; second run sees no placeholders, returns immediately with no backup created

**Wired into 3 code paths in `provision_stack_identity`:**
1. Declared seed path + file present (⊘ path): derives pubkey from existing seed → patches
2. Declared seed path + file missing (cortex#1101 path): generates seed → derives pubkey → patches
3. No declared seed path (legacy awk rewrite path): existing awk wires `stack.nkey_pub`; new call patches the remaining 2 sites after

## Test plan
- [x] `bash scripts/__tests__/stack-identity-provision-g3.sh` — 11 assertions, 5 cases (all pass)
- [x] `bash scripts/__tests__/stack-identity-provision.sh` — 5 existing regression tests (all pass)
- [x] `bunx tsc --noEmit` — clean (all errors pre-existing, count matches main)
- [x] `bun test src/` — `3373 pass, 216 fail, 197 errors` (identical to main — no regressions)
- [x] carve-out gate — PASS
- [x] `bunx eslint --quiet` — no TS files touched

Closes #1119
Refs #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)