### PR TITLE
feat(registry): C-1398 — echo request_id in register response (avoid /mine round-trip)

### DIFF
--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -235,8 +235,12 @@ describe("cortex provision-stack register (TC-1b #632)", () => {
       ]);
       expect(res.exitCode).toBe(0);
       const out = JSON.parse(res.stdout) as { data: Record<string, string> };
-      // C-1315 — the register response itself carries no request_id; the CLI
-      // does a PoP `/admission-requests/mine` read to surface it.
+      // C-1398 (#1398) — the register response now ECHOES the request_id (+
+      // PENDING status), so the CLI surfaces it WITHOUT the `/mine` round-trip.
+      // The output contract is UNCHANGED from the old `/mine` path (the echo
+      // path synthesises the SAME OwnAdmissionState and reuses the SAME
+      // helpers): a fresh PENDING register still reports sealed_secret "missing"
+      // and the full admit + secret-add-member next-step.
       expect(out.data.network_id).toBe("metafactory");
       expect(out.data.admission_status).toBe("PENDING");
       expect(out.data.sealed_secret).toBe("missing");

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -440,22 +440,37 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
   const humanLines: string[] = [];
   if (networkRes.networkId !== undefined) {
     data.network_id = networkRes.networkId;
-    if (reg.requestId !== undefined) {
-      // C-1398 — echoed by the register response; no round-trip needed.
+    if (reg.requestId !== undefined && reg.admissionStatus === "PENDING") {
+      // C-1398 — fast-path: the register response ECHOED the request_id and a
+      // PENDING status, so we surface it WITHOUT the `/mine` round-trip. #1398
+      // is "avoid the round-trip", NOT "change the output contract": we
+      // SYNTHESISE the SAME `OwnAdmissionState` the `/mine` path would have
+      // produced for a just-created PENDING row and reuse the SAME helpers, so
+      // the output is byte-identical — the ONLY behavioural change is no
+      // network call. A fresh PENDING register carries no sealed secret
+      // (`hasSealedSecret: false`), and the peer pubkey is the just-registered
+      // stack's own key — EXACTLY what the `/mine` path derived
+      // (`classifyOwnAdmissionRows(..., material.pubkeyB64)`). Any non-PENDING
+      // echoed status falls through to the `/mine` probe below, which reads the
+      // REAL sealed-delivery state (the echo does not convey it).
+      const s: OwnAdmissionState = {
+        networkId: networkRes.networkId,
+        state: "pending",
+        requestId: reg.requestId,
+        hasSealedSecret: false,
+        peerPubkey: matRes.material.pubkeyB64,
+      };
+      data.admission_status = admissionStatusLabel(s.state);
+      data.sealed_secret = s.hasSealedSecret ? "present" : "missing";
       data.request_id = reg.requestId;
-      data.admission_status = reg.admissionStatus ?? "PENDING";
-      data.next_for_admin = `cortex network admit ${reg.requestId} --apply`;
-      humanLines.push(
-        `  network: ${networkRes.networkId}`,
-        `  request-id: ${reg.requestId}   (give this to a network admin)`,
-        `  admission: ${data.admission_status}`,
-        `  next (admin): ${data.next_for_admin}`,
-      );
+      data.next_for_admin = nextForAdmin(networkRes.networkId, s);
+      humanLines.push(...registerStateLines(networkRes.networkId, s));
     } else {
-      // Fallback: older registry that does not echo the request_id — do the
-      // PoP-signed `/admission-requests/mine` read to discover it. Best-effort:
-      // a read failure NEVER fails a successful registration — we note the
-      // lookup was unavailable and point at the discovery command.
+      // Fallback: an older registry that does not echo the request_id, OR an
+      // already-decided echoed status whose sealed-delivery state must be read
+      // from `/mine`. PoP-signed `/admission-requests/mine` read to discover
+      // it. Best-effort: a read failure NEVER fails a successful registration —
+      // we note the lookup was unavailable and point at the discovery command.
       const probe = await resolveOwnAdmissionState(
         { registryUrl: urlRes.value, principalId: ctx.principalId, material: matRes.material },
         networkRes.networkId,

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -428,34 +428,54 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
     admission_request: reg.admission,
   };
 
-  // C-1315 — surface the admission request-id + sealed-delivery state the admin
-  // needs. The register RESPONSE does not carry the request_id (the registry
-  // route returns only the signed principal assertion), so we do a PoP-signed
-  // `/admission-requests/mine` read here for the just-registered network.
-  // Best-effort: a read failure NEVER fails a successful registration — we note
-  // the lookup was unavailable and point at the discovery command.
+  // C-1315 / C-1398 — surface the admission request-id + sealed-delivery state
+  // the admin needs. C-1398 (#1398): the register RESPONSE now ECHOES the
+  // request_id (+ status), so when it is present we read it DIRECTLY off the
+  // register result — no second PoP-signed `/admission-requests/mine`
+  // round-trip. On a fresh register the row is always PENDING with no sealed
+  // secret yet, so the echo carries everything the admin needs (the id to
+  // admit); richer sealed-delivery state is surfaced later by
+  // `cortex network join` / `cortex network status`. The `/mine` probe stays
+  // as the FALLBACK for an older registry that predates the echo.
   const humanLines: string[] = [];
   if (networkRes.networkId !== undefined) {
-    const probe = await resolveOwnAdmissionState(
-      { registryUrl: urlRes.value, principalId: ctx.principalId, material: matRes.material },
-      networkRes.networkId,
-    );
-    if (probe.ok) {
-      const s = probe.state;
-      data.network_id = networkRes.networkId;
-      data.admission_status = admissionStatusLabel(s.state);
-      data.sealed_secret = s.hasSealedSecret ? "present" : "missing";
-      if (s.requestId !== undefined) {
-        data.request_id = s.requestId;
-        data.next_for_admin = nextForAdmin(networkRes.networkId, s);
-      }
-      humanLines.push(...registerStateLines(networkRes.networkId, s));
-    } else {
-      data.admission_lookup = `unavailable: ${probe.reason}`;
+    data.network_id = networkRes.networkId;
+    if (reg.requestId !== undefined) {
+      // C-1398 — echoed by the register response; no round-trip needed.
+      data.request_id = reg.requestId;
+      data.admission_status = reg.admissionStatus ?? "PENDING";
+      data.next_for_admin = `cortex network admit ${reg.requestId} --apply`;
       humanLines.push(
-        `  admission: could not read the request-id from the registry (${probe.reason}).`,
-        `  Discover it later with (admin): cortex network admit --list-pending --admin-seed <path>.`,
+        `  network: ${networkRes.networkId}`,
+        `  request-id: ${reg.requestId}   (give this to a network admin)`,
+        `  admission: ${data.admission_status}`,
+        `  next (admin): ${data.next_for_admin}`,
       );
+    } else {
+      // Fallback: older registry that does not echo the request_id — do the
+      // PoP-signed `/admission-requests/mine` read to discover it. Best-effort:
+      // a read failure NEVER fails a successful registration — we note the
+      // lookup was unavailable and point at the discovery command.
+      const probe = await resolveOwnAdmissionState(
+        { registryUrl: urlRes.value, principalId: ctx.principalId, material: matRes.material },
+        networkRes.networkId,
+      );
+      if (probe.ok) {
+        const s = probe.state;
+        data.admission_status = admissionStatusLabel(s.state);
+        data.sealed_secret = s.hasSealedSecret ? "present" : "missing";
+        if (s.requestId !== undefined) {
+          data.request_id = s.requestId;
+          data.next_for_admin = nextForAdmin(networkRes.networkId, s);
+        }
+        humanLines.push(...registerStateLines(networkRes.networkId, s));
+      } else {
+        data.admission_lookup = `unavailable: ${probe.reason}`;
+        humanLines.push(
+          `  admission: could not read the request-id from the registry (${probe.reason}).`,
+          `  Discover it later with (admin): cortex network admit --list-pending --admin-seed <path>.`,
+        );
+      }
     }
   }
 
@@ -523,7 +543,19 @@ function registerStateLines(networkId: string, s: OwnAdmissionState): string[] {
  */
 type DoRegisterResult =
   | { ok: false; reason: string }
-  | { ok: true; note: string; admission: "ok" | "failed"; warning?: string };
+  | {
+      ok: true;
+      note: string;
+      admission: "ok" | "failed";
+      warning?: string;
+      // C-1398 (#1398) — the admission `request_id` + status ECHOED by the
+      // register response, so the caller can print the id WITHOUT the
+      // second PoP-signed `GET /admission-requests/mine` round-trip. Absent
+      // when talking to an older registry that predates the echo (the caller
+      // falls back to the `/mine` probe, which stays as the compatibility path).
+      requestId?: string;
+      admissionStatus?: string;
+    };
 
 /**
  * C-1269 — read the registry register-response for the non-fatal
@@ -540,6 +572,23 @@ function readAdmissionState(response: unknown): { failed: boolean; warning?: str
     }
   }
   return { failed: false };
+}
+
+/**
+ * C-1398 (#1398) — read the admission `request_id` (+ status) the register
+ * response now ECHOES, so the caller can surface the id WITHOUT the second
+ * PoP-signed `GET /admission-requests/mine` round-trip. Additive + back-compat:
+ * an older registry that predates the echo omits these fields, so both come
+ * back `undefined` and the caller falls back to the `/mine` probe. Mirrors the
+ * `readAdmissionState` shape (defensive `typeof` guards — the body is `unknown`).
+ */
+function readEchoedRequestId(response: unknown): { requestId?: string; admissionStatus?: string } {
+  if (typeof response !== "object" || response === null) return {};
+  const r = response as Record<string, unknown>;
+  return {
+    ...(typeof r.request_id === "string" && { requestId: r.request_id }),
+    ...(typeof r.admission_status === "string" && { admissionStatus: r.admission_status }),
+  };
 }
 
 /**
@@ -704,6 +753,9 @@ async function doRegister(
   // grants the request. Always surface this so the principal knows to expect
   // the admin-grant step before the stack can join the federation.
   const noteBase = `registration recorded; awaiting admin grant — your credential will be issued on approval (HTTP ${attempt.status.toString()}, registry: ${registryUrl})`;
+  // C-1398 — pull the echoed admission id off the (final) register response so
+  // the caller can print it without a `/mine` round-trip.
+  const echoed = readEchoedRequestId(attempt.response);
   return {
     ok: true,
     note:
@@ -712,6 +764,8 @@ async function doRegister(
         : noteBase,
     admission: admission.failed ? "failed" : "ok",
     ...(admission.warning !== undefined && { warning: admission.warning }),
+    ...(echoed.requestId !== undefined && { requestId: echoed.requestId }),
+    ...(echoed.admissionStatus !== undefined && { admissionStatus: echoed.admissionStatus }),
   };
 }
 

--- a/src/common/registry/admission-state.ts
+++ b/src/common/registry/admission-state.ts
@@ -7,8 +7,11 @@
  * This is the shared primitive behind two onboarding handles the CLI was
  * missing:
  *   - `provision-stack register --network <net>` prints the `request_id` the admin
- *     needs (the register response itself does not carry it — the registry route
- *     returns only the signed principal assertion), and
+ *     needs. As of C-1398 (#1398) the register response ECHOES `request_id` (+
+ *     `admission_status`), so the register path reads it DIRECTLY off that
+ *     response and this `/mine` read is now the FALLBACK for an older registry
+ *     that predates the echo (and still the path that surfaces sealed-secret
+ *     delivery state), and
  *   - `cortex network join` reports the REAL admission/sealed state (PENDING /
  *     admitted-but-unsealed / revoked) instead of falling through to the
  *     misleading legacy `.creds not found (#821)` preflight.

--- a/src/services/network-registry/__tests__/register-echo-request-id.test.ts
+++ b/src/services/network-registry/__tests__/register-echo-request-id.test.ts
@@ -1,0 +1,197 @@
+/**
+ * C-1398 (#1398) — the register response ECHOES the admission `request_id`.
+ *
+ * Follow-up from #1315: previously `POST /principals/:id/register` returned
+ * only the signed principal assertion and DISCARDED `upsertPending`'s return,
+ * so a client had to do a SECOND, PoP-signed `GET /admission-requests/mine`
+ * round-trip just to learn the id of the admission request it had created.
+ * This route now echoes `request_id` (+ `admission_status`) in the register
+ * success body. These tests pin:
+ *   - the echoed `request_id` is present, a string, and matches the id the
+ *     admin sees via the admin list / the member sees via `/mine` EXACTLY,
+ *   - `admission_status` is the raw `AdmissionRequest.status` ("PENDING"),
+ *   - the echo is idempotent (re-register → SAME id),
+ *   - it survives across per-network rows (two networks → two distinct ids),
+ *   - the additive fields do NOT disturb the signed assertion (back-compat).
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  makeSignedAdminRead,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import type { AdmissionRequest } from "../src/types";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+
+let env: Env;
+let admin: PrincipalKey;
+let principal: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, headers: Record<string, string> = {}, e: Env = env): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+/** Admin-list PENDING admission requests — the id source of truth to match. */
+async function listPending(): Promise<AdmissionRequest[]> {
+  const read = await makeSignedAdminRead(admin);
+  const res = await get("/admission-requests?status=PENDING", {
+    "x-admin-signed": JSON.stringify(read),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as AdmissionRequest[];
+}
+
+/** Member PoP read for `GET /admission-requests/mine` (mirror the field name). */
+async function makeSignedMineRead(
+  principalId: string,
+  memberKey: PrincipalKey,
+): Promise<{ claim: { principal_id: string; peer_pubkey: string; issued_at: string }; signature: string }> {
+  const claim = {
+    principal_id: principalId,
+    peer_pubkey: memberKey.publicKeyB64,
+    issued_at: new Date().toISOString(),
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signature = await signEd25519(memberKey.privateKeyB64, message);
+  return { claim, signature };
+}
+
+beforeEach(async () => {
+  resetStores();
+  _resetRateLimitBucketsForTest();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  principal = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+describe("C-1398 — register response echoes request_id", () => {
+  test("a successful register echoes request_id (string) + admission_status PENDING", async () => {
+    const res = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(typeof body.request_id).toBe("string");
+    expect((body.request_id as string).length).toBeGreaterThan(0);
+    expect(body.admission_status).toBe("PENDING");
+  });
+
+  test("the echoed request_id EXACTLY matches the admin-listed row id", async () => {
+    const res = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    const body = (await res.json()) as { request_id: string };
+
+    const pending = (await listPending()).filter((r) => r.principal_id === "alice");
+    expect(pending.length).toBe(1);
+    // Same opaque id, same format — the round-trip the echo replaces.
+    expect(body.request_id).toBe(pending[0]!.request_id);
+  });
+
+  test("the echoed request_id EXACTLY matches the /mine (AdmissionRequest) id", async () => {
+    const res = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    const body = (await res.json()) as { request_id: string };
+
+    const read = await makeSignedMineRead("alice", principal);
+    const mineRes = await get("/admission-requests/mine", { "x-pop-signed": JSON.stringify(read) });
+    expect(mineRes.status).toBe(200);
+    const rows = (await mineRes.json()) as AdmissionRequest[];
+    expect(rows.length).toBe(1);
+    // Field name AND value line up with what /mine returns.
+    expect(body.request_id).toBe(rows[0]!.request_id);
+  });
+
+  test("re-registering the SAME network echoes the SAME request_id (idempotent)", async () => {
+    const first = (await (
+      await post(
+        "/principals/alice/register",
+        await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+      )
+    ).json()) as { request_id: string };
+
+    const second = (await (
+      await post(
+        "/principals/alice/register",
+        await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+      )
+    ).json()) as { request_id: string };
+
+    expect(second.request_id).toBe(first.request_id);
+  });
+
+  test("two networks echo two DISTINCT request_ids, each matching its row", async () => {
+    const a = (await (
+      await post(
+        "/principals/alice/register",
+        await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+      )
+    ).json()) as { request_id: string };
+    const b = (await (
+      await post(
+        "/principals/alice/register",
+        await makeSignedRegistration("alice", principal, { networkId: "net-b" }),
+      )
+    ).json()) as { request_id: string };
+
+    expect(a.request_id).not.toBe(b.request_id);
+
+    const pending = (await listPending()).filter((r) => r.principal_id === "alice");
+    const byNet = new Map(pending.map((r) => [r.network_id, r.request_id]));
+    expect(byNet.get("net-a")!).toBe(a.request_id);
+    expect(byNet.get("net-b")!).toBe(b.request_id);
+  });
+
+  test("a network-less register also echoes a request_id", async () => {
+    const res = await post("/principals/alice/register", await makeSignedRegistration("alice", principal));
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(typeof body.request_id).toBe("string");
+    expect(body.admission_status).toBe("PENDING");
+  });
+
+  test("back-compat: the additive echo does NOT disturb the signed assertion", async () => {
+    const res = await post(
+      "/principals/alice/register",
+      await makeSignedRegistration("alice", principal, { networkId: "net-a" }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    // The signed fields a peer verifies are all still present + well-formed.
+    expect(body).toHaveProperty("payload");
+    expect(body).toHaveProperty("issued_at");
+    expect(body).toHaveProperty("registry");
+    expect(typeof body.signature).toBe("string");
+    expect((body.signature as string).length).toBeGreaterThan(0);
+    // The failure-path flag is NOT set on a success.
+    expect(body.admission_request).toBeUndefined();
+  });
+});

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -23,7 +23,7 @@ import {
   retryAfterSeconds,
   TOO_MANY_REQUESTS_BODY,
 } from "../rate-limit";
-import type { PrincipalRecord, SignedAssertion } from "../types";
+import type { AdmissionRequest, PrincipalRecord, SignedAssertion } from "../types";
 import {
   isValidPrincipalId,
   validateRegistrationClaim,
@@ -258,6 +258,15 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
       stacksWithPubkeys[0]?.stack_pubkey ?? claim.principal_pubkey;
     const requestedScope = `federated.${principalId}.>`;
     let admissionRequestFailed = false;
+    // C-1398 (#1398) — capture the admission row upsertPending returns so the
+    // register response can ECHO its `request_id` (+ status). Previously this
+    // return was discarded and a client (#1315) had to do a SECOND, PoP-signed
+    // `GET /admission-requests/mine` round-trip just to learn the id of the
+    // request it had just created. Echoing it here removes that round-trip and
+    // works even when the `/mine` read is unavailable. `undefined` iff the
+    // upsert threw below (the `admission_request: "failed"` path) — in which
+    // case there is no row and nothing to echo.
+    let admissionRequest: AdmissionRequest | undefined;
     try {
       const issuanceStore = getIssuanceStore(c.env);
       // ADR-0018 Gap-A — stamp the target network the joiner named (signed into
@@ -265,7 +274,7 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
       // key `(principal_id, peer_pubkey, network_id)`, so the same stack can
       // request admission to two networks. A network-less register (no
       // `network_id` in the claim) creates a network-less PENDING row.
-      await issuanceStore.upsertPending(
+      admissionRequest = await issuanceStore.upsertPending(
         principalId,
         peerPubkey,
         requestedScope,
@@ -311,7 +320,28 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
         201,
       );
     }
-    return c.json(assertion, 201);
+    // C-1398 (#1398) — success. ECHO the admission `request_id` (+ status) so a
+    // client (#1315) can read the id of the admission request it just created
+    // directly off THIS response, with no follow-up `GET /admission-requests/mine`
+    // round-trip. Additive + back-compat: the signed `payload`/`issued_at`/
+    // `registry`/`signature` fields are unchanged, so a client that ignores the
+    // extra fields (or an older registry that never emits them) keeps working.
+    // `request_id` mirrors the `/mine` (AdmissionRequest) field name + format
+    // EXACTLY — the same opaque hex id an admin admits. `admission_status`
+    // carries the raw `AdmissionRequest.status` ("PENDING" on a fresh register;
+    // the EXISTING status when a re-register returns an already-decided row).
+    // `admissionRequest` is only undefined on the failed-upsert path handled
+    // above, so on this path it is always present; the guard is belt-and-braces.
+    return c.json(
+      {
+        ...assertion,
+        ...(admissionRequest !== undefined && {
+          request_id: admissionRequest.request_id,
+          admission_status: admissionRequest.status,
+        }),
+      },
+      201,
+    );
   });
 
   app.get("/principals/:principal_id", async (c) => {


### PR DESCRIPTION
## What

Follow-up from #1315. `POST /principals/:id/register` discarded `upsertPending`'s return (`principals.ts:239`) and responded with only the signed principal assertion. A client therefore had to make a **second**, PoP-signed `GET /admission-requests/mine` round-trip just to learn the `request_id` of the admission request it had **just** created.

This makes the fix **server-side**: the register success response now **echoes** the created/existing PENDING `request_id` (+ `admission_status`), so a client reads it directly off the register response — no follow-up round-trip, and it works even when the `/mine` read is unavailable.

Not trust-path: this only adds fields to a response body. Signature verification / the signed assertion is untouched.

## How

- **Server (`src/services/network-registry/src/routes/principals.ts`)** — capture the `AdmissionRequest` that `upsertPending` returns (previously discarded) and spread `request_id` + `admission_status` onto the 201 success body. Guarded so the failed-upsert path (`admission_request: "failed"`) is unchanged. `request_id` mirrors the `/mine` (`AdmissionRequest`) field name + format **exactly**.
- **Client (`src/cli/cortex/commands/provision-stack.ts`)** — `readEchoedRequestId()` reads the echoed fields off the register response; `doRegister`'s result threads `requestId`/`admissionStatus`; `runRegister` uses the echoed id **directly** and skips the `/mine` round-trip, keeping the `/mine` probe as the **fallback** for an older registry that predates the echo.
- **`src/common/registry/admission-state.ts`** — updated the stale doc-comment that claimed "the register response itself does not carry it".

## Response shape — before → after

**Before** (register 201):
```jsonc
{ "payload": { /* PrincipalRecord */ }, "issued_at": "…", "registry": "…", "signature": "…" }
```

**After** (register 201 — additive fields in **bold**):
```jsonc
{
  "payload": { /* PrincipalRecord */ }, "issued_at": "…", "registry": "…", "signature": "…",
  "request_id": "a1b2…",        // ← echoed; same opaque hex id /mine returns
  "admission_status": "PENDING" // ← raw AdmissionRequest.status
}
```
The failure path (`admission_request: "failed"` + `warning`) is unchanged.

## Client thread-through

`registerStackIdentity` already returns the raw body as `response`. Thread-through site: `provision-stack.ts` → `doRegister` (extracts via `readEchoedRequestId`) → `runRegister` (prefers `reg.requestId`, `/mine` fallback when absent).

## Test

New `src/services/network-registry/__tests__/register-echo-request-id.test.ts`:
- register 201 body includes `request_id` (string) + `admission_status` "PENDING"
- echoed `request_id` **exactly matches** the admin-listed row id **and** the `/mine` `AdmissionRequest.request_id`
- idempotent re-register echoes the **same** id; two networks echo two **distinct** ids each matching their row
- network-less register also echoes; additive echo does **not** disturb the signed assertion (back-compat)

## Four-check results (from `../Cortex-echoreqid`)

| Check | Result |
|---|---|
| `bunx eslint --quiet .` | **0** |
| `bunx tsc --noEmit` | **0** |
| `bash scripts/check-carveouts.sh` | **PASS** |
| `bun test src/services/network-registry src/common/registry` | **416 pass / 0 fail** |
| `wrangler deploy --dry-run --env production` | **clean** (28.91 KiB gzip) |

## Deploy note

⚠️ This needs a **registry Worker prod redeploy** (`wrangler deploy --env production` from `src/services/network-registry`) to take effect — that is a **separate, held** step, not part of this PR.

Closes #1398. Refs #1315. Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB