### PR TITLE
ci: C-conf — confidentiality-gate caller (warn-only burn-in) (compass#87)

### DIFF
--- a/.confidentiality-allow.yaml
+++ b/.confidentiality-allow.yaml
@@ -1,0 +1,37 @@
+# Confidentiality gate allowlist — cortex (design doc §4 L1, umbrella compass#81).
+#
+# EMPTY SEED. Committed empty on purpose: cortex's tree is clean today and the
+# zero-entry ratchet is the stance (design doc §4 L2 "zero-entry ratchet").
+#
+# What this file is FOR:
+#   Narrow, principal-sanctioned carve-outs for TIER-2 public-shape false
+#   positives ONLY — e.g. a documented example ID, a sanctioned identifier in
+#   THIRD-PARTY-NOTICES.md. It is loaded by the L1 gate from the PR's BASE_SHA,
+#   never the PR head — so a violation cannot exempt itself in the same PR that
+#   introduces it (design doc §4 L1: "Allowlist is loaded from BASE_SHA").
+#
+# What this file is NOT for:
+#   - Denylist (tier-3) findings are NEVER allowlistable here. A denylist false
+#     positive is resolved ONLY via an `allow:` line in the PRIVATE compass
+#     denylist — never by echoing a term into this public file (design doc §4
+#     L1/L5: "denylist findings are never allowlistable via the committed
+#     `.confidentiality-allow`").
+#   - Real client/engagement identifiers. If the gate flags something real, the
+#     fix is to REMOVE the content, not to allowlist it.
+#
+# Discipline:
+#   - This file + `.github/workflows/**` are CODEOWNERS-protected; additions
+#     require code-owner review and MUST NOT land in the same PR as the violation
+#     they exempt.
+#   - Justification strings are PUBLIC — keep them engagement-neutral (a shape
+#     description + a link), never a client-identifying reason.
+#
+# Schema (when populated):
+#   allow:
+#     - rule: <tier-2 rule id, e.g. platform-id | internal-email | compliance-code>
+#       path: <glob the carve-out applies to>          # optional
+#       match: <exact public-safe literal, e.g. an all-zero placeholder id>  # optional
+#       reason: <engagement-neutral justification>
+#       added_by: <github-handle>
+version: 1
+allow: []

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,17 @@
 # is auto-assigned to review the other's contributions, satisfying
 # the required-approval rule on main.
 * @jcfischer @mellanon
+
+# ── Confidentiality-control surface (design doc §4 L1/L2, compass#81) ──
+# Explicit ownership of the security-sensitive gate wiring + allowlists. The
+# catch-all above already covers these; these entries make the requirement
+# self-documenting and keep protection intact if `*` is ever narrowed. A
+# floating ref, a dropped secret, or a self-exempting allowlist edit here is a
+# security regression, so both principals own these paths (CODEOWNERS' last
+# matching pattern wins).
+/.github/workflows/confidentiality-gate.yml   @jcfischer @mellanon
+/.github/workflows/confidentiality*.yml       @jcfischer @mellanon
+/.confidentiality-allow.yaml                  @jcfischer @mellanon
+# L2 shippable-hygiene gate + its allowlist (land in PR 5; protected from day 1).
+/scripts/check-shippable-hygiene.ts           @jcfischer @mellanon
+/shippable-hygiene-allowlist.txt              @jcfischer @mellanon

--- a/.github/workflows/confidentiality-gate.yml
+++ b/.github/workflows/confidentiality-gate.yml
@@ -1,0 +1,124 @@
+# Confidentiality gate — caller (design doc §4 L1, umbrella compass#81).
+#
+# This wires cortex onto the SHARED, reusable confidentiality gate that lives in
+# public `the-metafactory/metafactory-actions`. It is the point where the
+# epic's tooling becomes enforcing on cortex — the repo the cortex#1312 incident
+# leaked into.
+#
+# ─── WARN-ONLY BURN-IN (READ THIS) ──────────────────────────────────────────
+# This gate is intentionally in a **warn-only burn-in** posture (design doc §4 L1
+# acceptance: "≥3-day warn-only burn-in on cortex with <1 false BLOCK/week before
+# enforcement"; §6 Phase 1). Two things make it non-blocking today:
+#
+#   1. It runs in THIS standalone workflow, separate from the required CI jobs in
+#      `ci.yml` (Test / Lint / Typecheck / Compass-gov / Vocab). A finding here
+#      never turns those required checks red.
+#   2. It is NOT enrolled in the `protect-main` ruleset's required status checks.
+#      An un-required check cannot block a merge.
+#
+# During burn-in the `gate` job's own pass/fail is OBSERVATIONAL — that is the
+# whole point of a burn-in (collect the real finding/false-positive rate before
+# enforcing). The `burn-in-summary` job below surfaces that result as an
+# always-green, human-readable line so the posture is explicit in the Actions UI.
+#
+# NOTE on mechanism: GitHub does NOT allow `continue-on-error` on a job that
+# `uses:` a reusable workflow (only name/uses/with/secrets/needs/if/permissions
+# are permitted — confirmed with actionlint), and the reusable gate exposes no
+# warn/soft input. So warn-only is realized structurally (separate workflow +
+# not-required), not via `continue-on-error`.
+#
+# ─── FLIP TO ENFORCING (held ops step — DO NOT do it in this PR) ─────────────
+# After the burn-in window is clean, a PRINCIPAL (not an agent) flips enforcement:
+#
+#   1. Read the observed check-run context name from a completed run of this
+#      workflow (see compass `rollout-gate.ts`, design doc §4 L1
+#      "required-check identity fixed empirically").
+#   2. Add THAT context to the `protect-main` ruleset's `required_status_checks`
+#      (alongside the 5 existing cortex contexts).
+#
+# This is a HELD posture change (design doc OD-1 admin-bypass posture) and is
+# deliberately left to ops — this PR only stands the gate up in warn-only mode.
+#
+# Caller contract: metafactory-actions/README.md "Confidentiality gate — caller
+# usage" + scan/README.md. Both reusables are PINNED BY 40-HEX COMMIT SHA
+# (a movable tag/branch is a check-name-spoof + engine-selection vector, and the
+# gate fails closed if it cannot resolve an immutable engine SHA). We pass ONLY
+# the explicit named secrets — never `secrets: inherit` (that would hand every
+# caller secret to the reusable workflow).
+name: confidentiality-gate
+
+on:
+  pull_request:
+    # `edited` is included so a PR whose TITLE/BODY carries a denylisted term is
+    # re-scanned (the gate feeds PR title/body/branch to the engine as
+    # --extra-text). Design doc §4 L1: "pull_request trigger includes edited".
+    types: [opened, synchronize, reopened, edited]
+  push:
+    branches: [main]
+  schedule:
+    # Weekly history-mode scan (mode=auto ⇒ schedule→history). Findings from the
+    # history scan route PRIVATE per the design (compass issue + grove one-liner),
+    # never a public-repo issue.
+    - cron: "17 4 * * 1"
+
+# Least privilege at the top; the alert job widens to exactly what the push-alert
+# reusable needs (issues:write to file the SHA-free public bypass issue).
+permissions:
+  contents: read
+
+jobs:
+  # Tiers 1 (gitleaks) + 2 (public shape patterns) + 3 (org-secret hashed
+  # denylist). mode=auto maps pull_request→diff, push→tree, schedule→history.
+  gate:
+    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-gate.yml@51b48101d8014a97cfcf72c0840399b1acb871e3
+    permissions:
+      contents: read
+    secrets:
+      # Pass ONLY these two — NEVER `secrets: inherit`. The denylist org secret
+      # has "selected public repos" visibility; it is currently PLACEHOLDER-EMPTY
+      # (real terms are the principal's to add — engagement-open ritual, design
+      # doc §8), so tier 3 is inert on cortex until then. Tiers 1+2 still gate.
+      # On a same-repo run the reusable gate FAILS CLOSED if this secret is
+      # absent/empty (it must be configured for cortex); fork PRs run degraded.
+      MF_CONFIDENTIALITY_DENYLIST: ${{ secrets.MF_CONFIDENTIALITY_DENYLIST }}
+      CONF_DENYLIST_PEPPER: ${{ secrets.CONF_DENYLIST_PEPPER }}
+
+  # Detective control on the merge-bypass path (forced push / direct push /
+  # zero-approval `--admin` merge — the exact route of the incident's 3 PRs).
+  # Push-only. Alerts the private ops channel (with SHA) + files a SHA-FREE
+  # public issue. This is the "push-alert stub" of design doc §6 PR 4.
+  alert:
+    if: ${{ github.event_name == 'push' }}
+    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-push-alert.yml@51b48101d8014a97cfcf72c0840399b1acb871e3
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    secrets:
+      # Only the ops webhook — explicit, never inherit. Absent ⇒ the reusable
+      # still files the SHA-free public issue and warns that the private alert
+      # was skipped (fail-soft on the webhook, never fail-open on detection).
+      MF_OPS_DISCORD_WEBHOOK: ${{ secrets.MF_OPS_DISCORD_WEBHOOK }}
+
+  # Always-green burn-in signal. Surfaces the gate's OBSERVATIONAL result and the
+  # warn-only posture explicitly, so nobody mistakes a burn-in finding for a
+  # blocked build — and nobody mistakes this workflow for an enforcing gate yet.
+  burn-in-summary:
+    needs: [gate]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Report burn-in posture (never fails during burn-in)
+        env:
+          GATE_RESULT: ${{ needs.gate.result }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### confidentiality-gate — WARN-ONLY BURN-IN"
+            echo ""
+            echo "- gate job result (observational): **${GATE_RESULT}**"
+            echo "- posture: this workflow is **NOT** in required status checks; a finding here does not block merges."
+            echo "- flip to enforcing is a held ops step (see the header comment + design doc OD-1) — do not enable it in a feature PR."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "confidentiality-gate burn-in: gate result=${GATE_RESULT} (observational; not a required check)"

--- a/.github/workflows/confidentiality-gate.yml
+++ b/.github/workflows/confidentiality-gate.yml
@@ -70,9 +70,15 @@ jobs:
   # Tiers 1 (gitleaks) + 2 (public shape patterns) + 3 (org-secret hashed
   # denylist). mode=auto maps pull_request→diff, push→tree, schedule→history.
   gate:
-    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-gate.yml@51b48101d8014a97cfcf72c0840399b1acb871e3
+    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-gate.yml@5855a21e79f79ddd4b2506c920e2044ba0268d22
     permissions:
       contents: read
+    with:
+      # REQUIRED. Same 40-hex SHA the reusable is pinned at in `uses:@` above — this
+      # is the engine's immutability anchor. `github.job_workflow_sha` resolves EMPTY
+      # on cross-repo caller runs, so the gate cannot derive the engine SHA itself and
+      # needs this explicit pin (metafactory-actions fix: engine_sha input).
+      engine_sha: 5855a21e79f79ddd4b2506c920e2044ba0268d22
     secrets:
       # Pass ONLY these two — NEVER `secrets: inherit`. The denylist org secret
       # has "selected public repos" visibility; it is currently PLACEHOLDER-EMPTY
@@ -89,7 +95,7 @@ jobs:
   # public issue. This is the "push-alert stub" of design doc §6 PR 4.
   alert:
     if: ${{ github.event_name == 'push' }}
-    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-push-alert.yml@51b48101d8014a97cfcf72c0840399b1acb871e3
+    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-push-alert.yml@5855a21e79f79ddd4b2506c920e2044ba0268d22
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/confidentiality-gate.yml
+++ b/.github/workflows/confidentiality-gate.yml
@@ -70,7 +70,7 @@ jobs:
   # Tiers 1 (gitleaks) + 2 (public shape patterns) + 3 (org-secret hashed
   # denylist). mode=auto maps pull_request→diff, push→tree, schedule→history.
   gate:
-    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-gate.yml@5855a21e79f79ddd4b2506c920e2044ba0268d22
+    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-gate.yml@8ed0ab26f804aa98f74dcdcaf86917e09459f874
     permissions:
       contents: read
     with:
@@ -78,14 +78,25 @@ jobs:
       # is the engine's immutability anchor. `github.job_workflow_sha` resolves EMPTY
       # on cross-repo caller runs, so the gate cannot derive the engine SHA itself and
       # needs this explicit pin (metafactory-actions fix: engine_sha input).
-      engine_sha: 5855a21e79f79ddd4b2506c920e2044ba0268d22
+      engine_sha: 8ed0ab26f804aa98f74dcdcaf86917e09459f874
+      # Burn-in posture (design doc §4 L1). cortex has no MF_CONFIDENTIALITY_DENYLIST
+      # configured yet, so on the TRUSTED same-repo path we explicitly opt OUT of the
+      # fail-closed-on-absent-denylist behavior and DEGRADE to tiers 1+2 (gitleaks +
+      # shape patterns) + a warning. The reusable's default is `true` (fail closed);
+      # this `false` is a deliberate, greppable BURN-IN-ONLY opt-out. FLIP TO ENFORCE
+      # (held ops step, principal only): set this `true` (or remove the line) AND
+      # populate the denylist secret together — that is when tier 3 turns on and an
+      # absent/empty denylist fails closed again.
+      require_denylist: false
     secrets:
       # Pass ONLY these two — NEVER `secrets: inherit`. The denylist org secret
       # has "selected public repos" visibility; it is currently PLACEHOLDER-EMPTY
       # (real terms are the principal's to add — engagement-open ritual, design
       # doc §8), so tier 3 is inert on cortex until then. Tiers 1+2 still gate.
-      # On a same-repo run the reusable gate FAILS CLOSED if this secret is
-      # absent/empty (it must be configured for cortex); fork PRs run degraded.
+      # During burn-in (`require_denylist: false` above) an absent/empty denylist
+      # DEGRADES to tiers 1+2 + a warning — it does NOT fail closed. At the enforce
+      # flip a same-repo run FAILS CLOSED on an absent/empty denylist; fork PRs
+      # always run degraded.
       MF_CONFIDENTIALITY_DENYLIST: ${{ secrets.MF_CONFIDENTIALITY_DENYLIST }}
       CONF_DENYLIST_PEPPER: ${{ secrets.CONF_DENYLIST_PEPPER }}
 
@@ -95,7 +106,7 @@ jobs:
   # public issue. This is the "push-alert stub" of design doc §6 PR 4.
   alert:
     if: ${{ github.event_name == 'push' }}
-    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-push-alert.yml@5855a21e79f79ddd4b2506c920e2044ba0268d22
+    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-push-alert.yml@8ed0ab26f804aa98f74dcdcaf86917e09459f874
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## What

Wires cortex onto the **shared reusable confidentiality gate** + push-alert in public `the-metafactory/metafactory-actions` (design doc §4 **L1**, §6 **PR 4**, umbrella compass#81). This is the point where the confidentiality epic's tooling becomes **enforcing on cortex** — the repo the cortex#1312 incident leaked into.

Part of compass#87 (stacked): **PR 4** here + **PR 5** `feat/c-conf-hygiene-gate` (shippable-hygiene gate) follows on this branch.

## Files

- **`.github/workflows/confidentiality-gate.yml`** — caller that `uses:` both reusables, **pinned by 40-hex commit SHA** `8ed0ab26f804aa98f74dcdcaf86917e09459f874` (a movable tag/branch is a check-name-spoof + engine-selection vector; the gate fails closed if it can't resolve an immutable engine SHA):
  - `gate` — `pull_request` (incl. `edited`, so a denylisted PR title/body is re-scanned) + `push:main` + weekly `schedule`. `mode=auto` maps event→`diff`/`tree`/`history`. Passes **only** `MF_CONFIDENTIALITY_DENYLIST` + `CONF_DENYLIST_PEPPER` — **never `secrets: inherit`**.
  - `alert` (the §6 PR 4 *push-alert stub*) — push-only; passes **only** `MF_OPS_DISCORD_WEBHOOK`; job-scoped `issues: write` for the **SHA-free** public bypass issue.
  - `burn-in-summary` — always-green job that surfaces the gate's observational result + the warn-only posture.
- **`.confidentiality-allow.yaml`** — empty seed (zero-entry ratchet). Tier-2 carve-outs only; **denylist findings are never allowlistable here** (they resolve only in private compass).
- **`.github/CODEOWNERS`** — explicit code-owner protection of the gate workflow + allowlists (belt-and-braces over the existing `*` catch-all).

## Warn-only burn-in (not blocking)

Per design §4 L1 acceptance ("≥3-day warn-only burn-in … before enforcement") + §6 Phase 1, the gate is **non-blocking** today:
1. It runs in this **standalone** workflow, separate from the required CI jobs in `ci.yml` — a finding never turns those red.
2. It is **NOT** enrolled in `protect-main`'s required status checks — an un-required check can't block a merge.

> **Mechanism note (adversarial-review relevant):** GitHub does **not** allow `continue-on-error` on a job that `uses:` a reusable workflow (only `name/uses/with/secrets/needs/if/permissions` — confirmed with `actionlint`), and the reusable gate exposes no warn/soft input. So warn-only is realized **structurally** (separate workflow + not-required), not via `continue-on-error`.

**Flip to enforcing is a HELD ops step (not done here):** a principal reads the observed check-run context from a completed run and adds it to `protect-main`'s `required_status_checks` (design doc OD-1). Deliberately left to ops.

## Denylist status

`MF_CONFIDENTIALITY_DENYLIST` is currently **placeholder-empty** (real terms are the principal's to add — engagement-open ritual, §8), so **tier 3 is inert on cortex** until then. **Tiers 1+2 still gate.** Expected for burn-in.

## Validation

- `actionlint .github/workflows/confidentiality-gate.yml` → clean (exit 0).
- `.confidentiality-allow.yaml` parses (`{version:1, allow:[]}`).
- Branch cut from `origin/main` (`fefa0671`, rewritten-main lineage).

## Not in scope / do not do on merge

- Do **not** flip to enforcing / add required checks (held ops step).
- Do **not** merge — a fresh agent reviews this (security-sensitive: injection safety, no `secrets: inherit`, SHA-pin).

Refs: the-metafactory/compass#87
