### PR TITLE
feat(mc): CK-4a — sessions origin_stack_id + cross-stack WORKING aggregation (R1 data half)

### DIFF
--- a/src/surface/mc/__tests__/types.test.ts
+++ b/src/surface/mc/__tests__/types.test.ts
@@ -53,6 +53,7 @@ describe("mission-control types", () => {
       task_id: "t-1",
       state: "blocked",
       block_reason: { kind: "permission.request", payload: { requested_action: "tool.bash" } },
+      retry_after_ms: null,
       created_at: "2026-04-17T00:00:00Z",
       updated_at: "2026-04-17T00:00:00Z",
     };
@@ -79,6 +80,7 @@ describe("mission-control types", () => {
       classification: null,
       data_residency: null,
       home_principal: null,
+      origin_stack_id: null,
     };
     const controlled: Session = {
       id: "s-1",

--- a/src/surface/mc/__tests__/working-aggregation.test.ts
+++ b/src/surface/mc/__tests__/working-aggregation.test.ts
@@ -1,0 +1,268 @@
+/**
+ * CK-4a / #1295 — unit tests for the cross-stack WORKING aggregation read model
+ * (db/working-aggregation.ts) + the origin_stack_id / retry_after_ms migration +
+ * the origin backfill.
+ *
+ * Pins:
+ *   - the migration applies cleanly (both new columns present; idempotent re-init);
+ *   - per-origin active + sub-agent counts (from parent_session_id), null/own-origin
+ *     first, then origin id ASC;
+ *   - provider-retry folded from agent_task_assignment.retry_after_ms (MIN per
+ *     origin; session-less pending retry attributes to the null/own bucket);
+ *   - the NO-INTERIORS shape guard: a rollup carries ONLY metadata keys — a
+ *     federated PEER origin yields the same metadata-only aggregate, never a
+ *     session id / interior (the local mirror of the DashboardSnapshot guard);
+ *   - backfillOriginStackId stamps NULL rows only (idempotent, never overwrites).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+import { initDatabase } from "../db/init";
+import { backfillOriginStackId } from "../db/sessions";
+import {
+  listWorkingAggregation,
+  type WorkingStackAggregate,
+} from "../db/working-aggregation";
+
+// Every key any rollup (or its providerRetry) may carry. The no-interiors
+// allow-list — the local mirror of the worker dashboard-snapshot-contract guard.
+const ROLLUP_KEYS = new Set([
+  "originStackId",
+  "activeSessionCount",
+  "subAgentCount",
+  "providerRetry",
+]);
+const PROVIDER_RETRY_KEYS = new Set(["state", "retryAfterMs"]);
+
+function seedAgent(db: Database, id: string): void {
+  db.query(`INSERT OR IGNORE INTO agents (id, name, type) VALUES (?, ?, 'hands')`).run(id, `Agent ${id}`);
+}
+
+function seedTask(db: Database, id: string): void {
+  db.query(
+    `INSERT OR IGNORE INTO tasks (id, title, priority, principal_id, source_system)
+     VALUES (?, ?, 2, 'andreas', 'internal')`
+  ).run(id, `Task ${id}`);
+}
+
+function seedAssignment(
+  db: Database,
+  opts: { id: string; agentId: string; taskId: string; state: string; retryAfterMs?: number | null }
+): void {
+  // The schema CHECK requires block_reason iff state = 'blocked'.
+  const blockReason =
+    opts.state === "blocked"
+      ? JSON.stringify({ kind: "permission.request", payload: { requested_action: "tool.edit" } })
+      : null;
+  db.query(
+    `INSERT INTO agent_task_assignment (id, agent_id, task_id, state, block_reason, retry_after_ms)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(opts.id, opts.agentId, opts.taskId, opts.state, blockReason, opts.retryAfterMs ?? null);
+}
+
+function seedSession(
+  db: Database,
+  opts: {
+    id: string;
+    assignmentId: string;
+    originStackId?: string | null;
+    parentSessionId?: string | null;
+    endedAt?: string | null;
+  }
+): void {
+  db.query(
+    `INSERT INTO sessions
+       (id, assignment_id, endpoint_kind, started_at, ended_at, parent_session_id, origin_stack_id)
+     VALUES (?, ?, 'local.process.controlled', datetime('now'), ?, ?, ?)`
+  ).run(
+    opts.id,
+    opts.assignmentId,
+    opts.endedAt ?? null,
+    opts.parentSessionId ?? null,
+    opts.originStackId ?? null
+  );
+}
+
+/** Assert every rollup (and providerRetry) carries ONLY metadata keys. */
+function assertNoInteriors(rollups: WorkingStackAggregate[]): void {
+  for (const r of rollups) {
+    const unexpected = Object.keys(r).filter((k) => !ROLLUP_KEYS.has(k));
+    expect(unexpected).toEqual([]);
+    if (r.providerRetry) {
+      const pu = Object.keys(r.providerRetry).filter((k) => !PROVIDER_RETRY_KEYS.has(k));
+      expect(pu).toEqual([]);
+    }
+  }
+}
+
+describe("CK-4a origin_stack_id / retry_after_ms migration", () => {
+  let db: Database;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mc-ck4a-mig-${Date.now()}-${Math.random()}`);
+    db = initDatabase(join(tmpDir, "test.db"));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("adds origin_stack_id to sessions and retry_after_ms to agent_task_assignment", () => {
+    const sessionCols = (db.query(`PRAGMA table_info(sessions)`).all() as { name: string }[]).map((c) => c.name);
+    const ataCols = (db.query(`PRAGMA table_info(agent_task_assignment)`).all() as { name: string }[]).map((c) => c.name);
+    expect(sessionCols).toContain("origin_stack_id");
+    expect(ataCols).toContain("retry_after_ms");
+  });
+
+  it("creates the origin-stack lookup index", () => {
+    const idx = (db.query(`PRAGMA index_list(sessions)`).all() as { name: string }[]).map((i) => i.name);
+    expect(idx).toContain("idx_sessions_origin_stack_id");
+  });
+
+  it("is idempotent — re-initialising the same DB path does not throw", () => {
+    const path = join(tmpDir, "test.db");
+    db.close();
+    // Re-open: SCHEMA_SQL is IF NOT EXISTS and COLUMN_ADD_MIGRATIONS is
+    // pragma-gated, so the ALTERs skip the now-present columns without error.
+    db = initDatabase(path);
+    const sessionCols = (db.query(`PRAGMA table_info(sessions)`).all() as { name: string }[]).map((c) => c.name);
+    expect(sessionCols).toContain("origin_stack_id");
+  });
+});
+
+describe("listWorkingAggregation", () => {
+  let db: Database;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mc-ck4a-agg-${Date.now()}-${Math.random()}`);
+    db = initDatabase(join(tmpDir, "test.db"));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty when there are no sessions", () => {
+    expect(listWorkingAggregation(db)).toEqual([]);
+  });
+
+  it("counts active sessions and sub-agents per origin, own-origin first", () => {
+    seedAgent(db, "ag");
+    seedTask(db, "t");
+    // own/local origin (null): a root + its sub-agent (both active)
+    seedAssignment(db, { id: "a-local-root", agentId: "ag", taskId: "t", state: "running" });
+    seedAssignment(db, { id: "a-local-child", agentId: "ag", taskId: "t", state: "running" });
+    seedSession(db, { id: "s-local-root", assignmentId: "a-local-root", originStackId: null });
+    seedSession(db, { id: "s-local-child", assignmentId: "a-local-child", originStackId: null, parentSessionId: "s-local-root" });
+    // a federated PEER stack: one active root session
+    seedAssignment(db, { id: "a-peer", agentId: "ag", taskId: "t", state: "dispatched" });
+    seedSession(db, { id: "s-peer", assignmentId: "a-peer", originStackId: "andreas/peer-b" });
+    // a terminal (ended) session must be excluded from active counts
+    seedAssignment(db, { id: "a-done", agentId: "ag", taskId: "t", state: "running" });
+    seedSession(db, { id: "s-done", assignmentId: "a-done", originStackId: null, endedAt: "2026-07-01T00:00:00Z" });
+
+    const rollups = listWorkingAggregation(db);
+    expect(rollups.map((r) => r.originStackId)).toEqual([null, "andreas/peer-b"]);
+
+    const local = rollups[0]!;
+    expect(local.activeSessionCount).toBe(2);
+    expect(local.subAgentCount).toBe(1);
+    expect(local.providerRetry).toBeNull();
+
+    const peer = rollups[1]!;
+    expect(peer.activeSessionCount).toBe(1);
+    expect(peer.subAgentCount).toBe(0);
+  });
+
+  it("excludes sessions whose owning assignment is not in a working state", () => {
+    seedAgent(db, "ag");
+    seedTask(db, "t");
+    seedAssignment(db, { id: "a-blocked", agentId: "ag", taskId: "t", state: "blocked" });
+    seedSession(db, { id: "s-blocked", assignmentId: "a-blocked", originStackId: null });
+    expect(listWorkingAggregation(db)).toEqual([]);
+  });
+
+  it("folds provider-retry (MIN retry_after_ms) per origin from assignment rows", () => {
+    seedAgent(db, "ag");
+    seedTask(db, "t");
+    // two queued assignments awaiting retry, WITH sessions on the same origin
+    seedAssignment(db, { id: "a-r1", agentId: "ag", taskId: "t", state: "queued", retryAfterMs: 5000 });
+    seedAssignment(db, { id: "a-r2", agentId: "ag", taskId: "t", state: "queued", retryAfterMs: 1500 });
+    seedSession(db, { id: "s-r1", assignmentId: "a-r1", originStackId: null });
+    seedSession(db, { id: "s-r2", assignmentId: "a-r2", originStackId: null });
+
+    const rollups = listWorkingAggregation(db);
+    const local = rollups.find((r) => r.originStackId === null)!;
+    expect(local.providerRetry).toEqual({ state: "not_now", retryAfterMs: 1500 });
+  });
+
+  it("attributes a session-less pending retry to the own/local (null) origin", () => {
+    seedAgent(db, "ag");
+    seedTask(db, "t");
+    // queued assignment awaiting retry, NOT yet spawned (no session row)
+    seedAssignment(db, { id: "a-pending", agentId: "ag", taskId: "t", state: "queued", retryAfterMs: 3000 });
+
+    const rollups = listWorkingAggregation(db);
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0]!.originStackId).toBeNull();
+    expect(rollups[0]!.activeSessionCount).toBe(0);
+    expect(rollups[0]!.providerRetry).toEqual({ state: "not_now", retryAfterMs: 3000 });
+  });
+
+  it("a federated peer origin yields metadata-only — no interiors (guard)", () => {
+    seedAgent(db, "ag");
+    seedTask(db, "t");
+    seedAssignment(db, { id: "a-peer", agentId: "ag", taskId: "t", state: "running" });
+    seedSession(db, { id: "s-peer-secret", assignmentId: "a-peer", originStackId: "andreas/peer-b" });
+
+    const rollups = listWorkingAggregation(db);
+    assertNoInteriors(rollups);
+    // The peer's session id / interior must NOT leak anywhere in the output.
+    expect(JSON.stringify(rollups)).not.toContain("s-peer-secret");
+    expect(JSON.stringify(rollups)).not.toContain("assignment");
+  });
+});
+
+describe("backfillOriginStackId", () => {
+  let db: Database;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mc-ck4a-bf-${Date.now()}-${Math.random()}`);
+    db = initDatabase(join(tmpDir, "test.db"));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("stamps NULL-origin rows with the daemon's own stack id, idempotently", () => {
+    seedAgent(db, "ag");
+    seedTask(db, "t");
+    seedAssignment(db, { id: "a-1", agentId: "ag", taskId: "t", state: "running" });
+    seedAssignment(db, { id: "a-2", agentId: "ag", taskId: "t", state: "running" });
+    seedSession(db, { id: "s-null", assignmentId: "a-1", originStackId: null });
+    seedSession(db, { id: "s-attributed", assignmentId: "a-2", originStackId: "andreas/peer-b" });
+
+    const stamped = backfillOriginStackId(db, "andreas/local");
+    expect(stamped).toBe(1); // only the NULL row
+
+    const rows = db.query(`SELECT id, origin_stack_id FROM sessions ORDER BY id`).all() as {
+      id: string;
+      origin_stack_id: string | null;
+    }[];
+    const byId = new Map(rows.map((r) => [r.id, r.origin_stack_id]));
+    expect(byId.get("s-null")).toBe("andreas/local");
+    // a pre-attributed peer row is NEVER overwritten
+    expect(byId.get("s-attributed")).toBe("andreas/peer-b");
+
+    // second run is a no-op (idempotent)
+    expect(backfillOriginStackId(db, "andreas/local")).toBe(0);
+  });
+});

--- a/src/surface/mc/db/canonical-session.ts
+++ b/src/surface/mc/db/canonical-session.ts
@@ -252,6 +252,16 @@ export const CANONICAL_SESSION_COLUMNS: CanonicalSessionColumn[] = [
     default: null,
     note: "principal.home_principal (post-did:mf: strip).",
   },
+  // --- cross-stack origin (CK-4a / #1295 / decision D-8) ---
+  {
+    d1Name: "origin_stack_id",
+    localName: "origin_stack_id",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note:
+      "The stack this session ORIGINATED on — the schema-level attribution the cross-stack WORKING aggregation groups by (#1295). D-8 adopts a column + backfill that EXTENDS the ADR-0011 canonical row rather than forking a parallel origin table, so both substrates carry it and the read model stays a plain GROUP BY. NULL ⇒ own/local-stack origin (the pre-CK-4a and single-stack case) — an honest 'unattributed to a specific peer stack', never fabricated. Never sourced from an attacker-controlled payload; stamped from the stack's own resolved identity on write / backfill.",
+  },
 ];
 
 /** The two indices the session-tree refactor adds to BOTH substrates (Phase 0). */
@@ -295,5 +305,6 @@ export const CANONICAL_ADDED_COLUMNS = CANONICAL_SESSION_COLUMNS.filter((c) =>
     "classification",
     "data_residency",
     "home_principal",
+    "origin_stack_id",
   ].includes(c.d1Name)
 );

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -82,6 +82,16 @@ export const SCHEMA_SQL: string[] = [
     state TEXT NOT NULL DEFAULT 'queued'
       CHECK(state IN ('queued','dispatched','running','blocked','completed','failed','cancelled')),
     block_reason TEXT,
+    -- CK-4a / #1295: provider back-pressure hint. When the dispatch lifecycle
+    -- reports not_now { retry_after_ms } (rate/capacity exhaustion — see
+    -- src/runner/dispatch-listener.ts), the assignment sits pre-spawn (queued)
+    -- carrying the earliest-retry delay in ms. NULL ⇒ no pending provider retry.
+    -- LOCAL-ONLY: the dispatch lifecycle never crosses the federation boundary
+    -- (ADR-0005 / the CK-4a scope boundary — dispatch stays local), so the D1
+    -- substrate has no analogue. The read model (db/working-aggregation.ts)
+    -- PROJECTS this; the dispatch-listener → assignment WRITER is the CK-4a
+    -- write-half (#1514 lane) and is deliberately NOT wired here.
+    retry_after_ms INTEGER,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
     -- Invariant: block_reason is non-null iff state = 'blocked'.
@@ -136,7 +146,13 @@ export const SCHEMA_SQL: string[] = [
     cost_usd REAL,
     classification TEXT,
     data_residency TEXT,
-    home_principal TEXT
+    home_principal TEXT,
+    -- CK-4a / #1295 / ADR-0011 canonical: the ORIGIN-stack attribution the
+    -- cross-stack WORKING aggregation groups by (see canonical-session.ts).
+    -- NULL ⇒ own/local-stack origin. Its lookup index idx_sessions_origin_stack_id
+    -- is created by the origin_stack_id COLUMN_ADD_MIGRATIONS post[] (NOT here) —
+    -- same #961/#1048 pre-existing-DB rule as parent_session_id/substrate below.
+    origin_stack_id TEXT
   )`,
 
   // --- events ---
@@ -731,6 +747,36 @@ export const COLUMN_ADD_MIGRATIONS: ColumnAddMigration[] = [
   { table: "sessions", column: "classification", ddl: `ALTER TABLE sessions ADD COLUMN classification TEXT` },
   { table: "sessions", column: "data_residency", ddl: `ALTER TABLE sessions ADD COLUMN data_residency TEXT` },
   { table: "sessions", column: "home_principal", ddl: `ALTER TABLE sessions ADD COLUMN home_principal TEXT` },
+
+  // CK-4a / #1295 / D-8 — the cross-stack ORIGIN attribution for EXISTING DBs.
+  // Fresh DBs get it from the sessions CREATE TABLE above; an already-initialised
+  // DB (the running / aggregating MC-DB stacks) backfills the column here via the
+  // same pragma_table_info gate. Nullable TEXT, no FK (the origin is a stack
+  // IDENTITY string, not a row in this DB). The value-level backfill of existing
+  // NULL rows to this daemon's own stack id is a SEPARATE, id-aware step —
+  // `backfillOriginStackId(db, stackId)` in db/sessions.ts — because the schema
+  // layer does not know the resolved stack id (it lives in config, wired at boot).
+  // The lookup index runs in post[] (unconditional, so fresh DBs get it too).
+  {
+    table: "sessions",
+    column: "origin_stack_id",
+    ddl: `ALTER TABLE sessions ADD COLUMN origin_stack_id TEXT`,
+    post: [
+      `CREATE INDEX IF NOT EXISTS idx_sessions_origin_stack_id ON sessions(origin_stack_id)`,
+    ],
+  },
+
+  // CK-4a / #1295 — provider back-pressure hint for EXISTING assignment DBs.
+  // Fresh DBs get it from the agent_task_assignment CREATE TABLE above. Nullable
+  // INTEGER (ms); a plain ADD COLUMN with no CHECK/NOT NULL, so the ALTER is safe
+  // on a table with rows. LOCAL-ONLY (no D1 analogue — dispatch stays local per
+  // the CK-4a scope boundary). Read by db/working-aggregation.ts; writer deferred
+  // to the dispatch-listener write-half.
+  {
+    table: "agent_task_assignment",
+    column: "retry_after_ms",
+    ddl: `ALTER TABLE agent_task_assignment ADD COLUMN retry_after_ms INTEGER`,
+  },
 
   // P-14 U3.3 (#937) — origin-badge columns for EXISTING observability DBs.
   // Fresh DBs get these from the observability_events CREATE TABLE above; an

--- a/src/surface/mc/db/sessions.ts
+++ b/src/surface/mc/db/sessions.ts
@@ -35,6 +35,12 @@ export function createSession(
     principalId?: string | null;
     /** Denormalized lifecycle status. */
     status?: string | null;
+    /**
+     * CK-4a / #1295 — the stack this session ORIGINATED on. Omit (→ NULL) for
+     * own/local-stack origin, the pre-CK-4a / single-stack default. Stamped from
+     * the stack's own resolved identity; never from a peer-controlled payload.
+     */
+    originStackId?: string | null;
   }
 ): Session {
   const id = generateId();
@@ -45,12 +51,14 @@ export function createSession(
   const agentName = params.agentName ?? null;
   const principalId = params.principalId ?? null;
   const status = params.status ?? null;
+  const originStackId = params.originStackId ?? null;
 
   db.query(
     `INSERT INTO sessions
        (id, assignment_id, cc_session_id, endpoint_kind, pid, started_at,
-        parent_session_id, substrate, agent_id, agent_name, principal_id, status)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        parent_session_id, substrate, agent_id, agent_name, principal_id, status,
+        origin_stack_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     id,
     params.assignmentId,
@@ -63,7 +71,8 @@ export function createSession(
     agentId,
     agentName,
     principalId,
-    status
+    status,
+    originStackId
   );
 
   return {
@@ -89,6 +98,7 @@ export function createSession(
     classification: null,
     data_residency: null,
     home_principal: null,
+    origin_stack_id: originStackId,
   };
 }
 
@@ -115,6 +125,7 @@ interface SessionRow {
   classification: string | null;
   data_residency: string | null;
   home_principal: string | null;
+  origin_stack_id: string | null;
 }
 
 /**
@@ -147,6 +158,7 @@ export function rowToSession(row: SessionRow): Session {
     classification: row.classification,
     data_residency: row.data_residency,
     home_principal: row.home_principal,
+    origin_stack_id: row.origin_stack_id,
   };
 }
 
@@ -154,7 +166,34 @@ export function rowToSession(row: SessionRow): Session {
 export const SESSION_SELECT_COLUMNS = `id, assignment_id, cc_session_id, endpoint_kind, pid,
         started_at, ended_at, parent_session_id, substrate, agent_id, agent_name,
         principal_id, status, duration_ms, events_count, input_tokens, output_tokens,
-        cache_read_tokens, cost_usd, classification, data_residency, home_principal`;
+        cache_read_tokens, cost_usd, classification, data_residency, home_principal,
+        origin_stack_id`;
+
+/**
+ * CK-4a / #1295 / decision D-8 — value-level backfill of `origin_stack_id`.
+ *
+ * The COLUMN_ADD_MIGRATIONS ALTER (db/schema.ts) only ADDS the column (NULL for
+ * every pre-existing row). This stamps the daemon's OWN resolved `stackId` onto
+ * the rows that predate origin attribution — the sessions this stack produced
+ * itself, which by definition originate here. Scoped to `origin_stack_id IS NULL`
+ * so it is idempotent (re-running is a no-op) and NEVER overwrites a value already
+ * attributed to a specific origin (a peer stack's rows in an aggregating MC-DB, or
+ * a value a later write already stamped) — that would corrupt cross-stack grouping.
+ *
+ * Kept out of the schema migration on purpose: the schema layer does not know the
+ * resolved stack id (it lives in config, wired at daemon boot), so the id-aware
+ * backfill is a caller-invoked step. The boot wiring that calls this with the
+ * resolved stack id is the CK-4a write-half (server/runner scope) — deliberately
+ * NOT wired here (the CK-4a scope keeps `server.ts` untouched).
+ *
+ * Returns the number of rows stamped.
+ */
+export function backfillOriginStackId(db: Database, stackId: string): number {
+  const info = db
+    .query(`UPDATE sessions SET origin_stack_id = ? WHERE origin_stack_id IS NULL`)
+    .run(stackId);
+  return info.changes;
+}
 
 /**
  * Shared lookup for the most-recent session of an assignment. `activeOnly`

--- a/src/surface/mc/db/working-aggregation.ts
+++ b/src/surface/mc/db/working-aggregation.ts
@@ -1,0 +1,168 @@
+/**
+ * CK-4a / #1295 — cross-stack WORKING aggregation (LOCAL read model).
+ *
+ * The data half of the cockpit's cross-stack WORKING lane. `workingTileKey`
+ * React-key namespacing was never a data model; this projects a SCHEMA-level
+ * rollup keyed on `sessions.origin_stack_id` (decision D-8), aggregating the
+ * principal's OWN stacks — the sessions a single (aggregating, #1008 MC-DB)
+ * daemon can already see — into per-origin WORKING metadata.
+ *
+ * ── SCOPE BOUNDARY (CK-4a — stated once, enforced by shape) ──────────────────
+ * WORKING tile METADATA — state, counts, origin, timestamps — aggregates across
+ * the principal's own stacks (this module). Dispatch (spawn) and SESSION-interior
+ * drill stay LOCAL-only per ADR-0005 / #989 / #1008: this rollup NEVER carries a
+ * session id, prompt, tool call, diff, or any other interior — only counts and a
+ * provider-retry hint. A federated PEER's rows (a non-null `originStackId` that is
+ * not this daemon's own stack) therefore yield the SAME metadata-only shape as a
+ * local origin — an aggregate tile, never a drillable interior. That invariant is
+ * the local mirror of the worker's `DashboardSnapshot` no-interiors guard
+ * (worker/src/routes/state.ts + its dashboard-snapshot-contract test): this read
+ * flows THROUGH that same metadata-only discipline, never beside it. The shape is
+ * pinned by `__tests__/working-aggregation.test.ts` (allow-list of keys).
+ *
+ * ── Provider-retry is LOCAL-only ─────────────────────────────────────────────
+ * `providerRetry` is sourced from `agent_task_assignment.retry_after_ms` — the
+ * dispatch lifecycle's `not_now { retry_after_ms }` back-pressure. That lifecycle
+ * never crosses the federation boundary (dispatch stays local), so the D1 / cloud
+ * projection (worker `DashboardSnapshot.workingAggregation`) carries the same
+ * typed field but always `null`; only THIS local read model populates it.
+ */
+
+import type { Database } from "bun:sqlite";
+
+/**
+ * Provider back-pressure status for a stack's WORKING lane. Metadata ONLY — a
+ * semantic state tag + a delay in ms; never an interior.
+ */
+export interface ProviderRetryStatus {
+  /** The dispatch lifecycle's back-pressure state. `not_now` ⇒ rate/capacity exhausted. */
+  state: "not_now";
+  /** Earliest-retry delay in ms (the soonest across the stack's pending assignments). */
+  retryAfterMs: number;
+}
+
+/**
+ * One origin-stack's WORKING rollup — pure lifecycle METADATA (see the scope
+ * boundary above). Byte-shape-mirrored (not imported — separate bundle boundary,
+ * per lib/session-tree.ts) by the worker's `WorkingOriginRollup` in
+ * worker/src/routes/state.ts; the two are kept congruent by their respective
+ * shape guards. The local copy additionally POPULATES `providerRetry` (local-only).
+ */
+export interface WorkingStackAggregate {
+  /**
+   * The stack these WORKING sessions originated on. `null` ⇒ own/local-stack
+   * origin (the pre-CK-4a / single-stack case, or a session-less pending
+   * dispatch on this daemon). A non-null value that is not this daemon's own
+   * stack is a federated PEER — still metadata-only here.
+   */
+  originStackId: string | null;
+  /** Count of active (non-terminal, working-state) sessions on this origin stack. */
+  activeSessionCount: number;
+  /**
+   * Of those active sessions, how many are SUB-AGENTS — i.e. carry a
+   * `parent_session_id` (the substrate-projection edge; CONTEXT.md §Session tree).
+   */
+  subAgentCount: number;
+  /** Provider back-pressure across this origin's assignments; `null` ⇒ none pending. */
+  providerRetry: ProviderRetryStatus | null;
+}
+
+/** The three assignment states that qualify a session as "working" (mirrors working-agents.ts). */
+const WORKING_STATES = "('running','dispatched','queued')";
+
+/** The assignment states a pending provider-retry can sit in (pre-terminal). */
+const RETRYABLE_STATES = "('queued','dispatched','running','blocked')";
+
+interface MetaRow {
+  origin: string | null;
+  // COUNT(*) and SUM(CASE …) over a GROUP BY group are always non-null numbers.
+  active: number;
+  subagents: number;
+}
+
+interface RetryRow {
+  origin: string | null;
+  // MIN() is null only if every value in the group is null; the WHERE clause
+  // excludes null retry_after_ms, so returned groups are non-null — but kept
+  // nullable + guarded defensively against the empty-group edge.
+  soonest: number | null;
+}
+
+/**
+ * Aggregate the principal's own stacks into per-origin WORKING metadata.
+ *
+ * "Active" matches the WORKING grid partition exactly: a session that is itself
+ * open (`sessions.ended_at IS NULL`) AND whose owning assignment is in a working
+ * state (running/dispatched/queued) — the same partition `listWorkingAgents`
+ * qualifies a tile on. Sub-agent counts derive from `parent_session_id`.
+ *
+ * `providerRetry` folds `agent_task_assignment.retry_after_ms` per origin. A
+ * pending-retry assignment that has NOT spawned a session yet (session-less,
+ * pre-spawn) has no session-borne origin, so it attributes to the `null`
+ * (own/local) bucket via the LEFT JOIN — an honest "a local dispatch is waiting
+ * on the provider", never fabricated against a peer.
+ *
+ * Deterministic order: the `null` (own/local) origin first, then origin id ASC.
+ */
+export function listWorkingAggregation(db: Database): WorkingStackAggregate[] {
+  const metaRows = db
+    .query(
+      `SELECT s.origin_stack_id AS origin,
+              COUNT(*) AS active,
+              SUM(CASE WHEN s.parent_session_id IS NOT NULL THEN 1 ELSE 0 END) AS subagents
+       FROM sessions s
+       JOIN agent_task_assignment a ON a.id = s.assignment_id
+       WHERE s.ended_at IS NULL
+         AND a.state IN ${WORKING_STATES}
+       GROUP BY s.origin_stack_id`
+    )
+    .all() as MetaRow[];
+
+  const retryRows = db
+    .query(
+      `SELECT s.origin_stack_id AS origin,
+              MIN(a.retry_after_ms) AS soonest
+       FROM agent_task_assignment a
+       LEFT JOIN sessions s
+         ON s.assignment_id = a.id AND s.ended_at IS NULL
+       WHERE a.retry_after_ms IS NOT NULL
+         AND a.state IN ${RETRYABLE_STATES}
+       GROUP BY s.origin_stack_id`
+    )
+    .all() as RetryRow[];
+
+  // Merge the two folds on the shared origin key. Every origin that appears in
+  // EITHER fold gets a tile — an origin with only a pending retry (no active
+  // session yet) is honest WORKING state, and one with only sessions has a null
+  // retry.
+  const byOrigin = new Map<string | null, WorkingStackAggregate>();
+
+  const ensure = (origin: string | null): WorkingStackAggregate => {
+    let agg = byOrigin.get(origin);
+    if (!agg) {
+      agg = { originStackId: origin, activeSessionCount: 0, subAgentCount: 0, providerRetry: null };
+      byOrigin.set(origin, agg);
+    }
+    return agg;
+  };
+
+  for (const r of metaRows) {
+    const agg = ensure(r.origin);
+    agg.activeSessionCount = r.active;
+    agg.subAgentCount = r.subagents;
+  }
+
+  for (const r of retryRows) {
+    if (r.soonest == null) continue;
+    const agg = ensure(r.origin);
+    agg.providerRetry = { state: "not_now", retryAfterMs: r.soonest };
+  }
+
+  return [...byOrigin.values()].sort((a, b) => {
+    // null (own/local) origin sorts first; then origin id ascending.
+    if (a.originStackId === b.originStackId) return 0;
+    if (a.originStackId === null) return -1;
+    if (b.originStackId === null) return 1;
+    return a.originStackId < b.originStackId ? -1 : 1;
+  });
+}

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -447,6 +447,14 @@ export interface AgentTaskAssignment {
   task_id: string;
   state: AssignmentState;
   block_reason: BlockReason | null;
+  /**
+   * CK-4a / #1295 — provider back-pressure hint. Set from the dispatch
+   * lifecycle's `not_now { retry_after_ms }` (rate/capacity exhaustion); the
+   * assignment sits pre-spawn (`queued`) carrying the earliest-retry delay in ms.
+   * NULL ⇒ no pending provider retry. LOCAL-ONLY (no D1 analogue — dispatch stays
+   * local). Projected by db/working-aggregation.ts; writer is the write-half.
+   */
+  retry_after_ms: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -505,6 +513,13 @@ export interface Session {
   classification: string | null;
   data_residency: string | null;
   home_principal: string | null;
+  /**
+   * CK-4a / #1295 / D-8 — the stack this session ORIGINATED on; the schema-level
+   * attribution the cross-stack WORKING aggregation groups by. NULL ⇒ own/local
+   * stack (the pre-CK-4a / single-stack case). Stamped from the stack's own
+   * resolved identity on write / backfill, never from a peer-controlled payload.
+   */
+  origin_stack_id: string | null;
 }
 
 export interface McEvent {

--- a/src/surface/mc/worker/migrations/0006_session_origin_stack.sql
+++ b/src/surface/mc/worker/migrations/0006_session_origin_stack.sql
@@ -1,0 +1,31 @@
+-- CK-4a / #1295 / decision D-8 — cross-stack ORIGIN attribution on the D1 (cloud) snapshot.
+--
+-- Adds the canonical `origin_stack_id` field to the deployed D1 `sessions` table
+-- so the cloud schema matches the local bun:sqlite schema and the shared canonical
+-- source (../../db/canonical-session.ts, CANONICAL_SESSION_COLUMNS):
+--   - sessions.origin_stack_id  (the stack a session ORIGINATED on; NULL ⇒ own/local-stack origin)
+-- plus its lookup index. This is the schema-level origin the cross-stack WORKING
+-- aggregation (DashboardSnapshot.workingAggregation) groups by — replacing the
+-- workingTileKey React-key namespacing that was never a data model (#1295).
+--
+-- D-8 adopts a column + backfill that EXTENDS the ADR-0011 canonical row rather
+-- than forking a parallel origin table, so the read model stays a plain GROUP BY.
+--
+-- Apply: wrangler d1 execute grove-events --file=./migrations/0006_session_origin_stack.sql
+--   (registry/D1 deploys are principal-hands + `--env production`; file only here.)
+--
+-- Additive + idempotent-friendly: ADD COLUMN is one-shot (errors if re-applied on a
+-- DB that already has the column), the index uses IF NOT EXISTS. Mirrors 0005.
+--
+-- Scope note: the local SQLite `sessions` table gets this column from ../../db/schema.ts
+-- (fresh DBs via CREATE TABLE; existing DBs via the COLUMN_ADD_MIGRATIONS pragma-gated
+-- ALTER). Provider-retry (agent_task_assignment.retry_after_ms) is LOCAL-ONLY — D1
+-- carries no agent_task_assignment table, so there is deliberately no column for it here.
+
+ALTER TABLE sessions ADD COLUMN origin_stack_id TEXT;
+
+-- Cross-stack aggregation groups WORKING metadata by origin stack.
+CREATE INDEX IF NOT EXISTS idx_sessions_origin_stack_id ON sessions(origin_stack_id);
+
+-- Bump the schema_version row (0005 seeded version 2).
+INSERT OR IGNORE INTO schema_version (version) VALUES (3);

--- a/src/surface/mc/worker/schema.sql
+++ b/src/surface/mc/worker/schema.sql
@@ -41,7 +41,11 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- status/metrics/sovereignty are columns above) — these two close the gap.
   -- Added to deployed D1 via migrations/0005_session_tree.sql.
   parent_session_id TEXT,                   -- self-ref to the spawning session; NULL ⇒ agent-rooted
-  substrate TEXT NOT NULL DEFAULT 'claude-code'  -- claude-code | codex | … (attribute of a session)
+  substrate TEXT NOT NULL DEFAULT 'claude-code',  -- claude-code | codex | … (attribute of a session)
+  -- CK-4a / #1295 / D-8 canonical: the ORIGIN-stack attribution the cross-stack
+  -- WORKING aggregation (DashboardSnapshot.workingAggregation) groups by. NULL ⇒
+  -- own/local-stack origin. Added to deployed D1 via migrations/0006_session_origin_stack.sql.
+  origin_stack_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS github_events (
@@ -152,6 +156,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_home_principal ON sessions(home_principa
 -- (CANONICAL_SESSION_INDICES) the parity test pins on both substrates.
 CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_substrate ON sessions(substrate);
+-- CK-4a / #1295 — cross-stack aggregation groups WORKING metadata by origin stack.
+CREATE INDEX IF NOT EXISTS idx_sessions_origin_stack_id ON sessions(origin_stack_id);
 CREATE INDEX IF NOT EXISTS idx_github_repo ON github_events(repo, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_agent ON github_events(agent_authored, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_principal ON github_events(principal_id);

--- a/src/surface/mc/worker/src/__tests__/dashboard-snapshot-contract.test.ts
+++ b/src/surface/mc/worker/src/__tests__/dashboard-snapshot-contract.test.ts
@@ -77,6 +77,8 @@ const ALLOWED_COLUMNS: Record<string, string[]> = {
     "last_event_at", "progress_completed", "progress_total", "input_tokens",
     "output_tokens", "cache_read_tokens", "cost_usd", "classification",
     "data_residency", "home_principal", "parent_session_id", "substrate",
+    // CK-4a / #1295 — the cross-stack origin the workingAggregation groups by.
+    "origin_stack_id",
   ],
   session_activity: ["id", "session_id", "timestamp", "icon", "label", "detail"],
   // `payload` IS a raw-JSON-blob column (see the file header) — it exists,
@@ -132,8 +134,18 @@ function columnNamesForTable(schemaSql: string, table: string): string[] {
 
 const TOP_LEVEL_KEYS = new Set([
   "projects", "agents", "sessionTree", "recentCompletions", "recentActivity",
-  "stats", "accountUsage", "principalUsage", "homePrincipals", "updatedAt",
+  "stats", "accountUsage", "principalUsage", "homePrincipals",
+  // CK-4a / #1295 — cross-stack WORKING metadata rollup.
+  "workingAggregation", "updatedAt",
 ]);
+// CK-4a / #1295 — the workingAggregation section is metadata ONLY: an origin id,
+// two counts, and a provider-retry hint. NO session id / interior may appear here
+// (the cross-stack half of the no-interiors guard — see the file header + the
+// db/working-aggregation.ts scope boundary).
+const WORKING_ROLLUP_KEYS = new Set([
+  "originStackId", "activeSessionCount", "subAgentCount", "providerRetry",
+]);
+const PROVIDER_RETRY_KEYS = new Set(["state", "retryAfterMs"]);
 const PROJECT_KEYS = new Set(["id", "displayName"]);
 const AGENT_TILE_KEYS = new Set([
   "id", "name", "principalId", "homePrincipal", "sovereignty", "status", "currentTask",
@@ -260,6 +272,18 @@ function assertSnapshotShape(snapshot: DashboardSnapshot): void {
   for (const [principalId, usage] of Object.entries(snapshot.principalUsage)) {
     assertUsageSnapshot(usage as unknown as Record<string, unknown>, `principalUsage[${principalId}]`);
   }
+
+  // CK-4a / #1295 — the cross-stack WORKING rollup: metadata-only, no interiors.
+  for (const rollup of snapshot.workingAggregation) {
+    assertKeysAllowed(rollup as unknown as Record<string, unknown>, WORKING_ROLLUP_KEYS, "workingAggregation[]");
+    if (rollup.providerRetry) {
+      assertKeysAllowed(
+        rollup.providerRetry as unknown as Record<string, unknown>,
+        PROVIDER_RETRY_KEYS,
+        "workingAggregation[].providerRetry",
+      );
+    }
+  }
 }
 
 describe("DashboardSnapshot allow-list SHAPE guard for the public /api/state projection (S6, #1520)", () => {
@@ -378,6 +402,14 @@ describe("DashboardSnapshot allow-list SHAPE guard for the public /api/state pro
     expect(snapshot.recentActivity.some((i) => i.source === "github")).toBe(true);
     expect(snapshot.accountUsage).not.toBeNull();
     expect(snapshot.sessionTree.some((n) => n.children.length > 0)).toBe(true);
+    // CK-4a — the cross-stack WORKING rollup is populated (s-full + s-child are
+    // active under the null/own origin; s-child is the sub-agent), and the cloud
+    // projection never carries a provider-retry (dispatch lifecycle is local-only).
+    expect(snapshot.workingAggregation.length).toBeGreaterThan(0);
+    const ownOrigin = snapshot.workingAggregation.find((r) => r.originStackId === null);
+    expect(ownOrigin?.activeSessionCount).toBe(2);
+    expect(ownOrigin?.subAgentCount).toBe(1);
+    expect(snapshot.workingAggregation.every((r) => r.providerRetry === null)).toBe(true);
 
     assertSnapshotShape(snapshot);
   });

--- a/src/surface/mc/worker/src/routes/state.ts
+++ b/src/surface/mc/worker/src/routes/state.ts
@@ -197,6 +197,42 @@ export interface DailyStats {
 }
 
 /**
+ * CK-4a / #1295 — provider back-pressure status for a stack's WORKING lane.
+ * Metadata ONLY: a semantic tag + a delay in ms; never an interior.
+ *
+ * Byte-shape-mirror of `db/working-aggregation.ts`'s `ProviderRetryStatus` (a
+ * separate-bundle DUPLICATE, not an import — same rationale as
+ * `worker/src/lib/session-tree.ts` vs `lib/session-tree.ts`). In the CLOUD it is
+ * always `null` (the dispatch lifecycle is local-only — D1 has no
+ * `agent_task_assignment` table), typed here only so the DashboardSnapshot
+ * section shape stays congruent with the local read model.
+ */
+export interface ProviderRetryStatus {
+  state: "not_now";
+  retryAfterMs: number;
+}
+
+/**
+ * CK-4a / #1295 — one origin-stack's cross-stack WORKING rollup, keyed on
+ * `sessions.origin_stack_id` (decision D-8). Pure lifecycle METADATA — active +
+ * sub-agent counts + a provider-retry hint — and the ONLY thing that crosses the
+ * own-stacks boundary. Per ADR-0005 / the CK-4a scope boundary, a peer origin
+ * yields this same metadata-only shape, NEVER a session id/interior: this section
+ * is the cross-stack half of the DashboardSnapshot no-interiors guard, walked by
+ * `__tests__/dashboard-snapshot-contract.test.ts`.
+ *
+ * Byte-shape-mirror of `db/working-aggregation.ts`'s `WorkingStackAggregate`. The
+ * cloud producer sets `providerRetry` to `null` (local-only); the local read
+ * model populates it.
+ */
+export interface WorkingOriginRollup {
+  originStackId: string | null;
+  activeSessionCount: number;
+  subAgentCount: number;
+  providerRetry: ProviderRetryStatus | null;
+}
+
+/**
  * The `/api/state` payload shape — also the `state` slice of the combined
  * `/api/dashboard` payload ({@link CombinedDashboardPayload}, below).
  */
@@ -210,6 +246,13 @@ export interface DashboardSnapshot {
   accountUsage: UsageSnapshotInfo | null;
   principalUsage: Record<string, UsageSnapshotInfo>;
   homePrincipals: string[];
+  /**
+   * CK-4a / #1295 — cross-stack WORKING metadata, one rollup per
+   * `sessions.origin_stack_id`. Metadata-only (counts + provider-retry hint) and
+   * guarded by the no-interiors contract test. `providerRetry` is always `null`
+   * in this cloud projection (dispatch lifecycle is local-only).
+   */
+  workingAggregation: WorkingOriginRollup[];
   updatedAt: string;
 }
 
@@ -262,7 +305,7 @@ export async function buildSnapshot(
   project?: string | null,
   homePrincipal?: string | null,
 ): Promise<DashboardSnapshot> {
-  const [agents, completions, activity, dailyStats, projects, accountUsage, principalUsage, homePrincipals] = await Promise.all([
+  const [agents, completions, activity, dailyStats, projects, accountUsage, principalUsage, homePrincipals, workingAggregation] = await Promise.all([
     getActiveAgents(db, project, homePrincipal),
     getRecentCompletions(db, project, undefined, homePrincipal),
     getRecentActivity(db, project),
@@ -271,6 +314,7 @@ export async function buildSnapshot(
     getLatestAccountUsage(db),
     getPerPrincipalUsage(db),
     getKnownHomePrincipals(db),
+    getWorkingAggregation(db),
   ]);
 
   return {
@@ -298,6 +342,12 @@ export async function buildSnapshot(
      * dropdown; "Local only" (the default) corresponds to `null` here.
      */
     homePrincipals,
+    /**
+     * CK-4a / #1295 — cross-stack WORKING metadata rollup (counts by origin
+     * stack). Metadata-only; providerRetry is null in the cloud (dispatch is
+     * local-only). Flows through the no-interiors contract-test guard.
+     */
+    workingAggregation,
     updatedAt: new Date().toISOString(),
   };
 }
@@ -891,6 +941,40 @@ async function getDailyStats(db: D1Database, date?: string): Promise<DailyStats>
     filesChanged: pushResult?.files ?? 0,
     sessionsCompleted: sessionsResult?.count ?? 0,
   };
+}
+
+/**
+ * CK-4a / #1295 — cross-stack WORKING metadata rollup from D1, grouped by
+ * `sessions.origin_stack_id`. Counts ACTIVE sessions per origin stack and, of
+ * those, the SUB-AGENTS (`parent_session_id IS NOT NULL`).
+ *
+ * Metadata ONLY (ADR-0005 / the CK-4a scope boundary): counts + origin id, never
+ * a session id or interior. `providerRetry` is `null` in the cloud — the dispatch
+ * lifecycle that sources it (`agent_task_assignment.retry_after_ms`) is local-only
+ * and D1 carries no assignment table. The local read model
+ * (`db/working-aggregation.ts`) is the one that populates it.
+ *
+ * Deterministic order: the `null` (own/local) origin first, then origin id ASC —
+ * congruent with the local read model's sort.
+ */
+async function getWorkingAggregation(db: D1Database): Promise<WorkingOriginRollup[]> {
+  const { results } = await db.prepare(`
+    SELECT origin_stack_id AS origin,
+           COUNT(*) AS active,
+           SUM(CASE WHEN parent_session_id IS NOT NULL THEN 1 ELSE 0 END) AS subagents
+    FROM sessions
+    WHERE status = 'active'
+    GROUP BY origin_stack_id
+    ORDER BY (origin_stack_id IS NOT NULL), origin_stack_id
+  `).all();
+
+  return (results ?? []).map((r: Record<string, unknown>) => ({
+    originStackId: (r.origin as string | null) ?? null,
+    activeSessionCount: Number(r.active),
+    subAgentCount: Number(r.subagents),
+    // Local-only (dispatch lifecycle never reaches D1) — always null in the cloud.
+    providerRetry: null,
+  }));
 }
 
 async function getProjects(db: D1Database): Promise<string[]> {


### PR DESCRIPTION
R1 slice **CK-4a** (data half). Adds cross-stack WORKING **metadata** aggregation.

- **Migration (D-8, extends ADR-0011 canonical rows — no forked table):** `origin_stack_id` added to `CANONICAL_SESSION_COLUMNS` (single source → both substrates; parity test green by derivation); local + D1 schema + D1 migration 0006; idempotent `backfillOriginStackId` (stamps NULL rows only).
- **Read model THROUGH the guard:** `db/working-aggregation.ts` per-origin rollup (active + sub-agent counts + provider-retry MIN); `DashboardSnapshot.workingAggregation` flows through the extended no-interiors contract test (a federated peer yields metadata-only — peer session ids never appear).
- Scope boundary coded: WORKING metadata aggregates across own stacks; dispatch + SESSION-interior stay LOCAL-only (ADR-0005).
- **server.ts UNTOUCHED**; write-half (dispatch-listener retry writer), route-half (/api/sessions cross-stack read), and boot backfill call all deferred for a later rebase.
- 91/91 touched tests + 1215 broader pass; tsc 0; eslint clean; vocab PASS.

⏸ **D1 migration 0006 apply is [principal-hands]** (`wrangler ... --env production`, like FND-5). Code merges; migration apply held for @Andreas.

Generated by the R1 opus fleet (ck4a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c