### PR TITLE
fix(carveout): allowlist #1265 NSC server-config files (restore main green)

### DIFF
--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -213,6 +213,13 @@ ALLOWLIST_PATHS=(
   # faithful arc-CLI contract harness. Every "operator" is the NSC account-tree
   # sense (OperatorProvisioningPort / OP_ANDREAS), never the principal. Class: NSC.
   'src/cli/cortex/commands/__tests__/network-provision-integration.test.ts'
+  # cortex#1265 server-config bridge — the provision JWT-export adapter +
+  # its arc-contract test + the design doc. `operator` throughout = the NSC
+  # account-tree root (export-operator / operator-mode JWTs), never the principal.
+  # Same class as network-provision-lib.ts / network-make-live-lib.ts. Class: NSC.
+  'src/cli/cortex/commands/operator-mode-export.ts'
+  'src/cli/cortex/commands/__tests__/operator-mode-export.test.ts'
+  'docs/design-wrap-server-config-tooling.md'
   # G1d own-operator onboarding design doc — its whole subject is standing up the
   # principal's own NSC account tree (also caught by the `operator-onboarding`
   # line pattern; path-allowlisted for clarity). Class: NSC.

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2093,7 +2093,7 @@ function deriveProvisionInputs(
   if (!applyRes.ok) return { ok: false, reason: applyRes.reason, usage: true };
 
   // cortex#1265 — the SYS (system) account to best-effort export. `--system-account`
-  // overrides the conventional "SYS"; absent on a fresh operator (skipped — optional).
+  // overrides the conventional "SYS"; absent on a fresh nsc operator (skipped — optional).
   const systemAccountName = optionalValueFlag(flags, "--system-account") ?? "SYS";
   // The JWT export is ensure-shaped: it is a no-op once both operator_jwt AND
   // account_jwt already sit in config (the renderer's minimum).


### PR DESCRIPTION
Restores main to green after #1266 was admin-merged over a failing vocab carve-out gate. Adds the 3 new NSC-operator files (operator-mode-export + test + design doc) to the NSC-class allowlist and qualifies one new `network.ts` comment. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)