### PR TITLE
docs: Discord post-style rule — go easy on thank-you emojis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,10 @@ When invoked from a channel or thread, the agent should:
 
 See `docs/sop-discord-channel-routing.md` for the full SOP (lifted from grove-v2 at MIG-7.11).
 
+### Discord post style
+
+Keep posts **substantive and low-ceremony**. We turn work around fast, so back-to-back posts that each close with a thank-you emoji (🙏) read as repetitive filler. Use a closing 🙏 / "thanks" **sparingly** — reserve it for genuine first-time moments (a real first contribution, acknowledging a sharp catch the first time it happens), not as a default sign-off on every message. Default to ending on the substance. Same for decorative emoji generally: one purposeful lead emoji is fine; don't stack them.
+
 ## PAI Integration
 
 cortex provides two ways to integrate from PAI sessions (outside of Discord):

--- a/docs/agents-md/discord-routing.md
+++ b/docs/agents-md/discord-routing.md
@@ -16,3 +16,7 @@ When invoked from a channel or thread, the agent should:
 4. Route worklog to the invoking thread/channel
 
 See `docs/sop-discord-channel-routing.md` for the full SOP (lifted from grove-v2 at MIG-7.11).
+
+### Discord post style
+
+Keep posts **substantive and low-ceremony**. We turn work around fast, so back-to-back posts that each close with a thank-you emoji (🙏) read as repetitive filler. Use a closing 🙏 / "thanks" **sparingly** — reserve it for genuine first-time moments (a real first contribution, acknowledging a sharp catch the first time it happens), not as a default sign-off on every message. Default to ending on the substance. Same for decorative emoji generally: one purposeful lead emoji is fine; don't stack them.


### PR DESCRIPTION
Adds a **Discord post style** rule to CLAUDE.md (via its `discord-routing.md` section source): we turn work around fast, so back-to-back posts each closing with 🙏 read as filler — use a closing thank-you **sparingly** (genuine first-time moments only, not a default sign-off), and don't stack decorative emoji.

Both the section source (`docs/agents-md/discord-routing.md`) and the matching generated CLAUDE.md block are updated, cortex-only — deliberately **not** via `arc upgrade compass` (which regenerates ~165 checkouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)