### PR TITLE
test-bullet4

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-admit.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-admit.test.ts
@@ -10,9 +10,11 @@
  *         /admission-requests/:id/admit
  *      c. Optionally assign Discord role (O-5 via --discord-member)
  *
- * All live surfaces (registry HTTP, Discord API) are mocked via globalThis.fetch
- * and the DiscordAdmitClient injection seam. No arc binary is called — ADR-0015
- * retires Model-A credential minting.
+ * All live surfaces (registry HTTP, Discord API) are mocked via
+ * `globalThis.fetch` and — S5 (cortex#1519) — an injected fake
+ * {@link AdmitPortsFactory} for the Discord assign tests (replaces the old
+ * `__setDiscordAdmitClientForTests` mutable-singleton seam). No arc binary is
+ * called — ADR-0015 retires Model-A credential minting.
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
@@ -20,13 +22,9 @@ import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import {
-  dispatchNetwork,
-  __setDiscordAdmitClientForTests,
-  type DiscordAdmitClient,
-  type SecretPortsFactory,
-} from "../network";
+import { dispatchNetwork, type SecretPortsFactory, type AdmitPortsFactory, type ExitResult } from "../network";
 import type { NetworkSecretPorts } from "../network-secret-ports";
+import { buildLiveAdmitPorts } from "../network-admit-adapters";
 import { dispatchProvisionStack } from "../provision-stack";
 
 // cortex#1517 (S3, epic #1514) — live-registry round-trip coverage. Drives the
@@ -67,10 +65,20 @@ function freshDir(): string {
 const realFetch = globalThis.fetch;
 
 afterEach(() => {
-  __setDiscordAdmitClientForTests(null);
   globalThis.fetch = realFetch;
   while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
 });
+
+/**
+ * S5 (cortex#1519) — `dispatchNetwork` with an injected `admitPortsFactory`
+ * (11th positional param, after the 9 other injectable-ports factories).
+ * Used by the Discord-assign tests below to fake JUST the discord port while
+ * the registry/seal ports stay live (driven by the mocked `globalThis.fetch`
+ * / `secretPortsFactory`, same as every other test in this file).
+ */
+function dispatchWithAdmitPorts(argv: string[], admitPortsFactory: AdmitPortsFactory): Promise<ExitResult> {
+  return dispatchNetwork(argv, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, admitPortsFactory);
+}
 
 /**
  * Mint a real admin nkey seed file (chmod 600) via provision-stack and return
@@ -362,23 +370,21 @@ describe("cortex network admit — Discord O-5 role", () => {
   test("--discord-member with successful role assign → discord_status=assigned", async () => {
     const { seedPath } = await mintAdminSeed();
     const req = pendingRequest();
-    let resolvedRole = false;
-    let assignedRole = false;
+    let assignCalled = false;
 
-    const mockDiscord: DiscordAdmitClient = {
-      async resolveRoleId(_token, _guildId, roleName) {
-        resolvedRole = true;
-        expect(roleName).toBe("community-fleet");
-        return "role-id-123";
+    // S5 (cortex#1519) — inject a fake discord port; registry/seal stay LIVE
+    // (driven by the mocked fetch below), matching every other test here.
+    const admitPortsFactory: AdmitPortsFactory = (cfg) => ({
+      ...buildLiveAdmitPorts(cfg),
+      discord: {
+        async assignRole(inputs) {
+          assignCalled = true;
+          expect(inputs.role).toBe("community-fleet");
+          expect(inputs.member).toBe("user-snowflake-999");
+          return { status: "assigned", warning: "" };
+        },
       },
-      async assignRole(_token, _guildId, userId, roleId) {
-        assignedRole = true;
-        expect(userId).toBe("user-snowflake-999");
-        expect(roleId).toBe("role-id-123");
-        return { success: true };
-      },
-    };
-    __setDiscordAdmitClientForTests(mockDiscord);
+    });
 
     setMockFetch(async (input) => {
       const url = urlOf(input);
@@ -392,18 +398,17 @@ describe("cortex network admit — Discord O-5 role", () => {
       });
     });
 
-    const res = await dispatchNetwork([
+    const res = await dispatchWithAdmitPorts([
       "admit", "req-abc-123",
       "--admin-seed", seedPath,
       "--discord-member", "user-snowflake-999",
       "--discord-guild", "guild-123",
       "--apply",
       "--json",
-    ]);
+    ], admitPortsFactory);
 
     expect(res.exitCode).toBe(0);
-    expect(resolvedRole).toBe(true);
-    expect(assignedRole).toBe(true);
+    expect(assignCalled).toBe(true);
     const env = JSON.parse(res.stdout) as { data: { discord_status: string } };
     expect(env.data.discord_status).toBe("assigned");
   });
@@ -412,11 +417,17 @@ describe("cortex network admit — Discord O-5 role", () => {
     const { seedPath } = await mintAdminSeed();
     const req = pendingRequest();
 
-    const mockDiscord: DiscordAdmitClient = {
-      async resolveRoleId() { return "role-id-123"; },
-      async assignRole() { return { success: false, error: "missing_permissions" }; },
-    };
-    __setDiscordAdmitClientForTests(mockDiscord);
+    const admitPortsFactory: AdmitPortsFactory = (cfg) => ({
+      ...buildLiveAdmitPorts(cfg),
+      discord: {
+        async assignRole() {
+          return {
+            status: "failed",
+            warning: "Discord role assignment failed: missing_permissions — admission committed, assign role manually",
+          };
+        },
+      },
+    });
 
     setMockFetch(async (input) => {
       const url = urlOf(input);
@@ -430,14 +441,14 @@ describe("cortex network admit — Discord O-5 role", () => {
       });
     });
 
-    const res = await dispatchNetwork([
+    const res = await dispatchWithAdmitPorts([
       "admit", "req-abc-123",
       "--admin-seed", seedPath,
       "--discord-member", "user-999",
       "--discord-guild", "guild-123",
       "--apply",
       "--json",
-    ]);
+    ], admitPortsFactory);
 
     // Admission committed → exit 0. Discord partial failure is a warning.
     expect(res.exitCode).toBe(0);
@@ -446,19 +457,20 @@ describe("cortex network admit — Discord O-5 role", () => {
     expect(env.data.discord_warning).toContain("missing_permissions");
   });
 
-  test("custom --discord-role is forwarded to resolveRoleId", async () => {
+  test("custom --discord-role is forwarded to the discord port", async () => {
     const { seedPath } = await mintAdminSeed();
     const req = pendingRequest();
     let capturedRoleName = "";
 
-    const mockDiscord: DiscordAdmitClient = {
-      async resolveRoleId(_token, _guildId, roleName) {
-        capturedRoleName = roleName;
-        return "custom-role-id";
+    const admitPortsFactory: AdmitPortsFactory = (cfg) => ({
+      ...buildLiveAdmitPorts(cfg),
+      discord: {
+        async assignRole(inputs) {
+          capturedRoleName = inputs.role;
+          return { status: "assigned", warning: "" };
+        },
       },
-      async assignRole() { return { success: true }; },
-    };
-    __setDiscordAdmitClientForTests(mockDiscord);
+    });
 
     setMockFetch(async (input) => {
       const url = urlOf(input);
@@ -472,14 +484,14 @@ describe("cortex network admit — Discord O-5 role", () => {
       });
     });
 
-    await dispatchNetwork([
+    await dispatchWithAdmitPorts([
       "admit", "req-abc-123",
       "--admin-seed", seedPath,
       "--discord-member", "user-999",
       "--discord-guild", "guild-123",
       "--discord-role", "sovereign-member",
       "--apply",
-    ]);
+    ], admitPortsFactory);
 
     expect(capturedRoleName).toBe("sovereign-member");
   });

--- a/src/cli/cortex/commands/network-admit-adapters.ts
+++ b/src/cli/cortex/commands/network-admit-adapters.ts
@@ -1,0 +1,385 @@
+/**
+ * S5 (#1519, epic #1514) — LIVE + DRY-RUN adapters for `cortex network admit`
+ * / `cortex network reject` / `cortex network admit --list-pending`.
+ *
+ * The real side effects the orchestration (`network-admit-lib.ts`) depends on:
+ *   - REGISTRY — admin-signed reads (single request / status-filtered list)
+ *     + the admit/reject decision POST. The signed read header is built via
+ *     the lib's pure {@link buildAdmissionReadHeader}; the signed decision
+ *     claim is built by the lib's `buildAdmissionDecisionBody` and handed to
+ *     {@link AdmitRegistryPort.postDecision} already-signed (a build failure
+ *     and a POST failure are distinct error classes, so building stays out
+ *     of this port — see `network-admit-lib.ts`).
+ *   - DISCORD  — best-effort O-5 community-fleet role ASSIGN ONLY, moved
+ *     verbatim from network.ts's `runAdmit` inline block. The old
+ *     `__setDiscordAdmitClientForTests` mutable-singleton override is gone —
+ *     tests inject a fake {@link AdmitDiscordPort} via the ports factory
+ *     instead. Reject's role REMOVAL stays on the pre-S5
+ *     `removeDiscordFleetRole` helper in network.ts (shared with `secret
+ *     revoke-member`, out of scope here) — see network-admit-ports.ts.
+ *   - SEAL     — {@link sealAdmittedMember} moved VERBATIM (byte-for-byte,
+ *     same steps, same order) from network.ts. It delegates to the EXISTING
+ *     `secret add-member` orchestration via an injected `secretPortsFactory`
+ *     — no payload-key/PSK crypto runs here directly. cortex#1481/ADR-0018:
+ *     do not reorder or "clean up" this function — a changed byte in the
+ *     hub-locality gate or the seal-vs-write sequencing breaks federated
+ *     admission.
+ *
+ * Like the join/leave adapters (`network-adapters.ts`), this module exports
+ * BOTH a live constructor and a dry-run constructor. In practice `runAdmit`/
+ * `runReject` (network.ts) never construct EITHER for a dry-run invocation —
+ * dry-run prints its plan and returns before any port is built (the pre-S5
+ * behaviour: `fetchCalled` stays `false`). `buildDryRunAdmitPorts` exists for
+ * parity with the sibling triplets and as a defence-in-depth safe fallback,
+ * not because the current control flow reaches it.
+ */
+
+import {
+  assignRole as discordAssignRoleApi,
+  resolveRoleId as discordResolveRoleIdApi,
+  loadConfig as loadDiscordConfig,
+  resolveServerContext,
+} from "../lib/discord-roles";
+import type { StackIdentityMaterial } from "../../../bus/stack-provisioning";
+import { buildAdmissionReadHeader } from "./network-admit-lib";
+import { runNetworkSecret, type SecretInputs, type SecretReport } from "./network-secret-lib";
+import type { NetworkSecretPorts } from "./network-secret-ports";
+import { buildLiveSecretPorts } from "./network-secret-adapters";
+import type {
+  AdmissionDecision,
+  AdmissionListRow,
+  AdmissionRow,
+  AdmitDiscordPort,
+  AdmitPorts,
+  AdmitRegistryPort,
+  AdmitSealOutcome,
+  AdmitSealPort,
+  DiscordRoleInputs,
+  DiscordRoleOutcome,
+  GetRequestResult,
+  ListRequestsResult,
+  PostDecisionResult,
+  SealMemberArgs,
+  SignedAdmissionDecision,
+} from "./network-admit-ports";
+
+/**
+ * Mirrors network.ts's own `SecretPortsFactory` structurally (an inline type,
+ * not an import — avoids a circular import back into network.ts, which
+ * imports THIS file). C-1316's fold-in seal reuses `secret add-member`'s
+ * existing ports factory verbatim.
+ */
+export type SecretPortsFactory = (cfg: {
+  hubConfigPath: string;
+  registryUrl: string;
+  material: StackIdentityMaterial;
+}) => NetworkSecretPorts;
+
+export interface LiveAdmitPortsConfig {
+  registryUrl: string;
+  material: StackIdentityMaterial;
+  /** C-1316 — builds the ports the fold-in seal delegates to (`secret
+   *  add-member`). Only meaningful for `admit` (`reject` never seals).
+   *  Production omits it → the live secret-ports adapters. */
+  secretPortsFactory?: SecretPortsFactory;
+  /** Injectable fetch (tests). Production omits → globalThis.fetch. */
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+function buildAdmitPorts(cfg: LiveAdmitPortsConfig, mutate: boolean): AdmitPorts {
+  return {
+    registry: mutate ? buildLiveAdmitRegistryPort(cfg) : buildDryRunAdmitRegistryPort(),
+    discord: mutate ? buildLiveAdmitDiscordPort() : buildDryRunAdmitDiscordPort(),
+    seal: mutate ? buildLiveAdmitSealPort(cfg) : buildDryRunAdmitSealPort(),
+  };
+}
+
+/** Live ports — every effect mutates the deployment. */
+export function buildLiveAdmitPorts(cfg: LiveAdmitPortsConfig): AdmitPorts {
+  return buildAdmitPorts(cfg, true);
+}
+
+/** Dry-run ports — every mutation is a safe no-op. See the module doc for why
+ *  the current admit/reject control flow never actually reaches these. */
+export function buildDryRunAdmitPorts(cfg: LiveAdmitPortsConfig): AdmitPorts {
+  return buildAdmitPorts(cfg, false);
+}
+
+// =============================================================================
+// REGISTRY — admin-signed reads + the admit/reject decision POST.
+// =============================================================================
+
+function buildLiveAdmitRegistryPort(cfg: LiveAdmitPortsConfig): AdmitRegistryPort {
+  const base = cfg.registryUrl.replace(/\/+$/, "");
+  const fetchImpl = cfg.fetchImpl ?? globalThis.fetch;
+  const material = cfg.material;
+
+  return {
+    async getRequest(requestId): Promise<GetRequestResult> {
+      const readHeader = await buildAdmissionReadHeader(material);
+      const getUrl = `${base}/admission-requests/${encodeURIComponent(requestId)}`;
+      const resp = await fetchImpl(getUrl, {
+        method: "GET",
+        headers: { "Content-Type": "application/json", "x-admin-signed": readHeader },
+      });
+      if (resp.status === 404) return { outcome: "not_found" };
+      if (!resp.ok) {
+        const body = await resp.text();
+        return { outcome: "error", status: resp.status, body };
+      }
+      const row = (await resp.json()) as AdmissionRow;
+      return { outcome: "ok", row };
+    },
+
+    async listRequests(status): Promise<ListRequestsResult> {
+      const readHeader = await buildAdmissionReadHeader(material);
+      const getUrl = `${base}/admission-requests?status=${encodeURIComponent(status)}`;
+      const resp = await fetchImpl(getUrl, {
+        method: "GET",
+        headers: { "Content-Type": "application/json", "x-admin-signed": readHeader },
+      });
+      if (resp.status === 403) {
+        const body = await resp.text();
+        return { outcome: "forbidden", body };
+      }
+      if (!resp.ok) {
+        const body = await resp.text();
+        return { outcome: "error", status: resp.status, body };
+      }
+      const rows = (await resp.json()) as AdmissionListRow[];
+      return { outcome: "ok", rows };
+    },
+
+    async postDecision(
+      requestId: string,
+      decision: AdmissionDecision,
+      signedBody: SignedAdmissionDecision,
+    ): Promise<PostDecisionResult> {
+      const postUrl = `${base}/admission-requests/${encodeURIComponent(requestId)}/${decision}`;
+      const resp = await fetchImpl(postUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(signedBody),
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        // reject's richer classification (admit's lib collapses all three of
+        // these back into the SAME generic message it always used — see
+        // `admitDecisionFailureMessage` in network-admit-lib.ts).
+        if (resp.status === 409 && body.includes("already_decided")) return { outcome: "already_decided", body };
+        if (resp.status === 404) return { outcome: "not_found", body };
+        if (resp.status === 403) return { outcome: "forbidden", body };
+        return { outcome: "error", status: resp.status, body };
+      }
+      // Best-effort principal_id extraction (admit doesn't need it — it
+      // already has principal_id from the GET; reject's summary uses it).
+      try {
+        const row = (await resp.json()) as { principal_id?: string };
+        return { outcome: "ok", principalId: row.principal_id ?? "" };
+      } catch (_err) {
+        return { outcome: "ok" };
+      }
+    },
+  };
+}
+
+/** Dry-run registry port — never invoked by the current admit/reject control
+ *  flow (dry-run short-circuits in network.ts before any port is built), but
+ *  every method is a safe no-op in case that ever changes. */
+function buildDryRunAdmitRegistryPort(): AdmitRegistryPort {
+  return {
+    getRequest: () =>
+      Promise.resolve({ outcome: "error", status: 0, body: "dry-run — registry GET skipped (no mutation)" }),
+    listRequests: () => Promise.resolve({ outcome: "ok", rows: [] }),
+    postDecision: () =>
+      Promise.resolve({ outcome: "error", status: 0, body: "dry-run — registry POST skipped (no mutation)" }),
+  };
+}
+
+// =============================================================================
+// DISCORD — O-5 community-fleet role assign (admit only).
+//
+// NOTE: reject's role REMOVAL is NOT here — it's shared with `secret
+// revoke-member` (out of scope for this slice) and stays on the pre-S5
+// `removeDiscordFleetRole` helper in network.ts. See network-admit-ports.ts's
+// module doc for the full explanation.
+// =============================================================================
+
+/**
+ * Resolve the bot token + guild id an assign acts against: `--guild` flag >
+ * `--server` profile > top-level config (via `resolveServerContext`) — the
+ * SAME precedence admit's original inline block used.
+ */
+function resolveDiscordContext(inputs: DiscordRoleInputs): { botToken?: string; guildId?: string } {
+  const discordConfig = loadDiscordConfig();
+  const ctx = resolveServerContext(discordConfig, { server: inputs.server, guild: inputs.guild });
+  return { botToken: ctx.botToken, guildId: inputs.guild ?? ctx.guildId };
+}
+
+function buildLiveAdmitDiscordPort(): AdmitDiscordPort {
+  return {
+    async assignRole(inputs: DiscordRoleInputs): Promise<DiscordRoleOutcome> {
+      try {
+        const { botToken, guildId } = resolveDiscordContext(inputs);
+        if (!botToken) {
+          return {
+            status: "skipped_no_token",
+            warning: "Discord role not assigned: no bot token configured (run: discord config set botToken <token>)",
+          };
+        }
+        if (!guildId) {
+          return {
+            status: "skipped_no_guild",
+            warning:
+              "Discord role not assigned: no guild id configured — pass --discord-guild <id> or run: discord config set guildId <id>",
+          };
+        }
+        let roleId: string;
+        try {
+          roleId = await discordResolveRoleIdApi(botToken, guildId, inputs.role);
+        } catch (err) {
+          return {
+            status: "failed",
+            warning: `Discord role not assigned: ${err instanceof Error ? err.message : String(err)} — assign manually`,
+          };
+        }
+        const roleResult = await discordAssignRoleApi(botToken, guildId, inputs.member, roleId);
+        if (roleResult.success) return { status: "assigned", warning: "" };
+        return {
+          status: "failed",
+          warning: `Discord role assignment failed: ${roleResult.error ?? "unknown error"} — admission committed, assign role manually`,
+        };
+      } catch (err) {
+        return {
+          status: "failed",
+          warning: `Discord role assignment error: ${err instanceof Error ? err.message : String(err)} — admission committed, assign role manually`,
+        };
+      }
+    },
+  };
+}
+
+function buildDryRunAdmitDiscordPort(): AdmitDiscordPort {
+  return {
+    assignRole: () => Promise.resolve({ status: "skipped", warning: "dry-run — Discord role assign skipped (no mutation)" }),
+  };
+}
+
+// =============================================================================
+// SEAL — C-1316 admit-and-seal (fold the leaf-secret delivery into admit).
+//
+// cortex#1481/ADR-0018 — WIRE-SENSITIVE. Moved VERBATIM from network.ts: same
+// steps, same order, same hub-locality gate. Do not reorder or "clean up".
+// =============================================================================
+
+/**
+ * Seal + deliver the per-member leaf PSK for a just-admitted member by reusing
+ * the EXISTING `secret add-member` orchestration (`runNetworkSecret`) — nothing
+ * about sealing is reimplemented here.
+ *
+ * The caller has ALREADY committed the admission, so this NEVER throws and NEVER
+ * fails the admit: every failure mode returns a `fallback` outcome that surfaces
+ * the explicit `secret add-member` command instead. Failure modes it degrades on:
+ *   - the admission row is network-less (legacy `network_id = null`) — nothing to
+ *     bind a leaf PSK to;
+ *   - the hub config isn't local / readable (a fully-separable deployment where
+ *     the hub isn't on this host) — `readConf` rejects before any mutation;
+ *   - the admit signer isn't the hub-admin (registry-admin ≠ hub-admin) — the
+ *     registry refuses the sealed-secret delivery.
+ */
+async function sealAdmittedMember(args: {
+  networkId: string | null;
+  memberPubkey: string;
+  registryUrl: string;
+  hubConfigPath: string;
+  material: StackIdentityMaterial;
+  secretPortsFactory: SecretPortsFactory;
+  adminSeedPath: string;
+  /** cortex#1481 — force seal-only (never write the local hub) even when the
+   *  auto-detected locality would otherwise call the hub local. */
+  sealOnly?: boolean;
+  /** cortex#1481 — the hub's own federation account nkey-U, when known. */
+  hubAccount?: string;
+}): Promise<AdmitSealOutcome> {
+  const {
+    networkId,
+    memberPubkey,
+    registryUrl,
+    hubConfigPath,
+    material,
+    secretPortsFactory,
+    adminSeedPath,
+    sealOnly,
+    hubAccount,
+  } = args;
+
+  // A network-less admission row (legacy null network_id) can't be sealed — the
+  // leaf PSK is network-scoped, and `secret add-member` needs a real network id.
+  if (networkId === null || networkId === "") {
+    return {
+      status: "fallback",
+      steps: [],
+      reason:
+        "the admission row has no network_id (legacy / network-less request) — a leaf secret is network-scoped, so it can't be sealed automatically",
+      fallbackCmd: `cortex network secret add-member <network> ${memberPubkey} --admin-seed ${adminSeedPath} --apply`,
+    };
+  }
+
+  const fallbackCmd = `cortex network secret add-member ${networkId} ${memberPubkey} --admin-seed ${adminSeedPath} --apply`;
+
+  const inputs: SecretInputs = {
+    action: "add-member",
+    networkId,
+    memberPubkey,
+    deliver: "sealed",
+    apply: true,
+    ...(sealOnly !== undefined && { sealOnly }),
+    ...(hubAccount !== undefined && { hubAccount }),
+  };
+
+  let report: SecretReport;
+  try {
+    // #1316 nit (PR #1412): construct the ports factory INSIDE the try so the
+    // "seal NEVER throws / NEVER fails the admit" invariant is structural — a
+    // throwing factory (bad hub config, unreadable seed) degrades to `fallback`
+    // like every other seal failure instead of escaping past the committed admit.
+    const ports = secretPortsFactory({ hubConfigPath, registryUrl, material });
+    report = await runNetworkSecret(inputs, ports);
+  } catch (err) {
+    return {
+      status: "fallback",
+      steps: [],
+      reason: `seal could not run: ${err instanceof Error ? err.message : String(err)}`,
+      fallbackCmd,
+    };
+  }
+
+  if (!report.ok) {
+    return {
+      status: "fallback",
+      steps: report.steps,
+      reason: report.reason ?? "seal failed",
+      fallbackCmd,
+    };
+  }
+
+  return {
+    status: "sealed",
+    steps: report.steps,
+    ...(report.hubOwnerArtifact !== undefined && { hubOwnerArtifact: report.hubOwnerArtifact }),
+  };
+}
+
+function buildLiveAdmitSealPort(cfg: LiveAdmitPortsConfig): AdmitSealPort {
+  const secretPortsFactory = cfg.secretPortsFactory ?? ((c) => buildLiveSecretPorts(c));
+  return {
+    sealMember: (args: SealMemberArgs) => sealAdmittedMember({ ...args, secretPortsFactory }),
+  };
+}
+
+function buildDryRunAdmitSealPort(): AdmitSealPort {
+  return {
+    sealMember: () =>
+      Promise.resolve({ status: "skipped", steps: [], reason: "dry-run — seal skipped (no mutation)" }),
+  };
+}

--- a/src/cli/cortex/commands/network-admit-lib.ts
+++ b/src/cli/cortex/commands/network-admit-lib.ts
@@ -1,0 +1,446 @@
+/**
+ * S5 (#1519, epic #1514) — `cortex network admit` / `cortex network reject` /
+ * `cortex network admit --list-pending` orchestration (PURE over ports).
+ *
+ * Extracted from `network.ts`'s ADR-0015 `runAdmit`/C-1348 `runReject`/C-1314
+ * `runListPending` handlers, which stay in `network.ts` as thin commander
+ * wiring (parse + validate flags, load the admin-seed material, build ports,
+ * call the orchestrators below, format the returned report).
+ *
+ * The signing helpers ({@link buildAdmissionReadHeader},
+ * {@link buildAdmissionDecisionBody}) are deterministic crypto over the
+ * SAME `signAdminRequest` bridge every sibling admin-signed command uses
+ * (`network-authorize-lib.ts`, `network-secret-adapters.ts`) — no I/O, no
+ * `fetch`, no `Bun.spawn`. They are exported ONLY for `network-admit-adapters.ts`
+ * to build the signed requests — never for test convenience: the
+ * live-registry round-trip test (`network-admit.test.ts`, cortex#1517 S3)
+ * deliberately drives them only through the real `dispatchNetwork` command
+ * path, never by importing them directly.
+ */
+
+import { randomNonce, signAdminRequest, type StackIdentityMaterial } from "../../../bus/stack-provisioning";
+import type {
+  AdmissionDecision,
+  AdmissionListRow,
+  AdmitPorts,
+  AdmitSealOutcome,
+  DiscordRoleInputs,
+  GetRequestResult,
+  ListRequestsResult,
+  PostDecisionResult,
+  SignedAdmissionDecision,
+} from "./network-admit-ports";
+
+// =============================================================================
+// Deterministic crypto — admin-signed read header + decision claim.
+// =============================================================================
+
+/**
+ * Build an admin-signed read claim for the `x-admin-signed` header.
+ * No nonce (reads are idempotent). Uses the shared PKCS#8 signing bridge.
+ *
+ * Exported so `network-admit-adapters.ts` can build the signed GET requests
+ * without re-deriving the claim shape — NOT exported for test convenience
+ * (the live-registry round-trip test, cortex#1517 S3, deliberately drives
+ * this only through the real `dispatchNetwork` command path).
+ */
+export async function buildAdmissionReadHeader(material: StackIdentityMaterial): Promise<string> {
+  const claim = {
+    admin_pubkey: material.pubkeyB64,
+    issued_at: new Date().toISOString(),
+  };
+  return JSON.stringify(await signAdminRequest(material.seed, claim));
+}
+
+/**
+ * Build the admin-signed admission decision body (ADR-0015: `decision` selects
+ * admit vs reject; no leaf_package — decides the roster row only, mints nothing).
+ * Exported for `network-admit-adapters.ts`'s `postDecision`; see the note above.
+ */
+export async function buildAdmissionDecisionBody(
+  requestId: string,
+  material: StackIdentityMaterial,
+  decision: AdmissionDecision,
+  opts: { issuedAt?: string; nonce?: string } = {},
+): Promise<SignedAdmissionDecision> {
+  const claim = {
+    request_id: requestId,
+    decision,
+    admin_pubkey: material.pubkeyB64,
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+  return signAdminRequest(material.seed, claim);
+}
+
+// =============================================================================
+// C-1314 — pending-table rendering (pure).
+// =============================================================================
+
+/** Render the discovery table (human path). Peer pubkey is truncated to a
+ *  fingerprint for width; the full value rides the --json output. */
+export function renderPendingTable(
+  rows: AdmissionListRow[],
+  status: string,
+  networkFilter: string | undefined,
+  registryUrl: string,
+): string {
+  const scope = networkFilter !== undefined ? ` on network "${networkFilter}"` : "";
+  const header =
+    `cortex network admit --list-pending — ${rows.length.toString()} ${status} request(s)${scope} ` +
+    `(registry: ${registryUrl})`;
+  if (rows.length === 0) {
+    return `${header}\n  (none) — nothing to ${status === "PENDING" ? "admit" : "show"}.\n`;
+  }
+  const cells = rows.map((r) => ({
+    id: r.request_id,
+    principal: r.principal_id,
+    network: r.network_id ?? "(none)",
+    peer: `${r.peer_pubkey.slice(0, 12)}…`,
+    status: r.status,
+    created: r.created_at,
+  }));
+  const w = {
+    id: Math.max("REQUEST-ID".length, ...cells.map((c) => c.id.length)),
+    principal: Math.max("PRINCIPAL".length, ...cells.map((c) => c.principal.length)),
+    network: Math.max("NETWORK".length, ...cells.map((c) => c.network.length)),
+    peer: Math.max("PEER_PUBKEY".length, ...cells.map((c) => c.peer.length)),
+    status: Math.max("STATUS".length, ...cells.map((c) => c.status.length)),
+  };
+  const row = (id: string, principal: string, network: string, peer: string, st: string, created: string): string =>
+    `  ${id.padEnd(w.id)}  ${principal.padEnd(w.principal)}  ${network.padEnd(w.network)}  ${peer.padEnd(w.peer)}  ${st.padEnd(w.status)}  ${created}`;
+  const lines = [header, "", row("REQUEST-ID", "PRINCIPAL", "NETWORK", "PEER_PUBKEY", "STATUS", "CREATED")];
+  for (const c of cells) lines.push(row(c.id, c.principal, c.network, c.peer, c.status, c.created));
+  lines.push("", `To admit: cortex network admit <request-id> --admin-seed <path> --apply`, "");
+  return lines.join("\n");
+}
+
+/**
+ * Pull the current status out of the registry's `already_decided` 409 body.
+ * The route returns `{ error, details, current: <AdmissionRequest> }`; we read
+ * `current.status` (falling back to undefined so the caller degrades to a
+ * generic "already decided" line rather than crashing on an unexpected shape).
+ */
+function extractCurrentStatus(respBody: string): string | undefined {
+  try {
+    const parsed = JSON.parse(respBody) as { current?: { status?: string } };
+    const status = parsed.current?.status;
+    return typeof status === "string" ? status : undefined;
+  } catch (_err) {
+    return undefined;
+  }
+}
+
+// =============================================================================
+// `cortex network admit --list-pending` — C-1314 discovery orchestration.
+// =============================================================================
+
+export interface ListPendingInputs {
+  status: string;
+  networkFilter?: string;
+  registryUrl: string;
+  material: StackIdentityMaterial;
+}
+
+export interface ListPendingReport {
+  ok: boolean;
+  rows: AdmissionListRow[];
+  status: string;
+  networkFilter?: string;
+  registryUrl: string;
+  adminFingerprint: string;
+  reason?: string;
+}
+
+/** ADR-0020 read-scoping limitation, reconstructed verbatim from the pre-S5 inline message. */
+function forbiddenListMessage(networkFilter: string | undefined, body: string): string {
+  return (
+    `registry refused the list (HTTP 403 admin_not_authorized): admission reads are ` +
+    `GLOBAL-admin-only today, so a per-network admin cannot list PENDING requests` +
+    `${networkFilter !== undefined ? ` for "${networkFilter}"` : ""} from the CLI yet. ` +
+    `Per-network read-scoping is the ADR-0020 fast-follow; until then use a global-admin ` +
+    `seed or the MC admission queue (Pier). Registry said: ${body}`
+  );
+}
+
+export async function runNetworkListPending(
+  inputs: ListPendingInputs,
+  ports: AdmitPorts,
+): Promise<ListPendingReport> {
+  const base: Omit<ListPendingReport, "ok" | "rows" | "reason"> = {
+    status: inputs.status,
+    ...(inputs.networkFilter !== undefined && { networkFilter: inputs.networkFilter }),
+    registryUrl: inputs.registryUrl,
+    adminFingerprint: inputs.material.fingerprint,
+  };
+
+  let res: ListRequestsResult;
+  try {
+    res = await ports.registry.listRequests(inputs.status);
+  } catch (err) {
+    return {
+      ...base,
+      ok: false,
+      rows: [],
+      reason: `failed to list admission requests from registry: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (res.outcome === "forbidden") {
+    return { ...base, ok: false, rows: [], reason: forbiddenListMessage(inputs.networkFilter, res.body) };
+  }
+  if (res.outcome === "error") {
+    return { ...base, ok: false, rows: [], reason: `registry list failed (HTTP ${res.status.toString()}): ${res.body}` };
+  }
+
+  const filtered =
+    inputs.networkFilter !== undefined ? res.rows.filter((r) => r.network_id === inputs.networkFilter) : res.rows;
+  return { ...base, ok: true, rows: filtered };
+}
+
+// =============================================================================
+// ADR-0015 — `cortex network admit <request-id>` (apply-path decision + seal + Discord).
+// =============================================================================
+
+export interface AdmitInputs {
+  requestId: string;
+  registryUrl: string;
+  material: StackIdentityMaterial;
+  /** C-1316 — skip the fold-in seal, roster row only. */
+  rosterOnly: boolean;
+  /** cortex#1481 — force seal-only (never write the local hub). */
+  sealOnly: boolean;
+  /** cortex#1481 — the hub's own federation account nkey-U, when known. */
+  hubAccount?: string;
+  hubConfigPath: string;
+  /** The --admin-seed path (rides the seal's fallback command text). */
+  adminSeedPath: string;
+  discord?: DiscordRoleInputs;
+}
+
+/** Discriminated on `ok` so a caller narrows to `sealOutcome`/`principalId`
+ *  without a non-null assertion — both are ALWAYS set together on success. */
+export type AdmitReport =
+  | {
+      ok: true;
+      requestId: string;
+      adminFingerprint: string;
+      principalId: string;
+      sealOutcome: AdmitSealOutcome;
+      discordStatus: string;
+      discordWarning: string;
+    }
+  | {
+      ok: false;
+      requestId: string;
+      adminFingerprint: string;
+      reason: string;
+    };
+
+function admitFail(inputs: AdmitInputs, reason: string): AdmitReport {
+  return {
+    ok: false,
+    requestId: inputs.requestId,
+    adminFingerprint: inputs.material.fingerprint,
+    reason,
+  };
+}
+
+/** ADMIT's POST-failure message has always been fully generic — reconstruct the
+ *  exact prior text (`registry rejected admission (HTTP <n>): <body>`)
+ *  regardless of which discriminated outcome the registry response landed in. */
+function admitDecisionFailureMessage(res: Exclude<PostDecisionResult, { outcome: "ok" }>): string {
+  const status =
+    res.outcome === "not_found" ? 404 : res.outcome === "forbidden" ? 403 : res.outcome === "already_decided" ? 409 : res.status;
+  return `registry rejected admission (HTTP ${status.toString()}): ${res.body}`;
+}
+
+/**
+ * ADR-0015 replacement for `cortex creds grant`. Fetches the PENDING request,
+ * builds + POSTs the signed admit decision, folds in the C-1316 seal (unless
+ * `--roster-only`), and best-effort assigns the O-5 Discord role. The
+ * admission is committed the moment the POST succeeds — every step after that
+ * (seal, Discord) degrades to a warning/fallback rather than failing the admit.
+ */
+export async function runNetworkAdmit(inputs: AdmitInputs, ports: AdmitPorts): Promise<AdmitReport> {
+  // 1. Fetch the PENDING admission request (admin-signed GET).
+  let getRes: GetRequestResult;
+  try {
+    getRes = await ports.registry.getRequest(inputs.requestId);
+  } catch (err) {
+    return admitFail(inputs, `failed to fetch request from registry: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (getRes.outcome === "not_found") {
+    return admitFail(inputs, `request-id "${inputs.requestId}" not found in registry (HTTP 404)`);
+  }
+  if (getRes.outcome === "error") {
+    return admitFail(inputs, `registry GET failed (HTTP ${getRes.status.toString()}): ${getRes.body}`);
+  }
+  const { principal_id: requestPrincipalId, status: requestStatus, peer_pubkey: requestPeerPubkey, network_id: requestNetworkId } =
+    getRes.row;
+
+  // Must be PENDING to admit.
+  if (requestStatus !== "PENDING") {
+    return admitFail(
+      inputs,
+      `request "${inputs.requestId}" is not PENDING (status: ${requestStatus}) — cannot admit an already-decided request`,
+    );
+  }
+
+  // 2. Build + POST the signed admission decision. Building the claim (pure
+  // crypto) and submitting it (I/O) are DISTINCT failure classes with their
+  // own messages — mirrors the pre-S5 two-try-catch split exactly.
+  let signedBody: SignedAdmissionDecision;
+  try {
+    signedBody = await buildAdmissionDecisionBody(inputs.requestId, inputs.material, "admit");
+  } catch (err) {
+    return admitFail(inputs, `failed to build admission decision claim: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  let postRes: PostDecisionResult;
+  try {
+    postRes = await ports.registry.postDecision(inputs.requestId, "admit", signedBody);
+  } catch (err) {
+    return admitFail(inputs, `registry POST failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (postRes.outcome !== "ok") {
+    return admitFail(inputs, admitDecisionFailureMessage(postRes));
+  }
+
+  // 2b. C-1316 — admit-and-seal. The roster row is now ADMITTED; an admitted-
+  // but-unsealed peer is INERT. Reuse the EXISTING `secret add-member` flow
+  // (the seal port) — the admission is ALREADY committed, so the seal NEVER
+  // fails the admit.
+  let sealOutcome: AdmitSealOutcome;
+  if (inputs.rosterOnly) {
+    const net = requestNetworkId ?? "<network>";
+    sealOutcome = {
+      status: "skipped",
+      steps: [],
+      reason: "--roster-only: committed the roster row only, no seal",
+      fallbackCmd: `cortex network secret add-member ${net} ${requestPeerPubkey} --admin-seed ${inputs.adminSeedPath} --apply`,
+    };
+  } else {
+    sealOutcome = await ports.seal.sealMember({
+      networkId: requestNetworkId,
+      memberPubkey: requestPeerPubkey,
+      registryUrl: inputs.registryUrl,
+      hubConfigPath: inputs.hubConfigPath,
+      material: inputs.material,
+      adminSeedPath: inputs.adminSeedPath,
+      sealOnly: inputs.sealOnly,
+      ...(inputs.hubAccount !== undefined && { hubAccount: inputs.hubAccount }),
+    });
+  }
+
+  // 3. Assign Discord role (O-5) — when --discord-member is given.
+  let discordStatus = "skipped";
+  let discordWarning = "";
+  if (inputs.discord !== undefined) {
+    const outcome = await ports.discord.assignRole(inputs.discord);
+    discordStatus = outcome.status;
+    discordWarning = outcome.warning;
+  }
+
+  return {
+    ok: true,
+    requestId: inputs.requestId,
+    adminFingerprint: inputs.material.fingerprint,
+    principalId: requestPrincipalId,
+    sealOutcome,
+    discordStatus,
+    discordWarning,
+  };
+}
+
+// =============================================================================
+// C-1348 — `cortex network reject <request-id>` (admission DENIAL).
+// =============================================================================
+
+export interface RejectInputs {
+  requestId: string;
+  material: StackIdentityMaterial;
+}
+
+export interface RejectReport {
+  ok: boolean;
+  requestId: string;
+  adminFingerprint: string;
+  reason?: string;
+  /** Best-effort — "" when the registry's 200 body wasn't the expected shape. */
+  principalId?: string;
+}
+
+/** REJECT's richer failure mapping — 409 already_decided / 404 / 403 each get
+ *  their own actionable message; reconstructed verbatim from the pre-S5 inline logic. */
+function rejectDecisionFailureMessage(inputs: RejectInputs, res: Exclude<PostDecisionResult, { outcome: "ok" }>): string {
+  if (res.outcome === "already_decided") {
+    const current = extractCurrentStatus(res.body);
+    const was = current !== undefined ? ` (already ${current})` : "";
+    return `request "${inputs.requestId}" is already decided${was} — cannot reject an already-decided request`;
+  }
+  if (res.outcome === "not_found") {
+    return `request-id "${inputs.requestId}" not found in registry (HTTP 404)`;
+  }
+  if (res.outcome === "forbidden") {
+    return (
+      `not authorised to reject request "${inputs.requestId}" — the admin key (${inputs.material.fingerprint}) ` +
+      `is neither a global admin nor an admin of this request's network (HTTP 403)`
+    );
+  }
+  return `registry rejected the decision (HTTP ${res.status.toString()}): ${res.body}`;
+}
+
+/**
+ * ADR-0015's admission-denial verb — the exact mirror of {@link runNetworkAdmit},
+ * except the signed decision claim carries `decision: "reject"`. Grants +
+ * seals NOTHING (a rejected request has no roster row to make connectable),
+ * so — unlike admit — there is no seal step and no pre-check GET (the registry
+ * is the single authority; its POST response carries the decided row or the
+ * error).
+ *
+ * The C-1350 S3 Discord-role REMOVAL that rides along on a successful reject
+ * is NOT this orchestrator's job — it stays in `network.ts` on the shared
+ * `removeDiscordFleetRole` helper (also used by `secret revoke-member`, out
+ * of scope for this slice; see the note above that helper's definition).
+ */
+export async function runNetworkReject(inputs: RejectInputs, ports: AdmitPorts): Promise<RejectReport> {
+  // Building the claim (pure crypto) and submitting it (I/O) are DISTINCT
+  // failure classes with their own messages — mirrors admit's split.
+  let signedBody: SignedAdmissionDecision;
+  try {
+    signedBody = await buildAdmissionDecisionBody(inputs.requestId, inputs.material, "reject");
+  } catch (err) {
+    return {
+      ok: false,
+      requestId: inputs.requestId,
+      adminFingerprint: inputs.material.fingerprint,
+      reason: `failed to build admission decision claim: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  let postRes: PostDecisionResult;
+  try {
+    postRes = await ports.registry.postDecision(inputs.requestId, "reject", signedBody);
+  } catch (err) {
+    return {
+      ok: false,
+      requestId: inputs.requestId,
+      adminFingerprint: inputs.material.fingerprint,
+      reason: `registry POST failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (postRes.outcome !== "ok") {
+    return {
+      ok: false,
+      requestId: inputs.requestId,
+      adminFingerprint: inputs.material.fingerprint,
+      reason: rejectDecisionFailureMessage(inputs, postRes),
+    };
+  }
+
+  return {
+    ok: true,
+    requestId: inputs.requestId,
+    adminFingerprint: inputs.material.fingerprint,
+    principalId: postRes.principalId ?? "",
+  };
+}

--- a/src/cli/cortex/commands/network-admit-ports.ts
+++ b/src/cli/cortex/commands/network-admit-ports.ts
@@ -1,0 +1,191 @@
+/**
+ * S5 (#1519, epic #1514) — `cortex network admit` / `cortex network reject`
+ * injected-dependency seams.
+ *
+ * Mirrors the sibling triplets (`network-secret-ports.ts`,
+ * `network-authorize-ports.ts`): every SIDE EFFECT the admit/reject
+ * orchestration (`network-admit-lib.ts`) depends on is a port — a real adapter
+ * for production (`network-admit-adapters.ts`) and a fake the tests assert
+ * against. The three effect families (ADR-0015 + C-1316 + O-5):
+ *
+ *   - REGISTRY — admin-signed reads (single request / status-filtered list)
+ *     and the signed admit/reject decision POST.
+ *   - DISCORD  — best-effort community-fleet role assign (admit) / remove
+ *     (reject), O-5.
+ *   - SEAL     — fold the per-member leaf-secret delivery into a successful
+ *     admit by delegating to the EXISTING `secret add-member` orchestration
+ *     (C-1316). Payload-key / PSK crypto never runs here directly.
+ */
+
+import type { StackIdentityMaterial } from "../../../bus/stack-provisioning";
+
+// =============================================================================
+// REGISTRY — admission-request reads + the admit/reject decision POST.
+// =============================================================================
+
+/** One admission-request row as the registry's single-request GET returns it. */
+export interface AdmissionRow {
+  request_id: string;
+  principal_id: string;
+  status: string;
+  peer_pubkey: string;
+  network_id: string | null;
+}
+
+/** The subset of a row `admit --list-pending` renders (registry list GET). */
+export interface AdmissionListRow {
+  request_id: string;
+  principal_id: string;
+  peer_pubkey: string;
+  network_id: string | null;
+  status: string;
+  created_at: string;
+}
+
+/** Outcome of an admin-signed GET of a single admission request. */
+export type GetRequestResult =
+  | { outcome: "ok"; row: AdmissionRow }
+  | { outcome: "not_found" }
+  | { outcome: "error"; status: number; body: string };
+
+/**
+ * Outcome of an admin-signed GET of the status-filtered admission list.
+ * `forbidden` is the ADR-0020 read-scoping case (admin reads are
+ * GLOBAL-admin-only today) — kept distinct from a generic `error` so the
+ * caller can render its actionable fast-follow explanation.
+ */
+export type ListRequestsResult =
+  | { outcome: "ok"; rows: AdmissionListRow[] }
+  | { outcome: "forbidden"; body: string }
+  | { outcome: "error"; status: number; body: string };
+
+/**
+ * Outcome of POSTing a signed admission decision (`admit` | `reject`). The
+ * richer discriminants (`not_found` / `forbidden` / `already_decided`) exist
+ * because `reject` distinguishes them into different messages; `admit`
+ * currently folds every non-ok outcome into one generic message — see
+ * {@link file://./network-admit-lib.ts}'s two separate message builders.
+ */
+export type PostDecisionResult =
+  | { outcome: "ok"; principalId?: string }
+  | { outcome: "not_found"; body: string }
+  | { outcome: "forbidden"; body: string }
+  | { outcome: "already_decided"; body: string }
+  | { outcome: "error"; status: number; body: string };
+
+/** The two roster-decision verbs the registry's shared `handleDecision` accepts. */
+export type AdmissionDecision = "admit" | "reject";
+
+/** An admin-signed admission-decision claim, as `buildAdmissionDecisionBody`
+ *  (`network-admit-lib.ts`, pure crypto) produces it. */
+export interface SignedAdmissionDecision {
+  claim: { request_id: string; decision: AdmissionDecision; admin_pubkey: string; issued_at: string; nonce: string };
+  signature: string;
+}
+
+/** Admin-signed reads of + decisions on the registry's admission-request rows. */
+export interface AdmitRegistryPort {
+  /** Admin-signed GET of a single admission request by id. */
+  getRequest(requestId: string): Promise<GetRequestResult>;
+  /** Admin-signed GET of every request at `status` (client-filters by network). */
+  listRequests(status: string): Promise<ListRequestsResult>;
+  /**
+   * POST an ALREADY-SIGNED admission decision claim (built by the pure
+   * `buildAdmissionDecisionBody` in the lib — signing failures there are a
+   * DISTINCT error class from a POST/network failure, so the claim is built
+   * outside this port and just submitted here).
+   */
+  postDecision(requestId: string, decision: AdmissionDecision, signedBody: SignedAdmissionDecision): Promise<PostDecisionResult>;
+}
+
+// =============================================================================
+// DISCORD — O-5 community-fleet role assign (admit only).
+//
+// NOTE: the reject-side role REMOVAL is NOT part of this port — it turns out
+// to be shared with `secret revoke-member` (out of scope for this slice), so
+// it stays on the pre-S5 `removeDiscordFleetRole` helper in `network.ts`. Only
+// admit's assign side was confirmed admit-exclusive (verified against every
+// test file that references the Discord admit singleton).
+// =============================================================================
+
+/** The flags admit's fleet-role assign reads. */
+export interface DiscordRoleInputs {
+  /** The Discord member snowflake to assign the role to. */
+  member: string;
+  /** `--discord-server` profile name (optional). */
+  server?: string;
+  /** `--discord-guild` id override (optional). */
+  guild?: string;
+  /** Role name-or-id (defaults to `community-fleet`). */
+  role: string;
+}
+
+/** Outcome of a role assign — mirrors the CLI's discord_status/discord_warning fields. NEVER throws. */
+export interface DiscordRoleOutcome {
+  /** skipped | skipped_no_token | skipped_no_guild | assigned | failed. */
+  status: string;
+  /** Actionable warning when the role could not be assigned (empty on success). */
+  warning: string;
+}
+
+/** Best-effort O-5 community-fleet role assign (admit). Never throws — every failure degrades to a warning. */
+export interface AdmitDiscordPort {
+  assignRole(inputs: DiscordRoleInputs): Promise<DiscordRoleOutcome>;
+}
+
+// =============================================================================
+// SEAL — C-1316 admit-and-seal (fold the leaf-secret delivery into admit).
+// =============================================================================
+
+/** sealed = delivered (connectable); skipped = deliberately not run (--roster-only);
+ *  fallback = tried/skipped but couldn't seal (still inert). */
+export type AdmitSealStatus = "sealed" | "skipped" | "fallback";
+
+/** The outcome of folding the per-member leaf-secret seal into a successful admit. */
+export interface AdmitSealOutcome {
+  status: AdmitSealStatus;
+  /** Human transcript lines from the seal — NEVER carry a secret. */
+  steps: string[];
+  /** Why the seal was skipped or fell back. */
+  reason?: string;
+  /** The explicit `secret add-member` command to seal after the fact. */
+  fallbackCmd?: string;
+  /**
+   * cortex#1481 — present iff the seal's hub turned out to be EXTERNAL (or
+   * --seal-only forced it): the hub-owner artifact forwarded verbatim from
+   * `SecretReport.hubOwnerArtifact`. The caller prints it explicitly.
+   */
+  hubOwnerArtifact?: string[];
+}
+
+/** The per-call arguments `sealMember` needs — everything EXCEPT the adapter's
+ *  own construction-time `secretPortsFactory` dependency (that stays a config
+ *  field on the live adapter, not a per-call argument). */
+export interface SealMemberArgs {
+  networkId: string | null;
+  memberPubkey: string;
+  registryUrl: string;
+  hubConfigPath: string;
+  material: StackIdentityMaterial;
+  adminSeedPath: string;
+  /** cortex#1481 — force seal-only (never write the local hub) even when the
+   *  auto-detected locality would otherwise call the hub local. */
+  sealOnly?: boolean;
+  /** cortex#1481 — the hub's own federation account nkey-U, when known. */
+  hubAccount?: string;
+}
+
+/** Seal + deliver the per-member leaf PSK for a just-admitted member (C-1316). */
+export interface AdmitSealPort {
+  sealMember(args: SealMemberArgs): Promise<AdmitSealOutcome>;
+}
+
+// =============================================================================
+// The full port bundle the orchestrator depends on.
+// =============================================================================
+
+export interface AdmitPorts {
+  registry: AdmitRegistryPort;
+  discord: AdmitDiscordPort;
+  seal: AdmitSealPort;
+}

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -51,17 +51,16 @@ import {
   materialFromSeedString,
   buildNetworkCreateClaim,
   postNetworkCreate,
-  randomNonce,
-  signAdminRequest,
   type StackIdentityMaterial,
   type SignedNetworkCreateBody,
 } from "../../../bus/stack-provisioning";
 // O-5 community-fleet role grant (ADR-0015). These runtime helpers live in
 // cortex (src/cli/cortex/lib/discord-roles.ts) — NOT the metafactory-discord
 // bundle the CLI tooling moved to (ADR-0017, epic #1171 S2): the daemon-side
-// admit path cannot import from an external arc bundle.
+// admit path cannot import from an external arc bundle. Admit's ASSIGN side
+// moved to network-admit-adapters.ts (S5); reject's REMOVE side (shared with
+// `secret revoke-member`, out of scope for S5) still uses these directly.
 import {
-  assignRole,
   removeRole,
   resolveRoleId,
   loadConfig as loadDiscordConfig,
@@ -143,7 +142,6 @@ import {
   type SecretAction,
   type DeliveryMode,
   type SecretInputs,
-  type SecretReport,
   type KeyRotationInputs,
 } from "./network-secret-lib";
 import type {
@@ -194,6 +192,14 @@ import {
 } from "./network-authorize-lib";
 import type { NetworkAuthorizePorts } from "./network-authorize-ports";
 import { buildLiveAuthorizePorts } from "./network-authorize-adapters";
+import {
+  runNetworkAdmit,
+  runNetworkReject,
+  runNetworkListPending,
+  renderPendingTable,
+} from "./network-admit-lib";
+import type { AdmitPorts } from "./network-admit-ports";
+import { buildLiveAdmitPorts } from "./network-admit-adapters";
 
 export { type ExitResult } from "./_shared/exit-result";
 
@@ -2347,31 +2353,37 @@ const DEFAULT_ADMIT_REGISTRY_URL = DEFAULT_REGISTRY.url;
 /** Default Discord role for O-5 community-fleet admission. */
 const DEFAULT_ADMIT_DISCORD_ROLE = "community-fleet";
 
-/** Minimal Discord client surface injectable for tests. */
-export interface DiscordAdmitClient {
-  resolveRoleId(botToken: string, guildId: string, roleName: string): Promise<string>;
-  assignRole(botToken: string, guildId: string, userId: string, roleId: string): Promise<{ success: boolean; error?: string }>;
-}
+/**
+ * S5 (#1519, epic #1514) — factory for the admit/reject port bundle (registry
+ * reads/decision + admit's Discord role ASSIGN + the C-1316 seal delegation).
+ * Production builds the live adapters. Tests inject fakes that record calls
+ * without touching HTTP/Discord — replaces the pre-S5 (admit-only)
+ * `__setDiscordAdmitClientForTests` mutable-singleton override.
+ *
+ * NOTE: reject's Discord role REMOVE stays on `removeDiscordFleetRole` below,
+ * NOT this port — it turns out to be shared with `secret revoke-member`
+ * (`network-secret-cli.test.ts`, out of scope for this slice), so it isn't
+ * admit-exclusive the way the assign-side singleton is.
+ */
+export type AdmitPortsFactory = (cfg: {
+  registryUrl: string;
+  material: StackIdentityMaterial;
+  /** Only meaningful for `admit` — the C-1316 fold-in seal delegates to
+   *  `secret add-member`'s own ports factory. `reject` omits it. */
+  secretPortsFactory?: SecretPortsFactory;
+}) => AdmitPorts;
 
-let discordAdmitClientOverride: DiscordAdmitClient | null = null;
-
-/** Test-only setter. Production callers never touch this. Null restores default. */
-export function __setDiscordAdmitClientForTests(client: DiscordAdmitClient | null): void {
-  discordAdmitClientOverride = client;
-}
-
-/** Default production client — thin wrappers over the real discord lib. */
-const defaultDiscordAdmitClient: DiscordAdmitClient = {
-  resolveRoleId,
-  assignRole,
-};
+const DEFAULT_ADMIT_PORTS_FACTORY: AdmitPortsFactory = (cfg) => buildLiveAdmitPorts(cfg);
 
 // ---------------------------------------------------------------------------
 // C-1350 S3 — Tier-1 de-admission: REMOVE the community-fleet role (the inverse
-// of admit's assign). `reject` and `secret revoke-member` share this. The flag
-// resolution mirrors runAdmit's block EXACTLY (same names, same precedence, same
-// graceful degradation) — the only difference is it calls `removeRole`, and a
-// failure is ALWAYS non-fatal (the parent decision has already committed).
+// of admit's assign). `reject` and `secret revoke-member` share this — it is
+// NOT folded into the S5 `AdmitPorts.discord` port (admit-only) because
+// `secret revoke-member` (out of scope for this slice) depends on the same
+// singleton-override test seam. The flag resolution mirrors admit's block
+// EXACTLY (same names, same precedence, same graceful degradation) — the only
+// difference is it calls `removeRole`, and a failure is ALWAYS non-fatal (the
+// parent decision has already committed).
 // ---------------------------------------------------------------------------
 
 /** Minimal Discord client surface (role removal) injectable for tests. */
@@ -2414,11 +2426,11 @@ interface DiscordRemoveOutcome {
 }
 
 /**
- * Remove the community-fleet role from a de-admitted member, mirroring runAdmit's
+ * Remove the community-fleet role from a de-admitted member, mirroring admit's
  * assignment block byte-for-byte in resolution precedence:
  *   `--guild` flag > `--server` profile > top-level config (via
  *   resolveServerContext), with the injected test client short-circuiting token/
- *   guild resolution exactly as admit does.
+ *   guild resolution exactly as admit's did.
  *
  * ALWAYS best-effort: any resolution or API failure returns a `failed`/`skipped_*`
  * status + an actionable "remove the role manually" warning — it NEVER throws, so
@@ -2482,48 +2494,6 @@ async function removeDiscordFleetRole(
   }
 }
 
-/**
- * Build an admin-signed read claim for the `x-admin-signed` header.
- * No nonce (reads are idempotent). Uses the shared PKCS#8 signing bridge.
- */
-async function buildAdmissionReadHeader(
-  material: StackIdentityMaterial,
-): Promise<string> {
-  const claim = {
-    admin_pubkey: material.pubkeyB64,
-    issued_at: new Date().toISOString(),
-  };
-  return JSON.stringify(await signAdminRequest(material.seed, claim));
-}
-
-/**
- * The two roster-decision verbs the registry's shared `handleDecision` accepts
- * (`admit` | `reject`, `types.ts` AdmissionDecision). Both mint nothing — admit
- * moves PENDING→ADMITTED, reject moves PENDING→REJECTED. `revoke` is a distinct
- * post-admission motion, not a PENDING decision, so it is NOT in this union.
- */
-type AdmissionDecision = "admit" | "reject";
-
-/**
- * Build the admin-signed admission decision body (ADR-0015: `decision` selects
- * admit vs reject; no leaf_package — decides the roster row only, mints nothing).
- */
-async function buildAdmissionDecisionBody(
-  requestId: string,
-  material: StackIdentityMaterial,
-  decision: AdmissionDecision,
-  opts: { issuedAt?: string; nonce?: string } = {},
-): Promise<{ claim: { request_id: string; decision: AdmissionDecision; admin_pubkey: string; issued_at: string; nonce: string }; signature: string }> {
-  const claim = {
-    request_id: requestId,
-    decision,
-    admin_pubkey: material.pubkeyB64,
-    issued_at: opts.issuedAt ?? new Date().toISOString(),
-    nonce: opts.nonce ?? randomNonce(),
-  };
-  return signAdminRequest(material.seed, claim);
-}
-
 // =============================================================================
 // C-1314 — `cortex network admit --list-pending` (admission-queue discovery)
 // =============================================================================
@@ -2535,64 +2505,18 @@ async function buildAdmissionDecisionBody(
  *  the registry-side `validStatuses` gate in routes/admission-requests.ts. */
 const LIST_STATUSES = ["PENDING", "ADMITTED", "REJECTED", "REVOKED", "DEPARTED"] as const;
 
-/** The subset of an `AdmissionRequest` row this CLI renders (matches the
- *  registry `GET /admission-requests` response, `types.ts` AdmissionRequest). */
-interface AdmissionListRow {
-  request_id: string;
-  principal_id: string;
-  peer_pubkey: string;
-  network_id: string | null;
-  status: string;
-  created_at: string;
-}
-
-/** Render the discovery table (human path). Peer pubkey is truncated to a
- *  fingerprint for width; the full value rides the --json output. */
-function renderPendingTable(
-  rows: AdmissionListRow[],
-  status: string,
-  networkFilter: string | undefined,
-  registryUrl: string,
-): string {
-  const scope = networkFilter !== undefined ? ` on network "${networkFilter}"` : "";
-  const header =
-    `cortex network admit --list-pending — ${rows.length.toString()} ${status} request(s)${scope} ` +
-    `(registry: ${registryUrl})`;
-  if (rows.length === 0) {
-    return `${header}\n  (none) — nothing to ${status === "PENDING" ? "admit" : "show"}.\n`;
-  }
-  const cells = rows.map((r) => ({
-    id: r.request_id,
-    principal: r.principal_id,
-    network: r.network_id ?? "(none)",
-    peer: `${r.peer_pubkey.slice(0, 12)}…`,
-    status: r.status,
-    created: r.created_at,
-  }));
-  const w = {
-    id: Math.max("REQUEST-ID".length, ...cells.map((c) => c.id.length)),
-    principal: Math.max("PRINCIPAL".length, ...cells.map((c) => c.principal.length)),
-    network: Math.max("NETWORK".length, ...cells.map((c) => c.network.length)),
-    peer: Math.max("PEER_PUBKEY".length, ...cells.map((c) => c.peer.length)),
-    status: Math.max("STATUS".length, ...cells.map((c) => c.status.length)),
-  };
-  const row = (id: string, principal: string, network: string, peer: string, st: string, created: string): string =>
-    `  ${id.padEnd(w.id)}  ${principal.padEnd(w.principal)}  ${network.padEnd(w.network)}  ${peer.padEnd(w.peer)}  ${st.padEnd(w.status)}  ${created}`;
-  const lines = [header, "", row("REQUEST-ID", "PRINCIPAL", "NETWORK", "PEER_PUBKEY", "STATUS", "CREATED")];
-  for (const c of cells) lines.push(row(c.id, c.principal, c.network, c.peer, c.status, c.created));
-  lines.push("", `To admit: cortex network admit <request-id> --admin-seed <path> --apply`, "");
-  return lines.join("\n");
-}
-
 /**
  * `cortex network admit --list-pending [--status <s>] [--network <id>] --admin-seed <path> [--registry-url <url>] [--json]`
  *
  * C-1314 — the admission-queue DISCOVERY surface. An admin can't otherwise find
  * a request-id from the CLI (the alternatives were the MC Pier queue or a
  * hand-signed GET). Admin-signs a read claim into the `x-admin-signed` header
- * (reuses {@link buildAdmissionReadHeader} — no nonce, reads are idempotent) and
- * GETs `/admission-requests?status=<status>`, mirroring the admit apply-path
+ * and GETs `/admission-requests?status=<status>`, mirroring the admit apply-path
  * read + `findAdmittedRow`. Read-only: no --apply, no request-id positional.
+ *
+ * S5 (#1519) — thin commander wiring: parse + validate flags, load the admin
+ * material, build admit ports, call {@link runNetworkListPending}
+ * (`network-admit-lib.ts`), format the returned report.
  *
  * ADR-0020 read-scoping limitation: admin READS are GLOBAL-admin-only today
  * (the registry list route gates on `parseAdminPubkeys` — the global allowlist —
@@ -2601,7 +2525,11 @@ function renderPendingTable(
  * empty table) and point at the fast-follow. `--network` is a CLIENT-side filter
  * (the endpoint returns every network's rows at once).
  */
-async function runListPending(flags: FlagMap, json: boolean): Promise<ExitResult> {
+async function runListPending(
+  flags: FlagMap,
+  json: boolean,
+  admitPortsFactory: AdmitPortsFactory,
+): Promise<ExitResult> {
   // --admin-seed required: the list is admin-signed (no anonymous read).
   const seedRes = requireValueFlag(flags, "--admin-seed");
   if (!seedRes.ok) {
@@ -2635,61 +2563,32 @@ async function runListPending(flags: FlagMap, json: boolean): Promise<ExitResult
   if (!matRes.ok) return opError("admit", matRes.reason, json);
   const material = matRes.material;
 
-  let rows: AdmissionListRow[];
-  try {
-    const readHeader = await buildAdmissionReadHeader(material);
-    const getUrl = `${registryUrl.replace(/\/+$/, "")}/admission-requests?status=${encodeURIComponent(status)}`;
-    const resp = await globalThis.fetch(getUrl, {
-      method: "GET",
-      headers: { "Content-Type": "application/json", "x-admin-signed": readHeader },
-    });
-    if (resp.status === 403) {
-      // ADR-0020 read-scoping: reads are global-admin-only. A per-network admin
-      // lands here even for their own network — surface it readably rather than
-      // as a silent empty table.
-      const body = await resp.text();
-      return opError(
-        "admit",
-        `registry refused the list (HTTP 403 admin_not_authorized): admission reads are ` +
-          `GLOBAL-admin-only today, so a per-network admin cannot list PENDING requests` +
-          `${networkFilter !== undefined ? ` for "${networkFilter}"` : ""} from the CLI yet. ` +
-          `Per-network read-scoping is the ADR-0020 fast-follow; until then use a global-admin ` +
-          `seed or the MC admission queue (Pier). Registry said: ${body}`,
-        json,
-      );
-    }
-    if (!resp.ok) {
-      const body = await resp.text();
-      return opError("admit", `registry list failed (HTTP ${resp.status.toString()}): ${body}`, json);
-    }
-    rows = (await resp.json()) as AdmissionListRow[];
-  } catch (err) {
-    return opError(
-      "admit",
-      `failed to list admission requests from registry: ${err instanceof Error ? err.message : String(err)}`,
-      json,
-    );
-  }
+  const ports = admitPortsFactory({ registryUrl, material });
+  const report = await runNetworkListPending(
+    { status, ...(networkFilter !== undefined && { networkFilter }), registryUrl, material },
+    ports,
+  );
 
-  const filtered =
-    networkFilter !== undefined ? rows.filter((r) => r.network_id === networkFilter) : rows;
+  if (!report.ok) {
+    return opError("admit", report.reason ?? "list-pending failed", json);
+  }
 
   if (json) {
     return ok(
       renderJson(
-        envelopeOk(filtered, {
+        envelopeOk(report.rows, {
           subcommand: "admit",
           mode: "list-pending",
           status,
           ...(networkFilter !== undefined && { network: networkFilter }),
           registry_url: registryUrl,
           admin_fingerprint: material.fingerprint,
-          count: filtered.length.toString(),
+          count: report.rows.length.toString(),
         }),
       ),
     );
   }
-  return ok(renderPendingTable(filtered, status, networkFilter, registryUrl));
+  return ok(renderPendingTable(report.rows, status, networkFilter, registryUrl));
 }
 
 // =============================================================================
@@ -2740,6 +2639,12 @@ function normalizeHubAccountFlag(
  *
  * --network is intentionally absent: the request's network_id is stored at
  * register time. See cortex#1145 to thread it end-to-end.
+ *
+ * S5 (#1519) — thin commander wiring: parse + validate flags, load the admin
+ * material, and — for the apply path only — build admit ports and call
+ * {@link runNetworkAdmit} (`network-admit-lib.ts`). Dry-run stays fully
+ * inline (it never builds a port and never hits the registry — the
+ * `fetchCalled === false` contract the existing tests pin).
  */
 async function runAdmit(
   requestId: string,
@@ -2749,13 +2654,17 @@ async function runAdmit(
   // folded-in seal is testable with fake hub/registry/crypto ports. Production
   // omits it → the live adapters (`buildLiveSecretPorts`).
   secretPortsFactory: SecretPortsFactory = DEFAULT_SECRET_PORTS_FACTORY,
+  // S5 (cortex#1519) — injectable admit-ports factory so admit/reject CLI
+  // tests drive fake registry/Discord/seal ports. Production omits it → the
+  // live adapters (`buildLiveAdmitPorts`).
+  admitPortsFactory: AdmitPortsFactory = DEFAULT_ADMIT_PORTS_FACTORY,
 ): Promise<ExitResult> {
   // C-1314 — DISCOVERY mode. `--list-pending` is a read-only query for the
   // admission queue (no request-id positional, no --apply). Route it before the
   // request-id gate so `cortex network admit --list-pending` doesn't trip the
   // "missing request-id" usage error.
   if (flags["--list-pending"] === true) {
-    return runListPending(flags, json);
+    return runListPending(flags, json, admitPortsFactory);
   }
 
   if (!requestId) {
@@ -2791,7 +2700,7 @@ async function runAdmit(
   if (!matRes.ok) return opError("admit", matRes.reason, json);
   const material = matRes.material;
 
-  // DRY-RUN (default): print the plan, touch nothing
+  // DRY-RUN (default): print the plan, touch nothing — never builds a port.
   if (!applyRes.apply) {
     if (json) {
       return ok(
@@ -2816,174 +2725,51 @@ async function runAdmit(
     return ok(lines.join("\n"));
   }
 
-  // APPLY path
-
-  // 1. Fetch the PENDING admission request (admin-signed GET)
-  let requestPrincipalId: string;
-  let requestStatus: string;
-  // C-1316 — the just-admitted member's seal target. `peer_pubkey` is the
-  // ed25519 pubkey the leaf PSK is sealed to; `network_id` scopes the seal
-  // (null for legacy network-less rows — then the seal can't run).
-  let requestPeerPubkey: string;
-  let requestNetworkId: string | null;
-  try {
-    const readHeader = await buildAdmissionReadHeader(material);
-    const getUrl = `${registryUrl.replace(/\/+$/, "")}/admission-requests/${encodeURIComponent(requestId)}`;
-    const getResp = await globalThis.fetch(getUrl, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "x-admin-signed": readHeader,
-      },
-    });
-    if (getResp.status === 404) {
-      return opError("admit", `request-id "${requestId}" not found in registry (HTTP 404)`, json);
-    }
-    if (!getResp.ok) {
-      const body = await getResp.text();
-      return opError("admit", `registry GET failed (HTTP ${getResp.status.toString()}): ${body}`, json);
-    }
-    const req = (await getResp.json()) as {
-      request_id: string;
-      principal_id: string;
-      status: string;
-      peer_pubkey: string;
-      network_id: string | null;
-    };
-    requestPrincipalId = req.principal_id;
-    requestStatus = req.status;
-    requestPeerPubkey = req.peer_pubkey;
-    requestNetworkId = req.network_id;
-  } catch (err) {
-    return opError("admit", `failed to fetch request from registry: ${err instanceof Error ? err.message : String(err)}`, json);
-  }
-
-  // Must be PENDING to admit
-  if (requestStatus !== "PENDING") {
-    return opError("admit", `request "${requestId}" is not PENDING (status: ${requestStatus}) — cannot admit an already-decided request`, json);
-  }
-
-  // 2. Build + POST the signed admission decision
-  let decisionBody: { claim: { request_id: string; decision: AdmissionDecision; admin_pubkey: string; issued_at: string; nonce: string }; signature: string };
-  try {
-    decisionBody = await buildAdmissionDecisionBody(requestId, material, "admit");
-  } catch (err) {
-    return opError("admit", `failed to build admission decision claim: ${err instanceof Error ? err.message : String(err)}`, json);
-  }
-
-  try {
-    const postUrl = `${registryUrl.replace(/\/+$/, "")}/admission-requests/${encodeURIComponent(requestId)}/admit`;
-    const postResp = await globalThis.fetch(postUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(decisionBody),
-    });
-    if (!postResp.ok) {
-      const respBody = await postResp.text();
-      return opError("admit", `registry rejected admission (HTTP ${postResp.status.toString()}): ${respBody}`, json);
-    }
-  } catch (err) {
-    return opError("admit", `registry POST failed: ${err instanceof Error ? err.message : String(err)}`, json);
-  }
-
-  // 2b. C-1316 — admit-and-seal. The roster row is now ADMITTED; an admitted-but-
-  // unsealed peer is INERT (on the roster, but its leaf can't connect — no
-  // transport PSK). Under the metafactory Q5 collapse the admit signer
-  // (registry-admin) IS the hub-admin, so the SAME --admin-seed mints + seals +
-  // delivers the per-member leaf PSK in one concierge act. We reuse the EXISTING
-  // `secret add-member` flow (`sealAdmittedMember` → `runNetworkSecret`) — no
-  // sealing is reimplemented here. The admission is ALREADY committed, so the
-  // seal NEVER fails the admit: any problem (hub-admin ≠ registry-admin → registry
-  // refuses the delivery; hub config not local → readConf fails; legacy
-  // network-less row) degrades to a fallback that tells the admin to seal
-  // explicitly. Opt out entirely with --roster-only.
-  let sealOutcome: AdmitSealOutcome;
-  if (flags["--roster-only"] === true) {
-    const net = requestNetworkId ?? "<network>";
-    sealOutcome = {
-      status: "skipped",
-      steps: [],
-      reason: "--roster-only: committed the roster row only, no seal",
-      fallbackCmd: `cortex network secret add-member ${net} ${requestPeerPubkey} --admin-seed ${seedRes.value} --apply`,
-    };
-  } else {
-    sealOutcome = await sealAdmittedMember({
-      networkId: requestNetworkId,
-      memberPubkey: requestPeerPubkey,
+  // APPLY path — fetch/decision/seal/Discord all live in network-admit-lib.ts
+  // over network-admit-ports.ts.
+  const ports = admitPortsFactory({ registryUrl, material, secretPortsFactory });
+  const report = await runNetworkAdmit(
+    {
+      requestId,
       registryUrl,
-      hubConfigPath: optionalValueFlag(flags, "--hub-config") ?? DEFAULT_HUB_CONFIG_PATH,
       material,
-      secretPortsFactory,
-      adminSeedPath: seedRes.value,
+      rosterOnly: flags["--roster-only"] === true,
       // cortex#1481 — --seal-only forces the never-write-a-foreign-hub path even
       // when the auto-detected locality would otherwise call the hub local.
       sealOnly: flags["--seal-only"] === true,
+      hubConfigPath: optionalValueFlag(flags, "--hub-config") ?? DEFAULT_HUB_CONFIG_PATH,
+      adminSeedPath: seedRes.value,
       // Already nkey-U-validated above (fail-fast before the admission commits).
       ...(admitHubAccount !== undefined && { hubAccount: admitHubAccount }),
-    });
+      ...(discordMember !== undefined && {
+        discord: {
+          member: discordMember,
+          role: discordRole,
+          ...(discordServer !== undefined && { server: discordServer }),
+          ...(discordGuild !== undefined && { guild: discordGuild }),
+        },
+      }),
+    },
+    ports,
+  );
+
+  if (!report.ok) {
+    return opError("admit", report.reason, json);
   }
+  const sealOutcome = report.sealOutcome;
 
-  // 3. Assign Discord role (O-5) — when --discord-member is given
-  let discordStatus = "skipped";
-  let discordWarning = "";
-
-  if (discordMember !== undefined) {
-    const discordClient = discordAdmitClientOverride;
-    try {
-      const discordConfig = loadDiscordConfig();
-      const ctx = resolveServerContext(discordConfig, {
-        server: discordServer,
-        guild: discordGuild,
-      });
-
-      const botToken = discordClient ? "injected" : ctx.botToken;
-      const guildId = discordClient ? (discordGuild ?? ctx.guildId) : ctx.guildId;
-
-      if (!discordClient && !botToken) {
-        discordWarning = "Discord role not assigned: no bot token configured (run: discord config set botToken <token>)";
-        discordStatus = "skipped_no_token";
-      } else if (!guildId) {
-        discordWarning = "Discord role not assigned: no guild id configured — pass --discord-guild <id> or run: discord config set guildId <id>";
-        discordStatus = "skipped_no_guild";
-      } else {
-        const client = discordClient ?? defaultDiscordAdmitClient;
-        let roleId: string;
-        try {
-          roleId = await client.resolveRoleId(botToken ?? "", guildId, discordRole);
-        } catch (err) {
-          discordWarning = `Discord role not assigned: ${err instanceof Error ? err.message : String(err)} — assign manually`;
-          discordStatus = "failed";
-          roleId = "";
-        }
-
-        if (roleId) {
-          const roleResult = await client.assignRole(botToken ?? "", guildId, discordMember, roleId);
-          if (roleResult.success) {
-            discordStatus = "assigned";
-          } else {
-            discordWarning = `Discord role assignment failed: ${roleResult.error ?? "unknown error"} — admission committed, assign role manually`;
-            discordStatus = "failed";
-          }
-        }
-      }
-    } catch (err) {
-      discordWarning = `Discord role assignment error: ${err instanceof Error ? err.message : String(err)} — admission committed, assign role manually`;
-      discordStatus = "failed";
-    }
-  }
-
-  // 4. Output summary
+  // Output summary
   if (json) {
     const data: Record<string, string> = {
       subcommand: "admit",
       applied: "true",
       request_id: requestId,
-      principal_id: requestPrincipalId,
+      principal_id: report.principalId,
       admin_fingerprint: material.fingerprint,
       // C-1316 — make the peer's connectability machine-readable.
       seal_status: sealOutcome.status,
       connectable: sealOutcome.status === "sealed" ? "true" : "false",
-      ...(discordStatus !== "skipped" && { discord_status: discordStatus }),
+      ...(report.discordStatus !== "skipped" && { discord_status: report.discordStatus }),
     };
     if (sealOutcome.reason) data.seal_reason = sealOutcome.reason;
     if (sealOutcome.fallbackCmd) data.seal_fallback = sealOutcome.fallbackCmd;
@@ -2991,13 +2777,13 @@ async function runAdmit(
     // `surfaced` block) so it rides its OWN explicit key, joined with real
     // newlines, never folded into a step/reason field.
     if (sealOutcome.hubOwnerArtifact) data.hub_owner_artifact = sealOutcome.hubOwnerArtifact.join("\n");
-    if (discordWarning) data.discord_warning = discordWarning;
+    if (report.discordWarning) data.discord_warning = report.discordWarning;
     return ok(renderJson(envelopeOk([], data)));
   }
 
   const lines: string[] = [
     `cortex network admit ${requestId}: admitted`,
-    `  principal:   ${requestPrincipalId}`,
+    `  principal:   ${report.principalId}`,
     `  admin:       ${material.fingerprint}`,
   ];
   // C-1316 — the seal transcript: state plainly whether the peer is CONNECTABLE.
@@ -3019,10 +2805,10 @@ async function runAdmit(
     if (sealOutcome.fallbackCmd) lines.push(`               to seal: ${sealOutcome.fallbackCmd}`);
   }
   if (discordMember !== undefined) {
-    if (discordStatus === "assigned") {
+    if (report.discordStatus === "assigned") {
       lines.push(`  discord:     role "${discordRole}" assigned to member ${discordMember}`);
     } else {
-      lines.push(`  discord:     ${discordWarning}`);
+      lines.push(`  discord:     ${report.discordWarning}`);
     }
   }
   lines.push("");
@@ -3057,6 +2843,10 @@ async function runReject(
   requestId: string,
   flags: FlagMap,
   json: boolean,
+  // S5 (cortex#1519) — injectable admit-ports factory (shared with `admit`),
+  // so reject's Discord-removal path is testable with fake ports. Production
+  // omits it → the live adapters.
+  admitPortsFactory: AdmitPortsFactory = DEFAULT_ADMIT_PORTS_FACTORY,
 ): Promise<ExitResult> {
   if (!requestId) {
     return usageError("reject", "missing request-id (usage: cortex network reject <request-id> --admin-seed <path>; discover ids with `cortex network admit --list-pending --admin-seed <path>`)", json);
@@ -3080,7 +2870,7 @@ async function runReject(
   if (!matRes.ok) return opError("reject", matRes.reason, json);
   const material = matRes.material;
 
-  // DRY-RUN (default): print the plan, touch nothing
+  // DRY-RUN (default): print the plan, touch nothing — never builds a port.
   if (!applyRes.apply) {
     if (json) {
       return ok(
@@ -3107,72 +2897,23 @@ async function runReject(
     return ok(lines.join("\n"));
   }
 
-  // APPLY path
-  //
-  // Unlike admit, reject does NOT do an admin-signed GET pre-check first. Admit
-  // reads the row because it needs the peer_pubkey + network_id to SEAL; reject
-  // seals nothing, so it needs no read. Crucially, the admin READ gate is
-  // GLOBAL-admin-only today (ADR-0020 read-scoping — see runListPending), so a
-  // GET pre-check would 403 a PER-NETWORK admin BEFORE the POST that would in
-  // fact authorise them (handleDecision authorises global OR per-network admins).
-  // We therefore POST directly and let the registry be the single authority:
-  // its 200 body carries the decided row (principal_id/status) for the summary,
-  // and its own 409/403/404 map to clear, actionable CLI errors.
+  // APPLY path — the decision POST lives in network-admit-lib.ts over
+  // network-admit-ports.ts. No admin-signed GET pre-check first (see
+  // runNetworkReject's doc: the admin READ gate is GLOBAL-admin-only today,
+  // ADR-0020, so a GET pre-check would 403 a PER-NETWORK admin before the
+  // POST that would in fact authorise them).
+  const ports = admitPortsFactory({ registryUrl, material });
+  const report = await runNetworkReject({ requestId, material }, ports);
 
-  // 1. Build the signed admission decision (decision: reject)
-  let decisionBody: { claim: { request_id: string; decision: AdmissionDecision; admin_pubkey: string; issued_at: string; nonce: string }; signature: string };
-  try {
-    decisionBody = await buildAdmissionDecisionBody(requestId, material, "reject");
-  } catch (err) {
-    return opError("reject", `failed to build admission decision claim: ${err instanceof Error ? err.message : String(err)}`, json);
+  if (!report.ok) {
+    return opError("reject", report.reason ?? "reject failed", json);
   }
 
-  // 2. POST it to /admission-requests/:id/reject
-  let decidedPrincipalId = "";
-  try {
-    const postUrl = `${registryUrl.replace(/\/+$/, "")}/admission-requests/${encodeURIComponent(requestId)}/reject`;
-    const postResp = await globalThis.fetch(postUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(decisionBody),
-    });
-    if (!postResp.ok) {
-      const respBody = await postResp.text();
-      // Non-PENDING row → the registry's 409 already_decided. Surface the actual
-      // current status (ADMITTED/REJECTED/REVOKED) readably rather than raw JSON.
-      if (postResp.status === 409 && respBody.includes("already_decided")) {
-        const current = extractCurrentStatus(respBody);
-        const was = current !== undefined ? ` (already ${current})` : "";
-        return opError("reject", `request "${requestId}" is already decided${was} — cannot reject an already-decided request`, json);
-      }
-      if (postResp.status === 404) {
-        return opError("reject", `request-id "${requestId}" not found in registry (HTTP 404)`, json);
-      }
-      // 403 admin_not_authorized — e.g. a per-network admin rejecting a request
-      // that belongs to a DIFFERENT network (their key isn't on that network's
-      // admin allowlist and isn't a global admin). Surface it actionably.
-      if (postResp.status === 403) {
-        return opError("reject", `not authorised to reject request "${requestId}" — the admin key (${material.fingerprint}) is neither a global admin nor an admin of this request's network (HTTP 403)`, json);
-      }
-      return opError("reject", `registry rejected the decision (HTTP ${postResp.status.toString()}): ${respBody}`, json);
-    }
-    // 200 → the decided row. Pull principal_id for the summary (best-effort):
-    // if the body isn't the expected JSON (shouldn't happen on 200), the summary
-    // just omits the principal line — the rejection itself already committed, so
-    // decidedPrincipalId stays "" and we never fail a committed decision on it.
-    try {
-      const row = (await postResp.json()) as { principal_id?: string };
-      decidedPrincipalId = row.principal_id ?? "";
-    } catch (_err) {
-      // Intentionally ignored — see above; decidedPrincipalId remains "".
-    }
-  } catch (err) {
-    return opError("reject", `registry POST failed: ${err instanceof Error ? err.message : String(err)}`, json);
-  }
-
-  // 2b. C-1350 S3 — Tier-1 de-admission: remove the community-fleet role. The
-  // REJECTED decision is ALREADY committed above, so this is a final non-fatal
-  // step — any failure degrades to an actionable warning, never a hard error.
+  // C-1350 S3 — Tier-1 de-admission: remove the community-fleet role. The
+  // REJECTED decision is ALREADY committed above, so this is a final
+  // non-fatal step — any failure degrades to an actionable warning. Stays on
+  // `removeDiscordFleetRole` (shared with `secret revoke-member`), not the
+  // S5 `AdmitPorts.discord` port — see the note above `removeDiscordFleetRole`.
   let discordStatus = "skipped";
   let discordWarning = "";
   if (discordMember !== undefined) {
@@ -3184,7 +2925,7 @@ async function runReject(
     discordWarning = outcome.warning;
   }
 
-  // 3. Output summary — no seal (rejection grants nothing); Discord role removal
+  // Output summary — no seal (rejection grants nothing); Discord role removal
   // rides along only when --discord-member was given.
   if (json) {
     const data: Record<string, string> = {
@@ -3192,7 +2933,7 @@ async function runReject(
       applied: "true",
       request_id: requestId,
       decision: "reject",
-      ...(decidedPrincipalId ? { principal_id: decidedPrincipalId } : {}),
+      ...(report.principalId ? { principal_id: report.principalId } : {}),
       admin_fingerprint: material.fingerprint,
       ...(discordStatus !== "skipped" && { discord_status: discordStatus }),
     };
@@ -3202,7 +2943,7 @@ async function runReject(
 
   const lines: string[] = [
     `cortex network reject ${requestId}: rejected`,
-    ...(decidedPrincipalId ? [`  principal:   ${decidedPrincipalId}`] : []),
+    ...(report.principalId ? [`  principal:   ${report.principalId}`] : []),
     `  admin:       ${material.fingerprint}`,
   ];
   if (discordStatus === "removed") {
@@ -3212,146 +2953,6 @@ async function runReject(
   }
   lines.push(``);
   return ok(lines.join("\n"));
-}
-
-/**
- * Pull the current status out of the registry's `already_decided` 409 body.
- * The route returns `{ error, details, current: <AdmissionRequest> }`; we read
- * `current.status` (falling back to undefined so the caller degrades to a
- * generic "already decided" line rather than crashing on an unexpected shape).
- */
-function extractCurrentStatus(respBody: string): string | undefined {
-  try {
-    const parsed = JSON.parse(respBody) as { current?: { status?: string } };
-    const status = parsed.current?.status;
-    return typeof status === "string" ? status : undefined;
-  } catch (_err) {
-    return undefined;
-  }
-}
-
-// =============================================================================
-// C-1316 — admit-and-seal: fold the sealed leaf-secret delivery into admit
-// =============================================================================
-
-/** The outcome of the seal step folded into a successful admit. */
-type AdmitSealStatus = "sealed" | "skipped" | "fallback";
-interface AdmitSealOutcome {
-  /** sealed = delivered (connectable); skipped = deliberately not run
-   *  (--roster-only); fallback = tried/skipped but couldn't seal (still inert). */
-  status: AdmitSealStatus;
-  /** Human transcript lines from the seal — NEVER carry a secret. */
-  steps: string[];
-  /** Why the seal was skipped or fell back. */
-  reason?: string;
-  /** The explicit `secret add-member` command to seal after the fact. */
-  fallbackCmd?: string;
-  /**
-   * cortex#1481 — present iff the seal's hub turned out to be EXTERNAL (or
-   * --seal-only forced it): the hub-owner artifact `sealAdmittedMember`
-   * forwards verbatim from {@link SecretReport.hubOwnerArtifact}. The caller
-   * prints it explicitly (the one other legitimate place the raw PSK reaches
-   * stdout, alongside the OOB `surfaced` block).
-   */
-  hubOwnerArtifact?: string[];
-}
-
-/**
- * Seal + deliver the per-member leaf PSK for a just-admitted member by reusing
- * the EXISTING `secret add-member` orchestration (`runNetworkSecret`) — nothing
- * about sealing is reimplemented here.
- *
- * The caller has ALREADY committed the admission, so this NEVER throws and NEVER
- * fails the admit: every failure mode returns a `fallback` outcome that surfaces
- * the explicit `secret add-member` command instead. Failure modes it degrades on:
- *   - the admission row is network-less (legacy `network_id = null`) — nothing to
- *     bind a leaf PSK to;
- *   - the hub config isn't local / readable (a fully-separable deployment where
- *     the hub isn't on this host) — `readConf` rejects before any mutation;
- *   - the admit signer isn't the hub-admin (registry-admin ≠ hub-admin) — the
- *     registry refuses the sealed-secret delivery.
- */
-async function sealAdmittedMember(args: {
-  networkId: string | null;
-  memberPubkey: string;
-  registryUrl: string;
-  hubConfigPath: string;
-  material: StackIdentityMaterial;
-  secretPortsFactory: SecretPortsFactory;
-  adminSeedPath: string;
-  /** cortex#1481 — force seal-only (never write the local hub) even when the
-   *  auto-detected locality would otherwise call the hub local. */
-  sealOnly?: boolean;
-  /** cortex#1481 — the hub's own federation account nkey-U, when known. */
-  hubAccount?: string;
-}): Promise<AdmitSealOutcome> {
-  const {
-    networkId,
-    memberPubkey,
-    registryUrl,
-    hubConfigPath,
-    material,
-    secretPortsFactory,
-    adminSeedPath,
-    sealOnly,
-    hubAccount,
-  } = args;
-
-  // A network-less admission row (legacy null network_id) can't be sealed — the
-  // leaf PSK is network-scoped, and `secret add-member` needs a real network id.
-  if (networkId === null || networkId === "") {
-    return {
-      status: "fallback",
-      steps: [],
-      reason:
-        "the admission row has no network_id (legacy / network-less request) — a leaf secret is network-scoped, so it can't be sealed automatically",
-      fallbackCmd: `cortex network secret add-member <network> ${memberPubkey} --admin-seed ${adminSeedPath} --apply`,
-    };
-  }
-
-  const fallbackCmd = `cortex network secret add-member ${networkId} ${memberPubkey} --admin-seed ${adminSeedPath} --apply`;
-
-  const inputs: SecretInputs = {
-    action: "add-member",
-    networkId,
-    memberPubkey,
-    deliver: "sealed",
-    apply: true,
-    ...(sealOnly !== undefined && { sealOnly }),
-    ...(hubAccount !== undefined && { hubAccount }),
-  };
-
-  let report: SecretReport;
-  try {
-    // #1316 nit (PR #1412): construct the ports factory INSIDE the try so the
-    // "seal NEVER throws / NEVER fails the admit" invariant is structural — a
-    // throwing factory (bad hub config, unreadable seed) degrades to `fallback`
-    // like every other seal failure instead of escaping past the committed admit.
-    const ports = secretPortsFactory({ hubConfigPath, registryUrl, material });
-    report = await runNetworkSecret(inputs, ports);
-  } catch (err) {
-    return {
-      status: "fallback",
-      steps: [],
-      reason: `seal could not run: ${err instanceof Error ? err.message : String(err)}`,
-      fallbackCmd,
-    };
-  }
-
-  if (!report.ok) {
-    return {
-      status: "fallback",
-      steps: report.steps,
-      reason: report.reason ?? "seal failed",
-      fallbackCmd,
-    };
-  }
-
-  return {
-    status: "sealed",
-    steps: report.steps,
-    ...(report.hubOwnerArtifact !== undefined && { hubOwnerArtifact: report.hubOwnerArtifact }),
-  };
 }
 
 // =============================================================================
@@ -4262,6 +3863,9 @@ export async function dispatchNetwork(
   // cortex#1498 — injectable authorize-ports factory so `authorize` CLI tests
   // drive fake admission-lookup/delivery ports. Production omits → live.
   authorizePortsFactory: AuthorizePortsFactory = DEFAULT_AUTHORIZE_PORTS_FACTORY,
+  // S5 (cortex#1519) — injectable admit-ports factory so `admit`/`reject` CLI
+  // tests drive fake registry/Discord/seal ports. Production omits → live.
+  admitPortsFactory: AdmitPortsFactory = DEFAULT_ADMIT_PORTS_FACTORY,
 ): Promise<ExitResult> {
   let parsed;
   try {
@@ -4311,9 +3915,9 @@ export async function dispatchNetwork(
     case "authorize":
       return runAuthorize(parsed.positionals.member ?? "", parsed.flags, json, authorizePortsFactory);
     case "admit":
-      return runAdmit(parsed.positionals["request-id"] ?? "", parsed.flags, json, secretPortsFactory);
+      return runAdmit(parsed.positionals["request-id"] ?? "", parsed.flags, json, secretPortsFactory, admitPortsFactory);
     case "reject":
-      return runReject(parsed.positionals["request-id"] ?? "", parsed.flags, json);
+      return runReject(parsed.positionals["request-id"] ?? "", parsed.flags, json, admitPortsFactory);
     case "provision":
       return runProvision(parsed.positionals.stack ?? "", parsed.flags, json, load, provisionPortsFactory);
     case "make-live":


### PR DESCRIPTION
network.ts — runAdmit/runReject/runListPending shrink to commander wiring: parse+validate flags, load admin material, then (apply path only) build ports via the new admitPortsFactory, call the lib, format the report. Dry-run stays fully inline (never builds a port, never touches the registry — preserves the fetchCalled === false contract the existing tests pin).