### PR TITLE
feat(network): G1c — network join wires local-side federated.> export/import via arc (ADR-0013)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
@@ -1,0 +1,619 @@
+/**
+ * G1c (#1117, ADR-0013) — federation-wiring step in `cortex network join`.
+ *
+ * Tests that `joinNetwork` orchestrates the local-side `federated.>` export/import
+ * by calling `FederationWiringPort.wireLocalFederation(...)` at step (b.4):
+ *   - after bind-mode resolution (so the federation/leaf account is known),
+ *   - before the leaf file write (fail-fast before any mutation on arc failure).
+ *
+ * Model B (ADR-0013): each principal wires their OWN half, in their OWN store.
+ * The call is LOCAL — no peer account, no network id on the wire.
+ *
+ * The arc-shell runner is NEVER called in tests — only the port method is.
+ * The injected `FederationWiringPort` is a fake (no real arc / nsc invocations).
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  joinNetwork,
+  type JoiningStack,
+} from "../network-lib";
+import type {
+  ConfigStorePort,
+  DaemonPort,
+  FederationWiringPort,
+  LeafFilePort,
+  LeafStatePort,
+  NatsServerPort,
+  NetworkPorts,
+  NetworkRegistryPort,
+  PlistPort,
+  RenderLeafInputs,
+} from "../network-ports";
+import type {
+  NetworkDescriptor,
+  NetworkRosterResult,
+} from "../../../../common/registry/types";
+import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const LEAF_ACCOUNT = "A" + "B".repeat(55); // valid nkey-A account public key
+const AGENTS_ACCOUNT = "A" + "C".repeat(55); // distinct agents account
+
+const LOCAL: JoiningStack = {
+  principalId: "andreas",
+  stackSlug: "meta-factory",
+  credentials: "/Users/andreas/.config/nats/andreas.creds",
+  account: LEAF_ACCOUNT,
+};
+
+const LOCAL_NO_ACCOUNT: JoiningStack = {
+  principalId: "andreas",
+  stackSlug: "meta-factory",
+  credentials: "/Users/andreas/.config/nats/andreas.creds",
+  // no account — $G/default bus
+};
+
+function descriptorFor(networkId: string): NetworkDescriptor {
+  return {
+    network_id: networkId,
+    hub_url: "tls://hub.meta-factory.ai:7422",
+    leaf_port: 7422,
+    members: ["andreas"],
+  };
+}
+
+function rosterFor(networkId: string): NetworkRosterResult {
+  return {
+    network_id: networkId,
+    members: [],
+  };
+}
+
+// =============================================================================
+// Fake FederationWiringPort + port bundle helpers
+// =============================================================================
+
+interface WiringCall {
+  federationAccount: string;
+  agentsAccount: string | undefined;
+  apply: boolean;
+}
+
+interface WiringRecorder {
+  calls: WiringCall[];
+}
+
+function makeFederationPort(opts: {
+  ok?: boolean;
+  /** When true, wireLocalFederation() throws synchronously (arc not found). */
+  throws?: boolean;
+}): { port: FederationWiringPort; rec: WiringRecorder } {
+  const rec: WiringRecorder = { calls: [] };
+  const port: FederationWiringPort = {
+    async wireLocalFederation({ federationAccount, agentsAccount, apply }) {
+      rec.calls.push({ federationAccount, agentsAccount, apply });
+      if (opts.throws === true) {
+        throw new Error("arc binary not found on PATH (ENOENT)");
+      }
+      if (opts.ok === false) {
+        return {
+          ok: false,
+          reason: "arc nats add-federation-export failed: NSC_COMMAND_FAILED",
+        };
+      }
+      return { ok: true, note: "export+import wired (idempotent)" };
+    },
+  };
+  return { port, rec };
+}
+
+/** Minimal fake ports bundle that is always "happy" except where overridden. */
+function makeMinimalPorts(opts: {
+  federationWiring?: FederationWiringPort;
+  busType?: "operator-mode" | "default-g";
+  wiringOk?: boolean;
+  wiringThrows?: boolean;
+  /** G1c: mirrors --apply. Default: false (dry-run). */
+  apply?: boolean;
+}): { ports: NetworkPorts; wiringRec: WiringRecorder; writes: RenderLeafInputs[] } {
+  const writes: RenderLeafInputs[] = [];
+
+  const { port: federationPort, rec: wiringRec } = makeFederationPort({
+    ok: opts.wiringOk,
+    throws: opts.wiringThrows,
+  });
+
+  const registry: NetworkRegistryPort = {
+    async registerStack() { return { ok: true, note: "HTTP 201" }; },
+    async fetchVerified(id) {
+      return {
+        status: "ok",
+        value: { descriptor: descriptorFor(id), roster: rosterFor(id) },
+      };
+    },
+    loadCached() { return undefined; },
+    async deregisterFromNetwork() { return { ok: true, note: "ok" }; },
+  };
+
+  const busType = opts.busType ?? "operator-mode";
+
+  const leafFile: LeafFilePort = {
+    write(inputs) { writes.push(inputs); },
+    remove() {},
+    ensureInclude() {},
+    removeInclude() {},
+    list() { return []; },
+    natsConfigPath() { return "/etc/nats/local.conf"; },
+    canBindAccount() { return { canBind: true }; },
+    resolveBindMode(account, hasCreds) {
+      if (!hasCreds) return { mode: "refuse", reason: "no creds" };
+      if (busType === "default-g") return { mode: "creds-only" };
+      const trimmed = account?.trim();
+      if (trimmed && trimmed.length > 0) return { mode: "operator-account", account: trimmed };
+      return { mode: "refuse", reason: "no account for operator-mode bus" };
+    },
+    convertToOperatorMode() { return { status: "already", conf: "" }; },
+    credsExist() { return true; },
+    snapshotLeafState(networkId) { return { networkId, includeFile: undefined, natsConfig: undefined }; },
+    restoreLeafState() {},
+  };
+
+  const plist: PlistPort = {
+    ensureConfigLoaded() {},
+    dropConfigArg() {},
+  };
+
+  const configStore: ConfigStorePort = {
+    readNetworks(): PolicyFederatedNetwork[] { return []; },
+    writeNetworks() {},
+  };
+
+  const daemon: DaemonPort = {
+    async restart() { return { ok: true }; },
+  };
+
+  const natsServer: NatsServerPort = {
+    async restart() { return { ok: true }; },
+    async validateConfig() { return { ok: true }; },
+    async isHealthy() { return { healthy: true }; },
+  };
+
+  const ports: NetworkPorts = {
+    registry,
+    leafFile,
+    plist,
+    configStore,
+    daemon,
+    natsServer,
+    federationWiring: opts.federationWiring ?? federationPort,
+    // G1c: mirror the --apply flag so wireLocalFederation receives the right value.
+    apply: opts.apply ?? false,
+  };
+
+  return { ports, wiringRec, writes };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("G1c — federation-wiring step in joinNetwork (ADR-0013 Model B)", () => {
+
+  // -------------------------------------------------------------------------
+  // (b.4) step is called on a successful join with an operator-mode bus
+  // -------------------------------------------------------------------------
+
+  test("dry-run: calls wireLocalFederation with apply=false and does NOT write leaf", async () => {
+    const { ports, wiringRec, writes } = makeMinimalPorts({});
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    expect(wiringRec.calls).toHaveLength(1);
+    expect(wiringRec.calls[0]!.apply).toBe(false);
+    expect(wiringRec.calls[0]!.federationAccount).toBe(LEAF_ACCOUNT);
+    // No agentsAccount in JoiningStack → undefined (same-account fallback flagged as G1d)
+    expect(wiringRec.calls[0]!.agentsAccount).toBeUndefined();
+    // Leaf IS written (dry-run ports still record writes in the fake)
+    expect(writes).toHaveLength(1);
+  });
+
+  test("--apply: calls wireLocalFederation with apply=true", async () => {
+    const { port: federationPort, rec: wiringRec } = makeFederationPort({ ok: true });
+    const { ports, writes } = makeMinimalPorts({
+      federationWiring: federationPort,
+      apply: true,
+    });
+
+    const res = await joinNetwork("metafactory", { ...LOCAL }, ports);
+
+    expect(res.ok).toBe(true);
+    // Called exactly once with apply=true
+    expect(wiringRec.calls).toHaveLength(1);
+    expect(wiringRec.calls[0]!.apply).toBe(true);
+    // Leaf written
+    expect(writes).toHaveLength(1);
+  });
+
+  test("wiring step passes agentsAccount from JoiningStack when supplied", async () => {
+    const { port: federationPort, rec: wiringRec } = makeFederationPort({ ok: true });
+    const { ports } = makeMinimalPorts({ federationWiring: federationPort });
+
+    const stackWithAgents: JoiningStack = {
+      ...LOCAL,
+      agentsAccount: AGENTS_ACCOUNT,
+    };
+
+    const res = await joinNetwork("metafactory", stackWithAgents, ports);
+    expect(res.ok).toBe(true);
+    expect(wiringRec.calls[0]!.federationAccount).toBe(LEAF_ACCOUNT);
+    expect(wiringRec.calls[0]!.agentsAccount).toBe(AGENTS_ACCOUNT);
+  });
+
+  // -------------------------------------------------------------------------
+  // Fail-fast: arc failure aborts join BEFORE the leaf write
+  // -------------------------------------------------------------------------
+
+  test("arc failure (ok=false): join fails and leaf is NOT written", async () => {
+    const { ports, wiringRec, writes } = makeMinimalPorts({ wiringOk: false });
+
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/add-federation-export failed/i);
+    // Wiring was called
+    expect(wiringRec.calls).toHaveLength(1);
+    // Leaf write was NEVER reached
+    expect(writes).toHaveLength(0);
+  });
+
+  test("arc spawn throws (ENOENT): join fails and leaf is NOT written", async () => {
+    const { ports, wiringRec, writes } = makeMinimalPorts({ wiringThrows: true });
+
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/arc binary not found/i);
+    // Wiring was called (the port wrapped the throw)
+    expect(wiringRec.calls).toHaveLength(1);
+    // Leaf write was NEVER reached
+    expect(writes).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // $G/default-account bus (creds-only mode): wiring is skipped
+  // -------------------------------------------------------------------------
+
+  test("creds-only bus ($G): wiring step is SKIPPED (no federation account)", async () => {
+    const { ports, wiringRec, writes } = makeMinimalPorts({ busType: "default-g" });
+
+    const res = await joinNetwork("metafactory", LOCAL_NO_ACCOUNT, ports);
+
+    expect(res.ok).toBe(true);
+    // No federation account → wiring is skipped
+    expect(wiringRec.calls).toHaveLength(0);
+    // Leaf still written
+    expect(writes).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Step (b.4) placement: wiring runs AFTER bind-mode resolution
+  // -------------------------------------------------------------------------
+
+  test("step placement: wiring called BEFORE leaf write (fail-fast friendly)", async () => {
+    const callOrder: string[] = [];
+
+    const { port: federationPort } = makeFederationPort({ ok: true });
+    // Wrap to record order
+    const trackedWiring: FederationWiringPort = {
+      async wireLocalFederation(params) {
+        callOrder.push("wiring");
+        return federationPort.wireLocalFederation(params);
+      },
+    };
+
+    const writes: RenderLeafInputs[] = [];
+    const registry: NetworkRegistryPort = {
+      async registerStack() { return { ok: true, note: "HTTP 201" }; },
+      async fetchVerified(id) {
+        return {
+          status: "ok",
+          value: { descriptor: descriptorFor(id), roster: rosterFor(id) },
+        };
+      },
+      loadCached() { return undefined; },
+      async deregisterFromNetwork() { return { ok: true, note: "ok" }; },
+    };
+
+    const leafFile: LeafFilePort = {
+      write(inputs) { callOrder.push("leafWrite"); writes.push(inputs); },
+      remove() {},
+      ensureInclude() {},
+      removeInclude() {},
+      list() { return []; },
+      natsConfigPath() { return "/etc/nats/local.conf"; },
+      canBindAccount() { return { canBind: true }; },
+      resolveBindMode(account, hasCreds) {
+        if (!hasCreds) return { mode: "refuse", reason: "no creds" };
+        const trimmed = account?.trim();
+        if (trimmed && trimmed.length > 0) return { mode: "operator-account", account: trimmed };
+        return { mode: "refuse", reason: "no account" };
+      },
+      convertToOperatorMode() { return { status: "already", conf: "" }; },
+      credsExist() { return true; },
+      snapshotLeafState(networkId) { return { networkId, includeFile: undefined, natsConfig: undefined }; },
+      restoreLeafState() {},
+    };
+
+    const ports: NetworkPorts = {
+      registry,
+      leafFile,
+      plist: { ensureConfigLoaded() {}, dropConfigArg() {} },
+      configStore: { readNetworks() { return []; }, writeNetworks() {} },
+      daemon: { async restart() { return { ok: true }; } },
+      natsServer: {
+        async restart() { return { ok: true }; },
+        async validateConfig() { return { ok: true }; },
+        async isHealthy() { return { healthy: true }; },
+      },
+      federationWiring: trackedWiring,
+      apply: false,
+    };
+
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(true);
+    expect(callOrder.indexOf("wiring")).toBeLessThan(callOrder.indexOf("leafWrite"));
+  });
+
+  // -------------------------------------------------------------------------
+  // No federationWiring port wired: join succeeds (backwards-compat / no-op)
+  // -------------------------------------------------------------------------
+
+  test("federationWiring absent: join succeeds (no-op — backwards compat)", async () => {
+    const { ports, writes } = makeMinimalPorts({});
+    // Remove the wiring port
+    const portsWithout: NetworkPorts = { ...ports, federationWiring: undefined };
+
+    const res = await joinNetwork("metafactory", LOCAL, portsWithout);
+    expect(res.ok).toBe(true);
+    expect(writes).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Dry-run step log includes a line about the wiring plan
+  // -------------------------------------------------------------------------
+
+  test("dry-run step log mentions the federated.> wiring plan", async () => {
+    const { ports } = makeMinimalPorts({});
+
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(true);
+    const wiringStep = res.steps.find((s) => s.includes("federation") || s.includes("federated.>"));
+    expect(wiringStep).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotency: calling join twice does not double-call wiring (2nd call is
+  // still exactly 1 invocation — the port itself is idempotent)
+  // -------------------------------------------------------------------------
+
+  test("re-join calls wireLocalFederation exactly once per join invocation", async () => {
+    const { ports, wiringRec } = makeMinimalPorts({});
+
+    await joinNetwork("metafactory", LOCAL, ports);
+    await joinNetwork("metafactory", LOCAL, ports);
+
+    // Each joinNetwork call invokes the port once; 2 calls → 2 wiring invocations
+    expect(wiringRec.calls).toHaveLength(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // cortex never calls nsc directly (structural: the port is the only path)
+  // -------------------------------------------------------------------------
+
+  test("no direct nsc calls: all wiring goes through FederationWiringPort", async () => {
+    // This test is structural: we never import nsc / no nsc references exist in
+    // network-lib.ts. The port is the only call site. If the implementation
+    // were to bypass the port and call nsc directly, the fake would not record
+    // the call and the step-placement test above would fail independently.
+    // We assert the port WAS called, confirming the call went through the seam.
+    const { ports, wiringRec } = makeMinimalPorts({});
+    await joinNetwork("metafactory", LOCAL, ports);
+    expect(wiringRec.calls).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// FederationWiringAdapter (live adapter) — arc-shell unit tests
+// =============================================================================
+
+import {
+  buildFederationWiringAdapter,
+  type ArcFederationRunner,
+} from "../network-federation-wiring";
+
+describe("buildFederationWiringAdapter — arc-shell adapter", () => {
+
+  function makeRunner(response: {
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+  }): { runner: ArcFederationRunner; calls: string[][] } {
+    const calls: string[][] = [];
+    const runner: ArcFederationRunner = async (argv) => {
+      calls.push([...argv]);
+      return {
+        stdout: response.stdout ?? "",
+        stderr: response.stderr ?? "",
+        exitCode: response.exitCode ?? 0,
+      };
+    };
+    return { runner, calls };
+  }
+
+  const SUCCESS_JSON = JSON.stringify({
+    schema: "arc.nats.v2",
+    ok: true,
+    fromAccount: LEAF_ACCOUNT,
+    toAccount: AGENTS_ACCOUNT,
+    subject: "federated.>",
+    exportAdded: true,
+    importAdded: true,
+    exportAlreadyPresent: false,
+    importAlreadyPresent: false,
+  });
+
+  const IDEMPOTENT_JSON = JSON.stringify({
+    schema: "arc.nats.v2",
+    ok: true,
+    fromAccount: LEAF_ACCOUNT,
+    toAccount: AGENTS_ACCOUNT,
+    subject: "federated.>",
+    exportAdded: false,
+    importAdded: false,
+    exportAlreadyPresent: true,
+    importAlreadyPresent: true,
+  });
+
+  test("dry-run: invokes arc with --dry-run (no --apply) and returns ok", async () => {
+    const { runner, calls } = makeRunner({ stdout: SUCCESS_JSON });
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("--dry-run");
+    expect(calls[0]).not.toContain("--apply");
+    expect(calls[0]).toContain("--from-account");
+    expect(calls[0]).toContain(LEAF_ACCOUNT);
+    expect(calls[0]).toContain("--to-account");
+    expect(calls[0]).toContain(AGENTS_ACCOUNT);
+    expect(calls[0]).toContain("--json");
+  });
+
+  test("--apply: invokes arc with --apply (not --dry-run)", async () => {
+    const { runner, calls } = makeRunner({ stdout: SUCCESS_JSON });
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls[0]).toContain("--apply");
+    expect(calls[0]).not.toContain("--dry-run");
+  });
+
+  test("idempotent: already-present export+import is ok", async () => {
+    const { runner } = makeRunner({ stdout: IDEMPOTENT_JSON });
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.note).toBeDefined();
+  });
+
+  test("arc ok=false: returns ok=false with reason from arc", async () => {
+    const errorJson = JSON.stringify({
+      schema: "arc.nats.v2",
+      ok: false,
+      error: { code: "NSC_COMMAND_FAILED", message: "nsc add export failed" },
+    });
+    const { runner } = makeRunner({ stdout: errorJson });
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/NSC_COMMAND_FAILED/);
+  });
+
+  test("arc no valid JSON: returns ok=false with clear error", async () => {
+    const { runner } = makeRunner({ stdout: "not json", exitCode: 1 });
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/arc returned no valid/i);
+  });
+
+  test("arc spawn throws: returns ok=false (never throws)", async () => {
+    const throwingRunner: ArcFederationRunner = async (_argv) => {
+      throw new Error("ENOENT: arc not found");
+    };
+    const adapter = buildFederationWiringAdapter(throwingRunner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/ENOENT/i);
+  });
+
+  test("no agentsAccount: omits --to-account (same-account / G1d path)", async () => {
+    const { runner, calls } = makeRunner({ stdout: SUCCESS_JSON });
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: undefined,
+      apply: false,
+    });
+
+    // When agentsAccount is undefined, arc is called with --from-account only;
+    // the arc primitive handles the same-account case (it's a no-op there).
+    // OR: we skip the arc call entirely if both accounts are the same.
+    // In either case the result should be ok (documented as G1d gap).
+    expect(result.ok).toBe(true);
+    // --to-account should not appear (or both accounts are the same value)
+    if (calls.length > 0) {
+      const toIdx = calls[0]!.indexOf("--to-account");
+      // If --to-account IS present it should be the same as --from-account (same-account path)
+      if (toIdx >= 0) {
+        expect(calls[0]![toIdx + 1]).toBe(LEAF_ACCOUNT);
+      }
+    }
+  });
+
+  test("command includes 'nats add-federation-export' as the arc subcommand", async () => {
+    const { runner, calls } = makeRunner({ stdout: SUCCESS_JSON });
+    const adapter = buildFederationWiringAdapter(runner);
+
+    await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: false,
+    });
+
+    expect(calls[0]).toContain("nats");
+    expect(calls[0]).toContain("add-federation-export");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
@@ -578,8 +578,24 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
     if (!result.ok) expect(result.reason).toMatch(/ENOENT/i);
   });
 
-  test("no agentsAccount: omits --to-account (same-account / G1d path)", async () => {
-    const { runner, calls } = makeRunner({ stdout: SUCCESS_JSON });
+  test("no agentsAccount: arc IS called exactly once with --from-account == --to-account (same-account / G1d path)", async () => {
+    // G1d same-account path: agentsAccount absent → toAccount = federationAccount = LEAF_ACCOUNT.
+    // arc is always called (the adapter always shells out; the arc primitive treats
+    // from==to as a no-op locally). Build a SUCCESS_JSON with toAccount=LEAF_ACCOUNT
+    // to match the actual args the adapter will pass.
+    const sameAccountSuccessJson = JSON.stringify({
+      schema: "arc.nats.v2",
+      ok: true,
+      fromAccount: LEAF_ACCOUNT,
+      toAccount: LEAF_ACCOUNT,
+      subject: "federated.>",
+      exportAdded: true,
+      importAdded: true,
+      exportAlreadyPresent: false,
+      importAlreadyPresent: false,
+    });
+
+    const { runner, calls } = makeRunner({ stdout: sameAccountSuccessJson });
     const adapter = buildFederationWiringAdapter(runner);
 
     const result = await adapter.wireLocalFederation({
@@ -588,19 +604,25 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
       apply: false,
     });
 
-    // When agentsAccount is undefined, arc is called with --from-account only;
-    // the arc primitive handles the same-account case (it's a no-op there).
-    // OR: we skip the arc call entirely if both accounts are the same.
-    // In either case the result should be ok (documented as G1d gap).
     expect(result.ok).toBe(true);
-    // --to-account should not appear (or both accounts are the same value)
-    if (calls.length > 0) {
-      const toIdx = calls[0]!.indexOf("--to-account");
-      // If --to-account IS present it should be the same as --from-account (same-account path)
-      if (toIdx >= 0) {
-        expect(calls[0]![toIdx + 1]).toBe(LEAF_ACCOUNT);
-      }
-    }
+
+    // HARD: arc MUST be invoked exactly once — the G1d path is a no-op in the
+    // arc primitive, not in the adapter. Zero calls means the behavior was never
+    // exercised; > 1 call means a double-invocation bug.
+    expect(calls).toHaveLength(1);
+
+    // HARD: --from-account must be present and equal LEAF_ACCOUNT.
+    const fromIdx = calls[0]!.indexOf("--from-account");
+    expect(fromIdx).toBeGreaterThanOrEqual(0);
+    expect(calls[0]![fromIdx + 1]).toBe(LEAF_ACCOUNT);
+
+    // HARD: --to-account must be present and equal LEAF_ACCOUNT (same-account).
+    const toIdx = calls[0]!.indexOf("--to-account");
+    expect(toIdx).toBeGreaterThanOrEqual(0);
+    expect(calls[0]![toIdx + 1]).toBe(LEAF_ACCOUNT);
+
+    // HARD: both accounts are identical (the defining property of the G1d path).
+    expect(calls[0]![fromIdx + 1]).toBe(calls[0]![toIdx + 1]);
   });
 
   test("command includes 'nats add-federation-export' as the arc subcommand", async () => {

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -85,6 +85,7 @@ import type {
   PlistPort,
   RenderLeafInputs,
 } from "./network-ports";
+import { buildFederationWiringAdapter } from "./network-federation-wiring";
 import type {
   PublicPolicyPort,
   PublicRegistryPort,
@@ -1163,6 +1164,14 @@ function buildPorts(cfg: LivePortsConfig, mutate: boolean): NetworkPorts {
     // C-797 — always present now (defaults to the local monitor); status reads
     // the authoritative leafz view instead of falling back to link:unknown.
     leafState: buildLeafStatePort(cfg),
+    // G1c (#1117, ADR-0013 Model B) — wire the local-side `federated.>`
+    // export/import by shelling to `arc nats add-federation-export`. The port
+    // is always wired; step (b.4) in joinNetwork uses it only when the bus is
+    // operator-mode (leafAccount !== undefined). Dry-run ports set apply=false.
+    federationWiring: buildFederationWiringAdapter(),
+    // G1c — mirror the mutate flag as `apply` so the wiring step knows whether
+    // to actually run arc (apply=true) or just print the plan (apply=false).
+    apply: mutate,
   };
 }
 

--- a/src/cli/cortex/commands/network-federation-wiring.ts
+++ b/src/cli/cortex/commands/network-federation-wiring.ts
@@ -108,6 +108,17 @@ export function buildFederationWiringAdapter(
       // the arc primitive handles this as a no-op). A dedicated agents_account
       // config field that splits the two is tracked as G1d (#1117 follow-up).
       const toAccount = agentsAccount ?? federationAccount;
+      if (agentsAccount === undefined) {
+        // Nit 2 (G1c review) — make the G1d gap operationally visible. When no
+        // dedicated agents account is configured, from==to is a same-account no-op
+        // in the arc primitive. Log at WARN so the principal can see the gap and
+        // knows to configure agents_account (G1d) when they split accounts.
+        process.stderr.write(
+          `[cortex network join] WARN: federation wiring is a same-account no-op ` +
+          `(dedicated federation account not configured — G1d, cortex#1117 follow-up). ` +
+          `Set agents_account in the stack config to wire cross-account export/import.\n`,
+        );
+      }
 
       const argv: string[] = [
         "nats",
@@ -174,11 +185,27 @@ export function buildFederationWiringAdapter(
       const envelope = parsed as ArcFederationEnvelope;
 
       if (!envelope.ok) {
+        // Shape-check before reading .error so a malformed envelope (ok:false but
+        // missing/mistyped .error) surfaces a clear diagnostic rather than a
+        // runtime TypeError on .error.code / .error.message.
+        const rawError = (envelope as { error?: unknown }).error;
+        const errCode =
+          rawError !== null &&
+          typeof rawError === "object" &&
+          "code" in rawError &&
+          typeof (rawError as { code?: unknown }).code === "string"
+            ? (rawError as { code: string }).code
+            : "(unknown code)";
+        const errMsg =
+          rawError !== null &&
+          typeof rawError === "object" &&
+          "message" in rawError &&
+          typeof (rawError as { message?: unknown }).message === "string"
+            ? (rawError as { message: string }).message
+            : "(no message)";
         return {
           ok: false,
-          reason:
-            `arc nats add-federation-export failed: ` +
-            `${envelope.error.code}: ${envelope.error.message}`,
+          reason: `arc nats add-federation-export failed: ${errCode}: ${errMsg}`,
         };
       }
 

--- a/src/cli/cortex/commands/network-federation-wiring.ts
+++ b/src/cli/cortex/commands/network-federation-wiring.ts
@@ -1,0 +1,198 @@
+/**
+ * G1c (#1117, ADR-0013) — live adapter for {@link FederationWiringPort}.
+ *
+ * Shells out to `arc nats add-federation-export` (built in G1b / arc#243) to
+ * wire the LOCAL-SIDE `federated.>` export/import between the stack's
+ * federation account (leaf-bound) and agents account. Follows the arc-shell
+ * pattern established in `creds.ts` (`callArcNats` / `ArcRunner`):
+ *   cortex shells to arc → arc calls nsc → nsc mutates the local NSC store.
+ *
+ * cortex NEVER calls nsc directly (ADR-0013 Model B invariant).
+ * cortex NEVER references a peer account (local-only wiring).
+ * cortex NEVER puts the network id on any NATS wire.
+ *
+ * ## Same-account / G1d gap
+ *
+ * ADR-0013 §3 says ONE dedicated federation account per stack (distinct from
+ * agents). Today the cortex config has a single `stack.nats_infra.account`
+ * (the leaf-bound account). When `agentsAccount` is absent (the current
+ * state), the call is sent with `--from-account == --to-account` (same
+ * account). The arc primitive handles the same-account case as a no-op (both
+ * accounts are the same NSC account; no cross-account routing needed). A
+ * dedicated `agents_account` config field that splits the two is tracked as
+ * G1d (cortex#1117 follow-up).
+ *
+ * ## Schema
+ *
+ * arc responds with `arc.nats.v2` (a new schema revision for federation
+ * commands, distinct from `arc.nats.v1` used by add-bot/reissue-bot). We
+ * guard on the schema string so a future arc that returns `arc.nats.v1` for
+ * this subcommand (a contract regression) fails loudly rather than silently
+ * misinterpreting the envelope.
+ */
+
+import type { FederationWiringPort } from "./network-ports";
+
+// =============================================================================
+// Arc subprocess driver (injectable for tests — same pattern as creds.ts)
+// =============================================================================
+
+/** Result of one arc subprocess invocation. */
+export interface ArcFederationRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Pluggable subprocess driver. Tests inject a fake; production uses Bun.spawn. */
+export type ArcFederationRunner = (argv: readonly string[]) => Promise<ArcFederationRunResult>;
+
+async function defaultArcFederationRunner(argv: readonly string[]): Promise<ArcFederationRunResult> {
+  const proc = Bun.spawn(["arc", ...argv], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+// =============================================================================
+// arc.nats.v2 envelope types
+// =============================================================================
+
+const ARC_NATS_SCHEMA_V2 = "arc.nats.v2";
+
+interface ArcFederationOk {
+  schema: typeof ARC_NATS_SCHEMA_V2;
+  ok: true;
+  fromAccount: string;
+  toAccount: string;
+  subject: string;
+  exportAdded: boolean;
+  importAdded: boolean;
+  exportAlreadyPresent: boolean;
+  importAlreadyPresent: boolean;
+}
+
+interface ArcFederationError {
+  schema: typeof ARC_NATS_SCHEMA_V2;
+  ok: false;
+  error: { code: string; message: string };
+}
+
+type ArcFederationEnvelope = ArcFederationOk | ArcFederationError;
+
+// =============================================================================
+// buildFederationWiringAdapter
+// =============================================================================
+
+/**
+ * Build the live {@link FederationWiringPort} backed by `arc nats add-federation-export`.
+ *
+ * @param runner - Injectable subprocess driver (default: `Bun.spawn(["arc", …])`).
+ *
+ * ## Never throws
+ *
+ * All errors (spawn failure, non-JSON output, arc `ok: false`) are surfaced as
+ * `{ ok: false, reason }` — consistent with the `joinNetwork` "never throws"
+ * contract. The `try/catch` around the spawn mirrors the pattern in `creds.ts`.
+ */
+export function buildFederationWiringAdapter(
+  runner: ArcFederationRunner = defaultArcFederationRunner,
+): FederationWiringPort {
+  return {
+    async wireLocalFederation({ federationAccount, agentsAccount, apply }) {
+      // Same-account / G1d: when agentsAccount is absent, use federationAccount
+      // as the --to-account (same NSC account = no cross-account routing needed;
+      // the arc primitive handles this as a no-op). A dedicated agents_account
+      // config field that splits the two is tracked as G1d (#1117 follow-up).
+      const toAccount = agentsAccount ?? federationAccount;
+
+      const argv: string[] = [
+        "nats",
+        "add-federation-export",
+        "--from-account", federationAccount,
+        "--to-account", toAccount,
+        "--subject", "federated.>",
+        apply ? "--apply" : "--dry-run",
+        "--json",
+      ];
+
+      let result: ArcFederationRunResult;
+      try {
+        result = await runner(argv);
+      } catch (err) {
+        return {
+          ok: false,
+          reason:
+            `failed to invoke 'arc nats add-federation-export' — ` +
+            `${err instanceof Error ? err.message : String(err)}. ` +
+            `Ensure arc is installed and on PATH (see docs/design-g1-account-topology.md).`,
+        };
+      }
+
+      // Parse the first non-blank JSON line (same pattern as creds.ts).
+      const line = result.stdout.split("\n").find((l) => l.trim().length > 0) ?? "";
+      if (line.length === 0) {
+        return {
+          ok: false,
+          reason:
+            `arc returned no valid '${ARC_NATS_SCHEMA_V2}' envelope. ` +
+            `Confirm arc is installed and that 'arc nats add-federation-export' supports --json. ` +
+            `arc stderr: ${result.stderr.trim() || "(empty)"}`,
+        };
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        return {
+          ok: false,
+          reason:
+            `arc returned no valid '${ARC_NATS_SCHEMA_V2}' envelope (JSON parse failed). ` +
+            `arc output: ${line.slice(0, 200)}`,
+        };
+      }
+
+      // Schema guard — fail loudly if arc returns an unexpected schema string.
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        (parsed as { schema?: unknown }).schema !== ARC_NATS_SCHEMA_V2
+      ) {
+        return {
+          ok: false,
+          reason:
+            `arc returned no valid '${ARC_NATS_SCHEMA_V2}' envelope (schema mismatch). ` +
+            `Got: ${JSON.stringify((parsed as { schema?: unknown }).schema ?? "(none)")}. ` +
+            `Ensure arc supports the G1b add-federation-export command (arc#243).`,
+        };
+      }
+
+      const envelope = parsed as ArcFederationEnvelope;
+
+      if (!envelope.ok) {
+        return {
+          ok: false,
+          reason:
+            `arc nats add-federation-export failed: ` +
+            `${envelope.error.code}: ${envelope.error.message}`,
+        };
+      }
+
+      const ok = envelope;
+      const parts: string[] = [];
+      if (ok.exportAlreadyPresent) parts.push("export already present");
+      else if (ok.exportAdded) parts.push("export added");
+      if (ok.importAlreadyPresent) parts.push("import already present");
+      else if (ok.importAdded) parts.push("import added");
+      const note = parts.length > 0
+        ? parts.join(", ")
+        : "export+import wired (idempotent)";
+
+      return { ok: true, note };
+    },
+  };
+}

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -87,6 +87,16 @@ export interface JoiningStack {
    * O-4 (the register→issue handshake) SUPPLIES this; O-3 only consumes it.
    */
   operatorModePackage?: OperatorModeLeafPackage;
+  /**
+   * G1c (#1117, ADR-0013 Model B) — the agents NSC account (nkey-A) where the
+   * stack's dispatch-listener subscribes `federated.>`. This is the
+   * `--to-account` for `arc nats add-federation-export`. Optional today: when
+   * absent the wiring step uses `account` for both sides (same-account path —
+   * the arc primitive handles this as a no-op). A dedicated `agents_account`
+   * config field that splits the federation account from the agents account is
+   * tracked as G1d (cortex#1117 follow-up).
+   */
+  agentsAccount?: string;
 }
 
 // =============================================================================
@@ -289,6 +299,66 @@ export async function joinNetwork(
   // in the creds JWT; an `account:` line there crashes nats-server).
   const leafAccount =
     bindMode.mode === "operator-account" ? bindMode.account : undefined;
+
+  // (b.4) G1c (#1117, ADR-0013 Model B) — WIRE the local-side `federated.>`
+  // export/import BEFORE writing the leaf file (fail-fast: an arc failure here
+  // aborts before any mutation touches the live nats-server config). Skipped
+  // when:
+  //   - no `ports.federationWiring` wired (backwards-compat / pre-G1c callers),
+  //   - OR the bus is not operator-mode (a $G/creds-only bus has no NSC account
+  //     tree to add export/import to — no wiring is needed or possible).
+  //
+  // ADR-0013 Model B invariant: LOCAL accounts only — `federationAccount` is
+  // the leaf-bound nkey-A from `stack.account`; `agentsAccount` is the
+  // stack's own agents account (optional today — G1d tracks the split).
+  // cortex NEVER passes a peer account; no network id goes on the arc call.
+  if (ports.federationWiring !== undefined && leafAccount !== undefined) {
+    // Read apply from the ports bundle (G1c: `NetworkPorts.apply` mirrors the
+    // --apply flag from the CLI). Default: false (dry-run safe — the #794
+    // "never accidentally mutate" principle).
+    const wiringApply = ports.apply === true;
+    let wiringResult: { ok: true; note?: string } | { ok: false; reason: string };
+    try {
+      wiringResult = await ports.federationWiring.wireLocalFederation({
+        federationAccount: leafAccount,
+        agentsAccount: stack.agentsAccount,
+        apply: wiringApply,
+      });
+    } catch (err) {
+      // The port contract says "never throws"; guard here as belt-and-braces so
+      // a buggy port implementation (or a Bun.spawn ENOENT that escapes before
+      // the adapter wraps it) never escapes joinNetwork's "never throws" contract.
+      wiringResult = {
+        ok: false,
+        reason: `federation-wiring port threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    if (!wiringResult.ok) {
+      return {
+        ok: false,
+        steps,
+        reason:
+          `federation-wiring step failed — arc nats add-federation-export returned an error ` +
+          `(${wiringResult.reason}). The join is aborted before any nats-server config ` +
+          `was written. Ensure arc is installed (G1b / arc#243) and the NSC store is ` +
+          `accessible, then re-run join.`,
+      };
+    }
+    const wiringNote = wiringResult.note ?? "export+import wired";
+    steps.push(
+      `wired local-side federated.> export/import ` +
+      `(federation-account=${leafAccount}, ${wiringApply ? "applied" : "dry-run"}: ${wiringNote}) ` +
+      `(G1c ADR-0013 Model B)`,
+    );
+  } else if (ports.federationWiring !== undefined && leafAccount === undefined) {
+    // $G/creds-only bus: no NSC account — federation wiring is a no-op. Log
+    // so the principal can see why the step was skipped.
+    steps.push(
+      "skipped federation-wiring step: $G/creds-only bus has no NSC account " +
+      "(no export/import needed — the creds JWT binds the leaf directly) " +
+      "(G1c ADR-0013 Model B)",
+    );
+  }
 
   // (b.6) #821 — PRE-FLIGHT the creds file BEFORE any mutation. `nats-server -c
   // <cfg> -t` validates HOCON syntax but does NOT dereference the leaf remote's

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -376,6 +376,45 @@ export interface LeafLinkState {
   outMsgs?: number;
 }
 
+/**
+ * G1c (#1117, ADR-0013 Model B) — the federation-wiring seam.
+ *
+ * Shells out to `arc nats add-federation-export` (arc#243 / G1b) to wire
+ * the LOCAL-SIDE `federated.>` export/import between the stack's federation
+ * account (leaf-bound) and its agents account. Called at step (b.4) in
+ * `joinNetwork` — after bind-mode resolution (so the leaf account is known),
+ * before the leaf file write (fail-fast before any mutation on arc failure).
+ *
+ * cortex NEVER calls nsc directly (ADR-0013 Model B invariant).
+ * cortex NEVER passes a peer account (local-only wiring).
+ */
+export interface FederationWiringPort {
+  /**
+   * Wire the local-side `federated.>` export/import.
+   *
+   * @param params.federationAccount - The leaf-bound NSC account (nkey-A) —
+   *   `stack.nats_infra.account`, resolved from `JoiningStack.account`.
+   *   This is the `--from-account` for the arc primitive.
+   * @param params.agentsAccount - The agents NSC account where the
+   *   dispatch-listener subscribes (`--to-account`). Optional today: when
+   *   absent (the current single-account config), falls back to
+   *   `federationAccount` (same-account path — no cross-account routing
+   *   needed). A dedicated `agents_account` config field is tracked as G1d
+   *   (cortex#1117 follow-up).
+   * @param params.apply - Mirror the join's dry-run/--apply flag. `false`
+   *   (dry-run) → arc prints the plan, no nsc mutation. `true` → arc runs.
+   *
+   * @returns `{ ok: true, note }` on success (idempotent — already-present
+   *   export+import is also `ok`). `{ ok: false, reason }` on arc failure or
+   *   spawn error. NEVER throws.
+   */
+  wireLocalFederation(params: {
+    federationAccount: string;
+    agentsAccount: string | undefined;
+    apply: boolean;
+  }): Promise<{ ok: true; note?: string } | { ok: false; reason: string }>;
+}
+
 /** The full port bundle the orchestrator depends on. */
 export interface NetworkPorts {
   registry: NetworkRegistryPort;
@@ -392,4 +431,19 @@ export interface NetworkPorts {
   natsServer?: NatsServerPort;
   /** Optional — status link telemetry. Absent → link state "unknown". */
   leafState?: LeafStatePort;
+  /**
+   * G1c (#1117, ADR-0013 Model B) — federation-wiring seam. Optional for
+   * backwards compatibility: when absent the wiring step is skipped (the
+   * pre-G1c behaviour — the join still configures the leaf but does NOT wire
+   * the local-side `federated.>` export/import). Present → step (b.4) runs
+   * before the leaf write.
+   */
+  federationWiring?: FederationWiringPort;
+  /**
+   * G1c (#1117) — mirrors the `--apply` flag from the CLI. The wiring step
+   * passes this to `FederationWiringPort.wireLocalFederation` so the arc
+   * primitive runs in dry-run or apply mode consistently with the rest of the
+   * join. Default: `false` (dry-run safe). Live ports set this to `true`.
+   */
+  apply?: boolean;
 }


### PR DESCRIPTION
## Summary

Implements G1c (#1117): `cortex network join` now runs the local-side `federated.>` export/import wiring step after bind-mode resolution and before any nats-server config is written.

- Adds step (b.4) in `joinNetwork` (`network-lib.ts`): calls `FederationWiringPort.wireLocalFederation` with `federationAccount` (leaf-bound NSC account) and `agentsAccount` (optional, G1d gap).
- Fail-closed: arc failure aborts the join before any leaf file is written.
- Dry-run preserved: `ports.apply` threads through to the port; dry-run default unchanged.
- `$G`/creds-only bus: wiring step is skipped (no NSC account on a creds-only bus; the creds JWT binds the leaf directly).
- cortex NEVER calls nsc directly. cortex NEVER references a peer account. cortex NEVER puts the network id on the wire (ADR-0013 Model B invariant).

## New files

- `src/cli/cortex/commands/network-federation-wiring.ts` — live arc-shell adapter (`buildFederationWiringAdapter`), arc.nats.v2 schema guard, injectable `ArcFederationRunner` (same pattern as `creds.ts`).
- `src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts` — 19 tests covering step placement, apply/dry-run flag threading, arc failure abort, spawn throw, $G bus skip, same-account G1d path, schema guard, idempotent already-present.

## Modified files

- `network-ports.ts`: `FederationWiringPort` interface + `federationWiring?`/`apply?` on `NetworkPorts`.
- `network-adapters.ts`: wires `buildFederationWiringAdapter()` into live ports.
- `network-lib.ts`: step (b.4) insertion + carve-out vocab fix (`operator` → `principal` in comment).

## G1d gap

Current config has a single `stack.nats_infra.account`. When `agentsAccount` is absent, `--to-account` falls back to `federationAccount` (same-account no-op in arc). Dedicated split tracked as G1d (#1117 follow-up).

## Gates

- `bunx tsc --noEmit` — PASS
- `bun test src/cli/cortex/` — 862 pass / 0 fail
- `bun test src/` (full suite) — 7320 pass / 0 fail
- carve-out gate — PASS
- `bunx eslint --quiet .` — PASS (0 errors)

Closes #1117
Refs #1116