### PR TITLE
feat(cli): C-1139 — cortex network provision (one-command sovereign-operator setup) + agents_account (G1d)

### DIFF
--- a/docs/design-own-operator-onboarding.md
+++ b/docs/design-own-operator-onboarding.md
@@ -1,0 +1,185 @@
+# Design — own-operator onboarding: one-command sovereign setup (T1 / G1d)
+
+**Status:** design (2026-06-27) · **Author:** Luna (for Andreas) · **Issue:** cortex#1139 (G1d) · **EPIC:** cortex#1142 T1
+**Refs:** [ADR-0013](./adr/0013-sovereign-federation-model.md) (sovereign federation / Model B), [ADR-0012](./adr/0012-external-operator-account-isolation.md) (account isolation), [ADR-0015](#) (two-tier onboarding + admission gate), [`docs/design-onboarding-tooling-audit.md`](./design-onboarding-tooling-audit.md) (G1 linchpin), [`docs/sop-stack-onboarding.md`](./sop-stack-onboarding.md) §B0.1 (manual operator-mode conversion). `CONTEXT.md` §Identity & trust → **NSC operator**, **Federation account**, **Network-admission gate**.
+
+> **Scope.** This is a DESIGN-FIRST scoping note. It defines the one-command UX, the compose-vs-net-new split, the idempotency/dry-run contract, and a TDD plan. No feature code, no PR.
+
+---
+
+## 1. The problem this closes
+
+ADR-0013 drops the hub-minted guest account (Model A) entirely: **a principal MUST run their own NSC operator to federate.** The cost ADR-0013 §Decision-4 names explicitly — *"a newcomer with no NSC operator yet cannot federate until they stand one up"* — is paid down **"by investing in making 'stand up your own NSC operator' trivial (arc tooling)."** This doc designs that investment.
+
+Today, standing up the sovereign federation substrate is the **least-tooled edge in the whole lifecycle** — ranked #1 ("Federated account-topology — zero tooling (the linchpin)") in [`design-onboarding-tooling-audit.md`](./design-onboarding-tooling-audit.md). The manual recipe (SOP §B0.1) is: hand-author an operator-mode `nats-server` `.conf`, copy four operator blocks verbatim from `~/.config/nats/local.conf`, hand-`nsc` an account, and hope the leaf binds. The pieces that ARE tooled are scattered across three verbs:
+
+- `cortex provision-stack generate` — the **envelope signing** identity (`src/cli/cortex/commands/provision-stack.ts`)
+- `cortex creds issue` → `arc nats add-bot` — per-agent **bus connection** creds (`src/cli/cortex/commands/creds.ts`)
+- `cortex network join` — leaf render + O-3 bus operator-mode conversion + G1c local export/import (`src/cli/cortex/commands/network.ts`, `network-ports.ts`, `network-federation-wiring.ts`)
+
+**G1d** (cortex#1139) is the missing seam: the dedicated **federation account** + the **agents account** config concept, *provisioned* (minted under the principal's own operator), so G1c's same-account no-op fallback (`network-lib.ts:91-99`, `agentsAccount?`) becomes a real cross-account export/import. T1 (cortex#1142) is the wrapper that makes the whole substrate **one command**.
+
+### The three keys — DO NOT conflate (the accuracy correction)
+
+A stack ends up holding three distinct cryptographic artifacts, at three different layers. The recent review correction: **the signing key does NOT authenticate the bus.**
+
+| Artifact | Layer | Role | Provisioned by today |
+|---|---|---|---|
+| **Envelope signing seed** (`SU…`) | M3–M6 | signs envelopes; pubkey registered for verify | `cortex provision-stack generate` → `stack.nkey_seed_path` |
+| **Local bus connection creds** (`.creds`, an `A→U` JWT chain) | M1 (local) | authenticates the daemon's connection to its **own** nats-server | `cortex creds issue` → `arc nats add-bot` |
+| **Leaf shared secret** | M1 (federation) | authenticates the leaf transport pipe to a hub | out-of-band, two-party (ADR-0013 §Consequences) |
+
+The **unifying idea** is NOT "one key does all three." It is **one ROOT the principal holds — the NSC operator seed** — from which the NATS account tree (the federation account, the agents account) and the local connection `.creds` all descend via JWT signing chains. The envelope signing seed is a separate ed25519 keypair generated *by the same command* and stored beside the operator seed (see Open Question 1 on whether to literally derive it). The leaf shared secret is the one artifact that is **never derived** — it is the mutual two-party handshake, exchanged out-of-band.
+
+> **Layer discipline (the audit's hard rule, `design-onboarding-tooling-audit.md` §Separation of concerns):** cortex (M7) **orchestrates**; it **never runs `nsc` itself.** Every account-tree mutation goes *through arc* (`arc nats …`), the established precedent being `cortex creds issue → arc nats add-bot`. This design honors that: the new cortex verb shells to arc for every operator/account/creds mint and runs zero `nsc`.
+
+---
+
+## 2. One-command UX
+
+### Headline verb
+
+```
+cortex stack ensure-own-operator <stack> [--apply]
+```
+
+A new subcommand under the existing `cortex stack` family (sibling of `create` / `list`, `src/cli/cortex/commands/stack.ts`). It sits between `create` and `network join` in the stack lifecycle:
+
+```
+cortex stack create <slug>            # scaffold config-split skeleton (#808)
+cortex stack ensure-own-operator <s>  # ← THIS: mint the sovereign federation substrate
+cortex network join <network>         # leaf link + local export/import (already tooled)
+```
+
+`<stack>` resolves the same way `cortex stack list` already resolves a stack (config-split dir → `stack.id`), so `principal` and `stack.id` are read from config, never re-typed.
+
+### What it does (the pipeline, idempotent end-to-end)
+
+Each step is **ensure-shaped**: present-and-correct ⇒ no-op; absent ⇒ mint; present-but-conflicting ⇒ refuse (never clobber). Order matters — operator before accounts before export/import before config.
+
+1. **Ensure the NSC operator** (per-principal, one). If the principal has no operator seed at the conventional path, mint one via arc; write the seed `chmod 600`; refuse to clobber an existing seed (rotation is a deliberate, separate security event — mirrors `provision-stack generate`'s `--force` gate, `provision-stack.ts:202-218`).
+2. **Ensure the federation account** (per-stack, one — ADR-0013 §Decision-3). Mint a dedicated NSC account under the principal's operator via arc; this is the `A…` the leaf binds to → writes `stack.nats_infra.account` (`src/common/types/stack.ts:102`).
+3. **Ensure the agents account** (the G1d config concept). Mint/locate the account the dispatch-listener subscribes `federated.>` in; writes the new `stack.nats_infra.agents_account` field (net-new schema field, §3).
+4. **Ensure the local connection creds.** Mint the daemon's bus `.creds` under the agents account via arc (`arc nats add-bot`, the existing `cortex creds issue` path) → writes `stack.nats_infra.creds_path`.
+5. **Ensure the envelope signing identity.** Compose `provision-stack generate` (local-only, no `--register`) if `stack.nkey_seed_path` has no seed yet.
+6. **Pre-stage the local `federated.>` export/import** between federation-account ↔ agents-account (the G1c wiring, `arc nats add-federation-export`). This is *also* run by `cortex network join`; running it here makes the stack "ready to join" and turns G1c's same-account no-op into the real cross-account wire. Idempotent (the arc primitive is a no-op when already wired).
+7. **Ensure the bus is operator-mode under THIS principal's own operator.** Render the SOP §B0.1 operator-mode blocks (operator JWT + system_account + `resolver: MEMORY` + `resolver_preload`) into the stack's `nats-server` `.conf`, KEEPING the stack's own `server_name`/ports/JS domain. This reuses the O-3 `convertToOperatorMode` renderer (`network-ports.ts:194-215`) — but sourced from the principal's **own** freshly-minted operator material, not a hub-supplied package (the Model-B correction to O-3's input).
+
+**Terminal state:** the stack stands on an operator-mode bus rooted in the principal's own NSC operator, with a dedicated federation account, an agents account, the `federated.>` export/import pre-wired, valid local creds, and a registered-able signing identity. The only things left before `cortex network join` succeeds are the **two irreducible two-party steps** (audit §The two irreducible steps): the **leaf shared secret** and **hub topology agreement**. The command's closing output names exactly those two as the remaining manual moments.
+
+### Flags
+
+| Flag | Meaning |
+|---|---|
+| `<stack>` (positional) | config-split stack dir or `stack.id`; principal + stack.id read from config |
+| `--apply` | perform the mints/writes. **Default is dry-run** (prints the plan, touches nothing) — matches `stack create` (`stack.ts:120-132`) and `network join` (`network.ts:451-462`) |
+| `--dry-run` | explicit dry-run; `--apply` + `--dry-run` together is a usage error (mirror `resolveApply`, `stack.ts:126-132`) |
+| `--operator-seed <path>` | override the conventional operator-seed path (default: convention under `~/.config/nats/`) |
+| `--force` | allow re-minting over an EXISTING operator/account/signing seed (deliberate rotation; off by default — no-clobber is the default) |
+| `--json` | `{ status, items, data, error }` envelope (universal, per `_shared/envelope`) |
+
+### Output (dry-run, the default)
+
+```
+cortex stack ensure-own-operator andreas/research: dry-run (no mutation; pass --apply)
+  principal: andreas   stack: andreas/research
+  PLAN:
+    [mint ] NSC operator      OP_ANDREAS              (seed → ~/.config/nats/andreas.operator.seed, chmod 600)
+    [mint ] federation account AC_ANDREAS_RESEARCH_FED → stack.nats_infra.account
+    [ok   ] agents account     ANDREAS_AGENTS          (exists) → stack.nats_infra.agents_account
+    [mint ] local creds        andreas-research-bot    → stack.nats_infra.creds_path
+    [ok   ] signing identity    UA…                     (exists) → stack.nkey_seed_path
+    [wire ] export/import       federated.> : fed-acct → agents-acct
+    [conv ] bus → operator-mode  ~/.config/nats/research.conf (own operator OP_ANDREAS)
+  Re-run with --apply to execute.
+  AFTER this: exchange the leaf shared secret + agree hub topology with your peer, then `cortex network join <network>`.
+```
+
+---
+
+## 3. Compose vs net-new
+
+### Composes (reuse — do NOT reinvent)
+
+| Need | Existing primitive | File |
+|---|---|---|
+| dry-run/`--apply` boundary, mutual-exclusion | `resolveApply` pattern | `src/cli/cortex/commands/stack.ts:126-132`, `network.ts:451-462` |
+| subcommand parsing / `--json` envelope / exit codes | `parseSubcommandArgs`, `_shared/envelope`, `_shared/exit-result` | `src/cli/cortex/commands/_shared/` |
+| chmod-600 seed write + no-clobber-without-`--force` | `generateStackIdentity` / `enforceChmod600` | `provision-stack.ts:202-218`, `src/common/config/file-permissions.ts` |
+| signing identity (step 5) | `cortex provision-stack generate` | `provision-stack.ts` (`runGenerate`) |
+| local creds mint (step 4) | `cortex creds issue` → `arc nats add-bot` | `creds.ts` (`arcVerbFor`, `creds.ts:528`) |
+| local `federated.>` export/import (step 6) | `arc nats add-federation-export` via `FederationWiringPort` | `network-federation-wiring.ts`, `network-ports.ts:379-413` |
+| operator-mode `.conf` rendering (step 7) | `convertToOperatorMode` / `renderOperatorModeBlocks` (O-3) | `network-ports.ts:194-215` |
+| `stack.nats_infra` schema (account/creds_path/operator blocks) | `StackNatsInfraSchema` | `src/common/types/stack.ts:69-134` |
+
+### Net-new (the genuinely new code)
+
+1. **`cortex stack ensure-own-operator` orchestrator** — a new handler in `src/cli/cortex/commands/stack.ts` (+ a `stack-ensure-operator-lib.ts` for the pure plan-builder, mirroring `stack-lib.ts`). Wires the ports above into the 7-step ensure pipeline; live vs dry-run port selection like `network.ts:558`.
+
+2. **arc verbs for operator + account minting (the linchpin — lives in arc, cortex#1139 names this explicitly: "may need `arc nats add-account` if absent").** cortex shells to them; it never runs `nsc`:
+   - `arc nats init-operator <name> --json` — mint a principal's NSC operator (likely **net-new in arc**; verify against the arc contract). Idempotent / no-clobber.
+   - `arc nats add-account <name> --json` — mint a dedicated account under the operator (cortex#1139: "may need `arc nats add-account` if absent" — **verify whether arc already ships it**; if not, it's an arc dependency this work declares).
+   - A thin cortex driver mirroring `creds.ts`'s arc-subprocess pattern (`creds.ts:345` "arc nats subprocess driver", `arcVerbFor`, the `arc.nats.v1` schema pin `creds.ts:112`). New driver module `src/cli/cortex/commands/operator-provisioning.ts` (sibling of `network-federation-wiring.ts`).
+
+3. **The `agents_account` schema field (the G1d config concept).** Add `agents_account: z.string().regex(/^A[A-Z0-9]{55}$/).optional()` to `StackNatsInfraSchema` (`src/common/types/stack.ts:134`). This is the field `network-lib.ts:91-99` already reads as `agentsAccount?` and `network-ports.ts:401-402` flags as "tracked as G1d" — adding it splits the federation account from the agents account so the export/import is a real cross-account wire instead of the same-account no-op.
+
+4. **Config write-back helper** — write the six resolved fields (`account`, `agents_account`, `creds_path`, plus operator-mode `.conf` and `nkey_seed_path`) back into the config-split `stacks/<stack>.yaml`, reusing the same write path `network join` uses (`ConfigStorePort.writeNetworks` analogue, `network-ports.ts:289-294`). Addresses the audit's #4 finding (post-boot write-back trap) for the account fields.
+
+---
+
+## 4. Idempotency, no-clobber, dry-run boundary
+
+- **Ensure-shaped, not create-shaped.** Re-running on an already-set-up stack is a clean no-op that re-prints the plan with every line `[ok]`. This is the property the verb name (`ensure-`) promises and the audit's onboarding-agent capstone needs (an agent must be able to re-run safely).
+- **No-clobber seeds, `chmod 600`.** Every seed (operator, signing) is written `0600` and refuses to overwrite an existing seed without `--force` — reusing `enforceChmod600` + the `generateStackIdentity` clobber-refusal (`provision-stack.ts:172-218`). Rotation (`--force`) is a deliberate, loud, separate act, exactly as `provision-stack` treats it.
+- **Dry-run by default, `--apply` to mutate.** Matches `stack create` and `network join` precisely (the `resolveApply` contract). A dry-run reaches into **read-only** arc calls only where they exist (or pure plan computation) and renders the plan; it writes nothing, mints nothing, restarts nothing. `--apply` + `--dry-run` together → usage error (exit 2).
+- **Fail-fast before any mutation.** Resolve the full plan (what exists, what must be minted) and validate it BEFORE the first `--apply` write — so a half-provisioned stack is never left behind. Mirrors `network join`'s "READ all pre-flight checks before any mutation" discipline (`network-ports.ts:168-193`, `canBindAccount`/`resolveBindMode`).
+- **arc is the only account-tree mutator.** cortex emits zero `nsc`; every mint is an `arc nats …` subprocess with the `arc.nats.v1` schema check and the `MIN_ARC_VERSION` guard from `creds.ts`.
+
+---
+
+## 5. Test plan (TDD targets)
+
+Write tests first, against injected ports (the codebase's established seam style — `network-federation-wiring.test.ts` records port calls). No real `nsc`/arc in unit tests.
+
+**Pure plan-builder (`stack-ensure-operator-lib.test.ts`):**
+- Empty stack (nothing provisioned) → plan mints operator + fed-acct + agents-acct + creds + signing + wire + convert (7 actions).
+- Fully-provisioned stack → plan is all `[ok]`, zero mutations (idempotency proof).
+- Partial state: operator exists, accounts absent → mints only the accounts (each step independently ensure-shaped).
+- `agents_account` present + distinct from `account` → wire step is cross-account; absent → same-account no-op is flagged (the G1c→G1d transition assertion).
+
+**Orchestrator (`stack-ensure-operator.test.ts`, injected arc/file/plist ports):**
+- Dry-run (default): records ZERO mutating port calls; prints the plan; exit 0.
+- `--apply`: records the expected mint/write calls in order (operator → accounts → creds → wire → convert).
+- No-clobber: existing operator seed without `--force` → refuses, exit 1, seed untouched.
+- `--force`: re-mints (records the clobber), loud in output.
+- `--apply` + `--dry-run` → usage error, exit 2.
+- arc absent / below `MIN_ARC_VERSION` → clear, arc-naming error (reuse `creds.ts` error-surface assertions).
+- arc mint failure mid-pipeline → fail-fast, no partial config write-back (transactional-ish: validate-then-write).
+
+**Schema (`stack.test.ts` extension):**
+- `agents_account` accepts a valid `A…` NKey, rejects a `U…`/malformed key, stays optional.
+
+**Contract probe (integration, gated):**
+- Assert the exact arc verbs + `--json` shape the driver depends on (`init-operator`, `add-account`) exist at the pinned arc version — or fail with a precise "arc dependency unmet (cortex#1139 / G1d)" message. This is where the arc-side gap (Open Question 3) surfaces concretely.
+
+---
+
+## 6. Open questions (need an Andreas decision)
+
+1. **Derive the signing seed from the operator seed, or co-generate?** The unifying vision is "one root the principal holds = the operator seed." Cryptographically the envelope signing NKey (`provision-stack` `SU…`) is today an *independent* ed25519 keypair, not derived from the operator key. Two honest options: **(a)** one command generates BOTH seeds and stores the operator seed as "the seed you protect" (pragmatic, ships now, two files); **(b)** deterministically derive the signing seed from the operator seed via HKDF so there is literally one root secret (cleaner story, more crypto surface, harder rotation story). Recommend (a) for G1d; flag (b) as a follow-up if "one seed, period" is a hard requirement.
+
+2. **Verb home: `cortex stack ensure-own-operator` vs `cortex network ensure-operator` vs a top-level `cortex federation init`?** The operator is per-*principal*; the federation account is per-*stack*; the command spans both. I propose `cortex stack …` because it's a stack-lifecycle step (create → ensure-own-operator → join) and `<stack>` carries the principal. Confirm the home, or pick a name.
+
+3. **What does arc already ship?** cortex#1139 hedges: "may need `arc nats add-account` if absent." Need to confirm against the arc contract (`the-metafactory/arc:docs/integrations/cortex-creds.md`) which of `init-operator` / `add-account` exist. If absent, this work **declares an arc dependency** (an arc issue) and is blocked on it — `add-federation-export` (arc#243 / G1b) is the precedent for "cortex needs a new arc nats verb."
+
+4. **Agents account: per-stack or per-principal-shared?** ADR-0012 isolation argues per-stack; the live meta-factory bus shares one `ANDREAS_AGENTS` across stacks. Does `ensure-own-operator` mint a fresh agents account per stack, or reuse a principal-shared one? Affects whether step 3 is a mint or a locate.
+
+5. **Should ensure-own-operator also register the signing pubkey** (compose `provision-stack register`, network I/O), or stop at local-only and leave registration to the explicit `network join` / admission-gate flow? Registration is the network-admission-gate concern (ADR-0015) — I lean local-only here (keep the verb offline + idempotent), but confirm.
+
+6. **Bus restart on operator-mode conversion (step 7).** Converting an anonymous bus to operator-mode is a one-time restart (SOP §B0.1 "one-time bus-conversion restart"). Does `ensure-own-operator` perform the restart (like `network join` does via `NatsServerPort.restart`, with the #821 health-probe + rollback), or render the `.conf` and leave the restart to the subsequent `join`? Leaning: render-only here, restart at `join` (keeps this verb non-disruptive), but it means the bus isn't *live* operator-mode until join.
+
+---
+
+## 7. Sequencing
+
+G1d (the `agents_account` field + account provisioning) is the prerequisite that turns G1c's same-account no-op into a real cross-account wire. This verb (T1) is the wrapper. Per cortex#1142: **T1 feeds P1 (Pier)** — the onboarding concierge guides sovereign setup by driving exactly this command. So the deliverables, in order: (1) confirm/declare the arc verbs (Open Q3); (2) add the `agents_account` schema field; (3) the pure plan-builder + orchestrator behind the new `cortex stack ensure-own-operator`; (4) SOP §B0.1 rewrite to point at the one command instead of the manual recipe.

--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -174,6 +174,23 @@ ALLOWLIST_PATHS=(
   # "operator" is the NATS account-tree root, never the principal. Class: NSC.
   # RETIRE: never (NSC operator is the permanent qualified survivor, CONTEXT.md).
   'docs/design-g1-account-topology.md'
+  # G1d / T1 (cortex#1139) provision tooling — the arc-shell driver + pure
+  # orchestration + live adapters behind `cortex network provision`. Their entire
+  # subject is the NSC account tree (the principal's own nsc operator + the
+  # federation/agents accounts minted under it via arc). Every "operator" is the
+  # NATS account-tree root, never the principal. Same class as connection.ts /
+  # trust-resolver.ts / design-g1-account-topology.md / ADR-0013. Class: NSC.
+  # RETIRE: never (NSC operator is the permanent qualified survivor, CONTEXT.md).
+  'src/cli/cortex/commands/operator-provisioning.ts'
+  'src/cli/cortex/commands/network-provision-lib.ts'
+  'src/cli/cortex/commands/network-provision-adapters.ts'
+  'src/cli/cortex/commands/__tests__/operator-provisioning.test.ts'
+  'src/cli/cortex/commands/__tests__/network-provision-lib.test.ts'
+  'src/cli/cortex/commands/__tests__/network-provision-cli.test.ts'
+  # G1d own-operator onboarding design doc — its whole subject is standing up the
+  # principal's own NSC account tree (also caught by the `operator-onboarding`
+  # line pattern; path-allowlisted for clarity). Class: NSC.
+  'docs/design-own-operator-onboarding.md'
   # ADR-0013 sovereign federation — its whole subject is the NSC operator/account
   # model (own-operator federation, per-side export/import). Every "operator" is the
   # NATS account-tree root, never the principal. Class: NSC.

--- a/src/cli/cortex/commands/__tests__/network-provision-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-provision-adapters.test.ts
@@ -1,0 +1,70 @@
+/**
+ * G1d / T1 (cortex#1139) — LIVE signing-identity adapter tests.
+ *
+ * Regression cover for cortex#1236 BLOCKER: the live adapter must expand the
+ * portable `~` seed path at the fs boundary so the O_EXCL write and the
+ * existence probe target the SAME `$HOME`-rooted path. The CLI tests inject a
+ * fake signing port, so this is the only test that exercises the real adapter
+ * with a tilde path. HOME is pinned to a tmpdir; the signing port is NOT mocked.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { buildSigningIdentityAdapter } from "../network-provision-adapters";
+
+describe("buildSigningIdentityAdapter — live, tilde expansion (cortex#1236)", () => {
+  let home: string;
+  let prevHome: string | undefined;
+  const RAW_SEED = "~/.config/nats/andreas-research.seed";
+
+  beforeEach(() => {
+    prevHome = process.env.HOME;
+    home = mkdtempSync(join(tmpdir(), "cortex-provision-home-"));
+    process.env.HOME = home;
+    // generateStackIdentity writes the seed but does NOT mkdir -p; the real
+    // arc-provisioned tree already has ~/.config/nats — mirror that here.
+    mkdirSync(join(home, ".config", "nats"), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("generate writes the seed under $HOME, NOT a literal ~ dir", () => {
+    const adapter = buildSigningIdentityAdapter();
+    const res = adapter.generate({ seedPath: RAW_SEED, force: false });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.nkeyPub).toMatch(/^U/);
+      expect(res.fingerprint.length).toBeGreaterThan(0);
+    }
+
+    // The seed landed at the EXPANDED path…
+    const expanded = join(home, ".config", "nats", "andreas-research.seed");
+    expect(existsSync(expanded)).toBe(true);
+    // …and NOT in a literal "~" directory under cwd (the bug).
+    expect(existsSync(join(process.cwd(), "~"))).toBe(false);
+  });
+
+  test("exists agrees with generate on the expanded path (idempotent re-run, no EEXIST)", () => {
+    const adapter = buildSigningIdentityAdapter();
+
+    // Before generate: the probe sees nothing.
+    expect(adapter.exists(RAW_SEED)).toBe(false);
+
+    const first = adapter.generate({ seedPath: RAW_SEED, force: false });
+    expect(first.ok).toBe(true);
+
+    // After generate: the probe (expanded) sees the file the write (expanded)
+    // produced. Because they agree, the orchestrator's `signingNeeded =
+    // !signingSeedExists` short-circuits on a re-run → generate is never called
+    // again → no O_EXCL EEXIST. The divergence this asserts against is the
+    // cortex#1236 bug (probe expanded, write literal `~`).
+    expect(adapter.exists(RAW_SEED)).toBe(true);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-provision-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-provision-cli.test.ts
@@ -1,0 +1,186 @@
+/**
+ * G1d / T1 (cortex#1139) — CLI tests for `cortex network provision <stack>` and
+ * the `cortex network join` auto-provision. The config reader + provision ports
+ * are both injected, so no disk / arc / nsc is touched.
+ */
+import { describe, test, expect } from "bun:test";
+
+import { dispatchNetwork, type ProvisionPortsFactory } from "../network";
+import type { ConfigReader } from "../network-derive";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+import type { ProvisionPorts } from "../network-provision-lib";
+import type { FederationWiringPort } from "../network-ports";
+import type { OperatorProvisioningPort } from "../operator-provisioning";
+
+const FED_PUB = "A" + "B".repeat(55);
+const AGENTS_PUB = "A" + "C".repeat(55);
+
+function loaded(partial: Partial<LoadedConfig>): LoadedConfig {
+  return { config: {} as AgentConfig, inlineAgents: [], ...partial };
+}
+function reader(cfg: LoadedConfig): ConfigReader {
+  return () => cfg;
+}
+
+/** A config for an UN-provisioned stack (no nats_infra account tree yet). */
+const UNPROVISIONED = loaded({
+  principal: { id: "andreas" },
+  stack: { id: "andreas/research", nkey_seed_path: "~/.config/nats/andreas-research.seed" },
+});
+
+/** A config for a fully-provisioned stack. */
+const PROVISIONED = loaded({
+  principal: { id: "andreas" },
+  stack: {
+    id: "andreas/research",
+    nkey_seed_path: "~/.config/nats/andreas-research.seed",
+    nats_infra: {
+      config_path: "~/.config/nats/local.conf",
+      plist_path: "~/Library/LaunchAgents/nats.plist",
+      account: FED_PUB,
+      agents_account: AGENTS_PUB,
+      creds_path: "~/.config/nats/research.creds",
+    },
+  },
+});
+
+/** Recording fake ports factory. */
+function fakeFactory(): { factory: ProvisionPortsFactory; calls: string[]; writePath: string[] } {
+  const calls: string[] = [];
+  const writePath: string[] = [];
+  const factory: ProvisionPortsFactory = (stackConfigPath) => {
+    writePath.push(stackConfigPath);
+    const operator: OperatorProvisioningPort = {
+      initOperator: async ({ name }) => {
+        calls.push(`init-operator:${name}`);
+        return { ok: true, operator: name, pubKey: "OD4D", created: true, alreadyExisted: false, seedPath: null };
+      },
+      addAccount: async ({ name }) => {
+        calls.push(`add-account:${name}`);
+        return { ok: true, account: name, pubKey: name.endsWith("_AGENTS") ? AGENTS_PUB : FED_PUB, created: true, alreadyExisted: false };
+      },
+    };
+    const federationWiring: FederationWiringPort = {
+      wireLocalFederation: async () => {
+        calls.push("wire");
+        return { ok: true, note: "wired" };
+      },
+    };
+    const ports: ProvisionPorts = {
+      operator,
+      federationWiring,
+      signing: { exists: () => false, generate: () => { calls.push("signing"); return { ok: true, nkeyPub: "U" + "Z".repeat(55), fingerprint: "fp" }; } },
+      configWrite: { write: () => { calls.push("config-write"); return { ok: true }; } },
+    };
+    return ports;
+  };
+  return { factory, calls, writePath };
+}
+
+describe("cortex network provision — dry-run (default)", () => {
+  test("prints the plan, mutates nothing", async () => {
+    const { factory, calls } = fakeFactory();
+    const res = await dispatchNetwork(
+      ["provision", "andreas/research", "--config", "/x/research.yaml"],
+      reader(UNPROVISIONED),
+      undefined,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("dry-run");
+    expect(res.stdout).toContain("nsc operator");
+    expect(res.stdout).toContain("ANDREAS_RESEARCH_FED");
+    expect(res.stdout).toContain("ANDREAS_RESEARCH_AGENTS");
+    expect(calls).toEqual([]); // no effectful calls in dry-run
+  });
+
+  test("--json emits an envelope with the derived account-tree names", async () => {
+    const { factory } = fakeFactory();
+    const res = await dispatchNetwork(
+      ["provision", "andreas/research", "--config", "/x/research.yaml", "--json"],
+      reader(UNPROVISIONED),
+      undefined,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { status: string; data?: Record<string, string> };
+    expect(env.status).toBe("ok");
+    expect(env.data?.applied).toBe("false");
+    expect(env.data?.federation_account).toBe("ANDREAS_RESEARCH_FED");
+    expect(env.data?.agents_account).toBe("ANDREAS_RESEARCH_AGENTS");
+  });
+});
+
+describe("cortex network provision — apply", () => {
+  test("mints operator + both accounts, wires, writes config — in order", async () => {
+    const { factory, calls } = fakeFactory();
+    const res = await dispatchNetwork(
+      ["provision", "andreas/research", "--config", "/x/research.yaml", "--apply"],
+      reader(UNPROVISIONED),
+      undefined,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(calls).toEqual([
+      "init-operator:OP_ANDREAS",
+      "add-account:ANDREAS_RESEARCH_FED",
+      "add-account:ANDREAS_RESEARCH_AGENTS",
+      "signing",
+      "wire",
+      "config-write",
+    ]);
+  });
+
+  test("--apply + --dry-run is a usage error (exit 2)", async () => {
+    const { factory } = fakeFactory();
+    const res = await dispatchNetwork(
+      ["provision", "andreas/research", "--config", "/x/research.yaml", "--apply", "--dry-run"],
+      reader(UNPROVISIONED),
+      undefined,
+      factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("mutually exclusive");
+  });
+
+  test("a missing principal is a usage error", async () => {
+    const { factory } = fakeFactory();
+    const res = await dispatchNetwork(
+      ["provision", "research", "--config", "/x/research.yaml"],
+      reader(loaded({ stack: { id: "x/research" } })),
+      undefined,
+      factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("principal");
+  });
+});
+
+describe("cortex network join — auto-provision (cortex#1139)", () => {
+  test("an UN-provisioned stack auto-runs provision first (dry-run)", async () => {
+    const { factory, calls } = fakeFactory();
+    const res = await dispatchNetwork(
+      ["join", "metafactory", "--config", "/x/research.yaml"],
+      reader(UNPROVISIONED),
+      undefined,
+      factory,
+    );
+    // The auto-provision plan is prepended to the join output.
+    expect(res.stdout + res.stderr).toContain("auto-running `cortex network provision`");
+    expect(res.stdout + res.stderr).toContain("nsc operator");
+    expect(calls).toEqual([]); // dry-run: no mutations
+  });
+
+  test("a PROVISIONED stack does NOT auto-run provision", async () => {
+    const { factory, calls } = fakeFactory();
+    const res = await dispatchNetwork(
+      ["join", "metafactory", "--config", "/x/research.yaml"],
+      reader(PROVISIONED),
+      undefined,
+      factory,
+    );
+    expect(res.stdout + res.stderr).not.toContain("auto-running");
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-provision-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-provision-lib.test.ts
@@ -1,0 +1,274 @@
+/**
+ * G1d / T1 (cortex#1139) — tests for the pure provision orchestration behind
+ * `cortex network provision <stack>`. All arc/fs/nsc effects are injected ports
+ * recording their calls — no real nsc/arc/filesystem.
+ */
+import { describe, test, expect } from "bun:test";
+
+import type { FederationWiringPort } from "../network-ports";
+import type { OperatorProvisioningPort } from "../operator-provisioning";
+import {
+  buildProvisionPlan,
+  deriveProvisionNames,
+  provisionStack,
+  type ProvisionInputs,
+  type ProvisionPorts,
+  type ProvisionState,
+  type SigningIdentityPort,
+  type ProvisionConfigWritePort,
+} from "../network-provision-lib";
+
+const FED_PUB = "A" + "B".repeat(55);
+const AGENTS_PUB = "A" + "C".repeat(55);
+
+/** Spy ports recording every effectful call in order. */
+function makePorts(overrides?: {
+  operator?: Partial<OperatorProvisioningPort>;
+  signing?: Partial<SigningIdentityPort>;
+  federationWiring?: Partial<FederationWiringPort>;
+  configWrite?: Partial<ProvisionConfigWritePort>;
+}): { ports: ProvisionPorts; calls: string[]; written: unknown[] } {
+  const calls: string[] = [];
+  const written: unknown[] = [];
+
+  const operator: OperatorProvisioningPort = {
+    initOperator: async ({ name, force }) => {
+      calls.push(`init-operator:${name}${force ? ":force" : ""}`);
+      return { ok: true, operator: name, pubKey: "OD4D", created: true, alreadyExisted: false, seedPath: null };
+    },
+    addAccount: async ({ name }) => {
+      calls.push(`add-account:${name}`);
+      const pubKey = name.endsWith("_AGENTS") ? AGENTS_PUB : FED_PUB;
+      return { ok: true, account: name, pubKey, created: true, alreadyExisted: false };
+    },
+    ...overrides?.operator,
+  };
+
+  const signing: SigningIdentityPort = {
+    exists: () => false,
+    generate: ({ seedPath, force }) => {
+      calls.push(`signing-generate:${seedPath}${force ? ":force" : ""}`);
+      return { ok: true, nkeyPub: "U" + "Z".repeat(55), fingerprint: "fp" };
+    },
+    ...overrides?.signing,
+  };
+
+  const federationWiring: FederationWiringPort = {
+    wireLocalFederation: async ({ federationAccount, agentsAccount, apply }) => {
+      calls.push(`wire:${federationAccount}->${agentsAccount}:${apply ? "apply" : "dry"}`);
+      return { ok: true, note: "export+import wired" };
+    },
+    ...overrides?.federationWiring,
+  };
+
+  const configWrite: ProvisionConfigWritePort = {
+    write: (fields) => {
+      calls.push("config-write");
+      written.push(fields);
+      return { ok: true };
+    },
+    ...overrides?.configWrite,
+  };
+
+  return { ports: { operator, signing, federationWiring, configWrite }, calls, written };
+}
+
+function baseInputs(over?: Partial<ProvisionInputs>, state?: Partial<ProvisionState>): ProvisionInputs {
+  return {
+    principal: "andreas",
+    stackSlug: "research",
+    stackId: "andreas/research",
+    operatorName: "OP_ANDREAS",
+    federationAccountName: "ANDREAS_RESEARCH_FED",
+    agentsAccountName: "ANDREAS_RESEARCH_AGENTS",
+    seedPath: "~/.config/nats/andreas-research.seed",
+    credsPath: "~/.config/nats/research.creds",
+    force: false,
+    apply: false,
+    state: { federationAccount: undefined, agentsAccount: undefined, signingSeedExists: false, ...state },
+    ...over,
+  };
+}
+
+describe("deriveProvisionNames", () => {
+  test("per-stack agents account is distinct from the federation account", () => {
+    const r = deriveProvisionNames("andreas", "research");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.operatorName).toBe("OP_ANDREAS");
+      expect(r.federationAccountName).toBe("ANDREAS_RESEARCH_FED");
+      expect(r.agentsAccountName).toBe("ANDREAS_RESEARCH_AGENTS");
+      // ADR-0012 isolation — the two accounts are NOT the same.
+      expect(r.federationAccountName).not.toBe(r.agentsAccountName);
+    }
+  });
+
+  test("a second stack of the same principal mints DIFFERENT accounts", () => {
+    const a = deriveProvisionNames("andreas", "research");
+    const b = deriveProvisionNames("andreas", "production");
+    expect(a.ok && b.ok).toBe(true);
+    if (a.ok && b.ok) {
+      expect(a.agentsAccountName).not.toBe(b.agentsAccountName);
+    }
+  });
+
+  test("hyphens in segments become underscores (UPPER_SNAKE)", () => {
+    const r = deriveProvisionNames("andreas-x", "code-review");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.operatorName).toBe("OP_ANDREAS_X");
+      expect(r.federationAccountName).toBe("ANDREAS_X_CODE_REVIEW_FED");
+    }
+  });
+});
+
+describe("buildProvisionPlan", () => {
+  test("empty stack → 4 ensure actions (operator + 2 accounts + signing) + 2 wire steps", () => {
+    const plan = buildProvisionPlan(baseInputs());
+    const mintLike = plan.filter((p) => p.status === "mint" || p.status === "generate");
+    expect(mintLike.map((p) => p.step)).toEqual([
+      "nsc operator",
+      "federation account",
+      "agents account",
+      "signing seed",
+    ]);
+  });
+
+  test("fully-provisioned stack → every account/seed step is [ok]", () => {
+    const plan = buildProvisionPlan(
+      baseInputs({}, { federationAccount: FED_PUB, agentsAccount: AGENTS_PUB, signingSeedExists: true }),
+    );
+    const mintLike = plan.filter((p) => p.status === "mint" || p.status === "generate");
+    expect(mintLike).toEqual([]);
+  });
+
+  test("partial state: operator+fed present, agents absent → only agents mints", () => {
+    const plan = buildProvisionPlan(
+      baseInputs({}, { federationAccount: FED_PUB, agentsAccount: undefined, signingSeedExists: true }),
+    );
+    const mintLike = plan.filter((p) => p.status === "mint" || p.status === "generate");
+    expect(mintLike.map((p) => p.step)).toEqual(["agents account"]);
+  });
+
+  test("--force re-mints everything even when present", () => {
+    const plan = buildProvisionPlan(
+      baseInputs({ force: true }, { federationAccount: FED_PUB, agentsAccount: AGENTS_PUB, signingSeedExists: true }),
+    );
+    const mintLike = plan.filter((p) => p.status === "mint" || p.status === "generate");
+    expect(mintLike.length).toBe(4);
+  });
+});
+
+describe("provisionStack — dry-run (default)", () => {
+  test("records ZERO effectful port calls and does not write config", async () => {
+    const { ports, calls } = makePorts();
+    const res = await provisionStack(baseInputs({ apply: false }), ports);
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(false);
+    expect(calls).toEqual([]);
+    expect(res.steps.some((s) => s.includes("--apply"))).toBe(true);
+  });
+});
+
+describe("provisionStack — apply on an empty stack", () => {
+  test("records the mint/wire/write calls in order", async () => {
+    const { ports, calls, written } = makePorts();
+    const res = await provisionStack(baseInputs({ apply: true }), ports);
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(true);
+    expect(calls).toEqual([
+      "init-operator:OP_ANDREAS",
+      "add-account:ANDREAS_RESEARCH_FED",
+      "add-account:ANDREAS_RESEARCH_AGENTS",
+      "signing-generate:~/.config/nats/andreas-research.seed",
+      `wire:${FED_PUB}->${AGENTS_PUB}:apply`,
+      "config-write",
+    ]);
+    // Config write-back carries the minted (distinct) account pubkeys.
+    expect(written[0]).toMatchObject({ account: FED_PUB, agentsAccount: AGENTS_PUB });
+    expect(res.resolved?.account).toBe(FED_PUB);
+    expect(res.resolved?.agentsAccount).toBe(AGENTS_PUB);
+  });
+
+  test("the federated.> wire is CROSS-account (distinct from/to)", async () => {
+    const { ports, calls } = makePorts();
+    await provisionStack(baseInputs({ apply: true }), ports);
+    const wire = calls.find((c) => c.startsWith("wire:"));
+    expect(wire).toBe(`wire:${FED_PUB}->${AGENTS_PUB}:apply`);
+    expect(FED_PUB).not.toBe(AGENTS_PUB);
+  });
+});
+
+describe("provisionStack — idempotent apply re-run", () => {
+  test("fully-provisioned stack → no operator/account/signing mint calls", async () => {
+    const { ports, calls } = makePorts({ signing: { exists: () => true } });
+    const res = await provisionStack(
+      baseInputs({ apply: true }, { federationAccount: FED_PUB, agentsAccount: AGENTS_PUB, signingSeedExists: true }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(calls).not.toContain("init-operator:OP_ANDREAS");
+    expect(calls.some((c) => c.startsWith("add-account:"))).toBe(false);
+    expect(calls.some((c) => c.startsWith("signing-generate:"))).toBe(false);
+    // Wiring (idempotent) + config write still run to converge.
+    expect(calls).toContain(`wire:${FED_PUB}->${AGENTS_PUB}:apply`);
+    expect(calls).toContain("config-write");
+  });
+});
+
+describe("provisionStack — no-clobber & force", () => {
+  test("existing signing seed without --force is left untouched (no-clobber)", async () => {
+    const { ports, calls } = makePorts({ signing: { exists: () => true } });
+    await provisionStack(
+      baseInputs({ apply: true }, { federationAccount: undefined, agentsAccount: undefined, signingSeedExists: true }),
+      ports,
+    );
+    // generate is NEVER called when the seed exists and --force is off.
+    expect(calls.some((c) => c.startsWith("signing-generate:"))).toBe(false);
+  });
+
+  test("--force re-mints the signing seed (clobber) loudly", async () => {
+    const { ports, calls } = makePorts();
+    const res = await provisionStack(
+      baseInputs({ apply: true, force: true }, { federationAccount: FED_PUB, agentsAccount: AGENTS_PUB, signingSeedExists: true }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(calls).toContain("init-operator:OP_ANDREAS:force");
+    expect(calls.some((c) => c.startsWith("signing-generate:") && c.endsWith(":force"))).toBe(true);
+  });
+});
+
+describe("provisionStack — fail-fast", () => {
+  test("an arc add-account failure aborts BEFORE the config write", async () => {
+    const { ports, calls } = makePorts({
+      operator: {
+        initOperator: async ({ name }) => {
+          calls.push(`init-operator:${name}`);
+          return { ok: true, operator: name, pubKey: "OD4D", created: true, alreadyExisted: false, seedPath: null };
+        },
+        addAccount: async ({ name }) => {
+          calls.push(`add-account:${name}`);
+          return { ok: false, reason: "NSC_COMMAND_FAILED: boom" };
+        },
+      },
+    });
+    const res = await provisionStack(baseInputs({ apply: true }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("add-account");
+    // No config write-back on a mid-pipeline failure.
+    expect(calls).not.toContain("config-write");
+  });
+
+  test("a federation-wiring failure aborts before config write", async () => {
+    const { ports, calls } = makePorts({
+      federationWiring: {
+        wireLocalFederation: async () => ({ ok: false, reason: "arc add-federation-export failed" }),
+      },
+    });
+    const res = await provisionStack(baseInputs({ apply: true }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("wiring");
+    expect(calls).not.toContain("config-write");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/operator-provisioning.test.ts
+++ b/src/cli/cortex/commands/__tests__/operator-provisioning.test.ts
@@ -1,0 +1,157 @@
+/**
+ * G1d (cortex#1139) — tests for the arc-shell driver behind `cortex network
+ * provision`: `arc nats init-operator` + `arc nats add-account`. The arc
+ * subprocess is faked via the injectable runner — no real nsc/arc.
+ */
+import { describe, test, expect } from "bun:test";
+
+import {
+  buildOperatorProvisioningAdapter,
+  type ArcOperatorRunner,
+  type ArcOperatorRunResult,
+} from "../operator-provisioning";
+
+const SCHEMA = "arc.nats.operator.v1";
+
+/** A runner that returns a canned stdout JSON line. */
+function cannedRunner(payload: object, exitCode = 0): {
+  runner: ArcOperatorRunner;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const runner: ArcOperatorRunner = (argv) => {
+    calls.push([...argv]);
+    const result: ArcOperatorRunResult = {
+      stdout: JSON.stringify(payload) + "\n",
+      stderr: "",
+      exitCode,
+    };
+    return Promise.resolve(result);
+  };
+  return { runner, calls };
+}
+
+describe("operator-provisioning — init-operator", () => {
+  test("shells `arc nats init-operator --name <name> --json` and parses the ok envelope", async () => {
+    const { runner, calls } = cannedRunner({
+      schema: SCHEMA,
+      ok: true,
+      operator: "OP_ANDREAS",
+      pubKey: "OD4D",
+      created: true,
+      alreadyExisted: false,
+      seedPath: "/keys/O/AB/OD4D.nk",
+    });
+    const port = buildOperatorProvisioningAdapter(runner);
+    const res = await port.initOperator({ name: "OP_ANDREAS", force: false });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.operator).toBe("OP_ANDREAS");
+      expect(res.created).toBe(true);
+      expect(res.alreadyExisted).toBe(false);
+    }
+    expect(calls[0]).toEqual(["nats", "init-operator", "--name", "OP_ANDREAS", "--json"]);
+  });
+
+  test("appends --force when rotating", async () => {
+    const { runner, calls } = cannedRunner({
+      schema: SCHEMA,
+      ok: true,
+      operator: "OP_ANDREAS",
+      pubKey: "OD4D",
+      created: true,
+      alreadyExisted: true,
+      seedPath: null,
+    });
+    const port = buildOperatorProvisioningAdapter(runner);
+    await port.initOperator({ name: "OP_ANDREAS", force: true });
+    expect(calls[0]).toEqual(["nats", "init-operator", "--name", "OP_ANDREAS", "--force", "--json"]);
+  });
+
+  test("idempotent re-run surfaces alreadyExisted=true, created=false", async () => {
+    const { runner } = cannedRunner({
+      schema: SCHEMA,
+      ok: true,
+      operator: "OP_ANDREAS",
+      pubKey: "OD4D",
+      created: false,
+      alreadyExisted: true,
+      seedPath: "/keys/O/AB/OD4D.nk",
+    });
+    const port = buildOperatorProvisioningAdapter(runner);
+    const res = await port.initOperator({ name: "OP_ANDREAS", force: false });
+    expect(res.ok && res.alreadyExisted).toBe(true);
+    expect(res.ok && res.created).toBe(false);
+  });
+
+  test("surfaces an arc error envelope as { ok:false, reason }", async () => {
+    const { runner } = cannedRunner({
+      schema: SCHEMA,
+      ok: false,
+      error: { code: "NSC_NOT_INSTALLED", message: "nsc is not on PATH" },
+    });
+    const port = buildOperatorProvisioningAdapter(runner);
+    const res = await port.initOperator({ name: "OP_ANDREAS", force: false });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toContain("NSC_NOT_INSTALLED");
+      expect(res.reason).toContain("nsc is not on PATH");
+    }
+  });
+
+  test("a wrong schema string fails loudly (arc dependency unmet)", async () => {
+    const { runner } = cannedRunner({ schema: "arc.nats.v1", ok: true });
+    const port = buildOperatorProvisioningAdapter(runner);
+    const res = await port.initOperator({ name: "OP_ANDREAS", force: false });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("cortex#1139");
+  });
+
+  test("a spawn failure surfaces an install hint", async () => {
+    const runner: ArcOperatorRunner = () => Promise.reject(new Error("ENOENT: arc not found"));
+    const port = buildOperatorProvisioningAdapter(runner);
+    const res = await port.initOperator({ name: "OP_ANDREAS", force: false });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("arc nats init-operator");
+  });
+});
+
+describe("operator-provisioning — add-account", () => {
+  test("shells `arc nats add-account <name> --json` and parses the ok envelope", async () => {
+    const acct = "A" + "B".repeat(55);
+    const { runner, calls } = cannedRunner({
+      schema: SCHEMA,
+      ok: true,
+      account: "ANDREAS_RESEARCH_FED",
+      pubKey: acct,
+      created: true,
+      alreadyExisted: false,
+    });
+    const port = buildOperatorProvisioningAdapter(runner);
+    const res = await port.addAccount({ name: "ANDREAS_RESEARCH_FED" });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.account).toBe("ANDREAS_RESEARCH_FED");
+      expect(res.pubKey).toBe(acct);
+      expect(res.created).toBe(true);
+    }
+    expect(calls[0]).toEqual(["nats", "add-account", "ANDREAS_RESEARCH_FED", "--json"]);
+  });
+
+  test("idempotent re-run: alreadyExisted=true", async () => {
+    const acct = "A" + "C".repeat(55);
+    const { runner } = cannedRunner({
+      schema: SCHEMA,
+      ok: true,
+      account: "ANDREAS_RESEARCH_AGENTS",
+      pubKey: acct,
+      created: false,
+      alreadyExisted: true,
+    });
+    const port = buildOperatorProvisioningAdapter(runner);
+    const res = await port.addAccount({ name: "ANDREAS_RESEARCH_AGENTS" });
+    expect(res.ok && res.alreadyExisted).toBe(true);
+  });
+});

--- a/src/cli/cortex/commands/network-provision-adapters.ts
+++ b/src/cli/cortex/commands/network-provision-adapters.ts
@@ -15,6 +15,7 @@ import { dirname } from "path";
 
 import { parseDocument } from "yaml";
 
+import { expandTilde } from "../../../common/config/loader";
 import { generateStackIdentity } from "../../../bus/stack-provisioning";
 import { buildFederationWiringAdapter } from "./network-federation-wiring";
 import { buildOperatorProvisioningAdapter } from "./operator-provisioning";
@@ -33,14 +34,18 @@ import type {
  * REFUSES to clobber without `force` (the orchestrator only calls it when the
  * seed is absent OR `--force` is set, so the refusal is belt-and-braces).
  *
- * @param seedPathExpanded - the already-tilde-expanded `stack.nkey_seed_path`.
+ * The orchestrator threads the raw (portable `~`) `stack.nkey_seed_path` through
+ * the port so the config write-back persists the tilde form; the fs boundary
+ * here expands it (`expandTilde`) in BOTH `exists` and `generate` so the
+ * existence probe and the O_EXCL write target the same `$HOME`-rooted path
+ * (a divergence here breaks no-clobber idempotency — cortex#1236).
  */
 export function buildSigningIdentityAdapter(): SigningIdentityPort {
   return {
-    exists: (seedPath) => existsSync(seedPath),
+    exists: (seedPath) => existsSync(expandTilde(seedPath)),
     generate: ({ seedPath, force }) => {
       try {
-        const material = generateStackIdentity({ seedPath, force });
+        const material = generateStackIdentity({ seedPath: expandTilde(seedPath), force });
         return { ok: true, nkeyPub: material.nkeyPub, fingerprint: material.fingerprint };
       } catch (err) {
         return { ok: false, reason: err instanceof Error ? err.message : String(err) };

--- a/src/cli/cortex/commands/network-provision-adapters.ts
+++ b/src/cli/cortex/commands/network-provision-adapters.ts
@@ -1,0 +1,101 @@
+/**
+ * G1d / T1 (cortex#1139) — the LIVE adapters for `cortex network provision`.
+ *
+ * These touch the real world (nsc store via arc, the signing seed on disk, the
+ * stack config YAML). The orchestration is pure over the injected ports
+ * (`network-provision-lib.ts`); these adapters are only constructed on a real
+ * `--apply` invocation. The arc account-tree seam reuses
+ * `buildOperatorProvisioningAdapter` (operator-provisioning.ts) and the existing
+ * `buildFederationWiringAdapter` (network-federation-wiring.ts) — cortex NEVER
+ * runs nsc itself (ADR-0013 Model B invariant).
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { dirname } from "path";
+
+import { parseDocument } from "yaml";
+
+import { generateStackIdentity } from "../../../bus/stack-provisioning";
+import { buildFederationWiringAdapter } from "./network-federation-wiring";
+import { buildOperatorProvisioningAdapter } from "./operator-provisioning";
+import type {
+  ProvisionPorts,
+  SigningIdentityPort,
+  ProvisionConfigWritePort,
+} from "./network-provision-lib";
+
+// =============================================================================
+// Signing-identity adapter — composes provision-stack's generateStackIdentity
+// =============================================================================
+
+/**
+ * Live {@link SigningIdentityPort}. `generate` writes the seed `chmod 600` and
+ * REFUSES to clobber without `force` (the orchestrator only calls it when the
+ * seed is absent OR `--force` is set, so the refusal is belt-and-braces).
+ *
+ * @param seedPathExpanded - the already-tilde-expanded `stack.nkey_seed_path`.
+ */
+export function buildSigningIdentityAdapter(): SigningIdentityPort {
+  return {
+    exists: (seedPath) => existsSync(seedPath),
+    generate: ({ seedPath, force }) => {
+      try {
+        const material = generateStackIdentity({ seedPath, force });
+        return { ok: true, nkeyPub: material.nkeyPub, fingerprint: material.fingerprint };
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}
+
+// =============================================================================
+// Config write-back adapter — persist stack.nats_infra + nkey_seed_path
+// =============================================================================
+
+/**
+ * Live {@link ProvisionConfigWritePort}. Writes the resolved account-tree
+ * fields into the stack config YAML in place, preserving comments
+ * (parseDocument + setIn — same discipline as `ConfigStorePort.writeNetworks`).
+ *
+ * @param stackConfigPath - the already-resolved, tilde-expanded path to the
+ *   stack file the daemon loads (config-split `stacks/<slug>.yaml`, or the
+ *   legacy monolith). The CLI resolves this layout-aware before constructing.
+ */
+export function buildProvisionConfigWriteAdapter(stackConfigPath: string): ProvisionConfigWritePort {
+  return {
+    write: (fields) => {
+      try {
+        const doc = existsSync(stackConfigPath)
+          ? parseDocument(readFileSync(stackConfigPath, "utf-8"))
+          : parseDocument("");
+        doc.setIn(["stack", "nats_infra", "account"], fields.account);
+        doc.setIn(["stack", "nats_infra", "agents_account"], fields.agentsAccount);
+        doc.setIn(["stack", "nats_infra", "creds_path"], fields.credsPath);
+        doc.setIn(["stack", "nkey_seed_path"], fields.seedPath);
+        if (fields.nkeyPub !== undefined) {
+          doc.setIn(["stack", "nkey_pub"], fields.nkeyPub);
+        }
+        mkdirSync(dirname(stackConfigPath), { recursive: true });
+        writeFileSync(stackConfigPath, doc.toString(), "utf-8");
+        return { ok: true };
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}
+
+// =============================================================================
+// Full live port bundle
+// =============================================================================
+
+/** Build the full live {@link ProvisionPorts} bundle for a real `--apply` run. */
+export function buildLiveProvisionPorts(stackConfigPath: string): ProvisionPorts {
+  return {
+    operator: buildOperatorProvisioningAdapter(),
+    signing: buildSigningIdentityAdapter(),
+    federationWiring: buildFederationWiringAdapter(),
+    configWrite: buildProvisionConfigWriteAdapter(stackConfigPath),
+  };
+}

--- a/src/cli/cortex/commands/network-provision-lib.ts
+++ b/src/cli/cortex/commands/network-provision-lib.ts
@@ -1,0 +1,358 @@
+/**
+ * G1d / T1 (cortex#1139, ADR-0013 Model B) — the pure orchestration behind
+ * `cortex network provision <stack>`: the one-command sovereign account-topology
+ * setup. Stands up a principal's OWN nsc account tree so a stack can federate.
+ *
+ * The pipeline (ensure-shaped, idempotent end-to-end; ADR-0013 §Decision-4
+ * "make standing up your own nsc operator trivial"):
+ *
+ *   1. ensure the NSC operator        (arc nats init-operator)   — per principal
+ *   2. ensure the federation account  (arc nats add-account)     — per stack, leaf-bound
+ *   3. ensure the per-stack agents account (arc nats add-account)— ADR-0012 isolation
+ *   4. ensure the stack signing seed  (provision-stack generate) — chmod 600, no-clobber
+ *   5. wire federated.> export/import (arc nats add-federation-export) — fed → agents
+ *   6. write stack.nats_infra back    (account, agents_account, creds_path) + nkey_seed_path
+ *
+ * After this the stack is ready for `cortex network join` — only the two
+ * irreducible two-party steps remain (the leaf shared secret + hub topology
+ * agreement). The operator-mode `.conf` render + bus restart are LEFT TO JOIN
+ * (render-only here; join already performs the O-3 conversion + #821 health
+ * probe), so this verb is non-disruptive.
+ *
+ * This module is PURE over injected ports — zero fs / arc / nsc. The live
+ * adapters live in `network-provision-adapters.ts`; the arc account-tree seam is
+ * {@link OperatorProvisioningPort} (operator-provisioning.ts) + the existing
+ * {@link FederationWiringPort}. cortex NEVER runs nsc itself (ADR-0013 invariant).
+ *
+ * ## Idempotency & no-clobber
+ *
+ * Every step is ensure-shaped: present ⇒ no-op (rendered `[ok]`), absent ⇒ mint.
+ * State is read from CONFIG + filesystem, so a converged re-run shells zero mint
+ * calls (arc init-operator / add-account are themselves idempotent, but we skip
+ * them when config already carries the resolved pubkeys). The signing seed is
+ * NEVER overwritten without `--force` — an existing seed is left untouched
+ * (no-clobber); `--force` is a deliberate rotation that re-mints it.
+ *
+ * ## Dry-run vs apply
+ *
+ * Dry-run (the DEFAULT-safe posture) computes the plan from config + filesystem
+ * state and mutates NOTHING — it never shells the account-tree mint verbs (which
+ * have no dry-run mode in arc). `--apply` executes the mints + wiring + config
+ * write-back, fail-fast: the whole plan is validated before the first mutation,
+ * and any arc failure aborts BEFORE the config write so no half-provisioned
+ * config block is left behind.
+ */
+
+import type { FederationWiringPort } from "./network-ports";
+import type { OperatorProvisioningPort } from "./operator-provisioning";
+
+// =============================================================================
+// Name derivation — nsc operator + account names from {principal}/{slug}
+// =============================================================================
+
+/** nsc account names are strict UPPER_SNAKE (`[A-Z][A-Z0-9_]+`, arc's guard). */
+const ACCOUNT_NAME_RE = /^[A-Z][A-Z0-9_]+$/;
+/** nsc operator names permit a slightly wider charset (`[A-Za-z][A-Za-z0-9_-]*`). */
+const OPERATOR_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+/** UPPER_SNAKE a `{principal}` / `{slug}` segment (lowercase + hyphen → `_`). */
+function upperSnake(segment: string): string {
+  return segment.toUpperCase().replace(/-/g, "_");
+}
+
+/**
+ * Derive the nsc operator + the two account names for a stack. The operator is
+ * per-principal (`OP_<PRINCIPAL>`); the federation + agents accounts are
+ * per-stack (`<PRINCIPAL>_<STACK>_FED` / `_AGENTS`) so a principal's second
+ * stack mints DISTINCT accounts (ADR-0012 isolation — never shared).
+ */
+export function deriveProvisionNames(
+  principal: string,
+  slug: string,
+): { ok: true; operatorName: string; federationAccountName: string; agentsAccountName: string } | { ok: false; reason: string } {
+  const operatorName = `OP_${upperSnake(principal)}`;
+  const base = `${upperSnake(principal)}_${upperSnake(slug)}`;
+  const federationAccountName = `${base}_FED`;
+  const agentsAccountName = `${base}_AGENTS`;
+  if (!OPERATOR_NAME_RE.test(operatorName)) {
+    return { ok: false, reason: `derived nsc operator name "${operatorName}" is invalid (principal "${principal}")` };
+  }
+  for (const n of [federationAccountName, agentsAccountName]) {
+    if (!ACCOUNT_NAME_RE.test(n)) {
+      return { ok: false, reason: `derived account name "${n}" is invalid (must be UPPER_SNAKE)` };
+    }
+  }
+  return { ok: true, operatorName, federationAccountName, agentsAccountName };
+}
+
+// =============================================================================
+// Ports
+// =============================================================================
+
+/** Signing-identity seam (composes `provision-stack generate` / generateStackIdentity). */
+export interface SigningIdentityPort {
+  /** Is a signing seed already present at `seedPath`? Drives the dry-run plan. */
+  exists(seedPath: string): boolean;
+  /** Mint a fresh signing seed (`chmod 600`); `force` clobbers an existing one. */
+  generate(opts: { seedPath: string; force: boolean }):
+    | { ok: true; nkeyPub: string; fingerprint: string }
+    | { ok: false; reason: string };
+}
+
+/** Config write-back seam — persists the resolved `stack.nats_infra` fields. */
+export interface ProvisionConfigWritePort {
+  write(fields: {
+    account: string;
+    agentsAccount: string;
+    credsPath: string;
+    seedPath: string;
+    nkeyPub?: string;
+  }): { ok: true } | { ok: false; reason: string };
+}
+
+/** The full port bundle the orchestrator depends on. */
+export interface ProvisionPorts {
+  operator: OperatorProvisioningPort;
+  signing: SigningIdentityPort;
+  federationWiring: FederationWiringPort;
+  configWrite: ProvisionConfigWritePort;
+}
+
+// =============================================================================
+// Inputs + state + result
+// =============================================================================
+
+/** Observable pre-provision state (read from config + filesystem). */
+export interface ProvisionState {
+  /** `stack.nats_infra.account` (the leaf-bound federation account `A…` pubkey), if set. */
+  federationAccount: string | undefined;
+  /** `stack.nats_infra.agents_account` (`A…` pubkey), if set. */
+  agentsAccount: string | undefined;
+  /** Does the signing seed file exist on disk? */
+  signingSeedExists: boolean;
+}
+
+export interface ProvisionInputs {
+  principal: string;
+  stackSlug: string;
+  stackId: string;
+  operatorName: string;
+  federationAccountName: string;
+  agentsAccountName: string;
+  /** `stack.nkey_seed_path` — where the signing seed is / will be written. */
+  seedPath: string;
+  /** Conventional leaf `.creds` path recorded in config (minted at join). */
+  credsPath: string;
+  force: boolean;
+  apply: boolean;
+  state: ProvisionState;
+}
+
+export type PlanStatus = "mint" | "generate" | "wire" | "ok";
+
+export interface PlanItem {
+  step: string;
+  status: PlanStatus;
+  detail: string;
+}
+
+export interface ProvisionResult {
+  ok: boolean;
+  reason?: string;
+  applied: boolean;
+  plan: PlanItem[];
+  /** Human-readable plan/result lines for the CLI renderer. */
+  steps: string[];
+  /** The resolved fields (present on a successful apply). */
+  resolved?: { account: string; agentsAccount: string; credsPath: string; seedPath: string };
+}
+
+// =============================================================================
+// Plan builder (pure)
+// =============================================================================
+
+/**
+ * Compute the ensure-plan from observable state. Each step is `[ok]` when
+ * already present, `[mint]`/`[generate]` when absent (or always, under
+ * `--force`). The `federated.>` wiring is always a converge step (arc is
+ * idempotent). The operator is treated as present iff the federation account is
+ * (an account cannot exist without its operator).
+ */
+export function buildProvisionPlan(inputs: ProvisionInputs): PlanItem[] {
+  const { force, state } = inputs;
+  const operatorPresent = !force && state.federationAccount !== undefined;
+  const fedPresent = !force && state.federationAccount !== undefined;
+  const agentsPresent = !force && state.agentsAccount !== undefined;
+  const signingPresent = !force && state.signingSeedExists;
+
+  return [
+    {
+      step: "nsc operator",
+      status: operatorPresent ? "ok" : "mint",
+      detail: inputs.operatorName,
+    },
+    {
+      step: "federation account",
+      status: fedPresent ? "ok" : "mint",
+      detail: fedPresent ? `${inputs.federationAccountName} (${state.federationAccount})` : inputs.federationAccountName,
+    },
+    {
+      step: "agents account",
+      status: agentsPresent ? "ok" : "mint",
+      detail: agentsPresent ? `${inputs.agentsAccountName} (${state.agentsAccount})` : inputs.agentsAccountName,
+    },
+    {
+      step: "signing seed",
+      status: signingPresent ? "ok" : "generate",
+      detail: inputs.seedPath,
+    },
+    {
+      step: "federated.> export/import",
+      status: "wire",
+      detail: `${inputs.federationAccountName} → ${inputs.agentsAccountName}`,
+    },
+    {
+      step: "stack.nats_infra write-back",
+      status: "wire",
+      detail: "account, agents_account, creds_path, nkey_seed_path",
+    },
+  ];
+}
+
+/** Render a plan item as a CLI line (`[mint ] nsc operator   OP_ANDREAS`). */
+function renderPlanLine(item: PlanItem): string {
+  const tag = item.status.padEnd(8);
+  return `[${tag}] ${item.step.padEnd(28)} ${item.detail}`;
+}
+
+// =============================================================================
+// Orchestrator
+// =============================================================================
+
+/**
+ * Provision a stack's sovereign account topology. Pure over `ports`; NEVER
+ * throws (port failures surface as `{ ok: false, reason }`).
+ *
+ * Dry-run (`apply === false`): returns the plan; mutates nothing.
+ * Apply: executes mints + wiring + config write-back, fail-fast (validate the
+ * full plan, then mutate; abort before the config write on any arc failure).
+ */
+export async function provisionStack(
+  inputs: ProvisionInputs,
+  ports: ProvisionPorts,
+): Promise<ProvisionResult> {
+  const plan = buildProvisionPlan(inputs);
+  const planLines = plan.map(renderPlanLine);
+
+  if (!inputs.apply) {
+    return {
+      ok: true,
+      applied: false,
+      plan,
+      steps: [
+        ...planLines,
+        "",
+        "Re-run with --apply to execute.",
+        "AFTER this: exchange the leaf shared secret + agree hub topology with your peer, then `cortex network join <network>`.",
+      ],
+    };
+  }
+
+  const { force, state } = inputs;
+  const steps: string[] = [];
+
+  // The pubkeys we resolve (minted-or-existing) and write back to config.
+  let resolvedAccount = state.federationAccount;
+  let resolvedAgents = state.agentsAccount;
+  let resolvedNkeyPub: string | undefined;
+
+  const operatorNeeded = force || state.federationAccount === undefined;
+  const fedNeeded = force || state.federationAccount === undefined;
+  const agentsNeeded = force || state.agentsAccount === undefined;
+  const signingNeeded = force || !state.signingSeedExists;
+
+  // 1. NSC operator (per principal). Idempotent in arc; skipped when the
+  //    federation account already exists (it cannot exist without its operator).
+  if (operatorNeeded) {
+    const r = await ports.operator.initOperator({ name: inputs.operatorName, force });
+    if (!r.ok) return fail(plan, planLines, `init-operator failed: ${r.reason}`);
+    steps.push(`nsc operator ${r.alreadyExisted && !r.created ? "present" : r.created ? "minted" : "ensured"}: ${r.operator}`);
+  } else {
+    steps.push(`nsc operator present: ${inputs.operatorName}`);
+  }
+
+  // 2. Federation account (leaf-bound, per stack).
+  if (fedNeeded) {
+    const r = await ports.operator.addAccount({ name: inputs.federationAccountName });
+    if (!r.ok) return fail(plan, planLines, `add-account (federation) failed: ${r.reason}`);
+    resolvedAccount = r.pubKey;
+    steps.push(`federation account ${r.created ? "minted" : "present"}: ${r.account} (${r.pubKey})`);
+  } else {
+    steps.push(`federation account present: ${resolvedAccount}`);
+  }
+
+  // 3. Per-stack agents account (ADR-0012 isolation).
+  if (agentsNeeded) {
+    const r = await ports.operator.addAccount({ name: inputs.agentsAccountName });
+    if (!r.ok) return fail(plan, planLines, `add-account (agents) failed: ${r.reason}`);
+    resolvedAgents = r.pubKey;
+    steps.push(`agents account ${r.created ? "minted" : "present"}: ${r.account} (${r.pubKey})`);
+  } else {
+    steps.push(`agents account present: ${resolvedAgents}`);
+  }
+
+  // 4. Signing seed (chmod 600, no-clobber unless --force).
+  if (signingNeeded) {
+    const r = ports.signing.generate({ seedPath: inputs.seedPath, force });
+    if (!r.ok) return fail(plan, planLines, `signing-seed generate failed: ${r.reason}`);
+    resolvedNkeyPub = r.nkeyPub;
+    steps.push(`signing seed ${force ? "rotated" : "generated"}: ${inputs.seedPath} (chmod 600)`);
+  } else {
+    steps.push(`signing seed present (untouched): ${inputs.seedPath}`);
+  }
+
+  // Defensive: both account pubkeys must be resolved before wiring/write-back.
+  if (resolvedAccount === undefined || resolvedAgents === undefined) {
+    return fail(plan, planLines, "internal: account pubkeys unresolved after mint (should not happen)");
+  }
+
+  // 5. Wire the local-side federated.> export/import (fed-account → agents-account).
+  const wire = await ports.federationWiring.wireLocalFederation({
+    federationAccount: resolvedAccount,
+    agentsAccount: resolvedAgents,
+    apply: true,
+  });
+  if (!wire.ok) return fail(plan, planLines, `federation wiring failed: ${wire.reason}`);
+  steps.push(`federated.> export/import: ${wire.note ?? "wired"}`);
+
+  // 6. Write the resolved nats_infra fields back to the stack config.
+  const written = ports.configWrite.write({
+    account: resolvedAccount,
+    agentsAccount: resolvedAgents,
+    credsPath: inputs.credsPath,
+    seedPath: inputs.seedPath,
+    ...(resolvedNkeyPub !== undefined && { nkeyPub: resolvedNkeyPub }),
+  });
+  if (!written.ok) return fail(plan, planLines, `config write-back failed: ${written.reason}`);
+  steps.push("stack.nats_infra written (account, agents_account, creds_path, nkey_seed_path)");
+
+  steps.push("");
+  steps.push("Ready for `cortex network join <network>` — remaining: leaf shared secret + hub topology (two-party, out-of-band).");
+
+  return {
+    ok: true,
+    applied: true,
+    plan,
+    steps,
+    resolved: {
+      account: resolvedAccount,
+      agentsAccount: resolvedAgents,
+      credsPath: inputs.credsPath,
+      seedPath: inputs.seedPath,
+    },
+  };
+}
+
+function fail(plan: PlanItem[], planLines: string[], reason: string): ProvisionResult {
+  return { ok: false, reason, applied: true, plan, steps: planLines };
+}

--- a/src/cli/cortex/commands/network-provision-lib.ts
+++ b/src/cli/cortex/commands/network-provision-lib.ts
@@ -275,7 +275,7 @@ export async function provisionStack(
   //    federation account already exists (it cannot exist without its operator).
   if (operatorNeeded) {
     const r = await ports.operator.initOperator({ name: inputs.operatorName, force });
-    if (!r.ok) return fail(plan, planLines, `init-operator failed: ${r.reason}`);
+    if (!r.ok) return fail(plan, steps, `init-operator failed: ${r.reason}`);
     steps.push(`nsc operator ${r.alreadyExisted && !r.created ? "present" : r.created ? "minted" : "ensured"}: ${r.operator}`);
   } else {
     steps.push(`nsc operator present: ${inputs.operatorName}`);
@@ -284,7 +284,7 @@ export async function provisionStack(
   // 2. Federation account (leaf-bound, per stack).
   if (fedNeeded) {
     const r = await ports.operator.addAccount({ name: inputs.federationAccountName });
-    if (!r.ok) return fail(plan, planLines, `add-account (federation) failed: ${r.reason}`);
+    if (!r.ok) return fail(plan, steps, `add-account (federation) failed: ${r.reason}`);
     resolvedAccount = r.pubKey;
     steps.push(`federation account ${r.created ? "minted" : "present"}: ${r.account} (${r.pubKey})`);
   } else {
@@ -294,7 +294,7 @@ export async function provisionStack(
   // 3. Per-stack agents account (ADR-0012 isolation).
   if (agentsNeeded) {
     const r = await ports.operator.addAccount({ name: inputs.agentsAccountName });
-    if (!r.ok) return fail(plan, planLines, `add-account (agents) failed: ${r.reason}`);
+    if (!r.ok) return fail(plan, steps, `add-account (agents) failed: ${r.reason}`);
     resolvedAgents = r.pubKey;
     steps.push(`agents account ${r.created ? "minted" : "present"}: ${r.account} (${r.pubKey})`);
   } else {
@@ -304,7 +304,7 @@ export async function provisionStack(
   // 4. Signing seed (chmod 600, no-clobber unless --force).
   if (signingNeeded) {
     const r = ports.signing.generate({ seedPath: inputs.seedPath, force });
-    if (!r.ok) return fail(plan, planLines, `signing-seed generate failed: ${r.reason}`);
+    if (!r.ok) return fail(plan, steps, `signing-seed generate failed: ${r.reason}`);
     resolvedNkeyPub = r.nkeyPub;
     steps.push(`signing seed ${force ? "rotated" : "generated"}: ${inputs.seedPath} (chmod 600)`);
   } else {
@@ -313,7 +313,7 @@ export async function provisionStack(
 
   // Defensive: both account pubkeys must be resolved before wiring/write-back.
   if (resolvedAccount === undefined || resolvedAgents === undefined) {
-    return fail(plan, planLines, "internal: account pubkeys unresolved after mint (should not happen)");
+    return fail(plan, steps, "internal: account pubkeys unresolved after mint (should not happen)");
   }
 
   // 5. Wire the local-side federated.> export/import (fed-account → agents-account).
@@ -322,7 +322,7 @@ export async function provisionStack(
     agentsAccount: resolvedAgents,
     apply: true,
   });
-  if (!wire.ok) return fail(plan, planLines, `federation wiring failed: ${wire.reason}`);
+  if (!wire.ok) return fail(plan, steps, `federation wiring failed: ${wire.reason}`);
   steps.push(`federated.> export/import: ${wire.note ?? "wired"}`);
 
   // 6. Write the resolved nats_infra fields back to the stack config.
@@ -333,7 +333,7 @@ export async function provisionStack(
     seedPath: inputs.seedPath,
     ...(resolvedNkeyPub !== undefined && { nkeyPub: resolvedNkeyPub }),
   });
-  if (!written.ok) return fail(plan, planLines, `config write-back failed: ${written.reason}`);
+  if (!written.ok) return fail(plan, steps, `config write-back failed: ${written.reason}`);
   steps.push("stack.nats_infra written (account, agents_account, creds_path, nkey_seed_path)");
 
   steps.push("");
@@ -353,6 +353,9 @@ export async function provisionStack(
   };
 }
 
-function fail(plan: PlanItem[], planLines: string[], reason: string): ProvisionResult {
-  return { ok: false, reason, applied: true, plan, steps: planLines };
+function fail(plan: PlanItem[], steps: string[], reason: string): ProvisionResult {
+  // Return the steps accumulated so far (not the original plan) so a
+  // mid-pipeline abort surfaces how far provisioning actually got — e.g.
+  // operator minted, federation account failed (cortex#1236 NIT 2).
+  return { ok: false, reason, applied: true, plan, steps };
 }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -1769,7 +1769,7 @@ function shouldAutoProvision(cfg: LoadedConfig): boolean {
   return (
     cfg.principal?.id !== undefined &&
     cfg.stack?.id !== undefined &&
-    cfg.stack?.nats_infra?.account === undefined
+    cfg.stack.nats_infra?.account === undefined
   );
 }
 
@@ -1800,7 +1800,7 @@ async function maybeAutoProvision(
   // now sees the account tree and the join CAN proceed in the same invocation
   // (true plug-and-play). On a dry-run nothing was written, so the stack is
   // still unprovisioned and the join cannot meaningfully continue.
-  let provisionedAfter = false;
+  let provisionedAfter: boolean;
   try {
     provisionedAfter = isStackProvisioned(load(configPath));
   } catch {

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -117,6 +117,13 @@ import {
   type PingResult,
 } from "./network-ping-lib";
 import {
+  deriveProvisionNames,
+  provisionStack,
+  type ProvisionInputs,
+  type ProvisionPorts,
+} from "./network-provision-lib";
+import { buildLiveProvisionPorts } from "./network-provision-adapters";
+import {
   createLiveProbeBus,
   type LiveProbeBus,
 } from "./network-ping-adapters";
@@ -129,7 +136,7 @@ export { type ExitResult } from "./_shared/exit-result";
 // Grammar
 // =============================================================================
 
-type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "admit";
+type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "admit" | "provision";
 
 /**
  * Default registry URL when neither --registry-url nor config provides one.
@@ -312,6 +319,25 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--dry-run": "bool",
       },
     },
+    // G1d / T1 (cortex#1139, ADR-0013) — one-command sovereign account-topology
+    // setup. Mints the principal's OWN nsc operator + a dedicated federation
+    // account + a per-stack agents account (via arc), wires the local
+    // federated.> export/import, ensures the signing seed, and writes
+    // stack.nats_infra back — leaving the stack ready for `cortex network join`.
+    // DRY-RUN by default (prints the plan); --apply mutates. `cortex network
+    // join` auto-calls this when the stack isn't provisioned yet.
+    provision: {
+      positionals: ["stack"],
+      flags: {
+        "--config": "value",
+        "--principal": "value",
+        "--seed-path": "value",
+        "--creds": "value",
+        "--force": "bool",
+        "--apply": "bool",
+        "--dry-run": "bool",
+      },
+    },
   },
   universal: { "--json": "bool", "--help": "bool", "-h": "bool" },
 };
@@ -476,6 +502,7 @@ async function runJoin(
   flags: FlagMap,
   json: boolean,
   load: ConfigReader,
+  provisionPortsFactory: ProvisionPortsFactory,
 ): Promise<ExitResult> {
   // S5 (#739) — `join public` is the open-square opt-in, structurally distinct
   // from a federated join (no leaf, no creds/account, no peers). Route it to
@@ -487,6 +514,27 @@ async function runJoin(
   if (!NETWORK_ID_RE.test(networkId)) {
     return usageError("join", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
   }
+
+  // cortex#1139 — plug-and-play: if the stack hasn't been provisioned (no
+  // dedicated federation + agents account in config), auto-run `cortex network
+  // provision` first so a single `join` stands the whole substrate up. On an
+  // --apply provision failure we abort (a join with no account tree is doomed);
+  // otherwise we prepend the provision output and continue.
+  const autoProv = await maybeAutoProvision(flags, json, load, provisionPortsFactory);
+  if (autoProv.ran && (!autoProv.provisionedAfter || autoProv.provisionFailed)) {
+    // Provision ran but the stack isn't (yet) provisioned for THIS invocation —
+    // a dry-run (nothing written) or a failed apply. Surface the provision
+    // output + guidance; don't attempt a doomed join in the same run.
+    const guidance = autoProv.provisionFailed
+      ? ""
+      : json
+        ? ""
+        : "\ncortex network join: re-run after `cortex network provision <stack> --apply` to join.\n";
+    return autoProv.provisionFailed
+      ? { exitCode: 1, stdout: "", stderr: autoProv.output }
+      : { exitCode: 0, stdout: autoProv.output + guidance, stderr: "" };
+  }
+  const provPrefix = autoProv.output;
 
   // #753 — derive principal / stack / seed / registry / nats-infra (config +
   // convention), with each flag surviving as an optional override. Config-load
@@ -584,9 +632,14 @@ async function runJoin(
   });
   // cortex#1228 — prepend the custom-registry TOFU warning to stderr (when set)
   // so it is surfaced regardless of the flow's success/JSON mode.
-  return tofuWarning !== undefined
-    ? { ...flow, stderr: tofuWarning + flow.stderr }
-    : flow;
+  const withTofu =
+    tofuWarning !== undefined ? { ...flow, stderr: tofuWarning + flow.stderr } : flow;
+  // cortex#1139 — prepend any auto-provision output so the join transcript shows
+  // the substrate setup that ran first (to stdout on success, stderr on failure).
+  if (provPrefix === "") return withTofu;
+  return withTofu.exitCode === 0
+    ? { ...withTofu, stdout: provPrefix + withTofu.stdout }
+    : { ...withTofu, stderr: provPrefix + withTofu.stderr };
 }
 
 async function runLeave(
@@ -1533,6 +1586,230 @@ async function runAdmit(
 }
 
 // =============================================================================
+// G1d / T1 (cortex#1139) — `cortex network provision <stack>`
+// =============================================================================
+
+/**
+ * Factory for the provision port bundle. Production builds the live adapters
+ * (arc account-tree seam + signing + config write-back) targeting the stack's
+ * config file; tests inject fakes that record calls without touching arc/fs.
+ */
+export type ProvisionPortsFactory = (stackConfigPath: string) => ProvisionPorts;
+
+const DEFAULT_PROVISION_PORTS_FACTORY: ProvisionPortsFactory = (p) => buildLiveProvisionPorts(p);
+
+const STACK_SLUG_RE = /^[a-z][a-z0-9_-]*$/;
+
+/**
+ * Resolve where the `stack.nats_infra` write-back lands, layout-aware (mirrors
+ * `stackConfigPath` in network-adapters): a config-split pointer writes to its
+ * sibling `stacks/<basename>.yaml`; a legacy monolith writes to itself.
+ */
+function resolveStackWriteConfigPath(configPath: string): string {
+  const expanded = expandTilde(configPath);
+  const configDir = expanded.replace(/\/[^/]*$/, "");
+  if (existsSync(join(configDir, "system", "system.yaml"))) {
+    const base = (expanded.split("/").pop() ?? "").replace(/\.ya?ml$/i, "");
+    return join(configDir, "stacks", `${base}.yaml`);
+  }
+  return expanded;
+}
+
+/** Resolve the stack slug for provision: positional `{principal}/{slug}` or a
+ *  bare slug, else the single configured `stack.id`, else `default`. */
+function resolveProvisionSlug(
+  stackArg: string,
+  principal: string,
+  cfg: LoadedConfig,
+): { ok: true; slug: string } | { ok: false; reason: string } {
+  if (stackArg === "") {
+    const id = cfg.stack?.id;
+    const slug = id !== undefined ? id.split("/")[1] ?? "default" : "default";
+    return { ok: true, slug };
+  }
+  if (stackArg.includes("/")) {
+    const parts = stackArg.split("/");
+    if (parts.length !== 2 || parts[0] !== principal) {
+      return { ok: false, reason: `<stack> "${stackArg}" must be {principal}/{slug} with prefix matching principal "${principal}"` };
+    }
+    const slug = parts[1] ?? "";
+    if (!STACK_SLUG_RE.test(slug)) return { ok: false, reason: `<stack> slug "${slug}" must be letter-prefixed lowercase` };
+    return { ok: true, slug };
+  }
+  if (!STACK_SLUG_RE.test(stackArg)) return { ok: false, reason: `<stack> "${stackArg}" must be letter-prefixed lowercase` };
+  return { ok: true, slug: stackArg };
+}
+
+/** Build the {@link ProvisionInputs} from config + flags, or a usage reason. */
+function deriveProvisionInputs(
+  stackArg: string,
+  flags: FlagMap,
+  load: ConfigReader,
+): { ok: true; inputs: ProvisionInputs; stackConfigPath: string } | { ok: false; reason: string; usage: boolean } {
+  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH);
+  let cfg: LoadedConfig;
+  try {
+    cfg = load(configPath);
+  } catch (err) {
+    return { ok: false, reason: `config load failed: ${err instanceof Error ? err.message : String(err)}`, usage: false };
+  }
+
+  const principal = optionalValueFlag(flags, "--principal") ?? cfg.principal?.id;
+  if (principal === undefined || principal === "") {
+    return { ok: false, reason: "cannot resolve principal — pass --principal or set `principal.id` in cortex.yaml", usage: true };
+  }
+  if (!PRINCIPAL_ID_RE.test(principal)) {
+    return { ok: false, reason: `principal "${principal}" must be lowercase alphanumeric + hyphen, letter-prefixed`, usage: true };
+  }
+
+  const slugRes = resolveProvisionSlug(stackArg, principal, cfg);
+  if (!slugRes.ok) return { ok: false, reason: slugRes.reason, usage: true };
+  const slug = slugRes.slug;
+
+  const names = deriveProvisionNames(principal, slug);
+  if (!names.ok) return { ok: false, reason: names.reason, usage: true };
+
+  const seedPath = optionalValueFlag(flags, "--seed-path") ?? cfg.stack?.nkey_seed_path ?? `~/.config/nats/${principal}-${slug}.seed`;
+  const credsPath = optionalValueFlag(flags, "--creds") ?? cfg.stack?.nats_infra?.creds_path ?? `~/.config/nats/${slug}.creds`;
+
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return { ok: false, reason: applyRes.reason, usage: true };
+
+  const inputs: ProvisionInputs = {
+    principal,
+    stackSlug: slug,
+    stackId: `${principal}/${slug}`,
+    operatorName: names.operatorName, // nsc operator account name (OP_<PRINCIPAL>)
+    federationAccountName: names.federationAccountName,
+    agentsAccountName: names.agentsAccountName,
+    seedPath,
+    credsPath,
+    force: flags["--force"] === true,
+    apply: applyRes.apply,
+    state: {
+      federationAccount: cfg.stack?.nats_infra?.account,
+      agentsAccount: cfg.stack?.nats_infra?.agents_account,
+      signingSeedExists: existsSync(expandTilde(seedPath)),
+    },
+  };
+  return { ok: true, inputs, stackConfigPath: resolveStackWriteConfigPath(configPath) };
+}
+
+async function runProvision(
+  stackArg: string,
+  flags: FlagMap,
+  json: boolean,
+  load: ConfigReader,
+  portsFactory: ProvisionPortsFactory,
+): Promise<ExitResult> {
+  const derived = deriveProvisionInputs(stackArg, flags, load);
+  if (!derived.ok) {
+    return derived.usage ? usageError("provision", derived.reason, json) : opError("provision", derived.reason, json);
+  }
+  const { inputs, stackConfigPath } = derived;
+
+  const ports = portsFactory(stackConfigPath);
+  const res = await provisionStack(inputs, ports);
+
+  if (json) {
+    const data: Record<string, string> = {
+      stack: inputs.stackId,
+      applied: res.applied ? "true" : "false",
+      operator: inputs.operatorName, // nsc operator account
+      federation_account: inputs.federationAccountName,
+      agents_account: inputs.agentsAccountName,
+    };
+    if (res.resolved !== undefined) {
+      data.account = res.resolved.account;
+      data.agents_account_pubkey = res.resolved.agentsAccount;
+    }
+    const env = res.ok
+      ? envelopeOk([{ stack: inputs.stackId, plan: res.plan }], data)
+      : envelopeError(res.reason ?? "provision failed", data);
+    return res.ok
+      ? ok(renderJson(env))
+      : { exitCode: 1, stdout: "", stderr: renderJson(env) };
+  }
+
+  const header = res.applied
+    ? `cortex network provision ${inputs.stackId}: ${res.ok ? "ok" : "FAILED"}`
+    : `cortex network provision ${inputs.stackId}: dry-run (no mutation; pass --apply)`;
+  const body =
+    `${header}\n` +
+    `  principal: ${inputs.principal}   stack: ${inputs.stackId}\n` +
+    res.steps.map((s) => (s === "" ? "" : `  ${s}`)).join("\n") +
+    (res.ok ? "" : `\n  ✗ ${res.reason ?? "unknown failure"}`) +
+    "\n";
+  return res.ok ? ok(body) : { exitCode: 1, stdout: "", stderr: body };
+}
+
+/**
+ * `cortex network join` plug-and-play (cortex#1139) — when the stack isn't
+ * provisioned yet (no `stack.nats_infra.account` + `agents_account`),
+ * auto-run `cortex network provision` first so a single `join` stands the whole
+ * substrate up. Returns the provision output to PREPEND, and whether join
+ * should abort (an --apply provision that failed).
+ */
+/**
+ * A stack is "provisioned enough to join" once its federation account is in
+ * config (`stack.nats_infra.account`). `agents_account` is the G1d enhancement
+ * (cross-account wiring); its absence does NOT block a legacy join.
+ */
+function isStackProvisioned(cfg: LoadedConfig): boolean {
+  return cfg.stack?.nats_infra?.account !== undefined;
+}
+
+/**
+ * Auto-provision fires ONLY for a config that genuinely describes a cortex
+ * stack (principal.id + stack.id present) that has NOT yet minted its account
+ * tree. This deliberately EXCLUDES the fully-flagged / empty-config legacy join
+ * path (no principal/stack in config) so it never disrupts an explicit join.
+ */
+function shouldAutoProvision(cfg: LoadedConfig): boolean {
+  return (
+    cfg.principal?.id !== undefined &&
+    cfg.stack?.id !== undefined &&
+    cfg.stack?.nats_infra?.account === undefined
+  );
+}
+
+async function maybeAutoProvision(
+  flags: FlagMap,
+  json: boolean,
+  load: ConfigReader,
+  portsFactory: ProvisionPortsFactory,
+): Promise<{ ran: boolean; provisionedAfter: boolean; provisionFailed: boolean; output: string }> {
+  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH);
+  let cfg: LoadedConfig;
+  try {
+    cfg = load(configPath);
+  } catch {
+    // A broken config surfaces later in the join's own derive; don't double-fail.
+    return { ran: false, provisionedAfter: true, provisionFailed: false, output: "" };
+  }
+  if (!shouldAutoProvision(cfg)) {
+    return { ran: false, provisionedAfter: true, provisionFailed: false, output: "" };
+  }
+
+  // Auto-provision with the SAME apply posture as the join.
+  const res = await runProvision("", flags, json, load, portsFactory);
+  const out = res.stdout || res.stderr;
+  const banner = json ? "" : "cortex network join: stack not provisioned — auto-running `cortex network provision` first\n";
+
+  // Re-read: on an --apply run the live config write-back lands, so the re-read
+  // now sees the account tree and the join CAN proceed in the same invocation
+  // (true plug-and-play). On a dry-run nothing was written, so the stack is
+  // still unprovisioned and the join cannot meaningfully continue.
+  let provisionedAfter = false;
+  try {
+    provisionedAfter = isStackProvisioned(load(configPath));
+  } catch {
+    provisionedAfter = false;
+  }
+  return { ran: true, provisionedAfter, provisionFailed: res.exitCode !== 0, output: banner + out };
+}
+
+// =============================================================================
 // Dispatcher
 // =============================================================================
 
@@ -1545,6 +1822,10 @@ export async function dispatchNetwork(
   // #56 — injectable probe-bus factory so `ping` CLI tests drive a fake bus
   // without standing up NATS. Production omits it → the live NATS-backed bus.
   pingBusFactory: PingBusFactory = DEFAULT_PING_BUS_FACTORY,
+  // cortex#1139 — injectable provision-ports factory so `provision` / the join
+  // auto-provision CLI tests drive fake arc/fs ports. Production omits it → the
+  // live adapters (arc account-tree seam + signing + config write-back).
+  provisionPortsFactory: ProvisionPortsFactory = DEFAULT_PROVISION_PORTS_FACTORY,
 ): Promise<ExitResult> {
   let parsed;
   try {
@@ -1571,7 +1852,7 @@ export async function dispatchNetwork(
 
   switch (parsed.subcommand) {
     case "join":
-      return runJoin(parsed.positionals.network ?? "", parsed.flags, json, load);
+      return runJoin(parsed.positionals.network ?? "", parsed.flags, json, load, provisionPortsFactory);
     case "leave":
       return runLeave(parsed.positionals.network ?? "", parsed.flags, json, load);
     case "status":
@@ -1582,6 +1863,8 @@ export async function dispatchNetwork(
       return runPing(parsed.positionals.peer ?? "", parsed.flags, json, load, pingBusFactory);
     case "admit":
       return runAdmit(parsed.positionals["request-id"] ?? "", parsed.flags, json);
+    case "provision":
+      return runProvision(parsed.positionals.stack ?? "", parsed.flags, json, load, provisionPortsFactory);
   }
 }
 
@@ -1601,6 +1884,8 @@ Usage:
   cortex network admit  <request-id> --admin-seed <path> [--network <id>] [--registry-url <url>]
                         [--discord-member <id>] [--discord-guild <id>] [--discord-server <profile>]
                         [--discord-role <name>] [--apply] [--dry-run] [--json]
+  cortex network provision <stack> [--config <p>] [--principal <id>] [--seed-path <p>]
+                        [--creds <p>] [--force] [--apply] [--dry-run] [--json]
 
 The one-liner (#753): \`cortex network join <network>\` derives EVERYTHING from
 the loaded cortex.yaml — principal (principal.id), stack (stack.id), signing
@@ -1641,6 +1926,20 @@ Subcommands:
           signed claim it WOULD POST); pass --apply to actually write. The
           registry FAILS CLOSED if its REGISTRY_ADMIN_PUBKEYS allowlist is
           unset, and rejects (403) an admin key not on the allowlist.
+  provision (cortex#1139, ADR-0013) One-command sovereign account-topology setup.
+          Mints the principal's OWN nsc operator (OP_<PRINCIPAL>) + a dedicated
+          federation account + a per-stack agents account (ADR-0012 isolation),
+          wires the local federated.> export/import (federation account → agents
+          account), ensures the chmod-600 signing seed (no-clobber; --force to
+          rotate), and writes stack.nats_infra back — leaving the stack ready for
+          \`cortex network join\`. cortex runs zero nsc itself — it shells to arc
+          for the nsc \`init-operator\` / \`add-account\` / \`add-federation-export\`
+          mutations.
+          DRY-RUN by default (prints the plan); --apply mutates. \`cortex network
+          join\` auto-runs this when the stack isn't provisioned yet. The
+          operator-mode bus conversion + restart are left to \`join\` (this verb is
+          non-disruptive). Remaining two-party steps after provision: the leaf
+          shared secret + hub topology agreement (out-of-band).
   admit   (ADR-0015) One-command admin admission decision. Verifies the admin
           seed (chmod-600 gated), builds a signed admission decision claim
           (decision: "admit"), and POSTs it to /admission-requests/:id/admit

--- a/src/cli/cortex/commands/operator-provisioning.ts
+++ b/src/cli/cortex/commands/operator-provisioning.ts
@@ -1,0 +1,237 @@
+/**
+ * G1d (cortex#1139, ADR-0013 Model B) — the arc-shell driver for the
+ * sovereign account-topology primitives `arc nats init-operator` and
+ * `arc nats add-account` (arc#252 / arc#253).
+ *
+ * `cortex network provision <stack>` composes these alongside the existing
+ * `arc nats add-federation-export` (network-federation-wiring.ts) to stand up a
+ * principal's OWN NSC account tree — their nsc operator + a dedicated
+ * federation account + a per-stack agents account — so the stack can federate
+ * (ADR-0013: every principal runs their own nsc operator, hub mints nothing).
+ *
+ * cortex NEVER calls nsc directly — arc owns the nsc boundary; cortex shells to
+ * `arc nats …` and surfaces the result. Same arc-shell pattern as `creds.ts`
+ * (`callArcNats` / `ArcRunner`) and `network-federation-wiring.ts`:
+ *   cortex shells to arc → arc calls nsc → nsc mutates the local nsc store.
+ *
+ * ## Schema
+ *
+ * Both verbs respond with `arc.nats.operator.v1` (a namespace distinct from
+ * `arc.nats.v1` = add-bot and `arc.nats.federation.v1` = add-federation-export,
+ * so existing consumers are unaffected). We guard on the schema string so a
+ * contract regression fails loudly rather than silently misinterpreting the
+ * envelope.
+ *
+ * ## Mutation seam
+ *
+ * `init-operator` and `add-account` have NO dry-run mode in arc (they mint
+ * idempotently when absent, no-op when present). So this driver is only invoked
+ * on the `--apply` path; the provision orchestrator computes its dry-run PLAN
+ * from config + filesystem state and never shells here when not applying.
+ */
+
+// =============================================================================
+// Arc subprocess driver (injectable for tests — same pattern as creds.ts)
+// =============================================================================
+
+/** Result of one arc subprocess invocation. */
+export interface ArcOperatorRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Pluggable subprocess driver. Tests inject a fake; production uses Bun.spawn. */
+export type ArcOperatorRunner = (argv: readonly string[]) => Promise<ArcOperatorRunResult>;
+
+async function defaultArcOperatorRunner(argv: readonly string[]): Promise<ArcOperatorRunResult> {
+  const proc = Bun.spawn(["arc", ...argv], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+// =============================================================================
+// arc.nats.operator.v1 envelope types (mirror arc src/lib/json-response.ts)
+// =============================================================================
+
+const ARC_NATS_OPERATOR_SCHEMA = "arc.nats.operator.v1";
+
+interface ArcInitOperatorOk {
+  schema: typeof ARC_NATS_OPERATOR_SCHEMA;
+  ok: true;
+  operator: string;
+  pubKey: string;
+  created: boolean;
+  alreadyExisted: boolean;
+  seedPath: string | null;
+}
+
+interface ArcAddAccountOk {
+  schema: typeof ARC_NATS_OPERATOR_SCHEMA;
+  ok: true;
+  account: string;
+  pubKey: string;
+  created: boolean;
+  alreadyExisted: boolean;
+}
+
+interface ArcOperatorError {
+  schema: typeof ARC_NATS_OPERATOR_SCHEMA;
+  ok: false;
+  error: { code: string; message: string };
+}
+
+// =============================================================================
+// Port surface the provision orchestrator depends on
+// =============================================================================
+
+/** init-operator result, surfaced log-safe (no seed material). */
+export type InitOperatorResult =
+  | { ok: true; operator: string; pubKey: string; created: boolean; alreadyExisted: boolean; seedPath: string | null }
+  | { ok: false; reason: string };
+
+/** add-account result. `pubKey` is the account-class (`A…`) NKey. */
+export type AddAccountResult =
+  | { ok: true; account: string; pubKey: string; created: boolean; alreadyExisted: boolean }
+  | { ok: false; reason: string };
+
+/**
+ * The seam the provision orchestrator mints the NSC account tree through. Two
+ * methods, one per arc verb. Live impl shells to arc; tests inject a fake that
+ * records the calls in order. NEVER throws (arc failures → `{ ok: false }`).
+ */
+export interface OperatorProvisioningPort {
+  /** `arc nats init-operator --name <name> [--force] --json` — mint the
+   *  principal's nsc operator if absent (idempotent; `force` recreates). */
+  initOperator(opts: { name: string; force: boolean }): Promise<InitOperatorResult>;
+  /** `arc nats add-account <name> --json` — mint an account under the current
+   *  operator if absent (idempotent). Called once per account (federation +
+   *  per-stack agents). */
+  addAccount(opts: { name: string }): Promise<AddAccountResult>;
+}
+
+// =============================================================================
+// buildOperatorProvisioningAdapter
+// =============================================================================
+
+const MIN_ARC_NOTE =
+  "Ensure arc (>= the arc#253 release shipping `nats init-operator` / " +
+  "`nats add-account`) is installed and on PATH.";
+
+/** Parse the first non-blank JSON line from arc stdout, schema-guarded. */
+function parseOperatorEnvelope(
+  result: ArcOperatorRunResult,
+):
+  | { ok: true; envelope: ArcInitOperatorOk | ArcAddAccountOk | ArcOperatorError }
+  | { ok: false; reason: string } {
+  const line = result.stdout.split("\n").find((l) => l.trim().length > 0) ?? "";
+  if (line.length === 0) {
+    return {
+      ok: false,
+      reason:
+        `arc returned no valid '${ARC_NATS_OPERATOR_SCHEMA}' envelope. ${MIN_ARC_NOTE} ` +
+        `arc stderr: ${result.stderr.trim() || "(empty)"}`,
+    };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return {
+      ok: false,
+      reason:
+        `arc returned no valid '${ARC_NATS_OPERATOR_SCHEMA}' envelope (JSON parse failed). ` +
+        `arc output: ${line.slice(0, 200)}`,
+    };
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as { schema?: unknown }).schema !== ARC_NATS_OPERATOR_SCHEMA
+  ) {
+    return {
+      ok: false,
+      reason:
+        `arc returned no valid '${ARC_NATS_OPERATOR_SCHEMA}' envelope (schema mismatch). ` +
+        `Got: ${JSON.stringify((parsed as { schema?: unknown }).schema ?? "(none)")}. ` +
+        `arc dependency unmet (cortex#1139 / G1d) — ${MIN_ARC_NOTE}`,
+    };
+  }
+  return { ok: true, envelope: parsed as ArcInitOperatorOk | ArcAddAccountOk | ArcOperatorError };
+}
+
+/** Extract `{ code, message }` from an `ok:false` envelope, shape-checked. */
+function arcErrorReason(envelope: ArcOperatorError, verb: string): string {
+  const raw = (envelope as { error?: unknown }).error;
+  const code =
+    raw !== null && typeof raw === "object" && typeof (raw as { code?: unknown }).code === "string"
+      ? (raw as { code: string }).code
+      : "(unknown code)";
+  const message =
+    raw !== null && typeof raw === "object" && typeof (raw as { message?: unknown }).message === "string"
+      ? (raw as { message: string }).message
+      : "(no message)";
+  return `arc nats ${verb} failed: ${code}: ${message}`;
+}
+
+/**
+ * Build the live {@link OperatorProvisioningPort} backed by `arc nats
+ * init-operator` + `arc nats add-account`.
+ *
+ * @param runner - Injectable subprocess driver (default: `Bun.spawn(["arc", …])`).
+ */
+export function buildOperatorProvisioningAdapter(
+  runner: ArcOperatorRunner = defaultArcOperatorRunner,
+): OperatorProvisioningPort {
+  async function run(argv: readonly string[], verb: string): Promise<
+    { ok: true; envelope: ArcInitOperatorOk | ArcAddAccountOk } | { ok: false; reason: string }
+  > {
+    let result: ArcOperatorRunResult;
+    try {
+      result = await runner(argv);
+    } catch (err) {
+      return {
+        ok: false,
+        reason:
+          `failed to invoke 'arc nats ${verb}' — ${err instanceof Error ? err.message : String(err)}. ${MIN_ARC_NOTE}`,
+      };
+    }
+    const parsed = parseOperatorEnvelope(result);
+    if (!parsed.ok) return parsed;
+    if (!parsed.envelope.ok) return { ok: false, reason: arcErrorReason(parsed.envelope, verb) };
+    return { ok: true, envelope: parsed.envelope };
+  }
+
+  return {
+    async initOperator({ name, force }) {
+      const argv = ["nats", "init-operator", "--name", name, ...(force ? ["--force"] : []), "--json"];
+      const res = await run(argv, "init-operator");
+      if (!res.ok) return res;
+      const env = res.envelope as ArcInitOperatorOk;
+      return {
+        ok: true,
+        operator: env.operator,
+        pubKey: env.pubKey,
+        created: env.created,
+        alreadyExisted: env.alreadyExisted,
+        seedPath: env.seedPath,
+      };
+    },
+    async addAccount({ name }) {
+      const res = await run(["nats", "add-account", name, "--json"], "add-account");
+      if (!res.ok) return res;
+      const env = res.envelope as ArcAddAccountOk;
+      return {
+        ok: true,
+        account: env.account,
+        pubKey: env.pubKey,
+        created: env.created,
+        alreadyExisted: env.alreadyExisted,
+      };
+    },
+  };
+}

--- a/src/common/types/__tests__/stack.test.ts
+++ b/src/common/types/__tests__/stack.test.ts
@@ -251,6 +251,47 @@ describe("StackConfigSchema.nats_infra — platform service descriptor", () => {
     ).toThrow();
   });
 
+  // G1d (cortex#1139) — the dedicated agents account (split from the leaf-bound
+  // federation account) that `cortex network provision` mints per stack.
+  test("G1d — accepts a distinct agents_account (A-prefixed NKey)", () => {
+    const VALID_AGENTS = "A" + "C".repeat(55);
+    const parsed = StackConfigSchema.parse({
+      id: "andreas/research",
+      nats_infra: {
+        account: VALID_ACCOUNT,
+        agents_account: VALID_AGENTS,
+      },
+    });
+    expect(parsed.nats_infra?.account).toBe(VALID_ACCOUNT);
+    expect(parsed.nats_infra?.agents_account).toBe(VALID_AGENTS);
+  });
+
+  test("G1d — agents_account stays optional (omittable)", () => {
+    const parsed = StackConfigSchema.parse({
+      id: "andreas/research",
+      nats_infra: { account: VALID_ACCOUNT },
+    });
+    expect(parsed.nats_infra?.agents_account).toBeUndefined();
+  });
+
+  test("G1d — rejects a U-prefixed (user) key as agents_account", () => {
+    expect(() =>
+      StackConfigSchema.parse({
+        id: "andreas/research",
+        nats_infra: { agents_account: "U" + "B".repeat(55) },
+      }),
+    ).toThrow();
+  });
+
+  test("G1d — rejects a malformed agents_account", () => {
+    expect(() =>
+      StackConfigSchema.parse({
+        id: "andreas/research",
+        nats_infra: { agents_account: "A-too-short" },
+      }),
+    ).toThrow();
+  });
+
   test("rejects an unknown nats_infra key (strict schema)", () => {
     expect(() =>
       StackConfigSchema.parse({

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -104,6 +104,26 @@ export const StackNatsInfraSchema = z.object({
     "stack.nats_infra.account must be an account-class NKey (A-prefixed, 56 chars total)",
   ).optional(),
   /**
+   * G1d (cortex#1139, ADR-0012/0013) — the dedicated AGENTS account (`A…`
+   * nkey), DISTINCT from the leaf-bound federation {@link
+   * StackNatsInfraSchema.shape.account} above. `cortex network provision` mints
+   * ONE agents account per stack (ADR-0012 isolation — never a shared one); the
+   * dispatch-listener subscribes `federated.>` inside it, and the local
+   * `federated.>` export/import is wired federation-account → agents-account.
+   *
+   * Splitting the two accounts is what turns the federation-wiring step from a
+   * same-account no-op (the pre-G1d fallback in `network-federation-wiring.ts`,
+   * which logs a WARN and wires `--from-account == --to-account`) into a real
+   * CROSS-account export/import. Optional: when absent the wiring still falls
+   * back to the same-account no-op, so a stack provisioned before this field
+   * existed keeps working. Same A-prefixed account-class NKey grammar as
+   * `account`; strict prefix discrimination happens in the wiring renderer.
+   */
+  agents_account: z.string().regex(
+    /^A[A-Z0-9]{55}$/,
+    "stack.nats_infra.agents_account must be an account-class NKey (A-prefixed, 56 chars total)",
+  ).optional(),
+  /**
    * Path to the leaf `.creds` file for the network connection. Maps to the
    * `--creds` flag. OPTIONAL even within the block: when omitted, the join
    * derives the convention default `~/.config/nats/<network>.creds`


### PR DESCRIPTION
## What

Implements **PR3 / #1139** — `cortex network provision <stack>`, the one-command sovereign-operator setup (ADR-0013 Model B), plus the G1d `agents_account` config concept.

`cortex network provision <stack>` (sibling of `create`/`join`/`status`/`leave`) stands up a principal's OWN nsc account tree so a stack can federate:

1. ensure the NSC operator (`arc nats init-operator`) — per principal
2. ensure the federation account (`arc nats add-account`) — per stack, leaf-bound
3. ensure the **per-stack** agents account (`arc nats add-account`) — ADR-0012 isolation
4. ensure the stack signing seed (`generateStackIdentity`, chmod 600, no-clobber)
5. wire the local `federated.>` export/import (`arc nats add-federation-export`, federation-acct → agents-acct)
6. write `stack.nats_infra` back (`account`, `agents_account`, `creds_path`) + `nkey_seed_path`

cortex orchestrates; **arc executes** — cortex shells to arc for every nsc mutation and runs zero `nsc` itself (ADR-0013 invariant).

## Command surface

```
cortex network provision <stack> [--config <p>] [--principal <id>] [--seed-path <p>]
                                 [--creds <p>] [--force] [--apply] [--dry-run] [--json]
```

- **Dry-run by default** (prints the ensure-plan, mutates nothing); `--apply` mutates; `--apply`+`--dry-run` mutually exclusive (exit 2).
- **`--force`** = deliberate rotation (re-mints operator/accounts/signing seed).
- **Ensure-shaped + idempotent:** a converged re-run shells zero mint calls (state read from config + filesystem); seeds are never clobbered without `--force`.
- **Fail-fast:** any arc failure aborts **before** the config write-back, so no half-provisioned config block is left behind.
- **Plug-and-play:** `cortex network join` **auto-runs provision** when a config-described stack (principal.id + stack.id present) hasn't minted its account tree (`stack.nats_infra.account` absent). The legacy fully-flagged / empty-config join path is deliberately untouched.

Also: `agents_account` added to `StackNatsInfraSchema` — the field that splits the dedicated federation account from the agents account, turning `network-federation-wiring.ts`'s same-account no-op into a real cross-account export/import.

## Design open-question defaults (taken from the design's own recommendations)

- **Signing seed:** co-generate (option a), not HKDF-derive. (Flag (b) "one root secret" as a possible follow-up.)
- **register-pubkey:** left to `join` / the admission gate (provision stays local-only + offline).
- **Operator-mode bus conversion + restart:** **left to `join`** (this verb is render-/mutate-only on the account tree + config; it does not touch the bus, so it's non-disruptive). I scoped the operator-mode `.conf` render entirely to `join`'s existing O-3 path rather than rendering it here — flagging this as the one place I diverged slightly from the design's step 7 (which rendered the `.conf` here). Happy to fold the render in if preferred.
- **Creds (`arc add-bot`):** provision records the conventional `creds_path` but does **not** mint the bot user — creds minting stays with `cortex creds issue` / `join`. Provision sets up account *topology*; the user under the account is a separate concern. (The task's arc-verb list is exactly init-operator / add-account×2 / add-federation-export, which this matches.)

## What's mocked vs real

- **Real:** the arc contract is modeled exactly against arc#253 (`arc.nats.operator.v1`: `{operator,pubKey,created,alreadyExisted,seedPath}` / `{account,pubKey,created,alreadyExisted}`). Live adapters shell to arc, write the signing seed via `generateStackIdentity`, and persist `stack.nats_infra` with comment-preserving `parseDocument`+`setIn`.
- **Mocked in tests:** all arc/nsc/fs effects are behind injectable ports — `ArcOperatorRunner` (operator-provisioning), the `ProvisionPorts` bundle (lib), and a `ProvisionPortsFactory` threaded through `dispatchNetwork` (CLI). No real nsc/arc/disk in any unit test.

## Runtime dependency

**arc#253** (`arc nats init-operator` / `add-account`, schema `arc.nats.operator.v1`) — merged on arc `origin/main`; installed arc is 0.30.5. The driver fails loudly with an "arc dependency unmet (cortex#1139 / G1d)" message on a schema mismatch.

## Gate status

- `bunx tsc --noEmit` → **0 errors**
- `bash scripts/check-carveouts.sh` → **PASS** (the three new NSC-subject files + their tests + the design doc are path-allowlisted as Class NSC, mirroring `connection.ts` / `trust-resolver.ts` / `design-g1-account-topology.md` / ADR-0013; the few `operator` lines in `network.ts` are qualified via the `nsc` / `operator-mode` exemptions)
- `bun test src/cli/cortex/commands/ src/common/config/` → **1167 pass / 0 fail**

## Tests (TDD)

- `operator-provisioning.test.ts` — arc init-operator/add-account argv + envelope parsing, idempotent `alreadyExisted`, error + schema-mismatch + spawn-failure surfaces.
- `network-provision-lib.test.ts` — per-stack agents naming, plan-builder (empty / fully-provisioned / partial / `--force`), dry-run records zero calls, apply call-order, idempotent re-run skips mints, no-clobber, cross-account wire, fail-fast (no config write on mid-pipeline failure).
- `network-provision-cli.test.ts` — dry-run/apply/`--json`/usage errors + `join` auto-provision (fires when unprovisioned, skips when provisioned).
- `stack.test.ts` — `agents_account` accept / reject U-key / reject malformed / optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)