### PR TITLE
fix(sage-runner): fail-closed on missing verdict block + stamp classification/response_routing (compass#99 F11/F12)

### DIFF
--- a/src/__tests__/cortex.review-consumer.e2e.test.ts
+++ b/src/__tests__/cortex.review-consumer.e2e.test.ts
@@ -811,7 +811,27 @@ describe("cortex#327 — signature verification gate", () => {
 describe("cortex#331 Phase 1 — pi-dev substrate dispatch (factory wired into ReviewConsumer)", () => {
   let runtime: BusRuntime;
   let consumer: ReviewConsumer;
-  const stdoutMarkdown = "## sage review\n\nblockers=0 majors=0 nits=0 — looks good";
+  // Post-compass#99 F11 a `review.verdict.*` requires a well-formed
+  // `--emit-verdict-block` block (block-less stdout returns a prose
+  // `completed`, no synthetic verdict). sage#83 emits this block in
+  // production, so the round-trip fixture carries one (verdict=commented).
+  const stdoutMarkdown =
+    "## sage review\n\nblockers=0 majors=0 nits=0 — looks good\n\n```json\n" +
+    JSON.stringify(
+      {
+        verdict: "commented",
+        summary: "blockers=0 majors=0 nits=0 — looks good",
+        github_review_id: 0,
+        github_review_url: "",
+        submitted_at: "2026-07-02T00:00:00Z",
+        commit_id: "",
+        findings: { blockers: 0, majors: 0, nits: 0 },
+        inline_comments: 0,
+      },
+      null,
+      2,
+    ) +
+    "\n```";
 
   beforeAll(async () => {
     runtime = createBusRuntime();

--- a/src/runner/__tests__/sage-runner.test.ts
+++ b/src/runner/__tests__/sage-runner.test.ts
@@ -119,6 +119,51 @@ const whichSuccess: SageWhichFn = (cmd) =>
 const whichMissing: SageWhichFn = () => undefined;
 
 // ---------------------------------------------------------------------------
+// Verdict-block fixtures (cortex#888) — shared by the block-recovery tests and
+// the compass#99 F11/F12 tests. A well-formed block is the ONLY thing that
+// yields a `review.verdict.*` post-F11; block-less / malformed stdout returns
+// the prose-completion variant (no synthetic exit-code verdict).
+// ---------------------------------------------------------------------------
+
+function withBlock(body: string, block: Record<string, unknown>): string {
+  return `${body}\n\n\`\`\`json\n${JSON.stringify(block, null, 2)}\n\`\`\``;
+}
+
+const SAMPLE_BLOCK = {
+  verdict: "approved",
+  summary: "No findings. Sage approves.",
+  github_review_id: 999,
+  github_review_url: "https://github.com/o/r/pull/1#pullrequestreview-999",
+  submitted_at: "2026-06-10T09:11:36Z",
+  commit_id: "abc1234deadbeef",
+  findings: { blockers: 0, majors: 0, nits: 0 },
+  inline_comments: 0,
+};
+
+/**
+ * compass#99 F12 — a logical response-routing block (review-path shape). The
+ * runner echoes it verbatim onto BOTH terminal envelopes (verdict + failed),
+ * exactly as the CC path does (review-pipeline.ts).
+ */
+const FED_ROUTING = {
+  surface: "discord",
+  channel: "cortex",
+  thread: "cortex/pr/331",
+};
+
+/**
+ * Build ReviewPipelineOpts carrying a federated classification + response
+ * routing — the shape the FEDERATED review consumer hands the runner.
+ */
+function makeFederatedPipelineOpts(): ReviewPipelineOpts {
+  return {
+    ...makePipelineOpts(),
+    classification: "federated",
+    responseRouting: FED_ROUTING,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -134,7 +179,14 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
     const prior = process.env.SAGE_SUBSTRATE;
     delete process.env.SAGE_SUBSTRATE;
     try {
-      const stdout = "## review body\n\nverdict: commented";
+      // Post-compass#99 F11 the ONLY thing that yields a `review.verdict.*` is
+      // a well-formed `--emit-verdict-block` block (sage#83) — block-less
+      // stdout returns the prose-completion variant. The canonical happy path
+      // therefore carries a block; summary still echoes the FULL stdout.
+      const stdout = withBlock("## review body", {
+        ...SAMPLE_BLOCK,
+        verdict: "commented",
+      });
       const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
       const runner = makeSageReviewRunner({
         spawn: spawn.fn,
@@ -325,7 +377,9 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
         which: whichSuccess,
       });
       const result = await runner(makePipelineOpts());
-      expect(result.kind).toBe("verdict");
+      // This test pins the argv `--substrate` override; the block-less stdout
+      // yields a prose completion post-F11 (no synthetic verdict).
+      expect(result.kind).toBe("completed");
       expect(spawn.calls.length).toBe(1);
       expect(spawn.calls[0]!.slice(-3)).toEqual(["--substrate", "claude", "--emit-verdict-block"]);
     } finally {
@@ -357,7 +411,12 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
   // real failure. Before this fix any non-zero exit collapsed to
   // `dispatch.task.failed`, discarding the review markdown on stdout.
 
-  test("cortex#409 — sage exit 1 → changes-requested verdict (not failed), summary=stdout", async () => {
+  test("cortex#409 — sage exit 1 (block-less) → prose completion, NOT failed (exit 1 is a valid outcome)", async () => {
+    // cortex#409's invariant: exit 1 is a VALID review outcome (CI-gate
+    // convention), never an error — the review markdown on stdout is not
+    // discarded. Post-compass#99 F11 a block-less exit-1 run yields the
+    // prose-completion variant (presentation=stdout) rather than a synthetic
+    // `changes-requested` verdict. Still NOT `failed` — that's what #409 pins.
     const prior = process.env.SAGE_SUBSTRATE;
     delete process.env.SAGE_SUBSTRATE;
     try {
@@ -372,14 +431,10 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
       const opts = makePipelineOpts();
       const result = await runner(opts);
 
-      expect(result.kind).toBe("verdict");
-      if (result.kind !== "verdict") return;
-      const envelope: Envelope = result.envelope;
-      expect(envelope.type).toBe("review.verdict.changes-requested");
-      expect(envelope.correlation_id).toBe(opts.requestEnvelope.id);
-      const payload = envelope.payload as { verdict: string; summary: string };
-      expect(payload.verdict).toBe("changes-requested");
-      expect(payload.summary).toBe(stdout);
+      // Not failed (the #409 invariant), and not a synthetic verdict (F11).
+      expect(result.kind).toBe("completed");
+      if (result.kind !== "completed") return;
+      expect(result.presentation).toBe(stdout.trim());
     } finally {
       if (prior !== undefined) process.env.SAGE_SUBSTRATE = prior;
     }
@@ -493,27 +548,10 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
   // ---------------------------------------------------------------------
   // sage appends a fenced ```json verdict block under --emit-verdict-block
   // (sage#83). The runner parses it to recover the REAL decision (incl.
-  // `approved`, which the exit-code-only fallback cannot express) and the
-  // findings counts. A missing / malformed block falls back to exit-code
-  // mapping so a parse hiccup never drops an otherwise-valid review.
-
-  function withBlock(
-    body: string,
-    block: Record<string, unknown>,
-  ): string {
-    return `${body}\n\n\`\`\`json\n${JSON.stringify(block, null, 2)}\n\`\`\``;
-  }
-
-  const SAMPLE_BLOCK = {
-    verdict: "approved",
-    summary: "No findings. Sage approves.",
-    github_review_id: 999,
-    github_review_url: "https://github.com/o/r/pull/1#pullrequestreview-999",
-    submitted_at: "2026-06-10T09:11:36Z",
-    commit_id: "abc1234deadbeef",
-    findings: { blockers: 0, majors: 0, nits: 0 },
-    inline_comments: 0,
-  };
+  // `approved`, which the exit-code-only path cannot express) and the
+  // findings counts. A missing / malformed block now yields the
+  // prose-completion variant (compass#99 F11), NOT a synthetic verdict.
+  // (`withBlock` + `SAMPLE_BLOCK` fixtures live at the top of this file.)
 
   test("cortex#888 — exit 0 + block verdict=approved → review.verdict.approved (recovers approved)", async () => {
     const stdout = withBlock("## Sage code review — approved", SAMPLE_BLOCK);
@@ -580,29 +618,55 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
     expect(result.envelope.type).toBe("review.verdict.changes-requested");
   });
 
-  test("cortex#888 — malformed block falls back to exit-code mapping (exit 0 → commented)", async () => {
-    const stdout = "## Sage code review — commented\n\n```json\n{ not valid json\n```";
+  // compass#99 F11 — FAIL CLOSED on a missing/malformed verdict block
+  // ---------------------------------------------------------------------
+  // drift-8 / align cortex#503. The old exit-code fallback (exit 1 ⇒
+  // changes-requested, exit 0 ⇒ commented) could NEVER represent `approved`
+  // and manufactured a verdict no reviewer stood behind — a real merge-stall /
+  // false-signal risk. It is DROPPED: a missing OR malformed block now returns
+  // the `{ kind: "completed", presentation }` variant (the same third
+  // ReviewPipelineResult the CC path returns), NEVER a synthetic
+  // `review.verdict.*`. pilot's `--wait` keys on `review.verdict.*`, so no
+  // fabricated decision can reach it.
+
+  test("compass#99 F11 — MISSING verdict block (exit 0) → prose completion, NEVER a synthetic verdict", async () => {
+    const stdout = "## Sage code review — commented\n\n(no json block)";
     const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
     const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
     const result = await runner(makePipelineOpts());
 
-    expect(result.kind).toBe("verdict");
-    if (result.kind !== "verdict") return;
-    expect(result.envelope.type).toBe("review.verdict.commented");
-    // Fallback path → placeholder structured fields.
-    const payload = result.envelope.payload as { github_review_id: number };
-    expect(payload.github_review_id).toBe(0);
+    // Prose completion — NOT a verdict, NOT a failure.
+    expect(result.kind).toBe("completed");
+    if (result.kind !== "completed") return;
+    expect(result.presentation).toBe(stdout.trim());
+    // Structurally, a `completed` result carries NO envelope — so there is no
+    // `review.verdict.*` and no synthetic verdict on the wire at all.
+    expect("envelope" in result).toBe(false);
   });
 
-  test("cortex#888 — no block (older sage) falls back to exit-code mapping (exit 1 → changes-requested)", async () => {
+  test("compass#99 F11 — MISSING verdict block (exit 1) → prose completion (exit code no longer synthesises changes-requested)", async () => {
     const stdout = "## Sage code review — changes-requested\n\n(no json block)";
     const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 1));
     const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
     const result = await runner(makePipelineOpts());
 
-    expect(result.kind).toBe("verdict");
-    if (result.kind !== "verdict") return;
-    expect(result.envelope.type).toBe("review.verdict.changes-requested");
+    expect(result.kind).toBe("completed");
+    if (result.kind !== "completed") return;
+    expect(result.presentation).toBe(stdout.trim());
+  });
+
+  test("compass#99 F11 — MALFORMED verdict block (exit 0) → prose completion, NOT a synthetic verdict", async () => {
+    const stdout = "## Sage code review — commented\n\n```json\n{ not valid json\n```";
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
+    const result = await runner(makePipelineOpts());
+
+    // A malformed block means we cannot recover the real decision — we do NOT
+    // fabricate one from the exit code; we hand back the raw sage markdown.
+    expect(result.kind).toBe("completed");
+    if (result.kind !== "completed") return;
+    expect(result.presentation).toBe(stdout.trim());
+    expect("envelope" in result).toBe(false);
   });
 
   // compass#89 (§4 L3) — confidentiality flavor is a PRE-SPAWN cant_do
@@ -653,13 +717,92 @@ describe("cortex#331 Phase 1 — makeSageReviewRunner", () => {
         payload: { ...base.payload, flavor: "security" },
       };
       const result = await runner(opts);
-      expect(result.kind).toBe("verdict");
-      // The guard did NOT fire — sage spawned. And (deferred to #99) no
-      // `--lens` flag is threaded yet, so the argv is the unchanged shape.
+      // The guard did NOT fire — sage spawned (evidenced by the single spawn
+      // call + argv below). The block-less stdout yields a prose completion
+      // post-F11; the point of this test is that a non-confidentiality flavor
+      // is NOT refused, not the result shape.
+      expect(result.kind).toBe("completed");
+      // And (deferred to #99 F13) no `--lens` flag is threaded yet, so the
+      // argv is the unchanged shape.
       expect(spawn.calls.length).toBe(1);
       expect(spawn.calls[0]).not.toContain("--lens");
     } finally {
       if (prior !== undefined) process.env.SAGE_SUBSTRATE = prior;
     }
+  });
+
+  // compass#99 F12 — stamp classification + response_routing on terminals
+  // ---------------------------------------------------------------------
+  // wire-2. The sage terminal envelopes (verdict + failed) MUST be
+  // wire-IDENTICAL to the CC path (review-pipeline.ts:498/502 + :557/561): a
+  // FEDERATED review stamps `classification: "federated"` (so the emitted
+  // envelope's sovereignty matches the `federated.*` subject the consumer
+  // routes it on — federation-wire-protocol SOP check 5) and ECHOES the
+  // inbound `response_routing` so the review sink renders to the originating
+  // thread. Absent ⇒ `local` + no routing (unchanged local-consumer path).
+  // These assertions MIRROR the CC-path ones so the two engines can't re-drift.
+
+  test("compass#99 F12 — federated VERDICT carries classification=federated + echoed response_routing", async () => {
+    const stdout = withBlock("## Sage code review — approved", SAMPLE_BLOCK);
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
+
+    const result = await runner(makeFederatedPipelineOpts());
+
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    const envelope: Envelope = result.envelope;
+    // Sovereignty mirrors the inbound federated scope (SOP check 5).
+    expect(envelope.sovereignty.classification).toBe("federated");
+    // Response routing echoed verbatim onto the primary reply (the verdict).
+    const payload = envelope.payload as { response_routing?: unknown };
+    expect(payload.response_routing).toEqual(FED_ROUTING);
+  });
+
+  test("compass#99 F12 — LOCAL verdict defaults classification=local + omits response_routing", async () => {
+    // Parametric counterpart: the local review-consumer path passes neither
+    // field, so the verdict stays local and carries NO routing — identical to
+    // the pre-F12 behaviour, proving F12 is additive.
+    const stdout = withBlock("## Sage code review — approved", SAMPLE_BLOCK);
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
+
+    const result = await runner(makePipelineOpts());
+
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    const envelope: Envelope = result.envelope;
+    expect(envelope.sovereignty.classification).toBe("local");
+    expect("response_routing" in (envelope.payload as object)).toBe(false);
+  });
+
+  test("compass#99 F12 — federated FAILED terminal carries classification=federated + echoed response_routing", async () => {
+    // The other terminal the runner emits. A real error (exit ≥2) routes back
+    // to the federated requester, so its sovereignty + routing must match too.
+    const spawn = makeRecordingSpawn(makeSpawnResult("", "sage: boom", 2));
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
+
+    const result = await runner(makeFederatedPipelineOpts());
+
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") return;
+    const envelope: Envelope = result.envelope;
+    expect(envelope.type).toBe("dispatch.task.failed");
+    expect(envelope.sovereignty.classification).toBe("federated");
+    const payload = envelope.payload as { response_routing?: unknown };
+    expect(payload.response_routing).toEqual(FED_ROUTING);
+  });
+
+  test("compass#99 F12 — LOCAL failed terminal defaults classification=local + omits response_routing", async () => {
+    const spawn = makeRecordingSpawn(makeSpawnResult("", "sage: boom", 2));
+    const runner = makeSageReviewRunner({ spawn: spawn.fn, which: whichSuccess });
+
+    const result = await runner(makePipelineOpts());
+
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") return;
+    const envelope: Envelope = result.envelope;
+    expect(envelope.sovereignty.classification).toBe("local");
+    expect("response_routing" in (envelope.payload as object)).toBe(false);
   });
 });

--- a/src/runner/sage-runner.ts
+++ b/src/runner/sage-runner.ts
@@ -20,8 +20,10 @@
  *       env, else `pi`)
  *     → parses the structured verdict block from sage's stdout (cortex#888) →
  *       builds a `review.verdict.{approved|changes-requested|commented}` envelope
- *       (falls back to exit-code mapping when no block is present)
- *     → cortex publishes the verdict back to the bus → pilot's `--wait` catches it
+ *       from that block, or — when no well-formed block is present — returns a
+ *       prose `completed` result (compass#99 F11; NO synthetic exit-code verdict)
+ *     → cortex publishes the verdict (or a plain `dispatch.task.completed`) back
+ *       to the bus → pilot's `--wait` catches the verdict
  *
  * **What this module is.** A `ReviewPipelineRunner` factory with the same
  * signature `runReviewPipeline` exposes (`src/runner/review-pipeline.ts`), so it
@@ -50,12 +52,17 @@
  *
  * **Failure shape.** Mirrors `runReviewPipeline`'s contract:
  *
- *   | Outcome                          | result.kind | reason.kind |
- *   |----------------------------------|-------------|-------------|
- *   | sage exit 0                      | `verdict`   | (none)      |
- *   | sage exit != 0                   | `failed`    | `cant_do`   |
- *   | sage binary not found            | `failed`    | `cant_do`   |
- *   | spawn throw (env / sandbox bug)  | `failed`    | `cant_do`   |
+ *   | Outcome                              | result.kind | reason.kind |
+ *   |--------------------------------------|-------------|-------------|
+ *   | sage exit 0/1 + well-formed block    | `verdict`   | (none)      |
+ *   | sage exit 0/1 + missing/bad block    | `completed` | (none)      |
+ *   | sage exit >=2 (or killed)            | `failed`    | `cant_do`   |
+ *   | sage binary not found                | `failed`    | `cant_do`   |
+ *   | spawn throw (env / sandbox bug)      | `failed`    | `cant_do`   |
+ *
+ * The `completed` row is the compass#99 F11 fail-closed path: a missing or
+ * malformed `--emit-verdict-block` yields the raw sage markdown as a prose
+ * completion, NEVER a synthetic exit-code verdict.
  *
  * Phase 1 maps every non-happy outcome to `cant_do` because we don't yet
  * distinguish substrate-transient (`not_now`) from skill-permanent
@@ -254,11 +261,12 @@ export function makeSageReviewRunner(
     const substrate = opts.model ?? process.env.SAGE_SUBSTRATE ?? "pi";
     // cortex#888 — ask sage to append the structured verdict block as the
     // terminal stdout artefact (sage#83 `--emit-verdict-block`). We parse it
-    // below to recover the REAL decision (`approved` is invisible to the
-    // exit-code-only fallback) + findings counts. Older sage builds that
+    // below to recover the REAL decision (`approved` is invisible to an
+    // exit-code-only read) + findings counts. Older sage builds that
     // don't know the flag would error on it — but the flag shipped in
     // lockstep (sage#83) and the bundled sage is pinned, so this is safe;
-    // if the block is absent for any reason we fall back to exit-code mapping.
+    // if the block is absent/malformed we return a prose completion
+    // (compass#99 F11 — no synthetic verdict), never an exit-code decision.
     const argv = [sageBin, "review", prRef, "--substrate", substrate, "--emit-verdict-block"];
     // Propagate the dispatch's `--post` intent. `sage dispatch --post`
     // stamps `payload.post: true` (sage#8) and the review-consumer carries
@@ -328,28 +336,40 @@ export function makeSageReviewRunner(
 
     // cortex#888 (Phase 2) — recover the real verdict from sage's structured
     // block. sage emits it as the terminal ```json fence under
-    // `--emit-verdict-block` (sage#83). The block carries the true decision
-    // (incl. `approved`, invisible to the exit code) + findings counts +
-    // commit_id. A present, well-formed block wins; anything else
-    // (older sage, malformed JSON, missing block) falls back to the
-    // exit-code mapping below so a parse hiccup never drops a valid review.
+    // `--emit-verdict-block` (sage#83). A present, well-formed block carries
+    // the true decision (incl. `approved`, invisible to the exit code) +
+    // findings counts + commit_id, and is the ONLY thing that yields a
+    // `review.verdict.*`.
     const rawBlock = extractVerdictBlock(stdout);
     if (rawBlock !== null) {
       const parsed = parseVerdictBlock(rawBlock);
       if (parsed.ok) {
         return verdict(pipeline, correlationId, stdout, parsed.value.verdict, parsed.value);
       }
-      // Block present but malformed — log + fall through to exit-code mapping.
+      // Block present but malformed — log and fall through to the
+      // prose-completion path below. We deliberately do NOT synthesise a
+      // verdict from the exit code (compass#99 F11): a malformed block means we
+      // cannot recover the real decision, so fabricating one would risk a wrong
+      // merge signal.
       console.error(
-        `[sage] verdict block malformed (${parsed.detail}); falling back to exit-code mapping`,
+        `[sage] verdict block malformed (${parsed.detail}); ` +
+          `returning prose completion (no synthetic verdict)`,
       );
     }
 
-    // Fallback: exit 1 ⇒ changes-requested; exit 0 ⇒ commented (sage can't
-    // distinguish approved from commented via exit code alone).
-    const decision: ReviewVerdictKind =
-      exitCode === 1 ? "changes-requested" : "commented";
-    return verdict(pipeline, correlationId, stdout, decision);
+    // compass#99 F11 (drift-8; align cortex#503) — FAIL CLOSED on a
+    // missing/malformed verdict block: return the prose-completion variant, NOT
+    // a synthetic `review.verdict.*` derived from the exit code. The dropped
+    // fallback (exit 1 ⇒ changes-requested, exit 0 ⇒ commented) could NEVER
+    // represent `approved` and manufactured a decision no reviewer stood behind
+    // — a real merge-stall / false-signal risk. `--emit-verdict-block` shipped
+    // in lockstep (sage#83) and the sage binary is pinned, so a well-formed
+    // block is the norm; when it is absent we hand the raw sage markdown back
+    // as `presentation` — the SAME third `ReviewPipelineResult` the CC path
+    // returns (review-pipeline.ts) — and the consumer publishes a plain
+    // `dispatch.task.completed`, never a verdict. pilot's `--wait` keys on
+    // `review.verdict.*`, so no fabricated decision can reach it.
+    return { kind: "completed", presentation: stdout.trim() };
   };
 }
 
@@ -383,6 +403,11 @@ function defaultWhich(cmd: string): string | undefined {
  * for any non-happy substrate outcome. Phase 1 collapses every failure
  * to `cant_do` (see module docblock). Phase 2 splits substrate-transient
  * from skill-permanent.
+ *
+ * compass#99 F12 — `pipeline.classification` + `pipeline.responseRouting` are
+ * threaded onto the failed terminal too, so a federated review's error routes
+ * back to the requester with federated sovereignty + echoed routing,
+ * wire-identically to the CC path (review-pipeline.ts).
  */
 function failed(
   pipeline: ReviewPipelineOpts,
@@ -400,6 +425,17 @@ function failed(
     failedAt: new Date(),
     errorSummary,
     reason: { kind: "cant_do", detail: errorSummary },
+    // compass#99 F12 (wire-2) — a federated review's failed terminal routes
+    // back to the federated requester, so it must declare federated sovereignty
+    // + echo the response routing, wire-identically to the CC path
+    // (review-pipeline.ts). Default undefined ⇒ `local` + no routing (unchanged
+    // local-consumer behaviour).
+    ...(pipeline.classification !== undefined && {
+      classification: pipeline.classification,
+    }),
+    ...(pipeline.responseRouting !== undefined && {
+      responseRouting: pipeline.responseRouting,
+    }),
   });
   return { kind: "failed", envelope };
 }
@@ -408,13 +444,18 @@ function failed(
  * Build a `review.verdict.{decision}` envelope carrying sage's markdown
  * stdout as `payload.summary`.
  *
- * When `block` is supplied (cortex#888 — sage emitted a well-formed
- * `--emit-verdict-block` artefact), the structured fields (findings counts,
- * github review id/url, commit_id, submitted_at, inline_comments) come from
- * it. Without a block (fallback path: older sage, malformed JSON), those
- * fields surface as zeros / empty strings — pilot still sees a well-formed
- * envelope and principals can grep the markdown summary for the values.
- * `reviewer` stays `sage` (the substrate doing the review).
+ * The `block` argument (cortex#888 — sage's well-formed `--emit-verdict-block`
+ * artefact) supplies the structured fields (findings counts, github review
+ * id/url, commit_id, submitted_at, inline_comments). Post-compass#99 F11 the
+ * runner only reaches this helper WITH a well-formed block (a missing/malformed
+ * block returns a prose `completed` result upstream, not a verdict), so the
+ * `block?`-absent defaults below are defensive-only; when they do apply the
+ * fields surface as zeros / empty strings. `reviewer` stays `sage` (the
+ * substrate doing the review).
+ *
+ * compass#99 F12 — `pipeline.classification` + `pipeline.responseRouting` are
+ * threaded onto the verdict envelope so a federated review's terminal is
+ * wire-identical to the CC path (review-pipeline.ts).
  */
 function verdict(
   pipeline: ReviewPipelineOpts,
@@ -429,6 +470,20 @@ function verdict(
     source,
     kind: decision,
     correlationId,
+    // compass#99 F12 (wire-2) — federated sage verdicts declare federated
+    // sovereignty so the emitted envelope matches the `federated.*` subject the
+    // consumer routes it on (federation-wire-protocol SOP check 5: terminals
+    // mirror the inbound scope). Wire-identical to the CC path
+    // (review-pipeline.ts). Default undefined ⇒ `local` (unchanged).
+    ...(pipeline.classification !== undefined && {
+      classification: pipeline.classification,
+    }),
+    // compass#99 F12 — echo the inbound response routing onto the verdict (the
+    // primary reply) so the review sink renders it to the originating thread,
+    // exactly as the CC path does.
+    ...(pipeline.responseRouting !== undefined && {
+      responseRouting: pipeline.responseRouting,
+    }),
     payload: {
       repo: payload.repo,
       pr: payload.pr,


### PR DESCRIPTION
branched from origin/main (local was stale); rebased onto current origin/main (picked up C-832 + C-1316 which landed mid-flight — disjoint files, no conflicts).

**compass#99** — sage-runner terminal-envelope parity with the CC review path. This is **federation-wire code**; per `compass/sops/federation-wire-protocol.md`:

> `SOP: federation-wire-protocol | touches: emit | checklist: 5/5 PASS`

F12 is precisely a **check-5** conformance fix (*lifecycle/verdict envelopes mirror the inbound scope*) — today sage stamps `local` even on a federated review.

## F11 — fail-closed on a missing/malformed verdict block (drift-8; align cortex#503)

`makeSageReviewRunner` previously fell back to an **exit-code → synthetic verdict** when the `--emit-verdict-block` block was missing/malformed (exit 1 ⇒ `changes-requested`, exit 0 ⇒ `commented`). `approved` was **unrepresentable**, and the fabricated decision could reach pilot's `--wait` — a real **merge-stall / false-signal** risk.

That fallback is **dropped**. A missing **or** malformed block now returns the `{ kind: "completed", presentation: <stdout> }` variant — the **same third `ReviewPipelineResult`** the CC path returns (`review-pipeline.ts`). The consumer already handles `completed` (`review-consumer.ts`) → publishes a plain `dispatch.task.completed`, **never** a synthetic `review.verdict.*`. pilot's `--wait` keys on `review.verdict.*`, so no fabricated decision can reach it.

No escape hatch / `derived: "exit-code"` (default-OFF was the guidance): `--emit-verdict-block` shipped in lockstep (sage#83) and the sage binary is pinned, so the fallback was effectively dead code.

## F12 — stamp `classification` + `response_routing` on terminal envelopes (wire-2)

`verdict()` and `failed()` previously **ignored** `pipeline.classification` + `pipeline.responseRouting` (both already on `ReviewPipelineOpts`). They now spread both into `createReviewVerdictEvent` / `createReviewTaskFailedEvent` **exactly as the CC path does** (`review-pipeline.ts`). Result: a federated sage terminal declares **federated sovereignty** (SOP check 5) and echoes `response_routing`, so sage terminals become **wire-identical** to CC ones.

**Wire-consistency insurance:** latent until the first `engine: sage` federated deploy, but it keeps the two review engines from re-drifting on the federated path.

## Tests

- **F11**: a run with a **missing** block (exit 0 and exit 1) and a **malformed** block ⇒ `completed`/prose, **never** a `review.verdict.*` (asserts no `envelope` on the result — i.e. no synthetic verdict on the wire).
- **F12**: parametric — federated verdict carries `classification: "federated"` + the echoed `response_routing`; local default carries `classification: "local"` + **no** routing — asserted for **both** the verdict **and** the failed terminal, mirroring the CC-path assertions so the two engines can't re-drift.
- Updated the pre-existing tests that encoded the old exit-code synthesis (happy path + argv tests now carry a real block; the cortex#409 exit-1 test asserts `completed`-not-`failed`), **including** the e2e round-trip fixture in `cortex.review-consumer.e2e.test.ts` (now carries a real verdict block).

## Verify

- `bunx tsc --noEmit` → clean
- `bun test src/runner/__tests__/sage-runner.test.ts src/bus/__tests__/review-consumer.test.ts` (+ the touched `cortex.review-consumer.e2e.test.ts`) → **118 pass / 0 fail**
- `bunx eslint --quiet` on all changed files → clean

Do **not** merge — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)