### PR TITLE
feat(review): bind verdict to request id in signed payload (compass#95 replay-fix)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,6 +92,10 @@ _Avoid_: message (too loose — say envelope for the wrapper, payload for the co
 The inner content body of an **envelope** — the domain data, distinct from the envelope's routing/trust metadata.
 _Avoid_: message, body, data
 
+**`request_id`** (signed verdict→request binding):
+The dispatch's `correlation_id` value, additionally stamped INTO the **signed** `payload` of a `review.verdict.*` envelope. myelin signs the `payload` but deliberately **excludes** the top-level `correlation_id` (mutable routing metadata), so the binding must live in the payload: it cryptographically ties a verdict to the specific request it answers. The verdict consumer (pilot's `--wait`) asserts `payload.request_id` equals the awaited request's id before honoring a verdict — defeating **replay-rebind**, where a genuine signed verdict is replayed against a different pending request by rewriting the unsigned `correlation_id` (compass#95 / cortex#1366).
+_Avoid_: conflating with the top-level **`correlation_id`** (unsigned routing metadata that groups one dispatch; `request_id` is its signed, in-payload counterpart, used solely for verdict-to-request binding).
+
 **Capability**:
 A declared, bus-routable ability — e.g. `code-review.typescript`, `chat`, `release`, `security-scan`. An **assistant** declares the capabilities it offers; the `tasks.{capability}.{subcapability}` **subject** routes on it (for Offer mode); for Direct/Delegate mode the capability appears as the trailing segment after `tasks.@{assistant}` (e.g. `tasks.@luna.chat`). An **agent**'s JetStream consumer filters by capability. A capability may be *fulfilled by* a soma skill, but the capability is the wire-facing ability, not the implementation.
 

--- a/src/bus/__tests__/review-events.test.ts
+++ b/src/bus/__tests__/review-events.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { canonicalizeForSigning } from "@the-metafactory/myelin/identity";
 import { validateEnvelope, type Envelope } from "../myelin/envelope-validator";
 import {
   createReviewRequestEvent,
@@ -279,6 +280,31 @@ describe("createReviewVerdictEvent", () => {
     expect(env2.correlation_id).toBe(REQUEST_ENVELOPE_ID);
     // ...but the envelope ids themselves are distinct
     expect(env1.id).not.toBe(env2.id);
+  });
+
+  test("compass#95 (replay-fix) — payload carries request_id == correlationId, and it is inside the SIGNED canonical bytes", () => {
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "approved",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({ verdict: "approved" }),
+    });
+    // The SIGNED request-binding: pilot asserts `payload.request_id === awaited
+    // correlationId` to defeat replay-rebind (top-level correlation_id is NOT
+    // signed). It must equal the request envelope id verbatim.
+    expect((env.payload as { request_id?: unknown }).request_id).toBe(
+      REQUEST_ENVELOPE_ID,
+    );
+    // ...and it must land in the canonical bytes the signer commits to — proving
+    // an attacker cannot rewrite it without invalidating the signature. (payload
+    // ∈ myelin SIGNABLE_FIELDS; correlation_id is deliberately NOT.)
+    const canonical = new TextDecoder().decode(
+      canonicalizeForSigning(env as unknown as Parameters<typeof canonicalizeForSigning>[0]),
+    );
+    expect(canonical).toContain(`"request_id":"${REQUEST_ENVELOPE_ID}"`);
+    // Guard the asymmetry the fix relies on: correlation_id stays OUT of the
+    // signed bytes (that exclusion is exactly why the SIGNED request_id is needed).
+    expect(canonical).not.toContain("correlation_id");
   });
 
   test("each invocation returns a fresh UUID id", () => {

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -269,6 +269,13 @@ export type ReviewVerdictKind =
  * `nats-review-io.ts:ReviewCompletedPayload` is preserved so workflow-side
  * consumers (the existing `runReviewCycle` ReviewCycleIO) don't need
  * behavioural changes — only the subject and the `correlation_id` are new.
+ *
+ * **compass#95 (replay-fix) — emitted `request_id`.** The wire payload
+ * additionally carries `request_id` (the request envelope's id), stamped by
+ * {@link createReviewVerdictEvent} from `opts.correlationId`. It is a
+ * SIGNED request-binding pilot asserts against to defeat replay-rebind (see
+ * the builder). It is NOT a caller input on this interface — the builder is
+ * the single source so it can never drift from the top-level `correlation_id`.
  */
 export interface ReviewVerdictPayload {
   /** Owner/repo string, echoed from the request envelope. */
@@ -398,6 +405,18 @@ export function createReviewVerdictEvent(
     sovereignty: defaultReviewSovereignty(opts.source, opts.classification),
     correlationId: opts.correlationId,
     payload: {
+      // compass#95 (replay-fix) — SIGNED request binding. The top-level
+      // `correlation_id` is the verdict↔request binding pilot filters on, but
+      // myelin's canonical signing set EXCLUDES `correlation_id`
+      // (`identity/canonicalize.ts` — "mutable without invalidating signature").
+      // So a genuinely-signed verdict could be replayed with only its
+      // `correlation_id` rewritten and still verify (pilot#178 adversarial
+      // finding). Stamping the request id INTO the payload — which IS covered by
+      // the signature — gives pilot a cryptographically-bound field to assert
+      // against (`payload.request_id === awaited correlationId`), closing the
+      // replay-rebind. Sourced from `opts.correlationId` (the request envelope's
+      // id) so it can never drift from the top-level correlation_id.
+      request_id: opts.correlationId,
       repo: opts.payload.repo,
       pr: opts.payload.pr,
       reviewer: opts.payload.reviewer,


### PR DESCRIPTION
## What

Stamp the request envelope id into the verdict payload as a **signed** field (`payload.request_id`), sourced from `opts.correlationId` in `createReviewVerdictEvent`.

## Why (compass#95 replay-fix)

An adversarial review of **the-metafactory/pilot#178** (F4 verdict-signature verification) confirmed a **replay-rebind bypass**: pilot binds a verdict to its request solely on `correlation_id`, but myelin's canonical signing set **excludes** `correlation_id` (`identity/canonicalize.ts` — "mutable without invalidating signature"). So a genuinely-signed `approved` verdict can be replayed with only its `correlation_id` rewritten to a *different* pending request and still pass the crypto gate under `enforce` — driving the autonomous merge for a request it was never issued for.

The producer must give pilot a **signed** field to bind against. `payload` **is** covered by the signature (`payload ∈ SIGNABLE_FIELDS`), so `payload.request_id` is tamper-evident. Pilot then asserts `payload.request_id === awaited correlationId` (pilot#178), which a replayed verdict fails (its signed `request_id` is the *original* request's id).

## Changes

- `src/bus/review-events.ts` — `createReviewVerdictEvent` emits `payload.request_id = opts.correlationId`. Single source (the builder), so it can never drift from the top-level `correlation_id`. Both verdict emitters (`sage-runner`, `runner/review-pipeline`) route through this builder, so all verdict paths are covered.
- `src/bus/__tests__/review-events.test.ts` — asserts the emitted payload carries `request_id == REQUEST_ENVELOPE_ID` **and** that it lands in `canonicalizeForSigning(...)` output (proving it's in the bytes the signer commits to), while `correlation_id` stays out.

## Compat / ordering

Under `enforce`, pilot treats a verdict **lacking** `payload.request_id` as unverifiable → fail-closed. Acceptable because we control both producer and consumer. **This producer change should land first (or together) with the pilot assertion** so pilot has `request_id` to check.

## Verification

- `bun test src/bus/__tests__/review-events.test.ts` → 27 pass / 0 fail (incl. new binding test)
- review cluster (`review-events` + `review-consumer` + `co7-egress-pipeline` + `review-pipeline`) → 157 pass / 0 fail
- `bunx tsc --noEmit -p tsconfig.json` → 0 errors

Do **not** merge yet — paired with pilot#178; a fresh agent re-reviews.

Refs the-metafactory/compass#95

🤖 Generated with [Claude Code](https://claude.com/claude-code)