### PR TITLE
fix(mc): transport overlay + observability attention are dead code — respell to signal's hyphenated envelope types, regenerate fixtures from the canonical builder

### DIFF
--- a/src/bus/agent-network/__tests__/federated-observability-curation.test.ts
+++ b/src/bus/agent-network/__tests__/federated-observability-curation.test.ts
@@ -19,10 +19,10 @@ import {
 
 describe("evaluateObservabilityCuration — ALLOW-list (the folded classes)", () => {
   test.each([
-    "system.transport.leaf_connect",
-    "system.transport.leaf_disconnect",
-    "system.transport.liveness_drift",
-    "system.transport.roster_snapshot",
+    "system.transport.leaf-connect",
+    "system.transport.leaf-disconnect",
+    "system.transport.liveness-drift",
+    "system.transport.roster-snapshot",
     "system.transport.backend.reachable",
     "system.federation.peer.added",
     "system.federation.peer.removed",

--- a/src/bus/agent-network/__tests__/federated-observability-fold.test.ts
+++ b/src/bus/agent-network/__tests__/federated-observability-fold.test.ts
@@ -159,7 +159,7 @@ async function flush(): Promise<void> {
   await new Promise((r) => setTimeout(r, 0));
 }
 
-const TRANSPORT_TYPE = "system.transport.leaf_connect";
+const TRANSPORT_TYPE = "system.transport.leaf-connect";
 const TRANSPORT_SUBJECT = "federated.joel.research.system.transport.leaf_connect";
 
 // ===========================================================================

--- a/src/common/sideband/metrics.ts
+++ b/src/common/sideband/metrics.ts
@@ -12,11 +12,13 @@
  *   - `SearchResponse`              → {@link SearchResponse}
  *   - `SidebandLogRecord`           → {@link SidebandLogRecord}
  *
- * Signal's `cortex-sideband.md` is a P-9-era doc that predates the v2 reads
- * (U4.1 added `/metrics/summary` + `/search` to the SERVER under signal#127/#147
- * but the markdown spec wasn't refreshed); the contract source-of-truth for
- * these two endpoints is signal's `types.ts` + `server.ts`, which this module
- * mirrors. The `SidebandError` envelope is shared verbatim with the P-9 reads
+ * Signal's `docs/contract/cortex-sideband.md` documents both v2 reads since
+ * signal#152 (merged 2026-06-16): §2.5 `GET /metrics/summary` and §2.6
+ * `GET /search`. That doc + signal's `src/lib/sideband/types.ts` are the
+ * contract source-of-truth for these two endpoints; this module mirrors the
+ * `types.ts` shapes (the type-pin source) and is enforced at compile time
+ * against captured signal fixtures. The `SidebandError` envelope is shared
+ * verbatim with the P-9 reads
  * (see `proxy.ts`), so a v2 failure renders through the SAME honest
  * "interior capture not available" + `deep_link` affordance.
  *

--- a/src/surface/mc/__tests__/__fixtures__/signal-transport-envelopes.ts
+++ b/src/surface/mc/__tests__/__fixtures__/signal-transport-envelopes.ts
@@ -1,0 +1,191 @@
+/**
+ * CANONICAL SIGNAL TRANSPORT ENVELOPE FIXTURES — provenance-pinned (cortex#1467).
+ *
+ * These reproduce the myelin-canonical `system.transport.*` envelope shapes that
+ * signal's `SystemTransportPublisher` puts on the wire, derived from signal's OWN
+ * builder OUTPUT rather than hand-invented — so cortex's fixtures can never again
+ * pin an IMPOSSIBLE shape (the underscore-typed body that every real envelope's
+ * AJV validation rejects, which is why the U2.3 overlay + U2.1 attention arms
+ * shipped as dead code: cortex#1467 / signal recommendation 8).
+ *
+ * PROVENANCE (pinned):
+ *   - signal `main` @ 81eebaa
+ *   - builder:  signal/src/lib/transport-observability/publisher.ts
+ *               (buildEnvelope → buildCanonicalSystemEnvelope)
+ *   - shared:   signal/src/lib/system-events/envelope.ts
+ *               (subjectTailToType maps subject-tail `_`→`-` for the body `type`;
+ *                SOURCE_COMPONENT = "signal"; DEFAULT_DATA_RESIDENCY = "NZ")
+ *   - oracle:   signal/src/lib/system-events/__tests__/canonical-envelope-schema.test.ts
+ *               (transport leaf-connect :200-220; underscore-rejection :309-322)
+ *
+ * THE WIRE TRUTH (signal U0.4 canonicalisation), test-pinned by the oracle:
+ *   - envelope BODY `type`          → HYPHENS      (`system.transport.leaf-connect`)
+ *   - NATS SUBJECT                  → underscores  (`...system.transport.leaf_connect`)
+ *   - `extensions.namespace.action` → underscores  (the exact subject-leaf action)
+ *   - `payload.action`              → underscores  (the `TransportAction` enum)
+ *
+ * A fixture's top-level `type` MUST be the hyphen form: cortex's vendored myelin
+ * schema (`src/bus/myelin/vendor/envelope.schema.json`, `type` pattern
+ * `^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$`) forbids `_`, so an underscore type
+ * is REJECTED — signal pins exactly this at canonical-envelope-schema.test.ts:319.
+ * The companion test (`signal-transport-envelopes.test.ts`) routes every fixture
+ * through `validateEnvelope`, so a schema-invalid (underscore-typed) fixture FAILS
+ * the suite — the anti-drift belt that the old fixtures bypassed by calling the
+ * fold/producer directly, never touching AJV.
+ */
+
+import type { Envelope } from "../../../../bus/myelin/envelope-validator";
+
+/** Where these shapes came from — cite in review, and when regenerating. */
+export const SIGNAL_ENVELOPE_PROVENANCE = {
+  repo: "the-metafactory/signal",
+  commit: "81eebaa",
+  builder: "src/lib/transport-observability/publisher.ts",
+  shared: "src/lib/system-events/envelope.ts",
+  oracle: "src/lib/system-events/__tests__/canonical-envelope-schema.test.ts",
+} as const;
+
+/**
+ * The four transport envelope BODY `type` values — hyphen-mapped per the myelin
+ * type grammar. THE single source of truth for the spelling across the MC tests;
+ * import these rather than hard-coding a string a future edit could drift.
+ */
+export const TRANSPORT_TYPES = {
+  leafConnect: "system.transport.leaf-connect",
+  leafDisconnect: "system.transport.leaf-disconnect",
+  livenessDrift: "system.transport.liveness-drift",
+  rosterSnapshot: "system.transport.roster-snapshot",
+} as const;
+
+export type TransportType = (typeof TRANSPORT_TYPES)[keyof typeof TRANSPORT_TYPES];
+
+/** The subject-leaf action (underscores) that pairs with each hyphen `type`. */
+const ACTION_FOR_TYPE: Record<string, string> = {
+  [TRANSPORT_TYPES.leafConnect]: "leaf_connect",
+  [TRANSPORT_TYPES.leafDisconnect]: "leaf_disconnect",
+  [TRANSPORT_TYPES.livenessDrift]: "liveness_drift",
+  [TRANSPORT_TYPES.rosterSnapshot]: "roster_snapshot",
+};
+
+/**
+ * The underscore (subject-leaf) form of a hyphen `type` — the IMPOSSIBLE body
+ * spelling the myelin schema rejects. Only the trailing action segment carries a
+ * hyphen (`system`/`transport` do not), so a global `-`→`_` is exact here.
+ * Used by the anti-drift test to prove `validateEnvelope` fails the bad shape.
+ */
+export function toUnderscoreType(hyphenType: string): string {
+  return hyphenType.replace(/-/g, "_");
+}
+
+/** One observed NATS leaf — mirrors signal's `ObservedLeaf` (oracle :203-211). */
+const OBSERVED_LEAF = {
+  principal: "jc",
+  stack: "default",
+  network: "metafactory-community",
+  up_since: "2026-06-10T03:00:00.000Z",
+  rtt_ms: 8.4,
+  last_seen: null,
+  frames: { in_msgs: 16, out_msgs: 4, in_bytes: 2048, out_bytes: 512 },
+} as const;
+
+interface BuildOpts {
+  payload?: Record<string, unknown>;
+  id?: string;
+}
+
+/**
+ * Build a canonical signal transport envelope for `type` (hyphen form),
+ * reproducing `buildCanonicalSystemEnvelope`'s output field-for-field: 3-segment
+ * `source` `{principal}.{stack}.signal`, `local` sovereignty with NZ residency,
+ * and `extensions.namespace.action` carrying the underscore subject-leaf action.
+ * The result passes cortex's vendored myelin schema via `validateEnvelope`.
+ */
+export function makeTransportEnvelope(type: string, opts: BuildOpts = {}): Envelope {
+  const action = ACTION_FOR_TYPE[type] ?? "leaf_connect";
+  const envelope = {
+    id: opts.id ?? crypto.randomUUID(),
+    source: "andreas.laptop.signal",
+    type,
+    timestamp: "2026-06-12T00:00:00.000Z",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: { action, network: "metafactory-community", ...opts.payload },
+    extensions: {
+      schema_version: "2",
+      namespace: { domain: "system", entity: "transport", action },
+      stack_id: "andreas/laptop",
+    },
+  };
+  // The vendored myelin `Envelope` type is hand-narrowed; the extra canonical
+  // fields (extensions.*) ride along untyped exactly as on the real wire.
+  return envelope as unknown as Envelope;
+}
+
+/** A ready per-family fixture set with realistic transport bodies. */
+export interface TransportFamilyFixture {
+  /** The family label (for test names). */
+  family: "leaf-connect" | "leaf-disconnect" | "liveness-drift" | "roster-snapshot";
+  /** Hyphen-mapped body `type`. */
+  type: string;
+  /** A canonical, schema-valid envelope of this family. */
+  envelope: Envelope;
+  /** The transport body (`{ action, network, leaf?/leaves?/attributes? }`). */
+  payload: Record<string, unknown>;
+  /** The `{principal}/{stack}` this observation resolves to (for overlay asserts). */
+  peer: { principal: string; stack: string };
+}
+
+/** The canonical four transport families — the fixture set the MC tests fold. */
+export const TRANSPORT_FAMILY_FIXTURES: readonly TransportFamilyFixture[] = [
+  {
+    family: "leaf-connect",
+    type: TRANSPORT_TYPES.leafConnect,
+    payload: { leaf: { ...OBSERVED_LEAF } },
+    envelope: makeTransportEnvelope(TRANSPORT_TYPES.leafConnect, {
+      payload: { leaf: { ...OBSERVED_LEAF } },
+    }),
+    peer: { principal: "jc", stack: "default" },
+  },
+  {
+    family: "leaf-disconnect",
+    type: TRANSPORT_TYPES.leafDisconnect,
+    payload: {
+      leaf: { ...OBSERVED_LEAF, rtt_ms: null, last_seen: "2026-06-12T00:00:00.000Z" },
+    },
+    envelope: makeTransportEnvelope(TRANSPORT_TYPES.leafDisconnect, {
+      payload: {
+        leaf: { ...OBSERVED_LEAF, rtt_ms: null, last_seen: "2026-06-12T00:00:00.000Z" },
+      },
+    }),
+    peer: { principal: "jc", stack: "default" },
+  },
+  {
+    family: "liveness-drift",
+    type: TRANSPORT_TYPES.livenessDrift,
+    payload: {
+      reason: "peer jc/default → connected",
+      attributes: { peer: "jc/default", principal: "jc", stack: "default", from: null, to: "connected" },
+    },
+    envelope: makeTransportEnvelope(TRANSPORT_TYPES.livenessDrift, {
+      payload: {
+        reason: "peer jc/default → connected",
+        attributes: { peer: "jc/default", principal: "jc", stack: "default", from: null, to: "connected" },
+      },
+    }),
+    peer: { principal: "jc", stack: "default" },
+  },
+  {
+    family: "roster-snapshot",
+    type: TRANSPORT_TYPES.rosterSnapshot,
+    payload: { leaves: [{ ...OBSERVED_LEAF }] },
+    envelope: makeTransportEnvelope(TRANSPORT_TYPES.rosterSnapshot, {
+      payload: { leaves: [{ ...OBSERVED_LEAF }] },
+    }),
+    peer: { principal: "jc", stack: "default" },
+  },
+] as const;

--- a/src/surface/mc/__tests__/observability-db.test.ts
+++ b/src/surface/mc/__tests__/observability-db.test.ts
@@ -58,7 +58,7 @@ describe("observability_events storage", () => {
   it("lists by family, newest first, and overall", () => {
     insertObservabilityEvent(db, { envelopeId: "a", family: "signal", type: "system.signal.received", payload: {}, timestamp: "2026-06-01T00:00:00.000Z" });
     insertObservabilityEvent(db, { envelopeId: "b", family: "signal", type: "system.signal.dropped", payload: {}, timestamp: "2026-06-02T00:00:00.000Z" });
-    insertObservabilityEvent(db, { envelopeId: "c", family: "transport", type: "system.transport.leaf_connect", payload: {}, timestamp: "2026-06-03T00:00:00.000Z" });
+    insertObservabilityEvent(db, { envelopeId: "c", family: "transport", type: "system.transport.leaf-connect", payload: {}, timestamp: "2026-06-03T00:00:00.000Z" });
 
     const sig = listObservabilityEvents(db, 10, "signal");
     expect(sig.map((r) => r.envelopeId)).toEqual(["b", "a"]); // newest first
@@ -101,7 +101,7 @@ describe("pruneOldObservability — age-based retention", () => {
 
   it("pruneRetention reports prunedObservability in its summary", () => {
     const old = new Date(Date.now() - OBSERVABILITY_RETENTION_MS - 60_000).toISOString();
-    insertObservabilityEvent(db, { envelopeId: "old", family: "transport", type: "system.transport.leaf_disconnect", payload: {}, timestamp: old });
+    insertObservabilityEvent(db, { envelopeId: "old", family: "transport", type: "system.transport.leaf-disconnect", payload: {}, timestamp: old });
     const summary = pruneRetention(db);
     expect(summary.ok).toBe(true);
     expect(summary.prunedObservability).toBe(1);
@@ -119,19 +119,19 @@ describe("listTransportRosterEvents (P-14 U2.3) — payload-bearing transport re
       payload: { n: 1 }, timestamp: "2026-06-01T00:00:00.000Z",
     });
     insertObservabilityEvent(db, {
-      envelopeId: "t1", family: "transport", type: "system.transport.liveness_drift",
+      envelopeId: "t1", family: "transport", type: "system.transport.liveness-drift",
       payload: { action: "liveness_drift", network: "net", attributes: { peer: "jc/default", to: "connected" } },
       timestamp: "2026-06-02T00:00:00.000Z",
     });
     insertObservabilityEvent(db, {
-      envelopeId: "t2", family: "transport", type: "system.transport.leaf_connect",
+      envelopeId: "t2", family: "transport", type: "system.transport.leaf-connect",
       payload: { action: "leaf_connect", network: "net", leaf: { principal: "jc", stack: "default", network: "net", rtt_ms: 8.4 } },
       timestamp: "2026-06-03T00:00:00.000Z",
     });
 
     const rows = listTransportRosterEvents(db, 50);
     expect(rows.length).toBe(2); // signal row excluded
-    expect(rows[0]!.type).toBe("system.transport.leaf_connect"); // newest first
+    expect(rows[0]!.type).toBe("system.transport.leaf-connect"); // newest first
     // The payload round-trips back to an object (NOT stripped like the tab read).
     expect((rows[0]!.payload.leaf as Record<string, unknown>).rtt_ms).toBe(8.4);
     expect((rows[1]!.payload.attributes as Record<string, unknown>).to).toBe("connected");
@@ -142,7 +142,7 @@ describe("listTransportRosterEvents (P-14 U2.3) — payload-bearing transport re
     // so write a raw bad value to exercise the parse guard).
     db.query(
       `INSERT INTO observability_events (id, envelope_id, family, type, payload, timestamp)
-       VALUES (?, ?, 'transport', 'system.transport.roster_snapshot', '{not json', datetime('now'))`,
+       VALUES (?, ?, 'transport', 'system.transport.roster-snapshot', '{not json', datetime('now'))`,
     ).run(crypto.randomUUID(), "poison");
     const rows = listTransportRosterEvents(db, 10);
     expect(rows.length).toBe(1);
@@ -162,7 +162,7 @@ describe("observability origin badge (P-14 U3.3)", () => {
 
   it("defaults a row's origin to local when no origin is supplied (U2.1 contract)", () => {
     insertObservabilityEvent(db, {
-      envelopeId: "local-1", family: "transport", type: "system.transport.leaf_connect", payload: {},
+      envelopeId: "local-1", family: "transport", type: "system.transport.leaf-connect", payload: {},
     });
     expect(listObservabilityEvents(db, 10, "transport")[0]?.origin).toBe("local");
     expect(listTransportRosterEvents(db, 10)[0]?.origin).toBe("local");
@@ -172,7 +172,7 @@ describe("observability origin badge (P-14 U3.3)", () => {
     insertObservabilityEvent(db, {
       envelopeId: "fed-1",
       family: "transport",
-      type: "system.transport.liveness_drift",
+      type: "system.transport.liveness-drift",
       payload: { action: "liveness_drift", network: "net", attributes: { peer: "joel/research", to: "connected" } },
       origin: { kind: "foreign", peer: "joel/research" },
     });
@@ -187,18 +187,18 @@ describe("observability origin badge (P-14 U3.3)", () => {
     // origin_peer; an inconsistent row must not surface an un-attributed foreign.
     db.query(
       `INSERT INTO observability_events (id, envelope_id, family, type, payload, origin_kind, origin_peer, timestamp)
-       VALUES (?, ?, 'transport', 'system.transport.leaf_connect', '{}', 'foreign', NULL, datetime('now'))`,
+       VALUES (?, ?, 'transport', 'system.transport.leaf-connect', '{}', 'foreign', NULL, datetime('now'))`,
     ).run(crypto.randomUUID(), "broken-foreign");
     expect(listObservabilityEvents(db, 10, "transport")[0]?.origin).toBe("local");
   });
 
   it("local and foreign rows coexist, each carrying its own badge", () => {
     insertObservabilityEvent(db, {
-      envelopeId: "loc", family: "transport", type: "system.transport.leaf_connect",
+      envelopeId: "loc", family: "transport", type: "system.transport.leaf-connect",
       payload: {}, origin: "local", timestamp: "2026-06-01T00:00:00.000Z",
     });
     insertObservabilityEvent(db, {
-      envelopeId: "fed", family: "transport", type: "system.transport.leaf_connect",
+      envelopeId: "fed", family: "transport", type: "system.transport.leaf-connect",
       payload: {}, origin: { kind: "foreign", peer: "joel/research" }, timestamp: "2026-06-02T00:00:00.000Z",
     });
     const rows = listTransportRosterEvents(db, 10);

--- a/src/surface/mc/__tests__/observability-renderer.test.ts
+++ b/src/surface/mc/__tests__/observability-renderer.test.ts
@@ -91,7 +91,7 @@ describe("familyForType — four-family routing", () => {
 
   it("routes federation and transport", () => {
     expect(familyForType("system.federation.peer.added")).toBe("federation");
-    expect(familyForType("system.transport.leaf_disconnect")).toBe("transport");
+    expect(familyForType("system.transport.leaf-disconnect")).toBe("transport");
   });
 
   it("returns null for an unrelated type", () => {
@@ -125,7 +125,7 @@ describe("projectObservability — projection rows", () => {
     expect(projectObservability(db, envelope("system.signal.received", { summary: "ok" }), fakeRegistry)).toBe("signal");
     expect(projectObservability(db, envelope("system.signal.collector.degraded", { collector_id: "relay-1" }), fakeRegistry)).toBe("collector");
     expect(projectObservability(db, envelope("system.federation.peer.added", { peer: "jc" }), fakeRegistry)).toBe("federation");
-    expect(projectObservability(db, envelope("system.transport.leaf_connect", { leaf: "leaf-a" }), fakeRegistry)).toBe("transport");
+    expect(projectObservability(db, envelope("system.transport.leaf-connect", { leaf: "leaf-a" }), fakeRegistry)).toBe("transport");
 
     const counts = countObservabilityByFamily(db);
     expect(counts).toEqual({ signal: 1, collector: 1, federation: 1, transport: 1 });
@@ -172,7 +172,7 @@ describe("projectForeignObservability — origin-badged peer rows (U3.3)", () =>
   it("writes a FOREIGN-origin row + broadcasts, never local", () => {
     const fam = projectForeignObservability(
       db,
-      envelope("system.transport.leaf_connect", { leaf: "leaf-a" }),
+      envelope("system.transport.leaf-connect", { leaf: "leaf-a" }),
       "joel/research",
       fakeRegistry,
     );
@@ -187,7 +187,7 @@ describe("projectForeignObservability — origin-badged peer rows (U3.3)", () =>
     // local. As a foreign row it must NOT — no attention broadcast, no item.
     projectForeignObservability(
       db,
-      envelope("system.transport.leaf_disconnect", { leaf: "leaf-a" }),
+      envelope("system.transport.leaf-disconnect", { leaf: "leaf-a" }),
       "joel/research",
       fakeRegistry,
     );
@@ -198,7 +198,7 @@ describe("projectForeignObservability — origin-badged peer rows (U3.3)", () =>
 
   it("a LOCAL transport health signal STILL opens an attention item (regression guard)", () => {
     // Contrast: the same disconnect via the LOCAL path opens the att:adapter: item.
-    projectObservability(db, envelope("system.transport.leaf_disconnect", { leaf: "leaf-a" }), fakeRegistry);
+    projectObservability(db, envelope("system.transport.leaf-disconnect", { leaf: "leaf-a" }), fakeRegistry);
     expect(broadcasts.some((m) => m.type === "mc.projection" && m.family === "attention")).toBe(true);
   });
 });
@@ -238,7 +238,7 @@ describe("produceObservabilityAttention — att:adapter: open/resolve", () => {
     expect(attentionRow(db, backend!.itemId)?.status).toBe("open");
 
     const leaf = produceObservabilityAttention(db, {
-      type: "system.transport.leaf_disconnect",
+      type: "system.transport.leaf-disconnect",
       payload: { leaf: "leaf-a" },
     });
     expect(leaf).toMatchObject({ action: "opened" });

--- a/src/surface/mc/__tests__/signal-transport-envelopes.test.ts
+++ b/src/surface/mc/__tests__/signal-transport-envelopes.test.ts
@@ -1,0 +1,160 @@
+/**
+ * cortex#1467 — canonical transport-envelope ANTI-DRIFT suite.
+ *
+ * The U2.3 overlay + U2.1 attention arms shipped DEAD because cortex's fixtures
+ * pinned an impossible underscore-typed body and called the fold/producer
+ * DIRECTLY, bypassing AJV — green suites against a wire shape that can never
+ * occur (signal maps subject-tail `_`→`-` in `envelope.type`, and the myelin
+ * schema rejects `_` types; validation runs BEFORE the router). This suite closes
+ * that hole three ways, all driven by provenance-pinned fixtures reproduced from
+ * signal's builder output (signal `main` @ 81eebaa):
+ *
+ *   1. ANTI-DRIFT — each family's fixture is routed through `validateEnvelope`;
+ *      the hyphen form PASSES and the underscore form FAILS. A future fixture
+ *      that regresses to the impossible spelling now fails the suite (signal pins
+ *      the same at canonical-envelope-schema.test.ts:319).
+ *   2. AC1 — each canonical hyphen-typed row drives `buildTransportOverlay` to
+ *      NON-EMPTY output; no family falls through to `default: return []`.
+ *   3. AC2 — `produceObservabilityAttention` OPENS on `leaf-disconnect` and
+ *      RESOLVES on `leaf-connect`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { validateEnvelope } from "../../../bus/myelin/envelope-validator";
+import {
+  buildTransportOverlay,
+  overlayForStack,
+} from "../dashboard-v2/lib/network-transport-overlay";
+import { produceObservabilityAttention } from "../projection/observability-attention";
+import { ADAPTER_ATTENTION_PREFIX } from "../projection/adapter-lifecycle";
+import { SCHEMA_SQL } from "../db/schema";
+import type { TransportRosterEventRow } from "../api/observability-tab";
+import {
+  TRANSPORT_TYPES,
+  TRANSPORT_FAMILY_FIXTURES,
+  makeTransportEnvelope,
+  toUnderscoreType,
+} from "./__fixtures__/signal-transport-envelopes";
+
+// ---------------------------------------------------------------------------
+// 1. ANTI-DRIFT — the fixture envelopes clear cortex's vendored myelin schema,
+//    and the impossible underscore body is rejected. (cortex#1467 step 4)
+// ---------------------------------------------------------------------------
+
+describe("canonical transport fixtures — validateEnvelope anti-drift", () => {
+  for (const fx of TRANSPORT_FAMILY_FIXTURES) {
+    it(`${fx.family}: the canonical hyphen-typed envelope PASSES validateEnvelope`, () => {
+      const result = validateEnvelope(fx.envelope);
+      // Surface the AJV errors on failure so any drift is diagnosable.
+      if (!result.ok) {
+        throw new Error(
+          `validateEnvelope rejected canonical ${fx.family}: ${JSON.stringify(result.errors)}`,
+        );
+      }
+      expect(result.ok).toBe(true);
+    });
+
+    it(`${fx.family}: flipping the body type to the underscore form is REJECTED`, () => {
+      // The exact hole the old fixtures exploited: an underscore `type` never
+      // survives AJV (myelin type grammar forbids `_`), so it could only ever be
+      // "tested" by bypassing validation. Prove the schema bites.
+      const bad = makeTransportEnvelope(fx.type, { payload: fx.payload });
+      (bad as unknown as { type: string }).type = toUnderscoreType(fx.type);
+      expect(validateEnvelope(bad).ok).toBe(false);
+    });
+  }
+
+  it("the four fixtures cover exactly the four hyphen-typed families", () => {
+    expect(TRANSPORT_FAMILY_FIXTURES.map((f) => f.type).sort()).toEqual(
+      [
+        TRANSPORT_TYPES.leafConnect,
+        TRANSPORT_TYPES.leafDisconnect,
+        TRANSPORT_TYPES.livenessDrift,
+        TRANSPORT_TYPES.rosterSnapshot,
+      ].sort(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. AC1 — a canonical hyphen-typed row drives buildTransportOverlay to
+//    non-empty output for EVERY family (no default fall-through).
+// ---------------------------------------------------------------------------
+
+/** Project one canonical fixture into the DB-row shape the overlay folds. */
+function rowFor(type: string, payload: Record<string, unknown>): TransportRosterEventRow {
+  return {
+    id: crypto.randomUUID(),
+    type,
+    stackId: "metafactory-community",
+    payload,
+    origin: "local",
+    timestamp: "2026-06-12T00:00:00.000Z",
+  };
+}
+
+describe("buildTransportOverlay — per-family non-empty fold (AC1)", () => {
+  for (const fx of TRANSPORT_FAMILY_FIXTURES) {
+    it(`${fx.family}: folds to a non-empty overlay (never hits default: [])`, () => {
+      const overlay = buildTransportOverlay([rowFor(fx.type, fx.payload)]);
+      expect(overlay.byKey.size).toBeGreaterThan(0);
+      const peer = overlayForStack(overlay, fx.peer.principal, fx.peer.stack);
+      expect(peer).not.toBeNull();
+    });
+  }
+
+  it("the underscore body a real envelope can never carry folds to EMPTY (default arm)", () => {
+    // Belt: proves the overlay's exact-match arms are what the respell fixed —
+    // the pre-fix underscore spelling is exactly the dead `default: return []`.
+    const overlay = buildTransportOverlay([
+      rowFor(toUnderscoreType(TRANSPORT_TYPES.leafConnect), { leaf: { principal: "jc", stack: "default" } }),
+    ]);
+    expect(overlay.byKey.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. AC2 — attention OPENS on leaf-disconnect, RESOLVES on leaf-connect.
+// ---------------------------------------------------------------------------
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+function attentionStatus(db: Database, id: string): string | null {
+  const row = db.query(`SELECT status FROM attention_items WHERE id = ?`).get(id) as
+    | { status: string }
+    | null;
+  return row?.status ?? null;
+}
+
+describe("produceObservabilityAttention — leaf open/resolve (AC2)", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("OPENS on system.transport.leaf-disconnect and RESOLVES on system.transport.leaf-connect", () => {
+    const opened = produceObservabilityAttention(db, {
+      type: TRANSPORT_TYPES.leafDisconnect,
+      payload: { leaf: "jc/default" },
+    });
+    expect(opened).toMatchObject({ action: "opened" });
+    expect(opened?.itemId.startsWith(`${ADAPTER_ATTENTION_PREFIX}transport:`)).toBe(true);
+    expect(attentionStatus(db, opened!.itemId)).toBe("open");
+
+    const resolved = produceObservabilityAttention(db, {
+      type: TRANSPORT_TYPES.leafConnect,
+      payload: { leaf: "jc/default" },
+    });
+    expect(resolved).toMatchObject({ action: "resolved" });
+    // Same origin id → same item → the open transitions to resolved.
+    expect(resolved?.itemId).toBe(opened?.itemId);
+    expect(attentionStatus(db, opened!.itemId)).toBe("resolved");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter-transport.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter-transport.test.ts
@@ -56,7 +56,7 @@ function foreignTile(
 function driftRow(principal: string, stack: string, to: string): TransportRosterEventRow {
   return {
     id: crypto.randomUUID(),
-    type: "system.transport.liveness_drift",
+    type: "system.transport.liveness-drift",
     stackId: "net",
     timestamp: "2026-06-12T00:00:00.000Z",
     payload: {
@@ -73,7 +73,7 @@ function driftRow(principal: string, stack: string, to: string): TransportRoster
 function connectRow(principal: string, stack: string, rtt: number): TransportRosterEventRow {
   return {
     id: crypto.randomUUID(),
-    type: "system.transport.leaf_connect",
+    type: "system.transport.leaf-connect",
     stackId: "net",
     timestamp: "2026-06-12T00:00:00.000Z",
     payload: {

--- a/src/surface/mc/dashboard-v2/__tests__/network-transport-overlay.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-transport-overlay.test.ts
@@ -47,7 +47,7 @@ function drift(
   over: Partial<TransportRosterEventRow> = {},
 ): TransportRosterEventRow {
   return row({
-    type: "system.transport.liveness_drift",
+    type: "system.transport.liveness-drift",
     payload: {
       action: "liveness_drift",
       network: NET,
@@ -66,7 +66,7 @@ function leafConnect(
   over: Partial<TransportRosterEventRow> = {},
 ): TransportRosterEventRow {
   return row({
-    type: "system.transport.leaf_connect",
+    type: "system.transport.leaf-connect",
     payload: {
       action: "leaf_connect",
       network: NET,
@@ -83,7 +83,7 @@ function leafDisconnect(
   over: Partial<TransportRosterEventRow> = {},
 ): TransportRosterEventRow {
   return row({
-    type: "system.transport.leaf_disconnect",
+    type: "system.transport.leaf-disconnect",
     payload: {
       action: "leaf_disconnect",
       network: NET,
@@ -180,7 +180,7 @@ describe("buildTransportOverlay — fold (U2.3)", () => {
     const o = buildTransportOverlay([
       drift("jc", "default", "registered-absent", { timestamp: "2026-06-12T00:00:03.000Z" }),
       row({
-        type: "system.transport.roster_snapshot",
+        type: "system.transport.roster-snapshot",
         timestamp: "2026-06-12T00:00:02.000Z",
         payload: { action: "roster_snapshot", network: NET, leaves: [] },
       }),
@@ -226,7 +226,7 @@ describe("buildTransportOverlay — fold (U2.3)", () => {
   it("folds a roster_snapshot's leaves into connected verdicts with RTT", () => {
     const o = buildTransportOverlay([
       row({
-        type: "system.transport.roster_snapshot",
+        type: "system.transport.roster-snapshot",
         payload: {
           action: "roster_snapshot",
           network: NET,
@@ -246,7 +246,7 @@ describe("buildTransportOverlay — fold (U2.3)", () => {
   it("a leaf_disconnect seeds registered-absent (a leaf vanished)", () => {
     const o = buildTransportOverlay([
       row({
-        type: "system.transport.leaf_disconnect",
+        type: "system.transport.leaf-disconnect",
         payload: {
           action: "leaf_disconnect",
           network: NET,
@@ -261,8 +261,8 @@ describe("buildTransportOverlay — fold (U2.3)", () => {
 
   it("skips unreadable rows (poison payload / unknown type) without throwing", () => {
     const o = buildTransportOverlay([
-      row({ type: "system.transport.liveness_drift", payload: {} }), // no attributes
-      row({ type: "system.transport.something_else", payload: { foo: 1 } }),
+      row({ type: "system.transport.liveness-drift", payload: {} }), // no attributes
+      row({ type: "system.transport.something-else", payload: { foo: 1 } }),
       drift("jc", "default", "connected"),
     ]);
     expect(o.byKey.size).toBe(1);

--- a/src/surface/mc/dashboard-v2/hooks/use-observability.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-observability.ts
@@ -13,7 +13,7 @@
  * boot fetch retries on the next open rather than wedging the tab.
  *
  * Live-oracle path: stopping the relay / a leaf publishes
- * `system.signal.collector.degraded` / `system.transport.leaf_disconnect`, the
+ * `system.signal.collector.degraded` / `system.transport.leaf-disconnect`, the
  * renderer projects them (+ opens an `att:adapter:` attention item) and broadcasts
  * the `observability` family — which lands here within one poll's debounce.
  */

--- a/src/surface/mc/dashboard-v2/lib/network-transport-overlay.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-transport-overlay.ts
@@ -18,10 +18,10 @@
  *
  *   | signal envelope `type`                | overlay verdict it asserts                |
  *   |---------------------------------------|-------------------------------------------|
- *   | `system.transport.liveness_drift`     | `payload.attributes.to` (the drift target)|
- *   | `system.transport.leaf_connect`       | `connected` (a leaf appeared)             |
- *   | `system.transport.leaf_disconnect`    | `registered-absent` (a leaf vanished)     |
- *   | `system.transport.roster_snapshot`    | each `leaves[]` entry → `connected`        |
+ *   | `system.transport.liveness-drift`     | `payload.attributes.to` (the drift target)|
+ *   | `system.transport.leaf-connect`       | `connected` (a leaf appeared)             |
+ *   | `system.transport.leaf-disconnect`    | `registered-absent` (a leaf vanished)     |
+ *   | `system.transport.roster-snapshot`    | each `leaves[]` entry → `connected`        |
  *
  * `liveness_drift` is authoritative for a peer (it's signal's reconciled verdict,
  * including the `unregistered-present` anomaly + `registered-absent` that the
@@ -160,7 +160,7 @@ function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
   const origin = row.origin;
 
   switch (row.type) {
-    case "system.transport.liveness_drift": {
+    case "system.transport.liveness-drift": {
       // Authoritative: signal's reconciled verdict. The peer + verdict ride
       // `attributes` (reconciler: { peer, principal, stack, from, to }).
       const attrs = asRecord(payload.attributes);
@@ -198,14 +198,14 @@ function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
         },
       ];
     }
-    case "system.transport.leaf_connect":
-    case "system.transport.leaf_disconnect": {
+    case "system.transport.leaf-connect":
+    case "system.transport.leaf-disconnect": {
       const leaf = asRecord(payload.leaf);
       const principal = asString(leaf.principal);
       const stack = asString(leaf.stack);
       const key = peerKey(principal, stack);
       if (key === null || principal === null || stack === null) return [];
-      const connect = row.type === "system.transport.leaf_connect";
+      const connect = row.type === "system.transport.leaf-connect";
       const live = leafLiveness(leaf);
       return [
         {
@@ -223,7 +223,7 @@ function candidatesForRow(row: TransportRosterEventRow): Candidate[] {
         },
       ];
     }
-    case "system.transport.roster_snapshot": {
+    case "system.transport.roster-snapshot": {
       const leaves = Array.isArray(payload.leaves) ? payload.leaves : [];
       const out: Candidate[] = [];
       for (const raw of leaves) {

--- a/src/surface/mc/projection/observability-attention.ts
+++ b/src/surface/mc/projection/observability-attention.ts
@@ -14,8 +14,8 @@
  *   - `system.signal.collector.recovered`          → RESOLVE it
  *   - `system.transport.backend.unreachable`       → OPEN  att:adapter:transport:{id}
  *   - `system.transport.backend.reachable`         → RESOLVE it
- *   - `system.transport.leaf_disconnect`           → OPEN  att:adapter:transport:{id}
- *   - `system.transport.leaf_connect`              → RESOLVE it
+ *   - `system.transport.leaf-disconnect`           → OPEN  att:adapter:transport:{id}
+ *   - `system.transport.leaf-connect`              → RESOLVE it
  *
  * The origin id keys the item: `collector_id` (collector family) or `backend` /
  * `leaf` / `node` (transport family), falling back to the family name so a
@@ -63,9 +63,9 @@ function classify(type: string): Mapping | null {
       return { opens: true, ns: "transport", idKeys: ["backend", "backend_id", "id"] };
     case "system.transport.backend.reachable":
       return { opens: false, ns: "transport", idKeys: ["backend", "backend_id", "id"] };
-    case "system.transport.leaf_disconnect":
+    case "system.transport.leaf-disconnect":
       return { opens: true, ns: "transport", idKeys: ["leaf", "node", "peer", "id"] };
-    case "system.transport.leaf_connect":
+    case "system.transport.leaf-connect":
       return { opens: false, ns: "transport", idKeys: ["leaf", "node", "peer", "id"] };
     default:
       return null;


### PR DESCRIPTION
## Summary

Signal's U0.4 canonicalisation maps subject-tail underscores to hyphens in `envelope.type` (the NATS **subject** keeps `leaf_connect`; the wire **body type** is `system.transport.leaf-connect`), but cortex's Mission-Control transport overlay (U2.3) and the transport arms of the observability-attention producer (U2.1) switched on the underscore spellings. Because cortex's vendored myelin schema forbids underscore types and validation runs **before** the router, those exact-match arms were unreachable against every real envelope — a silent zero. This respells the matchers to the hyphen forms, regenerates the fixtures from signal's canonical builder output, and adds an anti-drift `validateEnvelope` gate so an impossible underscore-typed fixture can never again pass a green suite. Backend/collector arms are deliberately left for cortex#1468; NATS subjects and `payload.action`/`namespace.action` keep their underscores by design.

Closes #1467

## Verification

All four gates green (run in a clean worktree off `origin/main` @ `5e39b77d`):

```
$ bun test src/surface/mc/ src/bus/agent-network/
 2368 pass
 1 skip        # pre-existing: dashboard SPA test needs a dist/ build artifact
 0 fail
 8167 expect() calls
Ran 2369 tests across 168 files.

$ bunx tsc --noEmit
TSC_EXIT=0   (no output)

$ bun run lint:errors
$ eslint --quiet .
LINT_EXIT=0

$ bash scripts/check-carveouts.sh          # vocab carve-out gate, whole-tree
check-carveouts: PASS — no ungated deprecated-term live violations
CARVE_EXIT=0
```

Acceptance-criteria greps:

```
$ git grep -nE '"system\.transport\.[a-z]+_' -- src/     # type-position underscores
(no output)

$ git grep -n 'predates the v2 reads' -- src/
(no output)

# remaining system.transport.*_* matches are ONLY the 3 fold-test SUBJECT literals
# (federated-observability-fold.test.ts :163/:291/:434) — correct by design.
```

Anti-drift demonstration (AC3 — "flip a fixture to underscore ⇒ FAIL, then revert"):

```
# after temporarily setting the leaf-connect fixture type to the underscore form:
error: validateEnvelope rejected canonical leaf-connect:
  [{"instancePath":"/type","schemaPath":"#/properties/type/pattern","keyword":"pattern",
    "params":{"pattern":"^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){1,4}$"}, ...}]
(fail) ... leaf-connect: the canonical hyphen-typed envelope PASSES validateEnvelope
# fixture reverted; suite green again (15 pass / 0 fail).
```

## Acceptance criteria

- [x] Per-family: a canonical hyphen-typed row drives `buildTransportOverlay` to non-empty output (no family hits `default`). New per-family tests in `signal-transport-envelopes.test.ts`.
- [x] `produceObservabilityAttention` opens on `system.transport.leaf-disconnect`, resolves on `system.transport.leaf-connect`.
- [x] Fixture envelopes pass `validateEnvelope` per family; flipping one to the underscore form FAILS the suite (demonstrated above, reverted).
- [x] `git grep -nE '"system\.transport\.[a-z]+_' -- src/` → no matches.
- [x] `src/common/sideband/metrics.ts` header no longer claims the doc predates the v2 reads; cites §2.5/§2.6 (signal#152).
- [x] `bun test`, `bunx tsc --noEmit`, `bun run lint:errors`, `bash scripts/check-carveouts.sh` all pass.

## Out of scope (untouched, per the issue)

`system.transport.backend.{unreachable,reachable}` + collector recovery arms (cortex#1468), `server-vitals` strip (cortex#1469), durability (cortex#1470), signal-side emitters (signal#166), the subject-leaf migration proposal (myelin#215).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
