### PR TITLE
feat(network): C-1483 — validated, recoverable, canaried config mutations (epic #1479 slice 4)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -1426,27 +1426,30 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
     }
   });
 
-  test("MAJOR-1: validateConfig SKIPS (ok) when nats-server is not on PATH (no block)", async () => {
-    // The live adapter shells out to `nats-server -t`; on a host without the
-    // binary it must SKIP the gate (return ok), never block the join. We can't
-    // guarantee nats-server is absent on CI, so assert the result is well-formed
-    // (ok:true when skipped/passed; ok:false only with a -t reason).
+  test("MAJOR-1 / cortex#1495: validateConfig is three-state (valid | invalid | skipped), never a silent fail-open", async () => {
+    // The live adapter shells out to `nats-server -t`. We can't guarantee the
+    // binary's presence on CI, so assert the result is a well-formed three-state
+    // outcome: `valid`/`skipped` when the config is fine or the binary is missing,
+    // `invalid` (with a reason) only on a real -t failure. Crucially there is NO
+    // `ok:true` fail-open path any more — a missing binary is `skipped`, not `valid`.
     const dir = freshDir();
     const conf = join(dir, "local.conf");
     writeFileSync(conf, bareLocalConf(), "utf-8");
     const ports = buildLivePorts(cfgWithConfig(conf));
     const res = await ports.natsServer!.validateConfig();
-    if (!res.ok) {
+    if (res.status === "invalid") {
+      expect(res.reason).toContain("nats-server");
+    } else if (res.status === "skipped") {
       expect(res.reason).toContain("nats-server");
     } else {
-      expect(res.ok).toBe(true);
+      expect(res.status).toBe("valid");
     }
   });
 
-  test("MAJOR-1: dry-run validateConfig is inert (ok, never spawns)", async () => {
+  test("MAJOR-1: dry-run validateConfig is inert (valid, never spawns)", async () => {
     const ports = buildDryRunPorts(cfgWithConfig("/x/local.conf"));
     const res = await ports.natsServer!.validateConfig();
-    expect(res.ok).toBe(true);
+    expect(res.status).toBe("valid");
   });
 
   test("NIT-1: credsExist rejects a directory, a 0-byte file, and a non-creds file", () => {

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -208,6 +208,35 @@ describe("#754 live leaf-include wiring", () => {
     expect(after).toContain("system_account: ADSYSACCOUNT");
   });
 
+  test("cortex#1483 (join-4): ensureInclude writes a timestamped .bak of the PRIOR local.conf before mutating", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const original = bareLocalConf();
+    writeFileSync(conf, original, "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    ports.leafFile.ensureInclude("metafactory");
+
+    const baks = readdirSync(dir).filter((f) => f.startsWith("local.conf.bak-join-"));
+    expect(baks.length).toBe(1);
+    expect(readFileSync(join(dir, baks[0]!), "utf-8")).toBe(original);
+    // The live file carries the NEW content, not the backed-up original.
+    expect(readFileSync(conf, "utf-8")).toContain('include "leafnodes-metafactory.conf"');
+  });
+
+  test("cortex#1483 (join-4): a byte-stable ensureInclude re-run writes NO extra .bak (no-op, nothing to protect)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    ports.leafFile.ensureInclude("metafactory"); // mutates → 1 backup
+    ports.leafFile.ensureInclude("metafactory"); // idempotent no-op → no 2nd backup
+
+    const baks = readdirSync(dir).filter((f) => f.startsWith("local.conf.bak-join-"));
+    expect(baks.length).toBe(1);
+  });
+
   test("ensureInclude is idempotent + byte-stable on the live file", () => {
     const dir = freshDir();
     const conf = join(dir, "local.conf");
@@ -317,6 +346,21 @@ describe("O-3 live convertToOperatorMode — round-trip a real temp nats config"
     expect(after).toContain("domain: community-andreas");
     // NO leaf include — join renders its own
     expect(after).not.toMatch(/include[ \t]+["']leafnodes-/);
+  });
+
+  test("cortex#1483 (join-4): a converting write backs up the PRE-conversion bytes to a timestamped .bak", () => {
+    const dir = freshDir();
+    const conf = join(dir, "community.conf");
+    const original = anonLocalConf();
+    writeFileSync(conf, original, "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    const result = ports.leafFile.convertToOperatorMode(FAKE_PACKAGE);
+    expect(result.status).toBe("converted");
+
+    const baks = readdirSync(dir).filter((f) => f.startsWith("community.conf.bak-join-"));
+    expect(baks.length).toBe(1);
+    expect(readFileSync(join(dir, baks[0]!), "utf-8")).toBe(original);
   });
 
   test("already-operator-mode bus under the SAME operator → 'already', file unchanged + leaf can be added", () => {
@@ -1148,6 +1192,29 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
     expect(existsSync(leafPath)).toBe(true);
     // Mask off the file-type bits; only the permission bits must equal 0600.
     expect(statSync(leafPath).mode & 0o777).toBe(0o600);
+  });
+
+  test("cortex#1483 (join-4): a RE-write of the leaf include backs up the PRIOR bytes to a timestamped .bak", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    const binding = {
+      credentials: "/Users/andreas/.config/nats/andreas.creds",
+      account: "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+    };
+    // First write — nothing to back up yet.
+    ports.leafFile.write({ descriptor: brandVerified(descriptorForLeaf("metafactory")), binding });
+    const leafPath = join(dir, "leafnodes-metafactory.conf");
+    const firstWrite = readFileSync(leafPath, "utf-8");
+    expect(readdirSync(dir).some((f) => f.startsWith("leafnodes-metafactory.conf.bak-join-"))).toBe(false);
+
+    // A re-join re-renders the SAME network — the prior bytes must be .bak'd.
+    ports.leafFile.write({ descriptor: brandVerified(descriptorForLeaf("metafactory")), binding });
+    const baks = readdirSync(dir).filter((f) => f.startsWith("leafnodes-metafactory.conf.bak-join-"));
+    expect(baks.length).toBe(1);
+    expect(readFileSync(join(dir, baks[0]!), "utf-8")).toBe(firstWrite);
   });
 
   test("restore rewrites a pre-existing include file back to its prior bytes + keeps a pre-existing directive", () => {

--- a/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-federation-wiring.test.ts
@@ -180,7 +180,7 @@ function makeMinimalPorts(opts: {
 
   const natsServer: NatsServerPort = {
     async restart() { return { ok: true }; },
-    async validateConfig() { return { ok: true }; },
+    async validateConfig() { return { status: "valid" as const }; },
     async isHealthy() { return { healthy: true }; },
   };
 
@@ -359,7 +359,7 @@ describe("G1c — federation-wiring step in joinNetwork (ADR-0013 Model B)", () 
       daemon: { async restart() { return { ok: true }; } },
       natsServer: {
         async restart() { return { ok: true }; },
-        async validateConfig() { return { ok: true }; },
+        async validateConfig() { return { status: "valid" as const }; },
         async isHealthy() { return { healthy: true }; },
       },
       federationWiring: trackedWiring,

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -58,21 +58,7 @@ import {
   type ClockPort,
   type SettleWindowOptions,
 } from "../../../../common/nats/restart-with-settle";
-
-/**
- * cortex#1483 (join-4) — a `ClockPort` whose `sleep` resolves IMMEDIATELY
- * (no real `setTimeout`), so a multi-attempt settle window never actually
- * waits in tests. Records every requested delay so a test can assert the
- * backoff SCHEDULE without ever paying its wall-clock cost.
- */
-function instantClock(delays: number[] = []): ClockPort {
-  return {
-    sleep: (ms) => {
-      delays.push(ms);
-      return Promise.resolve();
-    },
-  };
-}
+import { instantClock } from "./settle-test-helpers";
 
 // O-3 (cortex#1053) — a public-repo-safe fake leaf package: the operator-mode
 // material `cortex network join` renders to convert an anonymous bus. O-4

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -226,8 +226,13 @@ function makeFakes(opts: {
    * report failure, never "restored to prior state". Default: healthy.
    */
   recoveryHealthy?: boolean;
-  /** #821 MAJOR-1 — make the pre-restart `nats-server -t` syntax gate FAIL. */
+  /** #821 MAJOR-1 — make the pre-restart `nats-server -t` syntax gate report INVALID. */
   validateConfigFails?: boolean;
+  /**
+   * cortex#1495 BLOCKER — make the `-t` gate report SKIPPED (binary missing):
+   * the join must WARN loudly + PROCEED (not refuse, not silently pass).
+   */
+  validateSkips?: boolean;
   /** #821 item-2 — make natsServer.restart() THROW synchronously (Bun.spawn ENOENT). */
   restartThrows?: boolean;
   /** #821 item-2 — make natsServer.validateConfig() THROW synchronously (spawn ENOENT). */
@@ -475,11 +480,16 @@ function makeFakes(opts: {
       if (opts.validateThrows === true) {
         throw new Error("spawn nats-server ENOENT");
       }
-      // #821 MAJOR-1 — default: the -t syntax gate passes. A test opts into a
-      // -t failure via `validateConfigFails: true`.
-      return opts.validateConfigFails === true
-        ? { ok: false, reason: "nats-server -t: parse error near line 12" }
-        : { ok: true };
+      // #821 MAJOR-1 / cortex#1495 — default: the -t syntax gate passes (`valid`).
+      // A test opts into an INVALID config via `validateConfigFails: true`, or the
+      // three-state SKIPPED (binary missing) via `validateSkips: true`.
+      if (opts.validateConfigFails === true) {
+        return { status: "invalid", reason: "nats-server -t: parse error near line 12" };
+      }
+      if (opts.validateSkips === true) {
+        return { status: "skipped", reason: "could not run nats-server -t: spawn nats-server ENOENT" };
+      }
+      return { status: "valid" };
     },
     async restart() {
       rec.natsRestarts++;

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -53,6 +53,26 @@ import {
   type OperatorModeLeafPackage,
 } from "../../../../common/nats/leaf-remote-renderer";
 import { nkeyToBase64Pubkey } from "../../../../common/registry/encoding";
+import {
+  DEFAULT_SETTLE_MAX_ATTEMPTS,
+  type ClockPort,
+  type SettleWindowOptions,
+} from "../../../../common/nats/restart-with-settle";
+
+/**
+ * cortex#1483 (join-4) — a `ClockPort` whose `sleep` resolves IMMEDIATELY
+ * (no real `setTimeout`), so a multi-attempt settle window never actually
+ * waits in tests. Records every requested delay so a test can assert the
+ * backoff SCHEDULE without ever paying its wall-clock cost.
+ */
+function instantClock(delays: number[] = []): ClockPort {
+  return {
+    sleep: (ms) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+  };
+}
 
 // O-3 (cortex#1053) — a public-repo-safe fake leaf package: the operator-mode
 // material `cortex network join` renders to convert an anonymous bus. O-4
@@ -212,6 +232,18 @@ function makeFakes(opts: {
   restartThrows?: boolean;
   /** #821 item-2 — make natsServer.validateConfig() THROW synchronously (spawn ENOENT). */
   validateThrows?: boolean;
+  /**
+   * cortex#1483 (join-4) — model a SLOW-BUT-HEALTHY bus within the INITIAL
+   * restart's settle window: unhealthy on attempts `< N`, healthy from
+   * attempt `N` onward. Takes precedence over `natsHealthy` when set.
+   */
+  natsHealthyAfterAttempt?: number;
+  /** cortex#1483 (join-4) — the same, but for the RECOVERY restart's settle window. */
+  recoveryHealthyAfterAttempt?: number;
+  /** cortex#1483 (join-4) — settle-window tuning threaded onto `ports.settle`. */
+  settle?: SettleWindowOptions;
+  /** cortex#1483 (join-4) — clock threaded onto `ports.clock`. Default: an instant fake (never really sleeps). */
+  clock?: ClockPort;
 }): { ports: NetworkPorts; rec: Recorder; storeRef: { networks: PolicyFederatedNetwork[] } } {
   const rec: Recorder = {
     registered: 0,
@@ -429,6 +461,12 @@ function makeFakes(opts: {
     },
   };
 
+  // cortex#1483 (join-4) — per-restart-phase attempt counter (keyed by
+  // `rec.natsRestarts` at call time), so `natsHealthyAfterAttempt`/
+  // `recoveryHealthyAfterAttempt` can model "healthy starting from the Nth
+  // poll WITHIN this phase" independent of the total probe count.
+  const phaseAttempts: Record<number, number> = {};
+
   const natsServer: NatsServerPort = {
     async validateConfig() {
       rec.validateConfigs++;
@@ -470,12 +508,28 @@ function makeFakes(opts: {
       // #821 — health is modelled PER PROBE so a test can make the FIRST restart
       // come up down (triggering rollback) and the RECOVERY restart ALSO come up
       // down (the BLOCKER case: a recovery that exits 0 but leaves the bus DOWN
-      // must still report failure, never "restored"). The first probe follows the
-      // first restart; the second probe follows the recovery restart.
-      const isRecoveryProbe = rec.healthProbes > 1;
-      const healthy = isRecoveryProbe
-        ? opts.recoveryHealthy ?? true
-        : opts.natsHealthy ?? true;
+      // must still report failure, never "restored").
+      //
+      // cortex#1483 (join-4) — the PHASE (initial vs recovery) is keyed off
+      // `rec.natsRestarts` (how many restart() calls have happened), NOT off
+      // `rec.healthProbes`: the settle window now probes MULTIPLE times WITHIN
+      // a single restart phase, so a probe-count check would flip to "recovery"
+      // mid-way through the initial phase's own retries. `natsRestarts` only
+      // advances on an actual restart() call, so it stays phase-correct
+      // regardless of how many settle attempts run in between.
+      const phase = rec.natsRestarts;
+      const isRecoveryProbe = phase > 1;
+      phaseAttempts[phase] = (phaseAttempts[phase] ?? 0) + 1;
+      const attemptInPhase = phaseAttempts[phase];
+      const healthyAfter = isRecoveryProbe
+        ? opts.recoveryHealthyAfterAttempt
+        : opts.natsHealthyAfterAttempt;
+      const healthy =
+        healthyAfter !== undefined
+          ? attemptInPhase >= healthyAfter
+          : isRecoveryProbe
+            ? opts.recoveryHealthy ?? true
+            : opts.natsHealthy ?? true;
       return healthy
         ? { healthy: true }
         : {
@@ -507,6 +561,13 @@ function makeFakes(opts: {
       ...(opts.admission !== undefined
         ? { admission: makeAdmissionStatePort(opts.admission) }
         : {}),
+      // cortex#1483 (join-4) — settle-window tuning (undefined ⇒
+      // probeHealthWithSettle's own sane defaults). ALWAYS wire an instant
+      // clock so a multi-attempt settle window never actually sleeps in tests
+      // — this is the ONLY thing that keeps a `natsHealthy: false` scenario
+      // (which now polls up to the full settle window) fast.
+      ...(opts.settle !== undefined ? { settle: opts.settle } : {}),
+      clock: opts.clock ?? instantClock(),
     },
     rec,
     storeRef,
@@ -1024,7 +1085,11 @@ describe("join", () => {
       // Rollback ran and the recovery restart was issued + HEALTH-PROBED.
       expect(rec.restores).toEqual(["metafactory"]);
       expect(rec.natsRestarts).toBe(2);
-      expect(rec.healthProbes).toBe(2); // BOTH restarts probed (the fix)
+      // cortex#1483 (join-4) — BOTH restarts are now polled across the FULL
+      // settle window (both phases stay unhealthy the whole time), not probed
+      // once each: DEFAULT_SETTLE_MAX_ATTEMPTS attempts for the initial restart
+      // + DEFAULT_SETTLE_MAX_ATTEMPTS for the recovery restart.
+      expect(rec.healthProbes).toBe(DEFAULT_SETTLE_MAX_ATTEMPTS * 2);
       // It must NOT claim the bus was restored — the recovery is down too.
       expect(res.reason).not.toContain("restored to prior state");
       expect(res.warnings?.some((w) => w.includes("restored to prior state"))).toBe(
@@ -1140,11 +1205,81 @@ describe("join", () => {
       const res = await joinNetwork("metafactory", LOCAL, ports);
 
       expect(res.ok).toBe(false); // the JOIN still failed (the leaf was bad)...
-      expect(rec.healthProbes).toBe(2);
+      // cortex#1483 (join-4) — the initial restart exhausts the FULL settle
+      // window (always unhealthy); the recovery restart is healthy on its
+      // FIRST probe (recoveryHealthy defaults true), so it needs just 1 more.
+      expect(rec.healthProbes).toBe(DEFAULT_SETTLE_MAX_ATTEMPTS + 1);
       // ...but the bus WAS restored — only then may we say so.
       expect(res.warnings?.some((w) => w.includes("restored to prior state"))).toBe(
         true,
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // cortex#1483 (join-4, epic #1479) — the settle-window: retry/backoff before
+  // the health verdict, so a slow-but-healthy bus is never mistaken for a
+  // genuinely down one (the #1476 gap-2 false alarm this slice closes).
+  // ---------------------------------------------------------------------------
+  describe("cortex#1483 settle-window retry/backoff", () => {
+    test("valid config + slow-but-healthy bus (healthy on the 3rd poll) → NO false 'bus DOWN', no rollback", async () => {
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        natsHealthyAfterAttempt: 3,
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(true);
+      // A single restart — settling to healthy never triggers a rollback.
+      expect(rec.natsRestarts).toBe(1);
+      expect(rec.restores).toEqual([]);
+      expect(rec.healthProbes).toBe(3);
+      expect(res.steps.some((s) => s.includes("verified healthy"))).toBe(true);
+    });
+
+    test("genuinely unhealthy across the WHOLE settle window → auto-rollback (custom small window)", async () => {
+      // A small, explicit settle window keeps this test's expected numbers
+      // self-evident rather than coupled to the production default.
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        natsHealthy: false,
+        settle: { maxAttempts: 3, initialDelayMs: 1 },
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("3 health check(s)");
+      // Exactly the configured maxAttempts — never more, never less.
+      expect(rec.healthProbes).toBe(3 + 1); // 3 initial (all unhealthy) + 1 recovery (healthy by default)
+      expect(rec.restores).toEqual(["metafactory"]);
+      expect(rec.natsRestarts).toBe(2);
+    });
+
+    test("settle window backoff schedule: exponential delays, capped, one fewer sleep than attempts", async () => {
+      const delays: number[] = [];
+      const { ports } = makeFakes({
+        busType: "operator-mode",
+        natsHealthy: false,
+        recoveryHealthy: false,
+        settle: { maxAttempts: 4, initialDelayMs: 100, backoffMultiplier: 2, maxDelayMs: 250 },
+        clock: instantClock(delays),
+      });
+      await joinNetwork("metafactory", LOCAL, ports);
+
+      // Both restart phases run the SAME 4-attempt window: 3 sleeps each phase
+      // (never sleeps after the LAST attempt) — 100, 200, 250(capped) per phase.
+      expect(delays).toEqual([100, 200, 250, 100, 200, 250]);
+    });
+
+    test("monitor-not-configured (INCONCLUSIVE→healthy, #831) settles on the FIRST attempt — no needless polling", async () => {
+      // The real adapter's #831 rule (an unconfigured monitor reads healthy) is
+      // adapter-level and untouched by this slice; this test locks in that the
+      // settle window respects it: a probe healthy on attempt 1 stops the loop
+      // immediately, never wasting the rest of the window.
+      const { ports, rec } = makeFakes({ busType: "operator-mode" }); // natsHealthy defaults true
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+      expect(res.ok).toBe(true);
+      expect(rec.healthProbes).toBe(1);
     });
   });
 

--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -28,15 +28,8 @@ import type { DaemonLocatorIO } from "../daemon-locator";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import type { ClockPort, SettleWindowOptions } from "../../../../common/nats/restart-with-settle";
-
-/**
- * cortex#1483 (join-4) — a `ClockPort` whose `sleep` resolves IMMEDIATELY, so a
- * multi-attempt settle window never actually waits in tests.
- */
-function instantClock(): ClockPort {
-  return { sleep: () => Promise.resolve() };
-}
+import type { SettleWindowOptions } from "../../../../common/nats/restart-with-settle";
+import { instantClock } from "./settle-test-helpers";
 
 const AGENTS_PUB = "A" + "R".repeat(55);
 const AGENTS_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBQVJSIn0.sig";
@@ -889,22 +882,50 @@ describe("buildNatsCanaryAdapter (live)", () => {
     expect(res.healthy).toBe(true);
     // A REAL signal — no longer flagged inconclusive.
     expect("inconclusive" in res && res.inconclusive).not.toBe(true);
-    // Probed the parsed client listen port on loopback.
+    // Probed the parsed client listen host:port.
+    expect(probed).toEqual([{ host: "127.0.0.1", port: 4222 }]);
+  });
+
+  test("cortex#1495 v3: no monitor + a NON-loopback listen host → probes THAT host (no false 127.0.0.1)", async () => {
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, "listen: 10.0.0.5:4222\n", "utf-8"); // bound to a specific address
+    const probed: { host: string; port: number }[] = [];
+    const adapter = buildNatsCanaryAdapter(true, undefined, async (host, port) => {
+      probed.push({ host, port });
+      return true;
+    });
+    const res = await adapter.isHealthy(conf);
+    expect(res.healthy).toBe(true);
+    // v3 important — the parsed host is dialled, NOT a hardcoded 127.0.0.1.
+    expect(probed).toEqual([{ host: "10.0.0.5", port: 4222 }]);
+  });
+
+  test("cortex#1495 v3: no monitor + a WILDCARD listen host maps to loopback for the connect", async () => {
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, "listen: 0.0.0.0:4222\n", "utf-8"); // wildcard bind
+    const probed: { host: string; port: number }[] = [];
+    const adapter = buildNatsCanaryAdapter(true, undefined, async (host, port) => {
+      probed.push({ host, port });
+      return true;
+    });
+    await adapter.isHealthy(conf);
+    // 0.0.0.0 is reachable via loopback → probe 127.0.0.1.
     expect(probed).toEqual([{ host: "127.0.0.1", port: 4222 }]);
   });
 
   test("cortex#1495 v2: no monitor + client port DOWN (TCP connect fails) → UNHEALTHY (rollback will fire)", async () => {
     const conf = join(dir, "local.conf");
     writeFileSync(conf, "port: 4299\n", "utf-8"); // client port via `port:`, no monitor
-    const probed: number[] = [];
-    const adapter = buildNatsCanaryAdapter(true, undefined, async (_host, port) => {
-      probed.push(port);
+    const probed: { host: string; port: number }[] = [];
+    const adapter = buildNatsCanaryAdapter(true, undefined, async (host, port) => {
+      probed.push({ host, port });
       return false; // nothing accepting → the restart left the bus down
     });
     const res = await adapter.isHealthy(conf);
     expect(res.healthy).toBe(false);
     if (!res.healthy) expect(res.reason).toContain("not accepting connections");
-    expect(probed).toEqual([4299]); // parsed from `port:`
+    // Bare `port:` → empty host defaulted to loopback; port parsed as 4299.
+    expect(probed).toEqual([{ host: "127.0.0.1", port: 4299 }]);
   });
 
   test("cortex#1495 v2: no monitor + client listen unresolvable (config absent) → discloses inconclusive-healthy", async () => {

--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -25,7 +25,7 @@ import {
 } from "../network-make-live-lib";
 import { insertIntoResolverPreload, findNatsServerDescriptor, buildResolverPreloadAdapter, buildNatsCanaryAdapter } from "../network-make-live-adapters";
 import type { DaemonLocatorIO } from "../daemon-locator";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { ClockPort, SettleWindowOptions } from "../../../../common/nats/restart-with-settle";
@@ -480,6 +480,49 @@ describe("makeLiveStack — cortex#1483 canary safety (natsCanary port)", () => 
     expect(res.reason).not.toContain("restored to prior state");
     expect(res.reason).toContain("intervene manually");
   });
+
+  // ── cortex#1495 v2 (important 2): the no-monitor bus (the #1476 class) is now
+  // liveness-probed by a real TCP connect, so auto-rollback is NO LONGER inert.
+  // End-to-end with the REAL canary adapter (injected TCP probe) + fake services.
+  test("v2 end-to-end: no-monitor bus + client port DOWN → real canary reports unhealthy → auto-rollback fires", async () => {
+    const cdir = mkdtempSync(join(tmpdir(), "cortex-canary-e2e-"));
+    try {
+      const conf = join(cdir, "local.conf");
+      writeFileSync(conf, "listen: 127.0.0.1:4222\n", "utf-8"); // valid HOCON, NO http monitor
+      const { ports, calls } = makePorts({ settle: { maxAttempts: 2, initialDelayMs: 1 } });
+      ports.natsCanary = buildNatsCanaryAdapter(true, undefined, async () => false); // client port DOWN
+      const res = await makeLiveStack(
+        makeInputs({ credsFileExists: true, resolverHasAccount: false }, { natsConfigPath: conf }),
+        ports,
+      );
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("not accepting connections");
+      // Rollback restored the config; the daemon was never restarted into a down bus.
+      expect(readFileSync(conf, "utf-8")).toBe("listen: 127.0.0.1:4222\n");
+      expect(calls).not.toContain("restart-daemon");
+    } finally {
+      rmSync(cdir, { recursive: true, force: true });
+    }
+  });
+
+  test("v2 end-to-end: no-monitor bus + client port UP → real canary reports healthy → no rollback, proceeds", async () => {
+    const cdir = mkdtempSync(join(tmpdir(), "cortex-canary-e2e-"));
+    try {
+      const conf = join(cdir, "local.conf");
+      writeFileSync(conf, "listen: 127.0.0.1:4222\n", "utf-8");
+      const { ports, calls } = makePorts({ settle: { maxAttempts: 2, initialDelayMs: 1 } });
+      ports.natsCanary = buildNatsCanaryAdapter(true, undefined, async () => true); // client port UP
+      const res = await makeLiveStack(
+        makeInputs({ credsFileExists: true, resolverHasAccount: false }, { natsConfigPath: conf }),
+        ports,
+      );
+      expect(res.ok).toBe(true);
+      // No rollback; the flow proceeded to the daemon restart.
+      expect(calls).toContain("restart-daemon");
+    } finally {
+      rmSync(cdir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ── resolver_preload insertion (multi-stack safety) ─────────────────────────────
@@ -761,6 +804,27 @@ describe("buildNatsCanaryAdapter (live)", () => {
     expect(readFileSync(conf, "utf-8")).toBe(original);
   });
 
+  test("cortex#1495 v2 (important 1): the restored (secret-bearing) config lands mode 0600 even under a permissive umask", () => {
+    const conf = join(dir, "local.conf");
+    const original = "server_name: work\nresolver_preload: { SECRET: eyJcreds }\n";
+    writeFileSync(conf, original, "utf-8");
+    const adapter = buildNatsCanaryAdapter(true);
+    const snap = adapter.snapshot(conf);
+
+    // Corrupt the live config (simulate a crashing restart's bad render)...
+    writeFileSync(conf, "broken\n", "utf-8");
+    // ...then roll back under a permissive umask so a mode-less write would land
+    // 0644. The restore must still land 0600 (the config carries leaf creds etc.).
+    const prevUmask = process.umask(0o022);
+    try {
+      adapter.restore(snap);
+    } finally {
+      process.umask(prevUmask);
+    }
+    expect(readFileSync(conf, "utf-8")).toBe(original);
+    expect(statSync(conf).mode & 0o777).toBe(0o600);
+  });
+
   test("restore removes a config that did NOT exist pre-mutation (the from-scratch bootstrap path)", () => {
     const conf = join(dir, "local.conf");
     const adapter = buildNatsCanaryAdapter(true);
@@ -813,12 +877,47 @@ describe("buildNatsCanaryAdapter (live)", () => {
     expect(res.healthy).toBe(false);
   });
 
-  test("isHealthy is INCONCLUSIVE (healthy) when the config declares no monitor (#831 parity)", async () => {
+  test("cortex#1495 v2: no monitor + client port UP (TCP connect ok) → genuinely healthy, NOT inconclusive", async () => {
     const conf = join(dir, "local.conf");
-    writeFileSync(conf, "listen: 127.0.0.1:4222\n", "utf-8"); // no http_port
-    const adapter = buildNatsCanaryAdapter(true);
+    writeFileSync(conf, "listen: 127.0.0.1:4222\n", "utf-8"); // no http_port monitor
+    const probed: { host: string; port: number }[] = [];
+    const adapter = buildNatsCanaryAdapter(true, undefined, async (host, port) => {
+      probed.push({ host, port });
+      return true; // client port accepting → bus is up
+    });
     const res = await adapter.isHealthy(conf);
     expect(res.healthy).toBe(true);
+    // A REAL signal — no longer flagged inconclusive.
+    expect("inconclusive" in res && res.inconclusive).not.toBe(true);
+    // Probed the parsed client listen port on loopback.
+    expect(probed).toEqual([{ host: "127.0.0.1", port: 4222 }]);
+  });
+
+  test("cortex#1495 v2: no monitor + client port DOWN (TCP connect fails) → UNHEALTHY (rollback will fire)", async () => {
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, "port: 4299\n", "utf-8"); // client port via `port:`, no monitor
+    const probed: number[] = [];
+    const adapter = buildNatsCanaryAdapter(true, undefined, async (_host, port) => {
+      probed.push(port);
+      return false; // nothing accepting → the restart left the bus down
+    });
+    const res = await adapter.isHealthy(conf);
+    expect(res.healthy).toBe(false);
+    if (!res.healthy) expect(res.reason).toContain("not accepting connections");
+    expect(probed).toEqual([4299]); // parsed from `port:`
+  });
+
+  test("cortex#1495 v2: no monitor + client listen unresolvable (config absent) → discloses inconclusive-healthy", async () => {
+    let tcpCalled = false;
+    const adapter = buildNatsCanaryAdapter(true, undefined, async () => {
+      tcpCalled = true;
+      return true;
+    });
+    const res = await adapter.isHealthy(join(dir, "does-not-exist.conf"));
+    expect(res.healthy).toBe(true);
+    expect("inconclusive" in res && res.inconclusive).toBe(true);
+    // Nothing to connect to — the TCP probe is not even attempted.
+    expect(tcpCalled).toBe(false);
   });
 
   test("dry-run isHealthy is trivially healthy (never probes)", async () => {

--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -83,8 +83,13 @@ function makePorts(over?: {
    * existing test above depends on).
    */
   withNatsCanary?: boolean;
-  /** cortex#1483 — make the canary's `nats-server -t` gate FAIL. */
+  /** cortex#1483 — make the canary's `nats-server -t` gate report INVALID. */
   canaryValidateFails?: boolean;
+  /**
+   * cortex#1495 BLOCKER — make the canary's `-t` gate report SKIPPED (binary
+   * missing): make-live must WARN loudly + PROCEED (not refuse, not silent pass).
+   */
+  canaryValidateSkips?: boolean;
   /** cortex#1483 — model the INITIAL restart's post-restart health. Default: healthy. */
   canaryNatsHealthy?: boolean;
   /** cortex#1483 — model the RECOVERY restart's post-restart health. Default: healthy. */
@@ -148,9 +153,13 @@ function makePorts(over?: {
           natsCanary: {
             async validateConfig() {
               calls.push("canary-validate");
-              return over.canaryValidateFails === true
-                ? { ok: false, reason: "nats-server -t: parse error" }
-                : { ok: true };
+              if (over.canaryValidateFails === true) {
+                return { status: "invalid", reason: "nats-server -t: parse error" };
+              }
+              if (over.canaryValidateSkips === true) {
+                return { status: "skipped", reason: "could not run nats-server -t: spawn nats-server ENOENT" };
+              }
+              return { status: "valid" };
             },
             snapshot(natsConfigPath) {
               calls.push("canary-snapshot");
@@ -818,23 +827,27 @@ describe("buildNatsCanaryAdapter (live)", () => {
     expect(res.healthy).toBe(true);
   });
 
-  test("dry-run validateConfig is inert (ok, never spawns)", async () => {
+  test("dry-run validateConfig is inert (valid, never spawns)", async () => {
     const adapter = buildNatsCanaryAdapter(false);
     const res = await adapter.validateConfig("/x/local.conf");
-    expect(res.ok).toBe(true);
+    expect(res.status).toBe("valid");
   });
 
-  test("validateConfig is well-formed regardless of whether nats-server is on PATH", async () => {
+  test("cortex#1495 BLOCKER: validateConfig is three-state (valid | invalid | skipped), never a silent fail-open", async () => {
     // Mirrors network-adapters.test.ts's MAJOR-1 pattern: we can't guarantee
-    // nats-server is installed on CI, so assert a well-formed result either way.
+    // nats-server is installed on CI, so assert a well-formed three-state result.
+    // A missing binary MUST be `skipped` (with a reason), NEVER a silent `valid`
+    // — that fail-open is the exact BLOCKER this slice closes.
     const conf = join(dir, "local.conf");
     writeFileSync(conf, "server_name: work\nlisten: 127.0.0.1:4222\n", "utf-8");
     const adapter = buildNatsCanaryAdapter(true);
     const res = await adapter.validateConfig(conf);
-    if (!res.ok) {
+    if (res.status === "invalid") {
+      expect(res.reason).toContain("nats-server");
+    } else if (res.status === "skipped") {
       expect(res.reason).toContain("nats-server");
     } else {
-      expect(res.ok).toBe(true);
+      expect(res.status).toBe("valid");
     }
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -23,11 +23,20 @@ import {
   type MakeLivePorts,
   type MakeLiveState,
 } from "../network-make-live-lib";
-import { insertIntoResolverPreload, findNatsServerDescriptor, buildResolverPreloadAdapter } from "../network-make-live-adapters";
+import { insertIntoResolverPreload, findNatsServerDescriptor, buildResolverPreloadAdapter, buildNatsCanaryAdapter } from "../network-make-live-adapters";
 import type { DaemonLocatorIO } from "../daemon-locator";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import type { ClockPort, SettleWindowOptions } from "../../../../common/nats/restart-with-settle";
+
+/**
+ * cortex#1483 (join-4) — a `ClockPort` whose `sleep` resolves IMMEDIATELY, so a
+ * multi-attempt settle window never actually waits in tests.
+ */
+function instantClock(): ClockPort {
+  return { sleep: () => Promise.resolve() };
+}
 
 const AGENTS_PUB = "A" + "R".repeat(55);
 const AGENTS_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJBQVJSIn0.sig";
@@ -68,8 +77,29 @@ function makePorts(over?: {
   daemonDescriptor?: string | undefined;
   exportFails?: boolean;
   mintFails?: boolean;
+  /**
+   * cortex#1483 (join-4) — wire a fake `natsCanary` port. Absent (default) ⇒
+   * `ports.natsCanary` stays `undefined` (the pre-#1483 behaviour every
+   * existing test above depends on).
+   */
+  withNatsCanary?: boolean;
+  /** cortex#1483 — make the canary's `nats-server -t` gate FAIL. */
+  canaryValidateFails?: boolean;
+  /** cortex#1483 — model the INITIAL restart's post-restart health. Default: healthy. */
+  canaryNatsHealthy?: boolean;
+  /** cortex#1483 — model the RECOVERY restart's post-restart health. Default: healthy. */
+  canaryRecoveryHealthy?: boolean;
+  /** cortex#1483 — healthy starting from the Nth poll WITHIN the initial phase. */
+  canaryNatsHealthyAfterAttempt?: number;
+  /** cortex#1483 — settle-window tuning threaded onto `ports.settle`. */
+  settle?: SettleWindowOptions;
 }): { ports: MakeLivePorts; calls: string[] } {
   const calls: string[] = [];
+  // cortex#1483 — the canary's snapshot is whatever `snapshot()` was called
+  // with; `restore()` records the restore + lets tests assert it ran.
+  let canaryConfigContents = "ORIGINAL-CONFIG-BYTES";
+  let canaryRestartCount = 0;
+  const canaryPhaseAttempts: Record<number, number> = {};
   const ports: MakeLivePorts = {
     creds: {
       mint: async ({ botName, account, credsPath }) => {
@@ -105,6 +135,7 @@ function makePorts(over?: {
       }),
       restartNats: async () => {
         calls.push("restart-nats");
+        canaryRestartCount++; // cortex#1483 — phase counter for the canary's isHealthy fake
         return { ok: true };
       },
       restartDaemon: async () => {
@@ -112,6 +143,45 @@ function makePorts(over?: {
         return { ok: true };
       },
     },
+    ...(over?.withNatsCanary === true
+      ? {
+          natsCanary: {
+            async validateConfig() {
+              calls.push("canary-validate");
+              return over.canaryValidateFails === true
+                ? { ok: false, reason: "nats-server -t: parse error" }
+                : { ok: true };
+            },
+            snapshot(natsConfigPath) {
+              calls.push("canary-snapshot");
+              return { natsConfigPath, contents: canaryConfigContents };
+            },
+            restore(snapshot) {
+              calls.push("canary-restore");
+              canaryConfigContents = snapshot.contents ?? "";
+            },
+            async isHealthy() {
+              calls.push("canary-isHealthy");
+              // cortex#1483 — phase (initial vs recovery) keyed off how many
+              // restartNats() calls have happened so far, mirroring network-lib
+              // test's `rec.natsRestarts` phase discriminator.
+              const phase = canaryRestartCount;
+              const isRecoveryProbe = phase > 1;
+              canaryPhaseAttempts[phase] = (canaryPhaseAttempts[phase] ?? 0) + 1;
+              const attemptInPhase = canaryPhaseAttempts[phase];
+              const healthy =
+                !isRecoveryProbe && over.canaryNatsHealthyAfterAttempt !== undefined
+                  ? attemptInPhase >= over.canaryNatsHealthyAfterAttempt
+                  : isRecoveryProbe
+                    ? over.canaryRecoveryHealthy ?? true
+                    : over.canaryNatsHealthy ?? true;
+              return healthy ? { healthy: true } : { healthy: false, reason: "monitor port 8222 not listening" };
+            },
+          },
+        }
+      : {}),
+    ...(over?.settle !== undefined ? { settle: over.settle } : {}),
+    clock: instantClock(),
   };
   return { ports, calls };
 }
@@ -329,6 +399,77 @@ describe("makeLiveStack — apply", () => {
     const txt = res.steps.join("\n");
     expect(txt).toContain("WARNING");
     expect(txt).toContain("NOT FOUND");
+  });
+});
+
+// ── cortex#1483 (join-4, epic #1479) — canary safety: validate-before-reload,
+// snapshot-before-mutate, settle-window health-verify, auto-rollback ───────────
+describe("makeLiveStack — cortex#1483 canary safety (natsCanary port)", () => {
+  test("no natsCanary wired → pre-#1483 behaviour: exit code trusted, no validate/health/rollback", async () => {
+    const { ports, calls } = makePorts(); // withNatsCanary omitted
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(true);
+    expect(calls).not.toContain("canary-validate");
+    expect(calls).not.toContain("canary-isHealthy");
+  });
+
+  test("valid config + healthy restart → validate THEN restart THEN health-verify, in order", async () => {
+    const { ports, calls } = makePorts({ withNatsCanary: true });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(true);
+    const order = calls.filter((c) => c.startsWith("canary-") || c === "restart-nats");
+    expect(order).toEqual(["canary-snapshot", "canary-validate", "restart-nats", "canary-isHealthy"]);
+    expect(res.steps.join("\n")).toContain("verified healthy");
+  });
+
+  test("invalid config → caught by -t BEFORE restart; restart never attempted; resolver write reverted", async () => {
+    const { ports, calls } = makePorts({ withNatsCanary: true, canaryValidateFails: true });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("config validation (-t) failed");
+    expect(calls).not.toContain("restart-nats");
+    expect(calls).toContain("canary-restore");
+    // Never proceeded to mint/daemon-restart after the refused reload.
+    expect(calls).not.toContain("restart-daemon");
+  });
+
+  test("slow-but-healthy bus (healthy on the 3rd poll) → NO false 'bus DOWN', no rollback", async () => {
+    const { ports, calls } = makePorts({ withNatsCanary: true, canaryNatsHealthyAfterAttempt: 3 });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(true);
+    expect(calls.filter((c) => c === "restart-nats").length).toBe(1);
+    expect(calls).not.toContain("canary-restore");
+    expect(calls.filter((c) => c === "canary-isHealthy").length).toBe(3);
+  });
+
+  test("genuinely unhealthy across the whole settle window → auto-rollback restores the snapshot + reloads", async () => {
+    const { ports, calls } = makePorts({
+      withNatsCanary: true,
+      canaryNatsHealthy: false,
+      settle: { maxAttempts: 2, initialDelayMs: 1 },
+    });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("2 health check(s)");
+    expect(calls).toContain("canary-restore");
+    // Rollback re-restarts + re-probes (recovery healthy by default → 1 more probe).
+    expect(calls.filter((c) => c === "restart-nats").length).toBe(2);
+    expect(calls.filter((c) => c === "canary-isHealthy").length).toBe(2 + 1);
+    expect(res.reason).toContain("restored to prior state");
+  });
+
+  test("worst case: recovery also stays unhealthy → clear manual-intervention warning, never claims 'restored'", async () => {
+    const { ports, calls } = makePorts({
+      withNatsCanary: true,
+      canaryNatsHealthy: false,
+      canaryRecoveryHealthy: false,
+      settle: { maxAttempts: 2, initialDelayMs: 1 },
+    });
+    const res = await makeLiveStack(makeInputs({ credsFileExists: true, resolverHasAccount: false }), ports);
+    expect(res.ok).toBe(false);
+    expect(calls).toContain("canary-restore");
+    expect(res.reason).not.toContain("restored to prior state");
+    expect(res.reason).toContain("intervene manually");
   });
 });
 
@@ -587,5 +728,113 @@ describe("makeLiveStack — defaulted credsPath write-back", () => {
     expect(res.ok).toBe(true);
     expect(writes).toHaveLength(0);
     expect(calls).not.toContain("config-write");
+  });
+});
+
+// ── cortex#1483 (join-4) — buildNatsCanaryAdapter (real fs + real HTTP probe) ───
+
+describe("buildNatsCanaryAdapter (live)", () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "cortex-canary-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("snapshot → mutate → restore reverts the config to exactly the prior bytes", () => {
+    const conf = join(dir, "local.conf");
+    const original = "server_name: work\nlisten: 127.0.0.1:4222\n";
+    writeFileSync(conf, original, "utf-8");
+    const adapter = buildNatsCanaryAdapter(true);
+
+    const snap = adapter.snapshot(conf);
+    expect(snap.contents).toBe(original);
+
+    writeFileSync(conf, "server_name: work\nresolver_preload: { A: eyJ }\n", "utf-8");
+    adapter.restore(snap);
+    expect(readFileSync(conf, "utf-8")).toBe(original);
+  });
+
+  test("restore removes a config that did NOT exist pre-mutation (the from-scratch bootstrap path)", () => {
+    const conf = join(dir, "local.conf");
+    const adapter = buildNatsCanaryAdapter(true);
+
+    const snap = adapter.snapshot(conf); // file absent → contents: undefined
+    expect(snap.contents).toBeUndefined();
+
+    writeFileSync(conf, "bootstrapped-from-scratch\n", "utf-8");
+    adapter.restore(snap);
+    expect(existsSync(conf)).toBe(false);
+  });
+
+  test("dry-run restore is inert (writes nothing)", () => {
+    const conf = join(dir, "local.conf");
+    const original = "server_name: work\n";
+    writeFileSync(conf, original, "utf-8");
+    const adapter = buildNatsCanaryAdapter(false);
+
+    const snap = adapter.snapshot(conf);
+    writeFileSync(conf, "mutated\n", "utf-8");
+    adapter.restore(snap);
+    expect(readFileSync(conf, "utf-8")).toBe("mutated\n");
+  });
+
+  test("isHealthy probes the config's own monitor and reports healthy on a 200", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new URL(req.url).pathname === "/healthz"
+          ? new Response("ok", { status: 200 })
+          : new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const conf = join(dir, "local.conf");
+      writeFileSync(conf, `http_port: ${(server.port ?? 0).toString()}\n`, "utf-8");
+      const adapter = buildNatsCanaryAdapter(true);
+      const res = await adapter.isHealthy(conf);
+      expect(res.healthy).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("isHealthy reports unhealthy when the config's monitor is unreachable", async () => {
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, "http_port: 1\n", "utf-8"); // nothing listens on :1
+    const adapter = buildNatsCanaryAdapter(true);
+    const res = await adapter.isHealthy(conf);
+    expect(res.healthy).toBe(false);
+  });
+
+  test("isHealthy is INCONCLUSIVE (healthy) when the config declares no monitor (#831 parity)", async () => {
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, "listen: 127.0.0.1:4222\n", "utf-8"); // no http_port
+    const adapter = buildNatsCanaryAdapter(true);
+    const res = await adapter.isHealthy(conf);
+    expect(res.healthy).toBe(true);
+  });
+
+  test("dry-run isHealthy is trivially healthy (never probes)", async () => {
+    const adapter = buildNatsCanaryAdapter(false);
+    const res = await adapter.isHealthy("/x/local.conf");
+    expect(res.healthy).toBe(true);
+  });
+
+  test("dry-run validateConfig is inert (ok, never spawns)", async () => {
+    const adapter = buildNatsCanaryAdapter(false);
+    const res = await adapter.validateConfig("/x/local.conf");
+    expect(res.ok).toBe(true);
+  });
+
+  test("validateConfig is well-formed regardless of whether nats-server is on PATH", async () => {
+    // Mirrors network-adapters.test.ts's MAJOR-1 pattern: we can't guarantee
+    // nats-server is installed on CI, so assert a well-formed result either way.
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, "server_name: work\nlisten: 127.0.0.1:4222\n", "utf-8");
+    const adapter = buildNatsCanaryAdapter(true);
+    const res = await adapter.validateConfig(conf);
+    if (!res.ok) {
+      expect(res.reason).toContain("nats-server");
+    } else {
+      expect(res.ok).toBe(true);
+    }
   });
 });

--- a/src/cli/cortex/commands/__tests__/settle-test-helpers.ts
+++ b/src/cli/cortex/commands/__tests__/settle-test-helpers.ts
@@ -1,0 +1,22 @@
+/**
+ * cortex#1495 v3 (nit) — shared test helpers for the settle-window / restart
+ * canary tests, so `network-lib.test.ts` and `network-make-live.test.ts` don't
+ * each copy the same fake clock.
+ */
+
+import type { ClockPort } from "../../../../common/nats/restart-with-settle";
+
+/**
+ * A {@link ClockPort} whose `sleep` resolves IMMEDIATELY (no real `setTimeout`),
+ * so a multi-attempt settle window never actually waits in tests. Pass a `delays`
+ * array to RECORD every requested delay and assert the backoff SCHEDULE without
+ * paying its wall-clock cost.
+ */
+export function instantClock(delays: number[] = []): ClockPort {
+  return {
+    sleep: (ms) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+  };
+}

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -56,6 +56,7 @@ import {
 } from "../../../common/nats/nats-service-manager";
 import { NetworkRegistryClient } from "../../../common/registry/network-client";
 import { NetworkCache } from "../../../common/registry/network-cache";
+import { backupConfigFile } from "../../../common/nats/config-backup";
 import {
   findCortexDaemonDescriptor,
   type DaemonLocatorIO,
@@ -546,6 +547,12 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
       // (e.g. 022 → 0644) would otherwise leave it world-readable. 0600 is the
       // correct floor even for a creds-path-only leaf (defence in depth).
       const leafPath = join(dir, leafIncludeFileName(inputs.descriptor.network_id));
+      // cortex#1483 (join-4) — a same-directory, timestamped `.bak` sidecar of
+      // whatever was there BEFORE this write (a re-join overwriting a prior
+      // working leaf include). No-op when the file is new. In ADDITION to (not
+      // instead of) the in-process snapshot/restore (#821) — a .bak survives the
+      // process exiting, giving a hand-recovery path even outside a `join` retry.
+      backupConfigFile(leafPath, "join");
       writeFileSync(leafPath, content, { mode: 0o600 });
       chmodSync(leafPath, 0o600);
     },
@@ -566,6 +573,8 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
       const next = ensureLeafInclude(current, networkId);
       if (next === current) return; // byte-stable no-op.
       mkdirSync(dirname(configPath), { recursive: true });
+      // cortex#1483 (join-4) — .bak the base config BEFORE the directive write.
+      backupConfigFile(configPath, "join");
       writeFileSync(configPath, next, "utf-8");
     },
     removeInclude(networkId) {
@@ -576,6 +585,8 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
       const current = readFileSync(configPath, "utf-8");
       const next = removeLeafInclude(current, networkId);
       if (next === current) return; // no-op.
+      // cortex#1483 (join-4) — .bak the base config BEFORE the directive removal.
+      backupConfigFile(configPath, "leave");
       writeFileSync(configPath, next, "utf-8");
     },
     list() {
@@ -625,6 +636,9 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
       // inert — it surfaces the decision in the step log without touching disk.
       if (result.status === "converted" && mutate) {
         mkdirSync(dirname(configPath), { recursive: true });
+        // cortex#1483 (join-4) — .bak whatever was there before the conversion
+        // (a no-op when the config is new — nothing to back up).
+        backupConfigFile(configPath, "join");
         // Security-review MAJOR (#1058) — ATOMIC write (tmp + rename). A
         // non-atomic writeFileSync truncated by a SIGKILL/OOM mid-write would
         // leave corrupt HOCON that crashes nats-server on its next restart →

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -1095,32 +1095,34 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
       // #821 MAJOR-1 — cheap pre-restart syntax gate: `nats-server -c <cfg> -t`.
       // Dry-run is inert. The gate is NECESSARY-NOT-SUFFICIENT (a syntax check
       // that does not resolve leaf creds/accounts — it passed for the original
-      // crash), so a non-zero exit is a HARD signal the config is broken, while a
-      // missing `nats-server` binary is SKIPPED (returns ok) rather than blocking
-      // the join on a machine where the test tool isn't installed.
-      if (!mutate) return { ok: true };
+      // crash), so a non-zero exit is a HARD `invalid` signal.
+      //
+      // cortex#1495 BLOCKER — a missing `nats-server` binary (spawn ENOENT) is
+      // `skipped`, NOT `valid`: fail-OPEN'ing here (the pre-fix `ok:true`) would
+      // let a bad config reload onto a live bus on any host without the binary.
+      // The caller warns loudly + proceeds on `skipped`, refuses on `invalid`.
+      if (!mutate) return { status: "valid" };
       const configPath = expandTilde(cfg.natsConfigPath ?? "");
       if (configPath.length === 0) {
         // No config to test — the restart step will surface the real error.
-        return { ok: true };
+        return { status: "valid" };
       }
       let result: { code: number; stderr: string };
       try {
         result = await bunExecRunner(["nats-server", "-c", configPath, "-t"]);
       } catch (err) {
-        // Spawn failure (e.g. binary not on PATH) → SKIP the gate, don't block.
-        process.stderr.write(
-          `network join: skipping nats-server -t gate (could not run nats-server: ${err instanceof Error ? err.message : String(err)})\n`,
-        );
-        return { ok: true };
+        return {
+          status: "skipped",
+          reason: `could not run nats-server -t: ${err instanceof Error ? err.message : String(err)}`,
+        };
       }
       if (result.code !== 0) {
         return {
-          ok: false,
+          status: "invalid",
           reason: `nats-server -c ${configPath} -t exited ${result.code.toString()}: ${result.stderr.trim()}`,
         };
       }
-      return { ok: true };
+      return { status: "valid" };
     },
     async isHealthy() {
       // #821 — probe nats-server's HTTP monitor to confirm it actually came back
@@ -1142,8 +1144,10 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
       // monitor we cannot confirm liveness, but we MUST NOT roll back a join
       // whose policy + peer were already written (the false-FAIL incident: a
       // single-file `local.conf` with no `http_port` ECONNREFUSED `:8222` and
-      // rolled back a good join). Absent monitor → treat as healthy.
-      if (!monitor.configured) return { healthy: true };
+      // rolled back a good join). Absent monitor → treat as healthy, but flag it
+      // INCONCLUSIVE (cortex#1495 important 3) so the caller's step log says
+      // "inconclusive, treated as healthy" rather than "verified healthy".
+      if (!monitor.configured) return { healthy: true, inconclusive: true };
       const base = monitor.url.replace(/\/+$/, "");
       // #821 MAJOR — BOUND the probe. A monitor that accepts the TCP connection
       // but never responds (hung/deadlocked nats-server — exactly the failure the

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -57,6 +57,7 @@ import {
 import { NetworkRegistryClient } from "../../../common/registry/network-client";
 import { NetworkCache } from "../../../common/registry/network-cache";
 import { backupConfigFile } from "../../../common/nats/config-backup";
+import { probeHealthzMonitor } from "../../../common/nats/healthz-probe";
 import {
   findCortexDaemonDescriptor,
   type DaemonLocatorIO,
@@ -1148,39 +1149,13 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
       // INCONCLUSIVE (cortex#1495 important 3) so the caller's step log says
       // "inconclusive, treated as healthy" rather than "verified healthy".
       if (!monitor.configured) return { healthy: true, inconclusive: true };
-      const base = monitor.url.replace(/\/+$/, "");
       // #821 MAJOR — BOUND the probe. A monitor that accepts the TCP connection
       // but never responds (hung/deadlocked nats-server — exactly the failure the
       // probe exists to catch) would hang an unbounded `fetch` forever and stall
-      // joinNetwork with no verdict. AbortSignal.timeout aborts after the
-      // configured budget; a timeout/abort is treated as healthy:false (the
-      // restart did NOT bring a responsive bus up).
+      // joinNetwork with no verdict. cortex#1495 v3 — the fetch+timeout+error-map
+      // body is the SHARED `probeHealthzMonitor` so join + make-live can't drift.
       const timeoutMs = cfg.healthProbeTimeoutMs ?? DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
-      try {
-        const res = await fetch(`${base}/healthz`, {
-          signal: AbortSignal.timeout(timeoutMs),
-        });
-        if (!res.ok) {
-          return {
-            healthy: false,
-            reason: `nats-server monitor ${base}/healthz returned HTTP ${res.status.toString()}`,
-          };
-        }
-        return { healthy: true };
-      } catch (err) {
-        // A timeout/abort means the monitor accepted but did not respond in time
-        // — the bus is hung, NOT healthy. A connection error means it's down or
-        // the port isn't listening. Either way the restart did NOT bring a
-        // healthy bus up. Distinguish the timeout for an actionable reason.
-        const isTimeout =
-          err instanceof DOMException && err.name === "TimeoutError";
-        return {
-          healthy: false,
-          reason: isTimeout
-            ? `nats-server monitor ${base}/healthz timed out after ${timeoutMs.toString()}ms (accepted the connection but never responded — bus hung)`
-            : `nats-server monitor ${base} unreachable: ${err instanceof Error ? err.message : String(err)}`,
-        };
-      }
+      return probeHealthzMonitor(monitor.url, timeoutMs);
     },
   };
 }

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -49,6 +49,7 @@ import {
   probeHealthWithSettle,
   realClock,
   settleFailureReason,
+  INCONCLUSIVE_HEALTH_NOTICE,
   type ConfigValidationOutcome,
 } from "../../../common/nats/restart-with-settle";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
@@ -878,7 +879,7 @@ export async function joinNetwork(
         ports.leafFile.restoreLeafState(snapshot);
         const recovery = await restartAndProbe();
         rollbackNote = recovery.ok
-          ? `rolled back leaf config + restarted nats-server (bus restored to prior state, ${recovery.inconclusive ? "health inconclusive — no monitor configured, treated as healthy per #831" : "verified healthy"})`
+          ? `rolled back leaf config + restarted nats-server (bus restored to prior state, ${recovery.inconclusive ? INCONCLUSIVE_HEALTH_NOTICE : "verified healthy"})`
           : `rolled back leaf config but the recovery restart did NOT bring the bus back up (${recovery.reason}) — bus may be DOWN, intervene manually`;
       } catch (err) {
         rollbackNote = `rollback FAILED (${err instanceof Error ? err.message : String(err)}) — bus may be DOWN, intervene manually`;
@@ -898,7 +899,7 @@ export async function joinNetwork(
     // inconclusive (#831 no-monitor). Report what actually happened.
     steps.push(
       initial.inconclusive
-        ? "restarted nats-server to load leaf config (health inconclusive — no monitor configured, treated as healthy per #831)"
+        ? `restarted nats-server to load leaf config (${INCONCLUSIVE_HEALTH_NOTICE})`
         : "restarted nats-server to load leaf config (verified healthy)",
     );
   }

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -45,7 +45,12 @@ import {
 } from "../../../common/types/cortex-config";
 import type { NetworkRosterResult } from "../../../common/registry/types";
 import { pskFingerprint } from "../../../common/nats/leaf-psk";
-import { probeHealthWithSettle, realClock } from "../../../common/nats/restart-with-settle";
+import {
+  probeHealthWithSettle,
+  realClock,
+  settleFailureReason,
+  type ConfigValidationOutcome,
+} from "../../../common/nats/restart-with-settle";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 import { buildRosterPeers } from "../../../bus/agent-network/roster-read";
 import {
@@ -771,17 +776,19 @@ export async function joinNetwork(
     // ultimately shell out via Bun.spawn, which THROWS SYNCHRONOUSLY on ENOENT
     // (launchctl/systemctl/nats-server not on PATH). joinNetwork is documented
     // "never throws", so guard the call: a thrown spawn error becomes a clean
-    // failure verdict, not an uncaught stack trace that wedges the CLI.
-    let validate: { ok: true } | { ok: false; reason: string };
+    // failure verdict, not an uncaught stack trace that wedges the CLI. A THROW
+    // is an unexpected contract violation (the real adapter never throws — it
+    // returns `skipped` on ENOENT), so treat it fail-SAFE as `invalid`/refuse.
+    let validate: ConfigValidationOutcome;
     try {
       validate = await natsServer.validateConfig();
     } catch (err) {
       validate = {
-        ok: false,
+        status: "invalid",
         reason: `nats-server config validation could not run: ${err instanceof Error ? err.message : String(err)}`,
       };
     }
-    if (!validate.ok) {
+    if (validate.status === "invalid") {
       try {
         ports.leafFile.restoreLeafState(snapshot);
       } catch (err) {
@@ -804,6 +811,16 @@ export async function joinNetwork(
         ...(warnings.length > 0 && { warnings }),
       };
     }
+    if (validate.status === "skipped") {
+      // cortex#1495 BLOCKER — "could not validate" is NOT "valid". Proceed (so a
+      // host without `nats-server` on PATH isn't hard-blocked) but WARN LOUDLY
+      // that the pre-reload safety gate did not run, never a silent pass.
+      const warn =
+        `could not run \`nats-server -t\` — ${validate.reason}; proceeding WITHOUT the ` +
+        `pre-reload validation safety gate (a broken config will not be caught before restart)`;
+      warnings.push(warn);
+      steps.push(`WARN: ${warn}`);
+    }
 
     // #821 — a restart that EXITS non-zero, OR one that exits 0 but leaves the
     // server DOWN (the community crash: `launchctl kickstart` returned 0, then
@@ -819,7 +836,7 @@ export async function joinNetwork(
     // (throws synchronously on ENOENT) / fetch; a throw here becomes a failure
     // result, never an uncaught escape from joinNetwork.
     const restartAndProbe = async (): Promise<
-      { ok: true } | { ok: false; reason: string }
+      { ok: true; inconclusive: boolean } | { ok: false; reason: string }
     > => {
       try {
         const r = await natsServer.restart();
@@ -838,14 +855,9 @@ export async function joinNetwork(
           ports.clock ?? realClock,
         );
         if (!settled.healthy) {
-          return {
-            ok: false,
-            reason:
-              `nats-server did not come back up after restart across ${settled.attempts.toString()} ` +
-              `health check(s) over the settle window (${settled.reason ?? "unknown"})`,
-          };
+          return { ok: false, reason: settleFailureReason(settled.attempts, settled.reason) };
         }
-        return { ok: true };
+        return { ok: true, inconclusive: settled.inconclusive === true };
       } catch (err) {
         return {
           ok: false,
@@ -866,7 +878,7 @@ export async function joinNetwork(
         ports.leafFile.restoreLeafState(snapshot);
         const recovery = await restartAndProbe();
         rollbackNote = recovery.ok
-          ? "rolled back leaf config + restarted nats-server (bus restored to prior state, verified healthy)"
+          ? `rolled back leaf config + restarted nats-server (bus restored to prior state, ${recovery.inconclusive ? "health inconclusive — no monitor configured, treated as healthy per #831" : "verified healthy"})`
           : `rolled back leaf config but the recovery restart did NOT bring the bus back up (${recovery.reason}) — bus may be DOWN, intervene manually`;
       } catch (err) {
         rollbackNote = `rollback FAILED (${err instanceof Error ? err.message : String(err)}) — bus may be DOWN, intervene manually`;
@@ -882,7 +894,13 @@ export async function joinNetwork(
         warnings: [...warnings, rollbackNote],
       };
     }
-    steps.push("restarted nats-server to load leaf config (verified healthy)");
+    // cortex#1495 important 3 — do NOT claim "verified healthy" when the probe was
+    // inconclusive (#831 no-monitor). Report what actually happened.
+    steps.push(
+      initial.inconclusive
+        ? "restarted nats-server to load leaf config (health inconclusive — no monitor configured, treated as healthy per #831)"
+        : "restarted nats-server to load leaf config (verified healthy)",
+    );
   }
 
   // (e.2) Restart the cortex daemon so it reconnects to the bus (now carrying

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -45,6 +45,7 @@ import {
 } from "../../../common/types/cortex-config";
 import type { NetworkRosterResult } from "../../../common/registry/types";
 import { pskFingerprint } from "../../../common/nats/leaf-psk";
+import { probeHealthWithSettle, realClock } from "../../../common/nats/restart-with-settle";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 import { buildRosterPeers } from "../../../bus/agent-network/roster-read";
 import {
@@ -823,11 +824,25 @@ export async function joinNetwork(
       try {
         const r = await natsServer.restart();
         if (!r.ok) return { ok: false, reason: r.reason };
-        const health = await natsServer.isHealthy();
-        if (!health.healthy) {
+        // cortex#1483 (join-4) — a SETTLE WINDOW, not a single immediate probe.
+        // `launchctl kickstart`/`systemctl restart` returning does not mean
+        // nats-server has rebound its HTTP monitor port yet; a lone probe here
+        // races that startup window and reads a HEALTHY bus as DOWN (the exact
+        // #1476 gap-2 false alarm: "bus may be DOWN, intervene manually" on a
+        // perfectly healthy bus). Poll with backoff — a slow-but-healthy bus is
+        // never mistaken for a genuinely down one; only exhausting the whole
+        // window without a healthy result is a real failure.
+        const settled = await probeHealthWithSettle(
+          () => natsServer.isHealthy(),
+          ports.settle,
+          ports.clock ?? realClock,
+        );
+        if (!settled.healthy) {
           return {
             ok: false,
-            reason: `nats-server did not come back up after restart (${health.reason})`,
+            reason:
+              `nats-server did not come back up after restart across ${settled.attempts.toString()} ` +
+              `health check(s) over the settle window (${settled.reason ?? "unknown"})`,
           };
         }
         return { ok: true };

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -31,7 +31,6 @@ import {
   configArgValue,
   type DaemonLocatorIO,
 } from "./daemon-locator";
-import { DEFAULT_MONITOR_URL, DEFAULT_HEALTH_PROBE_TIMEOUT_MS } from "./network-adapters";
 import type {
   CredsMintPort,
   AccountExportPort,
@@ -476,31 +475,41 @@ export function buildMakeLiveConfigWriteAdapter(mutate: boolean): MakeLiveConfig
 // include — the whole config IS the mutation target here).
 // =============================================================================
 
+// cortex#1495 nit 4 — kept LOCAL rather than imported from network-adapters.ts
+// (join's adapter), so make-live's canary adapter doesn't reach across into
+// join's module for a shared default. These mirror network-adapters.ts's
+// DEFAULT_MONITOR_URL / DEFAULT_HEALTH_PROBE_TIMEOUT_MS (the upstream nats
+// loopback monitor + a 5s probe bound); the two are independent by design.
+const MAKELIVE_DEFAULT_MONITOR_URL = "http://127.0.0.1:8222";
+const MAKELIVE_HEALTH_PROBE_TIMEOUT_MS = 5000;
+
 /** Live {@link NatsCanaryPort}. `nats-server -t` gate, snapshot/restore, /healthz probe. */
 export function buildNatsCanaryAdapter(mutate: boolean, healthProbeTimeoutMs?: number): NatsCanaryPort {
   return {
     async validateConfig(natsConfigPath) {
       // #821 MAJOR-1 parity — cheap pre-restart syntax gate. Dry-run is inert.
-      if (!mutate) return { ok: true };
+      if (!mutate) return { status: "valid" };
       const abs = expandTilde(natsConfigPath);
       let result: { code: number; stderr: string };
       try {
         result = await bunExecRunner(["nats-server", "-c", abs, "-t"]);
       } catch (err) {
-        // Missing binary (ENOENT) → SKIP the gate, don't block make-live on a
-        // machine where the test tool isn't installed (mirrors network-adapters.ts).
-        process.stderr.write(
-          `make-live: skipping nats-server -t gate (could not run nats-server: ${err instanceof Error ? err.message : String(err)})\n`,
-        );
-        return { ok: true };
+        // cortex#1495 BLOCKER — a missing binary (spawn ENOENT) is `skipped`,
+        // NOT `valid`: fail-OPEN here would let a bad config reload onto a live
+        // bus on any host without `nats-server` on PATH. The orchestrator warns
+        // loudly + proceeds on `skipped` rather than silently passing.
+        return {
+          status: "skipped",
+          reason: `could not run nats-server -t: ${err instanceof Error ? err.message : String(err)}`,
+        };
       }
       if (result.code !== 0) {
         return {
-          ok: false,
+          status: "invalid",
           reason: `nats-server -c ${abs} -t exited ${result.code.toString()}: ${result.stderr.trim()}`,
         };
       }
-      return { ok: true };
+      return { status: "valid" };
     },
     snapshot(natsConfigPath) {
       const abs = expandTilde(natsConfigPath);
@@ -530,10 +539,11 @@ export function buildNatsCanaryAdapter(mutate: boolean, healthProbeTimeoutMs?: n
       const abs = expandTilde(natsConfigPath);
       // Same precedence as network-adapters.ts's resolveMonitorBase: derive from
       // the config's own http_port/monitor_port/http; fall back to the upstream
-      // default. #831 parity — no monitor declared ⇒ INCONCLUSIVE (healthy), a
-      // configured-but-down monitor still reports unhealthy.
+      // default. #831 parity — no monitor declared ⇒ INCONCLUSIVE (healthy but
+      // flagged so the log doesn't over-claim), a configured-but-down monitor
+      // still reports unhealthy.
       let configured = false;
-      let base = DEFAULT_MONITOR_URL;
+      let base = MAKELIVE_DEFAULT_MONITOR_URL;
       if (existsSync(abs)) {
         const derived = natsConfigMonitorUrl(readFileSync(abs, "utf-8"));
         if (derived !== undefined) {
@@ -541,8 +551,10 @@ export function buildNatsCanaryAdapter(mutate: boolean, healthProbeTimeoutMs?: n
           configured = true;
         }
       }
-      if (!configured) return { healthy: true };
-      const timeoutMs = healthProbeTimeoutMs ?? DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
+      // cortex#1495 important 3 — no monitor ⇒ liveness cannot be CONFIRMED;
+      // healthy (never a false rollback) but flagged INCONCLUSIVE.
+      if (!configured) return { healthy: true, inconclusive: true };
+      const timeoutMs = healthProbeTimeoutMs ?? MAKELIVE_HEALTH_PROBE_TIMEOUT_MS;
       try {
         const res = await fetch(`${base.replace(/\/+$/, "")}/healthz`, {
           signal: AbortSignal.timeout(timeoutMs),

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -12,11 +12,17 @@
 import { existsSync, readFileSync, writeFileSync, copyFileSync, chmodSync, readdirSync, mkdirSync, renameSync, rmSync } from "fs";
 import { homedir } from "os";
 import { join, dirname } from "path";
+import { Socket } from "net";
 
 import { parseDocument } from "yaml";
 
 import { expandTilde } from "../../../common/config/loader";
-import { renderOperatorModeBlocks, renderBaseIsolatedConfig, natsConfigMonitorUrl } from "../../../common/nats/leaf-remote-renderer";
+import {
+  renderOperatorModeBlocks,
+  renderBaseIsolatedConfig,
+  natsConfigMonitorUrl,
+  natsConfigClientListenPort,
+} from "../../../common/nats/leaf-remote-renderer";
 import {
   selectNatsServiceManager,
   currentServicePlatform,
@@ -477,17 +483,63 @@ export function buildMakeLiveConfigWriteAdapter(mutate: boolean): MakeLiveConfig
 
 // cortex#1495 nit 4 — kept LOCAL rather than imported from network-adapters.ts
 // (join's adapter), so make-live's canary adapter doesn't reach across into
-// join's module for a shared default. These mirror network-adapters.ts's
-// DEFAULT_MONITOR_URL / DEFAULT_HEALTH_PROBE_TIMEOUT_MS (the upstream nats
-// loopback monitor + a 5s probe bound); the two are independent by design.
-const MAKELIVE_DEFAULT_MONITOR_URL = "http://127.0.0.1:8222";
+// join's module for a shared default. Mirrors network-adapters.ts's
+// DEFAULT_HEALTH_PROBE_TIMEOUT_MS (a 5s probe bound); the two are independent by
+// design. (cortex#1495 v2: the :8222 monitor DEFAULT was dropped — a bus with no
+// declared monitor now falls back to a TCP client-port probe, not a guessed :8222.)
 const MAKELIVE_HEALTH_PROBE_TIMEOUT_MS = 5000;
+/** NATS default client listen port — the TCP-connect liveness target when a bus declares no monitor. */
+const NATS_DEFAULT_CLIENT_PORT = 4222;
 
-/** Live {@link NatsCanaryPort}. `nats-server -t` gate, snapshot/restore, /healthz probe. */
-export function buildNatsCanaryAdapter(mutate: boolean, healthProbeTimeoutMs?: number): NatsCanaryPort {
+/**
+ * cortex#1495 v2 (important 2) — an injectable bounded TCP-connect probe. A bus
+ * with NO HTTP monitor (the #1476 community class) still has a client listen
+ * port; a successful connect is a REAL liveness signal (the process is up and
+ * accepting), a refused/timed-out connect means the restart left it DOWN → the
+ * orchestrator's auto-rollback fires. Injected so tests script connect-ok /
+ * connect-fail without opening a real socket. Resolves `true` on connect,
+ * `false` on refusal/timeout/error. NEVER rejects.
+ */
+export type TcpConnectProbe = (host: string, port: number, timeoutMs: number) => Promise<boolean>;
+
+/** Real bounded TCP connect (node `net.Socket`); destroyed the moment it settles. */
+const realTcpConnectProbe: TcpConnectProbe = (host, port, timeoutMs) =>
+  new Promise<boolean>((resolve) => {
+    const socket = new Socket();
+    let settled = false;
+    const finish = (ok: boolean): void => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => { finish(true); });
+    socket.once("timeout", () => { finish(false); });
+    socket.once("error", () => { finish(false); });
+    socket.connect(port, host);
+  });
+
+/**
+ * Live {@link NatsCanaryPort}. `nats-server -t` gate, snapshot/restore, and a
+ * two-tier post-restart liveness probe: the config's `/healthz` monitor when one
+ * is declared, else a TCP connect to the client listen port (cortex#1495 v2).
+ * `tcpConnect` is injectable so tests exercise the no-monitor path without a real
+ * socket; production uses {@link realTcpConnectProbe}.
+ */
+export function buildNatsCanaryAdapter(
+  mutate: boolean,
+  healthProbeTimeoutMs?: number,
+  tcpConnect: TcpConnectProbe = realTcpConnectProbe,
+): NatsCanaryPort {
   return {
     async validateConfig(natsConfigPath) {
       // #821 MAJOR-1 parity — cheap pre-restart syntax gate. Dry-run is inert.
+      // cortex#1495 v2 (suggestion) — the "invalid config → -t refuses the reload"
+      // contract is exercised at the ORCHESTRATION level with FAKE ports only
+      // (network-make-live.test.ts). It is not asserted against a real nats-server:
+      // that needs the `nats-server` binary in CI (out of scope) and would be flaky.
+      // The `code !== 0 → invalid` mapping below is the single point of trust.
       if (!mutate) return { status: "valid" };
       const abs = expandTilde(natsConfigPath);
       let result: { code: number; stderr: string };
@@ -530,31 +582,52 @@ export function buildNatsCanaryAdapter(mutate: boolean, healthProbeTimeoutMs?: n
       // Atomic write (temp + rename) — a crash mid-rollback must never corrupt
       // the very config it is trying to restore (mirrors network-adapters.ts's
       // O-3 atomicWriteFileSync).
+      // cortex#1495 v2 (important 1) — the nats config is SECRET-bearing (leaf
+      // creds, hub authorization users, payload keys), so the restore write is
+      // created 0600 (mode on the temp + explicit chmod against a permissive
+      // umask), same discipline as the `.bak` sidecar and the leaf-include write.
       const tmp = `${natsConfigPath}.tmp-canary-restore-${process.pid.toString()}`;
-      writeFileSync(tmp, contents, "utf-8");
+      writeFileSync(tmp, contents, { mode: 0o600 });
+      chmodSync(tmp, 0o600);
       renameSync(tmp, natsConfigPath);
     },
     async isHealthy(natsConfigPath) {
       if (!mutate) return { healthy: true };
       const abs = expandTilde(natsConfigPath);
-      // Same precedence as network-adapters.ts's resolveMonitorBase: derive from
-      // the config's own http_port/monitor_port/http; fall back to the upstream
-      // default. #831 parity — no monitor declared ⇒ INCONCLUSIVE (healthy but
-      // flagged so the log doesn't over-claim), a configured-but-down monitor
-      // still reports unhealthy.
-      let configured = false;
-      let base = MAKELIVE_DEFAULT_MONITOR_URL;
-      if (existsSync(abs)) {
-        const derived = natsConfigMonitorUrl(readFileSync(abs, "utf-8"));
-        if (derived !== undefined) {
-          base = derived;
-          configured = true;
-        }
-      }
-      // cortex#1495 important 3 — no monitor ⇒ liveness cannot be CONFIRMED;
-      // healthy (never a false rollback) but flagged INCONCLUSIVE.
-      if (!configured) return { healthy: true, inconclusive: true };
       const timeoutMs = healthProbeTimeoutMs ?? MAKELIVE_HEALTH_PROBE_TIMEOUT_MS;
+      const configText = existsSync(abs) ? readFileSync(abs, "utf-8") : undefined;
+      // Same precedence as network-adapters.ts's resolveMonitorBase: derive the
+      // monitor from the config's own http_port/monitor_port/http.
+      let base: string | undefined;
+      if (configText !== undefined) {
+        const derived = natsConfigMonitorUrl(configText);
+        if (derived !== undefined) base = derived;
+      }
+
+      // cortex#1495 v2 (important 2) — a bus with NO HTTP monitor (the #1476
+      // community bus class: no `http_port`) must NOT read as inconclusive-healthy,
+      // or auto-rollback goes inert on the exact config that motivated this slice.
+      // Fall back to a REAL liveness signal: a bounded TCP connect to the client
+      // listen port (parsed from `listen:`/`port:`, default 4222). Connect ⇒
+      // genuinely healthy (NOT inconclusive); refused/timeout ⇒ unhealthy → the
+      // orchestrator rolls back. RESIDUAL: a listening client port proves the
+      // process is up + accepting, not that JetStream fully recovered — but it
+      // catches the "nats-server crashed on the new config" case the slice targets.
+      if (base === undefined) {
+        if (configText === undefined) {
+          // The client listen addr genuinely can't be resolved (config
+          // absent/unreadable) — disclosed fallback to inconclusive-healthy.
+          return { healthy: true, inconclusive: true };
+        }
+        const port = natsConfigClientListenPort(configText) ?? NATS_DEFAULT_CLIENT_PORT;
+        const connected = await tcpConnect("127.0.0.1", port, timeoutMs);
+        return connected
+          ? { healthy: true }
+          : {
+              healthy: false,
+              reason: `bus client port 127.0.0.1:${port.toString()} not accepting connections after restart (no HTTP monitor to probe; TCP connect failed)`,
+            };
+      }
       try {
         const res = await fetch(`${base.replace(/\/+$/, "")}/healthz`, {
           signal: AbortSignal.timeout(timeoutMs),

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -9,20 +9,21 @@
  * tree + JWT come from arc (ADR-0013 Model B invariant).
  */
 
-import { existsSync, readFileSync, writeFileSync, copyFileSync, chmodSync, readdirSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, copyFileSync, chmodSync, readdirSync, mkdirSync, renameSync, rmSync } from "fs";
 import { homedir } from "os";
 import { join, dirname } from "path";
 
 import { parseDocument } from "yaml";
 
 import { expandTilde } from "../../../common/config/loader";
-import { renderOperatorModeBlocks, renderBaseIsolatedConfig } from "../../../common/nats/leaf-remote-renderer";
+import { renderOperatorModeBlocks, renderBaseIsolatedConfig, natsConfigMonitorUrl } from "../../../common/nats/leaf-remote-renderer";
 import {
   selectNatsServiceManager,
   currentServicePlatform,
   bunExecRunner,
   type ServicePlatform,
 } from "../../../common/nats/nats-service-manager";
+import { backupConfigFile } from "../../../common/nats/config-backup";
 import {
   findCortexDaemonDescriptor,
   parsePlistProgramArguments,
@@ -30,6 +31,7 @@ import {
   configArgValue,
   type DaemonLocatorIO,
 } from "./daemon-locator";
+import { DEFAULT_MONITOR_URL, DEFAULT_HEALTH_PROBE_TIMEOUT_MS } from "./network-adapters";
 import type {
   CredsMintPort,
   AccountExportPort,
@@ -37,6 +39,8 @@ import type {
   ServiceRestartPort,
   MakeLiveConfigWritePort,
   MakeLivePorts,
+  NatsCanaryPort,
+  NatsConfigSnapshot,
 } from "./network-make-live-lib";
 
 // =============================================================================
@@ -224,8 +228,10 @@ export function buildResolverPreloadAdapter(): ResolverPreloadPort {
         if (next === null) {
           return { ok: false, reason: `could not locate a resolver_preload { … } block in ${abs}` };
         }
-        // Back up before the in-place edit (timestamped — the rollback artefact).
-        copyFileSync(abs, `${abs}.bak-makelive-${Date.now().toString()}`);
+        // cortex#1483 (join-4) — back up before the in-place edit (timestamped —
+        // the rollback artefact), via the ONE shared .bak helper so this and the
+        // bootstrap write below never drift on naming.
+        backupConfigFile(abs, "makelive");
         writeFileSync(abs, next, "utf-8");
         return { ok: true, changed: true };
       } catch (err) {
@@ -285,7 +291,7 @@ export function buildResolverPreloadAdapter(): ResolverPreloadPort {
         // freshly-synthesised config has nothing to back up. Ensure the parent dir
         // exists, then write in place.
         if (fileExists) {
-          copyFileSync(abs, `${abs}.bak-makelive-${Date.now().toString()}`);
+          backupConfigFile(abs, "makelive");
         } else {
           mkdirSync(dirname(abs), { recursive: true });
         }
@@ -461,6 +467,106 @@ export function buildMakeLiveConfigWriteAdapter(mutate: boolean): MakeLiveConfig
   };
 }
 
+// =============================================================================
+// Canary adapter (cortex#1483, join-4) — validate/snapshot/health/rollback
+// around the nats-server restart. Mirrors network-adapters.ts's
+// buildNatsServerPort (validateConfig via `nats-server -t`, isHealthy via the
+// config's own /healthz monitor) + the #821 leaf-state snapshot/restore
+// pattern, adapted to make-live's single nats config file (no per-network leaf
+// include — the whole config IS the mutation target here).
+// =============================================================================
+
+/** Live {@link NatsCanaryPort}. `nats-server -t` gate, snapshot/restore, /healthz probe. */
+export function buildNatsCanaryAdapter(mutate: boolean, healthProbeTimeoutMs?: number): NatsCanaryPort {
+  return {
+    async validateConfig(natsConfigPath) {
+      // #821 MAJOR-1 parity — cheap pre-restart syntax gate. Dry-run is inert.
+      if (!mutate) return { ok: true };
+      const abs = expandTilde(natsConfigPath);
+      let result: { code: number; stderr: string };
+      try {
+        result = await bunExecRunner(["nats-server", "-c", abs, "-t"]);
+      } catch (err) {
+        // Missing binary (ENOENT) → SKIP the gate, don't block make-live on a
+        // machine where the test tool isn't installed (mirrors network-adapters.ts).
+        process.stderr.write(
+          `make-live: skipping nats-server -t gate (could not run nats-server: ${err instanceof Error ? err.message : String(err)})\n`,
+        );
+        return { ok: true };
+      }
+      if (result.code !== 0) {
+        return {
+          ok: false,
+          reason: `nats-server -c ${abs} -t exited ${result.code.toString()}: ${result.stderr.trim()}`,
+        };
+      }
+      return { ok: true };
+    },
+    snapshot(natsConfigPath) {
+      const abs = expandTilde(natsConfigPath);
+      return {
+        natsConfigPath: abs,
+        contents: existsSync(abs) ? readFileSync(abs, "utf-8") : undefined,
+      };
+    },
+    restore(snapshot: NatsConfigSnapshot) {
+      if (!mutate) return;
+      const { natsConfigPath, contents } = snapshot;
+      if (contents === undefined) {
+        // The config did not exist pre-mutation (the from-scratch bootstrap
+        // path) — remove what make-live wrote so a retry starts clean.
+        rmSync(natsConfigPath, { force: true });
+        return;
+      }
+      // Atomic write (temp + rename) — a crash mid-rollback must never corrupt
+      // the very config it is trying to restore (mirrors network-adapters.ts's
+      // O-3 atomicWriteFileSync).
+      const tmp = `${natsConfigPath}.tmp-canary-restore-${process.pid.toString()}`;
+      writeFileSync(tmp, contents, "utf-8");
+      renameSync(tmp, natsConfigPath);
+    },
+    async isHealthy(natsConfigPath) {
+      if (!mutate) return { healthy: true };
+      const abs = expandTilde(natsConfigPath);
+      // Same precedence as network-adapters.ts's resolveMonitorBase: derive from
+      // the config's own http_port/monitor_port/http; fall back to the upstream
+      // default. #831 parity — no monitor declared ⇒ INCONCLUSIVE (healthy), a
+      // configured-but-down monitor still reports unhealthy.
+      let configured = false;
+      let base = DEFAULT_MONITOR_URL;
+      if (existsSync(abs)) {
+        const derived = natsConfigMonitorUrl(readFileSync(abs, "utf-8"));
+        if (derived !== undefined) {
+          base = derived;
+          configured = true;
+        }
+      }
+      if (!configured) return { healthy: true };
+      const timeoutMs = healthProbeTimeoutMs ?? DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
+      try {
+        const res = await fetch(`${base.replace(/\/+$/, "")}/healthz`, {
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (!res.ok) {
+          return {
+            healthy: false,
+            reason: `nats-server monitor ${base}/healthz returned HTTP ${res.status.toString()}`,
+          };
+        }
+        return { healthy: true };
+      } catch (err) {
+        const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
+        return {
+          healthy: false,
+          reason: isTimeout
+            ? `nats-server monitor ${base}/healthz timed out after ${timeoutMs.toString()}ms (accepted the connection but never responded — bus hung)`
+            : `nats-server monitor ${base} unreachable: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    },
+  };
+}
+
 /** Build the live {@link MakeLivePorts} bundle for a real `--apply` run. */
 export function buildLiveMakeLivePorts(mutate: boolean): MakeLivePorts {
   return {
@@ -469,5 +575,6 @@ export function buildLiveMakeLivePorts(mutate: boolean): MakeLivePorts {
     resolver: buildResolverPreloadAdapter(),
     restart: buildServiceRestartAdapter(mutate),
     configWrite: buildMakeLiveConfigWriteAdapter(mutate),
+    natsCanary: buildNatsCanaryAdapter(mutate),
   };
 }

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -21,8 +21,9 @@ import {
   renderOperatorModeBlocks,
   renderBaseIsolatedConfig,
   natsConfigMonitorUrl,
-  natsConfigClientListenPort,
+  natsConfigClientListen,
 } from "../../../common/nats/leaf-remote-renderer";
+import { probeHealthzMonitor } from "../../../common/nats/healthz-probe";
 import {
   selectNatsServiceManager,
   currentServicePlatform,
@@ -492,6 +493,23 @@ const MAKELIVE_HEALTH_PROBE_TIMEOUT_MS = 5000;
 const NATS_DEFAULT_CLIENT_PORT = 4222;
 
 /**
+ * cortex#1495 v3 (important) — map a PARSED nats `listen` host to the address the
+ * liveness TCP connect should actually dial:
+ *   - a specific host (`10.0.0.5`, `localhost`, an IPv6 literal) is used as-is —
+ *     hardcoding `127.0.0.1` would false-fail (and false-rollback) a bus that
+ *     listens on a non-loopback address;
+ *   - a WILDCARD bind is reachable via loopback: `0.0.0.0` → `127.0.0.1`,
+ *     `::`/`[::]` → `::1`;
+ *   - an empty/unparseable host (bare `port:` / `listen: <port>`) → `127.0.0.1`.
+ */
+function connectHostForListen(rawHost: string): string {
+  const h = rawHost.trim();
+  if (h === "" || h === "0.0.0.0") return "127.0.0.1";
+  if (h === "::" || h === "[::]") return "::1";
+  return h;
+}
+
+/**
  * cortex#1495 v2 (important 2) — an injectable bounded TCP-connect probe. A bus
  * with NO HTTP monitor (the #1476 community class) still has a client listen
  * port; a successful connect is a REAL liveness signal (the process is up and
@@ -608,10 +626,12 @@ export function buildNatsCanaryAdapter(
       // community bus class: no `http_port`) must NOT read as inconclusive-healthy,
       // or auto-rollback goes inert on the exact config that motivated this slice.
       // Fall back to a REAL liveness signal: a bounded TCP connect to the client
-      // listen port (parsed from `listen:`/`port:`, default 4222). Connect ⇒
-      // genuinely healthy (NOT inconclusive); refused/timeout ⇒ unhealthy → the
-      // orchestrator rolls back. RESIDUAL: a listening client port proves the
-      // process is up + accepting, not that JetStream fully recovered — but it
+      // listen address (parsed from `listen:`/`host:`+`port:`). Connect ⇒ genuinely
+      // healthy (NOT inconclusive); refused/timeout ⇒ unhealthy → the orchestrator
+      // rolls back. cortex#1495 v3 — dial the PARSED host (wildcard/empty mapped to
+      // loopback), never a hardcoded 127.0.0.1 that would false-fail a bus bound to
+      // a specific non-loopback address. RESIDUAL: a listening client port proves
+      // the process is up + accepting, not that JetStream fully recovered — but it
       // catches the "nats-server crashed on the new config" case the slice targets.
       if (base === undefined) {
         if (configText === undefined) {
@@ -619,35 +639,20 @@ export function buildNatsCanaryAdapter(
           // absent/unreadable) — disclosed fallback to inconclusive-healthy.
           return { healthy: true, inconclusive: true };
         }
-        const port = natsConfigClientListenPort(configText) ?? NATS_DEFAULT_CLIENT_PORT;
-        const connected = await tcpConnect("127.0.0.1", port, timeoutMs);
+        const listen = natsConfigClientListen(configText);
+        const host = connectHostForListen(listen?.host ?? "");
+        const port = listen?.port ?? NATS_DEFAULT_CLIENT_PORT;
+        const connected = await tcpConnect(host, port, timeoutMs);
         return connected
           ? { healthy: true }
           : {
               healthy: false,
-              reason: `bus client port 127.0.0.1:${port.toString()} not accepting connections after restart (no HTTP monitor to probe; TCP connect failed)`,
+              reason: `bus client port ${host}:${port.toString()} not accepting connections after restart (no HTTP monitor to probe; TCP connect failed)`,
             };
       }
-      try {
-        const res = await fetch(`${base.replace(/\/+$/, "")}/healthz`, {
-          signal: AbortSignal.timeout(timeoutMs),
-        });
-        if (!res.ok) {
-          return {
-            healthy: false,
-            reason: `nats-server monitor ${base}/healthz returned HTTP ${res.status.toString()}`,
-          };
-        }
-        return { healthy: true };
-      } catch (err) {
-        const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
-        return {
-          healthy: false,
-          reason: isTimeout
-            ? `nats-server monitor ${base}/healthz timed out after ${timeoutMs.toString()}ms (accepted the connection but never responded — bus hung)`
-            : `nats-server monitor ${base} unreachable: ${err instanceof Error ? err.message : String(err)}`,
-        };
-      }
+      // cortex#1495 v3 — shared `/healthz` fetch+timeout+error-map (join + make-live
+      // call the ONE helper so their probe bodies can't drift).
+      return probeHealthzMonitor(base, timeoutMs);
     },
   };
 }

--- a/src/cli/cortex/commands/network-make-live-lib.ts
+++ b/src/cli/cortex/commands/network-make-live-lib.ts
@@ -56,6 +56,12 @@
  */
 
 import type { OperatorModeLeafPackage, NatsBaseIdentity } from "../../../common/nats/leaf-remote-renderer";
+import {
+  probeHealthWithSettle,
+  realClock,
+  type ClockPort,
+  type SettleWindowOptions,
+} from "../../../common/nats/restart-with-settle";
 
 // =============================================================================
 // Ports
@@ -164,6 +170,47 @@ export interface MakeLiveConfigWritePort {
     | { ok: false; reason: string };
 }
 
+/**
+ * cortex#1483 (join-4) — a snapshot of `natsConfigPath`'s bytes (or absence),
+ * taken BEFORE the resolver/bootstrap mutation, so a restart that leaves the
+ * bus unhealthy can be rolled back to EXACTLY the pre-make-live state.
+ */
+export interface NatsConfigSnapshot {
+  natsConfigPath: string;
+  /** The prior file contents, or `undefined` if the file did not exist. */
+  contents: string | undefined;
+}
+
+/**
+ * cortex#1483 (join-4, epic #1479) — the CANARY safety port wrapping
+ * make-live's nats-server restart: validate-before-reload, snapshot-before-
+ * mutate, health-verify-after-restart (via {@link probeHealthWithSettle}),
+ * restore-on-genuine-failure. Kills two bugs: a hand-edit or a bad canary
+ * render taking a live public stack down with no recovery, and a restart
+ * whose success was trusted by EXIT CODE alone (`launchctl kickstart`/
+ * `systemctl restart` returning 0 while nats-server then crashes on the new
+ * config at runtime).
+ *
+ * OPTIONAL on {@link MakeLivePorts}: absent ⇒ the pre-#1483 behaviour
+ * (`restartNats`'s exit code trusted as-is, no validate/snapshot/rollback) —
+ * kept for callers/tests that predate this slice.
+ */
+export interface NatsCanaryPort {
+  /**
+   * `nats-server -c <natsConfigPath> -t` — the syntax gate. Reload the
+   * resolver/bootstrap change onto the live bus ONLY when this passes. A
+   * missing `nats-server` binary is SKIPPED (returns ok) rather than blocking
+   * make-live on a machine where the test tool isn't installed.
+   */
+  validateConfig(natsConfigPath: string): Promise<{ ok: true } | { ok: false; reason: string }>;
+  /** Pure READ: capture `natsConfigPath`'s current bytes (or absence). Taken BEFORE any mutation. */
+  snapshot(natsConfigPath: string): NatsConfigSnapshot;
+  /** Restore `natsConfigPath` to exactly the snapshotted bytes (or delete it if it did not exist). */
+  restore(snapshot: NatsConfigSnapshot): void;
+  /** A single post-restart health probe (e.g. the config's own monitor `/healthz`). */
+  isHealthy(natsConfigPath: string): Promise<{ healthy: true } | { healthy: false; reason: string }>;
+}
+
 export interface MakeLivePorts {
   creds: CredsMintPort;
   accountExport: AccountExportPort;
@@ -175,6 +222,23 @@ export interface MakeLivePorts {
    * predate it; only `deriveMakeLiveInputs` + `buildLiveMakeLivePorts` supply it).
    */
   configWrite?: MakeLiveConfigWritePort;
+  /**
+   * cortex#1483 (join-4) — OPTIONAL: the canary safety wrapper around the nats
+   * restart (validate/snapshot/health/rollback). Absent ⇒ pre-#1483 behaviour.
+   */
+  natsCanary?: NatsCanaryPort;
+  /**
+   * cortex#1483 (join-4) — settle-window tuning for the post-restart health
+   * verdict (see {@link probeHealthWithSettle}). Only consulted when
+   * {@link MakeLivePorts.natsCanary} is wired. Absent ⇒
+   * {@link probeHealthWithSettle}'s own sane defaults.
+   */
+  settle?: SettleWindowOptions;
+  /**
+   * cortex#1483 (join-4) — injectable wall-clock wait for the settle-window
+   * backoff delays. Absent ⇒ the real `setTimeout`-backed clock.
+   */
+  clock?: ClockPort;
 }
 
 // =============================================================================
@@ -446,6 +510,16 @@ export async function makeLiveStack(
   // post-hoc record shows exactly which services were restarted).
   const steps: string[] = [...targetLines];
 
+  // cortex#1483 (join-4) — CANARY safety: snapshot the nats config BEFORE any
+  // mutation (bootstrap/resolver) so a restart that leaves the bus unhealthy
+  // can be rolled back to EXACTLY the pre-make-live bytes. A pure READ, taken
+  // only when a nats restart will actually happen AND a canary port is wired
+  // (opt-in — absent ⇒ pre-#1483 behaviour, no snapshot/validate/rollback).
+  const natsSnapshot =
+    natsRestartNeeded && ports.natsCanary !== undefined
+      ? ports.natsCanary.snapshot(inputs.natsConfigPath)
+      : undefined;
+
   // 0. (cortex#1265) Bootstrap the operator-mode skeleton when the bus has no
   //    resolver_preload yet — renders operator + resolver: MEMORY + the federation
   //    account, KEEPING the bus's own server_name/listen/http. The agents account
@@ -518,9 +592,92 @@ export async function makeLiveStack(
   //    `--force`): a `--force` re-mint over an already-present account must not
   //    hard-restart a (potentially shared) nats-server for a no-op resolver.
   if (resolverChanged) {
-    const r = await ports.restart.restartNats(inputs.natsConfigPath);
-    if (!r.ok) return fail(plan, steps, `nats-server restart failed: ${r.reason}`);
-    steps.push(`nats-server restarted (loaded ${inputs.agentsAccountName} into MEMORY resolver)`);
+    const canary = ports.natsCanary;
+
+    // cortex#1483 (join-4) — VALIDATE-BEFORE-RELOAD: `nats-server -c <conf> -t`.
+    // Reload the resolver/bootstrap change onto the LIVE bus ONLY when it
+    // validates. Never-throws contract: validateConfig ultimately shells out
+    // (Bun.spawn throws synchronously on ENOENT), so guard the call.
+    if (canary !== undefined) {
+      let validated: { ok: true } | { ok: false; reason: string };
+      try {
+        validated = await canary.validateConfig(inputs.natsConfigPath);
+      } catch (err) {
+        validated = {
+          ok: false,
+          reason: `nats-server config validation could not run: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+      if (!validated.ok) {
+        if (natsSnapshot !== undefined) canary.restore(natsSnapshot);
+        return fail(
+          plan,
+          steps,
+          `nats-server config validation (-t) failed before restart, refusing to restart ` +
+            `(reverted the resolver_preload/bootstrap write): ${validated.reason}`,
+        );
+      }
+    }
+
+    // cortex#1483 (join-4) — restart, then a SETTLE-WINDOW health verdict (not a
+    // single immediate probe — see restart-with-settle.ts for why). Absent a
+    // canary port, the restart's exit code is trusted as-is (pre-#1483).
+    const restartAndProbe = async (): Promise<{ ok: true } | { ok: false; reason: string }> => {
+      try {
+        const r = await ports.restart.restartNats(inputs.natsConfigPath);
+        if (!r.ok) return r;
+        if (canary === undefined) return { ok: true };
+        const settled = await probeHealthWithSettle(
+          () => canary.isHealthy(inputs.natsConfigPath),
+          ports.settle,
+          ports.clock ?? realClock,
+        );
+        if (!settled.healthy) {
+          return {
+            ok: false,
+            reason:
+              `nats-server did not come back up after restart across ${settled.attempts.toString()} ` +
+              `health check(s) over the settle window (${settled.reason ?? "unknown"})`,
+          };
+        }
+        return { ok: true };
+      } catch (err) {
+        return {
+          ok: false,
+          reason: `nats-server restart/probe could not run: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    };
+
+    const initial = await restartAndProbe();
+    if (!initial.ok) {
+      // cortex#1483 (join-4) — AUTO-ROLLBACK: restore the pre-mutation snapshot
+      // and re-restart, health-probing the RECOVERY restart too (never trust its
+      // exit code alone — a recovery that exits 0 but leaves the bus down must
+      // still report failure, mirroring join's #821 rollback).
+      let rollbackNote: string;
+      if (natsSnapshot !== undefined && canary !== undefined) {
+        try {
+          canary.restore(natsSnapshot);
+          const recovery = await restartAndProbe();
+          rollbackNote = recovery.ok
+            ? "rolled back nats config + restarted (bus restored to prior state, verified healthy)"
+            : `rolled back nats config but the recovery restart did NOT bring the bus back up (${recovery.reason}) — bus may be DOWN, intervene manually`;
+        } catch (err) {
+          rollbackNote = `rollback FAILED (${err instanceof Error ? err.message : String(err)}) — bus may be DOWN, intervene manually`;
+        }
+      } else {
+        rollbackNote =
+          "no canary snapshot available (natsCanary port not wired) — could not roll back " +
+          "automatically; bus may be DOWN, intervene manually";
+      }
+      steps.push(`WARN: ${rollbackNote}`);
+      return fail(plan, steps, `nats-server restart failed (${initial.reason}); ${rollbackNote}`);
+    }
+    steps.push(
+      `nats-server restarted (loaded ${inputs.agentsAccountName} into MEMORY resolver` +
+        `${canary !== undefined ? ", verified healthy" : ""})`,
+    );
   }
 
   // 3. Mint the daemon's bus creds under the agents account (server now knows it).

--- a/src/cli/cortex/commands/network-make-live-lib.ts
+++ b/src/cli/cortex/commands/network-make-live-lib.ts
@@ -71,6 +71,7 @@ import {
   probeHealthWithSettle,
   realClock,
   settleFailureReason,
+  INCONCLUSIVE_HEALTH_NOTICE,
   type ClockPort,
   type ConfigValidationOutcome,
   type HealthProbeResult,
@@ -667,6 +668,16 @@ export async function makeLiveStack(
     // errors to typed results), matching the ports-don't-throw convention every
     // other step in makeLiveStack already relies on (mint/export/append). The one
     // guard that IS load-bearing — the rollback restore — is kept below.
+    //
+    // cortex#1495 v2 (suggestion) — this restart→settle-probe→rollback shape
+    // PARALLELS join's `restartAndProbe` in network-lib.ts. They are deliberately
+    // NOT extracted into one helper: the shared CORE already lives in
+    // `probeHealthWithSettle` + `settleFailureReason` + `INCONCLUSIVE_HEALTH_NOTICE`,
+    // and the surrounding orchestration differs materially (join restores LEAF
+    // state + threads warnings/network/usedCache into a JoinResult; make-live
+    // restores the WHOLE nats config into a MakeLiveResult). A further helper would
+    // need callbacks for restart/restore/result-shape and add coupling for little
+    // gain, so the parallel is documented rather than abstracted.
     const restartAndProbe = async (): Promise<
       { ok: true; inconclusive: boolean } | { ok: false; reason: string }
     > => {
@@ -699,7 +710,7 @@ export async function makeLiveStack(
           canary.restore(natsSnapshot);
           const recovery = await restartAndProbe();
           rollbackNote = recovery.ok
-            ? `rolled back nats config + restarted (bus restored to prior state, ${recovery.inconclusive ? "health inconclusive — no monitor configured, treated as healthy per #831" : "verified healthy"})`
+            ? `rolled back nats config + restarted (bus restored to prior state, ${recovery.inconclusive ? INCONCLUSIVE_HEALTH_NOTICE : "verified healthy"})`
             : `rolled back nats config but the recovery restart did NOT bring the bus back up (${recovery.reason}) — bus may be DOWN, intervene manually`;
         } catch (err) {
           rollbackNote = `rollback FAILED (${err instanceof Error ? err.message : String(err)}) — bus may be DOWN, intervene manually`;
@@ -714,7 +725,7 @@ export async function makeLiveStack(
     }
     steps.push(
       `nats-server restarted (loaded ${inputs.agentsAccountName} into MEMORY resolver` +
-        `${canary === undefined ? "" : initial.inconclusive ? ", health inconclusive — no monitor configured, treated as healthy per #831" : ", verified healthy"})`,
+        `${canary === undefined ? "" : initial.inconclusive ? `, ${INCONCLUSIVE_HEALTH_NOTICE}` : ", verified healthy"})`,
     );
   }
 

--- a/src/cli/cortex/commands/network-make-live-lib.ts
+++ b/src/cli/cortex/commands/network-make-live-lib.ts
@@ -53,13 +53,27 @@
  * Dry-run (the DEFAULT-safe posture) computes the plan from config + filesystem
  * and mutates NOTHING. `--apply` executes mint → resolver → nats restart →
  * daemon restart, fail-fast (any port failure aborts and surfaces how far it got).
+ *
+ * ## Restart safety (cortex#1483 join-4)
+ *
+ * When a {@link NatsCanaryPort} is wired, the nats-server restart is GUARDED —
+ * validate-before-reload (`-t`), snapshot-before-mutate, settle-window
+ * health-verify, and auto-rollback on a genuinely-unhealthy bus. This makes the
+ * common ways a live public bus goes down RECOVERABLE and LOUD; it is NOT an
+ * absolute "crash-proof" guarantee (cortex#1495): on a host without
+ * `nats-server` on PATH the `-t` gate cannot run — it is SKIPPED with a loud
+ * warning, not a silent pass — and the hub-side SIGHUP reload path is out of
+ * this slice's scope.
  */
 
 import type { OperatorModeLeafPackage, NatsBaseIdentity } from "../../../common/nats/leaf-remote-renderer";
 import {
   probeHealthWithSettle,
   realClock,
+  settleFailureReason,
   type ClockPort,
+  type ConfigValidationOutcome,
+  type HealthProbeResult,
   type SettleWindowOptions,
 } from "../../../common/nats/restart-with-settle";
 
@@ -182,14 +196,20 @@ export interface NatsConfigSnapshot {
 }
 
 /**
- * cortex#1483 (join-4, epic #1479) — the CANARY safety port wrapping
- * make-live's nats-server restart: validate-before-reload, snapshot-before-
- * mutate, health-verify-after-restart (via {@link probeHealthWithSettle}),
- * restore-on-genuine-failure. Kills two bugs: a hand-edit or a bad canary
- * render taking a live public stack down with no recovery, and a restart
- * whose success was trusted by EXIT CODE alone (`launchctl kickstart`/
- * `systemctl restart` returning 0 while nats-server then crashes on the new
- * config at runtime).
+ * cortex#1483 (join-4, epic #1479) — the CANARY safety port GUARDING make-live's
+ * nats-server restart: validate-before-reload, snapshot-before-mutate,
+ * settle-window health-verify (via {@link probeHealthWithSettle}), and
+ * auto-rollback on a genuinely-unhealthy bus. It hardens two failure modes: a
+ * hand-edit or a bad render taking a live public stack down with no recovery,
+ * and a restart whose success was trusted by EXIT CODE alone (`launchctl
+ * kickstart`/`systemctl restart` returning 0 while nats-server then crashes on
+ * the new config at runtime).
+ *
+ * cortex#1495 — this is a GUARDED/CANARIED restart, NOT an absolute
+ * "crash-proof" guarantee. Known gaps: on a host without `nats-server` on PATH
+ * the `-t` gate cannot run (SKIPPED — the caller warns loudly + proceeds), and
+ * the hub-side SIGHUP reload path (`network secret`) is out of this slice's
+ * scope. It makes the common failure modes recoverable + loud, not impossible.
  *
  * OPTIONAL on {@link MakeLivePorts}: absent ⇒ the pre-#1483 behaviour
  * (`restartNats`'s exit code trusted as-is, no validate/snapshot/rollback) —
@@ -197,18 +217,24 @@ export interface NatsConfigSnapshot {
  */
 export interface NatsCanaryPort {
   /**
-   * `nats-server -c <natsConfigPath> -t` — the syntax gate. Reload the
-   * resolver/bootstrap change onto the live bus ONLY when this passes. A
-   * missing `nats-server` binary is SKIPPED (returns ok) rather than blocking
-   * make-live on a machine where the test tool isn't installed.
+   * `nats-server -c <natsConfigPath> -t` — the syntax gate. cortex#1495 BLOCKER:
+   * returns a THREE-state {@link ConfigValidationOutcome} (valid / invalid /
+   * skipped). Reload ONLY on `valid`; refuse on `invalid`; on `skipped`
+   * (`nats-server` not on PATH / spawn failed) the caller warns LOUDLY that the
+   * gate did not run, then proceeds — never a silent fail-open pass.
    */
-  validateConfig(natsConfigPath: string): Promise<{ ok: true } | { ok: false; reason: string }>;
+  validateConfig(natsConfigPath: string): Promise<ConfigValidationOutcome>;
   /** Pure READ: capture `natsConfigPath`'s current bytes (or absence). Taken BEFORE any mutation. */
   snapshot(natsConfigPath: string): NatsConfigSnapshot;
   /** Restore `natsConfigPath` to exactly the snapshotted bytes (or delete it if it did not exist). */
   restore(snapshot: NatsConfigSnapshot): void;
-  /** A single post-restart health probe (e.g. the config's own monitor `/healthz`). */
-  isHealthy(natsConfigPath: string): Promise<{ healthy: true } | { healthy: false; reason: string }>;
+  /**
+   * A single post-restart health probe (e.g. the config's own monitor
+   * `/healthz`). cortex#1495 important 3 — the healthy variant may carry
+   * `inconclusive: true` (#831 no-monitor) so the caller logs "inconclusive,
+   * treated as healthy" rather than "verified healthy".
+   */
+  isHealthy(natsConfigPath: string): Promise<HealthProbeResult>;
 }
 
 export interface MakeLivePorts {
@@ -596,19 +622,27 @@ export async function makeLiveStack(
 
     // cortex#1483 (join-4) — VALIDATE-BEFORE-RELOAD: `nats-server -c <conf> -t`.
     // Reload the resolver/bootstrap change onto the LIVE bus ONLY when it
-    // validates. Never-throws contract: validateConfig ultimately shells out
-    // (Bun.spawn throws synchronously on ENOENT), so guard the call.
+    // validates. cortex#1495 BLOCKER — three outcomes, and a "could not
+    // validate" is NOT treated as "valid":
+    //   - invalid → restore + refuse (never crash the bus on a config we KNOW is
+    //     broken);
+    //   - skipped → the `-t` gate could not run (`nats-server` not on PATH);
+    //     WARN LOUDLY that the safety gate did not run, then proceed (so a host
+    //     without the binary isn't hard-blocked) — never a silent fail-open pass;
+    //   - valid   → proceed silently.
     if (canary !== undefined) {
-      let validated: { ok: true } | { ok: false; reason: string };
+      // The live adapter never throws (it maps spawn ENOENT to `skipped`); a
+      // stray throw is a contract violation → fail-SAFE as `invalid`/refuse.
+      let validated: ConfigValidationOutcome;
       try {
         validated = await canary.validateConfig(inputs.natsConfigPath);
       } catch (err) {
         validated = {
-          ok: false,
+          status: "invalid",
           reason: `nats-server config validation could not run: ${err instanceof Error ? err.message : String(err)}`,
         };
       }
-      if (!validated.ok) {
+      if (validated.status === "invalid") {
         if (natsSnapshot !== undefined) canary.restore(natsSnapshot);
         return fail(
           plan,
@@ -617,36 +651,37 @@ export async function makeLiveStack(
             `(reverted the resolver_preload/bootstrap write): ${validated.reason}`,
         );
       }
+      if (validated.status === "skipped") {
+        steps.push(
+          `WARN: could not run \`nats-server -t\` — ${validated.reason}; proceeding WITHOUT the ` +
+            `pre-reload validation safety gate (a broken config will not be caught before restart)`,
+        );
+      }
     }
 
     // cortex#1483 (join-4) — restart, then a SETTLE-WINDOW health verdict (not a
     // single immediate probe — see restart-with-settle.ts for why). Absent a
     // canary port, the restart's exit code is trusted as-is (pre-#1483).
-    const restartAndProbe = async (): Promise<{ ok: true } | { ok: false; reason: string }> => {
-      try {
-        const r = await ports.restart.restartNats(inputs.natsConfigPath);
-        if (!r.ok) return r;
-        if (canary === undefined) return { ok: true };
-        const settled = await probeHealthWithSettle(
-          () => canary.isHealthy(inputs.natsConfigPath),
-          ports.settle,
-          ports.clock ?? realClock,
-        );
-        if (!settled.healthy) {
-          return {
-            ok: false,
-            reason:
-              `nats-server did not come back up after restart across ${settled.attempts.toString()} ` +
-              `health check(s) over the settle window (${settled.reason ?? "unknown"})`,
-          };
-        }
-        return { ok: true };
-      } catch (err) {
-        return {
-          ok: false,
-          reason: `nats-server restart/probe could not run: ${err instanceof Error ? err.message : String(err)}`,
-        };
+    // cortex#1495 nit 2 — no local try/catch INSIDE the probe helper: the make-live
+    // restart/health ports don't throw (the live adapters map spawn ENOENT/fetch
+    // errors to typed results), matching the ports-don't-throw convention every
+    // other step in makeLiveStack already relies on (mint/export/append). The one
+    // guard that IS load-bearing — the rollback restore — is kept below.
+    const restartAndProbe = async (): Promise<
+      { ok: true; inconclusive: boolean } | { ok: false; reason: string }
+    > => {
+      const r = await ports.restart.restartNats(inputs.natsConfigPath);
+      if (!r.ok) return r;
+      if (canary === undefined) return { ok: true, inconclusive: false };
+      const settled = await probeHealthWithSettle(
+        () => canary.isHealthy(inputs.natsConfigPath),
+        ports.settle,
+        ports.clock ?? realClock,
+      );
+      if (!settled.healthy) {
+        return { ok: false, reason: settleFailureReason(settled.attempts, settled.reason) };
       }
+      return { ok: true, inconclusive: settled.inconclusive === true };
     };
 
     const initial = await restartAndProbe();
@@ -654,14 +689,17 @@ export async function makeLiveStack(
       // cortex#1483 (join-4) — AUTO-ROLLBACK: restore the pre-mutation snapshot
       // and re-restart, health-probing the RECOVERY restart too (never trust its
       // exit code alone — a recovery that exits 0 but leaves the bus down must
-      // still report failure, mirroring join's #821 rollback).
+      // still report failure, mirroring join's #821 rollback). This restore IS
+      // guarded: makeLiveStack has no outer never-throws boundary, so a throwing
+      // restore/recovery must become a clear "rollback FAILED" verdict, never an
+      // uncaught escape that leaves the bus down with no message.
       let rollbackNote: string;
       if (natsSnapshot !== undefined && canary !== undefined) {
         try {
           canary.restore(natsSnapshot);
           const recovery = await restartAndProbe();
           rollbackNote = recovery.ok
-            ? "rolled back nats config + restarted (bus restored to prior state, verified healthy)"
+            ? `rolled back nats config + restarted (bus restored to prior state, ${recovery.inconclusive ? "health inconclusive — no monitor configured, treated as healthy per #831" : "verified healthy"})`
             : `rolled back nats config but the recovery restart did NOT bring the bus back up (${recovery.reason}) — bus may be DOWN, intervene manually`;
         } catch (err) {
           rollbackNote = `rollback FAILED (${err instanceof Error ? err.message : String(err)}) — bus may be DOWN, intervene manually`;
@@ -676,7 +714,7 @@ export async function makeLiveStack(
     }
     steps.push(
       `nats-server restarted (loaded ${inputs.agentsAccountName} into MEMORY resolver` +
-        `${canary !== undefined ? ", verified healthy" : ""})`,
+        `${canary === undefined ? "" : initial.inconclusive ? ", health inconclusive — no monitor configured, treated as healthy per #831" : ", verified healthy"})`,
     );
   }
 

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -40,6 +40,7 @@ import type {
   StackLeafBinding,
 } from "../../../common/nats/leaf-remote-renderer";
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import type { ClockPort, SettleWindowOptions } from "../../../common/nats/restart-with-settle";
 
 // =============================================================================
 // Trust-boundary type — only a VERIFIED descriptor flows into the renderer.
@@ -534,4 +535,20 @@ export interface NetworkPorts {
    * join. Default: `false` (dry-run safe). Live ports set this to `true`.
    */
   apply?: boolean;
+  /**
+   * cortex#1483 (join-4) — the settle-window RETRY/BACKOFF tuning for the
+   * post-restart health verdict (see {@link probeHealthWithSettle}). Absent ⇒
+   * {@link probeHealthWithSettle}'s own sane defaults (5 attempts, 500ms→4s
+   * exponential backoff) — a single immediate probe (the pre-#1483 behaviour,
+   * and the exact #1476 gap-2 false-alarm) is no longer the default anywhere a
+   * `natsServer` port is wired. Tests inject small values so they run fast
+   * without depending on {@link NetworkPorts.clock}.
+   */
+  settle?: SettleWindowOptions;
+  /**
+   * cortex#1483 (join-4) — injectable wall-clock wait for the settle-window
+   * backoff delays. Absent ⇒ the real `setTimeout`-backed clock. Tests inject
+   * an instant clock so a multi-attempt settle window never actually sleeps.
+   */
+  clock?: ClockPort;
 }

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -40,7 +40,12 @@ import type {
   StackLeafBinding,
 } from "../../../common/nats/leaf-remote-renderer";
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
-import type { ClockPort, SettleWindowOptions } from "../../../common/nats/restart-with-settle";
+import type {
+  ClockPort,
+  ConfigValidationOutcome,
+  HealthProbeResult,
+  SettleWindowOptions,
+} from "../../../common/nats/restart-with-settle";
 
 // =============================================================================
 // Trust-boundary type — only a VERIFIED descriptor flows into the renderer.
@@ -344,10 +349,19 @@ export interface NatsServerPort {
    * leaf-remote's account against the account tree, so it PASSED for the original
    * #821 crash. It is therefore NECESSARY-NOT-SUFFICIENT: a cheap extra gate
    * layered ON TOP of the account-required + creds-exist + health-probe defenses,
-   * never the primary defense. A dry-run is inert (returns ok). When `nats-server`
-   * is not on PATH the gate is SKIPPED (returns ok) rather than blocking the join.
+   * never the primary defense.
+   *
+   * cortex#1495 BLOCKER — returns a THREE-state {@link ConfigValidationOutcome}:
+   *   - `valid`   — `-t` exited 0 (or dry-run / no config to test): reload safe.
+   *   - `invalid` — `-t` exited non-zero: the config IS broken → the caller
+   *     refuses the reload (never crash the bus on a config we know is bad).
+   *   - `skipped` — could NOT validate (`nats-server` not on PATH / spawn
+   *     failed). This is NOT "valid" — the caller must warn LOUDLY that the gate
+   *     did not run, then proceed (so hosts without the binary aren't hard-blocked)
+   *     rather than silently pass. The pre-#1495 code returned `ok:true` here,
+   *     which fail-OPEN let a bad config reload onto a live bus.
    */
-  validateConfig(): Promise<{ ok: true } | { ok: false; reason: string }>;
+  validateConfig(): Promise<ConfigValidationOutcome>;
   /**
    * #821 — restart-safety HEALTH PROBE. After a restart, confirm nats-server
    * actually came back UP (its monitor port is listening / the process is
@@ -364,8 +378,12 @@ export interface NatsServerPort {
    * would additionally poll `/leafz` for the expected remote (the C-797
    * leaf-state surface). Tracked as a follow-up; liveness is sufficient to catch
    * the #821 crash (a crashed server fails `/healthz`).
+   *
+   * cortex#1495 important 3 — the `{ healthy: true }` variant may carry
+   * `inconclusive: true` for the #831 no-monitor case, so the caller's step log
+   * can say "inconclusive, treated as healthy" instead of "verified healthy".
    */
-  isHealthy(): Promise<{ healthy: true } | { healthy: false; reason: string }>;
+  isHealthy(): Promise<HealthProbeResult>;
 }
 
 /**

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -22,7 +22,7 @@ import type { NetworkDescriptor } from "../../registry/types";
 import {
   natsConfigHasAccountTree,
   natsConfigMonitorUrl,
-  natsConfigClientListenPort,
+  natsConfigClientListen,
   leafIncludeFileName,
   mergeLeafRemotes,
   renderLeafIncludeFile,
@@ -526,42 +526,60 @@ describe("#821 natsConfigMonitorUrl", () => {
   });
 });
 
-describe("cortex#1495 v2 natsConfigClientListenPort", () => {
-  test("derives from `listen: 127.0.0.1:4222` (host:port)", () => {
-    expect(natsConfigClientListenPort("listen: 127.0.0.1:4222\n")).toBe(4222);
+describe("cortex#1495 v2/v3 natsConfigClientListen", () => {
+  test("derives host+port from `listen: 127.0.0.1:4222`", () => {
+    expect(natsConfigClientListen("listen: 127.0.0.1:4222\n")).toEqual({ host: "127.0.0.1", port: 4222 });
   });
 
-  test("derives from `listen: \"0.0.0.0:4299\"` (quoted host:port)", () => {
-    expect(natsConfigClientListenPort('listen: "0.0.0.0:4299"\n')).toBe(4299);
+  test("derives host+port from `listen: 10.0.0.5:4222` (v3: keep the NON-loopback host)", () => {
+    expect(natsConfigClientListen("listen: 10.0.0.5:4222\n")).toEqual({ host: "10.0.0.5", port: 4222 });
   });
 
-  test("derives from a bare `listen: 4300` (port only)", () => {
-    expect(natsConfigClientListenPort("listen: 4300\n")).toBe(4300);
+  test("derives from `listen: \"0.0.0.0:4299\"` (quoted, wildcard host kept RAW)", () => {
+    expect(natsConfigClientListen('listen: "0.0.0.0:4299"\n')).toEqual({ host: "0.0.0.0", port: 4299 });
   });
 
-  test("derives from the top-level `port: 4224` directive", () => {
-    expect(natsConfigClientListenPort("port: 4224\nhttp_port: 8224\n")).toBe(4224);
+  test("derives from bracketed IPv6 `listen: [::]:4222`", () => {
+    expect(natsConfigClientListen("listen: [::]:4222\n")).toEqual({ host: "::", port: 4222 });
+  });
+
+  test("derives from bracketed IPv6 with a real addr `listen: [2001:db8::1]:4222`", () => {
+    expect(natsConfigClientListen("listen: [2001:db8::1]:4222\n")).toEqual({ host: "2001:db8::1", port: 4222 });
+  });
+
+  test("a bare `listen: 4300` yields an empty host (caller defaults it)", () => {
+    expect(natsConfigClientListen("listen: 4300\n")).toEqual({ host: "", port: 4300 });
+  });
+
+  test("derives from the split `host:`/`port:` directive form", () => {
+    expect(natsConfigClientListen("host: 10.0.0.9\nport: 4224\nhttp_port: 8224\n")).toEqual({
+      host: "10.0.0.9",
+      port: 4224,
+    });
+  });
+
+  test("a bare `port: 4224` (no host directive) yields an empty host", () => {
+    expect(natsConfigClientListen("port: 4224\nhttp_port: 8224\n")).toEqual({ host: "", port: 4224 });
   });
 
   test("`listen:` wins over `port:` when both are present", () => {
-    expect(natsConfigClientListenPort("listen: 127.0.0.1:4222\nport: 9999\n")).toBe(4222);
+    expect(natsConfigClientListen("listen: 127.0.0.1:4222\nport: 9999\n")).toEqual({ host: "127.0.0.1", port: 4222 });
   });
 
   test("`http_port` / `monitor_port` never false-match the client `port:` parse", () => {
-    // Only a MONITOR port is declared — no client listen/port → undefined.
-    expect(natsConfigClientListenPort("http_port: 8222\nmonitor_port: 8223\n")).toBeUndefined();
+    expect(natsConfigClientListen("http_port: 8222\nmonitor_port: 8223\n")).toBeUndefined();
   });
 
   test("a COMMENTED-OUT listen/port does NOT count", () => {
-    expect(natsConfigClientListenPort("// listen: 4222\n# port: 4223\n")).toBeUndefined();
+    expect(natsConfigClientListen("// listen: 4222\n# port: 4223\n")).toBeUndefined();
   });
 
   test("tolerates an inline trailing comment on `listen:`", () => {
-    expect(natsConfigClientListenPort("listen: 127.0.0.1:4222 # client\n")).toBe(4222);
+    expect(natsConfigClientListen("listen: 127.0.0.1:4222 # client\n")).toEqual({ host: "127.0.0.1", port: 4222 });
   });
 
-  test("no listen/port directive → undefined (caller applies the 4222 default)", () => {
-    expect(natsConfigClientListenPort("server_name: work\n")).toBeUndefined();
+  test("no listen/port directive → undefined (caller applies the 127.0.0.1:4222 default)", () => {
+    expect(natsConfigClientListen("server_name: work\n")).toBeUndefined();
   });
 });
 

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -22,6 +22,7 @@ import type { NetworkDescriptor } from "../../registry/types";
 import {
   natsConfigHasAccountTree,
   natsConfigMonitorUrl,
+  natsConfigClientListenPort,
   leafIncludeFileName,
   mergeLeafRemotes,
   renderLeafIncludeFile,
@@ -522,6 +523,45 @@ describe("#821 natsConfigMonitorUrl", () => {
       "",
     ].join("\n");
     expect(natsConfigMonitorUrl(community)).toBe("http://127.0.0.1:8224");
+  });
+});
+
+describe("cortex#1495 v2 natsConfigClientListenPort", () => {
+  test("derives from `listen: 127.0.0.1:4222` (host:port)", () => {
+    expect(natsConfigClientListenPort("listen: 127.0.0.1:4222\n")).toBe(4222);
+  });
+
+  test("derives from `listen: \"0.0.0.0:4299\"` (quoted host:port)", () => {
+    expect(natsConfigClientListenPort('listen: "0.0.0.0:4299"\n')).toBe(4299);
+  });
+
+  test("derives from a bare `listen: 4300` (port only)", () => {
+    expect(natsConfigClientListenPort("listen: 4300\n")).toBe(4300);
+  });
+
+  test("derives from the top-level `port: 4224` directive", () => {
+    expect(natsConfigClientListenPort("port: 4224\nhttp_port: 8224\n")).toBe(4224);
+  });
+
+  test("`listen:` wins over `port:` when both are present", () => {
+    expect(natsConfigClientListenPort("listen: 127.0.0.1:4222\nport: 9999\n")).toBe(4222);
+  });
+
+  test("`http_port` / `monitor_port` never false-match the client `port:` parse", () => {
+    // Only a MONITOR port is declared — no client listen/port → undefined.
+    expect(natsConfigClientListenPort("http_port: 8222\nmonitor_port: 8223\n")).toBeUndefined();
+  });
+
+  test("a COMMENTED-OUT listen/port does NOT count", () => {
+    expect(natsConfigClientListenPort("// listen: 4222\n# port: 4223\n")).toBeUndefined();
+  });
+
+  test("tolerates an inline trailing comment on `listen:`", () => {
+    expect(natsConfigClientListenPort("listen: 127.0.0.1:4222 # client\n")).toBe(4222);
+  });
+
+  test("no listen/port directive → undefined (caller applies the 4222 default)", () => {
+    expect(natsConfigClientListenPort("server_name: work\n")).toBeUndefined();
   });
 });
 

--- a/src/common/nats/config-backup.ts
+++ b/src/common/nats/config-backup.ts
@@ -9,34 +9,55 @@
  * two mechanisms don't cover every config-mutating write, and an in-process
  * snapshot does not survive the process exiting. {@link backupConfigFile} is
  * the ONE shared helper so every config write this slice touches gets the
- * SAME timestamped, same-directory, permission-preserving recovery artefact —
- * independent of, and in addition to, any in-memory rollback.
+ * SAME timestamped, same-directory recovery artefact — independent of, and in
+ * addition to, any in-memory rollback.
+ *
+ * cortex#1495 important 2 — the backup carries SECRET-bearing config (leaf
+ * creds, hub authorization users, payload keys). It is created 0600 from the
+ * first byte (write with `mode: 0o600` + an explicit chmod against a permissive
+ * umask), NOT `copyFileSync`-then-`chmod` (which would leave a world-readable
+ * window while the file inherits the default create mode before the narrowing
+ * chmod). The backup is never more permissive than the secret it protects.
  */
 
-import { chmodSync, copyFileSync, existsSync, statSync } from "fs";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "fs";
 
 /**
- * Write a timestamped `.bak-<label>-<epochMillis>` sidecar of `path` BEFORE a
- * config mutation. No-op (returns `undefined`) when `path` does not exist yet
- * — nothing to back up (a fresh file has no prior state to protect). Mirrors
- * the file's own permission bits onto the backup (relevant for a 0600
- * secret-bearing config) — a best-effort mirror; a failure to chmod the backup
- * is logged but never blocks the backup itself (the backup's CONTENT, already
- * copied, is what matters for recovery).
+ * cortex#1495 nit 3 — a monotonic per-process counter so two backups taken in
+ * the SAME millisecond never collide on the same filename (the pre-fix
+ * `Date.now()`-only name could). Combined with the pid it is unique across
+ * concurrent processes too.
+ */
+let backupSeq = 0;
+
+/**
+ * Write a timestamped `.bak-<label>-<epochMillis>-<pid>-<seq>` sidecar of `path`
+ * BEFORE a config mutation, created 0600 (secret-safe). No-op (returns
+ * `undefined`) when `path` does not exist yet — nothing to back up (a fresh file
+ * has no prior state to protect). NEVER throws: the caller's write must proceed
+ * even if the backup itself failed (a failure is logged and surfaced by the
+ * `undefined` return).
  */
 export function backupConfigFile(path: string, label: string): string | undefined {
   if (!existsSync(path)) return undefined;
-  const backupPath = `${path}.bak-${label}-${Date.now().toString()}`;
-  copyFileSync(path, backupPath);
+  // Unique even for same-millisecond / concurrent-process writes (nit 3).
+  const suffix = `${Date.now().toString()}-${process.pid.toString()}-${(backupSeq++).toString()}`;
+  const backupPath = `${path}.bak-${label}-${suffix}`;
   try {
-    const mode = statSync(path).mode;
-    chmodSync(backupPath, mode & 0o777);
+    // important 2 — create the backup 0600 ATOMICALLY with the write (never
+    // copy-then-chmod). `writeFileSync`'s create mode is masked by the umask, so
+    // chmod back to 0600 to be robust against a permissive umask (mirrors the
+    // leaf-include 0600 discipline in network-adapters.ts).
+    const data = readFileSync(path);
+    writeFileSync(backupPath, data, { mode: 0o600 });
+    chmodSync(backupPath, 0o600);
   } catch (err) {
-    // Best-effort permission mirror — the backup's content is already safe on
-    // disk; a chmod failure here must never abort the caller's write.
+    // Best-effort — the caller's config write must proceed even if the backup
+    // failed. Surface it so the caller knows the recovery artefact is missing.
     process.stderr.write(
-      `config-backup: could not mirror permissions onto ${backupPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+      `config-backup: could not write backup ${backupPath}: ${err instanceof Error ? err.message : String(err)}\n`,
     );
+    return undefined;
   }
   return backupPath;
 }

--- a/src/common/nats/config-backup.ts
+++ b/src/common/nats/config-backup.ts
@@ -1,0 +1,42 @@
+/**
+ * cortex#1483 (join-4, epic #1479) — the shared `.bak` sidecar helper for a
+ * live nats-server config mutation.
+ *
+ * A hand-edit or a bad canary render can take a live, often public-facing,
+ * operator-mode bus down. `join`'s leaf-state snapshot/restore (#821) already
+ * gives an IN-PROCESS rollback path, and `make-live` already writes
+ * `.bak-makelive-<ts>` sidecars for its own resolver/creds writes — but those
+ * two mechanisms don't cover every config-mutating write, and an in-process
+ * snapshot does not survive the process exiting. {@link backupConfigFile} is
+ * the ONE shared helper so every config write this slice touches gets the
+ * SAME timestamped, same-directory, permission-preserving recovery artefact —
+ * independent of, and in addition to, any in-memory rollback.
+ */
+
+import { chmodSync, copyFileSync, existsSync, statSync } from "fs";
+
+/**
+ * Write a timestamped `.bak-<label>-<epochMillis>` sidecar of `path` BEFORE a
+ * config mutation. No-op (returns `undefined`) when `path` does not exist yet
+ * — nothing to back up (a fresh file has no prior state to protect). Mirrors
+ * the file's own permission bits onto the backup (relevant for a 0600
+ * secret-bearing config) — a best-effort mirror; a failure to chmod the backup
+ * is logged but never blocks the backup itself (the backup's CONTENT, already
+ * copied, is what matters for recovery).
+ */
+export function backupConfigFile(path: string, label: string): string | undefined {
+  if (!existsSync(path)) return undefined;
+  const backupPath = `${path}.bak-${label}-${Date.now().toString()}`;
+  copyFileSync(path, backupPath);
+  try {
+    const mode = statSync(path).mode;
+    chmodSync(backupPath, mode & 0o777);
+  } catch (err) {
+    // Best-effort permission mirror — the backup's content is already safe on
+    // disk; a chmod failure here must never abort the caller's write.
+    process.stderr.write(
+      `config-backup: could not mirror permissions onto ${backupPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+  return backupPath;
+}

--- a/src/common/nats/healthz-probe.ts
+++ b/src/common/nats/healthz-probe.ts
@@ -1,0 +1,44 @@
+/**
+ * cortex#1495 v3 (suggestion) — the ONE nats-server `/healthz` monitor probe,
+ * shared by both nats restart-safety adapters (`network-adapters.ts`
+ * `buildNatsServerPort.isHealthy` for join, `network-make-live-adapters.ts`
+ * `buildNatsCanaryAdapter.isHealthy` for make-live) so the fetch + timeout +
+ * error-mapping body can't drift between them.
+ *
+ * A bounded `fetch` of `<base>/healthz`: a 200 is healthy; a non-200 or a
+ * connect error is unhealthy; a TimeoutError (the monitor accepted the TCP
+ * connection but never responded — a hung/deadlocked nats-server) is unhealthy
+ * with a distinct, actionable reason. NEVER throws.
+ */
+
+import type { HealthProbeResult } from "./restart-with-settle";
+
+/**
+ * Probe `<base>/healthz` with a `timeoutMs` bound (`base` is the monitor URL,
+ * e.g. `http://127.0.0.1:8222`; a trailing slash is tolerated). Returns
+ * `{ healthy: true }` on a 200, else `{ healthy: false, reason }`.
+ */
+export async function probeHealthzMonitor(base: string, timeoutMs: number): Promise<HealthProbeResult> {
+  const clean = base.replace(/\/+$/, "");
+  try {
+    const res = await fetch(`${clean}/healthz`, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) {
+      return {
+        healthy: false,
+        reason: `nats-server monitor ${clean}/healthz returned HTTP ${res.status.toString()}`,
+      };
+    }
+    return { healthy: true };
+  } catch (err) {
+    // A timeout/abort means the monitor accepted but did not respond in time —
+    // the bus is hung, NOT healthy. A connection error means it's down or the
+    // port isn't listening. Distinguish the timeout for an actionable reason.
+    const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
+    return {
+      healthy: false,
+      reason: isTimeout
+        ? `nats-server monitor ${clean}/healthz timed out after ${timeoutMs.toString()}ms (accepted the connection but never responded — bus hung)`
+        : `nats-server monitor ${clean} unreachable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -1191,34 +1191,80 @@ export function natsConfigMonitorUrl(natsConfigText: string): string | undefined
 }
 
 /**
- * cortex#1495 v2 (important 2) — parse the nats-server CLIENT listen PORT from a
- * config, so a bus with NO HTTP monitor can still be liveness-probed by a plain
- * TCP connect to its client port (the #1476 community bus class: no `http_port`,
- * so the `/healthz` probe was inconclusive and auto-rollback went inert). Order:
- *   1. `listen: <host:port | port>` (the explicit client listen directive), then
- *   2. `port: <n>` (the top-level client-port directive).
- * Returns the port, or `undefined` when neither is present (the caller then
- * applies the NATS default 4222, or — if the config is unreadable — falls back to
- * the inconclusive-healthy disclosure). Comments are stripped first; only a
- * line-anchored `port` matches, so `http_port`/`monitor_port` never false-hit.
+ * cortex#1495 v2/v3 — the parsed nats-server CLIENT listen address (HOST + PORT).
+ * `host` is the RAW host as written in the config (`""` when only a bare port was
+ * given); the caller maps a wildcard/empty host to the right loopback for the
+ * connect (v3 important: probing a hardcoded `127.0.0.1` would false-rollback a
+ * bus that listens on a specific non-loopback address like `10.0.0.5:4222`).
  */
-export function natsConfigClientListenPort(natsConfigText: string): number | undefined {
+export interface NatsClientListen {
+  /** Raw listen host (`10.0.0.5`, `0.0.0.0`, `::`, `localhost`, or `""` for a bare port). */
+  host: string;
+  /** Client listen port. */
+  port: number;
+}
+
+/**
+ * cortex#1495 v2/v3 — parse the nats-server CLIENT listen HOST+PORT from a config,
+ * so a bus with NO HTTP monitor can still be liveness-probed by a plain TCP
+ * connect to its client listen address (the #1476 community bus class: no
+ * `http_port`, so the `/healthz` probe was inconclusive and auto-rollback went
+ * inert). Order:
+ *   1. `listen: <host:port | [ipv6]:port | port>` (the explicit listen directive), then
+ *   2. `port: <n>` (+ optional top-level `host:`) — the split-directive form.
+ * Returns `{ host, port }`, or `undefined` when neither is present (the caller
+ * then applies the NATS default `127.0.0.1:4222`, or — if the config is unreadable
+ * — falls back to the inconclusive-healthy disclosure). Comments are stripped
+ * first; only a line-anchored `port`/`host` matches, so `http_port`/`monitor_port`
+ * never false-hit.
+ */
+export function natsConfigClientListen(natsConfigText: string): NatsClientListen | undefined {
   const text = stripConfigComments(natsConfigText);
 
-  // `listen: <value>` — value may be `host:port` (`0.0.0.0:4222`), a bare port,
-  // or quoted, optionally with an inline trailing comment. Take the trailing port.
+  // `listen: <value>` — value may be `host:port` (`10.0.0.5:4222`), bracketed
+  // IPv6 (`[::]:4222`), a bare port, or quoted, optionally with an inline comment.
   const listen = /^[ \t]*listen[ \t]*[:=][ \t]*(.+)$/m.exec(text);
   if (listen?.[1] !== undefined) {
     const value = stripInlineComment(listen[1]).replace(/["']/g, "").trim();
-    const portMatch = /(?::|^)(\d{1,5})$/.exec(value);
-    if (portMatch?.[1] !== undefined) return Number.parseInt(portMatch[1], 10);
+    const hp = splitHostPort(value);
+    if (hp !== undefined) return hp;
   }
 
   // `port: <n>` — the top-level client-port directive (line-anchored so it never
-  // matches `http_port`/`monitor_port`, which start with a different token).
+  // matches `http_port`/`monitor_port`, which start with a different token). Pair
+  // it with an optional top-level `host:` directive when present.
   const port = /^[ \t]*port[ \t]*[:=][ \t]*(\d{1,5})\b/m.exec(text);
-  if (port?.[1] !== undefined) return Number.parseInt(port[1], 10);
+  if (port?.[1] !== undefined) {
+    const hostDirective = /^[ \t]*host[ \t]*[:=][ \t]*(.+)$/m.exec(text);
+    const host =
+      hostDirective?.[1] !== undefined
+        ? stripInlineComment(hostDirective[1]).replace(/["']/g, "").trim()
+        : "";
+    return { host, port: Number.parseInt(port[1], 10) };
+  }
 
+  return undefined;
+}
+
+/**
+ * Split a listen VALUE into `{ host, port }`. Handles bracketed IPv6
+ * (`[::]:4222`), `host:port` with a single colon (IPv4 / hostname), and a bare
+ * port (host `""`). Returns `undefined` when no port can be recovered.
+ */
+function splitHostPort(value: string): NatsClientListen | undefined {
+  // Bracketed IPv6 + port: `[::]:4222`, `[::1]:4222`, `[2001:db8::1]:4222`.
+  const bracket = /^\[([^\]]+)\]:(\d{1,5})$/.exec(value);
+  if (bracket?.[1] !== undefined && bracket[2] !== undefined) {
+    return { host: bracket[1], port: Number.parseInt(bracket[2], 10) };
+  }
+  // `host:port` with exactly one colon (IPv4 / hostname) — reject a bare
+  // multi-colon IPv6 without brackets (ambiguous; NATS uses the bracketed form).
+  const hostPort = /^(.+):(\d{1,5})$/.exec(value);
+  if (hostPort?.[1] !== undefined && hostPort[2] !== undefined && !hostPort[1].includes(":")) {
+    return { host: hostPort[1], port: Number.parseInt(hostPort[2], 10) };
+  }
+  // Bare port — no host specified.
+  if (/^\d{1,5}$/.test(value)) return { host: "", port: Number.parseInt(value, 10) };
   return undefined;
 }
 

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -1191,6 +1191,38 @@ export function natsConfigMonitorUrl(natsConfigText: string): string | undefined
 }
 
 /**
+ * cortex#1495 v2 (important 2) — parse the nats-server CLIENT listen PORT from a
+ * config, so a bus with NO HTTP monitor can still be liveness-probed by a plain
+ * TCP connect to its client port (the #1476 community bus class: no `http_port`,
+ * so the `/healthz` probe was inconclusive and auto-rollback went inert). Order:
+ *   1. `listen: <host:port | port>` (the explicit client listen directive), then
+ *   2. `port: <n>` (the top-level client-port directive).
+ * Returns the port, or `undefined` when neither is present (the caller then
+ * applies the NATS default 4222, or — if the config is unreadable — falls back to
+ * the inconclusive-healthy disclosure). Comments are stripped first; only a
+ * line-anchored `port` matches, so `http_port`/`monitor_port` never false-hit.
+ */
+export function natsConfigClientListenPort(natsConfigText: string): number | undefined {
+  const text = stripConfigComments(natsConfigText);
+
+  // `listen: <value>` — value may be `host:port` (`0.0.0.0:4222`), a bare port,
+  // or quoted, optionally with an inline trailing comment. Take the trailing port.
+  const listen = /^[ \t]*listen[ \t]*[:=][ \t]*(.+)$/m.exec(text);
+  if (listen?.[1] !== undefined) {
+    const value = stripInlineComment(listen[1]).replace(/["']/g, "").trim();
+    const portMatch = /(?::|^)(\d{1,5})$/.exec(value);
+    if (portMatch?.[1] !== undefined) return Number.parseInt(portMatch[1], 10);
+  }
+
+  // `port: <n>` — the top-level client-port directive (line-anchored so it never
+  // matches `http_port`/`monitor_port`, which start with a different token).
+  const port = /^[ \t]*port[ \t]*[:=][ \t]*(\d{1,5})\b/m.exec(text);
+  if (port?.[1] !== undefined) return Number.parseInt(port[1], 10);
+
+  return undefined;
+}
+
+/**
  * Strip a trailing inline `#` or `//` comment from a single config-line value.
  * `0.0.0.0:8224 # mon` → `0.0.0.0:8224`. Conservative: only cuts at a `#` or
  * `//` that is preceded by whitespace or start-of-string, so a `#`/`//` inside a

--- a/src/common/nats/restart-with-settle.ts
+++ b/src/common/nats/restart-with-settle.ts
@@ -119,6 +119,15 @@ export function settleFailureReason(attempts: number, reason: string | undefined
 }
 
 /**
+ * The ONE inconclusive-health notice (cortex#1495 v2 nit) — join and make-live
+ * both log this when a restart's liveness probe was INCONCLUSIVE (no reachable
+ * signal, treated as healthy so a good restart is never falsely rolled back).
+ * Extracted so the four prior copies across the two orchestrators can't drift.
+ */
+export const INCONCLUSIVE_HEALTH_NOTICE =
+  "health inconclusive — no monitor configured, treated as healthy per #831";
+
+/**
  * Poll `probe` up to `maxAttempts` times with exponential backoff (capped at
  * `maxDelayMs`), returning as soon as ANY attempt reports healthy. Never
  * throws — {@link HealthProbe} implementations (e.g. `NatsServerPort.isHealthy`)

--- a/src/common/nats/restart-with-settle.ts
+++ b/src/common/nats/restart-with-settle.ts
@@ -1,10 +1,16 @@
 /**
- * cortex#1483 (join-4, epic #1479) — the SHARED settle-window health-probe
- * retry/backoff core, used by BOTH `cortex network join` (network-lib.ts) and
- * `cortex network make-live` (network-make-live-lib.ts) after a nats-server
- * restart.
+ * cortex#1483 (join-4, epic #1479) — SHARED nats restart-safety primitives, used
+ * by BOTH `cortex network join` (network-lib.ts) and `cortex network make-live`
+ * (network-make-live-lib.ts) around a nats-server restart:
  *
- * ## The bug this closes
+ *   - {@link probeHealthWithSettle} — the settle-window health-probe retry/backoff.
+ *   - {@link ConfigValidationOutcome} — the three-state `nats-server -t` verdict
+ *     (VALID / INVALID / SKIPPED) so a "could not validate" is never silently
+ *     mistaken for "valid" (cortex#1495 BLOCKER).
+ *   - {@link settleFailureReason} — the ONE settle-failure message string, so the
+ *     join and make-live wordings can never drift (cortex#1495 nit 5).
+ *
+ * ## The bug the settle window closes
  *
  * `join --apply`'s restart called the health probe EXACTLY ONCE, immediately
  * after the restart exec returned. A freshly-restarted nats-server needs a
@@ -38,10 +44,31 @@ export const realClock: ClockPort = {
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 };
 
-export type HealthProbeResult = { healthy: true } | { healthy: false; reason: string };
+/**
+ * A single health-probe outcome. `inconclusive` (cortex#1495 important 3) marks
+ * the #831 no-monitor case: the bus declares no monitor, so liveness cannot be
+ * CONFIRMED — treated as healthy (never a false rollback) but flagged so the
+ * caller's log can say "inconclusive, treated as healthy" instead of the
+ * over-claimed "verified healthy".
+ */
+export type HealthProbeResult =
+  | { healthy: true; inconclusive?: boolean }
+  | { healthy: false; reason: string };
 
 /** A single health check — e.g. `NatsServerPort.isHealthy`. Never throws by contract. */
 export type HealthProbe = () => Promise<HealthProbeResult>;
+
+/**
+ * cortex#1495 BLOCKER — the THREE-state `nats-server -t` verdict. A "could not
+ * validate" (binary missing / spawn failure) MUST NOT be silently treated as
+ * "valid" (fail-open), which would let a BAD config reload onto a live bus on
+ * any host without `nats-server` on PATH. Callers refuse on `invalid`, warn
+ * loudly + proceed on `skipped`, and proceed silently on `valid`.
+ */
+export type ConfigValidationOutcome =
+  | { status: "valid" }
+  | { status: "invalid"; reason: string }
+  | { status: "skipped"; reason: string };
 
 /** Tunables for {@link probeHealthWithSettle}. Every field optional — sane defaults below. */
 export interface SettleWindowOptions {
@@ -70,8 +97,25 @@ export interface SettleResult {
   healthy: boolean;
   /** How many probe attempts ran (1..maxAttempts). */
   attempts: number;
+  /**
+   * cortex#1495 important 3 — set when the winning (healthy) attempt was
+   * INCONCLUSIVE (#831 no-monitor). Lets the caller log "inconclusive, treated
+   * as healthy" rather than "verified healthy".
+   */
+  inconclusive?: boolean;
   /** The LAST failure reason — present iff `!healthy`. */
   reason?: string;
+}
+
+/**
+ * The ONE settle-failure message (cortex#1495 nit 5) — join and make-live both
+ * use it so their post-restart failure wordings can never drift.
+ */
+export function settleFailureReason(attempts: number, reason: string | undefined): string {
+  return (
+    `nats-server did not come back up after restart across ${attempts.toString()} ` +
+    `health check(s) over the settle window (${reason ?? "unknown"})`
+  );
 }
 
 /**
@@ -91,16 +135,22 @@ export async function probeHealthWithSettle(
   const backoffMultiplier = opts.backoffMultiplier ?? DEFAULT_SETTLE_BACKOFF_MULTIPLIER;
   const maxDelayMs = opts.maxDelayMs ?? DEFAULT_SETTLE_MAX_DELAY_MS;
 
-  let delay = initialDelayMs;
+  // cortex#1495 nit 1 — cap the delay ONCE per value (here at assignment), so the
+  // sleep call never needs a second redundant Math.min.
+  let delay = Math.min(initialDelayMs, maxDelayMs);
   let lastReason = "health probe never ran";
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const result = await probe();
     if (result.healthy) {
-      return { healthy: true, attempts: attempt };
+      return {
+        healthy: true,
+        attempts: attempt,
+        ...(result.inconclusive === true && { inconclusive: true }),
+      };
     }
     lastReason = result.reason;
     if (attempt < maxAttempts) {
-      await clock.sleep(Math.min(delay, maxDelayMs));
+      await clock.sleep(delay);
       delay = Math.min(delay * backoffMultiplier, maxDelayMs);
     }
   }

--- a/src/common/nats/restart-with-settle.ts
+++ b/src/common/nats/restart-with-settle.ts
@@ -1,0 +1,108 @@
+/**
+ * cortex#1483 (join-4, epic #1479) — the SHARED settle-window health-probe
+ * retry/backoff core, used by BOTH `cortex network join` (network-lib.ts) and
+ * `cortex network make-live` (network-make-live-lib.ts) after a nats-server
+ * restart.
+ *
+ * ## The bug this closes
+ *
+ * `join --apply`'s restart called the health probe EXACTLY ONCE, immediately
+ * after the restart exec returned. A freshly-restarted nats-server needs a
+ * moment to rebind its HTTP monitor port; a single immediate probe races that
+ * startup window and reads a HEALTHY bus as DOWN — which then (a) rolled back
+ * a GOOD config and (b) false-alarmed "bus may be DOWN, intervene manually" on
+ * a perfectly healthy bus (the community incident, 2026-07-03, tracked as
+ * #1476 gap 2). `make-live`'s restart had NO health verification at all —
+ * `launchctl kickstart`/`systemctl restart` exiting 0 was trusted blindly, so a
+ * restart that "succeeded" while nats-server then crashed on the new config
+ * went unnoticed.
+ *
+ * {@link probeHealthWithSettle} polls the health probe up to `maxAttempts`
+ * times with exponential backoff, succeeding as soon as ANY attempt reports
+ * healthy. Only exhausting every attempt without a healthy result is a genuine
+ * failure — the one signal a caller may act on (rollback).
+ *
+ * Pure over an injected {@link ClockPort} so tests run instantly (no real
+ * `setTimeout` wait) while still asserting the backoff SCHEDULE and the exact
+ * number of probe attempts.
+ */
+
+/** Injectable wall-clock wait, so tests never really sleep. */
+export interface ClockPort {
+  /** Wait `ms` milliseconds. */
+  sleep(ms: number): Promise<void>;
+}
+
+/** Real wall-clock — the production default. */
+export const realClock: ClockPort = {
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+export type HealthProbeResult = { healthy: true } | { healthy: false; reason: string };
+
+/** A single health check — e.g. `NatsServerPort.isHealthy`. Never throws by contract. */
+export type HealthProbe = () => Promise<HealthProbeResult>;
+
+/** Tunables for {@link probeHealthWithSettle}. Every field optional — sane defaults below. */
+export interface SettleWindowOptions {
+  /** Max number of health polls, including the first. Default {@link DEFAULT_SETTLE_MAX_ATTEMPTS}. */
+  maxAttempts?: number;
+  /** Delay BEFORE the 2nd attempt (ms). Default {@link DEFAULT_SETTLE_INITIAL_DELAY_MS}. */
+  initialDelayMs?: number;
+  /** Multiplier applied to the delay after each failed attempt. Default {@link DEFAULT_SETTLE_BACKOFF_MULTIPLIER}. */
+  backoffMultiplier?: number;
+  /** Cap on the per-attempt delay (ms). Default {@link DEFAULT_SETTLE_MAX_DELAY_MS}. */
+  maxDelayMs?: number;
+}
+
+/**
+ * 5 attempts, starting at 500ms and doubling (capped at 4000ms), is a ~7.5s
+ * worst-case settle window — generous for a loopback nats-server monitor to
+ * rebind after `launchctl kickstart`/`systemctl restart`, far below any
+ * "the CLI is wedged" threshold.
+ */
+export const DEFAULT_SETTLE_MAX_ATTEMPTS = 5;
+export const DEFAULT_SETTLE_INITIAL_DELAY_MS = 500;
+export const DEFAULT_SETTLE_BACKOFF_MULTIPLIER = 2;
+export const DEFAULT_SETTLE_MAX_DELAY_MS = 4000;
+
+export interface SettleResult {
+  healthy: boolean;
+  /** How many probe attempts ran (1..maxAttempts). */
+  attempts: number;
+  /** The LAST failure reason — present iff `!healthy`. */
+  reason?: string;
+}
+
+/**
+ * Poll `probe` up to `maxAttempts` times with exponential backoff (capped at
+ * `maxDelayMs`), returning as soon as ANY attempt reports healthy. Never
+ * throws — {@link HealthProbe} implementations (e.g. `NatsServerPort.isHealthy`)
+ * already never throw by contract; this function does not add its own guard so
+ * a violation surfaces loudly rather than being silently absorbed.
+ */
+export async function probeHealthWithSettle(
+  probe: HealthProbe,
+  opts: SettleWindowOptions = {},
+  clock: ClockPort = realClock,
+): Promise<SettleResult> {
+  const maxAttempts = Math.max(1, opts.maxAttempts ?? DEFAULT_SETTLE_MAX_ATTEMPTS);
+  const initialDelayMs = opts.initialDelayMs ?? DEFAULT_SETTLE_INITIAL_DELAY_MS;
+  const backoffMultiplier = opts.backoffMultiplier ?? DEFAULT_SETTLE_BACKOFF_MULTIPLIER;
+  const maxDelayMs = opts.maxDelayMs ?? DEFAULT_SETTLE_MAX_DELAY_MS;
+
+  let delay = initialDelayMs;
+  let lastReason = "health probe never ran";
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await probe();
+    if (result.healthy) {
+      return { healthy: true, attempts: attempt };
+    }
+    lastReason = result.reason;
+    if (attempt < maxAttempts) {
+      await clock.sleep(Math.min(delay, maxDelayMs));
+      delay = Math.min(delay * backoffMultiplier, maxDelayMs);
+    }
+  }
+  return { healthy: false, attempts: maxAttempts, reason: lastReason };
+}


### PR DESCRIPTION
## What
Makes config writes on a live operator-mode nats bus **guarded** (validated + settle-window health-checked + auto-rollback) for both `join` and `make-live` — not an absolute "crash-proof" guarantee, but it closes the two real bugs from the metafactory-community bring-up:
1. `join` probed `isHealthy()` **exactly once**, right after the restart exec returned — so a still-booting-but-healthy bus read as down → it **rolled back a GOOD config and false-alarmed "bus may be DOWN"** (tracked as **#1476 gap-2**).
2. `make-live`'s nats restart had **zero** safety net — a `launchctl`/`systemctl` exit 0 was trusted even if nats-server then died on the new config.

Sub-issue of epic **#1479**, slice **join-4** (#1483). Absorbs **#1476** (robust restart).

## How
- **`src/common/nats/restart-with-settle.ts`** (new, pure) — `probeHealthWithSettle` over an injectable `ClockPort`: polls the health signal up to `maxAttempts` with exponential backoff (default **5 attempts, 500ms→4000ms, ~7.5s**), succeeding as soon as **any** attempt reports healthy; only exhausting every attempt is a genuine failure. Honors the **#831 rule** (no monitor configured → inconclusive→healthy, never a false rollback). Tests inject a fake clock, so the settle window costs **zero** wall-clock in CI.
- **`src/common/nats/config-backup.ts`** (new) — `.bak` sidecar helper wired into join-side config/leaf writes.
- **`join`** — `restartAndProbe` rewired from the once-only probe to the settle window.
- **`make-live`** — new `NatsCanaryPort`: `nats-server -t` **validate before reload** (invalid → reload never attempted), pre-mutation snapshot, settle-window health verdict, and **auto-rollback + health-verified recovery restart** on genuine failure — mirroring join's existing #821 pattern.

## Verification
- `bunx tsc --noEmit`, `bun run lint:errors`, `bash scripts/check-carveouts.sh` — all clean; **full suite 8744 pass / 0 fail**.
- ~30 new tests across `network-lib`, `network-adapters`, `network-make-live`: valid+slow-but-healthy → no false "bus DOWN"; **invalid config → the `-t` gate refuses the reload** (when `nats-server` is available — if the binary is missing the gate can't run and surfaces a loud warning rather than silently passing); write creates a `.bak`; genuinely-unhealthy after the full settle window → auto-rollback restores + reloads; monitor-not-configured → treated healthy. Fake-clock asserts the exact backoff schedule + probe-attempt count.

## Out of scope (flagged)
- **Auto-rollback restores from an in-memory pre-mutation snapshot** (race-free, mirrors join's #821 mechanism), not by re-reading the `.bak-*` file off disk. Functionally equivalent ("restore to known-good"); the `.bak` sidecar is the forensic/manual-recovery artifact.
- **Hub-owner SIGHUP reload** (`cortex network secret` on the hub) was outside the task's named seams — it has its own `-t` gate but no settle/rollback yet. Candidate follow-up.

Closes #1483
Refs #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
