### PR TITLE
feat(surface): C-1278 — MC Pier queue (pending admission requests, operator view) (MC-B1)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/pier-queue-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-queue-adapter.test.ts
@@ -1,7 +1,7 @@
 /**
  * MC-B1 (cortex#1278) — unit tests for the pure Pier-queue selection adapter.
  *
- * The Pier queue is the OPERATOR posture: PENDING admission requests for the
+ * The Pier queue is the ADMIN posture: PENDING admission requests for the
  * networks the serving principal ADMINS, awaiting Tier-2 grant (ADR-0015 /
  * ADR-0018; CONTEXT.md §172). The load-bearing property is the TRUST BOUNDARY —
  * pending is surfaced ONLY for a network whose admin-authoritative (`complete`)
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { selectPierQueue, isOperatorPosture } from "../lib/pier-queue-adapter";
+import { selectPierQueue, isAdminPosture } from "../lib/pier-queue-adapter";
 import type { NetworkMembershipDTO, MembershipMemberDTO } from "../../api/networks";
 
 function member(
@@ -34,19 +34,19 @@ function net(over: Partial<NetworkMembershipDTO> & { network_id: string }): Netw
   };
 }
 
-describe("isOperatorPosture", () => {
+describe("isAdminPosture", () => {
   it("is true ONLY for an ok + complete (admin-authoritative) roster read", () => {
-    expect(isOperatorPosture(net({ network_id: "n", roster_status: "ok", roster_scope: "complete" }))).toBe(true);
+    expect(isAdminPosture(net({ network_id: "n", roster_status: "ok", roster_scope: "complete" }))).toBe(true);
   });
 
   it("is false for a self-scoped read (member posture — pending not yours to see)", () => {
-    expect(isOperatorPosture(net({ network_id: "n", roster_status: "ok", roster_scope: "self" }))).toBe(false);
+    expect(isAdminPosture(net({ network_id: "n", roster_status: "ok", roster_scope: "self" }))).toBe(false);
   });
 
   it("is false for every degraded read (unreachable / unauthorized / not_configured)", () => {
-    expect(isOperatorPosture(net({ network_id: "n", roster_status: "unreachable", roster_scope: null }))).toBe(false);
-    expect(isOperatorPosture(net({ network_id: "n", roster_status: "unauthorized", roster_scope: null }))).toBe(false);
-    expect(isOperatorPosture(net({ network_id: "n", roster_status: "not_configured", roster_scope: null }))).toBe(false);
+    expect(isAdminPosture(net({ network_id: "n", roster_status: "unreachable", roster_scope: null }))).toBe(false);
+    expect(isAdminPosture(net({ network_id: "n", roster_status: "unauthorized", roster_scope: null }))).toBe(false);
+    expect(isAdminPosture(net({ network_id: "n", roster_status: "not_configured", roster_scope: null }))).toBe(false);
   });
 });
 
@@ -97,7 +97,7 @@ describe("selectPierQueue", () => {
         roster_status: "ok",
         roster_scope: "self",
         // even if the DTO somehow carried a pending member, a self read is not
-        // admin-authoritative — it must NOT appear in the operator queue.
+        // admin-authoritative — it must NOT appear in the admin queue.
         members: [member({ principal: "intruder", verdict: "pending" })],
       }),
     ]);

--- a/src/surface/mc/dashboard-v2/__tests__/pier-queue-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-queue-adapter.test.ts
@@ -1,0 +1,157 @@
+/**
+ * MC-B1 (cortex#1278) — unit tests for the pure Pier-queue selection adapter.
+ *
+ * The Pier queue is the OPERATOR posture: PENDING admission requests for the
+ * networks the serving principal ADMINS, awaiting Tier-2 grant (ADR-0015 /
+ * ADR-0018; CONTEXT.md §172). The load-bearing property is the TRUST BOUNDARY —
+ * pending is surfaced ONLY for a network whose admin-authoritative (`complete`)
+ * roster read succeeded. A `self`-scoped or degraded read must NEVER leak a
+ * pending entry: for a network you only MEMBER, the pending queue is not yours
+ * to see. DOM-free.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { selectPierQueue, isOperatorPosture } from "../lib/pier-queue-adapter";
+import type { NetworkMembershipDTO, MembershipMemberDTO } from "../../api/networks";
+
+function member(
+  over: Partial<MembershipMemberDTO> & { principal: string },
+): MembershipMemberDTO {
+  return {
+    verdict: "pending",
+    present_stacks: [],
+    ...over,
+  };
+}
+
+function net(over: Partial<NetworkMembershipDTO> & { network_id: string }): NetworkMembershipDTO {
+  return {
+    leaf_node: `${over.network_id}-leaf`,
+    roster_status: "ok",
+    roster_scope: "complete",
+    members: [],
+    ...over,
+  };
+}
+
+describe("isOperatorPosture", () => {
+  it("is true ONLY for an ok + complete (admin-authoritative) roster read", () => {
+    expect(isOperatorPosture(net({ network_id: "n", roster_status: "ok", roster_scope: "complete" }))).toBe(true);
+  });
+
+  it("is false for a self-scoped read (member posture — pending not yours to see)", () => {
+    expect(isOperatorPosture(net({ network_id: "n", roster_status: "ok", roster_scope: "self" }))).toBe(false);
+  });
+
+  it("is false for every degraded read (unreachable / unauthorized / not_configured)", () => {
+    expect(isOperatorPosture(net({ network_id: "n", roster_status: "unreachable", roster_scope: null }))).toBe(false);
+    expect(isOperatorPosture(net({ network_id: "n", roster_status: "unauthorized", roster_scope: null }))).toBe(false);
+    expect(isOperatorPosture(net({ network_id: "n", roster_status: "not_configured", roster_scope: null }))).toBe(false);
+  });
+});
+
+describe("selectPierQueue", () => {
+  it("surfaces pending requests for an admin (complete) network", () => {
+    const q = selectPierQueue([
+      net({
+        network_id: "alpha",
+        roster_scope: "complete",
+        members: [
+          member({ principal: "andreas", verdict: "admitted-present", present_stacks: ["research"] }),
+          member({ principal: "jc", verdict: "pending", present_stacks: ["main"] }),
+          member({ principal: "remy", verdict: "pending" }),
+        ],
+      }),
+    ]);
+    expect(q.adminNetworkCount).toBe(1);
+    expect(q.nonAdminNetworkCount).toBe(0);
+    expect(q.totalPending).toBe(2);
+    expect(q.groups).toHaveLength(1);
+    expect(q.groups[0]!.networkId).toBe("alpha");
+    expect(q.groups[0]!.leafNode).toBe("alpha-leaf");
+    expect(q.groups[0]!.requests.map((r) => r.principal)).toEqual(["jc", "remy"]);
+    // carries the requester's observed presence (informational — may be online pre-admission)
+    expect(q.groups[0]!.requests[0]!.presentStacks).toEqual(["main"]);
+  });
+
+  it("includes ONLY pending members — admitted/absent/unadmitted are excluded", () => {
+    const q = selectPierQueue([
+      net({
+        network_id: "alpha",
+        members: [
+          member({ principal: "a", verdict: "admitted-present", present_stacks: ["s"] }),
+          member({ principal: "b", verdict: "admitted-absent" }),
+          member({ principal: "c", verdict: "present-but-unadmitted", present_stacks: ["x"] }),
+          member({ principal: "d", verdict: "pending" }),
+        ],
+      }),
+    ]);
+    expect(q.totalPending).toBe(1);
+    expect(q.groups[0]!.requests.map((r) => r.principal)).toEqual(["d"]);
+  });
+
+  it("TRUST BOUNDARY: never leaks pending from a self-scoped network", () => {
+    const q = selectPierQueue([
+      net({
+        network_id: "beta",
+        roster_status: "ok",
+        roster_scope: "self",
+        // even if the DTO somehow carried a pending member, a self read is not
+        // admin-authoritative — it must NOT appear in the operator queue.
+        members: [member({ principal: "intruder", verdict: "pending" })],
+      }),
+    ]);
+    expect(q.totalPending).toBe(0);
+    expect(q.groups).toHaveLength(0);
+    expect(q.adminNetworkCount).toBe(0);
+    expect(q.nonAdminNetworkCount).toBe(1);
+  });
+
+  it("TRUST BOUNDARY: never leaks pending from a degraded (failed) read", () => {
+    for (const status of ["unreachable", "unauthorized", "not_configured"] as const) {
+      const q = selectPierQueue([
+        net({
+          network_id: "gamma",
+          roster_status: status,
+          roster_scope: null,
+          members: [member({ principal: "ghost", verdict: "pending" })],
+        }),
+      ]);
+      expect(q.totalPending).toBe(0);
+      expect(q.groups).toHaveLength(0);
+      expect(q.nonAdminNetworkCount).toBe(1);
+    }
+  });
+
+  it("counts admin vs non-admin networks across a mixed set, queueing only the admin ones", () => {
+    const q = selectPierQueue([
+      net({ network_id: "admin1", roster_scope: "complete", members: [member({ principal: "p1", verdict: "pending" })] }),
+      net({ network_id: "admin2", roster_scope: "complete", members: [] }), // admin, but empty queue
+      net({ network_id: "member1", roster_status: "ok", roster_scope: "self", members: [] }),
+      net({ network_id: "broken1", roster_status: "unreachable", roster_scope: null, members: [] }),
+    ]);
+    expect(q.adminNetworkCount).toBe(2);
+    expect(q.nonAdminNetworkCount).toBe(2);
+    expect(q.totalPending).toBe(1);
+    // only networks WITH >=1 pending become groups
+    expect(q.groups.map((g) => g.networkId)).toEqual(["admin1"]);
+  });
+
+  it("returns an empty queue for no networks", () => {
+    expect(selectPierQueue([])).toEqual({
+      groups: [],
+      totalPending: 0,
+      adminNetworkCount: 0,
+      nonAdminNetworkCount: 0,
+    });
+  });
+
+  it("does not mutate its input", () => {
+    const input = [
+      net({ network_id: "alpha", members: [member({ principal: "p", verdict: "pending" })] }),
+    ];
+    const snapshot = JSON.stringify(input);
+    selectPierQueue(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/pier-queue.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-queue.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * MC-B1 (cortex#1278) — PierQueue render tests (DOM-free via renderToStaticMarkup).
+ *
+ * Asserts the OPERATOR-posture rendering + the load-bearing trust boundary:
+ *   - renders the pending requests for networks you ADMIN (complete roster);
+ *   - renders NOTHING when you admin no networks (a pure member / non-federated
+ *     stack is byte-identical — no operator queue applies);
+ *   - renders a reassuring empty-inbox state when you admin networks but the
+ *     queue is clear;
+ *   - NEVER renders a pending principal sourced from a self-scoped / degraded
+ *     network read (the trust boundary, asserted through the DOM).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { PierQueue } from "../components/pier-queue";
+import type { NetworkMembershipDTO, MembershipMemberDTO } from "../hooks/use-networks";
+
+function member(
+  over: Partial<MembershipMemberDTO> & { principal: string },
+): MembershipMemberDTO {
+  return { verdict: "pending", present_stacks: [], ...over };
+}
+
+function net(over: Partial<NetworkMembershipDTO> & { network_id: string }): NetworkMembershipDTO {
+  return {
+    leaf_node: `${over.network_id}-leaf`,
+    roster_status: "ok",
+    roster_scope: "complete",
+    members: [],
+    ...over,
+  };
+}
+
+function render(networks: readonly NetworkMembershipDTO[]): string {
+  return renderToStaticMarkup(createElement(PierQueue, { networks }));
+}
+
+describe("PierQueue", () => {
+  it("renders nothing when the principal admins no networks", () => {
+    // pure member of one network, not federated to anything it admins
+    const html = render([net({ network_id: "beta", roster_scope: "self" })]);
+    expect(html).toBe("");
+  });
+
+  it("renders nothing for no networks at all", () => {
+    expect(render([])).toBe("");
+  });
+
+  it("renders pending requesters for an admin network", () => {
+    const html = render([
+      net({
+        network_id: "alpha",
+        members: [
+          member({ principal: "andreas", verdict: "admitted-present", present_stacks: ["research"] }),
+          member({ principal: "jc", verdict: "pending" }),
+        ],
+      }),
+    ]);
+    expect(html).toContain("Pier queue");
+    expect(html).toContain("alpha");
+    expect(html).toContain("jc");
+    // an admitted member is NOT a pending request
+    expect(html).not.toContain("andreas");
+  });
+
+  it("renders a clear-inbox state when admin networks have no pending", () => {
+    const html = render([
+      net({ network_id: "alpha", members: [member({ principal: "andreas", verdict: "admitted-present" })] }),
+    ]);
+    expect(html).toContain("Pier queue");
+    expect(html.toLowerCase()).toContain("no pending");
+  });
+
+  it("TRUST BOUNDARY: a pending principal on a self-scoped network never reaches the DOM", () => {
+    const html = render([
+      net({
+        network_id: "beta",
+        roster_status: "ok",
+        roster_scope: "self",
+        members: [member({ principal: "intruder", verdict: "pending" })],
+      }),
+    ]);
+    // you admin nothing → no panel at all, and certainly no "intruder"
+    expect(html).toBe("");
+    expect(html).not.toContain("intruder");
+  });
+
+  it("TRUST BOUNDARY: with a mix, only admin-network pending shows; self-network pending is suppressed", () => {
+    const html = render([
+      net({ network_id: "admin1", roster_scope: "complete", members: [member({ principal: "wanted", verdict: "pending" })] }),
+      net({ network_id: "member1", roster_status: "ok", roster_scope: "self", members: [member({ principal: "selfonly-principal", verdict: "pending" })] }),
+    ]);
+    expect(html).toContain("wanted");
+    expect(html).not.toContain("selfonly-principal");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/pier-queue.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-queue.test.tsx
@@ -1,10 +1,10 @@
 /**
  * MC-B1 (cortex#1278) — PierQueue render tests (DOM-free via renderToStaticMarkup).
  *
- * Asserts the OPERATOR-posture rendering + the load-bearing trust boundary:
+ * Asserts the ADMIN-posture rendering + the load-bearing trust boundary:
  *   - renders the pending requests for networks you ADMIN (complete roster);
  *   - renders NOTHING when you admin no networks (a pure member / non-federated
- *     stack is byte-identical — no operator queue applies);
+ *     stack is byte-identical — no admin queue applies);
  *   - renders a reassuring empty-inbox state when you admin networks but the
  *     queue is clear;
  *   - NEVER renders a pending principal sourced from a self-scoped / degraded

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -72,6 +72,7 @@ import { NetworkDetailPanel } from "./network-detail-panel";
 import { NetworkFilterBar } from "./network-filter-bar";
 import { NetworkSpotlight } from "./network-spotlight";
 import { NetworkRosterPanel } from "./network-roster-panel";
+import { PierQueue } from "./pier-queue";
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
 
 // Lazy: the xyflow + elk engine chunk loads only when this resolves (first
@@ -373,6 +374,11 @@ export function NetworkView({
       {/* MC-A1 — networks as first-class trust groups (admitted roster ⋈
           presence → membership verdict). Renders nothing when none are joined. */}
       <NetworkRosterPanel networks={networks} localPrincipal={servingPrincipal} />
+
+      {/* MC-B1 (cortex#1278) — Pier queue: PENDING admission requests for the
+          networks this principal ADMINS (operator posture). Read-only; renders
+          nothing when the principal admins no networks. */}
+      <PierQueue networks={networks} />
 
       {mode === "error" && (
         <div className="network-view-error">⚠ {state.error}</div>

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -376,7 +376,7 @@ export function NetworkView({
       <NetworkRosterPanel networks={networks} localPrincipal={servingPrincipal} />
 
       {/* MC-B1 (cortex#1278) — Pier queue: PENDING admission requests for the
-          networks this principal ADMINS (operator posture). Read-only; renders
+          networks this principal ADMINS (admin posture). Read-only; renders
           nothing when the principal admins no networks. */}
       <PierQueue networks={networks} />
 

--- a/src/surface/mc/dashboard-v2/components/pier-queue.tsx
+++ b/src/surface/mc/dashboard-v2/components/pier-queue.tsx
@@ -1,5 +1,5 @@
 /**
- * MC-B1 (cortex#1278) — the **Pier queue** panel: an operator's inbox of
+ * MC-B1 (cortex#1278) — the **Pier queue** panel: an admin's inbox of
  * PENDING admission requests awaiting Tier-2 grant (ADR-0015 / ADR-0018;
  * CONTEXT.md §172).
  *
@@ -30,7 +30,7 @@ export interface PierQueueProps {
 export function PierQueue({ networks }: PierQueueProps) {
   const queue = selectPierQueue(networks);
 
-  // The operator queue only exists for someone who admins a network. Admin
+  // The admin queue only exists for someone who admins a network. Admin
   // nothing → render nothing (keep a pure-member / non-federated stack
   // untouched).
   if (queue.adminNetworkCount === 0) return null;

--- a/src/surface/mc/dashboard-v2/components/pier-queue.tsx
+++ b/src/surface/mc/dashboard-v2/components/pier-queue.tsx
@@ -1,0 +1,102 @@
+/**
+ * MC-B1 (cortex#1278) — the **Pier queue** panel: an operator's inbox of
+ * PENDING admission requests awaiting Tier-2 grant (ADR-0015 / ADR-0018;
+ * CONTEXT.md §172).
+ *
+ * READ-ONLY. This slice surfaces who has requested to join which network so the
+ * network admin can SEE the queue; the grant/reject ACTION is MC-B2 (#1276) and
+ * lands as buttons here later. No action affordances in B1.
+ *
+ * ## Posture (the trust boundary, enforced in the pure adapter)
+ *
+ * The queue shows pending ONLY for networks the principal ADMINS (an
+ * admin-authoritative `complete` roster read — `selectPierQueue`). For a network
+ * the principal only MEMBERS, the pending list is not theirs to see, so it never
+ * appears here; the count of such networks is surfaced honestly as a footnote,
+ * never as an error.
+ *
+ * Additive + self-effacing (mirrors the A1 roster panel): when the principal
+ * admins NO networks, the panel renders nothing — a pure-member or non-federated
+ * stack is byte-identical to the pre-B1 view.
+ */
+
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import { selectPierQueue } from "../lib/pier-queue-adapter";
+
+export interface PierQueueProps {
+  networks: readonly NetworkMembershipDTO[];
+}
+
+export function PierQueue({ networks }: PierQueueProps) {
+  const queue = selectPierQueue(networks);
+
+  // The operator queue only exists for someone who admins a network. Admin
+  // nothing → render nothing (keep a pure-member / non-federated stack
+  // untouched).
+  if (queue.adminNetworkCount === 0) return null;
+
+  const adminPlural = queue.adminNetworkCount === 1 ? "" : "s";
+
+  return (
+    <section className="pier-queue-panel" aria-label="Pier queue (pending admission requests)">
+      <h3 className="pier-queue-title">
+        Pier queue <span className="dim">— pending admission requests</span>
+      </h3>
+      <p className="dim pier-queue-subtitle">
+        Principals awaiting <strong>Tier-2 grant</strong> to join a network you
+        administer. Read-only — review here; grant or reject from the registry.
+      </p>
+
+      {queue.totalPending === 0 ? (
+        <div className="dim pier-queue-empty">
+          No pending requests across {queue.adminNetworkCount} network{adminPlural}{" "}
+          you administer.
+        </div>
+      ) : (
+        <ul className="pier-queue-list">
+          {queue.groups.map((g) => (
+            <li key={g.networkId} className="pier-queue-group">
+              <div className="pier-queue-group-header">
+                <span className="pier-queue-id">{g.networkId}</span>
+                <span className="dim pier-queue-leaf">leaf: {g.leafNode}</span>
+                <span className="dim pier-queue-count">
+                  {g.requests.length} pending
+                </span>
+              </div>
+              <ul className="pier-queue-requests">
+                {g.requests.map((r) => (
+                  <li key={r.principal} className="pier-queue-request">
+                    <span className="pier-queue-principal">{r.principal}</span>
+                    <span
+                      className="pier-queue-badge tone-pending"
+                      title="Admission request pending — awaiting Tier-2 grant"
+                    >
+                      pending
+                    </span>
+                    {r.presentStacks.length > 0 ? (
+                      <span
+                        className="dim pier-queue-stacks"
+                        title="Stacks of this requester observed present (presence never confers membership)"
+                      >
+                        {r.presentStacks.join(", ")}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {queue.nonAdminNetworkCount > 0 ? (
+        <p className="dim pier-queue-footnote">
+          {queue.nonAdminNetworkCount} joined network
+          {queue.nonAdminNetworkCount === 1 ? "" : "s"} you don&rsquo;t administer{" "}
+          {queue.nonAdminNetworkCount === 1 ? "is" : "are"} hidden — pending
+          requests are visible only to a network&rsquo;s admin.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/lib/pier-queue-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/pier-queue-adapter.ts
@@ -1,0 +1,143 @@
+/**
+ * MC-B1 (cortex#1278) — pure selection adapter for the **Pier queue**: the
+ * OPERATOR view of PENDING admission requests awaiting Tier-2 grant.
+ *
+ * ## What the Pier queue is (and what it is NOT)
+ *
+ * A network is a roster of admitted principals (CONTEXT.md §188; ADR-0015 /
+ * ADR-0018). The admission gate is `register → PENDING → grant` (ADR-0015): a
+ * principal that has requested to join a network sits in a PENDING admission row
+ * until a network admin grants it (Tier-2, sovereign decision). The Pier queue
+ * is the network admin's INBOX of those pending requests — the read side of the
+ * approval surface. The grant/reject ACTION is MC-B2 (#1276 → #1279), NOT this
+ * slice: this is strictly read-only.
+ *
+ * ## Two postures (the load-bearing trust boundary)
+ *
+ * CONTEXT.md / the vision distinguish two postures:
+ *   - OPERATOR — the admin of a network they own. They CAN read the network's
+ *     full pending list (the registry `GET /admission-requests?status=PENDING`
+ *     is admin-gated). For this principal, pending requests are theirs to see —
+ *     and (in B2) to grant.
+ *   - MEMBER — a principal who merely belongs to a network they don't admin.
+ *     The pending list is NOT theirs to see; they can read only their own
+ *     admission row (`/admission-requests/mine`, a self-PoP read).
+ *
+ * `/api/networks` (MC-A1) carries this distinction as `roster_scope`:
+ *   - `roster_status === "ok" && roster_scope === "complete"` → an
+ *     admin-authoritative read succeeded → OPERATOR posture for that network.
+ *   - any other status/scope (`self`, `unreachable`, `unauthorized`,
+ *     `not_configured`) → NOT operator-authoritative.
+ *
+ * This adapter surfaces pending **only** for `complete`-scope networks. A
+ * self-scoped or degraded read NEVER contributes a pending entry — fail-closed:
+ * the queue is empty rather than leaking another principal's pending request
+ * for a network the viewer doesn't admin. This is the trust boundary B1 must
+ * never weaken.
+ *
+ * Pure: no I/O, no bus, no crypto. The membership verdict (`pending`) is
+ * computed server-side from the admission rows (ADR-0018 Q3); this is purely a
+ * verdict/scope → operator-queue projection, trivially unit-testable.
+ */
+
+import type { NetworkMembershipDTO } from "../../api/networks";
+
+/** One pending admission request awaiting Tier-2 grant, for the operator inbox. */
+export interface PierQueueRequest {
+  /** The network the principal has requested to join. */
+  networkId: string;
+  /** The network's leaf-node connection id (provenance, mirrors the roster panel). */
+  leafNode: string;
+  /** The principal requesting to join — awaiting the admin's grant. */
+  principal: string;
+  /**
+   * Stacks of the requester observed present, sorted/deduped server-side. A
+   * requester MAY already be online (e.g. statically pinned) before admission;
+   * this is informational only — presence never confers membership (ADR-0018 Q3).
+   */
+  presentStacks: string[];
+}
+
+/** Pending requests grouped under one operator-posture (admin) network. */
+export interface PierQueueNetworkGroup {
+  networkId: string;
+  leafNode: string;
+  /** The network's pending requests (config/member order, deduped upstream). */
+  requests: PierQueueRequest[];
+}
+
+/** The reconciled Pier queue: the operator's pending-admission inbox. */
+export interface PierQueue {
+  /** Admin (complete-roster) networks that have ≥1 pending request. */
+  groups: PierQueueNetworkGroup[];
+  /** Total pending requests across all operator-posture networks. */
+  totalPending: number;
+  /**
+   * Count of joined networks the principal ADMINS (complete-roster read). Defines
+   * the queue's authority scope — when 0, the operator queue does not apply.
+   */
+  adminNetworkCount: number;
+  /**
+   * Count of joined networks the principal does NOT admin (self-scoped or
+   * degraded read). Pending is NOT visible for these (honest posture, surfaced
+   * to the operator as a footnote — never as an error).
+   */
+  nonAdminNetworkCount: number;
+}
+
+/**
+ * Operator posture for ONE network: true iff the admin-authoritative
+ * (`complete`) admission-rows read succeeded. This is the single gate that
+ * decides whether a network's pending requests are the viewer's to see.
+ */
+export function isOperatorPosture(net: NetworkMembershipDTO): boolean {
+  return net.roster_status === "ok" && net.roster_scope === "complete";
+}
+
+/**
+ * Project the `/api/networks` DTO into the operator Pier queue.
+ *
+ * For each joined network: if it is NOT operator-posture, count it as non-admin
+ * and contribute NO pending entries (the trust boundary — fail-closed). If it
+ * IS operator-posture, collect its `pending`-verdict members as requests; a
+ * network becomes a group only when it has ≥1 pending request.
+ *
+ * Pure — does not mutate its input.
+ */
+export function selectPierQueue(
+  networks: readonly NetworkMembershipDTO[],
+): PierQueue {
+  const groups: PierQueueNetworkGroup[] = [];
+  let totalPending = 0;
+  let adminNetworkCount = 0;
+  let nonAdminNetworkCount = 0;
+
+  for (const net of networks) {
+    if (!isOperatorPosture(net)) {
+      // Trust boundary: pending is not ours to see for a network we don't admin.
+      nonAdminNetworkCount += 1;
+      continue;
+    }
+    adminNetworkCount += 1;
+
+    const requests: PierQueueRequest[] = net.members
+      .filter((m) => m.verdict === "pending")
+      .map((m) => ({
+        networkId: net.network_id,
+        leafNode: net.leaf_node,
+        principal: m.principal,
+        presentStacks: [...m.present_stacks],
+      }));
+
+    totalPending += requests.length;
+    if (requests.length > 0) {
+      groups.push({
+        networkId: net.network_id,
+        leafNode: net.leaf_node,
+        requests,
+      });
+    }
+  }
+
+  return { groups, totalPending, adminNetworkCount, nonAdminNetworkCount };
+}

--- a/src/surface/mc/dashboard-v2/lib/pier-queue-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/pier-queue-adapter.ts
@@ -1,6 +1,6 @@
 /**
  * MC-B1 (cortex#1278) — pure selection adapter for the **Pier queue**: the
- * OPERATOR view of PENDING admission requests awaiting Tier-2 grant.
+ * ADMIN view of PENDING admission requests awaiting Tier-2 grant.
  *
  * ## What the Pier queue is (and what it is NOT)
  *
@@ -15,7 +15,7 @@
  * ## Two postures (the load-bearing trust boundary)
  *
  * CONTEXT.md / the vision distinguish two postures:
- *   - OPERATOR — the admin of a network they own. They CAN read the network's
+ *   - ADMIN — the admin of a network they own. They CAN read the network's
  *     full pending list (the registry `GET /admission-requests?status=PENDING`
  *     is admin-gated). For this principal, pending requests are theirs to see —
  *     and (in B2) to grant.
@@ -25,9 +25,9 @@
  *
  * `/api/networks` (MC-A1) carries this distinction as `roster_scope`:
  *   - `roster_status === "ok" && roster_scope === "complete"` → an
- *     admin-authoritative read succeeded → OPERATOR posture for that network.
+ *     admin-authoritative read succeeded → ADMIN posture for that network.
  *   - any other status/scope (`self`, `unreachable`, `unauthorized`,
- *     `not_configured`) → NOT operator-authoritative.
+ *     `not_configured`) → NOT admin-authoritative.
  *
  * This adapter surfaces pending **only** for `complete`-scope networks. A
  * self-scoped or degraded read NEVER contributes a pending entry — fail-closed:
@@ -37,12 +37,12 @@
  *
  * Pure: no I/O, no bus, no crypto. The membership verdict (`pending`) is
  * computed server-side from the admission rows (ADR-0018 Q3); this is purely a
- * verdict/scope → operator-queue projection, trivially unit-testable.
+ * verdict/scope → admin-queue projection, trivially unit-testable.
  */
 
 import type { NetworkMembershipDTO } from "../../api/networks";
 
-/** One pending admission request awaiting Tier-2 grant, for the operator inbox. */
+/** One pending admission request awaiting Tier-2 grant, for the admin inbox. */
 export interface PierQueueRequest {
   /** The network the principal has requested to join. */
   networkId: string;
@@ -58,7 +58,7 @@ export interface PierQueueRequest {
   presentStacks: string[];
 }
 
-/** Pending requests grouped under one operator-posture (admin) network. */
+/** Pending requests grouped under one admin-posture (admin) network. */
 export interface PierQueueNetworkGroup {
   networkId: string;
   leafNode: string;
@@ -66,40 +66,40 @@ export interface PierQueueNetworkGroup {
   requests: PierQueueRequest[];
 }
 
-/** The reconciled Pier queue: the operator's pending-admission inbox. */
+/** The reconciled Pier queue: the admin's pending-admission inbox. */
 export interface PierQueue {
   /** Admin (complete-roster) networks that have ≥1 pending request. */
   groups: PierQueueNetworkGroup[];
-  /** Total pending requests across all operator-posture networks. */
+  /** Total pending requests across all admin-posture networks. */
   totalPending: number;
   /**
    * Count of joined networks the principal ADMINS (complete-roster read). Defines
-   * the queue's authority scope — when 0, the operator queue does not apply.
+   * the queue's authority scope — when 0, the admin queue does not apply.
    */
   adminNetworkCount: number;
   /**
    * Count of joined networks the principal does NOT admin (self-scoped or
    * degraded read). Pending is NOT visible for these (honest posture, surfaced
-   * to the operator as a footnote — never as an error).
+   * to the admin as a footnote — never as an error).
    */
   nonAdminNetworkCount: number;
 }
 
 /**
- * Operator posture for ONE network: true iff the admin-authoritative
+ * Admin posture for ONE network: true iff the admin-authoritative
  * (`complete`) admission-rows read succeeded. This is the single gate that
  * decides whether a network's pending requests are the viewer's to see.
  */
-export function isOperatorPosture(net: NetworkMembershipDTO): boolean {
+export function isAdminPosture(net: NetworkMembershipDTO): boolean {
   return net.roster_status === "ok" && net.roster_scope === "complete";
 }
 
 /**
- * Project the `/api/networks` DTO into the operator Pier queue.
+ * Project the `/api/networks` DTO into the admin Pier queue.
  *
- * For each joined network: if it is NOT operator-posture, count it as non-admin
+ * For each joined network: if it is NOT admin-posture, count it as non-admin
  * and contribute NO pending entries (the trust boundary — fail-closed). If it
- * IS operator-posture, collect its `pending`-verdict members as requests; a
+ * IS admin-posture, collect its `pending`-verdict members as requests; a
  * network becomes a group only when it has ≥1 pending request.
  *
  * Pure — does not mutate its input.
@@ -113,7 +113,7 @@ export function selectPierQueue(
   let nonAdminNetworkCount = 0;
 
   for (const net of networks) {
-    if (!isOperatorPosture(net)) {
+    if (!isAdminPosture(net)) {
       // Trust boundary: pending is not ours to see for a network we don't admin.
       nonAdminNetworkCount += 1;
       continue;

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -979,3 +979,39 @@ html, body {
 .tone-warn { color: var(--warn); }
 .tone-danger { color: var(--bad); }
 .tone-pending { color: var(--accent); }
+
+/* MC-B1 (cortex#1278) — Pier queue (operator inbox of pending admission
+   requests). Additive section in the Network view, below the roster panel. */
+.pier-queue-panel {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.pier-queue-title { margin: 0 0 2px; font-size: 14px; }
+.pier-queue-subtitle { margin: 0 0 10px; font-size: 12px; }
+.pier-queue-empty { font-size: 12px; padding: 4px 0; }
+.pier-queue-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.pier-queue-group {
+  padding: 8px 10px;
+  background: var(--panel-2);
+  border: 1px solid var(--line-soft);
+  border-radius: 6px;
+}
+.pier-queue-group-header {
+  display: flex; align-items: baseline; flex-wrap: wrap; gap: 8px;
+  margin-bottom: 6px;
+}
+.pier-queue-id { font-weight: 600; font-family: var(--mono); }
+.pier-queue-leaf { font-size: 11px; }
+.pier-queue-count { font-size: 11px; margin-left: auto; }
+.pier-queue-requests { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.pier-queue-request { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.pier-queue-principal { font-family: var(--mono); }
+.pier-queue-stacks { font-size: 11px; margin-left: auto; }
+.pier-queue-badge {
+  font-size: 10px; padding: 1px 7px; border-radius: 999px;
+  border: 1px solid currentColor; white-space: nowrap;
+}
+.pier-queue-footnote { font-size: 11px; margin: 8px 0 0; }


### PR DESCRIPTION
## MC-B1 (cortex#1278) — Pier queue: PENDING admission requests on the glass

Part of the MC catch-up umbrella (#1274), builds on MC-A1 (#1281, merged).

Surfaces the registry's **PENDING admission requests** on the MC Network view — the **operator's inbox** of principals who have requested to join a network they *admin*, awaiting **Tier-2 grant** (ADR-0015 `register → PENDING → grant`; ADR-0018; CONTEXT.md §172 Network-admission gate / §188). **Read-only** — the grant/reject *action* is MC-B2 (#1276).

### Reuses A1 end-to-end (no registry change needed)
A1 already plumbed the read: `resolveAdmittedRoster` (`src/bus/agent-network/admission-read.ts`) returns `pending[]` + an `authoritative` flag, and `GET /api/networks` already emits members with `verdict: "pending"` plus `roster_scope` (`complete` = admin-authoritative vs `self` = member-only). B1 is the **operator-posture projection + panel** on top of that data — no new fetch, no registry-side work.

### Two postures — the load-bearing trust boundary
- **OPERATOR** (admin of a network they own): the admin-gated list read succeeds → `roster_scope === "complete"` → pending is theirs to see.
- **MEMBER** (belongs but doesn't admin): the pending list is **not theirs to see** (registry `GET /admission-requests?status=PENDING` is admin-gated).

`selectPierQueue` surfaces pending **only** for `roster_status === "ok" && roster_scope === "complete"` networks. A `self`-scoped or degraded (`unreachable`/`unauthorized`/`not_configured`) read **never** contributes a pending entry — **fail-closed**. Non-admin networks are counted and surfaced honestly as a footnote, never as an error.

### Changes (additive, 6 files)
- `dashboard-v2/lib/pier-queue-adapter.ts` — pure `selectPierQueue` + `isOperatorPosture` (the trust boundary).
- `dashboard-v2/components/pier-queue.tsx` — read-only operator panel. Renders nothing when the principal admins no networks (pure-member / non-federated stack byte-identical, mirroring A1's roster panel). Clear-inbox state when admin networks have no pending.
- `components/network-view.tsx` — mount below the roster panel (import + 1 line). **Does not touch `network-nodes` / the graph** (A3's territory).
- `styles/global.css` — additive `.pier-queue-*` styles.

### Tests / gates
- **16 new** tests (adapter + component), incl. explicit trust-boundary cases: self-scope + degraded reads never leak pending; mixed-set suppression; pure-member renders nothing.
- `tsc --noEmit` clean · `lint:errors` clean · `bun test src/surface/mc` 2018 pass · `build:dashboard` succeeds with the `network-canvas-*` split chunk intact.

Closes #1278