### PR TITLE
feat(surface): C-1277 — per-network confidentiality posture badge (MC-A3)

### DIFF
--- a/src/common/crypto/__tests__/network-encryption-policy.test.ts
+++ b/src/common/crypto/__tests__/network-encryption-policy.test.ts
@@ -7,6 +7,7 @@ import type { PolicyFederatedNetwork } from "../../types/cortex-config";
 import {
   buildNetworkKeyring,
   buildSealPolicyByPrincipal,
+  confidentialityPosture,
   countEncryptionEnabledNetworks,
   defaultKeyId,
   networkKeyFromConfig,
@@ -187,5 +188,48 @@ describe("countEncryptionEnabledNetworks", () => {
         network({ id: "d" }), // unset
       ]),
     ).toBe(2);
+  });
+});
+
+describe("confidentialityPosture (MC-A3, ADR-0019/0018)", () => {
+  test("unset encryption ⇒ mode off, no key", () => {
+    expect(confidentialityPosture(network({ id: "research" }))).toEqual({
+      mode: "off",
+      keyPresent: false,
+      keyId: null,
+    });
+  });
+
+  test("enabled + key present ⇒ mode enabled, key present, default kid", () => {
+    expect(
+      confidentialityPosture(
+        network({ id: "research", encryption: "enabled", payload_key: K32_A }),
+      ),
+    ).toEqual({ mode: "enabled", keyPresent: true, keyId: "research/k1" });
+  });
+
+  test("required + explicit key id ⇒ surfaces the rotation epoch as keyId", () => {
+    expect(
+      confidentialityPosture(
+        network({
+          id: "research",
+          encryption: "required",
+          payload_key: K32_A,
+          payload_key_id: "research/epoch-7",
+        }),
+      ),
+    ).toEqual({ mode: "required", keyPresent: true, keyId: "research/epoch-7" });
+  });
+
+  test("HONESTY HINGE: enabled but NO key ⇒ mode enabled, keyPresent false (not actually sealing)", () => {
+    expect(
+      confidentialityPosture(network({ id: "research", encryption: "enabled" })),
+    ).toEqual({ mode: "enabled", keyPresent: false, keyId: null });
+  });
+
+  test("required but NO key ⇒ mode required, keyPresent false", () => {
+    expect(
+      confidentialityPosture(network({ id: "research", encryption: "required" })),
+    ).toEqual({ mode: "required", keyPresent: false, keyId: null });
   });
 });

--- a/src/common/crypto/network-encryption-policy.ts
+++ b/src/common/crypto/network-encryption-policy.ts
@@ -16,6 +16,9 @@ import {
   type NetworkKey,
 } from "./payload-encryption";
 
+/** Re-export so surface DTOs can name the mode without reaching into the crypto core. */
+export type { EncryptionMode } from "./payload-encryption";
+
 /** Default key id when a network sets `payload_key` but no `payload_key_id`. */
 export function defaultKeyId(networkId: string): string {
   return `${networkId}/k1`;
@@ -49,6 +52,49 @@ export function buildNetworkKeyring(
     if (k !== undefined) entries.push({ net: network.id, keys: [k] });
   }
   return new NetworkKeyring(entries);
+}
+
+/**
+ * MC-A3 (cortex#1277, ADR-0019/0018) — a network's TRUTHFUL confidentiality
+ * posture, derived from config alone, for read-only surfacing in Mission Control.
+ *
+ * `mode` and `keyPresent` are reported INDEPENDENTLY because they can disagree:
+ * a network with `encryption: enabled|required` but NO `payload_key` does NOT
+ * actually seal — the runtime publishes cleartext-with-a-loud-warning
+ * (ADR-0019 §5). That is the honesty hinge: such a network must NEVER be badged
+ * "encrypted" by the surface.
+ */
+export interface NetworkConfidentialityPosture {
+  /** Configured mode (`policy.federated.networks[].encryption`, default `off`). */
+  readonly mode: EncryptionMode;
+  /** Whether the per-network key `K` (`payload_key`) is actually held locally. */
+  readonly keyPresent: boolean;
+  /**
+   * Active key-id / rotation epoch when a key is held — the `extensions.enc.kid`
+   * the runtime stamps (`payload_key_id`, defaulting to `<network-id>/k1`,
+   * ADR-0019 §K-id). `null` when no key is present. Surfaces the rotation
+   * generation honestly without exposing `K` itself.
+   */
+  readonly keyId: string | null;
+}
+
+/**
+ * Derive a network's read-only confidentiality posture from its config. Pure +
+ * never-throws. Reports `mode` and `keyPresent` SEPARATELY so the surface can
+ * distinguish a truly-sealed network from one configured-to-seal that holds no
+ * key (publishing cleartext-with-warning, ADR-0019 §5) — the latter must not be
+ * badged "encrypted". Reuses {@link networkKeyFromConfig} (so the `keyId` is the
+ * exact `extensions.enc.kid` the runtime would stamp).
+ */
+export function confidentialityPosture(
+  network: PolicyFederatedNetwork,
+): NetworkConfidentialityPosture {
+  const key = networkKeyFromConfig(network);
+  return {
+    mode: network.encryption ?? "off",
+    keyPresent: key !== undefined,
+    keyId: key?.kid ?? null,
+  };
 }
 
 /** The seal decision for an outbound federated envelope to a given target. */

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -177,6 +177,9 @@ import {
   type AdmissionRowsProvider,
   type AdmissionRowsResult,
 } from "./bus/agent-network/admission-read";
+// MC-A3 (cortex#1277, ADR-0019/0018) — derive each joined network's read-only
+// confidentiality posture from config for the `/api/networks` view.
+import { confidentialityPosture } from "./common/crypto/network-encryption-policy";
 // MC-I1.S4 (ADR-0005 §4) — bus→MC dispatch-lifecycle projection renderer.
 import { createDispatchProjectionRenderer } from "./surface/mc/projection/dispatch-lifecycle-renderer";
 // P-14 U2.1 (#934) — bus→MC observability projection renderer (signal's four
@@ -5627,7 +5630,15 @@ export async function startCortex(
         networksViewForApi = {
           localPrincipal: principalId,
           networks: () =>
-            networksList.map((n) => ({ networkId: n.id, leafNode: n.leaf_node })),
+            networksList.map((n) => ({
+              networkId: n.id,
+              leafNode: n.leaf_node,
+              // MC-A3 — config-derived confidentiality posture (ADR-0019/0018).
+              // Read-only honesty: surfaces `enabled`/`required` WITH key as
+              // sealed, but a configured-without-key network as degraded, never
+              // faked "encrypted".
+              confidentiality: confidentialityPosture(n),
+            })),
           resolveAdmittedRoster: (networkId) =>
             resolveAdmittedRoster(networkId, admissionProvider),
         };

--- a/src/surface/mc/__tests__/networks-api.test.ts
+++ b/src/surface/mc/__tests__/networks-api.test.ts
@@ -14,6 +14,7 @@ import {
   type NetworksView,
   type ListNetworksResponse,
 } from "../api/networks";
+import type { NetworkConfidentialityPosture } from "../../../common/crypto/network-encryption-policy";
 import type {
   AgentPresenceSnapshotRecord,
   AgentPresenceView,
@@ -44,9 +45,17 @@ function rec(
   };
 }
 
+/** Default posture for the stubs that don't exercise confidentiality (off, no key). */
+const CLEARTEXT: NetworkConfidentialityPosture = {
+  mode: "off",
+  keyPresent: false,
+  keyId: null,
+};
+
 function view(
   rosters: Record<string, ResolveAdmittedRosterResult>,
   localPrincipal = "andreas",
+  confidentiality: Record<string, NetworkConfidentialityPosture> = {},
 ): NetworksView {
   return {
     localPrincipal,
@@ -54,6 +63,7 @@ function view(
       Object.keys(rosters).map((networkId) => ({
         networkId,
         leafNode: `${networkId}-leaf`,
+        confidentiality: confidentiality[networkId] ?? CLEARTEXT,
       })),
     resolveAdmittedRoster: (networkId) =>
       Promise.resolve(
@@ -80,7 +90,9 @@ describe("handleListNetworks — graceful states", () => {
   it("a throwing admission provider degrades to unreachable, never 5xx", async () => {
     const throwingView: NetworksView = {
       localPrincipal: "andreas",
-      networks: () => [{ networkId: "research-collab", leafNode: "rc-leaf" }],
+      networks: () => [
+        { networkId: "research-collab", leafNode: "rc-leaf", confidentiality: CLEARTEXT },
+      ],
       resolveAdmittedRoster: () => Promise.reject(new Error("transport boom")),
     };
     const res = await handleListNetworks(
@@ -184,6 +196,82 @@ describe("handleListNetworks — authoritative reconciliation", () => {
       principal: "newcomer",
       verdict: "pending",
       present_stacks: [],
+    });
+  });
+});
+
+describe("handleListNetworks — confidentiality posture carry-through (MC-A3, ADR-0019/0018)", () => {
+  it("carries the per-network posture through to the wire DTO (camelCase → snake_case)", async () => {
+    const res = await handleListNetworks(
+      view(
+        {
+          "research-collab": {
+            ok: true,
+            roster: { admitted: [], pending: [], authoritative: true },
+          },
+        },
+        "andreas",
+        {
+          "research-collab": {
+            mode: "required",
+            keyPresent: true,
+            keyId: "research-collab/k1",
+          },
+        },
+      ),
+      presenceView([rec({ agentId: "luna" })]),
+    );
+    const net = (await body(res)).networks[0]!;
+    expect(net.confidentiality).toEqual({
+      mode: "required",
+      key_present: true,
+      key_id: "research-collab/k1",
+    });
+  });
+
+  it("defaults to a cleartext posture when none is configured", async () => {
+    const res = await handleListNetworks(
+      view({
+        "research-collab": {
+          ok: true,
+          roster: { admitted: [], pending: [], authoritative: true },
+        },
+      }),
+      presenceView([rec({ agentId: "luna" })]),
+    );
+    const net = (await body(res)).networks[0]!;
+    expect(net.confidentiality).toEqual({
+      mode: "off",
+      key_present: false,
+      key_id: null,
+    });
+  });
+
+  it("posture is independent of a degraded roster read (still carried on a self-only read)", async () => {
+    const res = await handleListNetworks(
+      view(
+        {
+          "research-collab": {
+            ok: false,
+            reason: "unreachable",
+            detail: "registry down",
+          },
+        },
+        "andreas",
+        {
+          "research-collab": { mode: "enabled", keyPresent: false, keyId: null },
+        },
+      ),
+      presenceView([rec({ agentId: "luna" })]),
+    );
+    const net = (await body(res)).networks[0]!;
+    // Roster read failed, but the config-derived posture is still honestly carried
+    // (configured-to-seal, NO key — a degraded/cleartext posture, never "encrypted").
+    expect(net.roster_status).toBe("unreachable");
+    expect(net.confidentiality).toEqual({
+      mode: "enabled",
+      key_present: false,
+      key_id: null,
     });
   });
 });

--- a/src/surface/mc/__tests__/networks-http.test.ts
+++ b/src/surface/mc/__tests__/networks-http.test.ts
@@ -76,7 +76,13 @@ describe("GET /api/networks (HTTP)", () => {
   it("serves the reconciled membership through the wired view", async () => {
     const view: NetworksView = {
       localPrincipal: "andreas",
-      networks: () => [{ networkId: "research-collab", leafNode: "rc-leaf" }],
+      networks: () => [
+        {
+          networkId: "research-collab",
+          leafNode: "rc-leaf",
+          confidentiality: { mode: "off", keyPresent: false, keyId: null },
+        },
+      ],
       resolveAdmittedRoster: () =>
         Promise.resolve({
           ok: true,

--- a/src/surface/mc/api/networks.ts
+++ b/src/surface/mc/api/networks.ts
@@ -50,6 +50,10 @@
 
 import type { AgentPresenceView } from "./agents";
 import type { ResolveAdmittedRosterResult } from "../../../bus/agent-network/admission-read";
+import type {
+  EncryptionMode,
+  NetworkConfidentialityPosture,
+} from "../../../common/crypto/network-encryption-policy";
 import {
   reconcileNetworkMembership,
   derivePresentStacksByPrincipal,
@@ -65,6 +69,13 @@ export interface JoinedNetworkInfo {
   networkId: string;
   /** The network's leaf-node connection id (`.leaf_node`). */
   leafNode: string;
+  /**
+   * MC-A3 (cortex#1277, ADR-0019/0018) — the network's TRUTHFUL confidentiality
+   * posture, derived from config (`encryption` mode + `payload_key` presence +
+   * `payload_key_id`). `cortex.ts` supplies it via `confidentialityPosture(n)`;
+   * tests supply a stub. The handler maps it to the snake_case wire DTO.
+   */
+  confidentiality: NetworkConfidentialityPosture;
 }
 
 /**
@@ -95,6 +106,25 @@ export type RosterStatus =
 /** Whether the roster reflects the COMPLETE network or only the serving stack's row. */
 export type RosterScope = "complete" | "self";
 
+/** ADR-0019 per-network encryption mode, mirrored from config (wire DTO). */
+export type { EncryptionMode };
+
+/**
+ * MC-A3 (cortex#1277) — a network's confidentiality posture, snake_case for the
+ * `/api/networks` wire DTO. `mode` and `key_present` are reported INDEPENDENTLY:
+ * a network configured `enabled`/`required` with `key_present: false` is NOT
+ * actually sealing (cleartext-with-warning, ADR-0019 §5) and must never be badged
+ * "encrypted". The wire-side mirror of {@link NetworkConfidentialityPosture}.
+ */
+export interface NetworkConfidentialityDTO {
+  /** Configured mode (default `off`). */
+  mode: EncryptionMode;
+  /** Whether the per-network key `K` is actually held (the honesty hinge). */
+  key_present: boolean;
+  /** Active key-id / rotation epoch when a key is held; else `null`. */
+  key_id: string | null;
+}
+
 /** One reconciled roster member, snake_case for the DTO. */
 export interface MembershipMemberDTO {
   principal: string;
@@ -114,6 +144,12 @@ export interface NetworkMembershipDTO {
    * detection suppressed). `null` when the read failed.
    */
   roster_scope: RosterScope | null;
+  /**
+   * MC-A3 (cortex#1277, ADR-0019/0018) — the network's read-only confidentiality
+   * posture. Always present; the surface badges it honestly (never fakes
+   * "encrypted" for a configured-but-keyless network).
+   */
+  confidentiality: NetworkConfidentialityDTO;
   /** Admitted roster reconciled ⋈ presence into per-member verdicts. */
   members: MembershipMemberDTO[];
 }
@@ -231,6 +267,14 @@ export async function handleListNetworks(
         leaf_node: info.leafNode,
         roster_status: rosterStatus,
         roster_scope: rosterScope,
+        // MC-A3 — carry the config-derived confidentiality posture through to the
+        // wire DTO (camelCase posture → snake_case DTO). Read-only; the surface
+        // badges it honestly. Independent of the roster read above.
+        confidentiality: {
+          mode: info.confidentiality.mode,
+          key_present: info.confidentiality.keyPresent,
+          key_id: info.confidentiality.keyId,
+        },
         members: members.map((m) => ({
           principal: m.principal,
           verdict: m.verdict,

--- a/src/surface/mc/api/networks.ts
+++ b/src/surface/mc/api/networks.ts
@@ -115,6 +115,12 @@ export type { EncryptionMode };
  * a network configured `enabled`/`required` with `key_present: false` is NOT
  * actually sealing (cleartext-with-warning, ADR-0019 §5) and must never be badged
  * "encrypted". The wire-side mirror of {@link NetworkConfidentialityPosture}.
+ *
+ * **Consumer contract:** a consumer MUST combine `mode` AND `key_present` to
+ * judge whether traffic is actually sealed — `mode` alone over-claims (a
+ * keyless `enabled`/`required` network publishes cleartext). The canonical
+ * derivation is `confidentialityBadge` in `network-membership-adapter.ts`; new
+ * consumers should reuse it rather than re-deriving from `mode`.
  */
 export interface NetworkConfidentialityDTO {
   /** Configured mode (default `off`). */

--- a/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
@@ -5,10 +5,12 @@
 
 import { describe, it, expect } from "bun:test";
 import {
+  confidentialityBadge,
   verdictBadge,
   rosterStatusBadge,
   summarizeMembership,
 } from "../lib/network-membership-adapter";
+import type { NetworkConfidentialityDTO } from "../../api/networks";
 
 describe("verdictBadge", () => {
   it("maps each verdict to a distinct tone", () => {
@@ -43,6 +45,73 @@ describe("rosterStatusBadge", () => {
     expect(rosterStatusBadge("unreachable", null).tone).toBe("warn");
     expect(rosterStatusBadge("not_configured", null).label).toContain("pending");
     expect(rosterStatusBadge("unauthorized", null).label).toContain("authorized");
+  });
+});
+
+describe("confidentialityBadge (MC-A3, ADR-0019/0018)", () => {
+  const c = (over: Partial<NetworkConfidentialityDTO>): NetworkConfidentialityDTO => ({
+    mode: "off",
+    key_present: false,
+    key_id: null,
+    ...over,
+  });
+
+  it("enabled + key held ⇒ encrypted (ok)", () => {
+    const b = confidentialityBadge(c({ mode: "enabled", key_present: true, key_id: "n/k1" }));
+    expect(b.posture).toBe("encrypted");
+    expect(b.tone).toBe("ok");
+    expect(b.label).toBe("encrypted");
+    expect(b.title).toContain("n/k1");
+  });
+
+  it("required + key held ⇒ encrypted-required (ok), rejects cleartext inbound", () => {
+    const b = confidentialityBadge(c({ mode: "required", key_present: true, key_id: "n/k1" }));
+    expect(b.posture).toBe("encrypted-required");
+    expect(b.tone).toBe("ok");
+    expect(b.label).toContain("required");
+    expect(b.title).toContain("REJECTED");
+  });
+
+  it("off ⇒ cleartext (warn)", () => {
+    const b = confidentialityBadge(c({ mode: "off" }));
+    expect(b.posture).toBe("cleartext");
+    expect(b.tone).toBe("warn");
+  });
+
+  it("HONESTY HINGE: enabled but NO key ⇒ degraded (danger), never 'encrypted'", () => {
+    const b = confidentialityBadge(c({ mode: "enabled", key_present: false }));
+    expect(b.posture).toBe("degraded");
+    expect(b.tone).toBe("danger");
+    expect(b.label).not.toContain("encrypted");
+    expect(b.title).toContain("CLEARTEXT");
+  });
+
+  it("HONESTY HINGE: required but NO key ⇒ degraded (danger)", () => {
+    const b = confidentialityBadge(c({ mode: "required", key_present: false }));
+    expect(b.posture).toBe("degraded");
+    expect(b.tone).toBe("danger");
+  });
+
+  it("absent posture ⇒ unknown (warn), never assumed encrypted", () => {
+    const b = confidentialityBadge(undefined);
+    expect(b.posture).toBe("unknown");
+    expect(b.tone).toBe("warn");
+    expect(b.label).not.toContain("encrypted");
+  });
+
+  it("every posture has a non-empty label + title", () => {
+    const cases: (NetworkConfidentialityDTO | undefined)[] = [
+      c({ mode: "off" }),
+      c({ mode: "enabled", key_present: true }),
+      c({ mode: "required", key_present: true }),
+      c({ mode: "enabled", key_present: false }),
+      undefined,
+    ];
+    for (const tc of cases) {
+      const b = confidentialityBadge(tc);
+      expect(b.label.length).toBeGreaterThan(0);
+      expect(b.title.length).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
@@ -99,6 +99,16 @@ describe("confidentialityBadge (MC-A3, ADR-0019/0018)", () => {
     expect(b.label).not.toContain("encrypted");
   });
 
+  it("an unrecognized mode degrades to unknown at runtime, never 'encrypted'", () => {
+    // Defensive: a server sending a mode outside the union (forward-compat / bug)
+    // must hit the exhaustiveness default's runtime fallback, not over-claim.
+    const bogus = { mode: "weird", key_present: true, key_id: "n/k1" } as unknown as
+      NetworkConfidentialityDTO;
+    const b = confidentialityBadge(bogus);
+    expect(b.posture).toBe("unknown");
+    expect(b.label).not.toContain("encrypted");
+  });
+
   it("every posture has a non-empty label + title", () => {
     const cases: (NetworkConfidentialityDTO | undefined)[] = [
       c({ mode: "off" }),

--- a/src/surface/mc/dashboard-v2/__tests__/network-roster-panel.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-roster-panel.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * MC-A3 (cortex#1277) — NetworkRosterPanel render tests, focused on the
+ * per-network confidentiality posture chip (ADR-0019/0018).
+ *
+ * The panel is pure (no hooks / no xyflow), so it renders under
+ * `renderToStaticMarkup`. These assert the read-only HONESTY of the chip: a
+ * sealed network reads "encrypted", a configured-but-keyless network reads
+ * "no key" (degraded, never "encrypted"), and a cleartext network reads
+ * "cleartext".
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { NetworkRosterPanel } from "../components/network-roster-panel";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import type { NetworkConfidentialityDTO } from "../../api/networks";
+
+function net(
+  id: string,
+  confidentiality: NetworkConfidentialityDTO,
+): NetworkMembershipDTO {
+  return {
+    network_id: id,
+    leaf_node: `${id}-leaf`,
+    roster_status: "ok",
+    roster_scope: "complete",
+    confidentiality,
+    members: [
+      { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"] },
+    ],
+  };
+}
+
+function render(networks: NetworkMembershipDTO[]): string {
+  return renderToStaticMarkup(
+    createElement(NetworkRosterPanel, { networks, localPrincipal: "andreas" }),
+  );
+}
+
+describe("NetworkRosterPanel — confidentiality chip", () => {
+  it("renders nothing when no networks are joined", () => {
+    expect(render([])).toBe("");
+  });
+
+  it("badges a sealed (enabled + key) network as encrypted", () => {
+    const html = render([
+      net("research", { mode: "enabled", key_present: true, key_id: "research/k1" }),
+    ]);
+    expect(html).toContain('data-posture="encrypted"');
+    expect(html).toContain("encrypted");
+  });
+
+  it("badges a required + key network as encrypted (required)", () => {
+    const html = render([
+      net("research", { mode: "required", key_present: true, key_id: "research/k1" }),
+    ]);
+    expect(html).toContain('data-posture="encrypted-required"');
+    expect(html).toContain("required");
+  });
+
+  it("HONESTY: configured enabled but NO key renders degraded, never 'encrypted'", () => {
+    const html = render([
+      net("research", { mode: "enabled", key_present: false, key_id: null }),
+    ]);
+    expect(html).toContain('data-posture="degraded"');
+    expect(html).toContain("no key");
+    // The chip label must not claim encryption for a keyless network.
+    expect(html).toContain("encryption: no key");
+  });
+
+  it("badges a cleartext (off) network as cleartext", () => {
+    const html = render([
+      net("research", { mode: "off", key_present: false, key_id: null }),
+    ]);
+    expect(html).toContain('data-posture="cleartext"');
+    expect(html).toContain("cleartext");
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
@@ -16,6 +16,7 @@
 
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
 import {
+  confidentialityBadge,
   verdictBadge,
   rosterStatusBadge,
   summarizeMembership,
@@ -51,6 +52,7 @@ export function NetworkRosterPanel({
       <ul className="network-roster-list">
         {networks.map((net) => {
           const status = rosterStatusBadge(net.roster_status, net.roster_scope);
+          const confidentiality = confidentialityBadge(net.confidentiality);
           const summary = summarizeMembership(net);
           return (
             <li key={net.network_id} className="network-roster-group">
@@ -64,6 +66,16 @@ export function NetworkRosterPanel({
                   title={status.title}
                 >
                   {status.label}
+                </span>
+                {/* MC-A3 (cortex#1277) — per-network confidentiality posture
+                    (ADR-0019/0018). Read-only honesty: never "encrypted" without
+                    a key. `data-posture` is the stable token for automation/tests. */}
+                <span
+                  className={`network-roster-confidentiality tone-${confidentiality.tone}`}
+                  data-posture={confidentiality.posture}
+                  title={confidentiality.title}
+                >
+                  {confidentiality.label}
                 </span>
                 <span className="dim network-roster-summary">
                   {summary.present} present · {summary.absent} absent

--- a/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
@@ -148,8 +148,10 @@ function keyIdSuffix(c: NetworkConfidentialityDTO): string {
  *     cleartext-with-warning, ADR-0019 §5) — flagged `danger`, never "encrypted".
  *   - posture absent (older/stale server) → `unknown` — never assumed encrypted.
  *
- * Total over the `EncryptionMode` union (compiler-enforced; a new mode won't
- * silently fall through).
+ * Total over the `EncryptionMode` union: the `default` branch assigns `c.mode` to
+ * `never`, so adding a mode without a case is a COMPILE error (the project does
+ * not set `noImplicitReturns`, so this `never` assignment — not the switch shape —
+ * is what enforces totality). The runtime fallback is "unknown", never "encrypted".
  */
 export function confidentialityBadge(
   c: NetworkConfidentialityDTO | undefined,
@@ -201,6 +203,18 @@ export function confidentialityBadge(
         title:
           "Federated payloads cross in cleartext (signed, not sealed) — encryption is off (ADR-0019).",
       };
+    default: {
+      // Exhaustiveness guard: a new EncryptionMode must add a case above, or this
+      // assignment fails to compile. Runtime fallback degrades to "unknown" — it
+      // NEVER claims "encrypted" for an unrecognized mode (the honesty invariant).
+      const _exhaustive: never = c.mode;
+      return {
+        label: "encryption: unknown",
+        tone: "warn",
+        posture: "unknown",
+        title: `Unrecognized encryption mode '${String(_exhaustive)}' — not assumed encrypted (ADR-0019).`,
+      };
+    }
   }
 }
 

--- a/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
@@ -11,6 +11,7 @@
 
 import type {
   MembershipVerdict,
+  NetworkConfidentialityDTO,
   NetworkMembershipDTO,
   RosterStatus,
   RosterScope,
@@ -106,6 +107,99 @@ export function rosterStatusBadge(
         tone: "warn",
         title:
           "Live admission-rows read not wired (A1) — pending A2 + registry ADR-0018 Q3 roster fix",
+      };
+  }
+}
+
+// --- MC-A3: per-network confidentiality posture (ADR-0019/0018) -------------
+
+/**
+ * Stable, non-localized posture token — for `data-*` attributes, automation, and
+ * tests. Distinct from the human `label`.
+ */
+export type ConfidentialityPostureToken =
+  | "encrypted" // enabled + key held — sealed, transition window (cleartext-in still accepted)
+  | "encrypted-required" // required + key held — sealed, cleartext-in REJECTED
+  | "cleartext" // mode off — signed, not sealed
+  | "degraded" // enabled/required but NO key — publishing cleartext-with-warning (the honesty hinge)
+  | "unknown"; // posture not reported (older/stale server) — never assume encrypted
+
+/** A render-ready confidentiality badge. */
+export interface ConfidentialityBadge {
+  label: string;
+  tone: VerdictTone;
+  /** Stable posture token (data-* / tests); never localized. */
+  posture: ConfidentialityPostureToken;
+  /** Tooltip / aria description. */
+  title: string;
+}
+
+/** `(key <kid>)` suffix for a title when a key-id is known; else empty. */
+function keyIdSuffix(c: NetworkConfidentialityDTO): string {
+  return c.key_id ? ` (key ${c.key_id})` : "";
+}
+
+/**
+ * Map a network's confidentiality posture → a badge. READ-ONLY HONESTY: it
+ * NEVER badges "encrypted" unless a key is actually held. The two load-bearing
+ * cases the surface must not blur (ADR-0019):
+ *
+ *   - `enabled`/`required` but NO key → `degraded` (the runtime publishes
+ *     cleartext-with-warning, ADR-0019 §5) — flagged `danger`, never "encrypted".
+ *   - posture absent (older/stale server) → `unknown` — never assumed encrypted.
+ *
+ * Total over the `EncryptionMode` union (compiler-enforced; a new mode won't
+ * silently fall through).
+ */
+export function confidentialityBadge(
+  c: NetworkConfidentialityDTO | undefined,
+): ConfidentialityBadge {
+  if (c === undefined) {
+    return {
+      label: "encryption: unknown",
+      tone: "warn",
+      posture: "unknown",
+      title:
+        "Confidentiality posture not reported by the server — not assumed encrypted (ADR-0019).",
+    };
+  }
+  // Honesty hinge: configured-to-seal but no key ⇒ NOT actually sealing.
+  if ((c.mode === "enabled" || c.mode === "required") && !c.key_present) {
+    return {
+      label: "encryption: no key",
+      tone: "danger",
+      posture: "degraded",
+      title:
+        `Network is configured 'encryption: ${c.mode}' but no payload key (K) is present — ` +
+        "federated payloads publish in CLEARTEXT with a warning (ADR-0019 §5). Not sealed.",
+    };
+  }
+  switch (c.mode) {
+    case "required":
+      return {
+        label: "encrypted (required)",
+        tone: "ok",
+        posture: "encrypted-required",
+        title:
+          `Federated payloads sealed with the per-network key${keyIdSuffix(c)} (ADR-0019); ` +
+          "cleartext inbound is REJECTED.",
+      };
+    case "enabled":
+      return {
+        label: "encrypted",
+        tone: "ok",
+        posture: "encrypted",
+        title:
+          `Federated payloads sealed with the per-network key${keyIdSuffix(c)} (ADR-0019); ` +
+          "cleartext-but-signed inbound still accepted (transition window).",
+      };
+    case "off":
+      return {
+        label: "cleartext",
+        tone: "warn",
+        posture: "cleartext",
+        title:
+          "Federated payloads cross in cleartext (signed, not sealed) — encryption is off (ADR-0019).",
       };
   }
 }

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -971,9 +971,16 @@ html, body {
 .network-roster-member { display: flex; align-items: center; gap: 8px; font-size: 12px; }
 .network-roster-principal { font-family: var(--mono); }
 .network-roster-stacks { font-size: 11px; margin-left: auto; }
-.network-roster-badge, .network-roster-status {
+.network-roster-badge, .network-roster-status, .network-roster-confidentiality {
   font-size: 10px; padding: 1px 7px; border-radius: 999px;
   border: 1px solid currentColor; white-space: nowrap;
+}
+/* MC-A3 (cortex#1277) — confidentiality posture chip (ADR-0019/0018).
+   Tone carries the colour (ok/warn/danger); the degraded "no key" posture also
+   gets a subtle fill so it reads as a real anomaly, not just another chip. */
+.network-roster-confidentiality[data-posture="degraded"] {
+  background: color-mix(in srgb, var(--bad) 14%, transparent);
+  font-weight: 600;
 }
 .tone-ok { color: var(--ok); }
 .tone-warn { color: var(--warn); }


### PR DESCRIPTION
## What

MC-A3 (cortex#1277), part of the MC catch-up umbrella #1274. Badges each **joined network** on the Mission Control pane with its **truthful confidentiality posture** — encrypted (per-network key `K`, [ADR-0019](docs/adr/0019-federated-payload-encryption.md)) + sealed-delivery / rotation state ([ADR-0018](docs/adr/0018-admission-gate-and-leaf-secret-distribution.md)). Read-only honesty about whether a network's federated payloads are actually sealed.

Builds on A1 (#1281) — the network-first-class model + `/api/networks` + `network-roster-panel`.

## Where the posture comes from (traced)

Per-network, from `policy.federated.networks[]`:
- `encryption: off | enabled | required` (ADR-0019 lock 5, default `off`)
- `payload_key` **presence** — the per-network key `K`
- `payload_key_id` — the active rotation epoch (`extensions.enc.kid`, defaults `<network-id>/k1`)

**The honesty hinge (ADR-0019 §5):** a network configured `enabled`/`required` but with **no key** does NOT seal — the runtime publishes cleartext-with-a-warning. So `mode` and `key_present` are reported **independently**, and such a network is badged **"no key" (degraded, danger)** — never "encrypted". An absent posture → **"unknown"**, never faked.

## Posture → badge

| mode | key | badge | tone |
|---|---|---|---|
| `enabled` | present | `encrypted` | ok |
| `required` | present | `encrypted (required)` | ok |
| `enabled`/`required` | **absent** | `encryption: no key` (degraded) | danger |
| `off` | — | `cleartext` | warn |
| (not reported) | — | `encryption: unknown` | warn |

## Placement note

The posture is per-**network** (a stack can be on several networks), so it badges the **per-network roster panel** group header (A1's existing panel — **not** a new top-level panel, that's B1), **not** the presence-derived stack-hubs in the topology graph. Mapping per-network encryption onto a `{principal}/{stack}` hub would be ambiguous (which network's `K`?).

Absorbs the hosted-scope **H5 encryption badge** so MC-C does not duplicate it.

## Changes (scope-disciplined)

- `common/crypto/network-encryption-policy.ts` — `confidentialityPosture(network)` pure derivation (reuses `networkKeyFromConfig`, so `keyId` is the exact stamped kid).
- `surface/mc/api/networks.ts` — carry `confidentiality` through `JoinedNetworkInfo` → `NetworkMembershipDTO` (camelCase posture → snake_case wire DTO).
- `dashboard-v2/lib/network-membership-adapter.ts` — `confidentialityBadge` (total over `EncryptionMode`).
- `dashboard-v2/components/network-roster-panel.tsx` — render the chip in the group header.
- `dashboard-v2/styles/global.css` — chip style (degraded fill).
- `cortex.ts` — wire `confidentialityPosture(n)` into the `/api/networks` view (minimal).

## Tests & gates

- New/extended: posture derivation incl. the no-key honesty hinge; DTO carry-through (independent of a degraded roster read); badge mapping (all postures + unknown); panel render.
- `tsc --noEmit` clean · `lint:errors` clean · `bun test src/surface/mc src/common/crypto` → **2089 pass, 0 fail** · `check-carveouts` PASS.

Closes #1277
Refs #1274, ADR-0019, ADR-0018

🤖 Generated with [Claude Code](https://claude.com/claude-code)