### PR TITLE
fix(network): C-1527 — dry-run join must not register with the registry

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -2420,3 +2420,57 @@ describe("#800 daemon restart port", () => {
     if (!res.ok) expect(res.reason).toContain("no cortex daemon service found");
   });
 });
+
+// =============================================================================
+// #1527 — dry-run `network join` must NOT register with the registry.
+// registerStack upserts the stack pubkey AND raises a network-pinned PENDING
+// admission row; a preview (`join` without `--apply`) touching that is
+// join-issues-2026-06-26 §8. We stub global fetch to throw, so ANY HTTP attempt
+// fails the test — the dry-run gate must short-circuit before the transport.
+// =============================================================================
+
+describe("#1527 dry-run registerStack gate", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const cfgWithRegistry = () => ({
+    networkId: "metafactory",
+    principalId: "jc",
+    stackId: "jc/default",
+    platform: "darwin" as const,
+    // A reachable-looking registry + a seed: absent the gate, registerStack
+    // would attempt a live signed POST here.
+    registryUrl: "https://registry.example.test",
+    seedPath: "/tmp/cortex-c1527-nonexistent.seed",
+    announceCapabilities: ["code-review.typescript"],
+  });
+
+  test("dry-run registerStack returns the skip note and makes ZERO fetch calls", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      throw new Error("#1527: dry-run registerStack must not hit the network");
+    }) as unknown as typeof fetch;
+
+    const ports = buildDryRunPorts(cfgWithRegistry());
+    const res = await ports.registry.registerStack();
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.note).toContain("dry-run");
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("live registerStack proceeds past the gate into real registration (not the dry-run note)", async () => {
+    // Same config; the live port does NOT short-circuit on the gate — it runs
+    // the real path, which here fails on the absent seed file. The point is
+    // that it does NOT return the dry-run skip note (proving the gate is scoped
+    // to dry-run), and the failure is a genuine registration attempt.
+    const ports = buildLivePorts(cfgWithRegistry());
+    const res = await ports.registry.registerStack();
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason.toLowerCase()).not.toContain("dry-run");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -13,7 +13,7 @@
  * live ports bundle.
  */
 
-import { describe, test, expect, afterEach } from "bun:test";
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync, chmodSync, statSync } from "fs";
 import { tmpdir, homedir } from "os";
 import { join } from "path";
@@ -2431,20 +2431,32 @@ describe("#800 daemon restart port", () => {
 
 describe("#1527 dry-run registerStack gate", () => {
   const realFetch = globalThis.fetch;
-  afterEach(() => {
-    globalThis.fetch = realFetch;
-  });
+  let seedDir: string;
+  let seedPath: string;
 
   const cfgWithRegistry = () => ({
     networkId: "metafactory",
     principalId: "jc",
     stackId: "jc/default",
     platform: "darwin" as const,
-    // A reachable-looking registry + a seed: absent the gate, registerStack
-    // would attempt a live signed POST here.
+    // A reachable-looking registry + a REAL seed on disk: absent the gate,
+    // registerStack loads the seed, signs the claim, and POSTs it here.
     registryUrl: "https://registry.example.test",
-    seedPath: "/tmp/cortex-c1527-nonexistent.seed",
+    seedPath,
     announceCapabilities: ["code-review.typescript"],
+  });
+
+  // A genuine seed so the LIVE path's loadSeedMaterial succeeds and control
+  // actually reaches the network — otherwise a live-path test would fail at
+  // seed-load before ever exercising the gate (Sage HonestOracle catch).
+  beforeEach(() => {
+    seedDir = mkdtempSync(join(tmpdir(), "c1527-seed-"));
+    seedPath = join(seedDir, "stack.seed");
+    generateStackIdentity({ seedPath });
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    rmSync(seedDir, { recursive: true, force: true });
   });
 
   test("dry-run registerStack returns the skip note and makes ZERO fetch calls", async () => {
@@ -2462,14 +2474,21 @@ describe("#1527 dry-run registerStack gate", () => {
     expect(fetchCalls).toBe(0);
   });
 
-  test("live registerStack proceeds past the gate into real registration (not the dry-run note)", async () => {
-    // Same config; the live port does NOT short-circuit on the gate — it runs
-    // the real path, which here fails on the absent seed file. The point is
-    // that it does NOT return the dry-run skip note (proving the gate is scoped
-    // to dry-run), and the failure is a genuine registration attempt.
+  test("live registerStack reaches the registry POST (gate is dry-run only)", async () => {
+    // Same config + a valid seed, so the live path runs to completion and
+    // actually hits the network. We count fetch calls and throw to avoid a
+    // real registry — asserting fetchCalls > 0 proves it got PAST the gate to
+    // the transport (not merely that it avoided the dry-run note).
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      throw new Error("network down (test)");
+    }) as unknown as typeof fetch;
+
     const ports = buildLivePorts(cfgWithRegistry());
     const res = await ports.registry.registerStack();
 
+    expect(fetchCalls).toBeGreaterThan(0);
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.reason.toLowerCase()).not.toContain("dry-run");
   });

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -385,6 +385,17 @@ function buildRegistryPort(cfg: LivePortsConfig, mutate: boolean): NetworkRegist
 
   return {
     async registerStack() {
+      // DRY-RUN GATE (#1527) — register is a real registry mutation: it upserts
+      // the stack's pubkey AND raises a network-PINNED PENDING admission row an
+      // admin can `admit`. A dry-run join (a preview) must NOT fire it, exactly
+      // as `departFromNetwork` below gates its own POST. Without this, a
+      // "dry-run first" join per the SOPs performs a live registration — the
+      // observation logged as join-issues-2026-06-26 §8. The rest of a dry-run
+      // join (fetchVerified, config rendering) is read-only, so skipping the
+      // register leaves a faithful preview.
+      if (!mutate) {
+        return { ok: true, note: "dry-run — registry register skipped (no mutation)" };
+      }
       // ADR-0018 Gap-B (BLOCK-1/N3) — roster membership is NO LONGER implicit in
       // the announced capabilities. Under Gap-B a principal is "in" `networkId`
       // iff they hold an ADMITTED admission row for it (`rosterFromAdmissions`);

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -385,14 +385,12 @@ function buildRegistryPort(cfg: LivePortsConfig, mutate: boolean): NetworkRegist
 
   return {
     async registerStack() {
-      // DRY-RUN GATE (#1527) — register is a real registry mutation: it upserts
-      // the stack's pubkey AND raises a network-PINNED PENDING admission row an
+      // DRY-RUN GATE (#1527) — register is a registry MUTATION: it upserts the
+      // stack's pubkey AND raises a network-PINNED PENDING admission row an
       // admin can `admit`. A dry-run join (a preview) must NOT fire it, exactly
       // as `departFromNetwork` below gates its own POST. Without this, a
       // "dry-run first" join per the SOPs performs a live registration — the
-      // observation logged as join-issues-2026-06-26 §8. The rest of a dry-run
-      // join (fetchVerified, config rendering) is read-only, so skipping the
-      // register leaves a faithful preview.
+      // observation logged as join-issues-2026-06-26 §8.
       if (!mutate) {
         return { ok: true, note: "dry-run — registry register skipped (no mutation)" };
       }


### PR DESCRIPTION
## What

`cortex network join` without `--apply` (a dry-run preview) performed a **live registry write**. `registerStack()` ran its signed POST unconditionally, ignoring the port's `mutate` flag — so a preview upserted the stack pubkey **and** raised a network-pinned PENDING admission row an admin could `admit`, from a command the operator believed touched nothing. On a 2nd stack it could also 409.

This is the `docs/federation-join-issues-2026-06-26.md` §8 observation, at its exact site. The sibling `departFromNetwork` was already dry-run gated (with an explicit comment); `registerStack` simply omitted the same gate.

## Fix

One early-return mirroring the depart gate: when `!mutate`, return the skip note and make no POST. The rest of a dry-run join (fetchVerified, config rendering) is read-only, so the preview stays faithful.

## Test

Stubs global `fetch` to throw, then asserts a dry-run `registerStack` returns the skip note with **zero** fetch calls; a companion test confirms the live port still proceeds past the gate into real registration (so the gate is dry-run-scoped, not a blanket disable).

Full `network-adapters` suite: 83 pass / 0 fail. tsc clean.

Closes #1527. Prerequisite hardening for epic #1595 (surfaced by the #1526 design review, red-team R1-journey).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
