### PR TITLE
feat(mc): hub vitals strip — surface system.transport.server-vitals (CPU/mem/connections) in the Observability tab

### DIFF
--- a/src/surface/mc/__tests__/__fixtures__/signal-transport-envelopes.ts
+++ b/src/surface/mc/__tests__/__fixtures__/signal-transport-envelopes.ts
@@ -59,12 +59,25 @@ export const TRANSPORT_TYPES = {
 
 export type TransportType = (typeof TRANSPORT_TYPES)[keyof typeof TRANSPORT_TYPES];
 
+/**
+ * The hub SERVER-vitals body `type` (signal#154) — hyphen-mapped like the four
+ * families above, but a DISTINCT category: not a per-peer/leaf observation but
+ * the hub's own `/varz` resource vitals (cortex#1469). Kept out of
+ * {@link TRANSPORT_TYPES} because that constant is asserted to be exactly the
+ * four leaf/roster families the Network-view overlay folds; the vitals strip
+ * folds this one instead. Subject stays underscored (`...server_vitals`); the
+ * envelope body `type` is the hyphen form — the only spelling the myelin schema
+ * (and this fixture) accepts.
+ */
+export const SERVER_VITALS_TYPE = "system.transport.server-vitals" as const;
+
 /** The subject-leaf action (underscores) that pairs with each hyphen `type`. */
 const ACTION_FOR_TYPE: Record<string, string> = {
   [TRANSPORT_TYPES.leafConnect]: "leaf_connect",
   [TRANSPORT_TYPES.leafDisconnect]: "leaf_disconnect",
   [TRANSPORT_TYPES.livenessDrift]: "liveness_drift",
   [TRANSPORT_TYPES.rosterSnapshot]: "roster_snapshot",
+  [SERVER_VITALS_TYPE]: "server_vitals",
 };
 
 /**
@@ -189,3 +202,69 @@ export const TRANSPORT_FAMILY_FIXTURES: readonly TransportFamilyFixture[] = [
     peer: { principal: "jc", stack: "default" },
   },
 ] as const;
+
+// ---------------------------------------------------------------------------
+// Hub SERVER-vitals (signal#154 / cortex#1469) — a distinct transport body:
+// the hub's own `/varz` resource vitals, not a per-leaf observation. Reproduced
+// field-for-field from the pinned oracle
+// (signal canonical-envelope-schema.test.ts "server_vitals" case, signal @
+// 81eebaa) so the vitals strip folds the SAME shape production emits.
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical `ServerVitals` body — verbatim from the signal oracle. Field
+ * names are signal's `ServerVitals` interface
+ * (`src/lib/transport-observability/leafz-parser.ts`); numeric fields are
+ * concrete, string fields are non-null here (the strip tolerates null strings
+ * and a missing `vitals` separately — exercised in the fold unit tests).
+ */
+export const CANONICAL_SERVER_VITALS = {
+  server_id: "ND5XYZHUBSERVER000000000000000000000000000000000000",
+  server_name: "metafactory-hub",
+  version: "2.10.18",
+  uptime: "3d4h5m6s",
+  connections: 5,
+  leafnodes: 2,
+  routes: 0,
+  subscriptions: 87,
+  slow_consumers: 1,
+  mem: 134217728,
+  cpu: 12.5,
+  frames: { in_msgs: 100, out_msgs: 200, in_bytes: 300, out_bytes: 400 },
+} as const;
+
+/**
+ * A canonical, schema-valid `system.transport.server-vitals` envelope carrying
+ * {@link CANONICAL_SERVER_VITALS}. Built through {@link makeTransportEnvelope}
+ * (same builder as the four families) so it clears cortex's vendored myelin
+ * schema via `validateEnvelope` — the vitals-strip tests assert validity BEFORE
+ * folding, closing the same anti-drift hole cortex#1467 named.
+ */
+export const SERVER_VITALS_FIXTURE = {
+  type: SERVER_VITALS_TYPE,
+  network: "metafactory-community",
+  vitals: CANONICAL_SERVER_VITALS,
+  envelope: makeTransportEnvelope(SERVER_VITALS_TYPE, {
+    payload: { network: "metafactory-community", vitals: CANONICAL_SERVER_VITALS },
+  }),
+} as const;
+
+/**
+ * Build a `system.transport.server-vitals` envelope for `network`, optionally
+ * overriding individual `vitals` fields (e.g. a null string or a different
+ * `cpu`). Used by the fold tests to seed newest-per-network + tolerance cases
+ * without hand-writing envelope scaffolding.
+ */
+export function makeServerVitalsEnvelope(
+  network: string,
+  vitalsOverrides: Record<string, unknown> = {},
+  opts: { id?: string } = {},
+): Envelope {
+  return makeTransportEnvelope(SERVER_VITALS_TYPE, {
+    id: opts.id,
+    payload: {
+      network,
+      vitals: { ...CANONICAL_SERVER_VITALS, ...vitalsOverrides },
+    },
+  });
+}

--- a/src/surface/mc/dashboard-v2/__tests__/hub-vitals-strip.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/hub-vitals-strip.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * cortex#1469 — hub-vitals STRIP render (SSR).
+ *
+ * SSR-renders the whole Observability tab through `renderToStaticMarkup` so the
+ * strip is exercised WIRED IN (not in isolation), against a response built by
+ * the REAL API assembler `getObservability` from a DB seeded with the canonical
+ * server-vitals fixture. Pins:
+ *   - REAL vitals numbers render (CPU %, humanized mem, connections, leafnodes,
+ *     slow-consumers) with tabular numerals — from a fixture that passed
+ *     `validateEnvelope` before projection;
+ *   - the zero-row state renders the EXACT honest empty-state copy (signal#118),
+ *     and no vitals table — never synthesized numbers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+
+import { validateEnvelope } from "../../../../bus/myelin/envelope-validator";
+import { projectObservability } from "../../projection/observability-renderer";
+import { getObservability } from "../../api/observability-tab";
+import { SCHEMA_SQL } from "../../db/schema";
+import { ObservabilityView } from "../components/observability-view";
+import { HUB_VITALS_EMPTY_NOTE } from "../components/observability-view";
+import type { ObservabilityState } from "../hooks/use-observability";
+import {
+  SERVER_VITALS_FIXTURE,
+  TRANSPORT_FAMILY_FIXTURES,
+} from "../../__tests__/__fixtures__/signal-transport-envelopes";
+
+const LEAF_CONNECT_FIXTURE = TRANSPORT_FAMILY_FIXTURES.find(
+  (f) => f.family === "leaf-connect",
+)!;
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+function renderTab(db: Database): string {
+  const state: ObservabilityState = {
+    data: getObservability(db),
+    loaded: true,
+    error: null,
+  };
+  return renderToStaticMarkup(createElement(ObservabilityView, { state }));
+}
+
+describe("HubVitalsStrip — render", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("renders CPU/mem/connections/leafnodes/slow-consumers + age from a validated canonical row", () => {
+    // Validity BEFORE folding/rendering (acceptance criterion).
+    expect(validateEnvelope(SERVER_VITALS_FIXTURE.envelope).ok).toBe(true);
+    projectObservability(db, SERVER_VITALS_FIXTURE.envelope, undefined);
+
+    const html = renderTab(db);
+
+    expect(html).toContain("Hub vitals");
+    expect(html).toContain("metafactory-community"); // network name
+    expect(html).toContain("12.5%"); // cpu
+    expect(html).toContain("128.0 MB"); // mem, humanized
+    expect(html).toContain("tnum"); // tabular numerals on the numeric cells
+    // connections/leafnodes/slow-consumers land in tnum cells.
+    expect(html).toContain("hub-vitals-strip");
+    // The honest empty copy must NOT appear when a row exists.
+    expect(html).not.toContain(HUB_VITALS_EMPTY_NOTE);
+  });
+
+  it("renders the EXACT honest empty-state copy on zero server-vitals rows", () => {
+    const html = renderTab(db); // empty DB → no transport rows at all.
+    expect(html).toContain(HUB_VITALS_EMPTY_NOTE);
+    expect(html).not.toContain("hub-vitals-strip"); // no table, no synthetic numbers.
+  });
+
+  it("ignores a non-vitals transport row — strip stays in the empty state", () => {
+    // A leaf-connect row lands in the transport family + roster, but is not a
+    // vitals row, so the strip must not render it (and must show the empty copy).
+    expect(validateEnvelope(LEAF_CONNECT_FIXTURE.envelope).ok).toBe(true);
+    projectObservability(db, LEAF_CONNECT_FIXTURE.envelope, undefined);
+
+    const html = renderTab(db);
+    expect(html).toContain(HUB_VITALS_EMPTY_NOTE);
+    expect(html).not.toContain("hub-vitals-strip");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/hub-vitals.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/hub-vitals.test.ts
@@ -1,0 +1,230 @@
+/**
+ * cortex#1469 — hub-vitals fold + helpers.
+ *
+ * Two layers:
+ *   1. FULL PATH — the canonical server-vitals fixture (provenance-pinned from
+ *      signal's builder, cortex#1467) is asserted valid via `validateEnvelope`
+ *      BEFORE folding, projected through the REAL observability projection into
+ *      an in-memory DB, read back via `listTransportRosterEvents` (the exact
+ *      read `transportRoster` uses), and folded — so the row shape the fold sees
+ *      is production's, not a hand-built stub.
+ *   2. UNIT — the pure fold's tolerance rules (newest-per-network wins, non-
+ *      vitals transport rows ignored, malformed/`{}` payloads skipped, empty →
+ *      empty) + the byte/scrape-age formatters.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { validateEnvelope } from "../../../../bus/myelin/envelope-validator";
+import { projectObservability } from "../../projection/observability-renderer";
+import { listTransportRosterEvents } from "../../db/observability";
+import { SCHEMA_SQL } from "../../db/schema";
+import type { TransportRosterEventRow } from "../../api/observability-tab";
+import {
+  SERVER_VITALS_FIXTURE,
+  CANONICAL_SERVER_VITALS,
+  makeServerVitalsEnvelope,
+  toUnderscoreType,
+  TRANSPORT_TYPES,
+} from "../../__tests__/__fixtures__/signal-transport-envelopes";
+import {
+  foldHubVitals,
+  humanizeBytes,
+  formatScrapeAge,
+  scrapeAge,
+  HUB_VITALS_TYPE,
+} from "../lib/hub-vitals";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+/** Build a production-shaped transport-roster row without the DB round-trip. */
+function row(
+  over: Partial<TransportRosterEventRow> & { type: string; payload: Record<string, unknown> },
+): TransportRosterEventRow {
+  return {
+    id: crypto.randomUUID(),
+    stackId: null,
+    origin: "local",
+    timestamp: "2026-06-12T00:00:00.000Z",
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. FULL PATH — validate → project → read → fold (AC: assert validity first).
+// ---------------------------------------------------------------------------
+
+describe("hub vitals — canonical fixture through the real projection", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("the canonical server-vitals envelope PASSES validateEnvelope", () => {
+    const result = validateEnvelope(SERVER_VITALS_FIXTURE.envelope);
+    if (!result.ok) {
+      throw new Error(
+        `validateEnvelope rejected the canonical server-vitals fixture: ${JSON.stringify(result.errors)}`,
+      );
+    }
+    expect(result.ok).toBe(true);
+  });
+
+  it("projects into transport family and folds to the seeded vitals numbers", () => {
+    // Validity asserted BEFORE folding, per the acceptance criterion.
+    expect(validateEnvelope(SERVER_VITALS_FIXTURE.envelope).ok).toBe(true);
+
+    const family = projectObservability(db, SERVER_VITALS_FIXTURE.envelope, undefined);
+    expect(family).toBe("transport");
+
+    const rows = listTransportRosterEvents(db, 200);
+    const vitals = foldHubVitals(rows);
+
+    expect(vitals).toHaveLength(1);
+    const v = vitals[0]!;
+    expect(v.network).toBe("metafactory-community");
+    expect(v.serverName).toBe("metafactory-hub");
+    expect(v.cpu).toBe(CANONICAL_SERVER_VITALS.cpu); // 12.5
+    expect(v.mem).toBe(CANONICAL_SERVER_VITALS.mem); // 134217728
+    expect(v.connections).toBe(5);
+    expect(v.leafnodes).toBe(2);
+    expect(v.slowConsumers).toBe(1);
+    expect(humanizeBytes(v.mem)).toBe("128.0 MB");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. UNIT — the pure fold's tolerance rules.
+// ---------------------------------------------------------------------------
+
+describe("foldHubVitals — tolerance + newest-per-network", () => {
+  it("empty input folds to empty output", () => {
+    expect(foldHubVitals([])).toEqual([]);
+  });
+
+  it("keeps the NEWEST row per network (rows arrive newest-first)", () => {
+    const newer = row({
+      type: HUB_VITALS_TYPE,
+      timestamp: "2026-06-12T00:10:00.000Z",
+      payload: { network: "alpha", vitals: { ...CANONICAL_SERVER_VITALS, cpu: 99.9 } },
+    });
+    const older = row({
+      type: HUB_VITALS_TYPE,
+      timestamp: "2026-06-12T00:00:00.000Z",
+      payload: { network: "alpha", vitals: { ...CANONICAL_SERVER_VITALS, cpu: 1.1 } },
+    });
+    // newest-first order (DB ORDER BY timestamp DESC).
+    const vitals = foldHubVitals([newer, older]);
+    expect(vitals).toHaveLength(1);
+    expect(vitals[0]!.cpu).toBe(99.9);
+  });
+
+  it("folds one entry per distinct network, sorted by network name", () => {
+    const vitals = foldHubVitals([
+      row({ type: HUB_VITALS_TYPE, payload: { network: "beta", vitals: CANONICAL_SERVER_VITALS } }),
+      row({ type: HUB_VITALS_TYPE, payload: { network: "alpha", vitals: CANONICAL_SERVER_VITALS } }),
+    ]);
+    expect(vitals.map((v) => v.network)).toEqual(["alpha", "beta"]);
+  });
+
+  it("ignores non-vitals transport rows (e.g. leaf-connect)", () => {
+    const vitals = foldHubVitals([
+      row({
+        type: TRANSPORT_TYPES.leafConnect,
+        payload: { network: "alpha", leaf: { principal: "jc", stack: "default" } },
+      }),
+    ]);
+    expect(vitals).toEqual([]);
+  });
+
+  it("skips a row with a missing/non-object vitals body", () => {
+    const vitals = foldHubVitals([
+      row({ type: HUB_VITALS_TYPE, payload: { network: "alpha" } }), // no vitals
+      row({ type: HUB_VITALS_TYPE, payload: { network: "beta", vitals: {} as unknown } }),
+    ]);
+    // `{}` vitals is an object → folds (numbers default to 0); missing vitals → skipped.
+    expect(vitals.map((v) => v.network)).toEqual(["beta"]);
+    expect(vitals[0]!.cpu).toBe(0);
+    expect(vitals[0]!.serverName).toBeNull();
+  });
+
+  it("skips a row with no readable network", () => {
+    const vitals = foldHubVitals([
+      row({ type: HUB_VITALS_TYPE, payload: { vitals: CANONICAL_SERVER_VITALS } }), // no network
+    ]);
+    expect(vitals).toEqual([]);
+  });
+
+  it("tolerates null string fields (carries them as null)", () => {
+    const env = makeServerVitalsEnvelope("gamma", { server_name: null, version: null, uptime: null });
+    const payload = (env as unknown as { payload: Record<string, unknown> }).payload;
+    const vitals = foldHubVitals([row({ type: HUB_VITALS_TYPE, payload })]);
+    expect(vitals).toHaveLength(1);
+    expect(vitals[0]!.serverName).toBeNull();
+    expect(vitals[0]!.uptime).toBeNull();
+    // numeric fields still fold.
+    expect(vitals[0]!.connections).toBe(5);
+  });
+
+  it("matches ONLY the hyphen type — the underscore spelling never folds", () => {
+    // The underscore body a real envelope can never carry (subject-only spelling).
+    // Build it via toUnderscoreType so the impossible literal never appears as a
+    // type string in this tree (cortex#1469 PROHIBITION + AC underscore grep).
+    const vitals = foldHubVitals([
+      row({
+        type: toUnderscoreType(HUB_VITALS_TYPE),
+        payload: { network: "alpha", vitals: CANONICAL_SERVER_VITALS },
+      }),
+    ]);
+    expect(vitals).toEqual([]);
+  });
+});
+
+describe("humanizeBytes", () => {
+  it("formats across unit boundaries", () => {
+    expect(humanizeBytes(512)).toBe("512 B");
+    expect(humanizeBytes(1536)).toBe("1.5 KB");
+    expect(humanizeBytes(134217728)).toBe("128.0 MB");
+    expect(humanizeBytes(2 * 1024 * 1024 * 1024)).toBe("2.0 GB");
+  });
+  it("degrades a negative/NaN byte count to an em dash", () => {
+    expect(humanizeBytes(-1)).toBe("—");
+    expect(humanizeBytes(Number.NaN)).toBe("—");
+  });
+});
+
+describe("formatScrapeAge / scrapeAge", () => {
+  it("formats seconds, minutes, hours, days", () => {
+    expect(formatScrapeAge(5_000)).toBe("5s ago");
+    expect(formatScrapeAge(90_000)).toBe("1m ago");
+    expect(formatScrapeAge(2 * 3600_000)).toBe("2h ago");
+    expect(formatScrapeAge(3 * 86_400_000)).toBe("3d ago");
+  });
+  it("degrades a negative/NaN age to 'just now'", () => {
+    expect(formatScrapeAge(-1)).toBe("just now");
+    expect(formatScrapeAge(Number.NaN)).toBe("just now");
+  });
+  it("scrapeAge derives the delta from the row timestamp and now", () => {
+    const v = foldHubVitals([
+      row({
+        type: HUB_VITALS_TYPE,
+        timestamp: "2026-06-12T00:00:00.000Z",
+        payload: { network: "alpha", vitals: CANONICAL_SERVER_VITALS },
+      }),
+    ])[0]!;
+    const now = Date.parse("2026-06-12T00:00:30.000Z");
+    expect(scrapeAge(v, now)).toBe("30s ago");
+  });
+  it("degrades an unparseable timestamp to 'just now'", () => {
+    const v = foldHubVitals([
+      row({ type: HUB_VITALS_TYPE, timestamp: "not-a-date", payload: { network: "alpha", vitals: CANONICAL_SERVER_VITALS } }),
+    ])[0]!;
+    expect(scrapeAge(v, Date.parse("2026-06-12T00:00:30.000Z"))).toBe("just now");
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/observability-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/observability-view.tsx
@@ -21,6 +21,8 @@ import type { ObservabilityState } from "../hooks/use-observability";
 import type { ObsMetricsState } from "../hooks/use-obs-metrics";
 import { ObsMetricsPanels } from "./obs-metrics-panels";
 import type { ObservabilityEventRow } from "../../db/observability";
+import type { TransportRosterEventRow } from "../../api/observability-tab";
+import { foldHubVitals, humanizeBytes, scrapeAge } from "../lib/hub-vitals";
 
 function when(ts: string): string {
   // ISO-8601 (or SQLite 'YYYY-MM-DD HH:MM:SS') → compact 'YYYY-MM-DD HH:MM'.
@@ -68,6 +70,69 @@ function Section({ title, rows, count, emptyNote }: SectionProps) {
         {count > 0 ? <span className="dim">({count})</span> : null}
       </h3>
       {rows.length === 0 ? <p className="dim">{emptyNote}</p> : <EventTable rows={rows} />}
+    </div>
+  );
+}
+
+/**
+ * The exact honest empty-state copy for the hub-vitals strip (cortex#1469).
+ * Named signal#118 (hub provisioning) so the absence points at the real cause —
+ * the transport collector isn't running against the hub yet — not a cortex bug.
+ * Exported so the test can assert it verbatim without re-typing the string.
+ */
+export const HUB_VITALS_EMPTY_NOTE =
+  "no hub vitals — transport collector not running (signal#118)";
+
+/**
+ * cortex#1469 — the compact hub VITALS strip. Folds signal's
+ * `system.transport.server-vitals` rows (payload-bearing on `transportRoster`)
+ * into the latest vitals PER NETWORK and renders CPU / mem / connections /
+ * leafnodes / slow-consumers + scrape age. A strip, not a panel: no charts, no
+ * history, no synthesized numbers. Zero vitals rows → the honest empty state.
+ *
+ * Numbers use tabular numerals (`.tnum`) so columns align across rows.
+ */
+function HubVitalsStrip({ rows }: { rows: readonly TransportRosterEventRow[] }) {
+  const vitals = foldHubVitals(rows);
+  const now = Date.now();
+  return (
+    <div className="observability-section">
+      <h3>
+        Hub vitals{" "}
+        {vitals.length > 0 ? <span className="dim">({vitals.length})</span> : null}
+      </h3>
+      {vitals.length === 0 ? (
+        <p className="dim">{HUB_VITALS_EMPTY_NOTE}</p>
+      ) : (
+        <table className="observability-events hub-vitals-strip">
+          <thead>
+            <tr>
+              <th>Network</th>
+              <th>CPU</th>
+              <th>Mem</th>
+              <th>Conns</th>
+              <th>Leafs</th>
+              <th>Slow</th>
+              <th>Scraped</th>
+            </tr>
+          </thead>
+          <tbody>
+            {vitals.map((v) => (
+              <tr key={v.network}>
+                <td className="mono" title={v.serverName ?? undefined}>
+                  {v.network}
+                </td>
+                <td className="mono tnum">{v.cpu.toFixed(1)}%</td>
+                <td className="mono tnum">{humanizeBytes(v.mem)}</td>
+                <td className="mono tnum">{v.connections}</td>
+                <td className="mono tnum">{v.leafnodes}</td>
+                <td className="mono tnum">{v.slowConsumers}</td>
+                <td className="mono dim tnum">{scrapeAge(v, now)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }
@@ -137,6 +202,8 @@ export function ObservabilityView({ state, metrics }: ObservabilityViewProps) {
         count={data.counts.federation}
         emptyNote="No federation events. These are hub-emitted — a non-hub stack does not see federation envelopes until it joins a network and a roster arrives (U3.3). This empty state is expected on a leaf, not a fault."
       />
+
+      <HubVitalsStrip rows={data.transportRoster} />
 
       <Section
         title="Transport"

--- a/src/surface/mc/dashboard-v2/lib/hub-vitals.ts
+++ b/src/surface/mc/dashboard-v2/lib/hub-vitals.ts
@@ -1,0 +1,158 @@
+/**
+ * cortex#1469 — Hub VITALS fold (pure).
+ *
+ * signal#154/#157 taught signal's transport collector to scrape the NATS hub's
+ * `/varz` monitor endpoint and publish hub SERVER vitals — CPU, memory, client
+ * connections, leafnode count, slow consumers — as
+ * `system.transport.server-vitals` envelopes on every successful scrape tick.
+ * Cortex's Mission Control already files the whole `system.transport.*` family
+ * into `observability_events` (prefix routing,
+ * `projection/observability-renderer.ts`), so these rows land in the DB today —
+ * and reach the browser payload-bearing on `transportRoster`
+ * (`api/observability-tab.ts`). Nothing read them until this fold.
+ *
+ * ## SOURCED FROM SIGNAL — never re-derived (CONTEXT.md §Sourced-from-signal)
+ *
+ * cortex does not compute hub health. Every field here is taken VERBATIM from
+ * the `payload.vitals` body signal stamped from `/varz` (field names are
+ * signal's `ServerVitals`, `src/lib/transport-observability/leafz-parser.ts`).
+ * We only pick the NEWEST row per network and carry the numbers through.
+ *
+ * ## Wire-type spelling (the one that exists)
+ *
+ * The matched row `type` is the HYPHEN form `system.transport.server-vitals`.
+ * signal maps subject-tail `_`→`-` in `envelope.type`, and cortex's vendored
+ * myelin schema forbids `_` types — so `system.transport.server_vitals`
+ * (underscore) is a SUBJECT string that NEVER appears as a body/row `type`.
+ * Matching the underscore spelling would match nothing (cortex#1467/#1469).
+ *
+ * Pure + DOM-free → unit-testable against the canonical server-vitals fixture.
+ */
+
+import type { TransportRosterEventRow } from "../../api/observability-tab";
+
+/**
+ * The hub-vitals row `type` — HYPHEN form, the only spelling on the wire. THE
+ * single source of truth for the matcher spelling; import it rather than
+ * hard-coding a string a future edit could drift to the underscore (impossible)
+ * form.
+ */
+export const HUB_VITALS_TYPE = "system.transport.server-vitals" as const;
+
+/** One network's latest hub vitals, folded from the newest server-vitals row. */
+export interface HubVitals {
+  /** The network this hub serves (from the envelope `payload.network`). */
+  network: string;
+  /** NATS `server_name`, or null when signal reported it absent. */
+  serverName: string | null;
+  /** NATS server version string, or null. */
+  version: string | null;
+  /** Server uptime as signal's raw NATS string (e.g. "3d4h5m6s"), or null. */
+  uptime: string | null;
+  /** Current client connections. */
+  connections: number;
+  /** Current leaf-node connections (roster size from the server's view). */
+  leafnodes: number;
+  /** Slow-consumer count — the headline back-pressure signal. */
+  slowConsumers: number;
+  /** Resident memory in bytes. */
+  mem: number;
+  /** CPU usage percent as NATS reports it (0–100·cores). */
+  cpu: number;
+  /** The scrape row's timestamp (ISO-8601) — the basis for scrape age. */
+  timestamp: string;
+}
+
+function asStringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Fold transport-roster rows into the latest hub vitals PER NETWORK.
+ *
+ * - Keeps only rows whose `type` is {@link HUB_VITALS_TYPE} (hyphen form) — a
+ *   non-vitals transport row (e.g. `system.transport.leaf-connect`) is ignored.
+ * - Rows arrive newest-first (the DB read's `ORDER BY timestamp DESC`); the
+ *   fold keeps the FIRST seen per `payload.network`, so the newest scrape wins
+ *   without any clock comparison.
+ * - Skips a row with no readable `payload.network` string or a missing/
+ *   non-object `payload.vitals` (a malformed or `{}` body degrades to skipped,
+ *   never a throw). Null string fields are tolerated and carried as null.
+ *
+ * Result is sorted by network name for a stable strip render.
+ */
+export function foldHubVitals(
+  rows: readonly TransportRosterEventRow[],
+): HubVitals[] {
+  const byNetwork = new Map<string, HubVitals>();
+
+  for (const row of rows) {
+    if (row.type !== HUB_VITALS_TYPE) continue;
+
+    const network = asStringOrNull(row.payload.network);
+    if (network === null) continue;
+    if (byNetwork.has(network)) continue; // newest-first: first seen wins.
+
+    const vitals = row.payload.vitals;
+    if (!isRecord(vitals)) continue;
+
+    byNetwork.set(network, {
+      network,
+      serverName: asStringOrNull(vitals.server_name),
+      version: asStringOrNull(vitals.version),
+      uptime: asStringOrNull(vitals.uptime),
+      connections: asNumber(vitals.connections),
+      leafnodes: asNumber(vitals.leafnodes),
+      slowConsumers: asNumber(vitals.slow_consumers),
+      mem: asNumber(vitals.mem),
+      cpu: asNumber(vitals.cpu),
+      timestamp: row.timestamp,
+    });
+  }
+
+  return [...byNetwork.values()].sort((a, b) =>
+    a.network < b.network ? -1 : a.network > b.network ? 1 : 0,
+  );
+}
+
+/** Humanize a byte count to a compact `B`/`KB`/`MB`/`GB` string (base-1024). */
+export function humanizeBytes(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+/**
+ * Format a scrape age (ms between the row timestamp and now) as a compact
+ * "Xs ago" / "Xm ago" / "Xh ago" / "Xd ago". Negative/NaN → "just now".
+ */
+export function formatScrapeAge(ageMs: number): string {
+  if (!Number.isFinite(ageMs) || ageMs < 0) return "just now";
+  const s = Math.floor(ageMs / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+/**
+ * Scrape age for a vitals row given the current epoch-ms. Parses the row
+ * timestamp; an unparseable timestamp degrades to "just now" rather than NaN.
+ */
+export function scrapeAge(vitals: HubVitals, nowMs: number): string {
+  const then = Date.parse(vitals.timestamp);
+  if (Number.isNaN(then)) return "just now";
+  return formatScrapeAge(nowMs - then);
+}


### PR DESCRIPTION
## Summary

signal#154/#157 taught signal's transport collector to scrape the NATS hub's `/varz` endpoint and publish hub server vitals (CPU, memory, client connections, leafnodes, slow-consumers) as `system.transport.server-vitals` envelopes. Cortex already files the whole `system.transport.*` family into `observability_events` and ships those rows to the browser payload-bearing on `transportRoster` — but nothing read the vitals. This PR adds a compact read-only **hub-vitals strip** so the principal can see hub CPU/mem/connections and how stale the last scrape is.

**No new API endpoint** (rows already reach the client via `transportRoster` on `GET /api/observability-events`). **No signal changes.** A strip, not a panel — no charts, no history, no synthesized numbers.

### Placement choice (implementer's pick)
**Observability tab → Transport section** (`observability-view.tsx`), rendered above the existing `Section title="Transport"`.

Rationale — the *cheaper* placement: `data.transportRoster` is already in scope in `ObservabilityView` (the strip just folds it), so the strip needed **zero new plumbing**. The constellation-header alternative would have required threading `transportRoster` down through `network-view.tsx` → `constellation-header.tsx` (new props on two components) for no functional gain. Same projection surface, least surface area.

### Files
- **`dashboard-v2/lib/hub-vitals.ts`** (new) — pure fold `TransportRosterEventRow[]` → latest vitals **per network**: matches the **hyphen** type `system.transport.server-vitals` only, keeps the newest row per `payload.network` (rows arrive newest-first), reads `payload.vitals` by signal's exact `ServerVitals` field names, tolerates null string fields + missing/`{}` vitals (skips). Plus `humanizeBytes` and scrape-age formatters.
- **`dashboard-v2/components/observability-view.tsx`** — `HubVitalsStrip` + exact empty-state copy; tabular numerals (`.tnum`).
- **`__tests__/__fixtures__/signal-transport-envelopes.ts`** — **reuses cortex#1467's validator-routed fixture mechanism**; adds the canonical `server-vitals` body + builder (`SERVER_VITALS_FIXTURE`, `makeServerVitalsEnvelope`), provenance-pinned to signal `main` @ `81eebaa` (oracle: `canonical-envelope-schema.test.ts` server_vitals case). `TRANSPORT_TYPES` (the four leaf/roster families) left untouched — vitals is a distinct category.
- **`dashboard-v2/__tests__/hub-vitals.test.ts`** (new) — fold tolerance + formatters + full path: `validateEnvelope` → real `projectObservability` → `listTransportRosterEvents` → fold.
- **`dashboard-v2/__tests__/hub-vitals-strip.test.tsx`** (new) — SSR-renders the whole tab from a `getObservability` response; asserts real numbers render and the exact empty copy on zero rows.

### Acceptance criteria
- ✅ `git grep "system.transport.server-vitals" -- src/surface/mc` → non-test matcher present (`hub-vitals.ts:40` `HUB_VITALS_TYPE`); underscore spelling has **zero type-matcher hits** (only a `hub-vitals.ts` comment explaining why it's never matched).
- ✅ Strip renders CPU/mem/connections/leafnodes/slow-consumers + scrape age from a seeded canonical row that **passed `validateEnvelope`** (asserted before folding).
- ✅ Zero-row state renders exactly: `no hub vitals — transport collector not running (signal#118)`.
- ✅ Non-vitals transport rows (e.g. `system.transport.leaf-connect`) do not appear in the strip (unit + SSR tests).
- ✅ PROHIBITION honored: no underscore `type` matcher; no new API endpoint; signal untouched.

### Gate outputs (verbatim)
```
GATE 1 — bun test src/surface/mc/
 2195 pass
 1 skip
 0 fail
Ran 2196 tests across 157 files.

GATE 2 — bunx tsc --noEmit
tsc exit=0

GATE 3 — bun run lint:errors  ($ eslint --quiet .)
lint exit=0

GATE 4 — bash scripts/check-carveouts.sh
check-carveouts: PASS — no ungated deprecated-term live violations
carveout exit=0
```

Draft — depends on cortex#1467 (validator-routed fixture mechanism), which is merged. Not marking ready per lane discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)