### PR TITLE
fix(registry): C-1263 — admission-request upsert failure is visible, not silent

### DIFF
--- a/src/services/network-registry/__tests__/admission-silent-failure.test.ts
+++ b/src/services/network-registry/__tests__/admission-silent-failure.test.ts
@@ -1,0 +1,183 @@
+/**
+ * cortex#1263 — the admission-request hook must NOT fail silently.
+ *
+ * The register handler upserts a PENDING admission_requests row AFTER a
+ * successful registration, inside a try/catch that deliberately does NOT reject
+ * the registration (that part is correct — the principal record is already
+ * committed and the upsert is idempotent). The bug: when the upsert threw, the
+ * failure was swallowed entirely — the principal landed in `principals` with NO
+ * PENDING row, the admin saw nothing to admit, and the registrant believed they
+ * were queued (confirmed live: `chuvala`).
+ *
+ * The fix keeps NOT rejecting the registration but makes the failure VISIBLE:
+ *   1. a loud, structured `system.error` log line (greppable token +
+ *      principal_id / peer_pubkey / network_id / scope / error context);
+ *   2. a non-fatal `admission_request: "failed"` + `warning` flag on the
+ *      register RESPONSE body (additive, back-compat) so the registering cortex
+ *      can tell its principal "registered, but your admission request didn't
+ *      land — re-register to retry" (re-register self-heals, upsert idempotent).
+ *
+ * A successful upsert leaves the response unchanged (no warning, no flag).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import {
+  _setIssuanceStoreForTest,
+  type IssuanceRequestStore,
+} from "../src/store";
+import type { AdmissionRequest } from "../src/types";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+
+let env: Env;
+let principal: PrincipalKey;
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+/**
+ * An issuance store whose `upsertPending` always throws — stands in for the
+ * confirmed-live failure mode (principal registered before the admission tables
+ * deployed, or any transient DB error). Every other method throws too: this
+ * store must never be reached on a path other than the register hook.
+ */
+function makeFailingIssuanceStore(message: string): IssuanceRequestStore {
+  const boom = (): never => {
+    throw new Error(message);
+  };
+  return {
+    upsertPending: async () => boom(),
+    getIssuanceRequest: async () => boom(),
+    listIssuanceRequests: async () => boom(),
+    listIssuanceRequestsByPeer: async () => boom(),
+    transitionIssuanceRequest: async () => boom(),
+  } as unknown as IssuanceRequestStore;
+}
+
+type RegisterResponse = {
+  payload: unknown;
+  issued_at: string;
+  registry: string;
+  signature: string;
+  admission_request?: string;
+  warning?: string;
+};
+
+beforeEach(async () => {
+  resetStores();
+  _resetRateLimitBucketsForTest();
+  const reg = await makeRegistryKey();
+  principal = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    ENVIRONMENT: "test",
+  };
+});
+
+afterEach(() => {
+  resetStores();
+});
+
+describe("cortex#1263 — admission upsert failure is visible, not silent", () => {
+  test("upsert failure → registration still 201, but response carries the warning", async () => {
+    _setIssuanceStoreForTest(makeFailingIssuanceStore("simulated DB failure"));
+
+    const res = await post(
+      "/principals/chuvala/register",
+      await makeSignedRegistration("chuvala", principal, { networkId: "net-a" }),
+    );
+
+    // Registration is NOT rejected — the principal record is committed.
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as RegisterResponse;
+    // The signed assertion is intact (back-compat — payload still present/signed).
+    expect(body.payload).toBeDefined();
+    expect(body.signature).not.toBe("");
+    // The non-silent flags are present and explicit.
+    expect(body.admission_request).toBe("failed");
+    expect(typeof body.warning).toBe("string");
+    expect(body.warning).toContain("re-register");
+  });
+
+  test("upsert failure → a loud, structured system.error is emitted with context", async () => {
+    _setIssuanceStoreForTest(makeFailingIssuanceStore("simulated DB failure"));
+
+    const captured: string[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => {
+      captured.push(args.map(String).join(" "));
+    };
+    try {
+      const res = await post(
+        "/principals/chuvala/register",
+        await makeSignedRegistration("chuvala", principal, { networkId: "net-a" }),
+      );
+      expect(res.status).toBe(201);
+    } finally {
+      console.error = original;
+    }
+
+    const line = captured.find((l) =>
+      l.includes("admission_request_upsert_failed"),
+    );
+    expect(line).toBeDefined();
+    // Greppable monitor token + enough context to diagnose + re-raise.
+    expect(line).toContain("system.error");
+    expect(line).toContain("principal_id=chuvala");
+    expect(line).toContain("network_id=net-a");
+    expect(line).toContain("peer_pubkey=");
+    expect(line).toContain("requested_scope=");
+    expect(line).toContain("simulated DB failure");
+  });
+
+  test("successful upsert → response is the plain signed assertion (no warning, no flag)", async () => {
+    // Default in-memory issuance store (resetStores left it unset → real store).
+    const res = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as RegisterResponse;
+    expect(body.payload).toBeDefined();
+    expect(body.signature).not.toBe("");
+    // No warning fields on the happy path.
+    expect(body.admission_request).toBeUndefined();
+    expect(body.warning).toBeUndefined();
+  });
+
+  test("after a successful register, the PENDING row exists (regression anchor)", async () => {
+    const res = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    expect(res.status).toBe(201);
+
+    // The real in-memory store now holds the PENDING row the register hook wrote.
+    const { getIssuanceStore } = await import("../src/store");
+    const rows: AdmissionRequest[] = await getIssuanceStore(env).listIssuanceRequests(
+      "PENDING",
+    );
+    const alice = rows.filter((r) => r.principal_id === "alice");
+    expect(alice.length).toBe(1);
+    expect(alice[0]!.network_id).toBe("net-a");
+  });
+});

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -214,15 +214,23 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
     // This is the key that federated envelopes FROM this peer will be verified
     // against (per C-787). The requested_scope is derived from the principal_id.
     //
-    // Errors here are logged but NOT propagated to the caller: a failure to
-    // create the issuance request must not reject a valid registration — the
-    // principal record is already committed, and a retry of the issuance upsert
-    // is always safe (idempotent).
+    // Errors here do NOT reject the registration — a failure to create the
+    // issuance request must not reject a valid registration: the principal
+    // record is already committed, and a retry of the issuance upsert is always
+    // safe (idempotent). But the failure MUST NOT be silent (cortex#1263): a
+    // swallowed upsert leaves a principal in `principals` with NO PENDING
+    // admission row, so the admin sees nothing to admit and the registrant
+    // believes they are queued. We therefore (a) emit a loud, structured
+    // `system.error` log carrying enough context for a monitor / on-call to act,
+    // and (b) surface a non-fatal warning on the register RESPONSE so the
+    // registering cortex can tell its principal "registered, but your admission
+    // request didn't land — re-register to retry."
+    const peerPubkey =
+      stacksWithPubkeys[0]?.stack_pubkey ?? claim.principal_pubkey;
+    const requestedScope = `federated.${principalId}.>`;
+    let admissionRequestFailed = false;
     try {
       const issuanceStore = getIssuanceStore(c.env);
-      const peerPubkey =
-        stacksWithPubkeys[0]?.stack_pubkey ?? claim.principal_pubkey;
-      const requestedScope = `federated.${principalId}.>`;
       // ADR-0018 Gap-A — stamp the target network the joiner named (signed into
       // the claim) onto the PENDING admission row. This makes the idempotency
       // key `(principal_id, peer_pubkey, network_id)`, so the same stack can
@@ -235,15 +243,45 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
         claim.network_id,
       );
     } catch (err) {
+      admissionRequestFailed = true;
+      // Loud, structured system.error signal — mirrors the registry's other
+      // non-fatal error surfacing (`console.error` with the `[network-registry]`
+      // prefix, picked up by the platform log drain / monitor). The token
+      // `system.error admission_request_upsert_failed` is greppable; the context
+      // (principal_id, peer_pubkey, network_id, scope, error) is everything a
+      // monitor / on-call needs to diagnose and re-raise the PENDING row.
       console.error(
-        `[network-registry] issuance upsert failed for principal ${principalId}: ${err instanceof Error ? err.message : String(err)}`,
+        `[network-registry] system.error admission_request_upsert_failed ` +
+          `principal_id=${principalId} ` +
+          `peer_pubkey=${peerPubkey} ` +
+          `network_id=${claim.network_id ?? "(none)"} ` +
+          `requested_scope=${requestedScope} ` +
+          `error=${err instanceof Error ? err.message : String(err)}`,
       );
-      // Intentionally non-fatal: the principal record is committed.
+      // Intentionally non-fatal: the principal record is committed. The caller
+      // is told via the response warning below.
     }
 
     // Sign + return the canonical view so the principal gets the same
     // signed assertion shape peers will see.
     const assertion = await signAssertion(c.env, record);
+    if (admissionRequestFailed) {
+      // Additive, back-compat: the signed `payload`/`issued_at`/`registry`/
+      // `signature` fields are unchanged (clients that ignore extra fields keep
+      // working). The `admission_request: "failed"` flag + human-readable
+      // `warning` tell the registering cortex that registration succeeded but
+      // the admission request did NOT land — re-registering self-heals because
+      // `upsertPending` is idempotent.
+      return c.json(
+        {
+          ...assertion,
+          admission_request: "failed" as const,
+          warning:
+            "registered, but the PENDING admission request could not be created; re-register to retry (the upsert is idempotent)",
+        },
+        201,
+      );
+    }
     return c.json(assertion, 201);
   });
 


### PR DESCRIPTION
## Problem (root cause)

`src/services/network-registry/src/routes/principals.ts` — the register hook upserts a PENDING `admission_requests` row **after** a successful registration, inside a `try/catch` that deliberately swallowed the error (original lines ~237-242: `console.error(...)` then *"Intentionally non-fatal"* with no caller-visible signal).

When `issuanceStore.upsertPending(...)` fails (e.g. principal registered before the admission tables deployed, or any transient DB error), the principal record commits but **no PENDING `admission_requests` row is created — silently**. The admin sees nothing to admit; the registrant believes they are queued. **Confirmed live:** `chuvala` is in `principals` with no PENDING row.

## Fix

Keep **not** rejecting the registration (that's correct — the record is committed and `upsertPending` is idempotent), but make the failure **visible**:

1. **Loud structured `system.error`** — `console.error("[network-registry] system.error admission_request_upsert_failed principal_id=… peer_pubkey=… network_id=… requested_scope=… error=…")`. Greppable monitor token + full context to diagnose and re-raise the row. Mirrors how the registry surfaces its other non-fatal errors (`console.error` with the `[network-registry]` prefix → platform log drain).
2. **Non-fatal warning on the register RESPONSE** — additive, back-compat: the signed `payload`/`issued_at`/`registry`/`signature` fields are unchanged; a failed upsert adds `admission_request: "failed"` + a human-readable `warning` telling the registering cortex to re-register (which self-heals, the upsert being idempotent). The client (`postSigned` → `{ ok, status, response }`) surfaces extra fields verbatim, so older clients are unaffected.

3. **Admin repair endpoint** — considered, deferred as a follow-up. Re-register already self-heals; a dedicated admin re-raise path needs its own signed-admin auth + route + store method + tests and is not a small add.

## Tests

New `__tests__/admission-silent-failure.test.ts` (4 tests, injects a failing issuance store via `_setIssuanceStoreForTest`):
- upsert failure → registration still `201`, response carries `admission_request: "failed"` + `warning` (signed assertion intact)
- upsert failure → loud `system.error` emitted with `principal_id` / `peer_pubkey` / `network_id` / `requested_scope` / error message
- successful upsert → response is the plain signed assertion (no warning, no flag)
- regression anchor: after a successful register the PENDING row exists

## Gate

- `bunx tsc --noEmit` → 0
- `bash scripts/check-carveouts.sh` → PASS
- `bun test src/services/network-registry/ src/bus/` → 1400 pass, 0 fail
- `bun run lint:errors` → 0 errors

Closes #1263

🤖 Generated with [Claude Code](https://claude.com/claude-code)