### PR TITLE
feat(network): C-1315 — surface admission request-ids + sealed-delivery state

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -16,7 +16,8 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { dispatchNetwork } from "../network";
+import { dispatchNetwork, joinBlockerMessage } from "../network";
+import type { OwnAdmissionState } from "../../../../common/registry/admission-state";
 import type { LoadedConfig } from "../../../../common/config/loader";
 import type { AgentConfig } from "../../../../common/types/config";
 
@@ -610,5 +611,61 @@ describe("leave public", () => {
     ], EMPTY_READER);
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("nothing to do");
+  });
+});
+
+// =============================================================================
+// C-1315 — joinBlockerMessage: the actionable admission-state message that
+// REPLACES the misleading legacy `.creds not found (#821)` preflight on a
+// Model-B join with no resolved leaf secret.
+// =============================================================================
+
+describe("joinBlockerMessage (C-1315)", () => {
+  const NET = "metafactory";
+  function st(over: Partial<OwnAdmissionState>): OwnAdmissionState {
+    return {
+      state: over.state ?? "pending",
+      networkId: NET,
+      hasSealedSecret: over.hasSealedSecret ?? false,
+      peerPubkey: over.peerPubkey ?? "PUBKEY==",
+      ...(over.requestId !== undefined && { requestId: over.requestId }),
+    };
+  }
+
+  test("no-row → 'register first', names the network, NOT a .creds fix", () => {
+    const m = joinBlockerMessage(NET, st({ state: "no-row" }));
+    expect(m).toContain("no admission request exists");
+    expect(m).toContain(NET);
+    expect(m).toContain("register");
+    expect(m).toContain(".creds file is NOT the fix");
+  });
+
+  test("pending → surfaces the request-id + admit command", () => {
+    const m = joinBlockerMessage(NET, st({ state: "pending", requestId: "req-9" }));
+    expect(m).toContain("PENDING");
+    expect(m).toContain("req-9");
+    expect(m).toContain("cortex network admit req-9 --apply");
+  });
+
+  test("admitted-unsealed → tells the admin to seal (add-member <net> <pubkey>)", () => {
+    const m = joinBlockerMessage(NET, st({ state: "admitted-unsealed", requestId: "r", peerPubkey: "PK==" }));
+    expect(m).toContain("ADMITTED");
+    expect(m).toContain("cortex network secret add-member metafactory PK== --apply");
+    expect(m).toContain("auto-fetches");
+  });
+
+  test("admitted-sealed (open failed) → wrong-pubkey / re-seal guidance", () => {
+    const m = joinBlockerMessage(NET, st({ state: "admitted-sealed", hasSealedSecret: true, peerPubkey: "PK==" }));
+    expect(m).toContain("could not open it");
+    expect(m).toContain("PK==");
+  });
+
+  test("revoked / rejected → their own messages", () => {
+    expect(joinBlockerMessage(NET, st({ state: "revoked", requestId: "r" }))).toContain("REVOKED");
+    expect(joinBlockerMessage(NET, st({ state: "rejected", requestId: "r" }))).toContain("REJECTED");
+  });
+
+  test("unknown status → undefined (keep the original error)", () => {
+    expect(joinBlockerMessage(NET, st({ state: "unknown" }))).toBeUndefined();
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { dispatchNetwork, joinBlockerMessage } from "../network";
+import { dispatchNetwork, joinBlockerMessage, shouldReplaceCredsPreflightError } from "../network";
 import type { OwnAdmissionState } from "../../../../common/registry/admission-state";
 import type { LoadedConfig } from "../../../../common/config/loader";
 import type { AgentConfig } from "../../../../common/types/config";
@@ -667,5 +667,76 @@ describe("joinBlockerMessage (C-1315)", () => {
 
   test("unknown status → undefined (keep the original error)", () => {
     expect(joinBlockerMessage(NET, st({ state: "unknown" }))).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// C-1315 (review major, #1397) — shouldReplaceCredsPreflightError: the #821
+// creds-preflight error is rewritten to the Model-B admission message ONLY on
+// the Model-B no-secret path, and NEVER on an explicit `--creds` / `--leaf-
+// secret` join or a non-#821 failure.
+// =============================================================================
+
+describe("shouldReplaceCredsPreflightError (C-1315 #821 guard, #1397)", () => {
+  const CREDS_821 =
+    "leaf creds file not found at /tmp/typo.creds — refusing to render a leaf remote " +
+    "that cannot authenticate to the hub. Set stack.nats_infra.creds_path (or pass --creds) " +
+    "to an existing .creds file (cortex#821).";
+
+  test("Model-B no-secret path (no --creds, no leaf secret, #821) → replace", () => {
+    expect(
+      shouldReplaceCredsPreflightError({
+        joinOk: false,
+        resolvedLeafSecret: undefined,
+        explicitCredsFlag: undefined,
+        reason: CREDS_821,
+      }),
+    ).toBe(true);
+  });
+
+  test("explicit --creds <bad-path> join → KEEP the original creds-not-found error (NOT the Model-B rewrite)", () => {
+    // The review-major regression: a user who opted into creds-file auth and
+    // typo'd the path must see the genuine error, never "a .creds file is NOT the fix".
+    expect(
+      shouldReplaceCredsPreflightError({
+        joinOk: false,
+        resolvedLeafSecret: undefined,
+        explicitCredsFlag: "/tmp/typo.creds",
+        reason: CREDS_821,
+      }),
+    ).toBe(false);
+  });
+
+  test("explicit --leaf-secret join (leaf secret resolved) → keep original", () => {
+    expect(
+      shouldReplaceCredsPreflightError({
+        joinOk: false,
+        resolvedLeafSecret: "SECRET",
+        explicitCredsFlag: undefined,
+        reason: CREDS_821,
+      }),
+    ).toBe(false);
+  });
+
+  test("a non-#821 failure → keep original (marker absent)", () => {
+    expect(
+      shouldReplaceCredsPreflightError({
+        joinOk: false,
+        resolvedLeafSecret: undefined,
+        explicitCredsFlag: undefined,
+        reason: "some other join failure",
+      }),
+    ).toBe(false);
+  });
+
+  test("a successful join → never replace", () => {
+    expect(
+      shouldReplaceCredsPreflightError({
+        joinOk: true,
+        resolvedLeafSecret: undefined,
+        explicitCredsFlag: undefined,
+        reason: CREDS_821,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -211,6 +211,76 @@ describe("cortex provision-stack register (TC-1b #632)", () => {
     }
   });
 
+  test("[6c] register --network surfaces the admission request_id + PENDING state (C-1315)", async () => {
+    const env = await configuredEnv();
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, env);
+    }) as typeof globalThis.fetch;
+    try {
+      const res = await dispatchProvisionStack([
+        "register",
+        "andreas",
+        "--seed-path",
+        seedPath,
+        "--registry-url",
+        "http://registry.test",
+        "--network",
+        "metafactory",
+        "--json",
+      ]);
+      expect(res.exitCode).toBe(0);
+      const out = JSON.parse(res.stdout) as { data: Record<string, string> };
+      // C-1315 — the register response itself carries no request_id; the CLI
+      // does a PoP `/admission-requests/mine` read to surface it.
+      expect(out.data.network_id).toBe("metafactory");
+      expect(out.data.admission_status).toBe("PENDING");
+      expect(out.data.sealed_secret).toBe("missing");
+      expect(typeof out.data.request_id).toBe("string");
+      expect(out.data.request_id!.length).toBeGreaterThan(0);
+      expect(out.data.next_for_admin).toContain("cortex network admit");
+      expect(out.data.next_for_admin).toContain("secret add-member metafactory");
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("[6d] register --network human output prints the request-id + next-for-admin (C-1315)", async () => {
+    const env = await configuredEnv();
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "jc", "--seed-path", seedPath]);
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, env);
+    }) as typeof globalThis.fetch;
+    try {
+      const res = await dispatchProvisionStack([
+        "register",
+        "jc",
+        "--seed-path",
+        seedPath,
+        "--registry-url",
+        "http://registry.test",
+        "--network",
+        "metafactory",
+      ]);
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toContain("request-id:");
+      expect(res.stdout).toContain("admission: PENDING");
+      expect(res.stdout).toContain("next (admin):");
+      // The seed never leaks into human output.
+      expect(res.stdout).not.toContain(seedOnDisk(seedPath));
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   test("[6b] register surfaces a registry rejection as exit 1", async () => {
     // Unconfigured registry → 503 registry_unconfigured.
     const env: Env = { ENVIRONMENT: "test" };

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -684,6 +684,35 @@ export function joinBlockerMessage(networkId: string, s: OwnAdmissionState): str
 }
 
 /**
+ * C-1315 — decide whether a failed join's `#821` creds-preflight error should be
+ * REPLACED with the actionable Model-B admission-state message. Pure + exported
+ * so the invariant is unit-testable. The rewrite is confined to the Model-B
+ * no-secret path; it must fire ONLY when ALL hold:
+ *   - the join failed (`!joinOk`),
+ *   - no leaf secret was resolved (flag/config/auto-fetch) — else it's not the
+ *     no-secret path,
+ *   - NO explicit `--creds` flag was given — an explicit `--creds` join opted
+ *     into creds-file (Model-A) auth, so a missing/typo'd creds path is a genuine
+ *     "creds not found" error, NOT a Model-B admission gap; keep it verbatim
+ *     (review major, #1397), and
+ *   - the failure carries the `cortex#821` preflight marker.
+ */
+export function shouldReplaceCredsPreflightError(args: {
+  joinOk: boolean;
+  resolvedLeafSecret: string | undefined;
+  explicitCredsFlag: string | undefined;
+  reason: unknown;
+}): boolean {
+  return (
+    !args.joinOk &&
+    args.resolvedLeafSecret === undefined &&
+    args.explicitCredsFlag === undefined &&
+    typeof args.reason === "string" &&
+    args.reason.includes("cortex#821")
+  );
+}
+
+/**
  * C-1315 — when a join fails the Model-B creds preflight (#821) with no resolved
  * leaf secret, probe the joiner's OWN admission row (PoP `/mine` read) and return
  * the actionable state message. Best-effort: any inability to probe (no seed on
@@ -868,10 +897,12 @@ async function runJoin(
   // secret join, or a registry we can't reach, keeps the original #821 error.
   let effectiveReason = res.reason;
   if (
-    !res.ok &&
-    resolvedLeafSecret === undefined &&
-    typeof res.reason === "string" &&
-    res.reason.includes("cortex#821")
+    shouldReplaceCredsPreflightError({
+      joinOk: res.ok,
+      resolvedLeafSecret,
+      explicitCredsFlag: optionalValueFlag(flags, "--creds"),
+      reason: res.reason,
+    })
   ) {
     const actionable = await classifyModelBJoinBlocker(networkId, {
       seedPath: inputs.seedPath,

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -144,6 +144,10 @@ import {
 } from "./network-secret-adapters";
 import { fetchSealedLeafSecret } from "../../../common/registry/fetch-sealed-secret";
 import {
+  resolveOwnAdmissionState,
+  type OwnAdmissionState,
+} from "../../../common/registry/admission-state";
+import {
   createLiveProbeBus,
   type LiveProbeBus,
 } from "./network-ping-adapters";
@@ -631,6 +635,84 @@ async function maybeAutoFetchLeafSecret(
   return { leafSecret: res.leafPsk, leafUser: res.leafUser };
 }
 
+/**
+ * C-1315 — turn a classified admission state into the actionable message a
+ * Model-B joiner needs, REPLACING the misleading legacy `.creds not found (#821)`
+ * preflight. Returns `undefined` for states we can't explain (keep the original
+ * error). Every message states plainly that a legacy `.creds` file is NOT the fix.
+ */
+export function joinBlockerMessage(networkId: string, s: OwnAdmissionState): string | undefined {
+  const seal = `cortex network secret add-member ${networkId} ${s.peerPubkey} --apply`;
+  switch (s.state) {
+    case "no-row":
+      return (
+        `no admission request exists for network "${networkId}" — register first with ` +
+        `\`cortex provision-stack register <principal> --network ${networkId} --registry-url <url> --seed-path <seed>\`, ` +
+        `then have an admin admit + seal. (This is a Model-B secret-auth join; a legacy .creds file is NOT the fix.)`
+      );
+    case "pending":
+      return (
+        `admission request ${s.requestId ?? "(unknown)"} for "${networkId}" is PENDING — give this request-id to a ` +
+        `network admin to admit (\`cortex network admit ${s.requestId ?? "<id>"} --apply\`), then re-run join. ` +
+        `No sealed leaf secret has been delivered yet; a legacy .creds file is NOT the fix.`
+      );
+    case "admitted-unsealed":
+      return (
+        `admission request ${s.requestId ?? "(unknown)"} for "${networkId}" is ADMITTED, but the sealed leaf secret ` +
+        `has not been delivered — ask an admin to run \`${seal}\`. \`cortex network join\` then auto-fetches + ` +
+        `unseals it (you never handle a raw secret). A legacy .creds file is NOT the fix.`
+      );
+    case "admitted-sealed":
+      return (
+        `admission request ${s.requestId ?? "(unknown)"} for "${networkId}" is ADMITTED and a sealed leaf secret ` +
+        `EXISTS, but this stack could not open it — it is likely sealed to a different pubkey or corrupted. Verify ` +
+        `this stack's registered pubkey (${s.peerPubkey}) matches what the admin sealed to, or ask them to re-seal: \`${seal}\`.`
+      );
+    case "revoked":
+      return (
+        `admission for "${networkId}" was REVOKED (request ${s.requestId ?? "(unknown)"}) — membership was withdrawn. ` +
+        `Re-register or contact a network admin. A legacy .creds file is NOT the fix.`
+      );
+    case "rejected":
+      return (
+        `admission request ${s.requestId ?? "(unknown)"} for "${networkId}" was REJECTED by a network admin. ` +
+        `Contact them or re-register. A legacy .creds file is NOT the fix.`
+      );
+    default:
+      return undefined; // unknown status — keep the original error
+  }
+}
+
+/**
+ * C-1315 — when a join fails the Model-B creds preflight (#821) with no resolved
+ * leaf secret, probe the joiner's OWN admission row (PoP `/mine` read) and return
+ * the actionable state message. Best-effort: any inability to probe (no seed on
+ * disk, unreadable seed, registry unreachable) returns `undefined` so the caller
+ * keeps the original error rather than inventing a misleading one.
+ */
+async function classifyModelBJoinBlocker(
+  networkId: string,
+  inputs: { seedPath: string; registryUrl: string; principal: string },
+): Promise<string | undefined> {
+  const seedExpanded = expandTilde(inputs.seedPath);
+  if (!existsSync(seedExpanded)) return undefined;
+  let material;
+  try {
+    enforceChmod600(seedExpanded);
+    const seed = await readFile(seedExpanded, "utf-8");
+    material = materialFromSeedString(seed);
+  } catch (_err) {
+    // Can't load the stack identity → can't probe; keep the original error. Safe.
+    return undefined;
+  }
+  const probe = await resolveOwnAdmissionState(
+    { registryUrl: inputs.registryUrl, principalId: inputs.principal, material },
+    networkId,
+  );
+  if (!probe.ok) return undefined; // registry unreachable/not configured → keep original
+  return joinBlockerMessage(networkId, probe.state);
+}
+
 async function runJoin(
   networkId: string,
   flags: FlagMap,
@@ -776,7 +858,30 @@ async function runJoin(
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 
   const res = await joinNetwork(networkId, stack, ports);
-  const flow = renderFlowResult("join", networkId, res.ok, res.reason, res.steps, applyRes.apply, json, {
+
+  // C-1315 — when the join fails the Model-B creds preflight (#821) and no leaf
+  // secret was resolved (flag/config/auto-fetch), the REAL blocker is almost
+  // always an admission-state gap (not yet admitted / sealed delivery missing /
+  // revoked), NOT a missing legacy .creds file. Probe the joiner's own admission
+  // row and REPLACE the misleading message with the actionable state. Only fires
+  // on the secret-auth (Model-B) no-secret path; an explicit --creds / --leaf-
+  // secret join, or a registry we can't reach, keeps the original #821 error.
+  let effectiveReason = res.reason;
+  if (
+    !res.ok &&
+    resolvedLeafSecret === undefined &&
+    typeof res.reason === "string" &&
+    res.reason.includes("cortex#821")
+  ) {
+    const actionable = await classifyModelBJoinBlocker(networkId, {
+      seedPath: inputs.seedPath,
+      registryUrl: inputs.registryUrl,
+      principal: inputs.principal,
+    });
+    if (actionable !== undefined) effectiveReason = actionable;
+  }
+
+  const flow = renderFlowResult("join", networkId, res.ok, effectiveReason, res.steps, applyRes.apply, json, {
     used_cache: res.usedCache === true ? "true" : "false",
     peers: (res.resolvedPeers ?? []).join(","),
   });

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -52,6 +52,10 @@ import { readFile } from "fs/promises";
 import { expandTilde } from "../../../common/config/loader";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
 import {
+  resolveOwnAdmissionState,
+  type OwnAdmissionState,
+} from "../../../common/registry/admission-state";
+import {
   generateStackIdentity,
   materialFromSeedString,
   buildRegistrationClaim,
@@ -423,10 +427,88 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
     // C-1269 — surface the admission state so scripting consumers can gate on it.
     admission_request: reg.admission,
   };
+
+  // C-1315 — surface the admission request-id + sealed-delivery state the admin
+  // needs. The register RESPONSE does not carry the request_id (the registry
+  // route returns only the signed principal assertion), so we do a PoP-signed
+  // `/admission-requests/mine` read here for the just-registered network.
+  // Best-effort: a read failure NEVER fails a successful registration — we note
+  // the lookup was unavailable and point at the discovery command.
+  const humanLines: string[] = [];
+  if (networkRes.networkId !== undefined) {
+    const probe = await resolveOwnAdmissionState(
+      { registryUrl: urlRes.value, principalId: ctx.principalId, material: matRes.material },
+      networkRes.networkId,
+    );
+    if (probe.ok) {
+      const s = probe.state;
+      data.network_id = networkRes.networkId;
+      data.admission_status = admissionStatusLabel(s.state);
+      data.sealed_secret = s.hasSealedSecret ? "present" : "missing";
+      if (s.requestId !== undefined) {
+        data.request_id = s.requestId;
+        data.next_for_admin = nextForAdmin(networkRes.networkId, s);
+      }
+      humanLines.push(...registerStateLines(networkRes.networkId, s));
+    } else {
+      data.admission_lookup = `unavailable: ${probe.reason}`;
+      humanLines.push(
+        `  admission: could not read the request-id from the registry (${probe.reason}).`,
+        `  Discover it later with (admin): cortex network admit --list-pending --admin-seed <path>.`,
+      );
+    }
+  }
+
   if (ctx.json) return ok(renderJson(envelopeOk([], data)));
-  return ok(
-    `cortex provision-stack: ${reg.note}\n  principal: ${ctx.principalId}\n  stack: ${stackIdRes.stackId}\n  fingerprint: ${matRes.material.fingerprint}\n`,
-  );
+  const base = `cortex provision-stack: ${reg.note}\n  principal: ${ctx.principalId}\n  stack: ${stackIdRes.stackId}\n  fingerprint: ${matRes.material.fingerprint}\n`;
+  return ok(humanLines.length > 0 ? `${base}${humanLines.join("\n")}\n` : base);
+}
+
+/** Human label for a C-1315 admission state. */
+function admissionStatusLabel(state: OwnAdmissionState["state"]): string {
+  switch (state) {
+    case "no-row":
+      return "NONE";
+    case "pending":
+      return "PENDING";
+    case "admitted-unsealed":
+      return "ADMITTED (sealed secret not yet delivered)";
+    case "admitted-sealed":
+      return "ADMITTED (sealed secret delivered)";
+    case "revoked":
+      return "REVOKED";
+    case "rejected":
+      return "REJECTED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/** The admin's next command(s) to move this request forward (C-1315). */
+function nextForAdmin(networkId: string, s: OwnAdmissionState): string {
+  const admit = s.requestId !== undefined ? `cortex network admit ${s.requestId} --apply` : "";
+  const seal = `cortex network secret add-member ${networkId} ${s.peerPubkey} --apply`;
+  switch (s.state) {
+    case "pending":
+      return admit !== "" ? `${admit} && ${seal}` : seal;
+    case "admitted-unsealed":
+      return seal;
+    default:
+      return admit !== "" ? admit : seal;
+  }
+}
+
+/** Human-readable register-time admission lines (C-1315). */
+function registerStateLines(networkId: string, s: OwnAdmissionState): string[] {
+  const lines: string[] = [`  network: ${networkId}`];
+  if (s.requestId !== undefined) {
+    lines.push(`  request-id: ${s.requestId}   (give this to a network admin)`);
+  }
+  lines.push(`  admission: ${admissionStatusLabel(s.state)}`);
+  if (s.state === "pending" || s.state === "admitted-unsealed") {
+    lines.push(`  next (admin): ${nextForAdmin(networkId, s)}`);
+  }
+  return lines;
 }
 
 /**

--- a/src/common/registry/__tests__/admission-state.test.ts
+++ b/src/common/registry/__tests__/admission-state.test.ts
@@ -1,0 +1,188 @@
+/**
+ * C-1315 (#1315) — unit tests for the member-side admission-state read + classifier.
+ *
+ * `fetchOwnAdmissionRows` is transport-injectable; the classifier is pure. So the
+ * whole module is covered hermetically with a stub fetch + a real (generated)
+ * stack seed — no live registry.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createUser } from "nkeys.js";
+
+import {
+  classifyOwnAdmissionRows,
+  fetchOwnAdmissionRows,
+  resolveOwnAdmissionState,
+  rowHasSealedSecret,
+  type AdmissionMineRow,
+  type FetchLike,
+} from "../admission-state";
+import { materialFromSeedString, type StackIdentityMaterial } from "../../../bus/stack-provisioning";
+
+/** A real material (the PoP read signs with it — the sign step must not throw). */
+function realMaterial(): StackIdentityMaterial {
+  const kp = createUser();
+  const seed = new TextDecoder().decode(kp.getSeed());
+  return materialFromSeedString(seed);
+}
+
+/** Build a mine row with sane defaults. */
+function row(over: Partial<AdmissionMineRow> = {}): AdmissionMineRow {
+  return {
+    request_id: over.request_id ?? "req-abc",
+    principal_id: over.principal_id ?? "jc",
+    peer_pubkey: over.peer_pubkey ?? "PUBKEY==",
+    network_id: over.network_id === undefined ? "metafactory" : over.network_id,
+    status: over.status ?? "PENDING",
+    sealed_secret: over.sealed_secret === undefined ? null : over.sealed_secret,
+  };
+}
+
+// =============================================================================
+// classifyOwnAdmissionRows (pure)
+// =============================================================================
+
+describe("classifyOwnAdmissionRows", () => {
+  const PUB = "MYPUBKEY==";
+
+  test("no row for the network → no-row (no request-id)", () => {
+    const s = classifyOwnAdmissionRows([row({ network_id: "othernet" })], "metafactory", PUB);
+    expect(s.state).toBe("no-row");
+    expect(s.requestId).toBeUndefined();
+    expect(s.hasSealedSecret).toBe(false);
+    expect(s.peerPubkey).toBe(PUB);
+  });
+
+  test("PENDING → pending, request-id carried", () => {
+    const s = classifyOwnAdmissionRows([row({ status: "PENDING", request_id: "r1" })], "metafactory", PUB);
+    expect(s.state).toBe("pending");
+    expect(s.requestId).toBe("r1");
+    expect(s.hasSealedSecret).toBe(false);
+  });
+
+  test("ADMITTED with no sealed secret → admitted-unsealed", () => {
+    const s = classifyOwnAdmissionRows([row({ status: "ADMITTED", sealed_secret: null })], "metafactory", PUB);
+    expect(s.state).toBe("admitted-unsealed");
+    expect(s.hasSealedSecret).toBe(false);
+  });
+
+  test("ADMITTED WITH a sealed secret → admitted-sealed", () => {
+    const s = classifyOwnAdmissionRows([row({ status: "ADMITTED", sealed_secret: "SEALEDBLOB" })], "metafactory", PUB);
+    expect(s.state).toBe("admitted-sealed");
+    expect(s.hasSealedSecret).toBe(true);
+  });
+
+  test("empty-string sealed_secret is NOT sealed", () => {
+    expect(rowHasSealedSecret(row({ sealed_secret: "" }))).toBe(false);
+    const s = classifyOwnAdmissionRows([row({ status: "ADMITTED", sealed_secret: "" })], "metafactory", PUB);
+    expect(s.state).toBe("admitted-unsealed");
+  });
+
+  test("REVOKED / REJECTED / unknown map through", () => {
+    expect(classifyOwnAdmissionRows([row({ status: "REVOKED" })], "metafactory", PUB).state).toBe("revoked");
+    expect(classifyOwnAdmissionRows([row({ status: "REJECTED" })], "metafactory", PUB).state).toBe("rejected");
+    expect(classifyOwnAdmissionRows([row({ status: "WEIRD" })], "metafactory", PUB).state).toBe("unknown");
+  });
+
+  test("selects the row matching THIS network among several", () => {
+    const rows = [
+      row({ network_id: "metafactory", status: "ADMITTED", sealed_secret: "X", request_id: "rM" }),
+      row({ network_id: "metafactory-community", status: "PENDING", request_id: "rC" }),
+    ];
+    const s = classifyOwnAdmissionRows(rows, "metafactory-community", PUB);
+    expect(s.state).toBe("pending");
+    expect(s.requestId).toBe("rC");
+  });
+});
+
+// =============================================================================
+// fetchOwnAdmissionRows (injected transport)
+// =============================================================================
+
+describe("fetchOwnAdmissionRows", () => {
+  test("signs a PoP header, GETs /admission-requests/mine, returns rows", async () => {
+    const material = realMaterial();
+    let gotUrl = "";
+    let gotHeader = "";
+    const fetchImpl: FetchLike = async (url, init) => {
+      gotUrl = url;
+      gotHeader = (init?.headers?.["x-pop-signed"] as string) ?? "";
+      return { ok: true, status: 200, json: async () => [row({ request_id: "r-1" })] };
+    };
+    const res = await fetchOwnAdmissionRows({
+      registryUrl: "http://registry.test/",
+      principalId: "jc",
+      material,
+      fetchImpl,
+      now: () => new Date("2026-07-02T00:00:00.000Z"),
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.rows[0]!.request_id).toBe("r-1");
+    expect(gotUrl).toBe("http://registry.test/admission-requests/mine"); // trailing slash trimmed
+    const signed = JSON.parse(gotHeader) as { claim: { principal_id: string; peer_pubkey: string }; signature: string };
+    expect(signed.claim.principal_id).toBe("jc");
+    expect(signed.claim.peer_pubkey).toBe(material.pubkeyB64);
+    expect(signed.signature.length).toBeGreaterThan(0);
+  });
+
+  test("HTTP error → soft ok:false with the status", async () => {
+    const material = realMaterial();
+    const fetchImpl: FetchLike = async () => ({ ok: false, status: 403, json: async () => ({}) });
+    const res = await fetchOwnAdmissionRows({ registryUrl: "http://r.test", principalId: "jc", material, fetchImpl });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("403");
+  });
+
+  test("non-array body → soft ok:false (never throws)", async () => {
+    const material = realMaterial();
+    const fetchImpl: FetchLike = async () => ({ ok: true, status: 200, json: async () => ({ not: "an array" }) });
+    const res = await fetchOwnAdmissionRows({ registryUrl: "http://r.test", principalId: "jc", material, fetchImpl });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("non-array");
+  });
+
+  test("transport throw → soft ok:false (never throws)", async () => {
+    const material = realMaterial();
+    const fetchImpl: FetchLike = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const res = await fetchOwnAdmissionRows({ registryUrl: "http://r.test", principalId: "jc", material, fetchImpl });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("errored");
+  });
+});
+
+// =============================================================================
+// resolveOwnAdmissionState (read + classify)
+// =============================================================================
+
+describe("resolveOwnAdmissionState", () => {
+  test("read ok → classified state for the target network", async () => {
+    const material = realMaterial();
+    const fetchImpl: FetchLike = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => [row({ network_id: "metafactory", status: "ADMITTED", sealed_secret: null, request_id: "rX" })],
+    });
+    const res = await resolveOwnAdmissionState(
+      { registryUrl: "http://r.test", principalId: "jc", material, fetchImpl },
+      "metafactory",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.state.state).toBe("admitted-unsealed");
+      expect(res.state.requestId).toBe("rX");
+      expect(res.state.peerPubkey).toBe(material.pubkeyB64);
+    }
+  });
+
+  test("read failure propagates as ok:false", async () => {
+    const material = realMaterial();
+    const fetchImpl: FetchLike = async () => ({ ok: false, status: 500, json: async () => ({}) });
+    const res = await resolveOwnAdmissionState(
+      { registryUrl: "http://r.test", principalId: "jc", material, fetchImpl },
+      "metafactory",
+    );
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/common/registry/__tests__/admission-state.test.ts
+++ b/src/common/registry/__tests__/admission-state.test.ts
@@ -106,7 +106,7 @@ describe("fetchOwnAdmissionRows", () => {
     let gotHeader = "";
     const fetchImpl: FetchLike = async (url, init) => {
       gotUrl = url;
-      gotHeader = (init?.headers?.["x-pop-signed"] as string) ?? "";
+      gotHeader = init?.headers?.["x-pop-signed"] ?? "";
       return { ok: true, status: 200, json: async () => [row({ request_id: "r-1" })] };
     };
     const res = await fetchOwnAdmissionRows({

--- a/src/common/registry/admission-state.ts
+++ b/src/common/registry/admission-state.ts
@@ -1,0 +1,211 @@
+/**
+ * C-1315 (#1315) — the member-side **admission-state read**: a PoP-signed
+ * `GET /admission-requests/mine` that surfaces a stack's OWN admission rows
+ * (request-id + status + whether a sealed leaf secret has been delivered) WITHOUT
+ * dumping the sealed material.
+ *
+ * This is the shared primitive behind two onboarding handles the CLI was
+ * missing:
+ *   - `provision-stack register --network <net>` prints the `request_id` the admin
+ *     needs (the register response itself does not carry it — the registry route
+ *     returns only the signed principal assertion), and
+ *   - `cortex network join` reports the REAL admission/sealed state (PENDING /
+ *     admitted-but-unsealed / revoked) instead of falling through to the
+ *     misleading legacy `.creds not found (#821)` preflight.
+ *
+ * ## PoP signing — reuse, mint nothing
+ *
+ * The read is authorized by a proof-of-possession signature over
+ * `{ principal_id, peer_pubkey, issued_at }`, signed with the stack's OWN
+ * registered seed (the `SU…` nkey whose base64 ed25519 pubkey is the registry
+ * `peer_pubkey`). Signing reuses {@link signClaimWithSeed} + {@link canonicalJSON}
+ * — the SAME plumbing `fetchSealedLeafSecret` uses. No key is minted.
+ *
+ * ## Never throws
+ *
+ * Every failure is a typed `{ ok: false, reason }` so callers (register output,
+ * the join error path) branch without try/catch and degrade gracefully.
+ */
+
+import { canonicalJSON } from "./signing";
+import {
+  signClaimWithSeed,
+  type StackIdentityMaterial,
+} from "../../bus/stack-provisioning";
+
+/**
+ * One admission row as `GET /admission-requests/mine` returns it. Mirrors the
+ * registry `AdmissionRequest` (a separate deploy target — same redeclare
+ * rationale as the other consumer-side registry types).
+ */
+export interface AdmissionMineRow {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  network_id: string | null;
+  status: string;
+  sealed_secret: string | null;
+}
+
+/** Injectable fetch (defaults to `globalThis.fetch`) so callers/tests stay hermetic. */
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export interface FetchOwnAdmissionRowsInput {
+  /** Registry base URL. Trailing slashes trimmed. */
+  registryUrl: string;
+  /** The joining principal id (echoed into the signed claim). */
+  principalId: string;
+  /** The stack's identity material — pubkey (the registry `peer_pubkey`) + seed (signs the PoP claim). */
+  material: StackIdentityMaterial;
+  /** Injected transport (tests). Production omits → `globalThis.fetch`. */
+  fetchImpl?: FetchLike;
+  /** Injected clock (tests). Production omits → `Date`. */
+  now?: () => Date;
+}
+
+export type FetchOwnAdmissionRowsResult =
+  | { ok: true; rows: AdmissionMineRow[] }
+  | { ok: false; reason: string };
+
+/**
+ * PoP-sign + `GET /admission-requests/mine`, returning this stack's raw admission
+ * rows. The single `/mine` read implementation — `fetchSealedLeafSecret` layers
+ * its select-admitted-row + unseal on top of this. Never throws (soft-closed).
+ */
+export async function fetchOwnAdmissionRows(
+  input: FetchOwnAdmissionRowsInput,
+): Promise<FetchOwnAdmissionRowsResult> {
+  const fetchImpl: FetchLike = input.fetchImpl ?? globalThis.fetch;
+  const now = input.now ?? (() => new Date());
+
+  // 1. Sign the PoP read claim with the stack's own key (signature IS the auth).
+  const claim = {
+    principal_id: input.principalId,
+    peer_pubkey: input.material.pubkeyB64,
+    issued_at: now().toISOString(),
+  };
+  let header: string;
+  try {
+    const sig = await signClaimWithSeed(
+      input.material.seed,
+      new TextEncoder().encode(canonicalJSON(claim)),
+    );
+    header = JSON.stringify({ claim, signature: sig });
+  } catch (err) {
+    return { ok: false, reason: `failed to sign PoP read claim: ${errText(err)}` };
+  }
+
+  // 2. GET /admission-requests/mine.
+  let body: unknown;
+  try {
+    const url = `${input.registryUrl.replace(/\/+$/, "")}/admission-requests/mine`;
+    const resp = await fetchImpl(url, {
+      method: "GET",
+      headers: { "Content-Type": "application/json", "x-pop-signed": header },
+    });
+    if (!resp.ok) {
+      return { ok: false, reason: `registry mine-read failed (HTTP ${resp.status.toString()})` };
+    }
+    body = await resp.json();
+  } catch (err) {
+    return { ok: false, reason: `registry mine-read errored: ${errText(err)}` };
+  }
+
+  if (!Array.isArray(body)) {
+    return { ok: false, reason: "registry mine-read returned a non-array body" };
+  }
+  return { ok: true, rows: body as AdmissionMineRow[] };
+}
+
+/**
+ * Classified admission state for ONE network, from a stack's own `/mine` rows.
+ *   - `no-row`            — no admission request exists for this network.
+ *   - `pending`           — registered, awaiting admin admit.
+ *   - `admitted-unsealed` — admitted, but no sealed leaf secret delivered yet.
+ *   - `admitted-sealed`   — admitted AND a sealed leaf secret is present.
+ *   - `revoked` / `rejected` — admission withdrawn / refused.
+ *   - `unknown`           — an unrecognised status string (forward-compat).
+ */
+export type AdmissionRowState =
+  | "no-row"
+  | "pending"
+  | "admitted-unsealed"
+  | "admitted-sealed"
+  | "revoked"
+  | "rejected"
+  | "unknown";
+
+export interface OwnAdmissionState {
+  state: AdmissionRowState;
+  networkId: string;
+  /** The admission request-id (absent only for `no-row`). */
+  requestId?: string;
+  /** True when the row carries a non-empty sealed leaf secret. */
+  hasSealedSecret: boolean;
+  /** The registered stack pubkey (the admin needs it for `secret add-member`). */
+  peerPubkey: string;
+}
+
+/** True when a row carries a non-empty sealed leaf-secret blob. */
+export function rowHasSealedSecret(row: AdmissionMineRow): boolean {
+  return typeof row.sealed_secret === "string" && row.sealed_secret.length > 0;
+}
+
+/**
+ * Classify this stack's admission state for `networkId` from its own `/mine`
+ * rows + its pubkey. Pure. Selects the row whose `network_id` matches; a
+ * `no-row` result carries no `requestId`.
+ */
+export function classifyOwnAdmissionRows(
+  rows: AdmissionMineRow[],
+  networkId: string,
+  peerPubkey: string,
+): OwnAdmissionState {
+  const row = rows.find((r) => r.network_id === networkId);
+  if (row === undefined) {
+    return { state: "no-row", networkId, hasSealedSecret: false, peerPubkey };
+  }
+  const hasSealedSecret = rowHasSealedSecret(row);
+  const base = { networkId, requestId: row.request_id, hasSealedSecret, peerPubkey };
+  switch (row.status) {
+    case "PENDING":
+      return { ...base, state: "pending" };
+    case "ADMITTED":
+      return { ...base, state: hasSealedSecret ? "admitted-sealed" : "admitted-unsealed" };
+    case "REVOKED":
+      return { ...base, state: "revoked" };
+    case "REJECTED":
+      return { ...base, state: "rejected" };
+    default:
+      return { ...base, state: "unknown" };
+  }
+}
+
+export type ResolveOwnAdmissionStateResult =
+  | { ok: true; state: OwnAdmissionState }
+  | { ok: false; reason: string };
+
+/**
+ * Read + classify this stack's admission state for `networkId` in one call.
+ * Never throws — a read failure is a typed `{ ok: false, reason }` so the caller
+ * can degrade (e.g. keep the original error) rather than mislead.
+ */
+export async function resolveOwnAdmissionState(
+  input: FetchOwnAdmissionRowsInput,
+  networkId: string,
+): Promise<ResolveOwnAdmissionStateResult> {
+  const res = await fetchOwnAdmissionRows(input);
+  if (!res.ok) return res;
+  return {
+    ok: true,
+    state: classifyOwnAdmissionRows(res.rows, networkId, input.material.pubkeyB64),
+  };
+}
+
+/** Error → message, never echoing secret-bearing inputs. */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/common/registry/fetch-sealed-secret.ts
+++ b/src/common/registry/fetch-sealed-secret.ts
@@ -22,24 +22,13 @@
  * config/flag/oob behaviour rather than aborting.
  */
 
-import { canonicalJSON } from "./signing";
 import { openSealed } from "../crypto/seal-to-principal";
 import { decodeLeafSecretEnvelope } from "./sealed-leaf-secret";
 import {
-  signClaimWithSeed,
   rawEd25519SeedFromNkeySeed,
   type StackIdentityMaterial,
 } from "../../bus/stack-provisioning";
-
-/** The minimal admission-row shape the member PoP-read returns. */
-interface AdmissionMineRow {
-  request_id: string;
-  principal_id: string;
-  peer_pubkey: string;
-  network_id: string | null;
-  status: string;
-  sealed_secret: string | null;
-}
+import { fetchOwnAdmissionRows } from "./admission-state";
 
 /** Injectable fetch (defaults to `globalThis.fetch`) so tests stay hermetic. */
 export type FetchLike = (
@@ -74,46 +63,18 @@ export type FetchSealedLeafSecretResult =
 export async function fetchSealedLeafSecret(
   input: FetchSealedLeafSecretInput,
 ): Promise<FetchSealedLeafSecretResult> {
-  const fetchImpl: FetchLike = input.fetchImpl ?? globalThis.fetch;
-  const now = input.now ?? (() => new Date());
-
-  // 1. Sign the PoP read claim with the member's own key.
-  const claim = {
-    principal_id: input.principalId,
-    peer_pubkey: input.material.pubkeyB64,
-    issued_at: now().toISOString(),
-  };
-  let header: string;
-  try {
-    const sig = await signClaimWithSeed(
-      input.material.seed,
-      new TextEncoder().encode(canonicalJSON(claim)),
-    );
-    header = JSON.stringify({ claim, signature: sig });
-  } catch (err) {
-    return { ok: false, reason: `failed to sign PoP read claim: ${errText(err)}` };
-  }
-
-  // 2. GET /admission-requests/mine.
-  let rows: AdmissionMineRow[];
-  try {
-    const url = `${input.registryUrl.replace(/\/+$/, "")}/admission-requests/mine`;
-    const resp = await fetchImpl(url, {
-      method: "GET",
-      headers: { "Content-Type": "application/json", "x-pop-signed": header },
-    });
-    if (!resp.ok) {
-      return { ok: false, reason: `registry mine-read failed (HTTP ${resp.status.toString()})` };
-    }
-    rows = (await resp.json()) as AdmissionMineRow[];
-  } catch (err) {
-    return { ok: false, reason: `registry mine-read errored: ${errText(err)}` };
-  }
+  // 1-2. PoP-sign + GET /admission-requests/mine (shared read — C-1315).
+  const readRes = await fetchOwnAdmissionRows({
+    registryUrl: input.registryUrl,
+    principalId: input.principalId,
+    material: input.material,
+    ...(input.fetchImpl !== undefined && { fetchImpl: input.fetchImpl }),
+    ...(input.now !== undefined && { now: input.now }),
+  });
+  if (!readRes.ok) return { ok: false, reason: readRes.reason };
+  const rows = readRes.rows;
 
   // 3. Select the ADMITTED row for this network carrying a sealed blob.
-  if (!Array.isArray(rows)) {
-    return { ok: false, reason: "registry mine-read returned a non-array body" };
-  }
   const row = rows.find(
     (r) => r.network_id === input.networkId && r.status === "ADMITTED" && typeof r.sealed_secret === "string" && r.sealed_secret.length > 0,
   );


### PR DESCRIPTION
## What
Surfaces admission request-ids + sealed-delivery state so onboarding stops being opaque (#1315).

**register** (`provision-stack register --network`): now prints the `request_id` + status + sealed state + next-step-for-admin (human + `--json`). The register route returns only the signed principal assertion (verified: `upsertPending`'s return is discarded at principals.ts:239 — no request_id server-side), so this uses the issue's fallback: a client-side PoP-signed `GET /admission-requests/mine` read (same endpoint+signing `fetchSealedLeafSecret` already uses). Best-effort — a mine-read failure never fails a successful registration (notes "lookup unavailable" + points at `admit --list-pending`).

**join**: when the `#821` creds preflight fails on the Model-B no-secret path, replaces the misleading legacy `.creds not found` error with the real classified state — no-row→register first · PENDING→hand admin the request-id · ADMITTED-unsealed→admin runs `secret add-member` · sealed-but-unopenable→re-seal · revoked/rejected. Only fires on that path; explicit `--creds`/`--leaf-secret` or unreachable-registry keeps the original error (never invents).

## Files (7)
NEW `common/registry/admission-state.ts` (shared `/mine` read + pure classifier) · `fetch-sealed-secret.ts` refactored to reuse it (one read impl) · `provision-stack.ts` (register output) · `network.ts` (join #821 interception) · 3 tests. `network-secret-adapters.ts` (#1317) untouched — disjoint.

## Verify
check-carveouts PASS · tsc 0 · src/cli/cortex/commands 1099 pass/0 fail · src/common/registry 131 pass/0 fail (incl. refactor regression + register integration hitting the real in-memory registry).

## Residual (follow-ups)
1. Register surfacing is a 2nd round-trip (register POST → /mine GET); the robust fix is the registry echoing request_id in the register response — deferred to a follow-up (needs a registry change + redeploy).
2. Join #821 interception covered by unit tests of both halves; a full join-CLI integration test needs a provisioned-config fixture (deferred).

Closes #1315. Epic #1346 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB
