### PR TITLE
fix(runner): provision DEV_IMPLEMENT durable up-front so dev.implement binds (#1203)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3192,6 +3192,32 @@ export async function startCortex(
         scopeToken === "local"
           ? `cortex-dev-consumer-${principalId}-${consumer.agent.id}`
           : `cortex-dev-consumer-offer-${scopeToken}-${principalId}-${consumer.agent.id}`;
+      // cortex#1203 — provision the DEV_IMPLEMENT durable UP-FRONT, then bind.
+      // The review, brain and release lanes all `provisionReviewConsumer(...)`
+      // (jsm.consumers.add) before `consumer.start()`; the dev lane was the ONLY
+      // one that didn't — and `consumer.start()`/`subscribePull` BINDS an
+      // existing durable rather than creating it. With no `consumers.add`, the
+      // bind fails "consumer not found" and `dev.implement` never reaches ready
+      // (the F-2.1 consumer silently dormant). Mirrors the brain lane: the
+      // per-scope `pattern` is the durable's `filter_subject` (cortex#1186).
+      if (reviewJsm !== null) {
+        try {
+          await provisionReviewConsumer({
+            jsm: reviewJsm,
+            stream: "DEV_IMPLEMENT",
+            durable,
+            filterSubject: pattern,
+            maxDeliver: reviewConsumerMaxDeliver,
+          });
+        } catch (provisionErr) {
+          // Don't abort — let `consumer.start()` surface the bind failure via
+          // its own dormant/skip path (mirrors the review + brain lanes).
+          process.stderr.write(
+            `cortex: provisionReviewConsumer (dev) failed for "${durable}": ` +
+              `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+          );
+        }
+      }
       const started = await consumer.start({
         pattern,
         stream: "DEV_IMPLEMENT",

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3204,10 +3204,21 @@ export async function startCortex(
         try {
           await provisionReviewConsumer({
             jsm: reviewJsm,
-            stream: "DEV_IMPLEMENT",
+            // cortex#1203 review major-1: the config-resolved stream name (NOT a
+            // hardcoded "DEV_IMPLEMENT") — must match the stream as provisioned
+            // AND the `consumer.start({ stream })` below, or a renamed
+            // `bus.devImplement.stream.name` reproduces the very "consumer not
+            // found" this fixes.
+            stream: devImplementStream,
             durable,
             filterSubject: pattern,
             maxDeliver: reviewConsumerMaxDeliver,
+            // cortex#1203 review major-2: a dev implement runs far longer than a
+            // review, but is bounded by the dev session timeout. Size the durable
+            // ack-wait to that (+60s) so a legitimately-long run isn't redelivered
+            // mid-flight (the 20-min review default would → dead-letter → dup
+            // session). Defaults to 30m+ when the timeout is unset.
+            ackWaitNs: ((config.claude.asyncTimeoutMs ?? 1_800_000) + 60_000) * 1_000_000,
           });
         } catch (provisionErr) {
           // Don't abort — let `consumer.start()` surface the bind failure via
@@ -3220,7 +3231,9 @@ export async function startCortex(
       }
       const started = await consumer.start({
         pattern,
-        stream: "DEV_IMPLEMENT",
+        // cortex#1203 review major-1 — config-resolved name, matches the durable
+        // provisioned just above (not a hardcoded literal).
+        stream: devImplementStream,
         durable,
       });
       const scopeTag = scopeToken === "local" ? "" : ` (offer:${scopeToken})`;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3218,7 +3218,7 @@ export async function startCortex(
             // ack-wait to that (+60s) so a legitimately-long run isn't redelivered
             // mid-flight (the 20-min review default would → dead-letter → dup
             // session). Defaults to 30m+ when the timeout is unset.
-            ackWaitNs: ((config.claude.asyncTimeoutMs ?? 1_800_000) + 60_000) * 1_000_000,
+            ackWaitNs: (config.claude.asyncTimeoutMs + 60_000) * 1_000_000,
           });
         } catch (provisionErr) {
           // Don't abort — let `consumer.start()` surface the bind failure via


### PR DESCRIPTION
Closes #1203. **Last blocker in the dev-loop activation chain** (#1197 storage → config maxBytes → #1199 subject-overlap → this).

## Problem
On meta-factory (v5.26.1, all prior blockers fixed), `dev.implement` still failed `dev consumer init failed for agent=dev: consumer not found` → consumer never reached ready → dispatched `tasks.dev.implement` Offers would never be claimed.

## Root cause
`DevConsumer.start`→`runtime.subscribePull` **binds** a durable; it does not create it. The review/brain/release lanes all `provisionReviewConsumer(...)` (`jsm.consumers.add`) **before** `start()` — the dev lane was the only one missing that step (the `dev-consumer-boot.ts` header even says it should provision the durable up-front).

## Fix
Add the up-front `provisionReviewConsumer` for the DEV_IMPLEMENT durable (gated on `reviewJsm !== null`, `filterSubject` = the per-scope pattern per cortex#1186, `maxDeliver` = the review default), mirroring the brain lane exactly. +26 lines, one file.

tsc 0 · full suite 7372 pass (the 1 fail is a pre-existing `fs.watch` timing flake in `cortex.agents-reload.test.ts`, passes 2/3 on re-run, unrelated) · carve-out green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)