### PR TITLE
feat(mc): FND-6 — daemon mutation-surface hardening (R1 security floor)

### DIFF
--- a/src/surface/mc/__tests__/api.test.ts
+++ b/src/surface/mc/__tests__/api.test.ts
@@ -12,6 +12,8 @@ import {
   expect,
   beforeEach,
   afterEach,
+  beforeAll,
+  afterAll,
   spyOn,
 } from "bun:test";
 import { Database } from "bun:sqlite";
@@ -37,6 +39,26 @@ const fakeCatSpawn: SpawnFn = () =>
     stdout: "pipe",
     stderr: "pipe",
   });
+
+// FND-6: mutating routes (`/api/sessions`, `/input`, …) now require a CF-Access
+// identity on the loopback bind (mutation-guard identity gate). This file
+// exercises HANDLER behavior across the whole REST surface, not the gate (which
+// has dedicated coverage in mutation-guard-rebinding.test.ts), so inject the
+// loopback principal header on every test-server call. Non-mutating GETs ignore
+// it; guarded POSTs pass Gate 1 through it.
+const _realFetch = globalThis.fetch;
+beforeAll(() => {
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    if (!headers.has("Cf-Access-Authenticated-User-Email")) {
+      headers.set("Cf-Access-Authenticated-User-Email", "principal@example.com");
+    }
+    return _realFetch(input, { ...init, headers });
+  }) as unknown as typeof globalThis.fetch;
+});
+afterAll(() => {
+  globalThis.fetch = _realFetch;
+});
 
 interface TestContext {
   db: Database;

--- a/src/surface/mc/__tests__/curation-endpoints.test.ts
+++ b/src/surface/mc/__tests__/curation-endpoints.test.ts
@@ -22,6 +22,8 @@ import {
   expect,
   beforeEach,
   afterEach,
+  beforeAll,
+  afterAll,
 } from "bun:test";
 import { Database } from "bun:sqlite";
 import { join } from "path";
@@ -44,6 +46,25 @@ const fakeCatSpawn: SpawnFn = () =>
     stdout: "pipe",
     stderr: "pipe",
   });
+
+// FND-6: the curation mutations (requeue/abandon/handoff) now require a
+// CF-Access identity on the loopback bind (mutation-guard identity gate). These
+// tests exercise HANDLER behavior, not the gate — the gate has its own coverage
+// in mutation-guard-rebinding.test.ts — so inject the loopback principal header
+// on every test-server call here.
+const _realFetch = globalThis.fetch;
+beforeAll(() => {
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    if (!headers.has("Cf-Access-Authenticated-User-Email")) {
+      headers.set("Cf-Access-Authenticated-User-Email", "principal@example.com");
+    }
+    return _realFetch(input, { ...init, headers });
+  }) as unknown as typeof globalThis.fetch;
+});
+afterAll(() => {
+  globalThis.fetch = _realFetch;
+});
 
 interface TestContext {
   db: Database;

--- a/src/surface/mc/__tests__/curation-process-kill.test.ts
+++ b/src/surface/mc/__tests__/curation-process-kill.test.ts
@@ -22,6 +22,8 @@ import {
   expect,
   beforeEach,
   afterEach,
+  beforeAll,
+  afterAll,
 } from "bun:test";
 import { Database } from "bun:sqlite";
 import { join } from "path";
@@ -47,6 +49,24 @@ const fakeCatSpawn: SpawnFn = () =>
     stdout: "pipe",
     stderr: "pipe",
   });
+
+// FND-6: session spawn/control mutations now require a CF-Access identity on the
+// loopback bind (mutation-guard identity gate). These tests exercise HANDLER
+// behavior, not the gate (covered by mutation-guard-rebinding.test.ts), so
+// inject the loopback principal header on every test-server call here.
+const _realFetch = globalThis.fetch;
+beforeAll(() => {
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    if (!headers.has("Cf-Access-Authenticated-User-Email")) {
+      headers.set("Cf-Access-Authenticated-User-Email", "principal@example.com");
+    }
+    return _realFetch(input, { ...init, headers });
+  }) as unknown as typeof globalThis.fetch;
+});
+afterAll(() => {
+  globalThis.fetch = _realFetch;
+});
 
 interface TestContext {
   db: Database;

--- a/src/surface/mc/__tests__/mutation-guard-rebinding.test.ts
+++ b/src/surface/mc/__tests__/mutation-guard-rebinding.test.ts
@@ -1,0 +1,303 @@
+/**
+ * FND-6 — end-to-end coverage for the daemon mutation-surface hardening
+ * (docs/plan-mc-future-state.md §4.0), booting the REAL Bun.serve stack.
+ *
+ * The headline threat is **DNS rebinding**: attacker JS rebinds a hostname it
+ * controls to 127.0.0.1, becoming same-origin to the loopback daemon, and
+ * drives principal-credentialed mutations (`POST /api/sessions` spawns a CC
+ * session). `fetch` cannot forge the `Host` header (it is derived from the URL
+ * authority), so these cases use a **raw TCP socket** to send a hand-crafted
+ * HTTP/1.1 request with a spoofed `Host` / `Origin` — the exact shape a rebind
+ * produces — and assert the guard rejects it (403) before any handler runs.
+ *
+ * Also locks: unauthenticated `/api/sessions` is 401; the `mc.governance.
+ * principals` authorization binding (allowed → through; not-listed → 403); and
+ * the CK-6a attention lifecycle route rides the same gate.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import net from "node:net";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+import { startServer, type ServerContext } from "../server";
+import { initDatabase } from "../db/init";
+import { DEFAULT_CONFIG } from "../config";
+import { ProcessManager } from "../session/process-manager";
+import type { SpawnFn } from "../session/endpoint-resolver";
+import type { Config } from "../types";
+import { upsertAttentionItem } from "../db/attention";
+import type { Database } from "bun:sqlite";
+
+const PRINCIPAL = "principal@example.com";
+const AUTH_HEADER = { "Cf-Access-Authenticated-User-Email": PRINCIPAL };
+
+const fakeCatSpawn: SpawnFn = () =>
+  Bun.spawn(["cat"], { stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+
+interface Ctx {
+  db: Database;
+  ctx: ServerContext;
+  pm: ProcessManager;
+  port: number;
+  baseUrl: string;
+  tmpDir: string;
+}
+
+function start(governance?: string[]): Ctx {
+  const tmpDir = join(tmpdir(), `mc-fnd6-${Date.now()}-${Math.random()}`);
+  const db = initDatabase(join(tmpDir, "test.db"));
+  const pm = new ProcessManager();
+  const config: Config = {
+    ...DEFAULT_CONFIG,
+    port: 0, // ephemeral — bound port read back from ctx.server.port
+    ...(governance ? { governance: { principals: governance } } : {}),
+  };
+  const ctx = startServer(config, db, { processManager: pm, spawn: fakeCatSpawn });
+  const port = ctx.server.port;
+  if (port === undefined) throw new Error("server.port unresolved after start");
+  return { db, ctx, pm, port, baseUrl: `http://localhost:${port}`, tmpDir };
+}
+
+async function teardown(c: Ctx): Promise<void> {
+  await c.pm.closeAll();
+  c.ctx.stop(true);
+  c.db.close();
+  rmSync(c.tmpDir, { recursive: true, force: true });
+}
+
+/**
+ * Send a hand-crafted HTTP/1.1 request over a raw TCP socket so the `Host` /
+ * `Origin` headers are exactly what we write — the rebinding shape `fetch`
+ * refuses to produce. Returns the parsed status code.
+ */
+function rawHttp(
+  port: number,
+  opts: {
+    method?: string;
+    path: string;
+    host: string;
+    origin?: string;
+    email?: string;
+    body?: string;
+  },
+): Promise<number> {
+  const { method = "POST", path, host, origin, email, body = "" } = opts;
+  const lines = [`${method} ${path} HTTP/1.1`, `Host: ${host}`];
+  if (origin !== undefined) lines.push(`Origin: ${origin}`);
+  if (email !== undefined) lines.push(`Cf-Access-Authenticated-User-Email: ${email}`);
+  lines.push("Content-Type: application/json");
+  lines.push(`Content-Length: ${Buffer.byteLength(body, "utf8")}`);
+  lines.push("Connection: close");
+  lines.push("", body);
+  const payload = lines.join("\r\n");
+
+  return new Promise<number>((resolve, reject) => {
+    const sock = net.connect(port, "127.0.0.1", () => {
+      sock.write(payload);
+    });
+    let data = "";
+    sock.on("data", (chunk) => {
+      data += chunk.toString("utf8");
+    });
+    sock.on("end", () => {
+      const m = /^HTTP\/1\.[01] (\d{3})/.exec(data);
+      resolve(m ? Number(m[1]) : 0);
+    });
+    sock.on("error", reject);
+    sock.setTimeout(3000, () => {
+      sock.destroy();
+      reject(new Error("raw http request timed out"));
+    });
+  });
+}
+
+const SESSION_BODY = JSON.stringify({ title: "Hello" });
+
+describe("FND-6 — Host-header allowlist (anti-DNS-rebinding)", () => {
+  let c: Ctx;
+  afterEach(() => teardown(c));
+
+  it("REJECTS a mutating request with a foreign Host (the rebinding tell) — 403", async () => {
+    c = start();
+    // Rebind shape: connected to 127.0.0.1 but Host carries the attacker origin,
+    // AND a forged CF-Access identity header. The Host allowlist trips first.
+    const status = await rawHttp(c.port, {
+      path: "/api/sessions",
+      host: "evil.attacker.example",
+      email: PRINCIPAL,
+      body: SESSION_BODY,
+    });
+    expect(status).toBe(403);
+    // The spawn must NOT have run — no controlled process was created.
+    expect(c.pm.size).toBe(0);
+  });
+
+  it("ACCEPTS a legitimate loopback Host on the bound port", async () => {
+    c = start();
+    const status = await rawHttp(c.port, {
+      path: "/api/sessions",
+      host: `127.0.0.1:${c.port}`,
+      email: PRINCIPAL,
+      body: SESSION_BODY,
+    });
+    expect(status).toBe(201);
+  });
+
+  it("REJECTS a loopback host on the WRONG port — 403", async () => {
+    c = start();
+    const status = await rawHttp(c.port, {
+      path: "/api/sessions",
+      host: "127.0.0.1:1",
+      email: PRINCIPAL,
+      body: SESSION_BODY,
+    });
+    expect(status).toBe(403);
+  });
+});
+
+describe("FND-6 — foreign-Origin rejection", () => {
+  let c: Ctx;
+  afterEach(() => teardown(c));
+
+  it("REJECTS a mutating request bearing a foreign Origin — 403", async () => {
+    c = start();
+    const status = await rawHttp(c.port, {
+      path: "/api/sessions",
+      host: `127.0.0.1:${c.port}`,
+      origin: "https://evil.attacker.example",
+      email: PRINCIPAL,
+      body: SESSION_BODY,
+    });
+    expect(status).toBe(403);
+    expect(c.pm.size).toBe(0);
+  });
+
+  it("ACCEPTS a same-origin loopback Origin", async () => {
+    c = start();
+    const status = await rawHttp(c.port, {
+      path: "/api/sessions",
+      host: `127.0.0.1:${c.port}`,
+      origin: `http://127.0.0.1:${c.port}`,
+      email: PRINCIPAL,
+      body: SESSION_BODY,
+    });
+    expect(status).toBe(201);
+  });
+});
+
+describe("FND-6 — identity gate on the session-control routes", () => {
+  let c: Ctx;
+  afterEach(() => teardown(c));
+
+  it("REJECTS unauthenticated POST /api/sessions — 401 (no unauthenticated mutation tier)", async () => {
+    c = start();
+    // fetch → Host is the valid loopback authority; NO CF-Access identity header.
+    const res = await fetch(`${c.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: SESSION_BODY,
+    });
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("unauthenticated");
+    expect(c.pm.size).toBe(0);
+  });
+
+  it("ALLOWS an authenticated POST /api/sessions on loopback (unset allowlist) — 201", async () => {
+    c = start();
+    const res = await fetch(`${c.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...AUTH_HEADER },
+      body: SESSION_BODY,
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("REJECTS unauthenticated POST /api/assignments/:id/requeue — 401", async () => {
+    c = start();
+    const res = await fetch(`${c.baseUrl}/api/assignments/does-not-matter/requeue`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("FND-6 — authorization binding (mc.governance.principals)", () => {
+  let c: Ctx;
+  afterEach(() => teardown(c));
+
+  it("ALLOWS a listed principal — 201", async () => {
+    c = start([PRINCIPAL]);
+    const res = await fetch(`${c.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...AUTH_HEADER },
+      body: SESSION_BODY,
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("REJECTS an authenticated-but-unlisted principal — 403", async () => {
+    c = start(["someone@else.example"]);
+    const res = await fetch(`${c.baseUrl}/api/sessions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...AUTH_HEADER },
+      body: SESSION_BODY,
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("not_authorized");
+    expect(c.pm.size).toBe(0);
+  });
+});
+
+describe("FND-6 — CK-6a attention lifecycle rides the same gate", () => {
+  let c: Ctx;
+  afterEach(() => teardown(c));
+
+  function seedAttention(db: Database, id: string): void {
+    upsertAttentionItem(db, {
+      id,
+      stackId: "test-stack",
+      workItemId: null,
+      sessionId: null,
+      kind: "review",
+      severity: "normal",
+      status: "open",
+    });
+  }
+
+  it("REJECTS unauthenticated resolve — 401", async () => {
+    c = start();
+    seedAttention(c.db, "att-1");
+    const res = await fetch(`${c.baseUrl}/api/attention/att-1/resolve`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("ALLOWS an authenticated resolve — 200 and flips db status", async () => {
+    c = start();
+    seedAttention(c.db, "att-2");
+    const res = await fetch(`${c.baseUrl}/api/attention/att-2/resolve`, {
+      method: "POST",
+      headers: AUTH_HEADER,
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("resolved");
+    const row = c.db
+      .query("SELECT status FROM attention_items WHERE id = ?")
+      .get("att-2") as { status: string } | null;
+    expect(row?.status).toBe("resolved");
+  });
+
+  it("REJECTS a foreign Host on the attention route — 403", async () => {
+    c = start();
+    seedAttention(c.db, "att-3");
+    const status = await rawHttp(c.port, {
+      path: "/api/attention/att-3/dismiss",
+      host: "evil.attacker.example",
+      email: PRINCIPAL,
+    });
+    expect(status).toBe(403);
+  });
+});

--- a/src/surface/mc/api/__tests__/mutation-guard.test.ts
+++ b/src/surface/mc/api/__tests__/mutation-guard.test.ts
@@ -1,0 +1,177 @@
+/**
+ * FND-6 — unit coverage for the mutation-guard pure logic (Host/Origin
+ * allowlist, authorization binding, guarded-route predicate). The HTTP-level
+ * DNS-rebinding scenario is exercised end-to-end in
+ * `__tests__/mutation-guard-rebinding.test.ts`.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  buildAllowedHostnames,
+  parseHostHeader,
+  isHostAllowed,
+  isOriginAllowed,
+  checkAuthorization,
+  isIdentityGatedMutation,
+  isRebindExempt,
+  type MutationGuardContext,
+} from "../mutation-guard";
+
+function ctx(
+  overrides: Partial<MutationGuardContext> = {},
+): MutationGuardContext {
+  return {
+    isLoopback: true,
+    allowedHostnames: buildAllowedHostnames("127.0.0.1"),
+    listenPort: 8767,
+    principals: new Set<string>(),
+    ...overrides,
+  };
+}
+
+describe("buildAllowedHostnames", () => {
+  it("always includes the loopback interfaces", () => {
+    const hosts = buildAllowedHostnames("127.0.0.1");
+    expect(hosts.has("127.0.0.1")).toBe(true);
+    expect(hosts.has("localhost")).toBe(true);
+    expect(hosts.has("::1")).toBe(true);
+  });
+
+  it("adds a real configured hostname (lowercased)", () => {
+    const hosts = buildAllowedHostnames("MC.Internal.Example");
+    expect(hosts.has("mc.internal.example")).toBe(true);
+  });
+
+  it("does not add a wildcard bind as a hostname", () => {
+    expect(buildAllowedHostnames("0.0.0.0").has("0.0.0.0")).toBe(false);
+    expect(buildAllowedHostnames("::").has("::")).toBe(false);
+    expect(buildAllowedHostnames("").size).toBe(3);
+  });
+});
+
+describe("parseHostHeader", () => {
+  it("splits host:port", () => {
+    expect(parseHostHeader("localhost:8767")).toEqual({ host: "localhost", port: "8767" });
+    expect(parseHostHeader("127.0.0.1:8767")).toEqual({ host: "127.0.0.1", port: "8767" });
+  });
+  it("handles a bare host with no port", () => {
+    expect(parseHostHeader("localhost")).toEqual({ host: "localhost", port: null });
+  });
+  it("handles bracketed IPv6 with and without a port", () => {
+    expect(parseHostHeader("[::1]:8767")).toEqual({ host: "::1", port: "8767" });
+    expect(parseHostHeader("[::1]")).toEqual({ host: "::1", port: null });
+  });
+  it("treats an unbracketed bare IPv6 as host-only", () => {
+    expect(parseHostHeader("::1")).toEqual({ host: "::1", port: null });
+  });
+  it("lowercases the host", () => {
+    expect(parseHostHeader("EVIL.COM:8767")).toEqual({ host: "evil.com", port: "8767" });
+  });
+  it("rejects a non-numeric port and empty input", () => {
+    expect(parseHostHeader("localhost:abc")).toBeNull();
+    expect(parseHostHeader("")).toBeNull();
+  });
+});
+
+describe("isHostAllowed", () => {
+  it("accepts loopback hosts on the listening port", () => {
+    expect(isHostAllowed("127.0.0.1:8767", ctx())).toBe(true);
+    expect(isHostAllowed("localhost:8767", ctx())).toBe(true);
+    expect(isHostAllowed("[::1]:8767", ctx())).toBe(true);
+  });
+  it("accepts a bare loopback host (no port)", () => {
+    expect(isHostAllowed("localhost", ctx())).toBe(true);
+  });
+  it("rejects a foreign host — the DNS-rebinding tell", () => {
+    expect(isHostAllowed("evil.com:8767", ctx())).toBe(false);
+    expect(isHostAllowed("attacker.internal", ctx())).toBe(false);
+  });
+  it("rejects a loopback host on the WRONG port", () => {
+    expect(isHostAllowed("localhost:9999", ctx())).toBe(false);
+  });
+  it("fails closed on an absent or malformed Host", () => {
+    expect(isHostAllowed(null, ctx())).toBe(false);
+    expect(isHostAllowed("localhost:abc", ctx())).toBe(false);
+  });
+  it("accepts a configured non-loopback hostname", () => {
+    const c = ctx({ allowedHostnames: buildAllowedHostnames("mc.example.com") });
+    expect(isHostAllowed("mc.example.com:8767", c)).toBe(true);
+  });
+});
+
+describe("isOriginAllowed", () => {
+  it("allows an absent or empty Origin (non-browser / same-origin)", () => {
+    expect(isOriginAllowed(null, ctx())).toBe(true);
+    expect(isOriginAllowed("", ctx())).toBe(true);
+  });
+  it("allows a same-origin loopback Origin", () => {
+    expect(isOriginAllowed("http://localhost:8767", ctx())).toBe(true);
+    expect(isOriginAllowed("http://127.0.0.1:8767", ctx())).toBe(true);
+  });
+  it("rejects a foreign Origin", () => {
+    expect(isOriginAllowed("https://evil.com", ctx())).toBe(false);
+    expect(isOriginAllowed("http://evil.com:8767", ctx())).toBe(false);
+  });
+  it("rejects a loopback Origin on the wrong port", () => {
+    expect(isOriginAllowed("http://localhost:9999", ctx())).toBe(false);
+  });
+  it("rejects the opaque `null` origin and garbage", () => {
+    expect(isOriginAllowed("null", ctx())).toBe(false);
+    expect(isOriginAllowed("not-a-url", ctx())).toBe(false);
+  });
+});
+
+describe("checkAuthorization", () => {
+  it("allows a listed principal", () => {
+    const c = ctx({ principals: new Set(["principal@example.com"]) });
+    expect(checkAuthorization("principal@example.com", c)).toBeNull();
+  });
+  it("is case-insensitive on the principal", () => {
+    const c = ctx({ principals: new Set(["principal@example.com"]) });
+    expect(checkAuthorization("Principal@Example.com", c)).toBeNull();
+  });
+  it("403s an unlisted principal even on loopback", async () => {
+    const c = ctx({ principals: new Set(["someone@else.com"]) });
+    const res = checkAuthorization("principal@example.com", c);
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(403);
+    expect((await res?.json())?.error).toBe("not_authorized");
+  });
+  it("allows on loopback when the allowlist is unset (permissive)", () => {
+    expect(checkAuthorization("anyone@example.com", ctx({ principals: new Set() }))).toBeNull();
+  });
+  it("fails closed (403) off loopback when the allowlist is unset", async () => {
+    const c = ctx({ isLoopback: false, principals: new Set() });
+    const res = checkAuthorization("anyone@example.com", c);
+    expect(res?.status).toBe(403);
+    expect((await res?.json())?.error).toBe("not_authorized");
+  });
+});
+
+describe("isIdentityGatedMutation", () => {
+  it("gates the governed glass mutations", () => {
+    expect(isIdentityGatedMutation("POST", "/api/sessions")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/networks/admission-decision")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/assignments/abc/requeue")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/assignments/abc/abandon")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/assignments/abc/handoff")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/assignments/abc/input")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/attention/xyz/resolve")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/attention/xyz/dismiss")).toBe(true);
+  });
+  it("does NOT gate reads or non-governed routes", () => {
+    expect(isIdentityGatedMutation("GET", "/api/sessions")).toBe(false);
+    expect(isIdentityGatedMutation("GET", "/api/assignments/abc/requeue")).toBe(false);
+    expect(isIdentityGatedMutation("POST", "/api/tasks")).toBe(false);
+    expect(isIdentityGatedMutation("POST", "/api/github/webhook")).toBe(false);
+    expect(isIdentityGatedMutation("GET", "/api/attention")).toBe(false);
+  });
+});
+
+describe("isRebindExempt", () => {
+  it("exempts only the HMAC-authed webhook", () => {
+    expect(isRebindExempt("/api/github/webhook")).toBe(true);
+    expect(isRebindExempt("/api/sessions")).toBe(false);
+    expect(isRebindExempt("/api/networks/admission-decision")).toBe(false);
+  });
+});

--- a/src/surface/mc/api/attention.ts
+++ b/src/surface/mc/api/attention.ts
@@ -13,7 +13,11 @@
  */
 import type { Database } from "bun:sqlite";
 import type { AttentionItem } from "../types";
-import { listOpenAttention } from "../db/attention";
+import {
+  listOpenAttention,
+  resolveAttentionItem,
+  dismissAttentionItem,
+} from "../db/attention";
 import { getWorkItem } from "../db/work-items";
 
 export type AttentionLink =
@@ -52,4 +56,38 @@ export function handleListAttention(db: Database): Response {
     status: 200,
     headers: { "content-type": "application/json" },
   });
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * CK-6a — the attention lifecycle data route (POST resolve/dismiss over
+ * `db/attention setStatus`). A REAL db state op, distinct from Approve/Deny
+ * (which stays theater until SPX-8). Registered under the FND-6 identity gate
+ * in `server.ts`: no unauthenticated mutation joins the surface.
+ *
+ * @param action `"resolve"` (condition cleared) or `"dismiss"` (principal
+ *               cleared it without action). 404 when no open row changed.
+ */
+export function handleAttentionLifecycle(
+  db: Database,
+  id: string,
+  action: "resolve" | "dismiss",
+): Response {
+  const changed =
+    action === "resolve"
+      ? resolveAttentionItem(db, id)
+      : dismissAttentionItem(db, id);
+  if (!changed) {
+    return json(
+      { error: "not_found", detail: `no open attention item with id '${id}'` },
+      404,
+    );
+  }
+  return json({ status: action === "resolve" ? "resolved" : "dismissed", id }, 200);
 }

--- a/src/surface/mc/api/mutation-guard.ts
+++ b/src/surface/mc/api/mutation-guard.ts
@@ -1,0 +1,322 @@
+/**
+ * FND-6 — daemon mutation-surface hardening (docs/plan-mc-future-state.md §4.0).
+ *
+ * The MC daemon HTTP surface previously had **zero Host/Origin validation** and
+ * `isLoopbackBind()` keyed on the *bind*, not the *request*. On the dominant
+ * loopback deployment that let **DNS-rebinding** browser JS become same-origin
+ * to the daemon and drive its mutating routes — including `POST /api/sessions`
+ * / `/requeue` / `/abandon`, which spawn **principal-credentialed** CC sessions
+ * with no auth at all. This module is the single hardened checkpoint every
+ * mutating route passes through, closing that class before any new verb mounts.
+ *
+ * Four composed controls (all fail-closed — absent config ⇒ DENY):
+ *
+ *  (a) **Host-header allowlist** — a mutating request whose `Host` is not
+ *      `127.0.0.1:<port>` / `localhost:<port>` / `::1` / the configured
+ *      hostname is 403. This is the primary anti-DNS-rebinding control: the
+ *      browser sends the *original* hostname (`evil.com`) in `Host` even after
+ *      a rebind to 127.0.0.1, so a foreign `Host` unmasks the attack.
+ *  (b) **Foreign-Origin rejection** — a mutating request bearing an `Origin`
+ *      outside the allowlist is 403 (anti-CSRF / anti-rebinding second line).
+ *  (c) **Identity gate (Gate 1)** — governed glass mutations resolve a
+ *      CF-Access principal through the SAME bind-conditioned resolver the
+ *      admission route uses ({@link resolveRequestPrincipal}). No principal ⇒
+ *      401. There is no unauthenticated mutation tier (invariant 3).
+ *  (d) **Authorization binding** — the resolved principal must appear in the
+ *      configured `mc.governance.principals` allowlist, else 403. Fail-closed
+ *      off loopback when the allowlist is unset; on loopback an unset allowlist
+ *      stays permissive so legit local callers (the CF-fronted dashboard, the
+ *      CLI) keep working — the loopback boundary + Host/Origin are the gate
+ *      there.
+ *
+ * NOTE: typed-confirm is an **intent** control (human deliberateness), never a
+ * security control — it is trivially satisfiable programmatically and is NOT
+ * enforced here (invariant 3).
+ */
+
+import {
+  CF_ACCESS_EMAIL_HEADER,
+  CF_ACCESS_JWT_HEADER,
+  resolveRequestPrincipal,
+  type AdmissionAuthContext,
+} from "./networks-admission";
+
+/** HTTP methods that mutate state — the guard applies to these only. */
+export const MUTATING_METHODS: ReadonlySet<string> = new Set([
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+]);
+
+/**
+ * Wildcard / unspecified binds carry no single meaningful hostname, so they
+ * contribute nothing to the Host allowlist (a principal exposing MC on a
+ * wildcard bind must front it with a real hostname + `mc.governance.principals`
+ * — the off-loopback authorization path is then the gate).
+ */
+const WILDCARD_HOSTS: ReadonlySet<string> = new Set(["0.0.0.0", "::", "*", ""]);
+
+/**
+ * Build the set of hostnames a mutating request's `Host` / `Origin` may carry:
+ * the loopback interfaces plus the configured bind hostname (when it is a real
+ * name, not a wildcard). Lowercased for case-insensitive comparison.
+ */
+export function buildAllowedHostnames(configHostname: string): Set<string> {
+  const hosts = new Set<string>(["127.0.0.1", "::1", "localhost"]);
+  const h = configHostname.trim().toLowerCase();
+  if (!WILDCARD_HOSTS.has(h)) hosts.add(h);
+  return hosts;
+}
+
+/**
+ * The per-server, per-request-invariant inputs the guard needs. Computed once
+ * in `startServer` (the bind + config are fixed for the server's lifetime);
+ * `listenPort` is the ACTUAL bound port (`server.port`), which differs from
+ * `config.port` when the config asks for an ephemeral bind (port 0, tests).
+ */
+export interface MutationGuardContext {
+  /** True when MC is bound to a loopback interface. */
+  isLoopback: boolean;
+  /** Allowed `Host` / `Origin` hostnames (see {@link buildAllowedHostnames}). */
+  allowedHostnames: ReadonlySet<string>;
+  /** The actual bound port — `Host`/`Origin` port, when present, must match. */
+  listenPort: number;
+  /**
+   * `mc.governance.principals` — lowercased principal emails allowed to mutate.
+   * EMPTY = unset (fail-closed off loopback; permissive on loopback).
+   */
+  principals: ReadonlySet<string>;
+  /** CF-Access JWT verifier, present iff `cfAccess.aud` is configured. */
+  verifyJwt?: AdmissionAuthContext["verifyJwt"];
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Split a `Host` (or `Origin` authority) header into host + optional port.
+ * Handles bracketed IPv6 (`[::1]:8767`), `host:port`, and bare host. Returns
+ * `null` for a syntactically invalid value (→ the caller fails closed).
+ */
+export function parseHostHeader(
+  value: string,
+): { host: string; port: string | null } | null {
+  const v = value.trim();
+  if (v === "") return null;
+
+  // Bracketed IPv6 literal: [::1] or [::1]:port
+  if (v.startsWith("[")) {
+    const end = v.indexOf("]");
+    if (end === -1) return null;
+    const host = v.slice(1, end).toLowerCase();
+    if (host === "") return null;
+    const rest = v.slice(end + 1);
+    if (rest === "") return { host, port: null };
+    if (rest.startsWith(":") && /^\d+$/.test(rest.slice(1))) {
+      return { host, port: rest.slice(1) };
+    }
+    return null;
+  }
+
+  const colonCount = (v.match(/:/g) ?? []).length;
+  if (colonCount === 1) {
+    const idx = v.indexOf(":");
+    const host = v.slice(0, idx).toLowerCase();
+    const port = v.slice(idx + 1);
+    if (host === "" || !/^\d+$/.test(port)) return null;
+    return { host, port };
+  }
+  // Zero colons (bare host) or >1 (unbracketed bare IPv6, no port).
+  return { host: v.toLowerCase(), port: null };
+}
+
+/**
+ * (a) — is the request's `Host` header in the allowlist? A `null` Host (absent
+ * — malformed under HTTP/1.1) fails closed. A present port must match the
+ * actual listening port.
+ */
+export function isHostAllowed(
+  hostHeader: string | null,
+  ctx: MutationGuardContext,
+): boolean {
+  if (hostHeader === null) return false;
+  const parsed = parseHostHeader(hostHeader);
+  if (parsed === null) return false;
+  if (!ctx.allowedHostnames.has(parsed.host)) return false;
+  if (parsed.port !== null && parsed.port !== String(ctx.listenPort)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * (b) — is the request's `Origin` acceptable for a mutation? Absent/empty
+ * Origin is allowed (non-browser clients — the CLI, server-to-server — and
+ * same-origin navigations legitimately omit it; the Host allowlist is the
+ * anti-rebinding gate there). A literal `null` origin (opaque: sandboxed
+ * iframe, `file://`) is rejected. A present Origin must resolve to an allowed
+ * hostname (and matching port when specified).
+ */
+export function isOriginAllowed(
+  originHeader: string | null,
+  ctx: MutationGuardContext,
+): boolean {
+  if (originHeader === null) return true;
+  const o = originHeader.trim();
+  if (o === "") return true;
+  if (o.toLowerCase() === "null") return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(o);
+  } catch {
+    return false;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!ctx.allowedHostnames.has(host)) return false;
+  if (parsed.port !== "" && parsed.port !== String(ctx.listenPort)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * (a)+(b) — anti-DNS-rebinding + anti-CSRF for EVERY mutating request. Returns
+ * a 403 `Response` to send verbatim, or `null` when the request may proceed.
+ * Applied to all mutating routes except HMAC-authed M2M (see
+ * {@link isRebindExempt}) — a browser cannot forge the HMAC, so rebinding a
+ * signed webhook is inert.
+ */
+export function checkRebindGuard(
+  req: Request,
+  ctx: MutationGuardContext,
+): Response | null {
+  if (!isHostAllowed(req.headers.get("host"), ctx)) {
+    return json(
+      {
+        error: "forbidden_host",
+        detail:
+          "the Host header is not in the Mission Control allowlist " +
+          "(127.0.0.1 / localhost / ::1 / the configured hostname). This blocks " +
+          "DNS-rebinding: a browser sends the original hostname in Host even after " +
+          "a rebind to a loopback address.",
+      },
+      403,
+    );
+  }
+  if (!isOriginAllowed(req.headers.get("origin"), ctx)) {
+    return json(
+      {
+        error: "forbidden_origin",
+        detail:
+          "the Origin header is outside the Mission Control allowlist — a mutating " +
+          "request from a foreign origin is refused (anti-CSRF / anti-rebinding).",
+      },
+      403,
+    );
+  }
+  return null;
+}
+
+/**
+ * (d) — authorization binding. The resolved principal must appear in the
+ * configured `mc.governance.principals` allowlist. Unset allowlist:
+ * fail-closed (403) off loopback; permissive on loopback (preserve legit local
+ * callers — the loopback boundary + Host/Origin are the gate).
+ */
+export function checkAuthorization(
+  principal: string,
+  ctx: MutationGuardContext,
+): Response | null {
+  const id = principal.trim().toLowerCase();
+  if (ctx.principals.size > 0) {
+    if (!ctx.principals.has(id)) {
+      return json(
+        {
+          error: "not_authorized",
+          detail:
+            "the authenticated principal is not in the mc.governance.principals " +
+            "allowlist for this Mission Control daemon.",
+        },
+        403,
+      );
+    }
+    return null;
+  }
+  // Unset allowlist.
+  if (!ctx.isLoopback) {
+    return json(
+      {
+        error: "not_authorized",
+        detail:
+          "mc.governance.principals is unset — control-plane mutations are refused " +
+          "on a non-loopback bind (fail-closed). Configure the principal allowlist.",
+      },
+      403,
+    );
+  }
+  return null;
+}
+
+/**
+ * (c)+(d) — identity gate + authorization for a governed glass mutation.
+ * Resolves the CF-Access principal (bind-conditioned; the SAME resolver the
+ * admission route uses) then checks the authorization binding. Returns either a
+ * `Response` to send verbatim (401/403/503) or the resolved principal.
+ */
+export async function enforceMutationAuth(
+  req: Request,
+  ctx: MutationGuardContext,
+): Promise<Response | { principal: string }> {
+  const auth: AdmissionAuthContext = {
+    isLoopback: ctx.isLoopback,
+    emailHeader: req.headers.get(CF_ACCESS_EMAIL_HEADER) ?? undefined,
+    jwtAssertion: req.headers.get(CF_ACCESS_JWT_HEADER) ?? undefined,
+    ...(ctx.verifyJwt ? { verifyJwt: ctx.verifyJwt } : {}),
+  };
+  const who = await resolveRequestPrincipal(auth);
+  if (who instanceof Response) return who;
+
+  const denial = checkAuthorization(who, ctx);
+  if (denial) return denial;
+
+  return { principal: who };
+}
+
+/**
+ * Which mutating routes carry the full identity+authorization gate (c)+(d).
+ * The governed glass-mutation set: local session spawn/control (strictly higher
+ * blast than dispatch-to-peer — must not be the least-gated route), the Tier-2
+ * federation admission decision, and the attention lifecycle (CK-6a).
+ */
+export function isIdentityGatedMutation(
+  method: string,
+  pathname: string,
+): boolean {
+  if (!MUTATING_METHODS.has(method)) return false;
+  if (pathname === "/api/sessions") return true;
+  if (pathname === "/api/networks/admission-decision") return true;
+  if (/^\/api\/assignments\/[^/]+\/(requeue|abandon|handoff|input)$/.test(pathname)) {
+    return true;
+  }
+  if (/^\/api\/attention\/[^/]+\/(resolve|dismiss)$/.test(pathname)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Routes exempt from the Host/Origin anti-rebinding guard: HMAC-authed M2M
+ * only. `POST /api/github/webhook` authenticates by an HMAC signature over a
+ * shared secret a browser cannot forge, so rebinding it is inert — and it is
+ * legitimately reached cross-origin by the webhook proxy. Every other mutating
+ * route is guarded.
+ */
+export function isRebindExempt(pathname: string): boolean {
+  return pathname === "/api/github/webhook";
+}

--- a/src/surface/mc/api/networks-admission.ts
+++ b/src/surface/mc/api/networks-admission.ts
@@ -229,8 +229,15 @@ function parseBody(
  *      · verified JWT carries no `email` claim ⇒ 401
  *
  * Returns the resolved principal email, or a `Response` to return verbatim.
+ *
+ * FND-6 (cortex#, docs/plan-mc-future-state.md §4.0): exported + generalized so
+ * the shared mutation guard (`mutation-guard.ts`) resolves identity for EVERY
+ * governed glass mutation (`/api/sessions`, `/requeue`, `/abandon`, …) through
+ * the SAME bind-conditioned Gate-1 the admission route uses — one auth path, no
+ * drift. The error KEYS (`unauthenticated` / `not_configured`) are load-bearing
+ * (asserted by the admission unit tests); only the `detail` copy is generic.
  */
-async function resolveAdmissionPrincipal(
+export async function resolveRequestPrincipal(
   auth: AdmissionAuthContext,
 ): Promise<string | Response> {
   if (auth.isLoopback) {
@@ -240,8 +247,8 @@ async function resolveAdmissionPrincipal(
         {
           error: "unauthenticated",
           detail:
-            "a CF-Access authenticated principal identity is required to admit/reject " +
-            `(missing/empty ${CF_ACCESS_EMAIL_HEADER}). This mutation is not available on an unauthenticated request.`,
+            "a CF-Access authenticated principal identity is required for this mutation " +
+            `(missing/empty ${CF_ACCESS_EMAIL_HEADER}). This control-plane mutation is not available on an unauthenticated request.`,
         },
         401,
       );
@@ -256,7 +263,7 @@ async function resolveAdmissionPrincipal(
         error: "not_configured",
         detail:
           "cf-access is not configured for a non-loopback Mission Control bind — set " +
-          "`cfAccess.aud` (the Access application audience) so admit/reject can verify " +
+          "`cfAccess.aud` (the Access application audience) so this mutation can verify " +
           `the ${CF_ACCESS_JWT_HEADER}. Refusing to trust the raw email header off loopback.`,
       },
       503,
@@ -269,7 +276,7 @@ async function resolveAdmissionPrincipal(
       {
         error: "unauthenticated",
         detail:
-          "a verified CF-Access JWT is required to admit/reject on a non-loopback bind " +
+          "a verified CF-Access JWT is required for this mutation on a non-loopback bind " +
           `(missing/empty ${CF_ACCESS_JWT_HEADER}).`,
       },
       401,
@@ -283,7 +290,7 @@ async function resolveAdmissionPrincipal(
         error: "unauthenticated",
         detail:
           "the CF-Access JWT failed verification (bad signature, wrong audience/issuer, " +
-          "expired, or not yet valid). Refusing to admit/reject.",
+          "expired, or not yet valid). Refusing the mutation.",
       },
       401,
     );
@@ -294,7 +301,7 @@ async function resolveAdmissionPrincipal(
     return json(
       {
         error: "unauthenticated",
-        detail: "the verified CF-Access JWT carries no `email` claim to attribute the decision to.",
+        detail: "the verified CF-Access JWT carries no `email` claim to attribute the mutation to.",
       },
       401,
     );
@@ -317,7 +324,7 @@ export async function handleAdmissionDecision(
   rawBody: unknown,
 ): Promise<Response> {
   // Gate 1 — a CF-Access principal identity is required for a mutation.
-  const who = await resolveAdmissionPrincipal(auth);
+  const who = await resolveRequestPrincipal(auth);
   if (who instanceof Response) return who;
 
   // Gate 2 — body shape + typed-confirm.

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -6,7 +6,7 @@ import { readFileSync, existsSync } from "fs";
 import { parse as parseYaml } from "yaml";
 import { join } from "path";
 import { homedir } from "os";
-import type { Config, LogLevel, CfAccessConfig } from "./types";
+import type { Config, LogLevel, CfAccessConfig, GovernanceConfig } from "./types";
 import { resolveConfigFilePath } from "../../common/config/config-path";
 
 const VALID_LOG_LEVELS: ReadonlySet<LogLevel> = new Set([
@@ -123,6 +123,31 @@ export function loadConfig(configPath?: string): Readonly<Config> {
     };
   }
 
+  // FND-6 — `governance.principals` authorization allowlist. Parsed strictly:
+  // when the block is present, `principals` MUST be an array of non-empty
+  // strings (a malformed block throws rather than silently disabling the
+  // authorization binding on a mutating surface).
+  const governanceRaw = parsed.governance as Record<string, unknown> | undefined;
+  let governance: GovernanceConfig | undefined;
+  if (governanceRaw !== undefined) {
+    const rawPrincipals = governanceRaw.principals;
+    if (!Array.isArray(rawPrincipals)) {
+      throw new Error(
+        `governance.principals must be an array of principal emails in ${resolvedPath}`,
+      );
+    }
+    const principals: string[] = [];
+    for (const entry of rawPrincipals) {
+      if (typeof entry !== "string" || entry.trim() === "") {
+        throw new Error(
+          `governance.principals entries must be non-empty strings in ${resolvedPath}`,
+        );
+      }
+      principals.push(entry.trim());
+    }
+    governance = { principals };
+  }
+
   let level: LogLevel = DEFAULT_CONFIG.log.level;
   if (typeof log?.level === "string") {
     if (!VALID_LOG_LEVELS.has(log.level as LogLevel)) {
@@ -176,6 +201,7 @@ export function loadConfig(configPath?: string): Readonly<Config> {
           : DEFAULT_CONFIG.ws.maxClients,
     },
     ...(cfAccess ? { cfAccess } : {}),
+    ...(governance ? { governance } : {}),
   };
 
   return Object.freeze(config);

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -58,7 +58,16 @@ import { handleListRepositories } from "./api/git-repos";
 import { handleListPlans } from "./api/plans";
 import { handleGetPhaseDetail } from "./api/phase-detail";
 import { handleGetWorkItemDetail } from "./api/work-item-detail";
-import { handleListAttention } from "./api/attention";
+import { handleListAttention, handleAttentionLifecycle } from "./api/attention";
+import {
+  MUTATING_METHODS,
+  buildAllowedHostnames,
+  checkRebindGuard,
+  enforceMutationAuth,
+  isIdentityGatedMutation,
+  isRebindExempt,
+  type MutationGuardContext,
+} from "./api/mutation-guard";
 import { handleGetGovernance } from "./api/governance";
 import { handleGetObservability } from "./api/observability-tab";
 import { proxySideband } from "../../common/sideband/proxy";
@@ -242,6 +251,19 @@ export function startServer(
         })
     : undefined;
 
+  // FND-6 — mutation-surface hardening. The Host/Origin allowlist + principal
+  // allowlist are fixed for the server's lifetime (bind + config are fixed), so
+  // build the invariant part once; `listenPort` is resolved per request from
+  // `server.port` (differs from `config.port` on an ephemeral bind — tests).
+  const guardBase: Omit<MutationGuardContext, "listenPort"> = {
+    isLoopback,
+    allowedHostnames: buildAllowedHostnames(config.hostname),
+    principals: new Set(
+      (config.governance?.principals ?? []).map((p) => p.trim().toLowerCase()),
+    ),
+    ...(cfAccessVerifier ? { verifyJwt: cfAccessVerifier } : {}),
+  };
+
   const apiDeps: ApiDeps | null = options.processManager
     ? {
         processManager: options.processManager,
@@ -320,6 +342,11 @@ export function startServer(
         // MC-B2 — resolve the admission-decision signer lazily too (stack
         // identity + registry client boot after the server). null ⇒ 503.
         const admissionDecider = options.admissionDecider?.() ?? null;
+        // FND-6 — finalize the guard context with the ACTUAL bound port.
+        const guard: MutationGuardContext = {
+          ...guardBase,
+          listenPort: server.port ?? config.port,
+        };
         return handleApi(
           req,
           url,
@@ -329,8 +356,7 @@ export function startServer(
           localAggregation,
           networks,
           admissionDecider,
-          isLoopback,
-          cfAccessVerifier,
+          guard,
         );
       }
 
@@ -489,10 +515,22 @@ async function handleApi(
   localAggregation: LocalAggregationContext | null,
   networks: NetworksView | null = null,
   admissionDecider: AdmissionDecider | null = null,
-  isLoopback = true,
-  cfAccessVerifier?: AdmissionAuthContext["verifyJwt"]
+  guard: MutationGuardContext,
 ): Promise<Response> {
   const { pathname } = url;
+
+  // FND-6 — mutation-surface hardening, BEFORE any route match or body read.
+  // (a)+(b) Host/Origin anti-rebinding on every mutating route except HMAC M2M;
+  // (c)+(d) identity gate + authorization binding on the governed glass set.
+  // Runs first so no unauthenticated/rebound request can reach a handler.
+  if (MUTATING_METHODS.has(req.method) && !isRebindExempt(pathname)) {
+    const rebindDenial = checkRebindGuard(req, guard);
+    if (rebindDenial) return rebindDenial;
+  }
+  if (isIdentityGatedMutation(req.method, pathname)) {
+    const authResult = await enforceMutationAuth(req, guard);
+    if (authResult instanceof Response) return authResult;
+  }
 
   if (pathname === "/api/assignments") {
     if (req.method !== "GET") {
@@ -574,6 +612,23 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListAttention(db);
+  }
+
+  // CK-6a — POST /api/attention/:id/resolve|dismiss — attention lifecycle.
+  // A real db state op (db/attention setStatus), gated by the FND-6 identity
+  // guard above (see isIdentityGatedMutation). Approve/Deny stays theater until
+  // SPX-8 and is deliberately NOT mounted here.
+  const attentionLifecycleMatch =
+    /^\/api\/attention\/([^/]+)\/(resolve|dismiss)$/.exec(pathname);
+  if (attentionLifecycleMatch) {
+    if (req.method !== "POST") {
+      return methodNotAllowed(["POST"]);
+    }
+    const captured = attentionLifecycleMatch[1];
+    if (!captured) return new Response("Not Found", { status: 404 });
+    const id = decodeURIComponent(captured);
+    const action = attentionLifecycleMatch[2] as "resolve" | "dismiss";
+    return handleAttentionLifecycle(db, id, action);
   }
 
   // G-1115 — GET /api/governance — governance verdicts + summary + alarm tier.
@@ -722,15 +777,18 @@ async function handleApi(
     if (req.method !== "POST") {
       return methodNotAllowed(["POST"]);
     }
+    // The FND-6 guard already enforced Host/Origin + identity + authorization
+    // for this route; the handler re-resolves the principal for signing/audit
+    // (typed-confirm is its intent gate). `guard` carries the bind + verifier.
     const emailHeader = req.headers.get(CF_ACCESS_EMAIL_HEADER) ?? undefined;
     const jwtAssertion = req.headers.get(CF_ACCESS_JWT_HEADER) ?? undefined;
     const body = await parseJsonBody(req);
     if (body.error) return body.error;
     const auth: AdmissionAuthContext = {
-      isLoopback,
+      isLoopback: guard.isLoopback,
       emailHeader,
       jwtAssertion,
-      ...(cfAccessVerifier ? { verifyJwt: cfAccessVerifier } : {}),
+      ...(guard.verifyJwt ? { verifyJwt: guard.verifyJwt } : {}),
     };
     return handleAdmissionDecision(admissionDecider, auth, body.value);
   }

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -559,6 +559,22 @@ export interface Config {
    * "metafactory". Omitted entirely on every current (loopback) deployment.
    */
   cfAccess?: CfAccessConfig;
+  /**
+   * FND-6 — the `mc.governance.principals` authorization allowlist. Every
+   * governed glass mutation (`/api/sessions`, `/requeue`, `/abandon`, the
+   * attention lifecycle, admission-decision) checks the resolved CF-Access
+   * principal against this list. Fail-closed: unset ⇒ refuse mutations on a
+   * non-loopback bind (403); on loopback an unset list stays permissive so
+   * legit local callers keep working (the loopback boundary + Host/Origin are
+   * the gate there). Omitted on a default loopback dev deployment.
+   */
+  governance?: GovernanceConfig;
+}
+
+/** FND-6 — per-daemon control-plane authorization. */
+export interface GovernanceConfig {
+  /** Principal emails (CF-Access identities) allowed to run glass mutations. */
+  principals: string[];
 }
 
 /** cortex#1410 — CF Access application binding for non-loopback MC. */

--- a/src/surface/mc/worker/src/index.ts
+++ b/src/surface/mc/worker/src/index.ts
@@ -36,10 +36,20 @@ const app = new Hono<{ Bindings: Env }>();
 // Global middleware
 // ---------------------------------------------------------------------------
 
-// S-002: CORS restricted to known origins (comma-separated in env var)
+// S-002 / FND-6: CORS restricted to configured origins, DEFAULT-DENY.
+// `CORS_ORIGIN` unset ⇒ emit NO CORS headers (never `*`+credentials — that
+// pairing is an authenticated cross-origin read primitive and violates dev=prod
+// parity). Only when the principal configures explicit origins do we attach the
+// credentialed CORS middleware.
 app.use("*", async (c, next) => {
-  const raw = c.env.CORS_ORIGIN || "*";
-  const origins = raw.includes(",") ? raw.split(",").map((s) => s.trim()) : raw;
+  const raw = (c.env.CORS_ORIGIN ?? "").trim();
+  if (raw === "") {
+    // Fail-closed: no allowlist configured ⇒ same-origin only, no CORS headers.
+    return next();
+  }
+  const origins = raw.includes(",")
+    ? raw.split(",").map((s) => s.trim()).filter((s) => s !== "")
+    : raw;
   const corsMiddleware = cors({
     origin: origins,
     allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],


### PR DESCRIPTION
R1 slice **FND-6** — the security floor from the MC future-state plan (§4.0, [frontier-review]). Closes the DNS-rebinding / unauthenticated-mutating-route class before any glass verb builds on it.

- `api/mutation-guard.ts` (new) — Host-header allowlist + foreign-Origin rejection + identity gate + `mc.governance.principals` authz binding, all **fail-closed**.
- `server.ts`: every mutating route (incl. the previously-unauthenticated `POST /api/sessions`/`/requeue`/`/abandon` + attention lifecycle) now behind the guard.
- `worker/src/index.ts`: CORS default-**deny** (unset ⇒ no headers, never `*`).
- 41 guard+rebinding tests + 167 existing route tests pass; tsc 0; eslint clean; vocab PASS.

**Salvaged** from a stalled builder (work was complete, pre-verify) then fully re-verified by the orchestrator. **Merge HELD pending the adversarial refute-to-kill pass** (in progress) — no autonomous merge of daemon-auth code without it.

Generated by the R1 opus fleet (fnd6b) + adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c