### PR TITLE
fix(review): per-scope filter_subject on review durables — no fan-out double-post (cortex#1186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,17 @@
   claimed EVERY message on the CODE_REVIEW stream. An agent with >1 scope
   consumer therefore processed (and `--post`ed) the SAME review N times — a real
   PR (the-metafactory/arc#241) got 3 identical sage reviews. Filters are now
-  disjoint by scope, so a `local.…` request reaches exactly the local durable.
+  disjoint by scope, so a `local.…` request reaches exactly the local durable —
+  proven in `review-filter-disjoint.test.ts` (a `local.…` subject matches only
+  the local pattern; `local.`/`federated.` never both match).
   `provisionReviewConsumer` also gains a **filter-drift migration**:
   `filter_subject` is immutable on a JetStream durable, so a drift (e.g. a
   pre-fix `""`-filter durable) is reconciled by **delete + recreate** on the next
-  boot (the brief gap re-delivers in-flight messages; the review-consumer's
-  redelivery>1 abort makes that safe) — no manual `nats consumer rm`. NOTE: the
+  boot — no manual `nats consumer rm`. The recreated durable is forced to
+  `DeliverPolicy.New` so the migration does NOT replay the backlog (no mass
+  re-review/re-post); a message in-flight at migration is dropped (re-fireable —
+  the safe direction). Provisioning runs at boot before the consumer pulls, so
+  there is no concurrently-processing delivery to race. NOTE: the
   CODE_REVIEW stream subjects must include the `federated.…` patterns for the
   federated filters to bind (already in `reviewStreamSubjects` when federation is
   configured; a drifted live stream needs its subjects updated).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Non-breaking
 
+- **Review consumers no longer fan out + double-post (cortex#1186).** Each
+  per-agent review durable (local + federated-offer + federated-direct) is now
+  provisioned with a `filterSubject` matching the subject pattern its consumer
+  binds — previously omitted, so every durable had `filter_subject: ""` and
+  claimed EVERY message on the CODE_REVIEW stream. An agent with >1 scope
+  consumer therefore processed (and `--post`ed) the SAME review N times — a real
+  PR (the-metafactory/arc#241) got 3 identical sage reviews. Filters are now
+  disjoint by scope, so a `local.…` request reaches exactly the local durable.
+  `provisionReviewConsumer` also gains a **filter-drift migration**:
+  `filter_subject` is immutable on a JetStream durable, so a drift (e.g. a
+  pre-fix `""`-filter durable) is reconciled by **delete + recreate** on the next
+  boot (the brief gap re-delivers in-flight messages; the review-consumer's
+  redelivery>1 abort makes that safe) — no manual `nats consumer rm`. NOTE: the
+  CODE_REVIEW stream subjects must include the `federated.…` patterns for the
+  federated filters to bind (already in `reviewStreamSubjects` when federation is
+  configured; a drifted live stream needs its subjects updated).
+
 - **F-6 reflex bridge — review-consumer dispatch (`review: true`)**. A new
   fulfilment channel on `reflex_activation.targets[]`, alongside `prompt` (CC
   agent-session) and `handler` (code responder). With `review: true` +

--- a/src/__tests__/cortex.dev-stream-boot.test.ts
+++ b/src/__tests__/cortex.dev-stream-boot.test.ts
@@ -97,6 +97,7 @@ function makeRecordingJsm(): JsmRecorder {
         ({ name: cfg.durable_name } as unknown as ConsumerInfo),
       update: async (_stream, durable, cfg) =>
         ({ name: durable, config: cfg } as unknown as ConsumerInfo),
+      delete: async () => true,
     },
   };
   return { jsm, streamAdds };

--- a/src/__tests__/cortex.lifecycle-stream-boot.test.ts
+++ b/src/__tests__/cortex.lifecycle-stream-boot.test.ts
@@ -96,6 +96,7 @@ function makeRecordingJsm(): JsmRecorder {
         ({ name: cfg.durable_name } as unknown as ConsumerInfo),
       update: async (_stream, durable, cfg) =>
         ({ name: durable, config: cfg } as unknown as ConsumerInfo),
+      delete: async () => true,
     },
   };
   return { jsm, streamAdds };

--- a/src/bus/__tests__/reflex-activation-listener.test.ts
+++ b/src/bus/__tests__/reflex-activation-listener.test.ts
@@ -814,6 +814,7 @@ describe("ReflexActivationListener — lifecycle", () => {
           return {} as never;
         },
         update: async () => ({}) as never,
+        delete: async () => true,
       },
     };
     let boundOpts: Record<string, unknown> | undefined;
@@ -863,6 +864,7 @@ describe("ReflexActivationListener — lifecycle", () => {
           return {} as never;
         },
         update: async () => ({}) as never,
+        delete: async () => true,
       },
     };
     const augmented = ctrl.runtime as unknown as Record<string, unknown>;

--- a/src/bus/jetstream/__tests__/provision.test.ts
+++ b/src/bus/jetstream/__tests__/provision.test.ts
@@ -29,6 +29,7 @@ interface RecorderState {
   consumerInfoCalls: { stream: string; durable: string }[];
   consumerAddCalls: { stream: string; cfg: Record<string, unknown> }[];
   consumerUpdateCalls: { stream: string; durable: string; cfg: Record<string, unknown> }[];
+  consumerDeleteCalls: { stream: string; durable: string }[];
 }
 
 function makeJsm(opts: {
@@ -41,6 +42,7 @@ function makeJsm(opts: {
     consumerInfoCalls: [],
     consumerAddCalls: [],
     consumerUpdateCalls: [],
+    consumerDeleteCalls: [],
   };
   const jsm: ProvisionJsm = {
     streams: {
@@ -80,6 +82,10 @@ function makeJsm(opts: {
       update: async (stream, durable, cfg) => {
         state.consumerUpdateCalls.push({ stream, durable, cfg });
         return { name: durable, config: cfg } as unknown as ConsumerInfo;
+      },
+      delete: async (stream, durable) => {
+        state.consumerDeleteCalls.push({ stream, durable });
+        return true;
       },
     },
   };
@@ -330,6 +336,66 @@ describe("provisionReviewConsumer", () => {
     expect(cfg.ack_wait).toBe(DEFAULT_ACK_WAIT_NS);
     // No filter subject when not requested.
     expect("filter_subject" in cfg).toBe(false);
+  });
+
+  test("cortex#1186 — filterSubject is applied to the durable config on create", async () => {
+    const { jsm, state } = makeJsm({ existingConsumer: "not-found" });
+    const outcome = await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "cortex-review-consumer-jc-sage",
+      filterSubject: "local.jc.clawbox.tasks.code-review.>",
+      log: silentLog(),
+    });
+    expect(outcome).toBe("created");
+    expect(state.consumerAddCalls[0]!.cfg.filter_subject).toBe(
+      "local.jc.clawbox.tasks.code-review.>",
+    );
+  });
+
+  test("cortex#1186 — filter drift (durable created without filter) → delete + recreate with the filter", async () => {
+    // Pre-fix durable: created with no filter_subject (claims every message).
+    const existing = {
+      name: "cortex-review-consumer-jc-sage",
+      config: { ack_wait: DEFAULT_ACK_WAIT_NS, filter_subject: "" },
+    } as unknown as ConsumerInfo;
+    const { jsm, state } = makeJsm({ existingConsumer: existing });
+    const outcome = await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "cortex-review-consumer-jc-sage",
+      filterSubject: "local.jc.clawbox.tasks.code-review.>",
+      log: silentLog(),
+    });
+    // filter_subject is immutable → delete + recreate, not an in-place update.
+    expect(outcome).toBe("created");
+    expect(state.consumerDeleteCalls).toEqual([
+      { stream: "CODE_REVIEW", durable: "cortex-review-consumer-jc-sage" },
+    ]);
+    expect(state.consumerUpdateCalls.length).toBe(0);
+    expect(state.consumerAddCalls.length).toBe(1);
+    expect(state.consumerAddCalls[0]!.cfg.filter_subject).toBe(
+      "local.jc.clawbox.tasks.code-review.>",
+    );
+  });
+
+  test("cortex#1186 — matching filter + drifted ack_wait → update in place, NO delete/recreate", async () => {
+    const existing = {
+      name: "cortex-review-consumer-jc-sage",
+      config: { ack_wait: 30_000_000_000, filter_subject: "local.jc.clawbox.tasks.code-review.>" },
+    } as unknown as ConsumerInfo;
+    const { jsm, state } = makeJsm({ existingConsumer: existing });
+    const outcome = await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "cortex-review-consumer-jc-sage",
+      filterSubject: "local.jc.clawbox.tasks.code-review.>",
+      log: silentLog(),
+    });
+    expect(outcome).toBe("updated");
+    expect(state.consumerDeleteCalls.length).toBe(0);
+    expect(state.consumerAddCalls.length).toBe(0);
+    expect(state.consumerUpdateCalls.length).toBe(1);
   });
 
   test("idempotent — exists path with matching ack_wait returns 'exists' without add/update", async () => {

--- a/src/bus/jetstream/__tests__/provision.test.ts
+++ b/src/bus/jetstream/__tests__/provision.test.ts
@@ -377,6 +377,9 @@ describe("provisionReviewConsumer", () => {
     expect(state.consumerAddCalls[0]!.cfg.filter_subject).toBe(
       "local.jc.clawbox.tasks.code-review.>",
     );
+    // The recreated durable must start from `New`, NOT replay the backlog —
+    // a migration must not re-review + re-post every historical PR (cortex#1186).
+    expect(state.consumerAddCalls[0]!.cfg.deliver_policy).toBe("new");
   });
 
   test("cortex#1186 — matching filter + drifted ack_wait → update in place, NO delete/recreate", async () => {

--- a/src/bus/jetstream/__tests__/review-filter-disjoint.test.ts
+++ b/src/bus/jetstream/__tests__/review-filter-disjoint.test.ts
@@ -1,0 +1,66 @@
+/**
+ * cortex#1186 — demonstrate that the per-scope review-consumer filter patterns
+ * are DISJOINT, so a given review request reaches exactly one scope durable.
+ *
+ * The double-post bug was that every review durable was provisioned with NO
+ * `filter_subject` (claims every message). The fix wires each durable's filter
+ * to the pattern its consumer binds. This test proves those patterns can't
+ * overlap — the CHANGELOG's "disjoint by scope" claim, shown not asserted.
+ *
+ * Self-contained NATS subject matcher (token wildcards `*` and trailing `>`) so
+ * the property is verified without importing cortex's private pattern consts.
+ */
+import { describe, expect, test } from "bun:test";
+
+/** Minimal NATS subject/pattern match: `*` = exactly one token, `>` = one-or-more
+ *  trailing tokens (only valid as the last token). */
+function subjectMatches(subject: string, pattern: string): boolean {
+  const subTokens = subject.split(".");
+  const patTokens = pattern.split(".");
+  for (let i = 0; i < patTokens.length; i++) {
+    const p = patTokens[i]!;
+    if (p === ">") return i < subTokens.length; // ≥1 trailing token required
+    if (i >= subTokens.length) return false;
+    if (p !== "*" && p !== subTokens[i]) return false;
+  }
+  return subTokens.length === patTokens.length;
+}
+
+// The three scope patterns cortex provisions (principal=jc, stack=clawbox), per
+// `reviewSubjectPattern` / `reviewFederatedSubjectPattern` /
+// `reviewFederatedDirectSubjectPattern` in src/cortex.ts.
+const LOCAL = "local.jc.clawbox.tasks.code-review.>";
+const FED_OFFER = "federated.jc.clawbox.tasks.code-review.>";
+const FED_DIRECT = "federated.jc.clawbox.tasks.*.code-review.>";
+
+describe("cortex#1186 — review-consumer filter patterns are disjoint by scope", () => {
+  test("a local review request matches ONLY the local filter", () => {
+    const subject = "local.jc.clawbox.tasks.code-review.typescript";
+    expect(subjectMatches(subject, LOCAL)).toBe(true);
+    expect(subjectMatches(subject, FED_OFFER)).toBe(false);
+    expect(subjectMatches(subject, FED_DIRECT)).toBe(false);
+  });
+
+  test("a federated review request never matches the local filter", () => {
+    const offer = "federated.jc.clawbox.tasks.code-review.typescript";
+    const direct = "federated.jc.clawbox.tasks.@did-mf-x.code-review.typescript";
+    expect(subjectMatches(offer, LOCAL)).toBe(false);
+    expect(subjectMatches(direct, LOCAL)).toBe(false);
+    // federated-offer and federated-direct cover different shapes (the direct
+    // one carries the `@{did}` token the offer pattern has no slot for).
+    expect(subjectMatches(offer, FED_OFFER)).toBe(true);
+    expect(subjectMatches(direct, FED_OFFER)).toBe(false);
+    expect(subjectMatches(direct, FED_DIRECT)).toBe(true);
+  });
+
+  test("the local and federated prefixes can never both match one subject", () => {
+    for (const subject of [
+      "local.jc.clawbox.tasks.code-review.typescript",
+      "federated.jc.clawbox.tasks.code-review.python",
+      "federated.jc.clawbox.tasks.@did-mf-sage.code-review.rust",
+    ]) {
+      const matched = [LOCAL, FED_OFFER, FED_DIRECT].filter((p) => subjectMatches(subject, p));
+      expect(matched.length).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/src/bus/jetstream/__tests__/review-filter-disjoint.test.ts
+++ b/src/bus/jetstream/__tests__/review-filter-disjoint.test.ts
@@ -4,13 +4,14 @@
  *
  * The double-post bug was that every review durable was provisioned with NO
  * `filter_subject` (claims every message). The fix wires each durable's filter
- * to the pattern its consumer binds. This test proves those patterns can't
- * overlap — the CHANGELOG's "disjoint by scope" claim, shown not asserted.
+ * to the pattern its consumer binds. This test exercises the SAME production
+ * builder cortex provisions from (`reviewScopePatterns`), so it proves the real
+ * filters are disjoint — not hand-copied sample strings (sage cortex#1187 R2).
  *
- * Self-contained NATS subject matcher (token wildcards `*` and trailing `>`) so
- * the property is verified without importing cortex's private pattern consts.
+ * Self-contained NATS subject matcher (token wildcards `*` and trailing `>`).
  */
 import { describe, expect, test } from "bun:test";
+import { reviewScopePatterns } from "../review-subjects";
 
 /** Minimal NATS subject/pattern match: `*` = exactly one token, `>` = one-or-more
  *  trailing tokens (only valid as the last token). */
@@ -26,12 +27,9 @@ function subjectMatches(subject: string, pattern: string): boolean {
   return subTokens.length === patTokens.length;
 }
 
-// The three scope patterns cortex provisions (principal=jc, stack=clawbox), per
-// `reviewSubjectPattern` / `reviewFederatedSubjectPattern` /
-// `reviewFederatedDirectSubjectPattern` in src/cortex.ts.
-const LOCAL = "local.jc.clawbox.tasks.code-review.>";
-const FED_OFFER = "federated.jc.clawbox.tasks.code-review.>";
-const FED_DIRECT = "federated.jc.clawbox.tasks.*.code-review.>";
+// The REAL scope patterns cortex provisions from (principal=jc, stack=clawbox).
+const { local: LOCAL, federatedOffer: FED_OFFER, federatedDirect: FED_DIRECT } =
+  reviewScopePatterns("jc", "clawbox");
 
 describe("cortex#1186 — review-consumer filter patterns are disjoint by scope", () => {
   test("a local review request matches ONLY the local filter", () => {

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -238,23 +238,39 @@ export async function provisionReviewConsumer(
 
   try {
     const existing = await opts.jsm.consumers.info(opts.stream, opts.durable);
-    // cortex#422 — `ack_wait` is the one consumer field we DO reconcile on
-    // drift. The original durable was created without it (JetStream default
-    // 30s), so already-provisioned brokers carry the bug until the consumer
-    // is recreated. Update it in place when it doesn't match the desired
-    // deadline so a redeploy fixes live durables without a manual
-    // `nats consumer rm`. Other fields stay un-reconciled (v1 policy).
-    if (existing.config.ack_wait !== ackWaitNs) {
-      await opts.jsm.consumers.update(opts.stream, opts.durable, {
-        ...existing.config,
-        ack_wait: ackWaitNs,
-      });
+    // cortex#1186 — `filter_subject` is IMMUTABLE on a JetStream durable, so a
+    // drift can't be patched in place: it must be deleted + recreated. This is
+    // the migration path for durables created before the per-scope filter was
+    // wired (those carry `filter_subject: ""` and therefore claim EVERY message
+    // on the stream — the multi-durable fan-out that double-posts a review).
+    // The brief delete→recreate gap re-delivers any in-flight message; the
+    // review-consumer's redelivery>1 abort makes that safe.
+    const desiredFilter = opts.filterSubject ?? "";
+    const existingFilter = existing.config.filter_subject ?? "";
+    if (existingFilter !== desiredFilter) {
       log.info(
-        `jetstream-provision: updated consumer "${opts.durable}" ack_wait ${Math.round((existing.config.ack_wait ?? 0) / 1_000_000_000)}s → ${Math.round(ackWaitNs / 1_000_000_000)}s (cortex#422)`,
+        `jetstream-provision: consumer "${opts.durable}" filter drift ("${existingFilter || "<none>"}" → "${desiredFilter || "<none>"}") — recreating durable (cortex#1186)`,
       );
-      return "updated";
+      await opts.jsm.consumers.delete(opts.stream, opts.durable);
+      // Fall through to the create path below (re-applies the correct filter).
+    } else {
+      // cortex#422 — `ack_wait` is the one consumer field we reconcile in place
+      // (no filter drift, so an in-place update is legal). The original durable
+      // was created without it (JetStream default 30s); update it so a redeploy
+      // fixes live durables without a manual `nats consumer rm`. Other fields
+      // stay un-reconciled (v1 policy).
+      if (existing.config.ack_wait !== ackWaitNs) {
+        await opts.jsm.consumers.update(opts.stream, opts.durable, {
+          ...existing.config,
+          ack_wait: ackWaitNs,
+        });
+        log.info(
+          `jetstream-provision: updated consumer "${opts.durable}" ack_wait ${Math.round((existing.config.ack_wait ?? 0) / 1_000_000_000)}s → ${Math.round(ackWaitNs / 1_000_000_000)}s (cortex#422)`,
+        );
+        return "updated";
+      }
+      return "exists";
     }
-    return "exists";
   } catch (err) {
     if (!isNotFoundError(err)) {
       throw err;

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -236,6 +236,10 @@ export async function provisionReviewConsumer(
   const maxDeliver = opts.maxDeliver ?? DEFAULT_MAX_DELIVER;
   const ackWaitNs = opts.ackWaitNs ?? DEFAULT_ACK_WAIT_NS;
 
+  // Set when the drift branch deletes a durable to migrate its (immutable)
+  // filter_subject — the recreated durable then starts from `New` (see below).
+  let recreatedForFilter = false;
+
   try {
     const existing = await opts.jsm.consumers.info(opts.stream, opts.durable);
     // cortex#1186 — `filter_subject` is IMMUTABLE on a JetStream durable, so a
@@ -243,15 +247,22 @@ export async function provisionReviewConsumer(
     // the migration path for durables created before the per-scope filter was
     // wired (those carry `filter_subject: ""` and therefore claim EVERY message
     // on the stream — the multi-durable fan-out that double-posts a review).
-    // The brief delete→recreate gap re-delivers any in-flight message; the
-    // review-consumer's redelivery>1 abort makes that safe.
+    //
+    // SAFETY: the recreated durable is forced to `DeliverPolicy.New` (below), so
+    // it does NOT replay the stream backlog — a migration must not re-review +
+    // re-post every historical PR. A message in-flight on the OLD durable at
+    // migration time is dropped (the new durable starts from "now"); that is the
+    // safe direction for a one-shot fix (a missed review is re-fireable; a
+    // re-posted one is not). Provisioning runs at boot, BEFORE the consumer
+    // pulls, so there is no concurrently-processing delivery to race.
     const desiredFilter = opts.filterSubject ?? "";
     const existingFilter = existing.config.filter_subject ?? "";
     if (existingFilter !== desiredFilter) {
       log.info(
-        `jetstream-provision: consumer "${opts.durable}" filter drift ("${existingFilter || "<none>"}" → "${desiredFilter || "<none>"}") — recreating durable (cortex#1186)`,
+        `jetstream-provision: consumer "${opts.durable}" filter drift ("${existingFilter || "<none>"}" → "${desiredFilter || "<none>"}") — recreating durable from New (cortex#1186)`,
       );
       await opts.jsm.consumers.delete(opts.stream, opts.durable);
+      recreatedForFilter = true;
       // Fall through to the create path below (re-applies the correct filter).
     } else {
       // cortex#422 — `ack_wait` is the one consumer field we reconcile in place
@@ -280,7 +291,9 @@ export async function provisionReviewConsumer(
   const cfg: Partial<ConsumerConfig> = {
     durable_name: opts.durable,
     ack_policy: AckPolicy.Explicit,
-    deliver_policy: opts.deliverPolicy ?? DeliverPolicy.All,
+    // A filter-drift recreate forces `New` so the migration never replays the
+    // backlog (cortex#1186). A genuine first create honours the caller's policy.
+    deliver_policy: recreatedForFilter ? DeliverPolicy.New : (opts.deliverPolicy ?? DeliverPolicy.All),
     max_deliver: maxDeliver,
     ack_wait: ackWaitNs,
   };

--- a/src/bus/jetstream/review-subjects.ts
+++ b/src/bus/jetstream/review-subjects.ts
@@ -1,0 +1,31 @@
+/**
+ * The three per-scope review-consumer subject patterns for an agent on a given
+ * principal/stack. THE single source of these pattern shapes (cortex#1186):
+ * cortex's consumer provisioning (`src/cortex.ts`) and the disjointness test
+ * (`review-filter-disjoint.test.ts`) both build from here, so the test proves
+ * the REAL filter contract rather than stale hand-copied strings.
+ *
+ * Disjoint by construction:
+ *  - `local.…` vs `federated.…` first tokens can never both match one subject;
+ *  - the Direct pattern carries an extra whole-token `*` (the pilot#149
+ *    `@{did}`-encoded reviewer segment, spliced after `tasks.`) that the Offer
+ *    pattern has no slot for, so a Direct request never matches the Offer
+ *    pattern and vice-versa.
+ */
+export interface ReviewScopePatterns {
+  /** Local-scope binding: `local.{principal}.{stack}.tasks.code-review.>`. */
+  local: string;
+  /** Federated Offer binding: `federated.{principal}.{stack}.tasks.code-review.>`. */
+  federatedOffer: string;
+  /** Federated Direct binding (extra `@{did}` token): `federated.{principal}.{stack}.tasks.*.code-review.>`. */
+  federatedDirect: string;
+}
+
+/** Build the per-scope review subject patterns for a principal/stack. */
+export function reviewScopePatterns(principal: string, stack: string): ReviewScopePatterns {
+  return {
+    local: `local.${principal}.${stack}.tasks.code-review.>`,
+    federatedOffer: `federated.${principal}.${stack}.tasks.code-review.>`,
+    federatedDirect: `federated.${principal}.${stack}.tasks.*.code-review.>`,
+  };
+}

--- a/src/bus/jetstream/types.ts
+++ b/src/bus/jetstream/types.ts
@@ -36,5 +36,8 @@ export interface ProvisionJsm {
       durable: string,
       cfg: Partial<ConsumerConfig>,
     ): Promise<ConsumerInfo>;
+    // cortex#1186 — `filter_subject` is immutable on a durable, so a filter
+    // drift is migrated by delete + recreate.
+    delete(stream: string, durable: string): Promise<boolean>;
   };
 }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -98,6 +98,7 @@ import {
   provisionReviewStream,
   provisionReviewConsumer,
 } from "./bus/jetstream/provision";
+import { reviewScopePatterns } from "./bus/jetstream/review-subjects";
 import {
   verifySignedByChain,
   nkeyToBase64Pubkey,
@@ -1605,7 +1606,10 @@ export async function startCortex(
   // `>` never matches (NATS requires literal segments before the `>`).
   // Reuses `derivedStack.stack` resolved at boot (line 308) — same source
   // sage's bridge subscription already uses for `local.{principal}.{stack}.>`.
-  const reviewSubjectPattern = `local.${reviewPrincipalId}.${derivedStack.stack}.tasks.code-review.>`;
+  // cortex#1186 — sourced from the shared `reviewScopePatterns` builder so the
+  // consumer filters and the disjointness test prove the SAME contract.
+  const reviewScopePats = reviewScopePatterns(reviewPrincipalId, derivedStack.stack);
+  const reviewSubjectPattern = reviewScopePats.local;
   // CO-2 (cortex#941) — the offering-derived consumer binding for the
   // `code-review` capability. `resolveOffering` reads the per-stack offering
   // policy (default-deny ⇒ `local`-only when `policy.offerings` is absent);
@@ -1638,7 +1642,7 @@ export async function startCortex(
   // filter/consumer (back-compat — local path byte-for-byte unchanged).
   const federationConfigured =
     (resolvedPolicy?.federated?.networks ?? []).length > 0;
-  const reviewFederatedSubjectPattern = `federated.${reviewPrincipalId}.${derivedStack.stack}.tasks.code-review.>`;
+  const reviewFederatedSubjectPattern = reviewScopePats.federatedOffer;
   // cortex#725 (ADR 0001/0002 §2) — the FEDERATED **Direct** review pattern.
   // pilot#149's `--reviewer {name}@{principal}/{stack}` Direct dispatch lands
   // on `federated.{me}.{my-stack}.tasks.@{did-encoded-reviewer}.code-review.{flavor}`:
@@ -1655,7 +1659,7 @@ export async function startCortex(
   // (the `@{did}` lives ONLY on the subject — myelin's `type` grammar forbids
   // `@`), so `extractFlavor` + the whole federated consumer path work
   // unchanged: only this extra subscription differs from the Offer path.
-  const reviewFederatedDirectSubjectPattern = `federated.${reviewPrincipalId}.${derivedStack.stack}.tasks.*.code-review.>`;
+  const reviewFederatedDirectSubjectPattern = reviewScopePats.federatedDirect;
   const reviewConfig = options.bus?.review;
   const reviewStream = reviewConfig?.stream.name ?? "CODE_REVIEW";
   const reviewStreamMaxAgeNs =

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2202,6 +2202,15 @@ export async function startCortex(
       // instead of unconditionally claiming "ready".
       const durable = `cortex-review-consumer-${reviewPrincipalId}-${agent.id}`;
 
+      // The durable's filter MUST match the subscription pattern this consumer
+      // binds (`consumer.start({ pattern })` below), or the durable claims every
+      // message on the stream — the cortex#1186 multi-durable fan-out that
+      // double-posts a review when an agent has >1 scope consumer (local +
+      // federated + …). `reviewOfferingPatterns[0]` is the local scope's
+      // pattern (CO-1 default = `reviewSubjectPattern`); hoisted here so it
+      // feeds BOTH the provision filter and the start pattern below.
+      const primaryReviewPattern = reviewOfferingPatterns[0] ?? reviewSubjectPattern;
+
       // cortex#338 — provision the per-agent durable consumer up-front
       // so `consumer.start()` below binds successfully against a virgin
       // broker. Reuses `reviewJsm` resolved once before this loop.
@@ -2214,6 +2223,7 @@ export async function startCortex(
             jsm: reviewJsm,
             stream: reviewStream,
             durable,
+            filterSubject: primaryReviewPattern,
             maxDeliver: reviewConsumerMaxDeliver,
           });
           if (outcome === "created") {
@@ -2247,7 +2257,8 @@ export async function startCortex(
       // mirroring the cortex#686/#725 federated-consumer idiom. With no
       // offerings, `reviewOfferingPatterns` is exactly `[reviewSubjectPattern]`
       // and this slice-loop is empty — zero added boot behaviour.
-      const primaryReviewPattern = reviewOfferingPatterns[0] ?? reviewSubjectPattern;
+      // (`primaryReviewPattern` is hoisted above so it also feeds the durable's
+      // `filterSubject` — cortex#1186.)
       const started = await consumer.start({
         pattern: primaryReviewPattern,
         stream: reviewStream,
@@ -2316,6 +2327,9 @@ export async function startCortex(
               jsm: reviewJsm,
               stream: reviewStream,
               durable: offerDurable,
+              // Filter to THIS offer scope's pattern so it doesn't claim the
+              // local/other-scope durables' traffic (cortex#1186 fan-out).
+              filterSubject: extraPattern,
               maxDeliver: reviewConsumerMaxDeliver,
             });
             if (outcome === "created") {
@@ -2383,6 +2397,10 @@ export async function startCortex(
                 jsm: reviewJsm,
                 stream: reviewStream,
                 durable,
+                // Filter to THIS federated consumer's `federated.…` pattern so
+                // it claims only cross-principal traffic, never the local
+                // durable's `local.…` requests (cortex#1186 fan-out).
+                filterSubject: pattern,
                 maxDeliver: reviewConsumerMaxDeliver,
               });
               if (outcome === "created") {


### PR DESCRIPTION
Closes #1186.

## Root cause

A review-capable agent gets up to **3 scope durables** on the CODE_REVIEW stream — local (`cortex-review-consumer-{p}-{agent}`), federated-offer, and federated-direct. They were provisioned **without a `filter_subject`**, so every durable had `filter_subject: ""` and **claimed every message on the stream**. JetStream durables fan out independently, so an agent with >1 scope consumer received + processed + `sage --post`ed the **same** review request N times.

Real occurrence: the genuine e2e on **the-metafactory/arc#241** posted **3 identical `changes-requested` sage reviews** (all 3 sage durables delivered the same `local.…tasks.code-review.typescript` request; verified `filter_subject: None` on each).

## Fix

- **`cortex.ts`** — pass `filterSubject` to each `provisionReviewConsumer` call, set to the exact pattern that consumer's `consumer.start({ pattern })` already binds (local → `primaryReviewPattern`, offer → `extraPattern`, federated → the closure's `pattern` arg). Hoisted `primaryReviewPattern` above the local provision so it feeds both the filter and the start. Now the scope filters are **disjoint** → a `local.…` request reaches exactly the local durable.
- **`provision.ts`** — `filter_subject` is **immutable** on a JetStream durable, so a drift can't be patched in place. `provisionReviewConsumer` now **delete + recreates** the durable on filter drift (the migration path for pre-fix `""`-filter durables); `ack_wait` is still reconciled in place when the filter matches. The brief delete→recreate gap re-delivers in-flight messages — the review-consumer's `redelivery>1` abort makes that safe.
- **`types.ts`** — `ProvisionJsm` gains `consumers.delete`.

## Tests

- `filterSubject` applied to the durable config on create.
- Filter drift (pre-fix `""`-filter durable) → delete + recreate with the new filter (returns `created`, not `updated`).
- Matching filter + drifted `ack_wait` → in-place update, no delete (regression guard for cortex#422).
- `delete` added to affected jsm fakes.
- `src/bus` **1134 pass / 0 fail**; provision suite 25 pass; typecheck + carve-out clean.

## Deploy / migration (operator — NOT auto-applied)

Live durables created before this fix carry `filter_subject: ""`; the next cortex boot recreates them with the correct filter (the new drift path). **Caveat:** the federated filters (`federated.…`) must be a subset of the CODE_REVIEW stream's subjects. `reviewStreamSubjects` already includes them when federation is configured, but an existing **live stream that drifted to local-only subjects** must have its subjects updated first (the `provisionReviewStream` v1 "no auto-update" policy leaves a drifted stream alone — see the boot-log drift warning), or the federated consumer provision will fail with "subject not in stream". On clawbox specifically, the CODE_REVIEW stream is currently `local.*` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)