### PR TITLE
refactor(runner): S8 — startCortex lanes 2+3: wireBrainConsumers + wireReleaseConsumers

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -96,10 +96,8 @@ import { DaemonBrainHost } from "./brain/daemon-brain-host";
 import { wireDevConsumers } from "./runner/dev-consumer-boot";
 import { wireReviewConsumers } from "./runner/review-consumer-boot";
 import { wireBrainConsumers } from "./runner/brain-consumer-boot";
-import {
-  ReleaseConsumer,
-  type ReleaseConsumerAgent,
-} from "./runner/release-consumer";
+import { wireReleaseConsumers } from "./runner/release-consumer-boot";
+import { ReleaseConsumer } from "./runner/release-consumer";
 import {
   provisionReviewStream,
   provisionReviewConsumer,
@@ -2406,141 +2404,29 @@ export async function startCortex(
       }
     }
 
+    // S8 (epic #1514, cortex#1522) — the per-agent construct+provision+start+
+    // log body extracted to `wireReleaseConsumers`. Unlike the brain/review
+    // lanes, this construction has exactly ONE call site (this loop) and no
+    // `agents.d/` hot-reload path — see the module's file header for why that
+    // asymmetry is preserved, not "fixed".
+    // Block-scoped: shadows nothing outside this `if` (review's own
+    // `startForAgent` above is a sibling top-level binding, not visible from
+    // inside a nested reload closure the way brain's must be — release has no
+    // hot-reload path, so this name only ever needs to live here).
+    const { startForAgent } = wireReleaseConsumers({
+      principalId,
+      systemEventSource,
+      runtime,
+      makeOfferAdmission,
+      releaseConsumers,
+      releaseJsm,
+      releaseStream,
+      releaseConsumerMaxDeliver,
+      releaseOfferingPatterns,
+      releaseSubjectPattern,
+    });
     for (const agent of releaseCapableAgents) {
-      try {
-        const caps = agent.runtime?.capabilities ?? [];
-        const consumerAgent: ReleaseConsumerAgent = {
-          id: agent.id,
-          capabilities: caps,
-          ...(agent.runtime?.maxConcurrent !== undefined && {
-            maxConcurrent: agent.runtime.maxConcurrent,
-          }),
-        };
-        // F-4.1 — no executor wired yet (see block header). The consumer is
-        // dormant-but-present: capability declared + gate ladder live.
-        const consumer = new ReleaseConsumer({
-          agent: consumerAgent,
-          source: systemEventSource,
-          runtime,
-          // CO-2/CO-4 — per-offer-scope admission gate (inert on `local.`).
-          offerAdmission: makeOfferAdmission("release.cut"),
-        });
-        releaseConsumers.push(consumer);
-
-        const durable = `cortex-release-consumer-${principalId}-${agent.id}`;
-        if (releaseJsm !== null) {
-          try {
-            const outcome = await provisionReviewConsumer({
-              jsm: releaseJsm,
-              stream: releaseStream,
-              durable,
-              maxDeliver: releaseConsumerMaxDeliver,
-            });
-            if (outcome === "created") {
-              console.log(
-                `cortex: provisioned JetStream durable "${durable}" on stream "${releaseStream}"`,
-              );
-            } else if (outcome === "updated") {
-              console.log(
-                `cortex: reconciled JetStream durable "${durable}" on stream "${releaseStream}"`,
-              );
-            }
-          } catch (provisionErr) {
-            process.stderr.write(
-              `cortex: provisionReviewConsumer failed for "${durable}": ` +
-                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
-            );
-          }
-        }
-
-        // CO-2 (cortex#941) — bind on the offering-admitted scope prefixes.
-        // `releaseOfferingPatterns[0]` is byte-identical to
-        // `releaseSubjectPattern` for the CO-1 default (`local`-only); the
-        // `.slice(1)` loop is empty unless `release.cut` is offered wider.
-        const primaryReleasePattern =
-          releaseOfferingPatterns[0] ?? releaseSubjectPattern;
-        const started = await consumer.start({
-          pattern: primaryReleasePattern,
-          stream: releaseStream,
-          durable,
-        });
-        // F-4.1 — log line flags `executor=none` so a principal grepping boot
-        // can see the lane is declared but the forge seam is not yet wired.
-        if (started.subscribed) {
-          console.log(
-            `cortex: release consumer ready for agent=${agent.id} capability=release.cut executor=none (gated; principal-grant required) — PRINCIPAL-GATED, ALWAYS-HUMAN`,
-          );
-        } else {
-          console.log(
-            `cortex: release consumer DORMANT for agent=${agent.id} capability=release.cut executor=none — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.release.cut envelopes will not be claimed by this consumer)`,
-          );
-        }
-        // CO-2 — extra offering scopes (federated/public) beyond the primary
-        // local one, each on its own scope-named durable. Empty for the CO-1
-        // default ⇒ byte-identical boot.
-        for (const extraPattern of releaseOfferingPatterns.slice(1)) {
-          const scopeToken = extraPattern.split(".", 1)[0] ?? "scope";
-          // A NEW consumer instance per extra scope (one filter per JetStream
-          // pull consumer) — same idiom as the review lane + the NIT-fix on the
-          // dev lane. The CO-2/CO-4 admission gate is wired here too so the
-          // wider-scope release dispatch clears its floor.
-          const extraConsumer = new ReleaseConsumer({
-            agent: consumerAgent,
-            source: systemEventSource,
-            runtime,
-            offerAdmission: makeOfferAdmission("release.cut"),
-          });
-          releaseConsumers.push(extraConsumer);
-          const extraDurable = `cortex-release-consumer-offer-${scopeToken}-${principalId}-${agent.id}`;
-          if (releaseJsm !== null) {
-            try {
-              const outcome = await provisionReviewConsumer({
-                jsm: releaseJsm,
-                stream: releaseStream,
-                durable: extraDurable,
-                maxDeliver: releaseConsumerMaxDeliver,
-              });
-              if (outcome === "created") {
-                console.log(
-                  `cortex: provisioned JetStream durable "${extraDurable}" on stream "${releaseStream}"`,
-                );
-              } else if (outcome === "updated") {
-                console.log(
-                  `cortex: reconciled JetStream durable "${extraDurable}" on stream "${releaseStream}"`,
-                );
-              }
-            } catch (provisionErr) {
-              process.stderr.write(
-                `cortex: provisionReviewConsumer failed for "${extraDurable}": ` +
-                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
-              );
-            }
-          }
-          const extraStarted = await extraConsumer.start({
-            pattern: extraPattern,
-            stream: releaseStream,
-            durable: extraDurable,
-          });
-          if (extraStarted.subscribed) {
-            console.log(
-              `cortex: release consumer (offer:${scopeToken}) ready for agent=${agent.id} capability=release.cut executor=none pattern=${extraPattern}`,
-            );
-          } else {
-            console.log(
-              `cortex: release consumer (offer:${scopeToken}) DORMANT for agent=${agent.id} capability=release.cut executor=none — cortex MyelinRuntime subscriptions disabled (${extraPattern} envelopes will not be claimed by this consumer)`,
-            );
-          }
-        }
-      } catch (err) {
-        // Per CLAUDE.md "no empty catch blocks": a single agent's release
-        // consumer crash does NOT abort boot — siblings still wire. The
-        // consumer stays in `releaseConsumers[]` so the shutdown drain still
-        // calls `.stop()` (idempotent — handles the "never subscribed" case).
-        process.stderr.write(
-          `cortex: release consumer init failed for agent=${agent.id}: ` +
-            `${err instanceof Error ? err.message : String(err)}\n`,
-        );
-      }
+      await startForAgent(agent);
     }
   }
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -85,7 +85,6 @@ import {
   type BrainAttachmentRef,
   buildDispatchTaskEnvelope,
   BRAIN_TASK_SUBJECT_FAMILY,
-  type BrainConsumerAgent,
 } from "./bus/brain-consumer";
 import {
   SurfacePrincipalGate,
@@ -93,10 +92,10 @@ import {
   type PrincipalIdentity,
 } from "./bus/surface-principal-gate";
 import { GateReplyRouter } from "./bus/gate-reply-router";
-import { makeExecBrainRunner } from "./brain/exec-brain-runner";
 import { DaemonBrainHost } from "./brain/daemon-brain-host";
 import { wireDevConsumers } from "./runner/dev-consumer-boot";
 import { wireReviewConsumers } from "./runner/review-consumer-boot";
+import { wireBrainConsumers } from "./runner/brain-consumer-boot";
 import {
   ReleaseConsumer,
   type ReleaseConsumerAgent,
@@ -749,56 +748,6 @@ function targetAgentForDispatch(
     }),
     ...(agent.strictMcpConfig === true && { strictMcpConfig: true }),
   };
-}
-
-/**
- * Bot Packs B-1 (cortex#1033 §Maintainability) — collect the declared brain
- * secrets from THIS process's env. Only named keys are forwarded into the
- * brain's minimal env (the runner enforces the minimal-env policy; §8). A
- * named-but-unset secret is simply absent (logged once for visibility — the
- * install-time consent is the arc-side gate). Pure except for the stderr log.
- */
-function collectBrainSecrets(
-  agentId: string,
-  declared: readonly string[],
-): Record<string, string> {
-  const secrets: Record<string, string> = {};
-  const missing: string[] = [];
-  for (const name of declared) {
-    const value = process.env[name];
-    if (value !== undefined) secrets[name] = value;
-    else missing.push(name);
-  }
-  if (missing.length > 0) {
-    process.stderr.write(
-      `cortex: brain agent=${agentId} declares secrets not present in the ` +
-        `environment: [${missing.join(",")}] — they will be absent from ` +
-        `the brain process (install-time consent is the arc-side gate)\n`,
-    );
-  }
-  return secrets;
-}
-
-/**
- * Bot Packs B-1 (cortex#1033 §Maintainability) — read the persona text once at
- * brain start. `personaPath` is the loader-resolved file PATH. A
- * missing/unreadable persona is non-fatal: returns `undefined` (the brain
- * receives no persona) and logs once.
- */
-function loadBrainPersona(
-  agentId: string,
-  personaPath: string,
-): string | undefined {
-  try {
-    return readFileSync(personaPath, "utf-8");
-  } catch (personaErr) {
-    process.stderr.write(
-      `cortex: brain agent=${agentId} persona unreadable at "${personaPath}": ` +
-        `${personaErr instanceof Error ? personaErr.message : String(personaErr)} — ` +
-        `proceeding without persona\n`,
-    );
-    return undefined;
-  }
 }
 
 /**
@@ -2309,209 +2258,28 @@ export async function startCortex(
       })
     : undefined;
 
-  const startBrainConsumersForAgent = async (agent: Agent): Promise<void> => {
-    try {
-      const brain = agent.runtime?.brain;
-      if (brain?.kind !== "exec" || brain.run === undefined) {
-        // Defensive: the caller filters to exec brains with a `run`; a
-        // mis-routed builtin/absent brain is a no-op, not a crash.
-        return;
-      }
-      const caps = agent.runtime?.capabilities ?? [];
-      const consumerAgent: BrainConsumerAgent = {
-        id: agent.id,
-        capabilities: caps,
-        dispatchCapabilities: brain.dispatch_capabilities,
-        ...(agent.runtime?.maxConcurrent !== undefined && {
-          maxConcurrent: agent.runtime.maxConcurrent,
-        }),
-        ...(agent.runtime?.modelClass !== undefined && {
-          modelClass: agent.runtime.modelClass,
-        }),
-      };
-
-      // Resolve the per-task runner over the manifest `brain` block. `{pack}`
-      // expands to `{base}/{agentId}` (the arc install dir; design §7.1). The
-      // declared secrets resolve from THIS process's env at spawn — only the
-      // named keys are forwarded into the brain's minimal env (the runner
-      // enforces the minimal-env policy; §8). A named-but-unset secret is
-      // simply absent in the env (logged once for visibility). cortex#1033
-      // §Maintainability — secret collection + persona load are extracted to the
-      // module-level `collectBrainSecrets` / `loadBrainPersona` helpers so this
-      // startup closure reads as a sequence of named steps.
-      const packDir = join(brainPackBaseDir, agent.id);
-      const secrets = collectBrainSecrets(agent.id, brain.secrets);
-
-      // Persona delivered to the brain — per-task brains receive it on each task
-      // event; daemon brains receive it ONCE in the `hello` handshake (§5
-      // "Persona delivery"). A missing/unreadable persona is non-fatal.
-      const personaText = loadBrainPersona(agent.id, agent.persona);
-
-      // Bot Packs B-2 — `lifecycle: daemon` is hosted by a long-lived
-      // DaemonBrainHost (spawn once, socket-multiplex tasks, supervise + drain);
-      // `per-task` (default) keeps the B-1 per-spawn runner. Both feed the SAME
-      // BrainConsumer policy seam (the consumer is lifecycle-agnostic — it routes
-      // brain effects through the host hooks identically). The lifecycle-specific
-      // runner is mutually exclusive: a daemon agent passes `daemonHost` (no
-      // per-task runner constructed), a per-task agent passes `runBrainTask`.
-      // The `principalGate` (B-3, cortex#1021 W-2): when the principal has a
-      // configured surface identity, every brain consumer gets the SHARED
-      // `surfacePrincipalGate` — `ask_principal` renders to the task's
-      // surface/thread and awaits the principal's identity-checked reply via
-      // the `gateReplyRouter` bridge (wired into each adapter's inbound flow
-      // at adapter start). Tasks that are bus-only, on a surface this
-      // instance doesn't host, or on a surface with no configured principal
-      // id STILL fail closed inside the gate (resolve-time checks). With no
-      // principal surface identity at all the consumer keeps its
-      // DenyAllPrincipalGate default (B-1 fail-closed).
-      // Sovereignty audit-parity by default, mirroring ReviewConsumer (a
-      // self-declared modelClass is spoofable until bound to the signing
-      // identity, cortex#327).
-      const baseConsumerOpts = {
-        agent: consumerAgent,
-        source: systemEventSource,
-        runtime,
-        ...(personaText !== undefined && { persona: personaText }),
-        ...(surfacePrincipalGate !== undefined && {
-          principalGate: surfacePrincipalGate,
-        }),
-      };
-      let daemonHost: DaemonBrainHost | undefined;
-      let consumer: BrainConsumer;
-      if (brain.lifecycle === "daemon") {
-        daemonHost = new DaemonBrainHost({
-          agentId: agent.id,
-          run: brain.run,
-          packDir,
-          secrets,
-          maxRestarts: brain.maxRestarts,
-          ...(personaText !== undefined && { persona: personaText }),
-          // On degradation (restart budget exhausted) surface the agent via the
-          // presence producer's capability-change signal (drop to empty caps),
-          // the same path the reconcile uses (§7.4). Read the holder lazily —
-          // the producer is constructed after this boot closure runs.
-          onDegraded: (degradedId: string): void => {
-            const producer = brainPresenceHolder.producer;
-            if (producer !== null) {
-              producer.publishCapabilitiesChanged(degradedId, []);
-            }
-            process.stderr.write(
-              `cortex: daemon brain agent=${degradedId} marked DEGRADED — ` +
-                `restart budget exhausted; presence signalled\n`,
-            );
-          },
-        });
-        // Spawn + connect + hello. A spawn/connect failure is logged; the
-        // consumer still registers so a later reload can replace it. The
-        // consumer's runner (the host's runTask) fast-fails not_now until the
-        // host connects, so no task is silently lost.
-        // Non-blocking start (sage cortex#1035 round 3): start() resolves on
-        // the socket handshake, so awaiting here would make cortex boot
-        // latency the SUM of every daemon's spawn+auth. The consumer's
-        // runner fast-fails not_now until the host connects (documented
-        // above), so registering the consumer before the handshake settles
-        // loses nothing — failures land in the same stderr path.
-        void daemonHost.start().catch((startErr: unknown) => {
-          process.stderr.write(
-            `cortex: daemon brain host start failed for agent=${agent.id}: ` +
-              `${startErr instanceof Error ? startErr.message : String(startErr)}\n`,
-          );
-        });
-        daemonBrainHosts.push(daemonHost);
-        consumer = new BrainConsumer({ ...baseConsumerOpts, daemonHost });
-      } else {
-        const runBrainTask = makeExecBrainRunner({ run: brain.run, packDir, secrets });
-        consumer = new BrainConsumer({ ...baseConsumerOpts, runBrainTask });
-      }
-      brainConsumers.push(consumer);
-
-      // Provision + bind one durable pull consumer per declared capability.
-      // Subject grammar: `local.{principal}.{stack}.tasks.{capability}` (the
-      // myelin task-envelope grammar the design + agent envelopes use — the
-      // capability is a literal trailing segment, no `>` wildcard since a brain
-      // task subject is exact per capability). Durable name is unique per
-      // (principal, agent, capability).
-      //
-      // cortex#1033 §Architecture/§HonestOracle — provision ALL capability
-      // durables UP-FRONT and AWAIT them BEFORE calling `consumer.start()`, so
-      // the bind inside `start()` cannot race ahead of a not-yet-created durable
-      // on a virgin broker. This mirrors the review path (which awaits
-      // `provisionReviewConsumer` before `consumer.start()`); the brain path
-      // previously fired `void provisionReviewConsumer(...)` from inside the
-      // synchronous `resolve` callback, which returned the subscription params
-      // immediately while provisioning was still in flight. `resolve` is now a
-      // pure subject/durable resolver with no side effect.
-      // B-3 (cortex#1021): brain task subjects live on the `brain.` family /
-      // BRAIN_TASKS stream — NOT `tasks.`/CODE_REVIEW (where B-1 bound them,
-      // a stream that never carried non-code-review capabilities). The inbound
-      // dispatch publishes onto exactly this subject.
-      const brainCapabilities = consumerAgent.capabilities;
-      const brainDurableFor = (capability: string): string =>
-        `cortex-brain-consumer-${reviewPrincipalId}-${agent.id}-${capability.replaceAll(".", "-")}`;
-      const brainPatternFor = (capability: string): string =>
-        `local.${reviewPrincipalId}.${derivedStack.stack}.${BRAIN_TASK_SUBJECT_FAMILY}.${capability}`;
-
-      if (reviewJsm !== null) {
-        // Independent durables — provision in one parallel wave (sage
-        // cortex#1033 round 2); still awaited as a whole BEFORE start().
-        await Promise.all(
-          brainCapabilities.map(async (capability) => {
-            const durable = brainDurableFor(capability);
-            try {
-              await provisionReviewConsumer({
-                jsm: reviewJsm,
-                stream: brainTasksStream,
-                durable,
-                filterSubject: brainPatternFor(capability),
-                maxDeliver: reviewConsumerMaxDeliver,
-              });
-            } catch (provisionErr) {
-              // Don't abort — let `consumer.start()` surface the bind failure
-              // through its own dormant/skip path (mirrors the review path).
-              process.stderr.write(
-                `cortex: provisionReviewConsumer (brain) failed for "${durable}": ` +
-                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
-              );
-            }
-          }),
-        );
-      }
-
-      const started = await consumer.start({
-        resolve: (capability) => ({
-          pattern: brainPatternFor(capability),
-          stream: brainTasksStream,
-          durable: brainDurableFor(capability),
-        }),
-      });
-
-      const capSummary =
-        started.capabilities.length > 0 ? started.capabilities.join(",") : "(none)";
-      if (started.subscribedCapabilities.length > 0) {
-        console.log(
-          `cortex: brain consumer ready for agent=${agent.id} kind=exec ` +
-            `capabilities=[${capSummary}] subscribed=[${started.subscribedCapabilities.join(",")}] ` +
-            `gate=${surfacePrincipalGate !== undefined ? "surface" : "deny-all"}`,
-        );
-      } else {
-        console.log(
-          `cortex: brain consumer DORMANT for agent=${agent.id} kind=exec ` +
-            `capabilities=[${capSummary}] ` +
-            `gate=${surfacePrincipalGate !== undefined ? "surface" : "deny-all"} ` +
-            `— cortex MyelinRuntime subscriptions disabled ` +
-            `(G-1111 pending; tasks.{capability} envelopes will not be claimed by this brain)`,
-        );
-      }
-    } catch (err) {
-      // Per CLAUDE.md: log every error. One brain's wiring failure does NOT
-      // abort boot; the consumer (if pushed) stays in `brainConsumers[]` so the
-      // shutdown drain still calls `.stop()` (idempotent).
-      process.stderr.write(
-        `cortex: brain consumer init failed for agent=${agent.id}: ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    }
-  };
+  // S8 (epic #1514, cortex#1522) — the brain-consumer construction extracted
+  // to `wireBrainConsumers` (mirrors S7's `wireReviewConsumers`). Renamed at
+  // destructure (`startBrainForAgent`, not the bare `startForAgent` the
+  // module returns) because review's own `startForAgent` binding above lives
+  // in this SAME top-level scope — the two are unrelated bindings that would
+  // otherwise collide. Called at BOTH the boot loop below and the
+  // `agents.d/` hot-reload path (isBrainHosted, further down), exactly where
+  // the inline closure used to be called.
+  const { startForAgent: startBrainForAgent } = wireBrainConsumers({
+    brainPackBaseDir,
+    reviewPrincipalId,
+    stack: derivedStack.stack,
+    systemEventSource,
+    runtime,
+    ...(surfacePrincipalGate !== undefined && { surfacePrincipalGate }),
+    brainPresenceHolder,
+    brainConsumers,
+    daemonBrainHosts,
+    reviewJsm,
+    brainTasksStream,
+    reviewConsumerMaxDeliver,
+  });
 
   // Boot: start review consumers for every code-review-capable agent. Same
   // `startForAgent` the hot-reload path calls for a newly-added agent.
@@ -2521,7 +2289,7 @@ export async function startCortex(
   // Boot: start brain consumers for every exec-brain agent (B-1). Same closure
   // the hot-reload path calls for a newly-added exec-brain agent.
   for (const agent of brainAgents) {
-    await startBrainConsumersForAgent(agent);
+    await startBrainForAgent(agent);
   }
   if (reviewConsumers.length === 0) {
     // cortex#314 — same first-install-safety promotion as the
@@ -4611,7 +4379,7 @@ export async function startCortex(
         if (isReviewCapable(agent)) {
           await startForAgent(agent);
         } else if (isBrainHosted(agent)) {
-          await startBrainConsumersForAgent(agent);
+          await startBrainForAgent(agent);
         }
       }),
     );

--- a/src/runner/__tests__/brain-consumer-boot.test.ts
+++ b/src/runner/__tests__/brain-consumer-boot.test.ts
@@ -1,0 +1,246 @@
+/**
+ * S8 (epic #1514, cortex#1522) — brain-consumer boot-wiring tests.
+ *
+ * Unit-level coverage of `wireBrainConsumers` IN ISOLATION — no
+ * `startCortex`, no filesystem beyond a throwaway persona file, no NATS, no
+ * `agents.d/` boot machinery. Assertions the pre-extraction inline closure
+ * never had at this grain: that `startForAgent` can be exercised directly
+ * against a fixture opts object, that it binds the expected `brain.`-family
+ * subject pattern + durable per declared capability via the runtime's
+ * `subscribePull`, and that it pushes onto the shared `brainConsumers[]`
+ * array passed in (this module doesn't own that array's lifecycle — see the
+ * file header in `brain-consumer-boot.ts`).
+ *
+ * The full `startCortex` integration coverage (hot-add/remove/change,
+ * mutual exclusion with the review lane, dormancy) lives in
+ * `src/__tests__/cortex.agents-reload.test.ts` and continues to pass
+ * unchanged against this extraction — that file is the
+ * byte-identical-behaviour regression guard; this one is the new module's
+ * own unit contract.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  wireBrainConsumers,
+  type BrainBootAgent,
+  type WireBrainConsumersOpts,
+} from "../brain-consumer-boot";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+  MyelinSubscribePullOpts,
+} from "../../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../../bus/myelin/subscriber";
+import { BrainConsumer } from "../../bus/brain-consumer";
+import { DaemonBrainHost } from "../../brain/daemon-brain-host";
+
+interface RecordingRuntime extends MyelinRuntime {
+  subscribePullCalls: MyelinSubscribePullOpts[];
+}
+
+/** Mirrors `review-consumer-boot.test.ts`'s recorder — see that file for the rationale. */
+function fakeRuntime(): RecordingRuntime {
+  const handlers = new Set<EnvelopeHandler>();
+  const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+  return {
+    enabled: false,
+    subscribePullCalls,
+    onEnvelope(h) {
+      handlers.add(h);
+      return { unregister: () => handlers.delete(h) };
+    },
+    publish: async (_e: Envelope) => {},
+    stop: async () => {},
+    subscribePull: (opts: MyelinSubscribePullOpts): MyelinSubscriber => {
+      subscribePullCalls.push(opts);
+      return {
+        pattern: opts.pattern,
+        ready: Promise.resolve(),
+        stop: async () => {},
+      } as unknown as MyelinSubscriber;
+    },
+  };
+}
+
+// A throwaway persona file per test file run — `loadBrainPersona` reads it
+// from disk (a missing file is non-fatal, but we exercise the happy path).
+const personaDir = mkdtempSync(join(tmpdir(), "cortex-brain-boot-test-"));
+const personaPath = join(personaDir, "persona.md");
+writeFileSync(personaPath, "# test persona\n");
+afterAll(() => {
+  rmSync(personaDir, { recursive: true, force: true });
+});
+
+function baseOpts(overrides: Partial<WireBrainConsumersOpts> = {}): WireBrainConsumersOpts {
+  return {
+    brainPackBaseDir: personaDir,
+    reviewPrincipalId: "andreas",
+    stack: "work",
+    systemEventSource: { principal: "andreas", agent: "cortex", instance: "local" },
+    runtime: fakeRuntime(),
+    brainPresenceHolder: { producer: null },
+    brainConsumers: [],
+    daemonBrainHosts: [],
+    reviewJsm: null,
+    brainTasksStream: "BRAIN_TASKS",
+    reviewConsumerMaxDeliver: 5,
+    ...overrides,
+  };
+}
+
+function agent(
+  id: string,
+  capabilities: readonly string[],
+  brainOverrides: Partial<NonNullable<NonNullable<BrainBootAgent["runtime"]>["brain"]>> = {},
+): BrainBootAgent {
+  return {
+    id,
+    persona: personaPath,
+    runtime: {
+      capabilities,
+      brain: {
+        kind: "exec",
+        run: "bun {pack}/brain/main.ts",
+        lifecycle: "per-task",
+        secrets: [],
+        dispatch_capabilities: [],
+        maxRestarts: 3,
+        ...brainOverrides,
+      },
+    },
+  };
+}
+
+describe("wireBrainConsumers — per-capability binding", () => {
+  test("startForAgent binds one durable per capability and pushes onto the shared brainConsumers[]", async () => {
+    const runtime = fakeRuntime();
+    const brainConsumers: BrainConsumer[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({ runtime, brainConsumers }),
+    );
+
+    await startForAgent(agent("yarrow", ["soc.compose.flow"]));
+
+    expect(brainConsumers).toHaveLength(1);
+    expect(brainConsumers[0]!.agent.id).toBe("yarrow");
+
+    expect(runtime.subscribePullCalls).toHaveLength(1);
+    expect(runtime.subscribePullCalls[0]!.pattern).toBe(
+      "local.andreas.work.brain.soc.compose.flow",
+    );
+    expect(runtime.subscribePullCalls[0]!.durable).toBe(
+      "cortex-brain-consumer-andreas-yarrow-soc-compose-flow",
+    );
+    expect(runtime.subscribePullCalls[0]!.stream).toBe("BRAIN_TASKS");
+  });
+
+  test("a builtin/absent brain (no kind: exec) is a no-op — no consumer constructed", async () => {
+    const runtime = fakeRuntime();
+    const brainConsumers: BrainConsumer[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({ runtime, brainConsumers }),
+    );
+
+    await startForAgent({
+      id: "echo",
+      persona: personaPath,
+      runtime: { capabilities: ["code-review"] },
+    });
+
+    expect(brainConsumers).toHaveLength(0);
+    expect(runtime.subscribePullCalls).toHaveLength(0);
+  });
+
+  test("dormant runtime (no subscribePull) → consumer still constructed, no throw", async () => {
+    const dormantRuntime: MyelinRuntime = {
+      enabled: false,
+      onEnvelope: () => ({ unregister: () => {} }),
+      publish: async () => {},
+      stop: async () => {},
+      // subscribePull omitted — BrainConsumer.start() treats that as dormant.
+    };
+    const brainConsumers: BrainConsumer[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({ runtime: dormantRuntime, brainConsumers }),
+    );
+
+    await startForAgent(agent("yarrow", ["soc.compose.flow"]));
+
+    expect(brainConsumers).toHaveLength(1);
+  });
+});
+
+describe("wireBrainConsumers — daemon lifecycle", () => {
+  // Note: `wireBrainConsumers` fires `daemonHost.start()` non-blockingly
+  // (`void … .catch(...)`, mirroring the pre-extraction closure — see the
+  // module's file header). There is no `{pack}/brain/main.ts` under
+  // `personaDir` for this test, so that background spawn+connect rejects and
+  // logs a caught (not unhandled) stderr line sometime after this test's
+  // synchronous assertions — harmless, and not this test's concern (the real
+  // daemon connect/protocol lifecycle is `daemon-brain-host.test.ts`'s job).
+  test("lifecycle: daemon pushes a DaemonBrainHost onto the shared daemonBrainHosts[]", async () => {
+    const runtime = fakeRuntime();
+    const brainConsumers: BrainConsumer[] = [];
+    const daemonBrainHosts: DaemonBrainHost[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({ runtime, brainConsumers, daemonBrainHosts }),
+    );
+
+    await startForAgent(
+      agent("yarrow", ["soc.compose.flow"], { lifecycle: "daemon" }),
+    );
+
+    expect(brainConsumers).toHaveLength(1);
+    expect(daemonBrainHosts).toHaveLength(1);
+    expect(daemonBrainHosts[0]!.agentId).toBe("yarrow");
+  });
+});
+
+describe("wireBrainConsumers — per-agent failure isolation", () => {
+  test("a synchronous failure inside startForAgent is caught and logged, not thrown", async () => {
+    // A runtime whose `subscribePull` throws synchronously — simulates the
+    // consumer's construction/subscribe path failing partway through.
+    const throwingRuntime: MyelinRuntime = {
+      enabled: false,
+      onEnvelope: () => ({ unregister: () => {} }),
+      publish: async () => {},
+      stop: async () => {},
+      subscribePull: () => {
+        throw new Error("synthetic subscribePull failure");
+      },
+    };
+    const brainConsumers: BrainConsumer[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({ runtime: throwingRuntime, brainConsumers }),
+    );
+
+    const original = process.stderr.write.bind(process.stderr);
+    let stderr = "";
+    process.stderr.write = (chunk: unknown): boolean => {
+      stderr += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    };
+    try {
+      // Per CLAUDE.md "no empty catch blocks" — the wiring never rejects; it
+      // logs and moves on so sibling agents still wire (cortex.ts's
+      // `for (const agent of brainAgents)` boot loop depends on this).
+      await expect(
+        startForAgent(agent("yarrow", ["soc.compose.flow"])),
+      ).resolves.toBeUndefined();
+    } finally {
+      process.stderr.write = original;
+    }
+
+    expect(stderr).toContain("brain consumer init failed");
+    expect(stderr).toContain("agent=yarrow");
+    expect(stderr).toContain("synthetic subscribePull failure");
+    // The consumer was pushed onto brainConsumers[] BEFORE the failing
+    // subscribe (mirrors the pre-extraction closure's ordering), so the
+    // shutdown drain still sees it.
+    expect(brainConsumers).toHaveLength(1);
+  });
+});

--- a/src/runner/__tests__/release-consumer-boot.test.ts
+++ b/src/runner/__tests__/release-consumer-boot.test.ts
@@ -1,0 +1,201 @@
+/**
+ * S8 (epic #1514, cortex#1522) — release-consumer boot-wiring tests.
+ *
+ * Unit-level coverage of `wireReleaseConsumers` IN ISOLATION — no
+ * `startCortex`, no filesystem, no NATS. Assertions the pre-extraction
+ * inline per-agent loop body never had at this grain: that `startForAgent`
+ * can be exercised directly against a fixture opts object, that it binds the
+ * expected subject pattern + durable via the runtime's `subscribePull`, and
+ * that it pushes onto the shared `releaseConsumers[]` array passed in (this
+ * module doesn't own that array's lifecycle — see the file header in
+ * `release-consumer-boot.ts`).
+ *
+ * The full `startCortex` integration coverage (the byte-identical-when-absent
+ * hard contract, dormancy, partial-failure isolation) lives in
+ * `src/__tests__/cortex.release-consumer-boot.test.ts` and continues to pass
+ * unchanged against this extraction — that file is the
+ * byte-identical-behaviour regression guard; this one is the new module's
+ * own unit contract.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  wireReleaseConsumers,
+  type ReleaseBootAgent,
+  type WireReleaseConsumersOpts,
+} from "../release-consumer-boot";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+  MyelinSubscribePullOpts,
+} from "../../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../../bus/myelin/subscriber";
+import { ReleaseConsumer } from "../release-consumer";
+
+interface RecordingRuntime extends MyelinRuntime {
+  subscribePullCalls: MyelinSubscribePullOpts[];
+}
+
+/** Mirrors `review-consumer-boot.test.ts`'s recorder — see that file for the rationale. */
+function fakeRuntime(): RecordingRuntime {
+  const handlers = new Set<EnvelopeHandler>();
+  const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+  return {
+    enabled: false,
+    subscribePullCalls,
+    onEnvelope(h) {
+      handlers.add(h);
+      return { unregister: () => handlers.delete(h) };
+    },
+    publish: async (_e: Envelope) => {},
+    stop: async () => {},
+    subscribePull: (opts: MyelinSubscribePullOpts): MyelinSubscriber => {
+      subscribePullCalls.push(opts);
+      return {
+        pattern: opts.pattern,
+        ready: Promise.resolve(),
+        stop: async () => {},
+      } as unknown as MyelinSubscriber;
+    },
+  };
+}
+
+function baseOpts(overrides: Partial<WireReleaseConsumersOpts> = {}): WireReleaseConsumersOpts {
+  return {
+    principalId: "andreas",
+    systemEventSource: { principal: "andreas", agent: "cortex", instance: "local" },
+    runtime: fakeRuntime(),
+    makeOfferAdmission: () => () => ({ admit: true }),
+    releaseConsumers: [],
+    releaseJsm: null,
+    releaseStream: "RELEASE",
+    releaseConsumerMaxDeliver: 5,
+    releaseOfferingPatterns: ["local.andreas.work.tasks.release.cut"],
+    releaseSubjectPattern: "local.andreas.work.tasks.release.cut",
+    ...overrides,
+  };
+}
+
+function agent(id: string, capabilities: readonly string[]): ReleaseBootAgent {
+  return {
+    id,
+    runtime: { capabilities },
+  };
+}
+
+describe("wireReleaseConsumers — local binding", () => {
+  test("startForAgent binds the local pattern/durable and pushes onto the shared releaseConsumers[]", async () => {
+    const runtime = fakeRuntime();
+    const releaseConsumers: ReleaseConsumer[] = [];
+    const { startForAgent } = wireReleaseConsumers(
+      baseOpts({ runtime, releaseConsumers }),
+    );
+
+    await startForAgent(agent("forge", ["release.cut"]));
+
+    expect(releaseConsumers).toHaveLength(1);
+    expect(releaseConsumers[0]!.agent.id).toBe("forge");
+
+    expect(runtime.subscribePullCalls).toHaveLength(1);
+    expect(runtime.subscribePullCalls[0]!.pattern).toBe(
+      "local.andreas.work.tasks.release.cut",
+    );
+    expect(runtime.subscribePullCalls[0]!.durable).toBe(
+      "cortex-release-consumer-andreas-forge",
+    );
+    expect(runtime.subscribePullCalls[0]!.stream).toBe("RELEASE");
+  });
+
+  test("the generic 'release' capability also claims the lane", async () => {
+    const runtime = fakeRuntime();
+    const releaseConsumers: ReleaseConsumer[] = [];
+    const { startForAgent } = wireReleaseConsumers(
+      baseOpts({ runtime, releaseConsumers }),
+    );
+
+    await startForAgent(agent("forge", ["release"]));
+
+    expect(releaseConsumers).toHaveLength(1);
+  });
+
+  test("dormant runtime (no subscribePull) → consumer still constructed, no throw", async () => {
+    const dormantRuntime: MyelinRuntime = {
+      enabled: false,
+      onEnvelope: () => ({ unregister: () => {} }),
+      publish: async () => {},
+      stop: async () => {},
+      // subscribePull omitted — ReleaseConsumer.start() treats that as dormant.
+    };
+    const releaseConsumers: ReleaseConsumer[] = [];
+    const { startForAgent } = wireReleaseConsumers(
+      baseOpts({ runtime: dormantRuntime, releaseConsumers }),
+    );
+
+    await startForAgent(agent("forge", ["release.cut"]));
+
+    expect(releaseConsumers).toHaveLength(1);
+  });
+});
+
+describe("wireReleaseConsumers — CO-2 offer scope", () => {
+  test("a second offered scope binds an extra offer consumer on its own durable", async () => {
+    const runtime = fakeRuntime();
+    const releaseConsumers: ReleaseConsumer[] = [];
+    const { startForAgent } = wireReleaseConsumers(
+      baseOpts({
+        runtime,
+        releaseConsumers,
+        releaseOfferingPatterns: [
+          "local.andreas.work.tasks.release.cut",
+          "federated.andreas.work.tasks.release.cut",
+        ],
+      }),
+    );
+
+    await startForAgent(agent("forge", ["release.cut"]));
+
+    // Local + one offer-scope consumer.
+    expect(releaseConsumers).toHaveLength(2);
+    const patterns = runtime.subscribePullCalls.map((c) => c.pattern);
+    expect(patterns).toContain("local.andreas.work.tasks.release.cut");
+    expect(patterns).toContain("federated.andreas.work.tasks.release.cut");
+    const durables = runtime.subscribePullCalls.map((c) => c.durable);
+    expect(durables.some((d) => d.includes("offer-federated"))).toBe(true);
+  });
+});
+
+describe("wireReleaseConsumers — per-agent failure isolation", () => {
+  test("a synchronous failure inside startForAgent is caught and logged, not thrown", async () => {
+    const releaseConsumers: ReleaseConsumer[] = [];
+    const { startForAgent } = wireReleaseConsumers(
+      baseOpts({
+        releaseConsumers,
+        makeOfferAdmission: () => {
+          throw new Error("synthetic makeOfferAdmission failure");
+        },
+      }),
+    );
+
+    const original = process.stderr.write.bind(process.stderr);
+    let stderr = "";
+    process.stderr.write = (chunk: unknown): boolean => {
+      stderr += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    };
+    try {
+      // Per CLAUDE.md "no empty catch blocks" — the wiring never rejects; it
+      // logs and moves on so sibling agents still wire (cortex.ts's
+      // `for (const agent of releaseCapableAgents)` boot loop depends on this).
+      await expect(startForAgent(agent("forge", ["release.cut"]))).resolves.toBeUndefined();
+    } finally {
+      process.stderr.write = original;
+    }
+
+    expect(stderr).toContain("release consumer init failed");
+    expect(stderr).toContain("agent=forge");
+    expect(stderr).toContain("synthetic makeOfferAdmission failure");
+    // The failure happened before `new ReleaseConsumer`/`.push()` ran.
+    expect(releaseConsumers).toHaveLength(0);
+  });
+});

--- a/src/runner/brain-consumer-boot.ts
+++ b/src/runner/brain-consumer-boot.ts
@@ -1,0 +1,439 @@
+/**
+ * S8 lane 2 (epic #1514, plan §2, cortex#1522) — boot wiring for the
+ * per-agent exec-brain consumer construction, extracted from the
+ * ~200-line `startBrainConsumersForAgent` closure that used to live inline
+ * in `src/cortex.ts` (Bot Packs B-1/B-2, cortex#1021/#1033). Modeled on S7's
+ * `review-consumer-boot.ts`: a narrow structural `BrainBootAgent`
+ * projection + a `WireBrainConsumersOpts` interface listing every
+ * boot-scoped value the wiring needs, so the construction is
+ * unit-testable without standing up `startCortex`.
+ *
+ * **Same two-call-site shape as the review lane.** `cortex.ts` calls this
+ * construction TWICE — once in the boot loop over `brainAgents`, and again
+ * from the `agents.d/` hot-reload path for each added/changed exec-brain
+ * agent (§B-1 design §7/§11). `wireBrainConsumers` returns a callable,
+ * `startForAgent`, that `cortex.ts` invokes per agent at both sites, exactly
+ * where `startBrainConsumersForAgent(agent)` used to be called.
+ *
+ * **No hosting filter here.** The `isBrainHosted` predicate (an exec-brain
+ * agent with at least one declared capability) stays in `cortex.ts` — both
+ * call sites only ever invoke `startForAgent` for an agent already known to
+ * be brain-hosted (`brainAgents`/`isBrainHosted`). This module has nothing
+ * to decide about eligibility; it only builds + subscribes. Same division of
+ * labour as `wireReviewConsumers`.
+ *
+ * **`opts.brainConsumers` / `opts.daemonBrainHosts` are shared, NOT owned,
+ * arrays.** `cortex.ts` still declares `const brainConsumers: BrainConsumer[]
+ * = []` and `const daemonBrainHosts: DaemonBrainHost[] = []`, and reads both
+ * for the hot-reload diff (`drainConsumersForAgent`) and the shutdown drain —
+ * both well outside this slice's scope. `startForAgent` pushes onto the SAME
+ * array references (passed once as opts fields), so those call sites keep
+ * seeing every consumer/host this module wires, unchanged.
+ *
+ * **`opts.brainPresenceHolder` is a shared, mutable HOLDER OBJECT — not a
+ * mutable-capture that needs getter/setter threading.** The holder itself
+ * (`{ producer: AgentPresenceProducer | null }`) is a `const` in `cortex.ts`,
+ * constructed once, before this module is ever called; only its `.producer`
+ * FIELD is assigned later (once the presence producer is constructed,
+ * further down boot). Passing the object by reference means a daemon host's
+ * `onDegraded` callback — which fires at RUNTIME, long after boot, reading
+ * `opts.brainPresenceHolder.producer` lazily — sees the assignment cortex.ts
+ * made in between, exactly as the inline closure did. No getter/setter pair
+ * is needed because the reference itself is never reassigned.
+ *
+ * **Free-variable capture — no mutable-capture threading needed for the
+ * rest.** Every other value `WireBrainConsumersOpts` carries is a plain
+ * snapshot, because none of the captured `cortex.ts` `let`s are reassigned
+ * after `wireBrainConsumers` is constructed (boot-time, right where the old
+ * closure used to be defined) and before either call site runs: `runtime`
+ * (a `let`) is assigned once from either `options.injectRuntime` or
+ * `startMyelinRuntime(...)`, well before the boot loop or any hot-reload
+ * event. `surfacePrincipalGate`, `brainPackBaseDir`, `reviewJsm`,
+ * `brainTasksStream`, `reviewConsumerMaxDeliver`, `reviewPrincipalId`, and
+ * `systemEventSource` are all `const`s assigned exactly once, earlier in
+ * boot. The old closure only ever READ these — it never reassigned any of
+ * them — so a plain value capture at construction time is behaviourally
+ * identical to the inline closure's live-binding read.
+ *
+ * **`collectBrainSecrets` / `loadBrainPersona` moved here wholesale.** Both
+ * were module-level private helpers in `cortex.ts` with no callers outside
+ * the extracted closure — they move with it rather than staying behind as
+ * now-orphaned functions.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  BrainConsumer,
+  BRAIN_TASK_SUBJECT_FAMILY,
+  type BrainConsumerAgent,
+} from "../bus/brain-consumer";
+import { provisionReviewConsumer, type ProvisionJsm } from "../bus/jetstream/provision";
+import { makeExecBrainRunner } from "../brain/exec-brain-runner";
+import { DaemonBrainHost } from "../brain/daemon-brain-host";
+import type { SystemEventSource } from "../bus/system-events";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { AgentPresenceProducer } from "./agent-presence-producer";
+import type { SurfacePrincipalGate } from "../bus/surface-principal-gate";
+import type { AgentModelClass } from "../bus/sovereignty-gate";
+
+// ---------------------------------------------------------------------------
+// The narrow agent shape the boot wiring consumes
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal projection of a cortex.yaml `Agent` the brain boot wiring needs —
+ * structural (not the full Zod `Agent`) so `cortex.ts` passes
+ * `mergedAgents`/hot-reload agents without a cast, mirroring
+ * `ReviewBootAgent`/`DevBootAgent`.
+ */
+export interface BrainBootAgent {
+  id: string;
+  /** Path to the agent's persona markdown file (Architecture §9.3). */
+  persona: string;
+  runtime?: {
+    capabilities?: readonly string[];
+    maxConcurrent?: number;
+    /** Governance Stage 1b — feeds the consumer-side sovereignty gate. */
+    modelClass?: AgentModelClass;
+    brain?: {
+      kind: "builtin" | "exec";
+      /** Argv template, e.g. `"bun {pack}/brain/main.ts"`. Required for `exec`. */
+      run?: string;
+      lifecycle: "per-task" | "daemon";
+      /** Env var NAMES to forward into the brain's minimal env. */
+      secrets: readonly string[];
+      /** The manifest ALLOW-LIST for `dispatch` effects. */
+      dispatch_capabilities: readonly string[];
+      /** Daemon supervision restart cap (`lifecycle: daemon` only). */
+      maxRestarts: number;
+    };
+  };
+}
+
+/** Inputs `cortex.ts` threads into the brain-consumer boot wiring. */
+export interface WireBrainConsumersOpts {
+  /** Arc install dir `{pack}` expands to (`{brainPackBaseDir}/{agentId}`). */
+  brainPackBaseDir: string;
+  /** `{principal}` subject segment — durable names. */
+  reviewPrincipalId: string;
+  /** `{stack}` subject segment — subscribe pattern. */
+  stack: string;
+  /** Bus-side event source every consumer publishes lifecycle envelopes through. */
+  systemEventSource: SystemEventSource;
+  /** The (possibly dormant) MyelinRuntime the consumer subscribes against. */
+  runtime: MyelinRuntime;
+  /**
+   * B-3 (design-bot-packs.md §4, §6, §8) — the shared surface-reply gate for
+   * `ask_principal` effects. Undefined ⇒ the consumer keeps its DenyAll
+   * default (fail-closed — no configured surface identity to verify a reply
+   * against).
+   */
+  surfacePrincipalGate?: SurfacePrincipalGate;
+  /**
+   * Shared, mutable holder for the presence producer — see the file header's
+   * note on why this is a reference, not a getter/setter pair. `cortex.ts`
+   * owns the assignment (further down boot, once the producer is
+   * constructed); this module only reads `.producer` lazily inside a daemon
+   * host's `onDegraded` callback.
+   */
+  brainPresenceHolder: { producer: AgentPresenceProducer | null };
+  /**
+   * Shared consumer array — the SAME array `cortex.ts` owns for its
+   * hot-reload diff (`drainConsumersForAgent`) and shutdown drain. This
+   * module pushes onto it; it does not own the array's lifecycle.
+   */
+  brainConsumers: BrainConsumer[];
+  /**
+   * Shared daemon-host array — ditto, for `lifecycle: daemon` teardown
+   * (hot-swap drain + unconditional shutdown stop).
+   */
+  daemonBrainHosts: DaemonBrainHost[];
+  /** Resolved JetStream manager, or `null` when the runtime is dormant. */
+  reviewJsm: ProvisionJsm | null;
+  /** BRAIN_TASKS stream name (B-3, cortex#1021). */
+  brainTasksStream: string;
+  /** Durable max-deliver, shared with the review/release lanes. */
+  reviewConsumerMaxDeliver: number;
+}
+
+/** The callable `cortex.ts` invokes per agent, at both the boot loop and the `agents.d/` hot-reload sites. */
+export interface WiredBrainConsumers {
+  startForAgent: (agent: BrainBootAgent) => Promise<void>;
+}
+
+/**
+ * Bot Packs B-1 (cortex#1033 §Maintainability) — collect the declared brain
+ * secrets from THIS process's env. Only named keys are forwarded into the
+ * brain's minimal env (the runner enforces the minimal-env policy; §8). A
+ * named-but-unset secret is simply absent (logged once for visibility — the
+ * install-time consent is the arc-side gate). Pure except for the stderr log.
+ */
+function collectBrainSecrets(
+  agentId: string,
+  declared: readonly string[],
+): Record<string, string> {
+  const secrets: Record<string, string> = {};
+  const missing: string[] = [];
+  for (const name of declared) {
+    const value = process.env[name];
+    if (value !== undefined) secrets[name] = value;
+    else missing.push(name);
+  }
+  if (missing.length > 0) {
+    process.stderr.write(
+      `cortex: brain agent=${agentId} declares secrets not present in the ` +
+        `environment: [${missing.join(",")}] — they will be absent from ` +
+        `the brain process (install-time consent is the arc-side gate)\n`,
+    );
+  }
+  return secrets;
+}
+
+/**
+ * Bot Packs B-1 (cortex#1033 §Maintainability) — read the persona text once at
+ * brain start. `personaPath` is the loader-resolved file PATH. A
+ * missing/unreadable persona is non-fatal: returns `undefined` (the brain
+ * receives no persona) and logs once.
+ */
+function loadBrainPersona(
+  agentId: string,
+  personaPath: string,
+): string | undefined {
+  try {
+    return readFileSync(personaPath, "utf-8");
+  } catch (personaErr) {
+    process.stderr.write(
+      `cortex: brain agent=${agentId} persona unreadable at "${personaPath}": ` +
+        `${personaErr instanceof Error ? personaErr.message : String(personaErr)} — ` +
+        `proceeding without persona\n`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Build the per-agent exec-brain consumer construction. Returns
+ * `startForAgent` — the same construction the boot loop (over `brainAgents`)
+ * and the `agents.d/` hot-reload path (for an added/changed exec-brain
+ * agent) both call, so a hot-added agent's brain consumer starts identically
+ * to a boot agent's. Never throws: a single agent's consumer-init failure is
+ * caught and logged so siblings still wire (mirrors the pre-extraction
+ * closure).
+ */
+export function wireBrainConsumers(
+  opts: WireBrainConsumersOpts,
+): WiredBrainConsumers {
+  const startForAgent = async (agent: BrainBootAgent): Promise<void> => {
+    try {
+      const brain = agent.runtime?.brain;
+      if (brain?.kind !== "exec" || brain.run === undefined) {
+        // Defensive: the caller filters to exec brains with a `run`; a
+        // mis-routed builtin/absent brain is a no-op, not a crash.
+        return;
+      }
+      const caps = agent.runtime?.capabilities ?? [];
+      const consumerAgent: BrainConsumerAgent = {
+        id: agent.id,
+        capabilities: caps,
+        dispatchCapabilities: brain.dispatch_capabilities,
+        ...(agent.runtime?.maxConcurrent !== undefined && {
+          maxConcurrent: agent.runtime.maxConcurrent,
+        }),
+        ...(agent.runtime?.modelClass !== undefined && {
+          modelClass: agent.runtime.modelClass,
+        }),
+      };
+
+      // Resolve the per-task runner over the manifest `brain` block. `{pack}`
+      // expands to `{base}/{agentId}` (the arc install dir; design §7.1). The
+      // declared secrets resolve from THIS process's env at spawn — only the
+      // named keys are forwarded into the brain's minimal env (the runner
+      // enforces the minimal-env policy; §8). A named-but-unset secret is
+      // simply absent in the env (logged once for visibility). cortex#1033
+      // §Maintainability — secret collection + persona load are extracted to
+      // the module-level `collectBrainSecrets` / `loadBrainPersona` helpers so
+      // this startup closure reads as a sequence of named steps.
+      const packDir = join(opts.brainPackBaseDir, agent.id);
+      const secrets = collectBrainSecrets(agent.id, brain.secrets);
+
+      // Persona delivered to the brain — per-task brains receive it on each task
+      // event; daemon brains receive it ONCE in the `hello` handshake (§5
+      // "Persona delivery"). A missing/unreadable persona is non-fatal.
+      const personaText = loadBrainPersona(agent.id, agent.persona);
+
+      // Bot Packs B-2 — `lifecycle: daemon` is hosted by a long-lived
+      // DaemonBrainHost (spawn once, socket-multiplex tasks, supervise + drain);
+      // `per-task` (default) keeps the B-1 per-spawn runner. Both feed the SAME
+      // BrainConsumer policy seam (the consumer is lifecycle-agnostic — it routes
+      // brain effects through the host hooks identically). The lifecycle-specific
+      // runner is mutually exclusive: a daemon agent passes `daemonHost` (no
+      // per-task runner constructed), a per-task agent passes `runBrainTask`.
+      // The `principalGate` (B-3, cortex#1021 W-2): when the principal has a
+      // configured surface identity, every brain consumer gets the SHARED
+      // `surfacePrincipalGate` — `ask_principal` renders to the task's
+      // surface/thread and awaits the principal's identity-checked reply via
+      // the `gateReplyRouter` bridge (wired into each adapter's inbound flow
+      // at adapter start). Tasks that are bus-only, on a surface this
+      // instance doesn't host, or on a surface with no configured principal
+      // id STILL fail closed inside the gate (resolve-time checks). With no
+      // principal surface identity at all the consumer keeps its
+      // DenyAllPrincipalGate default (B-1 fail-closed).
+      // Sovereignty audit-parity by default, mirroring ReviewConsumer (a
+      // self-declared modelClass is spoofable until bound to the signing
+      // identity, cortex#327).
+      const baseConsumerOpts = {
+        agent: consumerAgent,
+        source: opts.systemEventSource,
+        runtime: opts.runtime,
+        ...(personaText !== undefined && { persona: personaText }),
+        ...(opts.surfacePrincipalGate !== undefined && {
+          principalGate: opts.surfacePrincipalGate,
+        }),
+      };
+      let daemonHost: DaemonBrainHost | undefined;
+      let consumer: BrainConsumer;
+      if (brain.lifecycle === "daemon") {
+        daemonHost = new DaemonBrainHost({
+          agentId: agent.id,
+          run: brain.run,
+          packDir,
+          secrets,
+          maxRestarts: brain.maxRestarts,
+          ...(personaText !== undefined && { persona: personaText }),
+          // On degradation (restart budget exhausted) surface the agent via the
+          // presence producer's capability-change signal (drop to empty caps),
+          // the same path the reconcile uses (§7.4). Read the holder lazily —
+          // the producer is constructed after this boot closure runs.
+          onDegraded: (degradedId: string): void => {
+            const producer = opts.brainPresenceHolder.producer;
+            if (producer !== null) {
+              producer.publishCapabilitiesChanged(degradedId, []);
+            }
+            process.stderr.write(
+              `cortex: daemon brain agent=${degradedId} marked DEGRADED — ` +
+                `restart budget exhausted; presence signalled\n`,
+            );
+          },
+        });
+        // Spawn + connect + hello. A spawn/connect failure is logged; the
+        // consumer still registers so a later reload can replace it. The
+        // consumer's runner (the host's runTask) fast-fails not_now until the
+        // host connects, so no task is silently lost.
+        // Non-blocking start (sage cortex#1035 round 3): start() resolves on
+        // the socket handshake, so awaiting here would make cortex boot
+        // latency the SUM of every daemon's spawn+auth. The consumer's
+        // runner fast-fails not_now until the host connects (documented
+        // above), so registering the consumer before the handshake settles
+        // loses nothing — failures land in the same stderr path.
+        void daemonHost.start().catch((startErr: unknown) => {
+          process.stderr.write(
+            `cortex: daemon brain host start failed for agent=${agent.id}: ` +
+              `${startErr instanceof Error ? startErr.message : String(startErr)}\n`,
+          );
+        });
+        opts.daemonBrainHosts.push(daemonHost);
+        consumer = new BrainConsumer({ ...baseConsumerOpts, daemonHost });
+      } else {
+        const runBrainTask = makeExecBrainRunner({ run: brain.run, packDir, secrets });
+        consumer = new BrainConsumer({ ...baseConsumerOpts, runBrainTask });
+      }
+      opts.brainConsumers.push(consumer);
+
+      // Provision + bind one durable pull consumer per declared capability.
+      // Subject grammar: `local.{principal}.{stack}.tasks.{capability}` (the
+      // myelin task-envelope grammar the design + agent envelopes use — the
+      // capability is a literal trailing segment, no `>` wildcard since a brain
+      // task subject is exact per capability). Durable name is unique per
+      // (principal, agent, capability).
+      //
+      // cortex#1033 §Architecture/§HonestOracle — provision ALL capability
+      // durables UP-FRONT and AWAIT them BEFORE calling `consumer.start()`, so
+      // the bind inside `start()` cannot race ahead of a not-yet-created durable
+      // on a virgin broker. This mirrors the review path (which awaits
+      // `provisionReviewConsumer` before `consumer.start()`); the brain path
+      // previously fired `void provisionReviewConsumer(...)` from inside the
+      // synchronous `resolve` callback, which returned the subscription params
+      // immediately while provisioning was still in flight. `resolve` is now a
+      // pure subject/durable resolver with no side effect.
+      // B-3 (cortex#1021): brain task subjects live on the `brain.` family /
+      // BRAIN_TASKS stream — NOT `tasks.`/CODE_REVIEW (where B-1 bound them,
+      // a stream that never carried non-code-review capabilities). The inbound
+      // dispatch publishes onto exactly this subject.
+      const brainCapabilities = consumerAgent.capabilities;
+      const brainDurableFor = (capability: string): string =>
+        `cortex-brain-consumer-${opts.reviewPrincipalId}-${agent.id}-${capability.replaceAll(".", "-")}`;
+      const brainPatternFor = (capability: string): string =>
+        `local.${opts.reviewPrincipalId}.${opts.stack}.${BRAIN_TASK_SUBJECT_FAMILY}.${capability}`;
+
+      if (opts.reviewJsm !== null) {
+        // Hoisted to a local `const` — a narrowed PROPERTY access
+        // (`opts.reviewJsm`) does not survive into the nested `async`
+        // closure below (TS drops property narrowing across closure
+        // boundaries), while a narrowed `const` binding does. Mirrors the
+        // pre-extraction closure, which narrowed a plain top-level `const
+        // reviewJsm`.
+        const jsm = opts.reviewJsm;
+        // Independent durables — provision in one parallel wave (sage
+        // cortex#1033 round 2); still awaited as a whole BEFORE start().
+        await Promise.all(
+          brainCapabilities.map(async (capability) => {
+            const durable = brainDurableFor(capability);
+            try {
+              await provisionReviewConsumer({
+                jsm,
+                stream: opts.brainTasksStream,
+                durable,
+                filterSubject: brainPatternFor(capability),
+                maxDeliver: opts.reviewConsumerMaxDeliver,
+              });
+            } catch (provisionErr) {
+              // Don't abort — let `consumer.start()` surface the bind failure
+              // through its own dormant/skip path (mirrors the review path).
+              process.stderr.write(
+                `cortex: provisionReviewConsumer (brain) failed for "${durable}": ` +
+                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+              );
+            }
+          }),
+        );
+      }
+
+      const started = await consumer.start({
+        resolve: (capability) => ({
+          pattern: brainPatternFor(capability),
+          stream: opts.brainTasksStream,
+          durable: brainDurableFor(capability),
+        }),
+      });
+
+      const capSummary =
+        started.capabilities.length > 0 ? started.capabilities.join(",") : "(none)";
+      if (started.subscribedCapabilities.length > 0) {
+        console.log(
+          `cortex: brain consumer ready for agent=${agent.id} kind=exec ` +
+            `capabilities=[${capSummary}] subscribed=[${started.subscribedCapabilities.join(",")}] ` +
+            `gate=${opts.surfacePrincipalGate !== undefined ? "surface" : "deny-all"}`,
+        );
+      } else {
+        console.log(
+          `cortex: brain consumer DORMANT for agent=${agent.id} kind=exec ` +
+            `capabilities=[${capSummary}] ` +
+            `gate=${opts.surfacePrincipalGate !== undefined ? "surface" : "deny-all"} ` +
+            `— cortex MyelinRuntime subscriptions disabled ` +
+            `(G-1111 pending; tasks.{capability} envelopes will not be claimed by this brain)`,
+        );
+      }
+    } catch (err) {
+      // Per CLAUDE.md: log every error. One brain's wiring failure does NOT
+      // abort boot; the consumer (if pushed) stays in `brainConsumers[]` so the
+      // shutdown drain still calls `.stop()` (idempotent).
+      process.stderr.write(
+        `cortex: brain consumer init failed for agent=${agent.id}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  };
+
+  return { startForAgent };
+}

--- a/src/runner/release-consumer-boot.ts
+++ b/src/runner/release-consumer-boot.ts
@@ -1,0 +1,261 @@
+/**
+ * S8 lane 3 (epic #1514, plan §2, cortex#1522) — boot wiring for the
+ * per-agent release-consumer construction, extracted from the per-agent body
+ * of the `if (releaseCapableAgents.length > 0) { … for (const agent of
+ * releaseCapableAgents) { … } }` inline block that used to live in
+ * `src/cortex.ts` (F-4.1, cortex#835).
+ *
+ * **Different shape than `wireBrainConsumers`/`wireReviewConsumers` — and
+ * why.** Both siblings extract a NAMED closure called from TWO sites (a boot
+ * loop AND an `agents.d/` hot-reload path). The release lane has no
+ * hot-reload path (cortex#835's F-4.1 never wired one for `release.cut` —
+ * "PRINCIPAL-GATED, ALWAYS-HUMAN" work is dispatched, not hot-swapped) and
+ * only ONE call site: the boot-time `for (const agent of
+ * releaseCapableAgents)` loop, itself gated behind
+ * `releaseCapableAgents.length > 0` (the "HARD CONTRACT — byte-identical boot
+ * when no agent declares the capability" the block's original header
+ * documents). This module extracts ONLY the per-agent
+ * construct+provision+start+log body — the surrounding gate, the
+ * `releaseCapableAgents` filter, the `RELEASE` stream provisioning, and the
+ * `releaseJsm` resolution all STAY in `cortex.ts`, unchanged, because they
+ * run once per boot (not once per agent) and nothing here needs to
+ * unit-test them in isolation.
+ *
+ * **PRESERVE THE ASYMMETRY.** Do not add a hot-reload call site for this
+ * lane — that would be new behaviour, not a refactor. If release ever needs
+ * hot-reload, that is a separate, deliberate change with its own review, not
+ * a side effect of this extraction.
+ *
+ * **`opts.releaseConsumers` is a shared, NOT owned, array.** `cortex.ts`
+ * still declares `const releaseConsumers: ReleaseConsumer[] = []` and reads
+ * it for the shutdown drain (outside this slice's scope). `startForAgent`
+ * pushes onto the SAME array reference (passed once as an opts field), so
+ * that call site keeps seeing every consumer this module wires, unchanged.
+ *
+ * **Free-variable capture — no mutable-capture threading needed.** Every
+ * value `WireReleaseConsumersOpts` carries is a plain snapshot: `runtime`
+ * (a `let`, elsewhere in `cortex.ts`) settles once at boot — well before the
+ * release block runs — and is never reassigned again; every other captured
+ * value (`principalId`, `systemEventSource`, `makeOfferAdmission`,
+ * `releaseJsm`, `releaseStream`, `releaseConsumerMaxDeliver`,
+ * `releaseOfferingPatterns`, `releaseSubjectPattern`) is a `const` assigned
+ * exactly once, in the `if (releaseCapableAgents.length > 0)` setup that
+ * remains in `cortex.ts` immediately before the (former) per-agent loop body
+ * this module now is. The old loop body only ever READ these — it never
+ * reassigned any of them — so a plain value capture at construction time is
+ * behaviourally identical to the inline loop's live-binding read.
+ */
+
+import {
+  ReleaseConsumer,
+  type ReleaseConsumerAgent,
+} from "./release-consumer";
+import { provisionReviewConsumer, type ProvisionJsm } from "../bus/jetstream/provision";
+import type { SystemEventSource } from "../bus/system-events";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { GateFloorDecision } from "../bus/gate-floor";
+
+// ---------------------------------------------------------------------------
+// The narrow agent shape the boot wiring consumes
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal projection of a cortex.yaml `Agent` the release boot wiring
+ * needs — structural (not the full Zod `Agent`) so `cortex.ts` passes
+ * `releaseCapableAgents` without a cast, mirroring `ReviewBootAgent`/
+ * `DevBootAgent`/`BrainBootAgent`.
+ */
+export interface ReleaseBootAgent {
+  id: string;
+  runtime?: {
+    capabilities?: readonly string[];
+    maxConcurrent?: number;
+  };
+}
+
+/** Inputs `cortex.ts` threads into the release-consumer boot wiring. */
+export interface WireReleaseConsumersOpts {
+  /** `{principal}` subject segment — durable names. */
+  principalId: string;
+  /** Bus-side event source every consumer publishes lifecycle envelopes through. */
+  systemEventSource: SystemEventSource;
+  /** The (possibly dormant) MyelinRuntime the consumer subscribes against. */
+  runtime: MyelinRuntime;
+  /** CO-2/CO-4 per-offer-scope admission gate factory, keyed by capability id. */
+  makeOfferAdmission: (
+    capability: string,
+  ) => (envelope: Envelope, subject: string) => GateFloorDecision;
+  /**
+   * Shared consumer array — the SAME array `cortex.ts` owns for the shutdown
+   * drain. This module pushes onto it; it does not own the array's
+   * lifecycle.
+   */
+  releaseConsumers: ReleaseConsumer[];
+  /** Resolved JetStream manager, or `null` when the runtime is dormant. */
+  releaseJsm: ProvisionJsm | null;
+  /** RELEASE stream name. */
+  releaseStream: string;
+  /** Durable max-deliver, shared with the review/brain lanes. */
+  releaseConsumerMaxDeliver: number;
+  /** CO-2 offer-scope Offer patterns for `release.cut` (`[releaseSubjectPattern]` for the local-only default). */
+  releaseOfferingPatterns: readonly string[];
+  /** The primary local subject pattern — the `releaseOfferingPatterns[0]` fallback. */
+  releaseSubjectPattern: string;
+}
+
+/** The callable `cortex.ts` invokes per agent, inside the preserved `if (releaseCapableAgents.length > 0) { for (…) }` boot block. */
+export interface WiredReleaseConsumers {
+  startForAgent: (agent: ReleaseBootAgent) => Promise<void>;
+}
+
+/**
+ * Build the per-agent release-consumer construction. Returns `startForAgent`
+ * — the same construction the boot-time `for (const agent of
+ * releaseCapableAgents)` loop calls (the lane's ONLY call site; no
+ * hot-reload — see the file header). Never throws: a single agent's
+ * consumer-init failure is caught and logged so siblings still wire (mirrors
+ * the pre-extraction loop body).
+ */
+export function wireReleaseConsumers(
+  opts: WireReleaseConsumersOpts,
+): WiredReleaseConsumers {
+  const startForAgent = async (agent: ReleaseBootAgent): Promise<void> => {
+    try {
+      const caps = agent.runtime?.capabilities ?? [];
+      const consumerAgent: ReleaseConsumerAgent = {
+        id: agent.id,
+        capabilities: caps,
+        ...(agent.runtime?.maxConcurrent !== undefined && {
+          maxConcurrent: agent.runtime.maxConcurrent,
+        }),
+      };
+      // F-4.1 — no executor wired yet (see block header). The consumer is
+      // dormant-but-present: capability declared + gate ladder live.
+      const consumer = new ReleaseConsumer({
+        agent: consumerAgent,
+        source: opts.systemEventSource,
+        runtime: opts.runtime,
+        // CO-2/CO-4 — per-offer-scope admission gate (inert on `local.`).
+        offerAdmission: opts.makeOfferAdmission("release.cut"),
+      });
+      opts.releaseConsumers.push(consumer);
+
+      const durable = `cortex-release-consumer-${opts.principalId}-${agent.id}`;
+      if (opts.releaseJsm !== null) {
+        try {
+          const outcome = await provisionReviewConsumer({
+            jsm: opts.releaseJsm,
+            stream: opts.releaseStream,
+            durable,
+            maxDeliver: opts.releaseConsumerMaxDeliver,
+          });
+          if (outcome === "created") {
+            console.log(
+              `cortex: provisioned JetStream durable "${durable}" on stream "${opts.releaseStream}"`,
+            );
+          } else if (outcome === "updated") {
+            console.log(
+              `cortex: reconciled JetStream durable "${durable}" on stream "${opts.releaseStream}"`,
+            );
+          }
+        } catch (provisionErr) {
+          process.stderr.write(
+            `cortex: provisionReviewConsumer failed for "${durable}": ` +
+              `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+          );
+        }
+      }
+
+      // CO-2 (cortex#941) — bind on the offering-admitted scope prefixes.
+      // `releaseOfferingPatterns[0]` is byte-identical to
+      // `releaseSubjectPattern` for the CO-1 default (`local`-only); the
+      // `.slice(1)` loop is empty unless `release.cut` is offered wider.
+      const primaryReleasePattern =
+        opts.releaseOfferingPatterns[0] ?? opts.releaseSubjectPattern;
+      const started = await consumer.start({
+        pattern: primaryReleasePattern,
+        stream: opts.releaseStream,
+        durable,
+      });
+      // F-4.1 — log line flags `executor=none` so a principal grepping boot
+      // can see the lane is declared but the forge seam is not yet wired.
+      if (started.subscribed) {
+        console.log(
+          `cortex: release consumer ready for agent=${agent.id} capability=release.cut executor=none (gated; principal-grant required) — PRINCIPAL-GATED, ALWAYS-HUMAN`,
+        );
+      } else {
+        console.log(
+          `cortex: release consumer DORMANT for agent=${agent.id} capability=release.cut executor=none — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.release.cut envelopes will not be claimed by this consumer)`,
+        );
+      }
+      // CO-2 — extra offering scopes (federated/public) beyond the primary
+      // local one, each on its own scope-named durable. Empty for the CO-1
+      // default ⇒ byte-identical boot.
+      for (const extraPattern of opts.releaseOfferingPatterns.slice(1)) {
+        const scopeToken = extraPattern.split(".", 1)[0] ?? "scope";
+        // A NEW consumer instance per extra scope (one filter per JetStream
+        // pull consumer) — same idiom as the review lane + the NIT-fix on the
+        // dev lane. The CO-2/CO-4 admission gate is wired here too so the
+        // wider-scope release dispatch clears its floor.
+        const extraConsumer = new ReleaseConsumer({
+          agent: consumerAgent,
+          source: opts.systemEventSource,
+          runtime: opts.runtime,
+          offerAdmission: opts.makeOfferAdmission("release.cut"),
+        });
+        opts.releaseConsumers.push(extraConsumer);
+        const extraDurable = `cortex-release-consumer-offer-${scopeToken}-${opts.principalId}-${agent.id}`;
+        if (opts.releaseJsm !== null) {
+          try {
+            const outcome = await provisionReviewConsumer({
+              jsm: opts.releaseJsm,
+              stream: opts.releaseStream,
+              durable: extraDurable,
+              maxDeliver: opts.releaseConsumerMaxDeliver,
+            });
+            if (outcome === "created") {
+              console.log(
+                `cortex: provisioned JetStream durable "${extraDurable}" on stream "${opts.releaseStream}"`,
+              );
+            } else if (outcome === "updated") {
+              console.log(
+                `cortex: reconciled JetStream durable "${extraDurable}" on stream "${opts.releaseStream}"`,
+              );
+            }
+          } catch (provisionErr) {
+            process.stderr.write(
+              `cortex: provisionReviewConsumer failed for "${extraDurable}": ` +
+                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+            );
+          }
+        }
+        const extraStarted = await extraConsumer.start({
+          pattern: extraPattern,
+          stream: opts.releaseStream,
+          durable: extraDurable,
+        });
+        if (extraStarted.subscribed) {
+          console.log(
+            `cortex: release consumer (offer:${scopeToken}) ready for agent=${agent.id} capability=release.cut executor=none pattern=${extraPattern}`,
+          );
+        } else {
+          console.log(
+            `cortex: release consumer (offer:${scopeToken}) DORMANT for agent=${agent.id} capability=release.cut executor=none — cortex MyelinRuntime subscriptions disabled (${extraPattern} envelopes will not be claimed by this consumer)`,
+          );
+        }
+      }
+    } catch (err) {
+      // Per CLAUDE.md "no empty catch blocks": a single agent's release
+      // consumer crash does NOT abort boot — siblings still wire. The
+      // consumer stays in `releaseConsumers[]` so the shutdown drain still
+      // calls `.stop()` (idempotent — handles the "never subscribed" case).
+      process.stderr.write(
+        `cortex: release consumer init failed for agent=${agent.id}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  };
+
+  return { startForAgent };
+}


### PR DESCRIPTION
## Summary

S8 (epic #1514, plan §2) — two behavior-preserving extractions from `src/cortex.ts` (6736 → 6390 lines), modeled on S7's `wireReviewConsumers` (#1542). Two separate commits, one lane each.

### Lane 2 — brain (`src/runner/brain-consumer-boot.ts`)

Extracts the ~200-line `startBrainConsumersForAgent` closure into `wireBrainConsumers(opts) → { startForAgent }`. Same two-call-site shape as review: the boot loop over `brainAgents` and the `agents.d/` hot-reload path both call the returned `startForAgent`, exactly where the inline closure used to be called. Destructured locally as `startBrainForAgent` (not the bare `startForAgent`) because review's own `startForAgent` binding lives in the same top-level scope of `startCortex` — the two would otherwise collide.

`collectBrainSecrets`/`loadBrainPersona` (previously module-level private helpers in `cortex.ts` with no other callers) moved wholesale into the new module.

**Captured opts** (all plain-value snapshots — no getter/setter threading needed): `brainPackBaseDir`, `reviewPrincipalId`, `stack` (`derivedStack.stack`), `systemEventSource`, `runtime`, `surfacePrincipalGate`, `brainPresenceHolder`, `brainConsumers`, `daemonBrainHosts`, `reviewJsm`, `brainTasksStream`, `reviewConsumerMaxDeliver`.

- `runtime` is a `let` elsewhere in `cortex.ts`, but it settles exactly once (either `options.injectRuntime` or `startMyelinRuntime(...)`) well before `wireBrainConsumers` is constructed and before either call site runs — read-only after that point, so a plain capture is behaviorally identical to the old closure's live-binding read.
- `brainPresenceHolder` is a **mutable holder object**, not a mutable-capture needing threading: the holder itself is a `const`, constructed once; only its `.producer` field is assigned later (once the presence producer is built, further down boot). Passed by reference so a daemon host's `onDegraded` callback — which fires at runtime, long after boot — still sees the field cortex.ts assigns in between, exactly like the inline closure did.
- `brainConsumers` / `daemonBrainHosts` are shared arrays cortex.ts still owns for the hot-reload diff (`drainConsumersForAgent`) and shutdown drain; this module only pushes onto them.

### Lane 3 — release (`src/runner/release-consumer-boot.ts`)

**Different shape than brain/review — deliberately.** Release has exactly **ONE call site** and **no hot-reload path** (F-4.1 never wired one for `release.cut` — "PRINCIPAL-GATED, ALWAYS-HUMAN" work is dispatched, not hot-swapped). Only the per-agent construct+provision+start+log body moves out; the surrounding `if (releaseCapableAgents.length > 0) { ... }` gate, the `releaseCapableAgents` filter, the `RELEASE` stream provisioning, and the `releaseJsm` resolution all **stay in `cortex.ts` unchanged** — they run once per boot, not once per agent, so there's nothing here to unit-test in isolation. **The asymmetry (no hot-reload) is preserved, not "fixed"** — inventing a hot-reload call site would be new behavior, out of scope for this extraction.

Since release's construction is fully contained inside its own `if` block (no other closure needs to reach it later), the destructured binding is literally `startForAgent` — it's block-scoped and doesn't collide with review's top-level `startForAgent`.

**Captured opts:** `principalId`, `systemEventSource`, `runtime`, `makeOfferAdmission`, `releaseConsumers`, `releaseJsm`, `releaseStream`, `releaseConsumerMaxDeliver`, `releaseOfferingPatterns`, `releaseSubjectPattern` — all `const`s assigned exactly once in the `if` setup immediately before the (former) loop body, read-only from the old loop's perspective. No mutables.

## Structure confirmed

- Brain: **2 call sites** — boot loop (`for (const agent of brainAgents) { await startBrainForAgent(agent); }`) and `agents.d/` hot-reload (`else if (isBrainHosted(agent)) { await startBrainForAgent(agent); }`).
- Release: **1 call site, no hot-reload** — `for (const agent of releaseCapableAgents) { await startForAgent(agent); }` inside the preserved `if` gate.
- `grep -n "startBrainConsumersForAgent" src/cortex.ts` → 0 matches (old name fully retired).

## Test coverage

**Existing integration tests — stayed green, unchanged:**
- `src/__tests__/cortex.agents-reload.test.ts` — the B-1 brain hot-reload suite (ADD/hot-reload an exec-brain fragment, mutual exclusion with the review path) — exercises brain lane through the real `startCortex` boot path.
- `src/__tests__/cortex.dev-stream-boot.test.ts` — `BRAIN_TASKS` stream provisioning.
- `src/__tests__/cortex.release-consumer-boot.test.ts` — the release lane's hard contract (byte-identical boot when zero release-capable agents), dormancy, and partial-failure isolation, through the real `startCortex` boot path.
- `src/__tests__/cortex.capability-boot.test.ts`, `src/__tests__/cortex.test.ts` — general boot regression.

**New unit tests (this PR):**
- `src/runner/__tests__/brain-consumer-boot.test.ts` — per-capability durable/pattern binding, builtin/absent-brain no-op, dormant-runtime non-throw, `lifecycle: daemon` pushes a `DaemonBrainHost`, per-agent failure isolation (logged, not thrown).
- `src/runner/__tests__/release-consumer-boot.test.ts` — local pattern/durable binding, the generic `release` capability alias, dormant-runtime non-throw, CO-2 offer-scope extra-durable binding, per-agent failure isolation.

I'm **not** claiming byte-identical output beyond what these tests actually pin (subject patterns, durable names, stream names, push-order into the shared arrays, and the specific log-line shapes asserted above) — the two existing `startCortex`-integration suites are the primary behavior-preservation proof; the new unit tests are this module's own contract, exercised without booting `startCortex`.

## Gates

```
bunx tsc --noEmit                                    → TSC=0
bun run lint:errors                                   → LINT=0
bun test src/runner src/__tests__/cortex.test.ts \
  src/__tests__/cortex.agents-reload.test.ts \
  src/__tests__/cortex.dev-stream-boot.test.ts \
  src/__tests__/cortex.release-consumer-boot.test.ts \
  src/__tests__/cortex.capability-boot.test.ts        → 948 pass, 0 fail
bun test (full suite)                                 → 8902-8903 pass, 8 skip, 8 todo, 0 fail
```

One flaky, wholly unrelated full-suite failure was observed on one run (`ConfigWatcher — github.repos hot-reload (cortex#135) > removing a repo from github.repos also applies as a safe field`, a filesystem-watcher timing test in `src/common/config/__tests__/watcher.test.ts`) — reproduces at 0/4 fail in isolation, confirming it's pre-existing fs-watch timing flake, not a regression from this change.

`cortex.ts`: 6736 → 6390 lines (net **-346**; two commits: brain lane -453/+43, release lane -138/net see individual commits).

Closes #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)