### PR TITLE
feat(surface): consolidate dev-loop run into one Discord thread (#1206 S2)

### DIFF
--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -20,6 +20,8 @@ import type {
   CCSessionLike,
 } from "../../substrates/claude-code/harness";
 import type { CCSessionResult, CCSessionOpts } from "../../runner/cc-session";
+import { ORCHESTRATOR_CAPABILITY } from "../../runner/orchestrator-command";
+import { readLogicalRouting } from "../../adapters/response-routing-delivery";
 
 /**
  * cortex#486 — adapter-side platform-id → principal resolution at
@@ -2329,5 +2331,118 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     expect(wouldIntercept("team")).toBe(false);
     expect(wouldIntercept("help")).toBe(false);
     expect(wouldIntercept("learning")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#1206 (S2) — dev-loop thread consolidation.
+//
+// When the orchestrator agent (vega) dispatches `implement {repo}#{N}` for the
+// principal, the dispatch carries the run's LOGICAL thread routing AND vega's
+// ack posts INTO that run thread (not the flat channel), so the principal
+// follows the whole run — ack → dev lifecycle → review verdict — in one place.
+// ---------------------------------------------------------------------------
+describe("DispatchHandler — dev-loop thread consolidation (cortex#1206 S2)", () => {
+  let originalLog: typeof console.log;
+
+  beforeEach(() => {
+    originalLog = console.log;
+    console.log = () => {};
+  });
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  function makeOrchestratorHandler(): { handler: DispatchHandler; runtime: RecordingRuntime } {
+    const runtime = makeRecordingRuntime();
+    const handler = new DispatchHandler({
+      config: makeConfig({
+        github: { ...makeConfig().github, repos: ["the-metafactory/cortex"] },
+      }),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: { principal: "andreas", agent: "cortex", instance: "local" },
+    });
+    return { handler, runtime };
+  }
+
+  const VEGA = {
+    id: "vega",
+    displayName: "Vega",
+    capabilities: [ORCHESTRATOR_CAPABILITY],
+  };
+
+  test("principal `implement` dispatches with run-thread routing + posts ack INTO the run thread", async () => {
+    const { handler, runtime } = makeOrchestratorHandler();
+    const adapter = new MockAdapter();
+    adapter.logicalSurface = "mock"; // the inbound surface resolves a thread
+
+    await handler.handleMessage(
+      adapter,
+      makeMsg({ content: "implement cortex#1196", authorIsPrincipal: true }),
+      VEGA,
+    );
+
+    // 1. The dispatch envelope carries the LOGICAL run-thread routing.
+    expect(runtime.publishes).toHaveLength(1);
+    const env = runtime.publishes[0]!;
+    expect(env.type).toBe("tasks.dev.implement");
+    expect(readLogicalRouting(env)).toEqual({
+      surface: "mock",
+      channel: "cortex",
+      thread: "cortex/issue/1196",
+    });
+
+    // 2. The handler resolved that logical address to a native thread (the SAME
+    //    `resolveLogicalTarget` the review-sink uses for the dev lifecycle).
+    expect(adapter.logicalTargetsResolved).toContainEqual({
+      surface: "mock",
+      channel: "cortex",
+      thread: "cortex/issue/1196",
+    });
+
+    // 3. vega's ack landed in the run thread, not the flat channel.
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.target.threadId).toBe("thread:cortex/issue/1196");
+    expect(adapter.sentMessages[0]!.text).toContain("the-metafactory/cortex#1196");
+  });
+
+  test("FALLBACK: when the surface can't thread, the ack degrades to the channel (never dropped)", async () => {
+    const { handler, runtime } = makeOrchestratorHandler();
+    const adapter = new MockAdapter();
+    // The mock drives a DIFFERENT logical surface, so `resolveLogicalTarget`
+    // returns null for the inbound `"mock"` surface — exactly the non-Discord /
+    // missing-channel degrade path.
+    adapter.logicalSurface = "some-other-surface";
+
+    await handler.handleMessage(
+      adapter,
+      makeMsg({ content: "implement cortex#1196", authorIsPrincipal: true }),
+      VEGA,
+    );
+
+    // The dispatch still published (the run still starts).
+    expect(runtime.publishes).toHaveLength(1);
+    // The ack is NOT dropped — it falls back to the inbound channel target
+    // (today's behaviour): channel-scope, no thread.
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.target.channelId).toBe("ch1");
+    expect(adapter.sentMessages[0]!.target.threadId).toBeUndefined();
+  });
+
+  test("FAIL-CLOSED: a non-principal `implement` is ignored — no dispatch, no thread, no ack", async () => {
+    const { handler, runtime } = makeOrchestratorHandler();
+    const adapter = new MockAdapter();
+    adapter.logicalSurface = "mock";
+
+    await handler.handleMessage(
+      adapter,
+      makeMsg({ content: "implement cortex#1196", authorIsPrincipal: false }),
+      VEGA,
+    );
+
+    expect(runtime.publishes).toHaveLength(0);
+    expect(adapter.logicalTargetsResolved).toHaveLength(0);
+    expect(adapter.sentMessages).toHaveLength(0);
   });
 });

--- a/src/bus/dev-events.ts
+++ b/src/bus/dev-events.ts
@@ -39,6 +39,12 @@
 import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope as buildSharedEnvelope } from "./envelope-builder";
 import type { SystemEventSource } from "./system-events";
+import type { LogicalResponseRouting } from "./dispatch-events";
+
+// Re-export so the orchestrator + dev consumer import the run-thread routing
+// shape from one place (it is defined alongside the lifecycle builders that
+// echo it). Purely ergonomic — the underlying type lives in `dispatch-events`.
+export type { LogicalResponseRouting } from "./dispatch-events";
 
 // Re-export the source shape under a domain-neutral alias — mirrors
 // `ReviewEventSource` in `review-events.ts`. Callers import from one place.
@@ -136,6 +142,17 @@ export interface CreateDevImplementRequestEventOpts {
   classification?: Classification;
   /** Payload per §3.4 step 1. */
   payload: DevImplementPayload;
+  /**
+   * cortex#1206 (S2) — the run's LOGICAL response routing (`{ surface, channel,
+   * thread }` — repo-short channel + `{repo-short}/issue/{N}` entity thread per
+   * the channel-routing SOP). Stamped VERBATIM onto `payload.response_routing`
+   * so the dev consumer echoes it onto every `dispatch.task.*` lifecycle
+   * envelope (`readLogicalRouting`) and the review-sink resolves it to the ONE
+   * run thread (the cortex#502/#1148 logical-routing spine). The builder never
+   * inspects it. Omitted ⇒ no `response_routing` on the wire — byte-identical to
+   * a pre-#1206 unrouted dispatch (backward compatible).
+   */
+  responseRouting?: LogicalResponseRouting;
 }
 
 /**
@@ -172,6 +189,12 @@ export function createDevImplementRequestEvent(
       ...(p.gates !== undefined && { gates: [...p.gates] }),
       ...(p.feature !== undefined && { feature: p.feature }),
       ...(p.title !== undefined && { title: p.title }),
+      // cortex#1206 (S2) — the run-thread address. Echoed verbatim by the dev
+      // consumer onto every lifecycle envelope; the review-sink resolves it to
+      // the one run thread. Omitted when absent (backward compatible).
+      ...(opts.responseRouting !== undefined && {
+        response_routing: opts.responseRouting,
+      }),
     },
   });
 }

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -669,13 +669,27 @@ export class DispatchHandler extends EventEmitter {
           source: this.systemEventSource
             ? { ...this.systemEventSource, agent: targetAgent.id }
             : undefined,
+          // cortex#1206 (S2) — the run-thread routing's surface is the inbound
+          // platform, so the lifecycle + ack consolidate on the right surface.
+          surface: msg.platform,
         });
         if (outcome.kind === "dispatched") {
           console.log(
             `dispatch-handler: [DEV-LOOP] ${adapter.instanceId} agent=${targetAgent.id} ` +
               `dispatched dev.implement for ${outcome.repo}#${outcome.issue} (envelope ${outcome.envelope.id})`,
           );
-          await adapter.postResponse(this.targetFromMsg(adapter, msg), outcome.ack);
+          // cortex#1206 (S2) — post the ack INTO the run thread (not the flat
+          // channel) so the principal follows the run start-to-finish in one
+          // place. Eagerly create-or-find the `{repo-short}/issue/{N}` thread via
+          // the SAME `resolveLogicalTarget` the review-sink uses for the dev
+          // lifecycle + verdict, so all of them land together. Degrade to the
+          // inbound channel target when the surface can't thread (non-Discord,
+          // missing repo channel, thread-create failure) — never drop the ack.
+          const runThreadTarget = await this.resolveRunThreadTarget(adapter, outcome.routing);
+          await adapter.postResponse(
+            runThreadTarget ?? this.targetFromMsg(adapter, msg),
+            outcome.ack,
+          );
           return;
         }
         if (outcome.kind === "ignored") {
@@ -1661,6 +1675,34 @@ export class DispatchHandler extends EventEmitter {
   private inboundCorrelationId(adapter: PlatformAdapter, msg: InboundMessage): string {
     const nativeId = (msg._native as { id?: string } | undefined)?.id;
     return nativeId ?? `synthetic:${adapter.instanceId}:${msg.channelId}:${msg.timestamp.toISOString()}`;
+  }
+
+  /**
+   * cortex#1206 (S2) — resolve the run's LOGICAL thread address to a native
+   * target so vega's dispatch ack lands in the SAME thread the dev-agent
+   * lifecycle + review verdict render to (the review-sink resolves the
+   * identical logical routing). `resolveLogicalTarget` is idempotent — it
+   * create-or-finds the `{repo-short}/issue/{N}` thread — and already falls back
+   * to a channel-scope target internally when the thread can't be created.
+   *
+   * Returns `null` when the surface/channel can't resolve (non-Discord surface,
+   * no repo channel) OR the resolve throws, so the caller degrades to the
+   * inbound channel target. The ack is NEVER dropped.
+   */
+  private async resolveRunThreadTarget(
+    adapter: PlatformAdapter,
+    routing: { surface: string; channel: string; thread?: string },
+  ): Promise<ResponseTarget | null> {
+    try {
+      return await adapter.resolveLogicalTarget(routing);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `dispatch-handler: [DEV-LOOP] run-thread resolve failed ` +
+          `(surface=${routing.surface}, channel=${routing.channel}): ${detail}`,
+      );
+      return null;
+    }
   }
 
   private targetFromMsg(adapter: PlatformAdapter, msg: InboundMessage): ResponseTarget {

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -682,9 +682,13 @@ export class DispatchHandler extends EventEmitter {
           // channel) so the principal follows the run start-to-finish in one
           // place. Eagerly create-or-find the `{repo-short}/issue/{N}` thread via
           // the SAME `resolveLogicalTarget` the review-sink uses for the dev
-          // lifecycle + verdict, so all of them land together. Degrade to the
-          // inbound channel target when the surface can't thread (non-Discord,
-          // missing repo channel, thread-create failure) — never drop the ack.
+          // lifecycle + verdict, so all of them land together. The `?? ` here
+          // degrades to the inbound channel ONLY when `resolveRunThreadTarget`
+          // returns null — i.e. the surface/channel didn't resolve (non-Discord
+          // surface, missing repo channel) or the resolve threw. A thread-CREATE
+          // failure does NOT land here: `resolveLogicalTarget` returns a
+          // channel-scope target for the repo-short channel, so the ack posts in
+          // `#{repo-short}` un-threaded. Either way the ack is never dropped.
           const runThreadTarget = await this.resolveRunThreadTarget(adapter, outcome.routing);
           await adapter.postResponse(
             runThreadTarget ?? this.targetFromMsg(adapter, msg),

--- a/src/runner/__tests__/orchestrator-command.test.ts
+++ b/src/runner/__tests__/orchestrator-command.test.ts
@@ -14,11 +14,15 @@ import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../../bus/myelin/runtime";
 import type { DevEventSource } from "../../bus/dev-events";
 import { parseDevImplementPayload } from "../../bus/dev-events";
+import { createDispatchTaskCompletedEvent } from "../../bus/dispatch-events";
+import { readLogicalRouting } from "../../adapters/response-routing-delivery";
 import {
   ORCHESTRATOR_CAPABILITY,
+  DEFAULT_RUN_SURFACE,
   parseImplementCommand,
   resolveRepo,
   buildImplementPayload,
+  buildRunThreadRouting,
   handleOrchestratorCommand,
 } from "../orchestrator-command";
 
@@ -236,5 +240,107 @@ describe("handleOrchestratorCommand — dispatch publish", () => {
 describe("ORCHESTRATOR_CAPABILITY", () => {
   test("is the stable routing marker id", () => {
     expect(ORCHESTRATOR_CAPABILITY).toBe("dev.orchestrate");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#1206 (S2) — dev-loop thread consolidation: run-thread routing
+// ---------------------------------------------------------------------------
+
+describe("buildRunThreadRouting", () => {
+  test("keys the run thread on the ENTITY (issue), repo-short channel", () => {
+    expect(buildRunThreadRouting("the-metafactory/cortex", 1196, "discord")).toEqual({
+      surface: "discord",
+      channel: "cortex",
+      thread: "cortex/issue/1196",
+    });
+  });
+
+  test("carries the inbound surface verbatim", () => {
+    expect(buildRunThreadRouting("the-metafactory/myelin", 7, "mattermost").surface).toBe(
+      "mattermost",
+    );
+  });
+});
+
+describe("handleOrchestratorCommand — run-thread routing (cortex#1206 S2)", () => {
+  test("stamps the LOGICAL run-thread routing on the dispatch envelope", async () => {
+    const { runtime, published } = recordingRuntime();
+    const outcome = await handleOrchestratorCommand({
+      text: "implement cortex#1196",
+      isOrchestrator: true,
+      authorIsPrincipal: true,
+      knownRepos: REPOS,
+      runtime,
+      source: SOURCE,
+      surface: "discord",
+    });
+
+    expect(outcome.kind).toBe("dispatched");
+    if (outcome.kind !== "dispatched") return;
+
+    // The outcome carries the routing so the handler can post the ack into it.
+    expect(outcome.routing).toEqual({
+      surface: "discord",
+      channel: "cortex",
+      thread: "cortex/issue/1196",
+    });
+
+    // The dispatch envelope carries the SAME routing as `response_routing` —
+    // this is exactly what the dev consumer reads via `readLogicalRouting`
+    // and echoes onto every lifecycle envelope.
+    const env = published[0]!;
+    expect(readLogicalRouting(env)).toEqual(outcome.routing);
+  });
+
+  test("surface defaults to discord when the caller omits it", async () => {
+    const { runtime, published } = recordingRuntime();
+    const outcome = await handleOrchestratorCommand({
+      text: "implement cortex#1196",
+      isOrchestrator: true,
+      authorIsPrincipal: true,
+      knownRepos: REPOS,
+      runtime,
+      source: SOURCE,
+    });
+    expect(outcome.kind).toBe("dispatched");
+    expect(readLogicalRouting(published[0]!)?.surface).toBe(DEFAULT_RUN_SURFACE);
+  });
+
+  test("the run routing flows dispatch → lifecycle unchanged (one thread key)", async () => {
+    const { runtime, published } = recordingRuntime();
+    const outcome = await handleOrchestratorCommand({
+      text: "implement cortex#1196",
+      isOrchestrator: true,
+      authorIsPrincipal: true,
+      knownRepos: REPOS,
+      runtime,
+      source: SOURCE,
+      surface: "discord",
+    });
+    expect(outcome.kind).toBe("dispatched");
+
+    // Simulate the dev consumer echoing the request's routing onto a terminal
+    // `dispatch.task.completed` (PR opened). The lifecycle envelope must carry
+    // the IDENTICAL logical thread address, so the review-sink resolves both
+    // the dispatch and the lifecycle to the SAME `{repo}/issue/N` thread.
+    const echoed = readLogicalRouting(published[0]!);
+    expect(echoed).not.toBeNull();
+    const completed = createDispatchTaskCompletedEvent({
+      source: SOURCE,
+      taskId: crypto.randomUUID(),
+      agentId: "forge",
+      correlationId: published[0]!.id,
+      responseRouting: echoed!,
+      startedAt: new Date(),
+      completedAt: new Date(),
+      resultSummary: "opened the-metafactory/cortex#1200",
+      chatResponse: JSON.stringify({ pr: { number: 1200 } }),
+    });
+    expect(readLogicalRouting(completed)).toEqual({
+      surface: "discord",
+      channel: "cortex",
+      thread: "cortex/issue/1196",
+    });
   });
 });

--- a/src/runner/orchestrator-command.ts
+++ b/src/runner/orchestrator-command.ts
@@ -37,6 +37,7 @@ import {
   createDevImplementRequestEvent,
   type DevEventSource,
   type DevImplementPayload,
+  type LogicalResponseRouting,
 } from "../bus/dev-events";
 
 /**
@@ -165,14 +166,64 @@ export function buildImplementPayload(
   };
 }
 
+/**
+ * The surface stamped on the run-thread routing when a caller predates the
+ * `surface` input (back-compat). Discord is the only live dev-loop surface.
+ */
+export const DEFAULT_RUN_SURFACE = "discord";
+
+/**
+ * Build the LOGICAL run-thread routing for a dispatched implement (cortex#1206
+ * S2 — dev-loop thread consolidation).
+ *
+ * A run is ONE thread, keyed on the ENTITY (the issue), addressed the
+ * channel-routing-SOP way:
+ *   - `channel` = the repo SHORT name — "repos get channels".
+ *   - `thread`  = `{repo-short}/issue/{N}` — "GitHub entities get threads".
+ *
+ * Keying on the issue (not the eventual PR) is deliberate: the dev consumer
+ * echoes THIS routing onto every `dispatch.task.*` lifecycle envelope, and the
+ * review-sink resolves it via the idempotent `findOrCreateThreadByName`, so
+ * vega's ack, the dev agent's progress + PR-opened, and echo's verdict all
+ * collapse into the single `{repo-short}/issue/{N}` thread — the run is one
+ * thread start-to-finish, never split issue→PR into two (cortex#1206 brief).
+ *
+ * Pure — no I/O. The native thread snowflake is created lazily by the surface
+ * (`resolveLogicalTarget`), keeping this boundary unit-testable.
+ */
+export function buildRunThreadRouting(
+  repo: string,
+  issue: number,
+  surface: string,
+): LogicalResponseRouting {
+  const repoShort = repo.slice(repo.indexOf("/") + 1);
+  return {
+    surface,
+    channel: repoShort,
+    thread: `${repoShort}/issue/${issue}`,
+  };
+}
+
 /** The decision the orchestrator command boundary returns to the handler. */
 export type OrchestratorOutcome =
   /** Not an orchestrator command — the caller falls through to normal chat. */
   | { kind: "pass-through" }
   /** Command matched but the gate refused (non-principal sender). Dropped. */
   | { kind: "ignored"; reason: string }
-  /** Command matched + dispatched. `ack` is the principal-facing confirmation. */
-  | { kind: "dispatched"; envelope: Envelope; repo: string; issue: number; ack: string }
+  /**
+   * Command matched + dispatched. `ack` is the principal-facing confirmation;
+   * `routing` is the run's LOGICAL thread address (cortex#1206 S2) stamped on
+   * the dispatch — the handler resolves it to post the ack into the SAME thread
+   * the dev-agent lifecycle + review verdict render to.
+   */
+  | {
+      kind: "dispatched";
+      envelope: Envelope;
+      repo: string;
+      issue: number;
+      ack: string;
+      routing: LogicalResponseRouting;
+    }
   /** Command matched but could not be actioned. `ack` explains why. */
   | { kind: "error"; ack: string };
 
@@ -203,6 +254,14 @@ export interface OrchestratorCommandInput {
    * `agent` segment names the orchestrator (e.g. `vega`).
    */
   source: DevEventSource | undefined;
+  /**
+   * cortex#1206 (S2) — the inbound surface (`msg.platform`, e.g. `"discord"`)
+   * the command arrived on. Stamped as the run-thread routing's `surface` so
+   * the lifecycle + ack consolidate on the right platform. Optional for
+   * back-compat with callers that predate run-thread consolidation; defaults to
+   * {@link DEFAULT_RUN_SURFACE}.
+   */
+  surface?: string;
 }
 
 /**
@@ -247,9 +306,20 @@ export async function handleOrchestratorCommand(
     };
   }
 
+  // cortex#1206 (S2) — the run-thread address. Stamped on the dispatch so the
+  // dev consumer echoes it onto every lifecycle envelope and the review-sink
+  // resolves it to the ONE run thread; ALSO returned so the handler posts the
+  // ack into that same thread (not the flat channel the command came from).
+  const routing = buildRunThreadRouting(
+    payload.repo,
+    cmd.issue,
+    input.surface ?? DEFAULT_RUN_SURFACE,
+  );
+
   const envelope = createDevImplementRequestEvent({
     source: input.source,
     payload,
+    responseRouting: routing,
   });
 
   await input.runtime.publish(envelope);
@@ -259,6 +329,7 @@ export async function handleOrchestratorCommand(
     envelope,
     repo: payload.repo,
     issue: cmd.issue,
+    routing,
     ack:
       `On it — dispatched \`dev.implement\` for **${payload.repo}#${cmd.issue}** ` +
       `(branch \`${payload.branch}\`). The dev agent will pick it up, open a PR, ` +


### PR DESCRIPTION
## What & why

S2-adjacent to the operator-driven dev-loop (#1206). Today vega posts her dispatch ack to the flat `#dev-loop` **channel**, and the dev agent's progress/PR and echo's review aren't threaded together — so a run kicked off like cortex#1196 is hard to follow. This consolidates **a whole run into ONE Discord thread**, keyed on the entity, so the principal follows it start-to-finish in one place.

## Thread-keying mechanism

The run thread is keyed on the **entity (the issue)**, carried as the **LOGICAL** `response_routing = { surface, channel: <repo-short>, thread: "<repo-short>/issue/<N>" }` — the channel-routing SOP shape ("repos get channels, entities get threads"). It rides the existing cortex#502/#1148 logical-routing spine, so there is **no new delivery path**:

- `orchestrator-command` stamps this routing onto the `tasks.dev.implement` request (via a new `responseRouting` option on the `dev-events` builder → `payload.response_routing`).
- The **dev consumer already echoes** `response_routing` onto every `dispatch.task.*` lifecycle envelope (`readLogicalRouting`); echo's `review.verdict.*` carries the same echoed routing.
- The **review-sink** resolves the logical address → a native thread via `adapter.resolveLogicalTarget`, which is the idempotent `findOrCreateThreadByName` for `{repo}/issue/N`. One entity key ⇒ one thread for the whole run.
- Keyed on the **issue** (not the eventual PR), so an issue→PR number difference does **not** split the run into two threads.

## How the threadId flows dispatch → lifecycle

1. orchestrator stamps the logical run routing on the dispatch envelope.
2. dev consumer echoes it onto `dispatch.task.started/completed(PR)/failed/aborted`.
3. echo's review.verdict carries the same echoed routing (from the review request).
4. review-sink resolves the identical logical routing → the one `{repo}/issue/N` thread.
5. **vega's ack** posts INTO that same thread: `dispatch-handler` resolves the logical address via the **same** `resolveLogicalTarget` the sink uses, eagerly creating the thread so the lifecycle posts join it.

## Fallback

If the surface can't thread (non-Discord, missing repo channel, thread-create failure) `resolveLogicalTarget` returns null and the ack **degrades to the inbound channel** (today's behavior) — never dropped.

## Wire-protocol-clean

The new field goes through the `dev-events` **schema builder**; no hand-spliced payload field, no raw connect, no hand-signed envelope (CONTEXT.md, federation-wire-protocol SOP).

## Files changed

- `src/bus/dev-events.ts` — optional `responseRouting` (LogicalResponseRouting) on the request builder → `payload.response_routing`.
- `src/runner/orchestrator-command.ts` — `buildRunThreadRouting` helper; `surface` input; stamps routing on the dispatch; returns it on the `dispatched` outcome.
- `src/bus/dispatch-handler.ts` — passes `surface: msg.platform`; resolves + posts the ack into the run thread (`resolveRunThreadTarget`), fallback to channel.
- Tests: `orchestrator-command.test.ts` (routing stamped + flows dispatch→lifecycle unchanged), `dispatch-handler.test.ts` (ack into run thread, fallback-to-channel, fail-closed non-principal).

## Gates

- `bunx tsc --noEmit` — **0**
- `bash scripts/check-carveouts.sh` — **PASS**
- `bunx eslint --quiet .` — **0**
- `bun test src/` — **7428 pass / 2 skip / 0 fail** (426 files)

## Follow-up / flags

- **S3 merge-gate post** is not yet implemented (the merge stays a human gate in S1); when it lands it reuses this same run routing. The ack already says "I'll hold at the merge gate for you".
- The run thread lands under the **repo-short channel** (`#cortex` → `cortex/issue/N`) regardless of which channel the `implement` command was typed in — this is deliberate (consistent with how echo's review already routes, and required so the ack + lifecycle land together). If no `#<repo-short>` channel exists in the guild, resolution returns null and the run degrades to the inbound channel (ack) with the lifecycle un-threaded.

Refs #1206. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)