### PR TITLE
fix(arc): manifest hook source must track SurfaceContext rename (#1079)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -54,12 +54,14 @@ provides:
       target: ~/.claude/skills/Discord
 
     # ─── Claude Code hooks ────────────────────────────────────
-    # Hook source filenames keep grove-era names (GroveContext.hook.ts,
-    # EventLogger.hook.ts, bash-guard.hook.ts) so the in-repo tree stays
-    # operator-facing-stable while internals migrate. The installed symlink
-    # targets ARE renamed to Cortex* so settings.json references are
-    # cortex-side and don't collide with grove leftovers.
-    - source: src/taps/cc-events/hooks/GroveContext.hook.ts
+    # Some hook source filenames keep grove-era names (EventLogger.hook.ts,
+    # bash-guard.hook.ts) so the in-repo tree stays operator-facing-stable
+    # while internals migrate. The installed symlink targets ARE renamed to
+    # Cortex* so settings.json references are cortex-side and don't collide
+    # with grove leftovers. NOTE: GroveContext.hook.ts was renamed to
+    # SurfaceContext.hook.ts in #1079 (GV-2) — the source path below MUST
+    # track that rename or arc recreates a dangling CortexContext symlink.
+    - source: src/taps/cc-events/hooks/SurfaceContext.hook.ts
       target: ~/.claude/hooks/CortexContext.hook.ts
     - source: src/taps/cc-events/hooks/EventLogger.hook.ts
       target: ~/.claude/hooks/CortexEventLogger.hook.ts

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -58,9 +58,10 @@ provides:
     # bash-guard.hook.ts) so the in-repo tree stays operator-facing-stable
     # while internals migrate. The installed symlink targets ARE renamed to
     # Cortex* so settings.json references are cortex-side and don't collide
-    # with grove leftovers. NOTE: GroveContext.hook.ts was renamed to
-    # SurfaceContext.hook.ts in #1079 (GV-2) — the source path below MUST
-    # track that rename or arc recreates a dangling CortexContext symlink.
+    # with grove leftovers. NOTE: each `source` below MUST match the actual
+    # filename in src/taps/cc-events/hooks/ — rename the file and update this
+    # path in the SAME commit, or arc recreates a dangling symlink at the
+    # target (the cause of the CortexContext breakage this entry fixes).
     - source: src/taps/cc-events/hooks/SurfaceContext.hook.ts
       target: ~/.claude/hooks/CortexContext.hook.ts
     - source: src/taps/cc-events/hooks/EventLogger.hook.ts


### PR DESCRIPTION
## Problem

After `arc upgrade Cortex`, the SessionStart context hook is dead. `~/.claude/hooks/CortexContext.hook.ts` is a **dangling symlink**:

```
CortexContext.hook.ts -> src/taps/cc-events/hooks/GroveContext.hook.ts   (file no longer exists)
```

#1079 (GV-2) renamed `GroveContext.hook.ts → SurfaceContext.hook.ts` (file + class + display string) but **did not update `arc-manifest.yaml` `provides.hooks`**, which still declared `source: src/taps/cc-events/hooks/GroveContext.hook.ts`. So `arc` recreates the `CortexContext` symlink pointing at a path that no longer exists, and the cortex session-context injection (network identity / channel scoping via `SurfaceContext`) silently fails on every Claude Code session start.

## Fix

- `arc-manifest.yaml` hook source → `src/taps/cc-events/hooks/SurfaceContext.hook.ts`
- Added a guard comment so a future hook rename keeps the manifest in sync.

The other two hook sources (`EventLogger.hook.ts`, `bash-guard.hook.ts`) keep their grove-era filenames and are unaffected.

## Verification

- `git show origin/main:src/taps/cc-events/hooks/SurfaceContext.hook.ts` resolves; `GroveContext.hook.ts` is gone on `origin/main`.
- Re-pointed the installed symlink locally to `SurfaceContext.hook.ts`; it resolves (`test -f` passes). After this lands, `arc upgrade Cortex` writes the correct target itself.
- `bunx tsc --noEmit` clean for the touched tree (pre-push smoke test passes).

## Out of scope

- The `caveman@caveman` plugin's SessionStart auto-injection (shown adjacent in the same hook dump that surfaced this) is unrelated to cortex — it's a separate Claude Code plugin, intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)