### PR TITLE
chore: bump to v5.28.0 — make-live daemon-switch (#1257)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.27.1"
+version: "5.28.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Minor release: `cortex network make-live <stack>` — the daemon-switch step that lands a provisioned stack onto its own sovereign account (mint creds → teach the NATS resolver → restart), with per-stack config derivation, dry-run target preview, pubkey-drift + operator-mode guards. Completes the PR7 migration tooling. 5.27.1 → 5.28.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)