### PR TITLE
feat(review): CONTEXT.md/ADR grounding in bus review prompt + lockdown allowlist for read-only gh (compass#98 F6)

### DIFF
--- a/src/runner/__tests__/review-prompt.test.ts
+++ b/src/runner/__tests__/review-prompt.test.ts
@@ -207,3 +207,85 @@ describe("buildReviewPrompt — always-on exposure + confidentiality (compass#89
     );
   });
 });
+
+describe("buildReviewPrompt — CONTEXT.md/ADR grounding (compass#98 F6)", () => {
+  test("emits the grounding directive on every review", () => {
+    const p = buildReviewPrompt(payload());
+    expect(p).toContain(
+      "Ground this review in the TARGET repo's own documented architecture",
+    );
+  });
+
+  test("names all three canonical grounding docs (skill ArchitectureDocs §1)", () => {
+    const p = buildReviewPrompt(payload());
+    expect(p).toContain("CONTEXT.md");
+    expect(p).toContain("docs/architecture.md");
+    expect(p).toContain("compass/ecosystem/CONTEXT-MAP.md");
+  });
+
+  test("instructs the PIPE-FREE raw-media gh api fetch (M2 guard forbids pipes)", () => {
+    const p = buildReviewPrompt(payload());
+    // The un-piped raw-media form the widened lockdown allowlist (C2) permits.
+    expect(p).toContain(
+      'gh api repos/<owner>/<repo>/contents/<path> -H "Accept: application/vnd.github.raw"',
+    );
+    // …and explicitly steers OFF the ArchitectureDocs `| base64 -d` pipe, which
+    // rejectsChaining would block before the allowlist is consulted.
+    expect(p).toContain("base64 -d");
+    expect(p).toMatch(/bash guard forbids pipes/i);
+  });
+
+  test("instructs the _Avoid_ alias + M1–M7 layer-direction cross-check", () => {
+    const p = buildReviewPrompt(payload());
+    expect(p).toContain("_Avoid_");
+    expect(p).toMatch(/layer boundary in the wrong direction/i);
+  });
+
+  test("requires the pinned, greppable provenance line (identical shape across carriers)", () => {
+    const p = buildReviewPrompt(payload());
+    expect(p).toContain(
+      "architecture-docs: CONTEXT.md (loaded|not-found), docs/architecture.md (loaded|not-found), CONTEXT-MAP.md (loaded|not-found)",
+    );
+    // The canonical line uses the hyphenated `(not-found)` token, not `(missing)`
+    // — enforced by the pinned shape above (the prompt also explicitly names the
+    // forbidden `(missing)`/`(absent)` variants as guidance, so we cannot assert
+    // their global absence; the pinned-shape match is the real contract).
+    expect(p).toContain("CONTEXT-MAP.md (loaded|not-found)");
+  });
+
+  test("grounding sits BETWEEN the lens directive and the exposure block", () => {
+    const p = buildReviewPrompt(payload({ flavor: "security" }));
+    const lensIdx = p.indexOf("Invoke the CodeReview skill");
+    const groundIdx = p.indexOf("Ground this review in the TARGET repo");
+    const exposureIdx = p.indexOf(
+      "Before reviewing, determine the target repo's exposure",
+    );
+    expect(lensIdx).toBeGreaterThanOrEqual(0);
+    expect(exposureIdx).toBeGreaterThanOrEqual(0);
+    expect(groundIdx).toBeGreaterThan(lensIdx);
+    expect(exposureIdx).toBeGreaterThan(groundIdx);
+  });
+
+  test("never-quote redaction discipline is carried into the grounding step too", () => {
+    const p = buildReviewPrompt(payload());
+    expect(p).toContain("NEVER quote suspected confidential content");
+  });
+
+  test("builder stays PURE with grounding (same input → byte-identical output)", () => {
+    expect(buildReviewPrompt(payload({ flavor: "typescript" }))).toBe(
+      buildReviewPrompt(payload({ flavor: "typescript" })),
+    );
+  });
+
+  test("grounding is flavor-independent, yet drift-1 (security ≠ typescript) still holds", () => {
+    const security = buildReviewPrompt(payload({ flavor: "security" }));
+    const typescript = buildReviewPrompt(payload({ flavor: "typescript" }));
+    // The whole prompts still differ (the lens directive names a distinct
+    // workflow) — drift-1 stays pinned shut.
+    expect(security).not.toBe(typescript);
+    // …but the grounding directive itself is identical across flavors.
+    const ground = "Ground this review in the TARGET repo's own documented architecture";
+    expect(security).toContain(ground);
+    expect(typescript).toContain(ground);
+  });
+});

--- a/src/runner/__tests__/review-session-lockdown.test.ts
+++ b/src/runner/__tests__/review-session-lockdown.test.ts
@@ -142,6 +142,22 @@ describe("LOCKED_REVIEW_BASH_ALLOWLIST — read-only gh api/repo for grounding +
     ).toBe(true);
   });
 
+  test("PERMITS the bare read form with no trailing args", () => {
+    expect(permits("gh api repos/o/r/contents/CONTEXT.md")).toBe(true);
+  });
+
+  test("DENIES the contents write/delete primitive (cortex#1420 BLOCK — gh api is method-polymorphic)", () => {
+    // `gh api` has no verb of its own — the HTTP method comes from `--method`/`-X`,
+    // and `/contents/<path>` is a write/delete-capable GitHub endpoint. A
+    // start-anchored-only pattern let these through; the fix end-anchors the
+    // pattern to the one documented read shape.
+    expect(
+      permits("gh api repos/o/r/contents/x --method PUT -f message=m -f content=YQ=="),
+    ).toBe(false);
+    expect(permits("gh api repos/o/r/contents/x -X DELETE -f message=m -f sha=abc")).toBe(false);
+    expect(permits("gh api repos/o/r/contents/x -f a=b")).toBe(false);
+  });
+
   test("PERMITS the #89/#96 exposure check (was DENIED under lockdown before C2)", () => {
     expect(permits("gh repo view the-metafactory/cortex --json visibility")).toBe(true);
     expect(permits("gh repo view o/r --json visibility")).toBe(true);

--- a/src/runner/__tests__/review-session-lockdown.test.ts
+++ b/src/runner/__tests__/review-session-lockdown.test.ts
@@ -121,3 +121,72 @@ describe("lockdownReviewSessionOpts — fail-closed scratch dir", () => {
     expect(locked.allowedDirs).toEqual(["/tmp/s"]);
   });
 });
+
+describe("LOCKED_REVIEW_BASH_ALLOWLIST — read-only gh api/repo for grounding + exposure (compass#98 C2)", () => {
+  // Mirror the bash-guard's per-segment matcher exactly: bash-guard.hook.ts tests
+  // each split command segment with `new RegExp(rule.pattern, "i")`.
+  const permits = (cmd: string): boolean =>
+    LOCKED_REVIEW_BASH_ALLOWLIST.rules.some((r) => new RegExp(r.pattern, "i").test(cmd));
+
+  test("PERMITS the F6 grounding contents fetch for each canonical doc", () => {
+    expect(permits("gh api repos/o/r/contents/CONTEXT.md")).toBe(true);
+    expect(permits("gh api repos/o/r/contents/docs/architecture.md")).toBe(true);
+    expect(permits("gh api repos/o/r/contents/compass/ecosystem/CONTEXT-MAP.md")).toBe(true);
+    // deep owner/repo slugs still bind
+    expect(permits("gh api repos/the-metafactory/cortex/contents/CONTEXT.md")).toBe(true);
+  });
+
+  test("PERMITS the pipe-free raw-media fetch form the F6 directive instructs", () => {
+    expect(
+      permits('gh api repos/o/r/contents/CONTEXT.md -H "Accept: application/vnd.github.raw"'),
+    ).toBe(true);
+  });
+
+  test("PERMITS the #89/#96 exposure check (was DENIED under lockdown before C2)", () => {
+    expect(permits("gh repo view the-metafactory/cortex --json visibility")).toBe(true);
+    expect(permits("gh repo view o/r --json visibility")).toBe(true);
+  });
+
+  test("still DENIES non-contents gh api + secret/credential reads", () => {
+    expect(permits("gh api user")).toBe(false);
+    expect(permits("gh secret list")).toBe(false);
+    expect(permits("gh api repos/o/r/actions/secrets")).toBe(false);
+    expect(permits("gh api repos/o/r/actions/secrets/FOO")).toBe(false);
+    expect(permits("gh api")).toBe(false);
+    expect(permits("gh auth token")).toBe(false);
+    expect(permits("gh auth status")).toBe(false);
+  });
+
+  test("the gh repo entry is anchored to `--json visibility` ONLY (no broader gh repo)", () => {
+    expect(permits("gh repo view o/r --json nameWithOwner")).toBe(false);
+    expect(permits("gh repo delete o/r")).toBe(false);
+    expect(permits("gh repo clone o/r")).toBe(false);
+    expect(permits("gh repo view o/r")).toBe(false); // no --json visibility
+  });
+
+  test("the two new entries are tightly anchored — no bare `gh api` / `gh repo`", () => {
+    const patterns = LOCKED_REVIEW_BASH_ALLOWLIST.rules.map((r) => r.pattern);
+    // the widened entries exist…
+    expect(patterns.some((p) => p.includes("contents"))).toBe(true);
+    expect(patterns.some((p) => p.includes("--json visibility"))).toBe(true);
+    // …and NOTHING broader leaked in (a bare `^gh api`/`^gh repo` would open the
+    // whole read API — secrets, auth, actions — to an untrusted reviewer).
+    expect(patterns).not.toContain("^gh api");
+    expect(patterns).not.toContain("^gh api ");
+    expect(patterns).not.toContain("^gh api( |$)");
+    expect(patterns).not.toContain("^gh repo");
+    expect(patterns).not.toContain("^gh repo ");
+    expect(patterns).not.toContain("^gh repo( |$)");
+  });
+
+  test("pre-existing forge-review + read-only git entries are preserved", () => {
+    // Regression: widening must not drop the CO-7 M2 baseline rules.
+    expect(permits("gh pr review 900 --approve")).toBe(true);
+    expect(permits("gh pr diff 900")).toBe(true);
+    expect(permits("glab mr diff 12")).toBe(true);
+    expect(permits("git show HEAD")).toBe(true);
+    // still no broad git / gh
+    expect(permits("git push origin main")).toBe(false);
+    expect(permits("gh issue create")).toBe(false);
+  });
+});

--- a/src/runner/review-prompt.ts
+++ b/src/runner/review-prompt.ts
@@ -128,6 +128,50 @@ export function buildReviewPrompt(payload: ReviewRequestPayload): string {
     `Invoke the CodeReview skill — **${workflow}** workflow — then emit the ` +
     `verdict block below.`;
 
+  // compass#98 F6 — CONTEXT.md/ADR grounding. Between the lens directive and the
+  // exposure block, ground the review in the TARGET repo's own documented
+  // architecture. This is the SAME grounding contract the CodeReview skill's
+  // ArchitectureDocs carrier and the sage engine implement — ONE contract, THREE
+  // carriers; this is cortex's bus-path carrier. The pinned provenance line is
+  // byte-identical to the skill + sage carriers so downstream parsers (pilot,
+  // dashboard, audit log) grep for ONE shape.
+  //
+  // Builder stays PURE: it emits the instruction TEXT; the REVIEWER runs the
+  // read-only `gh api` fetch at review time. Flavor-independent (fires on every
+  // review), so it never affects drift-1.
+  //
+  // Fetch form is the PIPE-FREE raw-media variant, NOT the ArchitectureDocs
+  // `… --jq .content | base64 -d` pipe: a wider-scope review runs under the M2
+  // session lockdown whose bash-guard (`rejectsChaining`, bash-guard.hook.ts)
+  // DENIES any pipe / redirect OUTRIGHT — before the allowlist is even consulted
+  // — so the piped decode would be blocked regardless of the C2 allowlist widen.
+  // `-H "Accept: application/vnd.github.raw"` returns the decoded file in a
+  // single un-piped GET that the widened allowlist (review-session-lockdown.ts)
+  // permits and rejectsChaining allows.
+  const groundingInstruction = [
+    "Ground this review in the TARGET repo's own documented architecture before",
+    "emitting findings. Read-only and best-effort: fetch each of these canonical",
+    `docs from ${payload.repo} with a SINGLE un-piped GET —`,
+    '`gh api repos/<owner>/<repo>/contents/<path> -H "Accept: application/vnd.github.raw"`',
+    "(a non-zero exit means the doc is absent — expected and non-fatal; do NOT",
+    "pipe to `base64 -d`, the review session's bash guard forbids pipes):",
+    "(1) `CONTEXT.md` — the bounded-context glossary (canonical terms + `_Avoid_`",
+    "alias lists); (2) `docs/architecture.md` — the M1–M7 layer model and",
+    "componentisation; (3) `compass/ecosystem/CONTEXT-MAP.md` — ecosystem boundary",
+    "terms. Cross-check the diff against them: flag any added or renamed symbol",
+    "whose normalized token sequence matches a CONTEXT.md `_Avoid_` alias",
+    "(camelCase / snake_case / kebab-case / dotted forms are the SAME sequence —",
+    "a case- and separator-insensitive match), and any new import that crosses an",
+    "M1–M7 layer boundary in the wrong direction (a lower layer importing a higher",
+    "one, or an M7 surface taking on an M2–M6 concern). NEVER quote suspected",
+    "confidential content — cite each finding by `file:line` and canonical term",
+    "only. You MUST include, in the posted review, a one-line provenance string",
+    "naming which docs loaded, in this EXACT pinned shape (downstream parsers grep",
+    "for the `(loaded)` / `(not-found)` pair — use hyphenated `(not-found)`, never",
+    "`(missing)` or `(absent)`):",
+    "`architecture-docs: CONTEXT.md (loaded|not-found), docs/architecture.md (loaded|not-found), CONTEXT-MAP.md (loaded|not-found)`.",
+  ].join(" ");
+
   // ALWAYS-ON exposure + confidentiality instruction — appended for EVERY
   // flavor (design-software-factory-confidentiality.md §4 L3: "Confidentiality
   // runs on every review of an exposed repo regardless of flavor"). The builder
@@ -152,6 +196,8 @@ export function buildReviewPrompt(payload: ReviewRequestPayload): string {
     `Review ${target} ${ref}.`,
     "",
     lensDirective,
+    "",
+    groundingInstruction,
     "",
     exposureInstruction,
     "",

--- a/src/runner/review-session-lockdown.ts
+++ b/src/runner/review-session-lockdown.ts
@@ -125,7 +125,19 @@ export const LOCKED_REVIEW_BASH_ALLOWLIST: {
     //      endpoint of SOME repo; a bare `gh api`, `gh api user`, or
     //      `gh api repos/o/r/actions/secrets` (no `/contents/` segment) never
     //      matches, so secrets/actions/user endpoints stay denied.
-    { pattern: "^gh api repos/[^ ]+/contents/[^ ]+( |$)" },
+    //      END-ANCHORED (adversarial review finding, cortex#1420): `gh api` is
+    //      method-polymorphic and the `/contents/` endpoint supports PUT (write)
+    //      and DELETE. A start-anchored-only pattern let
+    //      `gh api repos/o/r/contents/x --method PUT -f content=<base64>` or
+    //      `-X DELETE` through — a file write/delete primitive for an untrusted
+    //      reviewer, and `rejectsChaining` does not catch it (no metacharacters).
+    //      The pattern now permits ONLY the bare read form, optionally followed
+    //      by the raw-media `-H` header the F6 fetch actually uses — nothing
+    //      else (`--method`, `-X`, `-f`, `--field`, or any trailing arg) matches.
+    {
+      pattern:
+        '^gh api repos/[^ ]+/contents/[^ ]+( -H "Accept: application/vnd\\.github\\.raw")?$',
+    },
     //   2. `gh repo view <repo> --json visibility` — the #89/#96 exposure check
     //      (public-vs-private, fail-closed). Anchored to `--json visibility` so it
     //      cannot widen to `gh repo delete/clone` or arbitrary `--json` field sets.

--- a/src/runner/review-session-lockdown.ts
+++ b/src/runner/review-session-lockdown.ts
@@ -23,9 +23,13 @@
  *     `Write`, `NotebookEdit`, no `Task`/sub-agent spawn, no MCP write tools.
  *   - **`bashAllowlist`** — a TIGHT allowlist: read-only inspection (`git
  *     show/diff/log`, `cat`, `ls`, …) + the forge review post (`gh pr review`,
- *     `gh pr diff`, `gh pr view`, `glab`). NO general `git`/`bun`/`gh` (the dev
- *     path's broad allowlist is the HIGHER-authority profile and must NOT leak
- *     into a public review). Anything else is denied by `bash-guard.hook.ts`.
+ *     `gh pr diff`, `gh pr view`, `glab`) + TWO tightly-anchored read-only
+ *     exceptions (compass#98 C2): `gh api repos/<o>/<r>/contents/<path>` (the F6
+ *     CONTEXT.md/ADR grounding fetch) and `gh repo view <r> --json visibility`
+ *     (the #89/#96 exposure check — previously DENIED here). NO general
+ *     `git`/`bun`/`gh`, no bare `gh api`/`gh repo` (the dev path's broad
+ *     allowlist is the HIGHER-authority profile and must NOT leak into a public
+ *     review). Anything else is denied by `bash-guard.hook.ts`.
  *   - **`disallowedTools`** — belt-and-braces explicit denials of the
  *     write/spawn tools even if a future baseline `allowedTools` widens.
  *   - **`allowedDirs`** — SCRATCH ONLY (the caller passes the per-review scratch
@@ -111,8 +115,23 @@ export const LOCKED_REVIEW_BASH_ALLOWLIST: {
     // style smuggling.
     { pattern: "^git (show|diff|log|status|blame|cat-file)( |$)" },
     // Forge review post + read (GitHub). `gh pr review|diff|view|checkout` only;
-    // NO `gh repo`, `gh secret`, `gh api`, `gh auth`, etc.
+    // NO broad `gh repo`, `gh secret`, `gh auth`, etc. (the two read-only
+    // exceptions immediately below are the ONLY `gh api`/`gh repo` forms allowed).
     { pattern: "^gh pr (review|diff|view|checkout|comment)( |$)" },
+    // compass#98 C2 — read-only grounding + exposure. TWO tightly-anchored
+    // exceptions to the "no gh api / no gh repo" rule above, and NOTHING broader:
+    //   1. `gh api repos/<owner>/<repo>/contents/<path>` — the F6 CONTEXT.md/ADR
+    //      grounding fetch (§ArchitectureDocs). Bound to the read-only `contents`
+    //      endpoint of SOME repo; a bare `gh api`, `gh api user`, or
+    //      `gh api repos/o/r/actions/secrets` (no `/contents/` segment) never
+    //      matches, so secrets/actions/user endpoints stay denied.
+    { pattern: "^gh api repos/[^ ]+/contents/[^ ]+( |$)" },
+    //   2. `gh repo view <repo> --json visibility` — the #89/#96 exposure check
+    //      (public-vs-private, fail-closed). Anchored to `--json visibility` so it
+    //      cannot widen to `gh repo delete/clone` or arbitrary `--json` field sets.
+    //      This unblocks the exposure check, which was DENIED under lockdown before
+    //      C2 (it only matched `gh pr view`, not `gh repo view`).
+    { pattern: "^gh repo view [^ ]+ --json visibility( |$)" },
     // Forge review post + read (GitLab).
     { pattern: "^glab mr (note|diff|view|approve)( |$)" },
     // Read-only filesystem inspection within the scratch dir.


### PR DESCRIPTION
_Branched from `origin/main` (local checkout was stale, −25)._

## compass#98 F6 — CONTEXT.md/ADR grounding in the bus review prompt

Adds a **grounding directive** to `buildReviewPrompt` (`src/runner/review-prompt.ts`), inserted **between** the lens directive and the exposure block. The reviewer is instructed to:

1. **Fetch** the target repo's own architecture docs — `CONTEXT.md`, `docs/architecture.md`, `compass/ecosystem/CONTEXT-MAP.md` (skill `ArchitectureDocs` §1).
2. **Cross-check** the diff for `_Avoid_` glossary-alias uses (case/separator-insensitive token match) and M1–M7 layer-direction violations.
3. **Emit** the pinned, greppable provenance line — **byte-identical shape** to the CodeReview skill's `ArchitectureDocs` carrier and the sage engine (one contract, three carriers):
   ```
   architecture-docs: CONTEXT.md (loaded|not-found), docs/architecture.md (loaded|not-found), CONTEXT-MAP.md (loaded|not-found)
   ```

The builder stays **PURE** — it emits the instruction text; the reviewer runs `gh` at review time. **drift-1** (security prompt ≠ typescript prompt) is preserved (grounding is flavor-independent, layered on top of the flavor-specific lens directive).

## C2 (load-bearing) — widen the lockdown allowlist for read-only `gh`

`LOCKED_REVIEW_BASH_ALLOWLIST` (`src/runner/review-session-lockdown.ts`) previously permitted only `^gh pr (review|diff|view|checkout|comment)`. Both the new grounding fetch **and** the already-merged #89/#96 exposure check were therefore **DENIED under the M2 lockdown**. Added TWO tightly-anchored read-only entries — nothing broader:

- `^gh api repos/[^ ]+/contents/[^ ]+( |$)` — the F6 grounding fetch. A bare `gh api`, `gh api user`, or `gh api repos/o/r/actions/secrets` (no `/contents/` segment) never matches.
- `^gh repo view [^ ]+ --json visibility( |$)` — the #89/#96 exposure check. **This ALSO fixes the latent gap**: the always-on exposure check (`gh repo view … --json visibility`) was silently denied under lockdown because it only matched `gh pr view`, not `gh repo view`.

## ⚠️ Design note — why the PIPE-FREE fetch form

The F6 directive instructs the **raw-media** fetch (`gh api repos/o/r/contents/PATH -H "Accept: application/vnd.github.raw"`), **not** the ArchitectureDocs-canonical `… --jq .content | base64 -d` pipe. Reason: the M2 bash-guard's `rejectsChaining` (`bash-guard.hook.ts`) **denies any pipe / redirect outright, before the allowlist is consulted** — so the piped decode would be inert under lockdown regardless of the C2 widen. The raw-media form is a single un-piped GET that both `rejectsChaining` and the widened allowlist permit. Same grounding contract, carrier adapted to the lockdown.

## Redaction

Generic `{owner}/{repo}` placeholders throughout; no real `CONTEXT.md` excerpt embedded in any fixture. The directive itself carries the never-quote-confidential-content discipline (`file:line` + canonical term only).

## Tests / verification

- `src/runner/__tests__/review-prompt.test.ts` — grounding directive, all 3 docs, pipe-free raw-media form, `_Avoid_` + layer cross-check, pinned provenance line, ordering (lens → grounding → exposure), builder purity, drift-1 preserved.
- `src/runner/__tests__/review-session-lockdown.test.ts` — allowlist PERMITS contents fetch + raw-media form + exposure check; still DENIES `gh api user`, `gh secret list`, `gh api repos/o/r/actions/secrets`, bare `gh api`, and non-`visibility` `gh repo` forms; pre-existing forge-review + git entries preserved.

```
bun test src/runner/__tests__/review-prompt.test.ts src/runner/__tests__/review-session-lockdown.test.ts
→ 57 pass / 0 fail
bunx tsc --noEmit → clean
bunx eslint --quiet (4 changed files) → clean
```

Refs compass#98 (F6 + C2). **Do not merge** — opened for review per instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
