### PR TITLE
feat(mc): CK-1 — dive-to-stack altitude drill (R1)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/mc-dive.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-dive.test.ts
@@ -1,0 +1,225 @@
+/**
+ * CK-1 (cortex#1289) — constellation-click → altitude-coordinate mapping tests.
+ *
+ * Pins the two derivations the rest of CK-1 leans on:
+ *   - the SOVEREIGNTY bit (own-local vs federated) is derived with the SAME
+ *     `classifyOrigin` the node cards use — self + same-principal sibling are
+ *     own-local (`federated:false`), a cross-principal peer is `federated:true`;
+ *   - a selected local assistant's session tree flattens to rail SESSION targets
+ *     (children included), keyed off the working projection — never fabricated.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { AgentPresenceTile, AgentOrigin } from "../hooks/use-agents";
+import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import type { StackHubNodeData } from "../lib/network-graph-adapter";
+import {
+  isFederatedOrigin,
+  stackCoordFromHub,
+  stackCoordFromTile,
+  sessionTargetsForAssistant,
+} from "../lib/mc-dive";
+
+function hub(over: Partial<StackHubNodeData> & { origin: AgentOrigin }): StackHubNodeData {
+  return {
+    kind: "stack-hub",
+    servingPrincipal: "andreas",
+    principal: "andreas",
+    stack: "meta-factory",
+    agentCount: 1,
+    stackColor: "#fff",
+    ...over,
+  };
+}
+
+function tile(over: Partial<AgentPresenceTile> & { origin: AgentOrigin }): AgentPresenceTile {
+  return {
+    key: "andreas/meta-factory/luna",
+    agent_id: "luna",
+    assistant_name: "Luna",
+    nkey_public_key: "NKEYPUB",
+    principal: "andreas",
+    stack: "meta-factory",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 0,
+    ...over,
+  };
+}
+
+function workingTile(over: Partial<WorkingAgentTile> & { agent_id: string }): WorkingAgentTile {
+  return {
+    agent_name: over.agent_id,
+    agent_type: "head",
+    primary_state_rank: 1,
+    primary_state: "running",
+    primary_assignment: {
+      id: "a1",
+      task_id: "t1",
+      task_title: "primary",
+      task_priority: 1,
+      updated_at: "2026-07-08T00:00:00Z",
+    },
+    additional_active_count: 0,
+    sessions: [],
+    ...over,
+  };
+}
+
+describe("mc-dive — sovereignty classification (isFederatedOrigin)", () => {
+  it("a local origin is own-local (never federated)", () => {
+    expect(isFederatedOrigin("local", "andreas")).toBe(false);
+  });
+
+  it("a same-principal sibling is own-local (DB-read aggregation, not federation)", () => {
+    expect(isFederatedOrigin({ principal: "andreas", stack: "work" }, "andreas")).toBe(
+      false,
+    );
+  });
+
+  it("a cross-principal peer is federated", () => {
+    expect(isFederatedOrigin({ principal: "jc", stack: "research" }, "andreas")).toBe(
+      true,
+    );
+  });
+
+  it("conservatively federated when the serving principal is unknown", () => {
+    expect(isFederatedOrigin({ principal: "jc", stack: "research" }, null)).toBe(true);
+  });
+});
+
+describe("mc-dive — stackCoordFromHub", () => {
+  it("maps a LOCAL hub to an own-local coordinate", () => {
+    expect(stackCoordFromHub(hub({ origin: "local" }), "andreas")).toEqual({
+      principal: "andreas",
+      stack: "meta-factory",
+      federated: false,
+    });
+  });
+
+  it("maps a same-principal sibling hub to own-local", () => {
+    const data = hub({
+      origin: { principal: "andreas", stack: "work" },
+      principal: "andreas",
+      stack: "work",
+    });
+    expect(stackCoordFromHub(data, "andreas")).toEqual({
+      principal: "andreas",
+      stack: "work",
+      federated: false,
+    });
+  });
+
+  it("maps a FOREIGN peer hub to a federated coordinate", () => {
+    const data = hub({
+      origin: { principal: "jc", stack: "research" },
+      principal: "jc",
+      stack: "research",
+    });
+    expect(stackCoordFromHub(data, "andreas")).toEqual({
+      principal: "jc",
+      stack: "research",
+      federated: true,
+    });
+  });
+
+  it("returns null when the hub has no resolvable principal/stack", () => {
+    expect(
+      stackCoordFromHub(hub({ origin: "local", principal: null, stack: null }), "andreas"),
+    ).toBeNull();
+  });
+});
+
+describe("mc-dive — stackCoordFromTile", () => {
+  it("maps a LOCAL agent tile to its own stack (own-local)", () => {
+    expect(stackCoordFromTile(tile({ origin: "local" }), "andreas")).toEqual({
+      principal: "andreas",
+      stack: "meta-factory",
+      federated: false,
+    });
+  });
+
+  it("maps a FOREIGN agent tile to the verified peer stack (federated)", () => {
+    const t = tile({
+      key: "jc/research/atlas",
+      agent_id: "atlas",
+      principal: "jc",
+      stack: "research",
+      origin: { principal: "jc", stack: "research" },
+    });
+    expect(stackCoordFromTile(t, "andreas")).toEqual({
+      principal: "jc",
+      stack: "research",
+      federated: true,
+    });
+  });
+});
+
+describe("mc-dive — sessionTargetsForAssistant", () => {
+  const localCoord = { principal: "andreas", stack: "meta-factory", federated: false };
+
+  it("flattens the session tree (children included), labelling by task_title then id", () => {
+    const w = workingTile({
+      agent_id: "luna",
+      sessions: [
+        {
+          session_id: "s1",
+          parent_session_id: null,
+          substrate: "claude-code",
+          state: "running",
+          started_at: "2026-07-08T00:00:00Z",
+          ended_at: null,
+          task_title: "root task",
+          children: [
+            {
+              session_id: "s2",
+              parent_session_id: "s1",
+              substrate: "claude-code",
+              state: "running",
+              started_at: "2026-07-08T00:01:00Z",
+              ended_at: null,
+              task_title: null,
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+    expect(sessionTargetsForAssistant([w], "luna", localCoord)).toEqual([
+      { id: "s1", label: "root task" },
+      { id: "s2", label: "s2" },
+    ]);
+  });
+
+  it("is empty when the assistant has no working tile", () => {
+    expect(sessionTargetsForAssistant([], "luna", localCoord)).toEqual([]);
+  });
+
+  it("matches a sibling-tagged tile only when the stack matches exactly", () => {
+    const wRight = workingTile({
+      agent_id: "luna",
+      origin: { principal: "andreas", stack: "work" },
+      sessions: [
+        {
+          session_id: "sx",
+          parent_session_id: null,
+          substrate: "claude-code",
+          state: "running",
+          started_at: "2026-07-08T00:00:00Z",
+          ended_at: null,
+          task_title: "sibling work",
+          children: [],
+        },
+      ],
+    });
+    const siblingCoord = { principal: "andreas", stack: "work", federated: false };
+    expect(sessionTargetsForAssistant([wRight], "luna", siblingCoord)).toEqual([
+      { id: "sx", label: "sibling work" },
+    ]);
+    // A different stack coordinate must NOT pick up the sibling's sessions.
+    expect(sessionTargetsForAssistant([wRight], "luna", localCoord)).toEqual([]);
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/mc-shell-model.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-shell-model.test.ts
@@ -12,10 +12,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import type {
-  NetworkMembershipDTO,
-  MembershipMemberDTO,
-} from "../hooks/use-networks";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
 import {
   ALTITUDE_LEVELS,
   ALTITUDE_META,
@@ -25,15 +22,26 @@ import {
   buildBreadcrumb,
   drillToNetwork,
   ascendToRoot,
+  diveToStack,
+  selectAssistant,
+  openSession,
+  ascendToLevel,
+  stackReachesSession,
+  stackLabel,
   navigateToSegment,
   stopReachability,
   type AltitudeSelection,
+  type StackCoord,
 } from "../lib/mc-shell-model";
 
-function member(
-  over: Partial<MembershipMemberDTO> & { principal: string },
-): MembershipMemberDTO {
-  return { verdict: "admitted-present", present_stacks: [], accepts: "not-accepted", ...over };
+/** A dived OWN-LOCAL stack coordinate (SESSION-reachable). */
+function localStack(over: Partial<StackCoord> = {}): StackCoord {
+  return { principal: "andreas", stack: "meta-factory", federated: false, ...over };
+}
+
+/** A dived FEDERATED peer stack coordinate (SESSION-capped at ASSISTANT). */
+function peerStack(over: Partial<StackCoord> = {}): StackCoord {
+  return { principal: "jc", stack: "research", federated: true, ...over };
 }
 
 function net(
@@ -134,10 +142,13 @@ describe("MC-D2 shell model — breadcrumb", () => {
 });
 
 describe("MC-D2 shell model — navigation", () => {
-  it("drillToNetwork sets network level + id", () => {
+  it("drillToNetwork sets network level + id, clearing deeper coords", () => {
     expect(drillToNetwork("meridian")).toEqual({
       level: "network",
       networkId: "meridian",
+      stack: null,
+      assistantId: null,
+      sessionId: null,
     });
   });
 
@@ -173,10 +184,115 @@ describe("MC-D2 shell model — rail stop reachability", () => {
     expect(stopReachability("network", root, 0)).toBe("future");
   });
 
-  it("stack/assistant/session are future stubs in D2", () => {
+  it("stack/assistant/session are future until a stack is dived", () => {
+    // At NETWORK level (no stack dived) the deeper stops have no backing coord.
+    const atNetwork = drillToNetwork("meridian");
     for (const lvl of ["stack", "assistant", "session"] as const) {
-      expect(stopReachability(lvl, root, 9)).toBe("future");
+      expect(stopReachability(lvl, atNetwork, 9)).toBe("future");
     }
+  });
+});
+
+describe("CK-1 shell model — dive-to-stack reachability (data-driven)", () => {
+  it("STACK + ASSISTANT go live once a LOCAL stack is dived", () => {
+    const sel = diveToStack("meridian", localStack());
+    expect(stopReachability("stack", sel, 2)).toBe("current");
+    expect(stopReachability("assistant", sel, 2)).toBe("reachable");
+    // NETWORKS/NETWORK stay reachable above.
+    expect(stopReachability("networks", sel, 2)).toBe("reachable");
+    expect(stopReachability("network", sel, 2)).toBe("reachable");
+  });
+
+  it("STACK + ASSISTANT go live for a FEDERATED peer too (aggregate metadata)", () => {
+    const sel = diveToStack("meridian", peerStack());
+    expect(stopReachability("stack", sel, 2)).toBe("current");
+    expect(stopReachability("assistant", sel, 2)).toBe("reachable");
+  });
+
+  it("SESSION is reachable ONLY on an OWN-LOCAL stack", () => {
+    const local = diveToStack("meridian", localStack());
+    expect(stopReachability("session", local, 2)).toBe("reachable");
+  });
+
+  it("SESSION stays FUTURE for a federated peer — it bottoms out at STACK/ASSISTANT", () => {
+    const peer = diveToStack("meridian", peerStack());
+    expect(stopReachability("session", peer, 2)).toBe("future");
+    // The invariant, stated as the boundary: the deepest reachable federated
+    // stop is ASSISTANT; SESSION (and anything below) is unreachable.
+    expect(stopReachability("assistant", peer, 2)).toBe("reachable");
+    expect(stopReachability("session", peer, 2)).not.toBe("reachable");
+  });
+
+  it("SESSION stays FUTURE when no stack is dived", () => {
+    expect(stopReachability("session", ROOT_SELECTION, 2)).toBe("future");
+    expect(stopReachability("session", drillToNetwork("meridian"), 2)).toBe(
+      "future",
+    );
+  });
+
+  it("stackReachesSession: true for own-local, false for federated/absent", () => {
+    expect(stackReachesSession(localStack())).toBe(true);
+    expect(stackReachesSession(peerStack())).toBe(false);
+    expect(stackReachesSession(null)).toBe(false);
+  });
+});
+
+describe("CK-1 shell model — session gating (openSession)", () => {
+  it("opens a session on an own-local stack", () => {
+    const base = selectAssistant(diveToStack("meridian", localStack()), "luna");
+    const sel = openSession(base, "sess-123");
+    expect(sel).not.toBeNull();
+    expect(sel).toEqual({
+      level: "session",
+      networkId: "meridian",
+      stack: localStack(),
+      assistantId: "luna",
+      sessionId: "sess-123",
+    });
+  });
+
+  it("REFUSES to open a session on a federated peer stack (ADR-0005 defense in depth)", () => {
+    const base = selectAssistant(diveToStack("meridian", peerStack()), "atlas");
+    expect(openSession(base, "sess-xyz")).toBeNull();
+  });
+
+  it("REFUSES to open a session when no stack is dived", () => {
+    expect(openSession(drillToNetwork("meridian"), "sess-xyz")).toBeNull();
+  });
+});
+
+describe("CK-1 shell model — assistant selection + ascend", () => {
+  it("selectAssistant advances to ASSISTANT, preserving the stack, clearing session", () => {
+    const dived = diveToStack("meridian", localStack());
+    const withSession = openSession(
+      selectAssistant(dived, "luna"),
+      "sess-1",
+    )!;
+    // Re-selecting the assistant from the session-level selection clears session.
+    const sel = selectAssistant(withSession, "luna");
+    expect(sel).toEqual({
+      level: "assistant",
+      networkId: "meridian",
+      stack: localStack(),
+      assistantId: "luna",
+      sessionId: null,
+    });
+  });
+
+  it("ascendToLevel truncates every coordinate deeper than the target", () => {
+    const deep = openSession(
+      selectAssistant(diveToStack("meridian", localStack()), "luna"),
+      "sess-1",
+    )!;
+    expect(ascendToLevel(deep, "stack")).toEqual({
+      level: "stack",
+      networkId: "meridian",
+      stack: localStack(),
+      assistantId: null,
+      sessionId: null,
+    });
+    expect(ascendToLevel(deep, "network")).toEqual(drillToNetwork("meridian"));
+    expect(ascendToLevel(deep, "networks")).toEqual(ROOT_SELECTION);
   });
 });
 
@@ -194,5 +310,61 @@ describe("MC-D2 shell model — altitude metadata", () => {
   it("only the NETWORKS root carries an altitude annotation", () => {
     expect(ALTITUDE_META.networks.altLabel).toBe("10k ft");
     expect(ALTITUDE_META.network.altLabel).toBeUndefined();
+  });
+});
+
+describe("CK-1 shell model — deep breadcrumb + stackLabel", () => {
+  it("stackLabel is bare stack for local, principal/stack for federated", () => {
+    expect(stackLabel(localStack())).toBe("meta-factory");
+    expect(stackLabel(peerStack())).toBe("jc/research");
+  });
+
+  it("grows a segment per dived coordinate (network → stack → assistant → session)", () => {
+    const sel = openSession(
+      selectAssistant(diveToStack("meridian", localStack()), "luna"),
+      "sess-1",
+    )!;
+    const crumbs = buildBreadcrumb(sel);
+    expect(crumbs.map((c) => c.level)).toEqual([
+      "networks",
+      "network",
+      "stack",
+      "assistant",
+      "session",
+    ]);
+    expect(crumbs.map((c) => c.label)).toEqual([
+      "NETWORK·OF·NETWORKS",
+      "meridian",
+      "meta-factory",
+      "luna",
+      "sess-1",
+    ]);
+  });
+
+  it("a federated stack segment shows principal/stack and has no session below it", () => {
+    const sel = selectAssistant(diveToStack("meridian", peerStack()), "atlas");
+    const crumbs = buildBreadcrumb(sel);
+    expect(crumbs.map((c) => c.level)).toEqual([
+      "networks",
+      "network",
+      "stack",
+      "assistant",
+    ]);
+    const stackSeg = crumbs.find((c) => c.level === "stack")!;
+    expect(stackSeg.label).toBe("jc/research");
+  });
+
+  it("navigateToSegment round-trips every deep segment back to its exact selection", () => {
+    const sel = openSession(
+      selectAssistant(diveToStack("meridian", localStack()), "luna"),
+      "sess-1",
+    )!;
+    const crumbs = buildBreadcrumb(sel);
+    // Clicking the deepest (session) segment reconstructs the full selection.
+    expect(navigateToSegment(crumbs[crumbs.length - 1]!)).toEqual(sel);
+    // Clicking the stack segment reconstructs the stack-level selection.
+    expect(navigateToSegment(crumbs[2]!)).toEqual(
+      diveToStack("meridian", localStack()),
+    );
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/mc-shell.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-shell.test.tsx
@@ -124,6 +124,7 @@ describe("McAltitudeRail", () => {
         networks: NETWORKS,
         onAscendRoot: () => {},
         onDrillNetwork: () => {},
+        onAscendToLevel: () => {},
       }),
     );
     expect(html).toContain("ALTITUDE");
@@ -143,6 +144,7 @@ describe("McAltitudeRail", () => {
         networks: NETWORKS,
         onAscendRoot: () => {},
         onDrillNetwork: () => {},
+        onAscendToLevel: () => {},
       }),
     );
     for (const lvl of ["stack", "assistant", "session"]) {
@@ -159,6 +161,7 @@ describe("McAltitudeRail", () => {
         networks: NETWORKS,
         onAscendRoot: () => {},
         onDrillNetwork: () => {},
+        onAscendToLevel: () => {},
       }),
     );
     expect(html).toContain('data-network-id="meridian"');
@@ -178,6 +181,7 @@ describe("McAltitudeRail", () => {
         networks: [],
         onAscendRoot: () => {},
         onDrillNetwork: () => {},
+        onAscendToLevel: () => {},
       }),
     );
     expect(html).toMatch(/data-level="network"[^>]*data-reach="future"/);
@@ -192,6 +196,7 @@ describe("McAltitudeRail", () => {
         networks: NETWORKS,
         onAscendRoot: () => {},
         onDrillNetwork: () => {},
+        onAscendToLevel: () => {},
       }),
     );
     expect(html).toMatch(/data-level="network"[^>]*data-reach="current"/);

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -612,6 +612,13 @@ export function App() {
             // lands / on a non-federated stack; the panel renders nothing then.
             networks={networks.networks}
             onViewInWorkingGrid={() => setView("default")}
+            // CK-1 (cortex#1289) — diving the altitude rail to SESSION (an
+            // own-local assistant's session) opens the REUSED F-7 drill-down —
+            // the same App-level overlay attention/work-item flows drive via
+            // `setDrillId`. Own-local only (the Network view's `openSession`
+            // refuses a federated peer, ADR-0005), so no interior crosses the
+            // sovereignty boundary.
+            onOpenSession={(sessionId) => setDrillId(sessionId)}
             // G-1114.F.3 — dispatch-direct to a LOCAL agent, REUSING the
             // existing dispatch path (`POST /api/sessions` with `agentId`). The
             // panel only invokes this for a local agent (foreign peers get a

--- a/src/surface/mc/dashboard-v2/components/mc-altitude-rail.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-altitude-rail.tsx
@@ -1,16 +1,20 @@
 /**
- * MC-D2 (cortex#1289) — the constellation skin's **altitude rail** (left chrome).
+ * MC-D2 (cortex#1289) / CK-1 (cortex#1289) — the constellation skin's **altitude
+ * rail** (left chrome).
  *
  * The primary navigation gesture: a vertical spine of altitude stops —
  * NETWORKS (10k ft) → NETWORK → STACK → ASSISTANT → SESSION — with the current
- * level lit. D2 wires the top two against real data; the deeper three are honest
- * `future` stubs (dimmed, non-interactive) that D3+ deepens as it re-skins the
- * canvas.
+ * level lit. D2 wired the top two; CK-1 makes the whole spine live: diving into a
+ * constellation stack lights STACK/ASSISTANT, and — on an OWN-LOCAL stack only —
+ * the selected assistant's sessions expand as SESSION drill targets that open the
+ * reused F-7 drill-down interior. A FEDERATED peer bottoms out at STACK/ASSISTANT
+ * (SESSION stays a disabled `future` stub) — the ADR-0005 sovereignty boundary,
+ * rendered.
  *
- * The NETWORK stop, when reachable, expands the joined networks as drill targets:
- * click a network → drill in (NETWORKS → NETWORK); the lit NETWORKS stop ascends
- * back to the 10k-ft root. That makes NETWORKS ↔ NETWORK genuinely navigable with
- * the live `/api/networks` data — never a fabricated drill.
+ * The NETWORK stop expands the joined networks as drill targets; a reachable
+ * higher stop ascends to that level. Everything is backed by real coordinates on
+ * the selection — a stop is only interactive when `stopReachability` says so, so
+ * the rail never fabricates a drill.
  *
  * Presentation-only: reachability + posture are computed by `mc-shell-model`.
  */
@@ -19,10 +23,20 @@ import {
   ALTITUDE_LEVELS,
   ALTITUDE_META,
   networkPosture,
+  stackReachesSession,
   stopReachability,
+  type AltitudeLevel,
   type AltitudeSelection,
 } from "../lib/mc-shell-model";
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
+
+/** One SESSION drill target under the ASSISTANT stop (own-local sessions only). */
+export interface RailSessionTarget {
+  /** The session id (keys the reused drill-down interior). */
+  id: string;
+  /** Short label rendered on the rail. */
+  label: string;
+}
 
 export interface McAltitudeRailProps {
   /** The current you-are-here selection. */
@@ -33,6 +47,23 @@ export interface McAltitudeRailProps {
   onAscendRoot: () => void;
   /** Drill into a specific network (networks → network). */
   onDrillNetwork: (networkId: string) => void;
+  /**
+   * CK-1 — ascend to a reachable ancestor stop (network/stack/assistant/session),
+   * truncating deeper coordinates. The shell maps this through `ascendToLevel`.
+   */
+  onAscendToLevel: (level: AltitudeLevel) => void;
+  /**
+   * CK-1 — the selected LOCAL assistant's sessions, expanded under the ASSISTANT
+   * stop as SESSION drill targets. Empty for a federated peer (SESSION is capped)
+   * or when no assistant is selected — the rail renders none in that case.
+   */
+  sessionTargets?: readonly RailSessionTarget[];
+  /**
+   * CK-1 — open a session interior. Dives the rail to SESSION and mounts the
+   * reused F-7 drill-down (wired by the caller). Only ever called for an
+   * own-local session (ADR-0005).
+   */
+  onOpenSession?: (sessionId: string) => void;
 }
 
 export function McAltitudeRail({
@@ -40,6 +71,9 @@ export function McAltitudeRail({
   networks,
   onAscendRoot,
   onDrillNetwork,
+  onAscendToLevel,
+  sessionTargets = [],
+  onOpenSession,
 }: McAltitudeRailProps) {
   const networkCount = networks.length;
 
@@ -52,12 +86,33 @@ export function McAltitudeRail({
           const reach = stopReachability(level, selection, networkCount);
           const isFuture = reach === "future";
           const isCurrent = reach === "current";
+          const isReachable = reach === "reachable";
 
-          // The NETWORKS stop ascends to root; deeper interactive stops are
-          // reached by drilling (the NETWORK stop's children). Only NETWORKS is
-          // directly clickable as a stop in D2.
-          const onClick =
-            level === "networks" && !isCurrent ? onAscendRoot : undefined;
+          // Click behaviour is data-driven off reachability:
+          //   - NETWORKS  → ascend to the 10k-ft root;
+          //   - NETWORK   → ascend to the drilled network (only when one is
+          //     selected; otherwise the stop's children are the drill targets);
+          //   - STACK/ASSISTANT/SESSION → ascend to that reachable stop.
+          // A `future` or `current` stop is inert (children carry the forward
+          // drill). This never fabricates a target — `isReachable` gates it.
+          let onClick: (() => void) | undefined;
+          if (isReachable) {
+            if (level === "networks") onClick = onAscendRoot;
+            else if (level === "network") {
+              onClick =
+                selection.networkId !== null
+                  ? () => onAscendToLevel("network")
+                  : undefined;
+            } else onClick = () => onAscendToLevel(level);
+          }
+
+          // Only genuinely-future deeper stops carry the "not yet" copy. SESSION
+          // on a federated peer is the load-bearing case: it's `future` BY the
+          // sovereignty boundary, not because it's unbuilt — say so honestly.
+          const futureTitle =
+            level === "session" && selection.stack !== null
+              ? "SESSION — own-local stacks only; a federated peer bottoms out at ASSISTANT"
+              : `${meta.label} — dive into a stack to reach this level`;
 
           return (
             <li
@@ -79,16 +134,8 @@ export function McAltitudeRail({
                 // A disabled future stub is removed from the tab order, so its
                 // explanatory `title` is unreachable to AT — carry the same
                 // information on an always-announced `aria-label` instead.
-                aria-label={
-                  isFuture
-                    ? `${meta.label} — future level, arrives with the canvas re-skin`
-                    : undefined
-                }
-                title={
-                  isFuture
-                    ? `${meta.label} — drill arrives with the canvas re-skin`
-                    : undefined
-                }
+                aria-label={isFuture ? futureTitle : undefined}
+                title={isFuture ? futureTitle : undefined}
               >
                 <span className="mc-rail-dot" aria-hidden="true" />
                 <span className="mc-rail-stop-labels">
@@ -133,6 +180,37 @@ export function McAltitudeRail({
                   })}
                 </ul>
               )}
+
+              {/* CK-1 — SESSION drill targets under the ASSISTANT stop, for the
+                  selected OWN-LOCAL assistant only. Renders nothing for a
+                  federated peer (`stackReachesSession` false) — the boundary. */}
+              {level === "assistant" &&
+                stackReachesSession(selection.stack) &&
+                sessionTargets.length > 0 && (
+                  <ul className="mc-rail-sessions">
+                    {sessionTargets.map((s) => {
+                      const active = selection.sessionId === s.id;
+                      return (
+                        <li key={s.id} className="mc-rail-session">
+                          <button
+                            type="button"
+                            className={
+                              "mc-rail-session-btn" +
+                              (active ? " mc-rail-session-btn--active" : "")
+                            }
+                            data-session-id={s.id}
+                            aria-current={active ? "true" : undefined}
+                            onClick={() => onOpenSession?.(s.id)}
+                          >
+                            <span className="mc-rail-session-name">
+                              {s.label}
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
             </li>
           );
         })}

--- a/src/surface/mc/dashboard-v2/components/mc-shell.css
+++ b/src/surface/mc/dashboard-v2/components/mc-shell.css
@@ -340,6 +340,44 @@
   color: var(--tide);
 }
 
+/* CK-1 — SESSION drill targets under the ASSISTANT stop (own-local only). Mirror
+   the network drill list, one indent deeper. */
+.mc-rail-sessions {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0 0 0 22px;
+}
+.mc-rail-session {
+  margin-bottom: 4px;
+}
+.mc-rail-session-btn {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  padding: 3px 6px;
+  cursor: pointer;
+}
+.mc-rail-session-btn:hover {
+  background: color-mix(in oklch, var(--fg) 6%, transparent);
+}
+.mc-rail-session-btn--active {
+  border-color: color-mix(in oklch, var(--mer) 45%, transparent);
+  background: color-mix(in oklch, var(--mer) 10%, transparent);
+}
+.mc-rail-session-name {
+  font: 500 10px var(--mono);
+  color: var(--dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mc-rail-session-btn--active .mc-rail-session-name {
+  color: var(--fg);
+}
+
 .mc-rail-dive {
   text-align: center;
   font: 600 8px var(--mono);

--- a/src/surface/mc/dashboard-v2/components/mc-shell.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-shell.tsx
@@ -18,12 +18,13 @@
 
 import type { ReactNode } from "react";
 import { McCommandBar } from "./mc-command-bar";
-import { McAltitudeRail } from "./mc-altitude-rail";
+import { McAltitudeRail, type RailSessionTarget } from "./mc-altitude-rail";
 import {
   buildBreadcrumb,
   drillToNetwork,
   navigateToSegment,
   ascendToRoot,
+  ascendToLevel,
   selectedNetworkPosture,
   type AltitudeSelection,
 } from "../lib/mc-shell-model";
@@ -39,6 +40,18 @@ export interface McShellProps {
   selection: AltitudeSelection;
   /** Report a new selection from a chrome navigation gesture. */
   onSelectionChange: (next: AltitudeSelection) => void;
+  /**
+   * CK-1 — the selected LOCAL assistant's sessions, forwarded to the rail as
+   * SESSION drill targets (own-local only; empty for a federated peer). The
+   * caller (Network view) derives these from the working-agents session tree.
+   */
+  sessionTargets?: readonly RailSessionTarget[];
+  /**
+   * CK-1 — open a session interior (reuses the App-level F-7 drill-down). The
+   * caller wires this to the existing drill overlay; the shell only reports the
+   * chosen session id and dives the rail to SESSION.
+   */
+  onOpenSession?: (sessionId: string) => void;
   /** The framed pane (the existing Network view body). */
   children: ReactNode;
 }
@@ -48,6 +61,8 @@ export function McShell({
   networks,
   selection,
   onSelectionChange,
+  sessionTargets = [],
+  onOpenSession,
   children,
 }: McShellProps) {
   const breadcrumb = buildBreadcrumb(selection);
@@ -68,6 +83,11 @@ export function McShell({
           networks={networks}
           onAscendRoot={() => onSelectionChange(ascendToRoot())}
           onDrillNetwork={(id) => onSelectionChange(drillToNetwork(id))}
+          onAscendToLevel={(level) =>
+            onSelectionChange(ascendToLevel(selection, level))
+          }
+          sessionTargets={sessionTargets}
+          {...(onOpenSession ? { onOpenSession } : {})}
         />
         <div className="mc-shell-content">{children}</div>
       </div>

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -79,13 +79,51 @@ import { NetworkSpotlight } from "./network-spotlight";
 import { NetworkRosterPanel } from "./network-roster-panel";
 import { PierQueue } from "./pier-queue";
 import { McShell } from "./mc-shell";
-import { ROOT_SELECTION, type AltitudeSelection } from "../lib/mc-shell-model";
+import {
+  ROOT_SELECTION,
+  diveToStack,
+  selectAssistant,
+  openSession,
+  drillToNetwork,
+  stackReachesSession,
+  type AltitudeSelection,
+} from "../lib/mc-shell-model";
+import {
+  stackCoordFromHub,
+  stackCoordFromTile,
+  sessionTargetsForAssistant,
+} from "../lib/mc-dive";
+import type { NetworkGraph } from "../lib/network-graph-adapter";
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
 
 // Lazy: the xyflow + elk engine chunk loads only when this resolves (first
 // entry into the Network tab). Keep this the ONLY dynamic import in the view —
 // the other dashboard views stay statically bundled.
 const NetworkCanvas = lazy(() => import("./network-canvas"));
+
+/**
+ * CK-1 — derive the next altitude selection from a constellation hub click. A
+ * selected hub dives to that stack; a cleared selection (`hubId === null`)
+ * ascends to the current network context (or the 10k-ft root). An unresolvable
+ * hub leaves the altitude untouched — never a fabricated dive.
+ */
+function diveFromHub(
+  hubId: string | null,
+  graph: NetworkGraph,
+  servingPrincipal: string | null,
+  prevShell: AltitudeSelection,
+): AltitudeSelection {
+  if (hubId === null) {
+    return prevShell.networkId !== null
+      ? drillToNetwork(prevShell.networkId)
+      : ROOT_SELECTION;
+  }
+  const node = graph.nodes.find((n) => n.id === hubId);
+  if (!node || node.data.kind !== "stack-hub") return prevShell;
+  const coord = stackCoordFromHub(node.data, servingPrincipal);
+  if (coord === null) return prevShell;
+  return diveToStack(prevShell.networkId, coord);
+}
 
 export interface NetworkViewProps {
   state: AgentsState;
@@ -137,6 +175,16 @@ export interface NetworkViewProps {
    * roster panel renders nothing (a non-federated stack is unchanged).
    */
   networks?: readonly NetworkMembershipDTO[];
+  /**
+   * CK-1 (cortex#1289) — open a session interior on an OWN-LOCAL stack. When the
+   * principal dives the altitude rail to SESSION (picking one of a local
+   * assistant's sessions), the Network view calls this so the App mounts the
+   * REUSED F-7 drill-down overlay (App owns `setDrillId`). Never called for a
+   * federated peer (ADR-0005 — `openSession` refuses one). Omitted → the SESSION
+   * targets still dive the rail, but no interior mounts (a host without the drill
+   * wired, e.g. a test harness).
+   */
+  onOpenSession?: (sessionId: string) => void;
 }
 
 export function NetworkView({
@@ -148,6 +196,7 @@ export function NetworkView({
   matchTasks = [],
   transportRoster = [],
   networks = [],
+  onOpenSession,
 }: NetworkViewProps) {
   const mode = pickAgentsPanelMode(state);
 
@@ -236,10 +285,30 @@ export function NetworkView({
   const [selection, setSelection] = useState<SubtreeSelection>(
     EMPTY_SUBTREE_SELECTION,
   );
+
+  // CK-1 (cortex#1289) — the constellation shell-chrome selection (you-are-here).
+  // Owned here so the command-bar breadcrumb, the altitude rail, AND the dive
+  // gestures below all read/write ONE source. Declared before the hub/agent
+  // handlers so they can dive it; the network-dropout guard lives just below.
+  const [shellSelection, setShellSelection] =
+    useState<AltitudeSelection>(ROOT_SELECTION);
+
   const onToggleHubSelection = useCallback(
-    (clickedHubId: string | null) =>
-      setSelection((prev) => computeToggleHubSelection(prev, clickedHubId, graph)),
-    [graph],
+    (clickedHubId: string | null) => {
+      const nextSubtree = computeToggleHubSelection(
+        selection,
+        clickedHubId,
+        graph,
+      );
+      setSelection(nextSubtree);
+      // CK-1 — reflect the hub click on the altitude rail: a selected hub dives
+      // to that stack; a cleared selection ascends to the network context.
+      // Derived from the RESULTING subtree hub so highlight + altitude agree.
+      setShellSelection((prevShell) =>
+        diveFromHub(nextSubtree.selectedHubId, graph, servingPrincipal, prevShell),
+      );
+    },
+    [selection, graph, servingPrincipal],
   );
   // Re-derive the highlight set when the graph changes while a hub is selected
   // (an agent popped in/out of that stack), and clear a selection whose hub no
@@ -323,15 +392,38 @@ export function NetworkView({
 
   const closePanel = useCallback(() => setSelectedKey(null), []);
 
+  // CK-1 — selecting an agent node ALSO advances the altitude rail to ASSISTANT
+  // for that agent's stack (diving to the stack first if needed), so STACK +
+  // ASSISTANT go live and the rail can expand the assistant's own-local sessions.
+  // Wraps the D.4 panel selection; `key === null` (canvas deselect) leaves the
+  // altitude where it is (the hub-toggle owns ascent).
+  const onSelectAgentNode = useCallback(
+    (key: string | null) => {
+      setSelectedKey(key);
+      if (key === null) return;
+      const tile = resolveSelectedAgent(state.agents, key);
+      if (!tile) return;
+      const coord = stackCoordFromTile(tile, servingPrincipal);
+      setShellSelection((prev) =>
+        selectAssistant(diveToStack(prev.networkId, coord), tile.agent_id),
+      );
+    },
+    [state.agents, servingPrincipal],
+  );
+
   // D.5 — Cmd+K spotlight. Open state is local to the Network view (the spotlight
   // only makes sense here), and selecting a hit reuses D.4's selection path.
   const [spotlightOpen, setSpotlightOpen] = useState(false);
   const openSpotlight = useCallback(() => setSpotlightOpen(true), []);
   const closeSpotlight = useCallback(() => setSpotlightOpen(false), []);
-  const onSpotlightSelect = useCallback((key: string) => {
-    // Reuse D.4's selection: set the key → the live tile resolves → panel opens.
-    setSelectedKey(key);
-  }, []);
+  const onSpotlightSelect = useCallback(
+    (key: string) => {
+      // Reuse D.4's selection (now altitude-aware): live tile resolves → panel
+      // opens AND the rail advances to that agent's ASSISTANT stop.
+      onSelectAgentNode(key);
+    },
+    [onSelectAgentNode],
+  );
 
   // Cmd+K / Ctrl+K opens the spotlight. Registered on the CAPTURE phase so it
   // runs BEFORE the app-level global ⌘K palette (a bubble-phase listener) and
@@ -369,14 +461,10 @@ export function NetworkView({
     return () => window.removeEventListener("keydown", onKey);
   }, [selectedKey, spotlightOpen, closePanel]);
 
-  // MC-D2 (#1289) — the constellation shell-chrome selection (you-are-here).
-  // Owned here so BOTH the command-bar breadcrumb and the altitude rail read one
-  // source. D2 wires networks↔network; deeper levels are scaffolding (D3+).
-  const [shellSelection, setShellSelection] =
-    useState<AltitudeSelection>(ROOT_SELECTION);
   // If the drilled-into network drops out of the live `/api/networks` snapshot,
   // ascend back to the 10k-ft root rather than holding a stale selection (the
   // breadcrumb/posture would otherwise point at a network that no longer exists).
+  // This clears any dived stack/assistant/session below it too (ROOT_SELECTION).
   useEffect(() => {
     if (
       shellSelection.networkId !== null &&
@@ -386,12 +474,43 @@ export function NetworkView({
     }
   }, [networks, shellSelection.networkId]);
 
+  // CK-1 — the selected LOCAL assistant's sessions, expanded on the rail as
+  // SESSION drill targets. Own-local only (ADR-0005): empty for a federated peer
+  // (`stackReachesSession` false) or when no assistant is selected.
+  const sessionTargets = useMemo(() => {
+    if (
+      shellSelection.assistantId === null ||
+      shellSelection.stack === null ||
+      !stackReachesSession(shellSelection.stack)
+    ) {
+      return [];
+    }
+    return sessionTargetsForAssistant(
+      workingAgents,
+      shellSelection.assistantId,
+      shellSelection.stack,
+    );
+  }, [workingAgents, shellSelection.assistantId, shellSelection.stack]);
+
+  // CK-1 — open a session interior: dive the rail to SESSION (own-local only —
+  // `openSession` refuses a federated stack) and mount the REUSED App-level F-7
+  // drill-down via the host callback.
+  const handleOpenSession = useCallback(
+    (sessionId: string) => {
+      setShellSelection((prev) => openSession(prev, sessionId) ?? prev);
+      onOpenSession?.(sessionId);
+    },
+    [onOpenSession],
+  );
+
   return (
     <McShell
       principal={servingPrincipal}
       networks={networks}
       selection={shellSelection}
       onSelectionChange={setShellSelection}
+      sessionTargets={sessionTargets}
+      onOpenSession={handleOpenSession}
     >
     <section className="scaffold-section network-view" aria-label="Network (agent topology)">
       <h2>Network</h2>
@@ -451,7 +570,7 @@ export function NetworkView({
               >
                 <NetworkCanvas
                   graph={graph}
-                  onSelectAgent={setSelectedKey}
+                  onSelectAgent={onSelectAgentNode}
                   hover={hover}
                 />
               </Suspense>

--- a/src/surface/mc/dashboard-v2/lib/mc-dive.ts
+++ b/src/surface/mc/dashboard-v2/lib/mc-dive.ts
@@ -1,0 +1,115 @@
+/**
+ * CK-1 (cortex#1289) — map a constellation click to an altitude coordinate.
+ *
+ * The Network view's canvas speaks in stack-hub nodes and agent tiles; the
+ * altitude rail speaks in {@link StackCoord}s + session ids. This pure, DOM-free
+ * module bridges the two so the two derivations that MOST need pinning — the
+ * sovereignty bit (own-local vs federated) and the own-local session list — are
+ * unit-testable without mounting the canvas.
+ *
+ * The federated bit is derived with the SAME `classifyOrigin`/`isLocalCategory`
+ * the node cards + graph edges use, so "federated" means one thing everywhere:
+ * self + same-principal sibling ⇒ own-local (`false`); a cross-principal peer ⇒
+ * federated (`true`). SESSION altitude keys off it (ADR-0005).
+ */
+
+import type { AgentPresenceTile, AgentOrigin } from "../hooks/use-agents";
+import type {
+  SessionTreeNode,
+  WorkingAgentTile,
+} from "../hooks/use-working-agents";
+import type { StackHubNodeData } from "./network-graph-adapter";
+import { classifyOrigin, isLocalCategory } from "./agents-display";
+import type { StackCoord } from "./mc-shell-model";
+
+/**
+ * Whether an origin is a FEDERATED peer (`true`) or OWN-LOCAL (`false`). Own-local
+ * covers the serving stack (self) AND same-principal siblings (DB-read
+ * aggregation) — both stay this side of the ADR-0005 boundary.
+ */
+export function isFederatedOrigin(
+  origin: AgentOrigin,
+  servingPrincipal: string | null,
+): boolean {
+  return !isLocalCategory(classifyOrigin(origin, servingPrincipal));
+}
+
+/** The `{principal}/{stack}` an origin resolves to (mirrors the hub-grouping key). */
+function originScope(
+  origin: AgentOrigin,
+  fallbackPrincipal: string,
+  fallbackStack: string,
+): { principal: string; stack: string } {
+  return origin === "local"
+    ? { principal: fallbackPrincipal, stack: fallbackStack }
+    : { principal: origin.principal, stack: origin.stack };
+}
+
+/**
+ * A clicked stack-hub → its altitude {@link StackCoord}, or `null` when the hub
+ * carries no resolvable `{principal}/{stack}` (e.g. a foreign-only snapshot's
+ * local hub) — the caller then declines to dive rather than fabricate one.
+ */
+export function stackCoordFromHub(
+  data: StackHubNodeData,
+  servingPrincipal: string | null,
+): StackCoord | null {
+  if (data.principal === null || data.stack === null) return null;
+  return {
+    principal: data.principal,
+    stack: data.stack,
+    federated: isFederatedOrigin(data.origin, servingPrincipal),
+  };
+}
+
+/** A clicked agent tile → its owning stack's altitude {@link StackCoord}. */
+export function stackCoordFromTile(
+  tile: AgentPresenceTile,
+  servingPrincipal: string | null,
+): StackCoord {
+  const scope = originScope(tile.origin, tile.principal, tile.stack);
+  return {
+    principal: scope.principal,
+    stack: scope.stack,
+    federated: isFederatedOrigin(tile.origin, servingPrincipal),
+  };
+}
+
+/** Does a working tile belong to the given (own-local) stack? */
+function tileMatchesStack(tile: WorkingAgentTile, stack: StackCoord): boolean {
+  const origin = tile.origin ?? "local";
+  // A `"local"`-origin tile is the SERVING stack's own projection — own-local by
+  // construction. A sibling-tagged tile must match the dived stack exactly.
+  if (origin === "local") return true;
+  return origin.principal === stack.principal && origin.stack === stack.stack;
+}
+
+/**
+ * Flatten a selected OWN-LOCAL assistant's session tree into rail SESSION drill
+ * targets (id + short label). Lifecycle metadata only (ADR-0005) — never an
+ * interior. Empty when the assistant has no working tile on this stack.
+ *
+ * Scope note (CK-1): the working projection covers the SERVING stack (and, post
+ * #1008/#1065, sibling-tagged tiles). A same-principal sibling stack whose
+ * sessions aren't in this projection yields an honest empty list; cross-stack
+ * session aggregation is CK-4a's schema-origin work, not fabricated here.
+ */
+export function sessionTargetsForAssistant(
+  workingAgents: readonly WorkingAgentTile[],
+  assistantId: string,
+  stack: StackCoord,
+): { id: string; label: string }[] {
+  const tile = workingAgents.find(
+    (w) => w.agent_id === assistantId && tileMatchesStack(w, stack),
+  );
+  if (!tile) return [];
+  const out: { id: string; label: string }[] = [];
+  const walk = (nodes: readonly SessionTreeNode[]): void => {
+    for (const n of nodes) {
+      out.push({ id: n.session_id, label: n.task_title ?? n.session_id });
+      if (n.children.length > 0) walk(n.children);
+    }
+  };
+  walk(tile.sessions);
+  return out;
+}

--- a/src/surface/mc/dashboard-v2/lib/mc-shell-model.ts
+++ b/src/surface/mc/dashboard-v2/lib/mc-shell-model.ts
@@ -21,24 +21,31 @@
  * network is admin-posture iff its admin-authoritative (`complete`) admission-rows
  * read succeeded. We reuse `isAdminPosture` so the two surfaces can never drift.
  *
- * ## D2 scope — networks ↔ network works; deeper levels are scaffolding
+ * ## CK-1 scope — the rail is live below NETWORK (dive-to-stack)
  *
  * The altitude rail names five levels (NETWORKS → NETWORK → STACK → ASSISTANT →
- * SESSION). D2 wires the top two against real data (drill into a joined network,
- * ascend to the 10k-ft root); STACK/ASSISTANT/SESSION are honest `future` stubs
- * D3+ will deepen as it re-skins the canvas. No fabricated drill state.
+ * SESSION). D2 wired only the top two; CK-1 makes the whole spine data-driven.
+ * The selection now carries the drilled-into stack (a {@link StackCoord}), the
+ * selected assistant, and the opened session, so `stopReachability` classifies
+ * every stop from real state instead of returning a blanket `future`. Diving
+ * into a constellation stack lights STACK/ASSISTANT; selecting one of a local
+ * assistant's sessions lights SESSION and opens the reused F-7 drill-down as the
+ * interior. No fabricated drill state — a stop is `reachable` only when the
+ * coordinate that backs it is actually present.
  *
- * ## Sovereignty boundary — SESSION granularity is LOCAL-ONLY (extends ADR-0005)
+ * ## Sovereignty boundary — SESSION granularity is LOCAL-ONLY (ADR-0005)
  *
- * The SESSION level applies ONLY to the principal's OWN (local) stacks. Across
- * the federation boundary a peer principal's stacks expose AGGREGATED metadata at
+ * The SESSION level applies ONLY to the principal's OWN (local) stacks — the
+ * serving stack and same-principal siblings (DB-read aggregation). Across the
+ * federation boundary a peer principal's stacks expose AGGREGATED metadata at
  * best (presence, capability catalog, health, counts like "N active sessions") —
- * never individual sessions or interiors. So for a federated peer the deepest
+ * never individual sessions or interiors. So for a FEDERATED peer the deepest
  * reachable level is STACK/ASSISTANT (aggregate); SESSION is unreachable by
- * construction. The boundary is a feature, not a gap. D2 keeps STACK/ASSISTANT/
- * SESSION as inert `future` stubs (no peer-session drill is implied); the real
- * drill-depth enforcement lands in D3/D4, which MUST honour this rule. When D3+
- * adds the federated-vs-local coordinate to the selection, gate SESSION on it.
+ * construction. The boundary is a feature, not a gap. CK-1 carries the
+ * federated-vs-local bit on the selection's {@link StackCoord} (`federated`) and
+ * gates SESSION on it — `stopReachability('session', …)` is `future` for a
+ * federated stack, and `openSession` refuses one (defense in depth). Tests pin
+ * that a federated peer bottoms out at STACK/ASSISTANT.
  */
 
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
@@ -80,20 +87,55 @@ export const ALTITUDE_META: Record<AltitudeLevel, AltitudeStopMeta> = {
 };
 
 /**
- * The current you-are-here selection. D2 wires `networks` ↔ `network`; the
- * deeper levels carry no extra coordinates yet (D3+ adds stack/assistant/session
- * ids as it deepens the drill).
+ * A dived-into stack coordinate — the identity of ONE stack in the constellation
+ * (STACK level and deeper). Carries the sovereignty bit the SESSION gate keys on.
+ */
+export interface StackCoord {
+  /** The `{principal}` that owns the stack. */
+  principal: string;
+  /** The `{stack}` id within that principal. */
+  stack: string;
+  /**
+   * Sovereignty coordinate (ADR-0005). `false` for the serving principal's
+   * OWN-LOCAL stacks — its own stack AND same-principal siblings (DB-read
+   * aggregation, not federation). `true` for a CROSS-PRINCIPAL federated peer.
+   * SESSION altitude is reachable ONLY when `federated === false`; a federated
+   * peer bottoms out at STACK/ASSISTANT (aggregate metadata), never
+   * SESSION/ENVELOPE. Derive it from `classifyOrigin`/`isLocalCategory` at the
+   * call site (self + sibling ⇒ local ⇒ `false`; foreign ⇒ `true`).
+   */
+  federated: boolean;
+}
+
+/**
+ * The current you-are-here selection. `networks` ↔ `network` carry only the
+ * network id; CK-1 adds the deeper coordinates — the drilled-into `stack`, the
+ * selected `assistantId`, and the opened `sessionId` — so the whole rail is
+ * data-driven and the reused drill-down interior can be keyed off `sessionId`.
+ * Coordinates are `null` above the level that owns them.
  */
 export interface AltitudeSelection {
   level: AltitudeLevel;
   /** The drilled-into network id, or `null` at the networks (10k-ft) root. */
   networkId: string | null;
+  /** The dived-into stack (STACK level and deeper), or `null` above STACK. */
+  stack: StackCoord | null;
+  /** The selected assistant/agent id (ASSISTANT level and deeper), or `null`. */
+  assistantId: string | null;
+  /**
+   * The opened session id (SESSION level), or `null`. Keys the reused F-7
+   * drill-down interior. Only ever set on an OWN-LOCAL stack (ADR-0005).
+   */
+  sessionId: string | null;
 }
 
 /** The 10k-ft root — the networks level with no network selected. */
 export const ROOT_SELECTION: AltitudeSelection = {
   level: "networks",
   networkId: null,
+  stack: null,
+  assistantId: null,
+  sessionId: null,
 };
 
 /** Network posture toward a given network — per-network, never global. */
@@ -126,7 +168,20 @@ export function selectedNetworkPosture(
   return net ? networkPosture(net) : null;
 }
 
-/** One you-are-here breadcrumb segment (clickable to navigate back to it). */
+/**
+ * The rail/breadcrumb label for a dived stack: bare `{stack}` for an OWN-LOCAL
+ * stack, `{principal}/{stack}` for a federated peer (so the foreign provenance is
+ * always visible where it matters). Mirrors the node-card provenance convention.
+ */
+export function stackLabel(stack: StackCoord): string {
+  return stack.federated ? `${stack.principal}/${stack.stack}` : stack.stack;
+}
+
+/**
+ * One you-are-here breadcrumb segment (clickable to navigate back to it). Each
+ * segment carries the full coordinate set for its level so a click can
+ * reconstruct the exact selection (see {@link navigateToSegment}).
+ */
 export interface BreadcrumbSegment {
   /** The text shown for this segment. */
   label: string;
@@ -134,32 +189,85 @@ export interface BreadcrumbSegment {
   level: AltitudeLevel;
   /** The network this segment scopes to (`null` for the root segment). */
   networkId: string | null;
+  /** The dived stack for STACK+ segments; `null` above STACK. */
+  stack: StackCoord | null;
+  /** The assistant id for ASSISTANT+ segments; `null` above ASSISTANT. */
+  assistantId: string | null;
+  /** The session id for the SESSION segment; `null` above SESSION. */
+  sessionId: string | null;
 }
 
 /**
  * Build the you-are-here breadcrumb from the current selection. The root
- * (`NETWORK·OF·NETWORKS`) is always present; a drilled-into network appends a
- * second segment. Deeper levels append further segments in D3+.
+ * (`NETWORK·OF·NETWORKS`) is always present; each drilled-into coordinate appends
+ * a further segment (network → stack → assistant → session), so the breadcrumb
+ * grows exactly as deep as the selection.
  */
 export function buildBreadcrumb(
   selection: AltitudeSelection,
 ): BreadcrumbSegment[] {
   const segments: BreadcrumbSegment[] = [
-    { label: "NETWORK·OF·NETWORKS", level: "networks", networkId: null },
+    {
+      label: "NETWORK·OF·NETWORKS",
+      level: "networks",
+      networkId: null,
+      stack: null,
+      assistantId: null,
+      sessionId: null,
+    },
   ];
   if (selection.networkId !== null) {
     segments.push({
       label: selection.networkId,
       level: "network",
       networkId: selection.networkId,
+      stack: null,
+      assistantId: null,
+      sessionId: null,
+    });
+  }
+  if (selection.stack !== null) {
+    segments.push({
+      label: stackLabel(selection.stack),
+      level: "stack",
+      networkId: selection.networkId,
+      stack: selection.stack,
+      assistantId: null,
+      sessionId: null,
+    });
+  }
+  if (selection.assistantId !== null) {
+    segments.push({
+      label: selection.assistantId,
+      level: "assistant",
+      networkId: selection.networkId,
+      stack: selection.stack,
+      assistantId: selection.assistantId,
+      sessionId: null,
+    });
+  }
+  if (selection.sessionId !== null) {
+    segments.push({
+      label: selection.sessionId,
+      level: "session",
+      networkId: selection.networkId,
+      stack: selection.stack,
+      assistantId: selection.assistantId,
+      sessionId: selection.sessionId,
     });
   }
   return segments;
 }
 
-/** Drill into a specific network (networks → network). */
+/** Drill into a specific network (networks → network). Clears deeper coords. */
 export function drillToNetwork(networkId: string): AltitudeSelection {
-  return { level: "network", networkId };
+  return {
+    level: "network",
+    networkId,
+    stack: null,
+    assistantId: null,
+    sessionId: null,
+  };
 }
 
 /** Ascend back to the 10k-ft networks root. */
@@ -168,35 +276,131 @@ export function ascendToRoot(): AltitudeSelection {
 }
 
 /**
- * Resolve a breadcrumb-segment click into the next selection. The root segment
- * ascends to the 10k-ft view; a network segment re-selects that network.
+ * Dive from the constellation into one of its stacks (NETWORK → STACK) — the
+ * CK-1 dive-to-stack gesture. Carries the current network context and the stack
+ * coordinate (incl. the federated bit); clears assistant/session below it.
+ */
+export function diveToStack(
+  networkId: string | null,
+  stack: StackCoord,
+): AltitudeSelection {
+  return {
+    level: "stack",
+    networkId,
+    stack,
+    assistantId: null,
+    sessionId: null,
+  };
+}
+
+/**
+ * Select an assistant within the dived stack (STACK → ASSISTANT). Preserves the
+ * stack coordinate; clears any opened session below it. A no-op-safe builder: it
+ * keeps whatever `stack` the base selection carries (may be `null` if the caller
+ * hasn't dived — the rail only offers this when a stack is present).
+ */
+export function selectAssistant(
+  base: AltitudeSelection,
+  assistantId: string,
+): AltitudeSelection {
+  return {
+    level: "assistant",
+    networkId: base.networkId,
+    stack: base.stack,
+    assistantId,
+    sessionId: null,
+  };
+}
+
+/**
+ * Open a session interior on an OWN-LOCAL stack (ASSISTANT → SESSION), keying the
+ * reused F-7 drill-down. Returns `null` when the base stack is absent or
+ * FEDERATED — SESSION is unreachable across the federation boundary by
+ * construction (ADR-0005), so the model refuses to fabricate it. This is defense
+ * in depth alongside `stopReachability`; callers should also gate the affordance
+ * on `stackReachesSession`.
+ */
+export function openSession(
+  base: AltitudeSelection,
+  sessionId: string,
+): AltitudeSelection | null {
+  if (base.stack === null || base.stack.federated) return null;
+  return {
+    level: "session",
+    networkId: base.networkId,
+    stack: base.stack,
+    assistantId: base.assistantId,
+    sessionId,
+  };
+}
+
+/**
+ * Ascend the rail to an ancestor stop, truncating every coordinate deeper than
+ * `level`. Used when the principal clicks a reachable higher stop (or breadcrumb
+ * segment): going up to STACK drops the assistant + session, going up to NETWORK
+ * drops the stack too, and so on.
+ */
+export function ascendToLevel(
+  selection: AltitudeSelection,
+  level: AltitudeLevel,
+): AltitudeSelection {
+  const depth = ALTITUDE_LEVELS.indexOf(level);
+  return {
+    level,
+    networkId: depth >= 1 ? selection.networkId : null,
+    stack: depth >= 2 ? selection.stack : null,
+    assistantId: depth >= 3 ? selection.assistantId : null,
+    sessionId: depth >= 4 ? selection.sessionId : null,
+  };
+}
+
+/**
+ * Resolve a breadcrumb-segment click into the next selection. Each segment
+ * carries its full coordinate set, so navigation just reconstructs the selection
+ * at that segment's level (the root segment reconstructs {@link ROOT_SELECTION}).
  */
 export function navigateToSegment(
   segment: BreadcrumbSegment,
 ): AltitudeSelection {
-  if (segment.networkId === null) return ascendToRoot();
-  return drillToNetwork(segment.networkId);
+  return {
+    level: segment.level,
+    networkId: segment.networkId,
+    stack: segment.stack,
+    assistantId: segment.assistantId,
+    sessionId: segment.sessionId,
+  };
 }
 
 /** Reachability of a rail stop for the current data + selection. */
 export type StopReachability = "current" | "reachable" | "future";
 
 /**
- * Classify a rail stop:
+ * Whether SESSION altitude is reachable for a given stack — the ADR-0005 gate.
+ * True ONLY for an OWN-LOCAL stack (`stack !== null && !stack.federated`). A
+ * federated peer bottoms out at STACK/ASSISTANT, so this is `false` there and
+ * `stopReachability('session', …)` stays `future`.
+ */
+export function stackReachesSession(stack: StackCoord | null): boolean {
+  return stack !== null && !stack.federated;
+}
+
+/**
+ * Classify a rail stop from real selection state (CK-1 — no blanket `future`):
  *   - `current`   — the active level (lit on the rail);
- *   - `reachable` — navigable now with the data on hand;
- *   - `future`    — a deeper level D3+ will wire (a disabled stub today).
+ *   - `reachable` — navigable now with the coordinate that backs it present;
+ *   - `future`    — no backing coordinate yet (a disabled stub).
  *
- * `networks` is always reachable (the root you can always return to). `network`
- * is reachable iff ≥1 network is joined (otherwise there is nothing to drill
- * into — an honest `future` stub). `stack`/`assistant`/`session` are `future` in
- * D2 regardless of data.
- *
- * Forward rule for D3/D4 (the sovereignty boundary above): `session` is
- * reachable ONLY in a local/own-stack context. For a federated peer the deepest
- * reachable level is `stack`/`assistant` (aggregate) — `session` stays `future`
- * there by construction. D2 reaches none of these three, so it cannot
- * contradict the rule; D3/D4 must enforce it when they wire the deep drill.
+ * Rules:
+ *   - `networks` — always reachable (the root you can always return to).
+ *   - `network`  — reachable iff ≥1 network is joined (else nothing to drill
+ *     into — an honest `future` stub).
+ *   - `stack`    — reachable iff a stack has been dived into (`selection.stack`).
+ *   - `assistant`— reachable iff a stack is dived; ASSISTANT is aggregate metadata
+ *     available for BOTH local and federated peers, so it does not gate on the
+ *     federated bit.
+ *   - `session`  — reachable ONLY on an OWN-LOCAL stack (ADR-0005 sovereignty
+ *     boundary): `future` when no stack is dived AND `future` for a FEDERATED
+ *     peer — that peer bottoms out at STACK/ASSISTANT by construction.
  */
 export function stopReachability(
   level: AltitudeLevel,
@@ -206,5 +410,11 @@ export function stopReachability(
   if (level === selection.level) return "current";
   if (level === "networks") return "reachable";
   if (level === "network") return networkCount > 0 ? "reachable" : "future";
-  return "future";
+  if (level === "stack") return selection.stack !== null ? "reachable" : "future";
+  if (level === "assistant") {
+    return selection.stack !== null ? "reachable" : "future";
+  }
+  // level === "session" — own-local only (ADR-0005). Federated peers bottom out
+  // at STACK/ASSISTANT; a session is unreachable across the boundary.
+  return stackReachesSession(selection.stack) ? "reachable" : "future";
 }


### PR DESCRIPTION
R1 slice **CK-1** — the first of the cockpit serial spine. Makes the altitude rail live below NETWORK.

- `mc-dive.ts` (new) + data-driven `stopReachability` + `AltitudeSelection` gains stack/assistant/session coords; altitude-rail dive; drill-down reused as the SESSION interior.
- **ADR-0005 enforced:** SESSION/ENVELOPE reachable only on the principal's OWN-LOCAL stacks; federated peers bottom out (aggregate-only).
- 58 tests; tsc 0; eslint clean (committed source); vocab PASS.
- **Browser-QA verified** (6-shot walkthrough): dive renders the full path + opens a local session; the federated peer correctly BLOCKS session (visually confirmed — the #1070 inert-feature guard).

Salvaged from a stalled builder (work complete pre-verify), fully re-verified + visually QA'd by the orchestrator.

Generated by the R1 opus fleet (ck1b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c