### PR TITLE
feat(network): C-1484 — cortex network doctor <net> (epic #1479 slice 5)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-doctor-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-cli.test.ts
@@ -1,0 +1,245 @@
+/**
+ * CLI-level tests for `cortex network doctor` (cortex#1484, epic #1479).
+ *
+ * Drives `dispatchNetwork(["doctor", ...], fakeReader, ...defaults, doctorPortsFactory)`
+ * with an injected fake config reader AND an injected fake doctor-ports
+ * factory — no NATS, no `~/.config`, no live wire, no fs. Mirrors
+ * `network-ping-cli.test.ts`'s `fakeBusFactory`/`readerWithPeer` pattern:
+ * dispatch-level factory injection, not a real `runDoctorChecks` call (that's
+ * covered end-to-end by `network-doctor-lib.test.ts`).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { dispatchNetwork, type DoctorPortsFactory } from "../network";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+import type { NetworkDoctorPorts } from "../network-doctor-ports";
+import type { DoctorCheck } from "../network-doctor-lib";
+import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
+import { PROBE_REPLY_ECHO_TYPE } from "../../../../bus/probe-responder";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** A reader returning a minimal config — `dispatchNetwork`'s injected
+ *  doctor-ports factory supplies the canned checks, so the config content
+ *  only needs to satisfy `--principal` resolution + `derivePingInputs`. */
+function reader(): () => LoadedConfig {
+  return () =>
+    ({
+      config: { nats: { url: "nats://127.0.0.1:4222" } } as unknown as AgentConfig,
+      inlineAgents: [{ id: "sage" } as unknown as LoadedConfig["inlineAgents"][number]],
+      principal: { id: "andreas" },
+      stack: { id: "andreas/community" },
+      policy: {
+        federated: {
+          networks: [
+            {
+              id: "metafactory-community",
+              peers: [{ principal_id: "jc", stack_id: "jc/default" }],
+            } as unknown as NonNullable<
+              NonNullable<LoadedConfig["policy"]>["federated"]
+            >["networks"][number],
+          ],
+        },
+      } as unknown as LoadedConfig["policy"],
+    });
+}
+
+/** A fake doctor-ports factory that hands back a CANNED ports bundle (unused
+ *  by these CLI-level tests beyond satisfying the type — the checks
+ *  themselves are asserted via `network-doctor-lib.test.ts`). Records
+ *  invocation + stop, so the CLI test can assert the factory lifecycle. */
+function fakeDoctorFactory(): {
+  factory: DoctorPortsFactory;
+  invoked: () => boolean;
+  stopped: () => boolean;
+} {
+  let wasInvoked = false;
+  let wasStopped = false;
+  const ports: NetworkDoctorPorts = {
+    config: {
+      readNetworks: () => ({
+        networks: [
+          {
+            id: "metafactory-community",
+            leaf_node: "hub",
+            peers: [{ principal_id: "jc", stack_id: "jc/default" }],
+            accept_subjects: ["federated.>"],
+            deny_subjects: [],
+          } as unknown as PolicyFederatedNetwork,
+        ],
+      }),
+      expectedFedAccount: () => "ACCOUNT_A",
+    },
+    monitor: {
+      resolve: () => ({ url: "http://127.0.0.1:8222", configured: true }),
+      fetchLeafz: async () => ({
+        leafs: [{ name: "hub", account: "ACCOUNT_A", in_msgs: 3, out_msgs: 4 }],
+      }),
+    },
+    probe: {
+      bus: {
+        fireProbe: async (f) => ({
+          kind: "reply",
+          rttMs: 12,
+          reply: {
+            id: crypto.randomUUID(),
+            source: "jc.default.sage",
+            type: PROBE_REPLY_ECHO_TYPE,
+            timestamp: "2026-07-03T00:00:00.000Z",
+            correlation_id: f.correlationId,
+            sovereignty: {
+              classification: "federated",
+              data_residency: "NZ",
+              max_hop: 1,
+              frontier_ok: false,
+              model_class: "local-only",
+            },
+            payload: {
+              nonce: (f.request.payload as { nonce: string }).nonce,
+              server_ts: "2026-07-03T00:00:00.000Z",
+              responder_version: "1.0.0",
+            },
+          },
+        }),
+      },
+      newNonce: () => "nonce-1",
+      newCorrelationId: () => "corr-1",
+    },
+  };
+  const factory: DoctorPortsFactory = async () => {
+    wasInvoked = true;
+    return {
+      ports,
+      stop: async () => {
+        wasStopped = true;
+      },
+    };
+  };
+  return { factory, invoked: () => wasInvoked, stopped: () => wasStopped };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cortex network doctor — happy path", () => {
+  test("healthy — exit 0, human output lists every leg + the verdict", async () => {
+    const doctor = fakeDoctorFactory();
+    const res = await dispatchNetwork(
+      ["doctor", "metafactory-community", "--principal", "andreas"],
+      reader(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      doctor.factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex network doctor metafactory-community:");
+    expect(res.stdout).toContain("config-network");
+    expect(res.stdout).toContain("peer-reachable:jc/default");
+    expect(res.stdout).toContain("verdict: healthy");
+    expect(doctor.invoked()).toBe(true);
+    expect(doctor.stopped()).toBe(true);
+  });
+
+  test("--json emits the envelope with per-check rows + verdict", async () => {
+    const doctor = fakeDoctorFactory();
+    const res = await dispatchNetwork(
+      ["doctor", "metafactory-community", "--principal", "andreas", "--json"],
+      reader(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      doctor.factory,
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as {
+      status: string;
+      items: DoctorCheck[];
+      data: { network: string; verdict: string };
+    };
+    expect(parsed.status).toBe("ok");
+    expect(parsed.data.network).toBe("metafactory-community");
+    expect(parsed.data.verdict).toBe("healthy");
+    expect(parsed.items.some((c) => c.id === "config-network" && c.status === "pass")).toBe(true);
+    expect(
+      parsed.items.some((c) => c.id === "peer-reachable:jc/default" && c.status === "pass"),
+    ).toBe(true);
+    for (const item of parsed.items) {
+      expect(["member", "hub-owner", "admin", "peer"]).toContain(item.owner);
+    }
+  });
+});
+
+describe("cortex network doctor — degraded/broken exit codes", () => {
+  test("a fail leg drives a non-zero exit code, and the report goes to stderr", async () => {
+    let wasInvoked = false;
+    const ports: NetworkDoctorPorts = {
+      config: {
+        readNetworks: () => ({ networks: [] }), // network not configured ⇒ broken
+        expectedFedAccount: () => undefined,
+      },
+      monitor: {
+        resolve: () => ({ url: "http://127.0.0.1:8222", configured: true }),
+        fetchLeafz: async () => undefined,
+      },
+      probe: {
+        bus: { fireProbe: async () => ({ kind: "timeout" }) },
+        newNonce: () => "n",
+        newCorrelationId: () => "c",
+      },
+    };
+    const factory: DoctorPortsFactory = async () => {
+      wasInvoked = true;
+      return { ports, stop: async () => {} };
+    };
+    const res = await dispatchNetwork(
+      ["doctor", "metafactory-community", "--principal", "andreas"],
+      reader(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      factory,
+    );
+    expect(wasInvoked).toBe(true);
+    expect(res.exitCode).toBe(2); // DOCTOR_EXIT_CODE.broken
+    expect(res.stdout).toBe("");
+    expect(res.stderr).toContain("config-network");
+    expect(res.stderr).toContain("verdict: broken");
+  });
+});
+
+describe("cortex network doctor — usage", () => {
+  test("missing --principal is a usage error (exit 2)", async () => {
+    const doctor = fakeDoctorFactory();
+    const res = await dispatchNetwork(
+      ["doctor", "metafactory-community"],
+      reader(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      doctor.factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--principal");
+    expect(doctor.invoked()).toBe(false); // never builds ports on a usage error
+  });
+
+  test("top-level help mentions doctor", async () => {
+    const res = await dispatchNetwork(["--help"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex network doctor");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Tests for the `cortex network doctor` orchestration (cortex#1484, epic #1479).
+ *
+ * Drives `runDoctorChecks` with FAKE ports (a fake config port, a fake
+ * monitor port, and the SAME fake probe-bus shape `network-ping-lib.test.ts`
+ * uses) — no fs, no NATS, no HTTP, no live wire.
+ *
+ * Close-criteria (per the acceptance's check matrix):
+ *   (a) all-green — every leg pass, verdict healthy, exit 0.
+ *   (b) network-not-in-config — config-network fails, downstream legs skip.
+ *   (c) no monitor configured — monitor-reachable warns (not fails); leaf
+ *       checks skip; peer-reachable is unaffected (doesn't need /leafz).
+ *   (d) leaf down — leaf-established fails (a hard prerequisite ⇒ broken).
+ *   (e) peer timeout — peer-reachable fails with the ping timeout verdict.
+ *
+ * Plus a few extra legs (leaf-account-bound mismatch/report-only, a
+ * partial-peer-failure "degraded" verdict) since the orchestrator owns both
+ * the implementation and these tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Envelope } from "../../../../bus/myelin/envelope-validator";
+import { PROBE_REPLY_ECHO_TYPE } from "../../../../bus/probe-responder";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
+import {
+  DOCTOR_EXIT_CODE,
+  runDoctorChecks,
+  type DoctorCheck,
+} from "../network-doctor-lib";
+import type {
+  DoctorConfigPort,
+  LeafzResponse,
+  NetworkDoctorPorts,
+} from "../network-doctor-ports";
+import type {
+  NetworkPingPorts,
+  ProbeFireInputs,
+  ProbeRoundTripResult,
+} from "../network-ping-ports";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function loadedConfig(peers: { principal_id: string; stack_id: string }[]): LoadedConfig {
+  return {
+    config: { nats: { url: "nats://127.0.0.1:4222" } } as unknown as AgentConfig,
+    inlineAgents: [{ id: "luna" } as unknown as LoadedConfig["inlineAgents"][number]],
+    principal: { id: "andreas" },
+    stack: { id: "andreas/community" },
+    policy: {
+      federated: {
+        networks: [
+          {
+            id: "metafactory-community",
+            peers,
+          } as unknown as NonNullable<
+            NonNullable<LoadedConfig["policy"]>["federated"]
+          >["networks"][number],
+        ],
+      },
+    } as unknown as LoadedConfig["policy"],
+  };
+}
+
+function network(overrides: Partial<PolicyFederatedNetwork> = {}): PolicyFederatedNetwork {
+  return {
+    id: "metafactory-community",
+    leaf_node: "hub",
+    peers: [{ principal_id: "jc", stack_id: "jc/default" }],
+    accept_subjects: ["federated.>"],
+    deny_subjects: [],
+    ...overrides,
+  } as unknown as PolicyFederatedNetwork;
+}
+
+function fakeConfigPort(
+  networks: PolicyFederatedNetwork[],
+  expectedAccount?: string,
+): DoctorConfigPort {
+  return {
+    readNetworks: () => ({ networks }),
+    expectedFedAccount: () => expectedAccount,
+  };
+}
+
+function fakeMonitorPort(opts: {
+  configured: boolean;
+  leafz?: LeafzResponse;
+  url?: string;
+}): NetworkDoctorPorts["monitor"] {
+  return {
+    resolve: () => ({ url: opts.url ?? "http://127.0.0.1:8222", configured: opts.configured }),
+    fetchLeafz: async () => opts.leafz,
+  };
+}
+
+/** A fake probe-bus port (the exact `NetworkPingPorts` shape `pingPeer` consumes). */
+function fakeProbe(
+  respond: (fired: ProbeFireInputs, seq: number) => ProbeRoundTripResult,
+): NetworkPingPorts {
+  let seq = 0;
+  return {
+    bus: {
+      fireProbe: async (f) => {
+        seq++;
+        return respond(f, seq);
+      },
+    },
+    newNonce: () => `nonce-${seq}`,
+    newCorrelationId: () => `corr-${seq}`,
+  };
+}
+
+/** Build a conformant echo reply for a fired probe (mock responder). */
+function echoReply(fired: ProbeFireInputs, rttMs: number): ProbeRoundTripResult {
+  const reqPayload = fired.request.payload as { nonce: string; seq?: number };
+  const reply: Envelope = {
+    id: crypto.randomUUID(),
+    source: "jc.default.sage",
+    type: PROBE_REPLY_ECHO_TYPE,
+    timestamp: "2026-07-03T00:00:00.000Z",
+    correlation_id: fired.correlationId,
+    sovereignty: {
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 1,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: {
+      nonce: reqPayload.nonce,
+      server_ts: "2026-07-03T00:00:00.000Z",
+      responder_version: "1.0.0",
+      ...(reqPayload.seq !== undefined && { seq: reqPayload.seq }),
+    },
+  };
+  return { kind: "reply", rttMs, reply };
+}
+
+function findCheck(checks: DoctorCheck[], id: string): DoctorCheck {
+  const c = checks.find((x) => x.id === id);
+  if (c === undefined) throw new Error(`no check with id "${id}" in ${JSON.stringify(checks.map((x) => x.id))}`);
+  return c;
+}
+
+const ESTABLISHED_LEAFZ: LeafzResponse = {
+  leafs: [{ name: "hub", account: "ACCOUNT_A", in_msgs: 10, out_msgs: 12 }],
+};
+
+// ---------------------------------------------------------------------------
+// (a) all-green
+// ---------------------------------------------------------------------------
+
+describe("runDoctorChecks — (a) all-green", () => {
+  test("every leg passes, verdict healthy, exit 0", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 41)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    expect(res.verdict).toBe("healthy");
+    expect(res.exitCode).toBe(0);
+    expect(res.exitCode).toBe(DOCTOR_EXIT_CODE.healthy);
+    expect(res.checks).toHaveLength(5);
+    expect(findCheck(res.checks, "config-network").status).toBe("pass");
+    expect(findCheck(res.checks, "monitor-reachable").status).toBe("pass");
+    expect(findCheck(res.checks, "leaf-established").status).toBe("pass");
+    expect(findCheck(res.checks, "leaf-account-bound").status).toBe("pass");
+    const peerCheck = findCheck(res.checks, "peer-reachable:jc/default");
+    expect(peerCheck.status).toBe("pass");
+    expect(peerCheck.owner).toBe("peer");
+    expect(peerCheck.detail).toContain("rtt=41ms");
+    // Every check carries a responsible owner.
+    for (const c of res.checks) {
+      expect(["member", "hub-owner", "admin", "peer"]).toContain(c.owner);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) network-not-in-config
+// ---------------------------------------------------------------------------
+
+describe("runDoctorChecks — (b) network-not-in-config", () => {
+  test("config-network fails; downstream legs skip; no peer checks; verdict broken", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([]), // the requested network isn't configured at all
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    expect(findCheck(res.checks, "config-network").status).toBe("fail");
+    expect(findCheck(res.checks, "config-network").fix).toContain("join the network");
+    expect(findCheck(res.checks, "monitor-reachable").status).toBe("skip");
+    expect(findCheck(res.checks, "leaf-established").status).toBe("skip");
+    expect(findCheck(res.checks, "leaf-account-bound").status).toBe("skip");
+    expect(res.checks.some((c) => c.id.startsWith("peer-reachable:"))).toBe(false);
+    expect(res.verdict).toBe("broken");
+    expect(res.exitCode).toBe(DOCTOR_EXIT_CODE.broken);
+  });
+
+  test("a network with zero peers[] also fails config-network", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network({ peers: [] })]),
+      monitor: fakeMonitorPort({ configured: true }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "config-network").status).toBe("fail");
+    expect(findCheck(res.checks, "config-network").detail).toContain("no peers[]");
+  });
+
+  test("a network with empty accept_subjects[] also fails config-network", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network({ accept_subjects: [] })]),
+      monitor: fakeMonitorPort({ configured: true }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "config-network").status).toBe("fail");
+    expect(findCheck(res.checks, "config-network").detail).toContain("accept_subjects");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) no monitor configured → warn, not fail
+// ---------------------------------------------------------------------------
+
+describe("runDoctorChecks — (c) no monitor configured", () => {
+  test("monitor-reachable warns; leaf legs skip; peer-reachable is unaffected", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()]),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 30)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    const monitorCheck = findCheck(res.checks, "monitor-reachable");
+    expect(monitorCheck.status).toBe("warn");
+    expect(monitorCheck.fix).toContain("http_port/monitor_port");
+    expect(findCheck(res.checks, "leaf-established").status).toBe("skip");
+    expect(findCheck(res.checks, "leaf-account-bound").status).toBe("skip");
+    // The echo round-trip does not depend on /leafz — it still runs + passes.
+    expect(findCheck(res.checks, "peer-reachable:jc/default").status).toBe("pass");
+    // A warn never blocks "healthy" — only fails do.
+    expect(res.verdict).toBe("healthy");
+    expect(res.exitCode).toBe(0);
+  });
+
+  test("a configured-but-unreachable monitor FAILS (distinct from absent)", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()]),
+      monitor: fakeMonitorPort({ configured: true, leafz: undefined }), // fetch failed
+      probe: fakeProbe((f) => echoReply(f, 30)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "monitor-reachable").status).toBe("fail");
+    expect(findCheck(res.checks, "leaf-established").status).toBe("skip");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) leaf down
+// ---------------------------------------------------------------------------
+
+describe("runDoctorChecks — (d) leaf down", () => {
+  test("leaf-established fails (no matching/established leaf in /leafz); verdict broken", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()]),
+      monitor: fakeMonitorPort({ configured: true, leafz: { leafs: [] } }),
+      probe: fakeProbe(() => ({ kind: "timeout" })),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    const leafCheck = findCheck(res.checks, "leaf-established");
+    expect(leafCheck.status).toBe("fail");
+    expect(leafCheck.owner).toBe("hub-owner");
+    expect(leafCheck.fix).toContain("leaf not up");
+    expect(findCheck(res.checks, "leaf-account-bound").status).toBe("skip");
+    // leaf-established is a CRITICAL check — its failure makes the network
+    // fundamentally broken regardless of the peer-reachable outcome.
+    expect(res.verdict).toBe("broken");
+    expect(res.exitCode).toBe(DOCTOR_EXIT_CODE.broken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (e) peer timeout
+// ---------------------------------------------------------------------------
+
+describe("runDoctorChecks — (e) peer timeout", () => {
+  test("peer-reachable fails with the ping timeout verdict + a peer/hub fix", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe(() => ({ kind: "timeout" })),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    const peerCheck = findCheck(res.checks, "peer-reachable:jc/default");
+    expect(peerCheck.status).toBe("fail");
+    expect(peerCheck.owner).toBe("peer");
+    expect(peerCheck.fix).toContain("peer/hub");
+    // config-network + leaf-established both pass, but the single configured
+    // peer is entirely unreachable ⇒ the federation path is broken.
+    expect(res.verdict).toBe("broken");
+    expect(res.exitCode).toBe(DOCTOR_EXIT_CODE.broken);
+  });
+
+  test("partial peer failure (one of two peers times out) ⇒ degraded, not broken", async () => {
+    const twoPeerNetwork = network({
+      peers: [
+        { principal_id: "jc", stack_id: "jc/default" },
+        { principal_id: "andreas", stack_id: "andreas/community" },
+      ] as unknown as PolicyFederatedNetwork["peers"],
+    });
+    let calls = 0;
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([twoPeerNetwork], "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => {
+        calls++;
+        return calls === 1 ? { kind: "timeout" } : echoReply(f, 20);
+      }),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([
+        { principal_id: "jc", stack_id: "jc/default" },
+        { principal_id: "andreas", stack_id: "andreas/community" },
+      ]),
+      networkId: "metafactory-community",
+    });
+
+    expect(res.checks.filter((c) => c.id.startsWith("peer-reachable:"))).toHaveLength(2);
+    expect(res.verdict).toBe("degraded");
+    expect(res.exitCode).toBe(DOCTOR_EXIT_CODE.degraded);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// leaf-account-bound — mismatch fails, undeterminable degrades to warn
+// ---------------------------------------------------------------------------
+
+describe("runDoctorChecks — leaf-account-bound", () => {
+  test("mismatched account FAILS", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_EXPECTED"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }), // reports ACCOUNT_A
+      probe: fakeProbe((f) => echoReply(f, 10)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const accountCheck = findCheck(res.checks, "leaf-account-bound");
+    expect(accountCheck.status).toBe("fail");
+    expect(accountCheck.detail).toContain("ACCOUNT_A");
+    expect(accountCheck.detail).toContain("ACCOUNT_EXPECTED");
+  });
+
+  test("undeterminable expected account degrades to warn/report-only", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], undefined), // not derivable
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 10)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const accountCheck = findCheck(res.checks, "leaf-account-bound");
+    expect(accountCheck.status).toBe("warn");
+    expect(accountCheck.detail).toContain("ACCOUNT_A");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
@@ -313,6 +313,38 @@ describe("runDoctorChecks — (d) leaf down", () => {
 });
 
 // ---------------------------------------------------------------------------
+// (d2) lone-leaf fallback is an HONEST warn, not a silent pass
+// ---------------------------------------------------------------------------
+
+describe("runDoctorChecks — (d2) lone-leaf fallback", () => {
+  test("a single leaf whose name/account doesn't match leaf_node → leaf-established WARN (discloses the assumption), not a silent pass", async () => {
+    // One leaf, name "$G" (≠ leaf_node "hub"); account still "ACCOUNT_A" so
+    // only leaf-established is affected (leaf-account-bound stays a pass).
+    const LONE_UNNAMED: LeafzResponse = {
+      leafs: [{ name: "$G", account: "ACCOUNT_A", in_msgs: 3, out_msgs: 4 }],
+    };
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: LONE_UNNAMED }),
+      probe: fakeProbe((f) => echoReply(f, 20)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    const leaf = findCheck(res.checks, "leaf-established");
+    expect(leaf.status).toBe("warn");
+    expect(leaf.detail).toContain("assumed the sole leaf");
+    expect(leaf.owner).toBe("member");
+    // downstream leaf-account-bound still runs (established leaf was returned)
+    expect(findCheck(res.checks, "leaf-account-bound").status).toBe("pass");
+    // a warn is advisory — it must NOT make the verdict broken
+    expect(res.verdict).not.toBe("broken");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // (e) peer timeout
 // ---------------------------------------------------------------------------
 

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -1035,8 +1035,12 @@ export const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 5000;
  *      so a non-default bus (the community :8224) is probed on its OWN port;
  *   3. the upstream default `:8222`.
  * The config read is best-effort (a missing/unreadable file just falls through).
+ *
+ * Exported (cortex#1484) so `network-doctor-adapters.ts` reuses the IDENTICAL
+ * precedence + `configured` signal for its `monitor-reachable` check instead
+ * of re-deriving it.
  */
-function resolveMonitorBase(cfg: LivePortsConfig): { url: string; configured: boolean } {
+export function resolveMonitorBase(cfg: LivePortsConfig): { url: string; configured: boolean } {
   // #831 — `configured` says whether THIS bus actually declares a monitor
   // (explicit `--monitor-url` or an `http_port`/`monitor` in its nats config),
   // vs falling back to the upstream default `:8222`. The health probe uses it to

--- a/src/cli/cortex/commands/network-doctor-adapters.ts
+++ b/src/cli/cortex/commands/network-doctor-adapters.ts
@@ -1,0 +1,129 @@
+/**
+ * `cortex network doctor` — LIVE adapters (cortex#1484, epic #1479).
+ *
+ * Wires the real stack config file, the local nats-server HTTP monitor, and
+ * (via `createLiveProbeBus` in `network-ping-adapters.ts`) the real
+ * `MyelinRuntime` into the {@link NetworkDoctorPorts} the pure orchestrator
+ * (`network-doctor-lib.ts`) depends on. Constructed only on a real `cortex
+ * network doctor` invocation; tests inject fakes and never reach this file.
+ *
+ * READ-ONLY: `buildDoctorConfigPort` only reads `policy.federated.networks[]`
+ * (`readNetworksFromConfig`, the same reader join/leave/rotate-key use) and,
+ * best-effort, the rendered per-network leaf-include file; `buildMonitorPort`
+ * only GETs `/leafz`. Neither ever writes. `doctor` never mutates config,
+ * files, or services — its one live effect is the bounded probe echo the
+ * caller wires separately via `createLiveProbeBus`/`wrapRuntimeAsProbeBus`
+ * (reused verbatim from `network-ping-adapters.ts`, not re-implemented).
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+
+import { expandTilde } from "../../../common/config/loader";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import { leafIncludeFileName } from "../../../common/nats/leaf-remote-renderer";
+import {
+  resolveMonitorBase,
+  DEFAULT_HEALTH_PROBE_TIMEOUT_MS,
+  type LivePortsConfig,
+} from "./network-adapters";
+import type {
+  DoctorConfigPort,
+  DoctorNetworksSnapshot,
+  LeafzResponse,
+  MonitorPort,
+} from "./network-doctor-ports";
+
+/** Bound the `/leafz` probe so a hung monitor cannot stall `doctor` forever. */
+export const DEFAULT_LEAFZ_TIMEOUT_MS = DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
+
+/** Inputs {@link buildDoctorConfigPort} needs — a subset of {@link LivePortsConfig}. */
+export interface DoctorConfigAdapterConfig {
+  /** The COMPOSED `policy.federated.networks[]` from the loaded config — read
+   *  off the `LoadedConfig` the caller already built (the same source
+   *  `derivePingInputs` uses), NOT re-parsed off the raw `--config` file. This
+   *  is load-bearing for the config-split layout (#814): `policy.federated`
+   *  lives in `stacks/<slug>.yaml`, so re-reading the pointer file directly
+   *  would find zero networks. */
+  networks: PolicyFederatedNetwork[];
+  /** The stack's nats config path — used to locate the per-network leaf-include
+   *  file (`leafnodes-<network>.conf`) beside it for the account derivation. */
+  natsConfigPath?: string;
+}
+
+/**
+ * The live {@link DoctorConfigPort}: `readNetworks()` returns the COMPOSED
+ * `policy.federated.networks[]` (handling both the config-split and monolithic
+ * layouts the daemon loads); `expectedFedAccount()` best-effort parses the
+ * rendered per-network leaf-include file's `account:` line, when one exists on
+ * disk. Never throws.
+ */
+export function buildDoctorConfigPort(cfg: DoctorConfigAdapterConfig): DoctorConfigPort {
+  return {
+    readNetworks(): DoctorNetworksSnapshot {
+      return { networks: cfg.networks };
+    },
+
+    expectedFedAccount(networkId: string): string | undefined {
+      const natsConfigPath = expandTilde(cfg.natsConfigPath ?? "");
+      if (natsConfigPath.length === 0) return undefined;
+
+      let fileName: string;
+      try {
+        fileName = leafIncludeFileName(networkId);
+      } catch (_err) {
+        // Invalid network-id shape — nothing to derive; the check degrades to
+        // warn/report-only (undefined ⇒ "not derivable"). Safe to ignore.
+        return undefined;
+      }
+
+      const includePath = join(dirname(natsConfigPath), fileName);
+      if (!existsSync(includePath)) return undefined;
+
+      let text: string;
+      try {
+        text = readFileSync(includePath, "utf-8");
+      } catch (err) {
+        process.stderr.write(
+          `network-doctor-adapters: could not read leaf include ${includePath}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        return undefined;
+      }
+      // The include file is rendered by `serializeRemote` (leaf-remote-renderer.ts)
+      // — a bare `account: <nkey-U>` line, unquoted, when the leaf is
+      // operator-mode-bound. Absent entirely for a `$G`/default-bus remote.
+      const m = /^\s*account:\s*(\S+)/m.exec(text);
+      return m?.[1];
+    },
+  };
+}
+
+/**
+ * The live {@link MonitorPort}: resolves the monitor base via the SAME
+ * `resolveMonitorBase` precedence `status`/join's health-probe use, and
+ * fetches `/leafz` with a bounded timeout.
+ */
+export function buildMonitorPort(cfg: LivePortsConfig): MonitorPort {
+  return {
+    resolve() {
+      return resolveMonitorBase(cfg);
+    },
+
+    async fetchLeafz(): Promise<LeafzResponse | undefined> {
+      const base = resolveMonitorBase(cfg).url.replace(/\/+$/, "");
+      const timeoutMs = cfg.healthProbeTimeoutMs ?? DEFAULT_LEAFZ_TIMEOUT_MS;
+      try {
+        const res = await fetch(`${base}/leafz`, {
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (!res.ok) return undefined;
+        return (await res.json()) as LeafzResponse;
+      } catch (err) {
+        process.stderr.write(
+          `network-doctor-adapters: /leafz fetch failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        return undefined;
+      }
+    },
+  };
+}

--- a/src/cli/cortex/commands/network-doctor-adapters.ts
+++ b/src/cli/cortex/commands/network-doctor-adapters.ts
@@ -13,7 +13,7 @@
  * only GETs `/leafz`. Neither ever writes. `doctor` never mutates config,
  * files, or services — its one live effect is the bounded probe echo the
  * caller wires separately via `createLiveProbeBus`/`wrapRuntimeAsProbeBus`
- * (reused verbatim from `network-ping-adapters.ts`, not re-implemented).
+ * (the SAME probe transport `network-ping-adapters.ts` uses, not re-implemented).
  */
 
 import { existsSync, readFileSync } from "fs";

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -1,0 +1,471 @@
+/**
+ * `cortex network doctor` — PURE orchestration (cortex#1484, epic #1479).
+ *
+ * Verifies the WHOLE federation path from the joining member's own machine —
+ * config → local monitor → leaf established → leaf account binding → a real
+ * echoed round-trip per configured peer — and reports pass/fail/warn/skip +
+ * a fix + the responsible role, PER LEG. On a working link every leg is
+ * green, including the peer's echo reply; on a broken one it pinpoints the
+ * failing leg + who owns fixing it.
+ *
+ * Pure over {@link NetworkDoctorPorts}: no fs, no NATS, no HTTP here — the
+ * live adapters (`network-doctor-adapters.ts`) wire those; tests inject
+ * fakes. READ-ONLY except for the ONE bounded probe echo per peer (the
+ * SAME transport `cortex network ping` uses — `pingPeer`/`derivePingInputs`
+ * are reused verbatim, not re-implemented, so the peer-reachable leg is
+ * byte-identical to `ping`'s round-trip).
+ *
+ * Later checks `skip` when a hard prerequisite failed (spec's check matrix):
+ *   1. config-network      — the network is configured, has peers + accept_subjects
+ *   2. monitor-reachable   — the local nats-server HTTP monitor answers `/leafz`
+ *   3. leaf-established    — `/leafz` shows an established leaf for this network
+ *   4. leaf-account-bound  — the established leaf's account matches config (best-effort)
+ *   5. peer-reachable:<p>  — one check per configured peer, a real echo round-trip
+ */
+
+import type { LoadedConfig } from "../../../common/config/loader";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import {
+  derivePingInputs,
+  pingPeer,
+  type PingResult,
+} from "./network-ping-lib";
+import type {
+  DoctorConfigPort,
+  LeafzEntry,
+  LeafzResponse,
+  NetworkDoctorPorts,
+} from "./network-doctor-ports";
+
+// ---------------------------------------------------------------------------
+// Check taxonomy
+// ---------------------------------------------------------------------------
+
+export type DoctorCheckStatus = "pass" | "fail" | "warn" | "skip";
+export type DoctorCheckOwner = "member" | "hub-owner" | "admin" | "peer";
+
+/** One leg of the doctor report — pass/fail/warn/skip + a fix + the owner. */
+export interface DoctorCheck {
+  id: string;
+  title: string;
+  status: DoctorCheckStatus;
+  detail: string;
+  /** Actionable remediation. Present on `fail`/`warn`; omitted on `pass`/`skip`. */
+  fix?: string;
+  owner: DoctorCheckOwner;
+}
+
+export type DoctorVerdict = "healthy" | "degraded" | "broken";
+
+/** Exit-code taxonomy (mirrors `ping`'s VERDICT_EXIT_CODE convention). */
+export const DOCTOR_EXIT_CODE: Record<DoctorVerdict, number> = {
+  healthy: 0,
+  degraded: 1,
+  broken: 2,
+};
+
+/** Checks whose failure means the federation path is fundamentally down for
+ *  this network (not just degraded) — a hard prerequisite for everything after it. */
+const CRITICAL_CHECK_IDS = new Set(["config-network", "leaf-established"]);
+
+/** Default per-probe echo wait budget (ms) for the peer-reachable leg. */
+export const DEFAULT_DOCTOR_PROBE_TIMEOUT_MS = 6000;
+
+export interface DoctorOptions {
+  /** The already-loaded LOCAL stack config — the #753 seam. Supplies
+   *  principal/stack/assistant for deriving each peer-reachable probe's
+   *  inputs (`derivePingInputs`, reused verbatim from `ping`). */
+  cfg: LoadedConfig;
+  /** The network to doctor. */
+  networkId: string;
+  /** Per-probe echo wait budget (ms), overridable; defaults to
+   *  {@link DEFAULT_DOCTOR_PROBE_TIMEOUT_MS}. */
+  probeTimeoutMs?: number;
+}
+
+export interface DoctorRunResult {
+  checks: DoctorCheck[];
+  verdict: DoctorVerdict;
+  exitCode: number;
+}
+
+// ---------------------------------------------------------------------------
+// Small builders
+// ---------------------------------------------------------------------------
+
+function check(
+  id: string,
+  title: string,
+  status: DoctorCheckStatus,
+  detail: string,
+  owner: DoctorCheckOwner,
+  fix?: string,
+): DoctorCheck {
+  return { id, title, status, detail, owner, ...(fix !== undefined && { fix }) };
+}
+
+function skipCheck(id: string, title: string, detail: string, owner: DoctorCheckOwner): DoctorCheck {
+  return check(id, title, "skip", detail, owner);
+}
+
+/** `{principal}/{slug}` → the slug (falls back to the whole string). */
+function stackSlugFromStackId(stackId: string): string {
+  const parts = stackId.split("/");
+  return parts.length === 2 ? (parts[1] ?? stackId) : stackId;
+}
+
+// ---------------------------------------------------------------------------
+// Leg 1 — config-network
+// ---------------------------------------------------------------------------
+
+function checkConfigNetwork(
+  config: DoctorConfigPort,
+  networkId: string,
+): { result: DoctorCheck; network?: PolicyFederatedNetwork } {
+  const snapshot = config.readNetworks();
+  const network = snapshot.networks.find((n) => n.id === networkId);
+  const id = "config-network";
+  const title = `network "${networkId}" configured`;
+
+  if (network === undefined) {
+    return {
+      result: check(
+        id,
+        title,
+        "fail",
+        `network "${networkId}" is not present in policy.federated.networks[]`,
+        "member",
+        `join the network (\`cortex network join ${networkId}\`) or pass the correct --config/--stack`,
+      ),
+    };
+  }
+  if (network.peers.length === 0) {
+    return {
+      result: check(
+        id,
+        title,
+        "fail",
+        `network "${networkId}" has no peers[] configured`,
+        "member",
+        "add at least one peer to policy.federated.networks[].peers[] (re-join, or ask the hub owner for the roster)",
+      ),
+      network,
+    };
+  }
+  if (network.accept_subjects.length === 0) {
+    return {
+      result: check(
+        id,
+        title,
+        "fail",
+        `network "${networkId}" has an empty accept_subjects[] — inbound federated envelopes will be rejected`,
+        "member",
+        "set policy.federated.networks[].accept_subjects[] (re-join to re-derive it)",
+      ),
+      network,
+    };
+  }
+  return {
+    result: check(
+      id,
+      title,
+      "pass",
+      `${network.peers.length.toString()} peer(s), ${network.accept_subjects.length.toString()} accept_subjects`,
+      "member",
+    ),
+    network,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Leg 2 — monitor-reachable
+// ---------------------------------------------------------------------------
+
+async function checkMonitorReachable(
+  ports: NetworkDoctorPorts,
+): Promise<{ result: DoctorCheck; leafz?: LeafzResponse }> {
+  const id = "monitor-reachable";
+  const title = "local NATS monitor reachable";
+  const resolved = ports.monitor.resolve();
+
+  // #831 — absent monitor is INCONCLUSIVE, not a failure: warn, and let
+  // downstream leaf checks skip (they have no /leafz to read).
+  if (!resolved.configured) {
+    return {
+      result: check(
+        id,
+        title,
+        "warn",
+        "no monitor configured for this bus (no --monitor-url / http_port / monitor_port)",
+        "member",
+        "enable http_port/monitor_port on the local bus for full leaf verification",
+      ),
+    };
+  }
+
+  const leafz = await ports.monitor.fetchLeafz();
+  if (leafz === undefined) {
+    return {
+      result: check(
+        id,
+        title,
+        "fail",
+        `monitor at ${resolved.url} did not respond to /leafz`,
+        "member",
+        "confirm the local nats-server is running and its monitor port is reachable",
+      ),
+    };
+  }
+  return {
+    result: check(id, title, "pass", `${resolved.url}/leafz responded`, "member"),
+    leafz,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Leg 3 — leaf-established
+// ---------------------------------------------------------------------------
+
+function findEstablishedLeaf(
+  leafz: LeafzResponse,
+  leafNode: string,
+): LeafzEntry | undefined {
+  const leafs = leafz.leafs ?? [];
+  const named = leafs.find((l) => l.name === leafNode || l.account === leafNode);
+  if (named !== undefined) return named;
+  // A single-leaf stack (the common case) — treat the lone entry as ours even
+  // when `/leafz` doesn't echo back our configured `leaf_node` name.
+  return leafs.length === 1 ? leafs[0] : undefined;
+}
+
+function checkLeafEstablished(
+  leafz: LeafzResponse | undefined,
+  network: PolicyFederatedNetwork,
+): { result: DoctorCheck; established?: LeafzEntry } {
+  const id = "leaf-established";
+  const title = `leaf "${network.leaf_node}" established`;
+
+  if (leafz === undefined) {
+    return {
+      result: skipCheck(id, title, "skipped — no /leafz data (see monitor-reachable)", "member"),
+    };
+  }
+  const established = findEstablishedLeaf(leafz, network.leaf_node);
+  if (established === undefined) {
+    const seen = (leafz.leafs ?? []).map((l) => l.name ?? l.account ?? "?").join(", ");
+    return {
+      result: check(
+        id,
+        title,
+        "fail",
+        `no established leaf found for "${network.leaf_node}" in /leafz (leafs seen: ${seen === "" ? "none" : seen})`,
+        "hub-owner",
+        "leaf not up: creds/hub-authorization/hub-partition — check the legs below and the hub authorization",
+      ),
+    };
+  }
+  return {
+    result: check(
+      id,
+      title,
+      "pass",
+      `established (in=${(established.in_msgs ?? 0).toString()}, out=${(established.out_msgs ?? 0).toString()})`,
+      "hub-owner",
+    ),
+    established,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Leg 4 — leaf-account-bound
+// ---------------------------------------------------------------------------
+
+function checkLeafAccountBound(
+  config: DoctorConfigPort,
+  networkId: string,
+  established: LeafzEntry | undefined,
+): DoctorCheck {
+  const id = "leaf-account-bound";
+  const title = "leaf account binding";
+
+  if (established === undefined) {
+    return skipCheck(id, title, "skipped — no established leaf (see leaf-established)", "member");
+  }
+  const expected = config.expectedFedAccount(networkId);
+  const actual = established.account;
+  if (expected === undefined) {
+    return check(
+      id,
+      title,
+      "warn",
+      `leaf reports account "${actual ?? "(none)"}" — could not derive the EXPECTED account from config to verify (no rendered leaf-include account: line found)`,
+      "member",
+    );
+  }
+  if (actual !== expected) {
+    return check(
+      id,
+      title,
+      "fail",
+      `leaf is bound to account "${actual ?? "(none)"}" but config expects "${expected}"`,
+      "member",
+      "re-render the leaf include (rejoin) or fix the stack's operator-mode account config",
+    );
+  }
+  return check(id, title, "pass", `leaf bound to expected account "${expected}"`, "member");
+}
+
+// ---------------------------------------------------------------------------
+// Leg 5 — peer-reachable (one per configured peer)
+// ---------------------------------------------------------------------------
+
+function peerCheckFromPingResult(label: string, pr: PingResult): DoctorCheck {
+  const id = `peer-reachable:${label}`;
+  const title = `peer reachable: ${label}`;
+  switch (pr.verdict) {
+    case "reachable": {
+      const rtt = pr.stats.rttAvgMs !== undefined ? `${pr.stats.rttAvgMs.toFixed(0)}ms` : "?ms";
+      return check(id, title, "pass", `echo round-trip ok, rtt=${rtt}`, "peer");
+    }
+    case "timeout":
+      return check(
+        id,
+        title,
+        "fail",
+        pr.detail ?? `no echo from ${label} within the probe timeout`,
+        "peer",
+        "peer/hub — peer offline, its leaf is down, or the hub is partitioned; check the peer's own `cortex network doctor` and the hub authorization",
+      );
+    case "no-responder":
+      return check(
+        id,
+        title,
+        "fail",
+        pr.detail ?? `${label} routed the probe but did not echo a conformant reply`,
+        "peer",
+        "the peer's probe-responder is absent or too old — ask them to upgrade/restart their cortex daemon",
+      );
+    case "refused":
+      return check(
+        id,
+        title,
+        "fail",
+        pr.detail ?? `${label} refused the probe`,
+        "peer",
+        "peer gate — the peer's signing posture rejected us; confirm we're in their peers[] / enforce-posture allowlist",
+      );
+    case "not-configured":
+      return check(
+        id,
+        title,
+        "fail",
+        pr.detail ?? `no leaf route to ${label}`,
+        "member",
+        "member roster — check OUR policy.federated.networks[].peers[] and leaf link; the route to this peer isn't resolvable from here",
+      );
+  }
+}
+
+async function checkPeerReachable(
+  ports: NetworkDoctorPorts,
+  opts: DoctorOptions,
+  peer: PolicyFederatedNetwork["peers"][number],
+): Promise<DoctorCheck> {
+  const targetStack = stackSlugFromStackId(peer.stack_id);
+  const label = `${peer.principal_id}/${targetStack}`;
+  const timeoutMs = opts.probeTimeoutMs ?? DEFAULT_DOCTOR_PROBE_TIMEOUT_MS;
+
+  const derived = derivePingInputs({
+    cfg: opts.cfg,
+    targetPrincipal: peer.principal_id,
+    targetStack,
+    network: opts.networkId,
+    count: 1,
+    timeoutMs,
+  });
+  if (!derived.ok || derived.inputs === undefined) {
+    return check(
+      `peer-reachable:${label}`,
+      `peer reachable: ${label}`,
+      "fail",
+      derived.reason ?? "could not derive probe inputs",
+      "member",
+      "check --principal / cortex.yaml principal.id",
+    );
+  }
+
+  const pr = await pingPeer(derived.inputs, ports.probe);
+  return peerCheckFromPingResult(label, pr);
+}
+
+// ---------------------------------------------------------------------------
+// Verdict aggregation
+// ---------------------------------------------------------------------------
+
+function aggregateVerdict(checks: DoctorCheck[]): DoctorVerdict {
+  const anyFail = checks.some((c) => c.status === "fail");
+  if (!anyFail) return "healthy";
+
+  const criticalFail = checks.some(
+    (c) => c.status === "fail" && CRITICAL_CHECK_IDS.has(c.id),
+  );
+  if (criticalFail) return "broken";
+
+  const peerChecks = checks.filter((c) => c.id.startsWith("peer-reachable:"));
+  const allPeersFailed = peerChecks.length > 0 && peerChecks.every((c) => c.status === "fail");
+  if (allPeersFailed) return "broken";
+
+  return "degraded";
+}
+
+// ---------------------------------------------------------------------------
+// The orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Run every doctor check for `opts.networkId`, in order, skipping downstream
+ * legs when a hard prerequisite failed. Pure over {@link NetworkDoctorPorts}.
+ */
+export async function runDoctorChecks(
+  ports: NetworkDoctorPorts,
+  opts: DoctorOptions,
+): Promise<DoctorRunResult> {
+  const checks: DoctorCheck[] = [];
+
+  // 1. config-network — a hard prerequisite for everything else.
+  const configResult = checkConfigNetwork(ports.config, opts.networkId);
+  checks.push(configResult.result);
+  const network = configResult.network;
+  if (configResult.result.status !== "pass" || network === undefined) {
+    checks.push(
+      skipCheck("monitor-reachable", "local NATS monitor reachable", "skipped — network not configured (see config-network)", "member"),
+    );
+    checks.push(
+      skipCheck("leaf-established", "leaf established", "skipped — network not configured (see config-network)", "member"),
+    );
+    checks.push(
+      skipCheck("leaf-account-bound", "leaf account binding", "skipped — network not configured (see config-network)", "member"),
+    );
+    const verdict = aggregateVerdict(checks);
+    return { checks, verdict, exitCode: DOCTOR_EXIT_CODE[verdict] };
+  }
+
+  // 2. monitor-reachable
+  const monitorResult = await checkMonitorReachable(ports);
+  checks.push(monitorResult.result);
+
+  // 3. leaf-established
+  const leafResult = checkLeafEstablished(monitorResult.leafz, network);
+  checks.push(leafResult.result);
+
+  // 4. leaf-account-bound
+  checks.push(checkLeafAccountBound(ports.config, opts.networkId, leafResult.established));
+
+  // 5. peer-reachable — one per configured peer, a real echo round-trip.
+  for (const peer of network.peers) {
+    checks.push(await checkPeerReachable(ports, opts, peer));
+  }
+
+  const verdict = aggregateVerdict(checks);
+  return { checks, verdict, exitCode: DOCTOR_EXIT_CODE[verdict] };
+}

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -12,8 +12,9 @@
  * live adapters (`network-doctor-adapters.ts`) wire those; tests inject
  * fakes. READ-ONLY except for the ONE bounded probe echo per peer (the
  * SAME transport `cortex network ping` uses — `pingPeer`/`derivePingInputs`
- * are reused verbatim, not re-implemented, so the peer-reachable leg is
- * byte-identical to `ping`'s round-trip).
+ * are the SAME functions, not re-implemented — so the peer-reachable leg
+ * reuses `ping`'s exact probe transport, called with count:1 and doctor's own
+ * timeout and re-mapped to a DoctorCheck).
  *
  * Later checks `skip` when a hard prerequisite failed (spec's check matrix):
  *   1. config-network      — the network is configured, has peers + accept_subjects
@@ -74,7 +75,7 @@ export const DEFAULT_DOCTOR_PROBE_TIMEOUT_MS = 6000;
 export interface DoctorOptions {
   /** The already-loaded LOCAL stack config — the #753 seam. Supplies
    *  principal/stack/assistant for deriving each peer-reachable probe's
-   *  inputs (`derivePingInputs`, reused verbatim from `ping`). */
+   *  inputs (the SAME `derivePingInputs` `ping` uses). */
   cfg: LoadedConfig;
   /** The network to doctor. */
   networkId: string;
@@ -226,16 +227,23 @@ async function checkMonitorReachable(
 // Leg 3 — leaf-established
 // ---------------------------------------------------------------------------
 
+type LeafMatch = { leaf: LeafzEntry; match: "named" | "lone-fallback" };
+
 function findEstablishedLeaf(
   leafz: LeafzResponse,
   leafNode: string,
-): LeafzEntry | undefined {
+): LeafMatch | undefined {
   const leafs = leafz.leafs ?? [];
   const named = leafs.find((l) => l.name === leafNode || l.account === leafNode);
-  if (named !== undefined) return named;
-  // A single-leaf stack (the common case) — treat the lone entry as ours even
-  // when `/leafz` doesn't echo back our configured `leaf_node` name.
-  return leafs.length === 1 ? leafs[0] : undefined;
+  if (named !== undefined) return { leaf: named, match: "named" };
+  // Single-leaf bus (the common creds-only case): one leaf carries every
+  // network's federated traffic and `/leafz` often doesn't echo our configured
+  // `leaf_node` name. We attribute the lone leaf to this network — but flag it
+  // as an ASSUMPTION (not a name match), because with 2+ leaves we canNOT tell
+  // which is this network's, so we do NOT fall back there (returns undefined).
+  return leafs.length === 1 && leafs[0] !== undefined
+    ? { leaf: leafs[0], match: "lone-fallback" }
+    : undefined;
 }
 
 function checkLeafEstablished(
@@ -250,8 +258,8 @@ function checkLeafEstablished(
       result: skipCheck(id, title, "skipped — no /leafz data (see monitor-reachable)", "member"),
     };
   }
-  const established = findEstablishedLeaf(leafz, network.leaf_node);
-  if (established === undefined) {
+  const found = findEstablishedLeaf(leafz, network.leaf_node);
+  if (found === undefined) {
     const seen = (leafz.leafs ?? []).map((l) => l.name ?? l.account ?? "?").join(", ");
     return {
       result: check(
@@ -264,14 +272,26 @@ function checkLeafEstablished(
       ),
     };
   }
+  const { leaf: established, match } = found;
+  const traffic = `in=${(established.in_msgs ?? 0).toString()}, out=${(established.out_msgs ?? 0).toString()}`;
+  // A name/account match is a confident pass; a lone-leaf fallback is an
+  // honest WARN — the leaf is up, but /leafz didn't confirm it's THIS
+  // network's (it could belong to another network on a multi-leaf bus).
+  if (match === "lone-fallback") {
+    return {
+      result: check(
+        id,
+        title,
+        "warn",
+        `assumed the sole leaf on this bus (name/account "${established.name ?? established.account ?? "?"}" did not match the configured leaf_node "${network.leaf_node}") — correct for a single-leaf bus, unverifiable if you run multiple leaves; ${traffic}`,
+        "member",
+        "if this bus carries multiple leaves, ensure the leaf name matches leaf_node so doctor can attribute it to this network",
+      ),
+      established,
+    };
+  }
   return {
-    result: check(
-      id,
-      title,
-      "pass",
-      `established (in=${(established.in_msgs ?? 0).toString()}, out=${(established.out_msgs ?? 0).toString()})`,
-      "hub-owner",
-    ),
+    result: check(id, title, "pass", `established (${traffic})`, "hub-owner"),
     established,
   };
 }
@@ -462,9 +482,13 @@ export async function runDoctorChecks(
   checks.push(checkLeafAccountBound(ports.config, opts.networkId, leafResult.established));
 
   // 5. peer-reachable — one per configured peer, a real echo round-trip.
-  for (const peer of network.peers) {
-    checks.push(await checkPeerReachable(ports, opts, peer));
-  }
+  // Probes are independent request-replies keyed by correlation_id, so run
+  // them CONCURRENTLY — otherwise N unreachable peers cost N×probeTimeoutMs
+  // wall-clock (5 offline peers ≈ 30s). Promise.all preserves peers[] order.
+  const peerChecks = await Promise.all(
+    network.peers.map((peer) => checkPeerReachable(ports, opts, peer)),
+  );
+  checks.push(...peerChecks);
 
   const verdict = aggregateVerdict(checks);
   return { checks, verdict, exitCode: DOCTOR_EXIT_CODE[verdict] };

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -227,7 +227,10 @@ async function checkMonitorReachable(
 // Leg 3 — leaf-established
 // ---------------------------------------------------------------------------
 
-type LeafMatch = { leaf: LeafzEntry; match: "named" | "lone-fallback" };
+interface LeafMatch {
+  leaf: LeafzEntry;
+  match: "named" | "lone-fallback";
+}
 
 function findEstablishedLeaf(
   leafz: LeafzResponse,

--- a/src/cli/cortex/commands/network-doctor-ports.ts
+++ b/src/cli/cortex/commands/network-doctor-ports.ts
@@ -1,0 +1,98 @@
+/**
+ * `cortex network doctor` — injected-dependency seams (cortex#1484, epic #1479).
+ *
+ * Mirrors the `network-ping-ports.ts` pattern: the orchestrator
+ * (`network-doctor-lib.ts`) is PURE over these ports; the live adapters (in
+ * `network-doctor-adapters.ts`) wire the real config file, the local
+ * nats-server HTTP monitor, and the `MyelinRuntime` probe bus; tests inject
+ * fakes that never touch fs/NATS.
+ *
+ * `doctor` verifies the WHOLE federation path from the joining member's own
+ * machine and reports pass/fail + a fix + the responsible role, PER LEG. It
+ * is READ-ONLY except for the ONE bounded probe echo (reused verbatim from
+ * `cortex network ping` — see `network-ping-ports.ts`/`network-ping-lib.ts`).
+ */
+
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import type { NetworkPingPorts } from "./network-ping-ports";
+
+// =============================================================================
+// Config port — read-only `policy.federated.networks[]`
+// =============================================================================
+
+/** The raw on-disk networks snapshot `doctor` checks against. */
+export interface DoctorNetworksSnapshot {
+  networks: PolicyFederatedNetwork[];
+}
+
+/**
+ * Read-only config seam. The LIVE adapter reads straight off the resolved
+ * stack config file (the same `readNetworksFromConfig` pattern
+ * join/leave/rotate-key use), NOT a cached/derived view — so `doctor` reports
+ * against exactly what the daemon would load. Tests inject a fake snapshot.
+ */
+export interface DoctorConfigPort {
+  /** `policy.federated.networks[]`, raw off disk. Never throws — an unreadable
+   *  or absent config file resolves to `{ networks: [] }` (mirrors
+   *  `readNetworksFromConfig`'s own empty-on-absent behaviour). */
+  readNetworks(): DoctorNetworksSnapshot;
+  /**
+   * Best-effort EXPECTED federation account for `networkId`, derived from the
+   * rendered per-network leaf-include file's `account:` line (operator-mode
+   * bus) when one is on disk. `undefined` when not derivable (e.g. a `$G`
+   * default-bus leaf carries no `account:` line, or the leaf hasn't been
+   * rendered yet) — the leaf-account-bound check degrades to warn/report-only
+   * in that case rather than failing. Never throws.
+   */
+  expectedFedAccount(networkId: string): string | undefined;
+}
+
+// =============================================================================
+// Monitor port — the local nats-server HTTP monitor `/leafz` surface
+// =============================================================================
+
+/** One leaf connection as reported by `/leafz`. */
+export interface LeafzEntry {
+  account?: string;
+  name?: string;
+  in_msgs?: number;
+  out_msgs?: number;
+}
+
+/** The raw `/leafz` response body (only the fields `doctor` inspects). */
+export interface LeafzResponse {
+  leafs?: LeafzEntry[];
+}
+
+/**
+ * Read-only local nats-server monitor seam. `resolve()` mirrors
+ * `network-adapters.ts`'s `resolveMonitorBase` — same URL precedence
+ * (`--monitor-url` → derived from the stack's nats config → the upstream
+ * default `:8222`) and the same `configured` flag (the #831 "absent monitor
+ * = inconclusive" signal: `configured === false` means this bus declares no
+ * monitor at all, vs a genuinely-unreachable one).
+ */
+export interface MonitorPort {
+  /** Resolved monitor base URL + whether a monitor is genuinely CONFIGURED
+   *  for this bus (vs the bare upstream-default fallback). */
+  resolve(): { url: string; configured: boolean };
+  /** Fetch `/leafz`. Returns `undefined` on ANY failure (unreachable,
+   *  non-2xx, malformed body, timeout) — never throws. */
+  fetchLeafz(): Promise<LeafzResponse | undefined>;
+}
+
+// =============================================================================
+// The ports bundle
+// =============================================================================
+
+export interface NetworkDoctorPorts {
+  config: DoctorConfigPort;
+  monitor: MonitorPort;
+  /**
+   * The exact probe-bus port shape `cortex network ping` uses — reused
+   * verbatim (not re-implemented) so `doctor`'s peer-reachable leg is the
+   * SAME real echoed round-trip `ping` performs, just orchestrated as one
+   * check per configured peer instead of a `ping -c` report.
+   */
+  probe: NetworkPingPorts;
+}

--- a/src/cli/cortex/commands/network-doctor-ports.ts
+++ b/src/cli/cortex/commands/network-doctor-ports.ts
@@ -9,8 +9,8 @@
  *
  * `doctor` verifies the WHOLE federation path from the joining member's own
  * machine and reports pass/fail + a fix + the responsible role, PER LEG. It
- * is READ-ONLY except for the ONE bounded probe echo (reused verbatim from
- * `cortex network ping` — see `network-ping-ports.ts`/`network-ping-lib.ts`).
+ * is READ-ONLY except for the ONE bounded probe echo (the SAME probe transport
+ * `cortex network ping` uses — see `network-ping-ports.ts`/`network-ping-lib.ts`).
  */
 
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
@@ -20,21 +20,22 @@ import type { NetworkPingPorts } from "./network-ping-ports";
 // Config port — read-only `policy.federated.networks[]`
 // =============================================================================
 
-/** The raw on-disk networks snapshot `doctor` checks against. */
+/** The composed networks snapshot `doctor` checks against. */
 export interface DoctorNetworksSnapshot {
   networks: PolicyFederatedNetwork[];
 }
 
 /**
- * Read-only config seam. The LIVE adapter reads straight off the resolved
- * stack config file (the same `readNetworksFromConfig` pattern
- * join/leave/rotate-key use), NOT a cached/derived view — so `doctor` reports
- * against exactly what the daemon would load. Tests inject a fake snapshot.
+ * Read-only config seam. The LIVE adapter reads the COMPOSED
+ * `policy.federated.networks[]` off the already-loaded `LoadedConfig` (the same
+ * source `derivePingInputs` uses), so it reflects exactly what the daemon loads
+ * — including the config-split layout, where `policy.federated` lives in
+ * `stacks/<slug>.yaml` and a raw re-parse of the pointer file would find none.
+ * Tests inject a fake snapshot.
  */
 export interface DoctorConfigPort {
-  /** `policy.federated.networks[]`, raw off disk. Never throws — an unreadable
-   *  or absent config file resolves to `{ networks: [] }` (mirrors
-   *  `readNetworksFromConfig`'s own empty-on-absent behaviour). */
+  /** The composed `policy.federated.networks[]`. Never throws — resolves to
+   *  `{ networks: [] }` when the config declares none. */
   readNetworks(): DoctorNetworksSnapshot;
   /**
    * Best-effort EXPECTED federation account for `networkId`, derived from the
@@ -89,9 +90,9 @@ export interface NetworkDoctorPorts {
   config: DoctorConfigPort;
   monitor: MonitorPort;
   /**
-   * The exact probe-bus port shape `cortex network ping` uses — reused
-   * verbatim (not re-implemented) so `doctor`'s peer-reachable leg is the
-   * SAME real echoed round-trip `ping` performs, just orchestrated as one
+   * The exact probe-bus port shape `cortex network ping` uses — the SAME
+   * transport (not re-implemented) so `doctor`'s peer-reachable leg performs
+   * the same real echoed round-trip `ping` does, just orchestrated as one
    * check per configured peer instead of a `ping -c` report.
    */
   probe: NetworkPingPorts;

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -162,6 +162,16 @@ import {
 } from "./network-ping-adapters";
 import { buildPingSignerFromConfig } from "./network-ping-signer";
 import type { NetworkPingPorts } from "./network-ping-ports";
+import {
+  runDoctorChecks,
+  type DoctorRunResult,
+  type DoctorCheck,
+} from "./network-doctor-lib";
+import {
+  buildDoctorConfigPort,
+  buildMonitorPort,
+} from "./network-doctor-adapters";
+import type { NetworkDoctorPorts } from "./network-doctor-ports";
 
 export { type ExitResult } from "./_shared/exit-result";
 
@@ -169,7 +179,7 @@ export { type ExitResult } from "./_shared/exit-result";
 // Grammar
 // =============================================================================
 
-type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "admit" | "reject" | "provision" | "make-live" | "secret";
+type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "doctor" | "admit" | "reject" | "provision" | "make-live" | "secret";
 
 /**
  * Default registry URL when neither --registry-url nor config provides one.
@@ -335,6 +345,22 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--count": "value",
         // Per-probe echo wait budget (ms). Default 2000.
         "--timeout": "value",
+      },
+    },
+    // cortex#1484 (epic #1479) — verify the WHOLE federation path from the
+    // joining member's own machine: config → local monitor → leaf established
+    // → leaf account binding → a real echoed round-trip per configured peer.
+    // Read-only (+ one bounded probe echo per peer, reusing `ping`'s
+    // transport). Reports pass/fail/warn/skip + a fix + the responsible role
+    // PER LEG, so a broken link pinpoints the failing leg instead of a bare
+    // "not reachable". Derives principal/stack from cortex.yaml like status.
+    doctor: {
+      positionals: ["network"],
+      flags: {
+        "--config": "value",
+        "--principal": "value",
+        "--stack": "value",
+        "--monitor-url": "value",
       },
     },
     // ADR-0015 — one-command admin admission decision. Signs an admission
@@ -1439,6 +1465,143 @@ function renderPingResult(
   const body = lines.join("\n") + "\n";
   // Reachable → stdout/exit 0; any failure verdict → stderr + the verdict's
   // exit code (so scripts branch on `$?` per §3.3).
+  return res.exitCode === 0
+    ? { exitCode: 0, stdout: body, stderr: "" }
+    : { exitCode: res.exitCode, stdout: "", stderr: body };
+}
+
+// =============================================================================
+// cortex#1484 (epic #1479) — `cortex network doctor`
+// =============================================================================
+
+/**
+ * Factory for the doctor ports bundle. Production builds the live config +
+ * monitor + probe-bus adapters from the resolved {@link LivePortsConfig} +
+ * the loaded {@link LoadedConfig} (the probe-bus signer needs the full
+ * config, mirroring `PingBusFactory`); tests inject fakes. Returns the ports
+ * + a `stop()` to drain the runtime.
+ */
+export type DoctorPortsFactory = (
+  cfg: LoadedConfig,
+  livePortsCfg: LivePortsConfig,
+) => Promise<{ ports: NetworkDoctorPorts; stop: () => Promise<void> }>;
+
+/** The production factory — live config/monitor reads + a live NATS-backed probe bus. */
+const DEFAULT_DOCTOR_PORTS_FACTORY: DoctorPortsFactory = async (cfg, livePortsCfg) => {
+  // Reuse the SAME posture-gated signer + live probe bus `ping` uses, so
+  // doctor's peer-reachable leg is byte-identical to `ping`'s round-trip.
+  const signer = await buildPingSignerFromConfig(cfg);
+  const bus: LiveProbeBus = await createLiveProbeBus(cfg.config, signer);
+  const ports: NetworkDoctorPorts = {
+    config: buildDoctorConfigPort({
+      // Read the COMPOSED networks off the already-loaded config — NOT a raw
+      // re-parse of the pointer file, which finds zero networks under the
+      // config-split layout (policy.federated lives in stacks/<slug>.yaml). Same
+      // source `derivePingInputs` uses (network-ping-lib.ts).
+      networks: cfg.policy?.federated?.networks ?? [],
+      ...(livePortsCfg.natsConfigPath !== undefined && { natsConfigPath: livePortsCfg.natsConfigPath }),
+    }),
+    monitor: buildMonitorPort(livePortsCfg),
+    probe: {
+      bus,
+      newNonce: () => crypto.randomUUID(),
+      newCorrelationId: () => crypto.randomUUID(),
+    },
+  };
+  return { ports, stop: () => bus.stop() };
+};
+
+async function runDoctor(
+  networkId: string,
+  flags: FlagMap,
+  json: boolean,
+  load: ConfigReader,
+  doctorPortsFactory: DoctorPortsFactory,
+): Promise<ExitResult> {
+  const principalRes = requireValueFlag(flags, "--principal");
+  if (!principalRes.ok) return usageError("doctor", principalRes.reason, json);
+  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
+  if (!slugRes.ok) return usageError("doctor", slugRes.reason, json);
+
+  // #814-style — an explicit --config wins; otherwise resolve the NAMED
+  // stack's config layout-aware (mirrors status/ping so doctor reads the same
+  // file the daemon actually loads).
+  const doctorFlags: FlagMap =
+    optionalValueFlag(flags, "--config") === undefined
+      ? { ...flags, "--config": resolveStatusConfigPath(slugRes.slug) }
+      : flags;
+
+  let cfg: LoadedConfig;
+  try {
+    cfg = load(cortexConfigPathFromFlags(doctorFlags));
+  } catch (err) {
+    return opError("doctor", `config load failed: ${err instanceof Error ? err.message : String(err)}`, json);
+  }
+
+  const livePortsCfg = portsConfig(networkId, principalRes.value, slugRes.slug, doctorFlags);
+
+  let handle;
+  try {
+    handle = await doctorPortsFactory(cfg, livePortsCfg);
+  } catch (err) {
+    return opError("doctor", `failed to build doctor ports: ${err instanceof Error ? err.message : String(err)}`, json);
+  }
+  try {
+    const res = await runDoctorChecks(handle.ports, { cfg, networkId });
+    return renderDoctorResult(res, networkId, json);
+  } finally {
+    await handle.stop();
+  }
+}
+
+/** Render a {@link DoctorRunResult} — a human per-leg table or a `--json` envelope + exit code. */
+function renderDoctorResult(
+  res: DoctorRunResult,
+  networkId: string,
+  json: boolean,
+): ExitResult {
+  if (json) {
+    const env = envelopeOk(
+      res.checks.map((c) => ({
+        id: c.id,
+        title: c.title,
+        status: c.status,
+        detail: c.detail,
+        owner: c.owner,
+        ...(c.fix !== undefined && { fix: c.fix }),
+      })),
+      { network: networkId, verdict: res.verdict },
+    );
+    // JSON goes to stdout regardless of exit code — the verdict is always
+    // machine-readable; the exit code carries it too (mirrors `ping`).
+    return { exitCode: res.exitCode, stdout: renderJson(env), stderr: "" };
+  }
+
+  const icon = (status: DoctorCheck["status"]): string => {
+    switch (status) {
+      case "pass":
+        return "✓";
+      case "fail":
+        return "✗";
+      case "warn":
+        return "⚠";
+      case "skip":
+        return "·";
+    }
+  };
+
+  const lines: string[] = [`cortex network doctor ${networkId}:`, ""];
+  for (const c of res.checks) {
+    lines.push(`  ${icon(c.status)} ${c.id} — ${c.detail}`);
+    if (c.fix !== undefined) {
+      lines.push(`      fix (${c.owner}): ${c.fix}`);
+    }
+  }
+  lines.push("");
+  lines.push(`verdict: ${res.verdict}`);
+  const body = lines.join("\n") + "\n";
+  // Healthy → stdout/exit 0; degraded/broken → stderr + the verdict's exit
+  // code (so scripts branch on `$?`, mirroring `ping`).
   return res.exitCode === 0
     ? { exitCode: 0, stdout: body, stderr: "" }
     : { exitCode: res.exitCode, stdout: "", stderr: body };
@@ -3599,6 +3762,10 @@ export async function dispatchNetwork(
   // C-1349 Slice 2 — injectable rotate-key ports factory so the CLI tests drive
   // fake hub-conf/registry/crypto/keyStore ports. Production omits → live.
   keyRotationPortsFactory: KeyRotationPortsFactory = DEFAULT_KEY_ROTATION_PORTS_FACTORY,
+  // cortex#1484 — injectable doctor-ports factory so `doctor` CLI tests drive
+  // fake config/monitor/probe-bus ports without touching fs or NATS.
+  // Production omits it → the live adapters.
+  doctorPortsFactory: DoctorPortsFactory = DEFAULT_DOCTOR_PORTS_FACTORY,
 ): Promise<ExitResult> {
   let parsed;
   try {
@@ -3634,6 +3801,8 @@ export async function dispatchNetwork(
       return runCreate(parsed.positionals.network ?? "", parsed.flags, json);
     case "ping":
       return runPing(parsed.positionals.peer ?? "", parsed.flags, json, load, pingBusFactory);
+    case "doctor":
+      return runDoctor(parsed.positionals.network ?? "", parsed.flags, json, load, doctorPortsFactory);
     case "admit":
       return runAdmit(parsed.positionals["request-id"] ?? "", parsed.flags, json, secretPortsFactory);
     case "reject":
@@ -3669,6 +3838,7 @@ Usage:
   cortex network status [--principal <id>] [--stack <id>] [--monitor-url <url>] [--json]
   cortex network create <network> --hub <tls-url> --leaf-port <port> --admin-seed <path> [--network-admins <csv>] [--registry-url <url>] [--apply]
   cortex network ping   <peer> [--assistant <a>] [--network <id>] [--count N] [--timeout <ms>] [--json]
+  cortex network doctor <network> [--principal <id>] [--stack <id>] [--config <p>] [--monitor-url <url>] [--json]
   cortex network admit  <request-id> --admin-seed <path> [--registry-url <url>] [--hub-config <p>]
                         [--roster-only] [--discord-member <id>] [--discord-guild <id>]
                         [--discord-server <profile>] [--discord-role <name>] [--apply] [--dry-run] [--json]
@@ -3714,6 +3884,17 @@ Subcommands:
           3 no-responder / 4 timeout / 5 refused. --count for multiple probes
           (min/avg/max RTT); --assistant for a named Direct target; --network
           to disambiguate the topology (NEVER a wire segment).
+  doctor  (cortex#1484, epic #1479) Verify the WHOLE federation path from this
+          machine, leg by leg: network configured (peers[]/accept_subjects[])
+          → local NATS monitor reachable → leaf established → leaf account
+          binding → a REAL echoed round-trip per configured peer (reuses
+          ping's transport). Each leg reports pass/fail/warn/skip + a fix +
+          the responsible role (member/hub-owner/admin/peer), so a broken
+          link pinpoints the failing leg instead of a bare "not reachable".
+          READ-ONLY except for the bounded probe echo. No monitor configured
+          on the local bus degrades leaf checks to warn/skip, never fail (the
+          absent-monitor-is-inconclusive rule). Exit codes: 0 healthy /
+          1 degraded / 2 broken.
   status  Show joined networks, peers, accept-subjects, leaf link state + counters.
   leave   Reverse a join cleanly: remove the network + leaf include, drop the
           plist -c arg if no networks remain, restart. Idempotent.


### PR DESCRIPTION
## What
New read-only `cortex network doctor <net>` — the "am I actually federated?" check that the metafactory-community bring-up (Jul 2026) lacked. Walks the whole federation path from the joining member's machine and reports **pass/fail/warn/skip + a fix + the responsible role, per leg**.

Sub-issue of epic **#1479** (federation-join tooling redesign), slice **join-5** (#1484).

## Checks (skip downstream on a hard-prerequisite failure)
| leg | verifies | owner on fail |
|---|---|---|
| `config-network` | network in `policy.federated.networks[]`, has peers + `accept_subjects` | member |
| `monitor-reachable` | local nats `/leafz` monitor answers (**#831**: absent monitor = ⚠ warn, not fail) | member |
| `leaf-established` | `/leafz` shows an established leaf (not `status`, which lags) | hub-owner |
| `leaf-account-bound` | leaf bound to the expected FED account (best-effort) | member |
| `peer-reachable:<p>` | a **real echo round-trip** per peer (reuses `ping`'s `pingPeer` verbatim) | peer / member |

The peer leg replaces the misleading `/leafz out=0` with an honest end-to-end verdict (reachable/timeout/no-responder/refused/not-configured → RTT or a named owner).

## How
Ports-and-adapters, mirroring the `network-ping-*` triad: pure `runDoctorChecks` over `NetworkDoctorPorts`; live adapters reuse `resolveMonitorBase` + `/leafz` + the ping probe bus. Reads the **composed** `policy.federated.networks` off the loaded config (same source `derivePingInputs` uses) so it's correct under the **config-split layout** (where `policy.federated` lives in `stacks/<slug>.yaml`).

`--json` emits the `{status,items,data}` envelope. Exit: `healthy=0 / degraded=1 / broken=2`.

## Verification
- `bunx tsc --noEmit` clean; full command suite **1165 tests, 0 fail**; new tests: `network-doctor-lib.test.ts` + `network-doctor-cli.test.ts` (**16 pass**).
- **Live** against `metafactory`: correctly reports `config✓ / no-monitor⚠ / leaf-skip / peer-timeout✗ → broken` — the exact by-hand diagnosis, one command:
```
✓ config-network — 1 peer(s), 1 accept_subjects
⚠ monitor-reachable — no monitor configured for this bus
· leaf-established — skipped — no /leafz data
✗ peer-reachable:andreas/meta-factory — no echo within 6000ms (peer offline / leaf down / hub partition)
verdict: broken
```

## Out of scope (intentional)
- Doesn't add a `--timeout` CLI flag for the probe leg (overridable in code via `DoctorOptions.probeTimeoutMs`, default 6000ms) — can add if wanted.
- Presence-on-pane check (epic mentions it) deferred; the 5 legs cover the transport + dispatch path. Follow-up candidate.
- Exit taxonomy is 3-tier (healthy/degraded/broken) rather than ping's 2-tier — deliberate, documented, tested.

Closes #1484
Refs #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)