### PR TITLE
refactor(bus): S1 — one owner for the envelope source-string grammar

### DIFF
--- a/src/bus/capability-registry.ts
+++ b/src/bus/capability-registry.ts
@@ -118,6 +118,7 @@
 
 import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope } from "./envelope-builder";
+import { buildSource } from "./system-events";
 
 // ---------------------------------------------------------------------------
 // Public types — kept narrow so the publisher composes cleanly with both
@@ -249,10 +250,6 @@ export const CAPABILITY_REGISTERED_EVENT_TYPE = "agents.capabilities.registered"
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
-
-function buildSource(src: CapabilityRegistrySource): string {
-  return `${src.principal}.${src.agent}.${src.instance}`;
-}
 
 /**
  * Default sovereignty posture for capability-registration envelopes.

--- a/src/bus/dev-events.ts
+++ b/src/bus/dev-events.ts
@@ -38,7 +38,7 @@
 
 import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope as buildSharedEnvelope } from "./envelope-builder";
-import type { SystemEventSource } from "./system-events";
+import { buildSource, type SystemEventSource } from "./system-events";
 import type { LogicalResponseRouting } from "./dispatch-events";
 
 // Re-export so the orchestrator + dev consumer import the run-thread routing
@@ -54,10 +54,6 @@ export type DevEventSource = SystemEventSource;
 // module for the failure taxonomy (single source of truth stays in
 // `dispatch-events.ts` per cortex#249).
 export type { DispatchTaskFailedReason } from "./dispatch-events";
-
-function buildSource(src: SystemEventSource): string {
-  return `${src.principal}.${src.agent}.${src.instance}`;
-}
 
 /**
  * Default sovereignty for `tasks.dev.implement` envelopes. Same posture as

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -46,7 +46,7 @@
 
 import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope as buildSharedEnvelope } from "./envelope-builder";
-import type { SystemEventSource } from "./system-events";
+import { buildSource, type SystemEventSource } from "./system-events";
 
 // Re-export `SystemEventSource` under a domain-neutral alias so callers
 // in `runner/` import from one place. The alias is purely ergonomic;
@@ -131,10 +131,6 @@ export interface LogicalResponseRouting {
  * value — the type widening alone admits both producers.
  */
 export type AnyResponseRouting = ResponseRouting | LogicalResponseRouting;
-
-function buildSource(src: SystemEventSource): string {
-  return `${src.principal}.${src.agent}.${src.instance}`;
-}
 
 /**
  * Default sovereignty for `dispatch.task.*` events. Same posture as

--- a/src/bus/github-events.ts
+++ b/src/bus/github-events.ts
@@ -62,7 +62,7 @@
 
 import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope } from "./envelope-builder";
-import type { SystemEventSource } from "./system-events";
+import { buildSource, type SystemEventSource } from "./system-events";
 import { isUuid } from "../common/types/uuid";
 
 /**
@@ -71,10 +71,6 @@ import { isUuid } from "../common/types/uuid";
  * shortcut as `DispatchEventSource` in `bus/dispatch-events.ts`.
  */
 export type GithubEventSource = SystemEventSource;
-
-function buildSource(src: SystemEventSource): string {
-  return `${src.principal}.${src.agent}.${src.instance}`;
-}
 
 /**
  * Default sovereignty for `github.*` events. Principal-only by default / local

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -78,16 +78,12 @@ import {
   type DispatchTaskFailedOpts,
   type DispatchTaskFailedReason,
 } from "./dispatch-events";
-import type { SystemEventSource } from "./system-events";
+import { buildSource, type SystemEventSource } from "./system-events";
 
 // Re-export the source shape under a domain-neutral alias — mirrors the
 // `DispatchEventSource` pattern in `dispatch-events.ts`. Callers in the
 // review consumer / pilot import from one place.
 export type ReviewEventSource = SystemEventSource;
-
-function buildSource(src: SystemEventSource): string {
-  return `${src.principal}.${src.agent}.${src.instance}`;
-}
 
 /**
  * Default sovereignty for `tasks.code-review.*` and `review.verdict.*`

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -87,7 +87,22 @@ export interface SystemEventSource {
   dataResidency?: string;
 }
 
-export function buildSource(src: SystemEventSource): string {
+/**
+ * Single owner of the `{principal}.{agent}.{instance}` envelope-source
+ * grammar (myelin#185's 3-segment form). Every `system.*`/`github.*`/
+ * `dev.*`/`review.*`/`dispatch.*`/`agents.*` emitter shares this one
+ * function rather than re-deriving the string locally (cortex#1515 S1).
+ *
+ * The parameter is structural rather than `SystemEventSource` so
+ * domain-specific source shapes (e.g. `CapabilityRegistrySource`) can
+ * pass their value through without importing or extending
+ * `SystemEventSource` itself — same output, no type coupling.
+ */
+export function buildSource(src: {
+  principal: string;
+  agent: string;
+  instance: string;
+}): string {
   return `${src.principal}.${src.agent}.${src.instance}`;
 }
 


### PR DESCRIPTION
## Summary

Consolidates the `{principal}.{agent}.{instance}` envelope-source-string builder onto a single exported owner. Five files each had their own private `buildSource` copy computing the identical string — this deletes all five and routes them to the one already exported from `src/bus/system-events.ts`.

- Kept `system-events.ts:buildSource` as the single owner (least churn — `brain-consumer.ts` already imports from there).
- Widened its parameter to a structural `{ principal: string; agent: string; instance: string }` type (instead of the concrete `SystemEventSource`) so `capability-registry.ts`'s `CapabilityRegistrySource` — which intentionally does NOT share a type with `SystemEventSource` — can reuse the function without adopting that type coupling. Output is identical.
- Deleted the private copies in `github-events.ts`, `dev-events.ts`, `review-events.ts`, `dispatch-events.ts`, `capability-registry.ts` and replaced each with an import of the shared `buildSource`.

Behavior-preserving: same output string at every call site, no wire-format change.

Cites: plan §2 S1, epic #1514

## Out of scope

- **`src/bus/agent-network/builders.ts:84`** (`buildSource` on `AgentPresenceSource`) and **`src/bus/probe-responder.ts:413`** use a DIFFERENT segment grammar (different segments / different order) than the myelin#185 3-segment form consolidated here. Reconciling them would change wire bytes, so they're left untouched. Follow-up filed: #1529.
- **`src/bus/bus-dispatch-listener.ts:235`** (`ourSource` comparison) and **`src/bus/dispatch-source-publisher.ts:297`** (`source:` wire field) build the same string inline (not via a named `buildSource` function) from different source objects. Left as-is — candidate follow-up, kept out to keep this slice behavior-preserving.

## Gate results

- `bunx tsc --noEmit` — 0 errors
- `bun test src/bus` — 1264 pass, 1 skip, 0 fail (scoped)
- `bun test` (full) — 8857 pass, 8 skip, 8 todo, 1 fail; the 1 fail (`ConfigWatcher — github.repos hot-reload (cortex#135)`) is a pre-existing flaky timing test in `src/common/config/__tests__/watcher.test.ts`, unrelated to any file touched here — confirmed by re-running it in isolation (4 pass, 0 fail).
- `bun run lint:errors` — 0 errors

Closes #1515