### PR TITLE
feat(surface): C-1291 — MC-D4 trust indicators (key epoch on the confidentiality marker)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-constellation-header.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-constellation-header.test.ts
@@ -91,6 +91,27 @@ describe("buildConstellationHeader", () => {
     expect(row?.confidentiality).toBe("encrypted-required");
   });
 
+  test("D4 — sealed network carries the key epoch (the mockup's K7)", () => {
+    const [enabled] = buildConstellationHeader([
+      net({ confidentiality: { mode: "enabled", key_present: true, key_id: "k7" } }),
+    ]);
+    expect(enabled?.keyId).toBe("k7");
+  });
+
+  test("D4 HONESTY HINGE — no key epoch shown without a held key (off / degraded / unknown)", () => {
+    // off: encryption disabled → no epoch.
+    const [off] = buildConstellationHeader([
+      net({ confidentiality: { mode: "off", key_present: false, key_id: null } }),
+    ]);
+    expect(off?.keyId).toBeNull();
+    // degraded: configured to seal but NO key → never show an epoch (cleartext-with-warning).
+    const [degraded] = buildConstellationHeader([
+      net({ confidentiality: { mode: "required", key_present: false, key_id: "k7" } }),
+    ]);
+    expect(degraded?.confidentiality).toBe("degraded");
+    expect(degraded?.keyId).toBeNull();
+  });
+
   test("VOCAB GATE — posture is only ever 'admin' or 'member' (deprecated label gated)", () => {
     const rows = buildConstellationHeader([
       net({ roster_scope: "complete" }),
@@ -110,9 +131,10 @@ describe("buildConstellationHeader", () => {
       }),
     ]);
     const keys = Object.keys(row ?? {});
-    // The row is a presence-level aggregate: id, posture, stack count, A3 token.
+    // The row is a presence-level aggregate: id, posture, stack count, A3 token,
+    // and the per-network key epoch (D4). All network-scoped — nothing per-session.
     expect(keys.sort()).toEqual(
-      ["confidentiality", "networkId", "posture", "stackCount"].sort(),
+      ["confidentiality", "keyId", "networkId", "posture", "stackCount"].sort(),
     );
     // Defensively assert nothing session-shaped leaked in.
     for (const k of keys) {

--- a/src/surface/mc/dashboard-v2/components/constellation-header.tsx
+++ b/src/surface/mc/dashboard-v2/components/constellation-header.tsx
@@ -94,6 +94,15 @@ export function ConstellationHeader({ networks }: ConstellationHeaderProps) {
                   title={marker.title}
                 >
                   {marker.label}
+                  {row.keyId && (
+                    <span
+                      className="mc-ch-keyid"
+                      data-key-id={row.keyId}
+                      title={`Per-network payload key (epoch) ${row.keyId} — ADR-0019`}
+                    >
+                      {" · "}K{row.keyId}
+                    </span>
+                  )}
                 </span>
               )}
             </li>

--- a/src/surface/mc/dashboard-v2/lib/network-constellation-header.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-constellation-header.ts
@@ -61,6 +61,13 @@ export interface ConstellationHeaderNetwork {
    * (honest — `degraded`/`unknown` are never badged as encrypted).
    */
   confidentiality: ConfidentialityPostureToken;
+  /**
+   * MC-D4 (#1291) — the per-network payload-key id/epoch (ADR-0019), the
+   * mockup's `K7`. `null` when no key is held (off / degraded / unknown), so the
+   * skin shows the epoch ONLY alongside a genuinely-sealed marker — never a key
+   * label without a held key (the A3 honesty hinge, carried up to the header).
+   */
+  keyId: string | null;
 }
 
 /** Count distinct `{principal}/{stack}` pairs observed present across members. */
@@ -82,10 +89,18 @@ function countDistinctPresentStacks(net: NetworkMembershipDTO): number {
 export function buildConstellationHeader(
   networks: readonly NetworkMembershipDTO[],
 ): ConstellationHeaderNetwork[] {
-  return networks.map((net) => ({
-    networkId: net.network_id,
-    posture: isAdminPosture(net) ? "admin" : "member",
-    stackCount: countDistinctPresentStacks(net),
-    confidentiality: confidentialityBadge(net.confidentiality).posture,
-  }));
+  return networks.map((net) => {
+    const posture = confidentialityBadge(net.confidentiality).posture;
+    // Carry the key-id ONLY when a key is genuinely held (sealed posture). For
+    // off/degraded/unknown there is no live key, so no epoch is shown — the A3
+    // honesty hinge, preserved up to the header (never a key label sans key).
+    const sealed = posture === "encrypted" || posture === "encrypted-required";
+    return {
+      networkId: net.network_id,
+      posture: isAdminPosture(net) ? "admin" : "member",
+      stackCount: countDistinctPresentStacks(net),
+      confidentiality: posture,
+      keyId: sealed ? (net.confidentiality?.key_id ?? null) : null,
+    };
+  });
 }


### PR DESCRIPTION
Completes **MC-D4** (#1291, MC-UX #1287). D2/D3 already shipped the admin/member posture pill + the header confidentiality marker (🔒 sealed / ⚠ no key) + the `· admitted peer` federated edge — the core trust indicators. This adds the **per-network payload-key epoch** (the mockup's `K7`) to the sealed marker, reusing A3's `key_id`. Honesty hinge preserved: the epoch shows ONLY with a genuinely-held key (off/degraded/unknown → no epoch). Aggregate-only (no session field). Closes #1291.