### PR TITLE
chore(deps): bump myelin to v0.6.0 (a69ecd7)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@octokit/webhooks-methods": "^6.0.0",
         "@slack/socket-mode": "^2.0.7",
         "@slack/web-api": "^7.16.0",
-        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#7c6b71e9e16286d42ba6038d0be3ab30c498da39",
+        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -126,7 +126,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#7c6b71e", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/nats-core": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-7c6b71e"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#a69ecd7", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/nats-core": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-a69ecd7"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@octokit/webhooks-methods": "^6.0.0",
     "@slack/socket-mode": "^2.0.7",
     "@slack/web-api": "^7.16.0",
-    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#7c6b71e9e16286d42ba6038d0be3ab30c498da39",
+    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -334,17 +334,17 @@ describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", ()
     expect(result.ok).toBe(true);
   });
 
-  test("accepts a broadcast envelope (deprecated alias, R11 back-compat)", () => {
-    // Vocabulary migration 2026-05 — `broadcast` is the deprecated alias
-    // of `offer`. The transition schema still accepts it on read so
-    // JetStream-replayed pre-migration envelopes route through unchanged.
+  test("rejects a broadcast envelope (deprecated alias removed in myelin v0.6.0)", () => {
+    // Vocabulary migration 2026-05 — `broadcast` was the deprecated alias
+    // of `offer`. myelin v0.6.0 removed `broadcast` from the wire entirely,
+    // so the schema no longer accepts it on read.
     const env = {
       ...(validEnvelope as object),
       distribution_mode: "broadcast",
       sovereignty_required: "open",
     };
     const result = validateEnvelope(env);
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
   });
 
   test("rejects a direct envelope missing target_assistant", () => {
@@ -612,7 +612,7 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     // no longer dual-reads) ships here per
     // docs/migrations/0002-vocabulary-finish-2026-05.md §R10.
     expect(SCHEMA_SOURCE_COMMIT).toBe(
-      "7c6b71e9e16286d42ba6038d0be3ab30c498da39",
+      "a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1",
     );
   });
 

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -76,7 +76,7 @@ import schema from "./vendor/envelope.schema.json" with { type: "json" };
  * comments + tests use `myelin#161` to point at the merge that landed the
  * feature — they're the same change, different ticket facets.
  */
-export const SCHEMA_SOURCE_COMMIT = "7c6b71e9e16286d42ba6038d0be3ab30c498da39";
+export const SCHEMA_SOURCE_COMMIT = "a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather

--- a/src/bus/myelin/vendor/envelope.schema.json
+++ b/src/bus/myelin/vendor/envelope.schema.json
@@ -170,8 +170,8 @@
     },
     "distribution_mode": {
       "type": "string",
-      "enum": ["broadcast", "offer", "direct", "delegate"],
-      "description": "F-021: routing semantics. offer = competing consumers; direct = named recipient; delegate = outcome handoff (multi-step orchestration). R11 (vocabulary migration 2026-05): 'broadcast' renamed to 'offer'. Transition release accepts BOTH; 'broadcast' is deprecated and dropped in the breaking major."
+      "enum": ["offer", "direct", "delegate"],
+      "description": "F-021: routing semantics. offer = competing consumers; direct = named recipient; delegate = outcome handoff (multi-step orchestration). R11 (vocabulary migration 2026-05, breaking cut #180): 'broadcast' was renamed to 'offer' and removed from the wire — envelopes carrying it are rejected."
     },
     "target_assistant": {
       "type": "string",
@@ -180,21 +180,13 @@
     },
     "originator": {
       "type": "object",
-      "description": "myelin#160: policy-level actor identity, separate from the cryptographic signed_by chain. The chain proves WHO signed; originator names WHO the signer claims to be acting on behalf of. Covered by the signature (signer commits to the attribution claim). When absent, the signer is the actor. R2 (vocabulary migration 2026-05): the actor-DID field renamed 'principal'→'identity'; transition release accepts either, rejects both.",
-      "oneOf": [
-        { "required": ["identity", "attribution"] },
-        { "required": ["principal", "attribution"] }
-      ],
+      "description": "myelin#160: policy-level actor identity, separate from the cryptographic signed_by chain. The chain proves WHO signed; originator names WHO the signer claims to be acting on behalf of. Covered by the signature (signer commits to the attribution claim). When absent, the signer is the actor. R2 (vocabulary migration 2026-05, breaking cut): the actor-DID field is 'identity'; the deprecated 'principal' key was removed from the wire and is rejected by `additionalProperties: false`.",
+      "required": ["identity", "attribution"],
       "properties": {
         "identity": {
           "type": "string",
           "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
           "description": "DID of the actor whose capabilities this envelope asserts (R2 — renamed from 'principal')."
-        },
-        "principal": {
-          "type": "string",
-          "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
-          "description": "DEPRECATED (R2) — renamed to 'identity'. Accepted on read through the transition window; an originator carrying BOTH keys is rejected (dual_field_conflict)."
         },
         "attribution": {
           "type": "string",

--- a/src/taps/cc-events/__tests__/cc-events.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events.test.ts
@@ -214,7 +214,7 @@ describe("createCcEventEnvelope", () => {
       originatorPrincipal: "did:mf:cortex",
     });
     expect(env.originator).toEqual({
-      principal: "did:mf:cortex",
+      identity: "did:mf:cortex",
       attribution: "adapter-resolved",
     });
   });
@@ -356,7 +356,7 @@ describe("createCcEventPublisher", () => {
     for (const call of link.calls) {
       const env = JSON.parse(call.payload);
       expect(env.originator).toEqual({
-        principal: "did:mf:cortex",
+        identity: "did:mf:cortex",
         attribution: "adapter-resolved",
       });
     }

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -251,7 +251,7 @@ export function createCcEventEnvelope(
   // level so JSON serialisation picks it up downstream.
   if (opts.originatorPrincipal !== undefined) {
     envelope.originator = {
-      principal: opts.originatorPrincipal,
+      identity: opts.originatorPrincipal,
       attribution: "adapter-resolved",
     };
   }


### PR DESCRIPTION
## Summary

Bumps `@the-metafactory/myelin` to **v0.6.0** (commit `a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1`).

Pinned **by SHA** rather than the `#v0.6.0` tag because cortex's envelope-validator drift-guard test enforces a 40-char SHA on the `package.json` ref.

v0.6.0 is a **BREAKING** release — it removes `originator.principal` and `distribution_mode: "broadcast"` from the wire.

## Changes

- **`package.json` / `bun.lock`** — myelin pin → `a69ecd7`.
- **Schema re-vendor (lockstep):** copied `myelin/schemas/envelope.schema.json` over `src/bus/myelin/vendor/envelope.schema.json`; bumped `SCHEMA_SOURCE_COMMIT` in `envelope-validator.ts` and the matching expected constant in `envelope-validator.test.ts` to `a69ecd7`. Drift-guard test green.

## Mechanical v0.6.0 fallout

- `src/taps/cc-events/cc-events.ts` — the one originator builder still on the removed key: `originator: { principal }` → `{ identity }`.
- `src/taps/cc-events/__tests__/cc-events.test.ts` — flipped the two assertions on the built `originator.principal` to `identity`.
- `src/bus/myelin/__tests__/envelope-validator.test.ts` — the "accepts a broadcast envelope (deprecated alias)" test now expects **rejection** (`broadcast` removed from the wire).

All other `originator: {}` builders in the repo already used `identity`. No cortex code imported the removed `broadcastTaskSubject`; `getActorPrincipal` remains a valid deprecated alias in myelin, so no forced import rename was required.

## Verification

- `bunx tsc --noEmit` → **exit 0** (includes test files).
- `bun test` → **8634 pass / 1 fail**. The single fail is the pre-existing `check-carveouts vocab ratchet (F18)`, caused entirely by the untracked `docs/federation-join-issues-2026-06-26.md` (not touched by this PR). The previously-flaky `ConfigWatcher github.repos hot-reload` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)