### PR TITLE
fix(cortex): C-1071 — offer set/list folds agents.d into the effective catalog

### DIFF
--- a/src/cli/cortex/commands/__tests__/offer.test.ts
+++ b/src/cli/cortex/commands/__tests__/offer.test.ts
@@ -601,7 +601,11 @@ function stackLayer(extra: Rec = {}): Rec {
   };
 }
 
-function makeSplitDir(stacks: Record<string, Rec>, slug = "offer-test-cfg"): string {
+function makeSplitDir(
+  stacks: Record<string, Rec>,
+  slug = "offer-test-cfg",
+  agentsd: Record<string, Rec> = {},
+): string {
   const dir = join(tmpDir, slug);
   mkdirSync(join(dir, "system"), { recursive: true });
   mkdirSync(join(dir, "stacks"), { recursive: true });
@@ -609,7 +613,40 @@ function makeSplitDir(stacks: Record<string, Rec>, slug = "offer-test-cfg"): str
   for (const [name, content] of Object.entries(stacks)) {
     writeFileSync(join(dir, "stacks", `${name}.yaml`), YAML.stringify(content, { indent: 2, lineWidth: 0 }), "utf-8");
   }
+  // Optional bot-pack agents under `agents.d/<id>.yaml`, each with a sibling
+  // persona file (loadAgentsDirectory rejects a fragment whose persona path
+  // does not resolve). Mirrors the daemon-boot fragment layout (cortex#1071).
+  const entries = Object.entries(agentsd);
+  if (entries.length > 0) {
+    const agentsDir = join(dir, "agents.d");
+    mkdirSync(agentsDir, { recursive: true });
+    for (const [id, fragment] of entries) {
+      writeFileSync(join(agentsDir, `${id}.md`), `# ${id} persona\n`, "utf-8");
+      writeFileSync(
+        join(agentsDir, `${id}.yaml`),
+        YAML.stringify({ persona: `./${id}.md`, ...fragment }, { indent: 2, lineWidth: 0 }),
+        "utf-8",
+      );
+    }
+  }
   return dir;
+}
+
+/**
+ * A bot-pack agent fragment (the `agents.d/<id>.yaml` shape) declaring a
+ * capability via `runtime.capabilities[]` — e.g. the dev-loop `dev` agent
+ * providing `dev.implement` (cortex#1071). There is deliberately NO top-level
+ * `capabilities[]` catalog entry for it on the stack; the catalog the offer
+ * command validates against must be DERIVED from this fragment, mirroring what
+ * the daemon trusts at boot.
+ */
+function botPackAgent(id: string, capabilities: string[]): Rec {
+  return {
+    id,
+    displayName: id,
+    presence: {},
+    runtime: { substrate: "claude-code", mode: "in-process", capabilities },
+  };
 }
 
 async function run(argv: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
@@ -787,6 +824,99 @@ describe("dispatchOffer — CLI", () => {
     const written = YAML.parse(readFileSync(join(dir, "stacks", "work.yaml"), "utf-8")) as Rec;
     const net = ((written.policy as Rec).federated as Rec).networks as Rec[];
     expect(net[0]?.announce_capabilities).toEqual(["code-review.typescript"]);
+  });
+
+  // =========================================================================
+  // cortex#1071 — offer set/list folds agents.d (bot-pack-provided caps).
+  //
+  // A capability declared ONLY in a bot-pack fragment's
+  // `agents.d/<id>.yaml` `runtime.capabilities[]` (no top-level
+  // `capabilities[]` catalog entry on the stack) must be offerable: the
+  // offer-validation path derives the effective catalog the same way the
+  // daemon trusts merged agents at boot. Mirrors the dev-loop case
+  // (`dev.implement` provided by the `dev` bot-pack agent).
+  // =========================================================================
+
+  test("set federated for a bot-pack (agents.d) capability validates + writes (cortex#1071)", async () => {
+    const dir = makeSplitDir(
+      {
+        // Stack offers dev.implement but declares NO catalog entry for it —
+        // only the inline echo agent's code-review.typescript / chat exist.
+        work: stackLayer({
+          policy: {
+            federated: {
+              networks: [{ id: "metafactory-net", leaf_node: "leaf", max_hop: 1, peers: [] }],
+              registry: { url: "https://registry.example" },
+            },
+          },
+        }),
+      },
+      "offer-test-cfg",
+      { dev: botPackAgent("dev", ["dev.implement"]) },
+    );
+    // Pre-fix this fails: the composed config has no `dev.implement` in
+    // capabilities[] (composeRawConfig doesn't fold agents.d), so
+    // CortexConfigSchema rejects the offering. Post-fix the derived catalog
+    // carries it (provided_by:[dev]) and validation passes.
+    const r = await run([
+      "dev.implement", "--scope", "federated", "--network", "metafactory-net",
+      "--config", dir, "--apply",
+    ]);
+    expect(r.code).toBe(0);
+    const written = YAML.parse(readFileSync(join(dir, "stacks", "work.yaml"), "utf-8")) as Rec;
+    const policy = written.policy as Rec;
+    expect((policy.offerings as Rec[])[0]?.capability).toBe("dev.implement");
+    const net = (policy.federated as Rec).networks as Rec[];
+    expect(net[0]?.announce_capabilities).toEqual(["dev.implement"]);
+    expect(net[0]?.accept_subjects).toEqual([
+      "federated.andreas.work.tasks.dev.implement.>",
+    ]);
+  });
+
+  test("set local for a bot-pack capability validates (no catalog entry needed) (cortex#1071)", async () => {
+    const dir = makeSplitDir(
+      { work: stackLayer() },
+      "offer-test-cfg",
+      { dev: botPackAgent("dev", ["dev.implement"]) },
+    );
+    const r = await run(["dev.implement", "--scope", "local", "--config", dir, "--apply"]);
+    expect(r.code).toBe(0);
+    const written = YAML.parse(readFileSync(join(dir, "stacks", "work.yaml"), "utf-8")) as Rec;
+    expect(((written.policy as Rec).offerings as Rec[])[0]?.capability).toBe("dev.implement");
+  });
+
+  test("list surfaces a bot-pack capability with its provider agent (cortex#1071)", async () => {
+    const dir = makeSplitDir(
+      {
+        work: stackLayer({
+          policy: {
+            offerings: [{ capability: "dev.implement", scopes: ["local"] }],
+          },
+        }),
+      },
+      "offer-test-cfg",
+      { dev: botPackAgent("dev", ["dev.implement"]) },
+    );
+    const r = await run(["list", "--config", dir]);
+    expect(r.code).toBe(0);
+    // The derived catalog makes the bot-pack capability visible in list,
+    // attributed to its providing agent.
+    expect(r.stdout).toContain("dev.implement");
+    expect(r.stdout).toContain("dev");
+  });
+
+  test("a still-unknown capability (no catalog entry, no agents.d provider) → exit 1 (cortex#1071 guard)", async () => {
+    // The fold must not turn the catalog into a free-for-all: a capability
+    // that no inline catalog entry AND no agents.d agent provides still fails.
+    const dir = makeSplitDir(
+      { work: stackLayer() },
+      "offer-test-cfg",
+      { dev: botPackAgent("dev", ["dev.implement"]) },
+    );
+    const before = readFileSync(join(dir, "stacks", "work.yaml"), "utf-8");
+    const r = await run(["ghost.capability", "--scope", "local", "--config", dir, "--apply"]);
+    expect(r.code).toBe(1);
+    expect(readFileSync(join(dir, "stacks", "work.yaml"), "utf-8")).toBe(before);
   });
 });
 

--- a/src/cli/cortex/commands/offer.ts
+++ b/src/cli/cortex/commands/offer.ts
@@ -80,8 +80,10 @@ import { dirname, join, resolve } from "path";
 import { homedir } from "os";
 import YAML from "yaml";
 
-import { composeRawConfig } from "../../../common/config/loader";
+import { composeRawConfig, loadAgentsDirectory } from "../../../common/config/loader";
 import { deriveEffectiveCapabilityCatalog } from "../../../common/agents/capability-catalog";
+import type { Agent } from "../../../common/types/cortex-config";
+import type { Capability } from "../../../common/types/capability";
 import {
   type AcceptPolicy,
   type Offering,
@@ -783,6 +785,15 @@ export interface ResolvedTarget {
   configDir: string;
   /** Path to hand `composeRawConfig`. */
   composePath: string;
+  /**
+   * The `agents.d/` fragment directory to fold into the effective catalog when
+   * validating (cortex#1071). Mirrors the daemon-boot convention
+   * `join(dirname(configPath), "agents.d")` — for both config-split (configDir
+   * is the dir) and single-file legacy (configDir is the file's dir) this is
+   * `join(configDir, "agents.d")`. The directory need not exist;
+   * `loadAgentsDirectory` returns `[]` for a missing dir.
+   */
+  agentsDir: string;
   /** True for the legacy single-file form (target IS the cortex.yaml). */
   singleFile: boolean;
 }
@@ -839,7 +850,13 @@ export function resolveTarget(configPath: string, stackId: string | undefined): 
         `--stack ${stackId} given but --config ${resolved} is a single-file (legacy) config with no stacks/ layer`,
       );
     }
-    return { filePath: resolved, configDir, composePath: resolved, singleFile: true };
+    return {
+      filePath: resolved,
+      configDir,
+      composePath: resolved,
+      agentsDir: join(configDir, "agents.d"),
+      singleFile: true,
+    };
   }
 
   const stacksDir = join(configDir, "stacks");
@@ -849,11 +866,12 @@ export function resolveTarget(configPath: string, stackId: string | undefined): 
   }
 
   const composePath = join(configDir, "offer-pointer.yaml");
+  const agentsDir = join(configDir, "agents.d");
 
   if (stackId === undefined) {
     const [only] = stackFiles;
     if (stackFiles.length === 1 && only !== undefined) {
-      return { filePath: only, configDir, composePath, singleFile: false };
+      return { filePath: only, configDir, composePath, agentsDir, singleFile: false };
     }
     const names = stackFiles.map((f) => f.replace(`${stacksDir}/`, "")).join(", ");
     throw new Error(
@@ -867,7 +885,7 @@ export function resolveTarget(configPath: string, stackId: string | undefined): 
     const declaredId = readStackId(file);
     const base = file.slice(file.lastIndexOf("/") + 1).replace(/\.ya?ml$/, "");
     if (declaredId === wanted || base === wanted || base === wantedTail) {
-      return { filePath: file, configDir, composePath, singleFile: false };
+      return { filePath: file, configDir, composePath, agentsDir, singleFile: false };
     }
   }
   const names = stackFiles.map((f) => f.replace(`${stacksDir}/`, "")).join(", ");
@@ -1043,6 +1061,110 @@ function buildBackupPath(filePath: string): string {
 }
 
 // =============================================================================
+// agents.d fold — make the offer-validation catalog match the daemon's (cortex#1071)
+// =============================================================================
+
+/**
+ * Fold `agents.d/` bot-pack fragments into a raw (pre-schema) config object so
+ * the offer-validation path resolves capabilities through the SAME effective
+ * catalog the daemon trusts at boot (cortex#1071).
+ *
+ * The boot path (`src/cortex.ts`) merges `loadAgentsDirectory(agents.d)`
+ * fragments into the live agent set (inline wins on id) and the dispatch
+ * consumer trusts each merged agent's `runtime.capabilities[]` directly. But
+ * `composeRawConfig` only folds `system/ → network/ → surfaces/ → stacks/` — it
+ * NEVER reads `agents.d/`. So a capability provided ONLY by a bot-pack agent
+ * (declared in `agents.d/<id>.yaml` `runtime.capabilities[]`, no top-level
+ * `capabilities[]` entry) is invisible to `offer set/list`, and the composed
+ * config fails `CortexConfigSchema` ("offers <cap>, but no matching entry in
+ * the capabilities[] catalog") even though the daemon resolves it fine.
+ *
+ * This fold closes that gap WITHOUT touching the boot composer. It:
+ *   1. merges the loaded fragment agents into `raw.agents[]` (inline wins on
+ *      id — same rule as `src/cortex.ts` `mergedAgents`), so a synthesized
+ *      `provided_by:[<fragment-id>]` reference resolves to a declared agent;
+ *   2. derives the effective catalog via `deriveEffectiveCapabilityCatalog`
+ *      (the SAME function `offer list` and bot-packs B-0 use) and writes it back
+ *      to `raw.capabilities[]` — explicit entries pass through authoritative,
+ *      and capabilities that exist ONLY via agent declaration synthesize an
+ *      entry. Synthesized entries get a non-empty placeholder description so
+ *      they satisfy `CapabilitySchema` (which the live derivation path skips
+ *      because it runs AFTER parse).
+ *
+ * PURE-ish: returns a NEW object; `raw` is not mutated. Fragment-load failures
+ * propagate as `FragmentLoadError` (the caller surfaces them) — a malformed
+ * bot-pack should fail loudly here just as it does at boot.
+ *
+ * @param raw        the composed (or single-file-parsed) raw config object.
+ * @param agentsDir  the `agents.d/` directory to fold (may not exist →
+ *                   `loadAgentsDirectory` returns `[]`, raw passes through).
+ */
+function foldAgentsDirectoryCatalog(
+  raw: Record<string, unknown>,
+  agentsDir: string,
+): Record<string, unknown> {
+  const fragments = loadAgentsDirectory(agentsDir);
+  if (fragments.length === 0) return raw;
+
+  // Inline (composed) agents win on id — mirror src/cortex.ts mergedAgents.
+  const rawInlineAgents = Array.isArray(raw.agents) ? (raw.agents as unknown[]) : [];
+  const inlineIds = new Set(
+    rawInlineAgents
+      .map((a) => (isPlainObject(a) && typeof a.id === "string" ? a.id : undefined))
+      .filter((id): id is string => id !== undefined),
+  );
+  const newFragments = fragments.filter((f) => !inlineIds.has(f.id));
+  const mergedRawAgents: unknown[] = [...rawInlineAgents, ...newFragments];
+
+  // Build the Agent-shaped view the derivation reads (`id` + `runtime.capabilities`).
+  // Fragments are already-validated `Agent`s; inline raw agents may be only
+  // partially shaped, so we project the two fields the derivation consults.
+  const inlineAgentView: Agent[] = rawInlineAgents
+    .filter(isPlainObject)
+    .filter((a): a is Record<string, unknown> & { id: string } => typeof a.id === "string")
+    .map((a) => {
+      const runtime = isPlainObject(a.runtime) ? a.runtime : undefined;
+      const caps = runtime && Array.isArray(runtime.capabilities)
+        ? runtime.capabilities.filter((c): c is string => typeof c === "string")
+        : [];
+      return { id: a.id, runtime: { capabilities: caps } } as unknown as Agent;
+    });
+  const agentsForDerivation: Agent[] = [...inlineAgentView, ...newFragments];
+
+  const explicit: Capability[] = Array.isArray(raw.capabilities)
+    ? (raw.capabilities as Capability[])
+    : [];
+  const effective = deriveEffectiveCapabilityCatalog(explicit, agentsForDerivation);
+
+  // Synthesized entries carry `description: ""` (the live path skips the schema,
+  // so it never sees them). Our path validates BEFORE parse, and
+  // `CapabilitySchema.description` requires non-empty, so fill a placeholder for
+  // any entry the derivation synthesized (empty description ⇒ derived-only).
+  const foldedCapabilities = effective.map((c) =>
+    c.description === ""
+      ? {
+          ...c,
+          description: `provided by bot-pack agent(s): ${c.provided_by.join(", ") || "(none)"}`,
+        }
+      : c,
+  );
+
+  return { ...raw, agents: mergedRawAgents, capabilities: foldedCapabilities };
+}
+
+/**
+ * Compose the whole config from disk AND fold `agents.d/` into the effective
+ * catalog (cortex#1071). The single entry point all offer validation/list
+ * paths use so they share the daemon's view of provided capabilities.
+ */
+function composeRawConfigWithAgents(
+  composePath: string,
+  agentsDir: string,
+): Record<string, unknown> {
+  return foldAgentsDirectoryCatalog(composeRawConfig(composePath), agentsDir);
+}
+
+// =============================================================================
 // Compose-whole validation (mirrors config-merge.validateComposed)
 // =============================================================================
 
@@ -1058,14 +1180,26 @@ function validateComposed(
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
-    const res = CortexConfigSchema.safeParse(parsed);
+    // Single-file legacy still folds agents.d (the convention dir alongside the
+    // cortex.yaml) so a bot-pack capability is offerable in the monolith form too.
+    let folded: Record<string, unknown>;
+    try {
+      folded = isPlainObject(parsed)
+        ? foldAgentsDirectoryCatalog(parsed, target.agentsDir)
+        : (parsed as Record<string, unknown>);
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+    const res = CortexConfigSchema.safeParse(folded);
     return res.success ? { ok: true } : { ok: false, error: res.error.message };
   }
 
   let composed: Record<string, unknown>;
   try {
     writeFileSync(target.filePath, newLayerText, "utf-8");
-    composed = composeRawConfig(target.composePath);
+    // Fold agents.d into the effective catalog (cortex#1071) so a bot-pack-
+    // provided capability validates the same way the daemon resolves it.
+    composed = composeRawConfigWithAgents(target.composePath, target.agentsDir);
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   } finally {
@@ -1245,7 +1379,7 @@ function commitEdit(
   // Re-compose from disk + re-validate (belt-and-braces; catches a serialization
   // surprise the in-memory validation missed). Restore on failure.
   try {
-    const recomposed = composeRawConfig(target.composePath);
+    const recomposed = composeRawConfigWithAgents(target.composePath, target.agentsDir);
     const reval = CortexConfigSchema.safeParse(recomposed);
     if (!reval.success) {
       writeFileSync(target.filePath, originalText, "utf-8");
@@ -1415,10 +1549,16 @@ function runList(
     return opError("list", err instanceof Error ? err.message : String(err), json);
   }
   // Compose the WHOLE config so capabilities[] (a top-level block, possibly in a
-  // different layer) + offerings resolve together.
+  // different layer) + offerings resolve together, AND fold `agents.d/` into the
+  // effective catalog (cortex#1071) so bot-pack-provided capabilities — declared
+  // ONLY in `agents.d/<id>.yaml` `runtime.capabilities[]` — surface in the list,
+  // matching the catalog the daemon trusts at boot.
   let config: Record<string, unknown>;
   try {
-    config = composeRawConfig(target.composePath === target.filePath ? target.filePath : target.composePath);
+    config = composeRawConfigWithAgents(
+      target.composePath === target.filePath ? target.filePath : target.composePath,
+      target.agentsDir,
+    );
   } catch (err) {
     return opError("list", `cannot compose config: ${err instanceof Error ? err.message : String(err)}`, json);
   }
@@ -1427,15 +1567,12 @@ function runList(
     return opError("list", `config failed CortexConfigSchema — cannot list offerings.\n  ${parsed.error.message}`, json);
   }
   const cfg = parsed.data;
-  // EFFECTIVE catalog: explicit entries pass through authoritative; agents
-  // declaring capabilities nobody catalogued get synthesized entries
-  // (cortex#1021 B-0 — kills the manual capabilities[] cross-edit).
-  const effectiveCatalog = deriveEffectiveCapabilityCatalog(
-    cfg.capabilities,
-    cfg.agents,
-  );
+  // `cfg.capabilities` is ALREADY the effective catalog — `composeRawConfigWithAgents`
+  // folded `agents.d/` fragments into both `agents[]` and `capabilities[]` (via
+  // `deriveEffectiveCapabilityCatalog`, cortex#1021 B-0 + cortex#1071) before the
+  // parse above, so we read it directly rather than re-deriving.
   const rows = buildListRows(
-    effectiveCatalog.map((c) => ({ id: c.id, provided_by: c.provided_by })),
+    cfg.capabilities.map((c) => ({ id: c.id, provided_by: c.provided_by })),
     cfg.policy?.offerings,
   );
 


### PR DESCRIPTION
## What

`cortex offer set/list` validated the composed config via `composeRawConfig`, which folds `system/ → network/ → surfaces/ → stacks/` but **not `agents.d/`**. A capability provided *only* by a bot-pack agent (declared in `agents.d/<id>.yaml` `runtime.capabilities[]`, with no top-level `capabilities[]` entry) was invisible to the offer command, so the composed config failed `CortexConfigSchema`:

```
cortex offer dev.implement --scope federated --config ~/.config/cortex/dev-loop
→ policy.offerings[0] offers "dev.implement", but no matching entry exists
  in the top-level capabilities[] catalog
```

…even though the daemon resolves `dev.implement → provided_by:[dev]` correctly at boot.

Closes #1071. Refs the design umbrella #1133, cortex#1021 (B-0 bot packs), #942 (CO-3).

## The fix

Resolve capabilities in the **offer-validation path** through the **same effective catalog the daemon trusts**:

- **`foldAgentsDirectoryCatalog(raw, agentsDir)`** (new, in `offer.ts`): loads the `agents.d/` fragments via `loadAgentsDirectory`, merges them into `raw.agents[]` (**inline wins on id** — mirrors `src/cortex.ts` `mergedAgents`), derives the effective catalog via the **existing** `deriveEffectiveCapabilityCatalog` (cortex#1021 B-0), and writes it back to `raw.capabilities[]`. Explicit catalog entries pass through authoritative (no self-grant widening — Sage cortex#1027); only declaration-only capabilities synthesize an entry.
- **`composeRawConfigWithAgents(composePath, agentsDir)`** (new): `composeRawConfig` + the fold. Single entry point all offer paths use.
- `validateComposed` (single-file **and** config-split branches), the post-write re-compose in `commitEdit`, and `runList` now call it.
- `ResolvedTarget` carries `agentsDir = join(configDir, "agents.d")` — the daemon-boot convention for both layouts.

A synthesized (derived-only) catalog entry gets a non-empty placeholder description (`provided by bot-pack agent(s): <ids>`) so it satisfies `CapabilitySchema.description` (non-empty). The live `offer list` derivation skipped the schema because it ran *after* parse; this path validates *before* parse, so the field must be populated.

### Why the offer path, not `composeRawConfig`

`composeRawConfig` is the **boot composer**. The boot path already loads `agents.d/` separately (`loadAgentsDirectory`) and trusts the merged agents' `runtime.capabilities[]` directly — it never re-validates them against the catalog. Folding into `composeRawConfig` would either double-apply (boot loads agents.d a second time) or change the `LoadedConfig` shape boot depends on. Scoping the fold to the offer command keeps **boot byte-unchanged** while giving the offer command the daemon's view.

## Boot-unchanged proof

- `composeRawConfig`, `composeRawConfigWithSurfaces`, `loadConfigWithAgents`, `loadAgentsDirectory` are **untouched** — only new functions were added in `offer.ts`, calling the existing ones.
- `bun test src/common/config/__tests__/ src/common/agents/ …` → **562 pass, 0 fail** (config-loader, fragment-loader, capability-catalog, cortex-config, surfaces-on-loaded-config).
- Full `bun test` → **7301 pass, 2 skip, 0 fail** (two consecutive clean runs).

## Test approach (TDD)

Added 4 cases to `offer.test.ts` (RED-first, all now green), each backed by a new `makeSplitDir(..., agentsd)` helper + `botPackAgent()` fixture that drops a real `agents.d/<id>.yaml` fragment + persona, mirroring the dev-loop `dev` agent providing `dev.implement`:

1. `offer dev.implement --scope federated --apply` → validates + writes (offering + `announce_capabilities` + `accept_subjects: federated.andreas.work.tasks.dev.implement.>`).
2. `offer dev.implement --scope local --apply` → validates (local needs no catalog entry, but the write path still re-composes).
3. `offer list` → surfaces `dev.implement` attributed to provider `dev`.
4. **Guard:** a capability with **no** catalog entry **and no** agents.d provider (`ghost.capability`) still → exit 1 (the fold doesn't turn the catalog into a free-for-all).

## Gates

- `tsc --noEmit` clean
- `eslint` clean (changed files)
- carve-out vocab gate: **PASS** (no bare "operator")

## Caveats

- Synthesized descriptions are placeholders; a principal wanting human-readable descriptions still authors an explicit `capabilities[]` entry (unchanged behaviour).
- The fold reads `agents.d/` from `join(configDir, "agents.d")` for both layouts. A deployment using a non-conventional fragment dir (overridden only at the daemon via `options.agentsDir`) is out of scope — the offer command has no such override flag today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)