### PR TITLE
chore: bump to v6.1.0 — federation lifecycle E2E + admission/release hardening

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.0.0"
+version: "6.1.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Minor version bump per the versioning SOP — additive features + hardening + fixes, **no breaking changes** since v6.0.0.

**43 commits since v6.0.0** — the federation-lifecycle wave:

**Features:** `network reject` (#1348) · `network status` full lifecycle (#850) · admit-and-seal (#1316) · `admit --list-pending` (#1314) · offer own-scope (#1390) · SYS auto-wire (#1357) · stack-delete local (#1384) · register echoes request_id (#1398)

**Hardening (registry + MC trust path):** 2nd-stack 401 fix (#832) · shared canonicalJSON + pre-auth DoS caps (#1416/#1418) · verify-over-wire convergence (#1414) · stack-id derivation authority (#1364) · MC CF-Access JWT verification (#1410)

Registry already deployed to prod (bb8de03c). Phase-5 close-out on epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToA9s3K3bVoHbo8xr1iLZx