### PR TITLE
feat(adapters): slice renderer — lifecycle narrative to the per-slice thread (slice convergence B)

### DIFF
--- a/src/adapters/__tests__/envelope-renderer.test.ts
+++ b/src/adapters/__tests__/envelope-renderer.test.ts
@@ -137,6 +137,55 @@ describe("formatEnvelopeAsMarkdown — dispatch lifecycle", () => {
     }))).toBe("Ivy failed: claude exited 1");
   });
 
+  test("renders a dev-implement completed as an 'opened PR #N' milestone beat (slice convergence B / B3)", () => {
+    // The dev.implement consumer's terminal `completed` rides the PR ref as a
+    // JSON blob on `chat_response` (`dev-consumer.ts:744` —
+    // `chatResponse: JSON.stringify({ pr })`). Without this branch the slice
+    // renderer would post the raw `{"pr":{...}}` JSON into the slice thread.
+    // Render it as the clean "opened PR #N · url" milestone beat instead.
+    const pr = {
+      repo: "the-metafactory/cortex",
+      number: 1140,
+      url: "https://github.com/the-metafactory/cortex/pull/1140",
+    };
+    const out = formatDispatchLifecycle(
+      makeEnvelope({
+        type: "dispatch.task.completed",
+        payload: { agent_id: "forge", chat_response: JSON.stringify({ pr }) },
+      }),
+    );
+    expect(out).not.toBeNull();
+    // No raw JSON braces leak into the thread.
+    expect(out).not.toContain('{"pr"');
+    expect(out).toContain("opened");
+    expect(out).toContain("the-metafactory/cortex#1140");
+    expect(out).toContain("https://github.com/the-metafactory/cortex/pull/1140");
+  });
+
+  test("a plain-prose chat_response on completed still renders verbatim (no false PR-parse)", () => {
+    // The PR-milestone branch must only fire on a `{pr:{...}}` JSON blob, never
+    // swallow a normal chat reply (which is the common completed case).
+    const out = formatDispatchLifecycle(
+      makeEnvelope({
+        type: "dispatch.task.completed",
+        payload: { agent_id: "ivy", chat_response: "Here is the answer." },
+      }),
+    );
+    expect(out).toBe("Here is the answer.");
+  });
+
+  test("a completed with no chat_response still falls back to result_summary", () => {
+    // Regression guard: the PR-milestone branch must not disturb the existing
+    // result_summary fallback for non-chat dispatches.
+    const out = formatDispatchLifecycle(
+      makeEnvelope({
+        type: "dispatch.task.completed",
+        payload: { agent_id: "ivy", result_summary: "Done." },
+      }),
+    );
+    expect(out).toBe("Done.");
+  });
+
   test("renders a brain post's own text verbatim (cortex#1039 follow-up)", () => {
     // A brain `post` carries its content under payload.text — the composed
     // flow, the ask_principal prompt, per-step replies. Without rendering it

--- a/src/adapters/__tests__/review-sink.test.ts
+++ b/src/adapters/__tests__/review-sink.test.ts
@@ -850,3 +850,136 @@ describe("review-sink — attention delivery (ML.4)", () => {
     expect(adapter.sentMessages).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#1149 — slice convergence B: a slice's lifecycle narrative converges on
+// ONE {repo}/issue/N thread.
+//
+// The review sink IS the slice renderer (it already subscribes to
+// dispatch.task.* + review.verdict.*, reads logical routing, resolves
+// {repo}/issue/N → a thread via resolveLogicalTarget/findOrCreateThreadByName,
+// and renders via the existing formatters). These tests pin the slice
+// behaviour explicitly against the issue-thread address: a whole slice's beats
+// (started → post → completed → verdict) land in the ONE issue thread, in
+// order; an un-routed dispatch is skipped; and beats are never coalesced.
+// ---------------------------------------------------------------------------
+describe("review-sink — slice convergence (cortex#1149)", () => {
+  const issueThread = "cortex/issue/872";
+  const sliceRouting = logicalRouting("discord", "cortex", issueThread);
+
+  test("a slice's started+post+completed+verdict beats all land in the ONE issue thread, in order", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    // Distinct ids so the render-dedupe (per envelope.id) never collapses
+    // genuinely distinct beats. All carry the SAME slice address.
+    trigger(
+      envelopeWithId("00000000-0000-4000-8000-0000000009a1", "dispatch.task.started", {
+        agent_id: "forge",
+        response_routing: sliceRouting,
+      }),
+    );
+    trigger(
+      envelopeWithId("00000000-0000-4000-8000-0000000009a2", "dispatch.task.post", {
+        agent_id: "forge",
+        text: "building…",
+        response_routing: sliceRouting,
+      }),
+    );
+    trigger(
+      envelopeWithId("00000000-0000-4000-8000-0000000009a3", "dispatch.task.completed", {
+        agent_id: "forge",
+        chat_response: JSON.stringify({
+          pr: {
+            repo: "the-metafactory/cortex",
+            number: 1140,
+            url: "https://github.com/the-metafactory/cortex/pull/1140",
+          },
+        }),
+        response_routing: sliceRouting,
+      }),
+    );
+    trigger(
+      envelopeWithId("00000000-0000-4000-8000-0000000009a4", "review.verdict.approved", {
+        ...verdictPayload({ verdict: "approved", reviewer: "echo" }),
+        response_routing: sliceRouting,
+      }),
+    );
+    await flushMicrotasks();
+
+    // started → sendProgress; the other three → postResponse. ALL resolve the
+    // SAME issue thread (no pr/N thread, no per-dispatch fan-out).
+    for (const resolved of adapter.logicalTargetsResolved) {
+      expect(resolved).toEqual({ surface: "discord", channel: "cortex", thread: issueThread });
+    }
+    expect(adapter.progressSent).toHaveLength(1); // started
+    expect(adapter.progressSent[0]!.text).toContain("working");
+
+    // post, completed, verdict → three posts to the one thread, in order.
+    expect(adapter.sentMessages).toHaveLength(3);
+    for (const m of adapter.sentMessages) {
+      expect(m.target).toEqual({
+        instanceId: "discord-cortex",
+        channelId: "chan:cortex",
+        threadId: `thread:${issueThread}`,
+      });
+    }
+    expect(adapter.sentMessages[0]!.text).toContain("building…");
+    // The dev-implement completed renders as the clean "opened PR #N" milestone
+    // beat (not raw JSON).
+    expect(adapter.sentMessages[1]!.text).not.toContain('{"pr"');
+    expect(adapter.sentMessages[1]!.text).toContain("the-metafactory/cortex#1140");
+    // The verdict one-liner + reviewer ping.
+    expect(adapter.sentMessages[2]!.text).toContain("@echo");
+    expect(adapter.sentMessages[2]!.text).toContain("approved");
+  });
+
+  test("a dispatch beat WITHOUT response_routing is skipped (un-stamped → nothing posted)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelopeWithId("00000000-0000-4000-8000-0000000009b1", "dispatch.task.post", {
+        agent_id: "forge",
+        text: "building…",
+        // no response_routing — pilot A′ hasn't stamped a real address yet.
+      }),
+    );
+    await flushMicrotasks();
+
+    expect(adapter.sentMessages).toHaveLength(0);
+    expect(adapter.progressSent).toHaveLength(0);
+    expect(adapter.logicalTargetsResolved).toHaveLength(0);
+  });
+
+  test("no coalescing — two distinct beats produce two posts (not collapsed)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelopeWithId("00000000-0000-4000-8000-0000000009c1", "dispatch.task.post", {
+        agent_id: "forge",
+        text: "building…",
+        response_routing: sliceRouting,
+      }),
+    );
+    trigger(
+      envelopeWithId("00000000-0000-4000-8000-0000000009c2", "dispatch.task.post", {
+        agent_id: "forge",
+        text: "running gates…",
+        response_routing: sliceRouting,
+      }),
+    );
+    await flushMicrotasks();
+
+    expect(adapter.sentMessages).toHaveLength(2);
+    expect(adapter.sentMessages[0]!.text).toContain("building…");
+    expect(adapter.sentMessages[1]!.text).toContain("running gates…");
+  });
+});

--- a/src/adapters/envelope-renderer.ts
+++ b/src/adapters/envelope-renderer.ts
@@ -85,7 +85,19 @@ export function formatDispatchLifecycle(envelope: Envelope): string | null {
     // cortex#491 — full reply when present (chat round-trip), else the
     // dashboard summary label, else a terse default.
     const full = typeof payload.chat_response === "string" ? payload.chat_response.trim() : "";
-    if (full) return full;
+    if (full) {
+      // cortex#1149 (slice convergence B / B3) — the dev.implement consumer's
+      // terminal completed rides the PR ref as a JSON blob on `chat_response`
+      // (`dev-consumer.ts` — `chatResponse: JSON.stringify({ pr })`), because
+      // the dispatch builder has no dedicated `pr` field. On the slice thread
+      // that blob would post as raw JSON; render it instead as the clean
+      // "opened PR #N · url" milestone beat. Only a `{ pr: { repo, number } }`
+      // shape triggers this — any other prose falls through verbatim, so a
+      // normal chat reply is never swallowed.
+      const milestone = formatPrMilestone(full);
+      if (milestone !== null) return milestone;
+      return full;
+    }
     const summary = typeof payload.result_summary === "string" ? payload.result_summary.trim() : "Done.";
     return summary || "Done.";
   }
@@ -101,6 +113,42 @@ export function formatDispatchLifecycle(envelope: Envelope): string | null {
   }
 
   return null;
+}
+
+/**
+ * cortex#1149 (slice convergence B / B3) — parse a dev.implement completed's
+ * `chat_response` PR blob and render the "opened PR #N · url" milestone beat.
+ *
+ * The dev consumer rides the PR ref as `JSON.stringify({ pr })` on
+ * `chat_response` (there's no dedicated `pr` field on the dispatch builder).
+ * On the slice thread that blob would otherwise post as raw JSON. Returns the
+ * milestone string for a `{ pr: { repo, number, url? } }` shape, or `null` for
+ * any other text (a normal prose chat reply) so the caller falls through to
+ * rendering it verbatim — the parse is intentionally narrow.
+ */
+function formatPrMilestone(chatResponse: string): string | null {
+  // Cheap pre-check: only attempt a parse on something that looks like the
+  // `{pr:...}` blob, never on arbitrary prose.
+  if (!chatResponse.startsWith("{") || !chatResponse.includes('"pr"')) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(chatResponse);
+  } catch {
+    // Not JSON (prose that merely happens to start with `{`) — fall through.
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object") return null;
+  const pr = (parsed as Record<string, unknown>).pr;
+  if (pr === null || typeof pr !== "object") return null;
+  const ref = pr as Record<string, unknown>;
+  const repo = typeof ref.repo === "string" ? ref.repo : null;
+  const number = typeof ref.number === "number" ? ref.number : null;
+  if (repo === null || number === null) return null;
+  const url = typeof ref.url === "string" && ref.url.length > 0 ? ref.url : null;
+  const head = `opened ${repo}#${number}`;
+  return url ? `${head} · ${url}` : head;
 }
 
 /**


### PR DESCRIPTION
Closes #1149
Part of #1147

## What this is

Slice convergence **B**: a slice's lifecycle **narrative** (started → building → opened PR → review verdict → fixing → merged) converges on **one** `{repo}/issue/N` Discord thread under the repo/session channel, gathering `dispatch.task.{started,post,completed,failed,aborted}` + `review.verdict.*` for one slice, grouped by `response_routing.{channel,thread}`.

## Reuse vs delta (grounded first)

This turned out to be a **small delta** — the heavy lifting already shipped.

**Pre-existing (reused, NOT rebuilt):**
- `src/adapters/review-sink.ts` **is** the slice renderer. It already:
  - subscribes to BOTH `dispatch.task.*` (incl. `dispatch.task.post`) AND `review.verdict.*` via `runtime.subscribe` + `runtime.onEnvelope` (not `surfaceSubjects` — that would double-reply),
  - reads the **logical** `response_routing` (`{surface, channel, thread}`) via `readLogicalRouting`,
  - resolves `{repo}/issue/N` → a real thread via `adapter.resolveLogicalTarget`, which internally uses `resolveChannel` + `findOrCreateThreadByName` (`src/adapters/discord/index.ts`),
  - renders every beat through the **existing** `envelope-renderer.ts` formatters (`formatDispatchLifecycle`, `formatReviewVerdict`),
  - **skips** envelopes with no `response_routing` (un-stamped dispatches render nothing — `readLogicalRouting` → `null` → return),
  - does **no coalescing** (each delivery is per-`envelope.id`, dedup is exact-duplicate only via the shared `createRenderDedupe`).
- **Slice A** already wired `src/runner/dev-consumer.ts` to echo inbound `response_routing` onto every dev lifecycle envelope, so the address is on the wire.
- Because the thread name comes straight from `response_routing.thread`, grouping a slice's beats into ONE `{repo}/issue/N` thread (vs the `pr/N` thread) falls out for free — no new grouping logic needed.

**The delta (the only code change):**
- The dev.implement consumer's terminal `dispatch.task.completed` rides the PR ref as `JSON.stringify({ pr })` on `chat_response` (the dispatch builder has no dedicated `pr` field — flagged in F-2). `formatDispatchLifecycle` returned that blob verbatim, so the slice thread posted **raw JSON** instead of a clean milestone beat (work item B3).
- Fix: in the shared `formatDispatchLifecycle` (`src/adapters/envelope-renderer.ts`), parse a `{ pr: { repo, number, url? } }` `chat_response` and render the **"opened PR #N · url"** milestone beat. **Reuse — no new formatter, no new sink, no new SurfaceAdapter.** The parse is intentionally narrow (must start with `{`, contain `"pr"`, parse to an object with `pr.repo` + `pr.number`), so a normal prose chat reply is **never** swallowed.

No new surface-router registration was needed: the review-sink is already wired in `cortex.ts` (`createReviewSink`, ~line 4196) and already subscribes to the exact subjects.

## How it routes to the thread

`orchestrator stamps response_routing.thread = {repo}/issue/N` → `dev-consumer echoes it onto every dispatch.task.* envelope (Slice A)` → `review-sink reads the logical address, resolves it to a thread via findOrCreateThreadByName, renders the beat via the existing formatters, posts`. Every beat for the slice carries the same address, so they all land in the one issue thread, in order.

## Tests (TDD, mirror `src/adapters/__tests__` style; mock the discord adapter)

**`envelope-renderer.test.ts`** (the formatter delta):
- dev-implement `completed` with `chat_response = {"pr":{...}}` → clean `opened {repo}#N · url` beat, no raw JSON braces.
- plain-prose `chat_response` on `completed` → renders verbatim (no false PR-parse).
- `completed` with no `chat_response` → still falls back to `result_summary`.

**`review-sink.test.ts`** (slice convergence, `cortex#1149` block):
- a slice's `started + post + completed + verdict` beats, all carrying `response_routing.thread = "cortex/issue/872"` → started → `sendProgress`; post/completed/verdict → three `postResponse`s, **all resolving the ONE issue thread**, in order; the completed renders as the PR milestone (not JSON); the verdict carries the reviewer ping.
- a `dispatch.task.post` with **no** `response_routing` → skipped (nothing posted, no resolve).
- **no coalescing** — two distinct `post` beats → two posts (not collapsed).

## Gates
- `bunx tsc --noEmit` — clean.
- `bunx eslint <changed files>` — clean.
- `bun test src/adapters/__tests__/` — 92 pass / 0 fail.

## worklog-manager
Left **intact** — verified not in the diff (`git diff --name-only` has zero `worklog-manager` hits). Its retirement (work item B2) is split out per open-question #2 (broader blast radius); the renderer and worklog-manager coexist (distinct sources/channels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)