### PR TITLE
feat(lifecycle): C-1350 Slice 3 — Tier-1 de-admission pairing: role removal on revoke/reject

### DIFF
--- a/docs/sop-community-fleet-admission.md
+++ b/docs/sop-community-fleet-admission.md
@@ -100,9 +100,30 @@ else needs a human" true (acceptance §6).
 
 ## Step 4 — revoke (bulk or single)
 
-- **Single principal:** remove `community-fleet` from their member(s). Independently revoke
-  their bus creds (`cortex creds revoke <principal-bot>` / `arc nats remove-bot --delete-creds`) —
-  the two are deliberately separate handles.
+- **Single principal — de-admission is one command (C-1350 S3).** Pass `--discord-member`
+  to `secret revoke-member` (post-admission cut) or `reject` (deny a PENDING request) and
+  the bus de-admission and the Discord role removal happen in the same act:
+
+  ```
+  cortex network secret revoke-member <network> <member-pubkey> \
+      --admin-seed <hub-admin-seed> --discord-member <member-id> --apply
+  #   → cuts the hub authorization user (transport), marks the row REVOKED,
+  #     then REMOVES the community-fleet role from <member-id>
+
+  cortex network reject <request-id> \
+      --admin-seed <admin-seed> --discord-member <member-id> --apply
+  #   → moves the PENDING row to REJECTED, then REMOVES the role
+  ```
+
+  The role-removal step mirrors admit's assign flag block exactly —
+  `--discord-guild` / `--discord-server` / `--discord-role` (defaults to
+  `community-fleet`) resolve the guild + role the same way. It is **non-fatal**: if the
+  bot token / guild / role can't resolve, the command warns "remove the role manually"
+  and still exits 0 — the bus de-admission (the trust-bearing act) has already committed.
+  So the **manual Discord edit is now the fallback**, not the default path.
+
+  Bus creds remain a deliberately separate handle where a bot has its own creds
+  (`cortex creds revoke <principal-bot>` / `arc nats remove-bot --delete-creds`).
 - **Bulk:** remove the role from all holders (or delete/replace the role) — one act
   de-admits the whole fleet from Discord. (Bus de-admission is still per-bot cred revoke.)
 

--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
@@ -293,6 +293,8 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
   todo("step 4a (#1314): network admit --list-pending shows the PENDING row");
   // #1348 — the reject verb: a second registration rejected → REJECTED.
   todo("step 4b (#1348): network reject <id> on a second registration → row REJECTED");
+  // #1350 S1 — the depart motion: a member's own `leave --apply` exits the roster.
+  todo("step 4c (#1350 S1): member depart — leave exits the roster (ADMITTED→DEPARTED)");
 
   // ===========================================================================
   // Step 5 — Seal: mint the per-member leaf PSK, seal it to the member, and
@@ -342,6 +344,9 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
   // #1316 — the admit-and-seal FOLD: `network admit --and-seal` does step 4 + step
   // 5 in one privileged move (today they are two commands, driven separately above).
   todo("step 5a (#1316): network admit --and-seal folds admit + secret add-member");
+  // #1349 S1 — the M3 payload key K rides the SAME sealed blob: add-member seals
+  // payload_key, join installs it.
+  todo("step 5b (#1349 S1): sealed K delivery — add-member seals payload_key, join installs it");
 
   // ===========================================================================
   // Step 6 — Join: the #1220 regression anchor.
@@ -452,6 +457,10 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
     expect(row?.sealed_secret).toBeNull();
   });
 
+  // #1349 S2 — key rotation re-seals a fresh K' to every ADMITTED member (and
+  // NEVER to a REVOKED/DEPARTED row), bumping the kid.
+  todo("step 7b (#1349 S2): rotate-key re-seals K' to every ADMITTED member (never REVOKED/DEPARTED)");
+
   // ===========================================================================
   // Step 8 — Leave: joiner tears down its local federation wiring.
   //   Drives the REAL `leaveNetwork` orchestrator over an in-memory config store
@@ -528,4 +537,8 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
     const row = await getIssuanceStore(ctx.env).getIssuanceRequest(ctx.requestId!);
     expect(row?.status).toBe("REVOKED");
   });
+
+  // #1351 S2 — stack retirement tombstones the stack: `provision-stack retire`
+  // returns 409 while ADMITTED rows still reference it, then tombstones once clear.
+  todo("step 10 (#1351 S2): provision-stack retire tombstones the stack (409 while ADMITTED rows live)");
 });

--- a/src/cli/cortex/commands/__tests__/network-reject.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-reject.test.ts
@@ -21,7 +21,11 @@
 import { describe, test, expect, afterEach, beforeAll, afterAll } from "bun:test";
 import { join } from "path";
 
-import { dispatchNetwork } from "../network";
+import {
+  dispatchNetwork,
+  __setDiscordRemoveClientForTests,
+  type DiscordRemoveClient,
+} from "../network";
 import { dispatchProvisionStack } from "../provision-stack";
 import {
   REGISTRY_BASE,
@@ -206,6 +210,10 @@ describe("cortex network reject — apply E2E (real in-process registry)", () =>
     resetRegistry();
   });
 
+  // Reset any injected Discord removal client between tests so the non-discord
+  // cases above/below never see a stale mock.
+  afterEach(() => __setDiscordRemoveClientForTests(null));
+
   test("reject <id> --apply (global admin) → row REJECTED, exit 0", async () => {
     const { requestId } = await registerJoiner("joinerone");
 
@@ -297,5 +305,102 @@ describe("cortex network reject — apply E2E (real in-process registry)", () =>
     // The registry refused the decision — the row is untouched.
     const row = await getIssuanceStore(ctx.env).getIssuanceRequest(requestId);
     expect(row?.status).toBe("PENDING");
+  });
+
+  // ===========================================================================
+  // C-1350 S3 — Tier-1 de-admission pairing: --discord-member removes the role.
+  // Discord ids are non-numeric placeholder labels (never a live snowflake).
+  // ===========================================================================
+  test("reject --apply --discord-member → removeRole called after REJECTED, exit 0", async () => {
+    const { requestId } = await registerJoiner("joinersix");
+    let resolvedRole = false;
+    let removedRole = false;
+
+    const mockDiscord: DiscordRemoveClient = {
+      async resolveRoleId(_token, _guildId, roleName) {
+        resolvedRole = true;
+        expect(roleName).toBe("community-fleet");
+        return "role-id-123";
+      },
+      async removeRole(_token, _guildId, userId, roleId) {
+        removedRole = true;
+        expect(userId).toBe("member-snowflake-999");
+        expect(roleId).toBe("role-id-123");
+        return { success: true };
+      },
+    };
+    __setDiscordRemoveClientForTests(mockDiscord);
+
+    const res = await dispatchNetwork([
+      "reject", requestId,
+      "--admin-seed", ctx.globalAdminSeed,
+      "--registry-url", REGISTRY_BASE,
+      "--discord-member", "member-snowflake-999",
+      "--discord-guild", "guild-123",
+      "--apply", "--json",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    expect(resolvedRole).toBe(true);
+    expect(removedRole).toBe(true);
+    const env = JSON.parse(res.stdout) as { data: { discord_status: string } };
+    expect(env.data.discord_status).toBe("removed");
+    // The reject itself committed regardless.
+    const row = await getIssuanceStore(ctx.env).getIssuanceRequest(requestId);
+    expect(row?.status).toBe("REJECTED");
+  });
+
+  test("Discord role removal failure → exit 0 with warning (reject already committed)", async () => {
+    const { requestId } = await registerJoiner("joinerseven");
+
+    const mockDiscord: DiscordRemoveClient = {
+      async resolveRoleId() { return "role-id-123"; },
+      async removeRole() { return { success: false, error: "missing_permissions" }; },
+    };
+    __setDiscordRemoveClientForTests(mockDiscord);
+
+    const res = await dispatchNetwork([
+      "reject", requestId,
+      "--admin-seed", ctx.globalAdminSeed,
+      "--registry-url", REGISTRY_BASE,
+      "--discord-member", "member-999",
+      "--discord-guild", "guild-123",
+      "--apply", "--json",
+    ]);
+
+    // Reject committed → exit 0. The removal failure is a warning, never fatal.
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { data: { discord_status: string; discord_warning?: string } };
+    expect(env.data.discord_status).toBe("failed");
+    expect(env.data.discord_warning).toContain("missing_permissions");
+    const row = await getIssuanceStore(ctx.env).getIssuanceRequest(requestId);
+    expect(row?.status).toBe("REJECTED");
+  });
+
+  test("custom --discord-role is forwarded to resolveRoleId (flag-resolution parity with admit)", async () => {
+    const { requestId } = await registerJoiner("joinereight");
+    let capturedRole = "";
+
+    const mockDiscord: DiscordRemoveClient = {
+      async resolveRoleId(_token, _guildId, roleName) {
+        capturedRole = roleName;
+        return "custom-role-id";
+      },
+      async removeRole() { return { success: true }; },
+    };
+    __setDiscordRemoveClientForTests(mockDiscord);
+
+    const res = await dispatchNetwork([
+      "reject", requestId,
+      "--admin-seed", ctx.globalAdminSeed,
+      "--registry-url", REGISTRY_BASE,
+      "--discord-member", "member-999",
+      "--discord-guild", "guild-123",
+      "--discord-role", "custom-fleet",
+      "--apply",
+    ]);
+
+    expect(res.exitCode).toBe(0);
+    expect(capturedRole).toBe("custom-fleet");
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -12,7 +12,13 @@ import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createUser } from "nkeys.js";
-import { dispatchNetwork, __setJoinLeafSecretFetcherForTests, type SecretPortsFactory } from "../network";
+import {
+  dispatchNetwork,
+  __setJoinLeafSecretFetcherForTests,
+  __setDiscordRemoveClientForTests,
+  type SecretPortsFactory,
+  type DiscordRemoveClient,
+} from "../network";
 import type { NetworkSecretPorts } from "../network-secret-ports";
 import type { FetchSealedLeafSecretInput } from "../../../../common/registry/fetch-sealed-secret";
 
@@ -61,7 +67,10 @@ beforeEach(() => {
   writeFileSync(seedPath, seed, { mode: 0o600 });
   chmodSync(seedPath, 0o600);
 });
-afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  __setDiscordRemoveClientForTests(null);
+});
 
 function argv(...args: string[]): string[] {
   return args;
@@ -143,6 +152,109 @@ describe("cortex network secret revoke-member", () => {
     expect(res.exitCode).toBe(0);
     expect(calls.reloads).toBe(1);
     expect(calls.revoked).toEqual(["req1"]);
+  });
+
+  // ===========================================================================
+  // C-1350 S3 — Tier-1 de-admission pairing on revoke-member. The role removal
+  // is a NON-FATAL step AFTER the hub-cut + registry REVOKE. Discord ids are
+  // non-numeric placeholder labels (never a live snowflake).
+  // ===========================================================================
+  test("--discord-member --apply: removeRole called AFTER the registry revoke; exit 0", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    let removed = false;
+    const mockDiscord: DiscordRemoveClient = {
+      async resolveRoleId(_t, _g, roleName) {
+        // The revoke (hub cut + registry) must have committed before we get here.
+        expect(calls.revoked).toEqual(["req1"]);
+        expect(roleName).toBe("community-fleet");
+        return "role-id-123";
+      },
+      async removeRole(_t, _g, userId, roleId) {
+        removed = true;
+        expect(userId).toBe("member-snowflake-999");
+        expect(roleId).toBe("role-id-123");
+        return { success: true };
+      },
+    };
+    __setDiscordRemoveClientForTests(mockDiscord);
+
+    const res = await dispatchNetwork(
+      argv("secret", "revoke-member", "metafactory", MEMBER,
+        "--discord-member", "member-snowflake-999", "--discord-guild", "guild-123",
+        "--apply", "--json", "--admin-seed", seedPath),
+      undefined, undefined, undefined, factory,
+    );
+
+    expect(res.exitCode).toBe(0);
+    expect(removed).toBe(true);
+    expect(calls.revoked).toEqual(["req1"]);
+    const parsed = JSON.parse(res.stdout) as { data: Record<string, string> };
+    expect(parsed.data.discord_status).toBe("removed");
+  });
+
+  test("--discord-member: a removeRole failure still exits 0 with a warning (revoke already committed)", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const mockDiscord: DiscordRemoveClient = {
+      async resolveRoleId() { return "role-id-123"; },
+      async removeRole() { return { success: false, error: "missing_permissions" }; },
+    };
+    __setDiscordRemoveClientForTests(mockDiscord);
+
+    const res = await dispatchNetwork(
+      argv("secret", "revoke-member", "metafactory", MEMBER,
+        "--discord-member", "member-999", "--discord-guild", "guild-123",
+        "--apply", "--json", "--admin-seed", seedPath),
+      undefined, undefined, undefined, factory,
+    );
+
+    // The revoke committed (hub cut + registry) → exit 0; Discord failure is a warning.
+    expect(res.exitCode).toBe(0);
+    expect(calls.revoked).toEqual(["req1"]);
+    const parsed = JSON.parse(res.stdout) as { data: Record<string, string> };
+    expect(parsed.data.discord_status).toBe("failed");
+    expect(parsed.data.discord_warning).toContain("missing_permissions");
+  });
+
+  test("--discord-member on a FAILED revoke (no ADMITTED row) removes nothing", async () => {
+    const { factory } = fakeFactory({ admitted: undefined });
+    let removeCalled = false;
+    const mockDiscord: DiscordRemoveClient = {
+      async resolveRoleId() { return "role-id-123"; },
+      async removeRole() { removeCalled = true; return { success: true }; },
+    };
+    __setDiscordRemoveClientForTests(mockDiscord);
+
+    const res = await dispatchNetwork(
+      argv("secret", "revoke-member", "metafactory", MEMBER,
+        "--discord-member", "member-999", "--discord-guild", "guild-123",
+        "--apply", "--admin-seed", seedPath),
+      undefined, undefined, undefined, factory,
+    );
+
+    // No ADMITTED row → the revoke didn't commit → the role removal must NOT run
+    // (there is nothing to pair it with).
+    expect(res.exitCode).toBe(1);
+    expect(removeCalled).toBe(false);
+  });
+
+  test("custom --discord-role is forwarded to resolveRoleId (flag-resolution parity with admit)", async () => {
+    const { factory } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    let capturedRole = "";
+    const mockDiscord: DiscordRemoveClient = {
+      async resolveRoleId(_t, _g, roleName) { capturedRole = roleName; return "custom-role-id"; },
+      async removeRole() { return { success: true }; },
+    };
+    __setDiscordRemoveClientForTests(mockDiscord);
+
+    const res = await dispatchNetwork(
+      argv("secret", "revoke-member", "metafactory", MEMBER,
+        "--discord-member", "member-999", "--discord-guild", "guild-123",
+        "--discord-role", "custom-fleet", "--apply", "--admin-seed", seedPath),
+      undefined, undefined, undefined, factory,
+    );
+
+    expect(res.exitCode).toBe(0);
+    expect(capturedRole).toBe("custom-fleet");
   });
 });
 

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -63,6 +63,7 @@ import { canonicalJSON } from "../../../common/registry/signing";
 // admit path cannot import from an external arc bundle.
 import {
   assignRole,
+  removeRole,
   resolveRoleId,
   loadConfig as loadDiscordConfig,
   resolveServerContext,
@@ -379,15 +380,24 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
     // Signs an admission decision claim carrying decision:"reject" → POSTs to
     // `/admission-requests/:id/reject` → the PENDING row moves to REJECTED.
     // Grants + seals NOTHING (rejection has no roster row to make connectable),
-    // so it omits admit's Discord flags AND the --hub-config/--roster-only seal
-    // controls. Dry-run by DEFAULT: prints the claim it WOULD post; --apply
-    // executes. The row's network_id is fixed at register time; the registry
-    // authorises and acts on that stored value, so there is no network selector.
+    // so it omits admit's --hub-config/--roster-only seal controls. Dry-run by
+    // DEFAULT: prints the claim it WOULD post; --apply executes. The row's
+    // network_id is fixed at register time; the registry authorises and acts on
+    // that stored value, so there is no network selector.
+    //
+    // C-1350 S3 — Tier-1 de-admission pairing: `--discord-member` (+
+    // `--discord-guild/--discord-server/--discord-role`) mirrors admit's flag
+    // block, but REMOVES the community-fleet role as a final non-fatal step. A
+    // role-removal failure NEVER fails the reject (the decision already committed).
     reject: {
       positionals: ["request-id?"],
       flags: {
         "--admin-seed": "value",
         "--registry-url": "value",
+        "--discord-member": "value",
+        "--discord-server": "value",
+        "--discord-guild": "value",
+        "--discord-role": "value",
         "--apply": "bool",
         "--dry-run": "bool",
       },
@@ -446,6 +456,15 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--deliver": "value",
         // Override the hub leaf user (defaults to the member's principal id).
         "--leaf-user": "value",
+        // C-1350 S3 — revoke-member de-admission pairing: `--discord-member`
+        // (+ `--discord-guild/--discord-server/--discord-role`) mirrors admit's
+        // flag block, REMOVING the community-fleet role as a final non-fatal step
+        // after the hub-cut + registry REVOKE. A removal failure NEVER fails the
+        // revoke (transport is already cut, the row already REVOKED).
+        "--discord-member": "value",
+        "--discord-server": "value",
+        "--discord-guild": "value",
+        "--discord-role": "value",
         "--apply": "bool",
         "--dry-run": "bool",
       },
@@ -1784,6 +1803,122 @@ const defaultDiscordAdmitClient: DiscordAdmitClient = {
   assignRole,
 };
 
+// ---------------------------------------------------------------------------
+// C-1350 S3 — Tier-1 de-admission: REMOVE the community-fleet role (the inverse
+// of admit's assign). `reject` and `secret revoke-member` share this. The flag
+// resolution mirrors runAdmit's block EXACTLY (same names, same precedence, same
+// graceful degradation) — the only difference is it calls `removeRole`, and a
+// failure is ALWAYS non-fatal (the parent decision has already committed).
+// ---------------------------------------------------------------------------
+
+/** Minimal Discord client surface (role removal) injectable for tests. */
+export interface DiscordRemoveClient {
+  resolveRoleId(botToken: string, guildId: string, roleName: string): Promise<string>;
+  removeRole(botToken: string, guildId: string, userId: string, roleId: string): Promise<{ success: boolean; error?: string }>;
+}
+
+let discordRemoveClientOverride: DiscordRemoveClient | null = null;
+
+/** Test-only setter. Production callers never touch this. Null restores default. */
+export function __setDiscordRemoveClientForTests(client: DiscordRemoveClient | null): void {
+  discordRemoveClientOverride = client;
+}
+
+/** Default production client — thin wrappers over the real discord lib. */
+const defaultDiscordRemoveClient: DiscordRemoveClient = {
+  resolveRoleId,
+  removeRole,
+};
+
+/** The Discord flags the de-admission role removal reads (mirrors admit's). */
+interface DiscordRemoveFlags {
+  /** The member snowflake to strip the role from (`--discord-member`). */
+  member: string;
+  /** `--discord-server` profile name (optional). */
+  server?: string;
+  /** `--discord-guild` id override (optional). */
+  guild?: string;
+  /** Role name-or-id (`--discord-role`, defaults to community-fleet). */
+  role: string;
+}
+
+/** Outcome of the (best-effort) de-admission role removal. */
+interface DiscordRemoveOutcome {
+  /** skipped | skipped_no_token | skipped_no_guild | removed | failed. */
+  status: string;
+  /** Actionable warning when the role could not be removed (empty on success). */
+  warning: string;
+}
+
+/**
+ * Remove the community-fleet role from a de-admitted member, mirroring runAdmit's
+ * assignment block byte-for-byte in resolution precedence:
+ *   `--guild` flag > `--server` profile > top-level config (via
+ *   resolveServerContext), with the injected test client short-circuiting token/
+ *   guild resolution exactly as admit does.
+ *
+ * ALWAYS best-effort: any resolution or API failure returns a `failed`/`skipped_*`
+ * status + an actionable "remove the role manually" warning — it NEVER throws, so
+ * the parent `reject`/`revoke-member` decision (already committed) always stands.
+ *
+ * @param verb  the committed parent motion ("rejected" | "revoked") — woven into
+ *              the warning so the principal knows the decision itself held.
+ */
+async function removeDiscordFleetRole(
+  flags: DiscordRemoveFlags,
+  verb: string,
+): Promise<DiscordRemoveOutcome> {
+  const discordClient = discordRemoveClientOverride;
+  try {
+    const discordConfig = loadDiscordConfig();
+    const ctx = resolveServerContext(discordConfig, {
+      server: flags.server,
+      guild: flags.guild,
+    });
+
+    const botToken = discordClient ? "injected" : ctx.botToken;
+    const guildId = discordClient ? (flags.guild ?? ctx.guildId) : ctx.guildId;
+
+    if (!discordClient && !botToken) {
+      return {
+        status: "skipped_no_token",
+        warning: `Discord role not removed: no bot token configured (run: discord config set botToken <token>) — remove the role manually`,
+      };
+    }
+    if (!guildId) {
+      return {
+        status: "skipped_no_guild",
+        warning: `Discord role not removed: no guild id configured — pass --discord-guild <id> or run: discord config set guildId <id> — remove the role manually`,
+      };
+    }
+
+    const client = discordClient ?? defaultDiscordRemoveClient;
+    let roleId: string;
+    try {
+      roleId = await client.resolveRoleId(botToken ?? "", guildId, flags.role);
+    } catch (err) {
+      return {
+        status: "failed",
+        warning: `Discord role not removed: ${err instanceof Error ? err.message : String(err)} — member ${verb}, remove the role manually`,
+      };
+    }
+
+    const roleResult = await client.removeRole(botToken ?? "", guildId, flags.member, roleId);
+    if (roleResult.success) {
+      return { status: "removed", warning: "" };
+    }
+    return {
+      status: "failed",
+      warning: `Discord role removal failed: ${roleResult.error ?? "unknown error"} — member ${verb}, remove the role manually`,
+    };
+  } catch (err) {
+    return {
+      status: "failed",
+      warning: `Discord role removal error: ${err instanceof Error ? err.message : String(err)} — member ${verb}, remove the role manually`,
+    };
+  }
+}
+
 /**
  * Build an admin-signed read claim for the `x-admin-signed` header.
  * No nonce (reads are idempotent). Uses the shared PKCS#8 signing bridge.
@@ -2279,8 +2414,12 @@ async function runAdmit(
  * except the signed decision claim carries `decision: "reject"` and it POSTs to
  * `/admission-requests/:id/reject`. The registry's shared `handleDecision` moves
  * the PENDING row to REJECTED. Grants + seals NOTHING (a rejected request has no
- * roster row to make connectable), so — unlike admit — there is no seal step and
- * no Discord role assignment.
+ * roster row to make connectable), so — unlike admit — there is no seal step.
+ *
+ * C-1350 S3 — the Tier-1 de-admission pairing: where admit's `--discord-member`
+ * block ASSIGNS the community-fleet role, reject's REMOVES it (a final, non-fatal
+ * step after the REJECTED decision commits). Same flag names, same resolution
+ * precedence; a role-removal failure never fails the reject.
  *
  * Dry-run by default (safe posture). Pass --apply to execute.
  *
@@ -2304,6 +2443,11 @@ async function runReject(
   if (!applyRes.ok) return usageError("reject", applyRes.reason, json);
 
   const registryUrl = optionalValueFlag(flags, "--registry-url") ?? DEFAULT_ADMIT_REGISTRY_URL;
+  // C-1350 S3 — de-admission Discord flags (mirror admit's block exactly).
+  const discordMember = optionalValueFlag(flags, "--discord-member");
+  const discordServer = optionalValueFlag(flags, "--discord-server");
+  const discordGuild = optionalValueFlag(flags, "--discord-guild");
+  const discordRole = optionalValueFlag(flags, "--discord-role") ?? DEFAULT_ADMIT_DISCORD_ROLE;
 
   // Load + chmod-600-gate the admin seed
   const matRes = await adminMaterialFromSeedFile(seedRes.value);
@@ -2331,6 +2475,7 @@ async function runReject(
       `  decision:          reject`,
       `  registry:          ${registryUrl}`,
       `  admin_fingerprint: ${material.fingerprint}`,
+      ...(discordMember !== undefined ? [`  discord_member:    ${discordMember} (role "${discordRole}" would be removed)`] : []),
       ``,
     ];
     return ok(lines.join("\n"));
@@ -2399,28 +2544,47 @@ async function runReject(
     return opError("reject", `registry POST failed: ${err instanceof Error ? err.message : String(err)}`, json);
   }
 
-  // 3. Output summary — no seal, no Discord (rejection grants nothing).
-  if (json) {
-    return ok(
-      renderJson(
-        envelopeOk([], {
-          subcommand: "reject",
-          applied: "true",
-          request_id: requestId,
-          decision: "reject",
-          ...(decidedPrincipalId ? { principal_id: decidedPrincipalId } : {}),
-          admin_fingerprint: material.fingerprint,
-        }),
-      ),
+  // 2b. C-1350 S3 — Tier-1 de-admission: remove the community-fleet role. The
+  // REJECTED decision is ALREADY committed above, so this is a final non-fatal
+  // step — any failure degrades to an actionable warning, never a hard error.
+  let discordStatus = "skipped";
+  let discordWarning = "";
+  if (discordMember !== undefined) {
+    const outcome = await removeDiscordFleetRole(
+      { member: discordMember, server: discordServer, guild: discordGuild, role: discordRole },
+      "rejected",
     );
+    discordStatus = outcome.status;
+    discordWarning = outcome.warning;
+  }
+
+  // 3. Output summary — no seal (rejection grants nothing); Discord role removal
+  // rides along only when --discord-member was given.
+  if (json) {
+    const data: Record<string, string> = {
+      subcommand: "reject",
+      applied: "true",
+      request_id: requestId,
+      decision: "reject",
+      ...(decidedPrincipalId ? { principal_id: decidedPrincipalId } : {}),
+      admin_fingerprint: material.fingerprint,
+      ...(discordStatus !== "skipped" && { discord_status: discordStatus }),
+    };
+    if (discordWarning) data.discord_warning = discordWarning;
+    return ok(renderJson(envelopeOk([], data)));
   }
 
   const lines: string[] = [
     `cortex network reject ${requestId}: rejected`,
     ...(decidedPrincipalId ? [`  principal:   ${decidedPrincipalId}`] : []),
     `  admin:       ${material.fingerprint}`,
-    ``,
   ];
+  if (discordStatus === "removed") {
+    lines.push(`  discord:     community-fleet role removed`);
+  } else if (discordStatus !== "skipped") {
+    lines.push(`  discord:     ${discordWarning}`);
+  }
+  lines.push(``);
   return ok(lines.join("\n"));
 }
 
@@ -2601,6 +2765,12 @@ async function runSecret(
   const registryUrl = optionalValueFlag(flags, "--registry-url") ?? DEFAULT_SECRET_REGISTRY_URL;
   const hubConfigPath = optionalValueFlag(flags, "--hub-config") ?? DEFAULT_HUB_CONFIG_PATH;
   const leafUserOverride = optionalValueFlag(flags, "--leaf-user");
+  // C-1350 S3 — revoke-member de-admission Discord flags (mirror admit's block).
+  // Only meaningful for revoke-member; other actions ignore them.
+  const discordMember = optionalValueFlag(flags, "--discord-member");
+  const discordServer = optionalValueFlag(flags, "--discord-server");
+  const discordGuild = optionalValueFlag(flags, "--discord-guild");
+  const discordRole = optionalValueFlag(flags, "--discord-role") ?? DEFAULT_ADMIT_DISCORD_ROLE;
 
   // 4. Load + chmod-600-gate the hub-admin seed.
   const matRes = await hubAdminMaterialFromSeedFile(seedRes.value);
@@ -2623,6 +2793,30 @@ async function runSecret(
     return opError("secret", `secret ${action} failed: ${err instanceof Error ? err.message : String(err)}`, json);
   }
 
+  // 4b. C-1350 S3 — Tier-1 de-admission pairing for revoke-member. The hub cut +
+  // registry REVOKE are ALREADY committed in the report above (transport is cut,
+  // the row is REVOKED), so removing the community-fleet role is a final NON-FATAL
+  // step: any resolution/API failure degrades to an actionable warning and the
+  // revoke still exits 0. Only runs on a successfully-APPLIED revoke-member with
+  // --discord-member given (a dry-run or a failed revoke removes nothing).
+  let discordStatus = "skipped";
+  let discordWarning = "";
+  if (action === "revoke-member" && discordMember !== undefined) {
+    if (report.ok && report.applied) {
+      const outcome = await removeDiscordFleetRole(
+        { member: discordMember, server: discordServer, guild: discordGuild, role: discordRole },
+        "revoked",
+      );
+      discordStatus = outcome.status;
+      discordWarning = outcome.warning;
+    } else if (!report.applied) {
+      // Dry-run: surface the intent (no mutation) — mirrors admit's dry-run line.
+      discordStatus = "dry-run";
+    }
+    // A FAILED apply (report.ok === false) leaves discordStatus "skipped": the
+    // revoke didn't commit, so there is nothing to pair the role removal with.
+  }
+
   // 5. Render. SECRETS never appear in steps/data; the oob PSK is surfaced in a
   // dedicated, explicitly-labelled block (the one place a secret reaches stdout).
   if (json) {
@@ -2631,7 +2825,9 @@ async function runSecret(
       applied: report.applied ? "true" : "false",
       ...report.data,
       hub_admin_fingerprint: matRes.material.fingerprint,
+      ...(discordStatus !== "skipped" && { discord_status: discordStatus }),
     };
+    if (discordWarning) data.discord_warning = discordWarning;
     // The oob PSK is the hub-admin's to hand over — include it under an explicit
     // key so a machine consumer can pluck it, never folded into the plan text.
     if (report.surfaced) {
@@ -2647,6 +2843,13 @@ async function runSecret(
     : `cortex network secret ${action} ${networkId}: dry-run (no mutation; pass --apply)`;
   const lines = [header, ...report.steps.map((s) => `  ${s}`)];
   if (!report.ok) lines.push(`  ✗ ${report.reason ?? "unknown failure"}`);
+  if (discordStatus === "removed") {
+    lines.push(`  discord:    community-fleet role removed`);
+  } else if (discordStatus === "dry-run") {
+    lines.push(`  discord:    would remove role "${discordRole}" from member ${discordMember}`);
+  } else if (discordStatus !== "skipped") {
+    lines.push(`  discord:    ${discordWarning}`);
+  }
   if (report.surfaced) {
     lines.push("");
     lines.push("  ── OUT-OF-BAND SECRET (hand this to the member over a secure channel) ──");

--- a/src/cli/cortex/lib/__tests__/discord-roles.test.ts
+++ b/src/cli/cortex/lib/__tests__/discord-roles.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, test, spyOn } from "bun:test";
 import {
   assignRole,
+  removeRole,
   resolveRoleId,
   resolveServerContext,
   ServerContextError,
@@ -65,6 +66,53 @@ describe("assignRole", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/not found/);
     expect(result.error).not.toContain(BOT_TOKEN);
+    fetchMock.mockRestore();
+  });
+});
+
+describe("removeRole (C-1350 S3 — de-admission)", () => {
+  test("204 → success, hits the correct DELETE endpoint (inverse of assign)", async () => {
+    const fetchMock = spyOn(globalThis, "fetch").mockResolvedValueOnce(fakeResponse(204));
+    const result = await removeRole(BOT_TOKEN, GUILD, USER, ROLE_ID);
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      `https://discord.com/api/v10/guilds/${GUILD}/members/${USER}/roles/${ROLE_ID}`,
+    );
+    expect(init?.method).toBe("DELETE");
+    fetchMock.mockRestore();
+  });
+
+  test("403 → non-fatal RoleResult (never throws), names guild, hides token", async () => {
+    const fetchMock = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      fakeResponse(403, { message: "Missing Permissions" }),
+    );
+    // Non-fatal contract: it RESOLVES a failure result, it does NOT reject.
+    const result = await removeRole(BOT_TOKEN, GUILD, USER, ROLE_ID);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Manage Roles/);
+    expect(result.error).toMatch(GUILD);
+    expect(result.error).not.toContain(BOT_TOKEN);
+    fetchMock.mockRestore();
+  });
+
+  test("404 → member or role not found, non-fatal", async () => {
+    const fetchMock = spyOn(globalThis, "fetch").mockResolvedValueOnce(fakeResponse(404));
+    const result = await removeRole(BOT_TOKEN, GUILD, USER, ROLE_ID);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/);
+    expect(result.error).not.toContain(BOT_TOKEN);
+    fetchMock.mockRestore();
+  });
+
+  test("other status → surfaces status + body, non-fatal", async () => {
+    const fetchMock = spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      fakeResponse(500, { message: "boom" }),
+    );
+    const result = await removeRole(BOT_TOKEN, GUILD, USER, ROLE_ID);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/500/);
     fetchMock.mockRestore();
   });
 });

--- a/src/cli/cortex/lib/discord-roles.ts
+++ b/src/cli/cortex/lib/discord-roles.ts
@@ -243,6 +243,44 @@ export async function assignRole(
 }
 
 /**
+ * Remove a guild role from a member.
+ *
+ * Wraps `DELETE /guilds/{guild}/members/{user}/roles/{role}` (Discord v10) — the
+ * exact inverse of {@link assignRole}. Success = 204 (no body). Error mappings
+ * reuse {@link mapRoleError} (403 → bot lacks Manage Roles / role hierarchy;
+ * 404 → member or role not found; other → HTTP status + body). The bot token is
+ * NEVER included in error messages.
+ *
+ * Non-fatal by contract: the caller (`reject` / `secret revoke-member`
+ * de-admission) treats a failed removal as a logged warning, never a hard error
+ * — the parent revoke/reject decision has already committed and must not be
+ * failed by a Discord-side hiccup.
+ *
+ * Prerequisite (document; do NOT attempt to self-grant): the bot must have the
+ * **Manage Roles** permission AND its highest role must sit above
+ * `community-fleet` in the guild role hierarchy.
+ */
+export async function removeRole(
+  botToken: string,
+  guildId: string,
+  userId: string,
+  roleId: string,
+): Promise<RoleResult> {
+  const res = await fetch(
+    `${DISCORD_API}/guilds/${guildId}/members/${userId}/roles/${roleId}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bot ${botToken}` },
+    },
+  );
+
+  if (res.status === 204) return { success: true };
+
+  const body = await res.text();
+  return mapRoleError(res.status, body, guildId);
+}
+
+/**
  * Resolve a role name (or snowflake id) to a role id.
  *
  * A 17–20 digit input is treated as an id and returned unchanged (no network


### PR DESCRIPTION
## What

Slice 3 of cortex#1350 (non-trust lane): pair Tier-1 Discord **role removal** with the two de-admission verbs, so cutting a member from the fleet is one command instead of a bus/cred action + a manual Discord edit.

- `src/cli/cortex/lib/discord-roles.ts` — new `removeRole(botToken, guildId, userId, roleId)`: `DELETE /guilds/{g}/members/{u}/roles/{r}`, 204 = success, the **exact inverse** of `assignRole` with the same `RoleResult` non-fatal logged-failure posture (reuses `mapRoleError`; bot token never in error text).
- `secret revoke-member` + `network reject` — new `--discord-member` (+ `--discord-guild` / `--discord-server` / `--discord-role`) that call `removeRole` as a **final non-fatal step** after the existing steps. `revoke-member` removes only on a successfully-**applied** revoke (hub cut + registry REVOKE already committed); `reject` removes after the REJECTED decision commits.
- `docs/sop-community-fleet-admission.md` Step 4 — de-admission is now one command; the manual Discord edit becomes the fallback.
- E2E scoreboard — four `test.todo` entries added (see below).

## How (per the executor-grade build spec, issue comment 4871471862)

`runNetworkSecret` is pure-over-ports, so the Discord flags + `removeRole` call live in the CLI dispatchers (`runSecret` / `runReject` in `network.ts`), not in the pure lib — same layering as admit. A shared `removeDiscordFleetRole(...)` helper mirrors `runAdmit`'s assignment block byte-for-byte in resolution precedence; the working admit path is **untouched** (no regression surface). A parallel `DiscordRemoveClient` + `__setDiscordRemoveClientForTests` injection matches admit's test seam.

## Flag-parity vs admit

| Flag | admit (assign) | reject / revoke-member (remove) |
|---|---|---|
| `--discord-member` | member to assign role to | member to remove role from |
| `--discord-guild` | guild id override | same |
| `--discord-server` | named server profile | same |
| `--discord-role` | role (default `community-fleet`) | same default |
| precedence | `--guild` > `--server` profile > top-level config (via `resolveServerContext`); injected client short-circuits token/guild | **identical** |
| failure posture | warn + exit 0 (admission committed) | warn "remove the role manually" + exit 0 (decision committed) |

## Non-fatal posture — tests

- `removeRole` 204 success · 403/404/other → non-fatal `RoleResult` (never throws), guild named, token hidden.
- `revoke-member --discord-member` calls `removeRole` **after** the registry revoke · a `removeRole` failure still exits 0 with the warning · a FAILED revoke (no ADMITTED row) removes nothing · custom `--discord-role` forwarded.
- `reject --discord-member` likewise: removal after REJECTED · failure → exit 0 + warning · flag-resolution parity (custom role forwarded).

## E2E scoreboard todos added

- `step 4c (#1350 S1): member depart — leave exits the roster (ADMITTED→DEPARTED)`
- `step 5b (#1349 S1): sealed K delivery — add-member seals payload_key, join installs it`
- `step 7b (#1349 S2): rotate-key re-seals K' to every ADMITTED member (never REVOKED/DEPARTED)`
- `step 10 (#1351 S2): provision-stack retire tombstones the stack (409 while ADMITTED rows live)`

## Four-check results (from ../Cortex-roles)

- `bunx eslint --quiet .` → **0**
- `bunx tsc --noEmit` → **0**
- `bash scripts/check-carveouts.sh` → **PASS**
- `bun test src/cli/cortex/commands src/cli/cortex/lib` → **1178 pass, 9 todo, 0 fail**

Refs #1350 (Slice 3 of 3). Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196JFPf1tEudhBUvwWjEhgA