### PR TITLE
feat(network): C-1265 — wrap nsc server-config generation (provision JWT export + make-live bootstrap)

### DIFF
--- a/docs/design-wrap-server-config-tooling.md
+++ b/docs/design-wrap-server-config-tooling.md
@@ -1,8 +1,8 @@
 # Design — Wrap the raw `nsc` server-config generation in cortex tooling
 
-**Status:** design — DECISION PENDING SIGN-OFF (2026-06-28) · **Author:** Luna (for Andreas) · **Refs:** cortex#1265 (from #1262) · **Builds on:** [`design-onboarding-tooling-audit.md`](./design-onboarding-tooling-audit.md) (G1–G5), ADR-0013 (sovereign Model B), ADR-0012 (account isolation)
+**Status:** SIGNED OFF + IMPLEMENTED (2026-06-28) — Option A (provision) + A2 (make-live bootstrap) · **Author:** Luna (for Andreas) · **Refs:** cortex#1265 (from #1262), arc server-config-export · **Builds on:** [`design-onboarding-tooling-audit.md`](./design-onboarding-tooling-audit.md) (G1–G5), ADR-0013 (sovereign Model B), ADR-0012 (account isolation)
 
-> **This doc investigates and recommends; it does not implement.** The one decision that needs Andreas's sign-off before any code is written is in §4 — *where the server-config generation lives*. Everything else is supporting analysis.
+> **Decision (§4) is signed off and built.** Andreas approved **Option A** (the server-config JWT-export bridge lives in `cortex network provision`) and the secondary **A2** (the local-only path bootstraps its initial `.conf` via `cortex network make-live`). Implementation: provision now exports operator + federation + (best-effort) SYS JWTs into `stack.nats_infra` (`network-provision-lib.ts` + `operator-mode-export.ts`, backed by new arc verbs `nats export-operator` / `export-system`); make-live bootstraps an initial operator-mode resolver via `renderOperatorModeBlocks` when none exists. **Note on SYS:** `nsc add operator` does not auto-create a SYS account, and the renderer treats `system_account` as optional, so provision exports it *best-effort* (a missing SYS is a clean skip, never a failure) rather than forcing a new account into the tree.
 
 ---
 

--- a/docs/design-wrap-server-config-tooling.md
+++ b/docs/design-wrap-server-config-tooling.md
@@ -1,0 +1,145 @@
+# Design — Wrap the raw `nsc` server-config generation in cortex tooling
+
+**Status:** design — DECISION PENDING SIGN-OFF (2026-06-28) · **Author:** Luna (for Andreas) · **Refs:** cortex#1265 (from #1262) · **Builds on:** [`design-onboarding-tooling-audit.md`](./design-onboarding-tooling-audit.md) (G1–G5), ADR-0013 (sovereign Model B), ADR-0012 (account isolation)
+
+> **This doc investigates and recommends; it does not implement.** The one decision that needs Andreas's sign-off before any code is written is in §4 — *where the server-config generation lives*. Everything else is supporting analysis.
+
+---
+
+## 1. The question (cortex#1265)
+
+Per the plug-and-play / "feel like TCP/IP" vision, onboarding a stack should be **cortex-commands-only** — no operator ever types a raw `nsc` / `nats-server` line. We are most of the way there. The audit ([`design-onboarding-tooling-audit.md`](./design-onboarding-tooling-audit.md)) and the consolidated runbook ([`sop-onboard-peer-principal.md`](./sop-onboard-peer-principal.md)) wrapped account-tree minting (`cortex network provision`), the daemon switch (`cortex network make-live`), and the join (`cortex network join`). **One raw edge remains:** generating the **initial operator-mode NATS server config** for a brand-new stack's bus — the `operator:` JWT + `system_account:` + `resolver: MEMORY` + `resolver_preload { … }` blocks that turn a hard-isolated/anonymous bus into one that can host an account tree. The SOP teaches this as a hand-edit (`sop-stack-onboarding.md §B0.1`), classically produced by raw `nsc generate config --mem-resolver --sys-account SYS --config-file <path>`.
+
+This doc walks the onboarding flow end to end, isolates exactly where that raw edge is (and how narrow it actually is), and recommends a command-home.
+
+---
+
+## 2. Raw-command audit — every by-hand `nsc` / `arc` / `nats-server` step
+
+Walking `sop-onboard-peer-principal.md` Steps 1–8 (the happy path), plus the `§B0.1` bus-conversion the SOP defers to, plus the local-only `provision → make-live` path. **Verdict legend:** ✅ already cortex-commands-only · ⚠️ tooled-but-doc-lag · ❌ genuine raw-`nsc` gap.
+
+| # | Onboarding action | What the operator runs today | Tooling status |
+|---|---|---|---|
+| 1 | Stand up the stack | `cortex stack create <slug> --apply` | ✅ cortex. Scaffolds the config-split YAML. **Note:** it does **not** emit a NATS server `.conf` — `system.yaml` only points `nats.url` at a bus the operator is expected to already run. |
+| 2 | Stack signing identity | `cortex provision-stack generate …` (or auto-provisioned by `arc upgrade`) | ✅ cortex |
+| 3 | **Bus → operator-mode** (§B0.1) | **Hand-edit `<slug>.conf`**: paste `operator:` JWT, `system_account:`, `resolver: MEMORY`, `resolver_preload { <acct>: <jwt> }` — classically produced by raw **`nsc generate config --mem-resolver --sys-account SYS --config-file`** | ❌ **THE GAP (cortex#1265).** No cortex/arc verb renders the **initial** operator-mode server config for a fresh bus. Every downstream tool *assumes it already exists* (see §3). |
+| 4a | Dedicated federation account | `cortex network provision <stack> --apply` (wraps `arc nats init-operator` + `add-account` ×2 + `add-federation-export`) | ⚠️ tooled. The SOP §4a "honest status" note still tells operators to run raw **`nsc add account <fed>`** by hand — that is **doc-lag**: `cortex network provision` (cortex#1139, `network-provision-lib.ts`) now mints the operator + federation + agents accounts via arc. Fix the SOP. |
+| 4b | Register identity | `cortex provision-stack register …` | ✅ cortex |
+| 5 | Roster admission (hub) | `cortex network admit …` | ✅ cortex |
+| 5b | Leaf secret (hub) | `cortex network secret add-member …` | ✅ cortex |
+| 6 | Join the network | `cortex network join <network> --apply` | ✅ cortex. O-3 (cortex#1053) **auto-renders** the §B0.1 operator-mode blocks via `renderOperatorModeBlocks` — *but only from JWTs supplied in config* (see §3, the linchpin). |
+| 7 | Verify | `cortex network status` / `curl` | ✅ |
+| 8 | Go private (encryption) | config edits only | ✅ config-only |
+| — | New-network bring-up (admin) | `cortex network create …` | ✅ cortex (#747) |
+| — | Registry admin bootstrap (one-time) | `wrangler secret put REGISTRY_ADMIN_PUBKEYS` + `wrangler deploy` | ✅ acceptable — one-time, not `nsc` |
+| — | Local-only daemon switch | `cortex network make-live <stack> --apply` | ⚠️ tooled **but refuses a non-operator-mode bus** — it only *appends* an account to an **existing** `resolver_preload`; it cannot bootstrap one. Hits the same §B0.1 gap (see §3). |
+
+**Conclusion of the audit:** there is exactly **one** genuine raw-`nsc` gap left in the cortex-commands-only vision — **row 3: generating the initial operator-mode server config for a brand-new bus.** Row 4a is doc-lag (already wrapped). Everything else is already cortex-only or acceptably one-time.
+
+---
+
+## 3. Where the gap actually lives — the linchpin (verified in code)
+
+The gap is **narrower than it looks**, because the *renderer already exists*. Three facts, each verified against source:
+
+1. **The blocks renderer exists.** `renderOperatorModeBlocks(currentConf, pkg)` (`src/common/nats/leaf-remote-renderer.ts:882`) takes an anonymous/empty `.conf` plus an `OperatorModeLeafPackage` `{ operatorJwt, account, accountJwt, systemAccount?, systemAccountJwt? }` and emits exactly the §B0.1 blocks (`operator:`, `system_account:`, `resolver: MEMORY`, `resolver_preload { … }`) while preserving the stack's own `server_name`/`listen`/`http`/`jetstream.domain`. It is idempotent (byte-stable on a converted bus) and is what `cortex network join`'s `convertToOperatorMode` already calls (`network-adapters.ts:563`).
+
+2. **The renderer is starved of inputs.** `cortex network join` builds the package **purely from config** — `stack.nats_infra.{operator_jwt, account_jwt, system_account, system_account_jwt}` (`network-derive.ts:441-460`). If those fields are absent, *no package materialises* and join falls back to the #794 fail-fast. **Nothing populates those four JWT fields.** `cortex network provision` writes back `account`, `agents_account`, `creds_path`, `nkey_seed_path` (`network-provision-adapters.ts:77-83`) — but **not** the operator/account/system **JWTs** the renderer consumes. provision even says so explicitly: *"the operator-mode `.conf` render + bus restart are LEFT TO JOIN … render-only here"* (`network-provision-lib.ts:18-20`).
+
+3. **`make-live` can only append, never bootstrap.** `makeLiveStack` refuses early if the bus has no `resolver_preload { }` block, pointing the operator at §B0.1 by hand (`network-make-live-lib.ts:271-282`). It *appends* an account JWT to an existing resolver (via `arc nats export-account`), it does not create the operator-mode skeleton.
+
+**So the gap is a JWT-export-and-populate bridge, not a new renderer.** Concretely, two half-steps nobody owns:
+
+- **(a) Export** the operator JWT + federation/agents account JWT + system-account JWT from the freshly-minted `nsc` store. `arc nats export-account` already exists (make-live uses it); **`arc nats export-operator` / `export-system` (operator JWT + SYS account JWT) may be an arc-side gap** — confirm / file an arc issue.
+- **(b) Populate** them — either straight into the stack's `<slug>.conf` (render the initial operator-mode skeleton) *or* into `stack.nats_infra.{operator_jwt, account_jwt, system_account, system_account_jwt}` so the **existing** O-3 join / make-live path renders the conf with zero new rendering code.
+
+The account-minting (`provision`) and the rendering (`renderOperatorModeBlocks`) both already exist. **The bridge between them is the whole of cortex#1265.**
+
+---
+
+## 4. The command-home decision — RECOMMENDATION + alternatives ⟵ SIGN-OFF NEEDED
+
+This is the decision that needs Andreas's sign-off before implementation.
+
+### Recommended — Option A: extend `cortex network provision` (export + populate)
+
+Add a JWT-export + populate phase to the existing `provision` pipeline (`network-provision-lib.ts`), as steps 7–8 after the account mint and the `nats_infra` write-back it already does:
+
+```
+provision (today):  init-operator → add-account(fed) → add-account(agents)
+                     → generate seed → wire federated.> → write nats_infra{account,agents,creds,seed}
+provision (+1265):   … → export operator/account/system JWTs (via arc)
+                        → write nats_infra{operator_jwt, account_jwt, system_account, system_account_jwt}
+```
+
+Provision **stays non-disruptive**: it writes only *config* (exactly as it does today), never the `.conf` and never restarts the bus. The existing O-3 join renderer (and, with a small extension, make-live) then has everything it needs — `cortex network join` converts the bus to operator-mode automatically, and the operator runs **zero `nsc`**.
+
+**Why A:**
+- Smallest diff that closes the gap. provision already holds the minted account pubkeys, the arc account-tree seam (`buildOperatorProvisioningAdapter`), and the config write-back adapter — adding JWT-export to the same fail-fast, ensure-shaped pipeline is a few steps, not a new command.
+- Single source of truth: the account tree, its pubkeys, and its JWTs all resolve in one place, in one idempotent pass.
+- Reuses `renderOperatorModeBlocks` wholesale — no new rendering code, no second place that knows the §B0.1 grammar.
+- Preserves provision's documented non-disruption invariant (writes config, not the live bus).
+
+**The one secondary sub-decision A forces (the local-only path):** a stack that **never federates** never runs `join`, and `make-live` today *refuses* a non-operator-mode bus. So for that path, either (A1) `provision` also renders the initial `.conf` directly (a `--render-conf` flag — provision crosses one step into touching the bus config, still no restart), or (A2) teach `make-live` to **bootstrap** (render-if-absent via `renderOperatorModeBlocks`) instead of only appending. **Sub-recommendation: A2** — it keeps provision config-only and makes "operator-mode bootstrap" a property of the daemon-switch step that already owns the resolver, with `renderOperatorModeBlocks` reused there too.
+
+### Alternative — Option B: fold into `cortex stack create`
+
+Reject. `stack create` is deliberately a **pure, offline, no-overwrite scaffold** that runs *before* the nsc tree exists (provision mints it later). It has no JWTs to render and no seed to shell to arc with. Folding account-minting + JWT-export into it would make a fast offline scaffold suddenly require arc/nsc and a seed, breaking its character and its idempotency guarantees.
+
+### Alternative — Option C: a new verb `cortex network init-bus` / `cortex stack ensure-bus`
+
+A dedicated verb that exports the JWTs and renders the operator-mode `.conf` (sibling to make-live's daemon-switch).
+
+- **Pro:** cleanest single-responsibility ("make this stack's bus operator-mode"); most self-documenting; mirrors the make-live pattern.
+- **Con:** adds a *fourth* verb to the `create → provision → make-live → join` sequence — directly against the audit's "fewer steps" thrust — and would re-export the same JWTs provision is already best placed to export. A new verb earns its keep only if we want the `.conf` render to be an explicit, separately-invocable act rather than a byproduct of provision. **Fallback if Andreas wants the render kept out of provision entirely.**
+
+### The decision, stated for sign-off
+
+> **PRIMARY:** Server-config (JWT-export + populate) lives in **`cortex network provision`** (Option A, recommended) — vs. a new **`cortex network init-bus`** verb (Option C). `cortex stack create` (Option B) is rejected.
+>
+> **SECONDARY (only under A):** the local-only / never-federates path renders its initial `.conf` via **make-live bootstrap (A2, recommended)** vs. a **`provision --render-conf` flag (A1)**.
+>
+> **DEPENDENCY to confirm:** `arc nats export-operator` / `export-system` (operator JWT + SYS account JWT). `export-account` exists; the other two may need an arc verb — confirm or file an arc issue before implementation.
+
+---
+
+## 5. Sketch of the wrapper interface (NOT to be built yet)
+
+Illustrative only — to make the recommendation concrete. Under Option A the new seam is an **export port** alongside the existing `OperatorProvisioningPort`, shelling to arc (cortex never runs `nsc`):
+
+```ts
+/** Export operator-mode JWTs from the nsc store (cortex never runs nsc — arc owns it). */
+export interface OperatorModeExportPort {
+  /** `arc nats export-operator --json` → operator JWT (+ derived SYS account). */
+  exportOperator(): Promise<{ ok: true; operatorJwt: string } | { ok: false; reason: string }>;
+  /** `arc nats export-account <name> --json` → account pubkey + JWT (exists today). */
+  exportAccount(name: string): Promise<{ ok: true; pubKey: string; jwt: string } | { ok: false; reason: string }>;
+  /** `arc nats export-system --json` → SYS account pubkey + JWT (for system_account). */
+  exportSystem(): Promise<{ ok: true; pubKey: string; jwt: string } | { ok: false; reason: string }>;
+}
+```
+
+provision's config write-back (`ProvisionConfigWritePort.write`) gains four optional fields: `operatorJwt`, `accountJwt`, `systemAccount`, `systemAccountJwt`, persisted under `stack.nats_infra.*`. **Idempotency:** ensure-shaped like the rest of provision — present in config ⇒ no-op; absent ⇒ export + write. **No `--apply` mutation of the live bus** (config-only). The actual `.conf` render stays in `renderOperatorModeBlocks`, invoked by join (federated) or make-live-bootstrap (local-only).
+
+**Cases to honor (call out at implementation time, not now):**
+- **operator-mode** (the target): export the three JWTs, populate config, let join/make-live render.
+- **MEMORY resolver** specifically (not a full NATS account-server resolver): the existing renderer emits `resolver: MEMORY` + `resolver_preload` — the same shape `make-live` appends to. Keep them grammar-compatible (one renderer).
+- **already operator-mode** (established stack): export is a no-op if config already carries the JWTs — never clobber a hand-tuned `.conf`.
+
+---
+
+## 6. Layer-split check (CLAUDE.md / federation-wire-protocol SOP)
+
+This stays inside the established split: **cortex (M7) orchestrates; arc owns the `nsc` boundary.** cortex shells to `arc nats export-*` and renders config text — it **never runs `nsc`** (ADR-0013 invariant, the same precedent as `cortex creds issue → arc nats add-bot` and provision's `init-operator`/`add-account`). No `federated.*` envelope is emitted, routed, or consumed by this tooling, so the wire-protocol 5-check is **not** triggered (consistent with the audit's G1–G5 scoping). No network id ever goes on the wire.
+
+---
+
+## 7. Cross-references
+
+- [`design-onboarding-tooling-audit.md`](./design-onboarding-tooling-audit.md) — the G1–G5 audit this extends (server-config is the un-named residue of G1/G5)
+- [`sop-onboard-peer-principal.md`](./sop-onboard-peer-principal.md) — the consolidated runbook whose §B0.1 deferral is the gap; **§4a doc-lag** to fix (provision already wraps account creation)
+- [`sop-stack-onboarding.md §B0.1`](./sop-stack-onboarding.md) — the hand-edit this would replace
+- [`design-make-live-daemon-switch.md`](./design-make-live-daemon-switch.md) — the sibling daemon-switch (the A2 bootstrap would extend it)
+- [ADR-0013](./adr/0013-sovereign-federation-model.md) · [ADR-0012](./adr/0012-external-operator-account-isolation.md) — sovereign Model B + account isolation
+- **Code:** `network-provision-lib.ts` (extend) · `leaf-remote-renderer.ts:882` (`renderOperatorModeBlocks`, reuse) · `network-derive.ts:441` (the config fields to populate) · `network-make-live-lib.ts:271` (the bootstrap refusal A2 would relax)
+- **Issues:** cortex#1265 (this) · cortex#1262 (parent) · cortex#1139 (provision/G1d) · cortex#1053 (O-3 join conversion)

--- a/docs/sop-onboard-peer-principal.md
+++ b/docs/sop-onboard-peer-principal.md
@@ -46,25 +46,30 @@ This prints your `nkey_pub` (`U…`, 56 chars). Keep the seed chmod 600 — it i
 
 ### Step 3 — Ensure your bus is operator-mode
 
-Your stack's local NATS bus must be **operator-mode** (it must define your NSC operator, the system account, and the resolver preload including the federation account) before it can bind a leaf link to an operator-mode hub. A hard-isolated anonymous bus (no NSC operator, no accounts) cannot federate.
+Your stack's local NATS bus must be **operator-mode** (it must define your NSC operator, optionally the system account, and the resolver preload including the federation account) before it can bind a leaf link to an operator-mode hub. A hard-isolated anonymous bus (no NSC operator, no accounts) cannot federate.
 
-> **What operator-mode means here.** Your bus config must include the NSC operator JWT, `system_account`, `resolver: MEMORY`, and `resolver_preload` containing both your agents account and your system account. Mirror the four blocks from your existing operator-mode bus conf if you have one (e.g. `~/.config/nats/local.conf`). Keep your stack's own `server_name`, `listen` port, `jetstream.domain`, and `http` monitor port — do not copy the meta-factory leaf include, `cortex network join` renders its own leaf include for your stack.
+> **What operator-mode means here.** Your bus config must include the NSC operator JWT, optionally `system_account`, `resolver: MEMORY`, and `resolver_preload` containing your federation account (and, once landed, your agents account). Keep your stack's own `server_name`, `listen` port, `jetstream.domain`, and `http` monitor port — `cortex network join` renders its own leaf include for your stack.
 
-If your stack is already on an operator-mode bus (most established stacks are), skip to step 4.
+**You no longer hand-edit this (cortex#1265).** `cortex network provision` (step 4a) now **exports the operator-mode JWTs** — operator + federation account (+ SYS account, when present) — into `stack.nats_infra.{operator_jwt, account_jwt, system_account, system_account_jwt}`. From there the conversion is automatic and command-only:
 
-> **Converting a hard-isolated stack.** Edit `~/.config/nats/<slug>.conf` to add the operator-mode blocks, restart the bus, then continue. See [`sop-stack-onboarding.md §B0.1`](./sop-stack-onboarding.md#b01--the-bus-must-be-operator-mode-the-794-lesson) for the full procedure.
+- **Federating stack →** `cortex network join` (step 6) reads those fields and **renders the operator-mode `.conf` for you** (O-3 conversion). You run **zero `nsc generate config`**.
+- **Local-only stack (never federates) →** `cortex network make-live <slug> --apply` **bootstraps** the initial operator-mode resolver from the same JWTs (and lands the daemon on its agents account). Again, no raw `nsc`.
 
-### Step 4a — Create your dedicated federation account
+If your stack is already on an operator-mode bus (most established stacks are), nothing to do — both paths are idempotent and never clobber a hand-tuned `.conf`.
 
-Your stack needs a **dedicated federation account** under your NSC operator — separate from your agents account so federation traffic is blast-radius-isolated from internal work. This is the last-mile provisioning step (G1d):
+> **Manual fallback only.** The hand-edit in [`sop-stack-onboarding.md §B0.1`](./sop-stack-onboarding.md#b01--the-bus-must-be-operator-mode-the-794-lesson) is now a last-resort fallback, not the happy path — prefer `cortex network provision` + `join`/`make-live`.
+
+### Step 4a — Mint your account tree (one command)
+
+Stand up your sovereign account tree — your NSC operator, a **dedicated federation account** (separate from your agents account so federation traffic is blast-radius-isolated from internal work), the per-stack agents account, the `federated.>` export/import wiring, and the **operator-mode JWT export** (cortex#1265) — in a single command:
 
 ```bash
-arc nats add-federation-export --account <federation-account-name> --stack <principal>/<slug>
+cortex network provision <principal>/<slug> --apply
 ```
 
-> **Honest status (as of G5).** G1d (the dedicated-account provisioning primitive) emits a WARN no-op today — the `arc nats add-federation-export` command provisions the export/import wiring but the automated account-creation path is still the last-mile. If your NSC operator does not yet have a dedicated federation account, you create it once with `nsc add account <federation-account-name>` before running the arc command. This step becomes fully one-command when G1d ships.
+> **Status (G1d + cortex#1265).** This wraps `arc nats init-operator` + `add-account` (federation + agents) + `add-federation-export` + `export-{operator,account,system}`. It is **non-disruptive** — it writes only config (the account pubkeys AND the operator-mode JWTs into `stack.nats_infra`), never the `.conf` and never restarts the bus. The raw `nsc add account` / `nsc generate config` steps this SOP used to teach are gone; provision now covers account creation and the JWT export wholesale. Dry-run by default; pass `--apply` to mint.
 
-Add the federation account's NKey (`A…`) to your stack config under `stack.nats_infra.account`.
+`cortex network provision` writes the federation account's NKey (`A…`) to `stack.nats_infra.account` and the operator-mode JWTs alongside it — no manual edit required.
 
 ### Step 4b — Register your stack identity with the network registry
 

--- a/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
@@ -91,6 +91,7 @@ function fakeFactory(): { factory: MakeLivePortsFactory; calls: string[]; mutate
         hasAccount: () => false,
         hasResolverPreload: () => true, // M3 — operator-mode bus (fake)
         appendAccount: () => { calls.push("resolver-append"); return { ok: true, changed: true }; },
+        bootstrapOperatorMode: () => { calls.push("bootstrap"); return { ok: true, changed: true }; },
       },
       restart: {
         resolveTargets: () => ({ natsDescriptor: "/LA/nats.plist", daemonDescriptor: "/LA/cortex.plist" }),

--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -10,7 +10,7 @@
  * nats BEFORE the daemon), idempotent re-runs, and that the orchestrator never
  * touches the stack config (so encryption / federated config survives).
  */
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 
 import {
   makeLiveStack,
@@ -19,8 +19,11 @@ import {
   type MakeLivePorts,
   type MakeLiveState,
 } from "../network-make-live-lib";
-import { insertIntoResolverPreload, findNatsServerDescriptor } from "../network-make-live-adapters";
+import { insertIntoResolverPreload, findNatsServerDescriptor, buildResolverPreloadAdapter } from "../network-make-live-adapters";
 import type { DaemonLocatorIO } from "../daemon-locator";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 const AGENTS_PUB = "A" + "R".repeat(55);
 const AGENTS_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBQVJSIn0.sig";
@@ -50,6 +53,10 @@ function makePorts(over?: {
   hasResolverPreload?: boolean;
   /** Whether the append actually mutates (changed). Default true. */
   appendChanged?: boolean;
+  /** cortex#1265 — whether bootstrapOperatorMode reports a change. Default true. */
+  bootstrapChanged?: boolean;
+  /** cortex#1265 — make bootstrapOperatorMode fail (refuse/error). */
+  bootstrapFails?: boolean;
   /** BLOCK 3 — pubkey the export port returns (default the matching AGENTS_PUB). */
   exportPubKey?: string;
   /** BLOCK 2 — descriptors resolveTargets returns. */
@@ -80,6 +87,11 @@ function makePorts(over?: {
       appendAccount: ({ accountPubkey }) => {
         calls.push(`resolver-append:${accountPubkey}`);
         return { ok: true, changed: over?.appendChanged ?? true };
+      },
+      bootstrapOperatorMode: ({ natsConfigPath }) => {
+        calls.push(`bootstrap:${natsConfigPath}`);
+        if (over?.bootstrapFails) return { ok: false, reason: "operator-mode under a different operator" };
+        return { ok: true, changed: over?.bootstrapChanged ?? true };
       },
     },
     restart: {
@@ -204,6 +216,66 @@ describe("makeLiveStack — apply", () => {
     expect(calls).toEqual([]);
   });
 
+  // cortex#1265 — operator-mode bootstrap (local-only path) ─────────────────────
+  const FAKE_PKG = {
+    operatorJwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJPQUZBS0UifQ.sig",
+    account: "A" + "F".repeat(55),
+    accountJwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBRkVEIn0.sig",
+  };
+
+  test("bootstrap: no resolver_preload BUT package present → bootstrap → append → restart", async () => {
+    const { ports, calls } = makePorts({ hasResolverPreload: false });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: false, resolverHasAccount: false }, { operatorModePackage: FAKE_PKG }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(true);
+    // Bootstrap FIRST (creates the resolver_preload), then the agents append, then
+    // a SINGLE nats restart, then creds mint, then daemon restart.
+    expect(calls).toEqual([
+      `bootstrap:~/.config/nats/local.conf`,
+      `export:ANDREAS_WORK_AGENTS`,
+      `resolver-append:${AGENTS_PUB}`,
+      "restart-nats",
+      `mint:cortex-work@ANDREAS_WORK_AGENTS->~/.config/nats/cortex-work.creds`,
+      "restart-daemon",
+    ]);
+    expect(res.steps.join("\n")).toContain("operator-mode bootstrap");
+  });
+
+  test("bootstrap: a refuse (different operator) aborts before any append/restart", async () => {
+    const { ports, calls } = makePorts({ hasResolverPreload: false, bootstrapFails: true });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: false, resolverHasAccount: false }, { operatorModePackage: FAKE_PKG }),
+      ports,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("operator-mode bootstrap failed");
+    expect(calls).toEqual([`bootstrap:~/.config/nats/local.conf`]); // nothing after
+  });
+
+  test("bootstrap: the plan shows the bootstrap step in dry-run", async () => {
+    const { ports, calls } = makePorts({ hasResolverPreload: false });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: false, resolverHasAccount: false }, { apply: false, operatorModePackage: FAKE_PKG }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(false);
+    expect(res.steps.join("\n")).toContain("operator-mode bootstrap");
+    expect(calls).toEqual([]); // dry-run mutates nothing
+  });
+
+  test("bootstrap: refuses when NO package AND no resolver_preload (the #794 floor)", async () => {
+    const { ports, calls } = makePorts({ hasResolverPreload: false });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: false, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("no operator-mode JWTs");
+    expect(res.reason).toContain("provision");
+    expect(calls).toEqual([]);
+  });
+
   // BLOCK 3 — pubkey drift cross-check ─────────────────────────────────────────
   test("BLOCK 3: export-account pubkey ≠ config pubkey aborts before resolver write", async () => {
     const driftKey = "A" + "Q".repeat(55);
@@ -289,6 +361,60 @@ describe("insertIntoResolverPreload", () => {
 
   test("returns null when there is no resolver_preload block", () => {
     expect(insertIntoResolverPreload("listen: 127.0.0.1:4222\n", "x")).toBeNull();
+  });
+});
+
+// ── cortex#1265 — bootstrapOperatorMode adapter (real renderOperatorModeBlocks) ─
+
+describe("buildResolverPreloadAdapter — bootstrapOperatorMode (cortex#1265)", () => {
+  const PKG = {
+    operatorJwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJPUCJ9.sig",
+    account: "A" + "F".repeat(55),
+    accountJwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBRkVEIn0.sig",
+  };
+  // A plain bus config: server identity, NO operator-mode blocks.
+  const BASE_CONF = ['server_name: "research"', 'listen: "127.0.0.1:4222"', 'http: "127.0.0.1:8222"'].join("\n") + "\n";
+
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cortex-bootstrap-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("renders operator + resolver_preload (federation account), KEEPING server identity", () => {
+    const path = join(dir, "research.conf");
+    writeFileSync(path, BASE_CONF, "utf-8");
+    const adapter = buildResolverPreloadAdapter();
+
+    const r = adapter.bootstrapOperatorMode({ natsConfigPath: path, package: PKG });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.changed).toBe(true);
+
+    const out = readFileSync(path, "utf-8");
+    // operator-mode blocks rendered…
+    expect(out).toContain("operator: " + PKG.operatorJwt);
+    expect(out).toContain("resolver: MEMORY");
+    expect(out).toContain(`${PKG.account}: ${PKG.accountJwt}`);
+    // …and the bus's own identity preserved verbatim.
+    expect(out).toContain('server_name: "research"');
+    expect(out).toContain('listen: "127.0.0.1:4222"');
+    // The probe now reports operator-mode (so the append step finds the block).
+    expect(adapter.hasResolverPreload(path)).toBe(true);
+  });
+
+  test("idempotent: a second bootstrap on the converted bus is a no-op (changed:false)", () => {
+    const path = join(dir, "research.conf");
+    writeFileSync(path, BASE_CONF, "utf-8");
+    const adapter = buildResolverPreloadAdapter();
+    adapter.bootstrapOperatorMode({ natsConfigPath: path, package: PKG });
+    const second = adapter.bootstrapOperatorMode({ natsConfigPath: path, package: PKG });
+    expect(second.ok).toBe(true);
+    if (second.ok) expect(second.changed).toBe(false);
+  });
+
+  test("refuses when the base config file is absent (never fabricate server identity)", () => {
+    const adapter = buildResolverPreloadAdapter();
+    const r = adapter.bootstrapOperatorMode({ natsConfigPath: join(dir, "missing.conf"), package: PKG });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("not found");
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-provision-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-provision-adapters.test.ts
@@ -12,7 +12,10 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { buildSigningIdentityAdapter } from "../network-provision-adapters";
+import { readFileSync, writeFileSync } from "fs";
+import { parseDocument } from "yaml";
+
+import { buildSigningIdentityAdapter, buildProvisionConfigWriteAdapter } from "../network-provision-adapters";
 
 describe("buildSigningIdentityAdapter — live, tilde expansion (cortex#1236)", () => {
   let home: string;
@@ -66,5 +69,71 @@ describe("buildSigningIdentityAdapter — live, tilde expansion (cortex#1236)", 
     // again → no O_EXCL EEXIST. The divergence this asserts against is the
     // cortex#1236 bug (probe expanded, write literal `~`).
     expect(adapter.exists(RAW_SEED)).toBe(true);
+  });
+});
+
+// cortex#1265 — the config write-back persists the operator-mode JWTs.
+describe("buildProvisionConfigWriteAdapter — operator-mode JWT write-back (cortex#1265)", () => {
+  let dir: string;
+  const FED = "A" + "B".repeat(55);
+  const AGENTS = "A" + "C".repeat(55);
+  const SYS = "A" + "S".repeat(55);
+  const OP_JWT = "eyJ.op.sig";
+  const FED_JWT = "eyJ.fed.sig";
+  const SYS_JWT = "eyJ.sys.sig";
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "cortex-provision-cfg-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("writes operator_jwt/account_jwt/system_account[_jwt] under stack.nats_infra", () => {
+    const path = join(dir, "research.yaml");
+    writeFileSync(path, "stack:\n  id: andreas/research\n", "utf-8");
+    const adapter = buildProvisionConfigWriteAdapter(path);
+
+    const r = adapter.write({
+      account: FED,
+      agentsAccount: AGENTS,
+      credsPath: "~/.config/nats/research.creds",
+      seedPath: "~/.config/nats/andreas-research.seed",
+      operatorJwt: OP_JWT,
+      accountJwt: FED_JWT,
+      systemAccount: SYS,
+      systemAccountJwt: SYS_JWT,
+    });
+    expect(r.ok).toBe(true);
+
+    const doc = parseDocument(readFileSync(path, "utf-8"));
+    expect(doc.getIn(["stack", "nats_infra", "operator_jwt"])).toBe(OP_JWT);
+    expect(doc.getIn(["stack", "nats_infra", "account_jwt"])).toBe(FED_JWT);
+    expect(doc.getIn(["stack", "nats_infra", "system_account"])).toBe(SYS);
+    expect(doc.getIn(["stack", "nats_infra", "system_account_jwt"])).toBe(SYS_JWT);
+    // The pre-existing account-tree fields are written too.
+    expect(doc.getIn(["stack", "nats_infra", "account"])).toBe(FED);
+  });
+
+  test("omitted JWT fields are NOT written (never clobber a hand-tuned value)", () => {
+    const path = join(dir, "research.yaml");
+    writeFileSync(path, "stack:\n  id: andreas/research\n  nats_infra:\n    system_account: AKEEPME\n", "utf-8");
+    const adapter = buildProvisionConfigWriteAdapter(path);
+
+    // No system fields passed (SYS absent) — the existing system_account survives.
+    adapter.write({
+      account: FED,
+      agentsAccount: AGENTS,
+      credsPath: "~/c.creds",
+      seedPath: "~/s.seed",
+      operatorJwt: OP_JWT,
+      accountJwt: FED_JWT,
+    });
+
+    const doc = parseDocument(readFileSync(path, "utf-8"));
+    expect(doc.getIn(["stack", "nats_infra", "operator_jwt"])).toBe(OP_JWT);
+    // The pre-existing system_account was NOT clobbered.
+    expect(doc.getIn(["stack", "nats_infra", "system_account"])).toBe("AKEEPME");
+    expect(doc.getIn(["stack", "nats_infra", "system_account_jwt"])).toBeUndefined();
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-provision-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-provision-cli.test.ts
@@ -72,6 +72,11 @@ function fakeFactory(): { factory: ProvisionPortsFactory; calls: string[]; write
       federationWiring,
       signing: { exists: () => false, generate: () => { calls.push("signing"); return { ok: true, nkeyPub: "U" + "Z".repeat(55), fingerprint: "fp" }; } },
       configWrite: { write: () => { calls.push("config-write"); return { ok: true }; } },
+      export: {
+        exportOperator: async ({ name }) => { calls.push(`export-operator:${name}`); return { ok: true, operatorJwt: "eyJ.op.sig", pubKey: "OD4D" }; },
+        exportAccount: async (name) => { calls.push(`export-account:${name}`); return { ok: true, pubKey: FED_PUB, jwt: "eyJ.fed.sig" }; },
+        exportSystem: async ({ name }) => { calls.push(`export-system:${name}`); return { ok: false, reason: "no SYS", notFound: true }; },
+      },
     };
     return ports;
   };
@@ -128,6 +133,10 @@ describe("cortex network provision — apply", () => {
       "add-account:ANDREAS_RESEARCH_AGENTS",
       "signing",
       "wire",
+      // cortex#1265 — the operator-mode JWT export bridges wiring → config write.
+      "export-operator:OP_ANDREAS",
+      "export-account:ANDREAS_RESEARCH_FED",
+      "export-system:SYS",
       "config-write",
     ]);
   });

--- a/src/cli/cortex/commands/__tests__/network-provision-integration.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-provision-integration.test.ts
@@ -94,9 +94,15 @@ function buildPorts(runner: ArcFederationRunner): { ports: ProvisionPorts; writt
   const configWrite: ProvisionConfigWritePort = {
     write: (fields) => { written.push(fields); return { ok: true }; },
   };
+  // cortex#1265 — a fake export port (the export-arc seam is unit-tested separately).
+  const exportPort = {
+    exportOperator: async () => ({ ok: true as const, operatorJwt: "eyJ.op.sig", pubKey: "OD4D" }),
+    exportAccount: async () => ({ ok: true as const, pubKey: FED_PUB, jwt: "eyJ.fed.sig" }),
+    exportSystem: async () => ({ ok: false as const, reason: "no SYS", notFound: true }),
+  };
   // The REAL wiring adapter — only the arc subprocess runner is swapped.
   const federationWiring = buildFederationWiringAdapter(runner);
-  return { ports: { operator, signing, federationWiring, configWrite }, written };
+  return { ports: { operator, signing, federationWiring, configWrite, export: exportPort }, written };
 }
 
 function inputs(): ProvisionInputs {
@@ -107,11 +113,12 @@ function inputs(): ProvisionInputs {
     operatorName: "OP_ANDREAS",
     federationAccountName: "ANDREAS_WORK_FED",
     agentsAccountName: "ANDREAS_WORK_AGENTS",
+    systemAccountName: "SYS",
     seedPath: "~/.config/nats/cortex-work.nk",
     credsPath: "~/.config/nats/work.creds",
     force: false,
     apply: true,
-    state: { federationAccount: undefined, agentsAccount: undefined, signingSeedExists: false },
+    state: { federationAccount: undefined, agentsAccount: undefined, signingSeedExists: false, operatorModeJwtsPresent: false },
   };
 }
 

--- a/src/cli/cortex/commands/__tests__/network-provision-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-provision-lib.test.ts
@@ -16,10 +16,15 @@ import {
   type ProvisionState,
   type SigningIdentityPort,
   type ProvisionConfigWritePort,
+  type OperatorModeExportPort,
 } from "../network-provision-lib";
 
 const FED_PUB = "A" + "B".repeat(55);
 const AGENTS_PUB = "A" + "C".repeat(55);
+const SYS_PUB = "A" + "S".repeat(55);
+const OP_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJPUCJ9.sig";
+const FED_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBRkVEIn0.sig";
+const SYS_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBU1lTIn0.sig";
 
 /** Spy ports recording every effectful call in order. */
 function makePorts(overrides?: {
@@ -27,9 +32,12 @@ function makePorts(overrides?: {
   signing?: Partial<SigningIdentityPort>;
   federationWiring?: Partial<FederationWiringPort>;
   configWrite?: Partial<ProvisionConfigWritePort>;
-}): { ports: ProvisionPorts; calls: string[]; written: unknown[] } {
+  export?: Partial<OperatorModeExportPort>;
+  /** cortex#1265 — make exportSystem report the SYS account absent (a clean skip). */
+  systemAbsent?: boolean;
+}): { ports: ProvisionPorts; calls: string[]; written: Record<string, unknown>[] } {
   const calls: string[] = [];
-  const written: unknown[] = [];
+  const written: Record<string, unknown>[] = [];
 
   const operator: OperatorProvisioningPort = {
     initOperator: async ({ name, force }) => {
@@ -70,7 +78,24 @@ function makePorts(overrides?: {
     ...overrides?.configWrite,
   };
 
-  return { ports: { operator, signing, federationWiring, configWrite }, calls, written };
+  const exportPort: OperatorModeExportPort = {
+    exportOperator: async ({ name }) => {
+      calls.push(`export-operator:${name}`);
+      return { ok: true, operatorJwt: OP_JWT, pubKey: "OD4D" };
+    },
+    exportAccount: async (name) => {
+      calls.push(`export-account:${name}`);
+      return { ok: true, pubKey: FED_PUB, jwt: FED_JWT };
+    },
+    exportSystem: async ({ name }) => {
+      calls.push(`export-system:${name}`);
+      if (overrides?.systemAbsent) return { ok: false, reason: "no SYS", notFound: true };
+      return { ok: true, pubKey: SYS_PUB, jwt: SYS_JWT };
+    },
+    ...overrides?.export,
+  };
+
+  return { ports: { operator, signing, federationWiring, configWrite, export: exportPort }, calls, written };
 }
 
 function baseInputs(over?: Partial<ProvisionInputs>, state?: Partial<ProvisionState>): ProvisionInputs {
@@ -81,11 +106,18 @@ function baseInputs(over?: Partial<ProvisionInputs>, state?: Partial<ProvisionSt
     operatorName: "OP_ANDREAS",
     federationAccountName: "ANDREAS_RESEARCH_FED",
     agentsAccountName: "ANDREAS_RESEARCH_AGENTS",
+    systemAccountName: "SYS",
     seedPath: "~/.config/nats/andreas-research.seed",
     credsPath: "~/.config/nats/research.creds",
     force: false,
     apply: false,
-    state: { federationAccount: undefined, agentsAccount: undefined, signingSeedExists: false, ...state },
+    state: {
+      federationAccount: undefined,
+      agentsAccount: undefined,
+      signingSeedExists: false,
+      operatorModeJwtsPresent: false,
+      ...state,
+    },
     ...over,
   };
 }
@@ -182,10 +214,22 @@ describe("provisionStack — apply on an empty stack", () => {
       "add-account:ANDREAS_RESEARCH_AGENTS",
       "signing-generate:~/.config/nats/andreas-research.seed",
       `wire:${FED_PUB}->${AGENTS_PUB}:apply`,
+      // cortex#1265 — the JWT export bridges wiring → config write-back.
+      "export-operator:OP_ANDREAS",
+      "export-account:ANDREAS_RESEARCH_FED",
+      "export-system:SYS",
       "config-write",
     ]);
-    // Config write-back carries the minted (distinct) account pubkeys.
-    expect(written[0]).toMatchObject({ account: FED_PUB, agentsAccount: AGENTS_PUB });
+    // Config write-back carries the minted (distinct) account pubkeys + the
+    // operator-mode JWTs the O-3 join renderer reads (cortex#1265).
+    expect(written[0]).toMatchObject({
+      account: FED_PUB,
+      agentsAccount: AGENTS_PUB,
+      operatorJwt: OP_JWT,
+      accountJwt: FED_JWT,
+      systemAccount: SYS_PUB,
+      systemAccountJwt: SYS_JWT,
+    });
     expect(res.resolved?.account).toBe(FED_PUB);
     expect(res.resolved?.agentsAccount).toBe(AGENTS_PUB);
   });
@@ -236,6 +280,94 @@ describe("provisionStack — no-clobber & force", () => {
     expect(res.ok).toBe(true);
     expect(calls).toContain("init-operator:OP_ANDREAS:force");
     expect(calls.some((c) => c.startsWith("signing-generate:") && c.endsWith(":force"))).toBe(true);
+  });
+});
+
+describe("provisionStack — cortex#1265 operator-mode JWT export", () => {
+  test("exports operator + federation + system JWTs and writes them to config", async () => {
+    const { ports, calls, written } = makePorts();
+    const res = await provisionStack(baseInputs({ apply: true }), ports);
+    expect(res.ok).toBe(true);
+    expect(calls).toContain("export-operator:OP_ANDREAS");
+    expect(calls).toContain("export-account:ANDREAS_RESEARCH_FED");
+    expect(calls).toContain("export-system:SYS");
+    expect(written[0]).toMatchObject({
+      operatorJwt: OP_JWT,
+      accountJwt: FED_JWT,
+      systemAccount: SYS_PUB,
+      systemAccountJwt: SYS_JWT,
+    });
+  });
+
+  test("an ABSENT SYS account is a clean skip — operator+account still written", async () => {
+    const { ports, calls, written } = makePorts({ systemAbsent: true });
+    const res = await provisionStack(baseInputs({ apply: true }), ports);
+    expect(res.ok).toBe(true);
+    expect(calls).toContain("export-system:SYS");
+    expect(written[0]).toMatchObject({ operatorJwt: OP_JWT, accountJwt: FED_JWT });
+    // system fields omitted (not clobbered) when SYS is absent.
+    expect(written[0]?.systemAccount).toBeUndefined();
+    expect(written[0]?.systemAccountJwt).toBeUndefined();
+    expect(res.steps.join("\n")).toContain("system_account skipped");
+  });
+
+  test("idempotent: JWTs already in config → NO export calls (ensure-shaped)", async () => {
+    const { ports, calls } = makePorts();
+    const res = await provisionStack(
+      baseInputs(
+        { apply: true },
+        { federationAccount: FED_PUB, agentsAccount: AGENTS_PUB, signingSeedExists: true, operatorModeJwtsPresent: true },
+      ),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(calls.some((c) => c.startsWith("export-"))).toBe(false);
+    expect(res.steps.join("\n")).toContain("operator-mode JWTs present in config (untouched)");
+  });
+
+  test("--force re-exports the JWTs even when already present", async () => {
+    const { ports, calls } = makePorts();
+    const res = await provisionStack(
+      baseInputs(
+        { apply: true, force: true },
+        { federationAccount: FED_PUB, agentsAccount: AGENTS_PUB, signingSeedExists: true, operatorModeJwtsPresent: true },
+      ),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(calls).toContain("export-operator:OP_ANDREAS");
+  });
+
+  test("an export-operator failure aborts BEFORE the config write", async () => {
+    const { ports, calls } = makePorts({
+      export: {
+        exportOperator: async () => ({ ok: false, reason: "arc dependency unmet" }),
+      },
+    });
+    const res = await provisionStack(baseInputs({ apply: true }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("export-operator");
+    expect(calls).not.toContain("config-write");
+  });
+
+  test("account pubkey drift (export ≠ minted) aborts before config write", async () => {
+    const driftPub = "A" + "Q".repeat(55);
+    const { ports, calls } = makePorts({
+      export: {
+        exportAccount: async () => ({ ok: true, pubKey: driftPub, jwt: FED_JWT }),
+      },
+    });
+    const res = await provisionStack(baseInputs({ apply: true }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("pubkey drift");
+    expect(calls).not.toContain("config-write");
+  });
+
+  test("dry-run shows the operator-mode JWT export step in the plan", async () => {
+    const { ports } = makePorts();
+    const res = await provisionStack(baseInputs({ apply: false }), ports);
+    expect(res.ok).toBe(true);
+    expect(res.steps.join("\n")).toContain("operator-mode JWTs export");
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/operator-mode-export.test.ts
+++ b/src/cli/cortex/commands/__tests__/operator-mode-export.test.ts
@@ -1,0 +1,117 @@
+/**
+ * cortex#1265 — tests for the {@link OperatorModeExportPort} arc-shell adapter
+ * (the server-config bridge: export the operator-mode JWTs so provision can
+ * populate `stack.nats_infra`). Only the arc SUBPROCESS runner is swapped — for a
+ * faithful contract harness that emulates arc's REAL `nats export-*` CLI: it
+ * pins the argv cortex emits AND the `arc.nats.operator.v1` envelope it demands
+ * back (the anti-rot guard, sibling of the #1225 provision-integration test).
+ */
+import { describe, test, expect } from "bun:test";
+
+import { buildOperatorModeExportAdapter, type ArcExportRunner } from "../operator-mode-export";
+
+const OP_PUB = "O" + "D".repeat(55);
+const FED_PUB = "A" + "F".repeat(55);
+const SYS_PUB = "A" + "S".repeat(55);
+const OP_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJPUCJ9.sig";
+const FED_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBRkVEIn0.sig";
+const SYS_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBU1lTIn0.sig";
+
+const SCHEMA = "arc.nats.operator.v1";
+
+/**
+ * Faithful arc-CLI contract harness. Emulates arc's REAL `nats export-{operator,
+ * account,system}` verbs + the `arc.nats.operator.v1` envelope. `record` captures
+ * the argv. `sysAbsent` makes export-system return SYSTEM_ACCOUNT_NOT_FOUND.
+ */
+function arcContractRunner(record: string[][], opts?: { sysAbsent?: boolean }): ArcExportRunner {
+  return async (argv) => {
+    record.push([...argv]);
+    const json = (env: object) => ({ stdout: JSON.stringify(env) + "\n", stderr: "", exitCode: 0 });
+    const err = (code: string, message: string) => ({
+      stdout: JSON.stringify({ schema: SCHEMA, ok: false, error: { code, message } }) + "\n",
+      stderr: "",
+      exitCode: 1,
+    });
+    if (argv[0] !== "nats") return { stdout: "", stderr: "unknown command", exitCode: 1 };
+    switch (argv[1]) {
+      case "export-operator":
+        return json({ schema: SCHEMA, ok: true, operator: argv[argv.indexOf("--name") + 1], pubKey: OP_PUB, jwt: OP_JWT, seedPath: null });
+      case "export-account":
+        return json({ schema: SCHEMA, ok: true, account: argv[2], pubKey: FED_PUB, jwt: FED_JWT, seedPath: null });
+      case "export-system":
+        if (opts?.sysAbsent) return err("SYSTEM_ACCOUNT_NOT_FOUND", "system account \"SYS\" not found");
+        return json({ schema: SCHEMA, ok: true, account: argv[argv.indexOf("--name") + 1], pubKey: SYS_PUB, jwt: SYS_JWT, seedPath: null });
+      default:
+        return { stdout: "", stderr: `unknown command: ${argv.join(" ")}`, exitCode: 1 };
+    }
+  };
+}
+
+describe("operator-mode-export adapter — faithful arc contract", () => {
+  test("exportOperator emits `nats export-operator --name <op> --json` and parses the JWT", async () => {
+    const record: string[][] = [];
+    const adapter = buildOperatorModeExportAdapter(arcContractRunner(record));
+    const r = await adapter.exportOperator({ name: "OP_ANDREAS" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.operatorJwt).toBe(OP_JWT);
+      expect(r.pubKey).toBe(OP_PUB);
+    }
+    const argv = record.find((a) => a[1] === "export-operator");
+    expect(argv).toEqual(["nats", "export-operator", "--name", "OP_ANDREAS", "--json"]);
+  });
+
+  test("exportAccount emits `nats export-account <name> --json` and parses the JWT", async () => {
+    const record: string[][] = [];
+    const adapter = buildOperatorModeExportAdapter(arcContractRunner(record));
+    const r = await adapter.exportAccount("ANDREAS_WORK_FED");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.jwt).toBe(FED_JWT);
+      expect(r.pubKey).toBe(FED_PUB);
+    }
+    expect(record.find((a) => a[1] === "export-account")).toEqual(["nats", "export-account", "ANDREAS_WORK_FED", "--json"]);
+  });
+
+  test("exportSystem returns the SYS account when present", async () => {
+    const adapter = buildOperatorModeExportAdapter(arcContractRunner([]));
+    const r = await adapter.exportSystem({ name: "SYS" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.pubKey).toBe(SYS_PUB);
+      expect(r.jwt).toBe(SYS_JWT);
+    }
+  });
+
+  test("exportSystem maps SYSTEM_ACCOUNT_NOT_FOUND to notFound:true (the skip signal)", async () => {
+    const adapter = buildOperatorModeExportAdapter(arcContractRunner([], { sysAbsent: true }));
+    const r = await adapter.exportSystem({ name: "SYS" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.notFound).toBe(true);
+  });
+
+  test("a schema mismatch (arc too old) fails loudly", async () => {
+    const stale: ArcExportRunner = async () => ({
+      stdout: JSON.stringify({ schema: "arc.nats.v1", ok: true }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    const adapter = buildOperatorModeExportAdapter(stale);
+    const r = await adapter.exportOperator({ name: "OP_ANDREAS" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("schema mismatch");
+  });
+
+  test("a non-not-found arc error on exportSystem is NOT a skip (notFound:false)", async () => {
+    const broken: ArcExportRunner = async () => ({
+      stdout: JSON.stringify({ schema: SCHEMA, ok: false, error: { code: "NSC_NOT_INSTALLED", message: "boom" } }) + "\n",
+      stderr: "",
+      exitCode: 1,
+    });
+    const adapter = buildOperatorModeExportAdapter(broken);
+    const r = await adapter.exportSystem({ name: "SYS" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.notFound).toBe(false);
+  });
+});

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -14,6 +14,7 @@ import { homedir } from "os";
 import { join } from "path";
 
 import { expandTilde } from "../../../common/config/loader";
+import { renderOperatorModeBlocks } from "../../../common/nats/leaf-remote-renderer";
 import {
   selectNatsServiceManager,
   currentServicePlatform,
@@ -223,6 +224,35 @@ export function buildResolverPreloadAdapter(): ResolverPreloadPort {
         // Back up before the in-place edit (timestamped — the rollback artefact).
         copyFileSync(abs, `${abs}.bak-makelive-${Date.now().toString()}`);
         writeFileSync(abs, next, "utf-8");
+        return { ok: true, changed: true };
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+      }
+    },
+    // cortex#1265 — bootstrap an initial operator-mode skeleton (local-only path).
+    // Reuses renderOperatorModeBlocks (the SINGLE source of the §B0.1 grammar) so
+    // the bootstrapped conf is byte-identical to one `cortex network join` would
+    // render. APPENDS the operator-mode blocks to the bus's EXISTING config — it
+    // requires that config to exist (it carries the bus's server_name/listen/http),
+    // never fabricating a server identity.
+    bootstrapOperatorMode: ({ natsConfigPath, package: pkg }) => {
+      try {
+        const abs = expandTilde(natsConfigPath);
+        if (!existsSync(abs)) {
+          return {
+            ok: false,
+            reason:
+              `nats config not found at ${abs} — bootstrap appends operator-mode blocks to an ` +
+              "EXISTING bus config (carrying its server_name/listen/http). Create the base config first.",
+          };
+        }
+        const current = readFileSync(abs, "utf-8");
+        const result = renderOperatorModeBlocks(current, pkg);
+        if (result.status === "refuse") return { ok: false, reason: result.reason };
+        if (result.status === "already") return { ok: true, changed: false };
+        // converted — back up first (the rollback artefact), then write in place.
+        copyFileSync(abs, `${abs}.bak-makelive-${Date.now().toString()}`);
+        writeFileSync(abs, result.conf, "utf-8");
         return { ok: true, changed: true };
       } catch (err) {
         return { ok: false, reason: err instanceof Error ? err.message : String(err) };

--- a/src/cli/cortex/commands/network-make-live-lib.ts
+++ b/src/cli/cortex/commands/network-make-live-lib.ts
@@ -13,6 +13,9 @@
  *      `resolver_preload` (MEMORY resolver) in the nats config (default
  *      `~/.config/nats/local.conf`). Keyed on the account pubkey: pure addition,
  *      never disturbs the other stacks' accounts already there (multi-stack safe).
+ *      cortex#1265 — when the bus has NO `resolver_preload` yet (a fresh local-only
+ *      stack that never federates), BOOTSTRAP the operator-mode skeleton first from
+ *      the JWTs provision wrote into `stack.nats_infra` (instead of refusing).
  *   3. restart the NATS server so the MEMORY resolver loads the new account
  *      (a SIGHUP reload does NOT pick up resolver_preload — a hard restart is
  *      required; verified empirically, see docs/design-make-live-daemon-switch.md).
@@ -47,6 +50,8 @@
  * and mutates NOTHING. `--apply` executes mint → resolver → nats restart →
  * daemon restart, fail-fast (any port failure aborts and surfaces how far it got).
  */
+
+import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 
 // =============================================================================
 // Ports
@@ -92,6 +97,22 @@ export interface ResolverPreloadPort {
     accountName: string;
     accountPubkey: string;
     accountJwt: string;
+  }): { ok: true; changed: boolean } | { ok: false; reason: string };
+  /**
+   * cortex#1265 — bootstrap an INITIAL operator-mode skeleton into a config that
+   * has NO `resolver_preload` yet (the local-only path: a never-federates stack
+   * never runs `join`, so nothing else renders the operator-mode blocks). Renders
+   * `operator:` + optional `system_account:` + `resolver: MEMORY` +
+   * `resolver_preload { <federation account> }` via `renderOperatorModeBlocks`,
+   * KEEPING the bus's own `server_name`/`listen`/`http`/`jetstream.domain`, and
+   * backing up the config first. Idempotent: `changed:false` when the bus is
+   * already operator-mode under the SAME operator. Refuses (ok:false) on a
+   * malformed package OR a bus already operator-mode under a DIFFERENT operator
+   * (never clobber). The subsequent `appendAccount` then adds the agents account.
+   */
+  bootstrapOperatorMode(opts: {
+    natsConfigPath: string;
+    package: OperatorModeLeafPackage;
   }): { ok: true; changed: boolean } | { ok: false; reason: string };
 }
 
@@ -146,6 +167,14 @@ export interface MakeLiveInputs {
   credsPath: string;
   /** Path to the cortex config the daemon loads (for daemon-restart discovery). */
   cortexConfigPath: string;
+  /**
+   * cortex#1265 — the operator-mode leaf package assembled from
+   * `stack.nats_infra.{operator_jwt, account, account_jwt, system_account,
+   * system_account_jwt}` (provision populates these). Present ⇒ a bus with no
+   * `resolver_preload` is BOOTSTRAPPED operator-mode (instead of refused). Absent
+   * ⇒ the #794 refusal stands (no JWTs to render with).
+   */
+  operatorModePackage?: OperatorModeLeafPackage;
   /**
    * Path to the nats-server config carrying resolver_preload. BLOCK 1 — derived
    * PER-STACK from `stack.nats_infra.config_path` (or `--nats-config`); there is
@@ -260,29 +289,43 @@ export async function makeLiveStack(
     };
   }
 
-  // M3 — operator-mode guard (the `network join` #794 analogue). make-live teaches
-  // the nats-server a new account by appending to `resolver_preload`; a bus with no
-  // such block (the anonymous / hard-isolated `halden` pattern) is not operator-mode
-  // and make-live does not apply to it. Refuse BEFORE any mint/restart, in BOTH
-  // dry-run and apply, so the operator learns this rather than (under a defaulted
-  // config path) silently editing the wrong file. Runs against the SAME natsConfigPath
-  // the rest of the flow targets (BLOCK 1 derives it per-stack), so a category error
-  // is caught against the stack's own bus.
-  if (!ports.resolver.hasResolverPreload(inputs.natsConfigPath)) {
+  // M3 / cortex#1265 — operator-mode handling. make-live teaches the nats-server a
+  // new account by appending to `resolver_preload`; a bus with no such block (the
+  // anonymous / hard-isolated `halden` pattern, OR a fresh local-only stack) is not
+  // yet operator-mode. Two outcomes, decided BEFORE any mint/restart (so the choice
+  // shows in dry-run too), against the SAME natsConfigPath the rest of the flow
+  // targets (BLOCK 1 derives it per-stack):
+  //   - operator-mode JWTs in config (provision populated them) ⇒ BOOTSTRAP an
+  //     initial operator-mode skeleton (cortex#1265 local-only path).
+  //   - no JWTs ⇒ the #794 refusal stands — nothing to render with.
+  const bootstrapNeeded = !ports.resolver.hasResolverPreload(inputs.natsConfigPath);
+  if (bootstrapNeeded && inputs.operatorModePackage === undefined) {
     return {
       ok: false,
       applied: false,
       plan: [],
       reason:
         `${inputs.natsConfigPath} has no resolver_preload { … } block — this stack's bus is not ` +
-        "operator-mode; make-live does not apply. Convert the bus to operator-mode first " +
-        "(see docs/sop-stack-onboarding.md §B0.1) before landing the daemon on its agents account.",
+        "operator-mode, and stack.nats_infra carries no operator-mode JWTs to bootstrap one. Run " +
+        `\`cortex network provision ${inputs.stackSlug} --apply\` first (it populates ` +
+        "operator_jwt + account_jwt), or convert the bus by hand (docs/sop-stack-onboarding.md §B0.1).",
       steps: [],
     };
   }
 
-  const { credsNeeded, resolverNeeded, natsRestartNeeded, daemonRestartNeeded, plan } =
+  const { credsNeeded, resolverNeeded, natsRestartNeeded, daemonRestartNeeded, plan: corePlan } =
     planMakeLive(inputs);
+  // cortex#1265 — prepend the bootstrap step to the plan when it is needed.
+  const plan: PlanItem[] = bootstrapNeeded
+    ? [
+        {
+          step: "operator-mode bootstrap",
+          status: "wire",
+          detail: `render operator + resolver_preload (federation account) → ${inputs.natsConfigPath}`,
+        },
+        ...corePlan,
+      ]
+    : corePlan;
   const planLines = plan.map(renderPlanLine);
 
   // BLOCK 2 — resolve (read-only) the launchd/systemd descriptors the nats-server +
@@ -336,8 +379,28 @@ export async function makeLiveStack(
   // post-hoc record shows exactly which services were restarted).
   const steps: string[] = [...targetLines];
 
-  // 1. Teach the NATS server the agents account (append to resolver_preload).
+  // 0. (cortex#1265) Bootstrap the operator-mode skeleton when the bus has no
+  //    resolver_preload yet — renders operator + resolver: MEMORY + the federation
+  //    account, KEEPING the bus's own server_name/listen/http. The agents account
+  //    is appended in step 1 below. Done BEFORE the append so the block exists.
   let resolverChanged = false;
+  // bootstrapNeeded ⇒ operatorModePackage is defined (the guard above returns
+  // early otherwise). Re-narrow on the field directly to avoid a non-null `!`.
+  if (bootstrapNeeded && inputs.operatorModePackage !== undefined) {
+    const boot = ports.resolver.bootstrapOperatorMode({
+      natsConfigPath: inputs.natsConfigPath,
+      package: inputs.operatorModePackage,
+    });
+    if (!boot.ok) return fail(plan, steps, `operator-mode bootstrap failed: ${boot.reason}`);
+    resolverChanged = boot.changed;
+    steps.push(
+      boot.changed
+        ? `operator-mode bootstrap: rendered operator + resolver_preload (federation account) into ${inputs.natsConfigPath}`
+        : `operator-mode bootstrap: bus already operator-mode (no-op)`,
+    );
+  }
+
+  // 1. Teach the NATS server the agents account (append to resolver_preload).
   if (resolverNeeded) {
     const exported = await ports.accountExport.exportAccount(inputs.agentsAccountName);
     if (!exported.ok) return fail(plan, steps, `export-account failed: ${exported.reason}`);
@@ -365,7 +428,8 @@ export async function makeLiveStack(
       accountJwt: exported.jwt,
     });
     if (!appended.ok) return fail(plan, steps, `resolver_preload append failed: ${appended.reason}`);
-    resolverChanged = appended.changed;
+    // OR with any bootstrap change (cortex#1265) — a single nats restart covers both.
+    resolverChanged = resolverChanged || appended.changed;
     steps.push(
       appended.changed
         ? `resolver_preload: appended ${inputs.agentsAccountName} (${inputs.agentsAccountPubkey})`

--- a/src/cli/cortex/commands/network-provision-adapters.ts
+++ b/src/cli/cortex/commands/network-provision-adapters.ts
@@ -19,6 +19,7 @@ import { expandTilde } from "../../../common/config/loader";
 import { generateStackIdentity } from "../../../bus/stack-provisioning";
 import { buildFederationWiringAdapter } from "./network-federation-wiring";
 import { buildOperatorProvisioningAdapter } from "./operator-provisioning";
+import { buildOperatorModeExportAdapter } from "./operator-mode-export";
 import type {
   ProvisionPorts,
   SigningIdentityPort,
@@ -81,6 +82,21 @@ export function buildProvisionConfigWriteAdapter(stackConfigPath: string): Provi
         if (fields.nkeyPub !== undefined) {
           doc.setIn(["stack", "nkey_pub"], fields.nkeyPub);
         }
+        // cortex#1265 — the operator-mode JWTs the O-3 join / make-live-bootstrap
+        // renderer reads (network-derive). Set only when exported this run (omitted
+        // fields leave any hand-tuned value untouched — never clobbered).
+        if (fields.operatorJwt !== undefined) {
+          doc.setIn(["stack", "nats_infra", "operator_jwt"], fields.operatorJwt);
+        }
+        if (fields.accountJwt !== undefined) {
+          doc.setIn(["stack", "nats_infra", "account_jwt"], fields.accountJwt);
+        }
+        if (fields.systemAccount !== undefined) {
+          doc.setIn(["stack", "nats_infra", "system_account"], fields.systemAccount);
+        }
+        if (fields.systemAccountJwt !== undefined) {
+          doc.setIn(["stack", "nats_infra", "system_account_jwt"], fields.systemAccountJwt);
+        }
         mkdirSync(dirname(stackConfigPath), { recursive: true });
         writeFileSync(stackConfigPath, doc.toString(), "utf-8");
         return { ok: true };
@@ -102,5 +118,6 @@ export function buildLiveProvisionPorts(stackConfigPath: string): ProvisionPorts
     signing: buildSigningIdentityAdapter(),
     federationWiring: buildFederationWiringAdapter(),
     configWrite: buildProvisionConfigWriteAdapter(stackConfigPath),
+    export: buildOperatorModeExportAdapter(),
   };
 }

--- a/src/cli/cortex/commands/network-provision-lib.ts
+++ b/src/cli/cortex/commands/network-provision-lib.ts
@@ -11,13 +11,19 @@
  *   3. ensure the per-stack agents account (arc nats add-account)— ADR-0012 isolation
  *   4. ensure the stack signing seed  (provision-stack generate) — chmod 600, no-clobber
  *   5. wire federated.> export/import (arc nats add-federation-export) — fed → agents
- *   6. write stack.nats_infra back    (account, agents_account, creds_path) + nkey_seed_path
+ *   6. export operator-mode JWTs       (arc nats export-{operator,account,system}) — cortex#1265
+ *   7. write stack.nats_infra back    (account, agents_account, creds_path, nkey_seed_path,
+ *                                       operator_jwt, account_jwt, system_account[_jwt])
  *
  * After this the stack is ready for `cortex network join` — only the two
  * irreducible two-party steps remain (the leaf shared secret + hub topology
- * agreement). The operator-mode `.conf` render + bus restart are LEFT TO JOIN
- * (render-only here; join already performs the O-3 conversion + #821 health
- * probe), so this verb is non-disruptive.
+ * agreement). The operator-mode `.conf` render + bus restart are STILL LEFT TO
+ * JOIN (render-only here; join performs the O-3 conversion + #821 health probe),
+ * so this verb stays NON-DISRUPTIVE. cortex#1265 only adds the config-side JWT
+ * EXPORT that starves the renderer today: provision now populates the four
+ * `stack.nats_infra.{operator_jwt, account_jwt, system_account, system_account_jwt}`
+ * fields the O-3 join (and make-live bootstrap) read, so the operator runs zero
+ * raw `nsc generate config`. It writes ONLY config, never the `.conf`.
  *
  * This module is PURE over injected ports — zero fs / arc / nsc. The live
  * adapters live in `network-provision-adapters.ts`; the arc account-tree seam is
@@ -107,7 +113,43 @@ export interface ProvisionConfigWritePort {
     credsPath: string;
     seedPath: string;
     nkeyPub?: string;
+    /**
+     * cortex#1265 — the operator-mode JWTs that feed the O-3 join /
+     * make-live-bootstrap renderer (`renderOperatorModeBlocks`). Persisted under
+     * `stack.nats_infra.{operator_jwt, account_jwt, system_account,
+     * system_account_jwt}` — the exact fields `network-derive` reads. Omitted
+     * (left untouched) when not exported this run.
+     */
+    operatorJwt?: string;
+    accountJwt?: string;
+    systemAccount?: string;
+    systemAccountJwt?: string;
   }): { ok: true } | { ok: false; reason: string };
+}
+
+/**
+ * cortex#1265 — the export seam that bridges the minted nsc account tree to the
+ * operator-mode `.conf` renderer. Shells `arc nats export-{operator,account,
+ * system}` so cortex NEVER runs nsc (ADR-0013 invariant). Read-only over the nsc
+ * store; NEVER throws (arc failures → `{ ok: false }`).
+ */
+export interface OperatorModeExportPort {
+  /** `arc nats export-operator --name <name> --json` → operator JWT (+ pubkey). */
+  exportOperator(opts: { name: string }): Promise<
+    { ok: true; operatorJwt: string; pubKey: string } | { ok: false; reason: string }
+  >;
+  /** `arc nats export-account <name> --json` → account pubkey + JWT (exists today). */
+  exportAccount(name: string): Promise<
+    { ok: true; pubKey: string; jwt: string } | { ok: false; reason: string }
+  >;
+  /**
+   * `arc nats export-system --name <name> --json` → SYS account pubkey + JWT.
+   * `notFound` distinguishes "no SYS account exists" (a clean skip — SYS is
+   * optional, `nsc add operator` does not mint one) from a real arc failure.
+   */
+  exportSystem(opts: { name: string }): Promise<
+    { ok: true; pubKey: string; jwt: string } | { ok: false; reason: string; notFound: boolean }
+  >;
 }
 
 /** The full port bundle the orchestrator depends on. */
@@ -116,6 +158,7 @@ export interface ProvisionPorts {
   signing: SigningIdentityPort;
   federationWiring: FederationWiringPort;
   configWrite: ProvisionConfigWritePort;
+  export: OperatorModeExportPort;
 }
 
 // =============================================================================
@@ -130,6 +173,12 @@ export interface ProvisionState {
   agentsAccount: string | undefined;
   /** Does the signing seed file exist on disk? */
   signingSeedExists: boolean;
+  /**
+   * cortex#1265 — do `stack.nats_infra.operator_jwt` AND `account_jwt` already
+   * sit in config? Drives the ensure-shape of the JWT export: present ⇒ skip the
+   * export (no-op), absent ⇒ export + write. `--force` re-exports regardless.
+   */
+  operatorModeJwtsPresent: boolean;
 }
 
 export interface ProvisionInputs {
@@ -139,6 +188,8 @@ export interface ProvisionInputs {
   operatorName: string;
   federationAccountName: string;
   agentsAccountName: string;
+  /** cortex#1265 — the SYS (system) account name to best-effort export (default "SYS"). */
+  systemAccountName: string;
   /** `stack.nkey_seed_path` — where the signing seed is / will be written. */
   seedPath: string;
   /** Conventional leaf `.creds` path recorded in config (minted at join). */
@@ -148,7 +199,7 @@ export interface ProvisionInputs {
   state: ProvisionState;
 }
 
-export type PlanStatus = "mint" | "generate" | "wire" | "ok";
+export type PlanStatus = "mint" | "generate" | "wire" | "export" | "ok";
 
 export interface PlanItem {
   step: string;
@@ -184,6 +235,7 @@ export function buildProvisionPlan(inputs: ProvisionInputs): PlanItem[] {
   const fedPresent = !force && state.federationAccount !== undefined;
   const agentsPresent = !force && state.agentsAccount !== undefined;
   const signingPresent = !force && state.signingSeedExists;
+  const jwtsPresent = !force && state.operatorModeJwtsPresent;
 
   return [
     {
@@ -212,9 +264,14 @@ export function buildProvisionPlan(inputs: ProvisionInputs): PlanItem[] {
       detail: `${inputs.federationAccountName} → ${inputs.agentsAccountName}`,
     },
     {
+      step: "operator-mode JWTs export",
+      status: jwtsPresent ? "ok" : "export",
+      detail: `operator + ${inputs.federationAccountName} + ${inputs.systemAccountName} (system, best-effort)`,
+    },
+    {
       step: "stack.nats_infra write-back",
       status: "wire",
-      detail: "account, agents_account, creds_path, nkey_seed_path",
+      detail: "account, agents_account, creds_path, nkey_seed_path, operator_jwt, account_jwt, system_account[_jwt]",
     },
   ];
 }
@@ -325,6 +382,63 @@ export async function provisionStack(
   if (!wire.ok) return fail(plan, steps, `federation wiring failed: ${wire.reason}`);
   steps.push(`federated.> export/import: ${wire.note ?? "wired"}`);
 
+  // 5.5 (cortex#1265) — export the operator-mode JWTs so the O-3 join /
+  // make-live-bootstrap renderer (renderOperatorModeBlocks) materialises the
+  // operator-mode `.conf` with ZERO manual `nsc generate config`. Config-only +
+  // NON-DISRUPTIVE: nothing here touches the live bus (provision's documented
+  // invariant). Ensure-shaped: skipped when the JWTs already sit in config.
+  let operatorJwt: string | undefined;
+  let accountJwt: string | undefined;
+  let systemAccount: string | undefined;
+  let systemAccountJwt: string | undefined;
+  const jwtExportNeeded = force || !state.operatorModeJwtsPresent;
+  if (jwtExportNeeded) {
+    const opRes = await ports.export.exportOperator({ name: inputs.operatorName });
+    if (!opRes.ok) return fail(plan, steps, `export-operator failed: ${opRes.reason}`);
+    operatorJwt = opRes.operatorJwt;
+
+    const acctRes = await ports.export.exportAccount(inputs.federationAccountName);
+    if (!acctRes.ok) return fail(plan, steps, `export-account (federation) failed: ${acctRes.reason}`);
+    // Cross-check the exported account pubkey against the resolved federation
+    // pubkey — a divergence would render a `.conf` binding the leaf to the WRONG
+    // account (mirrors make-live's BLOCK 3 drift guard).
+    if (acctRes.pubKey !== resolvedAccount) {
+      return fail(
+        plan,
+        steps,
+        `account pubkey drift: federation account ${inputs.federationAccountName} resolved to ` +
+          `${resolvedAccount} but \`arc nats export-account\` returned ${acctRes.pubKey}.`,
+      );
+    }
+    accountJwt = acctRes.jwt;
+
+    // SYS is OPTIONAL + best-effort: `nsc add operator` does NOT mint one, and an
+    // operator-mode bus runs without it (the renderer treats system_account as
+    // optional). A missing SYS account is a clean skip, never a provision failure.
+    const sysRes = await ports.export.exportSystem({ name: inputs.systemAccountName });
+    if (sysRes.ok) {
+      systemAccount = sysRes.pubKey;
+      systemAccountJwt = sysRes.jwt;
+      steps.push(
+        `operator-mode JWTs exported: operator + ${inputs.federationAccountName} + ${inputs.systemAccountName} (system)`,
+      );
+    } else if (sysRes.notFound) {
+      steps.push(
+        `operator-mode JWTs exported: operator + ${inputs.federationAccountName} ` +
+          `(no ${inputs.systemAccountName} account — system_account skipped, optional)`,
+      );
+    } else {
+      // A non-"not-found" arc failure on the OPTIONAL system export: soft-skip
+      // with a visible warning rather than aborting the whole provision.
+      steps.push(
+        `operator-mode JWTs exported: operator + ${inputs.federationAccountName} ` +
+          `(WARNING: system export skipped — ${sysRes.reason})`,
+      );
+    }
+  } else {
+    steps.push("operator-mode JWTs present in config (untouched)");
+  }
+
   // 6. Write the resolved nats_infra fields back to the stack config.
   const written = ports.configWrite.write({
     account: resolvedAccount,
@@ -332,9 +446,18 @@ export async function provisionStack(
     credsPath: inputs.credsPath,
     seedPath: inputs.seedPath,
     ...(resolvedNkeyPub !== undefined && { nkeyPub: resolvedNkeyPub }),
+    ...(operatorJwt !== undefined && { operatorJwt }),
+    ...(accountJwt !== undefined && { accountJwt }),
+    ...(systemAccount !== undefined && { systemAccount }),
+    ...(systemAccountJwt !== undefined && { systemAccountJwt }),
   });
   if (!written.ok) return fail(plan, steps, `config write-back failed: ${written.reason}`);
-  steps.push("stack.nats_infra written (account, agents_account, creds_path, nkey_seed_path)");
+  steps.push(
+    "stack.nats_infra written (account, agents_account, creds_path, nkey_seed_path" +
+      (operatorJwt !== undefined ? ", operator_jwt, account_jwt" : "") +
+      (systemAccount !== undefined ? ", system_account, system_account_jwt" : "") +
+      ")",
+  );
 
   steps.push("");
   steps.push("Ready for `cortex network join <network>` — remaining: leaf shared secret + hub topology (two-party, out-of-band).");

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -129,6 +129,7 @@ import {
   type MakeLivePorts,
 } from "./network-make-live-lib";
 import { buildLiveMakeLivePorts, buildResolverPreloadAdapter } from "./network-make-live-adapters";
+import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 import {
   runNetworkSecret,
   type SecretAction,
@@ -1945,6 +1946,29 @@ function deriveMakeLiveInputs(
     resolverHasAccount: resolverProbe.hasAccount(natsConfigPath, agentsAccountPubkey),
   };
 
+  // cortex#1265 — assemble the operator-mode leaf package from the JWTs provision
+  // wrote into `stack.nats_infra` (same minimum + precedence as network-derive's
+  // O-3 join package). Present ⇒ a bus with no resolver_preload is BOOTSTRAPPED
+  // operator-mode instead of refused (the local-only path).
+  const ni = cfg.stack?.nats_infra;
+  const opJwt = ni?.operator_jwt;
+  const fedAccount = ni?.account;
+  const acctJwt = ni?.account_jwt;
+  const sysAccount = ni?.system_account;
+  const sysJwt = ni?.system_account_jwt;
+  const operatorModePackage: OperatorModeLeafPackage | undefined =
+    opJwt !== undefined && opJwt !== "" &&
+    fedAccount !== undefined && fedAccount !== "" &&
+    acctJwt !== undefined && acctJwt !== ""
+      ? {
+          operatorJwt: opJwt,
+          account: fedAccount,
+          accountJwt: acctJwt,
+          ...(sysAccount !== undefined && sysAccount !== "" && { systemAccount: sysAccount }),
+          ...(sysJwt !== undefined && sysJwt !== "" && { systemAccountJwt: sysJwt }),
+        }
+      : undefined;
+
   const inputs: MakeLiveInputs = {
     principal,
     stackSlug: slug,
@@ -1958,6 +1982,7 @@ function deriveMakeLiveInputs(
     force,
     apply: applyRes.apply,
     state,
+    ...(operatorModePackage !== undefined && { operatorModePackage }),
   };
   return { ok: true, inputs };
 }
@@ -2067,6 +2092,18 @@ function deriveProvisionInputs(
   const applyRes = resolveApply(flags);
   if (!applyRes.ok) return { ok: false, reason: applyRes.reason, usage: true };
 
+  // cortex#1265 — the SYS (system) account to best-effort export. `--system-account`
+  // overrides the conventional "SYS"; absent on a fresh operator (skipped — optional).
+  const systemAccountName = optionalValueFlag(flags, "--system-account") ?? "SYS";
+  // The JWT export is ensure-shaped: it is a no-op once both operator_jwt AND
+  // account_jwt already sit in config (the renderer's minimum).
+  const natsInfra = cfg.stack?.nats_infra;
+  const operatorModeJwtsPresent =
+    natsInfra?.operator_jwt !== undefined &&
+    natsInfra.operator_jwt !== "" &&
+    natsInfra.account_jwt !== undefined &&
+    natsInfra.account_jwt !== "";
+
   const inputs: ProvisionInputs = {
     principal,
     stackSlug: slug,
@@ -2074,6 +2111,7 @@ function deriveProvisionInputs(
     operatorName: names.operatorName, // nsc operator account name (OP_<PRINCIPAL>)
     federationAccountName: names.federationAccountName,
     agentsAccountName: names.agentsAccountName,
+    systemAccountName,
     seedPath,
     credsPath,
     force: flags["--force"] === true,
@@ -2082,6 +2120,7 @@ function deriveProvisionInputs(
       federationAccount: cfg.stack?.nats_infra?.account,
       agentsAccount: cfg.stack?.nats_infra?.agents_account,
       signingSeedExists: existsSync(expandTilde(seedPath)),
+      operatorModeJwtsPresent,
     },
   };
   return { ok: true, inputs, stackConfigPath: resolveStackWriteConfigPath(configPath) };

--- a/src/cli/cortex/commands/operator-mode-export.ts
+++ b/src/cli/cortex/commands/operator-mode-export.ts
@@ -1,0 +1,204 @@
+/**
+ * cortex#1265 — the arc-shell driver behind the {@link OperatorModeExportPort}:
+ * the server-config bridge that exports the operator-mode JWTs from the minted
+ * nsc account tree so `cortex network provision` can populate
+ * `stack.nats_infra.{operator_jwt, account_jwt, system_account, system_account_jwt}`.
+ *
+ * Those four fields are what `cortex network join`'s O-3 renderer
+ * (`renderOperatorModeBlocks`) — and the make-live bootstrap — consume to render
+ * the operator-mode `.conf` with ZERO manual `nsc generate config`. Today nothing
+ * populates them; this driver closes that gap.
+ *
+ * cortex NEVER runs nsc directly — arc owns the nsc boundary (ADR-0013 invariant).
+ * cortex shells `arc nats export-{operator,account,system} --json` and surfaces the
+ * result. Same arc-shell pattern as `operator-provisioning.ts`:
+ *   cortex shells to arc → arc calls nsc (`describe … --raw`) → JWT text back.
+ *
+ * ## Schema
+ *
+ * All three verbs respond with `arc.nats.operator.v1` (the same namespace as
+ * init-operator / add-account / export-account). We schema-guard so a contract
+ * regression fails loudly rather than silently misinterpreting the envelope.
+ *
+ * ## Read-only
+ *
+ * Every verb is a pure `nsc describe … --raw` on the arc side (no mutation), so
+ * this driver is safe to call in the provision `--apply` path AFTER the account
+ * mint without disturbing the live bus.
+ */
+
+import type { OperatorModeExportPort } from "./network-provision-lib";
+
+// =============================================================================
+// Arc subprocess driver (injectable for tests — mirrors operator-provisioning.ts)
+// =============================================================================
+
+export interface ArcExportRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Pluggable subprocess driver. Tests inject a fake; production uses Bun.spawn. */
+export type ArcExportRunner = (argv: readonly string[]) => Promise<ArcExportRunResult>;
+
+async function defaultArcExportRunner(argv: readonly string[]): Promise<ArcExportRunResult> {
+  const proc = Bun.spawn(["arc", ...argv], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+// =============================================================================
+// arc.nats.operator.v1 envelope types (mirror arc src/lib/json-response.ts)
+// =============================================================================
+
+const ARC_NATS_OPERATOR_SCHEMA = "arc.nats.operator.v1";
+
+interface ArcExportOperatorOk {
+  schema: typeof ARC_NATS_OPERATOR_SCHEMA;
+  ok: true;
+  operator: string;
+  pubKey: string;
+  jwt: string;
+  seedPath: string | null;
+}
+
+interface ArcExportAccountOk {
+  schema: typeof ARC_NATS_OPERATOR_SCHEMA;
+  ok: true;
+  account: string;
+  pubKey: string;
+  jwt: string;
+  seedPath: string | null;
+}
+
+interface ArcOperatorError {
+  schema: typeof ARC_NATS_OPERATOR_SCHEMA;
+  ok: false;
+  error: { code: string; message: string };
+}
+
+const MIN_ARC_NOTE =
+  "Ensure arc (>= the arc#1265 release shipping `nats export-operator` / " +
+  "`nats export-system`) is installed and on PATH.";
+
+/**
+ * Parse the first non-blank JSON line from arc stdout, schema-guarded. Returns
+ * the parsed `ok:true` envelope, OR the `{ code, reason }` from an `ok:false`
+ * envelope (so the caller can branch on the error CODE — e.g. SYS not-found).
+ */
+function parseExportEnvelope(
+  result: ArcExportRunResult,
+  verb: string,
+):
+  | { ok: true; envelope: ArcExportOperatorOk | ArcExportAccountOk }
+  | { ok: false; reason: string; code?: string } {
+  const line = result.stdout.split("\n").find((l) => l.trim().length > 0) ?? "";
+  if (line.length === 0) {
+    return {
+      ok: false,
+      reason:
+        `arc nats ${verb} returned no '${ARC_NATS_OPERATOR_SCHEMA}' envelope. ${MIN_ARC_NOTE} ` +
+        `arc stderr: ${result.stderr.trim() || "(empty)"}`,
+    };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return {
+      ok: false,
+      reason: `arc nats ${verb} returned non-JSON output: ${line.slice(0, 200)}`,
+    };
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as { schema?: unknown }).schema !== ARC_NATS_OPERATOR_SCHEMA
+  ) {
+    return {
+      ok: false,
+      reason:
+        `arc nats ${verb} returned no valid '${ARC_NATS_OPERATOR_SCHEMA}' envelope (schema mismatch). ` +
+        `arc dependency unmet (cortex#1265) — ${MIN_ARC_NOTE}`,
+    };
+  }
+  const env = parsed as ArcExportOperatorOk | ArcExportAccountOk | ArcOperatorError;
+  if (!env.ok) {
+    // Read the error shape through `unknown` so the defensive guards are
+    // necessary (mirrors operator-provisioning.ts's arcErrorReason).
+    const raw = (env as { error?: unknown }).error;
+    const code =
+      raw !== null && typeof raw === "object" && typeof (raw as { code?: unknown }).code === "string"
+        ? (raw as { code: string }).code
+        : undefined;
+    const message =
+      raw !== null && typeof raw === "object" && typeof (raw as { message?: unknown }).message === "string"
+        ? (raw as { message: string }).message
+        : "(no message)";
+    return {
+      ok: false,
+      reason: `arc nats ${verb} failed: ${code ?? "(unknown code)"}: ${message}`,
+      ...(code !== undefined && { code }),
+    };
+  }
+  return { ok: true, envelope: env };
+}
+
+/**
+ * Build the live {@link OperatorModeExportPort} backed by `arc nats
+ * export-{operator,account,system}`.
+ *
+ * @param runner - Injectable subprocess driver (default: `Bun.spawn(["arc", …])`).
+ */
+export function buildOperatorModeExportAdapter(
+  runner: ArcExportRunner = defaultArcExportRunner,
+): OperatorModeExportPort {
+  async function run(
+    argv: readonly string[],
+    verb: string,
+  ): Promise<
+    | { ok: true; envelope: ArcExportOperatorOk | ArcExportAccountOk }
+    | { ok: false; reason: string; code?: string }
+  > {
+    let result: ArcExportRunResult;
+    try {
+      result = await runner(argv);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `failed to invoke 'arc nats ${verb}' — ${err instanceof Error ? err.message : String(err)}. ${MIN_ARC_NOTE}`,
+      };
+    }
+    return parseExportEnvelope(result, verb);
+  }
+
+  return {
+    async exportOperator({ name }) {
+      const res = await run(["nats", "export-operator", "--name", name, "--json"], "export-operator");
+      if (!res.ok) return { ok: false, reason: res.reason };
+      const env = res.envelope as ArcExportOperatorOk;
+      return { ok: true, operatorJwt: env.jwt, pubKey: env.pubKey };
+    },
+    async exportAccount(name) {
+      const res = await run(["nats", "export-account", name, "--json"], "export-account");
+      if (!res.ok) return { ok: false, reason: res.reason };
+      const env = res.envelope as ArcExportAccountOk;
+      return { ok: true, pubKey: env.pubKey, jwt: env.jwt };
+    },
+    async exportSystem({ name }) {
+      const res = await run(["nats", "export-system", "--name", name, "--json"], "export-system");
+      if (!res.ok) {
+        // SYS is optional — distinguish "no SYS account" (a clean skip) from a
+        // real arc failure so provision treats absence as a soft skip.
+        return { ok: false, reason: res.reason, notFound: res.code === "SYSTEM_ACCOUNT_NOT_FOUND" };
+      }
+      const env = res.envelope as ArcExportAccountOk;
+      return { ok: true, pubKey: env.pubKey, jwt: env.jwt };
+    },
+  };
+}


### PR DESCRIPTION
**Closes #1265.** Design (first commit) + implementation (second commit). Decisions §4 signed off by Andreas: **Option A** (bridge lives in `cortex network provision`) + **A2** (local-only path bootstraps via `cortex network make-live`).

## The gap

The operator-mode `.conf` renderer `renderOperatorModeBlocks` (O-3 join) already existed, but was **starved**: join builds its package from `stack.nats_infra.{operator_jwt, account_jwt, system_account, system_account_jwt}` and **nothing populated those four JWT fields**. provision wrote account *pubkeys* but not the JWTs.

## What landed

**Provision JWT export** (`network-provision-lib.ts` + new `operator-mode-export.ts`):
- After the account mint + `federated.>` wiring, export the operator JWT + federation account JWT (required) and the SYS account JWT (**best-effort**) via the new `arc nats export-{operator,account,system}` verbs — cortex never runs nsc.
- Write them into `stack.nats_infra.{operator_jwt, account_jwt, system_account, system_account_jwt}`. **Config-only + non-disruptive** (no `.conf`, no bus restart — provision's documented invariant).
- Ensure-shaped (no-op once `operator_jwt` + `account_jwt` are present; `--force` re-exports). Account-pubkey drift cross-check. SYS absence is a clean skip — `nsc add operator` mints no SYS (verified, nsc 2.12.2) and the renderer treats `system_account` as optional.

**make-live bootstrap** (`network-make-live-lib.ts` + adapters):
- When the target nats-config has **no `resolver_preload`** yet (a fresh local-only stack that never federates), **bootstrap** an initial operator-mode resolver via `renderOperatorModeBlocks` from the populated JWTs, then append the agents account as before. Preserves the existing append path; idempotent; the #794 refusal still stands when no JWTs are available.

**arc verbs:** `export-operator` / `export-system` added in the-metafactory/arc#257 (mirroring the existing `export-account`).

**SOP:** `sop-onboard-peer-principal.md` §3 + §4a now point at `cortex network provision` + `join`/`make-live` and drop the raw `nsc generate config` / `nsc add account` steps; corrected the stale §4a "honest status" note.

## Note on SYS (a sub-detail the sign-off didn't spell out)

`nsc add operator` does **not** auto-create a SYS account, and the renderer treats `system_account` as optional. So provision exports it **best-effort** (a missing SYS is a clean skip, never a failure) rather than forcing a new account into the tree — the minimal, non-disruptive reading of the sign-off. operator + federation account are sufficient for an operational operator-mode bus.

## Tests / gates

provision JWT export + drift + SYS-skip + idempotency; the operator-mode-export arc-contract harness; the make-live bootstrap branch + `bootstrapOperatorMode` adapter against real `renderOperatorModeBlocks`; config write-back of the four JWT fields (no-clobber). `tsc` 0 (non-CSS), lint clean, full cortex CLI+nats suite green (1198). arc side green (454).

Depends on: the-metafactory/arc#257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)