### PR TITLE
fix(network): C-1436 — converge join guard principal segment onto config.principal.id authority

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -83,6 +83,9 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
     expect(res.ok).toBe(true);
     expect(res.inputs).toEqual({
       principal: "andreas",
+      // C-1436 — boot-authoritative principal from config.principal.id (born-aligned
+      // here: equals the locator `principal`). cfg.principal.id.
+      bootPrincipal: "andreas",
       stack: "andreas/meta-factory",
       // C-1364 — boot-authoritative slug from stack.id (born-aligned here: equals
       // the `stack` id's trailing segment). deriveStackId(FULL).stack.
@@ -253,6 +256,13 @@ describe("deriveJoinInputs — flag overrides win", () => {
     expect(res.ok).toBe(true);
     expect(res.inputs).toEqual({
       principal: "override-p",
+      // C-1436 — the `--principal` flag moves the LOCATOR/write-path principal
+      // ("override-p"), but `bootPrincipal` stays the config's `principal.id`
+      // ("andreas" from FULL). A flag override CANNOT move the federation identity
+      // the daemon boot validator enforces (`config.principal.id`) — this is the
+      // principal-axis drift the fix pins shut: guard scope derives from
+      // bootPrincipal, never the flag/locator `principal`.
+      bootPrincipal: "andreas",
       stack: "override-p/other",
       // C-1364 — the `--stack` flag moves the LOCATOR/write-path id ("other"),
       // but `bootStackSlug` stays the config's stack.id trailing segment
@@ -1012,5 +1022,279 @@ describe("C-1364 — join own-scope identity converges with boot on deriveStackI
     expect(inputs.bootStackSlug).toBe("meta-factory");
     expect(inputs.stack.split("/")[1]).toBe("meta-factory");
     expect(inputs.bootStackSlug).toBe(deriveStackId(FULL).stack);
+  });
+});
+
+// =============================================================================
+// C-1436 — the PRINCIPAL-axis mirror of C-1364. The join own-scope guard and the
+// daemon boot validator MUST derive the own-scope PRINCIPAL segment from ONE
+// authority. But — unlike the stack axis — that authority is `config.principal.id`
+// DIRECTLY, deliberately NOT `deriveStackId(config).principal`.
+//
+// Latent drift: the join own-scope guard built `federated.{me}.{stack}.`'s
+// principal segment from the flag/locator-honouring `inputs.principal`
+// (`--principal` wins), while the boot validator (`CortexConfigSchema` federated
+// subject-scope superRefine) pins it to `config.principal.id` — the value the
+// runtime stamps onto the wire (`resolvePrincipalId` → the
+// `federated.{principal}.{stack}.>` subscription + `envelope.source` seg[0]).
+// For a config where the locator principal (`--principal`) OR a `stack.id`
+// principal-half differs from `principal.id`, guard and boot DISAGREE — the join
+// persists an accept-list the daemon refuses to boot against, or a valid one is
+// falsely refused. The fix threads `bootPrincipal = cfg.principal.id` and pins
+// the guard to it.
+//
+// WHY NOT `deriveStackId(config).principal` (the C-1364 stack pattern): on the
+// documented override path (`principal.id: andreas` running
+// `stack.id: jcfischer/sage-host`) `deriveStackId().principal` is `jcfischer`,
+// while the runtime still subscribes `federated.andreas.…`. Converging onto it
+// would re-open the very split — so the boot validator pins to `config.principal.id`
+// and this fix converges the guard onto the SAME source. Fixture 2 below is the
+// case that proves this target choice.
+// =============================================================================
+
+describe("C-1436 — join own-scope principal converges with boot on config.principal.id", () => {
+  // Build a raw cortex config the DAEMON BOOTS from, parameterised on the
+  // principal.id / stack.id / accept-list, so parsing it through CortexConfigSchema
+  // runs the REAL subject-scope superRefine (the boot verdict).
+  function bootConfig(
+    principalId: string,
+    stackId: string,
+    accept: string[],
+  ): Record<string, unknown> {
+    return {
+      principal: { id: principalId },
+      agents: [
+        {
+          id: "luna",
+          displayName: "Luna",
+          persona: "./personas/luna.md",
+          presence: {
+            discord: {
+              token: "DISCORD_TOKEN",
+              guildId: "111111111111111111",
+              agentChannelId: "222222222222222222",
+              logChannelId: "333333333333333333",
+            },
+          },
+        },
+      ],
+      renderers: [],
+      claude: { model: "claude-opus-4-5", apiKey: "env:ANTHROPIC_API_KEY" },
+      stack: { id: stackId },
+      policy: {
+        federated: {
+          networks: [
+            {
+              id: "metafactory",
+              leaf_node: "leaf",
+              peers: [],
+              accept_subjects: accept,
+              deny_subjects: [],
+              announce_capabilities: [],
+              max_hop: 1,
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fixture 1 — the headline #1436 case: `--principal` drift. Config principal.id
+  // is "andreas" (born-aligned stack andreas/work), joined with `--principal
+  // other-p`. The flag moves the locator; boot still enforces "andreas".
+  // ---------------------------------------------------------------------------
+  const FLAG_DRIFT = loaded({
+    principal: { id: "andreas" },
+    stack: {
+      id: "andreas/work",
+      nkey_seed_path: "~/seed.nk",
+      nats_infra: {
+        config_path: "~/local.conf",
+        plist_path: "~/nats.plist",
+        account: "A" + "B".repeat(55),
+      },
+    },
+    policy: {
+      principals: [],
+      roles: [],
+      federated: {
+        networks: [],
+        registry: { url: DEFAULT_REGISTRY.url, pubkey: DEFAULT_REGISTRY.pubkey },
+      },
+    },
+  });
+
+  test("bootPrincipal tracks config.principal.id, NOT the --principal flag → guard + boot prefixes are identical", () => {
+    const res = deriveJoinInputs(
+      "metafactory",
+      { principal: "other-p" },
+      "/cfg",
+      reader(FLAG_DRIFT),
+      "darwin",
+    );
+    expect(res.ok).toBe(true);
+    const inputs = res.inputs;
+    if (inputs === undefined) throw new Error("expected inputs");
+
+    // The flag moved the LOCATOR / write-path principal (DA-5) ...
+    expect(inputs.principal).toBe("other-p");
+    // ... but the boot-authoritative own-scope principal stays config.principal.id.
+    expect(inputs.bootPrincipal).toBe("andreas");
+    // Stack axis is born-aligned here, so it contributes no drift of its own.
+    expect(inputs.bootStackSlug).toBe("work");
+
+    // BOOT derives its prefix EXACTLY as the superRefine does:
+    // ownFederatedSubjectScopePrefix(config.principal.id, deriveStackId(config).stack).
+    const bootPrefix = ownFederatedSubjectScopePrefix("andreas", deriveStackId(FLAG_DRIFT).stack);
+    // The JOIN GUARD now derives from bootPrincipal — must be identical (no split).
+    const guardPrefix = ownFederatedSubjectScopePrefix(inputs.bootPrincipal, inputs.bootStackSlug);
+    expect(guardPrefix).toBe(bootPrefix);
+    expect(guardPrefix).toBe("federated.andreas.work.");
+
+    // Regression witness: the PRE-FIX derivation (the flag/locator principal off
+    // inputs.principal) WOULD have produced a different prefix — the split this closes.
+    expect(ownFederatedSubjectScopePrefix(inputs.principal, inputs.bootStackSlug)).not.toBe(bootPrefix);
+    expect(ownFederatedSubjectScopePrefix(inputs.principal, inputs.bootStackSlug)).toBe(
+      "federated.other-p.work.",
+    );
+  });
+
+  test("Fixture 1 split-verdict: accept-list from bootPrincipal PASSES boot; the pre-fix flag-principal list is REFUSED", () => {
+    const res = deriveJoinInputs(
+      "metafactory",
+      { principal: "other-p" },
+      "/cfg",
+      reader(FLAG_DRIFT),
+      "darwin",
+    );
+    const inputs = res.inputs;
+    if (inputs === undefined) throw new Error("expected inputs");
+
+    // What the fixed join own-scope guard builds + persists: the own-scope
+    // accept-list from bootPrincipal ("andreas") + bootStackSlug ("work").
+    const acceptFromBoot = ownAcceptSubjects({
+      principal: inputs.bootPrincipal,
+      stack: inputs.bootStackSlug,
+    });
+    expect(acceptFromBoot.every((s) => s.startsWith("federated.andreas.work."))).toBe(true);
+
+    // The PRE-FIX path built the accept-list from the flag/locator principal ("other-p").
+    const acceptFromFlag = ownAcceptSubjects({
+      principal: inputs.principal,
+      stack: inputs.bootStackSlug,
+    });
+
+    // AGREEMENT: the daemon boot validator ACCEPTS exactly what the fixed join
+    // writes (boot pins principal to config.principal.id = "andreas") ...
+    expect(() =>
+      CortexConfigSchema.parse(bootConfig("andreas", "andreas/work", acceptFromBoot)),
+    ).not.toThrow();
+    // ... and REFUSES the pre-fix flag-principal list — the latent split closed.
+    expect(() =>
+      CortexConfigSchema.parse(bootConfig("andreas", "andreas/work", acceptFromFlag)),
+    ).toThrow();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fixture 2 — the OVERRIDE PATH, the case that PROVES the target choice. Config
+  // principal.id is "andreas" but stack.id is "jcfischer/sage-host" (principal-half
+  // "jcfischer" ≠ principal.id). No flags. deriveStackId(cfg).principal is
+  // "jcfischer" — using THAT for the guard would re-split against boot, which pins
+  // to config.principal.id = "andreas". bootPrincipal = config.principal.id gets
+  // it right.
+  // ---------------------------------------------------------------------------
+  const OVERRIDE_PATH = loaded({
+    principal: { id: "andreas" },
+    stack: {
+      id: "jcfischer/sage-host",
+      nkey_seed_path: "~/seed.nk",
+      nats_infra: {
+        config_path: "~/local.conf",
+        plist_path: "~/nats.plist",
+        account: "A" + "B".repeat(55),
+      },
+    },
+    policy: {
+      principals: [],
+      roles: [],
+      federated: {
+        networks: [],
+        registry: { url: DEFAULT_REGISTRY.url, pubkey: DEFAULT_REGISTRY.pubkey },
+      },
+    },
+  });
+
+  test("override path: bootPrincipal is config.principal.id, NOT deriveStackId().principal → matches boot", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(OVERRIDE_PATH), "darwin");
+    expect(res.ok).toBe(true);
+    const inputs = res.inputs;
+    if (inputs === undefined) throw new Error("expected inputs");
+
+    // deriveStackId splits the stack.id principal-half OFF ("jcfischer") — the
+    // WRONG authority for the wire principal.
+    expect(deriveStackId(OVERRIDE_PATH).principal).toBe("jcfischer");
+    // The fix pins bootPrincipal to config.principal.id — the wire principal.
+    expect(inputs.bootPrincipal).toBe("andreas");
+    expect(inputs.bootStackSlug).toBe("sage-host");
+
+    // BOOT's authority: ownFederatedSubjectScopePrefix(config.principal.id, deriveStackId.stack).
+    const bootPrefix = ownFederatedSubjectScopePrefix("andreas", deriveStackId(OVERRIDE_PATH).stack);
+    expect(bootPrefix).toBe("federated.andreas.sage-host.");
+    // The fixed guard (bootPrincipal) matches boot ...
+    expect(ownFederatedSubjectScopePrefix(inputs.bootPrincipal, inputs.bootStackSlug)).toBe(bootPrefix);
+    // ... while the team-lead's ORIGINAL target (deriveStackId().principal) would NOT —
+    // this is exactly why the principal axis must NOT mirror the stack axis.
+    expect(
+      ownFederatedSubjectScopePrefix(deriveStackId(OVERRIDE_PATH).principal, inputs.bootStackSlug),
+    ).not.toBe(bootPrefix);
+    expect(
+      ownFederatedSubjectScopePrefix(deriveStackId(OVERRIDE_PATH).principal, inputs.bootStackSlug),
+    ).toBe("federated.jcfischer.sage-host.");
+  });
+
+  test("Fixture 2 split-verdict: accept-list from config.principal.id PASSES boot; the deriveStackId-principal list is REFUSED", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(OVERRIDE_PATH), "darwin");
+    const inputs = res.inputs;
+    if (inputs === undefined) throw new Error("expected inputs");
+
+    // The fixed guard's own-scope accept-list (bootPrincipal = config.principal.id).
+    const acceptFromBoot = ownAcceptSubjects({
+      principal: inputs.bootPrincipal,
+      stack: inputs.bootStackSlug,
+    });
+    expect(acceptFromBoot.every((s) => s.startsWith("federated.andreas.sage-host."))).toBe(true);
+
+    // The list the team-lead's original (deriveStackId().principal = "jcfischer") target would build.
+    const acceptFromDeriveStackId = ownAcceptSubjects({
+      principal: deriveStackId(OVERRIDE_PATH).principal,
+      stack: inputs.bootStackSlug,
+    });
+
+    // AGREEMENT: boot (which pins principal to config.principal.id = "andreas")
+    // ACCEPTS exactly what the fixed join writes ...
+    expect(() =>
+      CortexConfigSchema.parse(bootConfig("andreas", "jcfischer/sage-host", acceptFromBoot)),
+    ).not.toThrow();
+    // ... and REFUSES the deriveStackId-principal list — proving `config.principal.id`
+    // is the correct authority and `deriveStackId().principal` would have re-split.
+    expect(() =>
+      CortexConfigSchema.parse(bootConfig("andreas", "jcfischer/sage-host", acceptFromDeriveStackId)),
+    ).toThrow();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Born-aligned — the common case, unchanged.
+  // ---------------------------------------------------------------------------
+  test("BORN-ALIGNED principal (no drift) is unchanged: bootPrincipal == the flag/locator principal", () => {
+    // FULL is born-aligned (principal.id andreas, stack.id andreas/meta-factory);
+    // no --principal override.
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(FULL), "darwin");
+    const inputs = res.inputs;
+    if (inputs === undefined) throw new Error("expected inputs");
+    // The locator and the boot authority coincide — exact pre-fix behaviour.
+    expect(inputs.bootPrincipal).toBe("andreas");
+    expect(inputs.principal).toBe("andreas");
+    expect(inputs.bootPrincipal).toBe(deriveStackId(FULL).principal);
   });
 });

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -50,7 +50,39 @@ import { resolveRegistryAnchor } from "./default-registry";
 
 /** The five join inputs `cortex network join` previously demanded as flags. */
 export interface DerivedJoinInputs {
+  /**
+   * Flag-honouring principal LOCATOR: `--principal` wins, else `principal.id`.
+   * Feeds the write-path target (`portsConfigFromInputs` → `stackId` /
+   * `provision-stack register`), which per ADR-0004 DA-5 follows the flag — NOT
+   * the federation-identity authority. See {@link bootPrincipal}.
+   */
   principal: string;
+  /**
+   * C-1436 — the boot-authoritative own-scope principal segment: `cfg.principal.id`,
+   * the EXACT value the daemon boot validator pins the federated subject scope to
+   * (`CortexConfigSchema` federated subject-scope superRefine → `config.principal.id`,
+   * cortex-config.ts) AND the value the runtime stamps onto the wire
+   * (`resolvePrincipalId(options.principal)` → the `federated.{principal}.{stack}.>`
+   * inbound subscription + `envelope.source` seg[0] on emit). So the join own-scope
+   * guard and boot can never split on a config whose `--principal` locator (or a
+   * `stack.id` principal-half) differs from `principal.id`.
+   *
+   * NOTE — this is `cfg.principal.id` DIRECTLY, deliberately NOT
+   * `deriveStackId(cfg).principal` (the mirror of the C-1364 stack axis does NOT
+   * carry over here). On the documented `deriveStackId` override path
+   * (`principal.id: andreas` running `stack.id: jcfischer/sage-host`)
+   * `deriveStackId().principal` is `jcfischer` while the runtime still subscribes
+   * `federated.andreas.…`; validating the guard against `jcfischer` would force a
+   * prefix that never matches boot — the very split this fixes. Boot pins to
+   * `config.principal.id` for exactly this reason (see the cortex-config.ts
+   * federated subject-scope superRefine rationale comment). Unlike {@link principal}
+   * it is flag-INDEPENDENT — `--principal` retargets the write-path locator but must
+   * NOT move the federation identity boot enforces.
+   * The join own-scope guard (`ownAcceptSubjects` / `ownFederatedSubjectScopePrefix`
+   * / `isFederatedSubjectInOwnScope` in `network-lib.ts`) MUST build its
+   * `federated.{principal}.` scope from THIS, never from {@link principal}.
+   */
+  bootPrincipal: string;
   /**
    * `{principal}/{slug}` canonical stack id — flag-honouring. `--stack` wins,
    * else `stack.id`, else `{principal}/default` (see {@link resolveStack}). This
@@ -370,13 +402,29 @@ export function deriveJoinInputs(
 ): DeriveResult<DerivedJoinInputs> {
   const cfg = load(configPath);
 
-  // principal — flag wins, else principal.id.
+  // principal (LOCATOR) — flag wins, else principal.id. Feeds the write-path
+  // target per ADR-0004 DA-5.
   const principal = overrides.principal ?? cfg.principal?.id;
   if (principal === undefined || principal === "") {
     return fail(
       "cannot resolve principal — pass --principal or set `principal.id` in cortex.yaml",
     );
   }
+
+  // C-1436 — the boot-authoritative own-scope principal segment. Pinned to
+  // `cfg.principal.id` DIRECTLY — the EXACT value the daemon boot validator uses
+  // (`CortexConfigSchema` federated subject-scope superRefine → `config.principal.id`)
+  // and the runtime stamps onto the wire (`federated.{principal}.{stack}.>` +
+  // `envelope.source` seg[0]). Deliberately NOT `deriveStackId(cfg).principal`:
+  // on the documented override path (`principal.id: andreas` running
+  // `stack.id: jcfischer/sage-host`) that would be `jcfischer` while the runtime
+  // subscribes `federated.andreas.…` — re-splitting the guard against boot. And
+  // deliberately flag-INDEPENDENT: `--principal` retargets the write-path locator
+  // (DA-5) but must never move the federation identity boot enforces. Falls back
+  // to the resolved `principal` only when the config declares no `principal.id`
+  // (the config-less / fully-flagged back-compat path, where no boot validator
+  // runs to split against).
+  const bootPrincipal = cfg.principal?.id ?? principal;
 
   const stack = resolveStack(principal, overrides.stack, cfg);
 
@@ -501,6 +549,7 @@ export function deriveJoinInputs(
     ok: true,
     inputs: {
       principal,
+      bootPrincipal,
       stack,
       bootStackSlug,
       seedPath,

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -892,7 +892,20 @@ async function runJoin(
   const resolvedLeafUser = inputs.leafUser ?? autoSecret?.leafUser;
 
   const stack: JoiningStack = {
-    principalId: inputs.principal,
+    // C-1436 — the own-scope federation identity's PRINCIPAL segment MUST derive
+    // from `config.principal.id` (via `inputs.bootPrincipal`), the SAME single
+    // authority the daemon boot validator pins to (`CortexConfigSchema` federated
+    // subject-scope superRefine → `config.principal.id`) and the runtime stamps
+    // onto the wire. `inputs.principal` is the flag/locator-honouring principal and
+    // stays the write-path target per ADR-0004 DA-5 — but a `--principal` override
+    // (or a `stack.id` principal-half) that differs from `principal.id` would make
+    // the guard validate `federated.{flag}.` while boot enforces `federated.{config}.`,
+    // letting a config pass the join own-scope guard yet fail daemon boot (or be
+    // falsely refused). NOTE — deliberately NOT `deriveStackId().principal` (the
+    // C-1364 stack-axis pattern does not carry over): on the override path that
+    // returns the `stack.id` principal-half, which is NOT the wire principal. Pin
+    // the guard to `bootPrincipal` so guard + boot can never split. See cortex#1436.
+    principalId: inputs.bootPrincipal,
     // C-1364 — the own-scope federation identity MUST derive from `stack.id` via
     // `deriveStackId` (ADR-0004), the SAME single authority the daemon boot
     // validator uses (`CortexConfigSchema` federated subject-scope superRefine).


### PR DESCRIPTION
## What

The `cortex network join` own-scope guard and the daemon boot validator derived the joining stack's federation **principal** segment from a **different** source, on the **same** validation contract — the PRINCIPAL-axis mirror of #1364 (which fixed the stack axis):

- **Join guard** (`network.ts` `runJoin` → `JoiningStack.principalId` → `ownAcceptSubjects` / `ownFederatedSubjectScopePrefix` / `isFederatedSubjectInOwnScope`) built its `federated.{me}.{stack}.` own-scope principal from the **flag/locator-honouring** `inputs.principal` (`--principal` wins, else `principal.id`).
- **Boot** (`CortexConfigSchema` federated subject-scope superRefine, `cortex-config.ts`) pins the same segment to `config.principal.id` — the value the runtime stamps onto the wire (`resolvePrincipalId` → the `federated.{principal}.{stack}.>` subscription + `envelope.source` seg[0]).

For a **born-aligned** config they agree. For a **drifted** config — a `--principal` override, or a `stack.id` principal-half ≠ `principal.id` — they **split**: the join persists an accept-list scoped to one principal the daemon then **refuses to boot** against, or **falsely refuses** a valid config.

## How

Thread `bootPrincipal = cfg.principal.id` out of `deriveJoinInputs` and pin `JoiningStack.principalId` to it. The guard now derives its principal identity from the **same authority** boot uses — one source, cannot drift.

The flag/locator principal (`inputs.principal`) is **retained** for the write-path target (`portsConfigFromInputs` → `stackId`, `provision-stack register`), which per **ADR-0004 DA-5** correctly follows the flag. Federation identity (from `config.principal.id`) and write-path locator are orthogonal; only the identity was wrong.

## Why `config.principal.id`, NOT `deriveStackId(cfg).principal`

**The principal axis is deliberately NOT an exact mirror of #1364's stack axis.** #1364 converged the stack segment onto `deriveStackId(config).stack`. The naive mirror would converge the principal onto `deriveStackId(config).principal` — **but that is wrong**, and the boot validator's own rationale comment (`cortex-config.ts`, the federated subject-scope superRefine, ≈ lines 3230–3246) says exactly why:

> The PRINCIPAL segment MUST come from `config.principal.id` … We deliberately do NOT take the principal from `deriveStackId(config).principal`: when an explicit `stack:` block declares a DIFFERENT principal-half (the documented override path — e.g. `principal.id: andreas` running `stack.id: jcfischer/sage-host`), `deriveStackId().principal` is `jcfischer` while the runtime still subscribes/emits on `federated.andreas.…`. Validating against `jcfischer` would force a prefix that never matches the live subscription — a silent-drop that parses clean. Pin the principal to the wire source.

So the boot authority is `config.principal.id`; the fix converges the guard onto that **same** source (`cortex-config.ts:3246` `const principal = config.principal.id;`). Converging onto `deriveStackId().principal` would have re-opened the split on the override path.

## Both derivation sites — before → after

| Site | Before | After |
|---|---|---|
| Join guard principal | `network.ts:895` `principalId: inputs.principal` (flag/locator) | `network.ts:908` `principalId: inputs.bootPrincipal` (`cfg.principal.id`) |
| Source of that value | (none — flag/locator only) | `network-derive.ts:427` `bootPrincipal = cfg.principal?.id ?? principal` (flag-independent), returned from `deriveJoinInputs` |
| Boot validator (unchanged) | `cortex-config.ts:3246` `config.principal.id` | *(unchanged — this is the authority we converge onto)* |
| Write-path locator (unchanged) | `network.ts` `portsConfigFromInputs(…, slugRes.slug, …)` uses `inputs.principal` | *(unchanged — ADR-0004 DA-5)* |

## Tests — two drifted-principal split-verdict fixtures + born-aligned

`network-derive.test.ts` → `describe("C-1436 …")`:

1. **Fixture 1 — `--principal` drift (headline #1436 case):** config `principal.id: andreas` (born-aligned stack `andreas/work`), joined with `--principal other-p`. `bootPrincipal` stays `andreas`; the guard prefix equals the boot prefix (`federated.andreas.work.`), while the pre-fix flag-principal prefix (`federated.other-p.work.`) differs. End-to-end via the **real `CortexConfigSchema.parse`**: the accept-list from `bootPrincipal` **passes** boot; the flag-principal list is **refused**. Both accept / both refuse — never split.
2. **Fixture 2 — the override path (proves the target choice):** config `principal.id: andreas` but `stack.id: jcfischer/sage-host`. `deriveStackId(cfg).principal === "jcfischer"` (asserted), but `bootPrincipal === "andreas"`. The fixed guard matches boot (`federated.andreas.sage-host.`); the `deriveStackId().principal` alternative (`federated.jcfischer.sage-host.`) does **not**. Via the real parser: the `config.principal.id` accept-list **passes**, the `deriveStackId().principal` list is **refused** — exactly the case where the naive mirror would have re-split.
3. **Born-aligned unchanged:** `FULL` (principal.id andreas, no override) has `bootPrincipal === principal === deriveStackId(FULL).principal === "andreas"`; pre-fix behaviour preserved. The two existing exact-shape `deriveJoinInputs` assertions were updated to include `bootPrincipal` (the flag-override one already carried a drifted `--principal override-p`, now asserting `bootPrincipal: "andreas"`).

Test-fixture Discord snowflakes use all-same-digit placeholders (`111…`/`222…`/`333…`) per the confidentiality-gate tier2 allow-list.

## Four-check results (from `../Cortex-princ`)

- `bunx eslint --quiet .` → **0** ✅
- `bunx tsc --noEmit` → **0** ✅
- `bash scripts/check-carveouts.sh` → **PASS** ✅
- `bun test src/cli/cortex/commands src/common/config` → **1410 pass, 0 fail** (5 todo) ✅

Closes #1436. Refs #1364, ADR-0004. Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB