### PR TITLE
refactor(mc): S4 — Mission Control db write-half (mutation SQL → db/ functions)

### DIFF
--- a/src/surface/mc/__tests__/assignments-db.test.ts
+++ b/src/surface/mc/__tests__/assignments-db.test.ts
@@ -1,0 +1,94 @@
+/**
+ * S4 (#1518) — unit tests for the assignment mutations lifted out of
+ * api/handlers.ts (`createQueuedAssignment`, `deleteAssignment`).
+ *
+ * Read-side coverage for `db/assignments.ts` (`listAssignments`,
+ * `listFocusArea`, `mostActiveAgent`) lives in the endpoint-level tests
+ * (api.test.ts, focus-area-ws.test.ts) — this file is scoped to the new
+ * write-half functions only.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { SCHEMA_SQL } from "../db/schema";
+import { createQueuedAssignment, deleteAssignment } from "../db/assignments";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+
+  db.exec(
+    `INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`
+  );
+  db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
+
+  return db;
+}
+
+interface AssignmentRow {
+  id: string;
+  agent_id: string;
+  task_id: string;
+  state: string;
+}
+
+function readAssignment(db: Database, id: string): AssignmentRow | null {
+  return db
+    .query(`SELECT id, agent_id, task_id, state FROM agent_task_assignment WHERE id = ?`)
+    .get(id) as AssignmentRow | null;
+}
+
+describe("createQueuedAssignment", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("inserts a row that starts in 'queued'", () => {
+    createQueuedAssignment(db, { id: "ata-1", agentId: "a-1", taskId: "t-1" });
+    expect(readAssignment(db, "ata-1")).toEqual({
+      id: "ata-1",
+      agent_id: "a-1",
+      task_id: "t-1",
+      state: "queued",
+    });
+  });
+
+  it("rejects an unknown agent_id (FK RESTRICT)", () => {
+    expect(() =>
+      createQueuedAssignment(db, { id: "ata-1", agentId: "ghost", taskId: "t-1" })
+    ).toThrow();
+  });
+
+  it("rejects an unknown task_id (FK RESTRICT)", () => {
+    expect(() =>
+      createQueuedAssignment(db, { id: "ata-1", agentId: "a-1", taskId: "ghost" })
+    ).toThrow();
+  });
+});
+
+describe("deleteAssignment", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("removes the row", () => {
+    createQueuedAssignment(db, { id: "ata-1", agentId: "a-1", taskId: "t-1" });
+    expect(readAssignment(db, "ata-1")).not.toBeNull();
+    deleteAssignment(db, "ata-1");
+    expect(readAssignment(db, "ata-1")).toBeNull();
+  });
+
+  it("is a no-op on an unknown id (no matching row, no throw)", () => {
+    expect(() => deleteAssignment(db, "does-not-exist")).not.toThrow();
+  });
+});

--- a/src/surface/mc/__tests__/tasks.test.ts
+++ b/src/surface/mc/__tests__/tasks.test.ts
@@ -525,10 +525,20 @@ describe("task mutations", () => {
 
   it("cancelTask sets status = 'cancelled' and bumps updated_at", () => {
     createInternalTask(db, { id: "t-1", title: "T", priority: 2, principalId: "op" });
-    const before = readTask("t-1");
-    expect(before?.status).toBe("open");
+    // Backdate updated_at so the "bumps" half of this test is deterministic
+    // regardless of how fast the test runs — unixepoch() is whole-seconds,
+    // so a same-second before/after pair would look unchanged without this.
+    const oldUpdatedAt = 1_000_000;
+    db.query(`UPDATE tasks SET updated_at = ? WHERE id = ?`).run(oldUpdatedAt, "t-1");
+
     cancelTask(db, "t-1");
-    expect(readTask("t-1")?.status).toBe("cancelled");
+
+    const after = readTask("t-1");
+    expect(after?.status).toBe("cancelled");
+    const { updated_at } = db
+      .query(`SELECT updated_at FROM tasks WHERE id = ?`)
+      .get("t-1") as { updated_at: number };
+    expect(updated_at).toBeGreaterThan(oldUpdatedAt);
   });
 
   it("cancelTask is a no-op on an unknown id (no matching row, no throw)", () => {

--- a/src/surface/mc/__tests__/tasks.test.ts
+++ b/src/surface/mc/__tests__/tasks.test.ts
@@ -16,7 +16,17 @@ import { tmpdir } from "os";
 import { rmSync } from "fs";
 
 import { initDatabase } from "../db/init";
-import { getTaskById, listTasks, epochSecondsToIso, STATE_RANKS } from "../db/tasks";
+import {
+  cancelTask,
+  createGithubImportedTask,
+  createInternalTask,
+  createTaskInIteration,
+  deleteTask,
+  getTaskById,
+  listTasks,
+  epochSecondsToIso,
+  STATE_RANKS,
+} from "../db/tasks";
 import { normalizeSqliteDatetime } from "../db/assignments";
 
 describe("epochSecondsToIso", () => {
@@ -394,5 +404,134 @@ describe("getTaskById", () => {
     ).run(sameTs, endTs);
     const t = getTaskById(db, "t-1");
     expect(t?.assignments[0]?.session?.id).toBe("s-ZZZ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S4 (#1518) — task mutations lifted out of api/handlers.ts
+// ---------------------------------------------------------------------------
+
+describe("task mutations", () => {
+  let db: Database;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mc-tasks-mutations-test-${Date.now()}-${Math.random()}`);
+    db = initDatabase(join(tmpDir, "test.db"));
+    db.query(
+      `INSERT INTO agents (id, name, type) VALUES ('ag', 'Agent', 'hands')`
+    ).run();
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function readTask(id: string) {
+    return db
+      .query(
+        `SELECT id, title, priority, principal_id, source_system, source_url,
+                source_external_id, iteration_id, status
+         FROM tasks WHERE id = ?`
+      )
+      .get(id) as
+      | {
+          id: string;
+          title: string;
+          priority: number;
+          principal_id: string;
+          source_system: string;
+          source_url: string | null;
+          source_external_id: string | null;
+          iteration_id: string | null;
+          status: string;
+        }
+      | null;
+  }
+
+  it("createInternalTask inserts an internal-source, ungrouped task", () => {
+    createInternalTask(db, {
+      id: "t-1",
+      title: "Fresh dispatch",
+      priority: 2,
+      principalId: "op",
+    });
+    expect(readTask("t-1")).toEqual({
+      id: "t-1",
+      title: "Fresh dispatch",
+      priority: 2,
+      principal_id: "op",
+      source_system: "internal",
+      source_url: null,
+      source_external_id: null,
+      iteration_id: null,
+      status: "open",
+    });
+  });
+
+  it("createGithubImportedTask inserts a github-source task with url + external id", () => {
+    createGithubImportedTask(db, {
+      id: "t-1",
+      title: "Fix the thing",
+      priority: 1,
+      principalId: "op",
+      sourceUrl: "https://github.com/x/y/issues/42",
+      externalId: "x/y#42",
+    });
+    expect(readTask("t-1")).toEqual({
+      id: "t-1",
+      title: "Fix the thing",
+      priority: 1,
+      principal_id: "op",
+      source_system: "github",
+      source_url: "https://github.com/x/y/issues/42",
+      source_external_id: "x/y#42",
+      iteration_id: null,
+      status: "open",
+    });
+  });
+
+  it("createTaskInIteration inserts an internal-source task pre-attached to an iteration", () => {
+    db.query(
+      `INSERT INTO iterations (id, title, state, priority) VALUES ('it-1', 'Iter', 'designing', 2)`
+    ).run();
+    createTaskInIteration(db, {
+      id: "t-1",
+      title: "Typed straight into the iteration",
+      priority: 2,
+      principalId: "op",
+      iterationId: "it-1",
+    });
+    expect(readTask("t-1")).toEqual({
+      id: "t-1",
+      title: "Typed straight into the iteration",
+      priority: 2,
+      principal_id: "op",
+      source_system: "internal",
+      source_url: null,
+      source_external_id: null,
+      iteration_id: "it-1",
+      status: "open",
+    });
+  });
+
+  it("deleteTask removes the row", () => {
+    createInternalTask(db, { id: "t-1", title: "T", priority: 2, principalId: "op" });
+    expect(readTask("t-1")).not.toBeNull();
+    deleteTask(db, "t-1");
+    expect(readTask("t-1")).toBeNull();
+  });
+
+  it("cancelTask sets status = 'cancelled' and bumps updated_at", () => {
+    createInternalTask(db, { id: "t-1", title: "T", priority: 2, principalId: "op" });
+    const before = readTask("t-1");
+    expect(before?.status).toBe("open");
+    cancelTask(db, "t-1");
+    expect(readTask("t-1")?.status).toBe("cancelled");
+  });
+
+  it("cancelTask is a no-op on an unknown id (no matching row, no throw)", () => {
+    expect(() => cancelTask(db, "does-not-exist")).not.toThrow();
   });
 });

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -35,11 +35,21 @@ import type {
 } from "./types";
 
 import {
+  createQueuedAssignment,
+  deleteAssignment,
   listAssignments,
   listFocusArea,
   mostActiveAgent,
 } from "../db/assignments";
-import { getTaskById, listTasks } from "../db/tasks";
+import {
+  cancelTask,
+  createGithubImportedTask,
+  createInternalTask,
+  createTaskInIteration,
+  deleteTask,
+  getTaskById,
+  listTasks,
+} from "../db/tasks";
 import { listWorkingAgents } from "../db/working-agents";
 import {
   aggregateWorkingAgents,
@@ -551,12 +561,12 @@ export function handleListEvents(
  * agent_task_assignment FK.
  */
 function ensureDefaultAgent(db: Database): string {
-  db.query(
-    `INSERT INTO agents (id, name, type, persistent)
-     VALUES (?, ?, 'hands', 1)
-     ON CONFLICT(id) DO NOTHING`
-  ).run(DEFAULT_AGENT_ID, DEFAULT_AGENT_NAME);
-  return DEFAULT_AGENT_ID;
+  return ensureAgentRow(db, {
+    id: DEFAULT_AGENT_ID,
+    name: DEFAULT_AGENT_NAME,
+    type: "hands",
+    persistent: true,
+  });
 }
 
 /**
@@ -730,16 +740,15 @@ export async function handleCreateSession(
 
   const insertRows = db.transaction(() => {
     if (!body.taskId) {
-      db.query(
-        `INSERT INTO tasks (id, title, priority, principal_id, source_system)
-         VALUES (?, ?, ?, ?, 'internal')`
-      ).run(taskId, title, DEFAULT_INTERNAL_TASK_PRIORITY, principalId);
+      createInternalTask(db, {
+        id: taskId,
+        title,
+        priority: DEFAULT_INTERNAL_TASK_PRIORITY,
+        principalId,
+      });
     }
 
-    db.query(
-      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
-       VALUES (?, ?, ?, 'queued')`
-    ).run(assignmentId, agentId, taskId);
+    createQueuedAssignment(db, { id: assignmentId, agentId, taskId });
   });
 
   try {
@@ -789,11 +798,9 @@ export async function handleCreateSession(
       // review.
       try {
         db.transaction(() => {
-          db.query(`DELETE FROM agent_task_assignment WHERE id = ?`).run(
-            assignmentId
-          );
+          deleteAssignment(db, assignmentId);
           if (!body.taskId) {
-            db.query(`DELETE FROM tasks WHERE id = ?`).run(taskId);
+            deleteTask(db, taskId);
           }
         })();
       } catch (rollbackErr) {
@@ -849,11 +856,9 @@ export async function handleCreateSession(
     } catch (err) {
       try {
         db.transaction(() => {
-          db.query(`DELETE FROM agent_task_assignment WHERE id = ?`).run(
-            assignmentId
-          );
+          deleteAssignment(db, assignmentId);
           if (!body.taskId) {
-            db.query(`DELETE FROM tasks WHERE id = ?`).run(taskId);
+            deleteTask(db, taskId);
           }
         })();
       } catch (rollbackErr) {
@@ -1553,9 +1558,7 @@ export function handleAbandonAssignment(
   // Update the task row. No state-machine transition on the assignment —
   // the assignment is already terminal (its row is preserved as historical
   // record per Decision 4's "no merging" rule).
-  db.query(
-    `UPDATE tasks SET status = 'cancelled', updated_at = unixepoch() WHERE id = ?`
-  ).run(row.task_id);
+  cancelTask(db, row.task_id);
 
   // Anchor the curation event on the assignment's latest (terminal) session.
   // The FK is to `sessions(id)`, not "active session" — terminal sessions
@@ -1709,10 +1712,11 @@ export async function handleHandoffAssignment(
   // rows on the same task are preserved (Decision 4 / F-8 Decision 4).
   const newAssignmentId = generateId();
   try {
-    db.query(
-      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
-       VALUES (?, ?, ?, 'queued')`
-    ).run(newAssignmentId, newAgentId, row.task_id);
+    createQueuedAssignment(db, {
+      id: newAssignmentId,
+      agentId: newAgentId,
+      taskId: row.task_id,
+    });
   } catch (err) {
     return error(
       `Failed to create new assignment: ${(err as Error).message}`,
@@ -1735,9 +1739,7 @@ export async function handleHandoffAssignment(
     );
   } catch (err) {
     try {
-      db.query(`DELETE FROM agent_task_assignment WHERE id = ?`).run(
-        newAssignmentId
-      );
+      deleteAssignment(db, newAssignmentId);
     } catch (rollbackErr) {
       process.stderr.write(
         `[api] handoff rollback after spawn-failure failed: ${(rollbackErr as Error).message}\n`
@@ -2074,12 +2076,14 @@ export async function handleCreateTask(
     { event: null };
 
   const insertAll = db.transaction(() => {
-    db.query(
-      `INSERT INTO tasks
-         (id, title, priority, principal_id,
-          source_system, source_url, source_external_id)
-       VALUES (?, ?, ?, ?, 'github', ?, ?)`
-    ).run(taskId, title, priority, principalId, sourceUrl, canonical);
+    createGithubImportedTask(db, {
+      id: taskId,
+      title,
+      priority,
+      principalId,
+      sourceUrl,
+      externalId: canonical,
+    });
 
     createShadowAssignmentAndSession(db, taskId, {
       assignmentId: shadowAssignmentId,
@@ -2242,9 +2246,7 @@ export function handleAbandonTask(
   const holder: { event: ReturnType<typeof createPrincipalCurationEvent> | null } =
     { event: null };
   const tx = db.transaction(() => {
-    db.query(
-      `UPDATE tasks SET status = 'cancelled', updated_at = unixepoch() WHERE id = ?`
-    ).run(taskId);
+    cancelTask(db, taskId);
 
     holder.event = createPrincipalCurationEvent(db, sessionRow.id, {
       kind: "abandon",
@@ -2820,11 +2822,13 @@ export function handleAttachTaskToIteration(
       // Per Echo grove-v2#42 (Major 2) — the touch is now inside the
       // same transaction so create-and-touch land atomically.
       db.transaction(() => {
-        db.query(
-          `INSERT INTO tasks
-             (id, title, priority, principal_id, source_system, iteration_id)
-           VALUES (?, ?, ?, ?, 'internal', ?)`
-        ).run(newTaskId, newTitle, prio, DEFAULT_PRINCIPAL_ID, iterationId);
+        createTaskInIteration(db, {
+          id: newTaskId,
+          title: newTitle,
+          priority: prio,
+          principalId: DEFAULT_PRINCIPAL_ID,
+          iterationId,
+        });
         touchIteration(db, iterationId);
       })();
     } catch (err) {

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -646,6 +646,27 @@ export function _resetDispatchDebounceForTests(): void {
 // `src/common/types/uuid.ts`. Same 8-4-4-4-12 hex layout, no
 // version/variant constraint (matches the comment above).
 
+/**
+ * Undo a just-inserted dispatch pair (assignment + optionally its
+ * internal task) after a same-request failure — observed duplicate
+ * ccSessionId, or controlled spawn failure. Both call sites in
+ * `handleCreateSession` ran this identical transaction inline; extracted
+ * so the rollback shape can't drift between them.
+ */
+function rollbackDispatch(
+  db: Database,
+  assignmentId: string,
+  taskId: string,
+  hadTaskId: boolean
+): void {
+  db.transaction(() => {
+    deleteAssignment(db, assignmentId);
+    if (!hadTaskId) {
+      deleteTask(db, taskId);
+    }
+  })();
+}
+
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function handleCreateSession(
   db: Database,
@@ -797,12 +818,7 @@ export async function handleCreateSession(
       // caller didn't supply taskId) lying around. Per Echo's PR-#56
       // review.
       try {
-        db.transaction(() => {
-          deleteAssignment(db, assignmentId);
-          if (!body.taskId) {
-            deleteTask(db, taskId);
-          }
-        })();
+        rollbackDispatch(db, assignmentId, taskId, Boolean(body.taskId));
       } catch (rollbackErr) {
         process.stderr.write(
           `[api] rollback after observed-dup-409 failed: ${(rollbackErr as Error).message}\n`
@@ -855,12 +871,7 @@ export async function handleCreateSession(
       endpoint = ep;
     } catch (err) {
       try {
-        db.transaction(() => {
-          deleteAssignment(db, assignmentId);
-          if (!body.taskId) {
-            deleteTask(db, taskId);
-          }
-        })();
+        rollbackDispatch(db, assignmentId, taskId, Boolean(body.taskId));
       } catch (rollbackErr) {
         process.stderr.write(
           `[api] rollback after spawn-failure failed: ${(rollbackErr as Error).message}\n`

--- a/src/surface/mc/db/assignments.ts
+++ b/src/surface/mc/db/assignments.ts
@@ -304,6 +304,45 @@ export function mostActiveAgent(db: Database): MostActiveAgent | null {
   };
 }
 
+// ---------------------------------------------------------------------------
+// S4 (#1518) — assignment mutations, lifted out of api/handlers.ts so
+// handlers stop knowing `agent_task_assignment` column names / state-enum
+// strings. Plain `db.query(...).run(...)` — no own `db.transaction` — so
+// callers can compose them inside a wider transaction (see e.g.
+// `handleCreateSession`, `handleHandoffAssignment`).
+// ---------------------------------------------------------------------------
+
+export interface CreateQueuedAssignmentParams {
+  id: string;
+  agentId: string;
+  taskId: string;
+}
+
+/**
+ * Insert a fresh `queued` assignment row. Shared by the dispatch path
+ * (`handleCreateSession`) and hand-off's new-assignment step
+ * (`handleHandoffAssignment`) — both mint an assignment that starts life
+ * in `queued`, to be driven through the state machine right after.
+ */
+export function createQueuedAssignment(
+  db: Database,
+  params: CreateQueuedAssignmentParams
+): void {
+  db.query(
+    `INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
+     VALUES (?, ?, ?, 'queued')`
+  ).run(params.id, params.agentId, params.taskId);
+}
+
+/**
+ * Delete an assignment row. Used by the dispatch-rollback paths (observed
+ * duplicate ccSessionId, spawn failure) that undo a just-inserted
+ * assignment — and by hand-off's own spawn-failure rollback.
+ */
+export function deleteAssignment(db: Database, id: string): void {
+  db.query(`DELETE FROM agent_task_assignment WHERE id = ?`).run(id);
+}
+
 // `normalizeSqliteDatetime` was lifted to `db/datetime.ts` per Echo's
 // PR #57 cycle-2 nit so `db/session-join.ts` can consume it without a
 // circular import back here. Re-exported for the existing call sites

--- a/src/surface/mc/db/tasks.ts
+++ b/src/surface/mc/db/tasks.ts
@@ -467,3 +467,118 @@ function hydrate(row: TaskRow, assignments: TaskAssignmentRow[]): TaskListItem {
     iteration,
   };
 }
+
+// ---------------------------------------------------------------------------
+// S4 (#1518) — task mutations, lifted out of api/handlers.ts so handlers
+// stop knowing `tasks` column names / status-enum strings. Each function is
+// a plain `db.query(...).run(...)` — no own `db.transaction` — so callers
+// can compose them inside a wider transaction (see e.g. `handleCreateSession`,
+// `handleCreateTask`).
+// ---------------------------------------------------------------------------
+
+export interface CreateInternalTaskParams {
+  id: string;
+  title: string;
+  priority: number;
+  principalId: string;
+}
+
+/**
+ * Insert an internal-source task (no GitHub ref, ungrouped). Used by the
+ * no-`taskId` branch of `POST /api/sessions` — a fresh task minted for a
+ * one-off dispatch.
+ */
+export function createInternalTask(
+  db: Database,
+  params: CreateInternalTaskParams
+): void {
+  db.query(
+    `INSERT INTO tasks (id, title, priority, principal_id, source_system)
+     VALUES (?, ?, ?, ?, 'internal')`
+  ).run(params.id, params.title, params.priority, params.principalId);
+}
+
+export interface CreateGithubImportedTaskParams {
+  id: string;
+  title: string;
+  priority: number;
+  principalId: string;
+  sourceUrl: string;
+  externalId: string;
+}
+
+/**
+ * Insert a GitHub-imported task (F-12b "add to queue"). Caller wraps this
+ * inside the same transaction as the shadow assignment/session + curation
+ * event inserts (see `handleCreateTask`).
+ */
+export function createGithubImportedTask(
+  db: Database,
+  params: CreateGithubImportedTaskParams
+): void {
+  db.query(
+    `INSERT INTO tasks
+       (id, title, priority, principal_id,
+        source_system, source_url, source_external_id)
+     VALUES (?, ?, ?, ?, 'github', ?, ?)`
+  ).run(
+    params.id,
+    params.title,
+    params.priority,
+    params.principalId,
+    params.sourceUrl,
+    params.externalId
+  );
+}
+
+export interface CreateTaskInIterationParams {
+  id: string;
+  title: string;
+  priority: number;
+  principalId: string;
+  iterationId: string;
+}
+
+/**
+ * Insert an internal-source task pre-attached to an iteration — the
+ * create-and-attach branch of `POST /api/iterations/:id/tasks`. Caller
+ * wraps this alongside `touchIteration` in one `db.transaction`.
+ */
+export function createTaskInIteration(
+  db: Database,
+  params: CreateTaskInIterationParams
+): void {
+  db.query(
+    `INSERT INTO tasks
+       (id, title, priority, principal_id, source_system, iteration_id)
+     VALUES (?, ?, ?, ?, 'internal', ?)`
+  ).run(
+    params.id,
+    params.title,
+    params.priority,
+    params.principalId,
+    params.iterationId
+  );
+}
+
+/**
+ * Delete a task row. Callers are responsible for clearing any FK-`RESTRICT`
+ * dependents (`agent_task_assignment.task_id`) first — used by the
+ * rollback paths in `handleCreateSession` that undo a just-inserted
+ * internal task after a same-transaction assignment/spawn failure.
+ */
+export function deleteTask(db: Database, id: string): void {
+  db.query(`DELETE FROM tasks WHERE id = ?`).run(id);
+}
+
+/**
+ * F-12/F-12b task-scope abandon — set `tasks.status = 'cancelled'`.
+ * Shared by `handleAbandonAssignment`'s task-scope branch and
+ * `handleAbandonTask` (the two call sites ran the byte-identical UPDATE
+ * statement before this extraction).
+ */
+export function cancelTask(db: Database, id: string): void {
+  db.query(
+    `UPDATE tasks SET status = 'cancelled', updated_at = unixepoch() WHERE id = ?`
+  ).run(id);
+}


### PR DESCRIPTION
## Summary

Moves the inline SQL mutation statements in `src/surface/mc/api/handlers.ts` (INSERT/UPDATE/DELETE against `tasks` and `agent_task_assignment`) behind domain-named functions in `src/surface/mc/db/tasks.ts` and `src/surface/mc/db/assignments.ts`. Handlers keep request parsing / validation / response shaping; the db layer now owns the SQL, `unixepoch()` timestamps, and status-enum strings — matching the existing read-side style (`db/tasks.ts`, `db/assignments.ts`, `db/sessions.ts`).

**Functions added:**

`db/tasks.ts`:
- `createInternalTask` — internal-source, ungrouped task (the no-`taskId` branch of `POST /api/sessions`)
- `createGithubImportedTask` — GitHub-sourced task with `source_url`/`source_external_id` (F-12b `POST /api/tasks`)
- `createTaskInIteration` — internal-source task pre-attached to an iteration (`POST /api/iterations/:id/tasks` create-and-attach branch)
- `deleteTask` — used by the two rollback paths in `handleCreateSession`
- `cancelTask` — `UPDATE tasks SET status='cancelled', updated_at=unixepoch()`, shared by `handleAbandonAssignment`'s task-scope branch and `handleAbandonTask` (these two call sites ran the byte-identical statement before this extraction — confirmed identical, not a hidden bug)

`db/assignments.ts`:
- `createQueuedAssignment` — insert a fresh `queued` assignment row, shared by the dispatch path (`handleCreateSession`) and hand-off's new-assignment step (`handleHandoffAssignment`)
- `deleteAssignment` — used by three rollback paths (observed-dup, spawn-failure x2)

`ensureDefaultAgent` (the one remaining inline `INSERT INTO agents`) now calls the existing `ensureAgentRow` helper instead of raw SQL, matching the pattern `ensureNamedAgent` already used.

None of the new functions open their own `db.transaction()` — they're plain `db.query(...).run(...)`, so callers keep composing them inside the same transactions the handlers already used.

## Out of scope (intentional, flagging so review doesn't need to chase these)

- Read-side query functions in `db/tasks.ts` / `db/assignments.ts` are untouched — this PR is write-half only per the S4 slice scope.
- `db/schema.ts` / migrations are untouched.
- One pre-existing, unrelated test flake was observed on a full-suite run: `src/common/config/__tests__/watcher.test.ts` (fs-watch polling, the test file's own comment notes it's "racy on loaded CI"). Passes cleanly in isolation; the file is nowhere near this change (`src/common/config/` vs. `src/surface/mc/`).

## Gate results

- `bunx tsc --noEmit` -> exit 0
- `bun run lint:errors` -> exit 0
- `bun test src/surface/mc` -> 2170 pass, 1 skip, 0 fail (154 files)
- `bun test` (full suite) -> 8880 pass, 8 skip, 8 todo, 2 fail -- both failures are the pre-existing `watcher.test.ts` flake above (verified passing in isolation, `bun test src/common/config/__tests__/watcher.test.ts` -> 4 pass, 0 fail)
- No-stragglers grep (`INSERT INTO`/`UPDATE `/`DELETE FROM` in `api/handlers.ts`) -> 0 executable mutation statements remain (one plain-text comment mentioning "UPDATE" is untouched, as expected)

Closes #1518

Generated with Claude Code
