### PR TITLE
feat(notify-discord): render pull_request activations, not just issues

### DIFF
--- a/src/bus/__tests__/notify-discord.test.ts
+++ b/src/bus/__tests__/notify-discord.test.ts
@@ -2,9 +2,11 @@
  * F-6 downstream — notify.discord code handler tests.
  *
  * Axes:
- *  1. parseIssueActivation — extracts repo/number/title/url/action; rejects
- *     non-objects / payloads without a repo.
- *  2. renderIssueMessage — formats; truncates over the Discord cap.
+ *  1. parseGithubActivation — extracts repo/kind/number/title/url/action from an
+ *     `issues` OR `pull_request` payload; rejects non-objects / payloads without
+ *     a repo.
+ *  2. renderActivationMessage — formats (New issue / New PR); truncates over the
+ *     Discord cap.
  *  3. createDiscordNotifier handler — known repo → webhook POST (with
  *     allowed_mentions:{parse:[]}) + `posted` visibility; unknown repo →
  *     `skipped` (returns, no throw); unparseable → `skipped`; a failed POST
@@ -20,8 +22,8 @@ import type { DiscordNotifyTarget } from "../../common/types/cortex-config";
 import type { FiredActivation } from "../reflex-activation-listener";
 import {
   createDiscordNotifier,
-  parseIssueActivation,
-  renderIssueMessage,
+  parseGithubActivation,
+  renderActivationMessage,
   type WebhookPostResult,
 } from "../notify-discord";
 
@@ -34,6 +36,13 @@ const ISSUE = {
   action: "opened",
   issue: { number: 42, title: "Bug: thing broke", html_url: "https://github.com/jc/reflex/issues/42" },
   repository: { full_name: "jc/reflex" },
+};
+
+const PR = {
+  action: "opened",
+  pull_request: { number: 7, title: "Add widget", html_url: "https://github.com/jc/reflex/pull/7" },
+  repository: "jc/reflex", // flat full_name — the github_hmac shape reflex-edge fires
+  github_event: "pull_request",
 };
 
 function activation(payload: unknown): FiredActivation {
@@ -77,18 +86,29 @@ const lastNotify = (published: Envelope[]) =>
 
 // ===========================================================================
 
-describe("parseIssueActivation", () => {
+describe("parseGithubActivation", () => {
   test("extracts repo + issue fields", () => {
-    expect(parseIssueActivation(ISSUE)).toEqual({
+    expect(parseGithubActivation(ISSUE)).toEqual({
       repo: "jc/reflex",
+      kind: "issue",
       number: 42,
       title: "Bug: thing broke",
       url: "https://github.com/jc/reflex/issues/42",
       action: "opened",
     });
   });
+  test("extracts repo + PR fields from a pull_request payload (kind=pr)", () => {
+    expect(parseGithubActivation(PR)).toEqual({
+      repo: "jc/reflex",
+      kind: "pr",
+      number: 7,
+      title: "Add widget",
+      url: "https://github.com/jc/reflex/pull/7",
+      action: "opened",
+    });
+  });
   test("accepts the flat `repository` string reflex-edge fires (github_hmac)", () => {
-    const r = parseIssueActivation({
+    const r = parseGithubActivation({
       action: "opened",
       issue: { number: 7, title: "t", html_url: "u" },
       repository: "the-metafactory/cortex", // flat full_name, not nested
@@ -97,29 +117,49 @@ describe("parseIssueActivation", () => {
     expect(r?.repo).toBe("the-metafactory/cortex");
     expect(r?.number).toBe(7);
   });
+  test("non-object issue (null / string) + pull_request present → kind=pr (no PR data under a `New issue` label)", () => {
+    for (const junkIssue of [null, "x", 0]) {
+      const r = parseGithubActivation({
+        action: "opened",
+        issue: junkIssue, // not a usable object → treated as absent
+        pull_request: { number: 3, title: "PR", html_url: "https://github.com/jc/reflex/pull/3" },
+        repository: "jc/reflex",
+      });
+      expect(r?.kind).toBe("pr");
+      expect(r?.number).toBe(3);
+      expect(renderActivationMessage(r!)).toContain("New PR");
+    }
+  });
   test("non-object / missing repo → undefined", () => {
-    expect(parseIssueActivation("nope")).toBeUndefined();
-    expect(parseIssueActivation(null)).toBeUndefined();
-    expect(parseIssueActivation({ issue: { number: 1 } })).toBeUndefined();
+    expect(parseGithubActivation("nope")).toBeUndefined();
+    expect(parseGithubActivation(null)).toBeUndefined();
+    expect(parseGithubActivation({ issue: { number: 1 } })).toBeUndefined();
   });
 });
 
-describe("renderIssueMessage", () => {
+describe("renderActivationMessage", () => {
   test("formats ref + title + url", () => {
-    const msg = renderIssueMessage(parseIssueActivation(ISSUE)!);
+    const msg = renderActivationMessage(parseGithubActivation(ISSUE)!);
     expect(msg).toContain("jc/reflex#42");
     expect(msg).toContain("Bug: thing broke");
     expect(msg).toContain("https://github.com/jc/reflex/issues/42");
   });
+  test("labels a PR activation `New PR` (not `New issue`)", () => {
+    const msg = renderActivationMessage(parseGithubActivation(PR)!);
+    expect(msg).toContain("New PR");
+    expect(msg).not.toContain("New issue");
+    expect(msg).toContain("jc/reflex#7");
+    expect(msg).toContain("https://github.com/jc/reflex/pull/7");
+  });
   test("truncates over the Discord cap", () => {
-    const msg = renderIssueMessage(
-      parseIssueActivation({ repository: { full_name: "a/b" }, issue: { number: 1, title: "x".repeat(5000) } })!,
+    const msg = renderActivationMessage(
+      parseGithubActivation({ repository: { full_name: "a/b" }, issue: { number: 1, title: "x".repeat(5000) } })!,
     );
     expect(msg.length).toBeLessThanOrEqual(1900);
   });
   test("escapes Discord markdown in untrusted titles (masked-link/format injection)", () => {
-    const msg = renderIssueMessage(
-      parseIssueActivation({
+    const msg = renderActivationMessage(
+      parseGithubActivation({
         repository: { full_name: "a/b" },
         issue: { number: 1, title: "[click](https://evil.example) **bold** `code`" },
       })!,
@@ -144,6 +184,21 @@ describe("createDiscordNotifier", () => {
     const body = JSON.parse(poster.calls[0]!.body);
     expect(body.content).toContain("jc/reflex#42");
     expect(body.allowed_mentions).toEqual({ parse: [] });
+    expect(lastNotify(ctrl.published)?.outcome).toBe("posted");
+  });
+
+  test("PR activation → POST with a `New PR` content line", async () => {
+    const ctrl = fakeRuntime();
+    const poster = recordingPoster();
+    const handler = createDiscordNotifier({ runtime: ctrl.runtime, source: SOURCE, targets: TARGETS, env: ENV, post: poster.post });
+
+    await handler(activation(PR));
+    await flush();
+
+    expect(poster.calls).toHaveLength(1);
+    const body = JSON.parse(poster.calls[0]!.body);
+    expect(body.content).toContain("New PR");
+    expect(body.content).toContain("jc/reflex#7");
     expect(lastNotify(ctrl.published)?.outcome).toBe("posted");
   });
 

--- a/src/bus/notify-discord.ts
+++ b/src/bus/notify-discord.ts
@@ -21,10 +21,10 @@
  *
  * ## Trust
  *
- * `activation.payload` is the webhook-controlled GitHub `issues` body — DATA,
- * never instructions (there is no LLM here). We extract typed fields only and
- * send `allowed_mentions: { parse: [] }` so an issue title containing
- * `@everyone` / `@here` / role mentions cannot ping the channel.
+ * `activation.payload` is the webhook-controlled GitHub `issues` / `pull_request`
+ * body — DATA, never instructions (there is no LLM here). We extract typed
+ * fields only and send `allowed_mentions: { parse: [] }` so an issue/PR title
+ * containing `@everyone` / `@here` / role mentions cannot ping the channel.
  */
 
 import type { DiscordNotifyTarget } from "../common/types/cortex-config";
@@ -60,9 +60,11 @@ const defaultPoster: WebhookPoster = async (url, body) => {
   return { ok: res.ok, status: res.status };
 };
 
-/** Typed view of the GitHub `issues` webhook fields we render. */
-export interface ParsedIssueActivation {
+/** Typed view of the GitHub `issues` / `pull_request` webhook fields we render. */
+export interface ParsedGithubActivation {
   repo: string;
+  /** Which GitHub object the fields came from — drives the message label. */
+  kind: "issue" | "pr";
   number: number | undefined;
   title: string | undefined;
   url: string | undefined;
@@ -91,7 +93,7 @@ export interface DiscordNotifierOpts {
 }
 
 /**
- * Extract the repo + issue fields from a fired activation payload.
+ * Extract the repo + issue/PR fields from a fired activation payload.
  *
  * Two `repository` shapes are accepted:
  *  - **flat string** — what reflex-edge's `github_hmac` source fires: it injects
@@ -100,14 +102,20 @@ export interface DiscordNotifierOpts {
  *    github_hmac branch: `repository: repo?.full_name`). Verified on the live
  *    deploy — a signed impulse fired `…payload:{repository:"owner/repo",…}`.
  *    e.g. `"repository":"owner/repo"`.
- *  - **nested `{full_name}`** — the raw GitHub `issues` webhook shape (fallback
- *    for a bus/manual source that forwards the body verbatim).
+ *  - **nested `{full_name}`** — the raw GitHub webhook shape (fallback for a
+ *    bus/manual source that forwards the body verbatim).
+ *
+ * The issue-vs-PR object is chosen by presence: an `issues` delivery carries a
+ * top-level `issue`; a `pull_request` delivery carries a top-level
+ * `pull_request` (both with `number`/`title`/`html_url`). `issue` wins if both
+ * are somehow present. When neither is present the fields are undefined but the
+ * activation still routes on `repo`.
  *
  * Returns undefined when the repo can't be determined (nothing to route on).
  */
-export function parseIssueActivation(
+export function parseGithubActivation(
   payload: unknown,
-): ParsedIssueActivation | undefined {
+): ParsedGithubActivation | undefined {
   if (payload === null || typeof payload !== "object") return undefined;
   const p = payload as Record<string, unknown>;
   const repository = p.repository;
@@ -119,14 +127,25 @@ export function parseIssueActivation(
         ? (repository as { full_name: string }).full_name
         : undefined;
   if (repo === undefined || repo.length === 0) return undefined;
-  const issue = p.issue as
-    | { number?: unknown; title?: unknown; html_url?: unknown }
-    | undefined;
+  type GithubNode = { number?: unknown; title?: unknown; html_url?: unknown };
+  const asNode = (v: unknown): GithubNode | undefined =>
+    typeof v === "object" && v !== null ? (v as GithubNode) : undefined;
+  const issue = asNode(p.issue);
+  const pr = asNode(p.pull_request);
+  // A usable *object* picks both the fields AND the label — an `issues` delivery
+  // carries an `issue` object, a `pull_request` delivery a `pull_request` object.
+  // Anything non-object (null / string / absent) is treated as not-present for
+  // both, so `issue` only wins the (never-seen) tie when it is a real object —
+  // PR data is never rendered under a `New issue` heading.
+  const usePr = issue === undefined && pr !== undefined;
+  const node = usePr ? pr : issue;
+  const kind: "issue" | "pr" = usePr ? "pr" : "issue";
   return {
     repo,
-    number: typeof issue?.number === "number" ? issue.number : undefined,
-    title: typeof issue?.title === "string" ? issue.title : undefined,
-    url: typeof issue?.html_url === "string" ? issue.html_url : undefined,
+    kind,
+    number: typeof node?.number === "number" ? node.number : undefined,
+    title: typeof node?.title === "string" ? node.title : undefined,
+    url: typeof node?.html_url === "string" ? node.html_url : undefined,
     action: typeof p.action === "string" ? p.action : undefined,
   };
 }
@@ -143,20 +162,21 @@ export function escapeDiscordMarkdown(text: string): string {
   return text.replace(/[\\*_~`|>[\]()]/g, "\\$&");
 }
 
-/** Render the Discord message `content` for an issue activation. */
-export function renderIssueMessage(issue: ParsedIssueActivation): string {
+/** Render the Discord message `content` for an issue/PR activation. */
+export function renderActivationMessage(event: ParsedGithubActivation): string {
   const ref =
-    issue.number !== undefined ? `${issue.repo}#${issue.number}` : issue.repo;
-  const title = escapeDiscordMarkdown(issue.title ?? "(no title)");
-  const head = `🟢 New issue **${ref}** — ${title}`;
-  const body = issue.url !== undefined ? `${head}\n${issue.url}` : head;
+    event.number !== undefined ? `${event.repo}#${event.number}` : event.repo;
+  const title = escapeDiscordMarkdown(event.title ?? "(no title)");
+  const label = event.kind === "pr" ? "New PR" : "New issue";
+  const head = `🟢 ${label} **${ref}** — ${title}`;
+  const body = event.url !== undefined ? `${head}\n${event.url}` : head;
   // Discord content cap is 2000 chars; keep well under.
   return body.length > 1900 ? `${body.slice(0, 1897)}...` : body;
 }
 
 /**
  * Build the `notify.discord` handler. The returned function:
- *  - parses the issue + resolves repo → webhook URL; on no-repo (unparseable
+ *  - parses the issue/PR + resolves repo → webhook URL; on no-repo (unparseable
  *    payload) or no-mapping (no env binding resolved at startup) it emits a
  *    `skipped` visibility and RETURNS. Re-firing within THIS process won't help
  *    (bindings resolve once at construction); fixing the env/config and
@@ -218,8 +238,8 @@ export function createDiscordNotifier(opts: DiscordNotifierOpts): ReflexActivati
   };
 
   return async (activation) => {
-    const issue = parseIssueActivation(activation.payload);
-    if (issue === undefined) {
+    const event = parseGithubActivation(activation.payload);
+    if (event === undefined) {
       log.warn(
         `notify-discord: activation ${activation.decisionId} has no resolvable repo — skipped`,
       );
@@ -229,30 +249,30 @@ export function createDiscordNotifier(opts: DiscordNotifierOpts): ReflexActivati
     // Exact repo mapping first, then the `"*"` catch-all (one webhook for every
     // repo — pairs with an org-level GitHub webhook). An exact entry overrides
     // the catch-all.
-    const webhookUrl = webhookByRepo.get(issue.repo) ?? webhookByRepo.get("*");
+    const webhookUrl = webhookByRepo.get(event.repo) ?? webhookByRepo.get("*");
     if (webhookUrl === undefined) {
-      log.warn(`notify-discord: no webhook configured for repo "${issue.repo}" (no catch-all) — skipped`);
-      emit("skipped", activation, issue.repo, "no-webhook-for-repo");
+      log.warn(`notify-discord: no webhook configured for repo "${event.repo}" (no catch-all) — skipped`);
+      emit("skipped", activation, event.repo, "no-webhook-for-repo");
       return;
     }
     const body = JSON.stringify({
-      content: renderIssueMessage(issue),
-      // Untrusted issue text must never ping the channel.
+      content: renderActivationMessage(event),
+      // Untrusted issue/PR text must never ping the channel.
       allowed_mentions: { parse: [] },
     });
     let res: WebhookPostResult;
     try {
       res = await post(webhookUrl, body);
     } catch (err) {
-      emit("failed", activation, issue.repo, errMsg(err));
+      emit("failed", activation, event.repo, errMsg(err));
       // Transient — throw so the bridge does not mark the Decision id as seen.
       throw err instanceof Error ? err : new Error(String(err));
     }
     if (!res.ok) {
-      emit("failed", activation, issue.repo, `http-${res.status}`);
-      throw new Error(`discord webhook POST for "${issue.repo}" returned HTTP ${res.status}`);
+      emit("failed", activation, event.repo, `http-${res.status}`);
+      throw new Error(`discord webhook POST for "${event.repo}" returned HTTP ${res.status}`);
     }
-    emit("posted", activation, issue.repo);
+    emit("posted", activation, event.repo);
   };
 }
 


### PR DESCRIPTION
## What

The F-6 `notify.discord` handler was **issue-only**: it read `payload.issue.*` and hardcoded a `🟢 New issue` label. The new reflex `github-pr-discord` blueprint (the-metafactory/reflex) fires the **same** `@jc/notify-discord` target with a `pull_request` payload — which has no top-level `issue`, so every field came back `undefined` and it would post `🟢 New issue {repo} — (no title)` with no URL.

## Change

- Parser reads `issue` **OR** `pull_request` — only a usable *object* selects (any non-object: null / string / absent is treated as not-present for both), and the same predicate drives both the fields and the `kind: "issue" | "pr"` label, so PR data is never rendered under a `New issue` heading.
- Renderer emits `New PR` vs `New issue` accordingly.
- Same fields (`number` / `title` / `html_url`), same repo routing, same SSRF guard + `allowed_mentions: { parse: [] }`.
- Rename `parseIssueActivation` → `parseGithubActivation`, `renderIssueMessage` → `renderActivationMessage` (only this file + its test import them).
- Added PR-shape + non-object-`issue` regression parse/render/handler tests.

## Scope of this diff (what it does and does NOT touch)

`git diff --name-only origin/main...HEAD` is **only** `src/bus/notify-discord.ts` + its test. This PR does **not** modify:
- the handler dispatch — `src/cortex.ts:4607` `handlers["discord-webhook"] = createDiscordNotifier({ … })` (unchanged),
- the config schema — `src/common/types/cortex-config.ts:2730` `handler: z.enum(["discord-webhook", "process"])` (unchanged).

The handler is dispatched **by name** (`discord-webhook`), so making it PR-capable needs no schema or dispatch edit. This PR makes **no claim** about the live per-principal config (`~/.config/cortex/cortex.yaml`) or the `notify.discord` repo→URL map — those are not in-repo and cannot be evidenced here; whether a given repo actually posts is an operator check (see Deploy step 4).

## Verify

- `bun test src/bus/__tests__/notify-discord.test.ts` → **19 pass, 0 fail** (new: PR parse/render/handler + non-object-`issue` regression)
- `bun test src/bus` → **1209 pass, 0 fail**
- `tsc --noEmit` → clean

## Reviewed

Iterated on `sage review the-metafactory/cortex#1439`:
- CodeQuality (`node`/`kind` null-semantics mismatch) → unified object-selection predicate + regression tests.
- HonestOracle (comment overstated tie handling) → selection now keys on a real object; comment matches code.
- HonestOracle (unproven operational guarantee) → this description no longer asserts "no wiring change required"; it states only diff-provable facts and defers the config/map check to the operator.

## Deploy (operator, after merge)

1. Redeploy cortex-prod on clawbox (restart picks up the handler).
2. reflex-edge: load `github-pr-discord` into KV.
3. GitHub: add a **Pull requests** delivery → `/impulse/github-pr-discord`, secret `GITHUB_WEBHOOK_SECRET`.
4. **Confirm** the `notify.discord` repo→URL map (in `~/.config/cortex/cortex.yaml`) has an entry — exact repo or `*` catch-all — for every repo whose PRs should post, and that `@jc/notify-discord` is present under `reflex_activation.targets` (it already is, for the live issue→Discord path). No map change is needed for repos already covered for issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)