### PR TITLE
docs: fix README-AGENTS.md install path — `arc install <url>` first, `arc upgrade` for updates (#1630)

### DIFF
--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -52,13 +52,29 @@ NATS, and the config `.conf` are identical); only the **service manager** differ
 
 **Path A — arc-managed (preferred when `arc` is available):**
 
+**First-time install.** cortex is not published to the arc registry yet, so
+`arc install cortex` (by *name*) reports *"not found in any source"* — and
+`arc upgrade cortex` reports *"not installed"* (upgrade is the *update* command,
+not the first step). Install by **git URL** instead: the repo is public and
+ships an `arc-manifest.yaml`, so arc installs it directly.
+
 ```bash
-arc upgrade cortex
+arc install https://github.com/the-metafactory/cortex --pin vX.Y.Z
 ```
 
-This installs the released package and renders + loads the launchd agents
-(`ai.meta-factory.cortex.*`). Note: `arc upgrade` tracks **GitHub releases**,
-not `main`.
+Use the latest release tag for `vX.Y.Z` (see the repo's
+[releases](https://github.com/the-metafactory/cortex/releases)). This installs
+the released package and renders + loads the launchd agents
+(`ai.meta-factory.cortex.*`).
+
+**Updates.** Once installed, track new GitHub releases with `arc upgrade cortex`
+(it tracks **GitHub releases**, not `main`, and only works on an
+already-installed package).
+
+> If you see a `404 … metafactory-registry … REGISTRY.yaml` warning, that's a
+> stale default source ([arc#267](https://github.com/the-metafactory/arc/issues/267)),
+> not a cortex problem — silence it with `arc source remove metafactory-registry`.
+> The git-URL install above never touches the registry.
 
 **Ordering:** seed auto-provisioning reads `stack.nkey_seed_path` from the
 stack config — which doesn't exist until §3.1 scaffolds it. On a fresh machine:


### PR DESCRIPTION
## What

Rewrites `README-AGENTS.md` §2 **Path A** so a first-time user gets a command that actually works.

### Before
Path A led with `arc upgrade cortex` as the install step. On a fresh machine that fails — `arc upgrade` is the *update* command:
```
❯ arc upgrade cortex
"cortex" is not installed
```
And the by-name install a new user reaches for also fails, because cortex isn't published to the arc registry:
```
❯ arc install cortex
"cortex" not found in any source.
```

### After
- **First-time install** → `arc install https://github.com/the-metafactory/cortex --pin vX.Y.Z` (install by git URL; repo is public + ships `arc-manifest.yaml`).
- **Updates** → `arc upgrade cortex` (unchanged; correctly framed as update-only now).
- Adds a note that the `404 metafactory-registry` warning is a stale default source (arc#267) with the `arc source remove metafactory-registry` one-liner.

## Why it's correct
Verified on a live install: `arc info cortex` → `Source: direct, Repo: https://github.com/the-metafactory/cortex`. cortex is arc-managed by git URL, not by registry name. `arc install --help` confirms `<name-or-url>` + `--pin <tag>`.

## Scope
Docs only. The registry publish gap and the dead default source (arc#267) are out of scope — this just makes the documented path match reality.

Reported by an external tester in community #cortex.

Closes #1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)