### PR TITLE
feat(network): C-1240 — leaf-secret tooling + sealed delivery (PR5b, ADR-0018)

### DIFF
--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -342,6 +342,35 @@ export function materialFromSeedString(seed: string): StackIdentityMaterial {
   return materialFromKeyPair(kp);
 }
 
+/**
+ * ADR-0018 PR5b — extract the RAW 32-byte ed25519 seed from a `SU…` NKey seed
+ * string. The leaf-secret open path ({@link openSealed} in
+ * `src/common/crypto/seal-to-principal.ts`) needs the raw seed bytes, not the
+ * nkey-wrapped form: the member unseals their leaf PSK with the SAME ed25519
+ * identity the stack signs envelopes with (no new key material, ADR-0019 L3).
+ *
+ * This is the single place the nkeys.js `getRawSeed()` accessor is surfaced for
+ * the crypto layer, keeping the ed25519→nkey bridge in one module.
+ *
+ * @throws if the seed is not a valid `SU…` user-class NKey seed.
+ */
+export function rawEd25519SeedFromNkeySeed(seed: string): Uint8Array {
+  const trimmed = seed.trim();
+  if (!trimmed.startsWith("SU")) {
+    throw new Error(
+      `stack-provisioning: expected a user-class NKey seed (SU…), got ${trimmed.slice(0, 2)}…`,
+    );
+  }
+  const kp = fromSeed(new TextEncoder().encode(trimmed));
+  const raw = rawSeedOf(kp);
+  if (raw.length !== 32) {
+    throw new Error(
+      `stack-provisioning: expected a 32-byte ed25519 seed, got ${raw.length.toString()}`,
+    );
+  }
+  return raw;
+}
+
 // =============================================================================
 // Registration claim (proof-of-possession)
 // =============================================================================

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -1465,6 +1465,7 @@ describe("#762 registerStack announces capabilities into the network", () => {
             created_at: "2026-01-01T00:00:00Z",
             updated_at: "2026-01-01T00:00:00Z",
             granted_by: "admin-pubkey",
+            sealed_secret: null,
           },
         ];
         const principals = await store.listPrincipals();

--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -1,0 +1,209 @@
+/**
+ * ADR-0018 PR5b — `cortex network secret` CLI dispatch tests.
+ *
+ * Drives dispatchNetwork end-to-end with an injected secret-ports factory + a
+ * real chmod-600 hub-admin seed file. Asserts: grammar validation, dry-run
+ * default (no mutation), --apply wiring, --json shape, oob surfacing, and that
+ * no secret leaks into the non-oob output.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createUser } from "nkeys.js";
+import { dispatchNetwork, __setJoinLeafSecretFetcherForTests, type SecretPortsFactory } from "../network";
+import type { NetworkSecretPorts } from "../network-secret-ports";
+import type { FetchSealedLeafSecretInput } from "../../../../common/registry/fetch-sealed-secret";
+
+let tmp: string;
+let seedPath: string;
+// A valid 44-char base64 Ed25519 pubkey (32 bytes → 44 b64 chars, one '=' pad).
+const MEMBER = btoa("A".repeat(32));
+
+// A recording fake ports bundle + factory.
+interface Calls {
+  reads: number;
+  writes: string[];
+  reloads: number;
+  posted: { requestId: string; blob: string }[];
+  revoked: string[];
+  minted: string[];
+}
+function fakeFactory(opts: { admitted?: { request_id: string; principal_id: string } } = {}): { factory: SecretPortsFactory; calls: Calls; conf: { text: string } } {
+  const calls: Calls = { reads: 0, writes: [], reloads: 0, posted: [], revoked: [], minted: [] };
+  const conf = { text: "leafnodes {\n  listen: 0.0.0.0:7422\n}\n" };
+  let mintN = 0;
+  const ports: NetworkSecretPorts = {
+    hub: {
+      confPath: "/fake/hub.conf",
+      readConf: async () => { calls.reads += 1; return conf.text; },
+      writeConf: async (t: string) => { conf.text = t; calls.writes.push(t); },
+      reload: async () => { calls.reloads += 1; },
+    },
+    admission: { findAdmittedRow: async () => opts.admitted },
+    delivery: {
+      postSealedSecret: async (requestId: string, blob: string) => { calls.posted.push({ requestId, blob }); },
+      revoke: async (requestId: string) => { calls.revoked.push(requestId); },
+    },
+    crypto: {
+      mintPsk: () => { const p = `PSK-${++mintN}`; calls.minted.push(p); return p; },
+      seal: async (plaintext: string, pubkey: string) => `SEALED(${pubkey.slice(0, 4)}:${plaintext})`,
+    },
+  };
+  return { factory: () => ports, calls, conf };
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "secret-cli-"));
+  seedPath = join(tmp, "hub-admin.seed");
+  const seed = new TextDecoder().decode(createUser().getSeed());
+  writeFileSync(seedPath, seed, { mode: 0o600 });
+  chmodSync(seedPath, 0o600);
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function argv(...args: string[]): string[] {
+  return args;
+}
+
+describe("cortex network secret — grammar", () => {
+  test("unknown action → usage error (exit 2)", async () => {
+    const { factory } = fakeFactory();
+    const res = await dispatchNetwork(argv("secret", "bogus", "metafactory", MEMBER, "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(2);
+  });
+
+  test("malformed member pubkey → usage error", async () => {
+    const { factory } = fakeFactory();
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", "not-a-pubkey", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(2);
+  });
+
+  test("rotate + --deliver oob → usage error", async () => {
+    const { factory } = fakeFactory();
+    const res = await dispatchNetwork(argv("secret", "rotate", "metafactory", MEMBER, "--deliver", "oob", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(2);
+  });
+});
+
+describe("cortex network secret add-member", () => {
+  test("dry-run (default) mutates nothing", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("dry-run");
+    expect(calls.writes.length).toBe(0);
+    expect(calls.reloads).toBe(0);
+    expect(calls.posted.length).toBe(0);
+  });
+
+  test("--apply sealed: adds hub user + reload + posts sealed blob; no secret in stdout", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(calls.writes.length).toBe(1);
+    expect(calls.reloads).toBe(1);
+    expect(calls.posted.length).toBe(1);
+    expect(calls.posted[0]!.requestId).toBe("req1");
+    // No minted PSK appears in stdout for the sealed path.
+    expect(res.stdout).not.toContain(calls.minted[0]!);
+  });
+
+  test("--apply oob: surfaces the PSK explicitly, registry untouched", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--deliver", "oob", "--apply", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(calls.posted.length).toBe(0); // registry untouched
+    expect(res.stdout).toContain("OUT-OF-BAND SECRET");
+    expect(res.stdout).toContain(calls.minted[0]!); // the PSK IS surfaced for handover
+  });
+
+  test("--json --apply sealed: machine-readable, applied=true, no oob secret key", async () => {
+    const { factory } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--json", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as { data: Record<string, string> };
+    expect(parsed.data.applied).toBe("true");
+    expect(parsed.data.request_id).toBe("req1");
+    expect(parsed.data).not.toHaveProperty("oob_leaf_secret");
+  });
+
+  test("no ADMITTED row → exit 1", async () => {
+    const { factory } = fakeFactory({ admitted: undefined });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(1);
+  });
+});
+
+describe("cortex network secret revoke-member", () => {
+  test("--apply: drops hub user + reload (cut) + registry revoke", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(argv("secret", "revoke-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(calls.reloads).toBe(1);
+    expect(calls.revoked).toEqual(["req1"]);
+  });
+});
+
+// =============================================================================
+// ADR-0018 PR5b — join plug-and-play: auto-fetch + unseal the leaf secret
+// =============================================================================
+
+describe("cortex network join — plug-and-play leaf-secret auto-fetch", () => {
+  afterEach(() => __setJoinLeafSecretFetcherForTests(null));
+
+  test("join with NO configured leaf-secret AUTO-fetches it from the admission gate", async () => {
+    // A real joiner seed so materialFromSeedString succeeds.
+    const joinerSeed = join(tmp, "joiner.seed");
+    writeFileSync(joinerSeed, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
+    chmodSync(joinerSeed, 0o600);
+
+    const seen: FetchSealedLeafSecretInput[] = [];
+    __setJoinLeafSecretFetcherForTests(async (input) => {
+      seen.push(input);
+      return { ok: true, leafPsk: "AUTO-PSK", leafUser: "andreas" };
+    });
+
+    // Dry-run join (no --apply): the descriptor fetch will fail against the
+    // unreachable registry, but the AUTO-FETCH runs first — we assert it was
+    // invoked with the right coordinates (the wiring), which is the PR's claim.
+    await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", joinerSeed,
+      "--creds", join(tmp, "andreas.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(tmp, "local.conf"),
+      "--plist", join(tmp, "nats.plist"),
+    ], (() => ({})) as never);
+
+    expect(seen.length).toBe(1);
+    expect(seen[0]!.networkId).toBe("metafactory");
+    expect(seen[0]!.principalId).toBe("andreas");
+    expect(seen[0]!.registryUrl).toBe("http://127.0.0.1:0");
+  });
+
+  test("an explicit --leaf-secret SUPPRESSES the auto-fetch", async () => {
+    const joinerSeed = join(tmp, "joiner2.seed");
+    writeFileSync(joinerSeed, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
+    chmodSync(joinerSeed, 0o600);
+    let called = false;
+    __setJoinLeafSecretFetcherForTests(async () => { called = true; return { ok: false, reason: "x" }; });
+
+    await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", joinerSeed,
+      "--leaf-secret", "EXPLICIT-PSK",
+      "--leaf-user", "andreas",
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(tmp, "local.conf"),
+      "--plist", join(tmp, "nats.plist"),
+    ], (() => ({})) as never);
+
+    expect(called).toBe(false);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
@@ -1,0 +1,197 @@
+/**
+ * ADR-0018 PR5b — `cortex network secret` orchestrator tests (fake ports).
+ *
+ * Proves the trust-path behaviours over injected ports:
+ *   - add-member sealed: mints PSK → adds hub user + reload → seals to the
+ *     member pubkey + posts to the admission row; NO secret in steps/data
+ *   - add-member oob: surfaces the PSK, registry untouched
+ *   - revoke-member: drops the hub user + reload (cuts transport) → registry revoke
+ *   - rotate: re-mints + re-writes the hub user + replaces the sealed blob
+ *   - dry-run (default) mutates NOTHING
+ *   - no ADMITTED row → ok:false, no mutation
+ */
+
+import { describe, test, expect } from "bun:test";
+import { runNetworkSecret, type SecretInputs } from "../network-secret-lib";
+import type { NetworkSecretPorts } from "../network-secret-ports";
+import { listHubLeafUsers } from "../../../../common/nats/hub-leaf-authorization";
+
+interface Recorder {
+  ports: NetworkSecretPorts;
+  hubConf: { text: string };
+  writes: string[];
+  reloads: number;
+  posted: { requestId: string; blob: string }[];
+  revoked: string[];
+  minted: string[];
+}
+
+function makePorts(opts: { admitted?: { request_id: string; principal_id: string }; startConf?: string } = {}): Recorder {
+  const hubConf = { text: opts.startConf ?? "leafnodes {\n  listen: 0.0.0.0:7422\n}\n" };
+  const writes: string[] = [];
+  let reloads = 0;
+  const posted: { requestId: string; blob: string }[] = [];
+  const revoked: string[] = [];
+  const minted: string[] = [];
+  let mintCounter = 0;
+
+  const ports: NetworkSecretPorts = {
+    hub: {
+      confPath: "/fake/hub.conf",
+      readConf: async () => hubConf.text,
+      writeConf: async (text: string) => {
+        hubConf.text = text;
+        writes.push(text);
+      },
+      reload: async () => {
+        reloads += 1;
+      },
+    },
+    admission: {
+      findAdmittedRow: async () => opts.admitted,
+    },
+    delivery: {
+      postSealedSecret: async (requestId: string, blob: string) => {
+        posted.push({ requestId, blob });
+      },
+      revoke: async (requestId: string) => {
+        revoked.push(requestId);
+      },
+    },
+    crypto: {
+      mintPsk: () => {
+        const p = `PSK-${++mintCounter}`;
+        minted.push(p);
+        return p;
+      },
+      seal: async (plaintext: string, pubkey: string) => `SEALED(${pubkey.slice(0, 6)}:${plaintext})`,
+    },
+  };
+  return {
+    ports,
+    hubConf,
+    writes,
+    get reloads() {
+      return reloads;
+    },
+    posted,
+    revoked,
+    minted,
+  };
+}
+
+const MEMBER_PUBKEY = "QkFTRTY0LU1FTUJFUi1QVUJLRVktNDQtY2hhcnMtZXhhY3Q=";
+
+function inputs(over: Partial<SecretInputs>): SecretInputs {
+  return {
+    action: "add-member",
+    networkId: "metafactory",
+    memberPubkey: MEMBER_PUBKEY,
+    deliver: "sealed",
+    apply: true,
+    ...over,
+  };
+}
+
+function assertNoSecretLeak(steps: string[], data: Record<string, string>, psk: string): void {
+  expect(steps.join("\n")).not.toContain(psk);
+  expect(JSON.stringify(data)).not.toContain(psk);
+}
+
+describe("add-member (sealed)", () => {
+  test("mints → adds hub user + reload → seals + posts to the admission row; no secret leak", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({ apply: true }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(true);
+    // Hub user added + reloaded
+    expect(listHubLeafUsers(r.hubConf.text)).toEqual([{ user: "alice", secret: "PSK-1" }]);
+    expect(r.writes.length).toBe(1);
+    expect(r.reloads).toBe(1);
+    // Sealed blob posted to the row (the envelope was sealed to the member pubkey)
+    expect(r.posted.length).toBe(1);
+    expect(r.posted[0]!.requestId).toBe("req1");
+    expect(r.posted[0]!.blob).toContain("leaf_psk");
+    // No revoke
+    expect(r.revoked.length).toBe(0);
+    // No PSK in the report surfaces
+    expect(report.surfaced).toBeUndefined();
+    assertNoSecretLeak(report.steps, report.data, "PSK-1");
+  });
+
+  test("--leaf-user override is honoured as the hub user", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    await runNetworkSecret(inputs({ leafUserOverride: "alice-laptop" }), r.ports);
+    expect(listHubLeafUsers(r.hubConf.text)[0]!.user).toBe("alice-laptop");
+  });
+});
+
+describe("add-member (oob)", () => {
+  test("surfaces the PSK and leaves the registry untouched", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({ deliver: "oob" }), r.ports);
+    expect(report.applied).toBe(true);
+    // Hub user added + reloaded (transport allowed)
+    expect(r.reloads).toBe(1);
+    // Registry untouched (no sealed post)
+    expect(r.posted.length).toBe(0);
+    // PSK surfaced for the hub-admin's out-of-band handover
+    expect(report.surfaced).toEqual({ leafUser: "alice", psk: "PSK-1" });
+    // ...but NOT in the regular steps/data
+    assertNoSecretLeak(report.steps, report.data, "PSK-1");
+  });
+});
+
+describe("revoke-member", () => {
+  test("drops the hub user + reload (cuts transport) → registry revoke", async () => {
+    // Start with the member already authorized in the hub config.
+    const start = "leafnodes {\n  # >>> cortex-managed leaf authorization (network secret tooling) — do not hand-edit\n  authorization {\n    users: [\n      { user: \"alice\", password: \"PSK-old\" }\n    ]\n  }\n  # <<< cortex-managed leaf authorization\n  listen: 0.0.0.0:7422\n}\n";
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" }, startConf: start });
+    const report = await runNetworkSecret(inputs({ action: "revoke-member" }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(true);
+    // Hub user gone (transport cut) + reloaded
+    expect(listHubLeafUsers(r.hubConf.text)).toEqual([]);
+    expect(r.hubConf.text).not.toContain("PSK-old");
+    expect(r.reloads).toBe(1);
+    // Registry revoke fired
+    expect(r.revoked).toEqual(["req1"]);
+  });
+});
+
+describe("rotate", () => {
+  test("re-mints + replaces the hub user + replaces the sealed blob", async () => {
+    const start = "leafnodes {\n  # >>> cortex-managed leaf authorization (network secret tooling) — do not hand-edit\n  authorization {\n    users: [\n      { user: \"alice\", password: \"PSK-old\" }\n    ]\n  }\n  # <<< cortex-managed leaf authorization\n}\n";
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" }, startConf: start });
+    const report = await runNetworkSecret(inputs({ action: "rotate" }), r.ports);
+    expect(report.applied).toBe(true);
+    // Hub user replaced with the new PSK; old inert
+    expect(listHubLeafUsers(r.hubConf.text)).toEqual([{ user: "alice", secret: "PSK-1" }]);
+    expect(r.hubConf.text).not.toContain("PSK-old");
+    // New sealed blob posted (replaces)
+    expect(r.posted.length).toBe(1);
+  });
+});
+
+describe("dry-run (default) + guards", () => {
+  test("dry-run mutates nothing", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({ apply: false }), r.ports);
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(false);
+    expect(r.writes.length).toBe(0);
+    expect(r.reloads).toBe(0);
+    expect(r.posted.length).toBe(0);
+    expect(r.revoked.length).toBe(0);
+  });
+
+  test("no ADMITTED row → ok:false, no mutation", async () => {
+    const r = makePorts({ admitted: undefined });
+    const report = await runNetworkSecret(inputs({ apply: true }), r.ports);
+    expect(report.ok).toBe(false);
+    expect(r.writes.length).toBe(0);
+    expect(r.posted.length).toBe(0);
+  });
+});

--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -1,0 +1,219 @@
+/**
+ * ADR-0018 PR5b (#1240) — LIVE adapters for `cortex network secret`.
+ *
+ * The real side effects the orchestrator (`network-secret-lib.ts`) depends on:
+ *   - HUB-LOCAL: read/write the hub nats-server config (chmod 600 — it carries
+ *     leaf secrets) + reload it (`nats-server --signal reload`, SIGHUP — an
+ *     in-place authorization reload, no restart). A `-c <conf> -t` syntax gate
+ *     runs first so a malformed config never reaches a live reload.
+ *   - REGISTRY: the admin-signed admission-row LOOKUP + the hub-admin-signed
+ *     sealed-secret delivery / revoke POSTs.
+ *
+ * These are ONLY constructed on a real `--apply` (or dry-run, which still reads).
+ * The orchestrator gates every MUTATION on `apply`, so the live mutating methods
+ * are not invoked during a dry-run.
+ */
+
+import { existsSync, readFileSync, writeFileSync, chmodSync, renameSync } from "fs";
+
+import { expandTilde } from "../../../common/config/loader";
+import { enforceChmod600 } from "../../../common/config/file-permissions";
+import { canonicalJSON } from "../../../common/registry/signing";
+import { sealToPrincipal } from "../../../common/crypto/seal-to-principal";
+import { mintLeafPsk } from "../../../common/nats/leaf-psk";
+import {
+  signClaimWithSeed,
+  randomNonce,
+  type StackIdentityMaterial,
+} from "../../../bus/stack-provisioning";
+import { bunExecRunner, type ExecRunner } from "../../../common/nats/nats-service-manager";
+import type {
+  NetworkSecretPorts,
+  HubAuthPort,
+  AdmissionLookupPort,
+  SealDeliveryPort,
+  SecretCrypto,
+} from "./network-secret-ports";
+
+export interface LiveSecretPortsConfig {
+  /** The hub nats-server config path (carries the leaf authorization users). */
+  hubConfigPath: string;
+  /** Registry base URL. */
+  registryUrl: string;
+  /** The HUB-ADMIN identity (seed signs the delivery/revoke + admin read). */
+  material: StackIdentityMaterial;
+  /** Injectable exec runner (tests). Production omits → bunExecRunner. */
+  exec?: ExecRunner;
+  /** Injectable fetch (tests). Production omits → globalThis.fetch. */
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+/** Build the full live port bundle. */
+export function buildLiveSecretPorts(cfg: LiveSecretPortsConfig): NetworkSecretPorts {
+  return {
+    hub: buildLiveHubAuthPort(cfg),
+    admission: buildLiveAdmissionLookupPort(cfg),
+    delivery: buildLiveSealDeliveryPort(cfg),
+    crypto: buildLiveSecretCrypto(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HUB-LOCAL — hub nats config read/write/reload
+// ---------------------------------------------------------------------------
+
+function buildLiveHubAuthPort(cfg: LiveSecretPortsConfig): HubAuthPort {
+  const confPath = expandTilde(cfg.hubConfigPath);
+  const exec = cfg.exec ?? bunExecRunner;
+  return {
+    confPath,
+    readConf(): Promise<string> {
+      if (!existsSync(confPath)) {
+        return Promise.reject(new Error(`hub config not found at ${confPath} (set --hub-config)`));
+      }
+      return Promise.resolve(readFileSync(confPath, "utf-8"));
+    },
+    writeConf(text: string): Promise<void> {
+      // The hub config now carries leaf SECRETS, so it is a secret-at-rest.
+      // Atomic write (temp + rename) so a SIGKILL mid-write never leaves
+      // corrupt HOCON that crashes nats-server, then chmod 600.
+      const tmp = `${confPath}.tmp-${process.pid.toString()}`;
+      writeFileSync(tmp, text, { mode: 0o600 });
+      chmodSync(tmp, 0o600);
+      renameSync(tmp, confPath);
+      chmodSync(confPath, 0o600);
+      return Promise.resolve();
+    },
+    async reload(): Promise<void> {
+      // Syntax gate first — never reload a broken config onto the live hub.
+      // Skip the gate (not the reload) if the nats-server binary is absent.
+      try {
+        const gate = await exec(["nats-server", "-c", confPath, "-t"]);
+        if (gate.code !== 0) {
+          throw new Error(`nats-server -c ${confPath} -t exited ${gate.code.toString()}: ${gate.stderr.trim()}`);
+        }
+      } catch (err) {
+        // A missing binary throws on spawn — degrade to a warning, still reload.
+        if (err instanceof Error && /exited \d/.test(err.message)) throw err;
+        process.stderr.write(
+          `cortex network secret: skipping nats-server -t gate (could not run nats-server: ${err instanceof Error ? err.message : String(err)})\n`,
+        );
+      }
+      // SIGHUP reload — nats-server applies authorization changes in place.
+      const reload = await exec(["nats-server", "--signal", "reload"]);
+      if (reload.code !== 0) {
+        throw new Error(`nats-server --signal reload exited ${reload.code.toString()}: ${reload.stderr.trim()}`);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// REGISTRY — admission lookup (admin read) + sealed delivery / revoke (hub-admin)
+// ---------------------------------------------------------------------------
+
+interface AdmissionRow {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  network_id: string | null;
+  status: string;
+}
+
+function buildLiveAdmissionLookupPort(cfg: LiveSecretPortsConfig): AdmissionLookupPort {
+  const base = cfg.registryUrl.replace(/\/+$/, "");
+  const fetchImpl = cfg.fetchImpl ?? globalThis.fetch;
+  return {
+    async findAdmittedRow(networkId, memberPubkey) {
+      // Admin-signed read of the ADMITTED list (x-admin-signed header). NOTE: the
+      // registry's read gate checks the REGISTRY-admin allowlist; for metafactory
+      // the hub-admin seed IS the registry-admin (Q5 collapse), so this works. A
+      // fully-separable deployment must put the hub-admin on REGISTRY_ADMIN_PUBKEYS
+      // for the lookup (documented in the PR).
+      const claim = { admin_pubkey: cfg.material.pubkeyB64, issued_at: new Date().toISOString() };
+      const signature = await signClaimWithSeed(cfg.material.seed, new TextEncoder().encode(canonicalJSON(claim)));
+      const resp = await fetchImpl(`${base}/admission-requests?status=ADMITTED`, {
+        method: "GET",
+        headers: { "Content-Type": "application/json", "x-admin-signed": JSON.stringify({ claim, signature }) },
+      });
+      if (!resp.ok) {
+        throw new Error(`registry admission list failed (HTTP ${resp.status.toString()}): ${await resp.text()}`);
+      }
+      const rows = (await resp.json()) as AdmissionRow[];
+      const row = rows.find((r) => r.network_id === networkId && r.peer_pubkey === memberPubkey && r.status === "ADMITTED");
+      return row ? { request_id: row.request_id, principal_id: row.principal_id } : undefined;
+    },
+  };
+}
+
+function buildLiveSealDeliveryPort(cfg: LiveSecretPortsConfig): SealDeliveryPort {
+  const base = cfg.registryUrl.replace(/\/+$/, "");
+  const fetchImpl = cfg.fetchImpl ?? globalThis.fetch;
+  return {
+    async postSealedSecret(requestId, sealedBlob) {
+      const claim = {
+        request_id: requestId,
+        sealed_secret: sealedBlob,
+        hub_admin_pubkey: cfg.material.pubkeyB64,
+        issued_at: new Date().toISOString(),
+        nonce: randomNonce(),
+      };
+      const signature = await signClaimWithSeed(cfg.material.seed, new TextEncoder().encode(canonicalJSON(claim)));
+      const resp = await fetchImpl(`${base}/admission-requests/${encodeURIComponent(requestId)}/sealed-secret`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ claim, signature }),
+      });
+      if (!resp.ok) {
+        throw new Error(`registry rejected sealed-secret (HTTP ${resp.status.toString()}): ${await resp.text()}`);
+      }
+    },
+    async revoke(requestId) {
+      const claim = {
+        request_id: requestId,
+        hub_admin_pubkey: cfg.material.pubkeyB64,
+        issued_at: new Date().toISOString(),
+        nonce: randomNonce(),
+      };
+      const signature = await signClaimWithSeed(cfg.material.seed, new TextEncoder().encode(canonicalJSON(claim)));
+      const resp = await fetchImpl(`${base}/admission-requests/${encodeURIComponent(requestId)}/revoke`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ claim, signature }),
+      });
+      if (!resp.ok) {
+        throw new Error(`registry rejected revoke (HTTP ${resp.status.toString()}): ${await resp.text()}`);
+      }
+    },
+  };
+}
+
+function buildLiveSecretCrypto(): SecretCrypto {
+  return {
+    mintPsk: () => mintLeafPsk(),
+    seal: (plaintext, pubkey) => sealToPrincipal(plaintext, pubkey),
+  };
+}
+
+/** Load + chmod-600-gate a hub-admin seed file, re-deriving its material. */
+export async function hubAdminMaterialFromSeedFile(
+  seedPath: string,
+): Promise<{ ok: true; material: StackIdentityMaterial } | { ok: false; reason: string }> {
+  const { readFile } = await import("fs/promises");
+  const { materialFromSeedString } = await import("../../../bus/stack-provisioning");
+  const expanded = expandTilde(seedPath);
+  if (!existsSync(expanded)) {
+    return { ok: false, reason: `--admin-seed file not found at ${expanded}` };
+  }
+  try {
+    enforceChmod600(expanded);
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    const seed = await readFile(expanded, "utf-8");
+    return { ok: true, material: materialFromSeedString(seed) };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/cli/cortex/commands/network-secret-lib.ts
+++ b/src/cli/cortex/commands/network-secret-lib.ts
@@ -1,0 +1,253 @@
+/**
+ * ADR-0018 PR5b (#1240) — `cortex network secret` orchestrator (PURE over ports).
+ *
+ * The per-member leaf PSK lifecycle (ADR-0018 Q2/Q5/Q6):
+ *
+ *   add-member  mint a per-member PSK → write the member's hub `authorization`
+ *               user + reload the hub (allow transport) → DELIVER: seal an
+ *               envelope to the member's pubkey and POST it to their ADMITTED
+ *               admission row (sealed, default), OR surface the PSK for an
+ *               out-of-band handover (oob).
+ *   rotate      re-mint + re-seal + replace; old PSK inert (hub user updated,
+ *               sealed blob replaced).
+ *   revoke-member  drop the member's hub `authorization` user + reload (CUT
+ *               transport — not just a roster row) → mark the admission row
+ *               REVOKED (registry).
+ *
+ * MUTATIONS gate on `apply`: dry-run resolves the plan (it may READ the registry
+ * row + the hub config to make the plan concrete) but performs NO write/reload/
+ * deliver/revoke. SECRETS NEVER appear in the returned report EXCEPT the oob
+ * surfaced PSK (which the hub-admin MUST receive to hand it over) — that lives in
+ * a dedicated `surfaced` field the caller renders explicitly, never in `steps`.
+ *
+ * The leaf PSK rides a {@link encodeLeafSecretEnvelope} JSON envelope so the M3
+ * per-network payload key (#1246) can ride the SAME sealed blob later with no
+ * schema change — that is the documented M3 seam.
+ */
+
+import { encodeLeafSecretEnvelope } from "../../../common/registry/sealed-leaf-secret";
+import { pskFingerprint } from "../../../common/nats/leaf-psk";
+import {
+  upsertHubLeafUser,
+  removeHubLeafUser,
+  HubAuthConflictError,
+} from "../../../common/nats/hub-leaf-authorization";
+import type { NetworkSecretPorts } from "./network-secret-ports";
+
+export type SecretAction = "add-member" | "revoke-member" | "rotate";
+export type DeliveryMode = "sealed" | "oob";
+
+export interface SecretInputs {
+  action: SecretAction;
+  networkId: string;
+  /** The member's registered ed25519 pubkey (base64) — the seal target + row key. */
+  memberPubkey: string;
+  /** add-member only: sealed (default) or oob. */
+  deliver: DeliveryMode;
+  /** Override the hub leaf user (defaults to the member's principal id). */
+  leafUserOverride?: string;
+  apply: boolean;
+}
+
+export interface SecretReport {
+  ok: boolean;
+  applied: boolean;
+  action: SecretAction;
+  networkId: string;
+  /** Human-readable plan/result steps — NEVER carry a secret. */
+  steps: string[];
+  /** Structured data for --json — NEVER carries a secret. */
+  data: Record<string, string>;
+  /** Failure reason (operational). */
+  reason?: string;
+  /**
+   * OOB delivery ONLY: the secret the hub-admin must hand over out-of-band. The
+   * caller renders this explicitly + separately (it is the one place a secret
+   * legitimately reaches stdout). Absent for sealed delivery.
+   */
+  surfaced?: { leafUser: string; psk: string };
+}
+
+/** Dispatch by action. */
+export async function runNetworkSecret(
+  inputs: SecretInputs,
+  ports: NetworkSecretPorts,
+): Promise<SecretReport> {
+  switch (inputs.action) {
+    case "add-member":
+      return addOrRotate(inputs, ports, /* rotate */ false);
+    case "rotate":
+      return addOrRotate(inputs, ports, /* rotate */ true);
+    case "revoke-member":
+      return revokeMember(inputs, ports);
+  }
+}
+
+/**
+ * add-member + rotate share the mint→hub-write→deliver shape. rotate REPLACES
+ * (the hub upsert + the sealed POST both overwrite in place; the old PSK is
+ * inert once the hub user is overwritten).
+ */
+async function addOrRotate(
+  inputs: SecretInputs,
+  ports: NetworkSecretPorts,
+  rotate: boolean,
+): Promise<SecretReport> {
+  const action: SecretAction = rotate ? "rotate" : "add-member";
+  const steps: string[] = [];
+  const data: Record<string, string> = {
+    action,
+    network: inputs.networkId,
+    member_fingerprint: inputs.memberPubkey.slice(0, 12),
+    deliver: inputs.deliver,
+  };
+
+  // 1. Resolve the ADMITTED admission row (read-only — safe in dry-run too).
+  const row = await ports.admission.findAdmittedRow(inputs.networkId, inputs.memberPubkey);
+  if (!row) {
+    return fail(action, inputs, steps, data, `no ADMITTED admission row for that member on network "${inputs.networkId}" — admit them first (cortex network admit)`);
+  }
+  const leafUser = inputs.leafUserOverride ?? row.principal_id;
+  data.request_id = row.request_id;
+  data.leaf_user = leafUser;
+
+  steps.push(`member:     ${inputs.memberPubkey.slice(0, 12)}… (request ${row.request_id})`);
+  steps.push(`leaf user:  ${leafUser}`);
+  steps.push(`deliver:    ${inputs.deliver}`);
+
+  if (!inputs.apply) {
+    steps.push(rotate
+      ? `would: re-mint PSK → REPLACE hub authorization user "${leafUser}" + reload → re-seal + replace sealed blob`
+      : `would: mint PSK → add hub authorization user "${leafUser}" + reload → ${inputs.deliver === "sealed" ? "seal + deliver to the admission row" : "surface PSK for out-of-band handover"}`);
+    return plan(action, inputs, steps, data);
+  }
+
+  // 2. Mint the PSK + write the hub authorization user + reload.
+  const psk = ports.crypto.mintPsk();
+  const fp = await pskFingerprint(psk);
+  data.psk_fingerprint = fp;
+
+  let conf: string;
+  try {
+    conf = await ports.hub.readConf();
+  } catch (err) {
+    return fail(action, inputs, steps, data, `failed to read hub config: ${errText(err)}`);
+  }
+  let nextConf: string;
+  try {
+    nextConf = upsertHubLeafUser(conf, leafUser, psk);
+  } catch (err) {
+    if (err instanceof HubAuthConflictError) {
+      return fail(action, inputs, steps, data, err.message);
+    }
+    return fail(action, inputs, steps, data, `failed to render hub authorization: ${errText(err)}`);
+  }
+  try {
+    await ports.hub.writeConf(nextConf);
+    await ports.hub.reload();
+  } catch (err) {
+    return fail(action, inputs, steps, data, `failed to write/reload hub config: ${errText(err)}`);
+  }
+  steps.push(`hub:        ${rotate ? "replaced" : "added"} authorization user "${leafUser}" + reloaded (psk ${fp})`);
+
+  // 3. Deliver.
+  if (inputs.deliver === "oob") {
+    steps.push(`deliver:    OOB — surface PSK for the privileged bot to hand over (registry untouched)`);
+    const report = plan(action, inputs, steps, data);
+    report.applied = true;
+    report.surfaced = { leafUser, psk };
+    return report;
+  }
+
+  // sealed (default): seal the envelope to the member + POST onto the row.
+  let sealed: string;
+  try {
+    const envelope = encodeLeafSecretEnvelope({ leaf_psk: psk, leaf_user: leafUser });
+    sealed = await ports.crypto.seal(envelope, inputs.memberPubkey);
+  } catch (err) {
+    return fail(action, inputs, steps, data, `failed to seal the secret to the member pubkey: ${errText(err)}`);
+  }
+  try {
+    await ports.delivery.postSealedSecret(row.request_id, sealed);
+  } catch (err) {
+    return fail(action, inputs, steps, data, `failed to deliver the sealed secret to the registry: ${errText(err)}`);
+  }
+  steps.push(`deliver:    sealed to member pubkey → posted to admission row ${row.request_id}`);
+
+  const report = plan(action, inputs, steps, data);
+  report.applied = true;
+  return report;
+}
+
+async function revokeMember(
+  inputs: SecretInputs,
+  ports: NetworkSecretPorts,
+): Promise<SecretReport> {
+  const action: SecretAction = "revoke-member";
+  const steps: string[] = [];
+  const data: Record<string, string> = {
+    action,
+    network: inputs.networkId,
+    member_fingerprint: inputs.memberPubkey.slice(0, 12),
+  };
+
+  const row = await ports.admission.findAdmittedRow(inputs.networkId, inputs.memberPubkey);
+  if (!row) {
+    return fail(action, inputs, steps, data, `no ADMITTED admission row for that member on network "${inputs.networkId}" — nothing to revoke`);
+  }
+  const leafUser = inputs.leafUserOverride ?? row.principal_id;
+  data.request_id = row.request_id;
+  data.leaf_user = leafUser;
+  steps.push(`member:     ${inputs.memberPubkey.slice(0, 12)}… (request ${row.request_id})`);
+  steps.push(`leaf user:  ${leafUser}`);
+
+  if (!inputs.apply) {
+    steps.push(`would: DROP hub authorization user "${leafUser}" + reload (CUT transport) → mark admission row REVOKED`);
+    return plan(action, inputs, steps, data);
+  }
+
+  // 1. Drop the hub authorization user + reload — MUST cut transport, not just
+  //    the roster row.
+  let conf: string;
+  try {
+    conf = await ports.hub.readConf();
+  } catch (err) {
+    return fail(action, inputs, steps, data, `failed to read hub config: ${errText(err)}`);
+  }
+  try {
+    const nextConf = removeHubLeafUser(conf, leafUser);
+    await ports.hub.writeConf(nextConf);
+    await ports.hub.reload();
+  } catch (err) {
+    return fail(action, inputs, steps, data, `failed to drop hub authorization user / reload: ${errText(err)}`);
+  }
+  steps.push(`hub:        dropped authorization user "${leafUser}" + reloaded (transport CUT)`);
+
+  // 2. Mark the admission row REVOKED (clears the sealed blob).
+  try {
+    await ports.delivery.revoke(row.request_id);
+  } catch (err) {
+    return fail(action, inputs, steps, data, `hub transport cut, but failed to mark the admission row REVOKED: ${errText(err)}`);
+  }
+  steps.push(`registry:   admission row ${row.request_id} marked REVOKED (sealed blob cleared)`);
+
+  const report = plan(action, inputs, steps, data);
+  report.applied = true;
+  return report;
+}
+
+// ---------------------------------------------------------------------------
+// Report helpers
+// ---------------------------------------------------------------------------
+
+function plan(action: SecretAction, inputs: SecretInputs, steps: string[], data: Record<string, string>): SecretReport {
+  return { ok: true, applied: false, action, networkId: inputs.networkId, steps, data };
+}
+
+function fail(action: SecretAction, inputs: SecretInputs, steps: string[], data: Record<string, string>, reason: string): SecretReport {
+  return { ok: false, applied: false, action, networkId: inputs.networkId, steps, data, reason };
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/cli/cortex/commands/network-secret-ports.ts
+++ b/src/cli/cortex/commands/network-secret-ports.ts
@@ -1,0 +1,66 @@
+/**
+ * ADR-0018 PR5b (#1240) — `cortex network secret` injected-dependency seams.
+ *
+ * Like `network-ports.ts` for join, every SIDE EFFECT the secret-tooling
+ * orchestrator (`network-secret-lib.ts`) depends on is a port: a real adapter
+ * for production (`network-secret-adapters.ts`) and a fake the tests assert
+ * against. The orchestrator is PURE over its ports and gates every MUTATION on
+ * `apply` — dry-run touches nothing.
+ *
+ * The mutations are the two halves of the per-member leaf PSK (ADR-0018):
+ *   - HUB-LOCAL: write the member's `authorization` user into the hub
+ *     nats-server config + reload it (cut/allow transport). The hub-admin
+ *     authority (Q5).
+ *   - REGISTRY: deliver the opaque sealed blob onto the member's ADMITTED
+ *     admission row (sealed mode), or revoke it. NEVER the registry-admin
+ *     admit gate — a distinct hub-admin authority.
+ */
+
+/** Read/write the hub nats-server config + reload it (SIGHUP). HUB-LOCAL. */
+export interface HubAuthPort {
+  /** Read the hub nats-server config text. */
+  readConf(): Promise<string>;
+  /** Write the hub config back (chmod 600 — it carries leaf secrets). */
+  writeConf(text: string): Promise<void>;
+  /** Reload the hub nats-server (SIGHUP) so the auth change takes effect. */
+  reload(): Promise<void>;
+  /** The hub config path, for plan/report output. */
+  readonly confPath: string;
+}
+
+/** Look up a member's admission row in the registry (read-only). */
+export interface AdmissionLookupPort {
+  /**
+   * Find the ADMITTED admission row for (networkId, memberPubkey). Returns the
+   * `request_id` + the member's `principal_id` (the leaf-user default), or
+   * `undefined` when no ADMITTED row exists for that member+network.
+   */
+  findAdmittedRow(
+    networkId: string,
+    memberPubkey: string,
+  ): Promise<{ request_id: string; principal_id: string } | undefined>;
+}
+
+/** Deliver / revoke the opaque sealed blob on the registry. HUB-ADMIN authority. */
+export interface SealDeliveryPort {
+  /** POST the opaque sealed ciphertext onto the ADMITTED row (add-member/rotate). */
+  postSealedSecret(requestId: string, sealedBlob: string): Promise<void>;
+  /** POST a hub-admin revoke (ADMITTED → REVOKED + clear blob). */
+  revoke(requestId: string): Promise<void>;
+}
+
+/** PSK minting + sealing. Injected so tests get deterministic material. */
+export interface SecretCrypto {
+  /** Mint a fresh per-member leaf PSK (base64url). */
+  mintPsk(): string;
+  /** Seal `plaintext` to `recipientPubkeyB64` (crypto_box_seal). */
+  seal(plaintext: string, recipientPubkeyB64: string): Promise<string>;
+}
+
+/** The full port bundle the orchestrator depends on. */
+export interface NetworkSecretPorts {
+  hub: HubAuthPort;
+  admission: AdmissionLookupPort;
+  delivery: SealDeliveryPort;
+  crypto: SecretCrypto;
+}

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -124,6 +124,18 @@ import {
 } from "./network-provision-lib";
 import { buildLiveProvisionPorts } from "./network-provision-adapters";
 import {
+  runNetworkSecret,
+  type SecretAction,
+  type DeliveryMode,
+  type SecretInputs,
+} from "./network-secret-lib";
+import type { NetworkSecretPorts } from "./network-secret-ports";
+import {
+  buildLiveSecretPorts,
+  hubAdminMaterialFromSeedFile,
+} from "./network-secret-adapters";
+import { fetchSealedLeafSecret } from "../../../common/registry/fetch-sealed-secret";
+import {
   createLiveProbeBus,
   type LiveProbeBus,
 } from "./network-ping-adapters";
@@ -136,7 +148,7 @@ export { type ExitResult } from "./_shared/exit-result";
 // Grammar
 // =============================================================================
 
-type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "admit" | "provision";
+type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "admit" | "provision" | "secret";
 
 /**
  * Default registry URL when neither --registry-url nor config provides one.
@@ -346,6 +358,27 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--dry-run": "bool",
       },
     },
+    // ADR-0018 PR5b (#1240) — leaf-secret tooling. `cortex network secret
+    // <action> <network> <member-pubkey>` where <action> ∈ {add-member,
+    // revoke-member, rotate}. Hub-admin authority (Q5): mints the per-member
+    // leaf PSK, writes the member's hub `authorization` user + reloads, and
+    // seals/delivers (or revokes) the secret. DRY-RUN by default; --apply mutates.
+    secret: {
+      positionals: ["action", "network", "member"],
+      flags: {
+        // The HUB-ADMIN seed (mints + seals + signs the registry delivery/revoke).
+        "--admin-seed": "value",
+        "--registry-url": "value",
+        // The hub nats-server config the per-member authorization user lands in.
+        "--hub-config": "value",
+        // add-member: sealed (default, plug-and-play) | oob (trusted bootstrap).
+        "--deliver": "value",
+        // Override the hub leaf user (defaults to the member's principal id).
+        "--leaf-user": "value",
+        "--apply": "bool",
+        "--dry-run": "bool",
+      },
+    },
   },
   universal: { "--json": "bool", "--help": "bool", "-h": "bool" },
 };
@@ -505,6 +538,60 @@ function resolveApply(
 // Subcommand handlers
 // =============================================================================
 
+/**
+ * ADR-0018 PR5b (#1240) — plug-and-play leaf-secret auto-fetch for `join`.
+ *
+ * The locked #1240 constraint: the joiner NEVER handles a secret. When no leaf
+ * secret is resolved from `--leaf-secret` / `stack.nats_infra.leaf_secret`,
+ * `join` AUTO-fetches the sealed blob from the member PoP-read endpoint,
+ * decrypts it with the joiner's OWN seed, and renders the leaf — fully
+ * automatic. BEST-EFFORT + SOFT-CLOSED: any failure (not yet admitted, no
+ * secret delivered, registry down, odd seed) returns `undefined` and the join
+ * falls through to its existing behaviour, so this never breaks a join that
+ * supplied its secret another way.
+ */
+type LeafSecretFetcher = typeof fetchSealedLeafSecret;
+let joinLeafSecretFetcherOverride: LeafSecretFetcher | null = null;
+
+/** Test-only — inject a fake leaf-secret fetcher for the join wiring. */
+export function __setJoinLeafSecretFetcherForTests(f: LeafSecretFetcher | null): void {
+  joinLeafSecretFetcherOverride = f;
+}
+
+async function maybeAutoFetchLeafSecret(
+  networkId: string,
+  inputs: { leafSecret?: string; seedPath: string; registryUrl: string; principal: string },
+): Promise<{ leafSecret: string; leafUser: string } | undefined> {
+  // Only when no leaf secret was resolved from flag/config (don't override an
+  // explicit secret-auth join).
+  if (inputs.leafSecret !== undefined) return undefined;
+
+  const seedExpanded = expandTilde(inputs.seedPath);
+  if (!existsSync(seedExpanded)) return undefined;
+
+  let material;
+  try {
+    enforceChmod600(seedExpanded);
+    const seed = await readFile(seedExpanded, "utf-8");
+    material = materialFromSeedString(seed);
+  } catch (_err) {
+    // Best-effort: a missing/group-readable/odd seed means we cannot auto-fetch.
+    // The join continues without an auto-secret (it may use creds, or fail later
+    // with a clearer leaf-binding error). Safe to ignore here.
+    return undefined;
+  }
+
+  const fetcher = joinLeafSecretFetcherOverride ?? fetchSealedLeafSecret;
+  const res = await fetcher({
+    registryUrl: inputs.registryUrl,
+    networkId,
+    principalId: inputs.principal,
+    material,
+  });
+  if (!res.ok) return undefined;
+  return { leafSecret: res.leafPsk, leafUser: res.leafUser };
+}
+
 async function runJoin(
   networkId: string,
   flags: FlagMap,
@@ -619,16 +706,24 @@ async function runJoin(
   const applyRes = resolveApply(flags);
   if (!applyRes.ok) return usageError("join", applyRes.reason, json);
 
+  // ADR-0018 PR5b — plug-and-play: when no leaf secret came from flag/config,
+  // auto-fetch + unseal it from the admission gate (the joiner never handles a
+  // secret). Best-effort: undefined ⇒ fall through to the existing behaviour.
+  const autoSecret = await maybeAutoFetchLeafSecret(networkId, inputs);
+  const resolvedLeafSecret = inputs.leafSecret ?? autoSecret?.leafSecret;
+  const resolvedLeafUser = inputs.leafUser ?? autoSecret?.leafUser;
+
   const stack: JoiningStack = {
     principalId: inputs.principal,
     stackSlug: slugRes.slug,
     credentials: expandTilde(inputs.credsPath),
     account: inputs.account,
     // C-1224 (ADR-0013 Model B) — pass the secret-auth leaf material (when
-    // resolved) so the join renders a secret-auth pipe binding the principal's
-    // OWN local account instead of a `.creds`-file leaf.
-    ...(inputs.leafSecret !== undefined && { leafSecret: inputs.leafSecret }),
-    ...(inputs.leafUser !== undefined && { leafUser: inputs.leafUser }),
+    // resolved, including PR5b's auto-fetched leaf PSK) so the join renders a
+    // secret-auth pipe binding the principal's OWN local account instead of a
+    // `.creds`-file leaf.
+    ...(resolvedLeafSecret !== undefined && { leafSecret: resolvedLeafSecret }),
+    ...(resolvedLeafUser !== undefined && { leafUser: resolvedLeafUser }),
     leafNode: optionalValueFlag(flags, "--leaf-node"),
     maxHop,
     // O-3 (cortex#1053) — pass the operator-mode leaf package (when resolved)
@@ -1602,6 +1697,129 @@ async function runAdmit(
 }
 
 // =============================================================================
+// ADR-0018 PR5b (#1240) — `cortex network secret <action> <network> <member>`
+// =============================================================================
+
+/** Default registry for the secret tooling — mirrors admit / create (#1228). */
+const DEFAULT_SECRET_REGISTRY_URL = DEFAULT_REGISTRY.url;
+/** Default hub nats-server config (the operator-mode hub local.conf). */
+const DEFAULT_HUB_CONFIG_PATH = "~/.config/nats/local.conf";
+/** Member pubkey grammar — 32-byte Ed25519, base64 (44 chars, padded). */
+const MEMBER_PUBKEY_RE = /^[A-Za-z0-9+/]{43}=$/;
+
+/**
+ * Factory for the secret port bundle. Production builds the live adapters (hub
+ * config fs + reload, registry admin-read + hub-admin delivery/revoke). Tests
+ * inject fakes that record calls without touching fs/registry/nats.
+ */
+export type SecretPortsFactory = (cfg: {
+  hubConfigPath: string;
+  registryUrl: string;
+  material: import("../../../bus/stack-provisioning").StackIdentityMaterial;
+}) => NetworkSecretPorts;
+
+const DEFAULT_SECRET_PORTS_FACTORY: SecretPortsFactory = (cfg) => buildLiveSecretPorts(cfg);
+
+async function runSecret(
+  actionArg: string,
+  networkId: string,
+  member: string,
+  flags: FlagMap,
+  json: boolean,
+  portsFactory: SecretPortsFactory,
+): Promise<ExitResult> {
+  // 1. Validate the action.
+  const validActions: SecretAction[] = ["add-member", "revoke-member", "rotate"];
+  if (!validActions.includes(actionArg as SecretAction)) {
+    return usageError("secret", `unknown action "${actionArg}" (expected one of: ${validActions.join(", ")})`, json);
+  }
+  const action = actionArg as SecretAction;
+
+  // 2. Validate network + member pubkey grammar.
+  if (!NETWORK_ID_RE.test(networkId)) {
+    return usageError("secret", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+  if (!MEMBER_PUBKEY_RE.test(member)) {
+    return usageError("secret", `member "${member}" must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)`, json);
+  }
+
+  // 3. Resolve delivery mode (add-member / rotate only — rotate is always sealed).
+  const deliverRaw = optionalValueFlag(flags, "--deliver") ?? "sealed";
+  if (deliverRaw !== "sealed" && deliverRaw !== "oob") {
+    return usageError("secret", `--deliver must be "sealed" or "oob" (got "${deliverRaw}")`, json);
+  }
+  const deliver: DeliveryMode = deliverRaw;
+  if (action === "rotate" && deliver === "oob") {
+    return usageError("secret", `rotate always re-seals; --deliver oob is only valid for add-member`, json);
+  }
+
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return usageError("secret", applyRes.reason, json);
+
+  const seedRes = requireValueFlag(flags, "--admin-seed");
+  if (!seedRes.ok) return usageError("secret", seedRes.reason, json);
+
+  const registryUrl = optionalValueFlag(flags, "--registry-url") ?? DEFAULT_SECRET_REGISTRY_URL;
+  const hubConfigPath = optionalValueFlag(flags, "--hub-config") ?? DEFAULT_HUB_CONFIG_PATH;
+  const leafUserOverride = optionalValueFlag(flags, "--leaf-user");
+
+  // 4. Load + chmod-600-gate the hub-admin seed.
+  const matRes = await hubAdminMaterialFromSeedFile(seedRes.value);
+  if (!matRes.ok) return opError("secret", matRes.reason, json);
+
+  const ports = portsFactory({ hubConfigPath, registryUrl, material: matRes.material });
+  const inputs: SecretInputs = {
+    action,
+    networkId,
+    memberPubkey: member,
+    deliver,
+    ...(leafUserOverride !== undefined && { leafUserOverride }),
+    apply: applyRes.apply,
+  };
+
+  let report;
+  try {
+    report = await runNetworkSecret(inputs, ports);
+  } catch (err) {
+    return opError("secret", `secret ${action} failed: ${err instanceof Error ? err.message : String(err)}`, json);
+  }
+
+  // 5. Render. SECRETS never appear in steps/data; the oob PSK is surfaced in a
+  // dedicated, explicitly-labelled block (the one place a secret reaches stdout).
+  if (json) {
+    const data: Record<string, string> = {
+      subcommand: "secret",
+      applied: report.applied ? "true" : "false",
+      ...report.data,
+      hub_admin_fingerprint: matRes.material.fingerprint,
+    };
+    // The oob PSK is the hub-admin's to hand over — include it under an explicit
+    // key so a machine consumer can pluck it, never folded into the plan text.
+    if (report.surfaced) {
+      data.oob_leaf_user = report.surfaced.leafUser;
+      data.oob_leaf_secret = report.surfaced.psk;
+    }
+    const env = report.ok ? envelopeOk([], data) : envelopeError(report.reason ?? "secret command failed", data);
+    return report.ok ? ok(renderJson(env)) : { exitCode: 1, stdout: "", stderr: renderJson(env) };
+  }
+
+  const header = report.applied
+    ? `cortex network secret ${action} ${networkId}: ${report.ok ? "ok" : "FAILED"}`
+    : `cortex network secret ${action} ${networkId}: dry-run (no mutation; pass --apply)`;
+  const lines = [header, ...report.steps.map((s) => `  ${s}`)];
+  if (!report.ok) lines.push(`  ✗ ${report.reason ?? "unknown failure"}`);
+  if (report.surfaced) {
+    lines.push("");
+    lines.push("  ── OUT-OF-BAND SECRET (hand this to the member over a secure channel) ──");
+    lines.push(`  leaf user:   ${report.surfaced.leafUser}`);
+    lines.push(`  leaf secret: ${report.surfaced.psk}`);
+  }
+  lines.push("");
+  const body = lines.join("\n");
+  return report.ok ? ok(body) : { exitCode: 1, stdout: "", stderr: body };
+}
+
+// =============================================================================
 // G1d / T1 (cortex#1139) — `cortex network provision <stack>`
 // =============================================================================
 
@@ -1842,6 +2060,9 @@ export async function dispatchNetwork(
   // auto-provision CLI tests drive fake arc/fs ports. Production omits it → the
   // live adapters (arc account-tree seam + signing + config write-back).
   provisionPortsFactory: ProvisionPortsFactory = DEFAULT_PROVISION_PORTS_FACTORY,
+  // ADR-0018 PR5b — injectable secret-ports factory so the `secret` CLI tests
+  // drive fake hub/registry/crypto ports. Production omits → the live adapters.
+  secretPortsFactory: SecretPortsFactory = DEFAULT_SECRET_PORTS_FACTORY,
 ): Promise<ExitResult> {
   let parsed;
   try {
@@ -1881,6 +2102,15 @@ export async function dispatchNetwork(
       return runAdmit(parsed.positionals["request-id"] ?? "", parsed.flags, json);
     case "provision":
       return runProvision(parsed.positionals.stack ?? "", parsed.flags, json, load, provisionPortsFactory);
+    case "secret":
+      return runSecret(
+        parsed.positionals.action ?? "",
+        parsed.positionals.network ?? "",
+        parsed.positionals.member ?? "",
+        parsed.flags,
+        json,
+        secretPortsFactory,
+      );
   }
 }
 
@@ -1902,6 +2132,9 @@ Usage:
                         [--discord-role <name>] [--apply] [--dry-run] [--json]
   cortex network provision <stack> [--config <p>] [--principal <id>] [--seed-path <p>]
                         [--creds <p>] [--force] [--apply] [--dry-run] [--json]
+  cortex network secret <add-member|revoke-member|rotate> <network> <member-pubkey>
+                        --admin-seed <hub-admin-seed> [--registry-url <url>] [--hub-config <p>]
+                        [--deliver sealed|oob] [--leaf-user <u>] [--apply] [--dry-run] [--json]
 
 The one-liner (#753): \`cortex network join <network>\` derives EVERYTHING from
 the loaded cortex.yaml — principal (principal.id), stack (stack.id), signing

--- a/src/common/nats/__tests__/hub-leaf-authorization.test.ts
+++ b/src/common/nats/__tests__/hub-leaf-authorization.test.ts
@@ -1,0 +1,105 @@
+/**
+ * ADR-0018 PR5b — hub-side leaf authorization renderer (pure) tests.
+ *
+ * The hub end of the per-member PSK: add/replace/remove a `leafnodes {
+ * authorization { users: [...] } }` entry idempotently, without touching the
+ * hub's own leafnodes directives, and never letting a hostile value
+ * break out of the users[] array.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  upsertHubLeafUser,
+  removeHubLeafUser,
+  hubLeafUserPresent,
+  listHubLeafUsers,
+  HubAuthConflictError,
+} from "../hub-leaf-authorization";
+
+describe("upsertHubLeafUser", () => {
+  test("adds a user into a config with no leafnodes block (creates the block)", () => {
+    const conf = `server_name: hub\nlisten: 0.0.0.0:4222\n`;
+    const out = upsertHubLeafUser(conf, "alice", "PSK-alice");
+    expect(out).toContain("leafnodes {");
+    expect(hubLeafUserPresent(out, "alice")).toBe(true);
+    expect(listHubLeafUsers(out)).toEqual([{ user: "alice", secret: "PSK-alice" }]);
+    // The hub's own directives are preserved verbatim.
+    expect(out).toContain("server_name: hub");
+    expect(out).toContain("listen: 0.0.0.0:4222");
+  });
+
+  test("inserts into an EXISTING leafnodes block, preserving its directives", () => {
+    const conf = `leafnodes {\n  listen: 0.0.0.0:7422\n  no_advertise: true\n}\n`;
+    const out = upsertHubLeafUser(conf, "alice", "PSK-alice");
+    expect(out).toContain("listen: 0.0.0.0:7422");
+    expect(out).toContain("no_advertise: true");
+    expect(hubLeafUserPresent(out, "alice")).toBe(true);
+  });
+
+  test("is idempotent — same (user, secret) re-render is byte-stable", () => {
+    const conf = `leafnodes {\n  listen: 0.0.0.0:7422\n}\n`;
+    const once = upsertHubLeafUser(conf, "alice", "PSK-alice");
+    const twice = upsertHubLeafUser(once, "alice", "PSK-alice");
+    expect(twice).toBe(once);
+  });
+
+  test("accumulates multiple distinct users (sorted)", () => {
+    let conf = `leafnodes {\n  listen: 0.0.0.0:7422\n}\n`;
+    conf = upsertHubLeafUser(conf, "bob", "PSK-bob");
+    conf = upsertHubLeafUser(conf, "alice", "PSK-alice");
+    expect(listHubLeafUsers(conf)).toEqual([
+      { user: "alice", secret: "PSK-alice" },
+      { user: "bob", secret: "PSK-bob" },
+    ]);
+  });
+
+  test("rotate: a new secret for an existing user REPLACES it (old inert)", () => {
+    let conf = upsertHubLeafUser(`leafnodes {}\n`, "alice", "PSK-old");
+    conf = upsertHubLeafUser(conf, "alice", "PSK-new");
+    const users = listHubLeafUsers(conf);
+    expect(users).toEqual([{ user: "alice", secret: "PSK-new" }]);
+    expect(conf).not.toContain("PSK-old");
+  });
+
+  test("rejects a malformed user (HOCON-injection guard)", () => {
+    expect(() => upsertHubLeafUser(`leafnodes {}\n`, 'a" } ] } evil {', "x")).toThrow();
+    expect(() => upsertHubLeafUser(`leafnodes {}\n`, "Alice", "x")).toThrow(); // uppercase
+  });
+
+  test("rejects an empty secret", () => {
+    expect(() => upsertHubLeafUser(`leafnodes {}\n`, "alice", "")).toThrow();
+  });
+
+  test("refuses to clobber a hand-written authorization block inside leafnodes", () => {
+    const conf = `leafnodes {\n  authorization {\n    user: legacy\n    password: hunter2\n  }\n}\n`;
+    expect(() => upsertHubLeafUser(conf, "alice", "PSK")).toThrow(HubAuthConflictError);
+  });
+});
+
+describe("removeHubLeafUser", () => {
+  test("removes a user; idempotent on an absent user", () => {
+    let conf = upsertHubLeafUser(`leafnodes {\n  listen: 0.0.0.0:7422\n}\n`, "alice", "PSK-alice");
+    conf = upsertHubLeafUser(conf, "bob", "PSK-bob");
+    conf = removeHubLeafUser(conf, "alice");
+    expect(hubLeafUserPresent(conf, "alice")).toBe(false);
+    expect(hubLeafUserPresent(conf, "bob")).toBe(true);
+    // The leaked secret is gone from the file (transport cut).
+    expect(conf).not.toContain("PSK-alice");
+    // idempotent
+    expect(removeHubLeafUser(conf, "alice")).toBe(conf);
+  });
+
+  test("removing the last user tears down the managed region, preserving hub directives", () => {
+    let conf = upsertHubLeafUser(`leafnodes {\n  listen: 0.0.0.0:7422\n}\n`, "alice", "PSK-alice");
+    conf = removeHubLeafUser(conf, "alice");
+    expect(conf).not.toContain("authorization");
+    expect(conf).not.toContain("PSK-alice");
+    expect(conf).toContain("listen: 0.0.0.0:7422");
+  });
+
+  test("add → remove round-trips to an empty user set", () => {
+    const base = `leafnodes {\n  listen: 0.0.0.0:7422\n}\n`;
+    const out = removeHubLeafUser(upsertHubLeafUser(base, "alice", "PSK"), "alice");
+    expect(listHubLeafUsers(out)).toEqual([]);
+  });
+});

--- a/src/common/nats/__tests__/leaf-psk.test.ts
+++ b/src/common/nats/__tests__/leaf-psk.test.ts
@@ -1,0 +1,30 @@
+/**
+ * ADR-0018 PR5b — leaf PSK minting tests.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { mintLeafPsk, pskFingerprint } from "../leaf-psk";
+
+describe("mintLeafPsk", () => {
+  test("mints a high-entropy base64url PSK (URL/HOCON-safe charset)", () => {
+    const psk = mintLeafPsk();
+    // 32 bytes → 43 base64url chars (no padding).
+    expect(psk.length).toBe(43);
+    expect(psk).toMatch(/^[A-Za-z0-9_-]+$/); // no +, /, =, @, : — safe in URL userinfo + HOCON
+  });
+
+  test("is unique across mints (CSPRNG)", () => {
+    const set = new Set(Array.from({ length: 100 }, () => mintLeafPsk()));
+    expect(set.size).toBe(100);
+  });
+});
+
+describe("pskFingerprint", () => {
+  test("is short, stable, and not the secret itself", async () => {
+    const psk = mintLeafPsk();
+    const fp = await pskFingerprint(psk);
+    expect(fp).toMatch(/^[0-9a-f]{8}$/);
+    expect(fp).not.toBe(psk);
+    expect(await pskFingerprint(psk)).toBe(fp); // stable
+  });
+});

--- a/src/common/nats/hub-leaf-authorization.ts
+++ b/src/common/nats/hub-leaf-authorization.ts
@@ -1,0 +1,302 @@
+/**
+ * ADR-0018 PR5b (#1240) — hub-side leaf `authorization` user management (PURE).
+ *
+ * The hub end of the per-member leaf PSK (ADR-0018 Q2). A member's nats-server
+ * leaf authenticates to the hub by presenting `user:secret` in the dial URL
+ * userinfo (rendered by `leaf-remote-renderer.ts`); the hub matches it against
+ * a `leafnodes { authorization { users: [{ user, password }] } }` entry. This
+ * module is the pure text transform that ADDS / REMOVES one such per-member
+ * entry on the hub's config — the hub-admin authority (Q5).
+ *
+ * ## Why a cortex-managed marker region (not free HOCON surgery)
+ *
+ * nats-server has exactly ONE `leafnodes {}` block (two do not merge — see
+ * `leaf-remote-renderer.ts` §"include-file vs in-place merge"). So the per-member
+ * users CANNOT live in a separate included file; they must edit the live
+ * `leafnodes.authorization.users` array. To keep that edit idempotent + reversible
+ * + safe, cortex owns a MARKER-DELIMITED region inside the leafnodes block:
+ *
+ *     leafnodes {
+ *       # >>> cortex-managed leaf authorization (network secret tooling) — do not hand-edit
+ *       authorization {
+ *         users: [
+ *           { user: "alice", password: "…" }
+ *         ]
+ *       }
+ *       # <<< cortex-managed leaf authorization
+ *       …the hub's own leafnodes directives (listen, tls, …) untouched…
+ *     }
+ *
+ * The functions parse the managed region's entries into a map keyed by `user`,
+ * mutate one entry, and re-render — so add/remove/rotate are idempotent and a
+ * remove of the last entry tears the region down to nothing. The hub's own
+ * own `leafnodes` directives (listen/tls/etc.) are never touched.
+ *
+ * ## Injection safety
+ *
+ * Both `user` and `password` are emitted as JSON-quoted HOCON strings, and the
+ * `user` is validated against a strict grammar before it is ever written, so a
+ * value carrying `"`/`{`/`}`/newline can never break out of the `users[]` array
+ * and inject nats-server directives. The PSK is base64url (see `leaf-psk.ts`),
+ * so quoting is belt-and-braces. The password value is NEVER logged by callers.
+ *
+ * Pure: text in, text out. The live file read/write + the SIGHUP reload are the
+ * adapter's job (`network-secret-adapters.ts`).
+ */
+
+/** Leaf `user` grammar — the userinfo USER (defaults to the principal id). */
+const LEAF_USER_RE = /^[a-z][a-z0-9_-]*$/;
+
+const MANAGED_START =
+  "# >>> cortex-managed leaf authorization (network secret tooling) — do not hand-edit";
+const MANAGED_END = "# <<< cortex-managed leaf authorization";
+
+/** One hub leaf-authorization user entry. */
+export interface HubLeafUser {
+  user: string;
+  /** The PSK (base64url). The matching `password` in the hub config. */
+  secret: string;
+}
+
+/**
+ * Thrown when the hub config carries a NON-cortex-managed `authorization {}`
+ * block inside `leafnodes` — we refuse to clobber a hand-written one.
+ */
+export class HubAuthConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HubAuthConflictError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return `conf` with the leaf `authorization` user `user` ⇒ `secret` ensured
+ * (added or replaced). Idempotent: re-rendering the same (user, secret) is a
+ * byte-stable no-op once present; a new secret for an existing user REPLACES it
+ * (rotate). Validates `user`; throws on a malformed user or a hand-written
+ * (non-managed) `authorization` block inside leafnodes.
+ */
+export function upsertHubLeafUser(conf: string, user: string, secret: string): string {
+  assertValidUser(user);
+  if (secret.length === 0) {
+    throw new Error("hub-leaf-authorization: refusing to write an empty leaf secret");
+  }
+  const users = parseManagedUsers(conf);
+  const next = users.filter((u) => u.user !== user);
+  next.push({ user, secret });
+  next.sort((a, b) => a.user.localeCompare(b.user)); // deterministic order
+  return writeManagedUsers(conf, next);
+}
+
+/**
+ * Return `conf` with the leaf `authorization` user `user` REMOVED. Idempotent:
+ * removing an absent user is a no-op. Removing the last user tears the managed
+ * region down (leaving the hub's own leafnodes directives intact).
+ */
+export function removeHubLeafUser(conf: string, user: string): string {
+  // No grammar assertion on remove — a caller cleaning up a legacy/odd user id
+  // should still be able to drop it.
+  const users = parseManagedUsers(conf);
+  if (!users.some((u) => u.user === user)) return conf; // idempotent no-op
+  const next = users.filter((u) => u.user !== user);
+  return writeManagedUsers(conf, next);
+}
+
+/** True iff the hub config carries a cortex-managed leaf user named `user`. */
+export function hubLeafUserPresent(conf: string, user: string): boolean {
+  return parseManagedUsers(conf).some((u) => u.user === user);
+}
+
+/** Read the cortex-managed leaf users from a hub config (for status/tests). */
+export function listHubLeafUsers(conf: string): HubLeafUser[] {
+  return parseManagedUsers(conf);
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function assertValidUser(user: string): void {
+  if (!LEAF_USER_RE.test(user)) {
+    throw new Error(
+      `hub-leaf-authorization: leaf user ${JSON.stringify(user)} must be letter-prefixed lowercase (${LEAF_USER_RE})`,
+    );
+  }
+}
+
+/**
+ * Locate the cortex-managed region (between the markers) and parse its user
+ * entries. Returns [] when no managed region exists yet.
+ */
+function parseManagedUsers(conf: string): HubLeafUser[] {
+  const region = extractManagedRegion(conf);
+  if (region === undefined) return [];
+  const users: HubLeafUser[] = [];
+  // Each entry is rendered `{ user: "x", password: "y" }`. The values cortex
+  // writes (grammar-checked user, base64url PSK) never contain `"`, so a
+  // non-greedy quoted-capture is exact for our own shape.
+  const re = /\{\s*user:\s*"([^"]*)",\s*password:\s*"([^"]*)"\s*\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(region)) !== null) {
+    users.push({ user: m[1] ?? "", secret: m[2] ?? "" });
+  }
+  return users;
+}
+
+/** The text between the managed markers (exclusive), or undefined if absent. */
+function extractManagedRegion(conf: string): string | undefined {
+  const start = conf.indexOf(MANAGED_START);
+  if (start < 0) return undefined;
+  const end = conf.indexOf(MANAGED_END, start);
+  if (end < 0) return undefined;
+  return conf.slice(start + MANAGED_START.length, end);
+}
+
+/** Render the managed region body (markers + authorization block) at `indent`. */
+function renderManagedRegion(users: HubLeafUser[], indent: string): string {
+  const inner = `${indent}  `;
+  const userInner = `${inner}    `;
+  const lines = [
+    `${indent}${MANAGED_START}`,
+    `${inner}authorization {`,
+    `${inner}  users: [`,
+    ...users.map(
+      (u) => `${userInner}{ user: ${JSON.stringify(u.user)}, password: ${JSON.stringify(u.secret)} }`,
+    ),
+    `${inner}  ]`,
+    `${inner}}`,
+    `${indent}${MANAGED_END}`,
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Write the managed user set back into `conf`, creating the leafnodes block /
+ * managed region as needed. When `users` is empty the managed region is removed
+ * entirely (and an empty leafnodes block cortex itself created is cleaned up).
+ */
+function writeManagedUsers(conf: string, users: HubLeafUser[]): string {
+  const hasRegion = extractManagedRegion(conf) !== undefined;
+
+  // Empty set → drop the region.
+  if (users.length === 0) {
+    if (!hasRegion) return conf;
+    return stripManagedRegion(conf);
+  }
+
+  const region = renderManagedRegion(users, "  ");
+
+  if (hasRegion) {
+    // Replace the existing managed region (markers inclusive) in place.
+    const start = conf.indexOf(MANAGED_START);
+    const endMarker = conf.indexOf(MANAGED_END, start);
+    const end = endMarker + MANAGED_END.length;
+    // Preserve the leading indentation already on the start-marker line.
+    const lineStart = conf.lastIndexOf("\n", start) + 1;
+    const leading = conf.slice(lineStart, start);
+    const renderedNoLeadFirst = region.replace(/^ {2}/, ""); // region rendered at indent "  "
+    return conf.slice(0, lineStart) + leading + renderedNoLeadFirst + conf.slice(end);
+  }
+
+  // No managed region yet — find / create the leafnodes block and insert it.
+  const leaf = findLeafnodesBlock(conf);
+  if (leaf === undefined) {
+    // No leafnodes block at all → append a fresh one carrying only our region.
+    const base = conf.replace(/\n*$/, "");
+    const prefix = base.length === 0 ? "" : `${base}\n\n`;
+    return `${prefix}leafnodes {\n${region}\n}\n`;
+  }
+
+  // A leafnodes block exists. Refuse to collide with a hand-written authorization.
+  if (hasNonManagedAuthorization(conf, leaf)) {
+    throw new HubAuthConflictError(
+      "hub-leaf-authorization: the hub config's `leafnodes` block already has a hand-written " +
+        "`authorization {}` — refusing to clobber it. Remove or convert it to the cortex-managed " +
+        "marker region first.",
+    );
+  }
+
+  // Insert the managed region just after the leafnodes opening brace.
+  const insertAt = leaf.openBraceIndex + 1;
+  return conf.slice(0, insertAt) + `\n${region}` + conf.slice(insertAt);
+}
+
+/** Remove the managed region (markers inclusive) + a leafnodes block cortex left empty. */
+function stripManagedRegion(conf: string): string {
+  const start = conf.indexOf(MANAGED_START);
+  const endMarker = conf.indexOf(MANAGED_END, start);
+  if (start < 0 || endMarker < 0) return conf;
+  const end = endMarker + MANAGED_END.length;
+  // Drop the whole region lines (including the newline before the start marker
+  // and the trailing newline after the end marker).
+  const lineStart = conf.lastIndexOf("\n", start); // index of the \n before the region (or -1)
+  const after = conf.indexOf("\n", end);
+  const cutStart = lineStart < 0 ? start : lineStart;
+  const cutEnd = after < 0 ? end : after;
+  let out = conf.slice(0, cutStart) + conf.slice(cutEnd);
+  // If this leaves an EMPTY `leafnodes { }` block cortex created, drop it too.
+  out = out.replace(/\n*leafnodes \{\s*\}\n?/g, (match) =>
+    // Only collapse a truly empty block (whitespace-only between braces).
+    /\{\s*\}/.test(match) ? "\n" : match,
+  );
+  return out;
+}
+
+interface LeafnodesBlock {
+  /** Index of the `{` opening the leafnodes block. */
+  openBraceIndex: number;
+  /** Index just past the matching `}`. */
+  closeBraceIndex: number;
+}
+
+/**
+ * Find the top-level `leafnodes { … }` block by brace matching. Tolerates
+ * `leafnodes {`, `leafnodes:{`, `leafnodes = {` and intervening whitespace.
+ * Returns undefined when no such block exists.
+ */
+function findLeafnodesBlock(conf: string): LeafnodesBlock | undefined {
+  const kw = /(^|\n)[ \t]*leafnodes[ \t]*[:=]?[ \t]*\{/;
+  const m = kw.exec(conf);
+  if (!m) return undefined;
+  const openBraceIndex = conf.indexOf("{", m.index);
+  if (openBraceIndex < 0) return undefined;
+  // Brace-match from the opening brace.
+  let depth = 0;
+  for (let i = openBraceIndex; i < conf.length; i++) {
+    const ch = conf[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return { openBraceIndex, closeBraceIndex: i + 1 };
+    }
+  }
+  return undefined; // unbalanced — treat as no usable block
+}
+
+/**
+ * True iff the leafnodes block carries an `authorization {` that is NOT inside
+ * the cortex-managed region. Used to refuse clobbering a hand-written auth.
+ */
+function hasNonManagedAuthorization(conf: string, leaf: LeafnodesBlock): boolean {
+  const block = conf.slice(leaf.openBraceIndex, leaf.closeBraceIndex);
+  const authRe = /(^|\n)[ \t]*authorization[ \t]*\{/g;
+  let m: RegExpExecArray | null;
+  while ((m = authRe.exec(block)) !== null) {
+    // Absolute index of this authorization keyword in the full conf.
+    const abs = leaf.openBraceIndex + m.index + (m[1]?.length ?? 0);
+    if (!isInsideManagedRegion(conf, abs)) return true;
+  }
+  return false;
+}
+
+function isInsideManagedRegion(conf: string, index: number): boolean {
+  const start = conf.indexOf(MANAGED_START);
+  if (start < 0 || index < start) return false;
+  const end = conf.indexOf(MANAGED_END, start);
+  if (end < 0) return false;
+  return index < end;
+}

--- a/src/common/nats/leaf-psk.ts
+++ b/src/common/nats/leaf-psk.ts
@@ -1,0 +1,53 @@
+/**
+ * ADR-0018 PR5b (#1240) — per-member leaf PSK minting.
+ *
+ * The leaf shared secret (ADR-0013) is a TRANSPORT PSK, not an identity
+ * credential: it authenticates a member's nats-server leaf link to the hub
+ * (presented as URL userinfo `tls://<user>:<secret>@host`, matched by the hub's
+ * `leafnodes { authorization { users: [{ user, password }] } }`). ADR-0018 Q2
+ * makes it PER-MEMBER (its own hub `authorization` user) so revoke is targeted
+ * and leaks are attributable.
+ *
+ * This module mints that PSK. It is the ONLY thing in the leaf-secret path that
+ * generates secret material; everything downstream (seal, hub-config write,
+ * registry delivery) carries it. The PSK is HIGH-ENTROPY (32 CSPRNG bytes) and
+ * URL/HOCON-safe (base64url, no `@`/`:`/`/`/`+` that would need escaping in the
+ * dial URL userinfo or the hub config). It is never logged.
+ */
+
+/** Length of a minted leaf PSK in raw bytes (256 bits of entropy). */
+const PSK_BYTES = 32;
+
+/**
+ * Mint a fresh per-member leaf PSK: 32 CSPRNG bytes, base64url-encoded (no
+ * padding). base64url keeps the secret free of characters that are significant
+ * in the leaf dial URL userinfo or in HOCON, so it round-trips cleanly through
+ * both the rendered hub config and the member's leaf remote without escaping
+ * surprises. NEVER log the return value — surface only a fingerprint if needed.
+ */
+export function mintLeafPsk(): string {
+  const bytes = new Uint8Array(PSK_BYTES);
+  crypto.getRandomValues(bytes);
+  return base64UrlNoPad(bytes);
+}
+
+/** Standard base64 → base64url, padding stripped. */
+function base64UrlNoPad(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * A short, LOG-SAFE fingerprint of a PSK (or any secret) — the first 8 chars of
+ * its SHA-256, hex. Use this in report output INSTEAD of the secret so a
+ * rotate/deliver can be correlated in logs without the secret ever appearing.
+ * Async (WebCrypto digest); callers in the leaf-secret path are already async.
+ */
+export async function pskFingerprint(secret: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  const bytes = new Uint8Array(digest).slice(0, 4);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/common/registry/__tests__/fetch-sealed-secret.test.ts
+++ b/src/common/registry/__tests__/fetch-sealed-secret.test.ts
@@ -1,0 +1,125 @@
+/**
+ * ADR-0018 PR5b — member-side fetch + unseal round-trip tests.
+ *
+ * Exercises the FULL crypto round-trip with REAL keys: mint a member identity,
+ * seal a leaf-secret envelope to its pubkey (as the hub-admin would), serve it
+ * through a fake `/admission-requests/mine`, and prove the member fetches +
+ * unseals exactly its own PSK — and that wrong-network / no-blob / tampered /
+ * wrong-recipient all fail soft-closed.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createUser } from "nkeys.js";
+import { sealToPrincipal } from "../../crypto/seal-to-principal";
+import { encodeLeafSecretEnvelope, decodeLeafSecretEnvelope } from "../sealed-leaf-secret";
+import { fetchSealedLeafSecret, type FetchLike } from "../fetch-sealed-secret";
+import { materialFromSeedString, type StackIdentityMaterial } from "../../../bus/stack-provisioning";
+
+function newMember(): StackIdentityMaterial {
+  const kp = createUser();
+  const seed = new TextDecoder().decode(kp.getSeed());
+  return materialFromSeedString(seed);
+}
+
+/** A fake registry serving a fixed set of /mine rows. */
+function fakeRegistry(rows: unknown[]): FetchLike {
+  return async (url) => {
+    if (url.endsWith("/admission-requests/mine")) {
+      return { ok: true, status: 200, json: async () => rows, text: async () => JSON.stringify(rows) };
+    }
+    return { ok: false, status: 404, json: async () => ({}), text: async () => "not found" };
+  };
+}
+
+async function sealedFor(material: StackIdentityMaterial, leafPsk: string, leafUser: string): Promise<string> {
+  const plaintext = encodeLeafSecretEnvelope({ leaf_psk: leafPsk, leaf_user: leafUser });
+  return sealToPrincipal(plaintext, material.pubkeyB64);
+}
+
+describe("fetchSealedLeafSecret — round-trip", () => {
+  test("member fetches + unseals its own leaf PSK", async () => {
+    const member = newMember();
+    const sealed = await sealedFor(member, "PSK-abc", "alice");
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealed },
+    ]);
+
+    const res = await fetchSealedLeafSecret({
+      registryUrl: "https://registry.example",
+      networkId: "metafactory",
+      principalId: "alice",
+      material: member,
+      fetchImpl,
+    });
+    expect(res).toEqual({ ok: true, leafPsk: "PSK-abc", leafUser: "alice" });
+  });
+
+  test("selects the row for the TARGET network (ignores other networks)", async () => {
+    const member = newMember();
+    const sealedMeta = await sealedFor(member, "PSK-meta", "alice");
+    const sealedOther = await sealedFor(member, "PSK-other", "alice");
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "other", status: "ADMITTED", sealed_secret: sealedOther },
+      { request_id: "r2", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealedMeta },
+    ]);
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
+    expect(res.ok && res.leafPsk).toBe("PSK-meta");
+  });
+
+  test("no admitted+sealed row → soft-closed { ok: false }", async () => {
+    const member = newMember();
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "PENDING", sealed_secret: null },
+    ]);
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  test("a blob sealed to a DIFFERENT member does not open (fails soft-closed)", async () => {
+    const member = newMember();
+    const stranger = newMember();
+    const sealedForStranger = await sealedFor(stranger, "PSK-x", "bob");
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealedForStranger },
+    ]);
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  test("a tampered ciphertext fails soft-closed", async () => {
+    const member = newMember();
+    const sealed = await sealedFor(member, "PSK-abc", "alice");
+    const tampered = sealed.slice(0, -4) + (sealed.endsWith("A") ? "B" : "A") + sealed.slice(-3);
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: tampered },
+    ]);
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+
+  test("registry HTTP error → soft-closed", async () => {
+    const member = newMember();
+    const fetchImpl: FetchLike = async () => ({ ok: false, status: 503, json: async () => ({}), text: async () => "down" });
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe("LeafSecretEnvelope — the M3 seam", () => {
+  test("encode→decode round-trips leaf_psk + leaf_user", () => {
+    const env = decodeLeafSecretEnvelope(encodeLeafSecretEnvelope({ leaf_psk: "p", leaf_user: "u" }));
+    expect(env).toEqual({ v: 1, leaf_psk: "p", leaf_user: "u" });
+  });
+
+  test("tolerates the future payload_key field (M3 #1246 rides the same envelope)", () => {
+    const json = encodeLeafSecretEnvelope({ leaf_psk: "p", leaf_user: "u", payload_key: "K" });
+    const env = decodeLeafSecretEnvelope(json);
+    expect(env.payload_key).toBe("K");
+    expect(env.leaf_psk).toBe("p");
+  });
+
+  test("rejects a malformed envelope without echoing the plaintext", () => {
+    expect(() => decodeLeafSecretEnvelope("not json")).toThrow(/not valid JSON/);
+    expect(() => decodeLeafSecretEnvelope(JSON.stringify({ leaf_user: "u" }))).toThrow(/leaf_psk/);
+  });
+});

--- a/src/common/registry/fetch-sealed-secret.ts
+++ b/src/common/registry/fetch-sealed-secret.ts
@@ -1,0 +1,147 @@
+/**
+ * ADR-0018 PR5b (#1240) — member-side fetch + unseal of the leaf secret.
+ *
+ * The plug-and-play half (#1240 locked constraint): `cortex network join`
+ * AUTO-fetches the sealed blob from the member PoP-read endpoint
+ * (`GET /admission-requests/mine`), decrypts it with the joiner's OWN seed, and
+ * renders the leaf — the user never copies/pastes a secret.
+ *
+ * This module is that primitive, transport-injectable so the join wiring + the
+ * tests drive it without a live registry. It:
+ *   1. signs a proof-of-possession read claim with the member's seed (the
+ *      signature IS the authorization — no admin key),
+ *   2. GETs `/admission-requests/mine`,
+ *   3. selects the ADMITTED row for the target network that carries a sealed
+ *      blob,
+ *   4. opens the `crypto_box_seal` with the member's raw ed25519 seed
+ *      ({@link openSealed}) and decodes the {@link LeafSecretEnvelope}.
+ *
+ * Returns the leaf PSK + user (and, once M3 lands, the same call surfaces the
+ * payload key from the SAME envelope). Fails SOFT-CLOSED: every failure is a
+ * typed `{ ok: false, reason }` so the join can fall through to its existing
+ * config/flag/oob behaviour rather than aborting.
+ */
+
+import { canonicalJSON } from "./signing";
+import { openSealed } from "../crypto/seal-to-principal";
+import { decodeLeafSecretEnvelope } from "./sealed-leaf-secret";
+import {
+  signClaimWithSeed,
+  rawEd25519SeedFromNkeySeed,
+  type StackIdentityMaterial,
+} from "../../bus/stack-provisioning";
+
+/** The minimal admission-row shape the member PoP-read returns. */
+interface AdmissionMineRow {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  network_id: string | null;
+  status: string;
+  sealed_secret: string | null;
+}
+
+/** Injectable fetch (defaults to `globalThis.fetch`) so tests stay hermetic. */
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown>; text: () => Promise<string> }>;
+
+export interface FetchSealedLeafSecretInput {
+  /** Registry base URL (e.g. the descriptor host). */
+  registryUrl: string;
+  /** The network whose leaf PSK we want. */
+  networkId: string;
+  /** The joining principal id (echoed into the signed claim). */
+  principalId: string;
+  /** The member's identity material — pubkey + seed (used to sign + unseal). */
+  material: StackIdentityMaterial;
+  /** Injected transport (tests). Production omits → `globalThis.fetch`. */
+  fetchImpl?: FetchLike;
+  /** Injected clock (tests). Production omits → `Date`. */
+  now?: () => Date;
+}
+
+export type FetchSealedLeafSecretResult =
+  | { ok: true; leafPsk: string; leafUser: string; payloadKey?: string }
+  | { ok: false; reason: string };
+
+/**
+ * Fetch + unseal this member's leaf secret for `networkId`. SOFT-CLOSED on every
+ * failure path (no throw): the join caller treats `{ ok: false }` as "no sealed
+ * secret available — fall through".
+ */
+export async function fetchSealedLeafSecret(
+  input: FetchSealedLeafSecretInput,
+): Promise<FetchSealedLeafSecretResult> {
+  const fetchImpl: FetchLike = input.fetchImpl ?? globalThis.fetch;
+  const now = input.now ?? (() => new Date());
+
+  // 1. Sign the PoP read claim with the member's own key.
+  const claim = {
+    principal_id: input.principalId,
+    peer_pubkey: input.material.pubkeyB64,
+    issued_at: now().toISOString(),
+  };
+  let header: string;
+  try {
+    const sig = await signClaimWithSeed(
+      input.material.seed,
+      new TextEncoder().encode(canonicalJSON(claim)),
+    );
+    header = JSON.stringify({ claim, signature: sig });
+  } catch (err) {
+    return { ok: false, reason: `failed to sign PoP read claim: ${errText(err)}` };
+  }
+
+  // 2. GET /admission-requests/mine.
+  let rows: AdmissionMineRow[];
+  try {
+    const url = `${input.registryUrl.replace(/\/+$/, "")}/admission-requests/mine`;
+    const resp = await fetchImpl(url, {
+      method: "GET",
+      headers: { "Content-Type": "application/json", "x-pop-signed": header },
+    });
+    if (!resp.ok) {
+      return { ok: false, reason: `registry mine-read failed (HTTP ${resp.status.toString()})` };
+    }
+    rows = (await resp.json()) as AdmissionMineRow[];
+  } catch (err) {
+    return { ok: false, reason: `registry mine-read errored: ${errText(err)}` };
+  }
+
+  // 3. Select the ADMITTED row for this network carrying a sealed blob.
+  if (!Array.isArray(rows)) {
+    return { ok: false, reason: "registry mine-read returned a non-array body" };
+  }
+  const row = rows.find(
+    (r) => r.network_id === input.networkId && r.status === "ADMITTED" && typeof r.sealed_secret === "string" && r.sealed_secret.length > 0,
+  );
+  if (!row?.sealed_secret) {
+    return {
+      ok: false,
+      reason: `no admitted+sealed admission row for network "${input.networkId}" (not yet admitted, or no secret delivered)`,
+    };
+  }
+
+  // 4. Open the sealed box with the member's raw seed + decode the envelope.
+  try {
+    const rawSeed = rawEd25519SeedFromNkeySeed(input.material.seed);
+    const plaintextBytes = await openSealed(row.sealed_secret, rawSeed);
+    const env = decodeLeafSecretEnvelope(new TextDecoder().decode(plaintextBytes));
+    return {
+      ok: true,
+      leafPsk: env.leaf_psk,
+      leafUser: env.leaf_user,
+      ...(env.payload_key !== undefined && { payloadKey: env.payload_key }),
+    };
+  } catch (err) {
+    // Generic — never echo seed/ciphertext/plaintext.
+    return { ok: false, reason: `failed to open sealed leaf secret: ${errText(err)}` };
+  }
+}
+
+/** Error → message, never echoing secret-bearing inputs. */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/common/registry/sealed-leaf-secret.ts
+++ b/src/common/registry/sealed-leaf-secret.ts
@@ -1,0 +1,89 @@
+/**
+ * ADR-0018 PR5b (#1240) — the SEALED secret envelope (the M3 seam).
+ *
+ * The hub-admin seals a small JSON envelope (not a bare PSK) to the member's
+ * pubkey, so the SAME sealed-delivery slot can carry MORE THAN the leaf PSK
+ * without a wire/schema change. PR5b populates `leaf_psk` + `leaf_user`. The
+ * per-network M3 payload key (#1246, ADR-0019) rides the SAME envelope later as
+ * `payload_key` — `cortex network secret add-member` seals both, `rotate` /
+ * `revoke-member` cover both, and the member-side decode already tolerates the
+ * extra field. That is the "one extra sealed blob via the same path" seam the
+ * issue asks PR5b to leave clean.
+ *
+ * The registry never sees this — it only carries the OPAQUE `crypto_box_seal`
+ * ciphertext of the JSON below.
+ */
+
+/** Envelope schema version. Bumped only on a breaking shape change. */
+export const LEAF_SECRET_ENVELOPE_VERSION = 1;
+
+/**
+ * The plaintext sealed to a member's pubkey. JSON, UTF-8, then
+ * {@link sealToPrincipal}. Keep it small + flat — `crypto_box_seal` has no size
+ * problem here, but the registry bounds the ciphertext (validate.isValidSealedSecret).
+ */
+export interface LeafSecretEnvelope {
+  /** Envelope version (currently {@link LEAF_SECRET_ENVELOPE_VERSION}). */
+  v: number;
+  /** The per-member leaf PSK (base64url). The transport secret (ADR-0018 Q2). */
+  leaf_psk: string;
+  /**
+   * The userinfo USER paired with `leaf_psk` — matches the hub's
+   * `authorization { user, password }` entry. Defaults to the member's
+   * principal id at mint time.
+   */
+  leaf_user: string;
+  /**
+   * M3 SEAM (#1246 / ADR-0019) — the per-network payload key, sealed alongside
+   * the leaf PSK once M3 lands. OPTIONAL + absent in PR5b. Decoders MUST tolerate
+   * its presence (and its absence). Its config field lives in M3, NOT here.
+   */
+  payload_key?: string;
+}
+
+/** Encode a {@link LeafSecretEnvelope} to the UTF-8 JSON that gets sealed. */
+export function encodeLeafSecretEnvelope(
+  fields: Omit<LeafSecretEnvelope, "v"> & { v?: number },
+): string {
+  const env: LeafSecretEnvelope = {
+    v: fields.v ?? LEAF_SECRET_ENVELOPE_VERSION,
+    leaf_psk: fields.leaf_psk,
+    leaf_user: fields.leaf_user,
+    ...(fields.payload_key !== undefined && { payload_key: fields.payload_key }),
+  };
+  return JSON.stringify(env);
+}
+
+/**
+ * Decode + validate the UNSEALED plaintext into a {@link LeafSecretEnvelope}.
+ * Fails closed on a malformed envelope (the member would otherwise render a leaf
+ * with a junk secret). Tolerates the future `payload_key` field. The error
+ * message NEVER echoes the plaintext (it may carry secret material).
+ */
+export function decodeLeafSecretEnvelope(plaintext: string): LeafSecretEnvelope {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(plaintext);
+  } catch (err) {
+    throw new Error("sealed-leaf-secret: unsealed payload is not valid JSON", { cause: err });
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("sealed-leaf-secret: unsealed payload must be a JSON object");
+  }
+  const p = parsed as Record<string, unknown>;
+  if (typeof p.leaf_psk !== "string" || p.leaf_psk.length === 0) {
+    throw new Error("sealed-leaf-secret: unsealed payload missing leaf_psk");
+  }
+  if (typeof p.leaf_user !== "string" || p.leaf_user.length === 0) {
+    throw new Error("sealed-leaf-secret: unsealed payload missing leaf_user");
+  }
+  if (p.payload_key !== undefined && typeof p.payload_key !== "string") {
+    throw new Error("sealed-leaf-secret: payload_key must be a string when present");
+  }
+  return {
+    v: typeof p.v === "number" ? p.v : LEAF_SECRET_ENVELOPE_VERSION,
+    leaf_psk: p.leaf_psk,
+    leaf_user: p.leaf_user,
+    ...(typeof p.payload_key === "string" && { payload_key: p.payload_key }),
+  };
+}

--- a/src/services/network-registry/__tests__/d1-mock.ts
+++ b/src/services/network-registry/__tests__/d1-mock.ts
@@ -49,6 +49,8 @@ interface IssuanceRequestRow {
   created_at: string;
   updated_at: string;
   granted_by: string | null;
+  /** ADR-0018 b′ (PR5b) — opaque sealed ciphertext; NULL until add-member. */
+  sealed_secret: string | null;
 }
 
 /** What D1's `.run()` returns — we only populate `meta.changes`. */
@@ -224,9 +226,29 @@ export class MockD1 {
         created_at: createdAt,
         updated_at: updatedAt,
         granted_by: null,
+        sealed_secret: null,
       };
       this.issuanceRequests.set(requestId, row);
       this.issuancePeerIndex.set(peerKey, requestId);
+      return { meta: { changes: 1 } };
+    }
+
+    // admission_requests: revoke (ADR-0018 Q6 — CAS on status='ADMITTED').
+    // `UPDATE ... SET status = 'REVOKED', sealed_secret = NULL ... WHERE ... AND status = 'ADMITTED'`.
+    // Checked BEFORE the generic `SET status` branch (that branch binds a
+    // newStatus param this literal-status statement does not carry).
+    if (sql.startsWith("UPDATE admission_requests SET status = 'REVOKED'")) {
+      const [updatedAt, requestId] = args as [string, string];
+      const existing = this.issuanceRequests.get(requestId);
+      if (!existing || existing.status !== "ADMITTED") {
+        return { meta: { changes: 0 } };
+      }
+      this.issuanceRequests.set(requestId, {
+        ...existing,
+        status: "REVOKED",
+        sealed_secret: null,
+        updated_at: updatedAt,
+      });
       return { meta: { changes: 1 } };
     }
 
@@ -250,6 +272,22 @@ export class MockD1 {
         updated_at: updatedAt,
       };
       this.issuanceRequests.set(requestId, updated);
+      return { meta: { changes: 1 } };
+    }
+
+    // admission_requests: setSealedSecret (ADR-0018 b′ — CAS on status='ADMITTED').
+    // `UPDATE ... SET sealed_secret = ?, updated_at = ? WHERE request_id = ? AND status = 'ADMITTED'`.
+    if (sql.startsWith("UPDATE admission_requests SET sealed_secret")) {
+      const [sealedSecret, updatedAt, requestId] = args as [string, string, string];
+      const existing = this.issuanceRequests.get(requestId);
+      if (!existing || existing.status !== "ADMITTED") {
+        return { meta: { changes: 0 } };
+      }
+      this.issuanceRequests.set(requestId, {
+        ...existing,
+        sealed_secret: sealedSecret,
+        updated_at: updatedAt,
+      });
       return { meta: { changes: 1 } };
     }
 

--- a/src/services/network-registry/__tests__/sealed-secret.test.ts
+++ b/src/services/network-registry/__tests__/sealed-secret.test.ts
@@ -1,0 +1,338 @@
+/**
+ * ADR-0018 PR5b (#1240) — hub-admin sealed-secret delivery + revoke endpoints.
+ *
+ * Trust-path coverage (the secret-delivery mechanism + the LEAF PSK slot):
+ *   sealed-secret write (hub-admin authority, Q5):
+ *     - allowlisted hub-admin writes the opaque blob onto an ADMITTED row → 200,
+ *       and the member PoP-read (/mine) then serves it
+ *     - the admit route mints NOTHING: sealed_secret is null right after admit,
+ *       only the hub-admin write populates it (two separable authorities)
+ *     - write against a non-ADMITTED (PENDING) row → 409 not_admitted
+ *     - write against an unknown request → 404
+ *     - forged signature → 401 ; non-allowlisted key → 403 ; no allowlist → 503
+ *     - replayed nonce → 409
+ *     - request_id path/body mismatch → 400 ; oversized/non-base64 blob → 400
+ *     - HUB-admin allowlist is HONOURED over registry-admin (separable): a
+ *       registry-admin-only key cannot write when a distinct hub allowlist is set
+ *     - collapse case: with only REGISTRY_ADMIN_PUBKEYS set, that key CAN write
+ *   rotate:
+ *     - a second sealed-secret write REPLACES the blob in place
+ *   revoke (Q6):
+ *     - hub-admin revoke of an ADMITTED row → 200 REVOKED + sealed_secret cleared,
+ *       and the member PoP-read no longer serves the blob
+ *     - revoke of a never-admitted (PENDING) row → 409 not_admitted
+ *     - revoke is idempotent (second revoke → 200 REVOKED)
+ *   secret hygiene:
+ *     - the opaque blob is the EXACT bytes written (registry never mutates it)
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  randomNonce,
+  resetStores,
+  makeSignedAdminRead,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import type { AdmissionRequest } from "../src/types";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+
+let env: Env;
+let admin: PrincipalKey;
+let hubAdmin: PrincipalKey;
+let principal: PrincipalKey;
+
+// A representative opaque sealed blob — the registry treats it as bytes; we only
+// need it to be valid base64 within the size bound. (The real CLI produces a
+// libsodium crypto_box_seal; the registry never decodes it.)
+const SEALED = btoa("sealed-leaf-psk-opaque-ciphertext-v1");
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, e: Env = env, headers: Record<string, string> = {}): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+async function registerPending(principalId: string): Promise<AdmissionRequest> {
+  const body = await makeSignedRegistration(principalId, principal, {
+    stacks: [{ stack_id: `${principalId}/main`, stack_pubkey: principal.publicKeyB64 }],
+    networkId: "metafactory",
+  });
+  const res = await post(`/principals/${principalId}/register`, body);
+  expect(res.status).toBe(201);
+  const signedRead = await makeSignedAdminRead(admin);
+  const listRes = await get(`/admission-requests?status=PENDING`, env, {
+    "x-admin-signed": JSON.stringify(signedRead),
+  });
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const found = list.find((r) => r.principal_id === principalId);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+async function makeAdmitDecision(requestId: string, adminKey: PrincipalKey) {
+  const claim = {
+    request_id: requestId,
+    decision: "admit" as const,
+    admin_pubkey: adminKey.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const signature = await signEd25519(adminKey.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+async function admit(requestId: string): Promise<void> {
+  const res = await post(`/admission-requests/${requestId}/admit`, await makeAdmitDecision(requestId, admin));
+  expect(res.status).toBe(200);
+}
+
+async function makeSealedWrite(
+  requestId: string,
+  signer: PrincipalKey,
+  opts: { sealed?: string; issuedAt?: string; nonce?: string; pubkeyOverride?: string } = {},
+) {
+  const claim = {
+    request_id: requestId,
+    sealed_secret: opts.sealed ?? SEALED,
+    hub_admin_pubkey: opts.pubkeyOverride ?? signer.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+  const signature = await signEd25519(signer.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+async function makeRevoke(
+  requestId: string,
+  signer: PrincipalKey,
+  opts: { issuedAt?: string; nonce?: string; pubkeyOverride?: string } = {},
+) {
+  const claim = {
+    request_id: requestId,
+    hub_admin_pubkey: opts.pubkeyOverride ?? signer.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+  const signature = await signEd25519(signer.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+/** Member PoP-read of their own admission rows. Returns the row for the network. */
+async function readMine(networkId: string): Promise<AdmissionRequest | undefined> {
+  const claim = {
+    principal_id: "alice",
+    peer_pubkey: principal.publicKeyB64,
+    issued_at: new Date().toISOString(),
+  };
+  const signature = await signEd25519(principal.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  const res = await get(`/admission-requests/mine`, env, { "x-pop-signed": JSON.stringify({ claim, signature }) });
+  expect(res.status).toBe(200);
+  const rows = (await res.json()) as AdmissionRequest[];
+  return rows.find((r) => r.network_id === networkId);
+}
+
+beforeEach(async () => {
+  resetStores();
+  _resetRateLimitBucketsForTest();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  hubAdmin = await makePrincipalKey();
+  principal = await makePrincipalKey();
+  // Distinct authorities by default: registry-admin admits, hub-admin delivers.
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    REGISTRY_HUB_ADMIN_PUBKEYS: hubAdmin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// Sealed-secret write — the secret-delivery mechanism
+// =============================================================================
+
+describe("POST /admission-requests/:id/sealed-secret — happy path", () => {
+  test("admit mints NOTHING: sealed_secret is null until the hub-admin writes it", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const beforeWrite = await readMine("metafactory");
+    expect(beforeWrite?.status).toBe("ADMITTED");
+    expect(beforeWrite?.sealed_secret).toBeNull();
+  });
+
+  test("hub-admin writes the opaque blob onto an ADMITTED row; /mine serves it verbatim", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, hubAdmin));
+    expect(res.status).toBe(200);
+    const updated = (await res.json()) as AdmissionRequest;
+    expect(updated.sealed_secret).toBe(SEALED);
+    expect(updated.status).toBe("ADMITTED");
+
+    const mine = await readMine("metafactory");
+    expect(mine?.sealed_secret).toBe(SEALED); // exact bytes — registry never mutates it
+  });
+
+  test("rotate REPLACES the blob in place", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, hubAdmin));
+    const next = btoa("rotated-leaf-psk-v2");
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, hubAdmin, { sealed: next }));
+    expect(res.status).toBe(200);
+    const mine = await readMine("metafactory");
+    expect(mine?.sealed_secret).toBe(next);
+  });
+});
+
+describe("POST /admission-requests/:id/sealed-secret — guards", () => {
+  test("write against a PENDING (not-admitted) row → 409 not_admitted", async () => {
+    const req = await registerPending("alice");
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, hubAdmin));
+    expect(res.status).toBe(409);
+    expect((await res.json() as { error: string }).error).toBe("not_admitted");
+  });
+
+  test("write against an unknown request → 404", async () => {
+    const unknown = "deadbeef".repeat(4); // 32 hex chars, valid grammar, no row
+    const res = await post(`/admission-requests/${unknown}/sealed-secret`, await makeSealedWrite(unknown, hubAdmin));
+    expect(res.status).toBe(404);
+  });
+
+  test("forged signature → 401", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    // Claim declares the hub-admin pubkey but is signed by a different key.
+    const attacker = await makePrincipalKey();
+    const body = await makeSealedWrite(req.request_id, attacker, { pubkeyOverride: hubAdmin.publicKeyB64 });
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, body);
+    expect(res.status).toBe(401);
+  });
+
+  test("non-allowlisted hub-admin key → 403", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const stranger = await makePrincipalKey();
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, stranger));
+    expect(res.status).toBe(403);
+  });
+
+  test("no hub-admin (nor registry-admin) allowlist → 503 fail-closed", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const noAdminEnv: Env = { ...env, REGISTRY_ADMIN_PUBKEYS: "", REGISTRY_HUB_ADMIN_PUBKEYS: "" };
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, hubAdmin), noAdminEnv);
+    expect(res.status).toBe(503);
+  });
+
+  test("replayed nonce → 409", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const body = await makeSealedWrite(req.request_id, hubAdmin);
+    const first = await post(`/admission-requests/${req.request_id}/sealed-secret`, body);
+    expect(first.status).toBe(200);
+    const replay = await post(`/admission-requests/${req.request_id}/sealed-secret`, body);
+    expect(replay.status).toBe(409);
+    expect((await replay.json() as { error: string }).error).toBe("nonce_replayed");
+  });
+
+  test("request_id body/path mismatch → 400", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const other = "abcd1234".repeat(4);
+    const body = await makeSealedWrite(other, hubAdmin); // claim.request_id != path
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, body);
+    expect(res.status).toBe(400);
+  });
+
+  test("non-base64 / oversized blob → 400", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const bad = await makeSealedWrite(req.request_id, hubAdmin, { sealed: "not valid base64 !!!" });
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, bad);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("two separable authorities (Q5)", () => {
+  test("a registry-admin-only key CANNOT write the sealed secret when a distinct hub allowlist is set", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    // `admin` is on REGISTRY_ADMIN_PUBKEYS but NOT REGISTRY_HUB_ADMIN_PUBKEYS.
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, admin));
+    expect(res.status).toBe(403);
+  });
+
+  test("collapse case: with only REGISTRY_ADMIN_PUBKEYS set, that key can deliver (hub authority falls back)", async () => {
+    const collapsedEnv: Env = { ...env, REGISTRY_HUB_ADMIN_PUBKEYS: "" };
+    const req = await registerPending("alice");
+    // admit + deliver both by `admin` (one principal = both authorities).
+    await post(`/admission-requests/${req.request_id}/admit`, await makeAdmitDecision(req.request_id, admin), collapsedEnv);
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, admin), collapsedEnv);
+    expect(res.status).toBe(200);
+  });
+});
+
+// =============================================================================
+// Revoke — cut the member (Q6)
+// =============================================================================
+
+describe("POST /admission-requests/:id/revoke", () => {
+  test("hub-admin revoke of an ADMITTED+sealed row → REVOKED + blob cleared; /mine stops serving it", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    await post(`/admission-requests/${req.request_id}/sealed-secret`, await makeSealedWrite(req.request_id, hubAdmin));
+
+    const res = await post(`/admission-requests/${req.request_id}/revoke`, await makeRevoke(req.request_id, hubAdmin));
+    expect(res.status).toBe(200);
+    const revoked = (await res.json()) as AdmissionRequest;
+    expect(revoked.status).toBe("REVOKED");
+    expect(revoked.sealed_secret).toBeNull();
+
+    const mine = await readMine("metafactory");
+    expect(mine?.status).toBe("REVOKED");
+    expect(mine?.sealed_secret).toBeNull();
+  });
+
+  test("revoke of a never-admitted (PENDING) row → 409 not_admitted", async () => {
+    const req = await registerPending("alice");
+    const res = await post(`/admission-requests/${req.request_id}/revoke`, await makeRevoke(req.request_id, hubAdmin));
+    expect(res.status).toBe(409);
+    expect((await res.json() as { error: string }).error).toBe("not_admitted");
+  });
+
+  test("revoke is idempotent — a second revoke → 200 REVOKED", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const first = await post(`/admission-requests/${req.request_id}/revoke`, await makeRevoke(req.request_id, hubAdmin));
+    expect(first.status).toBe(200);
+    const second = await post(`/admission-requests/${req.request_id}/revoke`, await makeRevoke(req.request_id, hubAdmin));
+    expect(second.status).toBe(200);
+    expect((await second.json() as AdmissionRequest).status).toBe("REVOKED");
+  });
+
+  test("revoke requires hub-admin authority: a non-allowlisted key → 403", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const stranger = await makePrincipalKey();
+    const res = await post(`/admission-requests/${req.request_id}/revoke`, await makeRevoke(req.request_id, stranger));
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/services/network-registry/migrations/0010_admission_sealed_secret.sql
+++ b/src/services/network-registry/migrations/0010_admission_sealed_secret.sql
@@ -1,0 +1,62 @@
+-- ADR-0018 PR5b (#1240) — leaf-secret sealed delivery + revoke.
+--
+-- Background
+-- ──────────
+-- PR5a created the member PoP-read endpoint with a `sealed_secret` slot that
+-- the response synthesised as NULL (the column did not yet exist). PR5b is the
+-- secret-delivery mechanism:
+--   1. Add `sealed_secret` column — the OPAQUE per-member ciphertext the
+--      hub-admin seals to the member's ed25519 pubkey (`crypto_box_seal`). The
+--      registry only ever carries this blob; it cannot read it (ADR-0018 Q1 b′).
+--   2. Add REVOKED to the status CHECK — `cortex network secret revoke-member`
+--      transitions ADMITTED → REVOKED (after cutting transport at the hub), so
+--      the roster + the member PoP-read both stop serving the member (Q6).
+--
+-- SQLite cannot add a value to a CHECK constraint nor (portably) DROP a column
+-- across all D1-supported versions, so we recreate the table — the SAME
+-- portable pattern migration 0007 used — preserving every column 0007/0008
+-- established, adding `sealed_secret`, widening the status CHECK, copying
+-- surviving rows, and recreating BOTH indexes (the status index AND the 0008
+-- per-network COALESCE unique index). New `sealed_secret` starts NULL for every
+-- copied row.
+--
+-- Safety: the registry is not yet deployed at this schema version (per the
+-- 0007/0008 headers), so the recreate has no live rows to migrate beyond the
+-- copy below.
+
+-- Step A — new table: 0007/0008 columns + sealed_secret + widened status CHECK.
+CREATE TABLE IF NOT EXISTS admission_requests_v2 (
+  request_id      TEXT    NOT NULL PRIMARY KEY,
+  principal_id    TEXT    NOT NULL,
+  peer_pubkey     TEXT    NOT NULL,
+  requested_scope TEXT    NOT NULL,
+  network_id      TEXT    ,
+  status          TEXT    NOT NULL DEFAULT 'PENDING'
+                          CHECK (status IN ('PENDING', 'ADMITTED', 'REJECTED', 'REVOKED')),
+  created_at      TEXT    NOT NULL,
+  updated_at      TEXT    NOT NULL,
+  granted_by      TEXT    ,
+  -- ADR-0018 Q1 (b′) — opaque per-member sealed ciphertext. The registry never
+  -- reads it. NULL until add-member (sealed) delivers it; NULL again on revoke.
+  sealed_secret   TEXT
+);
+
+-- Step B — copy surviving rows; sealed_secret starts NULL.
+INSERT INTO admission_requests_v2
+  (request_id, principal_id, peer_pubkey, requested_scope, network_id,
+   status, created_at, updated_at, granted_by, sealed_secret)
+SELECT
+  request_id, principal_id, peer_pubkey, requested_scope, network_id,
+  status, created_at, updated_at, granted_by, NULL
+FROM admission_requests;
+
+-- Step C — swap the table in.
+DROP TABLE IF EXISTS admission_requests;
+ALTER TABLE admission_requests_v2 RENAME TO admission_requests;
+
+-- Step D — recreate indexes (status + the 0008 per-network COALESCE unique).
+CREATE INDEX IF NOT EXISTS idx_admission_requests_status
+  ON admission_requests (status);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_admission_requests_peer_network
+  ON admission_requests (principal_id, peer_pubkey, COALESCE(network_id, ''));

--- a/src/services/network-registry/src/index.ts
+++ b/src/services/network-registry/src/index.ts
@@ -75,6 +75,22 @@ export interface Env extends RateLimitEnv, StoreEnv {
    * ignored.
    */
   REGISTRY_ADMIN_PUBKEYS?: string;
+  /**
+   * ADR-0018 Q5 (PR5b) — comma-separated allowlist of base64 Ed25519 pubkeys
+   * authorised to MINT/DELIVER per-member leaf secrets: the hub-admin authority
+   * that writes the opaque sealed blob (`POST /admission-requests/{id}/
+   * sealed-secret`) and revokes it (`/revoke`). DISTINCT from
+   * `REGISTRY_ADMIN_PUBKEYS` (the registry-admin that signs the admit decision
+   * and mints NOTHING) so a future network whose registry-admin ≠ hub-host keeps
+   * the two authorities separable.
+   *
+   * COLLAPSE CASE: when this is unset/blank the gate FALLS BACK to
+   * `REGISTRY_ADMIN_PUBKEYS` — for `metafactory` both authorities collapse into
+   * Luna (FleetAdmit Tier-2 runs admit AND secret-delivery as one concierge
+   * action), so one allowlist suffices. Set this separately only when the two
+   * authorities must diverge.
+   */
+  REGISTRY_HUB_ADMIN_PUBKEYS?: string;
   ENVIRONMENT?: string;
 }
 
@@ -85,7 +101,23 @@ export interface Env extends RateLimitEnv, StoreEnv {
  * fail-closed. Entries are trimmed; blank entries dropped.
  */
 export function parseAdminPubkeys(env: Env): Set<string> {
-  const raw = env.REGISTRY_ADMIN_PUBKEYS;
+  return parsePubkeySet(env.REGISTRY_ADMIN_PUBKEYS);
+}
+
+/**
+ * ADR-0018 Q5 (PR5b) — parse the HUB-admin allowlist (`REGISTRY_HUB_ADMIN_PUBKEYS`)
+ * for the sealed-secret-write + revoke routes. When that var is unset/blank the
+ * two authorities collapse: we FALL BACK to `REGISTRY_ADMIN_PUBKEYS` (the
+ * metafactory case where Luna is both authorities). Returns an EMPTY set only
+ * when NEITHER var is configured → the hub-admin routes 503 fail-closed.
+ */
+export function parseHubAdminPubkeys(env: Env): Set<string> {
+  const hub = parsePubkeySet(env.REGISTRY_HUB_ADMIN_PUBKEYS);
+  return hub.size > 0 ? hub : parseAdminPubkeys(env);
+}
+
+/** Shared parser: comma-separated base64 pubkeys → trimmed, non-empty set. */
+function parsePubkeySet(raw: string | undefined): Set<string> {
   if (typeof raw !== "string" || raw.trim().length === 0) return new Set();
   return new Set(
     raw

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -44,13 +44,17 @@
  */
 
 import { Hono, type Context } from "hono";
-import { parseAdminPubkeys, type Env } from "../index";
+import { parseAdminPubkeys, parseHubAdminPubkeys, type Env } from "../index";
 import { getNonceCache, getIssuanceStore, AlreadyDecidedError } from "../store";
 import {
   validateSignedAdmissionDecision,
   validateAdmissionDecisionClaim,
   validateSignedAdmissionRead,
   validateSignedAdmissionMineRead,
+  validateSignedSealedSecretWrite,
+  validateSealedSecretClaim,
+  validateSignedAdmissionRevoke,
+  validateAdmissionRevokeClaim,
   isValidRequestId,
 } from "../validate";
 import { canonicalJSON, verifyEd25519 } from "../signing";
@@ -275,6 +279,189 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
   app.post("/admission-requests/:request_id/reject", (c) => handleDecision(c, "reject"));
 
   // ---------------------------------------------------------------------------
+  // Helper: HUB-ADMIN-signed write gate (ADR-0018 Q5, PR5b).
+  //
+  // Distinct authority from the registry-admin admit gate: the HUB-admin mints
+  // the per-member secret + writes/clears the opaque sealed blob. Gated on
+  // `REGISTRY_HUB_ADMIN_PUBKEYS` (falling back to `REGISTRY_ADMIN_PUBKEYS` when
+  // the two authorities collapse into one principal — parseHubAdminPubkeys).
+  //
+  // Mirrors handleDecision's gate ORDER verbatim:
+  //   M2 request_id grammar → 503 fail-closed (FIRST) → M1 rate-limit →
+  //   JSON parse → envelope+claim validate → clock-skew → sig verify (FIRST) →
+  //   allowlist → nonce replay. Returns the verified claim or a Response to
+  //   short-circuit.
+  // ---------------------------------------------------------------------------
+
+  async function verifyHubAdminWrite<C extends { hub_admin_pubkey: string; issued_at: string; nonce: string }>(
+    c: Context<{ Bindings: Env }>,
+    requestId: string,
+    validateEnvelope: (body: unknown) => { ok: true; signed: { claim: unknown; signature: string } } | { ok: false; errors: unknown },
+    validateClaim: (claim: unknown, expectedRequestId: string) => { ok: true; claim: C } | { ok: false; errors: unknown },
+  ): Promise<{ ok: true; claim: C } | { ok: false; response: Response }> {
+    // M2 — validate request_id path param BEFORE body parse or crypto.
+    if (!isValidRequestId(requestId)) {
+      return { ok: false, response: c.json({ error: "invalid_request_id" }, 400) };
+    }
+
+    // 1. FAIL-CLOSED, FIRST: hub-admin allowlist must be configured.
+    const hubAdminPubkeys = parseHubAdminPubkeys(c.env);
+    if (hubAdminPubkeys.size === 0) {
+      return {
+        ok: false,
+        response: c.json(
+          {
+            error: "admin_not_configured",
+            details:
+              "neither REGISTRY_HUB_ADMIN_PUBKEYS nor REGISTRY_ADMIN_PUBKEYS provisioned; " +
+              "secret delivery is disabled (fail-closed). Set the hub-admin allowlist via " +
+              "`wrangler secret put` to enable signed hub-admin writes.",
+          },
+          503,
+        ),
+      };
+    }
+
+    // M1 — rate-limit BEFORE the expensive Ed25519 verify (register bucket).
+    const allowed = await checkRateLimit(c.env, "register", clientKey(c.req.raw, requestId));
+    if (!allowed) {
+      return {
+        ok: false,
+        response: c.json(TOO_MANY_REQUESTS_BODY, 429, {
+          "Retry-After": String(retryAfterSeconds("register")),
+        }),
+      };
+    }
+
+    // 2. Parse + validate envelope.
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (_err) {
+      return { ok: false, response: c.json({ error: "body must be valid JSON" }, 400) };
+    }
+    const envelopeCheck = validateEnvelope(body);
+    if (!envelopeCheck.ok) {
+      return { ok: false, response: c.json({ error: "validation_failed", details: envelopeCheck.errors }, 400) };
+    }
+    const claimResult = validateClaim(envelopeCheck.signed.claim, requestId);
+    if (!claimResult.ok) {
+      return { ok: false, response: c.json({ error: "validation_failed", details: claimResult.errors }, 400) };
+    }
+    const claim = claimResult.claim;
+
+    // 3. Clock-skew check.
+    const issued = Date.parse(claim.issued_at);
+    const now = Date.now();
+    if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
+      return {
+        ok: false,
+        response: c.json(
+          { error: "issued_at out of skew window", details: { skew_ms: now - issued, max_ms: CLOCK_SKEW_MS } },
+          400,
+        ),
+      };
+    }
+
+    // 4. Signature verification FIRST (before recording nonce), then allowlist.
+    const message = new TextEncoder().encode(canonicalJSON(claim)) as Uint8Array<ArrayBuffer>;
+    const gateResult = await applyAdminGate(
+      hubAdminPubkeys,
+      claim.hub_admin_pubkey,
+      envelopeCheck.signed.signature,
+      message,
+    );
+    if (gateResult) {
+      return { ok: false, response: c.json({ error: gateResult.error }, gateResult.status as 401 | 403) };
+    }
+
+    // 5. Replay check — only on the authentic + authorised path.
+    const nonceCache = getNonceCache(c.env);
+    const fresh = await nonceCache.recordIfFresh(claim.nonce, now);
+    if (!fresh) {
+      return { ok: false, response: c.json({ error: "nonce_replayed" }, 409) };
+    }
+
+    return { ok: true, claim };
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /admission-requests/:request_id/sealed-secret — ADR-0018 Q1 b′ / Q5
+  //
+  // The HUB-ADMIN delivers the opaque per-member sealed blob onto the ADMITTED
+  // row (add-member sealed mode; rotate REPLACES it). The registry persists the
+  // ciphertext it is handed and NEVER reads it. Gated on the hub-admin
+  // authority — the admit route mints nothing, this route is the only mint/seal
+  // sink. 409 not_admitted if the row is not ADMITTED (a secret can only be
+  // delivered to an admitted member).
+  // ---------------------------------------------------------------------------
+
+  app.post("/admission-requests/:request_id/sealed-secret", async (c) => {
+    const requestId = c.req.param("request_id") ?? "";
+    const gate = await verifyHubAdminWrite(
+      c,
+      requestId,
+      validateSignedSealedSecretWrite,
+      validateSealedSecretClaim,
+    );
+    if (!gate.ok) return gate.response;
+
+    const store = getIssuanceStore(c.env);
+    const updated = await store.setSealedSecret(requestId, gate.claim.sealed_secret);
+    if (!updated) {
+      // Row missing OR not ADMITTED — distinguish for the caller.
+      const existing = await store.getIssuanceRequest(requestId);
+      if (!existing) return c.json({ error: "not_found" }, 404);
+      return c.json(
+        { error: "not_admitted", details: `request ${requestId} is ${existing.status}, not ADMITTED — cannot deliver a sealed secret` },
+        409,
+      );
+    }
+    return c.json(updated, 200);
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /admission-requests/:request_id/revoke — ADR-0018 Q6
+  //
+  // The HUB-ADMIN marks an ADMITTED row REVOKED and CLEARS its sealed blob. The
+  // CLI cuts transport at the hub (drops the `authorization` user + reloads)
+  // BEFORE calling this — this is the registry-side half (roster + member
+  // PoP-read both stop serving the member). Idempotent: a second revoke of an
+  // already-REVOKED row returns 200. 409 if the row was never ADMITTED.
+  // ---------------------------------------------------------------------------
+
+  app.post("/admission-requests/:request_id/revoke", async (c) => {
+    const requestId = c.req.param("request_id") ?? "";
+    const gate = await verifyHubAdminWrite(
+      c,
+      requestId,
+      validateSignedAdmissionRevoke,
+      validateAdmissionRevokeClaim,
+    );
+    if (!gate.ok) return gate.response;
+
+    const store = getIssuanceStore(c.env);
+    let updated;
+    try {
+      updated = await store.revokeAdmission(requestId);
+    } catch (err) {
+      if (err instanceof AlreadyDecidedError) {
+        return c.json(
+          {
+            error: "not_admitted",
+            details: `request ${requestId} is ${err.request.status}, not ADMITTED — nothing to revoke`,
+            current: err.request,
+          },
+          409,
+        );
+      }
+      throw err;
+    }
+    if (!updated) return c.json({ error: "not_found" }, 404);
+    return c.json(updated, 200);
+  });
+
+  // ---------------------------------------------------------------------------
   // GET /admission-requests?status=<status>
   // ---------------------------------------------------------------------------
 
@@ -356,11 +543,15 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "signature_invalid" }, 401);
     }
 
-    // Return the caller's OWN admission rows (by the proven pubkey), each with
-    // the (empty-in-PR5a) sealed_secret slot. Never another member's queue.
+    // Return the caller's OWN admission rows (by the proven pubkey), each
+    // carrying its sealed_secret slot — POPULATED (PR5b) once the hub-admin has
+    // delivered the opaque blob (sealed to THIS member's pubkey, useless to
+    // anyone else), NULL before delivery and after revoke. Never another
+    // member's queue. The blob needs no extra auth: it is opaque to everyone but
+    // the holder of the matching seed (ADR-0018 Q4 b′).
     const store = getIssuanceStore(c.env);
     const rows = await store.listIssuanceRequestsByPeer(signed.claim.peer_pubkey);
-    const mine: AdmissionMineRow[] = rows.map((r) => ({ ...r, sealed_secret: null }));
+    const mine: AdmissionMineRow[] = rows;
     return c.json(mine, 200);
   });
 

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -226,6 +226,31 @@ export interface IssuanceRequestStore {
     newStatus: "ADMITTED" | "REJECTED",
     adminPubkey: string,
   ): Promise<AdmissionRequest | undefined>;
+
+  /**
+   * ADR-0018 Q1 (b′) / PR5b — persist the OPAQUE sealed ciphertext onto an
+   * ADMITTED admission row (the hub-admin `add-member` / `rotate` delivery).
+   * The store only writes the blob it is handed; it never reads or interprets
+   * it. Guarded on `status = 'ADMITTED'`: a not-yet-admitted (or revoked) row
+   * cannot carry a sealed secret, so a write against a non-ADMITTED row is a
+   * no-op and returns `undefined` (the route maps that to 409). Returns the
+   * updated row on success, `undefined` when the row is missing or not ADMITTED.
+   * `rotate` calls this again to REPLACE the blob in place (old copy inert).
+   */
+  setSealedSecret(
+    requestId: string,
+    sealedSecret: string,
+  ): Promise<AdmissionRequest | undefined>;
+
+  /**
+   * ADR-0018 Q6 / PR5b — transition an ADMITTED row to REVOKED and CLEAR its
+   * sealed blob (the bearer copy is dead once the hub `authorization` user is
+   * dropped). Guarded on `status = 'ADMITTED'`. Returns the updated row;
+   * `undefined` when the row is missing. Already-REVOKED is idempotent (returns
+   * the REVOKED row); a PENDING/REJECTED row throws {@link AlreadyDecidedError}
+   * (you cannot revoke a member that was never admitted).
+   */
+  revokeAdmission(requestId: string): Promise<AdmissionRequest | undefined>;
 }
 
 // =============================================================================
@@ -281,6 +306,7 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
       created_at: now,
       updated_at: now,
       granted_by: null,
+      sealed_secret: null,
     };
     this.requests.set(request.request_id, request);
     this.byPeer.set(peerKey, request.request_id);
@@ -317,6 +343,39 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
       ...existing,
       status: newStatus,
       granted_by: adminPubkey,
+      updated_at: new Date().toISOString(),
+    };
+    this.requests.set(requestId, updated);
+    return updated;
+  }
+
+  async setSealedSecret(
+    requestId: string,
+    sealedSecret: string,
+  ): Promise<AdmissionRequest | undefined> {
+    const existing = this.requests.get(requestId);
+    if (!existing) return undefined;
+    if (existing.status !== "ADMITTED") return undefined; // route → 409 not_admitted
+    const updated: AdmissionRequest = {
+      ...existing,
+      sealed_secret: sealedSecret,
+      updated_at: new Date().toISOString(),
+    };
+    this.requests.set(requestId, updated);
+    return updated;
+  }
+
+  async revokeAdmission(requestId: string): Promise<AdmissionRequest | undefined> {
+    const existing = this.requests.get(requestId);
+    if (!existing) return undefined;
+    if (existing.status === "REVOKED") return existing; // idempotent
+    if (existing.status !== "ADMITTED") {
+      throw new AlreadyDecidedError(existing);
+    }
+    const updated: AdmissionRequest = {
+      ...existing,
+      status: "REVOKED",
+      sealed_secret: null,
       updated_at: new Date().toISOString(),
     };
     this.requests.set(requestId, updated);
@@ -456,6 +515,53 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
       updated_at: now,
     };
   }
+
+  async setSealedSecret(
+    requestId: string,
+    sealedSecret: string,
+  ): Promise<AdmissionRequest | undefined> {
+    const existing = await this.getIssuanceRequest(requestId);
+    if (!existing) return undefined;
+    if (existing.status !== "ADMITTED") return undefined; // route → 409 not_admitted
+    const now = new Date().toISOString();
+    // CAS-ish guard: only an ADMITTED row can carry a sealed secret. A concurrent
+    // revoke between our read and this UPDATE flips the guard false → changes 0 →
+    // undefined (the route maps it to 409). `rotate` REPLACES the blob in place.
+    const res = await this.db
+      .prepare(
+        `UPDATE admission_requests
+         SET sealed_secret = ?, updated_at = ?
+         WHERE request_id = ? AND status = 'ADMITTED'`,
+      )
+      .bind(sealedSecret, now, requestId)
+      .run();
+    if ((res.meta?.changes ?? 0) === 0) return undefined;
+    return { ...existing, sealed_secret: sealedSecret, updated_at: now };
+  }
+
+  async revokeAdmission(requestId: string): Promise<AdmissionRequest | undefined> {
+    const existing = await this.getIssuanceRequest(requestId);
+    if (!existing) return undefined;
+    if (existing.status === "REVOKED") return existing; // idempotent no-op
+    if (existing.status !== "ADMITTED") {
+      throw new AlreadyDecidedError(existing);
+    }
+    const now = new Date().toISOString();
+    const res = await this.db
+      .prepare(
+        `UPDATE admission_requests
+         SET status = 'REVOKED', sealed_secret = NULL, updated_at = ?
+         WHERE request_id = ? AND status = 'ADMITTED'`,
+      )
+      .bind(now, requestId)
+      .run();
+    if ((res.meta?.changes ?? 0) === 0) {
+      // A concurrent revoke won the race; the row is already REVOKED.
+      const current = await this.getIssuanceRequest(requestId);
+      return current;
+    }
+    return { ...existing, status: "REVOKED", sealed_secret: null, updated_at: now };
+  }
 }
 
 /** Raw column shape for an admission_requests row. */
@@ -469,6 +575,8 @@ interface AdmissionRequestRow {
   created_at: string;
   updated_at: string;
   granted_by: string | null;
+  /** ADR-0018 b′ — opaque sealed ciphertext; NULL until add-member delivers it. */
+  sealed_secret: string | null;
 }
 
 function rowToAdmissionRequest(row: AdmissionRequestRow): AdmissionRequest {
@@ -482,6 +590,8 @@ function rowToAdmissionRequest(row: AdmissionRequestRow): AdmissionRequest {
     created_at: row.created_at,
     updated_at: row.updated_at,
     granted_by: row.granted_by,
+    // A row read from a pre-0010 isolate (column absent) coalesces to null.
+    sealed_secret: row.sealed_secret ?? null,
   };
 }
 

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -274,11 +274,18 @@ export interface CapabilityHit {
 
 /**
  * The lifecycle status of a network admission request.
- * Transitions: PENDING → ADMITTED (on admin admit/grant)
- *              PENDING → REJECTED (on admin reject)
- * Re-transitions are forbidden (409 already_decided).
+ * Transitions: PENDING  → ADMITTED (on registry-admin admit/grant)
+ *              PENDING  → REJECTED (on registry-admin reject)
+ *              ADMITTED → REVOKED  (ADR-0018 Q6 — hub-admin `revoke-member`:
+ *                                   the member's hub `authorization` user is
+ *                                   dropped + the hub reloaded, cutting
+ *                                   transport, and the row is marked REVOKED so
+ *                                   the roster + the member PoP-read both stop
+ *                                   serving it).
+ * Re-transitions out of a decided state are forbidden (409 already_decided);
+ * REVOKED is the one transition OUT of ADMITTED (and is itself terminal).
  */
-export type AdmissionStatus = "PENDING" | "ADMITTED" | "REJECTED";
+export type AdmissionStatus = "PENDING" | "ADMITTED" | "REJECTED" | "REVOKED";
 
 /**
  * A persisted admission request — the metadata record that a verified
@@ -318,6 +325,21 @@ export interface AdmissionRequest {
    * Null while PENDING.
    */
   granted_by: string | null;
+  /**
+   * ADR-0018 Q1 (b′) — the per-member secret(s), sealed to THIS member's
+   * registered ed25519 pubkey (libsodium `crypto_box_seal`, via
+   * {@link sealToPrincipal}). The registry only ever carries the OPAQUE
+   * ciphertext — it cannot read it, so the "registry holds no readable secret"
+   * invariant survives (it holds a blob the way it already holds opaque
+   * pubkeys). NULL until the hub-admin `cortex network secret add-member`
+   * delivers it (sealed mode), and NULL again after `revoke-member`.
+   *
+   * The leaf PSK rides here now (PR5b). The per-network M3 payload key (#1246,
+   * not yet merged) rides the SAME slot later — the seal carries a small JSON
+   * envelope so a second sealed blob (the payload key) can be added without a
+   * schema change. The registry never interprets the bytes either way.
+   */
+  sealed_secret: string | null;
 }
 
 /**
@@ -414,22 +436,83 @@ export interface SignedAdmissionMineRead {
 }
 
 /**
- * ADR-0018 Q4 (Gap-C) — one row of the member PoP-read response. The member's
- * own admission request, plus the (b′) `sealed_secret` slot.
+ * ADR-0018 Q1 (b′) / Q5 — the HUB-ADMIN-signed claim carried by
+ * `POST /admission-requests/{request_id}/sealed-secret`.
  *
- * `sealed_secret` is included in the shape NOW but always `null` in PR5a: the
- * sealed-to-pubkey leaf-secret blob is populated by PR5b (ADR-0018 Q1 b′).
- * Shipping the field now lets the member-read consumer pin the response shape
- * before the secret-delivery machinery lands.
+ * Q5 keeps two authorities distinct: the registry-admin signs the admit
+ * decision (PENDING → ADMITTED) and MINTS NOTHING; the HUB-ADMIN mints the
+ * per-member PSK, writes the hub `authorization` user, and seals the bearer
+ * copy. This claim is the second authority's write of that opaque sealed blob
+ * onto the ADMITTED row — gated on the hub-admin allowlist
+ * (`REGISTRY_HUB_ADMIN_PUBKEYS`, falling back to `REGISTRY_ADMIN_PUBKEYS` when
+ * the two authorities collapse into one principal, e.g. metafactory's Luna).
+ *
+ * The route NEVER mints the secret; it only persists the ciphertext the
+ * hub-admin sealed. The registry cannot read it.
  */
-export interface AdmissionMineRow extends AdmissionRequest {
+export interface SealedSecretWriteClaim {
+  /** Must equal the URL path parameter. Echoed for canonicalisation. */
+  request_id: string;
   /**
-   * ADR-0018 Q1 (b′) — the per-member leaf PSK, sealed to this member's pubkey
-   * (libsodium `crypto_box_seal`). NULL until PR5b populates it; the registry
-   * only ever carries the opaque ciphertext (it cannot read it).
+   * The opaque sealed ciphertext (standard base64, `crypto_box_seal`). The
+   * registry never decodes/interprets it — it is a blob useless to anyone but
+   * the member whose pubkey it was sealed to.
    */
-  sealed_secret: string | null;
+  sealed_secret: string;
+  /** Base64 Ed25519 pubkey of the hub-admin signing this claim. */
+  hub_admin_pubkey: string;
+  /** ISO-8601 UTC timestamp at which the hub-admin signed this claim. */
+  issued_at: string;
+  /** Random nonce to prevent replay (same replay cache as the admit gate). */
+  nonce: string;
 }
+
+/** On-wire envelope for a hub-admin sealed-secret write. */
+export interface SignedSealedSecretWrite {
+  claim: SealedSecretWriteClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}
+
+/**
+ * ADR-0018 Q6 — the HUB-ADMIN-signed claim carried by
+ * `POST /admission-requests/{request_id}/revoke`.
+ *
+ * Revoke cuts transport at the hub (the CLI drops the member's `authorization`
+ * user + reloads the hub) AND marks the admission row REVOKED so the roster and
+ * the member PoP-read both stop serving it. This is the registry-side half of
+ * that operation: an ADMITTED → REVOKED transition that also clears the sealed
+ * blob. Hub-admin authority (Q5), never the registry-admin admit gate.
+ */
+export interface AdmissionRevokeClaim {
+  /** Must equal the URL path parameter. */
+  request_id: string;
+  /** Base64 Ed25519 pubkey of the hub-admin signing this claim. */
+  hub_admin_pubkey: string;
+  /** ISO-8601 UTC timestamp at which the hub-admin signed this claim. */
+  issued_at: string;
+  /** Random nonce to prevent replay. */
+  nonce: string;
+}
+
+/** On-wire envelope for a hub-admin revoke. */
+export interface SignedAdmissionRevoke {
+  claim: AdmissionRevokeClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}
+
+/**
+ * ADR-0018 Q4 (Gap-C) — one row of the member PoP-read response. The member's
+ * own admission request, including the (b′) `sealed_secret` slot.
+ *
+ * As of PR5b the `sealed_secret` slot is POPULATED by the hub-admin
+ * `cortex network secret add-member` (sealed mode) and consumed by
+ * `cortex network join` (auto-fetch + unseal). It is part of the base
+ * {@link AdmissionRequest} now; this alias is retained as the documented
+ * member-read response shape.
+ */
+export type AdmissionMineRow = AdmissionRequest;
 
 // ---------------------------------------------------------------------------
 // Back-compat aliases — store-layer names still reference Issuance* names

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -19,12 +19,16 @@
 import type {
   AdmissionDecisionClaim,
   AdmissionReadClaim,
+  AdmissionRevokeClaim,
   Capability,
   RegistrationClaim,
+  SealedSecretWriteClaim,
   SignedAdmissionDecision,
   SignedAdmissionMineRead,
   SignedAdmissionRead,
+  SignedAdmissionRevoke,
   SignedRegistration,
+  SignedSealedSecretWrite,
   StackIdentity,
 } from "./types";
 
@@ -701,6 +705,181 @@ export function validateSignedAdmissionMineRead(
     signed: {
       claim: { principal_id: bc.principal_id, peer_pubkey: bc.peer_pubkey, issued_at: bc.issued_at },
       signature: b.signature,
+    },
+  };
+}
+
+// =============================================================================
+// ADR-0018 PR5b — hub-admin sealed-secret write + revoke claim validators
+// =============================================================================
+
+/**
+ * Bound on the opaque sealed ciphertext the registry stores (ADR-0018 b′). It
+ * must be base64 (the registry never decodes it, but a non-base64 value can
+ * only be junk) and bounded so a hostile hub-admin cannot stuff the row with an
+ * unbounded blob. A `crypto_box_seal` of a small secret is ~100 bytes base64;
+ * 8 KiB leaves generous headroom for the future M3 payload-key envelope (#1246)
+ * riding the SAME slot without a hard cliff.
+ */
+export function isValidSealedSecret(b64: string): boolean {
+  return typeof b64 === "string" && b64.length >= 1 && b64.length <= 8192 && BASE64_RE.test(b64);
+}
+
+/**
+ * Validate the `POST /admission-requests/{id}/sealed-secret` envelope
+ * ({ claim: SealedSecretWriteClaim, signature }). Mirrors
+ * `validateSignedAdmissionDecision` so the HUB-admin gate applies the identical
+ * 503/401/403 order.
+ */
+export function validateSignedSealedSecretWrite(
+  body: unknown,
+): { ok: true; signed: SignedSealedSecretWrite } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null || Array.isArray(b.claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be a non-array object" }] };
+  }
+  return {
+    ok: true,
+    signed: { claim: b.claim as SealedSecretWriteClaim, signature: b.signature },
+  };
+}
+
+/**
+ * Validate the `SealedSecretWriteClaim` payload before crypto verification.
+ * Cross-field rule: claim.request_id MUST match the URL path parameter
+ * (forged-attribution guard). The opaque `sealed_secret` is shape-checked only
+ * (base64 + bounded) — the registry never reads it.
+ */
+export function validateSealedSecretClaim(
+  claim: unknown,
+  expectedRequestId: string,
+): { ok: true; claim: SealedSecretWriteClaim } | { ok: false; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+
+  if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be an object" }] };
+  }
+  const c = claim as Record<string, unknown>;
+
+  if (typeof c.request_id !== "string" || c.request_id.length === 0) {
+    errors.push({ field: "request_id", message: "must be a non-empty string" });
+  } else if (c.request_id !== expectedRequestId) {
+    errors.push({
+      field: "request_id",
+      message: `body request_id "${c.request_id}" does not match path "${expectedRequestId}"`,
+    });
+  }
+
+  if (typeof c.sealed_secret !== "string" || !isValidSealedSecret(c.sealed_secret)) {
+    errors.push({ field: "sealed_secret", message: "must be base64, 1..8192 chars" });
+  }
+
+  if (typeof c.hub_admin_pubkey !== "string" || !isValidPubkey(c.hub_admin_pubkey)) {
+    errors.push({ field: "hub_admin_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
+  }
+
+  if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
+    errors.push({ field: "issued_at", message: "must be an ISO-8601 timestamp" });
+  }
+
+  if (typeof c.nonce !== "string" || c.nonce.length < 8 || c.nonce.length > 128) {
+    errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    claim: {
+      request_id: c.request_id as string,
+      sealed_secret: c.sealed_secret as string,
+      hub_admin_pubkey: c.hub_admin_pubkey as string,
+      issued_at: c.issued_at as string,
+      nonce: c.nonce as string,
+    },
+  };
+}
+
+/**
+ * Validate the `POST /admission-requests/{id}/revoke` envelope
+ * ({ claim: AdmissionRevokeClaim, signature }).
+ */
+export function validateSignedAdmissionRevoke(
+  body: unknown,
+): { ok: true; signed: SignedAdmissionRevoke } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null || Array.isArray(b.claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be a non-array object" }] };
+  }
+  return {
+    ok: true,
+    signed: { claim: b.claim as AdmissionRevokeClaim, signature: b.signature },
+  };
+}
+
+/**
+ * Validate the `AdmissionRevokeClaim` payload before crypto verification.
+ * Cross-field rule: claim.request_id MUST match the URL path parameter.
+ */
+export function validateAdmissionRevokeClaim(
+  claim: unknown,
+  expectedRequestId: string,
+): { ok: true; claim: AdmissionRevokeClaim } | { ok: false; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+
+  if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be an object" }] };
+  }
+  const c = claim as Record<string, unknown>;
+
+  if (typeof c.request_id !== "string" || c.request_id.length === 0) {
+    errors.push({ field: "request_id", message: "must be a non-empty string" });
+  } else if (c.request_id !== expectedRequestId) {
+    errors.push({
+      field: "request_id",
+      message: `body request_id "${c.request_id}" does not match path "${expectedRequestId}"`,
+    });
+  }
+
+  if (typeof c.hub_admin_pubkey !== "string" || !isValidPubkey(c.hub_admin_pubkey)) {
+    errors.push({ field: "hub_admin_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
+  }
+
+  if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
+    errors.push({ field: "issued_at", message: "must be an ISO-8601 timestamp" });
+  }
+
+  if (typeof c.nonce !== "string" || c.nonce.length < 8 || c.nonce.length > 128) {
+    errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    claim: {
+      request_id: c.request_id as string,
+      hub_admin_pubkey: c.hub_admin_pubkey as string,
+      issued_at: c.issued_at as string,
+      nonce: c.nonce as string,
     },
   };
 }


### PR DESCRIPTION
Implements **#1240 — PR5b: leaf-secret tooling + sealed delivery** per [ADR-0018](docs/adr/0018-admission-gate-and-leaf-secret-distribution.md) and the #1240 plug-and-play constraint. Builds on PR5a (#1244, admission rows + `sealed_secret` slot + member PoP-read) and seal-to-principal (#1238). Trust-path; TDD.

## Scope
The **secret-delivery mechanism + the LEAF PSK**. The mechanism delivers a member secret **sealed to the member's pubkey**; the leaf PSK is wired through it now. The per-network M3 **payload key** (#1246, not yet merged) rides the **same** mechanism later — see the M3 seam below. We did **not** block on M3.

## Command surface
```
cortex network secret add-member    <network> <member-pubkey> [--deliver sealed|oob]
cortex network secret revoke-member <network> <member-pubkey>
cortex network secret rotate        <network> <member-pubkey>
  --admin-seed <hub-admin-seed> [--registry-url <u>] [--hub-config <p>]
  [--leaf-user <u>] [--apply] [--dry-run] [--json]
```
Dry-run by default; `--apply` mutates. Hub-admin authority (Q5) — kept **separable in code** from the registry-admin admit (`REGISTRY_HUB_ADMIN_PUBKEYS`, falling back to `REGISTRY_ADMIN_PUBKEYS` for the metafactory collapse where Luna is both).

## Flow
- **add-member** — mint a per-member PSK → write the member's hub `authorization` user + reload the hub (allow transport) → **sealed** (default): `sealToPrincipal(envelope, memberPubkey)` → POST the opaque ciphertext to the ADMITTED admission row's `sealed_secret` slot; **oob**: surface the PSK for the privileged bot to hand over (registry untouched).
- **revoke-member** — drop the member's hub `authorization` user + **reload** (MUST cut transport, not just the roster) → mark the admission row **REVOKED** + clear the blob.
- **rotate** — re-mint + re-seal + replace; old PSK inert.
- The admit route still **mints nothing** — pinned by tests.

## Plug-and-play (#1240)
`cortex network join` AUTO-fetches the sealed blob (member PoP-read), decrypts it with the joiner's own seed, and renders the leaf — **the user never handles a secret**. Best-effort + soft-closed: falls through to the existing leaf-secret path on any miss, so it never breaks an existing join.

## Registry
- migration `0010` — `sealed_secret` column + `REVOKED` status (table-recreate, mirrors 0007/0008; re-applies both indexes).
- `POST /admission-requests/:id/sealed-secret` (hub-admin) + `POST /admission-requests/:id/revoke` (hub-admin); `/mine` now serves the real blob.

## M3 payload-key seam (for #1246)
The sealed plaintext is a small JSON envelope (`src/common/registry/sealed-leaf-secret.ts`): `{ v, leaf_psk, leaf_user }` today, with an optional `payload_key` the decoder already tolerates. M3 seals the per-network payload key into the **same** blob via the **same** `add-member`/`rotate`/`revoke-member` path — one extra sealed field, no wire/schema change. The payload-key *config field* lives in M3, not here.

## Gate status
- `bunx tsc --noEmit` — clean (registry workspace has pre-existing env-only `ArrayBuffer` lib errors in files this PR doesn't touch).
- `bash scripts/check-carveouts.sh` — PASS.
- scoped `bun test src/cli/cortex/commands/ src/services/network-registry/ src/bus/ src/common/` — 2632 pass / 0 fail.
- `bun run lint:errors` — clean.

New tests: registry sealed-secret + revoke (hub-admin authority, separable authorities, 409/401/403/503/replay, idempotent revoke); pure hub-authorization (add/replace/remove/idempotent/injection-guard); PSK minting; full seal→deliver→fetch→unseal round-trip with **real** keys (wrong-recipient/tampered/wrong-network all fail soft-closed); CLI lib + dispatch + join-wiring.

Closes #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)