### PR TITLE
feat(bus): C-1371 — R26 P1 AdmissionGate: KV-arbitrated substrate rate limiting at the spawn gate

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -237,6 +237,43 @@ policy:
         - tool.glob
         - tool.grep
   # ---------------------------------------------------------------------------
+  # admission — optional substrate rate limiting at the spawn gate (R26 P1)
+  # ---------------------------------------------------------------------------
+  # KV-arbitrated (NATS-KV / JetStream) token buckets + in-flight caps keyed on
+  # the envelope-resolved requester principal — exact across N cortex nodes.
+  # Design: docs/design-substrate-rate-limiting.md; contract:
+  # myelin/specs/admission.md. ABSENT block ⇒ the limiter is fully inert
+  # (byte-identical behaviour — no KV bucket, no checks, no new envelopes).
+  #
+  # Refusals are TRANSIENT: the requester gets a terminal dispatch.task.failed
+  # { kind: "not_now", retry_after_ms } ("busy — try again in ~Ns"), never a
+  # permanent deny. The anonymous open-onboarding principal (did:mf:public) is
+  # always clamped to a built-in ceiling of 2/min, 1 in-flight — config below
+  # can tighten it, never raise it. If the KV store errors, named principals
+  # degrade to node-local approximate buckets (a loud
+  # system.admission.degraded envelope fires); anonymous fails closed.
+  #
+  # admission:
+  #   stack:                    # tier 1 — global spawn ceiling (every dispatch)
+  #     max_concurrent: 8
+  #     per_minute: 30
+  #   defaults:                 # tier 2 — every principal unless overridden
+  #     per_minute: 6
+  #     per_hour: 60
+  #     max_concurrent: 3
+  #   roles:                    # role overrides (most permissive wins across
+  #     principal:              # a principal's roles — capability-union rule)
+  #       per_minute: 20
+  #       max_concurrent: 6
+  #   principals:               # per-principal override (most specific wins,
+  #     - id: amt-surface       # field by field); id must be declared above
+  #       per_minute: 12
+  #       max_concurrent: 2
+  #   anonymous:                # the open-onboarding floor (clamped to the
+  #     per_minute: 2           # built-in 2/min · 1-in-flight ceiling)
+  #     max_concurrent: 1
+
+  # ---------------------------------------------------------------------------
   # federated — optional cross-stack federation (Phase D + F-3)
   # ---------------------------------------------------------------------------
   # Each network is a trust closure with its own peers[], accept/deny subject

--- a/docs/design-substrate-rate-limiting.md
+++ b/docs/design-substrate-rate-limiting.md
@@ -1,0 +1,431 @@
+# Design — Substrate-tied rate limiting for the cortex/myelin dispatch fabric
+
+**Issue:** AzDO #3169 ("R26: Rate limiting in the cortex/myelin dispatch layer — shared, all surfaces")
+**Status:** SIGNED OFF (Andreas, 2026-07-02) — Design B accepted. Phase-1 implementation: cortex#1371; contract spec: myelin#195 (`myelin/specs/admission.md`); phase-3 transport migration tracked as cortex#1369.
+**Author:** Fable (distributed-systems design pass, 2026-07-02)
+
+> **§6 open questions — resolved at sign-off:**
+> **Q1** degrade to node-local approximate buckets + loud `system.*` event; anonymous/public (`PUBLIC_ORIGINATOR_DID`) FAILS CLOSED.
+> **Q2** ship tiers 1–2 only (stack ceiling + per-principal, role-derived with per-principal override); tiers 3–4 deferred.
+> **Q3** config lives in `policy.admission` (§4.1 schema), Zod-validated, reusing the `offering.ts` vocabulary; absent block ⇒ limiter fully inert (CO-4).
+> **Q4** R26 ships phases 1–2; the JetStream work-queue migration (phase 3a) stays a separate issue — cortex#1369.
+> **Q5** the admission contract is a myelin spec NOW (`specs/admission.md`, myelin#195), cortex the first implementation.
+> **Q6** reject-fast confirmed: interactive → terminal `not_now` + retry hint with a friendly renderer string; queued → `nak(retry_after_ms)`; never `term` for rate.
+
+---
+
+## 0. Requirements (as stated)
+
+1. Rate limiting **tied to the substrate** — the myelin/NATS dispatch fabric — not a
+   per-surface add-on. It must protect *every* surface that dispatches to agents
+   (Discord, web:amt, gh-webhook, dashboard, bus peers, future surfaces).
+2. Designed against the **spawn mechanism** (how cortex actually launches agent runs),
+   with a **future-state outlook**.
+3. Must survive **horizontal scale** — multiple cortex nodes/instances. A naive
+   per-principal in-memory token bucket does not coordinate across nodes and is
+   disqualified.
+
+---
+
+## 1. How dispatch/spawn works today (evidence)
+
+### 1.1 Every surface funnels into one envelope grammar
+
+All dispatch sources — platform adapters (Discord/Mattermost/Slack), the shared surface
+gateway (which carries the web surfaces, including `web:amt`), taps, dashboards, and
+assistant runtimes — converge on **one canonical publisher**:
+
+- `publishInboundChatDispatchEnvelope` is "the shared envelope/subject construction"
+  for every inbound action that becomes a `tasks.@{assistant}.{capability}` envelope
+  (`src/bus/dispatch-source-publisher.ts:11-19`; envelope `type: "tasks.chat"` at `:296`).
+- The web surface is a gateway binding (`web:` adapter, C-110 —
+  `src/gateway/gateway-adapters.ts:213-221`; instance id `web:{binding.instanceId}` at
+  `:334`). The gateway's `BusInboundSink` "delegates to
+  `publishInboundChatDispatchEnvelope` — the same canonical dispatch-source publisher
+  the per-stack dispatch-handler uses" (`src/gateway/bus-inbound-sink.ts:1-16`).
+- Subjects come from myelin's grammar: `directTaskSubject(principal, did, stack)` →
+  `local.{principal}.{stack}.tasks.@{encoded-did}.>`
+  (`myelin/src/subjects.ts:248-256`), e.g. `local.andreas.work.tasks.@did-mf-pylon.chat`.
+
+**Consequence:** the bus subject space *is* the substrate choke point. A limiter that
+gates envelope → spawn covers Discord, web:amt, and every future surface with zero
+per-surface code. This satisfies requirement 1 structurally.
+
+### 1.2 The spawn path (chat / direct dispatch)
+
+The runner's dispatch listener "consumes inbound dispatchable task envelopes directly
+from the MyelinRuntime and **spawns a substrate harness per dispatch**"
+(`src/runner/dispatch-listener.ts:1-4`). The pipeline inside `handleDispatchEnvelope`
+(`:1344`) is strictly ordered:
+
+1. **Chain verification** — `verifySignedByChain` (`:1445-1541`).
+2. **Re-sign on ingest** — gateway-injected envelopes arrive unsigned +
+   `originator`-stamped; the stack re-stamps them (`:1543-1594`).
+3. **Policy gate** — `PolicyEngine.check(principal, intent)`, "the single authorization
+   decision point for cortex" (`src/common/policy/engine.ts:4-13`); deny short-circuits
+   with `system.access.denied` + terminal `dispatch.task.failed`
+   (`dispatch-listener.ts:1783-1893`). Fail-closed when the engine is uninitialised
+   (`:1746-1781`).
+4. **Harness spawn** — a fresh `ClaudeCodeHarness` (or `AgentTeamHarness` for
+   `distribution_mode === "delegate"`) per dispatch (`:1950-1959`), which ultimately
+   runs `Bun.spawn(["claude", ...args])` (`src/runner/cc-session.ts:291`). Lifecycle
+   envelopes (`dispatch.task.started/completed/failed/aborted`) are drained back onto
+   the bus, at least one terminal envelope guaranteed (`:38-46`, `:1991-2000`).
+
+**There is no rate or admission check anywhere on this path.** The natural hook is
+between step 3 and step 4 — exactly where the policy gate already sits and where the
+refusal machinery already exists.
+
+### 1.3 The offer/queue paths (code-review, dev.implement, release)
+
+Offered capabilities ride **JetStream**: durable pull consumers bound via
+`js.consumers.get(stream, durable)` (`src/bus/myelin/subscriber.ts:402`), streams and
+durables provisioned idempotently at boot (`src/bus/jetstream/provision.ts:176-234`,
+Interest retention at `:223`, `ack_wait` 20 min at `:169`, `max_deliver` 5 at `:161`).
+Notably, "dev + prod instances on the same principal share competing-consumer semantics
+and a daemon restart resumes from the same JetStream offset" (`src/cortex.ts:1549-1552`)
+— the substrate already exploits shared durables for multi-instance coordination.
+
+These consumers each carry an **in-process concurrency gate**:
+`if (this.inFlight.size >= this.maxConcurrent)` → publish `dispatch.task.failed
+{kind:"not_now", retry_after_ms}` → `nak(delay)` (`src/runner/dev-consumer.ts:528-553`;
+same contract in `release-consumer.ts:57` and the review consumer). The dev consumer's
+TOCTOU note even names the missing primitive this design supplies: *"If a future
+push-mode or parallel-batch delivery ever makes the race real, BOTH consumers harden
+together (**a single shared admit-token primitive**) — they must not drift"*
+(`dev-consumer.ts:530-540`).
+
+### 1.4 The substrate already has a rate-limit **slot**, refusal taxonomy, and config vocabulary — just no limiter
+
+- **CO-4 gate floor** (`src/bus/gate-floor.ts`) composes upstream decisions into an
+  admission verdict, including `rateOk`: "Whether the rate-limit / cost-cap gate admits
+  the request. A `false` is `not_now` (transient backpressure — retry safe)"
+  (`gate-floor.ts:128-140`), with `DEFAULT_RATE_RETRY_AFTER_MS = 5000` (`:157`) and the
+  public floor's rate check at `:354-358`.
+- **Today `rateOk` is hard-coded `true`**: "`rateOk` — passed `true` (no limiter wired
+  yet; the §5 rate/cost cap is a CO-4-follow / CO-7 knob)" (`src/cortex.ts:1601-1603`,
+  literal `rateOk: true` at `:1663`). **R26 is the limiter that fills this slot.**
+- **Refusal taxonomy is settled**: `not_now` + `retry_after_ms` → `nak` (transient);
+  `policy_denied` / `compliance_block` → `term` (permanent) (`gate-floor.ts:143-154`,
+  `dev-consumer.ts:45-49`). Ordering principle: structural/permanent refusals before
+  transient ones (`gate-floor.ts:195-202`).
+- **Config vocabulary exists**: `RatePredicateSchema` (`per_minute`/`per_hour`/`per_day`,
+  `src/common/types/offering.ts:248-262`) and `PublicLimitsSchema`
+  (`max_concurrent`/`per_day`/`cost_cents_per_request`, `:289-310`) — currently only
+  attachable to *public offerings*, enforced nowhere.
+- **BudgetCheck** (cost caps) is a deliberate fail-closed seam awaiting real accounting
+  (cortex#977) (`src/runner/budget-check.ts:34-45`). The rate limiter and the future
+  budget accountant should share state machinery (see §6).
+
+### 1.5 The horizontal-scale reality check
+
+- The chat/direct dispatch path is **core NATS pub/sub** (`runtime.onEnvelope`,
+  `src/bus/myelin/runtime.ts:102`) — fan-out, at-most-once. **No queue groups are used
+  anywhere on the dispatch path** (queue-group support exists in the raw options,
+  `src/bus/nats/subscription.ts:40`, but nothing sets one). Two cortex nodes subscribing
+  the same `tasks.*` subject would **both spawn the same session**. Multi-node is
+  therefore not just a limiter problem — the dispatch plane itself needs
+  competing-consumer semantics (§5 Phase 3).
+- **Shared state available today: JetStream, and only JetStream.** No Redis, no shared
+  DB. NATS KV (a JetStream feature) is architecturally anticipated — architecture §7.2
+  specifies a capabilities KV bucket, deferred because "myelin's signed-KV API
+  (myelin#31) is the right home for that primitive and hasn't shipped"
+  (`src/bus/capability-registry.ts:93-101`). `runtime.jetstreamManager()` is already
+  exposed and bound to the primary NATS link (`src/bus/myelin/runtime.ts:1898-1916`).
+- Topology: NATS at `nats://localhost:4222` today (`src/bus/nats/connection.ts:29`);
+  the documented connection model is "leaf node connecting to a hub"
+  (`docs/architecture.md:244`), and "JetStream is **required** for `system.*` events"
+  (`docs/architecture.md` §4.2). So every future node — including leaf-node federation —
+  shares one JetStream domain per stack. That shared JetStream domain is the
+  coordination primitive this design builds on.
+
+### 1.6 Identity to key on
+
+The requester principal is already resolved substrate-side, surface-agnostically:
+`resolvePrincipalId`/`getActorPrincipal` "read `originator.identity` FIRST (the gateway
+stamps it) and only fall back to `signed_by[0]`" (`dispatch-listener.ts:1560-1563`).
+Roles grant capabilities of the form `dispatch.<agentId>`
+(`src/common/policy/factory.ts:71`; e.g. `engine.check("public", "dispatch.pier")`,
+`src/common/policy/resolve-access.ts:69-70`). Principals/roles live in the
+`policy:` block of `cortex.yaml` (`cortex.yaml.example:200-212`). The anonymous
+open-onboarding principal (`PUBLIC_ORIGINATOR_DID`, zero-authority) is a first-class
+principal too — it needs the *tightest* default limit.
+
+---
+
+## 2. Candidate designs
+
+All three key on **envelope-resolved identity** (requester principal × target agent ×
+capability), never on surface session state — that's what makes them substrate-tied.
+
+### Design A — JetStream-native admission (streams + consumer limits as the limiter)
+
+Migrate the direct-dispatch plane onto a per-stack `TASKS` stream (work-queue or
+interest retention); each agent gets a shared durable pull consumer; nodes compete.
+Concurrency is bounded by JetStream `max_ack_pending` on the durable; overflow queues
+in the stream; backpressure = `nak(delay)`; stale work expires via `max_age`.
+
+- **Across N nodes:** correct by construction — JetStream delivers each message to
+  exactly one node per shared durable; the in-flight ceiling is enforced server-side.
+  This is the same mechanism the review/dev/release consumers already trust
+  (`cortex.ts:1549-1552`).
+- **Keys on:** the *consumer* — i.e. per (stack, agent). **Cannot key on the
+  requester**: the subject carries the *target* (`tasks.@did`), not the sender; JetStream
+  limits attach to streams/consumers, not message-key groups. Per-principal fairness
+  would require subject-grammar changes (encoding the requester into the subject) plus
+  one consumer per principal — O(principals × agents) durables, a provisioning and
+  migration burden.
+- **Failure modes:** JetStream down ⇒ no dispatch at all (fail-closed by nature).
+  Consumer-config drift (the `provision.ts` drift-warning problem) becomes
+  limit-config drift.
+- **Cost/complexity:** high — migrates the hot chat path from core NATS to JetStream
+  pull loops; adds latency (small) and provisioning surface. Delivers *concurrency*
+  control and durability, **not request-rate windows** (`rate_limit_bps` on push
+  consumers is bytes-based — wrong dimension).
+
+**Verdict:** the right *future transport* for the dispatch plane (and the real fix for
+multi-node double-spawn), but not a rate limiter. It cannot express "principal X gets
+6 dispatches/min" — the requirement multi-tenant fairness actually needs.
+
+### Design B — Distributed token bucket in NATS KV (the "AdmissionGate" / shared admit-token primitive) — RECOMMENDED
+
+A small, pure-contract module — `checkAdmission(key, limits, now) → {admit} |
+{refuse, retry_after_ms}` — backed by a **NATS KV bucket** (JetStream-backed, e.g.
+`admission_{principal}_{stack}`), provisioned idempotently at boot exactly like
+`provision.ts` provisions streams. Token-bucket (or sliding-window) state per key;
+multi-node correctness via KV's **compare-and-swap** (`update(key, value, revision)`):
+
+```
+loop (bounded, e.g. 3 attempts):
+  entry, rev ← kv.get(key)            # miss ⇒ kv.create(key, fresh bucket)
+  bucket ← refill(entry, now)         # tokens += elapsed × rate, capped at burst
+  if bucket.tokens < cost: return refuse(retry_after = time_to_next_token)
+  bucket.tokens -= cost
+  if kv.update(key, bucket, rev) succeeds: return admit
+  # CAS lost — another node admitted concurrently; re-read and retry
+on retry exhaustion: fall back per configured failure posture (§4.3)
+```
+
+- **Across N nodes:** exact and race-free — CAS serialises concurrent admits on the
+  same key through the JetStream leader. No node-local state matters; nodes can scale
+  out/in freely; a restarted node inherits live counters. The KV bucket replicates with
+  the stream (R1 today; R3 when the NATS cluster grows) — the limiter's availability
+  is *identical to the dispatch fabric's own availability*.
+- **Keys on:** anything derivable from the envelope — recommended lattice in §4.1.
+  Same primitive also holds **in-flight concurrency counters** (admit ⇒ increment;
+  terminal lifecycle envelope ⇒ decrement — the harness guarantees a terminal envelope
+  per dispatch, `dispatch-listener.ts:38-40`), replacing the three divergent in-process
+  `maxConcurrent` gates with the "single shared admit-token primitive" the dev consumer
+  already anticipates (`dev-consumer.ts:536-540`).
+- **Failure modes:** (a) KV unreachable while core NATS is up — rare (same server), but
+  must have a declared posture (§4.3, open question 1); (b) CAS contention under hot
+  keys — bounded retries, then posture fallback; contention only matters at rates far
+  above any sane spawn ceiling (spawns are minutes-long Claude sessions); (c) counter
+  orphans (node dies mid-run) — reconciled by a TTL + sweeper listening to the
+  `dispatch.task.*` lifecycle (same recovery shape as R6/R14 patterns elsewhere);
+  (d) clock skew — refill uses each node's monotonic clock over deltas stored in the
+  entry; token buckets tolerate small skew by design.
+- **Cost/complexity:** low-moderate. One KV round-trip (sub-ms on localhost, low-ms on
+  a LAN cluster) per admission — noise against a spawn that costs minutes and dollars.
+  No new infrastructure: KV *is* JetStream, which the stack already requires
+  (`architecture.md` §4.2).
+
+### Design C — Node-local buckets with async coordination (limit/N split or usage gossip)
+
+Each node runs an in-memory bucket sized `limit / N`, or nodes broadcast
+`admission.usage` events and keep an eventually-consistent shared view.
+
+- **Across N nodes:** approximate only. `N` is dynamic (deploys, crashes, autoscale) so
+  effective limits drift; eventual consistency ⇒ over-admission windows exactly when it
+  matters (bursts). Worse, on today's fan-out subscription "divide by N" is meaningless
+  — all nodes see all envelopes (§1.5).
+- **Keys on:** same lattice as B, but each node holds a partial view.
+- **Failure modes:** silent limit erosion; no single number anyone can audit.
+- **Cost/complexity:** lowest latency (zero I/O), highest correctness debt.
+
+**Verdict:** rejected as the primary mechanism — it is precisely the "naive in-memory
+bucket" bottleneck Andreas flagged, dressed up. Retained only as the *degraded-mode
+fallback* when the KV store is briefly unreachable (§4.3).
+
+---
+
+## 3. Recommendation
+
+**Design B — a KV-arbitrated AdmissionGate at the spawn gate — with Design A's
+JetStream work-queue migration as the phase-3 completion of the multi-node dispatch
+plane.** Rationale, point by point against the crux:
+
+1. **Substrate-tied, all surfaces.** The check runs where the envelope becomes a spawn
+   (`handleDispatchEnvelope` step 3½, plus the three JetStream consumers' admission
+   gates), and it *is* the producer of the gate floor's `rateOk` — replacing the
+   hard-coded `true` at `cortex.ts:1663`. Discord, web:amt, gh-webhook, bus peers, and
+   any future surface are covered because they all must cross this gate to spawn.
+   No surface can opt out; no surface needs code.
+2. **Horizontal scale without a bottleneck.** State lives in the fabric's own durable
+   layer (NATS KV/JetStream), arbitrated by CAS — exact under N nodes, no per-node
+   drift, no new infra, no SPOF beyond the bus itself (without which nothing dispatches
+   anyway). This is the direct answer to the in-memory-bucket objection.
+3. **Right dimension.** Rate windows (per-minute/hour/day) *and* max-in-flight
+   concurrency, keyed per requester — which JetStream-only limits (Design A) cannot
+   express.
+4. **Future-state aligned.** The KV entry format + key grammar is specified as a myelin
+   contract (the substrate owns admission; cortex consumes it) — implemented
+   cortex-side first (mirroring `jetstream/provision.ts` pragmatism), migrating into
+   `@the-metafactory/myelin` alongside signed-KV (myelin#31). The same KV state
+   machinery later hosts the real BudgetCheck accounting (cortex#977) and can price
+   admits via the envelope's `economics` field (`myelin/src/envelope.ts:100,272`) —
+   rate limiting and cost budgeting become two policies over one admission primitive.
+5. **Reuses the settled refusal taxonomy** — no new failure vocabulary for surfaces to
+   learn (§4.4).
+
+### 3.1 What to key the limit on (multi-node answer)
+
+Key on **envelope identity, resolved substrate-side**: the requester principal
+(`originator.identity` → `signed_by[0]` fallback — the same resolution the policy gate
+trusts today). Because the key is derived from the envelope and the state is shared,
+*it does not matter which node consumes the envelope* — that is the property that makes
+the limit meaningful under horizontal scale. Recommended checking order (first refusal
+wins; evaluated cheapest-state-first):
+
+| Tier | Key | Protects against | Default |
+|---|---|---|---|
+| 1 | `stack` (global spawn ceiling) | total substrate overload / runaway loop | max_concurrent: e.g. 8; per_minute: e.g. 30 |
+| 2 | `principal` | one tenant/surface principal starving others (e.g. a looping web:amt) | per_minute + max_concurrent, role-derived |
+| 3 | `principal × agent` | one hot agent monopolised by one requester | optional, unset by default |
+| 4 | `capability` (e.g. `code-review`) | queue-flood on offered capabilities | optional; supersedes per-consumer maxConcurrent |
+
+The anonymous/public principal (open onboarding, `PUBLIC_ORIGINATOR_DID`) gets a
+hard-tight built-in default (e.g. 2/min, 1 in-flight) regardless of config.
+
+---
+
+## 4. Config model, semantics, observability
+
+### 4.1 Where limits live
+
+Extend the existing `policy:` block (already the home of principals/roles —
+`cortex.yaml.example:200`), reusing the Zod vocabulary from `offering.ts`:
+
+```yaml
+policy:
+  admission:
+    stack:                      # tier 1 — global ceiling
+      max_concurrent: 8
+      per_minute: 30
+    defaults:                   # tier 2 — every principal unless overridden
+      per_minute: 6
+      per_hour: 60
+      max_concurrent: 3
+    roles:                      # role-level overrides (union → most permissive wins,
+      principal:                # same union semantics as capability grants)
+        per_minute: 20
+        max_concurrent: 6
+      surface:                  # e.g. the amt-surface principal's role
+        per_minute: 10
+    principals:                 # tier-2 per-principal override (most specific wins)
+      - id: amt-surface
+        per_minute: 12
+        max_concurrent: 2
+    anonymous:                  # the open-onboarding floor — cannot be raised above
+      per_minute: 2             # a built-in cap
+      max_concurrent: 1
+```
+
+Resolution: `principals[id]` > `roles` (most permissive of the principal's roles, like
+capability union — `engine.ts` semantics) > `defaults`; `stack` always also applies.
+Public offerings keep their existing `accept.limits` (`PublicLimitsSchema`) — the gate
+floor composes both; the *tighter* bound wins. Absent `admission:` block ⇒ limiter off
+⇒ byte-identical behaviour (the CO-4 pattern: new gates must be provably inert until
+configured — `gate-floor.ts:29-37`).
+
+### 4.2 Enforcement points (all call the one primitive)
+
+1. `handleDispatchEnvelope` — after the policy allow, before harness construction
+   (`dispatch-listener.ts` between `:1913` and `:1950`). Ordering mirrors the gate
+   floor's rule: permanent refusals (policy) before transient ones (rate)
+   (`gate-floor.ts:195-202`) — and keeps KV I/O off the path of requests that were
+   going to be denied anyway.
+2. The offered-capability admission closure — supplies real `rateOk` to
+   `gateFloorForScope` (`cortex.ts:1663`).
+3. Review/dev/release consumers — their step-4 concurrency gates
+   (`dev-consumer.ts:528`) delegate to the shared primitive (in-flight counters in KV
+   instead of three process-local `Set`s).
+
+### 4.3 Reject-on-exceed semantics (what the surface sees)
+
+Exactly the existing taxonomy — nothing new on the wire:
+
+- **Interactive (chat/direct, core NATS):** terminal `dispatch.task.failed` with
+  `reason: { kind: "not_now", detail: "admission: rate limit (principal=…, window=…)",
+  retry_after_ms }` on the dispatch's correlation id. Surfaces already render terminal
+  failures (worklog-manager, Discord, MC); web:amt sees it on the reply leg it already
+  correlates (AMT-R12). Recommend a friendly renderer string ("busy — try again in
+  ~Ns") rather than raw taxonomy.
+- **Queued (JetStream consumers):** `nak(retry_after_ms)` + the same
+  `dispatch.task.failed not_now` event — JetStream redelivers after the delay, i.e.
+  throttled work *defers* instead of dying, up to `max_deliver` (5) attempts
+  (`provision.ts:161`).
+- **Never `term` for rate** — rate exhaustion is transient by definition; `term` is
+  reserved for policy/compliance (permanent) refusals.
+
+### 4.4 Observability
+
+- New audit envelope `system.admission.throttled` (sibling of
+  `system.access.denied`, `dispatch-listener.ts:1867-1871`) carrying key, tier,
+  window, current count, retry hint — JetStream-backed like all `system.*`.
+- Counters on the MC dashboard (Tier-1 card: throttles by principal/tier over time);
+  per-key gauges via the existing `transportMetricsSubject` plumbing
+  (`myelin/src/subjects.ts:546`).
+- Degraded-mode transitions (KV unreachable → fallback posture) MUST emit a loud
+  `system.*` event — never silent (the R6 lesson).
+- `cortex admission status` CLI: dump live KV buckets for a principal (debuggability —
+  the "single number anyone can audit" that Design C can't give).
+
+---
+
+## 5. Phased implementation outline
+
+- **Phase 1 — the primitive + the chat gate (first increment).**
+  `src/bus/admission/` module: KV bucket provisioning (idempotent, `provision.ts`
+  pattern), CAS token bucket, config schema (`policy.admission`), enforcement point 1
+  (dispatch-listener pre-spawn), tiers 1–2 (stack + principal), anonymous floor,
+  `system.admission.throttled` + renderer string. Absent config ⇒ inert.
+  *Covers Discord + web:amt + gateway surfaces end-to-end; correct under N nodes from
+  day one.*
+- **Phase 2 — one primitive everywhere.** In-flight concurrency counters w/
+  terminal-event decrement + orphan sweeper; migrate review/dev/release
+  `maxConcurrent` gates onto it; wire real `rateOk` into the gate-floor closure
+  (`cortex.ts:1663`); tiers 3–4 keys; MC dashboard tile.
+- **Phase 3 — future state.** (a) Migrate the direct-dispatch plane to a JetStream
+  `TASKS` work-queue with shared durables — fixes multi-node double-spawn (§1.5) and
+  adds `max_ack_pending` as a transport-level backstop under the KV limiter;
+  (b) push the admission contract down into `@the-metafactory/myelin` (with signed-KV,
+  myelin#31); (c) real BudgetCheck accounting (cortex#977) over the same KV state,
+  pricing admits via envelope `economics`.
+
+---
+
+## 6. Open questions for Andreas
+
+1. **Failure posture** when the KV admission store errors while dispatch still flows:
+   fail-closed (refuse spawns) or degrade to node-local approximate buckets with a loud
+   `system.*` event? (I lean degraded-local: NATS-down usually means no dispatch at
+   all, so the residual window is small — but public/anonymous keys should arguably
+   fail closed.)
+2. **Default key depth:** ship tiers 1–2 (stack + principal) only, or is
+   principal×agent (tier 3) needed from day one for the AMT/pylon seam?
+3. **Config home:** `policy.admission` (proposed) vs. limits as fields on
+   `RoleDefinition` — any preference for where operators tune this?
+4. **Phase-3 timing:** is multi-node cortex close enough that the JetStream
+   work-queue migration (double-spawn fix) should be pulled into this epic, or does
+   R26 ship phases 1–2 and the transport migration stays a separate issue?
+5. **Myelin ownership:** define the admission contract as a myelin spec now (with
+   cortex as first implementation), or cortex-local until signed-KV (myelin#31) ships?
+6. **Interactive semantics:** confirm reject-fast (`not_now` + retry hint rendered to
+   the user) for chat, rather than silently queueing throttled chat dispatches.
+
+---
+
+*Evidence base: cortex @ main (2026-07-02), myelin sibling checkout. All file:line
+references verified against working trees at `~/Developer/cortex` and
+`~/Developer/myelin`.*

--- a/docs/design-substrate-rate-limiting.md
+++ b/docs/design-substrate-rate-limiting.md
@@ -415,7 +415,7 @@ Exactly the existing taxonomy — nothing new on the wire:
 2. **Default key depth:** ship tiers 1–2 (stack + principal) only, or is
    principal×agent (tier 3) needed from day one for the AMT/pylon seam?
 3. **Config home:** `policy.admission` (proposed) vs. limits as fields on
-   `RoleDefinition` — any preference for where operators tune this?
+   `RoleDefinition` — any preference for where these limits are tuned?
 4. **Phase-3 timing:** is multi-node cortex close enough that the JetStream
    work-queue migration (double-spawn fix) should be pulled into this epic, or does
    R26 ship phases 1–2 and the transport migration stays a separate issue?

--- a/src/__tests__/cortex.security-posture-boot.test.ts
+++ b/src/__tests__/cortex.security-posture-boot.test.ts
@@ -116,11 +116,18 @@ function withCapturedConsoleLog<T>(
     });
 }
 
+// Hermetic agents.d/ (R26 P1 PR hygiene, cortex#1371): point every boot at an
+// EMPTY tmp agents dir so the suite never falls back to the principal's LIVE
+// `~/.config/cortex/agents.d/` — a live fragment whose `trust:` names an id
+// unknown to the test config crashes registry assembly (machine-state flake).
+const HERMETIC_AGENTS_DIR = mkdtempSync(join(tmpdir(), "cortex-posture-agents-hermetic-"));
+
 const COMMON_OPTS = {
   disableConfigWatcher: true,
   disableDashboard: true,
   disableOutboundPoller: true,
   principal: { id: "test-op" },
+  agentsDir: HERMETIC_AGENTS_DIR,
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -25,6 +25,13 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync, chmodSync, symlinkSync } from "fs";
+// Hermetic agents.d/ (R26 P1 PR hygiene, cortex#1371): every `startCortex`
+// boot in this file points `agentsDir` at an EMPTY tmp dir. Without it the
+// boot path falls back to the principal's LIVE `~/.config/cortex/agents.d/`
+// (the documented production fallback), and whatever fragments live there
+// (e.g. an agent whose `trust:` names an id not in the test config) crash
+// registry assembly — the whole suite then fails on machine state, not code.
+const HERMETIC_AGENTS_DIR = mkdtempSync(join(tmpdir(), "cortex-test-agents-hermetic-"));
 import { join, basename } from "path";
 import { tmpdir } from "os";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
@@ -117,6 +124,7 @@ describe("startCortex — construction", () => {
     const config = minimalConfig();
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       principal: { id: "test-op" },
@@ -140,6 +148,7 @@ describe("startCortex — construction", () => {
     });
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       principal: { id: "test-op" },
@@ -161,6 +170,7 @@ describe("startCortex — construction", () => {
     const handle = await startCortex(config, {
       stack: { id: "test-op/research" },
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       principal: { id: "test-op" },
@@ -187,6 +197,7 @@ describe("startCortex — wire-up", () => {
     const config = minimalConfig();
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
@@ -222,6 +233,7 @@ describe("startCortex — wire-up", () => {
     const config = minimalConfig();
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
@@ -298,6 +310,7 @@ describe("startCortex — wire-up", () => {
     });
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
@@ -329,6 +342,7 @@ describe("startCortex — wire-up", () => {
     try {
       await startCortex(noPrincipal, {
         disableConfigWatcher: true,
+        agentsDir: HERMETIC_AGENTS_DIR,
         disableDashboard: true,
         disableOutboundPoller: true,
         injectRuntime: runtime,
@@ -366,6 +380,7 @@ describe("startCortex — wire-up", () => {
     });
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
@@ -405,6 +420,7 @@ describe("startCortex — wire-up", () => {
     });
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
@@ -431,6 +447,7 @@ describe("startCortex — shutdown", () => {
     const config = minimalConfig();
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       principal: { id: "test-op" },
@@ -446,6 +463,7 @@ describe("startCortex — shutdown", () => {
     const config = minimalConfig();
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       principal: { id: "test-op" },
@@ -485,6 +503,7 @@ describe("startCortex — shutdown", () => {
     try {
       handle = await startCortex(minimalConfig(), {
         disableConfigWatcher: true,
+        agentsDir: HERMETIC_AGENTS_DIR,
         disableDashboard: true,
         disableOutboundPoller: true,
         injectRuntime: runtime,
@@ -529,6 +548,7 @@ describe("startCortex — error surface", () => {
     const config = minimalConfig({ networks: [] });
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       principal: { id: "test-op" },
@@ -545,6 +565,7 @@ describe("startCortex — error surface", () => {
     });
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+      agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       principal: { id: "test-op" },

--- a/src/__tests__/principal-identity-consistency.test.ts
+++ b/src/__tests__/principal-identity-consistency.test.ts
@@ -60,6 +60,14 @@
 import { describe, expect, test } from "bun:test";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import { startCortex } from "../cortex";
+// Hermetic agents.d/ (R26 P1 PR hygiene, cortex#1371) — see cortex.test.ts:
+// without an explicit `agentsDir` these boots read the principal's LIVE
+// `~/.config/cortex/agents.d/` and fail on machine state, not code.
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const HERMETIC_AGENTS_DIR = mkdtempSync(join(tmpdir(), "cortex-identity-agents-hermetic-"));
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type {
   EnvelopeHandler,
@@ -131,6 +139,7 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
 
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+    agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
@@ -232,6 +241,7 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
 
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+    agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
@@ -277,6 +287,7 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
 
     const handle = await startCortex(config, {
       disableConfigWatcher: true,
+    agentsDir: HERMETIC_AGENTS_DIR,
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
@@ -309,6 +320,7 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
     try {
       await startCortex(config, {
         disableConfigWatcher: true,
+    agentsDir: HERMETIC_AGENTS_DIR,
         disableDashboard: true,
         disableOutboundPoller: true,
         injectRuntime: runtime,
@@ -342,6 +354,7 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
     try {
       await startCortex(config, {
         disableConfigWatcher: true,
+    agentsDir: HERMETIC_AGENTS_DIR,
         disableDashboard: true,
         disableOutboundPoller: true,
         injectRuntime: runtime,

--- a/src/bus/admission/__tests__/gate.test.ts
+++ b/src/bus/admission/__tests__/gate.test.ts
@@ -1,0 +1,464 @@
+/**
+ * R26 P1 (cortex#1371) — tests for the AdmissionGate against an in-memory
+ * CAS-faithful KV stub. Covers the review checklist for the primitive:
+ *
+ *   - concurrent admits SERIALISE through CAS (exactly `limit` admits win);
+ *   - window rollover readmits;
+ *   - degrade path: store error ⇒ node-local fallback + loud transition
+ *     events (once per transition, recovery discards local state);
+ *   - anonymous fail-closed on store error + built-in ceiling clamp;
+ *   - refusals are READ-ONLY (no KV writes — myelin spec §5 rule 1);
+ *   - in-flight leases: acquire on admit, release on terminal, TTL prune;
+ *   - nothing-configured-for-requester ⇒ inert (zero KV I/O).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ProvisionKv, ProvisionKvEntry } from "../../jetstream/types";
+import { AdmissionGate, type DegradeMode } from "../gate";
+import type { AdmissionPolicy } from "../../../common/types/admission";
+
+const T0 = 1_751_412_000_000;
+
+/**
+ * In-memory KV faithful to the NATS-KV CAS semantics the gate relies on:
+ * `create` rejects when the key exists; `update` rejects unless the given
+ * revision is the live one. Tracks op counts so tests can assert the
+ * read-only-refusal property.
+ */
+function memoryKv(): {
+  kv: ProvisionKv;
+  data: Map<string, { value: Uint8Array; revision: number }>;
+  writes: () => number;
+  failNext: (n: number) => void;
+  failAll: (on: boolean) => void;
+} {
+  const data = new Map<string, { value: Uint8Array; revision: number }>();
+  let revisionCounter = 0;
+  let writeCount = 0;
+  let failNextN = 0;
+  let failEverything = false;
+  const maybeFail = () => {
+    if (failEverything) throw new Error("kv unavailable (simulated outage)");
+    if (failNextN > 0) {
+      failNextN--;
+      throw new Error("kv transient failure (simulated)");
+    }
+  };
+  const kv: ProvisionKv = {
+     
+    get: async (key): Promise<ProvisionKvEntry | null> => {
+      maybeFail();
+      const e = data.get(key);
+      if (e === undefined) return null;
+      return { value: e.value, revision: e.revision, operation: "PUT" };
+    },
+     
+    create: async (key, value): Promise<number> => {
+      maybeFail();
+      if (data.has(key)) throw new Error(`wrong last sequence: key "${key}" exists`);
+      writeCount++;
+      const revision = ++revisionCounter;
+      data.set(key, { value, revision });
+      return revision;
+    },
+     
+    update: async (key, value, revision): Promise<number> => {
+      maybeFail();
+      const e = data.get(key);
+      if (e?.revision !== revision) {
+        throw new Error(`wrong last sequence: expected ${e?.revision ?? "<absent>"}, got ${revision}`);
+      }
+      writeCount++;
+      const next = ++revisionCounter;
+      data.set(key, { value, revision: next });
+      return next;
+    },
+  };
+  return {
+    kv,
+    data,
+    writes: () => writeCount,
+    failNext: (n) => {
+      failNextN = n;
+    },
+    failAll: (on) => {
+      failEverything = on;
+    },
+  };
+}
+
+function makeGate(
+  config: AdmissionPolicy,
+  kv: ProvisionKv | null,
+  opts: {
+    clock?: () => number;
+    roles?: ReadonlyMap<string, readonly string[]>;
+    transitions?: { mode: DegradeMode; detail: string }[];
+    casAttempts?: number;
+    leaseTtlMs?: number;
+  } = {},
+): AdmissionGate {
+  return new AdmissionGate({
+    config,
+    kv,
+    principalRoles: opts.roles ?? new Map(),
+    clock: opts.clock ?? (() => T0),
+    log: { warn: () => {} },
+    ...(opts.transitions !== undefined && {
+      onDegradeTransition: (mode: DegradeMode, detail: string) => {
+        opts.transitions?.push({ mode, detail });
+      },
+    }),
+    ...(opts.casAttempts !== undefined && { casAttempts: opts.casAttempts }),
+    ...(opts.leaseTtlMs !== undefined && { leaseTtlMs: opts.leaseTtlMs }),
+  });
+}
+
+const named = (leaseId: string, principalId = "andreas") => ({
+  principalId,
+  anonymous: false,
+  leaseId,
+});
+
+describe("AdmissionGate — distributed (KV) path", () => {
+  test("admits under the limit, refuses over it, with per-window retry hint", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ defaults: { per_minute: 2 } }, m.kv);
+    expect((await gate.check(named("t1"))).admit).toBe(true);
+    expect((await gate.check(named("t2"))).admit).toBe(true);
+    const third = await gate.check(named("t3"));
+    expect(third.admit).toBe(false);
+    if (!third.admit) {
+      expect(third.reason).toBe("rate");
+      expect(third.tier).toBe("principal");
+      expect(third.key).toBe("rate.principal.andreas");
+      expect(third.window).toBe("per_minute");
+      expect(third.limit).toBe(2);
+      expect(third.retry_after_ms).toBeGreaterThan(0);
+      expect(third.degraded).toBe(false);
+    }
+  });
+
+  test("CONCURRENT admits serialise via CAS — exactly `limit` admits win", async () => {
+    const m = memoryKv();
+    // High CAS attempt budget: with 12 genuinely-concurrent contenders on one
+    // key, a fair loser needs several re-reads before the dust settles.
+    const gate = makeGate({ defaults: { per_minute: 5 } }, m.kv, {
+      casAttempts: 32,
+    });
+    const outcomes = await Promise.all(
+      Array.from({ length: 12 }, (_, i) => gate.check(named(`task-${i}`))),
+    );
+    const admits = outcomes.filter((o) => o.admit).length;
+    const refusals = outcomes.filter((o) => !o.admit);
+    expect(admits).toBe(5);
+    expect(refusals).toHaveLength(7);
+    // Every refusal is the transient rate taxonomy, never a store error.
+    for (const r of refusals) {
+      if (!r.admit) expect(r.reason).toBe("rate");
+    }
+  });
+
+  test("window rollover readmits after the window elapses", async () => {
+    const m = memoryKv();
+    let now = T0;
+    const gate = makeGate({ defaults: { per_minute: 1 } }, m.kv, {
+      clock: () => now,
+    });
+    expect((await gate.check(named("t1"))).admit).toBe(true);
+    expect((await gate.check(named("t2"))).admit).toBe(false);
+    now = T0 + 60_000;
+    expect((await gate.check(named("t3"))).admit).toBe(true);
+  });
+
+  test("refusals are READ-ONLY — no KV writes past the point of refusal", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ defaults: { per_minute: 1 } }, m.kv);
+    await gate.check(named("t1")); // consumes the single token (1 write)
+    const writesAfterAdmit = m.writes();
+    await gate.check(named("t2")); // refused — must not write
+    await gate.check(named("t3")); // refused — must not write
+    expect(m.writes()).toBe(writesAfterAdmit);
+  });
+
+  test("stack tier (tier 1) is evaluated before principal (tier 2) and wins refusals", async () => {
+    const m = memoryKv();
+    const gate = makeGate(
+      { stack: { per_minute: 1 }, defaults: { per_minute: 5 } },
+      m.kv,
+    );
+    expect((await gate.check(named("t1", "alice"))).admit).toBe(true);
+    // A DIFFERENT principal is refused by the shared stack ceiling.
+    const refused = await gate.check(named("t2", "bob"));
+    expect(refused.admit).toBe(false);
+    if (!refused.admit) {
+      expect(refused.tier).toBe("stack");
+      expect(refused.key).toBe("rate.stack");
+    }
+  });
+
+  test("max_concurrent: lease acquired on admit, released lease frees the slot", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ defaults: { max_concurrent: 1 } }, m.kv);
+    const first = await gate.check(named("t1"));
+    expect(first.admit).toBe(true);
+    const lease = first.admit ? first.lease : undefined;
+    expect(lease).toBeDefined();
+    expect(lease?.keys).toEqual(["inflight.principal.andreas"]);
+
+    const blocked = await gate.check(named("t2"));
+    expect(blocked.admit).toBe(false);
+    if (!blocked.admit) {
+      expect(blocked.reason).toBe("concurrency");
+      expect(blocked.limit).toBe(1);
+    }
+
+    if (lease !== undefined) await gate.release(lease);
+    expect((await gate.check(named("t3"))).admit).toBe(true);
+  });
+
+  test("orphan leases TTL-prune: a dead node's lease stops blocking after the TTL", async () => {
+    const m = memoryKv();
+    let now = T0;
+    const gate = makeGate({ defaults: { max_concurrent: 1 } }, m.kv, {
+      clock: () => now,
+      leaseTtlMs: 1000,
+    });
+    expect((await gate.check(named("orphan"))).admit).toBe(true);
+    // Never released (node died). Within the TTL the slot stays taken…
+    expect((await gate.check(named("t2"))).admit).toBe(false);
+    // …and after the TTL the prune rule frees it.
+    now = T0 + 1001;
+    expect((await gate.check(named("t3"))).admit).toBe(true);
+  });
+
+  test("role-derived limits: most permissive role wins; principal override beats roles", async () => {
+    const m = memoryKv();
+    const config: AdmissionPolicy = {
+      defaults: { per_minute: 1 },
+      roles: { basic: { per_minute: 2 }, power: { per_minute: 4 } },
+      principals: [{ id: "vip", per_minute: 6 }],
+    };
+    const roles = new Map<string, readonly string[]>([
+      ["dual", ["basic", "power"]],
+      ["vip", ["basic"]],
+    ]);
+    const gate = makeGate(config, m.kv, { roles });
+    // dual holds both roles → 4/min (most permissive), not 2.
+    for (let i = 0; i < 4; i++) {
+      expect((await gate.check(named(`d${i}`, "dual"))).admit).toBe(true);
+    }
+    expect((await gate.check(named("d4", "dual"))).admit).toBe(false);
+    // vip's principal override (6) beats its role (2) and the default (1).
+    for (let i = 0; i < 6; i++) {
+      expect((await gate.check(named(`v${i}`, "vip"))).admit).toBe(true);
+    }
+    expect((await gate.check(named("v6", "vip"))).admit).toBe(false);
+  });
+
+  test("requester with NO resolved limits is inert — zero KV I/O", async () => {
+    const m = memoryKv();
+    // Only a principal override for someone else — no stack, no defaults.
+    const gate = makeGate(
+      { principals: [{ id: "other", per_minute: 1 }] },
+      m.kv,
+    );
+    const outcome = await gate.check(named("t1", "unlimited"));
+    expect(outcome).toEqual({ admit: true, lease: undefined, degraded: false });
+    expect(m.data.size).toBe(0);
+    expect(m.writes()).toBe(0);
+  });
+});
+
+describe("AdmissionGate — anonymous principal", () => {
+  const anon = (leaseId: string) => ({
+    principalId: "public",
+    anonymous: true,
+    leaseId,
+  });
+
+  /** Admit + immediately release the in-flight lease, so the ceiling's
+   * `max_concurrent: 1` doesn't shadow the per-minute clamp under test. */
+  async function checkAndRelease(
+    gate: AdmissionGate,
+    leaseId: string,
+  ): Promise<Awaited<ReturnType<AdmissionGate["check"]>>> {
+    const outcome = await gate.check(anon(leaseId));
+    if (outcome.admit && outcome.lease !== undefined) {
+      await gate.release(outcome.lease);
+    }
+    return outcome;
+  }
+
+  test("built-in ceiling clamps config: 2/min even when config says 100/min", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ anonymous: { per_minute: 100 } }, m.kv);
+    expect((await checkAndRelease(gate, "a1")).admit).toBe(true);
+    expect((await checkAndRelease(gate, "a2")).admit).toBe(true);
+    const third = await checkAndRelease(gate, "a3");
+    expect(third.admit).toBe(false);
+    if (!third.admit) {
+      expect(third.reason).toBe("rate");
+      expect(third.limit).toBe(2);
+    }
+  });
+
+  test("ceiling's max_concurrent: 1 holds while an anonymous dispatch is in flight", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ anonymous: { per_minute: 100, max_concurrent: 50 } }, m.kv);
+    const first = await gate.check(anon("a1"));
+    expect(first.admit).toBe(true);
+    // Lease NOT released — the single in-flight slot is taken.
+    const second = await gate.check(anon("a2"));
+    expect(second.admit).toBe(false);
+    if (!second.admit) {
+      expect(second.reason).toBe("concurrency");
+      expect(second.limit).toBe(1);
+    }
+  });
+
+  test("ceiling applies even with NO anonymous block (any admission config arms it)", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ defaults: { per_minute: 50 } }, m.kv);
+    expect((await checkAndRelease(gate, "a1")).admit).toBe(true);
+    expect((await checkAndRelease(gate, "a2")).admit).toBe(true);
+    expect((await checkAndRelease(gate, "a3")).admit).toBe(false);
+  });
+
+  test("FAILS CLOSED on store error (never rides the local fallback)", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ defaults: { per_minute: 50 } }, m.kv);
+    m.failAll(true);
+    const outcome = await gate.check(anon("a1"));
+    expect(outcome.admit).toBe(false);
+    if (!outcome.admit) {
+      expect(outcome.reason).toBe("store_error");
+      expect(outcome.degraded).toBe(true);
+      expect(outcome.retry_after_ms).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("AdmissionGate — degrade posture (design §4.3 / Q1)", () => {
+  test("store outage degrades NAMED principals to local buckets, loudly, once", async () => {
+    const m = memoryKv();
+    const transitions: { mode: DegradeMode; detail: string }[] = [];
+    const gate = makeGate({ defaults: { per_minute: 2 } }, m.kv, { transitions });
+    m.failAll(true);
+
+    // Local fallback still ENFORCES the limits — approximate, not absent.
+    const first = await gate.check(named("t1"));
+    expect(first.admit).toBe(true);
+    if (first.admit) expect(first.degraded).toBe(true);
+    expect((await gate.check(named("t2"))).admit).toBe(true);
+    const refused = await gate.check(named("t3"));
+    expect(refused.admit).toBe(false);
+    if (!refused.admit) {
+      expect(refused.reason).toBe("rate");
+      expect(refused.degraded).toBe(true);
+    }
+    // ONE transition event for three degraded checks — per transition, not
+    // per request (design §4.4).
+    expect(transitions.map((t) => t.mode)).toEqual(["degraded-local"]);
+  });
+
+  test("recovery: next successful KV round-trip emits 'recovered' and discards local state", async () => {
+    const m = memoryKv();
+    const transitions: { mode: DegradeMode; detail: string }[] = [];
+    const gate = makeGate({ defaults: { per_minute: 2 } }, m.kv, { transitions });
+    m.failAll(true);
+    await gate.check(named("t1"));
+    m.failAll(false);
+    const recovered = await gate.check(named("t2"));
+    expect(recovered.admit).toBe(true);
+    if (recovered.admit) expect(recovered.degraded).toBe(false);
+    expect(transitions.map((t) => t.mode)).toEqual(["degraded-local", "recovered"]);
+  });
+
+  test("kv === null (provisioning failed at boot): permanently degraded, named ride local", async () => {
+    const transitions: { mode: DegradeMode; detail: string }[] = [];
+    const gate = makeGate({ defaults: { per_minute: 1 } }, null, { transitions });
+    const first = await gate.check(named("t1"));
+    expect(first.admit).toBe(true);
+    if (first.admit) expect(first.degraded).toBe(true);
+    expect((await gate.check(named("t2"))).admit).toBe(false);
+    expect(transitions.map((t) => t.mode)).toEqual(["degraded-local"]);
+  });
+
+  test("CAS exhaustion takes the store posture (degraded), not a crash", async () => {
+    const m = memoryKv();
+    const transitions: { mode: DegradeMode; detail: string }[] = [];
+    // casAttempts=1 + a competing writer that always wins ⇒ exhaustion.
+    const gate = makeGate({ defaults: { per_minute: 5 } }, m.kv, {
+      transitions,
+      casAttempts: 1,
+    });
+    // Seed the key, then wrap update to ALWAYS lose the race once.
+    await gate.check(named("seed"));
+    const realUpdate = m.kv.update.bind(m.kv);
+    let sabotage = true;
+    m.kv.update = async (key, value, revision) => {
+      if (sabotage) throw new Error("wrong last sequence (simulated racer)");
+      return realUpdate(key, value, revision);
+    };
+    const outcome = await gate.check(named("contended"));
+    sabotage = false;
+    // Named principal: degraded-local decision, still an ADMIT (limit 5).
+    expect(outcome.admit).toBe(true);
+    if (outcome.admit) expect(outcome.degraded).toBe(true);
+    expect(transitions.map((t) => t.mode)).toEqual(["degraded-local"]);
+  });
+
+  test("a NEWER-versioned entry takes the store posture (never guessed at)", async () => {
+    const m = memoryKv();
+    m.data.set("rate.principal.andreas", {
+      value: new TextEncoder().encode('{"v":2,"windows":{}}'),
+      revision: 1,
+    });
+    const transitions: { mode: DegradeMode; detail: string }[] = [];
+    const gate = makeGate({ defaults: { per_minute: 5 } }, m.kv, { transitions });
+    const outcome = await gate.check(named("t1"));
+    expect(outcome.admit).toBe(true); // named → local fallback admits
+    if (outcome.admit) expect(outcome.degraded).toBe(true);
+    expect(transitions.map((t) => t.mode)).toEqual(["degraded-local"]);
+  });
+
+  test("local lease release works in degraded mode", async () => {
+    const gate = makeGate({ defaults: { max_concurrent: 1 } }, null);
+    const first = await gate.check(named("t1"));
+    expect(first.admit).toBe(true);
+    const lease = first.admit ? first.lease : undefined;
+    expect(lease?.local).toBe(true);
+    expect((await gate.check(named("t2"))).admit).toBe(false);
+    if (lease !== undefined) await gate.release(lease);
+    expect((await gate.check(named("t3"))).admit).toBe(true);
+  });
+});
+
+describe("AdmissionGate — release robustness", () => {
+  test("release never throws, even on a hard store outage", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ defaults: { max_concurrent: 2 } }, m.kv);
+    const outcome = await gate.check(named("t1"));
+    const lease = outcome.admit ? outcome.lease : undefined;
+    expect(lease).toBeDefined();
+    m.failAll(true);
+    if (lease !== undefined) {
+      // Must resolve, never reject — a release failure is logged gate-side
+      // and the lease TTL self-heals.
+      await gate.release(lease);
+    }
+  });
+
+  test("double release is a no-op", async () => {
+    const m = memoryKv();
+    const gate = makeGate({ defaults: { max_concurrent: 2 } }, m.kv);
+    const outcome = await gate.check(named("t1"));
+    const lease = outcome.admit ? outcome.lease : undefined;
+    if (lease !== undefined) {
+      await gate.release(lease);
+      await gate.release(lease);
+    }
+    expect((await gate.check(named("t2"))).admit).toBe(true);
+  });
+});

--- a/src/bus/admission/__tests__/provision.test.ts
+++ b/src/bus/admission/__tests__/provision.test.ts
@@ -1,0 +1,135 @@
+/**
+ * R26 P1 (cortex#1371) — tests for the admission KV bucket provisioning
+ * (`provision.ts`): bucket naming, created/exists reporting, and the
+ * NON-FATAL unavailable path that hands the gate its degraded posture.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ProvisionJsm, ProvisionKv } from "../../jetstream/types";
+import { admissionBucketName, provisionAdmissionKv } from "../provision";
+
+const silentLog = { info: () => {}, warn: () => {} };
+
+function stubJsm(existingStreams: readonly string[]): ProvisionJsm {
+  return {
+    streams: {
+       
+      info: async (name: string) => {
+        if (existingStreams.includes(name)) {
+          return {} as Awaited<ReturnType<ProvisionJsm["streams"]["info"]>>;
+        }
+        const err = new Error("stream not found") as Error & {
+          api_error: { err_code: number };
+        };
+        err.api_error = { err_code: 10059 };
+        throw err;
+      },
+      add: async () => {
+        throw new Error("unexpected streams.add in admission provisioning");
+      },
+    },
+    consumers: {
+      info: async () => {
+        throw new Error("unused");
+      },
+      add: async () => {
+        throw new Error("unused");
+      },
+      update: async () => {
+        throw new Error("unused");
+      },
+      delete: async () => {
+        throw new Error("unused");
+      },
+    },
+  };
+}
+
+const stubKv: ProvisionKv = {
+   
+  get: async () => null,
+   
+  create: async () => 1,
+   
+  update: async () => 2,
+};
+
+describe("admissionBucketName", () => {
+  test("builds the myelin spec §2 shape from subject segments", () => {
+    expect(admissionBucketName("metafactory", "default")).toBe(
+      "admission_metafactory_default",
+    );
+    expect(admissionBucketName("andreas", "work")).toBe("admission_andreas_work");
+  });
+
+  test("defensively maps non-bucket-safe characters to '-'", () => {
+    expect(admissionBucketName("andreas", "an/odd.stack")).toBe(
+      "admission_andreas_an-odd-stack",
+    );
+  });
+});
+
+describe("provisionAdmissionKv", () => {
+  test("reports 'created' when the backing stream did not pre-exist", async () => {
+    const result = await provisionAdmissionKv({
+      jsm: stubJsm([]),
+       
+      openKv: async () => stubKv,
+      bucket: "admission_metafactory_default",
+      log: silentLog,
+    });
+    expect(result.outcome).toBe("created");
+    expect(result.kv).toBe(stubKv);
+  });
+
+  test("reports 'exists' when the backing stream pre-exists (idempotent boot)", async () => {
+    const result = await provisionAdmissionKv({
+      jsm: stubJsm(["KV_admission_metafactory_default"]),
+       
+      openKv: async () => stubKv,
+      bucket: "admission_metafactory_default",
+      log: silentLog,
+    });
+    expect(result.outcome).toBe("exists");
+    expect(result.kv).toBe(stubKv);
+  });
+
+  test("open failure is NON-FATAL: 'unavailable' + null kv (degraded posture), never a throw", async () => {
+    const result = await provisionAdmissionKv({
+      jsm: stubJsm([]),
+      openKv: async () => {
+        throw new Error("no jetstream");
+      },
+      bucket: "admission_metafactory_default",
+      log: silentLog,
+    });
+    expect(result).toEqual({ outcome: "unavailable", kv: null });
+  });
+
+  test("disabled runtime (openKv → null, jsm null) resolves 'unavailable'", async () => {
+    const result = await provisionAdmissionKv({
+      jsm: null,
+       
+      openKv: async () => null,
+      bucket: "admission_metafactory_default",
+      log: silentLog,
+    });
+    expect(result).toEqual({ outcome: "unavailable", kv: null });
+  });
+
+  test("a non-404 peek failure still proceeds to the KV open (open decides)", async () => {
+    const jsm = stubJsm([]);
+    jsm.streams.info = async () => {
+      throw new Error("auth timeout");
+    };
+    const result = await provisionAdmissionKv({
+      jsm,
+       
+      openKv: async () => stubKv,
+      bucket: "admission_metafactory_default",
+      log: silentLog,
+    });
+    expect(result.outcome).toBe("exists");
+    expect(result.kv).toBe(stubKv);
+  });
+});

--- a/src/bus/admission/__tests__/state.test.ts
+++ b/src/bus/admission/__tests__/state.test.ts
@@ -1,0 +1,188 @@
+/**
+ * R26 P1 (cortex#1371) — tests for the pure admission state machinery
+ * (`state.ts`): the entry formats + refill / prune / check / consume rules
+ * from the myelin admission contract (`myelin/specs/admission.md` §4).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  acquireLease,
+  checkInflight,
+  checkRate,
+  consumeRate,
+  encodeEntry,
+  parseInflightEntry,
+  parseRateEntry,
+  pruneInflight,
+  refillRateEntry,
+  refundRate,
+  releaseLease,
+  WINDOW_MS,
+  type InflightEntry,
+  type RateEntry,
+} from "../state";
+
+const T0 = 1_751_412_000_000; // arbitrary epoch-ms anchor
+
+describe("refillRateEntry", () => {
+  test("missing entry initialises every configured window at full capacity", () => {
+    const entry = refillRateEntry(undefined, { per_minute: 6, per_hour: 60 }, T0);
+    expect(entry.windows.per_minute).toEqual({ tokens: 6, refilled_at_ms: T0 });
+    expect(entry.windows.per_hour).toEqual({ tokens: 60, refilled_at_ms: T0 });
+    expect(entry.windows.per_day).toBeUndefined();
+  });
+
+  test("refills proportionally to elapsed time, capped at capacity", () => {
+    const drained: RateEntry = {
+      v: 1,
+      windows: { per_minute: { tokens: 0, refilled_at_ms: T0 } },
+    };
+    // Half a window later → half capacity refilled.
+    const half = refillRateEntry(drained, { per_minute: 6 }, T0 + WINDOW_MS.per_minute / 2);
+    expect(half.windows.per_minute?.tokens).toBeCloseTo(3, 5);
+    // Ten windows later → capped at capacity, not 60.
+    const capped = refillRateEntry(drained, { per_minute: 6 }, T0 + 10 * WINDOW_MS.per_minute);
+    expect(capped.windows.per_minute?.tokens).toBe(6);
+  });
+
+  test("window rollover: a fully-drained window admits again after one window", () => {
+    let entry = refillRateEntry(undefined, { per_minute: 2 }, T0);
+    entry = consumeRate(entry, { per_minute: 2 });
+    entry = consumeRate(entry, { per_minute: 2 });
+    expect(checkRate(entry, { per_minute: 2 }).ok).toBe(false);
+    // One full minute later the bucket is back at capacity.
+    const rolled = refillRateEntry(entry, { per_minute: 2 }, T0 + WINDOW_MS.per_minute);
+    expect(rolled.windows.per_minute?.tokens).toBe(2);
+    expect(checkRate(rolled, { per_minute: 2 }).ok).toBe(true);
+  });
+
+  test("clock skew clamp: a retrograde clock never mints tokens", () => {
+    const drained: RateEntry = {
+      v: 1,
+      windows: { per_minute: { tokens: 1, refilled_at_ms: T0 } },
+    };
+    const past = refillRateEntry(drained, { per_minute: 6 }, T0 - 30_000);
+    expect(past.windows.per_minute?.tokens).toBe(1);
+  });
+
+  test("drops windows no longer configured; initialises newly-configured ones full", () => {
+    const entry: RateEntry = {
+      v: 1,
+      windows: { per_minute: { tokens: 1, refilled_at_ms: T0 } },
+    };
+    const migrated = refillRateEntry(entry, { per_hour: 10 }, T0);
+    expect(migrated.windows.per_minute).toBeUndefined();
+    expect(migrated.windows.per_hour).toEqual({ tokens: 10, refilled_at_ms: T0 });
+  });
+});
+
+describe("checkRate", () => {
+  test("admits when every configured window holds ≥ 1 token", () => {
+    const entry = refillRateEntry(undefined, { per_minute: 1, per_day: 5 }, T0);
+    expect(checkRate(entry, { per_minute: 1, per_day: 5 })).toEqual({ ok: true });
+  });
+
+  test("refuses with the SLOWEST refusing window's retry hint", () => {
+    // Both windows drained; per_day refills far slower, so it dominates.
+    let entry = refillRateEntry(undefined, { per_minute: 1, per_day: 1 }, T0);
+    entry = consumeRate(entry, { per_minute: 1, per_day: 1 });
+    const verdict = checkRate(entry, { per_minute: 1, per_day: 1 });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.window).toBe("per_day");
+      expect(verdict.limit).toBe(1);
+      // One full token on a 1/day bucket = a full day.
+      expect(verdict.retry_after_ms).toBe(WINDOW_MS.per_day);
+    }
+  });
+
+  test("retry hint is time-to-one-token, not time-to-full", () => {
+    let entry = refillRateEntry(undefined, { per_minute: 6 }, T0);
+    for (let i = 0; i < 6; i++) entry = consumeRate(entry, { per_minute: 6 });
+    const verdict = checkRate(entry, { per_minute: 6 });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      // capacity 6/min ⇒ one token every 10s.
+      expect(verdict.retry_after_ms).toBe(10_000);
+    }
+  });
+});
+
+describe("refundRate", () => {
+  test("returns one token, capped at capacity", () => {
+    let entry = refillRateEntry(undefined, { per_minute: 3 }, T0);
+    entry = consumeRate(entry, { per_minute: 3 });
+    expect(entry.windows.per_minute?.tokens).toBe(2);
+    entry = refundRate(entry, { per_minute: 3 });
+    expect(entry.windows.per_minute?.tokens).toBe(3);
+    // Refunding at capacity does not overflow.
+    entry = refundRate(entry, { per_minute: 3 });
+    expect(entry.windows.per_minute?.tokens).toBe(3);
+  });
+});
+
+describe("in-flight leases", () => {
+  test("acquire → check → release round-trip", () => {
+    let entry = pruneInflight(undefined, T0, 3_600_000);
+    expect(checkInflight(entry, 2)).toEqual({ ok: true });
+    entry = acquireLease(entry, "task-a", T0);
+    entry = acquireLease(entry, "task-b", T0);
+    expect(checkInflight(entry, 2)).toEqual({ ok: false, limit: 2, observed: 2 });
+    entry = releaseLease(entry, "task-a");
+    expect(checkInflight(entry, 2)).toEqual({ ok: true });
+  });
+
+  test("acquire is idempotent on lease id", () => {
+    let entry = pruneInflight(undefined, T0, 3_600_000);
+    entry = acquireLease(entry, "task-a", T0);
+    entry = acquireLease(entry, "task-a", T0 + 5);
+    expect(entry.leases).toHaveLength(1);
+  });
+
+  test("release of an absent lease is a no-op (idempotent)", () => {
+    let entry = pruneInflight(undefined, T0, 3_600_000);
+    entry = acquireLease(entry, "task-a", T0);
+    entry = releaseLease(entry, "task-a");
+    entry = releaseLease(entry, "task-a");
+    expect(entry.leases).toHaveLength(0);
+  });
+
+  test("prune drops orphan leases past the TTL (dead-node self-healing)", () => {
+    const ttl = 3_600_000;
+    let entry: InflightEntry = { v: 1, leases: [] };
+    entry = acquireLease(entry, "orphan", T0);
+    entry = acquireLease(entry, "fresh", T0 + ttl);
+    const pruned = pruneInflight(entry, T0 + ttl + 1, ttl);
+    expect(pruned.leases.map((l) => l.id)).toEqual(["fresh"]);
+  });
+});
+
+describe("entry parsing (versioned, fail-explicit)", () => {
+  test("round-trips both entry kinds through encode/parse", () => {
+    const rate = refillRateEntry(undefined, { per_minute: 6 }, T0);
+    const parsedRate = parseRateEntry(encodeEntry(rate));
+    expect(parsedRate).toEqual({ kind: "ok", entry: rate });
+
+    const inflight = acquireLease({ v: 1, leases: [] }, "task-a", T0);
+    const parsedInflight = parseInflightEntry(encodeEntry(inflight));
+    expect(parsedInflight).toEqual({ kind: "ok", entry: inflight });
+  });
+
+  test("corrupt bytes / malformed shapes parse as corrupt (self-heal path)", () => {
+    const enc = new TextEncoder();
+    expect(parseRateEntry(enc.encode("not json")).kind).toBe("corrupt");
+    expect(parseRateEntry(enc.encode('{"v":1}')).kind).toBe("corrupt");
+    expect(
+      parseRateEntry(enc.encode('{"v":1,"windows":{"per_minute":{"tokens":"x"}}}')).kind,
+    ).toBe("corrupt");
+    expect(parseInflightEntry(enc.encode('{"v":1,"leases":[{"id":1}]}')).kind).toBe(
+      "corrupt",
+    );
+  });
+
+  test("a NEWER contract version parses as 'newer' (never guessed at)", () => {
+    const enc = new TextEncoder();
+    expect(parseRateEntry(enc.encode('{"v":2,"windows":{}}')).kind).toBe("newer");
+    expect(parseInflightEntry(enc.encode('{"v":9,"leases":[]}')).kind).toBe("newer");
+  });
+});

--- a/src/bus/admission/gate.ts
+++ b/src/bus/admission/gate.ts
@@ -1,0 +1,702 @@
+/**
+ * R26 P1 (cortex#1371) — the AdmissionGate: the KV-arbitrated distributed
+ * token bucket + in-flight lease counter at the spawn gate (design
+ * `docs/design-substrate-rate-limiting.md` Design B; contract
+ * `myelin/specs/admission.md`, myelin#195).
+ *
+ * ## What this is
+ *
+ * `check()` decides whether a policy-ALLOWED dispatch may spawn, keyed on the
+ * envelope-resolved requester principal. State lives in a NATS-KV bucket
+ * (JetStream-backed — the fabric's own durable layer), arbitrated by
+ * compare-and-swap on entry revisions: concurrent admits on the same key
+ * serialise through the JetStream leader, so the counters are EXACT under N
+ * cortex nodes — no node-local drift, no divide-by-N (§1.5 / Design C
+ * rejection).
+ *
+ * ## Tiers (phase 1 ships 1–2)
+ *
+ *   1. `stack`      — the global spawn ceiling (`rate.stack`, `inflight.stack`)
+ *   2. `principal`  — per-requester (`rate.principal.{id}`, `inflight.principal.{id}`),
+ *                     limits resolved principals > roles > defaults
+ *                     (`resolveAdmissionLimits`); the anonymous public
+ *                     principal is clamped to the built-in ceiling.
+ *
+ * ## Two-phase evaluation (spec §5.1)
+ *
+ * Evaluate (read-only — a REFUSED request writes NOTHING, so a flooder can't
+ * burn shared tokens or CAS-contend admitted traffic), then commit (CAS per
+ * tier, re-validating against the fresh read; a later-tier failure refunds
+ * earlier tiers best-effort — errs toward under-admission).
+ *
+ * ## Failure posture (design §4.3, Q1 sign-off)
+ *
+ * Store errors DEGRADE to node-local approximate buckets (same pure state
+ * functions over process memory) with a LOUD transition event — never
+ * silent — and recover on the next successful KV round-trip. The anonymous
+ * public principal FAILS CLOSED while degraded: zero-authority traffic never
+ * rides the approximate path.
+ *
+ * ## Inertness
+ *
+ * The gate is only ever CONSTRUCTED when `policy.admission` is configured
+ * (`cortex.ts`); with the block absent the dispatch path carries a single
+ * `undefined` check — byte-identical behaviour (the CO-4 rule,
+ * `gate-floor.ts:29-37`). Even when constructed, a requester whose resolved
+ * tiers carry no limits admits without touching the store.
+ */
+
+import type { ProvisionKv, ProvisionKvEntry } from "../jetstream/types";
+import type {
+  AdmissionLimits,
+  AdmissionPolicy,
+} from "../../common/types/admission";
+import { resolveAdmissionLimits } from "../../common/types/admission";
+import { DEFAULT_RATE_RETRY_AFTER_MS } from "../gate-floor";
+import type {
+  InflightEntry,
+  ParsedEntry,
+  RateEntry,
+  RateWindowName,
+} from "./state";
+import {
+  DEFAULT_LEASE_TTL_MS,
+  acquireLease,
+  checkInflight,
+  checkRate,
+  consumeRate,
+  encodeEntry,
+  parseInflightEntry,
+  parseRateEntry,
+  pruneInflight,
+  refillRateEntry,
+  refundRate,
+  releaseLease,
+} from "./state";
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+/** Tier names shipped in phase 1 (3–4 reserved — myelin spec §3). */
+export type AdmissionTierName = "stack" | "principal";
+
+export interface AdmissionCheckRequest {
+  /** Bare requester principal id, envelope-resolved (myelin spec §1). */
+  principalId: string;
+  /** True when the requester resolved to the anonymous public principal. */
+  anonymous: boolean;
+  /** Lease id for in-flight counters — the dispatch task id. */
+  leaseId: string;
+}
+
+/**
+ * Opaque in-flight lease handle — pass to {@link AdmissionGate.release} when
+ * the dispatch terminates (the harness guarantees a terminal lifecycle
+ * envelope, so callers release in a `finally`).
+ */
+export interface AdmissionLease {
+  leaseId: string;
+  /** In-flight keys that acquired a lease, in acquisition order. */
+  keys: string[];
+  /** True when acquired against the node-local degraded fallback. */
+  local: boolean;
+}
+
+export type AdmissionOutcome =
+  | { admit: true; lease: AdmissionLease | undefined; degraded: boolean }
+  | {
+      admit: false;
+      /** What refused: a rate window, a concurrency cap, or the store itself. */
+      reason: "rate" | "concurrency" | "store_error";
+      tier: AdmissionTierName;
+      key: string;
+      /** Refusing window (`per_minute`|`per_hour`|`per_day`) — rate refusals only. */
+      window?: RateWindowName;
+      limit?: number;
+      observed?: number;
+      retry_after_ms: number;
+      degraded: boolean;
+    };
+
+export type DegradeMode = "degraded-local" | "recovered";
+
+export interface AdmissionGateOptions {
+  /** The parsed `policy.admission` block. */
+  config: AdmissionPolicy;
+  /**
+   * The provisioned KV bucket, or `null` when provisioning failed / the
+   * runtime is disabled — the gate then runs PERMANENTLY degraded (loud).
+   */
+  kv: ProvisionKv | null;
+  /** Principal id → role ids, from `policy.principals[].role` (tier-2 resolution). */
+  principalRoles: ReadonlyMap<string, readonly string[]>;
+  /**
+   * Degrade-posture transition hook — `cortex.ts` wires this to publish the
+   * loud `system.admission.degraded` envelope (design §4.4: transitions MUST
+   * be loud, and are emitted per TRANSITION, never per request). The gate
+   * additionally writes stderr on every transition regardless.
+   */
+  onDegradeTransition?: (mode: DegradeMode, detail: string) => void;
+  /** Injectable clock (ms epoch) — tests drive window rollover with this. */
+  clock?: () => number;
+  /** Bounded CAS retry attempts per key (spec §5 RECOMMENDED 3). */
+  casAttempts?: number;
+  /** Orphan-lease TTL (spec §4.2). */
+  leaseTtlMs?: number;
+  log?: { warn: (msg: string) => void };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** A tier with resolved limits + its KV keys (myelin spec §3 grammar). */
+interface ResolvedTier {
+  tier: AdmissionTierName;
+  limits: AdmissionLimits;
+  rateKey: string;
+  inflightKey: string;
+}
+
+/** KV-key segment guard — principal ids are subject-grammar already; a dot
+ * would open a key hierarchy, so anything unexpected maps to `-`. */
+function keySegment(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function hasRateLimits(limits: AdmissionLimits): boolean {
+  return (
+    limits.per_minute !== undefined ||
+    limits.per_hour !== undefined ||
+    limits.per_day !== undefined
+  );
+}
+
+/** Internal signal: the KV store failed (I/O error, CAS exhaustion, or an
+ * entry newer than this build understands). Caught by `check()`/`release()`
+ * and mapped to the failure posture — never escapes the gate. */
+class AdmissionStoreError extends Error {}
+
+interface ReadState<T> {
+  /** Parsed state, or `undefined` when absent / tombstoned / corrupt. */
+  state: T | undefined;
+  /** Live revision to CAS against; `null` when the key has never existed. */
+  revision: number | null;
+}
+
+export class AdmissionGate {
+  private readonly config: AdmissionPolicy;
+  private readonly kv: ProvisionKv | null;
+  private readonly principalRoles: ReadonlyMap<string, readonly string[]>;
+  private readonly onDegradeTransition:
+    | ((mode: DegradeMode, detail: string) => void)
+    | undefined;
+  private readonly clock: () => number;
+  private readonly casAttempts: number;
+  private readonly leaseTtlMs: number;
+  private readonly log: { warn: (msg: string) => void };
+
+  /** True while operating on the node-local approximate fallback. */
+  private degraded = false;
+  /** Node-local approximate state (degraded posture only). */
+  private readonly localRate = new Map<string, RateEntry>();
+  private readonly localInflight = new Map<string, InflightEntry>();
+
+  constructor(opts: AdmissionGateOptions) {
+    this.config = opts.config;
+    this.kv = opts.kv;
+    this.principalRoles = opts.principalRoles;
+    this.onDegradeTransition = opts.onDegradeTransition;
+    this.clock = opts.clock ?? Date.now;
+    this.casAttempts = opts.casAttempts ?? 3;
+    this.leaseTtlMs = opts.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
+    this.log = opts.log ?? {
+      warn: (msg: string) => process.stderr.write(`${msg}\n`),
+    };
+  }
+
+  /**
+   * Decide admission for a policy-allowed dispatch. Never throws — every
+   * failure resolves to a decision per the §4.3 posture.
+   */
+  async check(req: AdmissionCheckRequest): Promise<AdmissionOutcome> {
+    const tiers = this.resolveTiers(req);
+    // Nothing configured for this requester ⇒ inert: admit without touching
+    // the store (and without flipping any degrade state).
+    if (tiers.length === 0) {
+      return { admit: true, lease: undefined, degraded: false };
+    }
+    const nowMs = this.clock();
+
+    if (this.kv !== null) {
+      try {
+        const outcome = await this.checkDistributed(tiers, req, nowMs);
+        this.noteRecovered();
+        return outcome;
+      } catch (err) {
+        if (!(err instanceof AdmissionStoreError)) {
+          // Unexpected fault — same posture as a store error, but say so.
+          this.log.warn(
+            `admission-gate: unexpected fault during KV check (${err instanceof Error ? err.message : String(err)}) — taking store-error posture`,
+          );
+        }
+        this.noteDegraded(
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    } else {
+      this.noteDegraded("admission KV bucket unavailable since boot");
+    }
+
+    // ---- Degraded posture (design §4.3, Q1) ----
+    if (req.anonymous) {
+      // Anonymous FAILS CLOSED: zero-authority traffic never rides the
+      // approximate path. Transient refusal — the store may recover.
+      const firstTier = tiers[0];
+      return {
+        admit: false,
+        reason: "store_error",
+        tier: firstTier !== undefined ? firstTier.tier : "principal",
+        key: firstTier !== undefined ? firstTier.rateKey : "rate.principal.public",
+        retry_after_ms: DEFAULT_RATE_RETRY_AFTER_MS,
+        degraded: true,
+      };
+    }
+    return this.checkLocal(tiers, req, nowMs);
+  }
+
+  /**
+   * Release an in-flight lease. Idempotent; NEVER throws — a release failure
+   * must not fail the dispatch it trails (orphans are pruned by the lease
+   * TTL, spec §4.2).
+   */
+  async release(lease: AdmissionLease): Promise<void> {
+    for (const key of lease.keys) {
+      if (lease.local || this.kv === null) {
+        const entry = this.localInflight.get(key);
+        if (entry !== undefined) {
+          this.localInflight.set(key, releaseLease(entry, lease.leaseId));
+        }
+        continue;
+      }
+      try {
+        await this.releaseDistributed(key, lease.leaseId);
+      } catch (err) {
+        // Logged, not rethrown: the TTL prune self-heals the orphan.
+        this.log.warn(
+          `admission-gate: lease release failed on "${key}" (lease=${lease.leaseId}): ${err instanceof Error ? err.message : String(err)} — orphan will TTL-prune`,
+        );
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Tier resolution
+  // -------------------------------------------------------------------------
+
+  private resolveTiers(req: AdmissionCheckRequest): ResolvedTier[] {
+    const tiers: ResolvedTier[] = [];
+    if (this.config.stack !== undefined) {
+      tiers.push({
+        tier: "stack",
+        limits: this.config.stack,
+        rateKey: "rate.stack",
+        inflightKey: "inflight.stack",
+      });
+    }
+    const principalLimits = resolveAdmissionLimits(this.config, {
+      principalId: req.principalId,
+      anonymous: req.anonymous,
+      roles: this.principalRoles.get(req.principalId) ?? [],
+    });
+    if (principalLimits !== undefined) {
+      const seg = keySegment(req.principalId);
+      tiers.push({
+        tier: "principal",
+        limits: principalLimits,
+        rateKey: `rate.principal.${seg}`,
+        inflightKey: `inflight.principal.${seg}`,
+      });
+    }
+    return tiers;
+  }
+
+  // -------------------------------------------------------------------------
+  // Distributed (KV/CAS) path — myelin spec §5
+  // -------------------------------------------------------------------------
+
+  private async checkDistributed(
+    tiers: ResolvedTier[],
+    req: AdmissionCheckRequest,
+    nowMs: number,
+  ): Promise<AdmissionOutcome> {
+    // ---- Phase A: evaluate, READ-ONLY (spec §5.1). First refusal in tier
+    // order wins and nothing is written anywhere. ----
+    for (const tier of tiers) {
+      if (hasRateLimits(tier.limits)) {
+        const read = await this.readRate(tier.rateKey);
+        const refilled = refillRateEntry(read.state, tier.limits, nowMs);
+        const verdict = checkRate(refilled, tier.limits);
+        if (!verdict.ok) {
+          return this.rateRefusal(tier, verdict, false);
+        }
+      }
+      if (tier.limits.max_concurrent !== undefined) {
+        const read = await this.readInflight(tier.inflightKey);
+        const pruned = pruneInflight(read.state, nowMs, this.leaseTtlMs);
+        const verdict = checkInflight(pruned, tier.limits.max_concurrent);
+        if (!verdict.ok) {
+          return this.inflightRefusal(tier, verdict, false);
+        }
+      }
+    }
+
+    // ---- Phase B: commit, CAS per key, re-validating each fresh read. A
+    // later-tier refusal / exhaustion refunds earlier tiers (best-effort —
+    // errs toward under-admission). ----
+    const committedRate: ResolvedTier[] = [];
+    const leaseKeys: string[] = [];
+    try {
+      for (const tier of tiers) {
+        if (hasRateLimits(tier.limits)) {
+          const verdict = await this.commitRate(tier, nowMs);
+          if (verdict !== null) {
+            await this.rollback(committedRate, leaseKeys, req.leaseId, nowMs);
+            return verdict;
+          }
+          committedRate.push(tier);
+        }
+        if (tier.limits.max_concurrent !== undefined) {
+          const verdict = await this.commitLease(tier, req.leaseId, nowMs);
+          if (verdict !== null) {
+            await this.rollback(committedRate, leaseKeys, req.leaseId, nowMs);
+            return verdict;
+          }
+          leaseKeys.push(tier.inflightKey);
+        }
+      }
+    } catch (err) {
+      // Store failure mid-commit: compensate what we consumed, then let the
+      // caller take the degraded posture for the WHOLE request.
+      await this.rollback(committedRate, leaseKeys, req.leaseId, nowMs);
+      throw err;
+    }
+
+    return {
+      admit: true,
+      lease:
+        leaseKeys.length > 0
+          ? { leaseId: req.leaseId, keys: leaseKeys, local: false }
+          : undefined,
+      degraded: false,
+    };
+  }
+
+  /** Commit one token consumption on a tier's rate key. `null` = committed;
+   * a refusal decision = the fresh re-read refused (lost the race). */
+  private async commitRate(
+    tier: ResolvedTier,
+    nowMs: number,
+  ): Promise<AdmissionOutcome | null> {
+    for (let attempt = 0; attempt < this.casAttempts; attempt++) {
+      const read = await this.readRate(tier.rateKey);
+      const refilled = refillRateEntry(read.state, tier.limits, nowMs);
+      const verdict = checkRate(refilled, tier.limits);
+      if (!verdict.ok) return this.rateRefusal(tier, verdict, false);
+      const consumed = consumeRate(refilled, tier.limits);
+      if (await this.casWrite(tier.rateKey, encodeEntry(consumed), read.revision)) {
+        return null;
+      }
+      // CAS lost — another node admitted concurrently; re-read and retry.
+    }
+    throw new AdmissionStoreError(
+      `CAS retries exhausted on "${tier.rateKey}" (${this.casAttempts} attempts)`,
+    );
+  }
+
+  /** Commit a lease acquisition on a tier's in-flight key. */
+  private async commitLease(
+    tier: ResolvedTier,
+    leaseId: string,
+    nowMs: number,
+  ): Promise<AdmissionOutcome | null> {
+    const maxConcurrent = tier.limits.max_concurrent;
+    if (maxConcurrent === undefined) return null;
+    for (let attempt = 0; attempt < this.casAttempts; attempt++) {
+      const read = await this.readInflight(tier.inflightKey);
+      const pruned = pruneInflight(read.state, nowMs, this.leaseTtlMs);
+      const verdict = checkInflight(pruned, maxConcurrent);
+      if (!verdict.ok) return this.inflightRefusal(tier, verdict, false);
+      const acquired = acquireLease(pruned, leaseId, nowMs);
+      if (
+        await this.casWrite(tier.inflightKey, encodeEntry(acquired), read.revision)
+      ) {
+        return null;
+      }
+    }
+    throw new AdmissionStoreError(
+      `CAS retries exhausted on "${tier.inflightKey}" (${this.casAttempts} attempts)`,
+    );
+  }
+
+  /** Best-effort compensation when a later tier aborts a partially-committed
+   * admit (spec §5.1): refund consumed tokens, release acquired leases. A
+   * failed refund is logged and dropped — under-admission is the safe
+   * direction and self-corrects on refill / TTL prune. */
+  private async rollback(
+    committedRate: ResolvedTier[],
+    leaseKeys: string[],
+    leaseId: string,
+    nowMs: number,
+  ): Promise<void> {
+    for (const tier of committedRate) {
+      try {
+        const read = await this.readRate(tier.rateKey);
+        const refilled = refillRateEntry(read.state, tier.limits, nowMs);
+        const refunded = refundRate(refilled, tier.limits);
+        await this.casWrite(tier.rateKey, encodeEntry(refunded), read.revision);
+      } catch (err) {
+        this.log.warn(
+          `admission-gate: rate refund failed on "${tier.rateKey}": ${err instanceof Error ? err.message : String(err)} — under-admission self-corrects on refill`,
+        );
+      }
+    }
+    for (const key of leaseKeys) {
+      try {
+        await this.releaseDistributed(key, leaseId);
+      } catch (err) {
+        this.log.warn(
+          `admission-gate: lease rollback failed on "${key}": ${err instanceof Error ? err.message : String(err)} — orphan will TTL-prune`,
+        );
+      }
+    }
+  }
+
+  private async releaseDistributed(key: string, leaseId: string): Promise<void> {
+    for (let attempt = 0; attempt < this.casAttempts; attempt++) {
+      const read = await this.readInflight(key);
+      if (read.state === undefined) return; // nothing to release
+      const released = releaseLease(read.state, leaseId);
+      if (released.leases.length === read.state.leases.length) return; // absent — idempotent no-op
+      if (await this.casWrite(key, encodeEntry(released), read.revision)) {
+        return;
+      }
+    }
+    throw new AdmissionStoreError(
+      `CAS retries exhausted releasing lease on "${key}"`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // KV plumbing
+  // -------------------------------------------------------------------------
+
+  private async kvGet(key: string): Promise<ProvisionKvEntry | null> {
+    if (this.kv === null) throw new AdmissionStoreError("KV unavailable");
+    try {
+      return await this.kv.get(key);
+    } catch (err) {
+      throw new AdmissionStoreError(
+        `KV get("${key}") failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private async readRate(key: string): Promise<ReadState<RateEntry>> {
+    const entry = await this.kvGet(key);
+    return this.decodeRead(key, entry, parseRateEntry);
+  }
+
+  private async readInflight(key: string): Promise<ReadState<InflightEntry>> {
+    const entry = await this.kvGet(key);
+    return this.decodeRead(key, entry, parseInflightEntry);
+  }
+
+  private decodeRead<T>(
+    key: string,
+    entry: ProvisionKvEntry | null,
+    parse: (bytes: Uint8Array) => ParsedEntry<T>,
+  ): ReadState<T> {
+    if (entry === null) return { state: undefined, revision: null };
+    // A DEL/PURGE tombstone carries a live revision but no value — treat the
+    // VALUE as absent while CAS-ing against the tombstone's revision.
+    if (entry.operation !== "PUT") {
+      return { state: undefined, revision: entry.revision };
+    }
+    const parsed = parse(entry.value);
+    if (parsed.kind === "newer") {
+      // An entry from a NEWER contract version — never guess (spec §4);
+      // surface as a store error so the posture machinery decides.
+      throw new AdmissionStoreError(
+        `entry "${key}" carries a newer admission-contract version than this build understands`,
+      );
+    }
+    if (parsed.kind === "corrupt") {
+      // Self-healing: treat as fresh state and overwrite on the next commit
+      // (spec §4) — but SAY so, corruption is never silent.
+      this.log.warn(
+        `admission-gate: corrupt entry at "${key}" (rev=${entry.revision}) — treating as fresh state (self-heals on next admit)`,
+      );
+      return { state: undefined, revision: entry.revision };
+    }
+    return { state: parsed.entry, revision: entry.revision };
+  }
+
+  /**
+   * CAS write: `create` when the key never existed, `update(revision)`
+   * otherwise. Returns `false` on a lost race (caller re-reads and retries);
+   * only genuinely-broken transport should reject, and the caller maps that
+   * to the store posture via the bounded retry loop.
+   */
+  private async casWrite(
+    key: string,
+    value: Uint8Array,
+    revision: number | null,
+  ): Promise<boolean> {
+    if (this.kv === null) throw new AdmissionStoreError("KV unavailable");
+    try {
+      if (revision === null) {
+        await this.kv.create(key, value);
+      } else {
+        await this.kv.update(key, value, revision);
+      }
+      return true;
+    } catch {
+      // nats.js surfaces both lost-CAS shapes ("wrong last sequence", key
+      // already exists) and transport faults as rejections; the bounded
+      // retry loop upstream re-reads and either wins, refuses on the fresh
+      // state, or exhausts into the store-error posture. Treating all
+      // rejections as retryable keeps us off brittle error-string parsing.
+      return false;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Node-local degraded fallback (design §4.3 / Design C, demoted to fallback)
+  // -------------------------------------------------------------------------
+
+  private checkLocal(
+    tiers: ResolvedTier[],
+    req: AdmissionCheckRequest,
+    nowMs: number,
+  ): AdmissionOutcome {
+    // Evaluate (read-only) — same two-phase discipline as the KV path so the
+    // refusal semantics can't drift between postures.
+    for (const tier of tiers) {
+      if (hasRateLimits(tier.limits)) {
+        const refilled = refillRateEntry(
+          this.localRate.get(tier.rateKey),
+          tier.limits,
+          nowMs,
+        );
+        const verdict = checkRate(refilled, tier.limits);
+        if (!verdict.ok) return this.rateRefusal(tier, verdict, true);
+      }
+      if (tier.limits.max_concurrent !== undefined) {
+        const pruned = pruneInflight(
+          this.localInflight.get(tier.inflightKey),
+          nowMs,
+          this.leaseTtlMs,
+        );
+        const verdict = checkInflight(pruned, tier.limits.max_concurrent);
+        if (!verdict.ok) return this.inflightRefusal(tier, verdict, true);
+      }
+    }
+    // Commit — single process, no CAS needed.
+    const leaseKeys: string[] = [];
+    for (const tier of tiers) {
+      if (hasRateLimits(tier.limits)) {
+        const refilled = refillRateEntry(
+          this.localRate.get(tier.rateKey),
+          tier.limits,
+          nowMs,
+        );
+        this.localRate.set(tier.rateKey, consumeRate(refilled, tier.limits));
+      }
+      if (tier.limits.max_concurrent !== undefined) {
+        const pruned = pruneInflight(
+          this.localInflight.get(tier.inflightKey),
+          nowMs,
+          this.leaseTtlMs,
+        );
+        this.localInflight.set(
+          tier.inflightKey,
+          acquireLease(pruned, req.leaseId, nowMs),
+        );
+        leaseKeys.push(tier.inflightKey);
+      }
+    }
+    return {
+      admit: true,
+      lease:
+        leaseKeys.length > 0
+          ? { leaseId: req.leaseId, keys: leaseKeys, local: true }
+          : undefined,
+      degraded: true,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Refusal builders + degrade transitions
+  // -------------------------------------------------------------------------
+
+  private rateRefusal(
+    tier: ResolvedTier,
+    verdict: Exclude<ReturnType<typeof checkRate>, { ok: true }>,
+    degraded: boolean,
+  ): AdmissionOutcome {
+    return {
+      admit: false,
+      reason: "rate",
+      tier: tier.tier,
+      key: tier.rateKey,
+      window: verdict.window,
+      limit: verdict.limit,
+      observed: verdict.observed,
+      retry_after_ms: verdict.retry_after_ms,
+      degraded,
+    };
+  }
+
+  private inflightRefusal(
+    tier: ResolvedTier,
+    verdict: Exclude<ReturnType<typeof checkInflight>, { ok: true }>,
+    degraded: boolean,
+  ): AdmissionOutcome {
+    return {
+      admit: false,
+      reason: "concurrency",
+      tier: tier.tier,
+      key: tier.inflightKey,
+      limit: verdict.limit,
+      observed: verdict.observed,
+      retry_after_ms: DEFAULT_RATE_RETRY_AFTER_MS,
+      degraded,
+    };
+  }
+
+  /** Enter the degraded posture — LOUD, once per transition (design §4.4). */
+  private noteDegraded(detail: string): void {
+    if (this.degraded) return;
+    this.degraded = true;
+    this.log.warn(
+      `admission-gate: DEGRADED to node-local approximate buckets — ${detail}. ` +
+        `Named principals ride the local fallback; anonymous dispatches FAIL CLOSED until the store recovers.`,
+    );
+    this.onDegradeTransition?.("degraded-local", detail);
+  }
+
+  /** Leave the degraded posture — also loud, and local state is discarded
+   * (the KV counters are authoritative again). */
+  private noteRecovered(): void {
+    if (!this.degraded) return;
+    this.degraded = false;
+    this.localRate.clear();
+    this.localInflight.clear();
+    this.log.warn(
+      "admission-gate: RECOVERED — KV admission store reachable again; node-local fallback state discarded",
+    );
+    this.onDegradeTransition?.("recovered", "KV admission store reachable again");
+  }
+}

--- a/src/bus/admission/index.ts
+++ b/src/bus/admission/index.ts
@@ -1,0 +1,43 @@
+/**
+ * R26 P1 (cortex#1371) — the substrate admission module: the KV-arbitrated
+ * AdmissionGate (distributed token bucket + in-flight lease counter) at the
+ * spawn gate, per `docs/design-substrate-rate-limiting.md` (Design B) and the
+ * myelin admission contract (`myelin/specs/admission.md`, myelin#195).
+ *
+ * Layout:
+ *   - `state.ts`     — pure entry formats + refill/prune/check/consume rules
+ *   - `provision.ts` — idempotent KV bucket provisioning (boot path)
+ *   - `gate.ts`      — the AdmissionGate: CAS arbitration, tiers 1–2,
+ *                      degrade-local posture, anonymous fail-closed
+ *
+ * Config lives in `policy.admission` (`src/common/types/admission.ts`);
+ * enforcement point 1 is the runner dispatch-listener (post-policy,
+ * pre-spawn). Absent config ⇒ nothing here is constructed (CO-4 inertness).
+ */
+
+export {
+  AdmissionGate,
+  type AdmissionCheckRequest,
+  type AdmissionGateOptions,
+  type AdmissionLease,
+  type AdmissionOutcome,
+  type AdmissionTierName,
+  type DegradeMode,
+} from "./gate";
+export {
+  admissionBucketName,
+  provisionAdmissionKv,
+  type ProvisionAdmissionKvOpts,
+  type ProvisionAdmissionKvResult,
+  type ProvisionAdmissionOutcome,
+} from "./provision";
+export {
+  DEFAULT_LEASE_TTL_MS,
+  RATE_WINDOW_NAMES,
+  WINDOW_MS,
+  type InflightEntry,
+  type InflightLease,
+  type RateEntry,
+  type RateWindowName,
+  type RateWindowState,
+} from "./state";

--- a/src/bus/admission/provision.ts
+++ b/src/bus/admission/provision.ts
@@ -1,0 +1,115 @@
+/**
+ * R26 P1 (cortex#1371) — idempotent NATS-KV bucket provisioning for the
+ * admission gate, mirroring the `src/bus/jetstream/provision.ts` pattern
+ * (assert-or-create at boot; never drop on shutdown — KV state outlives the
+ * process, and a restarted node inherits live counters).
+ *
+ * Bucket naming per the myelin admission contract (`myelin/specs/admission.md`
+ * §2): `admission_{principal}_{stack}` — one bucket per (principal, stack),
+ * the same granularity as the stack's JetStream domain, so the limiter's
+ * availability is identical to the dispatch fabric's own.
+ *
+ * The nats.js KV view (`js.views.kv(name)`) creates the bucket when it does
+ * not exist, so "provisioning" here is: peek at the backing stream
+ * (`KV_{bucket}`) to report created-vs-exists honestly in the boot log, then
+ * open the view. Failure is NON-FATAL by design — a `null` KV hands the gate
+ * its degraded posture (node-local approximate buckets + loud `system.*`
+ * event; anonymous fail-closed) rather than aborting boot: the failure
+ * posture is a designed state, not an exception path (design §4.3 / Q1).
+ */
+
+import type { ProvisionJsm, ProvisionKv } from "../jetstream/types";
+import { isNotFoundError } from "../jetstream/provision";
+
+/**
+ * Build the per-(principal, stack) admission bucket name (myelin admission
+ * spec §2). Inputs are subject-grammar segments already (`[a-z0-9-]`);
+ * anything outside the KV bucket-name charset is defensively mapped to `-`
+ * so a malformed segment degrades to an odd bucket name rather than a boot
+ * throw.
+ */
+export function admissionBucketName(principal: string, stack: string): string {
+  const clean = (s: string): string => s.replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `admission_${clean(principal)}_${clean(stack)}`;
+}
+
+export type ProvisionAdmissionOutcome = "created" | "exists" | "unavailable";
+
+export interface ProvisionAdmissionKvOpts {
+  /**
+   * Narrow JSM handle (from `runtime.jetstreamManager()`), or `null` when the
+   * runtime is disabled / the manager could not be resolved. Only used to
+   * report created-vs-exists — the KV open below is what actually creates.
+   */
+  jsm: ProvisionJsm | null;
+  /**
+   * Open (creating if absent) the KV bucket — `runtime.kvBucket(name)`.
+   * Returns `null` when the runtime is disabled.
+   */
+  openKv: (bucket: string) => Promise<ProvisionKv | null>;
+  bucket: string;
+  log?: { info: (msg: string) => void; warn: (msg: string) => void };
+}
+
+export interface ProvisionAdmissionKvResult {
+  outcome: ProvisionAdmissionOutcome;
+  /** The live KV handle, or `null` ⇒ the gate starts degraded (design §4.3). */
+  kv: ProvisionKv | null;
+}
+
+/**
+ * Provision (or assert presence of) the admission KV bucket. Idempotent —
+ * safe on every boot. NEVER throws: every failure path resolves to
+ * `{ outcome: "unavailable", kv: null }` with a loud warn, because the
+ * admission gate has a DESIGNED degraded posture for exactly this state.
+ */
+export async function provisionAdmissionKv(
+  opts: ProvisionAdmissionKvOpts,
+): Promise<ProvisionAdmissionKvResult> {
+  const log = opts.log ?? console;
+
+  // Peek at the backing stream so the boot log reports created-vs-exists —
+  // the same honesty `provisionReviewStream` gives streams. A peek failure
+  // (no JSM, transport error) is non-fatal: the open below still decides.
+  let preExisting: boolean | undefined;
+  if (opts.jsm !== null) {
+    try {
+      await opts.jsm.streams.info(`KV_${opts.bucket}`);
+      preExisting = true;
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        preExisting = false;
+      } else {
+        // Not a 404 — transport/auth trouble. Leave `preExisting` unknown and
+        // let the open below surface the real failure (logged there).
+        log.warn(
+          `admission-provision: stream peek for bucket "${opts.bucket}" failed (${err instanceof Error ? err.message : String(err)}) — continuing to KV open`,
+        );
+      }
+    }
+  }
+
+  let kv: ProvisionKv | null;
+  try {
+    kv = await opts.openKv(opts.bucket);
+  } catch (err) {
+    log.warn(
+      `admission-provision: KV bucket "${opts.bucket}" open FAILED (${err instanceof Error ? err.message : String(err)}) — admission gate starts DEGRADED (node-local buckets; anonymous fail-closed)`,
+    );
+    return { outcome: "unavailable", kv: null };
+  }
+  if (kv === null) {
+    log.warn(
+      `admission-provision: KV bucket "${opts.bucket}" unavailable (runtime disabled / no JetStream) — admission gate starts DEGRADED (node-local buckets; anonymous fail-closed)`,
+    );
+    return { outcome: "unavailable", kv: null };
+  }
+
+  if (preExisting === false) {
+    log.info(
+      `admission-provision: created KV bucket "${opts.bucket}" (stream KV_${opts.bucket}, history=1)`,
+    );
+    return { outcome: "created", kv };
+  }
+  return { outcome: "exists", kv };
+}

--- a/src/bus/admission/state.ts
+++ b/src/bus/admission/state.ts
@@ -1,0 +1,321 @@
+/**
+ * R26 P1 (cortex#1371) — pure admission-state machinery: the KV entry
+ * formats + refill / prune / check / consume rules from the myelin admission
+ * contract (`myelin/specs/admission.md` §4, myelin#195).
+ *
+ * Everything in this module is PURE + TOTAL: no I/O, no clock reads, no
+ * throws on the decision paths. The CAS loop in `gate.ts` (and the
+ * node-local degraded fallback) both drive these same functions, so the
+ * distributed and the degraded posture cannot drift on semantics — only on
+ * where the state lives.
+ *
+ * Entry-format invariants (spec §4):
+ *   - versioned (`v: 1`); a NEWER version than we understand is surfaced as
+ *     `"newer"` so the caller takes the store-error posture (never guess);
+ *     a CORRUPT entry is surfaced as `"corrupt"` so the caller may treat it
+ *     as fresh (self-healing) — biased choices live in the gate, not here.
+ *   - refill is clock-skew-clamped (`max(0, elapsed)`), deltas over the
+ *     LOCAL node's clock — token buckets tolerate small inter-node skew.
+ *   - refusals never mutate: `check*` functions read; `consume*` functions
+ *     return NEW objects (callers only persist on admit — spec §5 rule 1).
+ */
+
+import type { AdmissionLimits } from "../../common/types/admission";
+
+// ---------------------------------------------------------------------------
+// Entry shapes (myelin admission spec §4 — the wire interop surface)
+// ---------------------------------------------------------------------------
+
+/** Window lengths in milliseconds, keyed by the config vocabulary. */
+export const WINDOW_MS = {
+  per_minute: 60_000,
+  per_hour: 3_600_000,
+  per_day: 86_400_000,
+} as const;
+
+export type RateWindowName = keyof typeof WINDOW_MS;
+
+export const RATE_WINDOW_NAMES: readonly RateWindowName[] = [
+  "per_minute",
+  "per_hour",
+  "per_day",
+];
+
+/** Per-window token-bucket state (spec §4.1). */
+export interface RateWindowState {
+  /** Remaining tokens — fractional; capacity = the configured window limit. */
+  tokens: number;
+  /** Unix epoch ms of the last refill computation (writing node's clock). */
+  refilled_at_ms: number;
+}
+
+/** The `rate.*` entry — all configured windows under one CAS-guarded key. */
+export interface RateEntry {
+  v: 1;
+  windows: Partial<Record<RateWindowName, RateWindowState>>;
+}
+
+/** One in-flight lease (spec §4.2). */
+export interface InflightLease {
+  /** Unique lease id — the dispatch task/correlation id. */
+  id: string;
+  /** Unix epoch ms at acquisition. */
+  acquired_at_ms: number;
+}
+
+/** The `inflight.*` entry — a self-expiring lease list, not a bare counter. */
+export interface InflightEntry {
+  v: 1;
+  leases: InflightLease[];
+}
+
+/**
+ * Orphan-lease TTL (spec §4.2 prune rule) — leases older than this are
+ * presumed abandoned by a dead node and dropped on read. 1 h: comfortably
+ * above a long interactive session, small enough to bound orphan leakage.
+ * The phase-2 lifecycle sweeper reconciles faster; this is the floor.
+ */
+export const DEFAULT_LEASE_TTL_MS = 3_600_000;
+
+// ---------------------------------------------------------------------------
+// Parsing — versioned, fail-explicit
+// ---------------------------------------------------------------------------
+
+export type ParsedEntry<T> =
+  | { kind: "ok"; entry: T }
+  | { kind: "corrupt" }
+  | { kind: "newer" };
+
+function parseVersioned<T>(
+  bytes: Uint8Array,
+  validate: (v: unknown) => v is T,
+): ParsedEntry<T> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return { kind: "corrupt" };
+  }
+  if (typeof parsed !== "object" || parsed === null) return { kind: "corrupt" };
+  const v = (parsed as { v?: unknown }).v;
+  if (typeof v !== "number") return { kind: "corrupt" };
+  if (v > 1) return { kind: "newer" };
+  if (!validate(parsed)) return { kind: "corrupt" };
+  return { kind: "ok", entry: parsed };
+}
+
+function isRateEntry(v: unknown): v is RateEntry {
+  // Widened to `unknown` field types on purpose: the bytes came off the wire,
+  // so nothing about the shape may be assumed (a `Partial<RateEntry>` cast
+  // would let the type system erase the null/shape checks below as
+  // "unnecessary" when they are exactly the point).
+  const e = v as { v?: unknown; windows?: unknown };
+  if (e.v !== 1 || typeof e.windows !== "object" || e.windows === null) {
+    return false;
+  }
+  for (const state of Object.values(e.windows)) {
+    const s = state as { tokens?: unknown; refilled_at_ms?: unknown } | undefined;
+    if (
+      s === undefined ||
+      typeof s.tokens !== "number" ||
+      !Number.isFinite(s.tokens) ||
+      typeof s.refilled_at_ms !== "number"
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isInflightEntry(v: unknown): v is InflightEntry {
+  const e = v as { v?: unknown; leases?: unknown };
+  if (e.v !== 1 || !Array.isArray(e.leases)) return false;
+  return (e.leases as unknown[]).every((l) => {
+    if (typeof l !== "object" || l === null) return false;
+    const lease = l as { id?: unknown; acquired_at_ms?: unknown };
+    return typeof lease.id === "string" && typeof lease.acquired_at_ms === "number";
+  });
+}
+
+export function parseRateEntry(bytes: Uint8Array): ParsedEntry<RateEntry> {
+  return parseVersioned(bytes, isRateEntry);
+}
+
+export function parseInflightEntry(
+  bytes: Uint8Array,
+): ParsedEntry<InflightEntry> {
+  return parseVersioned(bytes, isInflightEntry);
+}
+
+export function encodeEntry(entry: RateEntry | InflightEntry): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(entry));
+}
+
+// ---------------------------------------------------------------------------
+// Rate — refill / check / consume / refund (spec §4.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Refill a rate entry against the resolved limits at `nowMs` (spec §4.1
+ * refill rule). Windows configured but absent from the entry initialise at
+ * FULL capacity; windows present but no longer configured are dropped.
+ * Missing entry (`undefined`) ⇒ fresh full-capacity state.
+ */
+export function refillRateEntry(
+  entry: RateEntry | undefined,
+  limits: AdmissionLimits,
+  nowMs: number,
+): RateEntry {
+  const windows: Partial<Record<RateWindowName, RateWindowState>> = {};
+  for (const name of RATE_WINDOW_NAMES) {
+    const capacity = limits[name];
+    if (capacity === undefined) continue;
+    const prior = entry?.windows[name];
+    if (prior === undefined) {
+      windows[name] = { tokens: capacity, refilled_at_ms: nowMs };
+      continue;
+    }
+    // Clock-skew clamp: a retrograde clock refuses-safe (no refill), never
+    // mints tokens.
+    const elapsed = Math.max(0, nowMs - prior.refilled_at_ms);
+    const tokens = Math.min(
+      capacity,
+      prior.tokens + (elapsed * capacity) / WINDOW_MS[name],
+    );
+    windows[name] = { tokens, refilled_at_ms: nowMs };
+  }
+  return { v: 1, windows };
+}
+
+export type RateCheck =
+  | { ok: true }
+  | {
+      ok: false;
+      window: RateWindowName;
+      limit: number;
+      observed: number;
+      retry_after_ms: number;
+    };
+
+/**
+ * Check a (freshly refilled) rate entry: admit iff every configured window
+ * holds ≥ 1 token. On refusal reports the SLOWEST refusing window and the
+ * time until one full token is available there (spec §4.1 retry hint).
+ */
+export function checkRate(entry: RateEntry, limits: AdmissionLimits): RateCheck {
+  let worst:
+    | { window: RateWindowName; limit: number; observed: number; retry: number }
+    | undefined;
+  for (const name of RATE_WINDOW_NAMES) {
+    const capacity = limits[name];
+    if (capacity === undefined) continue;
+    const state = entry.windows[name];
+    const tokens = state?.tokens ?? capacity;
+    if (tokens >= 1) continue;
+    const retry = Math.ceil(((1 - tokens) * WINDOW_MS[name]) / capacity);
+    if (worst === undefined || retry > worst.retry) {
+      worst = { window: name, limit: capacity, observed: tokens, retry };
+    }
+  }
+  if (worst === undefined) return { ok: true };
+  return {
+    ok: false,
+    window: worst.window,
+    limit: worst.limit,
+    observed: worst.observed,
+    retry_after_ms: worst.retry,
+  };
+}
+
+/** Consume one token from every configured window. Returns a NEW entry. */
+export function consumeRate(
+  entry: RateEntry,
+  limits: AdmissionLimits,
+): RateEntry {
+  const windows: Partial<Record<RateWindowName, RateWindowState>> = {};
+  for (const name of RATE_WINDOW_NAMES) {
+    const capacity = limits[name];
+    if (capacity === undefined) continue;
+    const state = entry.windows[name];
+    if (state === undefined) continue;
+    windows[name] = { ...state, tokens: state.tokens - 1 };
+  }
+  return { v: 1, windows };
+}
+
+/**
+ * Refund one token to every configured window, capped at capacity — the
+ * best-effort abort compensation for a multi-tier commit that failed after
+ * this tier consumed (spec §5.1). A failed refund errs toward
+ * UNDER-admission (safe direction); it self-corrects on refill.
+ */
+export function refundRate(
+  entry: RateEntry,
+  limits: AdmissionLimits,
+): RateEntry {
+  const windows: Partial<Record<RateWindowName, RateWindowState>> = {};
+  for (const name of RATE_WINDOW_NAMES) {
+    const capacity = limits[name];
+    if (capacity === undefined) continue;
+    const state = entry.windows[name];
+    if (state === undefined) continue;
+    windows[name] = { ...state, tokens: Math.min(capacity, state.tokens + 1) };
+  }
+  return { v: 1, windows };
+}
+
+// ---------------------------------------------------------------------------
+// In-flight — prune / check / acquire / release (spec §4.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Prune expired leases at `nowMs` (spec §4.2 prune rule). Missing entry ⇒
+ * empty lease list.
+ */
+export function pruneInflight(
+  entry: InflightEntry | undefined,
+  nowMs: number,
+  leaseTtlMs: number,
+): InflightEntry {
+  const leases = (entry?.leases ?? []).filter(
+    (l) => nowMs - l.acquired_at_ms <= leaseTtlMs,
+  );
+  return { v: 1, leases };
+}
+
+export type InflightCheck =
+  | { ok: true }
+  | { ok: false; limit: number; observed: number };
+
+/** Check a (freshly pruned) in-flight entry against `max_concurrent`. */
+export function checkInflight(
+  entry: InflightEntry,
+  maxConcurrent: number,
+): InflightCheck {
+  if (entry.leases.length < maxConcurrent) return { ok: true };
+  return { ok: false, limit: maxConcurrent, observed: entry.leases.length };
+}
+
+/** Append a lease. Returns a NEW entry. Idempotent on lease id. */
+export function acquireLease(
+  entry: InflightEntry,
+  leaseId: string,
+  nowMs: number,
+): InflightEntry {
+  if (entry.leases.some((l) => l.id === leaseId)) return entry;
+  return {
+    v: 1,
+    leases: [...entry.leases, { id: leaseId, acquired_at_ms: nowMs }],
+  };
+}
+
+/**
+ * Remove a lease by id. Returns a NEW entry; removing an absent lease is a
+ * no-op (release MUST be idempotent — spec §4.2 release rule).
+ */
+export function releaseLease(
+  entry: InflightEntry,
+  leaseId: string,
+): InflightEntry {
+  return { v: 1, leases: entry.leases.filter((l) => l.id !== leaseId) };
+}

--- a/src/bus/jetstream/types.ts
+++ b/src/bus/jetstream/types.ts
@@ -41,3 +41,32 @@ export interface ProvisionJsm {
     delete(stream: string, durable: string): Promise<boolean>;
   };
 }
+
+/**
+ * R26 P1 (cortex#1371) — one entry read from a {@link ProvisionKv} bucket.
+ * Mirror of nats.js's `KvEntry` minus everything the admission gate doesn't
+ * touch. `operation` matters: a `DEL`/`PURGE` tombstone is still returned by
+ * `get()` with a live revision — consumers MUST treat it as "absent value"
+ * while still CAS-ing against its revision.
+ */
+export interface ProvisionKvEntry {
+  value: Uint8Array;
+  revision: number;
+  operation: "PUT" | "DEL" | "PURGE";
+}
+
+/**
+ * Narrow NATS-KV surface — the subset of nats.js's `KV` view the admission
+ * gate uses (myelin `specs/admission.md` §5: get → create-if-absent →
+ * CAS-update on revision). Same neutral-module rationale as
+ * {@link ProvisionJsm}: the MyelinRuntime exposes a `kvBucket()` capability
+ * returning this shape, tests stub it in-memory, and the runtime stays
+ * decoupled from nats.js's full materialized-views surface.
+ */
+export interface ProvisionKv {
+  get(key: string): Promise<ProvisionKvEntry | null>;
+  /** Create-if-absent — rejects when the key already exists (CAS on absence). */
+  create(key: string, value: Uint8Array): Promise<number>;
+  /** Compare-and-swap update — rejects unless `revision` is the live revision. */
+  update(key: string, value: Uint8Array, revision: number): Promise<number>;
+}

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -256,6 +256,21 @@ export interface MyelinRuntime {
    * are cached.
    */
   jetstreamManager?(): Promise<import("../jetstream/types").ProvisionJsm | null>;
+  /**
+   * R26 P1 (cortex#1371) — resolve a narrow NATS-KV capability against the
+   * PRIMARY link (same single-link rationale as `jetstreamManager`), or
+   * `null` when the runtime is disabled. Opens (creating if absent —
+   * nats.js's `views.kv` is create-or-bind) the named KV bucket and returns
+   * the narrow `ProvisionKv` surface the admission gate consumes
+   * (get / create / CAS-update). Boot-path only today (the admission
+   * provisioning call) — no per-call caching; callers hold the returned
+   * handle for the process lifetime.
+   *
+   * OPTIONAL on the interface for the same additivity reason as
+   * `jetstreamManager` — existing fake-runtime test stubs keep their shapes;
+   * callers MUST treat an undefined property as a `null` return.
+   */
+  kvBucket?(name: string): Promise<import("../jetstream/types").ProvisionKv | null>;
   /** Best-effort shutdown — drains subscribers, closes the link. */
   stop(): Promise<void>;
 }
@@ -633,6 +648,11 @@ export async function startMyelinRuntime(
   // eslint-disable-next-line @typescript-eslint/require-await
   const jetstreamManagerDisabled = async (): Promise<null> => null;
 
+  // R26 P1 (cortex#1371) — disabled KV helper mirrors `jetstreamManagerDisabled`:
+  // null means "no link, no bucket" and the admission boot path degrades.
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const kvBucketDisabled = async (): Promise<null> => null;
+
   if (!config.nats?.url) {
     return {
       enabled: false,
@@ -641,6 +661,7 @@ export async function startMyelinRuntime(
       subscribePull: subscribePullDisabled,
       subscribe: subscribePushDisabled,
       jetstreamManager: jetstreamManagerDisabled,
+      kvBucket: kvBucketDisabled,
       stop: stopDisabled,
     };
   }
@@ -814,6 +835,7 @@ export async function startMyelinRuntime(
       subscribePull: subscribePullDisabled,
       subscribe: subscribePushDisabled,
       jetstreamManager: jetstreamManagerDisabled,
+      kvBucket: kvBucketDisabled,
       stop: stopDisabled,
     };
   }
@@ -1391,6 +1413,7 @@ export async function startMyelinRuntime(
       subscribePull: subscribePullDisabled,
       subscribe: subscribePushDisabled,
       jetstreamManager: jetstreamManagerDisabled,
+      kvBucket: kvBucketDisabled,
       stop: stopDisabled,
     };
   }
@@ -1906,6 +1929,17 @@ export async function startMyelinRuntime(
     return primary.jsmCache;
   };
 
+  // R26 P1 (cortex#1371) — narrow KV capability, PRIMARY-link-bound like the
+  // JSM above (no per-network KV). `views.kv` creates the bucket when absent
+  // (history=1: only the latest revision of an admission counter matters) and
+  // binds otherwise — idempotent, matching the provisioning helpers' contract.
+  // nats.js's `KV` satisfies the narrow `ProvisionKv` shape structurally.
+  const kvBucketEnabled = async (
+    name: string,
+  ): Promise<import("nats").KV> => {
+    return primaryLink.raw.jetstream().views.kv(name, { history: 1 });
+  };
+
   return {
     enabled: true,
     onEnvelope,
@@ -1914,6 +1948,7 @@ export async function startMyelinRuntime(
     subscribePull: subscribePullEnabled,
     subscribe: subscribePushEnabled,
     jetstreamManager: jetstreamManagerEnabled,
+    kvBucket: kvBucketEnabled,
     stop: async () => {
       if (stopped) return;
       stopped = true;

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1044,6 +1044,116 @@ export function createSystemAccessDeniedEvent(
 }
 
 // ---------------------------------------------------------------------------
+// system.admission.throttled / system.admission.degraded — R26 P1 (cortex#1371)
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured reason payload on `system.admission.throttled` envelopes.
+ * Mirrors the AdmissionGate's refusal shape (myelin `specs/admission.md` §9):
+ * which tier/key refused, on what dimension, at what limit, and the retry
+ * hint the requester was given. `degraded` flags decisions taken on the
+ * node-local fallback (design §4.3) so audit consumers can distinguish exact
+ * refusals from approximate ones.
+ */
+export interface SystemAdmissionThrottledReason {
+  /** Refusal dimension — `"rate"` | `"concurrency"` | `"store_error"`. */
+  kind: string;
+  /** Tier that refused — `"stack"` | `"principal"` (3–4 reserved). */
+  tier: string;
+  /** The KV key that refused (myelin admission spec §3 grammar). */
+  key: string;
+  /** Refusing rate window (`per_minute`|`per_hour`|`per_day`) — rate only. */
+  window?: string;
+  limit?: number;
+  observed?: number;
+  /** Backpressure hint forwarded to the requester (`not_now` taxonomy). */
+  retry_after_ms: number;
+  /** True when decided on the degraded node-local fallback. */
+  degraded: boolean;
+  [k: string]: unknown;
+}
+
+/**
+ * Options for `createSystemAdmissionThrottledEvent`. Extends the same common
+ * audit shape as `system.access.allowed`/`denied` — an admission refusal is
+ * an access decision, just a TRANSIENT one — so consumers join it on the
+ * same correlation/envelope keys they already use for the deny stream.
+ */
+export interface SystemAdmissionThrottledOpts extends SystemAccessCommonOpts {
+  reason: SystemAdmissionThrottledReason;
+}
+
+/**
+ * Construct a `system.admission.throttled` envelope (R26 P1, design §4.4) —
+ * the audit sibling of `system.access.denied` for the transient admission
+ * gate. Emitted by every enforcement point that refuses a dispatch on rate /
+ * concurrency / store-posture grounds; the paired TERMINAL lifecycle event is
+ * the `dispatch.task.failed { kind: "not_now" }` the enforcement point also
+ * publishes (an admission refusal never `term`s — it defers).
+ *
+ * Subject convention: `local.{principal}.system.admission.throttled` —
+ * surfaces subscribe to `system.admission.>` for the throttle stream, or
+ * join with `system.access.>` on `correlation_id`.
+ */
+export function createSystemAdmissionThrottledEvent(
+  opts: SystemAdmissionThrottledOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.admission.throttled",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    correlationId: opts.correlationId,
+    payload: {
+      principal_id: opts.principalId,
+      capability: opts.capability,
+      reason: opts.reason,
+      intent_sovereignty: opts.sovereignty,
+      envelope_id: opts.envelopeId,
+      envelope_subject: opts.envelopeSubject,
+      signed_by: opts.signedBy,
+    },
+  });
+}
+
+/** Options for `createSystemAdmissionDegradedEvent`. */
+export interface SystemAdmissionDegradedOpts {
+  source: SystemEventSource;
+  /**
+   * Posture transition: `"degraded-local"` = the KV admission store errored
+   * and named principals now ride node-local approximate buckets (anonymous
+   * fails closed); `"recovered"` = the store is reachable again and the
+   * local fallback state was discarded.
+   */
+  mode: "degraded-local" | "recovered";
+  /** Human-facing detail (the triggering error / recovery note). */
+  detail: string;
+  /** The admission KV bucket concerned (`admission_{principal}_{stack}`). */
+  bucket?: string;
+  classification?: Classification;
+}
+
+/**
+ * Construct a `system.admission.degraded` envelope (R26 P1, design §4.4:
+ * degraded-mode transitions MUST be loud — never silent, the R6 lesson).
+ * Emitted once per posture TRANSITION (into and out of degraded), not per
+ * request; the per-request `degraded: true` flag rides the throttle events.
+ */
+export function createSystemAdmissionDegradedEvent(
+  opts: SystemAdmissionDegradedOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.admission.degraded",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    payload: {
+      mode: opts.mode,
+      detail: opts.detail,
+      ...(opts.bucket !== undefined && { bucket: opts.bucket }),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // system.access.denied — IAW Phase D.2 federation-router variant
 // ---------------------------------------------------------------------------
 
@@ -1379,6 +1489,12 @@ export type SystemDispatchStage =
   // field is parsed. A successful decrypt is silent (flows on to `parsed`).
   | "payload-decrypt-rejected"
   | "policy-decision"
+  // R26 P1 (cortex#1371) — the admission gate (KV-arbitrated rate limiting)
+  // between the policy allow and harness construction. `pass` = admitted;
+  // `fail` = throttled (`not_now` terminal emitted, no spawn). Only emitted
+  // when `policy.admission` is configured — absent config skips the stage
+  // entirely (CO-4 inertness).
+  | "admission-checked"
   | "session-spawning"
   | "started";
 

--- a/src/common/types/__tests__/admission.test.ts
+++ b/src/common/types/__tests__/admission.test.ts
@@ -167,7 +167,7 @@ describe("PolicySchema integration — the CO-4 inertness + cross-refs", () => {
         trust: [],
       },
     ],
-    roles: [{ id: "principal", capabilities: ["operator"] }],
+    roles: [{ id: "principal", capabilities: ["dispatch.pylon"] }],
   };
 
   test("absent admission block parses to undefined (limiter fully inert)", () => {

--- a/src/common/types/__tests__/admission.test.ts
+++ b/src/common/types/__tests__/admission.test.ts
@@ -1,0 +1,226 @@
+/**
+ * R26 P1 (cortex#1371) — tests for the `policy.admission` config schema +
+ * limit resolution (`admission.ts`), and its integration into `PolicySchema`
+ * (optional field, cross-ref checks, inertness of the absent block).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  AdmissionLimitsSchema,
+  AdmissionPolicySchema,
+  ANONYMOUS_ADMISSION_CEILING,
+  clampAnonymousLimits,
+  resolveAdmissionLimits,
+} from "../admission";
+import { PolicySchema } from "../cortex-config";
+
+describe("AdmissionLimitsSchema", () => {
+  test("accepts any single bound", () => {
+    expect(AdmissionLimitsSchema.safeParse({ per_minute: 6 }).success).toBe(true);
+    expect(AdmissionLimitsSchema.safeParse({ max_concurrent: 3 }).success).toBe(true);
+  });
+
+  test("rejects an EMPTY bundle — {} must not masquerade as 'limited'", () => {
+    expect(AdmissionLimitsSchema.safeParse({}).success).toBe(false);
+  });
+
+  test("rejects unknown keys, zero, and negative values", () => {
+    expect(AdmissionLimitsSchema.safeParse({ per_second: 1 }).success).toBe(false);
+    expect(AdmissionLimitsSchema.safeParse({ per_minute: 0 }).success).toBe(false);
+    expect(AdmissionLimitsSchema.safeParse({ per_minute: -5 }).success).toBe(false);
+    expect(AdmissionLimitsSchema.safeParse({ per_minute: 1.5 }).success).toBe(false);
+  });
+});
+
+describe("AdmissionPolicySchema", () => {
+  test("accepts the design §4.1 reference shape", () => {
+    const parsed = AdmissionPolicySchema.safeParse({
+      stack: { max_concurrent: 8, per_minute: 30 },
+      defaults: { per_minute: 6, per_hour: 60, max_concurrent: 3 },
+      roles: { principal: { per_minute: 20, max_concurrent: 6 }, surface: { per_minute: 10 } },
+      principals: [{ id: "amt-surface", per_minute: 12, max_concurrent: 2 }],
+      anonymous: { per_minute: 2, max_concurrent: 1 },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("rejects unknown top-level keys (strict)", () => {
+    expect(
+      AdmissionPolicySchema.safeParse({ stacks: { per_minute: 1 } }).success,
+    ).toBe(false);
+  });
+
+  test("principal override requires an id and at least one bound", () => {
+    expect(
+      AdmissionPolicySchema.safeParse({ principals: [{ id: "x" }] }).success,
+    ).toBe(false);
+    expect(
+      AdmissionPolicySchema.safeParse({ principals: [{ per_minute: 1 }] }).success,
+    ).toBe(false);
+  });
+});
+
+describe("resolveAdmissionLimits — principals > roles (most permissive) > defaults, per field", () => {
+  const admission = AdmissionPolicySchema.parse({
+    defaults: { per_minute: 2, max_concurrent: 1 },
+    roles: {
+      basic: { per_minute: 4 },
+      power: { per_minute: 8, max_concurrent: 4 },
+    },
+    principals: [{ id: "vip", per_minute: 20 }],
+  });
+
+  test("defaults apply when nothing more specific matches", () => {
+    expect(
+      resolveAdmissionLimits(admission, {
+        principalId: "nobody",
+        anonymous: false,
+        roles: [],
+      }),
+    ).toEqual({ per_minute: 2, max_concurrent: 1 });
+  });
+
+  test("most permissive value wins across multiple roles", () => {
+    expect(
+      resolveAdmissionLimits(admission, {
+        principalId: "dev",
+        anonymous: false,
+        roles: ["basic", "power"],
+      }),
+    ).toEqual({ per_minute: 8, max_concurrent: 4 });
+  });
+
+  test("principal override wins per FIELD; unset fields fall through", () => {
+    // vip sets only per_minute — max_concurrent falls through role → default.
+    expect(
+      resolveAdmissionLimits(admission, {
+        principalId: "vip",
+        anonymous: false,
+        roles: ["basic"],
+      }),
+    ).toEqual({ per_minute: 20, max_concurrent: 1 });
+  });
+
+  test("returns undefined when NOTHING resolves (tier inert)", () => {
+    const bare = AdmissionPolicySchema.parse({
+      principals: [{ id: "someone-else", per_minute: 1 }],
+    });
+    expect(
+      resolveAdmissionLimits(bare, {
+        principalId: "unlimited",
+        anonymous: false,
+        roles: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  test("anonymous short-circuits to the clamped anonymous lane, ignoring defaults", () => {
+    expect(
+      resolveAdmissionLimits(admission, {
+        principalId: "public",
+        anonymous: true,
+        roles: [],
+      }),
+    ).toEqual({
+      per_minute: ANONYMOUS_ADMISSION_CEILING.per_minute,
+      max_concurrent: ANONYMOUS_ADMISSION_CEILING.max_concurrent,
+    });
+  });
+});
+
+describe("clampAnonymousLimits — the built-in ceiling (design §3.1)", () => {
+  test("absent config ⇒ the ceiling verbatim", () => {
+    expect(clampAnonymousLimits(undefined)).toEqual({
+      per_minute: 2,
+      max_concurrent: 1,
+    });
+  });
+
+  test("config can TIGHTEN but never RAISE the capped fields", () => {
+    expect(clampAnonymousLimits({ per_minute: 1 })).toEqual({
+      per_minute: 1,
+      max_concurrent: 1,
+    });
+    expect(clampAnonymousLimits({ per_minute: 100, max_concurrent: 9 })).toEqual({
+      per_minute: 2,
+      max_concurrent: 1,
+    });
+  });
+
+  test("extra windows pass through (they only AND-tighten)", () => {
+    expect(clampAnonymousLimits({ per_minute: 2, per_day: 10 })).toEqual({
+      per_minute: 2,
+      max_concurrent: 1,
+      per_day: 10,
+    });
+  });
+});
+
+describe("PolicySchema integration — the CO-4 inertness + cross-refs", () => {
+  const basePolicy = {
+    principals: [
+      {
+        id: "andreas",
+        home_principal: "andreas",
+        home_stack: "andreas/work",
+        role: ["principal"],
+        trust: [],
+      },
+    ],
+    roles: [{ id: "principal", capabilities: ["operator"] }],
+  };
+
+  test("absent admission block parses to undefined (limiter fully inert)", () => {
+    const parsed = PolicySchema.parse(basePolicy);
+    expect(parsed.admission).toBeUndefined();
+  });
+
+  test("a valid admission block parses through PolicySchema", () => {
+    const parsed = PolicySchema.parse({
+      ...basePolicy,
+      admission: {
+        stack: { max_concurrent: 8, per_minute: 30 },
+        roles: { principal: { per_minute: 20 } },
+        principals: [{ id: "andreas", per_minute: 12 }],
+      },
+    });
+    expect(parsed.admission?.stack?.per_minute).toBe(30);
+  });
+
+  test("admission.roles key must reference a declared role", () => {
+    const result = PolicySchema.safeParse({
+      ...basePolicy,
+      admission: { roles: { ghost: { per_minute: 1 } } },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.join(".") === "admission.roles.ghost")).toBe(true);
+    }
+  });
+
+  test("admission.principals[].id must reference a declared principal", () => {
+    const result = PolicySchema.safeParse({
+      ...basePolicy,
+      admission: { principals: [{ id: "ghost", per_minute: 1 }] },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.path.join(".") === "admission.principals.0.id"),
+      ).toBe(true);
+    }
+  });
+
+  test("duplicate admission.principals ids are rejected", () => {
+    const result = PolicySchema.safeParse({
+      ...basePolicy,
+      admission: {
+        principals: [
+          { id: "andreas", per_minute: 1 },
+          { id: "andreas", per_minute: 2 },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/common/types/admission.ts
+++ b/src/common/types/admission.ts
@@ -1,0 +1,259 @@
+/**
+ * R26 P1 (cortex#1371) — the `policy.admission` config schema + limit
+ * resolution for the substrate admission gate.
+ *
+ * Design: `docs/design-substrate-rate-limiting.md` §4.1 (Design B, signed off
+ * 2026-07-02). Contract: myelin `specs/admission.md` (myelin#195) — this module
+ * owns only the CONFIG side (which principal gets which windows); the shared
+ * KV state machinery lives in `src/bus/admission/`.
+ *
+ * ## Shape
+ *
+ * ```yaml
+ * policy:
+ *   admission:
+ *     stack:                    # tier 1 — global spawn ceiling
+ *       max_concurrent: 8
+ *       per_minute: 30
+ *     defaults:                 # tier 2 — every principal unless overridden
+ *       per_minute: 6
+ *       max_concurrent: 3
+ *     roles:                    # role-level overrides (most permissive wins,
+ *       principal:              # same union direction as capability grants)
+ *         per_minute: 20
+ *     principals:               # per-principal override (most specific wins)
+ *       - id: amt-surface
+ *         per_minute: 12
+ *     anonymous:                # the open-onboarding floor — clamped to the
+ *       per_minute: 2           # built-in ceiling regardless of config
+ *       max_concurrent: 1
+ * ```
+ *
+ * ## The CO-4 inertness contract
+ *
+ * The block is `.optional()` with NO default: an absent `admission:` block
+ * parses to `undefined`, `cortex.ts` never constructs an `AdmissionGate`, and
+ * behaviour is byte-identical to a build predating R26 (the same
+ * provably-inert-until-configured rule the gate floor documents at
+ * `gate-floor.ts:29-37`). The resolver — not a schema default — owns the
+ * "nothing configured ⇒ nothing limited" semantics.
+ *
+ * ## Vocabulary
+ *
+ * The window fields reuse the `offering.ts` rate vocabulary exactly
+ * (`per_minute`/`per_hour`/`per_day` from `RatePredicateSchema`,
+ * `max_concurrent` from `PublicLimitsSchema`) so operators tune ONE dialect
+ * across public-offering limits and admission limits.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Limits — the per-window vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * A bundle of admission limits. Every field optional, but an EMPTY bundle is
+ * rejected — `{}` would masquerade as "limited" while limiting nothing (the
+ * same rule `PublicLimitsSchema` enforces). Omit the block entirely to mean
+ * "no explicit limit at this level".
+ */
+export const AdmissionLimitsSchema = z
+  .object({
+    /** Requests per rolling minute (token bucket, capacity = value). */
+    per_minute: z.number().int().positive().optional(),
+    /** Requests per rolling hour. */
+    per_hour: z.number().int().positive().optional(),
+    /** Requests per rolling day. */
+    per_day: z.number().int().positive().optional(),
+    /** Max concurrently in-flight dispatches (KV lease counter). */
+    max_concurrent: z.number().int().positive().optional(),
+  })
+  .strict()
+  .refine(
+    (l) =>
+      l.per_minute !== undefined ||
+      l.per_hour !== undefined ||
+      l.per_day !== undefined ||
+      l.max_concurrent !== undefined,
+    {
+      message:
+        "admission limits must declare at least one bound (per_minute, per_hour, per_day, or max_concurrent); omit the block entirely to mean 'no explicit limit'",
+    },
+  );
+
+export type AdmissionLimits = z.infer<typeof AdmissionLimitsSchema>;
+
+/** A per-principal override entry — an id plus the limit vocabulary. */
+export const AdmissionPrincipalOverrideSchema = z
+  .object({
+    /** Principal id (bare, no `did:mf:` prefix) — must be declared in `policy.principals[]`. */
+    id: z.string().min(1),
+    per_minute: z.number().int().positive().optional(),
+    per_hour: z.number().int().positive().optional(),
+    per_day: z.number().int().positive().optional(),
+    max_concurrent: z.number().int().positive().optional(),
+  })
+  .strict()
+  .refine(
+    (l) =>
+      l.per_minute !== undefined ||
+      l.per_hour !== undefined ||
+      l.per_day !== undefined ||
+      l.max_concurrent !== undefined,
+    {
+      message:
+        "admission principal override must declare at least one bound (per_minute, per_hour, per_day, or max_concurrent)",
+    },
+  );
+
+export type AdmissionPrincipalOverride = z.infer<
+  typeof AdmissionPrincipalOverrideSchema
+>;
+
+// ---------------------------------------------------------------------------
+// The policy.admission block
+// ---------------------------------------------------------------------------
+
+export const AdmissionPolicySchema = z
+  .object({
+    /** Tier 1 — the global stack spawn ceiling. Applies to EVERY dispatch. */
+    stack: AdmissionLimitsSchema.optional(),
+    /** Tier 2 baseline — every principal unless a role/principal override wins. */
+    defaults: AdmissionLimitsSchema.optional(),
+    /**
+     * Tier 2 role overrides, keyed by role id (must be declared in
+     * `policy.roles[]` — cross-checked in `PolicySchema.superRefine`). When a
+     * principal holds several roles, the MOST PERMISSIVE value per field wins
+     * — the same union direction as capability grants (`engine.ts`).
+     */
+    roles: z.record(z.string(), AdmissionLimitsSchema).optional(),
+    /**
+     * Tier 2 per-principal overrides (most specific — beats roles and
+     * defaults, field by field). Ids must be declared in
+     * `policy.principals[]` (cross-checked in `PolicySchema.superRefine`).
+     */
+    principals: z.array(AdmissionPrincipalOverrideSchema).optional(),
+    /**
+     * The open-onboarding (anonymous `did:mf:public`) floor. CLAMPED at
+     * runtime to the built-in ceiling ({@link ANONYMOUS_ADMISSION_CEILING}:
+     * 2/min, 1 in-flight) — config can tighten it, never raise it. Absent ⇒
+     * the ceiling applies as-is whenever an `admission:` block is configured.
+     */
+    anonymous: AdmissionLimitsSchema.optional(),
+  })
+  .strict();
+
+export type AdmissionPolicy = z.infer<typeof AdmissionPolicySchema>;
+
+// ---------------------------------------------------------------------------
+// Resolution — which limits govern a given requester
+// ---------------------------------------------------------------------------
+
+/**
+ * The built-in anonymous ceiling (design §3.1): the zero-authority public
+ * principal gets a hard-tight default REGARDLESS of config — 2 dispatches a
+ * minute, 1 in flight. Config may add tighter windows (`per_hour`/`per_day`
+ * only further restrict) but can never raise these two.
+ */
+export const ANONYMOUS_ADMISSION_CEILING = {
+  per_minute: 2,
+  max_concurrent: 1,
+} as const;
+
+/** Inputs to {@link resolveAdmissionLimits}. */
+export interface ResolveAdmissionLimitsInput {
+  /** Bare requester principal id (envelope-resolved; see myelin admission spec §1). */
+  principalId: string;
+  /** True when the requester resolved to the anonymous public principal. */
+  anonymous: boolean;
+  /** Role ids the principal holds (from `policy.principals[].role`). */
+  roles: readonly string[];
+}
+
+const LIMIT_FIELDS = [
+  "per_minute",
+  "per_hour",
+  "per_day",
+  "max_concurrent",
+] as const;
+type LimitField = (typeof LIMIT_FIELDS)[number];
+
+/**
+ * Resolve the tier-2 (per-principal) limits for a requester, per design §4.1:
+ * `principals[id]` > `roles` (most permissive across the principal's roles)
+ * > `defaults` — resolved FIELD BY FIELD, so a principal override that only
+ * sets `per_minute` still inherits `max_concurrent` from its roles/defaults.
+ *
+ * The anonymous principal short-circuits to its own lane: the configured
+ * `anonymous:` block clamped to {@link ANONYMOUS_ADMISSION_CEILING} (absent ⇒
+ * the ceiling verbatim). `defaults`/`roles`/`principals` never apply to it —
+ * the open-onboarding identity cannot be widened by a generous default.
+ *
+ * Returns `undefined` when NO field resolves — that tier is then inert for
+ * this requester (no KV key is read or written).
+ */
+export function resolveAdmissionLimits(
+  admission: AdmissionPolicy,
+  input: ResolveAdmissionLimitsInput,
+): AdmissionLimits | undefined {
+  if (input.anonymous) {
+    return clampAnonymousLimits(admission.anonymous);
+  }
+
+  const override = admission.principals?.find((p) => p.id === input.principalId);
+  const resolved: Partial<Record<LimitField, number>> = {};
+  for (const field of LIMIT_FIELDS) {
+    const fromOverride = override?.[field];
+    if (fromOverride !== undefined) {
+      resolved[field] = fromOverride;
+      continue;
+    }
+    // Most permissive across the principal's roles that set the field —
+    // the capability-union direction (a second role never TIGHTENS what a
+    // first role granted).
+    let fromRoles: number | undefined;
+    for (const roleId of input.roles) {
+      const roleLimits = admission.roles?.[roleId];
+      const v = roleLimits?.[field];
+      if (v !== undefined && (fromRoles === undefined || v > fromRoles)) {
+        fromRoles = v;
+      }
+    }
+    if (fromRoles !== undefined) {
+      resolved[field] = fromRoles;
+      continue;
+    }
+    const fromDefaults = admission.defaults?.[field];
+    if (fromDefaults !== undefined) {
+      resolved[field] = fromDefaults;
+    }
+  }
+
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+}
+
+/**
+ * Clamp the configured anonymous limits to the built-in ceiling. Absent
+ * config ⇒ the ceiling verbatim; configured values are `min()`-ed against the
+ * ceiling on the capped fields (`per_minute`, `max_concurrent`) and passed
+ * through on the tighten-only fields (`per_hour`, `per_day` — extra windows
+ * AND against the ceiling, so they can only restrict further).
+ */
+export function clampAnonymousLimits(
+  configured: AdmissionLimits | undefined,
+): AdmissionLimits {
+  const clamped: AdmissionLimits = {
+    per_minute: Math.min(
+      configured?.per_minute ?? ANONYMOUS_ADMISSION_CEILING.per_minute,
+      ANONYMOUS_ADMISSION_CEILING.per_minute,
+    ),
+    max_concurrent: Math.min(
+      configured?.max_concurrent ?? ANONYMOUS_ADMISSION_CEILING.max_concurrent,
+      ANONYMOUS_ADMISSION_CEILING.max_concurrent,
+    ),
+  };
+  if (configured?.per_hour !== undefined) clamped.per_hour = configured.per_hour;
+  if (configured?.per_day !== undefined) clamped.per_day = configured.per_day;
+  return clamped;
+}

--- a/src/common/types/admission.ts
+++ b/src/common/types/admission.ts
@@ -42,7 +42,7 @@
  *
  * The window fields reuse the `offering.ts` rate vocabulary exactly
  * (`per_minute`/`per_hour`/`per_day` from `RatePredicateSchema`,
- * `max_concurrent` from `PublicLimitsSchema`) so operators tune ONE dialect
+ * `max_concurrent` from `PublicLimitsSchema`) so a stack tunes ONE dialect
  * across public-offering limits and admission limits.
  */
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -50,6 +50,7 @@ import { NKEY_PUBKEY_REGEX } from "./nkey";
 import { NatsSubjectsSchema } from "./nats-subjects";
 import { LETTER_PREFIX_ID_REGEX } from "./id";
 import { OfferingSchema, superRefineOfferings } from "./offering";
+import { AdmissionPolicySchema } from "./admission";
 import { CAPABILITY_ID_REGEX } from "./capability";
 import { checkPublicOfferingBackendGate } from "./public-offering-backend-gate";
 import { StackConfigSchema, deriveStackId } from "./stack";
@@ -2374,6 +2375,21 @@ export const PolicySchema = z.object({
    * default — is the single source of the default-deny semantics.
    */
   offerings: z.array(OfferingSchema).optional(),
+  /**
+   * R26 P1 (cortex#1371) — the substrate ADMISSION block: KV-arbitrated rate
+   * limiting at the spawn gate (design `docs/design-substrate-rate-limiting.md`
+   * §4.1; myelin `specs/admission.md`). Tier 1 (`stack`) is the global spawn
+   * ceiling; tier 2 resolves `principals[id]` > `roles` (most permissive) >
+   * `defaults`, field by field; `anonymous` is the open-onboarding floor,
+   * clamped to the built-in 2/min · 1-in-flight ceiling.
+   *
+   * **`.optional()`, deliberately no default** — mirrors `federated`/`public`/
+   * `offerings`: an ABSENT block means the AdmissionGate is never constructed
+   * and behaviour is byte-identical to a pre-R26 build (the CO-4
+   * provably-inert-until-configured rule, `gate-floor.ts:29-37`). Cross-refs
+   * (role keys, principal ids) are checked in the superRefine below.
+   */
+  admission: AdmissionPolicySchema.optional(),
   // v2.0.0 cutover (cortex#297) — `parallel_mode_enabled` retired with
   // the parallel-mode plumbing in adapters. PolicyEngine is the sole
   // authorisation gate; legacy role-resolver is gone.
@@ -2607,6 +2623,45 @@ export const PolicySchema = z.object({
           }
         }
       });
+    });
+  }
+
+  // R26 P1 (cortex#1371) — admission cross-refs. Same per-offender path
+  // pattern as the principal/role rules above: every admission.roles key must
+  // be a declared role, every admission.principals[].id a declared principal
+  // (and unique within the admission block) — a dangling override would
+  // silently never apply, which reads as "limited" while limiting nothing.
+  if (policy.admission !== undefined) {
+    const knownRoleIds = new Set(policy.roles.map((r) => r.id));
+    for (const roleId of Object.keys(policy.admission.roles ?? {})) {
+      if (!knownRoleIds.has(roleId)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `admission.roles key "${roleId}" references undeclared role — declare it in policy.roles[]`,
+          path: ["admission", "roles", roleId],
+        });
+      }
+    }
+    const knownPrincipalIds = new Set(policy.principals.map((p) => p.id));
+    const seenAdmissionPrincipal = new Map<string, number>();
+    (policy.admission.principals ?? []).forEach((entry, i) => {
+      if (!knownPrincipalIds.has(entry.id)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `admission.principals[${i}].id "${entry.id}" references undeclared principal — declare it in policy.principals[]`,
+          path: ["admission", "principals", i, "id"],
+        });
+      }
+      const dupAt = seenAdmissionPrincipal.get(entry.id);
+      if (dupAt !== undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: `admission.principals[${i}].id "${entry.id}" already declared at admission.principals[${dupAt}]`,
+          path: ["admission", "principals", i, "id"],
+        });
+      } else {
+        seenAdmissionPrincipal.set(entry.id, i);
+      }
     });
   }
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -65,6 +65,13 @@ import { DID_RE } from "@the-metafactory/myelin/identity";
 import { createSurfaceRouter, type SurfaceRouter } from "./bus/surface-router";
 import { createNetworkResolver } from "./bus/network-resolver";
 import type { SystemEventSource } from "./bus/system-events";
+// R26 P1 (cortex#1371) — the substrate admission gate + its loud degrade event.
+import { createSystemAdmissionDegradedEvent } from "./bus/system-events";
+import {
+  AdmissionGate,
+  admissionBucketName,
+  provisionAdmissionKv,
+} from "./bus/admission";
 import {
   publishCapabilityRegistry,
   buildCapabilityRegisteredEnvelope,
@@ -4375,6 +4382,84 @@ export async function startCortex(
   // Per-agent listeners; `start()`/`stop()`-ed as a set (mirrors how
   // `reviewConsumers` / `brainConsumers` are tracked + drained).
   const dispatchListeners: DispatchListener[] = [];
+  // R26 P1 (cortex#1371) — the substrate ADMISSION GATE (design
+  // `docs/design-substrate-rate-limiting.md` Design B; contract myelin
+  // `specs/admission.md`). Constructed ONLY when the principal declared a
+  // `policy.admission` block — absent block ⇒ `admissionGate` stays
+  // `undefined`, the listeners below receive no gate, and behaviour is
+  // byte-identical to a pre-R26 build (the CO-4 inertness rule,
+  // `gate-floor.ts:29-37`): no KV bucket provisioned, no admission reads,
+  // no new envelopes.
+  //
+  // State lives in the per-(principal, stack) NATS-KV bucket
+  // `admission_{principal}_{stack}` — provisioned idempotently here
+  // (mirroring the review-stream provisioning above) and arbitrated by CAS,
+  // so admission counters are EXACT across N cortex nodes. Provisioning
+  // failure is NON-FATAL: the gate starts in its designed DEGRADED posture
+  // (node-local approximate buckets + loud `system.admission.degraded`
+  // event; anonymous dispatches fail closed) rather than blocking boot.
+  let admissionGate: AdmissionGate | undefined;
+  if (resolvedPolicy?.admission !== undefined) {
+    const admissionBucket = admissionBucketName(principalId, derivedStack.stack);
+    let admissionJsm: import("./bus/jetstream/types").ProvisionJsm | null = null;
+    if (runtime.jetstreamManager !== undefined) {
+      try {
+        admissionJsm = await runtime.jetstreamManager();
+      } catch (err) {
+        process.stderr.write(
+          `cortex: jetstreamManager() resolution failed for admission provisioning — ` +
+            `continuing to KV open: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+    const provisionedAdmission = await provisionAdmissionKv({
+      jsm: admissionJsm,
+      openKv: async (bucket) =>
+        runtime.kvBucket !== undefined ? await runtime.kvBucket(bucket) : null,
+      bucket: admissionBucket,
+      log: console,
+    });
+    // Tier-2 resolution input: principal id → declared role ids. Built once
+    // from the SAME parsed policy the engine uses, so admission roles can't
+    // drift from authorisation roles.
+    const admissionPrincipalRoles = new Map<string, readonly string[]>(
+      resolvedPolicy.principals.map((p) => [p.id, p.role]),
+    );
+    admissionGate = new AdmissionGate({
+      config: resolvedPolicy.admission,
+      kv: provisionedAdmission.kv,
+      principalRoles: admissionPrincipalRoles,
+      // Design §4.4 — degrade transitions MUST be loud: a `system.admission.
+      // degraded` envelope per transition (the gate also writes stderr).
+      // Fire-and-forget with a logged rejection — the transition event must
+      // never block or fail an admission decision (no-empty-catch rule).
+      onDegradeTransition: (mode, detail) => {
+        void runtime
+          .publish(
+            createSystemAdmissionDegradedEvent({
+              source: systemEventSource,
+              mode,
+              detail,
+              bucket: admissionBucket,
+            }),
+          )
+          .catch((err: unknown) => {
+            process.stderr.write(
+              `cortex: system.admission.degraded publish failed (mode=${mode}): ` +
+                `${err instanceof Error ? err.message : String(err)}\n`,
+            );
+          });
+      },
+    });
+    console.log(
+      `cortex: admission gate ENABLED — bucket=${admissionBucket} ` +
+        `(${provisionedAdmission.outcome}), tiers=stack+principal, ` +
+        `stack=${resolvedPolicy.admission.stack !== undefined ? "configured" : "unset"}, ` +
+        `defaults=${resolvedPolicy.admission.defaults !== undefined ? "configured" : "unset"}, ` +
+        `anonymous=built-in-ceiling${resolvedPolicy.admission.anonymous !== undefined ? "+config" : ""}`,
+    );
+  }
+
   // Shared options every listener carries — only `receivingAgentId` + the
   // scoped `subjects` differ per agent. Built once so the per-agent wiring
   // can't drift between listeners.
@@ -4428,6 +4513,10 @@ export async function startCortex(
     ...(config.claude.bashAllowlist !== undefined && {
       bashAllowlist: config.claude.bashAllowlist,
     }),
+    // R26 P1 (cortex#1371) — admission gate. Spread-guarded like the other
+    // optional fields: an unconfigured stack passes NO gate and the listener's
+    // admission stage is skipped entirely (CO-4 inertness).
+    ...(admissionGate !== undefined && { admissionGate }),
   };
   if (chatAgents.length >= 2) {
     // Multi-agent: each chat-capable agent gets its OWN listener on its OWN

--- a/src/runner/__tests__/dispatch-listener-admission.test.ts
+++ b/src/runner/__tests__/dispatch-listener-admission.test.ts
@@ -1,0 +1,419 @@
+/**
+ * R26 P1 (cortex#1371) — enforcement-point tests: the ADMISSION GATE stage
+ * inside `handleDispatchEnvelope` (after the policy allow, before harness
+ * construction — design §4.2 enforcement point 1).
+ *
+ * Coverage:
+ *   1. INERTNESS — no `admissionGate` option (i.e. no `policy.admission`
+ *      block) ⇒ the dispatch pipeline emits exactly what it emitted pre-R26:
+ *      no `system.admission.*` envelopes, session spawns normally. This is
+ *      the listener-level proof of the CO-4 byte-identical contract.
+ *   2. THROTTLE — a refusing gate ⇒ `system.admission.throttled` (audit leg)
+ *      + terminal `dispatch.task.failed { kind: "not_now", retry_after_ms }`
+ *      with the friendly renderer summary, and NO session spawn.
+ *   3. ORDERING — a policy DENY never consults the admission gate (permanent
+ *      refusals before transient ones, `gate-floor.ts:195-202`).
+ *   4. IDENTITY — the gate is keyed on the SAME principal the policy gate
+ *      resolved.
+ *   5. LEASE LIFECYCLE — a `max_concurrent: 1` gate readmits after the first
+ *      dispatch terminates (the `finally` release around the harness drain).
+ *
+ * Mirrors the fixtures of `dispatch-listener.test.ts` (recording runtime,
+ * canonical Tasks-Domain subject, fake CC factory); chain verification is
+ * deliberately unwired (no trustResolver) — admission ordering relative to
+ * the POLICY gate is what's under test.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { SystemEventSource } from "../../bus/system-events";
+import {
+  createDispatchListener,
+  type CCSessionFactory,
+  type DispatchTaskReceivedPayload,
+} from "../dispatch-listener";
+import type { CCSessionResult } from "../cc-session";
+import { PolicyEngine } from "../../common/policy/engine";
+import { AdmissionGate } from "../../bus/admission";
+import type { AdmissionPolicy } from "../../common/types/admission";
+import type { ProvisionKv, ProvisionKvEntry } from "../../bus/jetstream/types";
+
+const SOURCE: SystemEventSource = {
+  principal: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+const CANONICAL_CORTEX_CHAT_SUBJECT =
+  "local.metafactory.tasks.@did-mf-cortex.chat";
+
+const TASK_ID = "11111111-1111-4111-8111-111111111111";
+const TASK_ID_2 = "22222222-2222-4222-8222-222222222222";
+
+const TERMINAL_TYPES = new Set([
+  "dispatch.task.completed",
+  "dispatch.task.failed",
+  "dispatch.task.aborted",
+  "system.access.denied",
+]);
+
+/** Wait for a terminal envelope (same de-flake rationale as the sibling
+ * suite, cortex#771): the pipeline's end is observable, never a fixed sleep. */
+async function settle(
+  published: () => readonly Envelope[],
+  { minObserveMs = 250, idleMs = 25 }: { minObserveMs?: number; idleMs?: number } = {},
+): Promise<void> {
+  const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 2));
+  const hasTerminal = () => published().some((e) => TERMINAL_TYPES.has(e.type));
+  const observeUntil = Date.now() + minObserveMs;
+  while (Date.now() < observeUntil && !hasTerminal()) {
+    await tick();
+  }
+  const idleUntil = Date.now() + idleMs;
+  while (Date.now() < idleUntil) {
+    await tick();
+  }
+}
+
+function recordingRuntime(): {
+  runtime: MyelinRuntime;
+  published: Envelope[];
+  trigger: (env: Envelope, subject: string) => void;
+} {
+  const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
+  const published: Envelope[] = [];
+  return {
+    runtime: {
+      enabled: true,
+      onEnvelope: (handler) => {
+        handlers.add(handler);
+        return {
+          unregister: () => {
+            handlers.delete(handler);
+          },
+        };
+      },
+       
+      publish: async (env) => {
+        published.push(env);
+      },
+       
+      subscribe: async (pattern) =>
+        ({
+          pattern,
+          ready: Promise.resolve(),
+          stop: async () => {},
+        }) as unknown as Awaited<
+          ReturnType<NonNullable<MyelinRuntime["subscribe"]>>
+        >,
+      stop: async () => {},
+    },
+    published,
+    trigger: (env, subject) => {
+      for (const h of handlers) h(env, subject);
+    },
+  };
+}
+
+function makeReceivedEnvelope(
+  payloadOverrides: Partial<DispatchTaskReceivedPayload> = {},
+): Envelope {
+  const payload: DispatchTaskReceivedPayload = {
+    task_id: TASK_ID,
+    agent_id: "cortex",
+    prompt: "say hello",
+    ...payloadOverrides,
+  };
+  return {
+    id: "00000000-0000-4000-8000-000000000000",
+    source: "metafactory.dispatch-handler.local",
+    type: "dispatch.task.received",
+    distribution_mode: "direct",
+    target_assistant: `did:mf:${payload.agent_id}`,
+    timestamp: "2026-05-09T12:00:00Z",
+    correlation_id: payload.task_id,
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: payload as unknown as Record<string, unknown>,
+  };
+}
+
+const SUCCESS_RESULT: CCSessionResult = {
+  success: true,
+  response: "Hello!",
+  exitCode: 0,
+  durationMs: 10,
+  sessionId: "session-admission-test",
+};
+
+function fakeFactory(result: CCSessionResult): {
+  factory: CCSessionFactory;
+  spawnCount: () => number;
+} {
+  let spawns = 0;
+  const factory: CCSessionFactory = () => {
+    spawns++;
+    const session = {
+      start() {
+        return session;
+      },
+      async wait() {
+        return result;
+      },
+    };
+    return session;
+  };
+  return { factory, spawnCount: () => spawns };
+}
+
+function engineGranting(capabilities: readonly string[]): PolicyEngine {
+  return new PolicyEngine({
+    principals: [
+      {
+        id: "cortex",
+        home_principal: "andreas",
+        home_stack: "andreas/research",
+        role: ["operator"],
+        trust: [],
+      },
+    ],
+    roles: [{ id: "operator", capabilities }],
+  });
+}
+
+/** In-memory CAS-faithful KV (same semantics as the gate suite's stub). */
+function memoryKv(): ProvisionKv {
+  const data = new Map<string, { value: Uint8Array; revision: number }>();
+  let revisionCounter = 0;
+  return {
+     
+    get: async (key): Promise<ProvisionKvEntry | null> => {
+      const e = data.get(key);
+      return e === undefined
+        ? null
+        : { value: e.value, revision: e.revision, operation: "PUT" };
+    },
+     
+    create: async (key, value): Promise<number> => {
+      if (data.has(key)) throw new Error("wrong last sequence: exists");
+      const revision = ++revisionCounter;
+      data.set(key, { value, revision });
+      return revision;
+    },
+     
+    update: async (key, value, revision): Promise<number> => {
+      const e = data.get(key);
+      if (e?.revision !== revision) {
+        throw new Error("wrong last sequence");
+      }
+      const next = ++revisionCounter;
+      data.set(key, { value, revision: next });
+      return next;
+    },
+  };
+}
+
+function makeGate(config: AdmissionPolicy): AdmissionGate {
+  return new AdmissionGate({
+    config,
+    kv: memoryKv(),
+    principalRoles: new Map(),
+    log: { warn: () => {} },
+  });
+}
+
+describe("dispatch-listener — admission gate (R26 P1 enforcement point 1)", () => {
+  test("INERT without an admissionGate: no system.admission.* envelopes, session spawns", async () => {
+    const r = recordingRuntime();
+    const { factory, spawnCount } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      // no admissionGate — the `policy.admission`-absent posture
+    });
+    await listener.start();
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+    await listener.stop();
+
+    expect(spawnCount()).toBe(1);
+    const types = r.published.map((e) => e.type);
+    expect(types).toContain("dispatch.task.completed");
+    expect(types.some((t) => t.startsWith("system.admission."))).toBe(false);
+  });
+
+  test("THROTTLED: audit + terminal not_now with retry hint, and NO spawn", async () => {
+    const r = recordingRuntime();
+    const { factory, spawnCount } = fakeFactory(SUCCESS_RESULT);
+    // per_minute: 1 — the second dispatch in the window must throttle.
+    const gate = makeGate({ defaults: { per_minute: 1 } });
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      admissionGate: gate,
+    });
+    await listener.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+    expect(spawnCount()).toBe(1);
+
+    const before = r.published.length;
+    r.trigger(
+      makeReceivedEnvelope({ task_id: TASK_ID_2 }),
+      CANONICAL_CORTEX_CHAT_SUBJECT,
+    );
+    await settle(() => r.published.slice(before));
+    await listener.stop();
+
+    // No second spawn.
+    expect(spawnCount()).toBe(1);
+
+    const after = r.published.slice(before);
+    // Audit leg — system.admission.throttled with the structured reason.
+    const throttled = after.find((e) => e.type === "system.admission.throttled");
+    expect(throttled).toBeDefined();
+    expect(throttled?.correlation_id).toBe(TASK_ID_2);
+    const reason = (throttled?.payload as {
+      principal_id?: string;
+      reason?: Record<string, unknown>;
+    });
+    expect(reason.principal_id).toBe("cortex");
+    expect(reason.reason?.kind).toBe("rate");
+    expect(reason.reason?.tier).toBe("principal");
+    expect(reason.reason?.window).toBe("per_minute");
+    expect(reason.reason?.degraded).toBe(false);
+    expect(reason.reason?.retry_after_ms).toBeGreaterThan(0);
+
+    // Lifecycle leg — TERMINAL not_now on the dispatch's correlation id with
+    // the friendly renderer summary (Q6). Never `policy_denied`, never a
+    // permanent kind.
+    const failed = after.find((e) => e.type === "dispatch.task.failed");
+    expect(failed).toBeDefined();
+    expect(failed?.correlation_id).toBe(TASK_ID_2);
+    const failedPayload = failed?.payload as {
+      reason?: { kind?: string; retry_after_ms?: number; detail?: string };
+      error?: string;
+      error_summary?: string;
+    };
+    expect(failedPayload.reason?.kind).toBe("not_now");
+    expect(failedPayload.reason?.retry_after_ms).toBeGreaterThan(0);
+    expect(failedPayload.reason?.detail).toContain("admission: rate limit");
+    expect(JSON.stringify(failed?.payload)).toContain("busy — try again in ~");
+
+    // No started/completed for the throttled task.
+    const startedForThrottled = after.some(
+      (e) => e.type === "dispatch.task.started" && e.correlation_id === TASK_ID_2,
+    );
+    expect(startedForThrottled).toBe(false);
+  });
+
+  test("ORDERING: a policy DENY never consults the admission gate", async () => {
+    const r = recordingRuntime();
+    const { factory, spawnCount } = fakeFactory(SUCCESS_RESULT);
+    const gate = makeGate({ defaults: { per_minute: 100 } });
+    let checked = 0;
+    const realCheck = gate.check.bind(gate);
+    gate.check = async (req) => {
+      checked++;
+      return realCheck(req);
+    };
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      // Engine grants NOTHING — the policy gate denies dispatch.cortex.
+      policyEngine: engineGranting([]),
+      admissionGate: gate,
+    });
+    await listener.start();
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+    await listener.stop();
+
+    expect(spawnCount()).toBe(0);
+    expect(checked).toBe(0); // the transient gate ran AFTER the permanent one — never
+    const types = r.published.map((e) => e.type);
+    expect(types).toContain("system.access.denied");
+    expect(types.some((t) => t.startsWith("system.admission."))).toBe(false);
+    // The terminal deny is policy_denied, not not_now.
+    const failed = r.published.find((e) => e.type === "dispatch.task.failed");
+    expect((failed?.payload as { reason?: { kind?: string } }).reason?.kind).toBe(
+      "policy_denied",
+    );
+  });
+
+  test("IDENTITY: the gate is keyed on the policy-resolved principal", async () => {
+    const r = recordingRuntime();
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const gate = makeGate({ defaults: { per_minute: 100 } });
+    const seen: { principalId: string; anonymous: boolean; leaseId: string }[] = [];
+    const realCheck = gate.check.bind(gate);
+    gate.check = async (req) => {
+      seen.push(req);
+      return realCheck(req);
+    };
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      admissionGate: gate,
+    });
+    await listener.start();
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+    await listener.stop();
+
+    // No chain, no originator ⇒ the policy gate resolved `payload.agent_id`
+    // ("cortex") — the admission gate MUST key on the same identity, with the
+    // task id as the lease id (myelin spec §1).
+    expect(seen).toEqual([
+      { principalId: "cortex", anonymous: false, leaseId: TASK_ID },
+    ]);
+  });
+
+  test("LEASE LIFECYCLE: max_concurrent slot is released when the dispatch terminates", async () => {
+    const r = recordingRuntime();
+    const { factory, spawnCount } = fakeFactory(SUCCESS_RESULT);
+    const gate = makeGate({ defaults: { max_concurrent: 1 } });
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      admissionGate: gate,
+    });
+    await listener.start();
+
+    // Dispatch 1 — admitted, runs, terminates (fake session resolves fast).
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+    expect(spawnCount()).toBe(1);
+
+    // Dispatch 2 — the ONLY way this admits is if dispatch 1's in-flight
+    // lease was released in the `finally` around the harness drain.
+    const before = r.published.length;
+    r.trigger(
+      makeReceivedEnvelope({ task_id: TASK_ID_2 }),
+      CANONICAL_CORTEX_CHAT_SUBJECT,
+    );
+    await settle(() => r.published.slice(before));
+    await listener.stop();
+
+    expect(spawnCount()).toBe(2);
+    const after = r.published.slice(before);
+    expect(after.some((e) => e.type === "system.admission.throttled")).toBe(false);
+    expect(after.some((e) => e.type === "dispatch.task.completed")).toBe(true);
+  });
+});

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -91,6 +91,7 @@ import type {
 import {
   createSystemAccessAllowedEvent,
   createSystemAccessDeniedEvent,
+  createSystemAdmissionThrottledEvent,
   createSystemDispatchStageEvent,
   type SystemDispatchStage,
   type SystemDispatchStageOutcome,
@@ -101,6 +102,10 @@ import type {
 } from "../common/substrates/types";
 import type { PolicyEngine } from "../common/policy/engine";
 import { extractAgentIdFromDid } from "../common/policy/did";
+// R26 P1 (cortex#1371) — the substrate admission gate (KV-arbitrated rate
+// limiting) + the anonymous public principal id it fails closed for.
+import type { AdmissionGate, AdmissionLease } from "../bus/admission";
+import { PUBLIC_PRINCIPAL_ID } from "../common/policy/factory";
 import { isUuid } from "../common/types/uuid";
 // M3 (cortex#1241, ADR-0019) — verify-then-decrypt the sealed dispatch payload.
 import { readMarker, NetworkKeyring } from "../common/crypto/payload-encryption";
@@ -524,6 +529,19 @@ export interface DispatchListenerOptions {
    * plumbing is complete and a future config knob is a one-line wire-up.
    */
   bashGuardDisabled?: boolean;
+  /**
+   * R26 P1 (cortex#1371) — the substrate ADMISSION GATE (design
+   * `docs/design-substrate-rate-limiting.md` Design B; myelin
+   * `specs/admission.md`). When supplied, every policy-ALLOWED dispatch is
+   * admission-checked (KV-arbitrated token bucket + in-flight lease, keyed on
+   * the envelope-resolved requester principal) BEFORE the harness is
+   * constructed; a refusal emits `system.admission.throttled` plus a terminal
+   * `dispatch.task.failed { kind: "not_now", retry_after_ms }` and never
+   * spawns. `cortex.ts` supplies this ONLY when `policy.admission` is
+   * configured — `undefined` (the default) is the CO-4 inert posture:
+   * byte-identical behaviour, zero admission reads.
+   */
+  admissionGate?: AdmissionGate;
 }
 
 export interface DispatchListener {
@@ -792,6 +810,7 @@ export function createDispatchListener(
     resolveFederatedPeer,
     bashAllowlist,
     bashGuardDisabled,
+    admissionGate,
     adapterId = "runner-dispatch-listener",
   } = opts;
   // v2.0.2 default: structural trust + ed25519 crypto verification.
@@ -873,6 +892,7 @@ export function createDispatchListener(
         traceDispatch,
         bashAllowlist,
         bashGuardDisabled,
+        admissionGate,
       });
     } catch (err) {
       process.stderr.write(
@@ -1339,6 +1359,12 @@ interface DispatchHandlerContext {
    * (no config knob); injected onto `DispatchRequest.runtime` when set.
    */
   bashGuardDisabled: boolean | undefined;
+  /**
+   * R26 P1 (cortex#1371) — admission gate. `undefined` ⇒ `policy.admission`
+   * is not configured ⇒ the admission stage is skipped entirely (CO-4
+   * inertness). See {@link DispatchListenerOptions.admissionGate}.
+   */
+  admissionGate: AdmissionGate | undefined;
 }
 
 async function handleDispatchEnvelope(
@@ -1366,6 +1392,7 @@ async function handleDispatchEnvelope(
     traceDispatch,
     bashAllowlist,
     bashGuardDisabled,
+    admissionGate,
   } = ctx;
   // cortex#492 — pre-parse trace context from CLEARTEXT METADATA ONLY. M3
   // (cortex#1241, ADR-0019) reorder: NOTHING reads the payload before
@@ -1743,6 +1770,12 @@ async function handleDispatchEnvelope(
   // leave it `undefined` so the engine skips the federation branch.
   const sourceNetwork = extractSourceNetwork(envelope, subject, federatedNetworksById);
   let gatedPrincipal: Principal | undefined;
+  // R26 P1 (cortex#1371) — in-flight admission lease, acquired by the
+  // admission gate below (only when `max_concurrent` tiers are configured)
+  // and released in the `finally` around the harness drain: the harness
+  // guarantees at least one terminal lifecycle envelope per dispatch, so the
+  // drain loop's end IS the dispatch's end.
+  let admissionLease: AdmissionLease | undefined;
   if (policyEngine === undefined) {
     // v2.0.1 (cortex#311): fail-closed when policy engine is unavailable.
     // In v2.0.0+ this only happens when principal declared empty
@@ -1910,6 +1943,101 @@ async function handleDispatchEnvelope(
       decision.capability,
     );
     gatedPrincipal = decision.principal;
+
+    // R26 P1 (cortex#1371) — ADMISSION GATE (enforcement point 1, design
+    // §4.2). Runs AFTER the policy allow and BEFORE harness construction:
+    // permanent refusals (policy) come before transient ones (rate) — the
+    // gate floor's ordering rule (`gate-floor.ts:195-202`) — and admission
+    // KV I/O stays off the path of requests that were going to be denied
+    // anyway. Keyed on the SAME principal the policy gate resolved
+    // (`decision.principalId` ← `originator.identity` → `signed_by[0]`), so
+    // admission and authorization can never key on divergent identities
+    // (myelin `specs/admission.md` §1). `admissionGate` is `undefined` when
+    // `policy.admission` is absent — this whole stage is then skipped
+    // (CO-4 inertness: byte-identical behaviour, zero admission reads).
+    if (admissionGate !== undefined) {
+      const admission = await admissionGate.check({
+        principalId: decision.principalId,
+        anonymous: decision.principalId === PUBLIC_PRINCIPAL_ID,
+        leaseId: payload.task_id,
+      });
+      if (!admission.admit) {
+        const retryAfterMs = admission.retry_after_ms;
+        trace(
+          traceDispatch,
+          runtime,
+          source,
+          "admission-checked",
+          "fail",
+          traceCtx,
+          `${admission.reason} tier=${admission.tier}${admission.window !== undefined ? ` window=${admission.window}` : ""}${admission.degraded ? " degraded" : ""}`,
+        );
+        process.stderr.write(
+          `[runner/dispatch-listener] admission throttled envelope ` +
+            `${envelope.id} (correlation_id=${envelope.correlation_id ?? "<none>"} ` +
+            `task_id=${payload.task_id} principal=${decision.principalId}): ` +
+            `${admission.reason} tier=${admission.tier} key=${admission.key}` +
+            (admission.window !== undefined ? ` window=${admission.window}` : "") +
+            `${admission.limit !== undefined ? ` limit=${admission.limit}` : ""} ` +
+            `retry_after_ms=${retryAfterMs}${admission.degraded ? " (degraded)" : ""}\n`,
+        );
+        // Audit leg — `system.admission.throttled`, the transient sibling of
+        // `system.access.denied` (design §4.4). Same audit-common fields so
+        // consumers join both streams on correlation/envelope keys.
+        const throttled = createSystemAdmissionThrottledEvent({
+          ...auditCommon,
+          reason: {
+            kind: admission.reason,
+            tier: admission.tier,
+            key: admission.key,
+            ...(admission.window !== undefined && { window: admission.window }),
+            ...(admission.limit !== undefined && { limit: admission.limit }),
+            ...(admission.observed !== undefined && {
+              observed: admission.observed,
+            }),
+            retry_after_ms: retryAfterMs,
+            degraded: admission.degraded,
+          },
+        });
+        await runtime.publish(throttled);
+        // Lifecycle leg — TERMINAL `not_now` on the dispatch's correlation id
+        // (Q6 sign-off): interactive surfaces render `errorSummary` (the
+        // friendly string); the structured taxonomy rides `reason.detail` +
+        // `retry_after_ms`. NEVER `term` semantics — rate exhaustion is
+        // transient by definition.
+        const retrySeconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+        const now = new Date();
+        const failed = createDispatchTaskFailedEvent({
+          source,
+          taskId: payload.task_id,
+          agentId: payload.agent_id,
+          startedAt: now,
+          failedAt: now,
+          errorSummary: `busy — try again in ~${retrySeconds}s`,
+          reason: {
+            kind: "not_now",
+            detail:
+              `admission: ${admission.reason === "concurrency" ? "concurrency limit" : admission.reason === "rate" ? "rate limit" : "admission store unavailable"} ` +
+              `(principal=${decision.principalId}, tier=${admission.tier}` +
+              (admission.window !== undefined ? `, window=${admission.window}` : "") +
+              `${admission.limit !== undefined ? `, limit=${admission.limit}` : ""})`,
+            retry_after_ms: retryAfterMs,
+          },
+        });
+        await runtime.publish(failed);
+        return;
+      }
+      admissionLease = admission.lease;
+      trace(
+        traceDispatch,
+        runtime,
+        source,
+        "admission-checked",
+        "pass",
+        traceCtx,
+        admission.degraded ? "degraded-local" : undefined,
+      );
+    }
   }
 
   // Per-dispatch harness — see fn-doc above for rationale. `source` is
@@ -1988,15 +2116,25 @@ async function handleDispatchEnvelope(
   // envelope passes through verbatim, exactly as before this change.
   const responseRouting = payload.response_routing;
   let firstYield = true;
-  for await (const env of harness.dispatch(req)) {
-    if (firstYield) {
-      firstYield = false;
-      // The harness produced its first lifecycle envelope — the session
-      // is actually running. Closes the trace: a dispatch that reaches
-      // `started` got all the way through to a live CC session.
-      trace(traceDispatch, runtime, source, "started", "info", traceCtx);
+  try {
+    for await (const env of harness.dispatch(req)) {
+      if (firstYield) {
+        firstYield = false;
+        // The harness produced its first lifecycle envelope — the session
+        // is actually running. Closes the trace: a dispatch that reaches
+        // `started` got all the way through to a live CC session.
+        trace(traceDispatch, runtime, source, "started", "info", traceCtx);
+      }
+      await runtime.publish(echoResponseRouting(env, responseRouting));
     }
-    await runtime.publish(echoResponseRouting(env, responseRouting));
+  } finally {
+    // R26 P1 (cortex#1371) — release the in-flight admission lease when the
+    // dispatch terminates (the harness guarantees a terminal envelope, and a
+    // throw lands here too). `release` is idempotent and never throws — a
+    // failed release is logged gate-side and the lease TTL self-heals.
+    if (admissionLease !== undefined && admissionGate !== undefined) {
+      await admissionGate.release(admissionLease);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #1371. R26 phase 1 (AzDO #3169) — implements **Design B** of the signed-off [`docs/design-substrate-rate-limiting.md`](https://github.com/the-metafactory/cortex/blob/feat/c-1371-admission-gate/docs/design-substrate-rate-limiting.md) (included here with its sign-off status + resolved Q1–Q6), consuming the myelin admission contract **[myelin#196](https://github.com/the-metafactory/myelin/pull/196)** (`myelin/specs/admission.md`).

## What

**`src/bus/admission/`** — the KV-arbitrated AdmissionGate:

- `state.ts` — pure entry formats + refill/prune/check/consume rules (per-window token buckets, clock-skew-clamped refill; self-expiring in-flight lease lists). Versioned (`v:1`); newer-version entries take the store posture, corrupt ones self-heal loudly.
- `provision.ts` — idempotent per-(principal, stack) KV bucket provisioning (`admission_{principal}_{stack}`), mirroring `jetstream/provision.ts`; failure is NON-FATAL by design (hands the gate its degraded posture).
- `gate.ts` — CAS arbitration (`get → refill → decide → update(revision)`, bounded retries), **two-phase**: refusals are READ-ONLY (a flooder can't burn shared tokens), commits re-validate per tier with best-effort refund. Exact under N nodes — no per-node drift.

**Tiers 1–2 (Q2):** `stack` global spawn ceiling + `principal` (resolution `principals[id]` > roles most-permissive > `defaults`, field by field). **Anonymous** (`did:mf:public`) clamped to the built-in **2/min · 1 in-flight** ceiling regardless of config.

**Config (Q3):** `policy.admission` block (`src/common/types/admission.ts`, Zod, reusing the `offering.ts` rate vocabulary) + superRefine cross-refs (role keys / principal ids must be declared). Documented in `cortex.yaml.example`.

**Enforcement point 1:** `dispatch-listener.ts` pre-spawn — AFTER the policy allow, BEFORE harness construction (permanent refusals before transient, `gate-floor.ts:195-202`), keyed on the **same principal the policy gate resolved** (`originator.identity` → `signed_by[0]`, myelin spec §1). In-flight lease released in a `finally` around the harness drain (the harness's guaranteed-terminal contract).

**Reject semantics (Q6):** refusal ⇒ `system.admission.throttled` (audit sibling of `system.access.denied`) + terminal `dispatch.task.failed { kind: "not_now", detail, retry_after_ms }` on the correlation id, `errorSummary` = friendly `busy — try again in ~Ns`. **Never `term` for rate.** New `admission-checked` dispatch-trace stage.

**Failure posture (Q1):** store error ⇒ named principals degrade to node-local approximate buckets with a loud `system.admission.degraded` envelope per TRANSITION (never silent, never per-request); **anonymous fails closed**. Recovery event on the next successful KV round-trip; local state discarded.

**Runtime:** `MyelinRuntime` gains a narrow `kvBucket()` capability (primary-link-bound `js.views.kv(name, {history: 1})` — the cortex#338 `jetstreamManager` pattern; disabled stubs return `null`).

## Inert when unconfigured (the CO-4 proof)

Absent `admission:` block ⇒ `resolvedPolicy.admission === undefined` ⇒ the gate is **never constructed**, no KV bucket is provisioned, the listener's admission stage is a single skipped `undefined` check, and no `system.admission.*` envelope can exist. Listener-level test: `dispatch-listener-admission.test.ts` "INERT without an admissionGate". Schema-level test: absent block parses to `undefined`.

## Tests (all green: 8165 pass / 0 fail; `bunx tsc --noEmit` clean; `eslint .` clean)

- `state.test.ts` — refill/rollover/skew-clamp, retry hints, lease prune, versioned parsing.
- `gate.test.ts` — **concurrent admits serialise via CAS** (12 contenders, exactly 5 win), window rollover, read-only refusals, degrade + recovery transitions (once per transition), **anonymous fail-closed** + ceiling clamp, CAS-exhaustion posture, lease TTL orphan healing, release idempotency/robustness.
- `provision.test.ts` — created/exists/unavailable (non-fatal).
- `admission.test.ts` — schema strictness, resolution precedence, anonymous clamp, PolicySchema cross-refs + absent-block inertness.
- `dispatch-listener-admission.test.ts` — inertness, throttle (audit + `not_now` terminal + no spawn), **ordering** (policy deny never consults the gate), identity join, lease release on terminal.

Second commit fixes 20 **pre-existing** boot-test failures (repo rule: fix all errors you see): the startCortex suites read the live `~/.config/cortex/agents.d/` and crashed on a machine-local fragment — they now pass a hermetic empty `agentsDir`.

## Out of scope / follow-ups

- **Phase 2** (shared in-flight counters replacing the 3 process-local `maxConcurrent` Sets, real `rateOk` at `cortex.ts` gate-floor closure, orphan sweeper, tiers 3–4, MC tile, status CLI) → **#1374**.
- **Phase 3** (JetStream work-queue for direct dispatch — multi-node double-spawn) → **#1369**.

⚠️ **Gated cutover:** do NOT merge/restart daemons off this PR — the planner gates merge + restart (R26 rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)