### PR TITLE
feat(surface): C-1279 — MC-B2 Tier-2 admit/reject action (CF-Access + typed-confirm, local-daemon-signed)

### DIFF
--- a/src/bus/agent-network/__tests__/admission-decision.test.ts
+++ b/src/bus/agent-network/__tests__/admission-decision.test.ts
@@ -1,0 +1,204 @@
+/**
+ * MC-B2 (cortex#1279) — tests for the admission-decision signer/poster.
+ *
+ * Covers the claim shape + real signature (byte-compatible with the registry
+ * validator), and the status→result mapping for every registry verdict, with a
+ * hermetic injected fetch. Never-throws is asserted on transport failure.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { createUser } from "nkeys.js";
+import {
+  buildAdmissionDecisionBody,
+  postAdmissionDecision,
+  type FetchLike,
+} from "../admission-decision";
+import {
+  materialFromSeedString,
+  type StackIdentityMaterial,
+} from "../../stack-provisioning";
+import { canonicalJSON } from "../../../common/registry/signing";
+
+function material(): StackIdentityMaterial {
+  const kp = createUser();
+  return materialFromSeedString(new TextDecoder().decode(kp.getSeed()));
+}
+
+/** A fetch stub that captures the request and returns a canned response. */
+function stubFetch(
+  status: number,
+  body: unknown,
+  capture?: (url: string, init: { method?: string; body?: string }) => void,
+): FetchLike {
+  return (url, init) => {
+    capture?.(url, init ?? {});
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    });
+  };
+}
+
+describe("buildAdmissionDecisionBody", () => {
+  it("builds the 5-field claim with the material's pubkey and a real signature", async () => {
+    const mat = material();
+    const signed = await buildAdmissionDecisionBody("req-abc-123", "admit", mat, {
+      issuedAt: "2026-07-02T00:00:00.000Z",
+      nonce: "deadbeefdeadbeef",
+    });
+    expect(signed.claim).toEqual({
+      request_id: "req-abc-123",
+      decision: "admit",
+      admin_pubkey: mat.pubkeyB64,
+      issued_at: "2026-07-02T00:00:00.000Z",
+      nonce: "deadbeefdeadbeef",
+    });
+    // base64 signature over canonicalJSON(claim); non-empty.
+    expect(signed.signature.length).toBeGreaterThan(0);
+    // The message that was signed is the canonical claim — the registry
+    // reconstructs the same bytes. Sanity-check it's stable/deterministic.
+    expect(canonicalJSON(signed.claim)).toContain('"decision":"admit"');
+  });
+
+  it("carries decision:reject when rejecting", async () => {
+    const signed = await buildAdmissionDecisionBody("req-x", "reject", material(), {
+      issuedAt: "2026-07-02T00:00:00.000Z",
+      nonce: "00000000abcdef01",
+    });
+    expect(signed.claim.decision).toBe("reject");
+  });
+
+  it("generates a fresh nonce + issued_at when not overridden", async () => {
+    const a = await buildAdmissionDecisionBody("req-y", "admit", material());
+    const b = await buildAdmissionDecisionBody("req-y", "admit", material());
+    expect(a.claim.nonce).not.toBe(b.claim.nonce);
+    expect(a.claim.issued_at.length).toBeGreaterThan(0);
+  });
+});
+
+describe("postAdmissionDecision", () => {
+  it("POSTs to the admit route and returns ADMITTED on 200", async () => {
+    let seenUrl = "";
+    let seenBody: unknown;
+    const fetchImpl = stubFetch(200, { status: "ADMITTED", request_id: "req-1" }, (url, init) => {
+      seenUrl = url;
+      seenBody = init.body ? JSON.parse(init.body) : undefined;
+    });
+    const res = await postAdmissionDecision({
+      registryUrl: "https://registry.test/",
+      requestId: "req-1",
+      decision: "admit",
+      material: material(),
+      fetchImpl,
+    });
+    expect(res).toEqual({ ok: true, status: "ADMITTED", requestId: "req-1" });
+    expect(seenUrl).toBe("https://registry.test/admission-requests/req-1/admit");
+    expect((seenBody as { claim: { decision: string } }).claim.decision).toBe("admit");
+  });
+
+  it("POSTs to the reject route and returns REJECTED on 200", async () => {
+    let seenUrl = "";
+    const fetchImpl = stubFetch(200, { status: "REJECTED", request_id: "req-2" }, (url) => {
+      seenUrl = url;
+    });
+    const res = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-2",
+      decision: "reject",
+      material: material(),
+      fetchImpl,
+    });
+    expect(res).toEqual({ ok: true, status: "REJECTED", requestId: "req-2" });
+    expect(seenUrl).toBe("https://registry.test/admission-requests/req-2/reject");
+  });
+
+  it("maps 403 → not_authorized", async () => {
+    const res = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-3",
+      decision: "admit",
+      material: material(),
+      fetchImpl: stubFetch(403, { error: "admin_not_authorized" }),
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe("not_authorized");
+  });
+
+  it("maps 503 → not_configured", async () => {
+    const res = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-4",
+      decision: "admit",
+      material: material(),
+      fetchImpl: stubFetch(503, { error: "admin_not_configured" }),
+    });
+    if (!res.ok) expect(res.reason).toBe("not_configured");
+    else throw new Error("expected failure");
+  });
+
+  it("distinguishes 409 already_decided from nonce_replayed", async () => {
+    const decided = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-5",
+      decision: "admit",
+      material: material(),
+      fetchImpl: stubFetch(409, { error: "already_decided" }),
+    });
+    const replayed = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-6",
+      decision: "admit",
+      material: material(),
+      fetchImpl: stubFetch(409, { error: "nonce_replayed" }),
+    });
+    if (!decided.ok) expect(decided.reason).toBe("already_decided");
+    else throw new Error("expected failure");
+    if (!replayed.ok) expect(replayed.reason).toBe("replayed");
+    else throw new Error("expected failure");
+  });
+
+  it("maps 404 → not_found and 400 → invalid", async () => {
+    const nf = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-7",
+      decision: "admit",
+      material: material(),
+      fetchImpl: stubFetch(404, { error: "not_found" }),
+    });
+    const bad = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-8",
+      decision: "admit",
+      material: material(),
+      fetchImpl: stubFetch(400, { error: "validation_failed" }),
+    });
+    if (!nf.ok) expect(nf.reason).toBe("not_found");
+    if (!bad.ok) expect(bad.reason).toBe("invalid");
+  });
+
+  it("never throws on a transport failure → unreachable", async () => {
+    const fetchImpl: FetchLike = () => Promise.reject(new Error("ECONNREFUSED"));
+    const res = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-9",
+      decision: "admit",
+      material: material(),
+      fetchImpl,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe("unreachable");
+  });
+
+  it("treats a 2xx with a missing status field as unreachable (malformed)", async () => {
+    const res = await postAdmissionDecision({
+      registryUrl: "https://registry.test",
+      requestId: "req-10",
+      decision: "admit",
+      material: material(),
+      fetchImpl: stubFetch(200, { nope: true }),
+    });
+    if (!res.ok) expect(res.reason).toBe("unreachable");
+    else throw new Error("expected failure");
+  });
+});

--- a/src/bus/agent-network/admission-decision.ts
+++ b/src/bus/agent-network/admission-decision.ts
@@ -1,0 +1,290 @@
+/**
+ * MC-B2 (cortex#1279) — the **write** sibling of the admission-rows READ
+ * providers: sign a Tier-2 admit/reject decision with THIS stack's own
+ * registered key and POST it to the registry's admin-gated decision route.
+ *
+ * ## Why this lives in the bus layer (not the surface)
+ *
+ * The signing key is the stack's `SU…` seed — the SAME material the member
+ * roster read PoP-signs with ({@link ../stack-provisioning.StackIdentityMaterial}).
+ * The surface layer (`src/surface/mc/`) never imports the bus and never touches
+ * a seed; `cortex.ts` wires this signer into an injected `AdmissionDecider` seam,
+ * exactly as it wires `createMemberRosterAdmissionProvider` for the read side.
+ * The local daemon holds the seed in-process; the CF worker (no seed) never
+ * calls this. The browser never signs.
+ *
+ * ## Reuse, mint nothing, reimplement nothing
+ *
+ * The claim shape `{ request_id, decision, admin_pubkey, issued_at, nonce }` and
+ * the `{ claim, signature }` envelope mirror the CLI admit path
+ * (`network.ts buildAdmissionDecisionBody`) and the registry validator
+ * (`validateAdmissionDecisionClaim`). Signing reuses {@link signClaimWithSeed} +
+ * {@link canonicalJSON} — the SAME plumbing the CLI and the read provider use —
+ * and the nonce comes from {@link randomNonce}. No crypto is reimplemented here.
+ *
+ * ## Authorization is the registry's call, surfaced honestly
+ *
+ * The registry accepts the write iff the signing pubkey is a GLOBAL admin
+ * (`REGISTRY_ADMIN_PUBKEYS`) OR the target network's per-network admin
+ * (`admin_pubkeys`, ADR-0020). When this stack is neither, the registry returns
+ * `403 admin_not_authorized`; we map it to a distinct `not_authorized` reason the
+ * surface renders readably (never a silent failure, never a 5xx).
+ *
+ * Never throws — every failure is a typed `{ ok: false }`, mirroring the read
+ * provider's fail-soft contract.
+ */
+
+import { canonicalJSON } from "../../common/registry/signing";
+import {
+  randomNonce,
+  signClaimWithSeed,
+  type StackIdentityMaterial,
+} from "../stack-provisioning";
+
+/** The two Tier-2 decisions, matching the registry's shared `handleDecision`. */
+export type AdmissionDecisionVerb = "admit" | "reject";
+
+/** The signed decision claim — byte-shape must match `validateAdmissionDecisionClaim`. */
+export interface AdmissionDecisionClaim {
+  request_id: string;
+  decision: AdmissionDecisionVerb;
+  admin_pubkey: string;
+  issued_at: string;
+  nonce: string;
+}
+
+/** A decision claim + detached signature, ready to POST. */
+export interface SignedAdmissionDecision {
+  claim: AdmissionDecisionClaim;
+  /** Base64 ed25519 signature over `canonicalJSON(claim)`. */
+  signature: string;
+}
+
+/**
+ * Build + sign an admission decision body. Reuses the CLI/read-provider signing
+ * primitives; the claim is signed over the SAME `canonicalJSON(claim)` the
+ * registry reconstructs and verifies. `opts` overrides (issuedAt/nonce) exist
+ * for deterministic tests only.
+ */
+export async function buildAdmissionDecisionBody(
+  requestId: string,
+  decision: AdmissionDecisionVerb,
+  material: StackIdentityMaterial,
+  opts: { issuedAt?: string; nonce?: string } = {},
+): Promise<SignedAdmissionDecision> {
+  const claim: AdmissionDecisionClaim = {
+    request_id: requestId,
+    decision,
+    admin_pubkey: material.pubkeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signature = await signClaimWithSeed(material.seed, message);
+  return { claim, signature };
+}
+
+/**
+ * Injectable `fetch`, narrowed to what this poster needs. Production omits it →
+ * `globalThis.fetch`; tests inject a hermetic stub. Mirrors the read provider.
+ */
+export type FetchLike = (
+  url: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+/** Construction inputs for {@link postAdmissionDecision}. */
+export interface PostAdmissionDecisionOptions {
+  /** Registry base URL (`policy.federated.registry.url`). Trailing slashes trimmed. */
+  registryUrl: string;
+  /** The admission request to decide. */
+  requestId: string;
+  /** admit | reject — selects both the route and the claim's `decision`. */
+  decision: AdmissionDecisionVerb;
+  /**
+   * The stack's identity material — its registered `SU…` seed + base64 pubkey.
+   * The pubkey must be a global or per-network admin for the registry to accept.
+   * SECRET (the seed) — never logged.
+   */
+  material: StackIdentityMaterial;
+  /** Per-request timeout (ms). Default 10s. */
+  requestTimeoutMs?: number;
+  /** Injected transport (tests). Production omits → `globalThis.fetch`. */
+  fetchImpl?: FetchLike;
+  /** Deterministic issued_at (tests). */
+  issuedAt?: string;
+  /** Deterministic nonce (tests). */
+  nonce?: string;
+  /** Logger seam (CLAUDE.md "no silent catches"). Default → `process.stderr`. */
+  logError?: (msg: string) => void;
+}
+
+/** Why a decision POST failed — a distinct, renderable state per registry verdict. */
+export type PostAdmissionDecisionFailure =
+  | "not_authorized" // 403 — this stack is not a global/per-network admin
+  | "not_configured" // 503 — registry has no admin allowlist provisioned
+  | "already_decided" // 409 — the request was already admitted/rejected
+  | "replayed" // 409 — nonce replay (should not happen with a fresh nonce)
+  | "rate_limited" // 429
+  | "invalid" // 400/401 — claim/signature rejected
+  | "not_found" // 404 — no such request
+  | "unreachable"; // transport / non-JSON / unexpected status
+
+/** The outcome of a decision POST — never thrown. */
+export type PostAdmissionDecisionResult =
+  | { ok: true; status: "ADMITTED" | "REJECTED"; requestId: string }
+  | { ok: false; reason: PostAdmissionDecisionFailure; detail: string; httpStatus?: number };
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Sign + POST a Tier-2 admit/reject decision to
+ * `POST {registry}/admission-requests/{id}/{admit|reject}`. Maps each registry
+ * status to a distinct, renderable {@link PostAdmissionDecisionResult}. Never
+ * throws (mirrors the read provider's fail-soft contract).
+ */
+export async function postAdmissionDecision(
+  options: PostAdmissionDecisionOptions,
+): Promise<PostAdmissionDecisionResult> {
+  const url = options.registryUrl.replace(/\/+$/, "");
+  const fetchImpl: FetchLike = options.fetchImpl ?? globalThis.fetch;
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const logError =
+    options.logError ??
+    ((msg: string) => {
+      process.stderr.write(`admission-decision: ${msg}\n`);
+    });
+
+  // 1. Sign the decision claim with the stack's OWN registered seed.
+  let signed: SignedAdmissionDecision;
+  try {
+    signed = await buildAdmissionDecisionBody(
+      options.requestId,
+      options.decision,
+      options.material,
+      {
+        ...(options.issuedAt !== undefined && { issuedAt: options.issuedAt }),
+        ...(options.nonce !== undefined && { nonce: options.nonce }),
+      },
+    );
+  } catch (err) {
+    logError(`failed to sign ${options.decision} claim: ${errText(err)}`);
+    return {
+      ok: false,
+      reason: "unreachable",
+      detail: `failed to sign the decision claim: ${errText(err)}`,
+    };
+  }
+
+  // 2. POST to the admit/reject route (the signature is the authorization).
+  const endpoint = `${url}/admission-requests/${encodeURIComponent(options.requestId)}/${options.decision}`;
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => {
+    controller.abort();
+  }, requestTimeoutMs);
+  let resp: Awaited<ReturnType<FetchLike>>;
+  try {
+    resp = await fetchImpl(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(signed),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const reason =
+      err instanceof Error && err.name === "AbortError"
+        ? `timed out after ${requestTimeoutMs.toString()}ms`
+        : errText(err);
+    logError(`POST ${endpoint} failed: ${reason}`);
+    return { ok: false, reason: "unreachable", detail: `decision POST errored: ${reason}` };
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+
+  // 3. Success — the registry returns the transitioned request row.
+  if (resp.ok) {
+    let row: unknown;
+    try {
+      row = await resp.json();
+    } catch (err) {
+      logError(`POST ${endpoint} 2xx but non-JSON: ${errText(err)}`);
+      return { ok: false, reason: "unreachable", detail: "decision response was not JSON" };
+    }
+    const status = readRowStatus(row);
+    if (status === undefined) {
+      return { ok: false, reason: "unreachable", detail: "decision response missing a status field" };
+    }
+    return { ok: true, status, requestId: options.requestId };
+  }
+
+  // 4. Map the registry error to a distinct, renderable reason.
+  const errorCode = await readErrorCode(resp);
+  const httpStatus = resp.status;
+  switch (httpStatus) {
+    case 403:
+      return {
+        ok: false,
+        reason: "not_authorized",
+        httpStatus,
+        detail:
+          "the registry refused the decision — this stack's key is not a global admin " +
+          "nor listed in the network's admin_pubkeys (ADR-0020). Only a network admin may admit/reject.",
+      };
+    case 503:
+      return {
+        ok: false,
+        reason: "not_configured",
+        httpStatus,
+        detail: "the registry has no admin allowlist provisioned (admin_not_configured) — decisions are disabled.",
+      };
+    case 429:
+      return { ok: false, reason: "rate_limited", httpStatus, detail: "the registry rate-limited the decision; retry shortly." };
+    case 409:
+      return errorCode === "nonce_replayed"
+        ? { ok: false, reason: "replayed", httpStatus, detail: "the registry saw this nonce already (replay) — retry with a fresh decision." }
+        : { ok: false, reason: "already_decided", httpStatus, detail: "this request was already decided (admitted or rejected)." };
+    case 404:
+      return { ok: false, reason: "not_found", httpStatus, detail: `no admission request "${options.requestId}" on the registry.` };
+    case 400:
+    case 401:
+      return { ok: false, reason: "invalid", httpStatus, detail: `the registry rejected the decision claim (${errorCode ?? `HTTP ${httpStatus.toString()}`}).` };
+    default:
+      logError(`POST ${endpoint} returned unexpected HTTP ${httpStatus.toString()} (${errorCode ?? "no code"})`);
+      return { ok: false, reason: "unreachable", httpStatus, detail: `the registry returned HTTP ${httpStatus.toString()}.` };
+  }
+}
+
+/** Read `.status` off the transitioned-request row, narrowed to the two terminal states. */
+function readRowStatus(row: unknown): "ADMITTED" | "REJECTED" | undefined {
+  if (row === null || typeof row !== "object") return undefined;
+  const s = (row as Record<string, unknown>).status;
+  return s === "ADMITTED" || s === "REJECTED" ? s : undefined;
+}
+
+/** Best-effort read of the registry's `{ error }` code; never throws. */
+async function readErrorCode(resp: { json: () => Promise<unknown> }): Promise<string | undefined> {
+  try {
+    const body = await resp.json();
+    if (body !== null && typeof body === "object") {
+      const e = (body as Record<string, unknown>).error;
+      if (typeof e === "string") return e;
+    }
+  } catch {
+    // Body wasn't JSON / already consumed — fall through to undefined.
+  }
+  return undefined;
+}
+
+/** Error → message, never echoing secret-bearing inputs. */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -5873,10 +5873,15 @@ export async function startCortex(
                 material: decisionMaterial,
               });
               // Audit trail (no secrets): who decided what, and the outcome.
+              // Deliberately does NOT log the client-supplied `network_id`: the
+              // registry authorizes off the request's STORED network, never the
+              // wire selector, so echoing a caller-chosen value could mislead a
+              // forensic reader (review nit adv-N2/rev-N2). request_id is the
+              // stable, registry-authoritative key.
               const auditOutcome = res.ok ? res.status : `refused(${res.reason})`;
               console.log(
                 `cortex: MC-B2 admission ${input.decision} — request=${input.requestId} ` +
-                  `network=${input.networkId} principal=${input.principal} -> ${auditOutcome}`,
+                  `principal=${input.principal} -> ${auditOutcome}`,
               );
               return res.ok
                 ? { ok: true, status: res.status, requestId: res.requestId }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -179,6 +179,10 @@ import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/r
 import { startMissionControl, type MissionControlHandle } from "./surface/mc/embed";
 import type { AgentPresenceView } from "./surface/mc/api/agents";
 import type { NetworksView } from "./surface/mc/api/networks";
+import type {
+  AdmissionDecider,
+  AdmissionDecisionResult,
+} from "./surface/mc/api/networks-admission";
 import {
   resolveAdmittedRoster,
   type AdmissionRowsProvider,
@@ -187,6 +191,9 @@ import {
 // MC-A2 (cortex#1276) — the LIVE member-posture admission-rows provider +
 // per-principal acceptance resolution (the second trust layer).
 import { createMemberRosterAdmissionProvider } from "./bus/agent-network/admission-rows-member-provider";
+// MC-B2 (cortex#1279) — the WRITE sibling: sign a Tier-2 admit/reject decision
+// with the stack seed and POST it to the registry (local-daemon-signed).
+import { postAdmissionDecision } from "./bus/agent-network/admission-decision";
 import {
   summarizeAcceptancePolicy,
   resolvePeerAcceptance,
@@ -5257,6 +5264,12 @@ export async function startCortex(
   // `resolvedPolicy` is known); `null` until then ⇒ the route serves an empty
   // list. The MC server resolves it per request.
   let networksViewForApi: NetworksView | null = null;
+  // MC-B2 (cortex#1279) — the admission-decision signer for the mutating
+  // `POST /api/networks/admission-decision` action. Assigned in the federation
+  // block below alongside `networksViewForApi` (it reuses the SAME stack
+  // identity material + resolved registry). `null` until then ⇒ the route 503s.
+  // Signs LOCALLY with the stack seed; never wired in the CF worker.
+  let admissionDeciderForApi: AdmissionDecider | null = null;
   // #1008/#989 — discovered LOCAL sibling stacks, used by BOTH the DB-read
   // pane-of-glass aggregation (the embed's `localAggregation` getter, below, for
   // session trees) AND the #989 bus sibling-presence aggregator (later, for
@@ -5334,6 +5347,11 @@ export async function startCortex(
         // MC-A1 (cortex#1275) — networks view (lazy; assigned in the federation
         // block once `resolvedPolicy` is known). null ⇒ empty `/api/networks`.
         networks: () => networksViewForApi,
+        // MC-B2 (cortex#1279) — the local-daemon admission-decision signer
+        // (lazy; assigned in the federation block once the stack identity +
+        // registry are resolved). null ⇒ `POST /api/networks/admission-decision`
+        // 503s honestly.
+        admissionDecider: () => admissionDeciderForApi,
         // #1008 — DB-read pane-of-glass aggregation. The getter returns a context
         // only when discovery produced a resolve-opts (dbRead on); otherwise null
         // ⇒ single-db feeds. Lazy so the roster can be (re)read consistently.
@@ -5834,6 +5852,42 @@ export async function startCortex(
             `as first-class trust groups (admission roster: ${live ? "LIVE member-read (A2)" : "not_configured — self-only"}; ` +
             "per-principal acceptance from offerings)",
         );
+
+        // MC-B2 (cortex#1279) — the WRITE sibling of the member-roster read:
+        // sign a Tier-2 admit/reject with the SAME `stackMaterial` and POST it to
+        // the registry. Unlike the read (which needs a pinned pubkey for the DD-9
+        // assertion verify), the write needs only the registry URL + the stack
+        // seed — the registry authorizes on the signing pubkey (global or
+        // per-network admin). Live iff we hold the stack seed AND a registry URL.
+        // Runs LOCALLY (this daemon holds the seed); the CF worker never reaches
+        // this code. null ⇒ `POST /api/networks/admission-decision` 503s.
+        if (stackMaterial !== undefined && resolvedRegistry !== undefined) {
+          const decisionRegistryUrl = resolvedRegistry.url;
+          const decisionMaterial = stackMaterial;
+          admissionDeciderForApi = {
+            decide: async (input): Promise<AdmissionDecisionResult> => {
+              const res = await postAdmissionDecision({
+                registryUrl: decisionRegistryUrl,
+                requestId: input.requestId,
+                decision: input.decision,
+                material: decisionMaterial,
+              });
+              // Audit trail (no secrets): who decided what, and the outcome.
+              const auditOutcome = res.ok ? res.status : `refused(${res.reason})`;
+              console.log(
+                `cortex: MC-B2 admission ${input.decision} — request=${input.requestId} ` +
+                  `network=${input.networkId} principal=${input.principal} -> ${auditOutcome}`,
+              );
+              return res.ok
+                ? { ok: true, status: res.status, requestId: res.requestId }
+                : { ok: false, reason: res.reason, detail: res.detail };
+            },
+          };
+          console.log(
+            "cortex: MC /api/networks/admission-decision wired — LIVE local-daemon-signed " +
+              "Tier-2 admit/reject (stack-seed-signed; CF-Access + typed-confirm gated at the surface)",
+          );
+        }
       }
 
       // P-14 U3.3 (#937) — the trust-verified federated OBSERVABILITY fold, the

--- a/src/surface/mc/__tests__/networks-admission-http.test.ts
+++ b/src/surface/mc/__tests__/networks-admission-http.test.ts
@@ -1,0 +1,135 @@
+/**
+ * MC-B2 (cortex#1279) — loopback-invariant guard for the mutating
+ * `POST /api/networks/admission-decision` route.
+ *
+ * ## Why this test exists (review nit adv-N1)
+ *
+ * Gate 1 of the admission-decision handler trusts the
+ * `Cf-Access-Authenticated-User-Email` header AS-IS — it never validates the
+ * `Cf-Access-Jwt-Assertion`. That is only safe because the daemon binds
+ * **loopback-only** (server.ts SEV-2): the sole path on which a request can both
+ * (a) carry that header and (b) reach the local signer is the principal's own
+ * CF-Access tunnel to their own daemon. A future regression that binds the server
+ * beyond loopback (e.g. `0.0.0.0`) would make the un-validated header trivially
+ * forgeable from the network — turning admission-signing into a remote-forge.
+ *
+ * These cases lock that trust boundary: they boot the REAL Bun.serve stack with a
+ * stub {@link AdmissionDecider} wired and assert the route is served on the
+ * loopback interface, and that Gate 1 (401 without the header) is enforced there.
+ * If the default bind ever moves off loopback, the hostname assertion fails loud.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+import { startServer, type ServerContext } from "../server";
+import { initDatabase } from "../db/init";
+import { DEFAULT_CONFIG } from "../config";
+import type {
+  AdmissionDecider,
+  AdmissionDecisionInput,
+  AdmissionDecisionResult,
+} from "../api/networks-admission";
+import type { Database } from "bun:sqlite";
+
+const PORT_BIND_ANY = 0;
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
+function boundPort(ctx: ServerContext): number {
+  const port = ctx.server.port;
+  if (port === undefined) throw new Error("server.port unresolved after start");
+  return port;
+}
+
+interface Ctx {
+  db: Database;
+  ctx: ServerContext;
+  baseUrl: string;
+  tmpDir: string;
+  calls: AdmissionDecisionInput[];
+}
+
+/**
+ * Boot the real server with a recording {@link AdmissionDecider} stub — no seed,
+ * no registry, no crypto; just enough to prove the route is wired and reachable.
+ */
+function startWithDecider(): Ctx {
+  const tmpDir = join(tmpdir(), `mc-admission-http-${Date.now()}-${Math.random()}`);
+  const db = initDatabase(join(tmpDir, "test.db"));
+  const calls: AdmissionDecisionInput[] = [];
+  const decider: AdmissionDecider = {
+    decide: (input): Promise<AdmissionDecisionResult> => {
+      calls.push(input);
+      return Promise.resolve({ ok: true, status: "ADMITTED", requestId: input.requestId });
+    },
+  };
+  const ctx = startServer({ ...DEFAULT_CONFIG, port: PORT_BIND_ANY }, db, {
+    admissionDecider: () => decider,
+  });
+  return { db, ctx, baseUrl: `http://localhost:${boundPort(ctx)}`, tmpDir, calls };
+}
+
+function teardown(c: Ctx): void {
+  c.ctx.stop(true);
+  c.db.close();
+  rmSync(c.tmpDir, { recursive: true, force: true });
+}
+
+describe("POST /api/networks/admission-decision — loopback invariant", () => {
+  let c: Ctx;
+  afterEach(() => {
+    teardown(c);
+  });
+
+  it("binds the admission-decision route to a loopback interface only", () => {
+    c = startWithDecider();
+    // The signing route's ONLY safety for the un-validated CF-Access header is
+    // that it is unreachable off loopback. If a regression binds beyond loopback
+    // (e.g. 0.0.0.0), this fails — do NOT relax it without re-designing Gate 1.
+    expect(LOOPBACK_HOSTS.has(c.ctx.server.hostname ?? "")).toBe(true);
+    expect(DEFAULT_CONFIG.hostname).toBe("127.0.0.1");
+  });
+
+  it("enforces Gate 1 (401 without the CF-Access header) on the loopback bind", async () => {
+    c = startWithDecider();
+    const res = await fetch(`${c.baseUrl}/api/networks/admission-decision`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        network_id: "acme",
+        request_id: "req-abc-123",
+        decision: "admit",
+        confirm: "req-abc-123",
+      }),
+    });
+    expect(res.status).toBe(401);
+    // The signer must NOT run when the identity header is absent.
+    expect(c.calls).toHaveLength(0);
+  });
+
+  it("reaches the wired signer over loopback when the CF-Access header is present", async () => {
+    c = startWithDecider();
+    const res = await fetch(`${c.baseUrl}/api/networks/admission-decision`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "Cf-Access-Authenticated-User-Email": "principal@example.com",
+      },
+      body: JSON.stringify({
+        network_id: "acme",
+        request_id: "req-abc-123",
+        decision: "admit",
+        confirm: "req-abc-123",
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ADMITTED", request_id: "req-abc-123" });
+    // Proves the route resolved the injected decider through the loopback stack,
+    // carrying the CF-Access principal for audit.
+    expect(c.calls).toHaveLength(1);
+    expect(c.calls[0]?.principal).toBe("principal@example.com");
+    expect(c.calls[0]?.decision).toBe("admit");
+  });
+});

--- a/src/surface/mc/api/__tests__/networks-admission.test.ts
+++ b/src/surface/mc/api/__tests__/networks-admission.test.ts
@@ -1,0 +1,137 @@
+/**
+ * MC-B2 (cortex#1279) — tests for `handleAdmissionDecision`: the two gates
+ * (CF-Access principal identity + typed-confirm) and the decider-verdict → HTTP
+ * mapping. Pure — the decider is a stub; no bus, no network.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  handleAdmissionDecision,
+  type AdmissionDecider,
+  type AdmissionDecisionResult,
+} from "../networks-admission";
+
+function decider(result: AdmissionDecisionResult): AdmissionDecider {
+  return { decide: () => Promise.resolve(result) };
+}
+
+/** A decider that must NOT be called (asserts the gate fired first). */
+const throwingDecider: AdmissionDecider = {
+  decide: () => {
+    throw new Error("decider should not be reached");
+  },
+};
+
+const OK_BODY = {
+  network_id: "alpha",
+  request_id: "req-abc-123",
+  decision: "admit",
+  confirm: "req-abc-123",
+};
+
+async function body(res: Response): Promise<Record<string, unknown>> {
+  return (await res.json()) as Record<string, unknown>;
+}
+
+describe("handleAdmissionDecision — gate 1: CF-Access principal identity", () => {
+  it("401 when the principal identity is absent", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, undefined, OK_BODY);
+    expect(res.status).toBe(401);
+    expect((await body(res)).error).toBe("unauthenticated");
+  });
+
+  it("401 when the principal identity is blank/whitespace", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, "   ", OK_BODY);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("handleAdmissionDecision — gate 2: body + typed-confirm", () => {
+  it("400 when the body is not an object", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", null);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when request_id is invalid", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, request_id: "!", confirm: "!" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when network_id is invalid", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, network_id: "Bad Net" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when decision is neither admit nor reject", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, decision: "revoke" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when confirm does not exactly echo request_id (typed-confirm gate)", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, confirm: "req-abc-124" });
+    expect(res.status).toBe(400);
+    expect((await body(res)).error).toBe("confirm must exactly match request_id");
+  });
+
+  it("400 when confirm has stray whitespace (exact echo, not trimmed)", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, confirm: "req-abc-123 " });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("handleAdmissionDecision — decider wiring", () => {
+  it("503 when the decider is not wired (null)", async () => {
+    const res = await handleAdmissionDecision(null, "op@x.io", OK_BODY);
+    expect(res.status).toBe(503);
+    expect((await body(res)).error).toBe("not_configured");
+  });
+
+  it("200 + status when the decider admits", async () => {
+    const res = await handleAdmissionDecision(
+      decider({ ok: true, status: "ADMITTED", requestId: "req-abc-123" }),
+      "op@x.io",
+      OK_BODY,
+    );
+    expect(res.status).toBe(200);
+    const b = await body(res);
+    expect(b.status).toBe("ADMITTED");
+    expect(b.request_id).toBe("req-abc-123");
+  });
+
+  it("200 + REJECTED when rejecting", async () => {
+    const res = await handleAdmissionDecision(
+      decider({ ok: true, status: "REJECTED", requestId: "req-abc-123" }),
+      "op@x.io",
+      { ...OK_BODY, decision: "reject" },
+    );
+    expect(res.status).toBe(200);
+    expect((await body(res)).status).toBe("REJECTED");
+  });
+
+  it("403 when the registry says not_authorized", async () => {
+    const res = await handleAdmissionDecision(
+      decider({ ok: false, reason: "not_authorized", detail: "not an admin" }),
+      "op@x.io",
+      OK_BODY,
+    );
+    expect(res.status).toBe(403);
+    const b = await body(res);
+    expect(b.error).toBe("not_authorized");
+    expect(b.detail).toBe("not an admin");
+  });
+
+  it("409 already_decided, 429 rate_limited, 404 not_found, 502 unreachable map through", async () => {
+    const cases: [AdmissionDecisionResult, number][] = [
+      [{ ok: false, reason: "already_decided", detail: "x" }, 409],
+      [{ ok: false, reason: "replayed", detail: "x" }, 409],
+      [{ ok: false, reason: "rate_limited", detail: "x" }, 429],
+      [{ ok: false, reason: "not_found", detail: "x" }, 404],
+      [{ ok: false, reason: "invalid", detail: "x" }, 400],
+      [{ ok: false, reason: "unreachable", detail: "x" }, 502],
+    ];
+    for (const [result, status] of cases) {
+      const res = await handleAdmissionDecision(decider(result), "op@x.io", OK_BODY);
+      expect(res.status).toBe(status);
+    }
+  });
+});

--- a/src/surface/mc/api/networks-admission.ts
+++ b/src/surface/mc/api/networks-admission.ts
@@ -1,0 +1,228 @@
+/**
+ * MC-B2 (cortex#1279) — the **mutating** Tier-2 admit/reject action from the
+ * Mission Control glass: `POST /api/networks/admission-decision`.
+ *
+ * ## Scope (principal decision, 2026-07-02)
+ *
+ * Ship the grant/reject action behind **CF-Access session + typed-confirm**;
+ * full step-up MFA (#1194) is a follow-up. The decision is **signed by the
+ * LOCAL daemon** with the principal's own stack seed (the daemon already holds it
+ * to PoP-sign roster reads) — the seed NEVER goes in the CF worker and the
+ * browser NEVER signs. This handler is the surface seam; `cortex.ts` injects the
+ * bus-layer signer as an {@link AdmissionDecider} (mirroring how it injects the
+ * member-roster read provider). The surface never imports the bus.
+ *
+ * ## The two gates (both required — reject if either is absent)
+ *
+ *  1. **CF-Access principal identity.** The `Cf-Access-Authenticated-User-Email`
+ *     header, injected by Cloudflare Access at the authenticated edge (the same
+ *     identity the worker's `getCfAccessEmail` derives). Absent/empty ⇒ 401. The
+ *     local MC server additionally binds loopback-only (server.ts SEV-2), so this
+ *     identity gate composes on top of the loopback boundary that already
+ *     protects the on-disk seed.
+ *  2. **Typed-confirm.** The client must echo the target `request_id` in the
+ *     `confirm` field — the deliberate, mirror of the CLI's
+ *     `cortex network admit <request-id> --apply` posture (the principal types the
+ *     id they mean to act on). Mismatch/absent ⇒ 400. This is the intent gate for
+ *     a control-plane mutation.
+ *
+ * Request-id-driven (Option A): the principal supplies the `request_id`
+ * (obtained from `cortex network admit --list-pending` or the registry). Auto-
+ * populating a PENDING queue with request_ids on the pier-queue rows is a
+ * documented follow-up (it needs the admin-list read path, which hits the
+ * ADR-0020 global-admin-read scoping and is admit-lane-adjacent).
+ */
+
+/** admit | reject — selects the registry route + claim decision. */
+export type AdmissionDecisionVerb = "admit" | "reject";
+
+/** What the injected decider is asked to do (principal identity carried for audit). */
+export interface AdmissionDecisionInput {
+  networkId: string;
+  requestId: string;
+  decision: AdmissionDecisionVerb;
+  /** The CF-Access-authenticated principal email (audit/correlation). */
+  principal: string;
+}
+
+/**
+ * Why the decision failed — a superset of the bus signer's failure reasons,
+ * surface-local so this module never imports the bus. `cortex.ts` maps the
+ * bus `PostAdmissionDecisionResult` onto this shape.
+ */
+export type AdmissionDecisionFailure =
+  | "not_authorized"
+  | "not_configured"
+  | "already_decided"
+  | "replayed"
+  | "rate_limited"
+  | "invalid"
+  | "not_found"
+  | "unreachable";
+
+/** The outcome of a signed decision — never thrown. */
+export type AdmissionDecisionResult =
+  | { ok: true; status: "ADMITTED" | "REJECTED"; requestId: string }
+  | { ok: false; reason: AdmissionDecisionFailure; detail: string };
+
+/**
+ * The injected seam the surface depends on to sign + POST a decision. `cortex.ts`
+ * supplies a live implementation built from the stack's identity material + the
+ * federated registry config; tests supply a stub. Returns `null` from the
+ * server's getter when federation/registry/signing identity is not configured
+ * (→ the handler 503s honestly).
+ */
+export interface AdmissionDecider {
+  decide(input: AdmissionDecisionInput): Promise<AdmissionDecisionResult>;
+}
+
+/** The `Cf-Access-Authenticated-User-Email` header (CF Access injects it at the edge). */
+export const CF_ACCESS_EMAIL_HEADER = "Cf-Access-Authenticated-User-Email";
+
+/** The POST body the dashboard sends. */
+interface AdmissionDecisionBody {
+  network_id: string;
+  request_id: string;
+  decision: AdmissionDecisionVerb;
+  /** Typed-confirm: must exactly equal `request_id`. */
+  confirm: string;
+}
+
+const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
+// A conservative request-id shape (registry `isValidRequestId` is the authority;
+// this is a cheap client-side pre-check so we never sign an obviously-bad id).
+const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$/;
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Map a decider failure reason to the HTTP status the dashboard branches on. */
+function failureStatus(reason: AdmissionDecisionFailure): number {
+  switch (reason) {
+    case "not_authorized":
+      return 403;
+    case "not_configured":
+      return 503;
+    case "already_decided":
+    case "replayed":
+      return 409;
+    case "rate_limited":
+      return 429;
+    case "invalid":
+      return 400;
+    case "not_found":
+      return 404;
+    case "unreachable":
+      return 502;
+  }
+}
+
+/**
+ * Validate the body shape (typed-confirm included). Pure — no I/O. Returns the
+ * normalised body or a `Response` (already the right status) to return verbatim.
+ */
+function parseBody(
+  raw: unknown,
+): { ok: true; body: AdmissionDecisionBody } | { ok: false; response: Response } {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, response: json({ error: "body must be a JSON object" }, 400) };
+  }
+  const b = raw as Record<string, unknown>;
+
+  if (typeof b.request_id !== "string" || !REQUEST_ID_RE.test(b.request_id)) {
+    return { ok: false, response: json({ error: "request_id must be a valid admission request id" }, 400) };
+  }
+  if (typeof b.network_id !== "string" || !NETWORK_ID_RE.test(b.network_id)) {
+    return { ok: false, response: json({ error: "network_id must be lowercase alphanumeric + hyphen, letter-prefixed" }, 400) };
+  }
+  if (b.decision !== "admit" && b.decision !== "reject") {
+    return { ok: false, response: json({ error: 'decision must be "admit" or "reject"' }, 400) };
+  }
+  // Typed-confirm: the principal must echo the request_id they mean to act on.
+  if (typeof b.confirm !== "string" || b.confirm !== b.request_id) {
+    return {
+      ok: false,
+      response: json(
+        {
+          error: "confirm must exactly match request_id",
+          detail:
+            "Type the request id to confirm this Tier-2 decision (mirrors the CLI --apply posture). " +
+            "This is the deliberate intent gate for a control-plane mutation.",
+        },
+        400,
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    body: {
+      network_id: b.network_id,
+      request_id: b.request_id,
+      decision: b.decision,
+      confirm: b.confirm,
+    },
+  };
+}
+
+/**
+ * Handle `POST /api/networks/admission-decision`.
+ *
+ * @param decider   The injected signer seam. `null` ⇒ 503 (no
+ *                  federation/registry/signing identity configured).
+ * @param principal The CF-Access principal email, extracted by the server from
+ *                  {@link CF_ACCESS_EMAIL_HEADER}. Empty/undefined ⇒ 401.
+ * @param rawBody   The parsed JSON body (server already enforced the size cap).
+ */
+export async function handleAdmissionDecision(
+  decider: AdmissionDecider | null,
+  principal: string | undefined,
+  rawBody: unknown,
+): Promise<Response> {
+  // Gate 1 — a CF-Access principal identity is required for a mutation.
+  const who = (principal ?? "").trim();
+  if (who.length === 0) {
+    return json(
+      {
+        error: "unauthenticated",
+        detail:
+          "a CF-Access authenticated principal identity is required to admit/reject " +
+          `(missing/empty ${CF_ACCESS_EMAIL_HEADER}). This mutation is not available on an unauthenticated request.`,
+      },
+      401,
+    );
+  }
+
+  // Gate 2 — body shape + typed-confirm.
+  const parsed = parseBody(rawBody);
+  if (!parsed.ok) return parsed.response;
+
+  // The signer seam must be wired (federation + registry + stack seed present).
+  if (decider === null) {
+    return json(
+      {
+        error: "not_configured",
+        detail:
+          "admission decisions are unavailable — no federated registry / stack signing identity is configured " +
+          "on this daemon (the decision must be signed locally with the stack seed).",
+      },
+      503,
+    );
+  }
+
+  const result = await decider.decide({
+    networkId: parsed.body.network_id,
+    requestId: parsed.body.request_id,
+    decision: parsed.body.decision,
+    principal: who,
+  });
+
+  if (result.ok) {
+    return json({ status: result.status, request_id: result.requestId }, 200);
+  }
+  return json({ error: result.reason, detail: result.detail }, failureStatus(result.reason));
+}

--- a/src/surface/mc/dashboard-v2/__tests__/pier-decide-lib.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-decide-lib.test.ts
@@ -1,0 +1,115 @@
+/**
+ * MC-B2 (cortex#1279) — pure-logic tests for the decide action: the
+ * typed-confirm gate, the POST verdict→outcome mapping (with an injected fetch),
+ * and the outcome→message summary.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  ADMISSION_DECISION_PATH,
+  canDecide,
+  describeOutcome,
+  submitDecision,
+  type FetchLike,
+} from "../lib/pier-decide-lib";
+
+function stubFetch(status: number, payload: unknown, capture?: (path: string, init: { body: string }) => void): FetchLike {
+  return (path, init) => {
+    capture?.(path, init);
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(payload),
+    });
+  };
+}
+
+describe("canDecide (typed-confirm gate)", () => {
+  it("false when the request id is empty", () => {
+    expect(canDecide({ requestId: "", confirm: "", busy: false })).toBe(false);
+    expect(canDecide({ requestId: "   ", confirm: "   ", busy: false })).toBe(false);
+  });
+  it("false when busy", () => {
+    expect(canDecide({ requestId: "req-1", confirm: "req-1", busy: true })).toBe(false);
+  });
+  it("false when confirm does not exactly echo the request id", () => {
+    expect(canDecide({ requestId: "req-1", confirm: "req-2", busy: false })).toBe(false);
+    expect(canDecide({ requestId: "req-1", confirm: "req-1 ", busy: false })).toBe(false);
+  });
+  it("true only on an exact echo, not busy", () => {
+    expect(canDecide({ requestId: "req-1", confirm: "req-1", busy: false })).toBe(true);
+  });
+});
+
+describe("submitDecision", () => {
+  it("POSTs to the endpoint and returns ok/ADMITTED on 200", async () => {
+    let seenPath = "";
+    let seenBody: unknown;
+    const res = await submitDecision(
+      { network_id: "alpha", request_id: "req-1", decision: "admit", confirm: "req-1" },
+      stubFetch(200, { status: "ADMITTED", request_id: "req-1" }, (path, init) => {
+        seenPath = path;
+        seenBody = JSON.parse(init.body);
+      }),
+    );
+    expect(seenPath).toBe(ADMISSION_DECISION_PATH);
+    expect((seenBody as { decision: string }).decision).toBe("admit");
+    expect(res).toEqual({ kind: "ok", status: "ADMITTED", requestId: "req-1" });
+  });
+
+  it("returns REJECTED on a reject 200", async () => {
+    const res = await submitDecision(
+      { network_id: "alpha", request_id: "req-2", decision: "reject", confirm: "req-2" },
+      stubFetch(200, { status: "REJECTED", request_id: "req-2" }),
+    );
+    expect(res).toEqual({ kind: "ok", status: "REJECTED", requestId: "req-2" });
+  });
+
+  it("surfaces the readable detail on a 403", async () => {
+    const res = await submitDecision(
+      { network_id: "alpha", request_id: "req-3", decision: "admit", confirm: "req-3" },
+      stubFetch(403, { error: "not_authorized", detail: "your key is not a network admin" }),
+    );
+    expect(res).toEqual({ kind: "error", message: "your key is not a network admin", httpStatus: 403 });
+  });
+
+  it("falls back to the error code when no detail is present", async () => {
+    const res = await submitDecision(
+      { network_id: "alpha", request_id: "req-4", decision: "admit", confirm: "req-4" },
+      stubFetch(409, { error: "already_decided" }),
+    );
+    expect(res).toEqual({ kind: "error", message: "already_decided", httpStatus: 409 });
+  });
+
+  it("never throws on a transport failure (httpStatus 0)", async () => {
+    const fetchImpl: FetchLike = () => Promise.reject(new Error("network down"));
+    const res = await submitDecision(
+      { network_id: "alpha", request_id: "req-5", decision: "admit", confirm: "req-5" },
+      fetchImpl,
+    );
+    expect(res).toEqual({ kind: "error", message: "network down", httpStatus: 0 });
+  });
+
+  it("treats a 200 with a bad status as an error", async () => {
+    const res = await submitDecision(
+      { network_id: "alpha", request_id: "req-6", decision: "admit", confirm: "req-6" },
+      stubFetch(200, { status: "MAYBE" }),
+    );
+    expect(res.kind).toBe("error");
+  });
+});
+
+describe("describeOutcome", () => {
+  it("summarises an admit", () => {
+    expect(describeOutcome({ kind: "ok", status: "ADMITTED", requestId: "req-1" })).toEqual({
+      tone: "ok",
+      text: "Request req-1 admitted.",
+    });
+  });
+  it("summarises a reject", () => {
+    expect(describeOutcome({ kind: "ok", status: "REJECTED", requestId: "req-2" }).text).toBe("Request req-2 rejected.");
+  });
+  it("passes an error message through", () => {
+    expect(describeOutcome({ kind: "error", message: "nope", httpStatus: 403 })).toEqual({ tone: "error", text: "nope" });
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/pier-decide.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-decide.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * MC-B2 (cortex#1279) — static render tests for PierDecideForm (no DOM harness;
+ * the interactive behaviour is covered by pier-decide-lib.test.ts). Asserts: no
+ * action surface without an admin network; both action buttons render disabled
+ * initially (typed-confirm not yet satisfied); a single admin network renders as
+ * a label and multiple as a select.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { PierDecideForm } from "../components/pier-decide";
+
+function render(adminNetworks: readonly string[]): string {
+  return renderToStaticMarkup(createElement(PierDecideForm, { adminNetworks }));
+}
+
+describe("PierDecideForm", () => {
+  it("renders nothing when the principal admins no networks", () => {
+    expect(render([])).toBe("");
+  });
+
+  it("renders Grant + Reject, both disabled before a request id is entered", () => {
+    const html = render(["alpha"]);
+    expect(html).toContain("Grant");
+    expect(html).toContain("Reject");
+    // Initial state: no request id, no confirm → both actions disabled.
+    const disabledButtons = html.match(/<button[^>]*disabled/g) ?? [];
+    expect(disabledButtons.length).toBe(2);
+  });
+
+  it("renders a single admin network as a static label (no select)", () => {
+    const html = render(["alpha"]);
+    expect(html).toContain("alpha");
+    expect(html).not.toContain("<select");
+  });
+
+  it("renders multiple admin networks as a select with an option each", () => {
+    const html = render(["alpha", "beta"]);
+    expect(html).toContain("<select");
+    expect(html).toContain("alpha");
+    expect(html).toContain("beta");
+  });
+
+  it("mentions the list-pending source so the principal knows where to get the id", () => {
+    const html = render(["alpha"]);
+    expect(html).toContain("--list-pending");
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/pier-decide.tsx
+++ b/src/surface/mc/dashboard-v2/components/pier-decide.tsx
@@ -1,0 +1,168 @@
+/**
+ * MC-B2 (cortex#1279) — the **Tier-2 admit/reject action** on the Pier queue.
+ *
+ * A thin shell over `pier-decide-lib` (all the load-bearing logic — the
+ * typed-confirm gate + the verdict→message mapping — lives there and is
+ * unit-tested). Request-id-driven (Option A): the principal supplies the
+ * `request_id` (from `cortex network admit --list-pending` / the registry) and
+ * re-types it into the confirm box to authorise the mutation, mirroring the CLI
+ * `cortex network admit <request-id> --apply` posture the approved scope cites.
+ *
+ * The decision is signed by the LOCAL daemon with the stack seed (never the
+ * browser, never the CF worker); this component only POSTs and renders the
+ * registry's verdict. On the not-an-admin case the endpoint returns 403 and we
+ * surface the readable `detail` inline (never a silent failure).
+ *
+ * Auto-populating request_ids onto the pending rows (so these become per-row
+ * buttons) needs the admin-list read path (ADR-0020 global-admin-read scoping,
+ * admit-lane-adjacent) → documented follow-up.
+ */
+
+import { useState } from "react";
+import {
+  ADMISSION_DECISION_PATH,
+  canDecide,
+  describeOutcome,
+  submitDecision,
+  type DecideOutcome,
+  type DecideVerb,
+  type FetchLike,
+} from "../lib/pier-decide-lib";
+
+export interface PierDecideFormProps {
+  /** Networks the principal ADMINS (complete-scope) — the decision's `network_id` options. */
+  adminNetworks: readonly string[];
+  /** Injected transport (tests). Production omits → `globalThis.fetch`. */
+  fetchImpl?: FetchLike;
+  /** Called after a successful decision (e.g. to trigger a networks refetch). */
+  onDecided?: () => void;
+}
+
+const defaultFetch: FetchLike = (path, init) => fetch(path, init);
+
+export function PierDecideForm({ adminNetworks, fetchImpl, onDecided }: PierDecideFormProps) {
+  const [networkId, setNetworkId] = useState<string>(adminNetworks[0] ?? "");
+  const [requestId, setRequestId] = useState<string>("");
+  const [confirm, setConfirm] = useState<string>("");
+  const [busy, setBusy] = useState<boolean>(false);
+  const [outcome, setOutcome] = useState<DecideOutcome | null>(null);
+
+  // No admin networks → no action surface (parent gates too; belt-and-braces).
+  if (adminNetworks.length === 0) return null;
+
+  const ready = canDecide({ requestId, confirm, busy });
+  const post = fetchImpl ?? defaultFetch;
+
+  async function decide(decision: DecideVerb): Promise<void> {
+    if (!canDecide({ requestId, confirm, busy })) return;
+    setBusy(true);
+    setOutcome(null);
+    const result = await submitDecision(
+      { network_id: networkId, request_id: requestId, decision, confirm },
+      post,
+    );
+    setBusy(false);
+    setOutcome(result);
+    if (result.kind === "ok") {
+      // Clear the entry so the same id can't be double-submitted by mistake.
+      setRequestId("");
+      setConfirm("");
+      onDecided?.();
+    }
+  }
+
+  const summary = outcome ? describeOutcome(outcome) : null;
+
+  return (
+    <div className="pier-decide" aria-label="Grant or reject an admission request">
+      <h4 className="pier-decide-title">
+        Grant / reject a request <span className="dim">— by request id</span>
+      </h4>
+      <p className="dim pier-decide-help">
+        Signed locally by your daemon with your stack key (needs your key on the
+        network&rsquo;s admins). Get the request id from{" "}
+        <code>cortex network admit --list-pending</code>, then type it twice to confirm.
+      </p>
+
+      <label className="pier-decide-field">
+        <span className="pier-decide-label">Network</span>
+        {adminNetworks.length === 1 ? (
+          <span className="pier-decide-network-single">{adminNetworks[0]}</span>
+        ) : (
+          <select
+            className="pier-decide-select"
+            value={networkId}
+            onChange={(e) => setNetworkId(e.target.value)}
+            disabled={busy}
+          >
+            {adminNetworks.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        )}
+      </label>
+
+      <label className="pier-decide-field">
+        <span className="pier-decide-label">Request id</span>
+        <input
+          className="pier-decide-input"
+          type="text"
+          value={requestId}
+          onChange={(e) => setRequestId(e.target.value)}
+          placeholder="req-…"
+          disabled={busy}
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <label className="pier-decide-field">
+        <span className="pier-decide-label">Confirm (re-type the request id)</span>
+        <input
+          className="pier-decide-input pier-decide-confirm"
+          type="text"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          placeholder="req-…"
+          disabled={busy}
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </label>
+
+      <div className="pier-decide-actions">
+        <button
+          type="button"
+          className="pier-decide-grant"
+          onClick={() => void decide("admit")}
+          disabled={!ready}
+          title={ready ? "Grant this request (admit onto the roster)" : "Enter a request id and re-type it to confirm"}
+        >
+          Grant
+        </button>
+        <button
+          type="button"
+          className="pier-decide-reject"
+          onClick={() => void decide("reject")}
+          disabled={!ready}
+          title={ready ? "Reject this request" : "Enter a request id and re-type it to confirm"}
+        >
+          Reject
+        </button>
+        {busy ? <span className="dim pier-decide-busy">deciding…</span> : null}
+      </div>
+
+      {summary ? (
+        <p
+          className={summary.tone === "ok" ? "pier-decide-result tone-ok" : "pier-decide-result tone-error"}
+          role={summary.tone === "error" ? "alert" : "status"}
+          data-path={ADMISSION_DECISION_PATH}
+        >
+          {summary.text}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/pier-queue.tsx
+++ b/src/surface/mc/dashboard-v2/components/pier-queue.tsx
@@ -21,14 +21,23 @@
  */
 
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
-import { selectPierQueue } from "../lib/pier-queue-adapter";
+import { isAdminPosture, selectPierQueue } from "../lib/pier-queue-adapter";
+import { PierDecideForm } from "./pier-decide";
+import type { FetchLike } from "../lib/pier-decide-lib";
 
 export interface PierQueueProps {
   networks: readonly NetworkMembershipDTO[];
+  /** Injected transport for the decide action (tests). Production omits → `fetch`. */
+  decideFetch?: FetchLike;
+  /** Called after a successful admit/reject (e.g. to refetch the networks view). */
+  onDecided?: () => void;
 }
 
-export function PierQueue({ networks }: PierQueueProps) {
+export function PierQueue({ networks, decideFetch, onDecided }: PierQueueProps) {
   const queue = selectPierQueue(networks);
+  // MC-B2 — the decision action targets networks the principal ADMINS
+  // (complete-scope), the SAME trust gate the queue itself uses.
+  const adminNetworks = networks.filter(isAdminPosture).map((n) => n.network_id);
 
   // The admin queue only exists for someone who admins a network. Admin
   // nothing → render nothing (keep a pure-member / non-federated stack
@@ -97,6 +106,14 @@ export function PierQueue({ networks }: PierQueueProps) {
           requests are visible only to a network&rsquo;s admin.
         </p>
       ) : null}
+
+      {/* MC-B2 — the Tier-2 grant/reject action (request-id-driven, typed-confirm,
+          local-daemon-signed). Only shown when the principal admins ≥1 network. */}
+      <PierDecideForm
+        adminNetworks={adminNetworks}
+        {...(decideFetch ? { fetchImpl: decideFetch } : {})}
+        {...(onDecided ? { onDecided } : {})}
+      />
     </section>
   );
 }

--- a/src/surface/mc/dashboard-v2/components/pier-queue.tsx
+++ b/src/surface/mc/dashboard-v2/components/pier-queue.tsx
@@ -3,9 +3,10 @@
  * PENDING admission requests awaiting Tier-2 grant (ADR-0015 / ADR-0018;
  * CONTEXT.md §172).
  *
- * READ-ONLY. This slice surfaces who has requested to join which network so the
- * network admin can SEE the queue; the grant/reject ACTION is MC-B2 (#1276) and
- * lands as buttons here later. No action affordances in B1.
+ * Surfaces who has requested to join which network so the network admin can SEE
+ * the queue, and — since MC-B2 (#1279) — ACT on it: the Tier-2 grant/reject
+ * affordance is embedded below as {@link PierDecideForm} (request-id-driven,
+ * CF-Access + typed-confirm gated, local-daemon-signed).
  *
  * ## Posture (the trust boundary, enforced in the pure adapter)
  *
@@ -53,7 +54,7 @@ export function PierQueue({ networks, decideFetch, onDecided }: PierQueueProps) 
       </h3>
       <p className="dim pier-queue-subtitle">
         Principals awaiting <strong>Tier-2 grant</strong> to join a network you
-        administer. Read-only — review here; grant or reject from the registry.
+        administer. Review here, then grant or reject below.
       </p>
 
       {queue.totalPending === 0 ? (

--- a/src/surface/mc/dashboard-v2/lib/pier-decide-lib.ts
+++ b/src/surface/mc/dashboard-v2/lib/pier-decide-lib.ts
@@ -1,0 +1,120 @@
+/**
+ * MC-B2 (cortex#1279) — pure logic for the **Tier-2 admit/reject action** from
+ * the Pier queue: request-id-driven, typed-confirm gated.
+ *
+ * The interactive form (`pier-decide.tsx`) is a thin shell over these pure
+ * helpers so the load-bearing behaviour — the typed-confirm gate + the
+ * registry-verdict → readable-message mapping — is unit-testable without a DOM
+ * harness (the dashboard tests render statically; there is no testing-library).
+ *
+ * Posture (mirrors the CLI `cortex network admit <request-id> --apply`): the
+ * principal supplies the `request_id` (from `cortex network admit --list-pending`
+ * or the registry) and re-types it into the confirm box — the deliberate intent
+ * gate for a control-plane mutation. The decision is signed by the LOCAL daemon
+ * with the stack seed; this client only POSTs and renders the verdict.
+ */
+
+/** admit | reject. */
+export type DecideVerb = "admit" | "reject";
+
+/** The POST body the endpoint expects (`confirm` must equal `request_id`). */
+export interface DecideBody {
+  network_id: string;
+  request_id: string;
+  decision: DecideVerb;
+  confirm: string;
+}
+
+/** The outcome of a decision POST, already mapped to something renderable. */
+export type DecideOutcome =
+  | { kind: "ok"; status: "ADMITTED" | "REJECTED"; requestId: string }
+  | { kind: "error"; message: string; httpStatus: number };
+
+/** Minimal fetch shape (injectable for tests). */
+export type FetchLike = (
+  path: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export const ADMISSION_DECISION_PATH = "/api/networks/admission-decision";
+
+/**
+ * The typed-confirm gate: a decision may be submitted only when a non-empty
+ * request-id has been entered AND the confirm box exactly echoes it AND no
+ * request is already in flight. Pure — the single source of truth the button's
+ * disabled state and any programmatic caller share.
+ */
+export function canDecide(input: {
+  requestId: string;
+  confirm: string;
+  busy: boolean;
+}): boolean {
+  const id = input.requestId.trim();
+  if (id.length === 0) return false;
+  if (input.busy) return false;
+  // Exact echo — NOT trimmed on the confirm side: the principal must reproduce
+  // the id verbatim (a stray space is a real mismatch, surfaced honestly).
+  return input.confirm === input.requestId;
+}
+
+/**
+ * POST a decision and map the response to a {@link DecideOutcome}. Reads the
+ * server's `{ error, detail }` on failure so the principal sees the readable
+ * `detail` (e.g. the not-an-admin explanation) rather than a bare status code.
+ * Never throws — a transport failure becomes `{ kind: "error", httpStatus: 0 }`.
+ */
+export async function submitDecision(
+  body: DecideBody,
+  fetchImpl: FetchLike,
+): Promise<DecideOutcome> {
+  let resp: Awaited<ReturnType<FetchLike>>;
+  try {
+    resp = await fetchImpl(ADMISSION_DECISION_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    return {
+      kind: "error",
+      message: err instanceof Error ? err.message : String(err),
+      httpStatus: 0,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await resp.json();
+  } catch {
+    parsed = null;
+  }
+  const obj = parsed !== null && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+
+  if (resp.ok) {
+    const status = obj.status;
+    if (status === "ADMITTED" || status === "REJECTED") {
+      const requestId = typeof obj.request_id === "string" ? obj.request_id : body.request_id;
+      return { kind: "ok", status, requestId };
+    }
+    return { kind: "error", message: "the decision succeeded but the response was malformed", httpStatus: resp.status };
+  }
+
+  // Failure — prefer the human `detail`, fall back to the `error` code, then HTTP.
+  const detail = typeof obj.detail === "string" ? obj.detail : undefined;
+  const error = typeof obj.error === "string" ? obj.error : undefined;
+  const message = detail ?? error ?? `HTTP ${resp.status.toString()}`;
+  return { kind: "error", message, httpStatus: resp.status };
+}
+
+/** A short, tone-tagged summary of an outcome for the result line. */
+export function describeOutcome(outcome: DecideOutcome): { tone: "ok" | "error"; text: string } {
+  if (outcome.kind === "ok") {
+    const verb = outcome.status === "ADMITTED" ? "admitted" : "rejected";
+    return { tone: "ok", text: `Request ${outcome.requestId} ${verb}.` };
+  }
+  return { tone: "error", text: outcome.message };
+}

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -24,6 +24,7 @@ import type { Config } from "./types";
 import type { WsClientRegistry } from "./ws/client-registry";
 import type { AgentPresenceView } from "./api/agents";
 import type { NetworksView } from "./api/networks";
+import type { AdmissionDecider } from "./api/networks-admission";
 import type { LocalAggregationProvider } from "./local-aggregation/sibling-db-reader";
 
 export interface MissionControlHandle {
@@ -95,6 +96,14 @@ export interface StartMissionControlOptions {
    * client + presence registry boot AFTER the embed. Omitted → empty list.
    */
   networks?: () => NetworksView | null;
+  /**
+   * MC-B2 (cortex#1279) — lazy accessor for the admission-decision signer,
+   * forwarded verbatim to `startServer` so `POST /api/networks/admission-decision`
+   * can sign a Tier-2 admit/reject LOCALLY with the stack seed. A GETTER (like
+   * `networks`) because the stack identity + registry client boot AFTER the
+   * embed. Omitted → the route 503s honestly.
+   */
+  admissionDecider?: () => AdmissionDecider | null;
   /**
    * P-14 U0.1 — Tier-3 sideband base URL (`config.mc.sideband`). Loopback-
    * enforced at config-parse time; forwarded verbatim to `startServer`, which
@@ -179,6 +188,7 @@ export async function startMissionControl(
       processManager,
       ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
       ...(opts.networks ? { networks: opts.networks } : {}),
+      ...(opts.admissionDecider ? { admissionDecider: opts.admissionDecider } : {}),
       ...(opts.localAggregation ? { localAggregation: opts.localAggregation } : {}),
       ...(opts.sidebandUrl ? { sidebandUrl: opts.sidebandUrl } : {}),
     });

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -41,6 +41,11 @@ import {
 import { handleListGitLinks } from "./api/git-links";
 import { handleListAgents, type AgentPresenceView } from "./api/agents";
 import { handleListNetworks, type NetworksView } from "./api/networks";
+import {
+  handleAdmissionDecision,
+  CF_ACCESS_EMAIL_HEADER,
+  type AdmissionDecider,
+} from "./api/networks-admission";
 import type {
   LocalAggregationContext,
   LocalAggregationProvider,
@@ -192,6 +197,16 @@ export interface StartServerOptions {
    */
   networks?: () => NetworksView | null;
   /**
+   * MC-B2 (cortex#1279) — lazy accessor for the admission-decision signer: the
+   * mutating Tier-2 admit/reject action (`POST /api/networks/admission-decision`).
+   * A GETTER like `networks` because the stack identity material + registry
+   * client boot AFTER the embed in `cortex.ts`; resolved per request. Returns
+   * `null` ⇒ no federation/registry/signing identity → the route 503s honestly.
+   * The signer runs LOCALLY (the daemon holds the stack seed); the CF worker
+   * never wires this.
+   */
+  admissionDecider?: () => AdmissionDecider | null;
+  /**
    * P-14 U0.1 — Tier-3 sideband base URL (`mc.sideband`). When present, the
    * `/api/observability/*` routes proxy to it server-side. Loopback-enforced
    * at config-parse time; the proxy re-checks at the request boundary.
@@ -284,6 +299,9 @@ export function startServer(
         // MC-A1 — resolve the networks view lazily too (registry/presence boot
         // after the server). null ⇒ the route serves an empty list.
         const networks = options.networks?.() ?? null;
+        // MC-B2 — resolve the admission-decision signer lazily too (stack
+        // identity + registry client boot after the server). null ⇒ 503.
+        const admissionDecider = options.admissionDecider?.() ?? null;
         return handleApi(
           req,
           url,
@@ -292,6 +310,7 @@ export function startServer(
           agentPresence,
           localAggregation,
           networks,
+          admissionDecider,
         );
       }
 
@@ -448,7 +467,8 @@ async function handleApi(
   deps: ApiDeps | null,
   agentPresence: AgentPresenceView | null,
   localAggregation: LocalAggregationContext | null,
-  networks: NetworksView | null = null
+  networks: NetworksView | null = null,
+  admissionDecider: AdmissionDecider | null = null
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -667,6 +687,23 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListNetworks(networks, agentPresence);
+  }
+
+  // MC-B2 (cortex#1279) — POST /api/networks/admission-decision — the mutating
+  // Tier-2 admit/reject action from the glass. Two gates (both required): the
+  // CF-Access principal identity header + a typed-confirm echo of the request_id.
+  // The decision is signed LOCALLY by the daemon with the stack seed (the CF
+  // worker never wires `admissionDecider`, so this route 503s there — the seed
+  // stays local). The loopback bind (SEV-2, above) is the boundary the identity
+  // gate composes on top of.
+  if (pathname === "/api/networks/admission-decision") {
+    if (req.method !== "POST") {
+      return methodNotAllowed(["POST"]);
+    }
+    const principal = req.headers.get(CF_ACCESS_EMAIL_HEADER) ?? undefined;
+    const body = await parseJsonBody(req);
+    if (body.error) return body.error;
+    return handleAdmissionDecision(admissionDecider, principal, body.value);
   }
 
   // F-17 — principal-driven GitHub iteration import.


### PR DESCRIPTION
## What
MC-B2: Tier-2 admit/reject **action** from the Mission Control glass (was read-only — pier-queue said "grant or reject from the registry"). Closes the last admit-*surface* gap: CLI ✅ Discord ✅ MC ✅.

Scoped per principal decision (2026-07-02, #1279 comment): CF-Access session + typed-confirm gate; **local-daemon-signed** (the daemon signs the decision with the operator's own stack seed — the same material + registry client the member-roster read uses; seed never in the CF worker; browser never signs; local MC binds loopback-only). Full step-up-MFA (#1194) is a follow-up.

## Signing path (Step-1 verified safe)
Daemon loads the stack seed server-side at boot (`loadStackSigningKey → materialFromSeedString`, held in-process), signs via the same `signClaimWithSeed`/`canonicalJSON` the CLI + roster-read use. Registry accepts the write if the signing pubkey is on global `REGISTRY_ADMIN_PUBKEYS` OR the network's per-network `admin_pubkeys` (ADR-0020); non-admin → 403 surfaced readably.

## Auth gate (both required, reject if either absent)
1. **CF-Access principal identity** — `Cf-Access-Authenticated-User-Email` header (absent → 401), atop the loopback bind.
2. **Typed-confirm** — body `confirm` must exactly echo `request_id` (mismatch → 400), mirroring `cortex network admit <request-id> --apply`. Request-id-driven (operator supplies the id from `admit --list-pending`).

## Files
Added: bus/agent-network/admission-decision.ts (+test) · surface/mc/api/networks-admission.ts (+test) · dashboard-v2/lib/pier-decide-lib.ts (+test) · dashboard-v2/components/pier-decide.tsx (+test). Modified: cortex.ts (inject live signer + audit log, no secrets) · surface/mc/server.ts · embed.ts · dashboard-v2/components/pier-queue.tsx.

## Verify
eslint . 0 · tsc 0 · check-carveouts PASS · `bun test src/surface/mc src/bus/agent-network` 2340 pass/0 fail · `bun run build:dashboard` OK (network-canvas split chunk present).

## Deployment note
Targets the local-daemon MC reached through the CF-Access-authenticated edge (where the identity header is injected). A pure-localhost dashboard with no CF Access in front gets 401 on the mutation (reads unaffected) → use the CLI or front the daemon with CF Access.

## Follow-ups (scoped out)
1. PENDING-queue auto-population + per-row request_id threading (AdmissionRow→DTO→pier-queue) → per-row buttons — admit-lane-adjacent, hits ADR-0020 global-admin-read scoping.
2. Step-up MFA #1194.
3. Cloud-worker-hosted MC path (worker can't sign — separate design).

Refs #1279. Epic #1346 (surface parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB
