### PR TITLE
fix(network): C-1265c — default nats.credsPath (zero-flag make-live) + onboarding ladder + prereqs

### DIFF
--- a/docs/sop-onboard-peer-principal.md
+++ b/docs/sop-onboard-peer-principal.md
@@ -18,6 +18,19 @@ The federation model (ADR-0013, Model B) is **sovereign**: every principal runs 
 
 This is the ordered sequence for a **new peer principal** joining an existing network. Both principals go through the same steps on their own side; the two irreducible two-party moments are called out explicitly in section 3.
 
+### Prerequisites
+
+Before Step 1, confirm your machine has:
+
+- **Bun** — the only supported runtime (`bun --version`). Never use npm / yarn / node.
+- **NATS server with JetStream** — one isolated bus per stack (`nats-server --version`). A federating stack's bus must also be operator-mode (NSC operator + the account the leaf binds to); see Step 3.
+- **Claude Code, authenticated** — the default execution substrate for dispatched work (`claude --version`).
+- **`arc`** *(recommended)* — the metafactory package manager (`arc --version`). It manages install, the launchd lifecycle, and signing-seed provisioning; `arc upgrade Cortex` auto-provisions your stack's NKey seed on first install. Cortex runs without it, but you then provision the seed and lifecycle by hand.
+
+**`soma` is not required** to run cortex — it is a separate, optional layer.
+
+Canonical prereq source: [`README-AGENTS.md` §1](../README-AGENTS.md#1-prerequisites).
+
 ### Step 1 — Stand up your own stack
 
 If you do not have a cortex stack yet, create one. The command scaffolds a born-aligned config-split skeleton (slug == `stack.id` trailing segment, no drift can form) and sets `stack.nkey_seed_path` to the conventional path:

--- a/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
@@ -73,7 +73,8 @@ const PROVISIONED_WITH_CONFIGPATH = loaded({
  * v5.30.2 — a provisioned, federation-ready stack whose `config.nats` carries NO
  * `credsPath` (a from-scratch `cortex stack create` stack before the seed lands,
  * OR a pre-existing unseeded stack). make-live must DEFAULT credsPath to the
- * conventional `~/.config/nats/<slug>.creds` rather than erroring for `--creds`.
+ * conventional bus/bot path `~/.config/nats/<slug>-bot.creds` (DISTINCT from the
+ * FEDERATION default `~/.config/nats/<slug>.creds`) rather than erroring for `--creds`.
  */
 const UNSEEDED_CREDS = loaded({
   principal: { id: "andreas" },
@@ -92,9 +93,22 @@ const UNSEEDED_CREDS = loaded({
   },
 });
 
-function fakeFactory(): { factory: MakeLivePortsFactory; calls: string[]; mutates: boolean[] } {
+/** A recorded credsPath write-back call (v5.30.2). */
+interface ConfigWriteCall {
+  systemConfigPath: string;
+  credsPath: string;
+}
+
+function fakeFactory(): {
+  factory: MakeLivePortsFactory;
+  calls: string[];
+  mutates: boolean[];
+  configWrites: ConfigWriteCall[];
+} {
   const calls: string[] = [];
   const mutates: boolean[] = [];
+  // Recorded into a SEPARATE array so it never disturbs the `calls`-ordering assertions.
+  const configWrites: ConfigWriteCall[] = [];
   const factory: MakeLivePortsFactory = (mutate) => {
     mutates.push(mutate);
     const ports: MakeLivePorts = {
@@ -121,10 +135,16 @@ function fakeFactory(): { factory: MakeLivePortsFactory; calls: string[]; mutate
         restartNats: async () => { calls.push("restart-nats"); return { ok: true }; },
         restartDaemon: async () => { calls.push("restart-daemon"); return { ok: true }; },
       },
+      configWrite: {
+        writeBusCredsPath: ({ systemConfigPath, credsPath }) => {
+          configWrites.push({ systemConfigPath, credsPath });
+          return { ok: true, path: systemConfigPath, changed: true };
+        },
+      },
     };
     return ports;
   };
-  return { factory, calls, mutates };
+  return { factory, calls, mutates, configWrites };
 }
 
 function run(argv: string[], cfg: LoadedConfig, factory: MakeLivePortsFactory) {
@@ -292,5 +312,48 @@ describe("cortex network make-live — credsPath default (v5.30.2, C-1265c)", ()
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain(customCreds);
     expect(res.stdout).not.toContain(BUS_CREDS_DEFAULT);
+  });
+});
+
+describe("cortex network make-live — credsPath write-back (v5.30.2, C-1265c)", () => {
+  test("on --apply, a DEFAULTED credsPath is written back into config.nats.credsPath", async () => {
+    const { factory, configWrites } = fakeFactory();
+    const res = await run(
+      ["make-live", "community", "--config", "/x/community.yaml", "--apply"],
+      UNSEEDED_CREDS, // no config.nats.credsPath, no --creds ⇒ defaulted
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    // Exactly one write-back, carrying the resolved `-bot` path…
+    expect(configWrites).toHaveLength(1);
+    expect(configWrites[0]?.credsPath).toBe(BUS_CREDS_DEFAULT);
+    // …targeting the SYSTEM-layer config. No `/x/system/system.yaml` marker exists
+    // for this test path, so it resolves to the monolith file (`/x/community.yaml`).
+    expect(configWrites[0]?.systemConfigPath).toBe("/x/community.yaml");
+    // …and the transcript records the self-documenting write.
+    expect(res.stdout).toContain("nats.credsPath defaulted");
+    expect(res.stdout).toContain("written to config");
+  });
+
+  test("on --apply, an EXPLICIT --creds is NEVER written back (no config mutation)", async () => {
+    const { factory, configWrites } = fakeFactory();
+    const res = await run(
+      ["make-live", "community", "--config", "/x/community.yaml", "--creds", "/custom/explicit/path.creds", "--apply"],
+      UNSEEDED_CREDS,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(configWrites).toHaveLength(0); // credsPathDefaulted=false ⇒ no write-back
+  });
+
+  test("on --apply, an EXPLICIT config.nats.credsPath is NEVER written back", async () => {
+    const { factory, configWrites } = fakeFactory();
+    const res = await run(
+      ["make-live", "community", "--config", "/x/community.yaml", "--apply"],
+      PROVISIONED_WITH_CONFIGPATH, // config.nats.credsPath = ABSENT_CREDS (explicit)
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(configWrites).toHaveLength(0);
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
@@ -236,8 +236,19 @@ describe("cortex network make-live — apply", () => {
   });
 });
 
+// The two default paths that MUST stay distinct (different NATS accounts).
+// BUS_DEFAULT is make-live's bus/bot-user creds (agents account); FED_DEFAULT is
+// provision's federation-user creds default (deriveProvisionInputs, network.ts).
+// slug = community for these tests.
+const BUS_CREDS_DEFAULT = "~/.config/nats/community-bot.creds";
+const FED_CREDS_DEFAULT = "~/.config/nats/community.creds";
+
 describe("cortex network make-live — credsPath default (v5.30.2, C-1265c)", () => {
-  test("defaults nats.credsPath to ~/.config/nats/<slug>.creds when unset (no --creds, no config)", async () => {
+  test("defaults nats.credsPath to ~/.config/nats/<slug>-bot.creds, DISTINCT from provision's federation default", async () => {
+    // Guard the invariant directly: the bus/bot default and the federation
+    // default must never resolve to the same file (different NATS accounts).
+    expect(BUS_CREDS_DEFAULT).not.toBe(FED_CREDS_DEFAULT);
+
     const { factory } = fakeFactory();
     const res = await run(
       // No --creds; UNSEEDED_CREDS has no config.nats.credsPath. slug=community.
@@ -246,10 +257,15 @@ describe("cortex network make-live — credsPath default (v5.30.2, C-1265c)", ()
       factory,
     );
     expect(res.exitCode).toBe(0); // no longer a usage error — a path is always derivable
-    // The bus-creds plan line names the conventional default per-stack bus creds…
-    expect(res.stdout).toContain("~/.config/nats/community.creds");
-    // …and NEVER the federation leaf creds (stack.nats_infra.creds_path) — proving
-    // the two are not conflated (a leaf-creds fallback was the wrong fix).
+    // The bus-creds plan line names the conventional `-bot` bus/bot-user path…
+    expect(res.stdout).toContain(BUS_CREDS_DEFAULT);
+    // …and NEVER provision's FEDERATION default `~/.config/nats/<slug>.creds`
+    // (`community-bot.creds` does not contain that substring) — proving make-live's
+    // bus user and `network join`'s federation user resolve to DIFFERENT files and
+    // cannot clobber each other on a fresh stack.
+    expect(res.stdout).not.toContain(FED_CREDS_DEFAULT);
+    // …and NEVER the stack's federation leaf creds (stack.nats_infra.creds_path) —
+    // a leaf-creds fallback was the wrong fix.
     expect(res.stdout).not.toContain("community-leaf.creds");
   });
 
@@ -262,7 +278,7 @@ describe("cortex network make-live — credsPath default (v5.30.2, C-1265c)", ()
     );
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain(ABSENT_CREDS);
-    expect(res.stdout).not.toContain("~/.config/nats/community.creds");
+    expect(res.stdout).not.toContain(BUS_CREDS_DEFAULT);
   });
 
   test("--creds flag takes precedence over both config and the default", async () => {
@@ -275,6 +291,6 @@ describe("cortex network make-live — credsPath default (v5.30.2, C-1265c)", ()
     );
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain(customCreds);
-    expect(res.stdout).not.toContain("~/.config/nats/community.creds");
+    expect(res.stdout).not.toContain(BUS_CREDS_DEFAULT);
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
@@ -69,6 +69,29 @@ const PROVISIONED_WITH_CONFIGPATH = loaded({
   },
 });
 
+/**
+ * v5.30.2 — a provisioned, federation-ready stack whose `config.nats` carries NO
+ * `credsPath` (a from-scratch `cortex stack create` stack before the seed lands,
+ * OR a pre-existing unseeded stack). make-live must DEFAULT credsPath to the
+ * conventional `~/.config/nats/<slug>.creds` rather than erroring for `--creds`.
+ */
+const UNSEEDED_CREDS = loaded({
+  principal: { id: "andreas" },
+  config: { nats: { name: "cortex-community" } } as unknown as AgentConfig,
+  stack: {
+    id: "andreas/community",
+    nkey_seed_path: "~/.config/nats/cortex-community.nk",
+    nats_infra: {
+      account: "A" + "B".repeat(55),
+      agents_account: AGENTS_PUB,
+      config_path: ABSENT_COMMUNITY_NATS,
+      // FEDERATION leaf creds — deliberately a DISTINCT path so a test can prove
+      // make-live does NOT conflate it with the defaulted bus creds.
+      creds_path: "~/.config/nats/community-leaf.creds",
+    },
+  },
+});
+
 function fakeFactory(): { factory: MakeLivePortsFactory; calls: string[]; mutates: boolean[] } {
   const calls: string[] = [];
   const mutates: boolean[] = [];
@@ -210,5 +233,48 @@ describe("cortex network make-live — apply", () => {
     );
     expect(res.exitCode).toBe(2);
     expect(res.stderr).toContain("mutually exclusive");
+  });
+});
+
+describe("cortex network make-live — credsPath default (v5.30.2, C-1265c)", () => {
+  test("defaults nats.credsPath to ~/.config/nats/<slug>.creds when unset (no --creds, no config)", async () => {
+    const { factory } = fakeFactory();
+    const res = await run(
+      // No --creds; UNSEEDED_CREDS has no config.nats.credsPath. slug=community.
+      ["make-live", "community", "--config", "/x/community.yaml"],
+      UNSEEDED_CREDS,
+      factory,
+    );
+    expect(res.exitCode).toBe(0); // no longer a usage error — a path is always derivable
+    // The bus-creds plan line names the conventional default per-stack bus creds…
+    expect(res.stdout).toContain("~/.config/nats/community.creds");
+    // …and NEVER the federation leaf creds (stack.nats_infra.creds_path) — proving
+    // the two are not conflated (a leaf-creds fallback was the wrong fix).
+    expect(res.stdout).not.toContain("community-leaf.creds");
+  });
+
+  test("config nats.credsPath takes precedence over the conventional default", async () => {
+    const { factory } = fakeFactory();
+    const res = await run(
+      ["make-live", "community", "--config", "/x/community.yaml"],
+      PROVISIONED_WITH_CONFIGPATH, // config.nats.credsPath = ABSENT_CREDS
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain(ABSENT_CREDS);
+    expect(res.stdout).not.toContain("~/.config/nats/community.creds");
+  });
+
+  test("--creds flag takes precedence over both config and the default", async () => {
+    const { factory } = fakeFactory();
+    const customCreds = "/custom/explicit/path.creds";
+    const res = await run(
+      ["make-live", "community", "--config", "/x/community.yaml", "--creds", customCreds],
+      UNSEEDED_CREDS,
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain(customCreds);
+    expect(res.stdout).not.toContain("~/.config/nats/community.creds");
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -8,7 +8,11 @@
  * under the agents account, the agents JWT appended to resolver_preload exactly
  * once, both services restarted ONLY when state changed (and in the right order:
  * nats BEFORE the daemon), idempotent re-runs, and that the orchestrator never
- * touches the stack config (so encryption / federated config survives).
+ * touches the STACK config / `nats_infra` (so encryption / federated config
+ * survives). NOTE (v5.30.2, cortex#1265): make-live MAY now write a single
+ * SYSTEM-layer key — `config.nats.credsPath` — but ONLY when it had to default it
+ * (`credsPathDefaulted` + an injected `configWrite` port). These unit tests pass an
+ * explicit credsPath and no `configWrite`, so that path never fires here.
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 
@@ -499,5 +503,89 @@ describe("findNatsServerDescriptor", () => {
       io: io(files),
     });
     expect(found).toBeUndefined();
+  });
+});
+
+// ── credsPath write-back on a DEFAULTED path (v5.30.2, cortex#1265) ──────────────
+
+describe("makeLiveStack — defaulted credsPath write-back", () => {
+  /** makePorts() + a recording configWrite spy (optionally forced to fail). */
+  function portsWithConfigWrite(fail?: boolean): {
+    ports: MakeLivePorts;
+    calls: string[];
+    writes: { systemConfigPath: string; credsPath: string }[];
+  } {
+    const { ports, calls } = makePorts();
+    const writes: { systemConfigPath: string; credsPath: string }[] = [];
+    return {
+      ports: {
+        ...ports,
+        configWrite: {
+          writeBusCredsPath: ({ systemConfigPath, credsPath }) => {
+            writes.push({ systemConfigPath, credsPath });
+            calls.push("config-write");
+            return fail === true
+              ? { ok: false, reason: "EACCES" }
+              : { ok: true, path: systemConfigPath, changed: true };
+          },
+        },
+      },
+      calls,
+      writes,
+    };
+  }
+
+  test("writes the defaulted path back BEFORE the daemon restart, in order", async () => {
+    const { ports, calls, writes } = portsWithConfigWrite();
+    const res = await makeLiveStack(
+      makeInputs(
+        { credsFileExists: false, resolverHasAccount: false },
+        {
+          credsPath: "~/.config/nats/work-bot.creds",
+          credsPathDefaulted: true,
+          systemConfigWritePath: "/Users/x/.config/cortex/work/system/system.yaml",
+        },
+      ),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(writes).toEqual([
+      { systemConfigPath: "/Users/x/.config/cortex/work/system/system.yaml", credsPath: "~/.config/nats/work-bot.creds" },
+    ]);
+    // config-write lands AFTER the mint and BEFORE the daemon restart.
+    expect(calls.indexOf("config-write")).toBeGreaterThan(calls.findIndex((c) => c.startsWith("mint:")));
+    expect(calls.indexOf("config-write")).toBeLessThan(calls.indexOf("restart-daemon"));
+  });
+
+  test("write-back failure fail-fasts and the daemon is NOT restarted", async () => {
+    const { ports, calls } = portsWithConfigWrite(true);
+    const res = await makeLiveStack(
+      makeInputs(
+        { credsFileExists: false, resolverHasAccount: false },
+        {
+          credsPath: "~/.config/nats/work-bot.creds",
+          credsPathDefaulted: true,
+          systemConfigWritePath: "/Users/x/.config/cortex/work/system/system.yaml",
+        },
+      ),
+      ports,
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toContain("nats.credsPath write-back failed");
+      expect(res.reason).toContain("by hand"); // actionable manual-fix instruction
+    }
+    expect(calls).not.toContain("restart-daemon"); // never restart into broken-auth
+  });
+
+  test("an EXPLICIT credsPath (credsPathDefaulted unset) never triggers a write-back", async () => {
+    const { ports, calls, writes } = portsWithConfigWrite();
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: false, resolverHasAccount: false }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(writes).toHaveLength(0);
+    expect(calls).not.toContain("config-write");
   });
 });

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -284,11 +284,14 @@ describe("create --apply", () => {
     expect(loaded.stack?.id).toBe("andreas/demo");
   });
 
-  test("prints next steps (provision → point daemon → network join)", async () => {
+  test("prints next steps (provision → make-live → point daemon → network join)", async () => {
     const cfg = freshDir();
     const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("arc upgrade");
+    // v5.30.2 (C-1265c): the provision → make-live bus-bring-up ladder is surfaced.
+    expect(res.stdout).toContain("cortex network provision demo");
+    expect(res.stdout).toContain("cortex network make-live demo");
     expect(res.stdout).toContain("network join");
   });
 });

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -141,14 +141,18 @@ describe("renderScaffold", () => {
     expect(stack?.contents).toContain("luna");
   });
 
-  test("system/system.yaml seeds the conventional bus credsPath (~/.config/nats/<slug>.creds)", () => {
+  test("system/system.yaml seeds the bus/bot credsPath (~/.config/nats/<slug>-bot.creds), distinct from the federation default", () => {
     // v5.30.2 (C-1265c): a from-scratch stack carries nats.credsPath explicitly,
     // so `cortex network make-live` needs no --creds flag. The path is the
-    // daemon's OWN bus creds under the agents account — the conventional
-    // per-stack path, NOT the federation leaf creds.
+    // daemon's OWN bus/bot creds under the agents account. The `-bot` suffix is
+    // load-bearing: it keeps this DISTINCT from provision's federation-user
+    // default `~/.config/nats/<slug>.creds` (different NATS account → must be a
+    // different file, or the second mint clobbers the first).
     const files = renderScaffold(inputs);
     const system = files.find((f) => f.relPath === "system/system.yaml");
-    expect(system?.contents).toContain("credsPath: ~/.config/nats/demo.creds");
+    expect(system?.contents).toContain("credsPath: ~/.config/nats/demo-bot.creds");
+    // The bus path must NOT equal the federation default for the same slug.
+    expect(system?.contents).not.toContain("credsPath: ~/.config/nats/demo.creds");
   });
 
   test("does NOT inline any signing seed material (key auto-provisioned later)", () => {

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -141,6 +141,16 @@ describe("renderScaffold", () => {
     expect(stack?.contents).toContain("luna");
   });
 
+  test("system/system.yaml seeds the conventional bus credsPath (~/.config/nats/<slug>.creds)", () => {
+    // v5.30.2 (C-1265c): a from-scratch stack carries nats.credsPath explicitly,
+    // so `cortex network make-live` needs no --creds flag. The path is the
+    // daemon's OWN bus creds under the agents account — the conventional
+    // per-stack path, NOT the federation leaf creds.
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    expect(system?.contents).toContain("credsPath: ~/.config/nats/demo.creds");
+  });
+
   test("does NOT inline any signing seed material (key auto-provisioned later)", () => {
     const files = renderScaffold(inputs);
     const all = files.map((f) => f.contents).join("\n");

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -13,6 +13,8 @@ import { existsSync, readFileSync, writeFileSync, copyFileSync, chmodSync, readd
 import { homedir } from "os";
 import { join, dirname } from "path";
 
+import { parseDocument } from "yaml";
+
 import { expandTilde } from "../../../common/config/loader";
 import { renderOperatorModeBlocks, renderBaseIsolatedConfig } from "../../../common/nats/leaf-remote-renderer";
 import {
@@ -33,6 +35,7 @@ import type {
   AccountExportPort,
   ResolverPreloadPort,
   ServiceRestartPort,
+  MakeLiveConfigWritePort,
   MakeLivePorts,
 } from "./network-make-live-lib";
 
@@ -425,6 +428,39 @@ export function buildServiceRestartAdapter(mutate: boolean): ServiceRestartPort 
 // Full live port bundle
 // =============================================================================
 
+/**
+ * cortex#1265 (v5.30.2) — persist a DEFAULTED `nats.credsPath` back to the daemon's
+ * config. Surgical single-key set via the YAML Document API (`setIn`), so every
+ * other key + comment (encryption, federated JWTs, `nats_infra`) survives. Targets
+ * the SYSTEM/bus layer only. On a dry-run (`mutate=false`) it no-ops (mirrors the
+ * restart adapter). A missing target file is an ERROR (never synthesise a partial
+ * config) — the daemon's config always exists by the time make-live runs.
+ */
+export function buildMakeLiveConfigWriteAdapter(mutate: boolean): MakeLiveConfigWritePort {
+  return {
+    writeBusCredsPath: ({ systemConfigPath, credsPath }) => {
+      const expanded = expandTilde(systemConfigPath);
+      if (!mutate) return { ok: true, path: expanded, changed: false };
+      try {
+        if (!existsSync(expanded)) {
+          return { ok: false, reason: `config file ${expanded} not found — cannot write nats.credsPath` };
+        }
+        const doc = parseDocument(readFileSync(expanded, "utf-8"));
+        // Idempotent: a matching value already present ⇒ no write, no churn.
+        if (doc.getIn(["nats", "credsPath"]) === credsPath) {
+          return { ok: true, path: expanded, changed: false };
+        }
+        doc.setIn(["nats", "credsPath"], credsPath);
+        mkdirSync(dirname(expanded), { recursive: true });
+        writeFileSync(expanded, doc.toString(), "utf-8");
+        return { ok: true, path: expanded, changed: true };
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}
+
 /** Build the live {@link MakeLivePorts} bundle for a real `--apply` run. */
 export function buildLiveMakeLivePorts(mutate: boolean): MakeLivePorts {
   return {
@@ -432,5 +468,6 @@ export function buildLiveMakeLivePorts(mutate: boolean): MakeLivePorts {
     accountExport: buildAccountExportAdapter(),
     resolver: buildResolverPreloadAdapter(),
     restart: buildServiceRestartAdapter(mutate),
+    configWrite: buildMakeLiveConfigWriteAdapter(mutate),
   };
 }

--- a/src/cli/cortex/commands/network-make-live-lib.ts
+++ b/src/cli/cortex/commands/network-make-live-lib.ts
@@ -147,11 +147,34 @@ export interface ServiceRestartPort {
   restartDaemon(cortexConfigPath: string): Promise<{ ok: true } | { ok: false; reason: string }>;
 }
 
+/**
+ * cortex#1265 (v5.30.2) — config write-back for a DEFAULTED `nats.credsPath`. When
+ * make-live had to synthesise the bus-creds path (neither `--creds` nor config
+ * supplied it), it persists the resolved path into the daemon's config so the
+ * daemon actually connects with it (runtime.ts only passes `credsPath` when set —
+ * an unset path → no creds → own-auth Authorization Violation on the operator-mode
+ * bus) and the config self-documents. Targets the SYSTEM/bus layer
+ * (`config.nats.credsPath`), NEVER `stack.nats_infra`: a surgical single-key set
+ * that preserves every other key + comment (encryption / federated JWTs survive).
+ */
+export interface MakeLiveConfigWritePort {
+  /** Persist `nats.credsPath = credsPath` into `systemConfigPath` (idempotent). */
+  writeBusCredsPath(opts: { systemConfigPath: string; credsPath: string }):
+    | { ok: true; path: string; changed: boolean }
+    | { ok: false; reason: string };
+}
+
 export interface MakeLivePorts {
   creds: CredsMintPort;
   accountExport: AccountExportPort;
   resolver: ResolverPreloadPort;
   restart: ServiceRestartPort;
+  /**
+   * cortex#1265 (v5.30.2) — OPTIONAL: persist a DEFAULTED `nats.credsPath` back to
+   * config. Absent ⇒ the write-back is skipped (back-compat for callers/tests that
+   * predate it; only `deriveMakeLiveInputs` + `buildLiveMakeLivePorts` supply it).
+   */
+  configWrite?: MakeLiveConfigWritePort;
 }
 
 // =============================================================================
@@ -180,6 +203,20 @@ export interface MakeLiveInputs {
   credsPath: string;
   /** Path to the cortex config the daemon loads (for daemon-restart discovery). */
   cortexConfigPath: string;
+  /**
+   * cortex#1265 (v5.30.2) — true when `credsPath` was DEFAULTED (neither `--creds`
+   * nor `config.nats.credsPath` supplied it). Drives the config write-back: a
+   * defaulted path is persisted into `systemConfigWritePath` so the daemon connects
+   * with it. An explicit `--creds`/config value is NEVER overwritten.
+   */
+  credsPathDefaulted?: boolean;
+  /**
+   * cortex#1265 (v5.30.2) — the config file a DEFAULTED `nats.credsPath` is written
+   * back into: the SYSTEM-layer `system/system.yaml` in a config-split layout, else
+   * the legacy monolith file. Consulted only when `credsPathDefaulted` is true AND
+   * `ports.configWrite` is present.
+   */
+  systemConfigWritePath?: string;
   /**
    * cortex#1265 — the operator-mode leaf package assembled from
    * `stack.nats_infra.{operator_jwt, account, account_jwt, system_account,
@@ -379,6 +416,14 @@ export async function makeLiveStack(
           `${inputs.cortexConfigPath} was found — --apply would fail at the daemon restart.`,
       );
     }
+    // cortex#1265 (v5.30.2) — preview the credsPath write-back when it was defaulted.
+    const defaultNote =
+      inputs.credsPathDefaulted === true && inputs.systemConfigWritePath !== undefined
+        ? [
+            "",
+            `nats.credsPath defaulted → ${inputs.credsPath} (would be written to config ${inputs.systemConfigWritePath} on --apply)`,
+          ]
+        : [];
     return {
       ok: true,
       applied: false,
@@ -388,6 +433,7 @@ export async function makeLiveStack(
         "",
         ...targetLines,
         ...(warnings.length > 0 ? ["", ...warnings] : []),
+        ...defaultNote,
         "",
         credsNeeded || resolverNeeded
           ? "Re-run with --apply to land the daemon on its agents account."
@@ -489,6 +535,38 @@ export async function makeLiveStack(
     steps.push(`bus creds minted: ${inputs.botName} @ ${inputs.agentsAccountName} → ${minted.credsPath} (chmod 600)`);
   } else {
     steps.push(`bus creds present (untouched): ${inputs.credsPath}`);
+  }
+
+  // 3.5 (cortex#1265, v5.30.2). When `nats.credsPath` was DEFAULTED (neither
+  //     --creds nor config supplied it), persist the resolved path into the daemon's
+  //     config BEFORE the daemon restart, so it reconnects with the creds it just
+  //     minted. runtime.ts only passes credsPath when set — an unset path means no
+  //     creds → own-auth Authorization Violation on the operator-mode bus. Surgical
+  //     single-key set on the SYSTEM/bus layer; NEVER touches nats_infra. Fail-fast
+  //     (before the restart) so we never restart into a broken-auth state.
+  if (
+    inputs.credsPathDefaulted === true &&
+    inputs.systemConfigWritePath !== undefined &&
+    ports.configWrite !== undefined
+  ) {
+    const wrote = ports.configWrite.writeBusCredsPath({
+      systemConfigPath: inputs.systemConfigWritePath,
+      credsPath: inputs.credsPath,
+    });
+    if (!wrote.ok) {
+      return fail(
+        plan,
+        steps,
+        `nats.credsPath write-back failed: ${wrote.reason}. The bus creds were minted at ` +
+          `${inputs.credsPath} but the daemon config still lacks nats.credsPath — add ` +
+          `\`nats.credsPath: ${inputs.credsPath}\` to ${inputs.systemConfigWritePath} by hand, then re-run.`,
+      );
+    }
+    steps.push(
+      wrote.changed
+        ? `nats.credsPath defaulted → ${inputs.credsPath} (written to config ${wrote.path})`
+        : `nats.credsPath already ${inputs.credsPath} in config ${wrote.path} (no-op)`,
+    );
   }
 
   // 4. Restart the cortex daemon so it reconnects with the new creds.

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -1910,10 +1910,26 @@ function deriveMakeLiveInputs(
     };
   }
 
-  const credsPath = optionalValueFlag(flags, "--creds") ?? cfg.config.nats?.credsPath;
-  if (credsPath === undefined || credsPath === "") {
-    return { ok: false, reason: "cannot resolve nats.credsPath — pass --creds or set `nats.credsPath` in config", usage: true };
-  }
+  // `nats.credsPath` is the daemon's OWN BUS creds — the user minted under the
+  // `agents` account by make-live's own `add-bot` (network-make-live-lib.ts:179,
+  // network-make-live-adapters.ts:96). It is DISTINCT from
+  // `stack.nats_infra.creds_path`, the FEDERATION LEAF creds minted under a
+  // DIFFERENT account at `network join`. The two must NEVER be conflated: a
+  // fallback to `nats_infra.creds_path` here would mint the bus user under the
+  // wrong account and collide with the leaf at join time (a tester proposed
+  // exactly that — it is wrong). When neither --creds nor config supplies a path,
+  // default to the conventional per-stack bus-creds path
+  // `~/.config/nats/<slug>.creds` — mirroring the nats-server config_path
+  // convention (`~/.config/nats/<slug>.conf`) and what live stacks already carry
+  // (community.creds, …). A from-scratch `cortex stack create` stack now also
+  // seeds this key explicitly in system.yaml, so this runtime default is the belt
+  // to that brace: a pre-existing, unseeded stack needs NO --creds flag for
+  // from-scratch make-live.
+  const credsPathRaw = optionalValueFlag(flags, "--creds") ?? cfg.config.nats?.credsPath;
+  const credsPath =
+    credsPathRaw !== undefined && credsPathRaw !== ""
+      ? credsPathRaw
+      : `~/.config/nats/${slug}.creds`;
   const botName = cfg.config.nats?.name ?? "cortex";
   // BLOCK 1 — derive the nats-server config PER STACK from the stack's OWN config
   // (`stack.nats_infra.config_path`, the same field `network join` derives from),

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -1910,26 +1910,28 @@ function deriveMakeLiveInputs(
     };
   }
 
-  // `nats.credsPath` is the daemon's OWN BUS creds — the user minted under the
-  // `agents` account by make-live's own `add-bot` (network-make-live-lib.ts:179,
+  // `nats.credsPath` is the daemon's OWN BUS/BOT creds — the user minted under
+  // the `agents` account by make-live's own `add-bot` (network-make-live-lib.ts:179,
   // network-make-live-adapters.ts:96). It is DISTINCT from
-  // `stack.nats_infra.creds_path`, the FEDERATION LEAF creds minted under a
-  // DIFFERENT account at `network join`. The two must NEVER be conflated: a
-  // fallback to `nats_infra.creds_path` here would mint the bus user under the
-  // wrong account and collide with the leaf at join time (a tester proposed
-  // exactly that — it is wrong). When neither --creds nor config supplies a path,
-  // default to the conventional per-stack bus-creds path
-  // `~/.config/nats/<slug>.creds` — mirroring the nats-server config_path
-  // convention (`~/.config/nats/<slug>.conf`) and what live stacks already carry
-  // (community.creds, …). A from-scratch `cortex stack create` stack now also
-  // seeds this key explicitly in system.yaml, so this runtime default is the belt
-  // to that brace: a pre-existing, unseeded stack needs NO --creds flag for
-  // from-scratch make-live.
+  // `stack.nats_infra.creds_path`, the FEDERATION creds minted under a DIFFERENT
+  // account at `network join`. The two must NEVER be conflated: a fallback to
+  // `nats_infra.creds_path` here would mint the bus user under the wrong account
+  // and collide with the federation user at join time (a tester proposed exactly
+  // that — it is wrong). When neither --creds nor config supplies a path, default
+  // to `~/.config/nats/<slug>-bot.creds` — the `-bot` suffix is LOAD-BEARING: it
+  // keeps this BUS/BOT-user path DISTINCT from provision's FEDERATION-user default
+  // `~/.config/nats/<slug>.creds` (deriveProvisionInputs, below). Two different
+  // NATS accounts MUST be two different files; a bare `<slug>.creds` here would
+  // resolve to the SAME path provision uses, so make-live (bus user, agents
+  // account) and `network join` (federation user) would clobber each other. A
+  // from-scratch `cortex stack create` stack now also seeds this key explicitly in
+  // system.yaml, so this runtime default is the belt to that brace: a pre-existing,
+  // unseeded stack needs NO --creds flag for from-scratch make-live.
   const credsPathRaw = optionalValueFlag(flags, "--creds") ?? cfg.config.nats?.credsPath;
   const credsPath =
     credsPathRaw !== undefined && credsPathRaw !== ""
       ? credsPathRaw
-      : `~/.config/nats/${slug}.creds`;
+      : `~/.config/nats/${slug}-bot.creds`;
   const botName = cfg.config.nats?.name ?? "cortex";
   // BLOCK 1 — derive the nats-server config PER STACK from the stack's OWN config
   // (`stack.nats_infra.config_path`, the same field `network join` derives from),
@@ -2125,6 +2127,10 @@ function deriveProvisionInputs(
   if (!names.ok) return { ok: false, reason: names.reason, usage: true };
 
   const seedPath = optionalValueFlag(flags, "--seed-path") ?? cfg.stack?.nkey_seed_path ?? `~/.config/nats/${principal}-${slug}.seed`;
+  // FEDERATION-user creds default. DELIBERATELY DISTINCT from make-live's BUS/BOT
+  // creds default `~/.config/nats/<slug>-bot.creds` (deriveMakeLiveInputs, above):
+  // these are two different NATS accounts (federation vs `agents`), so they MUST
+  // be two different files — a shared path would clobber on the second mint.
   const credsPath = optionalValueFlag(flags, "--creds") ?? cfg.stack?.nats_infra?.creds_path ?? `~/.config/nats/${slug}.creds`;
   // cortex#1265 (PR8) — the per-stack nats-server config path make-live + join
   // derive their `--nats-config` from. Preserve a value already in config (the

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -1928,10 +1928,8 @@ function deriveMakeLiveInputs(
   // system.yaml, so this runtime default is the belt to that brace: a pre-existing,
   // unseeded stack needs NO --creds flag for from-scratch make-live.
   const credsPathRaw = optionalValueFlag(flags, "--creds") ?? cfg.config.nats?.credsPath;
-  const credsPath =
-    credsPathRaw !== undefined && credsPathRaw !== ""
-      ? credsPathRaw
-      : `~/.config/nats/${slug}-bot.creds`;
+  const credsPathExplicit = credsPathRaw !== undefined && credsPathRaw !== "";
+  const credsPath = credsPathExplicit ? credsPathRaw : `~/.config/nats/${slug}-bot.creds`;
   const botName = cfg.config.nats?.name ?? "cortex";
   // BLOCK 1 — derive the nats-server config PER STACK from the stack's OWN config
   // (`stack.nats_infra.config_path`, the same field `network join` derives from),
@@ -2017,6 +2015,12 @@ function deriveMakeLiveInputs(
     botName,
     credsPath,
     cortexConfigPath: configPath,
+    // cortex#1265 (v5.30.2) — when credsPath was DEFAULTED, make-live persists the
+    // resolved path into the SYSTEM-layer config so the daemon connects with it
+    // (runtime.ts only passes credsPath when set). An explicit --creds/config value
+    // is never overwritten (credsPathDefaulted stays false).
+    credsPathDefaulted: !credsPathExplicit,
+    systemConfigWritePath: resolveSystemWriteConfigPath(configPath),
     natsConfigPath,
     force,
     apply: applyRes.apply,
@@ -2069,6 +2073,23 @@ function resolveStackWriteConfigPath(configPath: string): string {
     const base = (expanded.split("/").pop() ?? "").replace(/\.ya?ml$/i, "");
     return join(configDir, "stacks", `${base}.yaml`);
   }
+  return expanded;
+}
+
+/**
+ * Resolve where a DEFAULTED `nats.credsPath` write-back lands (cortex#1265,
+ * v5.30.2). `nats` is the SYSTEM/bus layer: in a config-split layout it lives in
+ * `<configDir>/system/system.yaml`; a legacy monolith carries it in the single
+ * file. Sibling of {@link resolveStackWriteConfigPath} but targeting the SYSTEM
+ * layer — the stack-layer file owns `nats_infra`, NOT `config.nats`. Writing
+ * `nats.credsPath` to the stack file would split-brain it away from the
+ * stack-create seed (which writes system.yaml) and from the config-table owner.
+ */
+function resolveSystemWriteConfigPath(configPath: string): string {
+  const expanded = expandTilde(configPath);
+  const configDir = expanded.replace(/\/[^/]*$/, "");
+  const systemYaml = join(configDir, "system", "system.yaml");
+  if (existsSync(systemYaml)) return systemYaml;
   return expanded;
 }
 

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -235,7 +235,7 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   const Display = displayName;
 
   return [
-    { relPath: "system/system.yaml", contents: systemYaml() },
+    { relPath: "system/system.yaml", contents: systemYaml(slug) },
     { relPath: "surfaces/surfaces.yaml", contents: surfacesYaml(agentId, stackId) },
     { relPath: `stacks/${slug}.yaml`, contents: stackYaml(slug, principal, stackId, agentId, Display, seedPath) },
     { relPath: `${slug}.yaml`, contents: pointerYaml(slug) },
@@ -243,7 +243,7 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   ];
 }
 
-function systemYaml(): string {
+function systemYaml(slug: string): string {
   // The cross-cutting substrate layer — substituted from
   // docs/config-layout/system/system.yaml. Identity is left at the safe
   // conventional default; `arc upgrade Cortex` auto-provisions the seed.
@@ -286,6 +286,12 @@ nats:
   url: nats://127.0.0.1:4222
   name: cortex
   subjects: []
+  # credsPath — the daemon's OWN bus creds, minted under the \`agents\` account by
+  # \`cortex network make-live\` (via add-bot). DISTINCT from
+  # stacks/${slug}.yaml's \`stack.nats_infra.creds_path\` (the FEDERATION LEAF creds,
+  # minted at \`cortex network join\` under a different account) — never conflate
+  # them. Conventional per-stack path, mirroring \`~/.config/nats/<slug>.conf\`.
+  credsPath: ~/.config/nats/${slug}.creds
   # NKey identity for envelope signing. The seedPath is the conventional path
   # \`arc upgrade Cortex\` auto-provisions on first install; publicKey is pinned
   # after first boot (paste from the cortex log \`stack signing key staged …\`).

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -286,12 +286,14 @@ nats:
   url: nats://127.0.0.1:4222
   name: cortex
   subjects: []
-  # credsPath — the daemon's OWN bus creds, minted under the \`agents\` account by
-  # \`cortex network make-live\` (via add-bot). DISTINCT from
-  # stacks/${slug}.yaml's \`stack.nats_infra.creds_path\` (the FEDERATION LEAF creds,
-  # minted at \`cortex network join\` under a different account) — never conflate
-  # them. Conventional per-stack path, mirroring \`~/.config/nats/<slug>.conf\`.
-  credsPath: ~/.config/nats/${slug}.creds
+  # credsPath — the daemon's OWN bus/bot creds, minted under the \`agents\` account
+  # by \`cortex network make-live\` (via add-bot). The \`-bot\` suffix is LOAD-BEARING:
+  # it keeps this path DISTINCT from stacks/${slug}.yaml's
+  # \`stack.nats_infra.creds_path\` (the FEDERATION creds, minted at
+  # \`cortex network join\` under a DIFFERENT account, conventional default
+  # \`~/.config/nats/${slug}.creds\`). Two different NATS accounts MUST be two
+  # different files — a shared path would clobber on the second mint.
+  credsPath: ~/.config/nats/${slug}-bot.creds
   # NKey identity for envelope signing. The seedPath is the conventional path
   # \`arc upgrade Cortex\` auto-provisions on first install; publicKey is pinned
   # after first boot (paste from the cortex log \`stack signing key staged …\`).

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -355,8 +355,10 @@ function renderPlan(
     lines.push("Next steps:");
     lines.push("  1. Fill the <REPLACE_ME> markers (Discord token/guild/channels, your Discord id).");
     lines.push(`  2. Provision the signing seed: arc upgrade Cortex   (auto-provisions ${seedPath} on first install)`);
-    lines.push(`  3. Point your daemon at the pointer: cortex start --config ${join(targetDir, `${slug}.yaml`)}`);
-    lines.push(`  4. Federate (optional): cortex network join <network>   (run from this stack's config)`);
+    lines.push(`  3. Mint this stack's bus account tree: cortex network provision ${slug} --apply   (mints the agents/system accounts)`);
+    lines.push(`  4. Bring the bus live: cortex network make-live ${slug} --apply   (mints this daemon's bus creds at ~/.config/nats/${slug}.creds + restarts nats-server)`);
+    lines.push(`  5. Point your daemon at the pointer: cortex start --config ${join(targetDir, `${slug}.yaml`)}`);
+    lines.push(`  6. Federate (optional): cortex network join <network>   (run from this stack's config)`);
   } else {
     lines.push("Re-run with --apply to write these files.");
   }

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -356,7 +356,7 @@ function renderPlan(
     lines.push("  1. Fill the <REPLACE_ME> markers (Discord token/guild/channels, your Discord id).");
     lines.push(`  2. Provision the signing seed: arc upgrade Cortex   (auto-provisions ${seedPath} on first install)`);
     lines.push(`  3. Mint this stack's bus account tree: cortex network provision ${slug} --apply   (mints the agents/system accounts)`);
-    lines.push(`  4. Bring the bus live: cortex network make-live ${slug} --apply   (mints this daemon's bus creds at ~/.config/nats/${slug}.creds + restarts nats-server)`);
+    lines.push(`  4. Bring the bus live: cortex network make-live ${slug} --apply   (mints this daemon's bus creds at ~/.config/nats/${slug}-bot.creds + restarts nats-server)`);
     lines.push(`  5. Point your daemon at the pointer: cortex start --config ${join(targetDir, `${slug}.yaml`)}`);
     lines.push(`  6. Federate (optional): cortex network join <network>   (run from this stack's config)`);
   } else {


### PR DESCRIPTION
## What & why
v5.30.1 closed the config-path loop; a walker retest (Rob, on Lares) confirmed it works end-to-end but found make-live still required `--creds` on a from-scratch stack. Root cause: `cortex stack create` never seeded `nats.credsPath`, so it was unset and make-live's resolver hard-errored.

## The fix
- **make-live defaults `nats.credsPath`** when unset → `~/.config/nats/<slug>-bot.creds` (precedence `--creds` > config > default). From-scratch ladder is now **zero-flag**.
- **`stack create` seeds** `nats.credsPath: ~/.config/nats/<slug>-bot.creds` so new stacks are self-documenting.
- **`stack create` next-steps** now teach the `provision → make-live` ladder, not just join.
- **Prereqs block** in `sop-onboard-peer-principal.md §2` (Bun · NATS+JS · Claude Code · arc).

## Trust-path: bus vs federation creds
`nats.credsPath` = the daemon's **bus** user (agents account, `add-bot`) — DISTINCT from `nats_infra.creds_path`, the **federation** leaf user (federation account, minted at join). A tester proposed falling back one to the other — wrong (different accounts). **Pre-review diagnosis caught a collision:** the initial bus default `<slug>.creds` was byte-identical to provision's federation default (`network.ts:2128`) → clobber on first federation. Fixed: bus default is the distinct `-bot` path; a test asserts the bus and federation defaults can never resolve to the same file.

## Residual (flagged)
- Pre-existing latent collision in the live `community` stack (bus == fed == `community.creds`) — out of scope here; needs a hand-edit if community ever federates.
- An operator can still hand-set `nats.credsPath == nats_infra.creds_path` and collide — defaults no longer cause it; a load-time cross-field validation is a candidate follow-up.

## Verification
tsc 0 · lint:errors 0 · check-carveouts PASS · 960 tests pass. Trust-path → adversarial review before merge.

Continuation of onboarding-hardening; retest by Rob confirmed v5.30.1's fix #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)