### PR TITLE
web adapter: bind ingress to configurable host (default 127.0.0.1)

### DIFF
--- a/src/adapters/web/__tests__/web-adapter.test.ts
+++ b/src/adapters/web/__tests__/web-adapter.test.ts
@@ -50,6 +50,7 @@ async function withBroadcastCapture(fn: () => Promise<void>): Promise<void> {
 
 function makeBinding(overrides: Partial<WebBinding> = {}): WebBinding {
   return {
+    host: "127.0.0.1",
     instanceId: "amt",
     port: 0, // ephemeral — overridden per test
     broadcastUrl: "http://localhost:9999/broadcast",
@@ -574,9 +575,27 @@ describe("WebBindingSchema — validation", () => {
       broadcastUrl: "http://example.com/broadcast",
     });
     expect(result.instanceId).toBe("amt");
+    expect(result.host).toBe("127.0.0.1"); // default — loopback only
     expect(result.port).toBe(8090); // default
     expect(result.transport).toBe("ws"); // default
     expect(result.authScheme).toBe("cf-access"); // default
+  });
+
+  test("host defaults to loopback", () => {
+    const r = WebBindingSchema.parse({
+      instanceId: "amt",
+      broadcastUrl: "http://x.com/b",
+    });
+    expect(r.host).toBe("127.0.0.1");
+  });
+
+  test("host override is honoured", () => {
+    const r = WebBindingSchema.parse({
+      instanceId: "amt",
+      broadcastUrl: "http://x.com/b",
+      host: "0.0.0.0",
+    });
+    expect(r.host).toBe("0.0.0.0");
   });
 
   test("missing instanceId fails validation", () => {
@@ -698,6 +717,7 @@ describe("buildGatewayAdapters — web bindings", () => {
         {
           agent: "ivy",
           binding: {
+            host: "127.0.0.1",
             instanceId: "amt",
             broadcastUrl: "http://example.com/broadcast",
             port: 8090,
@@ -721,8 +741,8 @@ describe("buildGatewayAdapters — web bindings", () => {
     const { factory, calls } = makeRecordingFactory();
     const surfaces: Surfaces = {
       web: [
-        { agent: "ivy", binding: { instanceId: "app-a", broadcastUrl: "http://a.com/broadcast", port: 8091, transport: "ws", authScheme: "none" } },
-        { agent: "ivy", binding: { instanceId: "app-b", broadcastUrl: "http://b.com/broadcast", port: 8092, transport: "sse", authScheme: "header" } },
+        { agent: "ivy", binding: { host: "127.0.0.1", instanceId: "app-a", broadcastUrl: "http://a.com/broadcast", port: 8091, transport: "ws", authScheme: "none" } },
+        { agent: "ivy", binding: { host: "127.0.0.1", instanceId: "app-b", broadcastUrl: "http://b.com/broadcast", port: 8092, transport: "sse", authScheme: "header" } },
       ],
     };
     const adapters = buildGatewayAdapters(surfaces, {
@@ -757,7 +777,7 @@ describe("buildGatewayAdapters — web bindings", () => {
       },
     };
     buildGatewayAdapters(
-      { web: [{ agent: "ivy", binding: { instanceId: "amt", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }] },
+      { web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "amt", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }] },
       { principal: "andreas", runtime: RUNTIME_STUB, factory },
     );
     expect(capturedSource).toMatchObject({
@@ -779,7 +799,7 @@ describe("buildGatewayAdapters — web bindings", () => {
       },
     };
     buildGatewayAdapters(
-      { web: [{ agent: "ivy", binding: { instanceId: "amt", broadcastUrl: "http://x.com/b", port: 8090, transport: "sse", authScheme: "header", authHeader: "X-User" } }] },
+      { web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "amt", broadcastUrl: "http://x.com/b", port: 8090, transport: "sse", authScheme: "header", authHeader: "X-User" } }] },
       { principal: "andreas", runtime: RUNTIME_STUB, factory },
     );
     const b = capturedWebBinding as Record<string, unknown>;
@@ -794,7 +814,7 @@ describe("buildGatewayAdapters — web bindings", () => {
     // WebAdapter must never subscribe to bus subjects (double-delivery prevention).
     // No surfaceConfig on the adapter — surfaceSubjects:[] means it's intentionally absent.
     const surfaces: Surfaces = {
-      web: [{ agent: "ivy", binding: { instanceId: "test", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }],
+      web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "test", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }],
     };
     const { factory } = makeRecordingFactory();
     const adapters = buildGatewayAdapters(surfaces, {
@@ -853,8 +873,8 @@ describe("WebAdapter — AMT agnosticism", () => {
 
     const surfaces: Surfaces = {
       web: [
-        { agent: "ivy", binding: { instanceId: "tenant-a", broadcastUrl: "http://a.com/b", port: 8091, transport: "ws", authScheme: "cf-access" } },
-        { agent: "oak", binding: { instanceId: "tenant-b", broadcastUrl: "http://b.com/b", port: 8092, transport: "ws", authScheme: "cf-access" } },
+        { agent: "ivy", binding: { host: "127.0.0.1", instanceId: "tenant-a", broadcastUrl: "http://a.com/b", port: 8091, transport: "ws", authScheme: "cf-access" } },
+        { agent: "oak", binding: { host: "127.0.0.1", instanceId: "tenant-b", broadcastUrl: "http://b.com/b", port: 8092, transport: "ws", authScheme: "cf-access" } },
       ],
     };
 

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -238,13 +238,14 @@ export class WebAdapter implements PlatformAdapter {
     this.onMessageCallback = onMessage;
 
     this.server = Bun.serve({
+      hostname: this.binding.host,
       port: this.binding.port,
       fetch: (req) => this.handleRequest(req),
     });
     this._serverPort = this.server.port ?? null;
 
     console.log(
-      `web-adapter[${this.instanceId}] agent=${this.agentId}: HTTP ingress listening on port ${this._serverPort} (transport=${this.binding.transport})`,
+      `web-adapter[${this.instanceId}] agent=${this.agentId}: HTTP ingress listening on ${this.binding.host}:${this._serverPort} (transport=${this.binding.transport})`,
     );
     return Promise.resolve();
   }

--- a/src/common/types/surfaces.ts
+++ b/src/common/types/surfaces.ts
@@ -185,6 +185,13 @@ export const WebBindingSchema = z
      */
     port: z.number().int().min(1).max(65535).default(8090),
     /**
+     * Bind address for the Bun HTTP ingress. Defaults to loopback so the
+     * ingress is never exposed on all interfaces; the CF-Access + cloudflared
+     * perimeter is the only public path. Set to `"0.0.0.0"` ONLY for a
+     * deliberately multi-homed deployment.
+     */
+    host: z.string().default("127.0.0.1"),
+    /**
      * URL to POST broadcast messages to when cortex wants to push a reply to
      * the web surface. For `transport: "ws"` this is the WS Durable Object's
      * `/broadcast` endpoint (mirrors `dashboard-socket.ts` DO protocol); for

--- a/src/gateway/__tests__/binding-resolver.test.ts
+++ b/src/gateway/__tests__/binding-resolver.test.ts
@@ -800,6 +800,7 @@ const WEB_SURFACES: Surfaces = {
       agent: "pylon",
       stack: "andreas/amt",
       binding: {
+        host: "127.0.0.1",
         instanceId: "amt",
         port: 8090,
         broadcastUrl: "http://localhost:9090/broadcast",
@@ -841,6 +842,7 @@ describe("buildBindingIndex — web collision throws", () => {
           agent: "pylon",
           stack: "andreas/amt",
           binding: {
+            host: "127.0.0.1",
             instanceId: "amt",
             port: 8090,
             broadcastUrl: "http://localhost:9090/broadcast",
@@ -852,6 +854,7 @@ describe("buildBindingIndex — web collision throws", () => {
           agent: "relay",
           stack: "andreas/work",
           binding: {
+            host: "127.0.0.1",
             instanceId: "amt", // duplicate — same demux key "web:amt"
             port: 8091,
             broadcastUrl: "http://localhost:9091/broadcast",
@@ -911,6 +914,7 @@ describe("distinctBoundStacks — web bindings", () => {
           agent: "pylon",
           stack: "andreas/amt", // same leaf — collapses to one entry
           binding: {
+            host: "127.0.0.1",
             instanceId: "amt",
             port: 8090,
             broadcastUrl: "http://localhost:9090/broadcast",
@@ -937,6 +941,7 @@ describe("distinctBoundStacks — web bindings", () => {
           agent: "pylon",
           stack: "andreas/amt",
           binding: {
+            host: "127.0.0.1",
             instanceId: "amt",
             port: 8090,
             broadcastUrl: "http://localhost:9090/broadcast",
@@ -962,6 +967,7 @@ describe("crossPrincipalBindings — web bindings", () => {
           agent: "pylon",
           stack: "other/amt",
           binding: {
+            host: "127.0.0.1",
             instanceId: "amt",
             port: 8090,
             broadcastUrl: "http://localhost:9090/broadcast",

--- a/src/gateway/__tests__/gateway-bootstrap.test.ts
+++ b/src/gateway/__tests__/gateway-bootstrap.test.ts
@@ -519,6 +519,7 @@ const WEB_SURFACES: Surfaces = {
       agent: "pylon",
       stack: "andreas/amt",
       binding: {
+        host: "127.0.0.1",
         instanceId: "amt",
         port: 8090,
         broadcastUrl: "http://localhost:9090/broadcast",

--- a/src/gateway/__tests__/surface-ownership-plan.test.ts
+++ b/src/gateway/__tests__/surface-ownership-plan.test.ts
@@ -243,6 +243,7 @@ const WEB_SURFACES: Surfaces = {
       agent: "pylon",
       stack: "andreas/amt",
       binding: {
+        host: "127.0.0.1",
         instanceId: "amt",
         port: 8090,
         broadcastUrl: "http://localhost:9090/broadcast",


### PR DESCRIPTION
Adds a `host` field to WebBindingSchema (default `127.0.0.1`) wired to Bun.serve so the web ingress binds loopback-only instead of all interfaces; the CF-Access + cloudflared perimeter stays the only public path. Back-compatible (catchall keeps old configs parsing). Tests: web-adapter 54/54, gateway 99/99, tsc/lint clean. Part of AMT-R8 (least-privilege AMT↔Pylon seam).