### PR TITLE
chore: bump to v5.30.0 — MC Model-B catch-up + constellation skin

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.29.0"
+version: "5.30.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release cut capturing the MC catch-up wave: A1 networks-first-class + admitted-roster⋈presence, A3 encryption posture badge, B1 Pier queue, Q3 registry member-read, D1 design tokens, D2 shell chrome, D3 constellation canvas. Closes the visible payoff (chrome + new data + reskinned canvas); D4/D5 (posture indicators + live traffic) follow.