### PR TITLE
chore: bump to v5.26.2

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.1"
+version: "5.26.2"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Patch release for #1203 (PR #1204) — provisions the DEV_IMPLEMENT durable up-front so the dev.implement consumer binds (last blocker in the dev-loop activation chain). Manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)