### PR TITLE
chore: bump to v5.26.6

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.5"
+version: "5.26.6"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
#1218 (#1217): surface-token placeholder resolution fails SOFT — a missing secret disables just that one surface + bubbles up (banner), instead of a FATAL boot abort + whole-stack crash loop. The brick-prevention fix. Manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)