### PR TITLE
feat(config): resolve __ENV__ placeholders in surface tokens at config-load (#1209)

### DIFF
--- a/src/common/config/__tests__/resolve-env-placeholders.test.ts
+++ b/src/common/config/__tests__/resolve-env-placeholders.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   for (const k of TOUCHED) {
-    if (saved[k] === undefined) delete process.env[k];
+    if (saved[k] === undefined) Reflect.deleteProperty(process.env, k);
     else process.env[k] = saved[k];
   }
 });
@@ -301,7 +301,7 @@ describe("resolveSurfaceBindingTokens — gateway binding map", () => {
           },
         },
       ],
-    } as unknown as Surfaces;
+    };
   }
 
   test("resolves a discord binding.token placeholder from env", () => {

--- a/src/common/config/__tests__/resolve-env-placeholders.test.ts
+++ b/src/common/config/__tests__/resolve-env-placeholders.test.ts
@@ -17,20 +17,32 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, chmodSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { stringify } from "yaml";
 
 import {
   ENV_PLACEHOLDER_PATTERN,
   EnvPlaceholderError,
+  assertNoUnresolvedPlaceholder,
   resolveAgentPresenceTokens,
+  resolveSurfaceBindingTokens,
   resolveSurfaceTokensInRawConfig,
 } from "../resolve-env-placeholders";
+import type { Surfaces } from "../../types/surfaces";
 import { loadConfigWithAgents, loadAgentFromFile } from "../loader";
 
 // ---------------------------------------------------------------------------
 // env hygiene — snapshot + restore the env vars these tests poke so they never
 // leak across tests (the resolver reads process.env directly).
 // ---------------------------------------------------------------------------
-const TOUCHED = ["VEGA_BOT_TOKEN", "PIER_BOT_TOKEN", "MM_API_TOKEN", "SLACK_BOT", "SLACK_APP"];
+const TOUCHED = [
+  "VEGA_BOT_TOKEN",
+  "PIER_BOT_TOKEN",
+  "MM_API_TOKEN",
+  "SLACK_BOT",
+  "SLACK_APP",
+  "GW_DISCORD_TOKEN",
+  "WS_ONLY_TOKEN",
+];
 const saved: Record<string, string | undefined> = {};
 
 beforeEach(() => {
@@ -255,5 +267,165 @@ presence:
     const fragPath = writePierFragment("inline-pier-token");
     const agent = loadAgentFromFile(fragPath, dir);
     expect(agent?.presence.discord?.token).toBe("inline-pier-token");
+  });
+});
+
+// ===========================================================================
+// cortex#1209 review — whitespace-only env (nit 1)
+// ===========================================================================
+describe("fail-closed on whitespace-only env (nit 1)", () => {
+  test("env var set to '   ' is treated as unset → fatal", () => {
+    process.env.VEGA_BOT_TOKEN = "   ";
+    const agent: Record<string, unknown> = {
+      presence: { discord: { token: "__VEGA_BOT_TOKEN__" } },
+    };
+    expect(() => resolveAgentPresenceTokens(agent, "agents[0]")).toThrow(EnvPlaceholderError);
+  });
+});
+
+// ===========================================================================
+// cortex#1209 review (MAJOR) — surfaces.yaml gateway-binding resolution
+// ===========================================================================
+describe("resolveSurfaceBindingTokens — gateway binding map", () => {
+  function surfacesWith(discordToken: string): Surfaces {
+    return {
+      discord: [
+        {
+          agent: "vega",
+          stack: "andreas/research",
+          binding: {
+            token: discordToken,
+            guildId: "111",
+            agentChannelId: "222",
+            logChannelId: "333",
+          },
+        },
+      ],
+    } as unknown as Surfaces;
+  }
+
+  test("resolves a discord binding.token placeholder from env", () => {
+    process.env.GW_DISCORD_TOKEN = "real-gw-token";
+    const surfaces = surfacesWith("__GW_DISCORD_TOKEN__");
+    resolveSurfaceBindingTokens(surfaces);
+    expect((surfaces.discord as any)[0].binding.token).toBe("real-gw-token");
+  });
+
+  test("fail-closed: unset env → EnvPlaceholderError naming the var (not the literal)", () => {
+    delete process.env.GW_DISCORD_TOKEN;
+    const surfaces = surfacesWith("__GW_DISCORD_TOKEN__");
+    let err: unknown;
+    try {
+      resolveSurfaceBindingTokens(surfaces);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(EnvPlaceholderError);
+    expect((err as EnvPlaceholderError).envVar).toBe("GW_DISCORD_TOKEN");
+    expect((err as Error).message).toContain("surfaces.discord[0].binding.token");
+  });
+
+  test("inline binding token → unchanged", () => {
+    const surfaces = surfacesWith("inline-gw-token");
+    resolveSurfaceBindingTokens(surfaces);
+    expect((surfaces.discord as any)[0].binding.token).toBe("inline-gw-token");
+  });
+
+  test("resolves slack botToken/appToken + mattermost apiToken bindings", () => {
+    process.env.SLACK_BOT = "xoxb-real";
+    process.env.SLACK_APP = "xapp-real";
+    process.env.MM_API_TOKEN = "mm-real";
+    const surfaces = {
+      slack: [
+        {
+          agent: "sage",
+          binding: { botToken: "__SLACK_BOT__", appToken: "__SLACK_APP__", workspaceId: "T0123456789" },
+        },
+      ],
+      mattermost: [
+        { agent: "echo", binding: { apiUrl: "https://mm.example.com", apiToken: "__MM_API_TOKEN__" } },
+      ],
+    } as unknown as Surfaces;
+    resolveSurfaceBindingTokens(surfaces);
+    expect((surfaces.slack as any)[0].binding.botToken).toBe("xoxb-real");
+    expect((surfaces.slack as any)[0].binding.appToken).toBe("xapp-real");
+    expect((surfaces.mattermost as any)[0].binding.apiToken).toBe("mm-real");
+  });
+});
+
+describe("assertNoUnresolvedPlaceholder (belt-and-suspenders)", () => {
+  test("throws naming the env var on a literal placeholder", () => {
+    expect(() => assertNoUnresolvedPlaceholder("__GW_DISCORD_TOKEN__", "x")).toThrow(/GW_DISCORD_TOKEN/);
+  });
+  test("passes a resolved / inline value", () => {
+    expect(() => assertNoUnresolvedPlaceholder("real-token", "x")).not.toThrow();
+    expect(() => assertNoUnresolvedPlaceholder(undefined, "x")).not.toThrow();
+  });
+});
+
+// ===========================================================================
+// End-to-end: a surfaces.yaml directory layout resolves binding tokens into
+// LoadedConfig.surfaces (the object the gateway consumes).
+// ===========================================================================
+describe("loader integration — surfaces.yaml directory layout (gateway path)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "c1209-surfaces-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function systemBlocks(): Record<string, unknown> {
+    return {
+      claude: { timeoutMs: 300000 },
+      paths: { publishedEventsDir: "/tmp/events/published", logDir: "/tmp/cortex/logs" },
+    };
+  }
+
+  function writeLayout(discordToken: string): string {
+    mkdirSync(join(dir, "system"), { recursive: true });
+    writeFileSync(join(dir, "system", "system.yaml"), stringify(systemBlocks()));
+    mkdirSync(join(dir, "surfaces"), { recursive: true });
+    writeFileSync(
+      join(dir, "surfaces", "surfaces.yaml"),
+      stringify({
+        surfaces: {
+          discord: [
+            {
+              agent: "vega",
+              stack: "andreas/research",
+              binding: {
+                token: discordToken,
+                guildId: "111",
+                agentChannelId: "222",
+                logChannelId: "333",
+              },
+            },
+          ],
+        },
+      }),
+    );
+    mkdirSync(join(dir, "stacks"), { recursive: true });
+    const persona = join(dir, "vega.md");
+    writeFileSync(persona, "# vega\n");
+    writeFileSync(
+      join(dir, "stacks", "research.yaml"),
+      stringify({
+        principal: { id: "andreas" },
+        agents: [{ id: "vega", displayName: "Vega", persona, trust: [], presence: {} }],
+      }),
+    );
+    return join(dir, "cortex.yaml");
+  }
+
+  test("placeholder in surfaces.yaml binding resolves into LoadedConfig.surfaces with env set", () => {
+    process.env.GW_DISCORD_TOKEN = "real-gw-secret";
+    const loaded = loadConfigWithAgents(writeLayout("__GW_DISCORD_TOKEN__"));
+    expect((loaded.surfaces?.discord as any)?.[0]?.binding.token).toBe("real-gw-secret");
+  });
+
+  test("placeholder in surfaces.yaml binding + unset env → fatal, env-var-named", () => {
+    delete process.env.GW_DISCORD_TOKEN;
+    expect(() => loadConfigWithAgents(writeLayout("__GW_DISCORD_TOKEN__"))).toThrow(/GW_DISCORD_TOKEN/);
   });
 });

--- a/src/common/config/__tests__/resolve-env-placeholders.test.ts
+++ b/src/common/config/__tests__/resolve-env-placeholders.test.ts
@@ -1,0 +1,259 @@
+/**
+ * cortex#1209 — `__ENV__` placeholder resolution for surface secret fields.
+ *
+ * Acceptance cases (from the issue):
+ *   - `token: __VEGA_BOT_TOKEN__` + env set → adapter receives the real token.
+ *   - placeholder + unset env → fatal, env-var-named error (NOT the literal).
+ *   - inline token → unchanged.
+ *   - Pier's `__PIER_BOT_TOKEN__` resolves the same way (fragment path).
+ *
+ * The unit layer here exercises the resolver directly + through the loader
+ * (`loadConfigWithAgents` for inline `agents[]`, `loadAgentFromFile` for an
+ * agents.d/ fragment). The loader is a boot path, so we drive it end-to-end
+ * with real temp files rather than mocking.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  ENV_PLACEHOLDER_PATTERN,
+  EnvPlaceholderError,
+  resolveAgentPresenceTokens,
+  resolveSurfaceTokensInRawConfig,
+} from "../resolve-env-placeholders";
+import { loadConfigWithAgents, loadAgentFromFile } from "../loader";
+
+// ---------------------------------------------------------------------------
+// env hygiene — snapshot + restore the env vars these tests poke so they never
+// leak across tests (the resolver reads process.env directly).
+// ---------------------------------------------------------------------------
+const TOUCHED = ["VEGA_BOT_TOKEN", "PIER_BOT_TOKEN", "MM_API_TOKEN", "SLACK_BOT", "SLACK_APP"];
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of TOUCHED) saved[k] = process.env[k];
+});
+afterEach(() => {
+  for (const k of TOUCHED) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+// ===========================================================================
+// Pattern + scalar resolver
+// ===========================================================================
+describe("ENV_PLACEHOLDER_PATTERN", () => {
+  test("matches a pure SCREAMING_CASE placeholder", () => {
+    expect(ENV_PLACEHOLDER_PATTERN.exec("__VEGA_BOT_TOKEN__")?.[1]).toBe("VEGA_BOT_TOKEN");
+  });
+
+  test("does NOT match partial / lowercase / embedded forms", () => {
+    expect(ENV_PLACEHOLDER_PATTERN.test("Bearer __X__")).toBe(false);
+    expect(ENV_PLACEHOLDER_PATTERN.test("__lower__")).toBe(false);
+    expect(ENV_PLACEHOLDER_PATTERN.test("xoxb-real-token")).toBe(false);
+    expect(ENV_PLACEHOLDER_PATTERN.test("__A B__")).toBe(false);
+  });
+});
+
+describe("resolveAgentPresenceTokens", () => {
+  test("resolves a discord token placeholder from env", () => {
+    process.env.VEGA_BOT_TOKEN = "real-vega-token";
+    const agent: Record<string, unknown> = {
+      presence: { discord: { token: "__VEGA_BOT_TOKEN__" } },
+    };
+    resolveAgentPresenceTokens(agent, "agents[0]");
+    expect((agent.presence as any).discord.token).toBe("real-vega-token");
+  });
+
+  test("fail-closed: unset env → EnvPlaceholderError naming the var, not the literal", () => {
+    delete process.env.VEGA_BOT_TOKEN;
+    const agent: Record<string, unknown> = {
+      presence: { discord: { token: "__VEGA_BOT_TOKEN__" } },
+    };
+    let err: unknown;
+    try {
+      resolveAgentPresenceTokens(agent, "agents[0]");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(EnvPlaceholderError);
+    expect((err as EnvPlaceholderError).envVar).toBe("VEGA_BOT_TOKEN");
+    expect((err as Error).message).toContain("VEGA_BOT_TOKEN");
+    expect((err as Error).message).toContain("agents[0].presence.discord.token");
+    // the literal placeholder must NOT silently survive onto the object
+    expect((agent.presence as any).discord.token).toBe("__VEGA_BOT_TOKEN__");
+  });
+
+  test("fail-closed: EMPTY env var is treated as unset", () => {
+    process.env.VEGA_BOT_TOKEN = "";
+    const agent: Record<string, unknown> = {
+      presence: { discord: { token: "__VEGA_BOT_TOKEN__" } },
+    };
+    expect(() => resolveAgentPresenceTokens(agent, "agents[0]")).toThrow(EnvPlaceholderError);
+  });
+
+  test("inline token passes through byte-identical", () => {
+    const agent: Record<string, unknown> = {
+      presence: { discord: { token: "inline-real-token-123" } },
+    };
+    resolveAgentPresenceTokens(agent, "agents[0]");
+    expect((agent.presence as any).discord.token).toBe("inline-real-token-123");
+  });
+
+  test("resolves mattermost.apiToken + slack.botToken/appToken", () => {
+    process.env.MM_API_TOKEN = "mm-real";
+    process.env.SLACK_BOT = "xoxb-real";
+    process.env.SLACK_APP = "xapp-real";
+    const agent: Record<string, unknown> = {
+      presence: {
+        mattermost: { apiToken: "__MM_API_TOKEN__" },
+        slack: { botToken: "__SLACK_BOT__", appToken: "__SLACK_APP__" },
+      },
+    };
+    resolveAgentPresenceTokens(agent, "agents[0]");
+    expect((agent.presence as any).mattermost.apiToken).toBe("mm-real");
+    expect((agent.presence as any).slack.botToken).toBe("xoxb-real");
+    expect((agent.presence as any).slack.appToken).toBe("xapp-real");
+  });
+
+  test("no presence block → no-op", () => {
+    const agent: Record<string, unknown> = { id: "x" };
+    expect(() => resolveAgentPresenceTokens(agent, "agents[0]")).not.toThrow();
+  });
+});
+
+describe("resolveSurfaceTokensInRawConfig", () => {
+  test("walks agents[] and resolves each presence token", () => {
+    process.env.VEGA_BOT_TOKEN = "real-vega";
+    const raw: Record<string, unknown> = {
+      agents: [
+        { id: "vega", presence: { discord: { token: "__VEGA_BOT_TOKEN__" } } },
+        { id: "luna", presence: { discord: { token: "inline-luna" } } },
+      ],
+    };
+    resolveSurfaceTokensInRawConfig(raw);
+    expect((raw.agents as any)[0].presence.discord.token).toBe("real-vega");
+    expect((raw.agents as any)[1].presence.discord.token).toBe("inline-luna");
+  });
+
+  test("no agents[] (legacy bot.yaml shape) → no-op", () => {
+    const raw: Record<string, unknown> = { discord: [{ token: "legacy-inline" }] };
+    expect(() => resolveSurfaceTokensInRawConfig(raw)).not.toThrow();
+    expect((raw.discord as any)[0].token).toBe("legacy-inline");
+  });
+});
+
+// ===========================================================================
+// End-to-end through the loader
+// ===========================================================================
+describe("loader integration — inline cortex.yaml agents[]", () => {
+  let dir: string;
+  let personaPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "c1209-inline-"));
+    personaPath = join(dir, "persona.md");
+    writeFileSync(personaPath, "# persona\n");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function writeCortexYaml(token: string): string {
+    const cfgPath = join(dir, "cortex.yaml");
+    const yaml = `
+principal:
+  id: andreas
+claude:
+  timeoutMs: 120000
+agents:
+  - id: vega
+    displayName: Vega
+    persona: ${personaPath}
+    presence:
+      discord:
+        enabled: true
+        token: ${token}
+        guildId: "111"
+        agentChannelId: "222"
+        logChannelId: "333"
+`;
+    writeFileSync(cfgPath, yaml);
+    chmodSync(cfgPath, 0o600);
+    return cfgPath;
+  }
+
+  test("__VEGA_BOT_TOKEN__ + env set → resolved token reaches the flattened presence", () => {
+    process.env.VEGA_BOT_TOKEN = "real-vega-secret";
+    const cfgPath = writeCortexYaml("__VEGA_BOT_TOKEN__");
+    const loaded = loadConfigWithAgents(cfgPath);
+    expect(loaded.inlineAgents[0]?.presence.discord?.token).toBe("real-vega-secret");
+    // flattened legacy-shape array (what the adapter loop consumes) too
+    expect(loaded.config.discord[0]?.token).toBe("real-vega-secret");
+  });
+
+  test("placeholder + unset env → fatal error naming the var, never the literal", () => {
+    delete process.env.VEGA_BOT_TOKEN;
+    const cfgPath = writeCortexYaml("__VEGA_BOT_TOKEN__");
+    expect(() => loadConfigWithAgents(cfgPath)).toThrow(/VEGA_BOT_TOKEN/);
+    expect(() => loadConfigWithAgents(cfgPath)).toThrow(EnvPlaceholderError);
+  });
+
+  test("inline token → unchanged", () => {
+    const cfgPath = writeCortexYaml("inline-discord-token-xyz");
+    const loaded = loadConfigWithAgents(cfgPath);
+    expect(loaded.inlineAgents[0]?.presence.discord?.token).toBe("inline-discord-token-xyz");
+  });
+});
+
+describe("loader integration — agents.d/ fragment (Pier path)", () => {
+  let dir: string;
+  let personaPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "c1209-frag-"));
+    personaPath = join(dir, "persona.md");
+    writeFileSync(personaPath, "# pier\n");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function writePierFragment(token: string): string {
+    const fragPath = join(dir, "pier.yaml");
+    const yaml = `
+id: pier
+displayName: Pier
+persona: ${personaPath}
+trust: []
+presence:
+  discord:
+    enabled: true
+    token: ${token}
+    guildId: "1505549701674700991"
+    agentChannelId: "1517154685595942972"
+    logChannelId: "1514679294553751613"
+`;
+    writeFileSync(fragPath, yaml);
+    return fragPath;
+  }
+
+  test("Pier's __PIER_BOT_TOKEN__ resolves identically", () => {
+    process.env.PIER_BOT_TOKEN = "real-pier-secret";
+    const fragPath = writePierFragment("__PIER_BOT_TOKEN__");
+    const agent = loadAgentFromFile(fragPath, dir);
+    expect(agent?.presence.discord?.token).toBe("real-pier-secret");
+  });
+
+  test("Pier fragment placeholder + unset env → fatal, env-var-named", () => {
+    delete process.env.PIER_BOT_TOKEN;
+    const fragPath = writePierFragment("__PIER_BOT_TOKEN__");
+    expect(() => loadAgentFromFile(fragPath, dir)).toThrow(/PIER_BOT_TOKEN/);
+  });
+
+  test("inline fragment token → unchanged", () => {
+    const fragPath = writePierFragment("inline-pier-token");
+    const agent = loadAgentFromFile(fragPath, dir);
+    expect(agent?.presence.discord?.token).toBe("inline-pier-token");
+  });
+});

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -26,6 +26,10 @@ import {
 } from "../types/cortex-config";
 import { foldSurfaceBindings, SurfacesSchema, type Surfaces } from "../types/surfaces";
 import { enforceChmod600 } from "./file-permissions";
+import {
+  resolveAgentPresenceTokens,
+  resolveSurfaceTokensInRawConfig,
+} from "./resolve-env-placeholders";
 
 /**
  * Hardening cap on a single fragment file's size. Echo M3 on cortex#62 —
@@ -503,6 +507,18 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
   // file. Capture the validated `Surfaces` binding map before the fold drops
   // the top-level `surfaces:` key (GW.a.3b.2a, cortex#524).
   const { raw, surfaces } = composeRawConfigWithSurfaces(expandedPath);
+
+  // cortex#1209 — resolve `__ENV__` placeholders in the surface secret fields
+  // (`agents[].presence.{discord.token, mattermost.apiToken, slack.botToken/
+  // appToken}`) from `process.env` BEFORE the schema parse. Runs here, after
+  // the deep-merge compose, so the resolved value reaches the flattened
+  // presence → adapter login, and so the Slack `^xoxb-`/`^xapp-` regexes in
+  // SlackPresenceSchema see a real token rather than a placeholder. A declared
+  // placeholder with an unset env var throws a fatal, env-var-named error
+  // (fail-closed) — the literal `__X__` never reaches an adapter. Inline tokens
+  // pass through byte-identical. Mutates `raw` in place (it is a freshly
+  // composed object — see `deepMerge`/single-file `parseYaml`).
+  resolveSurfaceTokensInRawConfig(raw);
 
   // Networks load against the on-disk path regardless of legacy/cortex shape —
   // both shapes share the same networks/ contract (G-500).
@@ -1025,6 +1041,17 @@ export function loadAgentFromFile(filePath: string, personaBaseDir: string): Age
         `agents-loader: fragment ${filename} declares id "${declaredId}" which differs from its filename stem "${filenameStem}". Convention is to match — principal tooling (arc, cortex agents list) keys on the id, but mismatch obscures filesystem lookup.`,
       );
     }
+  }
+
+  // cortex#1209 — resolve `__ENV__` placeholders in this fragment's surface
+  // secret tokens (`presence.{discord.token, mattermost.apiToken,
+  // slack.botToken/appToken}`) BEFORE the schema parse. agents.d/ fragments
+  // (e.g. Pier's `presence.discord.token: __PIER_BOT_TOKEN__`) do NOT pass
+  // through `composeRawConfig`, so they get the same fail-closed, never-on-disk
+  // resolution here. A pure raw record is required; non-object raw falls
+  // straight to AgentSchema.parse which raises the principal-friendly error.
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+    resolveAgentPresenceTokens(raw as Record<string, unknown>, filename);
   }
 
   let agent: Agent;

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -28,6 +28,7 @@ import { foldSurfaceBindings, SurfacesSchema, type Surfaces } from "../types/sur
 import { enforceChmod600 } from "./file-permissions";
 import {
   resolveAgentPresenceTokens,
+  resolveSurfaceBindingTokens,
   resolveSurfaceTokensInRawConfig,
 } from "./resolve-env-placeholders";
 
@@ -519,6 +520,14 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
   // pass through byte-identical. Mutates `raw` in place (it is a freshly
   // composed object — see `deepMerge`/single-file `parseYaml`).
   resolveSurfaceTokensInRawConfig(raw);
+
+  // cortex#1209 review (MAJOR) — the captured `surfaces` binding map is a
+  // SEPARATE pre-fold object threaded straight to the surface gateway
+  // (`buildGatewayAdapters`), bypassing the `raw.agents[]` walk above. Resolve
+  // its `binding.<token>` fields too so the `CORTEX_GATEWAY=1` path can never
+  // hand a literal `__X__` to Discord/Mattermost `connect()`. Same fail-closed
+  // contract; mutates the freshly-parsed `surfaces` object in place.
+  if (surfaces !== undefined) resolveSurfaceBindingTokens(surfaces);
 
   // Networks load against the on-disk path regardless of legacy/cortex shape —
   // both shapes share the same networks/ contract (G-500).

--- a/src/common/config/resolve-env-placeholders.ts
+++ b/src/common/config/resolve-env-placeholders.ts
@@ -1,0 +1,158 @@
+/**
+ * cortex#1209 — `__ENV__` placeholder resolution for surface secret fields.
+ *
+ * Bot-pack fragments declare a Discord/Slack/Mattermost surface token as a
+ * placeholder (Pier ships `presence.discord.token: __PIER_BOT_TOKEN__`;
+ * vega ships `__VEGA_BOT_TOKEN__`, #1206) with the contract "resolved at
+ * install time from the host environment … NEVER stored in this file."
+ *
+ * The resolution happens at **config-LOAD**, not arc-install: the on-disk
+ * config keeps the `__X__` placeholder; the real secret lives only in the
+ * daemon's environment + process memory. This honours the "never stored"
+ * comment — the token never touches disk.
+ *
+ * Scope (deliberately NARROW — not a blind whole-config walk):
+ *   - `presence.discord.token`
+ *   - `presence.mattermost.apiToken`
+ *   - `presence.slack.botToken`, `presence.slack.appToken`
+ *
+ * These are the surface secret fields per the issue. The Slack tokens MUST be
+ * resolved on the RAW object BEFORE the Zod parse, because
+ * `SlackPresenceSchema` regex-constrains `botToken` to `^xoxb-` / `appToken`
+ * to `^xapp-` — a placeholder would fail the regex if it reached the schema.
+ * Discord/Mattermost have no such constraint, but resolving all four on the
+ * raw object in one pass keeps the seam in a single place.
+ *
+ * Fail-closed (matches the loader's existing idiom — schema/permission/
+ * fragment errors all THROW at load): a declared placeholder whose env var is
+ * unset/empty raises a fatal `EnvPlaceholderError` that NAMES the env var.
+ * The literal `__X__` is NEVER passed through to an adapter (it would surface
+ * as a confusing Discord/Slack auth failure far from the real cause).
+ *
+ * Security: the resolved secret is NEVER logged; the error names the env var,
+ * never its value; the value is never written back to disk (the caller mutates
+ * the in-memory raw object only).
+ */
+
+/**
+ * A surface secret field whose VALUE is exactly `__SOME_ENV_VAR__` resolves to
+ * `process.env.SOME_ENV_VAR`. The match is anchored end-to-end: a partial
+ * occurrence (e.g. `Bearer __X__`) is treated as an inline literal and passes
+ * through unchanged. The capture is `[A-Z0-9_]+` — conventional SCREAMING_CASE
+ * env-var names (the Pier/vega precedent: `PIER_BOT_TOKEN`, `VEGA_BOT_TOKEN`).
+ */
+export const ENV_PLACEHOLDER_PATTERN = /^__([A-Z0-9_]+)__$/;
+
+/**
+ * Fatal error raised when a declared placeholder's environment variable is
+ * unset or empty. Carries the offending env-var name + the config field path
+ * so the boot path / principal sees exactly which variable to set, WITHOUT the
+ * resolved value ever appearing in the message.
+ */
+export class EnvPlaceholderError extends Error {
+  public readonly envVar: string;
+  public readonly fieldPath: string;
+
+  constructor(envVar: string, fieldPath: string) {
+    super(
+      `config: surface secret field "${fieldPath}" declares the placeholder ` +
+        `__${envVar}__ but environment variable ${envVar} is unset or empty. ` +
+        `Export ${envVar} in the cortex daemon's environment before launch ` +
+        `(e.g. \`export ${envVar}=...; arc install\`). The token is resolved ` +
+        `at config-load and never written to disk.`,
+    );
+    this.name = "EnvPlaceholderError";
+    this.envVar = envVar;
+    this.fieldPath = fieldPath;
+  }
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Resolve a single scalar value. A non-string, or a string that is NOT a pure
+ * `__ENV__` placeholder, is returned byte-identical (the backward-compat
+ * invariant — inline tokens are untouched). A pure placeholder is resolved
+ * from `process.env`; an unset/empty env var throws `EnvPlaceholderError`.
+ */
+function resolveScalar(value: unknown, fieldPath: string): unknown {
+  if (typeof value !== "string") return value;
+  const match = ENV_PLACEHOLDER_PATTERN.exec(value);
+  if (match === null) return value; // inline literal — passthrough
+  const envVar = match[1] as string;
+  const resolved = process.env[envVar];
+  if (resolved === undefined || resolved === "") {
+    throw new EnvPlaceholderError(envVar, fieldPath);
+  }
+  return resolved;
+}
+
+/**
+ * Resolve the surface secret tokens on a single agent-shaped raw object — one
+ * that may carry `presence.{discord,mattermost,slack}`. Mutates the object in
+ * place (the raw object is freshly parsed/cloned by the caller, so this is
+ * safe and idempotent). `pathPrefix` labels the field in error messages
+ * (e.g. `agents[0]` or a fragment filename).
+ */
+export function resolveAgentPresenceTokens(
+  agentLike: Record<string, unknown>,
+  pathPrefix: string,
+): void {
+  const presence = agentLike.presence;
+  if (!isPlainObject(presence)) return;
+
+  const discord = presence.discord;
+  if (isPlainObject(discord) && "token" in discord) {
+    discord.token = resolveScalar(
+      discord.token,
+      `${pathPrefix}.presence.discord.token`,
+    );
+  }
+
+  const mattermost = presence.mattermost;
+  if (isPlainObject(mattermost) && "apiToken" in mattermost) {
+    mattermost.apiToken = resolveScalar(
+      mattermost.apiToken,
+      `${pathPrefix}.presence.mattermost.apiToken`,
+    );
+  }
+
+  const slack = presence.slack;
+  if (isPlainObject(slack)) {
+    if ("botToken" in slack) {
+      slack.botToken = resolveScalar(
+        slack.botToken,
+        `${pathPrefix}.presence.slack.botToken`,
+      );
+    }
+    if ("appToken" in slack) {
+      slack.appToken = resolveScalar(
+        slack.appToken,
+        `${pathPrefix}.presence.slack.appToken`,
+      );
+    }
+  }
+}
+
+/**
+ * Post-compose pass over a whole raw config object (the deep-merged result of
+ * `composeRawConfig`). Walks the cortex-shape `agents[]` array and resolves
+ * each agent's surface secret tokens. Mutates `raw` in place.
+ *
+ * Legacy bot.yaml-shape configs (flat top-level `discord:[]` / `mattermost:[]`,
+ * no `presence` nesting) carry inline tokens only and are unaffected — they
+ * have no `agents[].presence` to walk. agents.d/ fragments are resolved
+ * separately at `loadAgentFromFile` (they never pass through this composer).
+ */
+export function resolveSurfaceTokensInRawConfig(raw: Record<string, unknown>): void {
+  const agents = raw.agents;
+  if (!Array.isArray(agents)) return;
+  for (let i = 0; i < agents.length; i++) {
+    const agent = agents[i];
+    if (isPlainObject(agent)) {
+      resolveAgentPresenceTokens(agent, `agents[${i}]`);
+    }
+  }
+}

--- a/src/common/config/resolve-env-placeholders.ts
+++ b/src/common/config/resolve-env-placeholders.ts
@@ -15,6 +15,12 @@
  *   - `presence.discord.token`
  *   - `presence.mattermost.apiToken`
  *   - `presence.slack.botToken`, `presence.slack.appToken`
+ *   - the gateway-binding mirror of the same fields under a `surfaces.yaml`
+ *     binding map (`surfaces.{discord,slack,mattermost}[].binding.<token>`),
+ *     which the surface gateway consumes via a SEPARATELY-captured `Surfaces`
+ *     object that bypasses the raw-config walk (cortex#1209 review — the
+ *     `CORTEX_GATEWAY=1` path was leaking the literal placeholder to
+ *     `connect()`).
  *
  * These are the surface secret fields per the issue. The Slack tokens MUST be
  * resolved on the RAW object BEFORE the Zod parse, because
@@ -41,6 +47,9 @@
  * through unchanged. The capture is `[A-Z0-9_]+` — conventional SCREAMING_CASE
  * env-var names (the Pier/vega precedent: `PIER_BOT_TOKEN`, `VEGA_BOT_TOKEN`).
  */
+import { isPlainObject } from "../types/object-guards";
+import type { Surfaces } from "../types/surfaces";
+
 export const ENV_PLACEHOLDER_PATTERN = /^__([A-Z0-9_]+)__$/;
 
 /**
@@ -67,15 +76,13 @@ export class EnvPlaceholderError extends Error {
   }
 }
 
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
-}
-
 /**
  * Resolve a single scalar value. A non-string, or a string that is NOT a pure
  * `__ENV__` placeholder, is returned byte-identical (the backward-compat
  * invariant — inline tokens are untouched). A pure placeholder is resolved
- * from `process.env`; an unset/empty env var throws `EnvPlaceholderError`.
+ * from `process.env`; an unset / empty / whitespace-only env var throws
+ * `EnvPlaceholderError` (a whitespace-only value would otherwise reach
+ * `connect()` as a garbage token — cortex#1209 review nit 1).
  */
 function resolveScalar(value: unknown, fieldPath: string): unknown {
   if (typeof value !== "string") return value;
@@ -83,10 +90,24 @@ function resolveScalar(value: unknown, fieldPath: string): unknown {
   if (match === null) return value; // inline literal — passthrough
   const envVar = match[1] as string;
   const resolved = process.env[envVar];
-  if (resolved === undefined || resolved === "") {
+  if (resolved === undefined || resolved.trim() === "") {
     throw new EnvPlaceholderError(envVar, fieldPath);
   }
   return resolved;
+}
+
+/**
+ * Defence-in-depth assertion (cortex#1209 review — belt-and-suspenders). Throws
+ * `EnvPlaceholderError` if `value` is STILL an unresolved `__ENV__` placeholder
+ * at the point a token is about to be handed to an adapter. Every load path is
+ * supposed to have resolved placeholders already; this guards against a future
+ * path that forgets to, so a literal `__X__` can never reach `connect()`.
+ */
+export function assertNoUnresolvedPlaceholder(value: unknown, fieldPath: string): void {
+  if (typeof value !== "string") return;
+  const match = ENV_PLACEHOLDER_PATTERN.exec(value);
+  if (match === null) return;
+  throw new EnvPlaceholderError(match[1] as string, fieldPath);
 }
 
 /**
@@ -153,6 +174,52 @@ export function resolveSurfaceTokensInRawConfig(raw: Record<string, unknown>): v
     const agent = agents[i];
     if (isPlainObject(agent)) {
       resolveAgentPresenceTokens(agent, `agents[${i}]`);
+    }
+  }
+}
+
+/**
+ * The secret token field(s) under each platform's `surfaces[].binding`. Mirror
+ * of the `presence.{platform}` token fields above — the surfaces.yaml binding
+ * map carries the SAME credentials in a `binding` sub-object.
+ */
+const SURFACE_BINDING_TOKEN_FIELDS: { platform: keyof Surfaces; fields: readonly string[] }[] = [
+  { platform: "discord", fields: ["token"] },
+  { platform: "slack", fields: ["botToken", "appToken"] },
+  { platform: "mattermost", fields: ["apiToken"] },
+];
+
+/**
+ * cortex#1209 review (MAJOR) — resolve `__ENV__` placeholders in the
+ * gateway-binding token fields of the SEPARATELY-captured `Surfaces` object.
+ *
+ * `composeRawConfigWithSurfaces` captures + validates the `surfaces:` binding
+ * map BEFORE `foldSurfaceBindings` folds it into `raw.agents[].presence`, then
+ * threads that pre-resolution object through `LoadedConfig.surfaces` →
+ * `startGatewayIfEnabled` → `buildGatewayAdapters`, which parses each
+ * `binding` and constructs an adapter from it. `resolveSurfaceTokensInRawConfig`
+ * only touches the folded `raw.agents[]` copy, so the gateway path would
+ * otherwise hand the literal `__X__` to Discord/Mattermost `connect()`.
+ *
+ * Resolving here (same fail-closed `EnvPlaceholderError`, same trim check) on
+ * the captured object closes the leak symmetrically. Mutates `surfaces` in
+ * place — it is the fresh result of `SurfacesSchema.parse`, not aliased to raw.
+ */
+export function resolveSurfaceBindingTokens(surfaces: Surfaces): void {
+  for (const { platform, fields } of SURFACE_BINDING_TOKEN_FIELDS) {
+    const entries = surfaces[platform];
+    if (!Array.isArray(entries)) continue;
+    for (let i = 0; i < entries.length; i++) {
+      const binding = (entries[i] as { binding?: unknown }).binding;
+      if (!isPlainObject(binding)) continue;
+      for (const field of fields) {
+        if (field in binding) {
+          binding[field] = resolveScalar(
+            binding[field],
+            `surfaces.${platform}[${i}].binding.${field}`,
+          );
+        }
+      }
     }
   }
 }

--- a/src/common/config/resolve-env-placeholders.ts
+++ b/src/common/config/resolve-env-placeholders.ts
@@ -86,9 +86,12 @@ export class EnvPlaceholderError extends Error {
  */
 function resolveScalar(value: unknown, fieldPath: string): unknown {
   if (typeof value !== "string") return value;
-  const match = ENV_PLACEHOLDER_PATTERN.exec(value);
-  if (match === null) return value; // inline literal — passthrough
-  const envVar = match[1] as string;
+  // The capture group is `string | undefined`; an absent match (inline literal)
+  // OR an unexpectedly-empty capture both pass through unchanged. The undefined
+  // guard narrows `envVar` to `string` without a type assertion (the project
+  // lint forbids both `as` and `!` here).
+  const envVar = ENV_PLACEHOLDER_PATTERN.exec(value)?.[1];
+  if (envVar === undefined) return value; // inline literal — passthrough
   const resolved = process.env[envVar];
   if (resolved === undefined || resolved.trim() === "") {
     throw new EnvPlaceholderError(envVar, fieldPath);
@@ -105,9 +108,9 @@ function resolveScalar(value: unknown, fieldPath: string): unknown {
  */
 export function assertNoUnresolvedPlaceholder(value: unknown, fieldPath: string): void {
   if (typeof value !== "string") return;
-  const match = ENV_PLACEHOLDER_PATTERN.exec(value);
-  if (match === null) return;
-  throw new EnvPlaceholderError(match[1] as string, fieldPath);
+  const envVar = ENV_PLACEHOLDER_PATTERN.exec(value)?.[1];
+  if (envVar === undefined) return;
+  throw new EnvPlaceholderError(envVar, fieldPath);
 }
 
 /**
@@ -171,7 +174,7 @@ export function resolveSurfaceTokensInRawConfig(raw: Record<string, unknown>): v
   const agents = raw.agents;
   if (!Array.isArray(agents)) return;
   for (let i = 0; i < agents.length; i++) {
-    const agent = agents[i];
+    const agent: unknown = agents[i];
     if (isPlainObject(agent)) {
       resolveAgentPresenceTokens(agent, `agents[${i}]`);
     }

--- a/src/common/types/object-guards.ts
+++ b/src/common/types/object-guards.ts
@@ -1,0 +1,15 @@
+/**
+ * Tiny structural type-guards shared across the config + types layers.
+ *
+ * Lifted here (cortex#1209 review nit) so the `isPlainObject` predicate has a
+ * single definition instead of being re-declared in `surfaces.ts`,
+ * `resolve-env-placeholders.ts`, and elsewhere.
+ */
+
+/**
+ * True for a non-null, non-array object (a YAML mapping / JSON object). Narrows
+ * `unknown` to `Record<string, unknown>` so callers can index it safely.
+ */
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/src/common/types/surfaces.ts
+++ b/src/common/types/surfaces.ts
@@ -73,6 +73,7 @@
 import { z } from "zod/v4";
 
 import { LETTER_PREFIX_ID_REGEX } from "./id";
+import { isPlainObject } from "./object-guards";
 
 // =============================================================================
 // Per-platform binding schemas — the credential/instance subset that moves
@@ -219,10 +220,6 @@ export type MattermostSurfaceBinding = z.infer<typeof MattermostSurfaceBindingSc
 // =============================================================================
 
 const PLATFORMS = ["discord", "slack", "mattermost"] as const;
-
-function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
-}
 
 /**
  * CFG.c.1/CFG.c.2 — fold a `surfaces:` block into the composed raw config's

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -385,3 +385,56 @@ describe("buildGatewayAdapters", () => {
     expect(_msgType).toBeUndefined();
   });
 });
+
+// =============================================================================
+// cortex#1209 belt-and-suspenders — a binding token that is STILL an
+// unresolved `__ENV__` placeholder at adapter-construction is a fail-fast, so
+// no path can ever hand the literal `__X__` to `connect()`.
+// =============================================================================
+describe("buildGatewayAdapters — unresolved placeholder fail-fast (#1209)", () => {
+  test("discord binding.token still __X__ → throws before the factory is called", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "vega",
+          stack: "andreas/research",
+          binding: {
+            token: "__VEGA_BOT_TOKEN__",
+            guildId: "111222333444555666",
+            agentChannelId: "aaa000000000000001",
+            logChannelId: "bbb000000000000002",
+          },
+        },
+      ],
+    };
+    expect(() => buildGatewayAdapters(surfaces, makeDeps(factory))).toThrow(/VEGA_BOT_TOKEN/);
+    // fail-fast: the factory must never have been reached with the literal
+    expect(calls.length).toBe(0);
+  });
+
+  test("mattermost binding.apiToken still __X__ → throws before the factory is called", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const surfaces: Surfaces = {
+      mattermost: [
+        {
+          agent: "echo",
+          stack: "andreas/ops",
+          binding: {
+            apiUrl: "https://mm.example.com",
+            apiToken: "__MM_API_TOKEN__",
+          },
+        },
+      ],
+    };
+    expect(() => buildGatewayAdapters(surfaces, makeDeps(factory))).toThrow(/MM_API_TOKEN/);
+    expect(calls.length).toBe(0);
+  });
+
+  test("resolved (inline) tokens pass the guard and construct normally", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const adapters = buildGatewayAdapters(DISCORD_SURFACES, makeDeps(factory));
+    expect(adapters.length).toBe(1);
+    expect(calls.length).toBe(1);
+  });
+});

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -67,6 +67,7 @@ import {
 } from "../common/types/cortex-config";
 import type { SystemEventSource } from "../bus/system-events";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
+import { assertNoUnresolvedPlaceholder } from "../common/config/resolve-env-placeholders";
 import { groupDiscordBindingsByToken } from "./discord-token-groups";
 // Back-compat re-export for callers that still import the old suppression helper here.
 export { gatewayOwnedSurfaceKeys } from "./surface-ownership-plan";
@@ -235,6 +236,12 @@ export function buildGatewayAdapters(
     const presence = presences[0];
     const firstBinding = group.entries[0]?.binding;
     if (!presence || !firstBinding) continue;
+    // cortex#1209 belt-and-suspenders — a resolved binding can never carry a
+    // literal `__X__` token; fail-fast if one slipped past the load-time
+    // resolver before it reaches Discord `connect()`.
+    for (const p of presences) {
+      assertNoUnresolvedPlaceholder(p.token, "surfaces.discord[].binding.token");
+    }
     const presenceByGuildId = new Map(presences.map((p) => [p.guildId, p] as const));
     const allowedGuildIds = new Set(presenceByGuildId.keys());
     adapters.push(
@@ -253,6 +260,8 @@ export function buildGatewayAdapters(
   // ── Slack — demux key = workspaceId ───────────────────────────────────────
   for (const entry of surfaces.slack ?? []) {
     const presence = SlackPresenceSchema.parse(entry.binding);
+    assertNoUnresolvedPlaceholder(presence.botToken, "surfaces.slack[].binding.botToken");
+    assertNoUnresolvedPlaceholder(presence.appToken, "surfaces.slack[].binding.appToken");
     const instanceId = `slack:${presence.workspaceId}`;
     adapters.push(
       factory.slack({
@@ -268,6 +277,7 @@ export function buildGatewayAdapters(
   // ── Mattermost — demux key = apiUrl (single-binding fallback) ─────────────
   for (const entry of surfaces.mattermost ?? []) {
     const presence = MattermostPresenceSchema.parse(entry.binding);
+    assertNoUnresolvedPlaceholder(presence.apiToken, "surfaces.mattermost[].binding.apiToken");
     // apiUrl is optional on the presence schema but required on the binding
     // schema; the binding-resolver keys the interim instance on it too.
     const instanceId = `mattermost:${presence.apiUrl ?? "<unset>"}`;


### PR DESCRIPTION
Closes #1209

## What
Resolve `__ENV__` placeholders in surface secret fields at **config-load** (not arc-install), so the token stays off disk — the config keeps the `__X__` placeholder; the real secret lives only in the daemon environment + process memory. Honours the Pier contract: *"resolved from the host environment … NEVER stored in this file."*

## Where the resolver runs
- **`src/common/config/resolve-env-placeholders.ts`** (new) — anchored `^__([A-Z0-9_]+)__$` → `process.env[$1]`. Pure scalar resolver + an agent-presence walker.
- **`loadConfigWithAgents`** — post-compose pass (`resolveSurfaceTokensInRawConfig(raw)`) right after `composeRawConfigWithSurfaces`, covering inline cortex.yaml `agents[]`.
- **`loadAgentFromFile`** — same resolution on each `agents.d/` fragment (the **Pier** path; fragments never pass through the composer).
- Both run **BEFORE** the Zod parse so the Slack `^xoxb-`/`^xapp-` regexes in `SlackPresenceSchema` see a real token, not a placeholder.

## Scoped fields (not a blind whole-config walk)
`presence.discord.token`, `presence.mattermost.apiToken`, `presence.slack.botToken`, `presence.slack.appToken`. Legacy flat `discord:[]`/`mattermost:[]` configs carry inline tokens only and are untouched (no `presence` nesting). The `surfaces:` gateway-binding block is intentionally out of scope (not a `presence.*` secret).

## Fail-closed behavior (and why)
**Fatal throw** (`EnvPlaceholderError`) naming the env var. This matches the loader's existing idiom — schema validation, chmod-600 enforcement, and fragment-load errors all **throw at load**; an empty `presence.discord.token` already fails `z.string().min(1)`. The literal `__X__` is **never** passed to an adapter (which would surface as a confusing Discord/Slack auth failure far from the cause). Empty env var is treated as unset.

## Security
The resolved secret is never logged and never written to disk; the error names the env var, never its value.

## Gates
- `bunx tsc --noEmit` — **clean** (exit 0)
- `bash scripts/check-carveouts.sh` — **PASS**
- Full `bun test src/` — **7407 pass / 2 skip**. Two parallel-load flakes (`AgentsDirectoryWatcher` fs.watch — the known ~1/3 flake; `DaemonBrainHost` concurrency round-trip) each **pass in isolation** and neither touches the config loader path.
- New `resolve-env-placeholders.test.ts` — 16 pass (resolved-token-reaches-adapter, unset→fatal-named-error asserting NOT the literal, inline-unchanged, Pier fragment identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)