### PR TITLE
refactor(cli): S2 — embody ADR-0004 with one stackSlugFromStackId

### DIFF
--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -39,6 +39,7 @@
  */
 
 import type { LoadedConfig } from "../../../common/config/loader";
+import { stackSlugFromStackId } from "../../../common/stack-id";
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
 import { samePubkey } from "../../../common/registry/pubkey-normalize";
 import {
@@ -142,12 +143,6 @@ function check(
 
 function skipCheck(id: string, title: string, detail: string, owner: DoctorCheckOwner): DoctorCheck {
   return check(id, title, "skip", detail, owner);
-}
-
-/** `{principal}/{slug}` → the slug (falls back to the whole string). */
-function stackSlugFromStackId(stackId: string): string {
-  const parts = stackId.split("/");
-  return parts.length === 2 ? (parts[1] ?? stackId) : stackId;
 }
 
 /** Truncate a pubkey for display in a check detail (never the full key —

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -24,6 +24,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { dirname, join } from "path";
 import { parse as parseYaml } from "yaml";
+import { stackSlugFromStackId } from "../../../common/stack-id";
 import { DEFAULT_STREAM_MAX_BYTES } from "../../../common/types/cortex-config";
 
 // =============================================================================
@@ -101,12 +102,6 @@ function extractStackId(configPath: string): string | undefined {
   return undefined;
 }
 
-/** The trailing `{slug}` segment of a `{principal}/{slug}` stack id. */
-function stackIdTrailingSlug(stackId: string): string {
-  const idx = stackId.lastIndexOf("/");
-  return idx === -1 ? stackId : stackId.slice(idx + 1);
-}
-
 /**
  * Discover all stacks under `configDir` — split-layout dirs (with the
  * `system/system.yaml` marker) and legacy `cortex*.yaml` monoliths. Mirrors
@@ -177,7 +172,7 @@ function buildDiscovered(
     ...(stackId !== undefined && { stackId }),
     layout,
     configPath,
-    ...(stackId !== undefined && { aligned: stackIdTrailingSlug(stackId) === slugLocator }),
+    ...(stackId !== undefined && { aligned: stackSlugFromStackId(stackId) === slugLocator }),
   };
 }
 
@@ -322,7 +317,7 @@ export function retiredSeedPath(seedPath: string, stamp: string): string {
  * error (those are validated + rejected upstream as usage errors).
  */
 export function assertAligned(slug: string, stackId: string): void {
-  const trailing = stackIdTrailingSlug(stackId);
+  const trailing = stackSlugFromStackId(stackId);
   if (trailing !== slug) {
     throw new Error(
       `alignment self-check failed (#808): stack.id "${stackId}" trailing segment "${trailing}" != slug "${slug}"`,

--- a/src/common/__tests__/stack-id.test.ts
+++ b/src/common/__tests__/stack-id.test.ts
@@ -18,6 +18,14 @@ describe("stackSlugFromStackId", () => {
     expect(stackSlugFromStackId("")).toBe("");
   });
 
+  // network-doctor-lib's PRIOR local impl (`parts.length === 2 ? parts[1] : stackId`)
+  // returned "a/b/c" unchanged for this input — a >2-segment id fell through its
+  // length check. Adopting this authority fn there DOES change that one
+  // degenerate-case result (see PR discussion on #1516/#1531). That's intended:
+  // canonical stack.id is always 2-part `{principal}/{slug}`, so no real stack.id
+  // ever hits this path — conforming onto the ADR-0004 authority (last segment,
+  // mirroring the shell `${id##*/}` step) is the point of this slice, not an
+  // accidental behavior change.
   test("multiple slashes: takes the LAST segment (lastIndexOf, not a 2-part split)", () => {
     expect(stackSlugFromStackId("a/b/c")).toBe("c");
   });

--- a/src/common/__tests__/stack-id.test.ts
+++ b/src/common/__tests__/stack-id.test.ts
@@ -1,0 +1,28 @@
+import { test, expect, describe } from "bun:test";
+import { stackSlugFromStackId } from "../stack-id";
+
+describe("stackSlugFromStackId", () => {
+  test("jc/default -> default", () => {
+    expect(stackSlugFromStackId("jc/default")).toBe("default");
+  });
+
+  test("andreas/meta-factory -> meta-factory", () => {
+    expect(stackSlugFromStackId("andreas/meta-factory")).toBe("meta-factory");
+  });
+
+  test("bare slug with no slash passes through unchanged", () => {
+    expect(stackSlugFromStackId("foo")).toBe("foo");
+  });
+
+  test("empty string passes through unchanged", () => {
+    expect(stackSlugFromStackId("")).toBe("");
+  });
+
+  test("multiple slashes: takes the LAST segment (lastIndexOf, not a 2-part split)", () => {
+    expect(stackSlugFromStackId("a/b/c")).toBe("c");
+  });
+
+  test("trailing slash: last segment is empty", () => {
+    expect(stackSlugFromStackId("jc/")).toBe("");
+  });
+});

--- a/src/common/stack-id.ts
+++ b/src/common/stack-id.ts
@@ -1,16 +1,24 @@
 /**
- * The single TS authority for deriving a stack **slug** from a `stack.id`
+ * The canonical derivation of a stack **slug** from a `stack.id`
  * (ADR-0004: "`stack.id`'s trailing segment is the single authority for the
  * stack slug"). Lifted from `stack-lib.ts`'s `stackIdTrailingSlug` (S2,
  * architecture-deepening epic #1514) so the real call sites import one
  * function instead of each carrying their own copy.
  *
- * Byte-for-byte replica of the trailing-segment step inside
- * `plist-render.sh`'s `extract_stack_id_slug` (the shell `id##` pattern strip
- * on the last slash) — take everything after the LAST `/`, or the whole
- * string when there is none. `scripts/lib/plist-render.sh`'s
- * `extract_stack_id_slug` mirrors THIS function; the shell script itself is
- * not edited here (do not re-derive this logic there).
+ * Scope: this owns the *authoritative* trailing-segment rule, but not every
+ * slug guess in the tree funnels through it yet. A few inline sites still
+ * derive a slug with a divergent `?? "default"` / `?? agentId` fallback
+ * (`stack-lib.ts` ~:635, `network.ts` ~:745 / ~:4022, `network-adapters.ts`
+ * ~:864) and are intentionally left untouched in S2 — routing them here would
+ * change behavior, not just structure. Route NEW call sites through this
+ * function; consolidating the divergent-fallback sites is a separate,
+ * behavior-affecting follow-up.
+ *
+ * The trailing-segment rule mirrors `plist-render.sh`'s `extract_stack_id_slug`
+ * (the shell's last-slash parameter strip) — everything after the LAST `/`, or
+ * the whole string when there is none. That cross-language parity is asserted here,
+ * not yet pinned by a shell-invoking test: `scripts/lib/plist-render.sh` must be
+ * kept in step with THIS function by hand (do not re-derive the logic there).
  */
 
 /** The trailing `{slug}` segment of a `{principal}/{slug}` stack id. */

--- a/src/common/stack-id.ts
+++ b/src/common/stack-id.ts
@@ -1,0 +1,20 @@
+/**
+ * The single TS authority for deriving a stack **slug** from a `stack.id`
+ * (ADR-0004: "`stack.id`'s trailing segment is the single authority for the
+ * stack slug"). Lifted from `stack-lib.ts`'s `stackIdTrailingSlug` (S2,
+ * architecture-deepening epic #1514) so the real call sites import one
+ * function instead of each carrying their own copy.
+ *
+ * Byte-for-byte replica of the trailing-segment step inside
+ * `plist-render.sh`'s `extract_stack_id_slug` (the shell `id##` pattern strip
+ * on the last slash) — take everything after the LAST `/`, or the whole
+ * string when there is none. `scripts/lib/plist-render.sh`'s
+ * `extract_stack_id_slug` mirrors THIS function; the shell script itself is
+ * not edited here (do not re-derive this logic there).
+ */
+
+/** The trailing `{slug}` segment of a `{principal}/{slug}` stack id. */
+export function stackSlugFromStackId(stackId: string): string {
+  const idx = stackId.lastIndexOf("/");
+  return idx === -1 ? stackId : stackId.slice(idx + 1);
+}


### PR DESCRIPTION
## Summary

- Adds `src/common/stack-id.ts` exporting `stackSlugFromStackId(stackId: string): string` — the single TS authority for deriving a stack slug from `stack.id` (ADR-0004: "`stack.id`'s trailing segment is the single authority for the stack slug"). Lifted verbatim from `stack-lib.ts`'s `stackIdTrailingSlug` (the `lastIndexOf`-based impl mirroring the shell `extract_stack_id_slug`'s trailing-segment step), preserving its exact edge-case behavior.
- `stack-lib.ts` (`discoverStacks`'s alignment check, `assertAligned`) now imports the shared function — byte-identical to its prior local impl (same `lastIndexOf` logic), so no behavior change there at all.
- `network-doctor-lib.ts` (`checkPeerReachable`) now imports the shared function too, but this one **is not byte-identical to its own prior local impl** — its old `parts.length === 2 ? (parts[1] ?? stackId) : stackId` returned the whole string unchanged on a >2-segment id (e.g. `"a/b/c"` → `"a/b/c"`), while the shared authority fn returns the last segment (`"a/b/c"` → `"c"`). This divergence only surfaces on a non-canonical `stack.id` (canonical ids are always 2-part `{principal}/{slug}` — that's what `peer.stack_id` is populated with in practice), so there's no observable production change; conforming this site onto the ADR-0004 authority instead of its own ad-hoc split is the actual intent of this slice, not an accidental side effect.
- Adds `src/common/__tests__/stack-id.test.ts` covering the lifted implementation's actual (not "improved") behavior on the standard case, a bare slug, empty string, multiple slashes, and a trailing slash.

Behavior-preserving for `stack-lib.ts`; for `network-doctor-lib.ts` it's authority-conformance per ADR-0004/S2 — identical on every canonical (2-part) `stack.id`, differing only on a degenerate multi-segment id that is never produced today.

## Out of scope

- **`daemon-locator.ts`'s `split("/")[1]` anchor is stale.** The issue's read-list points at line 8, which is JSDoc *documenting the historical bug* — it is not live code. `fix(cortex): C-800` already replaced slug-guessing with real `--config`-argument matching in the same commit that introduced this file, and no `split("/")[1]` call exists anywhere else in it (verified: whole-file grep for `split`/`slug`/`stackId`). Left untouched; flagged on #1516 before pushing.
- **`network-ping-signer.ts:90-110`** — no slug logic present (stale anchor per the task packet).
- **Four inline sites with a different fallback semantics are intentionally NOT folded in**, since their degenerate-case behavior differs from the authority fn (`?? "default"` / `?? agentId` vs. this fn's whole-string passthrough) and consolidating would be a behavior change, not a behavior-preserving one:
  - `stack-lib.ts:635` (`stackId.split("/")[1] ?? agentId` in a template literal)
  - `network.ts:745` (`?? "default"`)
  - `network.ts:4022` (`?? "default"`)
  - `network-adapters.ts:864` (`?? "default"`)
  Consolidating these is a behavior question for a follow-up, not this slice.
- `network.ts`, `network-lib.ts`, `network-derive.ts` are untouched (principal has in-flight uncommitted work there; none of S2's real call sites live in those files).

## Gate results

- `bunx tsc --noEmit` — 0 errors
- `bun test src/common src/cli/cortex/commands` — 2963 pass, 0 fail, 8 todo
- `bun test` (full) — 8863 pass, 1 fail, 8 skip, 8 todo. The 1 failure (`cortex.agents-reload.test.ts` "fs.watch fires the reconcile on a fragment add") is a timing-sensitive fs.watch test unrelated to this change — passes cleanly (19/19) run in isolation; flaked under full-suite parallel load.
- `bun run lint:errors` — 0 errors

Closes #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
