### PR TITLE
fix(network): C-1269 — register detects admission_request:failed, retries once, fails loud

### DIFF
--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -611,7 +611,7 @@ describe("cortex provision-stack register — C-1269 admission-request detection
    * The first-register path makes exactly ONE POST per attempt (no GET, since
    * it is not an add-stack), so `posts()` counts retry attempts directly.
    */
-  function mockRegistry(responses: Array<{ status: number; body: unknown }>): {
+  function mockRegistry(responses: { status: number; body: unknown }[]): {
     fetch: typeof globalThis.fetch;
     posts: () => number;
   } {
@@ -730,5 +730,149 @@ describe("cortex provision-stack register — C-1269 admission-request detection
     expect(env.error.context.network).toBe("research-collab");
     expect(env.error.context.warning).toBe(FAILED_WARNING);
     expect(env.error.context.manual_fallback).toContain("cortex provision-stack register andreas");
+  });
+
+  test("(d) admission failed then retry POST itself errors → exit 1, SAME actionable fallback (#1377)", async () => {
+    // #1377 review nit — when the RETRY POST fails at the transport/registry
+    // layer (not "2xx but admission failed"), the exit must still be non-zero
+    // AND carry the SAME actionable manual-fallback command, not a bare reason
+    // that omits it. The retry's error is folded into the surfaced warning.
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+    const mock = mockRegistry([
+      { status: 201, body: failedBody },                  // attempt 1: 2xx but admission failed
+      { status: 500, body: { error: "registry_down" } },  // retry: registry/transport error
+    ]);
+    const res = await withFetch(mock.fetch, () =>
+      dispatchProvisionStack([
+        "register", "andreas", "--seed-path", seedPath,
+        "--registry-url", "http://registry.test", "--network", "research-collab",
+      ]),
+    );
+    expect(res.exitCode).toBe(1); // NON-ZERO — never a silent success
+    expect(mock.posts()).toBe(2); // one initial + one retry
+    // Same actionable surface as path (c): network + manual re-register fallback.
+    expect(res.stderr).toContain("research-collab");
+    expect(res.stderr).toMatch(/re-register/i);
+    expect(res.stderr).toContain("cortex provision-stack register andreas");
+    // The retry's transport error is folded into the warning.
+    expect(res.stderr).toMatch(/automatic retry also failed/i);
+  });
+
+  test("(e) generate --register --json surfaces admission_request (parity with register, #1377)", async () => {
+    // #1377 review major — the generate --register success --json path must
+    // carry admission_request too, matching the standalone register contract.
+    const seedPath = join(freshDir(), "stack.nk");
+    const mock = mockRegistry([{ status: 201, body: ASSERTION }]);
+    const res = await withFetch(mock.fetch, () =>
+      dispatchProvisionStack([
+        "generate", "andreas", "--seed-path", seedPath,
+        "--register", "--registry-url", "http://registry.test", "--json",
+      ]),
+    );
+    expect(res.exitCode).toBe(0);
+    const out = JSON.parse(res.stdout) as { status: string; data: Record<string, string> };
+    expect(out.status).toBe("ok");
+    expect(out.data.admission_request).toBe("ok");
+  });
+});
+
+// =============================================================================
+// C-1269 (#1377 review) — the SUBTLEST guarantee: on the ADD-STACK path the
+// retry must REBUILD the claim (fresh signature-verified merge-read → fresh
+// `expected_updated_at` CAS token), NOT blind re-POST attempt-1's now-stale
+// body. Attempt 1 already bumped `updated_at`, so a blind re-POST would 409
+// `stale_record`. This exercises the real in-memory registry (not a canned
+// mock) so the CAS is genuinely enforced: exit 0 is proof the retry rebuilt.
+// =============================================================================
+describe("cortex provision-stack register — C-1269 add-stack CAS-rebuild-on-retry (#1377)", () => {
+  async function configuredEnv(): Promise<{ env: Env; registryPubkey: string }> {
+    resetStores();
+    const reg = await makeRegistryKey();
+    const adminKey = await makePrincipalKey();
+    return {
+      env: {
+        REGISTRY_SIGNING_KEY: reg.signingKey,
+        REGISTRY_PUBLIC_KEY: reg.publicKey,
+        REGISTRY_ADMIN_PUBKEYS: adminKey.publicKeyB64,
+        ENVIRONMENT: "test",
+      },
+      registryPubkey: reg.publicKey,
+    };
+  }
+
+  test("add-stack retry REBUILDS with a fresh CAS token → 2xx instead of 409 stale_record", async () => {
+    const { env, registryPubkey } = await configuredEnv();
+    const dir = freshDir();
+    const rootSeed = join(dir, "meta-factory.nk"); // principal ROOT (first stack)
+    const communitySeed = join(dir, "community.nk"); // the joining stack's key
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", rootSeed]);
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", communitySeed]);
+
+    const realFetch = globalThis.fetch;
+    let registerPosts = 0;
+    let mergeReadGets = 0;
+    let injectFailedOnNextPost = false;
+    // Route the CLI fetch at the real registry, but on the FIRST add-stack POST
+    // rewrite the (real, state-changing) 2xx response body to carry
+    // `admission_request: "failed"`. The principal record still commits +
+    // `updated_at` still bumps — so a blind re-POST of attempt-1's stale CAS
+    // token would 409. Only a genuine rebuild (fresh merge-read) yields 2xx.
+    globalThis.fetch = (async (input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      const url = new URL(req.url);
+      if (req.method === "GET" && url.pathname.startsWith("/principals/")) mergeReadGets += 1;
+      const res = await registryApp.fetch(req, env);
+      if (req.method === "POST") {
+        registerPosts += 1;
+        if (injectFailedOnNextPost && res.ok) {
+          injectFailedOnNextPost = false;
+          const body = (await res.clone().json()) as Record<string, unknown>;
+          return new Response(
+            JSON.stringify({ ...body, admission_request: "failed", warning: "injected: PENDING upsert failed" }),
+            { status: res.status, headers: { "Content-Type": "application/json" } },
+          );
+        }
+      }
+      return res;
+    }) as typeof globalThis.fetch;
+
+    try {
+      // 1. First registration — clean (establishes the root + andreas/meta-factory).
+      const first = await dispatchProvisionStack([
+        "register", "andreas", "--seed-path", rootSeed,
+        "--stack-id", "andreas/meta-factory", "--registry-url", "http://registry.test",
+      ]);
+      expect(first.exitCode).toBe(0);
+
+      // 2. Add-stack — inject an admission failure on the first add-stack POST so
+      //    the client MUST retry. Attempt 1 bumps updated_at; the retry must
+      //    re-read it or the registry 409s.
+      const postsBefore = registerPosts;
+      const getsBefore = mergeReadGets;
+      injectFailedOnNextPost = true;
+      const add = await dispatchProvisionStack([
+        "register", "andreas", "--seed-path", communitySeed,
+        "--stack-id", "andreas/community", "--principal-seed", rootSeed,
+        "--registry-url", "http://registry.test", "--registry-pubkey", registryPubkey,
+      ]);
+
+      // Exit 0 is the proof: a blind re-POST of the stale token would 409 →
+      // exit 1. Success means the retry rebuilt with the fresh CAS token.
+      expect(add.exitCode).toBe(0);
+      expect(registerPosts - postsBefore).toBe(2); // one initial + exactly one retry
+      // Each add-stack attempt re-issued its own signature-verified merge-read.
+      expect(mergeReadGets - getsBefore).toBeGreaterThanOrEqual(2);
+
+      // Registry ended consistent — both stacks survive (no data loss on retry).
+      const getRes = await registryApp.fetch(new Request("http://registry.test/principals/andreas"), env);
+      const json = (await getRes.json()) as { payload: { stacks: { stack_id: string }[] } };
+      expect(json.payload.stacks.map((s) => s.stack_id).sort()).toEqual([
+        "andreas/community",
+        "andreas/meta-factory",
+      ]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 });

--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -597,3 +597,138 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
     }
   });
 });
+
+// =============================================================================
+// C-1269 — register DETECTS `admission_request: "failed"`, retries ONCE, and
+// fails loud (never a silent success). These mock the registry HTTP responses
+// directly so the admission flag can be controlled per-attempt — the first
+// external walker (#1262) ended up registered with NO PENDING admission row and
+// nothing to admit, precisely because the client ignored this signal.
+// =============================================================================
+describe("cortex provision-stack register — C-1269 admission-request detection", () => {
+  /**
+   * Queue registry responses; each POST /register pops the next (last repeats).
+   * The first-register path makes exactly ONE POST per attempt (no GET, since
+   * it is not an add-stack), so `posts()` counts retry attempts directly.
+   */
+  function mockRegistry(responses: Array<{ status: number; body: unknown }>): {
+    fetch: typeof globalThis.fetch;
+    posts: () => number;
+  } {
+    let i = 0;
+    let posts = 0;
+    const fn = ((input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      if (req.method === "POST") {
+        const r = responses[Math.min(i, responses.length - 1)]!;
+        i += 1;
+        posts += 1;
+        return Promise.resolve(
+          new Response(JSON.stringify(r.body), {
+            status: r.status,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      // The first-register path issues no GET; anything else is a test bug.
+      return Promise.resolve(new Response(JSON.stringify({ error: "unexpected_get" }), { status: 500 }));
+    }) as typeof globalThis.fetch;
+    return { fetch: fn, posts: () => posts };
+  }
+
+  const ASSERTION = { payload: { principal_id: "andreas" }, issued_at: "t", registry: "R", signature: "sig" };
+  const FAILED_WARNING =
+    "registered, but the PENDING admission request could not be created; re-register to retry (the upsert is idempotent)";
+  const failedBody = { ...ASSERTION, admission_request: "failed", warning: FAILED_WARNING };
+
+  async function withFetch<T>(f: typeof globalThis.fetch, run: () => Promise<T>): Promise<T> {
+    const real = globalThis.fetch;
+    globalThis.fetch = f;
+    try {
+      return await run();
+    } finally {
+      globalThis.fetch = real;
+    }
+  }
+
+  test("(a) clean register — PENDING landed → exit 0, admission_request=ok, single POST", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+    const mock = mockRegistry([{ status: 201, body: ASSERTION }]);
+    const res = await withFetch(mock.fetch, () =>
+      dispatchProvisionStack([
+        "register", "andreas", "--seed-path", seedPath,
+        "--registry-url", "http://registry.test", "--json",
+      ]),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(mock.posts()).toBe(1); // no retry on a clean register
+    const out = JSON.parse(res.stdout) as { status: string; data: Record<string, string> };
+    expect(out.status).toBe("ok");
+    expect(out.data.admission_request).toBe("ok");
+    expect(out.data.registered).not.toContain("automatic retry");
+  });
+
+  test("(b) admission failed then retry OK → exit 0, retried once, admission_request=ok", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+    const mock = mockRegistry([
+      { status: 201, body: failedBody },   // first attempt: admission did not land
+      { status: 201, body: ASSERTION },    // retry: clean
+    ]);
+    const res = await withFetch(mock.fetch, () =>
+      dispatchProvisionStack([
+        "register", "andreas", "--seed-path", seedPath,
+        "--registry-url", "http://registry.test", "--network", "research-collab", "--json",
+      ]),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(mock.posts()).toBe(2); // retried exactly once
+    const out = JSON.parse(res.stdout) as { status: string; data: Record<string, string> };
+    expect(out.status).toBe("ok");
+    expect(out.data.admission_request).toBe("ok");
+    expect(out.data.registered).toContain("landed on automatic retry");
+  });
+
+  test("(c) admission failed then retry STILL failed → exit 1, actionable, retried once", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+    const mock = mockRegistry([{ status: 201, body: failedBody }]); // every attempt fails admission
+    const res = await withFetch(mock.fetch, () =>
+      dispatchProvisionStack([
+        "register", "andreas", "--seed-path", seedPath,
+        "--registry-url", "http://registry.test", "--network", "research-collab",
+      ]),
+    );
+    expect(res.exitCode).toBe(1); // NON-ZERO — never a silent success
+    expect(mock.posts()).toBe(2); // one initial + one retry
+    // Actionable: names the network, the warning, and the manual re-register fallback.
+    expect(res.stderr).toContain("research-collab");
+    expect(res.stderr).toContain(FAILED_WARNING);
+    expect(res.stderr).toMatch(/re-register/i);
+    expect(res.stderr).toContain("cortex provision-stack register andreas");
+    expect(res.stderr).toContain("--network research-collab");
+  });
+
+  test("(c-json) failed-after-retry with --json → error envelope carries admission context", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+    const mock = mockRegistry([{ status: 201, body: failedBody }]);
+    const res = await withFetch(mock.fetch, () =>
+      dispatchProvisionStack([
+        "register", "andreas", "--seed-path", seedPath,
+        "--registry-url", "http://registry.test", "--network", "research-collab", "--json",
+      ]),
+    );
+    expect(res.exitCode).toBe(1);
+    const env = JSON.parse(res.stderr) as {
+      status: string;
+      error: { reason: string; context: Record<string, string> };
+    };
+    expect(env.status).toBe("error");
+    expect(env.error.context.admission_request).toBe("failed");
+    expect(env.error.context.network).toBe("research-collab");
+    expect(env.error.context.warning).toBe(FAILED_WARNING);
+    expect(env.error.context.manual_fallback).toContain("cortex provision-stack register andreas");
+  });
+});

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -266,6 +266,16 @@ async function runGenerate(ctx: HandlerCtx): Promise<ExitResult> {
       networkRes.networkId,
     );
     if (!reg.ok) return opError(reg.reason, ctx.json, { fingerprint: material.fingerprint });
+    // C-1269 — same loud-fail contract as the standalone register path.
+    if (reg.admission === "failed") {
+      return admissionFailedResult(ctx, {
+        reg,
+        networkId: networkRes.networkId,
+        seedPath,
+        registryUrl: urlRes.value,
+        stackId: stackIdRes.stackId,
+      });
+    }
     registerNote = reg.note;
   }
 
@@ -386,11 +396,25 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
   );
   if (!reg.ok) return opError(reg.reason, ctx.json, { fingerprint: matRes.material.fingerprint });
 
+  // C-1269 — a 2xx registration whose admission request never landed (even
+  // after the retry) is NOT a success: fail loud + actionable, never silent.
+  if (reg.admission === "failed") {
+    return admissionFailedResult(ctx, {
+      reg,
+      networkId: networkRes.networkId,
+      seedPath: seedPathFlag.value,
+      registryUrl: urlRes.value,
+      stackId: stackIdRes.stackId,
+    });
+  }
+
   const data: Record<string, string> = {
     principal_id: ctx.principalId,
     stack_id: stackIdRes.stackId,
     fingerprint: matRes.material.fingerprint,
     registered: reg.note,
+    // C-1269 — surface the admission state so scripting consumers can gate on it.
+    admission_request: reg.admission,
   };
   if (ctx.json) return ok(renderJson(envelopeOk([], data)));
   return ok(
@@ -398,7 +422,55 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
   );
 }
 
-/** Shared register flow — build claim + POST. Returns a log-safe note. */
+/**
+ * Outcome of a register POST, from the CLIENT's point of view. C-1269 —
+ * `admission` is the load-bearing addition: a registration can succeed at the
+ * HTTP layer (2xx, `ok: true`) yet carry `admission_request: "failed"` in its
+ * body, meaning the principal record committed but the PENDING admission row
+ * did NOT (registry `principals.ts` §O-4a.1). The caller MUST NOT report a bare
+ * success in that case — there is nothing for the network admin to admit. This
+ * is the first external-walker regression #1262 (chuvala had a `principals` row
+ * but no PENDING `admission_requests` row, so there was nothing to admit).
+ */
+type DoRegisterResult =
+  | { ok: false; reason: string }
+  | { ok: true; note: string; admission: "ok" | "failed"; warning?: string };
+
+/**
+ * C-1269 — read the registry register-response for the non-fatal
+ * `admission_request: "failed"` flag the registry adds (server-side
+ * `principals.ts` lines 268-284) when the PENDING admission upsert fails but
+ * the principal record commits. Additive + back-compat: a response without the
+ * field (the normal success shape, or an older registry) reads as landed.
+ */
+function readAdmissionState(response: unknown): { failed: boolean; warning?: string } {
+  if (typeof response === "object" && response !== null && "admission_request" in response) {
+    const r = response as Record<string, unknown>;
+    if (r.admission_request === "failed") {
+      return { failed: true, ...(typeof r.warning === "string" && { warning: r.warning }) };
+    }
+  }
+  return { failed: false };
+}
+
+/**
+ * Shared register flow — build claim + POST, detect a failed admission-request
+ * raise, and retry ONCE. Returns a log-safe note plus the admission state.
+ *
+ * C-1269 idempotency (VERIFIED against the registry route + store, not assumed):
+ *   - `upsertPending` is `INSERT ... ON CONFLICT(principal_id, peer_pubkey,
+ *     COALESCE(network_id,'')) DO NOTHING` (store.ts D1IssuanceRequestStore) —
+ *     idempotent per the ADR-0018 Gap-A triple; a re-register never duplicates
+ *     the PENDING row.
+ *   - `putPrincipal` on a FIRST register carries no `expected_updated_at`, so it
+ *     is an UNCONDITIONAL upsert — a bare re-register is fully idempotent (this
+ *     is the #1262 external-walker path). On the ADD-STACK path the claim DOES
+ *     carry a CAS token (`expected_updated_at`), so a re-POST of the SAME body
+ *     would 409 `stale_record` (the first attempt already bumped `updated_at`).
+ *   Therefore the retry REBUILDS the claim (`attemptRegister` re-runs
+ *   `resolveMergedStacks`, which re-reads the current `updated_at`), making the
+ *   retry correct on BOTH paths rather than a blind re-POST of a stale body.
+ */
 async function doRegister(
   principalId: string,
   material: StackIdentityMaterial,
@@ -407,101 +479,183 @@ async function doRegister(
   rootMaterial?: StackIdentityMaterial,
   registryPubkey?: string,
   networkId?: string,
-): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
-  // C-787 — build the COMPLETE intended `stacks[]`. The register route does a
-  // FULL-OVERWRITE upsert of the `stacks` column with no read-merge, so a claim
-  // that carries only the new stack DROPS every stack already on record — the
-  // exact federation #787 exists to preserve (PR #790 data-loss blocker). On
-  // the add-stack path we therefore FETCH the principal's existing stacks and
-  // merge the new one in, so the root re-attests the full set and the route's
-  // overwrite becomes correct. C-791 — the merge-read is signature-verified
-  // against `registryPubkey` (fail closed on the add-stack path when absent).
+): Promise<DoRegisterResult> {
   const isAddStack = rootMaterial !== undefined;
 
-  const stacksRes = await resolveMergedStacks({
-    principalId,
-    stackId,
-    stackPubkey: material.pubkeyB64,
-    registryUrl,
-    ...(registryPubkey !== undefined && { registryPubkey }),
-    isAddStack,
-  });
-  if (!stacksRes.ok) return { ok: false, reason: stacksRes.reason };
-
-  // C-819 — merge-preserve CAPABILITIES, mirroring the stacks merge above. The
-  // register route does the SAME full-overwrite upsert on the `capabilities`
-  // column (store.ts: `capabilities = excluded.capabilities`), so a claim that
-  // carries no caps zeroes the principal's existing set — silently evicting
-  // them from every network roster (membership is implicit via
-  // `capability.networks[]`). `provision-stack register` announces NO new caps
-  // (it provisions a stack IDENTITY, not a network membership — that is what
-  // `cortex network join` is for), so its `announce` is empty: on the add-stack
-  // path the fetch+verify+union therefore PRESERVES the principal's existing
-  // caps unchanged (empty ∪ existing = existing), and on a first register there
-  // is nothing on record to preserve. `mergeExisting: isAddStack` keeps this
-  // consistent with the stacks merge (and shares the C-791 fail-closed verified
-  // read): merge only when adding to an already-registered principal (C-820
-  // renamed the field from `isAddStack`; here the merge IS gated on add-stack —
-  // provision-stack only preserves caps, it never re-announces network tags, so
-  // unlike the federated join it has no reason to fetch+merge on a first
-  // register). A register that genuinely intends to SHRINK caps is out of scope
-  // for this command — it never announces caps at all.
-  const capsRes = await resolveMergedCapabilities({
-    principalId,
-    registryUrl,
-    ...(registryPubkey !== undefined && { registryPubkey }),
-    announce: [],
-    mergeExisting: isAddStack,
-  });
-  if (!capsRes.ok) return { ok: false, reason: capsRes.reason };
-
-  let body: SignedRegistrationBody;
-  try {
-    body = await buildRegistrationClaim({
+  // One full build-claim + POST cycle. C-1269 — factored into a closure so the
+  // retry REBUILDS the claim (re-reading the CAS token via resolveMergedStacks)
+  // rather than blind-reposting a now-stale body. Returns the registry result
+  // triple on a 2xx, or a client-side error reason.
+  async function attemptRegister(): Promise<
+    { ok: false; reason: string } | { ok: true; status: number; response: unknown }
+  > {
+    // C-787 — build the COMPLETE intended `stacks[]`. The register route does a
+    // FULL-OVERWRITE upsert of the `stacks` column with no read-merge, so a claim
+    // that carries only the new stack DROPS every stack already on record — the
+    // exact federation #787 exists to preserve (PR #790 data-loss blocker). On
+    // the add-stack path we therefore FETCH the principal's existing stacks and
+    // merge the new one in, so the root re-attests the full set and the route's
+    // overwrite becomes correct. C-791 — the merge-read is signature-verified
+    // against `registryPubkey` (fail closed on the add-stack path when absent).
+    const stacksRes = await resolveMergedStacks({
       principalId,
-      material,
-      // C-787 — on the add-stack path the root signs; the new stack carries
-      // its own pubkey. On the first-register path rootMaterial is undefined
-      // and `material` both declares + signs (pre-C-787 behaviour).
-      ...(rootMaterial !== undefined && { rootMaterial }),
-      stacks: stacksRes.stacks,
-      // C-819 — re-attest the merged (preserved) capability set so the route's
-      // full-overwrite writes the complete set instead of clobbering to empty.
-      capabilities: capsRes.capabilities,
-      // #825 — CAS token: the updated_at the merge read. The route rejects
-      // (409 stale_record) if a concurrent host changed the row since.
-      ...(stacksRes.existingUpdatedAt !== undefined && { expectedUpdatedAt: stacksRes.existingUpdatedAt }),
-      // ADR-0018 Gap-A — pin the PENDING admission request to the target network.
-      ...(networkId !== undefined && { networkId }),
+      stackId,
+      stackPubkey: material.pubkeyB64,
+      registryUrl,
+      ...(registryPubkey !== undefined && { registryPubkey }),
+      isAddStack,
     });
-  } catch (err) {
-    return { ok: false, reason: `failed to build registration claim: ${err instanceof Error ? err.message : String(err)}` };
+    if (!stacksRes.ok) return { ok: false, reason: stacksRes.reason };
+
+    // C-819 — merge-preserve CAPABILITIES, mirroring the stacks merge above. The
+    // register route does the SAME full-overwrite upsert on the `capabilities`
+    // column (store.ts: `capabilities = excluded.capabilities`), so a claim that
+    // carries no caps zeroes the principal's existing set — silently evicting
+    // them from every network roster (membership is implicit via
+    // `capability.networks[]`). `provision-stack register` announces NO new caps
+    // (it provisions a stack IDENTITY, not a network membership — that is what
+    // `cortex network join` is for), so its `announce` is empty: on the add-stack
+    // path the fetch+verify+union therefore PRESERVES the principal's existing
+    // caps unchanged (empty ∪ existing = existing), and on a first register there
+    // is nothing on record to preserve. `mergeExisting: isAddStack` keeps this
+    // consistent with the stacks merge (and shares the C-791 fail-closed verified
+    // read): merge only when adding to an already-registered principal (C-820
+    // renamed the field from `isAddStack`; here the merge IS gated on add-stack —
+    // provision-stack only preserves caps, it never re-announces network tags, so
+    // unlike the federated join it has no reason to fetch+merge on a first
+    // register). A register that genuinely intends to SHRINK caps is out of scope
+    // for this command — it never announces caps at all.
+    const capsRes = await resolveMergedCapabilities({
+      principalId,
+      registryUrl,
+      ...(registryPubkey !== undefined && { registryPubkey }),
+      announce: [],
+      mergeExisting: isAddStack,
+    });
+    if (!capsRes.ok) return { ok: false, reason: capsRes.reason };
+
+    let body: SignedRegistrationBody;
+    try {
+      body = await buildRegistrationClaim({
+        principalId,
+        material,
+        // C-787 — on the add-stack path the root signs; the new stack carries
+        // its own pubkey. On the first-register path rootMaterial is undefined
+        // and `material` both declares + signs (pre-C-787 behaviour).
+        ...(rootMaterial !== undefined && { rootMaterial }),
+        stacks: stacksRes.stacks,
+        // C-819 — re-attest the merged (preserved) capability set so the route's
+        // full-overwrite writes the complete set instead of clobbering to empty.
+        capabilities: capsRes.capabilities,
+        // #825 — CAS token: the updated_at the merge read. The route rejects
+        // (409 stale_record) if a concurrent host changed the row since.
+        ...(stacksRes.existingUpdatedAt !== undefined && { expectedUpdatedAt: stacksRes.existingUpdatedAt }),
+        // ADR-0018 Gap-A — pin the PENDING admission request to the target network.
+        ...(networkId !== undefined && { networkId }),
+      });
+    } catch (err) {
+      return { ok: false, reason: `failed to build registration claim: ${err instanceof Error ? err.message : String(err)}` };
+    }
+
+    let result: Awaited<ReturnType<typeof registerStackIdentity>>;
+    try {
+      result = await registerStackIdentity({ registryUrl, principalId, body });
+    } catch (err) {
+      return { ok: false, reason: `registry POST failed: ${err instanceof Error ? err.message : String(err)}` };
+    }
+    if (!result.ok) {
+      const detail =
+        typeof result.response === "object" && result.response !== null
+          ? JSON.stringify(result.response)
+          : String(result.response);
+      return {
+        ok: false,
+        reason: `registry rejected registration (HTTP ${result.status.toString()}): ${detail}`,
+      };
+    }
+    return { ok: true, status: result.status, response: result.response };
   }
 
-  let result: Awaited<ReturnType<typeof registerStackIdentity>>;
-  try {
-    result = await registerStackIdentity({ registryUrl, principalId, body });
-  } catch (err) {
-    return { ok: false, reason: `registry POST failed: ${err instanceof Error ? err.message : String(err)}` };
+  let attempt = await attemptRegister();
+  if (!attempt.ok) return { ok: false, reason: attempt.reason };
+
+  // C-1269 — the registration is 2xx, but the response may still carry
+  // `admission_request: "failed"` (principal committed, PENDING row did not).
+  // Retry the raise ONCE — a rebuilt re-register is idempotent (see doRegister
+  // header: upsertPending ON CONFLICT DO NOTHING; putPrincipal unconditional on
+  // first register, CAS-refreshed on the rebuilt add-stack retry).
+  const netLabel = networkId !== undefined ? `network "${networkId}"` : "the (network-less) registration";
+  let admission = readAdmissionState(attempt.response);
+  let retried = false;
+  if (admission.failed) {
+    retried = true;
+    const retry = await attemptRegister();
+    if (!retry.ok) {
+      return {
+        ok: false,
+        reason:
+          `registration succeeded but the PENDING admission request for ${netLabel} did NOT land` +
+          `${admission.warning !== undefined ? ` (registry: ${admission.warning})` : ""}; ` +
+          `the automatic retry also failed: ${retry.reason}`,
+      };
+    }
+    attempt = retry;
+    admission = readAdmissionState(retry.response);
   }
-  if (!result.ok) {
-    const detail =
-      typeof result.response === "object" && result.response !== null
-        ? JSON.stringify(result.response)
-        : String(result.response);
-    return {
-      ok: false,
-      reason: `registry rejected registration (HTTP ${result.status.toString()}): ${detail}`,
-    };
-  }
+
   // O-4a.2 — a successful registration (2xx) triggers an issuance request that
   // starts PENDING. The leaf credential package is issued only after an admin
   // grants the request. Always surface this so the principal knows to expect
   // the admin-grant step before the stack can join the federation.
+  const noteBase = `registration recorded; awaiting admin grant — your credential will be issued on approval (HTTP ${attempt.status.toString()}, registry: ${registryUrl})`;
   return {
     ok: true,
-    note: `registration recorded; awaiting admin grant — your credential will be issued on approval (HTTP ${result.status.toString()}, registry: ${registryUrl})`,
+    note:
+      retried && !admission.failed
+        ? `${noteBase} [admission request landed on automatic retry]`
+        : noteBase,
+    admission: admission.failed ? "failed" : "ok",
+    ...(admission.warning !== undefined && { warning: admission.warning }),
   };
+}
+
+/**
+ * C-1269 — build the loud, actionable exit-1 result for a registration that
+ * succeeded at the HTTP layer but whose PENDING admission request did NOT land
+ * even after the automatic retry. NEVER a silent success: the stack is
+ * registered but there is nothing for the network admin to admit, so the
+ * operator must re-register (the upsert is idempotent). Names the network, the
+ * registry warning, and the exact manual re-register command.
+ */
+function admissionFailedResult(
+  ctx: HandlerCtx,
+  args: {
+    reg: Extract<DoRegisterResult, { ok: true }>;
+    networkId: string | undefined;
+    seedPath: string;
+    registryUrl: string;
+    stackId: string;
+  },
+): ExitResult {
+  const netLabel = args.networkId !== undefined ? `network "${args.networkId}"` : "the (network-less) registration";
+  const fallbackCmd =
+    `cortex provision-stack register ${ctx.principalId} ` +
+    `--seed-path ${args.seedPath} --registry-url ${args.registryUrl}` +
+    (args.stackId !== `${ctx.principalId}/default` ? ` --stack-id ${args.stackId}` : "") +
+    (args.networkId !== undefined ? ` --network ${args.networkId}` : "");
+  const reason =
+    `registration for ${ctx.principalId} landed, but the PENDING admission request for ${netLabel} did NOT ` +
+    `(the automatic retry also failed). Your stack IS registered, but there is nothing for the network admin ` +
+    `to admit yet` +
+    (args.reg.warning !== undefined ? ` — registry warning: ${args.reg.warning}` : "") +
+    `. Re-register to retry (the admission upsert is idempotent): ${fallbackCmd}`;
+  const context: Record<string, string> = {
+    admission_request: "failed",
+    ...(args.networkId !== undefined && { network: args.networkId }),
+    ...(args.reg.warning !== undefined && { warning: args.reg.warning }),
+    manual_fallback: fallbackCmd,
+  };
+  return opError(reason, ctx.json, context);
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -249,6 +249,10 @@ async function runGenerate(ctx: HandlerCtx): Promise<ExitResult> {
 
   // Optional registration (opt-in — never silent).
   let registerNote: string | undefined;
+  // C-1269 (#1377 review) — mirror runRegister: surface the admission state on
+  // the `generate --register` path too, so `--json` consumers can gate on it
+  // regardless of which entry point registered.
+  let registerAdmission: string | undefined;
   if (ctx.flags["--register"] === true) {
     const urlRes = requireValueFlag(ctx.flags, "--registry-url");
     if (!urlRes.ok) {
@@ -277,6 +281,7 @@ async function runGenerate(ctx: HandlerCtx): Promise<ExitResult> {
       });
     }
     registerNote = reg.note;
+    registerAdmission = reg.admission;
   }
 
   // SECRETS: only the pubkey + fingerprint are surfaced; the seed is on disk.
@@ -289,6 +294,8 @@ async function runGenerate(ctx: HandlerCtx): Promise<ExitResult> {
     seed_path: seedPath,
     seed_mode: "600",
     ...(registerNote !== undefined && { registered: registerNote }),
+    // C-1269 (#1377 review) — parity with runRegister's --json envelope.
+    ...(registerAdmission !== undefined && { admission_request: registerAdmission }),
   };
   if (ctx.json) {
     return ok(renderJson(envelopeOk([], data)));
@@ -584,23 +591,30 @@ async function doRegister(
   // Retry the raise ONCE — a rebuilt re-register is idempotent (see doRegister
   // header: upsertPending ON CONFLICT DO NOTHING; putPrincipal unconditional on
   // first register, CAS-refreshed on the rebuilt add-stack retry).
-  const netLabel = networkId !== undefined ? `network "${networkId}"` : "the (network-less) registration";
   let admission = readAdmissionState(attempt.response);
   let retried = false;
   if (admission.failed) {
     retried = true;
     const retry = await attemptRegister();
     if (!retry.ok) {
-      return {
-        ok: false,
-        reason:
-          `registration succeeded but the PENDING admission request for ${netLabel} did NOT land` +
-          `${admission.warning !== undefined ? ` (registry: ${admission.warning})` : ""}; ` +
+      // C-1269 (#1377 review) — attempt 1 was a 2xx (the principal record
+      // landed) but its PENDING admission row did NOT, and the automatic retry
+      // could not even reach a 2xx. This is still a registered-but-unadmittable
+      // stack, so keep `admission = failed` (fold the retry's transport error
+      // into the warning) and fall through to the SAME loud, actionable
+      // `admissionFailedResult` the retry-still-failed path uses — including the
+      // manual re-register fallback command — rather than returning a bare
+      // `ok:false` reason that omits it.
+      admission = {
+        failed: true,
+        warning:
+          `${admission.warning ?? "the PENDING admission request did not land"}; ` +
           `the automatic retry also failed: ${retry.reason}`,
       };
+    } else {
+      attempt = retry;
+      admission = readAdmissionState(retry.response);
     }
-    attempt = retry;
-    admission = readAdmissionState(retry.response);
   }
 
   // O-4a.2 — a successful registration (2xx) triggers an issuance request that
@@ -624,7 +638,7 @@ async function doRegister(
  * succeeded at the HTTP layer but whose PENDING admission request did NOT land
  * even after the automatic retry. NEVER a silent success: the stack is
  * registered but there is nothing for the network admin to admit, so the
- * operator must re-register (the upsert is idempotent). Names the network, the
+ * principal must re-register (the upsert is idempotent). Names the network, the
  * registry warning, and the exact manual re-register command.
  */
 function admissionFailedResult(


### PR DESCRIPTION
## What
On register, the registry already emits `admission_request:"failed"` + warning when the PENDING admission upsert fails (C-1263, principals.ts:228-284) — but the CLIENT ignored it, so the first external walker registered with NO PENDING row and nothing to admit (#1262). Now the client detects the flag, rebuilds + retries the register ONCE, and on a second failure exits non-zero with an actionable error (network + warning + manual fallback); `--json` carries the admission state.

## Retry idempotency (verified against store.ts, not assumed)
- `upsertPending` = INSERT … ON CONFLICT(principal_id, peer_pubkey, COALESCE(network_id,'')) DO NOTHING — idempotent per ADR-0018 Gap-A (migration 0008 normalises NULL→'').
- First register: no CAS token → unconditional upsert → bare retry idempotent (the #1262 path).
- Add-stack: claim carries expected_updated_at CAS → a blind re-POST would 409; so the retry REBUILDS the claim (re-reads fresh updated_at). Correct on both paths.

## Verify
tsc --noEmit exit 0 · provision-stack.test.ts 18 pass/0 fail (+4 new: clean, failed→retry→ok, failed→retry→failed exit1, json envelope) · src/cli/cortex/commands 1044 pass/0 fail.

Scope: provision-stack.ts + its test only; did NOT touch network.ts/network-lib.ts/e2e-lifecycle. Closes #1269. Epic #1346 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB