### PR TITLE
fix(lint): G1a test prefer-const (unbreak main)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-create-hub-account.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-create-hub-account.test.ts
@@ -116,7 +116,7 @@ describe("create with --hub-account (valid)", () => {
     const { seedPath, adminPubkey } = await mintAdminSeed();
     const reg = await makeRegistryKey();
 
-    let registryEnv: Env = {
+    const registryEnv: Env = {
       REGISTRY_SIGNING_KEY: reg.signingKey,
       REGISTRY_PUBLIC_KEY: reg.publicKey,
       REGISTRY_ADMIN_PUBKEYS: adminPubkey,


### PR DESCRIPTION
One-word prefer-const fix on G1a's new test (#1130 merged with it; CI Lint red on main). Refs #1117.