### PR TITLE
feat(cortex): S2 — per-agent builtin chat dispatch listeners (#1160)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -182,6 +182,12 @@ import type { Surfaces } from "./common/types/surfaces";
 import type { SurfaceGateway } from "./gateway/surface-gateway";
 
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
+// S2 (cortex#1160) — per-agent chat dispatch listeners derive their scoped
+// subscription subject (`local.{principal}.{stack}.tasks.@{enc-did}.>`) via the
+// canonical myelin subject builder so the subscribe-side pattern matches the
+// `dispatch-source-publisher` emit side byte-for-byte.
+import { directTaskSubject } from "@the-metafactory/myelin/subjects";
+import { chatCapableAgents } from "./runner/chat-capable-agents";
 // G-1114.B.2 — live agent-presence producer (online/heartbeat/offline) wired
 // into boot. G-1114.B.3 — the runtime registry subscriber it feeds.
 import {
@@ -4094,7 +4100,61 @@ export async function startCortex(
   // under the surface-router's 5s render-timeout. See
   // `src/runner/dispatch-listener.ts` file-header docblock for the
   // executor-vs-renderer rationale.
-  const dispatchListener: DispatchListener = createDispatchListener({
+  // S2 (cortex#1160) — per-agent builtin chat dispatch listeners.
+  //
+  // The builtin chat path is `createDispatchListener`: it consumes
+  // `tasks.@{agent}.chat` envelopes off the bus and spawns a CC session. The
+  // PERSONA / identity it runs under is NOT carried on the listener — it rides
+  // the envelope payload (`agent_id`, `agent_name`, the persona-baked `prompt`)
+  // stamped on the EMIT side by the per-agent `DispatchHandler.handleMessage`
+  // (S1 routes each adapter instance to its matched agent via
+  // `agentByDiscordToken`). So the only per-agent state a listener carries is
+  // (a) its `receivingAgentId` trust anchor and (b) its subscribed subject.
+  //
+  // Pre-S2 a SINGLE listener was constructed bound to `firstAgent.id`,
+  // subscribing to the default wildcard `tasks.*.>`. The wildcard caught EVERY
+  // agent's tasks subtree, but the handler does NOT filter inbound `agent_id`
+  // against `receivingAgentId` — so a second presence agent (Pier, installed as
+  // an agents.d fragment per S1) had an adapter that published
+  // `tasks.@pier.chat` but no listener consuming it on a per-agent subject →
+  // silence (epic #1158 Gap 2).
+  //
+  // The fix constructs one listener per CHAT-CAPABLE agent: an agent in
+  // `mergedAgents` with a platform `presence` (the surfaces it can be
+  // @-mentioned on) AND a builtin brain (NOT `runtime.brain.kind === "exec"` —
+  // those route via `BrainConsumer`). Headless agents (`presence: {}` —
+  // approver/dev/release) get NONE; they run via the dispatch-listener as
+  // bus-only workers but are never @-mentioned on a surface.
+  //
+  // **Double-delivery safety.** Because the handler does NOT filter by
+  // `agent_id`, N listeners ALL subscribing to the shared wildcard `tasks.*.>`
+  // would each process every agent's envelope → N-fold double-spawn. So when
+  // there are 2+ chat-capable agents, each listener subscribes to its OWN
+  // scoped subtree `local.{principal}.{stack}.tasks.@{enc-did}.>` (built via
+  // the canonical `directTaskSubject`, byte-matching the emit side) — the
+  // runtime fan-out delivers an agent's envelopes ONLY to that agent's
+  // listener. No subject overlap ⇒ no double-delivery.
+  //
+  // **Single-agent byte-identity (non-negotiable).** When there is AT MOST one
+  // chat-capable agent, we construct exactly ONE listener bound to
+  // `firstAgent.id` with the subject OMITTED — i.e. the default wildcard
+  // `tasks.*.>` — wiring byte-identical to pre-S2. This covers the common
+  // single-inline-agent stack (Luna-only), a legacy flat `bot.yaml` (no
+  // `agents[]` ⇒ `firstAgent` undefined ⇒ the existing no-listener guard), AND
+  // a headless-only multi-agent stack (dev-loop): none gain a spurious extra
+  // chat listener.
+  // S2 (cortex#1160) — the chat-capable set: an enabled platform presence AND a
+  // builtin (non-exec) brain. `isExecBrainAgent` is the SAME predicate the
+  // brain-hosting path uses, injected so the rule can't drift. Pure helper in
+  // `runner/chat-capable-agents.ts` so boot + tests share one definition.
+  const chatAgents = chatCapableAgents(mergedAgents, isExecBrainAgent);
+  // Per-agent listeners; `start()`/`stop()`-ed as a set (mirrors how
+  // `reviewConsumers` / `brainConsumers` are tracked + drained).
+  const dispatchListeners: DispatchListener[] = [];
+  // Shared options every listener carries — only `receivingAgentId` + the
+  // scoped `subjects` differ per agent. Built once so the per-agent wiring
+  // can't drift between listeners.
+  const sharedDispatchListenerOpts = {
     runtime,
     source: systemEventSource,
     stack: derivedStack.stack,
@@ -4107,7 +4167,6 @@ export async function startCortex(
     cryptoVerify: signingKnobs.cryptoVerify,
     rejectEmpty: signingKnobs.rejectEmpty,
     principalId,
-    ...(firstAgent !== undefined && { receivingAgentId: firstAgent.id }),
     // cortex#480 — implicit own-stack trust. Adapter-originated
     // dispatches are signed by the stack identity (`did:mf:<principal>-
     // <stack>`) via MyelinRuntime.publish; without this the verifier
@@ -4145,8 +4204,46 @@ export async function startCortex(
     ...(config.claude.bashAllowlist !== undefined && {
       bashAllowlist: config.claude.bashAllowlist,
     }),
-  });
-  await dispatchListener.start();
+  };
+  if (chatAgents.length >= 2) {
+    // Multi-agent: each chat-capable agent gets its OWN listener on its OWN
+    // scoped subtree subject so the runtime never fans the same envelope to
+    // two listeners.
+    for (const agent of chatAgents) {
+      const agentChatSubject = directTaskSubject(
+        principalId,
+        `did:mf:${agent.id}`,
+        derivedStack.stack,
+      );
+      const listener = createDispatchListener({
+        ...sharedDispatchListenerOpts,
+        receivingAgentId: agent.id,
+        subjects: [agentChatSubject],
+        // Disambiguate stderr/audit log prefixes per agent.
+        adapterId: `runner-dispatch-listener-${agent.id}`,
+      });
+      dispatchListeners.push(listener);
+      console.log(
+        `cortex: dispatch-listener started — receivingAgentId=${agent.id} ` +
+          `subject=${agentChatSubject}`,
+      );
+    }
+  } else {
+    // At-most-one chat-capable agent → exactly ONE listener, wiring
+    // byte-identical to pre-S2: bound to `firstAgent.id` (the existing
+    // `mergedAgents[0]` fallback, or undefined → the no-receivingAgentId
+    // path) with the default wildcard `tasks.*.>` subscription (subject
+    // OMITTED). Legacy flat bot.yaml (`firstAgent` undefined) keeps the
+    // historical no-op-receiver behaviour.
+    const listener = createDispatchListener({
+      ...sharedDispatchListenerOpts,
+      ...(firstAgent !== undefined && { receivingAgentId: firstAgent.id }),
+    });
+    dispatchListeners.push(listener);
+  }
+  for (const listener of dispatchListeners) {
+    await listener.start();
+  }
 
   // signal#113 P-11 (#56) — federated echo responder. The ICMP-analog of the
   // agent network: answers a reserved `probe.echo` capability IN THE RUNTIME
@@ -5796,7 +5893,16 @@ export async function startCortex(
           );
         }
       }
-      await completeAsync("dispatch-listener stop", dispatchListener.stop());
+      // S2 (cortex#1160) — drain every per-agent chat dispatch listener.
+      for (let i = 0; i < dispatchListeners.length; i++) {
+        const listener = dispatchListeners[i];
+        if (listener) {
+          await completeAsync(
+            `dispatch-listener stop[${i}]`,
+            listener.stop(),
+          );
+        }
+      }
       // signal#113 P-11 (#56) — drain the echo responder on the same boundary
       // as the dispatch listener. `stop()` is idempotent (no-op when dormant).
       await completeAsync("probe-responder stop", probeResponder.stop());

--- a/src/runner/__tests__/chat-capable-agents.test.ts
+++ b/src/runner/__tests__/chat-capable-agents.test.ts
@@ -1,0 +1,86 @@
+/**
+ * S2 (cortex#1160) — chat-capability filter unit tests.
+ *
+ * The boot path constructs one builtin chat dispatch listener per
+ * chat-capable agent. "Chat-capable" = an ENABLED platform presence AND a
+ * builtin (non-exec) brain. These tests pin that rule so the boot loop and the
+ * design stay in lockstep.
+ */
+import { describe, expect, test } from "bun:test";
+import type { Agent } from "../../common/types/cortex-config";
+import { chatCapableAgents, hasEnabledPresence } from "../chat-capable-agents";
+
+/** The SAME exec-brain predicate `cortex.ts` boot uses. */
+const isExecBrain = (a: Agent): boolean => a.runtime?.brain?.kind === "exec";
+
+function agent(id: string, overrides: Partial<Agent> = {}): Agent {
+  return {
+    id,
+    displayName: id,
+    persona: `/tmp/${id}.md`,
+    trust: [],
+    presence: {},
+    ...overrides,
+  };
+}
+
+// Minimal Discord presence. The schema fills the remaining defaults at parse
+// time; the chat-capability filter only reads `enabled` + block-presence, so a
+// structural literal (cast to the parsed shape) is sufficient for these tests.
+const discordPresence = (enabled = true): Agent["presence"] =>
+  ({
+    discord: {
+      enabled,
+      token: `${enabled ? "on" : "off"}-token`,
+      guildId: "g",
+      agentChannelId: "c",
+      logChannelId: "cl",
+    },
+  }) as Agent["presence"];
+
+describe("chatCapableAgents (S2 / cortex#1160)", () => {
+  test("a headless agent (presence: {}) is NOT chat-capable", () => {
+    const headless = agent("dev"); // presence: {}
+    expect(hasEnabledPresence(headless)).toBe(false);
+    expect(chatCapableAgents([headless], isExecBrain)).toEqual([]);
+  });
+
+  test("an agent with an enabled Discord presence IS chat-capable", () => {
+    const luna = agent("luna", { presence: discordPresence(true) });
+    expect(hasEnabledPresence(luna)).toBe(true);
+    expect(chatCapableAgents([luna], isExecBrain).map((a) => a.id)).toEqual([
+      "luna",
+    ]);
+  });
+
+  test("a DISABLED presence does not earn chat-capability (no live adapter)", () => {
+    const pier = agent("pier", { presence: discordPresence(false) });
+    expect(hasEnabledPresence(pier)).toBe(false);
+    expect(chatCapableAgents([pier], isExecBrain)).toEqual([]);
+  });
+
+  test("an exec-brain agent with presence is EXCLUDED (routes via BrainConsumer)", () => {
+    const sage = agent("sage", {
+      presence: discordPresence(true),
+      runtime: {
+        substrate: "claude-code",
+        mode: "in-process",
+        capabilities: ["code-review.typescript"],
+        brain: { kind: "exec", run: "bun {pack}/brain/main.ts" },
+      } as Agent["runtime"],
+    });
+    expect(chatCapableAgents([sage], isExecBrain)).toEqual([]);
+  });
+
+  test("mixed registry: only enabled-presence builtin agents survive, order preserved", () => {
+    const luna = agent("luna", { presence: discordPresence(true) });
+    const pierDisabled = agent("pier-off", { presence: discordPresence(false) });
+    const dev = agent("dev"); // headless
+    const pierLive = agent("pier", { presence: discordPresence(true) });
+    const result = chatCapableAgents(
+      [luna, pierDisabled, dev, pierLive],
+      isExecBrain,
+    ).map((a) => a.id);
+    expect(result).toEqual(["luna", "pier"]);
+  });
+});

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -21,6 +21,7 @@
 import { describe, expect, test } from "bun:test";
 import { createUser } from "@nats-io/nkeys";
 import { signEnvelope } from "@the-metafactory/myelin/identity";
+import { directTaskSubject } from "@the-metafactory/myelin/subjects";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import { createSurfaceRouter, type SurfaceRouter } from "../../bus/surface-router";
@@ -3560,5 +3561,130 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
       (e) => e.payload.stage === "recipient-mismatch",
     );
     expect(recipient?.payload.outcome).toBe("fail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S2 (cortex#1160) — per-agent listener subject isolation (no double-delivery)
+//
+// The boot path (`cortex.ts`) constructs one listener per chat-capable agent,
+// each subscribing to its OWN scoped subtree `tasks.@{enc-did}.>` (via
+// `directTaskSubject`) rather than the shared wildcard `tasks.*.>`. These tests
+// pin the load-bearing invariant: a `tasks.@{B}.chat` envelope reaches B's
+// runner ONLY, never A's — so N listeners on a shared runtime do NOT each
+// process every envelope (the N-fold double-spawn the wildcard would cause).
+// ---------------------------------------------------------------------------
+
+describe("createDispatchListener — S2 per-agent subject isolation (cortex#1160)", () => {
+  test("two scoped listeners: a tasks.@B.chat envelope routes to B only, not A", async () => {
+    const r = recordingRuntime();
+    // Each listener subscribes to its OWN agent subtree — exactly what the
+    // boot loop builds for chatCapableAgents.length >= 2.
+    const subjectA = directTaskSubject("metafactory", "did:mf:agent-a");
+    const subjectB = directTaskSubject("metafactory", "did:mf:agent-b");
+    const facA = fakeFactory(SUCCESS_RESULT);
+    const facB = fakeFactory(SUCCESS_RESULT);
+    // The inbound envelope resolves its principal from `agent_id` (empty-chain
+    // adapter dispatch) → principal `agent-b`; grant it `dispatch.agent-b`.
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "agent-b",
+          home_principal: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.agent-b"] }],
+    });
+    const listenerA = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      subjects: [subjectA],
+      receivingAgentId: "agent-a",
+      ccSessionFactory: facA.factory,
+      policyEngine: engine,
+    });
+    const listenerB = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      subjects: [subjectB],
+      receivingAgentId: "agent-b",
+      ccSessionFactory: facB.factory,
+      policyEngine: engine,
+    });
+    // Sanity: each listener self-subscribes to its OWN scoped subtree, NOT the
+    // shared wildcard — so the runtime never fans an envelope to both.
+    expect(listenerA.subjects).toEqual([subjectA]);
+    expect(listenerB.subjects).toEqual([subjectB]);
+    await listenerA.start();
+    await listenerB.start();
+
+    // Inbound chat envelope addressed to agent-b on agent-b's chat subject.
+    // The runtime fan-out hands it to BOTH listeners' onEnvelope handlers;
+    // A's subject filter rejects it, B's accepts and spawns.
+    r.trigger(
+      makeReceivedEnvelope({ agent_id: "agent-b" }),
+      "local.metafactory.tasks.@did-mf-agent-b.chat",
+    );
+    await settle(() => r.published);
+
+    // B spawned exactly one CC session; A spawned NONE (no double-delivery).
+    expect(facB.optsCaptured).toHaveLength(1);
+    expect(facA.optsCaptured).toHaveLength(0);
+    // The single dispatch ran under B's identity (sourced from payload.agent_id).
+    expect(facB.optsCaptured[0]!.agentId).toBe("agent-b");
+    // Exactly one terminal lifecycle envelope — not two.
+    const terminals = r.published.filter((e) => TERMINAL_TYPES.has(e.type));
+    expect(terminals).toHaveLength(1);
+
+    await listenerA.stop();
+    await listenerB.stop();
+  });
+
+  test("scoped listener IGNORES another agent's subtree (subject-rejected drop)", async () => {
+    const r = recordingRuntime();
+    const subjectA = directTaskSubject("metafactory", "did:mf:agent-a");
+    const facA = fakeFactory(SUCCESS_RESULT);
+    const listenerA = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      subjects: [subjectA],
+      receivingAgentId: "agent-a",
+      ccSessionFactory: facA.factory,
+    });
+    await listenerA.start();
+
+    // An envelope on AGENT-B's subtree must be dropped by A's subject filter.
+    r.trigger(
+      makeReceivedEnvelope({ agent_id: "agent-b" }),
+      "local.metafactory.tasks.@did-mf-agent-b.chat",
+    );
+    await settle(() => r.published);
+
+    // A never spawned and published nothing (a clean drop).
+    expect(facA.optsCaptured).toHaveLength(0);
+    expect(r.published).toEqual([]);
+
+    await listenerA.stop();
+  });
+
+  test("single chat-capable agent path stays on the wildcard (byte-identical regression)", async () => {
+    // The boot loop's `else` branch (<=1 chat-capable agent) omits `subjects`,
+    // so the listener falls back to the canonical wildcard `tasks.*.>` —
+    // identical to pre-S2. This pins that default so the single-agent stack
+    // never silently narrows.
+    const r = recordingRuntime();
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      receivingAgentId: "luna",
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    expect(listener.subjects).toEqual(["local.metafactory.tasks.*.>"]);
+    await listener.start();
+    expect(r.subscribedPatterns).toEqual(["local.metafactory.tasks.*.>"]);
+    await listener.stop();
   });
 });

--- a/src/runner/chat-capable-agents.ts
+++ b/src/runner/chat-capable-agents.ts
@@ -1,0 +1,61 @@
+/**
+ * S2 (cortex#1160) — which agents earn a builtin chat dispatch listener.
+ *
+ * The builtin chat path (`createDispatchListener`) consumes
+ * `tasks.@{agent}.chat` envelopes and spawns a CC session. An agent earns one
+ * of these listeners iff it is reachable on a human-facing surface AND it runs
+ * the builtin (in-process `claude-code`) brain:
+ *
+ *   - It has an ENABLED platform `presence` (discord / mattermost / slack) —
+ *     the surface a human @-mentions it on. A headless agent (`presence: {}`,
+ *     or every block `enabled: false`) is a bus-only worker; it runs CC via the
+ *     dispatch-listener but is never @-mentioned, so no chat dispatch arrives.
+ *   - It is NOT an exec-brain agent. An agent whose `runtime.brain.kind ===
+ *     "exec"` is hosted by a `BrainConsumer` for its declared capabilities; its
+ *     inbound @-mention becomes a `…brain.{capability}` bus task, NOT a
+ *     `tasks.@{agent}.chat` envelope (design-bot-packs §6 — "instead of, not in
+ *     addition to").
+ *
+ * Pure + side-effect-free so `cortex.ts` boot and tests share ONE rule (the
+ * cortex#1033 §Maintainability single-predicate pattern the `brainAgents` /
+ * `reviewCapableAgents` filters already follow).
+ */
+import type { Agent } from "../common/types/cortex-config";
+
+/** True when a presence block exists and is not explicitly disabled. */
+function isEnabledPresence(
+  block: { enabled?: boolean } | undefined,
+): boolean {
+  return block !== undefined && block.enabled !== false;
+}
+
+/**
+ * True when `agent` has at least one ENABLED platform presence — the criterion
+ * for being @-mentionable on a surface, mirroring the adapter loop's
+ * `if (!instance.enabled) continue` skip.
+ */
+export function hasEnabledPresence(agent: Agent): boolean {
+  const p = agent.presence;
+  return (
+    isEnabledPresence(p.discord)
+    || isEnabledPresence(p.mattermost)
+    || isEnabledPresence(p.slack)
+  );
+}
+
+/**
+ * Filter `agents` down to the ones that earn a builtin chat dispatch listener:
+ * an enabled platform presence AND a builtin (non-exec) brain.
+ *
+ * @param agents     the merged registry (inline ∪ agents.d fragments).
+ * @param isExecBrain predicate identifying exec-brain agents (hosted by a
+ *                    `BrainConsumer`, not the builtin chat path). Injected so
+ *                    the boot path and tests use the SAME definition the rest of
+ *                    `cortex.ts` uses, with no import cycle.
+ */
+export function chatCapableAgents(
+  agents: readonly Agent[],
+  isExecBrain: (a: Agent) => boolean,
+): Agent[] {
+  return agents.filter((a) => !isExecBrain(a) && hasEnabledPresence(a));
+}


### PR DESCRIPTION
## What

Closes epic #1158 **Gap 2** (response path): a non-primary agent (e.g. Pier, installed as an `agents.d/` fragment per S1) gets an adapter that publishes `tasks.@{agent}.chat`, but pre-S2 only ONE builtin chat dispatch listener was constructed (bound to `mergedAgents[0]` on the wildcard `tasks.*.>`) — so the second agent received nothing into a runner → silence.

This constructs one builtin chat dispatch listener **per chat-capable agent**.

## Investigation findings

**Q1 — which agents get a chat listener?** Agents in `mergedAgents` with an **ENABLED platform presence** (discord/mattermost/slack) **AND a builtin (non-exec) brain**. Confirmed against the schema (`PresenceSchema`, `presence: {}` valid for headless) and existing predicates: `isExecBrainAgent` (exec-brain routes via `BrainConsumer`, design-bot-packs §6 "instead of, not in addition to") and the adapter loop's `if (!instance.enabled) continue` (so a *disabled* presence — no live adapter, no inbound chat — earns no listener). Headless agents (`presence: {}` — approver/dev/release) get NONE.

**Q2 — runner singletons?** The chat-path runner components (`session-manager`, `worklog-manager`, `task-tracker`, `prompt-builder`, `security-preamble`, persona resolution) all live on the **EMIT side** (`DispatchHandler`, S1-wired per-agent via `agentByDiscordToken` → `targetAgent`). `createDispatchListener` is a thin consume-and-spawn that reads identity (`agent_id`, `agent_name`, persona-baked `prompt`) **off the envelope payload** and constructs a fresh harness per dispatch. The ONLY per-agent state a listener carries is its `receivingAgentId` (trust anchor) + subscribed subject. **No `firstAgent`-bound singleton blocked the change** — clean.

## Double-delivery risk (the load-bearing finding)

The listener subscribes to `tasks.*.>` (wildcard) by default and **does NOT filter inbound `agent_id` against `receivingAgentId`** — it dispatches any subject-matching envelope. So N listeners all on `tasks.*.>` would each process every agent's envelope → N-fold double-spawn. The fix: when there are 2+ chat-capable agents, **each listener subscribes to its OWN scoped subtree** `local.{principal}.{stack}.tasks.@{enc-did}.>` (built via `directTaskSubject`, byte-matching the `dispatch-source-publisher` emit side). No subject overlap ⇒ no double-delivery.

## Single-agent byte-identity (non-negotiable, preserved)

When there is **at most one** chat-capable agent → exactly ONE listener bound to `firstAgent.id` with the subject **omitted** (default wildcard `tasks.*.>`) — wiring byte-identical to pre-S2. Covers Luna-only, legacy flat `bot.yaml` (`firstAgent` undefined → existing no-listener guard), and a headless-only multi-agent stack (dev-loop: no spurious chat listener).

## Scope decision — BusDispatchListener stays single (documented)

Per the issue's explicit guidance, S2 is scoped to the **chat path** (`createDispatchListener`). `BusDispatchListener` is a **visibility-only** peer-dispatch observer: it subscribes to all envelopes, filters `dispatch.task.dispatched` from peers, and **emits one `system.bus.peer_dispatch_received` per arrival** — N copies would **double-emit** that visibility envelope, and it never spawns CC / responds. It is not the response path. Per-agent peer dispatch is a **follow-up**, not what makes Pier respond.

## Files

- `src/cortex.ts` — replace the single `createDispatchListener` construction with a loop over chat-capable agents (scoped subjects, per-agent `receivingAgentId`/`adapterId`); shared opts extracted; shutdown drains all listeners. `BusDispatchListener` unchanged.
- `src/runner/chat-capable-agents.ts` — pure `chatCapableAgents(agents, isExecBrain)` + `hasEnabledPresence` helper (boot + tests share one rule; `isExecBrainAgent` injected to avoid drift/cycle).
- `src/runner/__tests__/dispatch-listener.test.ts` — S2 isolation suite: `tasks.@B.chat` → B's runner only (one terminal envelope, not two), scoped listener drops another agent's subtree, single-agent wildcard regression.
- `src/runner/__tests__/chat-capable-agents.test.ts` — filter unit (headless / disabled / exec-brain excluded; order preserved).

## Gate (verbatim)

```
$ bunx tsc --noEmit
tsc: PASS

$ bun test src/runner/__tests__/chat-capable-agents.test.ts src/runner/__tests__/dispatch-listener.test.ts src/__tests__/cortex.agent-presence-boot.test.ts src/__tests__/cortex.test.ts
 130 pass
 0 fail
 382 expect() calls
Ran 130 tests across 4 files.

$ bash scripts/check-carveouts.sh
check-carveouts: PASS — no ungated deprecated-term live violations

$ bunx eslint src/cortex.ts src/runner/chat-capable-agents.ts src/runner/__tests__/chat-capable-agents.test.ts src/runner/__tests__/dispatch-listener.test.ts
eslint: PASS (0 problems)
```

Note: boot-level multi-agent wiring is covered indirectly (pure filter unit + `createDispatchListener` isolation tests) because an `enabled: true` Discord presence makes the boot path `await adapter.start()` a live Discord connection — the existing S1 boot tests likewise avoid that by using disabled presences.

Closes #1160
Part of #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)