### PR TITLE
fix(network): C-1225 — provision accepts arc.nats.federation.v1 from add-federation-export (PR7 unblock)

### DIFF
--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -184,6 +184,13 @@ ALLOWLIST_PATHS=(
   'src/cli/cortex/commands/operator-provisioning.ts'
   'src/cli/cortex/commands/network-provision-lib.ts'
   'src/cli/cortex/commands/network-provision-adapters.ts'
+  # network-federation-wiring.ts is the THIRD arc-shell provision adapter
+  # (FederationWiringPort, sibling to operator-provisioning.ts above). Its
+  # doc-comment names the NSC account-tree schemas (`arc.nats.operator.v1`,
+  # `init-operator`/`add-account`) only to contrast them with the federation
+  # schema it consumes — every "operator" is the NSC account-tree sense, never
+  # the principal (cortex#1225). Class: NSC.
+  'src/cli/cortex/commands/network-federation-wiring.ts'
   'src/cli/cortex/commands/__tests__/operator-provisioning.test.ts'
   'src/cli/cortex/commands/__tests__/network-provision-lib.test.ts'
   'src/cli/cortex/commands/__tests__/network-provision-cli.test.ts'

--- a/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
@@ -479,7 +479,7 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
     importAlreadyPresent: true,
   });
 
-  test("dry-run: invokes arc with --dry-run (no --apply) and returns ok", async () => {
+  test("dry-run: invokes arc with NO --apply and NO --dry-run (arc default is dry-run) and returns ok", async () => {
     const { runner, calls } = makeRunner({ stdout: SUCCESS_JSON });
     const adapter = buildFederationWiringAdapter(runner);
 
@@ -491,13 +491,43 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
 
     expect(result.ok).toBe(true);
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain("--dry-run");
+    // arc's add-federation-export has NO --dry-run flag: dry-run is the default
+    // and only --apply mutates. The non-apply branch must emit neither flag —
+    // passing --dry-run makes real arc exit 1 with `unknown option '--dry-run'`.
+    expect(calls[0]).not.toContain("--dry-run");
     expect(calls[0]).not.toContain("--apply");
     expect(calls[0]).toContain("--from-account");
     expect(calls[0]).toContain(LEAF_ACCOUNT);
     expect(calls[0]).toContain("--to-account");
     expect(calls[0]).toContain(AGENTS_ACCOUNT);
     expect(calls[0]).toContain("--json");
+  });
+
+  test("dry-run regression: a runner mimicking real arc's --dry-run rejection would surface failure (guards against a non-existent arc flag)", async () => {
+    // Mimic real arc's behaviour if the adapter ever regressed to passing a flag
+    // arc does not know (e.g. --dry-run): commander exits 1 with empty stdout and
+    // an `unknown option` error on stderr. This pins the regression to real-arc
+    // behaviour rather than a permissive mock that returns success for any argv.
+    const realArcLikeRunner: ArcFederationRunner = async (argv) => {
+      const unknown = argv.find(
+        (a) => a.startsWith("--") && a !== "--from-account" && a !== "--to-account"
+          && a !== "--subject" && a !== "--service" && a !== "--apply" && a !== "--json",
+      );
+      if (unknown !== undefined) {
+        return { stdout: "", stderr: `error: unknown option '${unknown}'`, exitCode: 1 };
+      }
+      return { stdout: SUCCESS_JSON, stderr: "", exitCode: 0 };
+    };
+    const adapter = buildFederationWiringAdapter(realArcLikeRunner);
+
+    // The shipping adapter (no --dry-run flag) succeeds against real-arc behaviour.
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: false,
+    });
+
+    expect(result.ok).toBe(true);
   });
 
   test("--apply: invokes arc with --apply (not --dry-run)", async () => {

--- a/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
@@ -456,7 +456,7 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
   }
 
   const SUCCESS_JSON = JSON.stringify({
-    schema: "arc.nats.v2",
+    schema: "arc.nats.federation.v1",
     ok: true,
     fromAccount: LEAF_ACCOUNT,
     toAccount: AGENTS_ACCOUNT,
@@ -468,7 +468,7 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
   });
 
   const IDEMPOTENT_JSON = JSON.stringify({
-    schema: "arc.nats.v2",
+    schema: "arc.nats.federation.v1",
     ok: true,
     fromAccount: LEAF_ACCOUNT,
     toAccount: AGENTS_ACCOUNT,
@@ -531,7 +531,7 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
 
   test("arc ok=false: returns ok=false with reason from arc", async () => {
     const errorJson = JSON.stringify({
-      schema: "arc.nats.v2",
+      schema: "arc.nats.federation.v1",
       ok: false,
       error: { code: "NSC_COMMAND_FAILED", message: "nsc add export failed" },
     });
@@ -584,7 +584,7 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
     // from==to as a no-op locally). Build a SUCCESS_JSON with toAccount=LEAF_ACCOUNT
     // to match the actual args the adapter will pass.
     const sameAccountSuccessJson = JSON.stringify({
-      schema: "arc.nats.v2",
+      schema: "arc.nats.federation.v1",
       ok: true,
       fromAccount: LEAF_ACCOUNT,
       toAccount: LEAF_ACCOUNT,
@@ -637,5 +637,106 @@ describe("buildFederationWiringAdapter — arc-shell adapter", () => {
 
     expect(calls[0]).toContain("nats");
     expect(calls[0]).toContain("add-federation-export");
+  });
+});
+
+// =============================================================================
+// cortex#1225 regression — accept arc's REAL schema, reject the wrong one
+//
+// The adapter originally required `arc.nats.v2`, a schema arc never shipped
+// (arc#243 namespaces federation results under `arc.nats.federation.v1`). That
+// made `cortex network provision --apply` always fail at the federation-wiring
+// step against real arc, blocking the PR7 live-stack migration. These tests
+// pin the contract to what arc ACTUALLY emits and prove the never-shipped
+// `arc.nats.v2` is rejected, so the regression cannot silently return.
+// =============================================================================
+
+describe("cortex#1225 — federation-wiring schema contract (arc.nats.federation.v1)", () => {
+  function makeRunner(stdout: string): { runner: ArcFederationRunner; calls: string[][] } {
+    const calls: string[][] = [];
+    const runner: ArcFederationRunner = async (argv) => {
+      calls.push([...argv]);
+      return { stdout, stderr: "", exitCode: 0 };
+    };
+    return { runner, calls };
+  }
+
+  // Mirrors arc's REAL AddFederationExportJson on --apply, including the extra
+  // `pushResult` field arc emits (which cortex does not model and must ignore).
+  const REAL_ARC_OUTPUT = JSON.stringify({
+    schema: "arc.nats.federation.v1",
+    ok: true,
+    fromAccount: LEAF_ACCOUNT,
+    toAccount: AGENTS_ACCOUNT,
+    subject: "federated.>",
+    exportAdded: true,
+    importAdded: true,
+    exportAlreadyPresent: false,
+    importAlreadyPresent: false,
+    pushResult: { fromAccount: "ok", toAccount: "ok" },
+  });
+
+  test("accepts the schema arc actually emits (arc.nats.federation.v1, incl. extra pushResult)", async () => {
+    const { runner } = makeRunner(REAL_ARC_OUTPUT);
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.note).toBeDefined();
+  });
+
+  test("rejects the never-shipped arc.nats.v2 as a schema mismatch (the original bug)", async () => {
+    const wrongSchema = JSON.stringify({
+      schema: "arc.nats.v2",
+      ok: true,
+      fromAccount: LEAF_ACCOUNT,
+      toAccount: AGENTS_ACCOUNT,
+      subject: "federated.>",
+      exportAdded: true,
+      importAdded: true,
+      exportAlreadyPresent: false,
+      importAlreadyPresent: false,
+    });
+    const { runner } = makeRunner(wrongSchema);
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/schema mismatch/i);
+      // The diagnostic names the schema we DID require + the one arc sent.
+      expect(result.reason).toMatch(/arc\.nats\.federation\.v1/);
+      expect(result.reason).toMatch(/arc\.nats\.v2/);
+    }
+  });
+
+  test("rejects a genuinely-malformed envelope (missing schema field)", async () => {
+    const noSchema = JSON.stringify({
+      ok: true,
+      fromAccount: LEAF_ACCOUNT,
+      toAccount: AGENTS_ACCOUNT,
+      subject: "federated.>",
+    });
+    const { runner } = makeRunner(noSchema);
+    const adapter = buildFederationWiringAdapter(runner);
+
+    const result = await adapter.wireLocalFederation({
+      federationAccount: LEAF_ACCOUNT,
+      agentsAccount: AGENTS_ACCOUNT,
+      apply: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/schema mismatch/i);
   });
 });

--- a/src/cli/cortex/commands/network-federation-wiring.ts
+++ b/src/cli/cortex/commands/network-federation-wiring.ts
@@ -24,11 +24,21 @@
  *
  * ## Schema
  *
- * arc responds with `arc.nats.v2` (a new schema revision for federation
- * commands, distinct from `arc.nats.v1` used by add-bot/reissue-bot). We
- * guard on the schema string so a future arc that returns `arc.nats.v1` for
- * this subcommand (a contract regression) fails loudly rather than silently
- * misinterpreting the envelope.
+ * arc responds with `arc.nats.federation.v1` (a SEPARATE schema namespace for
+ * federation commands — arc#243 / `ARC_NATS_FEDERATION_SCHEMA` in arc's
+ * `src/lib/json-response.ts` — distinct from `arc.nats.v1` used by
+ * add-bot/reissue-bot and `arc.nats.operator.v1` used by init-operator/
+ * add-account). We guard on the schema string so a future arc that returns a
+ * different schema for this subcommand (a contract regression) fails loudly
+ * rather than silently misinterpreting the envelope.
+ *
+ * NOTE (cortex#1225): this adapter originally required `arc.nats.v2` — a schema
+ * arc never shipped and explicitly chose NOT to (it namespaced federation under
+ * `arc.nats.federation.v1` so consumers guarding on `arc.nats.v1` stay
+ * unaffected). The mismatch made `cortex network provision --apply` ALWAYS fail
+ * at the federation-wiring step against real arc; the unit tests passed because
+ * their fixtures mocked the never-shipped `arc.nats.v2`. Fixed to accept the
+ * schema arc actually emits.
  */
 
 import type { FederationWiringPort } from "./network-ports";
@@ -58,13 +68,19 @@ async function defaultArcFederationRunner(argv: readonly string[]): Promise<ArcF
 }
 
 // =============================================================================
-// arc.nats.v2 envelope types
+// arc.nats.federation.v1 envelope types
+//
+// Mirrors arc's `AddFederationExportJson` (src/lib/json-response.ts). arc may
+// additionally emit a `pushResult` field on success; we intentionally do not
+// model it (cortex does not consume it — extra fields are forward-compatible).
 // =============================================================================
 
-const ARC_NATS_SCHEMA_V2 = "arc.nats.v2";
+/** Schema arc emits for `nats add-federation-export` (arc#243). Must match
+ *  arc's `ARC_NATS_FEDERATION_SCHEMA`; a divergence here breaks provision. */
+const ARC_NATS_FEDERATION_SCHEMA = "arc.nats.federation.v1";
 
 interface ArcFederationOk {
-  schema: typeof ARC_NATS_SCHEMA_V2;
+  schema: typeof ARC_NATS_FEDERATION_SCHEMA;
   ok: true;
   fromAccount: string;
   toAccount: string;
@@ -76,7 +92,7 @@ interface ArcFederationOk {
 }
 
 interface ArcFederationError {
-  schema: typeof ARC_NATS_SCHEMA_V2;
+  schema: typeof ARC_NATS_FEDERATION_SCHEMA;
   ok: false;
   error: { code: string; message: string };
 }
@@ -149,7 +165,7 @@ export function buildFederationWiringAdapter(
         return {
           ok: false,
           reason:
-            `arc returned no valid '${ARC_NATS_SCHEMA_V2}' envelope. ` +
+            `arc returned no valid '${ARC_NATS_FEDERATION_SCHEMA}' envelope. ` +
             `Confirm arc is installed and that 'arc nats add-federation-export' supports --json. ` +
             `arc stderr: ${result.stderr.trim() || "(empty)"}`,
         };
@@ -162,7 +178,7 @@ export function buildFederationWiringAdapter(
         return {
           ok: false,
           reason:
-            `arc returned no valid '${ARC_NATS_SCHEMA_V2}' envelope (JSON parse failed). ` +
+            `arc returned no valid '${ARC_NATS_FEDERATION_SCHEMA}' envelope (JSON parse failed). ` +
             `arc output: ${line.slice(0, 200)}`,
         };
       }
@@ -171,12 +187,12 @@ export function buildFederationWiringAdapter(
       if (
         typeof parsed !== "object" ||
         parsed === null ||
-        (parsed as { schema?: unknown }).schema !== ARC_NATS_SCHEMA_V2
+        (parsed as { schema?: unknown }).schema !== ARC_NATS_FEDERATION_SCHEMA
       ) {
         return {
           ok: false,
           reason:
-            `arc returned no valid '${ARC_NATS_SCHEMA_V2}' envelope (schema mismatch). ` +
+            `arc returned no valid '${ARC_NATS_FEDERATION_SCHEMA}' envelope (schema mismatch). ` +
             `Got: ${JSON.stringify((parsed as { schema?: unknown }).schema ?? "(none)")}. ` +
             `Ensure arc supports the G1b add-federation-export command (arc#243).`,
         };

--- a/src/cli/cortex/commands/network-federation-wiring.ts
+++ b/src/cli/cortex/commands/network-federation-wiring.ts
@@ -142,7 +142,13 @@ export function buildFederationWiringAdapter(
         "--from-account", federationAccount,
         "--to-account", toAccount,
         "--subject", "federated.>",
-        apply ? "--apply" : "--dry-run",
+        // arc's add-federation-export has NO --dry-run flag; dry-run is the
+        // DEFAULT and only --apply mutates (`arc nats add-federation-export
+        // --help`: "--apply … (default: dry-run)"). Passing --dry-run makes arc
+        // exit 1 with `unknown option '--dry-run'` and empty stdout, so the
+        // dry-run join path (network-lib.ts: apply defaults false) always failed
+        // federation-wiring. Emit --apply only when mutating; nothing otherwise.
+        ...(apply ? ["--apply"] : []),
         "--json",
       ];
 


### PR DESCRIPTION
## Summary

`cortex network provision <stack> --apply` succeeds at `init-operator` + `add-account` but **always fails** at the federation-wiring step against real arc:

```
✗ federation wiring failed: arc returned no valid 'arc.nats.v2' envelope (schema mismatch). Got: "arc.nats.federation.v1".
```

### Root cause

The federation-wiring adapter (`src/cli/cortex/commands/network-federation-wiring.ts`) required schema **`arc.nats.v2`** for the `arc nats add-federation-export` result. But arc#243 deliberately emits **`arc.nats.federation.v1`** — a *separate* schema namespace (`ARC_NATS_FEDERATION_SCHEMA` in arc's `src/lib/json-response.ts`) chosen specifically so consumers guarding on `arc.nats.v1` stay unaffected. arc never shipped `arc.nats.v2` and explicitly never will.

So the provision↔arc adapter (PR3 / #1139 / #1236) could **never** complete federation wiring against live arc — it was never exercised end-to-end. The unit tests passed only because their fixtures mocked the never-shipped `arc.nats.v2`.

## The fix

Two wire-contract bugs of the same class — both shipped green because the adapter was never run end-to-end against real arc and the mocks asserted arc behaviour arc does not have:

1. **Schema string (`arc.nats.v2` → `arc.nats.federation.v1`).** Rename `ARC_NATS_SCHEMA_V2` → `ARC_NATS_FEDERATION_SCHEMA = "arc.nats.federation.v1"` and validate the schema arc actually emits, mirroring the reference `creds.ts` `ARC_NATS_SCHEMA` pattern (named constant, real schema, clear error on mismatch).

2. **`--dry-run` argv flag (found + fixed during review).** The adapter passed `apply ? "--apply" : "--dry-run"`, but **arc's `add-federation-export` has no `--dry-run` option** — dry-run is the *default* and only `--apply` mutates (`arc nats add-federation-export --help`: `--apply … (default: dry-run)`). Passing `--dry-run` makes arc exit 1 with `error: unknown option '--dry-run'` and empty stdout, so the dry-run path failed with `arc returned no valid 'arc.nats.federation.v1' envelope`. This was reached on a real path: `cortex network join <network>` (`network-lib.ts:357`, `apply` defaults `false` per the #794 never-accidentally-mutate principle), so the **default dry-run join always failed federation-wiring**. The provision `--apply` path (#1225) hardcodes `apply: true` and was unaffected, which is why it wasn't caught by the schema fix alone. Fixed by emitting `--apply` only when mutating and **no flag** when dry-running: `...(apply ? ["--apply"] : [])`.

## Adapter audit (every arc invocation in the provision path)

The task called for plural bugs since the whole adapter was never run against live arc. I audited each arc call against arc's actual `src/lib/json-response.ts` contracts (arc v0.32.0) on **both** dimensions — schema/field shape **and** argv/flag contract. The argv-contract pass initially missed the `--dry-run` flag bug; the adversarial review caught it against live `arc` and it is fixed here alongside the schema bug.

| Step | File | arc schema | cortex required | argv/flag | Verdict |
|------|------|-----------|-----------------|-----------|---------|
| `init-operator` | operator-provisioning.ts | `arc.nats.operator.v1` | `arc.nats.operator.v1` | matches live arc | ✅ matches (fields too) — kept working |
| `add-account` | operator-provisioning.ts | `arc.nats.operator.v1` | `arc.nats.operator.v1` | name positional, matches | ✅ matches |
| `add-federation-export` | network-federation-wiring.ts | `arc.nats.federation.v1` | `arc.nats.v2` | passed non-existent `--dry-run` | ❌ **both fixed here** |
| `nats_infra` write-back | network-provision-lib.ts | (no arc — pure config write) | — | — | ✅ no contract |

Field shapes for `add-federation-export` match arc's `AddFederationExportJson` exactly (`fromAccount`, `toAccount`, `subject`, `exportAdded`, `importAdded`, `exportAlreadyPresent`, `importAlreadyPresent`); arc additionally emits `pushResult`, which cortex correctly ignores.

## Test

Updated `network-federation-wiring.test.ts` (`cortex#1225` regression block):
- **accepts** the schema arc actually emits (`arc.nats.federation.v1`, including arc's extra `pushResult` field — proves forward-compat)
- **rejects** the never-shipped `arc.nats.v2` as a schema mismatch (the original bug — diagnostic names both the required and received schema)
- **rejects** a genuinely-malformed envelope (missing `schema` field)
- **dry-run argv:** asserts the dry-run branch sends **neither `--apply` nor `--dry-run`** (was asserting `toContain("--dry-run")` against a permissive mock — the green-test-mocking-a-fiction pattern that let the flag bug ship); the `--apply` branch sends `--apply`
- **dry-run regression guard:** a runner that mimics real arc's commander behaviour (exit 1 + empty stdout + `unknown option` on any flag arc doesn't define) — pins the dry-run path to real-arc behaviour so a regression to a non-existent arc flag fails the test instead of passing against a mock

## Gates

- `bunx tsc --noEmit` → 0
- `bash scripts/check-carveouts.sh` → PASS (added the file to the NSC provision-tooling allowlist group — it's the third arc-shell provision adapter, sibling to `operator-provisioning.ts`; its doc-comment names `arc.nats.operator.v1` only to contrast schemas)
- `bun test src/cli/ src/common/` → 2398 pass, 0 fail
- `bun run lint:errors` → clean

Closes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
