### PR TITLE
docs(network): C-1142 R2 — retire Model-A leaf-cred-issuance runbook + lock --from-package retirement (ADR-0015)

### DIFF
--- a/docs/runbook-leaf-cred-issuance.md
+++ b/docs/runbook-leaf-cred-issuance.md
@@ -1,231 +1,37 @@
-# Runbook — Issue a leaf credential for a community principal (admin / admin-agent executable)
+# Runbook — Issue a leaf credential for a community principal — **RETIRED (Model A)**
 
-> **Superseded — see [ADR-0015](./adr/0015-two-tier-onboarding-and-admission-gate.md) and [`sop-onboard-peer-principal.md`](./sop-onboard-peer-principal.md).**
+> **Retired by [ADR-0015](./adr/0015-two-tier-onboarding-and-admission-gate.md) (2026-06-18).**
+> This runbook described the **Model-A hub-minted-credential** path — a network hub
+> minting a joiner a scoped guest credential under the hub's own NSC operator. That model
+> is dropped (ADR-0013 adopted sovereign federation; ADR-0015 retired the Model-A
+> machinery from `main`).
 >
-> The Model-A hub-minted-credential path described in this runbook is **retired** (ADR-0015, 2026-06-18).
-> The admission gate (`register → PENDING → admit`) now controls **roster membership only** — it mints
-> no credentials and issues no leaf packages. Community participation is either Tier 1 (Discord bot,
-> no NATS) or Tier 2 (sovereign NSC operator + Model-B federation join).
->
-> Archived on git tag/branch `model-a-hub-minted-creds` for reference.
+> **The full original runbook is preserved** on the git tag and branch
+> `model-a-hub-minted-creds` (and `archive/model-a-hub-minted-creds`) — recoverable if
+> Model B ever proves too cumbersome for community onboarding.
 
-**Status:** retired (ADR-0015)
-**Audience:** a **network/hub admin** (human or an admin agent with repo + arc/`nsc` access) onboarding a peer operator onto `metafactory-community`
-**Decision basis:** [ADR-0012](./adr/0012-external-operator-account-isolation.md) — **default: shared `community` account + per-operator scoped bot**; dedicated account is an opt-in for hard isolation
-**Related:** `docs/design-automated-operator-onboarding.md`, `docs/sop-stack-onboarding.md` §B0–B5, `docs/sop-federation-onboarding.md`, `docs/sop-network-join.md`, `docs/runbook-federation-peering.md`, the `cortex creds` ↔ `arc nats` contract (`the-metafactory/arc:docs/integrations/cortex-creds.md`)
+## What replaces it
 
-This is the **hub side** of community-principal onboarding: minting the one secret artifact —
-a leaf `.creds` — that lets a principal's cortex bind a NATS leaf to a hub. It is
-copy-paste and agent-executable. The principal-facing steps (what *they* run) are in
-`#assistant-fleet-onboarding` / `docs/sop-network-join.md`.
+- **Roster admission** is governed by the **network-admission gate** — `register → PENDING
+  → admit` — which mints **nothing** (it gates *who* is on a network roster, not
+  credentials). See `cortex network admit` and
+  [`sop-onboard-peer-principal.md`](./sop-onboard-peer-principal.md).
+- **Federation identity** is **sovereign**: every principal runs their **own** NSC
+  operator + a dedicated federation account, and the leaf link is a
+  **secret-authenticated transport pipe** (no cross-operator JWT trust, no hub-minted
+  accounts). See [ADR-0013](./adr/0013-sovereign-federation-model.md) and
+  [`sop-onboard-peer-principal.md`](./sop-onboard-peer-principal.md).
+- The **one irreducible secret handoff** that remains is the admin issuing a leaf `.creds`
+  **from their own NSC operator** (via `cortex creds issue` / `arc nats add-bot`, locally,
+  in their own account) and sharing it out-of-band. This is not Model A — no hub mints an
+  account *for* the joiner.
 
-> **Restart framing (read first).** Issuing a leaf cred for a **bot/user in an account the
-> hub already trusts is restart-free** — a user JWT is self-contained, signed by that
-> account; the hub needs no reload to accept it. A **hub restart is required only** when
-> you (a) add a **brand-new account** to a `resolver: MEMORY` hub (it must go into
-> `resolver_preload`), or (b) **revoke** under MEMORY (the revocation list is part of the
-> account JWT the hub holds in memory). The happy path below adds a *user* to the existing
-> shared `community` account → **no restart**.
+## Community participation tiers (ADR-0015)
 
----
+- **Tier 1 — Chat.** Bring your own Discord bot into `#assistant-fleet`. No NATS, no
+  credentials.
+- **Tier 2 — Sovereign.** Run your own NSC operator + stack + federation account and join
+  the bus the Model-B way. The hub issues you no account or credential.
 
-## Happy path — `cortex creds issue` (one command, restart-free)
-
-Per [ADR-0012](./adr/0012-external-operator-account-isolation.md), the **default** is a
-per-principal **bot in the shared `community` account**, scoped to that principal's federated
-namespace. Mint it in one command:
-
-```bash
-OP=northwoods                                   # the principal's handle (lowercase)
-cortex creds issue "leaf-$OP" \
-  -a community \
-  --pub "federated.$OP.>" \
-  --sub "federated.$OP.>"
-```
-
-This shells out to **`arc nats add-bot leaf-$OP -a community --pub federated.$OP.> --sub
-federated.$OP.> --json`** (contract: `arc:docs/integrations/cortex-creds.md`, schema
-`arc.nats.v1`). arc owns `nsc` + the `$SYS` account; cortex is a thin delegator. It:
-
-- mints the leaf user under the existing `community` account and signs its JWT,
-- writes the `.creds` file (mode `600`, under a `700` dir) and returns its absolute
-  `credsPath` + the durable `pubKey` (a `U…`) in the JSON envelope,
-- confines the user to `federated.$OP.>` (the least-privilege subject scope that **is** the
-  isolation boundary in shared-account mode — ADR-0012),
-- needs **no hub restart** — it adds a *user* to an account the hub already trusts.
-
-**Issuing admin (`nsc`-account-parameterized).** Pass `-a` for the `nsc` account you issue
-under — each admin issues under their **own** `nsc` account tree on their **own** hub; signing
-keys are never shared. arc resolves the active `nsc` account via `nsc env` when `-a` is omitted.
-
-| Issuing admin | Issue under | Hub endpoint |
-|---|---|---|
-| **Andreas** (worked example) | `-a community` (a `community` account under `OP_ANDREAS`) | `tls://nats.meta-factory.dev:7422` |
-| **JC** | a `community` account under **his own** operator (e.g. `OP_JCFISCHER`) | his hub endpoint |
-
-**Rotate / revoke** are the same one-command shape, restart-free in shared-account mode:
-
-```bash
-cortex creds rotate "leaf-$OP" -a community      # → arc nats reissue-bot (revokes old pubkey, mints new)
-cortex creds revoke "leaf-$OP" -a community      # → arc nats remove-bot --delete-creds (server-side revoke + push)
-```
-
-Then proceed to **Hand-off** below.
-
----
-
-## Fallback — one-time `community` account bootstrap (only when a dedicated account is needed)
-
-> ⚠️ **You only run this section in two cases:** (1) **once**, to bootstrap the shared
-> `community` account itself the very first time, before any principal can be issued into it;
-> or (2) when a principal takes the **dedicated-account opt-in** (ADR-0012) for hard,
-> namespace-level isolation. For every ordinary principal after the shared account exists,
-> **skip this — use the happy path above.** This is the raw-`nsc` path; it creates an
-> **account**, which under the MEMORY resolver is the one thing that **does** need a hub
-> restart.
-
-### Facts (Andreas's hub — the worked example)
-
-| | Value |
-|---|---|
-| Operator | `OP_ANDREAS` |
-| Shared external account | `community` — the default home for external-principal bots (ADR-0012) |
-| Internal agents' account | `ANDREAS_AGENTS` — **never** issue an external principal into this |
-| System account | `SYS` |
-| Hub config (resolver) | `~/.config/nats/local.conf` — `resolver: MEMORY` + `resolver_preload` |
-| Network | `metafactory-community` — hub `tls://nats.meta-factory.dev:7422`, leaf_port `7422` |
-| Resolver implication | a **new account** ⇒ add its JWT to `resolver_preload` + **restart the hub**; a new **user** in an existing account ⇒ **no restart** |
-
-**Pre-req:** `nsc env` shows YOUR operator selected (Andreas: `nsc env -o OP_ANDREAS`; JC selects his own). Every `nsc` command below issues under whatever operator is selected — so this single check is what makes the runbook correct for either admin.
-
-### Inputs
-
-- `ACCT_NAME` — the account to bootstrap. For the shared default this is `community`
-  (done once). For a dedicated-account opt-in, the principal's handle UPPER (e.g.
-  `NORTHWOODS`). Verify it's not already taken: `nsc list accounts`.
-
-### Steps
-
-#### 1. Create the account
-
-```bash
-ACCT=community                                                      # or e.g. NORTHWOODS for the dedicated opt-in
-nsc add account --name "$ACCT"
-nsc edit account --name "$ACCT" --sk generate                       # account signing key (good hygiene)
-# capture the account public key (A…) — the principal's `--account` value:
-ACCT_PUB=$(nsc describe account --name "$ACCT" --field sub --raw 2>/dev/null || nsc list accounts | awk -v a="$ACCT" '$0~a{print $4}')
-echo "account pubkey: $ACCT_PUB"
-```
-
-#### 2. Teach the hub the new account, then restart (MEMORY resolver — new ACCOUNT only)
-
-```bash
-ACCT_JWT=$(nsc describe account --name "$ACCT" --raw)               # the account JWT
-# Add to ~/.config/nats/local.conf resolver_preload:
-#   // Account "<ACCT>"
-#   <ACCT_PUB>: <ACCT_JWT>
-# then reload the hub (brief blip — andreas/jc leafs reconnect automatically):
-#   launchctl kickstart -k gui/$(id -u)/ai.meta-factory.nats.<hub-label>     # or your hub restart cmd
-```
-> ⚠️ This restart is **only** because step 1 created a **new account**. Confirm the hub
-> comes back up (`curl -s http://127.0.0.1:8222/healthz`) and andreas/jc leafs re-link
-> before issuing into it. Once the account exists, every per-principal bot issued into it
-> (happy path above) is **restart-free**.
-
-#### 3. Issue the principal's bot into the now-existing account
-
-For the shared `community` account, this is just the **happy path** above
-(`cortex creds issue leaf-$OP -a community --pub/--sub federated.$OP.>`) — restart-free.
-
-For a **dedicated-account opt-in**, issue the bot into that account the same way:
-
-```bash
-cortex creds issue "leaf-$OP" -a "$ACCT" --pub "federated.$OP.>" --sub "federated.$OP.>"
-```
-
-(Raw equivalent if `cortex creds` is unavailable on the hub box:
-`nsc add user --account "$ACCT" --name "leaf-$OP"`, scope it with
-`nsc edit user … --allow-pub/--allow-sub "federated.$OP.>"` + `_INBOX.>`, then
-`nsc generate creds --account "$ACCT" --name "leaf-$OP" > /tmp/$OP.leaf.creds; chmod 600`.)
-
----
-
-## Admit to Discord (grant-and-admit — run immediately after issuing the cred)
-
-After the leaf cred is issued, grant the principal presence in the community Discord by assigning the `community-fleet` role. This is the O-5 admission step: one command, same act as the cred grant.
-
-**Prerequisite (the bot must meet these; the command fails with a clear 403 if not):**
-- The bot token must have **Manage Roles** permission in the `metafactory-community` guild.
-- The bot's highest role must sit **above** `community-fleet` in the guild role hierarchy.
-
-**Command:**
-
-```bash
-OP_DISCORD_ID=<the-principal's-Discord-user-snowflake>
-
-# Assign community-fleet role — admits the principal to the community Discord
-discord role add --server community --role community-fleet --member "$OP_DISCORD_ID"
-```
-
-The `community-fleet` name is passed as-is; `discord role add` resolves it to its snowflake id via `GET /guilds/{guild}/roles`. If the name resolves ambiguously (duplicate role names), pass the snowflake id directly via `--role <id>`.
-
-**Revoke** (on offboarding, after `cortex creds revoke`):
-
-```bash
-discord role remove --server community --role community-fleet --member "$OP_DISCORD_ID"
-```
-
-> This step is human-executed (or admin-agent-executed). It is the "O-5 single act": issuing the cred and admitting to Discord happen in the same admin session, folded together — no separate watcher or daemon needed.
-
----
-
-## Hand-off package (out of band — see security note)
-
-Give the principal **four** things:
-1. the leaf `.creds` (path from `credsPath` in the issue output) — the leaf credential (**secret — bearer key**).
-2. `account pubkey` (the `A…`) — their `cortex network join --account` value.
-3. `account JWT` — for **their** local nats `resolver_preload` (operator-mode bus, §B0.1).
-4. Endpoint: `tls://nats.meta-factory.dev:7422` (already in the `metafactory-community` registry descriptor).
-
-The principal then runs the three commands in `#assistant-fleet-onboarding` (register → join → status).
-
-> Once the `register → issue → join` handshake lands (design spec O-4), the leaf package
-> rides the signed registration response and this manual hand-off goes away — see
-> `docs/design-automated-operator-onboarding.md` §3.
-
----
-
-## Security (Security-first)
-
-- The `.creds` is a **private bearer key**. Prefer an **encrypted / one-time** hand-off
-  (age/gpg, a self-destructing secret link, Signal) over a plain Discord paste.
-- If a private channel paste is used for convenience: **delete the message** once the principal
-  has pulled it, keep the channel's membership tight, and **rotate after first connect**
-  (`cortex creds rotate leaf-$OP -a community` — restart-free) so the pasted copy is dead.
-- The cred is **scoped + revocable** per ADR-0012 — confined to `federated.<slug>.>` at
-  issuance (the `--pub/--sub` scope, which is the isolation boundary in shared-account mode)
-  and independently revocable without touching any other principal.
-- In **shared-account (default) mode** there is no account wall behind the subject scope —
-  so keep `--pub/--sub` and `accept_subjects` strictly least-privilege, and prioritise the
-  signing → mTLS ramp for external principals. A principal needing a hard wall takes the
-  dedicated-account opt-in (ADR-0012).
-- v1 `federated.` payloads are cleartext-over-TLS, signing off.
-
-## Revoke (offboard / rotate)
-
-**Default (shared-account) — restart-free, one command:**
-
-```bash
-cortex creds revoke "leaf-$OP" -a community      # → arc nats remove-bot --delete-creds: server-side revoke + push + delete local creds
-```
-
-`arc` adds the bot's pubkey to the account revocation map and `nsc push`-es it; the bus
-rejects that cred going forward. If arc returns `PUSH_FAILED`, the **old creds remain VALID
-on the bus** — fix connectivity and retry the same command before considering it revoked.
-
-**Dedicated-account opt-in — fully offboarding the account needs a restart (MEMORY):**
-
-```bash
-cortex creds revoke "leaf-$OP" -a "$ACCT"        # revoke the user (server-side)
-# to drop the whole account: remove its block from resolver_preload + restart the hub
-```
+There is **no middle "guest bus" tier** (the Model-A hub-minted-guest-cred path). See
+[ADR-0015](./adr/0015-two-tier-onboarding-and-admission-gate.md).

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -130,6 +130,22 @@ describe("join usage", () => {
     expect(res.exitCode).toBe(2);
     expect(res.stderr).toContain("prefix matching");
   });
+
+  // ADR-0015 (R2) — the Model-A leaf-package INGESTION flag `--from-package`
+  // (O-4b) is retired. `cortex network join` no longer accepts an injected
+  // operator JWT + account JWT package; a Model-B stack mints its own and joins
+  // via the sovereign secret-auth pipe (or the O-3 operator-mode flags for its
+  // OWN NSC operator-mode bus). The flag must now be rejected as unknown rather
+  // than silently consuming an injected hub-minted package.
+  test("ADR-0015 — `--from-package` (Model-A ingestion) is rejected as unknown (exit 2)", async () => {
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--from-package", "/tmp/leaf-package.json",
+    ], EMPTY_READER);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("unknown flag: --from-package");
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## What this is

**#1142 R2 — retire Model-A (hub-minted creds) machinery.** Authority: **ADR-0015** §3 (retire from `main`: G2 credential-minting + leaf-package posting, O-4b `--from-package`, `docs/runbook-leaf-cred-issuance.md`; preserve on the archive ref) + ADR-0013 (sovereign federation, Model B).

## Audit finding — R2's destructive code work already landed (#1143)

A careful audit of `main` (which now includes PR3.5 / #1232) found that the bulk of R2 was **already merged via #1143** (`35204fb`, "R1+R2 — issuance→network-admission gate; retire Model-A cred machinery"):

| R2 target | State on `main` |
|---|---|
| Registry issuance routes (O-4a) | **Retired** by #1143 → repurposed as the R1 admission gate (`register → PENDING → admit`, mints nothing) |
| O-4b `--from-package` ingestion flag | **Removed** by #1143 (tombstone comments in `network-derive.ts` / `network.ts`) |
| `network-leaf-package.ts` (Model-A CLI) | **Deleted** by #1143 |
| `cortex creds grant` (G2 leaf-package minting/posting) | **Retired** by #1143 (`creds.ts` survivors: `list`/`issue`/`revoke`/`rotate`; help redirects to `cortex network admit`) |
| G5 runbook `creds issue --account community` step | **Reconciled** by #1143 — `sop-onboard-peer-principal.md` is fully Model-B (its remaining `creds issue` refs are the legit "admin issues a leaf from their OWN operator, out-of-band" sense) |
| `docs/runbook-leaf-cred-issuance.md` | **Only tombstoned at the head** by #1143 — still carried ~216 lines of live Model-A hub-mint body. ← **this PR finishes it** |

## What this PR changes

1. **Retire `docs/runbook-leaf-cred-issuance.md`** to a pure tombstone/redirect. The full Model-A body (`cortex creds issue -a community`, hub account-bootstrap fallback) is preserved on the archive ref, so the in-main copy was redundant. File kept (not deleted) so the 5 inbound doc links still resolve.
2. **Regression test:** `cortex network join --from-package <file>` is now asserted **rejected as an unknown flag** — `network join` no longer accepts an injected operator/account JWT package. Model-B mints its own. (The derive-without-package Model-B path was already covered by `network-derive.test.ts`.)

## Deliberately NOT removed — the O-3 operator-mode flags

The task brief asked to also remove `--operator-jwt`/`--account-jwt`/`operator_jwt`/`account_jwt`. **These were NOT removed** because ADR-0015 §Survivors explicitly lists **"O-3 (operator-mode auto-convert)"** as a Model-B survivor. A sovereign stack binds its leaf to a local account in its **OWN** NSC operator (ADR-0013 §1); these flags/`stack.nats_infra.*` fields are how `cortex network join` learns *that stack's own* operator + account JWTs to auto-convert an anonymous bus to operator-mode. The Model-A part was the **hub minting** the account JWT (registry issuance + `--from-package` + `creds grant`) — all already retired. Removing O-3 would break Model-B operator-mode federation and contradict both ADRs.

## Archive (STEP 2) — already satisfied on origin

Model-A is recoverable; the ADR-0015-named refs already exist on `origin`, both preserving the pre-#1143 code (incl. `network-leaf-package.ts`) at `c52aa88`:
- annotated **tag** `model-a-hub-minted-creds`
- **branch** `archive/model-a-hub-minted-creds`

No new archive branch was created — archiving from current `origin/main` (as a literal reading of the brief suggested) would be *worse*: it would capture a state where #1143 already stripped the Model-A code.

## O-4 / Model-A issues + branches the orchestrator should close

Now that R1+R2 are on `main`, these unmerged feature branches/issues are superseded (their work is retired, not merged):
- `feat/o4a1-issuance-requests` (O-4a.1 issuance-request broker)
- `feat/o4a2-leaf-package-serve` (O-4a.2 leaf-package serving route)
- `feat/o4b-leaf-package-consume` (O-4b `--from-package` consumer)
- `feat/g2-creds-grant` (G2 `cortex creds grant` minting/posting)
- `docs/leaf-cred-issuance-sop` (`Cortex-fed-onboard`) + `docs/g5-peer-onboarding-runbook` (`Cortex-g5-sop`) — Model-A runbook drafts, superseded by the reconciled G5 SOP + this tombstone

## Remaining Model-A doc residue (NOT touched here — flagged for R3/T1, avoid PR collision)

Other live docs still carry the Model-A `cortex creds issue … -a community` hub-mint onboarding step. Left for the onboarding-message/SOP reconciliation (R3) + sovereign-setup docs (T1), to avoid colliding with the active `Cortex-pier-r12` / `Cortex-admission-gate` worktrees:
- `docs/sop-stack-onboarding.md` (§"default issuance")
- `docs/sop-community-fleet-admission.md`
- `docs/design-automated-operator-onboarding.md` (historical O-4 design doc)

## Gates

- `bun install` — OK
- `bunx tsc --noEmit` — 0 errors
- `bash scripts/check-carveouts.sh` — PASS (new test comment qualifies "operator" via `operator JWT` / `operator-mode` line-exemptions)
- `bun test src/cli/cortex/commands/` — 885 pass / 0 fail (incl. the new `--from-package` rejection test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)