### PR TITLE
fix(cli): C-1352 — register agents/migrate-config as cortex verbs; de-reference broken cloud.ts

### DIFF
--- a/src/cli/cortex/commands/__tests__/cli-verb-registration.test.ts
+++ b/src/cli/cortex/commands/__tests__/cli-verb-registration.test.ts
@@ -1,0 +1,83 @@
+/**
+ * #1352 — regression guard against CLI verb drift.
+ *
+ * Three complete command modules (`agents`, `cloud`, `migrate-config`) shipped
+ * as standalone `import.meta.main` scripts that were never registered as
+ * commander verbs — while docs and cortex.ts:682 told users to run them as
+ * `cortex agents …` / `cortex migrate-config …`. Users following those hints hit
+ * "unknown command".
+ *
+ * This is a cheap, string-level guard for that whole class of drift: every
+ * command that cortex.ts's OWN user-facing strings promise (the fully
+ * backtick-quoted `cortex <verb>` form, e.g. the cortex.ts:682 upgrade hint
+ * `run \`cortex migrate-config\``) MUST be a registered commander command. If a
+ * future edit references `cortex <verb>` in a message without registering the
+ * verb, this fails.
+ *
+ * Deliberately strict on the reference pattern — a FULLY backtick-wrapped
+ * `cortex <verb>` — so prose/log phrases like "cortex config validation OK"
+ * (where `config` is a noun, not a subcommand) are not mistaken for command
+ * references.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// __tests__ → commands → cortex → cli → src → cortex.ts
+const CORTEX_TS_PATH = join(import.meta.dir, "../../../../cortex.ts");
+const source = readFileSync(CORTEX_TS_PATH, "utf-8");
+
+/** Command names registered via commander: `.command("<name>")`. */
+function registeredCommands(src: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of src.matchAll(/\.command\("([a-z][a-z-]*)"\)/g)) {
+    out.add(m[1]!);
+  }
+  return out;
+}
+
+/**
+ * Verbs referenced in a FULLY backtick-wrapped `cortex <verb>` form — the
+ * canonical "run this command" convention (cortex.ts:682). Only the leading
+ * verb token is captured; a trailing backtick right after it is required so
+ * `cortex config validation …` (not backtick-closed after the verb) is
+ * excluded.
+ */
+function referencedVerbs(src: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of src.matchAll(/`cortex ([a-z][a-z-]+)`/g)) {
+    out.add(m[1]!);
+  }
+  return out;
+}
+
+describe("#1352 — cortex CLI verb registration guard", () => {
+  const registered = registeredCommands(source);
+  const referenced = referencedVerbs(source);
+
+  test("cortex.ts registers the expected core verbs", () => {
+    // Sanity floor — if the registration table is refactored away, catch it here
+    // rather than letting the drift check pass vacuously.
+    for (const verb of ["start", "stop", "status", "network", "stack"]) {
+      expect(registered.has(verb)).toBe(true);
+    }
+  });
+
+  test("the two #1352 verbs are now registered", () => {
+    expect(registered.has("agents")).toBe(true);
+    expect(registered.has("migrate-config")).toBe(true);
+  });
+
+  test("the reference scanner actually found command references (not vacuous)", () => {
+    // The whole test is meaningless if the regex silently matches nothing after a
+    // future quoting-style change. Pin the canonical cortex.ts:682 reference.
+    expect(referenced.size).toBeGreaterThan(0);
+    expect(referenced.has("migrate-config")).toBe(true);
+  });
+
+  test("every `cortex <verb>` cortex.ts promises is a registered command", () => {
+    const missing = [...referenced].filter((verb) => !registered.has(verb));
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/cli/cortex/commands/cloud.ts
+++ b/src/cli/cortex/commands/cloud.ts
@@ -546,7 +546,7 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
   console.log("\nNext steps:");
   console.log("  1. Add the bot.yaml snippet above to ~/.config/cortex/bot.yaml");
   console.log("  2. Restart cortex: cortex stop && cortex start");
-  console.log("  3. Add more principals: cortex cloud add-principal --name JC --agent-name Ivy --endpoint URL --admin-key SECRET");
+  console.log("  3. Add more principals: bun src/cli/cortex/commands/cloud.ts add-principal --name JC --agent-name Ivy --endpoint URL --admin-key SECRET");
 }
 
 // =============================================================================
@@ -561,7 +561,7 @@ async function cloudAddPrincipal(flags: Record<string, string>): Promise<void> {
 
   if (!name || !agentName || !endpoint || !adminKey) {
     throw new Error(
-      "Usage: cortex cloud add-principal --name <principal> --agent-name <agent> --endpoint <URL> --admin-key <SECRET>",
+      "Usage: bun src/cli/cortex/commands/cloud.ts add-principal --name <principal> --agent-name <agent> --endpoint <URL> --admin-key <SECRET>",
     );
   }
 
@@ -685,7 +685,7 @@ async function cloudStatus(flags: Record<string, string>): Promise<void> {
 // =============================================================================
 
 // GV-1: cortex-first, grove-fallback. Resolved at module load; the daemon and
-// `cortex cloud repos` both read (never write) bot.yaml here.
+// `bun src/cli/cortex/commands/cloud.ts repos` both read (never write) bot.yaml here.
 const DEFAULT_CONFIG_PATH = resolveConfigFilePath("bot.yaml");
 
 interface BotYamlGithub {

--- a/src/cli/cortex/commands/migrate-config.ts
+++ b/src/cli/cortex/commands/migrate-config.ts
@@ -102,7 +102,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
 function printHelp(): void {
   console.log("cortex migrate-config — convert grove-v2 bot.yaml or cortex.yaml to cortex.yaml + policy block\n");
   console.log("Usage:");
-  console.log("  bun src/cli/cortex/commands/migrate-config.ts <input.yaml> [options]\n");
+  console.log("  cortex migrate-config <input.yaml> [options]\n");
   console.log("Options:");
   console.log("  --out FILE     Write to FILE (default: stdout)");
   console.log("  --labels FILE  Principal-id label overrides ({\"<platform>:<id>\": \"<principal-id>\"})");

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -276,6 +276,15 @@ import { dispatchProvisionStack } from "./cli/cortex/commands/provision-stack";
 import { dispatchRelease } from "./cli/cortex/commands/release";
 import { dispatchStack } from "./cli/cortex/commands/stack";
 import { dispatchCreds } from "./cli/cortex/commands/creds";
+// #1352 — `agents` + `migrate-config` were complete standalone `import.meta.main`
+// scripts, unreachable from the installed binary while docs
+// (docs/design-arc-agent-bots.md) and cortex.ts:682 told users to run them as
+// `cortex agents …` / `cortex migrate-config …`. Registered as passthrough
+// commander subcommands below so those references resolve. `dispatchAgents`
+// returns an ExitResult synchronously; `runMigrateConfig` returns the exit code
+// (it writes its own stdout/stderr). Neither boots the daemon — only `start` does.
+import { dispatchAgents } from "./cli/cortex/commands/agents";
+import { runMigrateConfig } from "./cli/cortex/commands/migrate-config";
 
 import { CloudPublisher } from "./taps/cc-events/cloud-publisher";
 import {
@@ -6990,6 +6999,43 @@ if (import.meta.main) {
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
       process.exit(result.exitCode);
+    });
+
+  // #1352 — `agents`: inspect + validate agents.d/ fragments and signal the
+  // running runtime to reload (SIGHUP). Same passthrough shape as `network` /
+  // `stack` / `creds`: `dispatchAgents` owns its own arg parsing (subcommand +
+  // flags + its own `--help`), so commander hands it the raw remaining argv
+  // untouched. `dispatchAgents` is synchronous (returns an ExitResult) — no
+  // await needed, but the write+exit tail matches the other verbs exactly.
+  program
+    .command("agents")
+    .description("Inspect + validate agent fragments; reload the running runtime (reload / list)")
+    .argument("[args...]", "agents subcommand + flags (see `cortex agents --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action((args: string[]) => {
+      const result = dispatchAgents(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
+    });
+
+  // #1352 — `migrate-config`: convert a grove-v2 bot.yaml / legacy cortex.yaml
+  // to the cortex config shape (MIG-7.2e). Makes the cortex.ts:682 upgrade hint
+  // (`run \`cortex migrate-config\``) true. Same passthrough shape as the verbs
+  // above. `runMigrateConfig` writes its own stdout/stderr and returns the exit
+  // code, so the action just propagates that code.
+  program
+    .command("migrate-config")
+    .description("Convert a grove-v2 bot.yaml / legacy cortex.yaml to the cortex config shape")
+    .argument("[args...]", "migrate-config input + flags (see `cortex migrate-config --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const exitCode = await runMigrateConfig(args);
+      process.exit(exitCode);
     });
 
   program.parse();


### PR DESCRIPTION
## What

`src/cortex.ts` registered 9 verbs while docs and its own strings promised more. Now: `cortex agents` and `cortex migrate-config` are real registered verbs (passthrough registration matching the existing `network`/`stack`/`creds` shape exactly; `agents.ts` already exported its dispatcher — no refactor needed, verified before touching). `cortex --help` lists both; `cortex.ts:682`'s own advice is now true.

**cloud.ts: de-referenced, not wired** — decision recorded on #1352 before finalizing: it's grove-legacy (39 grove markers), its `setup` resolves a worker dir that doesn't exist in cortex's layout (stale two-levels-under-src path math), and its deploy role is owned by `cortex release` + `arc upgrade`. Its self-referencing strings now point at the bun invocation.

**Regression guard** (new test, 4 cases): every fully backtick-quoted `cortex <verb>` in cortex.ts's own strings must be a registered command — with a non-vacuous pin on the :682 reference so quoting-style drift can't silence it.

## Verification

`tsc --noEmit` clean · `bun test src/cli` 1051 pass / 0 fail (40 files) · `bun src/cortex.ts agents --help` + `migrate-config --help` print usage · top-level help lists both.

## Reviewer notes (implementer-declared)

1. Runtime not exercised against a live daemon (dispatchers unchanged + own-tested; live smoke on an installed binary would close AC#1 fully).
2. `migrate-config` async action self-exits — same pattern as `network`/`release`.
3. Pre-existing deprecation hints at cortex.ts:70/1422 untouched (out of scope).

Closes #1352. Epic #1346 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB