### PR TITLE
fix(config): fail-soft surface-token resolution — disable the surface, not the stack (#1217)

### DIFF
--- a/src/common/config/__tests__/resolve-env-placeholders.test.ts
+++ b/src/common/config/__tests__/resolve-env-placeholders.test.ts
@@ -1,11 +1,16 @@
 /**
- * cortex#1209 — `__ENV__` placeholder resolution for surface secret fields.
+ * cortex#1209 / cortex#1217 — `__ENV__` placeholder resolution for surface
+ * secret fields, with fail-SOFT per-surface degradation.
  *
- * Acceptance cases (from the issue):
+ * Acceptance cases:
  *   - `token: __VEGA_BOT_TOKEN__` + env set → adapter receives the real token.
- *   - placeholder + unset env → fatal, env-var-named error (NOT the literal).
+ *   - placeholder + UNSET env → that ONE surface is DISABLED (`enabled:false`)
+ *     + scrubbed (no literal `__X__` survives) + a WARN is collected; the load
+ *     does NOT throw and the agent + rest of the config still load (cortex#1217
+ *     — the fail-closed throw used to crash-loop the whole stack).
  *   - inline token → unchanged.
  *   - Pier's `__PIER_BOT_TOKEN__` resolves the same way (fragment path).
+ *   - the surfaces.yaml gateway-binding path fails soft by DROPPING the entry.
  *
  * The unit layer here exercises the resolver directly + through the loader
  * (`loadConfigWithAgents` for inline `agents[]`, `loadAgentFromFile` for an
@@ -26,6 +31,7 @@ import {
   resolveAgentPresenceTokens,
   resolveSurfaceBindingTokens,
   resolveSurfaceTokensInRawConfig,
+  type SurfaceTokenWarning,
 } from "../resolve-env-placeholders";
 import type { Surfaces } from "../../types/surfaces";
 import { loadConfigWithAgents, loadAgentFromFile } from "../loader";
@@ -69,51 +75,37 @@ describe("ENV_PLACEHOLDER_PATTERN", () => {
     expect(ENV_PLACEHOLDER_PATTERN.test("xoxb-real-token")).toBe(false);
     expect(ENV_PLACEHOLDER_PATTERN.test("__A B__")).toBe(false);
   });
+
+  test("the scrub sentinels are NOT themselves placeholders (assert never re-fires)", () => {
+    // The disabled-surface sentinels must not look like `__ENV__` placeholders,
+    // or a downstream resolve pass / the belt-and-suspenders assert would trip.
+    expect(ENV_PLACEHOLDER_PATTERN.test("DISABLED-MISSING-SECRET-VEGA_BOT_TOKEN")).toBe(false);
+    expect(ENV_PLACEHOLDER_PATTERN.test("xoxb-DISABLED-SLACK_BOT")).toBe(false);
+    expect(ENV_PLACEHOLDER_PATTERN.test("xapp-DISABLED-SLACK_APP")).toBe(false);
+  });
 });
 
-describe("resolveAgentPresenceTokens", () => {
+describe("resolveAgentPresenceTokens — resolve / inline (unchanged behaviour)", () => {
   test("resolves a discord token placeholder from env", () => {
     process.env.VEGA_BOT_TOKEN = "real-vega-token";
     const agent: Record<string, unknown> = {
-      presence: { discord: { token: "__VEGA_BOT_TOKEN__" } },
+      id: "vega",
+      presence: { discord: { enabled: true, token: "__VEGA_BOT_TOKEN__" } },
     };
     resolveAgentPresenceTokens(agent, "agents[0]");
     expect((agent.presence as any).discord.token).toBe("real-vega-token");
-  });
-
-  test("fail-closed: unset env → EnvPlaceholderError naming the var, not the literal", () => {
-    delete process.env.VEGA_BOT_TOKEN;
-    const agent: Record<string, unknown> = {
-      presence: { discord: { token: "__VEGA_BOT_TOKEN__" } },
-    };
-    let err: unknown;
-    try {
-      resolveAgentPresenceTokens(agent, "agents[0]");
-    } catch (e) {
-      err = e;
-    }
-    expect(err).toBeInstanceOf(EnvPlaceholderError);
-    expect((err as EnvPlaceholderError).envVar).toBe("VEGA_BOT_TOKEN");
-    expect((err as Error).message).toContain("VEGA_BOT_TOKEN");
-    expect((err as Error).message).toContain("agents[0].presence.discord.token");
-    // the literal placeholder must NOT silently survive onto the object
-    expect((agent.presence as any).discord.token).toBe("__VEGA_BOT_TOKEN__");
-  });
-
-  test("fail-closed: EMPTY env var is treated as unset", () => {
-    process.env.VEGA_BOT_TOKEN = "";
-    const agent: Record<string, unknown> = {
-      presence: { discord: { token: "__VEGA_BOT_TOKEN__" } },
-    };
-    expect(() => resolveAgentPresenceTokens(agent, "agents[0]")).toThrow(EnvPlaceholderError);
+    // resolved surface stays enabled
+    expect((agent.presence as any).discord.enabled).toBe(true);
   });
 
   test("inline token passes through byte-identical", () => {
     const agent: Record<string, unknown> = {
-      presence: { discord: { token: "inline-real-token-123" } },
+      id: "vega",
+      presence: { discord: { enabled: true, token: "inline-real-token-123" } },
     };
     resolveAgentPresenceTokens(agent, "agents[0]");
     expect((agent.presence as any).discord.token).toBe("inline-real-token-123");
+    expect((agent.presence as any).discord.enabled).toBe(true);
   });
 
   test("resolves mattermost.apiToken + slack.botToken/appToken", () => {
@@ -121,6 +113,7 @@ describe("resolveAgentPresenceTokens", () => {
     process.env.SLACK_BOT = "xoxb-real";
     process.env.SLACK_APP = "xapp-real";
     const agent: Record<string, unknown> = {
+      id: "echo",
       presence: {
         mattermost: { apiToken: "__MM_API_TOKEN__" },
         slack: { botToken: "__SLACK_BOT__", appToken: "__SLACK_APP__" },
@@ -138,18 +131,111 @@ describe("resolveAgentPresenceTokens", () => {
   });
 });
 
+describe("resolveAgentPresenceTokens — fail SOFT on unset env (cortex#1217)", () => {
+  test("unset env → surface DISABLED, literal scrubbed, NO throw, WARN collected", () => {
+    delete process.env.VEGA_BOT_TOKEN;
+    const agent: Record<string, unknown> = {
+      id: "vega",
+      presence: { discord: { enabled: true, token: "__VEGA_BOT_TOKEN__" } },
+    };
+    const warnings: SurfaceTokenWarning[] = [];
+    // does NOT throw
+    expect(() => resolveAgentPresenceTokens(agent, "agents[0]", warnings)).not.toThrow();
+    const discord = (agent.presence as any).discord;
+    // surface disabled
+    expect(discord.enabled).toBe(false);
+    // the literal placeholder must NOT survive
+    expect(discord.token).not.toBe("__VEGA_BOT_TOKEN__");
+    expect(ENV_PLACEHOLDER_PATTERN.test(discord.token)).toBe(false);
+    // warning names the agent + env var (never a thrown error)
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      agent: "vega",
+      platform: "discord",
+      envVar: "VEGA_BOT_TOKEN",
+      fieldPath: "agents[0].presence.discord.token",
+    });
+  });
+
+  test("EMPTY / whitespace-only env var is treated as unset → soft-disable", () => {
+    process.env.VEGA_BOT_TOKEN = "   ";
+    const agent: Record<string, unknown> = {
+      id: "vega",
+      presence: { discord: { enabled: true, token: "__VEGA_BOT_TOKEN__" } },
+    };
+    const warnings: SurfaceTokenWarning[] = [];
+    resolveAgentPresenceTokens(agent, "agents[0]", warnings);
+    expect((agent.presence as any).discord.enabled).toBe(false);
+    expect(warnings).toHaveLength(1);
+  });
+
+  test("slack botToken missing → disabled + scrubbed to a schema-valid xoxb- sentinel", () => {
+    delete process.env.SLACK_BOT;
+    process.env.SLACK_APP = "xapp-real";
+    const agent: Record<string, unknown> = {
+      id: "sage",
+      presence: { slack: { enabled: true, botToken: "__SLACK_BOT__", appToken: "__SLACK_APP__" } },
+    };
+    const warnings: SurfaceTokenWarning[] = [];
+    resolveAgentPresenceTokens(agent, "agents[0]", warnings);
+    const slack = (agent.presence as any).slack;
+    expect(slack.enabled).toBe(false);
+    // scrubbed sentinel still satisfies the `^xoxb-` schema regex (so the parse
+    // downstream does not choke), but is plainly not a real token + not a literal
+    expect(slack.botToken.startsWith("xoxb-")).toBe(true);
+    expect(ENV_PLACEHOLDER_PATTERN.test(slack.botToken)).toBe(false);
+    expect(warnings[0]?.platform).toBe("slack");
+  });
+
+  test("one disabled surface does not affect a sibling resolvable surface", () => {
+    delete process.env.VEGA_BOT_TOKEN;
+    process.env.MM_API_TOKEN = "mm-real";
+    const agent: Record<string, unknown> = {
+      id: "vega",
+      presence: {
+        discord: { enabled: true, token: "__VEGA_BOT_TOKEN__" },
+        mattermost: { enabled: true, apiToken: "__MM_API_TOKEN__" },
+      },
+    };
+    const warnings: SurfaceTokenWarning[] = [];
+    resolveAgentPresenceTokens(agent, "agents[0]", warnings);
+    // discord disabled, mattermost still live + resolved
+    expect((agent.presence as any).discord.enabled).toBe(false);
+    expect((agent.presence as any).mattermost.enabled).toBe(true);
+    expect((agent.presence as any).mattermost.apiToken).toBe("mm-real");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.platform).toBe("discord");
+  });
+});
+
 describe("resolveSurfaceTokensInRawConfig", () => {
   test("walks agents[] and resolves each presence token", () => {
     process.env.VEGA_BOT_TOKEN = "real-vega";
     const raw: Record<string, unknown> = {
       agents: [
-        { id: "vega", presence: { discord: { token: "__VEGA_BOT_TOKEN__" } } },
-        { id: "luna", presence: { discord: { token: "inline-luna" } } },
+        { id: "vega", presence: { discord: { enabled: true, token: "__VEGA_BOT_TOKEN__" } } },
+        { id: "luna", presence: { discord: { enabled: true, token: "inline-luna" } } },
       ],
     };
     resolveSurfaceTokensInRawConfig(raw);
     expect((raw.agents as any)[0].presence.discord.token).toBe("real-vega");
     expect((raw.agents as any)[1].presence.discord.token).toBe("inline-luna");
+  });
+
+  test("one agent's unset env disables only THAT agent's surface; others untouched", () => {
+    delete process.env.VEGA_BOT_TOKEN;
+    const raw: Record<string, unknown> = {
+      agents: [
+        { id: "vega", presence: { discord: { enabled: true, token: "__VEGA_BOT_TOKEN__" } } },
+        { id: "luna", presence: { discord: { enabled: true, token: "inline-luna" } } },
+      ],
+    };
+    const warnings: SurfaceTokenWarning[] = [];
+    resolveSurfaceTokensInRawConfig(raw, warnings);
+    expect((raw.agents as any)[0].presence.discord.enabled).toBe(false);
+    expect((raw.agents as any)[1].presence.discord.enabled).toBe(true);
+    expect((raw.agents as any)[1].presence.discord.token).toBe("inline-luna");
+    expect(warnings.map((w) => w.agent)).toEqual(["vega"]);
   });
 
   test("no agents[] (legacy bot.yaml shape) → no-op", () => {
@@ -167,13 +253,15 @@ describe("loader integration — inline cortex.yaml agents[]", () => {
   let personaPath: string;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "c1209-inline-"));
+    dir = mkdtempSync(join(tmpdir(), "c1217-inline-"));
     personaPath = join(dir, "persona.md");
     writeFileSync(personaPath, "# persona\n");
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-  function writeCortexYaml(token: string): string {
+  // Two agents so we can assert the rest of the config still loads when one
+  // agent's surface token is missing (cortex#1217 blast-radius containment).
+  function writeCortexYaml(vegaToken: string): string {
     const cfgPath = join(dir, "cortex.yaml");
     const yaml = `
 principal:
@@ -187,10 +275,20 @@ agents:
     presence:
       discord:
         enabled: true
-        token: ${token}
+        token: ${vegaToken}
         guildId: "111"
         agentChannelId: "222"
         logChannelId: "333"
+  - id: luna
+    displayName: Luna
+    persona: ${personaPath}
+    presence:
+      discord:
+        enabled: true
+        token: inline-luna-token
+        guildId: "444"
+        agentChannelId: "555"
+        logChannelId: "666"
 `;
     writeFileSync(cfgPath, yaml);
     chmodSync(cfgPath, 0o600);
@@ -201,22 +299,66 @@ agents:
     process.env.VEGA_BOT_TOKEN = "real-vega-secret";
     const cfgPath = writeCortexYaml("__VEGA_BOT_TOKEN__");
     const loaded = loadConfigWithAgents(cfgPath);
-    expect(loaded.inlineAgents[0]?.presence.discord?.token).toBe("real-vega-secret");
+    const vega = loaded.inlineAgents.find((a) => a.id === "vega");
+    expect(vega?.presence.discord?.token).toBe("real-vega-secret");
+    expect(vega?.presence.discord?.enabled).toBe(true);
     // flattened legacy-shape array (what the adapter loop consumes) too
-    expect(loaded.config.discord[0]?.token).toBe("real-vega-secret");
+    const vegaInstance = loaded.config.discord.find((d) => d.token === "real-vega-secret");
+    expect(vegaInstance?.enabled).toBe(true);
+    expect(loaded.surfaceWarnings).toBeUndefined();
   });
 
-  test("placeholder + unset env → fatal error naming the var, never the literal", () => {
+  test("placeholder + UNSET env → surface disabled, NO throw, rest of stack loads", () => {
     delete process.env.VEGA_BOT_TOKEN;
     const cfgPath = writeCortexYaml("__VEGA_BOT_TOKEN__");
-    expect(() => loadConfigWithAgents(cfgPath)).toThrow(/VEGA_BOT_TOKEN/);
-    expect(() => loadConfigWithAgents(cfgPath)).toThrow(EnvPlaceholderError);
+    // The whole load must NOT throw (cortex#1217 — this is the crash-loop fix).
+    const loaded = loadConfigWithAgents(cfgPath);
+
+    // vega's discord surface is disabled + scrubbed (never the literal).
+    const vega = loaded.inlineAgents.find((a) => a.id === "vega");
+    expect(vega?.presence.discord?.enabled).toBe(false);
+    expect(vega?.presence.discord?.token).not.toBe("__VEGA_BOT_TOKEN__");
+    expect(ENV_PLACEHOLDER_PATTERN.test(vega?.presence.discord?.token ?? "")).toBe(false);
+
+    // luna (and the rest of the config) loaded normally.
+    const luna = loaded.inlineAgents.find((a) => a.id === "luna");
+    expect(luna?.presence.discord?.enabled).toBe(true);
+    expect(luna?.presence.discord?.token).toBe("inline-luna-token");
+
+    // bubbled up once, naming the agent + env var.
+    expect(loaded.surfaceWarnings).toHaveLength(1);
+    expect(loaded.surfaceWarnings?.[0]).toMatchObject({
+      agent: "vega",
+      platform: "discord",
+      envVar: "VEGA_BOT_TOKEN",
+    });
+  });
+
+  test("NO fail-open: the disabled surface is skipped by the adapter loop (enabled:false)", () => {
+    delete process.env.VEGA_BOT_TOKEN;
+    const cfgPath = writeCortexYaml("__VEGA_BOT_TOKEN__");
+    const loaded = loadConfigWithAgents(cfgPath);
+    // The flattened legacy-shape array (`config.discord`) is exactly what the
+    // boot-time adapter loop iterates, skipping every `enabled === false`
+    // instance before it ever constructs a DiscordAdapter / calls connect().
+    // Assert vega's flattened instance is present-but-disabled and carries no
+    // literal placeholder.
+    const vegaInstance = loaded.config.discord.find((d) => d.guildId === "111");
+    expect(vegaInstance).toBeDefined();
+    expect(vegaInstance?.enabled).toBe(false);
+    expect(ENV_PLACEHOLDER_PATTERN.test(vegaInstance?.token ?? "")).toBe(false);
+    // luna's live instance is untouched.
+    const lunaInstance = loaded.config.discord.find((d) => d.guildId === "444");
+    expect(lunaInstance?.enabled).toBe(true);
   });
 
   test("inline token → unchanged", () => {
     const cfgPath = writeCortexYaml("inline-discord-token-xyz");
     const loaded = loadConfigWithAgents(cfgPath);
-    expect(loaded.inlineAgents[0]?.presence.discord?.token).toBe("inline-discord-token-xyz");
+    const vega = loaded.inlineAgents.find((a) => a.id === "vega");
+    expect(vega?.presence.discord?.token).toBe("inline-discord-token-xyz");
+    expect(vega?.presence.discord?.enabled).toBe(true);
+    expect(loaded.surfaceWarnings).toBeUndefined();
   });
 });
 
@@ -225,7 +367,7 @@ describe("loader integration — agents.d/ fragment (Pier path)", () => {
   let personaPath: string;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "c1209-frag-"));
+    dir = mkdtempSync(join(tmpdir(), "c1217-frag-"));
     personaPath = join(dir, "persona.md");
     writeFileSync(personaPath, "# pier\n");
   });
@@ -255,36 +397,31 @@ presence:
     const fragPath = writePierFragment("__PIER_BOT_TOKEN__");
     const agent = loadAgentFromFile(fragPath, dir);
     expect(agent?.presence.discord?.token).toBe("real-pier-secret");
+    expect(agent?.presence.discord?.enabled).toBe(true);
   });
 
-  test("Pier fragment placeholder + unset env → fatal, env-var-named", () => {
+  test("Pier fragment placeholder + unset env → loads with discord DISABLED (no throw)", () => {
     delete process.env.PIER_BOT_TOKEN;
     const fragPath = writePierFragment("__PIER_BOT_TOKEN__");
-    expect(() => loadAgentFromFile(fragPath, dir)).toThrow(/PIER_BOT_TOKEN/);
+    // cortex#1217 — the fragment loader must NOT throw; the agent loads with its
+    // discord surface disabled rather than aborting the whole agents.d/ load.
+    const agent = loadAgentFromFile(fragPath, dir);
+    expect(agent).not.toBeNull();
+    expect(agent?.presence.discord?.enabled).toBe(false);
+    expect(agent?.presence.discord?.token).not.toBe("__PIER_BOT_TOKEN__");
+    expect(ENV_PLACEHOLDER_PATTERN.test(agent?.presence.discord?.token ?? "")).toBe(false);
   });
 
   test("inline fragment token → unchanged", () => {
     const fragPath = writePierFragment("inline-pier-token");
     const agent = loadAgentFromFile(fragPath, dir);
     expect(agent?.presence.discord?.token).toBe("inline-pier-token");
+    expect(agent?.presence.discord?.enabled).toBe(true);
   });
 });
 
 // ===========================================================================
-// cortex#1209 review — whitespace-only env (nit 1)
-// ===========================================================================
-describe("fail-closed on whitespace-only env (nit 1)", () => {
-  test("env var set to '   ' is treated as unset → fatal", () => {
-    process.env.VEGA_BOT_TOKEN = "   ";
-    const agent: Record<string, unknown> = {
-      presence: { discord: { token: "__VEGA_BOT_TOKEN__" } },
-    };
-    expect(() => resolveAgentPresenceTokens(agent, "agents[0]")).toThrow(EnvPlaceholderError);
-  });
-});
-
-// ===========================================================================
-// cortex#1209 review (MAJOR) — surfaces.yaml gateway-binding resolution
+// cortex#1209 review (MAJOR) + cortex#1217 — surfaces.yaml gateway bindings
 // ===========================================================================
 describe("resolveSurfaceBindingTokens — gateway binding map", () => {
   function surfacesWith(discordToken: string): Surfaces {
@@ -311,18 +448,40 @@ describe("resolveSurfaceBindingTokens — gateway binding map", () => {
     expect((surfaces.discord as any)[0].binding.token).toBe("real-gw-token");
   });
 
-  test("fail-closed: unset env → EnvPlaceholderError naming the var (not the literal)", () => {
+  test("fail SOFT: unset env → the binding ENTRY is dropped (gateway never builds it)", () => {
     delete process.env.GW_DISCORD_TOKEN;
     const surfaces = surfacesWith("__GW_DISCORD_TOKEN__");
-    let err: unknown;
-    try {
-      resolveSurfaceBindingTokens(surfaces);
-    } catch (e) {
-      err = e;
-    }
-    expect(err).toBeInstanceOf(EnvPlaceholderError);
-    expect((err as EnvPlaceholderError).envVar).toBe("GW_DISCORD_TOKEN");
-    expect((err as Error).message).toContain("surfaces.discord[0].binding.token");
+    const warnings: SurfaceTokenWarning[] = [];
+    expect(() => resolveSurfaceBindingTokens(surfaces, warnings)).not.toThrow();
+    // the unresolvable entry is gone — no literal can reach buildGatewayAdapters
+    expect(surfaces.discord).toHaveLength(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      agent: "vega",
+      platform: "discord",
+      envVar: "GW_DISCORD_TOKEN",
+      fieldPath: "surfaces.discord[0].binding.token",
+    });
+  });
+
+  test("fail SOFT drops ONLY the unresolvable entry; resolvable siblings survive", () => {
+    delete process.env.GW_DISCORD_TOKEN;
+    const surfaces = {
+      discord: [
+        {
+          agent: "vega",
+          binding: { token: "__GW_DISCORD_TOKEN__", guildId: "1", agentChannelId: "2", logChannelId: "3" },
+        },
+        {
+          agent: "luna",
+          binding: { token: "inline-live-token", guildId: "4", agentChannelId: "5", logChannelId: "6" },
+        },
+      ],
+    } as unknown as Surfaces;
+    resolveSurfaceBindingTokens(surfaces);
+    expect(surfaces.discord).toHaveLength(1);
+    expect((surfaces.discord as any)[0].agent).toBe("luna");
+    expect((surfaces.discord as any)[0].binding.token).toBe("inline-live-token");
   });
 
   test("inline binding token → unchanged", () => {
@@ -351,15 +510,40 @@ describe("resolveSurfaceBindingTokens — gateway binding map", () => {
     expect((surfaces.slack as any)[0].binding.appToken).toBe("xapp-real");
     expect((surfaces.mattermost as any)[0].binding.apiToken).toBe("mm-real");
   });
+
+  test("fail SOFT: a missing slack botToken drops the slack binding", () => {
+    delete process.env.SLACK_BOT;
+    process.env.SLACK_APP = "xapp-real";
+    const surfaces = {
+      slack: [
+        {
+          agent: "sage",
+          binding: { botToken: "__SLACK_BOT__", appToken: "__SLACK_APP__", workspaceId: "T0123456789" },
+        },
+      ],
+    } as unknown as Surfaces;
+    const warnings: SurfaceTokenWarning[] = [];
+    resolveSurfaceBindingTokens(surfaces, warnings);
+    expect(surfaces.slack).toHaveLength(0);
+    expect(warnings[0]?.platform).toBe("slack");
+    expect(warnings[0]?.envVar).toBe("SLACK_BOT");
+  });
 });
 
-describe("assertNoUnresolvedPlaceholder (belt-and-suspenders)", () => {
+describe("assertNoUnresolvedPlaceholder (belt-and-suspenders, retained strict path)", () => {
   test("throws naming the env var on a literal placeholder", () => {
     expect(() => assertNoUnresolvedPlaceholder("__GW_DISCORD_TOKEN__", "x")).toThrow(/GW_DISCORD_TOKEN/);
+  });
+  test("the thrown type is still EnvPlaceholderError", () => {
+    expect(() => assertNoUnresolvedPlaceholder("__GW_DISCORD_TOKEN__", "x")).toThrow(EnvPlaceholderError);
   });
   test("passes a resolved / inline value", () => {
     expect(() => assertNoUnresolvedPlaceholder("real-token", "x")).not.toThrow();
     expect(() => assertNoUnresolvedPlaceholder(undefined, "x")).not.toThrow();
+  });
+  test("passes a disabled-surface scrub sentinel (it is not a placeholder)", () => {
+    expect(() => assertNoUnresolvedPlaceholder("xoxb-DISABLED-SLACK_BOT", "x")).not.toThrow();
+    expect(() => assertNoUnresolvedPlaceholder("DISABLED-MISSING-SECRET-VEGA_BOT_TOKEN", "x")).not.toThrow();
   });
 });
 
@@ -371,7 +555,7 @@ describe("loader integration — surfaces.yaml directory layout (gateway path)",
   let dir: string;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "c1209-surfaces-"));
+    dir = mkdtempSync(join(tmpdir(), "c1217-surfaces-"));
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
@@ -422,10 +606,18 @@ describe("loader integration — surfaces.yaml directory layout (gateway path)",
     process.env.GW_DISCORD_TOKEN = "real-gw-secret";
     const loaded = loadConfigWithAgents(writeLayout("__GW_DISCORD_TOKEN__"));
     expect((loaded.surfaces?.discord as any)?.[0]?.binding.token).toBe("real-gw-secret");
+    expect(loaded.surfaceWarnings).toBeUndefined();
   });
 
-  test("placeholder in surfaces.yaml binding + unset env → fatal, env-var-named", () => {
+  test("placeholder in surfaces.yaml binding + unset env → binding dropped, NO throw", () => {
     delete process.env.GW_DISCORD_TOKEN;
-    expect(() => loadConfigWithAgents(writeLayout("__GW_DISCORD_TOKEN__"))).toThrow(/GW_DISCORD_TOKEN/);
+    const loaded = loadConfigWithAgents(writeLayout("__GW_DISCORD_TOKEN__"));
+    // the gateway map drops the unresolvable binding (no literal survives)
+    expect(loaded.surfaces?.discord ?? []).toHaveLength(0);
+    expect(loaded.surfaceWarnings).toHaveLength(1);
+    expect(loaded.surfaceWarnings?.[0]).toMatchObject({
+      platform: "discord",
+      envVar: "GW_DISCORD_TOKEN",
+    });
   });
 });

--- a/src/common/config/__tests__/resolve-env-placeholders.test.ts
+++ b/src/common/config/__tests__/resolve-env-placeholders.test.ts
@@ -34,7 +34,14 @@ import {
   type SurfaceTokenWarning,
 } from "../resolve-env-placeholders";
 import type { Surfaces } from "../../types/surfaces";
-import { loadConfigWithAgents, loadAgentFromFile } from "../loader";
+import {
+  loadConfigWithAgents,
+  loadAgentFromFile,
+  loadAgentsDirectory,
+  flattenDiscordPresences,
+  surfaceInstanceEnabled,
+} from "../loader";
+import type { Agent } from "../../types/cortex-config";
 
 // ---------------------------------------------------------------------------
 // env hygiene — snapshot + restore the env vars these tests poke so they never
@@ -619,5 +626,178 @@ describe("loader integration — surfaces.yaml directory layout (gateway path)",
       platform: "discord",
       envVar: "GW_DISCORD_TOKEN",
     });
+  });
+});
+
+// ===========================================================================
+// cortex#1217 review (MAJOR) — agents.d/ FRAGMENT disabled-surface warnings
+// must be COLLECTED into the sink (vega is a fragment), not only emitted to
+// stderr, so they reach the consolidated boot banner.
+// ===========================================================================
+describe("loadAgentsDirectory — fragment disabled-surface warnings reach the sink", () => {
+  let dir: string;
+  let agentsDir: string;
+  let personaPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "c1217-fragdir-"));
+    agentsDir = join(dir, "agents.d");
+    mkdirSync(agentsDir, { recursive: true });
+    personaPath = join(dir, "persona.md");
+    writeFileSync(personaPath, "# persona\n");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function writeFragment(id: string, token: string): void {
+    writeFileSync(
+      join(agentsDir, `${id}.yaml`),
+      `
+id: ${id}
+displayName: ${id}
+persona: ${personaPath}
+trust: []
+presence:
+  discord:
+    enabled: true
+    token: ${token}
+    guildId: "111"
+    agentChannelId: "222"
+    logChannelId: "333"
+`,
+    );
+  }
+
+  test("vega fragment with unset token → warning is COLLECTED (not just stderr) + surface disabled", () => {
+    delete process.env.VEGA_BOT_TOKEN;
+    writeFragment("vega", "__VEGA_BOT_TOKEN__");
+    // an enabled, inline-token sibling fragment that loads fine
+    writeFragment("luna", "inline-luna-token");
+
+    const warnings: SurfaceTokenWarning[] = [];
+    const agents = loadAgentsDirectory(agentsDir, warnings);
+
+    // both fragment agents still load (no throw, no aborted directory load)
+    expect(agents.map((a) => a.id).sort()).toEqual(["luna", "vega"]);
+    const vega = agents.find((a) => a.id === "vega");
+    expect(vega?.presence.discord?.enabled).toBe(false);
+
+    // the disabled-surface warning reached the sink → it can reach the banner
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      agent: "vega",
+      platform: "discord",
+      envVar: "VEGA_BOT_TOKEN",
+    });
+  });
+});
+
+// ===========================================================================
+// cortex#1217 review (NIT 2) — boot-loop no-fail-open lock.
+//
+// Reproduce the EXACT instance list + gate the boot path builds/uses
+// (`src/cortex.ts`: `discordInstances = [...config.discord,
+// ...flattenDiscordPresences(fragmentOnlyAgents)]`, then
+// `for (const instance of discordInstances) { if (!surfaceInstanceEnabled(...))
+// continue; new DiscordAdapter(...).start() }`). A `construct` spy stands in for
+// `new DiscordAdapter` / `.start()`/`connect()`. Asserts a fail-soft-disabled
+// surface is `continue`d past BEFORE construction — locking the guarantee at the
+// boot level, not just the resolver level.
+// ===========================================================================
+describe("boot adapter loop — disabled surface is skipped BEFORE construct/connect", () => {
+  let dir: string;
+  let agentsDir: string;
+  let personaPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "c1217-bootloop-"));
+    agentsDir = join(dir, "agents.d");
+    mkdirSync(agentsDir, { recursive: true });
+    personaPath = join(dir, "persona.md");
+    writeFileSync(personaPath, "# persona\n");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function writeInlineCortexYaml(): string {
+    const cfgPath = join(dir, "cortex.yaml");
+    // luna: inline token → enabled. vega: placeholder + (unset env) → disabled.
+    writeFileSync(
+      cfgPath,
+      `
+principal:
+  id: andreas
+claude:
+  timeoutMs: 120000
+agents:
+  - id: luna
+    displayName: Luna
+    persona: ${personaPath}
+    presence:
+      discord:
+        enabled: true
+        token: inline-luna-token
+        guildId: "444"
+        agentChannelId: "555"
+        logChannelId: "666"
+  - id: vega
+    displayName: Vega
+    persona: ${personaPath}
+    presence:
+      discord:
+        enabled: true
+        token: __VEGA_BOT_TOKEN__
+        guildId: "111"
+        agentChannelId: "222"
+        logChannelId: "333"
+`,
+    );
+    chmodSync(cfgPath, 0o600);
+    return cfgPath;
+  }
+
+  test("the gate skips every disabled instance before the adapter is constructed", () => {
+    delete process.env.VEGA_BOT_TOKEN;
+    const cfgPath = writeInlineCortexYaml();
+    const loaded = loadConfigWithAgents(cfgPath);
+
+    // Faithfully reconstruct the boot path's instance list (cortex.ts ~3634).
+    const inlineIds = new Set(loaded.inlineAgents.map((a) => a.id));
+    const fragmentOnlyAgents: Agent[] = loadAgentsDirectory(agentsDir).filter(
+      (a) => !inlineIds.has(a.id),
+    );
+    const discordInstances = [
+      ...loaded.config.discord,
+      ...flattenDiscordPresences(fragmentOnlyAgents),
+    ];
+
+    // `construct` stands in for `new DiscordAdapter(...).start()` (which would
+    // call `client.login(token)` → connect). It must NEVER run for a disabled
+    // instance, and must never receive a literal placeholder.
+    const constructed: { guildId: string; token: string }[] = [];
+    const connectAttempts: string[] = [];
+    for (const instance of discordInstances) {
+      // EXACT production gate (cortex.ts: `if (!surfaceInstanceEnabled(instance))`).
+      if (!surfaceInstanceEnabled(instance)) continue;
+      // Past the gate ⇒ the adapter would be constructed + login attempted.
+      constructed.push({ guildId: instance.guildId, token: instance.token });
+      connectAttempts.push(instance.token);
+    }
+
+    // luna (enabled) was constructed; vega (disabled) was skipped before construct.
+    expect(constructed.map((c) => c.guildId)).toEqual(["444"]);
+    expect(constructed.map((c) => c.token)).toEqual(["inline-luna-token"]);
+
+    // No connect attempt ever carried the literal placeholder OR vega's scrubbed
+    // sentinel — the disabled surface never reached connect at all.
+    expect(connectAttempts).not.toContain("__VEGA_BOT_TOKEN__");
+    for (const t of connectAttempts) {
+      expect(ENV_PLACEHOLDER_PATTERN.test(t)).toBe(false);
+    }
+
+    // Sanity: vega's instance IS present in the list but gated off (enabled:false)
+    // and carries no literal — proving the gate, not absence, is what protects it.
+    const vegaInstance = loaded.config.discord.find((d) => d.guildId === "111");
+    expect(vegaInstance?.enabled).toBe(false);
+    expect(surfaceInstanceEnabled(vegaInstance ?? { enabled: true })).toBe(false);
+    expect(ENV_PLACEHOLDER_PATTERN.test(vegaInstance?.token ?? "")).toBe(false);
   });
 });

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -30,6 +30,7 @@ import {
   resolveAgentPresenceTokens,
   resolveSurfaceBindingTokens,
   resolveSurfaceTokensInRawConfig,
+  type SurfaceTokenWarning,
 } from "./resolve-env-placeholders";
 
 /**
@@ -147,6 +148,18 @@ export interface LoadedConfig {
    * `undefined` for legacy bot.yaml input.
    */
   notify?: NotifyConfig;
+  /**
+   * cortex#1217 — surfaces disabled by fail-soft surface-token degradation. A
+   * surface secret placeholder (`presence.discord.token: __VEGA_BOT_TOKEN__`,
+   * the surfaces.yaml gateway bindings, …) whose env var is unset/empty no
+   * longer aborts the whole config load (which crash-looped the daemon and took
+   * the WHOLE stack offline) — that ONE surface is disabled + scrubbed, and the
+   * load continues. Each disabled surface is recorded here so the boot path can
+   * re-surface a consolidated principal-facing notification (the resolver
+   * already emits a per-surface stderr WARN at load time). Absent / empty when
+   * every surface token resolved.
+   */
+  surfaceWarnings?: SurfaceTokenWarning[];
 }
 
 /**
@@ -509,25 +522,33 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
   // the top-level `surfaces:` key (GW.a.3b.2a, cortex#524).
   const { raw, surfaces } = composeRawConfigWithSurfaces(expandedPath);
 
-  // cortex#1209 — resolve `__ENV__` placeholders in the surface secret fields
-  // (`agents[].presence.{discord.token, mattermost.apiToken, slack.botToken/
-  // appToken}`) from `process.env` BEFORE the schema parse. Runs here, after
-  // the deep-merge compose, so the resolved value reaches the flattened
-  // presence → adapter login, and so the Slack `^xoxb-`/`^xapp-` regexes in
-  // SlackPresenceSchema see a real token rather than a placeholder. A declared
-  // placeholder with an unset env var throws a fatal, env-var-named error
-  // (fail-closed) — the literal `__X__` never reaches an adapter. Inline tokens
-  // pass through byte-identical. Mutates `raw` in place (it is a freshly
-  // composed object — see `deepMerge`/single-file `parseYaml`).
-  resolveSurfaceTokensInRawConfig(raw);
+  // cortex#1209 / cortex#1217 — resolve `__ENV__` placeholders in the surface
+  // secret fields (`agents[].presence.{discord.token, mattermost.apiToken,
+  // slack.botToken/appToken}`) from `process.env` BEFORE the schema parse. Runs
+  // here, after the deep-merge compose, so the resolved value reaches the
+  // flattened presence → adapter login, and so the Slack `^xoxb-`/`^xapp-`
+  // regexes in SlackPresenceSchema see a real token rather than a placeholder.
+  //
+  // cortex#1217: a declared placeholder with an UNSET env var no longer throws
+  // (which FATAL-booted the daemon → launchd crash loop → whole stack offline).
+  // Instead that ONE surface is disabled (`presence.<platform>.enabled = false`)
+  // + the literal scrubbed, the load continues, and the miss is recorded in
+  // `surfaceWarnings` (the resolver also emits a per-surface stderr WARN). A
+  // resolved placeholder still resolves; an inline token is byte-identical.
+  // Mutates `raw` in place (it is a freshly composed object — see
+  // `deepMerge`/single-file `parseYaml`).
+  const surfaceWarnings: SurfaceTokenWarning[] = [];
+  resolveSurfaceTokensInRawConfig(raw, surfaceWarnings);
 
   // cortex#1209 review (MAJOR) — the captured `surfaces` binding map is a
   // SEPARATE pre-fold object threaded straight to the surface gateway
   // (`buildGatewayAdapters`), bypassing the `raw.agents[]` walk above. Resolve
   // its `binding.<token>` fields too so the `CORTEX_GATEWAY=1` path can never
-  // hand a literal `__X__` to Discord/Mattermost `connect()`. Same fail-closed
-  // contract; mutates the freshly-parsed `surfaces` object in place.
-  if (surfaces !== undefined) resolveSurfaceBindingTokens(surfaces);
+  // hand a literal `__X__` to Discord/Mattermost `connect()`. cortex#1217: an
+  // unresolvable binding ENTRY is dropped (the gateway has no per-binding
+  // enabled flag), recorded in the same `surfaceWarnings` sink. Mutates the
+  // freshly-parsed `surfaces` object in place.
+  if (surfaces !== undefined) resolveSurfaceBindingTokens(surfaces, surfaceWarnings);
 
   // Networks load against the on-disk path regardless of legacy/cortex shape —
   // both shapes share the same networks/ contract (G-500).
@@ -546,8 +567,20 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
   );
   const networks = loadNetworkFiles(networksDir, explicitNetworksDir);
 
+  // cortex#1217 — a surfaces.yaml binding is BOTH folded into the per-agent
+  // `presence` (so `resolveSurfaceTokensInRawConfig` disables it) AND resolved
+  // on the separately-captured gateway `surfaces` object (so
+  // `resolveSurfaceBindingTokens` drops it) — one missing env var therefore
+  // produces two records for the same root cause. Dedupe by agent+platform+var
+  // so the boot path bubbles each disabled surface up ONCE.
+  const dedupedWarnings = dedupeSurfaceWarnings(surfaceWarnings);
+
   if (isCortexShape(raw)) {
-    return loadCortexShape(raw, networks, surfaces);
+    const loaded = loadCortexShape(raw, networks, surfaces);
+    // Thread any fail-soft disabled-surface warnings through so the boot path
+    // can re-surface them. Only attach when non-empty (keeps the happy-path
+    // `LoadedConfig` byte-identical to pre-#1217).
+    return dedupedWarnings.length > 0 ? { ...loaded, surfaceWarnings: dedupedWarnings } : loaded;
   }
 
   // ---------------------------------------------------------------------
@@ -594,7 +627,29 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
   return {
     config: AgentConfigSchema.parse(merged),
     inlineAgents: [],
+    // cortex#1217 — legacy bot.yaml carries inline tokens (no agents[].presence
+    // walk), so this is normally empty; attach for shape-parity when non-empty.
+    ...(dedupedWarnings.length > 0 && { surfaceWarnings: dedupedWarnings }),
   };
+}
+
+/**
+ * cortex#1217 — collapse duplicate disabled-surface warnings (a surfaces.yaml
+ * binding is reported by both the folded-presence walk and the gateway-binding
+ * resolver) to one record per `agent|platform|envVar`, preserving first-seen
+ * order. The per-surface stderr WARN still fires at resolve time; this is the
+ * structured "bubble up once" list the boot path consumes.
+ */
+function dedupeSurfaceWarnings(warnings: SurfaceTokenWarning[]): SurfaceTokenWarning[] {
+  const seen = new Set<string>();
+  const out: SurfaceTokenWarning[] = [];
+  for (const w of warnings) {
+    const key = `${w.agent}|${w.platform}|${w.envVar}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(w);
+  }
+  return out;
 }
 
 /**

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -33,6 +33,8 @@ import {
   type SurfaceTokenWarning,
 } from "./resolve-env-placeholders";
 
+export type { SurfaceTokenWarning } from "./resolve-env-placeholders";
+
 /**
  * Hardening cap on a single fragment file's size. Echo M3 on cortex#62 —
  * unbounded readFileSync against an attacker- or accident-controlled file
@@ -640,7 +642,7 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
  * order. The per-surface stderr WARN still fires at resolve time; this is the
  * structured "bubble up once" list the boot path consumes.
  */
-function dedupeSurfaceWarnings(warnings: SurfaceTokenWarning[]): SurfaceTokenWarning[] {
+export function dedupeSurfaceWarnings(warnings: SurfaceTokenWarning[]): SurfaceTokenWarning[] {
   const seen = new Set<string>();
   const out: SurfaceTokenWarning[] = [];
   for (const w of warnings) {
@@ -993,6 +995,21 @@ export function flattenSlackPresences(agents: readonly Agent[]) {
   return out;
 }
 
+/**
+ * cortex#1217 — the boot adapter loop's "should this surface instance start?"
+ * gate, extracted so the no-fail-open guarantee is a SHARED, tested unit rather
+ * than three inline `!instance.enabled` checks. The per-platform
+ * adapter-construction loops in `src/cortex.ts` (discord / mattermost / slack)
+ * each `continue` past an instance for which this returns `false` BEFORE
+ * constructing the adapter or calling `connect()`. A surface disabled by
+ * fail-soft surface-token degradation (`resolveAgentPresenceTokens` →
+ * `enabled: false`) is carried through the presence-flatten, so this predicate
+ * is exactly what stops a missing-secret surface from ever opening a connection.
+ */
+export function surfaceInstanceEnabled(instance: { enabled: boolean }): boolean {
+  return instance.enabled;
+}
+
 // =============================================================================
 // F-2 — agents.d/ fragment loader
 // =============================================================================
@@ -1048,7 +1065,11 @@ export class FragmentLoadError extends Error {
  * this call (ENOENT race). The directory loader skips such files; single-file
  * callers translate `null` into a clear "file disappeared" error.
  */
-export function loadAgentFromFile(filePath: string, personaBaseDir: string): Agent | null {
+export function loadAgentFromFile(
+  filePath: string,
+  personaBaseDir: string,
+  warnings?: SurfaceTokenWarning[],
+): Agent | null {
   // Echo M3 — size guard before readFileSync.
   let size: number;
   try {
@@ -1115,7 +1136,11 @@ export function loadAgentFromFile(filePath: string, personaBaseDir: string): Age
   // resolution here. A pure raw record is required; non-object raw falls
   // straight to AgentSchema.parse which raises the principal-friendly error.
   if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
-    resolveAgentPresenceTokens(raw as Record<string, unknown>, filename);
+    // cortex#1217 — pass the warnings sink so a fragment agent's disabled
+    // surface (vega ships `presence.discord.token: __VEGA_BOT_TOKEN__` as an
+    // agents.d/ fragment) is COLLECTED, not just emitted to stderr — the boot
+    // path threads these into the consolidated disabled-surface banner.
+    resolveAgentPresenceTokens(raw as Record<string, unknown>, filename, warnings);
   }
 
   let agent: Agent;
@@ -1154,7 +1179,7 @@ export function loadAgentFromFile(filePath: string, personaBaseDir: string): Age
   return { ...agent, persona: personaPathResolved };
 }
 
-export function loadAgentsDirectory(dir: string): Agent[] {
+export function loadAgentsDirectory(dir: string, warnings?: SurfaceTokenWarning[]): Agent[] {
   const expandedDir = expandTilde(dir);
 
   if (!existsSync(expandedDir)) {
@@ -1168,7 +1193,9 @@ export function loadAgentsDirectory(dir: string): Agent[] {
 
   for (const filename of files) {
     const filePath = join(expandedDir, filename);
-    const agent = loadAgentFromFile(filePath, expandedDir);
+    // cortex#1217 — thread the sink so fragment-agent disabled-surface warnings
+    // reach the boot banner (deduped at the call site like the inline path).
+    const agent = loadAgentFromFile(filePath, expandedDir, warnings);
     if (agent === null) {
       // File vanished between readdir and read — skip silently.
       continue;

--- a/src/common/config/resolve-env-placeholders.ts
+++ b/src/common/config/resolve-env-placeholders.ts
@@ -1,5 +1,6 @@
 /**
- * cortex#1209 — `__ENV__` placeholder resolution for surface secret fields.
+ * cortex#1209 / cortex#1217 — `__ENV__` placeholder resolution for surface
+ * secret fields, with **fail-SOFT per-surface** degradation (cortex#1217).
  *
  * Bot-pack fragments declare a Discord/Slack/Mattermost surface token as a
  * placeholder (Pier ships `presence.discord.token: __PIER_BOT_TOKEN__`;
@@ -22,23 +23,60 @@
  *     `CORTEX_GATEWAY=1` path was leaking the literal placeholder to
  *     `connect()`).
  *
- * These are the surface secret fields per the issue. The Slack tokens MUST be
- * resolved on the RAW object BEFORE the Zod parse, because
- * `SlackPresenceSchema` regex-constrains `botToken` to `^xoxb-` / `appToken`
- * to `^xapp-` — a placeholder would fail the regex if it reached the schema.
- * Discord/Mattermost have no such constraint, but resolving all four on the
- * raw object in one pass keeps the seam in a single place.
+ * The Slack tokens MUST be resolved on the RAW object BEFORE the Zod parse,
+ * because `SlackPresenceSchema` regex-constrains `botToken` to `^xoxb-` /
+ * `appToken` to `^xapp-` — a placeholder would fail the regex if it reached the
+ * schema. Discord/Mattermost have no such constraint, but resolving all four on
+ * the raw object in one pass keeps the seam in a single place.
  *
- * Fail-closed (matches the loader's existing idiom — schema/permission/
- * fragment errors all THROW at load): a declared placeholder whose env var is
- * unset/empty raises a fatal `EnvPlaceholderError` that NAMES the env var.
- * The literal `__X__` is NEVER passed through to an adapter (it would surface
- * as a confusing Discord/Slack auth failure far from the real cause).
+ * ── cortex#1217 — fail SOFT, do not throw ────────────────────────────────────
  *
- * Security: the resolved secret is NEVER logged; the error names the env var,
- * never its value; the value is never written back to disk (the caller mutates
- * the in-memory raw object only).
+ * The original #1209 resolver was fail-CLOSED: a declared placeholder whose env
+ * var was unset/empty threw a fatal `EnvPlaceholderError` that aborted the
+ * WHOLE config load. In production that turned one agent's missing surface token
+ * into a daemon FATAL-boot → launchd `KeepAlive` restart → FATAL again = a
+ * crash loop that took the ENTIRE stack offline (forge/luna/echo/vega), not
+ * just the agent with the missing secret. An `arc upgrade` that wiped a
+ * hand-added token bricked the meta-factory stack.
+ *
+ * The blast radius of one agent's missing surface token must be that ONE
+ * surface — never the stack. So the surface-token path now degrades instead of
+ * throwing: when a surface secret placeholder cannot be resolved we
+ *
+ *   1. DISABLE that one surface — `presence.<platform>.enabled = false` for the
+ *      per-agent path (the adapter loop in `src/cortex.ts` skips every
+ *      `enabled === false` instance, so the adapter is never constructed and
+ *      `connect()` is never called); the gateway-binding path has no per-binding
+ *      `enabled` flag, so the unresolvable binding ENTRY is dropped from the
+ *      `Surfaces` map (`buildGatewayAdapters` then never builds an adapter for
+ *      it).
+ *   2. SCRUB the literal — the offending token field is replaced with an inert,
+ *      clearly-non-credential sentinel that still satisfies the field's schema
+ *      (Discord/Mattermost: any non-empty string; Slack: the `xoxb-`/`xapp-`
+ *      prefix the regex requires). The literal `__X__` therefore NEVER survives
+ *      onto the parsed config and can never reach an adapter — defence in depth
+ *      on top of the `enabled:false` skip. (No fail-open: the sentinel is not a
+ *      real token, and the surface it belongs to is disabled anyway.)
+ *   3. BUBBLE UP ONCE — a clear principal-facing WARN to `process.stderr`
+ *      naming the agent + the env var + the fix (`arc secrets set <agent>
+ *      <VAR>`), plus a structured {@link SurfaceTokenWarning} collected into the
+ *      caller's sink so the boot path can re-surface it (NOT silent).
+ *
+ * A RESOLVED placeholder still resolves to its real value; an INLINE
+ * (non-placeholder) token passes through byte-identical — the backward-compat
+ * invariant is unchanged. Only the missing-env path changed from throw → soft.
+ *
+ * The strict `EnvPlaceholderError` + {@link assertNoUnresolvedPlaceholder} are
+ * retained: the gateway's belt-and-suspenders assertion still guards against a
+ * literal reaching `connect()` on any FUTURE path that forgets to resolve, and
+ * any non-surface secret that legitimately needs fail-closed can keep throwing.
+ *
+ * Security: the resolved secret is NEVER logged; warnings name the env var,
+ * never its value; nothing is written back to disk (callers mutate the
+ * in-memory raw object only).
  */
+import { isPlainObject } from "../types/object-guards";
+import type { Surfaces } from "../types/surfaces";
 
 /**
  * A surface secret field whose VALUE is exactly `__SOME_ENV_VAR__` resolves to
@@ -47,16 +85,42 @@
  * through unchanged. The capture is `[A-Z0-9_]+` — conventional SCREAMING_CASE
  * env-var names (the Pier/vega precedent: `PIER_BOT_TOKEN`, `VEGA_BOT_TOKEN`).
  */
-import { isPlainObject } from "../types/object-guards";
-import type { Surfaces } from "../types/surfaces";
-
 export const ENV_PLACEHOLDER_PATTERN = /^__([A-Z0-9_]+)__$/;
 
 /**
- * Fatal error raised when a declared placeholder's environment variable is
- * unset or empty. Carries the offending env-var name + the config field path
- * so the boot path / principal sees exactly which variable to set, WITHOUT the
- * resolved value ever appearing in the message.
+ * The platform a disabled surface belongs to — carried on a
+ * {@link SurfaceTokenWarning} so the boot path can name the surface.
+ */
+export type SurfacePlatform = "discord" | "mattermost" | "slack";
+
+/**
+ * Structured record of a surface disabled by cortex#1217 fail-soft degradation.
+ * The boot path collects these (via the `warnings` sink) so it can re-surface a
+ * consolidated principal-facing notification beyond the per-field stderr WARN.
+ * Carries the env-var NAME, never its value.
+ */
+export interface SurfaceTokenWarning {
+  /** Agent id whose surface was disabled (or the binding's `agent` field). */
+  agent: string;
+  /** Which platform surface was disabled. */
+  platform: SurfacePlatform;
+  /** The unset/empty env var that the placeholder referenced. */
+  envVar: string;
+  /** The config field path of the offending token (for the principal). */
+  fieldPath: string;
+}
+
+/**
+ * Fatal error raised by the STRICT resolution path (retained for the
+ * belt-and-suspenders {@link assertNoUnresolvedPlaceholder} guard and for any
+ * non-surface secret that legitimately needs fail-closed). The surface-token
+ * load path NO LONGER throws this (cortex#1217 — it fails soft); the error type
+ * survives because the gateway-adapters assertion still uses it to guarantee a
+ * literal `__X__` can never reach `connect()` on a future un-resolved path.
+ *
+ * Carries the offending env-var name + the config field path so the boot path
+ * sees exactly which variable to set, WITHOUT the resolved value ever appearing
+ * in the message.
  */
 export class EnvPlaceholderError extends Error {
   public readonly envVar: string;
@@ -77,34 +141,12 @@ export class EnvPlaceholderError extends Error {
 }
 
 /**
- * Resolve a single scalar value. A non-string, or a string that is NOT a pure
- * `__ENV__` placeholder, is returned byte-identical (the backward-compat
- * invariant — inline tokens are untouched). A pure placeholder is resolved
- * from `process.env`; an unset / empty / whitespace-only env var throws
- * `EnvPlaceholderError` (a whitespace-only value would otherwise reach
- * `connect()` as a garbage token — cortex#1209 review nit 1).
- */
-function resolveScalar(value: unknown, fieldPath: string): unknown {
-  if (typeof value !== "string") return value;
-  // The capture group is `string | undefined`; an absent match (inline literal)
-  // OR an unexpectedly-empty capture both pass through unchanged. The undefined
-  // guard narrows `envVar` to `string` without a type assertion (the project
-  // lint forbids both `as` and `!` here).
-  const envVar = ENV_PLACEHOLDER_PATTERN.exec(value)?.[1];
-  if (envVar === undefined) return value; // inline literal — passthrough
-  const resolved = process.env[envVar];
-  if (resolved === undefined || resolved.trim() === "") {
-    throw new EnvPlaceholderError(envVar, fieldPath);
-  }
-  return resolved;
-}
-
-/**
  * Defence-in-depth assertion (cortex#1209 review — belt-and-suspenders). Throws
  * `EnvPlaceholderError` if `value` is STILL an unresolved `__ENV__` placeholder
  * at the point a token is about to be handed to an adapter. Every load path is
- * supposed to have resolved placeholders already; this guards against a future
- * path that forgets to, so a literal `__X__` can never reach `connect()`.
+ * supposed to have resolved (or, post-#1217, disabled+scrubbed) placeholders
+ * already; this guards against a future path that forgets to, so a literal
+ * `__X__` can never reach `connect()`.
  */
 export function assertNoUnresolvedPlaceholder(value: unknown, fieldPath: string): void {
   if (typeof value !== "string") return;
@@ -114,69 +156,184 @@ export function assertNoUnresolvedPlaceholder(value: unknown, fieldPath: string)
 }
 
 /**
+ * The discriminated result of a SOFT scalar resolution. `passthrough` carries
+ * the value to write back (a non-string, an inline literal, or the resolved
+ * secret); `missing` names the env var that was unset/empty so the caller can
+ * disable + scrub + warn.
+ */
+type SoftResolve =
+  | { readonly kind: "passthrough"; readonly value: unknown }
+  | { readonly kind: "missing"; readonly envVar: string };
+
+/**
+ * Resolve a single scalar WITHOUT throwing. A non-string, or a string that is
+ * NOT a pure `__ENV__` placeholder, passes through byte-identical (the
+ * backward-compat invariant — inline tokens are untouched). A pure placeholder
+ * resolves from `process.env`; an unset / empty / whitespace-only env var
+ * yields `{ kind: "missing" }` (a whitespace-only value would otherwise reach
+ * `connect()` as a garbage token — cortex#1209 review nit 1).
+ */
+function resolveScalarSoft(value: unknown): SoftResolve {
+  if (typeof value !== "string") return { kind: "passthrough", value };
+  // The capture group is `string | undefined`; an absent match (inline literal)
+  // OR an unexpectedly-empty capture both pass through unchanged. The undefined
+  // guard narrows `envVar` to `string` without a type assertion (the project
+  // lint forbids both `as` and `!` here).
+  const envVar = ENV_PLACEHOLDER_PATTERN.exec(value)?.[1];
+  if (envVar === undefined) return { kind: "passthrough", value }; // inline literal
+  const resolved = process.env[envVar];
+  if (resolved === undefined || resolved.trim() === "") {
+    return { kind: "missing", envVar };
+  }
+  return { kind: "passthrough", value: resolved };
+}
+
+/**
+ * An inert, clearly-non-credential sentinel that REPLACES a surface token whose
+ * env var could not be resolved, so the literal `__X__` never survives onto the
+ * parsed config. It still satisfies the field's schema:
+ *   - Slack `botToken` requires `^xoxb-`, `appToken` requires `^xapp-`.
+ *   - Discord `token` (and Mattermost `apiToken`) only require a non-empty
+ *     string.
+ * The sentinel embeds the env-var name for debuggability and is never a real
+ * token; the surface it belongs to is `enabled:false`, so it is never used.
+ */
+function disabledSentinel(platform: SurfacePlatform, field: string, envVar: string): string {
+  if (platform === "slack" && field === "botToken") return `xoxb-DISABLED-${envVar}`;
+  if (platform === "slack" && field === "appToken") return `xapp-DISABLED-${envVar}`;
+  return `DISABLED-MISSING-SECRET-${envVar}`;
+}
+
+/**
+ * Emit the one principal-facing WARN for a disabled surface to `process.stderr`
+ * — the launchd-log channel where the cortex#1217 crash-loop incident was
+ * diagnosed. Names the agent, the env var, and the exact fix. Never the value.
+ */
+function emitSurfaceDisabledWarning(w: SurfaceTokenWarning): void {
+  process.stderr.write(
+    `cortex config WARN: ${w.platform} surface for agent "${w.agent}" DISABLED — ` +
+      `${w.fieldPath} declares placeholder __${w.envVar}__ but env var ${w.envVar} ` +
+      `is unset or empty. This ONE surface will not start; the rest of the stack ` +
+      `boots normally. Fix: \`arc secrets set ${w.agent} ${w.envVar}\` (then reinstall).\n`,
+  );
+}
+
+/**
+ * Resolve ONE token field on a per-agent presence block, failing soft. On a
+ * resolved/inline value it writes the value back. On a missing env var it
+ * disables the surface (`block.enabled = false`), scrubs the literal to an inert
+ * sentinel, and records + emits a warning. Mutates `block` in place.
+ */
+function softResolvePresenceField(
+  block: Record<string, unknown>,
+  field: string,
+  platform: SurfacePlatform,
+  agent: string,
+  fieldPath: string,
+  warnings: SurfaceTokenWarning[] | undefined,
+): void {
+  if (!(field in block)) return;
+  const res = resolveScalarSoft(block[field]);
+  if (res.kind === "passthrough") {
+    block[field] = res.value;
+    return;
+  }
+  // Missing env → fail soft: disable THIS surface + scrub the literal + warn.
+  block.enabled = false;
+  block[field] = disabledSentinel(platform, field, res.envVar);
+  const warning: SurfaceTokenWarning = { agent, platform, envVar: res.envVar, fieldPath };
+  emitSurfaceDisabledWarning(warning);
+  if (warnings !== undefined) warnings.push(warning);
+}
+
+/**
  * Resolve the surface secret tokens on a single agent-shaped raw object — one
  * that may carry `presence.{discord,mattermost,slack}`. Mutates the object in
- * place (the raw object is freshly parsed/cloned by the caller, so this is
- * safe and idempotent). `pathPrefix` labels the field in error messages
- * (e.g. `agents[0]` or a fragment filename).
+ * place (the raw object is freshly parsed/cloned by the caller, so this is safe
+ * and idempotent). `pathPrefix` labels the field in messages (e.g. `agents[0]`
+ * or a fragment filename); the agent id (when present on `agentLike`) labels
+ * the warning so `arc secrets set <agent> <VAR>` is actionable.
+ *
+ * cortex#1217: a missing env var DISABLES that surface (+ scrubs + warns)
+ * instead of throwing. `warnings` is the optional collection sink.
  */
 export function resolveAgentPresenceTokens(
   agentLike: Record<string, unknown>,
   pathPrefix: string,
+  warnings?: SurfaceTokenWarning[],
 ): void {
   const presence = agentLike.presence;
   if (!isPlainObject(presence)) return;
 
+  const agent =
+    typeof agentLike.id === "string" && agentLike.id.length > 0 ? agentLike.id : pathPrefix;
+
   const discord = presence.discord;
-  if (isPlainObject(discord) && "token" in discord) {
-    discord.token = resolveScalar(
-      discord.token,
+  if (isPlainObject(discord)) {
+    softResolvePresenceField(
+      discord,
+      "token",
+      "discord",
+      agent,
       `${pathPrefix}.presence.discord.token`,
+      warnings,
     );
   }
 
   const mattermost = presence.mattermost;
-  if (isPlainObject(mattermost) && "apiToken" in mattermost) {
-    mattermost.apiToken = resolveScalar(
-      mattermost.apiToken,
+  if (isPlainObject(mattermost)) {
+    softResolvePresenceField(
+      mattermost,
+      "apiToken",
+      "mattermost",
+      agent,
       `${pathPrefix}.presence.mattermost.apiToken`,
+      warnings,
     );
   }
 
   const slack = presence.slack;
   if (isPlainObject(slack)) {
-    if ("botToken" in slack) {
-      slack.botToken = resolveScalar(
-        slack.botToken,
-        `${pathPrefix}.presence.slack.botToken`,
-      );
-    }
-    if ("appToken" in slack) {
-      slack.appToken = resolveScalar(
-        slack.appToken,
-        `${pathPrefix}.presence.slack.appToken`,
-      );
-    }
+    softResolvePresenceField(
+      slack,
+      "botToken",
+      "slack",
+      agent,
+      `${pathPrefix}.presence.slack.botToken`,
+      warnings,
+    );
+    softResolvePresenceField(
+      slack,
+      "appToken",
+      "slack",
+      agent,
+      `${pathPrefix}.presence.slack.appToken`,
+      warnings,
+    );
   }
 }
 
 /**
  * Post-compose pass over a whole raw config object (the deep-merged result of
  * `composeRawConfig`). Walks the cortex-shape `agents[]` array and resolves
- * each agent's surface secret tokens. Mutates `raw` in place.
+ * each agent's surface secret tokens (cortex#1217 fail-soft). Mutates `raw` in
+ * place; appends any disabled-surface warnings to `warnings`.
  *
  * Legacy bot.yaml-shape configs (flat top-level `discord:[]` / `mattermost:[]`,
  * no `presence` nesting) carry inline tokens only and are unaffected — they
  * have no `agents[].presence` to walk. agents.d/ fragments are resolved
  * separately at `loadAgentFromFile` (they never pass through this composer).
  */
-export function resolveSurfaceTokensInRawConfig(raw: Record<string, unknown>): void {
+export function resolveSurfaceTokensInRawConfig(
+  raw: Record<string, unknown>,
+  warnings?: SurfaceTokenWarning[],
+): void {
   const agents = raw.agents;
   if (!Array.isArray(agents)) return;
   for (let i = 0; i < agents.length; i++) {
     const agent: unknown = agents[i];
     if (isPlainObject(agent)) {
-      resolveAgentPresenceTokens(agent, `agents[${i}]`);
+      resolveAgentPresenceTokens(agent, `agents[${i}]`, warnings);
     }
   }
 }
@@ -186,43 +343,85 @@ export function resolveSurfaceTokensInRawConfig(raw: Record<string, unknown>): v
  * of the `presence.{platform}` token fields above — the surfaces.yaml binding
  * map carries the SAME credentials in a `binding` sub-object.
  */
-const SURFACE_BINDING_TOKEN_FIELDS: { platform: keyof Surfaces; fields: readonly string[] }[] = [
+const SURFACE_BINDING_TOKEN_FIELDS: { platform: SurfacePlatform; fields: readonly string[] }[] = [
   { platform: "discord", fields: ["token"] },
   { platform: "slack", fields: ["botToken", "appToken"] },
   { platform: "mattermost", fields: ["apiToken"] },
 ];
 
 /**
- * cortex#1209 review (MAJOR) — resolve `__ENV__` placeholders in the
- * gateway-binding token fields of the SEPARATELY-captured `Surfaces` object.
+ * cortex#1209 review (MAJOR) + cortex#1217 — resolve `__ENV__` placeholders in
+ * the gateway-binding token fields of the SEPARATELY-captured `Surfaces` object,
+ * failing soft.
  *
  * `composeRawConfigWithSurfaces` captures + validates the `surfaces:` binding
  * map BEFORE `foldSurfaceBindings` folds it into `raw.agents[].presence`, then
  * threads that pre-resolution object through `LoadedConfig.surfaces` →
- * `startGatewayIfEnabled` → `buildGatewayAdapters`, which parses each
- * `binding` and constructs an adapter from it. `resolveSurfaceTokensInRawConfig`
- * only touches the folded `raw.agents[]` copy, so the gateway path would
- * otherwise hand the literal `__X__` to Discord/Mattermost `connect()`.
+ * `startGatewayIfEnabled` → `buildGatewayAdapters`, which parses each `binding`
+ * and constructs an adapter from it. `resolveSurfaceTokensInRawConfig` only
+ * touches the folded `raw.agents[]` copy, so the gateway path would otherwise
+ * hand the literal `__X__` to Discord/Mattermost `connect()`.
  *
- * Resolving here (same fail-closed `EnvPlaceholderError`, same trim check) on
- * the captured object closes the leak symmetrically. Mutates `surfaces` in
- * place — it is the fresh result of `SurfacesSchema.parse`, not aliased to raw.
+ * The gateway has NO per-binding `enabled` flag (it builds an adapter for every
+ * entry present), so the fail-soft disable mechanism here is to DROP the
+ * unresolvable binding entry from the `Surfaces[platform]` array — then
+ * `buildGatewayAdapters` simply never builds an adapter for it. A resolved /
+ * inline value is written back unchanged. Mutates `surfaces` in place (it is the
+ * fresh result of `SurfacesSchema.parse`, not aliased to raw); appends warnings.
  */
-export function resolveSurfaceBindingTokens(surfaces: Surfaces): void {
+export function resolveSurfaceBindingTokens(
+  surfaces: Surfaces,
+  warnings?: SurfaceTokenWarning[],
+): void {
   for (const { platform, fields } of SURFACE_BINDING_TOKEN_FIELDS) {
     const entries = surfaces[platform];
     if (!Array.isArray(entries)) continue;
+
+    const kept: unknown[] = [];
     for (let i = 0; i < entries.length; i++) {
-      const binding = (entries[i] as { binding?: unknown }).binding;
-      if (!isPlainObject(binding)) continue;
+      const entry: unknown = entries[i];
+      const binding = isPlainObject(entry) ? entry.binding : undefined;
+      if (!isPlainObject(binding)) {
+        kept.push(entry); // nothing to resolve — keep verbatim
+        continue;
+      }
+
+      let missingEnvVar: string | undefined;
+      let missingField: string | undefined;
       for (const field of fields) {
-        if (field in binding) {
-          binding[field] = resolveScalar(
-            binding[field],
-            `surfaces.${platform}[${i}].binding.${field}`,
-          );
+        if (!(field in binding)) continue;
+        const res = resolveScalarSoft(binding[field]);
+        if (res.kind === "passthrough") {
+          binding[field] = res.value;
+        } else {
+          missingEnvVar = res.envVar;
+          missingField = field;
+          break; // one missing token disables the whole binding entry
         }
       }
+
+      if (missingEnvVar !== undefined && missingField !== undefined) {
+        // Fail soft: drop this binding entry so the gateway never builds it.
+        const agent =
+          isPlainObject(entry) && typeof entry.agent === "string" && entry.agent.length > 0
+            ? entry.agent
+            : `surfaces.${platform}[${i}]`;
+        const warning: SurfaceTokenWarning = {
+          agent,
+          platform,
+          envVar: missingEnvVar,
+          fieldPath: `surfaces.${platform}[${i}].binding.${missingField}`,
+        };
+        emitSurfaceDisabledWarning(warning);
+        if (warnings !== undefined) warnings.push(warning);
+        // entry NOT pushed to `kept` — it is dropped.
+      } else {
+        kept.push(entry);
+      }
     }
+
+    // Mutate the array in place (same reference threaded to LoadedConfig.surfaces).
+    entries.length = 0;
+    for (const e of kept) entries.push(e as never);
   }
 }

--- a/src/common/config/resolve-env-placeholders.ts
+++ b/src/common/config/resolve-env-placeholders.ts
@@ -377,14 +377,14 @@ export function resolveSurfaceBindingTokens(
     const entries = surfaces[platform];
     if (!Array.isArray(entries)) continue;
 
-    const kept: unknown[] = [];
+    // Indices of unresolvable binding entries, recorded as we scan, then spliced
+    // out (descending) after the scan. Splice mutates the typed array in place —
+    // the same reference threaded to `LoadedConfig.surfaces` — without any cast.
+    const dropIndices: number[] = [];
     for (let i = 0; i < entries.length; i++) {
       const entry: unknown = entries[i];
       const binding = isPlainObject(entry) ? entry.binding : undefined;
-      if (!isPlainObject(binding)) {
-        kept.push(entry); // nothing to resolve — keep verbatim
-        continue;
-      }
+      if (!isPlainObject(binding)) continue; // nothing to resolve — keep verbatim
 
       let missingEnvVar: string | undefined;
       let missingField: string | undefined;
@@ -401,7 +401,8 @@ export function resolveSurfaceBindingTokens(
       }
 
       if (missingEnvVar !== undefined && missingField !== undefined) {
-        // Fail soft: drop this binding entry so the gateway never builds it.
+        // Fail soft: mark this binding entry for drop so the gateway never
+        // builds it (there is no per-binding `enabled` flag to flip).
         const agent =
           isPlainObject(entry) && typeof entry.agent === "string" && entry.agent.length > 0
             ? entry.agent
@@ -414,14 +415,14 @@ export function resolveSurfaceBindingTokens(
         };
         emitSurfaceDisabledWarning(warning);
         if (warnings !== undefined) warnings.push(warning);
-        // entry NOT pushed to `kept` — it is dropped.
-      } else {
-        kept.push(entry);
+        dropIndices.push(i);
       }
     }
 
-    // Mutate the array in place (same reference threaded to LoadedConfig.surfaces).
-    entries.length = 0;
-    for (const e of kept) entries.push(e as never);
+    // Remove dropped entries back-to-front so earlier indices stay valid.
+    for (let j = dropIndices.length - 1; j >= 0; j--) {
+      const idx = dropIndices[j];
+      if (idx !== undefined) entries.splice(idx, 1);
+    }
   }
 }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -6555,8 +6555,23 @@ if (import.meta.main) {
       // exits the process non-zero instead of being swallowed as a "non-fatal"
       // unhandled rejection. The daemon must not survive a failed security gate.
       const handle = await bootOrDie(async () => {
-        const { config, inlineAgents, stack, policy, principal, bus, surfaces, reflexActivation, notify } =
+        const { config, inlineAgents, stack, policy, principal, bus, surfaces, reflexActivation, notify, surfaceWarnings } =
           loadConfigWithAgents(options.config);
+        // cortex#1217 — a surface secret placeholder with an unset env var no
+        // longer FATAL-boots the daemon (which crash-looped the whole stack).
+        // The resolver disabled that ONE surface + already emitted a per-surface
+        // stderr WARN; re-surface a consolidated, principal-facing boot banner so
+        // the disabled surfaces are not buried in the per-field lines. The daemon
+        // boots normally with every still-resolvable surface live.
+        if (surfaceWarnings !== undefined && surfaceWarnings.length > 0) {
+          const lines = surfaceWarnings
+            .map((w) => `  • ${w.platform} for agent "${w.agent}" — set ${w.envVar} (\`arc secrets set ${w.agent} ${w.envVar}\`)`)
+            .join("\n");
+          console.warn(
+            `cortex: ${surfaceWarnings.length} surface(s) DISABLED due to unresolved secret placeholders ` +
+              `(the stack booted; only these surfaces are degraded):\n${lines}`,
+          );
+        }
         return startCortex(config, {
           configPath: options.config,
           ...(inlineAgents.length > 0 && { inlineAgents }),

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -32,6 +32,9 @@ import {
   flattenDiscordPresences,
   flattenMattermostPresences,
   flattenSlackPresences,
+  surfaceInstanceEnabled,
+  dedupeSurfaceWarnings,
+  type SurfaceTokenWarning,
 } from "./common/config/loader";
 import {
   ConfigWatcher,
@@ -592,6 +595,17 @@ export interface StartCortexOptions {
    */
   surfaces?: Surfaces;
   /**
+   * cortex#1217 — disabled-surface warnings from the INLINE/gateway config
+   * load (`LoadedConfig.surfaceWarnings`). The boot path merges these with the
+   * agents.d/ FRAGMENT disabled-surface warnings (collected when this function
+   * loads `agents.d/`) and emits ONE consolidated, deduped principal-facing
+   * banner — so a fail-soft-disabled surface on a fragment agent (e.g. vega)
+   * bubbles UP, not only to stderr. Undefined/empty → no banner.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  surfaceWarnings?: SurfaceTokenWarning[];
+  /**
    * v2.0.0 cutover (cortex#297) — principal's platform-side ids surfaced
    * from `PrincipalConfigSchema` via `LoadedConfig.principal`. Replaces the
    * `AgentConfig.agent.operatorDiscordId/Mattermost/Slack` fields retired
@@ -1100,14 +1114,39 @@ export async function startCortex(
   const agentsDir = options.agentsDir
     ?? (options.configPath ? join(dirname(expandedConfigPath), "agents.d") : expandTilde("~/.config/cortex/agents.d/"));
   let fragmentAgents: Agent[] = [];
+  // cortex#1217 — collect fail-soft disabled-surface warnings from agents.d/
+  // fragments (vega ships its Discord token as a fragment placeholder). These
+  // are merged with the inline/gateway warnings from `options.surfaceWarnings`
+  // and surfaced in ONE consolidated boot banner below — so a disabled fragment
+  // surface bubbles UP, not only to stderr.
+  const fragmentSurfaceWarnings: SurfaceTokenWarning[] = [];
   try {
-    fragmentAgents = loadAgentsDirectory(agentsDir);
+    fragmentAgents = loadAgentsDirectory(agentsDir, fragmentSurfaceWarnings);
   } catch (err) {
     if (err instanceof FragmentLoadError) {
       console.error(`cortex: agents.d fragment load failed (non-fatal during AgentConfig migration): ${err.message}`);
     } else {
       throw err;
     }
+  }
+
+  // cortex#1217 — consolidated disabled-surface banner: inline/gateway warnings
+  // (from the config load) + agents.d/ fragment warnings, deduped per
+  // agent|platform|envVar so each disabled surface is reported ONCE. The
+  // per-surface stderr WARN already fired at resolve time; this is the
+  // principal-facing roll-up that names exactly what degraded and how to fix it.
+  const allSurfaceWarnings = dedupeSurfaceWarnings([
+    ...(options.surfaceWarnings ?? []),
+    ...fragmentSurfaceWarnings,
+  ]);
+  if (allSurfaceWarnings.length > 0) {
+    const lines = allSurfaceWarnings
+      .map((w) => `  • ${w.platform} for agent "${w.agent}" — set ${w.envVar} (\`arc secrets set ${w.agent} ${w.envVar}\`)`)
+      .join("\n");
+    console.warn(
+      `cortex: ${allSurfaceWarnings.length} surface(s) DISABLED due to unresolved secret placeholders ` +
+        `(the stack booted; only these surfaces are degraded):\n${lines}`,
+    );
   }
 
   // Merge: inline wins on id conflict (design §6.1). AgentConfig today carries
@@ -3647,7 +3686,9 @@ export async function startCortex(
   // three values are shared with the adapter loops below verbatim.
 
   for (const instance of discordInstances) {
-    if (!instance.enabled) {
+    // cortex#1217 — shared no-fail-open gate: a surface disabled by fail-soft
+    // token degradation is skipped here BEFORE `new DiscordAdapter` / login.
+    if (!surfaceInstanceEnabled(instance)) {
       console.log(`cortex: discord instance ${instance.instanceId ?? instance.guildId} disabled — skipping`);
       continue;
     }
@@ -3858,7 +3899,8 @@ export async function startCortex(
   }
 
   for (const instance of mattermostInstances) {
-    if (!instance.enabled) continue;
+    // cortex#1217 — shared no-fail-open gate (see discord loop).
+    if (!surfaceInstanceEnabled(instance)) continue;
     if (!instance.apiUrl || !instance.apiToken) {
       console.error(`cortex: mattermost instance ${instance.instanceId ?? "unnamed"} missing apiUrl/apiToken — skipping`);
       continue;
@@ -3959,7 +4001,8 @@ export async function startCortex(
   const startedSlack: StartedSlack[] = [];
 
   for (const instance of slackInstances) {
-    if (!instance.enabled) {
+    // cortex#1217 — shared no-fail-open gate (see discord loop).
+    if (!surfaceInstanceEnabled(instance)) {
       console.log(`cortex: slack instance ${instance.instanceId ?? instance.workspaceId} disabled — skipping`);
       continue;
     }
@@ -6559,20 +6602,11 @@ if (import.meta.main) {
           loadConfigWithAgents(options.config);
         // cortex#1217 — a surface secret placeholder with an unset env var no
         // longer FATAL-boots the daemon (which crash-looped the whole stack).
-        // The resolver disabled that ONE surface + already emitted a per-surface
-        // stderr WARN; re-surface a consolidated, principal-facing boot banner so
-        // the disabled surfaces are not buried in the per-field lines. The daemon
-        // boots normally with every still-resolvable surface live.
-        if (surfaceWarnings !== undefined && surfaceWarnings.length > 0) {
-          const lines = surfaceWarnings
-            .map((w) => `  • ${w.platform} for agent "${w.agent}" — set ${w.envVar} (\`arc secrets set ${w.agent} ${w.envVar}\`)`)
-            .join("\n");
-          console.warn(
-            `cortex: ${surfaceWarnings.length} surface(s) DISABLED due to unresolved secret placeholders ` +
-              `(the stack booted; only these surfaces are degraded):\n${lines}`,
-          );
-        }
+        // The resolver disabled that ONE surface; thread the inline/gateway
+        // warnings into startCortex, which merges them with the agents.d/
+        // fragment warnings it collects and emits ONE consolidated banner.
         return startCortex(config, {
+          ...(surfaceWarnings !== undefined && surfaceWarnings.length > 0 && { surfaceWarnings }),
           configPath: options.config,
           ...(inlineAgents.length > 0 && { inlineAgents }),
           ...(stack !== undefined && { stack }),


### PR DESCRIPTION
Closes #1217

## Problem (live incident)
The #1209/#1210 resolver was **fail-CLOSED**: a surface secret placeholder (`presence.discord.token: __VEGA_BOT_TOKEN__`) with an unset env var threw `EnvPlaceholderError` → aborted the whole config load → daemon FATAL-boot → launchd `KeepAlive` restart → FATAL again = a crash loop that took the **WHOLE stack** offline (forge/luna/echo/vega), not just the agent with the missing secret. An `arc upgrade` that wiped a hand-added `VEGA_BOT_TOKEN` bricked production.

## Fix — fail SOFT per-surface
When a surface secret placeholder can't be resolved, degrade that **one surface** instead of throwing.

### Disable mechanism (per surface type)
- **Per-agent presence** (`agents[].presence.{discord,mattermost,slack}` + `agents.d/` fragments): set `enabled = false` on the block **and scrub** the literal to an inert, schema-valid sentinel. The boot adapter loop (`src/cortex.ts`) already skips every `enabled === false` instance *before constructing the adapter*, so `connect()` is never called.
- **Gateway `surfaces:` bindings**: the gateway (`buildGatewayAdapters`) has no per-binding `enabled` flag, so the unresolvable binding **entry is dropped** from the `Surfaces` map — no adapter is built for it.

### Bubble-up path
- A per-surface **stderr WARN** at resolve time naming the agent + env var + fix (`arc secrets set <agent> <VAR>`) — the launchd-log channel where the incident was diagnosed.
- Structured `LoadedConfig.surfaceWarnings` (deduped per `agent|platform|envVar`), re-surfaced by the daemon boot path as a **consolidated banner**. Not silent.

### No fail-open (guarantees)
- `enabled:false` → the adapter is never constructed/started (control-flow proof, asserted via the flattened `config.discord` array the boot loop iterates).
- The literal `__X__` **never survives** onto the parsed config: per-agent it is scrubbed to an inert sentinel (Discord/Mattermost: `DISABLED-MISSING-SECRET-<VAR>`; Slack: `xoxb-`/`xapp-DISABLED-<VAR>` so the schema regex still passes); gateway it is dropped. A test asserts no value matching `ENV_PLACEHOLDER_PATTERN` ever reaches the flattened instance / `Surfaces`.

### Backward-compat
- A resolved placeholder still resolves to its real value; an inline (non-placeholder) token is byte-identical. Only the missing-env path changed (throw → soft).
- `EnvPlaceholderError` + `assertNoUnresolvedPlaceholder` are **retained** — the gateway-adapters belt-and-suspenders assert still guards `connect()`, and any non-surface secret that legitimately needs fail-closed can keep throwing.

## Files
- `src/common/config/resolve-env-placeholders.ts` — soft resolver (disable + scrub + warn; gateway drop); strict path retained.
- `src/common/config/loader.ts` — collect + dedupe warnings, surface on `LoadedConfig.surfaceWarnings`.
- `src/cortex.ts` — consolidated boot banner for disabled surfaces.
- `src/common/config/__tests__/resolve-env-placeholders.test.ts` — fail-soft coverage (unset → disabled + WARN + no throw + agent/rest still load; env set → resolves; inline unchanged; gateway drop; literal never reaches adapter).

## Gates
- `bunx tsc --noEmit` — clean
- `bunx eslint --quiet .` — clean
- `bash scripts/check-carveouts.sh` — PASS
- `bun test src/` — **7445 pass, 2 skip, 0 fail** (428 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)