### PR TITLE
feat(registry): C-1239 — admission-gate wiring (network_id + ADMITTED roster + member PoP read) [ADR-0018 PR5a]

### DIFF
--- a/docs/design-admission-gate-leaf-secret.md
+++ b/docs/design-admission-gate-leaf-secret.md
@@ -1,0 +1,360 @@
+# Design — Network-admission gate + leaf-secret distribution (C-1142 R1)
+
+**Status:** DESIGN — HELD for Andreas's review. No implementation, no PR until the load-bearing
+secret-distribution decision (§7, Q1) is made.
+**Feature:** cortex#1142 R1 — "repurpose O-4a `register→PENDING→grant` as the network-admission gate."
+**Authority:** [ADR-0015](adr/0015-two-tier-onboarding-and-admission-gate.md) (admission gate = identity-level
+approval, mints nothing) · [ADR-0013](adr/0013-sovereign-federation-model.md) (sovereign Model-B; leaf =
+secret-authenticated pipe) · `CONTEXT.md` §"Network-admission gate" + §"Joining a network".
+**Scope:** the two halves of R1 — (1) the admission gate, (2) leaf-secret distribution (the one net-new
+cross-party security surface).
+
+---
+
+## 0. TL;DR for the reviewer
+
+- **Half 1 (admission gate) is ~80% already built.** The `register → PENDING → ADMITTED` state machine, the
+  admin-signed admit/reject/list routes, the D1 + in-memory stores, migration `0007`, and the `cortex network
+  admit` CLI all exist on this branch's base. R1's remaining work is **three small wiring gaps** (§3.2), not a
+  new subsystem.
+- **Half 2 (leaf-secret distribution) is 100% net-new and undesigned.** Today the leaf shared secret is
+  **out-of-band** (ADR-0013 consequence; SOP-federation-onboarding §6). ADR-0015 + `CONTEXT.md` §188 say
+  admission "hands you the leaf shared secret" — but **no mechanism exists**. This doc designs it.
+- **There is a documented tension to resolve** (§7 Q1): ADR-0013 says the leaf secret is "exchanged
+  out-of-band"; ADR-0015/`CONTEXT.md` say it is "handed on admission." These can be reconciled, but the
+  reconciliation **changes the registry's security posture** (today it "signs nothing, holds no secret"). That
+  is the load-bearing decision and the reason this is HELD.
+- **Recommendation (§6):** generate the PSK **hub-side, per-member**, **seal it to the joiner's already-registered
+  pubkey** (sealed-box / X25519), and let the registry carry the *opaque ciphertext* only. The registry never
+  sees plaintext, so the "registry holds no readable secret" invariant survives, proof-of-possession is
+  intrinsic (only the registered private key decrypts), and revoke is per-member. A simpler **concierge
+  out-of-band** path is the acceptable v1 fallback if the sealing plumbing is too heavy for the first slice.
+
+---
+
+## 1. What R1 is (and is not)
+
+R1 repurposes the Model-A `register → PENDING → grant` machinery as an **identity-level admission gate** for a
+private network's roster. Per ADR-0015:
+
+> The `register → PENDING → grant` flow is repurposed as the network-admission gate. … It **mints nothing** — it
+> gates roster membership, not credentials.
+
+So R1 is two things:
+
+1. **The gate** — *who* is let onto a network's roster. A sovereign joiner registers (proof-of-possession of
+   their own key) → raises a PENDING admission request → an admin (or admin-agent, e.g. Luna via FleetAdmit)
+   approves → the joiner is a recognized peer on the roster. **Mints no credential, no account.**
+2. **The one thing that DOES cross the principal boundary on admission** — the **leaf shared secret** (the NATS
+   leafnode `authorization { user, password }` PSK). This is *not* an identity credential (ADR-0013: "the only
+   thing crossing the principal boundary is the leaf shared secret … never an identity credential"), but it IS a
+   secret that must travel from the hub admin to the admitted joiner. Designing that hand-over safely is the
+   substance of R1.
+
+R1 is **not**: minting accounts, issuing `.creds`, or any Model-A machinery (retired under R2). It is **not** the
+NATS-server-side leaf topology config (that is hub-local, provisioned by the hub admin on their own infra) —
+except insofar as the secret the joiner receives must match what the hub's `authorization` block accepts (§5.3).
+
+---
+
+## 2. Two trust layers (why a leaked PSK is bounded)
+
+The whole design rests on ADR-0013's structural-sovereignty point: **the leaf secret is a transport PSK, not an
+identity.** Trust is two-layered (`CONTEXT.md` §188):
+
+| Layer | Artifact | What it grants | What it does NOT grant |
+|---|---|---|---|
+| **Transport** | leaf shared secret (PSK) | attach a leaf link to the hub; carry `federated.>` frames | any identity; any peer's acceptance |
+| **Identity / acceptance** | per-principal `signed_by[]` chain + per-principal accept-policy (`network:<id>` or `principals:[…]`) | being *accepted* by a peer who pinned you / your network | nothing transport-level |
+
+Consequence for the threat model: **a compromised leaf secret lets an attacker attach to the medium and
+publish/subscribe on `federated.>` — but they still cannot forge a signed envelope (no signing key) and cannot be
+*accepted* by any peer who pins principals.** The realistic blast radius of a leaked PSK is therefore:
+**(a) DoS / traffic injection on `federated.>`, and (b) passive observation of federated payloads** — and (b) is
+real because **federation is cleartext-over-TLS in v1** (M3 sealed-payload encryption is designed but deferred,
+`CONTEXT.md` §"Federation confidentiality (v1)"). This is what raises the stakes on the PSK and what makes
+**per-member scope + rotation** worth the cost.
+
+---
+
+## 3. Half 1 — the admission gate
+
+### 3.1 What already exists (composes — file paths)
+
+All on this branch's base (lifted from the Model-A O-4a machinery, transformed by migration `0007`):
+
+| Concern | Where | State |
+|---|---|---|
+| `register` raises a PENDING request | `src/services/network-registry/src/routes/principals.ts` §"O-4a.1 issuance-request hook" (~L206-232) | EXISTS — non-fatal upsert after a successful register |
+| PENDING upsert (idempotent on `principal_id,peer_pubkey`) | `src/services/network-registry/src/store.ts` — `IssuanceRequestStore.upsertPending`, both `InMemoryIssuanceRequestStore` + `D1IssuanceRequestStore` | EXISTS |
+| `PENDING → ADMITTED / REJECTED` admin-signed transition | `src/services/network-registry/src/routes/admission-requests.ts` (`POST …/admit`, `POST …/reject`) | EXISTS |
+| Admin gate (503 not-configured → 401 sig-invalid → 403 not-authorized → nonce-replay → clock-skew) | `admission-requests.ts` `applyAdminGate` + `verifyAdminReadHeader`; reuses `parseAdminPubkeys` / `verifyEd25519` / `canonicalJSON` verbatim from network-create (#747) | EXISTS |
+| Admin-gated list/get (`GET /admission-requests?status=`, `GET /admission-requests/{id}`) | `admission-requests.ts` | EXISTS — admin-only (signed `x-admin-signed` header) |
+| Schema | `migrations/0007_admission_requests.sql` — `admission_requests(request_id, principal_id, peer_pubkey, requested_scope, network_id?, status, created_at, updated_at, granted_by)` | EXISTS |
+| CLI | `src/cli/cortex/commands/network.ts` — `cortex network admit` (signs an admit decision claim; explicitly **no `leaf_package`** — Model-A retired) | EXISTS |
+| Tests | `__tests__/admission-requests.test.ts`, `commands/__tests__/network-admit.test.ts` | EXISTS |
+
+The state machine, the admin gate, and the CLI verb are **done**. R1 does not rebuild them.
+
+### 3.2 What is net-new (the three wiring gaps)
+
+These are the gaps that stop the existing machinery from actually gating *network roster membership*:
+
+**Gap A — the request carries no network.** `register`'s hook calls `upsertPending(principalId, peerPubkey,
+requestedScope)` with **no `network_id`** (the column is nullable and left `NULL`). So a PENDING request is "this
+principal wants in" with no answer to "*into which network?*". R1 must:
+- Let the joiner name the target network at register/request time (`cortex provision-stack register
+  --network <id>` → claim carries `network_id`).
+- Persist it (`upsertPending(principalId, peerPubkey, requestedScope, networkId)`); the column already exists.
+- Make idempotency `(principal_id, peer_pubkey, network_id)` so the same stack can request two networks.
+
+**Gap B — ADMITTED is disconnected from the served roster.** `GET /networks/{id}` builds `members[]` via
+`membersFromPrincipals(...)` in `routes/networks.ts` (~L199) — derived from *announced capabilities listing the
+network*, **not** from ADMITTED status. So today admission "mints nothing" **and gates nothing the descriptor
+serves**. R1 must make the served roster filter on (or be sourced from) ADMITTED admission rows for that
+network. Decision point — see §7 Q3 (filter the derived view vs. make admission the source of truth for
+membership).
+
+**Gap C — the joiner cannot learn they were admitted.** The list/get routes are **admin-only**. A joiner has no
+authenticated way to poll "am I ADMITTED yet?" without an admin key. R1 needs *either* a member proof-of-possession
+read path (`GET /admission-requests/mine` signed by the registered key) *or* an out-of-band notify (Pier DMs
+"you're in") — and this choice is **coupled to the secret-delivery choice** (§6), because the natural place to
+hand the secret is the same place the joiner learns they're admitted.
+
+> None of Gap A/B/C is a new subsystem; each is a few lines + a test. The genuinely hard, net-new, security-bearing
+> work is Half 2.
+
+---
+
+## 4. Half 2 — leaf-secret distribution (the new security surface)
+
+### 4.1 The artifact
+
+The **leaf shared secret** is the NATS leafnode `authorization` password. Two copies exist, functionally:
+
+- **Verifier copy** — in the hub's `nats-server` `leafnodes{ authorization{ user, password } }` block. Hub-local;
+  the hub admin provisions it on their own infra (SOP §6). **Not cross-party.**
+- **Bearer copy** — in the admitted joiner's leaf *remote* (`policy.federated.networks[].nats` / the rendered
+  `leafnodes` remote `password`). The joiner needs this in cleartext to render their leaf. **This is the one copy
+  that must cross the principal boundary.**
+
+"Leaf-secret distribution" = getting the **bearer copy** from the hub admin to the admitted joiner safely, and
+keeping the **verifier copy** in sync (add/rotate/revoke).
+
+### 4.2 Who generates it
+
+The **hub admin** — the principal hosting the leaf hub for that network (for `metafactory`, Andreas). Generation is
+a hub-local act (`cortex network create` already owns hub topology; a `cortex network secret …` verb is the
+natural home). The **registry admin** and the **hub admin** *may* be the same identity but are conceptually
+distinct (§7 Q5).
+
+### 4.3 Scope — per-network vs per-member
+
+| | Per-network (one PSK for the whole roster) | Per-member (one PSK per admitted stack) |
+|---|---|---|
+| Hub config | one `authorization` user | one `authorization` user per member; reload on each admit |
+| Revoke one member | **rotate-all** (every member re-fetches + reloads) | drop that member's user; others untouched |
+| Blast radius of a leak | the whole network's transport | one member's link |
+| Sharing attribution | none (any member's copy is identical) | scoped to the leaking member |
+| v1 cost | trivial | needs hub-side per-admit reload automation |
+
+**Security-first → per-member.** It is the only option with targeted revoke and leak attribution. For a v1 roster
+of 2–3 stacks, **per-network is an acceptable bootstrap** if the per-admit hub reload is judged too heavy for the
+first slice — but the recommendation is to build toward per-member (§7 Q2).
+
+### 4.4 The three delivery options
+
+**(a) In-band via the admitted record** — the secret is embedded in the admission row the joiner reads back on
+approval.
+- Requires Gap-C's member-readable path. If the secret is plaintext in the row, **the registry holds a readable
+  cross-party secret** — it becomes a honeypot, and breaks the `CONTEXT.md` §194 invariant ("the registry … signs
+  nothing", "carries no account-topology material").
+- Replay/exposure window: as long as the row exists at rest.
+- Verdict: only acceptable if the embedded blob is **sealed** (→ becomes option b′).
+
+**(b) Fetched from the registry post-approval (proof-of-possession read)** — a dedicated
+`GET /networks/{id}/leaf-secret` endpoint, released only to an ADMITTED member who signs a PoP claim with their
+registered key.
+- Clean UX; enables Pier to fully automate. But **plaintext at rest in the registry** unless sealed → same
+  honeypot problem as (a). Registry compromise leaks every member's PSK for every network.
+- **(b′) — the strong variant: sealed-secret.** The hub admin, at admit time, **seals** the per-member PSK to the
+  joiner's *already-registered* Ed25519 pubkey (convert to X25519, libsodium `crypto_box_seal` / `age`). The
+  registry stores/serves only the **opaque ciphertext**. Only the holder of the registered private key can
+  decrypt → **proof-of-possession is intrinsic** (no extra auth needed to release the blob; it is useless to
+  anyone else). The registry **never sees plaintext** → the "holds no readable secret" invariant survives (it
+  holds a blob it cannot read, the way it already holds opaque pubkeys). Rotation makes a stale ciphertext inert.
+
+**(c) Out-of-band, via the concierge** — the secret never touches the registry; the hub admin / Pier delivers it
+over the admission channel (e.g. the `#assistant-fleet-onboarding` DM, or a more secure channel named in the DM).
+- Preserves ADR-0013 ("exchanged out-of-band") and the registry-holds-nothing invariant verbatim. Lightest to
+  build (no crypto, no new endpoint).
+- Cost: the PSK transits a third-party platform (Discord DMs are **not** end-to-end encrypted — Discord can read
+  them) unless the concierge deliberately routes it elsewhere; manual-ish; rotation/revoke is a human runbook.
+- The concierge (Pier/Luna) automates the *human* step, so it still "feels" handed-on-admission per ADR-0015.
+
+### 4.5 Side-by-side
+
+| | (a) admitted-record plaintext | (b) registry fetch plaintext | (b′) sealed-to-pubkey | (c) concierge OOB |
+|---|---|---|---|---|
+| Registry holds plaintext secret? | **yes** ❌ | **yes** ❌ | no (ciphertext only) ✅ | no ✅ |
+| PoP enforced? | needs added auth | needs added auth | **intrinsic** ✅ | n/a (human) |
+| Unapproved party can obtain? | if read leaks | if read leaks | no (can't decrypt) ✅ | only via admin misdelivery |
+| Registry compromise leaks secret? | **yes** ❌ | **yes** ❌ | no (only ciphertexts) ✅ | no ✅ |
+| Build cost | low | low | **medium** (sealing) | **lowest** |
+| Preserves ADR-0013 OOB / registry-holds-nothing | no | no | mostly (opaque blob) | **yes** |
+| Pier full-auto delivery | yes | yes | yes | partial (human-in-loop) |
+
+---
+
+## 5. Recommended design
+
+### 5.1 Recommendation
+
+**Adopt (b′) sealed-secret for the target design; ship (c) concierge-OOB as the v1 bootstrap if (b′)'s sealing is
+deferred. Use per-member PSK scope (per-network acceptable only as a 2–3-stack bootstrap).**
+
+Rationale, weighed against Andreas's standing principles:
+- **Security-first:** (b′) keeps the registry out of the readable-secret business (no honeypot), makes PoP
+  intrinsic, and bounds a leak to one member with targeted revoke. The remaining exposure (a member can still
+  hand their own decrypted PSK to a third party) is bounded by the §2 second trust layer and by rotation.
+- **Lightweight / no new infra:** (b′) adds no service — it reuses the registry as an opaque-blob carrier (which
+  is exactly how it already carries pubkeys) and a stdlib sealed-box. (c) adds literally nothing to the registry.
+- **Sovereignty (ADR-0013):** neither (b′) nor (c) puts an identity credential on the wire or in a hub's operator;
+  the PSK stays a transport artifact, the joiner's identity stays in their own NSC operator.
+
+### 5.2 Sequence (register → PENDING → admit → secret-delivery → join)
+
+```
+JOINER (sovereign newcomer)        REGISTRY (network.meta-factory.ai)        HUB ADMIN (Pier / Luna, hub-side)
+──────────────────────────         ─────────────────────────────────        ──────────────────────────────────
+1. provision-stack generate
+   (own NSC operator; own seed)
+2. provision-stack register
+   --network <id>  ───────────────▶ verify proof-of-possession (sig by
+   (pubkey + caps + network_id)      registered key) → store principal
+                                     → upsertPending(principal, peer_pubkey,
+                                       scope, network_id)   [Gap A]
+                                     ◀── 201 signed assertion
+                                                                      (admin polls / Pier notified)
+                                                                      3. GET /admission-requests?status=PENDING
+                                                                         (admin-signed) ──────────────────────▶
+                                     ◀──────────────────────────────────  reviews the request
+4. ADMIT decision:
+   - admin signs admit claim ──────▶ PENDING → ADMITTED, granted_by=admin
+     (network admit)                  [existing route]
+                                                                      5. HUB-LOCAL (the secret half):
+                                                                         - generate/lookup per-member PSK
+                                                                         - add member's `authorization` user to
+                                                                           hub nats-server + reload  [verifier copy]
+                                                                         - SEAL psk to joiner's registered pubkey
+                                          ◀── store sealed blob on the    (b′)  OR  DM the psk OOB (c)
+                                              ADMITTED row / secret endpoint
+6. learn admitted [Gap C] +
+   fetch sealed blob ──────────────▶ release opaque ciphertext (b′:
+                                     no extra auth needed) ──────────▶
+   decrypt with own seed → psk
+7. network join <id> --apply
+   renders leaf remote with
+   password=<psk>, binds to OWN
+   local account, wires export/
+   import, restarts  [existing]
+8. network status → leaf established; peers resolved from roster (now ADMITTED-gated, Gap B)
+```
+
+### 5.3 The hub-side half is local (don't forget it)
+
+Steps 5's "add member `authorization` user + reload" is **hub-local** and is NOT cross-party — it touches the
+hub admin's own `nats-server`. For per-member scope this couples *the registry admit* to *a hub reload*, both
+performed by the same admin-agent (Pier/Luna runs FleetAdmit: signs the registry admit AND updates the hub
+`authorization` + reload). Net-new tooling: a `cortex network secret add-member <network> <member-pubkey>` (mint
+PSK + write the hub `authorization` user + emit the sealed/OOB bearer copy) and `… revoke-member` / `… rotate`.
+
+### 5.4 Composes vs net-new (summary)
+
+**Composes (exists):** the whole `register→PENDING→ADMITTED` state machine + admin gate + admit/reject/list CLI
+(§3.1); `cortex network create` (hub topology); `cortex network join` leaf rendering (already consumes a
+password it has locally); `NetworkRecord`/`NetworkDescriptor`; the registered-pubkey directory (the seal target).
+
+**Net-new:**
+- Gap A: `network_id` on the request (CLI flag + claim field + `upsertPending` signature + idempotency key).
+- Gap B: ADMITTED → served roster (filter `membersFromPrincipals` on ADMITTED, or source membership from
+  admission rows).
+- Gap C: member-readable admitted status (PoP read) and/or Pier OOB notify.
+- Secret generation + hub `authorization` sync: `cortex network secret {add-member,revoke-member,rotate}`.
+- Delivery: (b′) sealed-box seal/unseal (Ed25519→X25519, `crypto_box_seal`/`age`) + a ciphertext-carrying
+  field/endpoint, **or** (c) the concierge OOB runbook (no registry change).
+- Rotation/revoke runbook + the `archive/model-a-hub-minted-creds` reversibility note stays intact.
+
+---
+
+## 6. Security model & threat analysis (secret distribution)
+
+**Assets:** the leaf PSK (bearer + verifier copies). **Adversaries:** an unapproved outsider; an admitted-then-
+malicious member; a registry compromise; a passive network observer.
+
+| Threat | (b′) sealed | (c) concierge OOB |
+|---|---|---|
+| **Unapproved party obtains the secret** | Cannot: the blob is sealed to the registered pubkey; only that private key decrypts. Registering a *different* key yields a blob sealed to a *different* key. PoP is intrinsic. | Cannot, unless the admin misdelivers (human-channel discipline; address in the runbook). |
+| **Registry compromise** | Leaks only **ciphertexts** — useless without member seeds. Invariant "registry holds no readable secret" preserved. | Registry never holds it. |
+| **Approved member replays / shares the secret** | Possible (they hold the plaintext PSK) **but bounded**: per-member scope ⇒ targeted revoke + leak attribution; §2 second layer ⇒ a third party on the pipe still cannot forge a signed envelope or be *accepted* by principal-pinning peers. Residual: passive read of cleartext-over-TLS `federated.>` payloads until rotation (M3 encryption deferred). | Same residual; per-member scope still gives targeted revoke. |
+| **Replay of a stale/rotated secret** | Inert after `rotate`/`revoke-member` (hub drops the `authorization` user); the old sealed blob no longer authenticates. | Same after rotation. |
+| **Man-in-the-middle on delivery** | TLS to the registry + the seal: even a TLS break yields only the ciphertext. | Depends on the OOB channel — **Discord DMs are not E2E**; prefer a named secure channel for the PSK, or move to (b′). |
+| **Exposure window at rest** | Ciphertext at rest indefinitely is fine (opaque). Plaintext exists only transiently on hub + joiner. | No registry at-rest; transient in the DM channel's history (a real residual — Discord retains DM history). |
+
+**Net security posture:** (b′) is strictly stronger on the at-rest and MITM axes; (c) is strictly simpler and
+keeps the registry untouched but pushes the secret through a non-E2E human channel. Both rely on the §2 second
+trust layer to bound a *shared* secret, and both want **per-member scope** + **rotation** to make revoke real and
+to cap the cleartext-payload-observation residual that exists until M3 payload encryption ships.
+
+---
+
+## 7. Open questions / decisions for Andreas (prioritized)
+
+**Q1 — [LOAD-BEARING] Where does the leaf secret live in transit: sealed-through-the-registry (b′) or
+out-of-band-via-concierge (c)?** This is the decision that gates the build. It reconciles the documented tension
+between **ADR-0013** ("the leaf secret … exchanged out-of-band") and **ADR-0015 / CONTEXT.md §188** ("admission …
+hands you the leaf shared secret"). It also decides whether the **registry's posture changes** from
+"identity-only, holds no secret" to "carries an opaque per-member ciphertext." Recommendation: **(b′) as target,
+(c) as v1 bootstrap.** If you pick (b′), we should add a one-line amendment to ADR-0013's "out-of-band" consequence
+noting the sealed-blob carrier is still not a cross-operator trust act.
+
+**Q2 — Per-member or per-network PSK scope?** Recommendation: **per-member** (targeted revoke + attribution),
+with per-network tolerated only as a 2–3-stack bootstrap. Per-member costs a hub `authorization`-reload on each
+admit (Pier automates it). Confirm you want the per-admit hub-reload coupling.
+
+**Q3 — How does ADMITTED become roster membership (Gap B)?** Two sub-options: (i) keep the derived
+`membersFromPrincipals` view but **filter it to ADMITTED** rows for that network, or (ii) make the admission table
+the **source of truth** for `members[]`. (i) is smaller; (ii) is cleaner but reworks the descriptor's
+membership source. Recommendation: **(i) for R1**, revisit (ii) if the derived view proves confusing.
+
+**Q4 — How does a joiner learn they're admitted (Gap C)?** A member PoP read endpoint (`GET
+/admission-requests/mine`, signed by the registered key) vs. **Pier OOB notify**. Couples to Q1: if (b′), the same
+PoP read naturally also serves the sealed blob; if (c), Pier already DMs them, so no new endpoint. Recommendation:
+**follow Q1** (b′ ⇒ add the PoP read; c ⇒ no endpoint).
+
+**Q5 — Is the hub admin the same identity as the registry admin?** Today `REGISTRY_ADMIN_PUBKEYS` gates the admit
+decision; the hub admin generates the PSK + edits the hub nats config. For `metafactory` both are Andreas/Luna, so
+they collapse — but the design should not *assume* it. Confirm whether R1 may assume "admit authority ⊇ hub-secret
+authority," or must keep them separable (matters if a future network's registry admin ≠ its hub host).
+
+**Q6 — Rotation cadence + revoke trigger.** No rotation policy exists. Minimum: `rotate` on suspected leak and on
+`network leave`/revoke. Recommendation: ship `secret rotate` + `revoke-member` in R1 (revoke is meaningless
+without them); a *scheduled* rotation cadence can be a follow-up.
+
+**Q7 — Does the cleartext-over-TLS `federated.>` residual (M3 deferred) change the priority of payload
+encryption?** A leaked-but-revoked PSK still permitted passive payload reads while it was live. If that residual
+is unacceptable for the community/3rd-party case, it pulls M3 sealed-payload (`docs/design-envelope-encryption.md`)
+forward. Flagging, not proposing — out of R1 scope, but the threat model surfaces it.
+
+---
+
+## 8. Build order (once Q1 is decided — NOT yet authorized)
+
+1. Gap A (`network_id` on the request) — unblocks "join *which* network."
+2. Gap B (ADMITTED → roster) — makes the gate actually gate.
+3. Secret tooling: `cortex network secret {add-member,revoke-member,rotate}` (hub-local verifier copy).
+4. Delivery per Q1: (b′) seal + ciphertext field + member PoP read (also closes Gap C), **or** (c) concierge OOB
+   runbook + Pier notify (closes Gap C without an endpoint).
+5. Wire into Pier (P1) so admit + secret-delivery is one concierge action (FleetAdmit Tier-2).
+
+Each slice is small and independently testable. **Held until Q1.**

--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -201,6 +201,13 @@ ALLOWLIST_PATHS=(
   # account-tree root, never the principal. Class: NSC.
   # RETIRE: never (NSC operator is the permanent qualified survivor, CONTEXT.md).
   'docs/adr/0015-two-tier-onboarding-and-admission-gate.md'
+  # ADR-0018 companion design — network-admission gate + leaf-secret distribution
+  # (the supplementary design ADR-0018 ratifies). Same sovereign-federation subject
+  # as ADR-0013/0015: every "operator" is the NSC operator (the NATS account-tree
+  # root the joiner keeps — the leaf PSK never crosses into a hub's operator),
+  # never the principal. Class: NSC.
+  # RETIRE: never (NSC operator is the permanent qualified survivor, CONTEXT.md).
+  'docs/design-admission-gate-leaf-secret.md'
   # ADR-0015 companion runbook — retired leaf-cred issuance runbook (Model-A, now
   # tombstoned). Its body carries legacy NSC operator issuance steps as historical
   # reference; the tombstone header also uses "NSC operator" in its summary of what

--- a/src/bus/__tests__/stack-provisioning.test.ts
+++ b/src/bus/__tests__/stack-provisioning.test.ts
@@ -43,8 +43,13 @@ import registryApp from "../../services/network-registry/src/index";
 import type { Env } from "../../services/network-registry/src/index";
 import {
   makeRegistryKey,
+  makePrincipalKey,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
   resetStores,
+  type PrincipalKey,
 } from "../../services/network-registry/__tests__/helpers";
+import type { AdmissionRequest } from "../../services/network-registry/src/types";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -467,30 +472,71 @@ describe("C-787 / C-791 — fetchExistingStacks (verified read side of add-stack
 });
 
 // =============================================================================
-// C-819 — capability merge-preserve (stop silent roster eviction)
+// C-819 — capability merge-preserve across re-register (ADR-0018 Gap-B model)
 // =============================================================================
 //
 // The register route does a FULL-OVERWRITE upsert of the `capabilities` column
 // (store.ts: `capabilities = excluded.capabilities`), identical to the stacks
-// column. Roster membership is IMPLICIT: a principal is "in" network X iff one
-// of its announced capabilities lists X in `capability.networks[]`. So a bare
-// re-register whose claim carries NO capabilities silently zeroes the set and
-// evicts the principal from every roster. `resolveMergedCapabilities` is the
-// capability twin of `resolveMergedStacks`: on the add-stack path it fetches
-// the (verified) existing set and unions the announce in, so an EMPTY announce
-// preserves the existing caps unchanged. These tests pin both the unit merge
-// semantics AND the end-to-end roster-survival behaviour against the real route.
+// column. `resolveMergedCapabilities` is the capability twin of
+// `resolveMergedStacks`: on the add-stack path it fetches the (verified)
+// existing set and unions the announce in, so an EMPTY announce preserves the
+// existing caps unchanged. That cap-merge behaviour is the C-819 concern and is
+// STILL valid — pinned by the unit tests below.
+//
+// What CHANGED (ADR-0018 Gap-B / Q3=ii): roster membership is no longer
+// capability-derived. The served roster `members[]` is now sourced from
+// ADMITTED admission rows, NOT from `capability.networks[]`. So the old
+// coupling "a caps-wipe evicts the principal from every roster" no longer
+// holds — membership and capabilities are independent facets. A principal is
+// "in" network X iff they hold an ADMITTED admission row for X; wiping their
+// caps (e.g. via a bare re-register) cannot evict an admitted member, and a
+// principal with caps-but-no-ADMITTED-row is NOT on the roster. The
+// silent-eviction footgun C-819 worked around is now structurally impossible.
+// These tests pin (a) the cap-merge semantics, and (b) that an ADMITTED
+// member's roster membership survives a bare re-register because it is
+// admission-derived, independent of the cap set.
 describe("C-819 — resolveMergedCapabilities preserves caps across re-register", () => {
   let registryPubkey = "";
+  let adminKey: PrincipalKey | undefined;
   async function configuredEnv(): Promise<Env> {
     resetStores();
     const reg = await makeRegistryKey();
     registryPubkey = reg.publicKey;
+    adminKey = await makePrincipalKey();
     return {
       REGISTRY_SIGNING_KEY: reg.signingKey,
       REGISTRY_PUBLIC_KEY: reg.publicKey,
+      REGISTRY_ADMIN_PUBKEYS: adminKey.publicKeyB64,
       ENVIRONMENT: "test",
     };
+  }
+
+  /**
+   * ADR-0018 Gap-B — admit the principal's PENDING request for `networkId` so
+   * they appear on the (admission-sourced) roster. Membership is no longer
+   * capability-derived; an admit is required.
+   */
+  async function admitInto(env: Env, principalId: string, networkId: string): Promise<void> {
+    const read = await makeSignedAdminRead(adminKey!);
+    const listRes = await registryApp.fetch(
+      new Request("http://registry.test/admission-requests?status=PENDING", {
+        headers: { "x-admin-signed": JSON.stringify(read) },
+      }),
+      env,
+    );
+    const list = (await listRes.json()) as AdmissionRequest[];
+    const req = list.find((r) => r.principal_id === principalId && r.network_id === networkId);
+    expect(req).toBeDefined();
+    const decision = await makeSignedAdminDecision(req!.request_id, "admit", adminKey!);
+    const admitRes = await registryApp.fetch(
+      new Request(`http://registry.test/admission-requests/${req!.request_id}/admit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(decision),
+      }),
+      env,
+    );
+    expect(admitRes.status).toBe(200);
   }
 
   function registryFetch(env: Env): typeof globalThis.fetch {
@@ -524,7 +570,9 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
 
   /**
    * Seed principal `jc` with a single stack that announces a `community-net`
-   * capability — so JC lands on the `community-net` roster (the live repro:
+   * capability AND targets `community-net` for admission (ADR-0018 Gap-A), then
+   * ADMIT the resulting PENDING request (Gap-B) — so JC lands on the
+   * `community-net` roster via an ADMITTED row (the live repro:
    * `metafactory-community` listed `jc`). Returns the root material so a later
    * re-register can sign as the same root (the rotation gate requires it).
    */
@@ -537,16 +585,22 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
       capabilities: [
         { id: "tasks.code-review", description: "JC reviews", networks: ["community-net"] },
       ],
+      // ADR-0018 Gap-A — name the target network so a PENDING admission row is
+      // raised for it; Gap-B then sources roster membership from the ADMITTED row.
+      networkId: "community-net",
     });
     await post(env, "/principals/jc/register", body);
+    // ADR-0018 Gap-B — admit JC into community-net so they are on the roster.
+    await admitInto(env, "jc", "community-net");
     return root;
   }
 
-  test("ACCEPTANCE — a bare add-stack register (empty announce) preserves JC's caps + roster membership", async () => {
+  test("ACCEPTANCE — a bare add-stack register (empty announce) preserves JC's caps + admission-derived roster membership", async () => {
     const env = await configuredEnv();
     const root = await seedJcWithCommunityCaps(env);
 
-    // Precondition: JC is on the community roster.
+    // Precondition: JC is on the community roster — via an ADMITTED row
+    // (ADR-0018 Gap-B), not via the announced capability.
     expect(await rosterMembers(env, "community-net")).toEqual(["jc"]);
 
     // Now stand up `jc/clawbox` (the live repro). It is a SECOND stack added by
@@ -579,14 +633,21 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
     const res = await post(env, "/principals/jc/register", body);
     expect(res.status).toBe(201);
 
-    // The footgun is closed: JC is STILL on the community roster.
+    // JC is STILL on the community roster — the bare re-register left JC's
+    // ADMITTED community-net row untouched (membership is admission-derived,
+    // ADR-0018 Gap-B), and the cap-merge preserved the capability facet too.
     expect(await rosterMembers(env, "community-net")).toEqual(["jc"]);
   });
 
-  test("REGRESSION GUARD — WITHOUT the merge (empty caps claim), the route DOES wipe + evict", async () => {
-    // Proves the merge is load-bearing: the same re-register WITHOUT
-    // resolveMergedCapabilities (empty caps in the claim) zeroes the set and
-    // evicts JC. This is the bug; the test above is the fix.
+  test("REGRESSION GUARD — under Gap-B a caps-wipe does NOT evict an ADMITTED member (silent eviction structurally impossible)", async () => {
+    // Pre-ADR-0018 this same re-register (empty caps claim → full-overwrite to
+    // []) zeroed JC's cap set AND evicted JC from every roster, because
+    // membership was capability-derived. Under ADR-0018 Gap-B membership is
+    // ADMITTED-derived and INDEPENDENT of caps: the cap-overwrite still happens
+    // (the cap facet is wiped), but JC's ADMITTED community-net row is untouched
+    // so JC stays on the roster. The silent-eviction footgun is now structurally
+    // impossible. (The cap-merge in the ACCEPTANCE test remains load-bearing for
+    // preserving the capability FACET — proven here by the caps actually wiping.)
     const env = await configuredEnv();
     const root = await seedJcWithCommunityCaps(env);
     expect(await rosterMembers(env, "community-net")).toEqual(["jc"]);
@@ -601,8 +662,21 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
     });
     const res = await post(env, "/principals/jc/register", body);
     expect(res.status).toBe(201);
-    // Roster eviction reproduced (jc → empty).
-    expect(await rosterMembers(env, "community-net")).toEqual([]);
+
+    // The cap FACET was wiped (full-overwrite to empty) — this is the behaviour
+    // the ACCEPTANCE test's merge guards against for the capability set.
+    const getRes = await registryApp.fetch(
+      new Request("http://registry.test/principals/jc"),
+      env,
+    );
+    const principal = (await getRes.json()) as {
+      payload: { capabilities: { id: string }[] };
+    };
+    expect(principal.payload.capabilities).toEqual([]);
+
+    // But roster membership is ADMITTED-derived → the caps-wipe did NOT evict
+    // JC. The old "caps-wipe → roster eviction" coupling no longer holds.
+    expect(await rosterMembers(env, "community-net")).toEqual(["jc"]);
   });
 
   test("union — a NEW announce is added, existing unrelated caps are kept (same-id new wins)", async () => {

--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -119,6 +119,13 @@ export interface RegistrationClaimShape {
   capabilities: { id: string; description?: string; networks?: string[] }[];
   /** #825 — optimistic-concurrency CAS token (record `updated_at` the merge read). */
   expected_updated_at?: string;
+  /**
+   * ADR-0018 Gap-A — the target network this registration requests admission
+   * into. Stamped onto the PENDING admission row by the register hook so a stack
+   * can request admission to two networks (per-network idempotency). Optional: a
+   * plain identity register (not a join) omits it. Part of the SIGNED claim.
+   */
+  network_id?: string;
   issued_at: string;
   nonce: string;
 }
@@ -402,6 +409,13 @@ export interface BuildRegistrationClaimOptions {
    * register / when no existing record was read.
    */
   readonly expectedUpdatedAt?: string;
+  /**
+   * ADR-0018 Gap-A — the target network this registration requests admission
+   * into. When set, it is signed into the claim as `network_id`; the register
+   * hook stamps it onto the PENDING admission row (per-network idempotency). Omit
+   * for a plain identity register that names no network.
+   */
+  readonly networkId?: string;
 }
 
 /**
@@ -440,6 +454,7 @@ export async function buildRegistrationClaim(
     stacks,
     capabilities: opts.capabilities ?? [],
     ...(opts.expectedUpdatedAt !== undefined && { expected_updated_at: opts.expectedUpdatedAt }),
+    ...(opts.networkId !== undefined && { network_id: opts.networkId }),
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
   };

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -40,7 +40,9 @@ import {
   InMemoryRegistryStore,
   rosterFromPrincipals,
   membersFromPrincipals,
+  rosterFromAdmissions,
 } from "../../../../services/network-registry/src/store";
+import type { AdmissionRequest } from "../../../../services/network-registry/src/types";
 import registryApp from "../../../../services/network-registry/src/index";
 import type { Env } from "../../../../services/network-registry/src/index";
 import {
@@ -1330,6 +1332,9 @@ describe("#762 registerStack announces capabilities into the network", () => {
       principal_pubkey: string;
       stacks: { stack_id: string }[];
       capabilities: { id: string; networks?: string[] }[];
+      // ADR-0018 Gap-A/Gap-B (BLOCK-1) — the register hook stamps this onto the
+      // PENDING admission row; the federated join MUST set it.
+      network_id?: string;
     };
   }
 
@@ -1419,6 +1424,61 @@ describe("#762 registerStack announces capabilities into the network", () => {
       expect(roster.members[0]?.capabilities).toEqual(["chat", "release"]);
     });
   });
+
+    // ADR-0018 Gap-A/Gap-B (BLOCK-1) — the REAL join producer
+    // (`registerStack` → `registerWithCapabilities` → `buildRegistrationClaim`)
+    // MUST pin the registration to the joined network (`network_id`), or the
+    // register hook raises a network-LESS PENDING row that can never enter the
+    // named-network roster — even after an admin `admit`.
+    test("a real join pins the claim to network_id → ADMITTED row lands in rosterFromAdmissions", async () => {
+      const dir = freshDir();
+      const seedPath = join(dir, "jc.nk");
+      generateStackIdentity({ seedPath });
+
+      await withFetchCapture(async (capture) => {
+        const ports = buildLivePorts(cfgWithSeed(seedPath, ["chat"]));
+        const res = await ports.registry.registerStack();
+        expect(res.ok).toBe(true);
+
+        const claim = capture.last!.claim;
+        // The join is network-PINNED (NOT null/undefined) — this is the BLOCK-1 fix.
+        expect(claim.network_id).toBe("metafactory");
+
+        // PROOF the pinned row, once ADMITTED, lands in the admission-sourced
+        // roster. Mirror the register hook: store the principal, raise the
+        // (now network-pinned) admission row, admit it, derive the roster.
+        const store = new InMemoryRegistryStore();
+        await store.putPrincipal(
+          claim.principal_id,
+          claim.principal_pubkey,
+          claim.stacks,
+          claim.capabilities,
+        );
+        const admitted: AdmissionRequest[] = [
+          {
+            request_id: "req-1",
+            principal_id: claim.principal_id,
+            peer_pubkey: claim.principal_pubkey,
+            requested_scope: `federated.${claim.principal_id}.>`,
+            network_id: claim.network_id!, // the pinned network
+            status: "ADMITTED",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            granted_by: "admin-pubkey",
+          },
+        ];
+        const principals = await store.listPrincipals();
+        const roster = rosterFromAdmissions(admitted, principals, "metafactory");
+        expect(roster.members.map((m) => m.principal_id)).toEqual(["jc"]);
+        expect(roster.members[0]?.capabilities).toEqual(["chat"]);
+
+        // CONTROL — had the join NOT pinned the network (the pre-fix bug), the
+        // same admission machinery with a network-less row yields an EMPTY
+        // roster: proof the pin is load-bearing, not incidental.
+        const networkless: AdmissionRequest[] = [{ ...admitted[0]!, network_id: null }];
+        expect(rosterFromAdmissions(networkless, principals, "metafactory").members).toEqual([]);
+      });
+    });
 
   test("a cap targeting ANOTHER network is NOT in this network's roster", async () => {
     const store = new InMemoryRegistryStore();

--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -32,8 +32,13 @@ import registryApp from "../../../../services/network-registry/src/index";
 import type { Env } from "../../../../services/network-registry/src/index";
 import {
   makeRegistryKey,
+  makePrincipalKey,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
   resetStores,
+  type PrincipalKey,
 } from "../../../../services/network-registry/__tests__/helpers";
+import type { AdmissionRequest } from "../../../../services/network-registry/src/types";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -239,15 +244,46 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
   // the registry pubkey. We keep it alongside the env so each test can pass it
   // via --registry-pubkey.
   let registryPubkey = "";
+  let adminKey: PrincipalKey | undefined;
   async function configuredEnv(): Promise<Env> {
     resetStores();
     const reg = await makeRegistryKey();
     registryPubkey = reg.publicKey;
+    adminKey = await makePrincipalKey();
     return {
       REGISTRY_SIGNING_KEY: reg.signingKey,
       REGISTRY_PUBLIC_KEY: reg.publicKey,
+      REGISTRY_ADMIN_PUBKEYS: adminKey.publicKeyB64,
       ENVIRONMENT: "test",
     };
+  }
+
+  /**
+   * ADR-0018 Gap-B — admit the principal's PENDING request for `networkId` so
+   * they appear on the (admission-sourced) roster. Membership is no longer
+   * capability-derived; an admit is required.
+   */
+  async function admitInto(env: Env, principalId: string, networkId: string): Promise<void> {
+    const read = await makeSignedAdminRead(adminKey!);
+    const listRes = await registryApp.fetch(
+      new Request("http://registry.test/admission-requests?status=PENDING", {
+        headers: { "x-admin-signed": JSON.stringify(read) },
+      }),
+      env,
+    );
+    const list = (await listRes.json()) as AdmissionRequest[];
+    const req = list.find((r) => r.principal_id === principalId && r.network_id === networkId);
+    expect(req).toBeDefined();
+    const decision = await makeSignedAdminDecision(req!.request_id, "admit", adminKey!);
+    const admitRes = await registryApp.fetch(
+      new Request(`http://registry.test/admission-requests/${req!.request_id}/admit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(decision),
+      }),
+      env,
+    );
+    expect(admitRes.status).toBe(200);
   }
 
   /** Route the CLI's global fetch at the in-memory registry app for `env`. */
@@ -328,6 +364,65 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
     } finally {
       restore();
     }
+  });
+
+  test("ADR-0018 Gap-A — register --network pins the PENDING admission request to the network", async () => {
+    const env = await configuredEnv();
+    const dir = freshDir();
+    const seed = join(dir, "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seed]);
+
+    const restore = routeFetchToRegistry(env);
+    try {
+      const res = await dispatchProvisionStack([
+        "register",
+        "andreas",
+        "--seed-path",
+        seed,
+        "--stack-id",
+        "andreas/meta-factory",
+        "--registry-url",
+        "http://registry.test",
+        "--network",
+        "research-collab",
+      ]);
+      expect(res.exitCode).toBe(0);
+
+      // The admission request created by the register hook carries network_id.
+      const read = await makeSignedAdminRead(adminKey!);
+      const listRes = await registryApp.fetch(
+        new Request("http://registry.test/admission-requests?status=PENDING", {
+          headers: { "x-admin-signed": JSON.stringify(read) },
+        }),
+        env,
+      );
+      const list = (await listRes.json()) as AdmissionRequest[];
+      const andreas = list.filter((r) => r.principal_id === "andreas");
+      expect(andreas.length).toBe(1);
+      expect(andreas[0]!.network_id).toBe("research-collab");
+    } finally {
+      restore();
+    }
+  });
+
+  test("ADR-0018 Gap-A — register rejects a malformed --network (exit 2, no POST)", async () => {
+    const env = await configuredEnv();
+    const dir = freshDir();
+    const seed = join(dir, "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seed]);
+    const res = await dispatchProvisionStack([
+      "register",
+      "andreas",
+      "--seed-path",
+      seed,
+      "--registry-url",
+      "http://registry.test",
+      "--network",
+      "Bad_Net",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toMatch(/--network/);
+    void env;
   });
 
   test("first registration (principal absent) still works — fetch+merge degrades to just the new stack", async () => {
@@ -429,6 +524,8 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
         capabilities: [
           { id: "tasks.code-review", description: "JC reviews", networks: ["community-net"] },
         ],
+        // ADR-0018 Gap-A — name the target network so admission is pinned to it.
+        networkId: "community-net",
       });
       const seedRes = await registryApp.fetch(
         new Request("http://registry.test/principals/jc/register", {
@@ -439,6 +536,9 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
         env,
       );
       expect(seedRes.status).toBe(201);
+      // ADR-0018 Gap-B — admit JC into community-net so they appear on the
+      // (admission-sourced) roster.
+      await admitInto(env, "jc", "community-net");
 
       // Precondition: JC is on the community roster.
       const rosterBefore = await registryApp.fetch(
@@ -462,7 +562,11 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
       ]);
       expect(add.exitCode).toBe(0);
 
-      // 3. JC's caps survived → JC is STILL on the community roster (footgun closed).
+      // 3. JC's admission survived the add-stack re-register → JC is STILL on the
+      //    community roster (ADR-0018 Gap-B: membership is admission-sourced; the
+      //    add-stack register raises a separate network-less PENDING row and does
+      //    not disturb the ADMITTED community-net row). Caps preservation (the
+      //    C-819 footgun) is asserted directly on the principal record below.
       const rosterAfter = await registryApp.fetch(
         new Request("http://registry.test/networks/community-net/roster"),
         env,

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -158,12 +158,14 @@ export interface LivePortsConfig {
   /**
    * #762 — the capability ids this stack announces INTO `networkId`, sourced
    * from the network's `announce_capabilities[]` policy block. The federated
-   * `registerStack` step announces these to the registry with
-   * `networks: [networkId]` so the principal joins the network's roster
-   * (`membersFromPrincipals` — implicit membership via `capability.networks[]`).
-   * Empty/absent → the stack registers with no capability targeting the network
-   * (the pre-#762 behaviour that left the roster empty); the join then warns and
-   * preserves any existing hand-pins rather than wiping them.
+   * `registerStack` step announces these to the registry tagged
+   * `networks: [networkId]`. Under ADR-0018 Gap-B these caps NO LONGER confer
+   * roster membership (that is now ADMITTED-derived — `rosterFromAdmissions`);
+   * they are the member's capability FACET, surfaced in the roster once the
+   * principal's network-pinned admission row is ADMITTED. Empty/absent → the
+   * stack still requests admission (the join names `networkId`) but advertises
+   * no capability for it; the join warns and preserves any existing hand-pins
+   * rather than wiping them.
    */
   announceCapabilities?: string[];
   /**
@@ -250,6 +252,20 @@ async function registerWithCapabilities(
    * of `deregisterCapabilities` is to shrink it to empty), so it must NOT union.
    */
   mergeExistingCaps = false,
+  /**
+   * ADR-0018 Gap-A/Gap-B (BLOCK-1) — the target network this registration
+   * REQUESTS ADMISSION INTO. When set, it is signed into the claim as
+   * `network_id`; the registry's register hook stamps it onto the PENDING
+   * admission row, so a `cortex network join <X>` writes a network-PINNED
+   * (`network_id = X`) PENDING row that an admin `admit` can promote to an
+   * ADMITTED row in network X's roster (`rosterFromAdmissions`). Only the
+   * FEDERATED join (`registerStack`) passes this — `cfg.networkId`. The
+   * public-index announce/deregister paths and the leave re-attestation pass
+   * the default `undefined`: they must NOT raise a network-admission request (a
+   * de-advertise / a LEAVE is not a join). Omitted → a network-less identity
+   * register (the pre-ADR-0018 row), exactly as before.
+   */
+  networkId?: string,
 ): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
   const url = cfg.registryUrl ?? "";
   const registryPubkey = cfg.registryPubkey;
@@ -331,6 +347,11 @@ async function registerWithCapabilities(
     // #825 — CAS token: the updated_at the merge read. The route 409s on a
     // concurrent change so two hosts joining/registering can't lost-update.
     ...(stacksRes.existingUpdatedAt !== undefined && { expectedUpdatedAt: stacksRes.existingUpdatedAt }),
+    // ADR-0018 Gap-A/Gap-B (BLOCK-1) — pin the join's PENDING admission row to
+    // the target network so an admin `admit` lands the principal in network
+    // `networkId`'s `rosterFromAdmissions`. Only the federated `registerStack`
+    // passes a `networkId`; the announce/deregister/leave paths omit it.
+    ...(networkId !== undefined && { networkId }),
   });
   let result;
   try {
@@ -353,15 +374,20 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
 
   return {
     async registerStack() {
-      // #762 — federated register MUST announce the stack's declared
-      // capabilities INTO this network so the principal joins the network's
-      // roster. Roster membership is implicit (`membersFromPrincipals`): a
-      // principal is "in" `networkId` iff one of its announced capabilities
-      // lists `networkId` in `capability.networks[]`. The pre-#762 code
-      // registered with an EMPTY capability list — the principal appeared at
-      // `/principals/{id}` but never in `/networks/{networkId}/roster`, so a
-      // registry-resolved join wrote 0 peers (and risked wiping a working
-      // hand-pin). We tag each announced capability with `networks: [networkId]`.
+      // ADR-0018 Gap-B (BLOCK-1/N3) — roster membership is NO LONGER implicit in
+      // the announced capabilities. Under Gap-B a principal is "in" `networkId`
+      // iff they hold an ADMITTED admission row for it (`rosterFromAdmissions`);
+      // the announced caps are an orthogonal FACET ("what an admitted member
+      // offers"), joined on top of membership. So this register does TWO things:
+      //   1. names the target network (`networkId` below) so the register hook
+      //      raises a network-PINNED PENDING admission row an admin can `admit`
+      //      (the actual roster-membership lever); and
+      //   2. tags each announced cap with `networks: [networkId]` so that, ONCE
+      //      ADMITTED, the member's capability facet surfaces in the roster.
+      //
+      // #762 history: the pre-#762 code registered with an EMPTY capability list
+      // AND no network_id, so the principal never entered the network's roster
+      // and a registry-resolved join wrote 0 peers (risking a hand-pin wipe).
       //
       // This is a registry CONTROL-PLANE action (a signed HTTP POST to
       // /principals/.../register), NOT a `federated.*` wire envelope — the
@@ -377,7 +403,12 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
       // (4th arg `true`), decoupled from the root seed: a plain re-join into a
       // SECOND network must accumulate `networks[]` (metafactory ∪ community),
       // not clobber the prior tag and evict the principal from that roster.
-      return registerWithCapabilities(cfg, announced, true, true);
+      // ADR-0018 Gap-A/Gap-B (BLOCK-1) — 5th arg `cfg.networkId` pins the join's
+      // PENDING admission row to the joined network so `admit` lands it on that
+      // network's `rosterFromAdmissions`. WITHOUT this the join writes a
+      // network-less (`network_id = null`) row that can NEVER enter the named
+      // roster — even after `admit`.
+      return registerWithCapabilities(cfg, announced, true, true, cfg.networkId);
     },
     fetchVerified(networkId) {
       // S1's fetchAndCache returns { descriptor, roster } on ok and refreshes

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -77,6 +77,8 @@ type ProvisionSubcommand = "generate" | "claim" | "register";
 
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 const STACK_ID_RE = /^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/;
+/** ADR-0018 Gap-A — network id grammar (mirrors the registry's NETWORK_ID_RE). */
+const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
 
 const SPEC: SubcommandSpec<ProvisionSubcommand> = {
   cliName: "provision-stack",
@@ -89,6 +91,9 @@ const SPEC: SubcommandSpec<ProvisionSubcommand> = {
         "--force": "bool",
         "--register": "bool",
         "--registry-url": "value",
+        // ADR-0018 Gap-A — name the target network when registering, so the
+        // PENDING admission request is pinned to it.
+        "--network": "value",
       },
     },
     claim: {
@@ -113,6 +118,10 @@ const SPEC: SubcommandSpec<ProvisionSubcommand> = {
         // drives the destructive full-overwrite re-attestation, so a
         // compromised registry can't omit a stack and cause a silent drop.
         "--registry-pubkey": "value",
+        // ADR-0018 Gap-A — the target network this registration requests
+        // admission into. Signed into the claim; the register hook stamps it
+        // onto the PENDING admission row (per-network idempotency).
+        "--network": "value",
       },
     },
   },
@@ -148,6 +157,27 @@ function resolveStackId(
     };
   }
   return { ok: true, stackId: stackIdFlag };
+}
+
+/**
+ * ADR-0018 Gap-A — resolve the optional `--network <id>` flag. Returns the
+ * validated network id, `undefined` when the flag is absent (a plain register
+ * that names no network), or an error result on a malformed value.
+ */
+function resolveNetworkId(
+  networkFlag: string | true | string[] | undefined,
+): { ok: true; networkId: string | undefined } | { ok: false; reason: string } {
+  if (networkFlag === undefined) return { ok: true, networkId: undefined };
+  if (networkFlag === true || typeof networkFlag !== "string") {
+    return { ok: false, reason: "--network requires a value" };
+  }
+  if (!NETWORK_ID_RE.test(networkFlag)) {
+    return {
+      ok: false,
+      reason: `--network "${networkFlag}" must be a valid network id (lowercase, letter-prefixed)`,
+    };
+  }
+  return { ok: true, networkId: networkFlag };
 }
 
 /** Pull a required value-flag; returns the string or an error result. */
@@ -224,7 +254,17 @@ async function runGenerate(ctx: HandlerCtx): Promise<ExitResult> {
     if (!urlRes.ok) {
       return usageError("generate", `--register also needs ${urlRes.reason}`, ctx.json);
     }
-    const reg = await doRegister(ctx.principalId, material, stackIdRes.stackId, urlRes.value);
+    const networkRes = resolveNetworkId(ctx.flags["--network"]);
+    if (!networkRes.ok) return usageError("generate", networkRes.reason, ctx.json);
+    const reg = await doRegister(
+      ctx.principalId,
+      material,
+      stackIdRes.stackId,
+      urlRes.value,
+      undefined,
+      undefined,
+      networkRes.networkId,
+    );
     if (!reg.ok) return opError(reg.reason, ctx.json, { fingerprint: material.fingerprint });
     registerNote = reg.note;
   }
@@ -331,6 +371,10 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
     registryPubkey = pubkeyFlag;
   }
 
+  // ADR-0018 Gap-A — optional target network for the admission request.
+  const networkRes = resolveNetworkId(ctx.flags["--network"]);
+  if (!networkRes.ok) return usageError("register", networkRes.reason, ctx.json);
+
   const reg = await doRegister(
     ctx.principalId,
     matRes.material,
@@ -338,6 +382,7 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
     urlRes.value,
     rootMaterial,
     registryPubkey,
+    networkRes.networkId,
   );
   if (!reg.ok) return opError(reg.reason, ctx.json, { fingerprint: matRes.material.fingerprint });
 
@@ -361,6 +406,7 @@ async function doRegister(
   registryUrl: string,
   rootMaterial?: StackIdentityMaterial,
   registryPubkey?: string,
+  networkId?: string,
 ): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
   // C-787 — build the COMPLETE intended `stacks[]`. The register route does a
   // FULL-OVERWRITE upsert of the `stacks` column with no read-merge, so a claim
@@ -425,6 +471,8 @@ async function doRegister(
       // #825 — CAS token: the updated_at the merge read. The route rejects
       // (409 stale_record) if a concurrent host changed the row since.
       ...(stacksRes.existingUpdatedAt !== undefined && { expectedUpdatedAt: stacksRes.existingUpdatedAt }),
+      // ADR-0018 Gap-A — pin the PENDING admission request to the target network.
+      ...(networkId !== undefined && { networkId }),
     });
   } catch (err) {
     return { ok: false, reason: `failed to build registration claim: ${err instanceof Error ? err.message : String(err)}` };
@@ -534,9 +582,9 @@ function topLevelHelp(): string {
   return `cortex provision-stack — stack-identity provisioning (TC-1b, #632)
 
 Usage:
-  cortex provision-stack generate <principal-id> --seed-path <path> [--stack-id <id>] [--force] [--register --registry-url <url>] [--json]
+  cortex provision-stack generate <principal-id> --seed-path <path> [--stack-id <id>] [--force] [--register --registry-url <url> [--network <id>]] [--json]
   cortex provision-stack claim    <principal-id> --seed-path <path> [--stack-id <id>] [--json]
-  cortex provision-stack register <principal-id> --seed-path <path> --registry-url <url> [--stack-id <id>] [--principal-seed <root-path> --registry-pubkey <b64>] [--json]
+  cortex provision-stack register <principal-id> --seed-path <path> --registry-url <url> [--network <id>] [--stack-id <id>] [--principal-seed <root-path> --registry-pubkey <b64>] [--json]
 
 Subcommands:
   generate   Generate a fresh NKey signing identity; write seed chmod 600
@@ -553,6 +601,9 @@ Flags:
   --force                Allow overwriting an existing seed (DELIBERATE rotation).
   --register             (generate only) also register the pubkey after generating.
   --registry-url <url>   Network-registry base URL for registration.
+  --network <id>         (register, ADR-0018) Target network to request admission
+                         into. Pins the PENDING admission request to this network
+                         so a stack can request admission to two networks.
   --principal-seed <p>   (register, #787) The principal ROOT seed (the FIRST
                          stack's seed) for adding a SECOND+ stack. The add-stack
                          claim is then root-signed; --seed-path is the new

--- a/src/services/network-registry/__tests__/admission-wiring.test.ts
+++ b/src/services/network-registry/__tests__/admission-wiring.test.ts
@@ -1,0 +1,306 @@
+/**
+ * ADR-0018 PR5a — admission-gate wiring tests.
+ *
+ * Gap A — network_id on the admission request:
+ *   - a register carrying `network_id` persists it on the PENDING row
+ *   - idempotency is now per-network: the SAME stack requesting TWO networks
+ *     creates TWO distinct rows; re-requesting the SAME network is idempotent
+ *   - a network-less register still dedupes on (principal, peer)
+ *
+ * Gap C — member proof-of-possession read (`GET /admission-requests/mine`):
+ *   - a member who signs with their REGISTERED key reads ONLY their own rows
+ *   - the response carries a `sealed_secret` slot (null in PR5a)
+ *   - a wrong-key signature → 401; a missing header → 400 (no metadata leak)
+ *   - rows are scoped to the proven pubkey — never another member's queue
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
+  randomNonce,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import type { AdmissionRequest } from "../src/types";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+
+let env: Env;
+let admin: PrincipalKey;
+let principal: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, headers: Record<string, string> = {}, e: Env = env): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+/** Admin-list PENDING admission requests (helper for Gap-A assertions). */
+async function listPending(): Promise<AdmissionRequest[]> {
+  const read = await makeSignedAdminRead(admin);
+  const res = await get("/admission-requests?status=PENDING", {
+    "x-admin-signed": JSON.stringify(read),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as AdmissionRequest[];
+}
+
+/**
+ * Build a member proof-of-possession read for `GET /admission-requests/mine`.
+ * Signed with the member's REGISTERED key (the signature IS the authorization).
+ */
+async function makeSignedMineRead(
+  principalId: string,
+  memberKey: PrincipalKey,
+  opts: { peerPubkeyOverride?: string; signWith?: PrincipalKey; issuedAt?: string } = {},
+): Promise<{ claim: { principal_id: string; peer_pubkey: string; issued_at: string }; signature: string }> {
+  const claim = {
+    principal_id: principalId,
+    peer_pubkey: opts.peerPubkeyOverride ?? memberKey.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signer = opts.signWith ?? memberKey;
+  const signature = await signEd25519(signer.privateKeyB64, message);
+  return { claim, signature };
+}
+
+beforeEach(async () => {
+  resetStores();
+  _resetRateLimitBucketsForTest();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  principal = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// Gap A — network_id persisted + per-network idempotency
+// =============================================================================
+
+describe("ADR-0018 Gap-A — network_id on the admission request", () => {
+  test("a register naming a network persists network_id on the PENDING row", async () => {
+    const res = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    expect(res.status).toBe(201);
+
+    const pending = await listPending();
+    const alice = pending.filter((r) => r.principal_id === "alice");
+    expect(alice.length).toBe(1);
+    expect(alice[0]!.network_id).toBe("net-a");
+  });
+
+  test("the same stack requesting TWO networks creates TWO distinct rows", async () => {
+    await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-b" }),
+    );
+
+    const pending = await listPending();
+    const alice = pending.filter((r) => r.principal_id === "alice");
+    expect(alice.length).toBe(2);
+    expect(alice.map((r) => r.network_id).sort()).toEqual(["net-a", "net-b"]);
+    // Distinct request_ids — the second network did not collide with the first.
+    expect(new Set(alice.map((r) => r.request_id)).size).toBe(2);
+  });
+
+  test("re-requesting the SAME network is idempotent (same request_id)", async () => {
+    const r1 = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    expect(r1.status).toBe(201);
+    const first = (await listPending()).find((r) => r.principal_id === "alice" && r.network_id === "net-a");
+    expect(first).toBeDefined();
+
+    const r2 = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    expect(r2.status).toBe(201);
+
+    const aliceNetA = (await listPending()).filter(
+      (r) => r.principal_id === "alice" && r.network_id === "net-a",
+    );
+    expect(aliceNetA.length).toBe(1);
+    expect(aliceNetA[0]!.request_id).toBe(first!.request_id);
+  });
+
+  test("a network-less register still dedupes on (principal, peer)", async () => {
+    await post("/principals/alice/register", await makeSignedRegistration("alice", principal));
+    await post("/principals/alice/register", await makeSignedRegistration("alice", principal));
+
+    const alice = (await listPending()).filter((r) => r.principal_id === "alice");
+    expect(alice.length).toBe(1);
+    expect(alice[0]!.network_id).toBeNull();
+  });
+
+  test("a malformed network_id is rejected (signed claim, 400)", async () => {
+    const res = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "Bad_Network" }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+// =============================================================================
+// Gap C — member proof-of-possession read endpoint
+// =============================================================================
+
+describe("ADR-0018 Gap-C — GET /admission-requests/mine (member PoP read)", () => {
+  test("a member signing with their registered key reads their own rows", async () => {
+    await post(
+      "/principals/carol/register",
+      await makeSignedRegistration("carol", principal, { networkId: "net-a" }),
+    );
+
+    const read = await makeSignedMineRead("carol", principal);
+    const res = await get("/admission-requests/mine", { "x-pop-signed": JSON.stringify(read) });
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as (AdmissionRequest & { sealed_secret: string | null })[];
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.principal_id).toBe("carol");
+    expect(rows[0]!.peer_pubkey).toBe(principal.publicKeyB64);
+    expect(rows[0]!.status).toBe("PENDING");
+    // PR5a — the sealed_secret slot is present but empty (PR5b populates it).
+    expect(rows[0]!).toHaveProperty("sealed_secret");
+    expect(rows[0]!.sealed_secret).toBeNull();
+  });
+
+  test("reflects status across networks after an admit", async () => {
+    await post(
+      "/principals/carol/register",
+      await makeSignedRegistration("carol", principal, { networkId: "net-a" }),
+    );
+    await post(
+      "/principals/carol/register",
+      await makeSignedRegistration("carol", principal, { networkId: "net-b" }),
+    );
+    // Admit the net-a request.
+    const pending = (await listPending()).filter((r) => r.principal_id === "carol");
+    const netA = pending.find((r) => r.network_id === "net-a")!;
+    const decision = await makeSignedAdminDecision(netA.request_id, "admit", admin);
+    await post(`/admission-requests/${netA.request_id}/admit`, decision);
+
+    const read = await makeSignedMineRead("carol", principal);
+    const res = await get("/admission-requests/mine", { "x-pop-signed": JSON.stringify(read) });
+    const rows = (await res.json()) as AdmissionRequest[];
+    expect(rows.length).toBe(2);
+    const byNet = new Map(rows.map((r) => [r.network_id, r.status]));
+    expect(byNet.get("net-a")).toBe("ADMITTED");
+    expect(byNet.get("net-b")).toBe("PENDING");
+  });
+
+  test("returns ONLY the caller's own rows, never another member's", async () => {
+    const other = await makePrincipalKey();
+    await post(
+      "/principals/carol/register",
+      await makeSignedRegistration("carol", principal, { networkId: "net-a" }),
+    );
+    await post(
+      "/principals/dave/register",
+      await makeSignedRegistration("dave", other, { networkId: "net-a" }),
+    );
+
+    const read = await makeSignedMineRead("carol", principal);
+    const res = await get("/admission-requests/mine", { "x-pop-signed": JSON.stringify(read) });
+    const rows = (await res.json()) as AdmissionRequest[];
+    expect(rows.every((r) => r.peer_pubkey === principal.publicKeyB64)).toBe(true);
+    expect(rows.some((r) => r.principal_id === "dave")).toBe(false);
+  });
+
+  test("a signature from the WRONG key → 401 (signature IS the authorization)", async () => {
+    await post(
+      "/principals/carol/register",
+      await makeSignedRegistration("carol", principal, { networkId: "net-a" }),
+    );
+    const attacker = await makePrincipalKey();
+    // Claims carol's registered pubkey but signs with the attacker's key.
+    const forged = await makeSignedMineRead("carol", principal, { signWith: attacker });
+    const res = await get("/admission-requests/mine", { "x-pop-signed": JSON.stringify(forged) });
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("signature_invalid");
+  });
+
+  test("a missing x-pop-signed header → 400 (no metadata leak)", async () => {
+    const res = await get("/admission-requests/mine");
+    expect(res.status).toBe(400);
+  });
+
+  test("a malformed x-pop-signed header → 400", async () => {
+    const res = await get("/admission-requests/mine", { "x-pop-signed": "{not json" });
+    expect(res.status).toBe(400);
+  });
+
+  test("an out-of-skew read token → 400", async () => {
+    await post(
+      "/principals/carol/register",
+      await makeSignedRegistration("carol", principal, { networkId: "net-a" }),
+    );
+    const old = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const stale = await makeSignedMineRead("carol", principal, { issuedAt: old });
+    const res = await get("/admission-requests/mine", { "x-pop-signed": JSON.stringify(stale) });
+    expect(res.status).toBe(400);
+  });
+
+  test("requires no admin key — works with no allowlist configured", async () => {
+    // The member PoP read is NOT an admin path: it must function even when the
+    // registry has no admin allowlist (the signature is the only authority).
+    const reg = await makeRegistryKey();
+    const noAdmin: Env = {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+    await post(
+      "/principals/carol/register",
+      await makeSignedRegistration("carol", principal, { networkId: "net-a" }),
+      noAdmin,
+    );
+    const read = await makeSignedMineRead("carol", principal);
+    const res = await get(
+      "/admission-requests/mine",
+      { "x-pop-signed": JSON.stringify(read) },
+      noAdmin,
+    );
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as AdmissionRequest[];
+    expect(rows.length).toBe(1);
+  });
+
+  test("'mine' is not swallowed by the :request_id param route", async () => {
+    // A bare GET /admission-requests/mine must hit the PoP route (400 missing
+    // header), NOT the admin :request_id route (which would 400 invalid_request_id
+    // or, with a valid-looking id, require an admin header).
+    const res = await get("/admission-requests/mine");
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("x-pop-signed header required");
+  });
+});

--- a/src/services/network-registry/__tests__/d1-mock.ts
+++ b/src/services/network-registry/__tests__/d1-mock.ts
@@ -97,7 +97,11 @@ export class MockD1 {
   readonly nonces = new Map<string, number>();
   /** Keyed by request_id */
   readonly issuanceRequests = new Map<string, IssuanceRequestRow>();
-  /** Maps (principal_id + "\x00" + peer_pubkey) → request_id for the unique constraint */
+  /**
+   * Maps (principal_id + "\x00" + peer_pubkey + "\x00" + COALESCE(network_id,''))
+   * → request_id for the ADR-0018 Gap-A per-network unique constraint (mirrors
+   * the `COALESCE(network_id, '')` expression index in migration 0008).
+   */
   private readonly issuancePeerIndex = new Map<string, string>();
 
   /** Count of writes, exposed so tests can assert query activity if needed. */
@@ -198,14 +202,15 @@ export class MockD1 {
       return { meta: { changes: n } };
     }
 
-    // admission_requests: INSERT ... ON CONFLICT(principal_id, peer_pubkey) DO NOTHING
-    // (M3 atomic upsert — D1IssuanceRequestStore.upsertPending, ADR-0015)
+    // admission_requests: INSERT ... ON CONFLICT(principal_id, peer_pubkey,
+    // COALESCE(network_id, '')) DO NOTHING (ADR-0018 Gap-A per-network upsert —
+    // D1IssuanceRequestStore.upsertPending)
     if (sql.startsWith("INSERT INTO admission_requests")) {
       const [requestId, principalId, peerPubkey, requestedScope, networkId, createdAt, updatedAt] = args as [
         string, string, string, string, string | null, string, string,
       ];
-      const peerKey = `${principalId}\x00${peerPubkey}`;
-      // ON CONFLICT(principal_id, peer_pubkey) DO NOTHING — idempotent.
+      const peerKey = `${principalId}\x00${peerPubkey}\x00${networkId ?? ""}`;
+      // ON CONFLICT(principal_id, peer_pubkey, COALESCE(network_id,'')) DO NOTHING.
       if (this.issuancePeerIndex.has(peerKey)) {
         return { meta: { changes: 0 } }; // existing row wins, no-op
       }
@@ -288,14 +293,25 @@ export class MockD1 {
       return row ? [row] : [];
     }
 
-    // admission_requests: SELECT by (principal_id, peer_pubkey)
+    // admission_requests: SELECT by (principal_id, peer_pubkey, COALESCE(network_id,''))
+    // (ADR-0018 Gap-A per-network select after upsert)
     if (sql.includes("FROM admission_requests WHERE principal_id = ? AND peer_pubkey =")) {
-      const [principalId, peerPubkey] = args as [string, string];
-      const key = `${principalId}\x00${peerPubkey}`;
+      const [principalId, peerPubkey, networkId] = args as [string, string, string | null];
+      const key = `${principalId}\x00${peerPubkey}\x00${networkId ?? ""}`;
       const requestId = this.issuancePeerIndex.get(key);
       if (!requestId) return [];
       const row = this.issuanceRequests.get(requestId);
       return row ? [row] : [];
+    }
+
+    // admission_requests: SELECT by peer_pubkey ORDER BY created_at
+    // (ADR-0018 Gap-C member PoP-read — listIssuanceRequestsByPeer). Checked
+    // BEFORE the status branch since both start "FROM admission_requests WHERE".
+    if (sql.includes("FROM admission_requests WHERE peer_pubkey =")) {
+      const peerPubkey = args[0] as string;
+      return [...this.issuanceRequests.values()]
+        .filter((r) => r.peer_pubkey === peerPubkey)
+        .sort((a, b) => a.created_at.localeCompare(b.created_at));
     }
 
     // admission_requests: SELECT by status ORDER BY created_at

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -77,6 +77,8 @@ export async function makeSignedRegistration(
     signWith?: PrincipalKey;
     /** #825 — optimistic-concurrency CAS token signed into the claim. */
     expectedUpdatedAt?: string;
+    /** ADR-0018 Gap-A — target network signed into the claim (pins admission). */
+    networkId?: string;
   } = {},
 ): Promise<{ claim: RegistrationClaim; signature: string }> {
   const claim: RegistrationClaim = {
@@ -85,6 +87,7 @@ export async function makeSignedRegistration(
     stacks: opts.stacks ?? [],
     capabilities: opts.capabilities ?? [],
     ...(opts.expectedUpdatedAt !== undefined && { expected_updated_at: opts.expectedUpdatedAt }),
+    ...(opts.networkId !== undefined && { network_id: opts.networkId }),
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
   };

--- a/src/services/network-registry/__tests__/migration-0009.test.ts
+++ b/src/services/network-registry/__tests__/migration-0009.test.ts
@@ -1,0 +1,166 @@
+/**
+ * ADR-0018 Gap-B (BLOCK-2) — migration 0009 backfill test.
+ *
+ * Runs the real SQL chain (0001 → 0004 → 0007 → 0008 → 0009) against
+ * `bun:sqlite` (D1 is SQLite under the hood) and proves the backfill
+ * grandfathers EXISTING capability-derived roster members into ADMITTED
+ * admission rows WITHOUT granting any new access:
+ *   - a principal whose `capabilities[].networks[]` names network X gets an
+ *     ADMITTED row pinned to X → appears in `rosterFromAdmissions`;
+ *   - a principal with NO capability targeting X gets NO row → absent;
+ *   - the backfill is idempotent (re-run inserts nothing — the 0008 unique
+ *     index on `(principal_id, peer_pubkey, COALESCE(network_id,''))`);
+ *   - a pre-existing ADMITTED row (peer_pubkey = principal pubkey) is not
+ *     duplicated.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { rosterFromAdmissions } from "../src/store";
+import type { AdmissionRequest, PrincipalRecord } from "../src/types";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "..", "migrations");
+
+let db: Database;
+
+function applyThrough0008(): void {
+  for (const f of [
+    "0001_init.sql",
+    "0004_issuance_requests.sql",
+    "0007_admission_requests.sql",
+    "0008_admission_network_idempotency.sql",
+  ]) {
+    db.run(readFileSync(join(migrationsDir, f), "utf8"));
+  }
+}
+
+function runBackfill(): void {
+  db.run(
+    readFileSync(
+      join(migrationsDir, "0009_backfill_admitted_from_capabilities.sql"),
+      "utf8",
+    ),
+  );
+}
+
+function insertPrincipal(
+  principalId: string,
+  pubkey: string,
+  capabilities: { id: string; networks?: string[] }[],
+): void {
+  db.run(
+    `INSERT INTO principals (principal_id, principal_pubkey, stacks, capabilities, updated_at)
+       VALUES (?, ?, '[]', ?, ?)`,
+    [principalId, pubkey, JSON.stringify(capabilities), "2026-01-01T00:00:00Z"],
+  );
+}
+
+/** Read all admission rows out of SQLite as typed AdmissionRequest[]. */
+function admissionRows(): AdmissionRequest[] {
+  return db
+    .query(
+      `SELECT request_id, principal_id, peer_pubkey, requested_scope, network_id,
+              status, created_at, updated_at, granted_by
+         FROM admission_requests`,
+    )
+    .all() as AdmissionRequest[];
+}
+
+/** Read all principals out of SQLite as typed PrincipalRecord[]. */
+function principalRecords(): PrincipalRecord[] {
+  const rows = db
+    .query(`SELECT principal_id, principal_pubkey, stacks, capabilities, updated_at FROM principals`)
+    .all() as {
+    principal_id: string;
+    principal_pubkey: string;
+    stacks: string;
+    capabilities: string;
+    updated_at: string;
+  }[];
+  return rows.map((r) => ({
+    principal_id: r.principal_id,
+    principal_pubkey: r.principal_pubkey,
+    stacks: JSON.parse(r.stacks),
+    capabilities: JSON.parse(r.capabilities),
+    updated_at: r.updated_at,
+  }));
+}
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  applyThrough0008();
+});
+
+describe("migration 0009 — backfill ADMITTED rows from capability membership", () => {
+  test("grandfathers a capability-networks[] member; a non-member is excluded", () => {
+    // jc is a roster member of net-a (and net-b) via its announced caps.
+    insertPrincipal("jc", "pk-jc", [
+      { id: "tasks.review", networks: ["net-a", "net-b"] },
+      { id: "tasks.deploy", networks: ["net-a"] },
+      { id: "tasks.noop" }, // no networks key — contributes no admission row
+    ]);
+    // andreas announces a cap with an EMPTY networks[] → member of NO network.
+    insertPrincipal("andreas", "pk-an", [{ id: "chat", networks: [] }]);
+    // bob targets a DIFFERENT network only.
+    insertPrincipal("bob", "pk-bob", [{ id: "chat", networks: ["other-net"] }]);
+
+    runBackfill();
+
+    const rows = admissionRows();
+    // jc → one ADMITTED row per targeted network; andreas → none; bob → other-net only.
+    const jcRows = rows.filter((r) => r.principal_id === "jc");
+    expect(jcRows.map((r) => r.network_id).sort()).toEqual(["net-a", "net-b"]);
+    for (const r of jcRows) {
+      expect(r.status).toBe("ADMITTED");
+      expect(r.peer_pubkey).toBe("pk-jc"); // peer_pubkey = principal pubkey
+      expect(r.requested_scope).toBe("federated.jc.>");
+      expect(r.granted_by).toBe("backfill:0009-grandfather"); // system marker, not admin
+    }
+    expect(rows.some((r) => r.principal_id === "andreas")).toBe(false);
+
+    // The cutover behaviour: rosterFromAdmissions over the backfilled rows
+    // reproduces the capability-derived membership exactly.
+    const admitted = admissionRows();
+    const principals = principalRecords();
+    const rosterA = rosterFromAdmissions(admitted, principals, "net-a");
+    expect(rosterA.members.map((m) => m.principal_id)).toEqual(["jc"]);
+    // SECURITY: a non-member (andreas) never enters the roster — no new access.
+    expect(rosterA.members.some((m) => m.principal_id === "andreas")).toBe(false);
+    // bob (other-net only) is NOT in net-a, but IS in other-net.
+    expect(rosterA.members.some((m) => m.principal_id === "bob")).toBe(false);
+    expect(
+      rosterFromAdmissions(admitted, principals, "other-net").members.map((m) => m.principal_id),
+    ).toEqual(["bob"]);
+
+    // The capability FACET is carried through onto the admitted member.
+    expect(rosterA.members[0]?.capabilities.sort()).toEqual(["tasks.deploy", "tasks.review"]);
+  });
+
+  test("idempotent — re-running the backfill inserts no duplicate rows", () => {
+    insertPrincipal("jc", "pk-jc", [{ id: "tasks.review", networks: ["net-a"] }]);
+    runBackfill();
+    const first = admissionRows().length;
+    expect(first).toBe(1);
+    runBackfill();
+    expect(admissionRows().length).toBe(first);
+  });
+
+  test("does not duplicate a pre-existing ADMITTED row for the same triple", () => {
+    insertPrincipal("jc", "pk-jc", [{ id: "tasks.review", networks: ["net-a"] }]);
+    // A real admission already exists for (jc, pk-jc, net-a).
+    db.run(
+      `INSERT INTO admission_requests
+         (request_id, principal_id, peer_pubkey, requested_scope, network_id, status, created_at, updated_at, granted_by)
+       VALUES ('real-id', 'jc', 'pk-jc', 'federated.jc.>', 'net-a', 'ADMITTED', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'admin-pubkey')`,
+    );
+    runBackfill();
+    const rows = admissionRows().filter((r) => r.principal_id === "jc" && r.network_id === "net-a");
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.request_id).toBe("real-id"); // the real row survives untouched
+    expect(rows[0]?.granted_by).toBe("admin-pubkey");
+  });
+});

--- a/src/services/network-registry/__tests__/networks.test.ts
+++ b/src/services/network-registry/__tests__/networks.test.ts
@@ -9,18 +9,23 @@ import {
   makePrincipalKey,
   makeRegistryKey,
   makeSignedRegistration,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
   resetStores,
   type PrincipalKey,
 } from "./helpers";
 import { canonicalJSON, verifyEd25519 } from "../src/signing";
 import { getStore } from "../src/store";
 import type {
+  AdmissionRequest,
+  Capability,
   NetworkDescriptor,
   NetworkRoster,
   SignedAssertion,
 } from "../src/types";
 
 let env: Env;
+let admin: PrincipalKey;
 
 async function post(path: string, body: unknown): Promise<Response> {
   return app.fetch(
@@ -33,16 +38,46 @@ async function post(path: string, body: unknown): Promise<Response> {
   );
 }
 
-async function get(path: string): Promise<Response> {
-  return app.fetch(new Request(`http://localhost${path}`), env);
+async function get(path: string, headers: Record<string, string> = {}): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), env);
+}
+
+/**
+ * ADR-0018 Gap-B — register a principal targeting `networkId`, then ADMIT the
+ * resulting PENDING request. After this the principal is a member of the network
+ * (admission is the source of truth). `capabilities` are the optional facet.
+ */
+async function registerAndAdmit(
+  principalId: string,
+  pKey: PrincipalKey,
+  networkId: string,
+  capabilities: Capability[] = [],
+): Promise<void> {
+  const reg = await post(
+    `/principals/${principalId}/register`,
+    await makeSignedRegistration(principalId, pKey, { networkId, capabilities }),
+  );
+  expect(reg.status).toBe(201);
+  const read = await makeSignedAdminRead(admin);
+  const listRes = await get("/admission-requests?status=PENDING", {
+    "x-admin-signed": JSON.stringify(read),
+  });
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const req = list.find((r) => r.principal_id === principalId && r.network_id === networkId);
+  expect(req).toBeDefined();
+  const decision = await makeSignedAdminDecision(req!.request_id, "admit", admin);
+  const admitRes = await post(`/admission-requests/${req!.request_id}/admit`, decision);
+  expect(admitRes.status).toBe(200);
 }
 
 beforeEach(async () => {
   resetStores();
   const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
   env = {
     REGISTRY_SIGNING_KEY: reg.signingKey,
     REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
     ENVIRONMENT: "test",
   };
 });
@@ -61,33 +96,25 @@ describe("GET /networks/:id/roster", () => {
     expect(json.payload.members).toEqual([]);
   });
 
-  test("aggregates principals whose capabilities target the network", async () => {
+  test("aggregates ADMITTED principals for the network, joining capabilities as a facet (ADR-0018 Gap-B)", async () => {
     const pA: PrincipalKey = await makePrincipalKey();
     const pB: PrincipalKey = await makePrincipalKey();
     const pC: PrincipalKey = await makePrincipalKey();
 
-    await post(
-      "/principals/alpha/register",
-      await makeSignedRegistration("alpha", pA, {
-        capabilities: [
-          { id: "tasks.code-review", networks: ["research-collab"] },
-          { id: "tasks.docs-edit", networks: ["docs-net"] },
-        ],
-      }),
-    );
-    await post(
-      "/principals/beta/register",
-      await makeSignedRegistration("beta", pB, {
-        capabilities: [{ id: "tasks.code-review", networks: ["research-collab"] }],
-      }),
-    );
-    // Gamma announces to a different network only — should be excluded.
-    await post(
-      "/principals/gamma/register",
-      await makeSignedRegistration("gamma", pC, {
-        capabilities: [{ id: "tasks.code-review", networks: ["other-net"] }],
-      }),
-    );
+    // alpha + beta are ADMITTED into research-collab — they appear.
+    await registerAndAdmit("alpha", pA, "research-collab", [
+      { id: "tasks.code-review", networks: ["research-collab"] },
+      { id: "tasks.docs-edit", networks: ["docs-net"] },
+    ]);
+    await registerAndAdmit("beta", pB, "research-collab", [
+      { id: "tasks.code-review", networks: ["research-collab"] },
+    ]);
+    // gamma ANNOUNCES a capability targeting research-collab but is NOT admitted
+    // into it (admitted into other-net instead). Capabilities no longer confer
+    // membership — gamma must be EXCLUDED.
+    await registerAndAdmit("gamma", pC, "other-net", [
+      { id: "tasks.code-review", networks: ["research-collab"] },
+    ]);
 
     const res = await get("/networks/research-collab/roster");
     expect(res.status).toBe(200);
@@ -186,32 +213,23 @@ describe("GET /networks/:id — descriptor (DD-12)", () => {
     expect(ok).toBe(true);
   });
 
-  test("members[] is derived from the roster (implicit membership)", async () => {
+  test("members[] is sourced from ADMITTED admission rows (ADR-0018 Gap-B)", async () => {
     await seedNetwork("research-collab", "tls://hub:7422", 7422);
 
     const pA: PrincipalKey = await makePrincipalKey();
     const pB: PrincipalKey = await makePrincipalKey();
     const pC: PrincipalKey = await makePrincipalKey();
 
-    await post(
-      "/principals/alpha/register",
-      await makeSignedRegistration("alpha", pA, {
-        capabilities: [{ id: "tasks.code-review", networks: ["research-collab"] }],
-      }),
-    );
-    await post(
-      "/principals/beta/register",
-      await makeSignedRegistration("beta", pB, {
-        capabilities: [{ id: "tasks.docs-edit", networks: ["research-collab"] }],
-      }),
-    );
-    // Gamma targets a different network — must NOT appear in members.
-    await post(
-      "/principals/gamma/register",
-      await makeSignedRegistration("gamma", pC, {
-        capabilities: [{ id: "tasks.code-review", networks: ["other-net"] }],
-      }),
-    );
+    // alpha + beta ADMITTED into research-collab; beta carries NO matching
+    // capability — an admitted-but-no-capability principal still appears.
+    await registerAndAdmit("alpha", pA, "research-collab", [
+      { id: "tasks.code-review", networks: ["research-collab"] },
+    ]);
+    await registerAndAdmit("beta", pB, "research-collab", []);
+    // gamma admitted into a DIFFERENT network — must NOT appear in members.
+    await registerAndAdmit("gamma", pC, "other-net", [
+      { id: "tasks.code-review", networks: ["other-net"] },
+    ]);
 
     const res = await get("/networks/research-collab");
     const json = (await res.json()) as SignedAssertion<NetworkDescriptor>;

--- a/src/services/network-registry/__tests__/rate-limit.test.ts
+++ b/src/services/network-registry/__tests__/rate-limit.test.ts
@@ -20,6 +20,8 @@ import {
   makePrincipalKey,
   makeRegistryKey,
   makeSignedRegistration,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
   resetStores,
   type PrincipalKey,
 } from "./helpers";
@@ -27,17 +29,20 @@ import {
   RATE_LIMITS,
   type RateLimitBinding,
 } from "../src/rate-limit";
-import type { SignedAssertion, PrincipalRecord } from "../src/types";
+import type { AdmissionRequest, SignedAssertion, PrincipalRecord } from "../src/types";
 
 let env: Env;
 let pKey: PrincipalKey;
+let admin: PrincipalKey;
 
 beforeEach(async () => {
   resetStores();
   const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
   env = {
     REGISTRY_SIGNING_KEY: reg.signingKey,
     REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
     ENVIRONMENT: "test",
   };
   pKey = await makePrincipalKey();
@@ -311,9 +316,31 @@ describe("#681 enumeration policy (dev = prod)", () => {
     await postRegister(
       "andreas",
       await makeSignedRegistration("andreas", pKey, {
+        networkId: "research-collab",
         capabilities: [{ id: "tasks.code-review", networks: ["research-collab"] }],
       }),
       "198.51.100.21",
+    );
+    // ADR-0018 Gap-B — membership is now admission-sourced; admit andreas into
+    // research-collab so the roster has a member (the shape is unchanged).
+    const read = await makeSignedAdminRead(admin);
+    const pendRes = await fetchApp(
+      reqWith("/admission-requests?status=PENDING", {
+        ip: "198.51.100.22",
+        headers: { "x-admin-signed": JSON.stringify(read) },
+      }),
+    );
+    const pend = (await pendRes.json()) as AdmissionRequest[];
+    const req = pend.find((r) => r.principal_id === "andreas" && r.network_id === "research-collab");
+    expect(req).toBeDefined();
+    const decision = await makeSignedAdminDecision(req!.request_id, "admit", admin);
+    await fetchApp(
+      reqWith(`/admission-requests/${req!.request_id}/admit`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(decision),
+        ip: "198.51.100.23",
+      }),
     );
 
     // roster: { network_id, members[] } with principal_id + pubkey + capabilities.

--- a/src/services/network-registry/migrations/0008_admission_network_idempotency.sql
+++ b/src/services/network-registry/migrations/0008_admission_network_idempotency.sql
@@ -1,0 +1,36 @@
+-- ADR-0018 Gap-A — per-network admission idempotency.
+--
+-- Background
+-- ──────────
+-- Migration 0007 created `admission_requests` with a unique index on
+-- `(principal_id, peer_pubkey)` — one admission row per (principal, peer). That
+-- pre-dates the network-admission gate naming the TARGET network: under
+-- ADR-0018 the joiner names the network at register time (`network_id`), and a
+-- single stack may request admission to TWO networks. The old index would make
+-- the second network's register collide with the first (ON CONFLICT DO NOTHING
+-- returns the first network's row), silently dropping the second request.
+--
+-- This migration re-keys idempotency to the TRIPLE
+-- `(principal_id, peer_pubkey, COALESCE(network_id, ''))`:
+--   - two DISTINCT networks for the same (principal, peer) are two distinct rows;
+--   - a network-less register (NULL network_id — a plain identity register, not
+--     a join) still dedupes, because `COALESCE(network_id, '')` normalises NULL
+--     to '' (SQLite would otherwise treat each raw NULL as distinct and re-insert
+--     a duplicate PENDING row on every re-register). This preserves the
+--     pre-ADR-0018 `(principal_id, peer_pubkey)` idempotency for that path.
+--
+-- The `network_id` column itself already exists (added nullable in 0007); this
+-- migration only swaps the unique index. The application-layer upsert
+-- (`D1IssuanceRequestStore.upsertPending`) targets the matching expression:
+--   ON CONFLICT(principal_id, peer_pubkey, COALESCE(network_id, '')) DO NOTHING.
+--
+-- Safety: index-only change; no row rewrite. The registry is not yet deployed
+-- at this schema version, so there are no live rows to migrate.
+
+-- Drop the old (principal_id, peer_pubkey) idempotency index.
+DROP INDEX IF EXISTS idx_admission_requests_peer;
+
+-- Re-create idempotency on the per-network triple. The COALESCE expression makes
+-- the index NULL-safe so a network-less register dedupes on (principal, peer).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_admission_requests_peer_network
+  ON admission_requests (principal_id, peer_pubkey, COALESCE(network_id, ''));

--- a/src/services/network-registry/migrations/0009_backfill_admitted_from_capabilities.sql
+++ b/src/services/network-registry/migrations/0009_backfill_admitted_from_capabilities.sql
@@ -1,0 +1,74 @@
+-- ADR-0018 Gap-B (BLOCK-2) — backfill: grandfather existing capability-derived
+-- roster members into ADMITTED admission rows.
+--
+-- Background
+-- ──────────
+-- Gap-B flips the SERVED roster source (`GET /networks/{id}` descriptor +
+-- `/roster`) from the capability-derived view (`membersFromPrincipals` — a
+-- principal is "in" network X iff one of its announced capabilities lists X in
+-- `capability.networks[]`) to the admission-derived view (`rosterFromAdmissions`
+-- — a principal is "in" X iff they hold an ADMITTED `admission_requests` row
+-- pinned to X).
+--
+-- Today's LIVE members are on the roster ONLY via the capability path; none hold
+-- an ADMITTED admission row (the admit step + `network_id` stamping are NEW —
+-- BLOCK-1). Without this backfill, the roster-source cutover would return an
+-- EMPTY roster on deploy, and the federation reconciler (which projects roster
+-- members → leaf peers) would wire 0 peers — the exact #762 hand-pin-wipe /
+-- federation-outage failure. This migration materialises the existing
+-- capability membership as ADMITTED rows so the cutover preserves the live
+-- roster byte-for-byte.
+--
+-- ⚠️ DEPLOY SEQUENCING — this migration MUST be applied on the registry deploy
+-- that ships the Gap-B roster-source switch (it is the data half of that change).
+-- Applying the code without this migration empties the live roster.
+--
+-- Security
+-- ────────
+-- This grandfathers ONLY principals ALREADY on the roster under the retired
+-- capability rule — i.e. those whose registered `capabilities[].networks[]`
+-- already names the network. It grants NO new access: every (principal, network)
+-- pair it admits was already a roster member a moment before the cutover. A
+-- principal with no capability targeting a network gets NO row (and stays off
+-- that roster). `granted_by` is a system/backfill marker, not an admin pubkey,
+-- so the provenance of these rows is auditable and distinguishable from a real
+-- admin admission.
+--
+-- Idempotency
+-- ───────────
+-- `INSERT OR IGNORE` respects the 0008 unique index
+-- `(principal_id, peer_pubkey, COALESCE(network_id, ''))`: re-running this
+-- migration (or running it after some members were admitted for real) inserts
+-- nothing for a (principal, peer, network) triple that already has a row. The
+-- `peer_pubkey` is the principal's own pubkey (matching the register hook's
+-- default when a claim carries no stacks); roster membership is keyed on
+-- `principal_id` + `network_id` (`rosterFromAdmissions` dedupes per principal),
+-- so a backfilled row and a later real admission row never double-count.
+--
+-- `requested_scope` mirrors the register hook (`federated.<principal>.>`).
+-- `created_at`/`updated_at` are the migration instant (ISO-8601 UTC, matching
+-- the `new Date().toISOString()` shape the application layer writes).
+--
+-- Implementation note: `capabilities` is a JSON text column; we walk it with
+-- `json_each` and explode each capability's `networks[]` array, grouping to one
+-- ADMITTED row per (principal, network). `json_each(NULL)` (a capability with no
+-- `networks` key) yields no rows, so caps without a network target contribute
+-- nothing.
+
+INSERT OR IGNORE INTO admission_requests
+  (request_id, principal_id, peer_pubkey, requested_scope, network_id,
+   status, created_at, updated_at, granted_by)
+SELECT
+  lower(hex(randomblob(16))),                       -- opaque hex request id
+  p.principal_id,
+  p.principal_pubkey,                               -- peer_pubkey = principal pubkey
+  'federated.' || p.principal_id || '.>',           -- mirror the register hook scope
+  net.value,                                        -- the network the cap targets
+  'ADMITTED',
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  'backfill:0009-grandfather'                        -- system marker, not an admin pubkey
+FROM principals AS p
+JOIN json_each(p.capabilities) AS cap
+JOIN json_each(json_extract(cap.value, '$.networks')) AS net
+GROUP BY p.principal_id, net.value;

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -50,6 +50,7 @@ import {
   validateSignedAdmissionDecision,
   validateAdmissionDecisionClaim,
   validateSignedAdmissionRead,
+  validateSignedAdmissionMineRead,
   isValidRequestId,
 } from "../validate";
 import { canonicalJSON, verifyEd25519 } from "../signing";
@@ -59,7 +60,7 @@ import {
   retryAfterSeconds,
   TOO_MANY_REQUESTS_BODY,
 } from "../rate-limit";
-import type { AdmissionStatus } from "../types";
+import type { AdmissionMineRow, AdmissionStatus } from "../types";
 
 /** Maximum clock skew for admin decision claims — mirrors the network-create route. */
 const CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes
@@ -295,6 +296,72 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     const store = getIssuanceStore(c.env);
     const requests = await store.listIssuanceRequests(status);
     return c.json(requests, 200);
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /admission-requests/mine — ADR-0018 Q4 (Gap-C) member PoP-read
+  //
+  // Released to a caller who signs a proof-of-possession claim with their OWN
+  // registered key. The signature IS the authorization (no admin key, no
+  // allowlist): the route verifies the signature against `claim.peer_pubkey`
+  // and returns ONLY the admission rows for that key, across all networks.
+  // Each row carries a `sealed_secret` slot (null in PR5a; PR5b populates the
+  // sealed-to-pubkey leaf-secret blob — ADR-0018 Q1 b′).
+  //
+  // Signed-read so an unauthenticated caller leaks NO metadata about the
+  // onboarding queue. MUST be registered before `/:request_id` so "mine" is
+  // not swallowed by the param route (where it would 400 as invalid_request_id).
+  // ---------------------------------------------------------------------------
+
+  app.get("/admission-requests/mine", async (c) => {
+    // M1 — rate-limit BEFORE the Ed25519 verify (read bucket).
+    const allowed = await checkRateLimit(c.env, "read", clientKey(c.req.raw));
+    if (!allowed) {
+      return c.json(TOO_MANY_REQUESTS_BODY, 429, {
+        "Retry-After": String(retryAfterSeconds("read")),
+      });
+    }
+
+    // Parse + validate the x-pop-signed header.
+    const headerVal = c.req.header("x-pop-signed");
+    if (!headerVal) {
+      return c.json({ error: "x-pop-signed header required" }, 400);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(headerVal);
+    } catch (_err) {
+      return c.json({ error: "x-pop-signed must be valid JSON" }, 400);
+    }
+    const readCheck = validateSignedAdmissionMineRead(parsed);
+    if (!readCheck.ok) {
+      return c.json({ error: "x-pop-signed validation_failed", details: readCheck.errors }, 400);
+    }
+    const { signed } = readCheck;
+
+    // Clock-skew — stop a captured read token being replayed indefinitely.
+    const issued = Date.parse(signed.claim.issued_at);
+    const now = Date.now();
+    if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
+      return c.json({ error: "issued_at out of skew window" }, 400);
+    }
+
+    // Proof-of-possession — the signature over canonicalJSON(claim) MUST verify
+    // against the claimed peer_pubkey. This signature IS the authorization: a
+    // caller who cannot sign for the key gets nothing (401), so the rows for a
+    // key are released only to a holder of that key.
+    const message = new TextEncoder().encode(canonicalJSON(signed.claim)) as Uint8Array<ArrayBuffer>;
+    const valid = await verifyEd25519(signed.claim.peer_pubkey, signed.signature, message);
+    if (!valid) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
+
+    // Return the caller's OWN admission rows (by the proven pubkey), each with
+    // the (empty-in-PR5a) sealed_secret slot. Never another member's queue.
+    const store = getIssuanceStore(c.env);
+    const rows = await store.listIssuanceRequestsByPeer(signed.claim.peer_pubkey);
+    const mine: AdmissionMineRow[] = rows.map((r) => ({ ...r, sealed_secret: null }));
+    return c.json(mine, 200);
   });
 
   // ---------------------------------------------------------------------------

--- a/src/services/network-registry/src/routes/networks.ts
+++ b/src/services/network-registry/src/routes/networks.ts
@@ -28,7 +28,13 @@
 import { Hono } from "hono";
 import { getRegistryPublicKey, parseAdminPubkeys, type Env } from "../index";
 import { signAssertion } from "./principals";
-import { getNonceCache, getStore, membersFromPrincipals, rosterFromPrincipals } from "../store";
+import {
+  getIssuanceStore,
+  getNonceCache,
+  getStore,
+  membersFromAdmissions,
+  rosterFromAdmissions,
+} from "../store";
 import {
   isValidNetworkId,
   validateNetworkCreateClaim,
@@ -191,12 +197,17 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
     if (!record) {
       return c.json({ error: "not_found" }, 404);
     }
+    // ADR-0018 Q3/Gap-B — membership is sourced from ADMITTED admission rows
+    // (the source of truth), NOT derived from announced capabilities. A
+    // principal appears in `members[]` iff they hold an ADMITTED row for this
+    // network; capabilities are joined on as an orthogonal facet (in /roster).
     const principals = await store.listPrincipals();
+    const admitted = await getIssuanceStore(c.env).listIssuanceRequests("ADMITTED");
     const descriptor: NetworkDescriptor = {
       network_id: record.network_id,
       hub_url: record.hub_url,
       leaf_port: record.leaf_port,
-      members: membersFromPrincipals(principals, networkId),
+      members: membersFromAdmissions(admitted, principals, networkId),
     };
     const assertion = await signAssertion(c.env, descriptor);
     return c.json(assertion);
@@ -208,8 +219,11 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "invalid network_id in path" }, 400);
     }
     const store = getStore(c.env);
+    // ADR-0018 Q3/Gap-B — roster sourced from ADMITTED admission rows, joining
+    // each admitted principal's pubkey + this-network capabilities (the facet).
     const principals = await store.listPrincipals();
-    const roster = rosterFromPrincipals(principals, networkId);
+    const admitted = await getIssuanceStore(c.env).listIssuanceRequests("ADMITTED");
+    const roster = rosterFromAdmissions(admitted, principals, networkId);
     const assertion = await signAssertion(c.env, roster);
     return c.json(assertion);
   });

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -223,7 +223,17 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
       const peerPubkey =
         stacksWithPubkeys[0]?.stack_pubkey ?? claim.principal_pubkey;
       const requestedScope = `federated.${principalId}.>`;
-      await issuanceStore.upsertPending(principalId, peerPubkey, requestedScope);
+      // ADR-0018 Gap-A — stamp the target network the joiner named (signed into
+      // the claim) onto the PENDING admission row. This makes the idempotency
+      // key `(principal_id, peer_pubkey, network_id)`, so the same stack can
+      // request admission to two networks. A network-less register (no
+      // `network_id` in the claim) creates a network-less PENDING row.
+      await issuanceStore.upsertPending(
+        principalId,
+        peerPubkey,
+        requestedScope,
+        claim.network_id,
+      );
     } catch (err) {
       console.error(
         `[network-registry] issuance upsert failed for principal ${principalId}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -203,6 +203,15 @@ export interface IssuanceRequestStore {
   listIssuanceRequests(status: AdmissionStatus): Promise<AdmissionRequest[]>;
 
   /**
+   * ADR-0018 Q4 (Gap-C) — list the admission requests belonging to a single
+   * member's registered pubkey, across all networks, ordered by created_at
+   * ascending. Backs the member PoP-read endpoint: the caller proves possession
+   * of `peerPubkey` (the signature IS the authorization) and receives ONLY the
+   * rows for that key — never another member's queue.
+   */
+  listIssuanceRequestsByPeer(peerPubkey: string): Promise<AdmissionRequest[]>;
+
+  /**
    * Transition a PENDING request to ADMITTED or REJECTED.
    *
    * The transition is gated on `status = 'PENDING'` (CAS-ish guard): if the
@@ -232,9 +241,21 @@ function generateRequestId(): string {
     .join("");
 }
 
+/**
+ * ADR-0018 Gap-A — the idempotency key for an admission request. Includes the
+ * target `network_id` so a stack can request admission to TWO networks without
+ * the second register colliding with the first. A network-less register (no
+ * `network_id`) normalises to the empty string, preserving the pre-ADR-0018
+ * `(principal_id, peer_pubkey)` idempotency for that path (mirrors the D1
+ * `COALESCE(network_id, '')` unique-index expression).
+ */
+function admissionPeerKey(principalId: string, peerPubkey: string, networkId?: string): string {
+  return `${principalId}\x00${peerPubkey}\x00${networkId ?? ""}`;
+}
+
 export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
   private readonly requests = new Map<string, AdmissionRequest>();
-  /** (principal_id + "\x00" + peer_pubkey) → request_id */
+  /** (principal_id + "\x00" + peer_pubkey + "\x00" + network_id) → request_id */
   private readonly byPeer = new Map<string, string>();
 
   async upsertPending(
@@ -243,7 +264,7 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
     requestedScope: string,
     networkId?: string,
   ): Promise<AdmissionRequest> {
-    const peerKey = `${principalId}\x00${peerPubkey}`;
+    const peerKey = admissionPeerKey(principalId, peerPubkey, networkId);
     const existingId = this.byPeer.get(peerKey);
     if (existingId !== undefined) {
       // Idempotent: return the existing row.
@@ -273,6 +294,12 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
   async listIssuanceRequests(status: AdmissionStatus): Promise<AdmissionRequest[]> {
     return [...this.requests.values()]
       .filter((r) => r.status === status)
+      .sort((a, b) => a.created_at.localeCompare(b.created_at));
+  }
+
+  async listIssuanceRequestsByPeer(peerPubkey: string): Promise<AdmissionRequest[]> {
+    return [...this.requests.values()]
+      .filter((r) => r.peer_pubkey === peerPubkey)
       .sort((a, b) => a.created_at.localeCompare(b.created_at));
   }
 
@@ -317,6 +344,13 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     // Contract: always returns the PENDING (or already-decided) row for this
     // (principal_id, peer_pubkey) pair; never throws on a concurrent insert;
     // never creates a duplicate.
+    // ADR-0018 Gap-A — the idempotency / conflict target is now the TRIPLE
+    // `(principal_id, peer_pubkey, COALESCE(network_id, ''))` (migration 0008).
+    // The `COALESCE(...,'')` makes a network-less register (NULL network_id)
+    // still dedupe — SQLite treats raw NULLs as distinct, which would re-insert
+    // a duplicate PENDING row on every plain re-register; normalising NULL→''
+    // restores the pre-ADR-0018 `(principal_id, peer_pubkey)` idempotency for
+    // that path while keeping two DISTINCT networks as two distinct rows.
     const now = new Date().toISOString();
     const requestId = generateRequestId();
     await this.db
@@ -324,17 +358,20 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
         `INSERT INTO admission_requests
            (request_id, principal_id, peer_pubkey, requested_scope, network_id, status, created_at, updated_at, granted_by)
          VALUES (?, ?, ?, ?, ?, 'PENDING', ?, ?, NULL)
-         ON CONFLICT(principal_id, peer_pubkey) DO NOTHING`,
+         ON CONFLICT(principal_id, peer_pubkey, COALESCE(network_id, '')) DO NOTHING`,
       )
       .bind(requestId, principalId, peerPubkey, requestedScope, networkId ?? null, now, now)
       .run();
 
-    // Unconditional SELECT — retrieves the winner (our insert or the existing row).
+    // Unconditional SELECT — retrieves the winner (our insert or the existing
+    // row) for THIS network. The `COALESCE` mirrors the conflict target so a
+    // NULL network_id matches the empty-string-normalised bind, and two networks
+    // never cross-select each other's row.
     const row = await this.db
       .prepare(
-        "SELECT * FROM admission_requests WHERE principal_id = ? AND peer_pubkey = ?",
+        "SELECT * FROM admission_requests WHERE principal_id = ? AND peer_pubkey = ? AND COALESCE(network_id, '') = COALESCE(?, '')",
       )
-      .bind(principalId, peerPubkey)
+      .bind(principalId, peerPubkey, networkId ?? null)
       .first<AdmissionRequestRow>();
 
     // The row MUST exist at this point: either we inserted it or it pre-existed.
@@ -361,6 +398,16 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
         "SELECT * FROM admission_requests WHERE status = ? ORDER BY created_at ASC",
       )
       .bind(status)
+      .all<AdmissionRequestRow>();
+    return (res.results ?? []).map(rowToAdmissionRequest);
+  }
+
+  async listIssuanceRequestsByPeer(peerPubkey: string): Promise<AdmissionRequest[]> {
+    const res = await this.db
+      .prepare(
+        "SELECT * FROM admission_requests WHERE peer_pubkey = ? ORDER BY created_at ASC",
+      )
+      .bind(peerPubkey)
       .all<AdmissionRequestRow>();
     return (res.results ?? []).map(rowToAdmissionRequest);
   }
@@ -941,6 +988,65 @@ export function membersFromPrincipals(
   return rosterFromPrincipals(principals, networkId)
     .members.map((m) => m.principal_id)
     .sort();
+}
+
+/**
+ * ADR-0018 Q3/Gap-B — compute a network's roster from ADMITTED admission rows.
+ *
+ * Admission is the SOURCE OF TRUTH for membership: a principal is "in" network
+ * X iff they hold an ADMITTED admission row for X. Announced capabilities NO
+ * LONGER confer membership — they are an orthogonal facet ("what an admitted
+ * member offers"), joined on top of membership (possibly empty). This is the
+ * resolution of the bug class ADR-0015 warns against (conflating membership
+ * with capability).
+ *
+ * For each distinct ADMITTED principal in the network we join their principal
+ * record for `principal_pubkey` and the capabilities they announced into THIS
+ * network (the facet). An admitted principal with no record (should not happen
+ * — the register hook creates the record before the admission row) is skipped
+ * defensively rather than emitted with an empty pubkey. Sorted by principal_id
+ * for a stable, canonical-friendly response.
+ */
+export function rosterFromAdmissions(
+  admitted: AdmissionRequest[],
+  principals: PrincipalRecord[],
+  networkId: string,
+): NetworkRoster {
+  const byId = new Map(principals.map((p) => [p.principal_id, p]));
+  const seen = new Set<string>();
+  const members: NetworkRoster["members"] = [];
+  for (const row of admitted) {
+    if (row.status !== "ADMITTED" || row.network_id !== networkId) continue;
+    if (seen.has(row.principal_id)) continue;
+    seen.add(row.principal_id);
+    const record = byId.get(row.principal_id);
+    if (!record) continue; // defensive: admitted principal must have registered.
+    const capabilities = record.capabilities
+      .filter((cap) => (cap.networks ?? []).includes(networkId))
+      .map((cap) => cap.id);
+    members.push({
+      principal_id: record.principal_id,
+      principal_pubkey: record.principal_pubkey,
+      capabilities,
+    });
+  }
+  members.sort((a, b) => a.principal_id.localeCompare(b.principal_id));
+  return { network_id: networkId, members };
+}
+
+/**
+ * ADR-0018 Q3/Gap-B — derive a network's lightweight membership list (principal
+ * ids) for the descriptor from ADMITTED admission rows. Mirrors
+ * {@link membersFromPrincipals} (the retired capability-derived view) but is
+ * sourced from admission, so the descriptor's `members[]` can never disagree
+ * with the admission-sourced `/roster`. Unique + sorted for a stable response.
+ */
+export function membersFromAdmissions(
+  admitted: AdmissionRequest[],
+  principals: PrincipalRecord[],
+  networkId: string,
+): string[] {
+  return rosterFromAdmissions(admitted, principals, networkId).members.map((m) => m.principal_id);
 }
 
 /**

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -388,9 +388,12 @@ export interface SignedAdmissionRead {
  */
 export interface AdmissionMineReadClaim {
   /**
-   * The principal the caller is asking about. Echoed for canonicalisation and
-   * cross-checked against the returned rows; the real authority is the
-   * signature over `peer_pubkey`.
+   * The principal the caller is asking about. Echoed into the signed claim for
+   * canonicalisation/audit only — the route does NOT cross-check it against the
+   * returned rows. The sole authority is the signature over `peer_pubkey`: the
+   * route queries by the verified `peer_pubkey` (`listIssuanceRequestsByPeer`),
+   * so the released rows are exactly those owned by the proven key regardless of
+   * this field's value.
    */
   principal_id: string;
   /**

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -88,6 +88,19 @@ export interface RegistrationClaim {
   /** Capabilities the principal wants advertised. */
   capabilities: Capability[];
   /**
+   * ADR-0018 Gap-A — the target network this registration is requesting
+   * admission into. When present, the register hook stamps it onto the PENDING
+   * admission request so the idempotency key becomes
+   * `(principal_id, peer_pubkey, network_id)` — a stack can request admission to
+   * two networks without the second register colliding with the first.
+   *
+   * OPTIONAL: a registration that names no network (a plain identity register,
+   * not a join) creates a network-less PENDING row (`network_id = null`). Part
+   * of the SIGNED canonical claim — a MITM cannot strip or forge the target
+   * network, so admission is always pinned to the network the joiner named.
+   */
+  network_id?: string;
+  /**
    * #825 — optimistic concurrency. The `updated_at` of the record this claim's
    * merge was computed from (captured during the client's verified read). The
    * registry compare-and-sets on it: if the stored row changed since (a
@@ -357,6 +370,62 @@ export interface SignedAdmissionRead {
   claim: AdmissionReadClaim;
   /** Base64 Ed25519 signature over canonical-JSON(claim). */
   signature: string;
+}
+
+/**
+ * ADR-0018 Q4 (Gap-C) — the member proof-of-possession read claim carried by
+ * `GET /admission-requests/mine`.
+ *
+ * Unlike the admin read claim, this is signed by the MEMBER's own registered
+ * key — the signature over `canonicalJSON(claim)` against `peer_pubkey` IS the
+ * authorization (no admin key, no allowlist). A caller learns ONLY the
+ * admission rows belonging to the key they can prove possession of: the route
+ * returns the rows whose `peer_pubkey` equals the (verified) claimed pubkey.
+ *
+ * No nonce (reads are idempotent); clock-skew applies to stop a captured token
+ * being replayed indefinitely. Signed-read so an unauthenticated caller leaks
+ * no metadata about the onboarding queue.
+ */
+export interface AdmissionMineReadClaim {
+  /**
+   * The principal the caller is asking about. Echoed for canonicalisation and
+   * cross-checked against the returned rows; the real authority is the
+   * signature over `peer_pubkey`.
+   */
+  principal_id: string;
+  /**
+   * The member's registered Ed25519 pubkey (base64). The claim is signed with
+   * the matching private key, so verifying the signature against this field
+   * proves possession — the rows for this pubkey are released, nothing else.
+   */
+  peer_pubkey: string;
+  /** ISO-8601 UTC; within the CLOCK_SKEW_MS window. */
+  issued_at: string;
+}
+
+/** On-wire envelope for a member PoP read authorisation. */
+export interface SignedAdmissionMineRead {
+  claim: AdmissionMineReadClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}
+
+/**
+ * ADR-0018 Q4 (Gap-C) — one row of the member PoP-read response. The member's
+ * own admission request, plus the (b′) `sealed_secret` slot.
+ *
+ * `sealed_secret` is included in the shape NOW but always `null` in PR5a: the
+ * sealed-to-pubkey leaf-secret blob is populated by PR5b (ADR-0018 Q1 b′).
+ * Shipping the field now lets the member-read consumer pin the response shape
+ * before the secret-delivery machinery lands.
+ */
+export interface AdmissionMineRow extends AdmissionRequest {
+  /**
+   * ADR-0018 Q1 (b′) — the per-member leaf PSK, sealed to this member's pubkey
+   * (libsodium `crypto_box_seal`). NULL until PR5b populates it; the registry
+   * only ever carries the opaque ciphertext (it cannot read it).
+   */
+  sealed_secret: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -22,6 +22,7 @@ import type {
   Capability,
   RegistrationClaim,
   SignedAdmissionDecision,
+  SignedAdmissionMineRead,
   SignedAdmissionRead,
   SignedRegistration,
   StackIdentity,
@@ -330,6 +331,21 @@ export function validateRegistrationClaim(
     errors.push({ field: "expected_updated_at", message: "must be a string when present" });
   }
 
+  // ADR-0018 Gap-A — optional target network. Same SIGNED-bytes discipline as
+  // expected_updated_at: it is part of the canonical claim, so it must be
+  // PRESERVED verbatim into the reconstructed claim, or every network-bearing
+  // register would fail signature verification (401). When present it must be a
+  // valid network id (free declaration — the same grammar a network create uses).
+  if (
+    c.network_id !== undefined &&
+    (typeof c.network_id !== "string" || !isValidNetworkId(c.network_id))
+  ) {
+    errors.push({
+      field: "network_id",
+      message: "must be a valid network id (lowercase alphanumeric + hyphen, letter-prefixed) when present",
+    });
+  }
+
   if (errors.length > 0) return { ok: false, errors };
 
   return {
@@ -340,6 +356,7 @@ export function validateRegistrationClaim(
       stacks,
       capabilities,
       ...(typeof c.expected_updated_at === "string" && { expected_updated_at: c.expected_updated_at }),
+      ...(typeof c.network_id === "string" && { network_id: c.network_id }),
       issued_at: c.issued_at as string,
       nonce: c.nonce as string,
     },
@@ -635,6 +652,54 @@ export function validateSignedAdmissionRead(
     ok: true,
     signed: {
       claim: { admin_pubkey: bc.admin_pubkey, issued_at: bc.issued_at },
+      signature: b.signature,
+    },
+  };
+}
+
+/**
+ * ADR-0018 Q4 (Gap-C) — validate the `x-pop-signed` header for the member
+ * PoP-read endpoint `GET /admission-requests/mine`. The header value is JSON:
+ * `{ claim: AdmissionMineReadClaim, signature: string }`. No nonce (reads are
+ * idempotent). Clock-skew applies. The route verifies the signature against
+ * `claim.peer_pubkey` — that signature is the authorization (no admin key).
+ */
+export function validateSignedAdmissionMineRead(
+  body: unknown,
+): { ok: true; signed: SignedAdmissionMineRead } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null || Array.isArray(b.claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be a non-array object" }] };
+  }
+  const bc = b.claim as Record<string, unknown>;
+  if (typeof bc.principal_id !== "string" || !isValidPrincipalId(bc.principal_id)) {
+    return {
+      ok: false,
+      errors: [{ field: "claim.principal_id", message: "must be a valid principal id" }],
+    };
+  }
+  if (typeof bc.peer_pubkey !== "string" || !isValidPubkey(bc.peer_pubkey)) {
+    return {
+      ok: false,
+      errors: [{ field: "claim.peer_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" }],
+    };
+  }
+  if (typeof bc.issued_at !== "string" || Number.isNaN(Date.parse(bc.issued_at))) {
+    return { ok: false, errors: [{ field: "claim.issued_at", message: "must be an ISO-8601 timestamp" }] };
+  }
+  return {
+    ok: true,
+    signed: {
+      claim: { principal_id: bc.principal_id, peer_pubkey: bc.peer_pubkey, issued_at: bc.issued_at },
       signature: b.signature,
     },
   };


### PR DESCRIPTION
Closes #1239. Implements ADR-0018 **PR5a** — wires the existing admission state machine (register→PENDING→ADMITTED, admit/reject, `cortex network admit`, migration 0007) so it actually gates roster membership. Trust-path; **no secret material** (that is PR5b).

## Gap A — `network_id` on the request
- `cortex provision-stack register --network <id>` signs the target network into the registration claim (`RegistrationClaim.network_id`, validated + preserved into the signed canonical bytes).
- The register hook persists it via `upsertPending(principalId, peerPubkey, requestedScope, networkId)`.
- Idempotency re-keyed to `(principal_id, peer_pubkey, COALESCE(network_id,''))` — **migration 0008** swaps the unique index; both `InMemoryIssuanceRequestStore` and `D1IssuanceRequestStore` (+ the D1 mock) updated. A stack can now request two networks; a network-less register still dedupes on `(principal, peer)`.

## Gap B — admission is the source of truth for the roster (Q3=ii)
- `GET /networks/{id}` (descriptor) and `/roster` now source `members[]` from **ADMITTED** admission rows for the network (`rosterFromAdmissions` / `membersFromAdmissions`), replacing the capability-derived `membersFromPrincipals`.
- Capabilities become an orthogonal facet joined on (possibly empty). A principal appears **iff** they hold an ADMITTED row — announced capabilities no longer confer membership.
- Descriptor shape unchanged (`members: string[]`); roster keeps `principal_pubkey` + `capabilities`.

## Gap C — member PoP-read endpoint (Q4)
- New `GET /admission-requests/mine`, released to a caller who signs a proof-of-possession claim (`x-pop-signed`) with their **registered key** — the signature IS the authorization (no admin key, no allowlist).
- Returns that member's own admission rows + status across networks, each carrying a `sealed_secret` slot (**null in PR5a**; PR5b populates the sealed-to-pubkey blob, ADR-0018 Q1 b′).
- Signed-read — missing/forged header leaks no metadata. Registered before `/:request_id` so `mine` is not swallowed by the param route.

## Docs
- Brought `docs/design-admission-gate-leaf-secret.md` onto main (supplementary design ADR-0018 ratifies) and allowlisted it in `scripts/check-carveouts.sh` (NSC-operator sovereignty prose, same class as ADR-0013/0015).

## Tests (TDD)
- **Gap A** (`admission-wiring.test.ts` + `provision-stack.test.ts`): network_id persisted; two networks → two rows; same network idempotent; network-less still dedupes; malformed network rejected; CLI `--network` plumbing.
- **Gap B** (`networks.test.ts`): only ADMITTED appear; capability-but-not-admitted does **not**; admitted-but-no-capability **does**; existing roster/descriptor + #681 + C-819 tests updated to the admission model.
- **Gap C** (`admission-wiring.test.ts`): PoP-signed read returns only own rows; status across networks; wrong-key → 401; unsigned/malformed/stale → 400; works without an admin allowlist.

## Gate status
- `bunx tsc --noEmit` (root): **clean**
- `bash scripts/check-carveouts.sh`: **PASS**
- `bun test src/services/network-registry/ src/cli/cortex/commands/`: **1124 pass / 0 fail**
- `bun run lint:errors`: **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-up — BLOCK-1 + BLOCK-2 fixes (commit 9ed09a7)

Addresses the two REQUEST_CHANGES BLOCKs (both rooted in the new ADMITTED-by-network roster having no populated producer for real members) + nits N2/N3.

### BLOCK-1 — real `cortex network join` now pins `network_id`
The canonical join producer (`registerStack` → `registerWithCapabilities` → `buildRegistrationClaim`) never threaded `networkId` — only `provision-stack register --network` did. A real join therefore wrote a `network_id = null` PENDING row that could **never** enter network X's `rosterFromAdmissions` (even after `admit`). Fix: thread `cfg.networkId` through `registerWithCapabilities` into the claim on the **join path only** (announce / deregister / leave still omit it — a de-advertise or a LEAVE must not raise an admission request). New test: a real join pins `network_id=X` and, once ADMITTED, the principal lands in `rosterFromAdmissions` — with a network-less control proving the pin is load-bearing.

### BLOCK-2 — backfill migration `0009` (grandfather existing members)
Switching the served roster to ADMITTED rows with no backfill would empty the live roster on deploy (today's members are on the roster via capability `networks[]`, hold no ADMITTED rows) → the reconciler wires **0 peers** (the #762 hand-pin-wipe / federation outage). Migration `0009_backfill_admitted_from_capabilities.sql`: for each `(principal, network X)` where the principal's registered capabilities already list X, `INSERT OR IGNORE` an `ADMITTED` row (`peer_pubkey` = principal pubkey, `granted_by = backfill:0009-grandfather`, scope `federated.<principal>.>`), idempotent against the 0008 unique triple `(principal_id, peer_pubkey, COALESCE(network_id,''))`.
- **SECURITY:** grandfathers **ONLY** members already on the roster under the retired capability rule — grants **no** new access; a principal with no capability targeting X gets no row. `granted_by` is a system marker (auditably distinct from a real admin admission), not an admin pubkey.
- New `migration-0009.test.ts`: a capability-`networks[]` member appears in `rosterFromAdmissions` post-backfill; a non-member does not; re-run inserts no duplicate; a pre-existing real ADMITTED row is untouched.
- No InMemory-store mirror was needed — the existing route tests already drive the real `admit` flow (C-819), and the new tests cover the backfill at the SQL + `rosterFromAdmissions` layer directly.

### ⚠️ DEPLOY SEQUENCING (held for principal)
Migration `0009` **MUST be applied on the registry deploy that ships this Gap-B roster-source switch** — it is the data half of the cutover. Applying the code without the migration empties the live roster. Apply order on deploy:
```
bunx wrangler d1 migrations apply cortex-network-registry --env production --remote
```
(The deploy itself remains held for the principal; this is a sequencing note for whoever runs it.)

### Nits
- **N2** — corrected `AdmissionMineReadClaim.principal_id` doc: the route does **not** cross-check it; sole authority is the signature over `peer_pubkey` (`listIssuanceRequestsByPeer`).
- **N3** — refreshed the stale `membersFromPrincipals` / implicit-membership comments in `network-adapters.ts` to the Gap-B admission-derived model.
- **N1** — left as-is per the reviewer (acceptable: matches the admin-read pattern, no secret in PR5a).

### Gates (re-run, broad scope)
- `bunx tsc --noEmit`: **clean (0)**
- `bash scripts/check-carveouts.sh` (CI scope — fresh checkout, no registry `node_modules`): **PASS**
- `bun run lint:errors`: **clean**
- `bun test src/services/network-registry/ src/bus/ src/cli/cortex/commands/`: **2303 pass / 0 fail**
