### PR TITLE
fix(install): from-source `bun link` yields a working `cortex` command (#1329)

### DIFF
--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -63,16 +63,24 @@ stack config — which doesn't exist until §3.1 scaffolds it. On a fresh machin
 install (this section) → configure (§3) → re-run `arc upgrade Cortex` (or
 provision manually per §3.3) so the seed lands at the declared path.
 
-**Path B — from source:**
+**Path B — from source** (for contributors / the fork-and-PR workflow; Path A is
+the managed path for normal operation):
 
 ```bash
 git clone https://github.com/the-metafactory/cortex
 cd cortex
 bun install
+bun link          # puts `cortex` on PATH via ~/.bun/bin
+cortex --version  # confirm it resolves
 ```
 
-Run the daemon directly with `bun src/cortex.ts start --config <pointer>` or
-via an installed `cortex` binary. Verify with `bun test` and `bun run lint`.
+Run the daemon with `cortex start --config <pointer>` (or directly with
+`bun src/cortex.ts start --config <pointer>`). Verify with `bun test` and
+`bun run lint`.
+
+**Updating a from-source clone:** `cd cortex && git pull && bun install` — a clean
+fast-forward if you haven't modified anything. For an arc-managed install, update
+with `arc upgrade Cortex` instead (Path A).
 
 ## 3. Configure a stack
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@the-metafactory/cortex",
   "module": "index.ts",
   "type": "module",
+  "bin": {
+    "cortex": "./src/cortex.ts"
+  },
   "license": "AGPL-3.0-only",
   "private": true,
   "exports": {


### PR DESCRIPTION
Closes #1329.

cortex's `package.json` had no `bin` field, so `bun link` on a from-source clone registered the package globally but created **no `~/.bun/bin/cortex` executable** — `cortex --version` failed with `command not found`. arc's install never hit this because arc puts the binary on PATH itself (independent of `package.json` bin); the gap is specific to the **from-source / fork-and-PR path** (Path B).

**Fix:**
- `package.json` — add `bin: { "cortex": "./src/cortex.ts" }` (mirrors arc; the entrypoint already has the `#!/usr/bin/env bun` shebang + a `--version` handler).
- `README-AGENTS.md` Path B — document the `bun link` step, make explicit that **arc (Path A) is the managed path** for normal operation, and add how to **update** a from-source clone (`git pull`).

**Verified:** clean clone → `bun install` → `bun link` → `cortex --version` → `5.30.2` (then unlinked, no lingering global symlink).

Reported by @vpzed during a Debian-13 from-source install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)