### PR TITLE
harden(mc): C-1410 — verify CF-Access JWT assertion, not the raw email header

### DIFF
--- a/src/common/auth/cf-access-jwt.ts
+++ b/src/common/auth/cf-access-jwt.ts
@@ -1,0 +1,187 @@
+/**
+ * Shared CF Access JWT verifier (cortex#1410).
+ *
+ * WebCrypto-only (no external dependency) so it runs UNCHANGED in both:
+ *   - the CF Worker runtime (dashboard read-endpoint gating), and
+ *   - the local Bun daemon (Mission Control admission-decision Gate 1).
+ *
+ * It relies only on primitives present in both runtimes: `crypto.subtle`,
+ * `fetch`, `atob`, `TextEncoder`/`TextDecoder`.
+ *
+ * Verification is FAIL-CLOSED: any malformed / unsigned / wrong-`aud` /
+ * wrong-`iss` / expired / not-yet-valid token — and any JWKS-fetch failure —
+ * returns `null`. Callers MUST treat `null` as "reject", never as "fall
+ * through to a weaker trust path".
+ *
+ * Extracted from the two near-duplicate copies that previously lived in the
+ * worker (`worker/src/user-auth/middleware/cf-access.ts` and `worker/src/
+ * auth.ts`); both now delegate here. This copy additionally verifies `iss`
+ * (the team issuer) and `nbf`/`iat` that the originals skipped.
+ */
+
+/** CF Access JWKs carry a `kid` that the base `JsonWebKey` type omits. */
+type CfAccessJwk = JsonWebKey & { kid?: string };
+
+export interface CfAccessVerifyOptions {
+  /** The Access application AUD tag the token's `aud` must contain. */
+  readonly aud: string;
+  /** CF Access team slug (e.g. "metafactory") → derives issuer + JWKS URL. */
+  readonly teamDomain: string;
+  /** Clock override (seconds since epoch) for deterministic tests. */
+  readonly nowSeconds?: number;
+  /** Clock-skew tolerance, in seconds (default 60). */
+  readonly clockSkewSeconds?: number;
+  /** `fetch` override for tests (defaults to the global `fetch`). */
+  readonly fetchImpl?: typeof fetch;
+}
+
+const KEY_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes — CF rotates keys slowly.
+const jwksCache = new Map<string, { keys: CfAccessJwk[]; fetchedAt: number }>();
+
+/** CF Access certs (JWKS) endpoint for a team. */
+export function cfAccessCertsUrl(teamDomain: string): string {
+  return `https://${teamDomain}.cloudflareaccess.com/cdn-cgi/access/certs`;
+}
+
+/** CF Access token issuer (`iss`) for a team. */
+export function cfAccessIssuer(teamDomain: string): string {
+  return `https://${teamDomain}.cloudflareaccess.com`;
+}
+
+/** Test seam: drop the module-scoped JWKS cache between cases. */
+export function resetCfAccessJwksCache(): void {
+  jwksCache.clear();
+}
+
+async function getCfAccessKeys(
+  teamDomain: string,
+  fetchImpl: typeof fetch,
+): Promise<CfAccessJwk[]> {
+  const url = cfAccessCertsUrl(teamDomain);
+  const cached = jwksCache.get(url);
+  if (cached && Date.now() - cached.fetchedAt < KEY_CACHE_TTL_MS) {
+    return cached.keys;
+  }
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    throw new Error(`CF Access JWKS fetch failed: ${res.status}`);
+  }
+  const data = (await res.json()) as { keys: CfAccessJwk[] };
+  jwksCache.set(url, { keys: data.keys, fetchedAt: Date.now() });
+  return data.keys;
+}
+
+async function importVerifyKey(jwk: JsonWebKey): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+}
+
+// Returns an ArrayBuffer-backed view (not the bare `Uint8Array`, which widens
+// to `ArrayBufferLike` under bun-types and fails `crypto.subtle` typing).
+function base64urlToBytes(input: string): Uint8Array<ArrayBuffer> {
+  const b64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function decodeJsonSegment(segment: string): unknown {
+  return JSON.parse(new TextDecoder().decode(base64urlToBytes(segment)));
+}
+
+/**
+ * Verify a CF Access JWT and return its decoded payload, or `null` when the
+ * token is not a valid, current, correctly-scoped CF Access assertion.
+ *
+ * Checks (all must pass): three-part shape, `alg === "RS256"`, `aud` contains
+ * the configured audience, `iss` equals the team issuer, `exp` present and not
+ * past, `nbf`/`iat` (when present) not in the future — then the RS256 signature
+ * against the team's JWKS.
+ */
+export async function verifyCfAccessJwt(
+  token: string,
+  opts: CfAccessVerifyOptions,
+): Promise<Record<string, unknown> | null> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const skew = opts.clockSkewSeconds ?? 60;
+  const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000);
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
+
+  let header: { alg?: unknown; kid?: unknown };
+  try {
+    header = decodeJsonSegment(headerB64) as { alg?: unknown; kid?: unknown };
+  } catch (_err: unknown) {
+    return null; // Unparseable header ⇒ reject (fail closed).
+  }
+  if (header.alg !== "RS256") return null;
+  const kid = typeof header.kid === "string" ? header.kid : undefined;
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = decodeJsonSegment(payloadB64) as Record<string, unknown>;
+  } catch (_err: unknown) {
+    return null; // Unparseable payload ⇒ reject.
+  }
+
+  // Audience — the Access application this token was minted for.
+  const aud = payload.aud;
+  const audOk = Array.isArray(aud) ? aud.includes(opts.aud) : aud === opts.aud;
+  if (!audOk) return null;
+
+  // Issuer — the team domain that signed it.
+  if (payload.iss !== cfAccessIssuer(opts.teamDomain)) return null;
+
+  // Expiry — REQUIRED. Absent or past (beyond skew) ⇒ reject.
+  const exp = payload.exp;
+  if (typeof exp !== "number" || exp + skew < now) return null;
+
+  // Not-before — if present, must not be in the future (beyond skew).
+  const nbf = payload.nbf;
+  if (typeof nbf === "number" && nbf - skew > now) return null;
+
+  // Issued-at — if present, must not be in the future (beyond skew).
+  const iat = payload.iat;
+  if (typeof iat === "number" && iat - skew > now) return null;
+
+  let keys: CfAccessJwk[];
+  try {
+    keys = await getCfAccessKeys(opts.teamDomain, fetchImpl);
+  } catch (err: unknown) {
+    // FAIL CLOSED: without the signing keys we cannot verify, so we must NOT
+    // authenticate. Log for ops visibility (`console.*` is cross-runtime).
+    console.error(
+      `cf-access-jwt: JWKS unavailable, failing closed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+
+  const candidates = kid ? keys.filter((k) => k.kid === kid) : keys;
+  // Copy the signed bytes into a length-allocated (ArrayBuffer-backed) view so
+  // it is a `BufferSource` under every lib resolution — TextEncoder.encode's
+  // `ArrayBufferLike` generic otherwise trips crypto.subtle.verify's typing.
+  const encoded = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+  const signed = new Uint8Array(encoded.length);
+  signed.set(encoded);
+  const signature = base64urlToBytes(signatureB64);
+
+  for (const jwk of candidates) {
+    try {
+      const key = await importVerifyKey(jwk);
+      if (await crypto.subtle.verify("RSASSA-PKCS1-v1_5", key, signature, signed)) {
+        return payload;
+      }
+    } catch (_err: unknown) {
+      continue; // This key didn't import/verify; try the next candidate.
+    }
+  }
+  return null;
+}

--- a/src/surface/mc/api/__tests__/networks-admission.test.ts
+++ b/src/surface/mc/api/__tests__/networks-admission.test.ts
@@ -1,18 +1,47 @@
 /**
- * MC-B2 (cortex#1279) — tests for `handleAdmissionDecision`: the two gates
- * (CF-Access principal identity + typed-confirm) and the decider-verdict → HTTP
- * mapping. Pure — the decider is a stub; no bus, no network.
+ * MC-B2 (cortex#1279) + #1410 — tests for `handleAdmissionDecision`: the two
+ * gates (bind-conditioned CF-Access principal identity + typed-confirm) and the
+ * decider-verdict → HTTP mapping.
+ *
+ * Loopback cases are pure (stub decider). Non-loopback cases exercise the REAL
+ * shared CF-Access verifier against a locally-generated RS256 keypair + a
+ * stubbed JWKS fetch — no network.
  */
 
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeAll, beforeEach } from "bun:test";
 import {
   handleAdmissionDecision,
   type AdmissionDecider,
+  type AdmissionDecisionInput,
   type AdmissionDecisionResult,
+  type AdmissionAuthContext,
 } from "../networks-admission";
+import {
+  verifyCfAccessJwt,
+  resetCfAccessJwksCache,
+  cfAccessIssuer,
+} from "../../../../common/auth/cf-access-jwt";
+
+const TEAM = "metafactory";
+const AUD = "test-access-aud-tag";
+const ISS = cfAccessIssuer(TEAM);
 
 function decider(result: AdmissionDecisionResult): AdmissionDecider {
   return { decide: () => Promise.resolve(result) };
+}
+
+/** A decider that records its input (to assert the resolved principal). */
+function recordingDecider(): { decider: AdmissionDecider; calls: AdmissionDecisionInput[] } {
+  const calls: AdmissionDecisionInput[] = [];
+  return {
+    calls,
+    decider: {
+      decide: (input) => {
+        calls.push(input);
+        return Promise.resolve({ ok: true, status: "ADMITTED", requestId: input.requestId });
+      },
+    },
+  };
 }
 
 /** A decider that must NOT be called (asserts the gate fired first). */
@@ -29,59 +58,221 @@ const OK_BODY = {
   confirm: "req-abc-123",
 };
 
+/** Loopback auth context (current behavior): trusts the email header. */
+function loopbackAuth(email: string | undefined): AdmissionAuthContext {
+  return { isLoopback: true, emailHeader: email, jwtAssertion: undefined };
+}
+
+/**
+ * Non-loopback auth context. `emailHeader` is deliberately set to a FORGED
+ * value to prove it is ignored off loopback — only the verified JWT counts.
+ */
+function nonLoopbackAuth(
+  jwt: string | undefined,
+  verifyJwt?: AdmissionAuthContext["verifyJwt"],
+): AdmissionAuthContext {
+  return {
+    isLoopback: false,
+    emailHeader: "forged@evil.test",
+    jwtAssertion: jwt,
+    ...(verifyJwt ? { verifyJwt } : {}),
+  };
+}
+
 async function body(res: Response): Promise<Record<string, unknown>> {
   return (await res.json()) as Record<string, unknown>;
 }
 
-describe("handleAdmissionDecision — gate 1: CF-Access principal identity", () => {
+// ── Crypto helpers for the non-loopback (verified-JWT) cases ───────────────
+
+function b64url(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function b64urlStr(s: string): string {
+  return b64url(new TextEncoder().encode(s));
+}
+
+const RSA_PARAMS = {
+  name: "RSASSA-PKCS1-v1_5",
+  modulusLength: 2048,
+  publicExponent: new Uint8Array([1, 0, 1]),
+  hash: "SHA-256",
+} as const;
+
+let signKey: CryptoKey; // the "real" signer whose pubkey is in the stub JWKS
+let wrongKey: CryptoKey; // an off-JWKS signer, for the bad-signature case
+let jwksJwk: JsonWebKey & { kid: string };
+
+async function mint(
+  key: CryptoKey,
+  claims: Record<string, unknown>,
+  kid = "test-kid",
+): Promise<string> {
+  const header = b64urlStr(JSON.stringify({ alg: "RS256", kid, typ: "JWT" }));
+  const payload = b64urlStr(JSON.stringify(claims));
+  const data = new TextEncoder().encode(`${header}.${payload}`);
+  const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, data);
+  return `${header}.${payload}.${b64url(new Uint8Array(sig))}`;
+}
+
+/** stub fetch returning our single-key JWKS. */
+const stubFetch = ((): Promise<Response> =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ keys: [jwksJwk] }) } as unknown as Response)) as unknown as typeof fetch;
+
+/** stub fetch that fails (JWKS unavailable). */
+const failFetch = ((): Promise<Response> =>
+  Promise.resolve({ ok: false, status: 503 } as unknown as Response)) as unknown as typeof fetch;
+
+/** Build a verifier bound to aud+team, an injected fetch, and a fixed clock. */
+function verifierWith(
+  fetchImpl: typeof fetch,
+  nowSeconds: number,
+): AdmissionAuthContext["verifyJwt"] {
+  return (token: string) =>
+    verifyCfAccessJwt(token, { aud: AUD, teamDomain: TEAM, fetchImpl, nowSeconds });
+}
+
+const NOW = 1_700_000_000;
+function validClaims(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return { aud: AUD, iss: ISS, email: "principal@example.com", iat: NOW - 30, exp: NOW + 3600, ...over };
+}
+
+beforeAll(async () => {
+  const kp = await crypto.subtle.generateKey(RSA_PARAMS, true, ["sign", "verify"]);
+  const kp2 = await crypto.subtle.generateKey(RSA_PARAMS, true, ["sign", "verify"]);
+  signKey = kp.privateKey;
+  wrongKey = kp2.privateKey;
+  const exported = await crypto.subtle.exportKey("jwk", kp.publicKey);
+  jwksJwk = { ...exported, kid: "test-kid", alg: "RS256" };
+});
+
+beforeEach(() => {
+  resetCfAccessJwksCache();
+});
+
+describe("handleAdmissionDecision — gate 1 (loopback): CF-Access email header", () => {
   it("401 when the principal identity is absent", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, undefined, OK_BODY);
+    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth(undefined), OK_BODY);
     expect(res.status).toBe(401);
     expect((await body(res)).error).toBe("unauthenticated");
   });
 
   it("401 when the principal identity is blank/whitespace", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, "   ", OK_BODY);
+    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth("   "), OK_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it("trusts the email header on loopback (no JWT needed) — reaches the decider", async () => {
+    const { decider: d, calls } = recordingDecider();
+    const res = await handleAdmissionDecision(d, loopbackAuth("op@x.io"), OK_BODY);
+    expect(res.status).toBe(200);
+    expect(calls[0]?.principal).toBe("op@x.io");
+  });
+});
+
+describe("handleAdmissionDecision — gate 1 (non-loopback): verified CF-Access JWT (#1410)", () => {
+  it("503 fail-closed when cfAccess is not configured (no verifier)", async () => {
+    const res = await handleAdmissionDecision(throwingDecider, nonLoopbackAuth("x.y.z"), OK_BODY);
+    expect(res.status).toBe(503);
+    expect((await body(res)).error).toBe("not_configured");
+  });
+
+  it("401 when the JWT assertion header is absent", async () => {
+    const auth = nonLoopbackAuth(undefined, verifierWith(stubFetch, NOW));
+    const res = await handleAdmissionDecision(throwingDecider, auth, OK_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts a valid JWT and takes the principal from the verified email claim (ignoring the forged header)", async () => {
+    const token = await mint(signKey, validClaims());
+    const { decider: d, calls } = recordingDecider();
+    const res = await handleAdmissionDecision(d, nonLoopbackAuth(token, verifierWith(stubFetch, NOW)), OK_BODY);
+    expect(res.status).toBe(200);
+    expect(calls[0]?.principal).toBe("principal@example.com");
+    expect(calls[0]?.principal).not.toBe("forged@evil.test");
+  });
+
+  it("401 fail-closed on a bad signature (signed by an off-JWKS key)", async () => {
+    const token = await mint(wrongKey, validClaims());
+    const res = await handleAdmissionDecision(throwingDecider, nonLoopbackAuth(token, verifierWith(stubFetch, NOW)), OK_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 fail-closed on an expired token", async () => {
+    const token = await mint(signKey, validClaims({ exp: NOW - 3600, iat: NOW - 7200 }));
+    const res = await handleAdmissionDecision(throwingDecider, nonLoopbackAuth(token, verifierWith(stubFetch, NOW)), OK_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 fail-closed on the wrong audience", async () => {
+    const token = await mint(signKey, validClaims({ aud: "some-other-app" }));
+    const res = await handleAdmissionDecision(throwingDecider, nonLoopbackAuth(token, verifierWith(stubFetch, NOW)), OK_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 fail-closed on the wrong issuer", async () => {
+    const token = await mint(signKey, validClaims({ iss: cfAccessIssuer("someone-else") }));
+    const res = await handleAdmissionDecision(throwingDecider, nonLoopbackAuth(token, verifierWith(stubFetch, NOW)), OK_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 fail-closed when nbf is in the future", async () => {
+    const token = await mint(signKey, validClaims({ nbf: NOW + 3600, exp: NOW + 7200 }));
+    const res = await handleAdmissionDecision(throwingDecider, nonLoopbackAuth(token, verifierWith(stubFetch, NOW)), OK_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 fail-closed when the JWKS fetch fails (never falls open)", async () => {
+    const token = await mint(signKey, validClaims());
+    const res = await handleAdmissionDecision(throwingDecider, nonLoopbackAuth(token, verifierWith(failFetch, NOW)), OK_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 fail-closed when the verified JWT carries no email claim", async () => {
+    const token = await mint(signKey, validClaims({ email: undefined }));
+    const res = await handleAdmissionDecision(throwingDecider, nonLoopbackAuth(token, verifierWith(stubFetch, NOW)), OK_BODY);
     expect(res.status).toBe(401);
   });
 });
 
 describe("handleAdmissionDecision — gate 2: body + typed-confirm", () => {
   it("400 when the body is not an object", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", null);
+    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth("op@x.io"), null);
     expect(res.status).toBe(400);
   });
 
   it("400 when request_id is invalid", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, request_id: "!", confirm: "!" });
+    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth("op@x.io"), { ...OK_BODY, request_id: "!", confirm: "!" });
     expect(res.status).toBe(400);
   });
 
   it("400 when network_id is invalid", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, network_id: "Bad Net" });
+    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth("op@x.io"), { ...OK_BODY, network_id: "Bad Net" });
     expect(res.status).toBe(400);
   });
 
   it("400 when decision is neither admit nor reject", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, decision: "revoke" });
+    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth("op@x.io"), { ...OK_BODY, decision: "revoke" });
     expect(res.status).toBe(400);
   });
 
   it("400 when confirm does not exactly echo request_id (typed-confirm gate)", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, confirm: "req-abc-124" });
+    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth("op@x.io"), { ...OK_BODY, confirm: "req-abc-124" });
     expect(res.status).toBe(400);
     expect((await body(res)).error).toBe("confirm must exactly match request_id");
   });
 
   it("400 when confirm has stray whitespace (exact echo, not trimmed)", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, "op@x.io", { ...OK_BODY, confirm: "req-abc-123 " });
+    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth("op@x.io"), { ...OK_BODY, confirm: "req-abc-123 " });
     expect(res.status).toBe(400);
   });
 });
 
 describe("handleAdmissionDecision — decider wiring", () => {
   it("503 when the decider is not wired (null)", async () => {
-    const res = await handleAdmissionDecision(null, "op@x.io", OK_BODY);
+    const res = await handleAdmissionDecision(null, loopbackAuth("op@x.io"), OK_BODY);
     expect(res.status).toBe(503);
     expect((await body(res)).error).toBe("not_configured");
   });
@@ -89,7 +280,7 @@ describe("handleAdmissionDecision — decider wiring", () => {
   it("200 + status when the decider admits", async () => {
     const res = await handleAdmissionDecision(
       decider({ ok: true, status: "ADMITTED", requestId: "req-abc-123" }),
-      "op@x.io",
+      loopbackAuth("op@x.io"),
       OK_BODY,
     );
     expect(res.status).toBe(200);
@@ -101,7 +292,7 @@ describe("handleAdmissionDecision — decider wiring", () => {
   it("200 + REJECTED when rejecting", async () => {
     const res = await handleAdmissionDecision(
       decider({ ok: true, status: "REJECTED", requestId: "req-abc-123" }),
-      "op@x.io",
+      loopbackAuth("op@x.io"),
       { ...OK_BODY, decision: "reject" },
     );
     expect(res.status).toBe(200);
@@ -111,7 +302,7 @@ describe("handleAdmissionDecision — decider wiring", () => {
   it("403 when the registry says not_authorized", async () => {
     const res = await handleAdmissionDecision(
       decider({ ok: false, reason: "not_authorized", detail: "not an admin" }),
-      "op@x.io",
+      loopbackAuth("op@x.io"),
       OK_BODY,
     );
     expect(res.status).toBe(403);
@@ -130,7 +321,7 @@ describe("handleAdmissionDecision — decider wiring", () => {
       [{ ok: false, reason: "unreachable", detail: "x" }, 502],
     ];
     for (const [result, status] of cases) {
-      const res = await handleAdmissionDecision(decider(result), "op@x.io", OK_BODY);
+      const res = await handleAdmissionDecision(decider(result), loopbackAuth("op@x.io"), OK_BODY);
       expect(res.status).toBe(status);
     }
   });

--- a/src/surface/mc/api/networks-admission.ts
+++ b/src/surface/mc/api/networks-admission.ts
@@ -14,12 +14,17 @@
  *
  * ## The two gates (both required — reject if either is absent)
  *
- *  1. **CF-Access principal identity.** The `Cf-Access-Authenticated-User-Email`
- *     header, injected by Cloudflare Access at the authenticated edge (the same
- *     identity the worker's `getCfAccessEmail` derives). Absent/empty ⇒ 401. The
- *     local MC server additionally binds loopback-only (server.ts SEV-2), so this
- *     identity gate composes on top of the loopback boundary that already
- *     protects the on-disk seed.
+ *  1. **CF-Access principal identity — bind-conditioned (#1410).** On a
+ *     **loopback** bind (every current deployment; server.ts SEV-2) the
+ *     `Cf-Access-Authenticated-User-Email` header is trusted as-is — the
+ *     request can only reach the local signer over the principal's own
+ *     loopback interface (the invariant the #1279 http test locks). On a
+ *     **non-loopback** bind that header is forgeable, so the route instead
+ *     REQUIRES a `Cf-Access-Jwt-Assertion` verified against the CF Access team
+ *     JWKS (`aud`/`iss`/`exp`/`nbf` + RS256 signature) and takes the principal
+ *     from the verified `email` claim. Fail-closed off loopback: no
+ *     `cfAccess.aud` configured ⇒ 503; missing/invalid JWT ⇒ 401. This turns
+ *     the loopback bind into defense-in-depth rather than the sole gate.
  *  2. **Typed-confirm.** The client must echo the target `request_id` in the
  *     `confirm` field — the deliberate, mirror of the CLI's
  *     `cortex network admit <request-id> --apply` posture (the principal types the
@@ -78,6 +83,46 @@ export interface AdmissionDecider {
 
 /** The `Cf-Access-Authenticated-User-Email` header (CF Access injects it at the edge). */
 export const CF_ACCESS_EMAIL_HEADER = "Cf-Access-Authenticated-User-Email";
+
+/** The signed `Cf-Access-Jwt-Assertion` header (the JWT CF Access injects at the edge). */
+export const CF_ACCESS_JWT_HEADER = "Cf-Access-Jwt-Assertion";
+
+/** Hostnames that denote a loopback bind. Single source of "is this loopback". */
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(["127.0.0.1", "::1", "localhost"]);
+
+/**
+ * cortex#1410 — whether an MC bind hostname is a loopback interface.
+ *
+ * On a **loopback** bind the admission route trusts the CF-Access email header
+ * directly: the request can only originate from the principal's own machine
+ * (the boundary the #1279 http test locks). On **any other** bind that header
+ * is trivially forgeable, so the route instead requires a CF-Access JWT
+ * verified against the team JWKS. An empty/unknown hostname is treated as
+ * NON-loopback (fail-safe → demands the JWT).
+ */
+export function isLoopbackBind(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname.trim().toLowerCase());
+}
+
+/**
+ * Gate-1 auth inputs, resolved by the server per request. The bind decides
+ * which identity proof is required (see {@link isLoopbackBind}).
+ */
+export interface AdmissionAuthContext {
+  /** True when MC is bound to a loopback interface. */
+  isLoopback: boolean;
+  /** Raw `Cf-Access-Authenticated-User-Email` — trusted ONLY on a loopback bind. */
+  emailHeader: string | undefined;
+  /** Raw `Cf-Access-Jwt-Assertion` — verified on a non-loopback bind. */
+  jwtAssertion: string | undefined;
+  /**
+   * CF-Access JWT verifier, pre-bound to the configured `aud` + `teamDomain`.
+   * Present iff `cfAccess.aud` is configured. On a non-loopback bind its
+   * ABSENCE fails the route closed (503). Returns the verified claims, or
+   * `null` to reject (fail closed).
+   */
+  verifyJwt?: (token: string) => Promise<Record<string, unknown> | null>;
+}
 
 /** The POST body the dashboard sends. */
 interface AdmissionDecisionBody {
@@ -170,32 +215,110 @@ function parseBody(
 }
 
 /**
- * Handle `POST /api/networks/admission-decision`.
+ * Resolve the CF-Access principal for Gate 1 — bind-conditioned (#1410):
  *
- * @param decider   The injected signer seam. `null` ⇒ 503 (no
- *                  federation/registry/signing identity configured).
- * @param principal The CF-Access principal email, extracted by the server from
- *                  {@link CF_ACCESS_EMAIL_HEADER}. Empty/undefined ⇒ 401.
- * @param rawBody   The parsed JSON body (server already enforced the size cap).
+ *  - **Loopback bind:** trust the `Cf-Access-Authenticated-User-Email` header
+ *    as-is (unchanged pre-#1410 behavior; the loopback boundary is the gate,
+ *    locked by the #1279 http test). Empty ⇒ 401.
+ *  - **Non-loopback bind:** the raw email header is forgeable, so REQUIRE a
+ *    CF-Access JWT verified against the team JWKS; the principal comes from the
+ *    verified `email` claim. Fails closed on every branch:
+ *      · `cfAccess.aud` not configured (no verifier) ⇒ 503
+ *      · missing JWT header ⇒ 401
+ *      · JWT fails verification (sig/aud/iss/exp/nbf) ⇒ 401
+ *      · verified JWT carries no `email` claim ⇒ 401
+ *
+ * Returns the resolved principal email, or a `Response` to return verbatim.
  */
-export async function handleAdmissionDecision(
-  decider: AdmissionDecider | null,
-  principal: string | undefined,
-  rawBody: unknown,
-): Promise<Response> {
-  // Gate 1 — a CF-Access principal identity is required for a mutation.
-  const who = (principal ?? "").trim();
-  if (who.length === 0) {
+async function resolveAdmissionPrincipal(
+  auth: AdmissionAuthContext,
+): Promise<string | Response> {
+  if (auth.isLoopback) {
+    const who = (auth.emailHeader ?? "").trim();
+    if (who.length === 0) {
+      return json(
+        {
+          error: "unauthenticated",
+          detail:
+            "a CF-Access authenticated principal identity is required to admit/reject " +
+            `(missing/empty ${CF_ACCESS_EMAIL_HEADER}). This mutation is not available on an unauthenticated request.`,
+        },
+        401,
+      );
+    }
+    return who;
+  }
+
+  // Non-loopback: do NOT trust the raw email header — verify the JWT.
+  if (!auth.verifyJwt) {
+    return json(
+      {
+        error: "not_configured",
+        detail:
+          "cf-access is not configured for a non-loopback Mission Control bind — set " +
+          "`cfAccess.aud` (the Access application audience) so admit/reject can verify " +
+          `the ${CF_ACCESS_JWT_HEADER}. Refusing to trust the raw email header off loopback.`,
+      },
+      503,
+    );
+  }
+
+  const token = (auth.jwtAssertion ?? "").trim();
+  if (token.length === 0) {
     return json(
       {
         error: "unauthenticated",
         detail:
-          "a CF-Access authenticated principal identity is required to admit/reject " +
-          `(missing/empty ${CF_ACCESS_EMAIL_HEADER}). This mutation is not available on an unauthenticated request.`,
+          "a verified CF-Access JWT is required to admit/reject on a non-loopback bind " +
+          `(missing/empty ${CF_ACCESS_JWT_HEADER}).`,
       },
       401,
     );
   }
+
+  const claims = await auth.verifyJwt(token);
+  if (claims === null) {
+    return json(
+      {
+        error: "unauthenticated",
+        detail:
+          "the CF-Access JWT failed verification (bad signature, wrong audience/issuer, " +
+          "expired, or not yet valid). Refusing to admit/reject.",
+      },
+      401,
+    );
+  }
+
+  const email = typeof claims.email === "string" ? claims.email.trim() : "";
+  if (email.length === 0) {
+    return json(
+      {
+        error: "unauthenticated",
+        detail: "the verified CF-Access JWT carries no `email` claim to attribute the decision to.",
+      },
+      401,
+    );
+  }
+  return email;
+}
+
+/**
+ * Handle `POST /api/networks/admission-decision`.
+ *
+ * @param decider The injected signer seam. `null` ⇒ 503 (no
+ *                federation/registry/signing identity configured).
+ * @param auth    Gate-1 auth inputs (bind-conditioned; see
+ *                {@link resolveAdmissionPrincipal}).
+ * @param rawBody The parsed JSON body (server already enforced the size cap).
+ */
+export async function handleAdmissionDecision(
+  decider: AdmissionDecider | null,
+  auth: AdmissionAuthContext,
+  rawBody: unknown,
+): Promise<Response> {
+  // Gate 1 — a CF-Access principal identity is required for a mutation.
+  const who = await resolveAdmissionPrincipal(auth);
+  if (who instanceof Response) return who;
 
   // Gate 2 — body shape + typed-confirm.
   const parsed = parseBody(rawBody);

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -6,7 +6,7 @@ import { readFileSync, existsSync } from "fs";
 import { parse as parseYaml } from "yaml";
 import { join } from "path";
 import { homedir } from "os";
-import type { Config, LogLevel } from "./types";
+import type { Config, LogLevel, CfAccessConfig } from "./types";
 import { resolveConfigFilePath } from "../../common/config/config-path";
 
 const VALID_LOG_LEVELS: ReadonlySet<LogLevel> = new Set([
@@ -95,6 +95,34 @@ export function loadConfig(configPath?: string): Readonly<Config> {
   const hooks = parsed.hooks as Record<string, unknown> | undefined;
   const ws = parsed.ws as Record<string, unknown> | undefined;
 
+  // cortex#1410 — CF Access binding (only meaningful on a non-loopback bind).
+  // Parsed strictly: `cfAccess.aud` must be a non-empty string when the block
+  // is present; a malformed block throws rather than silently disabling the
+  // gate on a non-loopback MC.
+  const cfAccessRaw = parsed.cfAccess as Record<string, unknown> | undefined;
+  let cfAccess: CfAccessConfig | undefined;
+  if (cfAccessRaw !== undefined) {
+    if (typeof cfAccessRaw.aud !== "string" || cfAccessRaw.aud.trim() === "") {
+      throw new Error(
+        `cfAccess.aud must be a non-empty string in ${resolvedPath} (the Access application audience tag)`,
+      );
+    }
+    if (
+      cfAccessRaw.teamDomain !== undefined &&
+      (typeof cfAccessRaw.teamDomain !== "string" || cfAccessRaw.teamDomain.trim() === "")
+    ) {
+      throw new Error(
+        `cfAccess.teamDomain must be a non-empty string when set in ${resolvedPath}`,
+      );
+    }
+    cfAccess = {
+      aud: cfAccessRaw.aud,
+      ...(typeof cfAccessRaw.teamDomain === "string"
+        ? { teamDomain: cfAccessRaw.teamDomain }
+        : {}),
+    };
+  }
+
   let level: LogLevel = DEFAULT_CONFIG.log.level;
   if (typeof log?.level === "string") {
     if (!VALID_LOG_LEVELS.has(log.level as LogLevel)) {
@@ -147,6 +175,7 @@ export function loadConfig(configPath?: string): Readonly<Config> {
           ? ws.maxClients
           : DEFAULT_CONFIG.ws.maxClients,
     },
+    ...(cfAccess ? { cfAccess } : {}),
   };
 
   return Object.freeze(config);

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -44,8 +44,12 @@ import { handleListNetworks, type NetworksView } from "./api/networks";
 import {
   handleAdmissionDecision,
   CF_ACCESS_EMAIL_HEADER,
+  CF_ACCESS_JWT_HEADER,
+  isLoopbackBind,
   type AdmissionDecider,
+  type AdmissionAuthContext,
 } from "./api/networks-admission";
+import { verifyCfAccessJwt } from "../../common/auth/cf-access-jwt";
 import type {
   LocalAggregationContext,
   LocalAggregationProvider,
@@ -224,6 +228,20 @@ export function startServer(
   const wsRegistry = new WsClientRegistry();
   const maxClients = config.ws.maxClients;
 
+  // cortex#1410 — bind-conditioned Gate 1 for the admission-decision route.
+  // On a loopback bind we keep trusting the CF-Access email header; off
+  // loopback we require a verified CF-Access JWT. Computed once here (the bind
+  // + config are fixed for the server's lifetime) and passed into handleApi.
+  const isLoopback = isLoopbackBind(config.hostname);
+  const cfAccess = config.cfAccess;
+  const cfAccessVerifier: AdmissionAuthContext["verifyJwt"] = cfAccess
+    ? (token: string): Promise<Record<string, unknown> | null> =>
+        verifyCfAccessJwt(token, {
+          aud: cfAccess.aud,
+          teamDomain: cfAccess.teamDomain ?? "metafactory",
+        })
+    : undefined;
+
   const apiDeps: ApiDeps | null = options.processManager
     ? {
         processManager: options.processManager,
@@ -311,6 +329,8 @@ export function startServer(
           localAggregation,
           networks,
           admissionDecider,
+          isLoopback,
+          cfAccessVerifier,
         );
       }
 
@@ -468,7 +488,9 @@ async function handleApi(
   agentPresence: AgentPresenceView | null,
   localAggregation: LocalAggregationContext | null,
   networks: NetworksView | null = null,
-  admissionDecider: AdmissionDecider | null = null
+  admissionDecider: AdmissionDecider | null = null,
+  isLoopback = true,
+  cfAccessVerifier?: AdmissionAuthContext["verifyJwt"]
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -700,10 +722,17 @@ async function handleApi(
     if (req.method !== "POST") {
       return methodNotAllowed(["POST"]);
     }
-    const principal = req.headers.get(CF_ACCESS_EMAIL_HEADER) ?? undefined;
+    const emailHeader = req.headers.get(CF_ACCESS_EMAIL_HEADER) ?? undefined;
+    const jwtAssertion = req.headers.get(CF_ACCESS_JWT_HEADER) ?? undefined;
     const body = await parseJsonBody(req);
     if (body.error) return body.error;
-    return handleAdmissionDecision(admissionDecider, principal, body.value);
+    const auth: AdmissionAuthContext = {
+      isLoopback,
+      emailHeader,
+      jwtAssertion,
+      ...(cfAccessVerifier ? { verifyJwt: cfAccessVerifier } : {}),
+    };
+    return handleAdmissionDecision(admissionDecider, auth, body.value);
   }
 
   // F-17 — principal-driven GitHub iteration import.

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -550,6 +550,23 @@ export interface Config {
   log: { level: LogLevel };
   hooks: HooksConfig;
   ws: WsConfig;
+  /**
+   * cortex#1410 — CF Access verification for the mutating admission-decision
+   * route when MC is bound BEYOND loopback. On a loopback bind this is unused
+   * (the loopback boundary is the gate). On a non-loopback bind it MUST be set,
+   * or the route fails closed: whoever exposes MC non-loopback supplies the
+   * Access application `aud` at deploy time. `teamDomain` defaults to
+   * "metafactory". Omitted entirely on every current (loopback) deployment.
+   */
+  cfAccess?: CfAccessConfig;
+}
+
+/** cortex#1410 — CF Access application binding for non-loopback MC. */
+export interface CfAccessConfig {
+  /** The Access application AUD tag the CF-Access JWT must be scoped to. */
+  aud: string;
+  /** CF Access team slug → issuer + JWKS URL. Defaults to "metafactory". */
+  teamDomain?: string;
 }
 
 export interface WsConfig {

--- a/src/surface/mc/worker/src/auth.ts
+++ b/src/surface/mc/worker/src/auth.ts
@@ -10,6 +10,7 @@
 
 import type { Context, Next } from "hono";
 import type { Env } from "./index";
+import { verifyCfAccessJwt } from "../../../../common/auth/cf-access-jwt";
 
 // =============================================================================
 // S-005: Audit Logging
@@ -128,110 +129,18 @@ export async function requireAdmin(c: Context<{ Bindings: Env }>, next: Next) {
 // S-001: CF Access JWT Validation
 // =============================================================================
 
-// CF Access team domain — used to fetch public keys for JWT verification
+// CF Access team domain — used to fetch public keys for JWT verification.
 const CF_ACCESS_TEAM = "metafactory";
-const CF_CERTS_URL = `https://${CF_ACCESS_TEAM}.cloudflareaccess.com/cdn-cgi/access/certs`;
-
-// Cache the JWK keyset in module scope (warm across requests within same isolate)
-let cachedKeys: { keys: JsonWebKey[]; fetchedAt: number } | null = null;
-const KEY_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
-
-/** Fetch CF Access public keys (JWKs) with caching. */
-async function getCfAccessKeys(): Promise<JsonWebKey[]> {
-  if (cachedKeys && Date.now() - cachedKeys.fetchedAt < KEY_CACHE_TTL_MS) {
-    return cachedKeys.keys;
-  }
-  const res = await fetch(CF_CERTS_URL);
-  if (!res.ok) throw new Error(`Failed to fetch CF Access certs: ${res.status}`);
-  const data = await res.json() as { keys: JsonWebKey[] };
-  cachedKeys = { keys: data.keys, fetchedAt: Date.now() };
-  return data.keys;
-}
-
-/** Import a JWK as a CryptoKey for RS256 verification. */
-async function importKey(jwk: JsonWebKey): Promise<CryptoKey> {
-  return crypto.subtle.importKey(
-    "jwk",
-    jwk,
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["verify"],
-  );
-}
-
-/** Base64url decode to Uint8Array. */
-function base64urlDecode(str: string): Uint8Array {
-  const padded = str.replace(/-/g, "+").replace(/_/g, "/");
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
-}
-
-/**
- * Validate a CF Access JWT.
- * Returns the decoded payload on success, or null on failure.
- */
-async function validateCfAccessJwt(
-  token: string,
-  audience: string,
-): Promise<Record<string, unknown> | null> {
-  const parts = token.split(".");
-  if (parts.length !== 3) return null;
-
-  const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
-
-  // Decode header to find key ID
-  let header: { kid?: string; alg?: string };
-  try {
-    header = JSON.parse(new TextDecoder().decode(base64urlDecode(headerB64)));
-  } catch (_err: unknown) {
-    return null;
-  }
-  if (header.alg !== "RS256") return null;
-
-  // Decode payload
-  let payload: Record<string, unknown>;
-  try {
-    payload = JSON.parse(new TextDecoder().decode(base64urlDecode(payloadB64)));
-  } catch (_err: unknown) {
-    return null;
-  }
-
-  // Check audience
-  const aud = payload.aud;
-  if (Array.isArray(aud) ? !aud.includes(audience) : aud !== audience) return null;
-
-  // Check expiration
-  const exp = payload.exp as number | undefined;
-  if (exp && exp < Math.floor(Date.now() / 1000)) return null;
-
-  // Verify signature against CF Access public keys
-  const keys = await getCfAccessKeys();
-  const matchingKeys = header.kid
-    ? keys.filter((k) => (k as any).kid === header.kid)
-    : keys;
-
-  const signedData = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
-  const signature = base64urlDecode(signatureB64);
-
-  for (const jwk of matchingKeys) {
-    try {
-      const cryptoKey = await importKey(jwk);
-      const valid = await crypto.subtle.verify("RSASSA-PKCS1-v1_5", cryptoKey, signature, signedData);
-      if (valid) return payload;
-    } catch (_err: unknown) {
-      continue; // Try next key
-    }
-  }
-
-  return null;
-}
 
 /**
  * S-001: Middleware that requires a valid CF Access JWT on read endpoints.
  * The JWT comes from the CF_Authorization cookie (set by CF Access login flow).
  * If CF_ACCESS_AUD is not configured, this middleware is a no-op (allows local dev).
+ *
+ * cortex#1410: signature/claims verification is delegated to the shared,
+ * runtime-agnostic verifier (`src/common/auth/cf-access-jwt.ts`) — which now
+ * also checks `iss` + `nbf`/`iat` and requires `exp` — instead of the private
+ * copy that used to live here.
  */
 export async function requireCfAccess(c: Context<{ Bindings: Env; Variables: { cfAccessEmail: string } }>, next: Next) {
   const audience = c.env.CF_ACCESS_AUD;
@@ -256,7 +165,7 @@ export async function requireCfAccess(c: Context<{ Bindings: Env; Variables: { c
     return c.json({ error: "authentication required" }, 403);
   }
 
-  const payload = await validateCfAccessJwt(token, audience);
+  const payload = await verifyCfAccessJwt(token, { aud: audience, teamDomain: CF_ACCESS_TEAM });
   if (!payload) {
     logAuditEvent(c.env.CORTEX_DB, { eventType: "cf_access_auth", result: "failure", ip, endpoint, method, detail: "invalid or expired JWT" });
     return c.json({ error: "invalid or expired access token" }, 403);

--- a/src/surface/mc/worker/src/user-auth/middleware/cf-access.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/cf-access.ts
@@ -1,48 +1,17 @@
 /**
  * GA-1: CF Access JWT validation helpers.
  * Extracted for reuse by requireRole() — the JWT validation logic itself.
+ *
+ * cortex#1410: the signature/claims verification now lives in the shared,
+ * runtime-agnostic verifier (`src/common/auth/cf-access-jwt.ts`); this module
+ * keeps the worker-shaped helpers (`env`/cookie plumbing) and delegates the
+ * crypto to it. The team domain is a fixed CF constant for this deployment.
  */
 
 import type { AuthBindings } from "../types";
-
-/** CF Access JWKs include `kid` which standard JsonWebKey does not. */
-type CfAccessJwk = JsonWebKey & { kid?: string };
+import { verifyCfAccessJwt } from "../../../../../../common/auth/cf-access-jwt";
 
 const CF_ACCESS_TEAM = "metafactory";
-const CF_CERTS_URL = `https://${CF_ACCESS_TEAM}.cloudflareaccess.com/cdn-cgi/access/certs`;
-
-// Cache the JWK keyset in module scope (warm across requests within same isolate)
-let cachedKeys: { keys: CfAccessJwk[]; fetchedAt: number } | null = null;
-const KEY_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
-
-async function getCfAccessKeys(): Promise<CfAccessJwk[]> {
-  if (cachedKeys && Date.now() - cachedKeys.fetchedAt < KEY_CACHE_TTL_MS) {
-    return cachedKeys.keys;
-  }
-  const res = await fetch(CF_CERTS_URL);
-  if (!res.ok) throw new Error(`Failed to fetch CF Access certs: ${res.status}`);
-  const data = await res.json() as { keys: CfAccessJwk[] };
-  cachedKeys = { keys: data.keys, fetchedAt: Date.now() };
-  return data.keys;
-}
-
-async function importKey(jwk: JsonWebKey): Promise<CryptoKey> {
-  return crypto.subtle.importKey(
-    "jwk",
-    jwk,
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["verify"],
-  );
-}
-
-function base64urlDecode(str: string): Uint8Array {
-  const padded = str.replace(/-/g, "+").replace(/_/g, "/");
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
-}
 
 /**
  * Validate a CF Access JWT.
@@ -52,52 +21,7 @@ export async function validateCfAccessJwt(
   token: string,
   audience: string,
 ): Promise<Record<string, unknown> | null> {
-  const parts = token.split(".");
-  if (parts.length !== 3) return null;
-
-  const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
-
-  let header: { kid?: string; alg?: string };
-  try {
-    header = JSON.parse(new TextDecoder().decode(base64urlDecode(headerB64)));
-  } catch (_err: unknown) {
-    return null;
-  }
-  if (header.alg !== "RS256") return null;
-
-  let payload: Record<string, unknown>;
-  try {
-    payload = JSON.parse(new TextDecoder().decode(base64urlDecode(payloadB64)));
-  } catch (_err: unknown) {
-    return null;
-  }
-
-  const aud = payload.aud;
-  if (Array.isArray(aud) ? !aud.includes(audience) : aud !== audience) return null;
-
-  // Reject tokens without expiry — CF Access tokens should always include exp
-  const exp = payload.exp as number | undefined;
-  if (!exp || exp < Math.floor(Date.now() / 1000)) return null;
-
-  const keys = await getCfAccessKeys();
-  const matchingKeys = header.kid
-    ? keys.filter((k) => k.kid === header.kid)
-    : keys;
-
-  const signedData = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
-  const signature = base64urlDecode(signatureB64);
-
-  for (const jwk of matchingKeys) {
-    try {
-      const cryptoKey = await importKey(jwk);
-      const valid = await crypto.subtle.verify("RSASSA-PKCS1-v1_5", cryptoKey, signature, signedData);
-      if (valid) return payload;
-    } catch (_err: unknown) {
-      continue; // Try next key
-    }
-  }
-
-  return null;
+  return verifyCfAccessJwt(token, { aud: audience, teamDomain: CF_ACCESS_TEAM });
 }
 
 /**


### PR DESCRIPTION
## What

Gate 1 of the MC admission-decision route (`POST /api/networks/admission-decision`) trusted the plaintext `Cf-Access-Authenticated-User-Email` header. That is safe **only** because MC binds loopback-only (#1279 locks the invariant), but fragile: bind MC beyond loopback — or front it with a proxy that doesn't strip client `Cf-Access-*` headers — and the admit/reject action becomes trivially forgeable (any caller sets the email → signs a grant).

This hardens Gate 1 to **verify the signed `Cf-Access-Jwt-Assertion`** against the CF Access team JWKS, so authentication holds independent of the bind. The loopback bind becomes defense-in-depth, not the sole gate.

## How — bind-conditioned fail-closed

The threat model is "if MC is ever bound beyond loopback", so the gate keys on the **bind**, not on AUD-presence:

| Bind | `cfAccess.aud` | Behavior |
|---|---|---|
| **loopback** (127.0.0.1 / ::1 / localhost) | — | Trust the email header **as-is** (unchanged; every current deployment). |
| **non-loopback** | configured | **Require** a verified `Cf-Access-Jwt-Assertion`; principal = verified `email` claim. |
| **non-loopback** | absent | **Fail closed (503)** — refuse rather than trust the raw header off loopback. |

Breaks **zero** current deployments (all loopback), lands the full verification machinery, and flips to full strength automatically when MC is exposed non-loopback + AUD provisioned. Bind is derived from `Config.hostname` via a single `isLoopbackBind()` helper (empty/unknown host ⇒ treated non-loopback = fail-safe).

## Where the team-domain + AUD config comes from

- New optional `cfAccess?: { aud: string; teamDomain?: string }` on the **MC `Config`** (`mission-control.yaml`), parsed strictly (a malformed block throws rather than silently disabling the gate).
- `teamDomain` defaults to **`metafactory`** (the existing hardcoded CF team constant).
- **`aud`** (the Access application audience tag) is **supplied at deploy time** by whoever exposes MC non-loopback — it is a wrangler secret today, not committed. No current (loopback) deployment needs it, so this lands without the value. **Not hardcoded/guessed.**

## Which claims are validated

The shared verifier (`src/common/auth/cf-access-jwt.ts`, WebCrypto RS256 — no new dep) checks, all fail-closed:

- **signature** — RS256 against the team JWKS (10-min cached; **fetch failure ⇒ reject**, never open)
- **`aud`** — contains the configured Access application audience
- **`iss`** — equals `https://<team>.cloudflareaccess.com` *(newly added)*
- **`exp`** — present and not past (required)
- **`nbf` / `iat`** — when present, not in the future *(newly added)*
- **`alg`** must be `RS256`; principal taken from the verified **`email`** claim

Extracted from the two near-duplicate copies previously in the worker (`worker/src/auth.ts` + `worker/src/user-auth/middleware/cf-access.ts`); both now delegate to the shared module (dedup).

## Fail-closed matrix (each → reject, with a test)

| Case (non-loopback) | Result |
|---|---|
| `cfAccess.aud` not configured | **503** |
| missing `Cf-Access-Jwt-Assertion` | **401** |
| bad signature (off-JWKS key) | **401** |
| expired (`exp` past) | **401** |
| wrong `aud` | **401** |
| wrong `iss` | **401** |
| `nbf` in the future | **401** |
| JWKS fetch fails | **401** (never open) |
| verified JWT has no `email` claim | **401** |

Crypto cases use a locally-generated RS256 keypair + stubbed JWKS (no network).

## Loopback invariant retained

The #1279 http test (`networks-admission-http.test.ts`) is **unchanged** and still passes — the loopback bind + email-header trust path is intact.

## Four-check gate (from the worktree)

- `bunx eslint --quiet .` → **0**
- `bunx tsc --noEmit` → **0**
- `bash scripts/check-carveouts.sh` → **PASS**
- `bun test src/surface/mc src/common/auth` → **2144 pass, 0 fail** (1 skip — dashboard SPA, pre-existing)

Closes #1410. Refs #1279. Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB
