### PR TITLE
feat(registry): FND-5 — per-network admin READ scoping for admission-requests (R1)

### DIFF
--- a/docs/adr/0020-per-network-admin-authority.md
+++ b/docs/adr/0020-per-network-admin-authority.md
@@ -1,6 +1,6 @@
 # ADR 0020 — Per-network admin authority in the registry schema
 
-**Status:** accepted (2026-06-29) · **Refines:** ADR-0015 (two-tier onboarding + admission gate) · **Descends:** ADR-0003 (network-join control plane), ADR-0013 (sovereign federation) · **Refs:** cortex#1321, #110, `docs/research-federation-decentralization.md`, CONTEXT.md §Network posture (admin vs member)
+**Status:** accepted (2026-06-29) · **Amended:** 2026-07-07 (FND-5 — admin read-scoping, see Amendment below) · **Refines:** ADR-0015 (two-tier onboarding + admission gate) · **Descends:** ADR-0003 (network-join control plane), ADR-0013 (sovereign federation) · **Refs:** cortex#1321, #110, `docs/research-federation-decentralization.md`, CONTEXT.md §Network posture (admin vs member)
 
 ## Context
 
@@ -40,8 +40,14 @@ Privilege model (anti-self-escalation):
    network OR global admin**. Authorization is keyed off the request's stored
    `network_id`, never off anything on the wire. A network-less request
    (`network_id` null) stays global-admin-only.
-4. **Admin READS** (list/get admission requests) → **global admin only** for now
-   (see Consequences — per-network read-scoping is a fast-follow).
+4. **Admin READS** (list/get admission requests) → **per-network admin for the
+   network they NAME in the signed read claim, OR global admin** (the FND-5
+   amendment below; at acceptance this was global-admin-only). Authorization is
+   keyed off the claimed `network_id` — bound INTO the signature — checked
+   against THAT network's `admin_pubkeys`: a per-network admin is authorised for,
+   and FORCED to, their own network's rows; a global admin sees all (and MAY
+   narrow to one network). Unsigned/unauthorized ⇒ 403. A network-less request
+   (`network_id` null) stays global-admin-only.
 
 `REGISTRY_ADMIN_PUBKEYS` is retained as the **bootstrap admin for `metafactory`**
 and the always-valid super-admin — backward compatible: a network with no
@@ -67,9 +73,10 @@ on the wire. The federation-wire-protocol SOP 5-check is unaffected.
   seed; the `cortex network create --network-admins` ergonomic flag is a
   fast-follow.
 - **Per-network admin read-scoping** (letting a per-network admin LIST their
-  network's pending requests) is a fast-follow — today they must be handed the
-  `request_id`. The architectural unlock (grant-by-per-network-admin) does not
-  depend on it.
+  network's pending requests) — DELIVERED by the FND-5 amendment below (it was a
+  fast-follow at acceptance time, when a per-network admin had to be handed the
+  `request_id` out-of-band). The grant-by-per-network-admin unlock never depended
+  on it.
 
 ## Alternatives considered
 
@@ -83,3 +90,46 @@ on the wire. The federation-wire-protocol SOP 5-check is unaffected.
   research's longer-term direction (#1322 follow-on). Heavier; deferred. The
   comma-separated-pubkeys column mirrors the existing grammar with zero new
   primitives.
+
+## Amendment — FND-5: per-network admin read-scoping (2026-07-07)
+
+**Refs:** FND-5 (`docs/plan-mc-future-state.md` §4.0), unblocks FLG-5 (MC pier
+request-id). **Descends:** this ADR §Decision point 4 (Admin READS).
+
+At acceptance, decision point 4 kept **admin READS** (`GET /admission-requests`
+list + single-row GET) **global-admin-only**, with per-network read-scoping named
+as a fast-follow. That gap hard-blocked a per-network admin's daemon from
+fetching its OWN network's pending `request_id`s (it had to be handed them
+out-of-band), which in turn blocked the MC pier request-id feature (FLG-5).
+
+**Change.** The read gate now resolves the signed reader to a **read scope**,
+mirroring the admission-GRANT authority already shipped for admit/reject
+(point 3):
+
+- The read claim (`AdmissionReadClaim`, carried in the `x-admin-signed` header)
+  gains an **OPTIONAL `network_id`**, **bound INTO the signed bytes** so a token
+  minted to read network A cannot be replayed to read network B.
+- **Global admin** (`REGISTRY_ADMIN_PUBKEYS`) → reads **all** networks' rows
+  (incl. network-less rows), and MAY pass `network_id` to narrow to one. This is
+  backward-compatible: the pre-FND-5 two-field claim (no `network_id`) still
+  reads everything.
+- **Per-network admin** → MUST name a `network_id`; authorised **only** as an
+  admin of THAT network (its stored `admin_pubkeys`), and the result is **FORCED**
+  to that one network's rows. Naming a network they do not administer, or omitting
+  the scope, ⇒ **403**.
+- Gate order is unchanged and fail-closed: `503 admin_not_configured` → `429`
+  rate-limit → `400` header/skew → `401 signature_invalid` → `403
+  admin_not_authorized`, then the scope filter. Single-row cross-network reads
+  return **404** (not 403) so a non-owning admin gets no existence oracle.
+
+**Security-critical invariant (test-enforced):** a per-network admin can NEVER
+read another network's rows — not by naming it, not by omitting the scope, not
+through the single-row GET. Authorization is keyed off the claimed `network_id`
+checked against that network's `admin_pubkeys`, never off anything a caller could
+forge past the signature.
+
+**Unchanged.** Control-plane only — no subject/envelope/`source`/`originator`
+change; the `admin_pubkeys` set never appears on the wire. Network CREATE stays
+global-only; a per-network admin still cannot manage `admin_pubkeys`
+(anti-self-escalation, point 2). A network-less request (`network_id` null) stays
+global-admin-only.

--- a/src/services/network-registry/__tests__/admin-read-scope.test.ts
+++ b/src/services/network-registry/__tests__/admin-read-scope.test.ts
@@ -1,0 +1,330 @@
+/**
+ * FND-5 (ADR-0020 §4 read-scoping) — per-network admin READ scoping.
+ *
+ * Before FND-5, listing/getting admission-requests was GLOBAL-admin-only, so a
+ * per-network admin's daemon could not fetch its OWN network's pending
+ * request-ids (it had to be handed them out-of-band). This hard-blocked the MC
+ * pier request-id feature (FLG-5).
+ *
+ * FND-5 lets `GET /admission-requests?status=` (and the single-row GET) accept a
+ * signed read claim from an admin who is EITHER a per-network admin of the
+ * network they NAME in the claim, OR a global admin — and returns ONLY that
+ * network's rows to the per-network admin. A global admin still sees all (and
+ * MAY narrow to one network).
+ *
+ * SECURITY-CRITICAL PROPERTY (explicitly tested below): a per-network admin
+ * MUST NOT be able to read another network's rows — not by naming it, not by
+ * omitting the scope, not through the single-row GET.
+ *
+ * Control-plane only — no wire-grammar change. Mirrors the read gate order:
+ * 503 admin_not_configured → 429 rate-limit → 400 header/skew → 401 sig →
+ * 403 admin_not_authorized (+ scope filter).
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedNetworkCreate,
+  makeSignedRegistration,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import type { AdmissionRequest } from "../src/types";
+
+let env: Env;
+let globalAdmin: PrincipalKey;
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(
+  path: string,
+  headers: Record<string, string> = {},
+  e: Env = env,
+): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+/** Create a network (as the global admin), optionally with a per-network admin set. */
+async function createNetwork(networkId: string, adminPubkeys?: string): Promise<Response> {
+  const body = await makeSignedNetworkCreate(networkId, globalAdmin, { adminPubkeys });
+  return post(`/networks/${networkId}`, body);
+}
+
+/**
+ * Register a principal (optionally into a network) and return the PENDING
+ * admission request. Uses a GLOBAL-admin unscoped read to locate the row (which
+ * still returns ALL networks post-FND-5).
+ */
+async function registerInto(principalId: string, networkId?: string): Promise<AdmissionRequest> {
+  const pk = await makePrincipalKey();
+  const reg = await makeSignedRegistration(principalId, pk, {
+    ...(networkId !== undefined && { networkId }),
+    stacks: [{ stack_id: `${principalId}/main`, stack_pubkey: pk.publicKeyB64 }],
+  });
+  const regRes = await post(`/principals/${principalId}/register`, reg);
+  expect(regRes.status).toBe(201);
+
+  const signedRead = await makeSignedAdminRead(globalAdmin);
+  const listRes = await get("/admission-requests?status=PENDING", {
+    "x-admin-signed": JSON.stringify(signedRead),
+  });
+  expect(listRes.status).toBe(200);
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const found = list.find(
+    (r) => r.principal_id === principalId && r.network_id === (networkId ?? null),
+  );
+  expect(found).toBeDefined();
+  return found!;
+}
+
+/** List admission-requests by status as a given admin, with an optional network scope. */
+async function listAs(
+  adminKey: PrincipalKey,
+  status: string,
+  opts: { networkId?: string; signWith?: PrincipalKey } = {},
+): Promise<Response> {
+  const signed = await makeSignedAdminRead(adminKey, opts);
+  return get(`/admission-requests?status=${status}`, {
+    "x-admin-signed": JSON.stringify(signed),
+  });
+}
+
+/** Fetch a single admission-request as a given admin, with an optional network scope. */
+async function getOneAs(
+  adminKey: PrincipalKey,
+  requestId: string,
+  opts: { networkId?: string } = {},
+): Promise<Response> {
+  const signed = await makeSignedAdminRead(adminKey, opts);
+  return get(`/admission-requests/${requestId}`, {
+    "x-admin-signed": JSON.stringify(signed),
+  });
+}
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  globalAdmin = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: globalAdmin.publicKeyB64,
+    ENVIRONMENT: "test",
+  } as Env;
+});
+
+// =============================================================================
+// Per-network admin read scoping — the core of FND-5
+// =============================================================================
+
+describe("GET /admission-requests — per-network admin read scope", () => {
+  test("a per-network admin sees ONLY their own network's rows", async () => {
+    const adminA = await makePrincipalKey();
+    const adminB = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    expect((await createNetwork("net-b", adminB.publicKeyB64)).status).toBe(201);
+
+    const reqA = await registerInto("joel", "net-a");
+    await registerInto("vincent", "net-b"); // a row in the OTHER network
+
+    const res = await listAs(adminA, "PENDING", { networkId: "net-a" });
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as AdmissionRequest[];
+
+    expect(rows.map((r) => r.request_id)).toEqual([reqA.request_id]);
+    expect(rows.every((r) => r.network_id === "net-a")).toBe(true);
+    // The other network's row is absent.
+    expect(rows.some((r) => r.network_id === "net-b")).toBe(false);
+  });
+
+  test("SECURITY: a per-network admin CANNOT read another network's rows by naming it → 403", async () => {
+    const adminA = await makePrincipalKey();
+    const adminB = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    expect((await createNetwork("net-b", adminB.publicKeyB64)).status).toBe(201);
+    await registerInto("vincent", "net-b");
+
+    // admin A signs a read scoped to net-b — a network A does NOT administer.
+    const res = await listAs(adminA, "PENDING", { networkId: "net-b" });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("admin_not_authorized");
+  });
+
+  test("SECURITY: a per-network admin CANNOT read ALL networks by omitting the scope → 403", async () => {
+    const adminA = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    await registerInto("joel", "net-a");
+
+    // No networkId in the claim → a non-global admin has nothing to scope to.
+    const res = await listAs(adminA, "PENDING");
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("admin_not_authorized");
+  });
+
+  test("a stranger (neither global nor per-network admin) naming a network → 403", async () => {
+    const adminA = await makePrincipalKey();
+    const stranger = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    await registerInto("joel", "net-a");
+
+    const res = await listAs(stranger, "PENDING", { networkId: "net-a" });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("admin_not_authorized");
+  });
+
+  test("scoping also applies to ADMITTED (not just PENDING)", async () => {
+    const adminA = await makePrincipalKey();
+    const adminB = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    expect((await createNetwork("net-b", adminB.publicKeyB64)).status).toBe(201);
+
+    const reqA = await registerInto("joel", "net-a");
+    const reqB = await registerInto("vincent", "net-b");
+
+    // Admit one row in each network (each by its own per-network admin).
+    expect((await post(`/admission-requests/${reqA.request_id}/admit`, await makeSignedAdminDecision(reqA.request_id, "admit", adminA))).status).toBe(200);
+    expect((await post(`/admission-requests/${reqB.request_id}/admit`, await makeSignedAdminDecision(reqB.request_id, "admit", adminB))).status).toBe(200);
+
+    const res = await listAs(adminA, "ADMITTED", { networkId: "net-a" });
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as AdmissionRequest[];
+    expect(rows.map((r) => r.request_id)).toEqual([reqA.request_id]);
+  });
+});
+
+// =============================================================================
+// Global admin — still sees all; may narrow
+// =============================================================================
+
+describe("GET /admission-requests — global admin", () => {
+  test("global admin with NO scope sees ALL networks' rows (regression)", async () => {
+    const adminA = await makePrincipalKey();
+    const adminB = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    expect((await createNetwork("net-b", adminB.publicKeyB64)).status).toBe(201);
+    const reqA = await registerInto("joel", "net-a");
+    const reqB = await registerInto("vincent", "net-b");
+
+    const res = await listAs(globalAdmin, "PENDING");
+    expect(res.status).toBe(200);
+    const ids = ((await res.json()) as AdmissionRequest[]).map((r) => r.request_id).sort();
+    expect(ids).toEqual([reqA.request_id, reqB.request_id].sort());
+  });
+
+  test("global admin MAY narrow to one network", async () => {
+    const adminA = await makePrincipalKey();
+    const adminB = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    expect((await createNetwork("net-b", adminB.publicKeyB64)).status).toBe(201);
+    const reqA = await registerInto("joel", "net-a");
+    await registerInto("vincent", "net-b");
+
+    const res = await listAs(globalAdmin, "PENDING", { networkId: "net-a" });
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as AdmissionRequest[];
+    expect(rows.map((r) => r.request_id)).toEqual([reqA.request_id]);
+  });
+
+  test("a network-less row (network_id null) stays GLOBAL-admin-only (ADR-0020 §3)", async () => {
+    const adminA = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    const netless = await registerInto("solo"); // no network
+    await registerInto("joel", "net-a");
+
+    // Global admin (unscoped) sees the network-less row.
+    const gRes = await listAs(globalAdmin, "PENDING");
+    const gIds = ((await gRes.json()) as AdmissionRequest[]).map((r) => r.request_id);
+    expect(gIds).toContain(netless.request_id);
+
+    // A per-network admin scoped to net-a never sees it (null !== "net-a").
+    const aRes = await listAs(adminA, "PENDING", { networkId: "net-a" });
+    const aIds = ((await aRes.json()) as AdmissionRequest[]).map((r) => r.request_id);
+    expect(aIds).not.toContain(netless.request_id);
+  });
+});
+
+// =============================================================================
+// Auth failures — fail-closed
+// =============================================================================
+
+describe("GET /admission-requests — auth failures", () => {
+  test("no x-admin-signed header → 400 (unsigned enumeration blocked)", async () => {
+    const res = await get("/admission-requests?status=PENDING");
+    expect(res.status).toBe(400);
+  });
+
+  test("forged signature (wrong signing key) → 401", async () => {
+    const adminA = await makePrincipalKey();
+    const attacker = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+
+    // Claim declares adminA's pubkey but is signed by the attacker's key.
+    const res = await listAs(adminA, "PENDING", { networkId: "net-a", signWith: attacker });
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("signature_invalid");
+  });
+
+  test("admin_not_configured (no REGISTRY_ADMIN_PUBKEYS) → 503 fail-closed", async () => {
+    const bareEnv = { ...env, REGISTRY_ADMIN_PUBKEYS: "" } as Env;
+    const signed = await makeSignedAdminRead(globalAdmin);
+    const res = await get(
+      "/admission-requests?status=PENDING",
+      { "x-admin-signed": JSON.stringify(signed) },
+      bareEnv,
+    );
+    expect(res.status).toBe(503);
+  });
+});
+
+// =============================================================================
+// Single-row GET — same scope
+// =============================================================================
+
+describe("GET /admission-requests/:request_id — per-network admin read scope", () => {
+  test("a per-network admin can fetch a row in THEIR network", async () => {
+    const adminA = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    const reqA = await registerInto("joel", "net-a");
+
+    const res = await getOneAs(adminA, reqA.request_id, { networkId: "net-a" });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as AdmissionRequest).request_id).toBe(reqA.request_id);
+  });
+
+  test("SECURITY: a per-network admin fetching another network's row → 404 (no existence leak)", async () => {
+    const adminA = await makePrincipalKey();
+    const adminB = await makePrincipalKey();
+    expect((await createNetwork("net-a", adminA.publicKeyB64)).status).toBe(201);
+    expect((await createNetwork("net-b", adminB.publicKeyB64)).status).toBe(201);
+    const reqB = await registerInto("vincent", "net-b");
+
+    // admin A is an admin of net-a; asks for net-a scope but a net-b row id.
+    const res = await getOneAs(adminA, reqB.request_id, { networkId: "net-a" });
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: string }).error).toBe("not_found");
+  });
+
+  test("global admin can fetch any network's row", async () => {
+    const adminB = await makePrincipalKey();
+    expect((await createNetwork("net-b", adminB.publicKeyB64)).status).toBe(201);
+    const reqB = await registerInto("vincent", "net-b");
+
+    const res = await getOneAs(globalAdmin, reqB.request_id);
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as AdmissionRequest).request_id).toBe(reqB.request_id);
+  });
+});

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -151,10 +151,15 @@ export async function makeSignedAdminRead(
     issuedAt?: string;
     /** Sign with a DIFFERENT key — forged signature test. */
     signWith?: PrincipalKey;
+    /** FND-5 — bind an optional network scope into the signed claim. */
+    networkId?: string;
   } = {},
 ): Promise<{ claim: AdmissionReadClaim; signature: string }> {
   const claim: AdmissionReadClaim = {
     admin_pubkey: adminKey.publicKeyB64,
+    // Only include network_id when supplied — keeps canonicalJSON stable for the
+    // backward-compatible two-field (unscoped, global) read claim.
+    ...(opts.networkId !== undefined && { network_id: opts.networkId }),
     issued_at: opts.issuedAt ?? new Date().toISOString(),
   };
   const message = new TextEncoder().encode(canonicalJSON(claim));

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -253,39 +253,52 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
 
   // ---------------------------------------------------------------------------
   // Helper: verify admin signature for read endpoints (x-admin-signed header)
+  //
+  // FND-5 (ADR-0020 §4 read-scoping) — reads are no longer global-admin-only.
+  // The gate resolves the caller to a READ SCOPE (fail-closed):
+  //   - scope === null      → GLOBAL admin, read ALL networks (incl. network-less
+  //                            rows). The caller MAY narrow with claim.network_id.
+  //   - scope === <id>      → read is FORCED to that one network's rows.
+  //
+  // Authorization is keyed off the network the caller NAMES in the signed claim
+  // (bound into the signature, so a token minted for network A cannot read B),
+  // checked against THAT network's stored `admin_pubkeys` — NEVER off anything a
+  // caller could forge past the signature. The security-critical property: a
+  // per-network admin is authorised for — and scoped to — exactly the network
+  // they administer, and nothing else (unauthorised ⇒ 403).
   // ---------------------------------------------------------------------------
 
-  async function verifyAdminReadHeader(
+  async function resolveAdminReadScope(
     c: Context<{ Bindings: Env }>,
-  ): Promise<{ error: string; status: number } | null> {
+  ): Promise<{ ok: true; scope: string | null } | { ok: false; error: string; status: number }> {
     // 1. FAIL-CLOSED: admin allowlist must be configured.
     const adminPubkeys = parseAdminPubkeys(c.env);
     if (adminPubkeys.size === 0) {
-      return { error: "admin_not_configured", status: 503 };
+      return { ok: false, error: "admin_not_configured", status: 503 };
     }
 
     // M1 — rate-limit BEFORE the Ed25519 verify.
     const allowed = await checkRateLimit(c.env, "read", clientKey(c.req.raw));
     if (!allowed) {
-      return { error: "rate_limited", status: 429 };
+      return { ok: false, error: "rate_limited", status: 429 };
     }
 
     // 2. Parse + validate x-admin-signed header.
     const headerVal = c.req.header("x-admin-signed");
     if (!headerVal) {
-      return { error: "x-admin-signed header required", status: 400 };
+      return { ok: false, error: "x-admin-signed header required", status: 400 };
     }
 
     let parsed: unknown;
     try {
       parsed = JSON.parse(headerVal);
     } catch (_err) {
-      return { error: "x-admin-signed must be valid JSON", status: 400 };
+      return { ok: false, error: "x-admin-signed must be valid JSON", status: 400 };
     }
 
     const readCheck = validateSignedAdmissionRead(parsed);
     if (!readCheck.ok) {
-      return { error: "x-admin-signed validation_failed", status: 400 };
+      return { ok: false, error: "x-admin-signed validation_failed", status: 400 };
     }
     const { signed } = readCheck;
 
@@ -293,16 +306,39 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     const issued = Date.parse(signed.claim.issued_at);
     const now = Date.now();
     if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
-      return { error: "issued_at out of skew window", status: 400 };
+      return { ok: false, error: "issued_at out of skew window", status: 400 };
     }
 
-    // 4. Signature + allowlist check (no nonce for reads — idempotent).
+    // 4. Signature check FIRST (no nonce for reads — idempotent). Verify over the
+    // reconstructed claim (validate echoes network_id only when the caller sent
+    // it) so the bytes match what the caller signed either way.
     const message = new TextEncoder().encode(canonicalJSON(signed.claim));
     const valid = await verifyEd25519(signed.claim.admin_pubkey, signed.signature, message as Uint8Array<ArrayBuffer>);
-    if (!valid) return { error: "signature_invalid", status: 401 };
-    if (!adminPubkeys.has(signed.claim.admin_pubkey)) return { error: "admin_not_authorized", status: 403 };
+    if (!valid) return { ok: false, error: "signature_invalid", status: 401 };
 
-    return null; // pass
+    // 5. Authorisation + scoping (FND-5). A GLOBAL admin reads all networks (and
+    // MAY narrow to a named one). Otherwise the caller MUST name a network they
+    // administer — authorised ONLY as a per-network admin of THAT network, and
+    // the read is FORCED to it. Anything else is 403 (a per-network admin cannot
+    // read all networks, nor a network they do not administer).
+    const isGlobal = adminPubkeys.has(signed.claim.admin_pubkey);
+    const claimedNetworkId = signed.claim.network_id;
+
+    if (isGlobal) {
+      // Global admin: honour an optional narrowing, else read everything.
+      return { ok: true, scope: claimedNetworkId ?? null };
+    }
+
+    // Per-network path: a network MUST be named (no network ⇒ nothing to scope
+    // to, and a non-global admin may not read all → 403).
+    if (!claimedNetworkId) {
+      return { ok: false, error: "admin_not_authorized", status: 403 };
+    }
+    const net = await getStore(c.env).getNetwork(claimedNetworkId);
+    if (!parseNetworkAdminPubkeys(net?.admin_pubkeys).has(signed.claim.admin_pubkey)) {
+      return { ok: false, error: "admin_not_authorized", status: 403 };
+    }
+    return { ok: true, scope: claimedNetworkId };
   }
 
   // ---------------------------------------------------------------------------
@@ -685,9 +721,9 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
   // ---------------------------------------------------------------------------
 
   app.get("/admission-requests", async (c) => {
-    const authError = await verifyAdminReadHeader(c);
-    if (authError) {
-      return c.json({ error: authError.error }, authError.status as 400 | 401 | 403 | 429 | 503);
+    const auth = await resolveAdminReadScope(c);
+    if (!auth.ok) {
+      return c.json({ error: auth.error }, auth.status as 400 | 401 | 403 | 429 | 503);
     }
 
     const status = c.req.query("status") as AdmissionStatus | undefined;
@@ -706,7 +742,14 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
 
     const store = getIssuanceStore(c.env);
     const requests = await store.listIssuanceRequests(status);
-    return c.json(requests, 200);
+    // FND-5 — scope the result to the authorised network. A GLOBAL admin's scope
+    // is null → all rows (incl. network-less). A per-network admin's scope is
+    // their network id → ONLY that network's rows (a network-less row, network_id
+    // null, never matches a concrete scope, so it stays global-admin-only per
+    // ADR-0020 §3). Filtering here (not in SQL) keeps the store interface intact;
+    // the admission queue is small and the filtered set never leaves the worker.
+    const scoped = auth.scope === null ? requests : requests.filter((r) => r.network_id === auth.scope);
+    return c.json(scoped, 200);
   });
 
   // ---------------------------------------------------------------------------
@@ -784,9 +827,9 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
   // ---------------------------------------------------------------------------
 
   app.get("/admission-requests/:request_id", async (c) => {
-    const authError = await verifyAdminReadHeader(c);
-    if (authError) {
-      return c.json({ error: authError.error }, authError.status as 400 | 401 | 403 | 429 | 503);
+    const auth = await resolveAdminReadScope(c);
+    if (!auth.ok) {
+      return c.json({ error: auth.error }, auth.status as 400 | 401 | 403 | 429 | 503);
     }
 
     const requestId = c.req.param("request_id") ?? "";
@@ -797,6 +840,14 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     const store = getIssuanceStore(c.env);
     const request = await store.getIssuanceRequest(requestId);
     if (!request) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    // FND-5 — a per-network admin (scope = their network id) must not read a row
+    // outside their network. Return 404, NOT 403, so a non-owning admin cannot
+    // even confirm the row EXISTS (no existence oracle across networks). A global
+    // admin (scope null) is unaffected; a global admin who narrowed to a network
+    // likewise only sees that network's rows.
+    if (auth.scope !== null && request.network_id !== auth.scope) {
       return c.json({ error: "not_found" }, 404);
     }
     return c.json(request, 200);

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -443,6 +443,21 @@ export interface SignedAdmissionDecision {
 export interface AdmissionReadClaim {
   /** The admin's own pubkey — used for allowlist check. */
   admin_pubkey: string;
+  /**
+   * FND-5 (ADR-0020 §4 read-scoping) — OPTIONAL network scope, bound INTO the
+   * signed claim so a token minted for network A cannot be replayed to read
+   * network B.
+   *
+   * Authorization + scoping (fail-closed, enforced in the read gate):
+   *   - PER-NETWORK admin → MUST name a network they administer; the read is
+   *     FORCED to that network's rows only. Naming a network they do NOT
+   *     administer (or omitting it) ⇒ 403. This is the security-critical
+   *     property: a per-network admin can never read another network's rows.
+   *   - GLOBAL admin (`REGISTRY_ADMIN_PUBKEYS`) → MAY name a network to narrow
+   *     the result, or OMIT it to read ALL networks (backward-compatible with
+   *     the pre-FND-5 global-only read).
+   */
+  network_id?: string;
   /** ISO-8601 UTC; within the CLOCK_SKEW_MS window. */
   issued_at: string;
 }

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -741,13 +741,32 @@ export function validateSignedAdmissionRead(
       errors: [{ field: "claim.admin_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" }],
     };
   }
+  // FND-5 — OPTIONAL network scope. When present it must be a well-formed
+  // network id; the read gate then FORCES a per-network admin's read to it.
+  if (
+    bc.network_id !== undefined &&
+    (typeof bc.network_id !== "string" || !isValidNetworkId(bc.network_id))
+  ) {
+    return {
+      ok: false,
+      errors: [{ field: "claim.network_id", message: "must be a valid network id" }],
+    };
+  }
   if (typeof bc.issued_at !== "string" || Number.isNaN(Date.parse(bc.issued_at))) {
     return { ok: false, errors: [{ field: "claim.issued_at", message: "must be an ISO-8601 timestamp" }] };
   }
   return {
     ok: true,
     signed: {
-      claim: { admin_pubkey: bc.admin_pubkey, issued_at: bc.issued_at },
+      // Reconstruct the claim the caller signed. Include network_id ONLY when
+      // supplied — so the signature verifies over the same canonicalJSON bytes
+      // whether or not the caller scoped the read (backward compatible with the
+      // pre-FND-5 two-field claim).
+      claim: {
+        admin_pubkey: bc.admin_pubkey,
+        ...(typeof bc.network_id === "string" && { network_id: bc.network_id }),
+        issued_at: bc.issued_at,
+      },
       signature: b.signature,
     },
   };


### PR DESCRIPTION
R1 slice **FND-5** from the MC future-state plan. Registry `GET /admission-requests` reads were global-admin-only (ADR-0020 §4); a per-network admin's daemon couldn't fetch its OWN pending request-ids — hard-blocks the MC pier request-ids (FLG-5).

- `resolveAdminReadScope`: global admin ⇒ all (may narrow); per-network admin ⇒ **forced** to a network they administer (checked vs that network's `admin_pubkeys`), else 403. `network_id` is **bound into the signature** (no cross-network replay). LIST filters rows; single-GET cross-network ⇒ 404 (no existence oracle). Backward-compatible (333 existing tests unchanged).
- ADR-0020 amended; 14 new security tests incl. explicit cross-network denial.

**Adversarially verified — HOLDS** (opus refute-to-kill pass: signature smuggling, scope-null escalation, LIST filter, GET oracle, null-network rows all fail to leak). Reviewed + safe to deploy.

⏸ **Deploy is HELD [principal-hands]** — code is inert until `wrangler deploy --env production` (never bare deploy — dev-DB clobber). @Andreas runs the deploy.

Generated by the R1 opus fleet (r1-fnd5) + adversarial review (r1-fnd5-refute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c