### PR TITLE
fix(stack create): system.yaml identity.seedPath uses resolved cortex-<slug>.nk (#1442)

### DIFF
--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -141,6 +141,17 @@ describe("renderScaffold", () => {
     expect(stack?.contents).toContain("assistant");
   });
 
+  test("system/system.yaml identity.seedPath carries the resolved per-stack seed path (cortex-<slug>.nk, not cortex.nk)", () => {
+    // Regression (Vincent Zontini report): systemYaml() previously ignored the
+    // resolved seedPath and hardcoded `~/.config/nats/cortex.nk`, so the
+    // generated system.yaml disagreed with stacks/<slug>.yaml's nkey_seed_path
+    // and made users think the identity block needed different data.
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    expect(system?.contents).toContain("seedPath: ~/.config/nats/cortex-demo.nk");
+    expect(system?.contents).not.toContain("seedPath: ~/.config/nats/cortex.nk");
+  });
+
   test("system/system.yaml seeds the bus/bot credsPath (~/.config/nats/<slug>-bot.creds), distinct from the federation default", () => {
     // v5.30.2 (C-1265c): a from-scratch stack carries nats.credsPath explicitly,
     // so `cortex network make-live` needs no --creds flag. The path is the

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -235,7 +235,7 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   const Display = displayName;
 
   return [
-    { relPath: "system/system.yaml", contents: systemYaml(slug) },
+    { relPath: "system/system.yaml", contents: systemYaml(slug, seedPath) },
     { relPath: "surfaces/surfaces.yaml", contents: surfacesYaml(agentId, stackId) },
     { relPath: `stacks/${slug}.yaml`, contents: stackYaml(slug, principal, stackId, agentId, Display, seedPath) },
     { relPath: `${slug}.yaml`, contents: pointerYaml(slug) },
@@ -243,10 +243,11 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   ];
 }
 
-function systemYaml(slug: string): string {
+function systemYaml(slug: string, seedPath: string): string {
   // The cross-cutting substrate layer — substituted from
-  // docs/config-layout/system/system.yaml. Identity is left at the safe
-  // conventional default; `arc upgrade cortex` auto-provisions the seed.
+  // docs/config-layout/system/system.yaml. Identity's seedPath is the resolved
+  // per-stack conventional path (matches stacks/<slug>.yaml's nkey_seed_path);
+  // `arc upgrade cortex` auto-provisions the seed there.
   return `# =============================================================================
 # system.yaml — the cross-cutting machine / substrate layer (IAW CFG.b)
 # =============================================================================
@@ -294,13 +295,14 @@ nats:
   # \`~/.config/nats/${slug}.creds\`). Two different NATS accounts MUST be two
   # different files — a shared path would clobber on the second mint.
   credsPath: ~/.config/nats/${slug}-bot.creds
-  # NKey identity for envelope signing. The seedPath is the conventional path
-  # \`arc upgrade cortex\` auto-provisions on first install; publicKey is pinned
-  # after first boot (paste from the cortex log \`stack signing key staged …\`).
+  # NKey identity for envelope signing. seedPath is the conventional per-stack
+  # path \`arc upgrade cortex\` auto-provisions on first install; publicKey holds
+  # the SAME U-prefixed key you pin as \`nkey_pub\` in stacks/${slug}.yaml — paste
+  # it from the cortex log \`stack signing key staged …\` after first boot.
   identity:
-    seedPath: ~/.config/nats/cortex.nk
+    seedPath: ${seedPath}
     # Valid-FORMAT placeholder so this file loads; REPLACE after first boot.
-    publicKey: ${NKEY_PUB_PLACEHOLDER}   # <REPLACE_ME>: U-prefixed pubkey
+    publicKey: ${NKEY_PUB_PLACEHOLDER}   # <REPLACE_ME>: same value as nkey_pub (U-prefixed)
 
 bus:
   review:


### PR DESCRIPTION
Closes #1442.

## What
`cortex stack create <slug>` was generating `system/system.yaml` with a hardcoded `nats.identity.seedPath: ~/.config/nats/cortex.nk` instead of the resolved per-stack path `~/.config/nats/cortex-<slug>.nk`. The slug was substituted everywhere else but missed here, so `system.yaml` disagreed with `stacks/<slug>.yaml`'s `nkey_seed_path`.

## Changes (surgical)
- `renderScaffold()` now passes the already-resolved `seedPath` into `systemYaml(slug, seedPath)`; the identity block emits `seedPath: ${seedPath}`.
- Reworded the `publicKey` comment to state it holds the **same value as `nkey_pub`**, removing the "identity block needs different data" confusion Vincent flagged.
- Added a regression test: `system.yaml` identity carries `cortex-demo.nk`, never `cortex.nk`.

## Verification
`bun test stack-lib.test.ts stack-cli.test.ts provision-stack.test.ts` → 54 pass, 0 fail.

## Follow-up
#1443 tracks Vincent's enhancement (accept non-secret `nkey_pub` / Discord snowflake IDs as CLI flags to auto-populate scaffolds) — intentionally out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
