### PR TITLE
feat(network): C-1314 — cortex network admit --list-pending

### DIFF
--- a/docs/sop-onboard-peer-principal.md
+++ b/docs/sop-onboard-peer-principal.md
@@ -146,18 +146,26 @@ cortex provision-stack register <principal> \
 **Hub side (the network admin admits the request):**
 
 ```bash
-# List pending requests
+# List pending requests (C-1314) — admin-signs the query, prints the queue
+# (request-id · principal · network · peer · status · created) so you can copy
+# the request-id. --status defaults to PENDING; --network filters client-side.
 cortex network admit --list-pending \
   --registry-url https://network.meta-factory.ai \
   --admin-seed ~/.config/nats/admin.nk
 
-# Admit (approves roster membership; mints nothing)
+# Admit (approves roster membership; mints nothing). The network_id is read from
+# the stored request (set at register time) — there is no --network flag here.
 cortex network admit <request-id> \
-  --network <network> \
   --registry-url https://network.meta-factory.ai \
   --admin-seed ~/.config/nats/admin.nk \
   --apply
 ```
+
+> **Read-scoping caveat (ADR-0020 fast-follow):** admin *reads* — including
+> `--list-pending` — are **global-admin-only** today; a per-network admin gets a
+> readable `403 admin_not_authorized` even for their own network. Use a global-
+> admin seed (or the MC admission queue / Pier) until per-network read-scoping
+> lands.
 
 **Step 5b — Receive the leaf shared secret (sealed, automatic)**
 

--- a/src/cli/cortex/commands/__tests__/network-admit.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-admit.test.ts
@@ -570,6 +570,20 @@ describe("cortex network admit --list-pending (C-1314)", () => {
     expect(env.items[0]!.request_id).toBe("req-json-1");
   });
 
+  test("empty queue renders the (none) line, not a bare header (exit 0)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    setMockFetch(async () =>
+      new Response("[]", { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+    const res = await dispatchNetwork([
+      "admit", "--list-pending",
+      "--admin-seed", seedPath,
+    ]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("0 PENDING request(s)");
+    expect(res.stdout).toContain("(none)");
+  });
+
   test("--network filters the returned rows client-side", async () => {
     const { seedPath } = await mintAdminSeed();
     setMockFetch(async () =>

--- a/src/cli/cortex/commands/__tests__/network-admit.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-admit.test.ts
@@ -476,6 +476,162 @@ describe("cortex network admit — Discord O-5 role", () => {
 // Signature verification — decision vocabulary
 // =============================================================================
 
+// =============================================================================
+// C-1314 — `cortex network admit --list-pending` (admission-queue discovery)
+// =============================================================================
+describe("cortex network admit --list-pending (C-1314)", () => {
+  /** A list row as the registry `GET /admission-requests` returns it. */
+  function row(overrides: Partial<{ request_id: string; principal_id: string; network_id: string | null; status: string }> = {}) {
+    return {
+      request_id: overrides.request_id ?? "req-abc-123",
+      principal_id: overrides.principal_id ?? "peer-principal",
+      peer_pubkey: "A" + "B".repeat(43), // 44-char base64-ish
+      requested_scope: "federated.peer-principal.>",
+      network_id: overrides.network_id === undefined ? "metafactory-community" : overrides.network_id,
+      status: overrides.status ?? "PENDING",
+      created_at: "2026-06-18T00:00:00.000Z",
+      updated_at: "2026-06-18T00:00:00.000Z",
+      granted_by: null,
+    };
+  }
+
+  test("usage error without --admin-seed (exit 2)", async () => {
+    let fetchCalled = false;
+    setMockFetch(async () => {
+      fetchCalled = true;
+      return new Response("[]", { status: 200 });
+    });
+    const res = await dispatchNetwork(["admit", "--list-pending"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--admin-seed");
+    expect(fetchCalled).toBe(false); // never hit the network on a usage error
+  });
+
+  test("renders a table from the mocked list response; admin-signs GET ?status=PENDING", async () => {
+    const { seedPath } = await mintAdminSeed();
+    let gotUrl = "";
+    let gotAdminHeader = "";
+    setMockFetch(async (input, init) => {
+      gotUrl = urlOf(input);
+      const hdrs = new Headers(init?.headers);
+      gotAdminHeader = hdrs.get("x-admin-signed") ?? "";
+      return new Response(
+        JSON.stringify([
+          row({ request_id: "req-111", principal_id: "chuvala" }),
+          row({ request_id: "req-222", principal_id: "jc", network_id: "metafactory" }),
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const res = await dispatchNetwork([
+      "admit", "--list-pending",
+      "--admin-seed", seedPath,
+      "--registry-url", "http://registry.test",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    // Hit the LIST endpoint (not the single-request GET) with the signed header.
+    expect(gotUrl).toContain("/admission-requests?status=PENDING");
+    expect(gotAdminHeader.length).toBeGreaterThan(0);
+    const signed = JSON.parse(gotAdminHeader) as { claim: { admin_pubkey: string }; signature: string };
+    expect(signed.signature.length).toBeGreaterThan(0);
+    // Table carries both rows + their principals + networks + status.
+    expect(res.stdout).toContain("req-111");
+    expect(res.stdout).toContain("chuvala");
+    expect(res.stdout).toContain("req-222");
+    expect(res.stdout).toContain("metafactory");
+    expect(res.stdout).toContain("PENDING");
+    expect(res.stdout).toContain("2 PENDING request(s)");
+  });
+
+  test("--json emits the rows as items + count/status metadata", async () => {
+    const { seedPath } = await mintAdminSeed();
+    setMockFetch(async () =>
+      new Response(JSON.stringify([row({ request_id: "req-json-1" })]), {
+        status: 200, headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const res = await dispatchNetwork([
+      "admit", "--list-pending",
+      "--admin-seed", seedPath,
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as {
+      status: string;
+      items: { request_id: string }[];
+      data: { mode: string; status: string; count: string };
+    };
+    expect(env.status).toBe("ok");
+    expect(env.data.mode).toBe("list-pending");
+    expect(env.data.status).toBe("PENDING");
+    expect(env.data.count).toBe("1");
+    expect(env.items[0]!.request_id).toBe("req-json-1");
+  });
+
+  test("--network filters the returned rows client-side", async () => {
+    const { seedPath } = await mintAdminSeed();
+    setMockFetch(async () =>
+      new Response(
+        JSON.stringify([
+          row({ request_id: "req-a", network_id: "metafactory" }),
+          row({ request_id: "req-b", network_id: "research-collab" }),
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const res = await dispatchNetwork([
+      "admit", "--list-pending",
+      "--admin-seed", seedPath,
+      "--network", "research-collab",
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { items: { request_id: string }[]; data: { count: string; network: string } };
+    expect(env.data.network).toBe("research-collab");
+    expect(env.data.count).toBe("1");
+    expect(env.items.map((r) => r.request_id)).toEqual(["req-b"]);
+  });
+
+  test("403 from the registry is surfaced readably (ADR-0020 read-scoping), exit 1", async () => {
+    const { seedPath } = await mintAdminSeed();
+    setMockFetch(async () =>
+      new Response(JSON.stringify({ error: "admin_not_authorized" }), {
+        status: 403, headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const res = await dispatchNetwork([
+      "admit", "--list-pending",
+      "--admin-seed", seedPath,
+      "--network", "research-collab",
+    ]);
+    expect(res.exitCode).toBe(1);
+    // Readable, not a silent empty table.
+    expect(res.stderr).toContain("403");
+    expect(res.stderr).toMatch(/GLOBAL-admin-only/i);
+    expect(res.stderr).toContain("ADR-0020");
+    expect(res.stderr).toContain("research-collab");
+  });
+
+  test("invalid --status is a usage error (exit 2)", async () => {
+    const { seedPath } = await mintAdminSeed();
+    let fetchCalled = false;
+    setMockFetch(async () => {
+      fetchCalled = true;
+      return new Response("[]", { status: 200 });
+    });
+    const res = await dispatchNetwork([
+      "admit", "--list-pending",
+      "--admin-seed", seedPath,
+      "--status", "BOGUS",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--status");
+    expect(fetchCalled).toBe(false);
+  });
+});
+
 describe("cortex network admit — signed claim shape", () => {
   test("claim carries decision=admit (NOT grant)", async () => {
     const { seedPath } = await mintAdminSeed();

--- a/src/cli/cortex/commands/_shared/__tests__/parser.test.ts
+++ b/src/cli/cortex/commands/_shared/__tests__/parser.test.ts
@@ -171,6 +171,52 @@ describe("parseSubcommandArgs — positionals", () => {
   });
 });
 
+// C-1314 (#1388) — a trailing `?` on a declared positional name marks it
+// OPTIONAL: the value is captured under the BARE name, and its absence is NOT a
+// MissingPositionalError. This is the cross-cutting primitive `cortex network
+// admit` relies on (`positionals: ["request-id?"]`), so it is pinned directly at
+// the parser layer here — not only indirectly through the admit CLI tests.
+describe("parseSubcommandArgs — optional positional (trailing `?`)", () => {
+  // `admit` mirrors the real network SPEC: one OPTIONAL positional. `mixed`
+  // proves a REQUIRED positional followed by an OPTIONAL one behaves correctly.
+  const optSpec: SubcommandSpec<"admit" | "mixed"> = {
+    cliName: "opt-cli",
+    subcommands: {
+      admit: { positionals: ["request-id?"], flags: { "--list-pending": "bool" } },
+      mixed: { positionals: ["action", "request-id?"] },
+    },
+    universal: { "--help": "bool", "-h": "bool", "--json": "bool" },
+  };
+
+  test("present → captured under the BARE name (without the `?`)", () => {
+    const r = parseSubcommandArgs(optSpec, ["admit", "req-abc-123"]);
+    expect(r.subcommand).toBe("admit");
+    expect(r.positionals["request-id"]).toBe("req-abc-123");
+    // never keyed under the raw `request-id?` name
+    expect(r.positionals["request-id?"]).toBeUndefined();
+  });
+
+  test("absent → NO MissingPositionalError (optional), subcommand still parses", () => {
+    let r!: ReturnType<typeof parseSubcommandArgs<"admit" | "mixed">>;
+    expect(() => {
+      r = parseSubcommandArgs(optSpec, ["admit", "--list-pending"]);
+    }).not.toThrow();
+    expect(r.subcommand).toBe("admit");
+    expect(r.positionals["request-id"]).toBeUndefined();
+    expect(r.flags["--list-pending"]).toBe(true);
+  });
+
+  test("required-then-optional: required present + optional absent → ok", () => {
+    const r = parseSubcommandArgs(optSpec, ["mixed", "go"]);
+    expect(r.positionals["action"]).toBe("go");
+    expect(r.positionals["request-id"]).toBeUndefined();
+  });
+
+  test("required-then-optional: the REQUIRED one still throws when absent", () => {
+    expect(() => parseSubcommandArgs(optSpec, ["mixed"])).toThrow(MissingPositionalError);
+  });
+});
+
 describe("parseSubcommandArgs — flag order independence", () => {
   test("flags before subcommand still resolve to that subcommand's allowlist", () => {
     // --creds-dir BEFORE 'list' should still parse cleanly: the first pass

--- a/src/cli/cortex/commands/_shared/__tests__/parser.test.ts
+++ b/src/cli/cortex/commands/_shared/__tests__/parser.test.ts
@@ -208,7 +208,7 @@ describe("parseSubcommandArgs — optional positional (trailing `?`)", () => {
 
   test("required-then-optional: required present + optional absent → ok", () => {
     const r = parseSubcommandArgs(optSpec, ["mixed", "go"]);
-    expect(r.positionals["action"]).toBe("go");
+    expect(r.positionals.action).toBe("go");
     expect(r.positionals["request-id"]).toBeUndefined();
   });
 

--- a/src/cli/cortex/commands/_shared/parser.ts
+++ b/src/cli/cortex/commands/_shared/parser.ts
@@ -74,7 +74,9 @@ export interface SubcommandSpec<SubcommandName extends string> {
 }
 
 export interface SubcommandRule {
-  /** Ordered list of named required positionals AFTER the subcommand name. */
+  /** Ordered list of named positionals AFTER the subcommand name. Required by
+   *  default; a trailing `?` on a name marks that positional OPTIONAL (captured
+   *  under the bare name, e.g. `"request-id?"` → `positionals["request-id"]`). */
   positionals?: string[];
   /** Per-subcommand flag allowlist (in addition to universal flags). */
   flags?: Record<string, FlagKind>;
@@ -206,14 +208,20 @@ export function parseSubcommandArgs<S extends string>(
         `unexpected extra positional argument: "${arg}"`,
       );
     }
-    out.positionals[declared[nameIdx] ?? ""] = arg;
+    // A positional name may carry a trailing `?` to mark it OPTIONAL; the
+    // captured value is stored under the bare name (without the `?`).
+    out.positionals[(declared[nameIdx] ?? "").replace(/\?$/, "")] = arg;
     i++;
   }
 
   // Required-positionals check: every declared positional must be present.
-  // Skip for help / unknown subcommands — caller renders usage.
+  // A trailing `?` marks a positional OPTIONAL — skip the presence check for it
+  // (backward-compatible: no existing positional name uses `?`). Skip entirely
+  // for help / unknown subcommands — caller renders usage.
   if (activeRule) {
-    for (const name of activeRule.positionals ?? []) {
+    for (const rawName of activeRule.positionals ?? []) {
+      if (rawName.endsWith("?")) continue; // optional positional
+      const name = rawName;
       if (!(name in out.positionals)) {
         // Pass `out.rawSubcommand` so callers don't have to re-scan argv
         // (Echo cortex#66 round-1 warning — naive re-scan dropped flag-

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -336,7 +336,10 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
     // Tracking issue: cortex#1145 — thread network_id from register through
     // the admission gate so the stored row is always network-scoped.
     admit: {
-      positionals: ["request-id"],
+      // C-1314 — request-id is OPTIONAL (trailing `?`): the discovery mode
+      // `admit --list-pending` takes no request-id. The admit-a-request path
+      // still validates its presence in runAdmit.
+      positionals: ["request-id?"],
       flags: {
         "--admin-seed": "value",
         "--registry-url": "value",
@@ -346,6 +349,15 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--discord-role": "value",
         "--apply": "bool",
         "--dry-run": "bool",
+        // C-1314 — DISCOVERY mode. `cortex network admit --list-pending` admin-
+        // signs a read (`x-admin-signed`) and GETs
+        // `/admission-requests?status=<status>`, printing the queue so an admin
+        // can find the request-id to admit. Read-only (no --apply; no request-id
+        // positional). `--status` defaults to PENDING; `--network` filters the
+        // returned rows client-side (the endpoint lists all networks at once).
+        "--list-pending": "bool",
+        "--status": "value",
+        "--network": "value",
       },
     },
     // G1d / T1 (cortex#1139, ADR-0013) — one-command sovereign account-topology
@@ -1543,6 +1555,170 @@ async function buildAdmissionDecisionBody(
   return { claim, signature };
 }
 
+// =============================================================================
+// C-1314 — `cortex network admit --list-pending` (admission-queue discovery)
+// =============================================================================
+
+/** Admission-request statuses the registry list endpoint accepts. */
+const LIST_STATUSES = ["PENDING", "ADMITTED", "REJECTED"] as const;
+
+/** The subset of an `AdmissionRequest` row this CLI renders (matches the
+ *  registry `GET /admission-requests` response, `types.ts` AdmissionRequest). */
+interface AdmissionListRow {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  network_id: string | null;
+  status: string;
+  created_at: string;
+}
+
+/** Render the discovery table (human path). Peer pubkey is truncated to a
+ *  fingerprint for width; the full value rides the --json output. */
+function renderPendingTable(
+  rows: AdmissionListRow[],
+  status: string,
+  networkFilter: string | undefined,
+  registryUrl: string,
+): string {
+  const scope = networkFilter !== undefined ? ` on network "${networkFilter}"` : "";
+  const header =
+    `cortex network admit --list-pending — ${rows.length.toString()} ${status} request(s)${scope} ` +
+    `(registry: ${registryUrl})`;
+  if (rows.length === 0) {
+    return `${header}\n  (none) — nothing to ${status === "PENDING" ? "admit" : "show"}.\n`;
+  }
+  const cells = rows.map((r) => ({
+    id: r.request_id,
+    principal: r.principal_id,
+    network: r.network_id ?? "(none)",
+    peer: `${r.peer_pubkey.slice(0, 12)}…`,
+    status: r.status,
+    created: r.created_at,
+  }));
+  const w = {
+    id: Math.max("REQUEST-ID".length, ...cells.map((c) => c.id.length)),
+    principal: Math.max("PRINCIPAL".length, ...cells.map((c) => c.principal.length)),
+    network: Math.max("NETWORK".length, ...cells.map((c) => c.network.length)),
+    peer: Math.max("PEER_PUBKEY".length, ...cells.map((c) => c.peer.length)),
+    status: Math.max("STATUS".length, ...cells.map((c) => c.status.length)),
+  };
+  const row = (id: string, principal: string, network: string, peer: string, st: string, created: string): string =>
+    `  ${id.padEnd(w.id)}  ${principal.padEnd(w.principal)}  ${network.padEnd(w.network)}  ${peer.padEnd(w.peer)}  ${st.padEnd(w.status)}  ${created}`;
+  const lines = [header, "", row("REQUEST-ID", "PRINCIPAL", "NETWORK", "PEER_PUBKEY", "STATUS", "CREATED")];
+  for (const c of cells) lines.push(row(c.id, c.principal, c.network, c.peer, c.status, c.created));
+  lines.push("", `To admit: cortex network admit <request-id> --admin-seed <path> --apply`, "");
+  return lines.join("\n");
+}
+
+/**
+ * `cortex network admit --list-pending [--status <s>] [--network <id>] --admin-seed <path> [--registry-url <url>] [--json]`
+ *
+ * C-1314 — the admission-queue DISCOVERY surface. An admin can't otherwise find
+ * a request-id from the CLI (the alternatives were the MC Pier queue or a
+ * hand-signed GET). Admin-signs a read claim into the `x-admin-signed` header
+ * (reuses {@link buildAdmissionReadHeader} — no nonce, reads are idempotent) and
+ * GETs `/admission-requests?status=<status>`, mirroring the admit apply-path
+ * read + `findAdmittedRow`. Read-only: no --apply, no request-id positional.
+ *
+ * ADR-0020 read-scoping limitation: admin READS are GLOBAL-admin-only today
+ * (the registry list route gates on `parseAdminPubkeys` — the global allowlist —
+ * NOT the target network's per-network admins). So a PER-NETWORK admin gets a
+ * 403 here even for their own network; we surface that readably (never a silent
+ * empty table) and point at the fast-follow. `--network` is a CLIENT-side filter
+ * (the endpoint returns every network's rows at once).
+ */
+async function runListPending(flags: FlagMap, json: boolean): Promise<ExitResult> {
+  // --admin-seed required: the list is admin-signed (no anonymous read).
+  const seedRes = requireValueFlag(flags, "--admin-seed");
+  if (!seedRes.ok) {
+    return usageError(
+      "admit",
+      `${seedRes.reason} — --list-pending admin-signs the query, so pass --admin-seed <path>`,
+      json,
+    );
+  }
+
+  // --status defaults to PENDING (the discovery case); validate the enum.
+  const statusRaw = optionalValueFlag(flags, "--status") ?? "PENDING";
+  const status = statusRaw.toUpperCase();
+  if (!(LIST_STATUSES as readonly string[]).includes(status)) {
+    return usageError("admit", `--status "${statusRaw}" must be one of ${LIST_STATUSES.join(", ")}`, json);
+  }
+
+  // --network is a CLIENT-side filter over the (all-networks) response.
+  const networkFilter = optionalValueFlag(flags, "--network");
+  if (networkFilter !== undefined && !NETWORK_ID_RE.test(networkFilter)) {
+    return usageError(
+      "admit",
+      `--network "${networkFilter}" must be lowercase alphanumeric + hyphen, letter-prefixed`,
+      json,
+    );
+  }
+
+  const registryUrl = optionalValueFlag(flags, "--registry-url") ?? DEFAULT_ADMIT_REGISTRY_URL;
+
+  const matRes = await adminMaterialFromSeedFile(seedRes.value);
+  if (!matRes.ok) return opError("admit", matRes.reason, json);
+  const material = matRes.material;
+
+  let rows: AdmissionListRow[];
+  try {
+    const readHeader = await buildAdmissionReadHeader(material);
+    const getUrl = `${registryUrl.replace(/\/+$/, "")}/admission-requests?status=${encodeURIComponent(status)}`;
+    const resp = await globalThis.fetch(getUrl, {
+      method: "GET",
+      headers: { "Content-Type": "application/json", "x-admin-signed": readHeader },
+    });
+    if (resp.status === 403) {
+      // ADR-0020 read-scoping: reads are global-admin-only. A per-network admin
+      // lands here even for their own network — surface it readably rather than
+      // as a silent empty table.
+      const body = await resp.text();
+      return opError(
+        "admit",
+        `registry refused the list (HTTP 403 admin_not_authorized): admission reads are ` +
+          `GLOBAL-admin-only today, so a per-network admin cannot list PENDING requests` +
+          `${networkFilter !== undefined ? ` for "${networkFilter}"` : ""} from the CLI yet. ` +
+          `Per-network read-scoping is the ADR-0020 fast-follow; until then use a global-admin ` +
+          `seed or the MC admission queue (Pier). Registry said: ${body}`,
+        json,
+      );
+    }
+    if (!resp.ok) {
+      const body = await resp.text();
+      return opError("admit", `registry list failed (HTTP ${resp.status.toString()}): ${body}`, json);
+    }
+    rows = (await resp.json()) as AdmissionListRow[];
+  } catch (err) {
+    return opError(
+      "admit",
+      `failed to list admission requests from registry: ${err instanceof Error ? err.message : String(err)}`,
+      json,
+    );
+  }
+
+  const filtered =
+    networkFilter !== undefined ? rows.filter((r) => r.network_id === networkFilter) : rows;
+
+  if (json) {
+    return ok(
+      renderJson(
+        envelopeOk(filtered, {
+          subcommand: "admit",
+          mode: "list-pending",
+          status,
+          ...(networkFilter !== undefined && { network: networkFilter }),
+          registry_url: registryUrl,
+          admin_fingerprint: material.fingerprint,
+          count: filtered.length.toString(),
+        }),
+      ),
+    );
+  }
+  return ok(renderPendingTable(filtered, status, networkFilter, registryUrl));
+}
+
 /**
  * `cortex network admit <request-id> --admin-seed <path> [--apply]`
  *
@@ -1561,8 +1737,16 @@ async function runAdmit(
   flags: FlagMap,
   json: boolean,
 ): Promise<ExitResult> {
+  // C-1314 — DISCOVERY mode. `--list-pending` is a read-only query for the
+  // admission queue (no request-id positional, no --apply). Route it before the
+  // request-id gate so `cortex network admit --list-pending` doesn't trip the
+  // "missing request-id" usage error.
+  if (flags["--list-pending"] === true) {
+    return runListPending(flags, json);
+  }
+
   if (!requestId) {
-    return usageError("admit", "missing request-id (usage: cortex network admit <request-id> --network <id> --admin-seed <path>)", json);
+    return usageError("admit", "missing request-id (usage: cortex network admit <request-id> --admin-seed <path>; discover ids with `cortex network admit --list-pending --admin-seed <path>`)", json);
   }
 
   const seedRes = requireValueFlag(flags, "--admin-seed");
@@ -2423,9 +2607,11 @@ Usage:
   cortex network status [--principal <id>] [--stack <id>] [--monitor-url <url>] [--json]
   cortex network create <network> --hub <tls-url> --leaf-port <port> --admin-seed <path> [--network-admins <csv>] [--registry-url <url>] [--apply]
   cortex network ping   <peer> [--assistant <a>] [--network <id>] [--count N] [--timeout <ms>] [--json]
-  cortex network admit  <request-id> --admin-seed <path> [--network <id>] [--registry-url <url>]
+  cortex network admit  <request-id> --admin-seed <path> [--registry-url <url>]
                         [--discord-member <id>] [--discord-guild <id>] [--discord-server <profile>]
                         [--discord-role <name>] [--apply] [--dry-run] [--json]
+  cortex network admit  --list-pending [--status <PENDING|ADMITTED|REJECTED>] [--network <id>]
+                        --admin-seed <path> [--registry-url <url>] [--json]
   cortex network provision <stack> [--config <p>] [--principal <id>] [--seed-path <p>]
                         [--creds <p>] [--force] [--apply] [--dry-run] [--json]
   cortex network make-live <stack> [--config <p>] [--principal <id>] [--nats-config <p>]
@@ -2515,6 +2701,14 @@ Subcommands:
           Mints nothing (no arc nats add-bot call — Model-A retired). Optionally
           assigns the Discord community-fleet role (O-5) via --discord-member.
           DRY-RUN by default; pass --apply to execute.
+          --list-pending (C-1314): DISCOVERY mode — admin-signs a read and lists
+          the admission queue (request-id · principal · network · peer · status ·
+          created) so you can find the id to admit. Read-only (no --apply).
+          --status defaults to PENDING; --network filters the rows client-side.
+          NOTE (ADR-0020 read-scoping): admin READS are GLOBAL-admin-only today,
+          so a per-network admin gets a readable 403 here even for their own
+          network (per-network read-scoping is the fast-follow). Use a global-
+          admin seed or the MC admission queue until then.
 
   join public   (S5, #739) Opt into the PUBLIC scope — the open square of the
           Internet of Agentic Work. Announces --capabilities to the registry


### PR DESCRIPTION
## What
Admins can now discover PENDING admission request-ids from the CLI (was: MC Pier queue or a hand-signed GET only). `cortex network admit --list-pending [--status <s>] [--network <id>] --admin-seed <p> [--json]` admin-signs the existing `GET /admission-requests?status=` and renders a table (request-id, principal, peer fingerprint, network, created). Read-only; reuses the same admin-signed GET the admit apply-path already uses.

## Verified contract (against the registry route, not help text)
`GET /admission-requests?status=` — status REQUIRED (400 otherwise); auth via `x-admin-signed` header (sig over canonicalJSON(claim), 5-min skew, no nonce); **GLOBAL-admin-only** reads (per-network admin gets 403 — the ADR-0020 read-scoping gap). Endpoint does not filter by network, so `--network` is client-side. The 403 is caught + surfaced readably (exit 1, names the network + the ADR-0020 fast-follow + suggests a global-admin seed / MC Pier), never a silent empty table. Documented in help + SOP §5.

## Note — shared-file change
`_shared/parser.ts`: a positional name ending in `?` is now OPTIONAL (admit positional became optional so discovery mode needs no request-id; admit-a-request still validates it in runAdmit). Additive, backward-compatible (nothing else uses the trailing `?`), covered by the full parser suite. Flagging as it is outside the admit file.

## Verify
`tsc --noEmit` 0 · `network-admit.test.ts` 22 pass/0 fail (+6) · `src/cli/cortex/commands` 1056 pass/0 fail · carve-out PASS.

Closes #1314. Epic #1346 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB
