### PR TITLE
fix(network): C-1317 — target hub reload at the specific nats-server (multi-stack safe)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-secret-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-adapters.test.ts
@@ -1,0 +1,147 @@
+/**
+ * #1317 — live HubAuthPort reload-targeting tests.
+ *
+ * The bug: the reload shelled out to a BARE `nats-server --signal reload`, which
+ * refuses when >1 nats-server runs (the normal multi-stack state). These tests
+ * drive the LIVE adapter's `reload()` with injected exec / process-lister /
+ * signal seams + a real temp hub config, and assert it targets the SPECIFIC
+ * hub PID:
+ *   - config-path match: SIGHUP goes to the one nats-server loading THIS conf,
+ *     amongst several
+ *   - pid_file declared: SIGHUP goes to the pid_file's PID (no process scan)
+ *   - no match: reload throws (never signals a wrong server)
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createUser } from "nkeys.js";
+import { buildLiveSecretPorts } from "../network-secret-adapters";
+import type { NatsProcess } from "../../../../common/nats/hub-reload-target";
+import { materialFromSeedString } from "../../../../bus/stack-provisioning";
+
+let tmp: string;
+let hubConf: string;
+
+function material() {
+  return materialFromSeedString(new TextDecoder().decode(createUser().getSeed()));
+}
+
+// A gate exec that always passes (nats-server -c <conf> -t → code 0).
+const passingGate = async () => ({ code: 0, stderr: "" });
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "secret-adapter-"));
+  hubConf = join(tmp, "local.conf");
+  writeFileSync(hubConf, "leafnodes {\n  listen: 0.0.0.0:7422\n}\n", { mode: 0o600 });
+  chmodSync(hubConf, 0o600);
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+describe("reload targeting — config-path match", () => {
+  test("SIGHUPs the one nats-server serving THIS config amongst several", async () => {
+    const signalled: { pid: number; sig: string }[] = [];
+    const processes: NatsProcess[] = [
+      { pid: 2264, command: `nats-server -c ${join(tmp, "community.conf")} -js` },
+      { pid: 2265, command: `nats-server -c ${hubConf} -js` },
+      { pid: 2266, command: `nats-server -c ${join(tmp, "halden.conf")} -js` },
+    ];
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: passingGate,
+      psLister: async () => processes,
+      signal: (pid, sig) => signalled.push({ pid, sig }),
+    });
+
+    await ports.hub.reload();
+    expect(signalled).toEqual([{ pid: 2265, sig: "SIGHUP" }]);
+  });
+
+  test("no nats-server serving this config → reload throws (no wrong signal)", async () => {
+    const signalled: number[] = [];
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: passingGate,
+      psLister: async () => [{ pid: 1, command: `nats-server -c ${join(tmp, "other.conf")}` }],
+      signal: (pid) => signalled.push(pid),
+    });
+
+    let err: unknown;
+    try {
+      await ports.hub.reload();
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/could not target the hub reload/);
+    expect(signalled.length).toBe(0);
+  });
+});
+
+describe("reload targeting — pid_file declared", () => {
+  test("SIGHUPs the pid_file's PID without scanning processes", async () => {
+    const pidFile = join(tmp, "nats.pid");
+    writeFileSync(pidFile, "8123\n");
+    writeFileSync(hubConf, `pid_file: "${pidFile}"\nleafnodes {\n  listen: 0.0.0.0:7422\n}\n`, { mode: 0o600 });
+
+    const signalled: { pid: number; sig: string }[] = [];
+    let listerCalled = false;
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: passingGate,
+      psLister: async () => {
+        listerCalled = true;
+        return [];
+      },
+      signal: (pid, sig) => signalled.push({ pid, sig }),
+    });
+
+    await ports.hub.reload();
+    expect(signalled).toEqual([{ pid: 8123, sig: "SIGHUP" }]);
+    // pid_file is authoritative — we must NOT have scanned the process list.
+    expect(listerCalled).toBe(false);
+  });
+
+  test("pid_file declared but missing on disk → falls back to process match", async () => {
+    writeFileSync(hubConf, `pid_file: "${join(tmp, "absent.pid")}"\nleafnodes {}\n`, { mode: 0o600 });
+    const signalled: number[] = [];
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: passingGate,
+      psLister: async () => [{ pid: 555, command: `nats-server -c ${hubConf}` }],
+      signal: (pid) => signalled.push(pid),
+    });
+    await ports.hub.reload();
+    expect(signalled).toEqual([555]);
+  });
+});
+
+describe("reload — gate failure still gates", () => {
+  test("a failing -t syntax gate aborts the reload (no signal)", async () => {
+    const signalled: number[] = [];
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: async () => ({ code: 1, stderr: "parse error" }),
+      psLister: async () => [{ pid: 1, command: `nats-server -c ${hubConf}` }],
+      signal: (pid) => signalled.push(pid),
+    });
+    let err: unknown;
+    try {
+      await ports.hub.reload();
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/-t exited 1/);
+    expect(signalled.length).toBe(0);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-secret-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-adapters.test.ts
@@ -1,15 +1,23 @@
 /**
- * #1317 — live HubAuthPort reload-targeting tests.
+ * #1317 / #1396 — live HubAuthPort reload-targeting tests.
  *
- * The bug: the reload shelled out to a BARE `nats-server --signal reload`, which
- * refuses when >1 nats-server runs (the normal multi-stack state). These tests
- * drive the LIVE adapter's `reload()` with injected exec / process-lister /
- * signal seams + a real temp hub config, and assert it targets the SPECIFIC
- * hub PID:
+ * The #1317 bug: the reload shelled out to a BARE `nats-server --signal reload`,
+ * which refuses when >1 nats-server runs (the normal multi-stack state). These
+ * tests drive the LIVE adapter's `reload()` with injected exec / process-lister /
+ * inspector / signal seams + a real temp hub config, and assert it targets the
+ * SPECIFIC hub PID:
  *   - config-path match: SIGHUP goes to the one nats-server loading THIS conf,
  *     amongst several
  *   - pid_file declared: SIGHUP goes to the pid_file's PID (no process scan)
  *   - no match: reload throws (never signals a wrong server)
+ *
+ * The #1396 trust-path hardening: before signalling, the adapter re-reads the
+ * target PID's LIVE argv and refuses unless it is still a nats-server serving
+ * THIS config. The invariant under test — **never signal an unverified PID**:
+ *   - pid_file points at a live-but-NON-nats process → fail loud, no signal
+ *   - pid_file points at a nats-server for a DIFFERENT config → fail loud
+ *   - target PID no longer exists (recycled/exited) → fail loud
+ *   - argv matches → signals exactly once
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -17,7 +25,7 @@ import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createUser } from "nkeys.js";
-import { buildLiveSecretPorts } from "../network-secret-adapters";
+import { buildLiveSecretPorts, type NatsProcessInspector } from "../network-secret-adapters";
 import type { NatsProcess } from "../../../../common/nats/hub-reload-target";
 import { materialFromSeedString } from "../../../../bus/stack-provisioning";
 
@@ -30,6 +38,15 @@ function material() {
 
 // A gate exec that always passes (nats-server -c <conf> -t → code 0).
 const passingGate = async () => ({ code: 0, stderr: "" });
+
+/**
+ * Build a per-PID argv inspector from a pid→command map — the #1396 re-check
+ * seam. A PID absent from the map reads as "no such process" (undefined), which
+ * the adapter treats as a fail-loud (the PID exited / was recycled).
+ */
+function inspectorFrom(map: Record<number, string>): NatsProcessInspector {
+  return async (pid) => (pid in map ? map[pid] : undefined);
+}
 
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), "secret-adapter-"));
@@ -53,6 +70,8 @@ describe("reload targeting — config-path match", () => {
       material: material(),
       exec: passingGate,
       psLister: async () => processes,
+      // Re-check reads the target's live argv — still the hub's nats-server.
+      inspect: inspectorFrom({ 2265: `nats-server -c ${hubConf} -js` }),
       signal: (pid, sig) => signalled.push({ pid, sig }),
     });
 
@@ -68,6 +87,7 @@ describe("reload targeting — config-path match", () => {
       material: material(),
       exec: passingGate,
       psLister: async () => [{ pid: 1, command: `nats-server -c ${join(tmp, "other.conf")}` }],
+      inspect: inspectorFrom({}),
       signal: (pid) => signalled.push(pid),
     });
 
@@ -99,12 +119,15 @@ describe("reload targeting — pid_file declared", () => {
         listerCalled = true;
         return [];
       },
+      // The pid_file's PID re-checks as the hub's nats-server → signalled.
+      inspect: inspectorFrom({ 8123: `nats-server -c ${hubConf} -js` }),
       signal: (pid, sig) => signalled.push({ pid, sig }),
     });
 
     await ports.hub.reload();
     expect(signalled).toEqual([{ pid: 8123, sig: "SIGHUP" }]);
-    // pid_file is authoritative — we must NOT have scanned the process list.
+    // pid_file is authoritative for RESOLUTION — we must NOT have scanned the
+    // process list. (The argv re-check inspects only that one PID, not the list.)
     expect(listerCalled).toBe(false);
   });
 
@@ -117,10 +140,121 @@ describe("reload targeting — pid_file declared", () => {
       material: material(),
       exec: passingGate,
       psLister: async () => [{ pid: 555, command: `nats-server -c ${hubConf}` }],
+      inspect: inspectorFrom({ 555: `nats-server -c ${hubConf}` }),
       signal: (pid) => signalled.push(pid),
     });
     await ports.hub.reload();
     expect(signalled).toEqual([555]);
+  });
+});
+
+describe("reload — #1396 trust-path: never signal an unverified PID", () => {
+  test("pid_file points at a live-but-NON-nats process → fail loud, no signal", async () => {
+    // Stale pid_file: the hub crashed, its PID (8123) was recycled onto an
+    // unrelated process. The blind path would SIGHUP-terminate it; the re-check
+    // must refuse.
+    const pidFile = join(tmp, "nats.pid");
+    writeFileSync(pidFile, "8123\n");
+    writeFileSync(hubConf, `pid_file: "${pidFile}"\nleafnodes {}\n`, { mode: 0o600 });
+
+    const signalled: number[] = [];
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: passingGate,
+      psLister: async () => [],
+      inspect: inspectorFrom({ 8123: "/usr/bin/postgres -D /var/lib/pg" }),
+      signal: (pid) => signalled.push(pid),
+    });
+
+    let err: unknown;
+    try {
+      await ports.hub.reload();
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/refusing to SIGHUP pid 8123/);
+    expect(String(err)).toMatch(/pid_file/);
+    expect(signalled.length).toBe(0);
+  });
+
+  test("pid_file points at a nats-server for a DIFFERENT config → fail loud, no signal", async () => {
+    const pidFile = join(tmp, "nats.pid");
+    writeFileSync(pidFile, "8123\n");
+    writeFileSync(hubConf, `pid_file: "${pidFile}"\nleafnodes {}\n`, { mode: 0o600 });
+
+    const signalled: number[] = [];
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: passingGate,
+      psLister: async () => [],
+      // A real nats-server — but serving a DIFFERENT config. Must not be signalled.
+      inspect: inspectorFrom({ 8123: `nats-server -c ${join(tmp, "other.conf")} -js` }),
+      signal: (pid) => signalled.push(pid),
+    });
+
+    let err: unknown;
+    try {
+      await ports.hub.reload();
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/refusing to SIGHUP pid 8123/);
+    expect(signalled.length).toBe(0);
+  });
+
+  test("config-match target exits before signal (recycled/gone) → fail loud, no signal", async () => {
+    // config-match found pid 2265, but between enumeration and signal it exited —
+    // the inspector reports no such process. The TOCTOU re-check must refuse.
+    const signalled: number[] = [];
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: passingGate,
+      psLister: async () => [{ pid: 2265, command: `nats-server -c ${hubConf} -js` }],
+      inspect: inspectorFrom({}), // 2265 no longer alive
+      signal: (pid) => signalled.push(pid),
+    });
+
+    let err: unknown;
+    try {
+      await ports.hub.reload();
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/refusing to SIGHUP pid 2265/);
+    expect(String(err)).toMatch(/<no such process>/);
+    expect(signalled.length).toBe(0);
+  });
+});
+
+describe("reload — signal-throw (EPERM) fails loud", () => {
+  test("a throwing signal sender is wrapped + rethrown, naming pid + via", async () => {
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      exec: passingGate,
+      psLister: async () => [{ pid: 2265, command: `nats-server -c ${hubConf} -js` }],
+      inspect: inspectorFrom({ 2265: `nats-server -c ${hubConf} -js` }),
+      signal: () => {
+        throw new Error("kill EPERM");
+      },
+    });
+
+    let err: unknown;
+    try {
+      await ports.hub.reload();
+    } catch (e) {
+      err = e;
+    }
+    expect(String(err)).toMatch(/SIGHUP to hub nats-server pid 2265/);
+    expect(String(err)).toMatch(/via config-match/);
+    expect(String(err)).toMatch(/EPERM/);
   });
 });
 

--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -3,11 +3,19 @@
  *
  * The real side effects the orchestrator (`network-secret-lib.ts`) depends on:
  *   - HUB-LOCAL: read/write the hub nats-server config (chmod 600 — it carries
- *     leaf secrets) + reload it (`nats-server --signal reload`, SIGHUP — an
- *     in-place authorization reload, no restart). A `-c <conf> -t` syntax gate
- *     runs first so a malformed config never reaches a live reload.
+ *     leaf secrets) + reload it (SIGHUP — an in-place authorization reload, no
+ *     restart). A `-c <conf> -t` syntax gate runs first so a malformed config
+ *     never reaches a live reload.
  *   - REGISTRY: the admin-signed admission-row LOOKUP + the hub-admin-signed
  *     sealed-secret delivery / revoke POSTs.
+ *
+ * #1317 — the reload targets the SPECIFIC hub process that serves THIS config,
+ * never a bare `nats-server --signal reload` (which refuses the moment >1
+ * nats-server runs locally — the normal multi-stack state). Resolution order:
+ * the config's `pid_file` (preferred — the server's authoritative self-report)
+ * → `nats-server --signal reload=<pid>`; otherwise the running nats-server whose
+ * argv loads this config path → `kill -SIGHUP <pid>`. See
+ * {@link file://../../../common/nats/hub-reload-target.ts} for the pure core.
  *
  * These are ONLY constructed on a real `--apply` (or dry-run, which still reads).
  * The orchestrator gates every MUTATION on `apply`, so the live mutating methods
@@ -22,6 +30,11 @@ import { canonicalJSON } from "../../../common/registry/signing";
 import { sealToPrincipal } from "../../../common/crypto/seal-to-principal";
 import { mintLeafPsk } from "../../../common/nats/leaf-psk";
 import {
+  readPidFileDirective,
+  resolveHubReloadTarget,
+  type NatsProcess,
+} from "../../../common/nats/hub-reload-target";
+import {
   signClaimWithSeed,
   randomNonce,
   type StackIdentityMaterial,
@@ -35,6 +48,41 @@ import type {
   SecretCrypto,
 } from "./network-secret-ports";
 
+/**
+ * Enumerate the running nats-server processes (pid + full command line). Used to
+ * find the process serving a given hub config when no `pid_file` is declared.
+ * Injected so tests assert reload-targeting without spawning `ps`.
+ */
+export type NatsProcessLister = () => Promise<NatsProcess[]>;
+
+/** Send `signal` (e.g. "SIGHUP") to `pid`. Injected so tests don't kill PIDs. */
+export type SignalSender = (pid: number, signal: NodeJS.Signals) => void;
+
+/** Real `ps`-backed process lister: every running nats-server with its argv. */
+export const bunNatsProcessLister: NatsProcessLister = async () => {
+  // `ps -axww -o pid=,command=` — no header, unlimited-width command column so a
+  // long `-c <path>` is never truncated. Filter to nats-server invocations.
+  const proc = Bun.spawn(["ps", "-axww", "-o", "pid=,command="], { stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+  const out = await new Response(proc.stdout).text();
+  const procs: NatsProcess[] = [];
+  for (const line of out.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    const sp = trimmed.indexOf(" ");
+    if (sp < 0) continue;
+    const pid = Number.parseInt(trimmed.slice(0, sp), 10);
+    const command = trimmed.slice(sp + 1).trim();
+    if (!Number.isInteger(pid)) continue;
+    // Match the nats-server binary at the head of the command (path-tolerant).
+    if (/(^|\/)nats-server(\s|$)/.test(command)) procs.push({ pid, command });
+  }
+  return procs;
+};
+
+/** Real `process.kill`-backed signal sender. */
+export const bunSignalSender: SignalSender = (pid, signal) => process.kill(pid, signal);
+
 export interface LiveSecretPortsConfig {
   /** The hub nats-server config path (carries the leaf authorization users). */
   hubConfigPath: string;
@@ -44,6 +92,10 @@ export interface LiveSecretPortsConfig {
   material: StackIdentityMaterial;
   /** Injectable exec runner (tests). Production omits → bunExecRunner. */
   exec?: ExecRunner;
+  /** Injectable nats-server process lister (tests). Production omits → ps-backed. */
+  psLister?: NatsProcessLister;
+  /** Injectable signal sender (tests). Production omits → process.kill. */
+  signal?: SignalSender;
   /** Injectable fetch (tests). Production omits → globalThis.fetch. */
   fetchImpl?: typeof globalThis.fetch;
 }
@@ -65,6 +117,8 @@ export function buildLiveSecretPorts(cfg: LiveSecretPortsConfig): NetworkSecretP
 function buildLiveHubAuthPort(cfg: LiveSecretPortsConfig): HubAuthPort {
   const confPath = expandTilde(cfg.hubConfigPath);
   const exec = cfg.exec ?? bunExecRunner;
+  const psLister = cfg.psLister ?? bunNatsProcessLister;
+  const sendSignal = cfg.signal ?? bunSignalSender;
   return {
     confPath,
     readConf(): Promise<string> {
@@ -99,13 +153,64 @@ function buildLiveHubAuthPort(cfg: LiveSecretPortsConfig): HubAuthPort {
           `cortex network secret: skipping nats-server -t gate (could not run nats-server: ${err instanceof Error ? err.message : String(err)})\n`,
         );
       }
-      // SIGHUP reload — nats-server applies authorization changes in place.
-      const reload = await exec(["nats-server", "--signal", "reload"]);
-      if (reload.code !== 0) {
-        throw new Error(`nats-server --signal reload exited ${reload.code.toString()}: ${reload.stderr.trim()}`);
+
+      // #1317 — reload the SPECIFIC hub that serves THIS config, never a bare
+      // `nats-server --signal reload` (it refuses when >1 nats-server runs —
+      // the normal multi-stack state). Prefer the config's `pid_file`; else
+      // match the running nats-server whose argv loads this config path.
+      const pidFromPidFile = readPidFromHubConfig(confPath);
+      let processes: NatsProcess[] = [];
+      if (pidFromPidFile === undefined) {
+        // Only enumerate when we have to (no pid_file to lean on).
+        processes = await psLister();
+      }
+      const targetRes = resolveHubReloadTarget(confPath, pidFromPidFile, processes);
+      if (!targetRes.ok) {
+        throw new Error(`could not target the hub reload: ${targetRes.reason}`);
+      }
+      // SIGHUP — nats-server applies authorization changes in place, no restart.
+      try {
+        sendSignal(targetRes.target.pid, "SIGHUP");
+      } catch (err) {
+        throw new Error(
+          `SIGHUP to hub nats-server pid ${targetRes.target.pid.toString()} ` +
+            `(resolved via ${targetRes.target.via}) failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
       }
     },
   };
+}
+
+/**
+ * If the hub config at `confPath` declares a `pid_file`, read the PID it holds.
+ * Returns `undefined` when no `pid_file` is declared OR the file is absent /
+ * unreadable / malformed — the caller then falls back to config-path matching.
+ */
+function readPidFromHubConfig(confPath: string): number | undefined {
+  let confText: string;
+  try {
+    confText = readFileSync(confPath, "utf-8");
+  } catch (_err) {
+    // The conf was just written by the orchestrator; an unreadable read here is
+    // unexpected but non-fatal — fall back to process matching.
+    return undefined;
+  }
+  const declared = readPidFileDirective(confText);
+  if (declared === undefined) return undefined;
+  const pidPath = expandTilde(declared);
+  if (!existsSync(pidPath)) return undefined;
+  let raw: string;
+  try {
+    raw = readFileSync(pidPath, "utf-8").trim();
+  } catch (err) {
+    process.stderr.write(
+      `cortex network secret: pid_file ${pidPath} declared but unreadable (${err instanceof Error ? err.message : String(err)}); falling back to process match\n`,
+    );
+    return undefined;
+  }
+  const pid = Number.parseInt(raw, 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -12,10 +12,18 @@
  * #1317 — the reload targets the SPECIFIC hub process that serves THIS config,
  * never a bare `nats-server --signal reload` (which refuses the moment >1
  * nats-server runs locally — the normal multi-stack state). Resolution order:
- * the config's `pid_file` (preferred — the server's authoritative self-report)
- * → `nats-server --signal reload=<pid>`; otherwise the running nats-server whose
- * argv loads this config path → `kill -SIGHUP <pid>`. See
- * {@link file://../../../common/nats/hub-reload-target.ts} for the pure core.
+ * the config's `pid_file` (preferred — the server's self-report); otherwise the
+ * running nats-server whose argv loads this config path.
+ *
+ * #1396 (trust-path) — a resolved PID is NOT signalled blind. A `pid_file`
+ * survives a crash / `kill -9` and its PID can recycle onto an innocent process,
+ * and the enumerate→signal step has a TOCTOU window; so immediately before the
+ * SIGHUP we re-read the target PID's LIVE argv (`ps -p <pid> -o command=`) and
+ * refuse unless it is still a nats-server loading THIS config
+ * ({@link argvIsNatsServerForConfig}). The signal is a raw `process.kill(pid,
+ * "SIGHUP")` — the argv re-check, not a nats-aware `--signal reload=<pid>` form,
+ * is the safety. See {@link file://../../../common/nats/hub-reload-target.ts}
+ * for the pure core + the argv predicate.
  *
  * These are ONLY constructed on a real `--apply` (or dry-run, which still reads).
  * The orchestrator gates every MUTATION on `apply`, so the live mutating methods
@@ -23,6 +31,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, chmodSync, renameSync } from "fs";
+import { resolve as resolvePath } from "path";
 
 import { expandTilde } from "../../../common/config/loader";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
@@ -32,6 +41,8 @@ import { mintLeafPsk } from "../../../common/nats/leaf-psk";
 import {
   readPidFileDirective,
   resolveHubReloadTarget,
+  argvIsNatsServerForConfig,
+  isNatsServerCommand,
   type NatsProcess,
 } from "../../../common/nats/hub-reload-target";
 import {
@@ -58,6 +69,13 @@ export type NatsProcessLister = () => Promise<NatsProcess[]>;
 /** Send `signal` (e.g. "SIGHUP") to `pid`. Injected so tests don't kill PIDs. */
 export type SignalSender = (pid: number, signal: NodeJS.Signals) => void;
 
+/**
+ * Read the full command line (argv joined) of a SINGLE running PID, or undefined
+ * when the PID is not alive / not readable. Used for the pre-signal argv re-check
+ * (#1396). Injected so the trust-path re-check is testable without real processes.
+ */
+export type NatsProcessInspector = (pid: number) => Promise<string | undefined>;
+
 /** Real `ps`-backed process lister: every running nats-server with its argv. */
 export const bunNatsProcessLister: NatsProcessLister = async () => {
   // `ps -axww -o pid=,command=` — no header, unlimited-width command column so a
@@ -74,10 +92,24 @@ export const bunNatsProcessLister: NatsProcessLister = async () => {
     const pid = Number.parseInt(trimmed.slice(0, sp), 10);
     const command = trimmed.slice(sp + 1).trim();
     if (!Number.isInteger(pid)) continue;
-    // Match the nats-server binary at the head of the command (path-tolerant).
-    if (/(^|\/)nats-server(\s|$)/.test(command)) procs.push({ pid, command });
+    // Match the nats-server binary at the head of the command (path-tolerant) —
+    // the ONE definition lives in the pure core, reused by the argv re-check.
+    if (isNatsServerCommand(command)) procs.push({ pid, command });
   }
   return procs;
+};
+
+/**
+ * Real `ps -p <pid> -o command=`-backed inspector: the live argv of one PID.
+ * Empty output / non-zero exit (no such process) → undefined. Portable across
+ * macOS + Linux; `/proc/<pid>/cmdline` would be a Linux-only alternative.
+ */
+export const bunNatsProcessInspector: NatsProcessInspector = async (pid) => {
+  const proc = Bun.spawn(["ps", "-p", pid.toString(), "-o", "command="], { stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+  if (proc.exitCode !== 0) return undefined; // no such process
+  const out = (await new Response(proc.stdout).text()).trim();
+  return out === "" ? undefined : out;
 };
 
 /** Real `process.kill`-backed signal sender. */
@@ -94,6 +126,8 @@ export interface LiveSecretPortsConfig {
   exec?: ExecRunner;
   /** Injectable nats-server process lister (tests). Production omits → ps-backed. */
   psLister?: NatsProcessLister;
+  /** Injectable per-PID argv inspector (tests). Production omits → `ps -p`-backed. */
+  inspect?: NatsProcessInspector;
   /** Injectable signal sender (tests). Production omits → process.kill. */
   signal?: SignalSender;
   /** Injectable fetch (tests). Production omits → globalThis.fetch. */
@@ -118,6 +152,7 @@ function buildLiveHubAuthPort(cfg: LiveSecretPortsConfig): HubAuthPort {
   const confPath = expandTilde(cfg.hubConfigPath);
   const exec = cfg.exec ?? bunExecRunner;
   const psLister = cfg.psLister ?? bunNatsProcessLister;
+  const inspectProcess = cfg.inspect ?? bunNatsProcessInspector;
   const sendSignal = cfg.signal ?? bunSignalSender;
   return {
     confPath,
@@ -168,13 +203,34 @@ function buildLiveHubAuthPort(cfg: LiveSecretPortsConfig): HubAuthPort {
       if (!targetRes.ok) {
         throw new Error(`could not target the hub reload: ${targetRes.reason}`);
       }
+
+      // #1396 trust-path — NEVER signal an unverified PID. Whether the target came
+      // from the pid_file (which survives a crash/`kill -9` and can point at a
+      // recycled, unrelated PID) or from config-match (a sub-ms enumerate→signal
+      // TOCTOU window), re-read its LIVE argv HERE, immediately before the SIGHUP,
+      // and refuse unless it is still a nats-server loading THIS config. SIGHUP's
+      // default disposition is TERMINATE, so an unverified signal could kill an
+      // innocent process. Both paths funnel through the ONE argv predicate.
+      const { pid, via } = targetRes.target;
+      const liveArgv = await inspectProcess(pid);
+      if (liveArgv === undefined || !argvIsNatsServerForConfig(liveArgv, confPath)) {
+        throw new Error(
+          `refusing to SIGHUP pid ${pid.toString()} (resolved via ${via}): its live argv is not a ` +
+            `nats-server serving ${resolvePath(confPath)} — argv: ${liveArgv ?? "<no such process>"}. ` +
+            (via === "pid_file"
+              ? `The pid_file is likely STALE (the hub crashed and this PID was recycled onto another process). ` +
+                `Remove the stale pid_file or restart the hub, then retry.`
+              : `The hub likely exited between enumeration and reload. Restart it, then retry.`),
+        );
+      }
+
       // SIGHUP — nats-server applies authorization changes in place, no restart.
       try {
-        sendSignal(targetRes.target.pid, "SIGHUP");
+        sendSignal(pid, "SIGHUP");
       } catch (err) {
         throw new Error(
-          `SIGHUP to hub nats-server pid ${targetRes.target.pid.toString()} ` +
-            `(resolved via ${targetRes.target.via}) failed: ${err instanceof Error ? err.message : String(err)}`,
+          `SIGHUP to hub nats-server pid ${pid.toString()} ` +
+            `(resolved via ${via}) failed: ${err instanceof Error ? err.message : String(err)}`,
           { cause: err },
         );
       }

--- a/src/common/nats/__tests__/hub-reload-target.test.ts
+++ b/src/common/nats/__tests__/hub-reload-target.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #1317 — `resolveHubReloadTarget` + `readPidFileDirective` unit tests.
+ *
+ * The reload must target the SPECIFIC hub serving THIS config, never a bare
+ * signal. Proves:
+ *   - pid_file (when declared + readable) wins
+ *   - config-path match picks the right PID amongst many nats-servers
+ *   - zero / ambiguous matches fail LOUDLY (never signal a wrong server)
+ *   - the pid_file directive parser tolerates HOCON spelling variants
+ */
+
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+import {
+  readPidFileDirective,
+  resolveHubReloadTarget,
+  type NatsProcess,
+} from "../hub-reload-target";
+
+const HUB = "/Users/op/.config/nats/local.conf";
+const OTHER1 = "/Users/op/.config/nats/community.conf";
+const OTHER2 = "/Users/op/.config/nats/halden.conf";
+
+function proc(pid: number, configPath: string, extra = "-js"): NatsProcess {
+  return { pid, command: `nats-server -c ${configPath} ${extra}` };
+}
+
+describe("resolveHubReloadTarget — pid_file path", () => {
+  test("a valid pid_file PID wins, processes ignored", () => {
+    const res = resolveHubReloadTarget(HUB, 4242, [proc(1, OTHER1)]);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.target.pid).toBe(4242);
+      expect(res.target.via).toBe("pid_file");
+    }
+  });
+
+  test("an invalid pid_file PID fails (never falls through to a wrong match)", () => {
+    const res = resolveHubReloadTarget(HUB, 0, [proc(7, HUB)]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("invalid PID");
+  });
+});
+
+describe("resolveHubReloadTarget — config-path match (the multi-stack case)", () => {
+  test("picks the single nats-server loading THIS config amongst many", () => {
+    // The exact failure scenario from the bug: three nats-servers running.
+    const processes = [proc(2264, OTHER1), proc(2265, HUB), proc(2266, OTHER2)];
+    const res = resolveHubReloadTarget(HUB, undefined, processes);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.target.pid).toBe(2265);
+      expect(res.target.via).toBe("config-match");
+    }
+  });
+
+  test("matches --config=<path> fused form too", () => {
+    const processes: NatsProcess[] = [
+      { pid: 10, command: `nats-server --config=${HUB} -js` },
+      { pid: 11, command: `nats-server --config=${OTHER1}` },
+    ];
+    const res = resolveHubReloadTarget(HUB, undefined, processes);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.target.pid).toBe(10);
+  });
+
+  test("resolves relative vs absolute config paths to the same target", () => {
+    const rel = "./local.conf";
+    const abs = resolve(rel);
+    const res = resolveHubReloadTarget(abs, undefined, [proc(99, rel)]);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.target.pid).toBe(99);
+  });
+
+  test("ZERO matches fails loudly (hub not running under this config)", () => {
+    const res = resolveHubReloadTarget(HUB, undefined, [proc(1, OTHER1), proc(2, OTHER2)]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toContain("no running nats-server");
+      expect(res.reason).toContain(resolve(HUB));
+    }
+  });
+
+  test("AMBIGUOUS (2+ matches) fails loudly, names the PIDs", () => {
+    const res = resolveHubReloadTarget(HUB, undefined, [proc(3, HUB), proc(4, HUB)]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toContain("ambiguous");
+      expect(res.reason).toContain("3, 4");
+    }
+  });
+
+  test("does NOT match a server whose config merely contains the name as a substring", () => {
+    // `local.conf.bak` must not match `local.conf`.
+    const res = resolveHubReloadTarget(HUB, undefined, [proc(5, `${HUB}.bak`)]);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe("readPidFileDirective", () => {
+  test("colon form, quoted", () => {
+    expect(readPidFileDirective(`pid_file: "/var/run/nats.pid"\nlisten: 0.0.0.0:4222\n`)).toBe(
+      "/var/run/nats.pid",
+    );
+  });
+  test("equals form, unquoted", () => {
+    expect(readPidFileDirective(`pid_file = /run/nats.pid\n`)).toBe("/run/nats.pid");
+  });
+  test("single-quoted", () => {
+    expect(readPidFileDirective(`  pid_file: '/run/x.pid'`)).toBe("/run/x.pid");
+  });
+  test("absent → undefined", () => {
+    expect(readPidFileDirective(`listen: 0.0.0.0:4222\n`)).toBeUndefined();
+  });
+  test("does not false-match a key that merely ends in pid_file-ish text", () => {
+    // A commented or differently-named key must not be picked up.
+    expect(readPidFileDirective(`# my_pid_file_note: nope\nlisten: x\n`)).toBeUndefined();
+  });
+});

--- a/src/common/nats/__tests__/hub-reload-target.test.ts
+++ b/src/common/nats/__tests__/hub-reload-target.test.ts
@@ -14,6 +14,8 @@ import { resolve } from "path";
 import {
   readPidFileDirective,
   resolveHubReloadTarget,
+  argvIsNatsServerForConfig,
+  isNatsServerCommand,
   type NatsProcess,
 } from "../hub-reload-target";
 
@@ -94,6 +96,45 @@ describe("resolveHubReloadTarget — config-path match (the multi-stack case)", 
     // `local.conf.bak` must not match `local.conf`.
     const res = resolveHubReloadTarget(HUB, undefined, [proc(5, `${HUB}.bak`)]);
     expect(res.ok).toBe(false);
+  });
+});
+
+describe("argvIsNatsServerForConfig — the pre-signal trust-path predicate (#1396)", () => {
+  test("true iff argv is a nats-server AND loads THIS config", () => {
+    expect(argvIsNatsServerForConfig(`nats-server -c ${HUB} -js`, HUB)).toBe(true);
+    expect(argvIsNatsServerForConfig(`/opt/nats/nats-server --config=${HUB}`, HUB)).toBe(true);
+  });
+
+  test("false for a nats-server serving a DIFFERENT config (stale/recycled guard)", () => {
+    expect(argvIsNatsServerForConfig(`nats-server -c ${OTHER1} -js`, HUB)).toBe(false);
+  });
+
+  test("false for a NON-nats process even if the path appears (recycled PID guard)", () => {
+    // A recycled PID running an unrelated process that merely mentions the path.
+    expect(argvIsNatsServerForConfig(`/usr/bin/tail -f ${HUB}`, HUB)).toBe(false);
+    expect(argvIsNatsServerForConfig(`postgres -c ${HUB}`, HUB)).toBe(false);
+  });
+
+  test("false on empty / non-matching argv", () => {
+    expect(argvIsNatsServerForConfig("", HUB)).toBe(false);
+    expect(argvIsNatsServerForConfig("nats-server -c /some/other.conf", HUB)).toBe(false);
+  });
+
+  test("resolves relative vs absolute config paths equal", () => {
+    const abs = resolve("./local.conf");
+    expect(argvIsNatsServerForConfig(`nats-server -c ./local.conf`, abs)).toBe(true);
+  });
+});
+
+describe("isNatsServerCommand", () => {
+  test("matches the binary at head, path-tolerant", () => {
+    expect(isNatsServerCommand("nats-server -c x")).toBe(true);
+    expect(isNatsServerCommand("/opt/nats/nats-server -c x")).toBe(true);
+  });
+  test("does not match unrelated processes or substrings", () => {
+    expect(isNatsServerCommand("postgres -D /data")).toBe(false);
+    expect(isNatsServerCommand("my-nats-server-wrapper")).toBe(false);
+    expect(isNatsServerCommand("")).toBe(false);
   });
 });
 

--- a/src/common/nats/hub-reload-target.ts
+++ b/src/common/nats/hub-reload-target.ts
@@ -1,0 +1,145 @@
+/**
+ * #1317 — resolve WHICH nats-server process a `cortex network secret` reload
+ * must signal.
+ *
+ * ## The bug this closes
+ *
+ * The hub reload shelled out to a BARE `nats-server --signal reload` with no
+ * target. That form refuses the moment it sees more than one nats-server
+ * process running locally:
+ *
+ *     nats-server: multiple nats-server processes running: 2264 2265 2266
+ *
+ * which is the NORMAL multi-stack state (e.g. `community.conf`, `local.conf`,
+ * `halden.conf` all live at once). The command already knows exactly WHICH hub
+ * config it just wrote — it must reload THAT server, never a global scan.
+ *
+ * ## This module
+ *
+ * The PURE selection core, decoupled from any process exec so it is directly
+ * unit-testable. Two resolution paths, in priority order:
+ *
+ *   1. **`pid_file` directive** — if the hub config declares `pid_file: <path>`,
+ *      that file holds the running server's PID. Preferred: it is the server's
+ *      own authoritative self-report. → `nats-server --signal reload=<pid>`.
+ *   2. **config-path match** — otherwise, find the single running nats-server
+ *      whose argv carries `-c <thisHubConfig>` (the resolved absolute path).
+ *      → `kill -SIGHUP <pid>`.
+ *
+ * The I/O (reading the pid_file, listing processes, sending the signal) lives in
+ * the adapter (`network-secret-adapters.ts`); this module only decides the
+ * target from already-gathered inputs.
+ */
+
+import { resolve as resolvePath } from "path";
+
+/** A running nats-server process, as gathered by the adapter's process lister. */
+export interface NatsProcess {
+  /** The process id. */
+  pid: number;
+  /** The full command line (argv joined), e.g. `nats-server -c /…/local.conf -js`. */
+  command: string;
+}
+
+/**
+ * The resolved reload target. `pid` is the process to signal; `via` records how
+ * it was resolved (for plan/log output). `pidFilePath`, when present, is the
+ * pid_file the PID came from (the adapter prefers `--signal reload=<pid>`).
+ */
+export interface HubReloadTarget {
+  pid: number;
+  via: "pid_file" | "config-match";
+}
+
+export type HubReloadTargetResult =
+  | { ok: true; target: HubReloadTarget }
+  | { ok: false; reason: string };
+
+/**
+ * Read the `pid_file` directive from a nats-server config, if declared. HOCON
+ * permits `pid_file: "…"`, `pid_file = …`, with or without quotes. Returns the
+ * raw path (caller resolves `~`/relative), or `undefined` when absent.
+ */
+export function readPidFileDirective(confText: string): string | undefined {
+  // pid_file (NATS canonical) — tolerate `:` or `=`, optional quotes, any ws.
+  const m = /(^|\n)\s*pid_file\s*[:=]\s*("([^"]*)"|'([^']*)'|(\S+))/.exec(confText);
+  if (m === null) return undefined;
+  const raw = (m[3] ?? m[4] ?? m[5] ?? "").trim();
+  return raw === "" ? undefined : raw;
+}
+
+/** Does this process command load `configPath` via `-c`/`--config`? */
+function commandLoadsConfig(command: string, configPath: string): boolean {
+  // Tokenise on whitespace; match the resolved abs path against the value that
+  // follows `-c`/`--config`, or the `--config=<path>` fused form. Resolve both
+  // sides so `./local.conf` and an absolute path compare equal.
+  const want = resolvePath(configPath);
+  const toks = command.split(/\s+/).filter((t) => t.length > 0);
+  for (let i = 0; i < toks.length; i++) {
+    const t = toks[i] ?? "";
+    if ((t === "-c" || t === "--config") && i + 1 < toks.length) {
+      const val = toks[i + 1] ?? "";
+      if (resolvePath(stripQuotes(val)) === want) return true;
+    }
+    if (t.startsWith("--config=")) {
+      if (resolvePath(stripQuotes(t.slice("--config=".length))) === want) return true;
+    }
+  }
+  return false;
+}
+
+function stripQuotes(s: string): string {
+  if (s.length >= 2 && ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'")))) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+/**
+ * Resolve the reload target for the hub at `configPath`.
+ *
+ * @param configPath   the (already tilde-expanded) hub config path that was written.
+ * @param pidFromPidFile  the PID read from the config's `pid_file`, if the config
+ *   declared one AND the file was readable; `undefined` otherwise. The adapter
+ *   resolves this so the pure core stays I/O-free.
+ * @param processes    the running nats-server processes the adapter enumerated.
+ *
+ * pid_file wins when present. Otherwise exactly one config-path match is
+ * required: zero matches ⇒ the hub isn't running (or runs under a different
+ * config path) — fail LOUDLY rather than signalling a wrong server; more than
+ * one match ⇒ ambiguous, also fail (the config must declare a `pid_file`).
+ */
+export function resolveHubReloadTarget(
+  configPath: string,
+  pidFromPidFile: number | undefined,
+  processes: NatsProcess[],
+): HubReloadTargetResult {
+  if (pidFromPidFile !== undefined) {
+    if (!Number.isInteger(pidFromPidFile) || pidFromPidFile <= 0) {
+      return { ok: false, reason: `pid_file held an invalid PID (${String(pidFromPidFile)})` };
+    }
+    return { ok: true, target: { pid: pidFromPidFile, via: "pid_file" } };
+  }
+
+  const matches = processes.filter((p) => commandLoadsConfig(p.command, configPath));
+  const only = matches[0];
+  if (matches.length === 1 && only !== undefined) {
+    return { ok: true, target: { pid: only.pid, via: "config-match" } };
+  }
+  if (matches.length === 0) {
+    return {
+      ok: false,
+      reason:
+        `no running nats-server is serving ${resolvePath(configPath)} ` +
+        `(found ${processes.length.toString()} nats-server process(es), none loading this config). ` +
+        `Start the hub, or declare a \`pid_file\` in the config so the reload can target it.`,
+    };
+  }
+  return {
+    ok: false,
+    reason:
+      `${matches.length.toString()} running nats-server processes load ${resolvePath(configPath)} ` +
+      `(PIDs ${matches.map((m) => m.pid.toString()).join(", ")}) — ambiguous. ` +
+      `Declare a \`pid_file\` in the config to disambiguate the reload target.`,
+  };
+}

--- a/src/common/nats/hub-reload-target.ts
+++ b/src/common/nats/hub-reload-target.ts
@@ -21,14 +21,26 @@
  *
  *   1. **`pid_file` directive** — if the hub config declares `pid_file: <path>`,
  *      that file holds the running server's PID. Preferred: it is the server's
- *      own authoritative self-report. → `nats-server --signal reload=<pid>`.
+ *      own self-report — but a `pid_file` is NOT removed on crash / `kill -9`,
+ *      so a stale file can point at a recycled, unrelated PID.
  *   2. **config-path match** — otherwise, find the single running nats-server
  *      whose argv carries `-c <thisHubConfig>` (the resolved absolute path).
- *      → `kill -SIGHUP <pid>`.
  *
- * The I/O (reading the pid_file, listing processes, sending the signal) lives in
- * the adapter (`network-secret-adapters.ts`); this module only decides the
- * target from already-gathered inputs.
+ * ## Trust-path invariant — never signal an unverified PID (#1396)
+ *
+ * Both a stale `pid_file` and the enumerate→signal TOCTOU window can put an
+ * innocent PID in front of the signal. So the adapter re-verifies the resolved
+ * PID's LIVE argv through {@link argvIsNatsServerForConfig} immediately before it
+ * `process.kill(pid, "SIGHUP")`s it — an argv that is not a nats-server loading
+ * THIS config is never signalled. This matters because SIGHUP's default
+ * disposition is TERMINATE: an unverified signal to a recycled PID would kill an
+ * arbitrary process. The signal is a raw `process.kill` (nats-server applies the
+ * authorization change in place); the argv re-check — NOT a nats-aware
+ * `--signal reload=<pid>` form — is the load-bearing safety.
+ *
+ * The I/O (reading the pid_file, listing/inspecting processes, sending the
+ * signal) lives in the adapter (`network-secret-adapters.ts`); this module
+ * decides the target from already-gathered inputs and owns the argv predicate.
  */
 
 import { resolve as resolvePath } from "path";
@@ -43,8 +55,9 @@ export interface NatsProcess {
 
 /**
  * The resolved reload target. `pid` is the process to signal; `via` records how
- * it was resolved (for plan/log output). `pidFilePath`, when present, is the
- * pid_file the PID came from (the adapter prefers `--signal reload=<pid>`).
+ * it was resolved (for plan/log output). The adapter re-verifies `pid`'s LIVE
+ * argv (see {@link argvIsNatsServerForConfig}) before signalling, regardless of
+ * how `via` resolved it.
  */
 export interface HubReloadTarget {
   pid: number;
@@ -68,11 +81,43 @@ export function readPidFileDirective(confText: string): string | undefined {
   return raw === "" ? undefined : raw;
 }
 
+/**
+ * Matches the `nats-server` binary at the head of a command line (path-tolerant:
+ * `nats-server`, `/opt/nats/nats-server …`). The ONE definition of "is this argv
+ * a nats-server", reused by the adapter's process lister AND the pre-signal argv
+ * re-check — so the two never drift.
+ */
+const NATS_SERVER_COMMAND = /(^|\/)nats-server(\s|$)/;
+
+/** Is `command` an invocation of the nats-server binary? */
+export function isNatsServerCommand(command: string): boolean {
+  return NATS_SERVER_COMMAND.test(command);
+}
+
+/**
+ * The trust-path predicate (#1396): may the PID whose LIVE argv is `command` be
+ * SIGHUP'd as the hub for `configPath`? True iff the argv (a) is a nats-server
+ * AND (b) loads THIS config via `-c`/`--config`. BOTH resolution paths call this
+ * ONE helper on the freshly-read argv immediately before signalling — the
+ * pid_file path to guard against a stale, PID-recycled file, and the config-match
+ * path to collapse the enumerate→signal TOCTOU window. A PID whose argv fails
+ * this check is NEVER signalled (SIGHUP's default disposition is TERMINATE).
+ */
+export function argvIsNatsServerForConfig(command: string, configPath: string): boolean {
+  return isNatsServerCommand(command) && commandLoadsConfig(command, configPath);
+}
+
 /** Does this process command load `configPath` via `-c`/`--config`? */
 function commandLoadsConfig(command: string, configPath: string): boolean {
   // Tokenise on whitespace; match the resolved abs path against the value that
   // follows `-c`/`--config`, or the `--config=<path>` fused form. Resolve both
   // sides so `./local.conf` and an absolute path compare equal.
+  //
+  // Known limitation: a config path containing whitespace cannot be recovered
+  // from unquoted `ps` output (argv is space-joined), so such a server never
+  // config-matches — it degrades to a fail-loud zero-match, never a mis-signal.
+  // Declare a `pid_file` for spaced paths. cortex configs live under
+  // ~/.config/cortex (no spaces), so real-world impact is nil.
   const want = resolvePath(configPath);
   const toks = command.split(/\s+/).filter((t) => t.length > 0);
   for (let i = 0; i < toks.length; i++) {


### PR DESCRIPTION
## What
`cortex network secret add-member|rotate|revoke-member --apply` shelled a bare `nats-server --signal reload`, which REFUSES when >1 nats-server runs (the normal multi-stack host state) — so the hub-config write landed but the reload failed: add-member aborted before seal+deliver, revoke-member didn't actually cut transport (#1317). Now the reload targets the SPECIFIC hub nats-server.

**Re-land of #1318** (@mellanon/Andreas, closed unmerged) — its design was correct; brought in its 4 files via `git checkout pr-1318 --` after confirming #1318 is a clean superset of current main (REGISTRY/crypto/seed code byte-identical; only the targeting is additive). Original authors credited.

## Targeting mechanism (pure core `common/nats/hub-reload-target.ts`, I/O injected)
1. `pid_file` directive present → read that PID → SIGHUP it (server's authoritative self-report; no scan).
2. Else enumerate running nats-servers (`ps -axww`) and select the ONE whose resolved `-c`/`--config` path equals this hub config path (path-resolved equality — substring/rel-vs-abs safe).
3. Zero matches OR ambiguous (2+) → **fail loudly** (never signal a wrong server); error names the resolved path + PIDs + suggests declaring `pid_file`. Signal via `process.kill(pid,"SIGHUP")`.

## Verify
check-carveouts PASS · tsc 0 · eslint 0 · hub-reload-target + adapter suites 18/0 · all network-secret+nats (13 files) 221/0.

## Trust-path residual risks (for the adversarial reviewer — please rule if 1+2 are merge-blocking)
1. **PID-reuse TOCTOU (config-match path):** between `ps` and `process.kill`, the target could exit + PID be recycled → SIGHUP an unrelated process (default disposition = TERMINATE). Narrow window, real. Mitigation: argv re-check immediately before signal, or route via `nats-server --signal reload=<pid>` (nats-aware).
2. **Stale pid_file:** trusts the file; a stale PID (server died, recycled) → SIGHUP wrong PID. pid_file is nats-written + hub config chmod 600, low exposure. #1318 used raw `process.kill` for both paths; the nats-aware form is more defensive.
3. write-then-reload still not transactional (explicitly OUT of #1317 targeting scope) — config written before reload; failure leaves config ahead of process; idempotent re-run reconciles; throws loudly, no silent swallow.
4. dry-run header cosmetic (#1317 point 3) — separate, untouched.
5. EPERM cross-uid → caught + rethrown clearly (fail-loud).
6. `ps` portability → misbehavior yields zero-match → fail-loud (safe default).

Closes #1317. Epic #1346 Phase 1 (trust-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB


---

## Update — `cff11ba7` (adversarial trust-path blocker resolved, discussion_r3511343898)

The residual risks 1 + 2 above are **now closed in-code**, and the doc/PR claims are corrected to match reality:

- **Resolution order (corrected):** pid_file (server self-report) or config-match resolves the PID, then — on **both** paths — the adapter re-reads the target PID's **live argv** (`ps -p <pid> -o command=`) immediately before the signal and refuses (fail-loud, no signal) unless it is still a `nats-server` loading THIS config (`argvIsNatsServerForConfig`). The signal is a **raw argv-verified `process.kill(pid,"SIGHUP")`** — NOT the nats-aware `nats-server --signal reload=<pid>` form (which was documented but never implemented; the docstrings + interface JSDoc are now corrected).
- **Risk 1 (config-match TOCTOU):** collapsed to near-zero — the argv re-read is the last step before the signal.
- **Risk 2 (stale pid_file):** closed — a stale/recycled PID whose live argv is not a matching nats-server is never signalled.
- Trust-path invariant ("never signal an unverified PID") is test-locked: pid_file→non-nats, pid_file→different-config, and config-match→gone-before-signal all fail loud with no signal; EPERM signal-throw covered.
