### PR TITLE
feat(mc): slice-rollup — bind dispatch anchor-tasks to the issue work_item (slice convergence C)

### DIFF
--- a/src/surface/mc/__tests__/slice-rollup-projection.test.ts
+++ b/src/surface/mc/__tests__/slice-rollup-projection.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Slice convergence C (cortex#1150 / docs/design-slice-activity-thread.md §C):
+ * MC rolls up a slice's per-dispatch activity under the issue's `work_item`.
+ *
+ * When the dispatch-lifecycle projection ingests an envelope carrying
+ * `response_routing.thread = "{repo}/issue/N"`, it:
+ *   - upserts the issue's `work_item` (keyed by the deterministic slice id,
+ *     provider github) — lazy-creating a stub when absent so a later GitHub
+ *     ingest enriches the SAME row by the same key, and
+ *   - links the per-dispatch anchor `task` to that work_item (the queryable
+ *     `tasks.work_item_id` column),
+ * keeping the existing `correlation_id` anchor intact (additive).
+ *
+ * Coverage axes (per the brief's TDD list):
+ *   1. One dispatch with an issue thread → a github work_item for the issue
+ *      exists and the anchor task is linked to it.
+ *   2. Two dispatches (implement corr-A + review corr-B) for the SAME issue →
+ *      both anchor tasks link to the SAME work_item (the slice rollup).
+ *   3. A later GitHub-ingest upsert for the same issue → enriches the SAME row
+ *      (no duplicate work_item, status/priority preserved, not clobbered).
+ *   4. No response_routing → no work_item link (backward compatible).
+ *   5. A non-issue thread (e.g. {repo}/pr/N) → no work_item link.
+ *   6. A FEDERATED dispatch's anchor links to the work_item too (lifecycle only).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { SCHEMA_SQL } from "../db/schema";
+import { upsertWorkItem, getWorkItem } from "../db/work-items";
+import { projectDispatchLifecycle } from "../projection/dispatch-lifecycle";
+import { workItemIdForSlice } from "../projection/anchor";
+import {
+  createDispatchTaskStartedEvent,
+  createDispatchTaskCompletedEvent,
+  type DispatchEventSource,
+  type LogicalResponseRouting,
+} from "../../../bus/dispatch-events";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+
+const SOURCE: DispatchEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+
+const STARTED_AT = new Date("2026-06-19T12:00:00.000Z");
+const COMPLETED_AT = new Date("2026-06-19T12:05:00.000Z");
+
+// Distinct per-dispatch task ids (each dispatch has its own correlation_id).
+const TASK_IMPLEMENT = "11111111-1111-4111-8111-111111111111";
+const TASK_REVIEW = "22222222-2222-4222-8222-222222222222";
+
+const ISSUE_THREAD = "cortex/issue/872";
+const SLICE_REF = { repo: "cortex", issueNumber: 872 };
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+function startedFor(
+  taskId: string,
+  routing?: LogicalResponseRouting,
+): Envelope {
+  return createDispatchTaskStartedEvent({
+    source: SOURCE,
+    taskId,
+    agentId: "cortex",
+    startedAt: STARTED_AT,
+    ...(routing !== undefined && { responseRouting: routing }),
+  });
+}
+
+function completedFor(
+  taskId: string,
+  routing?: LogicalResponseRouting,
+): Envelope {
+  return createDispatchTaskCompletedEvent({
+    source: SOURCE,
+    taskId,
+    agentId: "cortex",
+    startedAt: STARTED_AT,
+    completedAt: COMPLETED_AT,
+    resultSummary: "done",
+    ...(routing !== undefined && { responseRouting: routing }),
+  });
+}
+
+const logical = (thread: string): LogicalResponseRouting => ({
+  surface: "discord",
+  channel: "cortex",
+  thread,
+});
+
+/** The anchor task's work_item_id (the slice link), or null. */
+function anchorWorkItemId(db: Database, taskId: string): string | null {
+  const row = db
+    .query(`SELECT work_item_id FROM tasks WHERE id = ?`)
+    .get(`mc-dispatch-task-${taskId}`) as { work_item_id: string | null } | null;
+  return row ? row.work_item_id : null;
+}
+
+function workItemCount(db: Database): number {
+  return (
+    db.query(`SELECT COUNT(*) AS n FROM work_items`).get() as { n: number }
+  ).n;
+}
+
+describe("slice-rollup projection (slice convergence C)", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = setupDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("a dispatch with response_routing.thread={repo}/issue/N creates the issue work_item and links the anchor task", () => {
+    projectDispatchLifecycle(db, startedFor(TASK_IMPLEMENT, logical(ISSUE_THREAD)));
+
+    const expectedId = workItemIdForSlice(SLICE_REF);
+    const wi = getWorkItem(db, expectedId);
+    expect(wi).not.toBeNull();
+    expect(wi!.provider).toBe("github");
+    expect(wi!.externalId).toBe("cortex#872");
+
+    // The per-dispatch anchor task is linked to the issue work_item.
+    expect(anchorWorkItemId(db, TASK_IMPLEMENT)).toBe(expectedId);
+
+    // The correlation_id anchor stays intact (additive): the session row exists.
+    const sessions = db.query(`SELECT id FROM sessions`).all() as { id: string }[];
+    expect(sessions).toHaveLength(1);
+  });
+
+  it("two dispatches (implement + review) for the same issue link to the SAME work_item (the slice rollup)", () => {
+    // Implement dispatch (corr A) and review dispatch (corr B), same issue.
+    projectDispatchLifecycle(db, startedFor(TASK_IMPLEMENT, logical(ISSUE_THREAD)));
+    projectDispatchLifecycle(db, startedFor(TASK_REVIEW, logical(ISSUE_THREAD)));
+
+    const sliceId = workItemIdForSlice(SLICE_REF);
+
+    // Both anchor tasks point at the one slice work_item.
+    expect(anchorWorkItemId(db, TASK_IMPLEMENT)).toBe(sliceId);
+    expect(anchorWorkItemId(db, TASK_REVIEW)).toBe(sliceId);
+
+    // Exactly ONE work_item — the slice, not one per dispatch.
+    expect(workItemCount(db)).toBe(1);
+
+    // The slice card gathers its dispatches: query the anchor tasks by work_item.
+    const rolledUp = db
+      .query(`SELECT id FROM tasks WHERE work_item_id = ? ORDER BY id`)
+      .all(sliceId) as { id: string }[];
+    expect(rolledUp.map((r) => r.id)).toEqual([
+      `mc-dispatch-task-${TASK_IMPLEMENT}`,
+      `mc-dispatch-task-${TASK_REVIEW}`,
+    ]);
+  });
+
+  it("a later GitHub-ingest upsert for the same issue enriches the SAME row (no duplicate, status preserved)", () => {
+    // Slice projection lazy-creates the stub.
+    projectDispatchLifecycle(db, startedFor(TASK_IMPLEMENT, logical(ISSUE_THREAD)));
+    const sliceId = workItemIdForSlice(SLICE_REF);
+    expect(workItemCount(db)).toBe(1);
+
+    // A GitHub ingest enriches the SAME row by the same key (title, status, url).
+    upsertWorkItem(db, {
+      id: sliceId,
+      planId: null,
+      phaseId: null,
+      parentId: null,
+      title: "Slice convergence C — MC slice-rollup",
+      description: "the real issue title",
+      status: "open",
+      priority: "now",
+      provider: "github",
+      externalId: "cortex#872",
+      url: "https://github.com/the-metafactory/cortex/issues/872",
+    });
+
+    // Still ONE row — no parallel entity.
+    expect(workItemCount(db)).toBe(1);
+    const enriched = getWorkItem(db, sliceId)!;
+    expect(enriched.title).toBe("Slice convergence C — MC slice-rollup");
+    expect(enriched.status).toBe("open");
+    expect(enriched.url).toBe(
+      "https://github.com/the-metafactory/cortex/issues/872",
+    );
+
+    // A REDELIVERED slice dispatch must NOT clobber the enriched fields back to
+    // the empty stub defaults (create-if-absent, never downgrade).
+    projectDispatchLifecycle(db, completedFor(TASK_IMPLEMENT, logical(ISSUE_THREAD)));
+    const afterRedeliver = getWorkItem(db, sliceId)!;
+    expect(afterRedeliver.status).toBe("open");
+    expect(afterRedeliver.title).toBe("Slice convergence C — MC slice-rollup");
+    expect(workItemCount(db)).toBe(1);
+    // The anchor link still holds.
+    expect(anchorWorkItemId(db, TASK_IMPLEMENT)).toBe(sliceId);
+  });
+
+  it("no response_routing → no work_item link (backward compatible)", () => {
+    projectDispatchLifecycle(db, startedFor(TASK_IMPLEMENT));
+    expect(workItemCount(db)).toBe(0);
+    expect(anchorWorkItemId(db, TASK_IMPLEMENT)).toBeNull();
+  });
+
+  it("a non-issue thread ({repo}/pr/N) → no work_item link", () => {
+    projectDispatchLifecycle(db, startedFor(TASK_IMPLEMENT, logical("cortex/pr/57")));
+    expect(workItemCount(db)).toBe(0);
+    expect(anchorWorkItemId(db, TASK_IMPLEMENT)).toBeNull();
+  });
+
+  it("a federated dispatch's anchor links to the work_item too (lifecycle only, no special-case)", () => {
+    // A federated review dispatch carries the SAME slice address; only its
+    // terminal verdict lands (no interior projected from a peer). The anchor
+    // still links to the slice work_item exactly like a local dispatch.
+    projectDispatchLifecycle(db, completedFor(TASK_REVIEW, logical(ISSUE_THREAD)));
+    const sliceId = workItemIdForSlice(SLICE_REF);
+    expect(anchorWorkItemId(db, TASK_REVIEW)).toBe(sliceId);
+    expect(workItemCount(db)).toBe(1);
+  });
+});

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -47,6 +47,15 @@ export const SCHEMA_SQL: string[] = [
     source_url TEXT,
     source_external_id TEXT,
     related_refs_json TEXT,
+    -- Slice convergence C (cortex#1150 / docs/design-slice-activity-thread.md §C):
+    -- the slice-rollup link. A dispatch anchor-task points at the issue's
+    -- work_item (the slice) so MC rolls up a slice's per-dispatch activity under
+    -- ONE card. Queryable column (not buried in related_refs_json) so the slice
+    -- card gathers its dispatches with an indexed WHERE work_item_id = ? filter,
+    -- mirroring pull_requests.work_item_id. Intentionally NOT a hard FK: the
+    -- work_item may be a lazily-created stub and ingestion order isn't
+    -- guaranteed, matching pull_requests.work_item_id (wired, not enforced).
+    work_item_id TEXT,
     status TEXT NOT NULL DEFAULT 'open'
       CHECK(status IN ('open','in_progress','done','cancelled')),
     created_at INTEGER NOT NULL DEFAULT (unixepoch()),
@@ -212,6 +221,16 @@ export const SCHEMA_SQL: string[] = [
   // Composite covers status= filter via leftmost-prefix and the full ORDER BY.
   `CREATE INDEX IF NOT EXISTS idx_tasks_status_priority_updated
      ON tasks(status, priority, updated_at DESC)`,
+  // Slice convergence C (cortex#1150) — the slice card gathers its dispatch
+  // anchor-tasks by work_item_id; indexed for a straight scan, mirroring
+  // idx_pull_requests_work_item. The partner index idx_tasks_work_item is
+  // DELIBERATELY NOT declared here — it indexes work_item_id, a column an
+  // existing pre-C DB does not carry when init.ts runs this SCHEMA_SQL loop
+  // (which precedes the COLUMN_ADD_MIGRATIONS loop). Declaring it here crashes
+  // initDatabase on those DBs with `no such column: work_item_id` (the same
+  // #961/#1048 bug class as parent_session_id / origin_kind). It is created
+  // instead by the work_item_id COLUMN_ADD_MIGRATIONS post[] below, which runs
+  // AFTER the column ALTER AND unconditionally (so fresh DBs get it too).
 
   // --- iterations (F-13 / Decision 3) ---
   // Grove-owned lifecycle for the iteration planning surface. Per F-13
@@ -655,6 +674,21 @@ export const COLUMN_ADD_MIGRATIONS: ColumnAddMigration[] = [
     ],
   },
 
+  // Slice convergence C (cortex#1150) — tasks.work_item_id for EXISTING DBs.
+  // Fresh DBs get it from the tasks CREATE TABLE above; an already-initialised
+  // DB (the running stacks) backfills it here via the same pragma_table_info
+  // gate. Nullable, no FK clause (the work_item may be a lazy stub; matches the
+  // pull_requests.work_item_id "wired, not enforced" policy). The partner index
+  // is idempotent via CREATE INDEX IF NOT EXISTS.
+  {
+    table: "tasks",
+    column: "work_item_id",
+    ddl: `ALTER TABLE tasks ADD COLUMN work_item_id TEXT`,
+    post: [
+      `CREATE INDEX IF NOT EXISTS idx_tasks_work_item ON tasks(work_item_id)`,
+    ],
+  },
+
   // ST-P0 / ADR-0011 — canonical session columns for EXISTING DBs. Fresh DBs
   // get these from the sessions CREATE TABLE above; an already-initialised DB
   // (the running stacks) backfills them here via the same pragma_table_info
@@ -765,7 +799,11 @@ export const REBUILD_MIGRATIONS: RebuildMigration[] = [
     detect: (sql) => /source_system\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*source_system\s+IN/i.test(sql),
     steps: [
       // New tasks shape: base columns (source_system CHECK dropped; status CHECK
-      // kept) + the iteration_id column added by COLUMN_ADD_MIGRATIONS.
+      // kept) + every column added by COLUMN_ADD_MIGRATIONS (iteration_id;
+      // work_item_id — slice convergence C, cortex#1150). init.ts runs
+      // COLUMN_ADD_MIGRATIONS BEFORE this rebuild, so on an old-shape DB both
+      // added columns already exist on the live `tasks` table and the INSERT
+      // below can copy them.
       `CREATE TABLE tasks_new (
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
@@ -776,6 +814,7 @@ export const REBUILD_MIGRATIONS: RebuildMigration[] = [
         source_url TEXT,
         source_external_id TEXT,
         related_refs_json TEXT,
+        work_item_id TEXT,
         status TEXT NOT NULL DEFAULT 'open'
           CHECK(status IN ('open','in_progress','done','cancelled')),
         created_at INTEGER NOT NULL DEFAULT (unixepoch()),
@@ -785,19 +824,20 @@ export const REBUILD_MIGRATIONS: RebuildMigration[] = [
       // Explicit column list (never SELECT *) so a shape mismatch errors loudly.
       `INSERT INTO tasks_new
          (id, title, description, priority, principal_id, source_system,
-          source_url, source_external_id, related_refs_json, status,
-          created_at, updated_at, iteration_id)
+          source_url, source_external_id, related_refs_json, work_item_id,
+          status, created_at, updated_at, iteration_id)
        SELECT
           id, title, description, priority, principal_id, source_system,
-          source_url, source_external_id, related_refs_json, status,
-          created_at, updated_at, iteration_id
+          source_url, source_external_id, related_refs_json, work_item_id,
+          status, created_at, updated_at, iteration_id
        FROM tasks`,
       `DROP TABLE tasks`,
       `ALTER TABLE tasks_new RENAME TO tasks`,
-      // Recreate the indexes (SCHEMA_SQL's + the iteration_id partner index).
+      // Recreate the indexes (SCHEMA_SQL's + the iteration_id + work_item_id partners).
       `CREATE INDEX IF NOT EXISTS idx_tasks_status_priority_updated
          ON tasks(status, priority, updated_at DESC)`,
       `CREATE INDEX IF NOT EXISTS idx_tasks_iteration ON tasks(iteration_id)`,
+      `CREATE INDEX IF NOT EXISTS idx_tasks_work_item ON tasks(work_item_id)`,
     ],
   },
 ];

--- a/src/surface/mc/projection/anchor.ts
+++ b/src/surface/mc/projection/anchor.ts
@@ -18,6 +18,8 @@
 
 import type { Database } from "bun:sqlite";
 
+import { upsertWorkItem, getWorkItem } from "../db/work-items";
+
 /**
  * Deterministic MC task id prefix for a dispatch correlation_id. One MC task per
  * dispatch (`dispatch-lifecycle.ts` mints `${ANCHOR_TASK_PREFIX}${correlationId}`
@@ -52,4 +54,113 @@ export function findAnchorSession(
     )
     .get(anchorTaskId(correlationId)) as { session_id: string } | null;
   return row ? row.session_id : null;
+}
+
+// ---------------------------------------------------------------------------
+// Slice convergence C (cortex#1150 / docs/design-slice-activity-thread.md §C):
+// the slice IS the issue's `work_item`. The slice address `{repo}/issue/N`
+// rides every dispatch as `response_routing.thread` (slice convergence A); MC
+// resolves it to ONE work_item per issue and links the per-dispatch anchor
+// `task` to it, so the slice card rolls up all of a slice's dispatches.
+//
+// This is the anchor-join schema change the module docblock anticipated — a
+// `work_item` reference on the anchor task — landing here in the single anchor
+// home, alongside the correlation_id→anchor join (which stays intact).
+// ---------------------------------------------------------------------------
+
+/**
+ * A slice address parsed from a dispatch's `response_routing.thread`. The thread
+ * is the channel-routing SOP's `{repo}/issue/N` form — a SHORT repo name (the
+ * `#<repo-short>` channel convention), not `owner/repo`. The projection is
+ * config-free (no `github.repos` to resolve short→owner/repo), so the SHORT
+ * repo name is the convergence key both this projection and a per-slice GitHub
+ * issue enrichment key off — see {@link workItemIdForSlice}.
+ */
+export interface SliceRef {
+  repo: string;
+  issueNumber: number;
+}
+
+/** `{repo}/issue/N` — the channel-routing SOP slice-thread form. */
+const SLICE_THREAD_RE = /^([^/]+)\/issue\/(\d+)$/;
+
+/**
+ * Parse a `response_routing.thread` as a slice address. Returns null for any
+ * non-issue thread (e.g. a legacy `{repo}/pr/N` thread, or a free-form thread):
+ * those carry no slice work_item, so the projection leaves the anchor unlinked
+ * (backward compatible — the no-`response_routing` path is unchanged).
+ */
+export function parseSliceThread(thread: string | undefined): SliceRef | null {
+  if (typeof thread !== "string") return null;
+  const m = SLICE_THREAD_RE.exec(thread);
+  if (m === null) return null;
+  const repo = m[1];
+  const rawNumber = m[2];
+  if (repo === undefined || rawNumber === undefined) return null;
+  const issueNumber = Number(rawNumber);
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) return null;
+  return { repo, issueNumber };
+}
+
+/**
+ * The deterministic MC `work_item` id for a slice's issue. Keyed off the slice
+ * address (`github:{repo}/issue/N`), provider-namespaced like the `github:`
+ * repo-id convention in `adapters/github/ingest.ts`. Both the slice projection
+ * (here) and a per-slice GitHub issue enrichment derive the SAME id from the
+ * SAME `{repo}/issue/N` address, so the two converge on ONE row (upsert by id —
+ * no duplicate, no parallel entity), satisfying §C2's upsert-by-issue-key.
+ */
+export function workItemIdForSlice(ref: SliceRef): string {
+  return `github:${ref.repo}/issue/${ref.issueNumber}`;
+}
+
+/**
+ * Resolve the issue's `work_item` for a slice and link the per-dispatch anchor
+ * `task` to it (slice convergence C). Idempotent:
+ *
+ *   - the work_item is LAZY-created by its deterministic id ({@link workItemIdForSlice})
+ *     via the existing `upsertWorkItem` — but only when ABSENT. A later GitHub
+ *     ingest enriches the SAME row by the same key; we must not clobber a richer
+ *     row's `status`/`priority` with empty stub defaults on a redelivery, so we
+ *     create-if-absent rather than blind-upsert (the "stub now, enrich later,
+ *     never downgrade" rule). The id is the convergence key — one row per issue.
+ *   - the anchor task's `work_item_id` is set to that id.
+ *
+ * Called from the dispatch-lifecycle projection inside its anchor transaction.
+ * A no-op for a non-issue / absent thread (the caller passes null).
+ */
+export function linkAnchorToSliceWorkItem(
+  db: Database,
+  correlationId: string,
+  ref: SliceRef,
+): string {
+  const workItemId = workItemIdForSlice(ref);
+
+  // Create-if-absent: the stub carries only the identity fields the convergence
+  // key implies. If the row already exists (a prior dispatch's stub, OR a GitHub
+  // ingest's enriched row), we leave it untouched — reusing `upsertWorkItem`
+  // strictly for creation so a redelivery never resets an enriched status/priority
+  // to the empty stub defaults.
+  if (getWorkItem(db, workItemId) === null) {
+    upsertWorkItem(db, {
+      id: workItemId,
+      planId: null,
+      phaseId: null,
+      parentId: null,
+      title: `${ref.repo}#${ref.issueNumber}`,
+      description: null,
+      status: "",
+      priority: "",
+      provider: "github",
+      externalId: `${ref.repo}#${ref.issueNumber}`,
+      url: null,
+    });
+  }
+
+  db.query(`UPDATE tasks SET work_item_id = ? WHERE id = ?`).run(
+    workItemId,
+    anchorTaskId(correlationId),
+  );
+
+  return workItemId;
 }

--- a/src/surface/mc/projection/dispatch-lifecycle.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle.ts
@@ -76,7 +76,11 @@ import type { Database } from "bun:sqlite";
 import { generateId } from "../db/events";
 import { ensureAgentRow } from "../db/agents";
 import { applyTransition } from "../db/transitions";
-import { anchorTaskId } from "./anchor";
+import {
+  anchorTaskId,
+  parseSliceThread,
+  linkAnchorToSliceWorkItem,
+} from "./anchor";
 import type { AssignmentState } from "../types";
 
 /**
@@ -106,6 +110,25 @@ interface LifecyclePayload {
   task_id?: unknown;
   agent_id?: unknown;
   cc_session_id?: unknown;
+  // Slice convergence A→C: the slice address echoed onto every lifecycle
+  // envelope. `response_routing.thread` is the channel-routing `{repo}/issue/N`
+  // form; §C resolves it to the issue's work_item and links the anchor task.
+  response_routing?: unknown;
+}
+
+/**
+ * Read `payload.response_routing.thread` as a slice address (`{repo}/issue/N`).
+ * Returns null for any envelope without a parseable issue thread — the
+ * backward-compatible no-`response_routing` path (behaviour unchanged: no
+ * work_item link). Structural read; mirrors `readLogicalRouting` in
+ * `src/adapters/response-routing-delivery.ts` (kept local so the projection
+ * stays import-free of the adapter layer).
+ */
+function readSliceThread(payload: LifecyclePayload): string | undefined {
+  const raw = payload.response_routing;
+  if (raw === null || typeof raw !== "object") return undefined;
+  const thread = (raw as Record<string, unknown>).thread;
+  return typeof thread === "string" ? thread : undefined;
 }
 
 /** A read of the projected session for a correlation_id, via the anchor task. */
@@ -181,6 +204,12 @@ export function projectDispatchLifecycle(
   // (the builder's default) when the field is absent on the wire.
   const correlationId = envelope.correlation_id ?? taskId;
   const ccSessionId = asString(payload.cc_session_id);
+  // Slice convergence C: the slice address (if any) the anchor task links to.
+  // Parsed once here; a non-issue / absent thread → null → no work_item link
+  // (backward compatible). A FEDERATED dispatch carries the same address and is
+  // NOT special-cased — its anchor links to the work_item too, carrying
+  // lifecycle only (no interior, which is never projected from a peer).
+  const sliceRef = parseSliceThread(readSliceThread(payload));
 
   // Everything below runs in ONE transaction: anchor creation, transition, and
   // (for terminal) cc_session_id backfill + orphan reconciliation must be
@@ -195,6 +224,14 @@ export function projectDispatchLifecycle(
       // a fresh dispatch's started carries no id (pending).
       provisionalCcSessionId: kind === "started" ? ccSessionId : null,
     });
+
+    // Slice convergence C — link the per-dispatch anchor task to the slice's
+    // issue work_item. Runs on EVERY lifecycle kind (idempotent create-if-absent
+    // + UPDATE) so a terminal-first delivery (lost `started`) still links, and a
+    // redelivery is harmless. No-op when the dispatch carries no issue thread.
+    if (sliceRef !== null) {
+      linkAnchorToSliceWorkItem(db, correlationId, sliceRef);
+    }
 
     if (kind === "started") {
       // Drive the assignment dispatched → running so the working grid shows the


### PR DESCRIPTION
**Closes #1150** · Part of #1147 (`docs/design-slice-activity-thread.md` §Work items C; ADR-0016).

Makes Mission Control roll up a slice's per-dispatch activity under **the issue's `work_item`**, so the MC slice card and the Discord slice thread are two projections of the same issue. The slice *is* the issue's `work_item`; the per-dispatch anchor `tasks` bind to it.

## What changed

When the dispatch-lifecycle projection (`src/surface/mc/projection/dispatch-lifecycle.ts`) ingests a `dispatch.task.*` envelope carrying `response_routing.thread = "{repo}/issue/N"`, it now:

1. parses `{repo}` + issue number from the thread (`parseSliceThread`, in the shared anchor home `projection/anchor.ts`),
2. **upserts the issue's `work_item`** keyed by the deterministic slice id (`workItemIdForSlice` → `github:{repo}/issue/N`, provider `github`) via the existing **`upsertWorkItem`** — lazy-created as a minimal stub when absent,
3. **links the per-dispatch anchor `task` to that `work_item`** via a new `tasks.work_item_id` column.

The `correlation_id` anchor stays intact (additive). No `response_routing` (or a non-issue thread like `{repo}/pr/N`) → no link (backward compatible). A **federated** dispatch's anchor links to the work_item too, carrying lifecycle only — no special-case.

## Schema decision — column, not `related_refs_json`

I added a **queryable `tasks.work_item_id` column** rather than stuffing the link into `related_refs_json`. Rationale:

- The slice card gathers its dispatches with `WHERE work_item_id = ?` — that wants an **indexed column**, not a `json_extract` scan over a blob.
- It mirrors the existing `pull_requests.work_item_id` exactly (a queryable, indexed link column that is intentionally **not** a hard FK, since the work_item may be a lazily-created stub and ingestion order isn't guaranteed).
- `related_refs_json` is for opaque ref lists; a first-class rollup axis deserves a first-class column.

Migration follows the established patterns in `schema.ts`:
- column added to the `tasks` CREATE TABLE **and** to `COLUMN_ADD_MIGRATIONS` (for existing DBs);
- the partner index `idx_tasks_work_item` lives in the column-add's `post[]` (run after the ALTER, unconditionally), **not** in the top-level `SCHEMA_SQL` — declaring it there crashes `initDatabase` on a pre-C DB with `no such column: work_item_id` (the documented #961/#1048 bug class);
- the data-critical `REBUILD_MIGRATIONS` `tasks_new` shape **and** its explicit INSERT column list were updated to include `work_item_id`, per that block's ⚠️ "MUST reproduce the FULL current shape" warning.

## Upsert-by-issue-key convergence

`workItemIdForSlice` derives the same `github:{repo}/issue/N` id from the same `{repo}/issue/N` slice address, so the slice projection and a per-slice GitHub-issue enrichment converge on **one row** (upsert by id — no duplicate, no parallel entity). The link uses **create-if-absent** (checks `getWorkItem` before `upsertWorkItem`) so a redelivered dispatch never clobbers an enriched row's `status`/`priority` back to the empty stub defaults — "stub now, enrich later, never downgrade".

> Note on the projection being config-free: it has no `github.repos` to resolve the short repo name → `owner/repo`, so the convergence key is the short-repo slice address the thread already carries. The existing umbrella-sub-issue `GithubWorkItemSource` keys differently (`owner/repo#N`) — a distinct, plan-scoped concern; the per-slice issue enrichment contract is this `github:{repo}/issue/N` key.

## How the slice card gathers dispatches

`tasks.work_item_id` → the issue's `work_item`, which already aggregates (via existing FKs) the issue's `pull_requests`, `reviews`, `checks` — and now its dispatch anchor-tasks → assignments → `sessions` → interiors. One issue = one card.

## Tests

`src/surface/mc/__tests__/slice-rollup-projection.test.ts` (in-memory `bun:sqlite`, mirroring the existing projection-test style):

- a dispatch with `response_routing.thread = "cortex/issue/872"` → a github `work_item` for issue 872 exists and the anchor task is linked to it;
- two dispatches (implement corr-A + review corr-B) for the same issue → both anchor tasks link to the **same** `work_item` (the slice rollup), exactly one row, queryable by `work_item_id`;
- a later GitHub-ingest upsert for issue 872 → enriches the **same** row (no duplicate; status/title preserved; a redelivered slice dispatch does not clobber them);
- no `response_routing` → no link (backward compatible);
- a non-issue thread (`{repo}/pr/N`) → no link;
- a federated dispatch's anchor links too (lifecycle only).

## Gates

- `bunx tsc --noEmit` — clean.
- `bunx eslint` (changed files) — clean.
- `bun test src/surface/mc/` — **1971 pass, 0 fail** (incl. the new slice-rollup tests + the `tasks` schema / D.7c rebuild / ST-P0 migration / session-schema-parity suites that exercise the column add).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
