### PR TITLE
test: C-1355 — E2E lifecycle integration guard (register→admit→seal→join→revoke→leave)

### DIFF
--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/README.md
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/README.md
@@ -1,0 +1,114 @@
+# E2E admission lifecycle guard (C-1355)
+
+A scripted **register → admit → seal → join → revoke → leave** walkthrough that
+drives the REAL CLI code paths against a **local in-process registry** and
+**temp-dir config trees** — no Cloudflare, no D1, no NATS server, no network I/O.
+
+Every mid-funnel breakage in the admission epic (#832, #1262, #1220, #1316,
+#1317) was found by a HUMAN walking the SOP, usually an external first-time
+principal. Nothing in CI exercised the lifecycle **as a sequence**, so each fix
+could regress silently. This suite is that guard, and the epic's **progress
+meter**: steps gated on unmerged sub-issues are `test.todo(...)` named with their
+issue number; each fix PR flips its todo to live.
+
+## Files
+
+| File | What it is |
+|------|------------|
+| `lifecycle.test.ts` | The scripted walkthrough (steps 1–9), driven as an ordered, shared-state sequence. |
+| `harness.ts` | In-process registry + `globalThis.fetch` router, temp-dir helpers, the recording hub-reload stub, and the `leaveNetwork` ports builder (daemon-restart stub). |
+| `README.md` | This file. |
+
+## How to run
+
+```bash
+# scoped (dev)
+bun test src/cli/cortex/commands/__tests__/e2e-lifecycle/
+
+# the full suite runs it too (CI)
+bun test src/
+```
+
+Type-check: `bunx tsc --noEmit` (clean).
+
+## What is REAL vs STUBBED
+
+| Concern | Treatment |
+|---|---|
+| Network registry (`src/services/network-registry`) | **REAL** — the Hono `app` + in-memory store, driven via a `globalThis.fetch` router that forwards `http://127.0.0.1:18771/*` into `app.fetch(req, env)`. Any fetch to a non-registry URL **throws** (the suite must never touch the network). |
+| `stack create` / `network create` / `provision-stack register` / `network admit` | **REAL** — the exported dispatch functions (`dispatchStack`/`dispatchNetwork`/`dispatchProvisionStack`), same argv the binary runs. |
+| `network secret add-member / revoke-member` | **REAL** `runNetworkSecret` orchestrator + real Ed25519 seeds + real `crypto_box` seal + real registry delivery/admission ports. |
+| `network leave` | **REAL** `leaveNetwork` orchestrator over an in-memory `ConfigStorePort`. |
+| Boot config validator (`#1220`) | **REAL** — `CortexConfigSchema` (the same full validation the daemon runs at boot) applied to the join derivation's output. |
+| **Hub reload** (`network-secret-adapters.ts:87-107`) | **STUBBED** — `makeRecordingHubPort` keeps the hub config in memory and counts reloads instead of SIGHUP-ing a live nats-server. This is the seam **#1317** will make target the real multi-nats hub. |
+| **Daemon restart** (`DaemonPort.restart`) | **STUBBED** — the `leaveNetwork` ports builder records restart requests instead of `launchctl kickstart`. |
+| Real NATS server / Cloudflare / D1 / any network I/O | **NEVER**. |
+
+### Authority collapse (Q5)
+
+The guard uses ONE admin identity for the network-admin, hub-admin, and
+registry-admin roles (the Q5 "one principal is both authorities" collapse). The
+registry's hub-admin write gate falls back to `REGISTRY_ADMIN_PUBKEYS` when
+`REGISTRY_HUB_ADMIN_PUBKEYS` is unset, so a single seed drives create + admit +
+seal + revoke. A fully-separable deployment (distinct network-admin vs hub-admin)
+is a separate concern already unit-tested at the registry layer.
+
+## The two regression anchors (HARD assertions)
+
+- **#1262** — a registered principal MUST leave a **PENDING admission row**. The
+  bug was a registered principal with **no** row (the register hook swallowed the
+  upsert failure), so the admin saw nothing to admit. Pinned in **step 3**:
+  after `provision-stack register --network testnet`, the in-memory issuance
+  store has exactly one PENDING row for the member.
+- **#1220** — `network join` wrote a **peer-scoped** `accept_subjects` entry
+  (`federated.andreas.meta-factory.agent.>`) into `jc/default`, which the boot
+  config validator rejects (accept_subjects must begin with the receiving stack's
+  OWN `federated.{me}.{stack}.` scope), failing daemon boot. Pinned in **step 6**:
+  the join derivation's peer subtree is fed through the REAL `CortexConfigSchema`
+  and asserted to be rejected with an `accept_subjects` error, while the own-only
+  (zero-peer) derivation is asserted to PASS.
+
+## Step ↔ status map
+
+| Step | Coverage | Status |
+|---|---|---|
+| 1. Stand up (stack create ×2) | born-aligned, no drift | **LIVE** |
+| 2. Network create | NetworkRecord row incl. `admin_pubkeys` | **LIVE** |
+| 3. Register | PENDING admission row EXISTS (**#1262**) | **LIVE** |
+| 3b. Register output surfaces request-id | `#1315` | `test.todo` |
+| 4. Admit | row ADMITTED | **LIVE** |
+| 4a. `admit --list-pending` | `#1314` | `test.todo` |
+| 4b. `network reject` verb | `#1348` | `test.todo` |
+| 5. Seal (`secret add-member`, hub stubbed) | sealed blob on the row | **LIVE** |
+| 5a. `admit --and-seal` fold | `#1316` | `test.todo` |
+| 6. Join accept_subjects vs boot validator (**#1220**) | own-only PASS + peer REJECTED | **LIVE** |
+| 6b. Full join output passes config load (post-fix) | `#1220` fix | `test.todo` |
+| 7. Revoke (`secret revoke-member`) | REVOKED + blob cleared + hub user dropped | **LIVE** |
+| 8. Leave (`leaveNetwork`, daemon stubbed) | config cleaned + leaf torn down + daemon restarted | **LIVE** |
+| 9a. Idempotence — re-run leave | clean no-op (not-joined) | **LIVE** |
+| 9b. Idempotence — re-run revoke | clean no-op (nothing to revoke) | **LIVE** |
+
+## How to flip a `test.todo` to live
+
+1. Land the sibling fix (e.g. `#1314` adds `network admit --list-pending`).
+2. In `lifecycle.test.ts`, find the `todo("step … (#NNNN): …")` line for that
+   issue and replace it with a real `test("…", async () => { … })` that drives
+   the new verb and asserts against the in-process registry store (the harness
+   already exposes `getStore` / `getIssuanceStore` on `ctx.env`).
+3. For **#1220** specifically: once the join **writer** emits only own-scoped
+   subjects, flip step 6b to live (the full join output — own ∪ peers — passes
+   `CortexConfigSchema`) and update the step-6 HARD assertion, which currently
+   documents the *pre-fix* rejection.
+
+## Notes for a reviewer
+
+- The suite is an **ordered, shared-state** walkthrough (a break mid-funnel
+  fails loudly and cascades — that is the intent of a lifecycle guard, not a
+  smell). `ctx` threads the request-id, secret ports, and leave handle across
+  steps.
+- `test.todo("name")` is the correct single-arg runtime form (bun reports these
+  as todo); the `todo` cast near the top of `lifecycle.test.ts` only exists to
+  keep `tsc --noEmit` happy with the bundled bun-types signature.
+- `LIVE_NATS=1` real-server variant (spawning nats-servers to exercise the hub
+  reload + daemon restart for real) is intentionally **out of scope** here and a
+  future opt-in — do not block on it.

--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/harness.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/harness.ts
@@ -18,25 +18,19 @@
  *   - temp-dir config trees (pattern: PR #1343 stack-signing-boot isolation).
  *
  * The registry's module-scoped singletons (store, nonce cache, derived pubkey,
- * rate-limit buckets) are reset between runs via {@link resetRegistry} — the same
- * discipline `src/services/network-registry/__tests__/helpers.ts` uses.
+ * rate-limit buckets) are reset between runs via {@link resetRegistry}, which
+ * delegates to the registry's own exported `resetStores()`
+ * (`src/services/network-registry/__tests__/helpers.ts`) — the single source of
+ * truth for that reset list.
  */
 
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import app, {
-  type Env,
-  _resetDerivedPublicKeyForTest,
-} from "../../../../../services/network-registry/src/index";
+import app, { type Env } from "../../../../../services/network-registry/src/index";
 import { generateKeypair } from "../../../../../services/network-registry/src/signing";
-import {
-  _setStoreForTest,
-  _setIssuanceStoreForTest,
-  _setNonceCacheForTest,
-} from "../../../../../services/network-registry/src/store";
-import { _resetRateLimitBucketsForTest } from "../../../../../services/network-registry/src/rate-limit";
+import { resetStores } from "../../../../../services/network-registry/__tests__/helpers";
 import type { HubAuthPort } from "../../network-secret-ports";
 import type {
   NetworkPorts,
@@ -60,14 +54,14 @@ export const REGISTRY_BASE = "http://127.0.0.1:18771";
 
 /**
  * Reset EVERY module-scoped registry singleton so a run starts from a clean
- * store. Mirrors `resetStores()` in the registry's own test helpers.
+ * store. Delegates to the registry's own exported `resetStores()` instead of
+ * re-listing the `_set*` / `_reset*` hooks here, so a newly-added registry
+ * singleton is picked up automatically rather than silently drifting out of a
+ * hand-maintained copy (which would leak state between runs in the exact suite
+ * meant to catch regressions).
  */
 export function resetRegistry(): void {
-  _setStoreForTest(undefined);
-  _setIssuanceStoreForTest(undefined);
-  _setNonceCacheForTest(undefined);
-  _resetDerivedPublicKeyForTest();
-  _resetRateLimitBucketsForTest();
+  resetStores();
 }
 
 /**

--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/harness.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/harness.ts
@@ -1,0 +1,251 @@
+/**
+ * C-1355 — E2E lifecycle integration guard: shared harness.
+ *
+ * Everything the scripted walkthrough needs to run FULLY IN-PROCESS:
+ *
+ *   - a LOCAL in-process network-registry (the real Hono `app` from
+ *     `src/services/network-registry/src/index.ts` with the in-memory store —
+ *     NO Cloudflare, NO D1, NO network I/O);
+ *   - a `globalThis.fetch` router that forwards every request aimed at the
+ *     registry base URL into `app.fetch(req, env)` so the REAL CLI code paths
+ *     (`dispatchNetwork` / `dispatchProvisionStack` → `globalThis.fetch`) hit
+ *     the in-process registry instead of the wire. Any fetch to a NON-registry
+ *     URL throws — the suite must never touch the network;
+ *   - a recording HUB-reload port that stands in for the multi-nats hub reload
+ *     (`network-secret-adapters.ts:87-107`, the seam #1317 owns). It captures the
+ *     hub config in memory and counts reloads instead of SIGHUP-ing a live
+ *     nats-server;
+ *   - temp-dir config trees (pattern: PR #1343 stack-signing-boot isolation).
+ *
+ * The registry's module-scoped singletons (store, nonce cache, derived pubkey,
+ * rate-limit buckets) are reset between runs via {@link resetRegistry} — the same
+ * discipline `src/services/network-registry/__tests__/helpers.ts` uses.
+ */
+
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import app, {
+  type Env,
+  _resetDerivedPublicKeyForTest,
+} from "../../../../../services/network-registry/src/index";
+import { generateKeypair } from "../../../../../services/network-registry/src/signing";
+import {
+  _setStoreForTest,
+  _setIssuanceStoreForTest,
+  _setNonceCacheForTest,
+} from "../../../../../services/network-registry/src/store";
+import { _resetRateLimitBucketsForTest } from "../../../../../services/network-registry/src/rate-limit";
+import type { HubAuthPort } from "../../network-secret-ports";
+import type {
+  NetworkPorts,
+  ConfigStorePort,
+  DaemonPort,
+  NetworkRegistryPort,
+  LeafFilePort,
+  PlistPort,
+} from "../../network-ports";
+import type { PolicyFederatedNetwork } from "../../../../../common/types/cortex-config";
+
+export type { Env };
+
+/** The in-process registry base URL. Host is irrelevant (the app routes on the
+ * path only); a loopback high port keeps it visibly "local" + un-routable. */
+export const REGISTRY_BASE = "http://127.0.0.1:18771";
+
+// ---------------------------------------------------------------------------
+// Registry lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset EVERY module-scoped registry singleton so a run starts from a clean
+ * store. Mirrors `resetStores()` in the registry's own test helpers.
+ */
+export function resetRegistry(): void {
+  _setStoreForTest(undefined);
+  _setIssuanceStoreForTest(undefined);
+  _setNonceCacheForTest(undefined);
+  _resetDerivedPublicKeyForTest();
+  _resetRateLimitBucketsForTest();
+}
+
+/**
+ * Build a fresh registry `Env`. `adminPubkeys` seeds `REGISTRY_ADMIN_PUBKEYS`
+ * (the network-create + admit + admin-read allowlist). The hub-admin write gate
+ * (sealed-secret / revoke) FALLS BACK to `REGISTRY_ADMIN_PUBKEYS` when
+ * `REGISTRY_HUB_ADMIN_PUBKEYS` is unset (the Q5 "one principal is both
+ * authorities" collapse — see `admission-requests.ts` `parseHubAdminPubkeys`),
+ * so a single admin identity drives create + admit + seal + revoke in this guard.
+ */
+export async function makeRegistryEnv(adminPubkeys: string[]): Promise<Env> {
+  const reg = await generateKeypair();
+  return {
+    REGISTRY_SIGNING_KEY: reg.privateKeyB64,
+    REGISTRY_PUBLIC_KEY: reg.publicKeyB64,
+    REGISTRY_ADMIN_PUBKEYS: adminPubkeys.join(","),
+    ENVIRONMENT: "test",
+  };
+}
+
+/**
+ * Route `globalThis.fetch` into the in-process registry `app` for any request
+ * whose URL starts with {@link REGISTRY_BASE}; throw on anything else. Returns a
+ * restore function — call it in `afterAll`/`afterEach`.
+ */
+export function installRegistryFetchRouter(env: Env): () => void {
+  const real = globalThis.fetch;
+  const routed = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = urlOf(input);
+    if (url.startsWith(REGISTRY_BASE)) {
+      const req = input instanceof Request ? input : new Request(url, init);
+      return app.fetch(req, env);
+    }
+    throw new Error(
+      `e2e-lifecycle: blocked an external fetch to ${url} — the lifecycle guard must stay ` +
+        `fully in-process (registry base ${REGISTRY_BASE}). No network I/O is permitted.`,
+    );
+  }) as typeof globalThis.fetch;
+  globalThis.fetch = routed;
+  return () => {
+    globalThis.fetch = real;
+  };
+}
+
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+// ---------------------------------------------------------------------------
+// Recording HUB-reload port (the STUB seam — network-secret-adapters.ts:87-107)
+// ---------------------------------------------------------------------------
+
+/** A `HubAuthPort` that keeps the hub config in memory and COUNTS reloads
+ * instead of SIGHUP-ing a live nats-server. This is the exact port #1317 will
+ * make target the real multi-nats hub; here we assert it is EXERCISED. */
+export interface RecordingHubPort extends HubAuthPort {
+  /** How many times `reload()` was invoked. */
+  reloads: number;
+  /** Every text written via `writeConf`, in order. */
+  writes: string[];
+  /** The current in-memory hub config. */
+  conf: string;
+}
+
+export function makeRecordingHubPort(initialConf = ""): RecordingHubPort {
+  const port: RecordingHubPort = {
+    // A path string for plan/report output only — never read/written on disk.
+    confPath: "<stubbed hub nats-server config — in-memory, not a real file>",
+    reloads: 0,
+    writes: [],
+    conf: initialConf,
+    readConf(): Promise<string> {
+      return Promise.resolve(port.conf);
+    },
+    writeConf(text: string): Promise<void> {
+      port.conf = text;
+      port.writes.push(text);
+      return Promise.resolve();
+    },
+    reload(): Promise<void> {
+      port.reloads += 1;
+      return Promise.resolve();
+    },
+  };
+  return port;
+}
+
+// ---------------------------------------------------------------------------
+// Temp-dir management
+// ---------------------------------------------------------------------------
+
+const tmpDirs: string[] = [];
+
+/** Make a fresh temp dir tracked for teardown. */
+export function freshDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+
+/** Remove every tracked temp dir. Call in `afterAll`. */
+export function cleanupDirs(): void {
+  while (tmpDirs.length > 0) {
+    rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// leaveNetwork ports — the DAEMON-RESTART stub + an in-memory config store.
+// ---------------------------------------------------------------------------
+
+/** What a driven `leaveNetwork(...)` did, for assertions. */
+export interface LeavePortsHandle {
+  ports: NetworkPorts;
+  /** Live daemon-restart count (the stubbed launchctl kickstart). */
+  counters: { restarts: number };
+  /** Each `configStore.writeNetworks(...)` payload, in order. */
+  writes: PolicyFederatedNetwork[][];
+  /** Network ids whose `include` directive + leaf file were removed. */
+  removedIncludes: string[];
+  removedFiles: string[];
+  /** The live in-memory `policy.federated.networks[]`. */
+  current: () => PolicyFederatedNetwork[];
+}
+
+/**
+ * Build a `NetworkPorts` bundle for driving the REAL `leaveNetwork` orchestrator
+ * with an in-memory config store + a STUBBED daemon restart (the seam the issue
+ * calls out — no launchctl, no nats-server). Only the ports `leaveNetwork`
+ * actually touches are real; the join-only surface (bind-mode, operator-mode
+ * conversion, nats-server restart) is a typed no-op — leave never calls it.
+ */
+export function makeLeaveNetworkPorts(initial: PolicyFederatedNetwork[]): LeavePortsHandle {
+  let networks = [...initial];
+  const counters = { restarts: 0 };
+  const writes: PolicyFederatedNetwork[][] = [];
+  const removedIncludes: string[] = [];
+  const removedFiles: string[] = [];
+
+  const configStore: ConfigStorePort = {
+    readNetworks: () => [...networks],
+    writeNetworks: (next) => {
+      networks = [...next];
+      writes.push([...next]);
+    },
+  };
+  const daemon: DaemonPort = {
+    restart: () => {
+      counters.restarts += 1;
+      return Promise.resolve({ ok: true as const });
+    },
+  };
+  // Only `deregisterFromNetwork` is called by leave; the join-side registry
+  // methods are never reached, so a partial + cast keeps the fake small.
+  const registry = {
+    deregisterFromNetwork: () => Promise.resolve({ ok: true as const, note: "test no-op" }),
+  } as unknown as NetworkRegistryPort;
+  // Leave calls only removeInclude / remove / list.
+  const leafFile = {
+    removeInclude: (id: string) => {
+      removedIncludes.push(id);
+    },
+    remove: (id: string) => {
+      removedFiles.push(id);
+    },
+    list: (): string[] => [],
+  } as unknown as LeafFilePort;
+  const plist = {} as unknown as PlistPort;
+
+  const ports: NetworkPorts = { registry, leafFile, plist, configStore, daemon };
+  return {
+    ports,
+    counters,
+    writes,
+    removedIncludes,
+    removedFiles,
+    current: () => [...networks],
+  };
+}

--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
@@ -225,9 +225,12 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
 
   // ===========================================================================
   // Step 3 — Register: the #1262 regression anchor.
-  //   A registered principal MUST leave a PENDING admission row. The #1262 bug
-  //   was a registered principal with NO row (the register hook swallowed the
-  //   upsert failure), so the admin saw nothing to admit.
+  //   A registered principal MUST leave a PENDING admission row. In #1262 a
+  //   principal landed in the registry with NO PENDING row, so the admin saw
+  //   nothing to admit; the issue flags register + raise-admission-request as
+  //   separate steps and leaves the exact cause open (asking whether
+  //   `register --network` is meant to auto-raise). This guard pins the intended
+  //   outcome — register --network yields exactly one PENDING row.
   // ===========================================================================
   test("step 3: register joiner --network testnet → PENDING admission row EXISTS (#1262)", async () => {
     const res = await dispatchProvisionStack([

--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
@@ -1,0 +1,528 @@
+/**
+ * C-1355 — E2E lifecycle integration guard.
+ *
+ * A scripted register → admit → seal → join → revoke → leave walkthrough driven
+ * against a LOCAL in-process registry (`src/services/network-registry`) and
+ * temp-dir config trees. Every mid-funnel breakage in the admission epic (#832,
+ * #1262, #1220, #1316, #1317) was found by a HUMAN walking the SOP; nothing in CI
+ * exercised the lifecycle AS A SEQUENCE. This suite is that guard, and the epic's
+ * progress meter: steps gated on unmerged sub-issues are `todo(...)` named
+ * with their issue number; each fix PR flips its todo to live.
+ *
+ * WHAT IS REAL vs STUBBED (see README.md in this dir for the full matrix):
+ *   - REAL:  the registry Hono app + in-memory store; the CLI dispatch paths
+ *            (`dispatchStack` / `dispatchNetwork` / `dispatchProvisionStack`);
+ *            the `runNetworkSecret` orchestrator; real Ed25519 seeds + real
+ *            crypto_box seal; the REAL boot config validator (`CortexConfigSchema`).
+ *   - STUBBED: the hub-reload port (multi-nats SIGHUP — #1317's seam) and the
+ *            daemon-restart (not invoked; the join writer is asserted at the
+ *            derivation→validation seam, per #1220's own ask).
+ *   - NEVER:  a real NATS server, Cloudflare, D1, or any network I/O.
+ *
+ * The two REGRESSION ANCHORS this pins hard:
+ *   - #1262: a registered principal with NO PENDING admission row (silent-drop).
+ *   - #1220: `network join` writing a peer-scoped `accept_subjects` entry that
+ *            the REAL boot config validator rejects.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { dispatchStack } from "../../stack";
+import { discoverStacks } from "../../stack-lib";
+import { dispatchNetwork } from "../../network";
+import { dispatchProvisionStack } from "../../provision-stack";
+import { runNetworkSecret } from "../../network-secret-lib";
+import { buildLiveSecretPorts } from "../../network-secret-adapters";
+import type { NetworkSecretPorts } from "../../network-secret-ports";
+import { leaveNetwork } from "../../network-lib";
+
+import { deriveAcceptSubjects } from "../../../../../bus/agent-network/accept-subjects";
+import {
+  materialFromSeedString,
+  type StackIdentityMaterial,
+} from "../../../../../bus/stack-provisioning";
+import {
+  CortexConfigSchema,
+  PolicyFederatedNetworkSchema,
+} from "../../../../../common/types/cortex-config";
+import { hubLeafUserPresent } from "../../../../../common/nats/hub-leaf-authorization";
+import {
+  getStore,
+  getIssuanceStore,
+} from "../../../../../services/network-registry/src/store";
+
+import {
+  REGISTRY_BASE,
+  type Env,
+  makeRegistryEnv,
+  resetRegistry,
+  installRegistryFetchRouter,
+  makeRecordingHubPort,
+  type RecordingHubPort,
+  makeLeaveNetworkPorts,
+  type LeavePortsHandle,
+  freshDir,
+  cleanupDirs,
+} from "./harness";
+
+// The network + identities the walkthrough operates on.
+const NETWORK_ID = "testnet";
+const ADMIN_PRINCIPAL = "netadmin";
+const JOINER_PRINCIPAL = "joiner";
+const JOINER_STACK_SLUG = "work";
+const JOINER_STACK_ID = `${JOINER_PRINCIPAL}/${JOINER_STACK_SLUG}`;
+
+interface Ctx {
+  env: Env;
+  restoreFetch: () => void;
+  adminSeedPath: string;
+  adminPubkey: string;
+  adminMaterial: StackIdentityMaterial;
+  adminConfigDir: string;
+  joinerConfigDir: string;
+  joinerSeedPath: string;
+  joinerPubkey: string;
+  requestId?: string;
+  hub?: RecordingHubPort;
+  secretPorts?: NetworkSecretPorts;
+  leave?: LeavePortsHandle;
+}
+
+const ctx = {} as Ctx;
+
+/**
+ * bun accepts `todo("name")` at runtime (the suite reports these as todo),
+ * but the bundled bun-types signature wants a body fn, so `tsc --noEmit` flags a
+ * bare label. This cast keeps the correct single-arg runtime form type-clean.
+ */
+const todo = test.todo as unknown as (name: string) => void;
+
+/** Read `pubkey_b64` out of a `provision-stack generate --json` envelope. */
+function pubkeyFromGenerate(stdout: string): string {
+  const data = (JSON.parse(stdout) as { data?: { pubkey_b64?: string } }).data;
+  const pk = data?.pubkey_b64;
+  if (typeof pk !== "string" || pk.length === 0) {
+    throw new Error(`provision-stack generate --json produced no pubkey_b64: ${stdout}`);
+  }
+  return pk;
+}
+
+beforeAll(async () => {
+  resetRegistry();
+
+  // --- Mint the ADMIN identity (network admin + hub admin + registry admin —
+  //     the Q5 authority collapse; one seed drives create + admit + seal + revoke).
+  ctx.adminConfigDir = freshDir("c1355-admin-cfg-");
+  ctx.joinerConfigDir = freshDir("c1355-joiner-cfg-");
+  ctx.adminSeedPath = join(freshDir("c1355-admin-seed-"), "admin.nk");
+  const adminGen = await dispatchProvisionStack([
+    "generate",
+    ADMIN_PRINCIPAL,
+    "--seed-path",
+    ctx.adminSeedPath,
+    "--stack-id",
+    `${ADMIN_PRINCIPAL}/hub`,
+    "--json",
+  ]);
+  expect(adminGen.exitCode).toBe(0);
+  ctx.adminPubkey = pubkeyFromGenerate(adminGen.stdout);
+  ctx.adminMaterial = materialFromSeedString(readFileSync(ctx.adminSeedPath, "utf-8").trim());
+  expect(ctx.adminMaterial.pubkeyB64).toBe(ctx.adminPubkey);
+
+  // --- Registry env, now that we know the admin pubkey, + the fetch router.
+  ctx.env = await makeRegistryEnv([ctx.adminPubkey]);
+  ctx.restoreFetch = installRegistryFetchRouter(ctx.env);
+
+  // --- Mint the JOINER stack identity (the member that registers/joins).
+  ctx.joinerSeedPath = join(freshDir("c1355-joiner-seed-"), "joiner.nk");
+  const joinerGen = await dispatchProvisionStack([
+    "generate",
+    JOINER_PRINCIPAL,
+    "--seed-path",
+    ctx.joinerSeedPath,
+    "--stack-id",
+    JOINER_STACK_ID,
+    "--json",
+  ]);
+  expect(joinerGen.exitCode).toBe(0);
+  ctx.joinerPubkey = pubkeyFromGenerate(joinerGen.stdout);
+});
+
+afterAll(() => {
+  ctx.restoreFetch?.();
+  cleanupDirs();
+  resetRegistry();
+});
+
+describe("C-1355 — E2E admission lifecycle guard", () => {
+  // ===========================================================================
+  // Step 1 — Stand up: two stacks in temp config dirs, born-aligned, no drift.
+  // ===========================================================================
+  test("step 1: stack create (admin-side + joiner-side) → born-aligned, no drift", async () => {
+    const admin = await dispatchStack([
+      "create",
+      "hub",
+      "--principal",
+      ADMIN_PRINCIPAL,
+      "--config-dir",
+      ctx.adminConfigDir,
+      "--apply",
+    ]);
+    expect(admin.exitCode).toBe(0);
+
+    const joiner = await dispatchStack([
+      "create",
+      JOINER_STACK_SLUG,
+      "--principal",
+      JOINER_PRINCIPAL,
+      "--config-dir",
+      ctx.joinerConfigDir,
+      "--apply",
+    ]);
+    expect(joiner.exitCode).toBe(0);
+
+    // Born-aligned: the dir basename == the slug == the stack.id trailing segment,
+    // so `discoverStacks` reports every discovered stack as aligned (no drift).
+    const adminStacks = discoverStacks(ctx.adminConfigDir);
+    const joinerStacks = discoverStacks(ctx.joinerConfigDir);
+    expect(adminStacks.length).toBeGreaterThanOrEqual(1);
+    expect(joinerStacks.length).toBeGreaterThanOrEqual(1);
+    expect(adminStacks.every((s) => s.aligned === true)).toBe(true);
+    expect(joinerStacks.every((s) => s.aligned === true)).toBe(true);
+    expect(joinerStacks.some((s) => s.stackId === JOINER_STACK_ID)).toBe(true);
+  });
+
+  // ===========================================================================
+  // Step 2 — Network: create testnet against the in-process registry.
+  // ===========================================================================
+  test("step 2: network create → NetworkRecord row incl. admin_pubkeys", async () => {
+    const res = await dispatchNetwork([
+      "create",
+      NETWORK_ID,
+      "--hub",
+      "tls://127.0.0.1:17422",
+      "--leaf-port",
+      "17422",
+      "--admin-seed",
+      ctx.adminSeedPath,
+      "--network-admins",
+      ctx.adminPubkey,
+      "--registry-url",
+      REGISTRY_BASE,
+      "--apply",
+    ]);
+    expect(res.exitCode).toBe(0);
+
+    const record = await getStore(ctx.env).getNetwork(NETWORK_ID);
+    expect(record).toBeDefined();
+    expect(record!.hub_url).toBe("tls://127.0.0.1:17422");
+    expect(record!.leaf_port).toBe(17422);
+    // #1321 — the per-network admin allowlist (comma-separated base64 pubkeys).
+    expect(record!.admin_pubkeys ?? "").toContain(ctx.adminPubkey);
+  });
+
+  // ===========================================================================
+  // Step 3 — Register: the #1262 regression anchor.
+  //   A registered principal MUST leave a PENDING admission row. The #1262 bug
+  //   was a registered principal with NO row (the register hook swallowed the
+  //   upsert failure), so the admin saw nothing to admit.
+  // ===========================================================================
+  test("step 3: register joiner --network testnet → PENDING admission row EXISTS (#1262)", async () => {
+    const res = await dispatchProvisionStack([
+      "register",
+      JOINER_PRINCIPAL,
+      "--seed-path",
+      ctx.joinerSeedPath,
+      "--stack-id",
+      JOINER_STACK_ID,
+      "--registry-url",
+      REGISTRY_BASE,
+      "--network",
+      NETWORK_ID,
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+
+    // The principal record landed AND a PENDING admission row was created.
+    const pending = await getIssuanceStore(ctx.env).listIssuanceRequests("PENDING");
+    const mine = pending.filter((r) => r.peer_pubkey === ctx.joinerPubkey);
+    // HARD #1262 ASSERTION: exactly one PENDING row for this member, not zero.
+    expect(mine.length).toBe(1);
+    expect(mine[0]!.status).toBe("PENDING");
+    expect(mine[0]!.network_id).toBe(NETWORK_ID);
+    expect(mine[0]!.principal_id).toBe(JOINER_PRINCIPAL);
+
+    ctx.requestId = mine[0]!.request_id;
+    expect(ctx.requestId).toBeTruthy();
+  });
+
+  // #1315 — the register CLI should print the admission request-id back to the
+  // registrant so they can quote it. The ROW existing is asserted above (live);
+  // surfacing the id in the CLI OUTPUT lands with #1315.
+  todo(
+    "step 3b (#1315): register CLI output surfaces the admission request-id to the registrant",
+  );
+
+  // ===========================================================================
+  // Step 4 — Decide: admit the PENDING request → ADMITTED.
+  // ===========================================================================
+  test("step 4: network admit <request-id> --apply → row ADMITTED", async () => {
+    expect(ctx.requestId).toBeDefined();
+    const res = await dispatchNetwork([
+      "admit",
+      ctx.requestId!,
+      "--admin-seed",
+      ctx.adminSeedPath,
+      "--registry-url",
+      REGISTRY_BASE,
+      "--apply",
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+
+    const row = await getIssuanceStore(ctx.env).getIssuanceRequest(ctx.requestId!);
+    expect(row?.status).toBe("ADMITTED");
+  });
+
+  // #1314 — `network admit --list-pending` shows the row before the decision.
+  todo("step 4a (#1314): network admit --list-pending shows the PENDING row");
+  // #1348 — the reject verb: a second registration rejected → REJECTED.
+  todo("step 4b (#1348): network reject <id> on a second registration → row REJECTED");
+
+  // ===========================================================================
+  // Step 5 — Seal: mint the per-member leaf PSK, seal it to the member, and
+  //   deliver the opaque blob onto the ADMITTED row. The hub-reload port is
+  //   STUBBED (multi-nats reload = #1317); we assert it is EXERCISED and that the
+  //   sealed blob lands on the registry row.
+  // ===========================================================================
+  test("step 5: network secret add-member --apply (hub reload STUBBED) → sealed blob on the row", async () => {
+    expect(ctx.requestId).toBeDefined();
+    ctx.hub = makeRecordingHubPort("");
+    // Real admission/delivery/crypto ports (against the in-process registry via
+    // the routed fetch), with ONLY the hub-reload port swapped for the recorder.
+    const live = buildLiveSecretPorts({
+      hubConfigPath: "<unused — hub port overridden below>",
+      registryUrl: REGISTRY_BASE,
+      material: ctx.adminMaterial,
+      fetchImpl: globalThis.fetch,
+    });
+    ctx.secretPorts = { ...live, hub: ctx.hub };
+
+    const report = await runNetworkSecret(
+      {
+        action: "add-member",
+        networkId: NETWORK_ID,
+        memberPubkey: ctx.joinerPubkey,
+        deliver: "sealed",
+        apply: true,
+      },
+      ctx.secretPorts,
+    );
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(true);
+
+    // The stubbed hub-reload port was exercised (write + reload).
+    expect(ctx.hub.writes.length).toBeGreaterThanOrEqual(1);
+    expect(ctx.hub.reloads).toBeGreaterThanOrEqual(1);
+    // The member's leaf authorization user is present in the (stubbed) hub conf.
+    expect(hubLeafUserPresent(ctx.hub.conf, JOINER_PRINCIPAL)).toBe(true);
+
+    // The opaque sealed blob is present on the ADMITTED registry row.
+    const row = await getIssuanceStore(ctx.env).getIssuanceRequest(ctx.requestId!);
+    expect(row?.status).toBe("ADMITTED");
+    expect(typeof row?.sealed_secret).toBe("string");
+    expect((row?.sealed_secret ?? "").length).toBeGreaterThan(0);
+  });
+
+  // #1316 — the admit-and-seal FOLD: `network admit --and-seal` does step 4 + step
+  // 5 in one privileged move (today they are two commands, driven separately above).
+  todo("step 5a (#1316): network admit --and-seal folds admit + secret add-member");
+
+  // ===========================================================================
+  // Step 6 — Join: the #1220 regression anchor.
+  //   `network join` renders a stack's `accept_subjects` from its own identity ∪
+  //   its roster peers (deriveAcceptSubjects). Those subjects MUST pass the SAME
+  //   full config validation the daemon runs at boot (CortexConfigSchema). #1220:
+  //   join wrote a PEER-scoped subject (federated.andreas.meta-factory.agent.>)
+  //   into jc/default, which the validator rejects (accept_subjects must begin
+  //   with the receiving stack's OWN federated.{me}.{stack}. scope), failing boot.
+  // ===========================================================================
+  describe("step 6: join-rendered accept_subjects vs the REAL boot config validator (#1220)", () => {
+    // No `stack:` block → deriveStackId resolves `${principal}/default`, so the
+    // receiving scope is `federated.joiner.default.` — exactly jc/default's case.
+    const self = { principal: JOINER_PRINCIPAL, stack: "default" };
+
+    function federatedConfig(acceptSubjects: string[]): unknown {
+      return {
+        principal: { id: JOINER_PRINCIPAL },
+        agents: [
+          {
+            id: "luna",
+            displayName: "Luna",
+            persona: "./personas/luna.md",
+            presence: {
+              discord: {
+                token: "discord-bot-token",
+                guildId: "1487000000000000000",
+                agentChannelId: "1487000000000000001",
+                logChannelId: "1487000000000000002",
+              },
+            },
+          },
+        ],
+        claude: {},
+        policy: {
+          federated: {
+            networks: [
+              {
+                id: NETWORK_ID,
+                leaf_node: NETWORK_ID,
+                accept_subjects: acceptSubjects,
+                max_hop: 5,
+              },
+            ],
+          },
+        },
+      };
+    }
+
+    test("own-only accept_subjects (zero-peer join) PASS full config load (LIVE)", () => {
+      const accept = deriveAcceptSubjects(self, []);
+      expect(accept).toEqual(["federated.joiner.default.>"]);
+      const parsed = CortexConfigSchema.safeParse(federatedConfig(accept));
+      expect(parsed.success).toBe(true);
+    });
+
+    test("HARD #1220 assertion: a join-derived PEER subtree is REJECTED by the real config validator", () => {
+      // The join derivation adds the peer PRESENCE subtree — the exact string that
+      // broke jc/default's boot (issue #1220).
+      const derived = deriveAcceptSubjects(self, [
+        { principal: "andreas", stack: "meta-factory" },
+      ]);
+      expect(derived).toContain("federated.andreas.meta-factory.agent.>");
+
+      const parsed = CortexConfigSchema.safeParse(federatedConfig(derived));
+      // Current (buggy) behaviour: the peer-scoped subject fails the own-scope rule.
+      expect(parsed.success).toBe(false);
+      const issues = parsed.success ? "" : JSON.stringify(parsed.error.issues);
+      expect(issues).toContain("accept_subjects");
+    });
+
+    // When #1220 is fixed (the join writer emits only own-scoped subjects), the
+    // WHOLE join output must pass full config load. Flip this to live then, and
+    // update the HARD assertion above (which documents the pre-fix failure).
+    todo(
+      "step 6 (#1220 fix): full join output (own ∪ peers) passes CortexConfigSchema",
+    );
+  });
+
+  // ===========================================================================
+  // Step 7 — Revoke: cut the member. Row → REVOKED, sealed blob cleared, hub
+  //   authorization user dropped (transport CUT) via the stubbed reload.
+  // ===========================================================================
+  test("step 7: network secret revoke-member --apply → REVOKED, blob cleared, hub user dropped", async () => {
+    expect(ctx.secretPorts).toBeDefined();
+    const reloadsBefore = ctx.hub!.reloads;
+
+    const report = await runNetworkSecret(
+      {
+        action: "revoke-member",
+        networkId: NETWORK_ID,
+        memberPubkey: ctx.joinerPubkey,
+        deliver: "sealed",
+        apply: true,
+      },
+      ctx.secretPorts!,
+    );
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(true);
+
+    // Hub transport cut: the leaf authorization user is gone + a reload happened.
+    expect(hubLeafUserPresent(ctx.hub!.conf, JOINER_PRINCIPAL)).toBe(false);
+    expect(ctx.hub!.reloads).toBeGreaterThan(reloadsBefore);
+
+    // Registry row REVOKED and the sealed blob cleared.
+    const row = await getIssuanceStore(ctx.env).getIssuanceRequest(ctx.requestId!);
+    expect(row?.status).toBe("REVOKED");
+    expect(row?.sealed_secret).toBeNull();
+  });
+
+  // ===========================================================================
+  // Step 8 — Leave: joiner tears down its local federation wiring.
+  //   Drives the REAL `leaveNetwork` orchestrator over an in-memory config store
+  //   seeded with the joined network, with the daemon-restart adapter STUBBED
+  //   (the seam the issue calls out — no launchctl, no nats-server). Own-scoped
+  //   accept_subjects here (a valid zero-peer join; the #1220-invalid peer form is
+  //   pinned separately in step 6). Asserts: config cleaned, leaf teardown,
+  //   daemon restarted, roster no longer lists the network.
+  // ===========================================================================
+  test("step 8: network leave --apply → config cleaned + leaf torn down + daemon restarted (stubbed)", async () => {
+    const joined = PolicyFederatedNetworkSchema.parse({
+      id: NETWORK_ID,
+      leaf_node: NETWORK_ID,
+      accept_subjects: [`federated.${JOINER_PRINCIPAL}.default.>`],
+      max_hop: 5,
+    });
+    ctx.leave = makeLeaveNetworkPorts([joined]);
+
+    const res = await leaveNetwork(NETWORK_ID, ctx.leave.ports);
+    expect(res.ok).toBe(true);
+    expect(res.notJoined ?? false).toBe(false);
+    // policy.federated.networks[] rewritten WITHOUT testnet.
+    expect(ctx.leave.writes.length).toBe(1);
+    expect(ctx.leave.writes[0]).toEqual([]);
+    expect(ctx.leave.current()).toEqual([]);
+    // Leaf include directive + file torn down for the network.
+    expect(ctx.leave.removedIncludes).toContain(NETWORK_ID);
+    expect(ctx.leave.removedFiles).toContain(NETWORK_ID);
+    // Daemon restarted exactly once (the stubbed launchctl kickstart).
+    expect(ctx.leave.counters.restarts).toBe(1);
+    // Roster (remaining) no longer lists the network.
+    expect(res.remaining ?? []).not.toContain(NETWORK_ID);
+  });
+
+  // ===========================================================================
+  // Step 9 — Idempotence sweep: re-running leave AND revoke are clean no-ops.
+  // ===========================================================================
+  test("step 9a: idempotence — re-run network leave is a clean no-op (not-joined, no write/restart)", async () => {
+    expect(ctx.leave).toBeDefined();
+    const writesBefore = ctx.leave!.writes.length;
+    const restartsBefore = ctx.leave!.counters.restarts;
+
+    // The store is already empty from step 8 → leave short-circuits notJoined.
+    const res = await leaveNetwork(NETWORK_ID, ctx.leave!.ports);
+    expect(res.ok).toBe(true);
+    expect(res.notJoined).toBe(true);
+    // NOTHING mutated on the re-run.
+    expect(ctx.leave!.writes.length).toBe(writesBefore);
+    expect(ctx.leave!.counters.restarts).toBe(restartsBefore);
+  });
+
+  test("step 9b: idempotence — re-run revoke-member is a clean no-op (no hub write/reload, row unchanged)", async () => {
+    expect(ctx.secretPorts).toBeDefined();
+    const reloadsBefore = ctx.hub!.reloads;
+    const writesBefore = ctx.hub!.writes.length;
+
+    const report = await runNetworkSecret(
+      {
+        action: "revoke-member",
+        networkId: NETWORK_ID,
+        memberPubkey: ctx.joinerPubkey,
+        deliver: "sealed",
+        apply: true,
+      },
+      ctx.secretPorts!,
+    );
+    // No ADMITTED row remains → the orchestrator refuses with "nothing to revoke"
+    // and mutates NOTHING (idempotent no-op).
+    expect(report.applied).toBe(false);
+    expect(report.reason ?? "").toContain("nothing to revoke");
+    expect(ctx.hub!.reloads).toBe(reloadsBefore);
+    expect(ctx.hub!.writes.length).toBe(writesBefore);
+
+    const row = await getIssuanceStore(ctx.env).getIssuanceRequest(ctx.requestId!);
+    expect(row?.status).toBe("REVOKED");
+  });
+});


### PR DESCRIPTION
## What

The epic #1346 progress meter: a scripted lifecycle walkthrough driving the REAL CLI dispatch paths (`dispatchStack`/`dispatchNetwork`/`dispatchProvisionStack` + `runNetworkSecret` + `leaveNetwork`) against the REAL network-registry Hono app + in-memory store (fetch routed in-process; any non-registry fetch throws). No NATS, no CF/D1, no network I/O. 3 new files, +893 LOC, all under `src/cli/cortex/commands/__tests__/e2e-lifecycle/`; zero source changes.

**Live (11 cases):** stack create ×2 born-aligned → network create (+admin_pubkeys) → register --network (**#1262 hard assertion**: PENDING row exists, exactly 1) → admit → secret add-member (hub reload stubbed at the port) → accept_subjects vs the real `CortexConfigSchema` (**#1220 hard assertion**: peer-subtree subject rejected, own-only passes) → revoke-member → leave → idempotence sweep.

**test.todo (5, flip as siblings merge):** #1315, #1314, #1348, #1316, #1220-writer-fix.

## Reviewer probe points (from the implementer)

1. Q5 authority collapse — one admin seed for create+admit+seal (separable hub-admin is registry-layer unit-tested; README flags it).
2. Step 6 tests the derivation→validation seam, not a full join-writer drive (matches #1220's ask; 6b todo is the flip point).
3. Step 6 asserts the CURRENT buggy rejection — must be updated together with the #1220 writer fix (README documents).
4. Ordered shared-state suite (deliberate for a lifecycle guard; relies on bun sequential in-file execution).
5. One-line `todo` type cast for bun-types (runtime correct, 5 todo reported).

## Verification

`bun test src/cli/cortex/commands/__tests__/e2e-lifecycle/` → 11 pass, 5 todo, 0 fail, 62 expect(). `bunx tsc --noEmit` → 0 errors. eslint on the new dir → clean.

Closes #1355. Epic #1346 (Phase 5, started in Wave 1 by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB