### PR TITLE
harden(registry): C-1414 — converge signed routes on verify-over-wire

### DIFF
--- a/src/services/network-registry/__tests__/verify-over-wire.test.ts
+++ b/src/services/network-registry/__tests__/verify-over-wire.test.ts
@@ -1,0 +1,247 @@
+/**
+ * C-1414 — converge all signed write routes on verify-over-wire.
+ *
+ * #832 fixed ONLY the register route to verify the Ed25519 signature over the
+ * claim AS RECEIVED (canonicalJSON(signed.claim)) instead of the server's
+ * whitelist reconstruction. This converges the remaining signed routes —
+ * network-create, admission-decision (admit/reject), sealed-secret, revoke — on
+ * the same pattern.
+ *
+ * The guard each test encodes (mirroring register-canonical-drift.test.ts):
+ *   POSITIVE — a claim carrying an EXTRA signed field (a future/forward field the
+ *     server's reconstruction does not echo) still VERIFIES. Under the old
+ *     verify-over-reconstruction this 401'd (the #825→#832 regression); under
+ *     verify-over-wire it passes, because the server canonicalizes the same bytes
+ *     the client signed. Validation still ignores the unknown field (never
+ *     persisted), so the route reaches its happy path.
+ *   NEGATIVE — a claim carrying an extra field that the signature does NOT cover
+ *     (signed over the base claim, then the field added to the wire claim) is
+ *     REJECTED 401. Tamper-resistance is intact: mutating ANY field after signing
+ *     changes the verified bytes.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  makeSignedAdminRead,
+  randomNonce,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import type { AdmissionRequest } from "../src/types";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+
+let env: Env;
+let admin: PrincipalKey; // global registry-admin (admit/reject + network-create)
+let hubAdmin: PrincipalKey; // hub-admin (sealed-secret + revoke)
+let principal: PrincipalKey;
+
+const SEALED = btoa("sealed-leaf-psk-opaque-ciphertext-v1");
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+async function get(path: string, headers: Record<string, string> = {}): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), env);
+}
+
+/** Sign `claim` with `signer` and return the wire envelope, optionally SENDING a
+ *  DIFFERENT (tampered) claim than the one signed. */
+async function signed(
+  claim: Record<string, unknown>,
+  signer: PrincipalKey,
+  sendInstead?: Record<string, unknown>,
+): Promise<{ claim: unknown; signature: string }> {
+  const signature = await signEd25519(
+    signer.privateKeyB64,
+    new TextEncoder().encode(canonicalJSON(claim)),
+  );
+  return { claim: sendInstead ?? claim, signature };
+}
+
+async function registerPending(principalId: string): Promise<AdmissionRequest> {
+  const body = await makeSignedRegistration(principalId, principal, {
+    stacks: [{ stack_id: `${principalId}/main`, stack_pubkey: principal.publicKeyB64 }],
+    networkId: "metafactory",
+  });
+  const res = await post(`/principals/${principalId}/register`, body);
+  expect(res.status).toBe(201);
+  const read = await makeSignedAdminRead(admin);
+  const listRes = await get(`/admission-requests?status=PENDING`, {
+    "x-admin-signed": JSON.stringify(read),
+  });
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const found = list.find((r) => r.principal_id === principalId);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+function decisionClaim(requestId: string, decision: "admit" | "reject"): Record<string, unknown> {
+  return {
+    request_id: requestId,
+    decision,
+    admin_pubkey: admin.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+}
+
+async function admit(requestId: string): Promise<void> {
+  const res = await post(`/admission-requests/${requestId}/admit`, await signed(decisionClaim(requestId, "admit"), admin));
+  expect(res.status).toBe(200);
+}
+
+function createClaim(networkId: string): Record<string, unknown> {
+  return {
+    network_id: networkId,
+    hub_url: "tls://hub.meta-factory.ai:7422",
+    leaf_port: 7422,
+    admin_pubkey: admin.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+}
+
+function sealedClaim(requestId: string): Record<string, unknown> {
+  return {
+    request_id: requestId,
+    sealed_secret: SEALED,
+    hub_admin_pubkey: hubAdmin.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+}
+
+function revokeClaim(requestId: string): Record<string, unknown> {
+  return {
+    request_id: requestId,
+    hub_admin_pubkey: hubAdmin.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+}
+
+beforeEach(async () => {
+  resetStores();
+  _resetRateLimitBucketsForTest();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  hubAdmin = await makePrincipalKey();
+  principal = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    REGISTRY_HUB_ADMIN_PUBKEYS: hubAdmin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// admission-decision (admit / reject) — handleDecision
+// =============================================================================
+
+describe("#1414 — admission-decision verifies over the wire", () => {
+  test("admit: a claim with an EXTRA signed field verifies (200), not 401", async () => {
+    const req = await registerPending("alice");
+    const claim = { ...decisionClaim(req.request_id, "admit"), future_field: "forward-compat" };
+    const res = await post(`/admission-requests/${req.request_id}/admit`, await signed(claim, admin));
+    expect(res.status).toBe(200);
+  });
+
+  test("admit: an extra field NOT covered by the signature is rejected (401)", async () => {
+    const req = await registerPending("bob");
+    const base = decisionClaim(req.request_id, "admit");
+    // Sign the base claim, but SEND a claim with an added field → wire bytes differ.
+    const res = await post(
+      `/admission-requests/${req.request_id}/admit`,
+      await signed(base, admin, { ...base, injected: "tamper" }),
+    );
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error?: string }).error).toBe("signature_invalid");
+  });
+});
+
+// =============================================================================
+// network-create
+// =============================================================================
+
+describe("#1414 — network-create verifies over the wire", () => {
+  test("a claim with an EXTRA signed field verifies (200), not 401", async () => {
+    const claim = { ...createClaim("netpos"), future_field: "forward-compat" };
+    const res = await post(`/networks/netpos`, await signed(claim, admin));
+    expect(res.status).toBe(201); // created (verify-over-wire accepted the extra signed field)
+  });
+
+  test("an extra field NOT covered by the signature is rejected (401)", async () => {
+    const base = createClaim("netneg");
+    const res = await post(`/networks/netneg`, await signed(base, admin, { ...base, injected: "tamper" }));
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error?: string }).error).toBe("signature_invalid");
+  });
+});
+
+// =============================================================================
+// sealed-secret (hub-admin write)
+// =============================================================================
+
+describe("#1414 — sealed-secret verifies over the wire", () => {
+  test("a claim with an EXTRA signed field verifies (200), not 401", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const claim = { ...sealedClaim(req.request_id), future_field: "forward-compat" };
+    const res = await post(`/admission-requests/${req.request_id}/sealed-secret`, await signed(claim, hubAdmin));
+    expect(res.status).toBe(200);
+  });
+
+  test("an extra field NOT covered by the signature is rejected (401)", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const base = sealedClaim(req.request_id);
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await signed(base, hubAdmin, { ...base, injected: "tamper" }),
+    );
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error?: string }).error).toBe("signature_invalid");
+  });
+});
+
+// =============================================================================
+// revoke (hub-admin write)
+// =============================================================================
+
+describe("#1414 — revoke verifies over the wire", () => {
+  test("a claim with an EXTRA signed field verifies (200), not 401", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const claim = { ...revokeClaim(req.request_id), future_field: "forward-compat" };
+    const res = await post(`/admission-requests/${req.request_id}/revoke`, await signed(claim, hubAdmin));
+    expect(res.status).toBe(200);
+  });
+
+  test("an extra field NOT covered by the signature is rejected (401)", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const base = revokeClaim(req.request_id);
+    const res = await post(
+      `/admission-requests/${req.request_id}/revoke`,
+      await signed(base, hubAdmin, { ...base, injected: "tamper" }),
+    );
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error?: string }).error).toBe("signature_invalid");
+  });
+});

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -164,7 +164,22 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     }
 
     // 4. Signature verification FIRST (before recording nonce).
-    const message = new TextEncoder().encode(canonicalJSON(claim)) as Uint8Array<ArrayBuffer>;
+    // #1414 — verify over the claim AS RECEIVED (canonicalJSON(signed.claim)),
+    // NOT the whitelist reconstruction, converging on the #832 register pattern:
+    // a future signed field the reconstruction doesn't echo can no longer
+    // silently 401 a legitimate decision. The reconstruction (`claim`) stays for
+    // structural validation + the pubkey/allowlist/storage — validation already
+    // proved claim.admin_pubkey === signed.claim.admin_pubkey, so the key we
+    // verify + allowlist against is unchanged; only the signed BYTES converge.
+    // Fail closed (401) if the shared guarded canonicaliser throws on an
+    // over-deep/over-wide hostile body (#832 depth + #1418 width) — it can never
+    // match a real signature anyway.
+    let message: Uint8Array<ArrayBuffer>;
+    try {
+      message = new TextEncoder().encode(canonicalJSON(signed.claim)) as Uint8Array<ArrayBuffer>;
+    } catch (_err) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
     const sigValid = await verifyEd25519(claim.admin_pubkey, signed.signature, message);
     if (!sigValid) {
       return c.json({ error: "signature_invalid" }, 401);
@@ -378,7 +393,18 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     }
 
     // 4. Signature verification FIRST (before recording nonce), then allowlist.
-    const message = new TextEncoder().encode(canonicalJSON(claim)) as Uint8Array<ArrayBuffer>;
+    // #1414 — verify over the wire claim (canonicalJSON(signed.claim)), not the
+    // reconstruction (#832 pattern), so sealed-secret + revoke can't be broken by
+    // a future signed field. Validation already proved claim.hub_admin_pubkey ===
+    // signed.claim.hub_admin_pubkey, so the key we gate on is unchanged. Fail
+    // closed (401) if the guarded canonicaliser throws (over-deep/over-wide,
+    // #832/#1418).
+    let message: Uint8Array<ArrayBuffer>;
+    try {
+      message = new TextEncoder().encode(canonicalJSON(envelopeCheck.signed.claim)) as Uint8Array<ArrayBuffer>;
+    } catch (_err) {
+      return { ok: false, response: c.json({ error: "signature_invalid" }, 401) };
+    }
     const gateResult = await applyAdminGate(
       hubAdminPubkeys,
       claim.hub_admin_pubkey,

--- a/src/services/network-registry/src/routes/networks.ts
+++ b/src/services/network-registry/src/routes/networks.ts
@@ -153,7 +153,19 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
     // Signature verification FIRST (before recording the nonce — #695 rationale:
     // a bad-sig POST must not burn a durable nonce row). The admin signs
     // canonicalJSON(claim) with the key whose pubkey the claim declares.
-    const message = new TextEncoder().encode(canonicalJSON(claim));
+    // #1414 — verify over the claim AS RECEIVED (canonicalJSON(signed.claim)),
+    // NOT the whitelist reconstruction, converging on the #832 register pattern
+    // so a future signed field (mirroring #1321's admin_pubkeys) can't silently
+    // 401. The reconstruction (`claim`) still drives validation + the pubkey we
+    // verify/authorise against (validation proved claim.admin_pubkey ===
+    // signed.claim.admin_pubkey) + storage. Fail closed (401) if the shared
+    // guarded canonicaliser throws on an over-deep/over-wide body (#832/#1418).
+    let message: Uint8Array<ArrayBuffer>;
+    try {
+      message = new TextEncoder().encode(canonicalJSON(signed.claim)) as Uint8Array<ArrayBuffer>;
+    } catch (_err) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
     const valid = await verifyEd25519(claim.admin_pubkey, signed.signature, message);
     if (!valid) {
       return c.json({ error: "signature_invalid" }, 401);


### PR DESCRIPTION
## What

Follow-up to #832, which converged **only** the register route on **verify-over-wire** (`verifyEd25519(pubkey, canonicalJSON(signed.claim), sig)`) instead of verifying over the server's whitelist *reconstruction*. The reconstruction pattern is why a new signed field (`expected_updated_at`, #825) silently 401'd the 2nd-stack register.

This converges the remaining signed write routes on the same pattern:

| Route | File | Verify site |
|---|---|---|
| network-create | `routes/networks.ts` | `canonicalJSON(claim)` → `canonicalJSON(signed.claim)` |
| admission-decision (admit/reject) | `routes/admission-requests.ts` `handleDecision` | same |
| sealed-secret | `routes/admission-requests.ts` `verifyHubAdminWrite` | same |
| revoke | `routes/admission-requests.ts` `verifyHubAdminWrite` | same |

## How

- Each verify now canonicalizes the claim **as received** and is wrapped in a `try/catch` that **fails closed (401)** if the shared guarded canonicaliser throws on an over-deep/over-wide body — the #832 depth + #1418 width caps come **for free** now via the shared `src/common/registry/canonical-json.ts` (merged in #1427).
- The whitelist **reconstruction is kept** for structural validation + storage + the pubkey the route verifies/authorises against. Validation already proves `reconstruction.pubkey === signed.claim.pubkey`, so the key and the allowlist decision are unchanged — **only the signed bytes converge**.

## Per-route confirmation: client-signed shape === server-canonicalized shape

For every converged route the client signs `canonicalJSON(claim)` over the **exact object** it puts in the `{claim, signature}` envelope, and that field set **equals** the server reconstruction. So verify-over-wire is **byte-identical** to today's verify-over-reconstruction for all current traffic (no regression) and removes the latent field-drift 401.

| Route | Client signer | Signed shape | Reconstruction | Match |
|---|---|---|---|---|
| network-create | `buildNetworkCreateClaim` (`bus/stack-provisioning.ts`) | `{network_id,hub_url,leaf_port,admin_pubkey,issued_at,nonce,admin_pubkeys?}` | same | ✅ |
| admission-decision | `buildAdmissionDecisionBody` (`cli/.../network.ts`) | `{request_id,decision,admin_pubkey,issued_at,nonce}` | same | ✅ |
| sealed-secret | `buildLiveSealDeliveryPort.postSealedSecret` (`network-secret-adapters.ts`) | `{request_id,sealed_secret,hub_admin_pubkey,issued_at,nonce}` | same | ✅ |
| revoke | `buildLiveSealDeliveryPort.revoke` (`network-secret-adapters.ts`) | `{request_id,hub_admin_pubkey,issued_at,nonce}` | same | ✅ |

**No route diverges** — no shape mismatch, no forced conversion.

## Tests

`verify-over-wire.test.ts` — per route: a claim carrying an **extra signed field** verifies (200/201) — the forward-compat the old reconstruction rejected — and an extra field **not covered by the signature** is rejected (401), so tamper-resistance is intact.

## Four-check results
- `bunx eslint --quiet .` → **0**
- `bunx tsc --noEmit` (root) → **0**
- `bash scripts/check-carveouts.sh` → **PASS**
- `bunx wrangler deploy --dry-run --env production` (from `src/services/network-registry`) → **bundles** (143.54 KiB / 28.86 KiB gzip)
- `bun test src/services/network-registry src/common/registry` → **404 pass, 0 fail**

Closes #1414. Refs #832. Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB