### PR TITLE
chore: bump to v5.26.0 — F-6 reflex activation bridge

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.25.0"
+version: "5.26.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Bumps `arc-manifest.yaml` `5.25.0` → `5.26.0` (minor — F-6 is a new feature).

Cuts the release shipping the **reflex→cortex activation bridge** (#1178, closes #1177): cortex consumes reflex `reflex.activation.fired` events via a durable JetStream consumer on the REFLEX stream and re-emits them as `tasks.@{assistant}.{capability}` dispatches the existing executor runs — reflex activations finally become runs (the GitHub-issue→Discord, laptop-free path). Config-gated; zero behaviour change when `reflex_activation.targets` is unset.

Version is sole-sourced in `arc-manifest.yaml` (no package.json/toml version field); grep confirms no other `5.25.0` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)