### PR TITLE
fix(bus): review-subject Offer family single-token so CODE_REVIEW provisions (#1199)

### DIFF
--- a/src/bus/jetstream/__tests__/review-filter-disjoint.test.ts
+++ b/src/bus/jetstream/__tests__/review-filter-disjoint.test.ts
@@ -27,6 +27,28 @@ function subjectMatches(subject: string, pattern: string): boolean {
   return subTokens.length === patTokens.length;
 }
 
+/**
+ * cortex#1199 — JetStream's STREAM-subject overlap rule (stricter than routing
+ * disjointness): two subjects overlap if ANY subject could match both. A stream
+ * whose subject set contains an overlapping pair is REJECTED at `streams.add`.
+ * `>` absorbs the rest (→ overlap if the prefix matched); two single `*`/literal
+ * positions are compatible iff equal-or-`*`; otherwise length must match.
+ */
+function patternsOverlap(a: string, b: string): boolean {
+  const at = a.split(".");
+  const bt = b.split(".");
+  const n = Math.min(at.length, bt.length);
+  for (let i = 0; i < n; i++) {
+    const x = at[i]!;
+    const y = bt[i]!;
+    if (x === ">" || y === ">") return true; // `>` matches all remaining → a common subject exists
+    if (x !== "*" && y !== "*" && x !== y) return false; // concrete mismatch → disjoint
+  }
+  // No `>` reached and no concrete mismatch: a common subject exists ONLY if the
+  // two patterns require the same token count.
+  return at.length === bt.length;
+}
+
 // The REAL scope patterns cortex provisions from (principal=jc, stack=clawbox).
 const { local: LOCAL, federatedOffer: FED_OFFER, federatedDirect: FED_DIRECT } =
   reviewScopePatterns("jc", "clawbox");
@@ -60,5 +82,31 @@ describe("cortex#1186 — review-consumer filter patterns are disjoint by scope"
       const matched = [LOCAL, FED_OFFER, FED_DIRECT].filter((p) => subjectMatches(subject, p));
       expect(matched.length).toBeLessThanOrEqual(1);
     }
+  });
+
+  // cortex#1199 — the regression guard. Before the fix, FED_OFFER was
+  // `…tasks.code-review.>` which OVERLAPS FED_DIRECT `…tasks.*.code-review.>`
+  // under JetStream's stream-subject rule (a `tasks.code-review.code-review.x`
+  // matches both), so CODE_REVIEW failed to provision once Direct joined the
+  // set. The Offer family is now single-token (`…code-review.*`, 3 task tokens)
+  // and Direct is 4 — token-count disjoint. No pair in the stream's subject set
+  // may overlap, or `streams.add` rejects the whole stream.
+  test("no two stream-subject patterns overlap (JetStream provision contract)", () => {
+    const pats = [LOCAL, FED_OFFER, FED_DIRECT];
+    for (let i = 0; i < pats.length; i++) {
+      for (let j = i + 1; j < pats.length; j++) {
+        expect(patternsOverlap(pats[i]!, pats[j]!)).toBe(false);
+      }
+    }
+  });
+
+  test("patternsOverlap detects the cortex#1199 pre-fix overlap (sanity)", () => {
+    // The OLD Offer pattern (trailing `>`) DID overlap the Direct pattern.
+    expect(
+      patternsOverlap(
+        "federated.jc.clawbox.tasks.code-review.>",
+        "federated.jc.clawbox.tasks.*.code-review.>",
+      ),
+    ).toBe(true);
   });
 });

--- a/src/bus/jetstream/review-subjects.ts
+++ b/src/bus/jetstream/review-subjects.ts
@@ -33,11 +33,19 @@ export interface ReviewScopePatterns {
   federatedDirect: string;
 }
 
+/**
+ * The Offer-family task suffix — single-token `*` flavor (cortex#1199). THE one
+ * place this literal lives; cortex's offering-pattern call site imports it rather
+ * than re-typing the string, so the stream filter can't drift from the consumer
+ * patterns (the cortex#1199 review-major).
+ */
+export const REVIEW_OFFER_TASK_SUFFIX = "tasks.code-review.*";
+
 /** Build the per-scope review subject patterns for a principal/stack. */
 export function reviewScopePatterns(principal: string, stack: string): ReviewScopePatterns {
   return {
-    local: `local.${principal}.${stack}.tasks.code-review.*`,
-    federatedOffer: `federated.${principal}.${stack}.tasks.code-review.*`,
+    local: `local.${principal}.${stack}.${REVIEW_OFFER_TASK_SUFFIX}`,
+    federatedOffer: `federated.${principal}.${stack}.${REVIEW_OFFER_TASK_SUFFIX}`,
     federatedDirect: `federated.${principal}.${stack}.tasks.*.code-review.>`,
   };
 }

--- a/src/bus/jetstream/review-subjects.ts
+++ b/src/bus/jetstream/review-subjects.ts
@@ -5,17 +5,29 @@
  * (`review-filter-disjoint.test.ts`) both build from here, so the test proves
  * the REAL filter contract rather than stale hand-copied strings.
  *
- * Disjoint by construction:
+ * Disjoint by construction — and now disjoint at the JetStream STREAM-subject
+ * level too, not merely for request routing (cortex#1199):
  *  - `local.…` vs `federated.…` first tokens can never both match one subject;
- *  - the Direct pattern carries an extra whole-token `*` (the pilot#149
- *    `@{did}`-encoded reviewer segment, spliced after `tasks.`) that the Offer
- *    pattern has no slot for, so a Direct request never matches the Offer
- *    pattern and vice-versa.
+ *  - the Offer pattern ends in a single-token `*` (a `code-review.{flavor}`
+ *    capability is exactly `…tasks.code-review.{flavor}` — three task-suffix
+ *    tokens; the flavor is one token, `[a-z][a-z0-9-]*`), while the Direct
+ *    pattern carries the extra whole-token `*` (the pilot#149 `@{did}`-encoded
+ *    reviewer segment) BEFORE `code-review`, so it is four task-suffix tokens.
+ *
+ * The earlier Offer pattern used a trailing `>` (`…tasks.code-review.>`), which
+ * OVERLAPS the Direct `…tasks.*.code-review.>` under JetStream's stream-subject
+ * rule (a pathological `tasks.code-review.code-review.x` matches both) even
+ * though no real request ever does. JetStream rejects a stream whose subjects
+ * overlap, so CODE_REVIEW failed to provision with "subjects overlap" once the
+ * Direct pattern (cortex#1186) joined the set. Pinning the Offer to a single
+ * trailing `*` makes Offer (3 task tokens) and Direct (4) token-count disjoint —
+ * no subject can match both — so the stream provisions and routing is unchanged
+ * (every real `code-review.{flavor}` task still matches `…code-review.*`).
  */
 export interface ReviewScopePatterns {
-  /** Local-scope binding: `local.{principal}.{stack}.tasks.code-review.>`. */
+  /** Local-scope binding: `local.{principal}.{stack}.tasks.code-review.*` (single-token flavor; `*` not `>` to stay uniform with the Offer family — cortex#1199). */
   local: string;
-  /** Federated Offer binding: `federated.{principal}.{stack}.tasks.code-review.>`. */
+  /** Federated Offer binding: `federated.{principal}.{stack}.tasks.code-review.*` (single-token flavor; `*` not `>` so it stays JetStream-disjoint from the 4-token Direct pattern — cortex#1199). */
   federatedOffer: string;
   /** Federated Direct binding (extra `@{did}` token): `federated.{principal}.{stack}.tasks.*.code-review.>`. */
   federatedDirect: string;
@@ -24,8 +36,8 @@ export interface ReviewScopePatterns {
 /** Build the per-scope review subject patterns for a principal/stack. */
 export function reviewScopePatterns(principal: string, stack: string): ReviewScopePatterns {
   return {
-    local: `local.${principal}.${stack}.tasks.code-review.>`,
-    federatedOffer: `federated.${principal}.${stack}.tasks.code-review.>`,
+    local: `local.${principal}.${stack}.tasks.code-review.*`,
+    federatedOffer: `federated.${principal}.${stack}.tasks.code-review.*`,
     federatedDirect: `federated.${principal}.${stack}.tasks.*.code-review.>`,
   };
 }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -98,7 +98,7 @@ import {
   provisionReviewStream,
   provisionReviewConsumer,
 } from "./bus/jetstream/provision";
-import { reviewScopePatterns } from "./bus/jetstream/review-subjects";
+import { reviewScopePatterns, REVIEW_OFFER_TASK_SUFFIX } from "./bus/jetstream/review-subjects";
 import {
   verifySignedByChain,
   nkeyToBase64Pubkey,
@@ -1627,12 +1627,11 @@ export async function startCortex(
   // offering layer decides reachability, the existing federation block decides
   // verdict-routing. They compose; CO-2 touches only the Offer binding.
   const reviewOfferingPatterns = offeringSubjectPatterns(
-    // cortex#1199 — single-token `*` (not `>`): a `code-review.{flavor}` task is
-    // exactly `…tasks.code-review.{flavor}` (3 task tokens), so this stays
-    // JetStream stream-subject disjoint from the 4-token federated Direct
-    // pattern `…tasks.*.code-review.>`. A trailing `>` here overlaps Direct and
-    // makes CODE_REVIEW fail to provision once code-review is offered federated.
-    "tasks.code-review.*",
+    // cortex#1199 — the shared single-token `*` Offer suffix (owned by
+    // review-subjects.ts). Single-token (not `>`) keeps the offering-derived
+    // federated/public Offer patterns JetStream-disjoint from the 4-token Direct
+    // pattern, so CODE_REVIEW provisions even when code-review is offered federated.
+    REVIEW_OFFER_TASK_SUFFIX,
     reviewPrincipalId,
     derivedStack.stack,
     resolveOffering("code-review", resolvedPolicy?.offerings),

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1627,7 +1627,12 @@ export async function startCortex(
   // offering layer decides reachability, the existing federation block decides
   // verdict-routing. They compose; CO-2 touches only the Offer binding.
   const reviewOfferingPatterns = offeringSubjectPatterns(
-    "tasks.code-review.>",
+    // cortex#1199 — single-token `*` (not `>`): a `code-review.{flavor}` task is
+    // exactly `…tasks.code-review.{flavor}` (3 task tokens), so this stays
+    // JetStream stream-subject disjoint from the 4-token federated Direct
+    // pattern `…tasks.*.code-review.>`. A trailing `>` here overlaps Direct and
+    // makes CODE_REVIEW fail to provision once code-review is offered federated.
+    "tasks.code-review.*",
     reviewPrincipalId,
     derivedStack.stack,
     resolveOffering("code-review", resolvedPolicy?.offerings),


### PR DESCRIPTION
Closes #1199.

## Problem
CODE_REVIEW fails to provision: `subject "…tasks.code-review.>" overlaps with "…tasks.*.code-review.>"`. JetStream rejects a stream with overlapping subjects, so the review stream can't be (re)created → review consumers fail "stream not found". (Surfaced activating the dev-loop, cortex#1197 follow-on.)

## Root cause
The review stream's subject set contains Offer `…tasks.code-review.>` **and** federated Direct `…tasks.*.code-review.>` (added cortex#1186/#725). These overlap under JetStream's stream-subject rule (`tasks.code-review.code-review.x` matches both) even though no real request does. The original stream predated Direct and survived untouched; the overlap only bites on (re)creation.

## Fix (Option A — one stream, narrowed filter; grounded in the wire SOP)
`code-review.{flavor}` is single-token (`[a-z][a-z0-9-]*`), so an Offer subject is exactly `…tasks.code-review.{flavor}` — **3 task tokens**. Narrow the whole Offer family to single-token `*` (was trailing `>`):
- `review-subjects.ts`: `local` + `federatedOffer` → `…code-review.*`
- `cortex.ts`: the offering-pattern suffix → `tasks.code-review.*`
Direct stays 4 tokens (`…tasks.*.code-review.>`). 3-vs-4 **token-count disjoint** → no overlap, and every real `code-review.{flavor}` subject still matches. Adds a JetStream **stream-overlap regression test** (fails on the old `>`, passes now).

**Separation of concerns:** no myelin/wire-grammar change — ADR-0001 subject *shapes* are unchanged; this is purely cortex's M7 stream/consumer *filter binding*. Offer (capability-addressed) and Direct (agent-addressed) stay one stream (per-scope consumer filters, cortex#1186).

`tsc` 0 · 30 jetstream tests pass · carve-out green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)