### PR TITLE
chore(release): cortex v6.2.0 — federation-join tooling redesign (epic #1479 + #1498)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.1.0"
+version: "6.2.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump 6.1.0 → 6.2.0 (minor — features).

Ships the whole federation-join tooling redesign merged overnight:
- **C-1484** `cortex network doctor` — E2E federation verification (#1487)
- **C-1481** never write a foreign hub + `--seal-only` (#1491)
- **C-1482** reconcile the three representation-pairs + NKEY↔base64 (#1493)
- **C-1483** validated, recoverable, canaried config mutations (#1495)
- **C-1480** operator-mode config render complete (FED+AGENTS+SYS preload) (#1496)
- **C-1485** guided-join handoff state (#1499)
- **C-1498** real `hub_authorized_at` signal (#1501)

Registry migration 0013 already applied to dev + prod D1 (migration-before-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)