### PR TITLE
feat(cli): C-1224 — Model-B `network join` secret-authenticated leaf (own-account bind)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync, chmodSync } from "fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync, chmodSync, statSync } from "fs";
 import { tmpdir, homedir } from "os";
 import { join } from "path";
 
@@ -1024,6 +1024,34 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
     expect(existsSync(join(dir, "leafnodes-metafactory.conf"))).toBe(false);
     expect(existsSync(conf)).toBe(true); // base config NEVER deleted
     expect(readFileSync(conf, "utf-8")).toBe(original);
+  });
+
+  test("C-1224: the written leaf include file is mode 0600 even under a permissive umask (secret-at-rest)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    // Force a permissive umask so a bare `writeFileSync(..., mode: 0o600)` would
+    // be masked to 0640/0644 without the explicit chmod-back. The write must
+    // still land 0600 (the secret lives inside the file for Model B).
+    const prevUmask = process.umask(0o022);
+    try {
+      ports.leafFile.write({
+        descriptor: brandVerified(descriptorForLeaf("metafactory")),
+        binding: {
+          credentials: "/Users/andreas/.config/nats/andreas.creds",
+          account: "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+        },
+      });
+    } finally {
+      process.umask(prevUmask);
+    }
+
+    const leafPath = join(dir, "leafnodes-metafactory.conf");
+    expect(existsSync(leafPath)).toBe(true);
+    // Mask off the file-type bits; only the permission bits must equal 0600.
+    expect(statSync(leafPath).mode & 0o777).toBe(0o600);
   });
 
   test("restore rewrites a pre-existing include file back to its prior bytes + keeps a pre-existing directive", () => {

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -756,3 +756,80 @@ describe("deriveJoinInputs — operator-mode source precedence", () => {
     expect(res.inputs?.credsPath).toBe("~/.config/nats/metafactory-community.creds");
   });
 });
+
+// =============================================================================
+// C-1224 (ADR-0013 Model B) — leaf shared secret resolution.
+// =============================================================================
+
+describe("C-1224 — leaf-secret (secret-auth pipe) derivation", () => {
+  test("leaf_secret from config → leafSecret + leafUser defaults to principal", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/meta-factory",
+        nkey_seed_path: "~/.config/nats/cortex.nk",
+        nats_infra: {
+          config_path: "~/.config/nats/local.conf",
+          plist_path: "~/Library/LaunchAgents/nats.plist",
+          account: "A" + "B".repeat(55),
+          leaf_secret: "s3cr3t-from-config",
+        },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.leafSecret).toBe("s3cr3t-from-config");
+    // No leaf_user in config → defaults to the principal id.
+    expect(res.inputs?.leafUser).toBe("andreas");
+  });
+
+  test("leaf_user from config overrides the principal-id default", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/meta-factory",
+        nkey_seed_path: "~/.config/nats/cortex.nk",
+        nats_infra: {
+          config_path: "~/.config/nats/local.conf",
+          plist_path: "~/Library/LaunchAgents/nats.plist",
+          leaf_secret: "s3cr3t",
+          leaf_user: "andreas-leaf",
+        },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
+    expect(res.inputs?.leafUser).toBe("andreas-leaf");
+  });
+
+  test("--leaf-secret / --leaf-user flags win over config", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/meta-factory",
+        nkey_seed_path: "~/.config/nats/cortex.nk",
+        nats_infra: {
+          config_path: "~/.config/nats/local.conf",
+          plist_path: "~/Library/LaunchAgents/nats.plist",
+          leaf_secret: "config-secret",
+          leaf_user: "config-user",
+        },
+      },
+    });
+    const res = deriveJoinInputs(
+      "metafactory",
+      { leafSecret: "flag-secret", leafUser: "flag-user" },
+      "/cfg",
+      reader(cfg),
+      "darwin",
+    );
+    expect(res.inputs?.leafSecret).toBe("flag-secret");
+    expect(res.inputs?.leafUser).toBe("flag-user");
+  });
+
+  test("no leaf_secret anywhere → leafSecret + leafUser both absent (creds path)", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(FULL), "darwin");
+    expect(res.inputs?.leafSecret).toBeUndefined();
+    // leafUser is meaningless without a secret — never resolved on its own.
+    expect(res.inputs?.leafUser).toBeUndefined();
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -785,7 +785,7 @@ describe("join", () => {
       expect(res.reason).toContain("creds file not found");
       expect(res.reason).toContain("cortex#821");
       // The creds path was checked...
-      expect(rec.credsChecks).toEqual([LOCAL.credentials]);
+      expect(rec.credsChecks).toEqual([LOCAL.credentials ?? ""]);
       // ...and NOTHING was written/restarted (the refusal is before any mutation).
       expect(rec.writes.length).toBe(0);
       expect(rec.includesEnsured).toEqual([]);
@@ -801,7 +801,7 @@ describe("join", () => {
       const { ports, rec } = makeFakes({ busType: "operator-mode" });
       const res = await joinNetwork("metafactory", LOCAL, ports);
       expect(res.ok).toBe(true);
-      expect(rec.credsChecks).toEqual([LOCAL.credentials]);
+      expect(rec.credsChecks).toEqual([LOCAL.credentials ?? ""]);
     });
   });
 
@@ -1673,5 +1673,87 @@ describe("status", () => {
     });
     const res = await networkStatus(ports);
     expect(res.networks[0]!.link.state).toBe("unknown");
+  });
+});
+
+// =============================================================================
+// C-1224 (ADR-0013 Model B) — secret-authenticated leaf join.
+//
+// A Model-B join carries a leaf SHARED SECRET (not a `.creds` file): the leaf
+// authenticates the transport pipe via URL userinfo and binds the principal's
+// OWN local account. These assert the orchestration delta: the secret counts as
+// an auth method (bind-mode resolves), the `.creds` pre-flight is SKIPPED (no
+// creds file exists), and the write binding carries the secret + own account,
+// never a credentials path.
+// =============================================================================
+
+const LOCAL_SECRET: JoiningStack = {
+  principalId: "andreas",
+  stackSlug: "meta-factory",
+  // Model B — NO creds file; the credential is the leaf secret (URL userinfo).
+  leafSecret: "s3cr3t-leaf-pipe",
+  leafUser: "andreas",
+  account: "A" + "B".repeat(55),
+};
+
+describe("C-1224 — secret-auth leaf join (Model B)", () => {
+  test("operator-mode bus + secret binds own account; SKIPS the creds pre-flight", async () => {
+    const { ports, rec } = makeFakes({ busType: "operator-mode" });
+    const res = await joinNetwork("metafactory", LOCAL_SECRET, ports);
+
+    expect(res.ok).toBe(true);
+    // The `.creds` pre-flight is skipped — a secret-auth leaf has no creds file.
+    expect(rec.credsChecks).toEqual([]);
+    // Bind-mode WAS resolved (the secret satisfied the has-auth gate → hasCreds true).
+    expect(rec.bindModeChecks).toEqual([
+      { account: LOCAL_SECRET.account, hasCreds: true },
+    ]);
+    // The write binding carries the secret + the OWN account, and NO credentials.
+    expect(rec.writes.length).toBe(1);
+    const binding = rec.writes[0]!.binding;
+    expect(binding.leafSecret).toBe("s3cr3t-leaf-pipe");
+    expect(binding.leafUser).toBe("andreas");
+    expect(binding.account).toBe(LOCAL_SECRET.account);
+    expect(binding.credentials).toBeUndefined();
+  });
+
+  test("$G/default bus + secret-only (no account) renders no-account secret leaf", async () => {
+    const noAccount: JoiningStack = {
+      principalId: "andreas",
+      stackSlug: "meta-factory",
+      leafSecret: "s3cr3t",
+      leafUser: "andreas",
+    };
+    const { ports, rec } = makeFakes({ busType: "default-g" });
+    const res = await joinNetwork("metafactory", noAccount, ports);
+
+    expect(res.ok).toBe(true);
+    expect(rec.credsChecks).toEqual([]);
+    const binding = rec.writes[0]!.binding;
+    expect(binding.leafSecret).toBe("s3cr3t");
+    expect(binding.account).toBeUndefined();
+    expect(binding.credentials).toBeUndefined();
+  });
+
+  test("creds-path join is UNCHANGED — still pre-flights the creds file (no regression)", async () => {
+    const { ports, rec } = makeFakes({ busType: "operator-mode" });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(true);
+    // The legacy creds path STILL runs the #821 creds pre-flight.
+    expect(rec.credsChecks).toEqual([LOCAL.credentials ?? ""]);
+    const binding = rec.writes[0]!.binding;
+    expect(binding.credentials).toBe(LOCAL.credentials);
+    expect(binding.leafSecret).toBeUndefined();
+  });
+
+  test("operator-mode auto-convert path is untouched by the secret delta (Model-B survivor)", async () => {
+    // An anonymous bus + a leaf package still auto-converts (O-3) — the secret
+    // delta did not disturb the operator-mode-package flow. Here we exercise the
+    // creds-path join on an anonymous bus that converts, confirming no regression.
+    const withPkg: JoiningStack = { ...LOCAL, operatorModePackage: LOCAL_PACKAGE };
+    const { ports, rec } = makeFakes({ busType: "anonymous" });
+    const res = await joinNetwork("metafactory", withPkg, ports);
+    expect(res.ok).toBe(true);
+    expect(rec.conversions.length).toBe(1);
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -1756,4 +1756,41 @@ describe("C-1224 — secret-auth leaf join (Model B)", () => {
     expect(res.ok).toBe(true);
     expect(rec.conversions.length).toBe(1);
   });
+
+  test("secret-only leaf on an auto-converted anonymous bus binds the account (NOT a creds error)", async () => {
+    // Regression guard for the post-auto-convert re-resolve (network-lib:310):
+    // a secret-only Model-B leaf (hasCreds === false, hasSecret === true) on an
+    // anonymous bus must auto-convert (O-3) and then RE-RESOLVE on `hasLeafAuth`
+    // — not `hasCreds`. If it re-resolved on `hasCreds` the secret would be
+    // invisible and the join would abort with a misleading "no leaf creds
+    // available" despite a valid secret.
+    const secretWithPkg: JoiningStack = {
+      principalId: "andreas",
+      stackSlug: "community",
+      // Model B — NO creds file; the leaf secret is the only auth method.
+      leafSecret: "s3cr3t-leaf-pipe",
+      leafUser: "andreas",
+      account: LOCAL_PACKAGE.account,
+      operatorModePackage: LOCAL_PACKAGE,
+    };
+    const { ports, rec } = makeFakes({ busType: "anonymous" });
+    const res = await joinNetwork("metafactory-community", secretWithPkg, ports);
+
+    expect(res.ok).toBe(true);
+    // The bus auto-converted exactly once...
+    expect(rec.conversions).toEqual([LOCAL_PACKAGE]);
+    // ...and BOTH bind-mode resolves saw the secret as an auth method
+    // (hasCreds === true here is the modelled `hasLeafAuth`). The pre-fix bug
+    // passed the literal `hasCreds` (false) on the second resolve.
+    expect(rec.bindModeChecks).toEqual([
+      { account: LOCAL_PACKAGE.account, hasCreds: true },
+      { account: LOCAL_PACKAGE.account, hasCreds: true },
+    ]);
+    // The re-resolve bound the OWN account + carried the secret, no creds path.
+    expect(rec.writes.length).toBe(1);
+    const binding = rec.writes[0]!.binding;
+    expect(binding.account).toBe(LOCAL_PACKAGE.account);
+    expect(binding.leafSecret).toBe("s3cr3t-leaf-pipe");
+    expect(binding.credentials).toBeUndefined();
+  });
 });

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -21,6 +21,7 @@
  */
 
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -458,7 +459,15 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
       const content = renderLeafIncludeFile(inputs.descriptor, inputs.binding);
       if (!mutate) return; // dry-run: render to validate, but do not write.
       mkdirSync(dir, { recursive: true });
-      writeFileSync(join(dir, leafIncludeFileName(inputs.descriptor.network_id)), content, "utf-8");
+      // C-1224 (ADR-0013 Model B): for a secret-auth leaf the secret bytes live
+      // INSIDE this file (the `user:secret@host` userinfo of the rendered `url`),
+      // so it is a secret-at-rest. Write it 0600 AND re-chmod explicitly — the
+      // create `mode` is masked by the process umask, so a permissive umask
+      // (e.g. 022 → 0644) would otherwise leave it world-readable. 0600 is the
+      // correct floor even for a creds-path-only leaf (defence in depth).
+      const leafPath = join(dir, leafIncludeFileName(inputs.descriptor.network_id));
+      writeFileSync(leafPath, content, { mode: 0o600 });
+      chmodSync(leafPath, 0o600);
     },
     remove(networkId) {
       if (!mutate) return;

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -86,6 +86,21 @@ export interface DerivedJoinInputs {
   account?: string;
   credsPath: string;
   /**
+   * C-1224 (ADR-0013 Model B) — the **leaf shared secret** for a secret-
+   * authenticated transport-pipe leaf (`--leaf-secret` /
+   * `stack.nats_infra.leaf_secret`). Present ⇒ the join renders a secret-auth
+   * leaf (URL userinfo) binding the principal's OWN local account, instead of a
+   * `.creds`-file leaf. Absent ⇒ the legacy creds path.
+   */
+  leafSecret?: string;
+  /**
+   * C-1224 — the userinfo USER paired with {@link DerivedJoinInputs.leafSecret}
+   * (`--leaf-user` / `stack.nats_infra.leaf_user`). Resolved ONLY when a leaf
+   * secret is present; defaults to the principal id when neither flag nor config
+   * supplies one.
+   */
+  leafUser?: string;
+  /**
    * O-3 (cortex#1053) — the operator-mode leaf package, assembled from
    * `--operator-jwt` / `--account-jwt` / `--account` (+ optional
    * `--system-account` / `--system-account-jwt`) flags or the matching
@@ -142,6 +157,10 @@ export interface JoinOverrides {
   unitPath?: string;
   account?: string;
   credsPath?: string;
+  /** C-1224 (ADR-0013 Model B) — `--leaf-secret` (the secret-auth pipe secret). */
+  leafSecret?: string;
+  /** C-1224 — `--leaf-user` (userinfo user; defaults to the principal id). */
+  leafUser?: string;
   /** O-3 (#1053) — `--operator-jwt`. */
   operatorJwt?: string;
   /** O-3 (#1053) — `--account-jwt`. */
@@ -400,6 +419,20 @@ export function deriveJoinInputs(
   const credsPath =
     overrides.credsPath ?? natsInfra?.creds_path ?? defaultCredsPath(networkId);
 
+  // C-1224 (ADR-0013 Model B) — the leaf shared secret (secret-auth pipe). Flag
+  // wins, else `stack.nats_infra.leaf_secret`. When present, the join renders a
+  // secret-auth leaf binding the principal's OWN local `account` instead of a
+  // `.creds`-file leaf. The userinfo USER defaults to the principal id (the hub's
+  // `authorization { user, password }` user) unless flagged/configured. The user
+  // is resolved ONLY alongside a secret — it is meaningless without one.
+  const leafSecretRaw = overrides.leafSecret ?? natsInfra?.leaf_secret;
+  const leafSecret =
+    leafSecretRaw === undefined || leafSecretRaw === "" ? undefined : leafSecretRaw;
+  const leafUser =
+    leafSecret === undefined
+      ? undefined
+      : (overrides.leafUser ?? natsInfra?.leaf_user ?? principal);
+
   // O-3 (cortex#1053) — assemble the operator-mode leaf package. Precedence per
   // field: explicit flag > config (`stack.nats_infra.{operator_jwt,account_jwt,…}`).
   // The package materialises ONLY when its minimum (operator JWT + account + account
@@ -450,6 +483,8 @@ export function deriveJoinInputs(
       platform: descriptor.platform,
       ...(account !== undefined && { account }),
       credsPath,
+      ...(leafSecret !== undefined && { leafSecret }),
+      ...(leafUser !== undefined && { leafUser }),
       ...(operatorModePackage !== undefined && { operatorModePackage }),
       announceCapabilities,
     },

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -306,8 +306,12 @@ export async function joinNetwork(
         ? `converted the anonymous bus to operator-mode (rendered the operator/account/resolver blocks — O-3, #1053)`
         : `bus already operator-mode under this operator — no conversion needed (O-3, #1053)`,
     );
-    // Re-resolve against the now-operator-mode bus.
-    bindMode = ports.leafFile.resolveBindMode(stack.account, hasCreds);
+    // Re-resolve against the now-operator-mode bus. Use `hasLeafAuth` (not
+    // `hasCreds`) so a secret-only Model-B leaf (C-1224) that triggered the
+    // auto-convert still passes the "has an auth method" gate — otherwise it
+    // would abort with a misleading "no leaf creds available" despite a valid
+    // secret. Mirrors the first resolve at line 275.
+    bindMode = ports.leafFile.resolveBindMode(stack.account, hasLeafAuth);
   }
 
   if (bindMode.mode === "refuse") {

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -63,8 +63,28 @@ export interface JoiningStack {
   principalId: string;
   /** Local stack slug — the `{stack}` segment (the part after the `/`). */
   stackSlug: string;
-  /** Path to the leaf `.creds` file (absolute). */
-  credentials: string;
+  /**
+   * Path to the leaf `.creds` file (absolute). OPTIONAL since C-1224: a
+   * secret-authenticated leaf ({@link JoiningStack.leafSecret}) carries no creds
+   * file — its credential is the URL userinfo.
+   */
+  credentials?: string;
+  /**
+   * C-1224 (ADR-0013 Model B, §Decision-1) — the **leaf shared secret** for a
+   * secret-authenticated transport-pipe leaf. Present ⇒ `joinNetwork` renders a
+   * leaf that authenticates via URL userinfo (`tls://user:secret@host`) and binds
+   * the principal's OWN local {@link JoiningStack.account}, instead of a
+   * `.creds`-file leaf. The hub authenticates the remote with the matching
+   * `authorization { user, password: <leaf-secret> }`; each side binds locally,
+   * no cross-operator JWT trust. Absent ⇒ the legacy `.creds` path.
+   */
+  leafSecret?: string;
+  /**
+   * C-1224 — the userinfo USER paired with {@link JoiningStack.leafSecret}
+   * (matches the hub's `authorization { user, … }`). The CLI defaults it to the
+   * principal id; required whenever `leafSecret` is set.
+   */
+  leafUser?: string;
   /**
    * Local nkey-U account the leaf binds to (DD-8 already in nkey-U) — OPTIONAL
    * (#799). Present for an operator-mode bus; OMITTED for a `$G`/default bus
@@ -241,7 +261,18 @@ export async function joinNetwork(
   // This is a READ (no mutation), so dry-run surfaces the same decision.
   const hasCreds =
     typeof stack.credentials === "string" && stack.credentials.trim().length > 0;
-  let bindMode = ports.leafFile.resolveBindMode(stack.account, hasCreds);
+  // C-1224 (ADR-0013 Model B) — a leaf SECRET is an auth method on par with a
+  // `.creds` file: it authenticates the secret-auth transport pipe via URL
+  // userinfo. So it satisfies `resolveBindMode`'s "has an auth method" gate (the
+  // function only uses this to refuse a bus with NO way to authenticate, and to
+  // allow the creds-only/$G no-account render). The account-bind safety (#794:
+  // an `account:` line must resolve against the local operator-mode tree) is
+  // ORTHOGONAL and still enforced — a secret-auth leaf on an operator-mode bus
+  // still binds (and #794-validates) the local `account`.
+  const hasSecret =
+    typeof stack.leafSecret === "string" && stack.leafSecret.trim().length > 0;
+  const hasLeafAuth = hasCreds || hasSecret;
+  let bindMode = ports.leafFile.resolveBindMode(stack.account, hasLeafAuth);
 
   // (b.5.1) O-3 (cortex#1053, spec §4-D2) — AUTO-CONVERT an anonymous bus.
   //
@@ -367,7 +398,12 @@ export async function joinNetwork(
   // incident's rendered remote pointed at a creds file that did not exist. A
   // READ (identical in live + dry-run); refuse here rather than render a leaf
   // that can never connect.
-  if (!ports.leafFile.credsExist(stack.credentials)) {
+  //
+  // C-1224 (ADR-0013 Model B) — SKIP this for a secret-auth leaf: it carries no
+  // `.creds` file (its credential is the URL userinfo secret), so there is
+  // nothing on disk to pre-flight here. The secret's presence was already
+  // confirmed by `hasSecret` above.
+  if (!hasSecret && !ports.leafFile.credsExist(stack.credentials ?? "")) {
     return {
       ok: false,
       steps,
@@ -389,10 +425,21 @@ export async function joinNetwork(
   try {
     ports.leafFile.write({
       descriptor: verified,
-      binding: {
-        credentials: stack.credentials,
-        ...(leafAccount !== undefined && { account: leafAccount }),
-      },
+      // C-1224 (ADR-0013 Model B) — render the SECRET-AUTH leaf when a leaf
+      // secret is present (URL userinfo, no creds file); else the legacy
+      // `.creds`-file leaf. Both still carry the local `account:` (`leafAccount`)
+      // when the bus is operator-mode (#799). Mutually exclusive: the renderer
+      // prefers the secret when both are somehow present.
+      binding: hasSecret
+        ? {
+            ...(stack.leafSecret !== undefined && { leafSecret: stack.leafSecret }),
+            ...(stack.leafUser !== undefined && { leafUser: stack.leafUser }),
+            ...(leafAccount !== undefined && { account: leafAccount }),
+          }
+        : {
+            ...(stack.credentials !== undefined && { credentials: stack.credentials }),
+            ...(leafAccount !== undefined && { account: leafAccount }),
+          },
     });
   } catch (err) {
     return {

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -195,6 +195,14 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--principal-seed": "value",
         "--creds": "value",
         "--account": "value",
+        // C-1224 (ADR-0013 Model B) — the secret-authenticated leaf pipe. When
+        // set, the join renders a leaf that authenticates to the hub via URL
+        // userinfo (`tls://<user>:<secret>@host`) and binds the principal's OWN
+        // local account, instead of a `.creds`-file leaf. Map to
+        // stack.nats_infra.{leaf_secret,leaf_user}; `--leaf-user` defaults to the
+        // principal id. The secret DISTRIBUTION is out-of-band (held PR5).
+        "--leaf-secret": "value",
+        "--leaf-user": "value",
         // O-3 (cortex#1053) — the operator-mode "leaf package" flags. When the
         // stack's bus is anonymous/hard-isolated (the #794 fail-fast input),
         // these let `cortex network join` AUTO-CONVERT it to operator-mode
@@ -556,6 +564,9 @@ async function runJoin(
         ...readOverride(flags, "--unit", "unitPath"),
         ...readOverride(flags, "--account", "account"),
         ...readOverride(flags, "--creds", "credsPath"),
+        // C-1224 (ADR-0013 Model B) — secret-auth leaf overrides.
+        ...readOverride(flags, "--leaf-secret", "leafSecret"),
+        ...readOverride(flags, "--leaf-user", "leafUser"),
         // O-3 (cortex#1053) — operator-mode leaf-package overrides.
         ...readOverride(flags, "--operator-jwt", "operatorJwt"),
         ...readOverride(flags, "--account-jwt", "accountJwt"),
@@ -613,6 +624,11 @@ async function runJoin(
     stackSlug: slugRes.slug,
     credentials: expandTilde(inputs.credsPath),
     account: inputs.account,
+    // C-1224 (ADR-0013 Model B) — pass the secret-auth leaf material (when
+    // resolved) so the join renders a secret-auth pipe binding the principal's
+    // OWN local account instead of a `.creds`-file leaf.
+    ...(inputs.leafSecret !== undefined && { leafSecret: inputs.leafSecret }),
+    ...(inputs.leafUser !== undefined && { leafUser: inputs.leafUser }),
     leafNode: optionalValueFlag(flags, "--leaf-node"),
     maxHop,
     // O-3 (cortex#1053) — pass the operator-mode leaf package (when resolved)

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -519,3 +519,116 @@ describe("#821 natsConfigMonitorUrl", () => {
     expect(natsConfigMonitorUrl(community)).toBe("http://127.0.0.1:8224");
   });
 });
+
+// =============================================================================
+// C-1224 (ADR-0013 Model B) — SECRET-AUTHENTICATED leaf rendering.
+//
+// The Model-B leaf is a secret-authenticated transport pipe: it binds the
+// principal's OWN local account (in their own operator-mode NSC store) + authenticates
+// to the hub with the shared leaf secret, presented via the dial URL's userinfo
+// (`tls://user:secret@host:port`) — the ONLY remote-side form nats-server v2.x
+// accepts (a literal `authorization {}`/`username`/`password` field inside a
+// remote is rejected at config load). These tests assert the rendered fragment;
+// the empirical nats-server `-t` validation lives in the PR description.
+// =============================================================================
+
+const SECRET_BINDING: StackLeafBinding = {
+  // Model B: NO creds file — the credential is the URL userinfo secret.
+  leafSecret: "s3cr3t-leaf-pipe",
+  leafUser: "andreas",
+  // The principal's OWN local federation account (provision writes this).
+  account: "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+};
+
+describe("renderLeafRemote — C-1224 Model B secret-auth", () => {
+  test("renders secretAuth + own account, NO credentials, clean url", () => {
+    const remote = renderLeafRemote(DESCRIPTOR, SECRET_BINDING);
+    // Clean dial URL — the secret is NOT spliced into the structured url
+    // (status/logging surfaces stay secret-free).
+    expect(remote.url).toBe("tls://nats.meta-factory.dev:7422");
+    expect(remote.url).not.toContain("s3cr3t");
+    expect(remote.credentials).toBeUndefined();
+    expect(remote.secretAuth).toEqual({
+      user: "andreas",
+      secret: "s3cr3t-leaf-pipe",
+    });
+    // Own-account binding (operator-mode local account).
+    expect(remote.account).toBe(
+      "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+    );
+    expect(remote.network_id).toBe("metafactory");
+  });
+
+  test("secret-auth on a $G bus (no account) renders secretAuth, no account line", () => {
+    const noAccount: StackLeafBinding = {
+      leafSecret: "s3cr3t",
+      leafUser: "andreas",
+    };
+    const remote = renderLeafRemote(DESCRIPTOR, noAccount);
+    expect(remote.secretAuth).toEqual({ user: "andreas", secret: "s3cr3t" });
+    expect(remote.account).toBeUndefined();
+    expect(remote.credentials).toBeUndefined();
+  });
+
+  test("a leaf secret without a user is a hard error (userinfo needs the user)", () => {
+    const noUser: StackLeafBinding = { leafSecret: "s3cr3t" };
+    expect(() => renderLeafRemote(DESCRIPTOR, noUser)).toThrow(/leaf user/);
+  });
+
+  test("the secret wins when BOTH a secret and a creds path are present", () => {
+    const both: StackLeafBinding = {
+      ...SECRET_BINDING,
+      credentials: "/Users/andreas/.config/nats/andreas.creds",
+    };
+    const remote = renderLeafRemote(DESCRIPTOR, both);
+    expect(remote.secretAuth).toBeDefined();
+    expect(remote.credentials).toBeUndefined();
+  });
+
+  test("an invalid account nkey on the secret path still throws", () => {
+    const badAccount: StackLeafBinding = {
+      leafSecret: "s3cr3t",
+      leafUser: "andreas",
+      account: "BADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+    };
+    expect(() => renderLeafRemote(DESCRIPTOR, badAccount)).toThrow();
+  });
+});
+
+describe("renderLeafIncludeFile — C-1224 Model B secret-auth serialization", () => {
+  test("emits userinfo in the url, NO credentials line, with the account line", () => {
+    const conf = renderLeafIncludeFile(DESCRIPTOR, SECRET_BINDING);
+    // userinfo spliced into the dial URL (URL-encoded user:secret@host).
+    expect(conf).toContain(
+      'url: "tls://andreas:s3cr3t-leaf-pipe@nats.meta-factory.dev:7422"',
+    );
+    // No `.creds` file on a Model-B leaf.
+    expect(conf).not.toContain("credentials:");
+    // Own local account still bound (operator-mode).
+    expect(conf).toContain(
+      "account: AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+    );
+    expect(conf).toContain("leafnodes {");
+  });
+
+  test("URL-encodes a secret containing @ : / and space (authority boundary safe)", () => {
+    const tricky: StackLeafBinding = {
+      leafSecret: "p@ss:w/rd x",
+      leafUser: "andreas",
+    };
+    const conf = renderLeafIncludeFile(DESCRIPTOR, tricky);
+    // The raw secret must not appear unencoded (would break the userinfo@host
+    // boundary and could inject into the authority).
+    expect(conf).not.toContain("p@ss:w/rd x");
+    expect(conf).toContain("p%40ss%3Aw%2Frd%20x");
+  });
+
+  test("the creds path is unchanged — no userinfo, keeps the credentials line", () => {
+    const conf = renderLeafIncludeFile(DESCRIPTOR, BINDING);
+    expect(conf).toContain('url: "tls://nats.meta-factory.dev:7422"');
+    expect(conf).toContain(
+      'credentials: "/Users/andreas/.config/nats/andreas.creds"',
+    );
+    expect(conf).not.toContain("@nats.meta-factory.dev");
+  });
+});

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -77,8 +77,47 @@ export interface StackLeafBinding {
    * authenticates with (e.g. `~/.config/nats/andreas.creds`, expanded).
    * Must be absolute — nats-server resolves it relative to its working
    * directory otherwise, which under launchd is unpredictable.
+   *
+   * OPTIONAL since C-1224 (ADR-0013 Model B): a secret-authenticated leaf
+   * ({@link StackLeafBinding.leafSecret}) presents its credential via the dial
+   * URL's userinfo, NOT a `.creds` file — so the binding carries no creds path.
+   * EITHER `credentials` OR `leafSecret` must be present; `renderLeafRemote`
+   * fails loud when neither is.
    */
-  credentials: string;
+  credentials?: string;
+  /**
+   * C-1224 (ADR-0013 Model B, §Decision-1) — the **leaf shared secret** for a
+   * secret-authenticated transport-pipe leaf. When present, the leaf remote
+   * authenticates to the hub with this secret (the hub's `leafnodes{}` accept
+   * block carries the matching `authorization { user, password: <leaf-secret> }`)
+   * instead of a `.creds` JWT, and binds the link to a LOCAL NATS account
+   * ({@link StackLeafBinding.account}) in the joiner's OWN operator-mode NSC
+   * store. No cross-operator JWT trust.
+   *
+   * The secret is presented to nats-server via the dial URL's **userinfo**
+   * (`tls://<user>:<secret>@host:port`) — empirically the ONLY remote-side form
+   * nats-server v2.x accepts (a literal `authorization {}` / `username` /
+   * `password` field inside a `remotes[]` entry is rejected at config load).
+   * User + secret are URL-encoded on serialization so an `@`/`:`/`/` in the
+   * secret can never break the authority boundary.
+   *
+   * SECURITY: a leaf secret is sensitive material (like a `.creds` file). It is
+   * folded into the rendered config file's URL only — never into the structured
+   * {@link LeafRemote.url} (so status/log surfaces stay secret-free). Keep the
+   * rendered `leafnodes-<network>.conf` chmod 600.
+   *
+   * NOTE: PR4/#1224 only RENDERS a secret already present in config — the secret
+   * DISTRIBUTION path (how a joiner obtains it: out-of-band today, the admission
+   * gate later) is out of scope here (held PR5).
+   */
+  leafSecret?: string;
+  /**
+   * C-1224 — the userinfo USER paired with {@link StackLeafBinding.leafSecret}.
+   * Matches the `user` in the hub's `authorization { user, password }` accept
+   * block. Required whenever `leafSecret` is set; the caller defaults it to the
+   * principal id. Ignored on the `.creds` path.
+   */
+  leafUser?: string;
   /**
    * The LOCAL NATS account (nkey-U `A…`) that leaf traffic binds to —
    * OPTIONAL (#799).
@@ -109,17 +148,38 @@ export interface StackLeafBinding {
 export interface LeafRemote {
   /** Idempotency key — the network this remote dials. */
   network_id: string;
-  /** Fully-qualified leaf dial URL, e.g. `tls://nats.meta-factory.dev:7422`. */
+  /**
+   * Fully-qualified leaf dial URL, e.g. `tls://nats.meta-factory.dev:7422`.
+   * Always the CLEAN url — userinfo for a secret-authenticated leaf
+   * ({@link LeafRemote.secretAuth}) is NOT spliced in here; it is added only at
+   * serialization time so the structured remote (status/logging) stays
+   * secret-free. (C-1224)
+   */
   url: string;
-  /** Absolute path to the `.creds` file (leaf auth). */
-  credentials: string;
+  /**
+   * Absolute path to the `.creds` file (leaf auth). Present for the JWT-creds
+   * path; ABSENT for a secret-authenticated leaf ({@link LeafRemote.secretAuth}),
+   * whose credential is the URL userinfo. (C-1224 made this optional.)
+   */
+  credentials?: string;
   /**
    * The local NATS account (nkey-U) the leaf binds to — present ONLY in
    * operator-mode (#799). Absent (`undefined`) for a `$G`/default bus, where
    * the account binding rides in the `.creds` JWT and an `account:` line would
    * crash nats-server. When absent, {@link serializeRemote} omits the line.
+   *
+   * For a secret-authenticated leaf (C-1224, Model B) this is the principal's
+   * OWN local federation account — the leaf binds it locally while the secret
+   * authenticates the pipe. Present whenever the bus is operator-mode.
    */
   account?: string;
+  /**
+   * C-1224 (ADR-0013 Model B) — secret-auth material for a transport-pipe leaf.
+   * Present ⇒ {@link serializeRemote} splices `user:secret` (URL-encoded) into
+   * the dial URL's userinfo and emits NO `credentials:` line. Absent ⇒ the
+   * JWT-creds path. Mutually exclusive with {@link LeafRemote.credentials}.
+   */
+  secretAuth?: { user: string; secret: string };
 }
 
 /** A network id may only be a single path segment of safe characters. */
@@ -211,38 +271,54 @@ export function renderLeafRemote(
     );
   }
 
-  const credentials = binding.credentials.trim();
-  if (credentials.length === 0 || !credentials.startsWith("/")) {
+  // #799 — the account is OPTIONAL. When absent/empty the remote is rendered
+  // WITHOUT an `account:` line (the `$G`/default-bus mode — binding rides in the
+  // creds JWT / the secret-auth pipe). When present it must be a valid nkey-U:
+  // it is emitted BARE (unquoted) into HOCON (matching local.conf), so anything
+  // outside the nkey-U grammar could break out of the remotes[] block and inject
+  // directives.
+  const account = binding.account?.trim();
+  const accountIsSet = account !== undefined && account.length > 0;
+  if (accountIsSet && !NKEY_ACCOUNT.test(account)) {
     throw new Error(
-      `leaf-remote-renderer: credentials must be an absolute path, got ${JSON.stringify(binding.credentials)}`,
+      `leaf-remote-renderer: account for network "${descriptor.network_id}" is not a valid nkey-U account public key (expected ${NKEY_ACCOUNT}); got ${JSON.stringify(binding.account)}`,
     );
   }
 
-  // #799 — the account is OPTIONAL. When absent/empty the remote is rendered
-  // WITHOUT an `account:` line (the `$G`/default-bus mode — binding rides in the
-  // creds JWT). When present it must be a valid nkey-U: it is emitted BARE
-  // (unquoted) into HOCON (matching local.conf), so anything outside the nkey-U
-  // grammar could break out of the remotes[] block and inject directives.
-  const account = binding.account?.trim();
-  if (account !== undefined && account.length > 0) {
-    if (!NKEY_ACCOUNT.test(account)) {
+  // C-1224 (ADR-0013 Model B) — SECRET-AUTH path. When the binding carries a
+  // leaf secret, the leaf authenticates via URL userinfo (the secret-auth pipe),
+  // NOT a `.creds` file. It still binds the principal's OWN local `account` (when
+  // operator-mode). Mutually exclusive with the creds path: the secret wins (a
+  // Model-B join carries no creds).
+  const leafSecret = binding.leafSecret?.trim();
+  if (leafSecret !== undefined && leafSecret.length > 0) {
+    const leafUser = binding.leafUser?.trim();
+    if (leafUser === undefined || leafUser.length === 0) {
       throw new Error(
-        `leaf-remote-renderer: account for network "${descriptor.network_id}" is not a valid nkey-U account public key (expected ${NKEY_ACCOUNT}); got ${JSON.stringify(binding.account)}`,
+        `leaf-remote-renderer: a leaf secret was supplied for network "${descriptor.network_id}" without a leaf user — secret-auth needs the userinfo USER that matches the hub's \`authorization { user, password }\` (set stack.nats_infra.leaf_user or pass --leaf-user; it defaults to the principal id)`,
       );
     }
     return {
       network_id: descriptor.network_id,
       url: resolveLeafUrl(descriptor),
-      credentials,
-      account,
+      ...(accountIsSet && { account }),
+      secretAuth: { user: leafUser, secret: leafSecret },
     };
   }
 
-  // No account → `$G`/default mode: omit `account:` entirely.
+  // CREDS path — require an absolute creds file (the JWT-auth leaf).
+  const credentials = binding.credentials?.trim();
+  if (credentials === undefined || credentials.length === 0 || !credentials.startsWith("/")) {
+    throw new Error(
+      `leaf-remote-renderer: leaf binding for network "${descriptor.network_id}" needs either an absolute \`.creds\` path or a leaf secret — credentials must be an absolute path, got ${JSON.stringify(binding.credentials)}`,
+    );
+  }
+
   return {
     network_id: descriptor.network_id,
     url: resolveLeafUrl(descriptor),
     credentials,
+    ...(accountIsSet && { account }),
   };
 }
 
@@ -1033,22 +1109,50 @@ function monitorUrlForPort(port: string): string | undefined {
   return `http://127.0.0.1:${n.toString()}`;
 }
 
+/**
+ * C-1224 (ADR-0013 Model B) — splice `user:secret` into a clean dial URL's
+ * userinfo, URL-encoding both components so an `@`/`:`/`/`/space in the secret
+ * cannot break the authority boundary (and so nats-server — Go `url.Parse`,
+ * which DECODES userinfo — recovers the exact secret). This is the ONLY
+ * remote-side form nats-server v2.x accepts for user/password leaf auth (a
+ * literal `authorization {}` / `username` / `password` field inside a remote is
+ * rejected at config load — verified empirically).
+ */
+function buildSecretAuthUrl(url: string, user: string, secret: string): string {
+  const u = new URL(url);
+  u.username = encodeURIComponent(user);
+  u.password = encodeURIComponent(secret);
+  return u.toString();
+}
+
 /** Serialize one {@link LeafRemote} as a HOCON object literal (indented). */
 function serializeRemote(remote: LeafRemote, indent: string): string {
   // `url` + `credentials` are quoted (they contain `:`, `/`, `.` which are
   // HOCON-significant); `account` is a bare nkey-U token (matches the live
   // local.conf, which leaves the account pubkey unquoted).
   //
+  // C-1224 — for a SECRET-AUTH leaf the credential rides in the URL userinfo
+  // (`tls://user:secret@host:port`), so the emitted `url` carries it and there
+  // is NO `credentials:` line. For the JWT-creds leaf the `url` is clean and a
+  // `credentials:` line points at the `.creds` file. Exactly one of the two.
+  const emittedUrl =
+    remote.secretAuth !== undefined
+      ? buildSecretAuthUrl(remote.url, remote.secretAuth.user, remote.secretAuth.secret)
+      : remote.url;
+
+  const lines = [
+    `${indent}{`,
+    `${indent}  url: ${JSON.stringify(emittedUrl)}`,
+  ];
+  if (remote.credentials !== undefined && remote.credentials.length > 0) {
+    lines.push(`${indent}  credentials: ${JSON.stringify(remote.credentials)}`);
+  }
   // #799 — `account:` is OMITTED entirely for a `$G`/default-bus remote (no
   // account on the binding). A working hand-built `$G` leaf has no `account:`
   // line — the binding rides in the creds JWT — and emitting one would crash
   // nats-server (`cannot find local account "<A…>"`). Only an operator-mode
-  // remote (account present) carries the line.
-  const lines = [
-    `${indent}{`,
-    `${indent}  url: ${JSON.stringify(remote.url)}`,
-    `${indent}  credentials: ${JSON.stringify(remote.credentials)}`,
-  ];
+  // remote (account present) carries the line. A Model-B secret-auth leaf on an
+  // operator-mode bus carries BOTH the userinfo secret AND the local `account:`.
   if (remote.account !== undefined && remote.account.length > 0) {
     lines.push(`${indent}  account: ${remote.account}`);
   }

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -131,6 +131,29 @@ export const StackNatsInfraSchema = z.object({
    */
   creds_path: z.string().min(1).optional(),
   /**
+   * C-1224 (ADR-0013 Model B, §Decision-1) — the **leaf shared secret** for a
+   * secret-authenticated transport-pipe leaf. When set, `cortex network join`
+   * renders the network's leaf remote to authenticate to the hub with this
+   * secret (URL userinfo — the hub's `leafnodes{}` accept block carries the
+   * matching `authorization { user, password: <leaf-secret> }`) and binds the
+   * link to the principal's OWN local {@link StackNatsInfraSchema.shape.account}
+   * in their own NSC operator — no hub-minted `.creds`, no cross-operator JWT
+   * trust. OPTIONAL: a stack on the legacy `.creds` path, or one that never
+   * federates, omits it.
+   *
+   * This is SENSITIVE material (like the bot token + a `.creds` file): keep the
+   * stack file chmod 600. PR4/#1224 only RENDERS a secret already in config; the
+   * secret DISTRIBUTION path (out-of-band today; the admission gate later) is
+   * out of scope.
+   */
+  leaf_secret: z.string().min(1).optional(),
+  /**
+   * C-1224 — the userinfo USER paired with {@link StackNatsInfraSchema.shape.leaf_secret},
+   * matching the `user` in the hub's `authorization { user, password }` accept
+   * block. OPTIONAL: when omitted the join defaults it to the principal id.
+   */
+  leaf_user: z.string().min(1).optional(),
+  /**
    * O-3 (cortex#1053) — the operator-mode "leaf package": the material
    * `cortex network join` needs to AUTO-CONVERT an anonymous/hard-isolated bus
    * to operator-mode (rendering the SOP §B0.1 blocks) instead of fail-fasting


### PR DESCRIPTION
## What

Implements **Model-B `cortex network join`** (ADR-0013 §Decision-1, #1224): a joining stack's leaf authenticates the **secret-authenticated transport pipe** with the shared **leaf secret** and binds the principal's **OWN local account** (in their own operator-mode NSC store) — not a hub-minted `.creds` JWT, no cross-operator JWT trust.

This is the **code half of Model B** for the join/renderer side.

## Audit (already-done vs. delta)

PR3 (`cortex network provision`, just landed) writes the principal's own operator/account into `stack.nats_infra` (`account`, `agents_account`, `creds_path`). The audit found:

- **Own-account binding was ALREADY correct.** `nats_infra.account` → `deriveJoinInputs` → `JoiningStack.account` → bind-mode `operator-account` → leaf binding `account:`. Post-provision, that account is the principal's OWN federation account, so no change was needed there.
- **The renderer supported ONLY creds-file auth** (operator-account creds + account line, or `$G` creds-only). It had **no password/secret-auth path at all**. That was the delta.
- No `leaf_secret` field existed anywhere (the SOP calls the leaf secret the one out-of-band, not-cortex-generated artifact).

So the delta implemented is purely the **secret-auth render path**.

## Wire-format decision (empirically validated)

nats-server **v2.14 rejects** `authorization { }`, `username`, and `password` fields inside a `remotes[]` entry (`unknown field` at config load). The **only** remote-side form it accepts for user/password leaf auth is **URL userinfo**: `tls://<user>:<secret>@host:port`. So the joiner-side render presents the secret via userinfo (the hub side carries the literal `authorization { user, password }` accept block, hand-provisioned per the onboarding SOP). user+secret are **URL-encoded** so an `@`/`:`/`/`/space can't break the authority boundary (and Go's `url.Parse` decodes them back to the exact secret). The structured `LeafRemote.url` stays **secret-free** — the secret is folded in only at serialization (so status/log surfaces never leak it).

End-to-end: a rendered fragment with a special-char secret + own account **validates under `nats-server -t`**:
```
url: "tls://andreas:p%40ss%3Aw%2Frd%20x@nats.meta-factory.dev:7422"
account: AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX
```

## Command / render surface

- New flags on `cortex network join`: `--leaf-secret`, `--leaf-user` (→ `stack.nats_infra.leaf_secret` / `leaf_user`). `leaf_user` defaults to the principal id.
- New OPTIONAL config: `stack.nats_infra.leaf_secret`, `stack.nats_infra.leaf_user`.
- When a secret is present, join renders a userinfo secret-auth leaf binding the own `account`; the `.creds` pre-flight is skipped (no creds file); the write binding carries secret + account, no creds.

## Boundaries held

- **Only RENDERS a secret already in config** — secret **distribution** is out of scope (held PR5 / admission gate).
- **`--operator-jwt`/`--account-jwt` / O-3 operator-mode auto-convert KEPT** (ADR-0015 Model-B survivor).
- Admission gate / registry routes untouched.

## Gates

| Gate | Result |
|---|---|
| `bunx tsc --noEmit` | 0 errors |
| `bash scripts/check-carveouts.sh` | PASS |
| `bun run lint:errors` | clean |
| scoped tests (`src/common/nats/ src/cli/cortex/commands/`) | 1086 pass / 0 fail |

## Tests (TDD)

- renderer: secretAuth + own-account render, $G secret-only (no account line), secret-without-user error, secret-wins-over-creds, invalid-account guard, userinfo serialization, URL-encoding of `@:/ `+space, creds path unchanged.
- derive: `leaf_secret` from config, `leaf_user` default = principal, flags win, absent → both undefined.
- orchestration: secret join skips creds pre-flight + writes secret+account binding; `$G` secret-only no-account; **creds path unchanged (no regression)**; operator-mode auto-convert untouched.

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)