### PR TITLE
feat(surface): C-1276 — MC admission state + per-principal acceptance (MC-A2)

### DIFF
--- a/src/bus/agent-network/__tests__/admission-rows-member-provider.test.ts
+++ b/src/bus/agent-network/__tests__/admission-rows-member-provider.test.ts
@@ -1,0 +1,268 @@
+/**
+ * MC-A2 (cortex#1276) — tests for the LIVE member-posture admission-rows
+ * provider (`createMemberRosterAdmissionProvider`).
+ *
+ * Hermetic: a real `SU…` stack identity (so the PoP signature actually verifies)
+ * + a real Ed25519 registry keypair (so the DD-9 assertion verify is exercised
+ * end-to-end), driven over an injected `fetch`. The load-bearing properties:
+ *   - PoP-signs the member-read claim with the stack's OWN registered key;
+ *   - verifies the registry assertion before trusting a single member (DD-9);
+ *   - projects the admitted roster → `ADMITTED` rows, `scope: "complete"`;
+ *   - never throws — 401/403 → `unauthorized`, transport/unverifiable →
+ *     `unreachable`, no pinned key → `not_configured`.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { createUser } from "nkeys.js";
+import { createMemberRosterAdmissionProvider, type FetchLike } from "../admission-rows-member-provider";
+import {
+  materialFromSeedString,
+  type StackIdentityMaterial,
+} from "../../stack-provisioning";
+import { canonicalJSON, verifyEd25519 } from "../../../common/registry/signing";
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+/** A real stack identity (SU seed + base64 ed25519 pubkey) — PoP verifiable. */
+function stackMaterial(): StackIdentityMaterial {
+  const kp = createUser();
+  return materialFromSeedString(new TextDecoder().decode(kp.getSeed()));
+}
+
+/** A real Ed25519 registry keypair for signing DD-9 assertions. */
+async function registryKeypair(): Promise<{
+  privateKey: CryptoKey;
+  publicKeyB64: string;
+}> {
+  const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const raw = await crypto.subtle.exportKey("raw", kp.publicKey);
+  return { privateKey: kp.privateKey, publicKeyB64: bytesToBase64(new Uint8Array(raw)) };
+}
+
+/** Wrap a payload in a registry `SignedAssertion` the provider verifies (DD-9). */
+async function signAssertion(
+  privateKey: CryptoKey,
+  registryPubkey: string,
+  payload: unknown,
+): Promise<unknown> {
+  const issued_at = new Date().toISOString();
+  const bound = canonicalJSON({ payload, issued_at, registry: registryPubkey });
+  const sig = await crypto.subtle.sign(
+    { name: "Ed25519" },
+    privateKey,
+    new TextEncoder().encode(bound),
+  );
+  return {
+    payload,
+    issued_at,
+    registry: registryPubkey,
+    signature: bytesToBase64(new Uint8Array(sig)),
+  };
+}
+
+/** A `FetchLike` returning a fixed status + json body, capturing the request. */
+function fakeFetch(
+  status: number,
+  body: unknown,
+  capture?: (url: string, headers?: Record<string, string>) => void,
+): FetchLike {
+  return (url, init) => {
+    capture?.(url, init?.headers);
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    });
+  };
+}
+
+describe("createMemberRosterAdmissionProvider — happy path", () => {
+  it("PoP-signs the claim, verifies the assertion, and projects ADMITTED rows (scope=complete)", async () => {
+    const material = stackMaterial();
+    const reg = await registryKeypair();
+    const roster = {
+      network_id: "research-collab",
+      members: [
+        { principal_id: "andreas", principal_pubkey: "x", capabilities: [] },
+        { principal_id: "jc", principal_pubkey: "y", capabilities: ["code-review.typescript"] },
+      ],
+    };
+    const assertion = await signAssertion(reg.privateKey, reg.publicKeyB64, roster);
+
+    let seenUrl = "";
+    let seenHeader: string | undefined;
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example/",
+      registryPubkey: reg.publicKeyB64,
+      material,
+      fetchImpl: fakeFetch(200, assertion, (url, headers) => {
+        seenUrl = url;
+        seenHeader = headers?.["x-pop-signed"];
+      }),
+    });
+
+    const res = await provider.readAdmissionRows("research-collab");
+
+    // Hit the member endpoint (not the public /roster).
+    expect(seenUrl).toBe("https://registry.example/networks/research-collab/roster/member");
+
+    // The PoP header carries a claim for THIS network + this stack's pubkey, and
+    // the signature actually verifies against that pubkey (the authorization).
+    expect(seenHeader).toBeDefined();
+    const parsed = JSON.parse(seenHeader!) as {
+      claim: { network_id: string; peer_pubkey: string; issued_at: string };
+      signature: string;
+    };
+    expect(parsed.claim.network_id).toBe("research-collab");
+    expect(parsed.claim.peer_pubkey).toBe(material.pubkeyB64);
+    const popValid = await verifyEd25519(
+      parsed.claim.peer_pubkey,
+      parsed.signature,
+      new TextEncoder().encode(canonicalJSON(parsed.claim)),
+    );
+    expect(popValid).toBe(true);
+
+    // Projection: every roster member → an ADMITTED row, complete scope.
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.scope).toBe("complete");
+    expect(res.rows).toEqual([
+      { principal_id: "andreas", network_id: "research-collab", status: "ADMITTED" },
+      { principal_id: "jc", network_id: "research-collab", status: "ADMITTED" },
+    ]);
+  });
+
+  it("returns an empty (but complete) roster when the network has no admitted members", async () => {
+    const reg = await registryKeypair();
+    const assertion = await signAssertion(reg.privateKey, reg.publicKeyB64, {
+      network_id: "research-collab",
+      members: [],
+    });
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: fakeFetch(200, assertion),
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res).toEqual({ ok: true, rows: [], scope: "complete" });
+  });
+});
+
+describe("createMemberRosterAdmissionProvider — failure mapping (never throws)", () => {
+  it("no pinned registry pubkey → not_configured (never trust an unverifiable roster)", async () => {
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      material: stackMaterial(),
+      fetchImpl: fakeFetch(200, {}),
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("not_configured");
+  });
+
+  it("HTTP 403 (not a member) → unauthorized, a distinct real state", async () => {
+    const reg = await registryKeypair();
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: fakeFetch(403, { error: "not_a_member" }),
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("unauthorized");
+  });
+
+  it("HTTP 401 (bad signature) → unauthorized", async () => {
+    const reg = await registryKeypair();
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: fakeFetch(401, { error: "signature_invalid" }),
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("unauthorized");
+  });
+
+  it("HTTP 500 / other → unreachable", async () => {
+    const reg = await registryKeypair();
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: fakeFetch(500, { error: "boom" }),
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("unreachable");
+  });
+
+  it("transport throw → unreachable (never propagates)", async () => {
+    const reg = await registryKeypair();
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: () => Promise.reject(new Error("network down")),
+      logError: () => {},
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("unreachable");
+  });
+
+  it("assertion signed by the WRONG registry key → unreachable (DD-9 reject, payload NOT trusted)", async () => {
+    const realReg = await registryKeypair();
+    const attacker = await registryKeypair();
+    // Attacker signs a roster, but the provider pins the REAL registry pubkey.
+    const forged = await signAssertion(attacker.privateKey, attacker.publicKeyB64, {
+      network_id: "research-collab",
+      members: [{ principal_id: "mallory", principal_pubkey: "z", capabilities: [] }],
+    });
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: realReg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: fakeFetch(200, forged),
+      logError: () => {},
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("unreachable");
+  });
+
+  it("verified-but-wrong-network payload → unreachable (shape gate)", async () => {
+    const reg = await registryKeypair();
+    const assertion = await signAssertion(reg.privateKey, reg.publicKeyB64, {
+      network_id: "OTHER-network",
+      members: [],
+    });
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: fakeFetch(200, assertion),
+      logError: () => {},
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("unreachable");
+  });
+});

--- a/src/bus/agent-network/__tests__/admission-rows-member-provider.test.ts
+++ b/src/bus/agent-network/__tests__/admission-rows-member-provider.test.ts
@@ -226,6 +226,32 @@ describe("createMemberRosterAdmissionProvider — failure mapping (never throws)
     expect(res.reason).toBe("unreachable");
   });
 
+  it("a hung read aborts on the timeout signal → unreachable (never stalls /api/networks)", async () => {
+    const reg = await registryKeypair();
+    // A fetch that rejects with an AbortError when the wired signal fires.
+    const hangingFetch: FetchLike = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: hangingFetch,
+      requestTimeoutMs: 10,
+      logError: () => {},
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toBe("unreachable");
+    expect(res.detail).toContain("timed out");
+  });
+
   it("assertion signed by the WRONG registry key → unreachable (DD-9 reject, payload NOT trusted)", async () => {
     const realReg = await registryKeypair();
     const attacker = await registryKeypair();

--- a/src/bus/agent-network/__tests__/peer-acceptance.test.ts
+++ b/src/bus/agent-network/__tests__/peer-acceptance.test.ts
@@ -1,0 +1,121 @@
+/**
+ * MC-A2 (cortex#1276) — tests for per-principal acceptance (the second trust
+ * layer: admission grants membership, accept-policy chooses whom to trust).
+ *
+ * Drives `summarizeAcceptancePolicy` + `resolvePeerAcceptance` over plain
+ * offering literals — no I/O, no config-load. The load-bearing property:
+ * acceptance is DEFAULT-DENY (no offering ⇒ accept nobody), `{kind:'network'}`
+ * trusts the whole roster, `{kind:'principals'}` trusts only named peers, and
+ * the serving principal is always `self`.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  summarizeAcceptancePolicy,
+  resolvePeerAcceptance,
+  type PeerAcceptance,
+} from "../peer-acceptance";
+import type { Offering } from "../../../common/types/offering";
+
+function resolve(
+  offerings: Offering[] | undefined,
+  networkId: string,
+  member: string,
+  local = "andreas",
+): PeerAcceptance {
+  return resolvePeerAcceptance(
+    summarizeAcceptancePolicy(offerings),
+    networkId,
+    member,
+    local,
+  );
+}
+
+describe("resolvePeerAcceptance", () => {
+  it("the serving principal is always self", () => {
+    expect(resolve(undefined, "research-collab", "andreas")).toBe("self");
+  });
+
+  it("default-deny — no offerings ⇒ a peer is not-accepted", () => {
+    expect(resolve(undefined, "research-collab", "jc")).toBe("not-accepted");
+    expect(resolve([], "research-collab", "jc")).toBe("not-accepted");
+  });
+
+  it("{kind:'network'} trusts the WHOLE roster of that network", () => {
+    const offerings: Offering[] = [
+      {
+        capability: "code-review.typescript",
+        scopes: ["federated"],
+        accept: { kind: "network", network: "research-collab" },
+      },
+    ];
+    expect(resolve(offerings, "research-collab", "jc")).toBe("accepted-network");
+    expect(resolve(offerings, "research-collab", "anyone")).toBe("accepted-network");
+    // ...but NOT a peer on a DIFFERENT network.
+    expect(resolve(offerings, "other-net", "jc")).toBe("not-accepted");
+  });
+
+  it("{kind:'principals'} trusts only the NAMED peers", () => {
+    const offerings: Offering[] = [
+      {
+        capability: "code-review.typescript",
+        scopes: ["federated"],
+        accept: { kind: "principals", principals: ["jc", "zeta"] },
+      },
+    ];
+    expect(resolve(offerings, "research-collab", "jc")).toBe("accepted-named");
+    expect(resolve(offerings, "research-collab", "zeta")).toBe("accepted-named");
+    expect(resolve(offerings, "research-collab", "mallory")).toBe("not-accepted");
+  });
+
+  it("whole-roster acceptance takes precedence over a named match", () => {
+    const offerings: Offering[] = [
+      {
+        capability: "a.b",
+        scopes: ["federated"],
+        accept: { kind: "network", network: "research-collab" },
+      },
+      {
+        capability: "c.d",
+        scopes: ["federated"],
+        accept: { kind: "principals", principals: ["jc"] },
+      },
+    ];
+    expect(resolve(offerings, "research-collab", "jc")).toBe("accepted-network");
+  });
+
+  it("public {kind:'surface'} offerings never accept a bus peer", () => {
+    const offerings: Offering[] = [
+      {
+        capability: "code-review.typescript",
+        scopes: ["public"],
+        accept: {
+          kind: "surface",
+          surface: "github",
+          predicate: { kind: "repo-membership", repos: ["the-metafactory/*"] },
+        },
+      },
+    ];
+    expect(resolve(offerings, "research-collab", "jc")).toBe("not-accepted");
+  });
+});
+
+describe("summarizeAcceptancePolicy", () => {
+  it("collects network-wide ids and named principals across offerings", () => {
+    const summary = summarizeAcceptancePolicy([
+      {
+        capability: "a.b",
+        scopes: ["federated"],
+        accept: { kind: "network", network: "net-1" },
+      },
+      {
+        capability: "c.d",
+        scopes: ["federated"],
+        accept: { kind: "principals", principals: ["jc", "zeta"] },
+      },
+      { capability: "e.f", scopes: ["local"] },
+    ]);
+    expect([...summary.networkWide].sort()).toEqual(["net-1"]);
+    expect([...summary.namedPrincipals].sort()).toEqual(["jc", "zeta"]);
+  });
+});

--- a/src/bus/agent-network/admission-rows-member-provider.ts
+++ b/src/bus/agent-network/admission-rows-member-provider.ts
@@ -1,0 +1,283 @@
+/**
+ * MC-A2 (cortex#1276) — the **live** {@link AdmissionRowsProvider}: the
+ * member-posture admission-rows read that replaces A1's `not_configured` stub.
+ *
+ * ## What it reads
+ *
+ * The registry's PoP-signed member roster endpoint, `GET
+ * /networks/{network_id}/roster/member` (C-1282 / ADR-0018 Q4, DEPLOYED #1284).
+ * That route releases the network's **ADMITTED** peer-roster to any caller who
+ * proves possession of an ADMITTED member key for THAT network — the PoP
+ * signature IS the authorization (no admin key, no allowlist). It is the
+ * member-accessible sibling of the admin-gated full list, and the Q3-correct
+ * source of truth for membership (ADMITTED admission rows, NOT capabilities).
+ *
+ * Because the endpoint serves the COMPLETE admitted roster (the same payload the
+ * public `/roster` returns, ADR-0018 Q4), this provider returns
+ * `scope: "complete"` — the membership verdict is authoritative. PENDING rows
+ * are NOT in this payload (a member sees admitted peers, never the onboarding
+ * queue); a network where THIS stack holds admin credentials and wants the
+ * PENDING queue is the admin-posture path (the same `AdmissionRowsProvider`
+ * seam, fed by the admin list) and is out of scope here — pending stays `[]`.
+ *
+ * ## PoP signing — reuse, mint nothing
+ *
+ * The claim `{ network_id, peer_pubkey, issued_at }` is signed with the stack's
+ * OWN registered signing key (the `SU…` nkey from `stack.nkey_seed_path`, whose
+ * base64 ed25519 pubkey is the registry `peer_pubkey`). Signing reuses
+ * {@link signClaimWithSeed} + {@link canonicalJSON} — the SAME plumbing
+ * `fetchSealedLeafSecret` uses for the `/admission-requests/mine` PoP read. No
+ * key is minted; the running stack already holds this seed.
+ *
+ * ## DD-9 — verify the registry assertion
+ *
+ * The endpoint wraps the roster in a registry-`SignedAssertion`. We verify it
+ * against the pinned registry pubkey ({@link verifySignedAssertion}) before
+ * trusting a single principal id — a spoofed/compromised registry otherwise
+ * injects arbitrary roster members. No pinned pubkey ⇒ we cannot verify ⇒
+ * honest `not_configured` (never trust an unverifiable roster).
+ *
+ * ## Never 5xx, fail-soft (mirror A1's DD-10)
+ *
+ * Every failure is a typed `{ ok: false }` — the never-throw contract the A1
+ * seam + the `/api/networks` handler rely on. Auth-class failures (401/403)
+ * surface as `unauthorized` (a real, distinct state the pane shows honestly,
+ * never masked); transport / not-found / unverifiable failures surface as
+ * `unreachable`. The handler degrades either to a self-only membership rather
+ * than erroring. We deliberately do NOT mask a failure with a stale cached
+ * roster: on a TRUST pane, a silently-stale roster is more misleading than an
+ * honest "registry unreachable" chip (the constraint's blessed alternative).
+ */
+
+import { canonicalJSON } from "../../common/registry/signing";
+import { verifySignedAssertion } from "../../common/registry/verify-assertion";
+import {
+  signClaimWithSeed,
+  type StackIdentityMaterial,
+} from "../stack-provisioning";
+import type {
+  AdmissionRow,
+  AdmissionRowsProvider,
+  AdmissionRowsResult,
+} from "./admission-read";
+
+/**
+ * Injectable `fetch`, narrowed to what this provider needs. Production omits it
+ * → `globalThis.fetch`; tests inject a hermetic stub. Mirrors `fetch-sealed-secret`.
+ */
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+/** Construction inputs for {@link createMemberRosterAdmissionProvider}. */
+export interface MemberRosterAdmissionProviderOptions {
+  /** Registry base URL (`policy.federated.registry.url`). Trailing slashes trimmed. */
+  registryUrl: string;
+  /**
+   * Pinned registry pubkey (base64 Ed25519) for the DD-9 assertion verify
+   * (`policy.federated.registry.pubkey`). When absent/empty the provider cannot
+   * verify and returns `not_configured` — it NEVER trusts an unverifiable roster.
+   */
+  registryPubkey?: string;
+  /**
+   * The stack's identity material — its registered `SU…` seed + base64 pubkey.
+   * The pubkey is the registry `peer_pubkey`; the seed signs the PoP claim.
+   * SECRET (the seed) — never logged.
+   */
+  material: StackIdentityMaterial;
+  /** Per-request timeout (ms). Default 10s. */
+  requestTimeoutMs?: number;
+  /** Injected transport (tests). Production omits → `globalThis.fetch`. */
+  fetchImpl?: FetchLike;
+  /** Injected clock (tests). Production omits → `Date`. */
+  now?: () => Date;
+  /** Logger seam (CLAUDE.md "no silent catches"). Default → `process.stderr`. */
+  logError?: (msg: string) => void;
+}
+
+/** The minimal verified-roster shape the member endpoint returns (admission-sourced). */
+interface VerifiedRosterPayload {
+  network_id: string;
+  members: { principal_id: string }[];
+}
+
+/**
+ * Parse a DD-9-verified payload as the member roster — `{ network_id,
+ * members: [{ principal_id }] }`. A verified-but-wrong-shape payload is a
+ * wire-contract violation, not a value to trust → `undefined` (caller maps to
+ * `unreachable`). Mirrors `network-client`'s `parseRoster` discipline.
+ */
+function parseVerifiedRoster(
+  payload: unknown,
+  networkId: string,
+): VerifiedRosterPayload | undefined {
+  if (payload === null || typeof payload !== "object") return undefined;
+  const p = payload as Record<string, unknown>;
+  if (p.network_id !== networkId) return undefined;
+  if (!Array.isArray(p.members)) return undefined;
+  const members: { principal_id: string }[] = [];
+  for (const raw of p.members) {
+    if (raw === null || typeof raw !== "object") return undefined;
+    const m = raw as Record<string, unknown>;
+    if (typeof m.principal_id !== "string" || m.principal_id.length === 0) {
+      return undefined;
+    }
+    members.push({ principal_id: m.principal_id });
+  }
+  return { network_id: networkId, members };
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Build the live member-posture {@link AdmissionRowsProvider}. The returned
+ * provider PoP-signs + reads `GET /networks/{id}/roster/member`, verifies the
+ * registry assertion (DD-9), and projects the admitted roster into
+ * `AdmissionRow[]` (every member `status: "ADMITTED"`, `scope: "complete"`).
+ * Never throws.
+ */
+export function createMemberRosterAdmissionProvider(
+  options: MemberRosterAdmissionProviderOptions,
+): AdmissionRowsProvider {
+  const url = options.registryUrl.replace(/\/+$/, "");
+  const pinnedPubkey = options.registryPubkey;
+  const material = options.material;
+  const fetchImpl: FetchLike = options.fetchImpl ?? (globalThis.fetch as FetchLike);
+  const now = options.now ?? (() => new Date());
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const logError =
+    options.logError ??
+    ((msg: string) => {
+      process.stderr.write(`admission-rows-member-provider: ${msg}\n`);
+    });
+
+  async function readAdmissionRows(
+    networkId: string,
+  ): Promise<AdmissionRowsResult> {
+    // DD-9: no pinned pubkey ⇒ cannot verify ⇒ never trust the roster.
+    if (pinnedPubkey === undefined || pinnedPubkey === "") {
+      return {
+        ok: false,
+        reason: "not_configured",
+        detail:
+          "no pinned registry pubkey (policy.federated.registry.pubkey) — cannot verify the member roster assertion (DD-9)",
+      };
+    }
+
+    // 1. Sign the PoP read claim with the stack's OWN registered seed.
+    const claim = {
+      network_id: networkId,
+      peer_pubkey: material.pubkeyB64,
+      issued_at: now().toISOString(),
+    };
+    let header: string;
+    try {
+      const sig = await signClaimWithSeed(
+        material.seed,
+        new TextEncoder().encode(canonicalJSON(claim)),
+      );
+      header = JSON.stringify({ claim, signature: sig });
+    } catch (err) {
+      logError(
+        `failed to sign PoP read claim for "${networkId}": ${errText(err)}`,
+      );
+      return {
+        ok: false,
+        reason: "unreachable",
+        detail: `failed to sign PoP read claim: ${errText(err)}`,
+      };
+    }
+
+    // 2. GET the member roster endpoint (PoP header is the authorization).
+    const endpoint = `${url}/networks/${encodeURIComponent(networkId)}/roster/member`;
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => {
+      controller.abort();
+    }, requestTimeoutMs);
+    let resp: Awaited<ReturnType<FetchLike>>;
+    try {
+      resp = await fetchImpl(endpoint, {
+        method: "GET",
+        headers: { "Content-Type": "application/json", "x-pop-signed": header },
+      });
+    } catch (err) {
+      const reason =
+        err instanceof Error && err.name === "AbortError"
+          ? `timed out after ${requestTimeoutMs.toString()}ms`
+          : errText(err);
+      logError(`GET ${endpoint} failed: ${reason}`);
+      return { ok: false, reason: "unreachable", detail: `member roster read errored: ${reason}` };
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+
+    // 3. Map the HTTP status. 401/403 are a REAL authorization state (not this
+    //    stack's key, or not an admitted member) — surfaced as `unauthorized`,
+    //    distinct from transport `unreachable`. Everything else degrades to
+    //    `unreachable` so the network still renders self-only.
+    if (resp.status === 401 || resp.status === 403) {
+      return {
+        ok: false,
+        reason: "unauthorized",
+        detail: `registry refused the member roster read (HTTP ${resp.status.toString()}) — this stack is not an admitted member of "${networkId}"`,
+      };
+    }
+    if (!resp.ok) {
+      logError(`GET ${endpoint} returned HTTP ${resp.status.toString()}`);
+      return {
+        ok: false,
+        reason: "unreachable",
+        detail: `member roster read failed (HTTP ${resp.status.toString()})`,
+      };
+    }
+
+    // 4. Parse + DD-9 verify the registry assertion before trusting any member.
+    let rawBody: unknown;
+    try {
+      rawBody = await resp.json();
+    } catch (err) {
+      logError(`GET ${endpoint} JSON parse failed: ${errText(err)}`);
+      return { ok: false, reason: "unreachable", detail: "member roster response was not JSON" };
+    }
+    const verified = await verifySignedAssertion(rawBody, pinnedPubkey);
+    if (verified.kind !== "ok") {
+      logError(
+        `member roster assertion did not verify for "${networkId}" (${verified.kind}); rejecting (DD-9)`,
+      );
+      return {
+        ok: false,
+        reason: "unreachable",
+        detail: `member roster assertion failed DD-9 verification (${verified.kind})`,
+      };
+    }
+
+    // 5. Shape-validate + project ADMITTED members → AdmissionRow[].
+    const roster = parseVerifiedRoster(verified.payload, networkId);
+    if (roster === undefined) {
+      logError(`member roster payload shape invalid for "${networkId}"; rejecting`);
+      return {
+        ok: false,
+        reason: "unreachable",
+        detail: "member roster payload was not a valid roster shape",
+      };
+    }
+    const rows: AdmissionRow[] = roster.members.map((m) => ({
+      principal_id: m.principal_id,
+      network_id: networkId,
+      status: "ADMITTED" as const,
+    }));
+    return { ok: true, rows, scope: "complete" };
+  }
+
+  return { readAdmissionRows };
+}
+
+/** Error → message, never echoing secret-bearing inputs. */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/bus/agent-network/admission-rows-member-provider.ts
+++ b/src/bus/agent-network/admission-rows-member-provider.ts
@@ -67,7 +67,11 @@ import type {
  */
 export type FetchLike = (
   url: string,
-  init?: { method?: string; headers?: Record<string, string> },
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  },
 ) => Promise<{
   ok: boolean;
   status: number;
@@ -204,6 +208,7 @@ export function createMemberRosterAdmissionProvider(
       resp = await fetchImpl(endpoint, {
         method: "GET",
         headers: { "Content-Type": "application/json", "x-pop-signed": header },
+        signal: controller.signal,
       });
     } catch (err) {
       const reason =

--- a/src/bus/agent-network/admission-rows-member-provider.ts
+++ b/src/bus/agent-network/admission-rows-member-provider.ts
@@ -147,7 +147,7 @@ export function createMemberRosterAdmissionProvider(
   const url = options.registryUrl.replace(/\/+$/, "");
   const pinnedPubkey = options.registryPubkey;
   const material = options.material;
-  const fetchImpl: FetchLike = options.fetchImpl ?? (globalThis.fetch as FetchLike);
+  const fetchImpl: FetchLike = options.fetchImpl ?? globalThis.fetch;
   const now = options.now ?? (() => new Date());
   const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const logError =

--- a/src/bus/agent-network/peer-acceptance.ts
+++ b/src/bus/agent-network/peer-acceptance.ts
@@ -1,0 +1,108 @@
+/**
+ * MC-A2 (cortex#1276) — per-principal **acceptance** resolution for the MC
+ * Network view.
+ *
+ * ## Two-layer trust (CONTEXT.md §"Joining a network")
+ *
+ * Membership is **two-layered**, and this module is the SECOND layer:
+ *
+ *   1. **Network membership** — the admin curates the roster (who is ADMITTED).
+ *      That is the admission-rows layer (`admission-read.ts` / the live
+ *      member-roster provider).
+ *   2. **Per-principal acceptance** — even for an admitted peer, THIS principal
+ *      independently chooses whom to accept. "Trust is **granted** (admission)
+ *      *and* **chosen** (accept-policy), never *minted*."
+ *
+ * The acceptance choice is expressed by this stack's **capability offerings**
+ * (`policy.offerings[]`, the CO-1 model): a federated offering names WHO may
+ * dispatch it via its accept-policy —
+ *   - `{kind:'network', network:<id>}`  → trust the WHOLE roster of `<id>`;
+ *   - `{kind:'principals', principals}` → trust only the NAMED principals.
+ * (The same `network:<id>` vs `principals:[…]` accept grammar CONTEXT.md §190
+ * describes.) A peer this stack offers NOTHING federated to is **not accepted**
+ * — default-deny: an admitted peer you don't accept can sit on the roster while
+ * you dispatch it no work.
+ *
+ * This module distils the offerings ONCE into a {@link AcceptancePolicySummary}
+ * and answers, per (network, member), the {@link PeerAcceptance} verdict. Pure:
+ * no I/O, no bus, no config-load — the surface depends only on the result type.
+ */
+
+import type { Offering } from "../../common/types/offering";
+
+/**
+ * Whether — and HOW — this principal accepts a given peer (the second trust
+ * layer). Distinct from the membership verdict (admitted/pending/anomaly).
+ *
+ *   - `self`             — the serving principal itself (always "accepted").
+ *   - `accepted-network` — accepted because a federated offering trusts the
+ *                          WHOLE roster of this network (`{kind:'network'}`).
+ *   - `accepted-named`   — accepted because a federated offering names this
+ *                          principal explicitly (`{kind:'principals'}`).
+ *   - `not-accepted`     — no federated offering admits this peer (default-deny).
+ */
+export type PeerAcceptance =
+  | "self"
+  | "accepted-network"
+  | "accepted-named"
+  | "not-accepted";
+
+/**
+ * The distilled accept-policy of this stack's offerings — computed once, queried
+ * per member.
+ */
+export interface AcceptancePolicySummary {
+  /** Network ids this stack trusts WHOLE-ROSTER (a `{kind:'network'}` offering). */
+  networkWide: ReadonlySet<string>;
+  /** Principals named in any `{kind:'principals'}` federated offering. */
+  namedPrincipals: ReadonlySet<string>;
+}
+
+/**
+ * Distil `policy.offerings[]` into an {@link AcceptancePolicySummary}.
+ *
+ * Only the federated accept-policies matter for peer acceptance: `{kind:'network'}`
+ * contributes its `network` to `networkWide`; `{kind:'principals'}` contributes
+ * its names to `namedPrincipals`. Public (`{kind:'surface'}`) offerings admit
+ * surface requesters (no bus identity), never bus peers, so they are ignored
+ * here. `undefined`/empty offerings ⇒ accept nobody federated (default-deny).
+ */
+export function summarizeAcceptancePolicy(
+  offerings: readonly Offering[] | undefined,
+): AcceptancePolicySummary {
+  const networkWide = new Set<string>();
+  const namedPrincipals = new Set<string>();
+  for (const o of offerings ?? []) {
+    const accept = o.accept;
+    if (accept === undefined) continue;
+    if (accept.kind === "network") {
+      networkWide.add(accept.network);
+    } else if (accept.kind === "principals") {
+      for (const p of accept.principals) namedPrincipals.add(p);
+    }
+    // `{kind:'surface'}` (public) admits surface requesters, not bus peers — skip.
+  }
+  return { networkWide, namedPrincipals };
+}
+
+/**
+ * Resolve whether THIS principal accepts `memberPrincipal` on `networkId`.
+ *
+ * Precedence: self → whole-roster (network) → named principal → default-deny.
+ * The serving principal is always `self`; a whole-roster offering for the
+ * network accepts every member on it; otherwise an explicit name wins; else
+ * `not-accepted`.
+ *
+ * Pure + total.
+ */
+export function resolvePeerAcceptance(
+  summary: AcceptancePolicySummary,
+  networkId: string,
+  memberPrincipal: string,
+  localPrincipal: string,
+): PeerAcceptance {
+  if (memberPrincipal === localPrincipal) return "self";
+  if (summary.networkWide.has(networkId)) return "accepted-network";
+  if (summary.namedPrincipals.has(memberPrincipal)) return "accepted-named";
+  return "not-accepted";
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -5651,15 +5651,31 @@ export async function startCortex(
           }
         }
 
-        // The LIVE provider — or a `not_configured` provider when we lack the
-        // registry URL or the signing material to read + verify a roster.
-        const admissionProvider: AdmissionRowsProvider =
-          registry !== undefined && stackMaterial !== undefined
-            ? createMemberRosterAdmissionProvider({
-                registryUrl: registry.url,
+        // Resolve the registry pubkey through the SHARED anchor — exactly as the
+        // federated-verify seam (line ~3398) + the join path do. This is what
+        // pins the DEFAULT metafactory registry's compiled-in pubkey when config
+        // carries no explicit `registry.pubkey`; without it the live read would
+        // ship DARK (no pin ⇒ DD-9 fail-closed ⇒ not_configured) on the common
+        // production posture. A custom registry with no pin resolves to TOFU
+        // (no pubkey) — the provider then honestly stays not_configured (it does
+        // not TOFU a roster it cannot verify).
+        const resolvedRegistry =
+          registry !== undefined
+            ? resolveRegistryAnchor({
+                configUrl: registry.url,
                 ...(registry.pubkey !== undefined && {
-                  registryPubkey: registry.pubkey,
+                  configPubkey: registry.pubkey,
                 }),
+              })
+            : undefined;
+
+        // The LIVE provider — or a `not_configured` provider when we lack a
+        // pinned registry pubkey or the signing material to read + verify.
+        const admissionProvider: AdmissionRowsProvider =
+          resolvedRegistry?.pubkey !== undefined && stackMaterial !== undefined
+            ? createMemberRosterAdmissionProvider({
+                registryUrl: resolvedRegistry.url,
+                registryPubkey: resolvedRegistry.pubkey,
                 material: stackMaterial,
               })
             : {
@@ -5670,7 +5686,9 @@ export async function startCortex(
                     detail:
                       registry === undefined
                         ? "no federated registry configured (policy.federated.registry) — cannot read the admitted roster"
-                        : "no stack signing identity (stack.nkey_seed_path) — cannot PoP-sign the member roster read",
+                        : resolvedRegistry?.pubkey === undefined
+                          ? "no pinned registry pubkey (config pin / default-registry anchor / TOFU unavailable) — cannot DD-9-verify the member roster"
+                          : "no stack signing identity (stack.nkey_seed_path) — cannot PoP-sign the member roster read",
                   }),
               };
 
@@ -5702,7 +5720,8 @@ export async function startCortex(
               principalId,
             ),
         };
-        const live = registry !== undefined && stackMaterial !== undefined;
+        const live =
+          resolvedRegistry?.pubkey !== undefined && stackMaterial !== undefined;
         console.log(
           `cortex: MC /api/networks view wired — ${networksList.length.toString()} joined network(s) ` +
             `as first-class trust groups (admission roster: ${live ? "LIVE member-read (A2)" : "not_configured — self-only"}; ` +

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -177,6 +177,14 @@ import {
   type AdmissionRowsProvider,
   type AdmissionRowsResult,
 } from "./bus/agent-network/admission-read";
+// MC-A2 (cortex#1276) — the LIVE member-posture admission-rows provider +
+// per-principal acceptance resolution (the second trust layer).
+import { createMemberRosterAdmissionProvider } from "./bus/agent-network/admission-rows-member-provider";
+import {
+  summarizeAcceptancePolicy,
+  resolvePeerAcceptance,
+} from "./bus/agent-network/peer-acceptance";
+import { materialFromSeedString } from "./bus/stack-provisioning";
 // MC-A3 (cortex#1277, ADR-0019/0018) — derive each joined network's read-only
 // confidentiality posture from config for the `/api/networks` view.
 import { confidentialityPosture } from "./common/crypto/network-encryption-policy";
@@ -5595,38 +5603,83 @@ export async function startCortex(
         }
       }
 
-      // MC-A1 (cortex#1275) — wire the `/api/networks` view: surface the joined
-      // networks as first-class trust groups with their admitted roster ⋈
-      // presence → membership verdict. Membership is sourced from the ADMISSION
-      // ROWS (ADR-0018 Q3), NOT the capability-derived `GET /networks/{id}/roster`
-      // (`resolveNetworkRoster`) — conflating capability with membership is the
-      // bug Q3 forbids.
+      // MC-A1 (cortex#1275) / MC-A2 (cortex#1276) — wire the `/api/networks`
+      // view: surface the joined networks as first-class trust groups with their
+      // admitted roster ⋈ presence → membership verdict, PLUS each member's
+      // per-principal acceptance (the second trust layer). Membership is sourced
+      // from the ADMISSION ROWS (ADR-0018 Q3), NOT the capability-derived
+      // `GET /networks/{id}/roster` (`resolveNetworkRoster`) — conflating
+      // capability with membership is the bug Q3 forbids.
       //
-      // ESCALATION / FOLLOW-UP (A2 #1276): the LIVE admission-rows provider is
-      // not wired here. A non-admin member can read only its OWN admission rows
-      // today (signed PoP `GET /admission-requests/mine`, scope `self`); the FULL
-      // admitted roster is admin-gated, and a Q3-correct member-accessible PEER
-      // roster read is a registry-side prerequisite (registry `members[]` is
-      // still capability-derived — see `NetworkRoster` in the registry's
-      // types.ts). So A1 wires the seam + a `not_configured` provider: the view
-      // surfaces each joined network + the serving principal's own membership,
-      // with `roster_status: "not_configured"` until A2 drops in the real
-      // admission-rows provider. The model, reconciliation, endpoint, and
-      // frontend are all in place behind this single seam.
+      // A2 drops in the LIVE admission-rows provider: the PoP-signed member
+      // roster read `GET /networks/:id/roster/member` (C-1282 / ADR-0018 Q4,
+      // DEPLOYED #1284), signed with this stack's OWN registered key (the seed
+      // it already holds — mint nothing) and DD-9-verified against the pinned
+      // registry pubkey. It returns the COMPLETE admitted roster (scope
+      // `complete`), so membership verdicts are authoritative.
+      //
+      // POSTURE NOTE: the member read returns ADMITTED peers only — a member
+      // never sees a network's PENDING onboarding queue. PENDING enrichment for
+      // a network THIS stack ADMINS is the admin-list path (the SAME
+      // `AdmissionRowsProvider` seam, fed by the admin-gated list); it composes
+      // in once the daemon carries admin credentials (no admin-seed config in
+      // the stack today, so it would be dead code now — deliberately not built).
+      // The Pier queue (B1) already surfaces PENDING for admin-posture networks.
       const networksList = resolvedPolicy?.federated?.networks;
       if (networksList !== undefined && networksList.length > 0) {
-        // A1 seam — replaced by the self-PoP / admin-list admission-rows provider
-        // in A2. Returns `not_configured` so the endpoint degrades to self-only
-        // membership rather than building on the capability roster.
-        const admissionProvider: AdmissionRowsProvider = {
-          readAdmissionRows: (): Promise<AdmissionRowsResult> =>
-            Promise.resolve({
-              ok: false,
-              reason: "not_configured",
-              detail:
-                "live admission-rows read not wired (A1 seam) — pending A2 (#1276) + registry ADR-0018 Q3 roster fix",
-            }),
-        };
+        const registry = resolvedPolicy?.federated?.registry;
+
+        // Load this stack's registered identity material (pubkey + seed) to
+        // PoP-sign the member read. Reuses the chmod-600-gated signing-key
+        // loader; never mints a key. Non-fatal: a stack with no seed (or a load
+        // failure) leaves `material` undefined → the provider stays
+        // `not_configured` (honest self-only), never crashes the embed boot.
+        let stackMaterial: ReturnType<typeof materialFromSeedString> | undefined;
+        if (options.stack?.nkey_seed_path) {
+          try {
+            const kp = await loadStackSigningKey(
+              expandTilde(options.stack.nkey_seed_path),
+            );
+            stackMaterial = materialFromSeedString(
+              new TextDecoder().decode(kp.getSeed()),
+            );
+          } catch (err) {
+            console.error(
+              "cortex: MC /api/networks — could not load stack identity for the member roster read (non-fatal, self-only membership):",
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+        }
+
+        // The LIVE provider — or a `not_configured` provider when we lack the
+        // registry URL or the signing material to read + verify a roster.
+        const admissionProvider: AdmissionRowsProvider =
+          registry !== undefined && stackMaterial !== undefined
+            ? createMemberRosterAdmissionProvider({
+                registryUrl: registry.url,
+                ...(registry.pubkey !== undefined && {
+                  registryPubkey: registry.pubkey,
+                }),
+                material: stackMaterial,
+              })
+            : {
+                readAdmissionRows: (): Promise<AdmissionRowsResult> =>
+                  Promise.resolve({
+                    ok: false,
+                    reason: "not_configured",
+                    detail:
+                      registry === undefined
+                        ? "no federated registry configured (policy.federated.registry) — cannot read the admitted roster"
+                        : "no stack signing identity (stack.nkey_seed_path) — cannot PoP-sign the member roster read",
+                  }),
+              };
+
+        // The accept-policy summary (the second trust layer), distilled ONCE
+        // from this stack's offerings and queried per member.
+        const acceptanceSummary = summarizeAcceptancePolicy(
+          resolvedPolicy?.offerings,
+        );
+
         networksViewForApi = {
           localPrincipal: principalId,
           networks: () =>
@@ -5641,10 +5694,19 @@ export async function startCortex(
             })),
           resolveAdmittedRoster: (networkId) =>
             resolveAdmittedRoster(networkId, admissionProvider),
+          acceptsPeer: (networkId, memberPrincipal) =>
+            resolvePeerAcceptance(
+              acceptanceSummary,
+              networkId,
+              memberPrincipal,
+              principalId,
+            ),
         };
+        const live = registry !== undefined && stackMaterial !== undefined;
         console.log(
           `cortex: MC /api/networks view wired — ${networksList.length.toString()} joined network(s) ` +
-            "as first-class trust groups (admission-rows roster source pending A2 #1276)",
+            `as first-class trust groups (admission roster: ${live ? "LIVE member-read (A2)" : "not_configured — self-only"}; ` +
+            "per-principal acceptance from offerings)",
         );
       }
 

--- a/src/surface/mc/__tests__/networks-api.test.ts
+++ b/src/surface/mc/__tests__/networks-api.test.ts
@@ -20,6 +20,10 @@ import type {
   AgentPresenceView,
 } from "../api/agents";
 import type { ResolveAdmittedRosterResult } from "../../../bus/agent-network/admission-read";
+import {
+  summarizeAcceptancePolicy,
+  resolvePeerAcceptance,
+} from "../../../bus/agent-network/peer-acceptance";
 
 function presenceView(
   records: AgentPresenceSnapshotRecord[],
@@ -103,7 +107,12 @@ describe("handleListNetworks — graceful states", () => {
     const net = (await body(res)).networks[0]!;
     expect(net.roster_status).toBe("unreachable");
     expect(net.members).toEqual([
-      { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"] },
+      {
+        principal: "andreas",
+        verdict: "admitted-present",
+        present_stacks: ["main"],
+        accepts: "self",
+      },
     ]);
   });
 
@@ -125,7 +134,12 @@ describe("handleListNetworks — graceful states", () => {
     expect(net.roster_scope).toBeNull();
     // Self is still a member (joined stack) + present.
     expect(net.members).toEqual([
-      { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"] },
+      {
+        principal: "andreas",
+        verdict: "admitted-present",
+        present_stacks: ["main"],
+        accepts: "self",
+      },
     ]);
   });
 });
@@ -178,6 +192,7 @@ describe("handleListNetworks — authoritative reconciliation", () => {
       principal: "mallory",
       verdict: "present-but-unadmitted",
       present_stacks: ["s"],
+      accepts: "not-accepted",
     });
   });
 
@@ -196,6 +211,7 @@ describe("handleListNetworks — authoritative reconciliation", () => {
       principal: "newcomer",
       verdict: "pending",
       present_stacks: [],
+      accepts: "not-accepted",
     });
   });
 });
@@ -299,5 +315,62 @@ describe("handleListNetworks — self-scoped read suppresses anomalies (registry
     // jc is present but must NOT be flagged unadmitted — we can't prove it.
     expect(net.members.some((m) => m.verdict === "present-but-unadmitted")).toBe(false);
     expect(net.members.map((m) => m.principal)).toEqual(["andreas"]);
+  });
+});
+
+describe("handleListNetworks — per-principal acceptance (MC-A2, the second trust layer)", () => {
+  it("defaults to self/not-accepted when the view supplies no acceptsPeer resolver", async () => {
+    const res = await handleListNetworks(
+      view({
+        "research-collab": {
+          ok: true,
+          roster: { admitted: ["jc"], pending: [], authoritative: true },
+        },
+      }),
+      presenceView([rec({ agentId: "luna" })]),
+    );
+    const net = (await body(res)).networks[0]!;
+    const accepts = Object.fromEntries(net.members.map((m) => [m.principal, m.accepts]));
+    expect(accepts).toEqual({ andreas: "self", jc: "not-accepted" });
+  });
+
+  it("carries the live acceptance verdict per member (network-wide vs named vs deny)", async () => {
+    const summary = summarizeAcceptancePolicy([
+      {
+        capability: "a.b",
+        scopes: ["federated"],
+        accept: { kind: "network", network: "research-collab" },
+      },
+      {
+        capability: "c.d",
+        scopes: ["federated"],
+        accept: { kind: "principals", principals: ["zeta"] },
+      },
+    ]);
+    const v: NetworksView = {
+      localPrincipal: "andreas",
+      networks: () => [
+        { networkId: "research-collab", leafNode: "rc-leaf", confidentiality: CLEARTEXT },
+        { networkId: "other-net", leafNode: "on-leaf", confidentiality: CLEARTEXT },
+      ],
+      resolveAdmittedRoster: (networkId) =>
+        Promise.resolve(
+          networkId === "research-collab"
+            ? { ok: true, roster: { admitted: ["jc"], pending: [], authoritative: true } }
+            : { ok: true, roster: { admitted: ["zeta"], pending: [], authoritative: true } },
+        ),
+      acceptsPeer: (networkId, member) =>
+        resolvePeerAcceptance(summary, networkId, member, "andreas"),
+    };
+    const out = await handleListNetworks(v, presenceView([rec({ agentId: "luna" })]));
+    const nets = (await body(out)).networks;
+    const rc = nets.find((n) => n.network_id === "research-collab")!;
+    const other = nets.find((n) => n.network_id === "other-net")!;
+    const rcAccepts = Object.fromEntries(rc.members.map((m) => [m.principal, m.accepts]));
+    const otherAccepts = Object.fromEntries(other.members.map((m) => [m.principal, m.accepts]));
+    // research-collab is offered whole-roster → every peer accepted-network.
+    expect(rcAccepts).toEqual({ andreas: "self", jc: "accepted-network" });
+    // other-net is NOT whole-roster, but zeta is named → accepted-named.
+    expect(otherAccepts).toEqual({ andreas: "self", zeta: "accepted-named" });
   });
 });

--- a/src/surface/mc/api/networks.ts
+++ b/src/surface/mc/api/networks.ts
@@ -50,6 +50,7 @@
 
 import type { AgentPresenceView } from "./agents";
 import type { ResolveAdmittedRosterResult } from "../../../bus/agent-network/admission-read";
+import type { PeerAcceptance } from "../../../bus/agent-network/peer-acceptance";
 import type {
   EncryptionMode,
   NetworkConfidentialityPosture,
@@ -62,6 +63,7 @@ import {
 } from "./networks-membership";
 
 export type { MembershipVerdict } from "./networks-membership";
+export type { PeerAcceptance } from "../../../bus/agent-network/peer-acceptance";
 
 /** One joined network's static identity (from `policy.federated.networks[]`). */
 export interface JoinedNetworkInfo {
@@ -94,6 +96,16 @@ export interface NetworksView {
    * (ADR-0018 Q3). Wraps `resolveAdmittedRoster` — never throws.
    */
   resolveAdmittedRoster(networkId: string): Promise<ResolveAdmittedRosterResult>;
+  /**
+   * MC-A2 (cortex#1276) — the SECOND trust layer: does THIS principal *accept*
+   * `memberPrincipal` on `networkId`? Derived from `policy.offerings[]`
+   * accept-policy (`network:<id>` = whole roster, `principals:[…]` = named).
+   * Synchronous + pure (a distilled summary queried per member). OPTIONAL: a
+   * view that omits it (older wiring / a test stub) leaves acceptance at the
+   * handler default — `self` for the serving principal, `not-accepted`
+   * otherwise (default-deny). `cortex.ts` supplies the live resolver.
+   */
+  acceptsPeer?(networkId: string, memberPrincipal: string): PeerAcceptance;
 }
 
 /** Provenance/availability of a network's admission-rows read. */
@@ -136,6 +148,14 @@ export interface MembershipMemberDTO {
   principal: string;
   verdict: MembershipVerdict;
   present_stacks: string[];
+  /**
+   * MC-A2 (cortex#1276) — the SECOND trust layer: does THIS principal accept
+   * this member? `self` for the serving principal; `accepted-network` (whole
+   * roster trusted) / `accepted-named` (named in an offering) when accepted;
+   * `not-accepted` under default-deny. Membership (`verdict`) is admission;
+   * acceptance is THIS stack's independent accept-policy choice — orthogonal.
+   */
+  accepts: PeerAcceptance;
 }
 
 /** One network's membership view in the `GET /api/networks` response. */
@@ -285,6 +305,16 @@ export async function handleListNetworks(
           principal: m.principal,
           verdict: m.verdict,
           present_stacks: m.presentStacks,
+          // MC-A2 — the SECOND trust layer (acceptance), orthogonal to the
+          // membership verdict above. The view supplies the live resolver; when
+          // it's absent (older wiring / test stub) we default-deny honestly
+          // (self for the serving principal, not-accepted otherwise).
+          accepts:
+            view.acceptsPeer !== undefined
+              ? view.acceptsPeer(info.networkId, m.principal)
+              : m.principal === view.localPrincipal
+                ? "self"
+                : "not-accepted",
         })),
       };
     });

--- a/src/surface/mc/dashboard-v2/__tests__/constellation-canvas-render.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/constellation-canvas-render.test.tsx
@@ -28,7 +28,7 @@ function net(over: Partial<NetworkMembershipDTO>): NetworkMembershipDTO {
     roster_scope: "complete",
     confidentiality: { mode: "off", key_present: false, key_id: null },
     members: [
-      { principal: "andreas", verdict: "admitted-present", present_stacks: ["research"] },
+      { principal: "andreas", verdict: "admitted-present", present_stacks: ["research"], accepts: "self" },
     ],
     ...over,
   };
@@ -82,7 +82,7 @@ describe("ConstellationHeader (MC-D3 on-canvas network header)", () => {
             network_id: "tide",
             roster_scope: "self",
             members: [
-              { principal: "jc", verdict: "admitted-present", present_stacks: ["research"] },
+              { principal: "jc", verdict: "admitted-present", present_stacks: ["research"], accepts: "accepted-network" },
             ],
           }),
         ],

--- a/src/surface/mc/dashboard-v2/__tests__/mc-shell-model.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-shell-model.test.ts
@@ -33,7 +33,7 @@ import {
 function member(
   over: Partial<MembershipMemberDTO> & { principal: string },
 ): MembershipMemberDTO {
-  return { verdict: "admitted-present", present_stacks: [], ...over };
+  return { verdict: "admitted-present", present_stacks: [], accepts: "not-accepted", ...over };
 }
 
 function net(

--- a/src/surface/mc/dashboard-v2/__tests__/network-constellation-header.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-constellation-header.test.ts
@@ -62,10 +62,10 @@ describe("buildConstellationHeader", () => {
     const [row] = buildConstellationHeader([
       net({
         members: [
-          { principal: "andreas", verdict: "admitted-present", present_stacks: ["research", "work"] },
-          { principal: "jc", verdict: "admitted-present", present_stacks: ["research"] },
+          { principal: "andreas", verdict: "admitted-present", present_stacks: ["research", "work"], accepts: "self" },
+          { principal: "jc", verdict: "admitted-present", present_stacks: ["research"], accepts: "accepted-network" },
           // duplicate principal/stack must not double-count
-          { principal: "andreas", verdict: "admitted-absent", present_stacks: ["research"] },
+          { principal: "andreas", verdict: "admitted-absent", present_stacks: ["research"], accepts: "self" },
         ],
       }),
     ]);
@@ -77,7 +77,7 @@ describe("buildConstellationHeader", () => {
     const [row] = buildConstellationHeader([
       net({
         members: [
-          { principal: "jc", verdict: "admitted-absent", present_stacks: [] },
+          { principal: "jc", verdict: "admitted-absent", present_stacks: [], accepts: "accepted-network" },
         ],
       }),
     ]);
@@ -105,7 +105,7 @@ describe("buildConstellationHeader", () => {
     const [row] = buildConstellationHeader([
       net({
         members: [
-          { principal: "jc", verdict: "admitted-present", present_stacks: ["research"] },
+          { principal: "jc", verdict: "admitted-present", present_stacks: ["research"], accepts: "accepted-network" },
         ],
       }),
     ]);

--- a/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
@@ -5,12 +5,13 @@
 
 import { describe, it, expect } from "bun:test";
 import {
+  acceptanceBadge,
   confidentialityBadge,
   verdictBadge,
   rosterStatusBadge,
   summarizeMembership,
 } from "../lib/network-membership-adapter";
-import type { NetworkConfidentialityDTO } from "../../api/networks";
+import type { NetworkConfidentialityDTO, PeerAcceptance } from "../../api/networks";
 
 describe("verdictBadge", () => {
   it("maps each verdict to a distinct tone", () => {
@@ -125,15 +126,55 @@ describe("confidentialityBadge (MC-A3, ADR-0019/0018)", () => {
   });
 });
 
+describe("acceptanceBadge (MC-A2 — the second trust layer)", () => {
+  it("self renders as 'you' (ok)", () => {
+    const b = acceptanceBadge("self");
+    expect(b.token).toBe("self");
+    expect(b.tone).toBe("ok");
+    expect(b.label).toBe("you");
+  });
+
+  it("both accepted variants read as 'accepted' (ok) with distinct tokens", () => {
+    const net = acceptanceBadge("accepted-network");
+    const named = acceptanceBadge("accepted-named");
+    expect(net.tone).toBe("ok");
+    expect(named.tone).toBe("ok");
+    expect(net.label).toBe("accepted");
+    expect(named.label).toBe("accepted");
+    expect(net.token).toBe("accepted-network");
+    expect(named.token).toBe("accepted-named");
+  });
+
+  it("not-accepted is surfaced (warn) — admitted-but-not-accepted is visible", () => {
+    const b = acceptanceBadge("not-accepted");
+    expect(b.token).toBe("not-accepted");
+    expect(b.tone).toBe("warn");
+    expect(b.title).toContain("default-deny");
+  });
+
+  it("every acceptance value has a non-empty label + title", () => {
+    for (const a of [
+      "self",
+      "accepted-network",
+      "accepted-named",
+      "not-accepted",
+    ] as PeerAcceptance[]) {
+      const b = acceptanceBadge(a);
+      expect(b.label.length).toBeGreaterThan(0);
+      expect(b.title.length).toBeGreaterThan(0);
+    }
+  });
+});
+
 describe("summarizeMembership", () => {
   it("tallies members by verdict", () => {
     const summary = summarizeMembership({
       members: [
-        { principal: "a", verdict: "admitted-present", present_stacks: ["s"] },
-        { principal: "b", verdict: "admitted-absent", present_stacks: [] },
-        { principal: "c", verdict: "admitted-present", present_stacks: ["s"] },
-        { principal: "d", verdict: "present-but-unadmitted", present_stacks: ["x"] },
-        { principal: "e", verdict: "pending", present_stacks: [] },
+        { principal: "a", verdict: "admitted-present", present_stacks: ["s"], accepts: "accepted-network" },
+        { principal: "b", verdict: "admitted-absent", present_stacks: [], accepts: "not-accepted" },
+        { principal: "c", verdict: "admitted-present", present_stacks: ["s"], accepts: "accepted-named" },
+        { principal: "d", verdict: "present-but-unadmitted", present_stacks: ["x"], accepts: "not-accepted" },
+        { principal: "e", verdict: "pending", present_stacks: [], accepts: "not-accepted" },
       ],
     });
     expect(summary).toEqual({

--- a/src/surface/mc/dashboard-v2/__tests__/network-roster-panel.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-roster-panel.test.tsx
@@ -27,7 +27,7 @@ function net(
     roster_scope: "complete",
     confidentiality,
     members: [
-      { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"] },
+      { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
     ],
   };
 }
@@ -75,5 +75,47 @@ describe("NetworkRosterPanel — confidentiality chip", () => {
     ]);
     expect(html).toContain('data-posture="cleartext"');
     expect(html).toContain("cleartext");
+  });
+});
+
+describe("NetworkRosterPanel — per-principal acceptance chip (MC-A2)", () => {
+  const CLEARTEXT: NetworkConfidentialityDTO = {
+    mode: "off",
+    key_present: false,
+    key_id: null,
+  };
+
+  function netWithMembers(members: NetworkMembershipDTO["members"]): NetworkMembershipDTO {
+    return {
+      network_id: "research",
+      leaf_node: "research-leaf",
+      roster_status: "ok",
+      roster_scope: "complete",
+      confidentiality: CLEARTEXT,
+      members,
+    };
+  }
+
+  it("renders the acceptance chip for peers (accepted vs not-accepted)", () => {
+    const html = render([
+      netWithMembers([
+        { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
+        { principal: "jc", verdict: "admitted-present", present_stacks: ["research"], accepts: "accepted-network" },
+        { principal: "mallory", verdict: "admitted-absent", present_stacks: [], accepts: "not-accepted" },
+      ]),
+    ]);
+    expect(html).toContain('data-acceptance="accepted-network"');
+    expect(html).toContain('data-acceptance="not-accepted"');
+    expect(html).toContain("not accepted");
+  });
+
+  it("does NOT render an acceptance chip for the serving principal (self is marked '(you)')", () => {
+    const html = render([
+      netWithMembers([
+        { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
+      ]),
+    ]);
+    expect(html).toContain("(you)");
+    expect(html).not.toContain('data-acceptance="self"');
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/pier-queue-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-queue-adapter.test.ts
@@ -20,6 +20,7 @@ function member(
   return {
     verdict: "pending",
     present_stacks: [],
+    accepts: "not-accepted",
     ...over,
   };
 }

--- a/src/surface/mc/dashboard-v2/__tests__/pier-queue.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-queue.test.tsx
@@ -20,7 +20,7 @@ import type { NetworkMembershipDTO, MembershipMemberDTO } from "../hooks/use-net
 function member(
   over: Partial<MembershipMemberDTO> & { principal: string },
 ): MembershipMemberDTO {
-  return { verdict: "pending", present_stacks: [], ...over };
+  return { verdict: "pending", present_stacks: [], accepts: "not-accepted", ...over };
 }
 
 function net(over: Partial<NetworkMembershipDTO> & { network_id: string }): NetworkMembershipDTO {

--- a/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
@@ -16,6 +16,7 @@
 
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
 import {
+  acceptanceBadge,
   confidentialityBadge,
   verdictBadge,
   rosterStatusBadge,
@@ -93,6 +94,7 @@ export function NetworkRosterPanel({
                 <ul className="network-roster-members">
                   {net.members.map((m) => {
                     const badge = verdictBadge(m.verdict);
+                    const acceptance = acceptanceBadge(m.accepts);
                     const isYou = localPrincipal !== null && m.principal === localPrincipal;
                     return (
                       <li
@@ -111,6 +113,19 @@ export function NetworkRosterPanel({
                         >
                           {badge.label}
                         </span>
+                        {/* MC-A2 — the SECOND trust layer (acceptance), shown
+                            alongside the membership verdict. Self is already
+                            marked "(you)" above, so its acceptance badge is
+                            redundant — render it only for peers. */}
+                        {m.accepts !== "self" ? (
+                          <span
+                            className={`network-roster-acceptance tone-${acceptance.tone}`}
+                            data-acceptance={acceptance.token}
+                            title={acceptance.title}
+                          >
+                            {acceptance.label}
+                          </span>
+                        ) : null}
                         {m.present_stacks.length > 0 ? (
                           <span className="dim network-roster-stacks">
                             {m.present_stacks.join(", ")}

--- a/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
@@ -13,6 +13,7 @@ import type {
   MembershipVerdict,
   NetworkConfidentialityDTO,
   NetworkMembershipDTO,
+  PeerAcceptance,
   RosterStatus,
   RosterScope,
 } from "../../api/networks";
@@ -59,6 +60,71 @@ export function verdictBadge(verdict: MembershipVerdict): VerdictBadge {
         label: "pending",
         tone: "pending",
         title: "Admission request pending — not yet admitted",
+      };
+  }
+}
+
+// --- MC-A2: per-principal acceptance (the second trust layer) ---------------
+
+/**
+ * Stable, non-localized acceptance token — for `data-*` attributes, automation,
+ * and tests. Distinct from the human `label`.
+ */
+export type AcceptanceToken =
+  | "self"
+  | "accepted-network"
+  | "accepted-named"
+  | "not-accepted";
+
+/** A render-ready acceptance badge. */
+export interface AcceptanceBadge {
+  label: string;
+  tone: VerdictTone;
+  /** Stable token (data-* / tests); never localized. */
+  token: AcceptanceToken;
+  title: string;
+}
+
+/**
+ * Map a member's {@link PeerAcceptance} → a badge. Acceptance is the SECOND
+ * trust layer (CONTEXT.md §"Joining a network"): admission grants membership,
+ * accept-policy CHOOSES whom this principal trusts. `self` and the two accepted
+ * variants render quietly (ok/dim); `not-accepted` is surfaced (warn) so a peer
+ * that is admitted-but-not-accepted is VISIBLE — you dispatch it no federated
+ * work despite it being on the roster. Total over the union (compiler-enforced).
+ */
+export function acceptanceBadge(accepts: PeerAcceptance): AcceptanceBadge {
+  switch (accepts) {
+    case "self":
+      return {
+        label: "you",
+        tone: "ok",
+        token: "self",
+        title: "The serving principal — itself an admitted member",
+      };
+    case "accepted-network":
+      return {
+        label: "accepted",
+        tone: "ok",
+        token: "accepted-network",
+        title:
+          "Accepted: a federated offering trusts this network's whole roster (accept-policy network:<id>)",
+      };
+    case "accepted-named":
+      return {
+        label: "accepted",
+        tone: "ok",
+        token: "accepted-named",
+        title:
+          "Accepted: this principal is named in a federated offering's accept-policy (principals:[…])",
+      };
+    case "not-accepted":
+      return {
+        label: "not accepted",
+        tone: "warn",
+        token: "not-accepted",
+        title:
+          "Admitted to the roster but NOT accepted by this principal — no federated offering admits it (default-deny). You dispatch it no federated work.",
       };
   }
 }

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -971,9 +971,16 @@ html, body {
 .network-roster-member { display: flex; align-items: center; gap: 8px; font-size: 12px; }
 .network-roster-principal { font-family: var(--mono); }
 .network-roster-stacks { font-size: 11px; margin-left: auto; }
-.network-roster-badge, .network-roster-status, .network-roster-confidentiality {
+.network-roster-badge, .network-roster-status, .network-roster-confidentiality,
+.network-roster-acceptance {
   font-size: 10px; padding: 1px 7px; border-radius: 999px;
   border: 1px solid currentColor; white-space: nowrap;
+}
+/* MC-A2 (cortex#1276) — per-principal acceptance chip (the SECOND trust layer).
+   Accepted variants read quietly; "not accepted" gets a subtle fill so an
+   admitted-but-not-accepted peer is visible, not just another chip. */
+.network-roster-acceptance[data-acceptance="not-accepted"] {
+  background: color-mix(in srgb, var(--warn) 12%, transparent);
 }
 /* MC-A3 (cortex#1277) — confidentiality posture chip (ADR-0019/0018).
    Tone carries the colour (ok/warn/danger); the degraded "no key" posture also


### PR DESCRIPTION
## What

MC-A2 (cortex#1276), sub of the MC umbrella #1274. Replaces MC-A1's `not_configured` stub on `GET /api/networks` with the **LIVE** admission-rows provider, so the Network pane shows:

1. **The live ADMITTED roster per network + per-member admission state.** Sourced from the **admission rows** (ADR-0018 Q3), via the PoP-signed member roster read `GET /networks/:id/roster/member` (C-1282 / ADR-0018 Q4, DEPLOYED #1284). Returns the **COMPLETE** admitted roster (`scope: "complete"`) → membership verdicts are authoritative.
2. **Per-principal acceptance per member** — the SECOND trust layer (CONTEXT.md §"Joining a network"): admission *grants* membership, accept-policy *chooses* whom this principal trusts. Derived from `policy.offerings[]` accept-policy: `network:<id>` (whole roster) vs `principals:[…]` (named). Surfaced per member on the DTO (`accepts`) + an additive roster-panel chip.

## How

- **`src/bus/agent-network/admission-rows-member-provider.ts`** (new) — the live `AdmissionRowsProvider`. PoP-signs the claim `{network_id, peer_pubkey, issued_at}` with the stack's **own registered signing key** (the `SU…` seed it already holds — *mints nothing*, reuses `signClaimWithSeed`/`canonicalJSON`), GETs the member endpoint, **DD-9-verifies** the registry assertion against the pinned pubkey, and projects ADMITTED members → `AdmissionRow[]`.
- **`src/bus/agent-network/peer-acceptance.ts`** (new) — pure `summarizeAcceptancePolicy` + `resolvePeerAcceptance` (`self` / `accepted-network` / `accepted-named` / `not-accepted`, default-deny).
- **`src/surface/mc/api/networks.ts`** — `accepts` on `MembershipMemberDTO`; optional `acceptsPeer` on `NetworksView`; handler maps it per member (default `self`/`not-accepted` when absent).
- **`src/cortex.ts`** — wires the live provider (registry URL + pinned pubkey + stack material from `nkey_seed_path`) and `acceptsPeer` from `resolvedPolicy.offerings`. Falls back to `not_configured` (honest self-only) when registry/seed absent — never crashes the embed boot.
- **Frontend** — `acceptanceBadge` adapter + additive roster-panel chip (`data-acceptance` token) + minimal CSS. Self stays marked `(you)`, no redundant chip.

## Safety (mirror A1's DD-10 — never 5xx)

- `401/403` → `unauthorized` (a distinct, honest state — not masked).
- transport / not-found / unverifiable / no-seed → `unreachable` / `not_configured` → the network still renders **self-only**.
- DD-9: a roster signed by the wrong registry key is **rejected**, payload never trusted.
- Privacy: roster + admission-state only, **no sessions**. The member read returns ADMITTED peers only — a member never sees the PENDING onboarding queue. Admin-posture PENDING enrichment composes via the SAME seam (deliberately not built — no admin-seed config in the daemon yet; the Pier queue B1 surfaces PENDING for admin-posture).
- Vocab gate: `admin`/`member` terms only.

## Tests

New: member-provider (PoP correctness, DD-9 reject, status→reason mapping, never-throw), peer-acceptance (network-wide / named / default-deny / public-ignored), API handler acceptance, roster-panel acceptance chip, adapter `acceptanceBadge`. Updated existing A1/A3/B1 fixtures for the new required `accepts` field.

Gates: `bun test src/surface/mc src/bus/agent-network` (affected files green; pre-existing NATS-connect integration tests are flaky on slow runs — CI is the backstop), `bunx tsc --noEmit`, `bun run lint:errors`, `bun run build:dashboard` (network-canvas split held), `bash scripts/check-carveouts.sh` — all green.

Closes #1276. Refs #1274 (MC umbrella), C-1282 / #1284 (Q3 member-read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)