### PR TITLE
docs: clarify local vs federated — it's the agent network, not your Discord server

### DIFF
--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -21,6 +21,8 @@ cortex runs in layers — start at the bottom; each higher layer is **additive a
 
 **Local is the starting point** — get a local stack running first; federation is a later, opt-in step.
 
+> **This is about your *agent network* (the bus), not your chat surface.** Discord — a private server or a shared one — is just how you talk to your *own* assistant, and that choice is independent of the mode. **Local** = your stack stands alone (your agents, your bus, your machine; nobody else's stack involved). **Federated** = your bus links to a **specific trusted peer's**, so your agents and theirs can exchange work across the boundary — you choose exactly who you peer with; it is *not* an open or public group. (A public, open-to-anyone mode is not supported yet.)
+
 ---
 
 ## 1. Prerequisites


### PR DESCRIPTION
Surfaced by @vpzed: he read **federated** as "joining a public Discord server" and **local** as "a private Discord server." The mode table said "your bus" vs "a peer" but never debunked the Discord conflation.

Adds a note to the README-AGENTS mode section: the local/federated axis is about whether your **stack** connects to another principal's stack (the **bus**), and is **orthogonal to your Discord surface** (private or shared, either mode). Local = stands alone; federated = links to a specific trusted peer; public/open-to-anyone isn't a mode yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)