### PR TITLE
chore: bump to v5.26.4

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.3"
+version: "5.26.4"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Ship #1209 (#1210): config-load resolution of `__ENV__` placeholders in surface tokens (discord/mattermost/slack + the surfaces-gateway path), fail-closed + secret-safe. Unblocks vega's `__VEGA_BOT_TOKEN__` (#1206) and fixes Pier. Manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)