### PR TITLE
feat(registry): G1a — hub_account on the signed network descriptor + network create --hub-account

### DIFF
--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -462,6 +462,9 @@ export async function buildRegistrationClaim(
  * (`src/services/network-registry/src/validate.ts`). Reproduced rather than
  * imported because the registry is a separately-bundled CF Worker excluded
  * from the root tsconfig. MUST stay field-compatible with the route validator.
+ *
+ * G1a (cortex#1117): hub_account is optional — absent = back-compat
+ * (existing calls that omit it continue to work exactly as before).
  */
 export interface NetworkCreateClaimShape {
   network_id: string;
@@ -470,6 +473,11 @@ export interface NetworkCreateClaimShape {
   admin_pubkey: string;
   issued_at: string;
   nonce: string;
+  /**
+   * G1a: optional nkey-U account pubkey (`A…`). When present it is included
+   * in the signed canonical-JSON so the registry's `verifyEd25519` covers it.
+   */
+  hub_account?: string;
 }
 
 /** A network-create claim + detached signature, ready to POST. */
@@ -485,6 +493,12 @@ export interface BuildNetworkCreateClaimOptions {
   readonly leafPort: number;
   /** The admin identity material (carries the seed to sign with). */
   readonly material: StackIdentityMaterial;
+  /**
+   * G1a (cortex#1117): optional nkey-U hub account pubkey (`A…`).
+   * When supplied it is included in the signed claim (tamper-evident, DD-9).
+   * Absent = back-compat: claim has no hub_account field.
+   */
+  readonly hubAccount?: string;
   /** Override issued-at (tests / skew checks). Defaults to now. @internal */
   readonly issuedAt?: string;
   /** Override nonce (tests). Defaults to a fresh random hex. @internal */
@@ -502,6 +516,9 @@ export interface BuildNetworkCreateClaimOptions {
 export async function buildNetworkCreateClaim(
   opts: BuildNetworkCreateClaimOptions,
 ): Promise<SignedNetworkCreateBody> {
+  // Build the claim — omit hub_account entirely when not provided so the
+  // canonical-JSON bytes are identical to what a pre-G1a CLI would have
+  // signed (back-compat: the registry validator treats absent = ok).
   const claim: NetworkCreateClaimShape = {
     network_id: opts.networkId,
     hub_url: opts.hubUrl,
@@ -509,6 +526,7 @@ export async function buildNetworkCreateClaim(
     admin_pubkey: opts.material.pubkeyB64,
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
+    ...(opts.hubAccount !== undefined && { hub_account: opts.hubAccount }),
   };
   // Re-derive the KeyPair from the in-memory seed and sign over the SAME
   // canonical-JSON the registry route reconstructs and verifies.

--- a/src/cli/cortex/commands/__tests__/network-create-hub-account.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-create-hub-account.test.ts
@@ -1,0 +1,198 @@
+/**
+ * G1a — cortex network create --hub-account <A…> CLI tests (cortex#1117).
+ *
+ * Coverage:
+ *   1. --hub-account absent → claim has no hub_account field (back-compat).
+ *   2. --hub-account valid  → claim includes it; registry stores + returns it.
+ *   3. --hub-account malformed → usage error, exit 2, no registry I/O.
+ *   4. --apply with hub_account → registry accepts; GET descriptor returns it.
+ */
+
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { dispatchNetwork } from "../network";
+import { dispatchProvisionStack } from "../provision-stack";
+
+import registryApp from "../../../../services/network-registry/src/index";
+import type { Env } from "../../../../services/network-registry/src/index";
+import {
+  makeRegistryKey,
+  resetStores,
+} from "../../../../services/network-registry/__tests__/helpers";
+import type { NetworkDescriptor, SignedAssertion } from "../../../../services/network-registry/src/types";
+
+// A syntactically valid nkey-U account pubkey (A + 55 uppercase base32 chars).
+// Total length = 56 chars. Satisfies /^A[A-Z2-7]{55}$/.
+const VALID_HUB_ACCOUNT = "ACGYOGQ7OL6E6ZP6XFNGHPUWTYZ7CHOSZMFMZKYNUAMBYMDB7VK5NVDQ";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "g1a-create-cli-"));
+  tmpDirs.push(d);
+  return d;
+}
+
+async function mintAdminSeed(): Promise<{ seedPath: string; adminPubkey: string }> {
+  const seedPath = join(freshDir(), "admin.nk");
+  const res = await dispatchProvisionStack([
+    "generate",
+    "andreas",
+    "--seed-path",
+    seedPath,
+    "--json",
+  ]);
+  expect(res.exitCode).toBe(0);
+  const env = JSON.parse(res.stdout) as { data: { pubkey_b64: string } };
+  return { seedPath, adminPubkey: env.data.pubkey_b64 };
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  resetStores();
+});
+
+// =============================================================================
+// Back-compat: no --hub-account
+// =============================================================================
+
+describe("create without --hub-account (back-compat)", () => {
+  test("dry-run claim has no hub_account field", async () => {
+    const { seedPath } = await mintAdminSeed();
+
+    globalThis.fetch = (() => {
+      throw new Error("dry-run must not perform network I/O");
+    }) as unknown as typeof globalThis.fetch;
+
+    const res = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub.meta-factory.ai:7422",
+      "--leaf-port", "7422",
+      "--admin-seed", seedPath,
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as {
+      items: { claim: Record<string, unknown> }[];
+    };
+    const claim = env.items[0]!.claim;
+    // hub_account must not be present when the flag is not passed
+    expect(claim.hub_account).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// --hub-account valid
+// =============================================================================
+
+describe("create with --hub-account (valid)", () => {
+  test("dry-run claim includes hub_account", async () => {
+    const { seedPath } = await mintAdminSeed();
+
+    globalThis.fetch = (() => {
+      throw new Error("dry-run must not perform network I/O");
+    }) as unknown as typeof globalThis.fetch;
+
+    const res = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub.meta-factory.ai:7422",
+      "--leaf-port", "7422",
+      "--admin-seed", seedPath,
+      "--hub-account", VALID_HUB_ACCOUNT,
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as {
+      items: { claim: Record<string, unknown> }[];
+    };
+    expect(parsed.items[0]!.claim.hub_account).toBe(VALID_HUB_ACCOUNT);
+  });
+
+  test("--apply stores hub_account; GET descriptor returns it", async () => {
+    const { seedPath, adminPubkey } = await mintAdminSeed();
+    const reg = await makeRegistryKey();
+
+    let registryEnv: Env = {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      REGISTRY_ADMIN_PUBKEYS: adminPubkey,
+      ENVIRONMENT: "test",
+    };
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, registryEnv);
+    }) as typeof globalThis.fetch;
+
+    // POST with hub_account
+    const createRes = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub.meta-factory.ai:7422",
+      "--leaf-port", "7422",
+      "--admin-seed", seedPath,
+      "--hub-account", VALID_HUB_ACCOUNT,
+      "--registry-url", "https://network.test",
+      "--apply",
+    ]);
+    expect(createRes.exitCode).toBe(0);
+
+    // Verify GET returns hub_account in descriptor
+    const getRes = await registryApp.fetch(
+      new Request("http://network.test/networks/research-collab"),
+      registryEnv,
+    );
+    expect(getRes.status).toBe(200);
+    const desc = (await getRes.json()) as SignedAssertion<NetworkDescriptor & { hub_account?: string }>;
+    expect(desc.payload.hub_account).toBe(VALID_HUB_ACCOUNT);
+  });
+});
+
+// =============================================================================
+// --hub-account malformed → validation error, exit 2
+// =============================================================================
+
+describe("create with --hub-account (malformed)", () => {
+  test("empty string → usage error (exit 2)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const res = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub:7422",
+      "--leaf-port", "7422",
+      "--admin-seed", seedPath,
+      "--hub-account", "",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("hub-account");
+  });
+
+  test("S-prefix (seed not pubkey) → usage error (exit 2)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const seedLike = "SCGYOGQ7OL6E6ZP6XFNGHPUWTYZ7CHOSZMFMZKYNUAMBYMDB7VK5NVDQ";
+    const res = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub:7422",
+      "--leaf-port", "7422",
+      "--admin-seed", seedPath,
+      "--hub-account", seedLike,
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("hub-account");
+  });
+
+  test("too short → usage error (exit 2)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const res = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub:7422",
+      "--leaf-port", "7422",
+      "--admin-seed", seedPath,
+      "--hub-account", "ASHORT",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("hub-account");
+  });
+});

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -66,6 +66,8 @@ import {
   type LeafPackageFile,
 } from "./network-leaf-package";
 
+import { isNkeyAccountPubkey } from "../../../common/nats/leaf-remote-renderer";
+
 /**
  * #753 — the production config reader: `loadConfigWithAgents` wrapped so a
  * MISSING cortex.yaml is benign (a fully-flagged back-compat invocation works
@@ -252,6 +254,8 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--registry-url": "value",
         "--apply": "bool",
         "--dry-run": "bool",
+        // G1a (cortex#1117): optional nkey-U hub account pubkey.
+        "--hub-account": "value",
       },
     },
     // signal#113 P-11 (#56) — active federated reachability probe. Fires a
@@ -964,6 +968,21 @@ async function runCreate(
   const applyRes = resolveApply(flags);
   if (!applyRes.ok) return usageError("create", applyRes.reason, json);
 
+  // G1a (cortex#1117): --hub-account is OPTIONAL. When present it must be
+  // a valid nkey-U account pubkey (/^A[A-Z2-7]{55}$/) — validate locally
+  // before POSTing so the user sees a clear error immediately (exit 2), not
+  // the registry's 400 after a network round-trip.
+  const rawHubAccount = optionalValueFlag(flags, "--hub-account");
+  if (rawHubAccount !== undefined) {
+    if (rawHubAccount.length === 0 || !isNkeyAccountPubkey(rawHubAccount)) {
+      return usageError(
+        "create",
+        `--hub-account "${rawHubAccount}" must be a NATS nkey-U account pubkey (A + 55 uppercase base32 chars, e.g. A…)`,
+        json,
+      );
+    }
+  }
+
   const registryUrl = optionalValueFlag(flags, "--registry-url") ?? DEFAULT_REGISTRY_URL;
 
   // Load the admin nkey seed + derive its base64 pubkey (the SAME key shape +
@@ -978,6 +997,9 @@ async function runCreate(
       hubUrl,
       leafPort,
       material: matRes.material,
+      // G1a: only pass when present so the claim is identical to pre-G1a
+      // for callers that don't supply --hub-account (back-compat).
+      ...(rawHubAccount !== undefined && { hubAccount: rawHubAccount }),
     });
   } catch (err) {
     return opError("create", `failed to build network-create claim: ${err instanceof Error ? err.message : String(err)}`, json);
@@ -1002,6 +1024,7 @@ async function runCreate(
       `  registry:     ${registryUrl}`,
       `  hub_url:      ${hubUrl}`,
       `  leaf_port:    ${leafPort.toString()}`,
+      ...(rawHubAccount !== undefined ? [`  hub_account:  ${rawHubAccount}`] : []),
       `  admin_pubkey: ${matRes.material.pubkeyB64}`,
       `  fingerprint:  ${matRes.material.fingerprint}`,
       ``,
@@ -1043,7 +1066,9 @@ async function runCreate(
   }
   return ok(
     `cortex network create ${networkId}: created/updated at ${registryUrl} (HTTP ${result.status.toString()})\n` +
-      `  hub_url:   ${hubUrl}\n  leaf_port: ${leafPort.toString()}\n  admin:     ${matRes.material.fingerprint}\n`,
+      `  hub_url:   ${hubUrl}\n  leaf_port: ${leafPort.toString()}\n` +
+      (rawHubAccount !== undefined ? `  hub_account: ${rawHubAccount}\n` : "") +
+      `  admin:     ${matRes.material.fingerprint}\n`,
   );
 }
 
@@ -1434,6 +1459,13 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
   --admin-seed <path>     (create) path to the admin nkey seed (SU…) signing the claim.
                           admin_pubkey is derived from it; the registry's
                           REGISTRY_ADMIN_PUBKEYS allowlist must contain that pubkey.
+  --hub-account <A…>      (create, G1a, cortex#1117) OPTIONAL — the hub's NSC account
+                          public key (nkey-U pubkey, A + 55 uppercase base32 chars).
+                          When provided it is included in the signed claim (tamper-
+                          evident per DD-9) and returned by GET /networks/:id so a
+                          joining stack knows which NSC account to export/import into
+                          (G1c, future slice). Absent = "same-account / no cross-
+                          account wiring needed" (back-compat, Case A).
   --registry-url <url>    (create) registry base URL (default: https://network.meta-factory.ai).
   --apply                 Execute the live mutation (default: dry-run).
   --json                  Emit a { status, items, data, error } envelope.

--- a/src/common/registry/types.ts
+++ b/src/common/registry/types.ts
@@ -134,6 +134,17 @@ export interface NetworkDescriptor {
    * pubkeys + stacks) comes from `GET /networks/{id}/roster`.
    */
   members: string[];
+  /**
+   * G1a (cortex#1117) — the hub's NSC account public key (nkey-U, `A…`).
+   * OPTIONAL: absent means "no cross-account wiring needed" (Case A —
+   * hub and leaf share the same NSC account). When present, the joining stack uses this to
+   * configure the cross-account nats export/import (G1c, future slice).
+   * Grammar: `/^A[A-Z2-7]{55}$/` — same as the O-4b leaf-package `account`.
+   * Carried inside the signed assertion so tampering invalidates the
+   * registry signature (DD-9). The service-side `NetworkDescriptor` is the
+   * source of truth; this field mirrors it.
+   */
+  hub_account?: string;
 }
 
 /**

--- a/src/services/network-registry/__tests__/d1-mock.ts
+++ b/src/services/network-registry/__tests__/d1-mock.ts
@@ -36,6 +36,8 @@ interface NetworkRow {
   network_id: string;
   hub_url: string;
   leaf_port: number;
+  /** G1a (cortex#1117): nullable — NULL when not provided. */
+  hub_account: string | null;
   updated_at: string;
 }
 
@@ -174,17 +176,20 @@ export class MockD1 {
     }
 
     // networks: UPSERT (S2.5)
+    // G1a (cortex#1117): bind order is (networkId, hubUrl, leafPort, hubAccount|null, updatedAt)
     if (sql.startsWith("INSERT INTO networks")) {
-      const [networkId, hubUrl, leafPort, updatedAt] = args as [
+      const [networkId, hubUrl, leafPort, hubAccount, updatedAt] = args as [
         string,
         string,
         number,
+        string | null,
         string,
       ];
       this.networks.set(networkId, {
         network_id: networkId,
         hub_url: hubUrl,
         leaf_port: leafPort,
+        hub_account: hubAccount,
         updated_at: updatedAt,
       });
       // An UPSERT always touches exactly one row (insert or update).

--- a/src/services/network-registry/__tests__/g1a-hub-account.test.ts
+++ b/src/services/network-registry/__tests__/g1a-hub-account.test.ts
@@ -1,0 +1,299 @@
+/**
+ * G1a — hub_account on the signed network descriptor (cortex#1117).
+ *
+ * Tests the full stack: migration field, validation, store persistence, POST
+ * create route, GET descriptor route, and back-compat. All tests use the
+ * in-memory backend (no D1 binding in test env) via the same helpers as
+ * network-create.test.ts.
+ *
+ * Coverage:
+ *   Back-compat
+ *     - POST without hub_account still works (existing calls unchanged)
+ *     - GET without hub_account returns undefined field (no pollution)
+ *
+ *   Happy path
+ *     - POST with a valid hub_account stores it
+ *     - GET descriptor includes hub_account in the signed payload
+ *     - Signature still verifies end-to-end
+ *
+ *   Validation
+ *     - hub_account present but malformed (not nkey-U) → 400
+ *     - hub_account too short → 400
+ *     - hub_account starts with wrong prefix (S instead of A) → 400
+ *
+ *   CLI (buildNetworkCreateClaim)
+ *     - hub_account absent → claim has no hub_account field
+ *     - hub_account present → claim includes it, verified in signed payload
+ *
+ *   D1 store (in-memory)
+ *     - putNetwork with hub_account persists and getNetwork returns it
+ *     - putNetwork without hub_account returns undefined hub_account
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedNetworkCreate,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, verifyEd25519 } from "../src/signing";
+import { getStore } from "../src/store";
+import type { NetworkDescriptor, SignedAssertion } from "../src/types";
+
+// A syntactically valid nkey-U account pubkey (A + 55 uppercase base32 chars).
+// Must satisfy /^A[A-Z2-7]{55}$/. Total length = 56 chars.
+const VALID_HUB_ACCOUNT = "ACGYOGQ7OL6E6ZP6XFNGHPUWTYZ7CHOSZMFMZKYNUAMBYMDB7VK5NVDQ";
+
+let env: Env;
+let admin: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, e: Env = env): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`), e);
+}
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// Back-compat — existing calls (no hub_account) must be unaffected
+// =============================================================================
+
+describe("G1a back-compat: POST /networks/:id without hub_account", () => {
+  test("creates the network and returns a signed receipt (no hub_account field)", async () => {
+    const body = await makeSignedNetworkCreate("research-collab", admin, {
+      hubUrl: "tls://hub.meta-factory.ai:7422",
+      leafPort: 7422,
+      // No hubAccount — existing call shape
+    });
+    const res = await post("/networks/research-collab", body);
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as SignedAssertion<Record<string, unknown>>;
+    expect(json.payload.network_id).toBe("research-collab");
+    expect(json.payload.hub_url).toBe("tls://hub.meta-factory.ai:7422");
+    expect(json.payload.leaf_port).toBe(7422);
+    // hub_account absent or undefined — must not appear polluted
+    expect(json.payload.hub_account).toBeUndefined();
+  });
+
+  test("GET descriptor without hub_account returns undefined hub_account", async () => {
+    await post(
+      "/networks/research-collab",
+      await makeSignedNetworkCreate("research-collab", admin),
+    );
+    const res = await get("/networks/research-collab");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkDescriptor & { hub_account?: string }>;
+    expect(json.payload.hub_account).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Happy path — hub_account present in create + descriptor
+// =============================================================================
+
+describe("G1a hub_account: POST /networks/:id with hub_account", () => {
+  test("stores hub_account and returns it in the signed receipt", async () => {
+    const body = await makeSignedNetworkCreate("research-collab", admin, {
+      hubUrl: "tls://hub.meta-factory.ai:7422",
+      leafPort: 7422,
+      hubAccount: VALID_HUB_ACCOUNT,
+    });
+    const res = await post("/networks/research-collab", body);
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as SignedAssertion<Record<string, unknown>>;
+    expect(json.payload.hub_account).toBe(VALID_HUB_ACCOUNT);
+  });
+
+  test("GET descriptor includes hub_account in the signed payload", async () => {
+    await post(
+      "/networks/research-collab",
+      await makeSignedNetworkCreate("research-collab", admin, {
+        hubAccount: VALID_HUB_ACCOUNT,
+      }),
+    );
+    const res = await get("/networks/research-collab");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkDescriptor & { hub_account?: string }>;
+    expect(json.payload.hub_account).toBe(VALID_HUB_ACCOUNT);
+  });
+
+  test("GET descriptor hub_account is inside the signed payload (tamper-evident)", async () => {
+    await post(
+      "/networks/research-collab",
+      await makeSignedNetworkCreate("research-collab", admin, {
+        hubAccount: VALID_HUB_ACCOUNT,
+      }),
+    );
+    const res = await get("/networks/research-collab");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkDescriptor & { hub_account?: string }>;
+
+    // Verify the signature covers the payload INCLUDING hub_account
+    const bound = canonicalJSON({
+      payload: json.payload,
+      issued_at: json.issued_at,
+      registry: json.registry,
+    });
+    const ok = await verifyEd25519(
+      env.REGISTRY_PUBLIC_KEY!,
+      json.signature,
+      new TextEncoder().encode(bound),
+    );
+    expect(ok).toBe(true);
+
+    // hub_account is inside the signed payload, not outside
+    expect(json.payload.hub_account).toBe(VALID_HUB_ACCOUNT);
+  });
+
+  test("UPSERT: update hub_account on a second write", async () => {
+    const newAccount = "ADE7NLKP4DSPA4HXPUHJA3EV22N3TTTLJIZMUD65QVP624S2UP7J5QD6" as string;
+    await post(
+      "/networks/research-collab",
+      await makeSignedNetworkCreate("research-collab", admin, {
+        hubAccount: VALID_HUB_ACCOUNT,
+      }),
+    );
+    await post(
+      "/networks/research-collab",
+      await makeSignedNetworkCreate("research-collab", admin, {
+        hubAccount: newAccount,
+        hubUrl: "tls://hub.meta-factory.ai:7422",
+        leafPort: 7422,
+      }),
+    );
+    const res = await get("/networks/research-collab");
+    const json = (await res.json()) as SignedAssertion<NetworkDescriptor & { hub_account?: string }>;
+    expect(json.payload.hub_account).toBe(newAccount);
+  });
+
+  test("UPSERT: set hub_account on a network that initially had none", async () => {
+    // First write: no hub_account
+    await post(
+      "/networks/research-collab",
+      await makeSignedNetworkCreate("research-collab", admin),
+    );
+    // Second write: now adds hub_account
+    await post(
+      "/networks/research-collab",
+      await makeSignedNetworkCreate("research-collab", admin, {
+        hubAccount: VALID_HUB_ACCOUNT,
+      }),
+    );
+    const res = await get("/networks/research-collab");
+    const json = (await res.json()) as SignedAssertion<NetworkDescriptor & { hub_account?: string }>;
+    expect(json.payload.hub_account).toBe(VALID_HUB_ACCOUNT);
+  });
+});
+
+// =============================================================================
+// Validation — malformed hub_account → 400
+// =============================================================================
+
+describe("G1a validation: malformed hub_account", () => {
+  test("hub_account that is empty string → 400", async () => {
+    const body = await makeSignedNetworkCreate("research-collab", admin, {
+      hubAccount: "",
+    });
+    const res = await post("/networks/research-collab", body);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string; details: { field: string }[] };
+    expect(json.details.some((d) => d.field === "hub_account")).toBe(true);
+  });
+
+  test("hub_account that starts with 'S' (seed, not pubkey) → 400", async () => {
+    // S-prefix is a seed prefix, not a pubkey — same length as a valid key but wrong prefix
+    const seedLike = "SCGYOGQ7OL6E6ZP6XFNGHPUWTYZ7CHOSZMFMZKYNUAMBYMDB7VK5NVDQ" as string;
+    const body = await makeSignedNetworkCreate("research-collab", admin, {
+      hubAccount: seedLike,
+    });
+    const res = await post("/networks/research-collab", body);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string; details: { field: string }[] };
+    expect(json.details.some((d) => d.field === "hub_account")).toBe(true);
+  });
+
+  test("hub_account that is too short → 400", async () => {
+    const body = await makeSignedNetworkCreate("research-collab", admin, {
+      hubAccount: "ASHORT",
+    });
+    const res = await post("/networks/research-collab", body);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string; details: { field: string }[] };
+    expect(json.details.some((d) => d.field === "hub_account")).toBe(true);
+  });
+
+  test("hub_account that contains lowercase letters → 400", async () => {
+    // nkey-U uses uppercase base32 only — same length as valid but has lowercase
+    const body = await makeSignedNetworkCreate("research-collab", admin, {
+      hubAccount: "Acgyogq7ol6e6zp6xfnghpuwtyz7choszmfmzkynuambymdb7vk5nvdq",
+    });
+    const res = await post("/networks/research-collab", body);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string; details: { field: string }[] };
+    expect(json.details.some((d) => d.field === "hub_account")).toBe(true);
+  });
+
+  test("hub_account that is a non-string (number) → 400", async () => {
+    // Manually construct a body with a number for hub_account
+    const validBody = await makeSignedNetworkCreate("research-collab", admin, {
+      hubAccount: VALID_HUB_ACCOUNT,
+    });
+    // Forcibly override with a number (type-unsafe on purpose for test)
+    const tampered = {
+      ...validBody,
+      claim: { ...validBody.claim, hub_account: 42 },
+    };
+    const res = await post("/networks/research-collab", tampered as unknown as Record<string, unknown>);
+    // The signature will be invalid (claim was modified post-signing),
+    // but we still expect a 4xx (either 400 validation or 401 sig invalid)
+    expect(res.status >= 400).toBe(true);
+  });
+});
+
+// =============================================================================
+// Store — in-memory putNetwork / getNetwork with hub_account
+// =============================================================================
+
+describe("G1a store: putNetwork / getNetwork hub_account persistence", () => {
+  test("putNetwork with hub_account persists and getNetwork returns it", async () => {
+    const store = getStore(env);
+    const record = await store.putNetwork("test-net", "tls://hub:7422", 7422, VALID_HUB_ACCOUNT);
+    expect(record.hub_account).toBe(VALID_HUB_ACCOUNT);
+    const fetched = await store.getNetwork("test-net");
+    expect(fetched).toBeDefined();
+    expect(fetched!.hub_account).toBe(VALID_HUB_ACCOUNT);
+  });
+
+  test("putNetwork without hub_account returns undefined hub_account", async () => {
+    const store = getStore(env);
+    const record = await store.putNetwork("test-net", "tls://hub:7422", 7422);
+    expect(record.hub_account).toBeUndefined();
+    const fetched = await store.getNetwork("test-net");
+    expect(fetched).toBeDefined();
+    expect(fetched!.hub_account).toBeUndefined();
+  });
+});

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -166,6 +166,8 @@ export async function makeSignedAdminRead(
 /**
  * The admin claim shape carried by `POST /networks/:id` (#747). Mirrors
  * `NetworkCreateClaim` in `../src/validate`.
+ *
+ * G1a (cortex#1117): hub_account is optional — absent = back-compat.
  */
 export interface NetworkCreateClaim {
   network_id: string;
@@ -174,6 +176,8 @@ export interface NetworkCreateClaim {
   admin_pubkey: string;
   issued_at: string;
   nonce: string;
+  /** G1a: optional nkey-U hub account pubkey (`A…`). */
+  hub_account?: string;
 }
 
 /**
@@ -181,6 +185,9 @@ export interface NetworkCreateClaim {
  * just an Ed25519 keypair (the CLI derives it from an nkey seed; here we mint
  * one directly via `makePrincipalKey`). Tests override fields/signing-key to
  * exercise forged-signature / wrong-key / replay paths.
+ *
+ * G1a (cortex#1117): `hubAccount` is optional. When provided it is included
+ * in the signed claim. When absent the field is omitted entirely (back-compat).
  */
 export async function makeSignedNetworkCreate(
   networkId: string,
@@ -194,6 +201,8 @@ export async function makeSignedNetworkCreate(
     adminPubkeyOverride?: string;
     /** Sign with a DIFFERENT key than the claim declares — forged signature. */
     signWith?: PrincipalKey;
+    /** G1a: optional nkey-U hub account pubkey. */
+    hubAccount?: string;
   } = {},
 ): Promise<{ claim: NetworkCreateClaim; signature: string }> {
   const claim: NetworkCreateClaim = {
@@ -203,6 +212,8 @@ export async function makeSignedNetworkCreate(
     admin_pubkey: opts.adminPubkeyOverride ?? adminKey.publicKeyB64,
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
+    // G1a: only include when provided so canonical-JSON matches what the CLI signs.
+    ...(opts.hubAccount !== undefined && { hub_account: opts.hubAccount }),
   };
   const message = new TextEncoder().encode(canonicalJSON(claim));
   const signer = opts.signWith ?? adminKey;

--- a/src/services/network-registry/migrations/0005_network_hub_account.sql
+++ b/src/services/network-registry/migrations/0005_network_hub_account.sql
@@ -1,0 +1,20 @@
+-- cortex#1117 (G1a — hub_account on the signed network descriptor):
+-- Add `hub_account` to the `networks` table so the network descriptor can carry
+-- the hub's NSC account pubkey (nkey-U, A…). This is the OQ1 decision: the
+-- hub's account rides the SIGNED descriptor (authoritative, like hub_url, DD-12).
+--
+-- Strictly additive: the column is NULLABLE so existing rows remain valid
+-- (absent hub_account = "no cross-account wiring needed"). Only new writes
+-- that supply the field persist it; existing network-create calls without it
+-- continue to work exactly as before.
+--
+-- Apply:
+--   bunx wrangler d1 migrations apply cortex-network-registry-dev --env dev --remote
+--   bunx wrangler d1 migrations apply cortex-network-registry      --env production --remote
+--
+-- Grammar:  /^A[A-Z2-7]{55}$/ — the same nkey-U shape O-4b/registry
+-- use for leaf package accounts. Enforced at the route layer via
+-- isNkeyAccountPubkeyRegistry(); the SQL column is TEXT (D1 has no regex
+-- constraint syntax). Malformed values are rejected before they reach the store.
+
+ALTER TABLE networks ADD COLUMN hub_account TEXT;

--- a/src/services/network-registry/src/routes/networks.ts
+++ b/src/services/network-registry/src/routes/networks.ts
@@ -170,7 +170,13 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
     }
 
     const store = getStore(c.env);
-    const record = await store.putNetwork(claim.network_id, claim.hub_url, claim.leaf_port);
+    // G1a: pass hub_account (may be undefined — back-compat: existing calls omit it).
+    const record = await store.putNetwork(
+      claim.network_id,
+      claim.hub_url,
+      claim.leaf_port,
+      claim.hub_account,
+    );
 
     // Return the stored record wrapped in a registry-signed assertion — the
     // same shape GET /networks/:id serves, so the admin gets a verifiable
@@ -192,11 +198,15 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "not_found" }, 404);
     }
     const principals = await store.listPrincipals();
+    // G1a: include hub_account when present so it rides the signed payload (DD-9).
+    // Absent = back-compat: the field is simply not set on the descriptor object,
+    // preserving the existing S1 client contract for networks created without it.
     const descriptor: NetworkDescriptor = {
       network_id: record.network_id,
       hub_url: record.hub_url,
       leaf_port: record.leaf_port,
       members: membersFromPrincipals(principals, networkId),
+      ...(record.hub_account !== undefined && { hub_account: record.hub_account }),
     };
     const assertion = await signAssertion(c.env, descriptor);
     return c.json(assertion);

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -136,12 +136,16 @@ export interface RegistryStore {
    * script / direct D1 write), NOT via a public HTTP route — an unauthenticated
    * write the registry then signs would defeat DD-9 (descriptor poisoning).
    * Returns the post-write view. Callers are responsible for validating
-   * `hubUrl` / `leafPort`; the store only persists.
+   * `hubUrl` / `leafPort` / `hubAccount`; the store only persists.
+   *
+   * G1a (cortex#1117): `hubAccount` is optional (nkey-U `A…` pubkey).
+   * Absent = "same-account / no cross-account wiring needed" (back-compat).
    */
   putNetwork(
     networkId: string,
     hubUrl: string,
     leafPort: number,
+    hubAccount?: string,
   ): Promise<NetworkRecord>;
 
   /**
@@ -585,12 +589,16 @@ export class InMemoryRegistryStore implements RegistryStore {
     networkId: string,
     hubUrl: string,
     leafPort: number,
+    hubAccount?: string,
   ): Promise<NetworkRecord> {
     const record: NetworkRecord = {
       network_id: networkId,
       hub_url: hubUrl,
       leaf_port: leafPort,
       updated_at: new Date().toISOString(),
+      // G1a: only include hub_account when explicitly provided (back-compat:
+      // omitting preserves the field's absence on existing records).
+      ...(hubAccount !== undefined && { hub_account: hubAccount }),
     };
     this.networks.set(networkId, record);
     return record;
@@ -735,25 +743,31 @@ export class D1RegistryStore implements RegistryStore {
     networkId: string,
     hubUrl: string,
     leafPort: number,
+    hubAccount?: string,
   ): Promise<NetworkRecord> {
     const record: NetworkRecord = {
       network_id: networkId,
       hub_url: hubUrl,
       leaf_port: leafPort,
       updated_at: new Date().toISOString(),
+      // G1a: only include hub_account when explicitly provided (back-compat:
+      // omitting leaves the column NULL on existing rows unchanged).
+      ...(hubAccount !== undefined && { hub_account: hubAccount }),
     };
     // UPSERT: re-seeding a network replaces the topology row in place.
+    // G1a: hub_account is included in SET so a second write can update it.
     // Parameterised — no value is string-interpolated into SQL.
     await this.db
       .prepare(
-        `INSERT INTO networks (network_id, hub_url, leaf_port, updated_at)
-         VALUES (?, ?, ?, ?)
+        `INSERT INTO networks (network_id, hub_url, leaf_port, hub_account, updated_at)
+         VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(network_id) DO UPDATE SET
-           hub_url    = excluded.hub_url,
-           leaf_port  = excluded.leaf_port,
-           updated_at = excluded.updated_at`,
+           hub_url     = excluded.hub_url,
+           leaf_port   = excluded.leaf_port,
+           hub_account = excluded.hub_account,
+           updated_at  = excluded.updated_at`,
       )
-      .bind(networkId, hubUrl, leafPort, record.updated_at)
+      .bind(networkId, hubUrl, leafPort, hubAccount ?? null, record.updated_at)
       .run();
     return record;
   }
@@ -761,7 +775,7 @@ export class D1RegistryStore implements RegistryStore {
   async getNetwork(networkId: string): Promise<NetworkRecord | undefined> {
     const row = await this.db
       .prepare(
-        "SELECT network_id, hub_url, leaf_port, updated_at FROM networks WHERE network_id = ?",
+        "SELECT network_id, hub_url, leaf_port, hub_account, updated_at FROM networks WHERE network_id = ?",
       )
       .bind(networkId)
       .first<NetworkRow>();
@@ -798,16 +812,25 @@ interface NetworkRow {
   hub_url: string;
   /** SQLite stores the INTEGER column; D1 returns it as a JS number. */
   leaf_port: number;
+  /** G1a (cortex#1117) — nullable; NULL when the column was absent pre-migration
+   * or the network was created without a hub_account. */
+  hub_account: string | null;
   updated_at: string;
 }
 
 function rowToNetworkRecord(row: NetworkRow): NetworkRecord {
-  return {
+  const record: NetworkRecord = {
     network_id: row.network_id,
     hub_url: row.hub_url,
     leaf_port: row.leaf_port,
     updated_at: row.updated_at,
   };
+  // G1a: only include hub_account when the column is non-null (back-compat:
+  // pre-migration rows have NULL and must not appear polluted with undefined).
+  if (row.hub_account !== null && row.hub_account !== undefined) {
+    record.hub_account = row.hub_account;
+  }
+  return record;
 }
 
 /**

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -216,6 +216,17 @@ export interface NetworkDescriptor {
    * capabilities), not stored on the network record.
    */
   members: string[];
+  /**
+   * G1a (cortex#1117) — the hub's NSC account public key (nkey-U, `A…`).
+   * OPTIONAL: absent means "no cross-account wiring needed" (Case A —
+   * hub and leaf share the same NSC account).
+   * When present the joining stack's `cortex network join` (G1c) will use this
+   * to drive `arc nats add-federation-export --to-account <hub_account>`.
+   * Grammar: `/^A[A-Z2-7]{55}$/` — same as the O-4b leaf-package `account` field.
+   * Validated at create time; carried inside the signed assertion payload so any
+   * tampering invalidates the registry signature (DD-9).
+   */
+  hub_account?: string;
 }
 
 /**
@@ -235,6 +246,12 @@ export interface NetworkRecord {
   leaf_port: number;
   /** ISO-8601 UTC; when the topology was last (re-)seeded. */
   updated_at: string;
+  /**
+   * G1a (cortex#1117) — the hub's NSC account public key (nkey-U, `A…`).
+   * OPTIONAL: absent = "same-account / no cross-account wiring needed".
+   * Grammar: `/^A[A-Z2-7]{55}$/`.
+   */
+  hub_account?: string;
 }
 
 /**

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -378,6 +378,13 @@ export interface NetworkCreateClaim {
   issued_at: string;
   /** Random nonce to prevent replay. */
   nonce: string;
+  /**
+   * G1a (cortex#1117) — the hub's NSC account public key (nkey-U, `A…`).
+   * OPTIONAL: absent = "same-account / no cross-account wiring needed" (back-compat).
+   * When present MUST satisfy `/^A[A-Z2-7]{55}$/`; validated before storage.
+   * Part of the signed payload so it is tamper-evident (DD-9).
+   */
+  hub_account?: string;
 }
 
 /** The on-wire envelope: an admin claim + detached Ed25519 signature. */
@@ -450,19 +457,37 @@ export function validateNetworkCreateClaim(
     errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
   }
 
+  // hub_account — G1a (cortex#1117). OPTIONAL: absent = back-compat.
+  // When PRESENT must be a valid nkey-U account pubkey: /^A[A-Z2-7]{55}$/.
+  // Reuses isNkeyAccountPubkeyRegistry() — same validator + anti-drift
+  // contract as GrantLeafPackage.account (O-4b).
+  if (c.hub_account !== undefined) {
+    if (typeof c.hub_account !== "string" || !isNkeyAccountPubkeyRegistry(c.hub_account)) {
+      errors.push({
+        field: "hub_account",
+        message:
+          "must be a NATS nkey-U account pubkey (A + 55 uppercase base32 chars) when provided",
+      });
+    }
+  }
+
   if (errors.length > 0) return { ok: false, errors };
 
-  return {
-    ok: true,
-    claim: {
-      network_id: c.network_id as string,
-      hub_url: c.hub_url as string,
-      leaf_port: c.leaf_port as number,
-      admin_pubkey: c.admin_pubkey as string,
-      issued_at: c.issued_at as string,
-      nonce: c.nonce as string,
-    },
+  // Build the canonical claim — only include hub_account when present so the
+  // canonical-JSON bytes match exactly what the CLI signed (the CLI also
+  // omits the field when not provided, so the sig covers the same set of keys).
+  const result: NetworkCreateClaim = {
+    network_id: c.network_id as string,
+    hub_url: c.hub_url as string,
+    leaf_port: c.leaf_port as number,
+    admin_pubkey: c.admin_pubkey as string,
+    issued_at: c.issued_at as string,
+    nonce: c.nonce as string,
   };
+  if (typeof c.hub_account === "string") {
+    result.hub_account = c.hub_account;
+  }
+  return { ok: true, claim: result };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `hub_account` (nkey-U `A…` pubkey, `/^A[A-Z2-7]{55}$/`) to the **signed** `NetworkDescriptor` so joining principals can learn — from the tamper-evident descriptor — which NSC account their leaf must federate into (OQ1 decision, DD-9).
- Strictly additive + back-compat: absent `hub_account` = Case A (hub and leaf share the same NSC account), all existing networks and `network create` calls unaffected.
- **G1a scope only** — descriptor field + `cortex network create --hub-account` plumbing. Arc primitive (G1b) and join/grant orchestration (G1c) are later slices; they are NOT built here.

## Changes

| File | What |
|---|---|
| `src/services/network-registry/migrations/0005_network_hub_account.sql` | Nullable `hub_account TEXT` column on `networks` |
| `src/services/network-registry/src/types.ts` | `hub_account?: string` on `NetworkDescriptor` + `NetworkRecord` |
| `src/common/registry/types.ts` | Client-side `NetworkDescriptor` mirror |
| `src/services/network-registry/src/validate.ts` | `validateNetworkCreateClaim` rejects malformed `hub_account` |
| `src/services/network-registry/src/store.ts` | `putNetwork` / `getNetwork` persist + round-trip `hub_account` |
| `src/services/network-registry/src/routes/networks.ts` | POST passes claim field; GET spreads it into descriptor only when non-null |
| `src/bus/stack-provisioning.ts` | `buildNetworkCreateClaim` includes `hub_account` when provided |
| `src/cli/cortex/commands/network.ts` | `--hub-account` flag: local validation (exit 2 on malformed) before POST |
| `src/services/network-registry/__tests__/g1a-hub-account.test.ts` | 14 new tests (back-compat, happy path, validation, store, tamper-evidence) |
| `src/cli/cortex/commands/__tests__/network-create-hub-account.test.ts` | 6 new CLI tests |
| `src/services/network-registry/__tests__/helpers.ts` | `makeSignedNetworkCreate` supports `hubAccount` |
| `src/services/network-registry/__tests__/d1-mock.ts` | `NetworkRow` + UPSERT handler updated for 5-arg bind (hub_account column) |

## Test plan

- [x] `bun test src/services/network-registry/` — 244 pass, 0 fail
- [x] `bun test src/cli/cortex/` — 839 pass, 0 fail
- [x] `bun test src/` — 7297 pass, 0 fail
- [x] `bunx tsc --noEmit` (root tsconfig) — clean
- [x] Carve-out gate (`git diff HEAD` + untracked → `check-carveouts.sh`) — PASS
- [x] `bunx eslint --quiet` on all touched `.ts` files — clean

Refs #1117 #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)