### PR TITLE
fix(federation): self-short-circuit own presence + dedupe access.denied audit + bubble up (#1213)

### DIFF
--- a/src/bus/__tests__/access-denied-dedup.test.ts
+++ b/src/bus/__tests__/access-denied-dedup.test.ts
@@ -1,0 +1,97 @@
+/**
+ * cortex#1213 — `AccessDeniedDeduper` unit tests.
+ *
+ * The deduper is the defence-in-depth backstop that keeps a genuinely-repeated
+ * denial AUDITED (security preserved) but never FLOODING the bus. Clock is
+ * injected so the window behaviour is deterministic.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  AccessDeniedDeduper,
+  type DenialIdentity,
+} from "../access-denied-dedup";
+
+const ID: DenialIdentity = {
+  capability: "federated.subject_dispatch",
+  subject: "federated.andreas.meta-factory.agent.heartbeat",
+  reason: "peer_not_in_accept_list",
+  source: "andreas",
+};
+
+describe("AccessDeniedDeduper", () => {
+  test("first occurrence emits + firstSeen", () => {
+    const d = new AccessDeniedDeduper({ now: () => 0 });
+    const decision = d.decide(ID);
+    expect(decision.emit).toBe(true);
+    expect(decision.firstSeen).toBe(true);
+    expect(decision.suppressed).toBe(0);
+  });
+
+  test("identical denial inside the window is SUPPRESSED (counted, not emitted)", () => {
+    let clock = 0;
+    const d = new AccessDeniedDeduper({ now: () => clock, windowMs: 60_000 });
+    expect(d.decide(ID).emit).toBe(true); // first
+
+    clock = 30_000; // still inside the 60s window
+    const second = d.decide(ID);
+    expect(second.emit).toBe(false);
+    expect(second.firstSeen).toBe(false);
+    expect(second.suppressed).toBe(1);
+
+    clock = 31_000;
+    const third = d.decide(ID);
+    expect(third.emit).toBe(false);
+    expect(third.suppressed).toBe(2);
+  });
+
+  test("first occurrence AFTER the window emits a ROLLUP carrying the suppressed count", () => {
+    let clock = 0;
+    const d = new AccessDeniedDeduper({ now: () => clock, windowMs: 1_000 });
+    expect(d.decide(ID).emit).toBe(true); // first emit at t=0
+
+    clock = 500; // inside window — suppressed
+    expect(d.decide(ID).emit).toBe(false);
+    clock = 900; // inside window — suppressed
+    expect(d.decide(ID).emit).toBe(false);
+
+    clock = 1_000; // window elapsed → rollup emit
+    const rollup = d.decide(ID);
+    expect(rollup.emit).toBe(true);
+    expect(rollup.firstSeen).toBe(false);
+    expect(rollup.suppressed).toBe(2); // the two suppressed since the last emit
+
+    clock = 1_100; // counter reset after the rollup
+    const afterRollup = d.decide(ID);
+    expect(afterRollup.emit).toBe(false);
+    expect(afterRollup.suppressed).toBe(1);
+  });
+
+  test("distinct tuples are tracked independently", () => {
+    const d = new AccessDeniedDeduper({ now: () => 0 });
+    expect(d.decide(ID).emit).toBe(true);
+    // Same except reason — a DIFFERENT denial, emits on its own first occurrence.
+    expect(d.decide({ ...ID, reason: "max_hop_exceeded" }).emit).toBe(true);
+    // Same except source.
+    expect(d.decide({ ...ID, source: "joel" }).emit).toBe(true);
+    // The original tuple is still suppressed.
+    expect(d.decide(ID).emit).toBe(false);
+  });
+
+  test("stale entries are pruned under the soft cap (no unbounded growth)", () => {
+    let clock = 0;
+    const d = new AccessDeniedDeduper({
+      now: () => clock,
+      windowMs: 100,
+      maxEntries: 2,
+    });
+    d.decide({ ...ID, subject: "a" });
+    d.decide({ ...ID, subject: "b" });
+    clock = 1_000; // both windows elapsed
+    // Inserting a 3rd at-cap triggers a prune of the two stale entries, then
+    // re-inserting one of them is a fresh firstSeen (it was evicted).
+    d.decide({ ...ID, subject: "c" });
+    const reinserted = d.decide({ ...ID, subject: "a" });
+    expect(reinserted.firstSeen).toBe(true);
+  });
+});

--- a/src/bus/access-denied-dedup.ts
+++ b/src/bus/access-denied-dedup.ts
@@ -1,0 +1,144 @@
+/**
+ * cortex#1213 — rate-limit / dedupe for `system.access.denied` audit emits.
+ *
+ * ## Why
+ *
+ * A federated stack publishes its OWN presence onto `federated.{us}.agent.>`
+ * (so peers see it) which loops back to its own federated subscriber. Before
+ * the cortex#1213 self short-circuit that loopback was denied + audited on
+ * EVERY heartbeat tick — flooding `local.{principal}.{stack}.system.access.denied`
+ * with an identical envelope. The self short-circuit kills the loopback at the
+ * root; THIS helper is the defence-in-depth backstop: any genuinely-repeated
+ * denial (a real foreign peer that is misconfigured, a relay that keeps
+ * re-sending) is AUDITED — security is preserved — but can never FLOOD the bus.
+ *
+ * ## Contract
+ *
+ * A denial is identified by the tuple `(capability, subject, reason, source)`.
+ * The FIRST occurrence of a tuple emits; identical occurrences inside the
+ * window are suppressed (counted); the first occurrence AFTER the window
+ * elapses emits a rollup carrying the suppressed count, then the window
+ * restarts. So a tuple denied every 30 s with a 60 s window emits at most
+ * roughly once per 60 s, regardless of tick rate — the audit stays present
+ * (governance still sees it) but bounded.
+ *
+ * `firstSeen` is `true` exactly once per distinct tuple (until eviction); it
+ * drives the principal-facing "bubble up" WARN — surfaced ONCE, not per-tick.
+ *
+ * Pure + clock-injectable so it is deterministically unit-testable; it does
+ * NOT emit anything itself (callers own the `runtime.publish`), it only
+ * decides whether a caller SHOULD emit.
+ */
+
+/** The tuple a denial is deduped on. */
+export interface DenialIdentity {
+  /** Capability / intent the gate evaluated (e.g. `federated.subject_dispatch`). */
+  capability: string;
+  /** Subject the denied envelope arrived on. */
+  subject: string;
+  /** Structured reason `kind` (e.g. `peer_not_in_accept_list`). */
+  reason: string;
+  /** Source principal of the denied envelope (the actor being denied). */
+  source: string;
+}
+
+/** The dedup decision for a single denial occurrence. */
+export interface DenialDecision {
+  /** Whether the caller should publish the `system.access.denied` audit now. */
+  emit: boolean;
+  /**
+   * `true` the very FIRST time this tuple is seen (until eviction). Drives the
+   * once-per-tuple principal-facing bubble-up WARN.
+   */
+  firstSeen: boolean;
+  /**
+   * Identical denials suppressed since the last emit. `0` on the first emit;
+   * `> 0` on a rollup emit (so the rollup audit / log can say "+N suppressed").
+   */
+  suppressed: number;
+}
+
+/** Construction options — all optional; defaults match the cortex#1213 ask. */
+export interface AccessDeniedDeduperOptions {
+  /**
+   * Suppression window in ms. Default 60 000 (1 min): an identical denial
+   * emits at most once per minute. Small enough that a real misconfig still
+   * surfaces promptly, large enough that a per-tick (≈30 s) heartbeat can
+   * never flood.
+   */
+  windowMs?: number;
+  /** Injectable monotonic-ish clock (tests). Defaults to `Date.now`. */
+  now?: () => number;
+  /**
+   * Soft cap on tracked tuples. When exceeded, entries whose window has
+   * already elapsed are pruned (a denial that hasn't recurred within the
+   * window is, by definition, not flooding). Bounds memory for a pathological
+   * spread of distinct denial tuples. Default 4096.
+   */
+  maxEntries?: number;
+}
+
+interface Entry {
+  /** Last time we EMITTED for this tuple. */
+  lastEmitAt: number;
+  /** Identical denials suppressed since `lastEmitAt`. */
+  suppressed: number;
+}
+
+/**
+ * Windowed deduper for `system.access.denied` audit emits. One instance per
+ * consumer (the federated subscriber owns one); state is per-instance so a
+ * test can inject a clock and assert window behaviour without global bleed.
+ */
+export class AccessDeniedDeduper {
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly maxEntries: number;
+  private readonly entries = new Map<string, Entry>();
+
+  constructor(opts: AccessDeniedDeduperOptions = {}) {
+    this.windowMs = opts.windowMs ?? 60_000;
+    this.now = opts.now ?? Date.now;
+    this.maxEntries = opts.maxEntries ?? 4096;
+  }
+
+  /**
+   * Decide whether this denial occurrence should be emitted. Mutates internal
+   * state (records the emit / increments the suppressed counter).
+   */
+  decide(id: DenialIdentity): DenialDecision {
+    const key = keyOf(id);
+    const t = this.now();
+    const existing = this.entries.get(key);
+
+    if (existing === undefined) {
+      if (this.entries.size >= this.maxEntries) this.prune(t);
+      this.entries.set(key, { lastEmitAt: t, suppressed: 0 });
+      return { emit: true, firstSeen: true, suppressed: 0 };
+    }
+
+    if (t - existing.lastEmitAt >= this.windowMs) {
+      // Window elapsed — emit a rollup carrying the suppressed count, restart.
+      const suppressed = existing.suppressed;
+      existing.lastEmitAt = t;
+      existing.suppressed = 0;
+      return { emit: true, firstSeen: false, suppressed };
+    }
+
+    // Inside the window — suppress (but count, so the next rollup is honest).
+    existing.suppressed += 1;
+    return { emit: false, firstSeen: false, suppressed: existing.suppressed };
+  }
+
+  /** Drop entries whose window has elapsed (they are not flooding). */
+  private prune(now: number): void {
+    for (const [key, entry] of this.entries) {
+      if (now - entry.lastEmitAt >= this.windowMs) this.entries.delete(key);
+    }
+  }
+}
+
+/** Stable map key — ` ` separator can't appear in any of the fields. */
+function keyOf(id: DenialIdentity): string {
+  return `${id.source} ${id.capability} ${id.subject} ${id.reason}`;
+}

--- a/src/bus/agent-network/__tests__/federated-subscriber-self-deny.test.ts
+++ b/src/bus/agent-network/__tests__/federated-subscriber-self-deny.test.ts
@@ -1,0 +1,329 @@
+/**
+ * cortex#1213 — federation self-deny loop fix.
+ *
+ * A federated stack publishes its OWN presence onto `federated.{us}.agent.>`
+ * (so peers see it); that loops back to its own federated subscriber and — pre
+ * fix — the accept-list gate denied + audited it on EVERY heartbeat tick (we
+ * are not our own peer), flooding `system.access.denied`.
+ *
+ * Coverage:
+ *   1. OWN heartbeat (validly self-signed) ⇒ NOT denied, NO audit, NOT folded;
+ *      the crypto bytes-check still RUNS (proven by test 2's rejection of a
+ *      forged self-DID — same path, only the bytes differ).
+ *   2. Spoofed self-DID (bad signature) ⇒ STILL rejected + audited
+ *      (`chain_verify_failed`): the trust short-circuit is bytes-checked.
+ *   3. A genuinely-denied FOREIGN envelope ⇒ STILL denied, but audited at MOST
+ *      once per window (a 2nd identical denial is suppressed).
+ *   4. The principal-facing bubble-up fires exactly ONCE across repeats.
+ */
+
+import { describe, expect, test, mock } from "bun:test";
+import { createUser } from "@nats-io/nkeys";
+import { signEnvelope } from "@the-metafactory/myelin/identity";
+import {
+  startFederatedAgentPresenceSubscriber,
+  type DenialBubbleUp,
+} from "../federated-subscriber";
+import { AgentPresenceRegistry } from "../registry";
+import { createAgentHeartbeatEvent, type AgentPresenceSource } from "../builders";
+import type { Envelope } from "../../myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../../myelin/runtime";
+import type { MyelinSubscriber } from "../../myelin/subscriber";
+import type { SystemEventSource } from "../../system-events";
+import type {
+  PolicyFederated,
+  PolicyFederatedNetwork,
+} from "../../../common/types/cortex-config";
+import { TrustResolver } from "../../../common/agents/trust-resolver";
+import { AgentRegistry } from "../../../common/agents/registry";
+import { AccessDeniedDeduper } from "../../access-denied-dedup";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SYSTEM_SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+
+const STACK_IDENTITY = "did:mf:andreas-meta-factory";
+
+/** OUR OWN presence source — andreas/meta-factory (the receiving stack). */
+const SELF_SOURCE: AgentPresenceSource = {
+  principal: "andreas",
+  stack: "meta-factory",
+  instance: "local",
+};
+
+const SELF_SUBJECT = "federated.andreas.meta-factory.agent.heartbeat";
+const FOREIGN_SUBJECT = "federated.joel.research.agent.heartbeat";
+
+/** Generate an ed25519 NATS keypair; returns the NKey pub + raw base64 seed. */
+function generateEd25519KeyPair(): {
+  nkeyPub: string;
+  privateKeyBase64: string;
+} {
+  const kp = createUser();
+  const nkeyPub = kp.getPublicKey();
+  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
+  return { nkeyPub, privateKeyBase64: Buffer.from(rawSeed).toString("base64") };
+}
+
+/** An unsigned self-presence heartbeat (federated classification). */
+function selfHeartbeatBase(): Envelope {
+  return createAgentHeartbeatEvent({
+    source: SELF_SOURCE,
+    identity: {
+      nkey_public_key: "USELF",
+      agent_id: "luna",
+      assistant_name: "Luna",
+    },
+    scope: { principal: "andreas", stack: "meta-factory" },
+    sentAt: new Date("2026-06-25T09:00:00.000Z"),
+    classification: "federated",
+  });
+}
+
+/** A foreign heartbeat from joel (federated). */
+function foreignHeartbeat(): Envelope {
+  return createAgentHeartbeatEvent({
+    source: { principal: "joel", stack: "research", instance: "local" },
+    identity: {
+      nkey_public_key: "UPEER",
+      agent_id: "sage",
+      assistant_name: "Sage",
+    },
+    scope: { principal: "joel", stack: "research" },
+    sentAt: new Date("2026-06-25T09:00:00.000Z"),
+    classification: "federated",
+  });
+}
+
+/** Network where joel is NOT a peer (so joel is denied) but our own subtree is accepted. */
+function networkWithoutJoel(): PolicyFederatedNetwork {
+  return {
+    id: "metafactory",
+    leaf_node: "primary",
+    peers: [],
+    accept_subjects: ["federated.andreas.meta-factory.agent.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+function federatedPolicy(networks: PolicyFederatedNetwork[]): PolicyFederated {
+  return { networks };
+}
+
+function emptyTrustResolver(): TrustResolver {
+  return new TrustResolver(AgentRegistry.fromAgents([]));
+}
+
+// ---------------------------------------------------------------------------
+// Fake runtime
+// ---------------------------------------------------------------------------
+
+interface FakeRuntime extends MyelinRuntime {
+  fire(envelope: Envelope, subject: string, sourceLink?: string): void;
+  published: Envelope[];
+}
+
+function makeFakeRuntime(): FakeRuntime {
+  const handlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const fakeSubscriber = { stop: mock(() => Promise.resolve()) } as unknown as MyelinSubscriber;
+  return {
+    enabled: true,
+    published,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: (env: Envelope) => {
+      published.push(env);
+      return Promise.resolve();
+    },
+    stop: () => Promise.resolve(),
+    subscribe: () => Promise.resolve(fakeSubscriber),
+    fire(envelope, subject, sourceLink) {
+      for (const h of handlers) h(envelope, subject, sourceLink);
+    },
+  };
+}
+
+function deniedEnvelopes(runtime: FakeRuntime): Envelope[] {
+  return runtime.published.filter((e) => e.type === "system.access.denied");
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+/**
+ * The chain verify is async (ed25519 verifyAsync + a promise chain); a single
+ * macrotask tick is not enough to let it settle under full-suite load. Poll
+ * until `predicate` holds or the budget elapses.
+ */
+async function until(
+  predicate: () => boolean,
+  { tries = 200, stepMs = 5 }: { tries?: number; stepMs?: number } = {},
+): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, stepMs));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. OWN heartbeat — self short-circuit (root fix)
+// ---------------------------------------------------------------------------
+
+describe("cortex#1213 — self short-circuit", () => {
+  test("OWN validly-signed heartbeat ⇒ NOT denied, NO audit, NOT folded", async () => {
+    const { nkeyPub: stackNKeyPub, privateKeyBase64: stackSeed } =
+      generateEd25519KeyPair();
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity: STACK_IDENTITY,
+      stackNKeyPub,
+    });
+
+    // Sign the self heartbeat with the STACK key (own DID) — exactly how the
+    // runtime stamps an own-presence publish.
+    const signed = await signEnvelope(
+      selfHeartbeatBase() as unknown as Parameters<typeof signEnvelope>[0],
+      stackSeed,
+      STACK_IDENTITY,
+    );
+
+    runtime.fire(signed, SELF_SUBJECT, "primary");
+    // Give the async crypto verify ample time to settle, then assert the
+    // ABSENCE of any fold / audit (a generous fixed wait — there is no positive
+    // signal to poll for on the silent-drop happy path).
+    await new Promise((r) => setTimeout(r, 150));
+
+    // The self-loopback is silently dropped: not folded as a foreign record …
+    expect(registry.getAgents().length).toBe(0);
+    // … and crucially NO system.access.denied flood.
+    expect(deniedEnvelopes(runtime).length).toBe(0);
+    await handle.stop();
+  });
+
+  test("spoofed self-DID with a BAD signature ⇒ STILL rejected + audited (bytes-check runs)", async () => {
+    const { nkeyPub: stackNKeyPub, privateKeyBase64: stackSeed } =
+      generateEd25519KeyPair();
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity: STACK_IDENTITY,
+      stackNKeyPub,
+    });
+
+    const signed = await signEnvelope(
+      selfHeartbeatBase() as unknown as Parameters<typeof signEnvelope>[0],
+      stackSeed,
+      STACK_IDENTITY,
+    );
+    // TAMPER the signature — the stamp still CLAIMS our stack DID (so the trust
+    // short-circuit accepts it structurally) but the bytes no longer verify.
+    const signedEnv: Envelope = signed;
+    const chain = Array.isArray(signedEnv.signed_by) ? signedEnv.signed_by : [];
+    const firstStamp = chain[0];
+    if (firstStamp?.method !== "ed25519") {
+      throw new Error("test fixture: expected ed25519 stamp at index 0");
+    }
+    const tamperedSig = firstStamp.signature.startsWith("A")
+      ? "B" + firstStamp.signature.slice(1)
+      : "A" + firstStamp.signature.slice(1);
+    const tampered: Envelope = {
+      ...signedEnv,
+      signed_by: [{ ...firstStamp, signature: tamperedSig }],
+    };
+
+    runtime.fire(tampered, SELF_SUBJECT, "primary");
+    await until(() => deniedEnvelopes(runtime).length >= 1);
+
+    // Forged self-DID: not folded, and AUDITED as a chain-verify failure — the
+    // crypto bytes-check ran (the trust short-circuit alone would have accepted).
+    expect(registry.getAgents().length).toBe(0);
+    const denied = deniedEnvelopes(runtime);
+    expect(denied.length).toBe(1);
+    expect((denied[0]!.payload as { reason: { kind: string } }).reason.kind).toBe(
+      "chain_verify_failed",
+    );
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3 + 4. Dedupe + bubble-up — a real foreign denial is still denied, once
+// ---------------------------------------------------------------------------
+
+describe("cortex#1213 — dedupe + bubble-up", () => {
+  test("FOREIGN non-peer denied EVERY tick ⇒ audited at MOST once per window", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      // Large window so two back-to-back identical denials collapse to one.
+      denialDeduper: new AccessDeniedDeduper({ windowMs: 60_000 }),
+    });
+
+    // joel is in no network's peers[] ⇒ peer_not_in_accept_list, every tick.
+    runtime.fire(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    runtime.fire(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    runtime.fire(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    await flush();
+
+    // STILL denied (security preserved) but audited only ONCE (no flood).
+    expect(registry.getAgents().length).toBe(0);
+    expect(deniedEnvelopes(runtime).length).toBe(1);
+    await handle.stop();
+  });
+
+  test("bubble-up fires exactly ONCE across repeated identical denials", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const bubbles: DenialBubbleUp[] = [];
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      denialDeduper: new AccessDeniedDeduper({ windowMs: 60_000 }),
+      onDenialBubbleUp: (info) => bubbles.push(info),
+    });
+
+    runtime.fire(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    runtime.fire(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    runtime.fire(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    await flush();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbles[0]?.identity.reason).toBe("peer_not_in_accept_list");
+    await handle.stop();
+  });
+});

--- a/src/bus/agent-network/federated-subscriber.ts
+++ b/src/bus/agent-network/federated-subscriber.ts
@@ -105,6 +105,11 @@ import {
 } from "../surface-router";
 import { emitSystemAccessDenied } from "../emit-system-access-denied";
 import { verifySignedByChain } from "../verify-signed-by-chain";
+import {
+  AccessDeniedDeduper,
+  type DenialDecision,
+  type DenialIdentity,
+} from "../access-denied-dedup";
 import { AgentPresenceRegistry } from "./registry";
 import { AGENT_PRESENCE_TYPES } from "./envelopes";
 
@@ -206,6 +211,29 @@ export interface StartFederatedAgentPresenceSubscriberOptions {
   resolveFederatedPeer?: (
     peerPrincipal: string,
   ) => Promise<FederatedPeerResolution>;
+  /**
+   * cortex#1213 — windowed deduper for the `system.access.denied` audit emits
+   * this consumer makes. A TEST SEAM: production omits it and a fresh
+   * 60s-window deduper is created internally. Tests inject one with an injected
+   * clock to assert "audited at most once per window".
+   */
+  denialDeduper?: AccessDeniedDeduper;
+  /**
+   * cortex#1213 — principal-facing "bubble up" hook, invoked ONCE per distinct
+   * denial tuple (the first time it is seen). Default writes a clear WARN to
+   * `process.stderr`; production may also route a notify/dashboard signal. A
+   * self-deny or federation misconfig surfaces to the principal ONCE here
+   * rather than re-spamming the audit subject every tick.
+   */
+  onDenialBubbleUp?: (info: DenialBubbleUp) => void;
+}
+
+/** cortex#1213 — payload handed to {@link StartFederatedAgentPresenceSubscriberOptions.onDenialBubbleUp}. */
+export interface DenialBubbleUp {
+  /** The denied tuple (capability/subject/reason/source). */
+  identity: DenialIdentity;
+  /** Human-readable one-line summary (already includes a remediation hint). */
+  message: string;
 }
 
 /**
@@ -233,6 +261,50 @@ export async function startFederatedAgentPresenceSubscriber(
     resolveFederatedPeer,
   } = opts;
   const cryptoVerify = opts.cryptoVerify ?? true;
+  // cortex#1213 — dedupe the `system.access.denied` audit emits. Default to a
+  // fresh 60s-window deduper; tests inject one with an injected clock.
+  const denialDeduper = opts.denialDeduper ?? new AccessDeniedDeduper();
+  // cortex#1213 — principal-facing bubble-up. Default: a clear WARN to stderr,
+  // emitted ONCE per distinct denial tuple (the deduper's `firstSeen` flag).
+  const onDenialBubbleUp =
+    opts.onDenialBubbleUp ??
+    ((info: DenialBubbleUp): void => {
+      process.stderr.write(`[federated-presence] WARN ${info.message}\n`);
+    });
+
+  /**
+   * cortex#1213 — emit a `system.access.denied` audit through the deduper.
+   * `doEmit` performs the actual `runtime.publish` (via the existing
+   * emitFederationDenied / emitSystemAccessDenied helpers). We call it ONLY
+   * when the deduper says to (first occurrence or a post-window rollup), so a
+   * genuinely-repeated denial is still audited — security preserved — but never
+   * floods the bus. The first occurrence of each tuple also bubbles up ONCE.
+   */
+  const emitDeny = (id: DenialIdentity, doEmit: () => void): void => {
+    const decision: DenialDecision = denialDeduper.decide(id);
+    if (decision.firstSeen) {
+      onDenialBubbleUp({
+        identity: id,
+        message:
+          `federation denial: capability=${id.capability} subject=${id.subject} ` +
+          `reason=${id.reason} source=${id.source} — verify this peer is on a ` +
+          `shared network's peers[]/accept_subjects[] (or remove the federated ` +
+          `publish if this is the stack's OWN presence looping back).`,
+      });
+    }
+    if (decision.emit) doEmit();
+  };
+
+  /**
+   * cortex#1213 — bubble up a non-audited condition (no `system.access.denied`
+   * to emit) to the principal ONCE per distinct tuple. Routed through the SAME
+   * deduper so it can never flood stderr on a per-tick loopback.
+   */
+  const bubbleUpOnce = (id: DenialIdentity, message: string): void => {
+    if (denialDeduper.decide(id).firstSeen) {
+      onDenialBubbleUp({ identity: id, message });
+    }
+  };
   // POSTURE-GATED, matching the #484 dispatch-listener EXACTLY: production passes
   // `signingKnobs.rejectEmpty` (off/permissive → false ⇒ accept-list-only trust;
   // enforce → true ⇒ require a verifiable chain). Default `false` mirrors the
@@ -273,21 +345,58 @@ export async function startFederatedAgentPresenceSubscriber(
     if (!subjectMatches(pattern, subject)) return;
     if (!presenceTypes.has(envelope.type)) return;
 
+    const sourcePrincipal = envelope.source.split(".")[0] ?? envelope.source;
+
+    // === SELF-LOOPBACK SHORT-CIRCUIT (cortex#1213, mirrors cortex#480) =====
+    // A federated stack publishes its OWN presence onto `federated.{us}.agent.>`
+    // so peers see it; that publish LOOPS BACK to this subscriber. The
+    // accept-list gate below would then deny it (we are not our own peer →
+    // `peer_not_in_accept_list` / `unknown_network`) and audit it on EVERY
+    // heartbeat tick — a self-deny FLOOD (#1213).
+    //
+    // Detect the self-claim the SAME way `verifySignedByChain` does (cortex#480):
+    // the SOURCE stamp's `identity` equals the receiving stack's OWN signing DID
+    // (`stackIdentity`, from config — NOT the spoofable `envelope.source` /
+    // `payload` fields). When it matches, SKIP the federation accept-list (TRUST)
+    // gate — but the crypto bytes-check below STILL runs against `stackNKeyPub`,
+    // so a spoofed self-DID without our private key is rejected exactly as a
+    // forged foreign envelope. A crypto-verified self-loopback is silently
+    // DROPPED (B.3 already folds our LOCAL presence — we never fold our own as a
+    // foreign record) and emits NO deny-audit.
+    const claimsOwnStack =
+      stackIdentity !== undefined &&
+      getSignedByChain(envelope)[0]?.identity === stackIdentity;
+
     // === TRUST GATE 1 — federation accept-list (E.5) ======================
     // Mirror of the dispatch-listener's Option-D gate (cortex#484). A foreign
     // presence envelope from a peer NOT in any configured network's `peers[]`,
     // OR on a denied subject, OR over the hop budget, OR cross-network-spoofed
     // on the wrong leaf, is DROPPED here — never folded. The audit envelope
-    // makes the drop observable.
-    const decision = evaluateFederationGate(
-      subject,
-      envelope,
-      federatedNetworksById,
-      sourceLink,
-    );
-    if (decision !== "allow") {
-      emitFederationDenied(runtime, source, envelope, subject, decision);
-      return;
+    // makes the drop observable (deduped per #1213 so a repeat can't flood).
+    // SKIPPED for a self-loopback claim (the short-circuit above) — our own DID
+    // is never in our own `peers[]`, and the bytes-check (GATE 2) is the real
+    // boundary for a self-claim.
+    if (!claimsOwnStack) {
+      const decision = evaluateFederationGate(
+        subject,
+        envelope,
+        federatedNetworksById,
+        sourceLink,
+      );
+      if (decision !== "allow") {
+        emitDeny(
+          {
+            capability: "federated.subject_dispatch",
+            subject,
+            reason: decision.kind,
+            source: sourcePrincipal,
+          },
+          () => {
+            emitFederationDenied(runtime, source, envelope, subject, decision);
+          },
+        );
+        return;
+      }
     }
 
     // === TRUST GATE 2 — signed_by[] chain verification (E.5) ===============
@@ -295,6 +404,13 @@ export async function startFederatedAgentPresenceSubscriber(
     // failure DROPS the envelope (never folds). When no `trustResolver` /
     // `receivingAgentId` is wired, the chain check is skipped (the gate above
     // still bounded which peers can appear) and the envelope folds directly.
+    //
+    // For a self-loopback claim this is THE security check — the cortex#480
+    // own-stack short-circuit inside `verifySignedByChain` accepts the stamp
+    // structurally, then the crypto pass verifies the bytes against
+    // `stackNKeyPub`. The `resolveFederatedPeer` seam is OMITTED for a
+    // self-claim: the signer is our OWN stack, not a federated peer, so there is
+    // nothing to resolve (resolving ourselves as a peer would wrongly reject).
     if (trustResolver !== undefined && receivingAgentId !== undefined) {
       void verifySignedByChain(envelope, {
         resolver: trustResolver,
@@ -304,31 +420,47 @@ export async function startFederatedAgentPresenceSubscriber(
         ...(principalId !== undefined && { principalId }),
         ...(stackIdentity !== undefined && { stackIdentity }),
         ...(stackNKeyPub !== undefined && { stackNKeyPub }),
-        ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
+        ...(!claimsOwnStack &&
+          resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
       })
         .then((result) => {
           if (!result.valid) {
-            // Chain failed — DROP. A foreign presence envelope that can't be
-            // cryptographically attributed never appears in the view.
+            // Chain failed — DROP. A presence envelope that can't be
+            // cryptographically attributed never appears in the view. For a
+            // self-claim this is the spoofed-self path (a forged self-DID whose
+            // bytes don't verify against our NKey) — STILL rejected + audited.
             process.stderr.write(
-              `federated-agent-presence: dropping foreign presence ${envelope.type} ` +
+              `federated-agent-presence: dropping ${claimsOwnStack ? "self-claimed" : "foreign"} presence ${envelope.type} ` +
                 `(id=${envelope.id}) — signed_by chain verification failed: ` +
                 `${result.reason.kind}\n`,
             );
-            // cortex#932 — the drop was stderr-only; emit a queryable
-            // `system.access.denied` on our local audit stream so governance
-            // sees the chain-verify rejection. Carries signed_by[] verbatim.
-            emitSystemAccessDenied(runtime, source, envelope, {
-              envelopeSubject: subject,
-              principalId: envelope.source.split(".")[0] ?? envelope.source,
-              capability: envelope.type,
-              reason: {
-                kind: "chain_verify_failed",
-                verify_reason: result.reason.kind,
+            // cortex#932 — emit a queryable `system.access.denied` on our local
+            // audit stream so governance sees the chain-verify rejection.
+            // Deduped (#1213) so a repeated bad signer can't flood.
+            emitDeny(
+              {
+                capability: envelope.type,
+                subject,
+                reason: "chain_verify_failed",
+                source: sourcePrincipal,
               },
-            });
+              () => {
+                emitSystemAccessDenied(runtime, source, envelope, {
+                  envelopeSubject: subject,
+                  principalId: sourcePrincipal,
+                  capability: envelope.type,
+                  reason: {
+                    kind: "chain_verify_failed",
+                    verify_reason: result.reason.kind,
+                  },
+                });
+              },
+            );
             return;
           }
+          // Verified. A self-loopback is OUR OWN presence — silently DROP (do
+          // NOT fold our own agents as foreign records; B.3 owns the local copy).
+          if (claimsOwnStack) return;
           foldForeign(registry, envelope);
         })
         .catch((err: unknown) => {
@@ -342,20 +474,45 @@ export async function startFederatedAgentPresenceSubscriber(
           );
           // cortex#932 — a verifier FAULT is also a fail-closed drop; make it
           // observable on the local audit stream (distinct reason kind from a
-          // clean chain rejection so governance can tell "verifier broke" from
-          // "signature didn't verify").
-          emitSystemAccessDenied(runtime, source, envelope, {
-            envelopeSubject: subject,
-            principalId: envelope.source.split(".")[0] ?? envelope.source,
-            capability: envelope.type,
-            reason: { kind: "chain_verify_fault", fault: faultMessage },
-          });
+          // clean chain rejection). Deduped (#1213).
+          emitDeny(
+            {
+              capability: envelope.type,
+              subject,
+              reason: "chain_verify_fault",
+              source: sourcePrincipal,
+            },
+            () => {
+              emitSystemAccessDenied(runtime, source, envelope, {
+                envelopeSubject: subject,
+                principalId: sourcePrincipal,
+                capability: envelope.type,
+                reason: { kind: "chain_verify_fault", fault: faultMessage },
+              });
+            },
+          );
         });
       return;
     }
 
-    // No chain verifier wired — fold directly (the accept-list gate already
-    // bounded the admissible peers).
+    // No chain verifier wired. A self-loopback claim CANNOT be cryptographically
+    // verified here, so we cannot fold it (it would be our own presence anyway)
+    // — DROP it silently to stop the self-deny flood; the once-per-tuple
+    // bubble-up notes it is unverifiable. A foreign envelope folds directly (the
+    // accept-list gate already bounded the admissible peers).
+    if (claimsOwnStack) {
+      bubbleUpOnce(
+        {
+          capability: envelope.type,
+          subject,
+          reason: "self_loopback_unverifiable",
+          source: sourcePrincipal,
+        },
+        `self-loopback presence ${envelope.type} on ${subject} dropped — no ` +
+          `chain verifier wired to confirm the self-signature; not folded.`,
+      );
+      return;
+    }
     foldForeign(registry, envelope);
   };
 


### PR DESCRIPTION
Closes #1213.

## Problem

meta-factory is on the `metafactory` network (peer `jc`, accept `federated.andreas.meta-factory.>`). It publishes its OWN `federated.andreas.meta-factory.agent.heartbeat` so `jc` sees its presence — which loops back to its own federated subscriber. The accept-list gate peer-checks the source DID (`did:mf:andreas-meta-factory` = itself) against peers `[jc]`, finds self not in peers → `peer_not_in_accept_list` → `system.access.denied`, **every heartbeat tick** → flood.

## Fix (3 parts, mirrors the cortex#480 chain-verifier self short-circuit)

### 1. Self short-circuit (root) — `src/bus/agent-network/federated-subscriber.ts`
Before TRUST GATE 1, detect the self-claim the SAME way `verifySignedByChain` does (cortex#480): the SOURCE stamp's `identity` equals the receiving stack's own signing DID (`stackIdentity`, from config — **not** the spoofable `envelope.source`/`payload`). When it matches, the federation accept-list (trust) gate is **skipped**.

**Security constraint preserved:** only the *trust* check is short-circuited — the crypto **bytes-check still runs**. The existing GATE 2 `verifySignedByChain` (with `stackIdentity` + `stackNKeyPub` + `cryptoVerify`) verifies the self-signature against the stack NKey:
- verified self-loopback → silently **dropped** (B.3 already folds our LOCAL presence; we never fold our own as a foreign record), **no deny-audit**;
- spoofed self-DID with bad/absent signature → **rejected + audited** exactly like a forged foreign envelope.

The `resolveFederatedPeer` seam is omitted for a self-claim (we are not our own federated peer).

### 2. Dedupe — new `src/bus/access-denied-dedup.ts`
`AccessDeniedDeduper` (windowed, clock-injectable) keyed on `(capability, subject, reason, source)`: first occurrence emits, identical occurrences inside the window (default 60s) are suppressed (counted), the first after the window emits a rollup carrying the suppressed count. Wired through **all three** deny-emit sites in the federated subscriber (accept-list deny, chain_verify_failed, chain_verify_fault). A genuinely-denied **foreign** envelope is still denied + audited — security preserved — but can never flood.

### 3. Bubble up
A principal-facing WARN fires **once per distinct denial tuple** (driven by the deduper `firstSeen` flag) with a remediation hint — to `process.stderr` by default, with an injectable `onDenialBubbleUp` hook for a notify/dashboard signal. Never per-tick. The (now-deduped) `system.access.denied` remains the governance/dashboard signal.

## Where the self-short-circuit lives / proof the bytes-check runs
- Short-circuit: `federated-subscriber.ts` handler, `claimsOwnStack = stackIdentity !== undefined && getSignedByChain(envelope)[0]?.identity === stackIdentity`. GATE 1 is wrapped in `if (!claimsOwnStack)`; GATE 2 (crypto) always runs.
- Proof: test `spoofed self-DID with a BAD signature ⇒ STILL rejected + audited (chain_verify_failed)` — the trust short-circuit accepts the stamp structurally, so only the crypto pass can reject it. The valid-signature test silently drops with no audit.

## Dedup window / mechanism
`AccessDeniedDeduper.decide()` — `Map<tuple, {lastEmitAt, suppressed}>`, default 60s window, stale-entry prune under a 4096 soft cap. Default per-subscriber instance; a test seam (`denialDeduper`) injects an instance with an injected clock.

## Bubble-up path
`onDenialBubbleUp` option (default: a labelled `process.stderr.write` WARN), invoked once per tuple via the deduper `firstSeen`. No empty catches.

## Tests
- `src/bus/__tests__/access-denied-dedup.test.ts` — first-emit / suppress-in-window / rollup-after-window / independent tuples / prune.
- `src/bus/agent-network/__tests__/federated-subscriber-self-deny.test.ts` — own signed heartbeat (not denied / no audit / not folded), spoofed self-DID bad signature (rejected + audited, bytes-check proven), foreign non-peer (still denied, audited ≤once/window), bubble-up once.

## Gates
- `bunx tsc --noEmit` — clean
- `bunx eslint --quiet .` — clean
- `bash scripts/check-carveouts.sh` — PASS
- full `bun test src/` — **7429 pass, 2 skip, 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)