### PR TITLE
fix(ci): restore green main after #1441 — deploy-surface empty-set + docs vocab

### DIFF
--- a/docs/agents-md/dashboard-deployment.md
+++ b/docs/agents-md/dashboard-deployment.md
@@ -58,8 +58,9 @@ in `metafactory-actions`' `public-patterns.yaml` — out of scope for this repo.
 **Why `db:migrate:safe` is advisory.** Sequencing constraint from the design
 doc: this PR must not brick the canonical `db:migrate` command if the scan
 trips block-tier on `schema.sql` / `migrations/*.sql`. `migrations/0002_seed_data.sql`
-was verified clean (placeholder `operator@example.com`, cortex#1344) at
-authoring time — advisory mode is a safety margin against a future regression,
+was verified clean (its only seeded identity is a documented placeholder,
+cortex#1344) at authoring time — advisory mode is a safety margin against a
+future regression,
 not evidence of a known finding today.
 
 **Why `deploy:worker` is blocking.** The worker ships unbundled first-party

--- a/scripts/scan-deploy-surface.ts
+++ b/scripts/scan-deploy-surface.ts
@@ -195,6 +195,20 @@ export function main(argv: string[]): number {
     return 2;
   }
 
+  // Resolve the file set BEFORE touching the engine. An empty surface (nothing
+  // built yet) is trivially clean — there is no content to scan, so the engine
+  // is irrelevant and we must not fail-closed on its absence. This also keeps
+  // the "nothing built yet" developer path green in CI, where the installed
+  // engine is not present (the engine fail-closed check below only fires when
+  // there is actually something to scan).
+  const files = resolveSurfaceFiles(surfaceArg, root);
+  if (files.length === 0) {
+    process.stdout.write(
+      `scan-deploy-surface: ${surfaceArg} — no files to scan (build output missing? run the build step first) — treating as clean.\n`,
+    );
+    return 0;
+  }
+
   if (!existsSync(enginePath)) {
     const msg = `scan-deploy-surface: confidentiality-scan engine not found at ${enginePath} — fail-closed (install/refresh via arc upgrade compass).`;
     if (advisory) {
@@ -203,14 +217,6 @@ export function main(argv: string[]): number {
     }
     process.stderr.write(`${msg}\n`);
     return 3;
-  }
-
-  const files = resolveSurfaceFiles(surfaceArg, root);
-  if (files.length === 0) {
-    process.stdout.write(
-      `scan-deploy-surface: ${surfaceArg} — no files to scan (build output missing? run the build step first) — treating as clean.\n`,
-    );
-    return 0;
   }
 
   const codes: number[] = [];


### PR DESCRIPTION
## Why

**#1441 (compass#93) was merged past two red checks it introduced.** Both `Test`
and `Vocab carve-out gate` were **green on the parent commit** (`e8b1c990`) and
went **red only from `40b20215`** — pure self-inflicted regression from the
admin-merge. This PR restores `main` to green with two surgical fixes. No other
behavior changes.

## Fix 1 — `scan-deploy-surface`: resolve files before the engine check

The `Test` job failed on `empty file set (nothing built yet) is treated as clean`.
Root cause: `main()` did the engine-existence **fail-closed** check *before*
resolving the file set. An empty deploy surface has no content to scan, so the
engine is irrelevant — but the old order fail-closed (exit 3) whenever the engine
was **absent**, which is exactly the CI runner condition (the installed
confidentiality-scan engine isn't present on the runner). Locally it passed only
because the engine *is* installed on a dev box.

Fix: resolve the file set first; empty set → clean (exit 0) without touching the
engine. Files-present + missing-engine still fail-closes (exit 3, blocking) as
designed.

Verified against the CI condition (simulated missing engine):
- empty surface + no engine → **0** (clean) ✅
- files present + no engine (blocking) → **3** (fail-closed) ✅
- full test file: **14/14 green**

## Fix 2 — docs: drop the deprecated-vocab literal that tripped the ratchet

`docs/agents-md/dashboard-deployment.md` (new prose in #1441) quoted the literal
deprecated-vocab seed placeholder in the `db:migrate:safe` advisory-mode
rationale, which the **Vocab carve-out gate** (0002 ratchet) correctly flagged as
an ungated live violation on **new prose**. Reworded to describe the seed's
documented placeholder identity (cortex#1344) without re-introducing the
deprecated token — the right fix is to fix the prose, **not** to weaken the
ratchet with a carve-out.

`scripts/check-carveouts.sh docs/agents-md/dashboard-deployment.md` → PASS.

## Checks
- `bunx tsc --noEmit` — clean
- `bunx eslint --quiet scripts/scan-deploy-surface.ts` — clean
- Vocab gate — PASS · deploy-surface test — 14/14

Related: #1441 (the merge that introduced these), #1450 (separate deploy-surface
follow-up — **not** addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)