### PR TITLE
fix(registry): C-832 — verify register signature over signed wire bytes (2nd-stack 401) + canonical depth guard

### DIFF
--- a/src/common/registry/signing.ts
+++ b/src/common/registry/signing.ts
@@ -24,24 +24,46 @@
 // =============================================================================
 
 /**
+ * Hard cap on nesting depth. Mirrors the registry's guard (#832) so the two
+ * canonicalisers stay byte-compatible: a legitimate claim nests ~3 levels, so
+ * 64 never triggers for any real signing input — it exists only so the two
+ * implementations remain literally identical (the registry now canonicalizes
+ * attacker-controlled input and needs the DoS guard; carrying it here too keeps
+ * the RFC-8785 cross-checker pair from silently diverging).
+ */
+export const MAX_CANONICAL_DEPTH = 64;
+
+/** Thrown by {@link canonicalJSON} when nesting exceeds {@link MAX_CANONICAL_DEPTH}. */
+export class CanonicalDepthError extends Error {
+  constructor() {
+    super(`canonical JSON nesting exceeded ${MAX_CANONICAL_DEPTH} levels`);
+    this.name = "CanonicalDepthError";
+  }
+}
+
+/**
  * Mirror of the registry's `canonicalJSON`. Object keys sorted
  * lexicographically + recursively; `undefined` values skipped (to
  * match `JSON.stringify` behaviour after a parse/stringify round-trip);
- * no whitespace.
+ * no whitespace. Throws {@link CanonicalDepthError} beyond
+ * {@link MAX_CANONICAL_DEPTH} (matches the registry's #832 DoS guard).
  */
-export function canonicalJSON(value: unknown): string {
+export function canonicalJSON(value: unknown, depth = 0): string {
+  if (depth > MAX_CANONICAL_DEPTH) {
+    throw new CanonicalDepthError();
+  }
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value);
   }
   if (Array.isArray(value)) {
-    return "[" + value.map((v) => canonicalJSON(v)).join(",") + "]";
+    return "[" + value.map((v) => canonicalJSON(v, depth + 1)).join(",") + "]";
   }
   const obj = value as Record<string, unknown>;
   const keys = Object.keys(obj)
     .filter((k) => obj[k] !== undefined)
     .sort();
   const parts = keys.map(
-    (k) => JSON.stringify(k) + ":" + canonicalJSON(obj[k]),
+    (k) => JSON.stringify(k) + ":" + canonicalJSON(obj[k], depth + 1),
   );
   return "{" + parts.join(",") + "}";
 }

--- a/src/services/network-registry/__tests__/register-canonical-drift.test.ts
+++ b/src/services/network-registry/__tests__/register-canonical-drift.test.ts
@@ -1,0 +1,175 @@
+/**
+ * #832 — root-seed add-stack register returned `401 signature_invalid`: a
+ * canonicalization drift between what the client SIGNED and what the registry
+ * VERIFIED, on the merge (add-stack) path.
+ *
+ * ROOT CAUSE (design fragility): the register route verified the Ed25519
+ * signature over the server's whitelist *reconstruction* of the claim
+ * (`validateRegistrationClaim` rebuilds the claim from a fixed set of known
+ * fields), NOT over the claim as received on the wire. So ANY validly-signed
+ * field the reconstruction did not echo silently changed the canonical bytes
+ * and 401'd a legitimate register. That is exactly what the v5.4.0 batch
+ * (#825) tripped: the client began signing `expected_updated_at` (the CAS
+ * token) into the CAS-bearing add-stack claim, and a registry whose
+ * reconstruction dropped that field rejected every such register.
+ *
+ * FIX (#832): verify over the claim AS RECEIVED (`canonicalJSON(signed.claim)`)
+ * — one canonical contract, "the principal signs canonicalJSON(claim); the
+ * registry verifies the same bytes." Structural validation still runs (400 on
+ * malformed) and STORAGE still uses the whitelisted reconstruction, so an
+ * unknown/forward field is signed-but-ignored, never persisted.
+ *
+ * These tests drive the full Hono pipeline via `app.fetch`, so signature
+ * verification + store path run exactly as in production.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  randomNonce,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import type { SignedAssertion, PrincipalRecord } from "../src/types";
+
+let env: Env;
+let rootKey: PrincipalKey;
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    ENVIRONMENT: "test",
+  } as Env;
+  rootKey = await makePrincipalKey();
+});
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+/** Establish the principal's first stack (root pubkey on record). */
+async function registerFirstStack(): Promise<string> {
+  const body = await makeSignedRegistration("jc", rootKey, {
+    stacks: [{ stack_id: "jc/default", stack_pubkey: rootKey.publicKeyB64 }],
+  });
+  const res = await post("/principals/jc/register", body);
+  expect(res.status).toBe(201);
+  const json = (await res.json()) as SignedAssertion<PrincipalRecord>;
+  return json.payload.updated_at;
+}
+
+describe("#832 — verify over the claim as received (not the reconstruction)", () => {
+  test("REGRESSION: a CAS-bearing (expected_updated_at) root-signed add-stack register verifies (201)", async () => {
+    // This is the concrete #825→#832 field. The client's fetch-merge captures
+    // the record's updated_at and signs it into the claim as the CAS token; the
+    // registry MUST verify the same bytes it received. A reconstruction that
+    // dropped the field would 401 here — the exact production symptom.
+    const updatedAt = await registerFirstStack();
+
+    const communityKey = await makePrincipalKey();
+    const body = await makeSignedRegistration("jc", rootKey, {
+      expectedUpdatedAt: updatedAt,
+      stacks: [
+        { stack_id: "jc/default", stack_pubkey: rootKey.publicKeyB64 },
+        { stack_id: "jc/clawbox", stack_pubkey: communityKey.publicKeyB64 },
+      ],
+    });
+    const res = await post("/principals/jc/register", body);
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as SignedAssertion<PrincipalRecord>;
+    expect(json.payload.stacks.map((s) => s.stack_id).sort()).toEqual([
+      "jc/clawbox",
+      "jc/default",
+    ]);
+  });
+
+  test("a validly-signed claim carrying a forward-compatible optional field still verifies (201)", async () => {
+    // The invariant that closes the regression CLASS: a field the server does
+    // not (yet) model must not break signature verification. Before the fix the
+    // route verified over the reconstruction, which silently dropped this field
+    // → canonical mismatch → 401. After the fix the route verifies the received
+    // bytes → 201 — and the field is signed-but-ignored (never persisted).
+    await registerFirstStack();
+
+    const communityKey = await makePrincipalKey();
+    // Build the claim by hand so we can sign OVER an unknown field.
+    const claim = {
+      principal_id: "jc",
+      principal_pubkey: rootKey.publicKeyB64,
+      stacks: [
+        { stack_id: "jc/default", stack_pubkey: rootKey.publicKeyB64 },
+        { stack_id: "jc/clawbox", stack_pubkey: communityKey.publicKeyB64 },
+      ],
+      capabilities: [],
+      // A future optional the current server does not model — signed all the same.
+      client_protocol_version: "6.1.0",
+      issued_at: new Date().toISOString(),
+      nonce: randomNonce(),
+    };
+    const signature = await signEd25519(
+      rootKey.privateKeyB64,
+      new TextEncoder().encode(canonicalJSON(claim)),
+    );
+    const res = await post("/principals/jc/register", { claim, signature });
+    expect(res.status).toBe(201);
+
+    // The forward field was NOT persisted — storage uses the whitelist.
+    const getRes = await app.fetch(new Request("http://localhost/principals/jc"), env);
+    const json = (await getRes.json()) as SignedAssertion<PrincipalRecord & Record<string, unknown>>;
+    expect("client_protocol_version" in json.payload).toBe(false);
+  });
+
+  test("SECURITY: tampering with a stack_pubkey after signing still fails closed (401)", async () => {
+    // Verify-over-wire must not weaken tamper resistance: mutating any field
+    // after the root signs changes the very bytes verified, so the signature
+    // (over the original) still fails.
+    await registerFirstStack();
+
+    const communityKey = await makePrincipalKey();
+    const attackerKey = await makePrincipalKey();
+    const body = await makeSignedRegistration("jc", rootKey, {
+      stacks: [
+        { stack_id: "jc/default", stack_pubkey: rootKey.publicKeyB64 },
+        { stack_id: "jc/clawbox", stack_pubkey: communityKey.publicKeyB64 },
+      ],
+    });
+    body.claim.stacks[1]!.stack_pubkey = attackerKey.publicKeyB64; // tamper post-sign
+    const res = await post("/principals/jc/register", body);
+    expect(res.status).toBe(401);
+  });
+
+  test("SECURITY: a pathologically deep claim is rejected 401 (canonical depth guard, not a 500)", async () => {
+    // Verify runs BEFORE the signature is proven, so canonicalJSON now runs over
+    // unauthenticated input. A deeply-nested body must fail closed (401), never
+    // exhaust the stack or surface a 500.
+    let deep: unknown = "leaf";
+    for (let i = 0; i < 200; i++) deep = [deep];
+    const claim = {
+      principal_id: "jc",
+      principal_pubkey: rootKey.publicKeyB64,
+      stacks: [],
+      capabilities: [],
+      evil: deep,
+      issued_at: new Date().toISOString(),
+      nonce: randomNonce(),
+    };
+    // Signature is irrelevant — the depth guard trips before it can match.
+    const res = await post("/principals/jc/register", { claim, signature: "AA==" });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -119,13 +119,42 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
     // previous key to sign a transition claim — out of scope for v1,
     // tracked as a follow-up.
     //
+    // #832 — verify the signature over the claim AS RECEIVED ON THE WIRE
+    // (`signed.claim`), NOT over the server's validated *reconstruction*
+    // (`claim`). The reconstruction (validate.ts) rebuilds the claim from a
+    // fixed whitelist of known fields; verifying against it means ANY
+    // validly-signed field the reconstruction does not (yet) echo silently
+    // changes the canonical bytes and 401s a legitimate register. That is
+    // exactly the #825→#832 regression: the client began signing
+    // `expected_updated_at` into the CAS-bearing add-stack claim, and a
+    // registry whose reconstruction dropped that field rejected every such
+    // register with `signature_invalid` — a canonicalization drift between
+    // what the client SIGNED and what the server VERIFIED. The signed
+    // contract is "the principal signs canonicalJSON(claim); the registry
+    // verifies the SAME bytes", so the one canonical form is the received
+    // claim. Structural validation already ran above (malformed → 400), and
+    // STORAGE still uses the whitelisted `claim` — so an unknown/forward
+    // field is signed-but-ignored, never persisted. Tamper resistance is
+    // unchanged: mutating any field after signing changes these very bytes,
+    // so the signature (over the original) still fails closed (401).
+    //
     // #695 — verify the signature BEFORE recording the nonce. The nonce
     // cache is durable (D1, #694), so an unsigned/bad-signature POST that
     // recorded its nonce first would permanently burn that nonce row
     // without ever proving authenticity. A replay is only meaningful for
     // an authentic (validly-signed) claim, so we shed bad-sig POSTs with
     // 401 here and only consume a nonce on the authentic path below.
-    const message = new TextEncoder().encode(canonicalJSON(claim));
+    let canonical: string;
+    try {
+      canonical = canonicalJSON(signed.claim);
+    } catch (_err) {
+      // #832 — canonicalJSON throws CanonicalDepthError on a pathologically
+      // deep (hostile) claim. Fail closed: an over-depth payload can never
+      // match a legitimate signature, so treat it as a bad signature (401)
+      // rather than surfacing a 500.
+      return c.json({ error: "signature_invalid" }, 401);
+    }
+    const message = new TextEncoder().encode(canonical);
     const valid = await verifyEd25519(claim.principal_pubkey, signed.signature, message);
     if (!valid) {
       return c.json({ error: "signature_invalid" }, 401);

--- a/src/services/network-registry/src/signing.ts
+++ b/src/services/network-registry/src/signing.ts
@@ -23,15 +23,40 @@
 // =============================================================================
 
 /**
- * Deterministic JSON: object keys sorted recursively, no whitespace.
- * Arrays preserve their order. Throws on cycles (JSON.stringify behaviour).
+ * Hard cap on nesting depth. #832 — the register route now canonicalizes the
+ * claim AS RECEIVED (unauthenticated, attacker-controlled: verify runs before
+ * the signature is proven), so this recursion can be driven by hostile input.
+ * A legitimate registration claim nests ~3 levels deep (claim → stacks[] →
+ * metadata map); 64 is far beyond any real claim yet shallow enough that a
+ * deeply-nested body cannot exhaust the stack. Over-depth throws
+ * `CanonicalDepthError`, which the verify path catches and fails closed (401) —
+ * a hostile payload can never reach a legit signature anyway. The client-side
+ * mirror carries the identical guard so both stay byte-compatible.
  */
-export function canonicalJSON(value: unknown): string {
+export const MAX_CANONICAL_DEPTH = 64;
+
+/** Thrown by {@link canonicalJSON} when nesting exceeds {@link MAX_CANONICAL_DEPTH}. */
+export class CanonicalDepthError extends Error {
+  constructor() {
+    super(`canonical JSON nesting exceeded ${MAX_CANONICAL_DEPTH} levels`);
+    this.name = "CanonicalDepthError";
+  }
+}
+
+/**
+ * Deterministic JSON: object keys sorted recursively, no whitespace.
+ * Arrays preserve their order. Throws on cycles (JSON.stringify behaviour)
+ * and on nesting deeper than {@link MAX_CANONICAL_DEPTH} (#832 DoS guard).
+ */
+export function canonicalJSON(value: unknown, depth = 0): string {
+  if (depth > MAX_CANONICAL_DEPTH) {
+    throw new CanonicalDepthError();
+  }
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value);
   }
   if (Array.isArray(value)) {
-    return "[" + value.map((v) => canonicalJSON(v)).join(",") + "]";
+    return "[" + value.map((v) => canonicalJSON(v, depth + 1)).join(",") + "]";
   }
   const obj = value as Record<string, unknown>;
   // Mirror JSON.stringify's handling of `undefined`: skip object keys
@@ -43,7 +68,7 @@ export function canonicalJSON(value: unknown): string {
   const keys = Object.keys(obj)
     .filter((k) => obj[k] !== undefined)
     .sort();
-  const parts = keys.map((k) => JSON.stringify(k) + ":" + canonicalJSON(obj[k]));
+  const parts = keys.map((k) => JSON.stringify(k) + ":" + canonicalJSON(obj[k], depth + 1));
   return "{" + parts.join(",") + "}";
 }
 


### PR DESCRIPTION
## What
Fixes the 2nd-stack (root-seed add-stack) register **401 signature_invalid** (#832) and removes the underlying fragility that caused it.

## Root cause (pinned by repro, not reading)
The register route verified the Ed25519 signature over the server's **whitelist reconstruction** of the claim (`validateRegistrationClaim` rebuilds it from a fixed field set), NOT over the claim as signed on the wire. The client signs `canonicalJSON(clientClaim)` including `expected_updated_at` (the #825 CAS token the add-stack fetch-merge captures). Any validly-signed field the reconstruction doesn't echo → different canonical bytes → 401. #825 introduced `expected_updated_at`; a registry whose reconstruction dropped it 401'd every 2nd-stack register (same trap later hit `network_id`/#1239).

## ⚠️ Deploy-skew nuance (important)
The CURRENT in-repo registry ALREADY preserves `expected_updated_at` + `network_id` (#825's server half, 6fb37bd2). A repro driving the real client path against the in-memory registry returns 201 — the tree is internally consistent. **So JC's prod 401 is a client/server DEPLOY SKEW: the deployed registry predates #825's server half.** A plain `wrangler deploy --env production` of the current registry clears JC's 401. This PR additionally removes the fragility so it can't recur. **Prod still needs the registry wrangler deploy regardless.**

## The fix (one canonical contract, server-side)
- Verify over `canonicalJSON(signed.claim)` — the exact bytes the principal signed. Structural validation still runs (malformed → 400); STORAGE still uses the whitelisted reconstruction, so an unknown/forward field is signed-but-ignored, never persisted. Tamper resistance unchanged (mutate any field post-sign → different bytes → 401).
- DoS guard: verify now canonicalizes UNAUTHENTICATED input (pre-signature), so added `MAX_CANONICAL_DEPTH=64` + `CanonicalDepthError` to BOTH canonicalJSON mirrors (registry signing.ts + common/registry/signing.ts, kept byte-identical), fail-closed 401 on a pathologically deep body — no stack exhaustion, no 500.
- Scope: principals.ts (verify) + signing.ts (depth guard) only. Did NOT touch validate.ts (reconstruction still needed for storage + structural checks), network.ts/admit path (#1316).

## Verify (all four)
eslint . 0 · tsc 0 · check-carveouts PASS · `bun test src/cli/cortex/commands src/services/network-registry src/bus` 2622 pass/0 fail. Tests (drive full Hono app): forward-field 401→201, CAS-bearing add-stack 201, post-sign tamper 401, 200-deep body 401-not-500.

## Residual (for reviewers)
1. **Prod needs the registry `wrangler deploy --env production`** (separate from arc upgrade) — code alone doesn't clear JC.
2. Verify-over-wire canonicalizes attacker input pre-auth → bounded by depth-64 + register rate-limit (runs before verify) + Worker body-size limit.
3. **Scope asymmetry:** only the REGISTRATION verify path changed; network-create/admission-decision/sealed-secret/revoke still verify-over-reconstruction (same latent field-drift). Follow-up to converge them.
4. The two canonicalJSON mirrors must stay byte-identical incl. the depth cap (both 64); covered by round-trip tests, no shared-module enforcement.
5. Unknown fields signed-but-ignored (forward-compat by design; not surfaced back to client).

Closes #832. Epic #1346 (unblocks #1351 Slice 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB
