### PR TITLE
chore(deps): bump myelin to v0.5.0 (7c6b71e)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@octokit/webhooks-methods": "^6.0.0",
         "@slack/socket-mode": "^2.0.7",
         "@slack/web-api": "^7.16.0",
-        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#f5ec8658030e2fc185f123b06d8bf94d9f74cd84",
+        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#7c6b71e9e16286d42ba6038d0be3ab30c498da39",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -80,7 +80,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c", "sha512-PlffOgC1qoiqomRUVIM3nSE61q0VigytzlOMNcyKlmZT8r7cAgR7+vLQgSbVxNfrFoZVAmx0kgKF6TQnT5UNag=="],
+    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c"],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
@@ -126,7 +126,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#f5ec865", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-f5ec865", "sha512-Uu/giX/FcCwBPrVce/MYWqcx5y7wWK11trpi2wc+a7Jl52hd93vzoluEJlcpqmtQqIPRXMVPtRjlcMnUBuhWcw=="],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#7c6b71e", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/nats-core": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-7c6b71e"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@octokit/webhooks-methods": "^6.0.0",
     "@slack/socket-mode": "^2.0.7",
     "@slack/web-api": "^7.16.0",
-    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#f5ec8658030e2fc185f123b06d8bf94d9f74cd84",
+    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#7c6b71e9e16286d42ba6038d0be3ab30c498da39",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -612,7 +612,7 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     // no longer dual-reads) ships here per
     // docs/migrations/0002-vocabulary-finish-2026-05.md §R10.
     expect(SCHEMA_SOURCE_COMMIT).toBe(
-      "f5ec8658030e2fc185f123b06d8bf94d9f74cd84",
+      "7c6b71e9e16286d42ba6038d0be3ab30c498da39",
     );
   });
 

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -76,7 +76,7 @@ import schema from "./vendor/envelope.schema.json" with { type: "json" };
  * comments + tests use `myelin#161` to point at the merge that landed the
  * feature — they're the same change, different ticket facets.
  */
-export const SCHEMA_SOURCE_COMMIT = "f5ec8658030e2fc185f123b06d8bf94d9f74cd84";
+export const SCHEMA_SOURCE_COMMIT = "7c6b71e9e16286d42ba6038d0be3ab30c498da39";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather

--- a/src/bus/myelin/vendor/envelope.schema.json
+++ b/src/bus/myelin/vendor/envelope.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://myelin.metafactory.ai/schemas/envelope/v3",
   "title": "Myelin Envelope",
-  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message. v3 (vocabulary migration 2026-05, breaking cuts myelin#182 + myelin#183): `signed_by[].principal` → `identity` (myelin#182 — old key dropped from the wire) and `{org}` → `{principal}` with the `source` grammar tightened to the fixed-3 form `{principal}.{stack}.{assistant}` (myelin#183 — legacy 3–5 segment `org.agent.instance` shape no longer accepted; that was the shape the pilot review-loop bug exploited, see CONTEXT.md line 99). v3.0 (vocabulary migration 2026-05, breaking cut myelin#184): `target_principal` → `target_assistant` (R13 — old key dropped from the wire; direct/delegate envelopes carrying it are rejected by `additionalProperties: false`). The schema still accepts the deprecated form for the remaining transition fields (originator `principal`, distribution_mode `broadcast`) so pre-migration / JetStream-replayed envelopes validate; subsequent breaking cuts drop those. v2 stays published for consumers pinned to the transition grammar; v1 stays published for consumers pinned to the pre-migration grammar.",
+  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message. v3 (vocabulary migration 2026-05, breaking cuts myelin#182 + myelin#183): `signed_by[].principal` → `identity` (myelin#182 — old key dropped from the wire) and `{org}` → `{principal}` with the `source` grammar tightened to the fixed-3 form `{principal}.{stack}.{assistant}` (myelin#183 — legacy 3–5 segment `org.agent.instance` shape no longer accepted; that was the shape the pilot review-loop bug exploited, see CONTEXT.md line 99). R13 breaking cut: `target_principal` → `target_assistant` — the deprecated `target_principal` key is removed from the wire (rejected by `additionalProperties: false`); the `@`-target of a Tasks-Domain subject names an assistant, not a principal (see CONTEXT.md). The schema still accepts the deprecated form for the remaining transition fields (originator, distribution_mode broadcast) so pre-migration / JetStream-replayed envelopes validate; subsequent breaking cuts drop those. v2 stays published for consumers pinned to the transition grammar; v1 stays published for consumers pinned to the pre-migration grammar.",
   "type": "object",
   "required": ["id", "source", "type", "timestamp", "sovereignty", "payload"],
   "properties": {
@@ -27,6 +27,11 @@
       "type": "string",
       "format": "date-time",
       "description": "ISO-8601 timestamp of envelope creation."
+    },
+    "spec_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional wire grammar version (B1 rollout). 3 = current grammar; absent ⇒ legacy pre-field envelope. A SIGNABLE field. Phase 4a: accepted and signed when present, but not yet emitted by createEnvelope (verifiers before emitters)."
     },
     "correlation_id": {
       "type": "string",


### PR DESCRIPTION
## Summary

Bumps `@the-metafactory/myelin` from `f5ec865` to **v0.5.0** (commit `7c6b71e9e16286d42ba6038d0be3ab30c498da39`). Mechanical dependency bump — no feature/logic changes. Part of myelin's remediation plan (task G1).

### Why a SHA, not the `#v0.5.0` tag
cortex's vendored-schema drift guard (`src/bus/myelin/__tests__/envelope-validator.test.ts`) extracts a **40-char SHA** from the package.json myelin ref via `/#([0-9a-f]{40})$/` and asserts it equals `SCHEMA_SOURCE_COMMIT`. A tag ref has no SHA to extract, so the SHA form is required by design. Commit `7c6b71e` **is** v0.5.0 (`git rev-parse v0.5.0`), so this is semantically identical to the tag while keeping the drift guard intact.

## Changes
- `package.json` — myelin ref `#f5ec865` → `#7c6b71e9…`
- `bun.lock` — resolved to `#7c6b71e`
- `src/bus/myelin/vendor/envelope.schema.json` — **re-vendored** from myelin@7c6b71e (byte-identical to source). Only delta vs f5ec865: additive optional `spec_version` field (integer, minimum 1) — non-breaking.
- `src/bus/myelin/envelope-validator.ts` — `SCHEMA_SOURCE_COMMIT` → `7c6b71e9…`
- `src/bus/myelin/__tests__/envelope-validator.test.ts` — lockstep drift-guard constant → `7c6b71e9…`

No source/test vocabulary renames were needed: the myelin `Identity` `operator`→`network` rename was already complete in cortex, and `tsc` (which includes test files) is clean. Remaining `operator:` occurrences in the tree are cortex's own NATS/config vocabulary, unrelated to myelin.

## Verification
**`bunx tsc --noEmit`** → exit 0 (clean; program includes 462 `.test.ts` files).

**Drift-guard test** (`bun test src/bus/myelin/__tests__/envelope-validator.test.ts`):
```
61 pass  0 fail  105 expect() calls
```

**Full suite** (`bun test`):
```
8617 pass  7 skip  8 todo  1 fail  (8633 tests across 505 files)
```
The single fail — `check-carveouts vocab ratchet (F18) > whole-tree scan is green` — is **pre-existing and unrelated to this bump**: the whole-tree scan flags the untracked working-tree file `docs/federation-join-issues-2026-06-26.md` (present before this branch, not part of this PR). The `ConfigWatcher github.repos hot-reload` timing test is intermittently flaky under full-suite parallelism (passes in isolation) and is likewise unrelated. No new failures are attributable to the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)