### PR TITLE
feat(ci): deploy-surface confidentiality scan + opt-in scan-then-deploy wrappers (compass#93)

### DIFF
--- a/docs/agents-md/dashboard-deployment.md
+++ b/docs/agents-md/dashboard-deployment.md
@@ -28,3 +28,47 @@ The `build:dashboard` + `watch:dashboard` scripts in `package.json` codify step 
 - The dashboard frontend is static HTML/JS hosted on CF Pages.
 - Frontend connects to the API via URL params (`?api=`) or auto-detection.
 - CF Access cookies cover dashboard + API on each TLD (`.ai`, `.dev`, `.io`) — no cross-origin cookie issue, no bypass-everyone policies (see Critical Rules).
+
+## Deploy-surface confidentiality scan (opt-in wrappers)
+
+Design doc §4 L6 (compass#81/#93). `scripts/scan-deploy-surface.ts` shells to the
+installed `metafactory-actions` confidentiality-scan engine's `text` mode (tiers
+2+3 — public shape patterns + the hashed denylist) over the exact file set a
+deploy would ship, and three **NET-NEW, opt-in** `package.json` scripts wrap it
+around the existing deploy commands. These are ADDITIVE — the manual commands
+documented above (and the worker's own `bun run deploy` / `db:migrate`) are
+unchanged and remain the canonical path; nothing here rewires them.
+
+| Script | Wraps | Mode |
+|---|---|---|
+| `bun run deploy:dashboard` | `build:dashboard` → scan `dist/dashboard-v2/**` → `wrangler pages deploy` | **advisory** (warns, never blocks — see below) |
+| `bun run deploy:worker` | scan `src/surface/mc/worker/src/**/*.ts` → `wrangler deploy` (worker's own `deploy` script) | **blocking** (exit 1 aborts the deploy) |
+| `bun run db:migrate:safe` | scan `schema.sql` + `migrations/*.sql` → `wrangler d1 execute` (worker's own `db:migrate` script) | **advisory** (warns, never blocks) |
+
+**Why `deploy:dashboard` is advisory, not blocking.** The production dashboard
+build bundles third-party graph-layout code (`elkjs`, lazily chunked into
+`network-canvas-*.js` per G-1114.D). That vendor code's minified output
+contains large numeric constants that coincidentally match the scan's
+17–20-digit platform-id shape — verified empirically at authoring time: a real
+`bun run build:dashboard` trips 8 such findings, all inside vendor code, none a
+real platform id. Hard-blocking would brick `deploy:dashboard` on every run.
+Fixing this properly needs an upstream allow-rule (or vendor-chunk exclusion)
+in `metafactory-actions`' `public-patterns.yaml` — out of scope for this repo.
+
+**Why `db:migrate:safe` is advisory.** Sequencing constraint from the design
+doc: this PR must not brick the canonical `db:migrate` command if the scan
+trips block-tier on `schema.sql` / `migrations/*.sql`. `migrations/0002_seed_data.sql`
+was verified clean (placeholder `operator@example.com`, cortex#1344) at
+authoring time — advisory mode is a safety margin against a future regression,
+not evidence of a known finding today.
+
+**Why `deploy:worker` is blocking.** The worker ships unbundled first-party
+TypeScript (`src/surface/mc/worker/src/**/*.ts`), verified clean (0 findings)
+at authoring time, with no equivalent vendor-minification false-positive
+surface — so there's no reason to soften the gate there.
+
+Parked (not built here, per design doc §4 L6 + compass#93): the daemon-side
+`src/adapters/discord/response-poster.ts` public-guild gate; rewiring the
+canonical production deploy commands through the blocking scan; the arc-publish
+pre-`arc upgrade` hook that would scan `agents.d/**`/`personas/**`/
+`arc-manifest*.yaml` at package time.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "scripts": {
     "build:dashboard": "bun build src/surface/mc/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser --splitting",
     "watch:dashboard": "bun build src/surface/mc/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser --splitting --watch",
+    "deploy:dashboard": "bun run build:dashboard && bun scripts/scan-deploy-surface.ts dashboard --advisory && bunx wrangler pages deploy dist/dashboard-v2 --project-name grove-dashboard",
+    "deploy:worker": "bun scripts/scan-deploy-surface.ts worker && bun --cwd src/surface/mc/worker run deploy",
+    "db:migrate:safe": "bun scripts/scan-deploy-surface.ts d1 --advisory && bun --cwd src/surface/mc/worker run db:migrate",
     "lint": "eslint .",
     "lint:errors": "eslint --quiet .",
     "lint:fix": "eslint --fix ."

--- a/scripts/__tests__/scan-deploy-surface.test.ts
+++ b/scripts/__tests__/scan-deploy-surface.test.ts
@@ -1,0 +1,187 @@
+// Tests for the L6 deploy-surface confidentiality scan (design doc §4 L6,
+// compass#93, cortex feat/c-conf-deploy-gates).
+//
+// RUNTIME-CONSTRUCTED FIXTURES ONLY (self-conflict fix, matching
+// scripts/__tests__/check-shippable-hygiene.test.ts): every forbidden shape
+// this suite plants is built by concatenation at runtime, never written as a
+// literal — so this test file itself stays clean under the confidentiality
+// scanners (including the very engine it drives). The synthetic snowflake
+// below is obviously-fake and non-sequential; it is not a real platform id.
+//
+// ENGINE DEPENDENCY: this suite shells to the INSTALLED confidentiality-scan
+// engine (~/.config/metafactory/pkg/repos/metafactory-actions/scan/) — an
+// arc-managed local package, not something vendored into this repo or fetched
+// by GitHub Actions' `bun test` job. Mirrors the existing `hasClaude` /
+// `testClaude` self-skip pattern in src/common/test-utils.ts for the same
+// reason (external binary not present on GitHub Actions runners): tests that
+// need the real engine self-skip via `testEngine` so they still run locally
+// (and for the engineer driving this PR) without failing CI red for an
+// environment gap outside this PR's scope.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  DEFAULT_ENGINE_PATH,
+  main,
+  resolveSurfaceFiles,
+  scanFile,
+} from "../scan-deploy-surface";
+
+const hasEngine = existsSync(DEFAULT_ENGINE_PATH);
+const testEngine = test.skipIf(!hasEngine);
+
+// --- runtime-built forbidden strings (never literals) ----------------------
+const SYNTH_SNOWFLAKE = ["9", "8", "7", "6", "5", "4", "3", "2", "1", "8", "7", "6", "5", "4", "3", "2", "1"].join(
+  "",
+); // 17 digits, obviously synthetic — not all-zero / all-same-digit (so it isn't allowlisted)
+const SYNTH_INTERNAL_EMAIL = "leak" + "@" + "meta-factory" + ".ai"; // org's own domain, class-6 shape
+const PLACEHOLDER_SEED_EMAIL = "operator" + "@" + "example.com"; // RFC-reserved → clean
+
+function tmpRoot(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), `deploy-surface-${prefix}-`));
+}
+function write(root: string, rel: string, body: string): void {
+  const p = join(root, rel);
+  mkdirSync(join(p, ".."), { recursive: true });
+  writeFileSync(p, body);
+}
+function cleanup(root: string): void {
+  rmSync(root, { recursive: true, force: true });
+}
+
+describe("resolveSurfaceFiles — pure file-set resolution (no engine needed)", () => {
+  test("dashboard surface lists text-scannable build output, skips missing dir", () => {
+    const root = tmpRoot("dashboard-list");
+    expect(resolveSurfaceFiles("dashboard", root)).toEqual([]);
+    write(root, "dist/dashboard-v2/entry-abc123.js", "console.log(1);\n");
+    write(root, "dist/dashboard-v2/index.html", "<html></html>\n");
+    write(root, "dist/dashboard-v2/logo.png", "\x89PNG\r\n"); // binary — skipped, not scannable
+    const files = resolveSurfaceFiles("dashboard", root);
+    expect(files.some((f) => f.endsWith("entry-abc123.js"))).toBe(true);
+    expect(files.some((f) => f.endsWith("index.html"))).toBe(true);
+    expect(files.some((f) => f.endsWith("logo.png"))).toBe(false);
+    cleanup(root);
+  });
+
+  test("worker surface lists only src/**/*.ts under the worker package", () => {
+    const root = tmpRoot("worker-list");
+    write(root, "src/surface/mc/worker/src/index.ts", "export {};\n");
+    write(root, "src/surface/mc/worker/src/routes/health.ts", "export {};\n");
+    write(root, "src/surface/mc/worker/wrangler.toml", 'name = "cortex-api"\n');
+    const files = resolveSurfaceFiles("worker", root);
+    expect(files.length).toBe(2);
+    expect(files.every((f) => f.endsWith(".ts"))).toBe(true);
+  });
+
+  test("d1 surface lists schema.sql + migrations/*.sql, skips missing schema.sql", () => {
+    const root = tmpRoot("d1-list");
+    write(root, "src/surface/mc/worker/migrations/0001_a.sql", "CREATE TABLE a (id TEXT);\n");
+    write(root, "src/surface/mc/worker/migrations/0002_b.sql", "CREATE TABLE b (id TEXT);\n");
+    const noSchema = resolveSurfaceFiles("d1", root);
+    expect(noSchema.length).toBe(2); // schema.sql absent — just the migrations
+
+    write(root, "src/surface/mc/worker/schema.sql", "CREATE TABLE schema_version (v INT);\n");
+    const withSchema = resolveSurfaceFiles("d1", root);
+    expect(withSchema.length).toBe(3);
+    expect(withSchema.some((f) => f.endsWith("schema.sql"))).toBe(true);
+  });
+
+  test("unknown surface via main() exits 2 (usage error)", () => {
+    expect(main(["not-a-real-surface"])).toBe(2);
+  });
+
+  test("missing surface arg via main() exits 2", () => {
+    expect(main([])).toBe(2);
+  });
+});
+
+describe("scan-deploy-surface — engine fail-closed / advisory behavior", () => {
+  test("missing engine binary fails closed (exit 3) in blocking mode", () => {
+    const root = tmpRoot("no-engine");
+    write(root, "dist/dashboard-v2/app.js", "console.log('clean');\n");
+    const code = main(["dashboard", "--root", root, "--engine", join(root, "does-not-exist.ts")]);
+    expect(code).toBe(3);
+    cleanup(root);
+  });
+
+  test("missing engine binary in --advisory mode does not block (exit 0)", () => {
+    const root = tmpRoot("no-engine-advisory");
+    write(root, "src/surface/mc/worker/schema.sql", "CREATE TABLE t (id TEXT);\n");
+    const code = main(["d1", "--advisory", "--root", root, "--engine", join(root, "does-not-exist.ts")]);
+    expect(code).toBe(0);
+    cleanup(root);
+  });
+
+  test("empty file set (nothing built yet) is treated as clean", () => {
+    const root = tmpRoot("empty-dashboard");
+    const code = main(["dashboard", "--root", root]); // real DEFAULT_ENGINE_PATH — irrelevant, no files to scan
+    expect(code).toBe(0);
+    cleanup(root);
+  });
+});
+
+describe("scan-deploy-surface — against the REAL installed engine", () => {
+  testEngine("clean dashboard build output passes (exit 0)", () => {
+    const root = tmpRoot("real-dashboard-clean");
+    write(root, "dist/dashboard-v2/entry.js", "export const x = 1;\n");
+    write(root, "dist/dashboard-v2/index.html", "<!doctype html><html></html>\n");
+    const code = main(["dashboard", "--root", root]);
+    expect(code).toBe(0);
+    cleanup(root);
+  });
+
+  testEngine("planted fixture snowflake in dashboard build output BLOCKS (exit 1)", () => {
+    const root = tmpRoot("real-dashboard-block");
+    write(root, "dist/dashboard-v2/entry.js", `const leaked = "${SYNTH_SNOWFLAKE}";\n`);
+    const code = main(["dashboard", "--root", root]);
+    expect(code).toBe(1);
+    cleanup(root);
+  });
+
+  testEngine("planted internal-domain email in worker src BLOCKS (exit 1)", () => {
+    const root = tmpRoot("real-worker-block");
+    write(
+      root,
+      "src/surface/mc/worker/src/index.ts",
+      `export const CONTACT = "${SYNTH_INTERNAL_EMAIL}";\n`,
+    );
+    const code = main(["worker", "--root", root]);
+    expect(code).toBe(1);
+    cleanup(root);
+  });
+
+  testEngine("clean placeholder seed passes d1 surface (exit 0)", () => {
+    const root = tmpRoot("real-d1-clean");
+    write(
+      root,
+      "src/surface/mc/worker/migrations/0002_seed_data.sql",
+      `INSERT OR IGNORE INTO users (id, email) VALUES ('operator', '${PLACEHOLDER_SEED_EMAIL}');\n`,
+    );
+    const code = main(["d1", "--root", root]);
+    expect(code).toBe(0);
+    cleanup(root);
+  });
+
+  testEngine("d1 surface with a fixture finding does not block in --advisory mode (exit 0)", () => {
+    const root = tmpRoot("real-d1-advisory");
+    write(
+      root,
+      "src/surface/mc/worker/schema.sql",
+      `-- contact ${SYNTH_INTERNAL_EMAIL}\nCREATE TABLE t (id TEXT);\n`,
+    );
+    const code = main(["d1", "--advisory", "--root", root]);
+    expect(code).toBe(0); // advisory — findings printed but never block
+    cleanup(root);
+  });
+
+  testEngine("scanFile() returns the engine's own masked output — never the planted literal", () => {
+    const root = tmpRoot("real-mask-check");
+    const file = join(root, "probe.js");
+    write(root, "probe.js", `const leaked = "${SYNTH_SNOWFLAKE}";\n`);
+    const { code, output } = scanFile(DEFAULT_ENGINE_PATH, file, root);
+    expect(code).toBe(1);
+    expect(output).not.toContain(SYNTH_SNOWFLAKE);
+    cleanup(root);
+  });
+});

--- a/scripts/scan-deploy-surface.ts
+++ b/scripts/scan-deploy-surface.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env bun
+/**
+ * scan-deploy-surface.ts — L6 deploy-surface confidentiality scan
+ * (design doc §4 L6, compass#93, cortex feat/c-conf-deploy-gates).
+ *
+ * Scans the file SET a cortex deploy actually SHIPS — the CF Pages dashboard
+ * build output, the worker's own source tree, and the D1 schema/migration
+ * files — through the shared confidentiality-scan engine's `text` mode
+ * (`metafactory-actions/scan/confidentiality-scan.ts`). Text mode runs tiers
+ * 2+3 only (public shape patterns + the hashed denylist); tier 1 (gitleaks)
+ * is git-only and never runs here — there is no git range to scan, only a
+ * deploy-shaped set of files on disk (design doc §4 L6 / metafactory-actions
+ * README "text mode — scanning a string, not a git range").
+ *
+ * This module is a THIN orchestrator: it resolves the file set per surface,
+ * shells out to the installed engine once per file, and re-prints the
+ * engine's OWN masked output verbatim. It never re-renders a finding itself,
+ * so it can't become a second leak surface (the engine's masking guarantee
+ * is the only one that matters).
+ *
+ * Consumed by the OPT-IN package.json wrappers — `deploy:dashboard`,
+ * `deploy:worker`, `db:migrate:safe` (docs/agents-md/dashboard-deployment.md).
+ * These are NET-NEW additive scripts; the MANUAL deploy commands documented
+ * in CLAUDE.md / dashboard-deployment.md are unchanged and still work.
+ *
+ * Surfaces:
+ *   dashboard   <root>/dist/dashboard-v2/**            (CF Pages build output;
+ *               text-scannable files only — binary/font assets are skipped,
+ *               not exempted from anything else)
+ *   worker      <root>/src/surface/mc/worker/src/**\/*.ts   (the code
+ *               `wrangler deploy` ships for the cortex-api worker)
+ *   d1          <root>/src/surface/mc/worker/schema.sql +
+ *               <root>/src/surface/mc/worker/migrations/*.sql   (what
+ *               `db:migrate` ships, plus the migrations/ tree — the exact
+ *               path class the design doc cites as "the paths that
+ *               actually ship seed SQL")
+ *
+ * Exit codes (mirrors the underlying engine's contract):
+ *   0  clean
+ *   1  one or more BLOCK finding(s) (non-advisory mode only)
+ *   2  usage error (unknown surface / missing argument)
+ *   3  engine/config error — fail-closed (e.g. engine not installed)
+ *
+ * Usage:
+ *   bun scripts/scan-deploy-surface.ts dashboard [--advisory]
+ *   bun scripts/scan-deploy-surface.ts worker
+ *   bun scripts/scan-deploy-surface.ts d1 [--advisory]
+ *   bun scripts/scan-deploy-surface.ts <surface> --root <path>   # test override
+ *
+ * --advisory: print findings but ALWAYS exit 0.
+ *
+ * `d1` (`db:migrate:safe`): the design doc's sequencing constraint says this PR
+ * must not brick the canonical `db:migrate` command if the scan trips
+ * block-tier on schema.sql / migrations/*.sql. `0002_seed_data.sql` was
+ * verified clean at authoring time (placeholder `operator@example.com`,
+ * cortex#1344) — advisory mode here is a safety margin against a FUTURE false
+ * positive or a future non-placeholder seed landing unnoticed, not evidence a
+ * known finding exists today.
+ *
+ * `dashboard` (`deploy:dashboard`): advisory for a DIFFERENT, EMPIRICAL reason
+ * — the production dashboard build bundles third-party graph-layout code
+ * (elkjs, lazily chunked into `network-canvas-*.js` per G-1114.D) whose
+ * minified output contains large numeric constants that coincidentally match
+ * the 17–20-digit platform-id shape (tier2:platform-snowflake). Verified at
+ * authoring time: a real `bun run build:dashboard` trips 8 such findings, all
+ * inside vendor code, none of them a real platform id. Hard-blocking would
+ * brick `deploy:dashboard` on every run today. Fixing this properly means an
+ * upstream allow-rule in metafactory-actions' public-patterns.yaml (or a
+ * vendor-chunk exclusion) — out of scope for this PR (that repo isn't ours to
+ * change here) and explicitly parked alongside "rewiring the canonical
+ * production deploy through the blocking scan." `worker` stays BLOCKING: the
+ * worker ships unbundled first-party TypeScript (verified clean, 0 findings)
+ * and has no equivalent vendor-minification false-positive surface.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, relative, resolve } from "node:path";
+
+export const DEFAULT_ENGINE_PATH = join(
+  homedir(),
+  ".config/metafactory/pkg/repos/metafactory-actions/scan/confidentiality-scan.ts",
+);
+
+// Text-scannable extensions for the dashboard build output. Bun's build emits
+// js/css/html/map/json (and any inlined svg); fonts/images are skipped — not
+// because they're exempt, but because the engine scans TEXT content and a
+// binary asset has none to scan (the analogous git-mode "new binary" rule is
+// L1's concern, not this text-mode wrapper's).
+const DASHBOARD_SCAN_EXT = new Set([
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".html",
+  ".css",
+  ".map",
+  ".json",
+  ".txt",
+  ".svg",
+]);
+const WORKER_SCAN_EXT = new Set([".ts", ".tsx"]);
+const D1_SCAN_EXT = new Set([".sql"]);
+
+export type Surface = "dashboard" | "worker" | "d1";
+
+function extOf(name: string): string {
+  const i = name.lastIndexOf(".");
+  return i === -1 ? "" : name.slice(i).toLowerCase();
+}
+
+function listFilesRecursive(dir: string, allowExt: Set<string>): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  const walk = (d: string): void => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const abs = join(d, entry.name);
+      if (entry.isDirectory()) walk(abs);
+      else if (entry.isFile() && allowExt.has(extOf(entry.name))) out.push(abs);
+    }
+  };
+  walk(dir);
+  return out.sort();
+}
+
+/** Resolve the file set a deploy of `surface` would ship, rooted at `root`
+ *  (defaults to the repo root — two levels up from this script). Exported
+ *  for direct unit testing without shelling out to the engine. */
+export function resolveSurfaceFiles(surface: Surface, root: string): string[] {
+  switch (surface) {
+    case "dashboard":
+      return listFilesRecursive(join(root, "dist/dashboard-v2"), DASHBOARD_SCAN_EXT);
+    case "worker":
+      return listFilesRecursive(join(root, "src/surface/mc/worker/src"), WORKER_SCAN_EXT);
+    case "d1": {
+      const workerDir = join(root, "src/surface/mc/worker");
+      const files = [
+        join(workerDir, "schema.sql"),
+        ...listFilesRecursive(join(workerDir, "migrations"), D1_SCAN_EXT),
+      ].filter(existsSync);
+      return files.sort();
+    }
+    default: {
+      const _exhaustive: never = surface;
+      throw new Error(`unknown surface: ${_exhaustive as string}`);
+    }
+  }
+}
+
+function isSurface(v: string): v is Surface {
+  return v === "dashboard" || v === "worker" || v === "d1";
+}
+
+interface ScanOutcome {
+  code: number; // 0 clean · 1 block · 3 engine error
+  output: string;
+}
+
+/** Shell to the installed engine's `text` mode for a single file. Exported
+ *  so callers/tests can stub the engine path without touching argv parsing. */
+export function scanFile(enginePath: string, file: string, cwd: string): ScanOutcome {
+  const res = spawnSync("bun", [enginePath, "text", "--file", file], {
+    encoding: "utf8",
+    cwd,
+  });
+  if (res.error) {
+    return { code: 3, output: `engine spawn failed: ${res.error.message}` };
+  }
+  const output = [res.stdout, res.stderr].filter((s) => s && s.trim().length > 0).join("\n");
+  return { code: res.status ?? 3, output };
+}
+
+export function main(argv: string[]): number {
+  const positional = argv.filter((a) => !a.startsWith("--"));
+  const surfaceArg = positional[0];
+  const advisory = argv.includes("--advisory");
+  const rootIdx = argv.indexOf("--root");
+  const root = rootIdx !== -1 ? (argv[rootIdx + 1] ?? "") : resolve(import.meta.dir, "..");
+  const engineIdx = argv.indexOf("--engine");
+  const enginePath = engineIdx !== -1 ? (argv[engineIdx + 1] ?? "") : DEFAULT_ENGINE_PATH;
+
+  if (!surfaceArg || argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(
+      "usage: bun scripts/scan-deploy-surface.ts <dashboard|worker|d1> [--advisory] [--root <path>]\n",
+    );
+    return surfaceArg ? 0 : 2;
+  }
+  if (!isSurface(surfaceArg)) {
+    process.stderr.write(
+      `scan-deploy-surface: unknown surface "${surfaceArg}" — expected dashboard|worker|d1\n`,
+    );
+    return 2;
+  }
+  if (!root) {
+    process.stderr.write("scan-deploy-surface: --root requires a path\n");
+    return 2;
+  }
+
+  if (!existsSync(enginePath)) {
+    const msg = `scan-deploy-surface: confidentiality-scan engine not found at ${enginePath} — fail-closed (install/refresh via arc upgrade compass).`;
+    if (advisory) {
+      process.stdout.write(`${msg} (advisory mode — not blocking)\n`);
+      return 0;
+    }
+    process.stderr.write(`${msg}\n`);
+    return 3;
+  }
+
+  const files = resolveSurfaceFiles(surfaceArg, root);
+  if (files.length === 0) {
+    process.stdout.write(
+      `scan-deploy-surface: ${surfaceArg} — no files to scan (build output missing? run the build step first) — treating as clean.\n`,
+    );
+    return 0;
+  }
+
+  const codes: number[] = [];
+  for (const abs of files) {
+    const rel = relative(root, abs);
+    const { code, output } = scanFile(enginePath, abs, root);
+    codes.push(code);
+    if (code !== 0) {
+      process.stdout.write(`--- ${rel} ---\n${output}\n`);
+    }
+  }
+
+  // Fail-closed priority: an engine/config error (3) on ANY file means the
+  // scan is incomplete/untrustworthy for the whole surface, so it outranks
+  // a clean block-finding tally even if other files came back 1 or 0.
+  const finalCode = codes.includes(3) ? 3 : codes.includes(1) ? 1 : 0;
+
+  if (finalCode === 0) {
+    process.stdout.write(`scan-deploy-surface: ${surfaceArg} — clean (${files.length} file(s) scanned).\n`);
+    return 0;
+  }
+
+  if (advisory) {
+    process.stdout.write(
+      `scan-deploy-surface: ${surfaceArg} — findings above (advisory mode — NOT blocking; review before shipping).\n`,
+    );
+    return 0;
+  }
+
+  process.stderr.write(
+    `scan-deploy-surface: ${surfaceArg} — BLOCKED (exit ${finalCode}). Fix the findings above before deploying.\n`,
+  );
+  return finalCode;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary

Implements compass#93 (PR15 of the phase-3 surface-gate rollout, design doc §4 L6, umbrella compass#81) — a deploy-surface confidentiality scan module + three opt-in, additive `package.json` wrappers. Scope per the dispatch plan: **scan module + opt-in wrappers only**. The daemon-side Discord adapter gate, canonical-deploy rewiring, and the arc-publish hook are explicitly parked (see below).

- **`scripts/scan-deploy-surface.ts`** — shells to the installed `metafactory-actions` confidentiality-scan engine's `text` mode (`bun ~/.config/metafactory/pkg/repos/metafactory-actions/scan/confidentiality-scan.ts text --file <path>`, tiers 2+3 — public shape patterns + hashed denylist; tier1 `gitleaks` is git-only and never runs in `text` mode) over the file set a deploy actually ships:
  - `dashboard` → `dist/dashboard-v2/**` (text-scannable build output)
  - `worker` → `src/surface/mc/worker/src/**/*.ts`
  - `d1` → `schema.sql` + `migrations/*.sql`
- **Three NET-NEW, opt-in `package.json` scripts**, additive alongside the existing manual/canonical commands (nothing rewired, nothing replaced):
  | Script | Wraps | Mode |
  |---|---|---|
  | `deploy:dashboard` | `build:dashboard` → scan → `wrangler pages deploy` | **advisory** |
  | `deploy:worker` | scan → worker's own `deploy` (`wrangler deploy`) | **blocking** |
  | `db:migrate:safe` | scan → worker's own `db:migrate` | **advisory** |
- **Docs**: `docs/agents-md/dashboard-deployment.md` (the source file — `CLAUDE.md` itself is never hand-edited; regen is parked per the plan).

## Stale design-ref corrections (per the compass#93 plan)

- There was **no existing `deploy:dashboard` script** — the documented path was the 2-step manual `build:dashboard` then `bunx wrangler pages deploy`. `deploy:dashboard` is net-new.
- The D1 path is the worker's **`db:migrate`** (`wrangler d1 execute CORTEX_DB --file=./schema.sql`), not a `migrations apply` command.

## Two empirical findings from testing against the real repo

1. **`migrations/0002_seed_data.sql` is clean** — `operator@example.com` placeholder, confirmed via cortex#1344. `db:migrate:safe` stays **advisory** anyway, per the design doc's sequencing constraint: this PR must not brick the canonical `db:migrate` on a future false positive or regression.
2. **New finding, not anticipated by the plan**: `deploy:dashboard` MUST also be advisory. A real `bun run build:dashboard` trips **8 `tier2:platform-snowflake` findings**, all inside the vendored `elkjs` graph-layout engine (`network-canvas-*.js`, G-1114.D lazy chunk) — minified numeric constants that coincidentally match the 17–20-digit platform-id shape. Hard-blocking would brick the wrapper on every single run. A proper fix needs an upstream allow-rule in `metafactory-actions`' `public-patterns.yaml` (or a vendor-chunk exclusion) — out of scope for this repo. `deploy:worker` stays **blocking**: unbundled first-party TypeScript, verified clean (0 findings, 29 files scanned).

## Parked (not built here)

Per the design doc + compass#93 plan: the daemon-side `src/adapters/discord/response-poster.ts` public-guild gate (highest-volume live egress); rewiring the **canonical** production deploy commands through the blocking scan; the arc-publish pre-`arc upgrade` hook (`agents.d/**`/`personas/**`/`arc-manifest*.yaml` at package time); any `CLAUDE.md` regen.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint --quiet` on touched files — clean
- [x] `bun test scripts/__tests__/scan-deploy-surface.test.ts` — **14 pass, 0 fail**
      - Pure file-set resolution per surface (no engine dependency)
      - Engine fail-closed (exit 3) / advisory (exit 0) behavior
      - Integration tests against the **real installed engine**, self-skipping via `testEngine` (mirrors `src/common/test-utils.ts`'s `testClaude` pattern — GitHub Actions' `bun test` job has no `metafactory-actions` install, same reason `claude`-binary tests self-skip there)
      - All fixture terms are **runtime-constructed** (never literals), matching `check-shippable-hygiene.test.ts`'s self-conflict-fix convention
- [x] Manually ran `bun scripts/scan-deploy-surface.ts d1` and `worker` against the real repo tree — both clean
- [x] Manually built the real dashboard (`bun run build:dashboard`) and scanned the real output — surfaced the elkjs false-positive finding documented above

Not merging per instructions — please review.