### PR TITLE
chore: bump to v5.26.8

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.7"
+version: "5.26.8"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
#1231 (#1230): dev worker handles an existing branch (no hard-fail on re-dispatch) + commits the session's work before push (fixes 'no commits to verify'), with a fail-safe probe so a branch with work is never force-deleted. Manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)