### PR TITLE
feat(lifecycle): C-1350 Slice 1 — member depart: ADMITTED→DEPARTED via member-PoP endpoint

### DIFF
--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/harness.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/harness.ts
@@ -216,10 +216,12 @@ export function makeLeaveNetworkPorts(initial: PolicyFederatedNetwork[]): LeaveP
       return Promise.resolve({ ok: true as const });
     },
   };
-  // Only `deregisterFromNetwork` is called by leave; the join-side registry
-  // methods are never reached, so a partial + cast keeps the fake small.
+  // Only `deregisterFromNetwork` + `departFromNetwork` are called by leave; the
+  // join-side registry methods are never reached, so a partial + cast keeps the
+  // fake small.
   const registry = {
     deregisterFromNetwork: () => Promise.resolve({ ok: true as const, note: "test no-op" }),
+    departFromNetwork: () => Promise.resolve({ ok: true as const, note: "test no-op" }),
   } as unknown as NetworkRegistryPort;
   // Leave calls only removeInclude / remove / list.
   const leafFile = {

--- a/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
@@ -138,6 +138,7 @@ function makeMinimalPorts(opts: {
     },
     loadCached() { return undefined; },
     async deregisterFromNetwork() { return { ok: true, note: "ok" }; },
+    async departFromNetwork() { return { ok: true, note: "ok" }; },
   };
 
   const busType = opts.busType ?? "operator-mode";
@@ -327,6 +328,7 @@ describe("G1c — federation-wiring step in joinNetwork (ADR-0013 Model B)", () 
       },
       loadCached() { return undefined; },
       async deregisterFromNetwork() { return { ok: true, note: "ok" }; },
+    async departFromNetwork() { return { ok: true, note: "ok" }; },
     };
 
     const leafFile: LeafFilePort = {

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -137,6 +137,8 @@ interface Recorder {
   bindModeChecks: { account: string | undefined; hasCreds: boolean }[];
   /** C-820 — network ids the leave path asked the registry to deregister from. */
   deregistered: string[];
+  /** C-1350 — network ids the leave path asked the registry to depart from. */
+  departed: string[];
   /** #821 — creds-existence paths pre-flighted. */
   credsChecks: string[];
   /** #821 — networks whose leaf state was snapshotted (pre-mutation). */
@@ -157,6 +159,8 @@ function makeFakes(opts: {
   registerOk?: boolean;
   /** C-820 — outcome of the leave-side registry deregister (default: ok). */
   deregisterOk?: boolean;
+  /** C-1350 — outcome of the leave-side registry depart (default: ok). */
+  departOk?: boolean;
   restartOk?: boolean;
   /** #757 — make the nats-server restart fail (default: ok). */
   natsRestartOk?: boolean;
@@ -225,6 +229,7 @@ function makeFakes(opts: {
     bindChecks: [],
     bindModeChecks: [],
     deregistered: [],
+    departed: [],
     credsChecks: [],
     snapshots: [],
     restores: [],
@@ -265,6 +270,12 @@ function makeFakes(opts: {
       return opts.deregisterOk === false
         ? { ok: false, reason: "registry unreachable for retag" }
         : { ok: true, note: "retagged" };
+    },
+    async departFromNetwork(networkId) {
+      rec.departed.push(networkId);
+      return opts.departOk === false
+        ? { ok: false, reason: "registry unreachable for depart" }
+        : { ok: true, note: "admission row marked DEPARTED" };
     },
   };
 
@@ -1726,6 +1737,42 @@ describe("leave", () => {
     expect(rec.deregistered).toEqual(["community"]);
     expect((res.warnings ?? []).some((w) => w.includes("deregister-from-network") && w.includes("community"))).toBe(true);
   });
+
+  test("C-1350 — leave DEPARTs the member's admission row AFTER local teardown (happy path)", async () => {
+    const { ports, rec, storeRef } = makeFakes({
+      initialNetworks: [joinedNetwork("metafactory"), joinedNetwork("community")],
+    });
+    const res = await leaveNetwork("community", ports);
+
+    expect(res.ok).toBe(true);
+    // Local teardown happened.
+    expect(storeRef.networks.map((n) => n.id)).toEqual(["metafactory"]);
+    // The registry was asked to depart EXACTLY the left network.
+    expect(rec.departed).toEqual(["community"]);
+    // Depart runs AFTER the daemon restart (teardown-then-notify ordering).
+    const restartIdx = res.steps.findIndex((s) => s.includes("restarted stack daemon"));
+    const departIdx = res.steps.findIndex((s) => s.includes("registry depart"));
+    expect(restartIdx).toBeGreaterThanOrEqual(0);
+    expect(departIdx).toBeGreaterThan(restartIdx);
+    // No warning on the happy path.
+    expect(res.warnings ?? []).toHaveLength(0);
+  });
+
+  test("C-1350 — a registry depart FAILURE is non-fatal: local leave still ok, surfaced as a warning", async () => {
+    const { ports, rec, storeRef } = makeFakes({
+      initialNetworks: [joinedNetwork("community")],
+      departOk: false,
+    });
+    const res = await leaveNetwork("community", ports);
+
+    // The LOCAL leave succeeded despite the registry depart failing.
+    expect(res.ok).toBe(true);
+    expect(storeRef.networks.length).toBe(0);
+    expect(rec.restarts).toBe(1);
+    expect(rec.departed).toEqual(["community"]);
+    // The failure is surfaced as a warning (re-runnable), not a hard failure.
+    expect((res.warnings ?? []).some((w) => w.includes("registry depart") && w.includes("community"))).toBe(true);
+  });
 });
 
 // =============================================================================
@@ -1882,6 +1929,34 @@ describe("status", () => {
       expect(row.admission!.requestId).toBe("req-abc");
       // The network id the cleanup command needs rides the row.
       expect(row.networkId).toBe("metafactory");
+    });
+
+    test("a DEPARTED own-row surfaces a quiet informational departed summary (no warning)", async () => {
+      const { ports } = makeFakes({
+        initialNetworks: [joinedNetwork("metafactory")],
+        admission: {
+          metafactory: {
+            ok: true,
+            state: {
+              state: "departed",
+              networkId: "metafactory",
+              requestId: "req-dep",
+              hasSealedSecret: false,
+              peerPubkey: "PUB",
+              updatedAt: "2026-07-03T10:00:00.000Z",
+            },
+          },
+        },
+      });
+      const res = await networkStatus(ports);
+      const row = res.networks[0]!;
+      expect(row.admission).toBeDefined();
+      // Informational: departed=true, NOT revoked (no warning banner).
+      expect(row.admission!.departed).toBe(true);
+      expect(row.admission!.revoked).toBe(false);
+      expect(row.admission!.lookup).toBe("ok");
+      expect(row.admission!.departedAt).toBe("2026-07-03T10:00:00.000Z");
+      expect(row.admission!.requestId).toBe("req-dep");
     });
 
     test("an ADMITTED/live own-row attaches NO admission field (no false REVOKED)", async () => {

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -91,6 +91,7 @@ import type {
 } from "./network-ports";
 import {
   resolveOwnAdmissionState,
+  departOwnAdmission,
   type ResolveOwnAdmissionStateResult,
 } from "../../../common/registry/admission-state";
 import { buildFederationWiringAdapter } from "./network-federation-wiring";
@@ -372,7 +373,7 @@ async function registerWithCapabilities(
   return { ok: true, note: `HTTP ${result.status.toString()}` };
 }
 
-function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
+function buildRegistryPort(cfg: LivePortsConfig, mutate: boolean): NetworkRegistryPort {
   const url = cfg.registryUrl ?? "";
   const client = new NetworkRegistryClient({
     url,
@@ -428,9 +429,14 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
     async deregisterFromNetwork(networkId) {
       // C-820 (leave symmetry) — remove ONLY `networkId` from each capability's
       // registry `networks[]` (set-difference), re-attesting the reduced set so
-      // the principal exits this ONE network's roster while staying in the
-      // others. A registry control-plane POST, never a `federated.*` wire
-      // envelope (the network name never goes on the bus). Never throws.
+      // the principal's CAPABILITY FACET for this network is dropped while its
+      // caps stay tagged for the OTHER networks. Post-ADR-0018-Q3 this retag does
+      // NOT itself remove the member from the `members[]` roster — roster
+      // membership is now ADMITTED-admission-sourced (`rosterFromAdmissions`
+      // filters `status='ADMITTED'`), so leaving the roster is the job of the
+      // member self-DEPART (`departFromNetwork` → ADMITTED→DEPARTED), not this
+      // capability retag. A registry control-plane POST, never a `federated.*`
+      // wire envelope (the network name never goes on the bus). Never throws.
       //
       // SKIP cleanly (a `note`, not an error/warning) when the registry can't be
       // signed-to: no registry URL, or no seed to sign the re-attestation. Leave
@@ -457,6 +463,41 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
       // route. `mergeExistingCaps:false` — we already computed the exact intended
       // set (the union-then-subtract), so we must NOT re-union it back in.
       return registerWithCapabilities(cfg, retag.capabilities, true, false);
+    },
+    async departFromNetwork(networkId) {
+      // C-1350 Slice 1 — the member-side self-DEPART. PoP-sign + POST
+      // `/admission-requests/:id/depart`, transitioning the member's own
+      // ADMITTED row → DEPARTED so they drop out of `members[]`. NON-FATAL (the
+      // orchestrator warns and still reports the local leave `ok`).
+      //
+      // DRY-RUN GATE — unlike the cap retag above, this is a real state
+      // transition of the member's admission row, so a dry-run leave (a preview)
+      // must NOT fire it. Return a clean no-op note when not applying.
+      if (!mutate) {
+        return { ok: true, note: "dry-run — registry depart POST skipped (no mutation)" };
+      }
+      // SKIP cleanly when the registry can't be signed-to (no url/seed) — same
+      // posture as the deregister above; a stack with no registry has no row.
+      if (url === "" || cfg.seedPath === undefined || cfg.seedPath === "") {
+        return {
+          ok: true,
+          note: "no registry url/seed configured — skipped registry depart (local leave only)",
+        };
+      }
+      const matRes = loadSeedMaterial(cfg.seedPath, "--seed-path");
+      if (!matRes.ok) return { ok: false, reason: matRes.reason };
+
+      const res = await departOwnAdmission(
+        { registryUrl: url, principalId: cfg.principalId, material: matRes.material },
+        networkId,
+      );
+      if (!res.ok) return { ok: false, reason: res.reason };
+      if (res.outcome === "departed") {
+        return { ok: true, note: `admission row ${res.requestId} marked DEPARTED` };
+      }
+      // not-applicable — no ADMITTED row for this network (already gone / never
+      // admitted / already departed). A clean no-op, not a failure.
+      return { ok: true, note: `no admitted admission row to depart (state: ${res.state})` };
     },
   };
 }
@@ -1307,7 +1348,7 @@ const liveResolveOwnAdmissionState: AdmissionResolver = (networkId, inputs) =>
 
 function buildPorts(cfg: LivePortsConfig, mutate: boolean): NetworkPorts {
   return {
-    registry: buildRegistryPort(cfg),
+    registry: buildRegistryPort(cfg, mutate),
     leafFile: buildLeafFilePort(cfg, mutate),
     plist: buildPlistPort(cfg, mutate),
     configStore: buildConfigStorePort(cfg, mutate),

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -218,6 +218,14 @@ export interface AdmissionStatusInfo {
   revoked: boolean;
   /** ISO-8601 UTC the row was revoked (`updated_at`), when the registry supplied it. */
   revokedAt?: string;
+  /**
+   * C-1350 Slice 1 — true when this stack's own admission row is DEPARTED (the
+   * member left voluntarily). Purely informational — NO warning banner, unlike
+   * `revoked` (which is an involuntary kick the member should act on).
+   */
+  departed?: boolean;
+  /** ISO-8601 UTC the row was departed (`updated_at`), when the registry supplied it. */
+  departedAt?: string;
   /** The admission request id, when known — echoed for the admin/audit trail. */
   requestId?: string;
   /**
@@ -1018,6 +1026,24 @@ export async function leaveNetwork(
   }
   steps.push("restarted stack daemon");
 
+  // C-1350 Slice 1 — AFTER the local teardown succeeds, tell the registry the
+  // member left by transitioning their own ADMITTED row → DEPARTED (member PoP
+  // write). NON-FATAL, exactly like the deregister cap-retag above: a failure is
+  // a warning, the leave still reports `ok` (the local effect — the bus is off
+  // the network — already succeeded). Dry-run leaves return a clean no-op note
+  // (the adapter gates the actual POST on `--apply`).
+  const depart = await ports.registry.departFromNetwork(networkId);
+  if (depart.ok) {
+    steps.push(`registry depart for "${networkId}": ${depart.note}`);
+  } else {
+    const warn =
+      `registry depart for "${networkId}" failed (${depart.reason}) — the LOCAL leave completed, ` +
+      `but the registry admission row was not marked DEPARTED; re-run ` +
+      `\`cortex network leave ${networkId} --apply\` when the registry is reachable.`;
+    warnings.push(warn);
+    steps.push(`WARN: ${warn}`);
+  }
+
   return {
     ok: true,
     steps,
@@ -1160,6 +1186,18 @@ async function resolveAdmissionInfo(
   if (!res.ok) {
     // Non-fatal — surface the lookup gap, keep the row (match #1315 posture).
     return { revoked: false, lookup: "unavailable" };
+  }
+  // C-1350 Slice 1 — a DEPARTED row gets a quiet informational summary (the
+  // member left voluntarily; no warning). A REVOKED row keeps its warning
+  // banner. Everything else returns undefined so an ordinary row is unchanged.
+  if (res.state.state === "departed") {
+    return {
+      revoked: false,
+      departed: true,
+      lookup: "ok",
+      ...(res.state.updatedAt !== undefined && { departedAt: res.state.updatedAt }),
+      ...(res.state.requestId !== undefined && { requestId: res.state.requestId }),
+    };
   }
   if (res.state.state !== "revoked") return undefined;
   return {

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -121,6 +121,21 @@ export interface NetworkRegistryPort {
   deregisterFromNetwork(
     networkId: string,
   ): Promise<{ ok: true; note: string } | { ok: false; reason: string }>;
+  /**
+   * C-1350 Slice 1 (#1350) — the member-side self-DEPART: after `leave`'s local
+   * teardown, tell the registry the member left by transitioning their OWN
+   * ADMITTED row → DEPARTED (member PoP write; the signature IS the auth, no
+   * admin key). NON-FATAL like {@link deregisterFromNetwork} — a failure warns
+   * but the local leave still reports `ok`. A clean no-op (a `note`, not an
+   * error) when there is nothing to depart (no admitted row) or the registry
+   * cannot be signed-to (no url/seed). UNLIKE `deregisterFromNetwork`, this is
+   * gated on `--apply`: a dry-run leave returns a no-op note and NEVER mutates
+   * the registry row (departing a member's row is a real state transition, not a
+   * preview-safe read). Never throws.
+   */
+  departFromNetwork(
+    networkId: string,
+  ): Promise<{ ok: true; note: string } | { ok: false; reason: string }>;
 }
 
 /** Inputs to the leaf-include render — the trust boundary in one place. */

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -1130,6 +1130,11 @@ async function runStatus(
         `    ⚠ REVOKED — you were removed from "${n.networkId}"${when}. ` +
           `Run \`cortex network leave ${n.networkId} --apply\` to clean up the dead leaf.`,
       );
+    } else if (n.admission?.departed === true) {
+      // C-1350 Slice 1 — voluntary departure: a QUIET informational line, no
+      // warning banner (the member left on purpose; nothing to act on).
+      const when = n.admission.departedAt !== undefined ? ` ${n.admission.departedAt}` : "";
+      lines.push(`    admission: departed${when}`);
     } else if (n.admission?.lookup === "unavailable") {
       lines.push(`    admission_lookup: unavailable`);
     }
@@ -1834,8 +1839,12 @@ async function buildAdmissionDecisionBody(
 // C-1314 — `cortex network admit --list-pending` (admission-queue discovery)
 // =============================================================================
 
-/** Admission-request statuses the registry list endpoint accepts. */
-const LIST_STATUSES = ["PENDING", "ADMITTED", "REJECTED"] as const;
+/** Admission-request statuses the registry list endpoint accepts. C-1350 adds
+ *  REVOKED + DEPARTED so `admit --list-pending --status DEPARTED` surfaces
+ *  departed-but-not-hub-revoked rows (the admin's cue to run `secret
+ *  revoke-member` and cut the hub `authorization` user). Kept in lockstep with
+ *  the registry-side `validStatuses` gate in routes/admission-requests.ts. */
+const LIST_STATUSES = ["PENDING", "ADMITTED", "REJECTED", "REVOKED", "DEPARTED"] as const;
 
 /** The subset of an `AdmissionRequest` row this CLI renders (matches the
  *  registry `GET /admission-requests` response, `types.ts` AdmissionRequest). */

--- a/src/common/registry/__tests__/admission-state.test.ts
+++ b/src/common/registry/__tests__/admission-state.test.ts
@@ -14,6 +14,8 @@ import {
   fetchOwnAdmissionRows,
   resolveOwnAdmissionState,
   rowHasSealedSecret,
+  postDepartAdmission,
+  departOwnAdmission,
   type AdmissionMineRow,
   type FetchLike,
 } from "../admission-state";
@@ -79,10 +81,24 @@ describe("classifyOwnAdmissionRows", () => {
     expect(s.state).toBe("admitted-unsealed");
   });
 
-  test("REVOKED / REJECTED / unknown map through", () => {
+  test("REVOKED / REJECTED / DEPARTED / unknown map through", () => {
     expect(classifyOwnAdmissionRows([row({ status: "REVOKED" })], "metafactory", PUB).state).toBe("revoked");
     expect(classifyOwnAdmissionRows([row({ status: "REJECTED" })], "metafactory", PUB).state).toBe("rejected");
+    expect(classifyOwnAdmissionRows([row({ status: "DEPARTED" })], "metafactory", PUB).state).toBe("departed");
     expect(classifyOwnAdmissionRows([row({ status: "WEIRD" })], "metafactory", PUB).state).toBe("unknown");
+  });
+
+  // C-1350 Slice 1 — a DEPARTED row threads updated_at through as the departed-at
+  // date the quiet `admission: departed <date>` status line prints.
+  test("DEPARTED row carries updated_at through as updatedAt (the departed-at date)", () => {
+    const s = classifyOwnAdmissionRows(
+      [row({ status: "DEPARTED", updated_at: "2026-07-03T10:00:00.000Z", request_id: "rD" })],
+      "metafactory",
+      PUB,
+    );
+    expect(s.state).toBe("departed");
+    expect(s.updatedAt).toBe("2026-07-03T10:00:00.000Z");
+    expect(s.requestId).toBe("rD");
   });
 
   // C-1350 (Slice 2) — the row's updated_at is threaded through as updatedAt so a
@@ -203,5 +219,147 @@ describe("resolveOwnAdmissionState", () => {
       "metafactory",
     );
     expect(res.ok).toBe(false);
+  });
+});
+
+// =============================================================================
+// C-1350 Slice 1 — postDepartAdmission (member-PoP write) + departOwnAdmission
+// =============================================================================
+
+describe("postDepartAdmission", () => {
+  test("signs the depart claim + POSTs /admission-requests/:id/depart, returns the row", async () => {
+    const material = realMaterial();
+    let gotUrl = "";
+    let gotMethod = "";
+    let gotBody = "";
+    const fetchImpl: FetchLike = async (url, init) => {
+      gotUrl = url;
+      gotMethod = init?.method ?? "";
+      gotBody = init?.body ?? "";
+      return { ok: true, status: 200, json: async () => row({ request_id: "req-abc", status: "DEPARTED", sealed_secret: null }) };
+    };
+    const res = await postDepartAdmission({
+      registryUrl: "http://registry.test/",
+      principalId: "jc",
+      material,
+      requestId: "req-abc",
+      fetchImpl,
+      now: () => new Date("2026-07-03T00:00:00.000Z"),
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.row.status).toBe("DEPARTED");
+    expect(gotUrl).toBe("http://registry.test/admission-requests/req-abc/depart"); // trailing slash trimmed
+    expect(gotMethod).toBe("POST");
+    // Client signs-what-it-sends: the posted claim carries EXACTLY the fields the
+    // registry AdmissionDepartClaim canonicalises + a signature over them.
+    const body = JSON.parse(gotBody) as { claim: Record<string, unknown>; signature: string };
+    expect(body.claim.request_id).toBe("req-abc");
+    expect(body.claim.principal_id).toBe("jc");
+    expect(body.claim.peer_pubkey).toBe(material.pubkeyB64);
+    expect(typeof body.claim.issued_at).toBe("string");
+    expect(typeof body.claim.nonce).toBe("string");
+    expect((body.claim.nonce as string).length).toBeGreaterThanOrEqual(8);
+    expect(body.signature.length).toBeGreaterThan(0);
+  });
+
+  test("HTTP error → soft ok:false with the status (never throws)", async () => {
+    const material = realMaterial();
+    const fetchImpl: FetchLike = async () => ({ ok: false, status: 409, json: async () => ({}) });
+    const res = await postDepartAdmission({
+      registryUrl: "http://r.test",
+      principalId: "jc",
+      material,
+      requestId: "req-abc",
+      fetchImpl,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("409");
+  });
+
+  test("transport throw → soft ok:false (never throws)", async () => {
+    const material = realMaterial();
+    const fetchImpl: FetchLike = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const res = await postDepartAdmission({
+      registryUrl: "http://r.test",
+      principalId: "jc",
+      material,
+      requestId: "req-abc",
+      fetchImpl,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("errored");
+  });
+});
+
+describe("departOwnAdmission (read → depart if ADMITTED)", () => {
+  /** A fetch that answers the GET /mine read with `rows`, and any POST with `postResp`. */
+  function fetchFor(
+    rows: AdmissionMineRow[],
+    postResp: { ok: boolean; status: number; body?: unknown } = { ok: true, status: 200 },
+  ): FetchLike {
+    return async (_url, init) => {
+      if ((init?.method ?? "GET") === "GET") {
+        return { ok: true, status: 200, json: async () => rows };
+      }
+      return { ok: postResp.ok, status: postResp.status, json: async () => postResp.body ?? {} };
+    };
+  }
+
+  test("an ADMITTED row is departed → outcome 'departed' with the request-id", async () => {
+    const material = realMaterial();
+    const admittedRow = row({ network_id: "metafactory", status: "ADMITTED", request_id: "rX", peer_pubkey: material.pubkeyB64 });
+    const departedRow = { ...admittedRow, status: "DEPARTED", sealed_secret: null };
+    const res = await departOwnAdmission(
+      { registryUrl: "http://r.test", principalId: "jc", material, fetchImpl: fetchFor([admittedRow], { ok: true, status: 200, body: departedRow }) },
+      "metafactory",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.outcome).toBe("departed");
+      if (res.outcome === "departed") expect(res.requestId).toBe("rX");
+    }
+  });
+
+  test("a PENDING row → outcome 'not-applicable' (no depart POST fired)", async () => {
+    const material = realMaterial();
+    let posted = false;
+    const fetchImpl: FetchLike = async (_url, init) => {
+      if ((init?.method ?? "GET") !== "GET") posted = true;
+      return { ok: true, status: 200, json: async () => [row({ network_id: "metafactory", status: "PENDING" })] };
+    };
+    const res = await departOwnAdmission({ registryUrl: "http://r.test", principalId: "jc", material, fetchImpl }, "metafactory");
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.outcome).toBe("not-applicable");
+    expect(posted).toBe(false);
+  });
+
+  test("no row for the network → 'not-applicable'", async () => {
+    const material = realMaterial();
+    const res = await departOwnAdmission(
+      { registryUrl: "http://r.test", principalId: "jc", material, fetchImpl: fetchFor([row({ network_id: "othernet", status: "ADMITTED" })]) },
+      "metafactory",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.outcome).toBe("not-applicable");
+  });
+
+  test("a /mine read failure → ok:false (non-fatal for the caller)", async () => {
+    const material = realMaterial();
+    const fetchImpl: FetchLike = async () => ({ ok: false, status: 500, json: async () => ({}) });
+    const res = await departOwnAdmission({ registryUrl: "http://r.test", principalId: "jc", material, fetchImpl }, "metafactory");
+    expect(res.ok).toBe(false);
+  });
+
+  test("an ADMITTED row whose depart POST fails → ok:false", async () => {
+    const material = realMaterial();
+    const admittedRow = row({ network_id: "metafactory", status: "ADMITTED", request_id: "rX", peer_pubkey: material.pubkeyB64 });
+    const res = await departOwnAdmission(
+      { registryUrl: "http://r.test", principalId: "jc", material, fetchImpl: fetchFor([admittedRow], { ok: false, status: 503 }) },
+      "metafactory",
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("503");
   });
 });

--- a/src/common/registry/admission-state.ts
+++ b/src/common/registry/admission-state.ts
@@ -61,7 +61,7 @@ export interface AdmissionMineRow {
 /** Injectable fetch (defaults to `globalThis.fetch`) so callers/tests stay hermetic. */
 export type FetchLike = (
   url: string,
-  init?: { method?: string; headers?: Record<string, string> },
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
 ) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
 
 export interface FetchOwnAdmissionRowsInput {
@@ -147,6 +147,7 @@ export type AdmissionRowState =
   | "admitted-sealed"
   | "revoked"
   | "rejected"
+  | "departed"
   | "unknown";
 
 export interface OwnAdmissionState {
@@ -207,6 +208,10 @@ export function classifyOwnAdmissionRows(
       return { ...base, state: "revoked" };
     case "REJECTED":
       return { ...base, state: "rejected" };
+    case "DEPARTED":
+      // C-1350 Slice 1 — the member left voluntarily. Informational (no warning
+      // banner): departure is self-initiated, not an involuntary REVOKED kick.
+      return { ...base, state: "departed" };
     default:
       return { ...base, state: "unknown" };
   }
@@ -231,6 +236,114 @@ export async function resolveOwnAdmissionState(
     ok: true,
     state: classifyOwnAdmissionRows(res.rows, networkId, input.material.pubkeyB64),
   };
+}
+
+/**
+ * C-1350 Slice 1 (#1350) — the member-side self-DEPART write. PoP-signs a depart
+ * claim with the stack's OWN seed and POSTs
+ * `/admission-requests/{request_id}/depart`, transitioning the member's own
+ * ADMITTED row → DEPARTED. The signature IS the authorization (member PoP; no
+ * admin key) — the SAME plumbing `fetchOwnAdmissionRows` uses, promoted from a
+ * read to a write with a `nonce` for replay protection.
+ *
+ * Verify-over-wire discipline (client signs-what-it-sends): the claim object
+ * signed here is the EXACT object posted, so `canonicalJSON(claim)` on the
+ * server matches byte-for-byte regardless of key order.
+ *
+ * Never throws — every failure is a typed `{ ok: false, reason }` so the leave
+ * flow can treat it as NON-FATAL (warn, still leave locally).
+ */
+export type PostDepartResult =
+  | { ok: true; row: AdmissionMineRow }
+  | { ok: false; reason: string };
+
+export interface PostDepartInput extends FetchOwnAdmissionRowsInput {
+  /** The admission request id to depart (the member's own ADMITTED row). */
+  requestId: string;
+}
+
+export async function postDepartAdmission(input: PostDepartInput): Promise<PostDepartResult> {
+  const fetchImpl: FetchLike = input.fetchImpl ?? globalThis.fetch;
+  const now = input.now ?? (() => new Date());
+
+  // 1. Sign the depart claim with the stack's own key (signature IS the auth).
+  //    Shape MUST match the registry `AdmissionDepartClaim` exactly.
+  const claim = {
+    request_id: input.requestId,
+    principal_id: input.principalId,
+    peer_pubkey: input.material.pubkeyB64,
+    issued_at: now().toISOString(),
+    nonce: randomDepartNonce(),
+  };
+  let bodyStr: string;
+  try {
+    const sig = await signClaimWithSeed(
+      input.material.seed,
+      new TextEncoder().encode(canonicalJSON(claim)),
+    );
+    bodyStr = JSON.stringify({ claim, signature: sig });
+  } catch (err) {
+    return { ok: false, reason: `failed to sign depart claim: ${errText(err)}` };
+  }
+
+  // 2. POST /admission-requests/:id/depart.
+  try {
+    const base = input.registryUrl.replace(/\/+$/, "");
+    const url = `${base}/admission-requests/${encodeURIComponent(input.requestId)}/depart`;
+    const resp = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: bodyStr,
+    });
+    if (!resp.ok) {
+      return { ok: false, reason: `registry depart failed (HTTP ${resp.status.toString()})` };
+    }
+    const row = (await resp.json()) as AdmissionMineRow;
+    return { ok: true, row };
+  } catch (err) {
+    return { ok: false, reason: `registry depart errored: ${errText(err)}` };
+  }
+}
+
+/**
+ * C-1350 Slice 1 — read + classify this stack's admission state for `networkId`,
+ * then DEPART its ADMITTED row if (and only if) there is one. Reused by
+ * `leaveNetwork` so leaving a network also tells the registry "I left". Best
+ * effort — never throws:
+ *   - `departed`        — an ADMITTED row existed and was transitioned.
+ *   - `not-applicable`  — nothing to depart (no row / pending / rejected /
+ *                         already revoked / already departed). A clean no-op.
+ *   - `{ ok: false }`   — the `/mine` read or the depart POST failed.
+ */
+export type DepartOwnAdmissionResult =
+  | { ok: true; outcome: "departed"; requestId: string; row: AdmissionMineRow }
+  | { ok: true; outcome: "not-applicable"; state: AdmissionRowState }
+  | { ok: false; reason: string };
+
+export async function departOwnAdmission(
+  input: FetchOwnAdmissionRowsInput,
+  networkId: string,
+): Promise<DepartOwnAdmissionResult> {
+  const read = await fetchOwnAdmissionRows(input);
+  if (!read.ok) return { ok: false, reason: read.reason };
+
+  const state = classifyOwnAdmissionRows(read.rows, networkId, input.material.pubkeyB64);
+  const isAdmitted = state.state === "admitted-sealed" || state.state === "admitted-unsealed";
+  if (!isAdmitted || state.requestId === undefined) {
+    // No active ADMITTED row for this network — nothing to depart.
+    return { ok: true, outcome: "not-applicable", state: state.state };
+  }
+
+  const posted = await postDepartAdmission({ ...input, requestId: state.requestId });
+  if (!posted.ok) return { ok: false, reason: posted.reason };
+  return { ok: true, outcome: "departed", requestId: state.requestId, row: posted.row };
+}
+
+/** 16-byte hex nonce for the depart write (matches the registry 8..128-char bound). */
+function randomDepartNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 /** Error → message, never echoing secret-bearing inputs. */

--- a/src/services/network-registry/__tests__/depart.test.ts
+++ b/src/services/network-registry/__tests__/depart.test.ts
@@ -1,0 +1,358 @@
+/**
+ * C-1350 Slice 1 (#1350) — member self-DEPART endpoint
+ * `POST /admission-requests/:id/depart`.
+ *
+ * Trust-path coverage (member-PoP write, promoted from the `/mine` read):
+ *   - happy: an ADMITTED member departs their OWN row → 200 DEPARTED, sealed
+ *     blob cleared, and the roster (member PoP-read) drops them from members[]
+ *   - non-ADMITTED (PENDING / REJECTED / REVOKED) → 409 "already <STATUS>"
+ *   - idempotent re-depart of a DEPARTED row → 200
+ *   - wrong-member PoP (a different valid key) → 403 + the row stays ADMITTED
+ *   - forged signature → 401
+ *   - over-wide body (junk keys past the canonical cap) → 401, NEVER 500
+ *   - request_id path/body mismatch → 400 ; invalid request_id grammar → 400
+ *   - clock skew → 400 ; replayed nonce → 409
+ *   - NO admin allowlist is consulted — the own-row check IS the authz (a depart
+ *     succeeds with the admin allowlist empty, proving no admin gate)
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
+  randomNonce,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import { MAX_CANONICAL_KEYS } from "../src/signing";
+import type { AdmissionRequest } from "../src/types";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+
+let env: Env;
+let admin: PrincipalKey;
+let hubAdmin: PrincipalKey;
+let member: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, headers: Record<string, string> = {}, e: Env = env): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+/**
+ * Register `principalId` (signed by `pKey`) targeting `networkId`, then ADMIT the
+ * resulting PENDING row. After this the row's stored `peer_pubkey` is
+ * `pKey.publicKeyB64` and its status is ADMITTED.
+ */
+async function registerAndAdmit(
+  principalId: string,
+  pKey: PrincipalKey,
+  networkId: string,
+): Promise<AdmissionRequest> {
+  const reg = await post(
+    `/principals/${principalId}/register`,
+    await makeSignedRegistration(principalId, pKey, { networkId }),
+  );
+  expect(reg.status).toBe(201);
+  const req = await findRequest(principalId, networkId, "PENDING");
+  const decision = await makeSignedAdminDecision(req.request_id, "admit", admin);
+  const admitRes = await post(`/admission-requests/${req.request_id}/admit`, decision);
+  expect(admitRes.status).toBe(200);
+  return req;
+}
+
+/** Register-only — leaves a PENDING row. */
+async function registerPending(
+  principalId: string,
+  pKey: PrincipalKey,
+  networkId: string,
+): Promise<AdmissionRequest> {
+  const reg = await post(
+    `/principals/${principalId}/register`,
+    await makeSignedRegistration(principalId, pKey, { networkId }),
+  );
+  expect(reg.status).toBe(201);
+  return findRequest(principalId, networkId, "PENDING");
+}
+
+/** Look up a row by (principal, network) at an expected status via the admin list. */
+async function findRequest(
+  principalId: string,
+  networkId: string,
+  status: string,
+): Promise<AdmissionRequest> {
+  const read = await makeSignedAdminRead(admin);
+  const listRes = await get(`/admission-requests?status=${status}`, {
+    "x-admin-signed": JSON.stringify(read),
+  });
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const req = list.find((r) => r.principal_id === principalId && r.network_id === networkId);
+  expect(req).toBeDefined();
+  return req!;
+}
+
+/** Build a signed member-PoP depart envelope. Defaults sign with `member`. */
+async function makeDepart(
+  requestId: string,
+  signer: PrincipalKey,
+  opts: {
+    principalId?: string;
+    issuedAt?: string;
+    nonce?: string;
+    pubkeyOverride?: string;
+    requestIdOverride?: string;
+  } = {},
+) {
+  const claim = {
+    request_id: opts.requestIdOverride ?? requestId,
+    principal_id: opts.principalId ?? "alice",
+    peer_pubkey: opts.pubkeyOverride ?? signer.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+  const signature = await signEd25519(signer.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+/** Deliver the opaque sealed blob onto the ADMITTED row (hub-admin authority). */
+const SEALED = btoa("sealed-leaf-psk-opaque-ciphertext-v1");
+async function deliverSealed(requestId: string): Promise<void> {
+  const claim = {
+    request_id: requestId,
+    sealed_secret: SEALED,
+    hub_admin_pubkey: hubAdmin.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const signature = await signEd25519(hubAdmin.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  const res = await post(`/admission-requests/${requestId}/sealed-secret`, { claim, signature });
+  expect(res.status).toBe(200);
+}
+
+/** Hub-admin revoke of an ADMITTED row → REVOKED. */
+async function revoke(requestId: string): Promise<void> {
+  const claim = {
+    request_id: requestId,
+    hub_admin_pubkey: hubAdmin.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const signature = await signEd25519(hubAdmin.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  const res = await post(`/admission-requests/${requestId}/revoke`, { claim, signature });
+  expect(res.status).toBe(200);
+}
+
+beforeEach(async () => {
+  resetStores();
+  _resetRateLimitBucketsForTest();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  hubAdmin = await makePrincipalKey();
+  member = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    REGISTRY_HUB_ADMIN_PUBKEYS: hubAdmin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// Happy path — ADMITTED → DEPARTED
+// =============================================================================
+
+describe("POST /admission-requests/:id/depart — happy path", () => {
+  test("an ADMITTED member departs their OWN row → 200 DEPARTED, sealed blob cleared", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    await deliverSealed(req.request_id);
+
+    const res = await post(`/admission-requests/${req.request_id}/depart`, await makeDepart(req.request_id, member));
+    expect(res.status).toBe(200);
+    const departed = (await res.json()) as AdmissionRequest;
+    expect(departed.status).toBe("DEPARTED");
+    expect(departed.sealed_secret).toBeNull();
+  });
+
+  test("a departed member drops out of the network roster (members[])", async () => {
+    // alpha + beta both ADMITTED to the network; alpha then departs.
+    const alpha = await makePrincipalKey();
+    const beta = await makePrincipalKey();
+    const alphaReq = await registerAndAdmit("alpha", alpha, "research-collab");
+    await registerAndAdmit("beta", beta, "research-collab");
+
+    const depart = await makeDepart(alphaReq.request_id, alpha, { principalId: "alpha" });
+    const res = await post(`/admission-requests/${alphaReq.request_id}/depart`, depart);
+    expect(res.status).toBe(200);
+
+    // beta (still ADMITTED) reads the roster — alpha is gone, only beta remains.
+    const memberRead = {
+      network_id: "research-collab",
+      peer_pubkey: beta.publicKeyB64,
+      issued_at: new Date().toISOString(),
+    };
+    const sig = await signEd25519(beta.privateKeyB64, new TextEncoder().encode(canonicalJSON(memberRead)));
+    const rosterRes = await get("/networks/research-collab/roster/member", {
+      "x-pop-signed": JSON.stringify({ claim: memberRead, signature: sig }),
+    });
+    expect(rosterRes.status).toBe(200);
+    const json = (await rosterRes.json()) as { payload: { members: { principal_id: string }[] } };
+    const ids = json.payload.members.map((m) => m.principal_id).sort();
+    expect(ids).toEqual(["beta"]);
+  });
+
+  test("no admin allowlist is consulted — depart succeeds with the admin allowlist EMPTY", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    // Wipe BOTH admin authorities: the own-row PoP check is the ONLY gate.
+    const noAdminEnv: Env = { ...env, REGISTRY_ADMIN_PUBKEYS: "", REGISTRY_HUB_ADMIN_PUBKEYS: "" };
+    const res = await post(
+      `/admission-requests/${req.request_id}/depart`,
+      await makeDepart(req.request_id, member),
+      noAdminEnv,
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json() as AdmissionRequest).status).toBe("DEPARTED");
+  });
+
+  test("idempotent — a second depart of a DEPARTED row → 200 DEPARTED", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    const first = await post(`/admission-requests/${req.request_id}/depart`, await makeDepart(req.request_id, member));
+    expect(first.status).toBe(200);
+    const second = await post(`/admission-requests/${req.request_id}/depart`, await makeDepart(req.request_id, member));
+    expect(second.status).toBe(200);
+    expect((await second.json() as AdmissionRequest).status).toBe("DEPARTED");
+  });
+});
+
+// =============================================================================
+// 409 — cannot depart a row that is not an active admission
+// =============================================================================
+
+describe("POST /admission-requests/:id/depart — non-ADMITTED → 409 already <STATUS>", () => {
+  test("PENDING row → 409, message names 'already PENDING', row unchanged", async () => {
+    const req = await registerPending("alice", member, "metafactory");
+    const res = await post(`/admission-requests/${req.request_id}/depart`, await makeDepart(req.request_id, member));
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; details: string; current: AdmissionRequest };
+    expect(body.error).toBe("not_admitted");
+    expect(body.details).toContain("already PENDING");
+    expect(body.current.status).toBe("PENDING");
+  });
+
+  test("REJECTED row → 409 already REJECTED", async () => {
+    const req = await registerPending("alice", member, "metafactory");
+    const decision = await makeSignedAdminDecision(req.request_id, "reject", admin);
+    expect((await post(`/admission-requests/${req.request_id}/reject`, decision)).status).toBe(200);
+    const res = await post(`/admission-requests/${req.request_id}/depart`, await makeDepart(req.request_id, member));
+    expect(res.status).toBe(409);
+    expect((await res.json() as { details: string }).details).toContain("already REJECTED");
+  });
+
+  test("REVOKED row → 409 already REVOKED (a kicked member cannot 'depart')", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    await revoke(req.request_id);
+    const res = await post(`/admission-requests/${req.request_id}/depart`, await makeDepart(req.request_id, member));
+    expect(res.status).toBe(409);
+    expect((await res.json() as { details: string }).details).toContain("already REVOKED");
+  });
+});
+
+// =============================================================================
+// Fail-closed authz + input hardening
+// =============================================================================
+
+describe("POST /admission-requests/:id/depart — fail-closed", () => {
+  test("wrong-member PoP (a different valid key) → 403 + the row stays ADMITTED", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    const stranger = await makePrincipalKey();
+    // A perfectly valid PoP signature — but for the WRONG key (not the row owner).
+    const res = await post(`/admission-requests/${req.request_id}/depart`, await makeDepart(req.request_id, stranger));
+    expect(res.status).toBe(403);
+    expect((await res.json() as { error: string }).error).toBe("not_row_owner");
+
+    // The row is untouched — still ADMITTED (the owner can still read it as such).
+    const still = await findRequest("alice", "metafactory", "ADMITTED");
+    expect(still.status).toBe("ADMITTED");
+  });
+
+  test("forged signature (claim declares the owner key, signed by another) → 401", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    const attacker = await makePrincipalKey();
+    // Declares the member's pubkey but is signed by the attacker's key.
+    const body = await makeDepart(req.request_id, attacker, { pubkeyOverride: member.publicKeyB64 });
+    const res = await post(`/admission-requests/${req.request_id}/depart`, body);
+    expect(res.status).toBe(401);
+    expect((await res.json() as { error: string }).error).toBe("signature_invalid");
+  });
+
+  test("over-wide body (junk keys past the canonical cap) → 401, NEVER 500", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    const { claim, signature } = await makeDepart(req.request_id, member);
+    const bloated: Record<string, unknown> = { ...claim };
+    for (let i = 0; i <= MAX_CANONICAL_KEYS; i++) bloated[`junk${i.toString()}`] = i;
+    const res = await post(`/admission-requests/${req.request_id}/depart`, { claim: bloated, signature });
+    expect(res.status).not.toBe(500);
+    expect(res.status).toBe(401);
+    expect((await res.json() as { error: string }).error).toBe("signature_invalid");
+    // And the row is untouched (a hostile body never mutates state).
+    const still = await findRequest("alice", "metafactory", "ADMITTED");
+    expect(still.status).toBe("ADMITTED");
+  });
+
+  test("request_id body/path mismatch → 400", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    const other = "abcd1234".repeat(4);
+    const body = await makeDepart(req.request_id, member, { requestIdOverride: other });
+    const res = await post(`/admission-requests/${req.request_id}/depart`, body);
+    expect(res.status).toBe(400);
+  });
+
+  test("invalid request_id grammar in the path → 400", async () => {
+    const res = await post(`/admission-requests/not!a!valid!id/depart`, await makeDepart("not!a!valid!id", member));
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toBe("invalid_request_id");
+  });
+
+  test("unknown request → 404", async () => {
+    const unknown = "deadbeef".repeat(4);
+    const res = await post(`/admission-requests/${unknown}/depart`, await makeDepart(unknown, member));
+    expect(res.status).toBe(404);
+  });
+
+  test("issued_at out of the clock-skew window → 400", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    const stale = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30m ago
+    const res = await post(
+      `/admission-requests/${req.request_id}/depart`,
+      await makeDepart(req.request_id, member, { issuedAt: stale }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("replayed nonce (same signed envelope twice) → 409 nonce_replayed", async () => {
+    const req = await registerAndAdmit("alice", member, "metafactory");
+    const body = await makeDepart(req.request_id, member);
+    const first = await post(`/admission-requests/${req.request_id}/depart`, body);
+    expect(first.status).toBe(200);
+    // Same envelope again — the nonce is burned. (Row is already DEPARTED, but the
+    // replay guard fires BEFORE the transition, so this is 409 nonce_replayed.)
+    const replay = await post(`/admission-requests/${req.request_id}/depart`, body);
+    expect(replay.status).toBe(409);
+    expect((await replay.json() as { error: string }).error).toBe("nonce_replayed");
+  });
+});

--- a/src/services/network-registry/migrations/0012_admission_departed.sql
+++ b/src/services/network-registry/migrations/0012_admission_departed.sql
@@ -1,0 +1,65 @@
+-- C-1350 Slice 1 (#1350) — member self-depart: ADMITTED → DEPARTED.
+--
+-- Background
+-- ──────────
+-- A member leaving a network voluntarily is DISTINCT from an admin revoking them
+-- (ADR-0018 Q6 / migration 0010's REVOKED). `REVOKED` = the hub-admin kicked the
+-- member (involuntary); `DEPARTED` = the member left of their own accord. Keeping
+-- the two separable preserves the audit distinction ("left" vs "kicked") and lets
+-- the admin queue filter departed-but-not-hub-revoked rows (their cue to run
+-- `secret revoke-member` and cut the hub `authorization` user).
+--
+-- Like migration 0010's REVOKED add, DEPARTED must join the status CHECK. SQLite
+-- cannot add a value to a CHECK constraint (nor portably DROP a column across all
+-- D1-supported versions), so we recreate the table — the SAME portable pattern
+-- migrations 0007 and 0010 used — preserving every column 0007/0008/0010
+-- established (incl. `sealed_secret`), widening the status CHECK to add
+-- 'DEPARTED', copying surviving rows, and recreating BOTH indexes (the status
+-- index AND the 0008 per-network COALESCE unique index).
+--
+-- Roster: NO change needed. `rosterFromAdmissions()` filters `status='ADMITTED'`,
+-- so a DEPARTED row auto-drops from `members[]`/roster — the same mechanism a
+-- REVOKED row uses.
+--
+-- Deploy ordering: migration-first. This 0012 recreate MUST be applied before the
+-- Worker carrying the `/depart` route + widened `DEPARTED` status enum is
+-- deployed, so a DEPARTED write can never hit the pre-0012 CHECK (which would
+-- reject it). The prod deploy of both is a HELD principal checkpoint.
+
+-- Step A — new table: 0007/0008/0010 columns + widened status CHECK (+DEPARTED).
+CREATE TABLE IF NOT EXISTS admission_requests_v3 (
+  request_id      TEXT    NOT NULL PRIMARY KEY,
+  principal_id    TEXT    NOT NULL,
+  peer_pubkey     TEXT    NOT NULL,
+  requested_scope TEXT    NOT NULL,
+  network_id      TEXT    ,
+  status          TEXT    NOT NULL DEFAULT 'PENDING'
+                          CHECK (status IN ('PENDING', 'ADMITTED', 'REJECTED', 'REVOKED', 'DEPARTED')),
+  created_at      TEXT    NOT NULL,
+  updated_at      TEXT    NOT NULL,
+  granted_by      TEXT    ,
+  -- ADR-0018 Q1 (b′) — opaque per-member sealed ciphertext. The registry never
+  -- reads it. NULL until add-member (sealed) delivers it; NULL again on
+  -- revoke OR depart (a departed member must not retain a fetchable blob).
+  sealed_secret   TEXT
+);
+
+-- Step B — copy every surviving row unchanged (all existing statuses preserved).
+INSERT INTO admission_requests_v3
+  (request_id, principal_id, peer_pubkey, requested_scope, network_id,
+   status, created_at, updated_at, granted_by, sealed_secret)
+SELECT
+  request_id, principal_id, peer_pubkey, requested_scope, network_id,
+  status, created_at, updated_at, granted_by, sealed_secret
+FROM admission_requests;
+
+-- Step C — swap the table in.
+DROP TABLE IF EXISTS admission_requests;
+ALTER TABLE admission_requests_v3 RENAME TO admission_requests;
+
+-- Step D — recreate indexes (status + the 0008 per-network COALESCE unique).
+CREATE INDEX IF NOT EXISTS idx_admission_requests_status
+  ON admission_requests (status);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_admission_requests_peer_network
+  ON admission_requests (principal_id, peer_pubkey, COALESCE(network_id, ''));

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -55,6 +55,8 @@ import {
   validateSealedSecretClaim,
   validateSignedAdmissionRevoke,
   validateAdmissionRevokeClaim,
+  validateSignedAdmissionDepart,
+  validateAdmissionDepartClaim,
   isValidRequestId,
 } from "../validate";
 import { canonicalJSON, verifyEd25519 } from "../signing";
@@ -502,6 +504,133 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
   });
 
   // ---------------------------------------------------------------------------
+  // POST /admission-requests/:request_id/depart — C-1350 Slice 1 (#1350)
+  //
+  // The MEMBER leaves a network of their OWN accord (voluntary), transitioning
+  // their own ADMITTED row → DEPARTED and clearing its sealed blob. This is the
+  // member-side counterpart to the hub-admin `/revoke` (involuntary kick):
+  // `DEPARTED` keeps "left" separable from "kicked" for the audit + admin queue.
+  //
+  // Authority = MEMBER PROOF-OF-POSSESSION, promoted from the `/mine` read to a
+  // write. There is NO admin allowlist on this route — the signature over
+  // canonicalJSON(claim) against `claim.peer_pubkey` proves the caller holds the
+  // member key, and the OWN-ROW check (`peer_pubkey === row.peer_pubkey`) is the
+  // authz: a member can only depart their own row, never someone else's (403).
+  //
+  // Gate order (fail-closed, mirrors handleDecision): M2 request_id grammar →
+  // M1 rate-limit → JSON parse → envelope+claim validate → clock-skew → sig
+  // verify FIRST (over the wire claim; guarded canonicaliser throw → 401, never
+  // 500) → OWN-ROW ownership (403) → nonce burn (#695: only after the authentic
+  // + authorised path) → transition. Idempotent: re-departing a DEPARTED row →
+  // 200; a non-ADMITTED (PENDING/REJECTED/REVOKED) row → 409.
+  // ---------------------------------------------------------------------------
+
+  app.post("/admission-requests/:request_id/depart", async (c) => {
+    const requestId = c.req.param("request_id") ?? "";
+
+    // M2 — validate request_id path param BEFORE body parse or crypto.
+    if (!isValidRequestId(requestId)) {
+      return c.json({ error: "invalid_request_id" }, 400);
+    }
+
+    // M1 — rate-limit BEFORE the expensive Ed25519 verify (register/write bucket).
+    const allowed = await checkRateLimit(c.env, "register", clientKey(c.req.raw, requestId));
+    if (!allowed) {
+      return c.json(TOO_MANY_REQUESTS_BODY, 429, {
+        "Retry-After": String(retryAfterSeconds("register")),
+      });
+    }
+
+    // Parse + validate envelope, then the claim (binds request_id to the path).
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (_err) {
+      return c.json({ error: "body must be valid JSON" }, 400);
+    }
+    const envelopeCheck = validateSignedAdmissionDepart(body);
+    if (!envelopeCheck.ok) {
+      return c.json({ error: "validation_failed", details: envelopeCheck.errors }, 400);
+    }
+    const claimResult = validateAdmissionDepartClaim(envelopeCheck.signed.claim, requestId);
+    if (!claimResult.ok) {
+      return c.json({ error: "validation_failed", details: claimResult.errors }, 400);
+    }
+    const { claim } = claimResult;
+
+    // Clock-skew — bound a captured token's lifetime.
+    const issued = Date.parse(claim.issued_at);
+    const now = Date.now();
+    if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
+      return c.json(
+        { error: "issued_at out of skew window", details: { skew_ms: now - issued, max_ms: CLOCK_SKEW_MS } },
+        400,
+      );
+    }
+
+    // Signature verification FIRST (before recording the nonce). Verify over the
+    // WIRE claim (canonicalJSON(signed.claim), #1414) — the signature IS the
+    // proof of possession of `claim.peer_pubkey`. Fail closed (401) if the shared
+    // guarded canonicaliser throws on an over-deep/over-wide hostile body
+    // (#832/#1418) — it can never match a real signature anyway.
+    let message: Uint8Array<ArrayBuffer>;
+    try {
+      message = new TextEncoder().encode(canonicalJSON(envelopeCheck.signed.claim)) as Uint8Array<ArrayBuffer>;
+    } catch (_err) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
+    const sigValid = await verifyEd25519(claim.peer_pubkey, envelopeCheck.signed.signature, message);
+    if (!sigValid) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
+
+    // OWN-ROW authorisation — the proven member key MUST equal the target row's
+    // stored `peer_pubkey`. This ownership check IS the authz (no admin
+    // allowlist). Load the row to compare; a missing row is a 404, a wrong-owner
+    // row is a 403 and is left UNTOUCHED (a member can never depart another's
+    // row). Done BEFORE the nonce burn so a wrong-member probe cannot grief a
+    // legitimate member's nonce or leak beyond existence.
+    const store = getIssuanceStore(c.env);
+    const row = await store.getIssuanceRequest(requestId);
+    if (!row) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    if (row.peer_pubkey !== claim.peer_pubkey) {
+      return c.json({ error: "not_row_owner" }, 403);
+    }
+
+    // Replay check — only on the authentic + authorised path (#695 posture).
+    const nonceCache = getNonceCache(c.env);
+    const fresh = await nonceCache.recordIfFresh(claim.nonce, now);
+    if (!fresh) {
+      return c.json({ error: "nonce_replayed" }, 409);
+    }
+
+    // State transition: ADMITTED → DEPARTED (+ clear sealed blob). Idempotent on
+    // an already-DEPARTED row (200); a non-ADMITTED row is a 409 "already
+    // <STATUS>". `rosterFromAdmissions` filters ADMITTED, so the member drops out
+    // of `members[]` automatically.
+    let updated;
+    try {
+      updated = await store.departAdmission(requestId);
+    } catch (err) {
+      if (err instanceof AlreadyDecidedError) {
+        return c.json(
+          {
+            error: "not_admitted",
+            details: `request ${requestId} is already ${err.request.status}, not ADMITTED — nothing to depart`,
+            current: err.request,
+          },
+          409,
+        );
+      }
+      throw err;
+    }
+    if (!updated) return c.json({ error: "not_found" }, 404);
+    return c.json(updated, 200);
+  });
+
+  // ---------------------------------------------------------------------------
   // GET /admission-requests?status=<status>
   // ---------------------------------------------------------------------------
 
@@ -512,10 +641,15 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     }
 
     const status = c.req.query("status") as AdmissionStatus | undefined;
-    const validStatuses: AdmissionStatus[] = ["PENDING", "ADMITTED", "REJECTED"];
+    // C-1350 — REVOKED + DEPARTED admitted here too so the admin listing
+    // (`admit --list-pending --status DEPARTED|REVOKED`) surfaces
+    // departed-/kicked-but-not-yet-hub-revoked rows. The CLI's LIST_STATUSES
+    // (network.ts) and this server-side gate must stay in lockstep — a status
+    // accepted by one but rejected by the other 400s the list round-trip.
+    const validStatuses: AdmissionStatus[] = ["PENDING", "ADMITTED", "REJECTED", "REVOKED", "DEPARTED"];
     if (!status || !validStatuses.includes(status)) {
       return c.json(
-        { error: "status query param required", details: "must be one of PENDING, ADMITTED, REJECTED" },
+        { error: "status query param required", details: "must be one of PENDING, ADMITTED, REJECTED, REVOKED, DEPARTED" },
         400,
       );
     }

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -253,6 +253,20 @@ export interface IssuanceRequestStore {
    * (you cannot revoke a member that was never admitted).
    */
   revokeAdmission(requestId: string): Promise<AdmissionRequest | undefined>;
+
+  /**
+   * C-1350 Slice 1 (#1350) — transition an ADMITTED row to DEPARTED (the member
+   * left voluntarily) and CLEAR its sealed blob (a departed member must not
+   * retain a fetchable copy — same hygiene as revoke). Guarded on
+   * `status = 'ADMITTED'`. Returns the updated row; `undefined` when the row is
+   * missing. Already-DEPARTED is idempotent (returns the DEPARTED row); a
+   * PENDING/REJECTED/REVOKED row throws {@link AlreadyDecidedError} (you cannot
+   * depart a row that is not an active admission). Distinct from
+   * {@link revokeAdmission} only in the target status: DEPARTED (voluntary) vs
+   * REVOKED (admin-kicked). Roster needs NO change — `rosterFromAdmissions()`
+   * filters `status='ADMITTED'`, so DEPARTED auto-drops from `members[]`.
+   */
+  departAdmission(requestId: string): Promise<AdmissionRequest | undefined>;
 }
 
 // =============================================================================
@@ -377,6 +391,23 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
     const updated: AdmissionRequest = {
       ...existing,
       status: "REVOKED",
+      sealed_secret: null,
+      updated_at: new Date().toISOString(),
+    };
+    this.requests.set(requestId, updated);
+    return updated;
+  }
+
+  async departAdmission(requestId: string): Promise<AdmissionRequest | undefined> {
+    const existing = this.requests.get(requestId);
+    if (!existing) return undefined;
+    if (existing.status === "DEPARTED") return existing; // idempotent
+    if (existing.status !== "ADMITTED") {
+      throw new AlreadyDecidedError(existing);
+    }
+    const updated: AdmissionRequest = {
+      ...existing,
+      status: "DEPARTED",
       sealed_secret: null,
       updated_at: new Date().toISOString(),
     };
@@ -563,6 +594,36 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
       return current;
     }
     return { ...existing, status: "REVOKED", sealed_secret: null, updated_at: now };
+  }
+
+  async departAdmission(requestId: string): Promise<AdmissionRequest | undefined> {
+    const existing = await this.getIssuanceRequest(requestId);
+    if (!existing) return undefined;
+    if (existing.status === "DEPARTED") return existing; // idempotent no-op
+    if (existing.status !== "ADMITTED") {
+      throw new AlreadyDecidedError(existing);
+    }
+    const now = new Date().toISOString();
+    const res = await this.db
+      .prepare(
+        `UPDATE admission_requests
+         SET status = 'DEPARTED', sealed_secret = NULL, updated_at = ?
+         WHERE request_id = ? AND status = 'ADMITTED'`,
+      )
+      .bind(now, requestId)
+      .run();
+    if ((res.meta?.changes ?? 0) === 0) {
+      // The `WHERE status = 'ADMITTED'` guard flipped false between our SELECT
+      // and UPDATE — a concurrent transition landed. Re-derive the outcome from
+      // the CURRENT row so we never report a bogus success: an already-DEPARTED
+      // row is the idempotent case (200); anything else (a REVOKE that beat us,
+      // etc.) is a 409 via AlreadyDecidedError; a vanished row is 404.
+      const current = await this.getIssuanceRequest(requestId);
+      if (!current) return undefined;
+      if (current.status === "DEPARTED") return current;
+      throw new AlreadyDecidedError(current);
+    }
+    return { ...existing, status: "DEPARTED", sealed_secret: null, updated_at: now };
   }
 }
 

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -297,7 +297,7 @@ export interface CapabilityHit {
  * Re-transitions out of a decided state are forbidden (409 already_decided);
  * REVOKED is the one transition OUT of ADMITTED (and is itself terminal).
  */
-export type AdmissionStatus = "PENDING" | "ADMITTED" | "REJECTED" | "REVOKED";
+export type AdmissionStatus = "PENDING" | "ADMITTED" | "REJECTED" | "REVOKED" | "DEPARTED";
 
 /**
  * A persisted admission request — the metadata record that a verified
@@ -550,6 +550,50 @@ export interface AdmissionRevokeClaim {
 /** On-wire envelope for a hub-admin revoke. */
 export interface SignedAdmissionRevoke {
   claim: AdmissionRevokeClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}
+
+/**
+ * C-1350 Slice 1 (#1350) — the MEMBER-PoP-signed claim carried by
+ * `POST /admission-requests/{request_id}/depart`.
+ *
+ * Where {@link AdmissionRevokeClaim} is the HUB-ADMIN kicking a member
+ * (involuntary, ADMITTED → REVOKED), this claim is the MEMBER leaving of their
+ * own accord (voluntary, ADMITTED → DEPARTED). The authority model mirrors the
+ * `/mine` member PoP-read, promoted to a WRITE: the signature over
+ * `canonicalJSON(claim)` against `peer_pubkey` IS the authorization — there is
+ * NO admin allowlist on this route. The route additionally enforces
+ * own-row-only: the proven `peer_pubkey` MUST equal the target row's stored
+ * `peer_pubkey`, else 403 (a member can never depart someone else's row). A
+ * `nonce` is bound in (unlike the idempotent `/mine` read) because this is a
+ * state-transitioning write — replay protection per the admit/revoke posture.
+ */
+export interface AdmissionDepartClaim {
+  /** Must equal the URL path parameter. */
+  request_id: string;
+  /**
+   * The departing principal id. Echoed into the signed claim for
+   * canonicalisation/audit; the sole authority is the signature over
+   * `peer_pubkey` + the own-row ownership check (never this field).
+   */
+  principal_id: string;
+  /**
+   * The member's registered Ed25519 pubkey (base64). The claim is signed with
+   * the matching private key, so verifying the signature against this field
+   * proves possession — and the route then requires it to equal the row's
+   * stored `peer_pubkey`.
+   */
+  peer_pubkey: string;
+  /** ISO-8601 UTC timestamp at which the member signed this claim. */
+  issued_at: string;
+  /** Random nonce to prevent replay (state-transitioning write). */
+  nonce: string;
+}
+
+/** On-wire envelope for a member self-depart. */
+export interface SignedAdmissionDepart {
+  claim: AdmissionDepartClaim;
   /** Base64 Ed25519 signature over canonical-JSON(claim). */
   signature: string;
 }

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -18,6 +18,7 @@
 
 import type {
   AdmissionDecisionClaim,
+  AdmissionDepartClaim,
   AdmissionReadClaim,
   AdmissionRevokeClaim,
   Capability,
@@ -25,6 +26,7 @@ import type {
   SealedSecretWriteClaim,
   SignedAdmissionDecision,
   SignedAdmissionMineRead,
+  SignedAdmissionDepart,
   SignedAdmissionRead,
   SignedAdmissionRevoke,
   SignedNetworkRosterMemberRead,
@@ -961,6 +963,91 @@ export function validateAdmissionRevokeClaim(
     claim: {
       request_id: c.request_id as string,
       hub_admin_pubkey: c.hub_admin_pubkey as string,
+      issued_at: c.issued_at as string,
+      nonce: c.nonce as string,
+    },
+  };
+}
+
+/**
+ * C-1350 Slice 1 (#1350) — validate the `POST /admission-requests/{id}/depart`
+ * envelope ({ claim: AdmissionDepartClaim, signature }). Structural only; the
+ * route verifies the signature over the WIRE claim (`canonicalJSON(signed.claim)`,
+ * the #1414 verify-over-wire norm) and enforces the own-row ownership gate.
+ */
+export function validateSignedAdmissionDepart(
+  body: unknown,
+): { ok: true; signed: SignedAdmissionDepart } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null || Array.isArray(b.claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be a non-array object" }] };
+  }
+  return {
+    ok: true,
+    signed: { claim: b.claim as AdmissionDepartClaim, signature: b.signature },
+  };
+}
+
+/**
+ * C-1350 Slice 1 (#1350) — validate the `AdmissionDepartClaim` payload before
+ * crypto verification. Cross-field rule: claim.request_id MUST match the URL
+ * path parameter (a captured depart token for row A cannot be replayed against
+ * row B's path). Mirrors {@link validateAdmissionRevokeClaim} but keyed on the
+ * MEMBER `peer_pubkey` (the PoP authority) + `principal_id`, not a hub-admin key.
+ */
+export function validateAdmissionDepartClaim(
+  claim: unknown,
+  expectedRequestId: string,
+): { ok: true; claim: AdmissionDepartClaim } | { ok: false; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+
+  if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be an object" }] };
+  }
+  const c = claim as Record<string, unknown>;
+
+  if (typeof c.request_id !== "string" || c.request_id.length === 0) {
+    errors.push({ field: "request_id", message: "must be a non-empty string" });
+  } else if (c.request_id !== expectedRequestId) {
+    errors.push({
+      field: "request_id",
+      message: `body request_id "${c.request_id}" does not match path "${expectedRequestId}"`,
+    });
+  }
+
+  if (typeof c.principal_id !== "string" || !isValidPrincipalId(c.principal_id)) {
+    errors.push({ field: "principal_id", message: "must be a valid principal id" });
+  }
+
+  if (typeof c.peer_pubkey !== "string" || !isValidPubkey(c.peer_pubkey)) {
+    errors.push({ field: "peer_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
+  }
+
+  if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
+    errors.push({ field: "issued_at", message: "must be an ISO-8601 timestamp" });
+  }
+
+  if (typeof c.nonce !== "string" || c.nonce.length < 8 || c.nonce.length > 128) {
+    errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    claim: {
+      request_id: c.request_id as string,
+      principal_id: c.principal_id as string,
+      peer_pubkey: c.peer_pubkey as string,
       issued_at: c.issued_at as string,
       nonce: c.nonce as string,
     },


### PR DESCRIPTION
## What

Adds the **voluntary member self-depart** path for C-1350 Slice 1 — a member leaving a network of their own accord, kept **distinct** from the involuntary hub-admin `REVOKED` kick. A new `DEPARTED` admission state is reached through a **member-PoP-signed** `POST /admission-requests/:id/depart`. Keeping "left" separable from "kicked" preserves the audit distinction and gives the admin queue a clean filter (departed-but-not-hub-revoked rows → the admin's cue to run `secret revoke-member`).

Builds exactly to the **executor-grade build spec** (issue #1350 comment 4871471862, "Executor-grade build spec — Slices 1 + 3", the Slice 1 section). Slice 3 (Discord role removal) is a disjoint parallel PR — **no Slice 3 files touched** here.

## How

**Registry** (`src/services/network-registry/`)
- **`migrations/0012_admission_departed.sql`** — recreate-and-copy (SQLite can't `ALTER` a `CHECK`; same portable pattern as 0007/0010), widening the status `CHECK` to add `DEPARTED`, preserving every 0007/0008/0010 column + both indexes.
- **`types.ts`** — `AdmissionStatus += "DEPARTED"`; new `AdmissionDepartClaim` + `SignedAdmissionDepart`.
- **`store.ts`** — `departAdmission()` cloned from `revokeAdmission()` on both stores: transitions **ADMITTED-only**, `AlreadyDecidedError` (→409) otherwise, **idempotent** on an already-DEPARTED row, **clears `sealed_secret`**, stamps `updated_at`. Race-safe D1 branch (a concurrent REVOKE can never read as a bogus depart-success). Roster needs no change — `rosterFromAdmissions()` filters `ADMITTED`, so DEPARTED auto-drops from `members[]`.
- **`routes/admission-requests.ts`** — `POST /admission-requests/:id/depart`, **member-PoP** per the `/mine` pattern. Gate order mirrors `handleDecision`: request_id grammar → rate-limit → parse → envelope+claim validate → clock-skew → **sig verify FIRST** over the wire claim (`canonicalJSON(signed.claim)`, guarded canonicaliser throw → **401 never 500**) → **own-row 403** → **nonce burned only after verify+authz** (#695). **No admin allowlist** — the own-row ownership check (`peer_pubkey === row.peer_pubkey`) IS the authz.
- Listing `validStatuses` **and** the CLI `LIST_STATUSES` both widened (+`REVOKED` +`DEPARTED`), kept in lockstep so `admit --list-pending --status DEPARTED` round-trips.

**Client** (`src/cli/cortex/commands/`, `src/common/registry/`)
- `admission-state.ts` — `postDepartAdmission` + `departOwnAdmission` (read→depart-if-ADMITTED), reusing the `/mine` PoP helpers (no hand-rolled fetch/signing); a `departed` case in `classifyOwnAdmissionRows`.
- `leaveNetwork` POSTs the depart notice **AFTER** local teardown, **non-fatal** (warn, still `ok:true`) like the adjacent deregister posture.
- `network status` shows a quiet informational `admission: departed <date>` line — **no** warning banner.
- Corrected the stale `network-adapters.ts` roster comment (post-ADR-0018-Q3 the cap-retag no longer removes you from `members[]` — the depart transition does).

## Migration note

**0012 is migration-first.** The recreate-and-copy widening the CHECK MUST be applied **before** the Worker carrying the `/depart` route + `DEPARTED` enum, so a DEPARTED write can never hit the pre-0012 CHECK. The prod deploy (migration 0012 + Worker) is a **HELD principal checkpoint** — not deployed here.

## Fail-closed matrix (all tested)

| Input | Result | Test |
|---|---|---|
| ADMITTED, own key | 200 DEPARTED, `sealed_secret` cleared, roster drops member | happy + roster-drop |
| PENDING / REJECTED / REVOKED | 409 `already <STATUS>`, row unchanged | 3 tests |
| re-depart a DEPARTED row | 200 (idempotent) | idempotent |
| wrong-member (valid but non-owner key) | **403**, row stays ADMITTED | wrong-member |
| forged signature | 401 | forged |
| over-wide body (junk keys past cap) | **401 not 500**, row untouched | over-wide |
| request_id path/body mismatch | 400 | mismatch |
| invalid request_id grammar | 400 | grammar |
| clock-skew | 400 | skew |
| replayed nonce | 409 | replay |
| unknown request | 404 | unknown |
| admin allowlist EMPTY | 200 (own-row PoP is the only gate) | no-admin-gate |

Client: leave posts depart after teardown; registry failure → warning + `ok:true` (non-fatal); status shows `departed`; `departOwnAdmission` not-applicable on non-admitted rows.

## client-shape === server-shape

The client signs-what-it-sends: `postDepartAdmission` signs `canonicalJSON(claim)` over the exact `{request_id, principal_id, peer_pubkey, issued_at, nonce}` object it POSTs, and the server verifies over `canonicalJSON(signed.claim)` (the #1414 verify-over-wire norm) — byte-identical regardless of key order. A client test asserts the posted claim carries exactly those fields.

## Deviations from spec (flagged for review)

1. **Dry-run gate on the depart POST.** The spec says mirror `deregisterFromNetwork`'s non-fatal posture. I mirror the **error** posture but additionally **gate the depart POST on `--apply`** (a dry-run leave returns a clean no-op note, no registry mutation). Rationale: departing transitions the member's own admission row — a real state change, not a preview-safe read — so a dry-run leave must not fire it. `deregisterFromNetwork` is **not** gated (it fires on dry-run too); I left that pre-existing behaviour untouched (out of scope) but flag it here.
2. **Server-side `validStatuses` widened too.** The spec item 5 names only the CLI `LIST_STATUSES`, but the CLI list calls `GET /admission-requests?status=…`, whose own `validStatuses` gate would 400 `DEPARTED`. Both widened, kept in lockstep (commented).

## Four-check + wrangler (from ../Cortex-depart)

- `bunx eslint --quiet .` → **0** ✅
- `bunx tsc --noEmit` → **0** ✅
- `bash scripts/check-carveouts.sh` → **PASS** ("principal" not "operator") ✅
- `bun test src/services/network-registry src/common/registry src/cli/cortex/commands` → **1600 pass / 0 fail** (20 new depart-route tests, 11 new client tests, 3 new leave/status tests) ✅
- `bunx wrangler deploy --dry-run --env production` (node22 via fnm) → **bundles clean** (150.34 KiB / gzip 29.26 KiB) ✅

Refs #1350 (Slice 1 of 3). Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196JFPf1tEudhBUvwWjEhgA