### PR TITLE
feat(network): C-1349 Slice 1 — sealed payload-key delivery (add-member seals K, join installs it)

### DIFF
--- a/docs/sop-onboard-peer-principal.md
+++ b/docs/sop-onboard-peer-principal.md
@@ -232,9 +232,12 @@ curl https://network.meta-factory.ai/principals/<principal>  # → SignedAsserti
 
 Steps 1–7 give you a working federated link, but payloads still cross `federated.>` **cleartext-over-TLS** until you turn on encryption. A network is a **trust group** ([ADR-0019](./adr/0019-federated-payload-encryption.md)): all federated payloads — **Direct, Delegate, AND Offer** — are sealed with **one per-network symmetric key `K`**, readable only by admitted members and protected from any outsider on the transport (another network, the public, a non-member relay/hub).
 
-**1. Get the network key `K`.** Every admitted member of the network holds the same `K`. It is delivered sealed-to-your-pubkey over the **same admission/seal channel** that carried your leaf secret (no new ceremony). As of **v5.27.0** the *automatic* delivery of `K` through `join` is a follow-up (cortex#1246); today the admin hands you `K` (base64, decoding to exactly 32 bytes) over a secure channel and you stage it in config.
+**1. Get the network key `K`.** Every admitted member of the network holds the same `K`. It is delivered sealed-to-your-pubkey over the **same admission/seal channel** that carried your leaf secret (no new ceremony).
 
-**2. Enable encryption in your stack config** (`stacks/<slug>.yaml`):
+- **Default — sealed auto-delivery (C-1349 Slice 1).** When the network admin's hub config carries a `payload_key` for the network, `cortex network secret add-member <network> <member-pubkey> --admin-seed <seed> --apply` (and per-member `rotate`) seals `K` **into the same envelope** as your leaf PSK. Your `cortex network join <network> --apply` then auto-fetches, unseals, and **writes `encryption: enabled` + `payload_key` (+ kid) into your `stacks/<slug>.yaml` for you** — zero manual key handling, and the file is clamped to `0600`. `K` is never printed to a terminal, log, or dry-run output (only the kid + a SHA-256 fingerprint are shown). This is the path to prefer.
+- **Fallback — manual handoff.** If the hub config has no `payload_key` for the network yet (encryption not staged hub-side), `add-member` seals the PSK only and prints an info line pointing here. In that case the admin hands you `K` (base64, decoding to exactly 32 bytes) over a secure channel and you stage it in config as in step 2 below.
+
+**2. (Fallback only) Enable encryption in your stack config** (`stacks/<slug>.yaml`) — the sealed-delivery default writes this block for you:
 
 ```yaml
 policy:

--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
@@ -35,6 +35,7 @@ import { dispatchNetwork } from "../../network";
 import { dispatchProvisionStack } from "../../provision-stack";
 import { runNetworkSecret } from "../../network-secret-lib";
 import { buildLiveSecretPorts } from "../../network-secret-adapters";
+import { fetchSealedLeafSecret } from "../../../../../common/registry/fetch-sealed-secret";
 import type { NetworkSecretPorts } from "../../network-secret-ports";
 import { leaveNetwork } from "../../network-lib";
 
@@ -345,8 +346,50 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
   // 5 in one privileged move (today they are two commands, driven separately above).
   todo("step 5a (#1316): network admit --and-seal folds admit + secret add-member");
   // #1349 S1 — the M3 payload key K rides the SAME sealed blob: add-member seals
-  // payload_key, join installs it.
-  todo("step 5b (#1349 S1): sealed K delivery — add-member seals payload_key, join installs it");
+  // payload_key, join installs it. Flipped LIVE with the Slice 1 merge.
+  test("step 5b (#1349 S1): sealed K delivery — add-member seals payload_key, joiner unseals it", async () => {
+    expect(ctx.requestId).toBeDefined();
+    expect(ctx.secretPorts).toBeDefined();
+    // Clearly-FAKE 32-byte K (all-0x07) — never realistic key material.
+    const K = Buffer.alloc(32, 7).toString("base64");
+    const KID = `${NETWORK_ID}/k1`;
+
+    // add-member is idempotent on the ADMITTED row — re-seal WITH the payload key.
+    const report = await runNetworkSecret(
+      {
+        action: "add-member",
+        networkId: NETWORK_ID,
+        memberPubkey: ctx.joinerPubkey,
+        deliver: "sealed",
+        apply: true,
+        payloadKey: K,
+        payloadKeyKid: KID,
+      },
+      ctx.secretPorts!,
+    );
+    expect(report.ok).toBe(true);
+    // K is NEVER printed — only the kid + a fingerprint reach the report.
+    expect(report.steps.join("\n")).not.toContain(K);
+    expect(JSON.stringify(report.data)).not.toContain(K);
+    expect(report.data.payload_key_kid).toBe(KID);
+    expect(report.data.payload_key_fingerprint).toBeDefined();
+
+    // The joiner fetches + unseals the blob from the in-process registry and
+    // recovers K + kid — the end-to-end sealed-delivery path.
+    const joinerMaterial = materialFromSeedString(readFileSync(ctx.joinerSeedPath, "utf-8"));
+    const res = await fetchSealedLeafSecret({
+      registryUrl: REGISTRY_BASE,
+      networkId: NETWORK_ID,
+      principalId: JOINER_PRINCIPAL,
+      material: joinerMaterial,
+      fetchImpl: globalThis.fetch,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.payloadKey).toBe(K);
+      expect(res.payloadKeyKid).toBe(KID);
+    }
+  });
 
   // ===========================================================================
   // Step 6 — Join: the #1220 regression anchor.

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -689,6 +689,100 @@ describe("#756 config-split-aware policy write", () => {
     // Sanity: we never touched the real home.
     expect(realHome).not.toBe(home);
   });
+
+  // ---------------------------------------------------------------------------
+  // C-1349 Slice 1 — write-guard + payload-key install.
+  // ---------------------------------------------------------------------------
+
+  // Clearly-FAKE 32-byte key (all-zero base64) — never realistic K material.
+  const FAKE_K = Buffer.alloc(32).toString("base64");
+
+  function encryptedNetwork(id: string): PolicyFederatedNetwork {
+    return {
+      ...sampleNetwork(id),
+      encryption: "enabled",
+      payload_key: FAKE_K,
+      payload_key_id: `${id}/k1`,
+    };
+  }
+
+  test("installs the payload key K + kid, round-trips it, and clamps the file to 0600", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    const stacksDir = join(cortexDir, "meta-factory", "stacks");
+    mkdirSync(join(cortexDir, "meta-factory", "system"), { recursive: true });
+    writeFileSync(join(cortexDir, "meta-factory", "system", "system.yaml"), "{}\n", "utf-8");
+
+    withHome(home, () => {
+      const ports = buildLivePorts(cfgForStack("meta-factory"));
+      ports.configStore.writeNetworks([encryptedNetwork("metafactory")]);
+    });
+
+    const splitPath = join(stacksDir, "meta-factory.yaml");
+    const parsed = parseYaml(readFileSync(splitPath, "utf-8")) as {
+      policy?: { federated?: { networks?: PolicyFederatedNetwork[] } };
+    };
+    const net = parsed.policy?.federated?.networks?.[0];
+    expect(net?.encryption).toBe("enabled");
+    expect(net?.payload_key).toBe(FAKE_K);
+    expect(net?.payload_key_id).toBe("metafactory/k1");
+    // 0600 — K is a secret at rest.
+    expect(statSync(splitPath).mode & 0o777).toBe(0o600);
+  });
+
+  test("writes a timestamped .pre-join backup before overwriting an existing file", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    const stacksDir = join(cortexDir, "meta-factory", "stacks");
+    mkdirSync(join(cortexDir, "meta-factory", "system"), { recursive: true });
+    writeFileSync(join(cortexDir, "meta-factory", "system", "system.yaml"), "{}\n", "utf-8");
+    mkdirSync(stacksDir, { recursive: true });
+    const splitPath = join(stacksDir, "meta-factory.yaml");
+    const original =
+      "policy:\n  federated:\n    networks:\n      - id: research\n        leaf_node: research\n        peers: []\n        accept_subjects: [federated.andreas.meta-factory.>]\n        deny_subjects: []\n        announce_capabilities: []\n        max_hop: 1\n";
+    writeFileSync(splitPath, original, "utf-8");
+
+    withHome(home, () => {
+      const ports = buildLivePorts(cfgForStack("meta-factory"));
+      ports.configStore.writeNetworks([sampleNetwork("metafactory")]);
+    });
+
+    const backups = readdirSync(stacksDir).filter((f) => f.includes(".pre-join-") && f.endsWith(".bak"));
+    expect(backups.length).toBe(1);
+    // The backup holds the ORIGINAL content verbatim (recoverable).
+    expect(readFileSync(join(stacksDir, backups[0]!), "utf-8")).toBe(original);
+  });
+
+  test("validate-before-write: a malformed payload_key is REFUSED and the file is left untouched", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    const stacksDir = join(cortexDir, "meta-factory", "stacks");
+    mkdirSync(join(cortexDir, "meta-factory", "system"), { recursive: true });
+    writeFileSync(join(cortexDir, "meta-factory", "system", "system.yaml"), "{}\n", "utf-8");
+    mkdirSync(stacksDir, { recursive: true });
+    const splitPath = join(stacksDir, "meta-factory.yaml");
+    const original =
+      "policy:\n  federated:\n    networks:\n      - id: research\n        leaf_node: research\n        peers: []\n        accept_subjects: [federated.andreas.meta-factory.>]\n        deny_subjects: []\n        announce_capabilities: []\n        max_hop: 1\n";
+    writeFileSync(splitPath, original, "utf-8");
+
+    // A payload_key that is NOT 32 bytes when base64-decoded — the schema refine
+    // the daemon enforces at boot must reject it BEFORE any write.
+    const bad: PolicyFederatedNetwork = {
+      ...sampleNetwork("metafactory"),
+      encryption: "enabled",
+      payload_key: "dG9vLXNob3J0", // "too-short" — 9 bytes, not 32
+      payload_key_id: "metafactory/k1",
+    };
+
+    withHome(home, () => {
+      const ports = buildLivePorts(cfgForStack("meta-factory"));
+      expect(() => ports.configStore.writeNetworks([bad])).toThrow(/schema validation/);
+    });
+
+    // The original file is BYTE-IDENTICAL — the refused write never mutated it,
+    // and never leaked the key into the error path.
+    expect(readFileSync(splitPath, "utf-8")).toBe(original);
+  });
 });
 
 // =============================================================================

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -585,6 +585,70 @@ describe("join", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // C-1349 Slice 1 — join installs the sealed payload key K into the stack config.
+  // ---------------------------------------------------------------------------
+
+  // Clearly-FAKE payload key material — never realistic K bytes.
+  const FAKE_K = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+  test("installs encryption:enabled + payload_key + kid when the envelope carried K", async () => {
+    const { ports, storeRef } = makeFakes({});
+    const res = await joinNetwork(
+      "metafactory",
+      { ...LOCAL, payloadKey: FAKE_K, payloadKeyId: "metafactory/k1" },
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    const net = storeRef.networks[0]!;
+    expect(net.encryption).toBe("enabled");
+    expect(net.payload_key).toBe(FAKE_K);
+    expect(net.payload_key_id).toBe("metafactory/k1");
+    // K NEVER appears in the human step log — only the kid + a fingerprint.
+    expect(res.steps.join("\n")).not.toContain(FAKE_K);
+    expect(res.steps.join("\n")).toContain("metafactory/k1");
+  });
+
+  test("defaults the kid to <net>/k1 when the envelope carried K but no kid", async () => {
+    const { ports, storeRef } = makeFakes({});
+    const res = await joinNetwork("metafactory", { ...LOCAL, payloadKey: FAKE_K }, ports);
+    expect(res.ok).toBe(true);
+    expect(storeRef.networks[0]!.payload_key_id).toBe("metafactory/k1");
+  });
+
+  test("no K in the envelope → the entry carries NO encryption fields (cleartext, unchanged)", async () => {
+    const { ports, storeRef } = makeFakes({});
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(true);
+    const net = storeRef.networks[0]!;
+    expect(net.encryption).toBeUndefined();
+    expect(net.payload_key).toBeUndefined();
+    expect(net.payload_key_id).toBeUndefined();
+  });
+
+  test("re-join with no new K PRESERVES a prior encryption block verbatim", async () => {
+    const prior: PolicyFederatedNetwork = {
+      id: "metafactory",
+      leaf_node: "metafactory",
+      peers: [],
+      accept_subjects: [],
+      deny_subjects: [],
+      announce_capabilities: [],
+      max_hop: 1,
+      encryption: "enabled",
+      payload_key: FAKE_K,
+      payload_key_id: "metafactory/k1",
+    };
+    const { ports, storeRef } = makeFakes({ initialNetworks: [prior] });
+    // Re-join with NO payloadKey (the member already holds K; a plain re-join).
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(true);
+    const net = storeRef.networks[0]!;
+    expect(net.encryption).toBe("enabled");
+    expect(net.payload_key).toBe(FAKE_K);
+    expect(net.payload_key_id).toBe("metafactory/k1");
+  });
+
+  // ---------------------------------------------------------------------------
   // #794/#799 — choose the bind mode by bus type; FAIL FAST only on a genuinely
   // un-joinable bus (no crash). #799 relaxes the #794 guard for $G+creds buses.
   // ---------------------------------------------------------------------------

--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -143,6 +143,67 @@ describe("cortex network secret add-member", () => {
     const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
     expect(res.exitCode).toBe(1);
   });
+
+  // ===========================================================================
+  // C-1349 Slice 1 — the hub stack config supplies the payload key K, sealed
+  // alongside the PSK. K is a clearly-FAKE all-zero 32-byte key; it must ride the
+  // sealed blob but NEVER reach stdout.
+  // ===========================================================================
+  const FAKE_K = Buffer.alloc(32).toString("base64");
+
+  /** A config reader returning a hub stack config with K on `metafactory`. */
+  const loadWithK = ((_path: string) => ({
+    policy: {
+      federated: {
+        networks: [
+          { id: "metafactory", payload_key: FAKE_K, payload_key_id: "metafactory/k1" },
+        ],
+      },
+    },
+  })) as never;
+
+  test("--apply sealed with hub K configured → seals K + kid; K never in stdout", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(
+      argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath),
+      loadWithK, undefined, undefined, factory,
+    );
+    expect(res.exitCode).toBe(0);
+    // The sealed blob (fake seal echoes plaintext) carries payload_key + kid.
+    expect(calls.posted.length).toBe(1);
+    expect(calls.posted[0]!.blob).toContain("payload_key");
+    expect(calls.posted[0]!.blob).toContain("metafactory/k1");
+    // K itself NEVER reaches stdout — only the kid + a fingerprint.
+    expect(res.stdout).not.toContain(FAKE_K);
+    expect(res.stdout).toContain("metafactory/k1");
+  });
+
+  test("--apply sealed with NO hub K configured → blob carries no payload_key", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    // Inject an explicit reader with NO key for the network (hermetic — never the
+    // real ~/.config/cortex, which may carry a live metafactory K).
+    const loadNoK = ((_path: string) => ({ policy: { federated: { networks: [] } } })) as never;
+    const res = await dispatchNetwork(
+      argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath),
+      loadNoK, undefined, undefined, factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(calls.posted.length).toBe(1);
+    expect(calls.posted[0]!.blob).not.toContain("payload_key");
+  });
+
+  test("--json --apply with hub K → payload_key_kid + fingerprint surfaced, K is not", async () => {
+    const { factory } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(
+      argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--json", "--admin-seed", seedPath),
+      loadWithK, undefined, undefined, factory,
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as { data: Record<string, string> };
+    expect(parsed.data.payload_key_kid).toBe("metafactory/k1");
+    expect(parsed.data.payload_key_fingerprint).toBeDefined();
+    expect(res.stdout).not.toContain(FAKE_K);
+  });
 });
 
 describe("cortex network secret revoke-member", () => {

--- a/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
@@ -127,6 +127,64 @@ describe("add-member (sealed)", () => {
   });
 });
 
+// C-1349 Slice 1 — clearly-FAKE payload key (K) material. Never realistic bytes.
+const FAKE_K = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const FAKE_KID = "metafactory/k1";
+
+describe("add-member (sealed) — C-1349 payload key delivery", () => {
+  test("seals payload_key + payload_key_kid into the envelope when hub K is supplied", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(
+      inputs({ payloadKey: FAKE_K, payloadKeyKid: FAKE_KID }),
+      r.ports,
+    );
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(true);
+    // The UNSEALED envelope (the fake seal echoes plaintext) carries BOTH fields.
+    expect(r.posted.length).toBe(1);
+    expect(r.posted[0]!.blob).toContain("payload_key");
+    expect(r.posted[0]!.blob).toContain("payload_key_kid");
+    expect(r.posted[0]!.blob).toContain(FAKE_KID);
+    // K itself legitimately rides the SEALED blob, but must NEVER reach steps/data.
+    expect(report.steps.join("\n")).not.toContain(FAKE_K);
+    expect(JSON.stringify(report.data)).not.toContain(FAKE_K);
+    // The kid + a fingerprint are printable identifiers.
+    expect(report.data.payload_key_kid).toBe(FAKE_KID);
+    expect(report.data.payload_key_fingerprint).toBeDefined();
+    expect(report.data.payload_key_fingerprint).not.toContain(FAKE_K);
+  });
+
+  test("no hub K → envelope carries NO payload fields; an info step points at the SOP", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({}), r.ports);
+    expect(report.ok).toBe(true);
+    expect(r.posted.length).toBe(1);
+    expect(r.posted[0]!.blob).not.toContain("payload_key");
+    // No fingerprint / kid data when no K.
+    expect(report.data.payload_key_kid).toBeUndefined();
+    expect(report.data.payload_key_fingerprint).toBeUndefined();
+    // A single info line points the admin at the manual-handoff fallback.
+    expect(report.steps.join("\n").toLowerCase()).toContain("no payload key");
+  });
+});
+
+describe("rotate — C-1349 payload key delivery", () => {
+  test("re-seals with the CURRENT hub K included", async () => {
+    const start =
+      'leafnodes {\n  # >>> cortex-managed leaf authorization (network secret tooling) — do not hand-edit\n  authorization {\n    users: [\n      { user: "alice", password: "PSK-old" }\n    ]\n  }\n  # <<< cortex-managed leaf authorization\n}\n';
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" }, startConf: start });
+    const report = await runNetworkSecret(
+      inputs({ action: "rotate", payloadKey: FAKE_K, payloadKeyKid: FAKE_KID }),
+      r.ports,
+    );
+    expect(report.applied).toBe(true);
+    expect(r.posted.length).toBe(1);
+    expect(r.posted[0]!.blob).toContain("payload_key_kid");
+    expect(r.posted[0]!.blob).toContain(FAKE_KID);
+    expect(report.steps.join("\n")).not.toContain(FAKE_K);
+  });
+});
+
 describe("add-member (oob)", () => {
   test("surfaces the PSK and leaves the registry untouched", async () => {
     const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -75,6 +75,7 @@ import type {
   PolicyFederatedNetwork,
   PolicyPublic,
 } from "../../../common/types/cortex-config";
+import { PolicyFederatedNetworkSchema } from "../../../common/types/cortex-config";
 
 import type {
   AdmissionStatePort,
@@ -930,14 +931,102 @@ function buildConfigStorePort(cfg: LivePortsConfig, mutate: boolean): ConfigStor
       // hand-maintained monolith in place. parseDocument + setIn keeps the
       // header/inline comments (incl. `# DO NOT EDIT BY HAND`) that
       // parseYaml→stringifyYaml would strip.
-      const doc = existsSync(path)
-        ? parseDocument(readFileSync(path, "utf-8"))
-        : parseDocument("");
+      // C-1349 Slice 1 — the offer.ts write-guard pattern (VALIDATE-before-write →
+      // timestamped backup → atomic write → re-parse verify → restore-on-failure).
+      // The join now writes the per-network payload key K into this file (a secret
+      // at rest), so a malformed entry (e.g. a wrong-length K that boots into
+      // cleartext-with-warning, or a corrupt/partial write) must NEVER silently
+      // land in the stack config.
+
+      // (1) VALIDATE-before-write, SCOPED to the payload key K this slice adds
+      // (never the whole entry — that would newly reject hand-pinned peer shapes
+      // this writer has always tolerated). A `payload_key` MUST base64-decode to
+      // exactly 32 bytes — the SAME refine the daemon enforces at boot; a
+      // malformed K (that would boot into cleartext-with-warning, ADR-0019 §5)
+      // aborts BEFORE any fs mutation, leaving the file untouched. The entry
+      // (which carries K) is never echoed — only its id + the field name.
+      for (const n of networks) {
+        if (n.payload_key === undefined) continue;
+        const check = PolicyFederatedNetworkSchema.shape.payload_key.safeParse(n.payload_key);
+        if (!check.success) {
+          throw new Error(
+            `refusing to write policy.federated.networks — entry "${n.id}" has an invalid payload_key (schema validation failed: must be base64 decoding to exactly 32 bytes)`,
+          );
+        }
+      }
+
+      const existed = existsSync(path);
+      const originalText = existed ? readFileSync(path, "utf-8") : undefined;
+      const doc = parseDocument(originalText ?? "");
       doc.setIn(["policy", "federated", "networks"], networks);
+      const nextText = doc.toString();
       mkdirSync(dirname(path), { recursive: true });
-      writeFileSync(path, doc.toString(), "utf-8");
+
+      // (2) Timestamped backup (only when a file existed — a fresh file is removed
+      // on failure instead).
+      let backupPath: string | undefined;
+      if (existed && originalText !== undefined) {
+        backupPath = `${path}.pre-join-${backupStamp()}.bak`;
+        writeFileSync(backupPath, originalText, "utf-8");
+      }
+
+      // (3) Atomic write, then (4) re-parse verify the networks round-trip. Any
+      // parse failure / mismatch means the write corrupted the file → RESTORE the
+      // original (or remove a freshly-created file) and rethrow so the join
+      // orchestrator's try/catch converts it to a clean { ok: false } abort.
+      try {
+        atomicWriteFileSync(path, nextText);
+        const reparsed = parseYaml(readFileSync(path, "utf-8")) as
+          | { policy?: { federated?: { networks?: PolicyFederatedNetwork[] } } }
+          | null;
+        const readBack = reparsed?.policy?.federated?.networks ?? [];
+        // Project each entry to id + encryption mode + payload-key PRESENCE (never
+        // K's VALUE into a comparison that could reach an error path) + kid, then
+        // compare the ordered projections. Length-sensitive; no index access.
+        const project = (list: readonly PolicyFederatedNetwork[]): string =>
+          JSON.stringify(
+            list.map((n) => [
+              n.id,
+              n.encryption ?? null,
+              n.payload_key !== undefined,
+              n.payload_key_id ?? null,
+            ]),
+          );
+        if (project(readBack) !== project(networks)) {
+          throw new Error("policy.federated.networks did not round-trip after write");
+        }
+      } catch (err) {
+        if (originalText !== undefined) atomicWriteFileSync(path, originalText);
+        else rmSync(path, { force: true });
+        throw new Error(
+          `config write verification failed for ${path} — restored original${backupPath ? ` (backup ${backupPath})` : ""}: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+      }
+
+      // (5) K is a secret at rest — clamp the file to 0600 when any network carries
+      // a payload key (mirrors the leaf-include 0600 floor; the create umask can
+      // otherwise leave it group/world-readable).
+      if (networks.some((n) => n.payload_key !== undefined)) {
+        chmodSync(path, 0o600);
+      }
     },
   };
+}
+
+/** Timestamped suffix for the pre-join config backup (offer.ts write-guard). */
+function backupStamp(): string {
+  const now = new Date();
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  return [
+    now.getFullYear(),
+    pad(now.getMonth() + 1),
+    pad(now.getDate()),
+    "T",
+    pad(now.getHours()),
+    pad(now.getMinutes()),
+    pad(now.getSeconds()),
+  ].join("");
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -44,6 +44,7 @@ import {
   PolicyFederatedReconcileSchema,
 } from "../../../common/types/cortex-config";
 import type { NetworkRosterResult } from "../../../common/registry/types";
+import { pskFingerprint } from "../../../common/nats/leaf-psk";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 import { buildRosterPeers } from "../../../bus/agent-network/roster-read";
 import {
@@ -116,6 +117,23 @@ export interface JoiningStack {
    * O-4 (the register→issue handshake) SUPPLIES this; O-3 only consumes it.
    */
   operatorModePackage?: OperatorModeLeafPackage;
+  /**
+   * C-1349 Slice 1 — the per-network payload key `K` (base64, 32 bytes) the
+   * admin sealed into the leaf-secret envelope (`secret add-member`/`rotate`),
+   * unsealed by the join's auto-fetch. Present ⇒ `joinNetwork` writes
+   * `encryption: enabled` + `payload_key` (+ {@link payloadKeyId}) into the
+   * stack's `policy.federated.networks[<net>]` entry, so the member enables M3
+   * confidentiality with zero manual key handling. Absent ⇒ the entry's
+   * encryption block is left untouched (fresh join stays cleartext; re-join
+   * PRESERVES any prior block verbatim). K is NEVER logged.
+   */
+  payloadKey?: string;
+  /**
+   * C-1349 Slice 1 — the key id (rotation epoch) paired with {@link payloadKey}
+   * (`<net>/k1` by default), written as `payload_key_id`. Only meaningful when
+   * {@link payloadKey} is set.
+   */
+  payloadKeyId?: string;
   /**
    * G1c (#1117, ADR-0013 Model B) — the agents NSC account (nkey-A) where the
    * stack's dispatch-listener subscribes `federated.>`. This is the
@@ -611,6 +629,36 @@ export async function joinNetwork(
     reconcile = PolicyFederatedReconcileSchema.parse({ enabled: true });
   }
 
+  // C-1349 Slice 1 — the M3 encryption block. A freshly-DELIVERED payload key
+  // (`stack.payloadKey`, unsealed from the leaf-secret envelope) turns encryption
+  // ON and installs K + kid. With NO new key, PRESERVE the prior entry's block
+  // verbatim (exactly as `announce_capabilities` above) so a re-join never wipes
+  // an already-installed key; a first join with no key leaves the block absent
+  // (cleartext, unchanged from today). K is NEVER logged — only the kid + a
+  // fingerprint reach `steps`.
+  let encryptionFields: Pick<
+    PolicyFederatedNetwork,
+    "encryption" | "payload_key" | "payload_key_id"
+  > = {};
+  if (typeof stack.payloadKey === "string" && stack.payloadKey.length > 0) {
+    const kid = stack.payloadKeyId ?? `${networkId}/k1`;
+    encryptionFields = {
+      encryption: "enabled",
+      payload_key: stack.payloadKey,
+      payload_key_id: kid,
+    };
+    const kFp = await pskFingerprint(stack.payloadKey);
+    steps.push(
+      `encryption: installed payload key K (kid ${kid}, fp ${kFp}) — network "${networkId}" now seals M3 payloads`,
+    );
+  } else if (priorEntry?.encryption !== undefined) {
+    encryptionFields = {
+      encryption: priorEntry.encryption,
+      ...(priorEntry.payload_key !== undefined && { payload_key: priorEntry.payload_key }),
+      ...(priorEntry.payload_key_id !== undefined && { payload_key_id: priorEntry.payload_key_id }),
+    };
+  }
+
   const entry: PolicyFederatedNetwork = {
     id: networkId,
     leaf_node: stack.leafNode ?? networkId,
@@ -628,6 +676,8 @@ export async function joinNetwork(
     // (default [] only on a first join where no block exists yet).
     announce_capabilities: priorEntry?.announce_capabilities ?? [],
     max_hop: stack.maxHop ?? 1,
+    // C-1349 Slice 1 — M3 encryption (delivered-K install / re-join preserve).
+    ...encryptionFields,
   };
 
   // (d) Merge the network into the federation config with registry-resolved

--- a/src/cli/cortex/commands/network-secret-lib.ts
+++ b/src/cli/cortex/commands/network-secret-lib.ts
@@ -46,6 +46,23 @@ export interface SecretInputs {
   deliver: DeliveryMode;
   /** Override the hub leaf user (defaults to the member's principal id). */
   leafUserOverride?: string;
+  /**
+   * C-1349 Slice 1 — the per-network payload key `K` (base64, 32 bytes) read
+   * from the HUB STACK's own resolved config (`policy.federated.networks[<net>]
+   * .payload_key`) by the CLI. When present (add-member / rotate), it is sealed
+   * into the envelope alongside the leaf PSK so `network join` installs it. When
+   * ABSENT (encryption-off network, or no K configured hub-side), the envelope
+   * is sealed exactly as before and an info line points at the SOP fallback.
+   * The orchestrator NEVER mints K — delivery reads the existing hub-side key
+   * verbatim (minting is Slice 2's `rotate-key`).
+   */
+  payloadKey?: string;
+  /**
+   * C-1349 Slice 1 — the key id (rotation epoch) paired with {@link payloadKey}
+   * (`payload_key_id ?? <network>/k1`). Rides beside K in the envelope so the
+   * joiner installs both. Only meaningful when {@link payloadKey} is set.
+   */
+  payloadKeyKid?: string;
   apply: boolean;
 }
 
@@ -119,6 +136,19 @@ async function addOrRotate(
     steps.push(rotate
       ? `would: re-mint PSK → REPLACE hub authorization user "${leafUser}" + reload → re-seal + replace sealed blob`
       : `would: mint PSK → add hub authorization user "${leafUser}" + reload → ${inputs.deliver === "sealed" ? "seal + deliver to the admission row" : "surface PSK for out-of-band handover"}`);
+    // C-1349 Slice 1 — surface whether the sealed blob will carry the payload key
+    // K (kid only, NEVER K). oob never carries K (manual bootstrap path).
+    if (inputs.deliver === "sealed") {
+      const payloadKey =
+        typeof inputs.payloadKey === "string" && inputs.payloadKey.length > 0
+          ? inputs.payloadKey
+          : undefined;
+      steps.push(
+        payloadKey !== undefined
+          ? `would: seal payload key K (kid ${inputs.payloadKeyKid ?? `${inputs.networkId}/k1`}) — join would install encryption`
+          : `would: no payload key configured hub-side for "${inputs.networkId}" — sealing PSK only (SOP Step 8 for manual encryption)`,
+      );
+    }
     return plan(action, inputs, steps, data);
   }
 
@@ -160,9 +190,39 @@ async function addOrRotate(
   }
 
   // sealed (default): seal the envelope to the member + POST onto the row.
+  // C-1349 Slice 1 — when the hub stack config carries a payload key K for this
+  // network, seal it (+ its kid) alongside the leaf PSK so `network join`
+  // installs it with zero manual key handling. K NEVER reaches steps/data — only
+  // its kid + a SHA-256 fingerprint are printable. Absent K ⇒ seal as before +
+  // an info line pointing at the SOP manual-handoff fallback.
+  const payloadKey =
+    typeof inputs.payloadKey === "string" && inputs.payloadKey.length > 0
+      ? inputs.payloadKey
+      : undefined;
+  let payloadKeyKid: string | undefined;
+  if (payloadKey !== undefined) {
+    payloadKeyKid = inputs.payloadKeyKid ?? `${inputs.networkId}/k1`;
+    // Log-safe correlation of K: kid + first 8 hex of SHA-256(K). NEVER K.
+    const kFp = await pskFingerprint(payloadKey);
+    data.payload_key_kid = payloadKeyKid;
+    data.payload_key_fingerprint = kFp;
+    steps.push(`payload key: sealed K (kid ${payloadKeyKid}, fp ${kFp}) — join installs encryption`);
+  } else {
+    steps.push(
+      `payload key: no payload key configured hub-side for "${inputs.networkId}" — sealing PSK only; the member enables encryption via the manual handoff in sop-onboard-peer-principal.md Step 8`,
+    );
+  }
+
   let sealed: string;
   try {
-    const envelope = encodeLeafSecretEnvelope({ leaf_psk: psk, leaf_user: leafUser });
+    const envelope = encodeLeafSecretEnvelope({
+      leaf_psk: psk,
+      leaf_user: leafUser,
+      ...(payloadKey !== undefined && {
+        payload_key: payloadKey,
+        payload_key_kid: payloadKeyKid,
+      }),
+    });
     sealed = await ports.crypto.seal(envelope, inputs.memberPubkey);
   } catch (err) {
     return fail(action, inputs, steps, data, `failed to seal the secret to the member pubkey: ${errText(err)}`);

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -145,6 +145,7 @@ import {
   hubAdminMaterialFromSeedFile,
 } from "./network-secret-adapters";
 import { fetchSealedLeafSecret } from "../../../common/registry/fetch-sealed-secret";
+import { defaultKeyId } from "../../../common/crypto/network-encryption-policy";
 import {
   resolveOwnAdmissionState,
   type OwnAdmissionState,
@@ -452,6 +453,13 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--registry-url": "value",
         // The hub nats-server config the per-member authorization user lands in.
         "--hub-config": "value",
+        // C-1349 Slice 1 — the HUB STACK's cortex config (config-split dir sentinel
+        // or legacy monolith). Read-only: sourced for the per-network payload key
+        // K (`policy.federated.networks[<net>].payload_key`) to seal alongside the
+        // PSK. A config LOCATOR only — K is never a flag/second store. Defaults to
+        // the standard `~/.config/cortex` path (like join/create/status).
+        "--config": "value",
+        "--stack": "value",
         // add-member: sealed (default, plug-and-play) | oob (trusted bootstrap).
         "--deliver": "value",
         // Override the hub leaf user (defaults to the member's principal id).
@@ -651,7 +659,7 @@ export function __setJoinLeafSecretFetcherForTests(f: LeafSecretFetcher | null):
 async function maybeAutoFetchLeafSecret(
   networkId: string,
   inputs: { leafSecret?: string; seedPath: string; registryUrl: string; principal: string },
-): Promise<{ leafSecret: string; leafUser: string } | undefined> {
+): Promise<{ leafSecret: string; leafUser: string; payloadKey?: string; payloadKeyKid?: string } | undefined> {
   // Only when no leaf secret was resolved from flag/config (don't override an
   // explicit secret-auth join).
   if (inputs.leafSecret !== undefined) return undefined;
@@ -679,7 +687,15 @@ async function maybeAutoFetchLeafSecret(
     material,
   });
   if (!res.ok) return undefined;
-  return { leafSecret: res.leafPsk, leafUser: res.leafUser };
+  return {
+    leafSecret: res.leafPsk,
+    leafUser: res.leafUser,
+    // C-1349 Slice 1 — carry the sealed payload key K (+ kid) through to the
+    // join so it installs `encryption: enabled` + `payload_key` into the stack
+    // config. Absent on encryption-off networks / old blobs. K never logged.
+    ...(res.payloadKey !== undefined && { payloadKey: res.payloadKey }),
+    ...(res.payloadKeyKid !== undefined && { payloadKeyKid: res.payloadKeyKid }),
+  };
 }
 
 /**
@@ -911,6 +927,11 @@ async function runJoin(
   const autoSecret = await maybeAutoFetchLeafSecret(networkId, inputs);
   const resolvedLeafSecret = inputs.leafSecret ?? autoSecret?.leafSecret;
   const resolvedLeafUser = inputs.leafUser ?? autoSecret?.leafUser;
+  // C-1349 Slice 1 — the sealed envelope's payload key K (+ kid), when the admin
+  // sealed one via `secret add-member`/`rotate`. Present ⇒ join writes
+  // `encryption: enabled` + `payload_key` (+ kid) into stacks/<slug>.yaml.
+  const resolvedPayloadKey = autoSecret?.payloadKey;
+  const resolvedPayloadKeyKid = autoSecret?.payloadKeyKid;
 
   const stack: JoiningStack = {
     // C-1436 — the own-scope federation identity's PRINCIPAL segment MUST derive
@@ -945,6 +966,9 @@ async function runJoin(
     // `.creds`-file leaf.
     ...(resolvedLeafSecret !== undefined && { leafSecret: resolvedLeafSecret }),
     ...(resolvedLeafUser !== undefined && { leafUser: resolvedLeafUser }),
+    // C-1349 Slice 1 — sealed payload key K (+ kid) → join installs encryption.
+    ...(resolvedPayloadKey !== undefined && { payloadKey: resolvedPayloadKey }),
+    ...(resolvedPayloadKeyKid !== undefined && { payloadKeyId: resolvedPayloadKeyKid }),
     leafNode: optionalValueFlag(flags, "--leaf-node"),
     maxHop,
     // O-3 (cortex#1053) — pass the operator-mode leaf package (when resolved)
@@ -2732,6 +2756,50 @@ export type SecretPortsFactory = (cfg: {
 
 const DEFAULT_SECRET_PORTS_FACTORY: SecretPortsFactory = (cfg) => buildLiveSecretPorts(cfg);
 
+/**
+ * C-1349 Slice 1 — read the per-network payload key `K` (+ its kid) from the HUB
+ * STACK's own resolved cortex config (`policy.federated.networks[<net>]`), the
+ * SAME store the encryption runtime reads (`networkKeyFromConfig`). This is the
+ * single K custody source for sealed delivery (design decision #1: no `--payload
+ * -key-path` flag, no second store). `--config`/`--stack` are config LOCATORS
+ * resolved exactly as every sibling network verb does.
+ *
+ * Returns the base64 K string VERBATIM (the seal carries it opaquely) + the kid
+ * (`payload_key_id ?? <net>/k1`). NEVER logs K. A MISSING config or an
+ * encryption-off / keyless network → `{ ok: true }` with no key (seal PSK only).
+ * A config that EXISTS but fails to parse/validate FAILS (surfaced to the admin)
+ * rather than silently downgrading a network that is supposed to be encrypted.
+ */
+function resolveHubPayloadKey(
+  flags: FlagMap,
+  networkId: string,
+  load: ConfigReader,
+): { ok: true; payloadKey?: string; payloadKeyKid?: string } | { ok: false; reason: string } {
+  const path = resolveLocalStackConfigPath(flags);
+  let cfg: LoadedConfig;
+  try {
+    cfg = load(path);
+  } catch (err) {
+    return {
+      ok: false,
+      reason:
+        `failed to read the hub stack config ${path} for the network payload key: ` +
+        `${err instanceof Error ? err.message : String(err)} — fix the config, or pass ` +
+        `--config <path> to point at the hub stack's cortex config`,
+    };
+  }
+  const network = cfg.policy?.federated?.networks.find((n) => n.id === networkId);
+  if (network?.payload_key === undefined) {
+    // No config, encryption-off network, or a network with no K → seal PSK only.
+    return { ok: true };
+  }
+  return {
+    ok: true,
+    payloadKey: network.payload_key,
+    payloadKeyKid: network.payload_key_id ?? defaultKeyId(networkId),
+  };
+}
+
 async function runSecret(
   actionArg: string,
   networkId: string,
@@ -2739,6 +2807,10 @@ async function runSecret(
   flags: FlagMap,
   json: boolean,
   portsFactory: SecretPortsFactory,
+  // C-1349 Slice 1 — injectable hub stack config reader so the payload-key (K)
+  // read is testable without touching the principal's real `~/.config/cortex/`.
+  // Production omits → the tolerant `loadConfigWithAgents` reader.
+  load: ConfigReader = DEFAULT_READER,
 ): Promise<ExitResult> {
   // 1. Validate the action.
   const validActions: SecretAction[] = ["add-member", "revoke-member", "rotate"];
@@ -2785,6 +2857,22 @@ async function runSecret(
   const matRes = await hubAdminMaterialFromSeedFile(seedRes.value);
   if (!matRes.ok) return opError("secret", matRes.reason, json);
 
+  // 4b. C-1349 Slice 1 — resolve the per-network payload key K from the HUB
+  // STACK's own resolved config (design decision #1: hub config ONLY, no mint,
+  // no second store). add-member / rotate seal it alongside the PSK so join
+  // installs encryption; revoke-member does not touch K. A genuinely-broken hub
+  // config FAILS the command (never silently downgrade encryption); an ABSENT
+  // config or an encryption-off network → seal PSK only (the lib prints the
+  // SOP-fallback info line). K never reaches this function's output.
+  let payloadKey: string | undefined;
+  let payloadKeyKid: string | undefined;
+  if (action !== "revoke-member" && deliver === "sealed") {
+    const kRes = resolveHubPayloadKey(flags, networkId, load);
+    if (!kRes.ok) return opError("secret", kRes.reason, json);
+    payloadKey = kRes.payloadKey;
+    payloadKeyKid = kRes.payloadKeyKid;
+  }
+
   const ports = portsFactory({ hubConfigPath, registryUrl, material: matRes.material });
   const inputs: SecretInputs = {
     action,
@@ -2792,6 +2880,8 @@ async function runSecret(
     memberPubkey: member,
     deliver,
     ...(leafUserOverride !== undefined && { leafUserOverride }),
+    ...(payloadKey !== undefined && { payloadKey }),
+    ...(payloadKeyKid !== undefined && { payloadKeyKid }),
     apply: applyRes.apply,
   };
 
@@ -3413,6 +3503,7 @@ export async function dispatchNetwork(
         parsed.flags,
         json,
         secretPortsFactory,
+        load,
       );
   }
 }
@@ -3506,7 +3597,11 @@ Subcommands:
           the cortex daemon so it reconnects under the agents account. cortex
           runs zero nsc — it shells arc \`add-bot\` / \`export-account\`.
           Network-agnostic (local OR federated; for federated, run \`join\` after
-          to render the leaf). NEVER touches encryption/payload_key config.
+          to render the leaf). make-live NEVER touches encryption/payload_key
+          config — that is join's job: when the sealed leaf-secret envelope
+          carries a payload key K (from \`secret add-member\`/\`rotate\`), join
+          installs \`encryption: enabled\` + \`payload_key\` into the stack config
+          (C-1349 Slice 1).
           The nats-server config it edits + hard-restarts is derived PER-STACK
           from stack.nats_infra.config_path (or --nats-config) — there is NO
           shared default, so a co-located stack on its OWN nats-server

--- a/src/common/registry/__tests__/sealed-leaf-secret.test.ts
+++ b/src/common/registry/__tests__/sealed-leaf-secret.test.ts
@@ -1,0 +1,103 @@
+/**
+ * C-1349 Slice 1 — the sealed leaf-secret envelope now carries the per-network
+ * payload key `K` (`payload_key`) AND its key id (`payload_key_kid`, the new
+ * field). These tests pin:
+ *   - encode → decode round-trips leaf_psk + leaf_user (unchanged baseline)
+ *   - encode → decode round-trips payload_key + payload_key_kid when present
+ *   - decode TOLERATES an old blob with neither field (backward compat)
+ *   - decode tolerates payload_key present but kid absent, and vice-versa
+ *   - decode fails closed on a malformed kid type
+ *
+ * Fixtures use CLEARLY-FAKE key material (never realistic K bytes).
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  encodeLeafSecretEnvelope,
+  decodeLeafSecretEnvelope,
+  LEAF_SECRET_ENVELOPE_VERSION,
+} from "../sealed-leaf-secret";
+
+// Clearly-fake placeholder key material — an all-A base64 blob, never real K.
+const FAKE_K = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const FAKE_KID = "metafactory/k1";
+
+describe("encodeLeafSecretEnvelope / decodeLeafSecretEnvelope", () => {
+  test("round-trips leaf_psk + leaf_user (no payload key) — baseline unchanged", () => {
+    const env = decodeLeafSecretEnvelope(
+      encodeLeafSecretEnvelope({ leaf_psk: "psk-1", leaf_user: "alice" }),
+    );
+    expect(env.v).toBe(LEAF_SECRET_ENVELOPE_VERSION);
+    expect(env.leaf_psk).toBe("psk-1");
+    expect(env.leaf_user).toBe("alice");
+    expect(env.payload_key).toBeUndefined();
+    expect(env.payload_key_kid).toBeUndefined();
+  });
+
+  test("round-trips payload_key + payload_key_kid when both present", () => {
+    const env = decodeLeafSecretEnvelope(
+      encodeLeafSecretEnvelope({
+        leaf_psk: "psk-1",
+        leaf_user: "alice",
+        payload_key: FAKE_K,
+        payload_key_kid: FAKE_KID,
+      }),
+    );
+    expect(env.payload_key).toBe(FAKE_K);
+    expect(env.payload_key_kid).toBe(FAKE_KID);
+  });
+
+  test("decode tolerates an OLD blob: JSON with neither payload field", () => {
+    // A pre-#1349 envelope shape (v1, leaf_psk + leaf_user only).
+    const oldBlob = JSON.stringify({ v: 1, leaf_psk: "psk-1", leaf_user: "alice" });
+    const env = decodeLeafSecretEnvelope(oldBlob);
+    expect(env.leaf_psk).toBe("psk-1");
+    expect(env.payload_key).toBeUndefined();
+    expect(env.payload_key_kid).toBeUndefined();
+  });
+
+  test("decode tolerates payload_key present but kid absent", () => {
+    const blob = JSON.stringify({
+      v: 1,
+      leaf_psk: "psk-1",
+      leaf_user: "alice",
+      payload_key: FAKE_K,
+    });
+    const env = decodeLeafSecretEnvelope(blob);
+    expect(env.payload_key).toBe(FAKE_K);
+    expect(env.payload_key_kid).toBeUndefined();
+  });
+
+  test("decode tolerates kid present but payload_key absent (defensive)", () => {
+    const blob = JSON.stringify({
+      v: 1,
+      leaf_psk: "psk-1",
+      leaf_user: "alice",
+      payload_key_kid: FAKE_KID,
+    });
+    const env = decodeLeafSecretEnvelope(blob);
+    expect(env.payload_key).toBeUndefined();
+    expect(env.payload_key_kid).toBe(FAKE_KID);
+  });
+
+  test("decode fails closed when payload_key_kid is the wrong type", () => {
+    const blob = JSON.stringify({
+      v: 1,
+      leaf_psk: "psk-1",
+      leaf_user: "alice",
+      payload_key: FAKE_K,
+      payload_key_kid: 42,
+    });
+    expect(() => decodeLeafSecretEnvelope(blob)).toThrow(/payload_key_kid/);
+  });
+
+  test("encode omits payload_key_kid when payload_key is present but kid is not", () => {
+    const json = encodeLeafSecretEnvelope({
+      leaf_psk: "psk-1",
+      leaf_user: "alice",
+      payload_key: FAKE_K,
+    });
+    expect(json).not.toContain("payload_key_kid");
+    expect(json).toContain("payload_key");
+  });
+});

--- a/src/common/registry/fetch-sealed-secret.ts
+++ b/src/common/registry/fetch-sealed-secret.ts
@@ -52,7 +52,7 @@ export interface FetchSealedLeafSecretInput {
 }
 
 export type FetchSealedLeafSecretResult =
-  | { ok: true; leafPsk: string; leafUser: string; payloadKey?: string }
+  | { ok: true; leafPsk: string; leafUser: string; payloadKey?: string; payloadKeyKid?: string }
   | { ok: false; reason: string };
 
 /**
@@ -95,6 +95,7 @@ export async function fetchSealedLeafSecret(
       leafPsk: env.leaf_psk,
       leafUser: env.leaf_user,
       ...(env.payload_key !== undefined && { payloadKey: env.payload_key }),
+      ...(env.payload_key_kid !== undefined && { payloadKeyKid: env.payload_key_kid }),
     };
   } catch (err) {
     // Generic — never echo seed/ciphertext/plaintext.

--- a/src/common/registry/sealed-leaf-secret.ts
+++ b/src/common/registry/sealed-leaf-secret.ts
@@ -34,11 +34,21 @@ export interface LeafSecretEnvelope {
    */
   leaf_user: string;
   /**
-   * M3 SEAM (#1246 / ADR-0019) — the per-network payload key, sealed alongside
-   * the leaf PSK once M3 lands. OPTIONAL + absent in PR5b. Decoders MUST tolerate
-   * its presence (and its absence). Its config field lives in M3, NOT here.
+   * M3 SEAM (#1246 / ADR-0019) — the per-network payload key `K`, sealed
+   * alongside the leaf PSK. Populated by `cortex network secret add-member` /
+   * `rotate` when the hub stack config carries a `payload_key` for the network
+   * (C-1349 Slice 1). OPTIONAL + absent on encryption-off networks and on
+   * pre-C-1349 blobs. Decoders MUST tolerate its presence AND its absence.
    */
   payload_key?: string;
+  /**
+   * C-1349 Slice 1 — the key id (rotation epoch) of {@link payload_key}, the
+   * `<network>/k<n>` the runtime stamps into `extensions.enc.kid`
+   * (`payload_key_id` in stack config, default `<network>/k1`). Rides beside
+   * `payload_key` so the joiner installs BOTH; decoders MUST tolerate its
+   * absence (old blobs, and a `payload_key` sealed before this field existed).
+   */
+  payload_key_kid?: string;
 }
 
 /** Encode a {@link LeafSecretEnvelope} to the UTF-8 JSON that gets sealed. */
@@ -50,6 +60,7 @@ export function encodeLeafSecretEnvelope(
     leaf_psk: fields.leaf_psk,
     leaf_user: fields.leaf_user,
     ...(fields.payload_key !== undefined && { payload_key: fields.payload_key }),
+    ...(fields.payload_key_kid !== undefined && { payload_key_kid: fields.payload_key_kid }),
   };
   return JSON.stringify(env);
 }
@@ -80,10 +91,14 @@ export function decodeLeafSecretEnvelope(plaintext: string): LeafSecretEnvelope 
   if (p.payload_key !== undefined && typeof p.payload_key !== "string") {
     throw new Error("sealed-leaf-secret: payload_key must be a string when present");
   }
+  if (p.payload_key_kid !== undefined && typeof p.payload_key_kid !== "string") {
+    throw new Error("sealed-leaf-secret: payload_key_kid must be a string when present");
+  }
   return {
     v: typeof p.v === "number" ? p.v : LEAF_SECRET_ENVELOPE_VERSION,
     leaf_psk: p.leaf_psk,
     leaf_user: p.leaf_user,
     ...(typeof p.payload_key === "string" && { payload_key: p.payload_key }),
+    ...(typeof p.payload_key_kid === "string" && { payload_key_kid: p.payload_key_kid }),
   };
 }


### PR DESCRIPTION
## What

`cortex network secret add-member` / per-member `rotate` now seal the per-network **payload key K** (+ its `payload_key_kid`) into the SAME sealed leaf-secret envelope as the PSK, and `cortex network join` unseals it and writes `encryption: enabled` + `payload_key` (+ kid) into the joining stack's `stacks/<slug>.yaml` — zero manual key handling.

## How (per design comment [4871479211](https://github.com/the-metafactory/cortex/issues/1349#issuecomment-4871479211))

- **Envelope seam** (`sealed-leaf-secret.ts`): added `payload_key_kid` beside the existing optional `payload_key`; encode/decode tolerate absence (old blobs), fail closed on a wrong-typed kid.
- **Seal** (`network-secret-lib.ts`): add-member/rotate include `payload_key` + `payload_key_kid` when K is supplied; without K → sealed exactly as today + an info line pointing at SOP Step 8.
- **Join install** (`network-lib.ts`): entry construction writes the encryption block from the unsealed K; a **re-join with no new K PRESERVES** the prior block verbatim (mirrors `announce_capabilities`); no K → the entry stays cleartext (unchanged).
- **Write-guard** (`network-adapters.ts` `writeNetworks`): the offer.ts pattern — scoped **validate-before-write** (K must base64-decode to 32 bytes) → timestamped `.pre-join` backup → atomic write → re-parse round-trip verify → **restore-on-failure**; file clamped to **0600** when it carries K.
- **Join fetch** (`fetch-sealed-secret.ts`, `maybeAutoFetchLeafSecret`): surface `payload_key_kid` through to the join.
- **SOP Step 8** updated: sealed auto-delivery is the default, manual handoff the fallback. Clarified the (accurate) make-live "never touches encryption" help.

## K custody statement (hub config ONLY)

K is read from the **hub stack's own resolved config** — `policy.federated.networks[<net>].payload_key` — via the standard `--config` locator + `loadConfigWithAgents` that every sibling network verb already uses. **No `--payload-key-path` flag, no second store, no minting at add-member** (minting is Slice 2's `rotate-key`). A missing / encryption-off / keyless network → seal PSK only; a genuinely **broken** hub config FAILS the command (never a silent encryption downgrade).

> Note: this is the STOP-and-report item from kickoff — the secret verbs didn't load the stack config today. Resolved by adopting the same `--config` locator the sibling verbs use (a config locator, not a key input). Called out for the refute-review.

## Never-prints-K evidence

K never appears in stdout, logs, dry-run, error messages, or test snapshots. The only printable identifiers are the **kid** + the **first 8 hex of SHA-256(K)**. Verified by grepping the diff: **no K value reaches any `steps.push` / `throw` / `console` / stdout path**; the sole K sinks are (1) the sealed envelope, (2) the at-rest config write (chmod 600), (3) presence-only (`!== undefined`) comparisons. A dedicated assertion covers the human + JSON output paths, and the E2E round-trip asserts `not.toContain(K)` on both `steps` and `data`.

## Write-guard behavior (backup/restore tested)

- installs K + kid, round-trips through YAML, clamps the file to `0600`
- writes a timestamped `.pre-join-*.bak` holding the original **verbatim** (recoverable)
- a **malformed** `payload_key` is REFUSED before any write; the file is left **byte-identical** (validate-before-write / original preserved), key never echoed into the error

## Old-blob tolerance

`decodeLeafSecretEnvelope` tolerates envelopes with neither `payload_key` nor `payload_key_kid`, and either-present-without-the-other; a wrong-typed kid fails closed.

## Four-check gate (from `../Cortex-kdeliver`)

```
1. bunx eslint --quiet <touched>                                  → 0
2. bunx tsc --noEmit                                              → 0
3. bash scripts/check-carveouts.sh                               → PASS
4. bun test src/cli/cortex/commands src/common/registry src/common/crypto
     → 1420 pass, 8 todo, 0 fail
```

Includes the E2E lifecycle **step 5b flipped LIVE** (add-member seals K → joiner fetches + unseals it end-to-end through the in-process registry).

## Deviations

- Line drift from the issue's cited numbers (all verified against the live tree): the stale "NEVER touches encryption" comment was at `network.ts:3600` (issue said :2499) — it lives in make-live's help and was clarified rather than reworded as a join comment; the join fetch/unseal seam is `maybeAutoFetchLeafSecret` (`network.ts:651`).
- Write-guard: the current `writeNetworks` was **unguarded** (plain write) — added the full guard. The validate step is **scoped to the payload_key field** (not the whole entry) to avoid newly rejecting hand-pinned peer shapes this writer has always tolerated.

Refs #1349 (Slice 1 of 2 — Slice 2 rotate-key remains). Epic #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196JFPf1tEudhBUvwWjEhgA