### PR TITLE
chore: bump to v5.25.0

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.24.0"
+version: "5.25.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release bump for **v5.25.0** — deploys the Pier public-domain onboarding concierge + the presence-adapter-flip (everything merged since v5.24.0). One-line `arc-manifest.yaml` version bump so `arc upgrade Cortex` can pull it. Full notes on the GH release.