### PR TITLE
fix(discord): treat gateway RESUME as connected in the shard health tracker

### DIFF
--- a/src/adapters/discord/__tests__/client-degraded.test.ts
+++ b/src/adapters/discord/__tests__/client-degraded.test.ts
@@ -219,3 +219,69 @@ describe("createDiscordClient degraded timer", () => {
     client.destroy();
   });
 });
+
+// A successful gateway RESUME emits shardResume with NO shardReady. Discord
+// cycles gateway sessions routinely, so resume-only recoveries are the common
+// path — the health tracker must treat them exactly like shardReady, or
+// `lastConnectedAt` (stamped only on READY) goes stale across resumed
+// sessions and the shardReconnecting log reads like an hours-long outage
+// while the shard is actually connected and delivering events.
+describe("createDiscordClient shardResume health", () => {
+  test("shardResume refreshes lastConnectedAt and connected state", async () => {
+    const { client, health } = setupClient({ degradedThresholdMs: 100 });
+    (client as any).emit("shardReady", 0);
+    const readyAt = health.lastConnectedAt;
+    expect(readyAt).toBeInstanceOf(Date);
+    await new Promise((r) => setTimeout(r, 15));
+    (client as any).emit("shardDisconnect", { code: 1006 } as any, 0);
+    expect(health.currentlyConnected).toBe(false);
+    (client as any).emit("shardResume", 0, 3);
+    expect(health.currentlyConnected).toBe(true);
+    expect(health.lastConnectedAt).toBeInstanceOf(Date);
+    expect(health.lastConnectedAt!.getTime()).toBeGreaterThan(readyAt!.getTime());
+    client.removeAllListeners();
+    client.destroy();
+  });
+
+  test("shardResume before threshold cancels the degraded timer", async () => {
+    const { client, health, onDegraded } = setupClient({ degradedThresholdMs: 50 });
+    (client as any).emit("shardDisconnect", { code: 1006 } as any, 0);
+    (client as any).emit("shardResume", 0, 0);
+    await new Promise((r) => setTimeout(r, 80));
+    expect(health.degraded).toBe(false);
+    expect(onDegraded).not.toHaveBeenCalled();
+    client.removeAllListeners();
+    client.destroy();
+  });
+
+  test("shardResume after degraded fires onRecovered and clears state (parity with shardReady)", async () => {
+    const { client, health, onRecovered } = setupClient({ degradedThresholdMs: 20 });
+    (client as any).emit("shardDisconnect", { code: 1006 } as any, 0);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(health.degraded).toBe(true);
+    (client as any).emit("shardResume", 0, 12);
+    expect(health.degraded).toBe(false);
+    expect(health.degradedSince).toBeNull();
+    expect(health.currentlyConnected).toBe(true);
+    expect(onRecovered).toHaveBeenCalledTimes(1);
+    client.removeAllListeners();
+    client.destroy();
+  });
+
+  test("routine ready log line is unchanged; resume gets its own line", () => {
+    const lines: string[] = [];
+    const log = console.log;
+    console.log = (...args) => { lines.push(args.join(" ")); };
+    try {
+      const { client } = setupClient();
+      (client as any).emit("shardReady", 0);
+      (client as any).emit("shardResume", 0, 7);
+      expect(lines).toContain("discord-test: shard 0 ready (reconnects so far: 0)");
+      expect(lines).toContain("discord-test: shard 0 resumed, 7 events replayed (reconnects so far: 0)");
+      client.removeAllListeners();
+      client.destroy();
+    } finally {
+      console.log = log;
+    }
+  });
+});

--- a/src/adapters/discord/client.ts
+++ b/src/adapters/discord/client.ts
@@ -119,7 +119,15 @@ export function createDiscordClient(
     console.log(`  Guild: ${info.guildId}`);
   });
 
-  client.on("shardReady", (shardId) => {
+  // Shared connected-bookkeeping for shardReady (fresh IDENTIFY) and
+  // shardResume (gateway session RESUME after a drop). Discord routinely
+  // cycles gateway connections, and a successful RESUME emits shardResume
+  // with NO shardReady — so a resume-only recovery must refresh the same
+  // health state. Without this, `lastConnectedAt` (stamped only on READY)
+  // goes stale across resumed sessions and the shardReconnecting log reads
+  // like an hours-long outage ("last connected: 36336s ago") while the
+  // shard is actually connected and delivering events.
+  const markShardConnected = (shardId: number, via: string) => {
     health.currentlyConnected = true;
     health.lastConnectedAt = new Date();
     clearDegradedTimer();
@@ -140,10 +148,18 @@ export function createDiscordClient(
     health.degraded = false;
     health.degradedSince = null;
     if (!wasDegraded) {
-      // Normal reconnect within threshold — emit the routine ready log. When
-      // we crossed the degraded threshold, RECOVERED above already conveys it.
-      console.log(`${tag}: shard ${shardId} ready (reconnects so far: ${health.reconnectCount})`);
+      // Normal (re)connect within threshold — emit the routine log. When we
+      // crossed the degraded threshold, RECOVERED above already conveys it.
+      console.log(`${tag}: shard ${shardId} ${via} (reconnects so far: ${health.reconnectCount})`);
     }
+  };
+
+  client.on("shardReady", (shardId) => {
+    markShardConnected(shardId, "ready");
+  });
+
+  client.on("shardResume", (shardId, replayedEvents) => {
+    markShardConnected(shardId, `resumed, ${replayedEvents} events replayed`);
   });
 
   client.on("shardDisconnect", (closeEvent, shardId) => {


### PR DESCRIPTION
## Problem

A successful gateway RESUME emits `shardResume` with **no** `shardReady`. The shard health tracker (`createShardHealthTracker` in `src/adapters/discord/client.ts`) only stamps `lastConnectedAt` on `shardReady`, so across resumed sessions the reconnecting log accrues to e.g.:

```
pier-discord: shard 0 reconnecting (#7, last connected: 36336s ago)
```

…while the shard is actually connected and delivering events (zero `shardDisconnect`, zero `DEGRADED`, inbound messages still arriving). Observed tonight on every host (community/halden/meta-factory); it read as a 10-hour Discord outage during a Pier incident and cost real triage time before being ruled out.

## Fix

Extract the `shardReady` bookkeeping into `markShardConnected()` and wire `shardResume` to it:
- stamps `lastConnectedAt`, restores `currentlyConnected`
- cancels the degraded timer (a resume within threshold is a recovery)
- fires `onRecovered` on a resume-after-degraded (parity with `shardReady`)

The routine `shard N ready` log line is **byte-identical** (log-parsing safe); resumes log their own line with the replayed-event count.

## Tests

4 new tests in `client-degraded.test.ts` (resume refreshes health; resume cancels degraded timer; resume-after-degraded fires `onRecovered`; log-line contract). Full discord adapter suite: 183 pass, 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFjcnUvvUXWzNTV1EW6uXs