### PR TITLE
feat(cli): C-1325 — cortex network create --network-admins (set per-network admins)

### DIFF
--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -514,6 +514,13 @@ export interface NetworkCreateClaimShape {
   admin_pubkey: string;
   issued_at: string;
   nonce: string;
+  /**
+   * #1321 — OPTIONAL per-network admin allowlist (comma-separated base64 Ed25519
+   * pubkeys). Only a GLOBAL admin's create/update may set it (the registry
+   * enforces that — ADR-0020). Omitted on a plain topology create/update so the
+   * canonical-JSON the registry verifies stays byte-identical to pre-#1321 claims.
+   */
+  admin_pubkeys?: string;
 }
 
 /** A network-create claim + detached signature, ready to POST. */
@@ -533,6 +540,12 @@ export interface BuildNetworkCreateClaimOptions {
   readonly issuedAt?: string;
   /** Override nonce (tests). Defaults to a fresh random hex. @internal */
   readonly nonce?: string;
+  /**
+   * #1321 — OPTIONAL per-network admin allowlist to set on the network record
+   * (comma-separated base64 pubkeys). Accepted by the registry only from a GLOBAL
+   * admin (ADR-0020). Omit on a plain topology create/update.
+   */
+  readonly adminPubkeys?: string;
 }
 
 /**
@@ -553,6 +566,9 @@ export async function buildNetworkCreateClaim(
     admin_pubkey: opts.material.pubkeyB64,
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
+    // Only include admin_pubkeys when set — keeps canonicalJSON byte-identical to
+    // pre-#1321 claims when omitted, so existing signatures/tests are unaffected.
+    ...(opts.adminPubkeys !== undefined && { admin_pubkeys: opts.adminPubkeys }),
   };
   // Re-derive the KeyPair from the in-memory seed and sign over the SAME
   // canonical-JSON the registry route reconstructs and verifies.

--- a/src/cli/cortex/commands/__tests__/network-create.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-create.test.ts
@@ -31,6 +31,7 @@ import {
   makeRegistryKey,
   resetStores,
 } from "../../../../services/network-registry/__tests__/helpers";
+import { getStore } from "../../../../services/network-registry/src/store";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -119,6 +120,98 @@ describe("create usage", () => {
     ]);
     expect(res.exitCode).toBe(1);
     expect(res.stderr).toContain("not found");
+  });
+
+  test("--network-admins with a malformed pubkey (exit 2)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const res = await dispatchNetwork([
+      "create", "research-collab", "--hub", "tls://hub:7422", "--leaf-port", "7422",
+      "--admin-seed", seedPath, "--network-admins", "not-a-valid-pubkey",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--network-admins");
+  });
+
+  test("--network-admins with only blanks/commas (exit 2)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const res = await dispatchNetwork([
+      "create", "research-collab", "--hub", "tls://hub:7422", "--leaf-port", "7422",
+      "--admin-seed", seedPath, "--network-admins", " , , ",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("at least one");
+  });
+});
+
+// =============================================================================
+// #1321 — --network-admins (per-network admin allowlist)
+// =============================================================================
+
+describe("create --network-admins (#1321)", () => {
+  test("dry-run: a valid --network-admins lands in the signed claim (normalised)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    const { adminPubkey: pna } = await mintAdminSeed();
+
+    globalThis.fetch = (() => {
+      throw new Error("dry-run must not perform network I/O");
+    }) as unknown as typeof globalThis.fetch;
+
+    const res = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub.meta-factory.ai:7422", "--leaf-port", "7422",
+      "--admin-seed", seedPath,
+      "--network-admins", ` ${pna} , `, // whitespace + trailing comma → normalised
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { items: { claim: Record<string, unknown> }[] };
+    expect(env.items[0]!.claim.admin_pubkeys).toBe(pna);
+  });
+
+  test("dry-run: omitting --network-admins leaves admin_pubkeys absent (back-compat)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    globalThis.fetch = (() => {
+      throw new Error("dry-run must not perform network I/O");
+    }) as unknown as typeof globalThis.fetch;
+
+    const res = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub:7422", "--leaf-port", "7422", "--admin-seed", seedPath, "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { items: { claim: Record<string, unknown> }[] };
+    expect(env.items[0]!.claim.admin_pubkeys).toBeUndefined();
+  });
+
+  test("--apply: a global admin's --network-admins persists to the network record", async () => {
+    const { seedPath, adminPubkey } = await mintAdminSeed();
+    const { adminPubkey: pna } = await mintAdminSeed();
+    const reg = await makeRegistryKey();
+    const registryEnv: Env = {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      REGISTRY_ADMIN_PUBKEYS: adminPubkey,
+      ENVIRONMENT: "test",
+    };
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, registryEnv);
+    }) as typeof globalThis.fetch;
+
+    const res = await dispatchNetwork([
+      "create", "research-collab",
+      "--hub", "tls://hub.meta-factory.ai:7422", "--leaf-port", "7422",
+      "--admin-seed", seedPath,
+      "--network-admins", pna,
+      "--registry-url", "https://network.test",
+      "--apply",
+    ]);
+    expect(res.exitCode).toBe(0);
+
+    // The per-network admin set is persisted on the network record (end-to-end:
+    // CLI → signed claim → real registry route → store).
+    const stored = await getStore(registryEnv).getNetwork("research-collab");
+    expect(stored?.admin_pubkeys).toBe(pna);
   });
 });
 

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -293,6 +293,7 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--hub": "value",
         "--leaf-port": "value",
         "--admin-seed": "value",
+        "--network-admins": "value",
         "--registry-url": "value",
         "--apply": "bool",
         "--dry-run": "bool",
@@ -1167,6 +1168,24 @@ async function runCreate(
 
   const registryUrl = optionalValueFlag(flags, "--registry-url") ?? DEFAULT_REGISTRY_URL;
 
+  // #1321 — optional per-network admins (comma-separated base64 Ed25519 pubkeys).
+  // The registry accepts admin_pubkeys ONLY from a GLOBAL admin (ADR-0020); the
+  // CLI validates the SHAPE locally for fast feedback and normalises (trim, drop
+  // blanks) before signing. Omitted → a plain topology create/update.
+  let adminPubkeys: string | undefined;
+  const networkAdminsRaw = optionalValueFlag(flags, "--network-admins");
+  if (networkAdminsRaw !== undefined) {
+    const entries = networkAdminsRaw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+    if (entries.length === 0) {
+      return usageError("create", "--network-admins must list at least one base64 pubkey", json);
+    }
+    const bad = entries.find((e) => !MEMBER_PUBKEY_RE.test(e));
+    if (bad !== undefined) {
+      return usageError("create", `--network-admins entry "${bad}" must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)`, json);
+    }
+    adminPubkeys = entries.join(",");
+  }
+
   // Load the admin nkey seed + derive its base64 pubkey (the SAME key shape +
   // signing path provision-stack uses), then build the signed claim.
   const matRes = await adminMaterialFromSeedFile(seedRes.value);
@@ -1179,6 +1198,7 @@ async function runCreate(
       hubUrl,
       leafPort,
       material: matRes.material,
+      adminPubkeys,
     });
   } catch (err) {
     return opError("create", `failed to build network-create claim: ${err instanceof Error ? err.message : String(err)}`, json);
@@ -1205,6 +1225,7 @@ async function runCreate(
       `  leaf_port:    ${leafPort.toString()}`,
       `  admin_pubkey: ${matRes.material.pubkeyB64}`,
       `  fingerprint:  ${matRes.material.fingerprint}`,
+      `  network_admins: ${adminPubkeys ?? "(none — defers to global REGISTRY_ADMIN_PUBKEYS)"}`,
       ``,
       `Would POST ${registryUrl}/networks/${networkId}:`,
       JSON.stringify(body, null, 2),
@@ -2400,7 +2421,7 @@ Usage:
   cortex network join   <network> [--apply] [--config <p>] [overrides…]
   cortex network leave  <network> [--apply] [--config <p>] [overrides…]
   cortex network status [--principal <id>] [--stack <id>] [--monitor-url <url>] [--json]
-  cortex network create <network> --hub <tls-url> --leaf-port <port> --admin-seed <path> [--registry-url <url>] [--apply]
+  cortex network create <network> --hub <tls-url> --leaf-port <port> --admin-seed <path> [--network-admins <csv>] [--registry-url <url>] [--apply]
   cortex network ping   <peer> [--assistant <a>] [--network <id>] [--count N] [--timeout <ms>] [--json]
   cortex network admit  <request-id> --admin-seed <path> [--network <id>] [--registry-url <url>]
                         [--discord-member <id>] [--discord-guild <id>] [--discord-server <profile>]
@@ -2560,6 +2581,10 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
   --admin-seed <path>     (create) path to the admin nkey seed (SU…) signing the claim.
                           admin_pubkey is derived from it; the registry's
                           REGISTRY_ADMIN_PUBKEYS allowlist must contain that pubkey.
+  --network-admins <csv>  (create) comma-separated base64 Ed25519 pubkeys to set as
+                          THIS network's per-network admins (#1321). They may admit
+                          onto its roster + update its topology. Accepted only from a
+                          GLOBAL admin's claim. Omit → defers to REGISTRY_ADMIN_PUBKEYS.
   --registry-url <url>    (create) registry base URL (default: https://network.meta-factory.ai).
   --apply                 Execute the live mutation (default: dry-run).
   --json                  Emit a { status, items, data, error } envelope.


### PR DESCRIPTION
Closes #1325. Fast-follow to #1321 (merged via #1323). Parent #110.

## What

Wires the per-network admin allowlist through the normal CLI path. After #1321 the registry stores `NetworkRecord.admin_pubkeys` and accepts it from a GLOBAL admin's signed claim — but there was no ergonomic way to set it. Now:

```
cortex network create <net> --hub <url> --leaf-port <p> --admin-seed <seed> --network-admins <csv> [--apply]
```

- `buildNetworkCreateClaim` (`stack-provisioning.ts`): optional `adminPubkeys` → `claim.admin_pubkeys`, **conditionally included** so `canonicalJSON` stays byte-identical to pre-#1321 claims when omitted (existing signatures/tests unaffected).
- `cortex network create`: `--network-admins <csv>` flag (registered as a value flag in the create subcommand spec); validates each entry against the ed25519 base64 pubkey shape (`MEMBER_PUBKEY_RE`), normalises (trim, drop blanks), surfaces in dry-run output; help text updated.
- The registry accepts `admin_pubkeys` **only from a GLOBAL admin** (anti-self-escalation enforced server-side, #1321 / ADR-0020) — the CLI just plumbs the field.

## Control-plane only

No wire-grammar change. Federation wire-protocol 5-check unaffected.

## Verification

- `bun test` (CLI commands + bus + network-registry) → **2011 pass / 0 fail**
- `bunx tsc --noEmit` → clean · vocab carve-out gate → PASS
- Tests +5: dry-run claim shape (normalised), malformed pubkey → exit 2, blanks-only → exit 2, omitted → `admin_pubkeys` absent (back-compat), and an **end-to-end `--apply` → persist** slice through the real registry route asserting the network record carries the admin set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)