### PR TITLE
feat(network): C-1498 — real hub_authorized_at signal for guided-join (closes the #1485 hub-authorize stub)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -1630,6 +1630,7 @@ describe("#762 registerStack announces capabilities into the network", () => {
             updated_at: "2026-01-01T00:00:00Z",
             granted_by: "admin-pubkey",
             sealed_secret: null,
+            hub_authorized_at: null,
           },
         ];
         const principals = await store.listPrincipals();

--- a/src/cli/cortex/commands/__tests__/network-authorize-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-authorize-cli.test.ts
@@ -1,0 +1,162 @@
+/**
+ * cortex#1498 (epic #1479 follow-up) — `cortex network authorize` CLI dispatch
+ * tests.
+ *
+ * Drives `dispatchNetwork` end-to-end with an injected authorize-ports factory
+ * + a real chmod-600 hub-admin seed file. Asserts: grammar validation, dry-run
+ * default (no mutation), --apply wiring, --json shape.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createUser } from "nkeys.js";
+import { dispatchNetwork, type AuthorizePortsFactory } from "../network";
+import type { NetworkAuthorizePorts } from "../network-authorize-ports";
+
+let tmp: string;
+let seedPath: string;
+// A valid 44-char base64 Ed25519 pubkey (32 bytes → 44 b64 chars, one '=' pad).
+const MEMBER = btoa("A".repeat(32));
+
+interface Calls {
+  posted: string[];
+}
+
+function fakeFactory(opts: { admitted?: { request_id: string; principal_id: string } } = {}): {
+  factory: AuthorizePortsFactory;
+  calls: Calls;
+} {
+  const calls: Calls = { posted: [] };
+  const ports: NetworkAuthorizePorts = {
+    admission: { findAdmittedRow: async () => opts.admitted },
+    delivery: {
+      postAuthorize: async (requestId: string) => {
+        calls.posted.push(requestId);
+      },
+    },
+  };
+  return { factory: () => ports, calls };
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "authorize-cli-"));
+  seedPath = join(tmp, "hub-admin.seed");
+  const seed = new TextDecoder().decode(createUser().getSeed());
+  writeFileSync(seedPath, seed, { mode: 0o600 });
+  chmodSync(seedPath, 0o600);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function argv(...args: string[]): string[] {
+  return args;
+}
+
+/** dispatchNetwork(argv, load, ping, provision, secret, makeLive, keyRotation, doctor, handoff, authorize). */
+function runAuthorizeCli(args: string[], factory: AuthorizePortsFactory) {
+  return dispatchNetwork(
+    args,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    factory,
+  );
+}
+
+describe("cortex network authorize — grammar", () => {
+  test("missing --network → usage error (exit 2)", async () => {
+    const { factory } = fakeFactory();
+    const res = await runAuthorizeCli(argv("authorize", MEMBER, "--admin-seed", seedPath), factory);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--network");
+  });
+
+  test("bad --network grammar → usage error (exit 2)", async () => {
+    const { factory } = fakeFactory();
+    const res = await runAuthorizeCli(argv("authorize", MEMBER, "--network", "BAD_CAPS", "--admin-seed", seedPath), factory);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("lowercase");
+  });
+
+  test("missing member pubkey → usage error (exit 2)", async () => {
+    const { factory } = fakeFactory();
+    const res = await runAuthorizeCli(argv("authorize", "--network", "metafactory", "--admin-seed", seedPath), factory);
+    expect(res.exitCode).toBe(2);
+  });
+
+  test("malformed member pubkey → usage error (exit 2)", async () => {
+    const { factory } = fakeFactory();
+    const res = await runAuthorizeCli(argv("authorize", "not-a-pubkey", "--network", "metafactory", "--admin-seed", seedPath), factory);
+    expect(res.exitCode).toBe(2);
+  });
+
+  test("missing --admin-seed → usage error (exit 2)", async () => {
+    const { factory } = fakeFactory();
+    const res = await runAuthorizeCli(argv("authorize", MEMBER, "--network", "metafactory"), factory);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--admin-seed");
+  });
+
+  test("--apply and --dry-run are mutually exclusive (exit 2)", async () => {
+    const { factory } = fakeFactory();
+    const res = await runAuthorizeCli(
+      argv("authorize", MEMBER, "--network", "metafactory", "--admin-seed", seedPath, "--apply", "--dry-run"),
+      factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("mutually exclusive");
+  });
+});
+
+describe("cortex network authorize — dry-run default", () => {
+  test("dry-run (default) resolves the row but posts NOTHING", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req-1", principal_id: "alice" } });
+    const res = await runAuthorizeCli(argv("authorize", MEMBER, "--network", "metafactory", "--admin-seed", seedPath), factory);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("dry-run");
+    expect(calls.posted).toEqual([]);
+  });
+
+  test("no ADMITTED row → operational failure (exit 1), no mutation", async () => {
+    const { factory, calls } = fakeFactory({});
+    const res = await runAuthorizeCli(argv("authorize", MEMBER, "--network", "metafactory", "--admin-seed", seedPath), factory);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("no ADMITTED admission row");
+    expect(calls.posted).toEqual([]);
+  });
+});
+
+describe("cortex network authorize --apply", () => {
+  test("--apply POSTs the authorize claim onto the resolved row", async () => {
+    const { factory, calls } = fakeFactory({ admitted: { request_id: "req-1", principal_id: "alice" } });
+    const res = await runAuthorizeCli(
+      argv("authorize", MEMBER, "--network", "metafactory", "--admin-seed", seedPath, "--apply"),
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).not.toContain("dry-run");
+    expect(calls.posted).toEqual(["req-1"]);
+  });
+
+  test("--json emits the applied envelope", async () => {
+    const { factory } = fakeFactory({ admitted: { request_id: "req-1", principal_id: "alice" } });
+    const res = await runAuthorizeCli(
+      argv("authorize", MEMBER, "--network", "metafactory", "--admin-seed", seedPath, "--apply", "--json"),
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as { status: string; data: { applied: string; request_id: string } };
+    expect(parsed.status).toBe("ok");
+    expect(parsed.data.applied).toBe("true");
+    expect(parsed.data.request_id).toBe("req-1");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-authorize-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-authorize-lib.test.ts
@@ -1,0 +1,83 @@
+/**
+ * cortex#1498 (epic #1479 follow-up) — `cortex network authorize` orchestrator
+ * tests (fake ports).
+ *
+ * Proves the trust-path behaviours over injected ports:
+ *   - dry-run (default) resolves the ADMITTED row but posts NOTHING
+ *   - --apply POSTs the authorize claim onto the resolved row
+ *   - no ADMITTED row → ok:false, no mutation, an actionable reason
+ *   - a delivery-port failure surfaces as ok:false with the error text
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createUser } from "@nats-io/nkeys";
+import { nkeyToBase64Pubkey } from "../../../../common/registry/encoding";
+import { runNetworkAuthorize, type AuthorizeInputs } from "../network-authorize-lib";
+import type { NetworkAuthorizePorts } from "../network-authorize-ports";
+
+function makePorts(admitted?: { request_id: string; principal_id: string }): {
+  ports: NetworkAuthorizePorts;
+  posted: string[];
+} {
+  const posted: string[] = [];
+  const ports: NetworkAuthorizePorts = {
+    admission: {
+      findAdmittedRow: async () => admitted,
+    },
+    delivery: {
+      postAuthorize: async (requestId: string) => {
+        posted.push(requestId);
+      },
+    },
+  };
+  return { ports, posted };
+}
+
+const MEMBER_PUBKEY = nkeyToBase64Pubkey(createUser().getPublicKey())!;
+
+describe("runNetworkAuthorize", () => {
+  test("dry-run (default) resolves the row but posts NOTHING", async () => {
+    const { ports, posted } = makePorts({ request_id: "req-1", principal_id: "alice" });
+    const inputs: AuthorizeInputs = { networkId: "metafactory", memberPubkey: MEMBER_PUBKEY, apply: false };
+    const report = await runNetworkAuthorize(inputs, ports);
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(false);
+    expect(report.data.request_id).toBe("req-1");
+    expect(posted).toEqual([]);
+    expect(report.steps.some((s) => s.includes("would:"))).toBe(true);
+  });
+
+  test("--apply POSTs the authorize claim onto the resolved row", async () => {
+    const { ports, posted } = makePorts({ request_id: "req-1", principal_id: "alice" });
+    const inputs: AuthorizeInputs = { networkId: "metafactory", memberPubkey: MEMBER_PUBKEY, apply: true };
+    const report = await runNetworkAuthorize(inputs, ports);
+    expect(report.ok).toBe(true);
+    expect(report.applied).toBe(true);
+    expect(posted).toEqual(["req-1"]);
+  });
+
+  test("no ADMITTED row → ok:false, no mutation, actionable reason", async () => {
+    const { ports, posted } = makePorts(undefined);
+    const inputs: AuthorizeInputs = { networkId: "metafactory", memberPubkey: MEMBER_PUBKEY, apply: true };
+    const report = await runNetworkAuthorize(inputs, ports);
+    expect(report.ok).toBe(false);
+    expect(report.applied).toBe(false);
+    expect(posted).toEqual([]);
+    expect(report.reason).toContain("no ADMITTED admission row");
+  });
+
+  test("delivery failure surfaces as ok:false with the error text", async () => {
+    const ports: NetworkAuthorizePorts = {
+      admission: { findAdmittedRow: async () => ({ request_id: "req-1", principal_id: "alice" }) },
+      delivery: {
+        postAuthorize: async () => {
+          throw new Error("registry rejected authorize (HTTP 403)");
+        },
+      },
+    };
+    const inputs: AuthorizeInputs = { networkId: "metafactory", memberPubkey: MEMBER_PUBKEY, apply: true };
+    const report = await runNetworkAuthorize(inputs, ports);
+    expect(report.ok).toBe(false);
+    expect(report.reason).toContain("registry rejected authorize");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -15,6 +15,7 @@ import { describe, test, expect, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { createUser } from "nkeys.js";
 
 import { dispatchNetwork, joinBlockerMessage, shouldReplaceCredsPreflightError, type HandoffPortsFactory } from "../network";
 import type { OwnAdmissionState, ResolveOwnAdmissionStateResult } from "../../../../common/registry/admission-state";
@@ -22,6 +23,8 @@ import type { LoadedConfig } from "../../../../common/config/loader";
 import type { AgentConfig } from "../../../../common/types/config";
 import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
 import type { NetworkHandoffPorts, HandoffHubAuthPort } from "../network-handoff-ports";
+import { buildLiveHandoffPorts } from "../network-handoff-adapters";
+import { __setAdmissionResolverForTests } from "../network-adapters";
 
 // #753 — a reader returning an EMPTY config so derivation tests are
 // deterministic (no dependence on the dev machine's real ~/.config/cortex).
@@ -318,6 +321,39 @@ describe("#1485 — join --guided guard DISCRIMINATES", () => {
     expect(res.exitCode).toBe(1);
     expect(res.stderr).not.toContain("cannot bring the leaf up");
     expect(res.stderr).toContain("dry-run");
+  });
+
+  test("cortex#1498 — REAL adapter (buildLiveHandoffPorts) + a marked row → join --guided PROCEEDS with NO --hub-authorized-confirmed attestation", async () => {
+    // Unlike the fakes above, this drives the REAL hub-authorize adapter
+    // (`buildLiveHubAuthPort` via `buildLiveHandoffPorts`) — proving the
+    // cortex#1498 wiring itself, not just the pure state model. The admission
+    // read (both the seal AND hub-authorize legs go through the SAME
+    // `buildAdmissionStatePort`) is stubbed via the `__setAdmissionResolverForTests`
+    // seam, but everything downstream (buildLiveHubAuthPort → HandoffHubAuthPort
+    // → gatherHandoffSignals → guardLeafUp) is the REAL production code path.
+    const dir = freshDir();
+    const seedPath = join(dir, "seed.nk");
+    writeFileSync(seedPath, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
+    __setAdmissionResolverForTests(async () => ({
+      ok: true,
+      state: {
+        state: "admitted-sealed",
+        networkId: "metafactory",
+        requestId: "req-1",
+        hasSealedSecret: true,
+        peerPubkey: "PUBKEY_FIXTURE",
+        hubAuthorizedAt: "2026-03-01T00:00:00.000Z",
+      },
+    }));
+    try {
+      const realHandoffFactory: HandoffPortsFactory = (cfg, networks) => buildLiveHandoffPorts(cfg, networks);
+      const res = await joinWithHandoff(guidedArgv(dir, ["--guided"]), realHandoffFactory);
+      expect(res.exitCode).toBe(1);
+      expect(res.stderr).not.toContain("cannot bring the leaf up");
+      expect(res.stderr).toContain("dry-run");
+    } finally {
+      __setAdmissionResolverForTests(null);
+    }
   });
 
   test("sealed + hub-authorize REAL false → BLOCKS EVEN WITH attestation (attestation cannot override)", async () => {

--- a/src/cli/cortex/commands/__tests__/network-handoff-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-handoff-adapters.test.ts
@@ -100,6 +100,22 @@ describe("buildLiveHubAuthPort", () => {
     expect(res.reason).toContain("registry mine-read errored");
   });
 
+  test("REMOTE member (member != cfg.principalId) → confirmed: undefined (not observable, never reads own row as theirs)", async () => {
+    // A resolver that WOULD return a marked row — proving the remote-member
+    // guard short-circuits BEFORE the /mine read, so we never mislabel our own
+    // row as the remote member's.
+    let resolverCalled = false;
+    __setAdmissionResolverForTests(async () => {
+      resolverCalled = true;
+      return admittedWith("2026-03-01T00:00:00.000Z");
+    });
+    const port = buildLiveHubAuthPort(cfg()); // cfg().principalId === "andreas"
+    const res = await port.resolveHubAuthorized("metafactory", "someone-else");
+    expect(res.confirmed).toBeUndefined();
+    expect(res.reason).toContain("not observable");
+    expect(resolverCalled).toBe(false); // guard fired before the read
+  });
+
   test("no seed configured at all → confirmed: undefined (never throws)", async () => {
     __setAdmissionResolverForTests(async () => admittedWith("2026-03-01T00:00:00.000Z"));
     const port = buildLiveHubAuthPort({

--- a/src/cli/cortex/commands/__tests__/network-handoff-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-handoff-adapters.test.ts
@@ -1,0 +1,115 @@
+/**
+ * cortex#1498 (epic #1479 follow-up) — `buildLiveHubAuthPort` tests.
+ *
+ * The hub-authorize leg's LIVE adapter reads the registry's real
+ * `hub_authorized_at` marker via the SAME `buildAdmissionStatePort` `/mine`
+ * path the seal leg uses. These tests drive it via the `__setAdmissionResolverForTests`
+ * seam (the SAME seam `network-adapters.ts` exposes for `status` tests) so no
+ * real HTTP round trip is needed — but a REAL (temp) seed file is required,
+ * since `buildAdmissionStatePort` loads + chmod-checks it before ever reaching
+ * the injected resolver.
+ *
+ *   - a row WITH `hubAuthorizedAt` → `confirmed: true`
+ *   - a row WITHOUT it (or no row at all) → `confirmed: false` (a REAL
+ *     negative — this is the behavior change from the pre-#1498 stub, which
+ *     always returned `undefined`)
+ *   - the admission read itself failing (registry unreachable / no seed
+ *     configured) → `confirmed: undefined` (the documented fallback)
+ */
+
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createUser } from "nkeys.js";
+
+import { buildLiveHubAuthPort } from "../network-handoff-adapters";
+import { __setAdmissionResolverForTests, type LivePortsConfig } from "../network-adapters";
+import type { ResolveOwnAdmissionStateResult } from "../../../../common/registry/admission-state";
+
+let tmp: string;
+let seedPath: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "s4-handoff-adapters-"));
+  seedPath = join(tmp, "hub-admin.seed");
+  writeFileSync(seedPath, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
+});
+
+afterEach(() => {
+  __setAdmissionResolverForTests(null);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function cfg(): LivePortsConfig {
+  return {
+    networkId: "metafactory",
+    principalId: "andreas",
+    stackId: "andreas/meta-factory",
+    registryUrl: "http://127.0.0.1:0", // never actually dialed — resolver is overridden
+    seedPath,
+  };
+}
+
+function admittedWith(hubAuthorizedAt?: string): ResolveOwnAdmissionStateResult {
+  return {
+    ok: true,
+    state: {
+      state: "admitted-sealed",
+      networkId: "metafactory",
+      requestId: "req-1",
+      hasSealedSecret: true,
+      peerPubkey: "PUBKEY_FIXTURE",
+      ...(hubAuthorizedAt !== undefined && { hubAuthorizedAt }),
+    },
+  };
+}
+
+describe("buildLiveHubAuthPort", () => {
+  test("row WITH hub_authorized_at → confirmed: true", async () => {
+    __setAdmissionResolverForTests(async () => admittedWith("2026-03-01T00:00:00.000Z"));
+    const port = buildLiveHubAuthPort(cfg());
+    const res = await port.resolveHubAuthorized("metafactory", "andreas");
+    expect(res.confirmed).toBe(true);
+    expect(res.reason).toBeUndefined();
+  });
+
+  test("row WITHOUT hub_authorized_at → confirmed: false (a REAL negative)", async () => {
+    __setAdmissionResolverForTests(async () => admittedWith(undefined));
+    const port = buildLiveHubAuthPort(cfg());
+    const res = await port.resolveHubAuthorized("metafactory", "andreas");
+    expect(res.confirmed).toBe(false);
+    expect(res.reason).toContain("cortex network authorize");
+  });
+
+  test("no admission row at all → confirmed: false", async () => {
+    __setAdmissionResolverForTests(async () => ({
+      ok: true,
+      state: { state: "no-row", networkId: "metafactory", hasSealedSecret: false, peerPubkey: "PUBKEY_FIXTURE" },
+    }));
+    const port = buildLiveHubAuthPort(cfg());
+    const res = await port.resolveHubAuthorized("metafactory", "andreas");
+    expect(res.confirmed).toBe(false);
+  });
+
+  test("admission read failure (registry unreachable) → confirmed: undefined (documented fallback)", async () => {
+    __setAdmissionResolverForTests(async () => ({ ok: false, reason: "registry mine-read errored: fetch failed" }));
+    const port = buildLiveHubAuthPort(cfg());
+    const res = await port.resolveHubAuthorized("metafactory", "andreas");
+    expect(res.confirmed).toBeUndefined();
+    expect(res.reason).toContain("registry mine-read errored");
+  });
+
+  test("no seed configured at all → confirmed: undefined (never throws)", async () => {
+    __setAdmissionResolverForTests(async () => admittedWith("2026-03-01T00:00:00.000Z"));
+    const port = buildLiveHubAuthPort({
+      networkId: "metafactory",
+      principalId: "andreas",
+      stackId: "andreas/meta-factory",
+      registryUrl: "http://127.0.0.1:0",
+      // seedPath omitted entirely
+    });
+    const res = await port.resolveHubAuthorized("metafactory", "andreas");
+    expect(res.confirmed).toBeUndefined();
+  });
+});

--- a/src/cli/cortex/commands/network-authorize-adapters.ts
+++ b/src/cli/cortex/commands/network-authorize-adapters.ts
@@ -1,0 +1,94 @@
+/**
+ * cortex#1498 (epic #1479 follow-up) — LIVE adapters for `cortex network authorize`.
+ *
+ * Two real side effects the orchestrator (`network-authorize-lib.ts`) depends on:
+ *   - the admin-signed admission-row LOOKUP (find the member's ADMITTED row) —
+ *     the SAME `GET /admission-requests?status=ADMITTED` + filter shape
+ *     `network-secret-adapters.ts`'s lookup uses (hub-admin authority collapses
+ *     with the registry-admin read allowlist for the common single-principal
+ *     deployment — see the same NOTE there).
+ *   - the hub-admin-signed authorize POST — stamps `hub_authorized_at` onto
+ *     the row (cortex#1498). Mints nothing; no local fs/nats-config write at
+ *     all (unlike `network secret`, `authorize` never touches the hub-local
+ *     nats-server config — it is a registry-only write).
+ */
+
+import { canonicalJSON } from "../../../common/registry/signing";
+import { signClaimWithSeed, randomNonce, type StackIdentityMaterial } from "../../../bus/stack-provisioning";
+import type { AdmissionLookupPort, HubAuthorizeDeliveryPort, NetworkAuthorizePorts } from "./network-authorize-ports";
+
+export interface LiveAuthorizePortsConfig {
+  /** Registry base URL. */
+  registryUrl: string;
+  /** The HUB-ADMIN identity (signs the admission-list read + the authorize claim). */
+  material: StackIdentityMaterial;
+  /** Injectable fetch (tests). Production omits → globalThis.fetch. */
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+/** Build the full live port bundle. */
+export function buildLiveAuthorizePorts(cfg: LiveAuthorizePortsConfig): NetworkAuthorizePorts {
+  return {
+    admission: buildLiveAdmissionLookupPort(cfg),
+    delivery: buildLiveHubAuthorizeDeliveryPort(cfg),
+  };
+}
+
+interface AdmissionRow {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  network_id: string | null;
+  status: string;
+}
+
+function buildLiveAdmissionLookupPort(cfg: LiveAuthorizePortsConfig): AdmissionLookupPort {
+  const base = cfg.registryUrl.replace(/\/+$/, "");
+  const fetchImpl = cfg.fetchImpl ?? globalThis.fetch;
+  return {
+    async findAdmittedRow(networkId, memberPubkey) {
+      // Admin-signed read of the ADMITTED list (x-admin-signed header) — the
+      // SAME shape `network-secret-adapters.ts`'s lookup uses. NOTE: the
+      // registry's read gate checks the REGISTRY-admin allowlist; for a
+      // single-principal deployment the hub-admin seed IS the registry-admin
+      // (Q5 collapse), so this works. A fully-separable deployment must put
+      // the hub-admin on REGISTRY_ADMIN_PUBKEYS for the lookup.
+      const claim = { admin_pubkey: cfg.material.pubkeyB64, issued_at: new Date().toISOString() };
+      const signature = await signClaimWithSeed(cfg.material.seed, new TextEncoder().encode(canonicalJSON(claim)));
+      const resp = await fetchImpl(`${base}/admission-requests?status=ADMITTED`, {
+        method: "GET",
+        headers: { "Content-Type": "application/json", "x-admin-signed": JSON.stringify({ claim, signature }) },
+      });
+      if (!resp.ok) {
+        throw new Error(`registry admission list failed (HTTP ${resp.status.toString()}): ${await resp.text()}`);
+      }
+      const rows = (await resp.json()) as AdmissionRow[];
+      const row = rows.find((r) => r.network_id === networkId && r.peer_pubkey === memberPubkey && r.status === "ADMITTED");
+      return row ? { request_id: row.request_id, principal_id: row.principal_id } : undefined;
+    },
+  };
+}
+
+function buildLiveHubAuthorizeDeliveryPort(cfg: LiveAuthorizePortsConfig): HubAuthorizeDeliveryPort {
+  const base = cfg.registryUrl.replace(/\/+$/, "");
+  const fetchImpl = cfg.fetchImpl ?? globalThis.fetch;
+  return {
+    async postAuthorize(requestId) {
+      const claim = {
+        request_id: requestId,
+        hub_admin_pubkey: cfg.material.pubkeyB64,
+        issued_at: new Date().toISOString(),
+        nonce: randomNonce(),
+      };
+      const signature = await signClaimWithSeed(cfg.material.seed, new TextEncoder().encode(canonicalJSON(claim)));
+      const resp = await fetchImpl(`${base}/admission-requests/${encodeURIComponent(requestId)}/authorize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ claim, signature }),
+      });
+      if (!resp.ok) {
+        throw new Error(`registry rejected authorize (HTTP ${resp.status.toString()}): ${await resp.text()}`);
+      }
+    },
+  };
+}

--- a/src/cli/cortex/commands/network-authorize-adapters.ts
+++ b/src/cli/cortex/commands/network-authorize-adapters.ts
@@ -11,10 +11,25 @@
  *     the row (cortex#1498). Mints nothing; no local fs/nats-config write at
  *     all (unlike `network secret`, `authorize` never touches the hub-local
  *     nats-server config — it is a registry-only write).
+ *
+ * AUTHORITY COUPLING (v1 design choice — governance question, flagged not
+ * resolved): stamping `hub_authorized_at` currently requires the SAME
+ * hub-admin authority (`REGISTRY_HUB_ADMIN_PUBKEYS`, falling back to
+ * `REGISTRY_ADMIN_PUBKEYS`) that attaches the sealed secret — the authorize
+ * route reuses the sealed-secret route's `verifyHubAdminWrite` gate verbatim
+ * (ADR-0018 Q5). Whether the HUB OWNER — the person who actually applies the
+ * leaf `authorization` on their own VM — should be a DISTINCT authority from
+ * the registry/network admin (rather than collapsed into the hub-admin
+ * allowlist) is a governance question for the team (Andreas), not settled
+ * here. The `#1481` hub-owner-artifact flow already assumes the hub owner and
+ * the seal-issuing admin can be different people; wiring a hub-owner-scoped
+ * signing authority for this stamp would make the guided-join handoff's
+ * "whose job is it" model fully faithful. Tracked as a follow-up.
  */
 
 import { canonicalJSON } from "../../../common/registry/signing";
 import { signClaimWithSeed, randomNonce, type StackIdentityMaterial } from "../../../bus/stack-provisioning";
+import { samePubkey } from "../../../common/registry/pubkey-normalize";
 import type { AdmissionLookupPort, HubAuthorizeDeliveryPort, NetworkAuthorizePorts } from "./network-authorize-ports";
 
 export interface LiveAuthorizePortsConfig {
@@ -63,7 +78,14 @@ function buildLiveAdmissionLookupPort(cfg: LiveAuthorizePortsConfig): AdmissionL
         throw new Error(`registry admission list failed (HTTP ${resp.status.toString()}): ${await resp.text()}`);
       }
       const rows = (await resp.json()) as AdmissionRow[];
-      const row = rows.find((r) => r.network_id === networkId && r.peer_pubkey === memberPubkey && r.status === "ADMITTED");
+      // cortex#1482 — compare via `samePubkey` (encoding-blind) so a member
+      // passed as an nkey OR base64 resolves the SAME registry row (rows store
+      // base64). The lib already normalizes to base64 before calling, but the
+      // adapter stays robust either way — consistent with what `secret`/`admit`
+      // do post-#1482.
+      const row = rows.find(
+        (r) => r.network_id === networkId && r.status === "ADMITTED" && samePubkey(r.peer_pubkey, memberPubkey),
+      );
       return row ? { request_id: row.request_id, principal_id: row.principal_id } : undefined;
     },
   };

--- a/src/cli/cortex/commands/network-authorize-lib.ts
+++ b/src/cli/cortex/commands/network-authorize-lib.ts
@@ -1,0 +1,118 @@
+/**
+ * cortex#1498 (epic #1479 follow-up) — `cortex network authorize` orchestrator
+ * (PURE over ports).
+ *
+ * The hub-owner side of the guided-join handoff's hub-authorize leg
+ * (`network-handoff-lib.ts`): after the hub owner has applied the member's
+ * leaf `authorization` entry on their OWN nats-server config (the #1481
+ * hub-owner artifact — printed by `cortex network secret add-member
+ * --seal-only` / an EXTERNAL-hub `add-member`), they run THIS command to
+ * stamp the registry's `hub_authorized_at` (cortex#1498) — the real signal
+ * that replaces the `--hub-authorized-confirmed` honor-system attestation.
+ *
+ * Mints nothing; writes nothing hub-local. It is a single admin-signed
+ * registry write, gated on the SAME hub-admin authority as the sealed-secret
+ * delivery (ADR-0018 Q5). MUTATION gates on `apply`: dry-run resolves the
+ * admission-row lookup (read-only, safe) and prints the plan; `--apply` POSTs
+ * the signed claim.
+ */
+
+import { toBase64Pubkey, looksLikeNkeyRole } from "../../../common/registry/pubkey-normalize";
+import type { NetworkAuthorizePorts } from "./network-authorize-ports";
+
+export interface AuthorizeInputs {
+  networkId: string;
+  /** The member's registered ed25519 pubkey (base64, or an nkey of either encoding) — the row key. */
+  memberPubkey: string;
+  apply: boolean;
+}
+
+export interface AuthorizeReport {
+  ok: boolean;
+  applied: boolean;
+  networkId: string;
+  /** Human-readable plan/result steps. */
+  steps: string[];
+  /** Structured data for --json. */
+  data: Record<string, string>;
+  /** Failure reason (operational). */
+  reason?: string;
+}
+
+/**
+ * Stamp `hub_authorized_at` onto the member's ADMITTED admission row for
+ * `networkId`. Dry-run by default (resolves the row, prints the plan);
+ * `apply` POSTs the signed claim.
+ */
+export async function runNetworkAuthorize(
+  inputs: AuthorizeInputs,
+  ports: NetworkAuthorizePorts,
+): Promise<AuthorizeReport> {
+  const steps: string[] = [];
+  // cortex#1482-style normalize: accept either encoding (base64 or an nkey of
+  // either role) for the lookup, falling back to the raw value so an
+  // already-malformed input fails exactly as it did before this normalize.
+  const memberPubkeyB64 = toBase64Pubkey(inputs.memberPubkey) ?? inputs.memberPubkey;
+  const data: Record<string, string> = {
+    action: "authorize",
+    network: inputs.networkId,
+    member_fingerprint: memberPubkeyB64.slice(0, 12),
+  };
+
+  const row = await ports.admission.findAdmittedRow(inputs.networkId, memberPubkeyB64);
+  if (!row) {
+    return fail(inputs, steps, data, noAdmittedRowMessage(inputs.networkId, inputs.memberPubkey));
+  }
+  data.request_id = row.request_id;
+  steps.push(`member:     ${memberPubkeyB64.slice(0, 12)}… (request ${row.request_id})`);
+
+  if (!inputs.apply) {
+    steps.push(`would: stamp hub_authorized_at on the registry admission row (hub-admin authority)`);
+    return plan(inputs, steps, data);
+  }
+
+  try {
+    await ports.delivery.postAuthorize(row.request_id);
+  } catch (err) {
+    return fail(inputs, steps, data, `failed to stamp the registry: ${errText(err)}`);
+  }
+  steps.push(`registry:   admission row ${row.request_id} stamped hub_authorized_at`);
+
+  const report = plan(inputs, steps, data);
+  report.applied = true;
+  return report;
+}
+
+function plan(inputs: AuthorizeInputs, steps: string[], data: Record<string, string>): AuthorizeReport {
+  return { ok: true, applied: false, networkId: inputs.networkId, steps, data };
+}
+
+function fail(
+  inputs: AuthorizeInputs,
+  steps: string[],
+  data: Record<string, string>,
+  reason: string,
+): AuthorizeReport {
+  return { ok: false, applied: false, networkId: inputs.networkId, steps, data, reason };
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * cortex#1482-style — a plausible copy-paste mix-up: the member's OWN
+ * registered/PoP pubkey and the hub's federation account are DIFFERENT keys
+ * (seal-target ≠ leaf-account, ADR-0018). Explain it when the RAW value looks
+ * like the other representation (an nkey-account, `A…`); otherwise the bare
+ * "not admitted yet" message (a real, distinct failure).
+ */
+function noAdmittedRowMessage(networkId: string, rawMemberPubkey: string): string {
+  const bare = `no ADMITTED admission row for that member on network "${networkId}" — admit them first (cortex network admit), or check the member pubkey`;
+  if (!looksLikeNkeyRole(rawMemberPubkey, "account")) return bare;
+  return (
+    `${bare}. "${rawMemberPubkey.slice(0, 12)}…" looks like a FED account nkey (A…), but admission ` +
+    `rows are keyed to the member's REGISTERED/PoP pubkey — a different key, not a hub's federation ` +
+    `account. Pass the member's registered/PoP pubkey here instead (base64 or a U… nkey — either encoding works).`
+  );
+}

--- a/src/cli/cortex/commands/network-authorize-ports.ts
+++ b/src/cli/cortex/commands/network-authorize-ports.ts
@@ -1,0 +1,38 @@
+/**
+ * cortex#1498 (epic #1479 follow-up) — `cortex network authorize` injected-
+ * dependency seams.
+ *
+ * Mirrors the `network-secret-ports.ts` pattern: the orchestrator
+ * (`network-authorize-lib.ts`) is PURE over these ports; the live adapter
+ * (`network-authorize-adapters.ts`) wires the real admin-signed admission
+ * lookup + the hub-admin-signed authorize POST; tests inject fakes that never
+ * touch HTTP.
+ *
+ * This command is the registry-side write half of the #1481 hub-owner
+ * artifact hand-off: the CLI already renders the EXACT `leafnodes {}` snippet
+ * the hub owner adds to their OWN nats-server config
+ * (`renderHubOwnerArtifact`, `network-secret-lib.ts`); `cortex network
+ * authorize` is the step they run AFTER applying it, stamping the registry's
+ * `hub_authorized_at` (cortex#1498) so a member's `join --guided` / `handoff
+ * status` sees a real signal instead of the honor-system
+ * `--hub-authorized-confirmed` attestation.
+ */
+
+import type { AdmissionLookupPort } from "./network-secret-ports";
+
+// The admission-row lookup is the IDENTICAL shape `network-secret-ports.ts`
+// already defines (find the ADMITTED row for a network+member) — reused
+// directly rather than redeclared.
+export type { AdmissionLookupPort };
+
+/** POST the hub-admin-signed authorize claim onto the ADMITTED row. HUB-ADMIN authority (ADR-0018 Q5). */
+export interface HubAuthorizeDeliveryPort {
+  /** Stamp `hub_authorized_at` on the row (idempotent server-side re-stamp on a re-run). */
+  postAuthorize(requestId: string): Promise<void>;
+}
+
+/** The full port bundle the orchestrator depends on. */
+export interface NetworkAuthorizePorts {
+  admission: AdmissionLookupPort;
+  delivery: HubAuthorizeDeliveryPort;
+}

--- a/src/cli/cortex/commands/network-handoff-adapters.ts
+++ b/src/cli/cortex/commands/network-handoff-adapters.ts
@@ -70,17 +70,33 @@ export function buildStubHubAuthPort(): HandoffHubAuthPort {
  *     pre-#1498 stub, so `--hub-authorized-confirmed` still has a real job in
  *     a degraded-connectivity case.
  *
- * `member` is UNUSED here — same limitation `buildAdmissionStatePort`'s seal
- * leg already has: the `/mine` PoP read can only prove possession of THIS
- * host's own signing key, so it can only ever answer "is MY OWN row
- * authorized", never a third party's. `handoff status <member>` is only
- * authoritative when `member` is the principal running the command (mirrors
- * the leaf-up leg's own local-only caveat in `gatherHandoffSignals`).
+ * REMOTE-MEMBER guard (Sage #1501): the `/mine` PoP read can only prove
+ * possession of THIS host's OWN signing key, so it always resolves the row for
+ * `cfg.principalId` — never a third party's. Reporting our OWN hub-authorize as
+ * a REMOTE member's would be a false read (the SAME bug class the leaf-up leg's
+ * remote-member guard in `gatherHandoffSignals` already fixes). So when the
+ * requested `member` is NOT this host's own principal, the signal is
+ * `undefined` (not observable from here) — NOT a read of our own row mislabeled
+ * as theirs. `cfg.principalId` IS the `selfPrincipal` the orchestrator passes
+ * (both derive from the SAME resolved principal in `runHandoff` / `runJoin`),
+ * so the comparison is faithful without threading a second self argument.
  */
 export function buildLiveHubAuthPort(cfg: LivePortsConfig): HandoffHubAuthPort {
   const admission = buildAdmissionStatePort(cfg);
   return {
-    async resolveHubAuthorized(networkId: string, _member: string): Promise<HubAuthorizeResolution> {
+    async resolveHubAuthorized(networkId: string, member: string): Promise<HubAuthorizeResolution> {
+      if (member !== cfg.principalId) {
+        // A member's hub-authorize marker lives on THEIR admission row, which
+        // only THEIR machine can PoP-read. Never report this host's own row as
+        // the remote member's — undefined = "not observable from here".
+        return {
+          confirmed: undefined,
+          reason:
+            `not observable for member "${member}" from "${cfg.principalId}"'s machine — the hub-authorize ` +
+            `marker lives on the member's own admission row, which only their machine can PoP-read. Run ` +
+            `this on the member's own machine for an authoritative reading.`,
+        };
+      }
       const res = await admission.resolve(networkId);
       if (!res.ok) {
         return {

--- a/src/cli/cortex/commands/network-handoff-adapters.ts
+++ b/src/cli/cortex/commands/network-handoff-adapters.ts
@@ -9,8 +9,10 @@
  *     + `buildMonitorPort` from `network-doctor-adapters.ts` (the SAME
  *     `readNetworks()` + `/leafz` reads `doctor` uses).
  *
- * The one adapter that is genuinely local to this module is the hub-authorize
- * leg — and it is a DOCUMENTED STUB. See {@link buildStubHubAuthPort}.
+ * The hub-authorize leg ({@link buildLiveHubAuthPort}) is the ONE port
+ * genuinely local to this module — it now reads the REAL `hub_authorized_at`
+ * registry marker (cortex#1498), via the SAME `buildAdmissionStatePort` `/mine`
+ * read the seal leg uses (one registry round trip serves both legs).
  */
 
 import type { LivePortsConfig } from "./network-adapters";
@@ -24,34 +26,16 @@ import type {
 } from "./network-handoff-ports";
 
 /**
- * The hub-authorize leg adapter — a DOCUMENTED STUB (cortex#1485).
+ * The hub-authorize leg adapter — a DOCUMENTED STUB (cortex#1485), retained
+ * only as the documented fallback shape / for tests that want an
+ * always-undefined port. Production wires {@link buildLiveHubAuthPort}
+ * instead (cortex#1498).
  *
- * `resolveHubAuthorized` ALWAYS returns `confirmed: undefined`, because there
- * is NO signal a member's machine can read to confirm the hub owner applied
- * the authorization:
- *   - The member has no hub-side visibility at all (the cortex#1481 constraint
- *     that made `admit`/`secret` grow a seal-only path in the first place).
- *   - The registry's admission row carries only an OPAQUE ciphertext sealed to
- *     the member's OWN pubkey (ADR-0018 Q1) — there is nothing on it that says
- *     "the hub owner has authorized this member". This is the SAME gap
- *     `cortex network doctor`'s Pair 3 leg (`sealed-secret-hub-authorized`,
- *     cortex#1482) already documents and always `skip`s.
- *   - A successful leaf connection is NOT a usable signal here — leaf-up is
- *     precisely the thing this handoff GATES on hub-authorize, so inferring
- *     hub-authorize from it would be circular.
- *
- * The clean fix — and the counterpart WRITE this stub is designed to read the
- * moment it exists — is an EXPLICIT per-member marker on the registry
- * admission row (a `hub_authorized_at` timestamp / boolean) that the hub owner
- * STAMPS when they apply the authorization. That is a real change to the
- * registry's `admission_requests` SQL table (`src/services/network-registry/
- * src/{types,store}.ts`) plus a hub-owner-side action (most naturally a flag on
- * the existing `secret add-member` / `admit` seal path), so it is out of scope
- * for THIS slice — tracked as a follow-up. The pure state model
- * ({@link import("./network-handoff-lib").deriveHandoffState}) already types
- * this signal `boolean | undefined` and treats `undefined` as fail-closed
- * (NOT done), so the moment a live `hub_authorized_at` read is wired here,
- * nothing in the state model or the leaf-up guard changes.
+ * `resolveHubAuthorized` ALWAYS returns `confirmed: undefined` — this was the
+ * ONLY possible answer before the registry grew a `hub_authorized_at` marker:
+ * the member has no hub-side visibility (cortex#1481) and the admission row
+ * carried only an opaque sealed-secret ciphertext (ADR-0018 Q1), nothing that
+ * said "the hub owner authorized this member".
  */
 export function buildStubHubAuthPort(): HandoffHubAuthPort {
   return {
@@ -68,6 +52,56 @@ export function buildStubHubAuthPort(): HandoffHubAuthPort {
 }
 
 /**
+ * cortex#1498 (epic #1479 follow-up) — the LIVE hub-authorize leg adapter.
+ *
+ * Reads the member's own admission row via the SAME `/mine` PoP-read path the
+ * seal leg uses ({@link import("./network-adapters").buildAdmissionStatePort}
+ * — `OwnAdmissionState.hubAuthorizedAt`, populated from the registry's
+ * `hub_authorized_at` column). This makes the signal a REAL `boolean`:
+ *   - `confirmed: true`  — the row carries a `hub_authorized_at` stamp (the
+ *     hub owner ran `cortex network authorize`).
+ *   - `confirmed: false` — the row exists (or doesn't) but carries NO stamp —
+ *     a real "not yet authorized", per the module doc's hub-authorize
+ *     semantics (a real `false`, `--hub-authorized-confirmed` cannot override
+ *     it — see `network-handoff-lib.ts`'s `hubAuthorizeDone`).
+ *   - `confirmed: undefined` — ONLY when the admission read itself failed
+ *     (registry unreachable, no seed/registry-url configured) — the
+ *     documented fallback for "cannot auto-verify from here", same as the
+ *     pre-#1498 stub, so `--hub-authorized-confirmed` still has a real job in
+ *     a degraded-connectivity case.
+ *
+ * `member` is UNUSED here — same limitation `buildAdmissionStatePort`'s seal
+ * leg already has: the `/mine` PoP read can only prove possession of THIS
+ * host's own signing key, so it can only ever answer "is MY OWN row
+ * authorized", never a third party's. `handoff status <member>` is only
+ * authoritative when `member` is the principal running the command (mirrors
+ * the leaf-up leg's own local-only caveat in `gatherHandoffSignals`).
+ */
+export function buildLiveHubAuthPort(cfg: LivePortsConfig): HandoffHubAuthPort {
+  const admission = buildAdmissionStatePort(cfg);
+  return {
+    async resolveHubAuthorized(networkId: string, _member: string): Promise<HubAuthorizeResolution> {
+      const res = await admission.resolve(networkId);
+      if (!res.ok) {
+        return {
+          confirmed: undefined,
+          reason: `cannot read the hub-authorize marker from the registry — ${res.reason}`,
+        };
+      }
+      if (res.state.hubAuthorizedAt !== undefined) {
+        return { confirmed: true };
+      }
+      return {
+        confirmed: false,
+        reason:
+          "the registry admission row carries no hub_authorized_at marker yet — the hub owner has not " +
+          "run `cortex network authorize` for this member",
+      };
+    },
+  };
+}
+
+/**
  * Build the live handoff ports bundle from the resolved {@link LivePortsConfig}
  * + the composed `policy.federated.networks[]` (read off the already-loaded
  * config, NOT re-parsed — the config-split #814 concern). Read-only: every
@@ -79,7 +113,7 @@ export function buildLiveHandoffPorts(
 ): NetworkHandoffPorts {
   return {
     admission: buildAdmissionStatePort(cfg),
-    hubAuth: buildStubHubAuthPort(),
+    hubAuth: buildLiveHubAuthPort(cfg),
     config: buildDoctorConfigPort({
       networks,
       ...(cfg.natsConfigPath !== undefined && { natsConfigPath: cfg.natsConfigPath }),

--- a/src/cli/cortex/commands/network-handoff-lib.ts
+++ b/src/cli/cortex/commands/network-handoff-lib.ts
@@ -25,16 +25,17 @@
  *     read `cortex network status`'s C-1350 lookup uses.
  *   - **hub-authorize** (hub owner) — `boolean | undefined`:
  *       - `true`  — a real signal says the hub owner applied the authorization
- *                   (the #1498 registry `hub_authorized_at` marker, once wired).
+ *                   (cortex#1498 — the registry's `hub_authorized_at` marker,
+ *                   stamped by `cortex network authorize`).
  *       - `false` — a real signal says they have NOT (a HARD negative — a
  *                   member attestation can NEVER override it).
- *       - `undefined` — cannot be auto-verified from the member side today (the
- *                   documented-stub / remote case: no hub-side visibility per
- *                   cortex#1481, no registry marker until #1498). This is where
- *                   the member ATTESTATION (`attested`) applies: it upgrades an
- *                   `undefined` to treated-done, so `--guided` is a real
- *                   deliberate-confirmation gate TODAY, not an unconditional
- *                   off-switch. It NEVER upgrades a real `false`.
+ *       - `undefined` — the read itself failed (registry unreachable, no
+ *                   seed/registry-url configured) — cannot auto-verify from
+ *                   here at all. This is where the member ATTESTATION
+ *                   (`attested`) applies: it upgrades an `undefined` to
+ *                   treated-done, so `--guided` is a real deliberate-
+ *                   confirmation gate for a degraded-connectivity case, not an
+ *                   unconditional off-switch. It NEVER upgrades a real `false`.
  *   - **leaf-up** (member) — `boolean | undefined`. `true`/`false` from the
  *     LOCAL `/leafz` when the report is about the local stack; `undefined` when
  *     the report is about a REMOTE member (a member's leaf is observable only on
@@ -186,14 +187,14 @@ export function deriveHandoffState(
           ? leg(
               "hub-authorize",
               "done",
-              "attested by the member via `--hub-authorized-confirmed` (no registry marker yet — #1498)",
+              "attested by the member via `--hub-authorized-confirmed` (the registry read could not confirm it directly)",
             )
           : leg(
               "hub-authorize",
               "pending",
-              "cannot be auto-verified from the member side — documented stub (no hub-owner marker on the " +
-                "registry row until #1498); treated as NOT done, fail-closed. If the hub owner has confirmed " +
-                "they applied your authorization, re-run `join` with `--hub-authorized-confirmed`",
+              "cannot be auto-verified right now (the registry read failed — unreachable, or no seed/registry-url " +
+                "configured); treated as NOT done, fail-closed. If the hub owner has confirmed they applied your " +
+                "authorization, re-run `join` with `--hub-authorized-confirmed`",
             );
 
   const leafReady = signals.sealed && hubDone;
@@ -265,8 +266,9 @@ export function guardLeafUp(state: HandoffState, networkId: string): LeafUpGuard
         allowed: false,
         message:
           `cannot bring the leaf up for "${networkId}": hub authorization can't be auto-verified from here ` +
-          `yet (no registry marker until #1498). If the hub owner has confirmed they applied your ` +
-          `authorization on the hub, re-run with \`--hub-authorized-confirmed\`.`,
+          `right now (the registry read failed — unreachable, or no seed/registry-url configured). If the ` +
+          `hub owner has confirmed they applied your authorization on the hub, re-run with ` +
+          `\`--hub-authorized-confirmed\`.`,
       };
   }
 }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -188,6 +188,13 @@ import {
 } from "./network-handoff-lib";
 import type { NetworkHandoffPorts } from "./network-handoff-ports";
 import { buildLiveHandoffPorts } from "./network-handoff-adapters";
+import {
+  runNetworkAuthorize,
+  type AuthorizeInputs,
+  type AuthorizeReport,
+} from "./network-authorize-lib";
+import type { NetworkAuthorizePorts } from "./network-authorize-ports";
+import { buildLiveAuthorizePorts } from "./network-authorize-adapters";
 
 export { type ExitResult } from "./_shared/exit-result";
 
@@ -195,7 +202,7 @@ export { type ExitResult } from "./_shared/exit-result";
 // Grammar
 // =============================================================================
 
-type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "doctor" | "admit" | "reject" | "provision" | "make-live" | "secret" | "handoff";
+type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping" | "doctor" | "admit" | "reject" | "provision" | "make-live" | "secret" | "handoff" | "authorize";
 
 /**
  * Default registry URL when neither --registry-url nor config provides one.
@@ -290,11 +297,13 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         // leaf-up step is GATED on the 3-leg handoff state: it refuses (fails
         // closed) unless the seal leg is done AND the hub-authorize leg is
         // effectively done, instead of storming the hub with an unauthorized leaf.
-        // OPT-IN, never the default. Because the hub-authorize leg can't be
-        // auto-verified today (documented stub until the #1498 registry marker),
-        // --guided is a DELIBERATE-CONFIRMATION gate: it forces the member to
-        // acknowledge the un-auto-verifiable leg via --hub-authorized-confirmed
-        // rather than blocking unconditionally (Sage #1499).
+        // OPT-IN, never the default. The hub-authorize leg now reads a REAL
+        // registry signal (cortex#1498 — `cortex network authorize` stamps
+        // `hub_authorized_at`); when that read is unreachable/unconfigured it
+        // degrades to the documented undefined fallback, so --guided remains a
+        // DELIBERATE-CONFIRMATION gate: --hub-authorized-confirmed lets the
+        // member acknowledge an un-auto-verifiable leg — but NEVER overrides a
+        // real negative (Sage #1499).
         "--guided": "bool",
         // cortex#1485 (Sage #1499) — member ATTESTATION for the guided-join gate:
         // "the hub owner has confirmed to me they applied my authorization". Under
@@ -580,6 +589,23 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--monitor-url": "value",
         "--registry-url": "value",
         "--seed-path": "value",
+      },
+    },
+    // cortex#1498 (epic #1479 follow-up) — the HUB-OWNER's side of the guided-
+    // join handoff's hub-authorize leg. Run AFTER applying the member's leaf
+    // `authorization` entry on the hub's OWN nats-server config (the #1481
+    // hub-owner artifact) to stamp the registry's `hub_authorized_at`, the real
+    // signal `handoff status` / `join --guided` read. Hub-admin authority — the
+    // SAME allowlist `secret add-member`'s sealed delivery uses (ADR-0018 Q5).
+    // Mints nothing; no local fs/nats-config write. Dry-run by DEFAULT.
+    authorize: {
+      positionals: ["member"],
+      flags: {
+        "--network": "value",
+        "--admin-seed": "value",
+        "--registry-url": "value",
+        "--apply": "bool",
+        "--dry-run": "bool",
       },
     },
   },
@@ -1722,10 +1748,10 @@ function renderDoctorResult(
 
 /**
  * Factory for the handoff ports bundle. Production builds the live
- * admission-read + documented-stub hub-auth + config + monitor adapters from
- * the resolved {@link LivePortsConfig} + the composed networks; tests inject a
- * fake. Read-only — no `stop()` needed (unlike doctor, handoff opens no probe
- * bus).
+ * admission-read + live hub-auth (cortex#1498 — reads the registry's
+ * `hub_authorized_at` marker) + config + monitor adapters from the resolved
+ * {@link LivePortsConfig} + the composed networks; tests inject a fake.
+ * Read-only — no `stop()` needed (unlike doctor, handoff opens no probe bus).
  */
 export type HandoffPortsFactory = (
   cfg: LivePortsConfig,
@@ -1733,7 +1759,7 @@ export type HandoffPortsFactory = (
 ) => NetworkHandoffPorts;
 
 /** The production factory — reuses the live admission + doctor config/monitor
- *  adapters + the documented hub-authorize stub. */
+ *  adapters + the live hub-authorize read (cortex#1498). */
 const DEFAULT_HANDOFF_PORTS_FACTORY: HandoffPortsFactory = (cfg, networks) =>
   buildLiveHandoffPorts(cfg, networks);
 
@@ -1853,6 +1879,94 @@ function renderHandoffReport(report: HandoffReport, json: boolean): ExitResult {
     lines.push(`  note: ${note}`);
   }
   return ok(lines.join("\n") + "\n");
+}
+
+// =============================================================================
+// cortex#1498 (epic #1479 follow-up) — `cortex network authorize <member>`
+// =============================================================================
+
+/** Member pubkey grammar — the SAME acceptance `secret`/`admit` use (either encoding). */
+const AUTHORIZE_PUBKEY_LABEL = "32-byte Ed25519 pubkey — base64 (44 chars) or an NKey public key (A…/U… + 55 base32 chars)";
+
+/**
+ * Factory for the authorize port bundle. Production builds the live adapters
+ * (admin-signed admission lookup + hub-admin-signed authorize POST). Tests
+ * inject fakes that record calls without touching HTTP.
+ */
+export type AuthorizePortsFactory = (cfg: {
+  registryUrl: string;
+  material: StackIdentityMaterial;
+}) => NetworkAuthorizePorts;
+
+const DEFAULT_AUTHORIZE_PORTS_FACTORY: AuthorizePortsFactory = (cfg) => buildLiveAuthorizePorts(cfg);
+
+/**
+ * `cortex network authorize <member> --network <net> --admin-seed <path> [--apply]`.
+ * The hub owner runs this AFTER applying the member's leaf `authorization`
+ * entry on their OWN nats-server config (the #1481 hub-owner artifact), to
+ * stamp the registry's `hub_authorized_at` (cortex#1498) — the real signal
+ * `handoff status` / `join --guided` read in place of the honor-system
+ * `--hub-authorized-confirmed` attestation. Dry-run by DEFAULT; --apply POSTs.
+ */
+async function runAuthorize(
+  member: string,
+  flags: FlagMap,
+  json: boolean,
+  portsFactory: AuthorizePortsFactory,
+): Promise<ExitResult> {
+  const networkRes = requireValueFlag(flags, "--network");
+  if (!networkRes.ok) return usageError("authorize", networkRes.reason, json);
+  const networkId = networkRes.value;
+  if (!NETWORK_ID_RE.test(networkId)) {
+    return usageError("authorize", `--network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+  if (member === "") {
+    return usageError("authorize", `requires a member pubkey (usage: cortex network authorize <member-pubkey> --network <net>)`, json);
+  }
+  if (detectPubkey(member) === undefined) {
+    return usageError("authorize", `member "${member}" must be a ${AUTHORIZE_PUBKEY_LABEL}`, json);
+  }
+
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return usageError("authorize", applyRes.reason, json);
+
+  const seedRes = requireValueFlag(flags, "--admin-seed");
+  if (!seedRes.ok) return usageError("authorize", seedRes.reason, json);
+
+  const registryUrl = optionalValueFlag(flags, "--registry-url") ?? DEFAULT_REGISTRY_URL;
+
+  const matRes = await hubAdminMaterialFromSeedFile(seedRes.value);
+  if (!matRes.ok) return opError("authorize", matRes.reason, json);
+
+  const ports = portsFactory({ registryUrl, material: matRes.material });
+  const inputs: AuthorizeInputs = { networkId, memberPubkey: member, apply: applyRes.apply };
+
+  let report: AuthorizeReport;
+  try {
+    report = await runNetworkAuthorize(inputs, ports);
+  } catch (err) {
+    return opError("authorize", `authorize failed: ${err instanceof Error ? err.message : String(err)}`, json);
+  }
+
+  if (json) {
+    const data: Record<string, string> = {
+      subcommand: "authorize",
+      applied: report.applied ? "true" : "false",
+      ...report.data,
+      hub_admin_fingerprint: matRes.material.fingerprint,
+    };
+    const env = report.ok ? envelopeOk([], data) : envelopeError(report.reason ?? "authorize command failed", data);
+    return report.ok ? ok(renderJson(env)) : { exitCode: 1, stdout: "", stderr: renderJson(env) };
+  }
+
+  const header = report.applied
+    ? `cortex network authorize ${networkId}: ${report.ok ? "ok" : "FAILED"}`
+    : `cortex network authorize ${networkId}: dry-run (no mutation; pass --apply)`;
+  const lines = [header, ...report.steps.map((s) => `  ${s}`)];
+  if (!report.ok) lines.push(`  ✗ ${report.reason ?? "unknown failure"}`);
+  lines.push("");
+  const body = lines.join("\n");
+  return report.ok ? ok(body) : { exitCode: 1, stdout: "", stderr: body };
 }
 
 // =============================================================================
@@ -4150,6 +4264,9 @@ export async function dispatchNetwork(
   // cortex#1485 — injectable handoff-ports factory so `handoff` CLI tests drive
   // fake admission/hub-auth/config/monitor ports. Production omits → live.
   handoffPortsFactory: HandoffPortsFactory = DEFAULT_HANDOFF_PORTS_FACTORY,
+  // cortex#1498 — injectable authorize-ports factory so `authorize` CLI tests
+  // drive fake admission-lookup/delivery ports. Production omits → live.
+  authorizePortsFactory: AuthorizePortsFactory = DEFAULT_AUTHORIZE_PORTS_FACTORY,
 ): Promise<ExitResult> {
   let parsed;
   try {
@@ -4196,6 +4313,8 @@ export async function dispatchNetwork(
         load,
         handoffPortsFactory,
       );
+    case "authorize":
+      return runAuthorize(parsed.positionals.member ?? "", parsed.flags, json, authorizePortsFactory);
     case "admit":
       return runAdmit(parsed.positionals["request-id"] ?? "", parsed.flags, json, secretPortsFactory);
     case "reject":
@@ -4233,6 +4352,8 @@ Usage:
   cortex network ping   <peer> [--assistant <a>] [--network <id>] [--count N] [--timeout <ms>] [--json]
   cortex network doctor <network> [--principal <id>] [--stack <id>] [--config <p>] [--monitor-url <url>] [--json]
   cortex network handoff status <member> --network <net> [--principal <id>] [--stack <id>] [--config <p>] [--json]
+  cortex network authorize <member-pubkey> --network <net> --admin-seed <hub-admin-seed>
+                        [--registry-url <url>] [--apply] [--dry-run] [--json]
   cortex network admit  <request-id> --admin-seed <path> [--registry-url <url>] [--hub-config <p>]
                         [--roster-only] [--seal-only] [--hub-account <A…>] [--discord-member <id>]
                         [--discord-guild <id>] [--discord-server <profile>] [--discord-role <name>]
@@ -4299,13 +4420,23 @@ Subcommands:
           so nobody has to guess what's outstanding or whose turn it is. The seal
           leg reads the member's own ADMITTED admission row (sealed leaf secret
           present); the leaf-up leg reuses doctor's /leafz leaf-established
-          lookup. The hub-authorize leg is a DOCUMENTED STUB (always "pending —
-          cannot confirm from the member side"): the member has no hub-side
-          visibility and the registry row carries no hub-owner authorization
-          marker yet — confirming it needs a hub-owner-side \`hub_authorized_at\`
-          registry field (follow-up), so it is treated fail-closed (NOT done).
-          Read-only. The enforcement counterpart is \`join --guided\`, which
-          refuses to bring the leaf up until seal + hub-authorize are confirmed.
+          lookup. The hub-authorize leg (cortex#1498) reads the registry's
+          \`hub_authorized_at\` marker — a REAL true/false once the hub owner has
+          run \`cortex network authorize\`; a registry-unreachable read degrades to
+          the documented undefined fallback (fail-closed, NOT done). Read-only.
+          The enforcement counterpart is \`join --guided\`, which refuses to bring
+          the leaf up until seal + hub-authorize are confirmed (or, absent a
+          real signal, the \`--hub-authorized-confirmed\` attestation).
+  authorize (cortex#1498, epic #1479 follow-up) The HUB OWNER's side of the
+          hub-authorize leg. Run \`cortex network authorize <member-pubkey>
+          --network <net> --admin-seed <hub-admin-seed>\` AFTER applying the
+          member's leaf \`authorization\` entry on the hub's OWN nats-server
+          config (the #1481 hub-owner artifact printed by \`secret add-member
+          --seal-only\` / an EXTERNAL-hub add-member) to stamp the registry's
+          \`hub_authorized_at\`. Hub-admin authority — the SAME allowlist
+          \`secret add-member\`'s sealed delivery uses (ADR-0018 Q5). Mints
+          nothing; no local fs/nats-config write (registry-only). DRY-RUN by
+          default; --apply POSTs the signed claim.
   status  Show joined networks, peers, accept-subjects, leaf link state + counters.
   leave   Reverse a join cleanly: remove the network + leaf include, drop the
           plist -c arg if no networks remain, restart. Idempotent.

--- a/src/common/registry/admission-state.ts
+++ b/src/common/registry/admission-state.ts
@@ -56,6 +56,13 @@ export interface AdmissionMineRow {
    * best-effort hint, never a hard dependency.
    */
   updated_at?: string;
+  /**
+   * cortex#1498 (epic #1479 follow-up) — ISO-8601 UTC the hub owner stamped via
+   * `cortex network authorize`; `null`/absent until they do. OPTIONAL on the
+   * wire for the SAME reason as {@link updated_at}: a pre-#1498 registry
+   * doesn't carry the column at all.
+   */
+  hub_authorized_at?: string | null;
 }
 
 /** Injectable fetch (defaults to `globalThis.fetch`) so callers/tests stay hermetic. */
@@ -166,6 +173,15 @@ export interface OwnAdmissionState {
    * `no-row` and for an older registry that omits `updated_at`.
    */
   updatedAt?: string;
+  /**
+   * cortex#1498 (epic #1479 follow-up) — ISO-8601 UTC the hub owner stamped via
+   * `cortex network authorize`. Present iff the registry row carries a
+   * non-empty `hub_authorized_at`. This is the REAL signal
+   * `buildLiveHubAuthPort` (network-handoff-adapters.ts) reads to replace the
+   * `--hub-authorized-confirmed` honor-system attestation. Undefined for
+   * `no-row` and for a row the hub owner hasn't authorized yet.
+   */
+  hubAuthorizedAt?: string;
 }
 
 /** True when a row carries a non-empty sealed leaf-secret blob. */
@@ -197,6 +213,10 @@ export function classifyOwnAdmissionRows(
     // older registry omits it). On a REVOKED row this is the revoked-at date.
     ...(typeof row.updated_at === "string" && row.updated_at.length > 0
       ? { updatedAt: row.updated_at }
+      : {}),
+    // cortex#1498 — carry the hub-owner authorization stamp through, when present.
+    ...(typeof row.hub_authorized_at === "string" && row.hub_authorized_at.length > 0
+      ? { hubAuthorizedAt: row.hub_authorized_at }
       : {}),
   };
   switch (row.status) {

--- a/src/services/network-registry/__tests__/hub-authorize.test.ts
+++ b/src/services/network-registry/__tests__/hub-authorize.test.ts
@@ -1,0 +1,348 @@
+/**
+ * cortex#1498 (epic #1479 follow-up) — hub-owner authorization marker.
+ *
+ * Trust-path coverage (the hub-authorize registry write — same authority
+ * model as sealed-secret delivery, ADR-0018 Q5):
+ *   authorize write (hub-admin authority):
+ *     - allowlisted hub-admin stamps `hub_authorized_at` onto an ADMITTED row → 200
+ *     - write against a non-ADMITTED (PENDING) row → 409 not_admitted
+ *     - write against an unknown request → 404
+ *     - forged signature → 401 ; non-allowlisted key → 403 ; no allowlist → 503
+ *     - replayed nonce → 409
+ *     - request_id path/body mismatch → 400
+ *     - re-authorize (second write) is allowed (re-stamps the timestamp)
+ *   revoke / depart clear the stamp:
+ *     - revoke of an authorized ADMITTED row → REVOKED + hub_authorized_at cleared
+ *     - depart of an authorized ADMITTED row → DEPARTED + hub_authorized_at cleared
+ *   store-level (InMemoryIssuanceRequestStore.markHubAuthorized):
+ *     - sets hub_authorized_at on an ADMITTED row
+ *     - no-op (undefined) on a non-ADMITTED row
+ *     - no-op (undefined) on a missing row
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  randomNonce,
+  resetStores,
+  makeSignedAdminRead,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import type { AdmissionRequest } from "../src/types";
+import { InMemoryIssuanceRequestStore } from "../src/store";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+
+let env: Env;
+let admin: PrincipalKey;
+let hubAdmin: PrincipalKey;
+let principal: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, e: Env = env, headers: Record<string, string> = {}): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+async function registerPending(principalId: string): Promise<AdmissionRequest> {
+  const body = await makeSignedRegistration(principalId, principal, {
+    stacks: [{ stack_id: `${principalId}/main`, stack_pubkey: principal.publicKeyB64 }],
+    networkId: "metafactory",
+  });
+  const res = await post(`/principals/${principalId}/register`, body);
+  expect(res.status).toBe(201);
+  const signedRead = await makeSignedAdminRead(admin);
+  const listRes = await get(`/admission-requests?status=PENDING`, env, {
+    "x-admin-signed": JSON.stringify(signedRead),
+  });
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const found = list.find((r) => r.principal_id === principalId);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+async function makeAdmitDecision(requestId: string, adminKey: PrincipalKey) {
+  const claim = {
+    request_id: requestId,
+    decision: "admit" as const,
+    admin_pubkey: adminKey.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const signature = await signEd25519(adminKey.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+async function admit(requestId: string): Promise<void> {
+  const res = await post(`/admission-requests/${requestId}/admit`, await makeAdmitDecision(requestId, admin));
+  expect(res.status).toBe(200);
+}
+
+async function makeAuthorize(
+  requestId: string,
+  signer: PrincipalKey,
+  opts: { issuedAt?: string; nonce?: string; pubkeyOverride?: string } = {},
+) {
+  const claim = {
+    request_id: requestId,
+    hub_admin_pubkey: opts.pubkeyOverride ?? signer.publicKeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+  const signature = await signEd25519(signer.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+async function makeRevoke(requestId: string, signer: PrincipalKey) {
+  const claim = {
+    request_id: requestId,
+    hub_admin_pubkey: signer.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const signature = await signEd25519(signer.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+async function makeDepart(requestId: string, principalId: string, signer: PrincipalKey) {
+  const claim = {
+    request_id: requestId,
+    principal_id: principalId,
+    peer_pubkey: signer.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const signature = await signEd25519(signer.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+/** Member PoP-read of their own admission rows. Returns the row for the network. */
+async function readMine(networkId: string): Promise<AdmissionRequest | undefined> {
+  const claim = {
+    principal_id: "alice",
+    peer_pubkey: principal.publicKeyB64,
+    issued_at: new Date().toISOString(),
+  };
+  const signature = await signEd25519(principal.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  const res = await get(`/admission-requests/mine`, env, { "x-pop-signed": JSON.stringify({ claim, signature }) });
+  expect(res.status).toBe(200);
+  const rows = (await res.json()) as AdmissionRequest[];
+  return rows.find((r) => r.network_id === networkId);
+}
+
+beforeEach(async () => {
+  resetStores();
+  _resetRateLimitBucketsForTest();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  hubAdmin = await makePrincipalKey();
+  principal = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    REGISTRY_HUB_ADMIN_PUBKEYS: hubAdmin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+// =============================================================================
+// Authorize write — the hub-authorize registry marker (cortex#1498)
+// =============================================================================
+
+describe("POST /admission-requests/:id/authorize — happy path", () => {
+  test("admit stamps NOTHING: hub_authorized_at is null until the hub-admin authorizes", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const mine = await readMine("metafactory");
+    expect(mine?.status).toBe("ADMITTED");
+    expect(mine?.hub_authorized_at).toBeNull();
+  });
+
+  test("hub-admin authorizes an ADMITTED row; /mine then reports it", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+
+    // A real (within clock-skew) issued_at — the persisted hub_authorized_at
+    // is the CLAIM's issued_at, not the registry's receipt time, so a distinct
+    // value here still proves the row carries exactly what the hub-admin signed.
+    const issuedAt = new Date(Date.now() - 1000).toISOString();
+    const res = await post(
+      `/admission-requests/${req.request_id}/authorize`,
+      await makeAuthorize(req.request_id, hubAdmin, { issuedAt }),
+    );
+    expect(res.status).toBe(200);
+    const updated = (await res.json()) as AdmissionRequest;
+    expect(updated.hub_authorized_at).toBe(issuedAt);
+    expect(updated.status).toBe("ADMITTED");
+
+    const mine = await readMine("metafactory");
+    expect(mine?.hub_authorized_at).toBe(issuedAt);
+  });
+
+  test("a second authorize (re-run) re-stamps the timestamp", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const first = new Date(Date.now() - 2000).toISOString();
+    const second = new Date(Date.now() - 1000).toISOString();
+    await post(`/admission-requests/${req.request_id}/authorize`, await makeAuthorize(req.request_id, hubAdmin, { issuedAt: first }));
+    const res = await post(
+      `/admission-requests/${req.request_id}/authorize`,
+      await makeAuthorize(req.request_id, hubAdmin, { issuedAt: second }),
+    );
+    expect(res.status).toBe(200);
+    const mine = await readMine("metafactory");
+    expect(mine?.hub_authorized_at).toBe(second);
+  });
+});
+
+describe("POST /admission-requests/:id/authorize — guards", () => {
+  test("write against a PENDING (not-admitted) row → 409 not_admitted", async () => {
+    const req = await registerPending("alice");
+    const res = await post(`/admission-requests/${req.request_id}/authorize`, await makeAuthorize(req.request_id, hubAdmin));
+    expect(res.status).toBe(409);
+    expect((await res.json() as { error: string }).error).toBe("not_admitted");
+  });
+
+  test("write against an unknown request → 404", async () => {
+    const unknown = "deadbeef".repeat(4);
+    const res = await post(`/admission-requests/${unknown}/authorize`, await makeAuthorize(unknown, hubAdmin));
+    expect(res.status).toBe(404);
+  });
+
+  test("forged signature → 401", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const attacker = await makePrincipalKey();
+    const body = await makeAuthorize(req.request_id, attacker, { pubkeyOverride: hubAdmin.publicKeyB64 });
+    const res = await post(`/admission-requests/${req.request_id}/authorize`, body);
+    expect(res.status).toBe(401);
+  });
+
+  test("non-allowlisted hub-admin key → 403", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const stranger = await makePrincipalKey();
+    const res = await post(`/admission-requests/${req.request_id}/authorize`, await makeAuthorize(req.request_id, stranger));
+    expect(res.status).toBe(403);
+  });
+
+  test("no hub-admin (nor registry-admin) allowlist → 503 fail-closed", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const noAdminEnv: Env = { ...env, REGISTRY_ADMIN_PUBKEYS: "", REGISTRY_HUB_ADMIN_PUBKEYS: "" };
+    const res = await post(`/admission-requests/${req.request_id}/authorize`, await makeAuthorize(req.request_id, hubAdmin), noAdminEnv);
+    expect(res.status).toBe(503);
+  });
+
+  test("replayed nonce → 409", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const body = await makeAuthorize(req.request_id, hubAdmin);
+    const first = await post(`/admission-requests/${req.request_id}/authorize`, body);
+    expect(first.status).toBe(200);
+    const replay = await post(`/admission-requests/${req.request_id}/authorize`, body);
+    expect(replay.status).toBe(409);
+    expect((await replay.json() as { error: string }).error).toBe("nonce_replayed");
+  });
+
+  test("request_id body/path mismatch → 400", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const other = "abcd1234".repeat(4);
+    const body = await makeAuthorize(other, hubAdmin);
+    const res = await post(`/admission-requests/${req.request_id}/authorize`, body);
+    expect(res.status).toBe(400);
+  });
+
+  test("two separable authorities: a registry-admin-only key CANNOT authorize when a distinct hub allowlist is set", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    const res = await post(`/admission-requests/${req.request_id}/authorize`, await makeAuthorize(req.request_id, admin));
+    expect(res.status).toBe(403);
+  });
+});
+
+// =============================================================================
+// Revoke / depart clear the hub-authorize stamp (cortex#1498)
+// =============================================================================
+
+describe("revoke / depart clear hub_authorized_at", () => {
+  test("hub-admin revoke of an authorized ADMITTED row clears hub_authorized_at", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    await post(`/admission-requests/${req.request_id}/authorize`, await makeAuthorize(req.request_id, hubAdmin));
+    expect((await readMine("metafactory"))?.hub_authorized_at).not.toBeNull();
+
+    const res = await post(`/admission-requests/${req.request_id}/revoke`, await makeRevoke(req.request_id, hubAdmin));
+    expect(res.status).toBe(200);
+    const revoked = (await res.json()) as AdmissionRequest;
+    expect(revoked.status).toBe("REVOKED");
+    expect(revoked.hub_authorized_at).toBeNull();
+  });
+
+  test("member depart of an authorized ADMITTED row clears hub_authorized_at", async () => {
+    const req = await registerPending("alice");
+    await admit(req.request_id);
+    await post(`/admission-requests/${req.request_id}/authorize`, await makeAuthorize(req.request_id, hubAdmin));
+
+    const res = await post(`/admission-requests/${req.request_id}/depart`, await makeDepart(req.request_id, "alice", principal));
+    expect(res.status).toBe(200);
+    const departed = (await res.json()) as AdmissionRequest;
+    expect(departed.status).toBe("DEPARTED");
+    expect(departed.hub_authorized_at).toBeNull();
+  });
+});
+
+// =============================================================================
+// Store-level — InMemoryIssuanceRequestStore.markHubAuthorized
+// =============================================================================
+
+describe("InMemoryIssuanceRequestStore.markHubAuthorized", () => {
+  test("sets hub_authorized_at on an ADMITTED row", async () => {
+    const store = new InMemoryIssuanceRequestStore();
+    const pending = await store.upsertPending("alice", "pk-alice", "federated.alice.>", "metafactory");
+    await store.transitionIssuanceRequest(pending.request_id, "ADMITTED", "admin-pubkey");
+
+    const updated = await store.markHubAuthorized(pending.request_id, "2026-04-01T00:00:00.000Z");
+    expect(updated?.hub_authorized_at).toBe("2026-04-01T00:00:00.000Z");
+    expect(updated?.status).toBe("ADMITTED");
+  });
+
+  test("no-op (undefined) on a non-ADMITTED (PENDING) row", async () => {
+    const store = new InMemoryIssuanceRequestStore();
+    const pending = await store.upsertPending("alice", "pk-alice", "federated.alice.>", "metafactory");
+
+    const result = await store.markHubAuthorized(pending.request_id, "2026-04-01T00:00:00.000Z");
+    expect(result).toBeUndefined();
+  });
+
+  test("no-op (undefined) on a missing row", async () => {
+    const store = new InMemoryIssuanceRequestStore();
+    const result = await store.markHubAuthorized("no-such-request-id", "2026-04-01T00:00:00.000Z");
+    expect(result).toBeUndefined();
+  });
+
+  test("no-op (undefined) on a REVOKED row (cannot re-authorize a revoked member)", async () => {
+    const store = new InMemoryIssuanceRequestStore();
+    const pending = await store.upsertPending("alice", "pk-alice", "federated.alice.>", "metafactory");
+    await store.transitionIssuanceRequest(pending.request_id, "ADMITTED", "admin-pubkey");
+    await store.revokeAdmission(pending.request_id);
+
+    const result = await store.markHubAuthorized(pending.request_id, "2026-04-01T00:00:00.000Z");
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/services/network-registry/__tests__/migration-0013.test.ts
+++ b/src/services/network-registry/__tests__/migration-0013.test.ts
@@ -1,0 +1,126 @@
+/**
+ * cortex#1498 (epic #1479 follow-up) — migration 0013 (`hub_authorized_at`).
+ *
+ * Runs the real SQL chain (0001 → 0004 → 0007 → 0008 → 0010 → 0012 → 0013)
+ * against `bun:sqlite` (D1 is SQLite under the hood) and proves the ADD COLUMN
+ * is additive + nullable + backward-compatible:
+ *   - applies cleanly on top of the full admission_requests chain (0007's
+ *     recreate, 0008's unique index, 0010's sealed_secret + REVOKED,
+ *     0012's DEPARTED);
+ *   - a PRE-EXISTING row (inserted before 0013 runs) reads back with
+ *     `hub_authorized_at = NULL` — no data loss, no default value;
+ *   - a fresh row after 0013 defaults to NULL too;
+ *   - the column can be set + cleared like any other nullable TEXT column
+ *     (proving the ALTER produced a real, writable column, not just a
+ *     read-only view).
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(here, "..", "migrations");
+
+let db: Database;
+
+function applyThrough0012(): void {
+  for (const f of [
+    "0001_init.sql",
+    "0004_issuance_requests.sql",
+    "0007_admission_requests.sql",
+    "0008_admission_network_idempotency.sql",
+    "0010_admission_sealed_secret.sql",
+    "0012_admission_departed.sql",
+  ]) {
+    db.run(readFileSync(join(migrationsDir, f), "utf8"));
+  }
+}
+
+function apply0013(): void {
+  db.run(readFileSync(join(migrationsDir, "0013_admission_hub_authorized.sql"), "utf8"));
+}
+
+interface Row {
+  request_id: string;
+  status: string;
+  hub_authorized_at: string | null;
+}
+
+function insertPending(requestId: string): void {
+  db.run(
+    `INSERT INTO admission_requests
+       (request_id, principal_id, peer_pubkey, requested_scope, network_id, status, created_at, updated_at, granted_by)
+     VALUES (?, ?, ?, ?, ?, 'PENDING', ?, ?, NULL)`,
+    [requestId, "alice", "pk-alice", "federated.alice.>", "metafactory", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"],
+  );
+}
+
+function readRow(requestId: string): Row {
+  return db
+    .query(`SELECT request_id, status, hub_authorized_at FROM admission_requests WHERE request_id = ?`)
+    .get(requestId) as Row;
+}
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  applyThrough0012();
+});
+
+describe("migration 0013 — hub_authorized_at ADD COLUMN", () => {
+  test("applies cleanly on top of the 0001..0012 chain", () => {
+    expect(() => apply0013()).not.toThrow();
+  });
+
+  test("a PRE-EXISTING row (inserted before 0013) reads back hub_authorized_at = NULL — no data loss", () => {
+    insertPending("req-pre-existing");
+    apply0013();
+    const row = readRow("req-pre-existing");
+    expect(row.hub_authorized_at).toBeNull();
+    expect(row.status).toBe("PENDING"); // untouched by the ALTER
+  });
+
+  test("a row inserted AFTER 0013 defaults hub_authorized_at to NULL too", () => {
+    apply0013();
+    insertPending("req-post-migration");
+    const row = readRow("req-post-migration");
+    expect(row.hub_authorized_at).toBeNull();
+  });
+
+  test("the column is writable — UPDATE sets it, and it can be cleared back to NULL", () => {
+    apply0013();
+    insertPending("req-writable");
+    db.run(`UPDATE admission_requests SET status = 'ADMITTED' WHERE request_id = ?`, ["req-writable"]);
+
+    db.run(`UPDATE admission_requests SET hub_authorized_at = ? WHERE request_id = ?`, [
+      "2026-02-01T00:00:00Z",
+      "req-writable",
+    ]);
+    expect(readRow("req-writable").hub_authorized_at).toBe("2026-02-01T00:00:00Z");
+
+    db.run(`UPDATE admission_requests SET hub_authorized_at = NULL WHERE request_id = ?`, ["req-writable"]);
+    expect(readRow("req-writable").hub_authorized_at).toBeNull();
+  });
+
+  test("re-applying 0013 is idempotent (IF NOT EXISTS-equivalent for D1's ADD COLUMN semantics is out of scope — this asserts the migration itself only runs once in the real runner); running it a second time on a FRESH db still just adds the column", () => {
+    // Sanity: applying to a second fresh chain (not re-applying to the SAME db,
+    // which SQLite would reject with a duplicate-column error — the real
+    // migration runner never re-applies a migration to the same database).
+    const db2 = new Database(":memory:");
+    for (const f of [
+      "0001_init.sql",
+      "0004_issuance_requests.sql",
+      "0007_admission_requests.sql",
+      "0008_admission_network_idempotency.sql",
+      "0010_admission_sealed_secret.sql",
+      "0012_admission_departed.sql",
+      "0013_admission_hub_authorized.sql",
+    ]) {
+      db2.run(readFileSync(join(migrationsDir, f), "utf8"));
+    }
+    const cols = db2.query(`PRAGMA table_info(admission_requests)`).all() as { name: string }[];
+    expect(cols.map((c) => c.name)).toContain("hub_authorized_at");
+  });
+});

--- a/src/services/network-registry/migrations/0013_admission_hub_authorized.sql
+++ b/src/services/network-registry/migrations/0013_admission_hub_authorized.sql
@@ -1,0 +1,31 @@
+-- cortex#1498 (epic #1479 follow-up) — HUB-OWNER authorization marker.
+--
+-- Background
+-- ──────────
+-- #1485 (guided-join) modeled a network join as a 3-leg handoff: seal (admin)
+-- → hub-authorize (hub owner) → leaf-up (member). The hub-authorize leg had NO
+-- registry-side signal — the cortex CLI's `buildStubHubAuthPort` always
+-- returned `confirmed: undefined` (a documented stub), so a member could only
+-- get past that leg via the honor-system `--hub-authorized-confirmed`
+-- attestation (`join --guided`).
+--
+-- This migration adds the real signal: `hub_authorized_at`, a nullable
+-- ISO-8601 UTC timestamp the HUB OWNER stamps (via the new `cortex network
+-- authorize` command, hub-admin authority — the SAME authority that attaches
+-- the sealed leaf secret, ADR-0018 Q5) once they have applied the member's
+-- leaf `authorization` entry on their OWN hub nats-server config (the #1481
+-- hub-owner artifact). NULL = not yet authorized — the default for every row,
+-- including every row that existed before this migration.
+--
+-- Strictly additive: nullable, no CHECK constraint touched (unlike the
+-- REVOKED/DEPARTED status widenings in migrations 0010/0012, this doesn't
+-- extend an enum) — a plain `ALTER TABLE ... ADD COLUMN`, the SAME shape as
+-- migration 0011's `admin_pubkeys`. Existing rows/deploys are unaffected: a
+-- pre-0013 isolate reading a row simply never sees the column, and the store
+-- layer (`rowToAdmissionRequest`) coalesces a missing value to `null`.
+--
+-- Apply:
+--   bunx wrangler d1 migrations apply cortex-network-registry-dev --env dev --remote
+--   bunx wrangler d1 migrations apply cortex-network-registry      --env production --remote
+
+ALTER TABLE admission_requests ADD COLUMN hub_authorized_at TEXT;

--- a/src/services/network-registry/migrations/0013_admission_hub_authorized.sql
+++ b/src/services/network-registry/migrations/0013_admission_hub_authorized.sql
@@ -17,14 +17,30 @@
 -- hub-owner artifact). NULL = not yet authorized — the default for every row,
 -- including every row that existed before this migration.
 --
--- Strictly additive: nullable, no CHECK constraint touched (unlike the
--- REVOKED/DEPARTED status widenings in migrations 0010/0012, this doesn't
--- extend an enum) — a plain `ALTER TABLE ... ADD COLUMN`, the SAME shape as
--- migration 0011's `admin_pubkeys`. Existing rows/deploys are unaffected: a
--- pre-0013 isolate reading a row simply never sees the column, and the store
--- layer (`rowToAdmissionRequest`) coalesces a missing value to `null`.
+-- Shape: nullable, no CHECK constraint touched (unlike the REVOKED/DEPARTED
+-- status widenings in migrations 0010/0012, this doesn't extend an enum) — a
+-- plain `ALTER TABLE ... ADD COLUMN`, the SAME shape as migration 0011's
+-- `admin_pubkeys`.
 --
--- Apply:
+-- DEPLOY ORDERING — MIGRATION-BEFORE-CODE IS MANDATORY (NOT optional):
+-- ────────────────────────────────────────────────────────────────────
+-- This ADD COLUMN is backward-compatible for READS only: a pre-0013 isolate
+-- reading a row never sees the column, and the store layer
+-- (`rowToAdmissionRequest`) coalesces a missing value to `null`. But the
+-- cortex#1498 code has a HARD dependency on this column at the WRITE path:
+-- `revokeAdmission` / `departAdmission` now emit
+-- `SET ... hub_authorized_at = NULL`, and `markHubAuthorized` emits
+-- `SET hub_authorized_at = ?`. If the NEW code is deployed BEFORE this
+-- migration runs, those existing revoke/depart endpoints (and the new
+-- authorize endpoint) throw "no such column: hub_authorized_at" → 500.
+--
+-- Therefore: APPLY THIS MIGRATION TO THE REGISTRY DB *BEFORE* DEPLOYING THE
+-- cortex#1498 WORKER. It is NOT safe to ship the code first. (This is the
+-- opposite constraint from migrations 0007/0010/0012, which recreated the
+-- table and were framed "not yet deployed at this schema version" — 0013 is
+-- an incremental ADD against a live schema, so the ordering is load-bearing.)
+--
+-- Apply (migration FIRST, then deploy the code):
 --   bunx wrangler d1 migrations apply cortex-network-registry-dev --env dev --remote
 --   bunx wrangler d1 migrations apply cortex-network-registry      --env production --remote
 

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -26,6 +26,12 @@
  *     Admin-gated single-request fetch. Same auth as the list surface.
  *     404 when the request_id is not found.
  *
+ *   POST /admission-requests/{request_id}/authorize (cortex#1498)
+ *     HUB-ADMIN-signed: stamps `hub_authorized_at` onto an ADMITTED row.
+ *     Same authority + gate order as sealed-secret (below). 409 not_admitted
+ *     if the row is not ADMITTED. This is the real signal the guided-join
+ *     handoff's hub-authorize leg reads.
+ *
  * Trust model
  * ───────────
  * All write operations reuse the network-create admin gate EXACTLY:
@@ -55,6 +61,8 @@ import {
   validateSealedSecretClaim,
   validateSignedAdmissionRevoke,
   validateAdmissionRevokeClaim,
+  validateSignedHubAuthorize,
+  validateHubAuthorizeClaim,
   validateSignedAdmissionDepart,
   validateAdmissionDepartClaim,
   isValidRequestId,
@@ -456,6 +464,45 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
       if (!existing) return c.json({ error: "not_found" }, 404);
       return c.json(
         { error: "not_admitted", details: `request ${requestId} is ${existing.status}, not ADMITTED — cannot deliver a sealed secret` },
+        409,
+      );
+    }
+    return c.json(updated, 200);
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /admission-requests/:request_id/authorize — cortex#1498
+  //
+  // The HUB-ADMIN stamps `hub_authorized_at` onto the ADMITTED row once they
+  // have applied the member's leaf `authorization` entry on their OWN hub
+  // nats-server config (the #1481 hub-owner artifact). SAME authority as the
+  // sealed-secret write (hub-admin, ADR-0018 Q5) — mints nothing, just records
+  // that the hub owner did their part of the 3-leg guided-join handoff (seal →
+  // hub-authorize → leaf-up). This is the real signal `cortex network handoff
+  // status` / `join --guided` read in place of the honor-system
+  // `--hub-authorized-confirmed` attestation. 409 not_admitted if the row is
+  // not ADMITTED (mirrors sealed-secret's guard — nothing to authorize until
+  // the roster admission has landed).
+  // ---------------------------------------------------------------------------
+
+  app.post("/admission-requests/:request_id/authorize", async (c) => {
+    const requestId = c.req.param("request_id") ?? "";
+    const gate = await verifyHubAdminWrite(
+      c,
+      requestId,
+      validateSignedHubAuthorize,
+      validateHubAuthorizeClaim,
+    );
+    if (!gate.ok) return gate.response;
+
+    const store = getIssuanceStore(c.env);
+    const updated = await store.markHubAuthorized(requestId, gate.claim.issued_at);
+    if (!updated) {
+      // Row missing OR not ADMITTED — distinguish for the caller.
+      const existing = await store.getIssuanceRequest(requestId);
+      if (!existing) return c.json({ error: "not_found" }, 404);
+      return c.json(
+        { error: "not_admitted", details: `request ${requestId} is ${existing.status}, not ADMITTED — cannot authorize` },
         409,
       );
     }

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -498,7 +498,10 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     const store = getIssuanceStore(c.env);
     const updated = await store.markHubAuthorized(requestId, gate.claim.issued_at);
     if (!updated) {
-      // Row missing OR not ADMITTED — distinguish for the caller.
+      // Row missing OR not ADMITTED — distinguish for the caller. This is the
+      // SAME re-read the sealed-secret route uses (Sage #1501 nit: an extra
+      // SELECT on the cold error path only, to map 404 vs 409 — kept verbatim
+      // for parity with sealed-secret rather than optimised away).
       const existing = await store.getIssuanceRequest(requestId);
       if (!existing) return c.json({ error: "not_found" }, 404);
       return c.json(

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -245,19 +245,40 @@ export interface IssuanceRequestStore {
   ): Promise<AdmissionRequest | undefined>;
 
   /**
+   * cortex#1498 (epic #1479 follow-up) — persist the hub-owner's authorization
+   * stamp onto an ADMITTED admission row (the `cortex network authorize`
+   * write). Mirrors {@link setSealedSecret}'s CAS shape exactly: guarded on
+   * `status = 'ADMITTED'` — a not-yet-admitted (or revoked/departed) row cannot
+   * carry a hub-authorize stamp, so a write against a non-ADMITTED row is a
+   * no-op and returns `undefined` (the route maps that to 409). Returns the
+   * updated row on success, `undefined` when the row is missing or not
+   * ADMITTED. `timestampIso` is the value to persist (the hub-admin's signed
+   * claim `issued_at` — the moment THEY authorized, not the registry's receipt
+   * time); `updated_at` is independently stamped `now` by the store, same as
+   * every other transition.
+   */
+  markHubAuthorized(
+    requestId: string,
+    timestampIso: string,
+  ): Promise<AdmissionRequest | undefined>;
+
+  /**
    * ADR-0018 Q6 / PR5b — transition an ADMITTED row to REVOKED and CLEAR its
    * sealed blob (the bearer copy is dead once the hub `authorization` user is
-   * dropped). Guarded on `status = 'ADMITTED'`. Returns the updated row;
-   * `undefined` when the row is missing. Already-REVOKED is idempotent (returns
-   * the REVOKED row); a PENDING/REJECTED row throws {@link AlreadyDecidedError}
-   * (you cannot revoke a member that was never admitted).
+   * dropped) AND its hub-authorize stamp (cortex#1498 — a revoked member is no
+   * longer authorized). Guarded on `status = 'ADMITTED'`. Returns the updated
+   * row; `undefined` when the row is missing. Already-REVOKED is idempotent
+   * (returns the REVOKED row); a PENDING/REJECTED row throws
+   * {@link AlreadyDecidedError} (you cannot revoke a member that was never
+   * admitted).
    */
   revokeAdmission(requestId: string): Promise<AdmissionRequest | undefined>;
 
   /**
    * C-1350 Slice 1 (#1350) — transition an ADMITTED row to DEPARTED (the member
    * left voluntarily) and CLEAR its sealed blob (a departed member must not
-   * retain a fetchable copy — same hygiene as revoke). Guarded on
+   * retain a fetchable copy — same hygiene as revoke) AND its hub-authorize
+   * stamp (cortex#1498 — a departed member is no longer authorized). Guarded on
    * `status = 'ADMITTED'`. Returns the updated row; `undefined` when the row is
    * missing. Already-DEPARTED is idempotent (returns the DEPARTED row); a
    * PENDING/REJECTED/REVOKED row throws {@link AlreadyDecidedError} (you cannot
@@ -323,6 +344,7 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
       updated_at: now,
       granted_by: null,
       sealed_secret: null,
+      hub_authorized_at: null,
     };
     this.requests.set(request.request_id, request);
     this.byPeer.set(peerKey, request.request_id);
@@ -381,6 +403,22 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
     return updated;
   }
 
+  async markHubAuthorized(
+    requestId: string,
+    timestampIso: string,
+  ): Promise<AdmissionRequest | undefined> {
+    const existing = this.requests.get(requestId);
+    if (!existing) return undefined;
+    if (existing.status !== "ADMITTED") return undefined; // route → 409 not_admitted
+    const updated: AdmissionRequest = {
+      ...existing,
+      hub_authorized_at: timestampIso,
+      updated_at: new Date().toISOString(),
+    };
+    this.requests.set(requestId, updated);
+    return updated;
+  }
+
   async revokeAdmission(requestId: string): Promise<AdmissionRequest | undefined> {
     const existing = this.requests.get(requestId);
     if (!existing) return undefined;
@@ -392,6 +430,7 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
       ...existing,
       status: "REVOKED",
       sealed_secret: null,
+      hub_authorized_at: null,
       updated_at: new Date().toISOString(),
     };
     this.requests.set(requestId, updated);
@@ -409,6 +448,7 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
       ...existing,
       status: "DEPARTED",
       sealed_secret: null,
+      hub_authorized_at: null,
       updated_at: new Date().toISOString(),
     };
     this.requests.set(requestId, updated);
@@ -572,6 +612,29 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     return { ...existing, sealed_secret: sealedSecret, updated_at: now };
   }
 
+  async markHubAuthorized(
+    requestId: string,
+    timestampIso: string,
+  ): Promise<AdmissionRequest | undefined> {
+    const existing = await this.getIssuanceRequest(requestId);
+    if (!existing) return undefined;
+    if (existing.status !== "ADMITTED") return undefined; // route → 409 not_admitted
+    const now = new Date().toISOString();
+    // CAS-ish guard: only an ADMITTED row can carry a hub-authorize stamp. A
+    // concurrent revoke/depart between our read and this UPDATE flips the guard
+    // false → changes 0 → undefined (the route maps it to 409).
+    const res = await this.db
+      .prepare(
+        `UPDATE admission_requests
+         SET hub_authorized_at = ?, updated_at = ?
+         WHERE request_id = ? AND status = 'ADMITTED'`,
+      )
+      .bind(timestampIso, now, requestId)
+      .run();
+    if ((res.meta?.changes ?? 0) === 0) return undefined;
+    return { ...existing, hub_authorized_at: timestampIso, updated_at: now };
+  }
+
   async revokeAdmission(requestId: string): Promise<AdmissionRequest | undefined> {
     const existing = await this.getIssuanceRequest(requestId);
     if (!existing) return undefined;
@@ -583,7 +646,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     const res = await this.db
       .prepare(
         `UPDATE admission_requests
-         SET status = 'REVOKED', sealed_secret = NULL, updated_at = ?
+         SET status = 'REVOKED', sealed_secret = NULL, hub_authorized_at = NULL, updated_at = ?
          WHERE request_id = ? AND status = 'ADMITTED'`,
       )
       .bind(now, requestId)
@@ -593,7 +656,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
       const current = await this.getIssuanceRequest(requestId);
       return current;
     }
-    return { ...existing, status: "REVOKED", sealed_secret: null, updated_at: now };
+    return { ...existing, status: "REVOKED", sealed_secret: null, hub_authorized_at: null, updated_at: now };
   }
 
   async departAdmission(requestId: string): Promise<AdmissionRequest | undefined> {
@@ -607,7 +670,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     const res = await this.db
       .prepare(
         `UPDATE admission_requests
-         SET status = 'DEPARTED', sealed_secret = NULL, updated_at = ?
+         SET status = 'DEPARTED', sealed_secret = NULL, hub_authorized_at = NULL, updated_at = ?
          WHERE request_id = ? AND status = 'ADMITTED'`,
       )
       .bind(now, requestId)
@@ -623,7 +686,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
       if (current.status === "DEPARTED") return current;
       throw new AlreadyDecidedError(current);
     }
-    return { ...existing, status: "DEPARTED", sealed_secret: null, updated_at: now };
+    return { ...existing, status: "DEPARTED", sealed_secret: null, hub_authorized_at: null, updated_at: now };
   }
 }
 
@@ -640,6 +703,8 @@ interface AdmissionRequestRow {
   granted_by: string | null;
   /** ADR-0018 b′ — opaque sealed ciphertext; NULL until add-member delivers it. */
   sealed_secret: string | null;
+  /** cortex#1498 — ISO-8601 UTC hub-owner authorization stamp; NULL until `authorize`. */
+  hub_authorized_at: string | null;
 }
 
 function rowToAdmissionRequest(row: AdmissionRequestRow): AdmissionRequest {
@@ -655,6 +720,8 @@ function rowToAdmissionRequest(row: AdmissionRequestRow): AdmissionRequest {
     granted_by: row.granted_by,
     // A row read from a pre-0010 isolate (column absent) coalesces to null.
     sealed_secret: row.sealed_secret ?? null,
+    // A row read from a pre-0013 isolate (column absent) coalesces to null.
+    hub_authorized_at: row.hub_authorized_at ?? null,
   };
 }
 

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -369,6 +369,19 @@ export interface AdmissionRequest {
    * schema change. The registry never interprets the bytes either way.
    */
   sealed_secret: string | null;
+  /**
+   * cortex#1498 (epic #1479 follow-up) — ISO-8601 UTC timestamp the HUB OWNER
+   * stamps (via `cortex network authorize`, hub-admin authority — the SAME
+   * authority as {@link sealed_secret}'s delivery, ADR-0018 Q5) once they have
+   * applied this member's leaf `authorization` entry on their OWN hub
+   * nats-server config (the #1481 hub-owner artifact). This is the real signal
+   * the guided-join handoff's hub-authorize leg reads (`cortex network handoff
+   * status` / `join --guided`) — replacing the honor-system
+   * `--hub-authorized-confirmed` attestation with a registry-backed fact. NULL
+   * until authorized; cleared back to NULL on `revoke`/`depart` (a revoked or
+   * departed member is no longer authorized).
+   */
+  hub_authorized_at: string | null;
 }
 
 /**
@@ -567,6 +580,37 @@ export interface AdmissionRevokeClaim {
 /** On-wire envelope for a hub-admin revoke. */
 export interface SignedAdmissionRevoke {
   claim: AdmissionRevokeClaim;
+  /** Base64 Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}
+
+/**
+ * cortex#1498 (epic #1479 follow-up) — the HUB-ADMIN-signed claim carried by
+ * `POST /admission-requests/{request_id}/authorize`.
+ *
+ * The counterpart to {@link AdmissionRevokeClaim}: instead of cutting
+ * transport, this STAMPS `hub_authorized_at` onto an ADMITTED row once the hub
+ * owner has applied the member's leaf `authorization` entry on their OWN hub
+ * nats-server config (the #1481 hub-owner artifact). Same authority as
+ * {@link SealedSecretWriteClaim} (hub-admin, ADR-0018 Q5) — the registry
+ * mints nothing here either; it only records that the hub owner did their
+ * part of the 3-leg guided-join handoff (seal → hub-authorize → leaf-up).
+ */
+export interface HubAuthorizeClaim {
+  /** Must equal the URL path parameter. */
+  request_id: string;
+  /** Base64 Ed25519 pubkey of the hub-admin signing this claim. */
+  hub_admin_pubkey: string;
+  /** ISO-8601 UTC timestamp at which the hub-admin signed this claim — the
+   *  value persisted as {@link AdmissionRequest.hub_authorized_at}. */
+  issued_at: string;
+  /** Random nonce to prevent replay. */
+  nonce: string;
+}
+
+/** On-wire envelope for a hub-admin authorize. */
+export interface SignedHubAuthorize {
+  claim: HubAuthorizeClaim;
   /** Base64 Ed25519 signature over canonical-JSON(claim). */
   signature: string;
 }

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -1031,6 +1031,14 @@ export function validateSignedHubAuthorize(
 /**
  * Validate the `HubAuthorizeClaim` payload before crypto verification.
  * Cross-field rule: claim.request_id MUST match the URL path parameter.
+ *
+ * Freshness/replay (Sage #1501): this validator only checks `issued_at` is a
+ * well-formed ISO-8601 timestamp — the actual freshness WINDOW is enforced at
+ * the ROUTE by `verifyHubAdminWrite` (the shared hub-admin write gate), which
+ * rejects `Math.abs(now - issued) > CLOCK_SKEW_MS` (400) and burns the `nonce`
+ * against the replay cache (409), exactly as the sealed-secret/revoke claims
+ * do. So a signed authorize claim is NOT replayable indefinitely — the bound
+ * lives one layer up, deliberately, not here.
  */
 export function validateHubAuthorizeClaim(
   claim: unknown,

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -22,6 +22,7 @@ import type {
   AdmissionReadClaim,
   AdmissionRevokeClaim,
   Capability,
+  HubAuthorizeClaim,
   RegistrationClaim,
   SealedSecretWriteClaim,
   SignedAdmissionDecision,
@@ -29,6 +30,7 @@ import type {
   SignedAdmissionDepart,
   SignedAdmissionRead,
   SignedAdmissionRevoke,
+  SignedHubAuthorize,
   SignedNetworkRosterMemberRead,
   SignedRegistration,
   SignedSealedSecretWrite,
@@ -951,6 +953,89 @@ export function validateAdmissionRevokeClaim(
   claim: unknown,
   expectedRequestId: string,
 ): { ok: true; claim: AdmissionRevokeClaim } | { ok: false; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+
+  if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be an object" }] };
+  }
+  const c = claim as Record<string, unknown>;
+
+  if (typeof c.request_id !== "string" || c.request_id.length === 0) {
+    errors.push({ field: "request_id", message: "must be a non-empty string" });
+  } else if (c.request_id !== expectedRequestId) {
+    errors.push({
+      field: "request_id",
+      message: `body request_id "${c.request_id}" does not match path "${expectedRequestId}"`,
+    });
+  }
+
+  if (typeof c.hub_admin_pubkey !== "string" || !isValidPubkey(c.hub_admin_pubkey)) {
+    errors.push({ field: "hub_admin_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
+  }
+
+  if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
+    errors.push({ field: "issued_at", message: "must be an ISO-8601 timestamp" });
+  }
+
+  if (typeof c.nonce !== "string" || c.nonce.length < 8 || c.nonce.length > 128) {
+    errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    claim: {
+      request_id: c.request_id as string,
+      hub_admin_pubkey: c.hub_admin_pubkey as string,
+      issued_at: c.issued_at as string,
+      nonce: c.nonce as string,
+    },
+  };
+}
+
+// =============================================================================
+// cortex#1498 — hub-admin authorize claim validators
+// =============================================================================
+
+/**
+ * Validate the `POST /admission-requests/{id}/authorize` envelope
+ * ({ claim: HubAuthorizeClaim, signature }). Structurally identical to
+ * {@link validateSignedAdmissionRevoke} (same hub-admin authority, same
+ * fields) — kept as its own function so the two write verbs stay
+ * independently evolvable (e.g. `authorize` growing a field revoke never
+ * needs, or vice versa).
+ */
+export function validateSignedHubAuthorize(
+  body: unknown,
+): { ok: true; signed: SignedHubAuthorize } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null || Array.isArray(b.claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be a non-array object" }] };
+  }
+  return {
+    ok: true,
+    signed: { claim: b.claim as HubAuthorizeClaim, signature: b.signature },
+  };
+}
+
+/**
+ * Validate the `HubAuthorizeClaim` payload before crypto verification.
+ * Cross-field rule: claim.request_id MUST match the URL path parameter.
+ */
+export function validateHubAuthorizeClaim(
+  claim: unknown,
+  expectedRequestId: string,
+): { ok: true; claim: HubAuthorizeClaim } | { ok: false; errors: ValidationError[] } {
   const errors: ValidationError[] = [];
 
   if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {


### PR DESCRIPTION
feat(network): C-1498 — real hub_authorized_at signal for the guided-join hub-authorize leg

Follow-up to #1485 (guided-join). The hub-authorize leg had no registry-side
signal — buildStubHubAuthPort always returned confirmed:undefined, so a member
could only pass that leg via the honor-system --hub-authorized-confirmed
attestation. This wires the REAL signal.

Registry (network-registry service):
- migration 0013: additive, nullable `ALTER TABLE admission_requests
  ADD COLUMN hub_authorized_at TEXT` (same shape as 0011's admin_pubkeys; no
  CHECK/enum touched; existing rows coalesce to null for READS). NOTE: the new
  code has a HARD dependency on this migration — revoke/departAdmission now
  *write* `hub_authorized_at = NULL`, so shipping the code against a pre-0013 DB
  would 500 those existing endpoints. **Migration-before-code ordering is
  mandatory** (see DEPLOY NOTE).
- store markHubAuthorized(requestId, tsIso): CAS-guarded on status='ADMITTED'
  (mirrors setSealedSecret); revokeAdmission/departAdmission now also CLEAR
  hub_authorized_at back to NULL (a revoked/departed member is not authorized).
- POST /admission-requests/:id/authorize — built on the SAME verifyHubAdminWrite
  helper the sealed-leaf route uses (hub-admin allowlist, rate-limit, sig verify,
  nonce replay); 404 missing, 409 not_admitted on non-ADMITTED.
- validateSignedHubAuthorize / HubAuthorizeClaim (mirror the revoke validators).

Cortex CLI:
- `cortex network authorize <member-pubkey> --network <net> --admin-seed <seed>
  [--registry-url] [--apply]` — the hub-owner command run AFTER applying the leaf
  authorization on their hub VM (the #1481 artifact). Dry-run by default.
- buildLiveHubAuthPort: reads the member's own admission row via the same /mine
  PoP path the seal leg uses → confirmed:true (row carries hub_authorized_at),
  false (no stamp). undefined ("not observable from here") on TWO paths: (a) a
  remote member — member != this host's principal, so its /mine row isn't
  PoP-readable from here (checked BEFORE any read); (b) a registry read failure
  (unreachable / no seed configured). Wired into buildLiveHandoffPorts,
  replacing the stub.
- network-handoff-lib.ts UNCHANGED (deriveHandoffState/guardLeafUp/hubAuthorizeDone
  were already typed boolean|undefined fail-closed) — wiring the real read is a
  no-op in the model + guard, exactly as #1485 was designed.

Scope: --guided stays OPT-IN (not flipped to default) — that's a deliberate
breaking change for a separate PR once operators have the marker-write in hand.

Tests: store markHubAuthorized (ADMITTED/non-ADMITTED/missing/revoked-clears);
the route (authorized signer sets it; unauthorized fail-closed; 404; not_admitted);
migration 0013 applies; the authorize CLI (dry-run + --apply); the live read
adapter (stamp→true, none→false, unreachable→undefined); and a join --guided
integration test proving it PROCEEDS on a real marked row with NO attestation.

tsc/lint/carve-out clean; full suite 8857 pass.

DEPLOY NOTE (ordering is MANDATORY): apply the D1 migration to the live registry
FIRST — `bunx wrangler d1 migrations apply cortex-network-registry --env production --remote`
— THEN deploy the new registry code. The new revoke/depart write path references
`hub_authorized_at`, so deploying the code against a pre-0013 DB would 500 those
endpoints. Migrate first, then ship.

Closes #1498
Refs #1479 #1485

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
