### PR TITLE
fix(registry): dev env routes TOML placement — dev worker deployed with no triggers

### DIFF
--- a/src/services/network-registry/wrangler.toml
+++ b/src/services/network-registry/wrangler.toml
@@ -68,6 +68,18 @@ migrations_dir = "migrations"
 name = "cortex-network-registry-dev"
 workers_dev = false
 
+# Dev route. The principal must create the proxied DNS record for
+# network-dev.meta-factory.ai in the meta-factory.ai zone, then
+# `wrangler deploy --env dev`. Same-zone TLS + CF Access still apply.
+# Additional TLDs (.dev/.io) can be added analogously if multi-TLD is wanted.
+# NOTE: `routes` must sit ABOVE the [[env.dev.d1_databases]] table-array —
+# TOML scopes any key that follows a table-array header to that array
+# element, so a misplaced `routes` deploys the dev worker with NO triggers
+# (wrangler: 'Unexpected fields found in env.dev.d1_databases[0]: "routes"').
+routes = [
+  { pattern = "network-dev.meta-factory.ai/*", zone_name = "meta-factory.ai" }
+]
+
 # #682 — dev D1 (cortex-network-registry-dev). Same `binding = "DB"` as
 # prod; only the database differs.
 [[env.dev.d1_databases]]
@@ -75,14 +87,6 @@ binding = "DB"
 database_name = "cortex-network-registry-dev"
 database_id = "19925196-a7ba-4fe0-85fa-4c8181a96bba"
 migrations_dir = "migrations"
-
-# Dev route. The principal must create the proxied DNS record for
-# network-dev.meta-factory.ai in the meta-factory.ai zone, then
-# `wrangler deploy --env dev`. Same-zone TLS + CF Access still apply.
-# Additional TLDs (.dev/.io) can be added analogously if multi-TLD is wanted.
-routes = [
-  { pattern = "network-dev.meta-factory.ai/*", zone_name = "meta-factory.ai" }
-]
 
 [env.dev.vars]
 ENVIRONMENT = "development"


### PR DESCRIPTION
## What

Moves `routes = [...]` in `src/services/network-registry/wrangler.toml` from below `[[env.dev.d1_databases]]` to directly under `[env.dev]`, and documents the TOML ordering constraint.

## Why

TOML scopes any key that follows a table-array header to that array element. The dev route was therefore parsed as a field of the D1 binding, wrangler warned `Unexpected fields found in env.dev.d1_databases[0]: "routes"`, and `wrangler deploy --env dev` reported **No deploy targets** — the dev worker shipped with no triggers. The `network-dev.meta-factory.ai` host only kept serving because an earlier route binding survives on the zone; if that route were ever dropped, deploys would silently not re-create it.

Found live during the #1347 Stage-1 go-live deploy (dev+prod D1 migration 0011 + worker deploys — see #1347 for the full evidence trail).

## Verification

- Before: `wrangler deploy --env dev` → warning + "No deploy targets"
- After: `wrangler deploy --env dev --dry-run` → clean parse, no warning
- Post-merge step: `bunx wrangler deploy --env dev` from main to bind triggers via the config (idempotent against the surviving zone route)

Part of epic #1346 (Phase 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB