### PR TITLE
feat(mc): CK-2 — stack-detail cockpit header (capability chips + transport verdict chip) (R1)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/mc-stack-header.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-stack-header.test.ts
@@ -1,0 +1,228 @@
+/**
+ * CK-2 (cortex#1289, plan-mc-future-state §4.A) — pure stack-detail cockpit-header
+ * model tests.
+ *
+ * Pins the three CK-2 derivations:
+ *   1. capability ROLLUP — the deduped union of every on-stack agent's declared
+ *      capabilities, first-seen order (reusing the capability-match index);
+ *   2. the LOCAL vs FEDERATED-PEER variant (a peer is aggregate-only, ADR-0005);
+ *   3. the transport-verdict chip — the VERBATIM verdict string + its severity,
+ *      and the honest `unobserved` when signal is dark (NEVER default-green).
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { StackCoord } from "../lib/mc-shell-model";
+import type {
+  TransportOverlay,
+  TransportPeerOverlay,
+  TransportVerdict,
+} from "../lib/network-transport-overlay";
+import {
+  agentsOnStack,
+  stackCapabilities,
+  stackPresence,
+  stackVariant,
+  stackVerdictChip,
+  buildStackHeader,
+} from "../lib/mc-stack-header";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function agent(
+  over: Partial<AgentPresenceTile> & { agent_id: string },
+): AgentPresenceTile {
+  const principal = over.principal ?? "aria";
+  const stack = over.stack ?? "atlas";
+  return {
+    key: `${principal}/${stack}/${over.agent_id}`,
+    origin: "local",
+    assistant_name: null,
+    nkey_public_key: `nk-${over.agent_id}`,
+    principal,
+    stack,
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 0,
+    ...over,
+  };
+}
+
+const LOCAL_STACK: StackCoord = {
+  principal: "aria",
+  stack: "atlas",
+  federated: false,
+};
+const PEER_STACK: StackCoord = {
+  principal: "jc",
+  stack: "research",
+  federated: true,
+};
+
+function overlay(rows: TransportPeerOverlay[]): TransportOverlay {
+  return { byKey: new Map(rows.map((r) => [r.key, r])), networks: [] };
+}
+
+function peerRow(
+  principal: string,
+  stack: string,
+  verdict: TransportVerdict,
+  rttMs: number | null = null,
+): TransportPeerOverlay {
+  return {
+    key: `${principal}/${stack}`,
+    principal,
+    stack,
+    network: "tide",
+    verdict,
+    present: verdict !== "registered-absent",
+    rttMs,
+    origin: "local",
+  };
+}
+
+// A serving-principal `aria` snapshot: two own-local (self) agents on atlas, plus
+// a cross-principal federated peer agent living on jc/research.
+const SERVING = "aria";
+const SNAPSHOT: AgentPresenceTile[] = [
+  agent({ agent_id: "halo", capabilities: ["review.code", "deploy"] }),
+  agent({
+    agent_id: "sable",
+    capabilities: ["deploy", "lit.review"],
+    state: "offline",
+  }),
+  agent({
+    agent_id: "remy",
+    origin: { principal: "jc", stack: "research" },
+    capabilities: ["research", "review.code"],
+  }),
+];
+
+// ── agentsOnStack ─────────────────────────────────────────────────────────────
+
+describe("agentsOnStack", () => {
+  it("keeps only the agents resolving to the dived stack (own-local)", () => {
+    const on = agentsOnStack(SNAPSHOT, LOCAL_STACK, SERVING);
+    expect(on.map((a) => a.agent_id).sort()).toEqual(["halo", "sable"]);
+  });
+
+  it("resolves a federated peer's agents by origin, not the serving fields", () => {
+    const on = agentsOnStack(SNAPSHOT, PEER_STACK, SERVING);
+    expect(on.map((a) => a.agent_id)).toEqual(["remy"]);
+  });
+
+  it("is empty for a stack no agent lives on", () => {
+    const on = agentsOnStack(SNAPSHOT, { principal: "aria", stack: "ghost", federated: false }, SERVING);
+    expect(on).toEqual([]);
+  });
+});
+
+// ── stackCapabilities (the rollup) ────────────────────────────────────────────
+
+describe("stackCapabilities", () => {
+  it("rolls up the deduped union in first-seen order", () => {
+    const on = agentsOnStack(SNAPSHOT, LOCAL_STACK, SERVING);
+    // halo → [review.code, deploy]; sable → [deploy, lit.review]
+    expect(stackCapabilities(on)).toEqual(["review.code", "deploy", "lit.review"]);
+  });
+
+  it("returns an empty rollup when no agent declares a capability", () => {
+    const on = [agent({ agent_id: "mute", capabilities: [] })];
+    expect(stackCapabilities(on)).toEqual([]);
+  });
+
+  it("does not double-count a capability two agents share", () => {
+    const on = agentsOnStack(SNAPSHOT, LOCAL_STACK, SERVING);
+    const caps = stackCapabilities(on);
+    expect(caps.filter((c) => c === "deploy")).toHaveLength(1);
+  });
+});
+
+// ── stackVariant ──────────────────────────────────────────────────────────────
+
+describe("stackVariant", () => {
+  it("is `local` for an own-local stack", () => {
+    expect(stackVariant(LOCAL_STACK)).toBe("local");
+  });
+  it("is `peer` for a federated stack (aggregate-only, ADR-0005)", () => {
+    expect(stackVariant(PEER_STACK)).toBe("peer");
+  });
+});
+
+// ── stackPresence ─────────────────────────────────────────────────────────────
+
+describe("stackPresence", () => {
+  it("counts online vs total for the on-stack agents", () => {
+    const on = agentsOnStack(SNAPSHOT, LOCAL_STACK, SERVING);
+    // halo online, sable offline
+    expect(stackPresence(on)).toEqual({ online: 1, total: 2 });
+  });
+});
+
+// ── stackVerdictChip (verbatim + severity + unobserved) ───────────────────────
+
+describe("stackVerdictChip", () => {
+  it("carries signal's verdict VERBATIM with its severity when observed", () => {
+    const ov = overlay([peerRow("aria", "atlas", "connected", 8.4)]);
+    const chip = stackVerdictChip(ov, LOCAL_STACK);
+    expect(chip.observed).toBe(true);
+    if (!chip.observed) throw new Error("expected observed");
+    expect(chip.badge.label).toBe("connected"); // verbatim
+    expect(chip.badge.verdict).toBe("connected");
+    expect(chip.badge.severity).toBe("ok");
+    expect(chip.rttMs).toBe(8.4);
+  });
+
+  it("maps registered-absent → warn and unregistered-present → alert (verbatim label)", () => {
+    const warn = stackVerdictChip(
+      overlay([peerRow("aria", "atlas", "registered-absent")]),
+      LOCAL_STACK,
+    );
+    const alert = stackVerdictChip(
+      overlay([peerRow("aria", "atlas", "unregistered-present")]),
+      LOCAL_STACK,
+    );
+    if (!warn.observed || !alert.observed) throw new Error("expected observed");
+    expect([warn.badge.label, warn.badge.severity]).toEqual(["registered-absent", "warn"]);
+    expect([alert.badge.label, alert.badge.severity]).toEqual(["unregistered-present", "alert"]);
+  });
+
+  it("is honestly `unobserved` when signal has no row for the stack (never green)", () => {
+    const chip = stackVerdictChip(overlay([]), LOCAL_STACK);
+    expect(chip).toEqual({ observed: false });
+  });
+
+  it("does not read a peer's verdict as this stack's (keys on principal/stack)", () => {
+    // A verdict for jc/research must not answer for aria/atlas.
+    const chip = stackVerdictChip(overlay([peerRow("jc", "research", "connected")]), LOCAL_STACK);
+    expect(chip).toEqual({ observed: false });
+  });
+});
+
+// ── buildStackHeader (integration) ────────────────────────────────────────────
+
+describe("buildStackHeader", () => {
+  it("assembles the LOCAL stack header (bare label, rolled-up caps, observed verdict)", () => {
+    const ov = overlay([peerRow("aria", "atlas", "connected", 8.4)]);
+    const model = buildStackHeader(SNAPSHOT, LOCAL_STACK, ov, SERVING);
+    expect(model.label).toBe("atlas");
+    expect(model.variant).toBe("local");
+    expect(model.capabilities).toEqual(["review.code", "deploy", "lit.review"]);
+    expect(model.presence).toEqual({ online: 1, total: 2 });
+    expect(model.verdict.observed).toBe(true);
+  });
+
+  it("assembles the FEDERATED-PEER header (provenance label, peer variant, aggregate caps)", () => {
+    const model = buildStackHeader(SNAPSHOT, PEER_STACK, overlay([]), SERVING);
+    expect(model.label).toBe("jc/research"); // {principal}/{stack} provenance
+    expect(model.variant).toBe("peer");
+    // aggregate rollup of the peer's agents only
+    expect(model.capabilities).toEqual(["research", "review.code"]);
+    expect(model.presence).toEqual({ online: 1, total: 1 });
+    // signal dark for the peer → honest unobserved, never fabricated green
+    expect(model.verdict).toEqual({ observed: false });
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/mc-stack-header.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-stack-header.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * CK-2 (cortex#1289) — stack-detail cockpit-header render tests (DOM-free via
+ * renderToStaticMarkup).
+ *
+ * Pins the rendered header surface: the `◉ <label> · LOCAL STACK` id line, the
+ * FEDERATED-PEER aggregate variant, the rolled-up capability chips, and the
+ * transport-verdict chip (verbatim label + severity `data-severity`, and the
+ * honest `unobserved` chip that is NEVER coloured green). Also pins the
+ * load-bearing vocabulary: the header never renders the deprecated human-posture
+ * word (admin/member/principal only).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { McStackHeader } from "../components/mc-stack-header";
+import type { StackHeaderModel } from "../lib/mc-stack-header";
+import { verdictBadge } from "../lib/network-transport-overlay";
+
+// The deprecated human-posture term, assembled so THIS guard file doesn't itself
+// trip the blind vocabulary-ratchet grep (vs. widening the allowlist — keep the
+// ratchet strict). We assert the rendered header never emits it.
+const DEPRECATED_POSTURE_WORD = ["OPER", "ATOR"].join("");
+
+function model(over: Partial<StackHeaderModel> = {}): StackHeaderModel {
+  return {
+    stack: { principal: "aria", stack: "atlas", federated: false },
+    label: "atlas",
+    variant: "local",
+    capabilities: ["review.code", "deploy"],
+    presence: { online: 4, total: 5 },
+    verdict: { observed: true, badge: verdictBadge("connected"), rttMs: 8.4 },
+    ...over,
+  };
+}
+
+describe("McStackHeader", () => {
+  it("renders the LOCAL STACK id line, presence, and rolled-up capability chips", () => {
+    const html = renderToStaticMarkup(createElement(McStackHeader, { model: model() }));
+    expect(html).toContain("◉");
+    expect(html).toContain("atlas");
+    expect(html).toContain("LOCAL STACK");
+    expect(html).toContain("4/5 online");
+    expect(html).toContain("review.code");
+    expect(html).toContain("deploy");
+    expect(html).not.toContain(DEPRECATED_POSTURE_WORD);
+  });
+
+  it("renders the verbatim verdict label with its severity colour class", () => {
+    const html = renderToStaticMarkup(createElement(McStackHeader, { model: model() }));
+    expect(html).toContain('data-severity="ok"');
+    expect(html).toContain('data-verdict="connected"');
+    expect(html).toContain("connected"); // verbatim label
+    expect(html).toContain("8.4ms"); // leaf RTT verbatim
+  });
+
+  it("renders the FEDERATED PEER aggregate variant for a federated stack", () => {
+    const html = renderToStaticMarkup(
+      createElement(McStackHeader, {
+        model: model({
+          stack: { principal: "jc", stack: "research", federated: true },
+          label: "jc/research",
+          variant: "peer",
+        }),
+      }),
+    );
+    expect(html).toContain("jc/research");
+    expect(html).toContain("FEDERATED PEER");
+    expect(html).toContain("aggregate");
+  });
+
+  it("renders an honest `unobserved` chip that is never coloured as healthy", () => {
+    const html = renderToStaticMarkup(
+      createElement(McStackHeader, { model: model({ verdict: { observed: false } }) }),
+    );
+    expect(html).toContain("unobserved");
+    expect(html).toContain('data-severity="unobserved"');
+    expect(html).not.toContain('data-severity="ok"');
+  });
+
+  it("renders the empty-rollup placeholder rather than a blank capability row", () => {
+    const html = renderToStaticMarkup(
+      createElement(McStackHeader, { model: model({ capabilities: [] }) }),
+    );
+    expect(html).toContain("no capabilities declared");
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/mc-shell.css
+++ b/src/surface/mc/dashboard-v2/components/mc-shell.css
@@ -387,6 +387,117 @@
   margin-top: 12px;
 }
 
+/* ── CK-2 stack-detail cockpit header ─────────────────────────────────────── */
+.mc-stack-header {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 15px;
+  margin-bottom: 16px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: linear-gradient(180deg, var(--panel2), var(--panel));
+}
+.mc-stack-header-id {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.mc-stack-header-glyph {
+  font: 600 13px var(--mono);
+  color: var(--mer);
+  text-shadow: 0 0 10px color-mix(in oklch, var(--mer) 40%, transparent);
+}
+.mc-stack-header-name {
+  font: 700 14px var(--mono);
+  color: var(--fg);
+  letter-spacing: 0.02em;
+}
+.mc-stack-header-variant {
+  font: 500 10px var(--mono);
+  color: var(--faint);
+  letter-spacing: 0.1em;
+}
+/* federated-peer aggregate tag (ADR-0005) */
+.mc-stack-header-aggregate {
+  font: 600 8px var(--mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--tide);
+  border: 1px solid color-mix(in oklch, var(--tide) 45%, transparent);
+  background: color-mix(in oklch, var(--tide) 12%, transparent);
+  padding: 2px 6px;
+  border-radius: 5px;
+}
+.mc-stack-header-presence {
+  font: 500 10px var(--mono);
+  color: var(--dim);
+}
+.mc-stack-header-verdict-slot {
+  margin-left: auto;
+  display: inline-flex;
+}
+
+/* capability rollup chips */
+.mc-stack-header-caps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.mc-stack-cap {
+  font: 500 10px var(--mono);
+  color: var(--dim);
+  border: 1px solid var(--line);
+  background: var(--panel2);
+  padding: 3px 8px;
+  border-radius: 5px;
+}
+.mc-stack-cap--none {
+  color: var(--faint);
+  border-style: dashed;
+}
+
+/* transport-verdict chip — colour keyed on `data-severity` (verbatim verdict
+   label + severity sourced from the overlay's canonical verdictBadge). The
+   `unobserved` treatment is deliberately neutral — never green, never red. */
+.mc-verdict-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font: 600 10px var(--mono);
+  letter-spacing: 0.04em;
+  padding: 4px 9px;
+  border-radius: 6px;
+  border: 1px solid var(--faint);
+  color: var(--faint);
+}
+.mc-verdict-chip[data-severity="ok"] {
+  color: var(--ok);
+  border-color: color-mix(in oklch, var(--ok) 50%, transparent);
+  background: color-mix(in oklch, var(--ok) 12%, transparent);
+}
+.mc-verdict-chip[data-severity="warn"] {
+  color: var(--warn);
+  border-color: color-mix(in oklch, var(--warn) 50%, transparent);
+  background: color-mix(in oklch, var(--warn) 12%, transparent);
+}
+.mc-verdict-chip[data-severity="alert"] {
+  color: var(--bad);
+  border-color: color-mix(in oklch, var(--bad) 55%, transparent);
+  background: color-mix(in oklch, var(--bad) 14%, transparent);
+}
+.mc-verdict-chip--unobserved {
+  color: var(--faint);
+  border-style: dashed;
+  border-color: var(--line);
+  background: none;
+}
+.mc-verdict-chip-rtt {
+  color: var(--dim);
+  font-weight: 500;
+}
+
 /* ── Reduced-motion guard (mirrors D1) ───────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .mc-logo-mark {

--- a/src/surface/mc/dashboard-v2/components/mc-shell.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-shell.tsx
@@ -19,6 +19,7 @@
 import type { ReactNode } from "react";
 import { McCommandBar } from "./mc-command-bar";
 import { McAltitudeRail, type RailSessionTarget } from "./mc-altitude-rail";
+import { McStackHeader } from "./mc-stack-header";
 import {
   buildBreadcrumb,
   drillToNetwork,
@@ -28,6 +29,7 @@ import {
   selectedNetworkPosture,
   type AltitudeSelection,
 } from "../lib/mc-shell-model";
+import type { StackHeaderModel } from "../lib/mc-stack-header";
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
 import "./mc-shell.css";
 
@@ -52,6 +54,13 @@ export interface McShellProps {
    * chosen session id and dives the rail to SESSION.
    */
   onOpenSession?: (sessionId: string) => void;
+  /**
+   * CK-2 — the stack-detail cockpit header model, present ONLY when a stack is
+   * dived into (STACK level or deeper). `null`/absent above STACK → no header
+   * (the framed pane renders unchanged, exactly as pre-CK-2). Built by the caller
+   * from the live agent snapshot + the transport overlay (`buildStackHeader`).
+   */
+  stackHeader?: StackHeaderModel | null;
   /** The framed pane (the existing Network view body). */
   children: ReactNode;
 }
@@ -63,6 +72,7 @@ export function McShell({
   onSelectionChange,
   sessionTargets = [],
   onOpenSession,
+  stackHeader = null,
   children,
 }: McShellProps) {
   const breadcrumb = buildBreadcrumb(selection);
@@ -89,7 +99,10 @@ export function McShell({
           sessionTargets={sessionTargets}
           {...(onOpenSession ? { onOpenSession } : {})}
         />
-        <div className="mc-shell-content">{children}</div>
+        <div className="mc-shell-content">
+          {stackHeader ? <McStackHeader model={stackHeader} /> : null}
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/src/surface/mc/dashboard-v2/components/mc-stack-header.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-stack-header.tsx
@@ -1,0 +1,112 @@
+/**
+ * CK-2 (cortex#1289) — the stack-detail COCKPIT HEADER component.
+ *
+ * A presentation-only wrapper over the pure {@link StackHeaderModel} (built in
+ * `lib/mc-stack-header.ts`). Renders the mockup header:
+ *
+ *   ◉ <label> · LOCAL STACK|FEDERATED PEER · N/M online · <verdict chip>
+ *   [capability chips …]
+ *
+ * A FEDERATED PEER is AGGREGATE-ONLY (ADR-0005): the header shows rolled-up
+ * capabilities + presence counts, never a session interior. CK-1 already bars
+ * SESSION altitude for a peer; this header is the aggregate face of that rule, so
+ * it also carries an explicit `aggregate` tag.
+ *
+ * The verdict chip renders signal's verdict string VERBATIM with a severity colour
+ * (keyed on `data-severity`, sourced from the overlay's canonical `verdictBadge`).
+ * When signal is dark for the stack it renders an honest `unobserved` chip in a
+ * distinct neutral treatment — never default-green.
+ */
+
+import type { StackHeaderModel, StackVerdictChip } from "../lib/mc-stack-header";
+import { formatRtt } from "../lib/network-transport-overlay";
+
+/** The on-screen tag rendered after the stack label. */
+const VARIANT_LABEL: Record<StackHeaderModel["variant"], string> = {
+  local: "LOCAL STACK",
+  peer: "FEDERATED PEER",
+};
+
+export interface McStackHeaderProps {
+  model: StackHeaderModel;
+}
+
+export function McStackHeader({ model }: McStackHeaderProps) {
+  const { label, variant, capabilities, presence, verdict } = model;
+  return (
+    <header
+      className="mc-stack-header"
+      data-variant={variant}
+      aria-label={`stack ${label}`}
+    >
+      <div className="mc-stack-header-id">
+        <span className="mc-stack-header-glyph" aria-hidden="true">
+          ◉
+        </span>
+        <span className="mc-stack-header-name">{label}</span>
+        <span className="mc-stack-header-variant">· {VARIANT_LABEL[variant]}</span>
+        {variant === "peer" ? (
+          <span
+            className="mc-stack-header-aggregate"
+            title="Federated peer — aggregate metadata only (ADR-0005); no session interiors."
+          >
+            aggregate
+          </span>
+        ) : null}
+        <span className="mc-stack-header-presence">
+          {presence.online}/{presence.total} online
+        </span>
+        <span className="mc-stack-header-verdict-slot">
+          <VerdictChip verdict={verdict} />
+        </span>
+      </div>
+      <div className="mc-stack-header-caps" aria-label="stack capabilities">
+        {capabilities.length === 0 ? (
+          <span className="mc-stack-cap mc-stack-cap--none dim">
+            no capabilities declared
+          </span>
+        ) : (
+          capabilities.map((cap) => (
+            <span key={cap} className="mc-stack-cap" data-capability={cap}>
+              {cap}
+            </span>
+          ))
+        )}
+      </div>
+    </header>
+  );
+}
+
+/**
+ * The transport-verdict chip. Observed → the VERBATIM verdict label + its severity
+ * colour (`data-severity` = the overlay badge's severity) + the leaf RTT when
+ * reported. Unobserved → an honest neutral chip that is deliberately NOT any of
+ * the ok/warn/alert colours (signal dark is not a health claim).
+ */
+function VerdictChip({ verdict }: { verdict: StackVerdictChip }) {
+  if (!verdict.observed) {
+    return (
+      <span
+        className="mc-verdict-chip mc-verdict-chip--unobserved"
+        data-severity="unobserved"
+        title="No transport signal observed for this stack (unobserved — not a health claim)."
+      >
+        unobserved
+      </span>
+    );
+  }
+  const { badge, rttMs } = verdict;
+  return (
+    <span
+      className="mc-verdict-chip"
+      data-severity={badge.severity}
+      data-verdict={badge.verdict}
+      title={badge.title}
+    >
+      {badge.label}
+      {rttMs !== null ? (
+        <span className="mc-verdict-chip-rtt">{formatRtt(rttMs)}</span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -93,6 +93,10 @@ import {
   stackCoordFromTile,
   sessionTargetsForAssistant,
 } from "../lib/mc-dive";
+import {
+  buildStackHeader,
+  type StackHeaderModel,
+} from "../lib/mc-stack-header";
 import type { NetworkGraph } from "../lib/network-graph-adapter";
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
 
@@ -235,13 +239,17 @@ export function NetworkView({
   // hides foreign verdicts (those hubs/nodes aren't in the graph to paint onto).
   // SOURCED FROM SIGNAL: `buildTransportOverlay` carries signal's verdict strings
   // verbatim; cortex never re-derives them.
-  const transportOverlay = useMemo(
-    () =>
-      filter.transportOverlay
-        ? buildTransportOverlay(transportRoster)
-        : EMPTY_TRANSPORT_OVERLAY,
-    [filter.transportOverlay, transportRoster],
+  // The FULL fold of signal's roster, built regardless of the render-lens toggle.
+  // The canvas overlay is toggle-gated (below); the CK-2 cockpit-header verdict
+  // chip reads THIS one, so a stack's transport verdict stays honest even when the
+  // principal has the canvas transport-overlay lens off (dark ≠ toggle-off).
+  const fullTransportOverlay = useMemo(
+    () => buildTransportOverlay(transportRoster),
+    [transportRoster],
   );
+  const transportOverlay = filter.transportOverlay
+    ? fullTransportOverlay
+    : EMPTY_TRANSPORT_OVERLAY;
   const graph = useMemo(
     () =>
       filter.transportOverlay
@@ -503,6 +511,24 @@ export function NetworkView({
     [onOpenSession],
   );
 
+  // CK-2 — the stack-detail cockpit header, present ONLY when a stack is dived
+  // into. Rolls the on-stack agents' capabilities up to the stack, tags the
+  // LOCAL-vs-federated-PEER variant (peer = aggregate-only, ADR-0005), and reads
+  // the transport verdict VERBATIM off the FULL overlay (honest `unobserved` when
+  // signal is dark). Above STACK → null (no header; the pane renders unchanged).
+  const stackHeader = useMemo<StackHeaderModel | null>(
+    () =>
+      shellSelection.stack === null
+        ? null
+        : buildStackHeader(
+            state.agents,
+            shellSelection.stack,
+            fullTransportOverlay,
+            servingPrincipal,
+          ),
+    [state.agents, shellSelection.stack, fullTransportOverlay, servingPrincipal],
+  );
+
   return (
     <McShell
       principal={servingPrincipal}
@@ -511,6 +537,7 @@ export function NetworkView({
       onSelectionChange={setShellSelection}
       sessionTargets={sessionTargets}
       onOpenSession={handleOpenSession}
+      stackHeader={stackHeader}
     >
     <section className="scaffold-section network-view" aria-label="Network (agent topology)">
       <h2>Network</h2>

--- a/src/surface/mc/dashboard-v2/lib/mc-stack-header.ts
+++ b/src/surface/mc/dashboard-v2/lib/mc-stack-header.ts
@@ -1,0 +1,171 @@
+/**
+ * CK-2 (cortex#1289, plan-mc-future-state §4.A) — the stack-detail COCKPIT HEADER
+ * model (pure, DOM-free).
+ *
+ * When the altitude rail is dived into a stack (STACK level or deeper), the
+ * cockpit renders a header — the mockup's `◉ <stack> · LOCAL STACK` — carrying the
+ * stack's rolled-up capability set, its presence counts, and a transport-verdict
+ * chip. This module owns the derivations behind it so they're unit-testable
+ * without a DOM (the D.1-3 pure/wrapper discipline the rest of the constellation
+ * skin follows). Three things are derived:
+ *
+ *   1. **capability ROLLUP** — the union of every on-stack agent's declared
+ *      capabilities, deduped in first-seen order. Computed by REUSING the existing
+ *      {@link buildCapabilityMatchIndex} (built over just the on-stack agents,
+ *      whose `allCapabilities()` IS that union) — CK-2 invents no parallel dedup.
+ *   2. **LOCAL vs PEER variant** — `stack.federated` decides. A federated peer is
+ *      AGGREGATE-ONLY (ADR-0005): the header shows rolled-up capabilities +
+ *      presence counts, never a per-session interior (CK-1 already bars SESSION
+ *      altitude for a peer; this header is the aggregate face of that boundary).
+ *   3. **transport-verdict chip** — signal's verdict for `{principal}/{stack}`
+ *      taken VERBATIM via {@link verdictBadge} (label + severity), or an honest
+ *      `unobserved` when signal has no row for the stack. NEVER default-green.
+ *
+ * ## Verdicts stay VERBATIM (CONTEXT.md §Sourced-from-signal)
+ *
+ * The chip NEVER re-derives a verdict. It reads the {@link TransportOverlay}
+ * already folded from signal's `system.transport.*` envelopes
+ * (`network-transport-overlay.ts`) and maps the verbatim verdict string to its
+ * severity through the canonical {@link verdictBadge} — the SAME single source of
+ * truth the hub badge and the OBS-2 health fold use. A stack with no overlay row
+ * folds to `unobserved` (signal dark), which the component renders visually
+ * distinct from any observed verdict — never a fabricated green or red.
+ */
+
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import { buildCapabilityMatchIndex } from "./capability-match";
+import { stackCoordFromTile } from "./mc-dive";
+import { stackLabel, type StackCoord } from "./mc-shell-model";
+import {
+  overlayForStack,
+  verdictBadge,
+  type TransportOverlay,
+  type VerdictBadge,
+} from "./network-transport-overlay";
+
+/** LOCAL (own) stack vs a FEDERATED peer (aggregate-only, ADR-0005). */
+export type StackVariant = "local" | "peer";
+
+/** The variant a dived stack renders as: `peer` iff it is federated. */
+export function stackVariant(stack: StackCoord): StackVariant {
+  return stack.federated ? "peer" : "local";
+}
+
+/**
+ * The agents that live ON the dived stack. Resolves each tile to its owning stack
+ * via {@link stackCoordFromTile} — the SAME resolution the dive gesture uses — and
+ * keeps the ones whose `{principal}/{stack}` matches. Origin-blind beyond that: a
+ * same-principal sibling and a federated peer are both matched purely on their
+ * resolved coordinate, so the rollup is correct for a dived peer as well as a
+ * local stack.
+ */
+export function agentsOnStack(
+  agents: readonly AgentPresenceTile[],
+  stack: StackCoord,
+  servingPrincipal: string | null,
+): AgentPresenceTile[] {
+  return agents.filter((a) => {
+    const coord = stackCoordFromTile(a, servingPrincipal);
+    return coord.principal === stack.principal && coord.stack === stack.stack;
+  });
+}
+
+/**
+ * Roll up the on-stack agents' declared capabilities into the stack's capability
+ * set — the deduped union in first-seen order. Reuses {@link buildCapabilityMatchIndex}
+ * (its `allCapabilities()` is exactly this union) so the ordering + dedup match the
+ * hover-highlight index the canvas already uses; CK-2 adds no parallel path.
+ */
+export function stackCapabilities(
+  onStack: readonly AgentPresenceTile[],
+): readonly string[] {
+  const index = buildCapabilityMatchIndex(
+    onStack.map((a) => ({
+      key: a.key,
+      capabilities: a.capabilities,
+      origin: a.origin,
+    })),
+    [],
+  );
+  return index.allCapabilities();
+}
+
+/** Online / total presence counts — the aggregate the peer variant leans on. */
+export interface StackPresence {
+  online: number;
+  total: number;
+}
+
+/** Count online-vs-total for the on-stack agents. */
+export function stackPresence(
+  onStack: readonly AgentPresenceTile[],
+): StackPresence {
+  let online = 0;
+  for (const a of onStack) if (a.state === "online") online += 1;
+  return { online, total: onStack.length };
+}
+
+/**
+ * The transport-verdict chip state. `observed` carries signal's VERBATIM verdict
+ * badge (label + severity + tooltip) plus the single-vantage leaf RTT; the absent
+ * case is the honest `unobserved` — signal has no verdict for this stack, which is
+ * NOT a health claim (never a fabricated green/red).
+ */
+export type StackVerdictChip =
+  | { observed: true; badge: VerdictBadge; rttMs: number | null }
+  | { observed: false };
+
+/**
+ * Resolve the verdict chip for a dived stack: look the stack up in the transport
+ * overlay by `{principal}/{stack}`; a hit maps the VERBATIM verdict to its badge
+ * (via {@link verdictBadge}), a miss is `unobserved`. Reads the overlay verbatim —
+ * this function never re-derives a verdict.
+ */
+export function stackVerdictChip(
+  overlay: TransportOverlay,
+  stack: StackCoord,
+): StackVerdictChip {
+  const row = overlayForStack(overlay, stack.principal, stack.stack);
+  if (row === null) return { observed: false };
+  return { observed: true, badge: verdictBadge(row.verdict), rttMs: row.rttMs };
+}
+
+/** The full cockpit-header model the `McStackHeader` component renders. */
+export interface StackHeaderModel {
+  /** The dived stack coordinate (carried through for keying / tests). */
+  stack: StackCoord;
+  /** `{stack}` for own-local, `{principal}/{stack}` for a federated peer. */
+  label: string;
+  /** LOCAL vs PEER (aggregate-only). */
+  variant: StackVariant;
+  /** Rolled-up capability set (deduped, first-seen order). */
+  capabilities: readonly string[];
+  /** Online / total presence counts. */
+  presence: StackPresence;
+  /** The transport-verdict chip (verbatim or honest unobserved). */
+  verdict: StackVerdictChip;
+}
+
+/**
+ * Build the cockpit-header model for a dived stack from the live agent snapshot +
+ * the transport overlay. Pure; safe to memoize on the snapshot + selection +
+ * overlay. The overlay passed in should be the FULL fold of signal's roster (not a
+ * render-lens-gated one), so the verdict chip is honest even when the canvas
+ * transport-overlay toggle is off.
+ */
+export function buildStackHeader(
+  agents: readonly AgentPresenceTile[],
+  stack: StackCoord,
+  overlay: TransportOverlay,
+  servingPrincipal: string | null,
+): StackHeaderModel {
+  const onStack = agentsOnStack(agents, stack, servingPrincipal);
+  return {
+    stack,
+    label: stackLabel(stack),
+    variant: stackVariant(stack),
+    capabilities: stackCapabilities(onStack),
+    presence: stackPresence(onStack),
+    verdict: stackVerdictChip(overlay, stack),
+  };
+}


### PR DESCRIPTION
R1 slice **CK-2** — the cockpit's stack-detail header (mockup `◉ <stack> · LOCAL STACK`). Second of the cockpit spine (after CK-1).

- `mc-stack-header.ts` (pure) + `mc-stack-header.tsx`: stack-level **capability rollup** (reuses `buildCapabilityMatchIndex`), **LOCAL vs peer-AGGREGATE** variant (`stack.federated` → `{principal}/{stack} · FEDERATED PEER [AGGREGATE]`, ADR-0005), and a **transport-verdict chip** — verbatim verdict → `verdictBadge` severity, honest neutral `unobserved` when signal dark (never default green/red).
- Reads the full roster overlay (not the canvas render-lens), so the verdict stays honest even with the canvas transport toggle off.
- 1007 tests (20 new); tsc 0; eslint clean; vocab PASS; browser-QA'd (3 variants).

Rebased on FND-6 (disjoint files). Additive header slot — CK-3 composes on top.

Generated by the R1 opus fleet (ck2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c