### PR TITLE
fix(dev-loop): handle existing branch + commit the session's work (#1230)

### DIFF
--- a/src/runner/__tests__/dev-consumer-boot.test.ts
+++ b/src/runner/__tests__/dev-consumer-boot.test.ts
@@ -28,6 +28,7 @@ import type {
   DevWorkspace,
   DevCommandRunner,
   DevForge,
+  DevGitInspector,
 } from "../dev-consumer";
 import { MemoryDevSessionStore } from "../dev-session-store";
 
@@ -57,6 +58,10 @@ const NOOP_SEAMS: NonNullable<WireDevConsumersOpts["seamsOverride"]> = {
   forge: {
     openPr: async () => ({ repo: "o/r", number: 1, url: "u" }),
   } satisfies DevForge,
+  gitInspector: {
+    status: async () => ({ commitsAhead: 1, hasUncommittedChanges: false }),
+    commitAll: async () => {},
+  } satisfies DevGitInspector,
   sessionStore: new MemoryDevSessionStore(),
 };
 

--- a/src/runner/__tests__/dev-consumer.test.ts
+++ b/src/runner/__tests__/dev-consumer.test.ts
@@ -48,8 +48,10 @@ import {
   type DevCommandResult,
   type DevForge,
   type DevPrRef,
+  type DevGitInspector,
   type DevOfferAdmissionGate,
 } from "../dev-consumer";
+import type { DevWorktreeStatus } from "../dev-worktree";
 import { MemoryDevSessionStore, type DevSessionStore } from "../dev-session-store";
 import type { CCSessionFactory, CCSessionLike } from "../../substrates/claude-code/harness";
 import type { CCSessionOpts, CCSessionResult } from "../cc-session";
@@ -173,6 +175,37 @@ function fakeForge(opts: { fail?: boolean; pr?: DevPrRef } = {}): FakeForge {
   };
 }
 
+interface FakeGitInspector extends DevGitInspector {
+  committed: { cwd: string; message: string }[];
+  statusCalls: { cwd: string; base: string; branch: string }[];
+}
+/**
+ * Fake commit-safety seam. Defaults to "agent committed" (1 commit ahead,
+ * clean tree) so the existing happy-path tests proceed unchanged. Override
+ * `status` to simulate uncommitted-leftover / nothing-produced. `commitAll`
+ * flips the recorded status to clean+ahead so a re-inspect would proceed.
+ */
+function fakeGitInspector(
+  opts: { status?: DevWorktreeStatus; failStatus?: boolean; failCommit?: boolean } = {},
+): FakeGitInspector {
+  const committed: FakeGitInspector["committed"] = [];
+  const statusCalls: FakeGitInspector["statusCalls"] = [];
+  const status = opts.status ?? { commitsAhead: 1, hasUncommittedChanges: false };
+  return {
+    committed,
+    statusCalls,
+    status: async (c) => {
+      statusCalls.push(c);
+      if (opts.failStatus) throw new Error("git rev-list failed");
+      return status;
+    },
+    commitAll: async (c) => {
+      committed.push(c);
+      if (opts.failCommit) throw new Error("git commit -S failed: no signing key");
+    },
+  };
+}
+
 /** A CC session factory returning a fixed result; records the opts it saw. */
 function fakeCcFactory(
   result: CCSessionResult,
@@ -210,6 +243,7 @@ function baseOpts(overrides: Partial<DevConsumerOpts> = {}): DevConsumerOpts {
     workspace: overrides.workspace ?? fakeWorkspace(),
     commandRunner: overrides.commandRunner ?? fakeRunner(),
     forge: overrides.forge ?? fakeForge(),
+    gitInspector: overrides.gitInspector ?? fakeGitInspector(),
     sessionStore: overrides.sessionStore ?? new MemoryDevSessionStore(),
     ...overrides,
   };
@@ -487,6 +521,126 @@ describe("DevConsumer.processEnvelope — F-2.1", () => {
     const consumer = new DevConsumer(baseOpts({ workspace }));
     await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
     expect(workspace.removed).toEqual([{ path: "/tmp/Cortex-c-300" }]);
+  });
+
+  // --- cortex#1230 Bug 2 — commit safety -----------------------------------
+
+  test("1230: session edits + commits → push + PR (happy path, no fallback commit)", async () => {
+    const runtime = createRecordingRuntime();
+    const forge = fakeForge();
+    // Agent committed: 1 commit ahead, clean tree.
+    const git = fakeGitInspector({ status: { commitsAhead: 1, hasUncommittedChanges: false } });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, forge, gitInspector: git }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision).toEqual({ kind: "ack" });
+    // No fallback commit — the agent committed its own work.
+    expect(git.committed).toHaveLength(0);
+    expect(git.statusCalls).toHaveLength(1);
+    expect(forge.calls).toHaveLength(1);
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+  });
+
+  test("1230: session edits but forgets to commit → consumer commits the leftover + pushes", async () => {
+    const runtime = createRecordingRuntime();
+    const forge = fakeForge();
+    // Agent forgot: nothing committed, but the working tree is dirty.
+    const git = fakeGitInspector({
+      status: { commitsAhead: 0, hasUncommittedChanges: true },
+    });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, forge, gitInspector: git }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision).toEqual({ kind: "ack" });
+    // Consumer committed the leftover with a conventional fallback message.
+    expect(git.committed).toHaveLength(1);
+    expect(git.committed[0]!.cwd).toBe("/tmp/Cortex-c-300");
+    expect(git.committed[0]!.message).toBe(
+      "feat: implement the-metafactory/cortex#300 (dev-loop fallback commit)",
+    );
+    // The run is NOT lost — the PR still opens.
+    expect(forge.calls).toHaveLength(1);
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+  });
+
+  test("1230: session produces NOTHING → clear typed failure (NOT the forge push error)", async () => {
+    const runtime = createRecordingRuntime();
+    const forge = fakeForge();
+    // Nothing produced: no commits ahead, clean tree.
+    const git = fakeGitInspector({
+      status: { commitsAhead: 0, hasUncommittedChanges: false },
+    });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, forge, gitInspector: git }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    // No commit attempted, and the forge push is NEVER reached.
+    expect(git.committed).toHaveLength(0);
+    expect(forge.calls).toHaveLength(0);
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    const detail = (reasonOf(failed) as { detail: string }).detail;
+    // The CLEAR "no implementation" reason — NOT forge's "no commits to verify".
+    expect(detail).toContain("session produced no implementation/commits");
+    expect(detail).not.toContain("no commits to verify");
+  });
+
+  test("1230: fallback commit message falls back to a truncated brief when no issue", async () => {
+    const runtime = createRecordingRuntime();
+    const git = fakeGitInspector({
+      status: { commitsAhead: 0, hasUncommittedChanges: true },
+    });
+    const noIssue: DevImplementPayload = { ...PAYLOAD };
+    delete (noIssue as { issue?: number }).issue;
+
+    const consumer = new DevConsumer(baseOpts({ runtime, gitInspector: git }));
+    await consumer.processEnvelope(makeRequest(noIssue), LOCAL_SUBJECT, null);
+
+    expect(git.committed).toHaveLength(1);
+    expect(git.committed[0]!.message).toMatch(/^feat: .+ \(dev-loop fallback commit\)$/);
+  });
+
+  test("1230: git status inspection throws → cant_do + term; worktree removed; PR not opened", async () => {
+    const runtime = createRecordingRuntime();
+    const workspace = fakeWorkspace();
+    const forge = fakeForge();
+    const git = fakeGitInspector({ failStatus: true });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, workspace, forge, gitInspector: git }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    expect(forge.calls).toHaveLength(0);
+    expect(workspace.removed).toHaveLength(1);
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect((reasonOf(failed) as { detail: string }).detail).toContain(
+      "git state inspection failed",
+    );
+  });
+
+  test("1230: fallback commit throws → cant_do + term; PR not opened", async () => {
+    const runtime = createRecordingRuntime();
+    const forge = fakeForge();
+    const git = fakeGitInspector({
+      status: { commitsAhead: 0, hasUncommittedChanges: true },
+      failCommit: true,
+    });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, forge, gitInspector: git }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    expect(forge.calls).toHaveLength(0);
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect((reasonOf(failed) as { detail: string }).detail).toContain("fallback commit");
   });
 
   test("worktree create failure → cant_do + term; no CC spawned", async () => {

--- a/src/runner/__tests__/dev-worktree.test.ts
+++ b/src/runner/__tests__/dev-worktree.test.ts
@@ -1,0 +1,178 @@
+/**
+ * cortex#1230 — tests for `runner/dev-worktree.ts`.
+ *
+ *   Bug 1 — branch-collision handling:
+ *     - `decideBranchAction` truth table (pure).
+ *     - `createWorktreeHandlingExistingBranch` orchestration against a recording
+ *       fake `WorktreeIO`: absent → create-fresh; stale → delete+recreate;
+ *       commits-ahead → reuse; open-PR → reuse. A re-dispatch with a stale
+ *       branch NEVER hard-fails.
+ *   Bug 2 — post-session commit decision:
+ *     - `decidePostSessionAction` truth table (pure).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  decideBranchAction,
+  decidePostSessionAction,
+  createWorktreeHandlingExistingBranch,
+  type WorktreeIO,
+  type BranchState,
+  type BranchAction,
+} from "../dev-worktree";
+
+// ---------------------------------------------------------------------------
+// Recording fake WorktreeIO
+// ---------------------------------------------------------------------------
+
+interface RecordingIO extends WorktreeIO {
+  calls: string[];
+}
+
+function recordingIO(state: {
+  branchExists: boolean;
+  commitsAhead?: number;
+  openPrNumber?: number | null;
+}): RecordingIO {
+  const calls: string[] = [];
+  return {
+    calls,
+    branchExists: async () => {
+      calls.push("branchExists");
+      return state.branchExists;
+    },
+    commitsAhead: async () => {
+      calls.push("commitsAhead");
+      return state.commitsAhead ?? 0;
+    },
+    openPrNumber: async () => {
+      calls.push("openPrNumber");
+      return state.openPrNumber ?? null;
+    },
+    pruneWorktrees: async () => {
+      calls.push("pruneWorktrees");
+    },
+    deleteBranch: async () => {
+      calls.push("deleteBranch");
+    },
+    addWorktreeNewBranch: async () => {
+      calls.push("addWorktreeNewBranch");
+    },
+    addWorktreeExistingBranch: async () => {
+      calls.push("addWorktreeExistingBranch");
+    },
+  };
+}
+
+const OPTS = { branch: "feat/1196-cortex", base: "main", path: "/tmp/Cortex-x" };
+
+// ---------------------------------------------------------------------------
+// Bug 1 — decideBranchAction (pure)
+// ---------------------------------------------------------------------------
+
+describe("decideBranchAction", () => {
+  const cases: { name: string; state: BranchState; expectKind: BranchAction["kind"] }[] = [
+    {
+      name: "absent → create-fresh",
+      state: { branchExists: false, commitsAhead: 0, openPrNumber: null },
+      expectKind: "create-fresh",
+    },
+    {
+      name: "exists, no commits, no PR → recreate-stale",
+      state: { branchExists: true, commitsAhead: 0, openPrNumber: null },
+      expectKind: "recreate-stale",
+    },
+    {
+      name: "exists with commits, no PR → reuse-existing",
+      state: { branchExists: true, commitsAhead: 3, openPrNumber: null },
+      expectKind: "reuse-existing",
+    },
+    {
+      name: "exists with an open PR (even 0 commits ahead) → reuse-existing",
+      state: { branchExists: true, commitsAhead: 0, openPrNumber: 57 },
+      expectKind: "reuse-existing",
+    },
+  ];
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(decideBranchAction(c.state).kind).toBe(c.expectKind);
+    });
+  }
+
+  test("an open PR wins over commits-ahead and carries the PR number", () => {
+    const action = decideBranchAction({ branchExists: true, commitsAhead: 9, openPrNumber: 42 });
+    expect(action).toEqual({ kind: "reuse-existing", openPrNumber: 42 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 1 — createWorktreeHandlingExistingBranch (orchestration)
+// ---------------------------------------------------------------------------
+
+describe("createWorktreeHandlingExistingBranch", () => {
+  test("absent branch → prune then `-b` create-fresh", async () => {
+    const io = recordingIO({ branchExists: false });
+    const result = await createWorktreeHandlingExistingBranch(io, OPTS);
+
+    expect(result.action.kind).toBe("create-fresh");
+    expect(result.path).toBe("/tmp/Cortex-x");
+    expect(io.calls).toEqual(["pruneWorktrees", "branchExists", "addWorktreeNewBranch"]);
+  });
+
+  test("stale existing branch → delete + recreate (re-dispatch does NOT hard-fail)", async () => {
+    const io = recordingIO({ branchExists: true, commitsAhead: 0, openPrNumber: null });
+    const result = await createWorktreeHandlingExistingBranch(io, OPTS);
+
+    expect(result.action.kind).toBe("recreate-stale");
+    expect(io.calls).toContain("deleteBranch");
+    expect(io.calls).toContain("addWorktreeNewBranch");
+    // Never the existing-branch (reuse) path for a stale branch.
+    expect(io.calls).not.toContain("addWorktreeExistingBranch");
+  });
+
+  test("branch with commits → reuse the existing branch (warm-resume, no `-b`)", async () => {
+    const io = recordingIO({ branchExists: true, commitsAhead: 2, openPrNumber: null });
+    const result = await createWorktreeHandlingExistingBranch(io, OPTS);
+
+    expect(result.action.kind).toBe("reuse-existing");
+    expect(io.calls).toContain("addWorktreeExistingBranch");
+    expect(io.calls).not.toContain("deleteBranch");
+    expect(io.calls).not.toContain("addWorktreeNewBranch");
+  });
+
+  test("branch with an open PR → reuse, surfacing the PR number", async () => {
+    const io = recordingIO({ branchExists: true, commitsAhead: 0, openPrNumber: 88 });
+    const result = await createWorktreeHandlingExistingBranch(io, OPTS);
+
+    expect(result.action).toEqual({ kind: "reuse-existing", openPrNumber: 88 });
+    expect(io.calls).toContain("addWorktreeExistingBranch");
+    expect(io.calls).not.toContain("deleteBranch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 2 — decidePostSessionAction (pure)
+// ---------------------------------------------------------------------------
+
+describe("decidePostSessionAction", () => {
+  test("commits ahead, clean tree → proceed", () => {
+    expect(
+      decidePostSessionAction({ commitsAhead: 1, hasUncommittedChanges: false }).kind,
+    ).toBe("proceed");
+  });
+
+  test("uncommitted changes → commit-then-proceed (even with commits already ahead)", () => {
+    expect(
+      decidePostSessionAction({ commitsAhead: 0, hasUncommittedChanges: true }).kind,
+    ).toBe("commit-then-proceed");
+    expect(
+      decidePostSessionAction({ commitsAhead: 2, hasUncommittedChanges: true }).kind,
+    ).toBe("commit-then-proceed");
+  });
+
+  test("nothing ahead, clean tree → fail-no-implementation", () => {
+    expect(
+      decidePostSessionAction({ commitsAhead: 0, hasUncommittedChanges: false }).kind,
+    ).toBe("fail-no-implementation");
+  });
+});

--- a/src/runner/__tests__/dev-worktree.test.ts
+++ b/src/runner/__tests__/dev-worktree.test.ts
@@ -31,8 +31,8 @@ interface RecordingIO extends WorktreeIO {
 
 function recordingIO(state: {
   branchExists: boolean;
-  commitsAhead?: number;
-  openPrNumber?: number | null;
+  commitsAhead?: number | "unknown";
+  openPrNumber?: number | null | "unknown";
 }): RecordingIO {
   const calls: string[] = [];
   return {
@@ -103,6 +103,41 @@ describe("decideBranchAction", () => {
     const action = decideBranchAction({ branchExists: true, commitsAhead: 9, openPrNumber: 42 });
     expect(action).toEqual({ kind: "reuse-existing", openPrNumber: 42 });
   });
+
+  // FAIL-SAFE: an indeterminate probe must NEVER reach recreate-stale.
+  test("commitsAhead unknown (probe failed) → reuse-existing, never delete", () => {
+    expect(
+      decideBranchAction({ branchExists: true, commitsAhead: "unknown", openPrNumber: null }).kind,
+    ).toBe("reuse-existing");
+  });
+
+  test("openPrNumber unknown (probe failed) → reuse-existing, never delete", () => {
+    expect(
+      decideBranchAction({ branchExists: true, commitsAhead: 0, openPrNumber: "unknown" }).kind,
+    ).toBe("reuse-existing");
+  });
+
+  test("both probes unknown → reuse-existing (when in doubt, keep the branch)", () => {
+    expect(
+      decideBranchAction({
+        branchExists: true,
+        commitsAhead: "unknown",
+        openPrNumber: "unknown",
+      }).kind,
+    ).toBe("reuse-existing");
+  });
+
+  test("a CONFIRMED open PR still wins even when commitsAhead is unknown", () => {
+    expect(
+      decideBranchAction({ branchExists: true, commitsAhead: "unknown", openPrNumber: 7 }),
+    ).toEqual({ kind: "reuse-existing", openPrNumber: 7 });
+  });
+
+  test("recreate-stale requires BOTH probes confirmed (0 commits AND no PR)", () => {
+    expect(
+      decideBranchAction({ branchExists: true, commitsAhead: 0, openPrNumber: null }).kind,
+    ).toBe("recreate-stale");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -146,6 +181,31 @@ describe("createWorktreeHandlingExistingBranch", () => {
 
     expect(result.action).toEqual({ kind: "reuse-existing", openPrNumber: 88 });
     expect(io.calls).toContain("addWorktreeExistingBranch");
+    expect(io.calls).not.toContain("deleteBranch");
+  });
+
+  // FAIL-SAFE (regression guard for the major review finding): a probe that
+  // FAILS (commitsAhead/openPrNumber → "unknown") must REUSE the branch, never
+  // `git branch -D` it. Locks in "when in doubt, never delete unpushed work".
+  test("commitsAhead probe failed (unknown) → reuse, branch is NEVER deleted", async () => {
+    const io = recordingIO({ branchExists: true, commitsAhead: "unknown", openPrNumber: null });
+    const result = await createWorktreeHandlingExistingBranch(io, OPTS);
+
+    expect(result.action.kind).toBe("reuse-existing");
+    expect(io.calls).toContain("addWorktreeExistingBranch");
+    expect(io.calls).not.toContain("deleteBranch");
+    expect(io.calls).not.toContain("addWorktreeNewBranch");
+  });
+
+  test("both probes failed (unknown) → reuse, branch is NEVER deleted", async () => {
+    const io = recordingIO({
+      branchExists: true,
+      commitsAhead: "unknown",
+      openPrNumber: "unknown",
+    });
+    const result = await createWorktreeHandlingExistingBranch(io, OPTS);
+
+    expect(result.action.kind).toBe("reuse-existing");
     expect(io.calls).not.toContain("deleteBranch");
   });
 });

--- a/src/runner/dev-consumer-boot.ts
+++ b/src/runner/dev-consumer-boot.ts
@@ -450,8 +450,13 @@ function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
         ["rev-list", "--count", `origin/${base}..${branch}`],
         { cwd: opts.repoRoot, env: opts.env, allowFailure: true },
       );
+      // FAIL SAFE: a probe ERROR is "unknown", NEVER 0. Coercing a failed
+      // `git rev-list` to 0 would let a branch with unpushed local commits be
+      // mis-read as stale and force-deleted (data loss). Only a code-0,
+      // parseable count is a CONFIRMED number.
+      if (r.code !== 0) return "unknown";
       const n = Number(r.stdout.trim());
-      return r.code === 0 && Number.isFinite(n) ? n : 0;
+      return Number.isFinite(n) ? n : "unknown";
     },
     openPrNumber: async (branch) => {
       const r = await run(
@@ -459,8 +464,14 @@ function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
         ["pr", "list", "--head", branch, "--state", "open", "--json", "number", "--jq", ".[0].number // empty"],
         { cwd: opts.repoRoot, env: ghEnv, allowFailure: true },
       );
-      const n = Number(r.stdout.trim());
-      return r.code === 0 && Number.isInteger(n) && n > 0 ? n : null;
+      // FAIL SAFE: a `gh` ERROR is "unknown", NEVER null — an "I couldn't check
+      // for a PR" must not read as "there is no PR → deletable". A CONFIRMED
+      // empty result (code 0, no number) is the only `null`.
+      if (r.code !== 0) return "unknown";
+      const s = r.stdout.trim();
+      if (s === "") return null;
+      const n = Number(s);
+      return Number.isInteger(n) && n > 0 ? n : null;
     },
     pruneWorktrees: async () => {
       await run("git", ["worktree", "prune"], {
@@ -527,18 +538,23 @@ function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
   // push boundary refuses unsigned commits) when it forgot to.
   const gitInspector: DevGitInspector = {
     status: async ({ cwd, base }) => {
+      // FAIL SAFE (review nit — same fail-to-0 footgun as the worktree probes):
+      // a probe error PROPAGATES (no `allowFailure`), so a failed `rev-list` /
+      // `status` surfaces as a clear `cant_do` ("git state inspection failed")
+      // via the consumer's try/catch — NEVER a false "no implementation
+      // produced" verdict synthesised from a coerced-to-0 count + empty status.
       const ahead = await run(
         "git",
         ["rev-list", "--count", `origin/${base}..HEAD`],
-        { cwd, env: opts.env, allowFailure: true },
+        { cwd, env: opts.env },
       );
-      const n = Number(ahead.stdout.trim());
-      const commitsAhead = ahead.code === 0 && Number.isFinite(n) ? n : 0;
-      const st = await run("git", ["status", "--porcelain"], {
-        cwd,
-        env: opts.env,
-        allowFailure: true,
-      });
+      const commitsAhead = Number(ahead.stdout.trim());
+      if (!Number.isFinite(commitsAhead)) {
+        throw new Error(
+          `unexpected git rev-list output: ${JSON.stringify(ahead.stdout)}`,
+        );
+      }
+      const st = await run("git", ["status", "--porcelain"], { cwd, env: opts.env });
       return { commitsAhead, hasUncommittedChanges: st.stdout.trim().length > 0 };
     },
     commitAll: async ({ cwd, message }) => {

--- a/src/runner/dev-consumer-boot.ts
+++ b/src/runner/dev-consumer-boot.ts
@@ -61,10 +61,15 @@ import {
   type DevCommandResult,
   type DevForge,
   type DevPrRef,
+  type DevGitInspector,
   type DevOfferAdmissionGate,
 } from "./dev-consumer";
 import { FileDevSessionStore, type DevSessionStore } from "./dev-session-store";
 import { readCommitSignatures, type CommitSigningIO } from "./commit-signing";
+import {
+  createWorktreeHandlingExistingBranch,
+  type WorktreeIO,
+} from "./dev-worktree";
 
 export { DevConsumer } from "./dev-consumer";
 
@@ -165,6 +170,7 @@ export interface WireDevConsumersOpts {
     workspace: DevWorkspace;
     commandRunner: DevCommandRunner;
     forge: DevForge;
+    gitInspector: DevGitInspector;
     sessionStore: DevSessionStore;
   };
   /** Optional logger. Defaults to `console`. */
@@ -286,6 +292,7 @@ export function wireDevConsumers(opts: WireDevConsumersOpts): WiredDevConsumer[]
           workspace: seams.workspace,
           commandRunner: seams.commandRunner,
           forge: seams.forge,
+          gitInspector: seams.gitInspector,
           sessionStore: seams.sessionStore,
           sessionOpts,
           ...(opts.offerAdmission !== undefined && {
@@ -402,6 +409,7 @@ interface BuiltSeams {
   workspace: DevWorkspace;
   commandRunner: DevCommandRunner;
   forge: DevForge;
+  gitInspector: DevGitInspector;
   sessionStore: DevSessionStore;
 }
 
@@ -415,16 +423,95 @@ function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
   const slugify = (branch: string): string =>
     branch.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "dev";
 
+  // §3.5b — the scoped forge token (when set) is injected into the child env as
+  // GH_TOKEN for every `gh` call (the open-PR-lookup probe + the actual push),
+  // never the principal's ambient PAT unless the scoped token is absent (the
+  // warned ambient-fallback path).
+  const ghEnv: Record<string, string | undefined> = { ...opts.env };
+  if (opts.scopedToken !== undefined && opts.scopedToken.length > 0) {
+    ghEnv.GH_TOKEN = opts.scopedToken;
+  }
+
+  // cortex#1230 Bug 1 — the IO seam the branch-collision handling drives. Each
+  // verb is a thin `git`/`gh` spawn; the decision (create-fresh / recreate-stale
+  // / reuse-existing) lives in the pure `decideBranchAction` (dev-worktree.ts).
+  const worktreeIO: WorktreeIO = {
+    branchExists: async (branch) => {
+      const r = await run(
+        "git",
+        ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`],
+        { cwd: opts.repoRoot, env: opts.env, allowFailure: true },
+      );
+      return r.code === 0;
+    },
+    commitsAhead: async (branch, base) => {
+      const r = await run(
+        "git",
+        ["rev-list", "--count", `origin/${base}..${branch}`],
+        { cwd: opts.repoRoot, env: opts.env, allowFailure: true },
+      );
+      const n = Number(r.stdout.trim());
+      return r.code === 0 && Number.isFinite(n) ? n : 0;
+    },
+    openPrNumber: async (branch) => {
+      const r = await run(
+        "gh",
+        ["pr", "list", "--head", branch, "--state", "open", "--json", "number", "--jq", ".[0].number // empty"],
+        { cwd: opts.repoRoot, env: ghEnv, allowFailure: true },
+      );
+      const n = Number(r.stdout.trim());
+      return r.code === 0 && Number.isInteger(n) && n > 0 ? n : null;
+    },
+    pruneWorktrees: async () => {
+      await run("git", ["worktree", "prune"], {
+        cwd: opts.repoRoot,
+        env: opts.env,
+        allowFailure: true,
+      });
+    },
+    deleteBranch: async (branch) => {
+      await run("git", ["branch", "-D", branch], {
+        cwd: opts.repoRoot,
+        env: opts.env,
+        allowFailure: true,
+      });
+    },
+    addWorktreeNewBranch: async (path, branch, base) => {
+      await run("git", ["worktree", "add", path, "-b", branch, `origin/${base}`], {
+        cwd: opts.repoRoot,
+        env: opts.env,
+      });
+    },
+    addWorktreeExistingBranch: async (path, branch) => {
+      await run("git", ["worktree", "add", path, branch], {
+        cwd: opts.repoRoot,
+        env: opts.env,
+      });
+    },
+  };
+
   const workspace: DevWorkspace = {
     create: async ({ branch, base, chainId }) => {
       // Worktree-discipline SOP: `../Cortex-{slug}` cut from origin/{base}.
+      // cortex#1230 Bug 1 — handle a PRE-EXISTING branch (a re-dispatch of the
+      // fixed `feat/{N}-{repo}` branch) instead of hard-failing on `-b`.
       const slug = `${slugify(branch)}-${chainId.slice(0, 8)}`;
       const path = `${opts.repoRoot}/../Cortex-${slug}`;
-      await run(
-        "git",
-        ["worktree", "add", path, "-b", branch, `origin/${base}`],
-        { cwd: opts.repoRoot, env: opts.env },
-      );
+      const result = await createWorktreeHandlingExistingBranch(worktreeIO, {
+        branch,
+        base,
+        path,
+      });
+      if (result.action.kind !== "create-fresh") {
+        const prNote =
+          result.action.kind === "reuse-existing" && result.action.openPrNumber !== null
+            ? ` (open PR #${result.action.openPrNumber})`
+            : "";
+        process.stderr.write(
+          `cortex/dev-consumer: branch ${branch} already existed — ` +
+            `${result.action.kind}${prNote}\n`,
+        );
+      }
       return { path };
     },
     remove: async ({ path }) => {
@@ -432,6 +519,33 @@ function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
         cwd: opts.repoRoot,
         env: opts.env,
       });
+    },
+  };
+
+  // cortex#1230 Bug 2 — commit-safety seam. Inspect the worktree's git state
+  // after the CC session; commit the agent's leftover changes (SIGNED — the
+  // push boundary refuses unsigned commits) when it forgot to.
+  const gitInspector: DevGitInspector = {
+    status: async ({ cwd, base }) => {
+      const ahead = await run(
+        "git",
+        ["rev-list", "--count", `origin/${base}..HEAD`],
+        { cwd, env: opts.env, allowFailure: true },
+      );
+      const n = Number(ahead.stdout.trim());
+      const commitsAhead = ahead.code === 0 && Number.isFinite(n) ? n : 0;
+      const st = await run("git", ["status", "--porcelain"], {
+        cwd,
+        env: opts.env,
+        allowFailure: true,
+      });
+      return { commitsAhead, hasUncommittedChanges: st.stdout.trim().length > 0 };
+    },
+    commitAll: async ({ cwd, message }) => {
+      await run("git", ["add", "-A"], { cwd, env: opts.env });
+      // `-S` — the fallback commit MUST be signed (W5.0); the forge push
+      // boundary fails closed on any unsigned commit. NEVER `--no-gpg-sign`.
+      await run("git", ["commit", "-S", "-m", message], { cwd, env: opts.env });
     },
   };
 
@@ -509,7 +623,7 @@ function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
   };
 
   const sessionStore = new FileDevSessionStore(opts.sessionStorePath);
-  return { workspace, commandRunner, forge, sessionStore };
+  return { workspace, commandRunner, forge, gitInspector, sessionStore };
 }
 
 interface RunResult {

--- a/src/runner/dev-consumer.ts
+++ b/src/runner/dev-consumer.ts
@@ -78,6 +78,7 @@ import type { CCSessionFactory, CCSessionLike } from "../substrates/claude-code/
 import type { CCSessionOpts, CCSessionResult } from "./cc-session";
 import type { DevSessionStore } from "./dev-session-store";
 import { readLogicalRouting } from "../adapters/response-routing-delivery";
+import { decidePostSessionAction, type DevWorktreeStatus } from "./dev-worktree";
 
 // ---------------------------------------------------------------------------
 // Injected seams — the testability + authority surface
@@ -162,6 +163,32 @@ export interface DevPrRef {
   url: string;
 }
 
+/**
+ * Commit-safety seam (cortex#1230 Bug 2). After the CC session and before the
+ * forge push, the consumer inspects the worktree's git state and, if the agent
+ * edited but forgot to commit, commits the leftover so the run isn't lost.
+ * Production wires real `git` (see `dev-consumer-boot.ts`); tests inject git
+ * state. Kept narrow — exactly inspect + commit.
+ */
+export interface DevGitInspector {
+  /**
+   * Inspect the worktree at `cwd`: commits ahead of `origin/<base>` and whether
+   * the working tree has uncommitted changes (tracked or untracked). Throws on
+   * a git failure — the consumer maps the throw to a `cant_do` failure.
+   */
+  status(opts: {
+    cwd: string;
+    base: string;
+    branch: string;
+  }): Promise<DevWorktreeStatus>;
+  /**
+   * Commit ALL changes in the worktree at `cwd` with `message` (the fallback
+   * commit when the agent forgot). MUST produce a SIGNED commit — the forge
+   * push boundary refuses unsigned commits (W5.0). Throws on failure.
+   */
+  commitAll(opts: { cwd: string; message: string }): Promise<void>;
+}
+
 // ---------------------------------------------------------------------------
 // Construction options
 // ---------------------------------------------------------------------------
@@ -238,6 +265,12 @@ export interface DevConsumerOpts {
   /** Forge push + PR-open seam (carries the agent's scoped identity). */
   forge: DevForge;
   /**
+   * Commit-safety seam (cortex#1230 Bug 2) — inspect the worktree's git state
+   * after the CC session and commit leftover changes the agent forgot. Tests
+   * inject git state; production wires real `git`.
+   */
+  gitInspector: DevGitInspector;
+  /**
    * Warm-session store (§3.6b). Maps correlation-chain id → CC session id so
    * a fix-cycle resumes the implement session. Tests inject
    * `MemoryDevSessionStore`; production wires `FileDevSessionStore`.
@@ -302,6 +335,7 @@ export class DevConsumer {
   private readonly workspace: DevWorkspace;
   private readonly commandRunner: DevCommandRunner;
   private readonly forge: DevForge;
+  private readonly gitInspector: DevGitInspector;
   private readonly sessionStore: DevSessionStore;
   private readonly sessionOpts?: Partial<
     Omit<CCSessionOpts, "prompt" | "cwd" | "resumeSessionId">
@@ -328,6 +362,7 @@ export class DevConsumer {
     this.workspace = opts.workspace;
     this.commandRunner = opts.commandRunner;
     this.forge = opts.forge;
+    this.gitInspector = opts.gitInspector;
     this.sessionStore = opts.sessionStore;
     if (opts.sessionOpts !== undefined) this.sessionOpts = opts.sessionOpts;
     this.offerAdmission = opts.offerAdmission;
@@ -686,6 +721,55 @@ export class DevConsumer {
         return await this.failTerminal(envelope, startedAt, reason, responseRouting);
       }
 
+      // 7b-2. Commit safety (cortex#1230 Bug 2). The pipeline pushes + opens
+      //       the PR, but the AGENT must commit. The brief now tells it to
+      //       (orchestrator-command `buildBrief`); this is the belt-and-braces
+      //       backstop for the two real failure modes:
+      //         - agent edited but forgot to commit → commit the leftover so
+      //           the run isn't lost (+ WARN — the agent should commit itself).
+      //         - agent produced nothing at all     → a CLEAR typed failure
+      //           naming "no implementation", NOT forge's confusing "no commits
+      //           to verify" surfaced from deep in the push path.
+      let gitStatus: DevWorktreeStatus;
+      try {
+        gitStatus = await this.gitInspector.status({
+          cwd: worktreePath,
+          base: payload.base,
+          branch: payload.branch,
+        });
+      } catch (err) {
+        return await this.failTerminal(envelope, startedAt, {
+          kind: "cant_do",
+          detail: `git state inspection failed: ${errText(err)}`,
+        }, responseRouting);
+      }
+
+      const postSession = decidePostSessionAction(gitStatus);
+      if (postSession.kind === "fail-no-implementation") {
+        return await this.failTerminal(envelope, startedAt, {
+          kind: "cant_do",
+          detail:
+            "session produced no implementation/commits — no commits ahead of " +
+            `${payload.base} and a clean working tree`,
+        }, responseRouting);
+      }
+      if (postSession.kind === "commit-then-proceed") {
+        const message = fallbackCommitMessage(payload);
+        try {
+          await this.gitInspector.commitAll({ cwd: worktreePath, message });
+        } catch (err) {
+          return await this.failTerminal(envelope, startedAt, {
+            kind: "cant_do",
+            detail: `fallback commit of the session's uncommitted changes failed: ${errText(err)}`,
+          }, responseRouting);
+        }
+        process.stderr.write(
+          `dev-consumer: agent left uncommitted changes for ${payload.repo}` +
+            `${payload.issue !== undefined ? `#${payload.issue}` : ""} — committed ` +
+            `them with a fallback message (the agent should commit its own work)\n`,
+        );
+      }
+
       // 7c. Gates — run in declared order, stop at the first red.
       const gates = payload.gates ?? [];
       for (const command of gates) {
@@ -899,6 +983,20 @@ function redeliveryCountFrom(msg: JsMsg | null): number {
 
 function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Build the conventional-commit message for the fallback commit when the agent
+ * edited but forgot to commit (cortex#1230 Bug 2). Prefers the issue ref for a
+ * short, stable subject; falls back to a truncated brief. The `(dev-loop
+ * fallback commit)` suffix marks it as the safety-net commit in the log.
+ */
+export function fallbackCommitMessage(payload: DevImplementPayload): string {
+  const subject =
+    payload.issue !== undefined
+      ? `implement ${payload.repo}#${payload.issue}`
+      : truncate(payload.brief, 60);
+  return `feat: ${subject} (dev-loop fallback commit)`;
 }
 
 /** Cap a gate's output tail for the failure detail. */

--- a/src/runner/dev-worktree.ts
+++ b/src/runner/dev-worktree.ts
@@ -42,10 +42,18 @@
 export interface BranchState {
   /** Does a local ref `refs/heads/<branch>` already exist? */
   branchExists: boolean;
-  /** Commits on the branch ahead of `origin/<base>` (0 when the branch is absent). */
-  commitsAhead: number;
-  /** The number of an OPEN PR whose head is this branch, or `null` when none. */
-  openPrNumber: number | null;
+  /**
+   * Commits on the branch ahead of `origin/<base>`. `"unknown"` when the probe
+   * could NOT determine it (a `git rev-list` error) — a fail-SAFE sentinel the
+   * decider treats as "do not delete", NEVER coerced to `0`.
+   */
+  commitsAhead: number | "unknown";
+  /**
+   * The number of an OPEN PR whose head is this branch, `null` when CONFIRMED
+   * none, or `"unknown"` when the probe failed (a `gh` error) — the same
+   * fail-SAFE sentinel that forbids the destructive path.
+   */
+  openPrNumber: number | null | "unknown";
 }
 
 /** What {@link createWorktreeHandlingExistingBranch} does about the branch. */
@@ -60,16 +68,26 @@ export type BranchAction =
 /**
  * Decide what to do about a (possibly pre-existing) dispatched branch. PURE.
  *
- * Order is load-bearing: an OPEN PR or commits-ahead ALWAYS wins (reuse — never
- * destroy work that a human may be reviewing). Only a truly stale branch (no
- * commits ahead AND no open PR) is reclaimed.
+ * Order is load-bearing, and the invariant is FAIL-SAFE: the destructive path
+ * (`recreate-stale` → `git branch -D`) is reachable ONLY when BOTH probes
+ * CONFIRMED the branch is worthless — `commitsAhead === 0` AND `openPrNumber ===
+ * null`. An OPEN PR, commits-ahead, OR an INDETERMINATE probe (`"unknown"`, e.g.
+ * a transient git/gh error) all route to `reuse-existing` — never delete from
+ * an unknown state, because unpushed local commits live only in this branch
+ * (the warm-resume case Bug 2 creates). When in doubt, keep the branch.
  */
 export function decideBranchAction(state: BranchState): BranchAction {
   if (!state.branchExists) return { kind: "create-fresh" };
-  if (state.openPrNumber !== null) {
+  // A CONFIRMED open PR always reuses (carry the number for the log).
+  if (typeof state.openPrNumber === "number") {
     return { kind: "reuse-existing", openPrNumber: state.openPrNumber };
   }
+  // FAIL SAFE: any indeterminate probe ⇒ reuse, NEVER the `git branch -D` path.
+  if (state.commitsAhead === "unknown" || state.openPrNumber === "unknown") {
+    return { kind: "reuse-existing", openPrNumber: null };
+  }
   if (state.commitsAhead > 0) return { kind: "reuse-existing", openPrNumber: null };
+  // Both probes CONFIRMED: 0 commits ahead, no open PR → genuinely stale.
   return { kind: "recreate-stale" };
 }
 
@@ -82,10 +100,19 @@ export function decideBranchAction(state: BranchState): BranchAction {
 export interface WorktreeIO {
   /** True iff a local ref `refs/heads/<branch>` exists. */
   branchExists(branch: string): Promise<boolean>;
-  /** Count of commits on `<branch>` ahead of `origin/<base>`. */
-  commitsAhead(branch: string, base: string): Promise<number>;
-  /** The number of an OPEN PR whose head is `<branch>`, or `null`. */
-  openPrNumber(branch: string): Promise<number | null>;
+  /**
+   * Count of commits on `<branch>` ahead of `origin/<base>`. MUST return
+   * `"unknown"` (not `0`) when the probe cannot determine it — a probe error
+   * read as `0` would mis-classify a branch with unpushed commits as stale and
+   * delete it. Fail SAFE.
+   */
+  commitsAhead(branch: string, base: string): Promise<number | "unknown">;
+  /**
+   * The number of an OPEN PR whose head is `<branch>`, `null` when CONFIRMED
+   * none, or `"unknown"` when the probe failed. Same fail-SAFE contract as
+   * {@link WorktreeIO.commitsAhead}.
+   */
+  openPrNumber(branch: string): Promise<number | null | "unknown">;
   /** Prune worktree refs whose directories no longer exist (best-effort). */
   pruneWorktrees(): Promise<void>;
   /** Delete the local branch (`git branch -D <branch>`). */

--- a/src/runner/dev-worktree.ts
+++ b/src/runner/dev-worktree.ts
@@ -1,0 +1,190 @@
+/**
+ * cortex#1230 — dev-worker robustness: branch-collision handling (Bug 1) +
+ * post-session commit-state decision (Bug 2).
+ *
+ * Same shape as `commit-signing.ts`: PURE deciders (`decideBranchAction`,
+ * `decidePostSessionAction`) take plain state and return an action, and a thin
+ * IO seam (`WorktreeIO`) does the git/gh spawning. The production seam in
+ * `dev-consumer-boot.ts` wires `WorktreeIO` to real `git`/`gh`; tests drive the
+ * deciders + the orchestration (`createWorktreeHandlingExistingBranch`) with a
+ * recording fake and never touch a real repo.
+ *
+ * ## Bug 1 — branch collision
+ * The dispatched branch is a FIXED `feat/{N}-{repo}` (orchestrator-command),
+ * so a re-dispatch collides with a prior run's leftover branch and the naive
+ * `git worktree add -b <branch>` fails (`a branch named '…' already exists`).
+ * {@link createWorktreeHandlingExistingBranch} never hard-fails on an existing
+ * branch:
+ *   - branch absent                       → create fresh (`-b`).
+ *   - branch STALE (no commits ahead of   → delete + recreate fresh. A stale
+ *     base AND no open PR)                   leftover is worthless; reclaim it.
+ *   - branch has commits OR an open PR    → REUSE it (`git worktree add` with no
+ *                                            `-b`) — the warm-resume path: the
+ *                                            CC session resumes and continues
+ *                                            the in-flight work / open PR.
+ *
+ * ## Bug 2 — no commits → push refused
+ * The pipeline pushes + opens the PR but the AGENT must commit. After the CC
+ * session {@link decidePostSessionAction} reads the worktree's git state:
+ *   - uncommitted changes present (agent  → COMMIT them (fallback) so the run
+ *     forgot to commit)                      isn't lost, then proceed.
+ *   - commits ahead, clean tree           → proceed (the agent committed).
+ *   - nothing at all                      → a clear typed failure naming "no
+ *                                            implementation", NOT forge's
+ *                                            confusing "no commits to verify".
+ */
+
+// ---------------------------------------------------------------------------
+// Bug 1 — branch-collision handling
+// ---------------------------------------------------------------------------
+
+/** The git state of the dispatched branch, relative to its base. */
+export interface BranchState {
+  /** Does a local ref `refs/heads/<branch>` already exist? */
+  branchExists: boolean;
+  /** Commits on the branch ahead of `origin/<base>` (0 when the branch is absent). */
+  commitsAhead: number;
+  /** The number of an OPEN PR whose head is this branch, or `null` when none. */
+  openPrNumber: number | null;
+}
+
+/** What {@link createWorktreeHandlingExistingBranch} does about the branch. */
+export type BranchAction =
+  /** Branch absent — `git worktree add <path> -b <branch> origin/<base>`. */
+  | { kind: "create-fresh" }
+  /** Branch is a stale leftover — delete it, then create fresh. */
+  | { kind: "recreate-stale" }
+  /** Branch carries work / an open PR — reuse it (warm-resume); never `-b`. */
+  | { kind: "reuse-existing"; openPrNumber: number | null };
+
+/**
+ * Decide what to do about a (possibly pre-existing) dispatched branch. PURE.
+ *
+ * Order is load-bearing: an OPEN PR or commits-ahead ALWAYS wins (reuse — never
+ * destroy work that a human may be reviewing). Only a truly stale branch (no
+ * commits ahead AND no open PR) is reclaimed.
+ */
+export function decideBranchAction(state: BranchState): BranchAction {
+  if (!state.branchExists) return { kind: "create-fresh" };
+  if (state.openPrNumber !== null) {
+    return { kind: "reuse-existing", openPrNumber: state.openPrNumber };
+  }
+  if (state.commitsAhead > 0) return { kind: "reuse-existing", openPrNumber: null };
+  return { kind: "recreate-stale" };
+}
+
+/**
+ * IO seam — the git/gh operations {@link createWorktreeHandlingExistingBranch}
+ * needs. Production wires these to real `git`/`gh` (see `dev-consumer-boot.ts`);
+ * tests inject a recording fake. Kept narrow — exactly the verbs the
+ * branch-handling orchestration uses.
+ */
+export interface WorktreeIO {
+  /** True iff a local ref `refs/heads/<branch>` exists. */
+  branchExists(branch: string): Promise<boolean>;
+  /** Count of commits on `<branch>` ahead of `origin/<base>`. */
+  commitsAhead(branch: string, base: string): Promise<number>;
+  /** The number of an OPEN PR whose head is `<branch>`, or `null`. */
+  openPrNumber(branch: string): Promise<number | null>;
+  /** Prune worktree refs whose directories no longer exist (best-effort). */
+  pruneWorktrees(): Promise<void>;
+  /** Delete the local branch (`git branch -D <branch>`). */
+  deleteBranch(branch: string): Promise<void>;
+  /** `git worktree add <path> -b <branch> origin/<base>` — fresh branch. */
+  addWorktreeNewBranch(path: string, branch: string, base: string): Promise<void>;
+  /** `git worktree add <path> <branch>` — check out the EXISTING branch. */
+  addWorktreeExistingBranch(path: string, branch: string): Promise<void>;
+}
+
+/** Result of {@link createWorktreeHandlingExistingBranch}. */
+export interface CreateWorktreeResult {
+  /** The worktree path created (echoes the input). */
+  path: string;
+  /** Which branch action was taken — surfaced for the boot log. */
+  action: BranchAction;
+}
+
+/**
+ * Create a worktree for `branch` at `path`, handling a PRE-EXISTING branch
+ * instead of failing (Bug 1). Composes the IO seam with {@link decideBranchAction}.
+ *
+ * Prunes stale worktree refs first so a leftover worktree dir that was deleted
+ * out from under git (the common cleanup-failure shape) doesn't block a
+ * recreate/reuse. A genuinely live worktree still holding the branch will make
+ * the underlying `git worktree add` throw — the caller maps that to a typed
+ * `cant_do` failure (NOT a crash), which is the acceptable surfaced outcome.
+ */
+export async function createWorktreeHandlingExistingBranch(
+  io: WorktreeIO,
+  opts: { branch: string; base: string; path: string },
+): Promise<CreateWorktreeResult> {
+  const { branch, base, path } = opts;
+
+  // Clear refs to worktree dirs that no longer exist so a recreate/reuse isn't
+  // blocked by a half-cleaned prior run. Best-effort — never the failure.
+  await io.pruneWorktrees();
+
+  const branchExists = await io.branchExists(branch);
+  if (!branchExists) {
+    await io.addWorktreeNewBranch(path, branch, base);
+    return { path, action: { kind: "create-fresh" } };
+  }
+
+  // Branch exists — is it worth keeping? (commits ahead OR an open PR ⇒ reuse).
+  const [commitsAhead, openPrNumber] = await Promise.all([
+    io.commitsAhead(branch, base),
+    io.openPrNumber(branch),
+  ]);
+  const action = decideBranchAction({ branchExists: true, commitsAhead, openPrNumber });
+
+  switch (action.kind) {
+    case "recreate-stale":
+      await io.deleteBranch(branch);
+      await io.addWorktreeNewBranch(path, branch, base);
+      return { path, action };
+    case "reuse-existing":
+      await io.addWorktreeExistingBranch(path, branch);
+      return { path, action };
+    case "create-fresh":
+      // Unreachable (branchExists is true here) — handled defensively so the
+      // switch is exhaustive and a future decider change can't silently skip
+      // creating the worktree.
+      await io.addWorktreeNewBranch(path, branch, base);
+      return { path, action };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2 — post-session commit-state decision
+// ---------------------------------------------------------------------------
+
+/** The worktree's git state after the CC session, relative to base. */
+export interface DevWorktreeStatus {
+  /** Commits on the branch ahead of `origin/<base>`. */
+  commitsAhead: number;
+  /** True when the working tree has uncommitted changes (tracked or untracked). */
+  hasUncommittedChanges: boolean;
+}
+
+/** What the consumer does after the CC session, before the forge push. */
+export type PostSessionAction =
+  /** Agent committed (commits ahead, clean tree) — push straight through. */
+  | { kind: "proceed" }
+  /** Agent edited but left changes uncommitted — fallback-commit, then push. */
+  | { kind: "commit-then-proceed" }
+  /** Agent produced nothing — fail with a clear "no implementation" reason. */
+  | { kind: "fail-no-implementation" };
+
+/**
+ * Decide the post-session action from the worktree's git state. PURE.
+ *
+ * Uncommitted changes ALWAYS win the leftover-commit path (capture the work
+ * whether or not earlier commits exist — never lose a partial run). A clean
+ * tree with commits ahead proceeds. A clean tree with nothing ahead is the
+ * "session produced no implementation" failure.
+ */
+export function decidePostSessionAction(status: DevWorktreeStatus): PostSessionAction {
+  if (status.hasUncommittedChanges) return { kind: "commit-then-proceed" };
+  if (status.commitsAhead > 0) return { kind: "proceed" };
+  return { kind: "fail-no-implementation" };
+}

--- a/src/runner/orchestrator-command.ts
+++ b/src/runner/orchestrator-command.ts
@@ -134,9 +134,12 @@ function buildBrief(repo: string, issue: number): string {
     `Implement ${repo}#${issue}. ` +
     `Read the issue for the full spec and acceptance criteria ` +
     `(\`gh issue view ${issue} --repo ${repo}\`), follow the repo's CONTEXT.md ` +
-    `and Standard Operating Procedures, work in a worktree-isolated feature ` +
-    `branch, and open a PR that closes #${issue}. Do NOT merge — the merge is ` +
-    `a human gate.`
+    `and Standard Operating Procedures, and work in your worktree. ` +
+    `When the implementation is done you MUST COMMIT your work with a ` +
+    `conventional-commit message (e.g. \`feat: … (closes #${issue})\`) before ` +
+    `you finish — the dev-loop pushes your branch and opens the PR for you, so ` +
+    `you only need to COMMIT (do NOT push or open the PR yourself, and do NOT ` +
+    `merge — the merge is a human gate).`
   );
 }
 


### PR DESCRIPTION
## What & why

Two dev-**worker** bugs surfaced running `@vega implement cortex#1196` — the infra is fine, but the worker flow never produced a PR. This fixes both so a dispatched implement run reaches push + PR.

### Bug 1 — branch collision
`orchestrator-command.ts` dispatches a **fixed** branch `feat/{N}-{repo}`. The worktree *path* is unique (`-<hash>`) but the *branch* isn't, so a re-dispatch collided with a prior run's leftover branch → `git worktree add -b feat/1196-cortex …: a branch named '…' already exists`.

New `src/runner/dev-worktree.ts` adds a pure `decideBranchAction` + `createWorktreeHandlingExistingBranch` (same pure-decider + thin-IO-seam shape as `commit-signing.ts`). The production worktree-create seam now routes through it and **never hard-fails on an existing branch**:

| Branch state | Action |
|---|---|
| absent | create fresh (`-b`) |
| stale — no commits ahead of base **and** no open PR | delete + recreate fresh |
| has commits **or** an open PR | **reuse** the branch (warm-resume; `git worktree add` with no `-b`), logging the open PR number |

It prunes stale worktree refs first (the common cleanup-failure shape). A genuinely live worktree still holding the branch surfaces as a typed `cant_do` failure, not a crash.

### Bug 2 — no commits → push refused
The pipeline does `worktree → CC session → gates → push + PR` with **no commit step** — it relied on the agent to commit, but nothing told it to (the old brief said "open a PR", which the consumer actually does). It edited files, never committed → forge: `refusing to push … no commits to verify`.

1. **Prompt** (`orchestrator-command.ts buildBrief`): now explicitly instructs the agent to **COMMIT** its implementation (conventional commit) before finishing, and that the dev-loop pushes + opens the PR (so the agent must only commit). *(Note: the dev session prompt is `payload.brief` — `prompt-builder.ts buildPrompt` is the Discord chat path, not the dev-implement path, so the brief is the correct lever.)*
2. **Consumer safety** — a new injected `DevGitInspector` seam + pure `decidePostSessionAction`. After the CC session, before the forge push:
   - **uncommitted leftover** (agent forgot) → fallback-commit it (signed `-S`, so the W5.0 push-boundary signing gate passes) with `feat: implement <repo>#<issue> (dev-loop fallback commit)` + a WARN — the run isn't lost.
   - **nothing produced** → a clear typed `dispatch.task.failed` whose reason names `session produced no implementation/commits`, **not** forge's confusing `no commits to verify`.

## Seams kept injectable
Both bug surfaces stay behind injected seams (`DevWorkspace.create` production impl for Bug 1; the new `DevGitInspector` for Bug 2). Tests drive the deciders, the worktree orchestration, and the consumer commit-safety paths with fakes — no real git/gh/CC.

## Tests
- `dev-worktree.test.ts` — `decideBranchAction` + `decidePostSessionAction` truth tables; `createWorktreeHandlingExistingBranch` orchestration (absent / stale / commits / open-PR; re-dispatch with a stale branch never hard-fails).
- `dev-consumer.test.ts` — session edits+commits → push+PR (unchanged); edits-but-forgets → consumer commits leftover + pushes; produces-nothing → clear typed failure asserted **not** to be the forge push error; status-throw and fallback-commit-throw paths.
- Existing dev-consumer / boot / orchestrator tests still pass.

## Gates
- `bunx tsc --noEmit` ✅
- `bunx eslint --quiet .` ✅
- `bash scripts/check-carveouts.sh` ✅ (PASS)
- full `bun test src/` ✅ — 7470 pass, 0 fail (the known `cortex.agents-reload` fs.watch flake didn't fire)

Closes #1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)