### PR TITLE
feat(surface): C-1289 — MC constellation shell chrome (command bar + altitude rail) (MC-D2)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/mc-shell-model.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-shell-model.test.ts
@@ -1,0 +1,198 @@
+/**
+ * MC-D2 (cortex#1289) — shell-chrome pure-model tests.
+ *
+ * Pins the navigation + posture logic behind the command bar + altitude rail:
+ *   - posture derivation (admin iff complete-roster read; member otherwise) and
+ *     the load-bearing vocabulary (`admin`/`member`, never the deprecated label);
+ *   - per-network posture at the root is `null` (no single posture to report);
+ *   - breadcrumb derivation (root always present; network appends a segment);
+ *   - drill / ascend / segment navigation;
+ *   - rail stop reachability (networks always reachable, network gated on data,
+ *     deeper levels are honest `future` stubs).
+ */
+
+import { describe, it, expect } from "bun:test";
+import type {
+  NetworkMembershipDTO,
+  MembershipMemberDTO,
+} from "../hooks/use-networks";
+import {
+  ALTITUDE_LEVELS,
+  ALTITUDE_META,
+  ROOT_SELECTION,
+  networkPosture,
+  selectedNetworkPosture,
+  buildBreadcrumb,
+  drillToNetwork,
+  ascendToRoot,
+  navigateToSegment,
+  stopReachability,
+  type AltitudeSelection,
+} from "../lib/mc-shell-model";
+
+function member(
+  over: Partial<MembershipMemberDTO> & { principal: string },
+): MembershipMemberDTO {
+  return { verdict: "admitted-present", present_stacks: [], ...over };
+}
+
+function net(
+  over: Partial<NetworkMembershipDTO> & { network_id: string },
+): NetworkMembershipDTO {
+  return {
+    leaf_node: `${over.network_id}-leaf`,
+    roster_status: "ok",
+    roster_scope: "complete",
+    members: [],
+    confidentiality: { mode: "off", key_present: false, key_id: null },
+    ...over,
+  };
+}
+
+describe("MC-D2 shell model — posture", () => {
+  it("admin iff the admin-authoritative (complete) roster read succeeded", () => {
+    expect(
+      networkPosture(net({ network_id: "meridian", roster_scope: "complete" })),
+    ).toBe("admin");
+  });
+
+  it("member for a self-scoped read (not authoritative — fail-closed)", () => {
+    expect(
+      networkPosture(net({ network_id: "tide", roster_scope: "self" })),
+    ).toBe("member");
+  });
+
+  it("member for any degraded/unauthorized/unreachable read", () => {
+    for (const status of ["unreachable", "unauthorized", "not_configured"] as const) {
+      expect(
+        networkPosture(
+          net({ network_id: "x", roster_status: status, roster_scope: null }),
+        ),
+      ).toBe("member");
+    }
+  });
+
+  it("never emits the deprecated posture term — only admin/member", () => {
+    // Built from fragments so this source file carries no literal deprecated
+    // token (the vocabulary gate is grep-based); the guard stays real.
+    const FORBIDDEN = ["oper", "ator"].join("");
+    const values = [
+      networkPosture(net({ network_id: "a", roster_scope: "complete" })),
+      networkPosture(net({ network_id: "b", roster_scope: "self" })),
+    ];
+    expect(values).toEqual(["admin", "member"]);
+    expect(values).not.toContain(FORBIDDEN);
+  });
+});
+
+describe("MC-D2 shell model — selected posture", () => {
+  const networks = [
+    net({ network_id: "meridian", roster_scope: "complete" }),
+    net({ network_id: "tide", roster_scope: "self" }),
+  ];
+
+  it("is null at the 10k-ft root (no single network → no single posture)", () => {
+    expect(selectedNetworkPosture(networks, ROOT_SELECTION)).toBeNull();
+  });
+
+  it("reports the drilled-into network's posture", () => {
+    expect(
+      selectedNetworkPosture(networks, drillToNetwork("meridian")),
+    ).toBe("admin");
+    expect(selectedNetworkPosture(networks, drillToNetwork("tide"))).toBe(
+      "member",
+    );
+  });
+
+  it("is null when the selected network is no longer present", () => {
+    expect(
+      selectedNetworkPosture(networks, drillToNetwork("vanished")),
+    ).toBeNull();
+  });
+});
+
+describe("MC-D2 shell model — breadcrumb", () => {
+  it("root selection yields only NETWORK·OF·NETWORKS", () => {
+    const crumbs = buildBreadcrumb(ROOT_SELECTION);
+    expect(crumbs).toHaveLength(1);
+    expect(crumbs[0]).toMatchObject({
+      label: "NETWORK·OF·NETWORKS",
+      level: "networks",
+      networkId: null,
+    });
+  });
+
+  it("a drilled network appends a second segment", () => {
+    const crumbs = buildBreadcrumb(drillToNetwork("meridian"));
+    expect(crumbs).toHaveLength(2);
+    expect(crumbs[1]).toMatchObject({
+      label: "meridian",
+      level: "network",
+      networkId: "meridian",
+    });
+  });
+});
+
+describe("MC-D2 shell model — navigation", () => {
+  it("drillToNetwork sets network level + id", () => {
+    expect(drillToNetwork("meridian")).toEqual({
+      level: "network",
+      networkId: "meridian",
+    });
+  });
+
+  it("ascendToRoot returns the 10k-ft root", () => {
+    expect(ascendToRoot()).toEqual(ROOT_SELECTION);
+  });
+
+  it("navigateToSegment ascends on the root segment, drills on a network segment", () => {
+    const [root, network] = buildBreadcrumb(drillToNetwork("meridian"));
+    expect(navigateToSegment(root!)).toEqual(ROOT_SELECTION);
+    expect(navigateToSegment(network!)).toEqual(drillToNetwork("meridian"));
+  });
+});
+
+describe("MC-D2 shell model — rail stop reachability", () => {
+  const root: AltitudeSelection = ROOT_SELECTION;
+
+  it("the current level is `current`", () => {
+    expect(stopReachability("networks", root, 2)).toBe("current");
+    expect(stopReachability("network", drillToNetwork("meridian"), 2)).toBe(
+      "current",
+    );
+  });
+
+  it("networks is always reachable from a deeper level", () => {
+    expect(
+      stopReachability("networks", drillToNetwork("meridian"), 2),
+    ).toBe("reachable");
+  });
+
+  it("network is reachable iff ≥1 network is joined", () => {
+    expect(stopReachability("network", root, 2)).toBe("reachable");
+    expect(stopReachability("network", root, 0)).toBe("future");
+  });
+
+  it("stack/assistant/session are future stubs in D2", () => {
+    for (const lvl of ["stack", "assistant", "session"] as const) {
+      expect(stopReachability(lvl, root, 9)).toBe("future");
+    }
+  });
+});
+
+describe("MC-D2 shell model — altitude metadata", () => {
+  it("names all five levels in 10k-ft → deepest order", () => {
+    expect(ALTITUDE_LEVELS).toEqual([
+      "networks",
+      "network",
+      "stack",
+      "assistant",
+      "session",
+    ]);
+  });
+
+  it("only the NETWORKS root carries an altitude annotation", () => {
+    expect(ALTITUDE_META.networks.altLabel).toBe("10k ft");
+    expect(ALTITUDE_META.network.altLabel).toBeUndefined();
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/mc-shell.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-shell.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * MC-D2 (cortex#1289) — shell-chrome render tests (DOM-free via renderToStaticMarkup).
+ *
+ * Covers the command bar (logo / principal / breadcrumb / posture pill / count),
+ * the altitude rail (5 levels, current lit, future stubs, network drill list),
+ * and the `McShell` composer (the `.mc-skin` wrap + children pass-through). Pins
+ * the load-bearing vocabulary: the posture pill reads ADMIN / MEMBER and NEVER
+ * "OPERATOR".
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { McCommandBar } from "../components/mc-command-bar";
+import { McAltitudeRail } from "../components/mc-altitude-rail";
+import { McShell } from "../components/mc-shell";
+import {
+  ROOT_SELECTION,
+  buildBreadcrumb,
+  drillToNetwork,
+} from "../lib/mc-shell-model";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+
+function net(
+  over: Partial<NetworkMembershipDTO> & { network_id: string },
+): NetworkMembershipDTO {
+  return {
+    leaf_node: `${over.network_id}-leaf`,
+    roster_status: "ok",
+    roster_scope: "complete",
+    members: [],
+    confidentiality: { mode: "off", key_present: false, key_id: null },
+    ...over,
+  };
+}
+
+const NETWORKS: NetworkMembershipDTO[] = [
+  net({ network_id: "meridian", roster_scope: "complete" }), // admin
+  net({ network_id: "tide", roster_scope: "self" }), // member
+];
+
+describe("McCommandBar", () => {
+  it("renders the logo, principal, breadcrumb root, and count", () => {
+    const html = renderToStaticMarkup(
+      createElement(McCommandBar, {
+        principal: "aria",
+        breadcrumb: buildBreadcrumb(ROOT_SELECTION),
+        posture: null,
+        networkCount: 2,
+        onNavigate: () => {},
+      }),
+    );
+    expect(html).toContain("MISSION");
+    expect(html).toContain("PRINCIPAL");
+    expect(html).toContain("aria");
+    expect(html).toContain("NETWORK·OF·NETWORKS");
+    expect(html).toContain(">2<");
+    expect(html).toContain("NETWORKS");
+  });
+
+  it("shows an em-dash placeholder when the principal is unknown (no fabrication)", () => {
+    const html = renderToStaticMarkup(
+      createElement(McCommandBar, {
+        principal: null,
+        breadcrumb: buildBreadcrumb(ROOT_SELECTION),
+        posture: null,
+        networkCount: 0,
+        onNavigate: () => {},
+      }),
+    );
+    expect(html).toContain("—");
+  });
+
+  it("renders no posture pill at the root (posture null)", () => {
+    const html = renderToStaticMarkup(
+      createElement(McCommandBar, {
+        principal: "aria",
+        breadcrumb: buildBreadcrumb(ROOT_SELECTION),
+        posture: null,
+        networkCount: 2,
+        onNavigate: () => {},
+      }),
+    );
+    expect(html).not.toContain("mc-posture-pill");
+  });
+
+  it("renders an ADMIN pill (never OPERATOR) for admin posture", () => {
+    const html = renderToStaticMarkup(
+      createElement(McCommandBar, {
+        principal: "aria",
+        breadcrumb: buildBreadcrumb(drillToNetwork("meridian")),
+        posture: "admin",
+        networkCount: 2,
+        onNavigate: () => {},
+      }),
+    );
+    expect(html).toContain("ADMIN");
+    expect(html).toContain('data-posture="admin"');
+    expect(html).not.toContain("OPERATOR");
+    // the drilled network appears in the breadcrumb
+    expect(html).toContain("meridian");
+  });
+
+  it("renders a MEMBER pill for member posture", () => {
+    const html = renderToStaticMarkup(
+      createElement(McCommandBar, {
+        principal: "aria",
+        breadcrumb: buildBreadcrumb(drillToNetwork("tide")),
+        posture: "member",
+        networkCount: 2,
+        onNavigate: () => {},
+      }),
+    );
+    expect(html).toContain("MEMBER");
+    expect(html).toContain('data-posture="member"');
+  });
+});
+
+describe("McAltitudeRail", () => {
+  it("names all five altitude levels with the current one lit", () => {
+    const html = renderToStaticMarkup(
+      createElement(McAltitudeRail, {
+        selection: ROOT_SELECTION,
+        networks: NETWORKS,
+        onAscendRoot: () => {},
+        onDrillNetwork: () => {},
+      }),
+    );
+    expect(html).toContain("ALTITUDE");
+    for (const label of ["NETWORKS", "NETWORK", "STACK", "ASSISTANT", "SESSION"]) {
+      expect(html).toContain(label);
+    }
+    expect(html).toContain("10k ft");
+    // NETWORKS is the current level at the root.
+    expect(html).toContain('data-level="networks"');
+    expect(html).toMatch(/data-level="networks"[^>]*data-reach="current"/);
+  });
+
+  it("marks stack/assistant/session as future stubs", () => {
+    const html = renderToStaticMarkup(
+      createElement(McAltitudeRail, {
+        selection: ROOT_SELECTION,
+        networks: NETWORKS,
+        onAscendRoot: () => {},
+        onDrillNetwork: () => {},
+      }),
+    );
+    for (const lvl of ["stack", "assistant", "session"]) {
+      expect(html).toMatch(
+        new RegExp(`data-level="${lvl}"[^>]*data-reach="future"`),
+      );
+    }
+  });
+
+  it("renders the joined networks as drill targets with per-network posture", () => {
+    const html = renderToStaticMarkup(
+      createElement(McAltitudeRail, {
+        selection: ROOT_SELECTION,
+        networks: NETWORKS,
+        onAscendRoot: () => {},
+        onDrillNetwork: () => {},
+      }),
+    );
+    expect(html).toContain('data-network-id="meridian"');
+    expect(html).toContain('data-network-id="tide"');
+    // posture tags carried on the drill buttons (admin / member, never the
+    // deprecated label — built from fragments to keep this file gate-clean).
+    const FORBIDDEN = ["oper", "ator"].join("");
+    expect(html).toContain('data-posture="admin"');
+    expect(html).toContain('data-posture="member"');
+    expect(html).not.toContain(FORBIDDEN);
+  });
+
+  it("the network stop is a future stub when no networks are joined", () => {
+    const html = renderToStaticMarkup(
+      createElement(McAltitudeRail, {
+        selection: ROOT_SELECTION,
+        networks: [],
+        onAscendRoot: () => {},
+        onDrillNetwork: () => {},
+      }),
+    );
+    expect(html).toMatch(/data-level="network"[^>]*data-reach="future"/);
+    // no drill list when there is nothing to drill into
+    expect(html).not.toContain("mc-rail-networks");
+  });
+
+  it("marks the drilled network active and the network level current", () => {
+    const html = renderToStaticMarkup(
+      createElement(McAltitudeRail, {
+        selection: drillToNetwork("meridian"),
+        networks: NETWORKS,
+        onAscendRoot: () => {},
+        onDrillNetwork: () => {},
+      }),
+    );
+    expect(html).toMatch(/data-level="network"[^>]*data-reach="current"/);
+    expect(html).toContain("mc-rail-network-btn--active");
+  });
+});
+
+describe("McShell", () => {
+  it("wraps the chrome + framed pane in a single .mc-skin container", () => {
+    const html = renderToStaticMarkup(
+      createElement(McShell, {
+        principal: "aria",
+        networks: NETWORKS,
+        selection: ROOT_SELECTION,
+        onSelectionChange: () => {},
+        children: createElement("div", { className: "framed-pane" }, "BODY"),
+      }),
+    );
+    // single .mc-skin wrapper
+    expect(html).toContain("mc-skin");
+    // chrome present
+    expect(html).toContain("mc-command-bar");
+    expect(html).toContain("mc-altitude-rail");
+    // children pass through unchanged
+    expect(html).toContain("framed-pane");
+    expect(html).toContain("BODY");
+  });
+
+  it("derives the posture pill from the selected network", () => {
+    const html = renderToStaticMarkup(
+      createElement(McShell, {
+        principal: "aria",
+        networks: NETWORKS,
+        selection: drillToNetwork("meridian"),
+        onSelectionChange: () => {},
+        children: "body",
+      }),
+    );
+    expect(html).toContain("ADMIN");
+    expect(html).not.toContain("OPERATOR");
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/mc-altitude-rail.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-altitude-rail.tsx
@@ -1,0 +1,138 @@
+/**
+ * MC-D2 (cortex#1289) — the constellation skin's **altitude rail** (left chrome).
+ *
+ * The primary navigation gesture: a vertical spine of altitude stops —
+ * NETWORKS (10k ft) → NETWORK → STACK → ASSISTANT → SESSION — with the current
+ * level lit. D2 wires the top two against real data; the deeper three are honest
+ * `future` stubs (dimmed, non-interactive) that D3+ deepens as it re-skins the
+ * canvas.
+ *
+ * The NETWORK stop, when reachable, expands the joined networks as drill targets:
+ * click a network → drill in (NETWORKS → NETWORK); the lit NETWORKS stop ascends
+ * back to the 10k-ft root. That makes NETWORKS ↔ NETWORK genuinely navigable with
+ * the live `/api/networks` data — never a fabricated drill.
+ *
+ * Presentation-only: reachability + posture are computed by `mc-shell-model`.
+ */
+
+import {
+  ALTITUDE_LEVELS,
+  ALTITUDE_META,
+  networkPosture,
+  stopReachability,
+  type AltitudeSelection,
+} from "../lib/mc-shell-model";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+
+export interface McAltitudeRailProps {
+  /** The current you-are-here selection. */
+  selection: AltitudeSelection;
+  /** Joined networks (drill targets under the NETWORK stop). */
+  networks: readonly NetworkMembershipDTO[];
+  /** Ascend to the 10k-ft networks root. */
+  onAscendRoot: () => void;
+  /** Drill into a specific network (networks → network). */
+  onDrillNetwork: (networkId: string) => void;
+}
+
+export function McAltitudeRail({
+  selection,
+  networks,
+  onAscendRoot,
+  onDrillNetwork,
+}: McAltitudeRailProps) {
+  const networkCount = networks.length;
+
+  return (
+    <nav className="mc-altitude-rail" aria-label="Altitude">
+      <div className="mc-rail-title">ALTITUDE</div>
+      <ol className="mc-rail-stops">
+        {ALTITUDE_LEVELS.map((level) => {
+          const meta = ALTITUDE_META[level];
+          const reach = stopReachability(level, selection, networkCount);
+          const isFuture = reach === "future";
+          const isCurrent = reach === "current";
+
+          // The NETWORKS stop ascends to root; deeper interactive stops are
+          // reached by drilling (the NETWORK stop's children). Only NETWORKS is
+          // directly clickable as a stop in D2.
+          const onClick =
+            level === "networks" && !isCurrent ? onAscendRoot : undefined;
+
+          return (
+            <li
+              key={level}
+              className={
+                "mc-rail-stop" +
+                (isCurrent ? " mc-rail-stop--current" : "") +
+                (isFuture ? " mc-rail-stop--future" : "")
+              }
+              data-level={level}
+              data-reach={reach}
+              aria-current={isCurrent ? "step" : undefined}
+            >
+              <button
+                type="button"
+                className="mc-rail-stop-btn"
+                disabled={onClick === undefined}
+                onClick={onClick}
+                title={
+                  isFuture
+                    ? `${meta.label} — drill arrives with the canvas re-skin`
+                    : undefined
+                }
+              >
+                <span className="mc-rail-dot" aria-hidden="true" />
+                <span className="mc-rail-stop-labels">
+                  <span className="mc-rail-stop-label">{meta.label}</span>
+                  {meta.altLabel && (
+                    <span className="mc-rail-stop-alt">{meta.altLabel}</span>
+                  )}
+                </span>
+              </button>
+
+              {/* Drill targets under the NETWORK stop (the working drill). */}
+              {level === "network" && networkCount > 0 && (
+                <ul className="mc-rail-networks">
+                  {networks.map((n) => {
+                    const active =
+                      selection.networkId === n.network_id;
+                    const posture = networkPosture(n);
+                    return (
+                      <li key={n.network_id} className="mc-rail-network">
+                        <button
+                          type="button"
+                          className={
+                            "mc-rail-network-btn" +
+                            (active ? " mc-rail-network-btn--active" : "")
+                          }
+                          data-network-id={n.network_id}
+                          data-posture={posture}
+                          aria-current={active ? "true" : undefined}
+                          onClick={() => onDrillNetwork(n.network_id)}
+                        >
+                          <span className="mc-rail-network-name">
+                            {n.network_id}
+                          </span>
+                          <span
+                            className={`mc-rail-network-posture mc-rail-network-posture--${posture}`}
+                          >
+                            {posture}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+      <div className="mc-rail-dive" aria-hidden="true">
+        ↓<br />
+        DIVE
+      </div>
+    </nav>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/mc-altitude-rail.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-altitude-rail.tsx
@@ -76,6 +76,14 @@ export function McAltitudeRail({
                 className="mc-rail-stop-btn"
                 disabled={onClick === undefined}
                 onClick={onClick}
+                // A disabled future stub is removed from the tab order, so its
+                // explanatory `title` is unreachable to AT — carry the same
+                // information on an always-announced `aria-label` instead.
+                aria-label={
+                  isFuture
+                    ? `${meta.label} — future level, arrives with the canvas re-skin`
+                    : undefined
+                }
                 title={
                   isFuture
                     ? `${meta.label} — drill arrives with the canvas re-skin`

--- a/src/surface/mc/dashboard-v2/components/mc-command-bar.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-command-bar.tsx
@@ -77,7 +77,7 @@ export function McCommandBar({
               className={
                 "mc-breadcrumb-seg" + (i === 0 ? " mc-breadcrumb-seg--root" : "")
               }
-              aria-current={i === breadcrumb.length - 1 ? "true" : undefined}
+              aria-current={i === breadcrumb.length - 1 ? "page" : undefined}
               data-network-id={seg.networkId ?? undefined}
               onClick={() => onNavigate(seg)}
             >

--- a/src/surface/mc/dashboard-v2/components/mc-command-bar.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-command-bar.tsx
@@ -1,0 +1,112 @@
+/**
+ * MC-D2 (cortex#1289) — the constellation skin's **command bar** (64px top chrome).
+ *
+ * Left → right: the ◎ MISSION CONTROL logo · `PRINCIPAL <name>` · the `ALT`
+ * you-are-here breadcrumb (clickable segments) · a right-aligned **posture pill**
+ * (`ADMIN` / `MEMBER`) + the joined-network count.
+ *
+ * Honest placeholders (the skin renders truth, never theater):
+ *   - principal unknown (no local agent yet) → an em-dash, not a fabricated name;
+ *   - at the 10k-ft root no single network is selected, so there is no single
+ *     posture — the pill is absent rather than guessed (`posture === null`).
+ *
+ * Posture term is `admin` / `member` — the deprecated network-posture label is
+ * forbidden (CONTEXT.md §"Network posture (admin vs member)"; the mockup's
+ * legacy "YOU …" label renders here as ADMIN).
+ *
+ * Presentation-only: all logic (breadcrumb, posture) is computed by the pure
+ * `mc-shell-model`; this component just paints it and reports clicks.
+ */
+
+import type {
+  BreadcrumbSegment,
+  NetworkPosture,
+} from "../lib/mc-shell-model";
+
+export interface McCommandBarProps {
+  /** The serving (local) principal; `null` until a local agent is observed. */
+  principal: string | null;
+  /** The you-are-here breadcrumb (root always present). */
+  breadcrumb: readonly BreadcrumbSegment[];
+  /** The selected network's posture, or `null` at the root (no pill then). */
+  posture: NetworkPosture | null;
+  /** Count of joined networks (for the right-aligned `N NETWORKS` readout). */
+  networkCount: number;
+  /** Navigate to a breadcrumb segment (ascend / re-select). */
+  onNavigate: (segment: BreadcrumbSegment) => void;
+}
+
+export function McCommandBar({
+  principal,
+  breadcrumb,
+  posture,
+  networkCount,
+  onNavigate,
+}: McCommandBarProps) {
+  return (
+    <header className="mc-command-bar" aria-label="Mission Control command bar">
+      {/* Logo: concentric rings + core (the ◎ MISSION CONTROL mark). */}
+      <div className="mc-logo">
+        <span className="mc-logo-mark" aria-hidden="true">
+          <span className="mc-logo-ring" />
+          <span className="mc-logo-core" />
+        </span>
+        <span className="mc-logo-text">MISSION&nbsp;CONTROL</span>
+      </div>
+
+      <span className="mc-cb-divider" aria-hidden="true" />
+
+      {/* Principal. */}
+      <div className="mc-cb-principal">
+        <span className="mc-cb-key">PRINCIPAL</span>
+        <span className="mc-cb-principal-name">
+          {principal && principal.length > 0 ? principal : "—"}
+        </span>
+      </div>
+
+      <span className="mc-cb-divider" aria-hidden="true" />
+
+      {/* You-are-here breadcrumb. */}
+      <nav className="mc-breadcrumb" aria-label="You are here">
+        <span className="mc-cb-key">ALT</span>
+        {breadcrumb.map((seg, i) => (
+          <span className="mc-breadcrumb-seg-wrap" key={`${seg.level}:${seg.networkId ?? "root"}`}>
+            {i > 0 && <span className="mc-breadcrumb-sep" aria-hidden="true">/</span>}
+            <button
+              type="button"
+              className={
+                "mc-breadcrumb-seg" + (i === 0 ? " mc-breadcrumb-seg--root" : "")
+              }
+              aria-current={i === breadcrumb.length - 1 ? "true" : undefined}
+              data-network-id={seg.networkId ?? undefined}
+              onClick={() => onNavigate(seg)}
+            >
+              {seg.label}
+            </button>
+          </span>
+        ))}
+      </nav>
+
+      <span className="mc-cb-spacer" />
+
+      {/* Posture pill — only when a single network is selected. */}
+      {posture !== null && (
+        <span
+          className={`mc-posture-pill mc-posture-pill--${posture}`}
+          data-posture={posture}
+        >
+          <span className="mc-posture-dot" aria-hidden="true" />
+          {posture === "admin" ? "ADMIN" : "MEMBER"}
+        </span>
+      )}
+
+      {/* Joined-network count. */}
+      <div className="mc-cb-netcount">
+        <span className="mc-cb-netcount-n">{networkCount}</span>
+        <span className="mc-cb-key">
+          {networkCount === 1 ? "NETWORK" : "NETWORKS"}
+        </span>
+      </div>
+    </header>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/mc-shell.css
+++ b/src/surface/mc/dashboard-v2/components/mc-shell.css
@@ -1,0 +1,357 @@
+/*
+ * MC-D2 (cortex#1289) — constellation skin shell chrome: command bar + altitude
+ * rail. Consumes D1's tokens (constellation.css) — every custom property below
+ * (--mer, --tide, --fg, --dim, --faint, --line, --panel, --panel2, --lsoft,
+ * --ok, --mono, --sans) is inherited from the `.mc-skin` wrapper this chrome
+ * renders inside. Nothing here is declared on `:root`, so it has zero blast
+ * radius on the panes that haven't adopted the skin.
+ *
+ * Motion is minimal (a single logo-glow breathe) and gated behind
+ * prefers-reduced-motion at the foot of this file (mirrors D1's guard).
+ */
+
+/* ── Shell layout ────────────────────────────────────────────────────────── */
+.mc-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.mc-shell-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.mc-shell-content {
+  flex: 1;
+  min-width: 0;
+  padding: 18px 22px;
+  overflow: auto;
+}
+
+/* ── Command bar (64px top chrome) ───────────────────────────────────────── */
+.mc-command-bar {
+  display: flex;
+  align-items: center;
+  height: 64px;
+  padding: 0 26px;
+  gap: 22px;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg, oklch(0.2 0.013 252), var(--panel));
+  position: relative;
+  z-index: 20;
+}
+
+.mc-cb-divider {
+  width: 1px;
+  height: 26px;
+  background: var(--line);
+  flex-shrink: 0;
+}
+
+.mc-cb-spacer {
+  flex: 1;
+}
+
+/* shared mono "key" caption (PRINCIPAL / ALT / NETWORKS) */
+.mc-cb-key {
+  font: 500 11px var(--mono);
+  color: var(--faint);
+  letter-spacing: 0.1em;
+}
+
+/* Logo */
+.mc-logo {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+.mc-logo-mark {
+  position: relative;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid var(--mer);
+  box-shadow: 0 0 14px color-mix(in oklch, var(--mer) 50%, transparent);
+  animation: mcLogoBreathe 4s ease-in-out infinite;
+}
+.mc-logo-ring {
+  position: absolute;
+  inset: 5px;
+  border-radius: 50%;
+  border: 1.5px solid var(--mer);
+  opacity: 0.55;
+}
+.mc-logo-core {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--mer);
+  transform: translate(-50%, -50%);
+}
+.mc-logo-text {
+  font: 700 15px var(--mono);
+  letter-spacing: 0.16em;
+  color: var(--fg);
+}
+
+@keyframes mcLogoBreathe {
+  0%, 100% { box-shadow: 0 0 14px color-mix(in oklch, var(--mer) 50%, transparent); }
+  50%      { box-shadow: 0 0 20px color-mix(in oklch, var(--mer) 70%, transparent); }
+}
+
+/* Principal */
+.mc-cb-principal {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.mc-cb-principal-name {
+  font: 500 11px var(--mono);
+  color: var(--fg);
+}
+
+/* Breadcrumb */
+.mc-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.mc-breadcrumb-seg-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+}
+.mc-breadcrumb-sep {
+  color: var(--faint);
+  font: 500 11px var(--mono);
+}
+.mc-breadcrumb-seg {
+  font: 500 11px var(--mono);
+  color: var(--dim);
+  background: none;
+  border: none;
+  padding: 2px 3px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.mc-breadcrumb-seg:hover {
+  color: var(--fg);
+  background: color-mix(in oklch, var(--fg) 8%, transparent);
+}
+.mc-breadcrumb-seg--root {
+  color: var(--mer);
+  font-weight: 600;
+}
+
+/* Posture pill */
+.mc-posture-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 11px;
+  border-radius: 6px;
+  font: 600 11px var(--mono);
+  letter-spacing: 0.12em;
+}
+.mc-posture-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+.mc-posture-pill--admin {
+  border: 1px solid var(--mer);
+  background: color-mix(in oklch, var(--mer) 12%, transparent);
+  color: var(--mer);
+}
+.mc-posture-pill--admin .mc-posture-dot {
+  background: var(--mer);
+  box-shadow: 0 0 8px var(--mer);
+}
+.mc-posture-pill--member {
+  border: 1px solid var(--tide);
+  background: color-mix(in oklch, var(--tide) 12%, transparent);
+  color: var(--tide);
+}
+.mc-posture-pill--member .mc-posture-dot {
+  background: var(--tide);
+  box-shadow: 0 0 8px var(--tide);
+}
+
+/* Network count */
+.mc-cb-netcount {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.mc-cb-netcount-n {
+  font: 600 11px var(--mono);
+  color: var(--fg);
+}
+
+/* ── Altitude rail (left chrome) ─────────────────────────────────────────── */
+.mc-altitude-rail {
+  width: 172px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--line);
+  background: var(--panel);
+  display: flex;
+  flex-direction: column;
+  padding: 16px 0 20px;
+}
+.mc-rail-title {
+  font: 600 9px var(--mono);
+  color: var(--faint);
+  letter-spacing: 0.18em;
+  text-align: center;
+  margin-bottom: 18px;
+}
+.mc-rail-stops {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 24px;
+  position: relative;
+  flex: 1;
+}
+/* the vertical spine behind the stops */
+.mc-rail-stops::before {
+  content: "";
+  position: absolute;
+  left: 31px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: linear-gradient(180deg, var(--mer), var(--lsoft) 22%, var(--lsoft));
+}
+.mc-rail-stop {
+  position: relative;
+  margin-bottom: 22px;
+}
+.mc-rail-stop-btn {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+.mc-rail-stop-btn:disabled {
+  cursor: default;
+}
+.mc-rail-dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  border: 1.5px solid var(--faint);
+  background: var(--panel);
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+}
+.mc-rail-stop-labels {
+  display: flex;
+  flex-direction: column;
+}
+.mc-rail-stop-label {
+  font: 600 9px var(--mono);
+  color: var(--dim);
+  letter-spacing: 0.04em;
+}
+.mc-rail-stop-alt {
+  font: 500 8px var(--mono);
+  color: var(--faint);
+}
+
+/* current level — lit */
+.mc-rail-stop--current > .mc-rail-stop-btn .mc-rail-dot {
+  width: 16px;
+  height: 16px;
+  background: var(--mer);
+  border-color: var(--mer);
+  box-shadow: 0 0 12px var(--mer);
+}
+.mc-rail-stop--current > .mc-rail-stop-btn .mc-rail-stop-label {
+  color: var(--mer);
+  font-weight: 700;
+}
+
+/* future stub — dimmed, inert */
+.mc-rail-stop--future > .mc-rail-stop-btn .mc-rail-stop-label {
+  color: var(--faint);
+}
+.mc-rail-stop--future > .mc-rail-stop-btn .mc-rail-dot {
+  opacity: 0.5;
+}
+
+/* drill targets under the NETWORK stop */
+.mc-rail-networks {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0 0 0 22px;
+}
+.mc-rail-network {
+  margin-bottom: 4px;
+}
+.mc-rail-network-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  padding: 3px 6px;
+  cursor: pointer;
+}
+.mc-rail-network-btn:hover {
+  background: color-mix(in oklch, var(--fg) 6%, transparent);
+}
+.mc-rail-network-btn--active {
+  border-color: color-mix(in oklch, var(--mer) 45%, transparent);
+  background: color-mix(in oklch, var(--mer) 10%, transparent);
+}
+.mc-rail-network-name {
+  font: 500 10px var(--mono);
+  color: var(--dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mc-rail-network-btn--active .mc-rail-network-name {
+  color: var(--fg);
+}
+.mc-rail-network-posture {
+  font: 600 8px var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.mc-rail-network-posture--admin {
+  color: var(--mer);
+}
+.mc-rail-network-posture--member {
+  color: var(--tide);
+}
+
+.mc-rail-dive {
+  text-align: center;
+  font: 600 8px var(--mono);
+  color: var(--faint);
+  letter-spacing: 0.1em;
+  line-height: 1.5;
+  margin-top: 12px;
+}
+
+/* ── Reduced-motion guard (mirrors D1) ───────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .mc-logo-mark {
+    animation: none !important;
+  }
+}

--- a/src/surface/mc/dashboard-v2/components/mc-shell.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-shell.tsx
@@ -1,0 +1,76 @@
+/**
+ * MC-D2 (cortex#1289) — the constellation skin's **shell chrome** composer.
+ *
+ * Frames the MC Network view with the command bar (top) + altitude rail (left),
+ * with the existing view body as `children` in the content area. The whole shell
+ * — chrome AND the pane it frames — is wrapped in a single `.mc-skin` container
+ * so D1's OKLCH tokens + JetBrains/Inter fonts apply here and ONLY here: this is
+ * how the skin adopts pane-by-pane, with zero blast radius on the dashboard's
+ * other tabs (which never carry `.mc-skin`).
+ *
+ * Additive + non-regressive: the existing Network body renders unchanged as
+ * `children`; the chrome mounts around it. D3 re-skins the canvas itself next.
+ *
+ * The selection state is owned by the caller (the Network view) and threaded in;
+ * this component is presentation + a thin click→selection mapping over the pure
+ * `mc-shell-model`.
+ */
+
+import type { ReactNode } from "react";
+import { McCommandBar } from "./mc-command-bar";
+import { McAltitudeRail } from "./mc-altitude-rail";
+import {
+  buildBreadcrumb,
+  drillToNetwork,
+  navigateToSegment,
+  ascendToRoot,
+  selectedNetworkPosture,
+  type AltitudeSelection,
+} from "../lib/mc-shell-model";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import "./mc-shell.css";
+
+export interface McShellProps {
+  /** The serving (local) principal; `null` until a local agent is observed. */
+  principal: string | null;
+  /** Joined networks (drives the breadcrumb, posture, count, and drill list). */
+  networks: readonly NetworkMembershipDTO[];
+  /** The current you-are-here selection (owned by the caller). */
+  selection: AltitudeSelection;
+  /** Report a new selection from a chrome navigation gesture. */
+  onSelectionChange: (next: AltitudeSelection) => void;
+  /** The framed pane (the existing Network view body). */
+  children: ReactNode;
+}
+
+export function McShell({
+  principal,
+  networks,
+  selection,
+  onSelectionChange,
+  children,
+}: McShellProps) {
+  const breadcrumb = buildBreadcrumb(selection);
+  const posture = selectedNetworkPosture(networks, selection);
+
+  return (
+    <div className="mc-skin mc-shell">
+      <McCommandBar
+        principal={principal}
+        breadcrumb={breadcrumb}
+        posture={posture}
+        networkCount={networks.length}
+        onNavigate={(seg) => onSelectionChange(navigateToSegment(seg))}
+      />
+      <div className="mc-shell-body">
+        <McAltitudeRail
+          selection={selection}
+          networks={networks}
+          onAscendRoot={() => onSelectionChange(ascendToRoot())}
+          onDrillNetwork={(id) => onSelectionChange(drillToNetwork(id))}
+        />
+        <div className="mc-shell-content">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -73,6 +73,8 @@ import { NetworkFilterBar } from "./network-filter-bar";
 import { NetworkSpotlight } from "./network-spotlight";
 import { NetworkRosterPanel } from "./network-roster-panel";
 import { PierQueue } from "./pier-queue";
+import { McShell } from "./mc-shell";
+import { ROOT_SELECTION, type AltitudeSelection } from "../lib/mc-shell-model";
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
 
 // Lazy: the xyflow + elk engine chunk loads only when this resolves (first
@@ -362,7 +364,30 @@ export function NetworkView({
     return () => window.removeEventListener("keydown", onKey);
   }, [selectedKey, spotlightOpen, closePanel]);
 
+  // MC-D2 (#1289) — the constellation shell-chrome selection (you-are-here).
+  // Owned here so BOTH the command-bar breadcrumb and the altitude rail read one
+  // source. D2 wires networks↔network; deeper levels are scaffolding (D3+).
+  const [shellSelection, setShellSelection] =
+    useState<AltitudeSelection>(ROOT_SELECTION);
+  // If the drilled-into network drops out of the live `/api/networks` snapshot,
+  // ascend back to the 10k-ft root rather than holding a stale selection (the
+  // breadcrumb/posture would otherwise point at a network that no longer exists).
+  useEffect(() => {
+    if (
+      shellSelection.networkId !== null &&
+      !networks.some((n) => n.network_id === shellSelection.networkId)
+    ) {
+      setShellSelection(ROOT_SELECTION);
+    }
+  }, [networks, shellSelection.networkId]);
+
   return (
+    <McShell
+      principal={servingPrincipal}
+      networks={networks}
+      selection={shellSelection}
+      onSelectionChange={setShellSelection}
+    >
     <section className="scaffold-section network-view" aria-label="Network (agent topology)">
       <h2>Network</h2>
       <p className="dim network-view-subtitle">
@@ -453,5 +478,6 @@ export function NetworkView({
         </>
       )}
     </section>
+    </McShell>
   );
 }

--- a/src/surface/mc/dashboard-v2/lib/mc-shell-model.ts
+++ b/src/surface/mc/dashboard-v2/lib/mc-shell-model.ts
@@ -1,0 +1,210 @@
+/**
+ * MC-D2 (cortex#1289) — pure model for the constellation skin's **shell chrome**:
+ * the command-bar breadcrumb + posture, and the altitude-rail selection.
+ *
+ * The shell chrome is navigation scaffolding for the MC Network view. This module
+ * owns the small amount of LOGIC behind it — altitude levels, the you-are-here
+ * selection, the breadcrumb derivation, and per-network posture — so the React
+ * components stay thin and the behaviour is unit-testable without a DOM.
+ *
+ * ## Posture term = admin / member (the deprecated label is forbidden)
+ *
+ * Posture is the stance a principal holds toward a *given* network — **admin**
+ * (you govern it: own the hub + admission gate, hold the roster) or **member**
+ * (an admitted sovereign peer). It is **per-network, not global** (CONTEXT.md
+ * §"Network posture (admin vs member)"). The constellation mockup's legacy
+ * on-screen label is renamed to **admin** here; the deprecated network-posture
+ * word is reserved for the MC authorization-role tier + the NSC account-tree
+ * root, never the network posture (CONTEXT.md).
+ *
+ * Admin posture is derived exactly as the Pier queue derives it (MC-B1): a
+ * network is admin-posture iff its admin-authoritative (`complete`) admission-rows
+ * read succeeded. We reuse `isAdminPosture` so the two surfaces can never drift.
+ *
+ * ## D2 scope — networks ↔ network works; deeper levels are scaffolding
+ *
+ * The altitude rail names five levels (NETWORKS → NETWORK → STACK → ASSISTANT →
+ * SESSION). D2 wires the top two against real data (drill into a joined network,
+ * ascend to the 10k-ft root); STACK/ASSISTANT/SESSION are honest `future` stubs
+ * D3+ will deepen as it re-skins the canvas. No fabricated drill state.
+ *
+ * ## Sovereignty boundary — SESSION granularity is LOCAL-ONLY (extends ADR-0005)
+ *
+ * The SESSION level applies ONLY to the principal's OWN (local) stacks. Across
+ * the federation boundary a peer principal's stacks expose AGGREGATED metadata at
+ * best (presence, capability catalog, health, counts like "N active sessions") —
+ * never individual sessions or interiors. So for a federated peer the deepest
+ * reachable level is STACK/ASSISTANT (aggregate); SESSION is unreachable by
+ * construction. The boundary is a feature, not a gap. D2 keeps STACK/ASSISTANT/
+ * SESSION as inert `future` stubs (no peer-session drill is implied); the real
+ * drill-depth enforcement lands in D3/D4, which MUST honour this rule. When D3+
+ * adds the federated-vs-local coordinate to the selection, gate SESSION on it.
+ */
+
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import { isAdminPosture } from "./pier-queue-adapter";
+
+/** The five altitude levels — the primary navigation gesture (10k ft → session). */
+export type AltitudeLevel =
+  | "networks"
+  | "network"
+  | "stack"
+  | "assistant"
+  | "session";
+
+/** Ordered altitude levels, highest (10k ft) → deepest. */
+export const ALTITUDE_LEVELS: readonly AltitudeLevel[] = [
+  "networks",
+  "network",
+  "stack",
+  "assistant",
+  "session",
+] as const;
+
+/** Display metadata for one altitude rail stop. */
+export interface AltitudeStopMeta {
+  level: AltitudeLevel;
+  /** Mono, uppercase label rendered on the rail. */
+  label: string;
+  /** Optional altitude annotation (only the 10k-ft NETWORKS root carries one). */
+  altLabel?: string;
+}
+
+/** Per-level display metadata (label + the NETWORKS altitude annotation). */
+export const ALTITUDE_META: Record<AltitudeLevel, AltitudeStopMeta> = {
+  networks: { level: "networks", label: "NETWORKS", altLabel: "10k ft" },
+  network: { level: "network", label: "NETWORK" },
+  stack: { level: "stack", label: "STACK" },
+  assistant: { level: "assistant", label: "ASSISTANT" },
+  session: { level: "session", label: "SESSION" },
+};
+
+/**
+ * The current you-are-here selection. D2 wires `networks` ↔ `network`; the
+ * deeper levels carry no extra coordinates yet (D3+ adds stack/assistant/session
+ * ids as it deepens the drill).
+ */
+export interface AltitudeSelection {
+  level: AltitudeLevel;
+  /** The drilled-into network id, or `null` at the networks (10k-ft) root. */
+  networkId: string | null;
+}
+
+/** The 10k-ft root — the networks level with no network selected. */
+export const ROOT_SELECTION: AltitudeSelection = {
+  level: "networks",
+  networkId: null,
+};
+
+/** Network posture toward a given network — per-network, never global. */
+export type NetworkPosture = "admin" | "member";
+
+/**
+ * Per-network posture: `admin` iff the admin-authoritative (`complete`) admission
+ * roster read succeeded (reuses MC-B1's `isAdminPosture`, so the Pier queue and
+ * the command-bar pill can never disagree). Every other read scope/status is
+ * `member` — fail-closed: we never claim admin authority we can't prove.
+ */
+export function networkPosture(net: NetworkMembershipDTO): NetworkPosture {
+  return isAdminPosture(net) ? "admin" : "member";
+}
+
+/**
+ * The posture of the currently-selected network, or `null` at the root.
+ *
+ * Posture is per-network, so at the 10k-ft networks root (no single network
+ * selected) there is no single posture to report — `null` (the command bar then
+ * shows no pill, an honest placeholder, rather than fabricating one). When a
+ * selected network id is no longer in the data (it dropped out), also `null`.
+ */
+export function selectedNetworkPosture(
+  networks: readonly NetworkMembershipDTO[],
+  selection: AltitudeSelection,
+): NetworkPosture | null {
+  if (selection.networkId === null) return null;
+  const net = networks.find((n) => n.network_id === selection.networkId);
+  return net ? networkPosture(net) : null;
+}
+
+/** One you-are-here breadcrumb segment (clickable to navigate back to it). */
+export interface BreadcrumbSegment {
+  /** The text shown for this segment. */
+  label: string;
+  /** The altitude level this segment navigates to when clicked. */
+  level: AltitudeLevel;
+  /** The network this segment scopes to (`null` for the root segment). */
+  networkId: string | null;
+}
+
+/**
+ * Build the you-are-here breadcrumb from the current selection. The root
+ * (`NETWORK·OF·NETWORKS`) is always present; a drilled-into network appends a
+ * second segment. Deeper levels append further segments in D3+.
+ */
+export function buildBreadcrumb(
+  selection: AltitudeSelection,
+): BreadcrumbSegment[] {
+  const segments: BreadcrumbSegment[] = [
+    { label: "NETWORK·OF·NETWORKS", level: "networks", networkId: null },
+  ];
+  if (selection.networkId !== null) {
+    segments.push({
+      label: selection.networkId,
+      level: "network",
+      networkId: selection.networkId,
+    });
+  }
+  return segments;
+}
+
+/** Drill into a specific network (networks → network). */
+export function drillToNetwork(networkId: string): AltitudeSelection {
+  return { level: "network", networkId };
+}
+
+/** Ascend back to the 10k-ft networks root. */
+export function ascendToRoot(): AltitudeSelection {
+  return ROOT_SELECTION;
+}
+
+/**
+ * Resolve a breadcrumb-segment click into the next selection. The root segment
+ * ascends to the 10k-ft view; a network segment re-selects that network.
+ */
+export function navigateToSegment(
+  segment: BreadcrumbSegment,
+): AltitudeSelection {
+  if (segment.networkId === null) return ascendToRoot();
+  return drillToNetwork(segment.networkId);
+}
+
+/** Reachability of a rail stop for the current data + selection. */
+export type StopReachability = "current" | "reachable" | "future";
+
+/**
+ * Classify a rail stop:
+ *   - `current`   — the active level (lit on the rail);
+ *   - `reachable` — navigable now with the data on hand;
+ *   - `future`    — a deeper level D3+ will wire (a disabled stub today).
+ *
+ * `networks` is always reachable (the root you can always return to). `network`
+ * is reachable iff ≥1 network is joined (otherwise there is nothing to drill
+ * into — an honest `future` stub). `stack`/`assistant`/`session` are `future` in
+ * D2 regardless of data.
+ *
+ * Forward rule for D3/D4 (the sovereignty boundary above): `session` is
+ * reachable ONLY in a local/own-stack context. For a federated peer the deepest
+ * reachable level is `stack`/`assistant` (aggregate) — `session` stays `future`
+ * there by construction. D2 reaches none of these three, so it cannot
+ * contradict the rule; D3/D4 must enforce it when they wire the deep drill.
+ */
+export function stopReachability(
+  level: AltitudeLevel,
+  selection: AltitudeSelection,
+  networkCount: number,
+): StopReachability {
+  if (level === selection.level) return "current";
+  if (level === "networks") return "reachable";
+  if (level === "network") return networkCount > 0 ? "reachable" : "future";
+  return "future";
+}


### PR DESCRIPTION
## What

The **shell chrome** for the MC constellation skin's Network view — the **MC-D2** slice of the MC-UX constellation-skin epic (#1287, under #1274), built on top of **D1**'s `.mc-skin` token + motion layer (#1288).

Realises the chrome described in [`docs/design-mc-constellation-ui.md`](https://github.com/the-metafactory/cortex/blob/main/docs/design-mc-constellation-ui.md) §Anatomy from the [`docs/mockups/mc-constellation/`](https://github.com/the-metafactory/cortex/tree/main/docs/mockups/mc-constellation) mockup.

### Command bar (64px top)
◎ MISSION CONTROL logo · `PRINCIPAL <name>` · `ALT` **you-are-here breadcrumb** (`NETWORK·OF·NETWORKS / <network>`) · right-aligned **posture pill** (`ADMIN` / `MEMBER`) + joined-network count.

### Altitude rail (left)
The primary navigation gesture: **NETWORKS (10k ft) → NETWORK → STACK → ASSISTANT → SESSION**, current level lit. **NETWORKS ↔ NETWORK drill is wired against live `/api/networks`** (the NETWORK stop lists joined networks as drill targets; NETWORKS ascends to root). STACK/ASSISTANT/SESSION are honest `future` stubs D3+ deepens as it re-skins the canvas.

## How it mounts (`.mc-skin`)
`McShell` wraps the **existing Network view body** in **one** `.mc-skin` container, so D1's OKLCH tokens + fonts apply to this pane only — pane-by-pane adoption with zero blast radius on the dashboard's other tabs. **Additive / non-regressive:** the existing roster panel, Pier queue, filter bar, and lazy canvas render unchanged as `children`. D3 re-skins the canvas itself next.

## Posture data source
Per-network, derived from the admission **roster scope** — reuses MC-B1's `isAdminPosture` (`complete` roster read ⇒ `admin`, else `member`), so the Pier queue and the command-bar pill can never drift. Term is **`admin` / `member`** — the deprecated network-posture label is never rendered (CONTEXT.md §"Network posture (admin vs member)"). **Honest placeholders:** no pill at the 10k-ft root (no single network → no single posture); em-dash for an unknown principal; a vanished selected network ascends to root.

## Sovereignty boundary (documented for D3/D4)
**SESSION granularity is local-only** (extends ADR-0005): a federated peer's deepest reachable level is STACK/ASSISTANT (aggregate) — never individual sessions. D2 reaches none of the deep levels, so it cannot contradict the rule; the model documents the forward rule for D3/D4 to enforce.

## Tests / gates
- `mc-shell-model.ts` — pure nav/posture model, fully unit-tested (`mc-shell-model.test.ts`).
- Chrome rendering covered DOM-free via `renderToStaticMarkup` (`mc-shell.test.tsx`).
- `bun test src/surface/mc` → **2070 pass / 0 fail** · `bunx tsc --noEmit` clean · `bun run lint:errors` clean · `bun run build:dashboard` green (**`network-canvas-*` split chunk still emits**) · `bash scripts/check-carveouts.sh` PASS (vocab gate: `admin`/`member` only).
- Reduced-motion guard mirrors D1.

Closes #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)