### PR TITLE
docs(adr): ADR-0017 — surface tooling as arc bundles + Discord decoupling plan (S0)

### DIFF
--- a/docs/adr/0017-surface-tooling-arc-bundles.md
+++ b/docs/adr/0017-surface-tooling-arc-bundles.md
@@ -1,0 +1,71 @@
+# ADR-0017 — Surface tooling distributed as arc bundles; Cortex core owns runtime + adapters
+
+**Status:** accepted · **Date:** 2026-06-19 · **Refs:** ADR-0014 (capability-authorized agents), design-bot-packs.md, the marketplace building-block direction (#95)
+
+## Context
+
+Cortex today vendors each surface's *operator/agent tooling* inline — the Discord
+CLI + its skill live at `src/cli/discord/` (CLI `discord.ts` + `lib/` + `skill/SKILL.md` + `Workflows/`).
+More surfaces are coming (Mattermost, Slack, …), and the same shape would repeat:
+a per-surface CLI + skills baked into the cortex monolith.
+
+But there are **two distinct Discord concerns in the repo, and they are already decoupled**:
+
+1. **The adapter** (`src/adapters/discord/`) — the live bot *presence*, woven into the
+   bus / dispatch / surface-router. This *is* cortex's M7 surface; it is the runtime.
+2. **The CLI + skills** (`src/cli/discord/`) — operator/agent *tooling* (post / read /
+   role / threads, plus the wrapping skill). Nothing in cortex imports from it; it imports
+   only its own `./lib/*` plus one shared helper (`common/config/config-path`). It is a
+   self-contained unit whose only consumers are external (the `~/bin/discord` shim and
+   agents via the skill).
+
+We want surface tooling to be **modular, independently versioned, reusable outside
+cortex, and distributable** — the marketplace building-block direction — without
+destabilising the runtime.
+
+## Decision
+
+**Split the surface concern across two layers:**
+
+- **Cortex core owns the runtime + the surface ADAPTERS** (live presence). Adapters stay
+  in cortex — they are woven into the bus and are the M7 surface, not separable tooling.
+- **Surface TOOLING (CLI + skills) is extracted into per-surface arc bundles.** The first
+  is **`metafactory-discord`** (the Discord CLI + the existing skill + the new
+  `fleet-admit` / `discord-role` / `discord-post` skills). Cortex **declares the bundle as
+  a dependency** (`arc-manifest.yaml` `dependencies:`).
+
+**Distribution:** repo-first. The bundle is a repository under the `the-metafactory` org,
+`arc install`-able **from the git repo**. Registry publication (`arc install metafactory-discord`
+by name) is a later step — we are NOT bundling/distributing it on the metafactory registry yet.
+
+**Per-agent scoping:** which agent may invoke which skill is governed by cortex's
+`allowedSkills` (cortex#710), not by what's installed. Luna → `fleet-admit` (trusted
+executor); Pier → `discord-post` only (public surface, for #137); default-deny `Skill`
+elsewhere. The public/trusted boundary (ADR-0015, the Pier gate) is enforced by the
+grant, from one shared pack.
+
+## Consequences
+
+- Cortex shrinks: the Discord CLI source leaves the runtime repo; cortex consumes it as a
+  dependency. The one shared helper (`config-path`) is vendored into the bundle (small,
+  path-resolution only) so the bundle is standalone.
+- Each future surface follows the same shape (`metafactory-mattermost`, …) — a clean,
+  repeatable pattern instead of monolith growth.
+- The bundle is reusable outside cortex (a PAI session can `arc install metafactory-discord`
+  for the skills without running the daemon).
+- A dependency edge is introduced (cortex → metafactory-discord). Until arc auto-resolves
+  package dependencies on `arc install Cortex`, the bundle is installed explicitly; the
+  `dependencies:` declaration records the intent and is the seam to close.
+
+## Alternatives considered
+
+- **Keep everything in cortex (status quo).** Rejected: monolith growth, no reuse, every
+  surface re-bakes its CLI into the runtime repo.
+- **Extract the adapter too (surfaces as full plugins: adapter + CLI + skills per bundle).**
+  Rejected *for now* — the adapter is deeply woven into the bus/dispatch/surface-router; a
+  plugin adapter model is a much larger change. Deferred to a separate future ADR; this ADR
+  extracts only the cleanly-decoupled tooling layer.
+- **A skills-only bundle that wraps the cortex-resident CLI.** Rejected: leaves the CLI in
+  the monolith and creates a "CLI must be on PATH" coupling between the bundle and cortex;
+  shipping the CLI *with* the skills (they already live together at `src/cli/discord/`)
+  keeps them versioned as one unit.

--- a/docs/adr/0017-surface-tooling-arc-bundles.md
+++ b/docs/adr/0017-surface-tooling-arc-bundles.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-Cortex today vendors each surface's *operator/agent tooling* inline — the Discord
+Cortex today vendors each surface's *principal/agent tooling* inline — the Discord
 CLI + its skill live at `src/cli/discord/` (CLI `discord.ts` + `lib/` + `skill/SKILL.md` + `Workflows/`).
 More surfaces are coming (Mattermost, Slack, …), and the same shape would repeat:
 a per-surface CLI + skills baked into the cortex monolith.
@@ -13,7 +13,7 @@ But there are **two distinct Discord concerns in the repo, and they are already 
 
 1. **The adapter** (`src/adapters/discord/`) — the live bot *presence*, woven into the
    bus / dispatch / surface-router. This *is* cortex's M7 surface; it is the runtime.
-2. **The CLI + skills** (`src/cli/discord/`) — operator/agent *tooling* (post / read /
+2. **The CLI + skills** (`src/cli/discord/`) — principal/agent *tooling* (post / read /
    role / threads, plus the wrapping skill). Nothing in cortex imports from it; it imports
    only its own `./lib/*` plus one shared helper (`common/config/config-path`). It is a
    self-contained unit whose only consumers are external (the `~/bin/discord` shim and

--- a/docs/design-discord-bundle-decoupling.md
+++ b/docs/design-discord-bundle-decoupling.md
@@ -1,0 +1,76 @@
+# Design — Decouple the Discord CLI + skills into the `metafactory-discord` bundle
+
+**Status:** plan · **Date:** 2026-06-19 · **ADR:** [0017](adr/0017-surface-tooling-arc-bundles.md) · **Drives:** the epic below
+
+## Goal
+
+Move cortex's Discord *tooling* (CLI + skills) out of the runtime repo into a standalone,
+arc-installable bundle under `the-metafactory` org, and have cortex consume it as a
+dependency — so surface tooling is modular + reusable, and we can use it to manage
+onboarding in the metafactory community (Luna runs `fleet-admit`; Pier surfaces).
+
+Cortex keeps the live Discord **adapter** (`src/adapters/discord/`); only the **tooling**
+(`src/cli/discord/`) moves.
+
+## Extraction facts (verified)
+
+- Nothing in cortex imports from `src/cli/discord/` → removing it breaks no cortex internals.
+- `src/cli/discord/` imports only its own `./lib/*` **plus one** shared helper:
+  `lib/config.ts → ../../../common/config/config-path`. That helper (a `~/.config/cortex`
+  path resolver) is vendored into the bundle. No other coupling.
+- `src/cli/discord/skill/SKILL.md` + `Workflows/` already exist — the wrapping skill ships
+  with the CLI as one unit.
+
+## Target repo: `the-metafactory/metafactory-discord`
+
+```
+metafactory-discord/
+  arc-manifest.yaml        # name: discord, namespace: metafactory, type: skill/bundle, provides
+  cli/                     # the extracted discord CLI (discord.ts + lib/, config-path vendored)
+  skills/
+    discord/SKILL.md       # the existing CLI-wrapping skill (post/read/role/threads)
+    fleet-admit/SKILL.md   # NEW — the two-tier admission procedure
+  bin/discord              # the PATH shim arc installs (replaces cortex's ~/bin/discord)
+  README.md  CLAUDE.md  package.json  tests
+```
+
+Skills provided:
+
+| Skill | Wraps | Granted to |
+|---|---|---|
+| `discord-post` / `discord-read` | `discord post` / `read` | any agent that speaks on Discord (Pier *surfacing*, #137) |
+| `discord-role` | `discord role add/remove` | role-grant capability (Luna) |
+| `fleet-admit` | `discord role add community-fleet` + `cortex network admit` | the composed admission procedure (Luna) |
+
+## Distribution (repo-first)
+
+- **Now:** `arc install <git-url of metafactory-discord>` — install from the repo. NOT on
+  the metafactory registry yet.
+- **Cortex dependency:** cortex `arc-manifest.yaml` `dependencies:` declares
+  `metafactory-discord`. (Confirm whether arc auto-resolves package deps on
+  `arc install Cortex`; if not, install the bundle explicitly + record the intent.)
+- **Later:** registry publication → `arc install metafactory-discord` by name.
+
+## Onboarding wiring (the payoff)
+
+- Grant `allowedSkills` per agent: **Luna → `fleet-admit`** (trusted executor),
+  **Pier → `discord-post`** only (public surface), default-deny elsewhere.
+- Flow: newcomer → Pier (guides, public, zero authority) → surfaces a passive request in
+  `#assistant-fleet-onboarding` → **principal** tells Luna "admit them" → Luna runs
+  `fleet-admit`. Pier never pings Luna (Luna trusts no bots; Pier isn't a principal).
+
+## Slices (epic)
+
+- **S0** — this ADR + design doc (the decision). *(this PR)*
+- **S1** — create `the-metafactory/metafactory-discord`; extract `src/cli/discord/` (CLI +
+  existing skill) into it; vendor `config-path`; arc-manifest; tests pass standalone;
+  `arc install` from repo works.
+- **S2** — cortex consumes the bundle: remove `src/cli/discord/` from cortex; `~/bin/discord`
+  comes from the bundle; cortex `arc-manifest` declares the dependency; cortex build + tests
+  green without the CLI. *(the decoupling)*
+- **S3** — add `fleet-admit` + `discord-role` / `discord-post` skills to the bundle.
+- **S4** — wire onboarding: install the bundle, set `allowedSkills` (Luna→`fleet-admit`,
+  Pier→`discord-post`), verify the admit flow end-to-end in the community.
+
+Each slice: build → adversarial review → gate → merge (auto-dev SOP). PR merges
+dual-announce to `#cortex` on both grove + metafactory-community.


### PR DESCRIPTION
S0 of the Discord-bundle decoupling epic. **Design only** — no code moves in this PR.

- **ADR-0017** — Cortex core owns runtime + surface *adapters*; surface *tooling* (CLI + skills) becomes per-surface arc bundles. First: `metafactory-discord`. Cortex depends on it. Repo-first distribution. Adapter-as-plugin deferred to a future ADR.
- **design-discord-bundle-decoupling.md** — extraction plan (the CLI is self-contained except one `config-path` helper to vendor) + S0..S4 slices + onboarding wiring (Luna→`fleet-admit`, Pier→`discord-post`).

Verified: nothing in cortex imports `src/cli/discord/`; it imports only its own `./lib/*` + that one helper — clean extraction.