### PR TITLE
chore: bump to v5.30.2 — C-1265c zero-flag make-live creds + onboarding ladder

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.30.1"
+version: "5.30.2"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Release bump for **#1305** (C-1265c). make-live defaults `nats.credsPath` → `~/.config/nats/<slug>-bot.creds` (bus creds, distinct from the federation `<slug>.creds`) + writes it back to config; `stack create` seeds it + surfaces the provision→make-live ladder; prereqs block added. From-scratch onboarding is now fully zero-flag. Rob's Linux retest confirmed v5.30.1's loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)