### PR TITLE
feat(surface): C-1275 — MC networks as first-class trust groups + admitted-roster ⋈ presence (MC-A1)

### DIFF
--- a/src/bus/agent-network/__tests__/admission-read.test.ts
+++ b/src/bus/agent-network/__tests__/admission-read.test.ts
@@ -1,0 +1,133 @@
+/**
+ * MC-A1 (cortex#1275) — unit tests for the admission-rows read (ADR-0018 Q3
+ * source of truth). Drives `resolveAdmittedRoster` over a fake
+ * `AdmissionRowsProvider` — no transport, no registry, no crypto.
+ *
+ * The load-bearing property: membership comes from the admission STATUS
+ * (ADMITTED / PENDING), filtered to the target network — never from capabilities,
+ * and a SELF-scoped read is flagged non-authoritative so the caller suppresses
+ * anomaly detection.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveAdmittedRoster,
+  type AdmissionRow,
+  type AdmissionRowsProvider,
+  type AdmissionRowsResult,
+} from "../admission-read";
+
+function provider(result: AdmissionRowsResult): AdmissionRowsProvider {
+  return { readAdmissionRows: () => Promise.resolve(result) };
+}
+
+function row(over: Partial<AdmissionRow> & { principal_id: string }): AdmissionRow {
+  return { network_id: "research-collab", status: "ADMITTED", ...over };
+}
+
+describe("resolveAdmittedRoster", () => {
+  it("projects ADMITTED rows → admitted[], PENDING rows → pending[]", async () => {
+    const res = await resolveAdmittedRoster(
+      "research-collab",
+      provider({
+        ok: true,
+        scope: "complete",
+        rows: [
+          row({ principal_id: "jc", status: "ADMITTED" }),
+          row({ principal_id: "newcomer", status: "PENDING" }),
+        ],
+      }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.roster.admitted).toEqual(["jc"]);
+    expect(res.roster.pending).toEqual(["newcomer"]);
+    expect(res.roster.authoritative).toBe(true);
+  });
+
+  it("drops REJECTED / REVOKED rows — they are not members", async () => {
+    const res = await resolveAdmittedRoster(
+      "research-collab",
+      provider({
+        ok: true,
+        scope: "complete",
+        rows: [
+          row({ principal_id: "rejected", status: "REJECTED" }),
+          row({ principal_id: "revoked", status: "REVOKED" }),
+          row({ principal_id: "jc", status: "ADMITTED" }),
+        ],
+      }),
+    );
+    expect(res.ok && res.roster.admitted).toEqual(["jc"]);
+    expect(res.ok && res.roster.pending).toEqual([]);
+  });
+
+  it("filters to the target network, dropping other-network + network-less rows", async () => {
+    const res = await resolveAdmittedRoster(
+      "research-collab",
+      provider({
+        ok: true,
+        scope: "complete",
+        rows: [
+          row({ principal_id: "jc", network_id: "research-collab", status: "ADMITTED" }),
+          row({ principal_id: "other", network_id: "ops-net", status: "ADMITTED" }),
+          row({ principal_id: "registered-only", network_id: null, status: "ADMITTED" }),
+        ],
+      }),
+    );
+    expect(res.ok && res.roster.admitted).toEqual(["jc"]);
+  });
+
+  it("flags a SELF-scoped read non-authoritative (anomaly detection must be suppressed)", async () => {
+    const res = await resolveAdmittedRoster(
+      "research-collab",
+      provider({
+        ok: true,
+        scope: "self",
+        rows: [row({ principal_id: "andreas", status: "ADMITTED" })],
+      }),
+    );
+    expect(res.ok && res.roster.authoritative).toBe(false);
+    expect(res.ok && res.roster.admitted).toEqual(["andreas"]);
+  });
+
+  it("dedupes principals, preserving first-seen order", async () => {
+    const res = await resolveAdmittedRoster(
+      "research-collab",
+      provider({
+        ok: true,
+        scope: "complete",
+        rows: [
+          row({ principal_id: "b", status: "ADMITTED" }),
+          row({ principal_id: "a", status: "ADMITTED" }),
+          row({ principal_id: "b", status: "ADMITTED" }),
+        ],
+      }),
+    );
+    expect(res.ok && res.roster.admitted).toEqual(["b", "a"]);
+  });
+
+  it("passes through a read failure verbatim (never throws)", async () => {
+    const res = await resolveAdmittedRoster(
+      "research-collab",
+      provider({ ok: false, reason: "unreachable", detail: "registry down" }),
+    );
+    expect(res.ok).toBe(false);
+    expect(!res.ok && res.reason).toBe("unreachable");
+  });
+
+  it("never treats capabilities as membership — there is no capability input at all", async () => {
+    // Asserted by construction: AdmissionRow has no capability field, and the
+    // projection keys solely on `status`. An ADMITTED row with no capabilities
+    // is still a full member.
+    const res = await resolveAdmittedRoster(
+      "research-collab",
+      provider({
+        ok: true,
+        scope: "complete",
+        rows: [row({ principal_id: "silent-member", status: "ADMITTED" })],
+      }),
+    );
+    expect(res.ok && res.roster.admitted).toEqual(["silent-member"]);
+  });
+});

--- a/src/bus/agent-network/admission-read.ts
+++ b/src/bus/agent-network/admission-read.ts
@@ -1,0 +1,154 @@
+/**
+ * MC-A1 (cortex#1275) — the **admission-rows** read: the ADR-0018 Q3 source of
+ * truth for network membership.
+ *
+ * ## Why this exists (and why NOT `roster-read.ts`)
+ *
+ * A network is a **roster of admitted principals** (CONTEXT.md §188). ADR-0018
+ * **Q3** is emphatic: the roster `members[]` are sourced from **ADMITTED
+ * admission rows**, *not* from announced capabilities — "capabilities are an
+ * orthogonal facet … never the thing that confers membership."
+ *
+ * The existing registry roster read (`roster-read.ts` → `resolveNetworkRoster`,
+ * #1086) consumes `GET /networks/{id}/roster`, whose `members[]` the registry
+ * STILL documents as **capability-derived**
+ * (`src/services/network-registry/src/types.ts` `NetworkRoster`: "membership is
+ * implicit: a principal is in a network if any of their capabilities lists that
+ * network"). Building a *membership* verdict on that read would conflate
+ * capability with membership — exactly the bug class ADR-0015/0018 warn against.
+ * So this module deliberately reads the **admission rows** instead, keyed on the
+ * `AdmissionStatus` (`PENDING | ADMITTED | REJECTED | REVOKED`).
+ *
+ * The Q3-correct *peer* roster read (registry `members[] ← ADMITTED rows`, or an
+ * equivalent member-accessible admitted-roster endpoint) is a **registry-side
+ * prerequisite** that has not yet landed: today a non-admin member can read only
+ * its OWN admission rows (`GET /admission-requests/mine`, a signed PoP read);
+ * the FULL roster list (`GET /admission-requests?status=…`) is admin-gated. This
+ * module therefore models that reality explicitly via {@link AdmissionRowsResult}
+ * `scope` (`"complete"` admin/authoritative vs `"self"` member-PoP) so the
+ * caller knows whether a present-but-unlisted principal is a real anomaly
+ * (`complete`) or simply unknowable from a self-only read (`self`).
+ *
+ * ## Reuse target
+ *
+ * `resolveAdmittedRoster` + the {@link AdmissionRowsProvider} seam are the clean,
+ * reusable foundation the admission-state slice (A2, #1276) and the Pier/PENDING
+ * queue (B1, #1278) build on — not an inline read. The seam is injected so the
+ * orchestration is unit-testable with a fake provider and carries no transport,
+ * crypto, or auth specifics itself.
+ */
+
+/**
+ * Admission lifecycle status, mirroring the registry's `AdmissionStatus`
+ * (`src/services/network-registry/src/types.ts`). Re-declared on the consumer
+ * side (the registry is a separate deploy target — same redeclare rationale as
+ * `src/common/registry/types.ts`).
+ */
+export type AdmissionStatus = "PENDING" | "ADMITTED" | "REJECTED" | "REVOKED";
+
+/**
+ * One admission row, narrowed to the membership-relevant fields. A row binds a
+ * principal to a network at a status. `network_id === null` is a network-less
+ * registration row (registered-but-not-joined) — never a member of any specific
+ * network, so {@link resolveAdmittedRoster} ignores it.
+ */
+export interface AdmissionRow {
+  principal_id: string;
+  network_id: string | null;
+  status: AdmissionStatus;
+}
+
+/**
+ * Outcome of a {@link AdmissionRowsProvider} read. Never throws — every failure
+ * is a discriminated `ok:false` so a long-running view/reconciler branches
+ * without try/catch.
+ *
+ * `scope` on success distinguishes the two member-readable surfaces:
+ *   - `"complete"` — the rows are the FULL network roster (admin-authoritative).
+ *     A present principal NOT in the admitted set is a real anomaly.
+ *   - `"self"` — the rows are only the caller's OWN admission rows (member PoP
+ *     read). The roster is NOT fully known; anomaly detection MUST be suppressed.
+ */
+export type AdmissionRowsResult =
+  | { ok: true; rows: AdmissionRow[]; scope: "complete" | "self" }
+  | {
+      ok: false;
+      reason: "unreachable" | "unauthorized" | "not_configured";
+      detail: string;
+    };
+
+/**
+ * The injected admission-rows read seam. The concrete implementations
+ * (self-PoP `/admission-requests/mine`; admin-list `GET /admission-requests`)
+ * live with their transport/crypto; this interface is all the orchestration —
+ * and the MC endpoint — depend on. Never throws.
+ */
+export interface AdmissionRowsProvider {
+  readAdmissionRows(networkId: string): Promise<AdmissionRowsResult>;
+}
+
+/** The reconciled admitted/pending roster for one network, from admission rows. */
+export interface AdmittedRoster {
+  /** Principal ids whose admission row for this network is `ADMITTED`. */
+  admitted: string[];
+  /** Principal ids whose admission row for this network is `PENDING`. */
+  pending: string[];
+  /**
+   * True when the underlying read was the COMPLETE roster (admin-authoritative).
+   * False for a SELF-only member read — the caller MUST NOT treat a present
+   * non-admitted principal as an anomaly, since the roster is not fully known.
+   */
+  authoritative: boolean;
+}
+
+/** Outcome of {@link resolveAdmittedRoster}. Never throws. */
+export type ResolveAdmittedRosterResult =
+  | { ok: true; roster: AdmittedRoster }
+  | {
+      ok: false;
+      reason: "unreachable" | "unauthorized" | "not_configured";
+      detail: string;
+    };
+
+function dedupePreserveOrder(ids: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+/**
+ * Resolve "who is ADMITTED / PENDING on `networkId`" from the **admission rows**
+ * (ADR-0018 Q3 source of truth), via the injected provider.
+ *
+ * Filters to rows for THIS network (drops network-less registration rows),
+ * projects `ADMITTED` → `admitted[]` and `PENDING` → `pending[]` (deduped,
+ * first-seen order), and carries the read's `scope` through to
+ * `authoritative`. `REJECTED` / `REVOKED` rows are NOT members and are dropped.
+ *
+ * Pure over its injected provider — no transport, crypto, or auth here.
+ */
+export async function resolveAdmittedRoster(
+  networkId: string,
+  provider: AdmissionRowsProvider,
+): Promise<ResolveAdmittedRosterResult> {
+  const res = await provider.readAdmissionRows(networkId);
+  if (!res.ok) {
+    return { ok: false, reason: res.reason, detail: res.detail };
+  }
+  const forNetwork = res.rows.filter((r) => r.network_id === networkId);
+  const admitted = dedupePreserveOrder(
+    forNetwork.filter((r) => r.status === "ADMITTED").map((r) => r.principal_id),
+  );
+  const pending = dedupePreserveOrder(
+    forNetwork.filter((r) => r.status === "PENDING").map((r) => r.principal_id),
+  );
+  return {
+    ok: true,
+    roster: { admitted, pending, authoritative: res.scope === "complete" },
+  };
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -171,6 +171,12 @@ import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/r
 // MC-I1.S1 (ADR-0005) — in-process Mission Control embed (supersedes api.*).
 import { startMissionControl, type MissionControlHandle } from "./surface/mc/embed";
 import type { AgentPresenceView } from "./surface/mc/api/agents";
+import type { NetworksView } from "./surface/mc/api/networks";
+import {
+  resolveAdmittedRoster,
+  type AdmissionRowsProvider,
+  type AdmissionRowsResult,
+} from "./bus/agent-network/admission-read";
 // MC-I1.S4 (ADR-0005 §4) — bus→MC dispatch-lifecycle projection renderer.
 import { createDispatchProjectionRenderer } from "./surface/mc/projection/dispatch-lifecycle-renderer";
 // P-14 U2.1 (#934) — bus→MC observability projection renderer (signal's four
@@ -5127,6 +5133,12 @@ export async function startCortex(
   // registry boots AFTER this embed (below), so the getter returns `null` until
   // we assign it post-registry-start. The MC server resolves it per request.
   let presenceViewForApi: AgentPresenceView | null = null;
+  // MC-A1 (cortex#1275) — mutable holder threaded into the MC server as a lazy
+  // getter so `GET /api/networks` can read the joined networks + their admitted
+  // roster ⋈ presence. Assigned in the federation block below (after
+  // `resolvedPolicy` is known); `null` until then ⇒ the route serves an empty
+  // list. The MC server resolves it per request.
+  let networksViewForApi: NetworksView | null = null;
   // #1008/#989 — discovered LOCAL sibling stacks, used by BOTH the DB-read
   // pane-of-glass aggregation (the embed's `localAggregation` getter, below, for
   // session trees) AND the #989 bus sibling-presence aggregator (later, for
@@ -5201,6 +5213,9 @@ export async function startCortex(
         port: config.mc.port,
         ...(mcHeadless ? { headless: true } : {}),
         agentPresence: () => presenceViewForApi,
+        // MC-A1 (cortex#1275) — networks view (lazy; assigned in the federation
+        // block once `resolvedPolicy` is known). null ⇒ empty `/api/networks`.
+        networks: () => networksViewForApi,
         // #1008 — DB-read pane-of-glass aggregation. The getter returns a context
         // only when discovery produced a resolve-opts (dbRead on); otherwise null
         // ⇒ single-db feeds. Lazy so the roster can be (re)read consistently.
@@ -5575,6 +5590,51 @@ export async function startCortex(
             "cortex: federation roster reconciler started — continuously admitting roster-named peers (opt-in per network; registry-authoritative; chain-verify unchanged)",
           );
         }
+      }
+
+      // MC-A1 (cortex#1275) — wire the `/api/networks` view: surface the joined
+      // networks as first-class trust groups with their admitted roster ⋈
+      // presence → membership verdict. Membership is sourced from the ADMISSION
+      // ROWS (ADR-0018 Q3), NOT the capability-derived `GET /networks/{id}/roster`
+      // (`resolveNetworkRoster`) — conflating capability with membership is the
+      // bug Q3 forbids.
+      //
+      // ESCALATION / FOLLOW-UP (A2 #1276): the LIVE admission-rows provider is
+      // not wired here. A non-admin member can read only its OWN admission rows
+      // today (signed PoP `GET /admission-requests/mine`, scope `self`); the FULL
+      // admitted roster is admin-gated, and a Q3-correct member-accessible PEER
+      // roster read is a registry-side prerequisite (registry `members[]` is
+      // still capability-derived — see `NetworkRoster` in the registry's
+      // types.ts). So A1 wires the seam + a `not_configured` provider: the view
+      // surfaces each joined network + the serving principal's own membership,
+      // with `roster_status: "not_configured"` until A2 drops in the real
+      // admission-rows provider. The model, reconciliation, endpoint, and
+      // frontend are all in place behind this single seam.
+      const networksList = resolvedPolicy?.federated?.networks;
+      if (networksList !== undefined && networksList.length > 0) {
+        // A1 seam — replaced by the self-PoP / admin-list admission-rows provider
+        // in A2. Returns `not_configured` so the endpoint degrades to self-only
+        // membership rather than building on the capability roster.
+        const admissionProvider: AdmissionRowsProvider = {
+          readAdmissionRows: (): Promise<AdmissionRowsResult> =>
+            Promise.resolve({
+              ok: false,
+              reason: "not_configured",
+              detail:
+                "live admission-rows read not wired (A1 seam) — pending A2 (#1276) + registry ADR-0018 Q3 roster fix",
+            }),
+        };
+        networksViewForApi = {
+          localPrincipal: principalId,
+          networks: () =>
+            networksList.map((n) => ({ networkId: n.id, leafNode: n.leaf_node })),
+          resolveAdmittedRoster: (networkId) =>
+            resolveAdmittedRoster(networkId, admissionProvider),
+        };
+        console.log(
+          `cortex: MC /api/networks view wired — ${networksList.length.toString()} joined network(s) ` +
+            "as first-class trust groups (admission-rows roster source pending A2 #1276)",
+        );
       }
 
       // P-14 U3.3 (#937) — the trust-verified federated OBSERVABILITY fold, the

--- a/src/surface/mc/__tests__/networks-api.test.ts
+++ b/src/surface/mc/__tests__/networks-api.test.ts
@@ -77,6 +77,24 @@ describe("handleListNetworks — graceful states", () => {
     expect(await body(res)).toEqual({ networks: [] });
   });
 
+  it("a throwing admission provider degrades to unreachable, never 5xx", async () => {
+    const throwingView: NetworksView = {
+      localPrincipal: "andreas",
+      networks: () => [{ networkId: "research-collab", leafNode: "rc-leaf" }],
+      resolveAdmittedRoster: () => Promise.reject(new Error("transport boom")),
+    };
+    const res = await handleListNetworks(
+      throwingView,
+      presenceView([rec({ agentId: "luna" })]),
+    );
+    expect(res.status).toBe(200);
+    const net = (await body(res)).networks[0]!;
+    expect(net.roster_status).toBe("unreachable");
+    expect(net.members).toEqual([
+      { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"] },
+    ]);
+  });
+
   it("read failure degrades to a self-only membership, never 5xx", async () => {
     const res = await handleListNetworks(
       view({

--- a/src/surface/mc/__tests__/networks-api.test.ts
+++ b/src/surface/mc/__tests__/networks-api.test.ts
@@ -1,0 +1,197 @@
+/**
+ * MC-A1 (cortex#1275) — `handleListNetworks` tests.
+ *
+ * Drives the handler directly over a stub `NetworksView` + `AgentPresenceView`
+ * (the minimal read-only contracts; no bus, no registry, no HTTP). Covers the
+ * graceful no-federation path, the admitted ⋈ presence reconciliation, the
+ * self-scoped anomaly-suppression (the registry-Q3-prerequisite reality), the
+ * authoritative anomaly path, and read-failure degradation (never 5xx).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  handleListNetworks,
+  type NetworksView,
+  type ListNetworksResponse,
+} from "../api/networks";
+import type {
+  AgentPresenceSnapshotRecord,
+  AgentPresenceView,
+} from "../api/agents";
+import type { ResolveAdmittedRosterResult } from "../../../bus/agent-network/admission-read";
+
+function presenceView(
+  records: AgentPresenceSnapshotRecord[],
+): AgentPresenceView {
+  return { getAgents: () => records };
+}
+
+function rec(
+  over: Partial<AgentPresenceSnapshotRecord> & { agentId: string },
+): AgentPresenceSnapshotRecord {
+  const { agentId } = over;
+  return {
+    key: `andreas/main/${agentId}`,
+    origin: "local",
+    nkeyPublicKey: `N${agentId}`,
+    assistantName: null,
+    principal: "andreas",
+    stack: "main",
+    capabilities: [],
+    state: "online",
+    lastSeenAt: 1000,
+    ...over,
+  };
+}
+
+function view(
+  rosters: Record<string, ResolveAdmittedRosterResult>,
+  localPrincipal = "andreas",
+): NetworksView {
+  return {
+    localPrincipal,
+    networks: () =>
+      Object.keys(rosters).map((networkId) => ({
+        networkId,
+        leafNode: `${networkId}-leaf`,
+      })),
+    resolveAdmittedRoster: (networkId) =>
+      Promise.resolve(
+        rosters[networkId] ?? {
+          ok: false,
+          reason: "not_configured",
+          detail: "no roster",
+        },
+      ),
+  };
+}
+
+async function body(res: Response): Promise<ListNetworksResponse> {
+  return (await res.json()) as ListNetworksResponse;
+}
+
+describe("handleListNetworks — graceful states", () => {
+  it("view === null → empty networks list (no federation configured)", async () => {
+    const res = await handleListNetworks(null, null);
+    expect(res.status).toBe(200);
+    expect(await body(res)).toEqual({ networks: [] });
+  });
+
+  it("read failure degrades to a self-only membership, never 5xx", async () => {
+    const res = await handleListNetworks(
+      view({
+        "research-collab": {
+          ok: false,
+          reason: "unreachable",
+          detail: "registry down",
+        },
+      }),
+      presenceView([rec({ agentId: "luna" })]),
+    );
+    expect(res.status).toBe(200);
+    const out = await body(res);
+    const net = out.networks[0]!;
+    expect(net.roster_status).toBe("unreachable");
+    expect(net.roster_scope).toBeNull();
+    // Self is still a member (joined stack) + present.
+    expect(net.members).toEqual([
+      { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"] },
+    ]);
+  });
+});
+
+describe("handleListNetworks — authoritative reconciliation", () => {
+  it("admitted peer present → admitted-present; admitted peer absent → admitted-absent", async () => {
+    const res = await handleListNetworks(
+      view({
+        "research-collab": {
+          ok: true,
+          roster: { admitted: ["jc", "zeta"], pending: [], authoritative: true },
+        },
+      }),
+      presenceView([
+        rec({ agentId: "luna" }), // andreas/main present
+        rec({
+          agentId: "echo",
+          origin: { kind: "foreign", principal: "jc", stack: "research" },
+        }),
+      ]),
+    );
+    const net = (await body(res)).networks[0]!;
+    expect(net.roster_scope).toBe("complete");
+    const byPrincipal = Object.fromEntries(net.members.map((m) => [m.principal, m.verdict]));
+    expect(byPrincipal).toEqual({
+      andreas: "admitted-present",
+      jc: "admitted-present",
+      zeta: "admitted-absent",
+    });
+  });
+
+  it("present foreign principal admitted to NO network → present-but-unadmitted (anomaly)", async () => {
+    const res = await handleListNetworks(
+      view({
+        "research-collab": {
+          ok: true,
+          roster: { admitted: ["jc"], pending: [], authoritative: true },
+        },
+      }),
+      presenceView([
+        rec({ agentId: "luna" }),
+        rec({
+          agentId: "x",
+          origin: { kind: "foreign", principal: "mallory", stack: "s" },
+        }),
+      ]),
+    );
+    const net = (await body(res)).networks[0]!;
+    expect(net.members).toContainEqual({
+      principal: "mallory",
+      verdict: "present-but-unadmitted",
+      present_stacks: ["s"],
+    });
+  });
+
+  it("pending admission request surfaces as pending", async () => {
+    const res = await handleListNetworks(
+      view({
+        "research-collab": {
+          ok: true,
+          roster: { admitted: [], pending: ["newcomer"], authoritative: true },
+        },
+      }),
+      presenceView([rec({ agentId: "luna" })]),
+    );
+    const net = (await body(res)).networks[0]!;
+    expect(net.members).toContainEqual({
+      principal: "newcomer",
+      verdict: "pending",
+      present_stacks: [],
+    });
+  });
+});
+
+describe("handleListNetworks — self-scoped read suppresses anomalies (registry-Q3 reality)", () => {
+  it("does NOT flag present peers as anomalies when the roster is self-only", async () => {
+    const res = await handleListNetworks(
+      view({
+        "research-collab": {
+          ok: true,
+          // self-only read: we know we're admitted, but NOT the peer roster.
+          roster: { admitted: ["andreas"], pending: [], authoritative: false },
+        },
+      }),
+      presenceView([
+        rec({ agentId: "luna" }),
+        rec({
+          agentId: "echo",
+          origin: { kind: "foreign", principal: "jc", stack: "research" },
+        }),
+      ]),
+    );
+    const net = (await body(res)).networks[0]!;
+    expect(net.roster_scope).toBe("self");
+    // jc is present but must NOT be flagged unadmitted — we can't prove it.
+    expect(net.members.some((m) => m.verdict === "present-but-unadmitted")).toBe(false);
+    expect(net.members.map((m) => m.principal)).toEqual(["andreas"]);
+  });
+});

--- a/src/surface/mc/__tests__/networks-http.test.ts
+++ b/src/surface/mc/__tests__/networks-http.test.ts
@@ -1,0 +1,124 @@
+/**
+ * MC-A1 (cortex#1275) — `GET /api/networks` end-to-end route tests.
+ *
+ * Drives the route through the real Bun.serve HTTP stack with stub
+ * `NetworksView` + `AgentPresenceView` getters — confirming the route is wired,
+ * the lazy getter resolves per request, the no-view path serves an empty list,
+ * and non-GET methods are rejected.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+import { startServer, type ServerContext } from "../server";
+import { initDatabase } from "../db/init";
+import { DEFAULT_CONFIG } from "../config";
+import type { NetworksView } from "../api/networks";
+import type { AgentPresenceView } from "../api/agents";
+import type { Database } from "bun:sqlite";
+
+const PORT_BIND_ANY = 0;
+
+function boundPort(ctx: ServerContext): number {
+  const port = ctx.server.port;
+  if (port === undefined) throw new Error("server.port unresolved after start");
+  return port;
+}
+
+interface Ctx {
+  db: Database;
+  ctx: ServerContext;
+  baseUrl: string;
+  tmpDir: string;
+}
+
+function startWith(opts: {
+  networks?: () => NetworksView | null;
+  agentPresence?: () => AgentPresenceView | null;
+}): Ctx {
+  const tmpDir = join(tmpdir(), `mc-networks-test-${Date.now()}-${Math.random()}`);
+  const db = initDatabase(join(tmpDir, "test.db"));
+  const ctx = startServer({ ...DEFAULT_CONFIG, port: PORT_BIND_ANY }, db, {
+    ...(opts.networks ? { networks: opts.networks } : {}),
+    ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
+  });
+  return { db, ctx, baseUrl: `http://localhost:${boundPort(ctx)}`, tmpDir };
+}
+
+function teardown(c: Ctx): void {
+  c.ctx.stop(true);
+  c.db.close();
+  rmSync(c.tmpDir, { recursive: true, force: true });
+}
+
+describe("GET /api/networks (HTTP)", () => {
+  let c: Ctx;
+  afterEach(() => {
+    teardown(c);
+  });
+
+  it("returns an empty list when no networks view is wired", async () => {
+    c = startWith({});
+    const res = await fetch(`${c.baseUrl}/api/networks`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ networks: [] });
+  });
+
+  it("returns an empty list when the getter resolves to null", async () => {
+    c = startWith({ networks: () => null });
+    const res = await fetch(`${c.baseUrl}/api/networks`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).networks).toEqual([]);
+  });
+
+  it("serves the reconciled membership through the wired view", async () => {
+    const view: NetworksView = {
+      localPrincipal: "andreas",
+      networks: () => [{ networkId: "research-collab", leafNode: "rc-leaf" }],
+      resolveAdmittedRoster: () =>
+        Promise.resolve({
+          ok: true,
+          roster: { admitted: ["jc"], pending: [], authoritative: true },
+        }),
+    };
+    const presence: AgentPresenceView = {
+      getAgents: () => [
+        {
+          key: "andreas/main/luna",
+          origin: "local",
+          agentId: "luna",
+          nkeyPublicKey: "NL",
+          assistantName: "Luna",
+          principal: "andreas",
+          stack: "main",
+          capabilities: [],
+          state: "online",
+          lastSeenAt: 1,
+        },
+      ],
+    };
+    c = startWith({ networks: () => view, agentPresence: () => presence });
+    const res = await fetch(`${c.baseUrl}/api/networks`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.networks).toHaveLength(1);
+    expect(body.networks[0].network_id).toBe("research-collab");
+    expect(body.networks[0].leaf_node).toBe("rc-leaf");
+    expect(body.networks[0].roster_scope).toBe("complete");
+    const byPrincipal = Object.fromEntries(
+      body.networks[0].members.map((m: { principal: string; verdict: string }) => [
+        m.principal,
+        m.verdict,
+      ]),
+    );
+    expect(byPrincipal).toEqual({ andreas: "admitted-present", jc: "admitted-absent" });
+  });
+
+  it("rejects non-GET methods", async () => {
+    c = startWith({ networks: () => null });
+    const res = await fetch(`${c.baseUrl}/api/networks`, { method: "POST" });
+    expect(res.status).toBe(405);
+  });
+});

--- a/src/surface/mc/__tests__/networks-membership.test.ts
+++ b/src/surface/mc/__tests__/networks-membership.test.ts
@@ -1,0 +1,206 @@
+/**
+ * MC-A1 (cortex#1275) — unit tests for the pure membership-reconciliation logic
+ * (intent roster ⋈ presence reality → verdict). No HTTP, no registry, no bus.
+ *
+ * The load-bearing trust property under test: the registry roster is the SOURCE
+ * OF TRUTH for membership (ADR-0018 Q3); presence only decides present/absent;
+ * capabilities never enter the picture; and presence is keyed by VERIFIED
+ * origin, never a wire token.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  reconcileNetworkMembership,
+  derivePresentStacksByPrincipal,
+  foreignPresentPrincipals,
+} from "../api/networks-membership";
+import type { AgentPresenceSnapshotRecord } from "../api/agents";
+
+function present(
+  entries: Record<string, string[]>,
+): Map<string, readonly string[]> {
+  return new Map(Object.entries(entries));
+}
+
+function rec(
+  over: Partial<AgentPresenceSnapshotRecord> & { agentId: string },
+): AgentPresenceSnapshotRecord {
+  const { agentId } = over;
+  return {
+    key: `andreas/research/${agentId}`,
+    origin: "local",
+    nkeyPublicKey: `N${agentId}`,
+    assistantName: null,
+    principal: "andreas",
+    stack: "research",
+    capabilities: [],
+    state: "online",
+    lastSeenAt: 1000,
+    ...over,
+  };
+}
+
+describe("reconcileNetworkMembership — verdict semantics", () => {
+  it("admitted + present → admitted-present (with present stacks)", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["jc"],
+      presentStacksByPrincipal: present({ jc: ["research"] }),
+    });
+    expect(members).toEqual([
+      { principal: "jc", verdict: "admitted-present", presentStacks: ["research"] },
+    ]);
+  });
+
+  it("admitted + absent → admitted-absent (no present stacks)", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["jc"],
+      presentStacksByPrincipal: present({}),
+    });
+    expect(members).toEqual([
+      { principal: "jc", verdict: "admitted-absent", presentStacks: [] },
+    ]);
+  });
+
+  it("present but on no roster + flagged a candidate → present-but-unadmitted (anomaly)", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["andreas"],
+      presentStacksByPrincipal: present({ andreas: ["main"], mallory: ["x"] }),
+      anomalyCandidates: ["mallory"],
+    });
+    expect(members).toContainEqual({
+      principal: "mallory",
+      verdict: "present-but-unadmitted",
+      presentStacks: ["x"],
+    });
+  });
+
+  it("pending request not yet admitted → pending", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["andreas"],
+      presentStacksByPrincipal: present({ andreas: ["main"] }),
+      pending: ["newcomer"],
+    });
+    expect(members).toContainEqual({
+      principal: "newcomer",
+      verdict: "pending",
+      presentStacks: [],
+    });
+  });
+});
+
+describe("reconcileNetworkMembership — precedence + determinism", () => {
+  it("admitted wins over pending on overlap (roster is authoritative)", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["jc"],
+      presentStacksByPrincipal: present({ jc: ["research"] }),
+      pending: ["jc"], // also (stale) pending → must not double-list
+    });
+    expect(members).toHaveLength(1);
+    expect(members[0]).toEqual({
+      principal: "jc",
+      verdict: "admitted-present",
+      presentStacks: ["research"],
+    });
+  });
+
+  it("a candidate that is admitted is NOT an anomaly", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["jc"],
+      presentStacksByPrincipal: present({ jc: ["research"] }),
+      anomalyCandidates: ["jc"],
+    });
+    expect(members.filter((m) => m.verdict === "present-but-unadmitted")).toHaveLength(0);
+  });
+
+  it("an anomaly candidate that is NOT present is dropped (no phantom anomalies)", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["andreas"],
+      presentStacksByPrincipal: present({ andreas: ["main"] }),
+      anomalyCandidates: ["ghost"], // not present → not an anomaly
+    });
+    expect(members.map((m) => m.principal)).toEqual(["andreas"]);
+  });
+
+  it("orders admitted (roster order) → pending → anomalies; dedupes present stacks", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["b", "a"],
+      presentStacksByPrincipal: present({
+        a: ["s2", "s1", "s1"],
+        b: ["s1"],
+        c: ["x"],
+      }),
+      pending: ["p"],
+      anomalyCandidates: ["c"],
+    });
+    expect(members.map((m) => m.principal)).toEqual(["b", "a", "p", "c"]);
+    // a's stacks deduped + sorted
+    expect(members.find((m) => m.principal === "a")?.presentStacks).toEqual(["s1", "s2"]);
+  });
+
+  it("capabilities never confer membership — an admitted-absent member with no presence stays absent regardless of any capability facet", () => {
+    // The helper has no capability input at all; this asserts the contract by
+    // construction — membership is roster ⋈ presence only.
+    const members = reconcileNetworkMembership({
+      admitted: ["offerer"],
+      presentStacksByPrincipal: present({}),
+    });
+    expect(members[0]?.verdict).toBe("admitted-absent");
+  });
+});
+
+describe("derivePresentStacksByPrincipal — verified-origin keying", () => {
+  it("keys a local agent under the SERVING principal + its own stack", () => {
+    const map = derivePresentStacksByPrincipal(
+      [rec({ agentId: "luna", origin: "local", principal: "andreas", stack: "main" })],
+      "andreas",
+    );
+    expect(map.get("andreas")).toEqual(["main"]);
+  });
+
+  it("keys a foreign agent under its VERIFIED origin, NOT the wire principal/stack", () => {
+    const map = derivePresentStacksByPrincipal(
+      [
+        rec({
+          agentId: "echo",
+          origin: { kind: "foreign", principal: "jc", stack: "research" },
+          // wire fields a peer could spoof — must be IGNORED:
+          principal: "spoofed",
+          stack: "spoofed-stack",
+        }),
+      ],
+      "andreas",
+    );
+    expect(map.get("jc")).toEqual(["research"]);
+    expect(map.has("spoofed")).toBe(false);
+  });
+
+  it("excludes offline agents from presence", () => {
+    const map = derivePresentStacksByPrincipal(
+      [rec({ agentId: "luna", state: "offline", offlineReason: "shutdown" })],
+      "andreas",
+    );
+    expect(map.size).toBe(0);
+  });
+
+  it("merges multiple agents of a principal across stacks (sorted unique)", () => {
+    const map = derivePresentStacksByPrincipal(
+      [
+        rec({ agentId: "a", origin: { kind: "foreign", principal: "jc", stack: "s2" } }),
+        rec({ agentId: "b", origin: { kind: "foreign", principal: "jc", stack: "s1" } }),
+        rec({ agentId: "c", origin: { kind: "foreign", principal: "jc", stack: "s1" } }),
+      ],
+      "andreas",
+    );
+    expect(map.get("jc")).toEqual(["s1", "s2"]);
+  });
+});
+
+describe("foreignPresentPrincipals", () => {
+  it("returns present cross-principal ids, excluding the serving principal, sorted", () => {
+    const out = foreignPresentPrincipals(
+      present({ andreas: ["main"], jc: ["research"], zeta: ["x"] }),
+      "andreas",
+    );
+    expect(out).toEqual(["jc", "zeta"]);
+  });
+});

--- a/src/surface/mc/api/networks-membership.ts
+++ b/src/surface/mc/api/networks-membership.ts
@@ -1,0 +1,223 @@
+/**
+ * MC-A1 (cortex#1275) — pure membership-reconciliation logic for the MC Network
+ * view's "networks as first-class trust groups" surface.
+ *
+ * A network is a **roster of admitted principals** (CONTEXT.md §188; ADR-0015 /
+ * ADR-0018). The registry is the **source of truth** for that roster: its
+ * `members[]` come from ADMITTED admission rows, NOT from announced capabilities
+ * (ADR-0018 Q3). Capabilities are an orthogonal facet — what an admitted member
+ * *offers*, never the thing that *confers* membership. This module therefore
+ * NEVER reads or considers capabilities; it reconciles the admitted **roster
+ * (intent)** against observed **presence (reality)** into a per-member
+ * **membership verdict**.
+ *
+ * ## The reconciliation (intent ⋈ reality)
+ *
+ *   - **intent**  — the admitted-principal roster (from the registry; the
+ *     endpoint injects the local/serving principal too, since a joined stack is
+ *     itself a member).
+ *   - **reality** — which principals we actually observe present, derived from
+ *     the in-memory agent-presence registry. Presence is keyed by the
+ *     **verified origin** `{principal}` (the ADR-0003 roster identity), NEVER an
+ *     attacker-controlled wire token (mirrors `network-graph-adapter`'s
+ *     origin-grouping rule).
+ *
+ * The verdict per member:
+ *   - `admitted-present`        — on the roster AND observed present.
+ *   - `admitted-absent`         — on the roster but not observed present.
+ *   - `present-but-unadmitted`  — observed present (federated) but on no roster
+ *                                 — an ANOMALY worth surfacing (e.g. a stale
+ *                                 roster, or a hand-pinned static peer with no
+ *                                 registry admission).
+ *   - `pending`                 — a pending admission request, not yet admitted.
+ *                                 (A1 has no pending source — the registry
+ *                                 roster carries ADMITTED rows only — so the
+ *                                 endpoint passes none; the verdict exists so
+ *                                 A2/A3/B build on a complete model.)
+ *
+ * Pure + dependency-light: no I/O, no bus, no registry client. The only import
+ * is the structural presence-record TYPE from the sibling `/api/agents`
+ * contract, so the reality-derivation helper can read a snapshot. Trivially
+ * unit-testable.
+ */
+
+import type { AgentPresenceSnapshotRecord } from "./agents";
+
+/**
+ * The reconciled standing of one principal against a network's admitted roster.
+ * See the module header for the precise semantics of each value.
+ */
+export type MembershipVerdict =
+  | "admitted-present"
+  | "admitted-absent"
+  | "present-but-unadmitted"
+  | "pending";
+
+/** One reconciled roster member: a principal + its membership verdict. */
+export interface MembershipMember {
+  /** The member principal id (the roster is principal-keyed; ADR-0018 Q3). */
+  principal: string;
+  /** Reconciled standing of this principal against the roster ⋈ presence. */
+  verdict: MembershipVerdict;
+  /**
+   * Stacks of this principal observed present (verified-origin-keyed), sorted +
+   * deduped. Empty for an absent or pending-without-presence member. Presence
+   * detail only — never a session interior (ADR-0007).
+   */
+  presentStacks: string[];
+}
+
+/** Inputs to {@link reconcileNetworkMembership} — one network's intent ⋈ reality. */
+export interface ReconcileMembershipInput {
+  /**
+   * Admitted principal ids for THIS network (the registry roster = source of
+   * truth, ADR-0018 Q3). The endpoint injects the serving principal here too: a
+   * joined stack is itself an admitted member of the network. Order is
+   * preserved in the output (deduped first-seen).
+   */
+  admitted: readonly string[];
+  /**
+   * Reality: principal → the stacks of that principal observed present. Keyed by
+   * the VERIFIED origin principal (never a wire token). A principal is "present"
+   * iff it has a non-empty entry here.
+   */
+  presentStacksByPrincipal: ReadonlyMap<string, readonly string[]>;
+  /**
+   * Principals with a PENDING admission request (B2 source). Empty in A1 — the
+   * registry roster carries ADMITTED rows only. A pending principal that is also
+   * admitted is treated as admitted (the roster wins).
+   */
+  pending?: readonly string[];
+  /**
+   * Foreign principals present that THIS network should consider for the
+   * `present-but-unadmitted` anomaly. The endpoint supplies only principals
+   * admitted to NO joined network, so a peer admitted on another network is not
+   * falsely flagged as an anomaly here. A present principal already in
+   * `admitted` / `pending` is never an anomaly.
+   */
+  anomalyCandidates?: readonly string[];
+}
+
+/**
+ * Reconcile one network's admitted roster (intent) against observed presence
+ * (reality) into a per-member verdict list.
+ *
+ * Ordering is deterministic + stable: admitted members first (first-seen roster
+ * order), then pending (input order), then anomalies (input order). Each
+ * principal appears at most once — admitted ⊐ pending ⊐ anomaly precedence.
+ *
+ * Pure: no I/O, no mutation of inputs.
+ */
+export function reconcileNetworkMembership(
+  input: ReconcileMembershipInput,
+): MembershipMember[] {
+  const { admitted, presentStacksByPrincipal } = input;
+  const pending = input.pending ?? [];
+  const anomalyCandidates = input.anomalyCandidates ?? [];
+
+  const seen = new Set<string>();
+  const members: MembershipMember[] = [];
+
+  const stacksOf = (principal: string): string[] => {
+    const stacks = presentStacksByPrincipal.get(principal);
+    if (stacks === undefined || stacks.length === 0) return [];
+    // Sorted + deduped for a deterministic, render-stable detail.
+    return [...new Set(stacks)].sort();
+  };
+  const isPresent = (principal: string): boolean =>
+    stacksOf(principal).length > 0;
+
+  // 1) Admitted roster (intent). Present → admitted-present, else admitted-absent.
+  for (const principal of admitted) {
+    if (seen.has(principal)) continue;
+    seen.add(principal);
+    const presentStacks = stacksOf(principal);
+    members.push({
+      principal,
+      verdict: presentStacks.length > 0 ? "admitted-present" : "admitted-absent",
+      presentStacks,
+    });
+  }
+
+  // 2) Pending admission requests not already admitted (roster wins on overlap).
+  for (const principal of pending) {
+    if (seen.has(principal)) continue;
+    seen.add(principal);
+    members.push({
+      principal,
+      verdict: "pending",
+      presentStacks: stacksOf(principal),
+    });
+  }
+
+  // 3) Anomalies — present but on no roster + not pending. Surfaced so a stale
+  //    roster or an un-admitted hand-pinned peer is VISIBLE, never silently
+  //    rendered as a member.
+  for (const principal of anomalyCandidates) {
+    if (seen.has(principal)) continue;
+    if (!isPresent(principal)) continue; // only present principals are anomalies
+    seen.add(principal);
+    members.push({
+      principal,
+      verdict: "present-but-unadmitted",
+      presentStacks: stacksOf(principal),
+    });
+  }
+
+  return members;
+}
+
+/**
+ * Derive the presence reality map — principal → present stacks — from an
+ * agent-presence snapshot.
+ *
+ * Trust rule (mirrors `network-graph-adapter.originScope`): a principal/stack is
+ * taken from the record's VERIFIED ORIGIN — `localPrincipal` + the record's own
+ * stack for a `"local"` agent, or the chain-verified `{principal,stack}` for a
+ * `"foreign"` agent — NEVER the wire `principal`/`stack` fields (which a peer
+ * could spoof). Only `state: "online"` records count as present (a known-offline
+ * agent is not live presence).
+ *
+ * Returns a map keyed by verified principal → sorted unique present stacks.
+ */
+export function derivePresentStacksByPrincipal(
+  records: readonly AgentPresenceSnapshotRecord[],
+  localPrincipal: string,
+): Map<string, string[]> {
+  const byPrincipal = new Map<string, Set<string>>();
+  for (const r of records) {
+    if (r.state !== "online") continue;
+    const principal = r.origin === "local" ? localPrincipal : r.origin.principal;
+    const stack = r.origin === "local" ? r.stack : r.origin.stack;
+    let stacks = byPrincipal.get(principal);
+    if (stacks === undefined) {
+      stacks = new Set<string>();
+      byPrincipal.set(principal, stacks);
+    }
+    stacks.add(stack);
+  }
+  const out = new Map<string, string[]>();
+  for (const [principal, stacks] of byPrincipal) {
+    out.set(principal, [...stacks].sort());
+  }
+  return out;
+}
+
+/**
+ * The set of FOREIGN principals (cross-principal — not the serving principal)
+ * observed present. The endpoint subtracts the union of all admitted rosters
+ * from this to compute each network's anomaly candidates. Local + same-principal
+ * sibling presence is the serving stack itself, never a federated anomaly, so
+ * the serving principal is excluded.
+ */
+export function foreignPresentPrincipals(
+  presentStacksByPrincipal: ReadonlyMap<string, readonly string[]>,
+  localPrincipal: string,
+): string[] {
+  const out: string[] = [];
+  for (const principal of presentStacksByPrincipal.keys()) {
+    if (principal === localPrincipal) continue;
+    out.push(principal);
+  }
+  return out.sort();
+}

--- a/src/surface/mc/api/networks.ts
+++ b/src/surface/mc/api/networks.ts
@@ -166,7 +166,18 @@ export async function handleListNetworks(
     const resolved = await Promise.all(
       joined.map(async (n) => ({
         info: n,
-        result: await view.resolveAdmittedRoster(n.networkId),
+        // The `resolveAdmittedRoster` contract is never-throw, but A2's live
+        // provider carries transport + crypto: enforce the never-5xx guarantee
+        // STRUCTURALLY here so a stray rejection degrades to "unreachable"
+        // (the network still renders self-only) rather than rejecting the
+        // Promise.all and falling through to the 500 path.
+        result: await view.resolveAdmittedRoster(n.networkId).catch(
+          (err: unknown): ResolveAdmittedRosterResult => ({
+            ok: false,
+            reason: "unreachable",
+            detail: `admission read threw: ${err instanceof Error ? err.message : String(err)}`,
+          }),
+        ),
       })),
     );
 

--- a/src/surface/mc/api/networks.ts
+++ b/src/surface/mc/api/networks.ts
@@ -1,0 +1,243 @@
+/**
+ * MC-A1 (cortex#1275) — `GET /api/networks` (networks-as-first-class data source).
+ *
+ * Serves each JOINED network as a first-class **trust group** with its ADMITTED
+ * roster, reconciled against observed presence into a per-member **membership
+ * verdict**. This is the Network view's admission-layer feed, the sibling of the
+ * transport-layer reconciliation MC already does (U2.3/U3.3 via signal).
+ *
+ * ## Source of truth = admission rows (ADR-0018 Q3), NOT the capability roster
+ *
+ * Membership is read from the **admission rows** via `resolveAdmittedRoster`
+ * (`src/bus/agent-network/admission-read.ts`), keyed on `AdmissionStatus`. We
+ * deliberately do NOT use the registry's `GET /networks/{id}/roster`
+ * (`resolveNetworkRoster`, #1086): that route's `members[]` is still
+ * **capability-derived** (registry `src/services/network-registry/src/types.ts`
+ * `NetworkRoster`), and conflating capability with membership is the exact bug
+ * ADR-0018 Q3 forbids. Capabilities never enter this handler.
+ *
+ * ## Authoritative vs self-scoped reads (registry-side Q3 prerequisite)
+ *
+ * Today a non-admin member can authoritatively read only its OWN admission rows
+ * (member PoP read). The FULL admitted roster (admin-list) is admin-gated, and a
+ * Q3-correct member-accessible *peer* roster read is a registry-side
+ * prerequisite that has not yet landed. The admission read carries this through
+ * as `roster.authoritative`: when the roster is NOT authoritative (a self-only
+ * read), the handler SUPPRESSES anomaly detection — a present non-admitted
+ * principal is not flagged `present-but-unadmitted`, because admission simply
+ * isn't knowable from a self-only read (avoids a false-anomaly storm over
+ * legitimately-admitted peers we can't yet enumerate).
+ *
+ * ## Dependency direction (surface must not import the bus)
+ *
+ * Like `/api/agents`, the server depends only on the minimal {@link NetworksView}
+ * interface declared here; `cortex.ts` adapts the concrete admission-rows
+ * provider + `policy.federated.networks` to it at boot. The MC surface imports
+ * only the result TYPE from the admission-read lib (type-only), never the bus.
+ *
+ * ## Graceful, never-5xx
+ *
+ *   - `view === null` (no registry/federation) → `{networks:[]}`. "No networks"
+ *     is the correct rendering, not an error.
+ *   - admission read failure (unreachable / unauthorized / not_configured) → the
+ *     network still renders (self-only membership, status surfaced). Never a 5xx.
+ *
+ * ## No signal dependency
+ *
+ * The CORE membership verdict is admission ⋈ presence only. Signal enriches the
+ * TRANSPORT layer (the existing overlay), never membership; no signal import.
+ */
+
+import type { AgentPresenceView } from "./agents";
+import type { ResolveAdmittedRosterResult } from "../../../bus/agent-network/admission-read";
+import {
+  reconcileNetworkMembership,
+  derivePresentStacksByPrincipal,
+  foreignPresentPrincipals,
+  type MembershipVerdict,
+} from "./networks-membership";
+
+export type { MembershipVerdict } from "./networks-membership";
+
+/** One joined network's static identity (from `policy.federated.networks[]`). */
+export interface JoinedNetworkInfo {
+  /** Network id (`policy.federated.networks[].id`). */
+  networkId: string;
+  /** The network's leaf-node connection id (`.leaf_node`). */
+  leafNode: string;
+}
+
+/**
+ * The minimal read-only contract the MC server depends on to serve
+ * `/api/networks`. `cortex.ts` supplies a live implementation built from
+ * `policy.federated.{networks,registry}` + the admission-rows provider; tests
+ * supply a stub. The surface layer never imports the bus.
+ */
+export interface NetworksView {
+  /** The serving (local) principal — itself an admitted member of each joined network. */
+  localPrincipal: string;
+  /** The joined networks (config order). */
+  networks(): JoinedNetworkInfo[];
+  /**
+   * Resolve a network's ADMITTED/PENDING roster from the **admission rows**
+   * (ADR-0018 Q3). Wraps `resolveAdmittedRoster` — never throws.
+   */
+  resolveAdmittedRoster(networkId: string): Promise<ResolveAdmittedRosterResult>;
+}
+
+/** Provenance/availability of a network's admission-rows read. */
+export type RosterStatus =
+  | "ok" // rows read (see `roster_scope` for complete vs self)
+  | "unreachable" // registry unreachable
+  | "unauthorized" // caller not authorized for this read
+  | "not_configured"; // no registry / admission read configured
+
+/** Whether the roster reflects the COMPLETE network or only the serving stack's row. */
+export type RosterScope = "complete" | "self";
+
+/** One reconciled roster member, snake_case for the DTO. */
+export interface MembershipMemberDTO {
+  principal: string;
+  verdict: MembershipVerdict;
+  present_stacks: string[];
+}
+
+/** One network's membership view in the `GET /api/networks` response. */
+export interface NetworkMembershipDTO {
+  network_id: string;
+  leaf_node: string;
+  /** Availability of the admission-rows read this membership was reconciled against. */
+  roster_status: RosterStatus;
+  /**
+   * `complete` (admin-authoritative roster) vs `self` (only the serving stack's
+   * own admission row is known — peer membership not yet enumerable; anomaly
+   * detection suppressed). `null` when the read failed.
+   */
+  roster_scope: RosterScope | null;
+  /** Admitted roster reconciled ⋈ presence into per-member verdicts. */
+  members: MembershipMemberDTO[];
+}
+
+/** `GET /api/networks` response body. */
+export interface ListNetworksResponse {
+  networks: NetworkMembershipDTO[];
+}
+
+/** Map a `resolveAdmittedRoster` failure to a {@link RosterStatus}. */
+function failureStatus(
+  reason: "unreachable" | "unauthorized" | "not_configured",
+): RosterStatus {
+  return reason;
+}
+
+/**
+ * Handle `GET /api/networks`.
+ *
+ * `view === null` → empty list (no federation / no registry — graceful). Else,
+ * for each joined network: resolve its admitted roster from the admission rows,
+ * inject the serving principal (a joined stack is itself a member), reconcile
+ * against presence, and — ONLY for authoritative (complete) rosters — attach
+ * federation-wide anomalies (foreign principals present but admitted to NONE of
+ * the joined networks' COMPLETE rosters).
+ *
+ * Async because the admission read is async.
+ */
+export async function handleListNetworks(
+  view: NetworksView | null,
+  presence: AgentPresenceView | null,
+): Promise<Response> {
+  try {
+    if (view === null) {
+      return Response.json({ networks: [] } satisfies ListNetworksResponse);
+    }
+
+    const records = presence ? presence.getAgents() : [];
+    const presentStacksByPrincipal = derivePresentStacksByPrincipal(
+      records,
+      view.localPrincipal,
+    );
+
+    const joined = view.networks();
+
+    // Resolve every roster first so the anomaly candidates can be computed
+    // against the union of admitted principals across all AUTHORITATIVE networks
+    // (a self-only read contributes no completeness, so it can't authorize an
+    // anomaly verdict).
+    const resolved = await Promise.all(
+      joined.map(async (n) => ({
+        info: n,
+        result: await view.resolveAdmittedRoster(n.networkId),
+      })),
+    );
+
+    // Anomaly candidates only make sense when SOME network gave an authoritative
+    // (complete) roster — otherwise we can't tell unadmitted from unknowable.
+    const anyAuthoritative = resolved.some(
+      (r) => r.result.ok && r.result.roster.authoritative,
+    );
+    const unionAdmitted = new Set<string>([view.localPrincipal]);
+    for (const { result } of resolved) {
+      if (result.ok && result.roster.authoritative) {
+        for (const p of result.roster.admitted) unionAdmitted.add(p);
+      }
+    }
+    const globalAnomalies = anyAuthoritative
+      ? foreignPresentPrincipals(presentStacksByPrincipal, view.localPrincipal).filter(
+          (p) => !unionAdmitted.has(p),
+        )
+      : [];
+
+    const networks: NetworkMembershipDTO[] = resolved.map(({ info, result }) => {
+      // The serving principal is always an admitted member of a network it has
+      // joined.
+      const admitted = [view.localPrincipal];
+      let pending: string[] = [];
+      let rosterStatus: RosterStatus;
+      let rosterScope: RosterScope | null;
+
+      if (result.ok) {
+        for (const p of result.roster.admitted) admitted.push(p);
+        pending = result.roster.pending.filter((p) => p !== view.localPrincipal);
+        rosterScope = result.roster.authoritative ? "complete" : "self";
+        rosterStatus = "ok";
+      } else {
+        rosterStatus = failureStatus(result.reason);
+        rosterScope = null;
+      }
+
+      // Attach anomalies ONLY for an authoritative roster — a self-scoped or
+      // failed read cannot prove a present peer is unadmitted.
+      const authoritative = result.ok && result.roster.authoritative;
+      const members = reconcileNetworkMembership({
+        admitted,
+        presentStacksByPrincipal,
+        pending,
+        ...(authoritative ? { anomalyCandidates: globalAnomalies } : {}),
+      });
+
+      return {
+        network_id: info.networkId,
+        leaf_node: info.leafNode,
+        roster_status: rosterStatus,
+        roster_scope: rosterScope,
+        members: members.map((m) => ({
+          principal: m.principal,
+          verdict: m.verdict,
+          present_stacks: m.presentStacks,
+        })),
+      };
+    });
+
+    return Response.json({ networks } satisfies ListNetworksResponse);
+  } catch (err) {
+    process.stderr.write(
+      `[api] GET /api/networks failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return Response.json(
+      {
+        error: `Failed to list networks: ${err instanceof Error ? err.message : String(err)}`,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
@@ -1,0 +1,78 @@
+/**
+ * MC-A1 (cortex#1275) — unit tests for the pure networks roster presentation
+ * adapter (verdict → badge, roster_status → chip, member tally). DOM-free.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  verdictBadge,
+  rosterStatusBadge,
+  summarizeMembership,
+} from "../lib/network-membership-adapter";
+
+describe("verdictBadge", () => {
+  it("maps each verdict to a distinct tone", () => {
+    expect(verdictBadge("admitted-present").tone).toBe("ok");
+    expect(verdictBadge("admitted-absent").tone).toBe("warn");
+    expect(verdictBadge("present-but-unadmitted").tone).toBe("danger");
+    expect(verdictBadge("pending").tone).toBe("pending");
+  });
+
+  it("gives every verdict a non-empty label + title", () => {
+    for (const v of [
+      "admitted-present",
+      "admitted-absent",
+      "present-but-unadmitted",
+      "pending",
+    ] as const) {
+      const b = verdictBadge(v);
+      expect(b.label.length).toBeGreaterThan(0);
+      expect(b.title.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("rosterStatusBadge", () => {
+  it("distinguishes complete vs self-only authoritative reads", () => {
+    expect(rosterStatusBadge("ok", "complete").tone).toBe("ok");
+    expect(rosterStatusBadge("ok", "self").tone).toBe("warn");
+    expect(rosterStatusBadge("ok", "self").label).toContain("self");
+  });
+
+  it("surfaces degraded reads honestly", () => {
+    expect(rosterStatusBadge("unreachable", null).tone).toBe("warn");
+    expect(rosterStatusBadge("not_configured", null).label).toContain("pending");
+    expect(rosterStatusBadge("unauthorized", null).label).toContain("authorized");
+  });
+});
+
+describe("summarizeMembership", () => {
+  it("tallies members by verdict", () => {
+    const summary = summarizeMembership({
+      members: [
+        { principal: "a", verdict: "admitted-present", present_stacks: ["s"] },
+        { principal: "b", verdict: "admitted-absent", present_stacks: [] },
+        { principal: "c", verdict: "admitted-present", present_stacks: ["s"] },
+        { principal: "d", verdict: "present-but-unadmitted", present_stacks: ["x"] },
+        { principal: "e", verdict: "pending", present_stacks: [] },
+      ],
+    });
+    expect(summary).toEqual({
+      present: 2,
+      absent: 1,
+      unadmitted: 1,
+      pending: 1,
+      total: 5,
+    });
+  });
+
+  it("handles an empty member set", () => {
+    expect(summarizeMembership({ members: [] })).toEqual({
+      present: 0,
+      absent: 0,
+      unadmitted: 0,
+      pending: 0,
+      total: 0,
+    });
+  });
+});

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -39,6 +39,7 @@ import { usePlans } from "./hooks/use-plans";
 import { usePhaseDetail } from "./hooks/use-phase-detail";
 import { useAttention } from "./hooks/use-attention";
 import { useAgents } from "./hooks/use-agents";
+import { useNetworks } from "./hooks/use-networks";
 import { useGovernance } from "./hooks/use-governance";
 import { useObservability } from "./hooks/use-observability";
 import { useObsMetrics } from "./hooks/use-obs-metrics";
@@ -129,6 +130,10 @@ export function App() {
   // G-1114.B.4 — stack-local agent-presence data (fetched only when on the
   // Network tab); live-refreshed off the `agent.presence` WS frame.
   const agents = useAgents(ws, view === "network");
+  // MC-A1 (cortex#1275) — joined networks + admitted roster ⋈ presence, for the
+  // Network view's first-class trust-group panel. Fetched only when the tab is
+  // visible; refreshes off the same `agent.presence` signal as `useAgents`.
+  const networks = useNetworks(ws, view === "network");
   // G-1115 — governance verdicts, fetched only when the tab is visible.
   const governance = useGovernance(ws, view === "governance");
   // P-14 U2.1 (#934) — observability events (signal's four system.* families),
@@ -602,6 +607,10 @@ export function App() {
             // the Network view's transport overlay. Empty until the obs fetch
             // lands / on a non-hub stack; the overlay paints nothing then.
             transportRoster={observability.data?.transportRoster ?? []}
+            // MC-A1 — joined networks as first-class trust groups (admitted
+            // roster ⋈ presence → membership verdict). Empty until the fetch
+            // lands / on a non-federated stack; the panel renders nothing then.
+            networks={networks.networks}
             onViewInWorkingGrid={() => setView("default")}
             // G-1114.F.3 — dispatch-direct to a LOCAL agent, REUSING the
             // existing dispatch path (`POST /api/sessions` with `agentId`). The

--- a/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
@@ -1,0 +1,118 @@
+/**
+ * MC-A1 (cortex#1275) — the networks-as-first-class roster panel.
+ *
+ * Renders each JOINED network as a first-class trust group (CONTEXT.md §188): a
+ * group header (network id · leaf · roster-status chip · per-verdict summary)
+ * over its admitted-roster member rows, each carrying its membership verdict
+ * badge. The membership verdict is computed SERVER-SIDE from the admission rows
+ * (ADR-0018 Q3) — this component is pure presentation off the `/api/networks`
+ * DTO and the pure `network-membership-adapter`.
+ *
+ * Additive: rendered ABOVE the agent-topology canvas in the Network view. The
+ * local-stack agent pane (the graph) is untouched — this panel renders nothing
+ * when there are no joined networks, so a non-federated stack is byte-identical
+ * to the pre-A1 view.
+ */
+
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import {
+  verdictBadge,
+  rosterStatusBadge,
+  summarizeMembership,
+} from "../lib/network-membership-adapter";
+
+export interface NetworkRosterPanelProps {
+  networks: readonly NetworkMembershipDTO[];
+  /** The serving principal — its own row is marked "you". */
+  localPrincipal?: string | null;
+}
+
+export function NetworkRosterPanel({
+  networks,
+  localPrincipal = null,
+}: NetworkRosterPanelProps) {
+  // Nothing joined → render nothing (keep the agent pane untouched for a
+  // non-federated stack).
+  if (networks.length === 0) return null;
+
+  return (
+    <section
+      className="network-roster-panel"
+      aria-label="Networks (trust groups)"
+    >
+      <h3 className="network-roster-title">
+        Networks <span className="dim">— trust groups</span>
+      </h3>
+      <p className="dim network-roster-subtitle">
+        Each network is a roster of <strong>admitted principals</strong> (the
+        registry is the source of truth), reconciled against observed presence
+        into a membership verdict.
+      </p>
+      <ul className="network-roster-list">
+        {networks.map((net) => {
+          const status = rosterStatusBadge(net.roster_status, net.roster_scope);
+          const summary = summarizeMembership(net);
+          return (
+            <li key={net.network_id} className="network-roster-group">
+              <div className="network-roster-group-header">
+                <span className="network-roster-id">{net.network_id}</span>
+                <span className="dim network-roster-leaf">
+                  leaf: {net.leaf_node}
+                </span>
+                <span
+                  className={`network-roster-status tone-${status.tone}`}
+                  title={status.title}
+                >
+                  {status.label}
+                </span>
+                <span className="dim network-roster-summary">
+                  {summary.present} present · {summary.absent} absent
+                  {summary.pending > 0 ? ` · ${summary.pending} pending` : ""}
+                  {summary.unadmitted > 0
+                    ? ` · ${summary.unadmitted} unadmitted`
+                    : ""}
+                </span>
+              </div>
+              {net.members.length === 0 ? (
+                <div className="dim network-roster-empty">
+                  No admitted members resolved.
+                </div>
+              ) : (
+                <ul className="network-roster-members">
+                  {net.members.map((m) => {
+                    const badge = verdictBadge(m.verdict);
+                    const isYou = localPrincipal !== null && m.principal === localPrincipal;
+                    return (
+                      <li
+                        key={m.principal}
+                        className="network-roster-member"
+                      >
+                        <span className="network-roster-principal">
+                          {m.principal}
+                          {isYou ? (
+                            <span className="dim network-roster-you"> (you)</span>
+                          ) : null}
+                        </span>
+                        <span
+                          className={`network-roster-badge tone-${badge.tone}`}
+                          title={badge.title}
+                        >
+                          {badge.label}
+                        </span>
+                        {m.present_stacks.length > 0 ? (
+                          <span className="dim network-roster-stacks">
+                            {m.present_stacks.join(", ")}
+                          </span>
+                        ) : null}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -71,6 +71,8 @@ import { isSpotlightOpenChord } from "../lib/network-spotlight";
 import { NetworkDetailPanel } from "./network-detail-panel";
 import { NetworkFilterBar } from "./network-filter-bar";
 import { NetworkSpotlight } from "./network-spotlight";
+import { NetworkRosterPanel } from "./network-roster-panel";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
 
 // Lazy: the xyflow + elk engine chunk loads only when this resolves (first
 // entry into the Network tab). Keep this the ONLY dynamic import in the view —
@@ -120,6 +122,13 @@ export interface NetworkViewProps {
    * emitting yet). SOURCED FROM SIGNAL — the view never re-derives substrate health.
    */
   transportRoster?: readonly TransportRosterEventRow[];
+  /**
+   * MC-A1 (cortex#1275) — joined networks + their admitted roster ⋈ presence →
+   * membership verdict, from `/api/networks` (via `useNetworks`). Rendered as
+   * first-class trust groups ABOVE the agent-topology canvas. Empty default → the
+   * roster panel renders nothing (a non-federated stack is unchanged).
+   */
+  networks?: readonly NetworkMembershipDTO[];
 }
 
 export function NetworkView({
@@ -130,6 +139,7 @@ export function NetworkView({
   dispatchingAgentKeys,
   matchTasks = [],
   transportRoster = [],
+  networks = [],
 }: NetworkViewProps) {
   const mode = pickAgentsPanelMode(state);
 
@@ -359,6 +369,10 @@ export function NetworkView({
         federated peers, their declared capabilities, and their liveness, laid
         out around each stack&rsquo;s hub. Filter by scope to focus on this stack.
       </p>
+
+      {/* MC-A1 — networks as first-class trust groups (admitted roster ⋈
+          presence → membership verdict). Renders nothing when none are joined. */}
+      <NetworkRosterPanel networks={networks} localPrincipal={servingPrincipal} />
 
       {mode === "error" && (
         <div className="network-view-error">⚠ {state.error}</div>

--- a/src/surface/mc/dashboard-v2/hooks/use-networks.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-networks.ts
@@ -1,0 +1,118 @@
+/**
+ * MC-A1 (cortex#1275) — networks-as-first-class panel hook.
+ *
+ * Fetches `GET /api/networks` (joined networks + their admitted roster ⋈
+ * presence → membership verdict) and keeps it fresh off the same
+ * `agent.presence` WebSocket refresh signal `use-agents` uses — a presence
+ * mutation can flip a member between `admitted-present` / `admitted-absent`, so a
+ * presence frame re-reads the membership too.
+ *
+ * Mirrors `use-agents` exactly (lifetime/race guard via `aliveRef` + `genRef` +
+ * `AbortController`; debounced refetch; boot-error-only surfacing). Only fetches
+ * when `enabled` (the Network tab is visible).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiFailure, getJson } from "../lib/api";
+import type {
+  ListNetworksResponse,
+  NetworkMembershipDTO,
+} from "../../api/networks";
+import type { WsClient, WsMessage } from "./use-websocket";
+
+export type {
+  NetworkMembershipDTO,
+  MembershipMemberDTO,
+  RosterStatus,
+  RosterScope,
+} from "../../api/networks";
+
+export interface NetworksState {
+  networks: NetworkMembershipDTO[];
+  loaded: boolean;
+  /** Boot error only — refetch failures are swallowed (warn-only). */
+  error: string | null;
+}
+
+/** Coalesce a burst of presence frames (a boot fan-out) into one refresh. */
+const REFETCH_DEBOUNCE_MS = 150;
+
+export function useNetworks(ws: WsClient, enabled: boolean): NetworksState {
+  const [networks, setNetworks] = useState<NetworkMembershipDTO[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const genRef = useRef(0);
+  const aliveRef = useRef(true);
+  const bootedRef = useRef(false);
+  const enabledRef = useRef(enabled);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const fetchNetworks = useCallback(async (signal?: AbortSignal) => {
+    const myGen = ++genRef.current;
+    try {
+      const body = await getJson<ListNetworksResponse>(
+        "/api/networks",
+        signal ? { signal } : undefined,
+      );
+      if (!aliveRef.current || genRef.current !== myGen) return;
+      setNetworks(body.networks ?? []);
+      setError(null);
+      bootedRef.current = true;
+    } catch (e) {
+      if (!aliveRef.current || genRef.current !== myGen) return;
+      if ((e as { name?: string })?.name === "AbortError") return;
+      const msg =
+        e instanceof ApiFailure
+          ? e.info.message
+          : e instanceof Error
+            ? e.message
+            : String(e);
+      if (!bootedRef.current) {
+        setError(msg);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn("[use-networks] refetch failed:", msg);
+      }
+    } finally {
+      if (aliveRef.current && genRef.current === myGen) setLoaded(true);
+    }
+  }, []);
+
+  // Boot fetch — only when the tab is visible.
+  useEffect(() => {
+    if (!enabled) return;
+    const ac = new AbortController();
+    void fetchNetworks(ac.signal);
+    return () => ac.abort();
+  }, [enabled, fetchNetworks]);
+
+  // Live refresh on the `agent.presence` broadcast (a presence change can flip a
+  // member's present/absent verdict). Debounced; gated on `enabled` via a ref.
+  const subscribe = ws.subscribe;
+  useEffect(() => {
+    function onPresence(_msg: WsMessage) {
+      if (!enabledRef.current) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        debounceRef.current = null;
+        void fetchNetworks();
+      }, REFETCH_DEBOUNCE_MS);
+    }
+    return subscribe("agent.presence", onPresence);
+  }, [subscribe, fetchNetworks]);
+
+  return { networks, loaded, error };
+}

--- a/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
@@ -1,0 +1,150 @@
+/**
+ * MC-A1 (cortex#1275) — pure presentation adapter for the networks-as-first-class
+ * roster panel. Maps the `/api/networks` DTO into render-ready badge/label shapes.
+ *
+ * Kept out of the React tree so the mapping is unit-testable without a DOM — the
+ * panel component consumes the output. Mirrors `network-graph-adapter`'s
+ * pure-projection pattern. Carries NO membership logic of its own (the verdict
+ * is computed server-side from the admission rows, ADR-0018 Q3); this is purely
+ * verdict → visual.
+ */
+
+import type {
+  MembershipVerdict,
+  NetworkMembershipDTO,
+  RosterStatus,
+  RosterScope,
+} from "../../api/networks";
+
+/** Visual tone for a verdict badge — maps to a CSS class on the panel. */
+export type VerdictTone = "ok" | "warn" | "danger" | "pending";
+
+/** A render-ready verdict badge. */
+export interface VerdictBadge {
+  label: string;
+  tone: VerdictTone;
+  /** Tooltip / aria description. */
+  title: string;
+}
+
+/**
+ * Map a membership verdict → badge. Deterministic + total over the union, so the
+ * compiler enforces a case for every verdict (a new verdict won't silently fall
+ * through).
+ */
+export function verdictBadge(verdict: MembershipVerdict): VerdictBadge {
+  switch (verdict) {
+    case "admitted-present":
+      return {
+        label: "present",
+        tone: "ok",
+        title: "Admitted to the roster and observed present",
+      };
+    case "admitted-absent":
+      return {
+        label: "absent",
+        tone: "warn",
+        title: "Admitted to the roster but not observed present",
+      };
+    case "present-but-unadmitted":
+      return {
+        label: "unadmitted",
+        tone: "danger",
+        title:
+          "Observed present but on no admitted roster — an anomaly (stale roster or un-admitted peer)",
+      };
+    case "pending":
+      return {
+        label: "pending",
+        tone: "pending",
+        title: "Admission request pending — not yet admitted",
+      };
+  }
+}
+
+/** A human label + tone for the roster read's availability. */
+export interface RosterStatusBadge {
+  label: string;
+  tone: VerdictTone;
+  title: string;
+}
+
+/**
+ * Map a network's `roster_status` (+ `roster_scope`) → a small status chip so it
+ * is clear at a glance whether a roster is live + authoritative or self-only /
+ * degraded — the registry-Q3 reality is surfaced honestly, never hidden.
+ */
+export function rosterStatusBadge(
+  status: RosterStatus,
+  scope: RosterScope | null,
+): RosterStatusBadge {
+  switch (status) {
+    case "ok":
+      return scope === "complete"
+        ? { label: "roster: complete", tone: "ok", title: "Authoritative admitted roster" }
+        : {
+            label: "roster: self-only",
+            tone: "warn",
+            title:
+              "Only this stack's own admission is known; peer roster not yet enumerable",
+          };
+    case "unreachable":
+      return {
+        label: "registry unreachable",
+        tone: "warn",
+        title: "Could not reach the registry — showing self membership only",
+      };
+    case "unauthorized":
+      return {
+        label: "not authorized",
+        tone: "warn",
+        title: "This stack is not authorized to read the full roster",
+      };
+    case "not_configured":
+      return {
+        label: "roster source pending",
+        tone: "warn",
+        title:
+          "Live admission-rows read not wired (A1) — pending A2 + registry ADR-0018 Q3 roster fix",
+      };
+  }
+}
+
+/** Per-verdict counts for a network's member set (for the panel summary). */
+export interface MembershipSummary {
+  present: number;
+  absent: number;
+  unadmitted: number;
+  pending: number;
+  total: number;
+}
+
+/** Tally a network's members by verdict — pure, for the panel header summary. */
+export function summarizeMembership(
+  net: Pick<NetworkMembershipDTO, "members">,
+): MembershipSummary {
+  const summary: MembershipSummary = {
+    present: 0,
+    absent: 0,
+    unadmitted: 0,
+    pending: 0,
+    total: net.members.length,
+  };
+  for (const m of net.members) {
+    switch (m.verdict) {
+      case "admitted-present":
+        summary.present += 1;
+        break;
+      case "admitted-absent":
+        summary.absent += 1;
+        break;
+      case "present-but-unadmitted":
+        summary.unadmitted += 1;
+        break;
+      case "pending":
+        summary.pending += 1;
+        break;
+    }
+  }
+  return summary;
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -940,3 +940,42 @@ html, body {
   padding: 4px 10px; border-radius: 6px; cursor: pointer;
 }
 .theme-btn:hover { border-color: var(--accent); }
+
+/* MC-A1 (cortex#1275) — networks-as-first-class roster panel.
+   Additive section above the agent-topology canvas in the Network view. */
+.network-roster-panel {
+  margin: 8px 0 16px;
+  padding: 12px 14px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.network-roster-title { margin: 0 0 2px; font-size: 14px; }
+.network-roster-subtitle { margin: 0 0 10px; font-size: 12px; }
+.network-roster-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.network-roster-group {
+  padding: 8px 10px;
+  background: var(--panel-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 6px;
+}
+.network-roster-group-header {
+  display: flex; align-items: baseline; flex-wrap: wrap; gap: 8px;
+  margin-bottom: 6px;
+}
+.network-roster-id { font-weight: 600; font-family: var(--mono); }
+.network-roster-leaf { font-size: 11px; }
+.network-roster-summary { font-size: 11px; margin-left: auto; }
+.network-roster-empty { font-size: 12px; padding: 4px 0; }
+.network-roster-members { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.network-roster-member { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.network-roster-principal { font-family: var(--mono); }
+.network-roster-stacks { font-size: 11px; margin-left: auto; }
+.network-roster-badge, .network-roster-status {
+  font-size: 10px; padding: 1px 7px; border-radius: 999px;
+  border: 1px solid currentColor; white-space: nowrap;
+}
+.tone-ok { color: var(--ok); }
+.tone-warn { color: var(--warn); }
+.tone-danger { color: var(--bad); }
+.tone-pending { color: var(--accent); }

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -23,6 +23,7 @@ import { HookStreamPoller } from "./hooks/poller";
 import type { Config } from "./types";
 import type { WsClientRegistry } from "./ws/client-registry";
 import type { AgentPresenceView } from "./api/agents";
+import type { NetworksView } from "./api/networks";
 import type { LocalAggregationProvider } from "./local-aggregation/sibling-db-reader";
 
 export interface MissionControlHandle {
@@ -87,6 +88,13 @@ export interface StartMissionControlOptions {
    * AFTER the embed starts.
    */
   localAggregation?: LocalAggregationProvider;
+  /**
+   * MC-A1 (cortex#1275) — lazy accessor for the networks view. Forwarded verbatim
+   * to `startServer` so `/api/networks` surfaces joined networks + their admitted
+   * roster ⋈ presence. A GETTER (like `agentPresence`) because the registry
+   * client + presence registry boot AFTER the embed. Omitted → empty list.
+   */
+  networks?: () => NetworksView | null;
   /**
    * P-14 U0.1 — Tier-3 sideband base URL (`config.mc.sideband`). Loopback-
    * enforced at config-parse time; forwarded verbatim to `startServer`, which
@@ -170,6 +178,7 @@ export async function startMissionControl(
     serverCtx = startServer(config, db, {
       processManager,
       ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
+      ...(opts.networks ? { networks: opts.networks } : {}),
       ...(opts.localAggregation ? { localAggregation: opts.localAggregation } : {}),
       ...(opts.sidebandUrl ? { sidebandUrl: opts.sidebandUrl } : {}),
     });

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -40,6 +40,7 @@ import {
 } from "./api/handlers";
 import { handleListGitLinks } from "./api/git-links";
 import { handleListAgents, type AgentPresenceView } from "./api/agents";
+import { handleListNetworks, type NetworksView } from "./api/networks";
 import type {
   LocalAggregationContext,
   LocalAggregationProvider,
@@ -182,6 +183,15 @@ export interface StartServerOptions {
    */
   localAggregation?: LocalAggregationProvider;
   /**
+   * MC-A1 (cortex#1275) — lazy accessor for the networks view (serves
+   * `GET /api/networks`: joined networks + their admitted roster ⋈ presence →
+   * membership verdict). A GETTER like `agentPresence` because the registry
+   * client + presence registry boot AFTER the embed in `cortex.ts`; resolved per
+   * request. Returns `null` ⇒ no federation/registry configured → the route
+   * serves an empty `{networks:[]}`.
+   */
+  networks?: () => NetworksView | null;
+  /**
    * P-14 U0.1 — Tier-3 sideband base URL (`mc.sideband`). When present, the
    * `/api/observability/*` routes proxy to it server-side. Loopback-enforced
    * at config-parse time; the proxy re-checks at the request boundary.
@@ -271,7 +281,18 @@ export function startServer(
         // #1008 — resolve the DB-read aggregation context lazily too; null ⇒
         // single-db feeds (the pre-#1008 path).
         const localAggregation = options.localAggregation?.() ?? null;
-        return handleApi(req, url, db, apiDeps, agentPresence, localAggregation);
+        // MC-A1 — resolve the networks view lazily too (registry/presence boot
+        // after the server). null ⇒ the route serves an empty list.
+        const networks = options.networks?.() ?? null;
+        return handleApi(
+          req,
+          url,
+          db,
+          apiDeps,
+          agentPresence,
+          localAggregation,
+          networks,
+        );
       }
 
       // --- Dashboard static ---
@@ -426,7 +447,8 @@ async function handleApi(
   db: Database,
   deps: ApiDeps | null,
   agentPresence: AgentPresenceView | null,
-  localAggregation: LocalAggregationContext | null
+  localAggregation: LocalAggregationContext | null,
+  networks: NetworksView | null = null
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -634,6 +656,17 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListAgents(db, agentPresence, localAggregation);
+  }
+
+  // MC-A1 (cortex#1275) — GET /api/networks — joined networks as first-class
+  // trust groups + their admitted roster (admission rows = source of truth,
+  // ADR-0018 Q3) reconciled ⋈ presence into a membership verdict. `networks ===
+  // null` (no federation/registry) → empty list. Read-only.
+  if (pathname === "/api/networks") {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    return handleListNetworks(networks, agentPresence);
   }
 
   // F-17 — principal-driven GitHub iteration import.


### PR DESCRIPTION
Closes #1275. Sub-slice of the Mission Control catch-up umbrella **#1274**. Foundation A2 (#1276) / A3 / B1 (#1278) build on this.

## What this does

Surfaces **joined networks as first-class trust groups** on the MC Network view. Each network is a **roster of admitted principals** (CONTEXT.md §188), reconciled against observed presence into a per-member **membership verdict**:

| verdict | meaning |
|---|---|
| `admitted-present` | on the admitted roster AND observed present |
| `admitted-absent` | on the roster, not observed present |
| `present-but-unadmitted` | observed present, on no roster — an **anomaly** (stale roster / un-admitted peer) |
| `pending` | a pending admission request, not yet admitted |

## Trust-boundary correction vs the brief (ADR-0018 Q3)

The brief pointed at `roster-read.ts` (`resolveNetworkRoster`, #1086). **Verified that read is the wrong source for membership**: the registry's `GET /networks/{id}/roster` `members[]` is still documented **capability-derived** (`NetworkRoster`, `src/services/network-registry/src/types.ts` — "membership is implicit: a principal is in a network if any of their capabilities lists that network"). That directly contradicts **ADR-0018 Q3** ("roster `members[]` ← ADMITTED admission rows, NOT announced capabilities"). Building a membership verdict on it would conflate capability with membership — the exact bug ADR-0015/0018 forbid.

So this slice anchors membership on the **admission rows** (`AdmissionStatus`) via a new reusable lib, and **never reads a capability to decide membership**.

## ⚠️ ESCALATION — registry-side Q3 prerequisite (blocks the LIVE peer roster)

The authoritative ADMITTED roster is **not yet member-accessible**:
- `GET /admission-requests?status=ADMITTED` — the full roster — is **admin-gated** (`verifyAdminReadHeader`).
- `GET /admission-requests/mine` — member-accessible (signed PoP) — returns **only the caller's own** rows (`scope: self`).
- A Q3-correct member-accessible **peer** roster read (registry `members[] ← ADMITTED rows`) is a **registry-side prerequisite that has not landed** — the same prerequisite the hosted feed (MC-C) depends on.

A1 therefore wires the full plumbing (model, reconciliation, endpoint, frontend) behind a single `AdmissionRowsProvider` seam, with a `not_configured` provider for now. The endpoint **suppresses anomaly detection on a non-authoritative (self-only) read** so legitimately-admitted peers we can't yet enumerate are never falsely flagged. **A2 (#1276) drops in the live admission-rows provider** once the registry Q3 read exists.

**Recommend not merging until the umbrella owner confirms the A1-foundation-now / live-source-in-A2 split** (this is the trust/federation ambiguity my brief says to escalate rather than self-merge).

## Shape

`GET /api/networks` →
```jsonc
{ "networks": [ {
  "network_id": "research-collab",
  "leaf_node": "rc-leaf",
  "roster_status": "ok |unreachable|unauthorized|not_configured",
  "roster_scope": "complete|self|null",
  "members": [ { "principal": "jc", "verdict": "admitted-present", "present_stacks": ["research"] } ]
} ] }
```

## Files

- `bus/agent-network/admission-read.ts` — **reusable** admission-rows read (`resolveAdmittedRoster` + `AdmissionRowsProvider` seam, `scope` complete/self). A2/B1 reuse.
- `surface/mc/api/networks-membership.ts` — pure reconciliation; presence keyed on **verified origin**, never a wire token; anomaly detection opt-in.
- `surface/mc/api/networks.ts` — `GET /api/networks` (NetworksView seam); graceful, never-5xx.
- `server.ts` / `embed.ts` / `cortex.ts` — lazy-getter wiring (mirrors `/api/agents`).
- `dashboard-v2/`: `use-networks` hook, pure `network-membership-adapter` (verdict→badge), `network-roster-panel` (additive — local agent pane untouched, renders nothing when no networks joined).

## Constraints honoured

- Registry/admission = source of truth for membership; **capabilities never confer membership**.
- Read-only display; no mutation (grant/admit is B2).
- No signal dependency in the core (signal enriches transport only).
- Local pane + #1082/#1044 (idle local stacks) unregressed.

## Gates (all green locally)

- `bunx tsc --noEmit` ✅
- `bun run lint:errors` ✅
- `bun test src/surface/mc src/bus/agent-network` → **2131 pass / 0 fail** (37 new) ✅
- `bun run build:dashboard` ✅ (the `network-canvas-*` split chunk still emits)
- `bash scripts/check-carveouts.sh` ✅

Refs ADR-0015, ADR-0018 (Q3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)