### PR TITLE
refactor(runner): S7 — startCortex lane 1: wireReviewConsumers

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -77,11 +77,7 @@ import {
   buildCapabilityRegisteredEnvelope,
   type CapabilityRegistryEntry,
 } from "./bus";
-import {
-  ReviewConsumer,
-  type ReviewConsumerAgent,
-  type SignatureVerifier,
-} from "./bus/review-consumer";
+import { ReviewConsumer } from "./bus/review-consumer";
 import {
   BrainConsumer,
   buildBrainTaskPayload,
@@ -100,6 +96,7 @@ import { GateReplyRouter } from "./bus/gate-reply-router";
 import { makeExecBrainRunner } from "./brain/exec-brain-runner";
 import { DaemonBrainHost } from "./brain/daemon-brain-host";
 import { wireDevConsumers } from "./runner/dev-consumer-boot";
+import { wireReviewConsumers } from "./runner/review-consumer-boot";
 import {
   ReleaseConsumer,
   type ReleaseConsumerAgent,
@@ -109,15 +106,9 @@ import {
   provisionReviewConsumer,
 } from "./bus/jetstream/provision";
 import { reviewScopePatterns, REVIEW_OFFER_TASK_SUFFIX } from "./bus/jetstream/review-subjects";
-import {
-  verifySignedByChain,
-  nkeyToBase64Pubkey,
-} from "./bus/verify-signed-by-chain";
+import { nkeyToBase64Pubkey } from "./bus/verify-signed-by-chain";
 import { bootVerifierSelfCheck } from "./bus/verifier-self-check";
-import { CCSession, type CCSessionOpts } from "./runner/cc-session";
-import { makeSageReviewRunner } from "./runner/sage-runner";
-import { resolveReviewEngine } from "./runner/review-engine";
-import { runReviewPipeline } from "./runner/review-pipeline";
+import { type CCSessionOpts } from "./runner/cc-session";
 import {
   resolveOffering,
   offeringSubjectPatterns,
@@ -129,12 +120,7 @@ import type { GateFloorContext, GateFloorDecision } from "./bus/gate-floor";
 // (M1/M2/M4/M6). Composed per offer-scope by `co7-review-hardening`; every
 // helper short-circuits to the pre-CO-7 behaviour on `local` scope, so a stack
 // with no `policy.offerings` wires byte-identically to today.
-import {
-  reviewPromptForScope,
-  reviewSessionOptsForScope,
-  resolveComplianceOk,
-} from "./runner/co7-review-hardening";
-import { withCo7EgressGuard } from "./runner/co7-egress-pipeline";
+import { resolveComplianceOk } from "./runner/co7-review-hardening";
 import {
   getSignedByChain,
   type Envelope,
@@ -2098,492 +2084,38 @@ export async function startCortex(
     // ── /B-3 provision BRAIN_TASKS ──────────────────────────────────────────
   }
 
-  // B-0 (cortex#1021) — the per-agent review-consumer construction, lifted out
-  // of the boot loop into a reusable closure so the agents.d/ hot-reload path
-  // (below) can START a newly-ADDED agent's consumers through the SAME
-  // construction it uses at boot — no duplicated wiring. It captures every
-  // boot-scoped dependency it needs (trustResolver, signingKnobs, signer,
-  // resolvedPolicy, derivedStack, reviewJsm, the offering/federation patterns,
-  // systemEventSource, the reviewConsumers array, …) by closure; nothing new is
-  // threaded as a parameter. Pushes the consumers it creates onto
+  // S7 (epic #1514, cortex#1521) — the per-agent review-consumer
+  // construction now lives in `wireReviewConsumers` (review-consumer-boot.ts),
+  // extracted from the ~475-line inline closure that used to live here. Same
+  // motivation as before the move: the agents.d/ hot-reload path (below) START
+  // a newly-ADDED agent's consumers through the SAME construction boot uses —
+  // no duplicated wiring. `startForAgent` pushes the consumers it creates onto
   // `reviewConsumers[]` (the same array the shutdown drain walks), so a
   // hot-added agent's consumers drain on shutdown identically to a boot agent's.
-  const startReviewConsumersForAgent = async (agent: Agent): Promise<void> => {
-    try {
-      const caps = agent.runtime?.capabilities ?? [];
-      const consumerAgent: ReviewConsumerAgent = {
-        id: agent.id,
-        capabilities: caps,
-        ...(agent.runtime?.maxConcurrent !== undefined && {
-          maxConcurrent: agent.runtime.maxConcurrent,
-        }),
-        // Governance Stage 1b — the agent's declared model class feeds the
-        // consumer-side sovereignty gate. Absent → the gate fails closed for
-        // local-only tasks.
-        ...(agent.runtime?.modelClass !== undefined && {
-          modelClass: agent.runtime.modelClass,
-        }),
-      };
-      // cortex#327 follow-up (D1) — build the per-agent signature verifier
-      // closure when this agent declares a non-empty `trust:[]` list.
-      //
-      // **Default-ON, fail-open posture.** Agents with `trust: []` (the
-      // shape that says "I accept anything from anyone the runtime
-      // delivered") get NO verifier — the gate in `ReviewConsumer.processEnvelope`
-      // is a no-op, matching the pre-#329 behaviour. Agents with at least
-      // one trusted peer get the verifier wired and the gate enforces.
-      // This is the one-way ratchet: as principals add `trust:` entries
-      // to their cortex.yaml, signature enforcement strengthens
-      // automatically without any flag toggling.
-      //
-      // The closure captures `trustResolver`, `agent.id`, and the
-      // configured principalId — same triple the bus-peer harness
-      // (`src/substrates/bus-peer/harness.ts`) supplies to
-      // verifySignedByChain on its inbound path. `cryptoVerify: true`
-      // engages B.1c canonical-bytes verification on top of B.1a
-      // structural-trust resolution.
-      //
-      // Reason mapping: discriminated `ChainRejectionReason` → short
-      // grep-friendly string ("empty_chain", "signer_not_trusted",
-      // "crypto_verify_failed", etc.) so the structured stderr line
-      // landed in #329 carries the rejection class verbatim. The full
-      // myelin-side detail is logged separately by the trust resolver.
-      const agentTrustList = agent.trust;
-      const verifyPrincipalId = reviewPrincipalId;
-      const signatureVerifier: SignatureVerifier | undefined =
-        agentTrustList.length === 0
-          ? undefined
-          : async (envelope) => {
-              const r = await verifySignedByChain(envelope, {
-                resolver: trustResolver,
-                receivingAgentId: agent.id,
-                cryptoVerify: signingKnobs.cryptoVerify,
-                // TC-0 (#628) — posture-gated empty-chain rejection. `off`/
-                // `permissive` → `false` (verify but never reject empty
-                // adapter-originated chains); `enforce` → `true`. Pre-TC-0
-                // this relied on the `verifySignedByChain` default
-                // (`rejectEmpty: true`); the posture now sets it explicitly
-                // so seed-less / off stacks stay non-rejecting.
-                rejectEmpty: signingKnobs.rejectEmpty,
-                principalId: verifyPrincipalId,
-                // cortex#535 (TC-1a) — implicit own-stack trust, mirroring
-                // the bus-dispatch-listener wiring below. Pilot review-
-                // requests are signed with the STACK identity
-                // (`did:mf:<principal>-<stack>`), NOT an agent identity, so
-                // without `stackIdentity` the stack DID misses the cortex#480
-                // own-stack short-circuit and gets rejected as
-                // `principal_has_no_nkey_pub`. Thread the SAME conditional-
-                // spread options the dispatch-listener passes so self-signed
-                // review-requests verify cleanly instead of being dropped.
-                ...(signer !== undefined && { stackIdentity: signer.principal }),
-                ...(stackNKeyPubForVerifier !== undefined && {
-                  stackNKeyPub: stackNKeyPubForVerifier,
-                }),
-              });
-              if (r.valid) return { valid: true } as const;
-              return { valid: false, reason: r.reason.kind } as const;
-            };
-
-      // cortex#331 Phase 1 — substrate-aware pipelineRunner selection.
-      //
-      // **Why this lives in cortex (not sage).** Sage went in-process at
-      // sage#41 — its standalone launchd daemon and standalone NATS
-      // subscribe path are retired. Cortex's review-consumer is now the
-      // sole receiver for sage-owned review flavors.
-      //
-      // cortex#917 — the engine/model split. `resolveReviewEngine` reads
-      // `runtime.engine` (`sage` | `assistant`); the sage lens LLM is the
-      // orthogonal `runtime.model` (claude|codex|pi), NOT `substrate` (which is
-      // the M6 harness). `engine: sage` wires the sage lens-CLI runner,
-      // forwarding `model` to `sage review --substrate <model>`; `assistant`
-      // (and the legacy default) leaves `pipelineRunner` undefined so the
-      // ReviewConsumer falls through to `runReviewPipeline` → the Claude-Code
-      // SKILL.md path (`ccSessionFactory` stays wired for it). The resolver's
-      // legacy shim keeps pre-split `substrate: pi-dev` configs routing to sage
-      // (no forced model — SAGE_SUBSTRATE env still honoured).
-      //
-      // The sage runner resolves its binary lazily at first use (see
-      // `sage-runner.ts`'s lifetime note), so a missing sage on boot does not
-      // crash this loop — review requests surface the failure as
-      // `dispatch.task.failed` envelopes instead.
-      const { engine, model } = resolveReviewEngine(agent.runtime);
-      const pipelineRunner =
-        engine === "sage"
-          ? makeSageReviewRunner(model !== undefined ? { model } : {})
-          : undefined;
-
-      const reviewSessionOpts = buildReviewSessionOpts(config, agent);
-
-      // cortex#686 — shared construction options for the local + federated
-      // consumers. Both serve the SAME reviewer agent (same capabilities,
-      // verifier, substrate, prompt); they differ only in the `federated` flag
-      // (which flips verdict routing to the requester) and the subscription
-      // pattern/durable. Factored into a closure so the two consumers can't
-      // drift on the heavy CC-session / verifier / prompt wiring.
-      //
-      // CO-7 (epic cortex#939) — the closure is now SCOPE-AWARE. The `scope`
-      // argument (`local`/`federated`/`public`, derived from the bound subject
-      // prefix) selects the hardened M1 prompt + M2 least-privilege session +
-      // M4 egress-guarded pipeline for wider scopes. On `local` every helper
-      // short-circuits to the pre-CO-7 path (plain prompt, baseline opts, no
-      // egress wrap), so the local consumer is byte-identical to today.
-      const makeConsumer = (scope: OfferScope): ReviewConsumer => {
-        const federated = scope === "federated" || scope === "public";
-        // M1 — untrusted-content boundary prompt for wider scope; plain for local.
-        const scopedPromptBuilder = reviewPromptForScope(scope);
-        // M2 — least-privilege session lockdown for wider scope; baseline for local.
-        // `scratchDir` is left undefined here: the lockdown then fails CLOSED to
-        // "no dirs granted" (empty allowedDirs) for a wider-scope review rather
-        // than ever granting the principal's cwd to untrusted work. A per-review
-        // scratch dir is the F-5b follow-up's concern (the non-local backend
-        // owns the sandbox filesystem). For local, baseline opts (with their cwd)
-        // pass through unchanged.
-        const scopedSessionOpts = reviewSessionOptsForScope({
-          baseline: reviewSessionOpts,
-          scope,
-          agentId: agent.id,
-        });
-        // M4 — wrap the pipeline runner so a wider-scope review's free-text
-        // egress is leakage-scanned and a leak becomes `compliance_block`
-        // (the review is never posted). `local` returns the inner runner
-        // unchanged. The inner runner is the sage runner (if selected) or the
-        // default `runReviewPipeline` (passed `undefined` ⇒ the consumer's own
-        // default); we only override `pipelineRunner` when there is something to
-        // wrap (a non-local scope OR an explicit sage runner).
-        const baseRunner = pipelineRunner ?? runReviewPipeline;
-        const scopedPipelineRunner =
-          scope === "local"
-            ? pipelineRunner // undefined ⇒ consumer default; or the sage runner
-            : withCo7EgressGuard(scope, baseRunner);
-        return new ReviewConsumer({
-          agent: consumerAgent,
-          source: systemEventSource,
-          runtime,
-          // CC session factory — spawns a real `claude` process. Mirrors the
-          // default factory inside `ClaudeCodeHarness` (the harness keeps its
-          // own copy private; we don't re-export to avoid the symbol leaking
-          // into the public bus surface). Tests don't reach the factory
-          // unless `processEnvelope` is invoked; the boot test in
-          // `src/__tests__/cortex.review-consumer-boot.test.ts` only
-          // exercises instantiation + subscribe. Stays wired even when a
-          // non-CC pipelineRunner is selected — the consumer's type still
-          // requires the factory, and the CC path remains the default
-          // fallthrough for non-pi-dev substrates.
-          ccSessionFactory: (opts) => new CCSession(opts),
-          // PR-6 has no policy hook — that's a future PR (sovereignty /
-          // compliance gate). Until then the pipeline goes straight to CC.
-          // cortex#911 — the prompt now carries the verdict-block contract +
-          // post intent explicitly (`buildReviewPrompt`), not just bare intent.
-          // A thin persona used to review in prose and ask "Shall I post?",
-          // leaving the pipeline with no parseable block and nothing on the
-          // forge. Stating the contract in the prompt raises the floor on
-          // persona quality. Failure is asymmetric: a missing/malformed block
-          // drops only the verdict envelope (retryable), but a forge review,
-          // once posted, persists — see `buildReviewPrompt`'s docstring.
-          // Capability routing still happened on the subject
-          // (`tasks.code-review.*`).
-          // CO-7 M1 — scope-aware prompt builder (untrusted-content boundary for
-          // federated/public; plain trusted prompt for local — byte-identical).
-          promptBuilder: ({ payload }) => scopedPromptBuilder(payload),
-          // CO-7 M2 — scope-aware session opts (least-privilege lockdown for
-          // wider scope; baseline for local — byte-identical).
-          sessionOpts: scopedSessionOpts,
-          // CO-7 M4 — scope-aware pipeline runner (egress-guarded for wider
-          // scope; the sage runner or consumer default for local).
-          ...(scopedPipelineRunner !== undefined && {
-            pipelineRunner: scopedPipelineRunner,
-          }),
-          ...(signatureVerifier !== undefined && { signatureVerifier }),
-          // CO-2/CO-4 — the per-offer-scope admission gate. Inert on `local.`
-          // (byte-identical); gates the `federated.`/`public.` subjects this
-          // PR newly binds at their scope's floor before reviewer work.
-          offerAdmission: makeOfferAdmission("code-review"),
-          // cortex#686 — federated consumers route the verdict back to the
-          // requester's identity on the conformant `federated.{requester}.…`
-          // grammar (the cortex receiver that closes the cross-principal loop).
-          // The peer topology is passed so the consumer-path `peers[]` gate
-          // (ADR 0002 §5) can deny a non-peer requester BEFORE spawning the
-          // reviewer — defense-in-depth that, under `signing: off`, is the
-          // application-layer trust boundary on the consumer path.
-          ...(federated && {
-            federated: true,
-            federatedNetworks: resolvedPolicy?.federated?.networks ?? [],
-          }),
-        });
-      };
-
-      const consumer = makeConsumer("local");
-      reviewConsumers.push(consumer);
-      // Subscribe via the runtime's subscribePull helper. When the
-      // runtime is disabled the helper returns null inside start() and
-      // the consumer stays dormant — `started.subscribed` distinguishes
-      // the two cases so the boot log can be honest (cortex#334)
-      // instead of unconditionally claiming "ready".
-      const durable = `cortex-review-consumer-${reviewPrincipalId}-${agent.id}`;
-
-      // The durable's filter MUST match the subscription pattern this consumer
-      // binds (`consumer.start({ pattern })` below), or the durable claims every
-      // message on the stream — the cortex#1186 multi-durable fan-out that
-      // double-posts a review when an agent has >1 scope consumer (local +
-      // federated + …). `reviewOfferingPatterns[0]` is the local scope's
-      // pattern (CO-1 default = `reviewSubjectPattern`); hoisted here so it
-      // feeds BOTH the provision filter and the start pattern below.
-      const primaryReviewPattern = reviewOfferingPatterns[0] ?? reviewSubjectPattern;
-
-      // cortex#338 — provision the per-agent durable consumer up-front
-      // so `consumer.start()` below binds successfully against a virgin
-      // broker. Reuses `reviewJsm` resolved once before this loop.
-      // Idempotent — safe across restarts. Skipped when JSM isn't
-      // available (runtime dormant); the subsequent `consumer.start()`
-      // will then stay dormant too.
-      if (reviewJsm !== null) {
-        try {
-          const outcome = await provisionReviewConsumer({
-            jsm: reviewJsm,
-            stream: reviewStream,
-            durable,
-            filterSubject: primaryReviewPattern,
-            maxDeliver: reviewConsumerMaxDeliver,
-          });
-          if (outcome === "created") {
-            console.log(
-              `cortex: provisioned JetStream durable "${durable}" on stream "${reviewStream}"`,
-            );
-          } else if (outcome === "updated") {
-            console.log(
-              `cortex: reconciled JetStream durable "${durable}" ack_wait (cortex#422) on stream "${reviewStream}"`,
-            );
-          }
-        } catch (provisionErr) {
-          // Don't abort — let consumer.start surface the bind failure
-          // through its own error path so the principal sees the same
-          // stderr shape they'd see if the consumer existed but bind
-          // failed for another reason.
-          process.stderr.write(
-            `cortex: provisionReviewConsumer failed for "${durable}": ` +
-              `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
-          );
-        }
-      }
-
-      // CO-2 (cortex#941) — bind the Offer consumer on the scope prefixes the
-      // `code-review` offering admits. `reviewOfferingPatterns[0]` is the
-      // first admitted scope in canonical order (local → federated → public);
-      // for a `local`-only resolution (the CO-1 default) it is byte-identical
-      // to `reviewSubjectPattern`, so the primary `start()` below is unchanged.
-      // Any FURTHER patterns (federated/public, once CO-3 offers them wider)
-      // bind on a per-scope durable so each scope's traffic acks independently,
-      // mirroring the cortex#686/#725 federated-consumer idiom. With no
-      // offerings, `reviewOfferingPatterns` is exactly `[reviewSubjectPattern]`
-      // and this slice-loop is empty — zero added boot behaviour.
-      // (`primaryReviewPattern` is hoisted above so it also feeds the durable's
-      // `filterSubject` — cortex#1186.)
-      const started = await consumer.start({
-        pattern: primaryReviewPattern,
-        stream: reviewStream,
-        durable,
-      });
-      const flavorSummary =
-        consumer.flavors.length > 0 ? consumer.flavors.join(",") : "(none)";
-      // D1 visibility: surface whether signature verification is enforced
-      // on this consumer so principals can grep `signed=on/off` to confirm
-      // their trust:[] config landed where they expected.
-      const signedTag = signatureVerifier !== undefined ? "on" : "off";
-      // cortex#331 Phase 1 — surface the dispatching substrate so
-      // principals can grep `substrate=pi-dev` / `substrate=claude-code`
-      // to confirm sage agents (or any future substrate) actually
-      // received the substrate-aware factory. Unset substrate defaults
-      // to `claude-code` in the log (matches the runtime fallthrough).
-      //
-      // cortex#334 — distinguish "ready" (subscription open) from
-      // "DORMANT" (subscribePull returned null; G-1111 pending or
-      // nats.subjects empty). The previous unconditional "ready" line
-      // misled principals into chasing phantom misconfigs.
-      if (started.subscribed) {
-        console.log(
-          `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"}`,
-        );
-      } else {
-        console.log(
-          `cortex: review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)`,
-        );
-      }
-
-      // CO-2 (cortex#941) — bind the FURTHER offering scopes (federated/public)
-      // beyond the primary local one. Empty for the CO-1 default (`local`-only
-      // ⇒ `reviewOfferingPatterns` has length 1, so `.slice(1)` is empty ⇒ this
-      // loop never runs ⇒ byte-identical boot). Each extra scope binds on its
-      // OWN durable (scope token in the durable name) so the scopes ack
-      // independently, the same idiom as the cortex#686/#725 federated durables.
-      for (const extraPattern of reviewOfferingPatterns.slice(1)) {
-        const scopeToken = extraPattern.split(".", 1)[0] ?? "scope";
-        // MAJOR-1 fix (cortex#715 re-introduction): a `federated.`/`public.`
-        // offer-scope consumer MUST be constructed with `federated: true` so
-        // `ReviewConsumer.processEnvelope` decodes the REQUESTER from
-        // `originator.identity` and routes the verdict back cross-principal —
-        // `makeConsumer(false)` left `this.federated` unset, routing every
-        // verdict to SELF (the exact cortex#715 BLOCKER). `makeConsumer(true)`
-        // also wires `federatedNetworks` so the defense-in-depth `peers[]` gate
-        // runs. (`public` shares the federated verdict-routing path: a public
-        // requester reaches us through a surface but the verdict still routes to
-        // the relaying identity in `originator`, not self.)
-        // CO-7 — pass the actual offer-scope (not just a federated bool) so the
-        // consumer wires the scope-appropriate M1/M2/M4 hardening. A non-scope
-        // token (defensive) falls back to `public` — the STRICTEST hardening —
-        // never silently to local.
-        const offerScope: OfferScope =
-          scopeToken === "federated"
-            ? "federated"
-            : scopeToken === "public"
-              ? "public"
-              : "public";
-        const offerConsumer = makeConsumer(offerScope);
-        reviewConsumers.push(offerConsumer);
-        const offerDurable = `cortex-review-consumer-offer-${scopeToken}-${reviewPrincipalId}-${agent.id}`;
-        if (reviewJsm !== null) {
-          try {
-            const outcome = await provisionReviewConsumer({
-              jsm: reviewJsm,
-              stream: reviewStream,
-              durable: offerDurable,
-              // Filter to THIS offer scope's pattern so it doesn't claim the
-              // local/other-scope durables' traffic (cortex#1186 fan-out).
-              filterSubject: extraPattern,
-              maxDeliver: reviewConsumerMaxDeliver,
-            });
-            if (outcome === "created") {
-              console.log(
-                `cortex: provisioned JetStream durable "${offerDurable}" on stream "${reviewStream}"`,
-              );
-            } else if (outcome === "updated") {
-              console.log(
-                `cortex: reconciled JetStream durable "${offerDurable}" ack_wait (cortex#422) on stream "${reviewStream}"`,
-              );
-            }
-          } catch (provisionErr) {
-            process.stderr.write(
-              `cortex: provisionReviewConsumer failed for "${offerDurable}": ` +
-                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
-            );
-          }
-        }
-        const offerStarted = await offerConsumer.start({
-          pattern: extraPattern,
-          stream: reviewStream,
-          durable: offerDurable,
-        });
-        if (offerStarted.subscribed) {
-          console.log(
-            `cortex: review consumer (offer:${scopeToken}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} pattern=${extraPattern}`,
-          );
-        } else {
-          console.log(
-            `cortex: review consumer (offer:${scopeToken}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} — cortex MyelinRuntime subscriptions disabled (${extraPattern} envelopes will not be claimed by this consumer)`,
-          );
-        }
-      }
-
-      // cortex#686 (ADR 0001) — the FEDERATED review consumer. Subscribes this
-      // stack's OWN federated identity (`federated.{my-principal}.{my-stack}.
-      // tasks.code-review.>`) on the SAME CODE_REVIEW stream (its subject
-      // filter was extended above when federation is configured), via a
-      // SEPARATE durable so local + federated traffic ack independently. Routes
-      // the verdict back to the REQUESTER's identity (the `federated: true`
-      // flag). Only wired when a `federated:` policy block is declared — a
-      // non-federating deployment skips this entirely (back-compat).
-      if (federationConfigured) {
-        // cortex#686 + cortex#725 — wire BOTH federated consumers (Offer +
-        // Direct) for this agent. They share the `makeConsumer(true)`
-        // construction (same reviewer, verifier, peers gate, verdict-back) and
-        // the SAME CODE_REVIEW stream; they differ ONLY in the subscription
-        // pattern + the durable (so Offer and Direct traffic ack independently).
-        // Factored into a closure so the two can't drift on provisioning /
-        // start / log wiring.
-        const startFederatedConsumer = async (
-          mode: "offer" | "direct",
-          pattern: string,
-          durable: string,
-        ): Promise<void> => {
-          // CO-7 — the cortex#686/#725 federated-policy consumers bind on
-          // `federated.` subjects, so they wire the `federated`-scope M1/M2/M4
-          // hardening (untrusted-content boundary + least-privilege + egress
-          // guard) for cross-principal review requests.
-          const federatedConsumer = makeConsumer("federated");
-          reviewConsumers.push(federatedConsumer);
-          if (reviewJsm !== null) {
-            try {
-              const outcome = await provisionReviewConsumer({
-                jsm: reviewJsm,
-                stream: reviewStream,
-                durable,
-                // Filter to THIS federated consumer's `federated.…` pattern so
-                // it claims only cross-principal traffic, never the local
-                // durable's `local.…` requests (cortex#1186 fan-out).
-                filterSubject: pattern,
-                maxDeliver: reviewConsumerMaxDeliver,
-              });
-              if (outcome === "created") {
-                console.log(
-                  `cortex: provisioned JetStream durable "${durable}" on stream "${reviewStream}"`,
-                );
-              } else if (outcome === "updated") {
-                console.log(
-                  `cortex: reconciled JetStream durable "${durable}" ack_wait (cortex#422) on stream "${reviewStream}"`,
-                );
-              }
-            } catch (provisionErr) {
-              process.stderr.write(
-                `cortex: provisionReviewConsumer failed for "${durable}": ` +
-                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
-              );
-            }
-          }
-          const federatedStarted = await federatedConsumer.start({
-            pattern,
-            stream: reviewStream,
-            durable,
-          });
-          if (federatedStarted.subscribed) {
-            console.log(
-              `cortex: federated review consumer (${mode}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} pattern=${pattern}`,
-            );
-          } else {
-            console.log(
-              `cortex: federated review consumer (${mode}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
-            );
-          }
-        };
-
-        // cortex#686 (ADR 0001) — Offer: `federated.{me}.{stack}.tasks.code-review.>`.
-        await startFederatedConsumer(
-          "offer",
-          reviewFederatedSubjectPattern,
-          `cortex-review-consumer-federated-${reviewPrincipalId}-${agent.id}`,
-        );
-        // cortex#725 (ADR 0001/0002 §2) — Direct: this stack's OWN
-        // `federated.{me}.{stack}.tasks.@{did}.code-review.>` (the `@{did}` is
-        // the named reviewer/target-assistant). Routes the verdict back to the
-        // REQUESTER (from `originator.identity`) identically to the Offer path.
-        await startFederatedConsumer(
-          "direct",
-          reviewFederatedDirectSubjectPattern,
-          `cortex-review-consumer-federated-direct-${reviewPrincipalId}-${agent.id}`,
-        );
-      }
-    } catch (err) {
-      // Per CLAUDE.md: log every error. A single agent's consumer crash
-      // does NOT abort boot — siblings still get wired. Boot keeps the
-      // consumer in `reviewConsumers[]` so shutdown drain still calls
-      // `.stop()` (idempotent — handles the "never subscribed" case).
-      process.stderr.write(
-        `cortex: review consumer init failed for agent=${agent.id}: ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    }
-  };
+  const { startForAgent } = wireReviewConsumers({
+    reviewPrincipalId,
+    trustResolver,
+    signingKnobs,
+    ...(signer !== undefined && { signer }),
+    ...(stackNKeyPubForVerifier !== undefined && { stackNKeyPubForVerifier }),
+    systemEventSource,
+    runtime,
+    buildSessionOpts: (agent) => buildReviewSessionOpts(config, agent),
+    makeOfferAdmission,
+    federatedNetworks: resolvedPolicy?.federated?.networks ?? [],
+    reviewConsumers,
+    reviewOfferingPatterns,
+    reviewSubjectPattern,
+    reviewJsm,
+    reviewStream,
+    reviewConsumerMaxDeliver,
+    federationConfigured,
+    reviewFederatedSubjectPattern,
+    reviewFederatedDirectSubjectPattern,
+  });
 
   // Bot Packs B-1 (design-bot-packs.md §4, §6, §8) — start a BrainConsumer for
-  // an `exec`-brain agent. Mirrors `startReviewConsumersForAgent`'s shape: reads
+  // an `exec`-brain agent. Mirrors review-consumer-boot.ts's `startForAgent` shape: reads
   // the closure-captured boot state (runtime, systemEventSource, the
   // brainConsumers[] array the shutdown drain + reconcile walk), provisions the
   // per-capability JetStream durables, and binds the consumer. NEVER throws —
@@ -2982,9 +2514,9 @@ export async function startCortex(
   };
 
   // Boot: start review consumers for every code-review-capable agent. Same
-  // closure the hot-reload path calls for a newly-added agent.
+  // `startForAgent` the hot-reload path calls for a newly-added agent.
   for (const agent of reviewCapableAgents) {
-    await startReviewConsumersForAgent(agent);
+    await startForAgent(agent);
   }
   // Boot: start brain consumers for every exec-brain agent (B-1). Same closure
   // the hot-reload path calls for a newly-added exec-brain agent.
@@ -4883,7 +4415,7 @@ export async function startCortex(
   //      cortex.yaml agents still WIN on id conflict — design §6.1);
   //   2. swaps `agentRegistry` under a bumped `agentGeneration`;
   //   3. reconciles REVIEW CONSUMERS — an ADDED agent's consumers START via the
-  //      same `startReviewConsumersForAgent` boot uses; a REMOVED agent's
+  //      same `startForAgent` boot uses; a REMOVED agent's
   //      consumers DRAIN (`.stop()` lets in-flight finish) and leave
   //      `reviewConsumers[]`; a CHANGED agent is remove-then-add;
   //   4. reconciles the capability registry (Sage cortex#1027): re-publishes
@@ -5077,7 +4609,7 @@ export async function startCortex(
         const agent = freshById.get(id);
         if (agent === undefined) return;
         if (isReviewCapable(agent)) {
-          await startReviewConsumersForAgent(agent);
+          await startForAgent(agent);
         } else if (isBrainHosted(agent)) {
           await startBrainConsumersForAgent(agent);
         }

--- a/src/runner/__tests__/review-consumer-boot.test.ts
+++ b/src/runner/__tests__/review-consumer-boot.test.ts
@@ -1,0 +1,235 @@
+/**
+ * S7 (epic #1514, cortex#1521) — review-consumer boot-wiring tests.
+ *
+ * Unit-level coverage of `wireReviewConsumers` IN ISOLATION — no
+ * `startCortex`, no filesystem, no NATS, no `agents.d/` boot machinery.
+ * Assertions the pre-extraction inline closure never had at this grain:
+ * that `startForAgent` can be exercised directly against a fixture opts
+ * object, that it binds the expected subject pattern + durable via the
+ * runtime's `subscribePull`, and that it pushes onto the shared
+ * `reviewConsumers[]` array passed in (this module doesn't own that
+ * array's lifecycle — see the file header in `review-consumer-boot.ts`).
+ *
+ * The full `startCortex` integration coverage (multi-agent boot, CO-2
+ * offering scopes, ADR-0001 federation, dormancy, partial-failure
+ * isolation) lives in `src/__tests__/cortex.review-consumer-boot.test.ts`
+ * and continues to pass unchanged against this extraction — that file is
+ * the byte-identical-behaviour regression guard; this one is the new
+ * module's own unit contract.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  wireReviewConsumers,
+  type ReviewBootAgent,
+  type WireReviewConsumersOpts,
+} from "../review-consumer-boot";
+import { AgentRegistry } from "../../common/agents/registry";
+import { TrustResolver } from "../../common/agents/trust-resolver";
+import { resolveSigningKnobs } from "../../common/security-posture";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+  MyelinSubscribePullOpts,
+} from "../../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../../bus/myelin/subscriber";
+import { ReviewConsumer } from "../../bus/review-consumer";
+
+interface RecordingRuntime extends MyelinRuntime {
+  subscribePullCalls: MyelinSubscribePullOpts[];
+}
+
+/** Mirrors `cortex.review-consumer-boot.test.ts`'s recorder: records every
+ *  `subscribePull` invocation and hands back a synthetic subscriber whose
+ *  `ready` resolves immediately, so `consumer.start()` reports `subscribed: true`
+ *  without a real JetStream round-trip. */
+function fakeRuntime(): RecordingRuntime {
+  const handlers = new Set<EnvelopeHandler>();
+  const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+  return {
+    enabled: false,
+    subscribePullCalls,
+    onEnvelope(h) {
+      handlers.add(h);
+      return { unregister: () => handlers.delete(h) };
+    },
+    publish: async (_e: Envelope) => {},
+    stop: async () => {},
+    subscribePull: (opts: MyelinSubscribePullOpts): MyelinSubscriber => {
+      subscribePullCalls.push(opts);
+      // Cast through unknown — real MyelinSubscriber has private fields we
+      // deliberately don't synthesise; the test surface is the public
+      // lifecycle pair (pattern/ready/stop), same idiom as the cortex.ts
+      // boot test's recorder.
+      return {
+        pattern: opts.pattern,
+        ready: Promise.resolve(),
+        stop: async () => {},
+      } as unknown as MyelinSubscriber;
+    },
+  };
+}
+
+function baseOpts(overrides: Partial<WireReviewConsumersOpts> = {}): WireReviewConsumersOpts {
+  return {
+    reviewPrincipalId: "andreas",
+    trustResolver: new TrustResolver(AgentRegistry.fromAgents([])),
+    signingKnobs: resolveSigningKnobs("off"),
+    systemEventSource: { principal: "andreas", agent: "cortex", instance: "local" },
+    runtime: fakeRuntime(),
+    buildSessionOpts: () => ({}),
+    makeOfferAdmission: () => () => ({ admit: true }),
+    federatedNetworks: [],
+    reviewConsumers: [],
+    reviewOfferingPatterns: ["local.andreas.work.tasks.code-review.*"],
+    reviewSubjectPattern: "local.andreas.work.tasks.code-review.*",
+    reviewJsm: null,
+    reviewStream: "CODE_REVIEW",
+    reviewConsumerMaxDeliver: 5,
+    federationConfigured: false,
+    reviewFederatedSubjectPattern: "federated.andreas.work.tasks.code-review.>",
+    reviewFederatedDirectSubjectPattern: "federated.andreas.work.tasks.*.code-review.>",
+    ...overrides,
+  };
+}
+
+function agent(id: string, capabilities: readonly string[]): ReviewBootAgent {
+  return {
+    id,
+    displayName: id.charAt(0).toUpperCase() + id.slice(1),
+    trust: [],
+    runtime: { substrate: "claude-code", capabilities },
+  };
+}
+
+describe("wireReviewConsumers — local binding", () => {
+  test("startForAgent binds the local pattern/durable and pushes onto the shared reviewConsumers[]", async () => {
+    const runtime = fakeRuntime();
+    const reviewConsumers: ReviewConsumer[] = [];
+    const { startForAgent } = wireReviewConsumers(
+      baseOpts({ runtime, reviewConsumers }),
+    );
+
+    await startForAgent(agent("echo", ["code-review.typescript"]));
+
+    expect(reviewConsumers).toHaveLength(1);
+    expect(reviewConsumers[0]!.agent.id).toBe("echo");
+    expect(reviewConsumers[0]!.flavors).toEqual(["typescript"]);
+
+    expect(runtime.subscribePullCalls).toHaveLength(1);
+    expect(runtime.subscribePullCalls[0]!.pattern).toBe(
+      "local.andreas.work.tasks.code-review.*",
+    );
+    expect(runtime.subscribePullCalls[0]!.durable).toBe(
+      "cortex-review-consumer-andreas-echo",
+    );
+    expect(runtime.subscribePullCalls[0]!.stream).toBe("CODE_REVIEW");
+  });
+
+  test("dormant runtime (no subscribePull) → consumer still constructed, no throw", async () => {
+    const dormantRuntime: MyelinRuntime = {
+      enabled: false,
+      onEnvelope: () => ({ unregister: () => {} }),
+      publish: async () => {},
+      stop: async () => {},
+      // subscribePull omitted — ReviewConsumer.start() treats that the same
+      // as a `null` return (dormant), per the interface's additivity contract.
+    };
+    const reviewConsumers: ReviewConsumer[] = [];
+    const { startForAgent } = wireReviewConsumers(
+      baseOpts({ runtime: dormantRuntime, reviewConsumers }),
+    );
+
+    await startForAgent(agent("luna", ["code-review.security"]));
+
+    expect(reviewConsumers).toHaveLength(1);
+  });
+});
+
+describe("wireReviewConsumers — CO-2 offer-scope + ADR-0001 federation", () => {
+  test("a second offered scope binds an extra offer consumer on its own durable", async () => {
+    const runtime = fakeRuntime();
+    const reviewConsumers: ReviewConsumer[] = [];
+    const { startForAgent } = wireReviewConsumers(
+      baseOpts({
+        runtime,
+        reviewConsumers,
+        reviewOfferingPatterns: [
+          "local.andreas.work.tasks.code-review.*",
+          "federated.andreas.work.tasks.code-review.*",
+        ],
+      }),
+    );
+
+    await startForAgent(agent("echo", ["code-review.typescript"]));
+
+    // Local + one offer-scope consumer.
+    expect(reviewConsumers).toHaveLength(2);
+    const patterns = runtime.subscribePullCalls.map((c) => c.pattern);
+    expect(patterns).toContain("local.andreas.work.tasks.code-review.*");
+    expect(patterns).toContain("federated.andreas.work.tasks.code-review.*");
+    const durables = runtime.subscribePullCalls.map((c) => c.durable);
+    expect(durables.some((d) => d.includes("offer-federated"))).toBe(true);
+  });
+
+  test("federationConfigured → federated Offer + Direct consumers also bound", async () => {
+    const runtime = fakeRuntime();
+    const reviewConsumers: ReviewConsumer[] = [];
+    const { startForAgent } = wireReviewConsumers(
+      baseOpts({ runtime, reviewConsumers, federationConfigured: true }),
+    );
+
+    await startForAgent(agent("echo", ["code-review.typescript"]));
+
+    // Local + federated Offer + federated Direct = 3 consumers.
+    expect(reviewConsumers).toHaveLength(3);
+    const patterns = runtime.subscribePullCalls.map((c) => c.pattern);
+    expect(patterns).toContain("federated.andreas.work.tasks.code-review.>");
+    expect(patterns).toContain("federated.andreas.work.tasks.*.code-review.>");
+    const durables = runtime.subscribePullCalls.map((c) => c.durable);
+    expect(
+      durables.some((d) => d === "cortex-review-consumer-federated-andreas-echo"),
+    ).toBe(true);
+    expect(
+      durables.some(
+        (d) => d === "cortex-review-consumer-federated-direct-andreas-echo",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("wireReviewConsumers — per-agent failure isolation", () => {
+  test("a synchronous failure inside startForAgent is caught and logged, not thrown", async () => {
+    const reviewConsumers: ReviewConsumer[] = [];
+    const { startForAgent } = wireReviewConsumers(
+      baseOpts({
+        reviewConsumers,
+        buildSessionOpts: () => {
+          throw new Error("synthetic buildSessionOpts failure");
+        },
+      }),
+    );
+
+    const original = process.stderr.write.bind(process.stderr);
+    let stderr = "";
+    process.stderr.write = (chunk: unknown): boolean => {
+      stderr += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    };
+    try {
+      // Per CLAUDE.md "no empty catch blocks" — the wiring never rejects;
+      // it logs and moves on so sibling agents still wire (cortex.ts's
+      // `for (const agent of reviewCapableAgents)` boot loop depends on this).
+      await expect(startForAgent(agent("echo", ["code-review.typescript"]))).resolves.toBeUndefined();
+    } finally {
+      process.stderr.write = original;
+    }
+
+    expect(stderr).toContain("review consumer init failed");
+    expect(stderr).toContain("agent=echo");
+    expect(stderr).toContain("synthetic buildSessionOpts failure");
+    // The failure happened before `makeConsumer`/`.push()` ran.
+    expect(reviewConsumers).toHaveLength(0);
+  });
+});

--- a/src/runner/review-consumer-boot.ts
+++ b/src/runner/review-consumer-boot.ts
@@ -1,0 +1,646 @@
+/**
+ * S7 (epic #1514, plan §2, cortex#1521) — boot wiring for the per-agent
+ * review-consumer construction, extracted from the ~475-line
+ * `startReviewConsumersForAgent` closure that used to live inline in
+ * `src/cortex.ts` (B-0, cortex#1021). Shaped after `dev-consumer-boot.ts`:
+ * a narrow structural `*BootAgent` projection + a `WireXConsumersOpts`
+ * interface that lists every boot-scoped value the wiring needs, so the
+ * construction is unit-testable without standing up `startCortex`.
+ *
+ * **Different shape than `wireDevConsumers` — and why.** `wireDevConsumers`
+ * builds every dev-capable agent's consumer ONCE and returns the finished
+ * list; `cortex.ts` starts them. The review lane can't follow that shape
+ * byte-for-byte: `cortex.ts` calls this construction TWICE — once in the
+ * boot loop over `reviewCapableAgents`, and again from the `agents.d/`
+ * hot-reload path for each added/changed agent (§B-0 design §7/§11) — and
+ * the construction itself does the provisioning + `consumer.start()` +
+ * boot-log inline (the review lane never separates "build" from "start"
+ * the way the dev lane does). So `wireReviewConsumers` returns a callable,
+ * `startForAgent`, that `cortex.ts` invokes per agent at both sites,
+ * exactly where `startReviewConsumersForAgent(agent)` used to be called.
+ *
+ * **No dormancy filter here.** Unlike `wireDevConsumers` (which filters
+ * `agents` itself), the capability filter (`code-review`/`code-review.*`)
+ * stays in `cortex.ts` — both call sites only ever invoke `startForAgent`
+ * for an agent already known to be review-capable
+ * (`reviewCapableAgents`/`isReviewCapable`). This module has nothing to
+ * decide about eligibility; it only builds + subscribes.
+ *
+ * **`opts.reviewConsumers` is a shared, NOT owned, array.** `cortex.ts`
+ * still declares `const reviewConsumers: ReviewConsumer[] = []` and reads
+ * it for the hot-reload diff (`drainConsumersForAgent`) and the shutdown
+ * drain — both well outside this slice's scope. `startForAgent` pushes
+ * onto the SAME array reference (passed once as an opts field), so those
+ * call sites keep seeing every consumer this module wires, unchanged.
+ *
+ * **Free-variable capture — no mutable-capture threading needed.** Every
+ * value `WireReviewConsumersOpts` carries is a plain snapshot, not a
+ * getter/setter pair, because none of the captured `cortex.ts` `let`s are
+ * reassigned after `wireReviewConsumers` is constructed (boot-time, right
+ * where the old closure used to be defined) and before either call site
+ * runs: `signer` (cortex.ts, assigned once near boot-time signer setup)
+ * and `stackNKeyPubForVerifier` (assigned once alongside it) both settle
+ * before the first `startForAgent` call; `runtime` (also a `let`) is
+ * assigned once from either `options.injectRuntime` or
+ * `startMyelinRuntime(...)`, likewise before either call site. The old
+ * closure only ever READ these — it never reassigned any of them — so a
+ * plain value capture at construction time is behaviourally identical to
+ * the inline closure's live-binding read.
+ */
+
+import { CCSession, type CCSessionOpts } from "./cc-session";
+import { withCo7EgressGuard } from "./co7-egress-pipeline";
+import {
+  reviewPromptForScope,
+  reviewSessionOptsForScope,
+} from "./co7-review-hardening";
+import { resolveReviewEngine, type ReviewEngineInput } from "./review-engine";
+import { runReviewPipeline } from "./review-pipeline";
+import { makeSageReviewRunner } from "./sage-runner";
+import {
+  ReviewConsumer,
+  type ReviewConsumerAgent,
+  type SignatureVerifier,
+} from "../bus/review-consumer";
+import { provisionReviewConsumer, type ProvisionJsm } from "../bus/jetstream/provision";
+import { verifySignedByChain } from "../bus/verify-signed-by-chain";
+import type { SystemEventSource } from "../bus/system-events";
+import type { BusEnvelopeSigner, MyelinRuntime } from "../bus/myelin/runtime";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { GateFloorDecision } from "../bus/gate-floor";
+import type { OfferScope } from "../common/types/offering";
+import type { TrustResolver } from "../common/agents/trust-resolver";
+import type { ResolvedSigningKnobs } from "../common/security-posture";
+import type { PolicyFederatedNetwork } from "../common/types/cortex-config";
+import type { AgentModelClass } from "../bus/sovereignty-gate";
+
+// ---------------------------------------------------------------------------
+// The narrow agent shape the boot wiring consumes
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal projection of a cortex.yaml `Agent` the review boot wiring needs
+ * — structural (not the full Zod `Agent`) so `cortex.ts` passes
+ * `mergedAgents`/hot-reload agents without a cast, mirroring
+ * `DevBootAgent`. `runtime` intersects {@link ReviewEngineInput} because
+ * `resolveReviewEngine(agent.runtime)` is called directly (unlike the dev
+ * lane, which never reads engine/model/substrate).
+ */
+export interface ReviewBootAgent {
+  id: string;
+  displayName: string;
+  /** Peer agent ids this agent trusts — drives the per-agent signature verifier. */
+  trust: readonly string[];
+  runtime?: ReviewEngineInput & {
+    capabilities?: readonly string[];
+    maxConcurrent?: number;
+    /** Governance Stage 1b — feeds the consumer-side sovereignty gate. */
+    modelClass?: AgentModelClass;
+  };
+}
+
+/** Inputs `cortex.ts` threads into the review-consumer boot wiring. */
+export interface WireReviewConsumersOpts {
+  /** `{principal}` subject segment — durable names + the verifier's own-stack check. */
+  reviewPrincipalId: string;
+  /** B.1a structural-trust resolver backing the per-agent signature verifier. */
+  trustResolver: TrustResolver;
+  /** `security.signing` posture knobs — `cryptoVerify` + `rejectEmpty` are read. */
+  signingKnobs: ResolvedSigningKnobs;
+  /** This stack's own envelope signer, when attached — feeds the verifier's own-stack short-circuit. */
+  signer?: BusEnvelopeSigner;
+  /** This stack's NKey pubkey, for the same own-stack short-circuit. */
+  stackNKeyPubForVerifier?: string;
+  /** Bus-side event source every consumer publishes lifecycle/verdict envelopes through. */
+  systemEventSource: SystemEventSource;
+  /** The (possibly dormant) MyelinRuntime the consumer subscribes against. */
+  runtime: MyelinRuntime;
+  /**
+   * §3 review-session opts, pre-curried with `config` + `process.cwd()` by
+   * the caller (`buildReviewSessionOpts` stays exported from `cortex.ts`
+   * — this module doesn't import it, avoiding a `cortex.ts` ⇄
+   * `review-consumer-boot.ts` cycle).
+   */
+  buildSessionOpts: (agent: ReviewBootAgent) => Partial<Omit<CCSessionOpts, "prompt">>;
+  /** CO-2/CO-4 per-offer-scope admission gate factory, keyed by capability id. */
+  makeOfferAdmission: (
+    capability: string,
+  ) => (envelope: Envelope, subject: string) => GateFloorDecision;
+  /** cortex#686 federation roster (`policy.federated.networks`) for the federated consumer's `peers[]` gate. */
+  federatedNetworks: readonly PolicyFederatedNetwork[];
+  /**
+   * Shared consumer array — the SAME array `cortex.ts` owns for its
+   * hot-reload diff (`drainConsumersForAgent`) and shutdown drain. This
+   * module pushes onto it; it does not own the array's lifecycle.
+   */
+  reviewConsumers: ReviewConsumer[];
+  /** CO-2 offer-scope Offer patterns (`[reviewSubjectPattern]` for the local-only default). */
+  reviewOfferingPatterns: readonly string[];
+  /** The primary local subject pattern — the `reviewOfferingPatterns[0]` fallback. */
+  reviewSubjectPattern: string;
+  /** Resolved JetStream manager, or `null` when the runtime is dormant. */
+  reviewJsm: ProvisionJsm | null;
+  /** CODE_REVIEW stream name. */
+  reviewStream: string;
+  /** Durable max-deliver, shared with the release/brain lanes. */
+  reviewConsumerMaxDeliver: number;
+  /** Whether a `policy.federated` block is declared — gates the ADR-0001 federated consumers. */
+  federationConfigured: boolean;
+  /** cortex#686 (ADR 0001) federated Offer pattern. */
+  reviewFederatedSubjectPattern: string;
+  /** cortex#725 (ADR 0001/0002 §2) federated Direct pattern. */
+  reviewFederatedDirectSubjectPattern: string;
+}
+
+/** The callable `cortex.ts` invokes per agent, at both the boot loop and the `agents.d/` hot-reload sites. */
+export interface WiredReviewConsumers {
+  startForAgent: (agent: ReviewBootAgent) => Promise<void>;
+}
+
+/**
+ * Build the per-agent review-consumer construction. Returns `startForAgent`
+ * — the same construction the boot loop (over `reviewCapableAgents`) and
+ * the `agents.d/` hot-reload path (for an added/changed agent) both call,
+ * so a hot-added agent's consumers start identically to a boot agent's.
+ * Never throws: a single agent's consumer-init failure is caught and
+ * logged so siblings still wire (mirrors the pre-extraction closure).
+ */
+export function wireReviewConsumers(
+  opts: WireReviewConsumersOpts,
+): WiredReviewConsumers {
+  const startForAgent = async (agent: ReviewBootAgent): Promise<void> => {
+    try {
+      const caps = agent.runtime?.capabilities ?? [];
+      const consumerAgent: ReviewConsumerAgent = {
+        id: agent.id,
+        capabilities: caps,
+        ...(agent.runtime?.maxConcurrent !== undefined && {
+          maxConcurrent: agent.runtime.maxConcurrent,
+        }),
+        // Governance Stage 1b — the agent's declared model class feeds the
+        // consumer-side sovereignty gate. Absent → the gate fails closed for
+        // local-only tasks.
+        ...(agent.runtime?.modelClass !== undefined && {
+          modelClass: agent.runtime.modelClass,
+        }),
+      };
+      // cortex#327 follow-up (D1) — build the per-agent signature verifier
+      // closure when this agent declares a non-empty `trust:[]` list.
+      //
+      // **Default-ON, fail-open posture.** Agents with `trust: []` (the
+      // shape that says "I accept anything from anyone the runtime
+      // delivered") get NO verifier — the gate in `ReviewConsumer.processEnvelope`
+      // is a no-op, matching the pre-#329 behaviour. Agents with at least
+      // one trusted peer get the verifier wired and the gate enforces.
+      // This is the one-way ratchet: as principals add `trust:` entries
+      // to their cortex.yaml, signature enforcement strengthens
+      // automatically without any flag toggling.
+      //
+      // The closure captures `trustResolver`, `agent.id`, and the
+      // configured principalId — same triple the bus-peer harness
+      // (`src/substrates/bus-peer/harness.ts`) supplies to
+      // verifySignedByChain on its inbound path. `cryptoVerify: true`
+      // engages B.1c canonical-bytes verification on top of B.1a
+      // structural-trust resolution.
+      //
+      // Reason mapping: discriminated `ChainRejectionReason` → short
+      // grep-friendly string ("empty_chain", "signer_not_trusted",
+      // "crypto_verify_failed", etc.) so the structured stderr line
+      // landed in #329 carries the rejection class verbatim. The full
+      // myelin-side detail is logged separately by the trust resolver.
+      const agentTrustList = agent.trust;
+      const verifyPrincipalId = opts.reviewPrincipalId;
+      const signatureVerifier: SignatureVerifier | undefined =
+        agentTrustList.length === 0
+          ? undefined
+          : async (envelope) => {
+              const r = await verifySignedByChain(envelope, {
+                resolver: opts.trustResolver,
+                receivingAgentId: agent.id,
+                cryptoVerify: opts.signingKnobs.cryptoVerify,
+                // TC-0 (#628) — posture-gated empty-chain rejection. `off`/
+                // `permissive` → `false` (verify but never reject empty
+                // adapter-originated chains); `enforce` → `true`. Pre-TC-0
+                // this relied on the `verifySignedByChain` default
+                // (`rejectEmpty: true`); the posture now sets it explicitly
+                // so seed-less / off stacks stay non-rejecting.
+                rejectEmpty: opts.signingKnobs.rejectEmpty,
+                principalId: verifyPrincipalId,
+                // cortex#535 (TC-1a) — implicit own-stack trust, mirroring
+                // the bus-dispatch-listener wiring below. Pilot review-
+                // requests are signed with the STACK identity
+                // (`did:mf:<principal>-<stack>`), NOT an agent identity, so
+                // without `stackIdentity` the stack DID misses the cortex#480
+                // own-stack short-circuit and gets rejected as
+                // `principal_has_no_nkey_pub`. Thread the SAME conditional-
+                // spread options the dispatch-listener passes so self-signed
+                // review-requests verify cleanly instead of being dropped.
+                ...(opts.signer !== undefined && { stackIdentity: opts.signer.principal }),
+                ...(opts.stackNKeyPubForVerifier !== undefined && {
+                  stackNKeyPub: opts.stackNKeyPubForVerifier,
+                }),
+              });
+              if (r.valid) return { valid: true } as const;
+              return { valid: false, reason: r.reason.kind } as const;
+            };
+
+      // cortex#331 Phase 1 — substrate-aware pipelineRunner selection.
+      //
+      // **Why this lives in cortex (not sage).** Sage went in-process at
+      // sage#41 — its standalone launchd daemon and standalone NATS
+      // subscribe path are retired. Cortex's review-consumer is now the
+      // sole receiver for sage-owned review flavors.
+      //
+      // cortex#917 — the engine/model split. `resolveReviewEngine` reads
+      // `runtime.engine` (`sage` | `assistant`); the sage lens LLM is the
+      // orthogonal `runtime.model` (claude|codex|pi), NOT `substrate` (which is
+      // the M6 harness). `engine: sage` wires the sage lens-CLI runner,
+      // forwarding `model` to `sage review --substrate <model>`; `assistant`
+      // (and the legacy default) leaves `pipelineRunner` undefined so the
+      // ReviewConsumer falls through to `runReviewPipeline` → the Claude-Code
+      // SKILL.md path (`ccSessionFactory` stays wired for it). The resolver's
+      // legacy shim keeps pre-split `substrate: pi-dev` configs routing to sage
+      // (no forced model — SAGE_SUBSTRATE env still honoured).
+      //
+      // The sage runner resolves its binary lazily at first use (see
+      // `sage-runner.ts`'s lifetime note), so a missing sage on boot does not
+      // crash this loop — review requests surface the failure as
+      // `dispatch.task.failed` envelopes instead.
+      const { engine, model } = resolveReviewEngine(agent.runtime);
+      const pipelineRunner =
+        engine === "sage"
+          ? makeSageReviewRunner(model !== undefined ? { model } : {})
+          : undefined;
+
+      const reviewSessionOpts = opts.buildSessionOpts(agent);
+
+      // cortex#686 — shared construction options for the local + federated
+      // consumers. Both serve the SAME reviewer agent (same capabilities,
+      // verifier, substrate, prompt); they differ only in the `federated` flag
+      // (which flips verdict routing to the requester) and the subscription
+      // pattern/durable. Factored into a closure so the two consumers can't
+      // drift on the heavy CC-session / verifier / prompt wiring.
+      //
+      // CO-7 (epic cortex#939) — the closure is now SCOPE-AWARE. The `scope`
+      // argument (`local`/`federated`/`public`, derived from the bound subject
+      // prefix) selects the hardened M1 prompt + M2 least-privilege session +
+      // M4 egress-guarded pipeline for wider scopes. On `local` every helper
+      // short-circuits to the pre-CO-7 path (plain prompt, baseline opts, no
+      // egress wrap), so the local consumer is byte-identical to today.
+      const makeConsumer = (scope: OfferScope): ReviewConsumer => {
+        const federated = scope === "federated" || scope === "public";
+        // M1 — untrusted-content boundary prompt for wider scope; plain for local.
+        const scopedPromptBuilder = reviewPromptForScope(scope);
+        // M2 — least-privilege session lockdown for wider scope; baseline for local.
+        // `scratchDir` is left undefined here: the lockdown then fails CLOSED to
+        // "no dirs granted" (empty allowedDirs) for a wider-scope review rather
+        // than ever granting the principal's cwd to untrusted work. A per-review
+        // scratch dir is the F-5b follow-up's concern (the non-local backend
+        // owns the sandbox filesystem). For local, baseline opts (with their cwd)
+        // pass through unchanged.
+        const scopedSessionOpts = reviewSessionOptsForScope({
+          baseline: reviewSessionOpts,
+          scope,
+          agentId: agent.id,
+        });
+        // M4 — wrap the pipeline runner so a wider-scope review's free-text
+        // egress is leakage-scanned and a leak becomes `compliance_block`
+        // (the review is never posted). `local` returns the inner runner
+        // unchanged. The inner runner is the sage runner (if selected) or the
+        // default `runReviewPipeline` (passed `undefined` ⇒ the consumer's own
+        // default); we only override `pipelineRunner` when there is something to
+        // wrap (a non-local scope OR an explicit sage runner).
+        const baseRunner = pipelineRunner ?? runReviewPipeline;
+        const scopedPipelineRunner =
+          scope === "local"
+            ? pipelineRunner // undefined ⇒ consumer default; or the sage runner
+            : withCo7EgressGuard(scope, baseRunner);
+        return new ReviewConsumer({
+          agent: consumerAgent,
+          source: opts.systemEventSource,
+          runtime: opts.runtime,
+          // CC session factory — spawns a real `claude` process. Mirrors the
+          // default factory inside `ClaudeCodeHarness` (the harness keeps its
+          // own copy private; we don't re-export to avoid the symbol leaking
+          // into the public bus surface). Tests don't reach the factory
+          // unless `processEnvelope` is invoked; the boot test in
+          // `src/__tests__/cortex.review-consumer-boot.test.ts` only
+          // exercises instantiation + subscribe. Stays wired even when a
+          // non-CC pipelineRunner is selected — the consumer's type still
+          // requires the factory, and the CC path remains the default
+          // fallthrough for non-pi-dev substrates.
+          ccSessionFactory: (o) => new CCSession(o),
+          // PR-6 has no policy hook — that's a future PR (sovereignty /
+          // compliance gate). Until then the pipeline goes straight to CC.
+          // cortex#911 — the prompt now carries the verdict-block contract +
+          // post intent explicitly (`buildReviewPrompt`), not just bare intent.
+          // A thin persona used to review in prose and ask "Shall I post?",
+          // leaving the pipeline with no parseable block and nothing on the
+          // forge. Stating the contract in the prompt raises the floor on
+          // persona quality. Failure is asymmetric: a missing/malformed block
+          // drops only the verdict envelope (retryable), but a forge review,
+          // once posted, persists — see `buildReviewPrompt`'s docstring.
+          // Capability routing still happened on the subject
+          // (`tasks.code-review.*`).
+          // CO-7 M1 — scope-aware prompt builder (untrusted-content boundary for
+          // federated/public; plain trusted prompt for local — byte-identical).
+          promptBuilder: ({ payload }) => scopedPromptBuilder(payload),
+          // CO-7 M2 — scope-aware session opts (least-privilege lockdown for
+          // wider scope; baseline for local — byte-identical).
+          sessionOpts: scopedSessionOpts,
+          // CO-7 M4 — scope-aware pipeline runner (egress-guarded for wider
+          // scope; the sage runner or consumer default for local).
+          ...(scopedPipelineRunner !== undefined && {
+            pipelineRunner: scopedPipelineRunner,
+          }),
+          ...(signatureVerifier !== undefined && { signatureVerifier }),
+          // CO-2/CO-4 — the per-offer-scope admission gate. Inert on `local.`
+          // (byte-identical); gates the `federated.`/`public.` subjects this
+          // PR newly binds at their scope's floor before reviewer work.
+          offerAdmission: opts.makeOfferAdmission("code-review"),
+          // cortex#686 — federated consumers route the verdict back to the
+          // requester's identity on the conformant `federated.{requester}.…`
+          // grammar (the cortex receiver that closes the cross-principal loop).
+          // The peer topology is passed so the consumer-path `peers[]` gate
+          // (ADR 0002 §5) can deny a non-peer requester BEFORE spawning the
+          // reviewer — defense-in-depth that, under `signing: off`, is the
+          // application-layer trust boundary on the consumer path.
+          ...(federated && {
+            federated: true,
+            federatedNetworks: opts.federatedNetworks,
+          }),
+        });
+      };
+
+      const consumer = makeConsumer("local");
+      opts.reviewConsumers.push(consumer);
+      // Subscribe via the runtime's subscribePull helper. When the
+      // runtime is disabled the helper returns null inside start() and
+      // the consumer stays dormant — `started.subscribed` distinguishes
+      // the two cases so the boot log can be honest (cortex#334)
+      // instead of unconditionally claiming "ready".
+      const durable = `cortex-review-consumer-${opts.reviewPrincipalId}-${agent.id}`;
+
+      // The durable's filter MUST match the subscription pattern this consumer
+      // binds (`consumer.start({ pattern })` below), or the durable claims every
+      // message on the stream — the cortex#1186 multi-durable fan-out that
+      // double-posts a review when an agent has >1 scope consumer (local +
+      // federated + …). `reviewOfferingPatterns[0]` is the local scope's
+      // pattern (CO-1 default = `reviewSubjectPattern`); hoisted here so it
+      // feeds BOTH the provision filter and the start pattern below.
+      const primaryReviewPattern = opts.reviewOfferingPatterns[0] ?? opts.reviewSubjectPattern;
+
+      // cortex#338 — provision the per-agent durable consumer up-front
+      // so `consumer.start()` below binds successfully against a virgin
+      // broker. Reuses `reviewJsm` resolved once before this loop.
+      // Idempotent — safe across restarts. Skipped when JSM isn't
+      // available (runtime dormant); the subsequent `consumer.start()`
+      // will then stay dormant too.
+      if (opts.reviewJsm !== null) {
+        try {
+          const outcome = await provisionReviewConsumer({
+            jsm: opts.reviewJsm,
+            stream: opts.reviewStream,
+            durable,
+            filterSubject: primaryReviewPattern,
+            maxDeliver: opts.reviewConsumerMaxDeliver,
+          });
+          if (outcome === "created") {
+            console.log(
+              `cortex: provisioned JetStream durable "${durable}" on stream "${opts.reviewStream}"`,
+            );
+          } else if (outcome === "updated") {
+            console.log(
+              `cortex: reconciled JetStream durable "${durable}" ack_wait (cortex#422) on stream "${opts.reviewStream}"`,
+            );
+          }
+        } catch (provisionErr) {
+          // Don't abort — let consumer.start surface the bind failure
+          // through its own error path so the principal sees the same
+          // stderr shape they'd see if the consumer existed but bind
+          // failed for another reason.
+          process.stderr.write(
+            `cortex: provisionReviewConsumer failed for "${durable}": ` +
+              `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+          );
+        }
+      }
+
+      // CO-2 (cortex#941) — bind the Offer consumer on the scope prefixes the
+      // `code-review` offering admits. `reviewOfferingPatterns[0]` is the
+      // first admitted scope in canonical order (local → federated → public);
+      // for a `local`-only resolution (the CO-1 default) it is byte-identical
+      // to `reviewSubjectPattern`, so the primary `start()` below is unchanged.
+      // Any FURTHER patterns (federated/public, once CO-3 offers them wider)
+      // bind on a per-scope durable so each scope's traffic acks independently,
+      // mirroring the cortex#686/#725 federated-consumer idiom. With no
+      // offerings, `reviewOfferingPatterns` is exactly `[reviewSubjectPattern]`
+      // and this slice-loop is empty — zero added boot behaviour.
+      // (`primaryReviewPattern` is hoisted above so it also feeds the durable's
+      // `filterSubject` — cortex#1186.)
+      const started = await consumer.start({
+        pattern: primaryReviewPattern,
+        stream: opts.reviewStream,
+        durable,
+      });
+      const flavorSummary =
+        consumer.flavors.length > 0 ? consumer.flavors.join(",") : "(none)";
+      // D1 visibility: surface whether signature verification is enforced
+      // on this consumer so principals can grep `signed=on/off` to confirm
+      // their trust:[] config landed where they expected.
+      const signedTag = signatureVerifier !== undefined ? "on" : "off";
+      // cortex#331 Phase 1 — surface the dispatching substrate so
+      // principals can grep `substrate=pi-dev` / `substrate=claude-code`
+      // to confirm sage agents (or any future substrate) actually
+      // received the substrate-aware factory. Unset substrate defaults
+      // to `claude-code` in the log (matches the runtime fallthrough).
+      //
+      // cortex#334 — distinguish "ready" (subscription open) from
+      // "DORMANT" (subscribePull returned null; G-1111 pending or
+      // nats.subjects empty). The previous unconditional "ready" line
+      // misled principals into chasing phantom misconfigs.
+      if (started.subscribed) {
+        console.log(
+          `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"}`,
+        );
+      } else {
+        console.log(
+          `cortex: review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)`,
+        );
+      }
+
+      // CO-2 (cortex#941) — bind the FURTHER offering scopes (federated/public)
+      // beyond the primary local one. Empty for the CO-1 default (`local`-only
+      // ⇒ `reviewOfferingPatterns` has length 1, so `.slice(1)` is empty ⇒ this
+      // loop never runs ⇒ byte-identical boot). Each extra scope binds on its
+      // OWN durable (scope token in the durable name) so the scopes ack
+      // independently, the same idiom as the cortex#686/#725 federated durables.
+      for (const extraPattern of opts.reviewOfferingPatterns.slice(1)) {
+        const scopeToken = extraPattern.split(".", 1)[0] ?? "scope";
+        // MAJOR-1 fix (cortex#715 re-introduction): a `federated.`/`public.`
+        // offer-scope consumer MUST be constructed with `federated: true` so
+        // `ReviewConsumer.processEnvelope` decodes the REQUESTER from
+        // `originator.identity` and routes the verdict back cross-principal —
+        // `makeConsumer(false)` left `this.federated` unset, routing every
+        // verdict to SELF (the exact cortex#715 BLOCKER). `makeConsumer(true)`
+        // also wires `federatedNetworks` so the defense-in-depth `peers[]` gate
+        // runs. (`public` shares the federated verdict-routing path: a public
+        // requester reaches us through a surface but the verdict still routes to
+        // the relaying identity in `originator`, not self.)
+        // CO-7 — pass the actual offer-scope (not just a federated bool) so the
+        // consumer wires the scope-appropriate M1/M2/M4 hardening. A non-scope
+        // token (defensive) falls back to `public` — the STRICTEST hardening —
+        // never silently to local.
+        const offerScope: OfferScope =
+          scopeToken === "federated"
+            ? "federated"
+            : scopeToken === "public"
+              ? "public"
+              : "public";
+        const offerConsumer = makeConsumer(offerScope);
+        opts.reviewConsumers.push(offerConsumer);
+        const offerDurable = `cortex-review-consumer-offer-${scopeToken}-${opts.reviewPrincipalId}-${agent.id}`;
+        if (opts.reviewJsm !== null) {
+          try {
+            const outcome = await provisionReviewConsumer({
+              jsm: opts.reviewJsm,
+              stream: opts.reviewStream,
+              durable: offerDurable,
+              // Filter to THIS offer scope's pattern so it doesn't claim the
+              // local/other-scope durables' traffic (cortex#1186 fan-out).
+              filterSubject: extraPattern,
+              maxDeliver: opts.reviewConsumerMaxDeliver,
+            });
+            if (outcome === "created") {
+              console.log(
+                `cortex: provisioned JetStream durable "${offerDurable}" on stream "${opts.reviewStream}"`,
+              );
+            } else if (outcome === "updated") {
+              console.log(
+                `cortex: reconciled JetStream durable "${offerDurable}" ack_wait (cortex#422) on stream "${opts.reviewStream}"`,
+              );
+            }
+          } catch (provisionErr) {
+            process.stderr.write(
+              `cortex: provisionReviewConsumer failed for "${offerDurable}": ` +
+                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+            );
+          }
+        }
+        const offerStarted = await offerConsumer.start({
+          pattern: extraPattern,
+          stream: opts.reviewStream,
+          durable: offerDurable,
+        });
+        if (offerStarted.subscribed) {
+          console.log(
+            `cortex: review consumer (offer:${scopeToken}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} pattern=${extraPattern}`,
+          );
+        } else {
+          console.log(
+            `cortex: review consumer (offer:${scopeToken}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} — cortex MyelinRuntime subscriptions disabled (${extraPattern} envelopes will not be claimed by this consumer)`,
+          );
+        }
+      }
+
+      // cortex#686 (ADR 0001) — the FEDERATED review consumer. Subscribes this
+      // stack's OWN federated identity (`federated.{my-principal}.{my-stack}.
+      // tasks.code-review.>`) on the SAME CODE_REVIEW stream (its subject
+      // filter was extended above when federation is configured), via a
+      // SEPARATE durable so local + federated traffic ack independently. Routes
+      // the verdict back to the REQUESTER's identity (the `federated: true`
+      // flag). Only wired when a `federated:` policy block is declared — a
+      // non-federating deployment skips this entirely (back-compat).
+      if (opts.federationConfigured) {
+        // cortex#686 + cortex#725 — wire BOTH federated consumers (Offer +
+        // Direct) for this agent. They share the `makeConsumer(true)`
+        // construction (same reviewer, verifier, peers gate, verdict-back) and
+        // the SAME CODE_REVIEW stream; they differ ONLY in the subscription
+        // pattern + the durable (so Offer and Direct traffic ack independently).
+        // Factored into a closure so the two can't drift on provisioning /
+        // start / log wiring.
+        const startFederatedConsumer = async (
+          mode: "offer" | "direct",
+          pattern: string,
+          durableName: string,
+        ): Promise<void> => {
+          // CO-7 — the cortex#686/#725 federated-policy consumers bind on
+          // `federated.` subjects, so they wire the `federated`-scope M1/M2/M4
+          // hardening (untrusted-content boundary + least-privilege + egress
+          // guard) for cross-principal review requests.
+          const federatedConsumer = makeConsumer("federated");
+          opts.reviewConsumers.push(federatedConsumer);
+          if (opts.reviewJsm !== null) {
+            try {
+              const outcome = await provisionReviewConsumer({
+                jsm: opts.reviewJsm,
+                stream: opts.reviewStream,
+                durable: durableName,
+                // Filter to THIS federated consumer's `federated.…` pattern so
+                // it claims only cross-principal traffic, never the local
+                // durable's `local.…` requests (cortex#1186 fan-out).
+                filterSubject: pattern,
+                maxDeliver: opts.reviewConsumerMaxDeliver,
+              });
+              if (outcome === "created") {
+                console.log(
+                  `cortex: provisioned JetStream durable "${durableName}" on stream "${opts.reviewStream}"`,
+                );
+              } else if (outcome === "updated") {
+                console.log(
+                  `cortex: reconciled JetStream durable "${durableName}" ack_wait (cortex#422) on stream "${opts.reviewStream}"`,
+                );
+              }
+            } catch (provisionErr) {
+              process.stderr.write(
+                `cortex: provisionReviewConsumer failed for "${durableName}": ` +
+                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+              );
+            }
+          }
+          const federatedStarted = await federatedConsumer.start({
+            pattern,
+            stream: opts.reviewStream,
+            durable: durableName,
+          });
+          if (federatedStarted.subscribed) {
+            console.log(
+              `cortex: federated review consumer (${mode}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} pattern=${pattern}`,
+            );
+          } else {
+            console.log(
+              `cortex: federated review consumer (${mode}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} engine=${engine} model=${model ?? "default"} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
+            );
+          }
+        };
+
+        // cortex#686 (ADR 0001) — Offer: `federated.{me}.{stack}.tasks.code-review.>`.
+        await startFederatedConsumer(
+          "offer",
+          opts.reviewFederatedSubjectPattern,
+          `cortex-review-consumer-federated-${opts.reviewPrincipalId}-${agent.id}`,
+        );
+        // cortex#725 (ADR 0001/0002 §2) — Direct: this stack's OWN
+        // `federated.{me}.{stack}.tasks.@{did}.code-review.>` (the `@{did}` is
+        // the named reviewer/target-assistant). Routes the verdict back to the
+        // REQUESTER (from `originator.identity`) identically to the Offer path.
+        await startFederatedConsumer(
+          "direct",
+          opts.reviewFederatedDirectSubjectPattern,
+          `cortex-review-consumer-federated-direct-${opts.reviewPrincipalId}-${agent.id}`,
+        );
+      }
+    } catch (err) {
+      // Per CLAUDE.md: log every error. A single agent's consumer crash
+      // does NOT abort boot — siblings still get wired. Boot keeps the
+      // consumer in `reviewConsumers[]` so shutdown drain still calls
+      // `.stop()` (idempotent — handles the "never subscribed" case).
+      process.stderr.write(
+        `cortex: review consumer init failed for agent=${agent.id}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  };
+
+  return { startForAgent };
+}


### PR DESCRIPTION
## Summary

Extracts the ~475-line inline `startReviewConsumersForAgent` boot closure out of `src/cortex.ts` into a new `src/runner/review-consumer-boot.ts`, exporting `wireReviewConsumers(opts) → { startForAgent }`. Shaped after `src/runner/dev-consumer-boot.ts`'s pattern (structural `*BootAgent` projection + a `WireXConsumersOpts` interface enumerating every captured value), but the RETURN shape differs from `wireDevConsumers` — see "Shape decision" below.

Cites: plan §2 S7, epic #1514. Closes #1521.

## What moved vs. what stayed

- **Moved**: the entire closure body (consumer construction, signature-verifier build, engine/pipeline resolution, local + CO-2 offer-scope + ADR-0001 federated Offer/Direct consumer wiring, JetStream provisioning, all boot-log lines).
- **Stayed in `cortex.ts`**: the capability filter (`reviewCapableAgents`/`isReviewCapable`), the shared `reviewConsumers: ReviewConsumer[]` array's declaration and its hot-reload-diff/shutdown-drain usages, `buildReviewSessionOpts` (still exported from `cortex.ts`, still covered by `cortex.review-session-opts.test.ts`), and `makeOfferAdmission` (still built in `cortex.ts`, passed in as a function reference).

## Shape decision: `{ startForAgent }`, not `{ consumers, stop }`

The packet's completion criteria mentioned returning `{ consumers, stop }` "mirroring dev-boot's convention." On inspection, `wireDevConsumers` actually returns `WiredDevConsumer[]` (not `{consumers, stop}`), and — more importantly — the review lane's calling shape is structurally different from the dev lane's:

- `wireDevConsumers` builds every dev-capable agent's consumer **once**, synchronously, and returns the finished list; `cortex.ts` starts them itself.
- The review lane is invoked **twice**: once in the boot loop over `reviewCapableAgents`, and again from the `agents.d/` hot-reload path for each added/changed agent. The construction itself does provisioning + `consumer.start()` + logging inline — it never separates "build" from "start" the way the dev lane does.
- `reviewConsumers[]` is read by hot-reload diffing (`drainConsumersForAgent`) and the shutdown drain, both well outside this slice. Moving array ownership into the new module would have required touching those regions too — out of scope for a "move + wire" slice.

So `wireReviewConsumers(opts)` returns `{ startForAgent(agent) }`, and `opts.reviewConsumers` is the **same shared array** `cortex.ts` still owns and pushes into (passed by reference). Both call sites now read `await startForAgent(agent)` in place of the old `await startReviewConsumersForAgent(agent)` — same position in `startCortex`'s boot sequence, unchanged ordering relative to every other boot step.

## Captured opts — full list, mutability check

Every field on `WireReviewConsumersOpts` is a **plain snapshot**, not a getter/setter pair:

`reviewPrincipalId`, `trustResolver`, `signingKnobs`, `signer?`, `stackNKeyPubForVerifier?`, `systemEventSource`, `runtime`, `buildSessionOpts` (curried `buildReviewSessionOpts(config, agent)` — avoids a `cortex.ts` ⇄ `review-consumer-boot.ts` import cycle), `makeOfferAdmission`, `federatedNetworks`, `reviewConsumers` (shared array reference), `reviewOfferingPatterns`, `reviewSubjectPattern`, `reviewJsm`, `reviewStream`, `reviewConsumerMaxDeliver`, `federationConfigured`, `reviewFederatedSubjectPattern`, `reviewFederatedDirectSubjectPattern`.

**No mutable-capture threading needed.** `signer` and `stackNKeyPubForVerifier` are `let`s in `cortex.ts`, but each is assigned exactly once (`cortex.ts:975`, `:980`) during early boot setup, well before `wireReviewConsumers(...)` is constructed. `runtime` is also a `let`, assigned exactly once (`cortex.ts:1111`/`:1121`, from `options.injectRuntime` or `startMyelinRuntime(...)`), likewise before construction. None of these are ever reassigned again anywhere in the file (verified by grep for bare `= ` assignments). The old closure only ever *read* them — it never reassigned any of them — so a plain value snapshot at construction time is behaviorally identical to the inline closure's live-binding read. `reviewConsumers` itself is a `const` array; this module mutates it via `.push()`, which is safe to share by reference (no reassignment of the binding, just the same array everyone already had a handle on).

## Confirmed unchanged

`grep -n "startReviewConsumersForAgent" src/cortex.ts` → **0 matches** (both call sites now read `startForAgent`, and the two prose comments that referenced the old name were updated to match).

## Test coverage

- **New**: `src/runner/__tests__/review-consumer-boot.test.ts` — 5 unit tests exercising `wireReviewConsumers` directly (no `startCortex`), against a recording fake `MyelinRuntime` (same idiom as `cortex.review-consumer-boot.test.ts`'s recorder). Asserts: (1) the local consumer binds `local.andreas.work.tasks.code-review.*` on durable `cortex-review-consumer-andreas-echo` and is pushed onto the passed-in `reviewConsumers[]`; (2) a dormant runtime (no `subscribePull`) still constructs the consumer without throwing; (3) a second `reviewOfferingPatterns` entry binds an extra offer-scope consumer on an `offer-federated` durable; (4) `federationConfigured: true` wires both the federated Offer and Direct consumers on their expected patterns/durables; (5) a synchronous failure inside `startForAgent` (forced via a throwing `buildSessionOpts`) is caught and logged to stderr (`review consumer init failed`, `agent=echo`) without rejecting the returned promise, and no consumer is left in the array.
- **Unchanged, still green**: `src/__tests__/cortex.review-consumer-boot.test.ts` (8 tests) — the full `startCortex` integration regression suite covering multi-agent boot, CO-2 offering-scope binding, ADR-0001 federation, dormancy (`subscribePull` returns `null`), JSM-throw containment, and partial-failure isolation. This is the primary byte-identical-behavior proof for the extraction; it required zero changes.

## Gate results

- `bunx tsc --noEmit` → exit 0, no errors.
- `bun run lint:errors` (`eslint --quiet .`, strictTypeChecked + `no-unused-vars: error`) → exit 0. (Several imports that were only used inside the moved closure — `ReviewConsumerAgent`, `SignatureVerifier`, `verifySignedByChain`, `resolveReviewEngine`, `makeSageReviewRunner`, `runReviewPipeline`, `reviewPromptForScope`, `reviewSessionOptsForScope`, `withCo7EgressGuard`, `CCSession` — were removed from `cortex.ts`'s import block; each was individually confirmed to have zero remaining real usages there before removal.)
- `bun test src/runner src/__tests__/cortex.test.ts src/__tests__/cortex.review-consumer-boot.test.ts` → **911 pass, 0 fail**.
- `bun test` (full suite) → **8893 pass, 8 skip, 8 todo, 0 fail** across 520 files. No ECONNREFUSED-only suite failures observed.
- `src/cortex.ts`: 7204 → 6736 lines (**net −468**).

## Out of scope / not touched

- `buildReviewSessionOpts`'s own implementation and test file.
- The hot-reload diff logic (`drainConsumersForAgent`, `reconcileFromEvent`) and the shutdown drain — both still read/mutate `reviewConsumers[]` directly, unchanged.
- `wireDevConsumers` / `dev-consumer-boot.ts` itself (used only as the structural template).

## Test plan

- [x] `bunx tsc --noEmit`
- [x] `bun run lint:errors`
- [x] `bun test src/runner src/__tests__/cortex.test.ts src/__tests__/cortex.review-consumer-boot.test.ts`
- [x] `bun test` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)