### PR TITLE
fix(lint): drop 2 unnecessary type assertions in network.ts (restore green Lint gate)

### DIFF
--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2235,8 +2235,8 @@ async function runCreate(
   if (resolverModeRaw !== undefined && hubModeRaw !== "operator") {
     return usageError("create", `--resolver-mode requires --hub-mode operator`, json);
   }
-  const hubMode = hubModeRaw as "operator" | "simple" | undefined;
-  const resolverMode = resolverModeRaw as "nats" | "memory" | undefined;
+  const hubMode = hubModeRaw;
+  const resolverMode = resolverModeRaw;
 
   // Load the admin nkey seed + derive its base64 pubkey (the SAME key shape +
   // signing path provision-stack uses), then build the signed claim.


### PR DESCRIPTION
Main was **red on the blocking Lint gate** — `network.ts:2238-2239` `as` assertions flagged by `@typescript-eslint/no-unnecessary-type-assertion` (the guards immediately above already narrow `hubModeRaw`/`resolverModeRaw` to the asserted unions). Introduced by #1610 (C-1598).

`eslint --fix`; diff is only the 2 assertions removed; `bun run lint:errors` clean, `tsc --noEmit` 0 errors. Unblocks all in-flight PRs (surfaced by the FND-4 docs PR #1616).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c