### PR TITLE
feat(network): C-1257 — make-live daemon-switch (land a stack on its own account)

### DIFF
--- a/docs/design-make-live-daemon-switch.md
+++ b/docs/design-make-live-daemon-switch.md
@@ -76,20 +76,38 @@ Ensure-shaped, idempotent, dry-run by default (`--apply` mutates). Inputs derive
 from config (`nats.credsPath`, `nats.name`, `stack.nats_infra.agents_account`,
 principal/slug → `ANDREAS_<STACK>_AGENTS`) + flags:
 
+0. **Resolve the target nats-server PER STACK.** The nats config make-live edits +
+   hard-restarts is derived from `stack.nats_infra.config_path` (or `--nats-config`),
+   the same field `network join` derives from — there is **NO** hardcoded default.
+   `metafactory` + `work` legitimately resolve to the shared `~/.config/nats/local.conf`
+   from their own config; a co-located stack on its OWN nats-server (`community.conf`,
+   `halden.conf`) carries its own `config_path`. When neither flag nor config supplies
+   it, make-live **fails fast** rather than guessing — a silent `local.conf` default
+   would edit the wrong file and hard-restart the wrong (shared) server for a
+   community/halden stack. **Operator-mode guard:** a bus with no `resolver_preload`
+   block (the anonymous/hard-isolated `halden` pattern) is refused early — make-live
+   does not apply to it.
 1. **Mint creds under the agents account.** `arc nats add-bot <nats.name>
    --account <AGENTS> --output <nats.credsPath> --force`. The existing creds is
-   backed up to `<creds>.bak-makelive` first. Idempotent: skipped when the bot
-   user already exists under the agents account AND the creds file is present.
+   backed up to a **timestamped** `<creds>.bak-makelive-<ts>` first (so a second
+   `--apply`/`--force` never clobbers the FIRST migration's original-account
+   backup — the rollback artefact). Idempotent: skipped when the bot user already
+   exists under the agents account AND the creds file is present.
 2. **Teach the NATS server the new account.** Append the agents account JWT to
-   `resolver_preload` in the nats config (default `~/.config/nats/local.conf`).
-   Keyed on the account pubkey — present ⇒ no-op; absent ⇒ append a labelled
-   block. **Never touches other accounts** (multi-stack safety, §3.5). The account
-   JWT comes from `arc nats export-account <AGENTS>` (new read-only verb, arc#).
+   `resolver_preload` in the **resolved** nats config (§0). Keyed on the account
+   pubkey — present ⇒ no-op; absent ⇒ append a labelled block. **Never touches
+   other accounts** (multi-stack safety, §3.5). The account JWT comes from
+   `arc nats export-account <AGENTS>` (read-only verb). **Pubkey cross-check:** the
+   exported account pubkey is asserted equal to the config `agents_account` pubkey
+   (the resolver map key) before the write — a drift (slug rename / re-mint / stale
+   `nats_infra`) would write `<configPubkey>: <jwt-for-another-account>`, which nats
+   keys under `jwt.sub` → auth failure. Mismatch ⇒ fail-fast (re-run provision).
 3. **Restart the NATS server.** A MEMORY resolver does **NOT** pick up
    `resolver_preload` changes on `SIGHUP` (empirically verified — the appended
    account did not load after `kill -HUP`). A hard restart is required
-   (`launchctl kickstart -k <nats-service-label>`). Skipped when the resolver was
-   unchanged.
+   (`launchctl kickstart -k <nats-service-label>`). Gated on the resolver having
+   **actually changed** — a `--force` re-mint over an already-present account does
+   NOT hard-restart the (shared) server for a no-op resolver.
 4. **Restart the cortex daemon** so it reconnects with the new creds
    (`launchctl kickstart -k <cortex-daemon-label>`, descriptor discovered by the
    #800 `findCortexDaemonDescriptor` config-arg matcher). Skipped when nothing
@@ -97,7 +115,10 @@ principal/slug → `ANDREAS_<STACK>_AGENTS`) + flags:
 
 Service descriptors are discovered, never guessed: the cortex daemon by the #800
 `--config` matcher; the nats-server by a sibling matcher that finds the launchd
-plist / systemd unit running `nats-server -c <natsConfigPath>`.
+plist / systemd unit running `nats-server -c <natsConfigPath>`. **The dry-run
+resolves and PRINTS both restart targets** (the matched plist/unit paths) so the
+operator verifies the — possibly shared-server — blast radius before `--apply`; a
+needed-but-undiscoverable service surfaces as a dry-run WARNING.
 
 ### 3.3 Mechanics — FEDERATED stack
 
@@ -118,8 +139,9 @@ confidentiality setup is untouched by the account swap.
 
 - **Re-runnable.** Each step is ensure-shaped; a converged re-run mints nothing,
   edits nothing, and restarts nothing.
-- **Rollback** (documented, manual): restore `<creds>.bak-makelive` over
-  `nats.credsPath`, remove the agents-account block from `resolver_preload`
+- **Rollback** (documented, manual): restore the FIRST-migration
+  `<creds>.bak-makelive-<ts>` (the earliest timestamp — the original-account creds)
+  over `nats.credsPath`, remove the agents-account block from `resolver_preload`
   (restore `local.conf` from the timestamped backup make-live writes), restart the
   nats-server + the cortex daemon. The daemon returns to `ANDREAS_AGENTS`.
 

--- a/docs/design-make-live-daemon-switch.md
+++ b/docs/design-make-live-daemon-switch.md
@@ -1,0 +1,179 @@
+# Design — make-live / daemon-switch (land a provisioned stack onto its own account)
+
+**Feature:** C-1257 (PR7 / #1225, EPIC #1142, ADR-0013 Model B)
+**Status:** implemented (validated on the `work` throwaway stack)
+**Companion:** `cortex network provision` (#1253 + arc#255) — the non-disruptive account-tree mint this step lands.
+
+## 1. Problem
+
+`cortex network provision <stack> --apply` mints a principal's sovereign nsc
+account tree (`OP_<PRINCIPAL>` → `<PRINCIPAL>_<STACK>_FED` + `<PRINCIPAL>_<STACK>_AGENTS`),
+wires the local `federated.>` export/import, ensures the signing seed, and writes
+`stack.nats_infra` (`account`, `agents_account`, `creds_path`) back to config.
+
+Provision is deliberately **non-disruptive** — it never switches the running
+daemon onto the new account. Three gaps remain after provision (verified on
+`work`):
+
+1. **The creds file is never minted.** `nats_infra.creds_path` is written but no
+   `.creds` exists under the new agents account.
+2. **The local NATS server never learns the new account.** `~/.config/nats/local.conf`
+   (`resolver: MEMORY`) carries only the OLD shared `ANDREAS_AGENTS` account in
+   `resolver_preload`.
+3. **There is no make-live command for a LOCAL stack.** `cortex network join`
+   renders leaf/operator-mode config only for *federated* stacks; a local stack
+   (e.g. `work`) has no network, so nothing flips its daemon onto its own account.
+
+Result: provision succeeds, but the daemon keeps authenticating under
+`ANDREAS_AGENTS` — the shared second-signing-facility #1225 is eliminating.
+
+## 2. What the daemon authenticates with (ground truth)
+
+The cortex daemon opens ONE bus connection using **`nats.credsPath`** (the
+`.creds` file — `src/bus/nats/connection.ts`, `credsAuthenticator`). The account a
+connection lands in is determined entirely by that creds file. Confirmed on the
+live `work` daemon via the NATS monitor (`/connz?auth=true`):
+
+```
+cortex-work -> acct AADPQ7M7… (ANDREAS_AGENTS)     # before make-live
+cortex-work -> acct AARHPQIM… (ANDREAS_WORK_AGENTS)# after make-live
+```
+
+`nats.accountSigningKeyPath` is a **separate** concern — the SA-seed the
+`TrustResolver` uses to verify *peer* bots' signed request envelopes
+(`src/common/agents/trust-resolver.ts`). It is NOT used to open the daemon's own
+connection. See §7 (deferred).
+
+`nats_infra.creds_path` (provision's write-back) describes the FEDERATION leaf's
+creds — a different connection (server-to-server leaf), handled by `network join`.
+It is NOT the daemon's own connection creds. **make-live mints the daemon's own
+connection creds to `nats.credsPath`.**
+
+## 3. Decisions
+
+### 3.1 Command home — `cortex network make-live <stack>`
+
+make-live is a **separate, explicit step** (provision stays non-disruptive). It
+lives under `cortex network`, alongside `provision` and `join`, so the whole
+sovereign-bus pipeline reads as one namespace:
+
+```
+cortex network provision <stack> --apply   # mint account tree (non-disruptive)
+cortex network make-live  <stack> --apply   # land the daemon on its agents account
+cortex network join       <network> --apply # (federated only) render the leaf
+```
+
+**Fork for confirmation (Andreas):** the alternative home is `cortex stack make-live`
+(make-live operates on a single LOCAL stack's bus identity, which is arguably a
+`stack`-lifecycle concern like `stack create`). We chose `network` for
+pipeline-consistency with `provision` (which is also stack-scoped yet lives under
+`network`). The orchestration lib is pure and the dispatch wiring is one line, so
+moving it to `stack` later is trivial.
+
+### 3.2 Mechanics — LOCAL stack (the core daemon-switch)
+
+Ensure-shaped, idempotent, dry-run by default (`--apply` mutates). Inputs derived
+from config (`nats.credsPath`, `nats.name`, `stack.nats_infra.agents_account`,
+principal/slug → `ANDREAS_<STACK>_AGENTS`) + flags:
+
+1. **Mint creds under the agents account.** `arc nats add-bot <nats.name>
+   --account <AGENTS> --output <nats.credsPath> --force`. The existing creds is
+   backed up to `<creds>.bak-makelive` first. Idempotent: skipped when the bot
+   user already exists under the agents account AND the creds file is present.
+2. **Teach the NATS server the new account.** Append the agents account JWT to
+   `resolver_preload` in the nats config (default `~/.config/nats/local.conf`).
+   Keyed on the account pubkey — present ⇒ no-op; absent ⇒ append a labelled
+   block. **Never touches other accounts** (multi-stack safety, §3.5). The account
+   JWT comes from `arc nats export-account <AGENTS>` (new read-only verb, arc#).
+3. **Restart the NATS server.** A MEMORY resolver does **NOT** pick up
+   `resolver_preload` changes on `SIGHUP` (empirically verified — the appended
+   account did not load after `kill -HUP`). A hard restart is required
+   (`launchctl kickstart -k <nats-service-label>`). Skipped when the resolver was
+   unchanged.
+4. **Restart the cortex daemon** so it reconnects with the new creds
+   (`launchctl kickstart -k <cortex-daemon-label>`, descriptor discovered by the
+   #800 `findCortexDaemonDescriptor` config-arg matcher). Skipped when nothing
+   changed.
+
+Service descriptors are discovered, never guessed: the cortex daemon by the #800
+`--config` matcher; the nats-server by a sibling matcher that finds the launchd
+plist / systemd unit running `nats-server -c <natsConfigPath>`.
+
+### 3.3 Mechanics — FEDERATED stack
+
+make-live is **network-agnostic**: it lands the daemon on `ANDREAS_<STACK>_AGENTS`
+regardless of federation. For a federated stack the order is provision →
+make-live → `network join`; join renders the leaf (operator-mode `.conf` + leaf
+creds / secret-auth pipe) binding the FED account, and the provision-wired
+`federated.> ` export/import (FED → AGENTS) delivers cross-network traffic into
+the daemon's AGENTS account. The two accounts (FED for the leaf, AGENTS for the
+daemon) are exactly provision's split.
+
+**Encryption / `payload_key` survives by construction.** make-live edits only the
+creds file + `resolver_preload` + restarts two services. It NEVER touches
+`policy.federated`, the per-network `payload_key`, or any encryption block, so the
+confidentiality setup is untouched by the account swap.
+
+### 3.4 Idempotent + reversible
+
+- **Re-runnable.** Each step is ensure-shaped; a converged re-run mints nothing,
+  edits nothing, and restarts nothing.
+- **Rollback** (documented, manual): restore `<creds>.bak-makelive` over
+  `nats.credsPath`, remove the agents-account block from `resolver_preload`
+  (restore `local.conf` from the timestamped backup make-live writes), restart the
+  nats-server + the cortex daemon. The daemon returns to `ANDREAS_AGENTS`.
+
+### 3.5 Multi-stack on one nats-server
+
+The local nats-server (`homebrew.mxcl.nats-server`, `-c local.conf`) is shared by
+several stacks (`work`, `meta-factory`, the MC aggregators). The
+`resolver_preload` append is a **pure addition** keyed on the new account's
+pubkey; it neither rewrites nor reorders the accounts already present. Verified:
+after landing `work` on `ANDREAS_WORK_AGENTS`, every other connection stayed on
+`ANDREAS_AGENTS` and reconnected cleanly across the nats-server restart.
+
+## 4. New arc verb — `nats export-account <name>`
+
+A read-only companion to `init-operator` / `add-account` (schema
+`arc.nats.operator.v1`). Returns the account's pubkey, its account JWT (for
+`resolver_preload`), and its identity seed path (SA-seed, for the deferred
+`accountSigningKeyPath` rewrite):
+
+```
+arc nats export-account ANDREAS_WORK_AGENTS --json
+→ {"schema":"arc.nats.operator.v1","ok":true,"account":"ANDREAS_WORK_AGENTS",
+   "pubKey":"AARHPQIM…","jwt":"eyJ…","seedPath":"~/.local/share/nats/nsc/keys/keys/A/AR/AARHPQIM….nk"}
+```
+
+Pure read (`nsc describe account --raw` + keystore-path derivation). cortex never
+runs nsc — it shells `arc nats export-account` (the ADR-0013 invariant).
+
+## 5. Success oracle (validated on `work`)
+
+1. **new creds exist** under the agents account (`/connz` user iss = AGENTS).
+2. **resolver carries the new account** (a client with AGENTS creds connects).
+3. **daemon authenticates under `ANDREAS_WORK_AGENTS`** — `/connz?auth=true` shows
+   `cortex-work -> AARHPQIM…`, and `work-logs/` carries **0** own-auth
+   `Authorization Violation`.
+
+## 6. Anti-rot guard
+
+A real-spawn integration test (sibling of the arc#255 guard) exercises the make-
+live plan + apply against an injected arc/exec/fs contract, asserting: creds
+minted under the agents account, the agents JWT appended to `resolver_preload`
+exactly once (idempotent on re-run), both services restarted only when state
+changed, and the encryption/federated config left byte-identical.
+
+## 7. Deferred (explicit)
+
+- **`nats.accountSigningKeyPath` rewrite.** make-live does NOT repoint the
+  TrustResolver SA-seed to the new account in this iteration. It is not on the
+  daemon-auth path (creds-only), it lives in the higher-blast `system/` config
+  layer, and on a multi-agent stack the account-signing-key question (whether the
+  AGENTS account carries a dedicated signing key vs its identity key) needs its
+  own treatment. `export-account` already returns the `seedPath` so the rewrite is
+  a small follow-up. Flagged for Andreas.
+- **Full federated E2E.** Validated path is LOCAL (`work`). The federated
+  composition (make-live then `join`) is covered by design + the existing join
+  tests; a federated stack make-live + join round-trip is a follow-up on a
+  throwaway federated stack.

--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -191,6 +191,20 @@ ALLOWLIST_PATHS=(
   # schema it consumes — every "operator" is the NSC account-tree sense, never
   # the principal (cortex#1225). Class: NSC.
   'src/cli/cortex/commands/network-federation-wiring.ts'
+  # C-1257 (#1225/#1258, ADR-0013 Model B) make-live daemon-switch tooling — the
+  # pure orchestration + live arc-shell adapters + CLI wiring + design doc behind
+  # `cortex network make-live`. Their whole subject is the NSC account tree: the
+  # operator-mode bus, `arc nats export-account`/`add-bot`, the `resolver_preload`
+  # MEMORY resolver, and the per-stack agents account the daemon lands on. Every
+  # "operator" is the NATS account-tree / operator-mode sense (or the human running
+  # the daemon-switch), never the principal vocabulary. Same class as
+  # network-provision-lib.ts / network-federation-wiring.ts above. Class: NSC.
+  # RETIRE: never (NSC operator is the permanent qualified survivor, CONTEXT.md).
+  'src/cli/cortex/commands/network-make-live-lib.ts'
+  'src/cli/cortex/commands/network-make-live-adapters.ts'
+  'src/cli/cortex/commands/__tests__/network-make-live.test.ts'
+  'src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts'
+  'docs/design-make-live-daemon-switch.md'
   'src/cli/cortex/commands/__tests__/operator-provisioning.test.ts'
   'src/cli/cortex/commands/__tests__/network-provision-lib.test.ts'
   'src/cli/cortex/commands/__tests__/network-provision-cli.test.ts'

--- a/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
@@ -24,6 +24,7 @@ function reader(cfg: LoadedConfig): ConfigReader {
 
 const ABSENT_NATS = "/nonexistent-makelive-test/local.conf";
 const ABSENT_CREDS = "/nonexistent-makelive-test/cortex-work.creds";
+const ABSENT_COMMUNITY_NATS = "/nonexistent-makelive-test/community.conf";
 
 /** A fully-provisioned local stack (nats_infra.agents_account set). */
 const PROVISIONED = loaded({
@@ -47,6 +48,27 @@ const UNPROVISIONED = loaded({
   stack: { id: "andreas/work", nkey_seed_path: "~/.config/nats/cortex-work.nk" },
 });
 
+/**
+ * BLOCK 1 — a provisioned stack carrying its OWN per-stack nats-server config
+ * (`stack.nats_infra.config_path` → an absent path so the state probe reads
+ * "needs migration"). No `--nats-config` flag is passed: derivation must come
+ * from config, NOT a hardcoded shared local.conf default.
+ */
+const PROVISIONED_WITH_CONFIGPATH = loaded({
+  principal: { id: "andreas" },
+  config: { nats: { name: "cortex-community", credsPath: ABSENT_CREDS } } as unknown as AgentConfig,
+  stack: {
+    id: "andreas/community",
+    nkey_seed_path: "~/.config/nats/cortex-community.nk",
+    nats_infra: {
+      account: "A" + "B".repeat(55),
+      agents_account: AGENTS_PUB,
+      config_path: ABSENT_COMMUNITY_NATS, // community.conf, NOT the shared local.conf
+      creds_path: "~/.config/nats/community.creds",
+    },
+  },
+});
+
 function fakeFactory(): { factory: MakeLivePortsFactory; calls: string[]; mutates: boolean[] } {
   const calls: string[] = [];
   const mutates: boolean[] = [];
@@ -67,9 +89,11 @@ function fakeFactory(): { factory: MakeLivePortsFactory; calls: string[]; mutate
       },
       resolver: {
         hasAccount: () => false,
+        hasResolverPreload: () => true, // M3 — operator-mode bus (fake)
         appendAccount: () => { calls.push("resolver-append"); return { ok: true, changed: true }; },
       },
       restart: {
+        resolveTargets: () => ({ natsDescriptor: "/LA/nats.plist", daemonDescriptor: "/LA/cortex.plist" }),
         restartNats: async () => { calls.push("restart-nats"); return { ok: true }; },
         restartDaemon: async () => { calls.push("restart-daemon"); return { ok: true }; },
       },
@@ -97,6 +121,51 @@ describe("cortex network make-live — dry-run (default)", () => {
     expect(res.stdout).toContain("resolver_preload");
     expect(calls).toEqual([]); // dry-run: no effects
     expect(mutates).toEqual([false]); // ports built with mutate=false
+  });
+
+  test("BLOCK 2: prints the resolved nats-server + daemon restart targets", async () => {
+    const { factory } = fakeFactory();
+    const res = await run(
+      ["make-live", "work", "--config", "/x/work.yaml", "--nats-config", ABSENT_NATS],
+      PROVISIONED,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("nats-server restart target");
+    expect(res.stdout).toContain("/LA/nats.plist");
+    expect(res.stdout).toContain("cortex daemon restart target");
+    expect(res.stdout).toContain("/LA/cortex.plist");
+  });
+});
+
+describe("cortex network make-live — BLOCK 1 per-stack nats-config derivation", () => {
+  test("derives natsConfigPath from stack.nats_infra.config_path (no --nats-config flag)", async () => {
+    const { factory, calls } = fakeFactory();
+    const res = await run(
+      // NOTE: no --nats-config — must come from config, not a shared default.
+      ["make-live", "community", "--config", "/x/community.yaml", "--apply"],
+      PROVISIONED_WITH_CONFIGPATH,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    // The plan/transcript names the stack's OWN config_path, never local.conf.
+    expect(res.stdout).toContain(ABSENT_COMMUNITY_NATS);
+    expect(res.stdout).not.toContain("local.conf");
+    expect(calls).toContain("export:ANDREAS_COMMUNITY_AGENTS");
+  });
+
+  test("fail-fast (usage error) when neither --nats-config nor stack.nats_infra.config_path is set", async () => {
+    const { factory, calls } = fakeFactory();
+    // PROVISIONED has nats_infra.agents_account but NO config_path, and no flag.
+    const res = await run(
+      ["make-live", "work", "--config", "/x/work.yaml", "--apply"],
+      PROVISIONED,
+      factory,
+    );
+    expect(res.exitCode).toBe(2); // usage error
+    expect(res.stderr).toContain("config_path");
+    expect(res.stderr).toContain("local.conf"); // names the trap it refuses to default to
+    expect(calls).toEqual([]); // nothing minted/restarted
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
@@ -1,0 +1,144 @@
+/**
+ * C-1257 — CLI tests for `cortex network make-live <stack>`. The config reader +
+ * make-live ports are both injected; the read-only state probes are made
+ * deterministic by pointing --nats-config / --creds at nonexistent paths (absent
+ * ⇒ "needs migration"), so no real disk / arc / launchctl is touched.
+ */
+import { describe, test, expect } from "bun:test";
+
+import { dispatchNetwork, type MakeLivePortsFactory } from "../network";
+import type { ConfigReader } from "../network-derive";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+import type { MakeLivePorts } from "../network-make-live-lib";
+
+const AGENTS_PUB = "A" + "R".repeat(55);
+const AGENTS_JWT = "eyJ0eXAiOiJKV1QifQ.eyJzdWIiOiJBQVJSIn0.sig";
+
+function loaded(partial: Partial<LoadedConfig>): LoadedConfig {
+  return { config: {} as AgentConfig, inlineAgents: [], ...partial };
+}
+function reader(cfg: LoadedConfig): ConfigReader {
+  return () => cfg;
+}
+
+const ABSENT_NATS = "/nonexistent-makelive-test/local.conf";
+const ABSENT_CREDS = "/nonexistent-makelive-test/cortex-work.creds";
+
+/** A fully-provisioned local stack (nats_infra.agents_account set). */
+const PROVISIONED = loaded({
+  principal: { id: "andreas" },
+  config: { nats: { name: "cortex-work", credsPath: ABSENT_CREDS } } as unknown as AgentConfig,
+  stack: {
+    id: "andreas/work",
+    nkey_seed_path: "~/.config/nats/cortex-work.nk",
+    nats_infra: {
+      account: "A" + "B".repeat(55),
+      agents_account: AGENTS_PUB,
+      creds_path: "~/.config/nats/work.creds",
+    },
+  },
+});
+
+/** An un-provisioned stack (no nats_infra account tree). */
+const UNPROVISIONED = loaded({
+  principal: { id: "andreas" },
+  config: { nats: { name: "cortex-work", credsPath: ABSENT_CREDS } } as unknown as AgentConfig,
+  stack: { id: "andreas/work", nkey_seed_path: "~/.config/nats/cortex-work.nk" },
+});
+
+function fakeFactory(): { factory: MakeLivePortsFactory; calls: string[]; mutates: boolean[] } {
+  const calls: string[] = [];
+  const mutates: boolean[] = [];
+  const factory: MakeLivePortsFactory = (mutate) => {
+    mutates.push(mutate);
+    const ports: MakeLivePorts = {
+      creds: {
+        mint: async ({ account, credsPath }) => {
+          calls.push(`mint:${account}`);
+          return { ok: true, credsPath, userPubkey: "U" + "Z".repeat(55) };
+        },
+      },
+      accountExport: {
+        exportAccount: async (account) => {
+          calls.push(`export:${account}`);
+          return { ok: true, pubKey: AGENTS_PUB, jwt: AGENTS_JWT, seedPath: null };
+        },
+      },
+      resolver: {
+        hasAccount: () => false,
+        appendAccount: () => { calls.push("resolver-append"); return { ok: true, changed: true }; },
+      },
+      restart: {
+        restartNats: async () => { calls.push("restart-nats"); return { ok: true }; },
+        restartDaemon: async () => { calls.push("restart-daemon"); return { ok: true }; },
+      },
+    };
+    return ports;
+  };
+  return { factory, calls, mutates };
+}
+
+function run(argv: string[], cfg: LoadedConfig, factory: MakeLivePortsFactory) {
+  return dispatchNetwork(argv, reader(cfg), undefined, undefined, undefined, factory);
+}
+
+describe("cortex network make-live — dry-run (default)", () => {
+  test("prints the plan, mutates nothing", async () => {
+    const { factory, calls, mutates } = fakeFactory();
+    const res = await run(
+      ["make-live", "work", "--config", "/x/work.yaml", "--nats-config", ABSENT_NATS],
+      PROVISIONED,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("dry-run");
+    expect(res.stdout).toContain("ANDREAS_WORK_AGENTS");
+    expect(res.stdout).toContain("resolver_preload");
+    expect(calls).toEqual([]); // dry-run: no effects
+    expect(mutates).toEqual([false]); // ports built with mutate=false
+  });
+});
+
+describe("cortex network make-live — apply", () => {
+  test("runs export → resolver → nats restart → creds → daemon restart in order", async () => {
+    const { factory, calls, mutates } = fakeFactory();
+    const res = await run(
+      ["make-live", "work", "--config", "/x/work.yaml", "--nats-config", ABSENT_NATS, "--apply"],
+      PROVISIONED,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(calls).toEqual([
+      "export:ANDREAS_WORK_AGENTS",
+      "resolver-append",
+      "restart-nats",
+      "mint:ANDREAS_WORK_AGENTS",
+      "restart-daemon",
+    ]);
+    expect(mutates).toEqual([true]);
+  });
+
+  test("un-provisioned stack is a usage error naming provision", async () => {
+    const { factory, calls } = fakeFactory();
+    const res = await run(
+      ["make-live", "work", "--config", "/x/work.yaml", "--nats-config", ABSENT_NATS, "--apply"],
+      UNPROVISIONED,
+      factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("provision");
+    expect(calls).toEqual([]);
+  });
+
+  test("--apply + --dry-run is a usage error", async () => {
+    const { factory } = fakeFactory();
+    const res = await run(
+      ["make-live", "work", "--config", "/x/work.yaml", "--apply", "--dry-run"],
+      PROVISIONED,
+      factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("mutually exclusive");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -46,6 +46,15 @@ function makeInputs(state: MakeLiveState, over?: Partial<MakeLiveInputs>): MakeL
 /** Spy ports recording every effectful call in order. */
 function makePorts(over?: {
   resolverHas?: boolean;
+  /** M3 — resolver_preload block present (operator-mode bus). Default true. */
+  hasResolverPreload?: boolean;
+  /** Whether the append actually mutates (changed). Default true. */
+  appendChanged?: boolean;
+  /** BLOCK 3 — pubkey the export port returns (default the matching AGENTS_PUB). */
+  exportPubKey?: string;
+  /** BLOCK 2 — descriptors resolveTargets returns. */
+  natsDescriptor?: string | undefined;
+  daemonDescriptor?: string | undefined;
   exportFails?: boolean;
   mintFails?: boolean;
 }): { ports: MakeLivePorts; calls: string[] } {
@@ -62,17 +71,22 @@ function makePorts(over?: {
       exportAccount: async (account) => {
         calls.push(`export:${account}`);
         if (over?.exportFails) return { ok: false, reason: "export boom" };
-        return { ok: true, pubKey: AGENTS_PUB, jwt: AGENTS_JWT, seedPath: null };
+        return { ok: true, pubKey: over?.exportPubKey ?? AGENTS_PUB, jwt: AGENTS_JWT, seedPath: null };
       },
     },
     resolver: {
       hasAccount: () => over?.resolverHas ?? false,
+      hasResolverPreload: () => over?.hasResolverPreload ?? true,
       appendAccount: ({ accountPubkey }) => {
         calls.push(`resolver-append:${accountPubkey}`);
-        return { ok: true, changed: true };
+        return { ok: true, changed: over?.appendChanged ?? true };
       },
     },
     restart: {
+      resolveTargets: () => ({
+        natsDescriptor: "natsDescriptor" in (over ?? {}) ? over?.natsDescriptor : "/LA/nats.plist",
+        daemonDescriptor: "daemonDescriptor" in (over ?? {}) ? over?.daemonDescriptor : "/LA/cortex.plist",
+      }),
       restartNats: async () => {
         calls.push("restart-nats");
         return { ok: true };
@@ -166,6 +180,79 @@ describe("makeLiveStack — apply", () => {
     expect(res.ok).toBe(true);
     expect(res.applied).toBe(false);
     expect(calls).toEqual([]);
+  });
+
+  // M3 — operator-mode guard ──────────────────────────────────────────────────
+  test("M3: refuses a bus with no resolver_preload block (halden pattern)", async () => {
+    const { ports, calls } = makePorts({ hasResolverPreload: false });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: false, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.applied).toBe(false);
+    expect(res.reason).toContain("not");
+    expect(res.reason).toContain("operator-mode");
+    expect(res.reason).toContain("resolver_preload");
+    expect(calls).toEqual([]); // nothing minted/restarted
+  });
+
+  test("M3: refuses even in dry-run (preview catches the category error)", async () => {
+    const { ports, calls } = makePorts({ hasResolverPreload: false });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: false, resolverHasAccount: false }, { apply: false }),
+      ports,
+    );
+    expect(res.ok).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  // BLOCK 3 — pubkey drift cross-check ─────────────────────────────────────────
+  test("BLOCK 3: export-account pubkey ≠ config pubkey aborts before resolver write", async () => {
+    const driftKey = "A" + "Q".repeat(55);
+    const { ports, calls } = makePorts({ exportPubKey: driftKey });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("pubkey drift");
+    expect(res.reason).toContain(driftKey);
+    // exported, then aborted — NO resolver append, NO restart, NO mint.
+    expect(calls).toEqual([`export:ANDREAS_WORK_AGENTS`]);
+  });
+
+  // M2 — --force must not no-op-restart a shared nats-server ────────────────────
+  test("M2: --force with the account already present re-mints but does NOT restart nats", async () => {
+    // resolver already has the account ⇒ append no-ops (changed:false); --force
+    // still re-mints creds + restarts the daemon, but the shared nats-server must
+    // NOT be hard-restarted for a no-op resolver.
+    const { ports, calls } = makePorts({ resolverHas: true, appendChanged: false });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: true, resolverHasAccount: true }, { force: true }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(calls).toContain(`export:ANDREAS_WORK_AGENTS`);
+    expect(calls).toContain(`resolver-append:${AGENTS_PUB}`);
+    expect(calls).not.toContain("restart-nats"); // ← the M2 guarantee
+    expect(calls).toContain(`mint:cortex-work@ANDREAS_WORK_AGENTS->~/.config/nats/cortex-work.creds`);
+    expect(calls).toContain("restart-daemon");
+  });
+
+  // BLOCK 2 — dry-run resolves + prints the restart targets ─────────────────────
+  test("BLOCK 2: dry-run prints the resolved nats-server + daemon restart targets", async () => {
+    const { ports } = makePorts({ natsDescriptor: "/LA/homebrew.nats.plist", daemonDescriptor: "/LA/cortex.work.plist" });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: false, resolverHasAccount: false }, { apply: false }), ports);
+    expect(res.ok).toBe(true);
+    const txt = res.steps.join("\n");
+    expect(txt).toContain("nats-server restart target");
+    expect(txt).toContain("/LA/homebrew.nats.plist");
+    expect(txt).toContain("cortex daemon restart target");
+    expect(txt).toContain("/LA/cortex.work.plist");
+  });
+
+  test("BLOCK 2: dry-run warns when a NEEDED restart has no discoverable service", async () => {
+    const { ports } = makePorts({ natsDescriptor: undefined });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: false, resolverHasAccount: false }, { apply: false }), ports);
+    expect(res.ok).toBe(true);
+    const txt = res.steps.join("\n");
+    expect(txt).toContain("WARNING");
+    expect(txt).toContain("NOT FOUND");
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -1,0 +1,252 @@
+/**
+ * C-1257 — tests for the pure make-live orchestration behind
+ * `cortex network make-live <stack>` (the daemon-switch). All arc/fs/launchctl
+ * effects are injected ports recording their calls — no real arc/nsc/fs/services.
+ *
+ * The anti-rot guard (sibling of the #255 provision-integration guard): asserts
+ * the daemon-switch contract end-to-end against a faithful fake — creds minted
+ * under the agents account, the agents JWT appended to resolver_preload exactly
+ * once, both services restarted ONLY when state changed (and in the right order:
+ * nats BEFORE the daemon), idempotent re-runs, and that the orchestrator never
+ * touches the stack config (so encryption / federated config survives).
+ */
+import { describe, test, expect } from "bun:test";
+
+import {
+  makeLiveStack,
+  planMakeLive,
+  type MakeLiveInputs,
+  type MakeLivePorts,
+  type MakeLiveState,
+} from "../network-make-live-lib";
+import { insertIntoResolverPreload, findNatsServerDescriptor } from "../network-make-live-adapters";
+import type { DaemonLocatorIO } from "../daemon-locator";
+
+const AGENTS_PUB = "A" + "R".repeat(55);
+const AGENTS_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBQVJSIn0.sig";
+
+function makeInputs(state: MakeLiveState, over?: Partial<MakeLiveInputs>): MakeLiveInputs {
+  return {
+    principal: "andreas",
+    stackSlug: "work",
+    stackId: "andreas/work",
+    agentsAccountName: "ANDREAS_WORK_AGENTS",
+    agentsAccountPubkey: AGENTS_PUB,
+    botName: "cortex-work",
+    credsPath: "~/.config/nats/cortex-work.creds",
+    cortexConfigPath: "/Users/x/.config/cortex/work/work.yaml",
+    natsConfigPath: "~/.config/nats/local.conf",
+    force: false,
+    apply: true,
+    state,
+    ...over,
+  };
+}
+
+/** Spy ports recording every effectful call in order. */
+function makePorts(over?: {
+  resolverHas?: boolean;
+  exportFails?: boolean;
+  mintFails?: boolean;
+}): { ports: MakeLivePorts; calls: string[] } {
+  const calls: string[] = [];
+  const ports: MakeLivePorts = {
+    creds: {
+      mint: async ({ botName, account, credsPath }) => {
+        calls.push(`mint:${botName}@${account}->${credsPath}`);
+        if (over?.mintFails) return { ok: false, reason: "add-bot boom" };
+        return { ok: true, credsPath, userPubkey: "U" + "Z".repeat(55) };
+      },
+    },
+    accountExport: {
+      exportAccount: async (account) => {
+        calls.push(`export:${account}`);
+        if (over?.exportFails) return { ok: false, reason: "export boom" };
+        return { ok: true, pubKey: AGENTS_PUB, jwt: AGENTS_JWT, seedPath: null };
+      },
+    },
+    resolver: {
+      hasAccount: () => over?.resolverHas ?? false,
+      appendAccount: ({ accountPubkey }) => {
+        calls.push(`resolver-append:${accountPubkey}`);
+        return { ok: true, changed: true };
+      },
+    },
+    restart: {
+      restartNats: async () => {
+        calls.push("restart-nats");
+        return { ok: true };
+      },
+      restartDaemon: async () => {
+        calls.push("restart-daemon");
+        return { ok: true };
+      },
+    },
+  };
+  return { ports, calls };
+}
+
+// ── plan ──────────────────────────────────────────────────────────────────────
+
+describe("planMakeLive", () => {
+  test("first migration (resolver absent) needs every step", () => {
+    const p = planMakeLive(makeInputs({ credsFileExists: true, resolverHasAccount: false }));
+    expect(p.resolverNeeded).toBe(true);
+    expect(p.credsNeeded).toBe(true); // re-mint even though a (stale) creds file exists
+    expect(p.natsRestartNeeded).toBe(true);
+    expect(p.daemonRestartNeeded).toBe(true);
+  });
+
+  test("converged (resolver present + creds file present) needs nothing", () => {
+    const p = planMakeLive(makeInputs({ credsFileExists: true, resolverHasAccount: true }));
+    expect(p.resolverNeeded).toBe(false);
+    expect(p.credsNeeded).toBe(false);
+    expect(p.natsRestartNeeded).toBe(false);
+    expect(p.daemonRestartNeeded).toBe(false);
+  });
+
+  test("--force re-mints everything even when converged", () => {
+    const p = planMakeLive(makeInputs({ credsFileExists: true, resolverHasAccount: true }, { force: true }));
+    expect(p.resolverNeeded).toBe(true);
+    expect(p.credsNeeded).toBe(true);
+  });
+});
+
+// ── apply: ordering + completeness (the anti-rot guard) ─────────────────────────
+
+describe("makeLiveStack — apply", () => {
+  test("first migration: resolver → nats restart → creds → daemon restart, in order", async () => {
+    const { ports, calls } = makePorts();
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(true);
+    // The exact execution order — nats-server BEFORE the daemon so the creds
+    // never name an account the running server hasn't loaded yet.
+    expect(calls).toEqual([
+      `export:ANDREAS_WORK_AGENTS`,
+      `resolver-append:${AGENTS_PUB}`,
+      "restart-nats",
+      `mint:cortex-work@ANDREAS_WORK_AGENTS->~/.config/nats/cortex-work.creds`,
+      "restart-daemon",
+    ]);
+  });
+
+  test("idempotent: converged re-run mints nothing and restarts nothing", async () => {
+    const { ports, calls } = makePorts({ resolverHas: true });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: true }), ports);
+
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([]); // zero effects
+    expect(res.steps.join("\n")).toContain("Already live");
+  });
+
+  test("guard: missing agents_account fails fast (run provision first)", async () => {
+    const { ports, calls } = makePorts();
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: false, resolverHasAccount: false }, { agentsAccountPubkey: "" }),
+      ports,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("provision");
+    expect(calls).toEqual([]); // nothing mutated
+  });
+
+  test("export failure aborts BEFORE any creds mint or restart", async () => {
+    const { ports, calls } = makePorts({ exportFails: true });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("export-account");
+    expect(calls).toEqual([`export:ANDREAS_WORK_AGENTS`]); // no mint, no restart
+  });
+
+  test("dry-run mutates nothing", async () => {
+    const { ports, calls } = makePorts();
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }, { apply: false }), ports);
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(false);
+    expect(calls).toEqual([]);
+  });
+});
+
+// ── resolver_preload insertion (multi-stack safety) ─────────────────────────────
+
+describe("insertIntoResolverPreload", () => {
+  const CONF = [
+    "resolver: MEMORY",
+    "",
+    "resolver_preload: {",
+    "  // Account \"ANDREAS_AGENTS\"",
+    "  AOLD: eyJold",
+    "  // Account \"SYS\"",
+    "  ASYS: eyJsys",
+    "}",
+    "",
+    "http: \"127.0.0.1:8222\"",
+  ].join("\n");
+
+  test("inserts before the closing brace, preserving existing accounts", () => {
+    const out = insertIntoResolverPreload(CONF, "  // Account \"NEW\"\n  ANEW: eyJnew\n");
+    expect(out).not.toBeNull();
+    // existing accounts untouched
+    expect(out).toContain("AOLD: eyJold");
+    expect(out).toContain("ASYS: eyJsys");
+    // new account landed INSIDE the block (before the closing brace, before http)
+    const idxNew = out!.indexOf("ANEW: eyJnew");
+    const idxClose = out!.indexOf("\n}");
+    const idxHttp = out!.indexOf("http:");
+    expect(idxNew).toBeGreaterThan(0);
+    expect(idxNew).toBeLessThan(idxClose);
+    expect(idxClose).toBeLessThan(idxHttp);
+  });
+
+  test("returns null when there is no resolver_preload block", () => {
+    expect(insertIntoResolverPreload("listen: 127.0.0.1:4222\n", "x")).toBeNull();
+  });
+});
+
+// ── nats-server descriptor discovery (restart the RIGHT server) ─────────────────
+
+describe("findNatsServerDescriptor", () => {
+  const plist = (program: string, configArg: string) =>
+    `<plist><dict><key>ProgramArguments</key><array>` +
+    `<string>${program}</string><string>-js</string><string>-c</string><string>${configArg}</string>` +
+    `</array></dict></plist>`;
+
+  function io(files: Record<string, string>): DaemonLocatorIO {
+    return {
+      listDir: (dir) => Object.keys(files).filter((f) => f.startsWith(dir)).map((f) => f.slice(dir.length + 1)),
+      readFile: (p) => files[p] ?? (() => { throw new Error("ENOENT"); })(),
+      exists: (p) => p in files || Object.keys(files).some((f) => f.startsWith(p)),
+    };
+  }
+
+  test("matches the plist running nats-server -c <natsConfig>", () => {
+    const dir = "/la";
+    const files = {
+      [`${dir}/homebrew.mxcl.nats-server.plist`]: plist("/opt/homebrew/opt/nats-server/bin/nats-server", "/home/x/.config/nats/local.conf"),
+      [`${dir}/ai.meta-factory.cortex.work.plist`]: plist("bun", "/home/x/.config/cortex/work/work.yaml"),
+    };
+    const found = findNatsServerDescriptor({
+      platform: "darwin",
+      natsConfigPath: "/home/x/.config/nats/local.conf",
+      launchAgentsDir: dir,
+      systemdUserDir: "/sd",
+      io: io(files),
+    });
+    expect(found).toBe(`${dir}/homebrew.mxcl.nats-server.plist`);
+  });
+
+  test("returns undefined when no nats-server plist references the config", () => {
+    const dir = "/la";
+    const files = { [`${dir}/other.plist`]: plist("/usr/bin/redis", "/etc/redis.conf") };
+    const found = findNatsServerDescriptor({
+      platform: "darwin",
+      natsConfigPath: "/home/x/.config/nats/local.conf",
+      launchAgentsDir: dir,
+      systemdUserDir: "/sd",
+      io: io(files),
+    });
+    expect(found).toBeUndefined();
+  });
+});

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -1,0 +1,338 @@
+/**
+ * C-1257 — the LIVE adapters for `cortex network make-live`.
+ *
+ * These touch the real world: arc (`add-bot` / `export-account`), the nats config
+ * (`resolver_preload`), the creds file, and the launchd/systemd services. The
+ * orchestration is pure over the injected ports (`network-make-live-lib.ts`);
+ * these adapters are constructed only on a real `--apply` (the dry-run path uses
+ * read-only state probes built in the CLI). cortex NEVER runs nsc — the account
+ * tree + JWT come from arc (ADR-0013 Model B invariant).
+ */
+
+import { existsSync, readFileSync, writeFileSync, copyFileSync, chmodSync, readdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import { expandTilde } from "../../../common/config/loader";
+import {
+  selectNatsServiceManager,
+  currentServicePlatform,
+  bunExecRunner,
+  type ServicePlatform,
+} from "../../../common/nats/nats-service-manager";
+import {
+  findCortexDaemonDescriptor,
+  parsePlistProgramArguments,
+  parseUnitExecStartArgs,
+  configArgValue,
+  type DaemonLocatorIO,
+} from "./daemon-locator";
+import type {
+  CredsMintPort,
+  AccountExportPort,
+  ResolverPreloadPort,
+  ServiceRestartPort,
+  MakeLivePorts,
+} from "./network-make-live-lib";
+
+// =============================================================================
+// Arc subprocess driver (injectable for tests — mirrors operator-provisioning.ts)
+// =============================================================================
+
+export interface ArcRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+export type ArcRunner = (argv: readonly string[]) => Promise<ArcRunResult>;
+
+async function defaultArcRunner(argv: readonly string[]): Promise<ArcRunResult> {
+  const proc = Bun.spawn(["arc", ...argv], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+/** Parse the first non-blank JSON line from arc stdout. */
+function firstJsonLine(result: ArcRunResult): { ok: true; value: unknown } | { ok: false; reason: string } {
+  const line = result.stdout.split("\n").find((l) => l.trim().length > 0) ?? "";
+  if (line.length === 0) {
+    return { ok: false, reason: `arc returned no output. stderr: ${result.stderr.trim() || "(empty)"}` };
+  }
+  try {
+    return { ok: true, value: JSON.parse(line) };
+  } catch {
+    return { ok: false, reason: `arc returned non-JSON output: ${line.slice(0, 200)}` };
+  }
+}
+
+function arcEnvelopeError(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const v = value as { ok?: unknown; error?: { code?: unknown; message?: unknown } };
+  if (v.ok === false) {
+    const code = typeof v.error?.code === "string" ? v.error.code : "(unknown code)";
+    const message = typeof v.error?.message === "string" ? v.error.message : "(no message)";
+    return `${code}: ${message}`;
+  }
+  return undefined;
+}
+
+// =============================================================================
+// Creds-mint adapter — composes `arc nats add-bot`
+// =============================================================================
+
+/**
+ * Live {@link CredsMintPort}. Backs up any existing creds to
+ * `<credsPath>.bak-makelive` (the documented rollback artefact) BEFORE the mint,
+ * then shells `arc nats add-bot <bot> --account <agents> --output <creds>
+ * --force`. The creds land `chmod 600` (arc's `writeCredsFile`).
+ */
+export function buildCredsMintAdapter(runner: ArcRunner = defaultArcRunner): CredsMintPort {
+  return {
+    mint: async ({ botName, account, credsPath, force }) => {
+      const abs = expandTilde(credsPath);
+      // Back up the existing (old-account) creds before overwriting — the
+      // rollback artefact. chmod 600 so the backup is no more readable than the
+      // live creds it copies (#130 leaked-backup discipline).
+      if (existsSync(abs)) {
+        try {
+          const bak = `${abs}.bak-makelive`;
+          copyFileSync(abs, bak);
+          chmodSync(bak, 0o600);
+        } catch (err) {
+          return { ok: false, reason: `failed to back up existing creds at ${abs}: ${err instanceof Error ? err.message : String(err)}` };
+        }
+      }
+      // make-live always overwrites the daemon's connection creds (the prior
+      // creds were just backed up); `force` is accepted on the port for symmetry
+      // with the orchestrator's force flag but does not change add-bot here.
+      void force;
+      const argv = [
+        "nats", "add-bot", botName,
+        "--account", account,
+        "--output", abs,
+        "--force",
+        "--json",
+      ];
+      let result: ArcRunResult;
+      try {
+        result = await runner(argv);
+      } catch (err) {
+        return { ok: false, reason: `failed to invoke 'arc nats add-bot': ${err instanceof Error ? err.message : String(err)}` };
+      }
+      const parsed = firstJsonLine(result);
+      if (!parsed.ok) return { ok: false, reason: parsed.reason };
+      const envErr = arcEnvelopeError(parsed.value);
+      if (envErr !== undefined) return { ok: false, reason: `arc nats add-bot failed: ${envErr}` };
+      const v = parsed.value as { credsPath?: string; pubKey?: string };
+      return { ok: true, credsPath: v.credsPath ?? abs, userPubkey: v.pubKey ?? "" };
+    },
+  };
+}
+
+// =============================================================================
+// Account-export adapter — composes `arc nats export-account`
+// =============================================================================
+
+/** Live {@link AccountExportPort}. Shells `arc nats export-account <name> --json`. */
+export function buildAccountExportAdapter(runner: ArcRunner = defaultArcRunner): AccountExportPort {
+  return {
+    exportAccount: async (account) => {
+      let result: ArcRunResult;
+      try {
+        result = await runner(["nats", "export-account", account, "--json"]);
+      } catch (err) {
+        return { ok: false, reason: `failed to invoke 'arc nats export-account': ${err instanceof Error ? err.message : String(err)}` };
+      }
+      const parsed = firstJsonLine(result);
+      if (!parsed.ok) return { ok: false, reason: parsed.reason };
+      const envErr = arcEnvelopeError(parsed.value);
+      if (envErr !== undefined) return { ok: false, reason: `arc nats export-account failed: ${envErr}` };
+      const v = parsed.value as { pubKey?: string; jwt?: string; seedPath?: string | null };
+      if (typeof v.jwt !== "string" || !v.jwt.startsWith("eyJ") || typeof v.pubKey !== "string") {
+        return { ok: false, reason: `arc nats export-account returned no valid account JWT for ${account}` };
+      }
+      return { ok: true, pubKey: v.pubKey, jwt: v.jwt, seedPath: v.seedPath ?? null };
+    },
+  };
+}
+
+// =============================================================================
+// resolver_preload adapter — append an account block to the nats config
+// =============================================================================
+
+/**
+ * Insert `insertion` immediately before the closing brace of the
+ * `resolver_preload { … }` block in `text`. Uses a brace-matched scan so a
+ * nested object inside the block can't confuse the close detection. Returns the
+ * new text, or null when no resolver_preload block is found.
+ */
+export function insertIntoResolverPreload(text: string, insertion: string): string | null {
+  const key = /resolver_preload\s*[:=]?\s*\{/.exec(text);
+  if (key === null) return null;
+  const open = key.index + key[0].length - 1; // index of the `{`
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        // Insert before this closing brace (which sits at column 0 of its line).
+        const lineStart = text.lastIndexOf("\n", i) + 1;
+        return text.slice(0, lineStart) + insertion + text.slice(lineStart);
+      }
+    }
+  }
+  return null; // unbalanced braces — refuse to edit
+}
+
+/** Live {@link ResolverPreloadPort}. Edits the nats config on disk in place. */
+export function buildResolverPreloadAdapter(): ResolverPreloadPort {
+  return {
+    hasAccount: (natsConfigPath, accountPubkey) => {
+      const abs = expandTilde(natsConfigPath);
+      if (!existsSync(abs)) return false;
+      return readFileSync(abs, "utf-8").includes(accountPubkey);
+    },
+    appendAccount: ({ natsConfigPath, accountName, accountPubkey, accountJwt }) => {
+      try {
+        const abs = expandTilde(natsConfigPath);
+        if (!existsSync(abs)) return { ok: false, reason: `nats config not found at ${abs}` };
+        const text = readFileSync(abs, "utf-8");
+        if (text.includes(accountPubkey)) return { ok: true, changed: false }; // idempotent
+        const insertion = `  // Account "${accountName}" (cortex make-live)\n  ${accountPubkey}: ${accountJwt}\n`;
+        const next = insertIntoResolverPreload(text, insertion);
+        if (next === null) {
+          return { ok: false, reason: `could not locate a resolver_preload { … } block in ${abs}` };
+        }
+        // Back up before the in-place edit (timestamped — the rollback artefact).
+        copyFileSync(abs, `${abs}.bak-makelive-${Date.now().toString()}`);
+        writeFileSync(abs, next, "utf-8");
+        return { ok: true, changed: true };
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}
+
+// =============================================================================
+// Service-restart adapter — nats-server + cortex daemon
+// =============================================================================
+
+const LAUNCH_AGENTS_DIR = join(homedir(), "Library", "LaunchAgents");
+const SYSTEMD_USER_DIR = join(homedir(), ".config", "systemd", "user");
+
+const realLocatorIO: DaemonLocatorIO = {
+  listDir: (dir) => {
+    try {
+      return readdirSync(dir);
+    } catch {
+      return [];
+    }
+  },
+  readFile: (path) => readFileSync(path, "utf-8"),
+  exists: (path) => existsSync(path),
+};
+
+/**
+ * Find the launchd plist / systemd unit running `nats-server -c <natsConfigPath>`.
+ * Sibling of {@link findCortexDaemonDescriptor}: matches by the program looking
+ * like a nats-server AND the `-c`/`--config` arg pointing at the same nats config
+ * (so a multi-nats-server host restarts the RIGHT one — never guesses a label).
+ */
+export function findNatsServerDescriptor(opts: {
+  platform: ServicePlatform;
+  natsConfigPath: string;
+  launchAgentsDir: string;
+  systemdUserDir: string;
+  io: DaemonLocatorIO;
+}): string | undefined {
+  const { platform, natsConfigPath, io } = opts;
+  const target = expandTilde(natsConfigPath);
+  const matches = (args: string[]): boolean => {
+    const prog = (args[0] ?? "").toLowerCase();
+    if (!prog.includes("nats-server")) return false;
+    const cfg = configArgValue(args);
+    return cfg !== undefined && expandTilde(cfg) === target;
+  };
+  const dir = platform === "darwin" ? opts.launchAgentsDir : opts.systemdUserDir;
+  const namePattern = platform === "darwin" ? /\.plist$/ : /\.service$/;
+  if (!io.exists(dir)) return undefined;
+  for (const name of io.listDir(dir)) {
+    if (!namePattern.test(name)) continue;
+    const path = join(dir, name);
+    let text: string;
+    try {
+      text = io.readFile(path);
+    } catch {
+      continue;
+    }
+    const args = platform === "darwin" ? parsePlistProgramArguments(text) : parseUnitExecStartArgs(text);
+    if (matches(args)) return path;
+  }
+  return undefined;
+}
+
+/** Live {@link ServiceRestartPort}. Discovers descriptors, restarts via launchd/systemd. */
+export function buildServiceRestartAdapter(mutate: boolean): ServiceRestartPort {
+  const platform = currentServicePlatform();
+  return {
+    restartNats: async (natsConfigPath) => {
+      const descriptor = findNatsServerDescriptor({
+        platform,
+        natsConfigPath,
+        launchAgentsDir: LAUNCH_AGENTS_DIR,
+        systemdUserDir: SYSTEMD_USER_DIR,
+        io: realLocatorIO,
+      });
+      if (descriptor === undefined) {
+        return {
+          ok: false,
+          reason:
+            `could not find the launchd/systemd service running nats-server -c ${natsConfigPath}. ` +
+            `Restart the nats-server manually (its MEMORY resolver must reload to pick up the new account).`,
+        };
+      }
+      const mgr = selectNatsServiceManager({ platform, descriptorPath: descriptor, mutate, exec: bunExecRunner });
+      return mgr.restart();
+    },
+    restartDaemon: async (cortexConfigPath) => {
+      const descriptor = findCortexDaemonDescriptor({
+        platform,
+        cortexConfigPath,
+        launchAgentsDir: LAUNCH_AGENTS_DIR,
+        systemdUserDir: SYSTEMD_USER_DIR,
+        io: realLocatorIO,
+      });
+      if (descriptor === undefined) {
+        return {
+          ok: false,
+          reason:
+            `could not find the cortex daemon service loading ${cortexConfigPath}. ` +
+            `Restart the daemon manually so it reconnects with the new creds.`,
+        };
+      }
+      const mgr = selectNatsServiceManager({ platform, descriptorPath: descriptor, mutate, exec: bunExecRunner });
+      return mgr.restart();
+    },
+  };
+}
+
+// =============================================================================
+// Full live port bundle
+// =============================================================================
+
+/** Build the live {@link MakeLivePorts} bundle for a real `--apply` run. */
+export function buildLiveMakeLivePorts(mutate: boolean): MakeLivePorts {
+  return {
+    creds: buildCredsMintAdapter(),
+    accountExport: buildAccountExportAdapter(),
+    resolver: buildResolverPreloadAdapter(),
+    restart: buildServiceRestartAdapter(mutate),
+  };
+}

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -86,8 +86,8 @@ function arcEnvelopeError(value: unknown): string | undefined {
 
 /**
  * Live {@link CredsMintPort}. Backs up any existing creds to
- * `<credsPath>.bak-makelive` (the documented rollback artefact) BEFORE the mint,
- * then shells `arc nats add-bot <bot> --account <agents> --output <creds>
+ * `<credsPath>.bak-makelive-<ts>` (the documented rollback artefact) BEFORE the
+ * mint, then shells `arc nats add-bot <bot> --account <agents> --output <creds>
  * --force`. The creds land `chmod 600` (arc's `writeCredsFile`).
  */
 export function buildCredsMintAdapter(runner: ArcRunner = defaultArcRunner): CredsMintPort {
@@ -97,9 +97,13 @@ export function buildCredsMintAdapter(runner: ArcRunner = defaultArcRunner): Cre
       // Back up the existing (old-account) creds before overwriting — the
       // rollback artefact. chmod 600 so the backup is no more readable than the
       // live creds it copies (#130 leaked-backup discipline).
+      // M1 — TIMESTAMPED filename (mirrors the resolver backup below): a second
+      // `--apply`/`--force` must not clobber the FIRST migration's backup, which
+      // holds the original shared-account creds the rollback (§3.4) restores. A
+      // fixed `.bak-makelive` would copy the NEW agents creds over the original.
       if (existsSync(abs)) {
         try {
-          const bak = `${abs}.bak-makelive`;
+          const bak = `${abs}.bak-makelive-${Date.now().toString()}`;
           copyFileSync(abs, bak);
           chmodSync(bak, 0o600);
         } catch (err) {
@@ -198,6 +202,13 @@ export function buildResolverPreloadAdapter(): ResolverPreloadPort {
       if (!existsSync(abs)) return false;
       return readFileSync(abs, "utf-8").includes(accountPubkey);
     },
+    // M3 — operator-mode probe: does the config carry a resolver_preload block?
+    // Same brace-anchored pattern insertIntoResolverPreload uses to find the block.
+    hasResolverPreload: (natsConfigPath) => {
+      const abs = expandTilde(natsConfigPath);
+      if (!existsSync(abs)) return false;
+      return /resolver_preload\s*[:=]?\s*\{/.test(readFileSync(abs, "utf-8"));
+    },
     appendAccount: ({ natsConfigPath, accountName, accountPubkey, accountJwt }) => {
       try {
         const abs = expandTilde(natsConfigPath);
@@ -282,6 +293,29 @@ export function findNatsServerDescriptor(opts: {
 export function buildServiceRestartAdapter(mutate: boolean): ServiceRestartPort {
   const platform = currentServicePlatform();
   return {
+    // BLOCK 2 — read-only descriptor resolution for the dry-run preview. Reuses
+    // the SAME finders the restarts use, so the previewed target is exactly the
+    // one --apply would kickstart. Never mutates.
+    resolveTargets: ({ natsConfigPath, cortexConfigPath }) => {
+      const natsDescriptor = findNatsServerDescriptor({
+        platform,
+        natsConfigPath,
+        launchAgentsDir: LAUNCH_AGENTS_DIR,
+        systemdUserDir: SYSTEMD_USER_DIR,
+        io: realLocatorIO,
+      });
+      const daemonDescriptor = findCortexDaemonDescriptor({
+        platform,
+        cortexConfigPath,
+        launchAgentsDir: LAUNCH_AGENTS_DIR,
+        systemdUserDir: SYSTEMD_USER_DIR,
+        io: realLocatorIO,
+      });
+      return {
+        ...(natsDescriptor !== undefined && { natsDescriptor }),
+        ...(daemonDescriptor !== undefined && { daemonDescriptor }),
+      };
+    },
     restartNats: async (natsConfigPath) => {
       const descriptor = findNatsServerDescriptor({
         platform,

--- a/src/cli/cortex/commands/network-make-live-lib.ts
+++ b/src/cli/cortex/commands/network-make-live-lib.ts
@@ -1,0 +1,330 @@
+/**
+ * C-1257 (PR7/#1225, ADR-0013 Model B) — the pure orchestration behind
+ * `cortex network make-live <stack>`: the daemon-switch step that LANDS a
+ * provisioned stack onto its own sovereign agents account.
+ *
+ * `cortex network provision` is non-disruptive — it mints the account tree
+ * (`ANDREAS_<STACK>_FED` + `ANDREAS_<STACK>_AGENTS`) and writes `stack.nats_infra`
+ * but NEVER switches the running daemon. make-live closes that gap:
+ *
+ *   1. mint the daemon's bus creds UNDER the agents account, at `nats.credsPath`
+ *      (the very file the daemon authenticates with — `connection.ts`).
+ *   2. teach the local NATS server the new account — append its JWT to
+ *      `resolver_preload` (MEMORY resolver) in the nats config (default
+ *      `~/.config/nats/local.conf`). Keyed on the account pubkey: pure addition,
+ *      never disturbs the other stacks' accounts already there (multi-stack safe).
+ *   3. restart the NATS server so the MEMORY resolver loads the new account
+ *      (a SIGHUP reload does NOT pick up resolver_preload — a hard restart is
+ *      required; verified empirically, see docs/design-make-live-daemon-switch.md).
+ *   4. restart the cortex daemon so it reconnects with the new creds under the
+ *      agents account.
+ *
+ * make-live is NETWORK-AGNOSTIC: it lands the daemon on its agents account for
+ * BOTH a local stack (no network) and a federated one (where `cortex network
+ * join` then renders the leaf on the FED account). It NEVER touches
+ * `policy.federated` / `payload_key` / any encryption block, so a federated
+ * stack's confidentiality setup survives the account swap by construction.
+ *
+ * This module is PURE over injected ports — zero fs / arc / nsc / launchctl. The
+ * live adapters live in `network-make-live-adapters.ts`. cortex NEVER runs nsc
+ * (ADR-0013 invariant): the account JWT comes from `arc nats export-account` and
+ * the creds from `arc nats add-bot`.
+ *
+ * ## Idempotency
+ *
+ * Every step is ensure-shaped, gated on cheap filesystem reads:
+ *   - resolver: append iff the agents pubkey is ABSENT (idempotent, keyed on key).
+ *   - creds: (re-)mint iff this is a first migration (resolver did not yet carry
+ *     the account) OR the creds file is missing OR `--force`. A converged re-run
+ *     (resolver already carries the account AND the creds file exists) mints
+ *     nothing and restarts nothing.
+ *   - restarts: the nats-server restarts only when the resolver changed; the
+ *     daemon restarts only when the creds changed (or the nats-server did).
+ *
+ * ## Dry-run vs apply
+ *
+ * Dry-run (the DEFAULT-safe posture) computes the plan from config + filesystem
+ * and mutates NOTHING. `--apply` executes mint → resolver → nats restart →
+ * daemon restart, fail-fast (any port failure aborts and surfaces how far it got).
+ */
+
+// =============================================================================
+// Ports
+// =============================================================================
+
+/** Mint the daemon's bus creds under the agents account (composes `arc nats add-bot`). */
+export interface CredsMintPort {
+  /**
+   * Mint a `.creds` for `botName` under `account`, written to `credsPath`
+   * (`chmod 600`), backing up any existing creds to `<credsPath>.bak-makelive`
+   * first. `force` overwrites an existing user. Returns the user's pubkey.
+   */
+  mint(opts: { botName: string; account: string; credsPath: string; force: boolean }): Promise<
+    | { ok: true; credsPath: string; userPubkey: string }
+    | { ok: false; reason: string }
+  >;
+}
+
+/** Export an account's JWT (composes `arc nats export-account`). */
+export interface AccountExportPort {
+  exportAccount(account: string): Promise<
+    | { ok: true; pubKey: string; jwt: string; seedPath: string | null }
+    | { ok: false; reason: string }
+  >;
+}
+
+/** Append an account to the nats-server `resolver_preload` (MEMORY resolver). */
+export interface ResolverPreloadPort {
+  /** Is `accountPubkey` already present in the resolver_preload of `natsConfigPath`? */
+  hasAccount(natsConfigPath: string, accountPubkey: string): boolean;
+  /**
+   * Append a labelled `<pubkey>: <jwt>` block inside resolver_preload, backing
+   * up the config first. Idempotent: no-op (`changed:false`) when present.
+   */
+  appendAccount(opts: {
+    natsConfigPath: string;
+    accountName: string;
+    accountPubkey: string;
+    accountJwt: string;
+  }): { ok: true; changed: boolean } | { ok: false; reason: string };
+}
+
+/** Restart the nats-server + the cortex daemon (composes launchctl/systemctl). */
+export interface ServiceRestartPort {
+  /** Hard-restart the nats-server bound to `natsConfigPath` (loads new resolver_preload). */
+  restartNats(natsConfigPath: string): Promise<{ ok: true } | { ok: false; reason: string }>;
+  /** Restart the cortex daemon loading `cortexConfigPath` (reconnect with new creds). */
+  restartDaemon(cortexConfigPath: string): Promise<{ ok: true } | { ok: false; reason: string }>;
+}
+
+export interface MakeLivePorts {
+  creds: CredsMintPort;
+  accountExport: AccountExportPort;
+  resolver: ResolverPreloadPort;
+  restart: ServiceRestartPort;
+}
+
+// =============================================================================
+// Inputs + state + result
+// =============================================================================
+
+/** Observable pre-make-live state (read from config + filesystem). */
+export interface MakeLiveState {
+  /** Does the daemon's connection creds file (`nats.credsPath`) exist on disk? */
+  credsFileExists: boolean;
+  /** Does the nats config's resolver_preload already carry the agents account pubkey? */
+  resolverHasAccount: boolean;
+}
+
+export interface MakeLiveInputs {
+  principal: string;
+  stackSlug: string;
+  stackId: string;
+  /** `ANDREAS_<STACK>_AGENTS` — the account name to land the daemon on. */
+  agentsAccountName: string;
+  /** `stack.nats_infra.agents_account` pubkey (provision wrote it). REQUIRED. */
+  agentsAccountPubkey: string;
+  /** `nats.name` — the bot/user name minted under the agents account. */
+  botName: string;
+  /** `nats.credsPath` — the daemon's connection creds (where new creds land). */
+  credsPath: string;
+  /** Path to the cortex config the daemon loads (for daemon-restart discovery). */
+  cortexConfigPath: string;
+  /** Path to the nats-server config carrying resolver_preload (default local.conf). */
+  natsConfigPath: string;
+  force: boolean;
+  apply: boolean;
+  state: MakeLiveState;
+}
+
+export type StepStatus = "mint" | "wire" | "restart" | "ok";
+
+export interface PlanItem {
+  step: string;
+  status: StepStatus;
+  detail: string;
+}
+
+export interface MakeLiveResult {
+  ok: boolean;
+  reason?: string;
+  applied: boolean;
+  plan: PlanItem[];
+  steps: string[];
+}
+
+// =============================================================================
+// Plan (pure)
+// =============================================================================
+
+/**
+ * Decide which steps are NEEDED from observable state. A first migration is
+ * signalled by the resolver NOT yet carrying the agents account; on that path
+ * the creds are (re-)minted even if a (stale, old-account) creds file exists.
+ */
+export function planMakeLive(inputs: MakeLiveInputs): {
+  credsNeeded: boolean;
+  resolverNeeded: boolean;
+  natsRestartNeeded: boolean;
+  daemonRestartNeeded: boolean;
+  plan: PlanItem[];
+} {
+  const { force, state } = inputs;
+  const resolverNeeded = force || !state.resolverHasAccount;
+  // First migration (resolver absent) ⇒ mint regardless of a stale creds file.
+  const credsNeeded = force || !state.resolverHasAccount || !state.credsFileExists;
+  const natsRestartNeeded = resolverNeeded;
+  const daemonRestartNeeded = credsNeeded || natsRestartNeeded;
+
+  const plan: PlanItem[] = [
+    {
+      step: "resolver_preload account",
+      status: resolverNeeded ? "wire" : "ok",
+      detail: `${inputs.agentsAccountName} (${inputs.agentsAccountPubkey}) → ${inputs.natsConfigPath}`,
+    },
+    {
+      step: "nats-server restart",
+      status: natsRestartNeeded ? "restart" : "ok",
+      detail: inputs.natsConfigPath,
+    },
+    {
+      step: "bus creds (agents account)",
+      status: credsNeeded ? "mint" : "ok",
+      detail: `${inputs.botName} @ ${inputs.agentsAccountName} → ${inputs.credsPath}`,
+    },
+    {
+      step: "cortex daemon restart",
+      status: daemonRestartNeeded ? "restart" : "ok",
+      detail: inputs.cortexConfigPath,
+    },
+  ];
+  return { credsNeeded, resolverNeeded, natsRestartNeeded, daemonRestartNeeded, plan };
+}
+
+function renderPlanLine(item: PlanItem): string {
+  return `[${item.status.padEnd(8)}] ${item.step.padEnd(28)} ${item.detail}`;
+}
+
+// =============================================================================
+// Orchestrator
+// =============================================================================
+
+/**
+ * Land a provisioned stack's daemon onto its agents account. Pure over `ports`;
+ * NEVER throws (port failures surface as `{ ok: false, reason }`).
+ *
+ * Dry-run (`apply === false`): returns the plan; mutates nothing.
+ * Apply: resolver append → creds mint → nats restart → daemon restart, fail-fast.
+ */
+export async function makeLiveStack(
+  inputs: MakeLiveInputs,
+  ports: MakeLivePorts,
+): Promise<MakeLiveResult> {
+  // Guard: the agents account must have been provisioned first.
+  if (inputs.agentsAccountPubkey === "") {
+    return {
+      ok: false,
+      applied: false,
+      plan: [],
+      reason:
+        "stack.nats_infra.agents_account is not set — run `cortex network provision " +
+        `${inputs.stackSlug} --apply` + "` first to mint the account tree.",
+      steps: [],
+    };
+  }
+
+  const { credsNeeded, resolverNeeded, natsRestartNeeded, daemonRestartNeeded, plan } =
+    planMakeLive(inputs);
+  const planLines = plan.map(renderPlanLine);
+
+  if (!inputs.apply) {
+    return {
+      ok: true,
+      applied: false,
+      plan,
+      steps: [
+        ...planLines,
+        "",
+        credsNeeded || resolverNeeded
+          ? "Re-run with --apply to land the daemon on its agents account."
+          : "Already live on the agents account — nothing to do (re-run with --force to re-mint).",
+      ],
+    };
+  }
+
+  const steps: string[] = [];
+
+  // 1. Teach the NATS server the agents account (append to resolver_preload).
+  if (resolverNeeded) {
+    const exported = await ports.accountExport.exportAccount(inputs.agentsAccountName);
+    if (!exported.ok) return fail(plan, steps, `export-account failed: ${exported.reason}`);
+    const appended = ports.resolver.appendAccount({
+      natsConfigPath: inputs.natsConfigPath,
+      accountName: inputs.agentsAccountName,
+      accountPubkey: inputs.agentsAccountPubkey,
+      accountJwt: exported.jwt,
+    });
+    if (!appended.ok) return fail(plan, steps, `resolver_preload append failed: ${appended.reason}`);
+    steps.push(
+      appended.changed
+        ? `resolver_preload: appended ${inputs.agentsAccountName} (${inputs.agentsAccountPubkey})`
+        : `resolver_preload: ${inputs.agentsAccountName} already present (no-op)`,
+    );
+  } else {
+    steps.push(`resolver_preload: ${inputs.agentsAccountName} already present (no-op)`);
+  }
+
+  // 2. Restart the nats-server so the MEMORY resolver loads the new account.
+  //    Done BEFORE minting the daemon's new creds so there is never a window
+  //    where the creds on disk name an account the running server doesn't yet
+  //    know (which would surface a transient own-auth Authorization Violation if
+  //    the live daemon reconnected in that window). Both the OLD shared account
+  //    and the new agents account coexist in the resolver across this restart,
+  //    so the still-running daemon (on its OLD creds) reconnects cleanly.
+  if (natsRestartNeeded) {
+    const r = await ports.restart.restartNats(inputs.natsConfigPath);
+    if (!r.ok) return fail(plan, steps, `nats-server restart failed: ${r.reason}`);
+    steps.push(`nats-server restarted (loaded ${inputs.agentsAccountName} into MEMORY resolver)`);
+  }
+
+  // 3. Mint the daemon's bus creds under the agents account (server now knows it).
+  if (credsNeeded) {
+    const minted = await ports.creds.mint({
+      botName: inputs.botName,
+      account: inputs.agentsAccountName,
+      credsPath: inputs.credsPath,
+      force: inputs.force,
+    });
+    if (!minted.ok) return fail(plan, steps, `creds mint failed: ${minted.reason}`);
+    steps.push(`bus creds minted: ${inputs.botName} @ ${inputs.agentsAccountName} → ${minted.credsPath} (chmod 600)`);
+  } else {
+    steps.push(`bus creds present (untouched): ${inputs.credsPath}`);
+  }
+
+  // 4. Restart the cortex daemon so it reconnects with the new creds.
+  if (daemonRestartNeeded) {
+    const r = await ports.restart.restartDaemon(inputs.cortexConfigPath);
+    if (!r.ok) return fail(plan, steps, `cortex daemon restart failed: ${r.reason}`);
+    steps.push(`cortex daemon restarted — reconnecting under ${inputs.agentsAccountName}`);
+  }
+
+  if (!credsNeeded && !resolverNeeded) {
+    steps.push("");
+    steps.push("Already live on the agents account — nothing changed.");
+  } else {
+    steps.push("");
+    steps.push(`Landed ${inputs.stackId} on ${inputs.agentsAccountName}.`);
+    steps.push(
+      "Verify: the nats-server /connz?auth=true shows this stack's connection under the agents account, " +
+        "and the daemon log carries 0 own-auth Authorization Violation.",
+    );
+  }
+
+  return { ok: true, applied: true, plan, steps };
+}
+
+function fail(plan: PlanItem[], steps: string[], reason: string): MakeLiveResult {
+  // Surface the steps accumulated so far so a mid-pipeline abort shows how far
+  // make-live got (mirrors network-provision-lib's fail()).
+  return { ok: false, reason, applied: true, plan, steps };
+}

--- a/src/cli/cortex/commands/network-make-live-lib.ts
+++ b/src/cli/cortex/commands/network-make-live-lib.ts
@@ -78,6 +78,12 @@ export interface ResolverPreloadPort {
   /** Is `accountPubkey` already present in the resolver_preload of `natsConfigPath`? */
   hasAccount(natsConfigPath: string, accountPubkey: string): boolean;
   /**
+   * M3 — does `natsConfigPath` carry a `resolver_preload { … }` block at all?
+   * A bus with none (the anonymous / hard-isolated `halden` pattern) is NOT
+   * operator-mode and cannot host a make-live; the orchestrator refuses early.
+   */
+  hasResolverPreload(natsConfigPath: string): boolean;
+  /**
    * Append a labelled `<pubkey>: <jwt>` block inside resolver_preload, backing
    * up the config first. Idempotent: no-op (`changed:false`) when present.
    */
@@ -91,6 +97,16 @@ export interface ResolverPreloadPort {
 
 /** Restart the nats-server + the cortex daemon (composes launchctl/systemctl). */
 export interface ServiceRestartPort {
+  /**
+   * BLOCK 2 — read-only resolution of the launchd/systemd descriptors that
+   * `restartNats` / `restartDaemon` WOULD target. Surfaced in the dry-run plan so
+   * the operator verifies the (potentially SHARED) nats-server blast target
+   * before `--apply`. `undefined` ⇒ no matching service found.
+   */
+  resolveTargets(opts: { natsConfigPath: string; cortexConfigPath: string }): {
+    natsDescriptor?: string;
+    daemonDescriptor?: string;
+  };
   /** Hard-restart the nats-server bound to `natsConfigPath` (loads new resolver_preload). */
   restartNats(natsConfigPath: string): Promise<{ ok: true } | { ok: false; reason: string }>;
   /** Restart the cortex daemon loading `cortexConfigPath` (reconnect with new creds). */
@@ -130,7 +146,12 @@ export interface MakeLiveInputs {
   credsPath: string;
   /** Path to the cortex config the daemon loads (for daemon-restart discovery). */
   cortexConfigPath: string;
-  /** Path to the nats-server config carrying resolver_preload (default local.conf). */
+  /**
+   * Path to the nats-server config carrying resolver_preload. BLOCK 1 — derived
+   * PER-STACK from `stack.nats_infra.config_path` (or `--nats-config`); there is
+   * NO shared default, so a co-located stack on its own nats-server never targets
+   * the wrong (shared) config.
+   */
   natsConfigPath: string;
   force: boolean;
   apply: boolean;
@@ -173,7 +194,13 @@ export function planMakeLive(inputs: MakeLiveInputs): {
   const resolverNeeded = force || !state.resolverHasAccount;
   // First migration (resolver absent) ⇒ mint regardless of a stale creds file.
   const credsNeeded = force || !state.resolverHasAccount || !state.credsFileExists;
-  const natsRestartNeeded = resolverNeeded;
+  // M2 — the resolver_preload append actually CHANGES the file only when the
+  // account is ABSENT (append is keyed on the pubkey; a present account no-ops).
+  // `--force` re-mints creds but must NOT trigger a no-op hard-restart of a
+  // (potentially SHARED) nats-server, so the nats restart is gated on the
+  // resolver genuinely changing, not merely on `resolverNeeded`.
+  const resolverWillChange = !state.resolverHasAccount;
+  const natsRestartNeeded = resolverWillChange;
   const daemonRestartNeeded = credsNeeded || natsRestartNeeded;
 
   const plan: PlanItem[] = [
@@ -233,17 +260,70 @@ export async function makeLiveStack(
     };
   }
 
+  // M3 — operator-mode guard (the `network join` #794 analogue). make-live teaches
+  // the nats-server a new account by appending to `resolver_preload`; a bus with no
+  // such block (the anonymous / hard-isolated `halden` pattern) is not operator-mode
+  // and make-live does not apply to it. Refuse BEFORE any mint/restart, in BOTH
+  // dry-run and apply, so the operator learns this rather than (under a defaulted
+  // config path) silently editing the wrong file. Runs against the SAME natsConfigPath
+  // the rest of the flow targets (BLOCK 1 derives it per-stack), so a category error
+  // is caught against the stack's own bus.
+  if (!ports.resolver.hasResolverPreload(inputs.natsConfigPath)) {
+    return {
+      ok: false,
+      applied: false,
+      plan: [],
+      reason:
+        `${inputs.natsConfigPath} has no resolver_preload { … } block — this stack's bus is not ` +
+        "operator-mode; make-live does not apply. Convert the bus to operator-mode first " +
+        "(see docs/sop-stack-onboarding.md §B0.1) before landing the daemon on its agents account.",
+      steps: [],
+    };
+  }
+
   const { credsNeeded, resolverNeeded, natsRestartNeeded, daemonRestartNeeded, plan } =
     planMakeLive(inputs);
   const planLines = plan.map(renderPlanLine);
 
+  // BLOCK 2 — resolve (read-only) the launchd/systemd descriptors the nats-server +
+  // daemon restarts will target. make-live's highest-blast action is a HARD RESTART
+  // of a potentially SHARED nats-server, so the operator must be able to preview the
+  // exact service before --apply. Resolved here (not apply-only) so it shows in the
+  // dry-run plan AND prefixes the apply transcript.
+  const targets = ports.restart.resolveTargets({
+    natsConfigPath: inputs.natsConfigPath,
+    cortexConfigPath: inputs.cortexConfigPath,
+  });
+  const targetLines = [
+    `nats-server restart target → ${inputs.natsConfigPath} :: ${targets.natsDescriptor ?? "NOT FOUND (no launchd/systemd service runs nats-server -c this config)"}`,
+    `cortex daemon restart target → ${inputs.cortexConfigPath} :: ${targets.daemonDescriptor ?? "NOT FOUND (no cortex daemon service loads this config)"}`,
+  ];
+
   if (!inputs.apply) {
+    // Surface a dry-run WARNING when a NEEDED restart has no discoverable service —
+    // catch a missing descriptor before --apply rather than mid-pipeline.
+    const warnings: string[] = [];
+    if (natsRestartNeeded && targets.natsDescriptor === undefined) {
+      warnings.push(
+        "WARNING: nats-server restart is needed but no service running " +
+          `nats-server -c ${inputs.natsConfigPath} was found — --apply would fail at the restart step.`,
+      );
+    }
+    if (daemonRestartNeeded && targets.daemonDescriptor === undefined) {
+      warnings.push(
+        "WARNING: cortex daemon restart is needed but no service loading " +
+          `${inputs.cortexConfigPath} was found — --apply would fail at the daemon restart.`,
+      );
+    }
     return {
       ok: true,
       applied: false,
       plan,
       steps: [
         ...planLines,
+        "",
+        ...targetLines,
+        ...(warnings.length > 0 ? ["", ...warnings] : []),
         "",
         credsNeeded || resolverNeeded
           ? "Re-run with --apply to land the daemon on its agents account."
@@ -252,12 +332,32 @@ export async function makeLiveStack(
     };
   }
 
-  const steps: string[] = [];
+  // Prefix the apply transcript with the resolved blast targets too (so the
+  // post-hoc record shows exactly which services were restarted).
+  const steps: string[] = [...targetLines];
 
   // 1. Teach the NATS server the agents account (append to resolver_preload).
+  let resolverChanged = false;
   if (resolverNeeded) {
     const exported = await ports.accountExport.exportAccount(inputs.agentsAccountName);
     if (!exported.ok) return fail(plan, steps, `export-account failed: ${exported.reason}`);
+    // BLOCK 3 — the resolver_preload map is keyed by the JWT's subject (the account
+    // pubkey). We write the CONFIG pubkey as the KEY but the EXPORTED JWT as the
+    // VALUE; if they diverge (slug drift / a re-provision that re-minted the account /
+    // a stale nats_infra), the entry is `<configPubkey>: <jwt-for-a-different-account>`.
+    // nats-server keys the entry under jwt.sub, so the daemon creds (minted under the
+    // NAMED account) land in an account the server keyed differently → auth failure
+    // after restart. Cross-check the two and refuse on mismatch.
+    if (exported.pubKey !== inputs.agentsAccountPubkey) {
+      return fail(
+        plan,
+        steps,
+        "account pubkey drift: stack.nats_infra.agents_account is " +
+          `${inputs.agentsAccountPubkey} but \`arc nats export-account ${inputs.agentsAccountName}\` ` +
+          `returned ${exported.pubKey}. The config pubkey and the named account have diverged — ` +
+          "re-run `cortex network provision` to reconcile before make-live.",
+      );
+    }
     const appended = ports.resolver.appendAccount({
       natsConfigPath: inputs.natsConfigPath,
       accountName: inputs.agentsAccountName,
@@ -265,6 +365,7 @@ export async function makeLiveStack(
       accountJwt: exported.jwt,
     });
     if (!appended.ok) return fail(plan, steps, `resolver_preload append failed: ${appended.reason}`);
+    resolverChanged = appended.changed;
     steps.push(
       appended.changed
         ? `resolver_preload: appended ${inputs.agentsAccountName} (${inputs.agentsAccountPubkey})`
@@ -281,7 +382,10 @@ export async function makeLiveStack(
   //    the live daemon reconnected in that window). Both the OLD shared account
   //    and the new agents account coexist in the resolver across this restart,
   //    so the still-running daemon (on its OLD creds) reconnects cleanly.
-  if (natsRestartNeeded) {
+  //    M2 — gated on the resolver having ACTUALLY changed (not merely on
+  //    `--force`): a `--force` re-mint over an already-present account must not
+  //    hard-restart a (potentially shared) nats-server for a no-op resolver.
+  if (resolverChanged) {
     const r = await ports.restart.restartNats(inputs.natsConfigPath);
     if (!r.ok) return fail(plan, steps, `nats-server restart failed: ${r.reason}`);
     steps.push(`nats-server restarted (loaded ${inputs.agentsAccountName} into MEMORY resolver)`);

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -1868,9 +1868,6 @@ const DEFAULT_MAKE_LIVE_PORTS_FACTORY: MakeLivePortsFactory = (mutate) => buildL
 
 const STACK_SLUG_RE = /^[a-z][a-z0-9_-]*$/;
 
-/** Default nats-server config (resolver_preload host) for a LOCAL stack. */
-const DEFAULT_NATS_CONFIG_PATH = "~/.config/nats/local.conf";
-
 /** Build the {@link MakeLiveInputs} from config + flags, or a usage reason. */
 function deriveMakeLiveInputs(
   stackArg: string,
@@ -1916,7 +1913,26 @@ function deriveMakeLiveInputs(
     return { ok: false, reason: "cannot resolve nats.credsPath — pass --creds or set `nats.credsPath` in config", usage: true };
   }
   const botName = cfg.config.nats?.name ?? "cortex";
-  const natsConfigPath = optionalValueFlag(flags, "--nats-config") ?? DEFAULT_NATS_CONFIG_PATH;
+  // BLOCK 1 — derive the nats-server config PER STACK from the stack's OWN config
+  // (`stack.nats_infra.config_path`, the same field `network join` derives from),
+  // NEVER a hardcoded shared default. make-live edits the resolver_preload of, and
+  // HARD-RESTARTS, this exact nats-server; a `local.conf` default would silently
+  // target the shared metafactory server for a `community`/`halden` stack (wrong
+  // file + wrong server → blips metafactory + an own-auth Authorization Violation on
+  // the WRONG bus). Fail-fast when it can't be derived rather than guessing — the
+  // metafactory + work stacks legitimately carry `local.conf` in their own config.
+  const natsConfigPath =
+    optionalValueFlag(flags, "--nats-config") ?? cfg.stack?.nats_infra?.config_path;
+  if (natsConfigPath === undefined || natsConfigPath === "") {
+    return {
+      ok: false,
+      usage: true,
+      reason:
+        `cannot resolve the nats-server config for ${principal}/${slug} — pass --nats-config or set ` +
+        "`stack.nats_infra.config_path` in the stack config. make-live edits + hard-restarts THIS " +
+        "stack's nats-server; it must never default to the shared metafactory ~/.config/nats/local.conf.",
+    };
+  }
 
   const applyRes = resolveApply(flags);
   if (!applyRes.ok) return { ok: false, reason: applyRes.reason, usage: true };
@@ -2348,6 +2364,15 @@ Subcommands:
           runs zero nsc — it shells arc \`add-bot\` / \`export-account\`.
           Network-agnostic (local OR federated; for federated, run \`join\` after
           to render the leaf). NEVER touches encryption/payload_key config.
+          The nats-server config it edits + hard-restarts is derived PER-STACK
+          from stack.nats_infra.config_path (or --nats-config) — there is NO
+          shared default, so a co-located stack on its OWN nats-server
+          (community.conf / halden.conf) must carry config_path (or pass
+          --nats-config); it NEVER silently targets the shared metafactory
+          local.conf. Refuses a bus with no resolver_preload block (not
+          operator-mode). The dry-run prints the resolved nats-server + daemon
+          restart targets so the (possibly shared-server) blast radius is
+          verifiable before --apply.
           Idempotent + dry-run by default; --apply mutates; --force re-mints.
           Run AFTER \`cortex network provision <stack> --apply\`.
   admit   (ADR-0015) One-command admin admission decision. Verifies the admin

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -124,6 +124,12 @@ import {
 } from "./network-provision-lib";
 import { buildLiveProvisionPorts } from "./network-provision-adapters";
 import {
+  makeLiveStack,
+  type MakeLiveInputs,
+  type MakeLivePorts,
+} from "./network-make-live-lib";
+import { buildLiveMakeLivePorts, buildResolverPreloadAdapter } from "./network-make-live-adapters";
+import {
   runNetworkSecret,
   type SecretAction,
   type DeliveryMode,
@@ -148,7 +154,7 @@ export { type ExitResult } from "./_shared/exit-result";
 // Grammar
 // =============================================================================
 
-type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "admit" | "provision" | "secret";
+type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "admit" | "provision" | "make-live" | "secret";
 
 /**
  * Default registry URL when neither --registry-url nor config provides one.
@@ -352,6 +358,24 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--config": "value",
         "--principal": "value",
         "--seed-path": "value",
+        "--creds": "value",
+        "--force": "bool",
+        "--apply": "bool",
+        "--dry-run": "bool",
+      },
+    },
+    // C-1257 (PR7/#1225, ADR-0013 Model B) — the daemon-switch step. Lands a
+    // provisioned stack's daemon onto its own agents account: mints the bus
+    // creds under ANDREAS_<STACK>_AGENTS at nats.credsPath, teaches the local
+    // NATS server the account (resolver_preload), restarts the nats-server +
+    // the cortex daemon. DRY-RUN by default; --apply mutates. Run AFTER
+    // `cortex network provision <stack> --apply`.
+    "make-live": {
+      positionals: ["stack"],
+      flags: {
+        "--config": "value",
+        "--principal": "value",
+        "--nats-config": "value",
         "--creds": "value",
         "--force": "bool",
         "--apply": "bool",
@@ -1832,7 +1856,125 @@ export type ProvisionPortsFactory = (stackConfigPath: string) => ProvisionPorts;
 
 const DEFAULT_PROVISION_PORTS_FACTORY: ProvisionPortsFactory = (p) => buildLiveProvisionPorts(p);
 
+/**
+ * Factory for the make-live port bundle. Production builds the live adapters
+ * (arc add-bot/export-account + resolver_preload editor + launchctl restarts);
+ * `mutate` is the apply flag (false ⇒ the restart adapter no-ops, mirroring the
+ * service-manager dry-run). Tests inject fakes that record calls without arc/fs.
+ */
+export type MakeLivePortsFactory = (mutate: boolean) => MakeLivePorts;
+
+const DEFAULT_MAKE_LIVE_PORTS_FACTORY: MakeLivePortsFactory = (mutate) => buildLiveMakeLivePorts(mutate);
+
 const STACK_SLUG_RE = /^[a-z][a-z0-9_-]*$/;
+
+/** Default nats-server config (resolver_preload host) for a LOCAL stack. */
+const DEFAULT_NATS_CONFIG_PATH = "~/.config/nats/local.conf";
+
+/** Build the {@link MakeLiveInputs} from config + flags, or a usage reason. */
+function deriveMakeLiveInputs(
+  stackArg: string,
+  flags: FlagMap,
+  load: ConfigReader,
+): { ok: true; inputs: MakeLiveInputs } | { ok: false; reason: string; usage: boolean } {
+  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH);
+  let cfg: LoadedConfig;
+  try {
+    cfg = load(configPath);
+  } catch (err) {
+    return { ok: false, reason: `config load failed: ${err instanceof Error ? err.message : String(err)}`, usage: false };
+  }
+
+  const principal = optionalValueFlag(flags, "--principal") ?? cfg.principal?.id;
+  if (principal === undefined || principal === "") {
+    return { ok: false, reason: "cannot resolve principal — pass --principal or set `principal.id` in cortex.yaml", usage: true };
+  }
+  if (!PRINCIPAL_ID_RE.test(principal)) {
+    return { ok: false, reason: `principal "${principal}" must be lowercase alphanumeric + hyphen, letter-prefixed`, usage: true };
+  }
+
+  const slugRes = resolveProvisionSlug(stackArg, principal, cfg);
+  if (!slugRes.ok) return { ok: false, reason: slugRes.reason, usage: true };
+  const slug = slugRes.slug;
+
+  const names = deriveProvisionNames(principal, slug);
+  if (!names.ok) return { ok: false, reason: names.reason, usage: true };
+
+  const agentsAccountPubkey = cfg.stack?.nats_infra?.agents_account;
+  if (agentsAccountPubkey === undefined || agentsAccountPubkey === "") {
+    return {
+      ok: false,
+      usage: true,
+      reason:
+        `stack.nats_infra.agents_account is not set for ${principal}/${slug} — ` +
+        `run \`cortex network provision ${slug} --apply\` first to mint the account tree.`,
+    };
+  }
+
+  const credsPath = optionalValueFlag(flags, "--creds") ?? cfg.config.nats?.credsPath;
+  if (credsPath === undefined || credsPath === "") {
+    return { ok: false, reason: "cannot resolve nats.credsPath — pass --creds or set `nats.credsPath` in config", usage: true };
+  }
+  const botName = cfg.config.nats?.name ?? "cortex";
+  const natsConfigPath = optionalValueFlag(flags, "--nats-config") ?? DEFAULT_NATS_CONFIG_PATH;
+
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return { ok: false, reason: applyRes.reason, usage: true };
+  const force = flags["--force"] === true;
+
+  // Read-only state probes (cheap fs reads via the resolver adapter).
+  const resolverProbe = buildResolverPreloadAdapter();
+  const state = {
+    credsFileExists: existsSync(expandTilde(credsPath)),
+    resolverHasAccount: resolverProbe.hasAccount(natsConfigPath, agentsAccountPubkey),
+  };
+
+  const inputs: MakeLiveInputs = {
+    principal,
+    stackSlug: slug,
+    stackId: `${principal}/${slug}`,
+    agentsAccountName: names.agentsAccountName,
+    agentsAccountPubkey,
+    botName,
+    credsPath,
+    cortexConfigPath: configPath,
+    natsConfigPath,
+    force,
+    apply: applyRes.apply,
+    state,
+  };
+  return { ok: true, inputs };
+}
+
+async function runMakeLive(
+  stackArg: string,
+  flags: FlagMap,
+  json: boolean,
+  load: ConfigReader,
+  portsFactory: MakeLivePortsFactory,
+): Promise<ExitResult> {
+  const derived = deriveMakeLiveInputs(stackArg, flags, load);
+  if (!derived.ok) {
+    return derived.usage ? usageError("make-live", derived.reason, json) : opError("make-live", derived.reason, json);
+  }
+  const { inputs } = derived;
+
+  // Build live ports only on --apply; dry-run uses them too but the restart
+  // adapter no-ops when mutate=false (mirrors the service-manager contract).
+  const ports = portsFactory(inputs.apply);
+  const res = await makeLiveStack(inputs, ports);
+
+  return renderFlowResult(
+    "make-live",
+    inputs.stackId,
+    res.ok,
+    res.reason,
+    res.steps,
+    inputs.apply,
+    json,
+    { agents_account: inputs.agentsAccountName },
+  );
+}
 
 /**
  * Resolve where the `stack.nats_infra` write-back lands, layout-aware (mirrors
@@ -2063,6 +2205,9 @@ export async function dispatchNetwork(
   // ADR-0018 PR5b — injectable secret-ports factory so the `secret` CLI tests
   // drive fake hub/registry/crypto ports. Production omits → the live adapters.
   secretPortsFactory: SecretPortsFactory = DEFAULT_SECRET_PORTS_FACTORY,
+  // C-1257 — injectable make-live ports factory so the make-live CLI tests drive
+  // fake arc/fs/restart ports. Production omits → the live adapters.
+  makeLivePortsFactory: MakeLivePortsFactory = DEFAULT_MAKE_LIVE_PORTS_FACTORY,
 ): Promise<ExitResult> {
   let parsed;
   try {
@@ -2102,6 +2247,8 @@ export async function dispatchNetwork(
       return runAdmit(parsed.positionals["request-id"] ?? "", parsed.flags, json);
     case "provision":
       return runProvision(parsed.positionals.stack ?? "", parsed.flags, json, load, provisionPortsFactory);
+    case "make-live":
+      return runMakeLive(parsed.positionals.stack ?? "", parsed.flags, json, load, makeLivePortsFactory);
     case "secret":
       return runSecret(
         parsed.positionals.action ?? "",
@@ -2131,6 +2278,8 @@ Usage:
                         [--discord-member <id>] [--discord-guild <id>] [--discord-server <profile>]
                         [--discord-role <name>] [--apply] [--dry-run] [--json]
   cortex network provision <stack> [--config <p>] [--principal <id>] [--seed-path <p>]
+                        [--creds <p>] [--force] [--apply] [--dry-run] [--json]
+  cortex network make-live <stack> [--config <p>] [--principal <id>] [--nats-config <p>]
                         [--creds <p>] [--force] [--apply] [--dry-run] [--json]
   cortex network secret <add-member|revoke-member|rotate> <network> <member-pubkey>
                         --admin-seed <hub-admin-seed> [--registry-url <url>] [--hub-config <p>]
@@ -2189,6 +2338,18 @@ Subcommands:
           operator-mode bus conversion + restart are left to \`join\` (this verb is
           non-disruptive). Remaining two-party steps after provision: the leaf
           shared secret + hub topology agreement (out-of-band).
+  make-live (C-1257, ADR-0013 Model B) The daemon-switch — lands a PROVISIONED
+          stack's daemon onto its OWN agents account (ANDREAS_<STACK>_AGENTS).
+          Mints the bus creds under the agents account at nats.credsPath (the
+          file the daemon authenticates with), teaches the local NATS server the
+          account (resolver_preload, MEMORY resolver), then HARD-restarts the
+          nats-server (a SIGHUP reload does NOT load a new preloaded account) +
+          the cortex daemon so it reconnects under the agents account. cortex
+          runs zero nsc — it shells arc \`add-bot\` / \`export-account\`.
+          Network-agnostic (local OR federated; for federated, run \`join\` after
+          to render the leaf). NEVER touches encryption/payload_key config.
+          Idempotent + dry-run by default; --apply mutates; --force re-mints.
+          Run AFTER \`cortex network provision <stack> --apply\`.
   admit   (ADR-0015) One-command admin admission decision. Verifies the admin
           seed (chmod-600 gated), builds a signed admission decision claim
           (decision: "admit"), and POSTs it to /admission-requests/:id/admit


### PR DESCRIPTION
Closes #1257. Part of #1225 / EPIC #1142 (sovereign-stack migration, ADR-0013 Model B).

## The gap

`cortex network provision` (#1253 + arc#255) mints the per-stack account tree (`ANDREAS_<STACK>_FED` + `_AGENTS`), wires `federated.>`, and writes `nats_infra` — but is **non-disruptive**, so the daemon keeps authenticating under the shared `ANDREAS_AGENTS`. Verified on `work`: provision writes `nats_infra.creds_path` but never mints the creds; `local.conf` `resolver_preload` never learns the new account; there is no make-live command for a LOCAL stack.

## What this adds — `cortex network make-live <stack>`

A separate, explicit, idempotent daemon-switch step (dry-run by default):

1. **resolver_preload** — append the agents account JWT (from `arc nats export-account`) to the nats config (default `~/.config/nats/local.conf`). Keyed on pubkey → pure addition, never disturbs other stacks' accounts (multi-stack safe).
2. **nats-server restart** — a SIGHUP reload does **NOT** load a new preloaded account under a MEMORY resolver (verified empirically); a hard restart is required.
3. **bus creds** — `arc nats add-bot <nats.name> --account <agents> --output <nats.credsPath> --force` (the daemon's own connection creds, backed up first).
4. **cortex daemon restart** — reconnect under the agents account.

Order is resolver → nats restart → creds → daemon restart, so the creds never name an account the running server hasn't loaded yet (eliminates a transient own-auth violation).

**Command home:** chose `cortex network make-live` for pipeline-consistency with `provision` / `join` (all stack-scoped sovereign-bus verbs under `network`). The lib is pure, so moving it to `cortex stack make-live` later is one line — flagged for confirmation.

**Federated stacks:** make-live is network-agnostic — it lands the daemon on its agents account; `network join` then renders the leaf on the FED account. make-live NEVER touches `policy.federated` / `payload_key` / encryption, so confidentiality survives the swap by construction.

## Validated end-to-end on the `work` throwaway stack

`provision work --apply` → `make-live work --apply`:
- `/connz?auth=true`: `cortex-work -> ANDREAS_WORK_AGENTS` (was `ANDREAS_AGENTS`)
- `resolver_preload` carries the new account
- **0 own-auth Authorization Violations** in `work-logs/`
- other stacks (meta-factory, aggregators) undisturbed
- idempotent re-run = no-op (no mint, no restart)

## Bug catalog (this path was never built)

1. **No make-live command** for a local stack — built it.
2. **Creds never minted** under the agents account — make-live mints via `arc nats add-bot`.
3. **resolver_preload never taught the account** — make-live appends the JWT (new `arc nats export-account`, PR arc#256).
4. **SIGHUP reload doesn't load a new MEMORY-resolver account** — discovered empirically; make-live hard-restarts.
5. **Account field mismatch** — provision writes `nats_infra.creds_path` (`<slug>.creds`) but the daemon authenticates with `nats.credsPath` (`cortex-<slug>.creds`); make-live correctly targets `nats.credsPath`.
6. **Transient own-auth violation** during the restart window — fixed by ordering nats-restart before creds-mint.

## Tests (anti-rot guard)

`network-make-live.test.ts` (orchestrator: plan, exact apply order, idempotency, fail-fast, dry-run; `insertIntoResolverPreload` multi-stack safety; `findNatsServerDescriptor`) + `network-make-live-cli.test.ts` (dispatch + input derivation + provision-first guard). `tsc` 0, lint clean, 16 make-live tests + 46 network/provision tests green.

## Requires

arc#256 (`nats export-account`). Design: `docs/design-make-live-daemon-switch.md`.

## Deferred (flagged)

- `nats.accountSigningKeyPath` rewrite (TrustResolver SA-seed) — not on the daemon-auth path, lives in the higher-blast `system/` layer; `export-account` already returns the `seedPath` for the follow-up.
- Full federated make-live + join round-trip (validated path is LOCAL `work`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)