### PR TITLE
chore: bump to v5.27.1 — provision↔arc wire-contract fixes (#1253)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.27.0"
+version: "5.27.1"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Patch release carrying #1253: `cortex network provision` now accepts arc's real `arc.nats.federation.v1` schema (was requiring the never-shipped `arc.nats.v2`) and passes the correct `--apply`/dry-run argv to `add-federation-export` (arc has no `--dry-run` flag). Unblocks the PR7 live-stack migration. 5.27.0 → 5.27.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)