### PR TITLE
feat(registry): C-1596 — v2 sealed envelope carrying a credential-file payload

### DIFF
--- a/src/common/registry/__tests__/sealed-leaf-secret.test.ts
+++ b/src/common/registry/__tests__/sealed-leaf-secret.test.ts
@@ -15,7 +15,12 @@ import { describe, test, expect } from "bun:test";
 import {
   encodeLeafSecretEnvelope,
   decodeLeafSecretEnvelope,
+  encodeLeafSecretEnvelopeV2,
+  decodeAnyLeafSecretEnvelope,
+  isLeafSecretEnvelopeV2,
+  UnsupportedEnvelopeVersionError,
   LEAF_SECRET_ENVELOPE_VERSION,
+  LEAF_SECRET_ENVELOPE_VERSION_V2,
 } from "../sealed-leaf-secret";
 
 // Clearly-fake placeholder key material — an all-A base64 blob, never real K.
@@ -99,5 +104,93 @@ describe("encodeLeafSecretEnvelope / decodeLeafSecretEnvelope", () => {
     });
     expect(json).not.toContain("payload_key_kid");
     expect(json).toContain("payload_key");
+  });
+
+  // #1596 — the v1 decoder must reject a KNOWN-newer envelope with a clear
+  // "upgrade" error, NOT the old misleading "missing leaf_psk" path (which the
+  // C-1315 diagnostic then reports as "sealed to a different pubkey / corrupted").
+  test("v1 decoder rejects a v2 payload with UnsupportedEnvelopeVersionError (not 'missing leaf_psk')", () => {
+    const v2blob = encodeLeafSecretEnvelopeV2({
+      creds: "-----BEGIN NATS USER JWT-----\nFAKE\n------END NATS USER JWT------\n",
+      leaf_user: "alice/lab",
+      minted_at: "2026-07-06T00:00:00.000Z",
+    });
+    expect(() => decodeLeafSecretEnvelope(v2blob)).toThrow(UnsupportedEnvelopeVersionError);
+    expect(() => decodeLeafSecretEnvelope(v2blob)).toThrow(/upgrade cortex/i);
+    expect(() => decodeLeafSecretEnvelope(v2blob)).not.toThrow(/missing leaf_psk/);
+  });
+});
+
+// Clearly-fake creds text — never realistic JWT/nkey material.
+const FAKE_CREDS =
+  "-----BEGIN NATS USER JWT-----\nFAKE.JWT.PART\n------END NATS USER JWT------\n" +
+  "-----BEGIN USER NKEY SEED-----\nSUAFAKEFAKEFAKE\n------END USER NKEY SEED------\n";
+const MINTED_AT = "2026-07-06T12:00:00.000Z";
+
+describe("v2 envelope (creds payload) — #1596", () => {
+  test("round-trips creds + leaf_user + minted_at via decodeAny", () => {
+    const env = decodeAnyLeafSecretEnvelope(
+      encodeLeafSecretEnvelopeV2({ creds: FAKE_CREDS, leaf_user: "alice/lab", minted_at: MINTED_AT }),
+    );
+    expect(env.v).toBe(LEAF_SECRET_ENVELOPE_VERSION_V2);
+    expect(isLeafSecretEnvelopeV2(env)).toBe(true);
+    if (isLeafSecretEnvelopeV2(env)) {
+      expect(env.creds).toBe(FAKE_CREDS);
+      expect(env.leaf_user).toBe("alice/lab");
+      expect(env.minted_at).toBe(MINTED_AT);
+      expect(env.payload_key).toBeUndefined();
+    }
+  });
+
+  test("v2 rides payload_key + kid (K on the same envelope)", () => {
+    const env = decodeAnyLeafSecretEnvelope(
+      encodeLeafSecretEnvelopeV2({
+        creds: FAKE_CREDS,
+        leaf_user: "alice/lab",
+        minted_at: MINTED_AT,
+        payload_key: FAKE_K,
+        payload_key_kid: FAKE_KID,
+      }),
+    );
+    expect(isLeafSecretEnvelopeV2(env)).toBe(true);
+    if (isLeafSecretEnvelopeV2(env)) {
+      expect(env.payload_key).toBe(FAKE_K);
+      expect(env.payload_key_kid).toBe(FAKE_KID);
+    }
+  });
+
+  test("decodeAny still decodes a v1 blob (and narrows to NOT v2)", () => {
+    const env = decodeAnyLeafSecretEnvelope(
+      encodeLeafSecretEnvelope({ leaf_psk: "psk-1", leaf_user: "alice" }),
+    );
+    expect(env.v).toBe(LEAF_SECRET_ENVELOPE_VERSION);
+    expect(isLeafSecretEnvelopeV2(env)).toBe(false);
+  });
+
+  test("decodeAny rejects an UNKNOWN newer version (v3) with the upgrade error", () => {
+    const v3 = JSON.stringify({ v: 3, creds: FAKE_CREDS, leaf_user: "alice/lab", minted_at: MINTED_AT });
+    expect(() => decodeAnyLeafSecretEnvelope(v3)).toThrow(UnsupportedEnvelopeVersionError);
+    expect(() => decodeAnyLeafSecretEnvelope(v3)).toThrow(/upgrade cortex/i);
+  });
+
+  test("v2 fails closed on a missing creds field", () => {
+    const bad = JSON.stringify({ v: 2, leaf_user: "alice/lab", minted_at: MINTED_AT });
+    expect(() => decodeAnyLeafSecretEnvelope(bad)).toThrow(/v2 payload missing creds/);
+  });
+
+  test("v2 fails closed on a missing minted_at field", () => {
+    const bad = JSON.stringify({ v: 2, creds: FAKE_CREDS, leaf_user: "alice/lab" });
+    expect(() => decodeAnyLeafSecretEnvelope(bad)).toThrow(/v2 payload missing minted_at/);
+  });
+
+  test("v2 fails closed on a missing leaf_user (subject) field", () => {
+    const bad = JSON.stringify({ v: 2, creds: FAKE_CREDS, minted_at: MINTED_AT });
+    expect(() => decodeAnyLeafSecretEnvelope(bad)).toThrow(/v2 payload missing leaf_user/);
+  });
+
+  test("a v2 blob carries no leaf_psk (the discriminant, not an either-field relaxation)", () => {
+    const json = encodeLeafSecretEnvelopeV2({ creds: FAKE_CREDS, leaf_user: "alice/lab", minted_at: MINTED_AT });
+    expect(json).not.toContain("leaf_psk");
+    expect(json).toContain('"v":2');
   });
 });

--- a/src/common/registry/__tests__/sealed-leaf-secret.test.ts
+++ b/src/common/registry/__tests__/sealed-leaf-secret.test.ts
@@ -183,6 +183,11 @@ describe("v2 envelope (creds payload) — #1596", () => {
     expect(() => decodeAnyLeafSecretEnvelope(bad)).toThrow(/v2 payload missing minted_at/);
   });
 
+  test("v2 fails closed on a non-date minted_at (a garbage string is not a timestamp)", () => {
+    const bad = JSON.stringify({ v: 2, creds: FAKE_CREDS, leaf_user: "alice/lab", minted_at: "x" });
+    expect(() => decodeAnyLeafSecretEnvelope(bad)).toThrow(/parseable ISO-8601 date/);
+  });
+
   test("v2 fails closed on a missing leaf_user (subject) field", () => {
     const bad = JSON.stringify({ v: 2, creds: FAKE_CREDS, minted_at: MINTED_AT });
     expect(() => decodeAnyLeafSecretEnvelope(bad)).toThrow(/v2 payload missing leaf_user/);

--- a/src/common/registry/__tests__/sealed-leaf-secret.test.ts
+++ b/src/common/registry/__tests__/sealed-leaf-secret.test.ts
@@ -198,4 +198,16 @@ describe("v2 envelope (creds payload) — #1596", () => {
     expect(json).not.toContain("leaf_psk");
     expect(json).toContain('"v":2');
   });
+
+  test("v2 encoder fails fast on empty creds / leaf_user / bad minted_at (producer-side)", () => {
+    expect(() => encodeLeafSecretEnvelopeV2({ creds: "", leaf_user: "alice/lab", minted_at: MINTED_AT })).toThrow(/empty creds/);
+    expect(() => encodeLeafSecretEnvelopeV2({ creds: FAKE_CREDS, leaf_user: "", minted_at: MINTED_AT })).toThrow(/empty leaf_user/);
+    expect(() => encodeLeafSecretEnvelopeV2({ creds: FAKE_CREDS, leaf_user: "alice/lab", minted_at: "nope" })).toThrow(/minted_at/);
+  });
+
+  test("a string version (v: \"2\") is rejected, not mis-routed to the v1 path", () => {
+    const bad = JSON.stringify({ v: "2", creds: FAKE_CREDS, leaf_user: "alice/lab", minted_at: MINTED_AT });
+    expect(() => decodeAnyLeafSecretEnvelope(bad)).toThrow(/`v` must be a number/);
+    expect(() => decodeAnyLeafSecretEnvelope(bad)).not.toThrow(/missing leaf_psk/);
+  });
 });

--- a/src/common/registry/sealed-leaf-secret.ts
+++ b/src/common/registry/sealed-leaf-secret.ts
@@ -18,6 +18,18 @@
 export const LEAF_SECRET_ENVELOPE_VERSION = 1;
 
 /**
+ * v2 (#1596, epic #1595) — the credential-file payload. Where v1 carries a
+ * shared-string `leaf_psk` (Model-B / conf-mode hub), v2 carries the verbatim
+ * text of a per-member NSC user `.creds` file, so an operator-mode hub can seal
+ * a real transport credential through the SAME sealed-delivery channel (the
+ * #1526 design's core move). This is a DISCRIMINATED version, NOT a
+ * "leaf_psk XOR creds" relaxation of v1 — a version-blind either-field decoder
+ * would let a hostile courier silently downgrade the payload type (design §5.2,
+ * red-team R9/R12), so the payload variant is pinned by `v`.
+ */
+export const LEAF_SECRET_ENVELOPE_VERSION_V2 = 2;
+
+/**
  * The plaintext sealed to a member's pubkey. JSON, UTF-8, then
  * {@link sealToPrincipal}. Keep it small + flat — `crypto_box_seal` has no size
  * problem here, but the registry bounds the ciphertext (validate.isValidSealedSecret).
@@ -51,6 +63,48 @@ export interface LeafSecretEnvelope {
   payload_key_kid?: string;
 }
 
+/**
+ * v2 plaintext (#1596) — carries a per-member NSC user `.creds` file text
+ * instead of a shared PSK. Sealed to the member's pubkey exactly like v1; the
+ * registry still only ever holds the opaque ciphertext.
+ */
+export interface LeafSecretEnvelopeV2 {
+  /** Always {@link LEAF_SECRET_ENVELOPE_VERSION_V2}. The payload-variant discriminant. */
+  v: 2;
+  /**
+   * The verbatim `.creds` file text (user JWT + user nkey seed) the member
+   * writes to disk and points its leaf remote at. The transport credential.
+   */
+  creds: string;
+  /**
+   * The subject this credential was minted FOR — the member's
+   * `{principal}/{stack}` (or the leaf username). The member checks this
+   * matches its own identity before installing, so a courier that seals another
+   * member's real creds to this member (red-team R7) is refused rather than
+   * silently authenticating as someone else.
+   */
+  leaf_user: string;
+  /**
+   * ISO-8601 mint timestamp. The member uses it for a staleness check (a
+   * re-fetched, long-superseded credential can be rejected). Set at seal time.
+   */
+  minted_at: string;
+  /** M3 payload key `K` (ADR-0019) — rides v2 unchanged (see v1's `payload_key`). */
+  payload_key?: string;
+  /** Key id / rotation epoch of {@link payload_key} — rides v2 unchanged. */
+  payload_key_kid?: string;
+}
+
+/** Either envelope shape, discriminated by `v`. */
+export type AnyLeafSecretEnvelope = LeafSecretEnvelope | LeafSecretEnvelopeV2;
+
+/** Narrow an {@link AnyLeafSecretEnvelope} to the v2 (creds) variant. */
+export function isLeafSecretEnvelopeV2(
+  env: AnyLeafSecretEnvelope,
+): env is LeafSecretEnvelopeV2 {
+  return env.v === LEAF_SECRET_ENVELOPE_VERSION_V2;
+}
+
 /** Encode a {@link LeafSecretEnvelope} to the UTF-8 JSON that gets sealed. */
 export function encodeLeafSecretEnvelope(
   fields: Omit<LeafSecretEnvelope, "v"> & { v?: number },
@@ -66,12 +120,36 @@ export function encodeLeafSecretEnvelope(
 }
 
 /**
- * Decode + validate the UNSEALED plaintext into a {@link LeafSecretEnvelope}.
- * Fails closed on a malformed envelope (the member would otherwise render a leaf
- * with a junk secret). Tolerates the future `payload_key` field. The error
- * message NEVER echoes the plaintext (it may carry secret material).
+ * Encode a {@link LeafSecretEnvelopeV2} (creds payload) to the UTF-8 JSON that
+ * gets sealed. `v` is fixed at {@link LEAF_SECRET_ENVELOPE_VERSION_V2}.
  */
-export function decodeLeafSecretEnvelope(plaintext: string): LeafSecretEnvelope {
+export function encodeLeafSecretEnvelopeV2(
+  fields: Omit<LeafSecretEnvelopeV2, "v">,
+): string {
+  const env: LeafSecretEnvelopeV2 = {
+    v: LEAF_SECRET_ENVELOPE_VERSION_V2,
+    creds: fields.creds,
+    leaf_user: fields.leaf_user,
+    minted_at: fields.minted_at,
+    ...(fields.payload_key !== undefined && { payload_key: fields.payload_key }),
+    ...(fields.payload_key_kid !== undefined && { payload_key_kid: fields.payload_key_kid }),
+  };
+  return JSON.stringify(env);
+}
+
+/** Thrown when a decoder meets an envelope version it does not understand. */
+export class UnsupportedEnvelopeVersionError extends Error {
+  constructor(readonly version: number) {
+    super(
+      `sealed-leaf-secret: envelope version ${String(version)} is newer than this cortex understands — ` +
+        `upgrade cortex on this stack to open it. (This is NOT a corrupt or mis-sealed blob.)`,
+    );
+    this.name = "UnsupportedEnvelopeVersionError";
+  }
+}
+
+/** Parse the sealed plaintext to a JSON object, failing closed (never echoes it). */
+function parseEnvelopeObject(plaintext: string): Record<string, unknown> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(plaintext);
@@ -81,7 +159,25 @@ export function decodeLeafSecretEnvelope(plaintext: string): LeafSecretEnvelope 
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error("sealed-leaf-secret: unsealed payload must be a JSON object");
   }
-  const p = parsed as Record<string, unknown>;
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Decode + validate the UNSEALED plaintext into a v1 {@link LeafSecretEnvelope}.
+ * Fails closed on a malformed envelope (the member would otherwise render a leaf
+ * with a junk secret). Tolerates the `payload_key` field.
+ *
+ * #1596 — a KNOWN-newer version (`v > 1`) is rejected with a distinct
+ * {@link UnsupportedEnvelopeVersionError} that names the real remedy (upgrade
+ * cortex), NOT the previous misleading "missing leaf_psk" → "corrupted / wrong
+ * pubkey" path. v1-only callers should keep using this; new callers that speak
+ * v2 use {@link decodeAnyLeafSecretEnvelope}. The error NEVER echoes the plaintext.
+ */
+export function decodeLeafSecretEnvelope(plaintext: string): LeafSecretEnvelope {
+  const p = parseEnvelopeObject(plaintext);
+  if (typeof p.v === "number" && p.v > LEAF_SECRET_ENVELOPE_VERSION) {
+    throw new UnsupportedEnvelopeVersionError(p.v);
+  }
   if (typeof p.leaf_psk !== "string" || p.leaf_psk.length === 0) {
     throw new Error("sealed-leaf-secret: unsealed payload missing leaf_psk");
   }
@@ -101,4 +197,54 @@ export function decodeLeafSecretEnvelope(plaintext: string): LeafSecretEnvelope 
     ...(typeof p.payload_key === "string" && { payload_key: p.payload_key }),
     ...(typeof p.payload_key_kid === "string" && { payload_key_kid: p.payload_key_kid }),
   };
+}
+
+/** Decode + validate a v2 {@link LeafSecretEnvelopeV2} (creds payload). Fails closed. */
+function decodeLeafSecretEnvelopeV2(p: Record<string, unknown>): LeafSecretEnvelopeV2 {
+  if (typeof p.creds !== "string" || p.creds.length === 0) {
+    throw new Error("sealed-leaf-secret: v2 payload missing creds");
+  }
+  if (typeof p.leaf_user !== "string" || p.leaf_user.length === 0) {
+    throw new Error("sealed-leaf-secret: v2 payload missing leaf_user");
+  }
+  if (typeof p.minted_at !== "string" || p.minted_at.length === 0) {
+    throw new Error("sealed-leaf-secret: v2 payload missing minted_at");
+  }
+  if (p.payload_key !== undefined && typeof p.payload_key !== "string") {
+    throw new Error("sealed-leaf-secret: payload_key must be a string when present");
+  }
+  if (p.payload_key_kid !== undefined && typeof p.payload_key_kid !== "string") {
+    throw new Error("sealed-leaf-secret: payload_key_kid must be a string when present");
+  }
+  return {
+    v: LEAF_SECRET_ENVELOPE_VERSION_V2,
+    creds: p.creds,
+    leaf_user: p.leaf_user,
+    minted_at: p.minted_at,
+    ...(typeof p.payload_key === "string" && { payload_key: p.payload_key }),
+    ...(typeof p.payload_key_kid === "string" && { payload_key_kid: p.payload_key_kid }),
+  };
+}
+
+/**
+ * Version-aware decode of the UNSEALED plaintext into whichever envelope shape
+ * `v` selects. This is the decoder new (v2-speaking) consumers use — the member
+ * install path (#1597) branches on {@link isLeafSecretEnvelopeV2}.
+ *
+ * - `v` absent or `1` → v1 {@link LeafSecretEnvelope} (creds path never taken).
+ * - `v === 2`         → v2 {@link LeafSecretEnvelopeV2} (creds payload).
+ * - `v > 2`           → {@link UnsupportedEnvelopeVersionError} (upgrade cortex).
+ *
+ * Fails closed on any malformed shape; the error NEVER echoes the plaintext.
+ */
+export function decodeAnyLeafSecretEnvelope(plaintext: string): AnyLeafSecretEnvelope {
+  const p = parseEnvelopeObject(plaintext);
+  if (p.v === LEAF_SECRET_ENVELOPE_VERSION_V2) {
+    return decodeLeafSecretEnvelopeV2(p);
+  }
+  if (typeof p.v === "number" && p.v > LEAF_SECRET_ENVELOPE_VERSION_V2) {
+    throw new UnsupportedEnvelopeVersionError(p.v);
+  }
+  // v absent, v===1, or any v <= 1: the v1 decoder (which also guards v>1).
+  return decodeLeafSecretEnvelope(plaintext);
 }

--- a/src/common/registry/sealed-leaf-secret.ts
+++ b/src/common/registry/sealed-leaf-secret.ts
@@ -128,6 +128,16 @@ export function encodeLeafSecretEnvelope(
 export function encodeLeafSecretEnvelopeV2(
   fields: Omit<LeafSecretEnvelopeV2, "v">,
 ): string {
+  // Fail fast at the PRODUCER: never mint a blob our own decoder rejects.
+  if (fields.creds.length === 0) {
+    throw new Error("sealed-leaf-secret: cannot encode a v2 envelope with empty creds");
+  }
+  if (fields.leaf_user.length === 0) {
+    throw new Error("sealed-leaf-secret: cannot encode a v2 envelope with empty leaf_user");
+  }
+  if (fields.minted_at.length === 0 || Number.isNaN(Date.parse(fields.minted_at))) {
+    throw new Error("sealed-leaf-secret: cannot encode a v2 envelope with a non-ISO-8601 minted_at");
+  }
   const env: LeafSecretEnvelopeV2 = {
     v: LEAF_SECRET_ENVELOPE_VERSION_V2,
     creds: fields.creds,
@@ -182,7 +192,14 @@ function parseEnvelopeObject(plaintext: string): Record<string, unknown> {
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error("sealed-leaf-secret: unsealed payload must be a JSON object");
   }
-  return parsed as Record<string, unknown>;
+  const obj = parsed as Record<string, unknown>;
+  // `v`, when present, MUST be a number — else the numeric version guards below
+  // (and the upgrade-vs-v1 routing) silently mis-route a `v: "2"` string blob to
+  // the v1 "missing leaf_psk" path. Reject it here so every decoder is covered.
+  if ("v" in obj && typeof obj.v !== "number") {
+    throw new Error("sealed-leaf-secret: envelope version `v` must be a number when present");
+  }
+  return obj;
 }
 
 /**

--- a/src/common/registry/sealed-leaf-secret.ts
+++ b/src/common/registry/sealed-leaf-secret.ts
@@ -78,15 +78,17 @@ export interface LeafSecretEnvelopeV2 {
   creds: string;
   /**
    * The subject this credential was minted FOR — the member's
-   * `{principal}/{stack}` (or the leaf username). The member checks this
-   * matches its own identity before installing, so a courier that seals another
-   * member's real creds to this member (red-team R7) is refused rather than
-   * silently authenticating as someone else.
+   * `{principal}/{stack}` (or the leaf username). Carrying it here is what lets
+   * the member install (#1597) refuse a credential minted for a DIFFERENT
+   * subject (red-team R7: a courier sealing another member's real creds to this
+   * member). NOTE: this module only validates the field is present — the
+   * identity-binding CHECK itself lands in #1597, not here.
    */
   leaf_user: string;
   /**
-   * ISO-8601 mint timestamp. The member uses it for a staleness check (a
-   * re-fetched, long-superseded credential can be rejected). Set at seal time.
+   * ISO-8601 mint timestamp, set at seal time. Exists so the member install
+   * (#1597) can reject a re-fetched, long-superseded credential. NOTE: this
+   * module validates it is a PARSEABLE date; the staleness COMPARISON is #1597.
    */
   minted_at: string;
   /** M3 payload key `K` (ADR-0019) — rides v2 unchanged (see v1's `payload_key`). */
@@ -148,6 +150,27 @@ export class UnsupportedEnvelopeVersionError extends Error {
   }
 }
 
+/**
+ * Validate + extract the optional ADR-0019 payload-key rider (`payload_key` +
+ * `payload_key_kid`) shared by both the v1 and v2 decoders. Fails closed on a
+ * wrong-typed field; returns only the fields that are present. One site for a
+ * future K change instead of four.
+ */
+function readPayloadKeyFields(
+  p: Record<string, unknown>,
+): { payload_key?: string; payload_key_kid?: string } {
+  if (p.payload_key !== undefined && typeof p.payload_key !== "string") {
+    throw new Error("sealed-leaf-secret: payload_key must be a string when present");
+  }
+  if (p.payload_key_kid !== undefined && typeof p.payload_key_kid !== "string") {
+    throw new Error("sealed-leaf-secret: payload_key_kid must be a string when present");
+  }
+  return {
+    ...(typeof p.payload_key === "string" && { payload_key: p.payload_key }),
+    ...(typeof p.payload_key_kid === "string" && { payload_key_kid: p.payload_key_kid }),
+  };
+}
+
 /** Parse the sealed plaintext to a JSON object, failing closed (never echoes it). */
 function parseEnvelopeObject(plaintext: string): Record<string, unknown> {
   let parsed: unknown;
@@ -184,18 +207,11 @@ export function decodeLeafSecretEnvelope(plaintext: string): LeafSecretEnvelope 
   if (typeof p.leaf_user !== "string" || p.leaf_user.length === 0) {
     throw new Error("sealed-leaf-secret: unsealed payload missing leaf_user");
   }
-  if (p.payload_key !== undefined && typeof p.payload_key !== "string") {
-    throw new Error("sealed-leaf-secret: payload_key must be a string when present");
-  }
-  if (p.payload_key_kid !== undefined && typeof p.payload_key_kid !== "string") {
-    throw new Error("sealed-leaf-secret: payload_key_kid must be a string when present");
-  }
   return {
     v: typeof p.v === "number" ? p.v : LEAF_SECRET_ENVELOPE_VERSION,
     leaf_psk: p.leaf_psk,
     leaf_user: p.leaf_user,
-    ...(typeof p.payload_key === "string" && { payload_key: p.payload_key }),
-    ...(typeof p.payload_key_kid === "string" && { payload_key_kid: p.payload_key_kid }),
+    ...readPayloadKeyFields(p),
   };
 }
 
@@ -210,19 +226,15 @@ function decodeLeafSecretEnvelopeV2(p: Record<string, unknown>): LeafSecretEnvel
   if (typeof p.minted_at !== "string" || p.minted_at.length === 0) {
     throw new Error("sealed-leaf-secret: v2 payload missing minted_at");
   }
-  if (p.payload_key !== undefined && typeof p.payload_key !== "string") {
-    throw new Error("sealed-leaf-secret: payload_key must be a string when present");
-  }
-  if (p.payload_key_kid !== undefined && typeof p.payload_key_kid !== "string") {
-    throw new Error("sealed-leaf-secret: payload_key_kid must be a string when present");
+  if (Number.isNaN(Date.parse(p.minted_at))) {
+    throw new Error("sealed-leaf-secret: v2 payload minted_at must be a parseable ISO-8601 date");
   }
   return {
     v: LEAF_SECRET_ENVELOPE_VERSION_V2,
     creds: p.creds,
     leaf_user: p.leaf_user,
     minted_at: p.minted_at,
-    ...(typeof p.payload_key === "string" && { payload_key: p.payload_key }),
-    ...(typeof p.payload_key_kid === "string" && { payload_key_kid: p.payload_key_kid }),
+    ...readPayloadKeyFields(p),
   };
 }
 


### PR DESCRIPTION
Slice 1 of epic #1595 (the #1526 payload swap). Adds the v2 envelope shape the operator-mode join will seal — a per-member credential-file payload riding the same sealed-delivery channel as v1's shared string. Purely additive: nothing mints v2 yet (#1598) and the member install that consumes it is #1597; all current consumers untouched. Discriminated by version (not an either-field relaxation, per design §5.2 / red-team R9/R12); the v1 decoder now rejects a newer version with an explicit upgrade error instead of the old misleading path. Full detail in the commit message. Registry suite (201) + tsc + vocab gate green. Closes #1596.