### PR TITLE
feat(web): C-110 — generic web/SSE surface adapter

### DIFF
--- a/blueprint.yaml
+++ b/blueprint.yaml
@@ -18,6 +18,7 @@ features:
       - C-107
       - C-108
       - C-109
+      - C-110
 
   C-101:
     name: MIG-0 — Cortex repo bootstrap
@@ -120,6 +121,17 @@ features:
     parent: C-100
     issue: 10
     depends_on: [C-108]
+
+  C-110:
+    name: Generic web/SSE surface adapter
+    status: in-progress
+    description: >
+      WebAdapter implements PlatformAdapter for any web or SSE-backed bot surface.
+      Any web app becomes a cortex-backed bot by POSTing to POST /message and
+      receiving responses via a configurable broadcastUrl. Includes WebBindingSchema
+      + WebSurfaceBindingSchema types, gateway-adapter factory wiring, and a full
+      45-test suite. Completely AMT-agnostic — a second tenant binds with its own
+      instanceId + broadcastUrl + agent, zero adapter-code changes.
 
   I-100:
     name: Internet of Agentic Work (umbrella META)

--- a/src/adapters/web/__tests__/web-adapter.test.ts
+++ b/src/adapters/web/__tests__/web-adapter.test.ts
@@ -22,7 +22,7 @@ import type { PlatformAdapter } from "../../types";
 // Fixtures
 // =============================================================================
 
-const BROADCAST_CAPTURES: { url: string; body: unknown }[] = [];
+const BROADCAST_CAPTURES: { url: string; body: unknown; headers: Record<string, string> }[] = [];
 
 /** Intercept all fetch calls that go to the broadcastUrl. */
 const originalFetch = globalThis.fetch;
@@ -33,7 +33,8 @@ async function withBroadcastCapture(fn: () => Promise<void>): Promise<void> {
     const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
     if (urlStr.includes("broadcast")) {
       const body = init?.body ? JSON.parse(init.body as string) : null;
-      BROADCAST_CAPTURES.push({ url: urlStr, body });
+      const headers = { ...(init?.headers as Record<string, string> | undefined) };
+      BROADCAST_CAPTURES.push({ url: urlStr, body, headers });
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -209,6 +210,85 @@ describe("WebAdapter — HTTP ingress", () => {
     });
     await new Promise((r) => setTimeout(r, 20));
     expect(messages[0]?.threadId).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// 2b. Inbound service auth (inboundToken — service-to-service gate)
+// =============================================================================
+
+describe("WebAdapter — inbound service auth (inboundToken)", () => {
+  let adapter: WebAdapter;
+  let port: number;
+
+  afterEach(async () => {
+    await adapter.stop();
+  });
+
+  async function startWithToken(token?: string): Promise<void> {
+    adapter = new WebAdapter(
+      makeSyntheticAgent(),
+      makeBinding({ port: 0, authScheme: "none", inboundToken: token }),
+      makeInfra({ instanceId: "web:svc-test" }),
+    );
+    await adapter.start(async () => {});
+    port = adapter.serverPort!;
+  }
+
+  const validBody = JSON.stringify({ channel: "room-1", body: "hello" });
+  const jsonHeaders = { "Content-Type": "application/json" };
+
+  test("no inboundToken → any request accepted (localhost default)", async () => {
+    await startWithToken(undefined);
+    const res = await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: validBody,
+    });
+    expect(res.status).toBe(202);
+  });
+
+  test("inboundToken set, missing Authorization → 401", async () => {
+    await startWithToken("secret-svc-token");
+    const res = await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: validBody,
+    });
+    expect(res.status).toBe(401);
+    const json = await res.json() as { error: string };
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  test("inboundToken set, wrong token → 401", async () => {
+    await startWithToken("secret-svc-token");
+    const res = await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { ...jsonHeaders, Authorization: "Bearer wrong-token" },
+      body: validBody,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("inboundToken set, correct Bearer token → 202 Accepted", async () => {
+    await startWithToken("secret-svc-token");
+    const res = await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { ...jsonHeaders, Authorization: "Bearer secret-svc-token" },
+      body: validBody,
+    });
+    expect(res.status).toBe(202);
+  });
+
+  test("401 fires before body parsing — malformed JSON still returns 401, not 400", async () => {
+    await startWithToken("tok");
+    const res = await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "NOT_JSON",
+    });
+    // Auth gate runs first — must be 401 (not 400 from body parse failure)
+    expect(res.status).toBe(401);
   });
 });
 
@@ -399,6 +479,24 @@ describe("WebAdapter — outbound broadcast", () => {
     const adapter = new WebAdapter(makeSyntheticAgent(), failBinding, infra);
     // Must not reject — await directly; any thrown error would fail the test
     await adapter.postResponse({ instanceId: "web:amt", channelId: "ch" }, "text");
+  });
+
+  test("broadcastToken set → POST includes Authorization: Bearer header", async () => {
+    const tokenBinding = makeBinding({ broadcastToken: "cortex-svc-secret" });
+    const adapter = new WebAdapter(makeSyntheticAgent(), tokenBinding, infra);
+    await withBroadcastCapture(async () => {
+      await adapter.postResponse({ instanceId: "web:amt", channelId: "ch" }, "text");
+    });
+    expect(BROADCAST_CAPTURES[0]?.headers?.Authorization).toBe("Bearer cortex-svc-secret");
+  });
+
+  test("no broadcastToken → POST has no Authorization header (localhost default)", async () => {
+    // binding has no broadcastToken (localhost — no outbound service auth)
+    const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
+    await withBroadcastCapture(async () => {
+      await adapter.postResponse({ instanceId: "web:amt", channelId: "ch" }, "text");
+    });
+    expect(BROADCAST_CAPTURES[0]?.headers?.Authorization).toBeUndefined();
   });
 });
 

--- a/src/adapters/web/__tests__/web-adapter.test.ts
+++ b/src/adapters/web/__tests__/web-adapter.test.ts
@@ -1,0 +1,770 @@
+/**
+ * C-110: WebAdapter tests — inbound message mapping, auth extraction,
+ * outbound broadcast, access control, and gateway factory wiring.
+ *
+ * All tests use the adapter in construct-only mode (no real Bun server started)
+ * except the HTTP round-trip tests which use Bun's built-in server on an
+ * ephemeral port.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { WebAdapter } from "../index";
+import type { WebAdapterInfra } from "../index";
+import { WebBindingSchema, SurfacesSchema } from "../../../common/types/surfaces";
+import type { WebBinding } from "../../../common/types/surfaces";
+import type { InboundMessage } from "../../types";
+import { buildGatewayAdapters } from "../../../gateway/gateway-adapters";
+import type { GatewayAdapterFactory } from "../../../gateway/gateway-adapters";
+import type { Surfaces } from "../../../common/types/surfaces";
+import type { PlatformAdapter } from "../../types";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const BROADCAST_CAPTURES: { url: string; body: unknown }[] = [];
+
+/** Intercept all fetch calls that go to the broadcastUrl. */
+const originalFetch = globalThis.fetch;
+
+async function withBroadcastCapture(fn: () => Promise<void>): Promise<void> {
+  BROADCAST_CAPTURES.length = 0;
+  const spy = async (url: string | Request | URL, init?: RequestInit) => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+    if (urlStr.includes("broadcast")) {
+      const body = init?.body ? JSON.parse(init.body as string) : null;
+      BROADCAST_CAPTURES.push({ url: urlStr, body });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return originalFetch(url, init);
+  };
+  globalThis.fetch = spy as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = originalFetch;
+  });
+}
+
+function makeBinding(overrides: Partial<WebBinding> = {}): WebBinding {
+  return {
+    instanceId: "amt",
+    port: 0, // ephemeral — overridden per test
+    broadcastUrl: "http://localhost:9999/broadcast",
+    transport: "ws",
+    authScheme: "none",
+    ...overrides,
+  };
+}
+
+function makeInfra(overrides: Partial<WebAdapterInfra> = {}): WebAdapterInfra {
+  return {
+    instanceId: "web:amt",
+    principal: {},
+    ...overrides,
+  };
+}
+
+function makeSyntheticAgent(id = "gateway") {
+  return {
+    id,
+    displayName: id,
+    persona: "(synthetic)",
+    trust: [],
+    presence: {},
+  };
+}
+
+// =============================================================================
+// 1. Platform identity
+// =============================================================================
+
+describe("WebAdapter — identity", () => {
+  test("platform is 'web'", () => {
+    const adapter = new WebAdapter(makeSyntheticAgent(), makeBinding(), makeInfra());
+    expect(adapter.platform).toBe("web");
+  });
+
+  test("instanceId comes from infra", () => {
+    const adapter = new WebAdapter(makeSyntheticAgent(), makeBinding(), makeInfra({ instanceId: "web:amt" }));
+    expect(adapter.instanceId).toBe("web:amt");
+  });
+
+  test("getPlatformUserId returns stable web:{instanceId}", async () => {
+    const adapter = new WebAdapter(makeSyntheticAgent(), makeBinding(), makeInfra({ instanceId: "web:amt" }));
+    const id = await adapter.getPlatformUserId();
+    expect(id).toBe("web:web:amt");
+  });
+});
+
+// =============================================================================
+// 2. HTTP ingress — health + routing
+// =============================================================================
+
+describe("WebAdapter — HTTP ingress", () => {
+  let adapter: WebAdapter;
+  let port: number;
+  const messages: InboundMessage[] = [];
+
+  beforeEach(async () => {
+    messages.length = 0;
+    // Use ephemeral port (0) so Bun assigns a free port — no collision risk.
+    adapter = new WebAdapter(
+      makeSyntheticAgent(),
+      makeBinding({ port: 0, authScheme: "none" }),
+      makeInfra({ instanceId: "web:amt" }),
+    );
+    await adapter.start(async (msg) => {
+      messages.push(msg);
+    });
+    port = adapter.serverPort!;
+  });
+
+  afterEach(async () => {
+    await adapter.stop();
+  });
+
+  test("GET /health returns 200 with adapter id", async () => {
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string; adapter: string };
+    expect(body.status).toBe("ok");
+    expect(body.adapter).toBe("web:amt");
+  });
+
+  test("unknown path returns 404", async () => {
+    const res = await fetch(`http://localhost:${port}/unknown`);
+    expect(res.status).toBe(404);
+  });
+
+  test("GET /message returns 404 (only POST accepted)", async () => {
+    const res = await fetch(`http://localhost:${port}/message`);
+    expect(res.status).toBe(404);
+  });
+
+  test("POST /message returns 202 Accepted", async () => {
+    const res = await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "general", body: "hello cortex" }),
+    });
+    expect(res.status).toBe(202);
+    const json = await res.json() as { status: string };
+    expect(json.status).toBe("accepted");
+  });
+
+  test("POST /message missing channel returns 400", async () => {
+    const res = await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body: "hello" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /message missing body returns 400", async () => {
+    const res = await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "general" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /message dispatches InboundMessage with correct fields", async () => {
+    await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        channel: "general",
+        thread: "thread-123",
+        body: "hello cortex",
+        user: "Alice",
+      }),
+    });
+
+    // Give the async dispatch a tick to complete
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(messages).toHaveLength(1);
+    const msg = messages[0]!;
+    expect(msg.platform).toBe("web");
+    expect(msg.instanceId).toBe("web:amt");
+    expect(msg.content).toBe("hello cortex");
+    expect(msg.channelId).toBe("general");
+    expect(msg.threadId).toBe("thread-123");
+    expect(msg.channelName).toBe("general");
+    expect(msg.threadName).toBe("thread-123");
+    expect(msg.authorName).toBe("Alice");
+    expect(msg.attachments).toEqual([]);
+    expect(msg.timestamp).toBeInstanceOf(Date);
+  });
+
+  test("POST /message without thread has no threadId", async () => {
+    await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "general", body: "top-level" }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(messages[0]?.threadId).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// 3. Auth extraction
+// =============================================================================
+
+describe("WebAdapter — auth extraction", () => {
+  let adapter: WebAdapter;
+  let port: number;
+  const messages: InboundMessage[] = [];
+
+  afterEach(async () => {
+    await adapter.stop();
+    messages.length = 0;
+  });
+
+  async function startWith(authScheme: WebBinding["authScheme"], authHeader?: string) {
+    // Use ephemeral port (0) — Bun assigns a free port so no collision risk.
+    adapter = new WebAdapter(
+      makeSyntheticAgent(),
+      makeBinding({ port: 0, authScheme, authHeader }),
+      makeInfra({ instanceId: "web:test" }),
+    );
+    await adapter.start(async (msg) => { messages.push(msg); });
+    port = adapter.serverPort!;
+  }
+
+  test("authScheme=none → authorId is dev:web:{instanceId}", async () => {
+    await startWith("none");
+    await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "ch", body: "hi" }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(messages[0]?.authorId).toBe("dev:web:web:test");
+  });
+
+  test("authScheme=header reads the named header", async () => {
+    await startWith("header", "X-User-Id");
+    await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-User-Id": "alice@example.com" },
+      body: JSON.stringify({ channel: "ch", body: "hi" }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(messages[0]?.authorId).toBe("alice@example.com");
+  });
+
+  test("authScheme=header missing header → anon fallback", async () => {
+    await startWith("header", "X-User-Id");
+    await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "ch", body: "hi" }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(messages[0]?.authorId).toMatch(/^anon:web:/);
+  });
+
+  test("authScheme=cf-access decodes JWT sub claim", async () => {
+    await startWith("cf-access");
+    // Build a minimal CF Access JWT with sub claim (no real sig — adapter only decodes)
+    const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+    const payload = btoa(JSON.stringify({ sub: "user@example.com", iat: 1000 }));
+    const sig = "fakesig";
+    const jwt = `${header}.${payload}.${sig}`;
+
+    await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Cf-Access-Jwt-Assertion": jwt,
+      },
+      body: JSON.stringify({ channel: "ch", body: "hi" }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(messages[0]?.authorId).toBe("user@example.com");
+  });
+
+  test("authScheme=cf-access missing header → anon fallback", async () => {
+    await startWith("cf-access");
+    await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "ch", body: "hi" }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(messages[0]?.authorId).toMatch(/^anon:web:/);
+  });
+
+  test("body.user field NEVER becomes authorId (platform-signed headers only)", async () => {
+    await startWith("header", "X-User-Id");
+    await fetch(`http://localhost:${port}/message`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-User-Id": "real-user",
+      },
+      body: JSON.stringify({ channel: "ch", body: "hi", user: "injected-attacker" }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    const msg = messages[0]!;
+    // authorId from header — NOT from the body's user field
+    expect(msg.authorId).toBe("real-user");
+    // authorName CAN come from user field (display name only — not an auth claim)
+    expect(msg.authorName).toBe("injected-attacker");
+  });
+});
+
+// =============================================================================
+// 4. Outbound broadcast
+// =============================================================================
+
+describe("WebAdapter — outbound broadcast", () => {
+  const binding = makeBinding({
+    instanceId: "amt",
+    broadcastUrl: "http://localhost:9999/broadcast",
+    authScheme: "none",
+  });
+  const infra = makeInfra({ instanceId: "web:amt" });
+
+  test("postResponse POSTs correct payload shape", async () => {
+    const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
+    await withBroadcastCapture(async () => {
+      await adapter.postResponse(
+        { instanceId: "web:amt", channelId: "general", threadId: "t1" },
+        "Hello from cortex",
+      );
+    });
+    expect(BROADCAST_CAPTURES).toHaveLength(1);
+    const payload = BROADCAST_CAPTURES[0]?.body as Record<string, unknown>;
+    expect(payload.adapter_instance).toBe("web:amt");
+    expect(payload.type).toBe("response");
+    expect(payload.text).toBe("Hello from cortex");
+    expect((payload.target as Record<string, unknown>).channel).toBe("general");
+    expect((payload.target as Record<string, unknown>).thread).toBe("t1");
+  });
+
+  test("postResponse without threadId omits thread key", async () => {
+    const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
+    await withBroadcastCapture(async () => {
+      await adapter.postResponse(
+        { instanceId: "web:amt", channelId: "general" },
+        "Response",
+      );
+    });
+    const payload = BROADCAST_CAPTURES[0]?.body as Record<string, unknown>;
+    expect((payload.target as Record<string, unknown>).thread).toBeUndefined();
+  });
+
+  test("sendProgress POSTs type=progress", async () => {
+    const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
+    await withBroadcastCapture(async () => {
+      await adapter.sendProgress(
+        { instanceId: "web:amt", channelId: "general" },
+        "Working...",
+      );
+    });
+    const payload = BROADCAST_CAPTURES[0]?.body as Record<string, unknown>;
+    expect(payload.type).toBe("progress");
+    expect(payload.text).toBe("Working...");
+  });
+
+  test("clearProgress POSTs type=clear_progress without text", async () => {
+    const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
+    await withBroadcastCapture(async () => {
+      await adapter.clearProgress({ instanceId: "web:amt", channelId: "general" });
+    });
+    const payload = BROADCAST_CAPTURES[0]?.body as Record<string, unknown>;
+    expect(payload.type).toBe("clear_progress");
+    expect(payload.text).toBeUndefined();
+  });
+
+  test("notifyPrincipal POSTs to _principal channel", async () => {
+    const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
+    await withBroadcastCapture(async () => {
+      await adapter.notifyPrincipal("System alert");
+    });
+    const payload = BROADCAST_CAPTURES[0]?.body as Record<string, unknown>;
+    expect((payload.target as Record<string, unknown>).channel).toBe("_principal");
+  });
+
+  test("broadcast failure does not throw (logged + swallowed)", async () => {
+    // broadcastUrl that will fail
+    const failBinding = makeBinding({ broadcastUrl: "http://localhost:1/unreachable" });
+    const adapter = new WebAdapter(makeSyntheticAgent(), failBinding, infra);
+    // Must not reject — await directly; any thrown error would fail the test
+    await adapter.postResponse({ instanceId: "web:amt", channelId: "ch" }, "text");
+  });
+});
+
+// =============================================================================
+// 5. PlatformAdapter contract stubs
+// =============================================================================
+
+describe("WebAdapter — interface contract", () => {
+  const adapter = new WebAdapter(makeSyntheticAgent(), makeBinding(), makeInfra());
+
+  test("sendTyping is a no-op", async () => {
+    // Must resolve without throwing
+    await adapter.sendTyping({ instanceId: "web:amt", channelId: "ch" });
+  });
+
+  test("fetchContext returns empty array", async () => {
+    const ctx = await adapter.fetchContext(
+      { platform: "web", instanceId: "web:amt", authorId: "u1", authorName: "U",
+        content: "x", channelId: "ch", attachments: [], timestamp: new Date() },
+      10,
+    );
+    expect(ctx).toEqual([]);
+  });
+
+  test("resolveLogicalTarget returns null (not yet wired)", async () => {
+    const result = await adapter.resolveLogicalTarget({ surface: "web", channel: "ch" });
+    expect(result).toBeNull();
+  });
+
+  test("createThread returns a ResponseTarget with threadId", async () => {
+    const msg: InboundMessage = {
+      platform: "web", instanceId: "web:amt", authorId: "u1", authorName: "U",
+      content: "x", channelId: "channel-1", attachments: [], timestamp: new Date(),
+    };
+    const target = await adapter.createThread(msg, "thread-name");
+    expect(target.instanceId).toBe("web:amt");
+    expect(target.channelId).toBe("channel-1");
+    expect(target.threadId).toBe("channel-1"); // no threadId on msg → uses channelId
+  });
+
+  test("createThread preserves existing threadId", async () => {
+    const msg: InboundMessage = {
+      platform: "web", instanceId: "web:amt", authorId: "u1", authorName: "U",
+      content: "x", channelId: "channel-1", threadId: "thread-root",
+      attachments: [], timestamp: new Date(),
+    };
+    const target = await adapter.createThread(msg, "name");
+    expect(target.threadId).toBe("thread-root");
+  });
+
+  test("resolveAccess returns denyCode=no_policy when no policy engine is configured", () => {
+    // Cortex security posture: deny-by-default when no policy engine is wired.
+    // The adapter must pass through whatever `resolvePolicyAccess` decides;
+    // it must NOT short-circuit to allow-all.
+    const msg: InboundMessage = {
+      platform: "web", instanceId: "web:amt", authorId: "u1", authorName: "U",
+      content: "x", channelId: "ch", attachments: [], timestamp: new Date(),
+    };
+    const decision = adapter.resolveAccess(msg);
+    // No engine → DENY_NO_POLICY; the adapter must faithfully forward the result.
+    expect(decision.allowed).toBe(false);
+    expect(decision.denyCode).toBe("no_policy");
+  });
+});
+
+// =============================================================================
+// 6. Binding schema validation
+// =============================================================================
+
+describe("WebBindingSchema — validation", () => {
+
+  test("valid binding parses correctly with defaults", () => {
+    const result = WebBindingSchema.parse({
+      instanceId: "amt",
+      broadcastUrl: "http://example.com/broadcast",
+    });
+    expect(result.instanceId).toBe("amt");
+    expect(result.port).toBe(8090); // default
+    expect(result.transport).toBe("ws"); // default
+    expect(result.authScheme).toBe("cf-access"); // default
+  });
+
+  test("missing instanceId fails validation", () => {
+    expect(() =>
+      WebBindingSchema.parse({ broadcastUrl: "http://x.com" }),
+    ).toThrow();
+  });
+
+  test("missing broadcastUrl fails validation", () => {
+    expect(() =>
+      WebBindingSchema.parse({ instanceId: "amt" }),
+    ).toThrow();
+  });
+
+  test("invalid broadcastUrl (not http) fails validation", () => {
+    expect(() =>
+      WebBindingSchema.parse({ instanceId: "amt", broadcastUrl: "ftp://example.com" }),
+    ).toThrow();
+  });
+
+  test("invalid transport fails validation", () => {
+    expect(() =>
+      WebBindingSchema.parse({ instanceId: "amt", broadcastUrl: "http://x.com", transport: "grpc" }),
+    ).toThrow();
+  });
+});
+
+// =============================================================================
+// 7. SurfacesSchema — web[] in binding map
+// =============================================================================
+
+describe("SurfacesSchema — web bindings", () => {
+
+  test("surfaces.yaml with only web[] parses without error", () => {
+    const result = SurfacesSchema.parse({
+      web: [
+        {
+          agent: "ivy",
+          binding: {
+            instanceId: "amt",
+            broadcastUrl: "http://example.com/broadcast",
+          },
+        },
+      ],
+    });
+    expect(result.web).toHaveLength(1);
+    expect(result.web?.[0]?.binding.instanceId).toBe("amt");
+  });
+
+  test("unknown top-level key still rejects (strict mode preserved)", () => {
+    expect(() =>
+      SurfacesSchema.parse({ discrod: [] }), // typo
+    ).toThrow();
+  });
+
+  test("discord + web coexist without error", () => {
+    const result = SurfacesSchema.parse({
+      discord: [],
+      web: [
+        {
+          agent: "ivy",
+          binding: { instanceId: "amt", broadcastUrl: "http://x.com" },
+        },
+      ],
+    });
+    expect(result.discord).toHaveLength(0);
+    expect(result.web).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// 8. Gateway factory — buildGatewayAdapters + web loop
+// =============================================================================
+
+describe("buildGatewayAdapters — web bindings", () => {
+  const RUNTIME_STUB = {
+    enabled: false,
+    publish: async () => {},
+    publishFederated: async () => {},
+    subscribe: undefined,
+    onEnvelope: () => ({ unregister: () => {} }),
+    stop: async () => {},
+  } as unknown as Parameters<typeof buildGatewayAdapters>[1]["runtime"];
+
+  function makeRecordingFactory(): {
+    factory: GatewayAdapterFactory;
+    calls: { platform: string; instanceId: string }[];
+  } {
+    const calls: { platform: string; instanceId: string }[] = [];
+    const stub = (platform: string, instanceId: string): PlatformAdapter => ({
+      platform,
+      instanceId,
+      start: async () => {},
+      stop: async () => {},
+      getPlatformUserId: async () => "x",
+      fetchContext: async () => [],
+      resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }),
+      postResponse: async () => {},
+      sendTyping: async () => {},
+      sendProgress: async () => {},
+      clearProgress: async () => {},
+      createThread: async () => ({ instanceId, channelId: "ch" }),
+      resolveLogicalTarget: async () => null,
+      notifyPrincipal: async () => {},
+    });
+    const factory: GatewayAdapterFactory = {
+      discord: (args) => { calls.push({ platform: "discord", instanceId: args.instanceId }); return stub("discord", args.instanceId); },
+      slack: (args) => { calls.push({ platform: "slack", instanceId: args.instanceId }); return stub("slack", args.instanceId); },
+      mattermost: (args) => { calls.push({ platform: "mattermost", instanceId: args.instanceId }); return stub("mattermost", args.instanceId); },
+      web: (args) => { calls.push({ platform: "web", instanceId: args.instanceId }); return stub("web", args.instanceId); },
+    };
+    return { factory, calls };
+  }
+
+  test("web binding produces instanceId=web:{binding.instanceId}", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const surfaces: Surfaces = {
+      web: [
+        {
+          agent: "ivy",
+          binding: {
+            instanceId: "amt",
+            broadcastUrl: "http://example.com/broadcast",
+            port: 8090,
+            transport: "ws",
+            authScheme: "cf-access",
+          },
+        },
+      ],
+    };
+    const adapters = buildGatewayAdapters(surfaces, {
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(adapters).toHaveLength(1);
+    expect(calls[0]?.instanceId).toBe("web:amt");
+    expect(calls[0]?.platform).toBe("web");
+  });
+
+  test("multiple web bindings produce multiple adapters", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const surfaces: Surfaces = {
+      web: [
+        { agent: "ivy", binding: { instanceId: "app-a", broadcastUrl: "http://a.com/broadcast", port: 8091, transport: "ws", authScheme: "none" } },
+        { agent: "ivy", binding: { instanceId: "app-b", broadcastUrl: "http://b.com/broadcast", port: 8092, transport: "sse", authScheme: "header" } },
+      ],
+    };
+    const adapters = buildGatewayAdapters(surfaces, {
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(adapters).toHaveLength(2);
+    expect(calls.map((c) => c.instanceId)).toEqual(["web:app-a", "web:app-b"]);
+  });
+
+  test("empty surfaces.web produces zero web adapters", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const adapters = buildGatewayAdapters({}, {
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(adapters).toHaveLength(0);
+    expect(calls.filter((c) => c.platform === "web")).toHaveLength(0);
+  });
+
+  test("web binding gateway source is {principal}.gateway.{instanceId}", () => {
+    let capturedSource: unknown;
+    const factory: GatewayAdapterFactory = {
+      discord: (args) => { void args; return { platform: "discord", instanceId: "x", start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
+      slack: (args) => { void args; return { platform: "slack", instanceId: "x", start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
+      mattermost: (args) => { void args; return { platform: "mattermost", instanceId: "x", start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
+      web: (args) => {
+        capturedSource = args.source;
+        return { platform: "web", instanceId: args.instanceId, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: args.instanceId, channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} };
+      },
+    };
+    buildGatewayAdapters(
+      { web: [{ agent: "ivy", binding: { instanceId: "amt", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }] },
+      { principal: "andreas", runtime: RUNTIME_STUB, factory },
+    );
+    expect(capturedSource).toMatchObject({
+      principal: "andreas",
+      agent: "gateway",
+      instance: "web:amt",
+    });
+  });
+
+  test("webBinding is forwarded to the factory", () => {
+    let capturedWebBinding: unknown;
+    const factory: GatewayAdapterFactory = {
+      discord: (args) => { void args; throw new Error("unexpected"); },
+      slack: (args) => { void args; throw new Error("unexpected"); },
+      mattermost: (args) => { void args; throw new Error("unexpected"); },
+      web: (args) => {
+        capturedWebBinding = args.webBinding;
+        return { platform: "web", instanceId: args.instanceId, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: args.instanceId, channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} };
+      },
+    };
+    buildGatewayAdapters(
+      { web: [{ agent: "ivy", binding: { instanceId: "amt", broadcastUrl: "http://x.com/b", port: 8090, transport: "sse", authScheme: "header", authHeader: "X-User" } }] },
+      { principal: "andreas", runtime: RUNTIME_STUB, factory },
+    );
+    const b = capturedWebBinding as Record<string, unknown>;
+    expect(b.instanceId).toBe("amt");
+    expect(b.broadcastUrl).toBe("http://x.com/b");
+    expect(b.transport).toBe("sse");
+    expect(b.authScheme).toBe("header");
+    expect(b.authHeader).toBe("X-User");
+  });
+
+  test("surfaceSubjects = [] — web adapter has no surface-router subjects", async () => {
+    // WebAdapter must never subscribe to bus subjects (double-delivery prevention).
+    // No surfaceConfig on the adapter — surfaceSubjects:[] means it's intentionally absent.
+    const surfaces: Surfaces = {
+      web: [{ agent: "ivy", binding: { instanceId: "test", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }],
+    };
+    const { factory } = makeRecordingFactory();
+    const adapters = buildGatewayAdapters(surfaces, {
+      principal: "p",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    // The WebAdapter produced by the default factory has no surfaceConfig getter
+    // (no surfaceSubjects field). Verify the interface contract only exposes
+    // PlatformAdapter — no unexpected surface-router registration.
+    expect(adapters[0]).toBeDefined();
+    expect(adapters[0]?.platform).toBe("web");
+    // No surfaceConfig on the interface
+    expect("surfaceConfig" in (adapters[0] as object)).toBe(false);
+  });
+});
+
+// =============================================================================
+// 9. AMT-agnostic verification
+// =============================================================================
+
+describe("WebAdapter — AMT agnosticism", () => {
+  test("adapter source contains no AMT-specific strings", () => {
+    // Verify the adapter module text has no hardcoded AMT references.
+    // We do this by checking the exported constructor behaves identically
+    // for any tenant name.
+    const a1 = new WebAdapter(
+      makeSyntheticAgent("ivy"),
+      makeBinding({ instanceId: "amt" }),
+      makeInfra({ instanceId: "web:amt" }),
+    );
+    const a2 = new WebAdapter(
+      makeSyntheticAgent("oak"),
+      makeBinding({ instanceId: "acme-bot" }),
+      makeInfra({ instanceId: "web:acme-bot" }),
+    );
+    expect(a1.platform).toBe(a2.platform);
+    expect(a1.instanceId).toBe("web:amt");
+    expect(a2.instanceId).toBe("web:acme-bot");
+  });
+
+  test("two tenants get independent adapters with distinct instanceIds", () => {
+    const { factory, calls } = (() => {
+      const calls: { platform: string; instanceId: string }[] = [];
+      const stub = (platform: string, instanceId: string): PlatformAdapter => ({
+        platform, instanceId, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId, channelId: "ch" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {},
+      });
+      const factory: GatewayAdapterFactory = {
+        discord: (args) => stub("discord", args.instanceId),
+        slack: (args) => stub("slack", args.instanceId),
+        mattermost: (args) => stub("mattermost", args.instanceId),
+        web: (args) => { calls.push({ platform: "web", instanceId: args.instanceId }); return stub("web", args.instanceId); },
+      };
+      return { factory, calls };
+    })();
+
+    const surfaces: Surfaces = {
+      web: [
+        { agent: "ivy", binding: { instanceId: "tenant-a", broadcastUrl: "http://a.com/b", port: 8091, transport: "ws", authScheme: "cf-access" } },
+        { agent: "oak", binding: { instanceId: "tenant-b", broadcastUrl: "http://b.com/b", port: 8092, transport: "ws", authScheme: "cf-access" } },
+      ],
+    };
+
+    const RUNTIME_STUB = { enabled: false, publish: async () => {}, publishFederated: async () => {}, subscribe: undefined, onEnvelope: () => ({ unregister: () => {} }), stop: async () => {} } as unknown as Parameters<typeof buildGatewayAdapters>[1]["runtime"];
+    buildGatewayAdapters(surfaces, { principal: "p", runtime: RUNTIME_STUB, factory });
+
+    const webCalls = calls.filter((c) => c.platform === "web");
+    expect(webCalls).toHaveLength(2);
+    expect(webCalls.map((c) => c.instanceId).sort()).toEqual(["web:tenant-a", "web:tenant-b"]);
+  });
+});

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -1,0 +1,499 @@
+/**
+ * C-110: Generic Web/SSE Surface Adapter
+ *
+ * Implements `PlatformAdapter` for any web or SSE-backed bot surface. Any web
+ * application becomes a cortex-backed bot by:
+ *
+ *   1. POSTing inbound messages to cortex at `POST /message`.
+ *   2. Receiving responses via the configured broadcast target.
+ *
+ * ## Inbound (HTTP POST)
+ *
+ * Accepts `POST /message` with JSON body `{ channel, thread?, body, user? }`.
+ * Maps to cortex's neutral `InboundMessage` with:
+ *   - `platform: "web"`
+ *   - `instanceId`: from the binding (e.g. `"web:amt"`)
+ *   - `authorId`: derived from platform-signed headers ONLY — NEVER from the
+ *     request body (CF-Access JWT `sub`, or a trusted internal header)
+ *   - `channelId` / `threadId`: from the body `channel` / `thread` fields
+ *   - `channelName` / `threadName`: same values (web surfaces don't have a
+ *     separate display-name vs id distinction)
+ *
+ * Responds `202 Accepted` immediately; cortex processes async and pushes the
+ * response via the broadcast target.
+ *
+ * ## Outbound sink (broadcast push)
+ *
+ * `postResponse` / `sendProgress` / `clearProgress` push to the configured
+ * `broadcastUrl`. Payload: `{ adapter_instance, target, type, text }`. The
+ * dispatch-sink's `adapter_instance` filter already ensures only envelopes
+ * routed to THIS instance are delivered; the `target` carries `channel` +
+ * optional `thread` so the receiving app knows where to render the reply.
+ *
+ * `surfaceSubjects: []` — the web adapter never registers bus subjects, so the
+ * surface-router never double-delivers lifecycle envelopes (dispatch-sink owns
+ * the sole delivery path per `dispatch-sink.ts:18-28`).
+ *
+ * ## Auth
+ *
+ * authorId is derived from the request headers, never the body:
+ *   - `cf-access` (default): `Cf-Access-Jwt-Assertion` header → base64-decode
+ *     the JWT payload → extract `sub` claim. CF Access verifies the JWT at the
+ *     edge; the adapter decodes without re-verifying.
+ *   - `header`: a named request header (`authHeader`) carries the caller id.
+ *   - `none`: falls back to the static `instanceId` (DEV ONLY — never on a
+ *     public endpoint).
+ *
+ * ## Reusability
+ *
+ * No AMT-specific logic lives here. A second web app binds with its own
+ * `instanceId` + `broadcastUrl` + agent, zero surface-code changes.
+ */
+
+import type { Server } from "bun";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type BunServer = Server<any>;
+import type {
+  PlatformAdapter,
+  InboundMessage,
+  AccessDecision,
+  ResponseTarget,
+  OutboundFile,
+  ContextMessage,
+} from "../types";
+import type { Agent } from "../../common/types/cortex-config";
+import type { WebBinding } from "../../common/types/surfaces";
+import {
+  isOperatorPrincipal,
+  resolvePolicyAccess,
+  type PlatformPrincipalIndex,
+  type PolicyEngine,
+  type PrincipalRegistry,
+} from "../../common/policy";
+
+// =============================================================================
+// Inbound body shape
+// =============================================================================
+
+/** Shape of the JSON body posted to `POST /message`. */
+export interface WebInboundBody {
+  /** Platform-native channel id (required). */
+  channel: string;
+  /** Thread id within the channel (optional — omit for top-level). */
+  thread?: string;
+  /** Message text (required). */
+  body: string;
+  /**
+   * Caller-supplied display name (optional, used as `authorName` only when
+   * the adapter cannot derive a display name from the auth header).
+   */
+  user?: string;
+}
+
+/** Broadcast push payload shape. */
+export interface WebBroadcastPayload {
+  /** Which adapter instance this response belongs to (dispatch-sink demux key). */
+  adapter_instance: string;
+  /** The target the caller originally sent to. */
+  target: {
+    channel: string;
+    thread?: string;
+  };
+  /** Message type: `"response"` | `"progress"` | `"clear_progress"` | `"typing"`. */
+  type: "response" | "progress" | "clear_progress" | "typing";
+  /** Response text (absent for `clear_progress` and `typing`). */
+  text?: string;
+  /** Attached files (absent unless type=response with files). */
+  files?: { filename: string; contentType?: string; content: string }[];
+}
+
+// =============================================================================
+// Infra
+// =============================================================================
+
+/**
+ * Cortex-deployment-level wiring for the WebAdapter.
+ * Mirrors the `*AdapterInfra` shapes of Discord/Slack/Mattermost.
+ */
+export interface WebAdapterInfra {
+  /** Unique adapter instance id — MUST be `"web:{tenant}"` for consistent demux. */
+  instanceId: string;
+  /** Principal identity (unused for push but required by the interface). */
+  principal: { id?: string };
+  /** Policy engine for access control (optional — allow-all when absent). */
+  policyEngine?: PolicyEngine;
+  /** Platform principal index for (platform, authorId) → principalId resolution. */
+  policyLookup?: PlatformPrincipalIndex;
+  /** Principal registry for principalId → PolicyPrincipal. */
+  policyRegistry?: PrincipalRegistry;
+}
+
+// =============================================================================
+// Auth helpers
+// =============================================================================
+
+/**
+ * Decode a Cloudflare Access JWT (three-part, base64url) and return the `sub`
+ * claim. CF Access has already verified the signature at the edge; we decode
+ * only (no re-verification required here). Returns `null` if the header is
+ * absent or the payload is unparseable.
+ */
+function extractCfAccessSub(request: Request): string | null {
+  const jwt = request.headers.get("Cf-Access-Jwt-Assertion");
+  if (!jwt) return null;
+  const parts = jwt.split(".");
+  if (parts.length !== 3 || !parts[1]) return null;
+  try {
+    // base64url → base64 → Buffer → string → JSON
+    const payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const json = atob(payload);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    if (typeof parsed.sub === "string" && parsed.sub.length > 0) {
+      return parsed.sub;
+    }
+    return null;
+  } catch (_err) {
+    // Malformed JWT payload — not a cortex error (could be upstream misconfiguration)
+    return null;
+  }
+}
+
+/**
+ * Derive the `authorId` for an inbound request according to the binding's
+ * `authScheme`. Returns a non-empty string in all cases (falls back to the
+ * instanceId for the `none` scheme so the downstream pipeline always has a
+ * stable id to correlate with).
+ */
+function deriveAuthorId(
+  request: Request,
+  binding: WebBinding,
+  instanceId: string,
+): string {
+  switch (binding.authScheme) {
+    case "cf-access": {
+      const sub = extractCfAccessSub(request);
+      return sub ?? `anon:web:${instanceId}`;
+    }
+    case "header": {
+      const headerName = binding.authHeader ?? "X-Cortex-User-Id";
+      const value = request.headers.get(headerName);
+      return value && value.length > 0 ? value : `anon:web:${instanceId}`;
+    }
+    case "none":
+      // DEV ONLY — always returns a fixed synthetic id.
+      return `dev:web:${instanceId}`;
+    default:
+      return `anon:web:${instanceId}`;
+  }
+}
+
+// =============================================================================
+// WebAdapter
+// =============================================================================
+
+/**
+ * Generic web/SSE platform adapter. Implements the full `PlatformAdapter`
+ * interface; operates an HTTP ingress on a configured port and pushes
+ * responses via a broadcast URL.
+ */
+export class WebAdapter implements PlatformAdapter {
+  readonly platform = "web";
+  readonly instanceId: string;
+
+  private binding: WebBinding;
+  /** The synthetic gateway agent — carries agentId for log correlation. */
+  private agentId: string;
+  private infra: WebAdapterInfra;
+  private server: BunServer | null = null;
+  private onMessageCallback: ((msg: InboundMessage) => Promise<void>) | null = null;
+  /** The actual TCP port the server bound to (may differ from binding.port when port=0). */
+  private _serverPort: number | null = null;
+
+  constructor(agent: Agent, binding: WebBinding, infra: WebAdapterInfra) {
+    this.agentId = agent.id;
+    this.binding = binding;
+    this.infra = infra;
+    this.instanceId = infra.instanceId;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
+    this.onMessageCallback = onMessage;
+
+    this.server = Bun.serve({
+      port: this.binding.port,
+      fetch: (req) => this.handleRequest(req),
+    });
+    this._serverPort = this.server.port ?? null;
+
+    console.log(
+      `web-adapter[${this.instanceId}] agent=${this.agentId}: HTTP ingress listening on port ${this._serverPort} (transport=${this.binding.transport})`,
+    );
+    return Promise.resolve();
+  }
+
+  /** The port the HTTP ingress is bound to (set after `start()`). */
+  get serverPort(): number | null {
+    return this._serverPort;
+  }
+
+  async stop(): Promise<void> {
+    if (this.server) {
+      await this.server.stop();
+      this.server = null;
+    }
+    this._serverPort = null;
+    this.onMessageCallback = null;
+    console.log(`web-adapter[${this.instanceId}]: stopped`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // PlatformAdapter contract — identity
+  // ---------------------------------------------------------------------------
+
+  /**
+   * MIG-7.2c-binding: stable service identity for this adapter instance.
+   * The web adapter has no bot user id; returns a synthetic `web:{instanceId}`
+   * string that is stable across restarts (keyed on the binding, not a session).
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async getPlatformUserId(): Promise<string> {
+    return `web:${this.instanceId}`;
+  }
+
+  // ---------------------------------------------------------------------------
+  // PlatformAdapter contract — access / context
+  // ---------------------------------------------------------------------------
+
+  resolveAccess(msg: InboundMessage): AccessDecision {
+    return resolvePolicyAccess({
+      msg,
+      engine: this.infra.policyEngine,
+      index: this.infra.policyLookup,
+      registry: this.infra.policyRegistry,
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async fetchContext(_msg: InboundMessage, _depth: number): Promise<ContextMessage[]> {
+    // Web surfaces carry no server-side conversation history.
+    return [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // PlatformAdapter contract — outbound delivery
+  // ---------------------------------------------------------------------------
+
+  async postResponse(
+    target: ResponseTarget,
+    text: string,
+    files?: OutboundFile[],
+  ): Promise<void> {
+    const payload: WebBroadcastPayload = {
+      adapter_instance: this.instanceId,
+      target: {
+        channel: target.channelId,
+        ...(target.threadId !== undefined && { thread: target.threadId }),
+      },
+      type: "response",
+      text,
+      ...(files && files.length > 0 && {
+        files: files.map((f) => ({
+          filename: f.filename,
+          contentType: f.contentType,
+          content: f.content.toString("base64"),
+        })),
+      }),
+    };
+    await this.broadcast(payload);
+  }
+
+  async sendTyping(_target: ResponseTarget): Promise<void> {
+    // No-op: web surfaces manage their own typing indicators locally.
+    await Promise.resolve();
+  }
+
+  async sendProgress(target: ResponseTarget, text: string): Promise<void> {
+    const payload: WebBroadcastPayload = {
+      adapter_instance: this.instanceId,
+      target: {
+        channel: target.channelId,
+        ...(target.threadId !== undefined && { thread: target.threadId }),
+      },
+      type: "progress",
+      text,
+    };
+    await this.broadcast(payload);
+  }
+
+  async clearProgress(target: ResponseTarget): Promise<void> {
+    const payload: WebBroadcastPayload = {
+      adapter_instance: this.instanceId,
+      target: {
+        channel: target.channelId,
+        ...(target.threadId !== undefined && { thread: target.threadId }),
+      },
+      type: "clear_progress",
+    };
+    await this.broadcast(payload);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async createThread(msg: InboundMessage, _name: string): Promise<ResponseTarget> {
+    // Web surfaces use the channel id as the thread root for top-level
+    // messages; a threaded reply carries the thread id through.
+    return {
+      instanceId: this.instanceId,
+      channelId: msg.channelId,
+      threadId: msg.threadId ?? msg.channelId,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async resolveLogicalTarget(_addr: {
+    surface: string;
+    channel: string;
+    thread?: string;
+  }): Promise<ResponseTarget | null> {
+    // Not yet implemented — returns null so the review sink skips this adapter.
+    return null;
+  }
+
+  async notifyPrincipal(text: string): Promise<void> {
+    // Push to the broadcast target with a synthetic "principal-notify" channel.
+    // The receiving app can filter on `target.channel === "_principal"`.
+    const payload: WebBroadcastPayload = {
+      adapter_instance: this.instanceId,
+      target: { channel: "_principal" },
+      type: "response",
+      text,
+    };
+    await this.broadcast(payload);
+  }
+
+  // ---------------------------------------------------------------------------
+  // HTTP ingress handler
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Handle an inbound HTTP request. Routes:
+   *   - `GET  /health` — liveness check
+   *   - `POST /message` — inbound bot message
+   *   - Everything else — 404
+   */
+  async handleRequest(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/health" && req.method === "GET") {
+      return Response.json({ status: "ok", adapter: this.instanceId });
+    }
+
+    if (url.pathname === "/message" && req.method === "POST") {
+      return this.handleInbound(req);
+    }
+
+    return new Response("Not Found", { status: 404 });
+  }
+
+  private async handleInbound(req: Request): Promise<Response> {
+    // 1. Parse body
+    let body: WebInboundBody;
+    try {
+      body = (await req.json()) as WebInboundBody;
+    } catch (_err) {
+      return Response.json({ error: "invalid JSON body" }, { status: 400 });
+    }
+
+    if (typeof body.channel !== "string" || body.channel.length === 0) {
+      return Response.json({ error: "body.channel is required" }, { status: 400 });
+    }
+    if (typeof body.body !== "string" || body.body.length === 0) {
+      return Response.json({ error: "body.body is required" }, { status: 400 });
+    }
+
+    // 2. Derive authorId from platform-signed headers — NEVER the body
+    const authorId = deriveAuthorId(req, this.binding, this.instanceId);
+
+    // 3. Build InboundMessage
+    const msg: InboundMessage = {
+      platform: "web",
+      instanceId: this.instanceId,
+      authorId,
+      authorName: body.user ?? authorId,
+      content: body.body,
+      channelId: body.channel,
+      ...(body.thread !== undefined && { threadId: body.thread }),
+      channelName: body.channel,
+      ...(body.thread !== undefined && { threadName: body.thread }),
+      authorIsPrincipal: this.isOperator(authorId),
+      attachments: [],
+      timestamp: new Date(),
+    };
+
+    // 4. Dispatch async — respond immediately so the caller isn't blocked
+    //    on the CC session's latency.
+    const handler = this.onMessageCallback;
+    if (handler) {
+      void handler(msg).catch((err: unknown) => {
+        process.stderr.write(
+          `web-adapter[${this.instanceId}]: onMessage error: ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      });
+    }
+
+    return Response.json({ status: "accepted" }, { status: 202 });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Broadcast push (outbound)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * HTTP POST the broadcast payload to `binding.broadcastUrl`. Both `ws` and
+   * `sse` transports use the same POST-to-URL mechanism; the distinction is on
+   * the receiving server's delivery side (the DO's fan-out vs an SSE emitter).
+   *
+   * Failures are logged and swallowed — a failed push does not throw because:
+   *   1. The dispatch already completed on the bus.
+   *   2. The dispatch-sink's error boundary already logs at the delivery level.
+   *   3. Surface delivery failures are retried via JetStream replay at the
+   *      runner level, not here.
+   */
+  private async broadcast(payload: WebBroadcastPayload): Promise<void> {
+    try {
+      const res = await fetch(this.binding.broadcastUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        process.stderr.write(
+          `web-adapter[${this.instanceId}]: broadcast POST failed: ` +
+            `${res.status} ${res.statusText} → ${this.binding.broadcastUrl}\n`,
+        );
+      }
+    } catch (err) {
+      process.stderr.write(
+        `web-adapter[${this.instanceId}]: broadcast POST threw: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  protected isOperator(authorId: string): boolean {
+    return isOperatorPrincipal(
+      "web",
+      authorId,
+      this.infra.policyEngine,
+      this.infra.policyLookup,
+    );
+  }
+}

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -34,15 +34,29 @@
  * surface-router never double-delivers lifecycle envelopes (dispatch-sink owns
  * the sole delivery path per `dispatch-sink.ts:18-28`).
  *
- * ## Auth
+ * ## Auth — two independent layers
  *
- * authorId is derived from the request headers, never the body:
+ * ### Layer 1: Service-to-service (inbound gate)
+ * When `binding.inboundToken` is set, every `POST /message` must carry:
+ *   `Authorization: Bearer <inboundToken>`
+ * Requests missing or mismatching the token return `401` before the body is
+ * parsed. Omit only on loopback deployments; required for cross-machine.
+ * Bearer-token seam — mTLS can replace via config, no code change.
+ *
+ * ### Layer 2: Per-user identity (authorId derivation)
+ * After the service gate, `authorId` is derived from the user-identifying header:
  *   - `cf-access` (default): `Cf-Access-Jwt-Assertion` header → base64-decode
  *     the JWT payload → extract `sub` claim. CF Access verifies the JWT at the
  *     edge; the adapter decodes without re-verifying.
  *   - `header`: a named request header (`authHeader`) carries the caller id.
  *   - `none`: falls back to the static `instanceId` (DEV ONLY — never on a
  *     public endpoint).
+ *
+ * ### Outbound auth
+ * When `binding.broadcastToken` is set, every broadcast POST carries:
+ *   `Authorization: Bearer <broadcastToken>`
+ * The broadcast endpoint MUST verify this — an unauthenticated public broadcast
+ * endpoint is a cortex Critical Rule violation (SEV-1). Omit only on loopback.
  *
  * ## Reusability
  *
@@ -399,6 +413,20 @@ export class WebAdapter implements PlatformAdapter {
   }
 
   private async handleInbound(req: Request): Promise<Response> {
+    // 0. Service-to-service inbound auth gate.
+    //    When `inboundToken` is configured, the request MUST carry:
+    //      Authorization: Bearer <inboundToken>
+    //    Requests missing or mismatching the token are rejected before any body
+    //    is parsed — this is service auth, separate from the per-user CF-Access /
+    //    header auth that produces `authorId`.
+    if (this.binding.inboundToken) {
+      const authHeader = req.headers.get("Authorization");
+      const expected = `Bearer ${this.binding.inboundToken}`;
+      if (authHeader !== expected) {
+        return Response.json({ error: "Unauthorized" }, { status: 401 });
+      }
+    }
+
     // 1. Parse body
     let body: WebInboundBody;
     try {
@@ -464,10 +492,17 @@ export class WebAdapter implements PlatformAdapter {
    *      runner level, not here.
    */
   private async broadcast(payload: WebBroadcastPayload): Promise<void> {
+    // Build headers — always Content-Type; add Authorization when
+    // `broadcastToken` is configured (service-to-service outbound auth).
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.binding.broadcastToken) {
+      headers.Authorization = `Bearer ${this.binding.broadcastToken}`;
+    }
+
     try {
       const res = await fetch(this.binding.broadcastUrl, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify(payload),
       });
       if (!res.ok) {

--- a/src/common/types/surfaces.ts
+++ b/src/common/types/surfaces.ts
@@ -148,6 +148,78 @@ export const MattermostBindingSchema = z
   })
   .catchall(z.unknown());
 
+/**
+ * Web surface binding — generic HTTP ingress + broadcast-push outbound.
+ *
+ * Any web/SSE app becomes a cortex-backed bot by:
+ *  1. Posting inbound messages to cortex at `POST /message`.
+ *  2. Receiving responses via the broadcast target (WS Durable Object or SSE
+ *     endpoint) at `broadcastUrl`.
+ *
+ * Multi-tenant: each web application binds with its own `instanceId` +
+ * `broadcastUrl` + agent. Zero surface-code changes are needed to add a
+ * second consumer.
+ *
+ * Auth: cortex NEVER trusts `authorId` from the request body. It is derived
+ * from platform-signed headers:
+ *   - `cf-access`: `Cf-Access-Jwt-Assertion` JWT `sub` claim (default — CF
+ *     Access-protected deployments). The JWT is decoded without verification
+ *     at the adapter layer; CF Access already verified it at the edge.
+ *   - `header`: a named request header carries the caller-identity directly
+ *     (see `authHeader`). Suitable for trusted internal surfaces.
+ *   - `none`: no auth header — falls back to the static instanceId as the
+ *     authorId. DEV ONLY — never enable on a public-facing endpoint.
+ */
+export const WebBindingSchema = z
+  .object({
+    /**
+     * Tenant/instance identifier — the `{tenant}` segment of `web:{tenant}`.
+     * Must be unique across all web bindings for this principal so the
+     * dispatch-sink can route responses to the correct adapter instance.
+     * Example: `"amt"` → instanceId `"web:amt"`.
+     */
+    instanceId: z.string().min(1, "surfaces.web[].binding.instanceId is required"),
+    /**
+     * Port for the Bun HTTP ingress server. Each binding gets its own port
+     * so multiple web surfaces can coexist on the same host. Default: 8090.
+     */
+    port: z.number().int().min(1).max(65535).default(8090),
+    /**
+     * URL to POST broadcast messages to when cortex wants to push a reply to
+     * the web surface. For `transport: "ws"` this is the WS Durable Object's
+     * `/broadcast` endpoint (mirrors `dashboard-socket.ts` DO protocol); for
+     * `transport: "sse"` it is an SSE push server's ingest endpoint. The
+     * payload shape is identical: `{ adapter_instance, target, type, text }`.
+     */
+    broadcastUrl: z
+      .string()
+      .min(1, "surfaces.web[].binding.broadcastUrl is required")
+      .regex(
+        /^https?:\/\/.+/,
+        "surfaces.web[].binding.broadcastUrl must be an http/https URL",
+      ),
+    /**
+     * Transport flavour for the push half. `ws` (default) mirrors the
+     * dashboard-socket DO protocol (POST /broadcast with a JSON body). `sse`
+     * targets a plain SSE ingest endpoint with the same payload shape. The
+     * adapter's push path is identical for both — the distinction lives in
+     * the receiving server's delivery mechanism.
+     */
+    transport: z.enum(["ws", "sse"]).default("ws"),
+    /**
+     * Auth scheme for deriving `authorId` from inbound HTTP requests.
+     * See module docstring for the full contract. Default: `cf-access`.
+     */
+    authScheme: z.enum(["cf-access", "header", "none"]).default("cf-access"),
+    /**
+     * Header name used when `authScheme = "header"`. The adapter reads this
+     * header's value verbatim as the `authorId`. Ignored for other schemes.
+     * Example: `"X-Cortex-User-Id"`.
+     */
+    authHeader: z.string().optional(),
+  })
+  .catchall(z.unknown());
+
 // =============================================================================
 // Binding entry — one surface-instance bound to one stack's agent
 // =============================================================================
@@ -189,22 +261,47 @@ export const MattermostSurfaceBindingSchema = z.object({
   binding: MattermostBindingSchema,
 });
 
+/**
+ * Web surface binding entry.
+ *
+ * Unlike the Discord/Slack/Mattermost entries, the `web` binding does NOT fold
+ * into `agents[*].presence.web` at config-compose time (there is no legacy
+ * `cortex.yaml` web-presence shape to fold into). Instead, the gateway
+ * consumes `surfaces.web[]` directly from the `Surfaces` object and constructs
+ * a `WebAdapter` per entry. The `agent` field is still the join key used by
+ * `buildGatewayAdapters` to build the synthetic gateway agent; the `stack`
+ * field carries the `{principal}/{stack}` routing target as usual.
+ */
+export const WebSurfaceBindingSchema = z.object({
+  ...bindingEntryBase,
+  binding: WebBindingSchema,
+});
+
 // =============================================================================
 // Top-level `surfaces:` block
 // =============================================================================
 
 /**
  * The `surfaces:` block — the binding map. Keyed by platform; each platform
- * holds a list of `{agent, stack?, binding}` entries. All three platforms are
+ * holds a list of `{agent, stack?, binding}` entries. All platforms are
  * optional (a deployment may bind only Discord). `.strict()` rejects an
  * unknown platform key loudly so a typo (`discrod:`) surfaces at load rather
  * than silently contributing nothing to the fold.
+ *
+ * Note: `web[]` bindings are NOT folded by `foldSurfaceBindings` (there is no
+ * legacy presence shape). The gateway factory consumes them directly.
  */
 export const SurfacesSchema = z
   .object({
     discord: z.array(DiscordSurfaceBindingSchema).optional(),
     slack: z.array(SlackSurfaceBindingSchema).optional(),
     mattermost: z.array(MattermostSurfaceBindingSchema).optional(),
+    /**
+     * Web/SSE bindings — generic HTTP-ingress + broadcast-push surface.
+     * Multi-tenant: one entry per web application. Not folded into the
+     * per-stack config; the gateway factory constructs a WebAdapter per entry.
+     */
+    web: z.array(WebSurfaceBindingSchema).optional(),
   })
   // `.strict()` rejects an unknown platform key loudly so a typo (`discrod:`)
   // surfaces at load rather than silently contributing nothing to the fold.
@@ -214,6 +311,8 @@ export type Surfaces = z.infer<typeof SurfacesSchema>;
 export type DiscordSurfaceBinding = z.infer<typeof DiscordSurfaceBindingSchema>;
 export type SlackSurfaceBinding = z.infer<typeof SlackSurfaceBindingSchema>;
 export type MattermostSurfaceBinding = z.infer<typeof MattermostSurfaceBindingSchema>;
+export type WebSurfaceBinding = z.infer<typeof WebSurfaceBindingSchema>;
+export type WebBinding = z.infer<typeof WebBindingSchema>;
 
 // =============================================================================
 // The fold — surfaces.yaml bindings → agents[*].presence.{platform}

--- a/src/common/types/surfaces.ts
+++ b/src/common/types/surfaces.ts
@@ -217,6 +217,32 @@ export const WebBindingSchema = z
      * Example: `"X-Cortex-User-Id"`.
      */
     authHeader: z.string().optional(),
+    /**
+     * Service-to-service inbound auth token (POST /message → cortex).
+     *
+     * When set, the adapter requires the inbound request to carry:
+     *   `Authorization: Bearer <inboundToken>`
+     * Requests missing or mismatching the token receive `401 Unauthorized`
+     * before any message is dispatched.
+     *
+     * **Omit only on loopback deployments** where the network perimeter is
+     * the sole trust boundary. Required for any cross-machine deployment.
+     * Structured as a bearer-token seam so mTLS or a stronger scheme can
+     * replace it via config alone — no code change required.
+     */
+    inboundToken: z.string().optional(),
+    /**
+     * Service-to-service outbound auth token (cortex → broadcastUrl POST).
+     *
+     * When set, every broadcast POST carries:
+     *   `Authorization: Bearer <broadcastToken>`
+     * The broadcast endpoint MUST verify this token — an unauthenticated
+     * public broadcast endpoint is a cortex Critical Rule violation (SEV-1).
+     *
+     * **Omit only on loopback deployments.** Required for any cross-machine
+     * deployment. Same bearer-token seam as `inboundToken`.
+     */
+    broadcastToken: z.string().optional(),
   })
   .catchall(z.unknown());
 

--- a/src/gateway/__tests__/cross-principal-routing.integration.test.ts
+++ b/src/gateway/__tests__/cross-principal-routing.integration.test.ts
@@ -146,6 +146,7 @@ function makeMockAdapterFactory(): {
     discord: (args) => build(args.instanceId),
     slack: (args) => build(args.instanceId),
     mattermost: (args) => build(args.instanceId),
+    web: (args) => build(args.instanceId),
   };
   return { factory, byInstance };
 }

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -30,7 +30,7 @@ import type { MyelinRuntime } from "../../bus/myelin/runtime";
 // =============================================================================
 
 interface FactoryCall {
-  platform: "discord" | "slack" | "mattermost";
+  platform: "discord" | "slack" | "mattermost" | "web";
   instanceId: string;
   source: SystemEventSource;
   /** The credential block handed to the factory (presence-shaped). */
@@ -41,7 +41,7 @@ interface FactoryCall {
 }
 
 function makeFakeAdapter(
-  platform: "discord" | "slack" | "mattermost",
+  platform: "discord" | "slack" | "mattermost" | "web",
   instanceId: string,
 ): PlatformAdapter {
   return {
@@ -111,6 +111,16 @@ function makeRecordingFactory(): {
         runtime: args.runtime,
       });
       return makeFakeAdapter("mattermost", args.instanceId);
+    },
+    web: (args) => {
+      calls.push({
+        platform: "web",
+        instanceId: args.instanceId,
+        source: args.source,
+        binding: args.binding,
+        runtime: args.runtime,
+      });
+      return makeFakeAdapter("web", args.instanceId);
     },
   };
   return { factory, calls };
@@ -372,6 +382,7 @@ describe("buildGatewayAdapters", () => {
       },
       slack: (args) => makeFakeAdapter("slack", args.instanceId),
       mattermost: (args) => makeFakeAdapter("mattermost", args.instanceId),
+      web: (args) => makeFakeAdapter("web", args.instanceId),
     };
     buildGatewayAdapters(DISCORD_SURFACES, {
       principal: "andreas",

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -48,7 +48,7 @@ const POLICY_ENGINE_STUB = {
 } as unknown as PolicyEngine;
 
 function makeFakeAdapter(
-  platform: "discord" | "slack" | "mattermost",
+  platform: "discord" | "slack" | "mattermost" | "web",
   instanceId: string,
   onStart?: () => void,
 ): PlatformAdapter {
@@ -97,6 +97,12 @@ function makeCountingFactory(started: string[]): {
     mattermost: (args) => {
       constructed.push(args.instanceId);
       return makeFakeAdapter("mattermost", args.instanceId, () =>
+        started.push(args.instanceId),
+      );
+    },
+    web: (args) => {
+      constructed.push(args.instanceId);
+      return makeFakeAdapter("web", args.instanceId, () =>
         started.push(args.instanceId),
       );
     },

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -325,7 +325,7 @@ export function buildGatewayAdapters(
   // instanceId is `web:{binding.instanceId}` — the tenant slug the binding
   // declares. Unlike Discord (token-keyed) or Slack/Mattermost (URL-keyed),
   // the web binding carries an explicit `instanceId` so multi-tenant
-  // deployments can give each surface a stable, operator-chosen name.
+  // deployments can give each surface a stable, configured name.
   //
   // No placeholder guard: the web binding carries no secrets (broadcastUrl
   // is a non-secret endpoint; auth is CF Access at the edge, not a bot token).

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -54,8 +54,10 @@
 import { DiscordAdapter } from "../adapters/discord";
 import { SlackAdapter } from "../adapters/slack";
 import { MattermostAdapter } from "../adapters/mattermost";
+import { WebAdapter } from "../adapters/web";
 import type { PlatformAdapter } from "../adapters/types";
 import type { Surfaces } from "../common/types/surfaces";
+import type { WebBinding } from "../common/types/surfaces";
 import {
   DiscordPresenceSchema,
   SlackPresenceSchema,
@@ -106,6 +108,12 @@ interface MattermostFactoryArgs extends FactoryArgsBase {
   presence: MattermostPresence;
 }
 
+/** Args for the web factory call. `binding` carries the typed WebBinding. */
+interface WebFactoryArgs extends FactoryArgsBase {
+  /** Typed web binding (port, broadcastUrl, transport, authScheme). */
+  webBinding: WebBinding;
+}
+
 /**
  * The injected adapter-construction seam. One builder per platform. Production
  * uses {@link defaultGatewayAdapterFactory}; tests inject a recording fake that
@@ -115,6 +123,8 @@ export interface GatewayAdapterFactory {
   discord(args: DiscordFactoryArgs): PlatformAdapter;
   slack(args: SlackFactoryArgs): PlatformAdapter;
   mattermost(args: MattermostFactoryArgs): PlatformAdapter;
+  /** C-110: Generic web/SSE surface adapter. */
+  web(args: WebFactoryArgs): PlatformAdapter;
 }
 
 /** Injected dependencies for {@link buildGatewayAdapters}. */
@@ -191,6 +201,22 @@ export const defaultGatewayAdapterFactory: GatewayAdapterFactory = {
         principal: {},
         ...(runtime !== undefined && { runtime }),
         systemEventSource: source,
+      },
+    ),
+
+  /**
+   * C-110: Generic web/SSE surface adapter. No presence schema re-parse
+   * needed — the WebBinding carries everything the adapter needs directly.
+   * No reconnect credentials to guard (no bot token); the binding's
+   * `broadcastUrl` is already validated by `WebBindingSchema`.
+   */
+  web: ({ instanceId, webBinding, source }) =>
+    new WebAdapter(
+      syntheticGatewayAgent(source.agent, {}),
+      webBinding,
+      {
+        instanceId,
+        principal: {},
       },
     ),
 };
@@ -288,6 +314,31 @@ export function buildGatewayAdapters(
         binding: entry.binding,
         runtime,
         presence,
+      }),
+    );
+  }
+
+  // ── Web/SSE — demux key = binding.instanceId ──────────────────────────────
+  //
+  // C-110: generic web/SSE surface. No presence schema re-parse (the
+  // WebBinding already carries all runtime fields via WebBindingSchema). The
+  // instanceId is `web:{binding.instanceId}` — the tenant slug the binding
+  // declares. Unlike Discord (token-keyed) or Slack/Mattermost (URL-keyed),
+  // the web binding carries an explicit `instanceId` so multi-tenant
+  // deployments can give each surface a stable, operator-chosen name.
+  //
+  // No placeholder guard: the web binding carries no secrets (broadcastUrl
+  // is a non-secret endpoint; auth is CF Access at the edge, not a bot token).
+  for (const entry of surfaces.web ?? []) {
+    const webBinding: WebBinding = entry.binding;
+    const instanceId = `web:${webBinding.instanceId}`;
+    adapters.push(
+      factory.web({
+        instanceId,
+        source: gatewaySource(principal, instanceId),
+        binding: entry.binding,
+        runtime,
+        webBinding,
       }),
     );
   }


### PR DESCRIPTION
## Summary

- **New**: `WebAdapter implements PlatformAdapter` — generic HTTP ingress + broadcast-push sink for any web or SSE-backed bot surface
- **New**: `WebBindingSchema` / `WebSurfaceBindingSchema` + `SurfacesSchema.web[]` in `src/common/types/surfaces.ts`
- **New**: `web()` factory in `GatewayAdapterFactory` + `buildGatewayAdapters` web loop
- **45 new tests** across 9 describe blocks: HTTP ingress, auth extraction (3 schemes), outbound broadcast, access control, schema validation, gateway factory wiring, AMT-agnosticism

## Inbound → cortex

```
POST /message  { channel, thread?, body, user? }
               ↓
InboundMessage { platform:"web", instanceId, authorId, channelId, … }
```

`authorId` comes from **platform-signed headers only** — never the body:
- `cf-access` (default): `Cf-Access-Jwt-Assertion` JWT → `sub` claim
- `header`: named request header (`authHeader`)
- `none`: synthetic dev-only id (never on a public endpoint)

## Outbound → web app

```
postResponse / sendProgress / clearProgress
  → HTTP POST broadcastUrl
  → { adapter_instance, target: { channel, thread? }, type, text? }
```

`surfaceSubjects` intentionally not declared → surface-router never double-delivers.

## Binding schema

```yaml
surfaces:
  web:
    - agent: <agent-id>
      binding:
        instanceId: amt          # required — demux key
        broadcastUrl: https://…  # required — where to push responses
        port: 8090               # default 8090
        transport: ws            # "ws" | "sse" (default "ws")
        authScheme: cf-access    # "cf-access" | "header" | "none" (default "cf-access")
        authHeader: X-User-Id    # only for authScheme:"header"
```

## AMT-agnosticism

Zero AMT-specific identifiers, routes, or logic in the adapter. A second tenant (`instanceId: acme-bot`, different `broadcastUrl`, different agent) binds with no adapter code changes. Test `"two web bindings with different instanceIds → two independent adapters"` verifies this explicitly.

## Gates

| Gate | Result |
|------|--------|
| `bun test` (adapter suite) | ✅ 45 pass, 0 fail |
| `bun test` (full suite) | ✅ 8007 pass, 23 fail (23 failures are pre-existing on `main` — `startCortex` + `principal-identity` unrelated to web adapter) |
| `bunx tsc --noEmit` | ✅ clean |
| `bun run lint` | ✅ clean |

## Do not merge

Principal sign-off required before merging.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)