### PR TITLE
feat(network): C-1480 — render operator-mode config complete (FED+AGENTS+SYS preload) (epic #1479 slice 1)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-make-live.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live.test.ts
@@ -55,6 +55,15 @@ function makeInputs(state: MakeLiveState, over?: Partial<MakeLiveInputs>): MakeL
 /** Spy ports recording every effectful call in order. */
 function makePorts(over?: {
   resolverHas?: boolean;
+  /**
+   * cortex#1480 (join-1, epic #1479) — a per-pubkey override for
+   * `hasAccount`, so a test can distinguish "AGENTS already preloaded" from
+   * "FED already preloaded" (the fake otherwise answers the SAME `resolverHas`
+   * boolean regardless of which pubkey was queried). Undefined ⇒ falls back
+   * to the legacy `resolverHas`-for-everything behaviour every existing test
+   * above depends on.
+   */
+  hasAccountFor?: (accountPubkey: string) => boolean;
   /** M3 — resolver_preload block present (operator-mode bus). Default true. */
   hasResolverPreload?: boolean;
   /** Whether the append actually mutates (changed). Default true. */
@@ -114,7 +123,10 @@ function makePorts(over?: {
       },
     },
     resolver: {
-      hasAccount: () => over?.resolverHas ?? false,
+      hasAccount: (_natsConfigPath, accountPubkey) =>
+        over?.hasAccountFor !== undefined
+          ? over.hasAccountFor(accountPubkey)
+          : (over?.resolverHas ?? false),
       hasResolverPreload: () => over?.hasResolverPreload ?? true,
       appendAccount: ({ accountPubkey }) => {
         calls.push(`resolver-append:${accountPubkey}`);
@@ -350,6 +362,70 @@ describe("makeLiveStack — apply", () => {
     expect(res.reason).toContain("no operator-mode JWTs");
     expect(res.reason).toContain("provision");
     expect(calls).toEqual([]);
+  });
+
+  // cortex#1480 (join-1, epic #1479) — bootstrap must ALSO fire when
+  // resolver_preload already EXISTS but is missing the FED (or SYS) account
+  // the package carries, not only when the block is wholly absent. This is
+  // the real "does not define account <FED>" gap: a bus bootstrapped before
+  // FED existed (or hand-converted carrying only AGENTS) kept
+  // `hasResolverPreload` true forever, so the OLD `!hasResolverPreload`-only
+  // gate never revisited it and FED was never preloaded. ─────────────────────
+  test("cortex#1480: resolver_preload EXISTS (AGENTS only) but package's FED account is missing → bootstrap STILL fires", async () => {
+    const { ports, calls } = makePorts({
+      hasResolverPreload: true, // the block already exists (e.g. AGENTS-only, from a prior make-live)
+      hasAccountFor: (pubkey) => pubkey === AGENTS_PUB, // FED (FAKE_PKG.account) is NOT yet present
+    });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: true, resolverHasAccount: true }, { operatorModePackage: FAKE_PKG }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(true);
+    // The bootstrap/ensure step fires DESPITE hasResolverPreload:true, because
+    // the package's FED account was not yet present.
+    expect(calls[0]).toBe("bootstrap:~/.config/nats/local.conf");
+    expect(res.steps.join("\n")).toContain("operator-mode bootstrap");
+  });
+
+  test("cortex#1480: resolver_preload EXISTS and already carries FED + AGENTS (+ no SYS in package) → bootstrap is a no-op", async () => {
+    const { ports, calls } = makePorts({
+      hasResolverPreload: true,
+      hasAccountFor: () => true, // both FED and AGENTS already present
+    });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: true, resolverHasAccount: true }, { operatorModePackage: FAKE_PKG }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    // Fully converged: no bootstrap call, no append, no restart, nothing minted.
+    expect(calls).toEqual([]);
+    expect(res.steps.join("\n")).not.toContain("operator-mode bootstrap");
+  });
+
+  test("cortex#1480: resolver_preload EXISTS with FED present but the package's SYS account is missing → bootstrap STILL fires", async () => {
+    const PKG_WITH_SYS = { ...FAKE_PKG, systemAccount: "A" + "Y".repeat(55), systemAccountJwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJzdWIiOiJTWVMifQ.sig" };
+    const { ports, calls } = makePorts({
+      hasResolverPreload: true,
+      hasAccountFor: (pubkey) => pubkey === FAKE_PKG.account || pubkey === AGENTS_PUB, // SYS absent
+    });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: true, resolverHasAccount: true }, { operatorModePackage: PKG_WITH_SYS }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(calls[0]).toBe("bootstrap:~/.config/nats/local.conf");
+  });
+
+  test("cortex#1480: no operatorModePackage + resolver_preload already exists → unaffected (no bootstrap, matches pre-#1480 behaviour)", async () => {
+    const { ports, calls } = makePorts({ hasResolverPreload: true, resolverHas: true });
+    const res = await makeLiveStack(
+      makeInputs({ credsFileExists: true, resolverHasAccount: true }),
+      ports,
+    );
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([]);
+    expect(res.steps.join("\n")).not.toContain("operator-mode bootstrap");
   });
 
   // BLOCK 3 — pubkey drift cross-check ─────────────────────────────────────────

--- a/src/cli/cortex/commands/network-doctor-adapters.ts
+++ b/src/cli/cortex/commands/network-doctor-adapters.ts
@@ -53,6 +53,7 @@ export const DEFAULT_LEAFZ_TIMEOUT_MS = DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
  *
  * The brace-matched scan mirrors `insertIntoResolverPreload` (this same
  * codebase's existing resolver_preload-block locator, in
+ * `common/nats/leaf-remote-renderer.ts` as of cortex#1480 — previously
  * `network-make-live-adapters.ts`) — same block-opening regex, same
  * depth-counted brace walk — but EXTRACTS the block instead of inserting
  * into it.

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -22,7 +22,14 @@ import {
   renderBaseIsolatedConfig,
   natsConfigMonitorUrl,
   natsConfigClientListen,
+  insertIntoResolverPreload,
 } from "../../../common/nats/leaf-remote-renderer";
+
+// cortex#1480 — `insertIntoResolverPreload` now lives in leaf-remote-renderer.ts
+// (the PURE module) so `renderOperatorModeBlocks` can reuse it too. Re-exported
+// here under its original name so existing importers of this adapters module
+// (e.g. network-make-live.test.ts) are unaffected.
+export { insertIntoResolverPreload };
 import { probeHealthzMonitor } from "../../../common/nats/healthz-probe";
 import {
   selectNatsServiceManager,
@@ -181,32 +188,6 @@ export function buildAccountExportAdapter(runner: ArcRunner = defaultArcRunner):
 // =============================================================================
 // resolver_preload adapter — append an account block to the nats config
 // =============================================================================
-
-/**
- * Insert `insertion` immediately before the closing brace of the
- * `resolver_preload { … }` block in `text`. Uses a brace-matched scan so a
- * nested object inside the block can't confuse the close detection. Returns the
- * new text, or null when no resolver_preload block is found.
- */
-export function insertIntoResolverPreload(text: string, insertion: string): string | null {
-  const key = /resolver_preload\s*[:=]?\s*\{/.exec(text);
-  if (key === null) return null;
-  const open = key.index + key[0].length - 1; // index of the `{`
-  let depth = 0;
-  for (let i = open; i < text.length; i++) {
-    const ch = text[i];
-    if (ch === "{") depth++;
-    else if (ch === "}") {
-      depth--;
-      if (depth === 0) {
-        // Insert before this closing brace (which sits at column 0 of its line).
-        const lineStart = text.lastIndexOf("\n", i) + 1;
-        return text.slice(0, lineStart) + insertion + text.slice(lineStart);
-      }
-    }
-  }
-  return null; // unbalanced braces — refuse to edit
-}
 
 /** Live {@link ResolverPreloadPort}. Edits the nats config on disk in place. */
 export function buildResolverPreloadAdapter(): ResolverPreloadPort {

--- a/src/cli/cortex/commands/network-make-live-lib.ts
+++ b/src/cli/cortex/commands/network-make-live-lib.ts
@@ -128,12 +128,22 @@ export interface ResolverPreloadPort {
    * has NO `resolver_preload` yet (the local-only path: a never-federates stack
    * never runs `join`, so nothing else renders the operator-mode blocks). Renders
    * `operator:` + optional `system_account:` + `resolver: MEMORY` +
-   * `resolver_preload { <federation account> }` via `renderOperatorModeBlocks`,
-   * KEEPING the bus's own `server_name`/`listen`/`http`/`jetstream.domain`, and
-   * backing up the config first. Idempotent: `changed:false` when the bus is
-   * already operator-mode under the SAME operator. Refuses (ok:false) on a
-   * malformed package OR a bus already operator-mode under a DIFFERENT operator
-   * (never clobber). The subsequent `appendAccount` then adds the agents account.
+   * `resolver_preload { <federation account> [, <system account>] }` via
+   * `renderOperatorModeBlocks`, KEEPING the bus's own
+   * `server_name`/`listen`/`http`/`jetstream.domain`, and backing up the config
+   * first. The subsequent `appendAccount` then adds the agents account.
+   *
+   * cortex#1480 (join-1, epic #1479) — the orchestrator ALSO calls this when
+   * resolver_preload already EXISTS but is missing the federation (and/or
+   * system) account the package carries — the exact "does not define account
+   * <FED>" gap a bus bootstrapped before FED existed (or hand-converted
+   * carrying only the agents account) fell into forever under the old
+   * block-presence-only gate. `renderOperatorModeBlocks` handles both shapes:
+   * idempotent `changed:false` when the bus is ALREADY operator-mode under the
+   * SAME operator with every package account already preloaded; ENSURES any
+   * missing package account into the existing block (`changed:true`) when some
+   * are absent; refuses (ok:false) on a malformed package OR a bus already
+   * operator-mode under a DIFFERENT operator (never clobber).
    *
    * cortex#1265 (PR8) — when the target config does NOT exist yet (a truly
    * from-scratch stack), `baseIdentity` (when supplied) lets the adapter SYNTHESISE
@@ -447,7 +457,27 @@ export async function makeLiveStack(
   //   - operator-mode JWTs in config (provision populated them) ⇒ BOOTSTRAP an
   //     initial operator-mode skeleton (cortex#1265 local-only path).
   //   - no JWTs ⇒ the #794 refusal stands — nothing to render with.
-  const bootstrapNeeded = !ports.resolver.hasResolverPreload(inputs.natsConfigPath);
+  //
+  // cortex#1480 (join-1, epic #1479) — bootstrap must ALSO fire when
+  // resolver_preload already EXISTS but is missing an account THIS package
+  // carries (FED and/or SYS), not only when the block is wholly absent. A bus
+  // bootstrapped before its FED account existed (or hand-converted carrying
+  // only the AGENTS account) keeps `hasResolverPreload` true forever, so the
+  // old `!hasResolverPreload`-only gate never revisited it and FED was never
+  // preloaded — the "does not define account <FED>" fail-closed that blocked
+  // the metafactory-community bring-up. `hasAccount` is the SAME generic
+  // per-pubkey presence probe the always-run AGENTS append (step 1 below)
+  // already uses; reusing it here keeps the two checks from drifting.
+  const resolverBlockPresent = ports.resolver.hasResolverPreload(inputs.natsConfigPath);
+  const opPkg = inputs.operatorModePackage;
+  const fedAlreadyPreloaded =
+    opPkg === undefined || ports.resolver.hasAccount(inputs.natsConfigPath, opPkg.account);
+  const sysAlreadyPreloaded =
+    opPkg?.systemAccount === undefined ||
+    opPkg.systemAccount.length === 0 ||
+    ports.resolver.hasAccount(inputs.natsConfigPath, opPkg.systemAccount);
+  const bootstrapNeeded =
+    !resolverBlockPresent || (opPkg !== undefined && (!fedAlreadyPreloaded || !sysAlreadyPreloaded));
   if (bootstrapNeeded && inputs.operatorModePackage === undefined) {
     return {
       ok: false,
@@ -470,7 +500,9 @@ export async function makeLiveStack(
         {
           step: "operator-mode bootstrap",
           status: "wire",
-          detail: `render operator + resolver_preload (federation account) → ${inputs.natsConfigPath}`,
+          detail:
+            `ensure operator + resolver_preload carries the federation account (+ system, if any) → ` +
+            inputs.natsConfigPath,
         },
         ...corePlan,
       ]
@@ -564,8 +596,8 @@ export async function makeLiveStack(
     resolverChanged = boot.changed;
     steps.push(
       boot.changed
-        ? `operator-mode bootstrap: rendered operator + resolver_preload (federation account) into ${inputs.natsConfigPath}`
-        : `operator-mode bootstrap: bus already operator-mode (no-op)`,
+        ? `operator-mode bootstrap: ensured operator + resolver_preload carries the federation/system account(s) in ${inputs.natsConfigPath}`
+        : `operator-mode bootstrap: bus already operator-mode with all required accounts (no-op)`,
     );
   }
 

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, test } from "bun:test";
 import type { NetworkDescriptor } from "../../registry/types";
 import {
   natsConfigHasAccountTree,
+  natsConfigCanBindAccount,
   natsConfigMonitorUrl,
   natsConfigClientListen,
   leafIncludeFileName,
@@ -33,6 +34,7 @@ import {
   parseLoopbackListen,
   type LeafRemote,
   type StackLeafBinding,
+  type OperatorModeLeafPackage,
 } from "../leaf-remote-renderer";
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -136,6 +138,86 @@ describe("renderLeafRemote", () => {
     expect(() => renderLeafRemote(DESCRIPTOR, wrongPrefix)).toThrow();
     expect(() => renderLeafRemote(DESCRIPTOR, tooShort)).toThrow();
     expect(() => renderLeafRemote(DESCRIPTOR, breakout)).toThrow();
+  });
+});
+
+// =============================================================================
+// cortex#1480 (join-1, epic #1479) — the leaf binds the FED account, and the
+// FED account is genuinely present (bindable) in the rendered
+// resolver_preload. This is the end-to-end pure composition of the two
+// renderers `cortex network join` runs back to back: convert the bus
+// (renderOperatorModeBlocks), then render the leaf against it
+// (renderLeafRemote) — the exact invariant whose violation is the real
+// "does not define account <FED>" fail-closed.
+// =============================================================================
+
+describe("cortex#1480 — the leaf binds FED, and FED is present in the rendered resolver_preload", () => {
+  const OPERATOR_JWT =
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_OPERATOR_JWT_BODY.sig";
+  const FED_ACCOUNT = "A" + "F".repeat(55);
+  const FED_ACCOUNT_JWT =
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_FED_JWT_BODY.sig";
+  const AGENTS_ACCOUNT = "A" + "G".repeat(55);
+  const AGENTS_ACCOUNT_JWT =
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_AGENTS_JWT_BODY.sig";
+  const SYS_ACCOUNT = "A" + "S".repeat(55);
+  const SYS_ACCOUNT_JWT =
+    "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_SYS_JWT_BODY.sig";
+
+  const ANON_CONF = [
+    "server_name: community-andreas",
+    "listen: 127.0.0.1:4224",
+    "jetstream { store_dir: /Users/andreas/.config/nats/community-jetstream }",
+    "",
+  ].join("\n");
+
+  const PKG: OperatorModeLeafPackage = {
+    operatorJwt: OPERATOR_JWT,
+    account: FED_ACCOUNT,
+    accountJwt: FED_ACCOUNT_JWT,
+    agentsAccount: AGENTS_ACCOUNT,
+    agentsAccountJwt: AGENTS_ACCOUNT_JWT,
+    systemAccount: SYS_ACCOUNT,
+    systemAccountJwt: SYS_ACCOUNT_JWT,
+  };
+
+  test("the converted config's resolver_preload carries FED, AGENTS, and SYS — the leaf's bind target is present", () => {
+    const result = renderOperatorModeBlocks(ANON_CONF, PKG);
+    expect(result.status).toBe("converted");
+    if (result.status !== "converted") throw new Error("expected converted");
+
+    // ACCEPTANCE KEYSTONE — the FED account the leaf will bind is genuinely
+    // resolvable against the converted config (not merely text-present).
+    expect(natsConfigCanBindAccount(result.conf, FED_ACCOUNT).canBind).toBe(true);
+    expect(natsConfigCanBindAccount(result.conf, AGENTS_ACCOUNT).canBind).toBe(true);
+    expect(natsConfigCanBindAccount(result.conf, SYS_ACCOUNT).canBind).toBe(true);
+
+    // The leaf remote binds the FED account key — never AGENTS, never SYS.
+    const binding: StackLeafBinding = {
+      credentials: "/Users/andreas/.config/nats/andreas.creds",
+      account: FED_ACCOUNT,
+    };
+    const remote = renderLeafRemote(DESCRIPTOR, binding);
+    expect(remote.account).toBe(FED_ACCOUNT);
+    expect(remote.account).not.toBe(AGENTS_ACCOUNT);
+    expect(remote.account).not.toBe(SYS_ACCOUNT);
+
+    // And #799's own pre-flight bind-mode resolver agrees the converted
+    // config can bind THIS leaf's account (the check `cortex network join`
+    // runs immediately before rendering the leaf).
+    const bindMode = resolveLeafBindMode(result.conf, FED_ACCOUNT, true);
+    expect(bindMode.mode).toBe("operator-account");
+  });
+
+  test("re-resolving the leaf remote's include file renders `account: <FED pubkey>`, matching resolver_preload's key", () => {
+    const converted = renderOperatorModeBlocks(ANON_CONF, PKG);
+    if (converted.status !== "converted") throw new Error("expected converted");
+    const includeFile = renderLeafIncludeFile(DESCRIPTOR, {
+      credentials: "/Users/andreas/.config/nats/andreas.creds",
+      account: FED_ACCOUNT,
+    });
+    expect(includeFile).toContain(`account: ${FED_ACCOUNT}`);
+    expect(natsConfigCanBindAccount(converted.conf, FED_ACCOUNT).canBind).toBe(true);
   });
 });
 

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -21,7 +21,6 @@ import { describe, expect, test } from "bun:test";
 import type { NetworkDescriptor } from "../../registry/types";
 import {
   natsConfigHasAccountTree,
-  natsConfigCanBindAccount,
   natsConfigMonitorUrl,
   natsConfigClientListen,
   leafIncludeFileName,
@@ -143,13 +142,44 @@ describe("renderLeafRemote", () => {
 
 // =============================================================================
 // cortex#1480 (join-1, epic #1479) — the leaf binds the FED account, and the
-// FED account is genuinely present (bindable) in the rendered
-// resolver_preload. This is the end-to-end pure composition of the two
-// renderers `cortex network join` runs back to back: convert the bus
-// (renderOperatorModeBlocks), then render the leaf against it
-// (renderLeafRemote) — the exact invariant whose violation is the real
-// "does not define account <FED>" fail-closed.
+// FED pubkey appears as a literal preload KEY in the rendered resolver_preload.
+// This is the end-to-end pure composition of the two renderers `cortex network
+// join` runs back to back: convert the bus (renderOperatorModeBlocks), then
+// render the leaf against it (renderLeafRemote) — the exact invariant whose
+// violation is the real "does not define account <FED>" fail-closed. With fake
+// JWTs these are text-structure checks, NOT nats-server-verified.
 // =============================================================================
+
+/**
+ * INDEPENDENT structural parse of the rendered `resolver_preload { … }` block:
+ * the account pubkeys that appear as literal `<pubkey>:` KEY lines inside it.
+ * Deliberately does NOT call the production `natsConfigCanBindAccount`, so the
+ * keystone assertion is not circular with the code under test.
+ */
+function preloadKeys(conf: string): string[] {
+  const m = /resolver_preload\s*[:=]?\s*\{/.exec(conf);
+  if (m === null) return [];
+  const open = m.index + m[0].length - 1;
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < conf.length; i++) {
+    if (conf[i] === "{") depth++;
+    else if (conf[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end < 0) return [];
+  const keys: string[] = [];
+  for (const line of conf.slice(open + 1, end).split("\n")) {
+    const km = /^\s*(A[A-Z2-7]{55})\s*:/.exec(line);
+    if (km?.[1] !== undefined) keys.push(km[1]);
+  }
+  return keys;
+}
 
 describe("cortex#1480 — the leaf binds FED, and FED is present in the rendered resolver_preload", () => {
   const OPERATOR_JWT =
@@ -186,11 +216,13 @@ describe("cortex#1480 — the leaf binds FED, and FED is present in the rendered
     expect(result.status).toBe("converted");
     if (result.status !== "converted") throw new Error("expected converted");
 
-    // ACCEPTANCE KEYSTONE — the FED account the leaf will bind is genuinely
-    // resolvable against the converted config (not merely text-present).
-    expect(natsConfigCanBindAccount(result.conf, FED_ACCOUNT).canBind).toBe(true);
-    expect(natsConfigCanBindAccount(result.conf, AGENTS_ACCOUNT).canBind).toBe(true);
-    expect(natsConfigCanBindAccount(result.conf, SYS_ACCOUNT).canBind).toBe(true);
+    // ACCEPTANCE KEYSTONE — the FED (+AGENTS +SYS) pubkeys appear as literal
+    // preload KEYs, asserted by an INDEPENDENT structural parse (not the
+    // production predicate). Text-structure-verified, not nats-server-verified.
+    const keys = preloadKeys(result.conf);
+    expect(keys).toContain(FED_ACCOUNT);
+    expect(keys).toContain(AGENTS_ACCOUNT);
+    expect(keys).toContain(SYS_ACCOUNT);
 
     // The leaf remote binds the FED account key — never AGENTS, never SYS.
     const binding: StackLeafBinding = {
@@ -202,9 +234,9 @@ describe("cortex#1480 — the leaf binds FED, and FED is present in the rendered
     expect(remote.account).not.toBe(AGENTS_ACCOUNT);
     expect(remote.account).not.toBe(SYS_ACCOUNT);
 
-    // And #799's own pre-flight bind-mode resolver agrees the converted
-    // config can bind THIS leaf's account (the check `cortex network join`
-    // runs immediately before rendering the leaf).
+    // Integration check (a DIFFERENT function): #799's pre-flight bind-mode
+    // resolver reports operator-account for the converted config — the decision
+    // `cortex network join` makes immediately before rendering the leaf.
     const bindMode = resolveLeafBindMode(result.conf, FED_ACCOUNT, true);
     expect(bindMode.mode).toBe("operator-account");
   });
@@ -216,8 +248,10 @@ describe("cortex#1480 — the leaf binds FED, and FED is present in the rendered
       credentials: "/Users/andreas/.config/nats/andreas.creds",
       account: FED_ACCOUNT,
     });
+    // The leaf's `account:` line and the resolver_preload KEY are the SAME FED
+    // pubkey — asserted structurally on both sides (no production predicate).
     expect(includeFile).toContain(`account: ${FED_ACCOUNT}`);
-    expect(natsConfigCanBindAccount(converted.conf, FED_ACCOUNT).canBind).toBe(true);
+    expect(preloadKeys(converted.conf)).toContain(FED_ACCOUNT);
   });
 });
 

--- a/src/common/nats/__tests__/operator-mode-conversion.test.ts
+++ b/src/common/nats/__tests__/operator-mode-conversion.test.ts
@@ -29,6 +29,7 @@ import { describe, expect, test } from "bun:test";
 import {
   renderOperatorModeBlocks,
   natsConfigHasAccountTree,
+  natsConfigCanBindAccount,
   type OperatorModeConversion,
   type OperatorModeLeafPackage,
 } from "../leaf-remote-renderer";
@@ -75,6 +76,11 @@ const ACCOUNT_JWT =
 const SYS_ACCOUNT = "ADSYS6VXCEEKH62BYKGBHXQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVM";
 const SYS_ACCOUNT_JWT =
   "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_SYS_JWT_BODY.sig";
+// cortex#1480 (join-1, epic #1479) — the AGENTS account, the third leg of the
+// "FED + AGENTS + SYS" trio a fully-converged resolver_preload must carry.
+const AGENTS_ACCOUNT = "A" + "G".repeat(55);
+const AGENTS_ACCOUNT_JWT =
+  "eyJhbGciOiJlZDI1NTE5LW5rZXkiLCJ0eXAiOiJKV1QifQ.FAKE_AGENTS_JWT_BODY.sig";
 
 const PACKAGE: OperatorModeLeafPackage = {
   operatorJwt: OPERATOR_JWT,
@@ -86,6 +92,18 @@ const PACKAGE_WITH_SYS: OperatorModeLeafPackage = {
   ...PACKAGE,
   systemAccount: SYS_ACCOUNT,
   systemAccountJwt: SYS_ACCOUNT_JWT,
+};
+
+const PACKAGE_WITH_AGENTS: OperatorModeLeafPackage = {
+  ...PACKAGE,
+  agentsAccount: AGENTS_ACCOUNT,
+  agentsAccountJwt: AGENTS_ACCOUNT_JWT,
+};
+
+const PACKAGE_WITH_ALL_THREE: OperatorModeLeafPackage = {
+  ...PACKAGE_WITH_SYS,
+  agentsAccount: AGENTS_ACCOUNT,
+  agentsAccountJwt: AGENTS_ACCOUNT_JWT,
 };
 
 // =============================================================================
@@ -138,6 +156,34 @@ describe("renderOperatorModeBlocks — convert an anonymous bus (O-3 D2)", () =>
     expect(conf).toContain(`system_account: ${SYS_ACCOUNT}`);
     // and the SYS account is preloaded too
     expect(conf).toContain(`${SYS_ACCOUNT}: ${SYS_ACCOUNT_JWT}`);
+  });
+
+  // cortex#1480 (join-1, epic #1479) — resolver_preload must carry EVERY
+  // account the stack federates on: FED (always), AGENTS and SYS when the
+  // package carries them — and ONLY those it declares (no stray entries).
+  test("cortex#1480: preloads AGENTS alongside FED when the package carries one, and omits SYS when absent", () => {
+    const conf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE_WITH_AGENTS));
+    expect(conf).toContain(`${ACCOUNT}: ${ACCOUNT_JWT}`);
+    expect(conf).toContain(`${AGENTS_ACCOUNT}: ${AGENTS_ACCOUNT_JWT}`);
+    // "only those it declares" — no SYS account line was offered, so none renders.
+    expect(conf).not.toContain("system_account:");
+    expect(conf).not.toContain(SYS_ACCOUNT);
+  });
+
+  test("cortex#1480: preloads all three (FED + AGENTS + SYS) when the package carries all three", () => {
+    const conf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE_WITH_ALL_THREE));
+    expect(conf).toContain(`${ACCOUNT}: ${ACCOUNT_JWT}`);
+    expect(conf).toContain(`${AGENTS_ACCOUNT}: ${AGENTS_ACCOUNT_JWT}`);
+    expect(conf).toContain(`${SYS_ACCOUNT}: ${SYS_ACCOUNT_JWT}`);
+    expect(conf).toContain(`system_account: ${SYS_ACCOUNT}`);
+  });
+
+  test("cortex#1480 ACCEPTANCE KEYSTONE: every declared account is genuinely BINDABLE (natsConfigCanBindAccount), " +
+    "not merely text-present — the exact invariant whose violation is the real 'does not define account <FED>' fail-closed", () => {
+    const conf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE_WITH_ALL_THREE));
+    expect(natsConfigCanBindAccount(conf, ACCOUNT).canBind).toBe(true);
+    expect(natsConfigCanBindAccount(conf, AGENTS_ACCOUNT).canBind).toBe(true);
+    expect(natsConfigCanBindAccount(conf, SYS_ACCOUNT).canBind).toBe(true);
   });
 });
 
@@ -269,5 +315,88 @@ describe("renderOperatorModeBlocks — never clobber a foreign operator", () => 
     const convertedConf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
     const again = renderOperatorModeBlocks(convertedConf, PACKAGE);
     expect(again.status).toBe("already");
+  });
+});
+
+// =============================================================================
+// cortex#1480 (join-1, epic #1479) — ENSURE a MISSING account under the SAME
+// operator. This is the RED-first spec for the real production bug: a bus
+// bootstrapped before its FED account existed (or hand-converted carrying
+// only the AGENTS account) stays "operator-mode under the SAME operator"
+// forever, so the OLD operator-JWT-only "already" check silently left FED
+// un-preloaded — the exact "does not define account <FED>" fail-closed that
+// blocked the metafactory-community bring-up.
+// =============================================================================
+
+describe("renderOperatorModeBlocks — cortex#1480: ensure a MISSING account under the SAME operator", () => {
+  // A bus operator-mode under OPERATOR_JWT (the SAME operator PACKAGE uses)
+  // whose resolver_preload carries ONLY the AGENTS account — exactly the
+  // real-world shape (make-live's always-run AGENTS append succeeded; FED
+  // never got preloaded because the old bootstrap gate only fired when
+  // resolver_preload was WHOLLY ABSENT).
+  const AGENTS_ONLY_CONF = [
+    "server_name: community-andreas",
+    "listen: 127.0.0.1:4224",
+    `operator: ${OPERATOR_JWT}`,
+    "resolver: MEMORY",
+    "resolver_preload: {",
+    `  ${AGENTS_ACCOUNT}: ${AGENTS_ACCOUNT_JWT}`,
+    "}",
+    "",
+  ].join("\n");
+
+  test("precondition: the bus IS operator-mode but does NOT yet bind FED (the real bug's starting state)", () => {
+    expect(natsConfigHasAccountTree(AGENTS_ONLY_CONF)).toBe(true);
+    expect(natsConfigCanBindAccount(AGENTS_ONLY_CONF, ACCOUNT).canBind).toBe(false);
+  });
+
+  test("a FED-only package on the AGENTS-only bus ENSURES (appends) the missing FED account — status 'converted', not 'already'", () => {
+    const result = renderOperatorModeBlocks(AGENTS_ONLY_CONF, PACKAGE);
+    expect(result.status).toBe("converted");
+    const conf = mustConvert(result);
+    expect(conf).toContain(`${ACCOUNT}: ${ACCOUNT_JWT}`);
+    // the pre-existing AGENTS entry survives untouched.
+    expect(conf).toContain(`${AGENTS_ACCOUNT}: ${AGENTS_ACCOUNT_JWT}`);
+    // no duplicate `operator:` line — the skeleton itself was NOT re-rendered,
+    // only the missing account was spliced into the EXISTING resolver_preload.
+    const operatorLines = conf.split("\n").filter((l) => /^[ \t]*operator[ \t]*:/.test(l)); // operator-mode block
+    expect(operatorLines).toHaveLength(1);
+  });
+
+  test("ACCEPTANCE KEYSTONE: after the ensure, the FED account referenced by the leaf IS present (bindable) in the rendered resolver_preload", () => {
+    const conf = mustConvert(renderOperatorModeBlocks(AGENTS_ONLY_CONF, PACKAGE));
+    expect(natsConfigCanBindAccount(conf, ACCOUNT).canBind).toBe(true);
+  });
+
+  test("re-running the SAME package again after the ensure is now a byte-stable 'already' (nothing left missing)", () => {
+    const ensuredConf = mustConvert(renderOperatorModeBlocks(AGENTS_ONLY_CONF, PACKAGE));
+    const again = renderOperatorModeBlocks(ensuredConf, PACKAGE);
+    expect(again.status).toBe("already");
+    if (again.status !== "already") throw new Error("expected already");
+    expect(again.conf).toBe(ensuredConf); // byte-stable, no drift, no duplicate splice.
+  });
+
+  test("a package carrying an AGENTS account ALSO ensures AGENTS into a FED-only bus", () => {
+    // FED-only bus (mirrors a bus bootstrapped before AGENTS was ever included).
+    const fedOnlyConf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    expect(natsConfigCanBindAccount(fedOnlyConf, AGENTS_ACCOUNT).canBind).toBe(false);
+
+    const result = renderOperatorModeBlocks(fedOnlyConf, PACKAGE_WITH_AGENTS);
+    expect(result.status).toBe("converted");
+    const conf = mustConvert(result);
+    expect(natsConfigCanBindAccount(conf, ACCOUNT).canBind).toBe(true);
+    expect(natsConfigCanBindAccount(conf, AGENTS_ACCOUNT).canBind).toBe(true);
+  });
+
+  test("refuses (never silently drops the missing account) when operator-mode under THIS operator but no resolver_preload block exists to append into", () => {
+    const noPreloadBlock = [
+      `operator: ${OPERATOR_JWT}`,
+      `system_account: ${SYS_ACCOUNT}`, // an operator-mode signal, but no resolver_preload block anywhere
+      "",
+    ].join("\n");
+    const result = renderOperatorModeBlocks(noPreloadBlock, PACKAGE);
+    expect(result.status).toBe("refuse");
+    if (result.status !== "refuse") throw new Error("expected refuse");
+    expect(result.reason).toContain("resolver_preload");
   });
 });

--- a/src/common/nats/__tests__/operator-mode-conversion.test.ts
+++ b/src/common/nats/__tests__/operator-mode-conversion.test.ts
@@ -45,6 +45,39 @@ function mustConvert(result: OperatorModeConversion): string {
   return result.conf;
 }
 
+/**
+ * cortex#1480 — INDEPENDENT structural parse of the rendered `resolver_preload
+ * { … }` block: returns the account pubkeys that appear as literal `<pubkey>:`
+ * KEY lines inside it. Deliberately does NOT call any production predicate
+ * (`natsConfigCanBindAccount`), so a keystone assertion built on it can't be
+ * circular with the code under test (which computes what to append USING that
+ * predicate). Test-only; a small hand-rolled brace-matched extractor.
+ */
+function preloadKeys(conf: string): string[] {
+  const m = /resolver_preload\s*[:=]?\s*\{/.exec(conf);
+  if (m === null) return [];
+  const open = m.index + m[0].length - 1;
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < conf.length; i++) {
+    if (conf[i] === "{") depth++;
+    else if (conf[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end < 0) return [];
+  const keys: string[] = [];
+  for (const line of conf.slice(open + 1, end).split("\n")) {
+    const km = /^\s*(A[A-Z2-7]{55})\s*:/.exec(line);
+    if (km?.[1] !== undefined) keys.push(km[1]);
+  }
+  return keys;
+}
+
 // =============================================================================
 // Fixtures — an anonymous bus (the Part-1 hard-isolated shape) + a leaf package.
 // =============================================================================
@@ -178,12 +211,18 @@ describe("renderOperatorModeBlocks — convert an anonymous bus (O-3 D2)", () =>
     expect(conf).toContain(`system_account: ${SYS_ACCOUNT}`);
   });
 
-  test("cortex#1480 ACCEPTANCE KEYSTONE: every declared account is genuinely BINDABLE (natsConfigCanBindAccount), " +
-    "not merely text-present — the exact invariant whose violation is the real 'does not define account <FED>' fail-closed", () => {
+  test("cortex#1480 ACCEPTANCE KEYSTONE: FED + AGENTS + SYS each appear as a literal preload KEY in the rendered " +
+    "resolver_preload block — asserted by an INDEPENDENT structural parse (NOT the production bind predicate). With " +
+    "fake JWTs this is text-structure-verified, not nats-server-verified", () => {
     const conf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE_WITH_ALL_THREE));
+    const keys = preloadKeys(conf);
+    expect(keys).toContain(ACCOUNT);
+    expect(keys).toContain(AGENTS_ACCOUNT);
+    expect(keys).toContain(SYS_ACCOUNT);
+    // Secondary sanity check via the production predicate — kept, but NOT the
+    // keystone: it would be circular (renderOperatorModeBlocks decides what to
+    // append using this SAME predicate).
     expect(natsConfigCanBindAccount(conf, ACCOUNT).canBind).toBe(true);
-    expect(natsConfigCanBindAccount(conf, AGENTS_ACCOUNT).canBind).toBe(true);
-    expect(natsConfigCanBindAccount(conf, SYS_ACCOUNT).canBind).toBe(true);
   });
 });
 
@@ -363,9 +402,11 @@ describe("renderOperatorModeBlocks — cortex#1480: ensure a MISSING account und
     expect(operatorLines).toHaveLength(1);
   });
 
-  test("ACCEPTANCE KEYSTONE: after the ensure, the FED account referenced by the leaf IS present (bindable) in the rendered resolver_preload", () => {
+  test("ACCEPTANCE KEYSTONE: after the ensure, the FED pubkey appears as a literal preload KEY (INDEPENDENT structural parse, not the production predicate)", () => {
     const conf = mustConvert(renderOperatorModeBlocks(AGENTS_ONLY_CONF, PACKAGE));
-    expect(natsConfigCanBindAccount(conf, ACCOUNT).canBind).toBe(true);
+    expect(preloadKeys(conf)).toContain(ACCOUNT);
+    // pre-existing AGENTS key survives too.
+    expect(preloadKeys(conf)).toContain(AGENTS_ACCOUNT);
   });
 
   test("re-running the SAME package again after the ensure is now a byte-stable 'already' (nothing left missing)", () => {
@@ -379,13 +420,62 @@ describe("renderOperatorModeBlocks — cortex#1480: ensure a MISSING account und
   test("a package carrying an AGENTS account ALSO ensures AGENTS into a FED-only bus", () => {
     // FED-only bus (mirrors a bus bootstrapped before AGENTS was ever included).
     const fedOnlyConf = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
-    expect(natsConfigCanBindAccount(fedOnlyConf, AGENTS_ACCOUNT).canBind).toBe(false);
+    expect(preloadKeys(fedOnlyConf)).not.toContain(AGENTS_ACCOUNT);
 
     const result = renderOperatorModeBlocks(fedOnlyConf, PACKAGE_WITH_AGENTS);
     expect(result.status).toBe("converted");
     const conf = mustConvert(result);
-    expect(natsConfigCanBindAccount(conf, ACCOUNT).canBind).toBe(true);
-    expect(natsConfigCanBindAccount(conf, AGENTS_ACCOUNT).canBind).toBe(true);
+    expect(preloadKeys(conf)).toContain(ACCOUNT);
+    expect(preloadKeys(conf)).toContain(AGENTS_ACCOUNT);
+  });
+
+  // cortex#1480 — an operator-mode bus needs BOTH the SYS account in
+  // resolver_preload AND a top-level `system_account:` directive; the ensure
+  // path must add the directive too (not only the preload entry), or the server
+  // would know the account but never use it as the system account.
+  test("ensuring a SYS account into an operator-mode bus that lacks the `system_account:` directive ADDS the directive too", () => {
+    // A FED-only bus rendered from scratch carries NO `system_account:` (no SYS
+    // in that package) — the real starting shape.
+    const fedOnlyNoSys = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    expect(fedOnlyNoSys).not.toContain("system_account:");
+
+    const result = renderOperatorModeBlocks(fedOnlyNoSys, PACKAGE_WITH_SYS);
+    expect(result.status).toBe("converted");
+    const conf = mustConvert(result);
+    // SYS added to resolver_preload (structural) AND the top-level directive set.
+    expect(preloadKeys(conf)).toContain(SYS_ACCOUNT);
+    expect(conf).toContain(`system_account: ${SYS_ACCOUNT}`);
+  });
+
+  test("the SYS-directive ensure is idempotent: re-running is byte-stable 'already', directive not duplicated", () => {
+    const fedOnly = mustConvert(renderOperatorModeBlocks(ANON_CONF, PACKAGE));
+    const ensured = mustConvert(renderOperatorModeBlocks(fedOnly, PACKAGE_WITH_SYS));
+    const again = renderOperatorModeBlocks(ensured, PACKAGE_WITH_SYS);
+    expect(again.status).toBe("already");
+    if (again.status !== "already") throw new Error("expected already");
+    expect(again.conf).toBe(ensured);
+    const directiveLines = ensured
+      .split("\n")
+      .filter((l) => /^[ \t]*system_account[ \t]*:/.test(l));
+    expect(directiveLines).toHaveLength(1);
+  });
+
+  test("does NOT clobber an EXISTING `system_account:` directive when ensuring other accounts", () => {
+    // A bus whose SYS directive + SYS preload already exist, but FED is missing.
+    const withSysDirective = [
+      `operator: ${OPERATOR_JWT}`,
+      `system_account: ${SYS_ACCOUNT}`,
+      "resolver: MEMORY",
+      "resolver_preload: {",
+      `  ${SYS_ACCOUNT}: ${SYS_ACCOUNT_JWT}`,
+      "}",
+      "",
+    ].join("\n");
+    const conf = mustConvert(renderOperatorModeBlocks(withSysDirective, PACKAGE_WITH_SYS));
+    // FED got added; SYS directive stays exactly once (never re-appended).
+    expect(preloadKeys(conf)).toContain(ACCOUNT);
+    const directiveLines = conf.split("\n").filter((l) => /^[ \t]*system_account[ \t]*:/.test(l));
+    expect(directiveLines).toHaveLength(1);
   });
 
   test("refuses (never silently drops the missing account) when operator-mode under THIS operator but no resolver_preload block exists to append into", () => {

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -827,7 +827,7 @@ function hasNonLeafInclude(text: string): boolean {
 export interface OperatorModeLeafPackage {
   /** The NSC operator JWT (`eyJ…`) — the root of the local account tree. */
   operatorJwt: string;
-  /** The issued account public key (nkey-U, `A…`) the leaf binds to. */
+  /** The issued account public key (nkey-U, `A…`) the leaf binds to (FED). */
   account: string;
   /** The issued account's JWT (`eyJ…`) — preloaded under `resolver_preload`. */
   accountJwt: string;
@@ -835,16 +835,45 @@ export interface OperatorModeLeafPackage {
   systemAccount?: string;
   /** OPTIONAL system account JWT — preloaded alongside the issued account. */
   systemAccountJwt?: string;
+  /**
+   * cortex#1480 (join-1, epic #1479) — the stack's own per-stack AGENTS
+   * account (`stack.nats_infra.agents_account`, ADR-0012 isolation),
+   * OPTIONAL. When present (together with {@link
+   * OperatorModeLeafPackage.agentsAccountJwt}), {@link renderOperatorModeBlocks}
+   * preloads it ALONGSIDE the FED account (and SYS, if any) so ONE render
+   * produces a `resolver_preload` carrying every account the stack actually
+   * uses. Closes the gap where a bus's AGENTS account got preloaded (by
+   * make-live's always-run per-account append) while its FED account never
+   * did (historically only rendered on a truly-from-scratch bootstrap) —
+   * producing the "does not define account <FED>" fail-closed on join.
+   * Absent for callers with no AGENTS material (e.g. `cortex network join`,
+   * which only ever needs FED/SYS).
+   */
+  agentsAccount?: string;
+  /**
+   * cortex#1480 — the AGENTS account's JWT, paired with {@link
+   * OperatorModeLeafPackage.agentsAccount}. Required whenever `agentsAccount`
+   * is set (mirrors the {@link OperatorModeLeafPackage.systemAccount} /
+   * {@link OperatorModeLeafPackage.systemAccountJwt} pairing rule).
+   */
+  agentsAccountJwt?: string;
 }
 
 /**
  * The outcome of {@link renderOperatorModeBlocks}:
- *   - `converted` — the config was anonymous; the rendered operator-mode config
- *     is in `conf` (the orchestrator writes it).
+ *   - `converted` — either the config was anonymous (the operator-mode blocks
+ *     were rendered from scratch), OR it was ALREADY operator-mode under this
+ *     package's operator but missing one or more of the accounts the package
+ *     carries (cortex#1480 — those missing accounts were appended into the
+ *     EXISTING `resolver_preload` block). Either way `conf` is what the
+ *     orchestrator writes.
  *   - `already` — the config is ALREADY operator-mode under THIS package's
- *     operator JWT; `conf` is the unchanged bytes (a byte-stable no-op).
- *   - `refuse` — cannot convert: material absent/malformed, OR the config is
- *     already operator-mode under a DIFFERENT operator (never clobber it).
+ *     operator JWT AND already preloads every account the package carries;
+ *     `conf` is the unchanged bytes (a byte-stable no-op).
+ *   - `refuse` — cannot convert: material absent/malformed, the config is
+ *     already operator-mode under a DIFFERENT operator (never clobber it), or
+ *     it is operator-mode with no locatable `resolver_preload { … }` block to
+ *     append a missing account into.
  */
 export type OperatorModeConversion =
   | { status: "converted"; conf: string }
@@ -858,19 +887,71 @@ const OPERATOR_MODE_MARKER_END =
   "// --- end operator-mode blocks ---";
 
 /**
+ * Insert `insertion` immediately before the closing brace of the
+ * `resolver_preload { … }` block in `text`. Uses a brace-matched scan so a
+ * nested object inside the block can't confuse the close detection. Returns the
+ * new text, or null when no resolver_preload block is found.
+ *
+ * cortex#1480 (join-1, epic #1479) — lives here (rather than
+ * network-make-live-adapters.ts, its original home) so {@link
+ * renderOperatorModeBlocks} can reuse it PURELY when ENSURING a missing
+ * account into an ALREADY operator-mode config (the "same operator, missing
+ * account" branch) — the same text-splice make-live's `appendAccount` adapter
+ * already used for the AGENTS account, now the single source for BOTH join's
+ * O-3 conversion path and make-live's bootstrap/ensure path.
+ * `network-make-live-adapters.ts` re-exports this name so its existing
+ * importers are unaffected.
+ */
+export function insertIntoResolverPreload(text: string, insertion: string): string | null {
+  const key = /resolver_preload\s*[:=]?\s*\{/.exec(text);
+  if (key === null) return null;
+  const open = key.index + key[0].length - 1; // index of the `{`
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        // Insert before this closing brace (which sits at column 0 of its line).
+        const lineStart = text.lastIndexOf("\n", i) + 1;
+        return text.slice(0, lineStart) + insertion + text.slice(lineStart);
+      }
+    }
+  }
+  return null; // unbalanced braces — refuse to edit
+}
+
+/**
  * Render the SOP §B0.1 operator-mode blocks INTO `currentConf` from a leaf
  * package. PURE (text in, text out): no filesystem, no daemon. The orchestrator
  * (network-lib joinNetwork) calls this through the LeafFilePort, decides whether
  * to write the result, then proceeds with the existing leaf-remote render.
  *
  * Conversion rules:
- *   - **anonymous bus + complete package** → `converted`: append the four blocks,
- *     KEEPING the stack's own identity/ports/JS domain verbatim, NOT touching
- *     any `leafnodes`/`include` (the join renders its own per-network leaf).
- *   - **already operator-mode under THIS operator** → `already` (idempotent
- *     no-op: re-running a converted bus must not duplicate or drift).
+ *   - **anonymous bus + complete package** → `converted`: append the four blocks
+ *     (operator + optional system_account + resolver + resolver_preload for
+ *     FED [+ AGENTS, if the package carries one] [+ SYS]), KEEPING the stack's
+ *     own identity/ports/JS domain verbatim, NOT touching any `leafnodes`/
+ *     `include` (the join renders its own per-network leaf).
+ *   - **already operator-mode under THIS operator, every package account
+ *     already preloaded** → `already` (idempotent no-op: re-running a
+ *     converted bus must not duplicate or drift).
+ *   - **already operator-mode under THIS operator, but MISSING one or more of
+ *     the package's accounts** (cortex#1480) → `converted`: append ONLY the
+ *     missing `<pubkey>: <jwt>` entries into the EXISTING `resolver_preload`
+ *     block. This is the fix for the real "does not define account <FED>"
+ *     fail-closed: a bus bootstrapped before its FED account existed (or
+ *     hand-converted carrying only AGENTS) stayed "already operator-mode"
+ *     forever under the old operator-JWT-only check, so FED was never
+ *     preloaded. Presence is checked with {@link natsConfigCanBindAccount} —
+ *     the SAME token-boundary-safe check #794 uses — so a merely-embedded or
+ *     comment-only mention never counts as "already there".
  *   - **already operator-mode under a DIFFERENT operator** → `refuse`: never
  *     clobber a bus standing on someone else's account tree.
+ *   - **already operator-mode under THIS operator but no `resolver_preload`
+ *     block can be located to append a missing account into** → `refuse` with
+ *     an actionable reason (never silently drop the missing account).
  *   - **material absent/malformed** → `refuse` with an actionable reason (this
  *     is the #794 fail-fast, preserved for the genuinely-unconvertible case).
  *
@@ -889,6 +970,8 @@ export function renderOperatorModeBlocks(
   const accountJwt = pkg.accountJwt.trim();
   const systemAccount = pkg.systemAccount?.trim();
   const systemAccountJwt = pkg.systemAccountJwt?.trim();
+  const agentsAccount = pkg.agentsAccount?.trim();
+  const agentsAccountJwt = pkg.agentsAccountJwt?.trim();
 
   if (operatorJwt.length === 0) {
     return {
@@ -950,17 +1033,81 @@ export function renderOperatorModeBlocks(
       };
     }
   }
+  // cortex#1480 — an AGENTS account is OPTIONAL (mirrors the SYS validation
+  // above): if one is offered it must be well-formed AND paired with its JWT.
+  if (agentsAccount !== undefined && agentsAccount.length > 0) {
+    if (!NKEY_ACCOUNT.test(agentsAccount)) {
+      return {
+        status: "refuse",
+        reason: `agents account ${JSON.stringify(pkg.agentsAccount)} is not an nkey-U account public key`,
+      };
+    }
+    if (
+      agentsAccountJwt === undefined ||
+      agentsAccountJwt.length === 0 ||
+      !JWT_SHAPE.test(agentsAccountJwt)
+    ) {
+      return {
+        status: "refuse",
+        reason:
+          "an agents account was offered without a valid agents account JWT — " +
+          "`resolver_preload` must carry the AGENTS account's JWT too.",
+      };
+    }
+  }
 
-  // 2) Already operator-mode? Decide between idempotent no-op and clobber-refuse.
+  // The accounts THIS package wants preloaded — FED always, AGENTS/SYS when
+  // the package carries them. Shared by BOTH the "already, ensure missing"
+  // branch (2) and the "anonymous, render from scratch" branch (3) below so
+  // the two paths can never preload a different account set.
+  const wantedAccounts: { label: string; pubkey: string; jwt: string }[] = [
+    { label: "FED", pubkey: account, jwt: accountJwt },
+  ];
+  if (agentsAccount !== undefined && agentsAccount.length > 0) {
+    wantedAccounts.push({ label: "AGENTS", pubkey: agentsAccount, jwt: agentsAccountJwt ?? "" });
+  }
+  if (systemAccount !== undefined && systemAccount.length > 0) {
+    wantedAccounts.push({ label: "SYS", pubkey: systemAccount, jwt: systemAccountJwt ?? "" });
+  }
+
+  // 2) Already operator-mode? Decide between idempotent no-op, an ENSURE of any
+  // MISSING package account, and a clobber-refuse.
   if (natsConfigHasAccountTree(currentConf)) {
     const stripped = stripConfigComments(currentConf);
     const existingOperatorJwt = /^[ \t]*operator[ \t]*[:=][ \t]*(\S+)/m.exec( // operator-mode block line
       stripped,
     );
-    // SAME operator JWT already present → this package already converted it.
-    // Byte-stable no-op (the orchestrator may skip the write).
     if (existingOperatorJwt?.[1] === operatorJwt) {
-      return { status: "already", conf: currentConf };
+      // SAME operator JWT already present. cortex#1480 — that alone is NOT
+      // sufficient to call it "already done": a bus bootstrapped before its
+      // FED account existed (or hand-converted carrying only AGENTS) is
+      // STILL operator-mode under the SAME operator, yet resolver_preload may
+      // be missing one or more of the accounts THIS package carries. Ensure
+      // EVERY wanted account is actually bindable — natsConfigCanBindAccount
+      // is the SAME token-boundary-safe presence check #794 uses, so a
+      // merely-embedded or comment-only mention never counts as "present".
+      const missing = wantedAccounts.filter(
+        (w) => !natsConfigCanBindAccount(currentConf, w.pubkey).canBind,
+      );
+      if (missing.length === 0) {
+        // Byte-stable no-op (the orchestrator may skip the write).
+        return { status: "already", conf: currentConf };
+      }
+      const insertion = missing
+        .map((w) => `  // ${w.label} account (cortex#1480 ensure)\n  ${w.pubkey}: ${w.jwt}\n`)
+        .join("");
+      const next = insertIntoResolverPreload(currentConf, insertion);
+      if (next === null) {
+        return {
+          status: "refuse",
+          reason:
+            "the nats config is operator-mode under this operator but has no " +
+            "resolver_preload { … } block to add the missing account(s) into " +
+            `(${missing.map((w) => `${w.label} ${w.pubkey}`).join(", ")}) — convert/repair the ` +
+            "bus by hand (docs/sop-stack-onboarding.md §B0.1).",
+        };
+      }
+      return { status: "converted", conf: next };
     }
     // Operator-mode under a DIFFERENT (or unreadable) operator JWT — NEVER clobber.
     return {
@@ -976,12 +1123,7 @@ export function renderOperatorModeBlocks(
   // We APPEND them (KEEPING the stack's own identity/ports/JS domain verbatim,
   // and never touching any leafnodes/include). The trailing newline of the
   // source config is normalised so the appended block sits on its own lines.
-  const preload: string[] = [
-    `  ${account}: ${accountJwt}`,
-  ];
-  if (systemAccount !== undefined && systemAccount.length > 0) {
-    preload.push(`  ${systemAccount}: ${systemAccountJwt ?? ""}`);
-  }
+  const preload: string[] = wantedAccounts.map((w) => `  ${w.pubkey}: ${w.jwt}`);
 
   const blocks: string[] = [
     OPERATOR_MODE_MARKER,

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -880,11 +880,56 @@ export type OperatorModeConversion =
   | { status: "already"; conf: string }
   | { status: "refuse"; reason: string };
 
-/** A marker line so a human reading the converted config knows join wrote it. */
+/** A marker line so a reader of the converted config knows join wrote it. */
 const OPERATOR_MODE_MARKER =
   "// --- operator-mode blocks rendered by cortex network join (O-3, #1053) ---";
 const OPERATOR_MODE_MARKER_END =
   "// --- end operator-mode blocks ---";
+
+/**
+ * cortex#1480 — the shared "an OPTIONAL package account must be well-formed AND
+ * paired with its JWT" validator, used for BOTH the SYS and AGENTS package
+ * accounts (a half-specified account would emit a preload / `system_account`
+ * line the server can't resolve). Absent (undefined/empty) pubkey ⇒ ok (the
+ * account is optional). Extracted so the two rules cannot drift.
+ */
+function validateOptionalPackageAccount(
+  short: "SYS" | "AGENTS",
+  pubkey: string | undefined,
+  jwt: string | undefined,
+): { ok: true } | { ok: false; reason: string } {
+  if (pubkey === undefined || pubkey.length === 0) return { ok: true };
+  const noun = short === "SYS" ? "system account" : "agents account";
+  if (!NKEY_ACCOUNT.test(pubkey)) {
+    return { ok: false, reason: `${noun} ${JSON.stringify(pubkey)} is not an nkey-U account public key` };
+  }
+  if (jwt === undefined || jwt.length === 0 || !JWT_SHAPE.test(jwt)) {
+    return {
+      ok: false,
+      reason:
+        `${short === "SYS" ? "a" : "an"} ${noun} was offered without a valid ${noun} JWT — ` +
+        `\`resolver_preload\` must carry the ${short} account's JWT too.`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * cortex#1480 — true iff `natsConfigText` carries a top-level `system_account:`
+ * directive (comments stripped, so a commented-out one does not count).
+ */
+function hasSystemAccountDirective(natsConfigText: string): boolean {
+  return /^[ \t]*system_account[ \t]*[:=]/m.test(stripConfigComments(natsConfigText));
+}
+
+/**
+ * cortex#1480 — append a top-level `system_account: <pubkey>` directive. The
+ * pubkey is a validated nkey-U (emitted bare, matching the from-scratch render).
+ */
+function appendSystemAccountDirective(natsConfigText: string, sysPubkey: string): string {
+  const base = natsConfigText.replace(/\n+$/, "");
+  return `${base}\nsystem_account: ${sysPubkey}\n`;
+}
 
 /**
  * Insert `insertion` immediately before the closing brace of the
@@ -1010,51 +1055,14 @@ export function renderOperatorModeBlocks(
         "issued account's JWT (pass --account-jwt or set stack.nats_infra.account_jwt).",
     };
   }
-  // A SYS account is OPTIONAL, but if one is offered it must be well-formed
-  // AND paired with its JWT (a half-specified SYS account would emit a
-  // `system_account` line with no preload → nats-server can't resolve it).
-  if (systemAccount !== undefined && systemAccount.length > 0) {
-    if (!NKEY_ACCOUNT.test(systemAccount)) {
-      return {
-        status: "refuse",
-        reason: `system account ${JSON.stringify(pkg.systemAccount)} is not an nkey-U account public key`,
-      };
-    }
-    if (
-      systemAccountJwt === undefined ||
-      systemAccountJwt.length === 0 ||
-      !JWT_SHAPE.test(systemAccountJwt)
-    ) {
-      return {
-        status: "refuse",
-        reason:
-          "a system account was offered without a valid system account JWT — " +
-          "`resolver_preload` must carry the SYS account's JWT too.",
-      };
-    }
-  }
-  // cortex#1480 — an AGENTS account is OPTIONAL (mirrors the SYS validation
-  // above): if one is offered it must be well-formed AND paired with its JWT.
-  if (agentsAccount !== undefined && agentsAccount.length > 0) {
-    if (!NKEY_ACCOUNT.test(agentsAccount)) {
-      return {
-        status: "refuse",
-        reason: `agents account ${JSON.stringify(pkg.agentsAccount)} is not an nkey-U account public key`,
-      };
-    }
-    if (
-      agentsAccountJwt === undefined ||
-      agentsAccountJwt.length === 0 ||
-      !JWT_SHAPE.test(agentsAccountJwt)
-    ) {
-      return {
-        status: "refuse",
-        reason:
-          "an agents account was offered without a valid agents account JWT — " +
-          "`resolver_preload` must carry the AGENTS account's JWT too.",
-      };
-    }
-  }
+  // A SYS and an AGENTS account are each OPTIONAL, but if one is offered it must
+  // be well-formed AND paired with its JWT (a half-specified account would emit a
+  // preload / `system_account` line nats-server can't resolve). One shared
+  // validator so the two rules can't drift (cortex#1480).
+  const sysValid = validateOptionalPackageAccount("SYS", systemAccount, systemAccountJwt);
+  if (!sysValid.ok) return { status: "refuse", reason: sysValid.reason };
+  const agentsValid = validateOptionalPackageAccount("AGENTS", agentsAccount, agentsAccountJwt);
+  if (!agentsValid.ok) return { status: "refuse", reason: agentsValid.reason };
 
   // The accounts THIS package wants preloaded — FED always, AGENTS/SYS when
   // the package carries them. Shared by BOTH the "already, ensure missing"
@@ -1082,30 +1090,56 @@ export function renderOperatorModeBlocks(
       // sufficient to call it "already done": a bus bootstrapped before its
       // FED account existed (or hand-converted carrying only AGENTS) is
       // STILL operator-mode under the SAME operator, yet resolver_preload may
-      // be missing one or more of the accounts THIS package carries. Ensure
-      // EVERY wanted account is actually bindable — natsConfigCanBindAccount
-      // is the SAME token-boundary-safe presence check #794 uses, so a
-      // merely-embedded or comment-only mention never counts as "present".
+      // be missing one or more of the accounts THIS package carries. Presence
+      // is checked with natsConfigCanBindAccount — the SAME token-boundary-safe
+      // check #794 uses — so a merely-embedded or comment-only mention never
+      // counts as "present".
       const missing = wantedAccounts.filter(
         (w) => !natsConfigCanBindAccount(currentConf, w.pubkey).canBind,
       );
-      if (missing.length === 0) {
+      // cortex#1480 — an operator-mode config needs BOTH the SYS account
+      // PRELOADED (resolver_preload) AND a top-level `system_account: <SYS>`
+      // directive naming it: the preload lets nats-server RESOLVE the account,
+      // the directive tells it to USE that account as the system account (the
+      // `docs/config-layout/nats-server.conf.example` template documents both as
+      // required together for a JetStream bus). The from-scratch branch (3) below
+      // emits both, so this ensure-branch must match — otherwise a config that
+      // gains its SYS account here would know the account but never treat it as
+      // the system account. Add the directive idempotently: only when the package
+      // carries a SYS and the config has no `system_account:` directive yet
+      // (never clobber an existing one).
+      const sysDirectiveNeeded =
+        systemAccount !== undefined &&
+        systemAccount.length > 0 &&
+        !hasSystemAccountDirective(currentConf);
+      if (missing.length === 0 && !sysDirectiveNeeded) {
         // Byte-stable no-op (the orchestrator may skip the write).
         return { status: "already", conf: currentConf };
       }
-      const insertion = missing
-        .map((w) => `  // ${w.label} account (cortex#1480 ensure)\n  ${w.pubkey}: ${w.jwt}\n`)
-        .join("");
-      const next = insertIntoResolverPreload(currentConf, insertion);
-      if (next === null) {
-        return {
-          status: "refuse",
-          reason:
-            "the nats config is operator-mode under this operator but has no " +
-            "resolver_preload { … } block to add the missing account(s) into " +
-            `(${missing.map((w) => `${w.label} ${w.pubkey}`).join(", ")}) — convert/repair the ` +
-            "bus by hand (docs/sop-stack-onboarding.md §B0.1).",
-        };
+      let next = currentConf;
+      if (missing.length > 0) {
+        // One terse provenance marker for the whole appended run — this writes
+        // into the caller's LIVE nats config, so no per-line commentary.
+        const insertion =
+          "  // added by cortex network join/make-live (cortex#1480)\n" +
+          missing.map((w) => `  ${w.pubkey}: ${w.jwt}\n`).join("");
+        const inserted = insertIntoResolverPreload(next, insertion);
+        if (inserted === null) {
+          return {
+            status: "refuse",
+            reason:
+              "the nats config is operator-mode under this operator but has no " +
+              "resolver_preload { … } block to add the missing account(s) into " +
+              `(${missing.map((w) => `${w.label} ${w.pubkey}`).join(", ")}) — convert/repair the ` +
+              "bus by hand (docs/sop-stack-onboarding.md §B0.1).",
+          };
+        }
+        next = inserted;
+      }
+      if (sysDirectiveNeeded) {
+        // sysDirectiveNeeded ⇒ systemAccount is defined (TS narrows the aliased
+        // const condition), so no non-null assertion is needed.
+        next = appendSystemAccountDirective(next, systemAccount);
       }
       return { status: "converted", conf: next };
     }


### PR DESCRIPTION
## What
Fixes the **"does not define account `<FED>`" fail-closed** that blocked the metafactory-community join: an operator-mode bus whose `resolver_preload` carried only the AGENTS account would refuse a `join` because the leaf binds a FED account the server's resolver doesn't know.

Sub-issue of epic **#1479**, slice **join-1** (#1480). Absorbs **#1476** (FED-preload).

## Root cause
`renderOperatorModeBlocks`'s "already operator-mode" branch checked **only that the operator JWT matched** and returned the config byte-unchanged — it never verified that the accounts the package carries (FED, SYS) were actually preloaded. So a bus bootstrapped before its FED account existed (or hand-converted with only AGENTS) stayed "already operator-mode under the same operator" forever, and FED was never added. Hit by both `join`'s O-3 auto-convert path and `make-live`'s bootstrap path (whose `bootstrapNeeded` gate only fired when `resolver_preload` was *wholly absent*).

## Fix
- `OperatorModeLeafPackage` gains optional `agentsAccount`/`agentsAccountJwt` (alongside the existing `systemAccount`/`systemAccountJwt`). `renderOperatorModeBlocks` now computes the package's **wanted-account set** (FED always; AGENTS/SYS when present), uses the #794 **token-boundary-safe** `natsConfigCanBindAccount` to find any **missing** ones, and appends only the missing `pubkey: jwt` entries into the existing `resolver_preload` — returning `converted` instead of a no-op `already`. `insertIntoResolverPreload` moved here as the single pure source (re-exported for compat).
- `make-live`'s `bootstrapNeeded` now also fires when `resolver_preload` exists but the package's FED and/or SYS pubkey isn't present (via `ports.resolver.hasAccount`), not only when the block is wholly absent.

## Verification
- `bunx tsc --noEmit`, `bun run lint:errors`, `bash scripts/check-carveouts.sh` — all clean; **full suite 8779 pass / 0 fail**.
- Tests: the rendered `resolver_preload` contains exactly the account keys the stack declares (FED+AGENTS+SYS present-only); the leaf `account:` binds the FED key; and the **acceptance keystone** — the FED account referenced by the leaf is present in the rendered `resolver_preload` (the invariant whose violation is "does not define account `<FED>`") — asserted by an **independent** test-only `preloadKeys()` parse of the `resolver_preload {}` block (deliberately NOT via the production `natsConfigCanBindAccount` predicate, which would be circular — it's kept only as a labeled secondary sanity check). Plus a test that the ensure-branch also emits the `system_account:` directive when adding a SYS account. This is text-structure-verified, not nats-server-verified (see Out of scope).

## Out of scope (flagged)
- A real `nats-server -t` end-to-end couldn't run in the sandbox (no binary on PATH) — consistent with the pre-existing #1495 test-scope note; the pure invariant ("every referenced account is defined") is the documented substitute. Worth one live `nats-server -t` against a rendered fixture on a box with the binary before relying on it in anger.

Closes #1480
Refs #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
