### PR TITLE
feat(runner): thread review flavor into prompt+lens — fix drift-1 flavor-inert SEV-1 (compass#89 PR8)

### DIFF
--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -736,17 +736,24 @@ export class ReviewConsumer {
       return { kind: "term", reason: "payload validation failed" };
     }
 
-    // 2.4. drift-1 fix (compass#89): stamp the subject-derived <flavor> onto the
-    //       payload. The subject suffix is the routing AUTHORITY; the wire
-    //       payload never carries flavor. This one assignment threads flavor
-    //       into EVERY prompt builder (`buildReviewPrompt`, the CO-7
-    //       `buildUntrustedReviewPrompt`, `sage-runner`) with zero signature
-    //       changes — they all already receive `payload`. Without it,
-    //       `code-review.security` and `code-review.typescript` produced a
-    //       byte-identical prompt (the flavor-inert SEV-1). We narrow through
-    //       `isReviewFlavor` so an unknown/off-vocabulary suffix is left
-    //       unstamped (→ default FullReview lens) rather than widening the
-    //       payload type to a bare string.
+    // 2.4. drift-1 fix (compass#89): stamp the review <flavor> onto the payload.
+    //       The flavor is derived from `envelope.type` (via `extractFlavor`
+    //       above), and `type` ∈ myelin `SIGNABLE_FIELDS` — so it is
+    //       signature-covered and tamper-evident under `signing: enforce`. That
+    //       is what makes stamping HERE, before the 2.5 chain-verification gate,
+    //       safe: a downgraded flavor rewrites a signed field, so the gate
+    //       rejects the whole envelope and the tampered value never reaches a
+    //       review. (The flavor comes from the signed `type`, NOT the unsigned
+    //       wire subject — see `extractFlavor`.) The wire payload itself never
+    //       carries flavor. This one assignment threads flavor into EVERY prompt
+    //       builder (`buildReviewPrompt`, the CO-7 `buildUntrustedReviewPrompt`,
+    //       `sage-runner`) with zero signature changes — they all already
+    //       receive `payload`. Without it, `code-review.security` and
+    //       `code-review.typescript` produced a byte-identical prompt (the
+    //       flavor-inert SEV-1). We narrow through `isReviewFlavor` so an
+    //       unknown/off-vocabulary suffix is left unstamped (→ default
+    //       FullReview lens) rather than widening the payload type to a bare
+    //       string.
     if (isReviewFlavor(flavor)) {
       payload.flavor = flavor;
     }
@@ -1359,11 +1366,18 @@ export function deriveFlavors(capabilities: readonly string[]): string[] {
  * Extract `<flavor>` from a `tasks.code-review.<flavor>` envelope's
  * `type` field. Returns `null` if the envelope isn't a review request.
  *
- * The envelope `type` (NOT the wire subject) is the canonical source —
- * the wire subject includes the namespace prefix (`local.{principal}.`) and a
- * malformed subject would falsely match a partial slice. Pull-mode
- * subjects pass through as-is in NATS but the type field is what the
- * validator-approved envelope carries.
+ * SECURITY — reads `envelope.type` ONLY, never the raw NATS `_subject`.
+ * `type` ∈ myelin `SIGNABLE_FIELDS` (`@the-metafactory/myelin`
+ * `src/identity/canonicalize.ts`), so the derived flavor is
+ * signature-covered and tamper-evident under `signing: enforce`: a peer
+ * that tries to downgrade the lens (e.g. `confidentiality` → `generic`)
+ * must rewrite a signed field, which fails chain verification and is
+ * rejected. **Do NOT "simplify" this to parse the raw NATS subject** — the
+ * subject is UNSIGNED, so parsing it would drop signature coverage and
+ * reopen a silent lens-downgrade attack. (It is also less correct: the wire
+ * subject carries the `local.{principal}.` namespace prefix and a malformed
+ * subject could falsely match a partial slice.) The `_subject` param is
+ * intentionally unused — kept only for call-site signature symmetry.
  */
 export function extractFlavor(envelope: Envelope, _subject: string): string | null {
   const t = envelope.type;

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -78,6 +78,7 @@ import type { MyelinSubscriber } from "./myelin/subscriber";
 import type { AckDecision } from "./myelin/subscriber";
 import {
   createReviewTaskFailedEvent,
+  isReviewFlavor,
   type DispatchTaskFailedReason,
   type ReviewEventSource,
   type ReviewRequestPayload,
@@ -733,6 +734,21 @@ export class ReviewConsumer {
         requester,
       );
       return { kind: "term", reason: "payload validation failed" };
+    }
+
+    // 2.4. drift-1 fix (compass#89): stamp the subject-derived <flavor> onto the
+    //       payload. The subject suffix is the routing AUTHORITY; the wire
+    //       payload never carries flavor. This one assignment threads flavor
+    //       into EVERY prompt builder (`buildReviewPrompt`, the CO-7
+    //       `buildUntrustedReviewPrompt`, `sage-runner`) with zero signature
+    //       changes — they all already receive `payload`. Without it,
+    //       `code-review.security` and `code-review.typescript` produced a
+    //       byte-identical prompt (the flavor-inert SEV-1). We narrow through
+    //       `isReviewFlavor` so an unknown/off-vocabulary suffix is left
+    //       unstamped (→ default FullReview lens) rather than widening the
+    //       payload type to a bare string.
+    if (isReviewFlavor(flavor)) {
+      payload.flavor = flavor;
     }
 
     // 2.5. Signature-chain verification gate (cortex#327). Runs after the

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -187,6 +187,19 @@ export interface ReviewRequestPayload {
    * backwards compatibility with pre-sage#43 publishers.
    */
   forge?: "github" | "gitlab";
+  /**
+   * The `<flavor>` of the `tasks.code-review.<flavor>` subject this request
+   * arrived on — the routing authority for the review's PRIMARY lens
+   * (compass#89, drift-1 fix). NOT carried on the wire by the publisher:
+   * cortex STAMPS it from the subject suffix in the review consumer right
+   * after `parseReviewRequestPayload` (`review-consumer.ts`), so it threads
+   * into every prompt builder (`buildReviewPrompt`, the CO-7
+   * `buildUntrustedReviewPrompt`, `sage-runner`) with zero signature changes.
+   * OPTIONAL for wire back-compat: undefined ⇒ the default (FullReview) lens.
+   * Before this field, `code-review.security` and `code-review.typescript`
+   * produced a BYTE-IDENTICAL prompt — the flavor-inert SEV-1 this closes.
+   */
+  flavor?: ReviewFlavor;
 }
 
 /** Options for {@link createReviewRequestEvent}. */
@@ -311,6 +324,19 @@ export interface ReviewVerdictPayload {
   };
   /** Total inline comments posted with the review. */
   inline_comments: number;
+  /**
+   * compass#89 (design-software-factory-confidentiality.md §4 L3) —
+   * **machine-checkable execution evidence** that the Confidentiality lens ran
+   * for this review. `true` when the reviewer ran the lens (always-on for an
+   * EXPOSED repo), `false` when it deliberately did not. The autonomous loop
+   * parses this to distinguish a clean confidentiality run from a silent skip.
+   *
+   * OPTIONAL for wire forward-compat: REQUIRED would fail-closed every existing
+   * reviewer and the sage engine (which returns `cant_do` for the flavor and
+   * defers its lens threading to compass#99). Absent ⇒ "lens-ran unknown",
+   * NOT "lens did not run".
+   */
+  confidentiality_lens_ran?: boolean;
   /**
    * cortex#503 — **Presentation markdown.** Deterministic markdown computed
    * by cortex (NOT the reviewing agent) from the structured verdict fields

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -188,16 +188,20 @@ export interface ReviewRequestPayload {
    */
   forge?: "github" | "gitlab";
   /**
-   * The `<flavor>` of the `tasks.code-review.<flavor>` subject this request
-   * arrived on — the routing authority for the review's PRIMARY lens
-   * (compass#89, drift-1 fix). NOT carried on the wire by the publisher:
-   * cortex STAMPS it from the subject suffix in the review consumer right
-   * after `parseReviewRequestPayload` (`review-consumer.ts`), so it threads
-   * into every prompt builder (`buildReviewPrompt`, the CO-7
-   * `buildUntrustedReviewPrompt`, `sage-runner`) with zero signature changes.
-   * OPTIONAL for wire back-compat: undefined ⇒ the default (FullReview) lens.
-   * Before this field, `code-review.security` and `code-review.typescript`
-   * produced a BYTE-IDENTICAL prompt — the flavor-inert SEV-1 this closes.
+   * The review `<flavor>` for this request — the routing key for the review's
+   * PRIMARY lens (compass#89, drift-1 fix). Derived from `envelope.type`
+   * (`tasks.code-review.<flavor>`), which ∈ myelin `SIGNABLE_FIELDS`, so it is
+   * signature-covered → tamper-evident under `signing: enforce` (a downgraded
+   * flavor rewrites a signed field and fails chain verification). NOT carried
+   * on the wire as a payload field: cortex STAMPS it from the signed
+   * `envelope.type` in the review consumer (via `extractFlavor` — the signed
+   * type, NEVER the unsigned NATS subject) right after
+   * `parseReviewRequestPayload`, so it threads into every prompt builder
+   * (`buildReviewPrompt`, the CO-7 `buildUntrustedReviewPrompt`, `sage-runner`)
+   * with zero signature changes. OPTIONAL for wire back-compat: undefined ⇒ the
+   * default (FullReview) lens. Before this field, `code-review.security` and
+   * `code-review.typescript` produced a BYTE-IDENTICAL prompt — the
+   * flavor-inert SEV-1 this closes.
    */
   flavor?: ReviewFlavor;
 }

--- a/src/common/types/review-flavors.ts
+++ b/src/common/types/review-flavors.ts
@@ -23,6 +23,13 @@ export const REVIEW_FLAVORS = [
   "sql",
   "docs",
   "security",
+  // Cross-cutting lens, orthogonal to language — a `code-review.confidentiality`
+  // request selects the Confidentiality lens as the PRIMARY lens (compass#89 /
+  // design-software-factory-confidentiality.md §4 L3). Kept in lockstep with
+  // pilot's `KNOWN_SPECIALIZATIONS.CONFIDENTIALITY`. NOTE: the confidentiality
+  // *exposure* instruction is always-on for EVERY flavor in `buildReviewPrompt`;
+  // this flavor additionally makes it requestable as the primary lens.
+  "confidentiality",
 ] as const;
 
 export type ReviewFlavor = (typeof REVIEW_FLAVORS)[number];

--- a/src/runner/__tests__/review-prompt.test.ts
+++ b/src/runner/__tests__/review-prompt.test.ts
@@ -86,4 +86,96 @@ describe("buildReviewPrompt (cortex#911)", () => {
   test("is pure — identical input yields byte-identical output", () => {
     expect(buildReviewPrompt(payload({ post: true }))).toBe(buildReviewPrompt(payload({ post: true })));
   });
+
+  test("is pure even with a flavor stamped (compass#89)", () => {
+    expect(buildReviewPrompt(payload({ flavor: "security" }))).toBe(
+      buildReviewPrompt(payload({ flavor: "security" })),
+    );
+  });
+});
+
+describe("buildReviewPrompt — flavor → primary lens (compass#89 drift-1)", () => {
+  // THE load-bearing regression test. Before the fix, the flavor never reached
+  // the prompt, so `code-review.security` and `code-review.typescript` produced
+  // a BYTE-IDENTICAL prompt (the flavor-inert SEV-1). If this ever passes again
+  // by being equal, drift-1 has reopened.
+  test("security-flavor prompt !== typescript-flavor prompt", () => {
+    const security = buildReviewPrompt(payload({ flavor: "security" }));
+    const typescript = buildReviewPrompt(payload({ flavor: "typescript" }));
+    expect(security).not.toBe(typescript);
+  });
+
+  test("security selects the Security lens as the primary lens", () => {
+    const p = buildReviewPrompt(payload({ flavor: "security" }));
+    expect(p).toContain("**Security** lens as the primary lens");
+  });
+
+  test("confidentiality selects the Confidentiality lens as the primary lens", () => {
+    const p = buildReviewPrompt(payload({ flavor: "confidentiality" }));
+    expect(p).toContain("**Confidentiality** lens as the primary lens");
+  });
+
+  test("an unmapped flavor falls back to the FullReview primary lens", () => {
+    const p = buildReviewPrompt(payload({ flavor: "typescript" }));
+    expect(p).toContain("**FullReview** lens as the primary lens");
+  });
+
+  test("an unstamped payload (no flavor) falls back to FullReview", () => {
+    const p = buildReviewPrompt(payload());
+    expect(p).toContain("**FullReview** lens as the primary lens");
+  });
+
+  test("confidentiality primary directive differs from the always-on exposure mention", () => {
+    // The confidentiality flavor names Confidentiality as the PRIMARY lens, and
+    // the always-on exposure block ALSO mentions the Confidentiality lens for
+    // every flavor. They must be distinct strings so the primary-lens signal is
+    // not merely the ever-present exposure mention.
+    const conf = buildReviewPrompt(payload({ flavor: "confidentiality" }));
+    const ts = buildReviewPrompt(payload({ flavor: "typescript" }));
+    expect(conf).toContain("**Confidentiality** lens as the primary lens");
+    expect(ts).not.toContain("**Confidentiality** lens as the primary lens");
+  });
+});
+
+describe("buildReviewPrompt — always-on exposure + confidentiality (compass#89 §4 L3)", () => {
+  const FLAVORS = [
+    undefined,
+    "generic",
+    "typescript",
+    "security",
+    "confidentiality",
+  ] as const;
+
+  for (const flavor of FLAVORS) {
+    test(`exposure instruction is present for flavor=${flavor ?? "(none)"} (fires on EVERY flavor)`, () => {
+      const p = buildReviewPrompt(payload(flavor === undefined ? {} : { flavor }));
+      // The runtime gh check the reviewer must run.
+      expect(p).toContain("gh repo view the-metafactory/cortex --json visibility");
+      // Fail-closed exposure semantics.
+      expect(p).toContain("EXPOSED");
+      expect(p).toMatch(/errors, rate-limits, or returns\s+an unknown\/empty visibility/);
+      // Never-quote rule (redaction discipline baked into the prompt).
+      expect(p).toContain("NEVER quote suspected");
+      expect(p).toContain("`file:line`");
+    });
+  }
+
+  test("emits the machine-checkable confidentiality_lens_ran verdict field", () => {
+    const p = buildReviewPrompt(payload({ flavor: "confidentiality" }));
+    expect(p).toContain("confidentiality_lens_ran");
+    // …and the sample block stays valid JSON with the new field present.
+    const block = lastJsonBlock(p);
+    expect(block).not.toBeNull();
+    const parsed = JSON.parse(block!) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("confidentiality_lens_ran");
+    expect(typeof parsed.confidentiality_lens_ran).toBe("boolean");
+  });
+
+  test("builder stays PURE — it never actually shells out (no runtime gh call)", () => {
+    // Determinism guard: the exposure check is an INSTRUCTION to the reviewer,
+    // not a side effect of the builder. Same payload in → identical string out.
+    expect(buildReviewPrompt(payload({ flavor: "confidentiality" }))).toBe(
+      buildReviewPrompt(payload({ flavor: "confidentiality" })),
+    );
+  });
 });

--- a/src/runner/__tests__/sage-runner.test.ts
+++ b/src/runner/__tests__/sage-runner.test.ts
@@ -604,4 +604,62 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
     if (result.kind !== "verdict") return;
     expect(result.envelope.type).toBe("review.verdict.changes-requested");
   });
+
+  // compass#89 (§4 L3) — confidentiality flavor is a PRE-SPAWN cant_do
+  // ---------------------------------------------------------------------
+  // The sage engine has no confidentiality lens, so a
+  // `code-review.confidentiality` request must fail with `cant_do` BEFORE any
+  // subprocess runs — never silently run a generic pass and return a verdict
+  // that never looked for disclosure. This is the runtime guard for the
+  // generic-claim path; `--lens` threading for other flavors is deferred to
+  // compass#99.
+
+  test("compass#89 — payload.flavor=confidentiality → cant_do PRE-SPAWN (spawn never runs)", async () => {
+    const spawnThatMustNotRun: SageSpawnFn = () => {
+      throw new Error("sage-runner test: spawn must not run for a confidentiality request");
+    };
+    const runner = makeSageReviewRunner({
+      spawn: spawnThatMustNotRun,
+      which: whichSuccess, // binary resolvable — proves the refusal is flavor-driven, not missing-binary
+    });
+    const base = makePipelineOpts();
+    const opts: ReviewPipelineOpts = {
+      ...base,
+      payload: { ...base.payload, flavor: "confidentiality" },
+    };
+
+    // Must NOT throw — the consumer assumes a non-throwing pipeline runner.
+    const result = await runner(opts);
+
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") return;
+    const envelope: Envelope = result.envelope;
+    expect(envelope.type).toBe("dispatch.task.failed");
+    expect(envelope.correlation_id).toBe(opts.requestEnvelope.id);
+    const reason = (envelope.payload as { reason: { kind: string; detail: string } }).reason;
+    expect(reason.kind).toBe("cant_do");
+    expect(reason.detail).toContain("no confidentiality lens");
+  });
+
+  test("compass#89 — a non-confidentiality flavor still spawns sage (guard is confidentiality-only)", async () => {
+    const prior = process.env.SAGE_SUBSTRATE;
+    delete process.env.SAGE_SUBSTRATE;
+    try {
+      const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
+      const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
+      const base = makePipelineOpts();
+      const opts: ReviewPipelineOpts = {
+        ...base,
+        payload: { ...base.payload, flavor: "security" },
+      };
+      const result = await runner(opts);
+      expect(result.kind).toBe("verdict");
+      // The guard did NOT fire — sage spawned. And (deferred to #99) no
+      // `--lens` flag is threaded yet, so the argv is the unchanged shape.
+      expect(spawn.calls.length).toBe(1);
+      expect(spawn.calls[0]).not.toContain("--lens");
+    } finally {
+      if (prior !== undefined) process.env.SAGE_SUBSTRATE = prior;
+    }
+  });
 });

--- a/src/runner/__tests__/verdict-block.test.ts
+++ b/src/runner/__tests__/verdict-block.test.ts
@@ -1,0 +1,61 @@
+/**
+ * compass#89 (§4 L3) — unit coverage for the OPTIONAL
+ * `confidentiality_lens_ran` field on the shared verdict-block parser
+ * (`src/runner/verdict-block.ts`).
+ *
+ * The field is machine-checkable execution evidence that the Confidentiality
+ * lens ran. It is OPTIONAL for wire back-compat: a verdict block emitted before
+ * this field existed (or by the sage engine, which defers its lens threading to
+ * compass#99) MUST still parse. When present it MUST be a boolean.
+ *
+ * These tests exercise `parseVerdictBlock` directly (no pipeline harness) so the
+ * absent / present-true / present-false / present-wrong-type matrix is pinned in
+ * isolation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseVerdictBlock } from "../verdict-block";
+
+/** A minimal valid verdict block, before the optional field is added. */
+const BASE = {
+  verdict: "commented",
+  summary: "one-line summary",
+  github_review_id: 0,
+  github_review_url: "",
+  submitted_at: "2026-07-02T00:00:00Z",
+  commit_id: "deadbeef",
+  findings: { blockers: 0, majors: 0, nits: 0 },
+  inline_comments: 0,
+} as const;
+
+describe("parseVerdictBlock — confidentiality_lens_ran (compass#89)", () => {
+  test("absent field parses OK (back-compat) and stays undefined", () => {
+    const r = parseVerdictBlock(JSON.stringify(BASE));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.confidentiality_lens_ran).toBeUndefined();
+    expect("confidentiality_lens_ran" in r.value).toBe(false);
+  });
+
+  test("present true is carried through verbatim", () => {
+    const r = parseVerdictBlock(JSON.stringify({ ...BASE, confidentiality_lens_ran: true }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.confidentiality_lens_ran).toBe(true);
+  });
+
+  test("present false is carried through verbatim (NOT coerced to absent)", () => {
+    const r = parseVerdictBlock(JSON.stringify({ ...BASE, confidentiality_lens_ran: false }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.confidentiality_lens_ran).toBe(false);
+    expect("confidentiality_lens_ran" in r.value).toBe(true);
+  });
+
+  test("present-but-wrong-type is a contract error (validate-if-present)", () => {
+    const r = parseVerdictBlock(JSON.stringify({ ...BASE, confidentiality_lens_ran: "yes" }));
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.detail).toContain("confidentiality_lens_ran must be a boolean");
+  });
+});

--- a/src/runner/review-pipeline.ts
+++ b/src/runner/review-pipeline.ts
@@ -468,6 +468,13 @@ export async function runReviewPipeline(
       nits: parsed.value.findings.nits,
     },
     inline_comments: parsed.value.inline_comments,
+    // compass#89 (§4 L3) — carry the confidentiality-lens-ran evidence onto the
+    // verdict envelope so the autonomous loop can distinguish a clean lens run
+    // from a silent skip. Conditional spread: absent when the reviewer didn't
+    // emit it (older reviewers / sage), so the wire stays back-compatible.
+    ...(parsed.value.confidentiality_lens_ran !== undefined && {
+      confidentiality_lens_ran: parsed.value.confidentiality_lens_ran,
+    }),
     // cortex#503 — stamp the deterministic presentation markdown computed
     // by cortex from the structured fields. Zero LLM tokens: the reviewing
     // agent only authored `summary`; the heading/emoji/counts/link line are

--- a/src/runner/review-prompt.ts
+++ b/src/runner/review-prompt.ts
@@ -1,4 +1,30 @@
-import type { ReviewRequestPayload } from "../bus/review-events";
+import type { ReviewFlavor, ReviewRequestPayload } from "../bus/review-events";
+
+/**
+ * Map a review `<flavor>` to the CodeReview skill lens that runs as the
+ * PRIMARY lens for the review (compass#89 drift-1 fix). The flavor is the
+ * routing authority carried on the `tasks.code-review.<flavor>` subject and
+ * stamped onto the payload by the review consumer.
+ *
+ * The mapping is deliberately small and total: only `security` and
+ * `confidentiality` name a dedicated primary lens; every other flavor
+ * (`typescript`, `python`, `generic`, …) and an unstamped payload
+ * (`flavor === undefined`, e.g. legacy callers) fall through to the
+ * full-coverage `FullReview` lens. The full flavor→workflow catalog
+ * (`hardening`→HardeningReview, `skill-quality`→SkillReview, …) is F3's
+ * scope (compass#96); this map is the minimum that makes the two shipped
+ * dedicated lenses reachable and pins drift-1 shut.
+ */
+export function lensForFlavor(flavor: ReviewFlavor | undefined): string {
+  switch (flavor) {
+    case "security":
+      return "Security";
+    case "confidentiality":
+      return "Confidentiality";
+    default:
+      return "FullReview";
+  }
+}
 
 /**
  * Build the CC-session review prompt (cortex#911).
@@ -56,8 +82,39 @@ export function buildReviewPrompt(payload: ReviewRequestPayload): string {
         '`github_review_id` as `0` and `github_review_url` as `""`.',
       ].join(" ");
 
+  // drift-1 fix (compass#89): the flavor stamped onto the payload selects the
+  // PRIMARY lens. Before this the flavor never reached the prompt, so every
+  // flavor produced a byte-identical review (the flavor-inert SEV-1).
+  const lens = lensForFlavor(payload.flavor);
+  const lensDirective =
+    `Run the CodeReview skill's **${lens}** lens as the primary lens for this review.`;
+
+  // ALWAYS-ON exposure + confidentiality instruction — appended for EVERY
+  // flavor (design-software-factory-confidentiality.md §4 L3: "Confidentiality
+  // runs on every review of an exposed repo regardless of flavor"). The builder
+  // stays PURE: it emits the instruction; the REVIEWER performs the runtime
+  // `gh` check. Exposure detection FAILS CLOSED — unknown/error ⇒ EXPOSED.
+  const exposureInstruction = [
+    "Before reviewing, determine the target repo's exposure: run",
+    `\`gh repo view ${payload.repo} --json visibility\`. Treat the repo as`,
+    "EXPOSED if it is public OR if that command errors, rate-limits, or returns",
+    "an unknown/empty visibility (fail closed — never assume private). On an",
+    "EXPOSED repo you MUST additionally run the CodeReview skill's",
+    "**Confidentiality** lens (checks C1–C6: real orgs/people as content;",
+    "deployment fragments in shippable paths; real identities in",
+    "seeds/fixtures/migrations; live platform IDs; identity-embedding",
+    "codes/acronyms; private→public content lifts). NEVER quote suspected",
+    "confidential content anywhere (review body, verdict block, worklog) —",
+    "report each finding by category and `file:line` only, never the literal",
+    "value.",
+  ].join(" ");
+
   return [
     `Review ${target} ${ref}.`,
+    "",
+    lensDirective,
+    "",
+    exposureInstruction,
     "",
     "You MUST end your output with a single fenced ```json verdict block as the",
     "terminal artefact (the cortex review pipeline parses the LAST such block",
@@ -72,13 +129,17 @@ export function buildReviewPrompt(payload: ReviewRequestPayload): string {
     '  "submitted_at": "2026-01-01T00:00:00Z",',
     '  "commit_id": "<PR head commit SHA>",',
     '  "findings": { "blockers": 0, "majors": 0, "nits": 0 },',
-    '  "inline_comments": 0',
+    '  "inline_comments": 0,',
+    '  "confidentiality_lens_ran": false',
     "}",
     "```",
     "",
     '`verdict` MUST be exactly one of "approved", "changes-requested", or',
     '"commented". Replace every sample value above with the real value for this',
     "review; all fields are required and the integer fields must be integers.",
+    "Set `confidentiality_lens_ran` to `true` when you ran the Confidentiality",
+    "lens (you MUST run it — and therefore set `true` — on an EXPOSED repo),",
+    "`false` only when the repo is confirmed non-exposed and you did not run it.",
     "",
     postInstruction,
   ].join("\n");

--- a/src/runner/sage-runner.ts
+++ b/src/runner/sage-runner.ts
@@ -206,6 +206,26 @@ export function makeSageReviewRunner(
     // `Envelope.payload` is `unknown` so we narrow once here.
     const payload = pipeline.payload;
 
+    // compass#89 (§4 L3): the sage engine has NO confidentiality lens
+    // (zero-hit grep in its lens registry — see audit F8/compass#99). A
+    // `code-review.confidentiality` request must therefore fail PRE-SPAWN with
+    // `cant_do` rather than silently running sage's generic CodeQuality pass and
+    // returning a verdict that never looked for disclosure — the runtime guard
+    // for the generic-claim path (a boot-time capability guard covers the
+    // declared-capability path). Threading `--lens <flavor>` for the OTHER
+    // flavors is deferred to compass#99 (sage is an external pinned binary; an
+    // unconditional lens flag can break older builds), so the assistant-engine
+    // prompt (`buildReviewPrompt`) remains the live drift-1 fix.
+    if (payload.flavor === "confidentiality") {
+      return failed(
+        pipeline,
+        correlationId,
+        startedAt,
+        "sage engine has no confidentiality lens (compass#89/#99); " +
+          "route code-review.confidentiality to an assistant-engine reviewer",
+      );
+    }
+
     // Resolve the sage binary. Priority: explicit > env > $PATH.
     const sageBin =
       explicitBin ?? process.env.SAGE_BIN ?? which("sage") ?? undefined;

--- a/src/runner/verdict-block.ts
+++ b/src/runner/verdict-block.ts
@@ -21,6 +21,15 @@ export interface VerdictBlock {
   commit_id: string;
   findings: { blockers: number; majors: number; nits: number };
   inline_comments: number;
+  /**
+   * compass#89 (§4 L3) — OPTIONAL machine-checkable evidence that the
+   * Confidentiality lens ran. Present only when the emitting reviewer set it
+   * (new CC reviews via `buildReviewPrompt` do; older reviewers and the sage
+   * engine do not). Absent ⇒ "lens-ran unknown", validated only when present:
+   * REQUIRED here would fail-closed every verdict block emitted before this
+   * field existed.
+   */
+  confidentiality_lens_ran?: boolean;
 }
 
 export type ParseResult<T> =
@@ -108,6 +117,15 @@ export function parseVerdictBlock(raw: string): ParseResult<VerdictBlock> {
   if (typeof obj.inline_comments !== "number" || !Number.isInteger(obj.inline_comments)) {
     return { ok: false, detail: "inline_comments must be an integer" };
   }
+  // compass#89 — OPTIONAL confidentiality-lens-ran evidence: validate the type
+  // ONLY when present. A missing field is legal (older reviewers / sage) and
+  // maps to `undefined`; a present-but-wrong-typed field is a contract error.
+  if (
+    obj.confidentiality_lens_ran !== undefined &&
+    typeof obj.confidentiality_lens_ran !== "boolean"
+  ) {
+    return { ok: false, detail: "confidentiality_lens_ran must be a boolean when present" };
+  }
   if (
     typeof obj.findings !== "object" ||
     obj.findings === null ||
@@ -141,6 +159,11 @@ export function parseVerdictBlock(raw: string): ParseResult<VerdictBlock> {
         nits: findings.nits,
       },
       inline_comments: obj.inline_comments,
+      // Only carry the field when the reviewer emitted it — an absent field
+      // stays absent (undefined), never coerced to `false`.
+      ...(obj.confidentiality_lens_ran !== undefined && {
+        confidentiality_lens_ran: obj.confidentiality_lens_ran,
+      }),
     },
   };
 }


### PR DESCRIPTION
## What & why

The `<flavor>` segment of a `code-review.<flavor>` request was **routing-only theatre**. `buildReviewPrompt(payload)` (`src/runner/review-prompt.ts`) never saw the flavor, `ReviewRequestPayload` had no flavor field, and the prompt-build call at `review-consumer.ts` passed `{ agentId, payload }` — the flavor was **dropped**. Result: `code-review.security` and `code-review.typescript` produced a **BYTE-IDENTICAL** prompt/argv. A security review of trust-path code silently dispatched a generic review.

This is **drift-1** — a content-inert-flavor **SEV-1** (`the-metafactory/compass` audit `design-review-scaffolding-audit.md` **F2**, and confidentiality design `design-software-factory-confidentiality.md` **§4 L3 / G9**).

`ReviewRequestPayload` is a **wire type**; the fix respects the wire protocol + the deterministic-surface / dispatch-by-capability principles (cortex `CONTEXT.md`): the subject suffix stays the routing **authority**, the payload carries no new required wire field, and the prompt is built in code, not by the model.

## The fix — payload-stamping (minimal blast radius)

1. **`src/common/types/review-flavors.ts`** — append `"confidentiality"` to `REVIEW_FLAVORS` (cross-cutting, orthogonal to language). `cortex-config.ts` renders the flavor set dynamically, so `capability: code-review.confidentiality` becomes config-valid for free.
2. **`src/bus/review-events.ts`** — add optional `flavor?: ReviewFlavor` to `ReviewRequestPayload` (OPTIONAL → wire back-compat) + optional `confidentiality_lens_ran?: boolean` to `ReviewVerdictPayload`.
3. **`src/bus/review-consumer.ts`** — stamp the **already-extracted** subject flavor onto the payload right after `parseReviewRequestPayload` (narrowed through `isReviewFlavor`). This threads flavor into **every** builder site with zero signature changes: `buildReviewPrompt`, the CO-7 `buildUntrustedReviewPrompt` (it embeds `buildReviewPrompt` verbatim), and `sage-runner` — they all already receive `payload`.
4. **`src/runner/review-prompt.ts`** — read `payload.flavor`, inject an explicit **primary-lens** directive (`security→Security`, `confidentiality→Confidentiality`, `default→FullReview`).
5. **ALWAYS-ON exposure instruction** — `buildReviewPrompt` appends, for **every** flavor, an exposure + confidentiality directive: run `gh repo view <repo> --json visibility`; **public / unknown / error ⇒ treat EXPOSED** (fail closed); then apply the Confidentiality lens (C1–C6); **never quote** suspected content (category + `file:line` only). The builder stays **PURE** — the reviewer performs the runtime `gh` check.
6. **`src/runner/sage-runner.ts`** — `confidentiality` → **`cant_do` PRE-SPAWN** (sage has no confidentiality lens — §4 L3, the runtime guard for the generic-claim path). The full sage `--lens` lens-registry mapping for the other flavors is **deferred to compass#99** (sage is an external pinned binary; an unconditional `--lens` can break older builds).
7. **Verdict-block `lens-ran` field** — `src/runner/verdict-block.ts` adds optional `confidentiality_lens_ran?: boolean` (`parseVerdictBlock` validate-if-present, default absent — REQUIRED would fail-closed every existing reviewer + the sage path). Threaded onto `ReviewVerdictPayload` in `src/runner/review-pipeline.ts`, and into the emitted-block sample + prose in `review-prompt.ts`.

The **load-bearing live fix** is the assistant-engine prompt (step 4/5) — that is the path running today; the sage path is latent (no deployed agent sets `engine: sage`).

## Tests

New/extended `src/runner/__tests__/review-prompt.test.ts` — the load-bearing **prompt-inequality** test:
- `buildReviewPrompt({…, flavor:"security"}) !== buildReviewPrompt({…, flavor:"typescript"})` — pins drift-1 shut.
- `flavor:"confidentiality"` contains the Confidentiality-lens **primary** directive (distinct from the always-on exposure mention).
- **every** flavor (incl. unstamped) contains the always-on exposure instruction (regression).

Plus `sage-runner.test.ts` (confidentiality `cant_do` PRE-SPAWN + non-confidentiality still spawns, no `--lens`) and a focused `verdict-block.test.ts` (absent / true / false / wrong-type matrix).

Concrete demonstration:
```
security   line3: "Run the CodeReview skill's **Security** lens as the primary lens for this review."
typescript line3: "Run the CodeReview skill's **FullReview** lens as the primary lens for this review."
conf       line3: "Run the CodeReview skill's **Confidentiality** lens as the primary lens for this review."
security === typescript prompt?  false   ← drift-1 shut
```

### Verification (scoped)
- `bunx tsc --noEmit` — clean.
- `bun test src/runner/__tests__/review-prompt.test.ts` — **22 pass / 0 fail**.
- `bun test src/bus/ src/common/types/` — **1677 pass / 0 fail**.
- `bun test src/runner/` — **836 pass / 0 fail**.

## Scope / provenance
- Closes **G9** + the flavor-inert **SEV-1** (drift-1).
- Refs the-metafactory/compass#89 §4 L3, audit **F2**.
- Merge lockstep (per compass#89 plan): pilot PR9 → skill PR7 → **this (cortex PR8) LAST**.

Redaction: generic fixtures only (`the-metafactory/cortex`, all-zero snowflakes) — no client names, real identities, or live IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)