### PR TITLE
fix(agents): C-conf-0b — generalize pier fragment + neutralize fixture IDs (compass#84 L2, G1)

### DIFF
--- a/agents.d/pier.yaml
+++ b/agents.d/pier.yaml
@@ -1,6 +1,14 @@
 # ~/.config/cortex/agents.d/pier.yaml
 #
+# audience: generic
+#
 # Pier — onboarding-concierge assistant (ADR-0015, cortex#1142)
+#
+# This fragment ships in the PUBLIC arc package. It carries NO live deployment
+# identifiers: the Discord bot token AND every guild/channel id are `__ENV__`
+# placeholders resolved at cortex config-load from the daemon environment
+# (compass#84 / confidentiality L2). Set the PIER_* env vars before install; an
+# unset id/token fails SOFT — Pier's Discord surface is disabled, not a crash.
 #
 # This fragment is rendered by `arc install pier` into the installing
 # principal's `~/.config/cortex/agents.d/pier.yaml`.  It MUST NOT be
@@ -49,26 +57,29 @@ runtime:
     - chat                  # responds to newcomer messages in #onboard-your-fleet
 
 # Discord presence — bound to the metafactory community guild.
-# The bot token is a secret resolved at install time from the host
-# environment or principal vault.  It is NEVER stored in this file.
+# Every identifier below is a resolve-at-install `__ENV__` placeholder; NO live
+# token or snowflake is stored in this shippable fragment. All resolve at cortex
+# config-load from the daemon environment (compass#84 / L2). An unset value fails
+# SOFT — the Discord surface is disabled, the rest of the stack still boots.
 #
 # Three-channel topology (the public-entry / private-back-office split):
-#   guildId:        1505549701674700991  (The Metafactory — community guild)
-#   agentChannelId: 1517154685595942972  (#onboard-your-fleet — PUBLIC entry;
-#                                          newcomers must reach Pier here before
-#                                          they hold the community-fleet role)
-#   logChannelId:   1514679294553751613  (#assistant-fleet-onboarding — PRIVATE
-#                                          back-office; admission audit trail,
-#                                          principal + Pier only)
+#   guildId        (__PIER_GUILD_ID__)         — the metafactory community guild
+#   agentChannelId (__PIER_AGENT_CHANNEL_ID__) — the PUBLIC entry channel;
+#                    newcomers must reach Pier here before they hold the
+#                    community-fleet role
+#   logChannelId   (__PIER_LOG_CHANNEL_ID__)   — the PRIVATE back-office channel;
+#                    admission audit trail, principal + Pier only (never commit
+#                    its literal id)
 #
-# env var:   PIER_BOT_TOKEN         — set by the operator before arc install
+# env vars (set by the operator before arc install; see arc-manifest-pier.yaml):
+#   PIER_BOT_TOKEN · PIER_GUILD_ID · PIER_AGENT_CHANNEL_ID · PIER_LOG_CHANNEL_ID
 presence:
   discord:
     enabled: true
-    token: ${PIER_BOT_TOKEN}          # placeholder; resolved at cortex load
-    guildId: "1505549701674700991"        # The Metafactory community guild
-    agentChannelId: "1517154685595942972" # #onboard-your-fleet — public entry
-    logChannelId: "1514679294553751613"   # #assistant-fleet-onboarding — private back-office
+    token: __PIER_BOT_TOKEN__               # placeholder; resolved at cortex load
+    guildId: __PIER_GUILD_ID__              # resolve-at-install; community guild
+    agentChannelId: __PIER_AGENT_CHANNEL_ID__  # resolve-at-install; public entry
+    logChannelId: __PIER_LOG_CHANNEL_ID__   # resolve-at-install; private back-office
     dmOwner: false                    # Pier never claims DMs; it answers the public channel
     contextDepth: 10
     surfaceSubjects: []               # no raw envelope surface — Pier posts only via its persona

--- a/arc-manifest-pier.yaml
+++ b/arc-manifest-pier.yaml
@@ -1,6 +1,12 @@
 # arc-manifest-pier.yaml — Pier, the community onboarding concierge
 #
+# audience: generic
+#
 # arc install pier
+#
+# This manifest ships in the PUBLIC arc package and carries NO live deployment
+# identifiers: the bot token and every guild/channel id are resolve-at-install
+# `__ENV__` placeholders (compass#84 / L2).
 #
 # This is the arc package manifest for the Pier sub-bot.  It follows the
 # design-arc-agent-bots.md §4 schema: type: agent, targets: [cortex],
@@ -20,16 +26,20 @@
 #        no Skill — so it is structurally incapable of running
 #        `cortex network admit` / `cortex network secret` (ADR-0015 airgap).)
 #
-# REQUIRED ENV VAR (set before arc install):
-#   PIER_BOT_TOKEN  — the Discord bot token for the Pier bot application.
-#                     This is never stored in any file; it is resolved by
-#                     cortex's config loader from the env at startup.
-#                     Obtain the token from the Discord developer portal
-#                     for the "Pier" application in the metafactory org.
+# REQUIRED ENV VARS (set before arc install):
+#   PIER_BOT_TOKEN         — the Discord bot token for the Pier application.
+#                            Obtain it from the Discord developer portal for the
+#                            "Pier" application in the metafactory org.
+#   PIER_GUILD_ID          — the metafactory community guild id.
+#   PIER_AGENT_CHANNEL_ID  — the PUBLIC entry channel id.
+#   PIER_LOG_CHANNEL_ID    — the PRIVATE back-office channel id (admission audit).
+# None are stored in any shippable file; cortex's config loader resolves each
+# from the daemon environment at startup (compass#84 / L2). An unset value fails
+# SOFT — Pier's Discord surface is disabled, the rest of the stack still boots.
 #
 # NO-GOING-LIVE CONSTRAINTS (P1):
 #   - Do not execute `arc install` against a live stack until the principal
-#     has set PIER_BOT_TOKEN and reviewed the persona.
+#     has set the PIER_* env vars and reviewed the persona.
 #   - No `arc install` execution, no `cortex creds issue` for Pier, no
 #     Discord bot login.  This manifest is install-READY; going-live is a
 #     separate operator step documented in §GOING-LIVE below.
@@ -64,23 +74,25 @@ identity:
   trust: [luna]                # Pier trusts Luna (the principal's primary DA) to delegate tasks
 
 # Discord presence — community guild only.
-# Token is injected at runtime from env; never hardcoded.
-# guildId and the channel ids are public identifiers (no-secret).
+# Every identifier is a resolve-at-install `__ENV__` placeholder; NO live token
+# or snowflake is stored in this shippable manifest (compass#84 / L2). The
+# logChannelId in particular is a PRIVATE back-office channel — never commit its
+# literal id. All values resolve at cortex config-load from the daemon env.
 #
 # Three-channel topology (public-entry / private-back-office split) — MUST match
 # agents.d/pier.yaml:
-#   agentChannelId: #onboard-your-fleet      (PUBLIC entry — newcomers reach Pier
-#                                             here BEFORE they hold any role)
-#   logChannelId:   #assistant-fleet-onboarding (PRIVATE back-office — admission
-#                                             audit trail, principal + Pier only)
+#   agentChannelId (__PIER_AGENT_CHANNEL_ID__) — PUBLIC entry; newcomers reach
+#                    Pier here BEFORE they hold any role
+#   logChannelId   (__PIER_LOG_CHANNEL_ID__)   — PRIVATE back-office; admission
+#                    audit trail, principal + Pier only
 presence:
   discord:
     enabled: true
-    guildId: "1505549701674700991"          # The Metafactory community guild
-    agentChannelId: "1517154685595942972"   # #onboard-your-fleet — public entry
-    logChannelId: "1514679294553751613"     # #assistant-fleet-onboarding — private back-office
-    # token is resolved at cortex load from env PIER_BOT_TOKEN
-    # (declared in agents.d/pier.yaml as ${PIER_BOT_TOKEN})
+    guildId: __PIER_GUILD_ID__               # resolve-at-install; community guild
+    agentChannelId: __PIER_AGENT_CHANNEL_ID__   # resolve-at-install; public entry
+    logChannelId: __PIER_LOG_CHANNEL_ID__    # resolve-at-install; private back-office
+    # token + all ids resolve at cortex load from the daemon env
+    # (agents.d/pier.yaml declares the token as __PIER_BOT_TOKEN__)
 
 # provides — files dropped by arc install (§4 manifest schema)
 provides:
@@ -101,7 +113,7 @@ provides:
 # design doc where the bot "appears in dashboard" without a separate cred.
 lifecycle:
   preinstall:
-    - scripts/pier/check-cortex-version.sh   # verifies cortex >= 5.24.0 + PIER_BOT_TOKEN set
+    - scripts/pier/check-cortex-version.sh   # verifies cortex >= 5.24.0 + PIER_* env vars set
   postinstall:
     - scripts/pier/signal-cortex-reload.sh   # FIRST — daemon registers Pier from agents.d/
 
@@ -122,8 +134,13 @@ dependencies:
 # 1. Create the "Pier" Discord application in the Discord developer portal
 #    for the metafactory org.  Note the bot token.
 #
-# 2. Set the env var on the host that runs cortex:
-#      export PIER_BOT_TOKEN=<token>           # or write to ~/.config/cortex/.env
+# 2. Set the env vars on the host that runs cortex (the DAEMON's environment —
+#    the launchd plist EnvironmentVariables or ~/.config/cortex/.env — not just
+#    the install shell; cortex resolves them at config-load, after install):
+#      export PIER_BOT_TOKEN=<token>
+#      export PIER_GUILD_ID=<community-guild-id>
+#      export PIER_AGENT_CHANNEL_ID=<public-entry-channel-id>
+#      export PIER_LOG_CHANNEL_ID=<private-back-office-channel-id>
 #
 # 3. In the metafactory-community guild (Discord admin):
 #    a. Create the `community-fleet` role (no guild-wide perms; channel overrides only)

--- a/blueprint.yaml
+++ b/blueprint.yaml
@@ -130,7 +130,7 @@ features:
       Any web app becomes a cortex-backed bot by POSTing to POST /message and
       receiving responses via a configurable broadcastUrl. Includes WebBindingSchema
       + WebSurfaceBindingSchema types, gateway-adapter factory wiring, and a full
-      45-test suite. Completely AMT-agnostic — a second tenant binds with its own
+      45-test suite. Completely tenant-agnostic — a second tenant binds with its own
       instanceId + broadcastUrl + agent, zero adapter-code changes.
 
   I-100:

--- a/scripts/pier/check-cortex-version.sh
+++ b/scripts/pier/check-cortex-version.sh
@@ -3,7 +3,17 @@
 #
 # Verifies:
 #   1. cortex >= 5.24.0 is installed (agents.d/ support + cortex network admit)
-#   2. PIER_BOT_TOKEN is set (required for Discord presence at cortex load time)
+#   2. PIER_BOT_TOKEN is set (required — the Discord surface secret)
+#   3. PIER_GUILD_ID / PIER_AGENT_CHANNEL_ID / PIER_LOG_CHANNEL_ID are set
+#      (WARN-only — an unset id fails SOFT at cortex load: only Pier's Discord
+#      surface is disabled, the stack still boots; compass#84 / L2)
+#
+# NOTE: cortex resolves the PIER_* placeholders at config-LOAD, from the cortex
+# DAEMON's environment (the launchd plist EnvironmentVariables, or
+# ~/.config/cortex/.env) — NOT this install shell. This gate can only read the
+# install shell, so a green check is necessary but not sufficient: the same vars
+# must be present where the daemon runs. (Full launchd-plist introspection is a
+# follow-up.)
 #
 # arc install pier runs this BEFORE dropping any files. If this fails,
 # the install aborts cleanly with no files written.
@@ -38,7 +48,7 @@ if (( MAJOR < REQUIRED_MAJOR || (MAJOR == REQUIRED_MAJOR && MINOR < REQUIRED_MIN
   exit 1
 fi
 
-# ── 3. Check PIER_BOT_TOKEN is set ────────────────────────────────────────
+# ── 3. Check PIER_BOT_TOKEN is set (hard requirement — the surface secret) ──
 if [[ -z "${PIER_BOT_TOKEN:-}" ]]; then
   echo "pier preinstall ERROR: PIER_BOT_TOKEN is not set." >&2
   echo "  Set it before installing:" >&2
@@ -47,5 +57,29 @@ if [[ -z "${PIER_BOT_TOKEN:-}" ]]; then
   exit 1
 fi
 
-echo "pier preinstall: cortex ${CORTEX_VERSION} OK; PIER_BOT_TOKEN set OK"
+# ── 4. Warn on any unset surface ID env var (compass#84 / L2 — fail SOFT) ───
+# A missing guild/channel id does NOT abort the install: at cortex load an unset
+# id disables ONLY Pier's Discord surface (the stack still boots). Warn clearly
+# so the operator sets them in the DAEMON's environment before going live.
+ID_VARS_UNSET=()
+for var in PIER_GUILD_ID PIER_AGENT_CHANNEL_ID PIER_LOG_CHANNEL_ID; do
+  if [[ -z "${!var:-}" ]]; then
+    ID_VARS_UNSET+=("$var")
+  fi
+done
+
+if (( ${#ID_VARS_UNSET[@]} > 0 )); then
+  echo "pier preinstall WARN: unset Pier surface id env var(s): ${ID_VARS_UNSET[*]}" >&2
+  echo "  Pier's Discord surface will be DISABLED at cortex load until these are set" >&2
+  echo "  in the cortex DAEMON's environment (launchd plist EnvironmentVariables or" >&2
+  echo "  ~/.config/cortex/.env — not just this install shell), e.g.:" >&2
+  for var in "${ID_VARS_UNSET[@]}"; do
+    echo "    export ${var}=<snowflake>" >&2
+  done
+  echo "  The install continues (the missing id fails SOFT, never a crash)." >&2
+  echo "pier preinstall: cortex ${CORTEX_VERSION} OK; PIER_BOT_TOKEN set OK; surface ids INCOMPLETE (see WARN)"
+  exit 0
+fi
+
+echo "pier preinstall: cortex ${CORTEX_VERSION} OK; PIER_BOT_TOKEN + all PIER_* surface ids set OK"
 exit 0

--- a/src/__tests__/cortex.stack-signing-boot.test.ts
+++ b/src/__tests__/cortex.stack-signing-boot.test.ts
@@ -110,7 +110,7 @@ function withCapturedConsoleLog<T>(fn: () => Promise<T>): Promise<{ result: T; l
 describe("startCortex — stack-signing boot warning (cortex#324)", () => {
   // Isolate from the principal's real ~/.config/cortex/agents.d/. startCortex
   // falls back to that dir when `agentsDir` is omitted, which leaked installed
-  // fragments (e.g. an amt-facilitator agent trusting `luna`) into these tests
+  // fragments (e.g. an acme-facilitator agent trusting `luna`) into these tests
   // and tripped trust-closure validation locally while passing in CI. Point the
   // registry assembly at an empty dir so boot sees only the in-memory config.
   const emptyAgentsDir = mkdtempSync(join(tmpdir(), "cortex-stack-signing-empty-agents-"));

--- a/src/adapters/web/__tests__/web-adapter.test.ts
+++ b/src/adapters/web/__tests__/web-adapter.test.ts
@@ -51,7 +51,7 @@ async function withBroadcastCapture(fn: () => Promise<void>): Promise<void> {
 function makeBinding(overrides: Partial<WebBinding> = {}): WebBinding {
   return {
     host: "127.0.0.1",
-    instanceId: "amt",
+    instanceId: "acme",
     port: 0, // ephemeral — overridden per test
     broadcastUrl: "http://localhost:9999/broadcast",
     transport: "ws",
@@ -62,7 +62,7 @@ function makeBinding(overrides: Partial<WebBinding> = {}): WebBinding {
 
 function makeInfra(overrides: Partial<WebAdapterInfra> = {}): WebAdapterInfra {
   return {
-    instanceId: "web:amt",
+    instanceId: "web:acme",
     principal: {},
     ...overrides,
   };
@@ -89,14 +89,14 @@ describe("WebAdapter — identity", () => {
   });
 
   test("instanceId comes from infra", () => {
-    const adapter = new WebAdapter(makeSyntheticAgent(), makeBinding(), makeInfra({ instanceId: "web:amt" }));
-    expect(adapter.instanceId).toBe("web:amt");
+    const adapter = new WebAdapter(makeSyntheticAgent(), makeBinding(), makeInfra({ instanceId: "web:acme" }));
+    expect(adapter.instanceId).toBe("web:acme");
   });
 
   test("getPlatformUserId returns stable web:{instanceId}", async () => {
-    const adapter = new WebAdapter(makeSyntheticAgent(), makeBinding(), makeInfra({ instanceId: "web:amt" }));
+    const adapter = new WebAdapter(makeSyntheticAgent(), makeBinding(), makeInfra({ instanceId: "web:acme" }));
     const id = await adapter.getPlatformUserId();
-    expect(id).toBe("web:web:amt");
+    expect(id).toBe("web:web:acme");
   });
 });
 
@@ -115,7 +115,7 @@ describe("WebAdapter — HTTP ingress", () => {
     adapter = new WebAdapter(
       makeSyntheticAgent(),
       makeBinding({ port: 0, authScheme: "none" }),
-      makeInfra({ instanceId: "web:amt" }),
+      makeInfra({ instanceId: "web:acme" }),
     );
     await adapter.start(async (msg) => {
       messages.push(msg);
@@ -132,7 +132,7 @@ describe("WebAdapter — HTTP ingress", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { status: string; adapter: string };
     expect(body.status).toBe("ok");
-    expect(body.adapter).toBe("web:amt");
+    expect(body.adapter).toBe("web:acme");
   });
 
   test("unknown path returns 404", async () => {
@@ -192,7 +192,7 @@ describe("WebAdapter — HTTP ingress", () => {
     expect(messages).toHaveLength(1);
     const msg = messages[0]!;
     expect(msg.platform).toBe("web");
-    expect(msg.instanceId).toBe("web:amt");
+    expect(msg.instanceId).toBe("web:acme");
     expect(msg.content).toBe("hello cortex");
     expect(msg.channelId).toBe("general");
     expect(msg.threadId).toBe("thread-123");
@@ -407,23 +407,23 @@ describe("WebAdapter — auth extraction", () => {
 
 describe("WebAdapter — outbound broadcast", () => {
   const binding = makeBinding({
-    instanceId: "amt",
+    instanceId: "acme",
     broadcastUrl: "http://localhost:9999/broadcast",
     authScheme: "none",
   });
-  const infra = makeInfra({ instanceId: "web:amt" });
+  const infra = makeInfra({ instanceId: "web:acme" });
 
   test("postResponse POSTs correct payload shape", async () => {
     const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
     await withBroadcastCapture(async () => {
       await adapter.postResponse(
-        { instanceId: "web:amt", channelId: "general", threadId: "t1" },
+        { instanceId: "web:acme", channelId: "general", threadId: "t1" },
         "Hello from cortex",
       );
     });
     expect(BROADCAST_CAPTURES).toHaveLength(1);
     const payload = BROADCAST_CAPTURES[0]?.body as Record<string, unknown>;
-    expect(payload.adapter_instance).toBe("web:amt");
+    expect(payload.adapter_instance).toBe("web:acme");
     expect(payload.type).toBe("response");
     expect(payload.text).toBe("Hello from cortex");
     expect((payload.target as Record<string, unknown>).channel).toBe("general");
@@ -434,7 +434,7 @@ describe("WebAdapter — outbound broadcast", () => {
     const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
     await withBroadcastCapture(async () => {
       await adapter.postResponse(
-        { instanceId: "web:amt", channelId: "general" },
+        { instanceId: "web:acme", channelId: "general" },
         "Response",
       );
     });
@@ -446,7 +446,7 @@ describe("WebAdapter — outbound broadcast", () => {
     const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
     await withBroadcastCapture(async () => {
       await adapter.sendProgress(
-        { instanceId: "web:amt", channelId: "general" },
+        { instanceId: "web:acme", channelId: "general" },
         "Working...",
       );
     });
@@ -458,7 +458,7 @@ describe("WebAdapter — outbound broadcast", () => {
   test("clearProgress POSTs type=clear_progress without text", async () => {
     const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
     await withBroadcastCapture(async () => {
-      await adapter.clearProgress({ instanceId: "web:amt", channelId: "general" });
+      await adapter.clearProgress({ instanceId: "web:acme", channelId: "general" });
     });
     const payload = BROADCAST_CAPTURES[0]?.body as Record<string, unknown>;
     expect(payload.type).toBe("clear_progress");
@@ -479,14 +479,14 @@ describe("WebAdapter — outbound broadcast", () => {
     const failBinding = makeBinding({ broadcastUrl: "http://localhost:1/unreachable" });
     const adapter = new WebAdapter(makeSyntheticAgent(), failBinding, infra);
     // Must not reject — await directly; any thrown error would fail the test
-    await adapter.postResponse({ instanceId: "web:amt", channelId: "ch" }, "text");
+    await adapter.postResponse({ instanceId: "web:acme", channelId: "ch" }, "text");
   });
 
   test("broadcastToken set → POST includes Authorization: Bearer header", async () => {
     const tokenBinding = makeBinding({ broadcastToken: "cortex-svc-secret" });
     const adapter = new WebAdapter(makeSyntheticAgent(), tokenBinding, infra);
     await withBroadcastCapture(async () => {
-      await adapter.postResponse({ instanceId: "web:amt", channelId: "ch" }, "text");
+      await adapter.postResponse({ instanceId: "web:acme", channelId: "ch" }, "text");
     });
     expect(BROADCAST_CAPTURES[0]?.headers?.Authorization).toBe("Bearer cortex-svc-secret");
   });
@@ -495,7 +495,7 @@ describe("WebAdapter — outbound broadcast", () => {
     // binding has no broadcastToken (localhost — no outbound service auth)
     const adapter = new WebAdapter(makeSyntheticAgent(), binding, infra);
     await withBroadcastCapture(async () => {
-      await adapter.postResponse({ instanceId: "web:amt", channelId: "ch" }, "text");
+      await adapter.postResponse({ instanceId: "web:acme", channelId: "ch" }, "text");
     });
     expect(BROADCAST_CAPTURES[0]?.headers?.Authorization).toBeUndefined();
   });
@@ -510,12 +510,12 @@ describe("WebAdapter — interface contract", () => {
 
   test("sendTyping is a no-op", async () => {
     // Must resolve without throwing
-    await adapter.sendTyping({ instanceId: "web:amt", channelId: "ch" });
+    await adapter.sendTyping({ instanceId: "web:acme", channelId: "ch" });
   });
 
   test("fetchContext returns empty array", async () => {
     const ctx = await adapter.fetchContext(
-      { platform: "web", instanceId: "web:amt", authorId: "u1", authorName: "U",
+      { platform: "web", instanceId: "web:acme", authorId: "u1", authorName: "U",
         content: "x", channelId: "ch", attachments: [], timestamp: new Date() },
       10,
     );
@@ -529,18 +529,18 @@ describe("WebAdapter — interface contract", () => {
 
   test("createThread returns a ResponseTarget with threadId", async () => {
     const msg: InboundMessage = {
-      platform: "web", instanceId: "web:amt", authorId: "u1", authorName: "U",
+      platform: "web", instanceId: "web:acme", authorId: "u1", authorName: "U",
       content: "x", channelId: "channel-1", attachments: [], timestamp: new Date(),
     };
     const target = await adapter.createThread(msg, "thread-name");
-    expect(target.instanceId).toBe("web:amt");
+    expect(target.instanceId).toBe("web:acme");
     expect(target.channelId).toBe("channel-1");
     expect(target.threadId).toBe("channel-1"); // no threadId on msg → uses channelId
   });
 
   test("createThread preserves existing threadId", async () => {
     const msg: InboundMessage = {
-      platform: "web", instanceId: "web:amt", authorId: "u1", authorName: "U",
+      platform: "web", instanceId: "web:acme", authorId: "u1", authorName: "U",
       content: "x", channelId: "channel-1", threadId: "thread-root",
       attachments: [], timestamp: new Date(),
     };
@@ -553,7 +553,7 @@ describe("WebAdapter — interface contract", () => {
     // The adapter must pass through whatever `resolvePolicyAccess` decides;
     // it must NOT short-circuit to allow-all.
     const msg: InboundMessage = {
-      platform: "web", instanceId: "web:amt", authorId: "u1", authorName: "U",
+      platform: "web", instanceId: "web:acme", authorId: "u1", authorName: "U",
       content: "x", channelId: "ch", attachments: [], timestamp: new Date(),
     };
     const decision = adapter.resolveAccess(msg);
@@ -571,10 +571,10 @@ describe("WebBindingSchema — validation", () => {
 
   test("valid binding parses correctly with defaults", () => {
     const result = WebBindingSchema.parse({
-      instanceId: "amt",
+      instanceId: "acme",
       broadcastUrl: "http://example.com/broadcast",
     });
-    expect(result.instanceId).toBe("amt");
+    expect(result.instanceId).toBe("acme");
     expect(result.host).toBe("127.0.0.1"); // default — loopback only
     expect(result.port).toBe(8090); // default
     expect(result.transport).toBe("ws"); // default
@@ -583,7 +583,7 @@ describe("WebBindingSchema — validation", () => {
 
   test("host defaults to loopback", () => {
     const r = WebBindingSchema.parse({
-      instanceId: "amt",
+      instanceId: "acme",
       broadcastUrl: "http://x.com/b",
     });
     expect(r.host).toBe("127.0.0.1");
@@ -591,7 +591,7 @@ describe("WebBindingSchema — validation", () => {
 
   test("host override is honoured", () => {
     const r = WebBindingSchema.parse({
-      instanceId: "amt",
+      instanceId: "acme",
       broadcastUrl: "http://x.com/b",
       host: "0.0.0.0",
     });
@@ -606,19 +606,19 @@ describe("WebBindingSchema — validation", () => {
 
   test("missing broadcastUrl fails validation", () => {
     expect(() =>
-      WebBindingSchema.parse({ instanceId: "amt" }),
+      WebBindingSchema.parse({ instanceId: "acme" }),
     ).toThrow();
   });
 
   test("invalid broadcastUrl (not http) fails validation", () => {
     expect(() =>
-      WebBindingSchema.parse({ instanceId: "amt", broadcastUrl: "ftp://example.com" }),
+      WebBindingSchema.parse({ instanceId: "acme", broadcastUrl: "ftp://example.com" }),
     ).toThrow();
   });
 
   test("invalid transport fails validation", () => {
     expect(() =>
-      WebBindingSchema.parse({ instanceId: "amt", broadcastUrl: "http://x.com", transport: "grpc" }),
+      WebBindingSchema.parse({ instanceId: "acme", broadcastUrl: "http://x.com", transport: "grpc" }),
     ).toThrow();
   });
 });
@@ -635,14 +635,14 @@ describe("SurfacesSchema — web bindings", () => {
         {
           agent: "ivy",
           binding: {
-            instanceId: "amt",
+            instanceId: "acme",
             broadcastUrl: "http://example.com/broadcast",
           },
         },
       ],
     });
     expect(result.web).toHaveLength(1);
-    expect(result.web?.[0]?.binding.instanceId).toBe("amt");
+    expect(result.web?.[0]?.binding.instanceId).toBe("acme");
   });
 
   test("unknown top-level key still rejects (strict mode preserved)", () => {
@@ -657,7 +657,7 @@ describe("SurfacesSchema — web bindings", () => {
       web: [
         {
           agent: "ivy",
-          binding: { instanceId: "amt", broadcastUrl: "http://x.com" },
+          binding: { instanceId: "acme", broadcastUrl: "http://x.com" },
         },
       ],
     });
@@ -718,7 +718,7 @@ describe("buildGatewayAdapters — web bindings", () => {
           agent: "ivy",
           binding: {
             host: "127.0.0.1",
-            instanceId: "amt",
+            instanceId: "acme",
             broadcastUrl: "http://example.com/broadcast",
             port: 8090,
             transport: "ws",
@@ -733,7 +733,7 @@ describe("buildGatewayAdapters — web bindings", () => {
       factory,
     });
     expect(adapters).toHaveLength(1);
-    expect(calls[0]?.instanceId).toBe("web:amt");
+    expect(calls[0]?.instanceId).toBe("web:acme");
     expect(calls[0]?.platform).toBe("web");
   });
 
@@ -777,13 +777,13 @@ describe("buildGatewayAdapters — web bindings", () => {
       },
     };
     buildGatewayAdapters(
-      { web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "amt", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }] },
+      { web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "acme", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }] },
       { principal: "andreas", runtime: RUNTIME_STUB, factory },
     );
     expect(capturedSource).toMatchObject({
       principal: "andreas",
       agent: "gateway",
-      instance: "web:amt",
+      instance: "web:acme",
     });
   });
 
@@ -799,11 +799,11 @@ describe("buildGatewayAdapters — web bindings", () => {
       },
     };
     buildGatewayAdapters(
-      { web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "amt", broadcastUrl: "http://x.com/b", port: 8090, transport: "sse", authScheme: "header", authHeader: "X-User" } }] },
+      { web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "acme", broadcastUrl: "http://x.com/b", port: 8090, transport: "sse", authScheme: "header", authHeader: "X-User" } }] },
       { principal: "andreas", runtime: RUNTIME_STUB, factory },
     );
     const b = capturedWebBinding as Record<string, unknown>;
-    expect(b.instanceId).toBe("amt");
+    expect(b.instanceId).toBe("acme");
     expect(b.broadcastUrl).toBe("http://x.com/b");
     expect(b.transport).toBe("sse");
     expect(b.authScheme).toBe("header");
@@ -833,18 +833,18 @@ describe("buildGatewayAdapters — web bindings", () => {
 });
 
 // =============================================================================
-// 9. AMT-agnostic verification
+// 9. tenant-agnostic verification
 // =============================================================================
 
-describe("WebAdapter — AMT agnosticism", () => {
-  test("adapter source contains no AMT-specific strings", () => {
-    // Verify the adapter module text has no hardcoded AMT references.
+describe("WebAdapter — tenant agnosticism", () => {
+  test("adapter source contains no tenant-specific strings", () => {
+    // Verify the adapter module text has no hardcoded tenant references.
     // We do this by checking the exported constructor behaves identically
     // for any tenant name.
     const a1 = new WebAdapter(
       makeSyntheticAgent("ivy"),
-      makeBinding({ instanceId: "amt" }),
-      makeInfra({ instanceId: "web:amt" }),
+      makeBinding({ instanceId: "acme" }),
+      makeInfra({ instanceId: "web:acme" }),
     );
     const a2 = new WebAdapter(
       makeSyntheticAgent("oak"),
@@ -852,7 +852,7 @@ describe("WebAdapter — AMT agnosticism", () => {
       makeInfra({ instanceId: "web:acme-bot" }),
     );
     expect(a1.platform).toBe(a2.platform);
-    expect(a1.instanceId).toBe("web:amt");
+    expect(a1.instanceId).toBe("web:acme");
     expect(a2.instanceId).toBe("web:acme-bot");
   });
 

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -12,7 +12,7 @@
  * Accepts `POST /message` with JSON body `{ channel, thread?, body, user? }`.
  * Maps to cortex's neutral `InboundMessage` with:
  *   - `platform: "web"`
- *   - `instanceId`: from the binding (e.g. `"web:amt"`)
+ *   - `instanceId`: from the binding (e.g. `"web:acme"`)
  *   - `authorId`: derived from platform-signed headers ONLY — NEVER from the
  *     request body (CF-Access JWT `sub`, or a trusted internal header)
  *   - `channelId` / `threadId`: from the body `channel` / `thread` fields
@@ -60,7 +60,7 @@
  *
  * ## Reusability
  *
- * No AMT-specific logic lives here. A second web app binds with its own
+ * No tenant-specific logic lives here. A second web app binds with its own
  * `instanceId` + `broadcastUrl` + agent, zero surface-code changes.
  */
 

--- a/src/cli/cortex/commands/__tests__/pier-fragment.test.ts
+++ b/src/cli/cortex/commands/__tests__/pier-fragment.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { readFileSync, existsSync } from "fs";
-import { join, dirname } from "path";
+import { join } from "path";
 import { parse as parseYaml } from "yaml";
 
 // ---------------------------------------------------------------------------
@@ -110,39 +110,48 @@ describe("Pier agent fragment (agents.d/pier.yaml)", () => {
     expect(discord.enabled).toBe(true);
   });
 
-  test("presence.discord.guildId is the community guild snowflake", () => {
+  // compass#84 (L2) — the shippable fragment carries NO live snowflakes. Every
+  // surface id is an `__ENV__` placeholder resolved at cortex load from the
+  // daemon environment (the guild id, the public entry channel, and — most
+  // sensitively — the PRIVATE back-office channel). These assertions pin the
+  // placeholder form; a regression that re-hardcodes a literal id fails here.
+  test("presence.discord.guildId is a resolve-at-install placeholder (no literal snowflake)", () => {
     const f = loadFragment();
     const presence = f.presence as Record<string, unknown>;
     const discord = presence.discord as Record<string, unknown>;
-    // The Metafactory community guild (metafactory-community Discord server)
-    expect(discord.guildId).toBe("1505549701674700991");
+    expect(discord.guildId).toBe("__PIER_GUILD_ID__");
+    // defence in depth: never a bare 17-20 digit snowflake
+    expect(discord.guildId as string).not.toMatch(/^\d{17,20}$/);
   });
 
-  test("presence.discord.agentChannelId is #onboard-your-fleet (PUBLIC entry channel)", () => {
+  test("presence.discord.agentChannelId (PUBLIC entry) is a placeholder", () => {
     const f = loadFragment();
     const presence = f.presence as Record<string, unknown>;
     const discord = presence.discord as Record<string, unknown>;
-    // Pier must greet newcomers in a channel they can reach BEFORE holding the
-    // community-fleet role — the public entry, not the gated working surface.
-    expect(discord.agentChannelId).toBe("1517154685595942972");
+    // Pier greets newcomers in a channel they can reach BEFORE holding the
+    // community-fleet role — the public entry, shipped as a placeholder.
+    expect(discord.agentChannelId).toBe("__PIER_AGENT_CHANNEL_ID__");
+    expect(discord.agentChannelId as string).not.toMatch(/^\d{17,20}$/);
   });
 
-  test("presence.discord.logChannelId is #assistant-fleet-onboarding (PRIVATE back-office)", () => {
+  test("presence.discord.logChannelId (PRIVATE back-office) is a placeholder", () => {
     const f = loadFragment();
     const presence = f.presence as Record<string, unknown>;
     const discord = presence.discord as Record<string, unknown>;
-    // Admission audit trail lands in the private back-office (principal + Pier only),
-    // distinct from the public entry channel.
-    expect(discord.logChannelId).toBe("1514679294553751613");
+    // Admission audit trail lands in the private back-office (principal + Pier
+    // only). This id is the most sensitive — it MUST never be committed literally.
+    expect(discord.logChannelId).toBe("__PIER_LOG_CHANNEL_ID__");
+    expect(discord.logChannelId as string).not.toMatch(/^\d{17,20}$/);
   });
 
   test("presence.discord.token references env var placeholder (not a real token)", () => {
     const f = loadFragment();
     const presence = f.presence as Record<string, unknown>;
     const discord = presence.discord as Record<string, unknown>;
-    // Must be an env-var placeholder, never a hardcoded token
+    // Must be an `__ENV__` placeholder (the form the cortex config loader
+    // resolves), never a hardcoded token.
     const token = discord.token as string;
-    expect(token).toMatch(/\$\{.*TOKEN.*\}/);
+    expect(token).toMatch(/^__[A-Z0-9_]*TOKEN[A-Z0-9_]*__$/);
   });
 
   test("presence.discord.dmOwner is false (Pier is public-channel only)", () => {
@@ -305,10 +314,13 @@ describe("Pier arc-manifest (arc-manifest-pier.yaml)", () => {
 describe("Pier AIRGAP — structurally cannot admit or hold a secret", () => {
   const MANIFEST = join(REPO_ROOT, "arc-manifest-pier.yaml");
 
-  // The public entry channel (#onboard-your-fleet) and the private back-office
-  // (#assistant-fleet-onboarding). Pier greets in the PUBLIC channel.
-  const PUBLIC_ENTRY_CHANNEL = "1517154685595942972";
-  const PRIVATE_BACKOFFICE_CHANNEL = "1514679294553751613";
+  // The public entry channel and the private back-office channel — shipped as
+  // resolve-at-install `__ENV__` placeholders (compass#84 / L2), never literal
+  // snowflakes. Pier greets in the PUBLIC channel. The airgap invariant is that
+  // the manifest binds the PUBLIC entry, distinct from the PRIVATE back-office;
+  // asserting on the placeholders preserves that check without committing ids.
+  const PUBLIC_ENTRY_CHANNEL = "__PIER_AGENT_CHANNEL_ID__";
+  const PRIVATE_BACKOFFICE_CHANNEL = "__PIER_LOG_CHANNEL_ID__";
 
   // Any of these in a tool allowlist would break the airgap: Bash/Skill let Pier
   // shell out to the privileged CLI; Write/Edit let it tamper with config.

--- a/src/common/config/__tests__/resolve-env-placeholders.test.ts
+++ b/src/common/config/__tests__/resolve-env-placeholders.test.ts
@@ -568,9 +568,9 @@ presence:
   discord:
     enabled: true
     token: ${token}
-    guildId: "1505549701674700991"
-    agentChannelId: "1517154685595942972"
-    logChannelId: "1514679294553751613"
+    guildId: "000000000000000000"
+    agentChannelId: "000000000000000000"
+    logChannelId: "000000000000000000"
 `;
     writeFileSync(fragPath, yaml);
     return fragPath;

--- a/src/common/types/surfaces.ts
+++ b/src/common/types/surfaces.ts
@@ -176,7 +176,7 @@ export const WebBindingSchema = z
      * Tenant/instance identifier — the `{tenant}` segment of `web:{tenant}`.
      * Must be unique across all web bindings for this principal so the
      * dispatch-sink can route responses to the correct adapter instance.
-     * Example: `"amt"` → instanceId `"web:amt"`.
+     * Example: `"acme"` → instanceId `"web:acme"`.
      */
     instanceId: z.string().min(1, "surfaces.web[].binding.instanceId is required"),
     /**

--- a/src/gateway/__tests__/binding-resolver.test.ts
+++ b/src/gateway/__tests__/binding-resolver.test.ts
@@ -793,15 +793,15 @@ describe("crossPrincipalBindings — single-principal v1 guard", () => {
 // These tests pin the newly-wired paths so a future refactor can't silently
 // drop them again.
 
-/** One web binding — instanceId "amt" → demux key "web:amt". */
+/** One web binding — instanceId "acme" → demux key "web:acme". */
 const WEB_SURFACES: Surfaces = {
   web: [
     {
       agent: "pylon",
-      stack: "andreas/amt",
+      stack: "andreas/acme",
       binding: {
         host: "127.0.0.1",
-        instanceId: "amt",
+        instanceId: "acme",
         port: 8090,
         broadcastUrl: "http://localhost:9090/broadcast",
         transport: "ws",
@@ -815,17 +815,17 @@ describe("buildBindingIndex — web happy path", () => {
   test("web: indexes by instanceId prefixed with 'web:'", () => {
     const index = buildBindingIndex(WEB_SURFACES);
     expect(index.web.size).toBe(1);
-    expect(index.web.has("web:amt")).toBe(true);
+    expect(index.web.has("web:acme")).toBe(true);
   });
 
   test("web entry carries agent, principal, stack, and instance from fixture", () => {
     const index = buildBindingIndex(WEB_SURFACES);
-    const entry = index.web.get("web:amt");
+    const entry = index.web.get("web:acme");
     expect(entry).toBeDefined();
     expect(entry!.agent).toBe("pylon");
     expect(entry!.principal).toBe("andreas");
-    expect(entry!.stack).toBe("amt");
-    expect(entry!.instance).toBe("web:amt");
+    expect(entry!.stack).toBe("acme");
+    expect(entry!.instance).toBe("web:acme");
   });
 
   test("empty surfaces: web map is empty (web key present with size 0)", () => {
@@ -840,10 +840,10 @@ describe("buildBindingIndex — web collision throws", () => {
       web: [
         {
           agent: "pylon",
-          stack: "andreas/amt",
+          stack: "andreas/acme",
           binding: {
             host: "127.0.0.1",
-            instanceId: "amt",
+            instanceId: "acme",
             port: 8090,
             broadcastUrl: "http://localhost:9090/broadcast",
             transport: "ws",
@@ -855,7 +855,7 @@ describe("buildBindingIndex — web collision throws", () => {
           stack: "andreas/work",
           binding: {
             host: "127.0.0.1",
-            instanceId: "amt", // duplicate — same demux key "web:amt"
+            instanceId: "acme", // duplicate — same demux key "web:acme"
             port: 8091,
             broadcastUrl: "http://localhost:9091/broadcast",
             transport: "ws",
@@ -864,22 +864,22 @@ describe("buildBindingIndex — web collision throws", () => {
         },
       ],
     };
-    expect(() => buildBindingIndex(ambiguous)).toThrow(/web.*amt/i);
+    expect(() => buildBindingIndex(ambiguous)).toThrow(/web.*acme/i);
   });
 });
 
 describe("resolveBinding — web happy path", () => {
   test("web: resolves by instanceId (full 'web:<id>' key stamped by the WebAdapter)", () => {
     const index = buildBindingIndex(WEB_SURFACES);
-    // The WebAdapter stamps instanceId="web:amt" on every inbound message
-    const inbound = msg({ platform: "web", instanceId: "web:amt" });
+    // The WebAdapter stamps instanceId="web:acme" on every inbound message
+    const inbound = msg({ platform: "web", instanceId: "web:acme" });
     const match = resolveBinding(index, inbound);
     expect(match).not.toBeNull();
     expect(match!.platform).toBe("web");
     expect(match!.agent).toBe("pylon");
     expect(match!.principal).toBe("andreas");
-    expect(match!.stack).toBe("amt");
-    expect(match!.instance).toBe("web:amt");
+    expect(match!.stack).toBe("acme");
+    expect(match!.instance).toBe("web:acme");
   });
 
   test("web: instanceId not in index → null", () => {
@@ -890,14 +890,14 @@ describe("resolveBinding — web happy path", () => {
 
   test("web inbound against discord-only index → null (web map is empty)", () => {
     const index = buildBindingIndex(DISCORD_SURFACES);
-    const inbound = msg({ platform: "web", instanceId: "web:amt" });
+    const inbound = msg({ platform: "web", instanceId: "web:acme" });
     expect(resolveBinding(index, inbound)).toBeNull();
   });
 });
 
 describe("distinctBoundStacks — web bindings", () => {
   test("web-only surfaces: includes the web binding's stack leaf", () => {
-    expect(distinctBoundStacks(WEB_SURFACES)).toEqual(["amt"]);
+    expect(distinctBoundStacks(WEB_SURFACES)).toEqual(["acme"]);
   });
 
   test("web stack deduped when the same leaf appears in both discord and web", () => {
@@ -905,17 +905,17 @@ describe("distinctBoundStacks — web bindings", () => {
       discord: [
         {
           agent: "luna",
-          stack: "andreas/amt",
+          stack: "andreas/acme",
           binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
         },
       ],
       web: [
         {
           agent: "pylon",
-          stack: "andreas/amt", // same leaf — collapses to one entry
+          stack: "andreas/acme", // same leaf — collapses to one entry
           binding: {
             host: "127.0.0.1",
-            instanceId: "amt",
+            instanceId: "acme",
             port: 8090,
             broadcastUrl: "http://localhost:9090/broadcast",
             transport: "ws",
@@ -924,7 +924,7 @@ describe("distinctBoundStacks — web bindings", () => {
         },
       ],
     };
-    expect(distinctBoundStacks(surfaces)).toEqual(["amt"]);
+    expect(distinctBoundStacks(surfaces)).toEqual(["acme"]);
   });
 
   test("web adds a distinct stack leaf beyond discord's set", () => {
@@ -939,10 +939,10 @@ describe("distinctBoundStacks — web bindings", () => {
       web: [
         {
           agent: "pylon",
-          stack: "andreas/amt",
+          stack: "andreas/acme",
           binding: {
             host: "127.0.0.1",
-            instanceId: "amt",
+            instanceId: "acme",
             port: 8090,
             broadcastUrl: "http://localhost:9090/broadcast",
             transport: "ws",
@@ -951,7 +951,7 @@ describe("distinctBoundStacks — web bindings", () => {
         },
       ],
     };
-    expect(distinctBoundStacks(surfaces)).toEqual(["meta-factory", "amt"]);
+    expect(distinctBoundStacks(surfaces)).toEqual(["meta-factory", "acme"]);
   });
 });
 
@@ -965,10 +965,10 @@ describe("crossPrincipalBindings — web bindings", () => {
       web: [
         {
           agent: "pylon",
-          stack: "other/amt",
+          stack: "other/acme",
           binding: {
             host: "127.0.0.1",
-            instanceId: "amt",
+            instanceId: "acme",
             port: 8090,
             broadcastUrl: "http://localhost:9090/broadcast",
             transport: "ws",
@@ -977,6 +977,6 @@ describe("crossPrincipalBindings — web bindings", () => {
         },
       ],
     };
-    expect(crossPrincipalBindings(surfaces, "andreas")).toEqual(["other/amt"]);
+    expect(crossPrincipalBindings(surfaces, "andreas")).toEqual(["other/acme"]);
   });
 });

--- a/src/gateway/__tests__/gateway-bootstrap.test.ts
+++ b/src/gateway/__tests__/gateway-bootstrap.test.ts
@@ -512,15 +512,15 @@ describe("maybeCreateSurfaceGateway — error propagation", () => {
 // never started. This block pins the corrected path.
 // =============================================================================
 
-/** Web-only surfaces — one binding, instanceId "amt". */
+/** Web-only surfaces — one binding, instanceId "acme". */
 const WEB_SURFACES: Surfaces = {
   web: [
     {
       agent: "pylon",
-      stack: "andreas/amt",
+      stack: "andreas/acme",
       binding: {
         host: "127.0.0.1",
-        instanceId: "amt",
+        instanceId: "acme",
         port: 8090,
         broadcastUrl: "http://localhost:9090/broadcast",
         transport: "ws",

--- a/src/gateway/__tests__/surface-ownership-plan.test.ts
+++ b/src/gateway/__tests__/surface-ownership-plan.test.ts
@@ -236,15 +236,15 @@ describe("gatewayAdapterInstanceCollisions", () => {
 // was invisible to the ownership plan (0 bindings → gateway never started).
 // These tests pin the corrected paths.
 
-/** Web-only surfaces — one binding, instanceId "amt", agent "pylon". */
+/** Web-only surfaces — one binding, instanceId "acme", agent "pylon". */
 const WEB_SURFACES: Surfaces = {
   web: [
     {
       agent: "pylon",
-      stack: "andreas/amt",
+      stack: "andreas/acme",
       binding: {
         host: "127.0.0.1",
-        instanceId: "amt",
+        instanceId: "acme",
         port: 8090,
         broadcastUrl: "http://localhost:9090/broadcast",
         transport: "ws",
@@ -280,7 +280,7 @@ describe("planSurfaceOwnership — web surfaces", () => {
       gatewayEnabled: true,
       principal: "andreas",
     });
-    expect(plan.gatewayAdapterInstanceIds).toContain("web:amt");
+    expect(plan.gatewayAdapterInstanceIds).toContain("web:acme");
   });
 
   test("outboundStacks includes the web binding's stack leaf", () => {
@@ -289,7 +289,7 @@ describe("planSurfaceOwnership — web surfaces", () => {
       gatewayEnabled: true,
       principal: "andreas",
     });
-    expect(plan.outboundStacks).toContain("amt");
+    expect(plan.outboundStacks).toContain("acme");
   });
 
   test("flag off with web-only surfaces keeps the inactive plan (gateway never starts)", () => {

--- a/src/gateway/binding-resolver.ts
+++ b/src/gateway/binding-resolver.ts
@@ -136,7 +136,7 @@ export interface GatewayBindingIndex {
   discord: Map<string, IndexEntry>;
   /** Slack: keyed by `binding.workspaceId` */
   slack: Map<string, IndexEntry>;
-  /** Web: keyed by the adapter instanceId stamped on InboundMessage (e.g. `web:amt`). */
+  /** Web: keyed by the adapter instanceId stamped on InboundMessage (e.g. `web:acme`). */
   web: Map<string, IndexEntry>;
   /**
    * Mattermost single-binding fallback.


### PR DESCRIPTION
PR 0b of the pier remediation (compass#84 L2). Supersedes #1368, which auto-closed when its 0a base branch was deleted on merge of #1367; rebased onto main.

- pier.yaml + arc-manifest-pier.yaml Discord snowflakes → `__PIER_*__` placeholders; token `${PIER_BOT_TOKEN}`→`__PIER_BOT_TOKEN__` (latent-bug fix — the `${}` form never matched the `__ENV__` resolver).
- Engagement acronym → neutral token (`acme`/`tenant`), whole-word, across the tree. **The rebase re-neutralized 85 occurrences that unrelated merges re-introduced into gateway/web tests after the original pass** — concrete evidence the gate must *enforce*, not warn.
- Test-fixture snowflakes → placeholders/all-zeros; preinstall gate warns on unset PIER_* env.
- Also neutralized a pre-existing missed `web:amt` in binding-resolver.ts (a NUL-byte-bearing file that reads as *binary* to grep — flagged as engine finding F3 on #85).

Invariant verified: 0 whole-word engagement-acronym + 0 pier snowflakes tree-wide (`grep -a`). tsc 0 · 486 config/web/gateway tests pass · carve-out gate PASS. Reviewed as #1368 (FullReview: MERGE, 3 advisory nits).

Closes the-metafactory/compass#84
Also closes #1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)