### PR TITLE
refactor(registry): C-1416/#1418 — single shared canonicalJSON module + pre-auth width/size caps

### DIFF
--- a/src/common/registry/__tests__/canonical-json.test.ts
+++ b/src/common/registry/__tests__/canonical-json.test.ts
@@ -1,0 +1,189 @@
+/**
+ * C-1416 / #1418 — the single shared canonicalJSON module.
+ *
+ * Locks three things:
+ *   1. ROUND-TRIP IDENTITY — the shared canonicaliser emits the EXACT bytes the
+ *      two hand-maintained mirrors emitted (asserted against known-good literals
+ *      + against a JSON.parse(JSON.stringify(...)) round-trip). This is the
+ *      regression guard: any future change to the byte output trips these.
+ *   2. NO-DRIFT — the registry-side `signing.ts` and the common-side `signing.ts`
+ *      now re-export the SAME function reference from `./canonical-json`, so they
+ *      are literally identical (===) and cannot diverge (#1416).
+ *   3. THE PRE-AUTH GUARDS — depth (#832) + width/size (#1418) caps throw, and
+ *      never fire for legit-sized input (so byte output is unchanged).
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  canonicalJSON,
+  CanonicalDepthError,
+  CanonicalWidthError,
+  MAX_CANONICAL_DEPTH,
+  MAX_CANONICAL_KEYS,
+  MAX_CANONICAL_ARRAY_LEN,
+  MAX_CANONICAL_NODES,
+} from "../canonical-json";
+import * as commonSigning from "../signing";
+import * as registrySigning from "../../../services/network-registry/src/signing";
+
+// =============================================================================
+// 1. Round-trip identity — known-good bytes (unchanged by the refactor)
+// =============================================================================
+
+describe("canonicalJSON — byte-exact output (round-trip identity)", () => {
+  test("primitives match JSON.stringify", () => {
+    expect(canonicalJSON(null)).toBe("null");
+    expect(canonicalJSON(42)).toBe("42");
+    expect(canonicalJSON(true)).toBe("true");
+    expect(canonicalJSON("x")).toBe('"x"');
+  });
+
+  test("object keys sorted lexicographically, no whitespace", () => {
+    expect(canonicalJSON({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  test("undefined-valued keys skipped (JSON.stringify parity)", () => {
+    expect(canonicalJSON({ a: 1, c: undefined, b: 2 })).toBe('{"a":1,"b":2}');
+  });
+
+  test("arrays preserve order", () => {
+    expect(canonicalJSON([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  test("nested structure: recursive sort, arrays in order", () => {
+    expect(canonicalJSON({ z: { y: 2, x: 1 }, a: [{ k: "v" }, 1] })).toBe(
+      '{"a":[{"k":"v"},1],"z":{"x":1,"y":2}}',
+    );
+  });
+
+  test("a realistic registration-claim shape → stable bytes", () => {
+    const claim = {
+      principal_id: "andreas",
+      principal_pubkey: "PUBKEY==",
+      stacks: [{ stack_id: "andreas/work" }, { stack_id: "andreas/research" }],
+      capabilities: [{ id: "code-review.typescript" }],
+      issued_at: "2026-07-03T00:00:00.000Z",
+      nonce: "abc123",
+    };
+    // Keys sorted: capabilities, issued_at, nonce, principal_id, principal_pubkey, stacks.
+    expect(canonicalJSON(claim)).toBe(
+      '{"capabilities":[{"id":"code-review.typescript"}],' +
+        '"issued_at":"2026-07-03T00:00:00.000Z","nonce":"abc123",' +
+        '"principal_id":"andreas","principal_pubkey":"PUBKEY==",' +
+        '"stacks":[{"stack_id":"andreas/work"},{"stack_id":"andreas/research"}]}',
+    );
+  });
+
+  test("output is invariant under JSON parse/stringify round-trip", () => {
+    const battery: unknown[] = [
+      { b: 1, a: 2, nested: { d: 4, c: 3 } },
+      [1, { y: 2, x: 1 }, "s"],
+      { list: [3, 2, 1], flag: true, name: "n" },
+      "plain string",
+      { unicode: "ünïcødé", "quote\"key": 1 },
+    ];
+    for (const v of battery) {
+      const roundTripped: unknown = JSON.parse(JSON.stringify(v));
+      expect(canonicalJSON(roundTripped)).toBe(canonicalJSON(v));
+    }
+  });
+});
+
+// =============================================================================
+// 2. No-drift — both signing.ts re-export the SAME function
+// =============================================================================
+
+describe("canonicalJSON — the two mirrors can no longer drift (#1416)", () => {
+  test("registry-side and common-side re-exports are the SAME reference", () => {
+    expect(registrySigning.canonicalJSON).toBe(commonSigning.canonicalJSON);
+    expect(registrySigning.canonicalJSON).toBe(canonicalJSON);
+    expect(registrySigning.MAX_CANONICAL_DEPTH).toBe(commonSigning.MAX_CANONICAL_DEPTH);
+    expect(registrySigning.CanonicalDepthError).toBe(commonSigning.CanonicalDepthError);
+  });
+
+  test("both produce identical bytes across a battery (belt-and-suspenders)", () => {
+    const battery: unknown[] = [
+      { b: 1, a: 2 },
+      [{ k: "v" }, 1, "x"],
+      { stacks: [{ stack_id: "p/s" }], nonce: "n", issued_at: "t" },
+    ];
+    for (const v of battery) {
+      expect(registrySigning.canonicalJSON(v)).toBe(commonSigning.canonicalJSON(v));
+    }
+  });
+});
+
+// =============================================================================
+// 3. Depth cap (#832)
+// =============================================================================
+
+/** Build an object nested `k` levels deep around a primitive. */
+function nest(k: number): unknown {
+  let inner: unknown = 0;
+  for (let i = 0; i < k; i++) inner = { n: inner };
+  return inner;
+}
+
+describe("canonicalJSON — depth cap (#832)", () => {
+  test(`at the limit (${MAX_CANONICAL_DEPTH.toString()}) → OK`, () => {
+    expect(() => canonicalJSON(nest(MAX_CANONICAL_DEPTH))).not.toThrow();
+  });
+
+  test(`over the limit (${(MAX_CANONICAL_DEPTH + 1).toString()}) → CanonicalDepthError`, () => {
+    expect(() => canonicalJSON(nest(MAX_CANONICAL_DEPTH + 1))).toThrow(CanonicalDepthError);
+  });
+});
+
+// =============================================================================
+// 4. Width / size caps (#1418) — the pre-auth DoS guards
+// =============================================================================
+
+describe("canonicalJSON — width/size caps (#1418)", () => {
+  test(`object with ${MAX_CANONICAL_KEYS.toString()} keys → OK; +1 → CanonicalWidthError`, () => {
+    const atLimit = Object.fromEntries(
+      Array.from({ length: MAX_CANONICAL_KEYS }, (_, i) => [`k${i.toString()}`, i]),
+    );
+    expect(() => canonicalJSON(atLimit)).not.toThrow();
+
+    const overLimit = Object.fromEntries(
+      Array.from({ length: MAX_CANONICAL_KEYS + 1 }, (_, i) => [`k${i.toString()}`, i]),
+    );
+    expect(() => canonicalJSON(overLimit)).toThrow(CanonicalWidthError);
+  });
+
+  test(`array of length ${MAX_CANONICAL_ARRAY_LEN.toString()} → OK; +1 → CanonicalWidthError`, () => {
+    const atLimit = Array.from({ length: MAX_CANONICAL_ARRAY_LEN }, (_, i) => i);
+    expect(() => canonicalJSON(atLimit)).not.toThrow();
+
+    const overLimit = Array.from({ length: MAX_CANONICAL_ARRAY_LEN + 1 }, (_, i) => i);
+    expect(() => canonicalJSON(overLimit)).toThrow(CanonicalWidthError);
+  });
+
+  test("distributed structure over the TOTAL node budget → CanonicalWidthError", () => {
+    // Each container stays UNDER its per-node cap, but the aggregate blows the
+    // MAX_CANONICAL_NODES budget — the vector the per-node caps alone miss.
+    const outerLen = 4000; // < MAX_CANONICAL_ARRAY_LEN
+    const innerLen = 60; // < MAX_CANONICAL_ARRAY_LEN
+    // outerLen + outerLen*innerLen = 4000 + 240000 = 244000 > MAX_CANONICAL_NODES.
+    expect(outerLen + outerLen * innerLen).toBeGreaterThan(MAX_CANONICAL_NODES);
+    const wide = Array.from({ length: outerLen }, () =>
+      Array.from({ length: innerLen }, (_, i) => i),
+    );
+    expect(() => canonicalJSON(wide)).toThrow(CanonicalWidthError);
+  });
+
+  test("legit-sized claim (well under every cap) never throws + round-trips", () => {
+    const claim = {
+      principal_id: "andreas",
+      principal_pubkey: "PUBKEY==",
+      stacks: Array.from({ length: 20 }, (_, i) => ({ stack_id: `andreas/s${i.toString()}` })),
+      capabilities: Array.from({ length: 20 }, (_, i) => ({ id: `cap.${i.toString()}` })),
+      metadata: { a: 1, b: 2, c: 3 },
+      issued_at: "2026-07-03T00:00:00.000Z",
+      nonce: "abc123",
+    };
+    expect(() => canonicalJSON(claim)).not.toThrow();
+    const roundTripped: unknown = JSON.parse(JSON.stringify(claim));
+    expect(canonicalJSON(roundTripped)).toBe(canonicalJSON(claim));
+  });
+});

--- a/src/common/registry/canonical-json.ts
+++ b/src/common/registry/canonical-json.ts
@@ -1,0 +1,162 @@
+/**
+ * Canonical JSON — the SINGLE shared source of truth (#1416).
+ *
+ * Both the network-registry Worker (`src/services/network-registry/src/signing.ts`)
+ * and the cortex-side client (`src/common/registry/signing.ts`) MUST agree
+ * byte-for-byte on what was signed. This was previously two hand-maintained
+ * mirrors kept identical by discipline + round-trip tests; any drift (a rule
+ * added to one, not the other) silently re-opened a signature-bytes mismatch —
+ * a self-inflicted 401 on one path. This module is that one canonicaliser; both
+ * `signing.ts` files import + re-export from here, so they cannot diverge.
+ *
+ * BUILD BOUNDARY (why this file is deliberately minimal). The registry is a
+ * separate deployable package (own package.json / tsconfig / wrangler.toml) that
+ * bundles for Cloudflare Workers; the client builds for bun/node. This module is
+ * therefore PURE TypeScript with ZERO imports and uses ONLY universal built-ins
+ * (`JSON.stringify`, `Object.keys`, `Array.isArray`) — no `atob`/`crypto`/node
+ * or worker-only APIs. That is precisely why only `canonicalJSON` (+ its guards)
+ * lives here and the base64/Ed25519 primitives — which need `atob`/`crypto.subtle`
+ * and differ by target — stay in each side's `signing.ts`. A pure leaf module
+ * bundles cleanly into the Worker (one extra file, no transitive deps) and
+ * tsc-checks under both tsconfigs.
+ *
+ * Scheme: recursive sort-keys canonicalisation (RFC 8785 / JCS for the primitive
+ * cases the registry actually signs — strings + small integer timestamps). Object
+ * keys emitted in lexicographic order, arrays preserve order, no whitespace,
+ * `undefined`-valued object keys skipped (to match `JSON.stringify` after a
+ * parse/stringify round-trip).
+ */
+
+// =============================================================================
+// Limits — the pre-auth DoS guards (#832 depth, #1418 width/size)
+// =============================================================================
+
+/**
+ * Hard cap on nesting depth (#832). The register route canonicalizes the claim
+ * AS RECEIVED — unauthenticated, attacker-controlled: verify runs BEFORE the
+ * signature is proven — so this recursion can be driven by hostile input. A
+ * legitimate claim nests ~3 levels (claim → stacks[] → metadata map); 64 is far
+ * beyond any real claim yet shallow enough a deeply-nested body cannot exhaust
+ * the stack.
+ */
+export const MAX_CANONICAL_DEPTH = 64;
+
+/**
+ * Max keys in a SINGLE object (#1418). The headline pre-auth amplification is a
+ * body with ~1e6 flat top-level keys: canonicalJSON would `Object.keys(...).sort()`
+ * all of them BEFORE the signature is checked. We bound the per-object key count
+ * and throw BEFORE the sort. A real claim object carries ~dozens of keys; 4096 is
+ * ~40× the largest plausible signing input, so it never fires for legit traffic.
+ */
+export const MAX_CANONICAL_KEYS = 4096;
+
+/**
+ * Max elements in a SINGLE array (#1418). Bounds a hostile `stacks[]` /
+ * `capabilities[]` (or any array) the same way as object width. Real arrays hold
+ * a handful of entries; 4096 is generous headroom.
+ */
+export const MAX_CANONICAL_ARRAY_LEN = 4096;
+
+/**
+ * Aggregate ceiling on TOTAL container entries visited across the whole structure
+ * (#1418). The per-object / per-array caps stop the single-wide-node attack; this
+ * bounds a DISTRIBUTED one (e.g. 4000 objects × 4000 keys) that stays under each
+ * per-node cap but sums to millions. A legit claim visits a few dozen entries;
+ * 200k is an enormous safety margin yet a hard bound on total pre-auth work.
+ */
+export const MAX_CANONICAL_NODES = 200_000;
+
+/** Thrown by {@link canonicalJSON} when nesting exceeds {@link MAX_CANONICAL_DEPTH}. */
+export class CanonicalDepthError extends Error {
+  constructor() {
+    super(`canonical JSON nesting exceeded ${MAX_CANONICAL_DEPTH} levels`);
+    this.name = "CanonicalDepthError";
+  }
+}
+
+/**
+ * Thrown by {@link canonicalJSON} when a single object's key count, a single
+ * array's length, or the total container-entry budget is exceeded (#1418). The
+ * register verify path catches every canonicalJSON throw and fails closed
+ * (`signature_invalid`, 401) — an over-wide body can never match a legitimate
+ * signature, so it is shed exactly like an over-deep one, never a 500.
+ */
+export class CanonicalWidthError extends Error {
+  constructor(detail: string) {
+    super(`canonical JSON width/size limit exceeded: ${detail}`);
+    this.name = "CanonicalWidthError";
+  }
+}
+
+// =============================================================================
+// canonicalJSON
+// =============================================================================
+
+/**
+ * Deterministic JSON: object keys sorted recursively, no whitespace, arrays in
+ * order, `undefined`-valued keys skipped. Throws on cycles (JSON.stringify
+ * behaviour), on nesting past {@link MAX_CANONICAL_DEPTH}, and on width/size past
+ * the {@link MAX_CANONICAL_KEYS} / {@link MAX_CANONICAL_ARRAY_LEN} /
+ * {@link MAX_CANONICAL_NODES} caps.
+ *
+ * The width/size guards NEVER change the emitted bytes for any input that stays
+ * under the caps — they only throw — so every legitimate claim canonicalizes to
+ * the exact same string the pre-#1418 canonicaliser produced (round-trip
+ * identity is preserved; the drift/round-trip tests lock this).
+ */
+export function canonicalJSON(value: unknown): string {
+  return canonicalize(value, 0, { nodes: 0 });
+}
+
+/** Mutable, per-top-level-call budget threaded through the recursion. */
+interface CanonicalBudget {
+  /** Running total of container entries (object keys + array elements) visited. */
+  nodes: number;
+}
+
+function canonicalize(value: unknown, depth: number, budget: CanonicalBudget): string {
+  if (depth > MAX_CANONICAL_DEPTH) {
+    throw new CanonicalDepthError();
+  }
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    // Fail fast: bound this array's length BEFORE mapping over it.
+    if (value.length > MAX_CANONICAL_ARRAY_LEN) {
+      throw new CanonicalWidthError(
+        `array length ${value.length} exceeds ${MAX_CANONICAL_ARRAY_LEN}`,
+      );
+    }
+    budget.nodes += value.length;
+    if (budget.nodes > MAX_CANONICAL_NODES) {
+      throw new CanonicalWidthError(
+        `total node budget exceeded ${MAX_CANONICAL_NODES}`,
+      );
+    }
+    return "[" + value.map((v) => canonicalize(v, depth + 1, budget)).join(",") + "]";
+  }
+
+  const obj = value as Record<string, unknown>;
+  // Fail fast: bound the RAW key count BEFORE the O(n log n) sort — the sort is
+  // the exact pre-auth amplification #1418 calls out.
+  const rawKeys = Object.keys(obj);
+  if (rawKeys.length > MAX_CANONICAL_KEYS) {
+    throw new CanonicalWidthError(
+      `object key count ${rawKeys.length} exceeds ${MAX_CANONICAL_KEYS}`,
+    );
+  }
+  budget.nodes += rawKeys.length;
+  if (budget.nodes > MAX_CANONICAL_NODES) {
+    throw new CanonicalWidthError(
+      `total node budget exceeded ${MAX_CANONICAL_NODES}`,
+    );
+  }
+  // Mirror JSON.stringify: skip `undefined`-valued keys so a claim built by
+  // spread-with-optionals (`{ ...base, metadata: undefined }`) canonicalizes the
+  // same as after a JSON.parse(JSON.stringify(...)) round-trip.
+  const keys = rawKeys.filter((k) => obj[k] !== undefined).sort();
+  const parts = keys.map((k) => JSON.stringify(k) + ":" + canonicalize(obj[k], depth + 1, budget));
+  return "{" + parts.join(",") + "}";
+}

--- a/src/common/registry/signing.ts
+++ b/src/common/registry/signing.ts
@@ -20,53 +20,23 @@
  */
 
 // =============================================================================
-// Canonical JSON — recursive sort-keys, no whitespace.
+// Canonical JSON — the ONE shared source (#1416). Previously a hand-maintained
+// mirror of the registry's copy; both now import + re-export the single pure-TS
+// canonicaliser at `./canonical-json` so they cannot drift (a drift silently
+// re-opened a signature-bytes mismatch → self-inflicted 401 on one path). Depth
+// (#832) + width/size (#1418) caps live there. Re-exported here so every
+// existing importer of this module keeps working unchanged.
 // =============================================================================
 
-/**
- * Hard cap on nesting depth. Mirrors the registry's guard (#832) so the two
- * canonicalisers stay byte-compatible: a legitimate claim nests ~3 levels, so
- * 64 never triggers for any real signing input — it exists only so the two
- * implementations remain literally identical (the registry now canonicalizes
- * attacker-controlled input and needs the DoS guard; carrying it here too keeps
- * the RFC-8785 cross-checker pair from silently diverging).
- */
-export const MAX_CANONICAL_DEPTH = 64;
-
-/** Thrown by {@link canonicalJSON} when nesting exceeds {@link MAX_CANONICAL_DEPTH}. */
-export class CanonicalDepthError extends Error {
-  constructor() {
-    super(`canonical JSON nesting exceeded ${MAX_CANONICAL_DEPTH} levels`);
-    this.name = "CanonicalDepthError";
-  }
-}
-
-/**
- * Mirror of the registry's `canonicalJSON`. Object keys sorted
- * lexicographically + recursively; `undefined` values skipped (to
- * match `JSON.stringify` behaviour after a parse/stringify round-trip);
- * no whitespace. Throws {@link CanonicalDepthError} beyond
- * {@link MAX_CANONICAL_DEPTH} (matches the registry's #832 DoS guard).
- */
-export function canonicalJSON(value: unknown, depth = 0): string {
-  if (depth > MAX_CANONICAL_DEPTH) {
-    throw new CanonicalDepthError();
-  }
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return "[" + value.map((v) => canonicalJSON(v, depth + 1)).join(",") + "]";
-  }
-  const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj)
-    .filter((k) => obj[k] !== undefined)
-    .sort();
-  const parts = keys.map(
-    (k) => JSON.stringify(k) + ":" + canonicalJSON(obj[k], depth + 1),
-  );
-  return "{" + parts.join(",") + "}";
-}
+export {
+  MAX_CANONICAL_DEPTH,
+  MAX_CANONICAL_KEYS,
+  MAX_CANONICAL_ARRAY_LEN,
+  MAX_CANONICAL_NODES,
+  CanonicalDepthError,
+  CanonicalWidthError,
+  canonicalJSON,
+} from "./canonical-json";
 
 // =============================================================================
 // Base64 helpers — standard alphabet (NOT url-safe).

--- a/src/services/network-registry/__tests__/register-canonical-width.test.ts
+++ b/src/services/network-registry/__tests__/register-canonical-width.test.ts
@@ -1,0 +1,97 @@
+/**
+ * #1418 — pre-auth canonicalJSON WIDTH/SIZE guard on the register route.
+ *
+ * The register route canonicalizes the claim AS RECEIVED (unauthenticated:
+ * `canonicalJSON(signed.claim)` runs BEFORE the signature is proven). #832 added
+ * a DEPTH cap; #1418 adds a WIDTH/size cap so a body with ~1e6 flat keys (or a
+ * huge array) can't drive the pre-auth `Object.keys(...).sort()`.
+ *
+ * `validateRegistrationClaim` reads only whitelisted fields and IGNORES unknown
+ * keys (#832: unknown/forward fields are signed-but-ignored, never persisted), so
+ * an over-wide claim passes structural validation and reaches canonicalJSON —
+ * where the width guard throws `CanonicalWidthError`, caught by the route and
+ * failed closed as `signature_invalid` (401). The contract we assert: an
+ * over-wide register is shed with 400/401, NEVER a 500.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import { MAX_CANONICAL_KEYS, MAX_CANONICAL_ARRAY_LEN } from "../src/signing";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+
+let env: Env;
+let pKey: PrincipalKey;
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    ENVIRONMENT: "test",
+  } as Env;
+  pKey = await makePrincipalKey();
+});
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+describe("#1418 — register with an over-wide claim fails closed (never 500)", () => {
+  test("claim with >MAX_CANONICAL_KEYS junk keys → 401, not 500", async () => {
+    // Build a structurally valid, validly-signed claim, then bloat the RECEIVED
+    // claim with junk keys past the per-object cap. (Validation ignores the extra
+    // keys; canonicalJSON(signed.claim) then trips the width guard pre-verify.)
+    const { claim, signature } = await makeSignedRegistration("jc", pKey, {
+      stacks: [{ stack_id: "jc/default", stack_pubkey: pKey.publicKeyB64 }],
+    });
+    const bloated: Record<string, unknown> = { ...claim };
+    for (let i = 0; i <= MAX_CANONICAL_KEYS; i++) bloated[`junk${i.toString()}`] = i;
+
+    const res = await post("/principals/jc/register", { claim: bloated, signature });
+
+    // Fail-closed: 401 (canonicalJSON threw → signature_invalid). NEVER 500.
+    expect(res.status).not.toBe(500);
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error?: string };
+    expect(json.error).toBe("signature_invalid");
+  });
+
+  test("claim carrying an over-long array → 401, not 500", async () => {
+    const { claim, signature } = await makeSignedRegistration("jc", pKey, {
+      stacks: [{ stack_id: "jc/default", stack_pubkey: pKey.publicKeyB64 }],
+    });
+    // Attach a huge array field on the received claim (ignored by validation).
+    const bloated: Record<string, unknown> = {
+      ...claim,
+      junk_array: Array.from({ length: MAX_CANONICAL_ARRAY_LEN + 1 }, (_, i) => i),
+    };
+
+    const res = await post("/principals/jc/register", { claim: bloated, signature });
+
+    expect(res.status).not.toBe(500);
+    expect(res.status).toBe(401);
+  });
+
+  test("a normal-width claim still registers (201) — guard never fires for legit input", async () => {
+    const body = await makeSignedRegistration("jc", pKey, {
+      stacks: [{ stack_id: "jc/default", stack_pubkey: pKey.publicKeyB64 }],
+    });
+    const res = await post("/principals/jc/register", body);
+    expect(res.status).toBe(201);
+  });
+});

--- a/src/services/network-registry/src/signing.ts
+++ b/src/services/network-registry/src/signing.ts
@@ -19,58 +19,24 @@
  */
 
 // =============================================================================
-// Canonical JSON
+// Canonical JSON — the ONE shared source (#1416). Both this Worker-side module
+// and the cortex client (`src/common/registry/signing.ts`) import + re-export
+// from `src/common/registry/canonical-json.ts`, so the two canonicalisers can
+// no longer drift. That module is pure TS (zero imports, no atob/crypto) so it
+// bundles for BOTH the Worker and bun/node — see its header for the boundary
+// reasoning. The base64/Ed25519 primitives below are target-specific and stay
+// here. Re-exported so this module's existing importers are unaffected.
 // =============================================================================
 
-/**
- * Hard cap on nesting depth. #832 — the register route now canonicalizes the
- * claim AS RECEIVED (unauthenticated, attacker-controlled: verify runs before
- * the signature is proven), so this recursion can be driven by hostile input.
- * A legitimate registration claim nests ~3 levels deep (claim → stacks[] →
- * metadata map); 64 is far beyond any real claim yet shallow enough that a
- * deeply-nested body cannot exhaust the stack. Over-depth throws
- * `CanonicalDepthError`, which the verify path catches and fails closed (401) —
- * a hostile payload can never reach a legit signature anyway. The client-side
- * mirror carries the identical guard so both stay byte-compatible.
- */
-export const MAX_CANONICAL_DEPTH = 64;
-
-/** Thrown by {@link canonicalJSON} when nesting exceeds {@link MAX_CANONICAL_DEPTH}. */
-export class CanonicalDepthError extends Error {
-  constructor() {
-    super(`canonical JSON nesting exceeded ${MAX_CANONICAL_DEPTH} levels`);
-    this.name = "CanonicalDepthError";
-  }
-}
-
-/**
- * Deterministic JSON: object keys sorted recursively, no whitespace.
- * Arrays preserve their order. Throws on cycles (JSON.stringify behaviour)
- * and on nesting deeper than {@link MAX_CANONICAL_DEPTH} (#832 DoS guard).
- */
-export function canonicalJSON(value: unknown, depth = 0): string {
-  if (depth > MAX_CANONICAL_DEPTH) {
-    throw new CanonicalDepthError();
-  }
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return "[" + value.map((v) => canonicalJSON(v, depth + 1)).join(",") + "]";
-  }
-  const obj = value as Record<string, unknown>;
-  // Mirror JSON.stringify's handling of `undefined`: skip object keys
-  // whose value is `undefined`. Without this, a producer that builds a
-  // claim by spread-with-optionals (`{ ...base, metadata: undefined }`)
-  // would canonicalize differently from the same claim after a
-  // round-trip through `JSON.parse(JSON.stringify(...))`, breaking
-  // signature verification at the receiver.
-  const keys = Object.keys(obj)
-    .filter((k) => obj[k] !== undefined)
-    .sort();
-  const parts = keys.map((k) => JSON.stringify(k) + ":" + canonicalJSON(obj[k], depth + 1));
-  return "{" + parts.join(",") + "}";
-}
+export {
+  MAX_CANONICAL_DEPTH,
+  MAX_CANONICAL_KEYS,
+  MAX_CANONICAL_ARRAY_LEN,
+  MAX_CANONICAL_NODES,
+  CanonicalDepthError,
+  CanonicalWidthError,
+  canonicalJSON,
+} from "../../../common/registry/canonical-json";
 
 // =============================================================================
 // Base64 (URL-safe NOT used — principals paste standard base64)


### PR DESCRIPTION
## What
Extracts the canonicalisation routine into ONE pure leaf module — `src/common/registry/canonical-json.ts` — and makes both signing mirrors (registry Worker `src/services/network-registry/src/signing.ts` + cortex client `src/common/registry/signing.ts`) import & re-export it. The two canonicalisers are now the **same function reference**, so they structurally cannot drift (the root cause behind the #832 add-stack 401). Also lands #1418: pre-auth width/size caps on canonicalJSON.

## Why (#1416 + #1418)
- **#1416:** the two hand-mirrored `canonicalJSON` implementations were a drift hazard — #832 was exactly a canonicalisation divergence producing a spurious 401. One source of truth kills the class of bug.
- **#1418:** `canonicalJSON` sorts object keys (O(n log n)) on the attacker-controlled claim BEFORE signature verification. Caps bound that pre-auth amplification, fail-closed.

## How
- Pure module: zero imports, only universal built-ins (`JSON.stringify`/`Object.keys`/`Array.isArray`). Base64/Ed25519 primitives (need `atob`/`crypto.subtle`, differ by build target) stay in each `signing.ts` — only canonicalJSON moved. Registry Worker imports UP into `src/common` via relative path; `wrangler deploy --dry-run --env production` bundles clean (143.16 KiB / 28.84 KiB gzip, all 4 bindings).
- Caps (fail-closed, all in the one module): `MAX_CANONICAL_KEYS=4096` (checked BEFORE the sort), `MAX_CANONICAL_ARRAY_LEN=4096`, `MAX_CANONICAL_NODES=200000` (aggregate budget — catches distributed bodies under per-node caps), `MAX_CANONICAL_DEPTH=64` (unchanged, #832). Over-limit → new `CanonicalWidthError`; the register route's existing try/catch sheds it to 401 (`signature_invalid`), never 500.
- Numbers are ~40× the largest plausible legit claim → **caps never fire for legit traffic → output bytes unchanged → round-trip identity preserved.**

## Round-trip-identity lock (regression guard)
- `canonical-json.test.ts`: byte-exact output vs known-good literals (primitives, sorted keys, undefined-skip, arrays, nested, full registration-claim shape) + parse/stringify invariance.
- **No-drift lock:** asserts `registrySigning.canonicalJSON === commonSigning.canonicalJSON === canonicalJSON` (same reference) + identical bytes across a battery.
- Depth+width: at-limit OK / over-limit throws for keys / array / total-node budget; legit-sized claim never throws + round-trips.
- `register-canonical-width.test.ts` (E2E via `app.fetch`): over-wide claim → 401 not 500; normal claim → 201.

## Verify (all four, whole-repo)
- `bunx eslint --quiet .` → exit 0
- `bunx tsc --noEmit` (root) → exit 0
- `bash scripts/check-carveouts.sh` → PASS
- `bun test src/services/network-registry src/common/registry src/bus` → 1658 pass / 1 skip / 0 fail (95 files)
- `wrangler deploy --dry-run --env production` → bundles clean

## Residuals (non-blocking, filed observations)
- Registry-local standalone `tsc -p src/services/network-registry/tsconfig.json` shows 41 errors — **confirmed pre-existing on clean origin/main** (Uint8Array/JsonWebKey lib skew in test files), 0 reference these files; authoritative root `tsc` (CI gate) is exit 0.
- `check-carveouts.sh` matches 'operator' inside *nested* `src/services/network-registry/node_modules` if the registry package is `bun install`-ed locally — follow-up worth a `-prune` on nested node_modules. 0 real source violations.
- #1418 scope is canonicalJSON only; `validate.ts` reads whitelisted fields (no O(n) key iteration); register rate-limit + CF caps remain the outer bound per the issue.

Closes #1416. Closes #1418. Epic #1346 hardening lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB