### PR TITLE
chore: bump to v5.27.0 — sovereign federation + end-to-end confidentiality

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.26.8"
+version: "5.27.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release bump for **v5.27.0**: 13 PRs delivering sovereign Model-B federation (one-command provision → join → admit) + **end-to-end payload confidentiality** (per-network key, sealed delivery, M3 encryption, Pier airgap). Additive/opt-in — encryption ships **dormant** (default-off). 5.26.8 → 5.27.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)