### PR TITLE
chore: bump to v6.0.0 (major — breaking package rename #1337)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.30.2"
+version: "6.0.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Major bump per the versioning SOP — the `Cortex → cortex` arc package rename (#1337) is breaking for existing installs (one-time `arc uninstall Cortex && arc install cortex`). Cuts the v6.0.0 release that makes the rename + the accumulated onboarding polish live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)