### PR TITLE
feat(registry): C-1321 — per-network admin authority in the registry schema

### DIFF
--- a/docs/adr/0020-per-network-admin-authority.md
+++ b/docs/adr/0020-per-network-admin-authority.md
@@ -1,0 +1,85 @@
+# ADR 0020 — Per-network admin authority in the registry schema
+
+**Status:** accepted (2026-06-29) · **Refines:** ADR-0015 (two-tier onboarding + admission gate) · **Descends:** ADR-0003 (network-join control plane), ADR-0013 (sovereign federation) · **Refs:** cortex#1321, #110, `docs/research-federation-decentralization.md`, CONTEXT.md §Network posture (admin vs member)
+
+## Context
+
+The federation-decentralisation research (#1319) found cortex is already
+sovereign at the operator + leaf + export/import layer (ADR-0013, Model B = BGP
+peering), but three meta-layer artifacts remained central. The first code-level
+gap: the **Network-admission gate** (who is admitted to a network's roster) and
+the network create/update gate both keyed on the **registry-wide**
+`REGISTRY_ADMIN_PUBKEYS` allowlist. One global authority could admit peers and
+write topology for *every* network. There was no per-network admin in the
+schema — even though the domain model already names the concept (**Network
+posture (admin vs member)**, CONTEXT.md §Network posture: an *admin* governs the
+hub + the admission gate + the roster; a *member* is an admitted sovereign peer).
+
+This is the "each AS admits to its own network" autonomy the research mapped onto
+BGP/Mastodon: connectivity/admission is bilateral and self-governed, while
+*allocation* (creating a network) can stay hierarchical (RIR/IANA-style).
+
+## Decision
+
+**Encode the existing Network-posture concept into the registry schema: a
+network carries its own `admin_pubkeys`, and the admission-grant + topology-update
+gates authorize against THAT network's admins OR the global allowlist.** No new
+mechanism — the `register → PENDING → grant` admission gate (ADR-0015) and the
+`POST /networks/{id}` create/update gate (#747) are re-sourced, not replaced.
+
+Privilege model (anti-self-escalation):
+
+1. **Network CREATE** → **global admin only** (`REGISTRY_ADMIN_PUBKEYS`). Creating
+   a network is a hierarchical act (allocation), per the research; a global admin
+   may set the initial `admin_pubkeys` at create.
+2. **Network UPDATE (topology)** → **per-network admin OR global admin**. But only
+   a **global** admin may set or change `admin_pubkeys` — a per-network admin
+   supplying it is refused `403 admin_pubkeys_requires_global_admin`, so a
+   per-network admin can neither add co-admins nor lock out the global admin.
+3. **Admission GRANT (admit/reject)** → **per-network admin for the request's
+   network OR global admin**. Authorization is keyed off the request's stored
+   `network_id`, never off anything on the wire. A network-less request
+   (`network_id` null) stays global-admin-only.
+4. **Admin READS** (list/get admission requests) → **global admin only** for now
+   (see Consequences — per-network read-scoping is a fast-follow).
+
+`REGISTRY_ADMIN_PUBKEYS` is retained as the **bootstrap admin for `metafactory`**
+and the always-valid super-admin — backward compatible: a network with no
+`admin_pubkeys` (NULL) behaves exactly as before (global-admin-only).
+
+This is **control-plane only**. No subject shape, no envelope field, no
+`selectLink`/`source`/`originator` change — the `admin_pubkeys` set never appears
+on the wire. The federation-wire-protocol SOP 5-check is unaffected.
+
+## Consequences
+
+- **Each network is sovereign over its own roster** — a per-network admin admits
+  peers to their network without holding the global key. This completes the
+  admission-gate sovereignty ADR-0015 implied.
+- **Schema:** `NetworkRecord.admin_pubkeys?` (TEXT, nullable, comma-separated
+  base64 — same grammar as the env var); D1 migration `0011_network_admin_pubkeys.sql`.
+- **Not exposed on the public descriptor (yet):** `GET /networks/{id}` keeps the
+  minimal `{network_id, hub_url, leaf_port, members}` shape. Surfacing the admin
+  set for MC **Network posture** rendering (#1275/#1276) is a fast-follow (it
+  touches the cortex-side `NetworkDescriptor` mirror + MC).
+- **No CLI yet to set it:** a global admin sets `admin_pubkeys` via the signed
+  `POST /networks/{id}` claim (`NetworkCreateClaim.admin_pubkeys`) or a store
+  seed; the `cortex network create --network-admins` ergonomic flag is a
+  fast-follow.
+- **Per-network admin read-scoping** (letting a per-network admin LIST their
+  network's pending requests) is a fast-follow — today they must be handed the
+  `request_id`. The architectural unlock (grant-by-per-network-admin) does not
+  depend on it.
+
+## Alternatives considered
+
+- **Let a per-network admin also manage `admin_pubkeys`** — fuller sovereignty,
+  but opens a self-escalation / global-lockout path. Rejected for v1; admin-set
+  management stays global. Can be revisited with explicit rotation rules.
+- **Make network CREATE per-network-admin too** — there is no per-network set
+  before a network exists, so create is necessarily global; keeping it global also
+  matches the research's "allocation is hierarchical" finding. Kept.
+- **Capability-based admission (Biscuit/VC) instead of an allowlist column** — the
+  research's longer-term direction (#1322 follow-on). Heavier; deferred. The
+  comma-separated-pubkeys column mirrors the existing grammar with zero new
+  primitives.

--- a/docs/adr/0020-per-network-admin-authority.md
+++ b/docs/adr/0020-per-network-admin-authority.md
@@ -5,7 +5,7 @@
 ## Context
 
 The federation-decentralisation research (#1319) found cortex is already
-sovereign at the operator + leaf + export/import layer (ADR-0013, Model B = BGP
+sovereign at the operator-account + leaf + export/import layer (ADR-0013, Model B = BGP
 peering), but three meta-layer artifacts remained central. The first code-level
 gap: the **Network-admission gate** (who is admitted to a network's roster) and
 the network create/update gate both keyed on the **registry-wide**

--- a/src/services/network-registry/__tests__/d1-mock.ts
+++ b/src/services/network-registry/__tests__/d1-mock.ts
@@ -37,6 +37,8 @@ interface NetworkRow {
   hub_url: string;
   leaf_port: number;
   updated_at: string;
+  /** #1321 — nullable per-network admin allowlist. */
+  admin_pubkeys?: string | null;
 }
 
 interface IssuanceRequestRow {
@@ -181,17 +183,19 @@ export class MockD1 {
 
     // networks: UPSERT (S2.5)
     if (sql.startsWith("INSERT INTO networks")) {
-      const [networkId, hubUrl, leafPort, updatedAt] = args as [
+      const [networkId, hubUrl, leafPort, updatedAt, adminPubkeys] = args as [
         string,
         string,
         number,
         string,
+        string | null | undefined,
       ];
       this.networks.set(networkId, {
         network_id: networkId,
         hub_url: hubUrl,
         leaf_port: leafPort,
         updated_at: updatedAt,
+        admin_pubkeys: adminPubkeys ?? null,
       });
       // An UPSERT always touches exactly one row (insert or update).
       return { meta: { changes: 1 } };

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -178,6 +178,8 @@ export interface NetworkCreateClaim {
   admin_pubkey: string;
   issued_at: string;
   nonce: string;
+  /** #1321 — optional per-network admin allowlist (comma-separated base64 pubkeys). */
+  admin_pubkeys?: string;
 }
 
 /**
@@ -198,6 +200,8 @@ export async function makeSignedNetworkCreate(
     adminPubkeyOverride?: string;
     /** Sign with a DIFFERENT key than the claim declares — forged signature. */
     signWith?: PrincipalKey;
+    /** #1321 — per-network admin allowlist to bootstrap (comma-separated base64). */
+    adminPubkeys?: string;
   } = {},
 ): Promise<{ claim: NetworkCreateClaim; signature: string }> {
   const claim: NetworkCreateClaim = {
@@ -207,6 +211,9 @@ export async function makeSignedNetworkCreate(
     admin_pubkey: opts.adminPubkeyOverride ?? adminKey.publicKeyB64,
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
+    // Only include admin_pubkeys when supplied — keeps canonicalJSON stable for
+    // the existing #747 tests that sign a claim without the field.
+    ...(opts.adminPubkeys !== undefined && { admin_pubkeys: opts.adminPubkeys }),
   };
   const message = new TextEncoder().encode(canonicalJSON(claim));
   const signer = opts.signWith ?? adminKey;

--- a/src/services/network-registry/__tests__/per-network-admin.test.ts
+++ b/src/services/network-registry/__tests__/per-network-admin.test.ts
@@ -1,0 +1,245 @@
+/**
+ * #1321 — per-network admin authorization.
+ *
+ * Encodes the existing domain concept **Network posture (admin vs member)**
+ * (CONTEXT.md §Network posture) into the registry schema: a network carries its
+ * own `admin_pubkeys`, and the network-create/update gate + the admission-grant
+ * gate authorize against THAT network's admins OR the global
+ * `REGISTRY_ADMIN_PUBKEYS` allowlist (the `metafactory` bootstrap admin).
+ *
+ * Privilege model (anti-self-escalation):
+ *   - network CREATE      → global admin only (may set initial admin_pubkeys)
+ *   - network UPDATE      → per-network admin OR global; but only a GLOBAL admin
+ *                           may change admin_pubkeys (a per-network admin cannot
+ *                           add co-admins or lock out the global admin)
+ *   - admission GRANT     → per-network admin (for the request's network) OR global
+ *   - admin READS         → global only (per-network read-scoping is a fast-follow)
+ *
+ * Control-plane only — NO wire-grammar change (no network on the wire; the
+ * `admin_pubkeys` set never appears in a subject/source/originator).
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedNetworkCreate,
+  makeSignedRegistration,
+  makeSignedAdminRead,
+  randomNonce,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import { getStore } from "../src/store";
+import type { AdmissionRequest } from "../src/types";
+
+let env: Env;
+let globalAdmin: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(
+  path: string,
+  e: Env = env,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+/** Build a signed admission decision (admit/reject) for the given admin key. */
+async function makeDecision(
+  requestId: string,
+  decision: "admit" | "reject",
+  adminKey: PrincipalKey,
+): Promise<{ claim: unknown; signature: string }> {
+  const claim = {
+    request_id: requestId,
+    decision,
+    admin_pubkey: adminKey.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signature = await signEd25519(adminKey.privateKeyB64, message);
+  return { claim, signature };
+}
+
+/** Create a network (as the global admin), optionally with a per-network admin set. */
+async function createNetwork(networkId: string, adminPubkeys?: string): Promise<Response> {
+  const body = await makeSignedNetworkCreate(networkId, globalAdmin, { adminPubkeys });
+  return post(`/networks/${networkId}`, body);
+}
+
+/** Register a principal into a network and return the PENDING admission request. */
+async function registerInto(principalId: string, networkId: string): Promise<AdmissionRequest> {
+  const pk = await makePrincipalKey();
+  const reg = await makeSignedRegistration(principalId, pk, {
+    networkId,
+    stacks: [{ stack_id: `${principalId}/main`, stack_pubkey: pk.publicKeyB64 }],
+  });
+  const regRes = await post(`/principals/${principalId}/register`, reg);
+  expect(regRes.status).toBe(201);
+
+  const signedRead = await makeSignedAdminRead(globalAdmin);
+  const listRes = await get("/admission-requests?status=PENDING", env, {
+    "x-admin-signed": JSON.stringify(signedRead),
+  });
+  expect(listRes.status).toBe(200);
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const found = list.find((r) => r.principal_id === principalId && r.network_id === networkId);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  globalAdmin = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: globalAdmin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// Admission grant — the core of #1321: each network sovereign over its roster
+// =============================================================================
+
+describe("admission grant — per-network admin", () => {
+  test("a per-network admin can admit a request to THEIR network (not a global admin)", async () => {
+    const pna = await makePrincipalKey(); // per-network admin, NOT on the global allowlist
+    expect((await createNetwork("research-collab", pna.publicKeyB64)).status).toBe(201);
+
+    const req = await registerInto("joel", "research-collab");
+    const decision = await makeDecision(req.request_id, "admit", pna);
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as AdmissionRequest).status).toBe("ADMITTED");
+  });
+
+  test("a per-network admin of network A CANNOT admit a request to network B → 403", async () => {
+    const adminA = await makePrincipalKey();
+    const adminB = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    expect((await createNetwork("net-b", adminB.publicKeyB64)).status).toBe(201);
+
+    const reqB = await registerInto("joel", "net-b");
+    const decision = await makeDecision(reqB.request_id, "admit", adminA); // A's admin, B's request
+    const res = await post(`/admission-requests/${reqB.request_id}/admit`, decision);
+
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("admin_not_authorized");
+  });
+
+  test("the global admin can still admit any network's request (regression)", async () => {
+    const pna = await makePrincipalKey();
+    expect((await createNetwork("research-collab", pna.publicKeyB64)).status).toBe(201);
+
+    const req = await registerInto("joel", "research-collab");
+    const decision = await makeDecision(req.request_id, "admit", globalAdmin);
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+
+    expect(res.status).toBe(200);
+  });
+
+  test("a stranger (neither global nor per-network admin) → 403", async () => {
+    const pna = await makePrincipalKey();
+    const stranger = await makePrincipalKey();
+    expect((await createNetwork("research-collab", pna.publicKeyB64)).status).toBe(201);
+
+    const req = await registerInto("joel", "research-collab");
+    const decision = await makeDecision(req.request_id, "admit", stranger);
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// =============================================================================
+// Network create/update — per-network admin authority + anti-escalation
+// =============================================================================
+
+describe("network create/update — per-network admin", () => {
+  test("a per-network admin can update their network's topology", async () => {
+    const pna = await makePrincipalKey();
+    expect((await createNetwork("research-collab", pna.publicKeyB64)).status).toBe(201);
+
+    const update = await makeSignedNetworkCreate("research-collab", pna, { hubUrl: "tls://new:7500", leafPort: 7500 });
+    const res = await post("/networks/research-collab", update);
+    expect(res.status).toBe(201);
+
+    const stored = await getStore(env).getNetwork("research-collab");
+    expect(stored?.hub_url).toBe("tls://new:7500");
+  });
+
+  test("a per-network admin CANNOT change admin_pubkeys (anti-self-escalation) → 403", async () => {
+    const pna = await makePrincipalKey();
+    const accomplice = await makePrincipalKey();
+    expect((await createNetwork("research-collab", pna.publicKeyB64)).status).toBe(201);
+
+    // pna tries to add `accomplice` to the admin set — must be refused.
+    const escalate = await makeSignedNetworkCreate("research-collab", pna, {
+      adminPubkeys: `${pna.publicKeyB64},${accomplice.publicKeyB64}`,
+    });
+    const res = await post("/networks/research-collab", escalate);
+    expect(res.status).toBe(403);
+
+    // The admin set is unchanged — accomplice still cannot admit.
+    const stored = await getStore(env).getNetwork("research-collab");
+    expect(stored?.admin_pubkeys).toBe(pna.publicKeyB64);
+  });
+
+  test("the global admin CAN set/change admin_pubkeys", async () => {
+    const pna = await makePrincipalKey();
+    expect((await createNetwork("research-collab").then((r) => r.status))).toBe(201);
+
+    const setAdmins = await makeSignedNetworkCreate("research-collab", globalAdmin, {
+      adminPubkeys: pna.publicKeyB64,
+    });
+    const res = await post("/networks/research-collab", setAdmins);
+    expect(res.status).toBe(201);
+
+    const stored = await getStore(env).getNetwork("research-collab");
+    expect(stored?.admin_pubkeys).toBe(pna.publicKeyB64);
+  });
+
+  test("a stranger cannot update a network with a per-network admin set → 403", async () => {
+    const pna = await makePrincipalKey();
+    const stranger = await makePrincipalKey();
+    expect((await createNetwork("research-collab", pna.publicKeyB64)).status).toBe(201);
+
+    const update = await makeSignedNetworkCreate("research-collab", stranger, { hubUrl: "tls://evil:7422" });
+    const res = await post("/networks/research-collab", update);
+    expect(res.status).toBe(403);
+  });
+
+  test("create persists admin_pubkeys", async () => {
+    const pna = await makePrincipalKey();
+    expect((await createNetwork("research-collab", pna.publicKeyB64)).status).toBe(201);
+    const stored = await getStore(env).getNetwork("research-collab");
+    expect(stored?.admin_pubkeys).toBe(pna.publicKeyB64);
+  });
+
+  test("malformed admin_pubkeys in claim → 400", async () => {
+    const body = await makeSignedNetworkCreate("research-collab", globalAdmin, {
+      adminPubkeys: "not-a-valid-base64-pubkey",
+    });
+    const res = await post("/networks/research-collab", body);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/services/network-registry/__tests__/per-network-admin.test.ts
+++ b/src/services/network-registry/__tests__/per-network-admin.test.ts
@@ -187,6 +187,24 @@ describe("network create/update — per-network admin", () => {
     expect(stored?.hub_url).toBe("tls://new:7500");
   });
 
+  test("a per-network topology update PRESERVES the existing admin set (no clobber)", async () => {
+    const pna = await makePrincipalKey();
+    expect((await createNetwork("research-collab", pna.publicKeyB64)).status).toBe(201);
+
+    // pna updates only topology — the claim carries no admin_pubkeys.
+    const update = await makeSignedNetworkCreate("research-collab", pna, { hubUrl: "tls://moved:7600", leafPort: 7600 });
+    expect((await post("/networks/research-collab", update)).status).toBe(201);
+
+    // The admin set must survive the update — not be nulled to global-only.
+    const stored = await getStore(env).getNetwork("research-collab");
+    expect(stored?.admin_pubkeys).toBe(pna.publicKeyB64);
+
+    // And the per-network admin can still admit afterwards (proves preservation end-to-end).
+    const req = await registerInto("joel", "research-collab");
+    const decision = await makeDecision(req.request_id, "admit", pna);
+    expect((await post(`/admission-requests/${req.request_id}/admit`, decision)).status).toBe(200);
+  });
+
   test("a per-network admin CANNOT change admin_pubkeys (anti-self-escalation) → 403", async () => {
     const pna = await makePrincipalKey();
     const accomplice = await makePrincipalKey();

--- a/src/services/network-registry/migrations/0011_network_admin_pubkeys.sql
+++ b/src/services/network-registry/migrations/0011_network_admin_pubkeys.sql
@@ -1,0 +1,25 @@
+-- #1321 (per-network admin authorization):
+-- Add `admin_pubkeys` to the `networks` table so each network carries its OWN
+-- admin allowlist — the **Network posture (admin vs member)** concept
+-- (cortex CONTEXT.md §Network posture) encoded into the registry schema. The
+-- per-network admins may admit/reject onto THIS network's roster and update its
+-- topology; the network is thereby sovereign over its own roster (ADR-0015
+-- admission gate, completed). Descends from ADR-0003 (network-join control
+-- plane) — control-plane only, no wire-grammar change.
+--
+-- Strictly additive: the column is NULLABLE so existing rows remain valid
+-- (NULL = "defer to the global REGISTRY_ADMIN_PUBKEYS only" — the `metafactory`
+-- bootstrap case). Existing network-create calls without the field continue to
+-- work exactly as before. Only a GLOBAL admin may set/change this column
+-- (anti-self-escalation, enforced at the route layer).
+--
+-- Format: comma-separated base64 Ed25519 pubkeys, mirroring the
+-- REGISTRY_ADMIN_PUBKEYS env var. The SQL column is TEXT (D1 has no regex
+-- constraint syntax); each entry is shape-validated at the route layer via
+-- isValidPubkey() before it reaches the store.
+--
+-- Apply:
+--   bunx wrangler d1 migrations apply cortex-network-registry-dev --env dev --remote
+--   bunx wrangler d1 migrations apply cortex-network-registry      --env production --remote
+
+ALTER TABLE networks ADD COLUMN admin_pubkeys TEXT;

--- a/src/services/network-registry/src/index.ts
+++ b/src/services/network-registry/src/index.ts
@@ -116,6 +116,15 @@ export function parseHubAdminPubkeys(env: Env): Set<string> {
   return hub.size > 0 ? hub : parseAdminPubkeys(env);
 }
 
+/**
+ * #1321 — parse a network's per-network `admin_pubkeys` field into a set. Same
+ * comma-separated base64 grammar as the global allowlist; an unset/blank field
+ * yields an EMPTY set (→ "this network defers to the global admins only").
+ */
+export function parseNetworkAdminPubkeys(raw: string | undefined): Set<string> {
+  return parsePubkeySet(raw);
+}
+
 /** Shared parser: comma-separated base64 pubkeys → trimmed, non-empty set. */
 function parsePubkeySet(raw: string | undefined): Set<string> {
   if (typeof raw !== "string" || raw.trim().length === 0) return new Set();

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -44,8 +44,8 @@
  */
 
 import { Hono, type Context } from "hono";
-import { parseAdminPubkeys, parseHubAdminPubkeys, type Env } from "../index";
-import { getNonceCache, getIssuanceStore, AlreadyDecidedError } from "../store";
+import { parseAdminPubkeys, parseHubAdminPubkeys, parseNetworkAdminPubkeys, type Env } from "../index";
+import { getNonceCache, getIssuanceStore, getStore, AlreadyDecidedError } from "../store";
 import {
   validateSignedAdmissionDecision,
   validateAdmissionDecisionClaim,
@@ -165,14 +165,28 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
 
     // 4. Signature verification FIRST (before recording nonce).
     const message = new TextEncoder().encode(canonicalJSON(claim)) as Uint8Array<ArrayBuffer>;
-    const gateResult = await applyAdminGate(
-      adminPubkeys,
-      claim.admin_pubkey,
-      signed.signature,
-      message,
-    );
-    if (gateResult) {
-      return c.json({ error: gateResult.error }, gateResult.status as 401 | 403);
+    const sigValid = await verifyEd25519(claim.admin_pubkey, signed.signature, message);
+    if (!sigValid) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
+
+    // 4b. Authorisation (#1321 per-network admin). The proven key must be
+    // authorised to admit onto THIS request's network — either a GLOBAL admin
+    // (REGISTRY_ADMIN_PUBKEYS, the metafactory bootstrap) OR a PER-NETWORK admin
+    // listed in the target network's `admin_pubkeys` (the **Network posture**
+    // authority — each network sovereign over its own roster, CONTEXT.md). A
+    // network-less request (network_id null) is global-admin-only. Authorization
+    // is keyed off the request's stored network_id, NEVER off anything on the
+    // wire — control-plane only.
+    const issuanceStore = getIssuanceStore(c.env);
+    const reqForAuth = await issuanceStore.getIssuanceRequest(requestId);
+    let authorized = adminPubkeys.has(claim.admin_pubkey);
+    if (!authorized && reqForAuth?.network_id) {
+      const net = await getStore(c.env).getNetwork(reqForAuth.network_id);
+      authorized = parseNetworkAdminPubkeys(net?.admin_pubkeys).has(claim.admin_pubkey);
+    }
+    if (!authorized) {
+      return c.json({ error: "admin_not_authorized" }, 403);
     }
 
     // 5. Replay check — only on authentic + authorised path.

--- a/src/services/network-registry/src/routes/networks.ts
+++ b/src/services/network-registry/src/routes/networks.ts
@@ -26,7 +26,7 @@
  */
 
 import { Hono } from "hono";
-import { getRegistryPublicKey, parseAdminPubkeys, type Env } from "../index";
+import { getRegistryPublicKey, parseAdminPubkeys, parseNetworkAdminPubkeys, type Env } from "../index";
 import { signAssertion } from "./principals";
 import {
   getIssuanceStore,
@@ -159,12 +159,30 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "signature_invalid" }, 401);
     }
 
-    // Authorisation: the (cryptographically proven) admin_pubkey MUST be in the
-    // configured allowlist. A valid signature from a NON-allowlisted key is a
-    // 403 — possession is proven, but the key is not authorised to write
-    // network topology. This is the core admin gate of #747.
-    if (!adminPubkeys.has(claim.admin_pubkey)) {
+    // Authorisation (#747 + #1321 per-network admin). The (cryptographically
+    // proven) admin_pubkey must be authorised to write THIS network — either:
+    //   (a) a GLOBAL admin (REGISTRY_ADMIN_PUBKEYS, the metafactory bootstrap), OR
+    //   (b) a PER-NETWORK admin listed in the existing record's `admin_pubkeys`
+    //       (the **Network posture (admin vs member)** authority — CONTEXT.md).
+    // On CREATE (no existing record) there is no per-network set yet, so only a
+    // global admin can create — network creation stays a hierarchical act
+    // (RIR/IANA-style), per the federation-decentralisation research.
+    const store = getStore(c.env);
+    const existing = await store.getNetwork(networkId);
+    const isGlobalAdmin = adminPubkeys.has(claim.admin_pubkey);
+    const perNetworkAdmins = parseNetworkAdminPubkeys(existing?.admin_pubkeys);
+    const isPerNetworkAdmin = perNetworkAdmins.has(claim.admin_pubkey);
+    if (!isGlobalAdmin && !isPerNetworkAdmin) {
       return c.json({ error: "admin_not_authorized" }, 403);
+    }
+
+    // Anti-self-escalation (#1321): only a GLOBAL admin may set or change a
+    // network's admin_pubkeys. A per-network admin governs the roster + topology
+    // but cannot add co-admins or lock out the global admin. A per-network admin
+    // who supplies admin_pubkeys is refused (403) rather than silently ignored,
+    // so the attempt is visible.
+    if (claim.admin_pubkeys !== undefined && !isGlobalAdmin) {
+      return c.json({ error: "admin_pubkeys_requires_global_admin" }, 403);
     }
 
     // Replay check — only on the authentic+authorised path so a nonce row is
@@ -176,8 +194,19 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "nonce_replayed" }, 409);
     }
 
-    const store = getStore(c.env);
-    const record = await store.putNetwork(claim.network_id, claim.hub_url, claim.leaf_port);
+    // Resolve the admin_pubkeys to persist: a global admin may set it from the
+    // claim; otherwise PRESERVE the existing set (never clobber on a per-network
+    // topology update). Always pass the resolved value so both store backends
+    // write the same thing.
+    const adminPubkeysToStore = isGlobalAdmin
+      ? (claim.admin_pubkeys ?? existing?.admin_pubkeys)
+      : existing?.admin_pubkeys;
+    const record = await store.putNetwork(
+      claim.network_id,
+      claim.hub_url,
+      claim.leaf_port,
+      adminPubkeysToStore,
+    );
 
     // Return the stored record wrapped in a registry-signed assertion — the
     // same shape GET /networks/:id serves, so the admin gets a verifiable

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -147,6 +147,8 @@ export interface RegistryStore {
     networkId: string,
     hubUrl: string,
     leafPort: number,
+    /** #1321 — per-network admin allowlist (comma-separated base64). Omit to leave unset. */
+    adminPubkeys?: string,
   ): Promise<NetworkRecord>;
 
   /**
@@ -732,12 +734,14 @@ export class InMemoryRegistryStore implements RegistryStore {
     networkId: string,
     hubUrl: string,
     leafPort: number,
+    adminPubkeys?: string,
   ): Promise<NetworkRecord> {
     const record: NetworkRecord = {
       network_id: networkId,
       hub_url: hubUrl,
       leaf_port: leafPort,
       updated_at: new Date().toISOString(),
+      ...(adminPubkeys !== undefined && { admin_pubkeys: adminPubkeys }),
     };
     this.networks.set(networkId, record);
     return record;
@@ -882,25 +886,28 @@ export class D1RegistryStore implements RegistryStore {
     networkId: string,
     hubUrl: string,
     leafPort: number,
+    adminPubkeys?: string,
   ): Promise<NetworkRecord> {
     const record: NetworkRecord = {
       network_id: networkId,
       hub_url: hubUrl,
       leaf_port: leafPort,
       updated_at: new Date().toISOString(),
+      ...(adminPubkeys !== undefined && { admin_pubkeys: adminPubkeys }),
     };
     // UPSERT: re-seeding a network replaces the topology row in place.
     // Parameterised — no value is string-interpolated into SQL.
     await this.db
       .prepare(
-        `INSERT INTO networks (network_id, hub_url, leaf_port, updated_at)
-         VALUES (?, ?, ?, ?)
+        `INSERT INTO networks (network_id, hub_url, leaf_port, updated_at, admin_pubkeys)
+         VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(network_id) DO UPDATE SET
-           hub_url    = excluded.hub_url,
-           leaf_port  = excluded.leaf_port,
-           updated_at = excluded.updated_at`,
+           hub_url       = excluded.hub_url,
+           leaf_port     = excluded.leaf_port,
+           updated_at    = excluded.updated_at,
+           admin_pubkeys = excluded.admin_pubkeys`,
       )
-      .bind(networkId, hubUrl, leafPort, record.updated_at)
+      .bind(networkId, hubUrl, leafPort, record.updated_at, adminPubkeys ?? null)
       .run();
     return record;
   }
@@ -908,7 +915,7 @@ export class D1RegistryStore implements RegistryStore {
   async getNetwork(networkId: string): Promise<NetworkRecord | undefined> {
     const row = await this.db
       .prepare(
-        "SELECT network_id, hub_url, leaf_port, updated_at FROM networks WHERE network_id = ?",
+        "SELECT network_id, hub_url, leaf_port, updated_at, admin_pubkeys FROM networks WHERE network_id = ?",
       )
       .bind(networkId)
       .first<NetworkRow>();
@@ -946,6 +953,8 @@ interface NetworkRow {
   /** SQLite stores the INTEGER column; D1 returns it as a JS number. */
   leaf_port: number;
   updated_at: string;
+  /** #1321 — nullable per-network admin allowlist (TEXT column, migration 0011). */
+  admin_pubkeys?: string | null;
 }
 
 function rowToNetworkRecord(row: NetworkRow): NetworkRecord {
@@ -954,6 +963,8 @@ function rowToNetworkRecord(row: NetworkRow): NetworkRecord {
     hub_url: row.hub_url,
     leaf_port: row.leaf_port,
     updated_at: row.updated_at,
+    // Normalise SQL NULL → undefined so the record shape matches the InMemory store.
+    ...(row.admin_pubkeys != null && { admin_pubkeys: row.admin_pubkeys }),
   };
 }
 

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -248,6 +248,18 @@ export interface NetworkRecord {
   leaf_port: number;
   /** ISO-8601 UTC; when the topology was last (re-)seeded. */
   updated_at: string;
+  /**
+   * #1321 — this network's admin allowlist: comma-separated base64 Ed25519
+   * pubkeys authorized to admit/reject onto THIS network's roster and to update
+   * its topology (the **Network posture (admin vs member)** concept, CONTEXT.md
+   * §Network posture, encoded into the schema). Format mirrors the global
+   * `REGISTRY_ADMIN_PUBKEYS` env var. `undefined`/empty means "global
+   * `REGISTRY_ADMIN_PUBKEYS` only" — the `metafactory` bootstrap case. Only a
+   * GLOBAL admin may set or change this field (anti-self-escalation). It is NOT
+   * exposed in {@link NetworkDescriptor} (kept off the public descriptor; MC
+   * posture rendering is a follow-up).
+   */
+  admin_pubkeys?: string;
 }
 
 /**

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -396,6 +396,14 @@ export interface NetworkCreateClaim {
   issued_at: string;
   /** Random nonce to prevent replay. */
   nonce: string;
+  /**
+   * #1321 — OPTIONAL per-network admin allowlist to set on the network record:
+   * comma-separated base64 Ed25519 pubkeys (same grammar as the global var).
+   * Only a GLOBAL admin may set/change this (the route enforces that — a
+   * per-network admin supplying it is rejected 403). Omitted on a plain
+   * topology update.
+   */
+  admin_pubkeys?: string;
 }
 
 /** The on-wire envelope: an admin claim + detached Ed25519 signature. */
@@ -468,6 +476,26 @@ export function validateNetworkCreateClaim(
     errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
   }
 
+  // admin_pubkeys (#1321) — OPTIONAL comma-separated base64 pubkeys; same shape
+  // as the global allowlist. Validate every entry so a malformed set is rejected
+  // pre-crypto rather than persisted. Authorization (only-global-may-set) is the
+  // route's job, not the validator's.
+  if (c.admin_pubkeys !== undefined) {
+    if (typeof c.admin_pubkeys !== "string") {
+      errors.push({ field: "admin_pubkeys", message: "must be a string (comma-separated base64 pubkeys) or omitted" });
+    } else {
+      const entries = c.admin_pubkeys
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (entries.length === 0) {
+        errors.push({ field: "admin_pubkeys", message: "must contain at least one pubkey when present" });
+      } else if (!entries.every((e) => isValidPubkey(e))) {
+        errors.push({ field: "admin_pubkeys", message: "every entry must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
+      }
+    }
+  }
+
   if (errors.length > 0) return { ok: false, errors };
 
   const result: NetworkCreateClaim = {
@@ -477,6 +505,7 @@ export function validateNetworkCreateClaim(
     admin_pubkey: c.admin_pubkey as string,
     issued_at: c.issued_at as string,
     nonce: c.nonce as string,
+    ...(c.admin_pubkeys !== undefined && { admin_pubkeys: c.admin_pubkeys as string }),
   };
   return { ok: true, claim: result };
 }


### PR DESCRIPTION
Closes #1321. First code-level fix from the federation-decentralisation research ([PR #1319](https://github.com/the-metafactory/cortex/pull/1319)). Parent #110.

## What & why

Encodes the existing domain concept **Network posture (admin vs member)** (CONTEXT.md §Network posture) into the registry schema so **each network is sovereign over its own roster**. Before, both the admission-grant gate and the network create/update gate keyed on the **registry-wide** `REGISTRY_ADMIN_PUBKEYS` — one global authority admitted peers for *every* network. This **re-sources** those gates (encode/re-source, not introduce — per Luna's guardrail), it does not add a new mechanism.

## Privilege model (anti-self-escalation)

| Action | Authorized by |
|---|---|
| Network **create** | global admin only (may set initial `admin_pubkeys`) — allocation stays hierarchical |
| Network **update** (topology) | per-network admin OR global; **only global** may change `admin_pubkeys` (`403 admin_pubkeys_requires_global_admin`) |
| Admission **grant** (admit/reject) | per-network admin for the request's network OR global — keyed off the stored `network_id` |
| Admin **reads** | global only (per-network read-scoping = fast-follow) |

`REGISTRY_ADMIN_PUBKEYS` is retained as the `metafactory` bootstrap/super-admin; a network with NULL `admin_pubkeys` behaves exactly as before (**backward compatible**).

## Control-plane only

No subject shape, no envelope field, no `selectLink`/`source`/`originator` change — the `admin_pubkeys` set never appears on the wire. **Federation wire-protocol SOP 5-check unaffected.**

## Changes

- `NetworkRecord.admin_pubkeys?` (TEXT, nullable, comma-separated base64) + D1 migration `0011_network_admin_pubkeys.sql`
- `NetworkCreateClaim.admin_pubkeys?` + validation (`validate.ts`)
- `parseNetworkAdminPubkeys` (`index.ts`); store `putNetwork`/`getNetwork`/`NetworkRow` (in-memory + D1 + d1-mock)
- `POST /networks/{id}` gate (`routes/networks.ts`); admit/reject gate (`routes/admission-requests.ts`)
- ADR-0020; +11 tests (`per-network-admin.test.ts`)

## Verification

- `bun test src/services/network-registry/` → **242 pass / 0 fail**
- `bunx tsc --noEmit` → **clean**

## Out of scope / fast-follows (flagged, not silently dropped)

- Expose `admin_pubkeys` on `GET /networks/{id}` for MC **Network posture** rendering (#1275/#1276) — touches the cortex-side `NetworkDescriptor` mirror + MC.
- `cortex network create --network-admins` CLI flag + `buildNetworkCreateClaim` plumbing (today a global admin sets it via the signed claim / store seed).
- Per-network admin **read-scoping** (list their network's pending requests).

## ⚠️ Merge hold

Trust-path (admission/authorization) change made during an autonomous run while JC is away. Prepared green + self-adversarially reviewed, but **merge is held for JC/Luna sign-off** per the autonomous-work SOP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)