### PR TITLE
fix(federation): self-short-circuit + dedupe the surface-router dispatch-deny path (#1222)

### DIFF
--- a/src/bus/__tests__/surface-router-self-deny.test.ts
+++ b/src/bus/__tests__/surface-router-self-deny.test.ts
@@ -1,0 +1,330 @@
+/**
+ * cortex#1222 — surface-router DISPATCH-deny self-deny flood fix (#1214 follow-up).
+ *
+ * #1214 self-short-circuited the inbound federated-SUBSCRIBER path. The LIVE
+ * flood is the surface-router's `federated.subject_dispatch` gate
+ * (`emitFederationDenied`): the stack publishes its OWN presence onto
+ * `federated.{us}.{stack}.agent.heartbeat`; the router denies it
+ * (`peer_not_in_accept_list` / `unknown_network` — we are not our own peer) and
+ * audits it on EVERY tick. #1214 EXPLICITLY flagged this path as out-of-scope.
+ *
+ * Coverage (mirrors federated-subscriber-self-deny.test.ts):
+ *   1. OWN validly-signed heartbeat ⇒ NOT denied, NO audit, NOT routed to
+ *      adapters; the crypto bytes-check still RUNS (proven by test 2).
+ *   2. Spoofed self-DID (bad signature) ⇒ STILL denied + audited
+ *      (`chain_verify_failed`): the trust short-circuit is bytes-checked.
+ *   3. A genuinely-denied FOREIGN dispatch ⇒ STILL denied, audited at MOST once
+ *      per window (a 2nd identical denial is suppressed).
+ *   4. The principal-facing bubble-up fires exactly ONCE across repeats.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createUser } from "@nats-io/nkeys";
+import { signEnvelope } from "@the-metafactory/myelin/identity";
+import {
+  createSurfaceRouter,
+  type SurfaceAdapter,
+  type SurfaceDenialBubbleUp,
+} from "../surface-router";
+import { createAgentHeartbeatEvent, type AgentPresenceSource } from "../agent-network/builders";
+import type { Envelope } from "../myelin/envelope-validator";
+import type { MyelinRuntime } from "../myelin/runtime";
+import type { SystemEventSource } from "../system-events";
+import type {
+  PolicyFederated,
+  PolicyFederatedNetwork,
+} from "../../common/types/cortex-config";
+import { TrustResolver } from "../../common/agents/trust-resolver";
+import { AgentRegistry } from "../../common/agents/registry";
+import { AccessDeniedDeduper } from "../access-denied-dedup";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SYSTEM_SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+
+const STACK_IDENTITY = "did:mf:andreas-meta-factory";
+
+/** OUR OWN presence source — andreas/meta-factory (the receiving stack). */
+const SELF_SOURCE: AgentPresenceSource = {
+  principal: "andreas",
+  stack: "meta-factory",
+  instance: "local",
+};
+
+const SELF_SUBJECT = "federated.andreas.meta-factory.agent.heartbeat";
+const FOREIGN_SUBJECT = "federated.joel.research.agent.heartbeat";
+
+/** Generate an ed25519 NATS keypair; returns the NKey pub + raw base64 seed. */
+function generateEd25519KeyPair(): {
+  nkeyPub: string;
+  privateKeyBase64: string;
+} {
+  const kp = createUser();
+  const nkeyPub = kp.getPublicKey();
+  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
+  return { nkeyPub, privateKeyBase64: Buffer.from(rawSeed).toString("base64") };
+}
+
+/** An unsigned self-presence heartbeat (federated classification). */
+function selfHeartbeatBase(): Envelope {
+  return createAgentHeartbeatEvent({
+    source: SELF_SOURCE,
+    identity: {
+      nkey_public_key: "USELF",
+      agent_id: "luna",
+      assistant_name: "Luna",
+    },
+    scope: { principal: "andreas", stack: "meta-factory" },
+    sentAt: new Date("2026-06-25T09:00:00.000Z"),
+    classification: "federated",
+  });
+}
+
+/** A foreign heartbeat from joel (federated). */
+function foreignHeartbeat(): Envelope {
+  return createAgentHeartbeatEvent({
+    source: { principal: "joel", stack: "research", instance: "local" },
+    identity: {
+      nkey_public_key: "UPEER",
+      agent_id: "sage",
+      assistant_name: "Sage",
+    },
+    scope: { principal: "joel", stack: "research" },
+    sentAt: new Date("2026-06-25T09:00:00.000Z"),
+    classification: "federated",
+  });
+}
+
+/** Network where joel is NOT a peer (so joel is denied) but our own subtree is accepted. */
+function networkWithoutJoel(): PolicyFederatedNetwork {
+  return {
+    id: "metafactory",
+    leaf_node: "primary",
+    peers: [],
+    accept_subjects: ["federated.andreas.meta-factory.agent.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+function federatedPolicy(networks: PolicyFederatedNetwork[]): PolicyFederated {
+  return { networks };
+}
+
+function emptyTrustResolver(): TrustResolver {
+  return new TrustResolver(AgentRegistry.fromAgents([]));
+}
+
+// ---------------------------------------------------------------------------
+// Fake runtime + a recording adapter
+// ---------------------------------------------------------------------------
+
+interface FakeRuntime extends MyelinRuntime {
+  published: Envelope[];
+}
+
+function makeFakeRuntime(): FakeRuntime {
+  const published: Envelope[] = [];
+  return {
+    enabled: true,
+    published,
+    onEnvelope() {
+      return { unregister: () => {} };
+    },
+    publish: (env: Envelope) => {
+      published.push(env);
+      return Promise.resolve();
+    },
+    stop: () => Promise.resolve(),
+  };
+}
+
+/** A recording adapter matching ALL federated presence so we can assert routed/not-routed. */
+function recordingAdapter(): { adapter: SurfaceAdapter; rendered: Envelope[] } {
+  const rendered: Envelope[] = [];
+  const adapter: SurfaceAdapter = {
+    id: "recorder",
+    subjects: ["federated.>"],
+    render: (envelope: Envelope) => {
+      rendered.push(envelope);
+      return Promise.resolve();
+    },
+  };
+  return { adapter, rendered };
+}
+
+function deniedEnvelopes(runtime: FakeRuntime): Envelope[] {
+  return runtime.published.filter((e) => e.type === "system.access.denied");
+}
+
+// ---------------------------------------------------------------------------
+// 1 + 2. Self short-circuit (root fix) — bytes-checked
+// ---------------------------------------------------------------------------
+
+describe("cortex#1222 — surface-router self short-circuit", () => {
+  test("OWN validly-signed heartbeat ⇒ NOT denied, NO audit, NOT routed", async () => {
+    const { nkeyPub: stackNKeyPub, privateKeyBase64: stackSeed } =
+      generateEd25519KeyPair();
+    const runtime = makeFakeRuntime();
+    const { adapter, rendered } = recordingAdapter();
+    const router = createSurfaceRouter(runtime, {
+      systemEventSource: SYSTEM_SOURCE,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity: STACK_IDENTITY,
+      stackNKeyPub,
+    });
+    router.register(adapter);
+
+    // Sign the self heartbeat with the STACK key (own DID) — exactly how the
+    // runtime stamps an own-presence publish.
+    const signed = await signEnvelope(
+      selfHeartbeatBase() as unknown as Parameters<typeof signEnvelope>[0],
+      stackSeed,
+      STACK_IDENTITY,
+    );
+
+    await router.dispatch(signed, SELF_SUBJECT, "primary");
+
+    // The verified self-loopback is silently dropped: NOT routed to any
+    // adapter (the stack renders its own presence off `local.*`) …
+    expect(rendered.length).toBe(0);
+    // … and crucially NO system.access.denied flood.
+    expect(deniedEnvelopes(runtime).length).toBe(0);
+  });
+
+  test("spoofed self-DID with a BAD signature ⇒ STILL denied + audited (bytes-check runs)", async () => {
+    const { nkeyPub: stackNKeyPub, privateKeyBase64: stackSeed } =
+      generateEd25519KeyPair();
+    const runtime = makeFakeRuntime();
+    const { adapter, rendered } = recordingAdapter();
+    const router = createSurfaceRouter(runtime, {
+      systemEventSource: SYSTEM_SOURCE,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity: STACK_IDENTITY,
+      stackNKeyPub,
+    });
+    router.register(adapter);
+
+    const signed = await signEnvelope(
+      selfHeartbeatBase() as unknown as Parameters<typeof signEnvelope>[0],
+      stackSeed,
+      STACK_IDENTITY,
+    );
+    // TAMPER the signature — the stamp still CLAIMS our stack DID (so the trust
+    // short-circuit accepts it structurally) but the bytes no longer verify.
+    const signedEnv: Envelope = signed;
+    const chain = Array.isArray(signedEnv.signed_by) ? signedEnv.signed_by : [];
+    const firstStamp = chain[0];
+    if (firstStamp?.method !== "ed25519") {
+      throw new Error("test fixture: expected ed25519 stamp at index 0");
+    }
+    const tamperedSig = firstStamp.signature.startsWith("A")
+      ? "B" + firstStamp.signature.slice(1)
+      : "A" + firstStamp.signature.slice(1);
+    const tampered: Envelope = {
+      ...signedEnv,
+      signed_by: [{ ...firstStamp, signature: tamperedSig }],
+    };
+
+    await router.dispatch(tampered, SELF_SUBJECT, "primary");
+
+    // Forged self-DID: NOT routed, and AUDITED as a chain-verify failure — the
+    // crypto bytes-check ran (the trust short-circuit alone would have accepted).
+    expect(rendered.length).toBe(0);
+    const denied = deniedEnvelopes(runtime);
+    expect(denied.length).toBe(1);
+    expect((denied[0]!.payload as { reason: { kind: string } }).reason.kind).toBe(
+      "chain_verify_failed",
+    );
+  });
+
+  test("self-claim with NO verifier wired ⇒ dropped (no flood), bubbles up once", async () => {
+    const { privateKeyBase64: stackSeed } = generateEd25519KeyPair();
+    const runtime = makeFakeRuntime();
+    const { adapter, rendered } = recordingAdapter();
+    const bubbles: SurfaceDenialBubbleUp[] = [];
+    const router = createSurfaceRouter(runtime, {
+      systemEventSource: SYSTEM_SOURCE,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      // NO trustResolver / receivingAgentId — the no-verifier branch.
+      stackIdentity: STACK_IDENTITY,
+      onDenialBubbleUp: (info) => bubbles.push(info),
+    });
+    router.register(adapter);
+
+    const signed = await signEnvelope(
+      selfHeartbeatBase() as unknown as Parameters<typeof signEnvelope>[0],
+      stackSeed,
+      STACK_IDENTITY,
+    );
+
+    await router.dispatch(signed, SELF_SUBJECT, "primary");
+    await router.dispatch(signed, SELF_SUBJECT, "primary");
+
+    // Dropped (never routed), no deny audit flood, bubble-up fires once.
+    expect(rendered.length).toBe(0);
+    expect(deniedEnvelopes(runtime).length).toBe(0);
+    expect(bubbles.length).toBe(1);
+    expect(bubbles[0]?.identity.reason).toBe("self_loopback_unverifiable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3 + 4. Dedupe + bubble-up — a real foreign denial is still denied, once
+// ---------------------------------------------------------------------------
+
+describe("cortex#1222 — surface-router dedupe + bubble-up", () => {
+  test("FOREIGN non-peer denied EVERY tick ⇒ audited at MOST once per window", async () => {
+    const runtime = makeFakeRuntime();
+    const { adapter, rendered } = recordingAdapter();
+    const router = createSurfaceRouter(runtime, {
+      systemEventSource: SYSTEM_SOURCE,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      // Large window so back-to-back identical denials collapse to one.
+      denialDeduper: new AccessDeniedDeduper({ windowMs: 60_000 }),
+    });
+    router.register(adapter);
+
+    // joel is in no network's peers[] ⇒ peer_not_in_accept_list, every tick.
+    await router.dispatch(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    await router.dispatch(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    await router.dispatch(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+
+    // STILL denied (never routed) but audited only ONCE (no flood).
+    expect(rendered.length).toBe(0);
+    expect(deniedEnvelopes(runtime).length).toBe(1);
+  });
+
+  test("bubble-up fires exactly ONCE across repeated identical denials", async () => {
+    const runtime = makeFakeRuntime();
+    const bubbles: SurfaceDenialBubbleUp[] = [];
+    const router = createSurfaceRouter(runtime, {
+      systemEventSource: SYSTEM_SOURCE,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      denialDeduper: new AccessDeniedDeduper({ windowMs: 60_000 }),
+      onDenialBubbleUp: (info) => bubbles.push(info),
+    });
+
+    await router.dispatch(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    await router.dispatch(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+    await router.dispatch(foreignHeartbeat(), FOREIGN_SUBJECT, "primary");
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbles[0]?.identity.reason).toBe("peer_not_in_accept_list");
+  });
+});

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -54,6 +54,14 @@ import {
 } from "./myelin/envelope-validator";
 import type { MyelinRuntime } from "./myelin/runtime";
 import { matchesFilter, type PayloadFilter } from "./payload-filter";
+import { verifySignedByChain } from "./verify-signed-by-chain";
+import { emitSystemAccessDenied } from "./emit-system-access-denied";
+import {
+  AccessDeniedDeduper,
+  type DenialDecision,
+  type DenialIdentity,
+} from "./access-denied-dedup";
+import type { TrustResolver } from "../common/agents/trust-resolver";
 
 // =============================================================================
 // Public types
@@ -175,6 +183,77 @@ export interface SurfaceRouterOptions {
    * NOT relax this gate.
    */
   public?: PolicyPublic;
+
+  // ===========================================================================
+  // cortex#1222 — self short-circuit + dedupe on the federation DISPATCH-deny
+  // path. The #1214 follow-up: #1214 fixed the inbound federated-SUBSCRIBER
+  // path; THIS surface-router dispatch path was explicitly flagged out-of-scope
+  // there and is the live self-deny flood. The fields below mirror the
+  // `startFederatedAgentPresenceSubscriber` options EXACTLY (do not invent a
+  // different shape) so the two trust paths stay consistent.
+  // ===========================================================================
+  /**
+   * The receiving stack's OWN signing DID (`did:mf:<principal>-<stack>`, from
+   * `signer.principal`). When set, an inbound `federated.*` dispatch whose
+   * SOURCE stamp identity equals this DID is recognised as the stack's OWN
+   * presence looping back (it published onto `federated.{us}.{stack}.agent.>`
+   * so peers see it). The federation accept-list (TRUST) gate is SKIPPED for
+   * it — we are not our own peer, so the gate would otherwise deny + audit it
+   * every heartbeat tick (the #1222 flood). The crypto bytes-check (below)
+   * STILL runs, so a spoofed self-DID without our key is rejected. Matched off
+   * config — NOT the spoofable `envelope.source` / `payload` — exactly like
+   * #1214 / cortex#480.
+   */
+  stackIdentity?: string;
+  /**
+   * The receiving stack's signing NKey public key. Required (with
+   * `stackIdentity` + a `trustResolver`) for the self-claim crypto bytes-check:
+   * `verifySignedByChain` registers the stack as a Principal so the self-signed
+   * stamp verifies against the stack's own NKey. Without it the self-loopback
+   * can't be cryptographically confirmed and is dropped unverified (never
+   * rendered) — still no flood, but no positive verify either.
+   */
+  stackNKeyPub?: string;
+  /** Principal id (e.g. `andreas`) — threaded into `verifySignedByChain`'s crypto pass. */
+  principalId?: string;
+  /**
+   * Trust resolver backing the self-claim crypto bytes-check. When supplied
+   * (with `receivingAgentId`), a self-claimed federated dispatch is run through
+   * `verifySignedByChain` before it is trusted: a VERIFIED self-loopback is
+   * dropped silently (the stack renders its own presence off `local.*`); a
+   * spoofed self-DID whose bytes don't verify is STILL denied + audited. When
+   * `undefined`, a self-claim is dropped UNVERIFIED (stops the flood without a
+   * bytes-check — safe because the loopback is never rendered).
+   */
+  trustResolver?: TrustResolver;
+  /** Receiving agent id whose `trust:` list governs admitted signers (self-claim verify). */
+  receivingAgentId?: string;
+  /** Whether the self-claim verify runs ed25519 crypto verification. Default `true`. */
+  cryptoVerify?: boolean;
+  /** Posture-gated empty-chain rejection for the self-claim verify. Default `false`. */
+  rejectEmpty?: boolean;
+  /**
+   * cortex#1222 — windowed deduper for the `system.access.denied` audit emits
+   * on the federation dispatch-deny path. A TEST SEAM: production omits it and
+   * a fresh 60s-window deduper is created internally. Tests inject one with a
+   * large window to assert "audited at most once per window".
+   */
+  denialDeduper?: AccessDeniedDeduper;
+  /**
+   * cortex#1222 — principal-facing "bubble up" hook, invoked ONCE per distinct
+   * denial tuple. Default writes a clear WARN to `process.stderr`. A self-deny
+   * misconfig (or a genuinely-denied foreign peer) surfaces to the principal
+   * ONCE here rather than re-spamming the audit subject every tick.
+   */
+  onDenialBubbleUp?: (info: SurfaceDenialBubbleUp) => void;
+}
+
+/** cortex#1222 — payload handed to {@link SurfaceRouterOptions.onDenialBubbleUp}. */
+export interface SurfaceDenialBubbleUp {
+  /** The denied tuple (capability/subject/reason/source). */
+  identity: DenialIdentity;
+  /** Human-readable one-line summary (already includes a remediation hint). */
+  message: string;
 }
 
 export interface SurfaceRouter {
@@ -312,6 +391,61 @@ export function createSurfaceRouter(
   // opted into public; the gate drops all inbound `public.*`.
   const policyPublic: PolicyPublic | undefined = opts?.public;
 
+  // === cortex#1222 — self short-circuit + dedupe inputs (mirror #1214) =======
+  const stackIdentity = opts?.stackIdentity;
+  const stackNKeyPub = opts?.stackNKeyPub;
+  const principalId = opts?.principalId;
+  const trustResolver = opts?.trustResolver;
+  const receivingAgentId = opts?.receivingAgentId;
+  const cryptoVerify = opts?.cryptoVerify ?? true;
+  const signingRejectEmpty = opts?.rejectEmpty ?? false;
+  // Dedupe the `system.access.denied` audit emits on the federation
+  // dispatch-deny path. Default: a fresh 60s-window deduper; tests inject one.
+  const denialDeduper = opts?.denialDeduper ?? new AccessDeniedDeduper();
+  // Principal-facing bubble-up. Default: a clear WARN to stderr, emitted ONCE
+  // per distinct denial tuple (the deduper's `firstSeen` flag).
+  const onDenialBubbleUp =
+    opts?.onDenialBubbleUp ??
+    ((info: SurfaceDenialBubbleUp): void => {
+      process.stderr.write(`[surface-router] WARN ${info.message}\n`);
+    });
+
+  /**
+   * cortex#1222 — emit a `system.access.denied` audit through the deduper.
+   * `doEmit` performs the actual `runtime.publish` (via the existing
+   * emitFederationDenied / emitSystemAccessDenied helpers). We call it ONLY
+   * when the deduper says to (first occurrence or a post-window rollup), so a
+   * genuinely-repeated FOREIGN denial is still audited — security preserved —
+   * but never floods the bus. The first occurrence of each tuple bubbles up
+   * ONCE. The hard DROP in `dispatch` is independent of this — every denied
+   * envelope is dropped every time; only the AUDIT is bounded.
+   */
+  const emitDeny = (id: DenialIdentity, doEmit: () => void): void => {
+    const decision: DenialDecision = denialDeduper.decide(id);
+    if (decision.firstSeen) {
+      onDenialBubbleUp({
+        identity: id,
+        message:
+          `federation dispatch denial: capability=${id.capability} subject=${id.subject} ` +
+          `reason=${id.reason} source=${id.source} — verify this peer is on a ` +
+          `shared network's peers[]/accept_subjects[] (or remove the federated ` +
+          `publish if this is the stack's OWN presence looping back).`,
+      });
+    }
+    if (decision.emit) doEmit();
+  };
+
+  /**
+   * cortex#1222 — bubble up a non-audited condition (no `system.access.denied`
+   * to emit) to the principal ONCE per distinct tuple. Routed through the SAME
+   * deduper so it can never flood stderr on a per-tick loopback.
+   */
+  const bubbleUpOnce = (id: DenialIdentity, message: string): void => {
+    if (denialDeduper.decide(id).firstSeen) {
+      onDenialBubbleUp({ identity: id, message });
+    }
+  };
+
   let started = false;
   let stopped = false;
   let envelopeReg: { unregister: () => void } | null = null;
@@ -394,6 +528,96 @@ export function createSurfaceRouter(
         federatedNetworksById.size > 0 &&
         effectiveSubject.startsWith("federated.")
       ) {
+        const sourcePrincipal =
+          envelope.source.split(".")[0] ?? envelope.source;
+
+        // === SELF-LOOPBACK SHORT-CIRCUIT (cortex#1222, mirrors #1214/cortex#480)
+        // A federated stack publishes its OWN presence onto
+        // `federated.{us}.{stack}.agent.>` so peers see it; that publish LOOPS
+        // BACK to this router. The accept-list gate below would then deny it
+        // (we are not our own peer → peer_not_in_accept_list / unknown_network)
+        // and emit a `system.access.denied` on EVERY heartbeat tick — the live
+        // #1222 self-deny FLOOD. #1214 fixed the inbound federated-SUBSCRIBER
+        // path and EXPLICITLY flagged THIS dispatch path as out-of-scope.
+        //
+        // Detect the self-claim the SAME way `verifySignedByChain` does
+        // (cortex#480): the SOURCE stamp's `identity` equals the receiving
+        // stack's OWN signing DID (`stackIdentity`, from config — NOT the
+        // spoofable `envelope.source` / `payload`). When it matches, SKIP the
+        // federation accept-list (TRUST) gate — but the crypto bytes-check
+        // below STILL runs, so a spoofed self-DID without our private key is
+        // rejected exactly as a forged foreign envelope.
+        const claimsOwnStack =
+          stackIdentity !== undefined &&
+          getSignedByChain(envelope)[0]?.identity === stackIdentity;
+
+        if (claimsOwnStack) {
+          // Crypto bytes-check the self-claim before trusting it. The own-stack
+          // short-circuit inside `verifySignedByChain` (cortex#480) accepts the
+          // stamp structurally; the crypto pass verifies the bytes against
+          // `stackNKeyPub`. `resolveFederatedPeer` is intentionally OMITTED —
+          // the signer is our OWN stack, not a federated peer (resolving
+          // ourselves as a peer would wrongly reject).
+          if (trustResolver !== undefined && receivingAgentId !== undefined) {
+            const result = await verifySignedByChain(envelope, {
+              resolver: trustResolver,
+              receivingAgentId,
+              rejectEmpty: signingRejectEmpty,
+              cryptoVerify,
+              ...(principalId !== undefined && { principalId }),
+              // `stackIdentity` is defined here — `claimsOwnStack` requires it.
+              stackIdentity,
+              ...(stackNKeyPub !== undefined && { stackNKeyPub }),
+            });
+            if (!result.valid) {
+              // Spoofed self-DID: the stamp CLAIMED our DID (so the trust
+              // short-circuit accepted it structurally) but the bytes don't
+              // verify against our NKey. STILL denied + audited (deduped) —
+              // exactly the no-accept-forged-envelope hole the issue calls out.
+              emitDeny(
+                {
+                  capability: "federated.subject_dispatch",
+                  subject: effectiveSubject,
+                  reason: "chain_verify_failed",
+                  source: sourcePrincipal,
+                },
+                () => {
+                  emitSystemAccessDenied(runtime, systemEventSource, envelope, {
+                    envelopeSubject: effectiveSubject,
+                    principalId: sourcePrincipal,
+                    capability: "federated.subject_dispatch",
+                    reason: {
+                      kind: "chain_verify_failed",
+                      verify_reason: result.reason.kind,
+                    },
+                  });
+                },
+              );
+              return;
+            }
+            // Verified self-loopback — OUR OWN presence, published for peers and
+            // looped back. NOT a foreign dispatch: drop it silently (the stack
+            // renders its own presence off the `local.*` subtree). No deny, no
+            // audit — the flood is gone.
+            return;
+          }
+          // No chain verifier wired — we cannot confirm the self-signature, so
+          // we cannot safely render it (it would be our own loopback anyway).
+          // Drop it silently to stop the self-deny flood; bubble up ONCE that
+          // it was unverifiable. Mirrors the #1214 "no verifier wired" branch.
+          bubbleUpOnce(
+            {
+              capability: "federated.subject_dispatch",
+              subject: effectiveSubject,
+              reason: "self_loopback_unverifiable",
+              source: sourcePrincipal,
+            },
+            `self-loopback dispatch on ${effectiveSubject} dropped — no chain ` +
+              `verifier wired to confirm the self-signature; not routed.`,
+          );
+          return;
+        }
+
         const decision = evaluateFederationGate(
           effectiveSubject,
           envelope,
@@ -406,12 +630,27 @@ export function createSurfaceRouter(
           sourceLink,
         );
         if (decision !== "allow") {
-          emitFederationDenied(
-            runtime,
-            systemEventSource,
-            envelope,
-            effectiveSubject,
-            decision,
+          // cortex#1222 — route the audit through the deduper so a
+          // genuinely-denied FOREIGN dispatch (a misconfigured peer re-sending
+          // every tick) is audited at MOST once per window, never per-tick.
+          // Security is preserved: the hard drop below still runs EVERY time;
+          // only the AUDIT is bounded. The first occurrence bubbles up once.
+          emitDeny(
+            {
+              capability: "federated.subject_dispatch",
+              subject: effectiveSubject,
+              reason: decision.kind,
+              source: sourcePrincipal,
+            },
+            () => {
+              emitFederationDenied(
+                runtime,
+                systemEventSource,
+                envelope,
+                effectiveSubject,
+                decision,
+              );
+            },
           );
           // Hard drop — denied envelopes never reach adapters. The
           // audit envelope above is the principal's only signal that

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3464,6 +3464,21 @@ export async function startCortex(
     // `cortex network join public`; an inbound public sender is admitted only
     // when `enabled: true` AND its source principal is on `allow_principals[]`.
     ...(resolvedPolicy?.public !== undefined && { public: resolvedPolicy.public }),
+    // cortex#1222 — self short-circuit + dedupe on the federation dispatch-deny
+    // path (the #1214 follow-up for THIS surface-router path). Mirrors the
+    // `startFederatedAgentPresenceSubscriber` wiring EXACTLY: a self-loopback
+    // `federated.{us}.{stack}.agent.*` dispatch (signed by our OWN stack DID)
+    // is recognised + bytes-checked + dropped instead of denied every tick,
+    // and a genuinely-denied foreign dispatch is audited ≤ once per window.
+    trustResolver,
+    ...(mergedAgents[0]?.id !== undefined && { receivingAgentId: mergedAgents[0].id }),
+    principalId,
+    cryptoVerify: signingKnobs.cryptoVerify,
+    rejectEmpty: signingKnobs.rejectEmpty,
+    ...(signer !== undefined && { stackIdentity: signer.principal }),
+    ...(stackNKeyPubForVerifier !== undefined && {
+      stackNKeyPub: stackNKeyPubForVerifier,
+    }),
     onAdapterError: (adapterId, err) => {
       console.error(`cortex: surface adapter "${adapterId}" render error:`, err.message);
     },


### PR DESCRIPTION
## What

Stop the federation **self-deny flood** on the **surface-router DISPATCH-deny path** — the #1214 follow-up.

#1214 self-short-circuited the inbound **federated-subscriber** path. The live flood (confirmed post-v5.26.6) is the **surface-router** `federated.subject_dispatch` gate (`emitFederationDenied`): the stack publishes its OWN presence onto `federated.{us}.{stack}.agent.heartbeat` so peers see it, that loops back to `createSurfaceRouter`'s dispatch gate, which denies it (`peer_not_in_accept_list` / `unknown_network` — we are not our own peer) and emits `system.access.denied` **every heartbeat tick**. The #1214 review explicitly flagged this surface-router path as out-of-scope/not-covered.

## Fix (extends the #1214 pattern to the surface-router path)

1. **Self short-circuit** — when the source stamp identity equals the receiving stack's OWN signing DID (`stackIdentity` from config, **not** the spoofable `envelope.source`/`payload`), SKIP the federation accept-list TRUST gate. Mirrors cortex#480 / #1214.
2. **SECURITY — bytes-check still runs.** The self-claim is run through `verifySignedByChain` (own-stack short-circuit + stack NKey crypto pass, `resolveFederatedPeer` omitted). A **verified** self-loopback is dropped silently (it is the stack's own presence meant for peers — the stack renders its own presence off `local.*`, not a foreign dispatch). A **spoofed** self-DID whose bytes don't verify is STILL denied + audited (`chain_verify_failed`). No verifier wired ⇒ dropped unverified (no flood, never rendered) + bubbled up once.
3. **Dedupe the audit** — reuse the #1214 `AccessDeniedDeduper`: a genuinely-denied FOREIGN dispatch is audited at most once per window, never per-tick. The hard drop still runs every time; only the audit is bounded.
4. **Bubble up once** per distinct denial tuple, consistent with #1214.

Wired in `cortex.ts` mirroring the `startFederatedAgentPresenceSubscriber` options exactly (`trustResolver` / `receivingAgentId` / `principalId` / `cryptoVerify` / `rejectEmpty` / `stackIdentity` / `stackNKeyPub`).

## Where the change lives

- `src/bus/surface-router.ts` — self short-circuit + dedupe on the `federated.subject_dispatch` deny path in `createSurfaceRouter`'s `dispatch`; new `SurfaceRouterOptions` fields + `SurfaceDenialBubbleUp`.
- `src/cortex.ts` — wires the new options at the `createSurfaceRouter` call site.
- `src/bus/__tests__/surface-router-self-deny.test.ts` — new (mirrors `federated-subscriber-self-deny.test.ts`).

## Tests / gates

- New suite (5 tests): OWN signed heartbeat ⇒ not denied / not routed / no audit; spoofed self-DID ⇒ STILL denied + `chain_verify_failed` (bytes-check ran); no-verifier self-claim ⇒ dropped + bubble once; FOREIGN non-peer denied every tick ⇒ audited ≤ once/window; bubble-up fires once.
- `bunx tsc --noEmit` ✅ · `bunx eslint --quiet .` ✅ · `bash scripts/check-carveouts.sh` ✅ (PASS) · `bun test src/` ✅ **7452 pass / 0 fail / 2 skip** (no flake hit).

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)