### PR TITLE
chore: bump to v5.26.3

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.2"
+version: "5.26.3"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Ship operator-driven dev-loop S1 (#1207, part of #1206): in-process orchestrator — principal-gated `@vega implement {repo}#{N}` → `dev.implement` dispatch via the stack runtime. Dormant until a `dev.orchestrate`-declaring agent (vega) is installed. Manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)