### PR TITLE
feat(network): C-1485 — model the two-party join handoff as state (guided join) (epic #1479 slice 6)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -201,6 +201,57 @@ describe("join dry-run safety", () => {
 });
 
 // =============================================================================
+// cortex#1485 — `join --guided` fail-closed leaf-up gate
+// =============================================================================
+
+describe("#1485 — join --guided guard", () => {
+  test("--guided refuses the leaf-up step when the hub-authorize leg is unconfirmed (exit 1)", async () => {
+    const dir = freshDir();
+    // A fully-flagged join whose admission read cannot succeed (no seed file /
+    // unreachable registry) ⇒ seal leg NOT done; the hub-authorize leg is the
+    // documented stub (always undefined). So the guard MUST refuse the leaf-up
+    // step, fail-closed, before any join mutation is attempted.
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--guided",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0", // unreachable by construction
+      "--seed-path", join(dir, "seed.nk"), // missing → admission read fails
+      "--creds", join(dir, "andreas.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+    ], EMPTY_READER);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("cannot bring the leaf up");
+    // The refusal names the outstanding leg (seal here — it gates hub-authorize).
+    expect(res.stderr).toContain("seal");
+    // And nothing was written to disk (the guard fired before any mutation).
+    expect(existsSync(join(dir, "local.conf"))).toBe(false);
+    expect(existsSync(join(dir, "nats.plist"))).toBe(false);
+  });
+
+  test("WITHOUT --guided the same join proceeds past the gate (fails later on register, exit 1) — proving the gate is opt-in", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", join(dir, "seed.nk"),
+      "--creds", join(dir, "andreas.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+    ], EMPTY_READER);
+    expect(res.exitCode).toBe(1);
+    // The failure is NOT the guided-gate refusal — it's the downstream register
+    // failure (dry-run banner present), confirming the gate did not fire.
+    expect(res.stderr).not.toContain("cannot bring the leaf up");
+    expect(res.stderr).toContain("dry-run");
+  });
+});
+
+// =============================================================================
 // cortex#1228 — TOFU is never silent for a custom registry; pinned ⇒ no warning
 // =============================================================================
 

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -16,10 +16,12 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { dispatchNetwork, joinBlockerMessage, shouldReplaceCredsPreflightError } from "../network";
-import type { OwnAdmissionState } from "../../../../common/registry/admission-state";
+import { dispatchNetwork, joinBlockerMessage, shouldReplaceCredsPreflightError, type HandoffPortsFactory } from "../network";
+import type { OwnAdmissionState, ResolveOwnAdmissionStateResult } from "../../../../common/registry/admission-state";
 import type { LoadedConfig } from "../../../../common/config/loader";
 import type { AgentConfig } from "../../../../common/types/config";
+import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
+import type { NetworkHandoffPorts, HandoffHubAuthPort } from "../network-handoff-ports";
 
 // #753 — a reader returning an EMPTY config so derivation tests are
 // deterministic (no dependence on the dev machine's real ~/.config/cortex).
@@ -201,51 +203,140 @@ describe("join dry-run safety", () => {
 });
 
 // =============================================================================
-// cortex#1485 — `join --guided` fail-closed leaf-up gate
+// cortex#1485 (Sage #1499) — `join --guided` discriminating leaf-up gate
 // =============================================================================
 
-describe("#1485 — join --guided guard", () => {
-  test("--guided refuses the leaf-up step when the hub-authorize leg is unconfirmed (exit 1)", async () => {
+// A canned admission state (ADMITTED, optionally sealed) for the guard's seal leg.
+function admitted(hasSealedSecret: boolean): ResolveOwnAdmissionStateResult {
+  return {
+    ok: true,
+    state: {
+      state: hasSealedSecret ? "admitted-sealed" : "admitted-unsealed",
+      networkId: "metafactory",
+      requestId: "req-1",
+      hasSealedSecret,
+      peerPubkey: "PUBKEY_FIXTURE",
+    },
+  };
+}
+
+/** An injectable handoff-ports factory for the `join --guided` guard: seal leg
+ *  from a canned admission state; hub-authorize either the documented stub
+ *  (undefined) or a real true/false; leaf-up unused by the guard. */
+function guidedHandoffFactory(opts: {
+  sealed: boolean;
+  hubConfirmed?: boolean; // undefined = documented stub
+}): HandoffPortsFactory {
+  const hubAuth: HandoffHubAuthPort =
+    opts.hubConfirmed === undefined
+      ? { resolveHubAuthorized: async () => ({ confirmed: undefined, reason: "documented stub" }) }
+      : { resolveHubAuthorized: async () => ({ confirmed: opts.hubConfirmed }) };
+  const ports: NetworkHandoffPorts = {
+    admission: { resolve: async () => admitted(opts.sealed) },
+    hubAuth,
+    config: {
+      readNetworks: () => ({
+        networks: [
+          { id: "metafactory", leaf_node: "hub", peers: [], accept_subjects: [], deny_subjects: [] } as unknown as PolicyFederatedNetwork,
+        ],
+      }),
+    },
+    monitor: { resolve: () => ({ url: "http://127.0.0.1:8222", configured: true }), fetchLeafz: async () => ({ leafs: [] }) },
+  };
+  return () => ports;
+}
+
+/** dispatchNetwork(argv, load, ping, provision, secret, makeLive, keyRotation, doctor, handoff). */
+function joinWithHandoff(argv: string[], factory: HandoffPortsFactory) {
+  return dispatchNetwork(
+    argv,
+    EMPTY_READER,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    factory,
+  );
+}
+
+/** The full-flag join argv that derives cleanly on EMPTY_READER + reaches the guard. */
+function guidedArgv(dir: string, extra: string[]): string[] {
+  return [
+    "join", "metafactory",
+    ...extra,
+    "--principal", "andreas",
+    "--registry-url", "http://127.0.0.1:0",
+    "--seed-path", join(dir, "seed.nk"),
+    "--creds", join(dir, "andreas.creds"),
+    "--account", "A" + "B".repeat(55),
+    "--nats-config", join(dir, "local.conf"),
+    "--plist", join(dir, "nats.plist"),
+  ];
+}
+
+describe("#1485 — join --guided guard DISCRIMINATES", () => {
+  test("seal NOT done → BLOCK naming the seal leg (exit 1, no disk mutation)", async () => {
     const dir = freshDir();
-    // A fully-flagged join whose admission read cannot succeed (no seed file /
-    // unreachable registry) ⇒ seal leg NOT done; the hub-authorize leg is the
-    // documented stub (always undefined). So the guard MUST refuse the leaf-up
-    // step, fail-closed, before any join mutation is attempted.
-    const res = await dispatchNetwork([
-      "join", "metafactory",
-      "--guided",
-      "--principal", "andreas",
-      "--registry-url", "http://127.0.0.1:0", // unreachable by construction
-      "--seed-path", join(dir, "seed.nk"), // missing → admission read fails
-      "--creds", join(dir, "andreas.creds"),
-      "--account", "A" + "B".repeat(55),
-      "--nats-config", join(dir, "local.conf"),
-      "--plist", join(dir, "nats.plist"),
-    ], EMPTY_READER);
+    const res = await joinWithHandoff(guidedArgv(dir, ["--guided"]), guidedHandoffFactory({ sealed: false }));
     expect(res.exitCode).toBe(1);
     expect(res.stderr).toContain("cannot bring the leaf up");
-    // The refusal names the outstanding leg (seal here — it gates hub-authorize).
     expect(res.stderr).toContain("seal");
-    // And nothing was written to disk (the guard fired before any mutation).
     expect(existsSync(join(dir, "local.conf"))).toBe(false);
     expect(existsSync(join(dir, "nats.plist"))).toBe(false);
   });
 
-  test("WITHOUT --guided the same join proceeds past the gate (fails later on register, exit 1) — proving the gate is opt-in", async () => {
+  test("sealed, hub-authorize undefined (stub), NO attestation → BLOCK pointing at --hub-authorized-confirmed (exit 1)", async () => {
     const dir = freshDir();
-    const res = await dispatchNetwork([
-      "join", "metafactory",
-      "--principal", "andreas",
-      "--registry-url", "http://127.0.0.1:0",
-      "--seed-path", join(dir, "seed.nk"),
-      "--creds", join(dir, "andreas.creds"),
-      "--account", "A" + "B".repeat(55),
-      "--nats-config", join(dir, "local.conf"),
-      "--plist", join(dir, "nats.plist"),
-    ], EMPTY_READER);
+    const res = await joinWithHandoff(guidedArgv(dir, ["--guided"]), guidedHandoffFactory({ sealed: true }));
     expect(res.exitCode).toBe(1);
-    // The failure is NOT the guided-gate refusal — it's the downstream register
-    // failure (dry-run banner present), confirming the gate did not fire.
+    expect(res.stderr).toContain("can't be auto-verified");
+    expect(res.stderr).toContain("--hub-authorized-confirmed");
+    expect(existsSync(join(dir, "local.conf"))).toBe(false);
+  });
+
+  test("sealed + --hub-authorized-confirmed → PROCEEDS past the gate (fails later on register, not the guard)", async () => {
+    const dir = freshDir();
+    const res = await joinWithHandoff(
+      guidedArgv(dir, ["--guided", "--hub-authorized-confirmed"]),
+      guidedHandoffFactory({ sealed: true }),
+    );
+    expect(res.exitCode).toBe(1);
+    // Proof the guard PASSED: no guard-refusal message; the failure is the
+    // downstream register (dry-run banner present).
+    expect(res.stderr).not.toContain("cannot bring the leaf up");
+    expect(res.stderr).toContain("dry-run");
+  });
+
+  test("sealed + hub-authorize REAL true → PROCEEDS with NO attestation needed", async () => {
+    const dir = freshDir();
+    const res = await joinWithHandoff(
+      guidedArgv(dir, ["--guided"]),
+      guidedHandoffFactory({ sealed: true, hubConfirmed: true }),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).not.toContain("cannot bring the leaf up");
+    expect(res.stderr).toContain("dry-run");
+  });
+
+  test("sealed + hub-authorize REAL false → BLOCKS EVEN WITH attestation (attestation cannot override)", async () => {
+    const dir = freshDir();
+    const res = await joinWithHandoff(
+      guidedArgv(dir, ["--guided", "--hub-authorized-confirmed"]),
+      guidedHandoffFactory({ sealed: true, hubConfirmed: false }),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("cannot bring the leaf up");
+    expect(res.stderr).toContain("cannot override");
+    expect(existsSync(join(dir, "local.conf"))).toBe(false);
+  });
+
+  test("WITHOUT --guided the gate never fires (proceeds to register) — proving it is opt-in", async () => {
+    const dir = freshDir();
+    // Even with an unsealed admission state, no --guided ⇒ no gate.
+    const res = await joinWithHandoff(guidedArgv(dir, []), guidedHandoffFactory({ sealed: false }));
+    expect(res.exitCode).toBe(1);
     expect(res.stderr).not.toContain("cannot bring the leaf up");
     expect(res.stderr).toContain("dry-run");
   });

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -100,6 +100,8 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
       credsPath: "~/.config/nats/mf.creds",
       // #762 — FULL declares no network block, so no caps to announce.
       announceCapabilities: [],
+      // cortex#1485 — FULL declares no networks, so the composed set is empty.
+      policyNetworks: [],
     });
   });
 
@@ -280,6 +282,8 @@ describe("deriveJoinInputs — flag overrides win", () => {
       credsPath: "/flag/x.creds",
       // #762 — no caps flag exists; caps derive from the network block (none here).
       announceCapabilities: [],
+      // cortex#1485 — composed networks (none in FULL).
+      policyNetworks: [],
     });
   });
 

--- a/src/cli/cortex/commands/__tests__/network-handoff-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-handoff-cli.test.ts
@@ -1,0 +1,197 @@
+/**
+ * CLI-level tests for `cortex network handoff status` (cortex#1485, epic #1479).
+ *
+ * Drives `dispatchNetwork(["handoff", "status", <member>, "--network", ...],
+ * fakeReader, ...defaults, handoffPortsFactory)` with an injected fake config
+ * reader AND an injected fake handoff-ports factory — no NATS, no ~/.config,
+ * no live wire, no fs. Mirrors `network-doctor-cli.test.ts`'s dispatch-level
+ * factory injection.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { dispatchNetwork, type HandoffPortsFactory } from "../network";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
+import type { ResolveOwnAdmissionStateResult } from "../../../../common/registry/admission-state";
+import type { NetworkHandoffPorts, HandoffHubAuthPort } from "../network-handoff-ports";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function reader(): () => LoadedConfig {
+  return () =>
+    ({
+      config: { nats: { url: "nats://127.0.0.1:4222" } } as unknown as AgentConfig,
+      inlineAgents: [{ id: "sage" } as unknown as LoadedConfig["inlineAgents"][number]],
+      principal: { id: "andreas" },
+      stack: { id: "andreas/community", nkey_seed_path: "~/.config/nats/andreas-community.seed" },
+      policy: {
+        federated: {
+          networks: [
+            {
+              id: "metafactory-community",
+              leaf_node: "hub",
+              peers: [{ principal_id: "jc", stack_id: "jc/default" }],
+              accept_subjects: ["federated.>"],
+              deny_subjects: [],
+            } as unknown as PolicyFederatedNetwork,
+          ],
+        },
+      } as unknown as LoadedConfig["policy"],
+    });
+}
+
+const STUB_HUB_AUTH: HandoffHubAuthPort = {
+  resolveHubAuthorized: async () => ({ confirmed: undefined, reason: "documented stub" }),
+};
+
+function admitted(hasSealedSecret: boolean): ResolveOwnAdmissionStateResult {
+  return {
+    ok: true,
+    state: {
+      state: hasSealedSecret ? "admitted-sealed" : "admitted-unsealed",
+      networkId: "metafactory-community",
+      requestId: "req-1",
+      hasSealedSecret,
+      peerPubkey: "PUBKEY_FIXTURE",
+    },
+  };
+}
+
+/** A fake handoff-ports factory — records invocation, hands back canned ports. */
+function fakeHandoffFactory(opts: {
+  sealed: boolean;
+  hubConfirmed?: boolean;
+  leafUp?: boolean;
+}): { factory: HandoffPortsFactory; invoked: () => boolean } {
+  let wasInvoked = false;
+  const ports: NetworkHandoffPorts = {
+    admission: { resolve: async () => admitted(opts.sealed) },
+    hubAuth:
+      opts.hubConfirmed === undefined
+        ? STUB_HUB_AUTH
+        : { resolveHubAuthorized: async () => ({ confirmed: opts.hubConfirmed }) },
+    config: {
+      readNetworks: () => ({
+        networks: [
+          {
+            id: "metafactory-community",
+            leaf_node: "hub",
+            peers: [{ principal_id: "jc", stack_id: "jc/default" }],
+            accept_subjects: ["federated.>"],
+            deny_subjects: [],
+          } as unknown as PolicyFederatedNetwork,
+        ],
+      }),
+    },
+    monitor: {
+      resolve: () => ({ url: "http://127.0.0.1:8222", configured: true }),
+      fetchLeafz: async () =>
+        opts.leafUp === true ? { leafs: [{ name: "hub", account: "A" }] } : { leafs: [] },
+    },
+  };
+  const factory: HandoffPortsFactory = () => {
+    wasInvoked = true;
+    return ports;
+  };
+  return { factory, invoked: () => wasInvoked };
+}
+
+/** dispatchNetwork(argv, load, ping, provision, secret, makeLive, keyRotation, doctor, handoff). */
+async function runHandoffCli(argv: string[], factory: HandoffPortsFactory) {
+  return dispatchNetwork(
+    argv,
+    reader(),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    factory,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cortex network handoff status — human output", () => {
+  test("sealed, hub-authorize stub: lists 3 legs, outstanding hub-authorize, cannot bring leaf up", async () => {
+    const f = fakeHandoffFactory({ sealed: true });
+    const res = await runHandoffCli(
+      ["handoff", "status", "andreas", "--network", "metafactory-community", "--principal", "andreas"],
+      f.factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex network handoff status andreas");
+    expect(res.stdout).toContain("seal [done]");
+    expect(res.stdout).toContain("hub-authorize [pending]");
+    expect(res.stdout).toContain("leaf-up [blocked]");
+    expect(res.stdout).toContain("outstanding: hub-authorize (owner: hub-owner)");
+    expect(res.stdout).toContain("can bring leaf up: no");
+    expect(f.invoked()).toBe(true);
+  });
+
+  test("all legs done when hub confirmed + leaf up", async () => {
+    const f = fakeHandoffFactory({ sealed: true, hubConfirmed: true, leafUp: true });
+    const res = await runHandoffCli(
+      ["handoff", "status", "andreas", "--network", "metafactory-community", "--principal", "andreas"],
+      f.factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("outstanding: none");
+    expect(res.stdout).toContain("can bring leaf up: yes");
+  });
+});
+
+describe("cortex network handoff status — --json", () => {
+  test("emits per-leg rows + next_leg / can_bring_leaf_up data", async () => {
+    const f = fakeHandoffFactory({ sealed: true });
+    const res = await runHandoffCli(
+      ["handoff", "status", "andreas", "--network", "metafactory-community", "--principal", "andreas", "--json"],
+      f.factory,
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as {
+      status: string;
+      items: { id: string; status: string; owner: string }[];
+      data: { network: string; member: string; next_leg?: string; next_owner?: string; can_bring_leaf_up: string };
+    };
+    expect(parsed.status).toBe("ok");
+    expect(parsed.data.network).toBe("metafactory-community");
+    expect(parsed.data.member).toBe("andreas");
+    expect(parsed.data.next_leg).toBe("hub-authorize");
+    expect(parsed.data.next_owner).toBe("hub-owner");
+    expect(parsed.data.can_bring_leaf_up).toBe("false");
+    expect(parsed.items.map((i) => i.id)).toEqual(["seal", "hub-authorize", "leaf-up"]);
+    for (const item of parsed.items) {
+      expect(["admin", "hub-owner", "member"]).toContain(item.owner);
+    }
+  });
+});
+
+describe("cortex network handoff — usage errors", () => {
+  test("--network required", async () => {
+    const f = fakeHandoffFactory({ sealed: true });
+    const res = await runHandoffCli(
+      ["handoff", "status", "andreas", "--principal", "andreas"],
+      f.factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--network");
+  });
+
+  test("unknown action rejected", async () => {
+    const f = fakeHandoffFactory({ sealed: true });
+    const res = await runHandoffCli(
+      ["handoff", "wat", "andreas", "--network", "metafactory-community", "--principal", "andreas"],
+      f.factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain('unknown action "wat"');
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-handoff-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-handoff-lib.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the `cortex network handoff` PURE state model (cortex#1485, epic
+ * #1479, join-6).
+ *
+ * Two layers, both hermetic:
+ *   - `deriveHandoffState` / `guardLeafUp` — pure, no ports. Every combination
+ *     of the three leg signals → the correct legs / nextLeg / owner /
+ *     canBringLeafUp, plus the fail-closed treatment of an `undefined`
+ *     (documented-stub) hub-authorize signal.
+ *   - `runHandoffStatus` — driven with FAKE ports (a fake admission port, the
+ *     documented-stub hub-auth resolution, a fake config + monitor port). No
+ *     fs, no HTTP, no NATS.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
+import type { ResolveOwnAdmissionStateResult } from "../../../../common/registry/admission-state";
+import type { LeafzResponse } from "../network-doctor-ports";
+import {
+  canBringLeafUp,
+  deriveHandoffState,
+  guardLeafUp,
+  runHandoffStatus,
+  type HandoffLegId,
+  type HandoffLegStatus,
+} from "../network-handoff-lib";
+import type {
+  HandoffHubAuthPort,
+  NetworkHandoffPorts,
+} from "../network-handoff-ports";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function statusOf(
+  legs: { id: HandoffLegId; status: HandoffLegStatus }[],
+  id: HandoffLegId,
+): HandoffLegStatus | undefined {
+  return legs.find((l) => l.id === id)?.status;
+}
+
+// ---------------------------------------------------------------------------
+// deriveHandoffState — every leg combination
+// ---------------------------------------------------------------------------
+
+describe("deriveHandoffState — leg combinations", () => {
+  test("nothing done: seal pending, later legs blocked, next=seal/admin", () => {
+    const s = deriveHandoffState({ sealed: false, hubAuthorized: undefined, leafUp: false });
+    expect(statusOf(s.legs, "seal")).toBe("pending");
+    expect(statusOf(s.legs, "hub-authorize")).toBe("blocked");
+    expect(statusOf(s.legs, "leaf-up")).toBe("blocked");
+    expect(s.nextLeg).toBe("seal");
+    expect(s.nextOwner).toBe("admin");
+    expect(s.canBringLeafUp).toBe(false);
+  });
+
+  test("sealed only, hub-authorize UNKNOWN (undefined): hub-authorize pending, leaf-up blocked, next=hub-authorize/hub-owner", () => {
+    const s = deriveHandoffState({ sealed: true, hubAuthorized: undefined, leafUp: false });
+    expect(statusOf(s.legs, "seal")).toBe("done");
+    expect(statusOf(s.legs, "hub-authorize")).toBe("pending");
+    expect(statusOf(s.legs, "leaf-up")).toBe("blocked");
+    expect(s.nextLeg).toBe("hub-authorize");
+    expect(s.nextOwner).toBe("hub-owner");
+    // fail-closed — undefined is NOT done.
+    expect(s.canBringLeafUp).toBe(false);
+  });
+
+  test("sealed only, hub-authorize explicitly false: same as unknown (fail-closed)", () => {
+    const s = deriveHandoffState({ sealed: true, hubAuthorized: false, leafUp: false });
+    expect(statusOf(s.legs, "hub-authorize")).toBe("pending");
+    expect(s.nextLeg).toBe("hub-authorize");
+    expect(s.canBringLeafUp).toBe(false);
+  });
+
+  test("sealed + hub-authorized, leaf not up: leaf-up pending, next=leaf-up/member, canBringLeafUp=true", () => {
+    const s = deriveHandoffState({ sealed: true, hubAuthorized: true, leafUp: false });
+    expect(statusOf(s.legs, "seal")).toBe("done");
+    expect(statusOf(s.legs, "hub-authorize")).toBe("done");
+    expect(statusOf(s.legs, "leaf-up")).toBe("pending");
+    expect(s.nextLeg).toBe("leaf-up");
+    expect(s.nextOwner).toBe("member");
+    expect(s.canBringLeafUp).toBe(true);
+  });
+
+  test("all three done: no outstanding leg, canBringLeafUp=true", () => {
+    const s = deriveHandoffState({ sealed: true, hubAuthorized: true, leafUp: true });
+    expect(s.legs.every((l) => l.status === "done")).toBe(true);
+    expect(s.nextLeg).toBeUndefined();
+    expect(s.nextOwner).toBeUndefined();
+    expect(s.canBringLeafUp).toBe(true);
+  });
+
+  test("legs are always exactly [seal, hub-authorize, leaf-up] in order", () => {
+    const s = deriveHandoffState({ sealed: false, hubAuthorized: false, leafUp: false });
+    expect(s.legs.map((l) => l.id)).toEqual(["seal", "hub-authorize", "leaf-up"]);
+    expect(s.legs.map((l) => l.owner)).toEqual(["admin", "hub-owner", "member"]);
+  });
+
+  test("hub-authorize done but seal NOT done cannot happen — seal gates hub-authorize (defensive: leaf up but not sealed still blocked)", () => {
+    // A pathological input: leafUp true while unsealed. Ordering must still hold —
+    // both later legs read blocked, canBringLeafUp false.
+    const s = deriveHandoffState({ sealed: false, hubAuthorized: true, leafUp: true });
+    expect(statusOf(s.legs, "hub-authorize")).toBe("blocked");
+    expect(statusOf(s.legs, "leaf-up")).toBe("blocked");
+    expect(s.nextLeg).toBe("seal");
+    expect(s.canBringLeafUp).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canBringLeafUp — the pure gate
+// ---------------------------------------------------------------------------
+
+describe("canBringLeafUp", () => {
+  test("true only when sealed AND hubAuthorized === true", () => {
+    expect(canBringLeafUp(true, true)).toBe(true);
+    expect(canBringLeafUp(true, false)).toBe(false);
+    expect(canBringLeafUp(true, undefined)).toBe(false);
+    expect(canBringLeafUp(false, true)).toBe(false);
+    expect(canBringLeafUp(false, undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// guardLeafUp — the enforcement message
+// ---------------------------------------------------------------------------
+
+describe("guardLeafUp", () => {
+  test("allows when canBringLeafUp", () => {
+    const s = deriveHandoffState({ sealed: true, hubAuthorized: true, leafUp: false });
+    const g = guardLeafUp(s, "metafactory-community");
+    expect(g.allowed).toBe(true);
+  });
+
+  test("refuses when hub-authorize pending, naming the outstanding leg + owner", () => {
+    const s = deriveHandoffState({ sealed: true, hubAuthorized: undefined, leafUp: false });
+    const g = guardLeafUp(s, "metafactory-community");
+    expect(g.allowed).toBe(false);
+    if (!g.allowed) {
+      expect(g.message).toContain("hub-authorize");
+      expect(g.message).toContain("hub-owner");
+      expect(g.message).toContain("metafactory-community");
+    }
+  });
+
+  test("refuses when seal pending, naming seal + admin", () => {
+    const s = deriveHandoffState({ sealed: false, hubAuthorized: undefined, leafUp: false });
+    const g = guardLeafUp(s, "net-x");
+    expect(g.allowed).toBe(false);
+    if (!g.allowed) {
+      expect(g.message).toContain("seal");
+      expect(g.message).toContain("admin");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runHandoffStatus — driven with fake ports
+// ---------------------------------------------------------------------------
+
+function net(overrides: Partial<PolicyFederatedNetwork> = {}): PolicyFederatedNetwork {
+  return {
+    id: "metafactory-community",
+    leaf_node: "hub",
+    peers: [{ principal_id: "jc", stack_id: "jc/default" }],
+    accept_subjects: ["federated.>"],
+    deny_subjects: [],
+    ...overrides,
+  } as unknown as PolicyFederatedNetwork;
+}
+
+function admittedResult(hasSealedSecret: boolean): ResolveOwnAdmissionStateResult {
+  return {
+    ok: true,
+    state: {
+      state: hasSealedSecret ? "admitted-sealed" : "admitted-unsealed",
+      networkId: "metafactory-community",
+      requestId: "req-1",
+      hasSealedSecret,
+      peerPubkey: "PUBKEY_FIXTURE",
+    },
+  };
+}
+
+const STUB_HUB_AUTH: HandoffHubAuthPort = {
+  resolveHubAuthorized: async () => ({
+    confirmed: undefined,
+    reason: "documented stub — no hub-owner marker",
+  }),
+};
+
+function fakePorts(opts: {
+  admission: ResolveOwnAdmissionStateResult;
+  networks: PolicyFederatedNetwork[];
+  leafz?: LeafzResponse;
+  hubAuth?: HandoffHubAuthPort;
+}): NetworkHandoffPorts {
+  return {
+    admission: { resolve: async () => opts.admission },
+    hubAuth: opts.hubAuth ?? STUB_HUB_AUTH,
+    config: { readNetworks: () => ({ networks: opts.networks }) },
+    monitor: {
+      resolve: () => ({ url: "http://127.0.0.1:8222", configured: true }),
+      fetchLeafz: async () => opts.leafz,
+    },
+  };
+}
+
+describe("runHandoffStatus", () => {
+  test("sealed + leaf up, hub-authorize stub: seal done, hub-authorize pending, leaf-up blocked (gated), canBringLeafUp false", async () => {
+    const ports = fakePorts({
+      admission: admittedResult(true),
+      networks: [net()],
+      leafz: { leafs: [{ name: "hub", account: "A", in_msgs: 1, out_msgs: 1 }] },
+    });
+    const report = await runHandoffStatus(ports, {
+      networkId: "metafactory-community",
+      member: "andreas",
+      selfPrincipal: "andreas",
+    });
+    expect(statusOf(report.state.legs, "seal")).toBe("done");
+    expect(statusOf(report.state.legs, "hub-authorize")).toBe("pending");
+    // leaf-up is blocked because hub-authorize (its prerequisite) is not done,
+    // EVEN THOUGH the fake /leafz shows an established leaf.
+    expect(statusOf(report.state.legs, "leaf-up")).toBe("blocked");
+    expect(report.state.canBringLeafUp).toBe(false);
+  });
+
+  test("sealed + hub-authorize confirmed + leaf up: all done", async () => {
+    const ports = fakePorts({
+      admission: admittedResult(true),
+      networks: [net()],
+      leafz: { leafs: [{ name: "hub", account: "A" }] },
+      hubAuth: { resolveHubAuthorized: async () => ({ confirmed: true }) },
+    });
+    const report = await runHandoffStatus(ports, {
+      networkId: "metafactory-community",
+      member: "andreas",
+      selfPrincipal: "andreas",
+    });
+    expect(report.state.legs.every((l) => l.status === "done")).toBe(true);
+    expect(report.state.canBringLeafUp).toBe(true);
+    expect(report.state.nextLeg).toBeUndefined();
+  });
+
+  test("not sealed: seal pending, note-free, next=seal", async () => {
+    const ports = fakePorts({
+      admission: admittedResult(false),
+      networks: [net()],
+      leafz: { leafs: [] },
+    });
+    const report = await runHandoffStatus(ports, {
+      networkId: "metafactory-community",
+      member: "andreas",
+      selfPrincipal: "andreas",
+    });
+    expect(statusOf(report.state.legs, "seal")).toBe("pending");
+    expect(report.state.nextLeg).toBe("seal");
+  });
+
+  test("admission read fails: adds a note, seal treated as not done", async () => {
+    const ports = fakePorts({
+      admission: { ok: false, reason: "registry unreachable" },
+      networks: [net()],
+    });
+    const report = await runHandoffStatus(ports, {
+      networkId: "metafactory-community",
+      member: "andreas",
+      selfPrincipal: "andreas",
+    });
+    expect(statusOf(report.state.legs, "seal")).toBe("pending");
+    expect(report.notes.some((n) => n.includes("registry unreachable"))).toBe(true);
+  });
+
+  test("member != selfPrincipal: adds the self-vs-remote leaf-up caveat note", async () => {
+    const ports = fakePorts({
+      admission: admittedResult(true),
+      networks: [net()],
+      leafz: { leafs: [{ name: "hub" }] },
+    });
+    const report = await runHandoffStatus(ports, {
+      networkId: "metafactory-community",
+      member: "jc",
+      selfPrincipal: "andreas",
+    });
+    expect(report.notes.some((n) => n.includes("leaf-up leg reflects THIS machine"))).toBe(true);
+  });
+
+  test("network not configured locally: leaf-up leg cannot read, note added", async () => {
+    const ports = fakePorts({
+      admission: admittedResult(true),
+      networks: [],
+    });
+    const report = await runHandoffStatus(ports, {
+      networkId: "metafactory-community",
+      member: "andreas",
+      selfPrincipal: "andreas",
+    });
+    expect(report.notes.some((n) => n.includes("not configured locally"))).toBe(true);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-handoff-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-handoff-lib.test.ts
@@ -92,6 +92,20 @@ describe("deriveHandoffState — leg combinations", () => {
     expect(s.canBringLeafUp).toBe(true);
   });
 
+  test("sealed + attested, leaf-up UNKNOWN (undefined): hub-authorize attested-done, leaf-up pending, canBringLeafUp=true", () => {
+    const s = deriveHandoffState(
+      { sealed: true, hubAuthorized: undefined, leafUp: undefined },
+      { attested: true },
+    );
+    expect(statusOf(s.legs, "hub-authorize")).toBe("done");
+    // leaf-up is ready (seal+hub done) but its state is unobservable → pending,
+    // NOT a false "done".
+    expect(statusOf(s.legs, "leaf-up")).toBe("pending");
+    expect(s.legs.find((l) => l.id === "leaf-up")?.detail).toContain("not observable");
+    expect(s.canBringLeafUp).toBe(true);
+    expect(s.nextLeg).toBe("leaf-up");
+  });
+
   test("legs are always exactly [seal, hub-authorize, leaf-up] in order", () => {
     const s = deriveHandoffState({ sealed: false, hubAuthorized: false, leafUp: false });
     expect(s.legs.map((l) => l.id)).toEqual(["seal", "hub-authorize", "leaf-up"]);
@@ -114,12 +128,23 @@ describe("deriveHandoffState — leg combinations", () => {
 // ---------------------------------------------------------------------------
 
 describe("canBringLeafUp", () => {
-  test("true only when sealed AND hubAuthorized === true", () => {
+  test("true when sealed AND hubAuthorized === true (no attestation needed)", () => {
     expect(canBringLeafUp(true, true)).toBe(true);
     expect(canBringLeafUp(true, false)).toBe(false);
     expect(canBringLeafUp(true, undefined)).toBe(false);
     expect(canBringLeafUp(false, true)).toBe(false);
     expect(canBringLeafUp(false, undefined)).toBe(false);
+  });
+
+  test("attestation upgrades an UNDEFINED hub-authorize (the discriminating case)", () => {
+    // undefined + attested → PROCEEDS.
+    expect(canBringLeafUp(true, undefined, true)).toBe(true);
+    // but still needs the seal leg.
+    expect(canBringLeafUp(false, undefined, true)).toBe(false);
+  });
+
+  test("attestation NEVER upgrades a REAL false hub-authorize", () => {
+    expect(canBringLeafUp(true, false, true)).toBe(false);
   });
 });
 
@@ -134,19 +159,43 @@ describe("guardLeafUp", () => {
     expect(g.allowed).toBe(true);
   });
 
-  test("refuses when hub-authorize pending, naming the outstanding leg + owner", () => {
+  test("PROCEEDS when hub-authorize is undefined but the member attests (--hub-authorized-confirmed)", () => {
+    const s = deriveHandoffState(
+      { sealed: true, hubAuthorized: undefined, leafUp: false },
+      { attested: true },
+    );
+    expect(s.canBringLeafUp).toBe(true);
+    expect(guardLeafUp(s, "metafactory-community").allowed).toBe(true);
+  });
+
+  test("refuses (hub-unverifiable) when hub-authorize undefined + NO attestation — message points at --hub-authorized-confirmed", () => {
     const s = deriveHandoffState({ sealed: true, hubAuthorized: undefined, leafUp: false });
+    expect(s.leafUpBlockedReason).toBe("hub-unverifiable");
     const g = guardLeafUp(s, "metafactory-community");
     expect(g.allowed).toBe(false);
     if (!g.allowed) {
-      expect(g.message).toContain("hub-authorize");
-      expect(g.message).toContain("hub-owner");
+      expect(g.message).toContain("can't be auto-verified");
+      expect(g.message).toContain("--hub-authorized-confirmed");
       expect(g.message).toContain("metafactory-community");
     }
   });
 
-  test("refuses when seal pending, naming seal + admin", () => {
+  test("refuses (hub-denied) on a REAL false hub-authorize EVEN with attestation — message says attestation cannot override", () => {
+    const s = deriveHandoffState(
+      { sealed: true, hubAuthorized: false, leafUp: false },
+      { attested: true },
+    );
+    expect(s.leafUpBlockedReason).toBe("hub-denied");
+    const g = guardLeafUp(s, "metafactory-community");
+    expect(g.allowed).toBe(false);
+    if (!g.allowed) {
+      expect(g.message).toContain("cannot override");
+    }
+  });
+
+  test("refuses (seal-pending) when seal pending, naming seal + admin", () => {
     const s = deriveHandoffState({ sealed: false, hubAuthorized: undefined, leafUp: false });
+    expect(s.leafUpBlockedReason).toBe("seal-pending");
     const g = guardLeafUp(s, "net-x");
     expect(g.allowed).toBe(false);
     if (!g.allowed) {
@@ -285,7 +334,9 @@ describe("runHandoffStatus", () => {
       member: "jc",
       selfPrincipal: "andreas",
     });
-    expect(report.notes.some((n) => n.includes("leaf-up leg reflects THIS machine"))).toBe(true);
+    expect(report.notes.some((n) => n.includes("not observable for member"))).toBe(true);
+    // The leaf-up signal is UNKNOWN for a remote member — never a false local read.
+    expect(statusOf(report.state.legs, "leaf-up") === "done").toBe(false);
   });
 
   test("network not configured locally: leaf-up leg cannot read, note added", async () => {

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -38,6 +38,7 @@
  */
 
 import type { LoadedConfig } from "../../../common/config/loader";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
 import type { ServicePlatform } from "../../../common/nats/nats-service-manager";
 import type { OperatorModeLeafPackage } from "../../../common/nats/leaf-remote-renderer";
 import { deriveStackId } from "../../../common/types/stack";
@@ -170,6 +171,13 @@ export interface DerivedJoinInputs {
    * principal joins the network's roster.
    */
   announceCapabilities: string[];
+  /**
+   * cortex#1485 (Sage #1499) — the COMPOSED `policy.federated.networks[]` from
+   * the loaded config, threaded through so the `join --guided` handoff guard can
+   * build its config port (leaf-up leg lookup) off the same composed networks
+   * the daemon loads, without re-reading the file. Empty when none are declared.
+   */
+  policyNetworks: PolicyFederatedNetwork[];
 }
 
 /** The leave inputs — a strict subset (no registry / seed / account / creds). */
@@ -566,6 +574,8 @@ export function deriveJoinInputs(
       ...(leafUser !== undefined && { leafUser }),
       ...(operatorModePackage !== undefined && { operatorModePackage }),
       announceCapabilities,
+      // cortex#1485 — the composed networks, for the --guided handoff guard.
+      policyNetworks: cfg.policy?.federated?.networks ?? [],
     },
   };
 }

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -446,6 +446,23 @@ function findEstablishedLeaf(
     : undefined;
 }
 
+/**
+ * cortex#1485 — the pure BOOLEAN form of the leaf-established leg, for reuse by
+ * `cortex network handoff`'s leaf-up leg. `true` iff `/leafz` shows an
+ * established leaf attributable to this network (a name/account match, or the
+ * lone-leaf fallback on a single-leaf bus — the SAME attribution
+ * {@link findEstablishedLeaf} applies for `doctor`'s leaf-established check).
+ * `undefined` leafz (no monitor data) ⇒ `false` (not established). Pure — no
+ * I/O; the caller supplies the `/leafz` snapshot.
+ */
+export function isLeafEstablished(
+  leafz: LeafzResponse | undefined,
+  network: PolicyFederatedNetwork,
+): boolean {
+  if (leafz === undefined) return false;
+  return findEstablishedLeaf(leafz, network.leaf_node) !== undefined;
+}
+
 function checkLeafEstablished(
   leafz: LeafzResponse | undefined,
   network: PolicyFederatedNetwork,

--- a/src/cli/cortex/commands/network-handoff-adapters.ts
+++ b/src/cli/cortex/commands/network-handoff-adapters.ts
@@ -1,0 +1,89 @@
+/**
+ * `cortex network handoff` — LIVE adapters (cortex#1485, epic #1479, join-6).
+ *
+ * Wires the three leg signals the pure orchestrator (`network-handoff-lib.ts`)
+ * depends on. Two are REUSED wholesale (no reimplementation):
+ *   - the seal leg's `admission` port is `buildAdmissionStatePort` from
+ *     `network-adapters.ts` (the SAME member PoP `/mine` read `status` uses).
+ *   - the leaf-up leg's `config` + `monitor` ports are `buildDoctorConfigPort`
+ *     + `buildMonitorPort` from `network-doctor-adapters.ts` (the SAME
+ *     `readNetworks()` + `/leafz` reads `doctor` uses).
+ *
+ * The one adapter that is genuinely local to this module is the hub-authorize
+ * leg — and it is a DOCUMENTED STUB. See {@link buildStubHubAuthPort}.
+ */
+
+import type { LivePortsConfig } from "./network-adapters";
+import { buildAdmissionStatePort } from "./network-adapters";
+import { buildDoctorConfigPort, buildMonitorPort } from "./network-doctor-adapters";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import type {
+  HandoffHubAuthPort,
+  HubAuthorizeResolution,
+  NetworkHandoffPorts,
+} from "./network-handoff-ports";
+
+/**
+ * The hub-authorize leg adapter — a DOCUMENTED STUB (cortex#1485).
+ *
+ * `resolveHubAuthorized` ALWAYS returns `confirmed: undefined`, because there
+ * is NO signal a member's machine can read to confirm the hub owner applied
+ * the authorization:
+ *   - The member has no hub-side visibility at all (the cortex#1481 constraint
+ *     that made `admit`/`secret` grow a seal-only path in the first place).
+ *   - The registry's admission row carries only an OPAQUE ciphertext sealed to
+ *     the member's OWN pubkey (ADR-0018 Q1) — there is nothing on it that says
+ *     "the hub owner has authorized this member". This is the SAME gap
+ *     `cortex network doctor`'s Pair 3 leg (`sealed-secret-hub-authorized`,
+ *     cortex#1482) already documents and always `skip`s.
+ *   - A successful leaf connection is NOT a usable signal here — leaf-up is
+ *     precisely the thing this handoff GATES on hub-authorize, so inferring
+ *     hub-authorize from it would be circular.
+ *
+ * The clean fix — and the counterpart WRITE this stub is designed to read the
+ * moment it exists — is an EXPLICIT per-member marker on the registry
+ * admission row (a `hub_authorized_at` timestamp / boolean) that the hub owner
+ * STAMPS when they apply the authorization. That is a real change to the
+ * registry's `admission_requests` SQL table (`src/services/network-registry/
+ * src/{types,store}.ts`) plus a hub-owner-side action (most naturally a flag on
+ * the existing `secret add-member` / `admit` seal path), so it is out of scope
+ * for THIS slice — tracked as a follow-up. The pure state model
+ * ({@link import("./network-handoff-lib").deriveHandoffState}) already types
+ * this signal `boolean | undefined` and treats `undefined` as fail-closed
+ * (NOT done), so the moment a live `hub_authorized_at` read is wired here,
+ * nothing in the state model or the leaf-up guard changes.
+ */
+export function buildStubHubAuthPort(): HandoffHubAuthPort {
+  return {
+    resolveHubAuthorized(_networkId: string, _member: string): Promise<HubAuthorizeResolution> {
+      return Promise.resolve({
+        confirmed: undefined,
+        reason:
+          "cannot be confirmed from the member side — the registry admission row carries no hub-owner " +
+          "authorization marker today (documented stub; needs a `hub_authorized_at`-style field the hub " +
+          "owner stamps on the seal path — follow-up). Treated as NOT done, fail-closed.",
+      });
+    },
+  };
+}
+
+/**
+ * Build the live handoff ports bundle from the resolved {@link LivePortsConfig}
+ * + the composed `policy.federated.networks[]` (read off the already-loaded
+ * config, NOT re-parsed — the config-split #814 concern). Read-only: every
+ * port here only reads (admission `/mine`, `/leafz`, config); none mutate.
+ */
+export function buildLiveHandoffPorts(
+  cfg: LivePortsConfig,
+  networks: PolicyFederatedNetwork[],
+): NetworkHandoffPorts {
+  return {
+    admission: buildAdmissionStatePort(cfg),
+    hubAuth: buildStubHubAuthPort(),
+    config: buildDoctorConfigPort({
+      networks,
+      ...(cfg.natsConfigPath !== undefined && { natsConfigPath: cfg.natsConfigPath }),
+    }),
+    monitor: buildMonitorPort(cfg),
+  };
+}

--- a/src/cli/cortex/commands/network-handoff-lib.ts
+++ b/src/cli/cortex/commands/network-handoff-lib.ts
@@ -15,37 +15,34 @@
  * — plus the enforcement gate (`guardLeafUp`) that refuses the leaf-up leg
  * until its dependencies are done.
  *
- * ## The three leg SIGNALS — what's real vs a documented stub
+ * ## The three leg SIGNALS — real vs unknown vs documented stub
  *
- *   - **seal** (admin) — REAL. Fed by {@link HandoffSignals.sealed}, which the
- *     orchestrator ({@link runHandoffStatus}) resolves via the SAME
- *     `AdmissionStatePort` PoP `/mine` read `cortex network status`'s C-1350
- *     admission lookup and `join`'s C-1315 blocker-classification already use
- *     — `hasSealedSecret` on the member's own ADMITTED admission row.
- *   - **hub-authorize** (hub owner) — a DOCUMENTED STUB today. This is
- *     exactly the gap `cortex network doctor`'s Pair 3 leg
- *     (`sealed-secret-hub-authorized`, cortex#1482) already named: the member
- *     has no hub-side visibility (cortex#1481), and the registry carries only
- *     an opaque ciphertext sealed to the member's OWN pubkey — there is no
- *     plaintext here to compare against the hub's live `authorization`
- *     entries. A real signal needs an EXPLICIT hub-owner-side marker (e.g. a
- *     `hub_authorized_at` field stamped onto the registry admission row by a
- *     hub-owner action) that does not exist yet — see
- *     `network-handoff-adapters.ts` for why (the `admission_requests` table
- *     is a real SQL table, so adding the column is a registry
- *     schema/migration — out of scope for this slice). `HandoffSignals.hubAuthorized`
- *     is typed `boolean | undefined` specifically so this module is ready to
- *     read that signal the moment it exists, without a shape change here.
- *   - **leaf-up** (member) — REAL. Fed by {@link HandoffSignals.leafUp}, which
- *     the orchestrator resolves via `isLeafEstablished` (exported from
- *     `network-doctor-lib.ts`) — the SAME `/leafz` leaf-established lookup
- *     `cortex network doctor`'s leg 3 (#1484) performs, not a second
- *     implementation.
+ * Each signal is a THREE-valued input (`true` / `false` / `undefined`), and
+ * the distinction is load-bearing (Sage review, #1499):
  *
- * `hubAuthorized: undefined` (the documented-stub state, always what the live
- * adapter returns today) is treated exactly like `false` — fail-closed: an
- * UNKNOWN hub-authorize leg blocks leaf-up exactly as a KNOWN-pending one
- * would. It never silently unblocks just because the signal happens not to
+ *   - **seal** (admin) — `boolean`. Fed by the member's own ADMITTED admission
+ *     row (`hasSealedSecret`), via the SAME `AdmissionStatePort` PoP `/mine`
+ *     read `cortex network status`'s C-1350 lookup uses.
+ *   - **hub-authorize** (hub owner) — `boolean | undefined`:
+ *       - `true`  — a real signal says the hub owner applied the authorization
+ *                   (the #1498 registry `hub_authorized_at` marker, once wired).
+ *       - `false` — a real signal says they have NOT (a HARD negative — a
+ *                   member attestation can NEVER override it).
+ *       - `undefined` — cannot be auto-verified from the member side today (the
+ *                   documented-stub / remote case: no hub-side visibility per
+ *                   cortex#1481, no registry marker until #1498). This is where
+ *                   the member ATTESTATION (`attested`) applies: it upgrades an
+ *                   `undefined` to treated-done, so `--guided` is a real
+ *                   deliberate-confirmation gate TODAY, not an unconditional
+ *                   off-switch. It NEVER upgrades a real `false`.
+ *   - **leaf-up** (member) — `boolean | undefined`. `true`/`false` from the
+ *     LOCAL `/leafz` when the report is about the local stack; `undefined` when
+ *     the report is about a REMOTE member (a member's leaf is observable only on
+ *     that member's own machine — reporting the local machine's leaf as theirs
+ *     would be a false read, Sage review #1499).
+ *
+ * `hubAuthorized: undefined` WITHOUT an attestation is treated as NOT done —
+ * fail-closed. It never silently unblocks just because the signal doesn't
  * exist yet.
  */
 
@@ -64,17 +61,32 @@ export interface HandoffLeg {
 
 /** The raw per-leg signals {@link deriveHandoffState} derives from. */
 export interface HandoffSignals {
-  /** seal leg — real: a sealed leaf secret present on the ADMITTED row. */
+  /** seal leg — a sealed leaf secret present on the ADMITTED row. */
   sealed: boolean;
   /**
-   * hub-authorize leg — `true`/`false` once a real hub-owner-side marker
-   * exists; `undefined` on the documented-stub path (today, always — see the
-   * module doc). Any value other than exactly `true` is treated as NOT done.
+   * hub-authorize leg — `true` (real done) / `false` (real NOT done, hard) /
+   * `undefined` (cannot auto-verify: documented-stub or remote). See module doc.
    */
   hubAuthorized: boolean | undefined;
-  /** leaf-up leg — real: an established leaf found for this network. */
-  leafUp: boolean;
+  /**
+   * leaf-up leg — `true`/`false` from LOCAL `/leafz`, or `undefined` when the
+   * report is about a remote member whose leaf this machine cannot observe.
+   */
+  leafUp: boolean | undefined;
 }
+
+/** Options for {@link deriveHandoffState}. */
+export interface DeriveHandoffOptions {
+  /**
+   * The member's own attestation (`join --hub-authorized-confirmed`): "the hub
+   * owner has confirmed to me that they applied my authorization". Upgrades an
+   * `undefined` hub-authorize signal to treated-done — but NEVER a real `false`.
+   */
+  attested?: boolean;
+}
+
+/** Why the leaf-up leg is not yet allowed (feeds {@link guardLeafUp}'s message). */
+export type LeafUpBlockedReason = "seal-pending" | "hub-unverifiable" | "hub-denied";
 
 export interface HandoffState {
   /** Always exactly 3 legs, in `seal, hub-authorize, leaf-up` order. */
@@ -84,98 +96,138 @@ export interface HandoffState {
   /** The owner of {@link nextLeg}. `undefined` when every leg is done. */
   nextOwner?: HandoffOwner;
   /**
-   * `true` only when BOTH `seal` and `hub-authorize` are done. This is
-   * exactly the gate {@link guardLeafUp} enforces before a member's leaf-up
-   * step is allowed to run.
+   * `true` only when `seal` is done AND the hub-authorize leg is effectively
+   * done (a real `true`, or an `undefined` upgraded by a member attestation —
+   * never a real `false`). This is exactly the gate {@link guardLeafUp}
+   * enforces before a member's leaf-up step is allowed to run.
    */
   canBringLeafUp: boolean;
+  /**
+   * When `canBringLeafUp` is false, WHY the leaf-up step is blocked — so
+   * {@link guardLeafUp} can name the right remedy (admin seal vs an
+   * un-auto-verifiable hub leg the member can attest vs a hard hub denial).
+   */
+  leafUpBlockedReason?: LeafUpBlockedReason;
 }
 
-const TITLES: Record<HandoffLegId, string> = {
-  seal: "seal — admin mints + seals the leaf secret",
-  "hub-authorize": "hub-authorize — hub owner applies the authorization",
-  "leaf-up": "leaf-up — member brings the leaf online",
+/** cortex#1485 (Sage #1499 nit) — the per-leg descriptor table, ONE place for
+ *  id → title + owner, so the derive branches don't each repeat them. */
+const LEG_DESCRIPTORS: Record<HandoffLegId, { title: string; owner: HandoffOwner }> = {
+  seal: { title: "seal — admin mints + seals the leaf secret", owner: "admin" },
+  "hub-authorize": {
+    title: "hub-authorize — hub owner applies the authorization",
+    owner: "hub-owner",
+  },
+  "leaf-up": { title: "leaf-up — member brings the leaf online", owner: "member" },
 };
 
-const OWNERS: Record<HandoffLegId, HandoffOwner> = {
-  seal: "admin",
-  "hub-authorize": "hub-owner",
-  "leaf-up": "member",
-};
-
-/**
- * Pure — `true` only when both legs a leaf-up depends on are DONE.
- * Fail-closed: an `undefined` (documented-stub / unknown) hub-authorize
- * signal is treated as NOT done, same as an explicit `false`.
- */
-export function canBringLeafUp(sealed: boolean, hubAuthorized: boolean | undefined): boolean {
-  return sealed && hubAuthorized === true;
+function leg(id: HandoffLegId, status: HandoffLegStatus, detail: string): HandoffLeg {
+  const d = LEG_DESCRIPTORS[id];
+  return { id, title: d.title, owner: d.owner, status, detail };
 }
 
 /**
- * Derive the full 3-leg handoff state from the raw signals. Pure — no I/O.
- * Ordering is fixed (seal → hub-authorize → leaf-up); a leg reads `blocked`
- * (rather than merely `pending`) once an EARLIER leg in the chain isn't done,
- * so the report always names exactly one leg as the outstanding next step.
+ * The effective "hub-authorize is done" decision. Pure. A real `true` is done;
+ * an `undefined` becomes done ONLY under a member attestation; a real `false`
+ * is NEVER done (attestation cannot override a real negative).
  */
-export function deriveHandoffState(signals: HandoffSignals): HandoffState {
-  const hubDone = signals.hubAuthorized === true;
+function hubAuthorizeDone(hubAuthorized: boolean | undefined, attested: boolean): boolean {
+  if (hubAuthorized === true) return true;
+  if (hubAuthorized === false) return false;
+  return attested; // undefined → attested upgrades it
+}
 
-  const seal: HandoffLeg = {
-    id: "seal",
-    title: TITLES.seal,
-    owner: OWNERS.seal,
-    status: signals.sealed ? "done" : "pending",
-    detail: signals.sealed
+/**
+ * Pure — `true` only when the seal leg is done AND the hub-authorize leg is
+ * effectively done. Fail-closed: an `undefined` hub-authorize with NO
+ * attestation is NOT done; a real `false` is NOT done even WITH attestation.
+ */
+export function canBringLeafUp(
+  sealed: boolean,
+  hubAuthorized: boolean | undefined,
+  attested = false,
+): boolean {
+  return sealed && hubAuthorizeDone(hubAuthorized, attested);
+}
+
+/**
+ * Derive the full 3-leg handoff state from the raw signals (+ optional member
+ * attestation). Pure — no I/O. Ordering is fixed (seal → hub-authorize →
+ * leaf-up); a leg reads `blocked` (rather than `pending`) once an EARLIER leg
+ * isn't done, so the report always names exactly one leg as the next step.
+ */
+export function deriveHandoffState(
+  signals: HandoffSignals,
+  opts: DeriveHandoffOptions = {},
+): HandoffState {
+  const attested = opts.attested === true;
+  const hubDone = hubAuthorizeDone(signals.hubAuthorized, attested);
+
+  const sealLeg = leg(
+    "seal",
+    signals.sealed ? "done" : "pending",
+    signals.sealed
       ? "sealed leaf secret present on the ADMITTED admission row"
       : "no sealed leaf secret yet — the admin has not run `cortex network secret add-member`",
-  };
+  );
 
-  const hubAuthorize: HandoffLeg = !signals.sealed
-    ? {
-        id: "hub-authorize",
-        title: TITLES["hub-authorize"],
-        owner: OWNERS["hub-authorize"],
-        status: "blocked",
-        detail: "blocked — waiting on the seal leg",
-      }
-    : {
-        id: "hub-authorize",
-        title: TITLES["hub-authorize"],
-        owner: OWNERS["hub-authorize"],
-        status: hubDone ? "done" : "pending",
-        detail: hubDone
-          ? "hub authorization confirmed"
-          : signals.hubAuthorized === undefined
-            ? "cannot be confirmed from here yet — documented stub (no hub-owner-side marker exists on the " +
-              "registry row today); treated as NOT done, fail-closed (see network-handoff-adapters.ts)"
-            : "hub owner has not yet confirmed authorization",
-      };
+  const hubLeg = !signals.sealed
+    ? leg("hub-authorize", "blocked", "blocked — waiting on the seal leg")
+    : signals.hubAuthorized === true
+      ? leg("hub-authorize", "done", "hub authorization confirmed by a registry signal")
+      : signals.hubAuthorized === false
+        ? leg(
+            "hub-authorize",
+            "pending",
+            "hub owner has NOT applied the authorization (registry reports NOT done) — a member " +
+              "attestation cannot override this real negative",
+          )
+        : attested
+          ? leg(
+              "hub-authorize",
+              "done",
+              "attested by the member via `--hub-authorized-confirmed` (no registry marker yet — #1498)",
+            )
+          : leg(
+              "hub-authorize",
+              "pending",
+              "cannot be auto-verified from the member side — documented stub (no hub-owner marker on the " +
+                "registry row until #1498); treated as NOT done, fail-closed. If the hub owner has confirmed " +
+                "they applied your authorization, re-run `join` with `--hub-authorized-confirmed`",
+            );
 
-  const leafUpReady = signals.sealed && hubDone;
-  const leafUp: HandoffLeg = !leafUpReady
-    ? {
-        id: "leaf-up",
-        title: TITLES["leaf-up"],
-        owner: OWNERS["leaf-up"],
-        status: "blocked",
-        detail: `blocked — waiting on ${signals.sealed ? "hub-authorize" : "seal"}`,
-      }
-    : {
-        id: "leaf-up",
-        title: TITLES["leaf-up"],
-        owner: OWNERS["leaf-up"],
-        status: signals.leafUp ? "done" : "pending",
-        detail: signals.leafUp ? "leaf established" : "leaf not yet brought up",
-      };
+  const leafReady = signals.sealed && hubDone;
+  const leafLeg = !leafReady
+    ? leg("leaf-up", "blocked", `blocked — waiting on ${signals.sealed ? "hub-authorize" : "seal"}`)
+    : signals.leafUp === true
+      ? leg("leaf-up", "done", "leaf established")
+      : signals.leafUp === undefined
+        ? leg(
+            "leaf-up",
+            "pending",
+            "leaf state not observable from here (remote member, or the network is not configured locally) " +
+              "— run this on the member's own machine for an authoritative reading",
+          )
+        : leg("leaf-up", "pending", "leaf not yet brought up");
 
-  const legs = [seal, hubAuthorize, leafUp];
+  const legs = [sealLeg, hubLeg, leafLeg];
   const next = legs.find((l) => l.status !== "done");
+  const canBring = signals.sealed && hubDone;
+
+  let blockedReason: LeafUpBlockedReason | undefined;
+  if (!canBring) {
+    blockedReason = !signals.sealed
+      ? "seal-pending"
+      : signals.hubAuthorized === false
+        ? "hub-denied"
+        : "hub-unverifiable"; // undefined + not attested
+  }
 
   return {
     legs,
     ...(next !== undefined && { nextLeg: next.id, nextOwner: next.owner }),
-    canBringLeafUp: canBringLeafUp(signals.sealed, signals.hubAuthorized),
+    canBringLeafUp: canBring,
+    ...(blockedReason !== undefined && { leafUpBlockedReason: blockedReason }),
   };
 }
 
@@ -183,26 +235,40 @@ export type LeafUpGuardResult = { allowed: true } | { allowed: false; message: s
 
 /**
  * The leaf-up ENFORCEMENT gate (#1485 acceptance point 2). Refuses
- * (fail-closed) unless {@link HandoffState.canBringLeafUp}. Returns an
- * actionable message naming the outstanding leg + its owner — never a bare
- * refusal, so a caller is never left storming the hub blind.
+ * (fail-closed) unless {@link HandoffState.canBringLeafUp}, with a message
+ * tailored to WHY — so the member gets an actionable next step, not a bare
+ * refusal: an admin seal, an attestation they can supply, or a hard hub denial
+ * they cannot override.
  */
 export function guardLeafUp(state: HandoffState, networkId: string): LeafUpGuardResult {
   if (state.canBringLeafUp) return { allowed: true };
-  // The outstanding leg is always `seal` or `hub-authorize` here (leaf-up
-  // itself is never the reason canBringLeafUp is false).
-  const blocking =
-    state.legs.find((l) => l.id !== "leaf-up" && l.status !== "done") ??
-    state.legs.find((l) => l.id === "hub-authorize");
-  const legId = blocking?.id ?? "hub-authorize";
-  const owner = blocking?.owner ?? "hub-owner";
-  return {
-    allowed: false,
-    message:
-      `cannot bring the leaf up for "${networkId}": the "${legId}" leg is not yet confirmed ` +
-      `(owner: ${owner}) — run \`cortex network handoff status <member> --network ${networkId}\` ` +
-      `and wait for that leg before retrying.`,
-  };
+  switch (state.leafUpBlockedReason) {
+    case "seal-pending":
+      return {
+        allowed: false,
+        message:
+          `cannot bring the leaf up for "${networkId}": the "seal" leg is not done (owner: admin) — an ` +
+          `admin must run \`cortex network secret add-member ${networkId} <member-pubkey> --apply\` to mint ` +
+          `+ seal your leaf secret first. Run \`cortex network handoff status <member> --network ${networkId}\`.`,
+      };
+    case "hub-denied":
+      return {
+        allowed: false,
+        message:
+          `cannot bring the leaf up for "${networkId}": the hub owner has NOT applied your authorization ` +
+          `(the hub-authorize leg reports a real NOT-done) — \`--hub-authorized-confirmed\` cannot override a ` +
+          `real negative signal. Wait for the hub owner to authorize you.`,
+      };
+    case "hub-unverifiable":
+    default:
+      return {
+        allowed: false,
+        message:
+          `cannot bring the leaf up for "${networkId}": hub authorization can't be auto-verified from here ` +
+          `yet (no registry marker until #1498). If the hub owner has confirmed they applied your ` +
+          `authorization on the hub, re-run with \`--hub-authorized-confirmed\`.`,
+      };
+  }
 }
 
 // =============================================================================
@@ -216,45 +282,43 @@ export interface HandoffReport {
   networkId: string;
   member: string;
   state: HandoffState;
-  /** Non-fatal context (a degraded port read, or the self-vs-remote leaf-up
-   *  caveat below) — never blocks the report, always surfaced to the caller. */
+  /** Non-fatal context (a degraded port read, the remote-member leaf-up
+   *  caveat) — never blocks the report, always surfaced to the caller. */
   notes: string[];
 }
 
-export interface RunHandoffStatusOptions {
+export interface GatherHandoffOptions {
   networkId: string;
-  /** The member positional — who this report is ABOUT. */
+  /** The member the report is ABOUT. */
   member: string;
   /**
-   * The principal this invocation is actually running AS (derived from
-   * --principal/config, the same way `doctor`/`status` resolve it). The
-   * leaf-up leg is inherently observable ONLY from the machine that's
-   * running — so when `member !== selfPrincipal`, `runHandoffStatus` adds an
-   * honest note instead of silently reporting a leaf-up leg that isn't
-   * actually about `member`.
+   * The principal this invocation is running AS. When `member !== selfPrincipal`
+   * the leaf-up leg is inherently unobservable from here, so its signal is
+   * `undefined` (unknown) instead of a false local `/leafz` read.
    */
   selfPrincipal: string;
 }
 
+export interface GatheredHandoffSignals {
+  signals: HandoffSignals;
+  notes: string[];
+}
+
 /**
- * Gather all three leg signals via the injected {@link NetworkHandoffPorts},
- * then derive the {@link HandoffState}. This is the READ half (acceptance
- * point 1); the ENFORCEMENT half is {@link guardLeafUp}, called separately by
- * whatever wires the leaf-up step (see `network.ts` `runJoin`'s `--guided`
- * preflight).
+ * cortex#1485 (Sage #1499) — the SHARED signal-gathering helper both
+ * `handoff status` and the `join --guided` guard call, so the two can never
+ * derive from different signals. Reads the seal leg (admission `/mine`), the
+ * hub-authorize leg (the injected hub-auth port — the documented stub today,
+ * the real #1498 read tomorrow, no caller change), and the leaf-up leg (LOCAL
+ * `/leafz` only). Never throws — a degraded read becomes a `note` + a
+ * fail-closed signal.
  */
-export async function runHandoffStatus(
+export async function gatherHandoffSignals(
   ports: NetworkHandoffPorts,
-  opts: RunHandoffStatusOptions,
-): Promise<HandoffReport> {
+  opts: GatherHandoffOptions,
+): Promise<GatheredHandoffSignals> {
   const notes: string[] = [];
-  if (opts.member !== opts.selfPrincipal) {
-    notes.push(
-      `checked from "${opts.selfPrincipal}"'s own machine — the leaf-up leg reflects THIS machine's local ` +
-        `leaf state, not necessarily "${opts.member}"'s. Run this command on the member's own machine for an ` +
-        `authoritative leaf-up leg.`,
-    );
-  }
+  const isLocal = opts.member === opts.selfPrincipal;
 
   const admissionRes = await ports.admission.resolve(opts.networkId);
   const sealed = admissionRes.ok && admissionRes.state.hasSealedSecret;
@@ -267,16 +331,42 @@ export async function runHandoffStatus(
     notes.push(`hub-authorize leg: ${hubRes.reason}`);
   }
 
-  const snapshot = ports.config.readNetworks();
-  const network = snapshot.networks.find((n) => n.id === opts.networkId);
-  let leafUp = false;
-  if (network === undefined) {
-    notes.push(`leaf-up leg: network "${opts.networkId}" is not configured locally yet`);
+  let leafUp: boolean | undefined;
+  if (!isLocal) {
+    // A member's leaf is observable only on the member's OWN machine — never
+    // report this machine's leaf as theirs (Sage #1499).
+    leafUp = undefined;
+    notes.push(
+      `leaf-up leg: not observable for member "${opts.member}" from "${opts.selfPrincipal}"'s machine — ` +
+        `only the member's own machine can observe its leaf. Reported as unknown.`,
+    );
   } else {
-    const leafz = await ports.monitor.fetchLeafz();
-    leafUp = isLeafEstablished(leafz, network);
+    const snapshot = ports.config.readNetworks();
+    const network = snapshot.networks.find((n) => n.id === opts.networkId);
+    if (network === undefined) {
+      leafUp = undefined;
+      notes.push(`leaf-up leg: network "${opts.networkId}" is not configured locally yet — reported as unknown`);
+    } else {
+      const leafz = await ports.monitor.fetchLeafz();
+      leafUp = isLeafEstablished(leafz, network);
+    }
   }
 
-  const state = deriveHandoffState({ sealed, hubAuthorized: hubRes.confirmed, leafUp });
+  return { signals: { sealed, hubAuthorized: hubRes.confirmed, leafUp }, notes };
+}
+
+/**
+ * Gather all three leg signals via the injected {@link NetworkHandoffPorts},
+ * then derive the {@link HandoffState}. The READ half (acceptance point 1);
+ * the ENFORCEMENT half is {@link guardLeafUp}, called by whatever wires the
+ * leaf-up step (see `network.ts` `runJoin`'s `--guided` preflight, which shares
+ * {@link gatherHandoffSignals}).
+ */
+export async function runHandoffStatus(
+  ports: NetworkHandoffPorts,
+  opts: GatherHandoffOptions,
+): Promise<HandoffReport> {
+  const { signals, notes } = await gatherHandoffSignals(ports, opts);
+  const state = deriveHandoffState(signals);
   return { networkId: opts.networkId, member: opts.member, state, notes };
 }

--- a/src/cli/cortex/commands/network-handoff-lib.ts
+++ b/src/cli/cortex/commands/network-handoff-lib.ts
@@ -1,0 +1,282 @@
+/**
+ * `cortex network handoff` — PURE state model (cortex#1485, epic #1479, join-6).
+ *
+ * A network join is a **3-leg handoff across up to 3 people/machines**:
+ *
+ *     seal (admin) → hub-authorize (hub owner) → leaf-up (member)
+ *
+ * Before this, each leg was a fire-and-forget verb (`secret add-member`, a
+ * hub-side nats-server edit nobody but the hub owner can see, `join --apply`)
+ * — nobody could ask "what's outstanding, and whose job is it?", and nothing
+ * enforced ORDER. Bringing the leaf up before the hub authorization was
+ * actually applied was a real Authorization-Violation storm window during
+ * the metafactory-community bring-up. This module models the handoff as
+ * STATE: three ordered legs, each `done | pending | blocked`, with an owner
+ * — plus the enforcement gate (`guardLeafUp`) that refuses the leaf-up leg
+ * until its dependencies are done.
+ *
+ * ## The three leg SIGNALS — what's real vs a documented stub
+ *
+ *   - **seal** (admin) — REAL. Fed by {@link HandoffSignals.sealed}, which the
+ *     orchestrator ({@link runHandoffStatus}) resolves via the SAME
+ *     `AdmissionStatePort` PoP `/mine` read `cortex network status`'s C-1350
+ *     admission lookup and `join`'s C-1315 blocker-classification already use
+ *     — `hasSealedSecret` on the member's own ADMITTED admission row.
+ *   - **hub-authorize** (hub owner) — a DOCUMENTED STUB today. This is
+ *     exactly the gap `cortex network doctor`'s Pair 3 leg
+ *     (`sealed-secret-hub-authorized`, cortex#1482) already named: the member
+ *     has no hub-side visibility (cortex#1481), and the registry carries only
+ *     an opaque ciphertext sealed to the member's OWN pubkey — there is no
+ *     plaintext here to compare against the hub's live `authorization`
+ *     entries. A real signal needs an EXPLICIT hub-owner-side marker (e.g. a
+ *     `hub_authorized_at` field stamped onto the registry admission row by a
+ *     hub-owner action) that does not exist yet — see
+ *     `network-handoff-adapters.ts` for why (the `admission_requests` table
+ *     is a real SQL table, so adding the column is a registry
+ *     schema/migration — out of scope for this slice). `HandoffSignals.hubAuthorized`
+ *     is typed `boolean | undefined` specifically so this module is ready to
+ *     read that signal the moment it exists, without a shape change here.
+ *   - **leaf-up** (member) — REAL. Fed by {@link HandoffSignals.leafUp}, which
+ *     the orchestrator resolves via `isLeafEstablished` (exported from
+ *     `network-doctor-lib.ts`) — the SAME `/leafz` leaf-established lookup
+ *     `cortex network doctor`'s leg 3 (#1484) performs, not a second
+ *     implementation.
+ *
+ * `hubAuthorized: undefined` (the documented-stub state, always what the live
+ * adapter returns today) is treated exactly like `false` — fail-closed: an
+ * UNKNOWN hub-authorize leg blocks leaf-up exactly as a KNOWN-pending one
+ * would. It never silently unblocks just because the signal happens not to
+ * exist yet.
+ */
+
+export type HandoffLegId = "seal" | "hub-authorize" | "leaf-up";
+export type HandoffLegStatus = "done" | "pending" | "blocked";
+export type HandoffOwner = "admin" | "hub-owner" | "member";
+
+/** One leg of the handoff report — status + owner + a human detail. */
+export interface HandoffLeg {
+  id: HandoffLegId;
+  title: string;
+  status: HandoffLegStatus;
+  owner: HandoffOwner;
+  detail: string;
+}
+
+/** The raw per-leg signals {@link deriveHandoffState} derives from. */
+export interface HandoffSignals {
+  /** seal leg — real: a sealed leaf secret present on the ADMITTED row. */
+  sealed: boolean;
+  /**
+   * hub-authorize leg — `true`/`false` once a real hub-owner-side marker
+   * exists; `undefined` on the documented-stub path (today, always — see the
+   * module doc). Any value other than exactly `true` is treated as NOT done.
+   */
+  hubAuthorized: boolean | undefined;
+  /** leaf-up leg — real: an established leaf found for this network. */
+  leafUp: boolean;
+}
+
+export interface HandoffState {
+  /** Always exactly 3 legs, in `seal, hub-authorize, leaf-up` order. */
+  legs: HandoffLeg[];
+  /** The next outstanding leg, in chain order. `undefined` when every leg is done. */
+  nextLeg?: HandoffLegId;
+  /** The owner of {@link nextLeg}. `undefined` when every leg is done. */
+  nextOwner?: HandoffOwner;
+  /**
+   * `true` only when BOTH `seal` and `hub-authorize` are done. This is
+   * exactly the gate {@link guardLeafUp} enforces before a member's leaf-up
+   * step is allowed to run.
+   */
+  canBringLeafUp: boolean;
+}
+
+const TITLES: Record<HandoffLegId, string> = {
+  seal: "seal — admin mints + seals the leaf secret",
+  "hub-authorize": "hub-authorize — hub owner applies the authorization",
+  "leaf-up": "leaf-up — member brings the leaf online",
+};
+
+const OWNERS: Record<HandoffLegId, HandoffOwner> = {
+  seal: "admin",
+  "hub-authorize": "hub-owner",
+  "leaf-up": "member",
+};
+
+/**
+ * Pure — `true` only when both legs a leaf-up depends on are DONE.
+ * Fail-closed: an `undefined` (documented-stub / unknown) hub-authorize
+ * signal is treated as NOT done, same as an explicit `false`.
+ */
+export function canBringLeafUp(sealed: boolean, hubAuthorized: boolean | undefined): boolean {
+  return sealed && hubAuthorized === true;
+}
+
+/**
+ * Derive the full 3-leg handoff state from the raw signals. Pure — no I/O.
+ * Ordering is fixed (seal → hub-authorize → leaf-up); a leg reads `blocked`
+ * (rather than merely `pending`) once an EARLIER leg in the chain isn't done,
+ * so the report always names exactly one leg as the outstanding next step.
+ */
+export function deriveHandoffState(signals: HandoffSignals): HandoffState {
+  const hubDone = signals.hubAuthorized === true;
+
+  const seal: HandoffLeg = {
+    id: "seal",
+    title: TITLES.seal,
+    owner: OWNERS.seal,
+    status: signals.sealed ? "done" : "pending",
+    detail: signals.sealed
+      ? "sealed leaf secret present on the ADMITTED admission row"
+      : "no sealed leaf secret yet — the admin has not run `cortex network secret add-member`",
+  };
+
+  const hubAuthorize: HandoffLeg = !signals.sealed
+    ? {
+        id: "hub-authorize",
+        title: TITLES["hub-authorize"],
+        owner: OWNERS["hub-authorize"],
+        status: "blocked",
+        detail: "blocked — waiting on the seal leg",
+      }
+    : {
+        id: "hub-authorize",
+        title: TITLES["hub-authorize"],
+        owner: OWNERS["hub-authorize"],
+        status: hubDone ? "done" : "pending",
+        detail: hubDone
+          ? "hub authorization confirmed"
+          : signals.hubAuthorized === undefined
+            ? "cannot be confirmed from here yet — documented stub (no hub-owner-side marker exists on the " +
+              "registry row today); treated as NOT done, fail-closed (see network-handoff-adapters.ts)"
+            : "hub owner has not yet confirmed authorization",
+      };
+
+  const leafUpReady = signals.sealed && hubDone;
+  const leafUp: HandoffLeg = !leafUpReady
+    ? {
+        id: "leaf-up",
+        title: TITLES["leaf-up"],
+        owner: OWNERS["leaf-up"],
+        status: "blocked",
+        detail: `blocked — waiting on ${signals.sealed ? "hub-authorize" : "seal"}`,
+      }
+    : {
+        id: "leaf-up",
+        title: TITLES["leaf-up"],
+        owner: OWNERS["leaf-up"],
+        status: signals.leafUp ? "done" : "pending",
+        detail: signals.leafUp ? "leaf established" : "leaf not yet brought up",
+      };
+
+  const legs = [seal, hubAuthorize, leafUp];
+  const next = legs.find((l) => l.status !== "done");
+
+  return {
+    legs,
+    ...(next !== undefined && { nextLeg: next.id, nextOwner: next.owner }),
+    canBringLeafUp: canBringLeafUp(signals.sealed, signals.hubAuthorized),
+  };
+}
+
+export type LeafUpGuardResult = { allowed: true } | { allowed: false; message: string };
+
+/**
+ * The leaf-up ENFORCEMENT gate (#1485 acceptance point 2). Refuses
+ * (fail-closed) unless {@link HandoffState.canBringLeafUp}. Returns an
+ * actionable message naming the outstanding leg + its owner — never a bare
+ * refusal, so a caller is never left storming the hub blind.
+ */
+export function guardLeafUp(state: HandoffState, networkId: string): LeafUpGuardResult {
+  if (state.canBringLeafUp) return { allowed: true };
+  // The outstanding leg is always `seal` or `hub-authorize` here (leaf-up
+  // itself is never the reason canBringLeafUp is false).
+  const blocking =
+    state.legs.find((l) => l.id !== "leaf-up" && l.status !== "done") ??
+    state.legs.find((l) => l.id === "hub-authorize");
+  const legId = blocking?.id ?? "hub-authorize";
+  const owner = blocking?.owner ?? "hub-owner";
+  return {
+    allowed: false,
+    message:
+      `cannot bring the leaf up for "${networkId}": the "${legId}" leg is not yet confirmed ` +
+      `(owner: ${owner}) — run \`cortex network handoff status <member> --network ${networkId}\` ` +
+      `and wait for that leg before retrying.`,
+  };
+}
+
+// =============================================================================
+// Orchestrator — gathers signals via injected ports, then derives + guards.
+// =============================================================================
+
+import { isLeafEstablished } from "./network-doctor-lib";
+import type { NetworkHandoffPorts } from "./network-handoff-ports";
+
+export interface HandoffReport {
+  networkId: string;
+  member: string;
+  state: HandoffState;
+  /** Non-fatal context (a degraded port read, or the self-vs-remote leaf-up
+   *  caveat below) — never blocks the report, always surfaced to the caller. */
+  notes: string[];
+}
+
+export interface RunHandoffStatusOptions {
+  networkId: string;
+  /** The member positional — who this report is ABOUT. */
+  member: string;
+  /**
+   * The principal this invocation is actually running AS (derived from
+   * --principal/config, the same way `doctor`/`status` resolve it). The
+   * leaf-up leg is inherently observable ONLY from the machine that's
+   * running — so when `member !== selfPrincipal`, `runHandoffStatus` adds an
+   * honest note instead of silently reporting a leaf-up leg that isn't
+   * actually about `member`.
+   */
+  selfPrincipal: string;
+}
+
+/**
+ * Gather all three leg signals via the injected {@link NetworkHandoffPorts},
+ * then derive the {@link HandoffState}. This is the READ half (acceptance
+ * point 1); the ENFORCEMENT half is {@link guardLeafUp}, called separately by
+ * whatever wires the leaf-up step (see `network.ts` `runJoin`'s `--guided`
+ * preflight).
+ */
+export async function runHandoffStatus(
+  ports: NetworkHandoffPorts,
+  opts: RunHandoffStatusOptions,
+): Promise<HandoffReport> {
+  const notes: string[] = [];
+  if (opts.member !== opts.selfPrincipal) {
+    notes.push(
+      `checked from "${opts.selfPrincipal}"'s own machine — the leaf-up leg reflects THIS machine's local ` +
+        `leaf state, not necessarily "${opts.member}"'s. Run this command on the member's own machine for an ` +
+        `authoritative leaf-up leg.`,
+    );
+  }
+
+  const admissionRes = await ports.admission.resolve(opts.networkId);
+  const sealed = admissionRes.ok && admissionRes.state.hasSealedSecret;
+  if (!admissionRes.ok) {
+    notes.push(`seal leg: could not read admission state — ${admissionRes.reason}`);
+  }
+
+  const hubRes = await ports.hubAuth.resolveHubAuthorized(opts.networkId, opts.member);
+  if (hubRes.reason !== undefined) {
+    notes.push(`hub-authorize leg: ${hubRes.reason}`);
+  }
+
+  const snapshot = ports.config.readNetworks();
+  const network = snapshot.networks.find((n) => n.id === opts.networkId);
+  let leafUp = false;
+  if (network === undefined) {
+    notes.push(`leaf-up leg: network "${opts.networkId}" is not configured locally yet`);
+  } else {
+    const leafz = await ports.monitor.fetchLeafz();
+    leafUp = isLeafEstablished(leafz, network);
+  }
+
+  const state = deriveHandoffState({ sealed, hubAuthorized: hubRes.confirmed, leafUp });
+  return { networkId: opts.networkId, member: opts.member, state, notes };
+}

--- a/src/cli/cortex/commands/network-handoff-ports.ts
+++ b/src/cli/cortex/commands/network-handoff-ports.ts
@@ -1,0 +1,58 @@
+/**
+ * `cortex network handoff` — injected-dependency seams (cortex#1485, epic #1479, join-6).
+ *
+ * Mirrors the `network-doctor-ports.ts` pattern: the orchestrator
+ * (`network-handoff-lib.ts`'s `runHandoffStatus`) is PURE over these ports;
+ * the live adapters (`network-handoff-adapters.ts`) wire the real admission
+ * registry read, the local nats-server monitor, and the documented hub-
+ * authorize stub; tests inject fakes that never touch fs/HTTP.
+ *
+ * Two of the three ports are NOT new interfaces — they're reused directly:
+ *   - `admission` is the SAME {@link AdmissionStatePort} `cortex network
+ *     status`'s C-1350 admission lookup already defines (`network-ports.ts`).
+ *   - `monitor` is the SAME {@link MonitorPort} `cortex network doctor`
+ *     (#1484) already defines (`network-doctor-ports.ts`).
+ * Only `hubAuth` (the documented-stub leg) and the read-only `config`
+ * projection are new to this module.
+ */
+
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import type { AdmissionStatePort } from "./network-ports";
+import type { MonitorPort } from "./network-doctor-ports";
+
+/** Read-only `policy.federated.networks[]` seam — the subset `handoff` needs
+ *  from {@link import("./network-doctor-ports").DoctorConfigPort}. */
+export interface HandoffConfigPort {
+  /** Never throws — resolves to `{ networks: [] }` when the config declares none. */
+  readNetworks(): { networks: PolicyFederatedNetwork[] };
+}
+
+/**
+ * The hub-authorize leg's resolution. `confirmed: undefined` is the
+ * DOCUMENTED-STUB state (see `network-handoff-lib.ts` module doc +
+ * `network-handoff-adapters.ts`) — always what the live adapter returns
+ * today, since no hub-owner-side marker exists yet on the registry row.
+ * `reason` is present whenever `confirmed !== true`, explaining WHY (either
+ * "not yet confirmed" or "cannot be determined — documented stub").
+ */
+export interface HubAuthorizeResolution {
+  confirmed: boolean | undefined;
+  reason?: string;
+}
+
+export interface HandoffHubAuthPort {
+  /** Resolve the hub-authorize leg for `member` on `networkId`. Never throws. */
+  resolveHubAuthorized(networkId: string, member: string): Promise<HubAuthorizeResolution>;
+}
+
+/** The full port bundle {@link import("./network-handoff-lib").runHandoffStatus} depends on. */
+export interface NetworkHandoffPorts {
+  /** seal leg — reused `AdmissionStatePort` (the member's own PoP `/mine` read). */
+  admission: AdmissionStatePort;
+  /** hub-authorize leg — documented stub today (see module doc). */
+  hubAuth: HandoffHubAuthPort;
+  /** leaf-up leg (network lookup half) — reused `readNetworks()` shape. */
+  config: HandoffConfigPort;
+  /** leaf-up leg (`/leafz` half) — reused `MonitorPort` from `doctor`. */
+  monitor: MonitorPort;
+}

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -105,6 +105,7 @@ import {
   buildDryRunPorts,
   buildLivePublicPorts,
   buildDryRunPublicPorts,
+  buildAdmissionStatePort,
   type LivePortsConfig,
 } from "./network-adapters";
 import {
@@ -178,6 +179,18 @@ import {
   buildMonitorPort,
 } from "./network-doctor-adapters";
 import type { NetworkDoctorPorts } from "./network-doctor-ports";
+import {
+  deriveHandoffState,
+  guardLeafUp,
+  runHandoffStatus,
+  type HandoffLeg,
+  type HandoffReport,
+} from "./network-handoff-lib";
+import type { NetworkHandoffPorts } from "./network-handoff-ports";
+import {
+  buildLiveHandoffPorts,
+  buildStubHubAuthPort,
+} from "./network-handoff-adapters";
 
 export { type ExitResult } from "./_shared/exit-result";
 
@@ -185,7 +198,7 @@ export { type ExitResult } from "./_shared/exit-result";
 // Grammar
 // =============================================================================
 
-type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "doctor" | "admit" | "reject" | "provision" | "make-live" | "secret";
+type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "doctor" | "admit" | "reject" | "provision" | "make-live" | "secret" | "handoff";
 
 /**
  * Default registry URL when neither --registry-url nor config provides one.
@@ -276,6 +289,14 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         // on `join public`; ignored on a federated join.
         "--capabilities": "value",
         "--allow": "value",
+        // cortex#1485 (epic #1479, join-6) — opt-in guided-join. When set, the
+        // leaf-up step is GATED on the 3-leg handoff state: it refuses (fails
+        // closed) unless the seal + hub-authorize legs are confirmed, instead of
+        // storming the hub with an unauthorized leaf. OPT-IN, never the default:
+        // the hub-authorize leg is a documented stub (always undefined ⇒
+        // fail-closed) until a hub-owner-side `hub_authorized_at` registry marker
+        // exists, so defaulting it would block EVERY join today.
+        "--guided": "bool",
         "--apply": "bool",
         "--dry-run": "bool",
       },
@@ -532,6 +553,28 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         // cortex#1481 — the hub's OWN federation account nkey-U, when the admin
         // already knows it. Rides the hub-owner artifact's `account:` field.
         "--hub-account": "value",
+      },
+    },
+    // cortex#1485 (epic #1479, join-6) — the guided-join handoff STATE. A join is
+    // a 3-leg handoff across ≤3 people/machines: seal (admin) → hub-authorize
+    // (hub owner) → leaf-up (member). `cortex network handoff status <member>
+    // --network <net>` shows, for that member, each leg's state (done | pending |
+    // blocked), the outstanding next leg, and WHOSE job it is. `action` is the
+    // verb (`status`); `member` is who the report is about. Read-only.
+    handoff: {
+      positionals: ["action", "member"],
+      flags: {
+        // The network whose handoff is being reported (required — a handoff is
+        // always network-scoped).
+        "--network": "value",
+        // Mirrors doctor/status: locate the LOCAL stack's config + admission
+        // read + leaf monitor for the seal/leaf-up leg signals.
+        "--config": "value",
+        "--principal": "value",
+        "--stack": "value",
+        "--monitor-url": "value",
+        "--registry-url": "value",
+        "--seed-path": "value",
       },
     },
   },
@@ -1036,6 +1079,31 @@ async function runJoin(
   };
 
   const cfg = portsConfigFromInputs(networkId, inputs, slugRes.slug, flags);
+
+  // cortex#1485 (epic #1479, join-6) — OPT-IN guided-join gate. When `--guided`
+  // is set, the leaf-up step is refused (fail-closed) unless the 3-leg handoff
+  // (seal → hub-authorize → leaf-up) has its seal + hub-authorize legs
+  // confirmed — so a member never storms the hub with an unauthorized leaf
+  // (the metafactory-community Authorization-Violation window). This is opt-in,
+  // NOT the default: the hub-authorize leg is a documented stub (always
+  // undefined ⇒ fail-closed) until a hub-owner-side `hub_authorized_at` registry
+  // marker exists, so defaulting it would block every join today. See
+  // `network-handoff-adapters.ts` `buildStubHubAuthPort`.
+  if (flags["--guided"] === true) {
+    const admission = buildAdmissionStatePort(cfg);
+    const hubAuth = buildStubHubAuthPort();
+    const admissionRes = await admission.resolve(networkId);
+    const sealed = admissionRes.ok && admissionRes.state.hasSealedSecret;
+    const hubRes = await hubAuth.resolveHubAuthorized(networkId, inputs.principal);
+    // leafUp:false — we are ABOUT to bring it up; the guard depends only on
+    // seal + hub-authorize.
+    const state = deriveHandoffState({ sealed, hubAuthorized: hubRes.confirmed, leafUp: false });
+    const guard = guardLeafUp(state, networkId);
+    if (!guard.allowed) {
+      return opError("join", guard.message, json);
+    }
+  }
+
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 
   const res = await joinNetwork(networkId, stack, ports);
@@ -1626,6 +1694,145 @@ function renderDoctorResult(
   return res.exitCode === 0
     ? { exitCode: 0, stdout: body, stderr: "" }
     : { exitCode: res.exitCode, stdout: "", stderr: body };
+}
+
+// =============================================================================
+// cortex#1485 (epic #1479, join-6) — `cortex network handoff status`
+// =============================================================================
+
+/**
+ * Factory for the handoff ports bundle. Production builds the live
+ * admission-read + documented-stub hub-auth + config + monitor adapters from
+ * the resolved {@link LivePortsConfig} + the composed networks; tests inject a
+ * fake. Read-only — no `stop()` needed (unlike doctor, handoff opens no probe
+ * bus).
+ */
+export type HandoffPortsFactory = (
+  cfg: LivePortsConfig,
+  networks: import("../../../common/types/cortex-config").PolicyFederatedNetwork[],
+) => NetworkHandoffPorts;
+
+/** The production factory — reuses the live admission + doctor config/monitor
+ *  adapters + the documented hub-authorize stub. */
+const DEFAULT_HANDOFF_PORTS_FACTORY: HandoffPortsFactory = (cfg, networks) =>
+  buildLiveHandoffPorts(cfg, networks);
+
+async function runHandoff(
+  action: string,
+  member: string,
+  flags: FlagMap,
+  json: boolean,
+  load: ConfigReader,
+  handoffPortsFactory: HandoffPortsFactory,
+): Promise<ExitResult> {
+  if (action !== "status") {
+    return usageError("handoff", `unknown action "${action}" — the only handoff action is "status"`, json);
+  }
+  const networkRes = requireValueFlag(flags, "--network");
+  if (!networkRes.ok) return usageError("handoff", networkRes.reason, json);
+  const networkId = networkRes.value;
+  if (!NETWORK_ID_RE.test(networkId)) {
+    return usageError("handoff", `--network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+  if (!PRINCIPAL_ID_RE.test(member)) {
+    return usageError("handoff", `member "${member}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+
+  const principalRes = requireValueFlag(flags, "--principal");
+  if (!principalRes.ok) return usageError("handoff", principalRes.reason, json);
+  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
+  if (!slugRes.ok) return usageError("handoff", slugRes.reason, json);
+
+  // Mirror doctor/status: an explicit --config wins; else resolve the NAMED
+  // stack's config layout-aware, so the seal/leaf-up leg reads reflect what the
+  // daemon actually loads.
+  const handoffFlags: FlagMap =
+    optionalValueFlag(flags, "--config") === undefined
+      ? { ...flags, "--config": resolveStatusConfigPath(slugRes.slug) }
+      : flags;
+
+  let cfg: LoadedConfig;
+  try {
+    cfg = load(cortexConfigPathFromFlags(handoffFlags));
+  } catch (err) {
+    return opError("handoff", `config load failed: ${err instanceof Error ? err.message : String(err)}`, json);
+  }
+
+  // The seal leg's `/mine` admission read needs a registry-url + signing seed —
+  // resolved the SAME best-effort way `status` does (C-1350).
+  const admissionCoords = resolveStatusAdmissionCoords(
+    handoffFlags,
+    principalRes.value,
+    slugRes.slug,
+    load,
+  );
+  const livePortsCfg: LivePortsConfig = {
+    ...portsConfig(networkId, principalRes.value, slugRes.slug, handoffFlags),
+    ...(admissionCoords.registryUrl !== undefined && { registryUrl: admissionCoords.registryUrl }),
+    ...(admissionCoords.seedPath !== undefined && { seedPath: admissionCoords.seedPath }),
+  };
+
+  const ports = handoffPortsFactory(livePortsCfg, cfg.policy?.federated?.networks ?? []);
+  const report = await runHandoffStatus(ports, {
+    networkId,
+    member,
+    selfPrincipal: principalRes.value,
+  });
+  return renderHandoffReport(report, json);
+}
+
+/** Render a {@link HandoffReport} — a human per-leg table or a `--json` envelope. */
+function renderHandoffReport(report: HandoffReport, json: boolean): ExitResult {
+  const { state } = report;
+  if (json) {
+    const env = envelopeOk(
+      state.legs.map((l) => ({
+        id: l.id,
+        title: l.title,
+        status: l.status,
+        owner: l.owner,
+        detail: l.detail,
+      })),
+      {
+        network: report.networkId,
+        member: report.member,
+        ...(state.nextLeg !== undefined && { next_leg: state.nextLeg }),
+        ...(state.nextOwner !== undefined && { next_owner: state.nextOwner }),
+        can_bring_leaf_up: state.canBringLeafUp ? "true" : "false",
+        ...(report.notes.length > 0 && { notes: report.notes.join(" | ") }),
+      },
+    );
+    return { exitCode: 0, stdout: renderJson(env), stderr: "" };
+  }
+
+  const icon = (status: HandoffLeg["status"]): string => {
+    switch (status) {
+      case "done":
+        return "✓";
+      case "pending":
+        return "…";
+      case "blocked":
+        return "·";
+    }
+  };
+  const lines: string[] = [
+    `cortex network handoff status ${report.member} (network "${report.networkId}"):`,
+    "",
+  ];
+  for (const l of state.legs) {
+    lines.push(`  ${icon(l.status)} ${l.id} [${l.status}] (owner: ${l.owner}) — ${l.detail}`);
+  }
+  lines.push("");
+  if (state.nextLeg !== undefined) {
+    lines.push(`outstanding: ${state.nextLeg} (owner: ${state.nextOwner ?? "?"})`);
+  } else {
+    lines.push("outstanding: none — all legs done");
+  }
+  lines.push(`can bring leaf up: ${state.canBringLeafUp ? "yes" : "no"}`);
+  for (const note of report.notes) {
+    lines.push(`  note: ${note}`);
+  }
+  return ok(lines.join("\n") + "\n");
 }
 
 // =============================================================================
@@ -3920,6 +4127,9 @@ export async function dispatchNetwork(
   // fake config/monitor/probe-bus ports without touching fs or NATS.
   // Production omits it → the live adapters.
   doctorPortsFactory: DoctorPortsFactory = DEFAULT_DOCTOR_PORTS_FACTORY,
+  // cortex#1485 — injectable handoff-ports factory so `handoff` CLI tests drive
+  // fake admission/hub-auth/config/monitor ports. Production omits → live.
+  handoffPortsFactory: HandoffPortsFactory = DEFAULT_HANDOFF_PORTS_FACTORY,
 ): Promise<ExitResult> {
   let parsed;
   try {
@@ -3957,6 +4167,15 @@ export async function dispatchNetwork(
       return runPing(parsed.positionals.peer ?? "", parsed.flags, json, load, pingBusFactory);
     case "doctor":
       return runDoctor(parsed.positionals.network ?? "", parsed.flags, json, load, doctorPortsFactory);
+    case "handoff":
+      return runHandoff(
+        parsed.positionals.action ?? "",
+        parsed.positionals.member ?? "",
+        parsed.flags,
+        json,
+        load,
+        handoffPortsFactory,
+      );
     case "admit":
       return runAdmit(parsed.positionals["request-id"] ?? "", parsed.flags, json, secretPortsFactory);
     case "reject":
@@ -3993,6 +4212,7 @@ Usage:
   cortex network create <network> --hub <tls-url> --leaf-port <port> --admin-seed <path> [--network-admins <csv>] [--registry-url <url>] [--apply]
   cortex network ping   <peer> [--assistant <a>] [--network <id>] [--count N] [--timeout <ms>] [--json]
   cortex network doctor <network> [--principal <id>] [--stack <id>] [--config <p>] [--monitor-url <url>] [--json]
+  cortex network handoff status <member> --network <net> [--principal <id>] [--stack <id>] [--config <p>] [--json]
   cortex network admit  <request-id> --admin-seed <path> [--registry-url <url>] [--hub-config <p>]
                         [--roster-only] [--seal-only] [--hub-account <A…>] [--discord-member <id>]
                         [--discord-guild <id>] [--discord-server <profile>] [--discord-role <name>]
@@ -4051,6 +4271,21 @@ Subcommands:
           on the local bus degrades leaf checks to warn/skip, never fail (the
           absent-monitor-is-inconclusive rule). Exit codes: 0 healthy /
           1 degraded / 2 broken.
+  handoff (cortex#1485, epic #1479) Model a network join as the 3-leg handoff it
+          actually is — seal (admin) → hub-authorize (hub owner) → leaf-up
+          (member) — as STATE. \`handoff status <member> --network <net>\` shows,
+          for that member, each leg's state (done | pending | blocked), the
+          outstanding next leg, and WHOSE job it is (admin / hub-owner / member),
+          so nobody has to guess what's outstanding or whose turn it is. The seal
+          leg reads the member's own ADMITTED admission row (sealed leaf secret
+          present); the leaf-up leg reuses doctor's /leafz leaf-established
+          lookup. The hub-authorize leg is a DOCUMENTED STUB (always "pending —
+          cannot confirm from the member side"): the member has no hub-side
+          visibility and the registry row carries no hub-owner authorization
+          marker yet — confirming it needs a hub-owner-side \`hub_authorized_at\`
+          registry field (follow-up), so it is treated fail-closed (NOT done).
+          Read-only. The enforcement counterpart is \`join --guided\`, which
+          refuses to bring the leaf up until seal + hub-authorize are confirmed.
   status  Show joined networks, peers, accept-subjects, leaf link state + counters.
   leave   Reverse a join cleanly: remove the network + leaf include, drop the
           plist -c arg if no networks remain, restart. Idempotent.
@@ -4208,6 +4443,11 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
   --allow <csv>           (join public) Comma-separated INBOUND allowlist of public
                           sender principals. Empty (default) = inbound DISABLED (OQ1
                           safe). Non-empty = inbound enabled, gated to these ids only.
+  --guided                (join, #1485) OPT-IN guided join: refuse to bring the leaf
+                          up (fail-closed) until the 3-leg handoff's seal + hub-authorize
+                          legs are confirmed, instead of storming the hub. Off by default
+                          (hub-authorize is a documented stub today — see 'handoff').
+  --network <net>         (handoff) the network whose handoff to report (required).
   --monitor-url <url>     (status) nats-server monitor base URL for leaf telemetry.
   --hub <tls-url>         (create) the hub's leaf-node dial URL (e.g. tls://hub.meta-factory.ai:7422).
   --leaf-port <port>      (create) the hub's leaf-node listen port (integer 1..65535).

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -105,7 +105,6 @@ import {
   buildDryRunPorts,
   buildLivePublicPorts,
   buildDryRunPublicPorts,
-  buildAdmissionStatePort,
   type LivePortsConfig,
 } from "./network-adapters";
 import {
@@ -181,16 +180,14 @@ import {
 import type { NetworkDoctorPorts } from "./network-doctor-ports";
 import {
   deriveHandoffState,
+  gatherHandoffSignals,
   guardLeafUp,
   runHandoffStatus,
   type HandoffLeg,
   type HandoffReport,
 } from "./network-handoff-lib";
 import type { NetworkHandoffPorts } from "./network-handoff-ports";
-import {
-  buildLiveHandoffPorts,
-  buildStubHubAuthPort,
-} from "./network-handoff-adapters";
+import { buildLiveHandoffPorts } from "./network-handoff-adapters";
 
 export { type ExitResult } from "./_shared/exit-result";
 
@@ -291,12 +288,20 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--allow": "value",
         // cortex#1485 (epic #1479, join-6) — opt-in guided-join. When set, the
         // leaf-up step is GATED on the 3-leg handoff state: it refuses (fails
-        // closed) unless the seal + hub-authorize legs are confirmed, instead of
-        // storming the hub with an unauthorized leaf. OPT-IN, never the default:
-        // the hub-authorize leg is a documented stub (always undefined ⇒
-        // fail-closed) until a hub-owner-side `hub_authorized_at` registry marker
-        // exists, so defaulting it would block EVERY join today.
+        // closed) unless the seal leg is done AND the hub-authorize leg is
+        // effectively done, instead of storming the hub with an unauthorized leaf.
+        // OPT-IN, never the default. Because the hub-authorize leg can't be
+        // auto-verified today (documented stub until the #1498 registry marker),
+        // --guided is a DELIBERATE-CONFIRMATION gate: it forces the member to
+        // acknowledge the un-auto-verifiable leg via --hub-authorized-confirmed
+        // rather than blocking unconditionally (Sage #1499).
         "--guided": "bool",
+        // cortex#1485 (Sage #1499) — member ATTESTATION for the guided-join gate:
+        // "the hub owner has confirmed to me they applied my authorization". Under
+        // --guided, upgrades an un-auto-verifiable (undefined) hub-authorize leg to
+        // treated-done so the leaf-up step PROCEEDS — but NEVER overrides a real
+        // negative (#1498) hub-authorize signal. Meaningless without --guided.
+        "--hub-authorized-confirmed": "bool",
         "--apply": "bool",
         "--dry-run": "bool",
       },
@@ -913,6 +918,12 @@ async function runJoin(
   json: boolean,
   load: ConfigReader,
   provisionPortsFactory: ProvisionPortsFactory,
+  // cortex#1485 (Sage #1499) — the SAME injectable handoff-ports factory the
+  // `handoff` command uses, so the `--guided` guard reads the leg signals through
+  // the live hub-auth port and picks up the #1498 real read automatically once
+  // wired (no code change), and CLI tests can inject a fake to drive both guard
+  // branches.
+  handoffPortsFactory: HandoffPortsFactory,
 ): Promise<ExitResult> {
   // S5 (#739) — `join public` is the open-square opt-in, structurally distinct
   // from a federated join (no leaf, no creds/account, no peers). Route it to
@@ -1080,24 +1091,33 @@ async function runJoin(
 
   const cfg = portsConfigFromInputs(networkId, inputs, slugRes.slug, flags);
 
-  // cortex#1485 (epic #1479, join-6) — OPT-IN guided-join gate. When `--guided`
-  // is set, the leaf-up step is refused (fail-closed) unless the 3-leg handoff
-  // (seal → hub-authorize → leaf-up) has its seal + hub-authorize legs
-  // confirmed — so a member never storms the hub with an unauthorized leaf
-  // (the metafactory-community Authorization-Violation window). This is opt-in,
-  // NOT the default: the hub-authorize leg is a documented stub (always
-  // undefined ⇒ fail-closed) until a hub-owner-side `hub_authorized_at` registry
-  // marker exists, so defaulting it would block every join today. See
-  // `network-handoff-adapters.ts` `buildStubHubAuthPort`.
+  // cortex#1485 (epic #1479, join-6; Sage #1499) — OPT-IN guided-join gate. When
+  // `--guided` is set, the leaf-up step is refused (fail-closed) unless the
+  // 3-leg handoff (seal → hub-authorize → leaf-up) is clear to bring the leaf
+  // up — so a member never storms the hub with an unauthorized leaf (the
+  // metafactory-community Authorization-Violation window). It reads the leg
+  // signals through the SAME injected handoff-ports factory `handoff status`
+  // uses (via the shared `gatherHandoffSignals`), so the #1498 real
+  // hub-authorize read is picked up automatically once wired — no code change
+  // here. Because that read is a documented stub TODAY (hub-authorize always
+  // undefined), --guided is a DELIBERATE-CONFIRMATION gate rather than an
+  // unconditional block: `--hub-authorized-confirmed` is the member attesting
+  // "the hub owner confirmed my authorization", which upgrades the
+  // un-auto-verifiable leg — but NEVER a real negative (#1498). This is
+  // deliberately NOT the default: without the attestation path it would block
+  // every join today.
   if (flags["--guided"] === true) {
-    const admission = buildAdmissionStatePort(cfg);
-    const hubAuth = buildStubHubAuthPort();
-    const admissionRes = await admission.resolve(networkId);
-    const sealed = admissionRes.ok && admissionRes.state.hasSealedSecret;
-    const hubRes = await hubAuth.resolveHubAuthorized(networkId, inputs.principal);
-    // leafUp:false — we are ABOUT to bring it up; the guard depends only on
-    // seal + hub-authorize.
-    const state = deriveHandoffState({ sealed, hubAuthorized: hubRes.confirmed, leafUp: false });
+    const handoffPorts = handoffPortsFactory(cfg, inputs.policyNetworks);
+    // member == the joining principal — this IS the local stack, so the leaf-up
+    // leg reads local `/leafz` (though the guard depends only on seal +
+    // hub-authorize).
+    const { signals } = await gatherHandoffSignals(handoffPorts, {
+      networkId,
+      member: inputs.principal,
+      selfPrincipal: inputs.principal,
+    });
+    const attested = flags["--hub-authorized-confirmed"] === true;
+    const state = deriveHandoffState(signals, { attested });
     const guard = guardLeafUp(state, networkId);
     if (!guard.allowed) {
       return opError("join", guard.message, json);
@@ -4156,7 +4176,7 @@ export async function dispatchNetwork(
 
   switch (parsed.subcommand) {
     case "join":
-      return runJoin(parsed.positionals.network ?? "", parsed.flags, json, load, provisionPortsFactory);
+      return runJoin(parsed.positionals.network ?? "", parsed.flags, json, load, provisionPortsFactory, handoffPortsFactory);
     case "leave":
       return runLeave(parsed.positionals.network ?? "", parsed.flags, json, load);
     case "status":
@@ -4444,9 +4464,17 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
                           sender principals. Empty (default) = inbound DISABLED (OQ1
                           safe). Non-empty = inbound enabled, gated to these ids only.
   --guided                (join, #1485) OPT-IN guided join: refuse to bring the leaf
-                          up (fail-closed) until the 3-leg handoff's seal + hub-authorize
-                          legs are confirmed, instead of storming the hub. Off by default
-                          (hub-authorize is a documented stub today — see 'handoff').
+                          up (fail-closed) until the 3-leg handoff is clear — seal done
+                          AND hub-authorize effectively done — instead of storming the
+                          hub. Off by default. Hub-authorize can't be auto-verified today
+                          (documented stub until #1498), so --guided is a deliberate-
+                          confirmation gate: pair it with --hub-authorized-confirmed once
+                          the hub owner tells you they applied your authorization.
+  --hub-authorized-confirmed  (join, #1485) member attestation: "the hub owner confirmed
+                          they applied my authorization on the hub". Under --guided,
+                          upgrades the un-auto-verifiable hub-authorize leg to done so the
+                          leaf-up step proceeds. NEVER overrides a real negative (#1498).
+                          No effect without --guided.
   --network <net>         (handoff) the network whose handoff to report (required).
   --monitor-url <url>     (status) nats-server monitor base URL for leaf telemetry.
   --hub <tls-url>         (create) the hub's leaf-node dial URL (e.g. tls://hub.meta-factory.ai:7422).


### PR DESCRIPTION
## What
Models a network join as the **3-leg handoff it actually is** — **seal (admin) → hub-authorize (hub owner) → leaf-up (member)** — as explicit tracked state, and adds an opt-in fail-closed enforcement gate that **guards against** the leaf-up-before-hub-auth **storm window** from the metafactory-community bring-up. To be clear about scope: it does not yet *close* that window — the gate is opt-in (`--guided`, not the default) and, until #1498 provides a real hub-authorize signal, self-attestable (`--hub-authorized-confirmed` is an honor-system member vouch). It makes the handoff *visible and deliberate*; closing the window fully is `--guided`-by-default + the #1498 signal.

Sub-issue of epic **#1479**, slice **join-6** — the capstone (#1485).

## How
- **Pure state model** (`network-handoff-lib.ts`): `deriveHandoffState(signals)` → the 3 ordered legs each `done | pending | blocked` + owner, the outstanding `nextLeg`/owner, and `canBringLeafUp`. Ordering is fixed (a later leg is `blocked` until earlier legs are `done`). `hubAuthorized` is typed `boolean | undefined`, and `undefined` is treated **fail-closed** (never "done").
- **`cortex network handoff status <member> --network <net>`** (human + `--json`): shows each leg's status, the outstanding leg, and whose job it is (admin / hub-owner / member).
- **`join --guided`** (opt-in): a fail-closed preflight — before any mutation it derives the handoff state and **refuses to bring the leaf up until seal + hub-authorize are confirmed**, naming the outstanding leg + owner.

## The three leg signals (honest about what's real)
| Leg | Signal | Real? |
|---|---|---|
| **seal** (admin) | `buildAdmissionStatePort.resolve().hasSealedSecret` on the member's ADMITTED row | ✅ real |
| **leaf-up** (member) | `isLeafEstablished` — reuses doctor's `/leafz` lookup (now exported) | ✅ real |
| **hub-authorize** (hub owner) | `buildStubHubAuthPort` → `confirmed: undefined` | ⚠️ **documented stub** |

**Why hub-authorize is a stub:** the member has no hub-side visibility (#1481) and the registry row is opaque ciphertext (#1482 Pair-3) — there's no signal to read. Deliberately **not** inferred from a successful leaf connection (circular — leaf-up is what we gate on it). The counterpart — a hub-owner-side `hub_authorized_at` marker on the registry row — is filed as **#1498**. The model already types this `boolean | undefined` and treats `undefined` fail-closed, so wiring the real read later changes nothing in the model or the guard.

**Why `--guided` is opt-in, not the join default:** since hub-authorize is always `undefined` today, defaulting the guard would block *every* join until #1498 lands. Opt-in until then.

## Verification
- `bunx tsc --noEmit`, `bun run lint:errors`, `bash scripts/check-carveouts.sh` — all clean.
- Tests: `network-handoff-lib.test.ts` (18 — all leg combos, fail-closed on `undefined` hub-authorize, guard message), `network-handoff-cli.test.ts` (6 — dispatch-level human+json), a `join --guided` guard case in `network-cli.test.ts` (fires fail-closed with `--guided`, proceeds without it — proving opt-in), doctor regression green. **65 pass / 0 fail**.

## Reviewer note
This is the capstone state machine — I'd value a human eye on the leg-signal design, especially the hub-authorize stub → #1498 boundary. Left un-merged for review rather than auto-merged.

Closes #1485
Refs #1479 #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
