### PR TITLE
feat(surface): C-1290 — MC constellation canvas re-skin (glowing star-map) (MC-D3)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/constellation-canvas-render.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/constellation-canvas-render.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * MC-D3 (cortex#1290) — render tests for the constellation canvas re-skin's
+ * presentational pieces that render WITHOUT the xyflow provider:
+ *
+ *   - `ConstellationHeader` — the on-canvas `<NETWORK> · admin|member · N stacks`
+ *     strip (admin/member vocab; aggregate-only — no session affordance).
+ *   - `StackHubCard` — the `● YOU ARE HERE` anchor renders ONLY on the serving
+ *     (local) stack, never on a federated peer hub.
+ *
+ * Both are pure (no hooks / no xyflow `<Handle>`), so they render under
+ * `renderToStaticMarkup`. The xyflow-bound canvas + edge label are exercised by
+ * the pure adapter/edge-flag tests instead (they can't mount DOM-less).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { ConstellationHeader } from "../components/constellation-header";
+import { StackHubCard } from "../components/network-nodes";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import type { StackHubNodeData } from "../lib/network-graph-adapter";
+
+function net(over: Partial<NetworkMembershipDTO>): NetworkMembershipDTO {
+  return {
+    network_id: "meridian",
+    leaf_node: "leaf-1",
+    roster_status: "ok",
+    roster_scope: "complete",
+    confidentiality: { mode: "off", key_present: false, key_id: null },
+    members: [
+      { principal: "andreas", verdict: "admitted-present", present_stacks: ["research"] },
+    ],
+    ...over,
+  };
+}
+
+function hub(over: Partial<StackHubNodeData>): StackHubNodeData {
+  return {
+    kind: "stack-hub",
+    origin: "local",
+    servingPrincipal: "andreas",
+    principal: "andreas",
+    stack: "research",
+    agentCount: 2,
+    stackColor: "#5cc8ff",
+    ...over,
+  };
+}
+
+describe("ConstellationHeader (MC-D3 on-canvas network header)", () => {
+  it("renders nothing for a non-federated stack (no joined networks)", () => {
+    expect(renderToStaticMarkup(createElement(ConstellationHeader, { networks: [] }))).toBe("");
+  });
+
+  it("an admin-posture network reads `admin` + a present-stack count", () => {
+    const html = renderToStaticMarkup(
+      createElement(ConstellationHeader, {
+        networks: [net({ roster_scope: "complete" })],
+      }),
+    );
+    expect(html).toContain('data-posture="admin"');
+    expect(html).toContain(">admin<");
+    expect(html).toContain("1 stack");
+  });
+
+  it("a self-scoped network reads `member` (never admin)", () => {
+    const html = renderToStaticMarkup(
+      createElement(ConstellationHeader, {
+        networks: [net({ roster_scope: "self" })],
+      }),
+    );
+    expect(html).toContain('data-posture="member"');
+    expect(html).toContain(">member<");
+    expect(html).not.toContain('data-posture="admin"');
+  });
+
+  it("AGGREGATE-ONLY — the header surfaces no session affordance (no peer drill)", () => {
+    const html = renderToStaticMarkup(
+      createElement(ConstellationHeader, {
+        networks: [
+          net({
+            network_id: "tide",
+            roster_scope: "self",
+            members: [
+              { principal: "jc", verdict: "admitted-present", present_stacks: ["research"] },
+            ],
+          }),
+        ],
+      }),
+    );
+    // No session word anywhere in the federated-peer-bearing header markup.
+    expect(html.toLowerCase()).not.toContain("session");
+  });
+});
+
+describe("StackHubCard — ● YOU ARE HERE anchor (MC-D3)", () => {
+  it("renders the anchor on the SELF (local-origin) stack hub", () => {
+    const html = renderToStaticMarkup(
+      createElement(StackHubCard, { data: hub({ origin: "local" }) }),
+    );
+    expect(html).toContain('data-you-are-here="true"');
+    expect(html).toContain("YOU ARE HERE");
+  });
+
+  it("does NOT render the anchor on a federated peer hub", () => {
+    const html = renderToStaticMarkup(
+      createElement(StackHubCard, {
+        data: hub({
+          origin: { principal: "jc", stack: "research" },
+          principal: "jc",
+          stack: "research",
+        }),
+      }),
+    );
+    expect(html).not.toContain("YOU ARE HERE");
+  });
+
+  it("does NOT render the anchor on a same-principal SIBLING hub (only the serving stack)", () => {
+    const html = renderToStaticMarkup(
+      createElement(StackHubCard, {
+        data: hub({
+          // A same-principal object origin (DB-read sibling) is local but NOT the
+          // serving stack — only the literal local origin earns the anchor.
+          origin: { principal: "andreas", stack: "work" },
+          stack: "work",
+        }),
+      }),
+    );
+    expect(html).not.toContain("YOU ARE HERE");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-constellation-header.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-constellation-header.test.ts
@@ -1,0 +1,122 @@
+/**
+ * MC-D3 (cortex#1290) — pure constellation-header projection tests.
+ *
+ * The constellation canvas header reads `<NETWORK> · <admin|member> · N stacks`
+ * off the same `/api/networks` DTO the A1 roster panel consumes. The two
+ * load-bearing invariants under test:
+ *
+ *   1. POSTURE VOCAB — the header says `admin` / `member` (CONTEXT.md §"Network
+ *      posture"; the design's original on-screen label is renamed to admin, and
+ *      the deprecated word is gated out of src/ by check-carveouts). The posture
+ *      is the SAME admin-authoritative determination the Pier queue uses
+ *      (`isAdminPosture`) — reused, not re-derived.
+ *   2. AGGREGATE-ONLY — the header carries presence-level aggregate counts only
+ *      (a distinct-present-stacks tally + the A3 confidentiality token). It never
+ *      surfaces a session field, so it cannot become a session-drill into a
+ *      federated peer.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { NetworkMembershipDTO } from "../../api/networks";
+import { buildConstellationHeader } from "../lib/network-constellation-header";
+
+function net(over: Partial<NetworkMembershipDTO>): NetworkMembershipDTO {
+  return {
+    network_id: "meridian",
+    leaf_node: "leaf-1",
+    roster_status: "ok",
+    roster_scope: "complete",
+    confidentiality: { mode: "off", key_present: false, key_id: null },
+    members: [],
+    ...over,
+  };
+}
+
+describe("buildConstellationHeader", () => {
+  test("empty networks → empty header (a non-federated stack renders no header)", () => {
+    expect(buildConstellationHeader([])).toEqual([]);
+  });
+
+  test("admin posture: an authoritative complete-roster read → admin", () => {
+    const [row] = buildConstellationHeader([
+      net({ roster_status: "ok", roster_scope: "complete" }),
+    ]);
+    expect(row?.posture).toBe("admin");
+  });
+
+  test("member posture: a self-scoped read → member (never admin)", () => {
+    const [row] = buildConstellationHeader([
+      net({ roster_status: "ok", roster_scope: "self" }),
+    ]);
+    expect(row?.posture).toBe("member");
+  });
+
+  test("member posture: a degraded read (unreachable) → member, never admin", () => {
+    const [row] = buildConstellationHeader([
+      net({ roster_status: "unreachable", roster_scope: null }),
+    ]);
+    expect(row?.posture).toBe("member");
+  });
+
+  test("stackCount tallies DISTINCT present {principal}/{stack} across members", () => {
+    const [row] = buildConstellationHeader([
+      net({
+        members: [
+          { principal: "andreas", verdict: "admitted-present", present_stacks: ["research", "work"] },
+          { principal: "jc", verdict: "admitted-present", present_stacks: ["research"] },
+          // duplicate principal/stack must not double-count
+          { principal: "andreas", verdict: "admitted-absent", present_stacks: ["research"] },
+        ],
+      }),
+    ]);
+    // andreas/research, andreas/work, jc/research → 3 distinct
+    expect(row?.stackCount).toBe(3);
+  });
+
+  test("stackCount is 0 when no member has a present stack (presence ≠ membership)", () => {
+    const [row] = buildConstellationHeader([
+      net({
+        members: [
+          { principal: "jc", verdict: "admitted-absent", present_stacks: [] },
+        ],
+      }),
+    ]);
+    expect(row?.stackCount).toBe(0);
+  });
+
+  test("carries the A3 confidentiality token (D4 finalizes the K-marker; render what's available)", () => {
+    const [row] = buildConstellationHeader([
+      net({ confidentiality: { mode: "required", key_present: true, key_id: "k7" } }),
+    ]);
+    expect(row?.confidentiality).toBe("encrypted-required");
+  });
+
+  test("VOCAB GATE — posture is only ever 'admin' or 'member' (deprecated label gated)", () => {
+    const rows = buildConstellationHeader([
+      net({ roster_scope: "complete" }),
+      net({ network_id: "tide", roster_scope: "self" }),
+    ]);
+    for (const r of rows) {
+      expect(["admin", "member"]).toContain(r.posture);
+    }
+  });
+
+  test("AGGREGATE-ONLY — a header row exposes no session field (no drill into peers)", () => {
+    const [row] = buildConstellationHeader([
+      net({
+        members: [
+          { principal: "jc", verdict: "admitted-present", present_stacks: ["research"] },
+        ],
+      }),
+    ]);
+    const keys = Object.keys(row ?? {});
+    // The row is a presence-level aggregate: id, posture, stack count, A3 token.
+    expect(keys.sort()).toEqual(
+      ["confidentiality", "networkId", "posture", "stackCount"].sort(),
+    );
+    // Defensively assert nothing session-shaped leaked in.
+    for (const k of keys) {
+      expect(k.toLowerCase()).not.toContain("session");
+    }
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
@@ -565,3 +565,42 @@ describe("collectLegendStacks (#1068)", () => {
     expect(new Set(rows.map((r) => r.color)).size).toBe(3);
   });
 });
+
+describe("buildNetworkGraph — federated edge flag (MC-D3 #1290)", () => {
+  it("flags a CROSS-PRINCIPAL foreign peer's hub→agent edges federated=true", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+    ]);
+    const foreignEdge = g.edges.find((e) => e.target === "jc/research/sage");
+    expect(foreignEdge?.data?.federated).toBe(true);
+  });
+
+  it("leaves a LOCAL stack's hub→agent edges federated=false (solid)", () => {
+    const g = buildNetworkGraph([tile({ agent_id: "luna" })]);
+    const localEdge = g.edges.find((e) => e.target === "andreas/research/luna");
+    expect(localEdge?.data?.federated).toBe(false);
+  });
+
+  it("leaves a SAME-PRINCIPAL sibling's edges federated=false (local, not federation)", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      siblingTile({ agent_id: "echo", stack: "work" }),
+    ]);
+    const siblingEdge = g.edges.find((e) => e.target === "andreas/work/echo");
+    expect(siblingEdge?.data?.federated).toBe(false);
+  });
+
+  it("the edge flag agrees with the node classifier for the same origin", () => {
+    const g = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+    ]);
+    const foreignEdge = g.edges.find((e) => e.target === "jc/research/sage");
+    // The classifier says foreign for jc (a cross-principal peer vs serving andreas).
+    expect(classifyOrigin({ principal: "jc", stack: "research" }, "andreas")).toBe(
+      "foreign",
+    );
+    expect(foreignEdge?.data?.federated).toBe(true);
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/constellation-canvas.css
+++ b/src/surface/mc/dashboard-v2/components/constellation-canvas.css
@@ -1,0 +1,282 @@
+/*
+ * MC-D3 (cortex#1290) — the constellation CANVAS skin.
+ *
+ * Re-skins the EXISTING network graph (ELK + React Flow) into the glowing
+ * star-map from the mockup — radial-glow orb nodes keyed to each stack's hue, a
+ * "you are here" anchor on the serving stack, dashed + flowing federated edges,
+ * and an atmospheric background. It restyles the canvas's DOM; it does NOT
+ * rebuild the engine (the lazy `network-canvas-*` chunk + the ELK/React-Flow
+ * pipeline are untouched).
+ *
+ * ── Scope: every rule is under `.mc-skin` ────────────────────────────────────
+ * The MC-D2 `McShell` wraps the whole Network view in a single `.mc-skin`
+ * container, so D1's OKLCH tokens (--bg/--panel/--stack-color/--mer/--ok/--warn/
+ * --bad) resolve here. Scoping under `.mc-skin` keeps every other dashboard tab
+ * (which never carries the class) byte-identical — additive, zero blast radius.
+ *
+ * ── Truth, never theater ─────────────────────────────────────────────────────
+ * Glow + motion reflect REAL state only: the liveness pulse is gated on the
+ * agent's observed `online` state, the federated dash-flow on the verified
+ * `federated` (cross-principal) edge flag. Nothing fakes liveness. A federated
+ * peer renders in AGGREGATE (presence, capabilities, state) and carries a
+ * visible "federated · admitted peer" boundary — it is NEVER drillable into
+ * sessions (ADR-0007 / the sovereignty boundary); that boundary is enforced in
+ * the components, and made legible here.
+ *
+ * ── Motion ───────────────────────────────────────────────────────────────────
+ * All animation is held on its resting frame under `prefers-reduced-motion`
+ * (the guard at the foot of this file mirrors D1's). The federated edge reuses
+ * D1's `.edge-live--fed` (dashFlowFed) class, already guarded in constellation.css.
+ */
+
+/* ── Atmosphere ─────────────────────────────────────────────────────────────
+ * The canvas is a dark radial "atmosphere" rather than the flat panel. The
+ * per-stack hues bloom against near-black-blue. */
+.mc-skin .network-canvas-wrap {
+  background:
+    radial-gradient(
+      ellipse 120% 80% at 50% -10%,
+      color-mix(in oklch, var(--mer) 14%, transparent) 0%,
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 90% 70% at 80% 110%,
+      color-mix(in oklch, var(--tide) 10%, transparent) 0%,
+      transparent 60%
+    ),
+    var(--bg);
+  border-color: color-mix(in oklch, var(--mer) 22%, var(--line));
+}
+.mc-skin .network-canvas-wrap .react-flow,
+.mc-skin .network-canvas-wrap .react-flow__renderer {
+  background: transparent;
+}
+/* Mute React Flow's default dotted background grid against the atmosphere. */
+.mc-skin .react-flow__background {
+  opacity: 0.35;
+}
+
+/* ── Agent orbs ─────────────────────────────────────────────────────────────
+ * The agent card becomes a glowing orb-card keyed to its stack hue. The glow
+ * tint is the inline `--stack-color` each node already carries. */
+.mc-skin .network-node-agent {
+  position: relative;
+  border: 1px solid color-mix(in oklch, var(--stack-color, var(--mer)) 45%, var(--line));
+  border-left-width: 3px;
+  border-left-color: var(--stack-color, var(--mer));
+  border-radius: 12px;
+  background:
+    radial-gradient(
+      circle at 18% 0%,
+      color-mix(in oklch, var(--stack-color, var(--mer)) 22%, transparent) 0%,
+      transparent 60%
+    ),
+    color-mix(in oklch, var(--panel) 86%, var(--bg));
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 22%, transparent),
+    0 0 18px -2px color-mix(in oklch, var(--stack-color, var(--mer)) 30%, transparent);
+}
+
+/* Liveness glow — ONLY when the agent is actually online (truth, not theater).
+ * Breathes the orb's halo; offline orbs are dimmed + static. */
+.mc-skin .network-node-agent.network-node-online {
+  animation: mcOrbBreathe 3.4s ease-in-out infinite;
+}
+.mc-skin .network-node-agent.network-node-offline {
+  opacity: 0.55;
+  filter: saturate(0.6);
+  box-shadow: none;
+}
+@keyframes mcOrbBreathe {
+  0%, 100% {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 22%, transparent),
+      0 0 16px -3px color-mix(in oklch, var(--stack-color, var(--mer)) 26%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 38%, transparent),
+      0 0 26px 0 color-mix(in oklch, var(--stack-color, var(--mer)) 42%, transparent);
+  }
+}
+
+/* TTL-lapse (silent drop) reads as a warn-tinted orb. */
+.mc-skin .network-node-agent.network-node-ttl-lapse {
+  border-color: color-mix(in oklch, var(--warn) 55%, var(--line));
+}
+
+/* ── Stack hubs (the cluster cores) ─────────────────────────────────────────
+ * The hub is a brighter core glowing in its stack hue. */
+.mc-skin .network-node-hub {
+  border-radius: 14px;
+  border-color: var(--stack-color, var(--mer));
+  background:
+    radial-gradient(
+      circle at 50% 35%,
+      color-mix(in oklch, var(--stack-color, var(--mer)) 30%, transparent) 0%,
+      transparent 70%
+    ),
+    color-mix(in oklch, var(--panel) 80%, var(--bg));
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 40%, transparent),
+    0 0 28px -2px color-mix(in oklch, var(--stack-color, var(--mer)) 45%, transparent);
+}
+.mc-skin .network-hub-label {
+  color: var(--fg);
+  text-shadow: 0 0 10px color-mix(in oklch, var(--stack-color, var(--mer)) 50%, transparent);
+}
+
+/* ● YOU ARE HERE — the serving (local) stack anchor. A glowing pill. */
+.mc-skin .network-hub-you-are-here {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 1px 0 2px 0;
+  padding: 1px 8px;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--bg);
+  background: var(--ok);
+  border-radius: 999px;
+  box-shadow: 0 0 14px -1px color-mix(in oklch, var(--ok) 70%, transparent);
+  animation: mcAnchorPulse 2.6s ease-in-out infinite;
+}
+@keyframes mcAnchorPulse {
+  0%, 100% { box-shadow: 0 0 12px -2px color-mix(in oklch, var(--ok) 60%, transparent); }
+  50%      { box-shadow: 0 0 20px 1px  color-mix(in oklch, var(--ok) 85%, transparent); }
+}
+
+/* ── Federated peers (aggregate-only, visible boundary) ──────────────────────
+ * A cross-principal foreign hub/agent is dashed + cool-tinted; the provenance
+ * badge reads its admitted `{principal}/{stack}`. This is the sovereignty
+ * boundary made legible — these orbs show aggregate presence only and are not
+ * drillable into sessions. */
+.mc-skin .network-node-foreign,
+.mc-skin .network-node-hub-foreign {
+  border-style: dashed;
+  border-color: color-mix(in oklch, var(--tide) 55%, var(--line));
+}
+.mc-skin .network-node-provenance {
+  color: color-mix(in oklch, var(--tide) 75%, var(--fg));
+}
+
+/* ── Capability + state chips ───────────────────────────────────────────────*/
+.mc-skin .network-node-cap {
+  font-family: var(--mono);
+  border-color: color-mix(in oklch, var(--stack-color, var(--mer)) 35%, var(--line));
+  color: color-mix(in oklch, var(--fg) 80%, var(--stack-color, var(--mer)));
+  background: color-mix(in oklch, var(--stack-color, var(--mer)) 8%, transparent);
+}
+.mc-skin .network-node-cap.network-node-cap-highlighted {
+  border-color: var(--stack-color, var(--mer));
+  box-shadow: 0 0 10px -2px color-mix(in oklch, var(--stack-color, var(--mer)) 60%, transparent);
+}
+.mc-skin .network-node-state.state-online { color: var(--ok); }
+.mc-skin .network-node-state.state-offline { color: var(--warn); }
+.mc-skin .network-node-reason-ttl-lapse { color: var(--warn); }
+
+/* ── Edges — glowing connectors; federated = dashed + flowing + labelled ─────*/
+.mc-skin .react-flow__edge-path {
+  filter: drop-shadow(0 0 3px color-mix(in oklch, var(--mer) 30%, transparent));
+}
+/* The federated edge label — `● federated · admitted peer`. */
+.mc-skin .mc-edge-fed-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  padding: 1px 7px;
+  color: color-mix(in oklch, var(--tide) 80%, var(--fg));
+  background: color-mix(in oklch, var(--panel) 86%, var(--bg));
+  border: 1px solid color-mix(in oklch, var(--tide) 50%, var(--line));
+  border-radius: 999px;
+  box-shadow: 0 0 12px -3px color-mix(in oklch, var(--tide) 50%, transparent);
+}
+.mc-skin .mc-edge-fed-label span[aria-hidden="true"] {
+  color: var(--tide);
+}
+
+/* ── On-canvas network header — `<NETWORK> · admin|member · N stacks` ─────────
+ * Overlays the top of the star-map (the mockup's network header strip). */
+.mc-skin .mc-constellation-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 4;
+  padding: 8px 12px;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    color-mix(in oklch, var(--bg) 78%, transparent) 0%,
+    transparent 100%
+  );
+}
+.mc-skin .mc-constellation-header-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.mc-skin .mc-constellation-header-net {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  pointer-events: auto;
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklch, var(--mer) 30%, var(--line));
+  background: color-mix(in oklch, var(--panel) 80%, var(--bg));
+}
+.mc-skin .mc-ch-name {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg);
+}
+.mc-skin .mc-ch-sep { color: var(--faint); }
+.mc-skin .mc-ch-posture {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  font-size: 9.5px;
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+/* admin = you govern it (warm/authoritative); member = admitted peer (cool). */
+.mc-skin .mc-ch-posture-admin {
+  color: var(--bg);
+  background: var(--warn);
+}
+.mc-skin .mc-ch-posture-member {
+  color: color-mix(in oklch, var(--fg) 85%, var(--mer));
+  background: color-mix(in oklch, var(--mer) 18%, transparent);
+  border: 1px solid color-mix(in oklch, var(--mer) 45%, transparent);
+}
+.mc-skin .mc-ch-stacks { color: var(--dim); }
+.mc-skin .mc-ch-conf {
+  margin-left: 2px;
+  font-size: 9.5px;
+  color: var(--dim);
+}
+.mc-skin .mc-ch-conf[data-confidentiality="degraded"] { color: var(--bad); }
+.mc-skin .mc-ch-conf[data-confidentiality="encrypted-required"],
+.mc-skin .mc-ch-conf[data-confidentiality="encrypted"] { color: var(--ok); }
+
+/* ── Reduced-motion guard ───────────────────────────────────────────────────
+ * Hold every constellation-canvas animation on its resting frame; the static
+ * glow shapes + tokens remain. Mirrors D1's guard for this slice's own keyframes
+ * (D1 already guards `.edge-live--fed`). */
+@media (prefers-reduced-motion: reduce) {
+  .mc-skin .network-node-agent.network-node-online,
+  .mc-skin .network-hub-you-are-here {
+    animation: none !important;
+  }
+}

--- a/src/surface/mc/dashboard-v2/components/constellation-header.tsx
+++ b/src/surface/mc/dashboard-v2/components/constellation-header.tsx
@@ -1,0 +1,105 @@
+/**
+ * MC-D3 (cortex#1290) — the constellation canvas NETWORK HEADER.
+ *
+ * Renders the mockup's per-network header strip — `<NETWORK> · <admin|member> ·
+ * N stacks` (e.g. `MERIDIAN · admin · 2 stacks`) — above the glowing star-map.
+ * It is a thin presentational shell over the pure `buildConstellationHeader`
+ * projection; all posture/aggregate logic lives there (unit-tested DOM-free).
+ *
+ * ## Vocabulary (load-bearing — CONTEXT.md §"Network posture (admin vs member)")
+ *
+ * The posture pill reads **admin** / **member** — the design mockup's original
+ * on-screen label is renamed to `admin` per the vocabulary migration. The
+ * deprecated network-posture word is reserved for the MC authorization-role tier
+ * + the NATS account-tree root, never this per-network posture (CONTEXT.md
+ * §"Network posture"); the `check-carveouts` ratchet enforces it.
+ *
+ * ## Sovereignty (the privacy boundary)
+ *
+ * The header is an AGGREGATE — network id, the viewer's posture, a present-stack
+ * tally, and the A3 confidentiality token. It exposes NO session affordance, for
+ * any network, admin or member: a federated peer is visible in aggregate but
+ * never drillable into sessions (ADR-0007). Self-effacing: no joined networks →
+ * renders nothing (a non-federated stack is unchanged).
+ */
+
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import {
+  buildConstellationHeader,
+  type ConstellationHeaderNetwork,
+} from "../lib/network-constellation-header";
+
+export interface ConstellationHeaderProps {
+  networks: readonly NetworkMembershipDTO[];
+}
+
+/** The A3 confidentiality token → a short, honest on-glass marker. */
+function confidentialityMarker(
+  token: ConstellationHeaderNetwork["confidentiality"],
+): { label: string; title: string } | null {
+  switch (token) {
+    case "encrypted-required":
+      return { label: "🔒 sealed (required)", title: "Sealed — cleartext-in rejected (key held)" };
+    case "encrypted":
+      return { label: "🔒 sealed", title: "Sealed — key held (transition window)" };
+    case "degraded":
+      return { label: "⚠ no key", title: "Configured to seal but no key — publishing cleartext (ADR-0019)" };
+    case "cleartext":
+      return { label: "signed", title: "Signed, not sealed (encryption off)" };
+    case "unknown":
+      // Never assume encrypted; the marker is finalized in D4. Show nothing
+      // rather than over-claim.
+      return null;
+  }
+}
+
+export function ConstellationHeader({ networks }: ConstellationHeaderProps) {
+  const rows = buildConstellationHeader(networks);
+  // Self-effacing: a non-federated stack (no joined networks) renders no header.
+  if (rows.length === 0) return null;
+
+  return (
+    <header className="mc-constellation-header" aria-label="Networks (constellation header)">
+      <ul className="mc-constellation-header-list">
+        {rows.map((row) => {
+          const marker = confidentialityMarker(row.confidentiality);
+          const stackPlural = row.stackCount === 1 ? "" : "s";
+          return (
+            <li
+              key={row.networkId}
+              className="mc-constellation-header-net"
+              data-network={row.networkId}
+              data-posture={row.posture}
+            >
+              <span className="mc-ch-name">{row.networkId}</span>
+              <span className="mc-ch-sep" aria-hidden="true">·</span>
+              <span
+                className={`mc-ch-posture mc-ch-posture-${row.posture}`}
+                title={
+                  row.posture === "admin"
+                    ? "You administer this network — roster, Pier queue, grant/revoke"
+                    : "You are an admitted member — a sovereign peer, no admin affordances"
+                }
+              >
+                {row.posture}
+              </span>
+              <span className="mc-ch-sep" aria-hidden="true">·</span>
+              <span className="mc-ch-stacks">
+                {row.stackCount} stack{stackPlural}
+              </span>
+              {marker && (
+                <span
+                  className="mc-ch-conf"
+                  data-confidentiality={row.confidentiality}
+                  title={marker.title}
+                >
+                  {marker.label}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </header>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/network-canvas.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-canvas.tsx
@@ -134,6 +134,10 @@ function FlowCanvas({
         data: {
           ...(e.layout as unknown as Record<string, unknown>),
           stackColor: e.data?.stackColor,
+          // MC-D3 (#1290) — carry the federation provenance so the constellation
+          // edge draws a federated (cross-principal admitted-peer) connector
+          // dashed + flowing, and labels it. Local/sibling edges stay solid.
+          federated: e.data?.federated ?? false,
         } as Record<string, unknown>,
       })),
     [laidOutEdges],

--- a/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
@@ -17,6 +17,7 @@
 import { useMemo, type CSSProperties } from "react";
 import {
   BaseEdge,
+  EdgeLabelRenderer,
   getSmoothStepPath,
   Position,
   type EdgeProps,
@@ -131,6 +132,11 @@ export default function NetworkElkEdge(props: EdgeProps) {
   const elkPoints = edgeData?.["elkPoints"] as Point[] | undefined;
   // #1068 — the hub→agent connector strokes in its stack's deterministic color.
   const stackColor = edgeData?.["stackColor"] as string | undefined;
+  // MC-D3 (#1290) — a CROSS-PRINCIPAL federated peer's edge: drawn dashed +
+  // flowing (the live bus-traffic "admitted peer" treatment) and labelled. The
+  // constellation skin's `.edge-live--fed` class supplies the dash geometry +
+  // `dashFlowFed` animation (reduced-motion-guarded in constellation.css).
+  const federated = edgeData?.["federated"] === true;
   const layoutSourceX = edgeData?.["layoutSourceX"] as number | undefined;
   const layoutSourceY = edgeData?.["layoutSourceY"] as number | undefined;
   const layoutTargetX = edgeData?.["layoutTargetX"] as number | undefined;
@@ -207,12 +213,39 @@ export default function NetworkElkEdge(props: EdgeProps) {
     }
   }
 
+  // MC-D3 — the federated edge midpoint, where the `federated · admitted peer`
+  // label sits. The label is a presence-level provenance marker (this is an
+  // admitted cross-principal peer relationship) — never a session affordance.
+  const labelX = (sourceX + targetX) / 2;
+  const labelY = (sourceY + targetY) / 2;
+
   return (
-    <BaseEdge
-      id={id}
-      path={path}
-      style={baseStyle as CSSProperties}
-      markerEnd={markerEnd}
-    />
+    <>
+      <BaseEdge
+        id={id}
+        path={path}
+        style={baseStyle as CSSProperties}
+        markerEnd={markerEnd}
+        // The constellation skin keys the dashed-flow treatment off this class
+        // (scoped under `.mc-skin`; inert in the un-skinned legacy render).
+        className={federated ? "edge-live--fed" : undefined}
+      />
+      {federated && (
+        <EdgeLabelRenderer>
+          <div
+            className="mc-edge-fed-label"
+            data-edge-federated="true"
+            style={{
+              position: "absolute",
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: "none",
+            }}
+            title="Federated bus relationship — an admitted cross-principal peer"
+          >
+            <span aria-hidden="true">●</span> federated · admitted peer
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
   );
 }

--- a/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
@@ -133,9 +133,11 @@ export default function NetworkElkEdge(props: EdgeProps) {
   // #1068 — the hub→agent connector strokes in its stack's deterministic color.
   const stackColor = edgeData?.["stackColor"] as string | undefined;
   // MC-D3 (#1290) — a CROSS-PRINCIPAL federated peer's edge: drawn dashed +
-  // flowing (the live bus-traffic "admitted peer" treatment) and labelled. The
+  // flowing to mark the "admitted peer" relationship, and labelled. The
   // constellation skin's `.edge-live--fed` class supplies the dash geometry +
-  // `dashFlowFed` animation (reduced-motion-guarded in constellation.css).
+  // `dashFlowFed` animation (reduced-motion-guarded in constellation.css). The
+  // flow here is the relationship treatment, not REAL bus traffic — binding the
+  // dash-flow to live envelope flow is D5 (#1292).
   const federated = edgeData?.["federated"] === true;
   const layoutSourceX = edgeData?.["layoutSourceX"] as number | undefined;
   const layoutSourceY = edgeData?.["layoutSourceY"] as number | undefined;
@@ -213,11 +215,19 @@ export default function NetworkElkEdge(props: EdgeProps) {
     }
   }
 
-  // MC-D3 — the federated edge midpoint, where the `federated · admitted peer`
-  // label sits. The label is a presence-level provenance marker (this is an
-  // admitted cross-principal peer relationship) — never a session affordance.
-  const labelX = (sourceX + targetX) / 2;
-  const labelY = (sourceY + targetY) / 2;
+  // MC-D3 — anchor the `federated · admitted peer` label ON the route, not on
+  // the straight chord: use the middle vertex of ELK's orthogonal polyline when
+  // present (so the pill sits on the connector, not floating off it), falling
+  // back to the chord midpoint only when ELK didn't route the edge. The label is
+  // a presence-level provenance marker (an admitted cross-principal peer
+  // relationship) — never a session affordance.
+  const { labelX, labelY } = useMemo(() => {
+    if (elkPoints && elkPoints.length >= 2) {
+      const mid = elkPoints[Math.floor(elkPoints.length / 2)]!;
+      return { labelX: mid.x, labelY: mid.y };
+    }
+    return { labelX: (sourceX + targetX) / 2, labelY: (sourceY + targetY) / 2 };
+  }, [elkPoints, sourceX, sourceY, targetX, targetY]);
 
   return (
     <>

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -86,6 +86,13 @@ export function StackHubCard({
   // hub with the local visual, identical to your own stack's treatment.
   const category = classifyOrigin(data.origin, data.servingPrincipal);
   const foreign = !isLocalCategory(category);
+  // MC-D3 (#1290) — the SELF stack (the serving stack, `origin === "local"`) is
+  // the constellation's "● YOU ARE HERE" anchor. Only the serving stack — NOT a
+  // same-principal sibling (DB-read aggregation) — earns the anchor, so it gates
+  // on the literal local origin, not `isLocalCategory` (which also covers
+  // siblings). Presence-level marker; renders in any context, styled as the
+  // glowing anchor only under `.mc-skin`.
+  const isSelfStack = data.origin === "local";
   // U2.3 — signal's intent⋈reality verdict for this stack (present only when the
   // transport overlay is on AND signal observed it). Taken verbatim from signal.
   const badge =
@@ -162,6 +169,11 @@ export function StackHubCard({
       <span className="network-hub-eyebrow dim">
         {foreign ? "federated stack" : "stack"}
       </span>
+      {isSelfStack && (
+        <span className="network-hub-you-are-here" data-you-are-here="true">
+          <span aria-hidden="true">●</span> YOU ARE HERE
+        </span>
+      )}
       <span className="network-hub-label">{label}</span>
       {badge && (
         <span

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -69,7 +69,12 @@ import {
 } from "../lib/network-graph-filter";
 import { isSpotlightOpenChord } from "../lib/network-spotlight";
 import { NetworkDetailPanel } from "./network-detail-panel";
+import { ConstellationHeader } from "./constellation-header";
 import { NetworkFilterBar } from "./network-filter-bar";
+// MC-D3 (#1290) — the constellation canvas skin. Scoped under `.mc-skin` (the
+// McShell wrapper), so importing it here loads the skin with the Network view
+// while staying inert on every other dashboard tab.
+import "./constellation-canvas.css";
 import { NetworkSpotlight } from "./network-spotlight";
 import { NetworkRosterPanel } from "./network-roster-panel";
 import { PierQueue } from "./pier-queue";
@@ -427,6 +432,10 @@ export function NetworkView({
             onOpenSpotlight={openSpotlight}
           />
           <div className="network-canvas-wrap">
+            {/* MC-D3 — on-canvas network header (<NETWORK> · admin|member · N
+                stacks), overlaying the top of the star-map. Renders nothing for a
+                non-federated stack. admin/member vocab (deprecated label gated). */}
+            <ConstellationHeader networks={networks} />
             {filteredAgents.length === 0 ? (
               // The snapshot has agents but the active filter excludes them all.
               // Keep the filter bar above so the principal can clear/relax it.

--- a/src/surface/mc/dashboard-v2/lib/network-constellation-header.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-constellation-header.ts
@@ -1,0 +1,91 @@
+/**
+ * MC-D3 (cortex#1290) — pure projection for the constellation canvas HEADER.
+ *
+ * The constellation star-map carries a per-network header reading
+ * `<NETWORK> · <admin|member> · N stacks` (the mockup's `MERIDIAN · … · 2 STACKS`).
+ * This adapter projects the `/api/networks` membership DTO (MC-A1) into that
+ * header model. It is the SKIN's read of the A-wave truth — it invents nothing.
+ *
+ * ## Posture vocab (load-bearing — CONTEXT.md §"Network posture (admin vs member)")
+ *
+ * The header says **admin** / **member**. The design mockup's original on-screen
+ * label is renamed to `admin` per the vocabulary migration — the deprecated
+ * network-posture word is reserved for the MC authorization-role tier + the NATS
+ * account-tree root, never the per-network posture (CONTEXT.md §"Network
+ * posture"). The posture is the SAME admin-authoritative determination the Pier
+ * queue uses — `isAdminPosture` (an `ok` + `complete` roster read) — REUSED here,
+ * not re-derived (one source of truth for "do I admin this network?").
+ *
+ * ## Aggregate-only (sovereignty — the privacy boundary)
+ *
+ * A header row carries presence-level AGGREGATES only: the network id, the
+ * viewer's posture, a distinct-present-stacks tally, and the A3 confidentiality
+ * token. It exposes no session field — so the header (like the rest of a
+ * federated peer's projection, ADR-0007) can never become a drill into another
+ * principal's session interiors. Full node→session→envelope drill is for the
+ * principal's OWN local stacks only; this header is sovereign by construction.
+ *
+ * Pure + DOM-free → unit-tested without a browser; the component takes the result
+ * and renders the header strip.
+ */
+
+import type { NetworkMembershipDTO } from "../../api/networks";
+import { isAdminPosture } from "./pier-queue-adapter";
+import {
+  confidentialityBadge,
+  type ConfidentialityPostureToken,
+} from "./network-membership-adapter";
+
+/** The viewer's stance toward a given network (CONTEXT.md §"Network posture"). */
+export type NetworkPosture = "admin" | "member";
+
+/** One network's constellation-header model — a presence-level aggregate. */
+export interface ConstellationHeaderNetwork {
+  /** The network's id (the header's leading label). */
+  networkId: string;
+  /**
+   * The viewer's per-network posture — `admin` (governs the network: roster,
+   * Pier queue, grant/revoke) or `member` (an admitted sovereign peer, no admin
+   * affordances). Derived via {@link isAdminPosture}; never the deprecated label.
+   */
+  posture: NetworkPosture;
+  /**
+   * Distinct `{principal}/{stack}` pairs observed PRESENT across this network's
+   * admitted members. Presence-level aggregate — never a session count. Presence
+   * does not confer membership (ADR-0018 Q3); this is "stacks alight right now".
+   */
+  stackCount: number;
+  /**
+   * MC-A3 (#1277) confidentiality posture token. The constellation's `K`
+   * encryption marker is FINALIZED in D4; D3 renders what A3 already wires
+   * (honest — `degraded`/`unknown` are never badged as encrypted).
+   */
+  confidentiality: ConfidentialityPostureToken;
+}
+
+/** Count distinct `{principal}/{stack}` pairs observed present across members. */
+function countDistinctPresentStacks(net: NetworkMembershipDTO): number {
+  const seen = new Set<string>();
+  for (const m of net.members) {
+    for (const stack of m.present_stacks) {
+      seen.add(`${m.principal}/${stack}`);
+    }
+  }
+  return seen.size;
+}
+
+/**
+ * Project the `/api/networks` DTO into the constellation header model — one row
+ * per joined network, in input order. Empty in → empty out (a non-federated
+ * stack renders no header). Pure; does not mutate its input.
+ */
+export function buildConstellationHeader(
+  networks: readonly NetworkMembershipDTO[],
+): ConstellationHeaderNetwork[] {
+  return networks.map((net) => ({
+    networkId: net.network_id,
+    posture: isAdminPosture(net) ? "admin" : "member",
+    stackCount: countDistinctPresentStacks(net),
+    confidentiality: confidentialityBadge(net.confidentiality).posture,
+  }));
+}

--- a/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
@@ -44,6 +44,7 @@ import type {
 } from "./network-transport-overlay";
 import { overlayForStack } from "./network-transport-overlay";
 import { stackColor } from "./stack-color";
+import { classifyOrigin, isLocalCategory } from "./agents-display";
 
 /** Reserved id for the synthetic LOCAL stack-root hub node (never a valid agent key). */
 export const STACK_HUB_NODE_ID = "__stack__";
@@ -196,10 +197,20 @@ export interface NetworkGraphEdge {
    * Edge `data` payload.
    *   - `stackColor` (#1068) — the hub's stack color, so the hub→agent connector
    *     strokes in the stack's hue (set at build time for every edge).
+   *   - `federated` (MC-D3 #1290) — true when this edge wires a CROSS-PRINCIPAL
+   *     federated peer's hub→agent (`classifyOrigin` → `foreign`). The
+   *     constellation skin draws a federated edge dashed + flowing
+   *     (`.edge-live--fed`) and labels it `federated · admitted peer`; a local or
+   *     same-principal-sibling edge is `false`/absent (solid). Presence-level
+   *     provenance, never a session field.
    *   - `transport` (U2.3) — optional health/lag overlay payload, sourced from
    *     signal (present only when the transport overlay is on).
    */
-  data?: { stackColor?: string; transport?: NetworkEdgeTransportData };
+  data?: {
+    stackColor?: string;
+    federated?: boolean;
+    transport?: NetworkEdgeTransportData;
+  };
 }
 
 /** The adapter's output: nodes + edges, pre-layout. */
@@ -320,6 +331,14 @@ export function buildNetworkGraph(
     // it, so a stack reads as one colored cluster. ADDITIVE over the shape/label
     // treatments — never the only signal.
     const color = stackColor(bucket.origin);
+    // MC-D3 (#1290) — federation provenance for this stack's edges. A
+    // CROSS-PRINCIPAL `foreign` peer's hub→agent edges draw dashed + flowing
+    // (admitted-peer bus relationship); the LOCAL hub and a same-principal
+    // SIBLING (DB-read aggregation) draw solid. Same `classifyOrigin` the node
+    // cards use, so edge + node agree on what "federated" means.
+    const federated = !isLocalCategory(
+      classifyOrigin(bucket.origin, servingPrincipal),
+    );
     nodes.push({
       id: bucket.hubId,
       type: "stackHub",
@@ -357,7 +376,7 @@ export function buildNetworkGraph(
         id: `hub-${a.key}`,
         source: bucket.hubId,
         target: a.key,
-        data: { stackColor: color },
+        data: { stackColor: color, federated },
       });
     }
   }


### PR DESCRIPTION
## What

MC-D3 (the centerpiece of the constellation skin epic #1287, under #1274). Re-skins the existing **network graph canvas** (ELK + React Flow) into the glowing **constellation / star-map** from the mockup ([`docs/design-mc-constellation-ui.md`](../blob/main/docs/design-mc-constellation-ui.md) · [`docs/mockups/mc-constellation/`](../blob/main/docs/mockups/mc-constellation/)). It renders **inside D2's `.mc-skin` McShell** (the command bar + altitude rail already frame it).

**Re-skin, not rebuild:** the ELK/React-Flow engine, the adapter/layout, and the lazy `network-canvas-*` split chunk are untouched — this restyles the DOM and adds the on-canvas header. `bun run build:dashboard` still emits the `network-canvas-*` chunk (verified: `network-canvas-qyztsr86.js` + `network-canvas-rqm2ns9b.css`).

## What the canvas looks like now

- **Orb nodes** keyed to each stack's hue (the inline `--stack-color`), with the existing capability + state chips. **Liveness glow** (`mcOrbBreathe`) is gated on the agent's **real observed `online` state**; offline orbs dim + go static. *Truth, never theater.*
- **`● YOU ARE HERE`** anchor on the serving (local-origin) stack hub — only the serving stack (not a same-principal sibling, not a federated peer).
- **Federated edges** (cross-principal hub→agent) drawn **dashed + flowing** (D1's `.edge-live--fed` / `dashFlowFed`) and labelled **`● federated · admitted peer`**. The `federated` flag is derived in the **pure adapter** via the same `classifyOrigin` the node cards use, so edge + node agree.
- **On-canvas network header** `<NETWORK> · admin|member · N stacks` from `/api/networks`, reusing **MC-B1's `isAdminPosture`** so posture can't drift from the Pier queue / command bar.
- Atmospheric radial background; **all motion honours `prefers-reduced-motion`**.

## Sovereignty boundary (load-bearing)

A **federated peer renders AGGREGATE only** (presence, capabilities, state) with a **visible `federated · admitted peer` boundary** — and is **NOT drillable into sessions** (ADR-0007 + the MC-D2 *SESSION-is-local-only* rule). D3 adds **no** peer-session drill affordance:
- The header model exposes only `{networkId, posture, stackCount, confidentiality}` — no session field (asserted in tests).
- The detail panel already renders presence/lifecycle only and treats a foreign peer as "activity not local" (unchanged here).
- The boundary is made **legible**, not breached.

## Vocab gate

admin / member only (CONTEXT.md §"Network posture"); `check-carveouts` gates the deprecated label. ✅ PASS.

## Additive / scoped

Every rule is scoped under `.mc-skin` (the McShell wrapper) → zero blast radius on other tabs; the roster panel / Pier queue / filter bar are unchanged.

## Gates

- `bun test src/surface/mc` → **2090 pass / 0 fail**
- `bunx tsc --noEmit` → clean
- `bun run lint:errors` → clean
- `bash scripts/check-carveouts.sh` → PASS
- `bun run build:dashboard` → split chunk emitted

## Tests added

- `network-constellation-header.test.ts` — pure projection: posture (admin/member via `isAdminPosture`), distinct-present-stack tally, aggregate-only shape, vocab.
- `network-graph-adapter.test.ts` — federated edge-flag derivation (foreign=true; local/sibling=false; agrees with `classifyOrigin`).
- `constellation-canvas-render.test.tsx` — header render (admin/member, no session affordance) + you-are-here anchor (self-only).

Closes #1290. Refs #1287, #1274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)