### PR TITLE
chore: bump to v5.29.0 — onboarding hardening (#1263/#1264/#1265)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.28.0"
+version: "5.29.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release bump: the three onboarding-hardening fixes from the first external SOP walks — admission silent-failure now visible (#1263), content-filter rejection is descriptive + actionable (#1264), and the NATS server-config is folded into one-command provision + make-live (#1265, no more raw nsc). 5.28.0 → 5.29.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)