### PR TITLE
chore: bump to v5.26.5

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.4"
+version: "5.26.5"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
- #1214 (#1213): federation self-deny short-circuit + access.denied dedup + bubble-up — stops the `system.access.denied` flood.
- #1212 (#1206 S2): dev-loop run consolidates into one Discord thread (`{repo}/issue/N`).
Manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)