### PR TITLE
feat(network): C-1597 — member-side install of the v2 leaf credential (epic #1595 slice 3)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -705,8 +705,10 @@ describe("cortex network join — plug-and-play leaf-secret auto-fetch", () => {
   });
 
   test("v2 install REPLACES a pre-existing looser file with different content, ending 0600", async () => {
-    // The Sage #1609 window: new credential text written over a 0644 file must
-    // never end up (or transit) group-readable — exercises the WRITE branch.
+    // Exercises the WRITE branch against a pre-existing 0644 file (the Sage
+    // #1609 window). Asserts the END state only — content replaced, final mode
+    // 0600; the no-transit-through-group-readable property is guaranteed by
+    // the tmp+rename design in installLeafCreds, not observable from here.
     const installDir = join(tmp, "nats-install-2");
     const installed = join(installDir, "metafactory-leaf.creds");
     mkdirSync(installDir, { recursive: true });

--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -657,74 +657,86 @@ describe("cortex network join — plug-and-play leaf-secret auto-fetch", () => {
   // #1597 (epic #1595) — v2 payload: the delivered per-member credential FILE
   // is installed at the conventional 0600 path before the join renders.
   // ===========================================================================
-  test("a v2 (credential-file) payload is installed 0600 at the conventional per-network path", async () => {
-    const joinerSeed = join(tmp, "joiner3.seed");
-    writeFileSync(joinerSeed, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
-    chmodSync(joinerSeed, 0o600);
 
-    // Clearly-FAKE `.creds` text (structure only, all-A payloads).
-    const FAKE_CREDS =
-      "-----BEGIN NATS USER JWT-----\n" + "A".repeat(64) + "\n------END NATS USER JWT------\n\n" +
-      "-----BEGIN USER NKEY SEED-----\nSUA" + "A".repeat(55) + "\n------END USER NKEY SEED------\n";
+  // Clearly-FAKE `.creds` text (structure only, all-A payloads).
+  const FAKE_CREDS =
+    "-----BEGIN NATS USER JWT-----\n" + "A".repeat(64) + "\n------END NATS USER JWT------\n\n" +
+    "-----BEGIN USER NKEY SEED-----\nSUA" + "A".repeat(55) + "\n------END USER NKEY SEED------\n";
 
-    const installDir = join(tmp, "nats-install");
-    __setLeafCredsInstallDirForTests(installDir);
-    __setJoinLeafSecretFetcherForTests(async () => ({
-      ok: true,
-      kind: "creds",
-      creds: FAKE_CREDS,
-      leafUser: "andreas/default",
-      mintedAt: "2026-07-06T00:00:00Z",
-    }));
+  /** Write a real joiner seed (so materialFromSeedString succeeds) → its path. */
+  function writeJoinerSeed(name: string): string {
+    const p = join(tmp, name);
+    writeFileSync(p, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
+    chmodSync(p, 0o600);
+    return p;
+  }
 
-    // Dry-run join: the descriptor fetch fails against the unreachable registry,
-    // but the auto-fetch + install run FIRST — the install is what #1597 claims.
-    await dispatchNetwork([
+  /** The shared dry-run join argv (descriptor fetch fails against the
+   *  unreachable registry, but the auto-fetch + install run FIRST). */
+  function joinArgs(seedPath: string): string[] {
+    return [
       "join", "metafactory",
       "--principal", "andreas",
       "--registry-url", "http://127.0.0.1:0",
-      "--seed-path", joinerSeed,
+      "--seed-path", seedPath,
       "--account", "A" + "B".repeat(55),
       "--nats-config", join(tmp, "local.conf"),
       "--plist", join(tmp, "nats.plist"),
-    ], (() => ({})) as never);
+    ];
+  }
+
+  function fakeV2Fetcher(creds: string): void {
+    __setJoinLeafSecretFetcherForTests(async () => ({
+      ok: true,
+      kind: "creds",
+      creds,
+      leafUser: "andreas/default",
+      mintedAt: "2026-07-06T00:00:00Z",
+    }));
+  }
+
+  test("a v2 (credential-file) payload is installed 0600 at the conventional per-network path", async () => {
+    const installDir = join(tmp, "nats-install");
+    __setLeafCredsInstallDirForTests(installDir);
+    fakeV2Fetcher(FAKE_CREDS);
+
+    await dispatchNetwork(joinArgs(writeJoinerSeed("joiner3.seed")), (() => ({})) as never);
 
     const installed = join(installDir, "metafactory-leaf.creds");
     expect(readFileSync(installed, "utf-8")).toBe(FAKE_CREDS);
     // 0600 — not group- or world-readable (the acceptance bar).
-    const mode = statSync(installed).mode & 0o777;
-    expect(mode).toBe(0o600);
+    expect(statSync(installed).mode & 0o777).toBe(0o600);
   });
 
-  test("v2 install is byte-stable + re-asserts 0600 on a pre-existing looser file", async () => {
-    const joinerSeed = join(tmp, "joiner4.seed");
-    writeFileSync(joinerSeed, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
-    chmodSync(joinerSeed, 0o600);
-
-    const FAKE_CREDS = "-----BEGIN NATS USER JWT-----\nAAAA\n------END NATS USER JWT------\n";
+  test("v2 install REPLACES a pre-existing looser file with different content, ending 0600", async () => {
+    // The Sage #1609 window: new credential text written over a 0644 file must
+    // never end up (or transit) group-readable — exercises the WRITE branch.
     const installDir = join(tmp, "nats-install-2");
     const installed = join(installDir, "metafactory-leaf.creds");
     mkdirSync(installDir, { recursive: true });
-    writeFileSync(installed, FAKE_CREDS, { mode: 0o644 }); // pre-existing, too loose
+    writeFileSync(installed, "-----BEGIN NATS USER JWT-----\nOLD\n", { mode: 0o644 });
 
     __setLeafCredsInstallDirForTests(installDir);
-    __setJoinLeafSecretFetcherForTests(async () => ({
-      ok: true,
-      kind: "creds",
-      creds: FAKE_CREDS,
-      leafUser: "andreas/default",
-      mintedAt: "2026-07-06T00:00:00Z",
-    }));
+    fakeV2Fetcher(FAKE_CREDS);
 
-    await dispatchNetwork([
-      "join", "metafactory",
-      "--principal", "andreas",
-      "--registry-url", "http://127.0.0.1:0",
-      "--seed-path", joinerSeed,
-      "--account", "A" + "B".repeat(55),
-      "--nats-config", join(tmp, "local.conf"),
-      "--plist", join(tmp, "nats.plist"),
-    ], (() => ({})) as never);
+    await dispatchNetwork(joinArgs(writeJoinerSeed("joiner4.seed")), (() => ({})) as never);
+
+    expect(readFileSync(installed, "utf-8")).toBe(FAKE_CREDS);
+    expect(statSync(installed).mode & 0o777).toBe(0o600);
+  });
+
+  test("v2 install is byte-stable + re-asserts 0600 on an IDENTICAL pre-existing looser file", async () => {
+    // Same content on disk → the write branch is skipped (no mtime churn) and
+    // only the trailing chmod tightens the looser pre-existing mode.
+    const installDir = join(tmp, "nats-install-3");
+    const installed = join(installDir, "metafactory-leaf.creds");
+    mkdirSync(installDir, { recursive: true });
+    writeFileSync(installed, FAKE_CREDS, { mode: 0o644 });
+
+    __setLeafCredsInstallDirForTests(installDir);
+    fakeV2Fetcher(FAKE_CREDS);
+
+    await dispatchNetwork(joinArgs(writeJoinerSeed("joiner5.seed")), (() => ({})) as never);
 
     expect(readFileSync(installed, "utf-8")).toBe(FAKE_CREDS);
     expect(statSync(installed).mode & 0o777).toBe(0o600);

--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -28,6 +28,7 @@ import type {
 } from "../network-secret-ports";
 import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
 import type { FetchSealedLeafSecretInput } from "../../../../common/registry/fetch-sealed-secret";
+import { FAKE_CREDS } from "../../../../common/registry/__tests__/fixtures";
 
 let tmp: string;
 let seedPath: string;
@@ -657,11 +658,6 @@ describe("cortex network join — plug-and-play leaf-secret auto-fetch", () => {
   // #1597 (epic #1595) — v2 payload: the delivered per-member credential FILE
   // is installed at the conventional 0600 path before the join renders.
   // ===========================================================================
-
-  // Clearly-FAKE `.creds` text (structure only, all-A payloads).
-  const FAKE_CREDS =
-    "-----BEGIN NATS USER JWT-----\n" + "A".repeat(64) + "\n------END NATS USER JWT------\n\n" +
-    "-----BEGIN USER NKEY SEED-----\nSUA" + "A".repeat(55) + "\n------END USER NKEY SEED------\n";
 
   /** Write a real joiner seed (so materialFromSeedString succeeds) → its path. */
   function writeJoinerSeed(name: string): string {

--- a/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-cli.test.ts
@@ -8,13 +8,14 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync, readFileSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createUser } from "nkeys.js";
 import {
   dispatchNetwork,
   __setJoinLeafSecretFetcherForTests,
+  __setLeafCredsInstallDirForTests,
   __setDiscordRemoveClientForTests,
   type SecretPortsFactory,
   type KeyRotationPortsFactory,
@@ -611,7 +612,10 @@ describe("cortex network secret revoke-member — C-1349 rotate-now recommendati
 // =============================================================================
 
 describe("cortex network join — plug-and-play leaf-secret auto-fetch", () => {
-  afterEach(() => __setJoinLeafSecretFetcherForTests(null));
+  afterEach(() => {
+    __setJoinLeafSecretFetcherForTests(null);
+    __setLeafCredsInstallDirForTests(null);
+  });
 
   test("join with NO configured leaf-secret AUTO-fetches it from the admission gate", async () => {
     // A real joiner seed so materialFromSeedString succeeds.
@@ -622,7 +626,7 @@ describe("cortex network join — plug-and-play leaf-secret auto-fetch", () => {
     const seen: FetchSealedLeafSecretInput[] = [];
     __setJoinLeafSecretFetcherForTests(async (input) => {
       seen.push(input);
-      return { ok: true, leafPsk: "AUTO-PSK", leafUser: "andreas" };
+      return { ok: true, kind: "psk", leafPsk: "AUTO-PSK", leafUser: "andreas" };
     });
 
     // Dry-run join (no --apply): the descriptor fetch will fail against the
@@ -643,6 +647,87 @@ describe("cortex network join — plug-and-play leaf-secret auto-fetch", () => {
     expect(seen[0]!.networkId).toBe("metafactory");
     expect(seen[0]!.principalId).toBe("andreas");
     expect(seen[0]!.registryUrl).toBe("http://127.0.0.1:0");
+    // #1597 (R7) — the join declares the member's OWN identities so a v2
+    // credential minted for a different subject is refused inside the fetch.
+    expect(seen[0]!.expectedLeafUsers).toContain("andreas/default");
+    expect(seen[0]!.expectedLeafUsers).toContain("andreas");
+  });
+
+  // ===========================================================================
+  // #1597 (epic #1595) — v2 payload: the delivered per-member credential FILE
+  // is installed at the conventional 0600 path before the join renders.
+  // ===========================================================================
+  test("a v2 (credential-file) payload is installed 0600 at the conventional per-network path", async () => {
+    const joinerSeed = join(tmp, "joiner3.seed");
+    writeFileSync(joinerSeed, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
+    chmodSync(joinerSeed, 0o600);
+
+    // Clearly-FAKE `.creds` text (structure only, all-A payloads).
+    const FAKE_CREDS =
+      "-----BEGIN NATS USER JWT-----\n" + "A".repeat(64) + "\n------END NATS USER JWT------\n\n" +
+      "-----BEGIN USER NKEY SEED-----\nSUA" + "A".repeat(55) + "\n------END USER NKEY SEED------\n";
+
+    const installDir = join(tmp, "nats-install");
+    __setLeafCredsInstallDirForTests(installDir);
+    __setJoinLeafSecretFetcherForTests(async () => ({
+      ok: true,
+      kind: "creds",
+      creds: FAKE_CREDS,
+      leafUser: "andreas/default",
+      mintedAt: "2026-07-06T00:00:00Z",
+    }));
+
+    // Dry-run join: the descriptor fetch fails against the unreachable registry,
+    // but the auto-fetch + install run FIRST — the install is what #1597 claims.
+    await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", joinerSeed,
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(tmp, "local.conf"),
+      "--plist", join(tmp, "nats.plist"),
+    ], (() => ({})) as never);
+
+    const installed = join(installDir, "metafactory-leaf.creds");
+    expect(readFileSync(installed, "utf-8")).toBe(FAKE_CREDS);
+    // 0600 — not group- or world-readable (the acceptance bar).
+    const mode = statSync(installed).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("v2 install is byte-stable + re-asserts 0600 on a pre-existing looser file", async () => {
+    const joinerSeed = join(tmp, "joiner4.seed");
+    writeFileSync(joinerSeed, new TextDecoder().decode(createUser().getSeed()), { mode: 0o600 });
+    chmodSync(joinerSeed, 0o600);
+
+    const FAKE_CREDS = "-----BEGIN NATS USER JWT-----\nAAAA\n------END NATS USER JWT------\n";
+    const installDir = join(tmp, "nats-install-2");
+    const installed = join(installDir, "metafactory-leaf.creds");
+    mkdirSync(installDir, { recursive: true });
+    writeFileSync(installed, FAKE_CREDS, { mode: 0o644 }); // pre-existing, too loose
+
+    __setLeafCredsInstallDirForTests(installDir);
+    __setJoinLeafSecretFetcherForTests(async () => ({
+      ok: true,
+      kind: "creds",
+      creds: FAKE_CREDS,
+      leafUser: "andreas/default",
+      mintedAt: "2026-07-06T00:00:00Z",
+    }));
+
+    await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", joinerSeed,
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(tmp, "local.conf"),
+      "--plist", join(tmp, "nats.plist"),
+    ], (() => ({})) as never);
+
+    expect(readFileSync(installed, "utf-8")).toBe(FAKE_CREDS);
+    expect(statSync(installed).mode & 0o777).toBe(0o600);
   });
 
   test("an explicit --leaf-secret SUPPRESSES the auto-fetch", async () => {

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -815,16 +815,19 @@ function leafCredsInstallPath(networkId: string): string {
 
 /**
  * #1597 — install the fetched v2 credential file at the conventional path.
- * Written as a NEW same-dir tmp file created 0600, then renamed over the
- * target: `writeFileSync`'s mode only applies to newly-created files, so a
- * direct overwrite of a looser pre-existing file would expose the fresh
- * credential group-readable until a trailing chmod (Sage #1609). The
- * tmp+rename keeps the text 0600 for its entire on-disk life AND makes the
- * replacement atomic. Byte-stable no-op when the content already matches
- * (re-join idempotency — no mtime churn), with the mode re-asserted either
- * way for a looser identical pre-existing file.
+ * Written as a NEW same-dir tmp file EXCLUSIVELY created 0600 (flag "wx" — a
+ * stale tmp from a crashed run is removed, never silently reused, so
+ * `writeFileSync`'s create-only mode semantics always apply), then renamed
+ * over the target: a direct overwrite of a looser pre-existing file would
+ * expose the fresh credential group-readable until a trailing chmod (Sage
+ * #1609). The tmp+rename keeps the text 0600 from creation to install AND
+ * makes the replacement atomic. Byte-stable no-op when the content already
+ * matches (re-join idempotency — no mtime churn), with the mode re-asserted
+ * either way for a looser identical pre-existing file. Returns whether a
+ * write happened so the caller can surface the mutation (it runs in dry-run
+ * too — see the call site).
  */
-function installLeafCreds(networkId: string, creds: string): string {
+function installLeafCreds(networkId: string, creds: string): { path: string; wrote: boolean } {
   const path = leafCredsInstallPath(networkId);
   let existing: string | undefined;
   try {
@@ -832,18 +835,20 @@ function installLeafCreds(networkId: string, creds: string): string {
   } catch (_err) {
     existing = undefined; // ENOENT etc. — treat as "not installed yet".
   }
-  if (existing !== creds) {
+  const wrote = existing !== creds;
+  if (wrote) {
     mkdirSync(dirname(path), { recursive: true });
     const tmp = `${path}.tmp-${process.pid}`;
-    writeFileSync(tmp, creds, { mode: 0o600 });
+    rmSync(tmp, { force: true }); // a stale tmp (crash + PID reuse) may be loose
     try {
+      writeFileSync(tmp, creds, { mode: 0o600, flag: "wx" });
       renameSync(tmp, path);
     } catch (err) {
       // Never leave the credential text behind under the tmp name.
       try {
         rmSync(tmp, { force: true });
       } catch (_cleanupErr) {
-        // Best-effort cleanup only — the rename failure below is the real error.
+        // Best-effort cleanup only — the write/rename failure is the real error.
       }
       throw err;
     }
@@ -851,7 +856,7 @@ function installLeafCreds(networkId: string, creds: string): string {
   // Re-assert 0600 on the byte-stable path — a pre-existing identical file may
   // carry looser permissions.
   chmodSync(path, 0o600);
-  return path;
+  return { path, wrote };
 }
 
 /**
@@ -905,14 +910,17 @@ async function maybeAutoFetchLeafSecret(
   // #1597 — a v2 envelope delivered a per-member `.creds` file (operator-mode
   // hub). Install it NOW, before the ports split: the #821 existence preflight
   // is a pure read in BOTH live and dry-run, so the file must exist for either
-  // mode to render a truthful plan. Installing the member's OWN delivered
-  // credential at its conventional 0600 path is member-local hygiene (the same
-  // class as the enforceChmod600 above), not live-deployment mutation — the
-  // nats config / plist / registry writes all stay behind --apply.
+  // mode to render a truthful plan (the issue pins this ordering: "the #821
+  // existence preflight passes because the file was just written"). This is a
+  // DELIBERATE carve-out from the "dry-run touches nothing" contract — it
+  // installs only the member's OWN delivered credential at its conventional
+  // 0600 path (the same member-local class as the enforceChmod600 above); the
+  // nats config / plist / registry writes all stay behind --apply. The
+  // stderr notice below keeps the mutation explicit in dry-run output.
   if (res.kind === "creds") {
-    let credsPath: string;
+    let install: { path: string; wrote: boolean };
     try {
-      credsPath = installLeafCreds(networkId, res.creds);
+      install = installLeafCreds(networkId, res.creds);
     } catch (err) {
       // Best-effort like every other auto-fetch failure: fall through to the
       // existing join behaviour, surfacing why on stderr (never the creds).
@@ -922,9 +930,16 @@ async function maybeAutoFetchLeafSecret(
       );
       return undefined;
     }
+    if (install.wrote) {
+      process.stderr.write(
+        `cortex network join: installed the fetched per-member leaf credential file at ` +
+          `${install.path} (0600). NOTE: this install happens even without --apply, so the ` +
+          `leaf-file preflight previews truthfully; all other join mutations stay behind --apply.\n`,
+      );
+    }
     return {
       kind: "creds-file",
-      credsPath,
+      credsPath: install.path,
       leafUser: res.leafUser,
       ...(res.payloadKey !== undefined && { payloadKey: res.payloadKey }),
       ...(res.payloadKeyKid !== undefined && { payloadKeyKid: res.payloadKeyKid }),

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -40,7 +40,7 @@
  * Exit codes: 0 success · 1 operational failure · 2 usage error.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { dirname, join } from "path";
 
@@ -815,11 +815,14 @@ function leafCredsInstallPath(networkId: string): string {
 
 /**
  * #1597 — install the fetched v2 credential file at the conventional path.
- * Created 0600 (never transitions through a group-readable state); byte-stable
- * no-op when the on-disk content already matches (re-join idempotency — no
- * mtime churn), with the mode re-asserted either way. A truncated write is
- * self-healing here (unlike the nats config, #1058): the next join re-fetches
- * and rewrites, and the #821 preflight refuses a marker-less torso.
+ * Written as a NEW same-dir tmp file created 0600, then renamed over the
+ * target: `writeFileSync`'s mode only applies to newly-created files, so a
+ * direct overwrite of a looser pre-existing file would expose the fresh
+ * credential group-readable until a trailing chmod (Sage #1609). The
+ * tmp+rename keeps the text 0600 for its entire on-disk life AND makes the
+ * replacement atomic. Byte-stable no-op when the content already matches
+ * (re-join idempotency — no mtime churn), with the mode re-asserted either
+ * way for a looser identical pre-existing file.
  */
 function installLeafCreds(networkId: string, creds: string): string {
   const path = leafCredsInstallPath(networkId);
@@ -831,10 +834,22 @@ function installLeafCreds(networkId: string, creds: string): string {
   }
   if (existing !== creds) {
     mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, creds, { mode: 0o600 });
+    const tmp = `${path}.tmp-${process.pid}`;
+    writeFileSync(tmp, creds, { mode: 0o600 });
+    try {
+      renameSync(tmp, path);
+    } catch (err) {
+      // Never leave the credential text behind under the tmp name.
+      try {
+        rmSync(tmp, { force: true });
+      } catch (_cleanupErr) {
+        // Best-effort cleanup only — the rename failure below is the real error.
+      }
+      throw err;
+    }
   }
-  // Re-assert 0600 even on the byte-stable path — a pre-existing file may have
-  // been created with looser permissions.
+  // Re-assert 0600 on the byte-stable path — a pre-existing identical file may
+  // carry looser permissions.
   chmodSync(path, 0o600);
   return path;
 }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -40,9 +40,9 @@
  * Exit codes: 0 success · 1 operational failure · 2 usage error.
  */
 
-import { existsSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { readFile } from "fs/promises";
-import { join } from "path";
+import { dirname, join } from "path";
 
 import { expandTilde, loadConfigWithAgents } from "../../../common/config/loader";
 import type { LoadedConfig } from "../../../common/config/loader";
@@ -794,10 +794,70 @@ export function __setJoinLeafSecretFetcherForTests(f: LeafSecretFetcher | null):
   joinLeafSecretFetcherOverride = f;
 }
 
+/**
+ * #1597 — where a fetched v2 per-member `.creds` file is installed. Deliberately
+ * the `-leaf` suffixed name, NOT `defaultCredsPath`'s `<network>.creds`: the
+ * derive convention path may carry a hand-placed Model-A file we must never
+ * clobber. Tests inject a tmp dir via {@link __setLeafCredsInstallDirForTests}.
+ */
+const LEAF_CREDS_INSTALL_DIR = "~/.config/nats";
+let leafCredsInstallDirOverride: string | null = null;
+
+/** Test-only — redirect the v2 creds install dir to a tmp dir. */
+export function __setLeafCredsInstallDirForTests(dir: string | null): void {
+  leafCredsInstallDirOverride = dir;
+}
+
+function leafCredsInstallPath(networkId: string): string {
+  const dir = leafCredsInstallDirOverride ?? expandTilde(LEAF_CREDS_INSTALL_DIR);
+  return join(dir, `${networkId}-leaf.creds`);
+}
+
+/**
+ * #1597 — install the fetched v2 credential file at the conventional path.
+ * Created 0600 (never transitions through a group-readable state); byte-stable
+ * no-op when the on-disk content already matches (re-join idempotency — no
+ * mtime churn), with the mode re-asserted either way. A truncated write is
+ * self-healing here (unlike the nats config, #1058): the next join re-fetches
+ * and rewrites, and the #821 preflight refuses a marker-less torso.
+ */
+function installLeafCreds(networkId: string, creds: string): string {
+  const path = leafCredsInstallPath(networkId);
+  let existing: string | undefined;
+  try {
+    existing = readFileSync(path, "utf-8");
+  } catch (_err) {
+    existing = undefined; // ENOENT etc. — treat as "not installed yet".
+  }
+  if (existing !== creds) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, creds, { mode: 0o600 });
+  }
+  // Re-assert 0600 even on the byte-stable path — a pre-existing file may have
+  // been created with looser permissions.
+  chmodSync(path, 0o600);
+  return path;
+}
+
+/**
+ * The join-side result of the auto-fetch, discriminated by which leaf-auth
+ * shape the sealed envelope delivered (#1597):
+ *   - `secret-auth` (v1) — the Model-B shared-string pipe; join renders the
+ *     URL-userinfo remote.
+ *   - `creds-file` (v2)  — a per-member NSC user `.creds` was fetched and is
+ *     ALREADY INSTALLED at `credsPath` (0600); join points the stack binding at
+ *     it and renders the existing creds-file remote branch.
+ */
+type AutoFetchedLeafAuth =
+  | { kind: "secret-auth"; leafSecret: string; leafUser: string; payloadKey?: string; payloadKeyKid?: string }
+  | { kind: "creds-file"; credsPath: string; leafUser: string; payloadKey?: string; payloadKeyKid?: string };
+
 async function maybeAutoFetchLeafSecret(
   networkId: string,
   inputs: { leafSecret?: string; seedPath: string; registryUrl: string; principal: string },
-): Promise<{ leafSecret: string; leafUser: string; payloadKey?: string; payloadKeyKid?: string } | undefined> {
+  /** #1597 (R7) — the member's OWN identities a v2 credential must be minted for. */
+  expectedLeafUsers: readonly string[],
+): Promise<AutoFetchedLeafAuth | undefined> {
   // Only when no leaf secret was resolved from flag/config (don't override an
   // explicit secret-auth join).
   if (inputs.leafSecret !== undefined) return undefined;
@@ -823,9 +883,41 @@ async function maybeAutoFetchLeafSecret(
     networkId,
     principalId: inputs.principal,
     material,
+    expectedLeafUsers,
   });
   if (!res.ok) return undefined;
+
+  // #1597 — a v2 envelope delivered a per-member `.creds` file (operator-mode
+  // hub). Install it NOW, before the ports split: the #821 existence preflight
+  // is a pure read in BOTH live and dry-run, so the file must exist for either
+  // mode to render a truthful plan. Installing the member's OWN delivered
+  // credential at its conventional 0600 path is member-local hygiene (the same
+  // class as the enforceChmod600 above), not live-deployment mutation — the
+  // nats config / plist / registry writes all stay behind --apply.
+  if (res.kind === "creds") {
+    let credsPath: string;
+    try {
+      credsPath = installLeafCreds(networkId, res.creds);
+    } catch (err) {
+      // Best-effort like every other auto-fetch failure: fall through to the
+      // existing join behaviour, surfacing why on stderr (never the creds).
+      process.stderr.write(
+        `cortex network join: fetched a v2 leaf credential for "${networkId}" but could not ` +
+          `install it: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return undefined;
+    }
+    return {
+      kind: "creds-file",
+      credsPath,
+      leafUser: res.leafUser,
+      ...(res.payloadKey !== undefined && { payloadKey: res.payloadKey }),
+      ...(res.payloadKeyKid !== undefined && { payloadKeyKid: res.payloadKeyKid }),
+    };
+  }
+
   return {
+    kind: "secret-auth",
     leafSecret: res.leafPsk,
     leafUser: res.leafUser,
     // C-1349 Slice 1 — carry the sealed payload key K (+ kid) through to the
@@ -1068,14 +1160,39 @@ async function runJoin(
   // ADR-0018 PR5b — plug-and-play: when no leaf secret came from flag/config,
   // auto-fetch + unseal it from the admission gate (the joiner never handles a
   // secret). Best-effort: undefined ⇒ fall through to the existing behaviour.
-  const autoSecret = await maybeAutoFetchLeafSecret(networkId, inputs);
+  //
+  // #1597 (R7) — the member's OWN identities a fetched v2 per-member credential
+  // must be minted for: both the flag/locator-honouring identity (the admission
+  // row's principal) and the boot-pinned identity (C-1436/C-1364 — what the
+  // daemon stamps on the wire), in `{principal}/{stack}` and bare-principal
+  // forms (v1's leaf_user convention is the bare principal id). Every entry is
+  // one of OUR identities, so the set stays a strict R7 guard: a credential
+  // minted for a different member can never match.
+  const expectedLeafUsers = [
+    ...new Set([
+      `${inputs.principal}/${slugRes.slug}`,
+      inputs.principal,
+      `${inputs.bootPrincipal}/${inputs.bootStackSlug}`,
+      inputs.bootPrincipal,
+    ]),
+  ];
+  const autoAuth = await maybeAutoFetchLeafSecret(networkId, inputs, expectedLeafUsers);
+  const autoSecret = autoAuth?.kind === "secret-auth" ? autoAuth : undefined;
   const resolvedLeafSecret = inputs.leafSecret ?? autoSecret?.leafSecret;
   const resolvedLeafUser = inputs.leafUser ?? autoSecret?.leafUser;
+  // #1597 — a fetched v2 credential file was installed at its conventional
+  // 0600 path: point the stack binding THERE (instead of the derive-time creds
+  // path) so joinNetwork renders the existing creds-file remote branch — the
+  // exact shape production operator-mode leaves run. The #821 existence
+  // preflight passes because the file was just written.
+  const resolvedCredsPath =
+    autoAuth?.kind === "creds-file" ? autoAuth.credsPath : expandTilde(inputs.credsPath);
   // C-1349 Slice 1 — the sealed envelope's payload key K (+ kid), when the admin
   // sealed one via `secret add-member`/`rotate`. Present ⇒ join writes
   // `encryption: enabled` + `payload_key` (+ kid) into stacks/<slug>.yaml.
-  const resolvedPayloadKey = autoSecret?.payloadKey;
-  const resolvedPayloadKeyKid = autoSecret?.payloadKeyKid;
+  // Rides BOTH envelope versions (#1597).
+  const resolvedPayloadKey = autoAuth?.payloadKey;
+  const resolvedPayloadKeyKid = autoAuth?.payloadKeyKid;
 
   const stack: JoiningStack = {
     // C-1436 — the own-scope federation identity's PRINCIPAL segment MUST derive
@@ -1102,7 +1219,7 @@ async function runJoin(
     // fail daemon boot (or be falsely refused). Pin the guard to `bootStackSlug`
     // so guard + boot can never split. See cortex#1364.
     stackSlug: inputs.bootStackSlug,
-    credentials: expandTilde(inputs.credsPath),
+    credentials: resolvedCredsPath,
     account: inputs.account,
     // C-1224 (ADR-0013 Model B) — pass the secret-auth leaf material (when
     // resolved, including PR5b's auto-fetched leaf PSK) so the join renders a

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -40,7 +40,7 @@
  * Exit codes: 0 success · 1 operational failure · 2 usage error.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { dirname, join } from "path";
 
@@ -821,19 +821,25 @@ function leafCredsInstallPath(networkId: string): string {
  * over the target: a direct overwrite of a looser pre-existing file would
  * expose the fresh credential group-readable until a trailing chmod (Sage
  * #1609). The tmp+rename keeps the text 0600 from creation to install AND
- * makes the replacement atomic. Byte-stable no-op when the content already
- * matches (re-join idempotency — no mtime churn), with the mode re-asserted
- * either way for a looser identical pre-existing file. Returns whether a
- * write happened so the caller can surface the mutation (it runs in dry-run
- * too — see the call site).
+ * makes the replacement atomic. When the content already matches, the write
+ * is skipped (re-join idempotency — no content/mtime churn) but a looser
+ * pre-existing mode is still tightened to 0600. BOTH mutations — the write
+ * and the mode-tighten — are reported to the caller, which surfaces them on
+ * stderr (this runs in dry-run too — see the call site).
  */
-function installLeafCreds(networkId: string, creds: string): { path: string; wrote: boolean } {
+function installLeafCreds(
+  networkId: string,
+  creds: string,
+): { path: string; wrote: boolean; tightened: boolean } {
   const path = leafCredsInstallPath(networkId);
   let existing: string | undefined;
   try {
     existing = readFileSync(path, "utf-8");
-  } catch (_err) {
-    existing = undefined; // ENOENT etc. — treat as "not installed yet".
+  } catch (err) {
+    // Only ENOENT means "not installed yet" — surface EACCES/EISDIR/etc. as
+    // the real filesystem problem they are (the caller's catch reports them).
+    if ((err as { code?: string }).code !== "ENOENT") throw err;
+    existing = undefined;
   }
   const wrote = existing !== creds;
   if (wrote) {
@@ -853,10 +859,12 @@ function installLeafCreds(networkId: string, creds: string): { path: string; wro
       throw err;
     }
   }
-  // Re-assert 0600 on the byte-stable path — a pre-existing identical file may
-  // carry looser permissions.
-  chmodSync(path, 0o600);
-  return { path, wrote };
+  // Tighten a looser mode ONLY when needed, and report it: even the
+  // identical-content path is a (metadata) mutation when a pre-existing file
+  // was group-readable. A fresh tmp+rename install is already 0600.
+  const tightened = (statSync(path).mode & 0o777) !== 0o600;
+  if (tightened) chmodSync(path, 0o600);
+  return { path, wrote, tightened };
 }
 
 /**
@@ -915,26 +923,32 @@ async function maybeAutoFetchLeafSecret(
   // DELIBERATE carve-out from the "dry-run touches nothing" contract — it
   // installs only the member's OWN delivered credential at its conventional
   // 0600 path (the same member-local class as the enforceChmod600 above); the
-  // nats config / plist / registry writes all stay behind --apply. The
-  // stderr notice below keeps the mutation explicit in dry-run output.
+  // nats config / plist / registry writes all stay behind --apply. EVERY
+  // mutation this carve-out performs — a content write AND a mode tighten —
+  // is surfaced by the stderr notice below, so dry-run output stays honest.
   if (res.kind === "creds") {
-    let install: { path: string; wrote: boolean };
+    let install: { path: string; wrote: boolean; tightened: boolean };
     try {
       install = installLeafCreds(networkId, res.creds);
     } catch (err) {
       // Best-effort like every other auto-fetch failure: fall through to the
       // existing join behaviour, surfacing why on stderr (never the creds).
+      // On a v2-only hub with nothing at the derive-time creds path this is
+      // NOT silent: the #821 existence preflight then fails the join loudly.
       process.stderr.write(
         `cortex network join: fetched a v2 leaf credential for "${networkId}" but could not ` +
           `install it: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       return undefined;
     }
-    if (install.wrote) {
+    if (install.wrote || install.tightened) {
+      const action = install.wrote
+        ? "installed the fetched per-member leaf credential file at"
+        : "tightened the mode of the leaf credential file at";
       process.stderr.write(
-        `cortex network join: installed the fetched per-member leaf credential file at ` +
-          `${install.path} (0600). NOTE: this install happens even without --apply, so the ` +
-          `leaf-file preflight previews truthfully; all other join mutations stay behind --apply.\n`,
+        `cortex network join: ${action} ${install.path} (0600). NOTE: this happens even ` +
+          `without --apply, so the leaf-file preflight previews truthfully; all other join ` +
+          `mutations stay behind --apply.\n`,
       );
     }
     return {

--- a/src/common/registry/__tests__/fetch-sealed-secret.test.ts
+++ b/src/common/registry/__tests__/fetch-sealed-secret.test.ts
@@ -11,7 +11,11 @@
 import { describe, test, expect } from "bun:test";
 import { createUser } from "nkeys.js";
 import { sealToPrincipal } from "../../crypto/seal-to-principal";
-import { encodeLeafSecretEnvelope, decodeLeafSecretEnvelope } from "../sealed-leaf-secret";
+import {
+  encodeLeafSecretEnvelope,
+  encodeLeafSecretEnvelopeV2,
+  decodeLeafSecretEnvelope,
+} from "../sealed-leaf-secret";
 import { fetchSealedLeafSecret, type FetchLike } from "../fetch-sealed-secret";
 import { materialFromSeedString, type StackIdentityMaterial } from "../../../bus/stack-provisioning";
 
@@ -51,7 +55,7 @@ describe("fetchSealedLeafSecret — round-trip", () => {
       material: member,
       fetchImpl,
     });
-    expect(res).toEqual({ ok: true, leafPsk: "PSK-abc", leafUser: "alice" });
+    expect(res).toEqual({ ok: true, kind: "psk", leafPsk: "PSK-abc", leafUser: "alice" });
   });
 
   test("selects the row for the TARGET network (ignores other networks)", async () => {
@@ -63,7 +67,7 @@ describe("fetchSealedLeafSecret — round-trip", () => {
       { request_id: "r2", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealedMeta },
     ]);
     const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
-    expect(res.ok && res.leafPsk).toBe("PSK-meta");
+    expect(res.ok && res.kind === "psk" && res.leafPsk).toBe("PSK-meta");
   });
 
   test("no admitted+sealed row → soft-closed { ok: false }", async () => {
@@ -102,6 +106,141 @@ describe("fetchSealedLeafSecret — round-trip", () => {
     const fetchImpl: FetchLike = async () => ({ ok: false, status: 503, json: async () => ({}), text: async () => "down" });
     const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
     expect(res.ok).toBe(false);
+  });
+});
+
+// =============================================================================
+// #1597 (epic #1595) — the v2 per-member credential-file payload.
+// =============================================================================
+
+/** Clearly-FAKE `.creds` text (structure only, all-A payloads). */
+const FAKE_CREDS =
+  "-----BEGIN NATS USER JWT-----\n" + "A".repeat(64) + "\n------END NATS USER JWT------\n\n" +
+  "-----BEGIN USER NKEY SEED-----\nSUA" + "A".repeat(55) + "\n------END USER NKEY SEED------\n";
+
+async function sealedV2For(
+  material: StackIdentityMaterial,
+  leafUser: string,
+  creds: string = FAKE_CREDS,
+): Promise<string> {
+  const plaintext = encodeLeafSecretEnvelopeV2({
+    creds,
+    leaf_user: leafUser,
+    minted_at: "2026-07-06T00:00:00Z",
+  });
+  return sealToPrincipal(plaintext, material.pubkeyB64);
+}
+
+describe("fetchSealedLeafSecret — v2 credential-file payload (#1597)", () => {
+  test("member fetches + unseals its own v2 credential (identity matches)", async () => {
+    const member = newMember();
+    const sealed = await sealedV2For(member, "alice/default");
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealed },
+    ]);
+    const res = await fetchSealedLeafSecret({
+      registryUrl: "x",
+      networkId: "metafactory",
+      principalId: "alice",
+      material: member,
+      fetchImpl,
+      expectedLeafUsers: ["alice/default", "alice"],
+    });
+    expect(res).toEqual({
+      ok: true,
+      kind: "creds",
+      creds: FAKE_CREDS,
+      leafUser: "alice/default",
+      mintedAt: "2026-07-06T00:00:00Z",
+    });
+  });
+
+  test("R7 — a v2 credential minted for a DIFFERENT subject is refused, creds never echoed", async () => {
+    const member = newMember();
+    const sealed = await sealedV2For(member, "mallory/default");
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealed },
+    ]);
+    const res = await fetchSealedLeafSecret({
+      registryUrl: "x",
+      networkId: "metafactory",
+      principalId: "alice",
+      material: member,
+      fetchImpl,
+      expectedLeafUsers: ["alice/default", "alice"],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toContain("mallory/default");
+      expect(res.reason).toContain("R7");
+      expect(res.reason).not.toContain(FAKE_CREDS.slice(0, 40));
+    }
+  });
+
+  test("R7 fail-closed — a v2 payload with NO expected identities supplied is refused", async () => {
+    const member = newMember();
+    const sealed = await sealedV2For(member, "alice/default");
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealed },
+    ]);
+    // No expectedLeafUsers — the caller cannot vouch for its own identity, so a
+    // v2 credential must NOT be installed even when it would have matched.
+    const res = await fetchSealedLeafSecret({
+      registryUrl: "x",
+      networkId: "metafactory",
+      principalId: "alice",
+      material: member,
+      fetchImpl,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("R7");
+  });
+
+  test("v1 envelopes are UNAFFECTED by expectedLeafUsers (no identity claim in v1)", async () => {
+    const member = newMember();
+    const sealed = await sealedFor(member, "PSK-abc", "some-hub-userinfo-user");
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealed },
+    ]);
+    const res = await fetchSealedLeafSecret({
+      registryUrl: "x",
+      networkId: "metafactory",
+      principalId: "alice",
+      material: member,
+      fetchImpl,
+      expectedLeafUsers: ["alice/default", "alice"],
+    });
+    expect(res).toEqual({ ok: true, kind: "psk", leafPsk: "PSK-abc", leafUser: "some-hub-userinfo-user" });
+  });
+
+  test("the M3 payload key rides the v2 envelope too", async () => {
+    const member = newMember();
+    const plaintext = encodeLeafSecretEnvelopeV2({
+      creds: FAKE_CREDS,
+      leaf_user: "alice/default",
+      minted_at: "2026-07-06T00:00:00Z",
+      payload_key: "K",
+      payload_key_kid: "metafactory/k1",
+    });
+    const sealed = await sealToPrincipal(plaintext, member.pubkeyB64);
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: sealed },
+    ]);
+    const res = await fetchSealedLeafSecret({
+      registryUrl: "x",
+      networkId: "metafactory",
+      principalId: "alice",
+      material: member,
+      fetchImpl,
+      expectedLeafUsers: ["alice/default"],
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok && res.kind === "creds") {
+      expect(res.payloadKey).toBe("K");
+      expect(res.payloadKeyKid).toBe("metafactory/k1");
+    } else {
+      throw new Error("expected the v2 creds kind");
+    }
   });
 });
 

--- a/src/common/registry/__tests__/fetch-sealed-secret.test.ts
+++ b/src/common/registry/__tests__/fetch-sealed-secret.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../sealed-leaf-secret";
 import { fetchSealedLeafSecret, type FetchLike } from "../fetch-sealed-secret";
 import { materialFromSeedString, type StackIdentityMaterial } from "../../../bus/stack-provisioning";
+import { FAKE_CREDS } from "./fixtures";
 
 function newMember(): StackIdentityMaterial {
   const kp = createUser();
@@ -112,11 +113,6 @@ describe("fetchSealedLeafSecret — round-trip", () => {
 // =============================================================================
 // #1597 (epic #1595) — the v2 per-member credential-file payload.
 // =============================================================================
-
-/** Clearly-FAKE `.creds` text (structure only, all-A payloads). */
-const FAKE_CREDS =
-  "-----BEGIN NATS USER JWT-----\n" + "A".repeat(64) + "\n------END NATS USER JWT------\n\n" +
-  "-----BEGIN USER NKEY SEED-----\nSUA" + "A".repeat(55) + "\n------END USER NKEY SEED------\n";
 
 async function sealedV2For(
   material: StackIdentityMaterial,

--- a/src/common/registry/__tests__/fixtures.ts
+++ b/src/common/registry/__tests__/fixtures.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared test fixtures for the sealed-envelope suites (#1597). Clearly-FAKE
+ * material only — structure-shaped, all-A payloads, never realistic keys.
+ */
+
+/** Clearly-FAKE `.creds` text (structure only, all-A payloads). */
+export const FAKE_CREDS =
+  "-----BEGIN NATS USER JWT-----\n" + "A".repeat(64) + "\n------END NATS USER JWT------\n\n" +
+  "-----BEGIN USER NKEY SEED-----\nSUA" + "A".repeat(55) + "\n------END USER NKEY SEED------\n";

--- a/src/common/registry/fetch-sealed-secret.ts
+++ b/src/common/registry/fetch-sealed-secret.ts
@@ -14,16 +14,18 @@
  *   3. selects the ADMITTED row for the target network that carries a sealed
  *      blob,
  *   4. opens the `crypto_box_seal` with the member's raw ed25519 seed
- *      ({@link openSealed}) and decodes the {@link LeafSecretEnvelope}.
+ *      ({@link openSealed}) and decodes the envelope — VERSION-AWARE (#1597,
+ *      epic #1595): a v1 envelope yields the PSK path, a v2 envelope yields the
+ *      per-member `.creds` file text the join installs on disk.
  *
- * Returns the leaf PSK + user (and, once M3 lands, the same call surfaces the
- * payload key from the SAME envelope). Fails SOFT-CLOSED: every failure is a
- * typed `{ ok: false, reason }` so the join can fall through to its existing
+ * Returns a `kind`-discriminated payload (the M3 payload key rides BOTH kinds
+ * from the SAME envelope). Fails SOFT-CLOSED: every failure is a typed
+ * `{ ok: false, reason }` so the join can fall through to its existing
  * config/flag/oob behaviour rather than aborting.
  */
 
 import { openSealed } from "../crypto/seal-to-principal";
-import { decodeLeafSecretEnvelope } from "./sealed-leaf-secret";
+import { decodeAnyLeafSecretEnvelope, isLeafSecretEnvelopeV2 } from "./sealed-leaf-secret";
 import {
   rawEd25519SeedFromNkeySeed,
   type StackIdentityMaterial,
@@ -49,10 +51,31 @@ export interface FetchSealedLeafSecretInput {
   fetchImpl?: FetchLike;
   /** Injected clock (tests). Production omits → `Date`. */
   now?: () => Date;
+  /**
+   * #1597 (red-team R7) — the member's OWN identities a v2 envelope's
+   * `leaf_user` (the subject the credential was minted FOR) must match, e.g.
+   * `["{principal}/{stack}", "{principal}"]`. FAIL-CLOSED for v2: when a v2
+   * envelope arrives and this is absent/empty, the fetch refuses — a caller
+   * that cannot state its own identity must not install a credential that may
+   * have been minted for someone else (a hostile courier sealing ANOTHER
+   * member's real creds to this member). v1 is unaffected: its `leaf_user` is
+   * the userinfo USER the hub pairs with the PSK, not an identity claim.
+   */
+  expectedLeafUsers?: readonly string[];
 }
 
 export type FetchSealedLeafSecretResult =
-  | { ok: true; leafPsk: string; leafUser: string; payloadKey?: string; payloadKeyKid?: string }
+  /** v1 envelope — the Model-B shared-string secret-auth pipe (ADR-0013). */
+  | { ok: true; kind: "psk"; leafPsk: string; leafUser: string; payloadKey?: string; payloadKeyKid?: string }
+  /**
+   * v2 envelope (#1597, epic #1595) — the per-member NSC user `.creds` file
+   * text for an operator-mode hub. The caller writes `creds` to disk (0600)
+   * and renders the EXISTING creds-file leaf-remote branch. `mintedAt` is the
+   * seal-time stamp, surfaced for observability; staleness is deliberately NOT
+   * enforced here — a legitimate join may happen days after admission, and
+   * there is no rotation story until #1599.
+   */
+  | { ok: true; kind: "creds"; creds: string; leafUser: string; mintedAt: string; payloadKey?: string; payloadKeyKid?: string }
   | { ok: false; reason: string };
 
 /**
@@ -85,13 +108,48 @@ export async function fetchSealedLeafSecret(
     };
   }
 
-  // 4. Open the sealed box with the member's raw seed + decode the envelope.
+  // 4. Open the sealed box with the member's raw seed + decode the envelope —
+  //    VERSION-AWARE (#1597): the payload variant is pinned by `v` (design
+  //    §5.2 / R9/R12 — never an either-field relaxation).
   try {
     const rawSeed = rawEd25519SeedFromNkeySeed(input.material.seed);
     const plaintextBytes = await openSealed(row.sealed_secret, rawSeed);
-    const env = decodeLeafSecretEnvelope(new TextDecoder().decode(plaintextBytes));
+    const env = decodeAnyLeafSecretEnvelope(new TextDecoder().decode(plaintextBytes));
+    if (isLeafSecretEnvelopeV2(env)) {
+      // R7 identity binding — refuse a credential minted for a DIFFERENT
+      // subject. FAIL-CLOSED when the caller supplied no expected identities.
+      // `leaf_user` is an identity label, not secret material — safe to name
+      // in the reason (the creds text itself is NEVER echoed).
+      const expected = input.expectedLeafUsers ?? [];
+      if (expected.length === 0) {
+        return {
+          ok: false,
+          reason:
+            `sealed envelope for "${input.networkId}" carries a v2 per-member credential, but the caller ` +
+            `supplied no expected identities to bind it to (R7) — refusing to install it`,
+        };
+      }
+      if (!expected.includes(env.leaf_user)) {
+        return {
+          ok: false,
+          reason:
+            `sealed v2 credential for "${input.networkId}" was minted for subject "${env.leaf_user}", ` +
+            `not this member (expected one of: ${expected.join(", ")}) — refusing to install it (R7)`,
+        };
+      }
+      return {
+        ok: true,
+        kind: "creds",
+        creds: env.creds,
+        leafUser: env.leaf_user,
+        mintedAt: env.minted_at,
+        ...(env.payload_key !== undefined && { payloadKey: env.payload_key }),
+        ...(env.payload_key_kid !== undefined && { payloadKeyKid: env.payload_key_kid }),
+      };
+    }
     return {
       ok: true,
+      kind: "psk",
       leafPsk: env.leaf_psk,
       leafUser: env.leaf_user,
       ...(env.payload_key !== undefined && { payloadKey: env.payload_key }),

--- a/src/common/registry/fetch-sealed-secret.ts
+++ b/src/common/registry/fetch-sealed-secret.ts
@@ -143,8 +143,7 @@ export async function fetchSealedLeafSecret(
         creds: env.creds,
         leafUser: env.leaf_user,
         mintedAt: env.minted_at,
-        ...(env.payload_key !== undefined && { payloadKey: env.payload_key }),
-        ...(env.payload_key_kid !== undefined && { payloadKeyKid: env.payload_key_kid }),
+        ...payloadKeyFields(env),
       };
     }
     return {
@@ -152,13 +151,23 @@ export async function fetchSealedLeafSecret(
       kind: "psk",
       leafPsk: env.leaf_psk,
       leafUser: env.leaf_user,
-      ...(env.payload_key !== undefined && { payloadKey: env.payload_key }),
-      ...(env.payload_key_kid !== undefined && { payloadKeyKid: env.payload_key_kid }),
+      ...payloadKeyFields(env),
     };
   } catch (err) {
     // Generic — never echo seed/ciphertext/plaintext.
     return { ok: false, reason: `failed to open sealed leaf secret: ${errText(err)}` };
   }
+}
+
+/** The optional ADR-0019 payload-key rider, in result-field casing (one site). */
+function payloadKeyFields(env: {
+  payload_key?: string;
+  payload_key_kid?: string;
+}): { payloadKey?: string; payloadKeyKid?: string } {
+  return {
+    ...(env.payload_key !== undefined && { payloadKey: env.payload_key }),
+    ...(env.payload_key_kid !== undefined && { payloadKeyKid: env.payload_key_kid }),
+  };
 }
 
 /** Error → message, never echoing secret-bearing inputs. */


### PR DESCRIPTION
Closes #1597. See the commit message for full detail. Out of scope: end-to-end guided-join green against a real hub needs the admit-side mint (#1598) — nothing seals a v2 payload yet; the self-test harness picks that up when #1598 lands.