### PR TITLE
feat(crypto): C-1238 — shared seal-to-principal sealed-box core

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c"],
+    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c", "sha512-PlffOgC1qoiqomRUVIM3nSE61q0VigytzlOMNcyKlmZT8r7cAgR7+vLQgSbVxNfrFoZVAmx0kgKF6TQnT5UNag=="],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
@@ -126,7 +126,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#f5ec865", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-f5ec865"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#f5ec865", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-f5ec865", "sha512-Uu/giX/FcCwBPrVce/MYWqcx5y7wWK11trpi2wc+a7Jl52hd93vzoluEJlcpqmtQqIPRXMVPtRjlcMnUBuhWcw=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "discord.js": "^14.25.1",
         "elkjs": "^0.11.1",
         "hono": "4.12.10",
+        "libsodium-wrappers": "^0.8.4",
         "nats": "^2.29.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -29,6 +30,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bun": "latest",
+        "@types/libsodium-wrappers": "^0.8.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "eslint": "^10.3.0",
@@ -78,7 +80,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c", "sha512-PlffOgC1qoiqomRUVIM3nSE61q0VigytzlOMNcyKlmZT8r7cAgR7+vLQgSbVxNfrFoZVAmx0kgKF6TQnT5UNag=="],
+    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c"],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
@@ -124,7 +126,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#f5ec865", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-f5ec865", "sha512-Uu/giX/FcCwBPrVce/MYWqcx5y7wWK11trpi2wc+a7Jl52hd93vzoluEJlcpqmtQqIPRXMVPtRjlcMnUBuhWcw=="],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#f5ec865", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-f5ec865"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -145,6 +147,8 @@
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/libsodium-wrappers": ["@types/libsodium-wrappers@0.8.2", "", { "dependencies": { "libsodium-wrappers": "*" } }, "sha512-+2IDfSULPUskSjIYfZl9suIUsIE5PXwoKZiE/j0MZWd+M9nEGvJDsk/ztMZKNhL1lBL+1CaypW0dQSjqPW2dMg=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
@@ -341,6 +345,10 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "libsodium": ["libsodium@0.8.4", "", {}, "sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw=="],
+
+    "libsodium-wrappers": ["libsodium-wrappers@0.8.4", "", { "dependencies": { "libsodium": "^0.8.0" } }, "sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/bun": "latest",
+    "@types/libsodium-wrappers": "^0.8.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.3.0",
@@ -48,6 +49,7 @@
     "discord.js": "^14.25.1",
     "elkjs": "^0.11.1",
     "hono": "4.12.10",
+    "libsodium-wrappers": "^0.8.4",
     "nats": "^2.29.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/common/crypto/__tests__/seal-to-principal.test.ts
+++ b/src/common/crypto/__tests__/seal-to-principal.test.ts
@@ -247,6 +247,20 @@ describe("seal-to-principal — input validation (no secret leakage)", () => {
     await expect(sealToPrincipal("x", "!!!not base64!!!")).rejects.toThrow();
   });
 
+  test("a 32-byte but off-curve ed25519 pubkey is rejected (fails closed, no leak)", async () => {
+    // Right length (32 bytes), wrong value: 0xFF×32 is not a valid ed25519
+    // point. libsodium's pk_to_curve25519 must reject non-canonical / off-curve
+    // encodings rather than derive a bogus X25519 key and seal to it. Locks the
+    // fail-closed behavior on the derivation boundary.
+    await sodium.ready;
+    const offCurveB64 = sodium.to_base64(
+      new Uint8Array(32).fill(0xff),
+      sodium.base64_variants.ORIGINAL,
+    );
+
+    await expect(sealToPrincipal("x", offCurveB64)).rejects.toThrow();
+  });
+
   test("a wrong-length seed is rejected by openSealed", async () => {
     const { edPubB64 } = await makeIdentity();
     const sealed = await sealToPrincipal("x", edPubB64);

--- a/src/common/crypto/__tests__/seal-to-principal.test.ts
+++ b/src/common/crypto/__tests__/seal-to-principal.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for the shared `seal-to-principal` core (#1238).
+ *
+ * This is the most security-critical primitive in the encryption series
+ * (ADR-0019 / docs/design-envelope-encryption.md §3.4), so the suite is
+ * deliberately adversarial: it proves authenticity (tamper rejection),
+ * confidentiality (a different recipient cannot open), derivation
+ * consistency (sender-side seal ↔ recipient-side open over the *published
+ * ed25519 pubkey*), and that no secret material leaks into error text.
+ */
+
+import { describe, expect, test } from "bun:test";
+import sodium from "libsodium-wrappers";
+
+import {
+  ed25519PubToX25519,
+  ed25519SeedToX25519,
+  openSealed,
+  sealToPrincipal,
+} from "../seal-to-principal";
+
+/** Deterministic-ish test identity: a fresh ed25519 seed + its public key b64. */
+async function makeIdentity(): Promise<{
+  seed: Uint8Array;
+  edPubB64: string;
+  edPub: Uint8Array;
+}> {
+  await sodium.ready;
+  const seed = sodium.randombytes_buf(32);
+  const kp = sodium.crypto_sign_seed_keypair(seed);
+  return {
+    seed,
+    edPub: kp.publicKey,
+    edPubB64: sodium.to_base64(kp.publicKey, sodium.base64_variants.ORIGINAL),
+  };
+}
+
+describe("seal-to-principal — round-trip", () => {
+  test("string plaintext seals and opens to the exact same bytes", async () => {
+    const { seed, edPubB64 } = await makeIdentity();
+    const plaintext = "the leaf PSK is hunter2 — never log me";
+
+    const sealed = await sealToPrincipal(plaintext, edPubB64);
+    const opened = await openSealed(sealed, seed);
+
+    expect(new TextDecoder().decode(opened)).toBe(plaintext);
+  });
+
+  test("Uint8Array plaintext seals and opens byte-identically", async () => {
+    const { seed, edPubB64 } = await makeIdentity();
+    const plaintext = new Uint8Array([0, 1, 2, 253, 254, 255, 0, 42]);
+
+    const sealed = await sealToPrincipal(plaintext, edPubB64);
+    const opened = await openSealed(sealed, seed);
+
+    expect(Array.from(opened)).toEqual(Array.from(plaintext));
+  });
+
+  test("empty plaintext round-trips", async () => {
+    const { seed, edPubB64 } = await makeIdentity();
+
+    const sealed = await sealToPrincipal(new Uint8Array(0), edPubB64);
+    const opened = await openSealed(sealed, seed);
+
+    expect(opened.length).toBe(0);
+  });
+
+  test("large plaintext (256 KiB) round-trips", async () => {
+    const { seed, edPubB64 } = await makeIdentity();
+    await sodium.ready;
+    const plaintext = sodium.randombytes_buf(256 * 1024);
+
+    const sealed = await sealToPrincipal(plaintext, edPubB64);
+    const opened = await openSealed(sealed, seed);
+
+    expect(Array.from(opened)).toEqual(Array.from(plaintext));
+  });
+
+  test("sealing the same plaintext twice yields different ciphertexts (ephemeral sender key)", async () => {
+    const { edPubB64 } = await makeIdentity();
+
+    const a = await sealToPrincipal("same", edPubB64);
+    const b = await sealToPrincipal("same", edPubB64);
+
+    // crypto_box_seal uses a fresh ephemeral keypair each call → IND-CPA.
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("seal-to-principal — output encoding", () => {
+  test("ciphertext is valid standard base64 and round-trips through base64", async () => {
+    const { edPubB64 } = await makeIdentity();
+
+    const sealed = await sealToPrincipal("payload", edPubB64);
+
+    // Standard alphabet (not url-safe): only [A-Za-z0-9+/=].
+    expect(sealed).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+    // Decodes without throwing and re-encodes to the same string.
+    await sodium.ready;
+    const bytes = sodium.from_base64(sealed, sodium.base64_variants.ORIGINAL);
+    const reencoded = sodium.to_base64(bytes, sodium.base64_variants.ORIGINAL);
+    expect(reencoded).toBe(sealed);
+  });
+
+  test("sealed box is 48 bytes longer than plaintext (epk[32] + MAC[16])", async () => {
+    const { edPubB64 } = await makeIdentity();
+    await sodium.ready;
+
+    const sealed = await sealToPrincipal(new Uint8Array(10), edPubB64);
+    const bytes = sodium.from_base64(sealed, sodium.base64_variants.ORIGINAL);
+
+    expect(bytes.length).toBe(10 + 32 + 16);
+  });
+});
+
+describe("seal-to-principal — confidentiality", () => {
+  test("a DIFFERENT recipient seed cannot open and leaks no plaintext", async () => {
+    const sender = await makeIdentity();
+    const attacker = await makeIdentity();
+    const secret = "TOP-SECRET-PSK";
+
+    const sealed = await sealToPrincipal(secret, sender.edPubB64);
+
+    let threw = false;
+    let recovered: Uint8Array | undefined;
+    try {
+      recovered = await openSealed(sealed, attacker.seed);
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+    // Belt-and-braces: even if a future impl returned instead of threw,
+    // it must never hand back the plaintext.
+    if (recovered) {
+      expect(new TextDecoder().decode(recovered)).not.toBe(secret);
+    }
+  });
+});
+
+describe("seal-to-principal — authenticity / integrity", () => {
+  test("a tampered ciphertext byte fails to open", async () => {
+    const { seed, edPubB64 } = await makeIdentity();
+    await sodium.ready;
+
+    const sealed = await sealToPrincipal("authentic message", edPubB64);
+    const bytes = sodium.from_base64(sealed, sodium.base64_variants.ORIGINAL);
+    // Flip a bit in the MAC/ciphertext region (after the 32-byte epk).
+    const last = bytes.length - 1;
+    bytes[last] = (bytes[last] ?? 0) ^ 0x01;
+    const tampered = sodium.to_base64(bytes, sodium.base64_variants.ORIGINAL);
+
+    await expect(openSealed(tampered, seed)).rejects.toThrow();
+  });
+
+  test("a tampered ephemeral-pubkey prefix fails to open", async () => {
+    const { seed, edPubB64 } = await makeIdentity();
+    await sodium.ready;
+
+    const sealed = await sealToPrincipal("authentic message", edPubB64);
+    const bytes = sodium.from_base64(sealed, sodium.base64_variants.ORIGINAL);
+    bytes[0] = (bytes[0] ?? 0) ^ 0x01; // corrupt the embedded ephemeral X25519 pubkey
+    const tampered = sodium.to_base64(bytes, sodium.base64_variants.ORIGINAL);
+
+    await expect(openSealed(tampered, seed)).rejects.toThrow();
+  });
+
+  test("a truncated sealed blob fails to open", async () => {
+    const { seed, edPubB64 } = await makeIdentity();
+    await sodium.ready;
+
+    const sealed = await sealToPrincipal("authentic message", edPubB64);
+    const bytes = sodium.from_base64(sealed, sodium.base64_variants.ORIGINAL);
+    const truncated = sodium.to_base64(
+      bytes.subarray(0, bytes.length - 4),
+      sodium.base64_variants.ORIGINAL,
+    );
+
+    await expect(openSealed(truncated, seed)).rejects.toThrow();
+  });
+});
+
+describe("seal-to-principal — derivation consistency", () => {
+  test("sender sealing to the PUBLISHED ed25519 pub ↔ recipient opening with own seed", async () => {
+    // Models the real flow: recipient registers `principal_pubkey` (ed25519,
+    // base64) in the registry; an unrelated sender resolves it and seals; the
+    // recipient opens with the seed it never published. No shared state but
+    // the public key.
+    const { seed, edPubB64 } = await makeIdentity();
+    const message = "derivation must agree across the two sides";
+
+    const sealed = await sealToPrincipal(message, edPubB64);
+    const opened = await openSealed(sealed, seed);
+
+    expect(new TextDecoder().decode(opened)).toBe(message);
+  });
+
+  test("ed25519PubToX25519 + ed25519SeedToX25519 are a consistent X25519 keypair", async () => {
+    const { seed, edPub } = await makeIdentity();
+    await sodium.ready;
+
+    const xPub = ed25519PubToX25519(edPub);
+    const xSec = ed25519SeedToX25519(seed);
+
+    // crypto_scalarmult_base(secret) must reproduce the converted public key.
+    const derivedPub = sodium.crypto_scalarmult_base(xSec);
+    expect(Array.from(derivedPub)).toEqual(Array.from(xPub));
+    expect(xPub.length).toBe(32);
+    expect(xSec.length).toBe(32);
+  });
+
+  test("M3 can layer on top: a manual crypto_box_seal to ed25519PubToX25519 opens via openSealed", async () => {
+    // Proves the exported conversion helper is the SAME derivation the core
+    // uses, so the M3 wrapper built on the helpers interoperates with the core.
+    const { seed, edPub } = await makeIdentity();
+    await sodium.ready;
+
+    const xPub = ed25519PubToX25519(edPub);
+    const manualSealed = sodium.crypto_box_seal(
+      sodium.from_string("built by M3"),
+      xPub,
+    );
+    const sealedB64 = sodium.to_base64(
+      manualSealed,
+      sodium.base64_variants.ORIGINAL,
+    );
+
+    const opened = await openSealed(sealedB64, seed);
+    expect(new TextDecoder().decode(opened)).toBe("built by M3");
+  });
+});
+
+describe("seal-to-principal — input validation (no secret leakage)", () => {
+  test("a non-32-byte recipient pubkey is rejected cleanly", async () => {
+    const shortB64 = await (async () => {
+      await sodium.ready;
+      return sodium.to_base64(
+        new Uint8Array(16),
+        sodium.base64_variants.ORIGINAL,
+      );
+    })();
+
+    await expect(sealToPrincipal("x", shortB64)).rejects.toThrow();
+  });
+
+  test("an undecodable base64 recipient pubkey is rejected cleanly", async () => {
+    await expect(sealToPrincipal("x", "!!!not base64!!!")).rejects.toThrow();
+  });
+
+  test("a wrong-length seed is rejected by openSealed", async () => {
+    const { edPubB64 } = await makeIdentity();
+    const sealed = await sealToPrincipal("x", edPubB64);
+
+    await expect(openSealed(sealed, new Uint8Array(31))).rejects.toThrow();
+  });
+
+  test("an undecodable base64 sealed blob is rejected by openSealed", async () => {
+    const { seed } = await makeIdentity();
+
+    await expect(openSealed("@@@not base64@@@", seed)).rejects.toThrow();
+  });
+
+  test("error messages never contain seed or plaintext material", async () => {
+    const { seed, edPubB64 } = await makeIdentity();
+    await sodium.ready;
+    const secret = "leaf-psk-do-not-log-me-zzz";
+    const sealed = await sealToPrincipal(secret, edPubB64);
+    const seedB64 = sodium.to_base64(seed, sodium.base64_variants.ORIGINAL);
+
+    // Tamper so open fails, then assert the surfaced message is generic.
+    const bytes = sodium.from_base64(sealed, sodium.base64_variants.ORIGINAL);
+    const last = bytes.length - 1;
+    bytes[last] = (bytes[last] ?? 0) ^ 0xff;
+    const tampered = sodium.to_base64(bytes, sodium.base64_variants.ORIGINAL);
+
+    let msg = "";
+    try {
+      await openSealed(tampered, seed);
+    } catch (err) {
+      msg = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(msg.length).toBeGreaterThan(0);
+    expect(msg).not.toContain(secret);
+    expect(msg).not.toContain(seedB64);
+    // Don't echo the raw ciphertext back either.
+    expect(msg).not.toContain(tampered);
+  });
+});

--- a/src/common/crypto/seal-to-principal.ts
+++ b/src/common/crypto/seal-to-principal.ts
@@ -118,7 +118,15 @@ export function ed25519SeedToX25519(ed25519Seed: Uint8Array): Uint8Array {
     );
   }
   const { privateKey } = sodium.crypto_sign_seed_keypair(ed25519Seed);
-  return sodium.crypto_sign_ed25519_sk_to_curve25519(privateKey);
+  try {
+    return sodium.crypto_sign_ed25519_sk_to_curve25519(privateKey);
+  } finally {
+    // Best-effort wipe of the expanded ed25519 secret key once the X25519
+    // secret is derived. JS GC may have copied it, but zeroizing the buffer
+    // we hold is cheap defense-in-depth for a seed-handling module. (The
+    // returned X25519 secret is the caller's to wipe after use.)
+    sodium.memzero(privateKey);
+  }
 }
 
 // ===========================================================================
@@ -182,15 +190,24 @@ export async function openSealed(
     sodium.crypto_sign_seed_keypair(ownEd25519Seed);
   const xPub = sodium.crypto_sign_ed25519_pk_to_curve25519(publicKey);
   const xSec = sodium.crypto_sign_ed25519_sk_to_curve25519(privateKey);
-  const sealed = bytesFromB64(sealedB64, "sealed blob");
   try {
-    return sodium.crypto_box_seal_open(sealed, xPub, xSec);
-  } catch (err) {
-    // Generic on purpose: do not distinguish "wrong recipient" from
-    // "tampered", and never surface key/ciphertext bytes.
-    throw new Error(
-      "seal-to-principal: failed to open sealed box (wrong recipient or tampered ciphertext)",
-      { cause: err },
-    );
+    const sealed = bytesFromB64(sealedB64, "sealed blob");
+    try {
+      return sodium.crypto_box_seal_open(sealed, xPub, xSec);
+    } catch (err) {
+      // Generic on purpose: do not distinguish "wrong recipient" from
+      // "tampered", and never surface key/ciphertext bytes.
+      throw new Error(
+        "seal-to-principal: failed to open sealed box (wrong recipient or tampered ciphertext)",
+        { cause: err },
+      );
+    }
+  } finally {
+    // Best-effort wipe of the derived secret material once the open has run.
+    // The outer try/finally guarantees the wipe even if base64 decode or the
+    // open throws. GC may have copied these, but zeroizing the buffers we
+    // hold is cheap defense-in-depth for a seed-handling module.
+    sodium.memzero(privateKey);
+    sodium.memzero(xSec);
   }
 }

--- a/src/common/crypto/seal-to-principal.ts
+++ b/src/common/crypto/seal-to-principal.ts
@@ -1,0 +1,196 @@
+/**
+ * `seal-to-principal` — the shared sealed-box crypto CORE (#1238).
+ *
+ * One cryptographic operation, two consumers. This module is the single
+ * implementation of "seal an opaque blob to a principal's already-registered
+ * ed25519 identity, anonymously" that BOTH of the following depend on:
+ *
+ *   1. Leaf-secret distribution (ADR-0018 option b′, PR5b) — seals the
+ *      per-member NATS leaf PSK to the admitted joiner's registered pubkey.
+ *      Uses this core DIRECTLY: `sealToPrincipal` / `openSealed`.
+ *
+ *   2. M3 federated payload encryption (ADR-0019 / docs/design-envelope-
+ *      encryption.md §3.4, TC-3) — seals the envelope `payload` to the
+ *      recipient stack's registered pubkey. Does NOT use the seal/open
+ *      functions here directly for its on-the-wire shape; instead it layers
+ *      an envelope-binding wrapper (`extensions.enc` + AEAD associated-data
+ *      over `id`/`type`/`sovereignty.classification`) on top of the exported
+ *      ed25519→X25519 conversion helpers.
+ *
+ * THE BOUNDARY (why this file is deliberately small):
+ *   - CORE (here)  = the ed25519→X25519 derivation + anonymous seal/open
+ *                    (`crypto_box_seal` / `crypto_box_seal_open` semantics).
+ *   - M3 (NOT here) = the AAD/AEAD envelope-binding wrapper. M3 owns that
+ *                     and builds it on the conversion helpers this module
+ *                     exports. Do not add envelope/AAD logic to this file.
+ *
+ * Having the ed25519→X25519 derivation in EXACTLY ONE place is the point:
+ * two independent derivations is a key-derivation-divergence and security-
+ * review hazard (ADR-0019 design constraint L4). Both consumers, one module.
+ *
+ * --- Construction ---------------------------------------------------------
+ * Sealed box = libsodium `crypto_box_seal` (anonymous-sender sealed box):
+ *   - The recipient identity is an ed25519 keypair (the SAME seed the stack
+ *     already signs envelopes with — NO new key material, ADR-0019 L3).
+ *   - The X25519 sealing keys are derived from that ed25519 identity via
+ *     `crypto_sign_ed25519_{pk,sk}_to_curve25519`.
+ *   - Each seal uses a fresh ephemeral X25519 keypair (forward-ish secrecy
+ *     against the sender; IND-CPA); the blob is `epk[32] || box`, and the
+ *     box authenticates with a Poly1305 tag — tamper-evident on open.
+ *   - The sender is anonymous: the recipient learns nothing about who sealed
+ *     it from the blob alone (authorship, where needed, is established by the
+ *     surrounding envelope `signed_by[]` chain, not by this core).
+ *
+ * Base64 is the STANDARD alphabet (not url-safe), matching the rest of the
+ * federation crypto surface (`src/common/registry/signing.ts`).
+ *
+ * --- Async note -----------------------------------------------------------
+ * libsodium-wrappers has no synchronous init; every entry point awaits the
+ * memoized `sodium.ready`. The leaf-secret and M3 publish/admission paths are
+ * already async, so this is free at the call sites.
+ */
+
+import sodium from "libsodium-wrappers";
+
+/** Length of an ed25519 seed / X25519 key, in bytes. */
+const SEED_BYTES = 32;
+const ED25519_PUB_BYTES = 32;
+
+/** Standard (non-url-safe) base64, to match the registry signing surface. */
+const B64 = (): typeof sodium.base64_variants.ORIGINAL =>
+  sodium.base64_variants.ORIGINAL;
+
+/**
+ * Resolve the libsodium ready promise once. `sodium.ready` is itself a
+ * memoized promise, so awaiting it repeatedly is cheap; this wrapper just
+ * gives the intent a name at each call site.
+ */
+async function ready(): Promise<void> {
+  await sodium.ready;
+}
+
+function bytesFromB64(b64: string, label: string): Uint8Array {
+  try {
+    return sodium.from_base64(b64, B64());
+  } catch (err) {
+    // Never echo the input back — it may be (or be derived from) secret
+    // material. Surface only the field name and the underlying cause.
+    throw new Error(`seal-to-principal: ${label} is not valid base64`, {
+      cause: err,
+    });
+  }
+}
+
+// ===========================================================================
+// Conversion helpers — exported so the M3 wrapper derives identically.
+// The derivation lives in EXACTLY these two functions (ADR-0019 L4).
+// ===========================================================================
+
+/**
+ * Derive the X25519 *public* key from a 32-byte ed25519 public key
+ * (`crypto_sign_ed25519_pk_to_curve25519`). This is the recipient's sealing
+ * key — the value M3 resolves from the registry's `principal_pubkey`.
+ *
+ * @throws if `ed25519Pub` is not exactly 32 bytes, or is not a valid
+ *   ed25519 point (libsodium rejects non-canonical / low-order points).
+ */
+export function ed25519PubToX25519(ed25519Pub: Uint8Array): Uint8Array {
+  if (ed25519Pub.length !== ED25519_PUB_BYTES) {
+    throw new Error(
+      `seal-to-principal: ed25519 public key must be ${ED25519_PUB_BYTES} bytes, got ${ed25519Pub.length}`,
+    );
+  }
+  return sodium.crypto_sign_ed25519_pk_to_curve25519(ed25519Pub);
+}
+
+/**
+ * Derive the X25519 *secret* key from a 32-byte ed25519 seed
+ * (`crypto_sign_ed25519_sk_to_curve25519`, via the seed's expanded secret
+ * key). This is the holder's opening key — derived from the SAME seed the
+ * stack signs with; no new key material.
+ *
+ * @throws if `ed25519Seed` is not exactly 32 bytes.
+ */
+export function ed25519SeedToX25519(ed25519Seed: Uint8Array): Uint8Array {
+  if (ed25519Seed.length !== SEED_BYTES) {
+    throw new Error(
+      `seal-to-principal: ed25519 seed must be ${SEED_BYTES} bytes, got ${ed25519Seed.length}`,
+    );
+  }
+  const { privateKey } = sodium.crypto_sign_seed_keypair(ed25519Seed);
+  return sodium.crypto_sign_ed25519_sk_to_curve25519(privateKey);
+}
+
+// ===========================================================================
+// Core seal / open — the anonymous sealed box. PR5b/leaf-secret uses these
+// directly; M3 layers its own envelope wrapper on the helpers above.
+// ===========================================================================
+
+/**
+ * Seal `plaintext` to a recipient's registered ed25519 identity, anonymously.
+ *
+ * Equivalent to libsodium `crypto_box_seal` against the X25519 key derived
+ * from the recipient's ed25519 public key. The sender is ephemeral and
+ * unauthenticated at this layer (authorship rides the envelope `signed_by[]`
+ * chain). Exactly what leaf-secret distribution (PR5b) needs to seal a PSK.
+ *
+ * @param plaintext  bytes (or a UTF-8 string) to seal.
+ * @param recipientEd25519PubB64  the recipient's ed25519 public key, standard
+ *   base64 (e.g. the registry `principal_pubkey`).
+ * @returns standard-base64 sealed ciphertext (`epk[32] || box`).
+ * @throws if the recipient key is not valid 32-byte base64 ed25519.
+ */
+export async function sealToPrincipal(
+  plaintext: Uint8Array | string,
+  recipientEd25519PubB64: string,
+): Promise<string> {
+  await ready();
+  const edPub = bytesFromB64(recipientEd25519PubB64, "recipient public key");
+  const xPub = ed25519PubToX25519(edPub);
+  const message =
+    typeof plaintext === "string" ? sodium.from_string(plaintext) : plaintext;
+  const sealed = sodium.crypto_box_seal(message, xPub);
+  return sodium.to_base64(sealed, B64());
+}
+
+/**
+ * Open a sealed blob with the holder's ed25519 seed.
+ *
+ * Derives the X25519 keypair from the seed and runs `crypto_box_seal_open`.
+ * Fails closed: a blob sealed to a different recipient, or any tampered /
+ * truncated blob, throws — and the error text carries NO seed or plaintext
+ * material (the cryptographic-doom guidance: authenticate, then reveal
+ * nothing on failure).
+ *
+ * @param sealedB64  standard-base64 sealed ciphertext from {@link sealToPrincipal}.
+ * @param ownEd25519Seed  the holder's 32-byte ed25519 seed.
+ * @returns the recovered plaintext bytes.
+ * @throws on a wrong-length seed, undecodable base64, or any open failure
+ *   (wrong recipient / tampered / truncated). The message is generic.
+ */
+export async function openSealed(
+  sealedB64: string,
+  ownEd25519Seed: Uint8Array,
+): Promise<Uint8Array> {
+  await ready();
+  if (ownEd25519Seed.length !== SEED_BYTES) {
+    throw new Error(
+      `seal-to-principal: seed must be ${SEED_BYTES} bytes, got ${ownEd25519Seed.length}`,
+    );
+  }
+  const { publicKey, privateKey } =
+    sodium.crypto_sign_seed_keypair(ownEd25519Seed);
+  const xPub = sodium.crypto_sign_ed25519_pk_to_curve25519(publicKey);
+  const xSec = sodium.crypto_sign_ed25519_sk_to_curve25519(privateKey);
+  const sealed = bytesFromB64(sealedB64, "sealed blob");
+  try {
+    return sodium.crypto_box_seal_open(sealed, xPub, xSec);
+  } catch (err) {
+    // Generic on purpose: do not distinguish "wrong recipient" from
+    // "tampered", and never surface key/ciphertext bytes.
+    throw new Error(
+      "seal-to-principal: failed to open sealed box (wrong recipient or tampered ciphertext)",
+      { cause: err },
+    );
+  }
+}


### PR DESCRIPTION
## What

The shared **`seal-to-principal`** crypto core — the single ed25519→X25519 derivation + anonymous sealed-box that **both** consumers in the encryption series depend on:

- **Leaf-secret distribution** (ADR-0018 option b′ / PR5b) — uses `sealToPrincipal` / `openSealed` **directly** to seal a per-member NATS leaf PSK to an admitted joiner's registered pubkey.
- **M3 federated payload encryption** (ADR-0019 / `docs/design-envelope-encryption.md` §3.4) — layers its own `extensions.enc` + AEAD associated-data envelope-binding wrapper **on top of the exported conversion helpers** (`ed25519PubToX25519`, `ed25519SeedToX25519`).

This is the L4 constraint made concrete: the ed25519→X25519 derivation lives in **exactly one place**, so the two call sites can never diverge.

## Scope (CORE only)

Per ADR-0019 §3.4, this slice is the core seal/open + conversions. **M3's AAD/AEAD envelope wrapper is explicitly NOT built here** — it's a separate slice that consumes the exported helpers. The module doc states both consumers and the boundary.

API (`src/common/crypto/seal-to-principal.ts`):

- `sealToPrincipal(plaintext: Uint8Array | string, recipientEd25519PubB64): Promise<string>` — anonymous `crypto_box_seal` to the recipient's X25519-from-ed25519 key; standard-base64 ciphertext.
- `openSealed(sealedB64, ownEd25519Seed: Uint8Array): Promise<Uint8Array>` — open with the holder's seed; fails closed.
- `ed25519PubToX25519(pub)` / `ed25519SeedToX25519(seed)` — the one-place derivation helpers M3 builds on.

> **Async note:** libsodium-wrappers has no synchronous init, so each entry point awaits the memoized `sodium.ready`. The literal sync signatures in the issue can't be honored against libsodium; both consumers (publish / admission) are already on async paths, so this is free at the call sites.

## Library choice — `libsodium-wrappers`

The design names **libsodium `crypto_box_seal`** and the `crypto_sign_ed25519_{pk,sk}_to_curve25519` conversions specifically. The repo had **no existing sealed-box lib** (cortex-side ed25519 is WebCrypto, which has no X25519/box; myelin uses `@noble/ed25519` v3, which is sign/verify only) — so a new dep was required regardless of choice. Given this is the most security-critical primitive in the series, using the audited primitive directly (rather than hand-rolling the sealed-box construction out of noble parts — ephemeral keypair + HSalsa20 key-derivation + blake2b nonce + xsalsa20poly1305, exactly the "subtle divergence" hazard the design warns about) is the correct call. One dep added: `libsodium-wrappers` (+ `@types/libsodium-wrappers` dev).

## Tests (TDD — 19, all green)

Round-trip (string / bytes / empty / 256 KiB); IND-CPA (same plaintext → different ciphertext); **wrong-recipient seed fails closed, no plaintext leak**; tampered ciphertext / tampered epk-prefix / truncated blob all rejected; cross-side derivation consistency (seal to a *published* ed25519 pub ↔ open with the unpublished seed); a manual M3-style `crypto_box_seal` to `ed25519PubToX25519(pub)` opens via the core (proves helper ↔ core derivation agree); base64 round-trips + shape; input validation (bad key length / undecodable base64 / wrong seed length); **error messages carry no seed or plaintext material**.

## Gates

- `bunx tsc --noEmit` → 0 errors
- `bash scripts/check-carveouts.sh` → PASS
- `bun test src/common/` → 1347 pass, 0 fail
- `bun run lint:errors` → clean

Closes #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)