### PR TITLE
fix(vocab): C-1220 hotfix — operator→principal, restore green main

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -1482,7 +1482,7 @@ describe("#1220 accept_subjects — join persists own-scope only", () => {
 
 // =============================================================================
 // cortex#1220 review blocker — join ENABLES the reconciler on a fresh join and
-// PRESERVES an operator's explicit choice on a re-join. Without this, narrowing
+// PRESERVES a principal's explicit choice on a re-join. Without this, narrowing
 // persisted accept_subjects to own-scope (above) admits ZERO peer presence,
 // because the reconciler that re-derives own ∪ peer in-memory is per-network
 // opt-in, default OFF — a silent in=0 regression.
@@ -1499,7 +1499,7 @@ describe("#1220 reconcile — join enables + preserves so peer presence is admit
     const net = storeRef.networks.find((n) => n.id === "metafactory")!;
     expect(net.reconcile).toBeDefined();
     expect(net.reconcile!.enabled).toBe(true);
-    // Fresh enable is not an operator override, so no disabled-WARN.
+    // Fresh enable is not a principal override, so no disabled-WARN.
     expect((res.warnings ?? []).some((w) => w.includes("reconcile.enabled=false"))).toBe(false);
   });
 
@@ -1518,7 +1518,7 @@ describe("#1220 reconcile — join enables + preserves so peer presence is admit
   });
 
   test("RE-join PRESERVES an explicit reconcile.enabled=false (never forced true) + loud WARN", async () => {
-    // An operator deliberately disabled the reconciler for this network. A re-join
+    // A principal deliberately disabled the reconciler for this network. A re-join
     // must NOT silently re-enable it — but MUST warn that peer presence won't be
     // admitted while it stays off (the silent in=0 mode, now announced).
     const disabled: PolicyFederatedNetwork = {

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -535,7 +535,7 @@ export async function joinNetwork(
   //     makes the reconciler load-bearing for peer presence, and our live stacks
   //     already run it.
   //   • RE-join (a reconcile block already exists) ⇒ PRESERVE it verbatim, exactly
-  //     as `announce_capabilities` is preserved below. An operator's explicit
+  //     as `announce_capabilities` is preserved below. A principal's explicit
   //     `reconcile.enabled: false` MUST survive a re-join (never forced back to
   //     true) — but we WARN loudly that peer presence will not be admitted while
   //     it stays off, so the silent-in=0 mode is at least announced.


### PR DESCRIPTION
Restores the green Vocab carve-out gate on main. The #1361 squash (b35ce7d5) landed 4 bare 'operator' (the-human) comments in network-lib.ts + network-lib.test.ts — an R9 deprecated-term violation the gate correctly flags; the merge went through --admin past the red gate (orchestrator error). Swaps them to 'principal'.

Confirmed on the b35ce7d5 main run: Vocab = the only real failure (Test passed — the PR-head Test red was the known CloudPublisher mTLS flake). `bash scripts/check-carveouts.sh` → PASS locally.

Refs #1220. Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB