### PR TITLE
test(network): C-1225 — provision→arc end-to-end integration guard (sovereign-provisioning hardening)

### DIFF
--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -194,6 +194,11 @@ ALLOWLIST_PATHS=(
   'src/cli/cortex/commands/__tests__/operator-provisioning.test.ts'
   'src/cli/cortex/commands/__tests__/network-provision-lib.test.ts'
   'src/cli/cortex/commands/__tests__/network-provision-cli.test.ts'
+  # provision→arc end-to-end integration test (C-1225 provision-chain hardening):
+  # drives the orchestrator through the real FederationWiringPort against a
+  # faithful arc-CLI contract harness. Every "operator" is the NSC account-tree
+  # sense (OperatorProvisioningPort / OP_ANDREAS), never the principal. Class: NSC.
+  'src/cli/cortex/commands/__tests__/network-provision-integration.test.ts'
   # G1d own-operator onboarding design doc — its whole subject is standing up the
   # principal's own NSC account tree (also caught by the `operator-onboarding`
   # line pattern; path-allowlisted for clarity). Class: NSC.

--- a/src/cli/cortex/commands/__tests__/network-provision-integration.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-provision-integration.test.ts
@@ -1,0 +1,157 @@
+/**
+ * C-1225 — end-to-end integration test for the `cortex network provision` chain
+ * at the cortex→arc seam.
+ *
+ * Where `network-provision-lib.test.ts` injects a fully-fake FederationWiringPort,
+ * this test drives the orchestrator through the REAL
+ * {@link buildFederationWiringAdapter} — the live adapter that builds the
+ * `arc nats add-federation-export …` argv and parses arc's
+ * `arc.nats.federation.v1` envelope. The only seam swapped is the arc SUBPROCESS
+ * runner, replaced by a faithful harness that enforces arc's REAL CLI contract:
+ * it rejects any option arc does not define (e.g. the never-shipped `--dry-run`)
+ * with a non-zero exit + `unknown option`, exactly like commander.
+ *
+ * This is the cortex-side anti-rot guard for the provision-chain hardening: it
+ * pins the argv cortex emits to arc AND the schema cortex demands back, so the
+ * #1225 class of bugs (wrong schema `arc.nats.v2`; passing `--dry-run`) cannot
+ * silently return. It complements the arc-side `nats-federation-integration`
+ * test that pins arc→nsc.
+ */
+import { describe, test, expect } from "bun:test";
+
+import { buildFederationWiringAdapter, type ArcFederationRunner } from "../network-federation-wiring";
+import {
+  provisionStack,
+  type ProvisionInputs,
+  type ProvisionPorts,
+  type SigningIdentityPort,
+  type ProvisionConfigWritePort,
+} from "../network-provision-lib";
+import type { OperatorProvisioningPort } from "../operator-provisioning";
+
+const FED_PUB = "A" + "F".repeat(55);
+const AGENTS_PUB = "A" + "G".repeat(55);
+
+/** The options arc's `nats add-federation-export` ACTUALLY defines (src/cli.ts). */
+const ARC_KNOWN_OPTS = new Set([
+  "--from-account",
+  "--to-account",
+  "--subject",
+  "--service",
+  "--apply",
+  "--json",
+]);
+
+/**
+ * Faithful arc-CLI contract harness. Asserts the argv prefix is
+ * `nats add-federation-export`, rejects any unknown option like commander
+ * (exit 1 + `unknown option`), and otherwise returns the
+ * `arc.nats.federation.v1` envelope. `record` captures the argv for assertions.
+ */
+function arcContractRunner(record: string[][]): ArcFederationRunner {
+  return async (argv) => {
+    record.push([...argv]);
+    if (argv[0] !== "nats" || argv[1] !== "add-federation-export") {
+      return { stdout: "", stderr: `unknown command: ${argv.join(" ")}`, exitCode: 1 };
+    }
+    for (const a of argv.slice(2)) {
+      if (a.startsWith("--") && !ARC_KNOWN_OPTS.has(a)) {
+        return { stdout: "", stderr: `error: unknown option '${a}'`, exitCode: 1 };
+      }
+    }
+    const apply = argv.includes("--apply");
+    const envelope = {
+      schema: "arc.nats.federation.v1",
+      ok: true,
+      fromAccount: argv[argv.indexOf("--from-account") + 1],
+      toAccount: argv[argv.indexOf("--to-account") + 1],
+      subject: "federated.>",
+      exportAdded: apply,
+      importAdded: apply,
+      exportAlreadyPresent: false,
+      importAlreadyPresent: false,
+      pushResult: { fromAccount: "skipped", toAccount: "skipped" },
+    };
+    return { stdout: JSON.stringify(envelope) + "\n", stderr: "", exitCode: 0 };
+  };
+}
+
+function buildPorts(runner: ArcFederationRunner): { ports: ProvisionPorts; written: unknown[] } {
+  const written: unknown[] = [];
+  const operator: OperatorProvisioningPort = {
+    initOperator: async ({ name }) => ({
+      ok: true, operator: name, pubKey: "OD4D", created: true, alreadyExisted: false, seedPath: null,
+    }),
+    addAccount: async ({ name }) => ({
+      ok: true, account: name, pubKey: name.endsWith("_AGENTS") ? AGENTS_PUB : FED_PUB,
+      created: true, alreadyExisted: false,
+    }),
+  };
+  const signing: SigningIdentityPort = {
+    exists: () => false,
+    generate: () => ({ ok: true, nkeyPub: "U" + "Z".repeat(55), fingerprint: "fp" }),
+  };
+  const configWrite: ProvisionConfigWritePort = {
+    write: (fields) => { written.push(fields); return { ok: true }; },
+  };
+  // The REAL wiring adapter — only the arc subprocess runner is swapped.
+  const federationWiring = buildFederationWiringAdapter(runner);
+  return { ports: { operator, signing, federationWiring, configWrite }, written };
+}
+
+function inputs(): ProvisionInputs {
+  return {
+    principal: "andreas",
+    stackSlug: "work",
+    stackId: "andreas/work",
+    operatorName: "OP_ANDREAS",
+    federationAccountName: "ANDREAS_WORK_FED",
+    agentsAccountName: "ANDREAS_WORK_AGENTS",
+    seedPath: "~/.config/nats/cortex-work.nk",
+    credsPath: "~/.config/nats/work.creds",
+    force: false,
+    apply: true,
+    state: { federationAccount: undefined, agentsAccount: undefined, signingSeedExists: false },
+  };
+}
+
+describe("C-1225 — provision → real arc wiring adapter (faithful arc CLI contract)", () => {
+  test("full --apply chain completes and emits arc's REAL add-federation-export argv", async () => {
+    const record: string[][] = [];
+    const { ports, written } = buildPorts(arcContractRunner(record));
+
+    const result = await provisionStack(inputs(), ports);
+
+    // Every step completed — including the wiring through the real adapter.
+    expect(result.ok).toBe(true);
+    expect(result.applied).toBe(true);
+    expect(result.resolved?.account).toBe(FED_PUB);
+    expect(result.resolved?.agentsAccount).toBe(AGENTS_PUB);
+    expect(written).toHaveLength(1);
+
+    // The adapter emitted arc's REAL contract: `nats add-federation-export`
+    // with --from-account/--to-account/--apply/--json and NO `--dry-run`.
+    const argv = record.find((a) => a[1] === "add-federation-export");
+    expect(argv).toBeDefined();
+    expect(argv).toContain("--from-account");
+    expect(argv).toContain("--to-account");
+    expect(argv).toContain("--apply");
+    expect(argv).toContain("--json");
+    expect(argv).not.toContain("--dry-run");
+    // from-account is the minted FED pubkey; to-account the AGENTS pubkey.
+    expect(argv![argv!.indexOf("--from-account") + 1]).toBe(FED_PUB);
+    expect(argv![argv!.indexOf("--to-account") + 1]).toBe(AGENTS_PUB);
+  });
+
+  test("an unknown option to arc (the never-shipped --dry-run) fails the chain", async () => {
+    // Direct proof the harness bites: a runner that injects --dry-run is rejected.
+    const record: string[][] = [];
+    const base = arcContractRunner(record);
+    const injecting: ArcFederationRunner = (argv) => base([...argv, "--dry-run"]);
+    const { ports } = buildPorts(injecting);
+
+    const result = await provisionStack(inputs(), ports);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("federation wiring failed");
+  });
+});


### PR DESCRIPTION
## What

Cortex-side anti-rot guard for the sovereign-provisioning chain
`cortex network provision → arc nats add-federation-export → nsc`, the companion
to the arc-side argv fixes in [the-metafactory/arc#255](https://github.com/the-metafactory/arc/pull/255).

While driving `cortex network provision work --apply` end-to-end against a live nsc operator (`OP_ANDREAS`) and the `work` throwaway stack, the chain was found to fail at the federation-wiring step against real nsc. All the **code** bugs were arc-side (wrong nsc flags + `nsc push` on a `resolver: MEMORY` operator); cortex's wiring adapter was already correct (it passes arc's flags, fixed in #1253). This PR adds the missing cortex-side regression coverage.

## Test added

`src/cli/cortex/commands/__tests__/network-provision-integration.test.ts` drives `provisionStack` (the orchestrator) through the **real** `buildFederationWiringAdapter`, swapping only the arc subprocess runner for a faithful harness that enforces arc's **real** `add-federation-export` CLI contract — it rejects any option arc does not define (e.g. the never-shipped `--dry-run`) with a non-zero exit, like commander, and returns the `arc.nats.federation.v1` envelope.

It asserts:
- the full 6-step `--apply` orchestration completes through the live wiring adapter;
- the adapter emits arc's real argv (`--from-account`/`--to-account`/`--apply`/`--json`, **no** `--dry-run`), with the minted FED/AGENTS pubkeys;
- injecting an unknown option fails the chain (direct proof the harness bites).

This pins both the argv cortex emits to arc and the schema it demands back, so the #1225 class (wrong schema `arc.nats.v2`; passing `--dry-run`) cannot silently return.

## Verification

`cortex network provision work --apply` now completes ALL steps cleanly (operator present, both accounts minted, federated.> export/import wired, nats_infra write-back), idempotent on re-run. The `work` daemon restarts and authenticates on its own bus with no Authorization Violation. Full chain detail in the harden session report.

Gate: `tsc --noEmit` 0, `check-carveouts.sh` PASS, provision/network tests 906 pass / 0 fail, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)