### PR TITLE
chore: bump to v5.30.1 — C-1265b provision→make-live config-path loop

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.30.0"
+version: "5.30.1"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release bump for **#1302** (C-1265b). Closes the make-live half of C-1265: provision writes `stack.nats_infra.config_path` so make-live bootstraps the operator-mode config from scratch (zero raw `nsc`), ships a placeholder-only sample `nats-server.conf`, hardens the synthesised `listen` to loopback. Onboarding from-scratch now completes with no manual `nsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)