### PR TITLE
feat(cli): C-1351 — cortex stack delete (local teardown, Slice 1)

### DIFF
--- a/src/cli/cortex/commands/__tests__/stack-delete-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-delete-cli.test.ts
@@ -1,0 +1,239 @@
+/**
+ * C-1351 Slice 1 — `cortex stack delete` (local teardown) CLI tests.
+ *
+ * Covers: the DEFAULT-safe dry-run plan (touches nothing), the --apply teardown
+ * (config dir + nats conf + leaf includes removed, seed RETIRED not deleted),
+ * idempotency (2nd run is a clean no-op), the joined-network refusal (fail-
+ * closed, both modes), the --confirm destructive-action gate, and --purge-seeds.
+ *
+ * NEVER touches the real home — every test points --config-dir / --nats-dir /
+ * --launch-agents-dir at fresh tmp dirs, and never creates a plist (so the
+ * launchd path is skipped and no real `launchctl` runs). Mirrors the
+ * stack-cli.test.ts real-tmp-fs harness.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { dispatchStack } from "../stack";
+
+const tmpDirs: string[] = [];
+function freshRoots(): { configDir: string; natsDir: string; launchAgentsDir: string } {
+  const base = mkdtempSync(join(tmpdir(), "c1351-delete-"));
+  tmpDirs.push(base);
+  const configDir = join(base, "config", "cortex");
+  const natsDir = join(base, "config", "nats");
+  const launchAgentsDir = join(base, "LaunchAgents");
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(natsDir, { recursive: true });
+  mkdirSync(launchAgentsDir, { recursive: true });
+  return { configDir, natsDir, launchAgentsDir };
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+/** Seed a split-layout stack under <configDir>/<slug>/. `networks` (default
+ *  none) populates policy.federated.networks[] to exercise the joined gate. */
+function seedSplitStack(
+  configDir: string,
+  slug: string,
+  opts: { principal?: string; networks?: string[] } = {},
+): void {
+  const principal = opts.principal ?? "andreas";
+  const dir = join(configDir, slug);
+  mkdirSync(join(dir, "system"), { recursive: true });
+  mkdirSync(join(dir, "stacks"), { recursive: true });
+  writeFileSync(join(dir, "system", "system.yaml"), "nats:\n  url: nats://127.0.0.1:4222\n");
+  writeFileSync(join(dir, `${slug}.yaml`), "pointer: true\n");
+  let policyBlock = "";
+  if (opts.networks !== undefined && opts.networks.length > 0) {
+    const entries = opts.networks
+      .map((id) => `      - id: ${id}\n        leaf_node: ${id}\n`)
+      .join("");
+    policyBlock = `policy:\n  federated:\n    networks:\n${entries}`;
+  }
+  writeFileSync(
+    join(dir, "stacks", `${slug}.yaml`),
+    `principal:\n  id: ${principal}\nstack:\n  id: ${principal}/${slug}\n${policyBlock}`,
+  );
+}
+
+/** Seed the nats material (rendered conf + optional leaf include + seed). */
+function seedNatsMaterial(
+  natsDir: string,
+  slug: string,
+  opts: { leafNetwork?: string; seed?: boolean } = {},
+): void {
+  let conf = `port: 4222\nserver_name: ${slug}\n`;
+  if (opts.leafNetwork !== undefined) {
+    conf += `include "leafnodes-${opts.leafNetwork}.conf"\n`;
+    writeFileSync(join(natsDir, `leafnodes-${opts.leafNetwork}.conf`), "leafnodes { remotes: [] }\n");
+  }
+  writeFileSync(join(natsDir, `${slug}.conf`), conf);
+  if (opts.seed !== false) writeFileSync(join(natsDir, `cortex-${slug}.nk`), "SU_FAKE_SEED\n");
+}
+
+function delArgs(
+  slug: string,
+  roots: { configDir: string; natsDir: string; launchAgentsDir: string },
+  extra: string[] = [],
+): string[] {
+  return [
+    "delete",
+    slug,
+    "--config-dir",
+    roots.configDir,
+    "--nats-dir",
+    roots.natsDir,
+    "--launch-agents-dir",
+    roots.launchAgentsDir,
+    ...extra,
+  ];
+}
+
+// =============================================================================
+// dry-run (DEFAULT)
+// =============================================================================
+
+describe("delete — dry-run (default)", () => {
+  test("prints the teardown plan and touches NOTHING", async () => {
+    const roots = freshRoots();
+    seedSplitStack(roots.configDir, "research");
+    seedNatsMaterial(roots.natsDir, "research");
+
+    const res = await dispatchStack(delArgs("research", roots));
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("dry-run");
+    expect(res.stdout).toContain("teardown plan");
+    expect(res.stdout).toContain("config-split stack dir");
+    expect(res.stdout).toContain("[retire] signing seed");
+    // Nothing removed.
+    expect(existsSync(join(roots.configDir, "research"))).toBe(true);
+    expect(existsSync(join(roots.natsDir, "research.conf"))).toBe(true);
+    expect(existsSync(join(roots.natsDir, "cortex-research.nk"))).toBe(true);
+  });
+
+  test("absent artifacts show as skip; nothing-to-remove when the stack is gone", async () => {
+    const roots = freshRoots();
+    const res = await dispatchStack(delArgs("ghost", roots));
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("nothing to remove");
+  });
+});
+
+// =============================================================================
+// apply teardown + idempotency
+// =============================================================================
+
+describe("delete — apply", () => {
+  test("--apply --confirm tears down config + nats conf + leaf include; seed RETIRED not deleted", async () => {
+    const roots = freshRoots();
+    seedSplitStack(roots.configDir, "research");
+    seedNatsMaterial(roots.natsDir, "research", { leafNetwork: "metafactory" });
+
+    const res = await dispatchStack(delArgs("research", roots, ["--apply", "--confirm", "research"]));
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("torn down");
+    // Config dir (incl. pointer) + nats conf + leaf include gone.
+    expect(existsSync(join(roots.configDir, "research"))).toBe(false);
+    expect(existsSync(join(roots.natsDir, "research.conf"))).toBe(false);
+    expect(existsSync(join(roots.natsDir, "leafnodes-metafactory.conf"))).toBe(false);
+    // Seed RETIRED (renamed), not deleted.
+    expect(existsSync(join(roots.natsDir, "cortex-research.nk"))).toBe(false);
+    const retired = readdirSync(roots.natsDir).filter((f) => f.startsWith("cortex-research.nk.retired-"));
+    expect(retired.length).toBe(1);
+  });
+
+  test("second run is a clean idempotent no-op (no throw, exit 0)", async () => {
+    const roots = freshRoots();
+    seedSplitStack(roots.configDir, "research");
+    seedNatsMaterial(roots.natsDir, "research");
+
+    const first = await dispatchStack(delArgs("research", roots, ["--apply", "--confirm", "research"]));
+    expect(first.exitCode).toBe(0);
+
+    const second = await dispatchStack(delArgs("research", roots, ["--apply", "--confirm", "research"]));
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toContain("nothing to remove");
+  });
+
+  test("--purge-seeds wipes the seed (no retired sibling left)", async () => {
+    const roots = freshRoots();
+    seedSplitStack(roots.configDir, "research");
+    seedNatsMaterial(roots.natsDir, "research");
+
+    const res = await dispatchStack(
+      delArgs("research", roots, ["--apply", "--confirm", "research", "--purge-seeds"]),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(existsSync(join(roots.natsDir, "cortex-research.nk"))).toBe(false);
+    const retired = readdirSync(roots.natsDir).filter((f) => f.includes(".retired-"));
+    expect(retired.length).toBe(0);
+  });
+});
+
+// =============================================================================
+// joined-network gate (fail-closed)
+// =============================================================================
+
+describe("delete — joined-network refusal", () => {
+  test("refuses (exit 1) when joined, with the leave-first message — dry-run", async () => {
+    const roots = freshRoots();
+    seedSplitStack(roots.configDir, "research", { networks: ["metafactory"] });
+    seedNatsMaterial(roots.natsDir, "research");
+
+    const res = await dispatchStack(delArgs("research", roots));
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("still joined");
+    expect(res.stderr).toContain("cortex network leave metafactory --apply");
+    // Fail-closed: nothing removed.
+    expect(existsSync(join(roots.configDir, "research"))).toBe(true);
+  });
+
+  test("refuses under --apply too (never orphans a live roster membership)", async () => {
+    const roots = freshRoots();
+    seedSplitStack(roots.configDir, "research", { networks: ["metafactory", "othernet"] });
+
+    const res = await dispatchStack(delArgs("research", roots, ["--apply", "--confirm", "research"]));
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("2 network(s)");
+    expect(existsSync(join(roots.configDir, "research"))).toBe(true);
+  });
+});
+
+// =============================================================================
+// --confirm destructive-action gate
+// =============================================================================
+
+describe("delete — --confirm gate", () => {
+  test("--apply without --confirm → usage error (exit 2)", async () => {
+    const roots = freshRoots();
+    seedSplitStack(roots.configDir, "research");
+    const res = await dispatchStack(delArgs("research", roots, ["--apply"]));
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--confirm");
+    // Nothing removed.
+    expect(existsSync(join(roots.configDir, "research"))).toBe(true);
+  });
+
+  test("--confirm mismatch → usage error (exit 2, never a glob)", async () => {
+    const roots = freshRoots();
+    seedSplitStack(roots.configDir, "research");
+    const res = await dispatchStack(delArgs("research", roots, ["--apply", "--confirm", "reseach"]));
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("does not match");
+    expect(existsSync(join(roots.configDir, "research"))).toBe(true);
+  });
+
+  test("invalid slug → usage error (exit 2)", async () => {
+    const roots = freshRoots();
+    const res = await dispatchStack(delArgs("Bad Slug", roots));
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("must be lowercase");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/stack-delete-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-delete-cli.test.ts
@@ -2,9 +2,11 @@
  * C-1351 Slice 1 — `cortex stack delete` (local teardown) CLI tests.
  *
  * Covers: the DEFAULT-safe dry-run plan (touches nothing), the --apply teardown
- * (config dir + nats conf + leaf includes removed, seed RETIRED not deleted),
- * idempotency (2nd run is a clean no-op), the joined-network refusal (fail-
- * closed, both modes), the --confirm destructive-action gate, and --purge-seeds.
+ * (config dir + this stack's OWN nats conf removed, shared network-keyed leaf
+ * files PRESERVED per #1384, seed RETIRED not deleted), idempotency (2nd run is
+ * a clean no-op), the joined-network refusal (fail-closed, both modes), the
+ * --confirm destructive-action gate, --purge-seeds, and the per-artifact
+ * failure branch (continue + record + non-zero exit, #1384).
  *
  * NEVER touches the real home — every test points --config-dir / --nats-dir /
  * --launch-agents-dir at fresh tmp dirs, and never creates a plist (so the
@@ -130,7 +132,7 @@ describe("delete — dry-run (default)", () => {
 // =============================================================================
 
 describe("delete — apply", () => {
-  test("--apply --confirm tears down config + nats conf + leaf include; seed RETIRED not deleted", async () => {
+  test("--apply --confirm tears down config + OWN nats conf; PRESERVES shared leaf file; seed RETIRED (#1384)", async () => {
     const roots = freshRoots();
     seedSplitStack(roots.configDir, "research");
     seedNatsMaterial(roots.natsDir, "research", { leafNetwork: "metafactory" });
@@ -139,10 +141,13 @@ describe("delete — apply", () => {
 
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("torn down");
-    // Config dir (incl. pointer) + nats conf + leaf include gone.
+    // Config dir (incl. pointer) + this stack's OWN rendered nats conf gone.
     expect(existsSync(join(roots.configDir, "research"))).toBe(false);
     expect(existsSync(join(roots.natsDir, "research.conf"))).toBe(false);
-    expect(existsSync(join(roots.natsDir, "leafnodes-metafactory.conf"))).toBe(false);
+    // #1384 (MAJOR) — the shared, network-keyed leaf file is PRESERVED: it is
+    // owned by `cortex network leave`, and a live sibling stack on the same
+    // network may still include it. Deleting it here would break the sibling.
+    expect(existsSync(join(roots.natsDir, "leafnodes-metafactory.conf"))).toBe(true);
     // Seed RETIRED (renamed), not deleted.
     expect(existsSync(join(roots.natsDir, "cortex-research.nk"))).toBe(false);
     const retired = readdirSync(roots.natsDir).filter((f) => f.startsWith("cortex-research.nk.retired-"));
@@ -235,5 +240,60 @@ describe("delete — --confirm gate", () => {
     const res = await dispatchStack(delArgs("Bad Slug", roots));
     expect(res.exitCode).toBe(2);
     expect(res.stderr).toContain("must be lowercase");
+  });
+});
+
+describe("delete — apply, per-artifact failure branch (#1384)", () => {
+  // Force ONE artifact removal to fail deterministically + hermetically: seed the
+  // rendered nats conf as a NON-EMPTY DIRECTORY where a file is expected, so the
+  // `remove-file` op (`rmSync(path, { force: true })`, no `recursive`) throws.
+  // The other artifacts remove cleanly — proving the loop CONTINUES past failure.
+  function seedWithUnremovableConf(roots: {
+    configDir: string;
+    natsDir: string;
+    launchAgentsDir: string;
+  }): void {
+    seedSplitStack(roots.configDir, "research");
+    writeFileSync(join(roots.natsDir, "cortex-research.nk"), "SU_FAKE_SEED\n");
+    const confAsDir = join(roots.natsDir, "research.conf");
+    mkdirSync(confAsDir, { recursive: true });
+    writeFileSync(join(confAsDir, "blocker"), "x\n"); // non-empty → non-recursive rm throws
+  }
+
+  test("--json: records the failure, continues, exits NON-ZERO with per-action failed flag + failed_count", async () => {
+    const roots = freshRoots();
+    seedWithUnremovableConf(roots);
+
+    const res = await dispatchStack(delArgs("research", roots, ["--apply", "--confirm", "research", "--json"]));
+
+    // Partial teardown is NOT a success — the exit code is the machine signal.
+    expect(res.exitCode).toBe(1);
+    const env = JSON.parse(res.stdout) as {
+      status: string;
+      items: { label: string; path: string; failed?: string; failed_reason?: string }[];
+      data: Record<string, string>;
+    };
+    expect(env.data.applied).toBe("true");
+    expect(env.data.failed_count).toBe("1");
+    const failed = env.items.find((i) => i.failed === "true");
+    expect(failed).toBeDefined();
+    expect(failed!.label).toBe("rendered nats config");
+    expect(typeof failed!.failed_reason).toBe("string");
+    // The loop CONTINUED: the config-split dir was still removed and the seed
+    // still retired despite the earlier per-artifact failure.
+    expect(existsSync(join(roots.configDir, "research"))).toBe(false);
+    const retired = readdirSync(roots.natsDir).filter((f) => f.startsWith("cortex-research.nk.retired-"));
+    expect(retired.length).toBe(1);
+  });
+
+  test("human mode: surfaces the ⚠ failure + PARTIAL banner, exits NON-ZERO", async () => {
+    const roots = freshRoots();
+    seedWithUnremovableConf(roots);
+
+    const res = await dispatchStack(delArgs("research", roots, ["--apply", "--confirm", "research"]));
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toMatch(/⚠ rendered nats config teardown failed \(continuing\)/);
+    expect(res.stdout).toMatch(/PARTIAL teardown/);
   });
 });

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -16,6 +16,10 @@ import {
   discoverStacks,
   assertAligned,
   renderScaffold,
+  resolveStackArtifacts,
+  readJoinedNetworkIds,
+  parseLeafIncludeFiles,
+  retiredSeedPath,
   type ScaffoldInputs,
 } from "../stack-lib";
 
@@ -160,5 +164,81 @@ describe("renderScaffold", () => {
     const all = files.map((f) => f.contents).join("\n");
     // No SU… seed ever appears in scaffolded output.
     expect(all).not.toMatch(/\bSU[A-Z0-9]{20,}/);
+  });
+});
+
+// =============================================================================
+// C-1351 Slice 1 — teardown pure helpers
+// =============================================================================
+
+describe("resolveStackArtifacts", () => {
+  test("computes the conventional local artifact paths for a slug", () => {
+    const art = resolveStackArtifacts(
+      { configDir: "/cfg/cortex", natsDir: "/cfg/nats", launchAgentsDir: "/la" },
+      "research",
+    );
+    expect(art.configStackDir).toBe("/cfg/cortex/research");
+    expect(art.policyConfigFile).toBe("/cfg/cortex/research/stacks/research.yaml");
+    expect(art.natsConf).toBe("/cfg/nats/research.conf");
+    expect(art.seed).toBe("/cfg/nats/cortex-research.nk");
+    expect(art.daemonPlist).toBe("/la/ai.meta-factory.cortex.research.plist");
+    expect(art.natsPlist).toBe("/la/ai.meta-factory.nats.research.plist");
+  });
+});
+
+describe("readJoinedNetworkIds", () => {
+  test("empty for an absent file", () => {
+    expect(readJoinedNetworkIds(join(freshDir(), "nope.yaml"))).toEqual([]);
+  });
+
+  test("empty when no policy.federated.networks block", () => {
+    const dir = freshDir();
+    const f = join(dir, "s.yaml");
+    writeFileSync(f, "principal:\n  id: andreas\nstack:\n  id: andreas/research\n");
+    expect(readJoinedNetworkIds(f)).toEqual([]);
+  });
+
+  test("returns the joined network ids (mirrors readNetworks read path)", () => {
+    const dir = freshDir();
+    const f = join(dir, "s.yaml");
+    writeFileSync(
+      f,
+      "policy:\n  federated:\n    networks:\n      - id: metafactory\n        leaf_node: metafactory\n      - id: othernet\n        leaf_node: othernet\n",
+    );
+    expect(readJoinedNetworkIds(f)).toEqual(["metafactory", "othernet"]);
+  });
+});
+
+describe("parseLeafIncludeFiles", () => {
+  test("empty for an absent conf", () => {
+    expect(parseLeafIncludeFiles(join(freshDir(), "none.conf"))).toEqual([]);
+  });
+
+  test("resolves each `include \"leafnodes-*.conf\"` to an absolute path in the conf dir", () => {
+    const dir = freshDir();
+    const conf = join(dir, "research.conf");
+    writeFileSync(
+      conf,
+      'port: 4222\ninclude "leafnodes-metafactory.conf"\ninclude "leafnodes-othernet.conf"\n',
+    );
+    expect(parseLeafIncludeFiles(conf)).toEqual([
+      join(dir, "leafnodes-metafactory.conf"),
+      join(dir, "leafnodes-othernet.conf"),
+    ]);
+  });
+
+  test("ignores non-leaf includes", () => {
+    const dir = freshDir();
+    const conf = join(dir, "research.conf");
+    writeFileSync(conf, 'include "resolver.conf"\ninclude "leafnodes-net.conf"\n');
+    expect(parseLeafIncludeFiles(conf)).toEqual([join(dir, "leafnodes-net.conf")]);
+  });
+});
+
+describe("retiredSeedPath", () => {
+  test("appends .retired-<stamp> (retire, not destroy)", () => {
+    expect(retiredSeedPath("/nats/cortex-research.nk", "2026-07-02T00-00-00-000Z")).toBe(
+      "/nats/cortex-research.nk.retired-2026-07-02T00-00-00-000Z",
+    );
   });
 });

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -22,7 +22,8 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
+import { parse as parseYaml } from "yaml";
 import { DEFAULT_STREAM_MAX_BYTES } from "../../../common/types/cortex-config";
 
 // =============================================================================
@@ -178,6 +179,135 @@ function buildDiscovered(
     configPath,
     ...(stackId !== undefined && { aligned: stackIdTrailingSlug(stackId) === slugLocator }),
   };
+}
+
+// =============================================================================
+// Teardown (C-1351 Slice 1 — `cortex stack delete`, local teardown)
+// =============================================================================
+//
+// The DEATH story that complements `create` (the birth story). Pure path
+// resolution + read-only inspection live here; the effectful teardown (plist
+// unload, fs removal, seed retire) lives in `stack.ts` — mirroring the
+// create-side lib/command split so this module stays trivially testable.
+//
+// SCOPE (Slice 1): local artifacts ONLY. Registry-side deregistration
+// (`provision-stack retire`) is Slice 2 — deferred (depends on #832 + a
+// tombstone-vs-delete design call). Nothing here touches the registry or the
+// bus; the joined-network read below is READ-ONLY.
+
+/** The three filesystem roots teardown spans. Overridable (tests point them at
+ *  tmp dirs; a principal with non-standard paths can override too). */
+export interface TeardownRoots {
+  /** Cortex config dir (`~/.config/cortex`). Holds the config-split stack dir. */
+  configDir: string;
+  /** NATS material dir (`~/.config/nats`). Holds the rendered `<slug>.conf`,
+   *  leaf includes, and the signing seed. */
+  natsDir: string;
+  /** launchd LaunchAgents dir (`~/Library/LaunchAgents`) — the daemon + nats
+   *  plists. On Linux this is the systemd user-unit dir; the caller decides. */
+  launchAgentsDir: string;
+}
+
+/** Resolved absolute paths of every local artifact a stack owns. Pure — computed
+ *  from the slug + roots by CONVENTION (the same paths `stack create` /
+ *  sop-stack-onboarding.md Step 2/4 write), so teardown finds them without a
+ *  config parse. Existence is checked by the caller (missing pieces are skipped
+ *  — teardown is idempotent). */
+export interface StackArtifacts {
+  /** The config-split stack dir (`<configDir>/<slug>/`) — contains system/,
+   *  surfaces/, stacks/<slug>.yaml, personas/, and the `<slug>.yaml` pointer, so
+   *  removing this dir removes the pointer with it. */
+  configStackDir: string;
+  /** The policy-bearing file (`<configStackDir>/stacks/<slug>.yaml`) — where
+   *  `policy.federated.networks[]` lives under the split layout (mirrors
+   *  `network-adapters.ts` `stackConfigPath`). Read-only here (the joined gate). */
+  policyConfigFile: string;
+  /** Rendered nats-server config (`<natsDir>/<slug>.conf`, sop Step 2). */
+  natsConf: string;
+  /** The stack's signing seed (`<natsDir>/cortex-<slug>.nk`). RETIRED (renamed),
+   *  never deleted, unless `--purge-seeds` (key destruction is a conscious act). */
+  seed: string;
+  /** Cortex daemon plist (`ai.meta-factory.cortex.<slug>.plist`, sop Step 4). */
+  daemonPlist: string;
+  /** Dedicated nats-server plist (`ai.meta-factory.nats.<slug>.plist`, sop Step 2). */
+  natsPlist: string;
+}
+
+export function resolveStackArtifacts(roots: TeardownRoots, slug: string): StackArtifacts {
+  const configStackDir = join(roots.configDir, slug);
+  return {
+    configStackDir,
+    policyConfigFile: join(configStackDir, "stacks", `${slug}.yaml`),
+    natsConf: join(roots.natsDir, `${slug}.conf`),
+    seed: join(roots.natsDir, `cortex-${slug}.nk`),
+    daemonPlist: join(roots.launchAgentsDir, `ai.meta-factory.cortex.${slug}.plist`),
+    natsPlist: join(roots.launchAgentsDir, `ai.meta-factory.nats.${slug}.plist`),
+  };
+}
+
+/**
+ * READ-ONLY: the network ids this stack is currently joined to
+ * (`policy.federated.networks[].id`), read from its policy-bearing config file.
+ * Mirrors `network-adapters.ts` `ConfigStorePort.readNetworks` byte-for-byte
+ * (`raw?.policy?.federated?.networks ?? []`) so the delete gate reads exactly
+ * what `network join`/`leave` wrote. Empty when the file is absent/unparseable
+ * (a stack with no config can't be joined). NEVER mutates.
+ *
+ * This is the ONLY point teardown inspects federated state, and it is read-only
+ * — the network.ts / network-lib.ts lane is untouched (C-1351 stays out of it).
+ */
+export function readJoinedNetworkIds(policyConfigFile: string): string[] {
+  if (!existsSync(policyConfigFile)) return [];
+  let raw: { policy?: { federated?: { networks?: { id?: string }[] } } } | null;
+  try {
+    raw = parseYaml(readFileSync(policyConfigFile, "utf-8")) as typeof raw;
+  } catch (_err) {
+    // Unparseable config carries no resolvable join state — treat as not-joined
+    // (a broken config can't be a live roster member). Safe to ignore.
+    return [];
+  }
+  const networks = raw?.policy?.federated?.networks ?? [];
+  return networks
+    .map((n) => n.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
+/**
+ * The leaf-include files a stack's rendered nats config references — the
+ * `include "leafnodes-<network>.conf"` directives `network join` wrote
+ * (`leaf-remote-renderer.ts` #754). Returned as absolute paths in the conf's own
+ * dir so teardown removes exactly the includes THIS stack's conf pulls in (never
+ * another stack's). Empty when the conf is absent/unreadable. Read-only.
+ */
+export function parseLeafIncludeFiles(natsConfPath: string): string[] {
+  if (!existsSync(natsConfPath)) return [];
+  let text: string;
+  try {
+    text = readFileSync(natsConfPath, "utf-8");
+  } catch (_err) {
+    // Unreadable conf → no includes to resolve; the conf itself is still removed
+    // by the caller. Safe to ignore.
+    return [];
+  }
+  const dir = dirname(natsConfPath);
+  const out: string[] = [];
+  const re = /^\s*include\s+"(leafnodes-[^"]+\.conf)"/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const file = m[1];
+    if (file !== undefined) out.push(join(dir, file));
+  }
+  return out;
+}
+
+/**
+ * The retire target for a signing seed: `<seed>.retired-<stamp>`. Renaming
+ * (not deleting) the seed is the default — destroying key material is a separate
+ * conscious act (`--purge-seeds`). `stamp` is supplied by the caller (a
+ * filesystem-safe timestamp) so this stays pure/deterministic in tests.
+ */
+export function retiredSeedPath(seedPath: string, stamp: string): string {
+  return `${seedPath}.retired-${stamp}`;
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -33,7 +33,8 @@
  * Exit codes: 0 success · 1 operational failure (conflict / write error) · 2 usage.
  */
 
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "fs";
+import { execFileSync } from "child_process";
 import { dirname, join } from "path";
 import { homedir } from "os";
 
@@ -44,8 +45,13 @@ import { parseSubcommandArgs, type FlagMap, type SubcommandSpec } from "./_share
 import {
   assertAligned,
   discoverStacks,
+  parseLeafIncludeFiles,
+  readJoinedNetworkIds,
   renderScaffold,
+  resolveStackArtifacts,
+  retiredSeedPath,
   type ScaffoldFile,
+  type TeardownRoots,
 } from "./stack-lib";
 
 export { type ExitResult } from "./_shared/exit-result";
@@ -54,7 +60,7 @@ export { type ExitResult } from "./_shared/exit-result";
 // Grammar
 // =============================================================================
 
-type StackSubcommand = "create" | "list";
+type StackSubcommand = "create" | "list" | "delete";
 
 /**
  * Slug + principal grammar. A slug is a single `{stack_id}` segment of the
@@ -69,6 +75,10 @@ const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 
 /** Default config dir (same canonical path the daemon + network CLI use). */
 const DEFAULT_CONFIG_DIR = "~/.config/cortex";
+/** Default NATS material dir (rendered `<slug>.conf`, leaf includes, seed). */
+const DEFAULT_NATS_DIR = "~/.config/nats";
+/** Default launchd LaunchAgents dir (the daemon + nats plists, macOS). */
+const DEFAULT_LAUNCH_AGENTS_DIR = "~/Library/LaunchAgents";
 /** Default agent id for the scaffolded stack — neutral placeholder, not a personal persona name (#1338). */
 const DEFAULT_AGENT_ID = "assistant";
 
@@ -90,6 +100,27 @@ const SPEC: SubcommandSpec<StackSubcommand> = {
       positionals: [],
       flags: {
         "--config-dir": "value",
+      },
+    },
+    delete: {
+      positionals: ["slug"],
+      flags: {
+        "--config-dir": "value",
+        // Advanced overrides for non-standard installs (default to the
+        // conventional ~/.config/nats and ~/Library/LaunchAgents). Also the
+        // seam the tests point at tmp dirs so teardown never touches the real
+        // home. Mirrors `cortex network`'s explicit --nats-config / --plist
+        // override posture.
+        "--nats-dir": "value",
+        "--launch-agents-dir": "value",
+        // Destructive-action confirmation: the literal slug must be typed after
+        // --confirm when --apply is set (never a glob).
+        "--confirm": "value",
+        // Full key destruction. Default is retire-not-delete for the signing
+        // seed; --purge-seeds opts into wiping it (a separate conscious act).
+        "--purge-seeds": "bool",
+        "--apply": "bool",
+        "--dry-run": "bool",
       },
     },
   },
@@ -371,6 +402,245 @@ function capitalize(s: string): string {
 }
 
 // =============================================================================
+// delete (C-1351 Slice 1 — local teardown)
+// =============================================================================
+
+/** One planned teardown action. `exists` drives dry-run rendering + the
+ *  idempotent apply (missing pieces are skipped, never an error). */
+interface TeardownAction {
+  /** Short label for the plan/summary line. */
+  label: string;
+  /** Absolute target path. */
+  path: string;
+  /** Present on disk right now. */
+  exists: boolean;
+  /** How --apply handles it. */
+  op: "unload+remove" | "remove-dir" | "remove-file" | "retire-seed" | "purge-seed";
+  /** For retire-seed: the resolved `<seed>.retired-<stamp>` destination. */
+  retireTo?: string;
+}
+
+/**
+ * Best-effort unload of a launchd plist before removing it (macOS). An
+ * already-unloaded / never-loaded service makes `launchctl unload` exit
+ * non-zero — non-fatal (we are tearing down), so we swallow it and continue.
+ * On non-darwin platforms the daemon is a systemd user unit, not a plist:
+ * Slice 1 targets the launchd path `cortex stack create` scaffolds; a systemd
+ * teardown is a documented follow-up. Never throws.
+ */
+function serviceUnload(plistPath: string, steps: string[]): void {
+  if (process.platform !== "darwin") return; // systemd teardown = Slice-1 follow-up
+  try {
+    execFileSync("launchctl", ["unload", plistPath], { stdio: "ignore" });
+    steps.push(`  unloaded launchd service: ${plistPath}`);
+  } catch (_err) {
+    // Non-fatal: the service may already be unloaded / never loaded. We still
+    // remove the plist file below. Surfaced as a soft note, not a failure.
+    steps.push(`  (launchctl unload skipped — service not loaded: ${plistPath})`);
+  }
+}
+
+/** Filesystem-safe timestamp for the retired-seed suffix. */
+function retireStamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function runDelete(
+  slug: string,
+  flags: FlagMap,
+  json: boolean,
+): ExitResult {
+  // --- validate slug -------------------------------------------------------
+  if (!SLUG_RE.test(slug)) {
+    return usageError(
+      "delete",
+      `slug "${slug}" must be lowercase alphanumeric + hyphen/underscore, letter-prefixed (the {stack_id} segment grammar)`,
+      json,
+    );
+  }
+
+  const roots: TeardownRoots = {
+    configDir: expandTildePath(optionalValueFlag(flags, "--config-dir") ?? DEFAULT_CONFIG_DIR),
+    natsDir: expandTildePath(optionalValueFlag(flags, "--nats-dir") ?? DEFAULT_NATS_DIR),
+    launchAgentsDir: expandTildePath(
+      optionalValueFlag(flags, "--launch-agents-dir") ?? DEFAULT_LAUNCH_AGENTS_DIR,
+    ),
+  };
+
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return usageError("delete", applyRes.reason, json);
+  const purgeSeeds = flags["--purge-seeds"] === true;
+
+  const art = resolveStackArtifacts(roots, slug);
+
+  // --- (a) joined-network gate (READ-ONLY, fail-closed, BOTH modes) --------
+  // Never orphan a live roster membership. Refuse in dry-run too — previewing a
+  // teardown that cannot run would be misleading; the actionable fix is the same.
+  const joined = readJoinedNetworkIds(art.policyConfigFile);
+  if (joined.length > 0) {
+    const leaveCmds = joined.map((n) => `cortex network leave ${n} --apply`).join("; ");
+    return opError(
+      "delete",
+      `refusing to delete "${slug}": still joined to ${joined.length.toString()} network(s) ` +
+        `(${joined.join(", ")}). Leave each first (never orphan a live roster membership): ${leaveCmds}.`,
+      json,
+    );
+  }
+
+  // --- destructive-action confirmation (apply only) ------------------------
+  if (applyRes.apply) {
+    const confirm = optionalValueFlag(flags, "--confirm");
+    if (confirm === undefined) {
+      return usageError(
+        "delete",
+        `--apply requires --confirm <slug>: type the literal slug "${slug}" to confirm a destructive teardown (never a glob)`,
+        json,
+      );
+    }
+    if (confirm !== slug) {
+      return usageError(
+        "delete",
+        `--confirm "${confirm}" does not match the slug "${slug}" — type the exact slug to confirm (never a glob)`,
+        json,
+      );
+    }
+  }
+
+  // --- build the ordered teardown plan -------------------------------------
+  // Order matters: stop services (b) before removing the config/nats files they
+  // load (c), and retire the seed last (d). Leaf includes are resolved from the
+  // conf's `include` directives so we remove exactly THIS stack's includes.
+  const stamp = retireStamp();
+  const leafIncludes = parseLeafIncludeFiles(art.natsConf);
+  const actions: TeardownAction[] = [
+    { label: "cortex daemon plist", path: art.daemonPlist, exists: existsSync(art.daemonPlist), op: "unload+remove" },
+    { label: "nats-server plist", path: art.natsPlist, exists: existsSync(art.natsPlist), op: "unload+remove" },
+    { label: "config-split stack dir (incl. pointer)", path: art.configStackDir, exists: existsSync(art.configStackDir), op: "remove-dir" },
+    { label: "rendered nats config", path: art.natsConf, exists: existsSync(art.natsConf), op: "remove-file" },
+    ...leafIncludes.map((p): TeardownAction => ({ label: "leaf include", path: p, exists: existsSync(p), op: "remove-file" })),
+    purgeSeeds
+      ? { label: "signing seed (PURGE)", path: art.seed, exists: existsSync(art.seed), op: "purge-seed" }
+      : { label: "signing seed (retire)", path: art.seed, exists: existsSync(art.seed), op: "retire-seed", retireTo: retiredSeedPath(art.seed, stamp) },
+  ];
+
+  // --- dry-run (DEFAULT): print the plan, touch NOTHING --------------------
+  if (!applyRes.apply) {
+    return renderTeardownPlan(slug, roots, actions, purgeSeeds, false, [], json);
+  }
+
+  // --- apply: execute in order, continuing past missing pieces -------------
+  const steps: string[] = [];
+  for (const a of actions) {
+    if (!a.exists) {
+      steps.push(`  skip (absent): ${a.label} — ${a.path}`);
+      continue;
+    }
+    try {
+      switch (a.op) {
+        case "unload+remove":
+          serviceUnload(a.path, steps);
+          rmSync(a.path, { force: true });
+          steps.push(`  removed ${a.label}: ${a.path}`);
+          break;
+        case "remove-dir":
+          rmSync(a.path, { recursive: true, force: true });
+          steps.push(`  removed ${a.label}: ${a.path}`);
+          break;
+        case "remove-file":
+          rmSync(a.path, { force: true });
+          steps.push(`  removed ${a.label}: ${a.path}`);
+          break;
+        case "purge-seed":
+          rmSync(a.path, { force: true });
+          steps.push(`  PURGED ${a.label}: ${a.path} (key material destroyed)`);
+          break;
+        case "retire-seed":
+          // Retire, don't destroy: rename the seed aside so key destruction is a
+          // separate conscious act (--purge-seeds).
+          renameSync(a.path, a.retireTo!);
+          steps.push(`  retired ${a.label}: ${a.path} → ${a.retireTo!} (NOT deleted; --purge-seeds to wipe)`);
+          break;
+      }
+    } catch (err) {
+      // Continue past a per-artifact failure (idempotent teardown) but record it
+      // so the operator can finish by hand. Never a silent swallow.
+      steps.push(
+        `  ⚠ ${a.label} teardown failed (continuing): ${a.path} — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return renderTeardownPlan(slug, roots, actions, purgeSeeds, true, steps, json);
+}
+
+function renderTeardownPlan(
+  slug: string,
+  roots: TeardownRoots,
+  actions: TeardownAction[],
+  purgeSeeds: boolean,
+  applied: boolean,
+  steps: string[],
+  json: boolean,
+): ExitResult {
+  const present = actions.filter((a) => a.exists);
+
+  if (json) {
+    return ok(
+      renderJson(
+        envelopeOk(
+          actions.map((a) => ({
+            label: a.label,
+            path: a.path,
+            op: a.op,
+            present: a.exists ? "true" : "false",
+            ...(a.retireTo !== undefined && { retire_to: a.retireTo }),
+          })),
+          {
+            slug,
+            config_dir: roots.configDir,
+            nats_dir: roots.natsDir,
+            launch_agents_dir: roots.launchAgentsDir,
+            purge_seeds: purgeSeeds ? "true" : "false",
+            present_count: present.length.toString(),
+            applied: applied ? "true" : "false",
+          },
+        ),
+      ),
+    );
+  }
+
+  const lines: string[] = [];
+  lines.push(`cortex stack delete ${slug}: ${applied ? "torn down" : "dry-run"}`);
+  if (!applied) lines.push("  (dry-run — no disk mutation; pass --apply --confirm " + slug + " to execute)");
+  lines.push("");
+  if (present.length === 0) {
+    lines.push(`  nothing to remove — no local artifacts found for "${slug}" (already torn down).`);
+    lines.push("");
+    return ok(lines.join("\n"));
+  }
+  lines.push(`  ${applied ? "teardown order (executed):" : "teardown plan (would execute in order):"}`);
+  for (const a of actions) {
+    const mark = a.exists ? (a.op === "retire-seed" ? "retire" : a.op === "purge-seed" ? "PURGE" : "remove") : "skip (absent)";
+    const extra = a.op === "retire-seed" && a.retireTo !== undefined ? ` → ${a.retireTo}` : "";
+    lines.push(`    • [${mark}] ${a.label}: ${a.path}${extra}`);
+  }
+  lines.push("");
+  if (applied && steps.length > 0) {
+    lines.push("  result:");
+    for (const s of steps) lines.push(s);
+    lines.push("");
+  }
+  if (!applied) {
+    lines.push("Slice 2 (registry deregistration) is a separate follow-up (#1351) — this teardown is LOCAL only.");
+    lines.push(`Re-run with --apply --confirm ${slug} to execute.`);
+  } else {
+    lines.push("Local teardown complete. Registry-side deregistration (Slice 2, #1351) is a separate step — not performed here.");
+  }
+  lines.push("");
+  return ok(lines.join("\n"));
+}
+
+// =============================================================================
 // list
 // =============================================================================
 
@@ -472,6 +742,8 @@ export function dispatchStack(argv: string[]): Promise<ExitResult> {
       return Promise.resolve(runCreate(parsed.positionals.slug ?? "", parsed.flags, json));
     case "list":
       return Promise.resolve(runList(parsed.flags, json));
+    case "delete":
+      return Promise.resolve(runDelete(parsed.positionals.slug ?? "", parsed.flags, json));
   }
 }
 
@@ -485,6 +757,7 @@ function topLevelHelp(): string {
 Usage:
   cortex stack create <slug> [--principal <id>] [--apply] [options]
   cortex stack list [--config-dir <path>] [--json]
+  cortex stack delete <slug> [--apply --confirm <slug>] [--purge-seeds] [options]
 
 The prevent-side complement to the install-time slug<->stack.id drift detector
 (warn_stack_identity_drift / ADR-0004). \`create\` scaffolds a config-split stack
@@ -502,10 +775,18 @@ Subcommands:
           auto-provisions it on first install. NEVER overwrites an existing dir.
   list    Show discovered stacks (split-layout dirs + legacy cortex*.yaml
           monoliths) with their stack.id and an aligned/DRIFT flag.
+  delete  Tear down a stack's LOCAL artifacts (C-1351 Slice 1): refuse if still
+          joined to any network (leave first), stop+unload the daemon + nats
+          plists, remove the config-split dir (incl. its pointer) + rendered
+          nats conf + leaf includes, and RETIRE (rename, not delete) the signing
+          seed. Registry-side deregistration is Slice 2 (a separate follow-up).
 
 Safety:
-  create defaults to DRY-RUN (prints the file set it WOULD write, touches
-  nothing). Pass --apply to write. --apply and --dry-run are mutually exclusive.
+  create + delete default to DRY-RUN (print the plan, touch nothing). Pass
+  --apply to execute. --apply and --dry-run are mutually exclusive. delete
+  additionally requires --confirm <slug> (the literal slug typed) with --apply,
+  and RETIRES the signing seed (rename to <seed>.retired-<timestamp>) rather
+  than deleting it — pass --purge-seeds to wipe key material.
 
 Flags (create):
   --principal <id>      The principal half of stack.id. Default: inferred from
@@ -520,6 +801,18 @@ Flags (create):
 
 Flags (list):
   --config-dir <path>   Config dir to scan (default: ~/.config/cortex).
+  --json                Emit a { status, items, data, error } envelope.
+
+Flags (delete):
+  --apply               Execute the teardown (default: dry-run).
+  --confirm <slug>      REQUIRED with --apply: the literal slug, typed, to
+                        confirm the destructive teardown (never a glob).
+  --purge-seeds         Wipe the signing seed instead of retiring it (rename).
+  --config-dir <path>   Config dir (default: ~/.config/cortex).
+  --nats-dir <path>     NATS material dir (default: ~/.config/nats) — the
+                        rendered <slug>.conf, leaf includes, and signing seed.
+  --launch-agents-dir <path>
+                        launchd LaunchAgents dir (default: ~/Library/LaunchAgents).
   --json                Emit a { status, items, data, error } envelope.
 `;
 }

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -45,7 +45,6 @@ import { parseSubcommandArgs, type FlagMap, type SubcommandSpec } from "./_share
 import {
   assertAligned,
   discoverStacks,
-  parseLeafIncludeFiles,
   readJoinedNetworkIds,
   renderScaffold,
   resolveStackArtifacts,
@@ -421,6 +420,17 @@ interface TeardownAction {
 }
 
 /**
+ * A per-artifact teardown failure recorded during --apply. #1384 review (MAJOR)
+ * — kept structurally (not just as human `steps` prose) so `--json` can surface
+ * it and the exit code can go non-zero on a partial teardown.
+ */
+interface TeardownFailure {
+  label: string;
+  path: string;
+  error: string;
+}
+
+/**
  * Best-effort unload of a launchd plist before removing it (macOS). An
  * already-unloaded / never-loaded service makes `launchctl unload` exit
  * non-zero — non-fatal (we are tearing down), so we swallow it and continue.
@@ -508,16 +518,23 @@ function runDelete(
 
   // --- build the ordered teardown plan -------------------------------------
   // Order matters: stop services (b) before removing the config/nats files they
-  // load (c), and retire the seed last (d). Leaf includes are resolved from the
-  // conf's `include` directives so we remove exactly THIS stack's includes.
+  // load (c), and retire the seed last (d).
+  //
+  // #1384 review (MAJOR) — we deliberately DO NOT remove the leaf-include files
+  // (`leafnodes-<network>.conf`). Those are NETWORK-keyed and live in the SHARED
+  // natsDir: two stacks on the same network reference the SAME file, and
+  // `cortex network leave` already owns + removes it (network-lib.ts). Removing
+  // it here is redundant in the happy path (a cleanly-left stack — which the
+  // joined-network refusal gate above guarantees — holds no leaf refs) and
+  // DESTRUCTIVE in a partial-leave state: it could delete a leaf conf a live
+  // SIBLING stack still includes, breaking the sibling's federation. We remove
+  // only THIS stack's OWN rendered nats config (`<natsDir>/<slug>.conf`).
   const stamp = retireStamp();
-  const leafIncludes = parseLeafIncludeFiles(art.natsConf);
   const actions: TeardownAction[] = [
     { label: "cortex daemon plist", path: art.daemonPlist, exists: existsSync(art.daemonPlist), op: "unload+remove" },
     { label: "nats-server plist", path: art.natsPlist, exists: existsSync(art.natsPlist), op: "unload+remove" },
     { label: "config-split stack dir (incl. pointer)", path: art.configStackDir, exists: existsSync(art.configStackDir), op: "remove-dir" },
     { label: "rendered nats config", path: art.natsConf, exists: existsSync(art.natsConf), op: "remove-file" },
-    ...leafIncludes.map((p): TeardownAction => ({ label: "leaf include", path: p, exists: existsSync(p), op: "remove-file" })),
     purgeSeeds
       ? { label: "signing seed (PURGE)", path: art.seed, exists: existsSync(art.seed), op: "purge-seed" }
       : { label: "signing seed (retire)", path: art.seed, exists: existsSync(art.seed), op: "retire-seed", retireTo: retiredSeedPath(art.seed, stamp) },
@@ -525,11 +542,16 @@ function runDelete(
 
   // --- dry-run (DEFAULT): print the plan, touch NOTHING --------------------
   if (!applyRes.apply) {
-    return renderTeardownPlan(slug, roots, actions, purgeSeeds, false, [], json);
+    return renderTeardownPlan(slug, roots, actions, purgeSeeds, false, [], [], json);
   }
 
   // --- apply: execute in order, continuing past missing pieces -------------
+  // #1384 review (MAJOR) — collect per-artifact failures STRUCTURALLY (not just
+  // as human `steps` prose) so the --json envelope can surface them and the exit
+  // code can go non-zero. A scripted `--json --apply` consumer must be able to
+  // detect a partial teardown, not see applied:true + exit 0 on an EACCES.
   const steps: string[] = [];
+  const failures: TeardownFailure[] = [];
   for (const a of actions) {
     if (!a.exists) {
       steps.push(`  skip (absent): ${a.label} — ${a.path}`);
@@ -554,23 +576,32 @@ function runDelete(
           rmSync(a.path, { force: true });
           steps.push(`  PURGED ${a.label}: ${a.path} (key material destroyed)`);
           break;
-        case "retire-seed":
+        case "retire-seed": {
           // Retire, don't destroy: rename the seed aside so key destruction is a
-          // separate conscious act (--purge-seeds).
-          renameSync(a.path, a.retireTo!);
-          steps.push(`  retired ${a.label}: ${a.path} → ${a.retireTo!} (NOT deleted; --purge-seeds to wipe)`);
+          // separate conscious act (--purge-seeds). retireTo is always set when
+          // the action is built (see the plan above); guard rather than assert
+          // non-null (lint: no-non-null-assertion).
+          const retireTo = a.retireTo;
+          if (retireTo === undefined) throw new Error(`retire-seed action missing retireTo: ${a.path}`);
+          renameSync(a.path, retireTo);
+          steps.push(`  retired ${a.label}: ${a.path} → ${retireTo} (NOT deleted; --purge-seeds to wipe)`);
           break;
+        }
       }
     } catch (err) {
       // Continue past a per-artifact failure (idempotent teardown) but record it
-      // so the operator can finish by hand. Never a silent swallow.
+      // so the principal can finish by hand. Never a silent swallow — the failure
+      // is captured both in human `steps` AND structurally in `failures` (below)
+      // so the --json path can surface it and the exit code can go non-zero.
+      const message = err instanceof Error ? err.message : String(err);
+      failures.push({ label: a.label, path: a.path, error: message });
       steps.push(
-        `  ⚠ ${a.label} teardown failed (continuing): ${a.path} — ${err instanceof Error ? err.message : String(err)}`,
+        `  ⚠ ${a.label} teardown failed (continuing): ${a.path} — ${message}`,
       );
     }
   }
 
-  return renderTeardownPlan(slug, roots, actions, purgeSeeds, true, steps, json);
+  return renderTeardownPlan(slug, roots, actions, purgeSeeds, true, steps, failures, json);
 }
 
 function renderTeardownPlan(
@@ -580,33 +611,46 @@ function renderTeardownPlan(
   purgeSeeds: boolean,
   applied: boolean,
   steps: string[],
+  failures: TeardownFailure[],
   json: boolean,
 ): ExitResult {
   const present = actions.filter((a) => a.exists);
+  // #1384 review (MAJOR) — a partial teardown (one or more artifact removals
+  // failed under --apply) is NOT a success. Exit non-zero so a scripted consumer
+  // can detect it, in BOTH --json and human modes.
+  const failedByPath = new Map(failures.map((f) => [f.path, f.error]));
+  const exitCode = failures.length > 0 ? 1 : 0;
 
   if (json) {
-    return ok(
-      renderJson(
-        envelopeOk(
-          actions.map((a) => ({
-            label: a.label,
-            path: a.path,
-            op: a.op,
-            present: a.exists ? "true" : "false",
-            ...(a.retireTo !== undefined && { retire_to: a.retireTo }),
-          })),
-          {
-            slug,
-            config_dir: roots.configDir,
-            nats_dir: roots.natsDir,
-            launch_agents_dir: roots.launchAgentsDir,
-            purge_seeds: purgeSeeds ? "true" : "false",
-            present_count: present.length.toString(),
-            applied: applied ? "true" : "false",
-          },
-        ),
-      ),
+    const envelope = envelopeOk(
+      actions.map((a) => {
+        const failure = failedByPath.get(a.path);
+        return {
+          label: a.label,
+          path: a.path,
+          op: a.op,
+          present: a.exists ? "true" : "false",
+          ...(a.retireTo !== undefined && { retire_to: a.retireTo }),
+          // Per-action outcome (only meaningful under --apply). A consumer can
+          // gate on `failed` per artifact; `failed_count` (in data) is the
+          // aggregate, and the process exit code mirrors it.
+          ...(failure !== undefined && { failed: "true", failed_reason: failure }),
+        };
+      }),
+      {
+        slug,
+        config_dir: roots.configDir,
+        nats_dir: roots.natsDir,
+        launch_agents_dir: roots.launchAgentsDir,
+        purge_seeds: purgeSeeds ? "true" : "false",
+        present_count: present.length.toString(),
+        applied: applied ? "true" : "false",
+        failed_count: failures.length.toString(),
+      },
     );
+    // status stays "ok" (the teardown ran + the plan is preserved in items), but
+    // the exit code signals the partial failure — the machine-readable handshake.
+    return { exitCode, stdout: renderJson(envelope), stderr: "" };
   }
 
   const lines: string[] = [];
@@ -633,11 +677,17 @@ function renderTeardownPlan(
   if (!applied) {
     lines.push("Slice 2 (registry deregistration) is a separate follow-up (#1351) — this teardown is LOCAL only.");
     lines.push(`Re-run with --apply --confirm ${slug} to execute.`);
+  } else if (failures.length > 0) {
+    // #1384 review (MAJOR) — surface the partial failure loudly + exit non-zero.
+    lines.push(
+      `PARTIAL teardown: ${failures.length.toString()} artifact(s) could NOT be removed (see ⚠ above) — ` +
+        `finish by hand or fix permissions and re-run. Registry-side deregistration (Slice 2, #1351) not performed.`,
+    );
   } else {
     lines.push("Local teardown complete. Registry-side deregistration (Slice 2, #1351) is a separate step — not performed here.");
   }
   lines.push("");
-  return ok(lines.join("\n"));
+  return { exitCode, stdout: lines.join("\n"), stderr: "" };
 }
 
 // =============================================================================
@@ -777,9 +827,15 @@ Subcommands:
           monoliths) with their stack.id and an aligned/DRIFT flag.
   delete  Tear down a stack's LOCAL artifacts (C-1351 Slice 1): refuse if still
           joined to any network (leave first), stop+unload the daemon + nats
-          plists, remove the config-split dir (incl. its pointer) + rendered
-          nats conf + leaf includes, and RETIRE (rename, not delete) the signing
-          seed. Registry-side deregistration is Slice 2 (a separate follow-up).
+          plists, remove the config-split dir (incl. its pointer) + this stack's
+          OWN rendered nats conf, and RETIRE (rename, not delete) the signing
+          seed. Shared network-keyed leaf files (leafnodes-<net>.conf) are NOT
+          touched — 'cortex network leave' owns those. Registry-side
+          deregistration is Slice 2 (a separate follow-up).
+          Slice-1 limitation: seed + nats-conf are resolved by SLUG CONVENTION
+          (<nats-dir>/<slug>.conf, conventional seed path), NOT the stack's
+          recorded stack.nkey_seed_path — a stack whose seed lives at a
+          non-default path is only partially torn down (finish by hand).
 
 Safety:
   create + delete default to DRY-RUN (print the plan, touch nothing). Pass


### PR DESCRIPTION
## What
Adds `cortex stack delete <slug>` — the local teardown counterpart to `stack create`. Dry-run DEFAULT; `--apply` requires `--confirm <slug>` (literal, never glob); `--json` supported. Idempotent.

Teardown order + gates: (a) **refuse if joined** to any network (reads policy.federated.networks[] read-only → 'run cortex network leave first', fail-closed, never orphans a roster row); (b) stop+unload daemon + dedicated nats-server plists (best-effort launchctl, darwin); (c) remove config-split dir + pointer + rendered nats conf + the leaf-includes THAT conf references; (d) signing seed → **retired** (renamed .retired-<stamp>, printed) by default, `--purge-seeds` to wipe (key destruction = separate conscious act). Paths overridable for hermetic tests.

Scope: stack.ts + stack-lib.ts + 2 tests only. network.ts/network-lib.ts/provision-stack.ts/e2e UNTOUCHED (the one federated-state touch is a READ of joined networks).

## Deferred — Slice 2 (registry deregistration)
Tombstone-vs-delete design call for JC first; `provision-stack retire` (root-seed, #791 machinery); refuse-while-ADMITTED; **blocked on #832** (shares the root-seed signing path). Follow-up.

## Verify
tsc --noEmit exit 0 · bun test src/cli/cortex/commands 1062 pass/0 fail (stack files 57/0). Vocab: uses 'principal' throughout.

Refs #1351 (Slice 2 pending). Epic #1346 Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB