### PR TITLE
chore(test): scrub the real community guild id from 4 test fixtures (residual of #1354)

### DIFF
--- a/src/cli/cortex/lib/__tests__/discord-roles.test.ts
+++ b/src/cli/cortex/lib/__tests__/discord-roles.test.ts
@@ -23,7 +23,7 @@ import {
   type DiscordCliConfig,
 } from "../discord-roles";
 
-const GUILD = "1505549701674700991";
+const GUILD = "555666777888999000";
 const USER = "123456789012345678";
 const ROLE_ID = "999000111222333444";
 const BOT_TOKEN = "Bot.secret-token-must-not-appear-in-errors";

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -176,7 +176,7 @@ const SAME_TOKEN_DISCORD_SURFACES: Surfaces = {
       stack: "jc/default",
       binding: {
         token: "tok-juniper",
-        guildId: "1505549701674700991",
+        guildId: "555666777888999000",
         agentChannelId: "1513296336739635322",
         logChannelId: "1513296336739635322",
       },
@@ -201,7 +201,7 @@ const SAME_TOKEN_DIFFERENT_STACKS_DISCORD_SURFACES: Surfaces = {
       stack: "jc/research",
       binding: {
         token: "tok-juniper",
-        guildId: "1505549701674700991",
+        guildId: "555666777888999000",
         agentChannelId: "1513296336739635322",
         logChannelId: "1513296336739635322",
       },
@@ -308,14 +308,14 @@ describe("buildGatewayAdapters", () => {
     expect(calls[0]?.instanceId).toMatch(/^discord:token:[0-9a-f]{12}$/);
     expect(calls[0]?.allowedGuildIds).toEqual([
       "1487023327791808592",
-      "1505549701674700991",
+      "555666777888999000",
     ]);
     expect(calls[0]?.presenceByGuildId).toEqual({
       "1487023327791808592": {
         agentChannelId: "1487023328324616266",
         logChannelId: "1487023328324616266",
       },
-      "1505549701674700991": {
+      "555666777888999000": {
         agentChannelId: "1513296336739635322",
         logChannelId: "1513296336739635322",
       },
@@ -332,11 +332,11 @@ describe("buildGatewayAdapters", () => {
     expect(adapters.length).toBe(2);
     expect(calls.map((call) => call.instanceId)).toEqual([
       "discord:1487023327791808592",
-      "discord:1505549701674700991",
+      "discord:555666777888999000",
     ]);
     expect(calls.map((call) => call.allowedGuildIds)).toEqual([
       ["1487023327791808592"],
-      ["1505549701674700991"],
+      ["555666777888999000"],
     ]);
   });
 

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -281,7 +281,7 @@ describe("startGatewayIfEnabled — flag on", () => {
           stack: "jc/default",
           binding: {
             token: "tok-juniper",
-            guildId: "1505549701674700991",
+            guildId: "555666777888999000",
             agentChannelId: "1513296336739635322",
             logChannelId: "1513296336739635322",
           },

--- a/src/gateway/__tests__/surface-ownership-plan.test.ts
+++ b/src/gateway/__tests__/surface-ownership-plan.test.ts
@@ -145,7 +145,7 @@ describe("planSurfaceOwnership", () => {
             stack: "jc/default",
             binding: {
               token: "discord-token",
-              guildId: "1505549701674700991",
+              guildId: "555666777888999000",
               agentChannelId: "1513296336739635322",
               logChannelId: "1513296336739635322",
             },
@@ -181,7 +181,7 @@ describe("planSurfaceOwnership", () => {
             stack: "jc/research",
             binding: {
               token: "discord-token",
-              guildId: "1505549701674700991",
+              guildId: "555666777888999000",
               agentChannelId: "1513296336739635322",
               logChannelId: "1513296336739635322",
             },
@@ -194,7 +194,7 @@ describe("planSurfaceOwnership", () => {
 
     expect(plan.gatewayAdapterInstanceIds).toEqual([
       "discord:1487023327791808592",
-      "discord:1505549701674700991",
+      "discord:555666777888999000",
     ]);
     expect(plan.outboundPrincipalStacks).toEqual([
       { principal: "jc", stack: "default" },


### PR DESCRIPTION
## What
#1354's core landed in #1370 (pier config ids → resolve-at-install `__PIER_*__` placeholders). This clears the one residual #1370 missed: the real community guild id (masked …0991) was still hard-coded in **11 places across 4 test fixtures** (discord-roles.test.ts, gateway-adapters/start-gateway/surface-ownership-plan tests). Replaced with a synthetic 18-digit id matching each file's existing synthetic-id convention.

## Proof
After the swap, all three real pier ids are ZERO repo-wide (guild …0991, public channel …2972, private log …1613). tsc --noEmit exit 0; the 4 touched fixtures + both placeholder validators → 142 pass/0 fail.

Out of scope (flagged): a *different* real-looking guild snowflake (…8592) used as a second-guild fixture in the same files — separate sweep if wanted.

Refs #1354 (already closed by #1370). Epic #1346 Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB