### PR TITLE
feat(cli): C-1228 — default registry trust anchor (PR3.5)

### DIFF
--- a/docs/config-layout/network/example-network.yaml
+++ b/docs/config-layout/network/example-network.yaml
@@ -35,10 +35,24 @@
 #     # registry — the network-registry endpoint + DD-9 trust pin.
 #     # `cortex network join <network>` (#753) derives its --registry-url /
 #     # --registry-pubkey from here, so the one-liner needs no registry flags.
+#     #
+#     # cortex#1228 — you usually DON'T need this block at all for the
+#     # metafactory network: the default registry (URL + Ed25519 pubkey) is
+#     # PRE-PINNED, compiled into cortex (the "root-CA" anchor), so a fresh
+#     # install trusts it with zero paste and zero TOFU. Only declare `registry:`
+#     # below to (a) point at a CUSTOM (non-default) network, or (b) override the
+#     # baked default. TODO(arc-populate): `arc upgrade Cortex` is intended to
+#     # also WRITE this block from the compiled-in DEFAULT_REGISTRY anchor
+#     # (defense-in-depth — pinned in binary AND visible in config); that
+#     # arc-side populate is a follow-up (tracked on #1228).
 #     registry:
-#       url: https://registry.meta-factory.ai
-#       # OPTIONAL pinned Ed25519 pubkey (base64, 44 chars). Omit for TOFU on
-#       # first boot; paste the pinned value here for zero-TOFU.
+#       # The canonical host that serves GET /registry/pubkey. (NOT
+#       # `registry.meta-factory.ai`, which does not resolve.)
+#       url: https://network.meta-factory.ai
+#       # OPTIONAL pinned Ed25519 pubkey (base64, 44 chars). On the DEFAULT url
+#       # above you can omit this — cortex pins the compiled-in anchor (no TOFU).
+#       # For a CUSTOM registry, omit ⇒ TOFU on first boot (with a warning);
+#       # paste the pinned value here for zero-TOFU.
 #       # pubkey: <REPLACE_ME_REGISTRY_PUBKEY>
 #
 #     networks:

--- a/src/cli/cortex/commands/__tests__/default-registry.test.ts
+++ b/src/cli/cortex/commands/__tests__/default-registry.test.ts
@@ -1,0 +1,159 @@
+/**
+ * cortex#1228 (PR3.5) — tests for the baked-in default registry trust anchor
+ * and the {@link resolveRegistryAnchor} precedence chokepoint.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  DEFAULT_REGISTRY,
+  isDefaultRegistryUrl,
+  resolveRegistryAnchor,
+  type RegistryAnchor,
+} from "../default-registry";
+
+// =============================================================================
+// The compiled-in anchor
+// =============================================================================
+
+describe("DEFAULT_REGISTRY anchor", () => {
+  test("host is the canonical network.meta-factory.ai (serves /registry/pubkey)", () => {
+    expect(DEFAULT_REGISTRY.url).toBe("https://network.meta-factory.ai");
+    // Must NOT be the stale `registry.` host (doesn't resolve).
+    expect(DEFAULT_REGISTRY.url).not.toContain("registry.meta-factory.ai");
+  });
+
+  test("pubkey is the VERIFIED live anchor (base64 Ed25519, 44 chars incl '=')", () => {
+    // Verified 2026-06-27 against GET https://network.meta-factory.ai/registry/pubkey.
+    expect(DEFAULT_REGISTRY.pubkey).toBe(
+      "ErrjFoLzi4jw7TuTqjPMg5OnQCH0oKUClWgr8VyYHmk=",
+    );
+    expect(DEFAULT_REGISTRY.pubkey).toHaveLength(44);
+    expect(DEFAULT_REGISTRY.pubkey.endsWith("=")).toBe(true);
+    // Non-empty ⇒ the default is genuinely pinned (no accidental TOFU fallback).
+    expect(DEFAULT_REGISTRY.pubkey).not.toBe("");
+  });
+
+  test("no rotation in progress (next undefined) in steady state", () => {
+    expect(DEFAULT_REGISTRY.next).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// isDefaultRegistryUrl
+// =============================================================================
+
+describe("isDefaultRegistryUrl", () => {
+  test("matches the anchor URL", () => {
+    expect(isDefaultRegistryUrl("https://network.meta-factory.ai")).toBe(true);
+  });
+  test("trailing-slash insensitive", () => {
+    expect(isDefaultRegistryUrl("https://network.meta-factory.ai/")).toBe(true);
+    expect(isDefaultRegistryUrl("https://network.meta-factory.ai///")).toBe(true);
+  });
+  test("a custom URL is NOT the default", () => {
+    expect(isDefaultRegistryUrl("https://registry.meta-factory.ai")).toBe(false);
+    expect(isDefaultRegistryUrl("https://r.test")).toBe(false);
+  });
+  test("undefined / empty is NOT the default", () => {
+    expect(isDefaultRegistryUrl(undefined)).toBe(false);
+    expect(isDefaultRegistryUrl("")).toBe(false);
+  });
+});
+
+// =============================================================================
+// resolveRegistryAnchor — the precedence chokepoint
+// =============================================================================
+
+describe("resolveRegistryAnchor — default fallback (the headline)", () => {
+  test("NOTHING configured → falls back to the default anchor, PINNED, no TOFU", () => {
+    const r = resolveRegistryAnchor({});
+    expect(r.url).toBe(DEFAULT_REGISTRY.url);
+    expect(r.pubkey).toBe(DEFAULT_REGISTRY.pubkey);
+    expect(r.tofu).toBe(false);
+    expect(r.trust).toBe("default-pinned");
+  });
+
+  test("default URL configured but NO pubkey → still pinned to the baked key (no TOFU)", () => {
+    const r = resolveRegistryAnchor({ configUrl: "https://network.meta-factory.ai" });
+    expect(r.pubkey).toBe(DEFAULT_REGISTRY.pubkey);
+    expect(r.tofu).toBe(false);
+    expect(r.trust).toBe("default-pinned");
+  });
+
+  test("default URL with trailing slash + no pubkey → still default-pinned", () => {
+    const r = resolveRegistryAnchor({ configUrl: "https://network.meta-factory.ai/" });
+    expect(r.pubkey).toBe(DEFAULT_REGISTRY.pubkey);
+    expect(r.trust).toBe("default-pinned");
+  });
+});
+
+describe("resolveRegistryAnchor — explicit pins win", () => {
+  test("flag pubkey wins over everything", () => {
+    const r = resolveRegistryAnchor({
+      flagUrl: "https://custom.test",
+      flagPubkey: "Z".repeat(43) + "=",
+      configUrl: "https://network.meta-factory.ai",
+      configPubkey: "Y".repeat(43) + "=",
+    });
+    expect(r.url).toBe("https://custom.test");
+    expect(r.pubkey).toBe("Z".repeat(43) + "=");
+    expect(r.tofu).toBe(false);
+    expect(r.trust).toBe("flag-pinned");
+  });
+
+  test("config pubkey pins when no flag", () => {
+    const r = resolveRegistryAnchor({
+      configUrl: "https://custom.test",
+      configPubkey: "Y".repeat(43) + "=",
+    });
+    expect(r.pubkey).toBe("Y".repeat(43) + "=");
+    expect(r.tofu).toBe(false);
+    expect(r.trust).toBe("config-pinned");
+  });
+
+  test("an explicit pin on the DEFAULT url is honoured as config/flag-pinned", () => {
+    const r = resolveRegistryAnchor({
+      configUrl: "https://network.meta-factory.ai",
+      configPubkey: "Y".repeat(43) + "=",
+    });
+    expect(r.pubkey).toBe("Y".repeat(43) + "=");
+    expect(r.trust).toBe("config-pinned");
+  });
+});
+
+describe("resolveRegistryAnchor — custom registry TOFU (gated)", () => {
+  test("custom URL, NO pubkey → TOFU (caller must warn)", () => {
+    const r = resolveRegistryAnchor({ configUrl: "https://custom.test" });
+    expect(r.url).toBe("https://custom.test");
+    expect(r.pubkey).toBeUndefined();
+    expect(r.tofu).toBe(true);
+    expect(r.trust).toBe("tofu");
+  });
+
+  test("flag URL (custom), NO pubkey → TOFU", () => {
+    const r = resolveRegistryAnchor({ flagUrl: "https://flag.custom" });
+    expect(r.tofu).toBe(true);
+    expect(r.trust).toBe("tofu");
+  });
+});
+
+describe("resolveRegistryAnchor — secure-by-default when the anchor is UNPINNED", () => {
+  // The escape hatch (if we ever ship without a verified pubkey): an empty
+  // anchor pubkey must NEVER be pinned — it must fall back to TOFU, not pin "".
+  const unpinned: RegistryAnchor = { url: "https://network.meta-factory.ai", pubkey: "" };
+
+  test("default URL + empty anchor pubkey → TOFU, NOT an empty pin", () => {
+    const r = resolveRegistryAnchor({ configUrl: "https://network.meta-factory.ai", anchor: unpinned });
+    expect(r.pubkey).toBeUndefined();
+    expect(r.tofu).toBe(true);
+    expect(r.trust).toBe("tofu");
+  });
+
+  test("nothing configured + empty anchor pubkey → default URL but TOFU", () => {
+    const r = resolveRegistryAnchor({ anchor: unpinned });
+    expect(r.url).toBe(unpinned.url);
+    expect(r.pubkey).toBeUndefined();
+    expect(r.tofu).toBe(true);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -86,15 +86,16 @@ describe("join usage", () => {
     expect(res.stderr).toContain("principal.id");
   });
 
-  test("#753 — principal flagged but no registry derivable → names registry field (exit 2)", async () => {
+  test("#753 — principal flagged, empty config → names the next missing field (exit 2)", async () => {
     const res = await dispatchNetwork(
       ["join", "metafactory", "--principal", "andreas"],
       EMPTY_READER,
     );
     expect(res.exitCode).toBe(2);
-    // First underivable required value after seed surfaces; with empty config
-    // the seed is also missing, so seed is named first.
-    expect(res.stderr).toMatch(/cannot resolve (signing seed|registry URL)/);
+    // cortex#1228 — the registry is no longer a missing-field error (it falls
+    // back to the default anchor), so the seed is the first underivable
+    // required value with an empty config.
+    expect(res.stderr).toContain("cannot resolve signing seed");
   });
 
   test("--apply and --dry-run are mutually exclusive (exit 2)", async () => {
@@ -179,6 +180,45 @@ describe("join dry-run safety", () => {
     ], EMPTY_READER);
     // Failure output goes to stderr; it still carries the dry-run banner.
     expect(res.stderr).toContain("dry-run");
+  });
+});
+
+// =============================================================================
+// cortex#1228 — TOFU is never silent for a custom registry; pinned ⇒ no warning
+// =============================================================================
+
+describe("#1228 — custom-registry TOFU warning", () => {
+  test("custom registry, NO pubkey → emits the explicit TOFU warning", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0", // custom + unreachable by construction
+      "--seed-path", join(dir, "seed.nk"),
+      "--creds", join(dir, "andreas.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+    ], EMPTY_READER);
+    // The warning is emitted before the (failing) register step.
+    expect(res.stderr).toContain("TOFU");
+    expect(res.stderr).toContain("custom");
+  });
+
+  test("custom registry WITH --registry-pubkey → NO TOFU warning (pinned)", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--registry-pubkey", "Z".repeat(43) + "=",
+      "--seed-path", join(dir, "seed.nk"),
+      "--creds", join(dir, "andreas.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+    ], EMPTY_READER);
+    expect(res.stderr).not.toContain("Trusting it on first use");
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -19,6 +19,7 @@ import {
   defaultCredsPath,
   type ConfigReader,
 } from "../network-derive";
+import { DEFAULT_REGISTRY } from "../default-registry";
 import type { LoadedConfig } from "../../../../common/config/loader";
 import type { AgentConfig } from "../../../../common/types/config";
 
@@ -173,7 +174,7 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
     expect(defaultCredsPath("metafactory")).toBe("~/.config/nats/metafactory.creds");
   });
 
-  test("registry pubkey absent → omitted (TOFU), still ok", () => {
+  test("CUSTOM registry, pubkey absent → omitted (TOFU) + registryTofu flag set", () => {
     const cfg = loaded({
       principal: { id: "andreas" },
       stack: {
@@ -183,13 +184,17 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
       },
       policy: {
         principals: [], roles: [],
+        // A CUSTOM (non-default) registry with no pubkey ⇒ TOFU.
         federated: { networks: [], registry: { url: "https://r.test" } },
       },
     });
     // Pin darwin — `plist_path` fixture (cortex#771; see above).
     const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
     expect(res.ok).toBe(true);
+    expect(res.inputs?.registryUrl).toBe("https://r.test");
     expect(res.inputs?.registryPubkey).toBeUndefined();
+    // cortex#1228 — the CLI uses this to surface the explicit TOFU warning.
+    expect(res.inputs?.registryTofu).toBe(true);
   });
 
   test("no stack.id → convention {principal}/default", () => {
@@ -296,16 +301,10 @@ describe("deriveJoinInputs — actionable missing-config errors", () => {
     expect(res.reason).toContain("stack.nkey_seed_path");
   });
 
-  test("no registry anywhere → names policy.federated.registry.url", () => {
-    const cfg = loaded({
-      principal: { id: "andreas" },
-      stack: { id: "andreas/mf", nkey_seed_path: "~/s" },
-    });
-    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
-    expect(res.ok).toBe(false);
-    expect(res.reason).toContain("policy.federated.registry.url");
-  });
-
+  // cortex#1228 — the registry is NO LONGER a missing-field error: when neither
+  // flag nor config supplies it, the derive falls back to the compiled-in
+  // DEFAULT_REGISTRY anchor (pinned, no TOFU). See the dedicated default-anchor
+  // describe block below. The next still-required field surfaces normally.
   test("no nats config path → names stack.nats_infra.config_path", () => {
     const cfg = loaded({
       principal: { id: "andreas" },
@@ -362,6 +361,79 @@ describe("deriveJoinInputs — actionable missing-config errors", () => {
     const res = deriveJoinInputs("metafactory", { account: acct }, "/cfg", reader(cfg), "darwin");
     expect(res.ok).toBe(true);
     expect(res.inputs?.account).toBe(acct);
+  });
+});
+
+// =============================================================================
+// cortex#1228 — default registry trust anchor: derive fallback + TOFU gating
+// =============================================================================
+
+describe("deriveJoinInputs — default registry anchor (#1228)", () => {
+  // A complete stack config WITHOUT a policy.federated.registry block. The
+  // registry must fall back to the compiled-in DEFAULT_REGISTRY anchor.
+  const NO_REGISTRY = loaded({
+    principal: { id: "andreas" },
+    stack: {
+      id: "andreas/meta-factory",
+      nkey_seed_path: "~/seed.nk",
+      nats_infra: { config_path: "~/c", plist_path: "~/p", account: "A" + "D".repeat(55) },
+    },
+    policy: { principals: [], roles: [], federated: { networks: [] } },
+  });
+
+  test("NO registry in config → falls back to DEFAULT_REGISTRY, PINNED, no TOFU", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(NO_REGISTRY), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.registryUrl).toBe(DEFAULT_REGISTRY.url);
+    expect(res.inputs?.registryPubkey).toBe(DEFAULT_REGISTRY.pubkey);
+    // The default is pre-pinned — registryTofu must be ABSENT (no warning).
+    expect(res.inputs?.registryTofu).toBeUndefined();
+  });
+
+  test("default URL configured but NO pubkey → still default-pinned (no TOFU)", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/meta-factory",
+        nkey_seed_path: "~/seed.nk",
+        nats_infra: { config_path: "~/c", plist_path: "~/p", account: "A" + "D".repeat(55) },
+      },
+      policy: {
+        principals: [], roles: [],
+        federated: { networks: [], registry: { url: DEFAULT_REGISTRY.url } },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.registryPubkey).toBe(DEFAULT_REGISTRY.pubkey);
+    expect(res.inputs?.registryTofu).toBeUndefined();
+  });
+
+  test("--registry-url override to a CUSTOM registry (no pubkey) → TOFU flagged", () => {
+    const res = deriveJoinInputs(
+      "metafactory",
+      { registryUrl: "https://my.custom.registry" },
+      "/cfg",
+      reader(NO_REGISTRY),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.registryUrl).toBe("https://my.custom.registry");
+    expect(res.inputs?.registryPubkey).toBeUndefined();
+    expect(res.inputs?.registryTofu).toBe(true);
+  });
+
+  test("--registry-pubkey override pins a custom registry (no TOFU)", () => {
+    const res = deriveJoinInputs(
+      "metafactory",
+      { registryUrl: "https://my.custom.registry", registryPubkey: "Z".repeat(43) + "=" },
+      "/cfg",
+      reader(NO_REGISTRY),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.registryPubkey).toBe("Z".repeat(43) + "=");
+    expect(res.inputs?.registryTofu).toBeUndefined();
   });
 });
 

--- a/src/cli/cortex/commands/default-registry.ts
+++ b/src/cli/cortex/commands/default-registry.ts
@@ -79,7 +79,7 @@ export const DEFAULT_REGISTRY: RegistryAnchor = {
 };
 
 /** First non-empty string in the list, or undefined. */
-function firstNonEmpty(...vals: Array<string | undefined>): string | undefined {
+function firstNonEmpty(...vals: (string | undefined)[]): string | undefined {
   for (const v of vals) {
     if (v !== undefined && v !== "") return v;
   }

--- a/src/cli/cortex/commands/default-registry.ts
+++ b/src/cli/cortex/commands/default-registry.ts
@@ -1,0 +1,172 @@
+/**
+ * cortex#1228 (PR3.5) — the baked-in **default registry trust anchor**.
+ *
+ * Root-CA model: cortex ships the metafactory network-registry as a pinned,
+ * well-known anchor so a *fresh install trusts the default network with zero
+ * paste and zero TOFU*. This removes the one un-TCP/IP step from the join flow
+ * ("step 3: pin the registry") — it disappears for the metafactory network
+ * (pre-pinned) and reappears only when deliberately joining a NON-default
+ * (custom) network. Part of EPIC #1142.
+ *
+ * ## Trust model
+ *
+ *   - **Default registry** → ALWAYS pre-pinned. The `pubkey` below is the
+ *     compiled-in anchor, so a join/boot against `DEFAULT_REGISTRY.url` verifies
+ *     against this key WITHOUT a TOFU window. More secure (no first-use
+ *     substitution window) AND zero-config.
+ *   - **Custom registry** (any URL ≠ the default) → TOFU is retained, but it is
+ *     surfaced with an explicit warning, never silent. A principal pinning a
+ *     custom anchor (`--registry-pubkey` / `policy.federated.registry.pubkey`)
+ *     gets that pin; an UNpinned custom registry trusts-on-first-use behind the
+ *     warning.
+ *
+ * ## Rotation
+ *
+ * `next` carries the NEXT anchor pubkey during a key-rotation overlap window.
+ * The intent (issue #1228) is that a verifier accepts a registry assertion
+ * signed by EITHER `pubkey` (current) OR `next` so a rotation does not break
+ * pinned clients mid-flight. `next` is `undefined` whenever no rotation is in
+ * progress (the steady state today). NOTE: the join/boot derive pins the
+ * CURRENT `pubkey`; the dual-accept `{current, next}` verification belongs to
+ * the registry client/resolver and is tracked as a follow-up (see
+ * {@link RegistryAnchor.next}).
+ *
+ * ## Defense-in-depth (the arc-populate half)
+ *
+ * `arc upgrade Cortex` is intended to also WRITE `policy.federated.registry.
+ * {url,pubkey}` from this anchor so the pin is both compiled into the binary
+ * AND visible in config. That arc-side populate is NOT in this repo — see the
+ * TODO in `docs/config-layout/network/example-network.yaml`. The in-cortex
+ * fallback implemented here means the pin is correct EVEN WHEN config omits it.
+ */
+
+/** A pinned registry trust anchor: a URL + its Ed25519 pubkey (base64). */
+export interface RegistryAnchor {
+  /** Registry base URL (no trailing slash, by convention). */
+  url: string;
+  /**
+   * Pinned Ed25519 pubkey (base64, 44 chars incl. the trailing `=`). An EMPTY
+   * string means "anchor not pinned" — callers MUST treat that as unpinned and
+   * fall back to TOFU rather than pinning an empty/garbage key (secure-by-
+   * default: never pin an unverified value).
+   */
+  pubkey: string;
+  /**
+   * Rotation overlap — the NEXT pubkey, accepted alongside {@link pubkey} during
+   * a key-rotation window. `undefined` in steady state. See module JSDoc.
+   */
+  next?: string;
+}
+
+/**
+ * The compiled-in metafactory registry anchor.
+ *
+ * `pubkey` VERIFIED 2026-06-27 against the live endpoint:
+ *   `curl -s https://network.meta-factory.ai/registry/pubkey`
+ *   → {"algorithm":"Ed25519","public_key":"ErrjFoLzi4jw7TuTqjPMg5OnQCH0oKUClWgr8VyYHmk="}
+ * cross-checked against `docs/sop-onboard-peer-principal.md` (the pinned 44-char
+ * trust anchor) and `docs/sop-network-registry.md`.
+ *
+ * Host is `network.meta-factory.ai` — the host that actually serves
+ * `/registry/pubkey` and that the registry `wrangler.toml` route points at.
+ * (`registry.meta-factory.ai` does NOT resolve; the old config-layout template
+ * used it by mistake — aligned in #1228.)
+ */
+export const DEFAULT_REGISTRY: RegistryAnchor = {
+  url: "https://network.meta-factory.ai",
+  pubkey: "ErrjFoLzi4jw7TuTqjPMg5OnQCH0oKUClWgr8VyYHmk=",
+  // next: undefined — no rotation in progress.
+};
+
+/** First non-empty string in the list, or undefined. */
+function firstNonEmpty(...vals: Array<string | undefined>): string | undefined {
+  for (const v of vals) {
+    if (v !== undefined && v !== "") return v;
+  }
+  return undefined;
+}
+
+/** Strip trailing slash(es) for a stable URL identity comparison. */
+function normalizeUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Is `url` the default (pre-pinned) registry? Trailing-slash-insensitive so
+ * `https://network.meta-factory.ai` and `…/` compare equal. `undefined` ⇒ no
+ * url given ⇒ NOT the default (the caller will fall back to the default url
+ * separately).
+ */
+export function isDefaultRegistryUrl(
+  url: string | undefined,
+  anchor: RegistryAnchor = DEFAULT_REGISTRY,
+): boolean {
+  if (url === undefined || url === "") return false;
+  return normalizeUrl(url) === normalizeUrl(anchor.url);
+}
+
+/** Which trust path produced the resolved registry. */
+export type RegistryTrust =
+  | "flag-pinned" // an explicit --registry-pubkey flag
+  | "config-pinned" // policy.federated.registry.pubkey
+  | "default-pinned" // the compiled-in DEFAULT_REGISTRY anchor (no TOFU)
+  | "tofu"; // custom registry, no pin → trust-on-first-use
+
+export interface ResolvedRegistry {
+  /** The resolved registry URL — ALWAYS present (falls back to the anchor). */
+  url: string;
+  /** The pinned pubkey, or `undefined` when TOFU applies. */
+  pubkey?: string;
+  /**
+   * `true` ⇒ no pubkey could be pinned and the registry is NOT the default —
+   * the caller will trust-on-first-use and MUST surface a warning.
+   */
+  tofu: boolean;
+  trust: RegistryTrust;
+}
+
+/**
+ * Resolve the registry URL + pubkey from (in precedence) flags → config →
+ * the compiled-in {@link DEFAULT_REGISTRY} anchor. This is the single chokepoint
+ * the join derive AND the boot path use so the trust posture is identical
+ * everywhere:
+ *
+ *   1. URL: flag → config → `anchor.url` (so it ALWAYS resolves — closes the
+ *      `network-derive.ts:320` hard-error gap).
+ *   2. pubkey, in order:
+ *      a. explicit pin (flag or config) → use it (`flag-pinned`/`config-pinned`).
+ *      b. else, if the resolved URL IS the default registry AND the anchor is
+ *         pinned (non-empty pubkey) → pin the baked key (`default-pinned`, NO
+ *         TOFU).
+ *      c. else (custom registry, or default-but-anchor-unpinned) → no pin,
+ *         `tofu: true` (`tofu`).
+ */
+export function resolveRegistryAnchor(opts: {
+  flagUrl?: string;
+  flagPubkey?: string;
+  configUrl?: string;
+  configPubkey?: string;
+  anchor?: RegistryAnchor;
+}): ResolvedRegistry {
+  const anchor = opts.anchor ?? DEFAULT_REGISTRY;
+  const url = firstNonEmpty(opts.flagUrl, opts.configUrl) ?? anchor.url;
+
+  const flagPubkey = firstNonEmpty(opts.flagPubkey);
+  if (flagPubkey !== undefined) {
+    return { url, pubkey: flagPubkey, tofu: false, trust: "flag-pinned" };
+  }
+  const configPubkey = firstNonEmpty(opts.configPubkey);
+  if (configPubkey !== undefined) {
+    return { url, pubkey: configPubkey, tofu: false, trust: "config-pinned" };
+  }
+
+  // No explicit pin — is this the pre-pinned default registry?
+  const anchorPubkey = firstNonEmpty(anchor.pubkey);
+  if (isDefaultRegistryUrl(url, anchor) && anchorPubkey !== undefined) {
+    return { url, pubkey: anchorPubkey, tofu: false, trust: "default-pinned" };
+  }
+
+  // Custom registry with no pin (or default registry whose anchor is unpinned)
+  // → trust-on-first-use. The caller surfaces the warning.
+  return { url, tofu: true, trust: "tofu" };
+}

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -19,8 +19,9 @@
  *   | principal         | --principal       | principal.id                                   | —                                  |
  *   | stack             | --stack           | stack.id (single configured stack)             | {principal}/default                |
  *   | seed-path         | --seed-path       | stack.nkey_seed_path                            | —                                  |
- *   | registry-url      | --registry-url    | policy.federated.registry.url                  | —                                  |
- *   | registry-pubkey   | --registry-pubkey | policy.federated.registry.pubkey               | — (TOFU when absent)               |
+ *   | registry-url      | --registry-url    | policy.federated.registry.url                  | DEFAULT_REGISTRY.url (#1228)        |
+ *   | registry-pubkey   | --registry-pubkey | policy.federated.registry.pubkey               | DEFAULT_REGISTRY.pubkey on the      |
+ *   |                   |                   |                                                | default URL; else TOFU (#1228)      |
  *   | nats-config       | --nats-config     | stack.nats_infra.config_path                   | —                                  |
  *   | plist             | --plist           | stack.nats_infra.plist_path                     | —                                  |
  *   | account           | --account         | stack.nats_infra.account                       | —                                  |
@@ -39,6 +40,7 @@
 import type { LoadedConfig } from "../../../common/config/loader";
 import type { ServicePlatform } from "../../../common/nats/nats-service-manager";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
+import { resolveRegistryAnchor } from "./default-registry";
 // network-leaf-package import removed — ADR-0015 retired O-4b / Model-A.
 
 // =============================================================================
@@ -53,6 +55,13 @@ export interface DerivedJoinInputs {
   seedPath: string;
   registryUrl: string;
   registryPubkey?: string;
+  /**
+   * cortex#1228 — `true` ⇒ the resolved registry is a CUSTOM (non-default)
+   * registry with no pinned pubkey, so the join will trust-on-first-use. The
+   * CLI surfaces an explicit warning when this is set (TOFU is never silent).
+   * Absent ⇒ the registry is pinned (default-anchor / config / flag), no TOFU.
+   */
+  registryTofu?: boolean;
   natsConfigPath: string;
   /**
    * macOS — the nats-server launchd plist path (`stack.nats_infra.plist_path`
@@ -339,16 +348,22 @@ export function deriveJoinInputs(
     );
   }
 
-  // registry — flag wins, else policy.federated.registry.{url,pubkey}.
+  // registry — cortex#1228: resolved through the shared anchor chokepoint.
+  // Precedence flag → config → the compiled-in DEFAULT_REGISTRY anchor, so the
+  // URL ALWAYS resolves (closes the old hard-error gap: a fresh install with no
+  // `policy.federated.registry` now defaults to the metafactory registry,
+  // PINNED, with NO TOFU window). pubkey: explicit pin wins; else the default
+  // anchor's baked pubkey when the URL is the default; else absent (TOFU on a
+  // custom registry, flagged via `registryTofu`).
   const registry = cfg.policy?.federated?.registry;
-  const registryUrl = overrides.registryUrl ?? registry?.url;
-  if (registryUrl === undefined || registryUrl === "") {
-    return fail(
-      "cannot resolve registry URL — pass --registry-url or set `policy.federated.registry.url` in cortex.yaml",
-    );
-  }
-  // pubkey stays optional everywhere (TOFU when absent).
-  const registryPubkey = overrides.registryPubkey ?? registry?.pubkey;
+  const resolvedRegistry = resolveRegistryAnchor({
+    ...(overrides.registryUrl !== undefined && { flagUrl: overrides.registryUrl }),
+    ...(overrides.registryPubkey !== undefined && { flagPubkey: overrides.registryPubkey }),
+    ...(registry?.url !== undefined && { configUrl: registry.url }),
+    ...(registry?.pubkey !== undefined && { configPubkey: registry.pubkey }),
+  });
+  const registryUrl = resolvedRegistry.url;
+  const registryPubkey = resolvedRegistry.pubkey;
 
   // nats-infra — flag wins, else stack.nats_infra.{config_path,plist_path,account}.
   const natsInfra = cfg.stack?.nats_infra;
@@ -428,6 +443,7 @@ export function deriveJoinInputs(
       seedPath,
       registryUrl,
       ...(registryPubkey !== undefined && { registryPubkey }),
+      ...(resolvedRegistry.tofu && { registryTofu: true }),
       natsConfigPath,
       ...(descriptor.plistPath !== undefined && { plistPath: descriptor.plistPath }),
       ...(descriptor.unitPath !== undefined && { unitPath: descriptor.unitPath }),

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -74,6 +74,7 @@ import {
   tolerantReader,
   type ConfigReader,
 } from "./network-derive";
+import { DEFAULT_REGISTRY } from "./default-registry";
 // network-leaf-package import removed — ADR-0015 retired O-4b / Model-A.
 
 /**
@@ -130,8 +131,12 @@ export { type ExitResult } from "./_shared/exit-result";
 
 type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "admit";
 
-/** Default registry URL when neither --registry-url nor config provides one. */
-const DEFAULT_REGISTRY_URL = "https://network.meta-factory.ai";
+/**
+ * Default registry URL when neither --registry-url nor config provides one.
+ * cortex#1228 — sourced from the single compiled-in {@link DEFAULT_REGISTRY}
+ * anchor (the host that actually serves `/registry/pubkey`).
+ */
+const DEFAULT_REGISTRY_URL = DEFAULT_REGISTRY.url;
 
 /**
  * #753 — default cortex.yaml path the config-deriver reads when no `--config`
@@ -521,6 +526,21 @@ async function runJoin(
   }
   const inputs = derived.inputs;
 
+  // cortex#1228 — TOFU is NEVER silent. A custom (non-default) registry with no
+  // pinned pubkey is trusted-on-first-use; surface a loud warning so the
+  // principal knows a network-path attacker could substitute the anchor. The
+  // default metafactory registry is pre-pinned (compiled-in) and never reaches
+  // this branch. Folded into the returned ExitResult.stderr (below) so it is
+  // both visible on the terminal AND captured by the CLI test harness.
+  const tofuWarning =
+    inputs.registryTofu === true
+      ? `cortex network join: WARNING — registry ${inputs.registryUrl} is a custom ` +
+        `(non-default) registry with NO pinned pubkey. Trusting it on first use (TOFU): ` +
+        `a network-path attacker could substitute their own trust anchor. Pin it with ` +
+        `--registry-pubkey <key> or policy.federated.registry.pubkey, or join the default ` +
+        `metafactory network (${DEFAULT_REGISTRY.url}, pre-pinned) with no --registry-url.\n`
+      : undefined;
+
   // Grammar checks on the RESOLVED principal (derived or flagged).
   if (!PRINCIPAL_ID_RE.test(inputs.principal)) {
     return usageError("join", `principal "${inputs.principal}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
@@ -558,10 +578,15 @@ async function runJoin(
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 
   const res = await joinNetwork(networkId, stack, ports);
-  return renderFlowResult("join", networkId, res.ok, res.reason, res.steps, applyRes.apply, json, {
+  const flow = renderFlowResult("join", networkId, res.ok, res.reason, res.steps, applyRes.apply, json, {
     used_cache: res.usedCache === true ? "true" : "false",
     peers: (res.resolvedPeers ?? []).join(","),
   });
+  // cortex#1228 — prepend the custom-registry TOFU warning to stderr (when set)
+  // so it is surfaced regardless of the flow's success/JSON mode.
+  return tofuWarning !== undefined
+    ? { ...flow, stderr: tofuWarning + flow.stderr }
+    : flow;
 }
 
 async function runLeave(
@@ -1245,8 +1270,8 @@ function opError(sub: string, reason: string, json: boolean): ExitResult {
 // ADR-0015 — runAdmit: one-command admin admission decision (R2, cortex#1142)
 // =============================================================================
 
-/** Default registry URL — mirrors network create / join constants. */
-const DEFAULT_ADMIT_REGISTRY_URL = "https://network.meta-factory.ai";
+/** Default registry URL — mirrors network create / join constants (#1228). */
+const DEFAULT_ADMIT_REGISTRY_URL = DEFAULT_REGISTRY.url;
 
 /** Default Discord role for O-5 community-fleet admission. */
 const DEFAULT_ADMIT_DISCORD_ROLE = "community-fleet";

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3379,9 +3379,7 @@ export async function startCortex(
       // window on the default). A custom registry with no pin still falls
       // through to the client's TOFU (pubkey left undefined here).
       const resolvedFederationRegistry = resolveRegistryAnchor({
-        ...(federationRegistryConfig.url !== undefined && {
-          configUrl: federationRegistryConfig.url,
-        }),
+        configUrl: federationRegistryConfig.url,
         ...(federationRegistryConfig.pubkey !== undefined && {
           configPubkey: federationRegistryConfig.pubkey,
         }),
@@ -3537,7 +3535,7 @@ export async function startCortex(
       // is the default registry and config omits the pubkey (no TOFU on the
       // default). Custom registries keep the client's TOFU (pubkey undefined).
       const resolvedRegistry = resolveRegistryAnchor({
-        ...(registryConfig.url !== undefined && { configUrl: registryConfig.url }),
+        configUrl: registryConfig.url,
         ...(registryConfig.pubkey !== undefined && { configPubkey: registryConfig.pubkey }),
       });
       registryClient = new RegistryClient({

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -253,6 +253,7 @@ import { WorklogManager } from "./runner/worklog-manager";
 // `cortex provision-stack register …` work directly (no `bun src/...` prefix).
 // These do NOT boot the daemon — only `start` does.
 import { dispatchNetwork } from "./cli/cortex/commands/network";
+import { resolveRegistryAnchor } from "./cli/cortex/commands/default-registry";
 import { dispatchOffer } from "./cli/cortex/commands/offer";
 import { dispatchProvisionStack } from "./cli/cortex/commands/provision-stack";
 import { dispatchRelease } from "./cli/cortex/commands/release";
@@ -3372,11 +3373,24 @@ export async function startCortex(
           `stack NKey pubkey ${stackNKeyPubForVerifier} to base64 ed25519\n`,
       );
     } else {
+      // cortex#1228 — resolve the registry pubkey through the shared anchor:
+      // when the configured URL is the default metafactory registry but no
+      // pubkey is pinned in config, pin the compiled-in anchor pubkey (no TOFU
+      // window on the default). A custom registry with no pin still falls
+      // through to the client's TOFU (pubkey left undefined here).
+      const resolvedFederationRegistry = resolveRegistryAnchor({
+        ...(federationRegistryConfig.url !== undefined && {
+          configUrl: federationRegistryConfig.url,
+        }),
+        ...(federationRegistryConfig.pubkey !== undefined && {
+          configPubkey: federationRegistryConfig.pubkey,
+        }),
+      });
       const peerResolver = new PrincipalPubkeyResolver({
         enabled: federationVerifyEnabled,
-        baseUrl: federationRegistryConfig.url,
-        ...(federationRegistryConfig.pubkey !== undefined && {
-          registryPubkey: federationRegistryConfig.pubkey,
+        baseUrl: resolvedFederationRegistry.url,
+        ...(resolvedFederationRegistry.pubkey !== undefined && {
+          registryPubkey: resolvedFederationRegistry.pubkey,
         }),
       });
       const peerRegistry = new MultiPrincipalIdentityRegistry({
@@ -3519,9 +3533,16 @@ export async function startCortex(
         `cortex: policy.federated.registry configured (${registryConfig.url}) but no peers declared — registry client dormant`,
       );
     } else {
+      // cortex#1228 — pin the compiled-in anchor pubkey when the configured URL
+      // is the default registry and config omits the pubkey (no TOFU on the
+      // default). Custom registries keep the client's TOFU (pubkey undefined).
+      const resolvedRegistry = resolveRegistryAnchor({
+        ...(registryConfig.url !== undefined && { configUrl: registryConfig.url }),
+        ...(registryConfig.pubkey !== undefined && { configPubkey: registryConfig.pubkey }),
+      });
       registryClient = new RegistryClient({
-        url: registryConfig.url,
-        ...(registryConfig.pubkey !== undefined && { pubkey: registryConfig.pubkey }),
+        url: resolvedRegistry.url,
+        ...(resolvedRegistry.pubkey !== undefined && { pubkey: resolvedRegistry.pubkey }),
         principalIds: peerPrincipalIds,
       });
       // Boot the client asynchronously — TOFU + initial refresh must


### PR DESCRIPTION
## Summary

Ship the metafactory network-registry as a **baked-in root trust anchor** (root-CA model) so a fresh install trusts the default network with **zero paste and zero TOFU**. Removes the one un-TCP/IP step ("pin the registry") from the join flow for the default network; it reappears only when deliberately joining a custom network. Part of EPIC #1142, sequenced **PR3.5** (before the Model-B join rework #1224 since both touch `network-derive.ts`).

Design: [`docs/design-network-join-control-plane.md`](docs/design-network-join-control-plane.md), [ADR-0003](docs/adr/0003-network-join-control-plane.md).

## What changed

1. **`src/cli/cortex/commands/default-registry.ts`** (new) — the compiled-in `DEFAULT_REGISTRY` anchor (`{ url, pubkey, next? }`), a pure `resolveRegistryAnchor` precedence chokepoint (flag → config → anchor), and `isDefaultRegistryUrl`. `next` is structurally present for rotation overlap.
2. **Join derive fallback** (`network-derive.ts`) — the registry URL now ALWAYS resolves (falls back to the anchor), closing the old `cannot resolve registry URL` hard-error. Both url and pubkey fall back; the default registry is always pinned (no TOFU).
3. **TOFU only for custom registries** — a non-default registry with no pin sets `registryTofu`, and the join CLI emits a loud, explicit warning (TOFU is never silent). The default is pre-pinned and never reaches that branch.
4. **Defense-in-depth at boot** (`cortex.ts`) — both registry consumers (federated-verify seam + RegistryClient) pin the anchor pubkey when the configured URL is the default and config omits the pubkey → no TOFU window on the default at boot.
5. **Hostname fix** — code and the config-layout template now agree on the canonical `network.meta-factory.ai` (the host that actually serves `/registry/pubkey`; `registry.meta-factory.ai` does not resolve).
6. **arc-populate** — left as a clear `TODO(arc-populate)` in the template + JSDoc (that half lives in the arc repo, not here). The in-cortex fallback makes the pin correct even when config omits it.

## Security

- **pubkey VERIFIED** 2026-06-27 against the live endpoint `GET https://network.meta-factory.ai/registry/pubkey` → `ErrjFoLzi4jw7TuTqjPMg5OnQCH0oKUClWgr8VyYHmk=`, cross-checked against `docs/sop-onboard-peer-principal.md` / `docs/sop-network-registry.md`.
- Secure-by-default: `resolveRegistryAnchor` refuses to pin an empty/unset anchor pubkey (falls back to TOFU rather than pinning garbage) — covered by tests.

## Tests (TDD)

- New `default-registry.test.ts` (17 tests): anchor identity, precedence, default-fallback, custom-TOFU, unpinned-anchor escape hatch.
- `network-derive.test.ts`: default-anchor describe block (fallback pins, custom TOFU flag, override pins); updated the obsolete "no registry → error" test.
- `network-cli.test.ts`: custom-registry emits the TOFU warning; pinned custom does not.

## Gate status
- `bunx tsc --noEmit`: **0 errors**
- `scripts/check-carveouts.sh`: **PASS**
- `bun test src/cli/cortex/commands/ src/common/config/`: **1136 pass / 0 fail**
- registry + federated-boot tests: **113 pass / 0 fail**

Closes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)