### PR TITLE
feat(network): C-1482 — reconcile the three representation-pairs + NKEY<->base64 normalize (epic #1479 slice 3)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-doctor-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-adapters.test.ts
@@ -68,4 +68,32 @@ describe("resolverPreloadHasAccountKey", () => {
     const text = "resolver_preload {\n  ACCOUNT_A: eyJhbGciOiJ...\n}\n";
     expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBe(true);
   });
+
+  test("an UNBALANCED brace in a full-line comment does NOT unbalance the scan (cheap-guard, Sage nit 5)", () => {
+    const text = [
+      "resolver_preload: {",
+      "  // TODO: rebalance this someday { and never close it",
+      "  ACCOUNT_A: eyJhbGciOiJ...",
+      "}",
+      "leafnodes { remotes: [] }",
+    ].join("\n");
+    // Without the full-line-comment guard, the lone `{` in the comment would
+    // push depth to 2 and the block would run past its real close.
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBe(true);
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_OTHER")).toBe(false);
+  });
+
+  test("an inline `tls://` after a value is NOT treated as a comment (guard only blanks LINE-LEADING //)", () => {
+    const text = [
+      "leafnodes {",
+      '  remotes: [ { url: "tls://hub:7422", account: "ACCOUNT_A" } ]',
+      "}",
+      "resolver_preload: {",
+      "  ACCOUNT_A: eyJhbGciOiJ...",
+      "}",
+    ].join("\n");
+    // The `tls://` mid-line must not be blanked (it isn't line-leading), and
+    // the leaf remote's account: line must still not false-positive.
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBe(true);
+  });
 });

--- a/src/cli/cortex/commands/__tests__/network-doctor-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-adapters.test.ts
@@ -1,0 +1,71 @@
+/**
+ * cortex#1482 (epic #1479, join-3, Pair 2) — `resolverPreloadHasAccountKey`
+ * unit tests. This is the ONE piece of non-trivial text parsing the doctor
+ * adapter adds (a brace-matched scan mirroring `insertIntoResolverPreload`);
+ * the pure orchestration behavior it feeds is covered end-to-end (fake
+ * ports) in `network-doctor-lib.test.ts`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { resolverPreloadHasAccountKey } from "../network-doctor-adapters";
+
+describe("resolverPreloadHasAccountKey", () => {
+  test("true when the account is a resolver_preload key", () => {
+    const text = [
+      "resolver: MEMORY",
+      "resolver_preload: {",
+      "  ACCOUNT_A: eyJhbGciOiJ...",
+      "}",
+    ].join("\n");
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBe(true);
+  });
+
+  test("false when resolver_preload exists but does NOT carry the account", () => {
+    const text = [
+      "resolver_preload: {",
+      "  ACCOUNT_OTHER: eyJhbGciOiJ...",
+      "}",
+    ].join("\n");
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBe(false);
+  });
+
+  test("does NOT false-positive on the account appearing elsewhere in the file (e.g. a leaf remote's account: line)", () => {
+    // The #1 reason a bare substring search is wrong: the leaf remote's OWN
+    // `account:` line commonly carries the SAME pubkey the resolver_preload
+    // question is about, but that's a DIFFERENT block.
+    const text = [
+      "leafnodes {",
+      '  remotes: [ { url: "tls://hub:7422", account: "ACCOUNT_A" } ]',
+      "}",
+      "resolver_preload: {",
+      "  ACCOUNT_OTHER: eyJhbGciOiJ...",
+      "}",
+    ].join("\n");
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBe(false);
+  });
+
+  test("undefined when there is no resolver_preload block at all (non-operator-mode bus)", () => {
+    const text = "listen: 0.0.0.0:4222\njetstream {}\n";
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBeUndefined();
+  });
+
+  test("handles a nested brace inside the block without mis-locating the close", () => {
+    const text = [
+      "resolver_preload: {",
+      "  ACCOUNT_A: eyJhbGciOiJ...",
+      "  // a comment with a { brace } inside it",
+      "  ACCOUNT_B: eyJhbGciOiJ...",
+      "}",
+      "other_block { unrelated: true }",
+    ].join("\n");
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBe(true);
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_B")).toBe(true);
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_C")).toBe(false);
+  });
+
+  test("matches the `resolver_preload {` (no colon) spelling too", () => {
+    const text = "resolver_preload {\n  ACCOUNT_A: eyJhbGciOiJ...\n}\n";
+    expect(resolverPreloadHasAccountKey(text, "ACCOUNT_A")).toBe(true);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-doctor-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-cli.test.ts
@@ -73,6 +73,7 @@ function fakeDoctorFactory(): {
         ],
       }),
       expectedFedAccount: () => "ACCOUNT_A",
+      resolverPreloadHasAccount: () => true,
     },
     monitor: {
       resolve: () => ({ url: "http://127.0.0.1:8222", configured: true }),
@@ -186,6 +187,7 @@ describe("cortex network doctor — degraded/broken exit codes", () => {
       config: {
         readNetworks: () => ({ networks: [] }), // network not configured ⇒ broken
         expectedFedAccount: () => undefined,
+        resolverPreloadHasAccount: () => undefined,
       },
       monitor: {
         resolve: () => ({ url: "http://127.0.0.1:8222", configured: true }),

--- a/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
@@ -50,7 +50,12 @@ function loadedConfig(peers: { principal_id: string; stack_id: string }[]): Load
     config: { nats: { url: "nats://127.0.0.1:4222" } } as unknown as AgentConfig,
     inlineAgents: [{ id: "luna" } as unknown as LoadedConfig["inlineAgents"][number]],
     principal: { id: "andreas" },
-    stack: { id: "andreas/community" },
+    // cortex#1482 — a registered/PoP pubkey fixture for the Pair 1 leg. A
+    // plain placeholder (not a real nkey) is fine: the leg only compares it
+    // against the (also-fake) FED account fixture via `samePubkey`, which
+    // returns `false` for anything that isn't a genuinely decodable pubkey —
+    // exactly what we want for two UNRELATED-looking fixture strings.
+    stack: { id: "andreas/community", nkey_pub: "REGISTERED_PUBKEY_FIXTURE" },
     policy: {
       federated: {
         networks: [
@@ -80,10 +85,15 @@ function network(overrides: Partial<PolicyFederatedNetwork> = {}): PolicyFederat
 function fakeConfigPort(
   networks: PolicyFederatedNetwork[],
   expectedAccount?: string,
+  // cortex#1482 (Pair 2) — `undefined` = "cannot determine" (no
+  // resolver_preload block / no local nats config, the (c) no-monitor-style
+  // default); tests that care about the leg override it explicitly.
+  resolverPreloadHasAccount?: (accountPubkey: string) => boolean | undefined,
 ): DoctorConfigPort {
   return {
     readNetworks: () => ({ networks }),
     expectedFedAccount: () => expectedAccount,
+    resolverPreloadHasAccount: resolverPreloadHasAccount ?? (() => undefined),
   };
 }
 
@@ -158,7 +168,7 @@ const ESTABLISHED_LEAFZ: LeafzResponse = {
 describe("runDoctorChecks — (a) all-green", () => {
   test("every leg passes, verdict healthy, exit 0", async () => {
     const ports: NetworkDoctorPorts = {
-      config: fakeConfigPort([network()], "ACCOUNT_A"),
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
       monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
       probe: fakeProbe((f) => echoReply(f, 41)),
     };
@@ -170,8 +180,13 @@ describe("runDoctorChecks — (a) all-green", () => {
     expect(res.verdict).toBe("healthy");
     expect(res.exitCode).toBe(0);
     expect(res.exitCode).toBe(DOCTOR_EXIT_CODE.healthy);
-    expect(res.checks).toHaveLength(5);
+    // 5 pre-#1482 legs + registered-vs-fed-account + resolver-preload-account
+    // + the sealed-secret-hub-authorized stub (always present, always skip).
+    expect(res.checks).toHaveLength(8);
     expect(findCheck(res.checks, "config-network").status).toBe("pass");
+    expect(findCheck(res.checks, "registered-vs-fed-account").status).toBe("pass");
+    expect(findCheck(res.checks, "resolver-preload-account").status).toBe("pass");
+    expect(findCheck(res.checks, "sealed-secret-hub-authorized").status).toBe("skip");
     expect(findCheck(res.checks, "monitor-reachable").status).toBe("pass");
     expect(findCheck(res.checks, "leaf-established").status).toBe("pass");
     expect(findCheck(res.checks, "leaf-account-bound").status).toBe("pass");
@@ -179,6 +194,8 @@ describe("runDoctorChecks — (a) all-green", () => {
     expect(peerCheck.status).toBe("pass");
     expect(peerCheck.owner).toBe("peer");
     expect(peerCheck.detail).toContain("rtt=41ms");
+    // A skip'd leg (Pair 3) is a valid outcome, not a broken/degraded verdict.
+    expect(res.verdict).not.toBe("broken");
     // Every check carries a responsible owner.
     for (const c of res.checks) {
       expect(["member", "hub-owner", "admin", "peer"]).toContain(c.owner);
@@ -434,5 +451,174 @@ describe("runDoctorChecks — leaf-account-bound", () => {
     const accountCheck = findCheck(res.checks, "leaf-account-bound");
     expect(accountCheck.status).toBe("warn");
     expect(accountCheck.detail).toContain("ACCOUNT_A");
+  });
+});
+
+// ===========================================================================
+// cortex#1482 (epic #1479, join-3) — the three representation-pairs.
+// ===========================================================================
+
+describe("runDoctorChecks — registered-vs-fed-account (Pair 1, informational)", () => {
+  test("a LEGITIMATE divergence (different keys) is a pass, never a fail", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const c = findCheck(res.checks, "registered-vs-fed-account");
+    expect(c.status).toBe("pass");
+    expect(c.detail).toContain("ADR-0018");
+    expect(res.verdict).not.toBe("broken");
+  });
+
+  test("no stack.nkey_pub configured → skip (not a failure)", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const cfg = loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]);
+    const res = await runDoctorChecks(ports, { cfg: { ...cfg, stack: { id: cfg.stack!.id } }, networkId: "metafactory-community" });
+    const c = findCheck(res.checks, "registered-vs-fed-account");
+    expect(c.status).toBe("skip");
+  });
+
+  test("FED account not yet derivable → warn (not fail) — never joined yet", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], undefined),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const c = findCheck(res.checks, "registered-vs-fed-account");
+    expect(c.status).toBe("warn");
+    expect(res.verdict).not.toBe("broken");
+  });
+
+  test("registered pubkey and FED account decoding to the SAME key material → warn, flagged as suspicious (still never fail)", async () => {
+    // A REAL (decodable) base64 pubkey on BOTH sides — samePubkey only fires
+    // on genuinely-decodable, byte-identical keys, not on two fixture
+    // strings that merely happen to be textually equal but decode to
+    // nothing (see the "LEGITIMATE divergence" test above, which uses
+    // non-decodable fixtures deliberately).
+    const sameKeyB64 = Buffer.from(new Uint8Array(32).fill(4)).toString("base64");
+    const cfg = loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]);
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], sameKeyB64),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: { ...cfg, stack: { id: cfg.stack!.id, nkey_pub: sameKeyB64 } },
+      networkId: "metafactory-community",
+    });
+    const c = findCheck(res.checks, "registered-vs-fed-account");
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("SAME key material");
+    expect(c.owner).toBe("admin");
+  });
+
+  test("skipped entirely when config-network fails (network not configured)", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([]),
+      monitor: fakeMonitorPort({ configured: true }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "registered-vs-fed-account").status).toBe("skip");
+    expect(findCheck(res.checks, "resolver-preload-account").status).toBe("skip");
+    expect(findCheck(res.checks, "sealed-secret-hub-authorized").status).toBe("skip");
+  });
+});
+
+describe("runDoctorChecks — resolver-preload-account (Pair 2)", () => {
+  test("a REAL mismatch (account not in resolver_preload) FAILS — the boot/auth failure this leg catches early", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", () => false),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const c = findCheck(res.checks, "resolver-preload-account");
+    expect(c.status).toBe("fail");
+    expect(c.detail).toContain("ACCOUNT_A");
+    expect(c.fix).toContain("resolver_preload");
+    expect(c.fix).toContain("restart");
+    // A real Pair 2 mismatch DOES flip the verdict — it's a real boot/auth bug.
+    expect(res.verdict).not.toBe("healthy");
+  });
+
+  test("account IS preloaded → pass", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "resolver-preload-account").status).toBe("pass");
+  });
+
+  test("cannot determine (no local nats config / no resolver_preload block at all) → warn, not fail", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", () => undefined),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const c = findCheck(res.checks, "resolver-preload-account");
+    expect(c.status).toBe("warn");
+    expect(res.verdict).not.toBe("broken");
+  });
+
+  test("no FED account derivable yet → skip", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], undefined, () => true),
+      monitor: fakeMonitorPort({ configured: false }),
+      probe: fakeProbe((f) => echoReply(f, 1)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "resolver-preload-account").status).toBe("skip");
+  });
+});
+
+describe("runDoctorChecks — sealed-secret-hub-authorized (Pair 3, documented stub)", () => {
+  test("ALWAYS skip, owner hub-owner, detail documents the follow-up — never fabricates a pass/fail it can't back", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 10)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const c = findCheck(res.checks, "sealed-secret-hub-authorized");
+    expect(c.status).toBe("skip");
+    expect(c.owner).toBe("hub-owner");
+    expect(c.detail).toContain("opaque ciphertext");
+    // A skip never blocks a healthy verdict.
+    expect(res.verdict).toBe("healthy");
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { describe, test, expect } from "bun:test";
+import { createAccount, createUser } from "@nats-io/nkeys";
+import { nkeyToBase64Pubkey } from "../../../../common/registry/encoding";
+import { toBase64Pubkey } from "../../../../common/registry/pubkey-normalize";
 import {
   runNetworkSecret,
   runNetworkKeyRotation,
@@ -286,6 +289,83 @@ describe("dry-run (default) + guards", () => {
     expect(report.ok).toBe(false);
     expect(r.writes.length).toBe(0);
     expect(r.posted.length).toBe(0);
+  });
+});
+
+// ===========================================================================
+// cortex#1482 (epic #1479, join-3) — Pair 1: registered/PoP pubkey ⟷ FED
+// account (seal-target ≠ leaf-account, ADR-0018). NKEY <-> base64
+// auto-convert at the admission lookup + the loud "wrong representation"
+// explanation instead of a bare "no ADMITTED row" error.
+// ===========================================================================
+
+describe("cortex#1482 — Pair 1: registered pubkey ⟷ FED account", () => {
+  test("an nkey-account-shaped member with no ADMITTED row gets the ADR-0018 explanation, not a bare error", async () => {
+    const r = makePorts({ admitted: undefined });
+    // Grammar-valid (A + 55 base32 chars), checksum-invalid — the SAME fixture
+    // style used across the existing --hub-account tests; the explanation is a
+    // grammar-only HINT (looksLikeNkeyRole), so it fires regardless.
+    const fakeAccountNkey = "A" + "D".repeat(55);
+    const report = await runNetworkSecret(inputs({ memberPubkey: fakeAccountNkey, apply: true }), r.ports);
+    expect(report.ok).toBe(false);
+    expect(report.reason).toContain("FED account nkey");
+    expect(report.reason).toContain("seal-target ≠ leaf-account");
+    expect(report.reason).toContain("ADR-0018");
+    expect(report.reason).toContain("--hub-account");
+    // The bare message is still the PREFIX (nothing removed, only appended).
+    expect(report.reason).toContain("no ADMITTED admission row for that member");
+  });
+
+  test("a base64 member with no ADMITTED row gets the BARE message (no representation claim we can't back)", async () => {
+    const r = makePorts({ admitted: undefined });
+    const report = await runNetworkSecret(inputs({ apply: true }), r.ports); // default MEMBER_PUBKEY is base64
+    expect(report.ok).toBe(false);
+    expect(report.reason).not.toContain("FED account nkey");
+    expect(report.reason).toContain("no ADMITTED admission row for that member");
+  });
+
+  test("revoke-member: the SAME explanation fires on the wrong-representation path", async () => {
+    const r = makePorts({ admitted: undefined });
+    const fakeAccountNkey = "A" + "E".repeat(55);
+    const report = await runNetworkSecret(
+      inputs({ action: "revoke-member", memberPubkey: fakeAccountNkey, apply: true }),
+      r.ports,
+    );
+    expect(report.ok).toBe(false);
+    expect(report.reason).toContain("FED account nkey");
+    expect(report.reason).toContain("nothing to revoke");
+  });
+
+  test("an nkey-user member is auto-converted to base64 for the admission lookup + the seal", async () => {
+    const nkeyU = createUser().getPublicKey();
+    const expectedB64 = nkeyToBase64Pubkey(nkeyU)!;
+    let lookedUpWith: string | undefined;
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const originalFind = r.ports.admission.findAdmittedRow;
+    r.ports.admission.findAdmittedRow = async (networkId: string, memberPubkey: string) => {
+      lookedUpWith = memberPubkey;
+      return originalFind(networkId, memberPubkey);
+    };
+
+    const report = await runNetworkSecret(inputs({ memberPubkey: nkeyU, apply: true }), r.ports);
+
+    expect(report.ok).toBe(true);
+    expect(lookedUpWith).toBe(expectedB64);
+    // The fingerprint printed in steps/data is derived from the NORMALIZED
+    // (base64) form too, not the raw nkey string.
+    expect(report.data.member_fingerprint).toBe(expectedB64.slice(0, 12));
+  });
+
+  test("an nkey-account member (the WRONG representation) is still converted to base64 for the lookup — the explanation only fires when that lookup MISSES", async () => {
+    // If an admission row genuinely exists keyed to these (unusual) bytes, the
+    // lookup succeeds and no explanation is needed — normalize-then-lookup
+    // never refuses solely because the input LOOKED like an account nkey.
+    const nkeyA = createAccount().getPublicKey();
+    const expectedB64 = toBase64Pubkey(nkeyA)!;
+    const r = makePorts({ admitted: { request_id: "req1", principal_id: "alice" } });
+    const report = await runNetworkSecret(inputs({ memberPubkey: nkeyA, apply: true }), r.ports);
+    expect(report.ok).toBe(true);
+    expect(report.data.member_fingerprint).toBe(expectedB64.slice(0, 12));
   });
 });
 

--- a/src/cli/cortex/commands/network-doctor-adapters.ts
+++ b/src/cli/cortex/commands/network-doctor-adapters.ts
@@ -56,15 +56,27 @@ export const DEFAULT_LEAFZ_TIMEOUT_MS = DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
  * `network-make-live-adapters.ts`) — same block-opening regex, same
  * depth-counted brace walk — but EXTRACTS the block instead of inserting
  * into it.
+ *
+ * Cheap-guard limitation (Sage review, nit 5): before the walk we blank out
+ * FULL-LINE `//` comments (see {@link blankFullLineComments}) so a stray
+ * `{`/`}` in a comment line can't unbalance the scan. We deliberately do NOT
+ * attempt to skip braces inside QUOTED strings — resolver_preload entries are
+ * `<pubkey>: <JWT>` pairs whose values (base32 nkeys, `eyJ…` JWTs) never
+ * contain braces, so a brace inside a quoted value doesn't occur in practice;
+ * a full string-tokenizer would balloon scope for a case NATS configs don't
+ * produce.
  */
 export function resolverPreloadHasAccountKey(text: string, accountPubkey: string): boolean | undefined {
-  const key = /resolver_preload\s*[:=]?\s*\{/.exec(text);
+  // Index-preserving: comment chars become spaces (same length), so every
+  // offset below still lines up with the original `text`.
+  const scanned = blankFullLineComments(text);
+  const key = /resolver_preload\s*[:=]?\s*\{/.exec(scanned);
   if (key === null) return undefined;
   const open = key.index + key[0].length - 1; // index of the `{`
   let depth = 0;
   let close = -1;
-  for (let i = open; i < text.length; i++) {
-    const ch = text[i];
+  for (let i = open; i < scanned.length; i++) {
+    const ch = scanned[i];
     if (ch === "{") depth++;
     else if (ch === "}") {
       depth--;
@@ -75,9 +87,24 @@ export function resolverPreloadHasAccountKey(text: string, accountPubkey: string
     }
   }
   if (close === -1) return undefined; // unbalanced braces — can't determine
-  const block = text.slice(open + 1, close);
+  const block = scanned.slice(open + 1, close);
   const escaped = accountPubkey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(`(^|[\\s{,])${escaped}\\s*:`).test(block);
+}
+
+/**
+ * Replace the `//…`-to-end-of-line portion of any FULL-LINE comment (a line
+ * whose first non-whitespace is `//`) with spaces of the SAME length, so
+ * character offsets are preserved for the brace walk. Only full-line comments
+ * are blanked — an inline `//` (which in a real config only ever follows a
+ * value, e.g. `tls://host` is NOT line-leading) is left alone, so we never
+ * mangle a `tls://` scheme or a value's own `//`.
+ */
+function blankFullLineComments(text: string): string {
+  return text.replace(
+    /^([ \t]*)\/\/[^\n]*/gm,
+    (match, indent: string) => indent + " ".repeat(match.length - indent.length),
+  );
 }
 
 /** Inputs {@link buildDoctorConfigPort} needs — a subset of {@link LivePortsConfig}. */

--- a/src/cli/cortex/commands/network-doctor-adapters.ts
+++ b/src/cli/cortex/commands/network-doctor-adapters.ts
@@ -37,6 +37,49 @@ import type {
 /** Bound the `/leafz` probe so a hung monitor cannot stall `doctor` forever. */
 export const DEFAULT_LEAFZ_TIMEOUT_MS = DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
 
+// =============================================================================
+// cortex#1482 (epic #1479, join-3, Pair 2) — resolver_preload account lookup.
+// =============================================================================
+
+/**
+ * True iff `accountPubkey` appears as a top-level KEY inside the
+ * `resolver_preload { … }` block of `text` (not merely anywhere in the file —
+ * a leaf remote's OWN `account: "<pubkey>"` line commonly carries the SAME
+ * account pubkey, so a bare substring search over the whole file would
+ * false-positive even when the account is NOT actually preloaded).
+ * `undefined` when `text` has no `resolver_preload { … }` block at all (can't
+ * determine — e.g. a non-operator-mode / hard-isolated bus, where the
+ * question doesn't apply, or an unbalanced/malformed config).
+ *
+ * The brace-matched scan mirrors `insertIntoResolverPreload` (this same
+ * codebase's existing resolver_preload-block locator, in
+ * `network-make-live-adapters.ts`) — same block-opening regex, same
+ * depth-counted brace walk — but EXTRACTS the block instead of inserting
+ * into it.
+ */
+export function resolverPreloadHasAccountKey(text: string, accountPubkey: string): boolean | undefined {
+  const key = /resolver_preload\s*[:=]?\s*\{/.exec(text);
+  if (key === null) return undefined;
+  const open = key.index + key[0].length - 1; // index of the `{`
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close === -1) return undefined; // unbalanced braces — can't determine
+  const block = text.slice(open + 1, close);
+  const escaped = accountPubkey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|[\\s{,])${escaped}\\s*:`).test(block);
+}
+
 /** Inputs {@link buildDoctorConfigPort} needs — a subset of {@link LivePortsConfig}. */
 export interface DoctorConfigAdapterConfig {
   /** The COMPOSED `policy.federated.networks[]` from the loaded config — read
@@ -94,6 +137,26 @@ export function buildDoctorConfigPort(cfg: DoctorConfigAdapterConfig): DoctorCon
       // operator-mode-bound. Absent entirely for a `$G`/default-bus remote.
       const m = /^\s*account:\s*(\S+)/m.exec(text);
       return m?.[1];
+    },
+
+    // cortex#1482 (Pair 2) — reads the SAME base nats config `natsConfigPath`
+    // points at (not the per-network leaf-include file `expectedFedAccount`
+    // reads) since `resolver_preload` lives on the bus's OWN config, not the
+    // per-network include.
+    resolverPreloadHasAccount(accountPubkey: string): boolean | undefined {
+      const natsConfigPath = expandTilde(cfg.natsConfigPath ?? "");
+      if (natsConfigPath.length === 0 || !existsSync(natsConfigPath)) return undefined;
+
+      let text: string;
+      try {
+        text = readFileSync(natsConfigPath, "utf-8");
+      } catch (err) {
+        process.stderr.write(
+          `network-doctor-adapters: could not read nats config ${natsConfigPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        return undefined;
+      }
+      return resolverPreloadHasAccountKey(text, accountPubkey);
     },
   };
 }

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -17,15 +17,30 @@
  * timeout and re-mapped to a DoctorCheck).
  *
  * Later checks `skip` when a hard prerequisite failed (spec's check matrix):
- *   1. config-network      — the network is configured, has peers + accept_subjects
- *   2. monitor-reachable   — the local nats-server HTTP monitor answers `/leafz`
- *   3. leaf-established    — `/leafz` shows an established leaf for this network
- *   4. leaf-account-bound  — the established leaf's account matches config (best-effort)
- *   5. peer-reachable:<p>  — one check per configured peer, a real echo round-trip
+ *   1. config-network              — the network is configured, has peers + accept_subjects
+ *   2. registered-vs-fed-account   — cortex#1482 Pair 1 (informational — legit divergence, never fails)
+ *   3. resolver-preload-account    — cortex#1482 Pair 2 (fails on a real preload mismatch)
+ *   4. sealed-secret-hub-authorized — cortex#1482 Pair 3 (documented stub — always skip)
+ *   5. monitor-reachable           — the local nats-server HTTP monitor answers `/leafz`
+ *   6. leaf-established            — `/leafz` shows an established leaf for this network
+ *   7. leaf-account-bound          — the established leaf's account matches config (best-effort)
+ *   8. peer-reachable:<p>          — one check per configured peer, a real echo round-trip
+ *
+ * Legs 2-4 (cortex#1482, epic #1479, join-3) surface the THREE representation
+ * pairs that nothing checked before: (1) registered/PoP pubkey ⟷ FED account
+ * (these can LEGITIMATELY differ — seal-target ≠ leaf-account, ADR-0018 — so
+ * this leg is informational, never a `fail`); (2) local `resolver_preload`
+ * accounts ⟷ leaf remote `account:` (a REAL mismatch here is a boot/auth
+ * failure waiting to happen — this leg DOES fail); (3) registry sealed-secret
+ * ⟷ hub authorization (needs hub-side visibility this command doesn't have —
+ * a documented stub, not a fabricated check). They are STATIC/config-only
+ * (no live NATS needed), so they run right after config-network and degrade
+ * gracefully (warn/skip) rather than block downstream legs.
  */
 
 import type { LoadedConfig } from "../../../common/config/loader";
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import { samePubkey } from "../../../common/registry/pubkey-normalize";
 import {
   derivePingInputs,
   pingPeer,
@@ -115,6 +130,13 @@ function stackSlugFromStackId(stackId: string): string {
   return parts.length === 2 ? (parts[1] ?? stackId) : stackId;
 }
 
+/** Truncate a pubkey for display in a check detail (never the full key —
+ *  these legs deal in PUBLIC keys, so truncation is for READABILITY, not
+ *  secrecy). */
+function shortKey(pubkey: string): string {
+  return `${pubkey.slice(0, 12)}…`;
+}
+
 // ---------------------------------------------------------------------------
 // Leg 1 — config-network
 // ---------------------------------------------------------------------------
@@ -176,6 +198,152 @@ function checkConfigNetwork(
     ),
     network,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Leg 1.5 — registered-vs-fed-account (cortex#1482, Pair 1 — informational)
+// ---------------------------------------------------------------------------
+
+/**
+ * cortex#1482 Pair 1 — surface the stack's registered/PoP pubkey ALONGSIDE
+ * this network's FED account so whoever runs `cortex network doctor` can see,
+ * at a glance, that they are (correctly) two DIFFERENT keys — seal-target ≠
+ * leaf-account, ADR-0018.
+ * Divergence is the EXPECTED, healthy state, so this leg NEVER fails; the
+ * worst outcome is `warn` (can't determine one side yet, or — a real red
+ * flag — the two decode to the SAME key material, which would mean the
+ * account was provisioned by reusing the registered identity key).
+ */
+function checkRegisteredVsFedAccount(
+  config: DoctorConfigPort,
+  networkId: string,
+  registeredPubkey: string | undefined,
+): DoctorCheck {
+  const id = "registered-vs-fed-account";
+  const title = "registered pubkey vs FED account (Pair 1)";
+
+  if (registeredPubkey === undefined) {
+    return skipCheck(
+      id,
+      title,
+      "skipped — no registered/PoP pubkey on this stack's config (stack.nkey_pub)",
+      "member",
+    );
+  }
+  const fedAccount = config.expectedFedAccount(networkId);
+  if (fedAccount === undefined) {
+    return check(
+      id,
+      title,
+      "warn",
+      `registered pubkey ${shortKey(registeredPubkey)} — FED account not derivable yet (no rendered leaf include; join first)`,
+      "member",
+    );
+  }
+  if (samePubkey(registeredPubkey, fedAccount)) {
+    return check(
+      id,
+      title,
+      "warn",
+      `registered pubkey and FED account decode to the SAME key material (${shortKey(registeredPubkey)}) — ` +
+        `these should be TWO DIFFERENT keys (seal-target ≠ leaf-account, ADR-0018); double-check the account ` +
+        `wasn't provisioned by reusing the registered identity key`,
+      "admin",
+      "provision a DEDICATED federation account for this stack rather than reusing the registered identity key",
+    );
+  }
+  return check(
+    id,
+    title,
+    "pass",
+    `registered pubkey ${shortKey(registeredPubkey)} and FED account ${shortKey(fedAccount)} are different keys, as expected (seal-target ≠ leaf-account, ADR-0018)`,
+    "member",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Leg 1.6 — resolver-preload-account (cortex#1482, Pair 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * cortex#1482 Pair 2 — the leaf remote binds an account that MUST be present
+ * in this bus's OWN `resolver_preload { … }`, or the bus can't authenticate
+ * the leaf at boot. Unlike Pair 1, a real mismatch here IS a failure — it is
+ * exactly the class of bug that otherwise only surfaces as a cryptic
+ * Authorization Violation at boot/reload time.
+ */
+function checkResolverPreloadAccount(
+  config: DoctorConfigPort,
+  fedAccount: string | undefined,
+): DoctorCheck {
+  const id = "resolver-preload-account";
+  const title = "leaf account preloaded on this bus (Pair 2)";
+
+  if (fedAccount === undefined) {
+    return skipCheck(
+      id,
+      title,
+      "skipped — no FED account derivable for this network yet (see registered-vs-fed-account / join first)",
+      "member",
+    );
+  }
+  const present = config.resolverPreloadHasAccount(fedAccount);
+  if (present === undefined) {
+    return check(
+      id,
+      title,
+      "warn",
+      `could not read this bus's resolver_preload (no local nats config found, or the bus declares no ` +
+        `resolver_preload block at all — expected for a non-operator-mode bus) — cannot verify account ` +
+        `${shortKey(fedAccount)} is preloaded`,
+      "member",
+    );
+  }
+  if (!present) {
+    return check(
+      id,
+      title,
+      "fail",
+      `leaf remote binds account ${shortKey(fedAccount)} but this bus's resolver_preload does NOT declare ` +
+        `it — the bus cannot authenticate this leaf (boot/auth failure)`,
+      "member",
+      `add account "${fedAccount}" to this bus's resolver_preload (arc nats export-account / cortex network ` +
+        `make-live) and restart the bus — a SIGHUP reload does not pick up resolver_preload changes`,
+    );
+  }
+  return check(id, title, "pass", `account ${shortKey(fedAccount)} is preloaded on this bus`, "member");
+}
+
+// ---------------------------------------------------------------------------
+// Leg 1.7 — sealed-secret-hub-authorized (cortex#1482, Pair 3 — stub)
+// ---------------------------------------------------------------------------
+
+/**
+ * cortex#1482 Pair 3 — is the sealed leaf PSK on the registry's admission row
+ * ACTUALLY authorized (an `authorization` user) on the hub? This is a
+ * genuinely hub-side question this command cannot answer from the joining
+ * member's own machine: the registry carries only an OPAQUE ciphertext
+ * sealed to the member's pubkey (ADR-0018 Q1) — nobody but the member can
+ * decrypt it, so there is no PSK to fingerprint-compare against the hub's
+ * `authorization` entries from here, even on a local hub. A "does the hub
+ * declare AN authorization user for this member" check would prove nothing
+ * about whether the SEALED SECRET matches it, so implementing that partial
+ * signal would be actively misleading (an outdated PSK still hits `pass`).
+ * Rather than fabricate a check this command can't back, this leg documents
+ * the gap: always `skip`, owner `hub-owner` (only they can verify it — e.g.
+ * fingerprint-comparing the decrypted PSK against the hub's live
+ * `authorization` users), with a fix pointing at the follow-up.
+ */
+function checkSealedSecretHubAuthorized(): DoctorCheck {
+  return skipCheck(
+    "sealed-secret-hub-authorized",
+    "registry sealed-secret ⟷ hub authorization (Pair 3)",
+    "not implemented from the member side — the registry holds only an opaque ciphertext sealed to the " +
+      "member's own pubkey (ADR-0018 Q1), so there is no plaintext PSK here to compare against the hub's " +
+      "authorization users. Verifying this pair needs HUB-SIDE visibility (the hub owner decrypting + " +
+      "fingerprint-comparing against their own nats config) — tracked as a follow-up, not fabricated here.",
+    "hub-owner",
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -461,6 +629,23 @@ export async function runDoctorChecks(
   const network = configResult.network;
   if (configResult.result.status !== "pass" || network === undefined) {
     checks.push(
+      skipCheck(
+        "registered-vs-fed-account",
+        "registered pubkey vs FED account (Pair 1)",
+        "skipped — network not configured (see config-network)",
+        "member",
+      ),
+    );
+    checks.push(
+      skipCheck(
+        "resolver-preload-account",
+        "leaf account preloaded on this bus (Pair 2)",
+        "skipped — network not configured (see config-network)",
+        "member",
+      ),
+    );
+    checks.push(checkSealedSecretHubAuthorized());
+    checks.push(
       skipCheck("monitor-reachable", "local NATS monitor reachable", "skipped — network not configured (see config-network)", "member"),
     );
     checks.push(
@@ -472,6 +657,15 @@ export async function runDoctorChecks(
     const verdict = aggregateVerdict(checks);
     return { checks, verdict, exitCode: DOCTOR_EXIT_CODE[verdict] };
   }
+
+  // 1.5-1.7. cortex#1482 — the three representation-pairs. Purely
+  // static/config-based (no live NATS), so they run right after
+  // config-network and don't gate anything downstream.
+  const registeredPubkey = opts.cfg.stack?.nkey_pub;
+  const fedAccount = ports.config.expectedFedAccount(opts.networkId);
+  checks.push(checkRegisteredVsFedAccount(ports.config, opts.networkId, registeredPubkey));
+  checks.push(checkResolverPreloadAccount(ports.config, fedAccount));
+  checks.push(checkSealedSecretHubAuthorized());
 
   // 2. monitor-reachable
   const monitorResult = await checkMonitorReachable(ports);

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -87,6 +87,26 @@ const CRITICAL_CHECK_IDS = new Set(["config-network", "leaf-established"]);
 /** Default per-probe echo wait budget (ms) for the peer-reachable leg. */
 export const DEFAULT_DOCTOR_PROBE_TIMEOUT_MS = 6000;
 
+/**
+ * cortex#1482 — id + title for the three representation-pair legs, in ONE
+ * place so the check bodies and the config-network-failed skip path can never
+ * drift apart (Sage review, nit 4).
+ */
+const PAIR_LEGS = {
+  registeredVsFedAccount: {
+    id: "registered-vs-fed-account",
+    title: "registered pubkey vs FED account (Pair 1)",
+  },
+  resolverPreloadAccount: {
+    id: "resolver-preload-account",
+    title: "leaf account preloaded on this bus (Pair 2)",
+  },
+  sealedSecretHubAuthorized: {
+    id: "sealed-secret-hub-authorized",
+    title: "registry sealed-secret ⟷ hub authorization (Pair 3)",
+  },
+} as const;
+
 export interface DoctorOptions {
   /** The already-loaded LOCAL stack config — the #753 seam. Supplies
    *  principal/stack/assistant for deriving each peer-reachable probe's
@@ -211,16 +231,26 @@ function checkConfigNetwork(
  * leaf-account, ADR-0018.
  * Divergence is the EXPECTED, healthy state, so this leg NEVER fails; the
  * worst outcome is `warn` (can't determine one side yet, or — a real red
- * flag — the two decode to the SAME key material, which would mean the
- * account was provisioned by reusing the registered identity key).
+ * flag — the two are the SAME key material, which would mean the account was
+ * provisioned by reusing the registered identity key).
+ *
+ * Representation handling (what this leg ACTUALLY does — no conversion):
+ *   - DISPLAY: each key is shown AS-STORED, via a 12-char prefix
+ *     ({@link shortKey}). Whatever encoding the config carries (the
+ *     registered pubkey is typically base64; the FED account a `U…`/`A…`
+ *     nkey) is what you see — this leg does NOT convert base64↔nkey for
+ *     display.
+ *   - COMPARISON: {@link samePubkey} decodes BOTH sides to their raw 32
+ *     ed25519 bytes and compares those, so it is representation- AND
+ *     role-agnostic — a base64 pubkey and an nkey of the same underlying key
+ *     compare EQUAL without either being re-encoded here.
  */
 function checkRegisteredVsFedAccount(
   config: DoctorConfigPort,
   networkId: string,
   registeredPubkey: string | undefined,
 ): DoctorCheck {
-  const id = "registered-vs-fed-account";
-  const title = "registered pubkey vs FED account (Pair 1)";
+  const { id, title } = PAIR_LEGS.registeredVsFedAccount;
 
   if (registeredPubkey === undefined) {
     return skipCheck(
@@ -276,8 +306,7 @@ function checkResolverPreloadAccount(
   config: DoctorConfigPort,
   fedAccount: string | undefined,
 ): DoctorCheck {
-  const id = "resolver-preload-account";
-  const title = "leaf account preloaded on this bus (Pair 2)";
+  const { id, title } = PAIR_LEGS.resolverPreloadAccount;
 
   if (fedAccount === undefined) {
     return skipCheck(
@@ -336,8 +365,8 @@ function checkResolverPreloadAccount(
  */
 function checkSealedSecretHubAuthorized(): DoctorCheck {
   return skipCheck(
-    "sealed-secret-hub-authorized",
-    "registry sealed-secret ⟷ hub authorization (Pair 3)",
+    PAIR_LEGS.sealedSecretHubAuthorized.id,
+    PAIR_LEGS.sealedSecretHubAuthorized.title,
     "not implemented from the member side — the registry holds only an opaque ciphertext sealed to the " +
       "member's own pubkey (ADR-0018 Q1), so there is no plaintext PSK here to compare against the hub's " +
       "authorization users. Verifying this pair needs HUB-SIDE visibility (the hub owner decrypting + " +
@@ -630,16 +659,16 @@ export async function runDoctorChecks(
   if (configResult.result.status !== "pass" || network === undefined) {
     checks.push(
       skipCheck(
-        "registered-vs-fed-account",
-        "registered pubkey vs FED account (Pair 1)",
+        PAIR_LEGS.registeredVsFedAccount.id,
+        PAIR_LEGS.registeredVsFedAccount.title,
         "skipped — network not configured (see config-network)",
         "member",
       ),
     );
     checks.push(
       skipCheck(
-        "resolver-preload-account",
-        "leaf account preloaded on this bus (Pair 2)",
+        PAIR_LEGS.resolverPreloadAccount.id,
+        PAIR_LEGS.resolverPreloadAccount.title,
         "skipped — network not configured (see config-network)",
         "member",
       ),

--- a/src/cli/cortex/commands/network-doctor-ports.ts
+++ b/src/cli/cortex/commands/network-doctor-ports.ts
@@ -46,6 +46,19 @@ export interface DoctorConfigPort {
    * in that case rather than failing. Never throws.
    */
   expectedFedAccount(networkId: string): string | undefined;
+  /**
+   * cortex#1482 (epic #1479, join-3, Pair 2) — best-effort: does the bus's
+   * OWN nats-server config (the SAME file the `natsConfigPath` adapter input
+   * points at) declare `accountPubkey` as a `resolver_preload { … }` KEY? A
+   * leaf remote binds an account that MUST be preloaded on this bus, or the
+   * bus can't authenticate the leaf at boot — this catches the mismatch
+   * statically, before it becomes a boot/auth failure. `undefined` when it
+   * cannot be determined (no natsConfigPath, file missing, or the config
+   * carries NO `resolver_preload { … }` block at all — e.g. a
+   * non-operator-mode / hard-isolated bus, where the question doesn't
+   * apply). Never throws.
+   */
+  resolverPreloadHasAccount(accountPubkey: string): boolean | undefined;
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/network-secret-lib.ts
+++ b/src/cli/cortex/commands/network-secret-lib.ts
@@ -26,6 +26,7 @@
  */
 
 import { encodeLeafSecretEnvelope } from "../../../common/registry/sealed-leaf-secret";
+import { looksLikeNkeyRole, toBase64Pubkey } from "../../../common/registry/pubkey-normalize";
 import { pskFingerprint } from "../../../common/nats/leaf-psk";
 import {
   upsertHubLeafUser,
@@ -337,23 +338,30 @@ async function addOrRotate(
 ): Promise<SecretReport> {
   const action: SecretAction = rotate ? "rotate" : "add-member";
   const steps: string[] = [];
+  // cortex#1482 (Pair 1) — normalize whatever encoding the caller passed
+  // (base64, or an nkey of EITHER role) to base64 for the lookup/seal below;
+  // fall back to the raw value when it isn't recognizable so an already-
+  // malformed input fails exactly as it did before this change. The RAW
+  // `inputs.memberPubkey` is kept separately (never overwritten) so
+  // `noAdmittedRowMessage` can still inspect what the caller actually typed.
+  const memberPubkeyB64 = toBase64Pubkey(inputs.memberPubkey) ?? inputs.memberPubkey;
   const data: Record<string, string> = {
     action,
     network: inputs.networkId,
-    member_fingerprint: inputs.memberPubkey.slice(0, 12),
+    member_fingerprint: memberPubkeyB64.slice(0, 12),
     deliver: inputs.deliver,
   };
 
   // 1. Resolve the ADMITTED admission row (read-only — safe in dry-run too).
-  const row = await ports.admission.findAdmittedRow(inputs.networkId, inputs.memberPubkey);
+  const row = await ports.admission.findAdmittedRow(inputs.networkId, memberPubkeyB64);
   if (!row) {
-    return fail(action, inputs, steps, data, `no ADMITTED admission row for that member on network "${inputs.networkId}" — admit them first (cortex network admit)`);
+    return fail(action, inputs, steps, data, noAdmittedRowMessage(inputs.networkId, inputs.memberPubkey, "admit them first (cortex network admit)"));
   }
   const leafUser = inputs.leafUserOverride ?? row.principal_id;
   data.request_id = row.request_id;
   data.leaf_user = leafUser;
 
-  steps.push(`member:     ${inputs.memberPubkey.slice(0, 12)}… (request ${row.request_id})`);
+  steps.push(`member:     ${memberPubkeyB64.slice(0, 12)}… (request ${row.request_id})`);
   steps.push(`leaf user:  ${leafUser}`);
   steps.push(`deliver:    ${inputs.deliver}`);
 
@@ -495,7 +503,7 @@ async function addOrRotate(
         payload_key_kid: payloadKeyKid,
       }),
     });
-    sealed = await ports.crypto.seal(envelope, inputs.memberPubkey);
+    sealed = await ports.crypto.seal(envelope, memberPubkeyB64);
   } catch (err) {
     return fail(action, inputs, steps, data, `failed to seal the secret to the member pubkey: ${errText(err)}`);
   }
@@ -542,20 +550,22 @@ async function revokeMember(
 ): Promise<SecretReport> {
   const action: SecretAction = "revoke-member";
   const steps: string[] = [];
+  // cortex#1482 (Pair 1) — SAME normalize-then-fall-back-to-raw as addOrRotate.
+  const memberPubkeyB64 = toBase64Pubkey(inputs.memberPubkey) ?? inputs.memberPubkey;
   const data: Record<string, string> = {
     action,
     network: inputs.networkId,
-    member_fingerprint: inputs.memberPubkey.slice(0, 12),
+    member_fingerprint: memberPubkeyB64.slice(0, 12),
   };
 
-  const row = await ports.admission.findAdmittedRow(inputs.networkId, inputs.memberPubkey);
+  const row = await ports.admission.findAdmittedRow(inputs.networkId, memberPubkeyB64);
   if (!row) {
-    return fail(action, inputs, steps, data, `no ADMITTED admission row for that member on network "${inputs.networkId}" — nothing to revoke`);
+    return fail(action, inputs, steps, data, noAdmittedRowMessage(inputs.networkId, inputs.memberPubkey, "nothing to revoke"));
   }
   const leafUser = inputs.leafUserOverride ?? row.principal_id;
   data.request_id = row.request_id;
   data.leaf_user = leafUser;
-  steps.push(`member:     ${inputs.memberPubkey.slice(0, 12)}… (request ${row.request_id})`);
+  steps.push(`member:     ${memberPubkeyB64.slice(0, 12)}… (request ${row.request_id})`);
   steps.push(`leaf user:  ${leafUser}`);
 
   if (!inputs.apply) {
@@ -607,6 +617,35 @@ function fail(action: SecretAction, inputs: SecretInputs, steps: string[], data:
 
 function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+// ===========================================================================
+// cortex#1482 (epic #1479, join-3) — Pair 1 reconciliation: registered/PoP
+// pubkey ⟷ FED account. These CAN legitimately differ (seal-target ≠
+// leaf-account, ADR-0018): a member's admission row is keyed to their
+// REGISTERED/PoP pubkey (a user-role identity key), while their leaf binds a
+// SEPARATE FED account (an account-role key). Passing the account key where
+// the admission lookup expects the registered pubkey used to fail with a
+// bare "no ADMITTED row" — {@link noAdmittedRowMessage} builds the loud,
+// plain explanation instead, but ONLY when the RAW value the caller typed is
+// shaped like the other representation (an nkey-account, `A…`). A value
+// that's already base64 or an nkey-user (the CORRECT shape) that simply
+// isn't admitted gets the bare message unchanged — base64 carries no role
+// annotation, so we cannot honestly claim a representation mismatch for it,
+// and "not admitted yet" is a real, distinct failure the explanation must
+// not paper over.
+// ===========================================================================
+
+function noAdmittedRowMessage(networkId: string, rawMemberPubkey: string, tail: string): string {
+  const bare = `no ADMITTED admission row for that member on network "${networkId}" — ${tail}`;
+  if (!looksLikeNkeyRole(rawMemberPubkey, "account")) return bare;
+  return (
+    `${bare}. "${rawMemberPubkey.slice(0, 12)}…" looks like a FED account nkey (A…), but admission ` +
+    `rows are keyed to the member's REGISTERED/PoP pubkey — a different key, not the hub's federation ` +
+    `account. These can legitimately differ (seal-target ≠ leaf-account, ADR-0018): pass the member's ` +
+    `registered/PoP pubkey here instead (base64 or a U… nkey — either encoding works). If you meant to ` +
+    `bind the HUB's own federation account, that's --hub-account, not the member pubkey.`
+  );
 }
 
 // ===========================================================================

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -131,7 +131,13 @@ import {
 } from "./network-make-live-lib";
 import { buildLiveMakeLivePorts, buildResolverPreloadAdapter } from "./network-make-live-adapters";
 import type { OperatorModeLeafPackage, NatsBaseIdentity } from "../../../common/nats/leaf-remote-renderer";
-import { parseLoopbackListen, isNkeyAccountPubkey } from "../../../common/nats/leaf-remote-renderer";
+import { parseLoopbackListen } from "../../../common/nats/leaf-remote-renderer";
+import {
+  detectPubkey,
+  looksLikeNkeyRole,
+  samePubkey,
+  toNkeyPubkey,
+} from "../../../common/registry/pubkey-normalize";
 import {
   runNetworkSecret,
   runNetworkKeyRotation,
@@ -2350,6 +2356,42 @@ async function runListPending(flags: FlagMap, json: boolean): Promise<ExitResult
   return ok(renderPendingTable(filtered, status, networkFilter, registryUrl));
 }
 
+// =============================================================================
+// cortex#1482 (epic #1479, join-3) — shared `--hub-account` boundary.
+// =============================================================================
+
+/**
+ * Validate + normalize a `--hub-account` flag value to the canonical
+ * nkey-account form. Accepts EITHER an nkey-U account key (`A…`) or its
+ * base64 form (auto-converts); REFUSES a value that looks like the member's
+ * own registered/PoP USER key (`U…`) with a plain explanation (seal-target ≠
+ * leaf-account, ADR-0018) rather than a bare grammar error. `raw === undefined`
+ * (nothing passed) is not an error — the caller's `hubAccount` stays
+ * `undefined` (omit ⇒ the printed artifact tells the hub owner to add the
+ * account themselves). Shared by `admit --hub-account` and
+ * `secret … --hub-account` — the SAME boundary, validated once.
+ */
+function normalizeHubAccountFlag(
+  raw: string | undefined,
+): { ok: true; value?: string } | { ok: false; reason: string } {
+  if (raw === undefined) return { ok: true };
+  const normalized = toNkeyPubkey(raw, "account");
+  if (normalized !== undefined) return { ok: true, value: normalized };
+  if (looksLikeNkeyRole(raw, "user")) {
+    return {
+      ok: false,
+      reason:
+        `--hub-account "${raw}" looks like a registered/PoP user nkey (U…) — that's the MEMBER's identity ` +
+        `key, not the hub's federation account. These are different keys (seal-target ≠ leaf-account, ` +
+        `ADR-0018); pass the hub's OWN account nkey (A…) or its base64 form instead.`,
+    };
+  }
+  return {
+    ok: false,
+    reason: `--hub-account "${raw}" is not a valid federation-account pubkey (expected an nkey-U account key "A…" (56 chars) or its base64 form (44 chars))`,
+  };
+}
+
 /**
  * `cortex network admit <request-id> --admin-seed <path> [--apply]`
  *
@@ -2396,14 +2438,17 @@ async function runAdmit(
   const discordGuild = optionalValueFlag(flags, "--discord-guild");
   const discordRole = optionalValueFlag(flags, "--discord-role") ?? DEFAULT_ADMIT_DISCORD_ROLE;
   // cortex#1481 (Sage review, Important 1) — validate --hub-account with the
-  // SAME nkey-U guard the `secret` path enforces (isNkeyAccountPubkey), and
-  // validate it HERE — before the admission is committed — so a malformed
-  // account fails fast (exit 2) rather than silently riding into the printed
-  // hub-owner artifact the hub owner pastes into a live nats-server config.
-  const admitHubAccount = optionalValueFlag(flags, "--hub-account");
-  if (admitHubAccount !== undefined && !isNkeyAccountPubkey(admitHubAccount)) {
-    return usageError("admit", `--hub-account "${admitHubAccount}" is not a valid nkey-U account public key (expected A + 55 base32 chars)`, json);
+  // SAME guard the `secret` path enforces, and validate it HERE — before the
+  // admission is committed — so a malformed account fails fast (exit 2)
+  // rather than silently riding into the printed hub-owner artifact the hub
+  // owner pastes into a live nats-server config. cortex#1482 — normalizes
+  // either encoding (nkey-U or base64) and explains a registered-vs-account
+  // role mismatch instead of a bare grammar error (ADR-0018).
+  const admitHubAccountRes = normalizeHubAccountFlag(optionalValueFlag(flags, "--hub-account"));
+  if (!admitHubAccountRes.ok) {
+    return usageError("admit", admitHubAccountRes.reason, json);
   }
+  const admitHubAccount = admitHubAccountRes.value;
 
   // Load + chmod-600-gate the admin seed
   const matRes = await adminMaterialFromSeedFile(seedRes.value);
@@ -3090,8 +3135,17 @@ async function runSecret(
   if (member === "") {
     return usageError("secret", `action "${action}" requires a member pubkey (usage: cortex network secret ${action} <network> <member-pubkey>)`, json);
   }
-  if (!MEMBER_PUBKEY_RE.test(member)) {
-    return usageError("secret", `member "${member}" must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)`, json);
+  // cortex#1482 — accept EITHER encoding (base64 OR an nkey-U, either role);
+  // the RAW string rides through unchanged into SecretInputs.memberPubkey —
+  // network-secret-lib.ts normalizes it for the actual lookup/seal and, on a
+  // miss, uses this same raw value to explain a registered-vs-account
+  // representation mismatch (ADR-0018) instead of a bare grammar error.
+  if (detectPubkey(member) === undefined) {
+    return usageError(
+      "secret",
+      `member "${member}" must be a 32-byte Ed25519 pubkey — base64 (44 chars) or an NKey public key (A…/U… + 55 base32 chars)`,
+      json,
+    );
   }
 
   // 3. Resolve delivery mode (add-member / rotate only — rotate is always sealed).
@@ -3121,10 +3175,23 @@ async function runSecret(
   const discordRole = optionalValueFlag(flags, "--discord-role") ?? DEFAULT_ADMIT_DISCORD_ROLE;
   // cortex#1481 — add-member/rotate only: force the seal-only path (never write
   // the local hub) + the hub's own account nkey-U, when the admin knows it.
+  // cortex#1482 — normalize either encoding (nkey-U or base64) and explain a
+  // registered-vs-account role mismatch instead of a bare grammar error.
   const sealOnly = flags["--seal-only"] === true;
-  const hubAccountRaw = optionalValueFlag(flags, "--hub-account");
-  if (hubAccountRaw !== undefined && !isNkeyAccountPubkey(hubAccountRaw)) {
-    return usageError("secret", `--hub-account "${hubAccountRaw}" is not a valid nkey-U account public key (expected A + 55 base32 chars)`, json);
+  const hubAccountRes = normalizeHubAccountFlag(optionalValueFlag(flags, "--hub-account"));
+  if (!hubAccountRes.ok) return usageError("secret", hubAccountRes.reason, json);
+  const hubAccount = hubAccountRes.value;
+  // cortex#1482 (Pair 1) — a plausible copy-paste mix-up: the member's OWN
+  // registered/PoP pubkey and the hub's federation account are DIFFERENT
+  // keys by design (seal-target ≠ leaf-account, ADR-0018). Catch it here,
+  // before either value reaches the lookup/artifact.
+  if (hubAccount !== undefined && samePubkey(member, hubAccount)) {
+    return usageError(
+      "secret",
+      `member pubkey and --hub-account resolve to the SAME key — they must be different (the member's ` +
+        `registered/PoP pubkey vs. the hub's federation account; seal-target ≠ leaf-account, ADR-0018)`,
+      json,
+    );
   }
 
   // 4. Load + chmod-600-gate the hub-admin seed.
@@ -3157,7 +3224,7 @@ async function runSecret(
     ...(payloadKey !== undefined && { payloadKey }),
     ...(payloadKeyKid !== undefined && { payloadKeyKid }),
     sealOnly,
-    ...(hubAccountRaw !== undefined && { hubAccount: hubAccountRaw }),
+    ...(hubAccount !== undefined && { hubAccount }),
     apply: applyRes.apply,
   };
 

--- a/src/common/registry/__tests__/pubkey-normalize.test.ts
+++ b/src/common/registry/__tests__/pubkey-normalize.test.ts
@@ -12,7 +12,6 @@ import { createAccount, createUser } from "@nats-io/nkeys";
 
 import {
   detectPubkey,
-  describePubkeyRepresentation,
   looksLikeNkeyRole,
   samePubkey,
   toBase64Pubkey,
@@ -163,18 +162,5 @@ describe("looksLikeNkeyRole — grammar-only hint (tolerates a bad checksum)", (
   test("false for the wrong role or non-nkey input", () => {
     expect(looksLikeNkeyRole(createUser().getPublicKey(), "account")).toBe(false);
     expect(looksLikeNkeyRole("not-a-pubkey", "account")).toBe(false);
-  });
-});
-
-describe("describePubkeyRepresentation", () => {
-  test("labels each representation distinctly", () => {
-    expect(describePubkeyRepresentation(createAccount().getPublicKey())).toContain("FED account");
-    expect(describePubkeyRepresentation(createUser().getPublicKey())).toContain("registered/PoP");
-    const b64 = Buffer.from(new Uint8Array(32).fill(5)).toString("base64");
-    expect(describePubkeyRepresentation(b64)).toContain("base64");
-  });
-
-  test("undefined for garbage", () => {
-    expect(describePubkeyRepresentation("not-a-pubkey")).toBeUndefined();
   });
 });

--- a/src/common/registry/__tests__/pubkey-normalize.test.ts
+++ b/src/common/registry/__tests__/pubkey-normalize.test.ts
@@ -1,0 +1,180 @@
+/**
+ * cortex#1482 (epic #1479, join-3) — pubkey-normalize util tests.
+ *
+ * Round-trips REAL nkeys (via `@nats-io/nkeys`, the same codec the rest of
+ * cortex trusts) between the nkey and base64 encodings, proves
+ * representation-agnostic equality, and proves the module never hand-waves a
+ * garbage input into a false positive.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createAccount, createUser } from "@nats-io/nkeys";
+
+import {
+  detectPubkey,
+  describePubkeyRepresentation,
+  looksLikeNkeyRole,
+  samePubkey,
+  toBase64Pubkey,
+  toNkeyPubkey,
+} from "../pubkey-normalize";
+
+describe("detectPubkey", () => {
+  test("detects a real user nkey", () => {
+    const nkeyU = createUser().getPublicKey();
+    const detected = detectPubkey(nkeyU);
+    expect(detected?.encoding).toBe("nkey");
+    expect(detected?.role).toBe("user");
+    expect(detected?.raw.length).toBe(32);
+  });
+
+  test("detects a real account nkey", () => {
+    const nkeyA = createAccount().getPublicKey();
+    const detected = detectPubkey(nkeyA);
+    expect(detected?.encoding).toBe("nkey");
+    expect(detected?.role).toBe("account");
+  });
+
+  test("detects a base64 pubkey (no role)", () => {
+    const b64 = Buffer.from(new Uint8Array(32).fill(7)).toString("base64");
+    const detected = detectPubkey(b64);
+    expect(detected?.encoding).toBe("base64");
+    expect(detected?.role).toBeUndefined();
+  });
+
+  test("rejects non-pubkey garbage", () => {
+    expect(detectPubkey("not-a-pubkey")).toBeUndefined();
+    expect(detectPubkey("")).toBeUndefined();
+    expect(detectPubkey("AAAA")).toBeUndefined();
+  });
+
+  test("rejects an nkey-shaped string with a bad checksum", () => {
+    // Grammar-valid (A + 55 base32 chars) but not a real, checksum-valid key.
+    expect(detectPubkey("A" + "B".repeat(55))).toBeUndefined();
+  });
+
+  test("trims surrounding whitespace", () => {
+    const nkeyU = createUser().getPublicKey();
+    expect(detectPubkey(`  ${nkeyU}\n`)?.encoding).toBe("nkey");
+  });
+});
+
+describe("toBase64Pubkey — NKEY -> base64 and passthrough", () => {
+  test("converts a real user nkey to base64", () => {
+    const kp = createUser();
+    const nkeyU = kp.getPublicKey();
+    const b64 = toBase64Pubkey(nkeyU);
+    expect(b64).toBeDefined();
+    expect(b64).toMatch(/^[A-Za-z0-9+/]{43}=$/);
+  });
+
+  test("converts a real account nkey to base64 too (base64 carries no role)", () => {
+    const nkeyA = createAccount().getPublicKey();
+    expect(toBase64Pubkey(nkeyA)).toMatch(/^[A-Za-z0-9+/]{43}=$/);
+  });
+
+  test("round-trips an already-base64 pubkey byte-identically", () => {
+    const b64 = Buffer.from(new Uint8Array(32).fill(9)).toString("base64");
+    expect(toBase64Pubkey(b64)).toBe(b64);
+  });
+
+  test("undefined for garbage", () => {
+    expect(toBase64Pubkey("not-a-pubkey")).toBeUndefined();
+  });
+});
+
+describe("toNkeyPubkey — base64 -> NKEY, passthrough, and role refusal", () => {
+  test("converts a base64 pubkey to the requested role", () => {
+    const b64 = Buffer.from(new Uint8Array(32)).toString("base64");
+    const asAccount = toNkeyPubkey(b64, "account");
+    expect(asAccount).toMatch(/^A[A-Z2-7]{55}$/);
+    const asUser = toNkeyPubkey(b64, "user");
+    expect(asUser).toMatch(/^U[A-Z2-7]{55}$/);
+  });
+
+  test("round-trips base64 -> nkey -> base64 for a real key", () => {
+    const kp = createUser();
+    const nkeyU = kp.getPublicKey();
+    const b64 = toBase64Pubkey(nkeyU)!;
+    const backToNkey = toNkeyPubkey(b64, "user");
+    expect(backToNkey).toBe(nkeyU);
+  });
+
+  test("passes through an nkey already of the requested role, VERBATIM (grammar-only, no checksum re-derivation)", () => {
+    // A deliberately-fake (checksum-invalid) but grammar-valid account nkey —
+    // the exact style used across the existing --hub-account test fixtures.
+    const fakeAccount = "A" + "D".repeat(55);
+    expect(toNkeyPubkey(fakeAccount, "account")).toBe(fakeAccount);
+  });
+
+  test("REFUSES to re-role a real nkey of the OTHER role", () => {
+    const nkeyU = createUser().getPublicKey();
+    expect(toNkeyPubkey(nkeyU, "account")).toBeUndefined();
+    const nkeyA = createAccount().getPublicKey();
+    expect(toNkeyPubkey(nkeyA, "user")).toBeUndefined();
+  });
+
+  test("undefined for garbage", () => {
+    expect(toNkeyPubkey("not-a-pubkey", "account")).toBeUndefined();
+  });
+});
+
+describe("samePubkey — representation-agnostic equality", () => {
+  test("true for the SAME key across nkey and base64 encodings", () => {
+    const kp = createUser();
+    const nkeyU = kp.getPublicKey();
+    const b64 = toBase64Pubkey(nkeyU)!;
+    expect(samePubkey(nkeyU, b64)).toBe(true);
+    expect(samePubkey(b64, nkeyU)).toBe(true);
+  });
+
+  test("true for the SAME raw bytes even across DIFFERENT roles (role-blind by design)", () => {
+    // Manually encode the identical 32 raw bytes as both a user and an
+    // account nkey — samePubkey compares key MATERIAL, not role.
+    const raw = new Uint8Array(32).fill(3);
+    const b64 = Buffer.from(raw).toString("base64");
+    const asUser = toNkeyPubkey(b64, "user")!;
+    const asAccount = toNkeyPubkey(b64, "account")!;
+    expect(samePubkey(asUser, asAccount)).toBe(true);
+  });
+
+  test("false for two DIFFERENT keys", () => {
+    const a = createUser().getPublicKey();
+    const b = createUser().getPublicKey();
+    expect(samePubkey(a, b)).toBe(false);
+  });
+
+  test("false (never throws) when either side isn't a recognizable pubkey", () => {
+    const nkeyU = createUser().getPublicKey();
+    expect(samePubkey(nkeyU, "garbage")).toBe(false);
+    expect(samePubkey("garbage", "also-garbage")).toBe(false);
+  });
+});
+
+describe("looksLikeNkeyRole — grammar-only hint (tolerates a bad checksum)", () => {
+  test("true for a real account nkey", () => {
+    expect(looksLikeNkeyRole(createAccount().getPublicKey(), "account")).toBe(true);
+  });
+
+  test("true for a shape-valid but checksum-invalid account nkey (the fixture style used elsewhere)", () => {
+    expect(looksLikeNkeyRole("A" + "D".repeat(55), "account")).toBe(true);
+  });
+
+  test("false for the wrong role or non-nkey input", () => {
+    expect(looksLikeNkeyRole(createUser().getPublicKey(), "account")).toBe(false);
+    expect(looksLikeNkeyRole("not-a-pubkey", "account")).toBe(false);
+  });
+});
+
+describe("describePubkeyRepresentation", () => {
+  test("labels each representation distinctly", () => {
+    expect(describePubkeyRepresentation(createAccount().getPublicKey())).toContain("FED account");
+    expect(describePubkeyRepresentation(createUser().getPublicKey())).toContain("registered/PoP");
+    const b64 = Buffer.from(new Uint8Array(32).fill(5)).toString("base64");
+    expect(describePubkeyRepresentation(b64)).toContain("base64");
+  });
+
+  test("undefined for garbage", () => {
+    expect(describePubkeyRepresentation("not-a-pubkey")).toBeUndefined();
+  });
+});

--- a/src/common/registry/pubkey-normalize.ts
+++ b/src/common/registry/pubkey-normalize.ts
@@ -31,6 +31,15 @@
  */
 
 import { Prefix } from "@nats-io/nkeys";
+// Deep import of the internal `Codec` (base32 + CRC16 + prefix-byte codec):
+// the package's PUBLIC API (`@nats-io/nkeys` mod) exposes keypair factories
+// (`createUser`, `fromPublic`, …) but NOT a raw pubkey→bytes decode / bytes→
+// pubkey encode, which this module needs for role-aware conversion + raw-byte
+// equality. This is a CONSCIOUS choice, not an accident, and it matches the
+// established repo pattern — `registry/encoding.ts` (the DD-8 bridge) and
+// `nats/leaf-remote-renderer.ts` already import `Codec` from the same subpath.
+// If a future @nats-io/nkeys promotes a public decode/encode, migrate all
+// three call sites together.
 import { Codec } from "@nats-io/nkeys/lib/codec";
 
 /**
@@ -50,6 +59,13 @@ const ROLE_PREFIX: Record<PubkeyRole, Prefix> = {
 
 /** The single letter each role's nkey encoding starts with. */
 const ROLE_LETTER: Record<PubkeyRole, string> = { account: "A", user: "U" };
+
+/** Per-role grammar-only shape regex, hoisted to module scope so
+ *  {@link looksLikeNkeyRole} never recompiles it per call. */
+const ROLE_NKEY_SHAPE: Record<PubkeyRole, RegExp> = {
+  account: /^A[A-Z2-7]{55}$/,
+  user: /^U[A-Z2-7]{55}$/,
+};
 
 /**
  * Union NKey-public GRAMMAR for the two roles this module covers: a single
@@ -206,20 +222,5 @@ export function samePubkey(a: string, b: string): boolean {
  * USING the decoded bytes), use {@link detectPubkey} instead.
  */
 export function looksLikeNkeyRole(value: string, role: PubkeyRole): boolean {
-  return new RegExp(`^${ROLE_LETTER[role]}[A-Z2-7]{55}$`).test(value.trim());
-}
-
-/**
- * Human-readable label for `value`'s detected representation, for error/
- * explanation messages. `undefined` when `value` isn't a recognizable
- * pubkey (checksum-verified for the nkey case — see {@link looksLikeNkeyRole}
- * for a grammar-only hint that tolerates a bad checksum).
- */
-export function describePubkeyRepresentation(value: string): string | undefined {
-  const detected = detectPubkey(value);
-  if (detected === undefined) return undefined;
-  if (detected.encoding === "base64") return "a base64 pubkey";
-  return detected.role === "account"
-    ? "a FED account nkey (A…)"
-    : "a registered/PoP user nkey (U…)";
+  return ROLE_NKEY_SHAPE[role].test(value.trim());
 }

--- a/src/common/registry/pubkey-normalize.ts
+++ b/src/common/registry/pubkey-normalize.ts
@@ -1,0 +1,225 @@
+/**
+ * cortex#1482 (epic #1479, join-3) — shared pubkey-normalize util.
+ *
+ * Three surfaces across the federation join path accept a pubkey in TWO
+ * legitimate encodings — the NATS NKey base32 form (`A…`/`U…`, 56 chars) and
+ * the registry's base64 raw-ed25519 form (44 chars) — and today each surface
+ * only accepts ONE of the two, so pasting the "wrong" (but equally valid)
+ * encoding fails with a grammar error instead of just working. This module is
+ * the single place that:
+ *
+ *   - DETECTS which encoding (and, for an nkey, which ROLE — account or
+ *     user) a string is in ({@link detectPubkey});
+ *   - CONVERTS between the two encodings ({@link toBase64Pubkey},
+ *     {@link toNkeyPubkey});
+ *   - compares two pubkeys for identity REGARDLESS of encoding/role
+ *     ({@link samePubkey}).
+ *
+ * Crypto is NOT hand-rolled: nkey decode/encode goes through the SAME
+ * `@nats-io/nkeys` `Codec` the bus-side verifier and the DD-8 registry bridge
+ * (`registry/encoding.ts`) already trust. This module adds the role
+ * DETECTION + role-aware conversion `encoding.ts` doesn't need — DD-8 is
+ * hardcoded to the User role because config/peers pubkeys there are always
+ * User; this module also covers the Account role for the FED-account surface
+ * (ADR-0018's "seal-target ≠ leaf-account": the registered/PoP identity
+ * pubkey is a User-role nkey, the hub's federation account is an
+ * Account-role nkey — two DIFFERENT keys, not two encodings of one key).
+ *
+ * Scope: account + user nkeys only (`A…`/`U…`) — the two roles that appear at
+ * cortex's pubkey boundaries today. The other NKey roles (operator NKeys,
+ * cluster, server, curve) are out of scope.
+ */
+
+import { Prefix } from "@nats-io/nkeys";
+import { Codec } from "@nats-io/nkeys/lib/codec";
+
+/**
+ * The two NKey roles this module resolves. Mirrors the two things
+ * cortex#1482's Pair 1 reconciles: `user` = the registered/PoP identity
+ * pubkey (the admission-row seal target); `account` = a FED account nkey
+ * (the leaf bind target). The two are DIFFERENT keys, not two encodings of
+ * one key — {@link toNkeyPubkey} refuses to silently re-role one into the
+ * other.
+ */
+export type PubkeyRole = "account" | "user";
+
+const ROLE_PREFIX: Record<PubkeyRole, Prefix> = {
+  account: Prefix.Account,
+  user: Prefix.User,
+};
+
+/** The single letter each role's nkey encoding starts with. */
+const ROLE_LETTER: Record<PubkeyRole, string> = { account: "A", user: "U" };
+
+/**
+ * Union NKey-public GRAMMAR for the two roles this module covers: a single
+ * role letter + 55 base32-alphabet chars = 56 total. Mirrors the existing
+ * per-role regexes (`NKEY_PUBKEY_REGEX` in `common/types/nkey.ts` for `U…`,
+ * the module-private `NKEY_ACCOUNT` in `leaf-remote-renderer.ts` for `A…`) —
+ * this is only the shape gate; {@link decodeNkeyPublic} checksum-verifies on
+ * top of it via `Codec.decode`.
+ */
+const NKEY_SHAPE = /^[AU][A-Z2-7]{55}$/;
+
+/** Base64 Ed25519 grammar — SAME shape `registry/encoding.ts` validates
+ *  against (43 standard-alphabet chars + one `=` of padding). */
+const BASE64_ED25519 = /^[A-Za-z0-9+/]{43}=$/;
+
+/** The result of {@link detectPubkey}. */
+export interface DetectedPubkey {
+  encoding: "nkey" | "base64";
+  /** Only set for `encoding: "nkey"` — base64 carries no role annotation. */
+  role?: PubkeyRole;
+  /** The decoded 32 raw ed25519 bytes. */
+  raw: Uint8Array;
+}
+
+/**
+ * Checksum-verified nkey decode: `trimmed` must match {@link NKEY_SHAPE} AND
+ * decode through `Codec.decode` (crockford-base32 + CRC16 + prefix-byte,
+ * matching the ROLE the leading letter declares). Returns `undefined` for
+ * anything that isn't a genuinely valid nkey of one of the two covered
+ * roles — a shape-only match with a bad checksum is NOT a valid key.
+ */
+function decodeNkeyPublic(trimmed: string): DetectedPubkey | undefined {
+  if (!NKEY_SHAPE.test(trimmed)) return undefined;
+  const role: PubkeyRole = trimmed.startsWith(ROLE_LETTER.account) ? "account" : "user";
+  try {
+    const raw = Codec.decode(ROLE_PREFIX[role], new TextEncoder().encode(trimmed));
+    return { encoding: "nkey", role, raw };
+  } catch {
+    // Shape-matched but failed the CRC16 checksum — not a valid nkey. Fall
+    // through to "not recognized" rather than throwing; a poison/malformed
+    // value must fail loudly at the CALLER's boundary, not crash here.
+    return undefined;
+  }
+}
+
+/** Decode a standard-base64 raw ed25519 pubkey (44 chars w/ padding) to its
+ *  32 raw bytes. `undefined` when `trimmed` isn't valid base64 shaped for a
+ *  32-byte payload. */
+function decodeBase64Public(trimmed: string): DetectedPubkey | undefined {
+  if (!BASE64_ED25519.test(trimmed)) return undefined;
+  let bin: string;
+  try {
+    bin = atob(trimmed);
+  } catch {
+    // The regex above should have caught any non-base64-alphabet input —
+    // defensive only.
+    return undefined;
+  }
+  if (bin.length !== 32) return undefined;
+  const raw = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) raw[i] = bin.charCodeAt(i);
+  return { encoding: "base64", raw };
+}
+
+/**
+ * Detect which of the two accepted encodings (and, for an nkey, which role)
+ * `value` is in. Returns `undefined` when `value` matches NEITHER grammar —
+ * the caller's "not a recognizable pubkey at all" case. Never throws.
+ */
+export function detectPubkey(value: string): DetectedPubkey | undefined {
+  const trimmed = value.trim();
+  return decodeNkeyPublic(trimmed) ?? decodeBase64Public(trimmed);
+}
+
+/**
+ * Normalize ANY accepted representation (nkey-account, nkey-user, or base64)
+ * to base64 — the registry / admission-row / seal-target surface. Base64 has
+ * no role annotation, so an nkey of EITHER role converts freely. Round-trips
+ * an already-base64 input byte-for-byte (canonical padding). `undefined`
+ * when `value` isn't a recognizable pubkey in either encoding.
+ */
+export function toBase64Pubkey(value: string): string | undefined {
+  const detected = detectPubkey(value);
+  if (detected === undefined) return undefined;
+  return Buffer.from(detected.raw).toString("base64");
+}
+
+/**
+ * Normalize `value` to the nkey form for `role`. Two cases:
+ *
+ *   - `value` is ALREADY nkey-shaped for `role` (`A…`/`U…`, 56 chars) —
+ *     passed through VERBATIM. Grammar-only (checksum not re-derived): this
+ *     mirrors the legacy per-role shape gates (`isNkeyAccountPubkey`, the
+ *     account role; `NKEY_PUBKEY_REGEX`, the user role) this module
+ *     supersedes, so a caller that already has the value in the right form
+ *     gets it back byte-identical — some callers embed it verbatim into a
+ *     printed config snippet a human later pastes, and round-tripping it
+ *     through decode+re-encode would be needless extra risk for no benefit.
+ *   - Otherwise, `value` is decoded (base64, or an nkey of a DIFFERENT
+ *     role — checksum-verified) and RE-ENCODED with the requested role. An
+ *     nkey of a role OTHER than `role` is REFUSED (`undefined`) — role is a
+ *     semantic fact about a key (which keypair it is), not a free encoding
+ *     choice, and silently re-badging a user key as an account key (or vice
+ *     versa) would hide exactly the seal-target ≠ leaf-account confusion
+ *     ADR-0018 warns about. A caller that wants to explain WHY a value was
+ *     refused should call {@link detectPubkey} or {@link looksLikeNkeyRole}
+ *     on the same input directly.
+ */
+export function toNkeyPubkey(value: string, role: PubkeyRole): string | undefined {
+  const trimmed = value.trim();
+  if (looksLikeNkeyRole(trimmed, role)) return trimmed;
+
+  const detected = detectPubkey(trimmed);
+  if (detected === undefined || detected.encoding === "nkey") {
+    // Either not recognizable at all, or an nkey of the OTHER role — refuse
+    // rather than re-role it.
+    return undefined;
+  }
+  try {
+    const encoded = Codec.encode(ROLE_PREFIX[role], detected.raw);
+    return new TextDecoder().decode(encoded);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Representation-agnostic equality: true iff `a` and `b` decode (any
+ * accepted encoding, either role) to the IDENTICAL 32 raw ed25519 bytes.
+ * Deliberately role-blind (an nkey's role prefix is a label on top of the
+ * key material, not part of it) — this answers "is this literally the same
+ * key", a different question from {@link toNkeyPubkey}'s role-aware
+ * refusal. `false` (never throws) when either side isn't a recognizable
+ * pubkey.
+ */
+export function samePubkey(a: string, b: string): boolean {
+  const da = detectPubkey(a);
+  const db = detectPubkey(b);
+  if (da === undefined || db === undefined) return false;
+  if (da.raw.length !== db.raw.length) return false;
+  for (let i = 0; i < da.raw.length; i++) {
+    if (da.raw[i] !== db.raw[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Grammar-only (NO checksum) shape gate: does `value` look like an nkey of
+ * `role` — right leading letter + length? For HINTS/explanations where
+ * cryptographic certainty isn't the point (e.g. "this looks like a FED
+ * account nkey, did you mean to pass the registered pubkey instead" — ADR-
+ * 0018) — a typo'd checksum shouldn't suppress the hint that would otherwise
+ * help the user spot their mistake. For a certainty-required check (actually
+ * USING the decoded bytes), use {@link detectPubkey} instead.
+ */
+export function looksLikeNkeyRole(value: string, role: PubkeyRole): boolean {
+  return new RegExp(`^${ROLE_LETTER[role]}[A-Z2-7]{55}$`).test(value.trim());
+}
+
+/**
+ * Human-readable label for `value`'s detected representation, for error/
+ * explanation messages. `undefined` when `value` isn't a recognizable
+ * pubkey (checksum-verified for the nkey case — see {@link looksLikeNkeyRole}
+ * for a grammar-only hint that tolerates a bad checksum).
+ */
+export function describePubkeyRepresentation(value: string): string | undefined {
+  const detected = detectPubkey(value);
+  if (detected === undefined) return undefined;
+  if (detected.encoding === "base64") return "a base64 pubkey";
+  return detected.role === "account"
+    ? "a FED account nkey (A…)"
+    : "a registered/PoP user nkey (U…)";
+}


### PR DESCRIPTION
## What
Three representation-pairs must agree, and nothing checked them — so mismatches surfaced late as cryptic errors or Authorization Violations. This reconciles all three **loudly**, and adds a shared NKEY↔base64 pubkey-normalize util.

Sub-issue of epic **#1479**, slice **join-3** (#1482).

## How
- **`src/common/registry/pubkey-normalize.ts`** (new) — detects nkey-vs-base64 and account-vs-user role via the real `@nats-io/nkeys` `Codec` (crockford-base32 + CRC16 checksum-verified, **no hand-rolled crypto**). `toBase64Pubkey`/`toNkeyPubkey` + a representation-agnostic `samePubkey`. Wired at the `secret <add-member|rotate|revoke>` member positional and `--hub-account` (both `secret` and `admit`), so **either encoding just works**.
- **Pair 1 — registered/PoP pubkey ⟷ FED account.** They legitimately differ (seal-target ≠ leaf-account, ADR-0018). When `findAdmittedRow` misses and the input looks like the *other* representation, it prints the plain ADR-0018 explanation instead of a bare `no ADMITTED row`. A CLI guard also catches `member == --hub-account` via `samePubkey`. New doctor leg `registered-vs-fed-account`: **pass** on legit divergence, **warn** only when undeterminable/identical, **never fail**.
- **Pair 2 — `resolver_preload` accounts ⟷ leaf remote `account:`.** New port + brace-matched `resolver_preload{}` block check; doctor leg `resolver-preload-account` **fails** when the leaf's FED account isn't actually a key in the bus's `resolver_preload` (before it becomes a boot/auth failure).
- **Pair 3 — registry sealed secret ⟷ hub authorization.** An **honest documented stub** (`skip`): the member holds only an opaque ciphertext sealed to their own pubkey (ADR-0018 Q1), so there's no plaintext here to compare against the hub's authorization users. A partial check would be misleading (a stale key still "passes"), so per the task's guidance it's a tracked follow-up, not fabricated.

## Verification
- `bunx tsc --noEmit`, `bun run lint:errors`, `bash scripts/check-carveouts.sh` — all clean; **full suite 8721 pass / 0 fail**.
- New tests: `pubkey-normalize.test.ts` (24 — NKEY↔base64 round-trip, `samePubkey` across representations, non-pubkey inputs), doctor reconcile-leg tests, pair-1 explanation test.
- **Live against `metafactory`:** the 3 reconcile legs render correctly. On that stack no FED account is derivable yet (no rendered leaf include), so `registered-vs-fed-account` fired its **`warn` / no-FED-account-yet branch** (showing the registered pubkey as-stored) — the `samePubkey` divergence-compare + the ADR-0018 explanation branches are exercised by **unit tests**, not this particular live run. Pair-2 (`resolver-preload-account`) skipped cleanly (no account derivable); pair-3 printed the honest "needs hub-side visibility" note. (`samePubkey` is representation-agnostic; the leg does not convert encodings for *display*.)

## Out of scope (intentional)
- Reconciliation surfaced in `doctor` only, not `status` (the task allowed "doctor and/or status"; doctor is the natural home it identifies).
- Pair-3 is a stub by design — can't be verified honestly without hub-side decrypt/fingerprint capability that doesn't exist in this codebase yet. Follow-up candidate.

Closes #1482
Refs #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
