### PR TITLE
feat(network): C-1481 — never write a foreign hub (seal-only + hub-owner artifact) (epic #1479 slice 2)

### DIFF
--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
@@ -38,6 +38,7 @@ import { buildLiveSecretPorts } from "../../network-secret-adapters";
 import { fetchSealedLeafSecret } from "../../../../../common/registry/fetch-sealed-secret";
 import type { NetworkSecretPorts } from "../../network-secret-ports";
 import { leaveNetwork } from "../../network-lib";
+import { NetworkCache } from "../../../../../common/registry/network-cache";
 
 import { deriveAcceptSubjects } from "../../../../../bus/agent-network/accept-subjects";
 import {
@@ -306,6 +307,19 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
   test("step 5: network secret add-member --apply (hub reload STUBBED) → sealed blob on the row", async () => {
     expect(ctx.requestId).toBeDefined();
     ctx.hub = makeRecordingHubPort("");
+    // cortex#1481 — the hub-locality gate compares the network's cached hub_url
+    // against this host; this walkthrough never runs a REAL `network join` (so
+    // nothing is genuinely cached for NETWORK_ID), and the step is explicitly
+    // exercising the LOCAL-hub happy path (the hub-reload port is stubbed, not
+    // absent). Seed a hermetic tmp-dir cache with a loopback hub_url so the gate
+    // resolves LOCAL here, exactly like a real "hub is this machine" deployment —
+    // never touching the developer's real ~/.config/cortex/network-cache/.
+    const networkCache = new NetworkCache({ cacheDir: freshDir("e2e-network-cache-") });
+    networkCache.store(
+      NETWORK_ID,
+      { network_id: NETWORK_ID, hub_url: "tls://localhost:7422", leaf_port: 7422, members: [] },
+      { network_id: NETWORK_ID, members: [] },
+    );
     // Real admission/delivery/crypto ports (against the in-process registry via
     // the routed fetch), with ONLY the hub-reload port swapped for the recorder.
     const live = buildLiveSecretPorts({
@@ -313,6 +327,7 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
       registryUrl: REGISTRY_BASE,
       material: ctx.adminMaterial,
       fetchImpl: globalThis.fetch,
+      networkCache,
     });
     ctx.secretPorts = { ...live, hub: ctx.hub };
 

--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
@@ -322,12 +322,17 @@ describe("C-1355 — E2E admission lifecycle guard", () => {
     );
     // Real admission/delivery/crypto ports (against the in-process registry via
     // the routed fetch), with ONLY the hub-reload port swapped for the recorder.
+    // cortex#1481 (Sage Important 2) — the loopback hub_url alias already drives
+    // the LOCAL decision, but inject no-op DNS/interface resolvers so the gate's
+    // interface probe stays fully hermetic (no real DNS lookup of "localhost").
     const live = buildLiveSecretPorts({
       hubConfigPath: "<unused — hub port overridden below>",
       registryUrl: REGISTRY_BASE,
       material: ctx.adminMaterial,
       fetchImpl: globalThis.fetch,
       networkCache,
+      resolveHostAddresses: async () => [],
+      localInterfaceAddresses: () => [],
     });
     ctx.secretPorts = { ...live, hub: ctx.hub };
 

--- a/src/cli/cortex/commands/__tests__/network-admit.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-admit.test.ts
@@ -501,11 +501,13 @@ function fakeSealFactory(
     hubUrl?: string;
     noHubCache?: boolean;
     localHostname?: string;
+    hubHostIsLocalInterface?: boolean;
   } = {},
 ): { factory: SecretPortsFactory; calls: SealCalls } {
   const calls: SealCalls = { reads: 0, writes: 0, reloads: 0, posted: [], minted: [] };
   const hubUrl = opts.noHubCache === true ? undefined : (opts.hubUrl ?? "tls://localhost:7422");
   const localHostname = opts.localHostname ?? "localhost";
+  const hubHostIsLocalInterface = opts.hubHostIsLocalInterface ?? false;
   const ports: NetworkSecretPorts = {
     hub: {
       confPath: "/fake/hub.conf",
@@ -529,6 +531,7 @@ function fakeSealFactory(
     hubLocality: {
       resolveHubUrl: async () => hubUrl,
       localHostname: () => localHostname,
+      hubHostIsLocalInterface: async () => hubHostIsLocalInterface,
     },
   };
   return { factory: () => ports, calls };

--- a/src/cli/cortex/commands/__tests__/network-admit.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-admit.test.ts
@@ -493,9 +493,19 @@ interface SealCalls {
  * with "no ADMITTED row"); `readThrows` simulates a non-local / unreadable hub.
  */
 function fakeSealFactory(
-  opts: { admitted?: { request_id: string; principal_id: string }; readThrows?: boolean } = {},
+  opts: {
+    admitted?: { request_id: string; principal_id: string };
+    readThrows?: boolean;
+    // cortex#1481 — hub-locality fakes. Defaults resolve LOCAL (loopback alias)
+    // so every PRE-#1481 test keeps its local-hub-write assumption unchanged.
+    hubUrl?: string;
+    noHubCache?: boolean;
+    localHostname?: string;
+  } = {},
 ): { factory: SecretPortsFactory; calls: SealCalls } {
   const calls: SealCalls = { reads: 0, writes: 0, reloads: 0, posted: [], minted: [] };
+  const hubUrl = opts.noHubCache === true ? undefined : (opts.hubUrl ?? "tls://localhost:7422");
+  const localHostname = opts.localHostname ?? "localhost";
   const ports: NetworkSecretPorts = {
     hub: {
       confPath: "/fake/hub.conf",
@@ -515,6 +525,10 @@ function fakeSealFactory(
     crypto: {
       mintPsk: () => { const p = "PSK-secret-x"; calls.minted.push(p); return p; },
       seal: async (plaintext: string, pubkey: string) => `SEALED(${pubkey.slice(0, 4)}:${plaintext})`,
+    },
+    hubLocality: {
+      resolveHubUrl: async () => hubUrl,
+      localHostname: () => localHostname,
     },
   };
   return { factory: () => ports, calls };
@@ -664,6 +678,137 @@ describe("cortex network admit — admit-and-seal (C-1316)", () => {
     expect(env.data.seal_status).toBe("fallback");
     expect(env.data.seal_fallback).toContain("<network>");
     expect(calls.reads).toBe(0);
+  });
+});
+
+// =============================================================================
+// cortex#1481 (epic #1479, join-2) — admit-and-seal hub locality gate.
+// The #1 storm cause: admit's fold-in seal shares the SAME hub-write seam as
+// `secret add-member` (sealAdmittedMember → runNetworkSecret), so it must
+// share the SAME never-write-a-foreign-hub fix.
+// =============================================================================
+describe("cortex network admit — admit-and-seal hub locality (cortex#1481)", () => {
+  test("external hub → seal_status sealed, NO local hub write, hub_owner_artifact present", async () => {
+    const { seedPath } = await mintAdminSeed();
+    mockAdmitFetch(pendingRequest());
+    const { factory, calls } = fakeSealFactory({
+      admitted: { request_id: "req-abc-123", principal_id: "peer-principal" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+
+    const res = await dispatchNetwork(
+      ["admit", "req-abc-123", "--admin-seed", seedPath, "--apply", "--json"],
+      undefined, undefined, undefined, factory,
+    );
+
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { data: { seal_status: string; connectable: string; hub_owner_artifact?: string } };
+    expect(env.data.seal_status).toBe("sealed");
+    expect(env.data.connectable).toBe("true");
+    // The local hub port's write/reload were NEVER called (spy assertion).
+    expect(calls.writes).toBe(0);
+    expect(calls.reloads).toBe(0);
+    // The registry seal still POSTed (machine-independent).
+    expect(calls.posted).toEqual(["req-abc-123"]);
+    expect(env.data.hub_owner_artifact).toBeDefined();
+    expect(env.data.hub_owner_artifact).toContain(calls.minted[0]);
+  });
+
+  test("external hub — human output prints the hub-owner artifact, still says CONNECTABLE", async () => {
+    const { seedPath } = await mintAdminSeed();
+    mockAdmitFetch(pendingRequest());
+    const { factory, calls } = fakeSealFactory({
+      admitted: { request_id: "req-abc-123", principal_id: "peer-principal" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+
+    const res = await dispatchNetwork(
+      ["admit", "req-abc-123", "--admin-seed", seedPath, "--apply"],
+      undefined, undefined, undefined, factory,
+    );
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("CONNECTABLE");
+    expect(res.stdout).toContain("HUB-OWNER ACTION REQUIRED");
+    expect(res.stdout).toContain(calls.minted[0]!);
+    expect(calls.writes).toBe(0);
+  });
+
+  test("--seal-only forces the artifact path even when the hub LOOKS local", async () => {
+    const { seedPath } = await mintAdminSeed();
+    mockAdmitFetch(pendingRequest());
+    const { factory, calls } = fakeSealFactory({ admitted: { request_id: "req-abc-123", principal_id: "peer-principal" } });
+
+    const res = await dispatchNetwork(
+      ["admit", "req-abc-123", "--admin-seed", seedPath, "--apply", "--seal-only", "--json"],
+      undefined, undefined, undefined, factory,
+    );
+
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { data: { seal_status: string; hub_owner_artifact?: string } };
+    expect(env.data.seal_status).toBe("sealed");
+    expect(calls.writes).toBe(0);
+    expect(calls.reloads).toBe(0);
+    expect(env.data.hub_owner_artifact).toBeDefined();
+  });
+
+  test("local hub, no --seal-only → writes exactly as before (pre-#1481 behaviour), no artifact", async () => {
+    const { seedPath } = await mintAdminSeed();
+    mockAdmitFetch(pendingRequest());
+    const { factory, calls } = fakeSealFactory({ admitted: { request_id: "req-abc-123", principal_id: "peer-principal" } });
+
+    const res = await dispatchNetwork(
+      ["admit", "req-abc-123", "--admin-seed", seedPath, "--apply", "--json"],
+      undefined, undefined, undefined, factory,
+    );
+
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { data: { seal_status: string; hub_owner_artifact?: string } };
+    expect(env.data.seal_status).toBe("sealed");
+    expect(calls.writes).toBe(1);
+    expect(calls.reloads).toBe(1);
+    expect(env.data.hub_owner_artifact).toBeUndefined();
+  });
+
+  test("no cached hub descriptor (can't determine locality) → treated as external, fail-safe", async () => {
+    const { seedPath } = await mintAdminSeed();
+    mockAdmitFetch(pendingRequest());
+    const { factory, calls } = fakeSealFactory({
+      admitted: { request_id: "req-abc-123", principal_id: "peer-principal" },
+      noHubCache: true,
+    });
+
+    const res = await dispatchNetwork(
+      ["admit", "req-abc-123", "--admin-seed", seedPath, "--apply", "--json"],
+      undefined, undefined, undefined, factory,
+    );
+
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { data: { hub_owner_artifact?: string } };
+    expect(calls.writes).toBe(0);
+    expect(calls.reloads).toBe(0);
+    expect(env.data.hub_owner_artifact).toBeDefined();
+  });
+
+  test("--hub-account rides the printed artifact's account: field", async () => {
+    const { seedPath } = await mintAdminSeed();
+    mockAdmitFetch(pendingRequest());
+    const { factory } = fakeSealFactory({
+      admitted: { request_id: "req-abc-123", principal_id: "peer-principal" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const account = "A" + "E".repeat(55);
+
+    const res = await dispatchNetwork(
+      ["admit", "req-abc-123", "--admin-seed", seedPath, "--apply", "--hub-account", account],
+      undefined, undefined, undefined, factory,
+    );
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain(`account: "${account}"`);
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-secret-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-adapters.test.ts
@@ -28,6 +28,8 @@ import { createUser } from "nkeys.js";
 import { buildLiveSecretPorts, type NatsProcessInspector } from "../network-secret-adapters";
 import type { NatsProcess } from "../../../../common/nats/hub-reload-target";
 import { materialFromSeedString } from "../../../../bus/stack-provisioning";
+import { NetworkCache } from "../../../../common/registry/network-cache";
+import type { NetworkDescriptor, NetworkRosterResult } from "../../../../common/registry/types";
 
 let tmp: string;
 let hubConf: string;
@@ -277,5 +279,66 @@ describe("reload — gate failure still gates", () => {
     }
     expect(String(err)).toMatch(/-t exited 1/);
     expect(signalled.length).toBe(0);
+  });
+});
+
+// =============================================================================
+// cortex#1481 — LIVE HubLocalityPort: reads the SAME DD-10 network-cache file
+// `cortex network join` writes (read-only, local disk — never a live registry
+// round trip), + an injectable hostname. Both are hermetic (tmp cache dir,
+// fake hostname) — never the developer's real ~/.config/cortex or real host.
+// =============================================================================
+describe("buildLiveHubLocalityPort (via buildLiveSecretPorts)", () => {
+  function fakeDescriptor(networkId: string, hubUrl: string): NetworkDescriptor {
+    return { network_id: networkId, hub_url: hubUrl, leaf_port: 7422, members: [] };
+  }
+  function fakeRoster(networkId: string): NetworkRosterResult {
+    return { network_id: networkId, members: [] };
+  }
+
+  test("resolveHubUrl reads the cached descriptor's hub_url written by `network join`", async () => {
+    const cacheDir = mkdtempSync(join(tmp, "netcache-"));
+    const cache = new NetworkCache({ cacheDir });
+    cache.store("metafactory", fakeDescriptor("metafactory", "tls://andreas-vm.example.com:7422"), fakeRoster("metafactory"));
+
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      networkCache: cache,
+      hostname: () => "jc-laptop.local",
+    });
+
+    await expect(ports.hubLocality.resolveHubUrl("metafactory")).resolves.toBe("tls://andreas-vm.example.com:7422");
+    expect(ports.hubLocality.localHostname()).toBe("jc-laptop.local");
+  });
+
+  test("resolveHubUrl resolves undefined when nothing is cached for the network (fail-safe upstream)", async () => {
+    const cacheDir = mkdtempSync(join(tmp, "netcache-empty-"));
+    const cache = new NetworkCache({ cacheDir });
+
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      networkCache: cache,
+      hostname: () => "jc-laptop.local",
+    });
+
+    await expect(ports.hubLocality.resolveHubUrl("never-joined")).resolves.toBeUndefined();
+  });
+
+  test("localHostname defaults to the injected os.hostname() when not overridden", () => {
+    const cacheDir = mkdtempSync(join(tmp, "netcache-hn-"));
+    const ports = buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      networkCache: new NetworkCache({ cacheDir }),
+    });
+    // Whatever the real machine's hostname is — just prove it's a non-empty string
+    // and that the port doesn't hard-fail without an injected override.
+    expect(typeof ports.hubLocality.localHostname()).toBe("string");
+    expect(ports.hubLocality.localHostname().length).toBeGreaterThan(0);
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-secret-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-adapters.test.ts
@@ -341,4 +341,55 @@ describe("buildLiveHubLocalityPort (via buildLiveSecretPorts)", () => {
     expect(typeof ports.hubLocality.localHostname()).toBe("string");
     expect(ports.hubLocality.localHostname().length).toBeGreaterThan(0);
   });
+
+  // Sage review Important 2 — the DNS→local-interface probe, with injected fake
+  // resolver + interface lister (no real DNS / NIC read).
+  function portsWith(opts: {
+    resolveHostAddresses: (host: string) => Promise<string[]>;
+    localInterfaceAddresses: () => string[];
+  }) {
+    return buildLiveSecretPorts({
+      hubConfigPath: hubConf,
+      registryUrl: "http://127.0.0.1:0",
+      material: material(),
+      networkCache: new NetworkCache({ cacheDir: mkdtempSync(join(tmp, "netcache-iface-")) }),
+      hostname: () => "macjcf",
+      resolveHostAddresses: opts.resolveHostAddresses,
+      localInterfaceAddresses: opts.localInterfaceAddresses,
+    });
+  }
+
+  test("hubHostIsLocalInterface → true when the hub FQDN resolves to a local NIC address", async () => {
+    const ports = portsWith({
+      resolveHostAddresses: async () => ["203.0.113.7", "192.168.1.42"],
+      localInterfaceAddresses: () => ["127.0.0.1", "192.168.1.42", "::1"],
+    });
+    await expect(ports.hubLocality.hubHostIsLocalInterface("tls://nats.meta-factory.dev:7422")).resolves.toBe(true);
+  });
+
+  test("hubHostIsLocalInterface → false when the hub FQDN resolves to a NON-local address", async () => {
+    const ports = portsWith({
+      resolveHostAddresses: async () => ["203.0.113.7"],
+      localInterfaceAddresses: () => ["127.0.0.1", "192.168.1.42"],
+    });
+    await expect(ports.hubLocality.hubHostIsLocalInterface("tls://nats.meta-factory.dev:7422")).resolves.toBe(false);
+  });
+
+  test("hubHostIsLocalInterface → false (fail-safe) when DNS resolution throws, never rethrows", async () => {
+    const ports = portsWith({
+      resolveHostAddresses: async () => { throw new Error("ENOTFOUND (fake)"); },
+      localInterfaceAddresses: () => ["127.0.0.1"],
+    });
+    await expect(ports.hubLocality.hubHostIsLocalInterface("tls://nats.meta-factory.dev:7422")).resolves.toBe(false);
+  });
+
+  test("hubHostIsLocalInterface → false for an unparseable hub_url (never calls the resolver)", async () => {
+    let resolverCalled = false;
+    const ports = portsWith({
+      resolveHostAddresses: async () => { resolverCalled = true; return []; },
+      localInterfaceAddresses: () => ["127.0.0.1"],
+    });
+    await expect(ports.hubLocality.hubHostIsLocalInterface("not a url :::")).resolves.toBe(false);
+    expect(resolverCalled).toBe(false);
+  });
 });

--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -42,10 +42,19 @@ interface Calls {
   revoked: string[];
   minted: string[];
 }
-function fakeFactory(opts: { admitted?: { request_id: string; principal_id: string } } = {}): { factory: SecretPortsFactory; calls: Calls; conf: { text: string } } {
+function fakeFactory(opts: {
+  admitted?: { request_id: string; principal_id: string };
+  // cortex#1481 — hub-locality fakes. Defaults resolve LOCAL (loopback alias)
+  // so every PRE-#1481 test keeps its local-hub-write assumption unchanged.
+  hubUrl?: string;
+  noHubCache?: boolean;
+  localHostname?: string;
+} = {}): { factory: SecretPortsFactory; calls: Calls; conf: { text: string } } {
   const calls: Calls = { reads: 0, writes: [], reloads: 0, posted: [], revoked: [], minted: [] };
   const conf = { text: "leafnodes {\n  listen: 0.0.0.0:7422\n}\n" };
   let mintN = 0;
+  const hubUrl = opts.noHubCache === true ? undefined : (opts.hubUrl ?? "tls://localhost:7422");
+  const localHostname = opts.localHostname ?? "localhost";
   const ports: NetworkSecretPorts = {
     hub: {
       confPath: "/fake/hub.conf",
@@ -61,6 +70,10 @@ function fakeFactory(opts: { admitted?: { request_id: string; principal_id: stri
     crypto: {
       mintPsk: () => { const p = `PSK-${++mintN}`; calls.minted.push(p); return p; },
       seal: async (plaintext: string, pubkey: string) => `SEALED(${pubkey.slice(0, 4)}:${plaintext})`,
+    },
+    hubLocality: {
+      resolveHubUrl: async () => hubUrl,
+      localHostname: () => localHostname,
     },
   };
   return { factory: () => ports, calls, conf };
@@ -209,6 +222,107 @@ describe("cortex network secret add-member", () => {
     expect(parsed.data.payload_key_kid).toBe("metafactory/k1");
     expect(parsed.data.payload_key_fingerprint).toBeDefined();
     expect(res.stdout).not.toContain(FAKE_K);
+  });
+});
+
+// =============================================================================
+// cortex#1481 (epic #1479, join-2) — hub locality: NEVER write a foreign hub.
+// =============================================================================
+
+describe("cortex network secret add-member — hub locality (cortex#1481)", () => {
+  test("external hub → no local hub write, artifact printed (human), no secret leak elsewhere", async () => {
+    const { factory, calls } = fakeFactory({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(calls.writes.length).toBe(0);
+    expect(calls.reloads).toBe(0);
+    expect(calls.posted.length).toBe(1); // registry seal still ran
+    expect(res.stdout).toContain("HUB-OWNER ACTION REQUIRED");
+    expect(res.stdout).toContain(calls.minted[0]!); // the artifact IS the one place it prints
+  });
+
+  test("external hub --json → hub_owner_artifact field carries the snippet + PSK", async () => {
+    const { factory, calls } = fakeFactory({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--json", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as { data: Record<string, string> };
+    expect(parsed.data.hub_owner_artifact).toContain("HUB-OWNER ACTION REQUIRED");
+    expect(parsed.data.hub_owner_artifact).toContain(calls.minted[0]);
+    expect(parsed.data.hub_locality).toBe("external");
+  });
+
+  test("--seal-only forces the artifact path even on a local-looking hub", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--seal-only", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(calls.writes.length).toBe(0);
+    expect(calls.reloads).toBe(0);
+    expect(calls.posted.length).toBe(1);
+    expect(res.stdout).toContain("HUB-OWNER ACTION REQUIRED");
+  });
+
+  test("local hub, no --seal-only → writes exactly as before, no artifact printed", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(calls.writes.length).toBe(1);
+    expect(calls.reloads).toBe(1);
+    expect(res.stdout).not.toContain("HUB-OWNER ACTION REQUIRED");
+  });
+
+  test("no cached hub descriptor (can't determine locality) → treated as external, fail-safe", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" }, noHubCache: true });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(calls.writes.length).toBe(0);
+    expect(calls.reloads).toBe(0);
+    expect(res.stdout).toContain("HUB-OWNER ACTION REQUIRED");
+  });
+
+  test("--hub-account <A…> rides the printed snippet's account: field", async () => {
+    const { factory } = fakeFactory({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const account = "A" + "D".repeat(55);
+    const res = await dispatchNetwork(
+      argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--hub-account", account, "--admin-seed", seedPath),
+      undefined, undefined, undefined, factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain(`account: "${account}"`);
+  });
+
+  test("malformed --hub-account → usage error (exit 2)", async () => {
+    const { factory } = fakeFactory({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const res = await dispatchNetwork(
+      argv("secret", "add-member", "metafactory", MEMBER, "--apply", "--hub-account", "not-an-nkey", "--admin-seed", seedPath),
+      undefined, undefined, undefined, factory,
+    );
+    expect(res.exitCode).toBe(2);
+  });
+
+  test("external hub dry-run: plan mentions seal-only + external, no mutation, no secret", async () => {
+    const { factory, calls } = fakeFactory({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const res = await dispatchNetwork(argv("secret", "add-member", "metafactory", MEMBER, "--admin-seed", seedPath), undefined, undefined, undefined, factory);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("dry-run");
+    expect(res.stdout.toLowerCase()).toContain("seal-only");
+    expect(calls.writes.length).toBe(0);
+    expect(calls.minted.length).toBe(0);
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -49,12 +49,14 @@ function fakeFactory(opts: {
   hubUrl?: string;
   noHubCache?: boolean;
   localHostname?: string;
+  hubHostIsLocalInterface?: boolean;
 } = {}): { factory: SecretPortsFactory; calls: Calls; conf: { text: string } } {
   const calls: Calls = { reads: 0, writes: [], reloads: 0, posted: [], revoked: [], minted: [] };
   const conf = { text: "leafnodes {\n  listen: 0.0.0.0:7422\n}\n" };
   let mintN = 0;
   const hubUrl = opts.noHubCache === true ? undefined : (opts.hubUrl ?? "tls://localhost:7422");
   const localHostname = opts.localHostname ?? "localhost";
+  const hubHostIsLocalInterface = opts.hubHostIsLocalInterface ?? false;
   const ports: NetworkSecretPorts = {
     hub: {
       confPath: "/fake/hub.conf",
@@ -74,6 +76,7 @@ function fakeFactory(opts: {
     hubLocality: {
       resolveHubUrl: async () => hubUrl,
       localHostname: () => localHostname,
+      hubHostIsLocalInterface: async () => hubHostIsLocalInterface,
     },
   };
   return { factory: () => ports, calls, conf };

--- a/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
@@ -16,6 +16,8 @@ import {
   runNetworkSecret,
   runNetworkKeyRotation,
   computeNextKid,
+  decideHubLocality,
+  renderHubOwnerArtifact,
   type SecretInputs,
   type KeyRotationInputs,
 } from "../network-secret-lib";
@@ -37,7 +39,18 @@ interface Recorder {
   minted: string[];
 }
 
-function makePorts(opts: { admitted?: { request_id: string; principal_id: string }; startConf?: string } = {}): Recorder {
+function makePorts(opts: {
+  admitted?: { request_id: string; principal_id: string };
+  startConf?: string;
+  // cortex#1481 — hub-locality fakes. Defaults resolve LOCAL (loopback alias)
+  // so every PRE-#1481 test keeps its local-hub-write assumption unchanged.
+  /** Cached hub_url the fake `resolveHubUrl` returns. Default: loopback (LOCAL). */
+  hubUrl?: string;
+  /** true ⇒ resolveHubUrl resolves undefined (no cached descriptor — "can't determine"). */
+  noHubCache?: boolean;
+  /** This machine's fake hostname. Default "localhost" (irrelevant when hubUrl is a loopback alias). */
+  localHostname?: string;
+} = {}): Recorder {
   const hubConf = { text: opts.startConf ?? "leafnodes {\n  listen: 0.0.0.0:7422\n}\n" };
   const writes: string[] = [];
   let reloads = 0;
@@ -45,6 +58,8 @@ function makePorts(opts: { admitted?: { request_id: string; principal_id: string
   const revoked: string[] = [];
   const minted: string[] = [];
   let mintCounter = 0;
+  const hubUrl = opts.noHubCache === true ? undefined : (opts.hubUrl ?? "tls://localhost:7422");
+  const localHostname = opts.localHostname ?? "localhost";
 
   const ports: NetworkSecretPorts = {
     hub: {
@@ -76,6 +91,10 @@ function makePorts(opts: { admitted?: { request_id: string; principal_id: string
         return p;
       },
       seal: async (plaintext: string, pubkey: string) => `SEALED(${pubkey.slice(0, 6)}:${plaintext})`,
+    },
+    hubLocality: {
+      resolveHubUrl: async () => hubUrl,
+      localHostname: () => localHostname,
     },
   };
   return {
@@ -262,6 +281,232 @@ describe("dry-run (default) + guards", () => {
     expect(report.ok).toBe(false);
     expect(r.writes.length).toBe(0);
     expect(r.posted.length).toBe(0);
+  });
+});
+
+// ===========================================================================
+// cortex#1481 (epic #1479, join-2) — hub locality: NEVER write a foreign hub.
+//
+// The #1 storm cause: `--hub-config` defaults to the LOCAL nats, so when a
+// network's hub is ANOTHER principal's server, add-member/rotate wrote the
+// leaf authorization onto the wrong machine — the real hub never saw it, and
+// the joiner's leaf Authorization-Violation-storms. These tests prove: (a) an
+// external hub never gets the local write (registry seal still runs, artifact
+// emitted); (b) --seal-only forces the same path even on a local-looking hub;
+// (c) a genuinely local hub still writes exactly as before; (d) an unresolved
+// hub_url (no cached descriptor) is treated as external — fail-safe.
+// ===========================================================================
+
+describe("decideHubLocality (pure)", () => {
+  test("loopback alias → local", () => {
+    expect(decideHubLocality("tls://localhost:7422", "some-other-hostname").kind).toBe("local");
+    expect(decideHubLocality("tls://127.0.0.1:7422", "some-other-hostname").kind).toBe("local");
+    expect(decideHubLocality("tls://[::1]:7422", "some-other-hostname").kind).toBe("local");
+  });
+
+  test("exact case-insensitive hostname match → local", () => {
+    expect(decideHubLocality("tls://Andreas-VM.local:7422", "andreas-vm.local").kind).toBe("local");
+  });
+
+  test("a genuinely different host → external, with a reason (no secret)", () => {
+    const v = decideHubLocality("tls://andreas-vm.example.com:7422", "jc-laptop.local");
+    expect(v.kind).toBe("external");
+    if (v.kind === "external") {
+      expect(v.hubUrl).toBe("tls://andreas-vm.example.com:7422");
+      expect(v.reason).toContain("andreas-vm.example.com");
+      expect(v.reason).toContain("does not match this machine");
+    }
+  });
+
+  test("no cached hub_url at all → external (fail-safe, cannot determine)", () => {
+    const v = decideHubLocality(undefined, "jc-laptop.local");
+    expect(v.kind).toBe("external");
+    if (v.kind === "external") {
+      expect(v.hubUrl).toBeUndefined();
+      expect(v.reason).toContain("no cached network descriptor");
+    }
+  });
+
+  test("an unparseable hub_url → external (fail-safe)", () => {
+    const v = decideHubLocality("not a url at all :::", "jc-laptop.local");
+    expect(v.kind).toBe("external");
+  });
+});
+
+describe("renderHubOwnerArtifact (pure)", () => {
+  test("carries the exact leafnodes{} authorization snippet + the PSK", () => {
+    const lines = renderHubOwnerArtifact({
+      networkId: "metafactory",
+      leafUser: "andreas",
+      psk: "PSK-for-the-hub-owner",
+      hubUrl: "tls://andreas-vm.example.com:7422",
+    }).join("\n");
+    expect(lines).toContain("leafnodes {");
+    expect(lines).toContain("authorization {");
+    expect(lines).toContain('"andreas"');
+    expect(lines).toContain("PSK-for-the-hub-owner");
+    expect(lines).toContain("tls://andreas-vm.example.com:7422");
+    // No account known → the user entry itself carries NO account: field...
+    expect(lines).toContain('{ user: "andreas", password: "PSK-for-the-hub-owner" }');
+    // ...but an advisory note points the hub owner at --hub-account.
+    expect(lines).toContain("--hub-account");
+  });
+
+  test("account-bound when --hub-account is known", () => {
+    const lines = renderHubOwnerArtifact({
+      networkId: "metafactory",
+      leafUser: "andreas",
+      psk: "PSK-x",
+      account: "A" + "B".repeat(55),
+    }).join("\n");
+    expect(lines).toContain(`account: "A${"B".repeat(55)}"`);
+  });
+
+  test("hub_url unknown → says so instead of fabricating one", () => {
+    const lines = renderHubOwnerArtifact({ networkId: "metafactory", leafUser: "andreas", psk: "PSK-x" }).join("\n");
+    expect(lines).toContain("could not be confirmed");
+  });
+});
+
+describe("add-member — hub locality gate (apply)", () => {
+  test("(a) external hub → NO local hub write/reload, artifact emitted, seal still posted", async () => {
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const report = await runNetworkSecret(inputs({ apply: true }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(true);
+    // The local hub port's write/reload were NEVER called (spy assertion).
+    expect(r.writes.length).toBe(0);
+    expect(r.reloads).toBe(0);
+    // The registry seal still ran (machine-independent).
+    expect(r.posted.length).toBe(1);
+    expect(r.posted[0]!.requestId).toBe("req1");
+    // The hub-owner artifact carries the PSK + is distinct from steps/data.
+    expect(report.hubOwnerArtifact).toBeDefined();
+    const artifact = report.hubOwnerArtifact!.join("\n");
+    expect(artifact).toContain(r.minted[0]!);
+    expect(artifact).toContain("tls://andreas-vm.example.com:7422");
+    assertNoSecretLeak(report.steps, report.data, r.minted[0]!);
+    expect(report.data.hub_locality).toBe("external");
+  });
+
+  test("(b) --seal-only on a LOCAL-looking hub → still no write + artifact emitted", async () => {
+    // hubUrl/localHostname default to the SAME loopback alias (would resolve
+    // local without the flag) — --seal-only must override that.
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({ apply: true, sealOnly: true }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(r.writes.length).toBe(0);
+    expect(r.reloads).toBe(0);
+    expect(r.posted.length).toBe(1);
+    expect(report.hubOwnerArtifact).toBeDefined();
+    expect(report.data.hub_locality).toBe("external");
+  });
+
+  test("(c) local hub, no --seal-only → writes exactly as before, no artifact", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({ apply: true }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(r.writes.length).toBe(1);
+    expect(r.reloads).toBe(1);
+    expect(listHubLeafUsers(r.hubConf.text)).toEqual([{ user: "alice", secret: "PSK-1" }]);
+    expect(report.hubOwnerArtifact).toBeUndefined();
+    expect(report.data.hub_locality).toBe("local");
+  });
+
+  test("(d) no cached descriptor (can't determine locality) → treated as EXTERNAL, fail-safe", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" }, noHubCache: true });
+    const report = await runNetworkSecret(inputs({ apply: true }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(r.writes.length).toBe(0);
+    expect(r.reloads).toBe(0);
+    expect(r.posted.length).toBe(1);
+    expect(report.hubOwnerArtifact).toBeDefined();
+    expect(report.data.hub_locality).toBe("external");
+  });
+
+  test("external hub + oob delivery → BOTH surfaced (member handover) AND hubOwnerArtifact (hub handover)", async () => {
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const report = await runNetworkSecret(inputs({ apply: true, deliver: "oob" }), r.ports);
+
+    expect(r.writes.length).toBe(0);
+    expect(r.reloads).toBe(0);
+    expect(r.posted.length).toBe(0); // oob never touches the registry
+    expect(report.surfaced).toEqual({ leafUser: "alice", psk: r.minted[0]! });
+    expect(report.hubOwnerArtifact).toBeDefined();
+  });
+
+  test("rotate on an external hub → no local hub write, re-seal still posted, artifact emitted", async () => {
+    const start = 'leafnodes {\n  # >>> cortex-managed leaf authorization (network secret tooling) — do not hand-edit\n  authorization {\n    users: [\n      { user: "alice", password: "PSK-old" }\n    ]\n  }\n  # <<< cortex-managed leaf authorization\n}\n';
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      startConf: start,
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const report = await runNetworkSecret(inputs({ action: "rotate", apply: true }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(r.writes.length).toBe(0);
+    expect(r.reloads).toBe(0);
+    // The OLD hub-side entry is untouched (we never wrote it).
+    expect(r.hubConf.text).toContain("PSK-old");
+    expect(r.posted.length).toBe(1);
+    expect(report.hubOwnerArtifact).toBeDefined();
+  });
+
+  test("--hub-account rides the artifact's account: field", async () => {
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const account = "A" + "C".repeat(55);
+    const report = await runNetworkSecret(inputs({ apply: true, hubAccount: account }), r.ports);
+    expect(report.hubOwnerArtifact!.join("\n")).toContain(`account: "${account}"`);
+  });
+});
+
+describe("add-member — hub locality gate (dry-run)", () => {
+  test("external hub dry-run: plan says SEAL-ONLY + emit artifact, no secret, no mutation", async () => {
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://andreas-vm.example.com:7422",
+      localHostname: "jc-laptop.local",
+    });
+    const report = await runNetworkSecret(inputs({ apply: false }), r.ports);
+    expect(report.applied).toBe(false);
+    expect(r.writes.length).toBe(0);
+    expect(r.reloads).toBe(0);
+    expect(r.posted.length).toBe(0);
+    expect(report.steps.join("\n").toLowerCase()).toContain("seal-only");
+    expect(report.steps.join("\n").toLowerCase()).toContain("external");
+    expect(report.data.hub_locality).toBe("external");
+  });
+
+  test("--seal-only dry-run on a local-looking hub: plan still says SEAL-ONLY", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({ apply: false, sealOnly: true }), r.ports);
+    expect(report.data.hub_locality).toBe("external");
+    expect(report.steps.join("\n").toLowerCase()).toContain("seal-only");
+  });
+
+  test("local hub dry-run: plan is unchanged from pre-#1481 wording", async () => {
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({ apply: false }), r.ports);
+    expect(report.data.hub_locality).toBe("local");
+    expect(report.steps.join("\n")).toContain('add hub authorization user "alice"');
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
@@ -50,6 +50,9 @@ function makePorts(opts: {
   noHubCache?: boolean;
   /** This machine's fake hostname. Default "localhost" (irrelevant when hubUrl is a loopback alias). */
   localHostname?: string;
+  /** Sage review Important 2 — fake DNS→local-interface signal. Default false
+   *  (the loopback-alias default already resolves LOCAL without it). */
+  hubHostIsLocalInterface?: boolean;
 } = {}): Recorder {
   const hubConf = { text: opts.startConf ?? "leafnodes {\n  listen: 0.0.0.0:7422\n}\n" };
   const writes: string[] = [];
@@ -60,6 +63,7 @@ function makePorts(opts: {
   let mintCounter = 0;
   const hubUrl = opts.noHubCache === true ? undefined : (opts.hubUrl ?? "tls://localhost:7422");
   const localHostname = opts.localHostname ?? "localhost";
+  const hubHostIsLocalInterface = opts.hubHostIsLocalInterface ?? false;
 
   const ports: NetworkSecretPorts = {
     hub: {
@@ -95,6 +99,7 @@ function makePorts(opts: {
     hubLocality: {
       resolveHubUrl: async () => hubUrl,
       localHostname: () => localHostname,
+      hubHostIsLocalInterface: async () => hubHostIsLocalInterface,
     },
   };
   return {
@@ -293,33 +298,61 @@ describe("dry-run (default) + guards", () => {
 // the joiner's leaf Authorization-Violation-storms. These tests prove: (a) an
 // external hub never gets the local write (registry seal still runs, artifact
 // emitted); (b) --seal-only forces the same path even on a local-looking hub;
-// (c) a genuinely local hub still writes exactly as before; (d) an unresolved
-// hub_url (no cached descriptor) is treated as external — fail-safe.
+// (c) a genuinely local hub (loopback/exact-hostname) still writes as before;
+// (c') a hub cached as an FQDN that resolves to a local interface ALSO writes
+// locally (the real hub-owner deployment — Sage review Important 2); (d) an
+// unresolved hub_url (no cached descriptor) is treated as external — fail-safe.
 // ===========================================================================
 
 describe("decideHubLocality (pure)", () => {
-  test("loopback alias → local", () => {
-    expect(decideHubLocality("tls://localhost:7422", "some-other-hostname").kind).toBe("local");
-    expect(decideHubLocality("tls://127.0.0.1:7422", "some-other-hostname").kind).toBe("local");
-    expect(decideHubLocality("tls://[::1]:7422", "some-other-hostname").kind).toBe("local");
+  // Convenience: the common "no interface signal" input.
+  const notLocalIface = (localHostname: string) => ({ localHostname, hubHostIsLocalInterface: false });
+
+  test("loopback alias → local (no interface signal needed)", () => {
+    expect(decideHubLocality("tls://localhost:7422", notLocalIface("some-other-hostname")).kind).toBe("local");
+    expect(decideHubLocality("tls://127.0.0.1:7422", notLocalIface("some-other-hostname")).kind).toBe("local");
+    expect(decideHubLocality("tls://[::1]:7422", notLocalIface("some-other-hostname")).kind).toBe("local");
   });
 
   test("exact case-insensitive hostname match → local", () => {
-    expect(decideHubLocality("tls://Andreas-VM.local:7422", "andreas-vm.local").kind).toBe("local");
+    expect(decideHubLocality("tls://Andreas-VM.local:7422", notLocalIface("andreas-vm.local")).kind).toBe("local");
   });
 
-  test("a genuinely different host → external, with a reason (no secret)", () => {
-    const v = decideHubLocality("tls://andreas-vm.example.com:7422", "jc-laptop.local");
+  test("Sage Important 2 — FQDN hub that resolves to a LOCAL INTERFACE → local (short hostname mismatch)", () => {
+    // The real-deployment case: hub cached as an FQDN, os.hostname() a short
+    // name — neither loopback nor exact-hostname fires, but the interface probe
+    // confirms it's this machine's own hub VM.
+    const v = decideHubLocality("tls://nats.meta-factory.dev:7422", {
+      localHostname: "macjcf",
+      hubHostIsLocalInterface: true,
+    });
+    expect(v.kind).toBe("local");
+  });
+
+  test("Sage Important 2 — FQDN hub, NOT a local interface → external", () => {
+    const v = decideHubLocality("tls://nats.meta-factory.dev:7422", {
+      localHostname: "macjcf",
+      hubHostIsLocalInterface: false,
+    });
+    expect(v.kind).toBe("external");
+    if (v.kind === "external") {
+      expect(v.hubUrl).toBe("tls://nats.meta-factory.dev:7422");
+      expect(v.reason).toContain("nats.meta-factory.dev");
+      expect(v.reason).toContain("local network interface");
+    }
+  });
+
+  test("a genuinely different host (no interface match) → external, with a reason", () => {
+    const v = decideHubLocality("tls://andreas-vm.example.com:7422", notLocalIface("jc-laptop.local"));
     expect(v.kind).toBe("external");
     if (v.kind === "external") {
       expect(v.hubUrl).toBe("tls://andreas-vm.example.com:7422");
       expect(v.reason).toContain("andreas-vm.example.com");
-      expect(v.reason).toContain("does not match this machine");
     }
   });
 
   test("no cached hub_url at all → external (fail-safe, cannot determine)", () => {
-    const v = decideHubLocality(undefined, "jc-laptop.local");
+    const v = decideHubLocality(undefined, notLocalIface("jc-laptop.local"));
     expect(v.kind).toBe("external");
     if (v.kind === "external") {
       expect(v.hubUrl).toBeUndefined();
@@ -328,7 +361,7 @@ describe("decideHubLocality (pure)", () => {
   });
 
   test("an unparseable hub_url → external (fail-safe)", () => {
-    const v = decideHubLocality("not a url at all :::", "jc-laptop.local");
+    const v = decideHubLocality("not a url at all :::", notLocalIface("jc-laptop.local"));
     expect(v.kind).toBe("external");
   });
 });
@@ -416,6 +449,25 @@ describe("add-member — hub locality gate (apply)", () => {
     expect(r.writes.length).toBe(1);
     expect(r.reloads).toBe(1);
     expect(listHubLeafUsers(r.hubConf.text)).toEqual([{ user: "alice", secret: "PSK-1" }]);
+    expect(report.hubOwnerArtifact).toBeUndefined();
+    expect(report.data.hub_locality).toBe("local");
+  });
+
+  test("(c') Sage Important 2 — FQDN hub that resolves to a local interface → writes locally (hostname mismatch)", async () => {
+    // The real hub-owner deployment: hub cached as an FQDN, os.hostname() a
+    // short name — the DNS→local-interface signal is what keeps the auto-write
+    // alive. Without it this would (wrongly) fall to the artifact path.
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      hubUrl: "tls://nats.meta-factory.dev:7422",
+      localHostname: "macjcf",
+      hubHostIsLocalInterface: true,
+    });
+    const report = await runNetworkSecret(inputs({ apply: true }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(r.writes.length).toBe(1);
+    expect(r.reloads).toBe(1);
     expect(report.hubOwnerArtifact).toBeUndefined();
     expect(report.data.hub_locality).toBe("local");
   });

--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -31,7 +31,8 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, chmodSync, renameSync } from "fs";
-import { resolve as resolvePath } from "path";
+import { resolve as resolvePath, join as joinPath } from "path";
+import { hostname as osHostname } from "os";
 
 import { expandTilde } from "../../../common/config/loader";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
@@ -51,6 +52,7 @@ import {
   type StackIdentityMaterial,
 } from "../../../bus/stack-provisioning";
 import { bunExecRunner, type ExecRunner } from "../../../common/nats/nats-service-manager";
+import { NetworkCache } from "../../../common/registry/network-cache";
 import {
   readNetworksFromConfig,
   writeNetworksGuarded,
@@ -61,6 +63,7 @@ import type {
   AdmissionLookupPort,
   SealDeliveryPort,
   SecretCrypto,
+  HubLocalityPort,
   NetworkKeyRotationPorts,
   AdmittedListPort,
   HubKeyStorePort,
@@ -140,6 +143,16 @@ export interface LiveSecretPortsConfig {
   signal?: SignalSender;
   /** Injectable fetch (tests). Production omits → globalThis.fetch. */
   fetchImpl?: typeof globalThis.fetch;
+  /**
+   * cortex#1481 — injectable network-descriptor cache (tests). Production
+   * omits → a {@link NetworkCache} rooted at the SAME `~/.config/cortex/
+   * network-cache/` DD-10 dir `cortex network join` writes (resolved via
+   * `expandTilde` for $HOME-honouring test hermeticity, mirroring
+   * `network-adapters.ts`'s `buildCachedNetworkPort`).
+   */
+  networkCache?: NetworkCache;
+  /** Injectable hostname resolver (tests). Production omits → `os.hostname()`. */
+  hostname?: () => string;
 }
 
 /** Build the full live port bundle. */
@@ -149,6 +162,7 @@ export function buildLiveSecretPorts(cfg: LiveSecretPortsConfig): NetworkSecretP
     admission: buildLiveAdmissionLookupPort(cfg),
     delivery: buildLiveSealDeliveryPort(cfg),
     crypto: buildLiveSecretCrypto(),
+    hubLocality: buildLiveHubLocalityPort(cfg),
   };
 }
 
@@ -361,6 +375,33 @@ function buildLiveSecretCrypto(): SecretCrypto {
   return {
     mintPsk: () => mintLeafPsk(),
     seal: (plaintext, pubkey) => sealToPrincipal(plaintext, pubkey),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// cortex#1481 — HUB LOCALITY: read-only, local-disk-only hub_url resolution.
+// ---------------------------------------------------------------------------
+
+/**
+ * cortex#1481 — LIVE {@link HubLocalityPort}: reads the SAME DD-10
+ * `~/.config/cortex/network-cache/<network>.json` last-known-good cache
+ * `cortex network join` writes (read-only, local disk — deliberately never a
+ * live registry round trip; see the port jsdoc for why), + `os.hostname()`.
+ * Both facts are injectable so tests never touch the real home directory or
+ * the real machine hostname.
+ */
+function buildLiveHubLocalityPort(cfg: LiveSecretPortsConfig): HubLocalityPort {
+  const cache =
+    cfg.networkCache ??
+    new NetworkCache({ cacheDir: expandTilde(joinPath("~", ".config", "cortex", "network-cache")) });
+  const getHostname = cfg.hostname ?? osHostname;
+  return {
+    resolveHubUrl(networkId) {
+      return Promise.resolve(cache.load(networkId)?.descriptor.hub_url);
+    },
+    localHostname() {
+      return getHostname();
+    },
   };
 }
 

--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -32,7 +32,8 @@
 
 import { existsSync, readFileSync, writeFileSync, chmodSync, renameSync } from "fs";
 import { resolve as resolvePath, join as joinPath } from "path";
-import { hostname as osHostname } from "os";
+import { hostname as osHostname, networkInterfaces as osNetworkInterfaces } from "os";
+import { lookup as dnsLookup } from "dns/promises";
 
 import { expandTilde } from "../../../common/config/loader";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
@@ -53,6 +54,7 @@ import {
 } from "../../../bus/stack-provisioning";
 import { bunExecRunner, type ExecRunner } from "../../../common/nats/nats-service-manager";
 import { NetworkCache } from "../../../common/registry/network-cache";
+import { extractHubHost } from "./network-secret-lib";
 import {
   readNetworksFromConfig,
   writeNetworksGuarded,
@@ -153,6 +155,18 @@ export interface LiveSecretPortsConfig {
   networkCache?: NetworkCache;
   /** Injectable hostname resolver (tests). Production omits → `os.hostname()`. */
   hostname?: () => string;
+  /**
+   * cortex#1481 (Sage review, Important 2) — injectable DNS resolver: host →
+   * its IP addresses (tests). Production omits → `dns/promises.lookup(host,
+   * {all:true})`. Used by `hubHostIsLocalInterface` to decide whether the hub's
+   * host points at this machine.
+   */
+  resolveHostAddresses?: (host: string) => Promise<string[]>;
+  /**
+   * cortex#1481 — injectable local-interface address lister (tests). Production
+   * omits → `os.networkInterfaces()` flattened to bare addresses.
+   */
+  localInterfaceAddresses?: () => string[];
 }
 
 /** Build the full live port bundle. */
@@ -382,25 +396,63 @@ function buildLiveSecretCrypto(): SecretCrypto {
 // cortex#1481 — HUB LOCALITY: read-only, local-disk-only hub_url resolution.
 // ---------------------------------------------------------------------------
 
+/** Production DNS resolver: host → its IP addresses (v4 + v6). */
+const defaultResolveHostAddresses = async (host: string): Promise<string[]> => {
+  const results = await dnsLookup(host, { all: true });
+  return results.map((r) => r.address);
+};
+
+/** Production local-interface lister: every address on `os.networkInterfaces()`. */
+const defaultLocalInterfaceAddresses = (): string[] => {
+  const out: string[] = [];
+  for (const ifaces of Object.values(osNetworkInterfaces())) {
+    for (const iface of ifaces ?? []) out.push(iface.address);
+  }
+  return out;
+};
+
 /**
  * cortex#1481 — LIVE {@link HubLocalityPort}: reads the SAME DD-10
  * `~/.config/cortex/network-cache/<network>.json` last-known-good cache
  * `cortex network join` writes (read-only, local disk — deliberately never a
- * live registry round trip; see the port jsdoc for why), + `os.hostname()`.
- * Both facts are injectable so tests never touch the real home directory or
- * the real machine hostname.
+ * live registry round trip; see the port jsdoc for why), + `os.hostname()`, +
+ * (Sage review Important 2) a DNS→local-interface probe so a hub owner whose
+ * own hub is cached as an FQDN still gets the local auto-write. Every fact is
+ * injectable so tests never touch the real home dir, hostname, DNS, or NICs.
  */
 function buildLiveHubLocalityPort(cfg: LiveSecretPortsConfig): HubLocalityPort {
   const cache =
     cfg.networkCache ??
     new NetworkCache({ cacheDir: expandTilde(joinPath("~", ".config", "cortex", "network-cache")) });
   const getHostname = cfg.hostname ?? osHostname;
+  const resolveHostAddresses = cfg.resolveHostAddresses ?? defaultResolveHostAddresses;
+  const localInterfaceAddresses = cfg.localInterfaceAddresses ?? defaultLocalInterfaceAddresses;
   return {
     resolveHubUrl(networkId) {
       return Promise.resolve(cache.load(networkId)?.descriptor.hub_url);
     },
     localHostname() {
       return getHostname();
+    },
+    async hubHostIsLocalInterface(hubUrl) {
+      // Parse the SAME host the pure decider matches on (one grammar, no drift).
+      const host = extractHubHost(hubUrl);
+      if (host === undefined) return false;
+      let addresses: string[];
+      try {
+        addresses = await resolveHostAddresses(host);
+      } catch (err) {
+        // FAIL-SAFE: a DNS failure must NEVER throw (the seal proceeds) and must
+        // NEVER be read as "local" (that would risk the foreign-hub write). Log
+        // + treat as NOT local → the caller falls to the EXTERNAL artifact path.
+        process.stderr.write(
+          `cortex network secret: hub host "${host}" DNS lookup failed (${err instanceof Error ? err.message : String(err)}); ` +
+            `treating the hub as NOT local (external) — fail-safe\n`,
+        );
+        return false;
+      }
+      const local = new Set(localInterfaceAddresses());
+      return addresses.some((a) => local.has(a));
     },
   };
 }

--- a/src/cli/cortex/commands/network-secret-lib.ts
+++ b/src/cli/cortex/commands/network-secret-lib.ts
@@ -53,6 +53,25 @@ export interface SecretInputs {
   /** Override the hub leaf user (defaults to the member's principal id). */
   leafUserOverride?: string;
   /**
+   * cortex#1481 — force the SEAL-ONLY path (registry seal + hub-owner artifact,
+   * NEVER a local hub write) even when {@link decideHubLocality} would otherwise
+   * call the hub local. The explicit opt-in for "I know this hub isn't mine, or
+   * I don't trust the auto-detection" — add-member/rotate only (revoke-member
+   * still cuts the local hub unconditionally; #1481 scopes the fix to the mint+
+   * write seam that storms).
+   */
+  sealOnly?: boolean;
+  /**
+   * cortex#1481 — the hub's OWN federation account nkey-U (`A…`), when the
+   * caller happens to know it (`--hub-account`). Only meaningful when the hub
+   * turns out to be EXTERNAL (or `sealOnly` is set): it rides the hub-owner
+   * artifact's `account:` field so the printed snippet is account-bound
+   * (operator-mode). Absent ⇒ the artifact omits `account:` and tells the hub
+   * owner to add it themselves (only they have visibility into their own
+   * account tree).
+   */
+  hubAccount?: string;
+  /**
    * C-1349 Slice 1 — the per-network payload key `K` (base64, 32 bytes) read
    * from the HUB STACK's own resolved config (`policy.federated.networks[<net>]
    * .payload_key`) by the CLI. When present (add-member / rotate), it is sealed
@@ -89,6 +108,15 @@ export interface SecretReport {
    * legitimately reaches stdout). Absent for sealed delivery.
    */
   surfaced?: { leafUser: string; psk: string };
+  /**
+   * cortex#1481 — present iff the hub turned out to be EXTERNAL (or `sealOnly`
+   * forced it): the EXACT `leafnodes { authorization { users: [...] } }`
+   * snippet + hand-off note the hub owner must add to THEIR OWN nats-server
+   * config, since the orchestrator refused to write it here. The other
+   * legitimate place the raw PSK reaches the caller (alongside `surfaced`) —
+   * the render caller shows it explicitly, never folds it into `steps`.
+   */
+  hubOwnerArtifact?: string[];
 }
 
 /** Dispatch by action. */
@@ -104,6 +132,161 @@ export async function runNetworkSecret(
     case "revoke-member":
       return revokeMember(inputs, ports);
   }
+}
+
+// ===========================================================================
+// cortex#1481 (epic #1479, join-2) — hub locality: NEVER write a foreign hub.
+//
+// The #1 storm cause: `--hub-config` defaults to the LOCAL nats, so when a
+// network's hub is ANOTHER principal's server, `add-member`/`admit --and-seal`
+// wrote the leaf authorization onto the admin's own laptop — never the real
+// hub — and the joiner's leaf then Authorization-Violation-storms against the
+// real hub (which never saw the PSK). {@link decideHubLocality} is the PURE,
+// fail-safe decision (data in, verdict out — no I/O); {@link
+// renderHubOwnerArtifact} is the PURE artifact the orchestrator emits INSTEAD
+// of the local write when the hub is external. Both are exported for direct
+// unit testing; `addOrRotate` is the only caller in the orchestrator itself.
+// ===========================================================================
+
+/** Loopback aliases considered an UNAMBIGUOUS match for "this host", as
+ *  returned by `new URL(...).hostname` (bracketed IPv6). Compared
+ *  case-insensitively against the parsed hub_url host. */
+const LOCAL_HOST_ALIASES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/**
+ * Parse the host out of a `hub_url` (a full `tls://host:port` URL — DD-12 —
+ * or a bare host; mirrors `resolveLeafUrl` in `leaf-remote-renderer.ts`).
+ * Returns `undefined` on an empty/unparseable value — the caller treats that
+ * as "cannot determine" (fails safe to EXTERNAL).
+ */
+function extractHubHost(hubUrl: string): string | undefined {
+  const raw = hubUrl.trim();
+  if (raw.length === 0) return undefined;
+  const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw);
+  const withScheme = hasScheme ? raw : `tls://${raw}`;
+  try {
+    const parsed = new URL(withScheme);
+    return parsed.hostname.length > 0 ? parsed.hostname : undefined;
+  } catch (_err) {
+    // A malformed hub_url is not this function's concern to report — the
+    // caller (decideHubLocality) turns an undefined host into "cannot
+    // determine" and fails safe to EXTERNAL, which is the correct behavior
+    // for a value we can't parse.
+    return undefined;
+  }
+}
+
+/** The cortex#1481 hub-locality verdict. `hubUrl` rides the EXTERNAL branch
+ *  (when known) so the hub-owner artifact can name the hub. */
+export type HubLocality =
+  | { kind: "local" }
+  | { kind: "external"; hubUrl?: string; reason: string };
+
+/**
+ * cortex#1481 — PURE, fail-safe locality decision. A network's hub counts as
+ * LOCAL only on a CONFIDENT match: a loopback alias, or an EXACT
+ * case-insensitive match against this machine's own hostname. Every other
+ * case — no cached descriptor, an unparseable hub_url, or a genuinely
+ * different host — is EXTERNAL. The asymmetry is deliberate: a false "local"
+ * IS the #1481 storm bug (writes a foreign hub); a false "external" only
+ * costs an extra hand-off step (the hub-owner artifact instead of an
+ * automatic write) — so every ambiguous case resolves to EXTERNAL.
+ */
+export function decideHubLocality(
+  hubUrl: string | undefined,
+  localHostname: string,
+): HubLocality {
+  if (hubUrl === undefined || hubUrl.trim() === "") {
+    return {
+      kind: "external",
+      reason:
+        "no cached network descriptor for this network on this host (never joined/synced here) — cannot confirm the hub is local; treating as EXTERNAL (fail-safe)",
+    };
+  }
+  const host = extractHubHost(hubUrl);
+  if (host === undefined) {
+    return {
+      kind: "external",
+      hubUrl,
+      reason: `could not parse a host from the network's hub_url ${JSON.stringify(hubUrl)} — treating as EXTERNAL (fail-safe)`,
+    };
+  }
+  const lowerHost = host.toLowerCase();
+  const lowerLocal = localHostname.trim().toLowerCase();
+  if (LOCAL_HOST_ALIASES.has(lowerHost) || (lowerLocal.length > 0 && lowerHost === lowerLocal)) {
+    return { kind: "local" };
+  }
+  return {
+    kind: "external",
+    hubUrl,
+    reason:
+      `network hub_url host "${host}" does not match this machine ` +
+      `(${localHostname.trim().length > 0 ? localHostname : "unknown hostname"}) — refusing to write the local nats config`,
+  };
+}
+
+/** Inputs {@link renderHubOwnerArtifact} needs to print the EXACT snippet the
+ *  hub owner adds to THEIR OWN nats-server config. */
+export interface HubOwnerArtifactInputs {
+  networkId: string;
+  /** The hub `authorization` user (the userinfo USER the leaf dials with). */
+  leafUser: string;
+  /** The freshly-minted PSK — the ONE legitimate reason this rides the artifact. */
+  psk: string;
+  /** The network's hub_url, when known (absent ⇒ locality couldn't be confirmed at all). */
+  hubUrl?: string;
+  /**
+   * The hub's OWN federation account nkey-U, when the caller happens to know
+   * it (`--hub-account`). Present ⇒ the snippet is account-bound
+   * (operator-mode). Absent ⇒ the snippet omits `account:` and the artifact
+   * tells the hub owner to add it themselves — only THEY have visibility into
+   * their own account tree.
+   */
+  account?: string;
+}
+
+/**
+ * cortex#1481 — render the EXACT `leafnodes { authorization { users: [...] }
+ * }` snippet the hub owner must add to THEIR OWN nats-server config, plus a
+ * hand-off note. This is what the orchestrator emits INSTEAD OF writing the
+ * local hub when the hub is external (or `--seal-only` forced it). PURE (data
+ * in, text out) — the second legitimate place (alongside
+ * `SecretReport.surfaced`) the raw PSK reaches the caller; the render layer
+ * shows it explicitly, never folds it into `steps`/`data`.
+ */
+export function renderHubOwnerArtifact(inputs: HubOwnerArtifactInputs): string[] {
+  const lines: string[] = [];
+  lines.push("── HUB-OWNER ACTION REQUIRED (this network's hub is NOT this machine) ──");
+  lines.push(
+    inputs.hubUrl !== undefined
+      ? `network:     ${inputs.networkId}  (hub: ${inputs.hubUrl})`
+      : `network:     ${inputs.networkId}  (hub location could not be confirmed from this host)`,
+  );
+  lines.push("Add this to the leafnodes {} block of the HUB's OWN nats-server config:");
+  lines.push("");
+  lines.push("leafnodes {");
+  lines.push("  authorization {");
+  lines.push("    users: [");
+  const accountField = inputs.account !== undefined ? `, account: ${JSON.stringify(inputs.account)}` : "";
+  lines.push(`      { user: ${JSON.stringify(inputs.leafUser)}, password: ${JSON.stringify(inputs.psk)}${accountField} }`);
+  lines.push("    ]");
+  lines.push("  }");
+  lines.push("}");
+  if (inputs.account === undefined) {
+    lines.push("");
+    lines.push(
+      "If that hub's bus is operator-mode, ALSO add an `account: \"<the hub's own federation " +
+        "account nkey-U>\"` field to this user entry — only the hub owner has visibility into " +
+        "their own account tree (pass --hub-account <A…> to this command if you already know it).",
+    );
+  }
+  lines.push("");
+  lines.push(
+    `Hand this snippet to whoever runs network "${inputs.networkId}"'s hub. After they add it, they ` +
+      "must validate (`nats-server -c <hub.conf> -t`) and reload (SIGHUP) their hub nats-server for " +
+      "the new leaf-authorization user to take effect.",
+  );
+  return lines;
 }
 
 /**
@@ -138,10 +321,39 @@ async function addOrRotate(
   steps.push(`leaf user:  ${leafUser}`);
   steps.push(`deliver:    ${inputs.deliver}`);
 
+  // cortex#1481 — resolve hub locality BEFORE any mutation, so both the
+  // dry-run plan and the apply path branch identically. `sealOnly` forces the
+  // EXTERNAL path even when the descriptor would otherwise read as local (the
+  // explicit "never write this hub" override) — but we still resolve the
+  // cached hub_url (a pure local-disk read) so the hub-owner artifact can name
+  // it when known.
+  const cachedHubUrl = await ports.hubLocality.resolveHubUrl(inputs.networkId);
+  const localityDecision = decideHubLocality(cachedHubUrl, ports.hubLocality.localHostname());
+  const locality: HubLocality =
+    inputs.sealOnly === true
+      ? {
+          kind: "external",
+          reason: "--seal-only forced: registry seal + hub-owner artifact only — the local hub is never written",
+          ...(cachedHubUrl !== undefined && { hubUrl: cachedHubUrl }),
+        }
+      : localityDecision;
+  steps.push(
+    locality.kind === "local"
+      ? `hub:        LOCAL (this host) — ${ports.hub.confPath}`
+      : `hub:        EXTERNAL — ${locality.reason}`,
+  );
+  data.hub_locality = locality.kind;
+
   if (!inputs.apply) {
-    steps.push(rotate
-      ? `would: re-mint PSK → REPLACE hub authorization user "${leafUser}" + reload → re-seal + replace sealed blob`
-      : `would: mint PSK → add hub authorization user "${leafUser}" + reload → ${inputs.deliver === "sealed" ? "seal + deliver to the admission row" : "surface PSK for out-of-band handover"}`);
+    if (locality.kind === "local") {
+      steps.push(rotate
+        ? `would: re-mint PSK → REPLACE hub authorization user "${leafUser}" + reload → re-seal + replace sealed blob`
+        : `would: mint PSK → add hub authorization user "${leafUser}" + reload → ${inputs.deliver === "sealed" ? "seal + deliver to the admission row" : "surface PSK for out-of-band handover"}`);
+    } else {
+      steps.push(rotate
+        ? `would: re-mint PSK → SEAL-ONLY (no local hub write — external hub) → re-seal + replace sealed blob → emit hub-owner artifact`
+        : `would: mint PSK → SEAL-ONLY (no local hub write — external hub) → ${inputs.deliver === "sealed" ? "seal + deliver to the admission row" : "surface PSK for out-of-band handover"} → emit hub-owner artifact`);
+    }
     // C-1349 Slice 1 — surface whether the sealed blob will carry the payload key
     // K (kid only, NEVER K). oob never carries K (manual bootstrap path).
     if (inputs.deliver === "sealed") {
@@ -158,33 +370,43 @@ async function addOrRotate(
     return plan(action, inputs, steps, data);
   }
 
-  // 2. Mint the PSK + write the hub authorization user + reload.
+  // 2. Mint the PSK, then EITHER write the hub authorization user + reload
+  //    (LOCAL hub) OR skip that write entirely (EXTERNAL hub / --seal-only —
+  //    cortex#1481: NEVER write a foreign hub's nats config).
   const psk = ports.crypto.mintPsk();
   const fp = await pskFingerprint(psk);
   data.psk_fingerprint = fp;
 
-  let conf: string;
-  try {
-    conf = await ports.hub.readConf();
-  } catch (err) {
-    return fail(action, inputs, steps, data, `failed to read hub config: ${errText(err)}`);
-  }
-  let nextConf: string;
-  try {
-    nextConf = upsertHubLeafUser(conf, leafUser, psk);
-  } catch (err) {
-    if (err instanceof HubAuthConflictError) {
-      return fail(action, inputs, steps, data, err.message);
+  if (locality.kind === "local") {
+    let conf: string;
+    try {
+      conf = await ports.hub.readConf();
+    } catch (err) {
+      return fail(action, inputs, steps, data, `failed to read hub config: ${errText(err)}`);
     }
-    return fail(action, inputs, steps, data, `failed to render hub authorization: ${errText(err)}`);
+    let nextConf: string;
+    try {
+      nextConf = upsertHubLeafUser(conf, leafUser, psk);
+    } catch (err) {
+      if (err instanceof HubAuthConflictError) {
+        return fail(action, inputs, steps, data, err.message);
+      }
+      return fail(action, inputs, steps, data, `failed to render hub authorization: ${errText(err)}`);
+    }
+    try {
+      await ports.hub.writeConf(nextConf);
+      await ports.hub.reload();
+    } catch (err) {
+      return fail(action, inputs, steps, data, `failed to write/reload hub config: ${errText(err)}`);
+    }
+    steps.push(`hub:        ${rotate ? "replaced" : "added"} authorization user "${leafUser}" + reloaded (psk ${fp})`);
+  } else {
+    // cortex#1481 — the #1 storm cause: DO NOT touch ports.hub at all. The
+    // registry seal below still runs (machine-independent); the hub-owner
+    // artifact attached below carries the exact snippet for whoever runs the
+    // real hub.
+    steps.push(`hub:        SKIPPED — no local nats config written (external hub); see the hub-owner artifact below`);
   }
-  try {
-    await ports.hub.writeConf(nextConf);
-    await ports.hub.reload();
-  } catch (err) {
-    return fail(action, inputs, steps, data, `failed to write/reload hub config: ${errText(err)}`);
-  }
-  steps.push(`hub:        ${rotate ? "replaced" : "added"} authorization user "${leafUser}" + reloaded (psk ${fp})`);
 
   // 3. Deliver.
   if (inputs.deliver === "oob") {
@@ -192,6 +414,15 @@ async function addOrRotate(
     const report = plan(action, inputs, steps, data);
     report.applied = true;
     report.surfaced = { leafUser, psk };
+    if (locality.kind === "external") {
+      report.hubOwnerArtifact = renderHubOwnerArtifact({
+        networkId: inputs.networkId,
+        leafUser,
+        psk,
+        ...(locality.hubUrl !== undefined && { hubUrl: locality.hubUrl }),
+        ...(inputs.hubAccount !== undefined && { account: inputs.hubAccount }),
+      });
+    }
     return report;
   }
 
@@ -242,6 +473,15 @@ async function addOrRotate(
 
   const report = plan(action, inputs, steps, data);
   report.applied = true;
+  if (locality.kind === "external") {
+    report.hubOwnerArtifact = renderHubOwnerArtifact({
+      networkId: inputs.networkId,
+      leafUser,
+      psk,
+      ...(locality.hubUrl !== undefined && { hubUrl: locality.hubUrl }),
+      ...(inputs.hubAccount !== undefined && { account: inputs.hubAccount }),
+    });
+  }
   return report;
 }
 

--- a/src/cli/cortex/commands/network-secret-lib.ts
+++ b/src/cli/cortex/commands/network-secret-lib.ts
@@ -157,16 +157,22 @@ const LOCAL_HOST_ALIASES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
  * Parse the host out of a `hub_url` (a full `tls://host:port` URL — DD-12 —
  * or a bare host; mirrors `resolveLeafUrl` in `leaf-remote-renderer.ts`).
  * Returns `undefined` on an empty/unparseable value — the caller treats that
- * as "cannot determine" (fails safe to EXTERNAL).
+ * as "cannot determine" (fails safe to EXTERNAL). Exported so the LIVE adapter
+ * ({@link HubLocalityPort.hubHostIsLocalInterface}) resolves the SAME host this
+ * decider matches on — one grammar, no drift.
  */
-function extractHubHost(hubUrl: string): string | undefined {
+export function extractHubHost(hubUrl: string): string | undefined {
   const raw = hubUrl.trim();
   if (raw.length === 0) return undefined;
   const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw);
   const withScheme = hasScheme ? raw : `tls://${raw}`;
   try {
     const parsed = new URL(withScheme);
-    return parsed.hostname.length > 0 ? parsed.hostname : undefined;
+    // Strip the IPv6 brackets URL keeps on `hostname` (`[::1]` → `::1`) so the
+    // adapter's DNS/interface comparison sees the bare address form.
+    const host = parsed.hostname;
+    if (host.length === 0) return undefined;
+    return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
   } catch (_err) {
     // A malformed hub_url is not this function's concern to report — the
     // caller (decideHubLocality) turns an undefined host into "cannot
@@ -183,18 +189,43 @@ export type HubLocality =
   | { kind: "external"; hubUrl?: string; reason: string };
 
 /**
+ * The signals {@link decideHubLocality} weighs. `hubHostIsLocalInterface` is
+ * the load-bearing one for a REAL deployment (Sage review, Important 2): the
+ * hub owner's own machine caches its hub as an FQDN while `os.hostname()`
+ * returns a short name, so neither the loopback-alias nor the exact-hostname
+ * signal fires — the DNS→local-interface resolution (done in the adapter) is
+ * what confirms "this FQDN is one of MY interfaces".
+ */
+export interface HubLocalityDeciderInputs {
+  /** This machine's own hostname (`os.hostname()`). */
+  localHostname: string;
+  /**
+   * True iff the hub_url's host resolves (via DNS) to one of THIS machine's
+   * own network interfaces — computed by the adapter
+   * ({@link HubLocalityPort.hubHostIsLocalInterface}), fail-safe `false` on any
+   * resolution error. The signal that keeps the auto-write path alive for a
+   * hub owner whose hub is cached as an FQDN.
+   */
+  hubHostIsLocalInterface: boolean;
+}
+
+/**
  * cortex#1481 — PURE, fail-safe locality decision. A network's hub counts as
- * LOCAL only on a CONFIDENT match: a loopback alias, or an EXACT
- * case-insensitive match against this machine's own hostname. Every other
- * case — no cached descriptor, an unparseable hub_url, or a genuinely
- * different host — is EXTERNAL. The asymmetry is deliberate: a false "local"
- * IS the #1481 storm bug (writes a foreign hub); a false "external" only
- * costs an extra hand-off step (the hub-owner artifact instead of an
- * automatic write) — so every ambiguous case resolves to EXTERNAL.
+ * LOCAL only on a CONFIDENT signal:
+ *   - the hub_url host is a loopback alias (`localhost`/`127.0.0.1`/`::1`), OR
+ *   - it EXACTLY case-insensitively matches this machine's hostname, OR
+ *   - it resolves (DNS) to one of this machine's OWN network interfaces
+ *     (`hubHostIsLocalInterface` — the real-FQDN-deployment signal, Sage
+ *     review Important 2).
+ * Every other case — no cached descriptor, an unparseable hub_url, or a host
+ * that is none of the above — is EXTERNAL. The asymmetry is deliberate: a
+ * false "local" IS the #1481 storm bug (writes a foreign hub); a false
+ * "external" only costs an extra hand-off step (the hub-owner artifact instead
+ * of an automatic write) — so every ambiguous case resolves to EXTERNAL.
  */
 export function decideHubLocality(
   hubUrl: string | undefined,
-  localHostname: string,
+  inputs: HubLocalityDeciderInputs,
 ): HubLocality {
   if (hubUrl === undefined || hubUrl.trim() === "") {
     return {
@@ -212,16 +243,21 @@ export function decideHubLocality(
     };
   }
   const lowerHost = host.toLowerCase();
-  const lowerLocal = localHostname.trim().toLowerCase();
-  if (LOCAL_HOST_ALIASES.has(lowerHost) || (lowerLocal.length > 0 && lowerHost === lowerLocal)) {
+  const lowerLocal = inputs.localHostname.trim().toLowerCase();
+  if (
+    LOCAL_HOST_ALIASES.has(lowerHost) ||
+    (lowerLocal.length > 0 && lowerHost === lowerLocal) ||
+    inputs.hubHostIsLocalInterface
+  ) {
     return { kind: "local" };
   }
   return {
     kind: "external",
     hubUrl,
     reason:
-      `network hub_url host "${host}" does not match this machine ` +
-      `(${localHostname.trim().length > 0 ? localHostname : "unknown hostname"}) — refusing to write the local nats config`,
+      `network hub_url host "${host}" is neither a loopback alias, this machine's ` +
+      `hostname (${inputs.localHostname.trim().length > 0 ? inputs.localHostname : "unknown hostname"}), ` +
+      `nor a local network interface — refusing to write the local nats config`,
   };
 }
 
@@ -326,9 +362,16 @@ async function addOrRotate(
   // EXTERNAL path even when the descriptor would otherwise read as local (the
   // explicit "never write this hub" override) — but we still resolve the
   // cached hub_url (a pure local-disk read) so the hub-owner artifact can name
-  // it when known.
+  // it when known. The DNS→local-interface probe (Sage review Important 2) only
+  // runs when there is a cached hub_url to probe — the load-bearing signal for
+  // a hub owner whose own hub is cached as an FQDN.
   const cachedHubUrl = await ports.hubLocality.resolveHubUrl(inputs.networkId);
-  const localityDecision = decideHubLocality(cachedHubUrl, ports.hubLocality.localHostname());
+  const hubHostIsLocalInterface =
+    cachedHubUrl !== undefined ? await ports.hubLocality.hubHostIsLocalInterface(cachedHubUrl) : false;
+  const localityDecision = decideHubLocality(cachedHubUrl, {
+    localHostname: ports.hubLocality.localHostname(),
+    hubHostIsLocalInterface,
+  });
   const locality: HubLocality =
     inputs.sealOnly === true
       ? {
@@ -414,15 +457,7 @@ async function addOrRotate(
     const report = plan(action, inputs, steps, data);
     report.applied = true;
     report.surfaced = { leafUser, psk };
-    if (locality.kind === "external") {
-      report.hubOwnerArtifact = renderHubOwnerArtifact({
-        networkId: inputs.networkId,
-        leafUser,
-        psk,
-        ...(locality.hubUrl !== undefined && { hubUrl: locality.hubUrl }),
-        ...(inputs.hubAccount !== undefined && { account: inputs.hubAccount }),
-      });
-    }
+    attachArtifactIfExternal(report, locality, inputs, leafUser, psk);
     return report;
   }
 
@@ -473,16 +508,32 @@ async function addOrRotate(
 
   const report = plan(action, inputs, steps, data);
   report.applied = true;
-  if (locality.kind === "external") {
-    report.hubOwnerArtifact = renderHubOwnerArtifact({
-      networkId: inputs.networkId,
-      leafUser,
-      psk,
-      ...(locality.hubUrl !== undefined && { hubUrl: locality.hubUrl }),
-      ...(inputs.hubAccount !== undefined && { account: inputs.hubAccount }),
-    });
-  }
+  attachArtifactIfExternal(report, locality, inputs, leafUser, psk);
   return report;
+}
+
+/**
+ * cortex#1481 (Sage review, nit) — attach the hub-owner artifact to `report`
+ * IFF the hub is external. Shared by the oob and sealed delivery tails of
+ * {@link addOrRotate} (the block was verbatim in both). The raw PSK riding the
+ * artifact is one of the two legitimate secret-to-caller channels (the other is
+ * `report.surfaced`); the render layer prints it explicitly, never in steps.
+ */
+function attachArtifactIfExternal(
+  report: SecretReport,
+  locality: HubLocality,
+  inputs: SecretInputs,
+  leafUser: string,
+  psk: string,
+): void {
+  if (locality.kind !== "external") return;
+  report.hubOwnerArtifact = renderHubOwnerArtifact({
+    networkId: inputs.networkId,
+    leafUser,
+    psk,
+    ...(locality.hubUrl !== undefined && { hubUrl: locality.hubUrl }),
+    ...(inputs.hubAccount !== undefined && { account: inputs.hubAccount }),
+  });
 }
 
 async function revokeMember(

--- a/src/cli/cortex/commands/network-secret-ports.ts
+++ b/src/cli/cortex/commands/network-secret-ports.ts
@@ -67,7 +67,7 @@ export interface SecretCrypto {
  * When the network's actual hub is ANOTHER principal's server, that write
  * lands on the admin's own laptop — never the real hub — so the joiner's leaf
  * presents a PSK the real hub never authorized and Authorization-Violation-
- * storms. (Real incident: the metafactory-community bring-up 2026-07-04 — the
+ * storms. (Real incident: the metafactory-community bring-up 2026-07-03 — the
  * PSK landed on the admin's local nats, never on the hub owner's VM.)
  */
 export interface HubLocalityPort {
@@ -86,6 +86,19 @@ export interface HubLocalityPort {
   resolveHubUrl(networkId: string): Promise<string | undefined>;
   /** This machine's own hostname (`os.hostname()`). Injectable for tests. */
   localHostname(): string;
+  /**
+   * cortex#1481 (Sage review, Important 2) — resolve whether `hubUrl`'s host
+   * points at one of THIS machine's own network interfaces. The load-bearing
+   * signal for a REAL deployment: `network join` caches the hub as an FQDN
+   * (e.g. `tls://nats.meta-factory.dev:7422`) while `os.hostname()` returns a
+   * short name (`macjcf`), so a loopback-alias / exact-hostname match alone
+   * calls the hub-owner's OWN VM external and kills the auto-write path. This
+   * resolves the host via DNS and compares against `os.networkInterfaces()`.
+   * FAIL-SAFE: any DNS/resolution error → `false` (→ EXTERNAL), NEVER throws
+   * (logged via `process.stderr.write`). `false` for an unparseable/absent
+   * host too.
+   */
+  hubHostIsLocalInterface(hubUrl: string): Promise<boolean>;
 }
 
 /** The full port bundle the orchestrator depends on. */

--- a/src/cli/cortex/commands/network-secret-ports.ts
+++ b/src/cli/cortex/commands/network-secret-ports.ts
@@ -57,12 +57,45 @@ export interface SecretCrypto {
   seal(plaintext: string, recipientPubkeyB64: string): Promise<string>;
 }
 
+/**
+ * cortex#1481 (epic #1479, join-2) — resolve whether THIS host is the
+ * network's hub, so the orchestrator can REFUSE to write a foreign hub's
+ * authorization onto the WRONG machine. Read-only.
+ *
+ * The #1 storm cause this exists to prevent: `add-member`/`admit --and-seal`
+ * write the minted leaf PSK into `--hub-config` (default: the LOCAL nats).
+ * When the network's actual hub is ANOTHER principal's server, that write
+ * lands on the admin's own laptop — never the real hub — so the joiner's leaf
+ * presents a PSK the real hub never authorized and Authorization-Violation-
+ * storms. (Real incident: the metafactory-community bring-up 2026-07-04 — the
+ * PSK landed on the admin's local nats, never on the hub owner's VM.)
+ */
+export interface HubLocalityPort {
+  /**
+   * The cached network descriptor's `hub_url` for `networkId` — the SAME
+   * `~/.config/cortex/network-cache/<network>.json` DD-10 last-known-good
+   * cache `cortex network join` writes after a verified fetch (S1, #735).
+   * Read-only, LOCAL DISK ONLY — deliberately never a live registry round
+   * trip: the secret-tooling adapters carry no registry-pubkey-pin setup
+   * today, and a live-fetch failure must never block a seal that would
+   * otherwise succeed. `undefined` when nothing is cached for this network on
+   * this host (never joined/synced here) — the pure decision function
+   * ({@link decideHubLocality} in `network-secret-lib.ts`) treats an
+   * unresolved hub_url as "cannot confirm local" and fails safe to EXTERNAL.
+   */
+  resolveHubUrl(networkId: string): Promise<string | undefined>;
+  /** This machine's own hostname (`os.hostname()`). Injectable for tests. */
+  localHostname(): string;
+}
+
 /** The full port bundle the orchestrator depends on. */
 export interface NetworkSecretPorts {
   hub: HubAuthPort;
   admission: AdmissionLookupPort;
   delivery: SealDeliveryPort;
   crypto: SecretCrypto;
+  /** cortex#1481 — the hub-locality read the orchestrator gates the hub write on. */
+  hubLocality: HubLocalityPort;
 }
 
 // ===========================================================================

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -131,7 +131,7 @@ import {
 } from "./network-make-live-lib";
 import { buildLiveMakeLivePorts, buildResolverPreloadAdapter } from "./network-make-live-adapters";
 import type { OperatorModeLeafPackage, NatsBaseIdentity } from "../../../common/nats/leaf-remote-renderer";
-import { parseLoopbackListen } from "../../../common/nats/leaf-remote-renderer";
+import { parseLoopbackListen, isNkeyAccountPubkey } from "../../../common/nats/leaf-remote-renderer";
 import {
   runNetworkSecret,
   runNetworkKeyRotation,
@@ -407,6 +407,14 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         // admit-without-seal case, or a fully-separable deployment where the
         // hub-admin ≠ the registry-admin and sealing is a genuinely separate step).
         "--roster-only": "bool",
+        // cortex#1481 — force the seal-only path (registry seal + hub-owner
+        // artifact, NEVER a local hub write) even when the auto-detected hub
+        // locality would otherwise call the hub local. Distinct from
+        // --roster-only: the seal (mint + deliver) STILL runs here.
+        "--seal-only": "bool",
+        // cortex#1481 — the hub's OWN federation account nkey-U, when the admin
+        // already knows it. Rides the hub-owner artifact's `account:` field.
+        "--hub-account": "value",
       },
     },
     // C-1348 (ADR-0015) — the admission DENIAL verb, the mirror of `admit`.
@@ -511,6 +519,13 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--discord-role": "value",
         "--apply": "bool",
         "--dry-run": "bool",
+        // cortex#1481 — force the seal-only path (registry seal + hub-owner
+        // artifact, NEVER a local hub write) for add-member/rotate, even when
+        // the auto-detected hub locality would otherwise call the hub local.
+        "--seal-only": "bool",
+        // cortex#1481 — the hub's OWN federation account nkey-U, when the admin
+        // already knows it. Rides the hub-owner artifact's `account:` field.
+        "--hub-account": "value",
       },
     },
   },
@@ -2502,6 +2517,7 @@ async function runAdmit(
       fallbackCmd: `cortex network secret add-member ${net} ${requestPeerPubkey} --admin-seed ${seedRes.value} --apply`,
     };
   } else {
+    const hubAccount = optionalValueFlag(flags, "--hub-account");
     sealOutcome = await sealAdmittedMember({
       networkId: requestNetworkId,
       memberPubkey: requestPeerPubkey,
@@ -2510,6 +2526,10 @@ async function runAdmit(
       material,
       secretPortsFactory,
       adminSeedPath: seedRes.value,
+      // cortex#1481 — --seal-only forces the never-write-a-foreign-hub path even
+      // when the auto-detected locality would otherwise call the hub local.
+      sealOnly: flags["--seal-only"] === true,
+      ...(hubAccount !== undefined && { hubAccount }),
     });
   }
 
@@ -2577,6 +2597,10 @@ async function runAdmit(
     };
     if (sealOutcome.reason) data.seal_reason = sealOutcome.reason;
     if (sealOutcome.fallbackCmd) data.seal_fallback = sealOutcome.fallbackCmd;
+    // cortex#1481 — the hub-owner artifact carries the raw PSK (like the OOB
+    // `surfaced` block) so it rides its OWN explicit key, joined with real
+    // newlines, never folded into a step/reason field.
+    if (sealOutcome.hubOwnerArtifact) data.hub_owner_artifact = sealOutcome.hubOwnerArtifact.join("\n");
     if (discordWarning) data.discord_warning = discordWarning;
     return ok(renderJson(envelopeOk([], data)));
   }
@@ -2590,6 +2614,12 @@ async function runAdmit(
   if (sealOutcome.status === "sealed") {
     lines.push(`  seal:        delivered — peer is now CONNECTABLE`);
     for (const s of sealOutcome.steps) lines.push(`    ${s}`);
+    // cortex#1481 — external hub (or --seal-only): the hub write never
+    // happened, so print the hub-owner artifact explicitly.
+    if (sealOutcome.hubOwnerArtifact) {
+      lines.push("");
+      for (const s of sealOutcome.hubOwnerArtifact) lines.push(`  ${s}`);
+    }
   } else if (sealOutcome.status === "skipped") {
     lines.push(`  seal:        skipped — ${sealOutcome.reason ?? "no seal"} (peer is ADMITTED but INERT)`);
     if (sealOutcome.fallbackCmd) lines.push(`               to seal: ${sealOutcome.fallbackCmd}`);
@@ -2826,6 +2856,14 @@ interface AdmitSealOutcome {
   reason?: string;
   /** The explicit `secret add-member` command to seal after the fact. */
   fallbackCmd?: string;
+  /**
+   * cortex#1481 — present iff the seal's hub turned out to be EXTERNAL (or
+   * --seal-only forced it): the hub-owner artifact `sealAdmittedMember`
+   * forwards verbatim from {@link SecretReport.hubOwnerArtifact}. The caller
+   * prints it explicitly (the one other legitimate place the raw PSK reaches
+   * stdout, alongside the OOB `surfaced` block).
+   */
+  hubOwnerArtifact?: string[];
 }
 
 /**
@@ -2851,8 +2889,23 @@ async function sealAdmittedMember(args: {
   material: StackIdentityMaterial;
   secretPortsFactory: SecretPortsFactory;
   adminSeedPath: string;
+  /** cortex#1481 — force seal-only (never write the local hub) even when the
+   *  auto-detected locality would otherwise call the hub local. */
+  sealOnly?: boolean;
+  /** cortex#1481 — the hub's own federation account nkey-U, when known. */
+  hubAccount?: string;
 }): Promise<AdmitSealOutcome> {
-  const { networkId, memberPubkey, registryUrl, hubConfigPath, material, secretPortsFactory, adminSeedPath } = args;
+  const {
+    networkId,
+    memberPubkey,
+    registryUrl,
+    hubConfigPath,
+    material,
+    secretPortsFactory,
+    adminSeedPath,
+    sealOnly,
+    hubAccount,
+  } = args;
 
   // A network-less admission row (legacy null network_id) can't be sealed — the
   // leaf PSK is network-scoped, and `secret add-member` needs a real network id.
@@ -2874,6 +2927,8 @@ async function sealAdmittedMember(args: {
     memberPubkey,
     deliver: "sealed",
     apply: true,
+    ...(sealOnly !== undefined && { sealOnly }),
+    ...(hubAccount !== undefined && { hubAccount }),
   };
 
   let report: SecretReport;
@@ -2902,7 +2957,11 @@ async function sealAdmittedMember(args: {
     };
   }
 
-  return { status: "sealed", steps: report.steps };
+  return {
+    status: "sealed",
+    steps: report.steps,
+    ...(report.hubOwnerArtifact !== undefined && { hubOwnerArtifact: report.hubOwnerArtifact }),
+  };
 }
 
 // =============================================================================
@@ -3051,6 +3110,13 @@ async function runSecret(
   const discordServer = optionalValueFlag(flags, "--discord-server");
   const discordGuild = optionalValueFlag(flags, "--discord-guild");
   const discordRole = optionalValueFlag(flags, "--discord-role") ?? DEFAULT_ADMIT_DISCORD_ROLE;
+  // cortex#1481 — add-member/rotate only: force the seal-only path (never write
+  // the local hub) + the hub's own account nkey-U, when the admin knows it.
+  const sealOnly = flags["--seal-only"] === true;
+  const hubAccountRaw = optionalValueFlag(flags, "--hub-account");
+  if (hubAccountRaw !== undefined && !isNkeyAccountPubkey(hubAccountRaw)) {
+    return usageError("secret", `--hub-account "${hubAccountRaw}" is not a valid nkey-U account public key (expected A + 55 base32 chars)`, json);
+  }
 
   // 4. Load + chmod-600-gate the hub-admin seed.
   const matRes = await hubAdminMaterialFromSeedFile(seedRes.value);
@@ -3081,6 +3147,8 @@ async function runSecret(
     ...(leafUserOverride !== undefined && { leafUserOverride }),
     ...(payloadKey !== undefined && { payloadKey }),
     ...(payloadKeyKid !== undefined && { payloadKeyKid }),
+    sealOnly,
+    ...(hubAccountRaw !== undefined && { hubAccount: hubAccountRaw }),
     apply: applyRes.apply,
   };
 
@@ -3149,6 +3217,10 @@ async function runSecret(
       data.oob_leaf_user = report.surfaced.leafUser;
       data.oob_leaf_secret = report.surfaced.psk;
     }
+    // cortex#1481 — the hub-owner artifact carries the raw PSK (like the OOB
+    // block above) so it rides its OWN explicit key, joined with real
+    // newlines, never folded into steps/data's other fields.
+    if (report.hubOwnerArtifact) data.hub_owner_artifact = report.hubOwnerArtifact.join("\n");
     const env = report.ok ? envelopeOk([], data) : envelopeError(report.reason ?? "secret command failed", data);
     return report.ok ? ok(renderJson(env)) : { exitCode: 1, stdout: "", stderr: renderJson(env) };
   }
@@ -3173,6 +3245,12 @@ async function runSecret(
     lines.push("  ── OUT-OF-BAND SECRET (hand this to the member over a secure channel) ──");
     lines.push(`  leaf user:   ${report.surfaced.leafUser}`);
     lines.push(`  leaf secret: ${report.surfaced.psk}`);
+  }
+  // cortex#1481 — external hub (or --seal-only): the hub write never
+  // happened, so print the exact hub-owner snippet explicitly.
+  if (report.hubOwnerArtifact) {
+    lines.push("");
+    for (const s of report.hubOwnerArtifact) lines.push(`  ${s}`);
   }
   lines.push("");
   const body = lines.join("\n");
@@ -3840,8 +3918,9 @@ Usage:
   cortex network ping   <peer> [--assistant <a>] [--network <id>] [--count N] [--timeout <ms>] [--json]
   cortex network doctor <network> [--principal <id>] [--stack <id>] [--config <p>] [--monitor-url <url>] [--json]
   cortex network admit  <request-id> --admin-seed <path> [--registry-url <url>] [--hub-config <p>]
-                        [--roster-only] [--discord-member <id>] [--discord-guild <id>]
-                        [--discord-server <profile>] [--discord-role <name>] [--apply] [--dry-run] [--json]
+                        [--roster-only] [--seal-only] [--hub-account <A…>] [--discord-member <id>]
+                        [--discord-guild <id>] [--discord-server <profile>] [--discord-role <name>]
+                        [--apply] [--dry-run] [--json]
   cortex network admit  --list-pending [--status <PENDING|ADMITTED|REJECTED>] [--network <id>]
                         --admin-seed <path> [--registry-url <url>] [--json]
   cortex network reject <request-id> --admin-seed <path> [--registry-url <url>] [--apply] [--dry-run] [--json]
@@ -3851,7 +3930,8 @@ Usage:
                         [--creds <p>] [--force] [--apply] [--dry-run] [--json]
   cortex network secret <add-member|revoke-member|rotate> <network> <member-pubkey>
                         --admin-seed <hub-admin-seed> [--registry-url <url>] [--hub-config <p>]
-                        [--deliver sealed|oob] [--leaf-user <u>] [--apply] [--dry-run] [--json]
+                        [--deliver sealed|oob] [--leaf-user <u>] [--seal-only] [--hub-account <A…>]
+                        [--apply] [--dry-run] [--json]
   cortex network secret rotate-key <network>   (network-wide K rotation — NO member pubkey)
                         --admin-seed <hub-admin-seed> [--config <p>] [--registry-url <url>]
                         [--hub-config <p>] [--apply] [--dry-run] [--json]
@@ -3955,11 +4035,21 @@ Subcommands:
           ADMIT-AND-SEAL (C-1316): on --apply, admit ALSO mints + seals + delivers
           the per-member leaf PSK (the \`secret add-member\` motion) so the peer is
           CONNECTABLE, not just rostered — no ADMITTED-but-inert peers. Reuses the
-          hub-local nats config at --hub-config (default ~/.config/nats/local.conf).
+          hub-local nats config at --hub-config (default ~/.config/nats/local.conf)
+          — but ONLY when that hub is actually LOCAL to this host (cortex#1481):
+          the network's cached hub_url is compared to this machine, and a hub that
+          is NOT this machine is NEVER written (the #1 storm cause — a foreign
+          write leaves the joiner's leaf presenting a PSK the real hub never
+          authorized). An external hub instead gets a registry-only seal + a
+          printed hub-owner artifact (the exact leafnodes{} authorization snippet
+          to hand to whoever runs that hub). Pass --seal-only to force that same
+          seal-only + artifact path even when the hub looks local (never touches
+          --hub-config); --hub-account <A…> names the hub's own federation account
+          nkey-U when you already know it, so the printed snippet is account-bound.
           The seal NEVER fails a committed admit: if it can't run (hub-admin ≠
-          registry-admin, or the hub config isn't local) it surfaces a fallback
+          registry-admin, or the hub config isn't readable) it surfaces a fallback
           telling you to run \`cortex network secret add-member\`. Pass --roster-only
-          to commit the roster row ONLY and skip the seal.
+          to commit the roster row ONLY and skip the seal entirely.
           --list-pending (C-1314): DISCOVERY mode — admin-signs a read and lists
           the admission queue (request-id · principal · network · peer · status ·
           created) so you can find the id to admit. Read-only (no --apply).

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2399,7 +2399,7 @@ async function runAdmit(
   // SAME nkey-U guard the `secret` path enforces (isNkeyAccountPubkey), and
   // validate it HERE — before the admission is committed — so a malformed
   // account fails fast (exit 2) rather than silently riding into the printed
-  // hub-owner artifact the operator pastes into a live nats-server config.
+  // hub-owner artifact the hub owner pastes into a live nats-server config.
   const admitHubAccount = optionalValueFlag(flags, "--hub-account");
   if (admitHubAccount !== undefined && !isNkeyAccountPubkey(admitHubAccount)) {
     return usageError("admit", `--hub-account "${admitHubAccount}" is not a valid nkey-U account public key (expected A + 55 base32 chars)`, json);

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2395,6 +2395,15 @@ async function runAdmit(
   const discordServer = optionalValueFlag(flags, "--discord-server");
   const discordGuild = optionalValueFlag(flags, "--discord-guild");
   const discordRole = optionalValueFlag(flags, "--discord-role") ?? DEFAULT_ADMIT_DISCORD_ROLE;
+  // cortex#1481 (Sage review, Important 1) — validate --hub-account with the
+  // SAME nkey-U guard the `secret` path enforces (isNkeyAccountPubkey), and
+  // validate it HERE — before the admission is committed — so a malformed
+  // account fails fast (exit 2) rather than silently riding into the printed
+  // hub-owner artifact the operator pastes into a live nats-server config.
+  const admitHubAccount = optionalValueFlag(flags, "--hub-account");
+  if (admitHubAccount !== undefined && !isNkeyAccountPubkey(admitHubAccount)) {
+    return usageError("admit", `--hub-account "${admitHubAccount}" is not a valid nkey-U account public key (expected A + 55 base32 chars)`, json);
+  }
 
   // Load + chmod-600-gate the admin seed
   const matRes = await adminMaterialFromSeedFile(seedRes.value);
@@ -2517,7 +2526,6 @@ async function runAdmit(
       fallbackCmd: `cortex network secret add-member ${net} ${requestPeerPubkey} --admin-seed ${seedRes.value} --apply`,
     };
   } else {
-    const hubAccount = optionalValueFlag(flags, "--hub-account");
     sealOutcome = await sealAdmittedMember({
       networkId: requestNetworkId,
       memberPubkey: requestPeerPubkey,
@@ -2529,7 +2537,8 @@ async function runAdmit(
       // cortex#1481 — --seal-only forces the never-write-a-foreign-hub path even
       // when the auto-detected locality would otherwise call the hub local.
       sealOnly: flags["--seal-only"] === true,
-      ...(hubAccount !== undefined && { hubAccount }),
+      // Already nkey-U-validated above (fail-fast before the admission commits).
+      ...(admitHubAccount !== undefined && { hubAccount: admitHubAccount }),
     });
   }
 
@@ -4037,12 +4046,15 @@ Subcommands:
           CONNECTABLE, not just rostered — no ADMITTED-but-inert peers. Reuses the
           hub-local nats config at --hub-config (default ~/.config/nats/local.conf)
           — but ONLY when that hub is actually LOCAL to this host (cortex#1481):
-          the network's cached hub_url is compared to this machine, and a hub that
-          is NOT this machine is NEVER written (the #1 storm cause — a foreign
-          write leaves the joiner's leaf presenting a PSK the real hub never
-          authorized). An external hub instead gets a registry-only seal + a
-          printed hub-owner artifact (the exact leafnodes{} authorization snippet
-          to hand to whoever runs that hub). Pass --seal-only to force that same
+          the network's cached hub_url is counted LOCAL when its host is a loopback
+          alias, exactly matches this machine's hostname, OR resolves (DNS) to one
+          of this machine's own network interfaces (the hub owner's own VM, even
+          when it's cached as an FQDN). A hub that is none of those is NEVER
+          written (the #1 storm cause — a foreign write leaves the joiner's leaf
+          presenting a PSK the real hub never authorized). An external hub instead
+          gets a registry-only seal + a printed hub-owner artifact (the exact
+          leafnodes{} authorization snippet to hand to whoever runs that hub). Pass
+          --seal-only to force that same
           seal-only + artifact path even when the hub looks local (never touches
           --hub-config); --hub-account <A…> names the hub's own federation account
           nkey-U when you already know it, so the printed snippet is account-bound.


### PR DESCRIPTION
## What
Fixes **the #1 storm cause** from the metafactory-community bring-up (Jul 2026): `secret add-member` / `admit --and-seal` minted a per-member leaf key then wrote the leaf `authorization` into the **local** nats (the `--hub-config` default). When the network's hub is another principal's server, that landed on the admin's laptop — never the real hub — so the joining member's leaf presented a key the hub never authorized → Authorization-Violation storm.

Sub-issue of epic **#1479**, slice **join-2** (#1481).

## How
- **`HubLocalityPort` + pure `decideHubLocality()`** — resolves the network's `hub_url` from the local DD-10 network-cache (`~/.config/cortex/network-cache/<net>.json`, the file `network join` writes) and compares its host to `os.hostname()`.
  - **LOCAL** only on a confident match: a loopback alias or an exact hostname match.
  - **EXTERNAL** for everything else — uncached descriptor, unparseable `hub_url`, or a genuinely different host. **Fail-safe direction:** a false "local" is the storm bug; a false "external" only costs an extra hand-off step.
- **`addOrRotate` branches on locality:** EXTERNAL **skips `readConf`/`writeConf`/`reload` entirely** (never touches local nats), still runs the machine-independent **registry seal**, and attaches a **hub-owner artifact** — the exact `leafnodes { authorization { … } }` snippet the real hub owner adds on their VM (account-bound for operator-mode hubs).
- **`--seal-only`** (new, on `secret add-member`/`rotate` + `admit`) forces the seal-only + artifact path even when the hub looks local.
- **`--hub-account <A…>`** (new) rides the artifact's `account:` field for operator-mode hubs (the remote hub's account isn't derivable from this principal's config).

## Verification
- `bunx tsc --noEmit` clean; `bun run lint:errors` clean; **full suite 8669 pass / 0 fail**.
- Secret/admit/adapters/e2e tests: **117 pass**. Every external/seal-only test asserts the fake hub `writeConf`/`reload` spies were **never called** (`writes.length === 0`) — the exact guarantee.
- Not live-smoked: `add-member` is admin-seed-gated and I don't hold the hub admin seed. The spy assertions cover the behavior.

## Out of scope (intentional, flagged as follow-ups)
- `hub_url` is resolved from the **local cache only**, not a live registry fetch — a registry-unreachable failure must never block an otherwise-good seal; an uncached network just becomes *more* conservative (emits the artifact).
- **`revoke-member` untouched** — shares the local-hub-write pattern but has a distinct failure profile (evictee stays connected vs the storm), and wasn't in #1481's stated seams. Candidate follow-up.
- The remote hub's `account` nkey isn't auto-resolved (not knowable from this side) → `--hub-account` supplies it when the admin knows it, else the artifact prints an honest advisory.

Closes #1481
Refs #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
