### PR TITLE
feat(surface): C-1288 — MC constellation skin design tokens + motion layer (MC-D1)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/constellation-tokens.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/constellation-tokens.test.ts
@@ -16,6 +16,10 @@ import { test, expect } from "bun:test";
 const cssPath = new URL("../styles/constellation.css", import.meta.url).pathname;
 const css = await Bun.file(cssPath).text();
 
+/** CSS with /* … *\/ comments stripped — so prose mentions of `:root` etc.
+ *  inside the header doc-comment don't fool the structural assertions. */
+const cssNoComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
 /** Required design tokens (exact custom-property names the mockup defines). */
 const REQUIRED_TOKENS = [
   "--bg", "--panel", "--panel2", "--line", "--lsoft",
@@ -39,18 +43,25 @@ test("every required design token is declared", () => {
   }
 });
 
-test("every required keyframe is defined", () => {
+test("every required keyframe is defined exactly once", () => {
   for (const name of REQUIRED_KEYFRAMES) {
-    expect(css).toContain(`@keyframes ${name}`);
+    // Keyframe names are document-global (not scopable); a duplicate would
+    // silently override. Pin each to a single definition here. The trailing
+    // boundary stops `dashFlow` matching inside `dashFlowFed`.
+    const matches = cssNoComments.match(
+      new RegExp(`@keyframes\\s+${name}(?![\\w-])`, "g"),
+    );
+    expect(matches?.length ?? 0).toBe(1);
   }
 });
 
 test("tokens are scoped under the .mc-skin wrapper, not bare :root", () => {
   // The opt-in wrapper must exist...
-  expect(css).toContain(".mc-skin {");
-  // ...and the skin must NOT re-declare the palette on a bare :root selector
-  // (that would override the live dashboard's tokens.css — a flag-day restyle).
-  expect(css).not.toMatch(/(^|\})\s*:root\b/);
+  expect(cssNoComments).toContain(".mc-skin {");
+  // ...and the skin must NOT re-declare the palette on a :root selector
+  // anywhere (that would override the live dashboard's tokens.css — a
+  // flag-day restyle). Checked against the comment-stripped source.
+  expect(cssNoComments).not.toContain(":root");
 });
 
 test("a prefers-reduced-motion guard disables the animations", () => {

--- a/src/surface/mc/dashboard-v2/__tests__/constellation-tokens.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/constellation-tokens.test.ts
@@ -1,0 +1,66 @@
+/**
+ * MC-D1 (cortex#1288) — constellation skin token + motion presence guard.
+ *
+ * The skin's view slices (D2–D5) consume `constellation.css` by NAME: a
+ * dropped token or renamed keyframe would silently break a downstream pane
+ * with no type error to catch it (it's CSS). This test pins the contract:
+ * the required tokens, keyframes, the `.mc-skin` scope choice, and the
+ * reduced-motion guard must all stay present.
+ *
+ * It also enforces the "additive, no `:root` restyle" invariant — the skin
+ * must NOT declare its palette on a bare `:root`, which would override the
+ * live dashboard's tokens.css.
+ */
+import { test, expect } from "bun:test";
+
+const cssPath = new URL("../styles/constellation.css", import.meta.url).pathname;
+const css = await Bun.file(cssPath).text();
+
+/** Required design tokens (exact custom-property names the mockup defines). */
+const REQUIRED_TOKENS = [
+  "--bg", "--panel", "--panel2", "--line", "--lsoft",
+  "--fg", "--dim", "--faint",
+  "--mer", "--tide",
+  "--ok", "--warn", "--bad",
+  "--d", "--a", "--h",
+  "--mono", "--sans",
+];
+
+/** Required keyframes (the motion contract D2–D5 reference by name). */
+const REQUIRED_KEYFRAMES = [
+  "corePulse", "coreSlow", "haloBreathe",
+  "dashFlow", "dashFlowFed",
+  "attnBlink", "ticker", "barSweep", "spin",
+];
+
+test("every required design token is declared", () => {
+  for (const token of REQUIRED_TOKENS) {
+    expect(css).toContain(`${token}:`);
+  }
+});
+
+test("every required keyframe is defined", () => {
+  for (const name of REQUIRED_KEYFRAMES) {
+    expect(css).toContain(`@keyframes ${name}`);
+  }
+});
+
+test("tokens are scoped under the .mc-skin wrapper, not bare :root", () => {
+  // The opt-in wrapper must exist...
+  expect(css).toContain(".mc-skin {");
+  // ...and the skin must NOT re-declare the palette on a bare :root selector
+  // (that would override the live dashboard's tokens.css — a flag-day restyle).
+  expect(css).not.toMatch(/(^|\})\s*:root\b/);
+});
+
+test("a prefers-reduced-motion guard disables the animations", () => {
+  expect(css).toContain("@media (prefers-reduced-motion: reduce)");
+  expect(css).toContain("animation: none");
+});
+
+test("glow primitives + flow dash geometry are present", () => {
+  expect(css).toContain("--glow-core");
+  expect(css).toContain("--glow-halo");
+  expect(css).toContain("--edge-dash");
+  expect(css).toContain("radial-gradient"); // node radial glow + atmosphere
+});

--- a/src/surface/mc/dashboard-v2/index.html
+++ b/src/surface/mc/dashboard-v2/index.html
@@ -31,6 +31,13 @@
         href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" />
   <link rel="stylesheet" href="./styles/tokens.css" />
   <link rel="stylesheet" href="./styles/global.css" />
+  <!--
+    Constellation skin (MC-D1, cortex#1288) — additive token + motion layer.
+    Every rule is scoped under `.mc-skin`, so this has zero effect until a
+    pane opts in by carrying that class (D2–D5). Loaded last so the skin's
+    scoped vars win inside an opted-in subtree without touching `:root`.
+  -->
+  <link rel="stylesheet" href="./styles/constellation.css" />
 </head>
 <body>
   <div id="root"></div>

--- a/src/surface/mc/dashboard-v2/index.html
+++ b/src/surface/mc/dashboard-v2/index.html
@@ -33,9 +33,10 @@
   <link rel="stylesheet" href="./styles/global.css" />
   <!--
     Constellation skin (MC-D1, cortex#1288) — additive token + motion layer.
-    Every rule is scoped under `.mc-skin`, so this has zero effect until a
-    pane opts in by carrying that class (D2–D5). Loaded last so the skin's
-    scoped vars win inside an opted-in subtree without touching `:root`.
+    Every selector rule is scoped under `.mc-skin`, so this has zero effect
+    until a pane opts in by carrying that class (D2–D5). Inside an opted-in
+    subtree the skin's vars win by proximity (nearest-defining-ancestor), not
+    load order; loaded last simply to keep it after the base token sheets.
   -->
   <link rel="stylesheet" href="./styles/constellation.css" />
 </head>

--- a/src/surface/mc/dashboard-v2/styles/constellation.css
+++ b/src/surface/mc/dashboard-v2/styles/constellation.css
@@ -1,0 +1,175 @@
+/*
+ * Constellation skin — design-system token + motion layer (MC-D1, cortex#1288).
+ *
+ * Foundational, ADDITIVE slice of the MC-UX constellation-skin epic
+ * (cortex#1287, under #1274). This file defines ONLY the vocabulary the
+ * skin's view slices (D2–D5) consume: the OKLCH palette, typography vars,
+ * glow primitives, and keyframes. It styles no existing component and
+ * removes nothing — the current dashboard keeps rendering unchanged.
+ *
+ * ── Scope decision: `.mc-skin` wrapper, NOT `:root` ──────────────────────
+ * The approved mockup reuses several token NAMES that the live dashboard
+ * already binds on `:root` via `tokens.css` (--bg, --panel, --fg, --dim/--faint,
+ * --d/--a/--h, --ok/--warn/--bad). Re-declaring those on `:root` here would
+ * silently override the running dashboard's palette — a flag-day restyle,
+ * which this slice explicitly must NOT do.
+ *
+ * Instead every token and primitive is scoped under a `.mc-skin` wrapper
+ * class. The constellation tokens therefore exist only inside whatever
+ * subtree opts in by carrying `class="mc-skin"`. D2–D5 adopt the skin
+ * incrementally — pane by pane — by wrapping their root element in
+ * `.mc-skin`, with zero blast radius on the panes that haven't migrated.
+ * When the whole dashboard has moved over, the wrapper can be hoisted to a
+ * top-level container (or, as a deliberate later step, promoted to `:root`).
+ *
+ * Fonts (JetBrains Mono + Inter) are already loaded once by the shell at
+ * `index.html` (Google Fonts <link>, the repo's established pattern), so this
+ * file declares the family vars only — it adds no new font request.
+ *
+ * Token-presence is guarded by
+ * `__tests__/constellation-tokens.test.ts` (fails if a required token,
+ * keyframe, the `.mc-skin` scope, or the reduced-motion guard is dropped).
+ */
+
+/* ── Palette + typography (scoped to the opt-in subtree) ─────────────────── */
+.mc-skin {
+  /* surfaces */
+  --bg: oklch(0.13 0.012 250);
+  --panel: oklch(0.175 0.012 252);
+  --panel2: oklch(0.215 0.013 252);
+  --line: oklch(0.33 0.013 252);
+  --lsoft: oklch(0.255 0.012 252);
+
+  /* text */
+  --fg: oklch(0.94 0.006 250);
+  --dim: oklch(0.66 0.012 250);
+  --faint: oklch(0.50 0.012 250);
+
+  /* network accents — meridian / tide */
+  --mer: oklch(0.76 0.13 224);
+  --tide: oklch(0.72 0.13 288);
+
+  /* status */
+  --ok: oklch(0.80 0.13 162);
+  --warn: oklch(0.82 0.13 78);
+  --bad: oklch(0.66 0.20 22);
+
+  /* attention coding — Deterministic / Agentic / Human */
+  --d: oklch(0.80 0.14 158);
+  --a: oklch(0.82 0.13 80);
+  --h: oklch(0.76 0.15 8);
+
+  /* typography */
+  --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+
+  /* ── derived glow primitives (compose these in D2–D5) ───────────────── */
+  /* node radial-glow fill: a soft core bloom keyed off any accent var.
+     Usage: background: var(--glow-core); with --glow-tint set per node. */
+  --glow-tint: var(--mer);
+  --glow-core: radial-gradient(
+    circle at 50% 50%,
+    color-mix(in oklch, var(--glow-tint) 85%, transparent) 0%,
+    color-mix(in oklch, var(--glow-tint) 35%, transparent) 45%,
+    transparent 72%
+  );
+  /* node halo ring shadow — breathes via .halo */
+  --glow-halo: 0 0 0 1px color-mix(in oklch, var(--glow-tint) 55%, transparent),
+               0 0 14px 2px color-mix(in oklch, var(--glow-tint) 30%, transparent);
+  /* edge dash geometry — the live bus-traffic flow primitive */
+  --edge-dash: 6 10;        /* stroke-dasharray */
+  --edge-dash-fed: 4 8;     /* federated edges run a tighter dash */
+
+  /* atmosphere — background ellipse behind the constellation */
+  background:
+    radial-gradient(
+      ellipse 120% 90% at 50% 0%,
+      color-mix(in oklch, var(--mer) 8%, transparent) 0%,
+      transparent 60%
+    ),
+    var(--bg);
+  color: var(--fg);
+  font-family: var(--sans);
+}
+
+/* ── Keyframes (the motion contract D2–D5 reference by name) ─────────────── */
+/* Node liveness: a steady core pulse, a slower variant, and a halo breathe. */
+@keyframes corePulse {
+  0%, 100% { opacity: 1;    transform: scale(1); }
+  50%      { opacity: 0.72; transform: scale(0.88); }
+}
+@keyframes coreSlow {
+  0%, 100% { opacity: 0.95; transform: scale(1); }
+  50%      { opacity: 0.60; transform: scale(0.92); }
+}
+@keyframes haloBreathe {
+  0%, 100% { opacity: 0.85; transform: scale(1); }
+  50%      { opacity: 0.35; transform: scale(1.18); }
+}
+
+/* Live bus-traffic flow along edges — marching-ants on stroke-dashoffset. */
+@keyframes dashFlow    { to { stroke-dashoffset: -160; } }
+@keyframes dashFlowFed { to { stroke-dashoffset: -220; } }
+
+/* Attention blink (needs-a-human markers). */
+@keyframes attnBlink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.3; }
+}
+
+/* Status ticker scroll. */
+@keyframes ticker { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* Metric bar sweep-in. */
+@keyframes barSweep { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+
+/* Generic spinner. */
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Reusable glow primitive classes (opt-in, scoped) ────────────────────── */
+/* Node core: a radial bloom that pulses. Set --glow-tint to recolour. */
+.mc-skin .core {
+  background: var(--glow-core);
+  border-radius: 50%;
+  animation: corePulse 2.4s ease-in-out infinite;
+}
+.mc-skin .core--slow { animation-name: coreSlow; animation-duration: 3.6s; }
+
+/* Node halo: a breathing ring around a node. */
+.mc-skin .halo {
+  box-shadow: var(--glow-halo);
+  border-radius: 50%;
+  animation: haloBreathe 3s ease-in-out infinite;
+}
+
+/* Live edge: dashed path animating its offset to show flow direction. */
+.mc-skin .edge-live {
+  stroke-dasharray: var(--edge-dash);
+  animation: dashFlow 2.2s linear infinite;
+}
+.mc-skin .edge-live--fed {
+  stroke-dasharray: var(--edge-dash-fed);
+  animation: dashFlowFed 1.8s linear infinite;
+}
+
+/* Attention marker. */
+.mc-skin .attn { animation: attnBlink 1.1s ease-in-out infinite; }
+
+/* Spinner primitive. */
+.mc-skin .spin { animation: spin 0.9s linear infinite; }
+
+/* ── Reduced-motion guard ────────────────────────────────────────────────
+ * Honour the OS "reduce motion" preference: hold every constellation
+ * animation on its resting frame. Tokens, colours, and the static glow
+ * shapes remain — only the motion stops. */
+@media (prefers-reduced-motion: reduce) {
+  .mc-skin .core,
+  .mc-skin .core--slow,
+  .mc-skin .halo,
+  .mc-skin .edge-live,
+  .mc-skin .edge-live--fed,
+  .mc-skin .attn,
+  .mc-skin .spin {
+    animation: none !important;
+  }
+}

--- a/src/surface/mc/dashboard-v2/styles/constellation.css
+++ b/src/surface/mc/dashboard-v2/styles/constellation.css
@@ -14,13 +14,27 @@
  * silently override the running dashboard's palette — a flag-day restyle,
  * which this slice explicitly must NOT do.
  *
- * Instead every token and primitive is scoped under a `.mc-skin` wrapper
- * class. The constellation tokens therefore exist only inside whatever
- * subtree opts in by carrying `class="mc-skin"`. D2–D5 adopt the skin
- * incrementally — pane by pane — by wrapping their root element in
- * `.mc-skin`, with zero blast radius on the panes that haven't migrated.
- * When the whole dashboard has moved over, the wrapper can be hoisted to a
- * top-level container (or, as a deliberate later step, promoted to `:root`).
+ * Instead every SELECTOR rule is scoped under a `.mc-skin` wrapper class.
+ * The constellation tokens therefore exist only inside whatever subtree opts
+ * in by carrying `class="mc-skin"`. D2–D5 adopt the skin incrementally — pane
+ * by pane — by wrapping their root element in `.mc-skin`, with zero blast
+ * radius on the panes that haven't migrated. When the whole dashboard has
+ * moved over, the wrapper can be hoisted to a top-level container (or, as a
+ * deliberate later step, promoted to `:root`).
+ *
+ * Caveat — `@keyframes` identifiers are NOT scopable: CSS keeps animation
+ * names in one document-global namespace, so the names below are global by
+ * construction (the `.mc-skin` wrapper confines the selectors that *apply*
+ * them, not the names themselves). There is no collision today (existing
+ * keyframes are toast-in / add-task-spin / focus-heartbeat / xyflow dashdraw),
+ * and the contract test asserts each name is defined exactly once here so a
+ * future duplicate turns into a red test rather than a silent override.
+ *
+ * Note for D2–D5 — the reduced-motion guard at the foot of this file lists
+ * the animated classes by name. `ticker` and `barSweep` keyframes ship here
+ * with no consuming class yet; when you add classes that use them, ALSO add
+ * those classes to the `prefers-reduced-motion` block or you reintroduce an
+ * accessibility regression.
  *
  * Fonts (JetBrains Mono + Inter) are already loaded once by the shell at
  * `index.html` (Google Fonts <link>, the repo's established pattern), so this


### PR DESCRIPTION
## MC-D1 — design-system token + motion layer

Foundational, **additive** slice of the MC-UX constellation-skin epic (#1287, under #1274). Adds the design-token vocabulary + motion contract that the skin's view slices **D2–D5** consume. Per [`docs/design-mc-constellation-ui.md`](https://github.com/the-metafactory/cortex/blob/main/docs/design-mc-constellation-ui.md) (spec lands via #1286; tokens were supplied inline).

### What's in it
- **New module** `src/surface/mc/dashboard-v2/styles/constellation.css` — OKLCH palette, typography vars, glow primitives, and keyframes (`corePulse`/`coreSlow`/`haloBreathe`/`dashFlow`/`dashFlowFed`/`attnBlink`/`ticker`/`barSweep`/`spin`).
- Shell (`index.html`) links it **last**; fonts (JetBrains Mono + Inter) already loaded by the shell — no new font request.
- Token-presence test `__tests__/constellation-tokens.test.ts` pins the token/keyframe/scope/reduced-motion contract.

### Token scope decision — `.mc-skin` wrapper, NOT `:root`
The mockup reuses token **names** the live dashboard already binds on `:root` via `tokens.css` (`--bg`, `--panel`, `--fg`, `--d/--a/--h`, `--ok/--warn/--bad`). Declaring those on `:root` would silently restyle the running dashboard — a flag-day restyle this slice must not do. Scoping under `.mc-skin` lets **D2–D5 adopt the skin pane-by-pane** with zero blast radius on un-migrated panes. Documented in the file header.

### Additive guarantees
- Existing `global.css` / components untouched (A3's confidentiality chip style preserved).
- Every rule is `.mc-skin`-scoped → existing dashboard render **unchanged** (no `.mc-skin` element exists yet).
- `@media (prefers-reduced-motion: reduce)` guard holds all animations on their resting frame.

### Gates (all green locally)
- `bun test src/surface/mc/dashboard-v2` — **840 pass / 0 fail** (incl. 5 new token-presence assertions)
- `bunx tsc --noEmit` — clean
- `bun run lint:errors` — clean
- `bash scripts/check-carveouts.sh` — PASS
- `bun run build:dashboard` — green; `network-canvas-*` split chunk emitted; constellation tokens confirmed in bundle

Closes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)