### PR TITLE
fix(bus): notify.discord — accept reflex's flat repository full_name (e2e fix)

### DIFF
--- a/src/bus/__tests__/notify-discord.test.ts
+++ b/src/bus/__tests__/notify-discord.test.ts
@@ -87,6 +87,16 @@ describe("parseIssueActivation", () => {
       action: "opened",
     });
   });
+  test("accepts the flat `repository` string reflex-edge fires (github_hmac)", () => {
+    const r = parseIssueActivation({
+      action: "opened",
+      issue: { number: 7, title: "t", html_url: "u" },
+      repository: "the-metafactory/cortex", // flat full_name, not nested
+      github_event: "issues",
+    });
+    expect(r?.repo).toBe("the-metafactory/cortex");
+    expect(r?.number).toBe(7);
+  });
   test("non-object / missing repo → undefined", () => {
     expect(parseIssueActivation("nope")).toBeUndefined();
     expect(parseIssueActivation(null)).toBeUndefined();

--- a/src/bus/notify-discord.ts
+++ b/src/bus/notify-discord.ts
@@ -91,18 +91,30 @@ export interface DiscordNotifierOpts {
 }
 
 /**
- * Extract the repo + issue fields from a fired activation payload (the raw
- * GitHub `issues` webhook body). Returns undefined when the repo can't be
- * determined (nothing to route on).
+ * Extract the repo + issue fields from a fired activation payload.
+ *
+ * Two `repository` shapes are accepted:
+ *  - **flat string** — what reflex-edge's `github_hmac` source actually fires:
+ *    it injects `repository` as the repo full_name (overwriting the nested
+ *    object) for flat `where`-matching, e.g. `"repository":"owner/repo"`.
+ *  - **nested `{full_name}`** — the raw GitHub `issues` webhook shape (fallback
+ *    for a bus/manual source that forwards the body verbatim).
+ *
+ * Returns undefined when the repo can't be determined (nothing to route on).
  */
 export function parseIssueActivation(
   payload: unknown,
 ): ParsedIssueActivation | undefined {
   if (payload === null || typeof payload !== "object") return undefined;
   const p = payload as Record<string, unknown>;
-  const repository = p.repository as { full_name?: unknown } | undefined;
+  const repository = p.repository;
   const repo =
-    typeof repository?.full_name === "string" ? repository.full_name : undefined;
+    typeof repository === "string"
+      ? repository
+      : typeof (repository as { full_name?: unknown } | undefined)?.full_name ===
+          "string"
+        ? (repository as { full_name: string }).full_name
+        : undefined;
   if (repo === undefined || repo.length === 0) return undefined;
   const issue = p.issue as
     | { number?: unknown; title?: unknown; html_url?: unknown }

--- a/src/bus/notify-discord.ts
+++ b/src/bus/notify-discord.ts
@@ -94,9 +94,12 @@ export interface DiscordNotifierOpts {
  * Extract the repo + issue fields from a fired activation payload.
  *
  * Two `repository` shapes are accepted:
- *  - **flat string** — what reflex-edge's `github_hmac` source actually fires:
- *    it injects `repository` as the repo full_name (overwriting the nested
- *    object) for flat `where`-matching, e.g. `"repository":"owner/repo"`.
+ *  - **flat string** — what reflex-edge's `github_hmac` source fires: it injects
+ *    `repository` as the repo full_name (overwriting the nested object) for flat
+ *    `where`-matching (see `the-metafactory/reflex` `src/edge/http.ts`, the
+ *    github_hmac branch: `repository: repo?.full_name`). Verified on the live
+ *    deploy — a signed impulse fired `…payload:{repository:"owner/repo",…}`.
+ *    e.g. `"repository":"owner/repo"`.
  *  - **nested `{full_name}`** — the raw GitHub `issues` webhook shape (fallback
  *    for a bus/manual source that forwards the body verbatim).
  *


### PR DESCRIPTION
End-to-end deploy surfaced a payload-shape mismatch. reflex-edge's `github_hmac` impulse source injects `repository` as a **flat full_name string** (overwriting the nested GitHub object) for flat `where`-matching. The fired activation payload is:
\`\`\`json
{"action":"opened","issue":{"number":1002,...},"repository":"the-metafactory/cortex","github_event":"issues","github_delivery":"..."}
\`\`\`
`parseIssueActivation` expected nested `repository.full_name` → `undefined` → handler skipped (`unparseable-payload`), no Discord post.

**Fix:** accept the flat `repository` string (primary — what reflex actually fires) with a nested `{full_name}` fallback (raw GitHub shape). Added a flat-shape parse test.

Confirmed live against the deployed reflex-edge + clawbox bridge: signed impulse → 202 → fired event on `local.jc.default.reflex.activation.fired` → durable consumer delivered → handler ran (this fix makes it parse + post instead of skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)