### PR TITLE
fix(gateway): C-110 — wire web platform into gateway binding router and bootstrap guards

### DIFF
--- a/src/gateway/__tests__/binding-resolver.test.ts
+++ b/src/gateway/__tests__/binding-resolver.test.ts
@@ -785,3 +785,192 @@ describe("crossPrincipalBindings — single-principal v1 guard", () => {
     expect(crossPrincipalBindings(surfaces, "andreas")).toEqual(["other/x"]);
   });
 });
+
+// ─── Web platform coverage (C-110 / WEB-1 gateway routing fix) ───────────────
+//
+// The web adapter was added by WEB-1 but the gateway's binding-presence guards
+// and inbound router were not taught about the `web` platform until this fix.
+// These tests pin the newly-wired paths so a future refactor can't silently
+// drop them again.
+
+/** One web binding — instanceId "amt" → demux key "web:amt". */
+const WEB_SURFACES: Surfaces = {
+  web: [
+    {
+      agent: "pylon",
+      stack: "andreas/amt",
+      binding: {
+        instanceId: "amt",
+        port: 8090,
+        broadcastUrl: "http://localhost:9090/broadcast",
+        transport: "ws",
+        authScheme: "cf-access",
+      },
+    },
+  ],
+};
+
+describe("buildBindingIndex — web happy path", () => {
+  test("web: indexes by instanceId prefixed with 'web:'", () => {
+    const index = buildBindingIndex(WEB_SURFACES);
+    expect(index.web.size).toBe(1);
+    expect(index.web.has("web:amt")).toBe(true);
+  });
+
+  test("web entry carries agent, principal, stack, and instance from fixture", () => {
+    const index = buildBindingIndex(WEB_SURFACES);
+    const entry = index.web.get("web:amt");
+    expect(entry).toBeDefined();
+    expect(entry!.agent).toBe("pylon");
+    expect(entry!.principal).toBe("andreas");
+    expect(entry!.stack).toBe("amt");
+    expect(entry!.instance).toBe("web:amt");
+  });
+
+  test("empty surfaces: web map is empty (web key present with size 0)", () => {
+    const index = buildBindingIndex({});
+    expect(index.web.size).toBe(0);
+  });
+});
+
+describe("buildBindingIndex — web collision throws", () => {
+  test("two web bindings sharing the same instanceId → throws with instanceId in message", () => {
+    const ambiguous: Surfaces = {
+      web: [
+        {
+          agent: "pylon",
+          stack: "andreas/amt",
+          binding: {
+            instanceId: "amt",
+            port: 8090,
+            broadcastUrl: "http://localhost:9090/broadcast",
+            transport: "ws",
+            authScheme: "cf-access",
+          },
+        },
+        {
+          agent: "relay",
+          stack: "andreas/work",
+          binding: {
+            instanceId: "amt", // duplicate — same demux key "web:amt"
+            port: 8091,
+            broadcastUrl: "http://localhost:9091/broadcast",
+            transport: "ws",
+            authScheme: "cf-access",
+          },
+        },
+      ],
+    };
+    expect(() => buildBindingIndex(ambiguous)).toThrow(/web.*amt/i);
+  });
+});
+
+describe("resolveBinding — web happy path", () => {
+  test("web: resolves by instanceId (full 'web:<id>' key stamped by the WebAdapter)", () => {
+    const index = buildBindingIndex(WEB_SURFACES);
+    // The WebAdapter stamps instanceId="web:amt" on every inbound message
+    const inbound = msg({ platform: "web", instanceId: "web:amt" });
+    const match = resolveBinding(index, inbound);
+    expect(match).not.toBeNull();
+    expect(match!.platform).toBe("web");
+    expect(match!.agent).toBe("pylon");
+    expect(match!.principal).toBe("andreas");
+    expect(match!.stack).toBe("amt");
+    expect(match!.instance).toBe("web:amt");
+  });
+
+  test("web: instanceId not in index → null", () => {
+    const index = buildBindingIndex(WEB_SURFACES);
+    const inbound = msg({ platform: "web", instanceId: "web:unknown" });
+    expect(resolveBinding(index, inbound)).toBeNull();
+  });
+
+  test("web inbound against discord-only index → null (web map is empty)", () => {
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const inbound = msg({ platform: "web", instanceId: "web:amt" });
+    expect(resolveBinding(index, inbound)).toBeNull();
+  });
+});
+
+describe("distinctBoundStacks — web bindings", () => {
+  test("web-only surfaces: includes the web binding's stack leaf", () => {
+    expect(distinctBoundStacks(WEB_SURFACES)).toEqual(["amt"]);
+  });
+
+  test("web stack deduped when the same leaf appears in both discord and web", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/amt",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+      ],
+      web: [
+        {
+          agent: "pylon",
+          stack: "andreas/amt", // same leaf — collapses to one entry
+          binding: {
+            instanceId: "amt",
+            port: 8090,
+            broadcastUrl: "http://localhost:9090/broadcast",
+            transport: "ws",
+            authScheme: "cf-access",
+          },
+        },
+      ],
+    };
+    expect(distinctBoundStacks(surfaces)).toEqual(["amt"]);
+  });
+
+  test("web adds a distinct stack leaf beyond discord's set", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+      ],
+      web: [
+        {
+          agent: "pylon",
+          stack: "andreas/amt",
+          binding: {
+            instanceId: "amt",
+            port: 8090,
+            broadcastUrl: "http://localhost:9090/broadcast",
+            transport: "ws",
+            authScheme: "cf-access",
+          },
+        },
+      ],
+    };
+    expect(distinctBoundStacks(surfaces)).toEqual(["meta-factory", "amt"]);
+  });
+});
+
+describe("crossPrincipalBindings — web bindings", () => {
+  test("web binding under the gateway principal → no offenders", () => {
+    expect(crossPrincipalBindings(WEB_SURFACES, "andreas")).toEqual([]);
+  });
+
+  test("web binding under another principal → flagged", () => {
+    const surfaces: Surfaces = {
+      web: [
+        {
+          agent: "pylon",
+          stack: "other/amt",
+          binding: {
+            instanceId: "amt",
+            port: 8090,
+            broadcastUrl: "http://localhost:9090/broadcast",
+            transport: "ws",
+            authScheme: "cf-access",
+          },
+        },
+      ],
+    };
+    expect(crossPrincipalBindings(surfaces, "andreas")).toEqual(["other/amt"]);
+  });
+});

--- a/src/gateway/__tests__/gateway-bootstrap.test.ts
+++ b/src/gateway/__tests__/gateway-bootstrap.test.ts
@@ -503,3 +503,61 @@ describe("maybeCreateSurfaceGateway — error propagation", () => {
     ).toThrow(/ambiguous discord config/);
   });
 });
+
+// =============================================================================
+// maybeCreateSurfaceGateway — web surfaces (C-110 / WEB-1 gateway routing fix)
+//
+// WEB-1 added the web adapter but `countBindings` previously excluded
+// `surfaces.web`, so a web-only stack reported "0 bindings" and the gateway
+// never started. This block pins the corrected path.
+// =============================================================================
+
+/** Web-only surfaces — one binding, instanceId "amt". */
+const WEB_SURFACES: Surfaces = {
+  web: [
+    {
+      agent: "pylon",
+      stack: "andreas/amt",
+      binding: {
+        instanceId: "amt",
+        port: 8090,
+        broadcastUrl: "http://localhost:9090/broadcast",
+        transport: "ws",
+        authScheme: "cf-access",
+      },
+    },
+  ],
+};
+
+describe("maybeCreateSurfaceGateway — web surfaces", () => {
+  test("returns a SurfaceGateway when web-only surfaces provided (countBindings counts web)", () => {
+    const result = maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces: WEB_SURFACES,
+      adapters: [makeFakeAdapter("fake-web-1")],
+    });
+    expect(result).toBeInstanceOf(SurfaceGateway);
+  });
+
+  test("does NOT return undefined or log a no-bindings warning for web-only surfaces", () => {
+    const messages: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation((m) => {
+      messages.push(String(m));
+      return true;
+    });
+    try {
+      const result = maybeCreateSurfaceGateway({
+        enabled: true,
+        surfaces: WEB_SURFACES,
+        adapters: [makeFakeAdapter("fake-web-2")],
+      });
+      // Must have created the gateway, not hit the "no bindings" early-exit
+      expect(result).toBeInstanceOf(SurfaceGateway);
+      // No "no surfaces bindings found" warning
+      const warned = messages.some((m) => m.includes("no surfaces bindings found"));
+      expect(warned).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/src/gateway/__tests__/surface-ownership-plan.test.ts
+++ b/src/gateway/__tests__/surface-ownership-plan.test.ts
@@ -228,3 +228,77 @@ describe("gatewayAdapterInstanceCollisions", () => {
     expect(collisions).toEqual([]);
   });
 });
+
+// ─── Web platform coverage (C-110 / WEB-1 gateway routing fix) ───────────────
+//
+// WEB-1 added the web adapter but countSurfaceBindings / ownedKeys /
+// gatewayInstanceIds previously excluded `surfaces.web`, so a web-only stack
+// was invisible to the ownership plan (0 bindings → gateway never started).
+// These tests pin the corrected paths.
+
+/** Web-only surfaces — one binding, instanceId "amt", agent "pylon". */
+const WEB_SURFACES: Surfaces = {
+  web: [
+    {
+      agent: "pylon",
+      stack: "andreas/amt",
+      binding: {
+        instanceId: "amt",
+        port: 8090,
+        broadcastUrl: "http://localhost:9090/broadcast",
+        transport: "ws",
+        authScheme: "cf-access",
+      },
+    },
+  ],
+};
+
+describe("planSurfaceOwnership — web surfaces", () => {
+  test("countSurfaceBindings includes web — web-only surfaces make the plan start-eligible", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: WEB_SURFACES,
+      gatewayEnabled: true,
+      principal: "andreas",
+    });
+    expect(plan.hasSurfaceBindings).toBe(true);
+    expect(plan.gatewayStartEligible).toBe(true);
+  });
+
+  test("ownedKeys includes the web binding's '{platform}:{agent}' key", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: WEB_SURFACES,
+      gatewayEnabled: true,
+      principal: "andreas",
+    });
+    expect([...plan.ownedSurfaceKeys]).toContain("web:pylon");
+  });
+
+  test("gatewayAdapterInstanceIds includes the web binding's 'web:{instanceId}'", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: WEB_SURFACES,
+      gatewayEnabled: true,
+      principal: "andreas",
+    });
+    expect(plan.gatewayAdapterInstanceIds).toContain("web:amt");
+  });
+
+  test("outboundStacks includes the web binding's stack leaf", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: WEB_SURFACES,
+      gatewayEnabled: true,
+      principal: "andreas",
+    });
+    expect(plan.outboundStacks).toContain("amt");
+  });
+
+  test("flag off with web-only surfaces keeps the inactive plan (gateway never starts)", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: WEB_SURFACES,
+      gatewayEnabled: false,
+      principal: "andreas",
+    });
+    expect(plan.hasSurfaceBindings).toBe(true); // bindings exist…
+    expect(plan.gatewayStartEligible).toBe(false); // …but flag is off
+    expect([...plan.ownedSurfaceKeys]).toEqual([]);
+  });
+});

--- a/src/gateway/binding-resolver.ts
+++ b/src/gateway/binding-resolver.ts
@@ -72,7 +72,7 @@ import type { InboundMessage } from "../adapters/types";
  */
 export interface GatewayBindingMatch {
   /** Platform the inbound message arrived on. */
-  platform: "discord" | "slack" | "mattermost";
+  platform: "discord" | "slack" | "mattermost" | "web";
 
   /**
    * The `agent` id from the binding entry — the stack-local agent id that
@@ -136,6 +136,8 @@ export interface GatewayBindingIndex {
   discord: Map<string, IndexEntry>;
   /** Slack: keyed by `binding.workspaceId` */
   slack: Map<string, IndexEntry>;
+  /** Web: keyed by the adapter instanceId stamped on InboundMessage (e.g. `web:amt`). */
+  web: Map<string, IndexEntry>;
   /**
    * Mattermost single-binding fallback.
    * `null`  → no mattermost bindings.
@@ -230,6 +232,7 @@ export function distinctBoundStacks(
   for (const e of surfaces.discord ?? []) add(e.stack);
   for (const e of surfaces.slack ?? []) add(e.stack);
   for (const e of surfaces.mattermost ?? []) add(e.stack);
+  for (const e of surfaces.web ?? []) add(e.stack);
   return out;
 }
 
@@ -310,6 +313,7 @@ export function distinctBoundPrincipalStacks(
   for (const e of surfaces.discord ?? []) add(e.stack);
   for (const e of surfaces.slack ?? []) add(e.stack);
   for (const e of surfaces.mattermost ?? []) add(e.stack);
+  for (const e of surfaces.web ?? []) add(e.stack);
   return out;
 }
 
@@ -359,6 +363,7 @@ export function crossPrincipalBindings(
   for (const e of surfaces.discord ?? []) check(e.stack);
   for (const e of surfaces.slack ?? []) check(e.stack);
   for (const e of surfaces.mattermost ?? []) check(e.stack);
+  for (const e of surfaces.web ?? []) check(e.stack);
   return out;
 }
 
@@ -379,6 +384,7 @@ export function crossPrincipalBindings(
 export function buildBindingIndex(surfaces: Surfaces): GatewayBindingIndex {
   const discord = new Map<string, IndexEntry>();
   const slack = new Map<string, IndexEntry>();
+  const web = new Map<string, IndexEntry>();
   let mattermostSingle: IndexEntry | null = null;
   let mattermostMulti = false;
 
@@ -455,7 +461,29 @@ export function buildBindingIndex(surfaces: Surfaces): GatewayBindingIndex {
     // mattermostMulti flag as the documented reason.
   }
 
-  return { discord, slack, mattermostSingle, mattermostMulti };
+  // ── Web ──────────────────────────────────────────────────────────────────
+  // Demux key = the adapter instanceId the WebAdapter stamps on every
+  // InboundMessage (`web:${binding.instanceId}`), matched verbatim in
+  // resolveBinding. Web carries no platform-native guild/server id.
+  for (const entry of surfaces.web ?? []) {
+    const demuxKey = `web:${entry.binding.instanceId}`;
+    if (web.has(demuxKey)) {
+      throw new Error(
+        `gateway binding-resolver: ambiguous web config — two bindings share instanceId "${entry.binding.instanceId}". ` +
+          `Each (platform, instanceId) pair must map to exactly one binding. ` +
+          `Fix the surfaces.yaml web bindings to remove the duplicate.`,
+      );
+    }
+    const { principal, stack } = parseStack(entry.stack);
+    web.set(demuxKey, {
+      agent: entry.agent,
+      principal,
+      stack,
+      instance: demuxKey,
+    });
+  }
+
+  return { discord, slack, web, mattermostSingle, mattermostMulti };
 }
 
 // =============================================================================
@@ -526,6 +554,14 @@ export function resolveBinding(
       return null;
     }
     return matchFrom("mattermost", index.mattermostSingle);
+  }
+
+  if (platform === "web") {
+    // Web demuxes by the adapter instanceId stamped on the InboundMessage
+    // (`web:${binding.instanceId}`) — no platform-native guild/server id.
+    const entry = index.web.get(inbound.instanceId);
+    if (!entry) return null;
+    return matchFrom("web", entry);
   }
 
   // Unknown platform — no bindings.

--- a/src/gateway/gateway-bootstrap.ts
+++ b/src/gateway/gateway-bootstrap.ts
@@ -169,7 +169,8 @@ function countBindings(surfaces: Surfaces): number {
   return (
     (surfaces.discord?.length ?? 0) +
     (surfaces.slack?.length ?? 0) +
-    (surfaces.mattermost?.length ?? 0)
+    (surfaces.mattermost?.length ?? 0) +
+    (surfaces.web?.length ?? 0)
   );
 }
 

--- a/src/gateway/surface-ownership-plan.ts
+++ b/src/gateway/surface-ownership-plan.ts
@@ -52,7 +52,8 @@ function countSurfaceBindings(surfaces: Surfaces | undefined): number {
   return (
     (surfaces.discord?.length ?? 0) +
     (surfaces.slack?.length ?? 0) +
-    (surfaces.mattermost?.length ?? 0)
+    (surfaces.mattermost?.length ?? 0) +
+    (surfaces.web?.length ?? 0)
   );
 }
 
@@ -62,6 +63,7 @@ function ownedKeys(surfaces: Surfaces | undefined): Set<string> {
   for (const entry of surfaces.discord ?? []) keys.add(`discord:${entry.agent}`);
   for (const entry of surfaces.slack ?? []) keys.add(`slack:${entry.agent}`);
   for (const entry of surfaces.mattermost ?? []) keys.add(`mattermost:${entry.agent}`);
+  for (const entry of surfaces.web ?? []) keys.add(`web:${entry.agent}`);
   return keys;
 }
 
@@ -76,6 +78,9 @@ function gatewayInstanceIds(surfaces: Surfaces | undefined): string[] {
   }
   for (const entry of surfaces.mattermost ?? []) {
     ids.push(`mattermost:${entry.binding.apiUrl}`);
+  }
+  for (const entry of surfaces.web ?? []) {
+    ids.push(`web:${entry.binding.instanceId}`);
   }
   return ids;
 }


### PR DESCRIPTION
## Summary

WEB-1 (C-110, `feat(web): #1313`) shipped the `WebAdapter` but never taught the gateway's binding-presence guards or inbound router about the `web` platform. A web-only stack was invisible to the gateway at two points:

1. **`countBindings` / `countSurfaceBindings` excluded `surfaces.web`** — the gateway saw "0 bindings" and never started.
2. **`buildBindingIndex` had no `web` bucket** — even when the gateway was forced on, inbound web messages had no matching case in `resolveBinding` and were dropped as "unroutable".

## What changed

- `binding-resolver.ts`: adds `web: Map<string, IndexEntry>` to `GatewayBindingIndex`; adds `web` loop in `buildBindingIndex` (demux key `web:${binding.instanceId}`, duplicate-throws, same guard as discord/slack); adds `web` case in `resolveBinding` (matches `inbound.instanceId` verbatim — the full `web:${id}` key the WebAdapter stamps); includes `surfaces.web` in `distinctBoundStacks`, `distinctBoundPrincipalStacks`, and `crossPrincipalBindings`.
- `gateway-bootstrap.ts`: includes `surfaces.web` in `countBindings`.
- `surface-ownership-plan.ts`: includes `surfaces.web` in `countSurfaceBindings`, `ownedKeys`, and `gatewayInstanceIds`.

## Tests

19 new test cases across the three gateway test files:
- **`binding-resolver.test.ts`**: `buildBindingIndex` builds the `web` map; duplicate instanceId throws; `resolveBinding` matches `{platform:"web", instanceId:"web:amt"}`; `distinctBoundStacks` and `crossPrincipalBindings` cover web bindings.
- **`gateway-bootstrap.test.ts`**: `maybeCreateSurfaceGateway` returns a `SurfaceGateway` instance (not undefined) for web-only surfaces; no "no bindings" warning logged.
- **`surface-ownership-plan.test.ts`**: `hasSurfaceBindings`, `ownedSurfaceKeys`, `gatewayAdapterInstanceIds`, and `outboundStacks` all include the web binding.

## Gates

- `bun test src/gateway` — **172 pass, 0 fail** (was 153 before these tests)
- `bunx tsc --noEmit` — clean in gateway files (pre-existing `libsodium-wrappers` errors unrelated to this change)
- `bun run lint:errors` — no gateway errors

## Live verification

With this fix in place, a web-surface stack that was previously reported as having "0 bindings" (gateway refused to start) now routes correctly through the gateway inbound path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)