### PR TITLE
feat(config): C-conf-0a — env-placeholder resolution for surface ID fields (compass#81 L2)

### DIFF
--- a/src/common/config/__tests__/resolve-env-placeholders.test.ts
+++ b/src/common/config/__tests__/resolve-env-placeholders.test.ts
@@ -55,6 +55,11 @@ const TOUCHED = [
   "SLACK_APP",
   "GW_DISCORD_TOKEN",
   "WS_ONLY_TOKEN",
+  // compass#84 (L2) — surface ID placeholder env vars.
+  "PIER_GUILD_ID",
+  "PIER_AGENT_CHANNEL_ID",
+  "PIER_LOG_CHANNEL_ID",
+  "GW_GUILD_ID",
 ];
 const saved: Record<string, string | undefined> = {};
 
@@ -212,6 +217,178 @@ describe("resolveAgentPresenceTokens — fail SOFT on unset env (cortex#1217)", 
     expect((agent.presence as any).mattermost.apiToken).toBe("mm-real");
     expect(warnings).toHaveLength(1);
     expect(warnings[0]?.platform).toBe("discord");
+  });
+});
+
+// ===========================================================================
+// compass#84 (L2) — surface ID placeholder fields (guildId / agentChannelId /
+// logChannelId). Symmetric to the surface *token* fields: a live guild/channel
+// snowflake in a SHIPPABLE fragment (Pier ships to the public arc package) is
+// deployment config, not template content. Shipping it as `__PIER_GUILD_ID__`
+// keeps the literal ID out of the repo and resolves it from the daemon env at
+// load — failing SOFT (surface disabled + WARN, never a crash) when unset.
+// ===========================================================================
+describe("resolveAgentPresenceTokens — surface ID placeholders (compass#84 L2)", () => {
+  test("resolves guildId/agentChannelId/logChannelId placeholders from env", () => {
+    process.env.PIER_GUILD_ID = "000000000000000001";
+    process.env.PIER_AGENT_CHANNEL_ID = "000000000000000002";
+    process.env.PIER_LOG_CHANNEL_ID = "000000000000000003";
+    const agent: Record<string, unknown> = {
+      id: "pier",
+      presence: {
+        discord: {
+          enabled: true,
+          token: "inline-token",
+          guildId: "__PIER_GUILD_ID__",
+          agentChannelId: "__PIER_AGENT_CHANNEL_ID__",
+          logChannelId: "__PIER_LOG_CHANNEL_ID__",
+        },
+      },
+    };
+    resolveAgentPresenceTokens(agent, "agents.d/pier.yaml");
+    const discord = (agent.presence as any).discord;
+    expect(discord.guildId).toBe("000000000000000001");
+    expect(discord.agentChannelId).toBe("000000000000000002");
+    expect(discord.logChannelId).toBe("000000000000000003");
+    // all resolvable ⇒ surface stays enabled
+    expect(discord.enabled).toBe(true);
+  });
+
+  test("inline (non-placeholder) IDs pass through byte-identical", () => {
+    const agent: Record<string, unknown> = {
+      id: "luna",
+      presence: {
+        discord: {
+          enabled: true,
+          token: "inline-token",
+          guildId: "123456789012345678",
+          agentChannelId: "223456789012345678",
+          logChannelId: "323456789012345678",
+        },
+      },
+    };
+    resolveAgentPresenceTokens(agent, "agents[0]");
+    const discord = (agent.presence as any).discord;
+    expect(discord.guildId).toBe("123456789012345678");
+    expect(discord.agentChannelId).toBe("223456789012345678");
+    expect(discord.enabled).toBe(true);
+  });
+
+  test("unset ID env → surface DISABLED, literal scrubbed (not a placeholder), WARN collected", () => {
+    delete process.env.PIER_GUILD_ID;
+    const agent: Record<string, unknown> = {
+      id: "pier",
+      presence: {
+        discord: { enabled: true, token: "inline-token", guildId: "__PIER_GUILD_ID__" },
+      },
+    };
+    const warnings: SurfaceTokenWarning[] = [];
+    expect(() => resolveAgentPresenceTokens(agent, "agents.d/pier.yaml", warnings)).not.toThrow();
+    const discord = (agent.presence as any).discord;
+    // surface disabled — a missing ID is as disqualifying as a missing token
+    expect(discord.enabled).toBe(false);
+    // the literal placeholder must NOT survive, and the scrub must NOT itself
+    // look like a placeholder (or a downstream resolve pass / the assert trips)
+    expect(discord.guildId).not.toBe("__PIER_GUILD_ID__");
+    expect(ENV_PLACEHOLDER_PATTERN.test(discord.guildId)).toBe(false);
+    // scrub is a non-empty string ⇒ still satisfies the `.min(1)` schema
+    expect(discord.guildId.length).toBeGreaterThan(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      agent: "pier",
+      platform: "discord",
+      envVar: "PIER_GUILD_ID",
+      fieldPath: "agents.d/pier.yaml.presence.discord.guildId",
+    });
+  });
+
+  test("a resolvable token but an unset ID env still disables the surface", () => {
+    process.env.PIER_BOT_TOKEN = "real-token";
+    delete process.env.PIER_LOG_CHANNEL_ID;
+    const agent: Record<string, unknown> = {
+      id: "pier",
+      presence: {
+        discord: {
+          enabled: true,
+          token: "__PIER_BOT_TOKEN__",
+          guildId: "123456789012345678",
+          logChannelId: "__PIER_LOG_CHANNEL_ID__",
+        },
+      },
+    };
+    const warnings: SurfaceTokenWarning[] = [];
+    resolveAgentPresenceTokens(agent, "agents.d/pier.yaml", warnings);
+    const discord = (agent.presence as any).discord;
+    // token resolved fine, but the missing channel ID disables the surface
+    expect(discord.token).toBe("real-token");
+    expect(discord.enabled).toBe(false);
+    expect(warnings.map((w) => w.envVar)).toContain("PIER_LOG_CHANNEL_ID");
+  });
+
+  test("optional worklogChannelId placeholder resolves when set; absent → no-op", () => {
+    process.env.PIER_LOG_CHANNEL_ID = "000000000000000009";
+    const agent: Record<string, unknown> = {
+      id: "pier",
+      presence: {
+        discord: { enabled: true, token: "inline", guildId: "1", worklogChannelId: "__PIER_LOG_CHANNEL_ID__" },
+      },
+    };
+    expect(() => resolveAgentPresenceTokens(agent, "agents[0]")).not.toThrow();
+    expect((agent.presence as any).discord.worklogChannelId).toBe("000000000000000009");
+    // a fragment with no worklogChannelId key at all must not choke
+    const bare: Record<string, unknown> = {
+      id: "x",
+      presence: { discord: { enabled: true, token: "inline", guildId: "1" } },
+    };
+    expect(() => resolveAgentPresenceTokens(bare, "agents[0]")).not.toThrow();
+    expect((bare.presence as any).discord.enabled).toBe(true);
+  });
+});
+
+describe("resolveSurfaceBindingTokens — ID placeholders (compass#84 L2)", () => {
+  test("resolves a binding.guildId placeholder from env", () => {
+    process.env.GW_GUILD_ID = "000000000000000010";
+    const surfaces = {
+      discord: [
+        {
+          agent: "pier",
+          binding: {
+            token: "inline-token",
+            guildId: "__GW_GUILD_ID__",
+            agentChannelId: "222",
+            logChannelId: "333",
+          },
+        },
+      ],
+    } as unknown as Surfaces;
+    resolveSurfaceBindingTokens(surfaces);
+    expect((surfaces.discord as any)[0].binding.guildId).toBe("000000000000000010");
+  });
+
+  test("fail SOFT: unset binding.guildId env → the binding ENTRY is dropped", () => {
+    delete process.env.GW_GUILD_ID;
+    const surfaces = {
+      discord: [
+        {
+          agent: "pier",
+          binding: {
+            token: "inline-token",
+            guildId: "__GW_GUILD_ID__",
+            agentChannelId: "222",
+            logChannelId: "333",
+          },
+        },
+      ],
+    } as unknown as Surfaces;
+    const warnings: SurfaceTokenWarning[] = [];
+    expect(() => resolveSurfaceBindingTokens(surfaces, warnings)).not.toThrow();
+    expect(surfaces.discord).toHaveLength(0);
+    expect(warnings[0]).toMatchObject({
+      agent: "pier",
+      platform: "discord",
+      envVar: "GW_GUILD_ID",
+      fieldPath: "surfaces.discord[0].binding.guildId",
+    });
   });
 });
 
@@ -799,5 +976,79 @@ agents:
     expect(vegaInstance?.enabled).toBe(false);
     expect(surfaceInstanceEnabled(vegaInstance ?? { enabled: true })).toBe(false);
     expect(ENV_PLACEHOLDER_PATTERN.test(vegaInstance?.token ?? "")).toBe(false);
+  });
+});
+
+// ===========================================================================
+// compass#84 (L2) — `.example` template fragments stay INVISIBLE to the loader.
+//
+// The structural-hygiene convention is that a shippable path holds either a
+// `.example` template (zeroed IDs / `__ENV__` placeholders / `<REPLACE_ME>`) or
+// a generic fragment. `loadAgentsDirectory` filters to `*.yaml`/`*.yml`, so a
+// `pier.yaml.example` is never loaded — its zeroed/placeholder content can never
+// disable a live surface or serialize into test/boot output. This regression
+// pins that invariant: if a future refactor of `listYamlFiles` widened the
+// filter to include `.example`, this test fails loudly.
+// ===========================================================================
+describe("loadAgentsDirectory — `.example` fragments are invisible (compass#84 L2)", () => {
+  let dir: string;
+  let agentsDir: string;
+  let personaPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "c84-example-"));
+    agentsDir = join(dir, "agents.d");
+    mkdirSync(agentsDir, { recursive: true });
+    personaPath = join(dir, "persona.md");
+    writeFileSync(personaPath, "# persona\n");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("a *.yaml.example template is not loaded; a sibling *.yaml is", () => {
+    // A real, loadable fragment.
+    writeFileSync(
+      join(agentsDir, "real.yaml"),
+      `
+id: real
+displayName: Real
+persona: ${personaPath}
+trust: []
+presence:
+  discord:
+    enabled: true
+    token: inline-token
+    guildId: "000000000000000000"
+    agentChannelId: "000000000000000000"
+    logChannelId: "000000000000000000"
+`,
+    );
+    // A `.example` template carrying `__ENV__` placeholders + zeroed IDs. If the
+    // loader ever picked this up, the unresolved `__EXAMPLE_*__` placeholders
+    // would (post-compass#84) DISABLE a surface / emit warnings — so a green
+    // assertion here also proves the template never reached the resolver.
+    writeFileSync(
+      join(agentsDir, "pier.yaml.example"),
+      `
+id: pier
+displayName: Pier
+persona: ${personaPath}
+trust: []
+presence:
+  discord:
+    enabled: true
+    token: __EXAMPLE_BOT_TOKEN__
+    guildId: __EXAMPLE_GUILD_ID__
+    agentChannelId: __EXAMPLE_AGENT_CHANNEL_ID__
+    logChannelId: __EXAMPLE_LOG_CHANNEL_ID__
+`,
+    );
+
+    const warnings: SurfaceTokenWarning[] = [];
+    const agents = loadAgentsDirectory(agentsDir, warnings);
+
+    // Only the real fragment loads; the `.example` is invisible.
+    expect(agents.map((a) => a.id)).toEqual(["real"]);
+    // The `.example` placeholders never reached the resolver ⇒ no disabled-surface warnings.
+    expect(warnings).toHaveLength(0);
   });
 });

--- a/src/common/config/resolve-env-placeholders.ts
+++ b/src/common/config/resolve-env-placeholders.ts
@@ -16,8 +16,14 @@
  *   - `presence.discord.token`
  *   - `presence.mattermost.apiToken`
  *   - `presence.slack.botToken`, `presence.slack.appToken`
+ *   - compass#84 (L2): `presence.discord.{guildId, agentChannelId,
+ *     logChannelId, worklogChannelId}` — the surface ID fields. A live
+ *     guild/channel snowflake in a SHIPPABLE fragment (Pier ships to the public
+ *     arc package, and one of its channels is a PRIVATE back-office channel) is
+ *     deployment config, not template content; it resolves from the daemon env
+ *     the same way the token does, with the same fail-SOFT degradation.
  *   - the gateway-binding mirror of the same fields under a `surfaces.yaml`
- *     binding map (`surfaces.{discord,slack,mattermost}[].binding.<token>`),
+ *     binding map (`surfaces.{discord,slack,mattermost}[].binding.<field>`),
  *     which the surface gateway consumes via a SEPARATELY-captured `Surfaces`
  *     object that bypasses the raw-config walk (cortex#1209 review — the
  *     `CORTEX_GATEWAY=1` path was leaking the literal placeholder to
@@ -92,6 +98,33 @@ export const ENV_PLACEHOLDER_PATTERN = /^__([A-Z0-9_]+)__$/;
  * {@link SurfaceTokenWarning} so the boot path can name the surface.
  */
 export type SurfacePlatform = "discord" | "mattermost" | "slack";
+
+/**
+ * compass#84 (L2) — the Discord presence ID fields that may carry an `__ENV__`
+ * placeholder resolved at load, symmetric to the surface *token* fields.
+ *
+ * A live guild/channel snowflake in a SHIPPABLE fragment is deployment config,
+ * not template content: it differs between two principals' deployments, and one
+ * of Pier's channels is a PRIVATE back-office channel. Shipping the fragment
+ * with `__PIER_GUILD_ID__` / `__PIER_AGENT_CHANNEL_ID__` / `__PIER_LOG_CHANNEL_ID__`
+ * keeps the literal ID out of the public repo and resolves it from the daemon
+ * environment at load — identical mechanism to the token, identical fail-SOFT
+ * degradation (surface disabled + `SurfaceTokenWarning`, never a boot crash).
+ *
+ * `worklogChannelId` is optional in the schema; absent ⇒ no-op. The schema
+ * (`z.coerce.string().min(1)`) imposes no digit/regex constraint, so the inert
+ * scrub sentinel ({@link disabledSentinel}) satisfies it the same way the token
+ * sentinels satisfy their fields.
+ */
+export const DISCORD_ID_FIELDS = [
+  "guildId",
+  "agentChannelId",
+  "logChannelId",
+  "worklogChannelId",
+] as const;
+
+/** Membership test used by {@link disabledSentinel} to pick an ID-shaped scrub. */
+const ID_FIELD_SET: ReadonlySet<string> = new Set(DISCORD_ID_FIELDS);
 
 /**
  * Structured record of a surface disabled by cortex#1217 fail-soft degradation.
@@ -201,6 +234,11 @@ function resolveScalarSoft(value: unknown): SoftResolve {
 function disabledSentinel(platform: SurfacePlatform, field: string, envVar: string): string {
   if (platform === "slack" && field === "botToken") return `xoxb-DISABLED-${envVar}`;
   if (platform === "slack" && field === "appToken") return `xapp-DISABLED-${envVar}`;
+  // compass#84 (L2) — an ID field (guildId/channelId) scrubs to a plainly-inert,
+  // non-numeric marker: it can never be mistaken for a real snowflake, embeds the
+  // env var for debuggability, satisfies `.min(1)`, and is not an `__ENV__`
+  // placeholder (so the belt-and-suspenders assert never re-fires on it).
+  if (ID_FIELD_SET.has(field)) return `DISABLED-MISSING-ID-${envVar}`;
   return `DISABLED-MISSING-SECRET-${envVar}`;
 }
 
@@ -278,6 +316,20 @@ export function resolveAgentPresenceTokens(
       `${pathPrefix}.presence.discord.token`,
       warnings,
     );
+    // compass#84 (L2) — resolve the ID placeholder fields on the same block. A
+    // missing ID env var is as disqualifying as a missing token: it disables the
+    // one surface (+ scrubs + warns), never the stack. `softResolvePresenceField`
+    // no-ops on any field absent from the block (worklogChannelId is optional).
+    for (const idField of DISCORD_ID_FIELDS) {
+      softResolvePresenceField(
+        discord,
+        idField,
+        "discord",
+        agent,
+        `${pathPrefix}.presence.discord.${idField}`,
+        warnings,
+      );
+    }
   }
 
   const mattermost = presence.mattermost;
@@ -339,15 +391,19 @@ export function resolveSurfaceTokensInRawConfig(
 }
 
 /**
- * The secret token field(s) under each platform's `surfaces[].binding`. Mirror
- * of the `presence.{platform}` token fields above — the surfaces.yaml binding
- * map carries the SAME credentials in a `binding` sub-object.
+ * The placeholder-resolvable field(s) under each platform's `surfaces[].binding`.
+ * Mirror of the `presence.{platform}` fields above — the surfaces.yaml binding
+ * map carries the SAME credentials (and, post-compass#84, the SAME Discord ID
+ * fields) in a `binding` sub-object. A missing env var on ANY of these drops the
+ * whole binding entry (the gateway has no per-binding `enabled` flag), so the
+ * gateway never builds an adapter from an unresolvable binding.
  */
-const SURFACE_BINDING_TOKEN_FIELDS: { platform: SurfacePlatform; fields: readonly string[] }[] = [
-  { platform: "discord", fields: ["token"] },
-  { platform: "slack", fields: ["botToken", "appToken"] },
-  { platform: "mattermost", fields: ["apiToken"] },
-];
+const SURFACE_BINDING_PLACEHOLDER_FIELDS: { platform: SurfacePlatform; fields: readonly string[] }[] =
+  [
+    { platform: "discord", fields: ["token", "guildId", "agentChannelId", "logChannelId"] },
+    { platform: "slack", fields: ["botToken", "appToken"] },
+    { platform: "mattermost", fields: ["apiToken"] },
+  ];
 
 /**
  * cortex#1209 review (MAJOR) + cortex#1217 — resolve `__ENV__` placeholders in
@@ -373,7 +429,7 @@ export function resolveSurfaceBindingTokens(
   surfaces: Surfaces,
   warnings?: SurfaceTokenWarning[],
 ): void {
-  for (const { platform, fields } of SURFACE_BINDING_TOKEN_FIELDS) {
+  for (const { platform, fields } of SURFACE_BINDING_PLACEHOLDER_FIELDS) {
     const entries = surfaces[platform];
     if (!Array.isArray(entries)) continue;
 


### PR DESCRIPTION
## What

Extend the existing `__ENV__` fail-soft placeholder resolver
(`src/common/config/resolve-env-placeholders.ts`) so it also resolves **Discord
surface ID fields** — `guildId`, `agentChannelId`, `logChannelId`,
`worklogChannelId` — plus their `surfaces.yaml` gateway-binding equivalents,
symmetric to how it already resolves the surface **token** fields.

This is the **L2 (structural layer)** loader change from the software-factory
confidentiality hardening plan (compass#81). It is the enabling change for the
PR 0b remediation (generalizing the pier fragment).

## Why

A live guild/channel snowflake committed in a shippable agent fragment is
**deployment config, not template content**: it differs between two principals'
deployments, and one of the fragment's channels is a **private back-office
channel**. Shipping the fragment with `__PIER_GUILD_ID__` /
`__PIER_AGENT_CHANNEL_ID__` / `__PIER_LOG_CHANNEL_ID__` keeps the literal ID out
of the public repo and resolves it from the daemon environment at load.

## Behaviour (fail-SOFT, per cortex#1217)

- A **resolvable** ID placeholder → real value; surface stays enabled.
- An **inline** (non-placeholder) ID → passes through byte-identical.
- A **missing** ID env var → that ONE surface is disabled (`enabled:false`), the
  literal is scrubbed to an inert `DISABLED-MISSING-ID-<ENVVAR>` sentinel
  (non-numeric, embeds the env var, satisfies the `.min(1)` schema, not itself an
  `__ENV__` placeholder), and a `SurfaceTokenWarning` is collected — **never a
  boot crash**. Identical semantics to the token path.
- Gateway-binding path drops the unresolvable binding entry (no per-binding
  `enabled` flag), so the gateway never builds an adapter from it.

## Design note (placeholder form)

The repo's mechanism is `__ENV__` (double-underscore), governed by
`ENV_PLACEHOLDER_PATTERN = /^__([A-Z0-9_]+)__$/`. The design doc §4 L2 says
"extends the `__ENV__` fail-soft resolution to guild/channel/team IDs", so this
PR extends that mechanism rather than introducing a parallel `${...}` resolver.

## Tests

- ID-field resolve / inline-passthrough / fail-soft-disable (per-agent presence
  **and** gateway binding paths)
- Regression test pinning that `*.yaml.example` fragments stay **invisible** to
  `loadAgentsDirectory` (the structural-hygiene template invariant)
- All new tests use **synthetic all-zero IDs** only — no real identifiers

## Verification

- `bun test src/common/config src/adapters/web` → **312 pass / 0 fail**
- `bunx tsc --noEmit` → clean
- `scripts/check-carveouts.sh` → PASS

Part of compass#81 (L2). PR 0b (stacked on this branch) does the pier-fragment
remediation and closes compass#84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)