### PR TITLE
fix(bus): JetStream DEFAULT_MAX_BYTES 512MiB→64MiB so the dev-loop's streams fit (#1197)

### DIFF
--- a/src/__tests__/cortex.dev-stream-boot.test.ts
+++ b/src/__tests__/cortex.dev-stream-boot.test.ts
@@ -248,11 +248,11 @@ describe("startCortex â€” DEV_IMPLEMENT stream boot wiring (F-2.2, cortex#835 â†
       `local.${PRINCIPAL}.${STACK}.tasks.dev.>`,
     ]);
     // Config posture mirrors CODE_REVIEW EXACTLY: Interest retention, File
-    // storage, 24h max_age, finite 512 MiB max_bytes, single replica.
+    // storage, 24h max_age, finite 64 MiB max_bytes, single replica.
     expect(String(dev.retention)).toBe("interest");
     expect(String(dev.storage)).toBe("file");
     expect(dev.max_age).toBe(24 * 3600 * 1e9);
-    expect(dev.max_bytes).toBe(512 * 1024 * 1024);
+    expect(dev.max_bytes).toBe(64 * 1024 * 1024);
     expect(dev.max_msgs).toBe(-1);
     expect(dev.num_replicas).toBe(1);
 

--- a/src/__tests__/cortex.lifecycle-stream-boot.test.ts
+++ b/src/__tests__/cortex.lifecycle-stream-boot.test.ts
@@ -247,11 +247,11 @@ describe("startCortex — REVIEW_LIFECYCLE stream boot wiring (cortex#835 / pilo
       `local.${PRINCIPAL}.${STACK}.dispatch.task.>`,
     ]);
     // Config posture mirrors CODE_REVIEW EXACTLY: Interest retention, File
-    // storage, 24h max_age, finite 512 MiB max_bytes, single replica.
+    // storage, 24h max_age, finite 64 MiB max_bytes, single replica.
     expect(String(lifecycle.retention)).toBe("interest");
     expect(String(lifecycle.storage)).toBe("file");
     expect(lifecycle.max_age).toBe(24 * 3600 * 1e9);
-    expect(lifecycle.max_bytes).toBe(512 * 1024 * 1024);
+    expect(lifecycle.max_bytes).toBe(64 * 1024 * 1024);
     expect(lifecycle.max_msgs).toBe(-1);
     expect(lifecycle.num_replicas).toBe(1);
 

--- a/src/bus/jetstream/__tests__/provision.test.ts
+++ b/src/bus/jetstream/__tests__/provision.test.ts
@@ -230,7 +230,9 @@ describe("provisionReviewStream", () => {
     // Finite max_bytes default — live deployment surfaced that NATS
     // accounts with storage-reservation caps reject max_bytes=-1
     // (unlimited) with "insufficient storage resources available".
-    expect(cfg.max_bytes).toBe(512 * 1024 * 1024);
+    // cortex#1197: 64 MiB (was 512 MiB) so >2 control-plane streams fit
+    // under the common `max_file: 1gb` JetStream cap (DEV_IMPLEMENT + release).
+    expect(cfg.max_bytes).toBe(64 * 1024 * 1024);
   });
 
   test("honors maxBytes override", async () => {

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -48,6 +48,7 @@ import type { ConsumerConfig, StreamInfo } from "nats";
 // Background: sage review on #338 round 3 (architecture).
 export type { ProvisionJsm } from "./types";
 import type { ProvisionJsm } from "./types";
+import { DEFAULT_STREAM_MAX_BYTES } from "../../common/types/cortex-config";
 
 /**
  * Outcome of `provisionReviewStream`. Includes `config-drift-warning`
@@ -156,7 +157,7 @@ export interface ProvisionConsumerOpts {
 }
 
 const DEFAULT_MAX_AGE_NS = 24 * 3600 * 1_000_000_000;
-const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_BYTES = DEFAULT_STREAM_MAX_BYTES;
 const DEFAULT_MAX_DELIVER = 5;
 /**
  * Default per-message ack deadline: 20 minutes in nanoseconds. Sized well

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -89,15 +89,22 @@ export interface ProvisionStreamOpts {
    */
   maxAgeNs?: number;
   /**
-   * Stream `max_bytes` cap. Default 512 MiB. Live deployment of #338
+   * Stream `max_bytes` cap. Default 64 MiB. Live deployment of #338
    * surfaced that NATS servers running with an account-level storage
    * reservation cap reject `max_bytes: -1` (unlimited) with
    * "insufficient storage resources available" even when raw disk is
-   * abundant. The 512 MiB default matches sibling stream sizing on
-   * JC's laptop (GROVE_EVENTS) and is large enough to absorb ~100k
-   * typical review-task envelopes; principals can override via
-   * `cortex.yaml` `bus.review.maxBytes` once that surface lands
-   * (G-1111e / #341).
+   * abundant — so the default must be a finite RESERVATION, not unlimited.
+   *
+   * cortex#1197: the previous 512 MiB default was ~8000× the actual
+   * footprint (these are interest-retention, max-age-bounded CONTROL-plane
+   * streams holding KB), and it capped a stack at only TWO streams under
+   * the common `max_file: 1gb` JetStream limit (2 × 512 MiB = the whole GB).
+   * The third stream a dev-loop stack needs — `DEV_IMPLEMENT` (and the
+   * release stream) — then failed to provision with "insufficient storage
+   * resources", silently disabling the `dev.implement` consumer. 64 MiB
+   * still absorbs ~100k typical envelopes yet fits ~16 streams per GB.
+   * Principals can override via `cortex.yaml` `bus.review.maxBytes` once
+   * that surface lands (G-1111e / #341).
    */
   maxBytes?: number;
   /**
@@ -149,7 +156,7 @@ export interface ProvisionConsumerOpts {
 }
 
 const DEFAULT_MAX_AGE_NS = 24 * 3600 * 1_000_000_000;
-const DEFAULT_MAX_BYTES = 512 * 1024 * 1024;
+const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
 const DEFAULT_MAX_DELIVER = 5;
 /**
  * Default per-message ack deadline: 20 minutes in nanoseconds. Sized well

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -23,6 +23,7 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { join } from "path";
+import { DEFAULT_STREAM_MAX_BYTES } from "../../../common/types/cortex-config";
 
 // =============================================================================
 // Discovery
@@ -298,7 +299,7 @@ bus:
     stream:
       name: CODE_REVIEW
       maxAgeSeconds: 86400
-      maxBytes: 536870912
+      maxBytes: ${DEFAULT_STREAM_MAX_BYTES}
     consumer:
       maxDeliver: 5
 `;

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -1017,7 +1017,7 @@ describe("Cross-cutting schemas — defaults populated by emptyDefault helper", 
     // Existing CODE_REVIEW posture — unchanged.
     expect(parsed.review.stream.name).toBe("CODE_REVIEW");
     expect(parsed.review.stream.maxAgeSeconds).toBe(86_400);
-    expect(parsed.review.stream.maxBytes).toBe(512 * 1024 * 1024);
+    expect(parsed.review.stream.maxBytes).toBe(64 * 1024 * 1024);
     expect(parsed.review.consumer.maxDeliver).toBe(5);
     // New REVIEW_LIFECYCLE stream — mirrors CODE_REVIEW's stream posture
     // exactly, and intentionally carries NO consumer sub-block (cortex
@@ -1025,7 +1025,7 @@ describe("Cross-cutting schemas — defaults populated by emptyDefault helper", 
     // reactor's concern — the cortex#835 follow-up).
     expect(parsed.lifecycle.stream.name).toBe("REVIEW_LIFECYCLE");
     expect(parsed.lifecycle.stream.maxAgeSeconds).toBe(86_400);
-    expect(parsed.lifecycle.stream.maxBytes).toBe(512 * 1024 * 1024);
+    expect(parsed.lifecycle.stream.maxBytes).toBe(64 * 1024 * 1024);
     expect("consumer" in parsed.lifecycle).toBe(false);
     // The two stream names MUST differ — they own disjoint subject spaces,
     // and a shared name would clash on `streams.add`.
@@ -1035,7 +1035,7 @@ describe("Cross-cutting schemas — defaults populated by emptyDefault helper", 
     // stream; the dev-agent's durable consumer is F-2.1's concern, cortex#853).
     expect(parsed.devImplement.stream.name).toBe("DEV_IMPLEMENT");
     expect(parsed.devImplement.stream.maxAgeSeconds).toBe(86_400);
-    expect(parsed.devImplement.stream.maxBytes).toBe(512 * 1024 * 1024);
+    expect(parsed.devImplement.stream.maxBytes).toBe(64 * 1024 * 1024);
     expect("consumer" in parsed.devImplement).toBe(false);
     // The DEV_IMPLEMENT name MUST differ from BOTH siblings — they own disjoint
     // subject spaces, and a shared name would clash on `streams.add`.

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -55,6 +55,29 @@ import { checkPublicOfferingBackendGate } from "./public-offering-backend-gate";
 import { StackConfigSchema, deriveStackId } from "./stack";
 
 // =============================================================================
+// JetStream stream sizing — single source of truth (cortex#1197)
+// =============================================================================
+
+/**
+ * Default `max_bytes` RESERVATION for a cortex control-plane JetStream stream
+ * (CODE_REVIEW, REVIEW_LIFECYCLE, DEV_IMPLEMENT, the release stream).
+ *
+ * These are interest-retention, max-age-bounded control streams that hold
+ * KB-scale envelopes. A live deployment showed the previous 512 MiB default
+ * was ~8000× the footprint AND — fatally — capped a stack at only TWO streams
+ * under the common `max_file: 1gb` JetStream limit (2 × 512 MiB = the whole GB),
+ * so the third stream a dev-loop stack needs (`DEV_IMPLEMENT`, plus the release
+ * stream) failed to provision with "insufficient storage resources available",
+ * silently disabling the `dev.implement` consumer (cortex#1197). 64 MiB still
+ * absorbs ~100k typical envelopes and fits ~16 streams per GB.
+ *
+ * EVERY stream-provisioning site reads this constant so the reservation can
+ * never drift between the schema defaults, the boot path, the provisioning
+ * helper fallback, and the `stack create` scaffold.
+ */
+export const DEFAULT_STREAM_MAX_BYTES = 64 * 1024 * 1024;
+
+// =============================================================================
 // Helper — Zod v4 empty-default workaround
 // =============================================================================
 
@@ -1230,11 +1253,11 @@ export const BusReviewConfigSchema = z.object({
       .number()
       .int("bus.review.stream.maxBytes must be an integer number of bytes")
       .positive("bus.review.stream.maxBytes must be positive")
-      .default(512 * 1024 * 1024),
+      .default(DEFAULT_STREAM_MAX_BYTES),
   }).default({
     name: "CODE_REVIEW",
     maxAgeSeconds: 86_400,
-    maxBytes: 512 * 1024 * 1024,
+    maxBytes: DEFAULT_STREAM_MAX_BYTES,
   }),
   consumer: z.object({
     /** Delivery attempts before JetStream stops redelivering the task. */
@@ -1263,7 +1286,7 @@ export const BusReviewConfigSchema = z.object({
  * across streams — the two streams partition the subject space cleanly).
  *
  * Posture mirrors `BusReviewConfigSchema.stream` EXACTLY (Interest
- * retention, File storage, 24h max_age, finite 512 MiB max_bytes). There
+ * retention, File storage, 24h max_age, finite 64 MiB max_bytes). There
  * is intentionally NO `consumer` sub-block: cortex provisions the stream
  * only; the durable consumers that read it are the DOWNSTREAM reactor's
  * concern (pilot's durable-consumer upgrade — the cortex#835 follow-up).
@@ -1287,11 +1310,11 @@ export const BusLifecycleConfigSchema = z.object({
       .number()
       .int("bus.lifecycle.stream.maxBytes must be an integer number of bytes")
       .positive("bus.lifecycle.stream.maxBytes must be positive")
-      .default(512 * 1024 * 1024),
+      .default(DEFAULT_STREAM_MAX_BYTES),
   }).default({
     name: "REVIEW_LIFECYCLE",
     maxAgeSeconds: 86_400,
-    maxBytes: 512 * 1024 * 1024,
+    maxBytes: DEFAULT_STREAM_MAX_BYTES,
   }),
 });
 
@@ -1312,7 +1335,7 @@ export const BusLifecycleConfigSchema = z.object({
  * after `tasks.`), so no subject of one is a prefix of any subject of another.
  *
  * Posture mirrors `BusReviewConfigSchema.stream` EXACTLY (Interest retention,
- * File storage, 24h max_age, finite 512 MiB max_bytes). There is intentionally
+ * File storage, 24h max_age, finite 64 MiB max_bytes). There is intentionally
  * NO `consumer` sub-block: cortex provisions the stream only; the durable
  * consumer that reads it is the dev-agent's concern (F-2.1, cortex#853).
  */
@@ -1335,11 +1358,11 @@ export const BusDevImplementConfigSchema = z.object({
       .number()
       .int("bus.devImplement.stream.maxBytes must be an integer number of bytes")
       .positive("bus.devImplement.stream.maxBytes must be positive")
-      .default(512 * 1024 * 1024),
+      .default(DEFAULT_STREAM_MAX_BYTES),
   }).default({
     name: "DEV_IMPLEMENT",
     maxAgeSeconds: 86_400,
-    maxBytes: 512 * 1024 * 1024,
+    maxBytes: DEFAULT_STREAM_MAX_BYTES,
   }),
 });
 
@@ -1348,7 +1371,7 @@ export const BusConfigSchema = z.object({
     stream: {
       name: "CODE_REVIEW",
       maxAgeSeconds: 86_400,
-      maxBytes: 512 * 1024 * 1024,
+      maxBytes: DEFAULT_STREAM_MAX_BYTES,
     },
     consumer: { maxDeliver: 5 },
   }),
@@ -1356,7 +1379,7 @@ export const BusConfigSchema = z.object({
     stream: {
       name: "REVIEW_LIFECYCLE",
       maxAgeSeconds: 86_400,
-      maxBytes: 512 * 1024 * 1024,
+      maxBytes: DEFAULT_STREAM_MAX_BYTES,
     },
   }),
   // F-2.2 (cortex#835 → cortex#865) — DEV_IMPLEMENT stream knobs. Sibling of
@@ -1368,7 +1391,7 @@ export const BusConfigSchema = z.object({
     stream: {
       name: "DEV_IMPLEMENT",
       maxAgeSeconds: 86_400,
-      maxBytes: 512 * 1024 * 1024,
+      maxBytes: DEFAULT_STREAM_MAX_BYTES,
     },
   }),
 });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -132,7 +132,7 @@ import {
 
 import { DiscordAdapter } from "./adapters/discord";
 import { createRenderer, type Renderer } from "./renderers";
-import { RendererSchema, deriveStackId } from "./common/types/cortex-config";
+import { RendererSchema, deriveStackId, DEFAULT_STREAM_MAX_BYTES } from "./common/types/cortex-config";
 import type {
   Agent,
   BusConfig,
@@ -1666,7 +1666,7 @@ export async function startCortex(
   const reviewStreamMaxAgeNs =
     (reviewConfig?.stream.maxAgeSeconds ?? 86_400) * 1_000_000_000;
   const reviewStreamMaxBytes =
-    reviewConfig?.stream.maxBytes ?? 512 * 1024 * 1024;
+    reviewConfig?.stream.maxBytes ?? DEFAULT_STREAM_MAX_BYTES;
   const reviewConsumerMaxDeliver = reviewConfig?.consumer.maxDeliver ?? 5;
 
   // cortex#835 / pilot#154 — the REVIEW_LIFECYCLE stream. A SECOND JetStream
@@ -1685,7 +1685,7 @@ export async function startCortex(
   const lifecycleStreamMaxAgeNs =
     (lifecycleConfig?.stream.maxAgeSeconds ?? 86_400) * 1_000_000_000;
   const lifecycleStreamMaxBytes =
-    lifecycleConfig?.stream.maxBytes ?? 512 * 1024 * 1024;
+    lifecycleConfig?.stream.maxBytes ?? DEFAULT_STREAM_MAX_BYTES;
 
   // ── F-2.2 (cortex#835 → cortex#865) DEV_IMPLEMENT config ──────────────────
   // Resolve the DEV_IMPLEMENT stream knobs alongside the review knobs. Sibling
@@ -1698,7 +1698,7 @@ export async function startCortex(
   const devImplementStreamMaxAgeNs =
     (devImplementConfig?.stream.maxAgeSeconds ?? 86_400) * 1_000_000_000;
   const devImplementStreamMaxBytes =
-    devImplementConfig?.stream.maxBytes ?? 512 * 1024 * 1024;
+    devImplementConfig?.stream.maxBytes ?? DEFAULT_STREAM_MAX_BYTES;
   // ── /F-2.2 DEV_IMPLEMENT config ───────────────────────────────────────────
 
   // cortex#338 — resolve the provisioning JSM and provision the
@@ -2948,10 +2948,10 @@ export async function startCortex(
     );
     const releaseStream = "RELEASE";
     // Reuse the review-lane stream defaults: a release-cut request is small +
-    // infrequent; 24h retention + 512MiB is ample and matches the operational
+    // infrequent; 24h retention + 64MiB is ample and matches the operational
     // posture principals already understand from CODE_REVIEW.
     const releaseStreamMaxAgeNs = 86_400 * 1_000_000_000;
-    const releaseStreamMaxBytes = 512 * 1024 * 1024;
+    const releaseStreamMaxBytes = DEFAULT_STREAM_MAX_BYTES;
     const releaseConsumerMaxDeliver = 5;
 
     // Resolve the provisioning JSM once (same contained-failure contract as the


### PR DESCRIPTION
Closes #1197.

## Problem
The `dev.implement` (and `release.cut`) consumers silently fail to bind on the meta-factory dev-loop stack. Root cause (full diagnosis in #1197): every control-plane stream reserves **512 MiB** (`provision.ts` `DEFAULT_MAX_BYTES`). Under the common `max_file: 1gb` JetStream cap, only **two** streams fit — `CODE_REVIEW` + `REVIEW_LIFECYCLE` consume the whole GB — so `DEV_IMPLEMENT` fails with `insufficient storage resources available` → `dev consumer init failed: stream not found`. Review survives (its stream already existed); implement + release don't.

## Fix
Drop `DEFAULT_MAX_BYTES` from **512 MiB → 64 MiB**. These are interest-retention, max-age-bounded control streams holding KB (meta-factory's `CODE_REVIEW` actual: 84KB) — 512 MiB was ~8000× over and capped a stack at 2 streams. 64 MiB still absorbs ~100k envelopes and fits **~16 streams/GB**. Test updated; `tsc` 0; carve-out green.

## Deploy note (load-bearing)
cortex does **not** auto-update existing streams (v1 no-auto-update). After this deploys, the already-512 MiB `CODE_REVIEW` + `REVIEW_LIFECYCLE` must be **deleted so cortex re-provisions them at 64 MiB** (or `nats stream edit --max-bytes`), reclaiming room for `DEV_IMPLEMENT` + the release stream. Then a meta-factory restart brings the `dev.implement` consumer live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)