### PR TITLE
chore: bump to v5.26.1

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.0"
+version: "5.26.1"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Patch release for the review-subject overlap fix (#1199, PRs #1200/#1201) that restores CODE_REVIEW provisioning. No code change beyond the manifest version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)