### PR TITLE
fix(stack): C-1453 — scaffolded stack boots on a fresh local-only bus

### DIFF
--- a/docs/sop-stack-onboarding.md
+++ b/docs/sop-stack-onboarding.md
@@ -27,7 +27,7 @@ A **stack** is one cortex deployment under a **principal** — its own signing i
 
 | Need | Why | How |
 |---|---|---|
-| **Bot is a member of the target guild** | the daemon can't join a guild for you | invite the assistant's Discord bot to the guild (Developer Portal OAuth URL, `scope=bot`, least-privilege perms). One bot can serve N guilds — the **C-704 guild filter** isolates each stack by `guildId`. |
+| **Bot is a member of the target guild** | the daemon can't join a guild for you | invite the assistant's Discord bot with an OAuth2 URL that carries **both** `scope=bot` **and** `permissions=<int>`, e.g. `https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot&permissions=68608`. ⚠️ The Developer Portal's **App → Installation → "Install Link"** is NOT this — it installs the *application* only and adds **no bot user**, so the bot never appears under Server Settings → Integrations and never answers (cortex#1453, reported by vpzed). One bot can serve N guilds — the **C-704 guild filter** isolates each stack by `guildId`. |
 | **Message Content intent ON** | the bot must read message content | Developer Portal → the bot's application → enable. (Already on if the bot reads any other guild.) |
 | **guildId + a channel id** | binding + the nominal agent/log channel | from the Discord client (Developer Mode → copy id) or `GET /guilds/{id}/channels` with the bot token. |
 | **A free local NATS port** | the isolated bus | meta-factory `:4222`, halden `:4223`, community `:4224` → use the next free pair (data + monitor `:82xx`). |
@@ -192,6 +192,7 @@ A healthy boot shows `Stack: <principal>/<slug>`, `connected to nats://…:<port
 
 ## Gotchas
 
+- **"Install Link" ≠ bot invite (cortex#1453):** the Developer Portal's App → Installation → "Install Link" adds the *application* but **no bot user** — the bot is absent from Server Settings → Integrations and silently never answers an @mention. Re-invite with an OAuth2 URL that includes `&scope=bot&permissions=<int>` (`68608` = View Channels + Send Messages + Send in Threads/Posts + Create Public Threads + Embed Links + Attach Files + Add Reactions + Read Message History). See the Prerequisites row above.
 - **One bot, many guilds (C-704):** reuse the assistant's bot token bound to a *different* `guildId` per stack; the guild filter makes each daemon act only on its bound guild. Running the same token in N processes = N gateway sessions (fine at low volume).
 - **gh auto-approve:** `claude.bashAllowlist` propagates to dispatched sessions (`cortex.ts` → `CORTEX_BASH_GUARD`); the bash-guard **auto-approves** matching commands (cortex#778) so async dispatch never stalls on an unanswerable prompt. Restrict reach with `bashAllowlist.repos` (a `gh` command targeting any other repo is denied; repo-less `gh` passes).
 - **Guild = restricted profile:** a guild @mention resolves to the DEFAULT (non-DM) profile **even for the principal** — so `bashAllowlist` gates *every* command. Size the allowlist for the work the stack must do.

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -265,6 +265,39 @@ describe("create --apply", () => {
     expect(existsSync(join(cfg, "demo", "personas", "echo.md"))).toBe(true);
   });
 
+  test("nats.url defaults to 4222 and credsPath ships commented — a fresh stack boots (cortex#1453)", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(0);
+    const systemYaml = readFileSync(join(cfg, "demo", "system", "system.yaml"), "utf-8");
+    expect(systemYaml).toContain("url: nats://127.0.0.1:4222");
+    // No ACTIVE credsPath: on a fresh local-only anonymous bus.
+    expect(systemYaml).not.toMatch(/^\s*credsPath:/m);
+  });
+
+  test("honours --nats-url for a bus on a non-default port (cortex#1453)", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas",
+      "--nats-url", "nats://127.0.0.1:4242", "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const systemYaml = readFileSync(join(cfg, "demo", "system", "system.yaml"), "utf-8");
+    expect(systemYaml).toContain("url: nats://127.0.0.1:4242");
+    expect(systemYaml).not.toContain("url: nats://127.0.0.1:4222");
+  });
+
+  test("rejects a malformed --nats-url (cortex#1453)", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas",
+      "--nats-url", "127.0.0.1:4242", "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(2); // usage error (mirrors --principal / --agent validation)
+    expect(res.stderr).toContain("--nats-url");
+    expect(existsSync(join(cfg, "demo"))).toBe(false);
+  });
+
   test("composed stack is discoverable as itself (round-trip uniqueness)", async () => {
     const cfg = freshDir();
     await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -127,6 +127,7 @@ describe("renderScaffold", () => {
     agentId: "assistant",
     displayName: "Demo",
     seedPath: "~/.config/nats/cortex-demo.nk",
+    natsUrl: "nats://127.0.0.1:4222",
   };
 
   test("emits the full file set", () => {
@@ -145,18 +146,39 @@ describe("renderScaffold", () => {
     expect(stack?.contents).toContain("assistant");
   });
 
-  test("system/system.yaml seeds the bus/bot credsPath (~/.config/nats/<slug>-bot.creds), distinct from the federation default", () => {
-    // v5.30.2 (C-1265c): a from-scratch stack carries nats.credsPath explicitly,
-    // so `cortex network make-live` needs no --creds flag. The path is the
-    // daemon's OWN bus/bot creds under the agents account. The `-bot` suffix is
-    // load-bearing: it keeps this DISTINCT from provision's federation-user
-    // default `~/.config/nats/<slug>.creds` (different NATS account → must be a
-    // different file, or the second mint clobbers the first).
+  test("system/system.yaml ships nats.credsPath COMMENTED OUT so a fresh local-only stack boots (cortex#1453)", () => {
+    // cortex#1453: a from-scratch stack runs on a hard-isolated ANONYMOUS bus
+    // (SOP Part 1) — no operator mode, no minted bot creds. An ACTIVE credsPath
+    // points at a file that doesn't exist yet, so the runtime logs
+    // "failed to connect — continuing without NATS: ENOENT … demo-bot.creds"
+    // and the whole bus plane goes dark. So the line ships commented; the
+    // documented `-bot` path + suffix stay in the comment as guidance, and
+    // `cortex network make-live` writes it back (it defaults credsPath to the
+    // same path and persists when defaulted, cortex#1265) at federation time.
     const files = renderScaffold(inputs);
     const system = files.find((f) => f.relPath === "system/system.yaml");
-    expect(system?.contents).toContain("credsPath: ~/.config/nats/demo-bot.creds");
-    // The bus path must NOT equal the federation default for the same slug.
+    // The guidance (the -bot path) is present as a COMMENT, not an active key.
+    expect(system?.contents).toContain("# credsPath: ~/.config/nats/demo-bot.creds");
+    // No ACTIVE credsPath: key at the start of a (indented) line — a bare boot
+    // must not dial creds. Matches an uncommented `credsPath:` with only
+    // leading whitespace before it.
+    expect(system?.contents).not.toMatch(/^\s*credsPath:/m);
+    // The documented bus path must NOT equal the federation default for the slug.
     expect(system?.contents).not.toContain("credsPath: ~/.config/nats/demo.creds");
+  });
+
+  test("system/system.yaml nats.url defaults to the 4222 convention (cortex#1453)", () => {
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    expect(system?.contents).toContain("url: nats://127.0.0.1:4222");
+  });
+
+  test("system/system.yaml nats.url honours a non-default natsUrl (cortex#1453)", () => {
+    // The exact scenario in the bug report: a stack whose bus listens on 4242.
+    const files = renderScaffold({ ...inputs, natsUrl: "nats://127.0.0.1:4242" });
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    expect(system?.contents).toContain("url: nats://127.0.0.1:4242");
+    expect(system?.contents).not.toContain("url: nats://127.0.0.1:4222");
   });
 
   test("does NOT inline any signing seed material (key auto-provisioned later)", () => {

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -344,6 +344,11 @@ export interface ScaffoldInputs {
   /** Conventional seed path (`~/.config/nats/cortex-<slug>.nk`). NOT generated
    *  here — `arc upgrade cortex` auto-provisions the seed on first install. */
   seedPath: string;
+  /** The `nats.url` the generated system.yaml dials. MUST match the port the
+   *  stack's nats-server listens on. Defaults to the metafactory-convention
+   *  `nats://127.0.0.1:4222`; set via `--nats-url` when the bus is on another
+   *  port so the scaffold is born matching it (cortex#1453). */
+  natsUrl: string;
 }
 
 /** A scaffold file to write, relative to the new stack's dir. */
@@ -361,11 +366,11 @@ export interface ScaffoldFile {
  * later (see `arc upgrade cortex` / postupgrade.sh §2).
  */
 export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
-  const { slug, principal, stackId, agentId, displayName, seedPath } = inputs;
+  const { slug, principal, stackId, agentId, displayName, seedPath, natsUrl } = inputs;
   const Display = displayName;
 
   return [
-    { relPath: "system/system.yaml", contents: systemYaml(slug) },
+    { relPath: "system/system.yaml", contents: systemYaml(slug, natsUrl) },
     { relPath: "surfaces/surfaces.yaml", contents: surfacesYaml(agentId, stackId) },
     { relPath: `stacks/${slug}.yaml`, contents: stackYaml(slug, principal, stackId, agentId, Display, seedPath) },
     { relPath: `${slug}.yaml`, contents: pointerYaml(slug) },
@@ -373,7 +378,7 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   ];
 }
 
-function systemYaml(slug: string): string {
+function systemYaml(slug: string, natsUrl: string): string {
   // The cross-cutting substrate layer — substituted from
   // docs/config-layout/system/system.yaml. Identity is left at the safe
   // conventional default; `arc upgrade cortex` auto-provisions the seed.
@@ -413,17 +418,30 @@ paths:
 # pattern double-binds the boot subscriber (the double-message problem,
 # cortex#491). The dispatch-listener self-subscribes its own interest at start.
 nats:
-  url: nats://127.0.0.1:4222
+  # url — MUST match the port your nats-server for this stack listens on
+  # (its \`listen:\` in ~/.config/nats/<slug>.conf). 4222 is the NATS default and
+  # the metafactory convention; pick another (e.g. 4223/4224) only if you stood
+  # the bus up on a different port, and set --nats-url at \`cortex stack create\`
+  # time so this line is born matching your bus (cortex#1453).
+  url: ${natsUrl}
   name: cortex
   subjects: []
   # credsPath — the daemon's OWN bus/bot creds, minted under the \`agents\` account
-  # by \`cortex network make-live\` (via add-bot). The \`-bot\` suffix is LOAD-BEARING:
-  # it keeps this path DISTINCT from stacks/${slug}.yaml's
-  # \`stack.nats_infra.creds_path\` (the FEDERATION creds, minted at
-  # \`cortex network join\` under a DIFFERENT account, conventional default
-  # \`~/.config/nats/${slug}.creds\`). Two different NATS accounts MUST be two
-  # different files — a shared path would clobber on the second mint.
-  credsPath: ~/.config/nats/${slug}-bot.creds
+  # by \`cortex network make-live\` (via add-bot). COMMENTED OUT by default: a
+  # fresh, local-only stack runs on a hard-isolated ANONYMOUS bus (no operator
+  # mode, no minted creds — SOP-stack-onboarding Part 1), so a credsPath here
+  # points at a file that does not exist yet and the runtime logs
+  # "failed to connect — continuing without NATS: ENOENT … <slug>-bot.creds",
+  # leaving the whole bus plane dark (cortex#1453). \`cortex network make-live\`
+  # mints the creds AND writes this line back (it defaults credsPath to the same
+  # path and persists it when defaulted, cortex#1265) when you convert this bus
+  # to operator-mode to federate — so uncommenting by hand is not required.
+  # The \`-bot\` suffix is LOAD-BEARING: it keeps this path DISTINCT from
+  # stacks/${slug}.yaml's \`stack.nats_infra.creds_path\` (the FEDERATION creds,
+  # minted at \`cortex network join\` under a DIFFERENT account, conventional
+  # default \`~/.config/nats/${slug}.creds\`). Two different NATS accounts MUST be
+  # two different files — a shared path would clobber on the second mint.
+  # credsPath: ~/.config/nats/${slug}-bot.creds
   # NKey identity for envelope signing. The seedPath is the conventional path
   # \`arc upgrade cortex\` auto-provisions on first install; publicKey is pinned
   # after first boot (paste from the cortex log \`stack signing key staged …\`).

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -80,6 +80,10 @@ const DEFAULT_NATS_DIR = "~/.config/nats";
 const DEFAULT_LAUNCH_AGENTS_DIR = "~/Library/LaunchAgents";
 /** Default agent id for the scaffolded stack — neutral placeholder, not a personal persona name (#1338). */
 const DEFAULT_AGENT_ID = "assistant";
+/** Default `nats.url` for the generated system.yaml — 4222 is the NATS default
+ *  and the metafactory convention. Overridable with --nats-url when the stack's
+ *  bus listens on another port, so the scaffold is born matching it (#1453). */
+const DEFAULT_NATS_URL = "nats://127.0.0.1:4222";
 
 const SPEC: SubcommandSpec<StackSubcommand> = {
   cliName: "stack",
@@ -90,6 +94,7 @@ const SPEC: SubcommandSpec<StackSubcommand> = {
         "--principal": "value",
         "--display-name": "value",
         "--agent": "value",
+        "--nats-url": "value",
         "--config-dir": "value",
         "--apply": "bool",
         "--dry-run": "bool",
@@ -258,6 +263,19 @@ function runCreate(
   const stackId = `${principal}/${slug}`;
   const seedPath = `~/.config/nats/cortex-${slug}.nk`;
 
+  // --- nats.url: default to the 4222 convention, override with --nats-url ---
+  // The generated system.yaml MUST dial the port the stack's nats-server
+  // listens on. A user who stood the bus up on a non-default port (e.g. 4242)
+  // otherwise gets a scaffold silently pointing at 4222 (#1453).
+  const natsUrl = optionalValueFlag(flags, "--nats-url") ?? DEFAULT_NATS_URL;
+  if (!/^(nats|tls):\/\/[^\s]+$/.test(natsUrl)) {
+    return usageError(
+      "create",
+      `--nats-url "${natsUrl}" must be a nats:// or tls:// URL (e.g. nats://127.0.0.1:4242)`,
+      json,
+    );
+  }
+
   const applyRes = resolveApply(flags);
   if (!applyRes.ok) return usageError("create", applyRes.reason, json);
 
@@ -300,7 +318,7 @@ function runCreate(
   }
 
   // --- render --------------------------------------------------------------
-  const files = renderScaffold({ slug, principal, stackId, agentId, displayName, seedPath });
+  const files = renderScaffold({ slug, principal, stackId, agentId, displayName, seedPath, natsUrl });
 
   // --- dry-run (DEFAULT): print the file set, touch NOTHING ----------------
   if (!applyRes.apply) {


### PR DESCRIPTION
## What & why

`cortex stack create` generated a `system/system.yaml` that broke a **fresh, local-only install** two ways — reported by **VictoryPapaZulu (vpzed)** standing a stack up on Debian 13 ([#1453](https://github.com/the-metafactory/cortex/issues/1453), [install gist](https://gist.github.com/vpzed/fc3b8da5ee9ecaea4a0d17e567ffbb17)).

The smoking gun is his boot log:
```
myelin-runtime: failed to connect — continuing without NATS: ENOENT: no such file or directory, statx '/home/cortexuser/.config/nats/gir-bot.creds'
```
The stack boots, Discord connects — but the **entire bus plane is silently dark**.

### 1. `nats.credsPath` was active by default (the real boot-killer)
C-1265c (v5.30.2) pre-seeded `credsPath: ~/.config/nats/<slug>-bot.creds` so `cortex network make-live` needs no `--creds` flag. But that creds file **only exists after make-live mints it**. The default `stack create` scenario is a **hard-isolated anonymous bus** (SOP-stack-onboarding Part 1 — no operator mode, no minted creds), so the file is absent and the runtime gives up on NATS entirely.

**Fix:** ship the line **commented out** (matching `docs/config-layout/`'s reference, which never carried it). make-live already **defaults** credsPath to the same path and **writes it back when defaulted** (C-1265c `credsPathDefaulted`) — so the federation path is unaffected, and its `UNSEEDED_CREDS` tests already cover the now-default absence.

### 2. `nats.url` port was hardcoded to 4222 with no override
The reporter stood his bus up on **4242** and the scaffold silently dialed 4222. Note **4222 is the correct default** (that's the NATS default; `local.conf` uses it; the whole codebase + conf-example converge on it — the report's "should be 4242" is *his* port). The bug is that it wasn't **settable**.

**Fix:** add `--nats-url` to `cortex stack create` (default `nats://127.0.0.1:4222`, validated as `nats://`|`tls://`), so the scaffold is **born matching the bus**. The `url` comment now says it MUST match the nats-server `listen:` port.

## Verification
- New unit + CLI tests: default 4222, `--nats-url` honoured, malformed URL rejected (exit 2), `credsPath` inactive on a fresh scaffold.
- Full `tsc --noEmit` clean; make-live suites still green (fresh scaffolds now ride the already-tested defaulted-credsPath write-back path).
- End-to-end: `cortex stack create gir --principal vpzed --nats-url nats://127.0.0.1:4242` → `url: nats://127.0.0.1:4242`, no active `credsPath:`.

## Follow-up (out of scope, flagging)
The scaffold's `nats.identity.seedPath` is a generic `~/.config/nats/cortex.nk` while the stack's real seed is `~/.config/nats/cortex-<slug>.nk` (`stacks/<slug>.yaml` `nkey_seed_path`). Signing works off the stack file, so it isn't blocking — but the two disagreeing paths are worth reconciling separately.

Closes #1453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3R1V6EMbjEUsiNi7kbnGZ