### PR TITLE
chore: bump to v5.26.7

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.6"
+version: "5.26.7"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
#1226 (#1222): self-short-circuit + dedupe the surface-router federated dispatch-deny path — stops the system.access.denied self-deny flood (the #1214 follow-up). Manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)