### PR TITLE
fix(lint): drop unnecessary type assertion in network-secret-adapters.ts (restore green)

### DIFF
--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -640,7 +640,7 @@ export function buildScopedUserMintAdapter(
   const pickRun = () => runner ?? scopedMintRunnerOverride ?? defaultArcScopedMintRunner;
   /** Read a string field from arc's OK envelope, or "" if absent. */
   const field = (env: ArcFederatedUserOk, key: keyof ArcFederatedUserOk): string =>
-    typeof env[key] === "string" ? (env[key] as string) : "";
+    typeof env[key] === "string" ? (env[key]) : "";
   /** The first REQUIRED field missing / empty on an ok:true envelope, or null.
    *  An `ok:true` envelope that omits a guaranteed field is a contract breach —
    *  fail typed rather than seal a v2 envelope with empty fingerprint data. */


### PR DESCRIPTION
main red on the blocking Lint gate — `network-secret-adapters.ts:643` `as string` (guard already narrows it), from #1619 (C-1599). eslint --fix; tsc 0. Unblocks the in-flight R1 fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c