### PR TITLE
fix(pier): public entry channel + drop retired roles field (Refs #1142)

### DIFF
--- a/agents.d/pier.yaml
+++ b/agents.d/pier.yaml
@@ -8,7 +8,7 @@
 # `arc upgrade pier`.  Edit the source in the pier package instead.
 #
 # Two axes governed here (per design-arc-agent-bots.md §2):
-#   Identity  — id, displayName, roles, trust
+#   Identity  — id, displayName, trust
 #   Presence  — discord bound to the metafactory community guild
 #
 # Substrate + capabilities are declared in arc-manifest-pier.yaml;
@@ -18,7 +18,10 @@
 id: pier
 displayName: Pier
 persona: ~/.config/cortex/personas/pier.md
-roles: [agent-restricted]
+# `roles:` is intentionally absent — AgentSchema.roles[] was retired at the
+# v2.0.0 cutover (cortex#297) and authorization now lives on policy.principals[].
+# Pier's "issues nothing" boundary is enforced by its persona + the admission
+# gate it can only *surface* (never approve); it mints no NATS credentials.
 trust: [luna]
 
 # Substrate + mode persisted per design-arc-agent-bots.md §4 Q3.
@@ -27,23 +30,29 @@ runtime:
   mode: in-process
   capabilities:
     - onboarding            # drives Tier-1 and Tier-2 community onboarding
-    - chat                  # responds to newcomer messages in #assistant-fleet-onboarding
+    - chat                  # responds to newcomer messages in #onboard-your-fleet
 
 # Discord presence — bound to the metafactory community guild.
 # The bot token is a secret resolved at install time from the host
 # environment or principal vault.  It is NEVER stored in this file.
 #
-# guildId:   1505549701674700991    (The Metafactory — community guild)
-# channel:   1514679294553751613    (#assistant-fleet-onboarding)
+# Three-channel topology (the public-entry / private-back-office split):
+#   guildId:        1505549701674700991  (The Metafactory — community guild)
+#   agentChannelId: 1517154685595942972  (#onboard-your-fleet — PUBLIC entry;
+#                                          newcomers must reach Pier here before
+#                                          they hold the community-fleet role)
+#   logChannelId:   1514679294553751613  (#assistant-fleet-onboarding — PRIVATE
+#                                          back-office; admission audit trail,
+#                                          principal + Pier only)
 #
 # env var:   PIER_BOT_TOKEN         — set by the operator before arc install
 presence:
   discord:
     enabled: true
     token: ${PIER_BOT_TOKEN}          # placeholder; resolved at cortex load
-    guildId: "1505549701674700991"    # The Metafactory community guild
-    agentChannelId: "1514679294553751613"  # #assistant-fleet-onboarding
-    logChannelId: "1514679294553751613"    # same channel — Pier is public-facing
+    guildId: "1505549701674700991"        # The Metafactory community guild
+    agentChannelId: "1517154685595942972" # #onboard-your-fleet — public entry
+    logChannelId: "1514679294553751613"   # #assistant-fleet-onboarding — private back-office
     dmOwner: false                    # Pier never claims DMs; it answers the public channel
     contextDepth: 10
     surfaceSubjects: []               # no raw envelope surface — Pier posts only via its persona

--- a/personas/pier.md
+++ b/personas/pier.md
@@ -4,7 +4,7 @@ preferredModel: claude-sonnet-4-5
 allowedTools: [Read, Bash]
 behavior:
   issues_nothing: true       # Pier admits and guides; it NEVER mints NATS credentials
-  greet_newcomers: true      # auto-greets on first message in #assistant-fleet-onboarding
+  greet_newcomers: true      # auto-greets on first message in #onboard-your-fleet (public entry)
   two_tier_aware: true
 temperature: 0.4
 maxTokens: 2048
@@ -13,9 +13,15 @@ tags: [onboarding, community, concierge, assistant-fleet]
 
 # Pier — Community Onboarding Concierge
 
-You are Pier, the onboarding concierge for the metafactory community guild.  You live in
-`#assistant-fleet-onboarding` and help newcomers participate in the assistant fleet.  You
-admit and guide — you issue nothing.
+You are Pier, the onboarding concierge for the metafactory community guild.  You greet
+newcomers in `#onboard-your-fleet` — the public entry channel anyone can reach before they
+hold any role — and help them participate in the assistant fleet.  You admit and guide —
+you issue nothing.
+
+Your admission audit trail (who you admitted, when, on whose approval) goes to
+`#assistant-fleet-onboarding`, the private back-office where only the principal and you can
+see it.  `#assistant-fleet` itself is the gated working surface a newcomer reaches *after*
+you assign them the `community-fleet` role.
 
 ## Identity and purpose
 

--- a/src/cli/cortex/commands/__tests__/pier-fragment.test.ts
+++ b/src/cli/cortex/commands/__tests__/pier-fragment.test.ts
@@ -75,10 +75,11 @@ describe("Pier agent fragment (agents.d/pier.yaml)", () => {
     expect(f.displayName).toBe("Pier");
   });
 
-  test("roles includes 'agent-restricted'", () => {
+  test("does NOT carry a retired `roles` field (AgentSchema.roles[] retired at v2.0.0, cortex#297)", () => {
     const f = loadFragment();
-    expect(Array.isArray(f.roles)).toBe(true);
-    expect(f.roles as string[]).toContain("agent-restricted");
+    // Authorization moved to policy.principals[]; the agent fragment must not
+    // re-introduce the retired field (Zod would silently strip it).
+    expect(f.roles).toBeUndefined();
   });
 
   test("trust includes 'luna'", () => {
@@ -117,11 +118,22 @@ describe("Pier agent fragment (agents.d/pier.yaml)", () => {
     expect(discord.guildId).toBe("1505549701674700991");
   });
 
-  test("presence.discord.agentChannelId is #assistant-fleet-onboarding", () => {
+  test("presence.discord.agentChannelId is #onboard-your-fleet (PUBLIC entry channel)", () => {
     const f = loadFragment();
     const presence = f.presence as Record<string, unknown>;
     const discord = presence.discord as Record<string, unknown>;
-    expect(discord.agentChannelId).toBe("1514679294553751613");
+    // Pier must greet newcomers in a channel they can reach BEFORE holding the
+    // community-fleet role — the public entry, not the gated working surface.
+    expect(discord.agentChannelId).toBe("1517154685595942972");
+  });
+
+  test("presence.discord.logChannelId is #assistant-fleet-onboarding (PRIVATE back-office)", () => {
+    const f = loadFragment();
+    const presence = f.presence as Record<string, unknown>;
+    const discord = presence.discord as Record<string, unknown>;
+    // Admission audit trail lands in the private back-office (principal + Pier only),
+    // distinct from the public entry channel.
+    expect(discord.logChannelId).toBe("1514679294553751613");
   });
 
   test("presence.discord.token references env var placeholder (not a real token)", () => {


### PR DESCRIPTION
## What

Two going-live fixes to the Pier onboarding-concierge package shipped in #1145.

### 1. Public entry channel (the chicken-and-egg fix)
`agentChannelId` pointed at the **private** `#assistant-fleet-onboarding`, so a brand-new community member — who holds no role yet — had no channel where they could reach Pier. You can't onboard through a channel that requires the very role onboarding grants.

Corrected to the **three-channel topology**:

| Channel | Role | Field |
|---|---|---|
| `#onboard-your-fleet` (`1517154685595942972`) | **Public entry** — anyone can post; Pier greets here | `agentChannelId` |
| `#assistant-fleet` | Gated working surface — unlocked by the `community-fleet` role | (not Pier-bound) |
| `#assistant-fleet-onboarding` (`1514679294553751613`) | **Private back-office** — admission audit trail, principal + Pier only | `logChannelId` |

### 2. Drop the retired `roles:` field
`roles: [agent-restricted]` is a **no-op** — `AgentSchema.roles[]` was retired at the v2.0.0 cutover (cortex#297); authorization moved to `policy.principals[]`. Zod silently strips it, so the fragment was carrying a field that does nothing. Removed, with a comment documenting that Pier's *issues-nothing* boundary is enforced by its persona + the surface-only admission gate (Pier mints no NATS credentials and has no bus identity — it's `mode: in-process`).

## Files
- `agents.d/pier.yaml` — channel rebind + roles removal + topology comments
- `personas/pier.md` — greet in `#onboard-your-fleet`; audit trail to back-office
- `src/cli/cortex/commands/__tests__/pier-fragment.test.ts` — assertions updated (agentChannelId → public, logChannelId → back-office, roles-absent invariant)

## Gates
- `bunx tsc --noEmit` — clean
- `bun test …/pier-fragment.test.ts` — 32 pass / 0 fail
- carve-out gate — PASS
- eslint (changed files) — clean

Refs #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)