### PR TITLE
fix(cli): neutral default agent id ('assistant'), not the personal 'luna' (#1338)

### DIFF
--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -216,7 +216,7 @@ describe("create dry-run (default)", () => {
     expect(res.stdout).toContain("system/system.yaml");
     expect(res.stdout).toContain("stacks/demo.yaml");
     expect(res.stdout).toContain("demo.yaml");
-    expect(res.stdout).toContain("personas/luna.md");
+    expect(res.stdout).toContain("personas/assistant.md");
     // NOTHING was written.
     expect(existsSync(join(cfg, "demo"))).toBe(false);
   });
@@ -243,14 +243,14 @@ describe("create --apply", () => {
     expect(existsSync(join(dir, "system", "system.yaml"))).toBe(true);
     expect(existsSync(join(dir, "stacks", "demo.yaml"))).toBe(true);
     expect(existsSync(join(dir, "demo.yaml"))).toBe(true);
-    expect(existsSync(join(dir, "personas", "luna.md"))).toBe(true);
+    expect(existsSync(join(dir, "personas", "assistant.md"))).toBe(true);
 
     // dir basename == slug == trailing segment of stack.id (the #808 invariant).
     const stackYaml = readFileSync(join(dir, "stacks", "demo.yaml"), "utf-8");
     expect(stackYaml).toContain("id: andreas/demo");
     expect(stackYaml).toContain("nkey_seed_path: ~/.config/nats/cortex-demo.nk");
-    // The chosen agent id is luna by default.
-    expect(stackYaml).toContain("luna");
+    // The chosen agent id is the neutral 'assistant' by default (#1338).
+    expect(stackYaml).toContain("assistant");
   });
 
   test("honours --agent + --display-name", async () => {

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -120,7 +120,7 @@ describe("renderScaffold", () => {
     slug: "demo",
     principal: "andreas",
     stackId: "andreas/demo",
-    agentId: "luna",
+    agentId: "assistant",
     displayName: "Demo",
     seedPath: "~/.config/nats/cortex-demo.nk",
   };
@@ -129,7 +129,7 @@ describe("renderScaffold", () => {
     const files = renderScaffold(inputs);
     const rels = files.map((f) => f.relPath).sort();
     expect(rels).toEqual(
-      ["demo.yaml", "personas/luna.md", "stacks/demo.yaml", "surfaces/surfaces.yaml", "system/system.yaml"].sort(),
+      ["demo.yaml", "personas/assistant.md", "stacks/demo.yaml", "surfaces/surfaces.yaml", "system/system.yaml"].sort(),
     );
   });
 
@@ -138,7 +138,7 @@ describe("renderScaffold", () => {
     const stack = files.find((f) => f.relPath === "stacks/demo.yaml");
     expect(stack?.contents).toContain("id: andreas/demo");
     expect(stack?.contents).toContain("nkey_seed_path: ~/.config/nats/cortex-demo.nk");
-    expect(stack?.contents).toContain("luna");
+    expect(stack?.contents).toContain("assistant");
   });
 
   test("system/system.yaml seeds the bus/bot credsPath (~/.config/nats/<slug>-bot.creds), distinct from the federation default", () => {

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -69,8 +69,8 @@ const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 
 /** Default config dir (same canonical path the daemon + network CLI use). */
 const DEFAULT_CONFIG_DIR = "~/.config/cortex";
-/** Default agent id for the scaffolded stack. */
-const DEFAULT_AGENT_ID = "luna";
+/** Default agent id for the scaffolded stack — neutral placeholder, not a personal persona name (#1338). */
+const DEFAULT_AGENT_ID = "assistant";
 
 const SPEC: SubcommandSpec<StackSubcommand> = {
   cliName: "stack",
@@ -512,7 +512,7 @@ Flags (create):
                         the single existing principal under --config-dir; if
                         zero or 2+ principals are present, it is REQUIRED.
   --display-name <name> The agent's display name (default: capitalized agent id).
-  --agent <id>          The agent id on the scaffolded stack (default: luna).
+  --agent <id>          The agent id on the scaffolded stack (default: assistant).
   --config-dir <path>   Config dir to create the stack under (default:
                         ~/.config/cortex). The stack lands at <config-dir>/<slug>/.
   --apply               Write the files (default: dry-run).


### PR DESCRIPTION
Closes #1338.

`cortex stack create` hardcoded `DEFAULT_AGENT_ID = "luna"`, so a brand-new user (no `--agent`) scaffolded `agent: luna`, `personas/luna.md`, and displayName `Luna` — a **personal persona name** on the community stack — leaking into what should be a generic template. @vpzed hit this running `cortex stack create gir --principal vpzed` and asked whether personal stuff had gotten into the repo.

**Fix:** default is now the neutral `assistant` (`--agent` still overrides). Updates the help text + the two tests that asserted the old default. 971 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)