### PR TITLE
feat(network): C-1350 Slice 2 — network status tells a REVOKED member to clean up

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -671,7 +671,10 @@ describe("joinBlockerMessage (C-1315)", () => {
   });
 
   test("revoked / rejected → their own messages", () => {
-    expect(joinBlockerMessage(NET, st({ state: "revoked", requestId: "r" }))).toContain("REVOKED");
+    const revoked = joinBlockerMessage(NET, st({ state: "revoked", requestId: "r" }));
+    expect(revoked).toContain("REVOKED");
+    // C-1350 (Slice 2) — the join error path also names the cleanup command.
+    expect(revoked).toContain("cortex network leave metafactory --apply");
     expect(joinBlockerMessage(NET, st({ state: "rejected", requestId: "r" }))).toContain("REJECTED");
   });
 

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -28,6 +28,7 @@ import {
   type JoiningStack,
 } from "../network-lib";
 import type {
+  AdmissionStatePort,
   CachedNetworkPort,
   CachedNetworkSummary,
   ConfigStorePort,
@@ -40,6 +41,7 @@ import type {
   PlistPort,
   RenderLeafInputs,
 } from "../network-ports";
+import type { ResolveOwnAdmissionStateResult } from "../../../../common/registry/admission-state";
 import type {
   NetworkDescriptor,
   NetworkRosterResult,
@@ -168,6 +170,13 @@ function makeFakes(opts: {
    * this list; absent → no port (status reports config-joined networks only).
    */
   cachedNetworks?: CachedNetworkSummary[];
+  /**
+   * C-1350 (Slice 2) — member-side admission resolver for `status`. Keyed by
+   * network id → the classified `/mine` result the fake port returns. When
+   * present, {@link makeFakes} wires an {@link AdmissionStatePort}; absent → no
+   * port (status attaches no admission field — the pre-C-1350 behaviour).
+   */
+  admission?: Record<string, ResolveOwnAdmissionStateResult>;
   /** #794 — make the stack's nats config UNABLE to bind the leaf account. */
   canBind?: boolean;
   /**
@@ -482,6 +491,11 @@ function makeFakes(opts: {
       ...(opts.cachedNetworks !== undefined
         ? { cachedNetworks: makeCachedNetworkPort(opts.cachedNetworks) }
         : {}),
+      // C-1350 (Slice 2) — wire the fake admission resolver only when a test
+      // supplies one, so pre-C-1350 status tests attach no admission field.
+      ...(opts.admission !== undefined
+        ? { admission: makeAdmissionStatePort(opts.admission) }
+        : {}),
     },
     rec,
     storeRef,
@@ -493,6 +507,23 @@ function makeCachedNetworkPort(list: CachedNetworkSummary[]): CachedNetworkPort 
   return {
     list() {
       return list;
+    },
+  };
+}
+
+/**
+ * C-1350 (Slice 2) — a fake {@link AdmissionStatePort} over a fixed network→result
+ * map. An unmapped network resolves `{ ok: false }` (models the registry
+ * unreachable / not-configured path → the `unavailable` best-effort hint).
+ */
+function makeAdmissionStatePort(
+  byNetwork: Record<string, ResolveOwnAdmissionStateResult>,
+): AdmissionStatePort {
+  return {
+    resolve(networkId): Promise<ResolveOwnAdmissionStateResult> {
+      return Promise.resolve(
+        byNetwork[networkId] ?? { ok: false, reason: "no stubbed admission result" },
+      );
     },
   };
 }
@@ -1819,6 +1850,115 @@ describe("status", () => {
     });
     const res = await networkStatus(ports);
     expect(res.networks[0]!.link.state).toBe("unknown");
+  });
+
+  // ===========================================================================
+  // C-1350 (Slice 2) — revoke tells the member.
+  // ===========================================================================
+  describe("C-1350: admission-state surfacing", () => {
+    test("a REVOKED own-row surfaces revoked + the cleanup command's network + date", async () => {
+      const { ports } = makeFakes({
+        initialNetworks: [joinedNetwork("metafactory")],
+        admission: {
+          metafactory: {
+            ok: true,
+            state: {
+              state: "revoked",
+              networkId: "metafactory",
+              requestId: "req-abc",
+              hasSealedSecret: false,
+              peerPubkey: "PUB",
+              updatedAt: "2026-07-01T12:00:00.000Z",
+            },
+          },
+        },
+      });
+      const res = await networkStatus(ports);
+      const row = res.networks[0]!;
+      expect(row.admission).toBeDefined();
+      expect(row.admission!.revoked).toBe(true);
+      expect(row.admission!.lookup).toBe("ok");
+      expect(row.admission!.revokedAt).toBe("2026-07-01T12:00:00.000Z");
+      expect(row.admission!.requestId).toBe("req-abc");
+      // The network id the cleanup command needs rides the row.
+      expect(row.networkId).toBe("metafactory");
+    });
+
+    test("an ADMITTED/live own-row attaches NO admission field (no false REVOKED)", async () => {
+      const leafState: LeafStatePort = {
+        async linkStates() {
+          return { metafactory: { state: "established" } };
+        },
+      };
+      const { ports } = makeFakes({
+        initialNetworks: [joinedNetwork("metafactory")],
+        leafState,
+        admission: {
+          metafactory: {
+            ok: true,
+            state: {
+              state: "admitted-sealed",
+              networkId: "metafactory",
+              requestId: "req-ok",
+              hasSealedSecret: true,
+              peerPubkey: "PUB",
+              updatedAt: "2026-07-01T12:00:00.000Z",
+            },
+          },
+        },
+      });
+      const res = await networkStatus(ports);
+      const row = res.networks[0]!;
+      expect(row.link.state).toBe("established");
+      // No admission field at all — an ordinary live row is unchanged.
+      expect(row.admission).toBeUndefined();
+    });
+
+    test("a failed /mine read degrades to admission_lookup unavailable (non-fatal)", async () => {
+      const { ports } = makeFakes({
+        initialNetworks: [joinedNetwork("metafactory")],
+        admission: {
+          metafactory: { ok: false, reason: "registry unreachable" },
+        },
+      });
+      const res = await networkStatus(ports);
+      // status still succeeds — the read is best-effort.
+      expect(res.ok).toBe(true);
+      const row = res.networks[0]!;
+      expect(row.admission).toBeDefined();
+      expect(row.admission!.revoked).toBe(false);
+      expect(row.admission!.lookup).toBe("unavailable");
+    });
+
+    test("no admission port wired → no admission field (pre-C-1350 unchanged)", async () => {
+      const { ports } = makeFakes({ initialNetworks: [joinedNetwork("metafactory")] });
+      const res = await networkStatus(ports);
+      expect(res.networks[0]!.admission).toBeUndefined();
+    });
+
+    test("a REVOKED row with no revoked-at date still surfaces revoked (older registry)", async () => {
+      const { ports } = makeFakes({
+        initialNetworks: [joinedNetwork("metafactory")],
+        admission: {
+          metafactory: {
+            ok: true,
+            state: {
+              state: "revoked",
+              networkId: "metafactory",
+              requestId: "req-nodate",
+              hasSealedSecret: false,
+              peerPubkey: "PUB",
+              // updatedAt omitted — an older registry that doesn't echo it.
+            },
+          },
+        },
+      });
+      const res = await networkStatus(ports);
+      const row = res.networks[0]!;
+      expect(row.admission!.revoked).toBe(true);
+      expect(row.admission!.revokedAt).toBeUndefined();
+      expect(row.admission!.requestId).toBe("req-nodate");
+    });
   });
 });
 

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -77,6 +77,7 @@ import type {
 } from "../../../common/types/cortex-config";
 
 import type {
+  AdmissionStatePort,
   CachedNetworkPort,
   ConfigStorePort,
   DaemonPort,
@@ -88,6 +89,10 @@ import type {
   PlistPort,
   RenderLeafInputs,
 } from "./network-ports";
+import {
+  resolveOwnAdmissionState,
+  type ResolveOwnAdmissionStateResult,
+} from "../../../common/registry/admission-state";
 import { buildFederationWiringAdapter } from "./network-federation-wiring";
 import type {
   PublicPolicyPort,
@@ -1230,6 +1235,73 @@ export function buildCachedNetworkPort(): CachedNetworkPort {
 }
 
 // =============================================================================
+// Admission-state port — C-1350 (Slice 2), member-side `/mine` read for status.
+// =============================================================================
+
+/**
+ * C-1350 (Slice 2) — override the member `/mine` admission resolver in tests so a
+ * CLI `status` test can stub a REVOKED row without a live registry. Production
+ * leaves this `null` → the real {@link resolveOwnAdmissionState} PoP read.
+ */
+type AdmissionResolver = (
+  networkId: string,
+  inputs: { registryUrl: string; principalId: string; material: StackIdentityMaterial },
+) => Promise<ResolveOwnAdmissionStateResult>;
+let admissionResolverOverride: AdmissionResolver | null = null;
+
+/** Test seam — inject a fake admission resolver (or `null` to restore live). */
+export function __setAdmissionResolverForTests(f: AdmissionResolver | null): void {
+  admissionResolverOverride = f;
+}
+
+/**
+ * C-1350 (Slice 2) — the live member-side admission-state resolver for `status`.
+ * PoP-signs `GET /admission-requests/mine` with the stack's OWN seed and
+ * classifies the row for `networkId`. Best-effort + non-fatal: a missing
+ * registry URL / seed path / unreadable seed becomes a typed `{ ok: false,
+ * reason }` so `status` degrades to `admission_lookup: unavailable` rather than
+ * failing. NEVER throws.
+ */
+export function buildAdmissionStatePort(cfg: LivePortsConfig): AdmissionStatePort {
+  return {
+    async resolve(networkId): Promise<ResolveOwnAdmissionStateResult> {
+      const registryUrl = cfg.registryUrl;
+      if (registryUrl === undefined || registryUrl === "") {
+        return { ok: false, reason: "no registry url configured for admission lookup" };
+      }
+      if (cfg.seedPath === undefined || cfg.seedPath === "") {
+        return { ok: false, reason: "no signing seed configured for admission lookup" };
+      }
+      const matRes = loadSeedMaterial(cfg.seedPath, "--seed-path");
+      if (!matRes.ok) return { ok: false, reason: matRes.reason };
+
+      const resolver = admissionResolverOverride ?? liveResolveOwnAdmissionState;
+      try {
+        return await resolver(networkId, {
+          registryUrl,
+          principalId: cfg.principalId,
+          material: matRes.material,
+        });
+      } catch (err) {
+        // resolveOwnAdmissionState is soft-closed, but guard the seam anyway so a
+        // faulty injected resolver can never break a read-only `status`.
+        return {
+          ok: false,
+          reason: `admission lookup errored: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    },
+  };
+}
+
+/** The production resolver — thin wrapper matching the {@link AdmissionResolver} shape. */
+const liveResolveOwnAdmissionState: AdmissionResolver = (networkId, inputs) =>
+  resolveOwnAdmissionState(
+    { registryUrl: inputs.registryUrl, principalId: inputs.principalId, material: inputs.material },
+    networkId,
+  );
+
+// =============================================================================
 // Bundle builders
 // =============================================================================
 
@@ -1248,6 +1320,11 @@ function buildPorts(cfg: LivePortsConfig, mutate: boolean): NetworkPorts {
     // REGISTERED networks (descriptor cached, not joined). Read-only; a missing
     // cache dir degrades to no registered rows.
     cachedNetworks: buildCachedNetworkPort(),
+    // C-1350 (Slice 2) — always wire the member-side admission resolver so
+    // `status` can tell a REVOKED member to clean up. Read-only + best-effort:
+    // absent registry-url / seed → the port returns `unavailable` (never throws),
+    // and only `networkStatus` reads it, so join/leave are unaffected.
+    admission: buildAdmissionStatePort(cfg),
     // G1c (#1117, ADR-0013 Model B) — wire the local-side `federated.>`
     // export/import by shelling to `arc nats add-federation-export`. The port
     // is always wired; step (b.4) in joinNetwork uses it only when the bus is

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -55,6 +55,7 @@ import {
   brandVerified,
   type NetworkPorts,
   type LeafLinkState,
+  type AdmissionStatePort,
 } from "./network-ports";
 
 // =============================================================================
@@ -197,6 +198,34 @@ export interface StatusNetworkRow {
   link: LeafLinkState;
   /** C-850 — lifecycle stage (JSON `items[].status` + human output). */
   status: NetworkLifecycleStatus;
+  /**
+   * C-1350 (Slice 2) — the member's OWN admission-row state for this network,
+   * from the PoP `/mine` read. Present ONLY when the {@link NetworkPorts.admission}
+   * port is wired AND (the row is REVOKED, or the lookup could not be completed).
+   * A live/admitted row leaves this UNDEFINED so an ordinary status row is
+   * byte-for-byte unchanged (no false REVOKED). Rides the JSON `items[]` so a
+   * revoked member's tooling sees `admission.revoked === true`.
+   */
+  admission?: AdmissionStatusInfo;
+}
+
+/**
+ * C-1350 (Slice 2) — the member-side admission summary attached to a status row.
+ * Populated only when meaningful (REVOKED, or the lookup was unavailable).
+ */
+export interface AdmissionStatusInfo {
+  /** True when this stack's own admission row for the network is REVOKED. */
+  revoked: boolean;
+  /** ISO-8601 UTC the row was revoked (`updated_at`), when the registry supplied it. */
+  revokedAt?: string;
+  /** The admission request id, when known — echoed for the admin/audit trail. */
+  requestId?: string;
+  /**
+   * `"ok"` when the `/mine` read succeeded; `"unavailable"` when it failed
+   * (registry unreachable / no seed / not configured). `unavailable` is the
+   * best-effort, non-fatal signal — `status` never fails on it.
+   */
+  lookup: "ok" | "unavailable";
 }
 
 // =============================================================================
@@ -1093,5 +1122,50 @@ export async function networkStatus(ports: NetworkPorts): Promise<StatusResult> 
     });
   }
 
-  return { ok: true, networks: [...configRows, ...registeredRows] };
+  const rows = [...configRows, ...registeredRows];
+
+  // C-1350 (Slice 2) — when the admission port is wired, check each network's
+  // OWN admission row (member PoP `/mine` read) and attach a revoked/unavailable
+  // summary. This is the member-side half of `secret revoke-member`: a revoked
+  // member sees an explicit REVOKED message + cleanup command instead of a dead
+  // leaf-include mystery. Best-effort + non-fatal — a read failure attaches an
+  // `admission_lookup: unavailable` hint and NEVER fails `status`. An admitted /
+  // live row gets NO admission field (output stays unchanged; no false REVOKED).
+  const admission = ports.admission;
+  if (admission !== undefined) {
+    await Promise.all(
+      rows.map(async (row) => {
+        const info = await resolveAdmissionInfo(admission, row.networkId);
+        if (info !== undefined) row.admission = info;
+      }),
+    );
+  }
+
+  return { ok: true, networks: rows };
+}
+
+/**
+ * C-1350 (Slice 2) — resolve the member-side admission summary for ONE network,
+ * or `undefined` when there is nothing to surface (admitted / pending / no row).
+ * Best-effort: a `/mine` read failure becomes `{ revoked: false, lookup:
+ * "unavailable" }` rather than throwing. Only a REVOKED row (or a failed lookup)
+ * produces a summary — everything else returns `undefined` so an ordinary status
+ * row is unchanged.
+ */
+async function resolveAdmissionInfo(
+  admission: AdmissionStatePort,
+  networkId: string,
+): Promise<AdmissionStatusInfo | undefined> {
+  const res = await admission.resolve(networkId);
+  if (!res.ok) {
+    // Non-fatal — surface the lookup gap, keep the row (match #1315 posture).
+    return { revoked: false, lookup: "unavailable" };
+  }
+  if (res.state.state !== "revoked") return undefined;
+  return {
+    revoked: true,
+    lookup: "ok",
+    ...(res.state.updatedAt !== undefined && { revokedAt: res.state.updatedAt }),
+    ...(res.state.requestId !== undefined && { requestId: res.state.requestId }),
+  };
 }

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -30,6 +30,7 @@ import type {
   NetworkDescriptor,
   NetworkRosterResult,
 } from "../../../common/registry/types";
+import type { ResolveOwnAdmissionStateResult } from "../../../common/registry/admission-state";
 import type { NetworkFetchResult } from "../../../common/registry/network-client";
 import type {
   AccountBindCheck,
@@ -400,6 +401,28 @@ export interface CachedNetworkSummary {
   peers: string[];
 }
 
+/**
+ * C-1350 (Slice 2) — read-only member-side admission-state resolver for
+ * `status`. Wraps the PoP `GET /admission-requests/mine` read
+ * ({@link resolveOwnAdmissionState}) so `networkStatus` can tell a member their
+ * OWN admission row for a network was REVOKED — the member-side half of
+ * `secret revoke-member` (which already flips the registry row) — instead of the
+ * silent dead-leaf-include / leaf-auth mystery.
+ *
+ * Optional on {@link NetworkPorts} (mirrors {@link LeafStatePort} /
+ * {@link CachedNetworkPort}): absent → `status` reports no admission state (the
+ * pre-C-1350 behaviour). Every failure is a typed `{ ok: false, reason }` (never
+ * throws) so a `/mine` read error degrades `status` to an `admission_lookup:
+ * unavailable` hint rather than breaking the read (best-effort, per #1315).
+ */
+export interface AdmissionStatePort {
+  /**
+   * Resolve THIS stack's own admission state for `networkId` via the member
+   * PoP `/mine` read. Never throws — a read failure is `{ ok: false, reason }`.
+   */
+  resolve(networkId: string): Promise<ResolveOwnAdmissionStateResult>;
+}
+
 /** One network's leaf link state for `status`. */
 export interface LeafLinkState {
   /** ESTABLISHED / connecting / down / unknown. */
@@ -472,6 +495,15 @@ export interface NetworkPorts {
    * set so registered-but-not-joined networks are no longer invisible.
    */
   cachedNetworks?: CachedNetworkPort;
+  /**
+   * C-1350 (Slice 2) — optional member-side admission-state resolver for
+   * `status`. Absent → `status` reports no admission state (pre-C-1350). Present
+   * → `networkStatus` checks each network's own admission row and, when REVOKED,
+   * surfaces the "you were REVOKED … run `cortex network leave <net> --apply`"
+   * cleanup message. Best-effort + non-fatal (a `/mine` read failure degrades to
+   * an `admission_lookup: unavailable` hint, never breaks `status`).
+   */
+  admission?: AdmissionStatePort;
   /**
    * G1c (#1117, ADR-0013 Model B) — federation-wiring seam. Optional for
    * backwards compatibility: when absent the wiring step is skipped (the

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -698,8 +698,10 @@ export function joinBlockerMessage(networkId: string, s: OwnAdmissionState): str
       );
     case "revoked":
       return (
-        `admission for "${networkId}" was REVOKED (request ${s.requestId ?? "(unknown)"}) — membership was withdrawn. ` +
-        `Re-register or contact a network admin. A legacy .creds file is NOT the fix.`
+        `admission for "${networkId}" was REVOKED (request ${s.requestId ?? "(unknown)"}` +
+        `${s.updatedAt !== undefined ? ` on ${s.updatedAt}` : ""}) — membership was withdrawn. ` +
+        `Run \`cortex network leave ${networkId} --apply\` to clean up the dead leaf, then re-register or ` +
+        `contact a network admin to re-join. A legacy .creds file is NOT the fix.`
       );
     case "rejected":
       return (
@@ -1040,6 +1042,7 @@ async function runLeave(
 async function runStatus(
   flags: FlagMap,
   json: boolean,
+  load: ConfigReader,
 ): Promise<ExitResult> {
   const principalRes = requireValueFlag(flags, "--principal");
   if (!principalRes.ok) return usageError("status", principalRes.reason, json);
@@ -1062,8 +1065,26 @@ async function runStatus(
       : flags;
 
   const cfg = portsConfig("", principalRes.value, slugRes.slug, statusFlags);
+
+  // C-1350 (Slice 2) — resolve the registry-url + signing-seed the member `/mine`
+  // admission read needs, the SAME precedence join/leave use (flag → config →
+  // the compiled-in default registry / stack seed convention). Best-effort: an
+  // unreadable config is NOT fatal for a read-only status — the admission port
+  // simply reports `unavailable` when it can't sign the read.
+  const admissionCoords = resolveStatusAdmissionCoords(
+    statusFlags,
+    principalRes.value,
+    slugRes.slug,
+    load,
+  );
+  const cfgWithAdmission: LivePortsConfig = {
+    ...cfg,
+    ...(admissionCoords.registryUrl !== undefined && { registryUrl: admissionCoords.registryUrl }),
+    ...(admissionCoords.seedPath !== undefined && { seedPath: admissionCoords.seedPath }),
+  };
+
   // status is read-only — live ports, but it only ever reads.
-  const ports: NetworkPorts = buildLivePorts(cfg);
+  const ports: NetworkPorts = buildLivePorts(cfgWithAdmission);
 
   const res = await networkStatus(ports);
   if (json) {
@@ -1086,9 +1107,63 @@ async function runStatus(
     if (n.link.inMsgs !== undefined || n.link.outMsgs !== undefined) {
       lines.push(`    counters: in=${(n.link.inMsgs ?? 0).toString()} out=${(n.link.outMsgs ?? 0).toString()}`);
     }
+    // C-1350 (Slice 2) — a REVOKED member sees an explicit message naming the
+    // network + the cleanup command, instead of the silent dead-leaf mystery.
+    // An unavailable lookup surfaces a non-fatal hint (matches #1315 posture);
+    // an admitted/live row carries no admission field, so nothing is added.
+    if (n.admission?.revoked === true) {
+      const when = n.admission.revokedAt !== undefined ? ` on ${n.admission.revokedAt}` : "";
+      lines.push(
+        `    ⚠ REVOKED — you were removed from "${n.networkId}"${when}. ` +
+          `Run \`cortex network leave ${n.networkId} --apply\` to clean up the dead leaf.`,
+      );
+    } else if (n.admission?.lookup === "unavailable") {
+      lines.push(`    admission_lookup: unavailable`);
+    }
     lines.push("");
   }
   return ok(lines.join("\n"));
+}
+
+/**
+ * C-1350 (Slice 2) — resolve the registry-url + signing-seed the status
+ * admission `/mine` read needs, mirroring join/leave precedence: flag →
+ * `policy.federated.registry` / `stack.nkey_seed_path` → the compiled-in default
+ * registry. Read-only + best-effort — a config that fails to load returns only
+ * what the flags gave (the port then reports `unavailable`), never throwing so a
+ * status read cannot fail on the admission lookup.
+ */
+function resolveStatusAdmissionCoords(
+  flags: FlagMap,
+  principal: string,
+  slug: string,
+  load: ConfigReader,
+): { registryUrl?: string; seedPath?: string } {
+  const flagRegistry = optionalValueFlag(flags, "--registry-url");
+  const flagSeed = optionalValueFlag(flags, "--seed-path");
+
+  let cfg: LoadedConfig | undefined;
+  try {
+    cfg = load(resolveStatusConfigPath(slug));
+  } catch (_err) {
+    // Read-only status must not fail because the config couldn't be loaded; fall
+    // back to flags + the default registry. The admission port reports
+    // `unavailable` when it still can't resolve a seed. Safe to ignore.
+    cfg = undefined;
+  }
+
+  const registryUrl =
+    flagRegistry ?? cfg?.policy?.federated?.registry?.url ?? DEFAULT_REGISTRY_URL;
+  const seedPath =
+    flagSeed ?? cfg?.stack?.nkey_seed_path ?? `~/.config/nats/${principal}-${slug}.seed`;
+
+  // Both always resolve to a string (flag → config → the non-empty default), but
+  // a flag could be an empty string — omit an empty value so the port falls back
+  // to reporting `unavailable` rather than signing a read with a blank url/seed.
+  return {
+    ...(registryUrl !== "" && { registryUrl }),
+    ...(seedPath !== "" && { seedPath }),
+  };
 }
 
 // =============================================================================
@@ -3092,7 +3167,7 @@ export async function dispatchNetwork(
     case "leave":
       return runLeave(parsed.positionals.network ?? "", parsed.flags, json, load);
     case "status":
-      return runStatus(parsed.flags, json);
+      return runStatus(parsed.flags, json, load);
     case "create":
       return runCreate(parsed.positionals.network ?? "", parsed.flags, json);
     case "ping":

--- a/src/common/registry/__tests__/admission-state.test.ts
+++ b/src/common/registry/__tests__/admission-state.test.ts
@@ -35,6 +35,7 @@ function row(over: Partial<AdmissionMineRow> = {}): AdmissionMineRow {
     network_id: over.network_id === undefined ? "metafactory" : over.network_id,
     status: over.status ?? "PENDING",
     sealed_secret: over.sealed_secret === undefined ? null : over.sealed_secret,
+    ...(over.updated_at !== undefined && { updated_at: over.updated_at }),
   };
 }
 
@@ -82,6 +83,24 @@ describe("classifyOwnAdmissionRows", () => {
     expect(classifyOwnAdmissionRows([row({ status: "REVOKED" })], "metafactory", PUB).state).toBe("revoked");
     expect(classifyOwnAdmissionRows([row({ status: "REJECTED" })], "metafactory", PUB).state).toBe("rejected");
     expect(classifyOwnAdmissionRows([row({ status: "WEIRD" })], "metafactory", PUB).state).toBe("unknown");
+  });
+
+  // C-1350 (Slice 2) — the row's updated_at is threaded through as updatedAt so a
+  // REVOKED member can be told WHEN they were removed.
+  test("REVOKED row carries updated_at through as updatedAt (the revoked-at date)", () => {
+    const s = classifyOwnAdmissionRows(
+      [row({ status: "REVOKED", updated_at: "2026-07-01T09:30:00.000Z" })],
+      "metafactory",
+      PUB,
+    );
+    expect(s.state).toBe("revoked");
+    expect(s.updatedAt).toBe("2026-07-01T09:30:00.000Z");
+  });
+
+  test("a row with no updated_at leaves updatedAt undefined (older registry)", () => {
+    const s = classifyOwnAdmissionRows([row({ status: "REVOKED" })], "metafactory", PUB);
+    expect(s.state).toBe("revoked");
+    expect(s.updatedAt).toBeUndefined();
   });
 
   test("selects the row matching THIS network among several", () => {

--- a/src/common/registry/admission-state.ts
+++ b/src/common/registry/admission-state.ts
@@ -48,6 +48,14 @@ export interface AdmissionMineRow {
   network_id: string | null;
   status: string;
   sealed_secret: string | null;
+  /**
+   * C-1350 (Slice 2) — ISO-8601 UTC of the row's last transition. On a REVOKED
+   * row this IS the revoked-at date (`revokeAdmission` stamps `updated_at` = now
+   * on the ADMITTED→REVOKED transition). OPTIONAL on the wire: an older registry
+   * (or a store that omits it) leaves it undefined, so consumers treat it as a
+   * best-effort hint, never a hard dependency.
+   */
+  updated_at?: string;
 }
 
 /** Injectable fetch (defaults to `globalThis.fetch`) so callers/tests stay hermetic. */
@@ -150,6 +158,13 @@ export interface OwnAdmissionState {
   hasSealedSecret: boolean;
   /** The registered stack pubkey (the admin needs it for `secret add-member`). */
   peerPubkey: string;
+  /**
+   * C-1350 (Slice 2) — the row's last-transition timestamp (`updated_at`), when
+   * the row carries one. For a `revoked` state this is the revoked-at date the
+   * member-facing "you were REVOKED … on <date>" message prints. Undefined for
+   * `no-row` and for an older registry that omits `updated_at`.
+   */
+  updatedAt?: string;
 }
 
 /** True when a row carries a non-empty sealed leaf-secret blob. */
@@ -172,7 +187,17 @@ export function classifyOwnAdmissionRows(
     return { state: "no-row", networkId, hasSealedSecret: false, peerPubkey };
   }
   const hasSealedSecret = rowHasSealedSecret(row);
-  const base = { networkId, requestId: row.request_id, hasSealedSecret, peerPubkey };
+  const base = {
+    networkId,
+    requestId: row.request_id,
+    hasSealedSecret,
+    peerPubkey,
+    // C-1350 — carry the row's last-transition date through (best-effort; an
+    // older registry omits it). On a REVOKED row this is the revoked-at date.
+    ...(typeof row.updated_at === "string" && row.updated_at.length > 0
+      ? { updatedAt: row.updated_at }
+      : {}),
+  };
   switch (row.status) {
     case "PENDING":
       return { ...base, state: "pending" };


### PR DESCRIPTION
## What

Slice 2 of #1350 (**revoke tells the member**). `secret revoke-member` already updates the registry admission row to REVOKED (sealed blob cleared) — the registry half. This adds the **member-side** half: `cortex network status` now reads the member's OWN admission row (the existing PoP `GET /admission-requests/mine` read from #1315) and, when it's REVOKED, prints an explicit message naming the network + the cleanup command, instead of the silent dead-leaf-include / leaf-auth mystery:

```
  metafactory  [disconnected]  [leaf:metafactory]  link:down
    peers:    ...
    ⚠ REVOKED — you were removed from "metafactory" on 2026-07-01T12:00:00.000Z. Run `cortex network leave metafactory --apply` to clean up the dead leaf.
```

## How

- **`admission-state.ts`** — thread the row's `updated_at` through `AdmissionMineRow` + a new `OwnAdmissionState.updatedAt` (the REVOKED-at date; `revokeAdmission` in the store already stamps `updated_at` on the ADMITTED→REVOKED transition). Optional on the wire — an older registry that omits it leaves `updatedAt` undefined.
- **`network-ports.ts`** — new **optional** `AdmissionStatePort` on `NetworkPorts`, mirroring the existing `leafState`/`cachedNetworks` optional-port pattern. Absent → status reports no admission state (pre-C-1350).
- **`network-lib.ts` (`networkStatus`)** — where the REVOKED check hooks in: after building the config-joined + registered rows, if the admission port is wired it resolves each row's `/mine` state (in parallel) and attaches `StatusNetworkRow.admission` (`AdmissionStatusInfo`) **only** when REVOKED or the lookup was unavailable. An admitted/live row gets **no** admission field, so an ordinary status row is byte-for-byte unchanged (no false REVOKED). The field rides the JSON `items[]`.
- **`network-adapters.ts`** — live `buildAdmissionStatePort` does the best-effort PoP `/mine` read via `resolveOwnAdmissionState`; wired into every ports bundle. A `__setAdmissionResolverForTests` seam is provided.
- **`network.ts` (`runStatus`)** — resolves the registry-url + signing-seed the `/mine` read needs, the **same precedence** join/leave use (flag → `policy.federated.registry` / `stack.nkey_seed_path` → the compiled-in default registry + seed convention). Renders the REVOKED cleanup line, and a non-fatal `admission_lookup: unavailable` hint when the read couldn't complete.

## Read-only + non-fatal

- **No registry mutation, no leave/revoke behavior change.** `status` only reads. The admission port is used exclusively by `networkStatus`, so `join`/`leave` are untouched.
- A `/mine` read failure (registry unreachable / no seed / not configured) degrades to `admission_lookup: unavailable` — matching the #1315 best-effort posture — and **never** breaks `status`. Guarded seam so a faulty resolver can't throw through a read-only command.

## Join-path hint

**Included** (clean touch): `joinBlockerMessage`'s REVOKED case now also names `cortex network leave <net> --apply` (+ the revoked-at date when known).

## The REVOKED-status test

`networkStatus` orchestrator tests with a fake `AdmissionStatePort`:
- REVOKED own-row → `admission.revoked === true` + `revokedAt` + `requestId`, network id on the row for the cleanup command.
- ADMITTED/live own-row → **no** `admission` field (no false REVOKED).
- Failed `/mine` read → `admission.lookup === "unavailable"`, `status` still `ok`.
- No admission port wired → no admission field (pre-C-1350 unchanged).
- REVOKED with no revoked-at date (older registry) → still surfaces revoked.

Plus `classifyOwnAdmissionRows` `updated_at`→`updatedAt` threading tests and the `joinBlockerMessage` REVOKED cleanup-command assertion.

## Pre-push gate (all four)

- `bunx eslint --quiet .` → **0**
- `bunx tsc --noEmit` → **0**
- `bash scripts/check-carveouts.sh` → **PASS**
- `bun test src/cli/cortex/commands src/common/registry` → **1303 pass, 0 fail**

Refs #1350 (Slice 2 of 3). Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2PprzzSHHikDL5PbDgjB