### PR TITLE
feat(bus): notify.discord `*` catch-all — all repos → one webhook

### DIFF
--- a/src/bus/__tests__/notify-discord.test.ts
+++ b/src/bus/__tests__/notify-discord.test.ts
@@ -137,6 +137,43 @@ describe("createDiscordNotifier", () => {
     expect(lastNotify(ctrl.published)?.outcome).toBe("posted");
   });
 
+  test("`*` catch-all routes a repo with no exact entry", async () => {
+    const ctrl = fakeRuntime();
+    const poster = recordingPoster();
+    const handler = createDiscordNotifier({
+      runtime: ctrl.runtime, source: SOURCE,
+      targets: [{ repo: "*", webhook_url_env: "DISCORD_WH_ALL" }],
+      env: { DISCORD_WH_ALL: WEBHOOK },
+      post: poster.post,
+    });
+
+    await handler(activation({ repository: { full_name: "the-metafactory/anything" }, issue: { number: 9, title: "x" } }));
+    await flush();
+
+    expect(poster.calls).toHaveLength(1);
+    expect(poster.calls[0]!.url).toBe(WEBHOOK);
+    expect(lastNotify(ctrl.published)?.outcome).toBe("posted");
+  });
+
+  test("exact repo entry overrides the `*` catch-all", async () => {
+    const ctrl = fakeRuntime();
+    const poster = recordingPoster();
+    const handler = createDiscordNotifier({
+      runtime: ctrl.runtime, source: SOURCE,
+      targets: [
+        { repo: "*", webhook_url_env: "DISCORD_WH_ALL" },
+        { repo: "jc/reflex", webhook_url_env: "DISCORD_WH_REFLEX" },
+      ],
+      env: { DISCORD_WH_ALL: "https://discord.com/api/webhooks/9/all", DISCORD_WH_REFLEX: WEBHOOK },
+      post: poster.post,
+    });
+
+    await handler(activation(ISSUE)); // repo jc/reflex
+    await flush();
+
+    expect(poster.calls[0]!.url).toBe(WEBHOOK); // exact, not the catch-all
+  });
+
   test("unknown repo → skipped, no POST, no throw", async () => {
     const ctrl = fakeRuntime();
     const poster = recordingPoster();

--- a/src/bus/notify-discord.ts
+++ b/src/bus/notify-discord.ts
@@ -211,9 +211,12 @@ export function createDiscordNotifier(opts: DiscordNotifierOpts): ReflexActivati
       emit("skipped", activation, undefined, "unparseable-payload");
       return;
     }
-    const webhookUrl = webhookByRepo.get(issue.repo);
+    // Exact repo mapping first, then the `"*"` catch-all (one webhook for every
+    // repo — pairs with an org-level GitHub webhook). An exact entry overrides
+    // the catch-all.
+    const webhookUrl = webhookByRepo.get(issue.repo) ?? webhookByRepo.get("*");
     if (webhookUrl === undefined) {
-      log.warn(`notify-discord: no webhook configured for repo "${issue.repo}" — skipped`);
+      log.warn(`notify-discord: no webhook configured for repo "${issue.repo}" (no catch-all) — skipped`);
       emit("skipped", activation, issue.repo, "no-webhook-for-repo");
       return;
     }

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -2609,7 +2609,12 @@ export type ReflexActivationConfig = z.infer<typeof ReflexActivationConfigSchema
  * a secret (it grants post access to that channel).
  */
 export const DiscordNotifyTargetSchema = z.object({
-  /** GitHub repo full name, e.g. `owner/repo` (matched against the activation payload). */
+  /**
+   * GitHub repo full name, e.g. `owner/repo` (matched against the activation
+   * payload). The special value `"*"` is a catch-all: any repo with no exact
+   * entry routes to this webhook (pair with an org-level GitHub webhook to
+   * notify every repo through one channel; an exact entry overrides it).
+   */
   repo: z.string().min(1),
   /**
    * Env/secret BINDING NAME holding the Discord webhook URL — never the URL


### PR DESCRIPTION
Adds a `repo: "*"` catch-all to the `notify.discord` handler (cortex#1180 follow-up): any repo with no exact mapping routes to the `*` webhook; exact entries override. Pairs with an **org-level GitHub webhook** so every metafactory repo's issues notify one Discord channel without enumerating repos.

- `src/bus/notify-discord.ts` — `webhookByRepo.get(repo) ?? webhookByRepo.get("*")`.
- `src/common/types/cortex-config.ts` — documents the `"*"` catch-all on `DiscordNotifyTarget.repo`.
- Tests: catch-all routes an unlisted repo; an exact entry overrides the catch-all.

Reproduce: `bunx tsc --noEmit`, `bun run lint`, `bun test src/bus/__tests__/notify-discord.test.ts`. CI on this PR (Lint / Test / Typecheck / Compass / Vocab gate) is the authoritative signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)