### PR TITLE
fix(network): C-1364 — converge join guard + boot on one deriveStackId authority

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -904,9 +904,9 @@ describe("C-1364 — join own-scope identity converges with boot on deriveStackI
           presence: {
             discord: {
               token: "DISCORD_TOKEN",
-              guildId: "123456789012345678",
-              agentChannelId: "234567890123456789",
-              logChannelId: "345678901234567890",
+              guildId: "111111111111111111",
+              agentChannelId: "222222222222222222",
+              logChannelId: "333333333333333333",
             },
           },
         },

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -22,6 +22,12 @@ import {
 import { DEFAULT_REGISTRY } from "../default-registry";
 import type { LoadedConfig } from "../../../../common/config/loader";
 import type { AgentConfig } from "../../../../common/types/config";
+import {
+  CortexConfigSchema,
+  deriveStackId,
+  ownFederatedSubjectScopePrefix,
+} from "../../../../common/types/cortex-config";
+import { ownAcceptSubjects } from "../../../../bus/agent-network/accept-subjects";
 
 // A minimal LoadedConfig stub — only the fields the deriver reads matter; the
 // `config` AgentConfig is never inspected by the deriver, so a bare cast keeps
@@ -78,6 +84,9 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
     expect(res.inputs).toEqual({
       principal: "andreas",
       stack: "andreas/meta-factory",
+      // C-1364 — boot-authoritative slug from stack.id (born-aligned here: equals
+      // the `stack` id's trailing segment). deriveStackId(FULL).stack.
+      bootStackSlug: "meta-factory",
       seedPath: "~/.config/nats/cortex.nk",
       registryUrl: "https://registry.meta-factory.ai",
       registryPubkey: "A".repeat(43) + "=",
@@ -245,6 +254,12 @@ describe("deriveJoinInputs — flag overrides win", () => {
     expect(res.inputs).toEqual({
       principal: "override-p",
       stack: "override-p/other",
+      // C-1364 — the `--stack` flag moves the LOCATOR/write-path id ("other"),
+      // but `bootStackSlug` stays the config's stack.id trailing segment
+      // ("meta-factory" from FULL). A flag override CANNOT move the federation
+      // identity the daemon boot validator enforces — this is the drift the fix
+      // pins shut: guard scope derives from bootStackSlug, never `stack`'s slug.
+      bootStackSlug: "meta-factory",
       seedPath: "/flag/seed.nk",
       registryUrl: "https://flag.registry",
       registryPubkey: "Z".repeat(43) + "=",
@@ -831,5 +846,171 @@ describe("C-1224 — leaf-secret (secret-auth pipe) derivation", () => {
     expect(res.inputs?.leafSecret).toBeUndefined();
     // leafUser is meaningless without a secret — never resolved on its own.
     expect(res.inputs?.leafUser).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// C-1364 — the join own-scope guard and the daemon boot validator MUST derive
+// the stack identity from ONE authority (`deriveStackId` → stack.id, ADR-0004).
+//
+// Latent drift (found by the PR #1361 adversarial review, vector 4): the join
+// own-scope guard built its `federated.{me}.{stack}.` scope from the flag/
+// locator-honouring slug (`resolveStackSlug(inputs.stack)`), while the boot
+// validator (`CortexConfigSchema` federated subject-scope superRefine) derives
+// it from `deriveStackId(config).stack`. For a BORN-ALIGNED stack the two agree;
+// for a DRIFTED stack (a `--stack` override, or a locator slug ≠ stack.id
+// trailing segment) they DISAGREE — the join then persists an accept-list scoped
+// to one identity that the daemon refuses to boot against, or falsely refuses a
+// valid one. The fix threads `bootStackSlug = deriveStackId(cfg).stack` and pins
+// the guard to it, so guard + boot can never split.
+// =============================================================================
+
+describe("C-1364 — join own-scope identity converges with boot on deriveStackId", () => {
+  // A DRIFTED stack: config `stack.id` trailing segment is "work", and the join
+  // is invoked with `--stack andreas/research` (slug "research" ≠ "work"). This
+  // is exactly the "slug ≠ stack.id trailing segment" class ADR-0004 targets.
+  const DRIFTED = loaded({
+    principal: { id: "andreas" },
+    stack: {
+      id: "andreas/work",
+      nkey_seed_path: "~/seed.nk",
+      nats_infra: {
+        config_path: "~/local.conf",
+        plist_path: "~/nats.plist",
+        account: "A" + "B".repeat(55),
+      },
+    },
+    policy: {
+      principals: [],
+      roles: [],
+      federated: {
+        networks: [],
+        registry: { url: DEFAULT_REGISTRY.url, pubkey: DEFAULT_REGISTRY.pubkey },
+      },
+    },
+  });
+
+  // Build a raw cortex config the DAEMON BOOTS from — stack.id "andreas/work",
+  // one federated network whose accept-list is the argument. Parsing it through
+  // CortexConfigSchema runs the REAL subject-scope superRefine (the boot verdict).
+  function bootConfigWithAccept(accept: string[]): Record<string, unknown> {
+    return {
+      principal: { id: "andreas" },
+      agents: [
+        {
+          id: "luna",
+          displayName: "Luna",
+          persona: "./personas/luna.md",
+          presence: {
+            discord: {
+              token: "DISCORD_TOKEN",
+              guildId: "123456789012345678",
+              agentChannelId: "234567890123456789",
+              logChannelId: "345678901234567890",
+            },
+          },
+        },
+      ],
+      renderers: [],
+      claude: { model: "claude-opus-4-5", apiKey: "env:ANTHROPIC_API_KEY" },
+      // The authority: stack.id trailing segment "work".
+      stack: { id: "andreas/work" },
+      policy: {
+        federated: {
+          networks: [
+            {
+              id: "metafactory",
+              leaf_node: "leaf",
+              peers: [],
+              accept_subjects: accept,
+              deny_subjects: [],
+              announce_capabilities: [],
+              max_hop: 1,
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  test("bootStackSlug tracks stack.id, NOT the --stack flag → guard + boot prefixes are identical", () => {
+    // Join with a --stack override whose slug ("research") disagrees with stack.id.
+    const res = deriveJoinInputs(
+      "metafactory",
+      { stack: "andreas/research" },
+      "/cfg",
+      reader(DRIFTED),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    const inputs = res.inputs;
+    if (inputs === undefined) throw new Error("expected inputs");
+
+    // The flag moved the LOCATOR / write-path id (DA-5) ...
+    expect(inputs.stack).toBe("andreas/research");
+    // ... but the boot-authoritative own-scope slug stays stack.id's segment.
+    expect(inputs.bootStackSlug).toBe("work");
+
+    // BOOT derives its prefix EXACTLY as the superRefine does:
+    // ownFederatedSubjectScopePrefix(config.principal.id, deriveStackId(config).stack).
+    const bootPrefix = ownFederatedSubjectScopePrefix("andreas", deriveStackId(DRIFTED).stack);
+    // The JOIN GUARD now derives from bootStackSlug — must be identical (no split).
+    const guardPrefix = ownFederatedSubjectScopePrefix(inputs.principal, inputs.bootStackSlug);
+    expect(guardPrefix).toBe(bootPrefix);
+    expect(guardPrefix).toBe("federated.andreas.work.");
+
+    // Regression witness: the PRE-FIX derivation (the flag/locator slug off
+    // inputs.stack) WOULD have produced a different prefix — the split this closes.
+    const preFixSlug = inputs.stack.split("/")[1];
+    if (preFixSlug === undefined) throw new Error("expected slug");
+    expect(preFixSlug).toBe("research");
+    expect(ownFederatedSubjectScopePrefix(inputs.principal, preFixSlug)).not.toBe(bootPrefix);
+  });
+
+  test("accept-list the join persists from bootStackSlug PASSES boot; the pre-fix flag-slug list is REFUSED (no split verdict)", () => {
+    const res = deriveJoinInputs(
+      "metafactory",
+      { stack: "andreas/research" },
+      "/cfg",
+      reader(DRIFTED),
+      "darwin",
+    );
+    const inputs = res.inputs;
+    if (inputs === undefined) throw new Error("expected inputs");
+
+    // What the join own-scope guard builds + persists (network-lib.ts): the
+    // own-scope accept-list from bootStackSlug ("work").
+    const acceptFromBoot = ownAcceptSubjects({
+      principal: inputs.principal,
+      stack: inputs.bootStackSlug,
+    });
+    expect(acceptFromBoot.every((s) => s.startsWith("federated.andreas.work."))).toBe(true);
+
+    // The PRE-FIX path built the accept-list from the flag/locator slug ("research").
+    const preFixSlug = inputs.stack.split("/")[1];
+    if (preFixSlug === undefined) throw new Error("expected slug");
+    const acceptFromFlag = ownAcceptSubjects({
+      principal: inputs.principal,
+      stack: preFixSlug,
+    });
+
+    // AGREEMENT: the daemon boot validator ACCEPTS exactly what the fixed join
+    // writes — both accept, no split.
+    expect(() => CortexConfigSchema.parse(bootConfigWithAccept(acceptFromBoot))).not.toThrow();
+    // And it REFUSES the pre-fix flag-slug list — proving the latent split the
+    // fix closes (join would have written a config the daemon bricks on).
+    expect(() => CortexConfigSchema.parse(bootConfigWithAccept(acceptFromFlag))).toThrow();
+  });
+
+  test("BORN-ALIGNED stack (no drift) is unchanged: bootStackSlug == the flag/locator slug", () => {
+    // FULL is born-aligned (stack.id andreas/meta-factory); no --stack override.
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(FULL), "darwin");
+    const inputs = res.inputs;
+    if (inputs === undefined) throw new Error("expected inputs");
+    // The two derivations coincide for a born-aligned stack — the exact
+    // pre-fix behaviour, preserved.
+    expect(inputs.bootStackSlug).toBe("meta-factory");
+    expect(inputs.stack.split("/")[1]).toBe("meta-factory");
+    expect(inputs.bootStackSlug).toBe(deriveStackId(FULL).stack);
   });
 });

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -40,6 +40,7 @@
 import type { LoadedConfig } from "../../../common/config/loader";
 import type { ServicePlatform } from "../../../common/nats/nats-service-manager";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
+import { deriveStackId } from "../../../common/types/stack";
 import { resolveRegistryAnchor } from "./default-registry";
 // network-leaf-package import removed — ADR-0015 retired O-4b / Model-A.
 
@@ -50,8 +51,28 @@ import { resolveRegistryAnchor } from "./default-registry";
 /** The five join inputs `cortex network join` previously demanded as flags. */
 export interface DerivedJoinInputs {
   principal: string;
-  /** `{principal}/{slug}` canonical stack id. */
+  /**
+   * `{principal}/{slug}` canonical stack id — flag-honouring. `--stack` wins,
+   * else `stack.id`, else `{principal}/default` (see {@link resolveStack}). This
+   * feeds the LOCATOR / write-path (`portsConfigFromInputs` → `stackId`), which
+   * per ADR-0004 DA-5 follows the file the daemon composes policy from — NOT the
+   * federation-identity authority.
+   */
   stack: string;
+  /**
+   * C-1364 — the boot-authoritative own-scope stack slug: `deriveStackId(cfg).stack`,
+   * the trailing segment of `stack.id` ALONE (ADR-0004: `stack.id` is the single
+   * stack-slug authority). This is the SAME derivation the daemon boot validator
+   * runs (`CortexConfigSchema` federated subject-scope superRefine →
+   * `deriveStackId(config).stack`), so the join own-scope guard and boot can never
+   * split on a drifted stack (locator/`--stack` slug ≠ `stack.id` trailing segment).
+   * Unlike {@link stack} it is flag-INDEPENDENT — a `--stack` override changes the
+   * write-path locator but must NOT move the federation identity boot enforces.
+   * The join own-scope guard (`ownAcceptSubjects` / `ownFederatedSubjectScopePrefix`
+   * / `isFederatedSubjectInOwnScope` in `network-lib.ts`) MUST build its
+   * `federated.{me}.{stack}.` scope from THIS, never from {@link stack}'s slug.
+   */
+  bootStackSlug: string;
   seedPath: string;
   registryUrl: string;
   registryPubkey?: string;
@@ -359,6 +380,14 @@ export function deriveJoinInputs(
 
   const stack = resolveStack(principal, overrides.stack, cfg);
 
+  // C-1364 — the boot-authoritative own-scope stack slug. Derived from the SAME
+  // loaded config the daemon boots from, via the SAME resolver the boot
+  // validator uses (`deriveStackId(cfg).stack`, ADR-0004 / ADR-0001 superRefine).
+  // This is flag-INDEPENDENT on purpose: a `--stack` override retargets the
+  // write-path locator (DA-5) but must never move the federation identity boot
+  // enforces, or the join own-scope guard and boot would split on a drifted stack.
+  const bootStackSlug = deriveStackId(cfg).stack;
+
   // seed-path — flag wins, else stack.nkey_seed_path.
   const seedPath = overrides.seedPath ?? cfg.stack?.nkey_seed_path;
   if (seedPath === undefined || seedPath === "") {
@@ -473,6 +502,7 @@ export function deriveJoinInputs(
     inputs: {
       principal,
       stack,
+      bootStackSlug,
       seedPath,
       registryUrl,
       ...(registryPubkey !== undefined && { registryPubkey }),

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -893,7 +893,16 @@ async function runJoin(
 
   const stack: JoiningStack = {
     principalId: inputs.principal,
-    stackSlug: slugRes.slug,
+    // C-1364 — the own-scope federation identity MUST derive from `stack.id` via
+    // `deriveStackId` (ADR-0004), the SAME single authority the daemon boot
+    // validator uses (`CortexConfigSchema` federated subject-scope superRefine).
+    // `slugRes.slug` (below) is the flag/locator-honouring slug and stays the
+    // write-path target per ADR-0004 DA-5 — but a `--stack` override or a drifted
+    // stack (locator slug ≠ `stack.id` trailing segment) would make it diverge
+    // from what boot enforces, letting a config pass the join own-scope guard yet
+    // fail daemon boot (or be falsely refused). Pin the guard to `bootStackSlug`
+    // so guard + boot can never split. See cortex#1364.
+    stackSlug: inputs.bootStackSlug,
     credentials: expandTilde(inputs.credsPath),
     account: inputs.account,
     // C-1224 (ADR-0013 Model B) — pass the secret-auth leaf material (when


### PR DESCRIPTION
## What

The `cortex network join` own-scope guard and the daemon boot validator each derived the joining stack's federation identity from a **different** source, on the **same** validation contract:

- **Join guard** (`network-lib.ts` `joinNetwork` → `ownAcceptSubjects` / `ownFederatedSubjectScopePrefix` / `isFederatedSubjectInOwnScope`) built its `federated.{me}.{stack}.` own-scope from `JoiningStack.stackSlug`, sourced from the **flag/locator-honouring** `resolveStackSlug(inputs.stack)`.
- **Boot** (`CortexConfigSchema` federated subject-scope superRefine) derives the same prefix from `deriveStackId(config).stack` — i.e. `stack.id`'s trailing segment, the **single stack-slug authority** per ADR-0004.

For a **born-aligned** stack they agree by luck. For a **drifted** stack — a `--stack` override, or a locator slug ≠ `stack.id` trailing segment (the class ADR-0004's `warn_stack_identity_drift` detector exists to catch) — they **split**: the join persists an accept-list scoped to one identity the daemon then **refuses to boot** against, or **falsely refuses** a valid config.

## How

Thread `bootStackSlug = deriveStackId(cfg).stack` out of `deriveJoinInputs` (it already loads the exact config the daemon boots from) and pin `JoiningStack.stackSlug` to it. The join own-scope guard now derives its identity from the **same `deriveStackId` authority** boot uses — one source, cannot drift.

The flag/locator slug (`slugRes.slug`) is **retained** for the write-path target (`portsConfigFromInputs` → `stackId`), which per **ADR-0004 DA-5** correctly follows the file the daemon composes policy from. Federation identity (from `stack.id`) and write-path locator are orthogonal; only the identity was wrong.

Direction check: ADR-0004 makes `stack.id` the single authority, and `deriveStackId` reads `stack.id` — so converging **onto** `deriveStackId` (not the flag-based derivation) is the correct direction, not a coin-flip.

## Both derivation sites — before → after

| Site | Before | After |
|---|---|---|
| Join guard identity | `network.ts:896` `stackSlug: slugRes.slug` (flag/locator) | `network.ts:903` `stackSlug: inputs.bootStackSlug` (`deriveStackId(cfg).stack`) |
| Source of that slug | `network.ts:872` `resolveStackSlug(inputs.principal, inputs.stack)` | `network-derive.ts:388` `bootStackSlug = deriveStackId(cfg).stack` (flag-independent), returned from `deriveJoinInputs` |
| Boot validator (unchanged) | `cortex-config.ts:3245` `deriveStackId(config).stack` | *(unchanged — this is the authority we converge onto)* |
| Write-path locator (unchanged) | `network.ts:914` `portsConfigFromInputs(…, slugRes.slug, …)` | *(unchanged — ADR-0004 DA-5)* |

## Test — drifted stack, split-verdict proof

`network-derive.test.ts` → `describe("C-1364 …")`, drifted fixture (`stack.id = andreas/work`, joined with `--stack andreas/research`, slug `research` ≠ `work`):

1. **`bootStackSlug` tracks `stack.id`, not the flag** — the `--stack` flag moves `inputs.stack` (locator) to `andreas/research`, but `bootStackSlug` stays `work`; the join-guard prefix equals the boot prefix (`federated.andreas.work.`), and the pre-fix flag-slug prefix (`…research.`) is shown to differ.
2. **End-to-end agreement via the REAL boot validator** — the accept-list the join persists (`ownAcceptSubjects` from `bootStackSlug`) **passes** `CortexConfigSchema.parse`; the pre-fix flag-slug accept-list is **refused** by the same parser. Both accept / both refuse — never split.
3. **Born-aligned unchanged** — a born-aligned stack (`FULL`, no override) has `bootStackSlug === deriveStackId(FULL).stack === the flag/locator slug` (`meta-factory`); pre-fix behaviour preserved. The two existing `deriveJoinInputs` exact-shape assertions were updated to include `bootStackSlug`.

## Four-check results (from `../Cortex-driftguard`)

- `bunx eslint --quiet .` → **0** ✅
- `bunx tsc --noEmit` → **0** ✅
- `bash scripts/check-carveouts.sh` → **PASS** ✅
- `bun test src/cli/cortex/commands src/common/config` → **1405 pass, 0 fail** (5 todo) ✅

Closes #1364. Refs ADR-0004, #1361. Epic #1346 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB