### PR TITLE
feat(review): reconcile flavor catalog + contractual skill/workflow invocation (compass#96 F16/F3)

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -160,28 +160,41 @@ stack:
 # and `provided_by[]` (≥1 declared agent id). Optional fields are `tags`,
 # `rate`, `cost` — see `src/common/types/capability.ts` for the full grammar.
 #
-# The 8 code-review.* flavors below match the arc-skill-code-review skill
-# pack shipped with Echo. Pilot's `pilot request-review --capability X`
-# requests resolve against this catalog, so every `--capability X` value
-# a principal might invoke must have a matching entry here.
+# The 11 code-review.* flavors below are the canonical review-flavor catalog
+# (the single source is `src/common/types/review-flavors.ts` REVIEW_FLAVORS —
+# every id here MUST resolve via `reviewFlavorOfCapability`, enforced by
+# `src/__tests__/review-flavors-catalog.test.ts`). Pilot's `pilot request-review
+# --capability X` requests resolve against this catalog, so every `--capability X`
+# value a principal might invoke must have a matching entry here. NOTE:
+# `architecture` / `performance` / `ecosystem-compliance` are LENSES inside
+# FullReview, not standalone flavors — they are intentionally absent.
 capabilities:
+  - id: code-review.generic
+    description: General-purpose code review (all lenses, no language specialisation)
+    provided_by: [echo]
   - id: code-review.typescript
     description: TypeScript code review (correctness, types, idioms)
     provided_by: [echo]
-  - id: code-review.documentation
+  - id: code-review.python
+    description: Python code review (correctness, types, idioms)
+    provided_by: [echo]
+  - id: code-review.rust
+    description: Rust code review (correctness, ownership, idioms)
+    provided_by: [echo]
+  - id: code-review.go
+    description: Go code review (correctness, concurrency, idioms)
+    provided_by: [echo]
+  - id: code-review.sql
+    description: SQL code review (queries, schema, migrations)
+    provided_by: [echo]
+  - id: code-review.docs
     description: Documentation review (markdown specs, design docs, READMEs)
     provided_by: [echo]
   - id: code-review.security
     description: Security review (auth, secrets, OWASP, defensive coding)
     provided_by: [echo]
-  - id: code-review.architecture
-    description: Architecture review (layering, dependencies, design fit)
-    provided_by: [echo]
-  - id: code-review.performance
-    description: Performance review (algorithmic complexity, hot paths, allocations)
-    provided_by: [echo]
-  - id: code-review.ecosystem-compliance
-    description: Ecosystem compliance review (CLAUDE.md, SOP adherence, conventions)
+  - id: code-review.confidentiality
+    description: Confidentiality review (real orgs/people/identities exposed in shippable paths)
     provided_by: [echo]
   - id: code-review.hardening
     description: Hardening review (defensive boundaries, failure handling, error paths)
@@ -346,12 +359,15 @@ agents:
       # genuinely should NOT provide that capability; otherwise keep
       # both surfaces in sync.
       capabilities:
+        - code-review.generic
         - code-review.typescript
-        - code-review.documentation
+        - code-review.python
+        - code-review.rust
+        - code-review.go
+        - code-review.sql
+        - code-review.docs
         - code-review.security
-        - code-review.architecture
-        - code-review.performance
-        - code-review.ecosystem-compliance
+        - code-review.confidentiality
         - code-review.hardening
         - code-review.skill-quality
     presence:

--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -320,8 +320,8 @@ policy:
   #         url: nats://research:4222
   #         credsPath: ~/.config/cortex/creds/research.creds
   #       peers:
-  #         - principal_id: jcfischer
-  #           stack_id: jcfischer/sage-host
+  #         - principal_id: peer-principal              # <REPLACE_ME>
+  #           stack_id: peer-principal/peer-stack       # <REPLACE_ME> ({principal}/{slug})
   #           principal_pubkey: U...   # peer stack NKey public key (56 chars)
   #       accept_subjects:
   #         - federated.research-collab.>

--- a/src/__tests__/cortex.review-session-opts.test.ts
+++ b/src/__tests__/cortex.review-session-opts.test.ts
@@ -113,4 +113,13 @@ describe("buildReviewSessionOpts — bus-side review-consumer CC opts", () => {
     const opts = buildReviewSessionOpts(configWith({}), agent());
     expect("bashAllowlist" in opts).toBe(false);
   });
+
+  test("pins allowedSkills to exactly ['code-review'] (compass#96 F3)", () => {
+    // The review prompt now contractually names a CodeReview workflow to
+    // invoke; without this pin cc-session's Skill Guard would deny the Skill
+    // tool and the reviewer could not run the workflow. Grant is exactly the
+    // one skill the review path needs — never wider.
+    const opts = buildReviewSessionOpts(configWith({}), agent());
+    expect(opts.allowedSkills).toEqual(["code-review"]);
+  });
 });

--- a/src/__tests__/cortex.yaml-example.test.ts
+++ b/src/__tests__/cortex.yaml-example.test.ts
@@ -37,13 +37,14 @@ describe("cortex.yaml.example — first-install starter config (cortex#314)", ()
     expect(parsed.agents.length).toBeGreaterThan(0);
   });
 
-  test("declares the 8 code-review.* capability flavors echo provides", () => {
-    // The capability-dispatch design has 8 canonical code-review flavors
-    // that arc-skill-code-review v0.4.0 ships with. The example MUST
-    // declare all 8 in the top-level catalog (and reference all 8 from
-    // the echo agent's runtime.capabilities[]) so a fresh principal
-    // copying the file does not have to know the flavor list to wire
-    // capability-dispatch end-to-end.
+  test("declares the 11 canonical code-review.* capability flavors echo provides", () => {
+    // compass#96 F16 — the canonical review-flavor catalog is the 11 flavors
+    // in REVIEW_FLAVORS (`src/common/types/review-flavors.ts`). The example MUST
+    // declare all 11 in the top-level catalog (and reference all 11 from the
+    // echo agent's runtime.capabilities[]) so a fresh principal copying the file
+    // does not have to know the flavor list to wire capability-dispatch
+    // end-to-end. `architecture` / `performance` / `ecosystem-compliance` are
+    // LENSES inside FullReview, not flavors — they must be ABSENT.
     const examplePath = join(import.meta.dir, "..", "..", "cortex.yaml.example");
     const raw = readFileSync(examplePath, "utf-8");
     const yamlObj: unknown = parseYaml(raw);
@@ -51,17 +52,30 @@ describe("cortex.yaml.example — first-install starter config (cortex#314)", ()
 
     const catalogIds = new Set(parsed.capabilities.map((c) => c.id));
     const expected = [
+      "code-review.generic",
       "code-review.typescript",
-      "code-review.documentation",
+      "code-review.python",
+      "code-review.rust",
+      "code-review.go",
+      "code-review.sql",
+      "code-review.docs",
       "code-review.security",
-      "code-review.architecture",
-      "code-review.performance",
-      "code-review.ecosystem-compliance",
+      "code-review.confidentiality",
       "code-review.hardening",
       "code-review.skill-quality",
     ];
     for (const id of expected) {
       expect(catalogIds.has(id)).toBe(true);
+    }
+
+    // The dropped ids (lenses, not flavors) must NOT reappear.
+    for (const phantom of [
+      "code-review.documentation",
+      "code-review.architecture",
+      "code-review.performance",
+      "code-review.ecosystem-compliance",
+    ]) {
+      expect(catalogIds.has(phantom)).toBe(false);
     }
 
     const echo = parsed.agents.find((a) => a.id === "echo");

--- a/src/__tests__/review-flavors-catalog.test.ts
+++ b/src/__tests__/review-flavors-catalog.test.ts
@@ -1,0 +1,96 @@
+/**
+ * compass#96 F16 — catalog reconciliation guard.
+ *
+ * `cortex.yaml.example`'s `code-review.<flavor>` capability catalog and the
+ * canonical `REVIEW_FLAVORS` vocabulary (`src/common/types/review-flavors.ts`)
+ * are two surfaces of ONE contract. Before this reconciliation they had drifted:
+ * the example declared `code-review.documentation` / `.architecture` /
+ * `.performance` / `.ecosystem-compliance` — ids that do NOT resolve via
+ * `reviewFlavorOfCapability` (phantoms a principal could `pilot request-review
+ * --capability` against and get nothing), while omitting real flavors.
+ *
+ * This test parses the on-disk example and asserts, in BOTH directions:
+ *   1. NO PHANTOM — every `code-review.*` id in the example (top-level catalog
+ *      AND every agent's runtime.capabilities[]) resolves via
+ *      `reviewFlavorOfCapability` / `isReviewFlavor`.
+ *   2. NO GAP — every canonical `REVIEW_FLAVORS` flavor is declared in the
+ *      example's top-level catalog, so the starter config is complete.
+ *
+ * A future flavor added to `REVIEW_FLAVORS` without updating the example (or a
+ * stray non-flavor capability added to the example) fails here.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parse as parseYaml } from "yaml";
+import { CortexConfigSchema } from "../common/types/cortex-config";
+import {
+  REVIEW_FLAVORS,
+  isReviewFlavor,
+  reviewFlavorOfCapability,
+} from "../common/types/review-flavors";
+
+function loadExample(): ReturnType<typeof CortexConfigSchema.parse> {
+  const examplePath = join(import.meta.dir, "..", "..", "cortex.yaml.example");
+  const raw = readFileSync(examplePath, "utf-8");
+  const yamlObj: unknown = parseYaml(raw);
+  return CortexConfigSchema.parse(yamlObj);
+}
+
+const CODE_REVIEW_PREFIX = "code-review.";
+
+describe("cortex.yaml.example — review-flavor catalog reconciliation (compass#96 F16)", () => {
+  test("every code-review.* id in the top-level catalog resolves to a flavor (no phantom)", () => {
+    const parsed = loadExample();
+    const ids = parsed.capabilities
+      .map((c) => c.id)
+      .filter((id) => id.startsWith(CODE_REVIEW_PREFIX));
+
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      // `reviewFlavorOfCapability` is the ONE parser of the `code-review.<flavor>`
+      // syntax; undefined means the id is not a known flavor (a phantom).
+      expect(reviewFlavorOfCapability(id)).toBeDefined();
+      // …and the trailing segment is a known flavor via `isReviewFlavor`.
+      expect(isReviewFlavor(id.slice(CODE_REVIEW_PREFIX.length))).toBe(true);
+    }
+  });
+
+  test("every code-review.* id in every agent's runtime.capabilities resolves (no phantom)", () => {
+    const parsed = loadExample();
+    const agentReviewIds = parsed.agents.flatMap((a) =>
+      (a.runtime?.capabilities ?? []).filter((id) =>
+        id.startsWith(CODE_REVIEW_PREFIX),
+      ),
+    );
+
+    expect(agentReviewIds.length).toBeGreaterThan(0);
+    for (const id of agentReviewIds) {
+      expect(reviewFlavorOfCapability(id)).toBeDefined();
+    }
+  });
+
+  test("the top-level catalog declares EVERY canonical flavor (no gap)", () => {
+    const parsed = loadExample();
+    const declared = new Set(
+      parsed.capabilities
+        .map((c) => c.id)
+        .filter((id) => id.startsWith(CODE_REVIEW_PREFIX))
+        .map((id) => id.slice(CODE_REVIEW_PREFIX.length)),
+    );
+    for (const flavor of REVIEW_FLAVORS) {
+      expect(declared.has(flavor)).toBe(true);
+    }
+  });
+
+  test("the example catalog is EXACTLY the canonical flavor set (bijective)", () => {
+    const parsed = loadExample();
+    const declared = parsed.capabilities
+      .map((c) => c.id)
+      .filter((id) => id.startsWith(CODE_REVIEW_PREFIX))
+      .map((id) => id.slice(CODE_REVIEW_PREFIX.length))
+      .sort();
+    expect(declared).toEqual([...REVIEW_FLAVORS].sort());
+  });
+});

--- a/src/common/types/review-flavors.ts
+++ b/src/common/types/review-flavors.ts
@@ -13,6 +13,37 @@
  * (`design-pilot-restructure.md` §4.1), since pilot is the other producer of
  * `tasks.code-review.<flavor>`. Adding a flavor edits this file AND requires the
  * matching pilot-side update (sage cortex#1185 review).
+ *
+ * ## Authoritative catalog — flavor → CodeReview workflow / primary lens
+ *
+ * This table is the SINGLE source the other review files render against:
+ * `cortex.yaml.example`'s `code-review.<flavor>` capability catalog (every id
+ * MUST be a row here — enforced by `review-flavors-catalog.test.ts`), the
+ * `workflowForFlavor` map in `src/runner/review-prompt.ts` (the contractual
+ * skill/workflow invocation, compass#96 F3), and the arc-skill-code-review
+ * `SKILL.md` routing table (Round-2 skill PR).
+ *
+ * | flavor            | CodeReview workflow | primary lens emphasis                    |
+ * |-------------------|---------------------|------------------------------------------|
+ * | `generic`         | FullReview          | all lenses, no language specialisation   |
+ * | `typescript`      | FullReview          | Correctness/Types (TypeScript idioms)    |
+ * | `python`          | FullReview          | Correctness/Types (Python idioms)        |
+ * | `rust`            | FullReview          | Correctness/Types (Rust idioms)          |
+ * | `go`              | FullReview          | Correctness/Types (Go idioms)            |
+ * | `sql`             | FullReview          | Correctness (queries, migrations)        |
+ * | `docs`            | FullReview          | Documentation (specs, design docs)       |
+ * | `security`        | SecurityReview      | Security (auth, secrets, OWASP)          |
+ * | `confidentiality` | FullReview          | Confidentiality (always-on §4 L3 block)  |
+ * | `hardening`       | HardeningReview     | Hardening (defensive boundaries)         |
+ * | `skill-quality`   | SkillReview         | Skill quality (AGENTSKILLS.io structure) |
+ *
+ * `security`, `hardening`, and `skill-quality` name a DEDICATED workflow; every
+ * other flavor runs FullReview with its primary-lens emphasis (a `confidentiality`
+ * request runs FullReview because the Confidentiality lens is already always-on
+ * for every review — compass#96 F3 decision, no separate ConfidentialityReview
+ * workflow). `architecture` / `performance` / `ecosystem-compliance` are LENSES
+ * inside FullReview, NOT standalone flavors — they are deliberately absent from
+ * this catalog (a `code-review.architecture` capability is a phantom).
  */
 export const REVIEW_FLAVORS = [
   "generic",
@@ -30,6 +61,13 @@ export const REVIEW_FLAVORS = [
   // *exposure* instruction is always-on for EVERY flavor in `buildReviewPrompt`;
   // this flavor additionally makes it requestable as the primary lens.
   "confidentiality",
+  // compass#96 F16 (WIDEN) — the two flavors whose CodeReview workflows already
+  // ship (HardeningReview, SkillReview) but were not bus-reachable as flavors.
+  // Adding them makes the `code-review.hardening` / `code-review.skill-quality`
+  // capabilities in `cortex.yaml.example` resolve (no phantom) and the catalog
+  // table above truthful. Kept in lockstep with pilot's KNOWN_SPECIALIZATIONS.
+  "hardening",
+  "skill-quality",
 ] as const;
 
 export type ReviewFlavor = (typeof REVIEW_FLAVORS)[number];

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -359,6 +359,12 @@ export { pidFileFor };
  * spawned CC sees only globally-configured MCP tools and politely
  * refuses with "I don't have access to GitHub CLI tools".
  *
+ * compass#96 F3 — also pins `allowedSkills: ['code-review']` so the
+ * contractual "Invoke the CodeReview skill — {Workflow} workflow"
+ * directive that `buildReviewPrompt` now emits can actually resolve the
+ * Skill tool (cc-session strips any `Skill` deny + registers the Skill
+ * Guard hook that pins the grant list, cortex#710).
+ *
  * `asyncTimeoutMs` matches the Discord path's choice (review work
  * is async). `bashAllowlist` is propagated when present; the runtime
  * gate at `src/runner/hooks/bash-guard.hook.ts:218` currently
@@ -383,6 +389,14 @@ export function buildReviewSessionOpts(
     allowedDirs: config.claude.allowedDirs,
     timeoutMs: config.claude.asyncTimeoutMs,
     cwd: process.cwd(),
+    // compass#96 F3 — pin the CodeReview skill for the review session. The
+    // prompt (`buildReviewPrompt`) now contractually names a CodeReview
+    // workflow (`workflowForFlavor`), so the reviewer must be able to invoke
+    // the Skill tool for `code-review`. cc-session honours `allowedSkills` by
+    // stripping any `Skill` deny + registering the Skill Guard hook that pins
+    // the grant list (cortex#710). Grant exactly the one skill the review path
+    // needs — nothing wider.
+    allowedSkills: ["code-review"],
     ...(config.claude.bashAllowlist !== undefined && {
       bashAllowlist: config.claude.bashAllowlist,
     }),

--- a/src/runner/__tests__/review-prompt.test.ts
+++ b/src/runner/__tests__/review-prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { buildReviewPrompt } from "../review-prompt";
+import { buildReviewPrompt, workflowForFlavor } from "../review-prompt";
 import type { ReviewRequestPayload } from "../../bus/review-events";
 
 function payload(over: Partial<ReviewRequestPayload> = {}): ReviewRequestPayload {
@@ -94,46 +94,74 @@ describe("buildReviewPrompt (cortex#911)", () => {
   });
 });
 
-describe("buildReviewPrompt — flavor → primary lens (compass#89 drift-1)", () => {
-  // THE load-bearing regression test. Before the fix, the flavor never reached
-  // the prompt, so `code-review.security` and `code-review.typescript` produced
-  // a BYTE-IDENTICAL prompt (the flavor-inert SEV-1). If this ever passes again
-  // by being equal, drift-1 has reopened.
+describe("workflowForFlavor — flavor → CodeReview workflow (compass#96 F3)", () => {
+  test("security → SecurityReview", () => {
+    expect(workflowForFlavor("security")).toBe("SecurityReview");
+  });
+  test("hardening → HardeningReview", () => {
+    expect(workflowForFlavor("hardening")).toBe("HardeningReview");
+  });
+  test("skill-quality → SkillReview", () => {
+    expect(workflowForFlavor("skill-quality")).toBe("SkillReview");
+  });
+  test("confidentiality → FullReview (F3 decision: no separate ConfidentialityReview)", () => {
+    // The always-on §4 L3 exposure block already makes the Confidentiality lens
+    // primary on every review, so the confidentiality flavor runs FullReview.
+    expect(workflowForFlavor("confidentiality")).toBe("FullReview");
+  });
+  test("language flavors → FullReview", () => {
+    for (const f of ["generic", "typescript", "python", "rust", "go", "sql", "docs"] as const) {
+      expect(workflowForFlavor(f)).toBe("FullReview");
+    }
+  });
+  test("an unstamped flavor (undefined) → FullReview", () => {
+    expect(workflowForFlavor(undefined)).toBe("FullReview");
+  });
+});
+
+describe("buildReviewPrompt — contractual workflow invocation (compass#96 F3)", () => {
+  test("emits the CONTRACTUAL 'Invoke the CodeReview skill' directive", () => {
+    const p = buildReviewPrompt(payload({ flavor: "security" }));
+    expect(p).toContain("Invoke the CodeReview skill");
+  });
+
+  test("security names the SecurityReview workflow in the directive", () => {
+    const p = buildReviewPrompt(payload({ flavor: "security" }));
+    expect(p).toContain("**SecurityReview** workflow");
+  });
+
+  test("hardening names the HardeningReview workflow", () => {
+    const p = buildReviewPrompt(payload({ flavor: "hardening" }));
+    expect(p).toContain("**HardeningReview** workflow");
+  });
+
+  test("skill-quality names the SkillReview workflow", () => {
+    const p = buildReviewPrompt(payload({ flavor: "skill-quality" }));
+    expect(p).toContain("**SkillReview** workflow");
+  });
+
+  test("a language flavor names the FullReview workflow", () => {
+    const p = buildReviewPrompt(payload({ flavor: "typescript" }));
+    expect(p).toContain("**FullReview** workflow");
+  });
+
+  test("an unstamped payload (no flavor) names the FullReview workflow", () => {
+    const p = buildReviewPrompt(payload());
+    expect(p).toContain("**FullReview** workflow");
+  });
+
+  test("confidentiality names the FullReview workflow (F3 decision)", () => {
+    const p = buildReviewPrompt(payload({ flavor: "confidentiality" }));
+    expect(p).toContain("**FullReview** workflow");
+  });
+
+  // THE load-bearing drift-1 regression (compass#89, preserved through F3):
+  // a flavor that names a DEDICATED workflow must not produce the same prompt
+  // as a language flavor. If these are ever byte-equal, flavor routing is inert.
   test("security-flavor prompt !== typescript-flavor prompt", () => {
     const security = buildReviewPrompt(payload({ flavor: "security" }));
     const typescript = buildReviewPrompt(payload({ flavor: "typescript" }));
     expect(security).not.toBe(typescript);
-  });
-
-  test("security selects the Security lens as the primary lens", () => {
-    const p = buildReviewPrompt(payload({ flavor: "security" }));
-    expect(p).toContain("**Security** lens as the primary lens");
-  });
-
-  test("confidentiality selects the Confidentiality lens as the primary lens", () => {
-    const p = buildReviewPrompt(payload({ flavor: "confidentiality" }));
-    expect(p).toContain("**Confidentiality** lens as the primary lens");
-  });
-
-  test("an unmapped flavor falls back to the FullReview primary lens", () => {
-    const p = buildReviewPrompt(payload({ flavor: "typescript" }));
-    expect(p).toContain("**FullReview** lens as the primary lens");
-  });
-
-  test("an unstamped payload (no flavor) falls back to FullReview", () => {
-    const p = buildReviewPrompt(payload());
-    expect(p).toContain("**FullReview** lens as the primary lens");
-  });
-
-  test("confidentiality primary directive differs from the always-on exposure mention", () => {
-    // The confidentiality flavor names Confidentiality as the PRIMARY lens, and
-    // the always-on exposure block ALSO mentions the Confidentiality lens for
-    // every flavor. They must be distinct strings so the primary-lens signal is
-    // not merely the ever-present exposure mention.
-    const conf = buildReviewPrompt(payload({ flavor: "confidentiality" }));
-    const ts = buildReviewPrompt(payload({ flavor: "typescript" }));
-    expect(conf).toContain("**Confidentiality** lens as the primary lens");
-    expect(ts).not.toContain("**Confidentiality** lens as the primary lens");
   });
 });
 

--- a/src/runner/review-pipeline.ts
+++ b/src/runner/review-pipeline.ts
@@ -4,8 +4,13 @@
  * **CC bridge for the capability-dispatch review consumer.** Translates a
  * single parsed `ReviewRequestPayload` into either a `review.verdict.<kind>`
  * envelope (success) or a `dispatch.task.failed` envelope (failure), by
- * running the CodeReview skill inside a Claude Code session and parsing the
- * structured verdict block the skill emits at the end of its output.
+ * spawning a Claude Code session and parsing the structured verdict block it
+ * emits at the end of its output. This module passes the `prompt` +
+ * `sessionOpts` through verbatim; it does not itself name a skill. Per
+ * compass#96 F3 the review PROMPT (`buildReviewPrompt`) contractually names the
+ * CodeReview workflow to invoke (`workflowForFlavor`), and the session OPTS
+ * (`buildReviewSessionOpts`) pin `allowedSkills: ['code-review']` so that Skill
+ * invocation resolves — the skill contract lives at those two seams, not here.
  *
  * Anchors:
  *   - `docs/design-capability-dispatch-review-consumer.md` §4.5 — skill

--- a/src/runner/review-prompt.ts
+++ b/src/runner/review-prompt.ts
@@ -21,7 +21,13 @@ import type { ReviewFlavor, ReviewRequestPayload } from "../bus/review-events";
  * This SUPERSEDES compass#89's `lensForFlavor` (which named a primary *lens*):
  * F3 promotes the directive from "run lens X" to "invoke workflow X", so the
  * reviewer runs the actual CodeReview skill workflow rather than a prose gesture
- * at a lens. Kept exhaustive over `ReviewFlavor` so a new flavor forces a choice.
+ * at a lens.
+ *
+ * GENUINELY exhaustive over `ReviewFlavor | undefined`: every flavor (and the
+ * unstamped `undefined`) is an EXPLICIT case, and the `default` branch pins
+ * `flavor` to `never`. Adding a 12th flavor to `REVIEW_FLAVORS` without a case
+ * here stops compiling (the `never` assignment fails) — the compiler forces the
+ * choice rather than letting a new flavor silently fall through to FullReview.
  */
 export function workflowForFlavor(flavor: ReviewFlavor | undefined): string {
   switch (flavor) {
@@ -31,10 +37,26 @@ export function workflowForFlavor(flavor: ReviewFlavor | undefined): string {
       return "HardeningReview";
     case "skill-quality":
       return "SkillReview";
-    default:
-      // generic / typescript / python / rust / go / sql / docs /
-      // confidentiality / undefined — full-coverage review.
+    // Full-coverage review — the language/generic/docs/confidentiality flavors
+    // carry their emphasis as a lens INSIDE FullReview, not a distinct workflow;
+    // `confidentiality` runs FullReview because the always-on §4 L3 exposure
+    // block already makes its lens primary. `undefined` = legacy/unstamped.
+    case undefined:
+    case "generic":
+    case "typescript":
+    case "python":
+    case "rust":
+    case "go":
+    case "sql":
+    case "docs":
+    case "confidentiality":
       return "FullReview";
+    default: {
+      // Compile-time exhaustiveness guard (repo idiom, cf. src/renderers/index.ts):
+      // if `flavor` is not `never` here, a REVIEW_FLAVORS entry lacks a case above.
+      const _exhaustive: never = flavor;
+      throw new Error(`unreachable review flavor: ${String(_exhaustive)}`);
+    }
   }
 }
 

--- a/src/runner/review-prompt.ts
+++ b/src/runner/review-prompt.ts
@@ -1,27 +1,39 @@
 import type { ReviewFlavor, ReviewRequestPayload } from "../bus/review-events";
 
 /**
- * Map a review `<flavor>` to the CodeReview skill lens that runs as the
- * PRIMARY lens for the review (compass#89 drift-1 fix). The flavor is the
+ * Map a review `<flavor>` to the CodeReview skill **workflow** that the reviewer
+ * is contractually instructed to invoke (compass#96 F3). The flavor is the
  * routing authority carried on the `tasks.code-review.<flavor>` subject and
  * stamped onto the payload by the review consumer.
  *
- * The mapping is deliberately small and total: only `security` and
- * `confidentiality` name a dedicated primary lens; every other flavor
- * (`typescript`, `python`, `generic`, …) and an unstamped payload
- * (`flavor === undefined`, e.g. legacy callers) fall through to the
- * full-coverage `FullReview` lens. The full flavor→workflow catalog
- * (`hardening`→HardeningReview, `skill-quality`→SkillReview, …) is F3's
- * scope (compass#96); this map is the minimum that makes the two shipped
- * dedicated lenses reachable and pins drift-1 shut.
+ * The mapping is deliberately small and total, and is the render of the
+ * authoritative catalog table in `src/common/types/review-flavors.ts`:
+ *   - `security`      → `SecurityReview`
+ *   - `hardening`     → `HardeningReview`
+ *   - `skill-quality` → `SkillReview`
+ *   - `confidentiality` → `FullReview` (the always-on §4 L3 exposure block already
+ *     makes the Confidentiality lens primary on every review — compass#96 F3
+ *     decision: no separate ConfidentialityReview workflow)
+ *   - every language flavor (`typescript`, `python`, `generic`, …) and an
+ *     unstamped payload (`flavor === undefined`, e.g. legacy callers) →
+ *     `FullReview` (full-coverage; the language is the emphasis, not a workflow).
+ *
+ * This SUPERSEDES compass#89's `lensForFlavor` (which named a primary *lens*):
+ * F3 promotes the directive from "run lens X" to "invoke workflow X", so the
+ * reviewer runs the actual CodeReview skill workflow rather than a prose gesture
+ * at a lens. Kept exhaustive over `ReviewFlavor` so a new flavor forces a choice.
  */
-export function lensForFlavor(flavor: ReviewFlavor | undefined): string {
+export function workflowForFlavor(flavor: ReviewFlavor | undefined): string {
   switch (flavor) {
     case "security":
-      return "Security";
-    case "confidentiality":
-      return "Confidentiality";
+      return "SecurityReview";
+    case "hardening":
+      return "HardeningReview";
+    case "skill-quality":
+      return "SkillReview";
     default:
+      // generic / typescript / python / rust / go / sql / docs /
+      // confidentiality / undefined — full-coverage review.
       return "FullReview";
   }
 }
@@ -82,12 +94,17 @@ export function buildReviewPrompt(payload: ReviewRequestPayload): string {
         '`github_review_id` as `0` and `github_review_url` as `""`.',
       ].join(" ");
 
-  // drift-1 fix (compass#89): the flavor stamped onto the payload selects the
-  // PRIMARY lens. Before this the flavor never reached the prompt, so every
-  // flavor produced a byte-identical review (the flavor-inert SEV-1).
-  const lens = lensForFlavor(payload.flavor);
+  // compass#96 F3 — the flavor stamped onto the payload selects the CodeReview
+  // skill WORKFLOW the reviewer must invoke. This is a CONTRACTUAL invocation
+  // (run this workflow), not a prose gesture at a lens — the reviewer's own
+  // `allowedSkills: ['code-review']` pin (buildReviewSessionOpts) makes the
+  // Skill tool available for it. Supersedes compass#89's primary-lens directive;
+  // the flavor still reaches the prompt, so flavors stay non-identical (drift-1
+  // remains pinned shut).
+  const workflow = workflowForFlavor(payload.flavor);
   const lensDirective =
-    `Run the CodeReview skill's **${lens}** lens as the primary lens for this review.`;
+    `Invoke the CodeReview skill — **${workflow}** workflow — then emit the ` +
+    `verdict block below.`;
 
   // ALWAYS-ON exposure + confidentiality instruction — appended for EVERY
   // flavor (design-software-factory-confidentiality.md §4 L3: "Confidentiality


### PR DESCRIPTION
## What

Round-1 PR B for **compass#96** — closes review-scaffolding audit findings **F16** (catalog reconciliation) and **F3** (contractual skill invocation). Builds on the just-merged **#89** (`review-prompt.ts` `lensForFlavor` + always-on exposure/confidentiality block — **kept intact**).

## F16 — catalog reconciliation (WIDEN decision)

The `code-review.*` capability catalog in `cortex.yaml.example` had drifted from the canonical `REVIEW_FLAVORS` vocabulary: it declared phantom ids (`documentation`, `architecture`, `performance`, `ecosystem-compliance` — only `typescript`+`security` actually resolved via `isReviewFlavor`) while omitting real flavors.

- **`src/common/types/review-flavors.ts`** — **WIDEN** `REVIEW_FLAVORS` with `hardening` + `skill-quality` (per the adopted decision): their `HardeningReview`/`SkillReview` workflows already ship, so widening makes them bus-reachable and keeps the example truthful (consistent with #89 wiring those flavors). Added an **authoritative doc-comment catalog table** (flavor → CodeReview workflow / primary-lens emphasis) — the single source the other files render against.
- **`cortex.yaml.example`** — reconciled the top-level catalog **and** echo's `runtime.capabilities[]` to the canonical **11**: `documentation`→`docs`; **ADD** `generic, python, rust, go, sql, confidentiality`; **DROP** `architecture, performance, ecosystem-compliance` (these are **lenses inside FullReview**, not standalone workflows); **KEEP** `hardening, skill-quality` (now widened) + `typescript, security`. Fixed the "The 8 code-review.* flavors" count comment → **11**.
- **NEW `src/__tests__/review-flavors-catalog.test.ts`** — bijective guard: every `code-review.*` id in the example (catalog + agent runtime) resolves via `reviewFlavorOfCapability` (**no phantom**) AND every `REVIEW_FLAVORS` flavor is declared (**no gap**).

## F3 — contractual skill invocation

- **`src/runner/review-prompt.ts`** — add `workflowForFlavor(flavor)` returning a **workflow** name: `security`→`SecurityReview`, `hardening`→`HardeningReview`, `skill-quality`→`SkillReview`, `confidentiality`→`FullReview`, default/languages/undefined→`FullReview`. Promote the directive from #89's primary-lens gesture to a **contractual** invocation: *"Invoke the CodeReview skill — **{Workflow}** workflow — then emit the verdict block."* The #89 **always-on exposure/confidentiality block is kept intact**.
  - **Decision:** `confidentiality`→`FullReview` (no separate `ConfidentialityReview` workflow) — the always-on §4 L3 block already makes the Confidentiality lens primary on every review.
- **`src/cortex.ts` `buildReviewSessionOpts`** — add `allowedSkills: ['code-review']` so the Skill Guard permits the contractual invocation. Plumbing pre-exists end-to-end (`CCSessionOpts.allowedSkills` → cc-session strips `Skill` from `disallowedTools` + pins via the gate hook, cortex#710).
- **`src/runner/review-pipeline.ts`** docblock — corrected the stale "running the CodeReview skill" claim: the prompt names the workflow + the opts pin the skill; this bridge passes both through.

## Tests / verification

- `bunx tsc --noEmit` — **clean**.
- `bun test` (scoped): `src/runner/__tests__/review-prompt.test.ts`, `src/__tests__/` (186 pass), `src/common/types/` (426 pass), `src/bus/__tests__/review-consumer + reflex` (166 pass). All green.
- `bunx eslint --quiet` on changed files — clean.

## Notes / follow-ups

- **WIDEN is a cross-repo wire contract.** `REVIEW_FLAVORS` must stay in lockstep with pilot's `KNOWN_SPECIALIZATIONS`; the matching pilot-side add of `hardening`/`skill-quality` is a follow-up (per the review-flavors.ts contract note).
- The **arc-skill-code-review `SKILL.md`** routing render (confidentiality/hardening/skill-quality + severity→bucket) lands in the **Round-2 skill PR** (compass#97), not here.

Cites **compass#96** (F16/F3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)