### PR TITLE
feat(registry): C-1282 — member-accessible ADMITTED peer-roster read (ADR-0018 Q4)

### DIFF
--- a/src/services/network-registry/__tests__/roster-member-read.test.ts
+++ b/src/services/network-registry/__tests__/roster-member-read.test.ts
@@ -1,0 +1,334 @@
+/**
+ * C-1282 (ADR-0018 Q4) — member-accessible ADMITTED peer-roster read.
+ *
+ * `GET /networks/:network_id/roster/member` releases the network's ADMITTED
+ * roster to a caller who proves possession of an ADMITTED member key for THAT
+ * network. The PoP signature IS the authorization (no admin key). Fail-closed:
+ *
+ *   - a non-member (registered-but-PENDING, REVOKED, or never-registered) → 403
+ *   - a member of a DIFFERENT network → 403 (network-scoped)
+ *   - a bad signature / unsigned request → 401 / 400 (no metadata leaked)
+ *
+ * The public `GET /networks/:id/roster` (federation-transport resolve path)
+ * is unchanged — this is a SEPARATE, PoP-gated surface for the MC member
+ * posture (#1275/#1276) and the hosted feed (#1280).
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519, verifyEd25519 } from "../src/signing";
+import type {
+  AdmissionRequest,
+  Capability,
+  NetworkRoster,
+  SignedAssertion,
+} from "../src/types";
+
+let env: Env;
+let admin: PrincipalKey;
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+async function get(path: string, headers: Record<string, string> = {}): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), env);
+}
+
+/**
+ * Register `principalId` targeting `networkId`, then ADMIT the resulting PENDING
+ * request. After this the principal is an ADMITTED member of the network.
+ */
+async function registerAndAdmit(
+  principalId: string,
+  pKey: PrincipalKey,
+  networkId: string,
+  capabilities: Capability[] = [],
+): Promise<void> {
+  const reg = await post(
+    `/principals/${principalId}/register`,
+    await makeSignedRegistration(principalId, pKey, { networkId, capabilities }),
+  );
+  expect(reg.status).toBe(201);
+  const read = await makeSignedAdminRead(admin);
+  const listRes = await get("/admission-requests?status=PENDING", {
+    "x-admin-signed": JSON.stringify(read),
+  });
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const req = list.find((r) => r.principal_id === principalId && r.network_id === networkId);
+  expect(req).toBeDefined();
+  const decision = await makeSignedAdminDecision(req!.request_id, "admit", admin);
+  const admitRes = await post(`/admission-requests/${req!.request_id}/admit`, decision);
+  expect(admitRes.status).toBe(200);
+}
+
+/** Register but DO NOT admit — leaves a PENDING row for `networkId`. */
+async function registerOnly(
+  principalId: string,
+  pKey: PrincipalKey,
+  networkId: string,
+): Promise<void> {
+  const reg = await post(
+    `/principals/${principalId}/register`,
+    await makeSignedRegistration(principalId, pKey, { networkId }),
+  );
+  expect(reg.status).toBe(201);
+}
+
+/**
+ * Build the signed `x-pop-signed` header for the member roster read. The claim
+ * binds the network_id + the member's peer_pubkey; signed by the member's key.
+ */
+async function makeMemberRead(
+  networkId: string,
+  member: PrincipalKey,
+  opts: {
+    issuedAt?: string;
+    peerPubkeyOverride?: string;
+    networkIdOverride?: string;
+    signWith?: PrincipalKey;
+  } = {},
+): Promise<string> {
+  const claim = {
+    network_id: opts.networkIdOverride ?? networkId,
+    peer_pubkey: opts.peerPubkeyOverride ?? member.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+  };
+  const signer = opts.signWith ?? member;
+  const signature = await signEd25519(
+    signer.privateKeyB64,
+    new TextEncoder().encode(canonicalJSON(claim)),
+  );
+  return JSON.stringify({ claim, signature });
+}
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+describe("GET /networks/:id/roster/member — member PoP-read (ADR-0018 Q4)", () => {
+  // ---------------------------------------------------------------------------
+  // Happy path — an ADMITTED member reads the network's ADMITTED roster
+  // ---------------------------------------------------------------------------
+
+  test("an ADMITTED member reads the full ADMITTED roster for their network", async () => {
+    const alpha = await makePrincipalKey();
+    const beta = await makePrincipalKey();
+    await registerAndAdmit("alpha", alpha, "research-collab", [
+      { id: "tasks.code-review", networks: ["research-collab"] },
+    ]);
+    await registerAndAdmit("beta", beta, "research-collab");
+
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", alpha),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkRoster>;
+    expect(json.payload.network_id).toBe("research-collab");
+    const ids = json.payload.members.map((m) => m.principal_id).sort();
+    expect(ids).toEqual(["alpha", "beta"]);
+    // capabilities are joined as a facet on the roster
+    const alphaRow = json.payload.members.find((m) => m.principal_id === "alpha");
+    expect(alphaRow?.capabilities).toEqual(["tasks.code-review"]);
+  });
+
+  test("the response is a registry-signed assertion (verifies against the registry pubkey)", async () => {
+    const alpha = await makePrincipalKey();
+    await registerAndAdmit("alpha", alpha, "research-collab");
+
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", alpha),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkRoster>;
+    expect(json.registry).toBe(env.REGISTRY_PUBLIC_KEY ?? "");
+    expect(json.signature.length).toBeGreaterThan(0);
+    // The assertion binds the {payload, issued_at, registry} triple (signAssertion).
+    const bound = canonicalJSON({
+      payload: json.payload,
+      issued_at: json.issued_at,
+      registry: json.registry,
+    });
+    const ok = await verifyEd25519(
+      json.registry,
+      json.signature,
+      new TextEncoder().encode(bound),
+    );
+    expect(ok).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fail-closed — the trust boundary
+  // ---------------------------------------------------------------------------
+
+  test("a NON-member (never registered) is refused with 403 — and learns nothing", async () => {
+    const alpha = await makePrincipalKey();
+    await registerAndAdmit("alpha", alpha, "research-collab");
+
+    const stranger = await makePrincipalKey();
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", stranger),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { members?: unknown };
+    expect(body.members).toBeUndefined();
+  });
+
+  test("a PENDING (registered-but-not-admitted) caller is refused with 403", async () => {
+    const pending = await makePrincipalKey();
+    await registerOnly("pending", pending, "research-collab");
+
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", pending),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("a member of a DIFFERENT network cannot read this network's roster (403, network-scoped)", async () => {
+    const alpha = await makePrincipalKey();
+    await registerAndAdmit("alpha", alpha, "research-collab");
+    const outsider = await makePrincipalKey();
+    await registerAndAdmit("outsider", outsider, "other-net");
+
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", outsider),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("a REVOKED member is refused with 403 (revocation cuts the read)", async () => {
+    const alpha = await makePrincipalKey();
+    const hubAdmin = await makePrincipalKey();
+    // hub-admin = registry-admin collapse: reuse admin as hub-admin authority.
+    env.REGISTRY_HUB_ADMIN_PUBKEYS = hubAdmin.publicKeyB64;
+    await registerAndAdmit("alpha", alpha, "research-collab");
+
+    // find alpha's ADMITTED request_id, then revoke it (hub-admin authority).
+    const read = await makeSignedAdminRead(admin);
+    const listRes = await get("/admission-requests?status=ADMITTED", {
+      "x-admin-signed": JSON.stringify(read),
+    });
+    const list = (await listRes.json()) as AdmissionRequest[];
+    const req = list.find((r) => r.principal_id === "alpha");
+    expect(req).toBeDefined();
+    const revokeClaim = {
+      request_id: req!.request_id,
+      hub_admin_pubkey: hubAdmin.publicKeyB64,
+      issued_at: new Date().toISOString(),
+      nonce: Math.random().toString(16).slice(2),
+    };
+    const revokeSig = await signEd25519(
+      hubAdmin.privateKeyB64,
+      new TextEncoder().encode(canonicalJSON(revokeClaim)),
+    );
+    const revokeRes = await post(`/admission-requests/${req!.request_id}/revoke`, {
+      claim: revokeClaim,
+      signature: revokeSig,
+    });
+    expect(revokeRes.status).toBe(200);
+
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", alpha),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Signature / claim integrity
+  // ---------------------------------------------------------------------------
+
+  test("a forged signature (signed by a different key) is refused with 401", async () => {
+    const alpha = await makePrincipalKey();
+    const attacker = await makePrincipalKey();
+    await registerAndAdmit("alpha", alpha, "research-collab");
+
+    // claim asserts alpha's pubkey but is signed by the attacker's key.
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", alpha, { signWith: attacker }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("a claim whose network_id does not match the path is rejected (400)", async () => {
+    const alpha = await makePrincipalKey();
+    await registerAndAdmit("alpha", alpha, "research-collab");
+
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", alpha, {
+        networkIdOverride: "other-net",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("a stale (out-of-skew) read token is rejected (400)", async () => {
+    const alpha = await makePrincipalKey();
+    await registerAndAdmit("alpha", alpha, "research-collab");
+
+    const stale = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", alpha, { issuedAt: stale }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("a missing x-pop-signed header is rejected (400) — no metadata leaked", async () => {
+    const res = await get("/networks/research-collab/roster/member");
+    expect(res.status).toBe(400);
+  });
+
+  test("a malformed x-pop-signed header (not JSON) is rejected (400)", async () => {
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": "not-json{",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("an invalid network_id in the path is rejected (400)", async () => {
+    const alpha = await makePrincipalKey();
+    const res = await get("/networks/INVALID_CAPS/roster/member", {
+      "x-pop-signed": await makeMemberRead("INVALID_CAPS", alpha),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("the member sees ONLY ADMITTED peers — PENDING peers are excluded from the roster", async () => {
+    const alpha = await makePrincipalKey();
+    const pending = await makePrincipalKey();
+    await registerAndAdmit("alpha", alpha, "research-collab");
+    await registerOnly("pending", pending, "research-collab");
+
+    const res = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": await makeMemberRead("research-collab", alpha),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkRoster>;
+    const ids = json.payload.members.map((m) => m.principal_id);
+    expect(ids).toEqual(["alpha"]);
+  });
+});

--- a/src/services/network-registry/src/routes/networks.ts
+++ b/src/services/network-registry/src/routes/networks.ts
@@ -39,6 +39,7 @@ import {
   isValidNetworkId,
   validateNetworkCreateClaim,
   validateSignedNetworkCreate,
+  validateSignedNetworkRosterMemberRead,
 } from "../validate";
 import { canonicalJSON, verifyEd25519 } from "../signing";
 import {
@@ -223,6 +224,103 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
     // each admitted principal's pubkey + this-network capabilities (the facet).
     const principals = await store.listPrincipals();
     const admitted = await getIssuanceStore(c.env).listIssuanceRequests("ADMITTED");
+    const roster = rosterFromAdmissions(admitted, principals, networkId);
+    const assertion = await signAssertion(c.env, roster);
+    return c.json(assertion);
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /networks/:network_id/roster/member — C-1282 (ADR-0018 Q4) member read
+  //
+  // The MEMBER-ACCESSIBLE read of a network's ADMITTED peer-roster. Released to
+  // a caller who proves possession of an ADMITTED member key for THIS network —
+  // the PoP signature IS the authorization (no admin key, no allowlist), mirror
+  // of `/admission-requests/mine`. FAIL-CLOSED at the membership gate: the
+  // proven pubkey MUST hold an ADMITTED row for `network_id`, else 403. A
+  // non-member (never-registered, PENDING, REVOKED, or admitted to a DIFFERENT
+  // network) learns nothing. The admitted-peer list is not sensitive to a
+  // fellow admitted member (ADR-0018 Q4), so an admitted member sees the full
+  // roster — the SAME payload the public `/roster` serves, minus no secrets
+  // (the roster carries none; sealed blobs stay on the per-member `/mine`).
+  //
+  // This is a SEPARATE surface from the public `/networks/:id/roster` (which the
+  // federation-transport resolve path consumes unauthenticated and is left
+  // unchanged). It exists for the MC member posture (#1275/#1276) + hosted feed
+  // (#1280), which authorize off the running stack's own registered key.
+  // ---------------------------------------------------------------------------
+
+  app.get("/networks/:network_id/roster/member", async (c) => {
+    const networkId = c.req.param("network_id");
+    if (!isValidNetworkId(networkId)) {
+      return c.json({ error: "invalid network_id in path" }, 400);
+    }
+
+    // Rate-limit BEFORE the Ed25519 verify (read bucket — idempotent GET).
+    const allowed = await checkRateLimit(c.env, "read", clientKey(c.req.raw, networkId));
+    if (!allowed) {
+      return c.json(TOO_MANY_REQUESTS_BODY, 429, {
+        "Retry-After": String(retryAfterSeconds("read")),
+      });
+    }
+
+    // Parse + validate the x-pop-signed header (signed-read so an
+    // unauthenticated caller leaks NO roster metadata).
+    const headerVal = c.req.header("x-pop-signed");
+    if (!headerVal) {
+      return c.json({ error: "x-pop-signed header required" }, 400);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(headerVal);
+    } catch (_err) {
+      return c.json({ error: "x-pop-signed must be valid JSON" }, 400);
+    }
+    const readCheck = validateSignedNetworkRosterMemberRead(parsed);
+    if (!readCheck.ok) {
+      return c.json({ error: "x-pop-signed validation_failed", details: readCheck.errors }, 400);
+    }
+    const { signed } = readCheck;
+
+    // The signed claim binds the network — reject a token minted for a DIFFERENT
+    // network than the path (a captured network-A token can't read network B).
+    if (signed.claim.network_id !== networkId) {
+      return c.json({ error: "network_id_mismatch" }, 400);
+    }
+
+    // Clock-skew — bound a captured read token's replay lifetime.
+    const issued = Date.parse(signed.claim.issued_at);
+    const now = Date.now();
+    if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
+      return c.json({ error: "issued_at out of skew window" }, 400);
+    }
+
+    // Proof-of-possession — the signature over canonicalJSON(claim) MUST verify
+    // against the claimed peer_pubkey. This signature IS the authorization: a
+    // caller who cannot sign for the key gets nothing (401).
+    const message = new TextEncoder().encode(canonicalJSON(signed.claim)) as Uint8Array<ArrayBuffer>;
+    const valid = await verifyEd25519(signed.claim.peer_pubkey, signed.signature, message);
+    if (!valid) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
+
+    // FAIL-CLOSED membership gate — the proven pubkey MUST hold an ADMITTED row
+    // for THIS network. A registered-but-PENDING key, a REVOKED key, or a key
+    // admitted only to another network is NOT a member and gets 403 (no roster).
+    const issuanceStore = getIssuanceStore(c.env);
+    const myRows = await issuanceStore.listIssuanceRequestsByPeer(signed.claim.peer_pubkey);
+    const isMember = myRows.some(
+      (r) => r.status === "ADMITTED" && r.network_id === networkId,
+    );
+    if (!isMember) {
+      return c.json({ error: "not_a_member" }, 403);
+    }
+
+    // Authorised — serve the network's ADMITTED roster (the same admission-sourced
+    // shape the public `/roster` returns), wrapped in a registry-signed assertion
+    // the member pins + verifies (DD-9).
+    const store = getStore(c.env);
+    const principals = await store.listPrincipals();
+    const admitted = await issuanceStore.listIssuanceRequests("ADMITTED");
     const roster = rosterFromAdmissions(admitted, principals, networkId);
     const assertion = await signAssertion(c.env, roster);
     return c.json(assertion);

--- a/src/services/network-registry/src/routes/networks.ts
+++ b/src/services/network-registry/src/routes/networks.ts
@@ -256,7 +256,15 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
     }
 
     // Rate-limit BEFORE the Ed25519 verify (read bucket — idempotent GET).
-    const allowed = await checkRateLimit(c.env, "read", clientKey(c.req.raw, networkId));
+    // Key by IP ONLY — exactly as the `/admission-requests/mine` sibling does.
+    // `network_id` is an attacker-controlled, format-only-validated path segment
+    // (existence is not checked until the membership gate), so keying on it would
+    // let one IP mint unbounded fresh read budgets by rotating the path, and the
+    // "shed before the expensive verify + D1 read" guard this line exists for
+    // would be bypassable. (The POST /networks mutation keys by (IP, network_id)
+    // for per-network fairness, but that is a 5/60s admin-gated write — the wrong
+    // precedent for a non-sensitive idempotent read whose gate sheds crypto.)
+    const allowed = await checkRateLimit(c.env, "read", clientKey(c.req.raw));
     if (!allowed) {
       return c.json(TOO_MANY_REQUESTS_BODY, 429, {
         "Retry-After": String(retryAfterSeconds("read")),

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -436,6 +436,46 @@ export interface SignedAdmissionMineRead {
 }
 
 /**
+ * C-1282 (ADR-0018 Q4) — the member proof-of-possession read claim carried by
+ * `GET /networks/{network_id}/roster/member`.
+ *
+ * Where {@link AdmissionMineReadClaim} releases a caller's OWN admission rows,
+ * this claim releases a NETWORK's ADMITTED peer-roster — but only to a caller
+ * who is themselves an ADMITTED member of that network. The signature over
+ * `canonicalJSON(claim)` against `peer_pubkey` IS the authorization (no admin
+ * key, no allowlist); the route then applies a fail-closed membership gate:
+ * the proven pubkey MUST hold an ADMITTED row for `network_id`, else 403. The
+ * admitted-peer list is not sensitive to a fellow admitted member (ADR-0018
+ * Q4), but a non-member learns nothing.
+ *
+ * `network_id` is bound INTO the signed claim (not just the path) so the
+ * signature is scoped to one network — a token captured for network A cannot
+ * be replayed against network B's path. The route rejects a claim whose
+ * `network_id` disagrees with the path parameter (400). No nonce (reads are
+ * idempotent); clock-skew applies to bound a captured token's lifetime.
+ */
+export interface NetworkRosterMemberReadClaim {
+  /** The network whose ADMITTED roster the caller is requesting. */
+  network_id: string;
+  /**
+   * The caller's registered Ed25519 pubkey (base64). The claim is signed with
+   * the matching private key, so verifying the signature against this field
+   * proves possession — and the membership gate then checks this pubkey is
+   * ADMITTED to `network_id`.
+   */
+  peer_pubkey: string;
+  /** ISO-8601 UTC; within the CLOCK_SKEW_MS window. */
+  issued_at: string;
+}
+
+/** On-wire envelope for a member network-roster PoP read authorisation. */
+export interface SignedNetworkRosterMemberRead {
+  claim: NetworkRosterMemberReadClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}
+
+/**
  * ADR-0018 Q1 (b′) / Q5 — the HUB-ADMIN-signed claim carried by
  * `POST /admission-requests/{request_id}/sealed-secret`.
  *

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -27,6 +27,7 @@ import type {
   SignedAdmissionMineRead,
   SignedAdmissionRead,
   SignedAdmissionRevoke,
+  SignedNetworkRosterMemberRead,
   SignedRegistration,
   SignedSealedSecretWrite,
   StackIdentity,
@@ -704,6 +705,59 @@ export function validateSignedAdmissionMineRead(
     ok: true,
     signed: {
       claim: { principal_id: bc.principal_id, peer_pubkey: bc.peer_pubkey, issued_at: bc.issued_at },
+      signature: b.signature,
+    },
+  };
+}
+
+/**
+ * C-1282 (ADR-0018 Q4) — validate the `x-pop-signed` header for the member
+ * network-roster read `GET /networks/{network_id}/roster/member`. The header
+ * value is JSON: `{ claim: NetworkRosterMemberReadClaim, signature: string }`.
+ *
+ * Like the `/mine` PoP read: no nonce (reads are idempotent), clock-skew
+ * applies, and the route verifies the signature against `claim.peer_pubkey`
+ * (that signature is the authorization). Unlike `/mine`, the claim binds a
+ * `network_id` so the signature is scoped to one network — the route additionally
+ * checks `claim.network_id` matches the path and that the proven pubkey is an
+ * ADMITTED member of it (the fail-closed gate lives in the route, not here).
+ */
+export function validateSignedNetworkRosterMemberRead(
+  body: unknown,
+): { ok: true; signed: SignedNetworkRosterMemberRead } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null || Array.isArray(b.claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be a non-array object" }] };
+  }
+  const bc = b.claim as Record<string, unknown>;
+  if (typeof bc.network_id !== "string" || !isValidNetworkId(bc.network_id)) {
+    return {
+      ok: false,
+      errors: [{ field: "claim.network_id", message: "must be a valid network id" }],
+    };
+  }
+  if (typeof bc.peer_pubkey !== "string" || !isValidPubkey(bc.peer_pubkey)) {
+    return {
+      ok: false,
+      errors: [{ field: "claim.peer_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" }],
+    };
+  }
+  if (typeof bc.issued_at !== "string" || Number.isNaN(Date.parse(bc.issued_at))) {
+    return { ok: false, errors: [{ field: "claim.issued_at", message: "must be an ISO-8601 timestamp" }] };
+  }
+  return {
+    ok: true,
+    signed: {
+      claim: { network_id: bc.network_id, peer_pubkey: bc.peer_pubkey, issued_at: bc.issued_at },
       signature: b.signature,
     },
   };


### PR DESCRIPTION
## What

Adds **`GET /networks/:network_id/roster/member`** — a **member-accessible**, PoP-gated read of a network's **ADMITTED** peer-roster. Released to a caller who proves possession of an **ADMITTED member key for that network**; the signature **is** the authorization (no admin key, no allowlist), mirroring the existing `/admission-requests/mine` PoP primitive (ADR-0018 **Q4**).

Closes #1282. Unblocks **MC-A1/A2** (#1275/#1276 — the live membership verdict for the MEMBER posture) and **MC-C hosted feed** (#1280, H0).

## Chosen approach: member-read endpoint (not gating the public roster)

The issue offered three options (member-read / `members[]`←ADMITTED / both). The faithful, lowest-blast-radius choice:

1. **Q3 (`members[]` ← ADMITTED rows) already shipped** in **C-1239** (`0c6b235`) — both `GET /networks/:id` and `GET /networks/:id/roster` already source membership from `rosterFromAdmissions(...)`, not capabilities. The issue text ("members[] still capability-derived") was stale. No further Q3 work needed; I verified it and left it.
2. **The real gap is the member-read** (ADR-0018 Q4 / design Gap-C extended to the network roster). I did **not** gate the existing `GET /networks/:id/roster`: that endpoint is on the **federation-transport resolve path** (`NetworkRegistryClient` → `resolve-federated-peers` → leaf wiring at boot/join). Adding PoP-auth there would break boot for every federating stack — out of scope and dangerous. The member-read is a **new, separately-authed surface** for the MC member posture, which authorizes off the running stack's own registered key.

## Auth model (fail-closed)

Gate order mirrors `/admission-requests/mine`:

1. `isValidNetworkId(path)` → 400
2. rate-limit (`read` bucket) **before** any crypto → 429
3. parse + validate `x-pop-signed` header → 400 (missing / non-JSON / bad shape → no metadata leaked)
4. `claim.network_id` must equal the path → 400 `network_id_mismatch` (the claim **binds** the network, so a token captured for network A can't be replayed against network B)
5. clock-skew (5 min) → 400
6. `verifyEd25519(claim.peer_pubkey, sig, canonicalJSON(claim))` → 401 `signature_invalid` — **the signature is the authorization**
7. **membership gate (the trust boundary):** the proven pubkey MUST hold a row with `status === "ADMITTED" && network_id === path`. A never-registered, **PENDING**, **REVOKED**, or **other-network** key → **403 `not_a_member`** (no roster body)
8. serve the ADMITTED roster (same admission-sourced shape as the public `/roster`; carries **no secrets** — sealed blobs stay per-member on `/mine`), wrapped in a registry-signed assertion (DD-9 pin+verify).

## Tests (TDD — written first, RED→GREEN)

`__tests__/roster-member-read.test.ts` (13 tests), trust-boundary focused:

- happy path: an ADMITTED member reads the full roster (capabilities joined as facet)
- response is a valid registry-signed assertion
- **403** for: never-registered, PENDING, REVOKED, member-of-different-network
- **401** for a forged signature (claim asserts member pubkey, signed by attacker)
- **400** for: network_id mismatch, stale token, missing header, malformed header, invalid path network_id
- roster excludes PENDING peers

## Gates

- `bun test` (full registry suite): **232 pass / 0 fail**
- `eslint --quiet` (changed files): clean
- `check-carveouts.sh` (diff): PASS
- root `tsc --noEmit` (CI gate): unaffected — the registry Worker is excluded from the root tsconfig. (The registry's own `bunx tsc` has a pre-existing `Uint8Array<ArrayBufferLike>` baseline shared by every sibling test file; the new test follows the identical established pattern and is off the CI typecheck path.)

## Deploy note

Registry deploys via `wrangler deploy --env production`, **not** `arc upgrade`. This PR does **not** deploy. No new env/secrets required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)