### PR TITLE
feat(mc): CK-3 — right-panel cockpit fusion (R1 · the core reskin)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/mc-cockpit-scope.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-cockpit-scope.test.ts
@@ -1,0 +1,272 @@
+/**
+ * CK-3 (cortex#1289) — pure re-scope lib tests. Pins that the cockpit narrows the
+ * whole-dashboard snapshots to the DIVED stack, that a federated coord fails closed
+ * (ADR-0005), and that governance summary/alarm re-derive honestly from the
+ * filtered rows.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  scopeWorkingTiles,
+  scopeAttention,
+  scopeGovernance,
+  cockpitDispatchAgent,
+} from "../lib/mc-cockpit-scope";
+import type { StackCoord } from "../lib/mc-shell-model";
+import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import type { AgentPresenceTile, AgentOrigin } from "../hooks/use-agents";
+import type { AttentionEntry } from "../../api/attention";
+import type { GovernanceResponse } from "../../api/governance";
+import type {
+  GovernanceVerdictRow,
+  GovernanceDenialRow,
+} from "../../db/governance";
+
+const LOCAL: StackCoord = { principal: "aria", stack: "meta-factory", federated: false };
+const SIBLING: StackCoord = { principal: "aria", stack: "work", federated: false };
+const PEER: StackCoord = { principal: "jc", stack: "home", federated: true };
+
+// ── working tiles ──────────────────────────────────────────────────────────
+
+function tile(agent_id: string, origin: AgentOrigin): WorkingAgentTile {
+  return {
+    agent_id,
+    agent_name: agent_id,
+    agent_type: "head",
+    primary_state_rank: 1,
+    primary_state: "running",
+    primary_assignment: {
+      id: `${agent_id}-a`,
+      task_id: `${agent_id}-t`,
+      task_title: "t",
+      task_priority: 1,
+      updated_at: "2026-07-08T00:00:00Z",
+    },
+    additional_active_count: 0,
+    origin,
+    sessions: [],
+  };
+}
+
+describe("scopeWorkingTiles", () => {
+  it("keeps local-origin tiles + sibling tiles matching the dived stack", () => {
+    const tiles = [
+      tile("luna", "local"),
+      tile("echo", { principal: "aria", stack: "work" }),
+      tile("sage", { principal: "jc", stack: "home" }),
+    ];
+    // Diving into the serving (local) stack: local tiles are own-local by
+    // construction; the foreign-sibling tagged tile for `work` is not this stack.
+    const scoped = scopeWorkingTiles(tiles, LOCAL).map((t) => t.agent_id);
+    expect(scoped).toEqual(["luna"]);
+  });
+
+  it("matches a sibling stack by {principal, stack}", () => {
+    const tiles = [
+      tile("luna", "local"),
+      tile("echo", { principal: "aria", stack: "work" }),
+    ];
+    const scoped = scopeWorkingTiles(tiles, SIBLING).map((t) => t.agent_id);
+    // local tile is own-local (matches any own-local dive per CK-1 semantics);
+    // echo is the sibling `work` stack's.
+    expect(scoped.sort()).toEqual(["echo", "luna"]);
+  });
+
+  it("fails closed for a federated peer coord (ADR-0005)", () => {
+    const tiles = [tile("sage", { principal: "jc", stack: "home" })];
+    expect(scopeWorkingTiles(tiles, PEER)).toEqual([]);
+  });
+});
+
+// ── attention ────────────────────────────────────────────────────────────────
+
+function attn(id: string, stackId: string): AttentionEntry {
+  return {
+    item: {
+      id,
+      stackId,
+      workItemId: null,
+      sessionId: null,
+      kind: "review",
+      severity: "normal",
+      status: "open",
+    },
+    link: { kind: "none" },
+  };
+}
+
+describe("scopeAttention", () => {
+  it("filters entries by AttentionItem.stackId", () => {
+    const entries = [
+      attn("a", "meta-factory"),
+      attn("b", "work"),
+      attn("c", "meta-factory"),
+    ];
+    const scoped = scopeAttention(entries, LOCAL).map((e) => e.item.id);
+    expect(scoped).toEqual(["a", "c"]);
+  });
+
+  it("fails closed for a federated peer coord", () => {
+    const entries = [attn("a", "home")];
+    expect(scopeAttention(entries, PEER)).toEqual([]);
+  });
+});
+
+// ── governance ───────────────────────────────────────────────────────────────
+
+function verdict(
+  over: Partial<GovernanceVerdictRow> & { id: string },
+): GovernanceVerdictRow {
+  return {
+    envelopeId: `${over.id}-env`,
+    layer: "resolved",
+    decision: "allow",
+    name: "act",
+    tool: null,
+    reason: null,
+    resolvedBy: null,
+    principal: "aria",
+    stack: "meta-factory",
+    createdAt: 1_000_000,
+    ...over,
+  };
+}
+
+function denial(
+  over: Partial<GovernanceDenialRow> & { id: string },
+): GovernanceDenialRow {
+  return {
+    envelopeId: `${over.id}-env`,
+    kind: "denied",
+    reasonKind: "authz",
+    isRefusal: false,
+    principalId: null,
+    capability: null,
+    envelopeSubject: null,
+    detail: null,
+    principal: "aria",
+    stack: "meta-factory",
+    createdAt: 1_000_000,
+    ...over,
+  };
+}
+
+const NOW = 2_000_000;
+const RECENT = NOW - 100; // inside 24h
+const OLD = NOW - 200_000; // > 24h ago
+
+function govResponse(over: Partial<GovernanceResponse>): GovernanceResponse {
+  return {
+    verdicts: [],
+    summary: { total: 0, allows: 0, denials: 0, defers: 0, byLayer: { l0: 0, tribunal: 0, gate: 0, resolved: 0 }, denials24h: 0 },
+    denials: [],
+    denialSummary: { total: 0, refusals: 0, otherDenials: 0, byReasonKind: {}, denials24h: 0 },
+    alarm: { tier: "none", denials24h: 0, note: "" },
+    windowDays: 30,
+    listCap: 200,
+    ...over,
+  };
+}
+
+describe("scopeGovernance", () => {
+  it("filters verdict + denial rows to the dived stack and re-derives the summary", () => {
+    const data = govResponse({
+      verdicts: [
+        verdict({ id: "v1", stack: "meta-factory", decision: "allow" }),
+        verdict({ id: "v2", stack: "meta-factory", decision: "deny", createdAt: RECENT }),
+        verdict({ id: "v3", stack: "work", decision: "deny", createdAt: RECENT }), // other stack
+        verdict({ id: "v4", stack: null }), // untagged — excluded
+      ],
+      denials: [
+        denial({ id: "d1", stack: "meta-factory", isRefusal: true, createdAt: RECENT }),
+        denial({ id: "d2", stack: "work" }), // other stack
+      ],
+    });
+    const scoped = scopeGovernance(data, LOCAL, NOW);
+    expect(scoped.verdicts.map((v) => v.id)).toEqual(["v1", "v2"]);
+    expect(scoped.summary.total).toBe(2);
+    expect(scoped.summary.allows).toBe(1);
+    expect(scoped.summary.denials).toBe(1);
+    expect(scoped.summary.denials24h).toBe(1); // v2 is a recent deny
+    expect(scoped.denials.map((d) => d.id)).toEqual(["d1"]);
+    expect(scoped.denialSummary.total).toBe(1);
+    expect(scoped.denialSummary.refusals).toBe(1);
+  });
+
+  it("re-derives the alarm tier from combined 24h denials (>=5 => high)", () => {
+    const verdicts: GovernanceVerdictRow[] = [];
+    for (let i = 0; i < 3; i++) {
+      verdicts.push(verdict({ id: `v${i}`, decision: "deny", createdAt: RECENT }));
+    }
+    const denials: GovernanceDenialRow[] = [];
+    for (let i = 0; i < 2; i++) {
+      denials.push(denial({ id: `d${i}`, createdAt: RECENT }));
+    }
+    const scoped = scopeGovernance(govResponse({ verdicts, denials }), LOCAL, NOW);
+    expect(scoped.alarm.tier).toBe("high"); // 3 + 2 = 5
+    expect(scoped.alarm.denials24h).toBe(5);
+  });
+
+  it("does not count denials older than 24h in the alarm", () => {
+    const scoped = scopeGovernance(
+      govResponse({ verdicts: [verdict({ id: "v", decision: "deny", createdAt: OLD })] }),
+      LOCAL,
+      NOW,
+    );
+    expect(scoped.summary.denials24h).toBe(0);
+    expect(scoped.alarm.tier).toBe("none");
+  });
+
+  it("fails closed for a federated peer coord", () => {
+    const data = govResponse({ verdicts: [verdict({ id: "v", stack: "home", principal: "jc" })] });
+    const scoped = scopeGovernance(data, PEER, NOW);
+    expect(scoped.verdicts).toEqual([]);
+    expect(scoped.summary.total).toBe(0);
+  });
+});
+
+// ── dispatch target ──────────────────────────────────────────────────────────
+
+function presence(
+  over: Partial<AgentPresenceTile> & { agent_id: string },
+): AgentPresenceTile {
+  return {
+    key: `k-${over.agent_id}`,
+    origin: "local",
+    assistant_name: null,
+    nkey_public_key: "pk",
+    principal: "aria",
+    stack: "meta-factory",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 0,
+    ...over,
+  };
+}
+
+describe("cockpitDispatchAgent", () => {
+  it("prefers an online local agent on the dived stack", () => {
+    const agents = [
+      presence({ agent_id: "offlineone", state: "offline" }),
+      presence({ agent_id: "luna", state: "online", assistant_name: "Luna" }),
+    ];
+    const target = cockpitDispatchAgent(agents, LOCAL, "aria");
+    expect(target?.tile.agent_id).toBe("luna");
+    expect(target?.label).toBe("Luna");
+  });
+
+  it("returns null when the stack has no local presence agent", () => {
+    const agents = [
+      presence({ agent_id: "sage", origin: { principal: "jc", stack: "home" }, principal: "jc", stack: "home" }),
+    ];
+    expect(cockpitDispatchAgent(agents, LOCAL, "aria")).toBeNull();
+  });
+
+  it("returns null for a federated peer coord (dispatch is local-only)", () => {
+    const agents = [presence({ agent_id: "luna" })];
+    expect(cockpitDispatchAgent(agents, PEER, "aria")).toBeNull();
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/mc-cockpit.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-cockpit.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * CK-3 (cortex#1289) — cockpit render tests (DOM-free via renderToStaticMarkup).
+ *
+ * Pins the fold: the four legacy surfaces mount stack-scoped; the DISPATCH verb is
+ * ADMIN-posture-gated + own-local; a federated peer shows the ADR-0005 aggregate
+ * notice, not the local lanes; and no cockpit copy renders the deprecated posture
+ * word (built from fragments so THIS file stays carve-out-gate-clean).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { McCockpit, type McCockpitProps } from "../components/mc-cockpit";
+import type { StackCoord } from "../lib/mc-shell-model";
+import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { AttentionEntry } from "../../api/attention";
+import type { GovernanceState } from "../hooks/use-governance";
+
+const FORBIDDEN = ["oper", "ator"].join(""); // the deprecated posture word
+
+const LOCAL: StackCoord = { principal: "aria", stack: "meta-factory", federated: false };
+const PEER: StackCoord = { principal: "jc", stack: "home", federated: true };
+
+const EMPTY_GOV: GovernanceState = { data: null, loaded: true, error: null };
+
+function workingTile(agent_id: string): WorkingAgentTile {
+  return {
+    agent_id,
+    agent_name: agent_id,
+    agent_type: "head",
+    primary_state_rank: 1,
+    primary_state: "running",
+    primary_assignment: {
+      id: `${agent_id}-a`,
+      task_id: `${agent_id}-t`,
+      task_title: `task for ${agent_id}`,
+      task_priority: 1,
+      updated_at: "2026-07-08T00:00:00Z",
+    },
+    additional_active_count: 0,
+    origin: "local",
+    sessions: [],
+  };
+}
+
+function presence(agent_id: string): AgentPresenceTile {
+  return {
+    key: `aria/meta-factory/${agent_id}`,
+    origin: "local",
+    agent_id,
+    assistant_name: agent_id === "luna" ? "Luna" : null,
+    nkey_public_key: "pk",
+    principal: "aria",
+    stack: "meta-factory",
+    capabilities: [],
+    state: "online",
+    offline_reason: null,
+    started_at: null,
+    last_heartbeat_at: null,
+    last_seen_at: 0,
+  };
+}
+
+function attn(id: string, stackId: string): AttentionEntry {
+  return {
+    item: { id, stackId, workItemId: null, sessionId: null, kind: "review", severity: "high", status: "open" },
+    link: { kind: "none" },
+  };
+}
+
+function props(over: Partial<McCockpitProps>): McCockpitProps {
+  return {
+    stack: LOCAL,
+    posture: "admin",
+    servingPrincipal: "aria",
+    presenceAgents: [],
+    workingAgents: [],
+    workingLoaded: true,
+    workingError: null,
+    attention: [],
+    attentionLoaded: true,
+    governance: EMPTY_GOV,
+    onOpenDrill: () => {},
+    ...over,
+  };
+}
+
+function render(over: Partial<McCockpitProps>): string {
+  return renderToStaticMarkup(createElement(McCockpit, props(over)));
+}
+
+describe("McCockpit — own-local stack", () => {
+  it("mounts the ATTENTION, WORKING, and GOVERN lanes", () => {
+    const html = render({});
+    expect(html).toContain("mc-cockpit");
+    expect(html).toContain("attention-view");
+    expect(html).toContain("working-grid-section");
+    expect(html).toContain("mc-cockpit-govern");
+    expect(html).toContain("GOVERN");
+    // never the deprecated posture word
+    expect(html).not.toContain(FORBIDDEN);
+  });
+
+  it("scopes attention to the dived stack (drops other stacks' items)", () => {
+    const html = render({
+      attention: [attn("mine", "meta-factory"), attn("theirs", "work")],
+    });
+    // The scoped entry's severity badge is present; the other-stack item is gone.
+    // (attention items key on id; both would show a `high` badge if unscoped.)
+    expect(html).toContain("mc-cockpit");
+    // 'theirs' belongs to stack 'work' — it must NOT contribute a link/label.
+    // The scoped queue is [mine]; assert exactly one attention <li>.
+    const liCount = (html.match(/attention-item/g) ?? []).length;
+    expect(liCount).toBe(1);
+  });
+
+  it("renders the DISPATCH verb for ADMIN posture with a local agent present", () => {
+    const html = render({
+      posture: "admin",
+      presenceAgents: [presence("luna")],
+      workingAgents: [workingTile("luna")],
+      onDispatchDirect: () => {},
+    });
+    expect(html).toContain("mc-cockpit-dispatch");
+    expect(html).toContain("Dispatch to");
+    expect(html).toContain("Luna");
+    expect(html).toContain("dispatch-btn");
+  });
+
+  it("does NOT render the DISPATCH verb for MEMBER posture (fail-closed)", () => {
+    const html = render({
+      posture: "member",
+      presenceAgents: [presence("luna")],
+      onDispatchDirect: () => {},
+    });
+    expect(html).not.toContain("dispatch-btn");
+    expect(html).toContain("participate in this network");
+    expect(html).not.toContain(FORBIDDEN);
+  });
+
+  it("does NOT render the DISPATCH verb for unknown posture (fail-closed)", () => {
+    const html = render({
+      posture: null,
+      presenceAgents: [presence("luna")],
+      onDispatchDirect: () => {},
+    });
+    expect(html).not.toContain("dispatch-btn");
+  });
+
+  it("shows an honest no-agent note for ADMIN posture with no local agent", () => {
+    const html = render({ posture: "admin", presenceAgents: [], onDispatchDirect: () => {} });
+    expect(html).not.toContain("dispatch-btn");
+    expect(html).toContain("No local agent online to dispatch");
+  });
+});
+
+describe("McCockpit — federated peer (ADR-0005)", () => {
+  it("renders the aggregate notice, not the local lanes", () => {
+    const html = render({ stack: PEER, posture: "member" });
+    expect(html).toContain("mc-cockpit--peer");
+    expect(html).toContain("AGGREGATE ONLY");
+    expect(html).toContain("federated peer");
+    // none of the local operational lanes are rendered for a peer
+    expect(html).not.toContain("attention-view");
+    expect(html).not.toContain("working-grid-section");
+    expect(html).not.toContain("dispatch-btn");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/mc-shell.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-shell.test.tsx
@@ -238,4 +238,39 @@ describe("McShell", () => {
     expect(html).toContain("ADMIN");
     expect(html).not.toContain("OPERATOR");
   });
+
+  it("renders the pane full-width when no cockpit is provided (non-regressive)", () => {
+    const html = renderToStaticMarkup(
+      createElement(McShell, {
+        principal: "aria",
+        networks: NETWORKS,
+        selection: ROOT_SELECTION,
+        onSelectionChange: () => {},
+        children: createElement("div", { className: "framed-pane" }, "BODY"),
+      }),
+    );
+    // No split/dock chrome above STACK.
+    expect(html).not.toContain("mc-shell-split");
+    expect(html).not.toContain("mc-cockpit-dock");
+    expect(html).toContain("framed-pane");
+  });
+
+  it("CK-3 — splits into pane + cockpit dock when a cockpit slot is given", () => {
+    const html = renderToStaticMarkup(
+      createElement(McShell, {
+        principal: "aria",
+        networks: NETWORKS,
+        selection: ROOT_SELECTION,
+        onSelectionChange: () => {},
+        cockpit: createElement("div", { className: "the-cockpit" }, "COCKPIT"),
+        children: createElement("div", { className: "framed-pane" }, "BODY"),
+      }),
+    );
+    expect(html).toContain("mc-shell-split");
+    expect(html).toContain("mc-cockpit-dock");
+    // both the framed pane AND the cockpit render
+    expect(html).toContain("framed-pane");
+    expect(html).toContain("the-cockpit");
+    expect(html).toContain("COCKPIT");
+  });
 });

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -69,6 +69,17 @@ import type { Command } from "./components/command-palette";
  */
 type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "work-item-detail" | "attention" | "kanban-detail" | "network" | "governance" | "observability";
 
+/**
+ * CK-3 / D-1(c) — the legacy escape hatch. The cockpit (in the Network view) is
+ * now the stack-scoped home for the ATTENTION + GOVERNANCE surfaces; their
+ * whole-dashboard standalone tabs are kept behind `?legacy=1` for ONE release,
+ * then CK-10 deletes them. Read once at module load (the flag never changes
+ * mid-session). SSR-safe (`renderToStaticMarkup` tests have no `window`).
+ */
+const LEGACY_ESCAPE_HATCH =
+  typeof window !== "undefined" &&
+  new URLSearchParams(window.location.search).get("legacy") === "1";
+
 export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
   // G-1113.C.7 — software mode gates the Repositories panel.
@@ -125,8 +136,14 @@ export function App() {
   const phaseDetail = usePhaseDetail(view === "phase-detail" ? selectedPhaseId : null);
   // G-1113.D.5 — work-item-detail data (fetched whenever a work item is selected).
   const workItemDetail = useWorkItemDetail(view === "work-item-detail" ? selectedWorkItemId : null);
-  // G-1113.E.3 — attention queue data (fetched only when on the Attention tab).
-  const attention = useAttention(ws, softwareMode && view === "attention");
+  // G-1113.E.3 — attention queue data. Enabled on the legacy Attention tab AND on
+  // the Network tab (CK-3): the cockpit's ATTENTION lane consumes this ONE
+  // snapshot (fetched once + WS-kept-fresh), scoped per-stack in the panel — the
+  // single subscription that replaces the folded surfaces' fetch-on-tab-visible.
+  const attention = useAttention(
+    ws,
+    (softwareMode && view === "attention") || view === "network",
+  );
   // G-1114.B.4 — stack-local agent-presence data (fetched only when on the
   // Network tab); live-refreshed off the `agent.presence` WS frame.
   const agents = useAgents(ws, view === "network");
@@ -134,8 +151,10 @@ export function App() {
   // Network view's first-class trust-group panel. Fetched only when the tab is
   // visible; refreshes off the same `agent.presence` signal as `useAgents`.
   const networks = useNetworks(ws, view === "network");
-  // G-1115 — governance verdicts, fetched only when the tab is visible.
-  const governance = useGovernance(ws, view === "governance");
+  // G-1115 — governance verdicts. Enabled on the legacy Governance tab AND on the
+  // Network tab (CK-3): the cockpit's GOVERN lane folds this audit scoped to the
+  // dived stack. Same single-snapshot rationale as `attention` above.
+  const governance = useGovernance(ws, view === "governance" || view === "network");
   // P-14 U2.1 (#934) — observability events (signal's four system.* families),
   // fetched when the Observability tab is visible; live-refreshed off the
   // `observability` mc.projection family.
@@ -378,15 +397,19 @@ export function App() {
         >
           Network
         </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={view === "governance"}
-          className={`tab${view === "governance" ? " active" : ""}`}
-          onClick={() => setView("governance")}
-        >
-          Governance
-        </button>
+        {/* CK-3 / D-1(c) — Governance folds into the stack cockpit (Network view).
+            The whole-dashboard tab survives behind `?legacy=1` for one release. */}
+        {LEGACY_ESCAPE_HATCH && (
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "governance"}
+            className={`tab${view === "governance" ? " active" : ""}`}
+            onClick={() => setView("governance")}
+          >
+            Governance <span className="dim mono" style={{ fontSize: 9 }}>legacy</span>
+          </button>
+        )}
         <button
           type="button"
           role="tab"
@@ -418,7 +441,9 @@ export function App() {
             Plans
           </button>
         )}
-        {softwareMode && (
+        {/* CK-3 / D-1(c) — Attention folds into the stack cockpit (Network view).
+            The whole-dashboard tab survives behind `?legacy=1` for one release. */}
+        {softwareMode && LEGACY_ESCAPE_HATCH && (
           <button
             type="button"
             role="tab"
@@ -426,7 +451,7 @@ export function App() {
             className={`tab${view === "attention" ? " active" : ""}`}
             onClick={() => setView("attention")}
           >
-            Attention
+            Attention <span className="dim mono" style={{ fontSize: 9 }}>legacy</span>
           </button>
         )}
       </nav>
@@ -580,9 +605,10 @@ export function App() {
           <SourcesView />
         )}
 
-        {view === "governance" && (
+        {view === "governance" && LEGACY_ESCAPE_HATCH && (
           /* G-1115 — read-only governance audit surface: verdicts from the
-             governed-action stack (pulse P-702) read back off the bus. */
+             governed-action stack (pulse P-702) read back off the bus. CK-3/D-1:
+             folded into the stack cockpit; this whole-dashboard tab is `?legacy=1`. */
           <GovernanceView state={governance} />
         )}
 
@@ -611,6 +637,24 @@ export function App() {
             // roster ⋈ presence → membership verdict). Empty until the fetch
             // lands / on a non-federated stack; the panel renders nothing then.
             networks={networks.networks}
+            // CK-3 — the app-scope snapshots the stack cockpit folds + scopes to
+            // the dived stack (ATTENTION / WORKING / GOVERN). One subscription each.
+            attention={attention}
+            governance={governance}
+            workingLoaded={working.loaded}
+            workingError={working.error}
+            // CK-3 — cockpit attention work-item deep link → work-item-detail
+            // (returns to the Network view). Needs software mode (the surface is
+            // software-mode-gated); honest toast otherwise.
+            onOpenWorkItem={(workItemId) => {
+              if (!softwareMode) {
+                showToast("Enable software mode to open work items", "info");
+                return;
+              }
+              setSelectedWorkItemId(workItemId);
+              setWorkItemBackView("network");
+              setView("work-item-detail");
+            }}
             onViewInWorkingGrid={() => setView("default")}
             // CK-1 (cortex#1289) — diving the altitude rail to SESSION (an
             // own-local assistant's session) opens the REUSED F-7 drill-down —
@@ -841,8 +885,9 @@ export function App() {
           />
         )}
 
-        {view === "attention" && softwareMode && (
-          /* G-1113.E.3 — attention queue surface (deep-links to WI / session). */
+        {view === "attention" && softwareMode && LEGACY_ESCAPE_HATCH && (
+          /* G-1113.E.3 — attention queue surface (deep-links to WI / session).
+             CK-3/D-1: folded into the stack cockpit; this tab is `?legacy=1`. */
           <AttentionView
             entries={attention.entries}
             loaded={attention.loaded}

--- a/src/surface/mc/dashboard-v2/components/mc-cockpit.css
+++ b/src/surface/mc/dashboard-v2/components/mc-cockpit.css
@@ -1,0 +1,256 @@
+/*
+ * CK-3 (cortex#1289) — right-panel COCKPIT re-skin.
+ *
+ * The cockpit FOLDS the four legacy surfaces (AttentionView / WorkingGrid /
+ * GovernanceView / DispatchButton) unchanged. Because it mounts inside McShell's
+ * `.mc-skin` wrapper, the shared token NAMES those components reference
+ * (--line/--warn/--bad/--ok/--dim/--faint/--fg/--mono/--sans) already resolve to
+ * the D1 constellation palette — so most colour adapts for free. This file adds
+ * the LANE LAYOUT + the chrome overrides that turn the components' `scaffold-*`
+ * markup into mc-skin panels in the narrow dock. Everything is scoped under
+ * `.mc-cockpit`, so it has zero blast radius on the legacy `?legacy=1` tabs.
+ */
+
+.mc-cockpit {
+  /* The scaffold components use `--accent`; mc-skin doesn't define it. Remap it to
+     the meridian accent so links/pills read on-brand inside the cockpit. */
+  --accent: var(--mer);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  font-family: var(--sans);
+  color: var(--fg);
+}
+
+/* ── Lane framing ─────────────────────────────────────────────────────────── */
+.mc-cockpit-lane {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: linear-gradient(180deg, var(--panel2), var(--panel));
+  padding: 12px 14px;
+}
+
+.mc-cockpit-lane-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.mc-cockpit-lane-title {
+  font: 700 11px var(--mono);
+  color: var(--faint);
+  letter-spacing: 0.14em;
+}
+
+/* Re-skin the folded components' section chrome: drop their card look (they get
+   the mc lane frame above) and normalise spacing for the narrow dock. */
+.mc-cockpit .scaffold-section,
+.mc-cockpit .working-grid-section {
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  box-shadow: none;
+}
+
+/* Their headings → the mono lane-title look. */
+.mc-cockpit h2 {
+  font: 700 11px var(--mono);
+  color: var(--faint);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin: 0 0 10px;
+}
+.mc-cockpit h3 {
+  font: 600 10px var(--mono);
+  color: var(--dim);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin: 12px 0 6px;
+}
+.mc-cockpit .dim {
+  color: var(--dim);
+}
+.mc-cockpit .faint {
+  color: var(--faint);
+}
+
+/* ── ATTENTION lane ───────────────────────────────────────────────────────── */
+.mc-cockpit .attention-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.mc-cockpit .attention-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-left-width: 3px;
+  border-radius: 6px;
+  background: var(--panel);
+  font: 500 11px var(--mono);
+}
+.mc-cockpit .attention-item .badge {
+  font: 600 9px var(--mono);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: var(--dim);
+}
+.mc-cockpit .attention-link {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--mer);
+  font: 500 11px var(--mono);
+  cursor: pointer;
+  padding: 2px 4px;
+}
+.mc-cockpit .attention-link:hover {
+  text-decoration: underline;
+}
+
+/* ── WORKING lane ─────────────────────────────────────────────────────────── */
+/* Single-column tiles — the dock is narrow, so the multi-column grid collapses. */
+.mc-cockpit .working-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.mc-cockpit .working-tile {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel);
+  padding: 9px 11px;
+  cursor: pointer;
+  color: var(--fg);
+}
+.mc-cockpit .working-tile:hover {
+  border-color: color-mix(in oklch, var(--mer) 45%, transparent);
+}
+.mc-cockpit .working-tile .agent {
+  font: 600 12px var(--mono);
+  color: var(--fg);
+}
+.mc-cockpit .working-tile .task {
+  font: 400 11px var(--sans);
+  color: var(--dim);
+  margin-top: 2px;
+}
+.mc-cockpit .working-tile .meta {
+  font: 500 10px var(--mono);
+  color: var(--faint);
+  margin-top: 4px;
+}
+.mc-cockpit .working-grid-empty,
+.mc-cockpit .working-grid-error {
+  font: 500 11px var(--mono);
+  color: var(--faint);
+  padding: 6px 0;
+}
+
+/* ── GOVERN lane ──────────────────────────────────────────────────────────── */
+.mc-cockpit-govern .governance-alarm {
+  font: 500 11px var(--mono);
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  margin: 0 0 10px;
+}
+.mc-cockpit-govern .governance-alarm.alarm-elevated {
+  border-color: color-mix(in oklch, var(--warn) 50%, transparent);
+  color: var(--warn);
+}
+.mc-cockpit-govern .governance-alarm.alarm-high {
+  border-color: color-mix(in oklch, var(--bad) 55%, transparent);
+  color: var(--bad);
+}
+/* The audit tables are wide; let them scroll inside the narrow dock rather than
+   forcing the whole panel to overflow. */
+.mc-cockpit-govern .governance-subsection {
+  overflow-x: auto;
+}
+.mc-cockpit-govern .governance-table {
+  border-collapse: collapse;
+  font: 500 10px var(--mono);
+  min-width: 100%;
+}
+.mc-cockpit-govern .governance-table th {
+  text-align: left;
+  color: var(--faint);
+  font-weight: 600;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+.mc-cockpit-govern .governance-table td {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--lsoft);
+  color: var(--dim);
+}
+.mc-cockpit-govern .governance-table .badge {
+  font: 600 9px var(--mono);
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+.mc-cockpit-govern .governance-summary {
+  font: 500 10px var(--mono);
+  color: var(--faint);
+  margin: 6px 0;
+}
+
+/* ── DISPATCH affordance (admin posture, own-local) ───────────────────────── */
+.mc-cockpit-dispatch {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+}
+.mc-cockpit-dispatch-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.mc-cockpit-dispatch-label {
+  font: 500 11px var(--mono);
+  color: var(--dim);
+}
+.mc-cockpit .mc-cockpit-dispatch-btn .dispatch-btn {
+  font: 600 10px var(--mono);
+  letter-spacing: 0.04em;
+  padding: 5px 12px;
+  border: 1px solid color-mix(in oklch, var(--mer) 45%, transparent);
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--mer) 12%, transparent);
+  color: var(--mer);
+  cursor: pointer;
+}
+.mc-cockpit .mc-cockpit-dispatch-btn .dispatch-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.mc-cockpit-note {
+  font: 500 11px var(--mono);
+  color: var(--faint);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ── Federated-peer aggregate notice (ADR-0005) ───────────────────────────── */
+.mc-cockpit--peer .mc-cockpit-peer-notice {
+  border: 1px dashed var(--line);
+  border-radius: 9px;
+  background: color-mix(in oklch, var(--tide) 7%, transparent);
+  padding: 14px 15px;
+}
+.mc-cockpit--peer .mc-cockpit-note {
+  color: var(--dim);
+}

--- a/src/surface/mc/dashboard-v2/components/mc-cockpit.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-cockpit.tsx
@@ -1,0 +1,218 @@
+/**
+ * CK-3 (cortex#1289) — the right-panel COCKPIT.
+ *
+ * Folds the four legacy standalone G-1113 surfaces — ATTENTION, WORKING, GOVERN
+ * (governance audit + DISPATCH) — into ONE stack-scoped panel that mounts inside
+ * `McShell`'s `.mc-skin` cockpit slot. This is a FOLD, not a rebuild: the four
+ * components (`AttentionView`, `WorkingGrid`, `GovernanceView`, `DispatchButton`)
+ * are REUSED verbatim; `mc-cockpit.css` re-skins their `scaffold-*` markup to the
+ * D1 mc tokens when they render inside `.mc-cockpit`, exactly the pane-by-pane
+ * adoption pattern McShell already uses.
+ *
+ * ## Stack-scoped, single snapshot subscription
+ *
+ * The legacy surfaces were whole-dashboard + fetch-on-tab-visible. The cockpit is
+ * scoped to the DIVED stack (`AltitudeSelection.stack`) via the pure
+ * `mc-cockpit-scope` lib, fed by the app-scope snapshots (one fetch + WS-kept-fresh
+ * per feed — the single subscription that replaces per-panel tab-gated polling).
+ * No fetching happens here.
+ *
+ * ## Sovereignty + posture (ADR-0005 + fail-closed posture gate)
+ *
+ *   - A FEDERATED PEER stack exposes AGGREGATE metadata only — its attention /
+ *     working / governance interiors are NOT ours. So a peer renders an honest
+ *     aggregate notice, never the local lanes.
+ *   - DISPATCH is a GOVERN affordance: it renders ONLY for ADMIN posture
+ *     (`isAdminPosture` via `selectedNetworkPosture`) on an OWN-LOCAL stack with a
+ *     local agent present. Member/unknown posture ⇒ no dispatch button, an honest
+ *     member note instead (no Leave button — invariant 16; CK-7 owns the full
+ *     GOVERN bar + member footer). Fail-closed: absent the admin proof, no verb.
+ *   - Dispatch reuses the FND-6-gated `POST /api/sessions` path through the host's
+ *     `onDispatchDirect` (App owns the call + identity context) — never a bypass.
+ *
+ * The mockup's on-screen posture word is the deprecated pre-migration term; this
+ * cockpit renders **admin / member** only.
+ */
+
+import { AttentionView } from "./attention-view";
+import { WorkingGrid } from "./working-grid";
+import { GovernanceView } from "./governance-view";
+import { DispatchButton } from "./dispatch-button";
+import {
+  scopeAttention,
+  scopeWorkingTiles,
+  scopeGovernance,
+  cockpitDispatchAgent,
+} from "../lib/mc-cockpit-scope";
+import { stackLabel, type StackCoord, type NetworkPosture } from "../lib/mc-shell-model";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import type { AttentionEntry } from "../../api/attention";
+import type { GovernanceState } from "../hooks/use-governance";
+import "./mc-cockpit.css";
+
+export interface McCockpitProps {
+  /** The dived stack (STACK level or deeper). The cockpit is scoped to it. */
+  stack: StackCoord;
+  /** Posture toward the selected network (`null` at the root / no network). */
+  posture: NetworkPosture | null;
+  /** Serving principal — classifies own-local vs federated for the dispatch pick. */
+  servingPrincipal: string | null;
+  /** Live presence agents (whole-dashboard) — scoped to the stack for dispatch. */
+  presenceAgents: readonly AgentPresenceTile[];
+  /** Working-agents snapshot (whole-dashboard) — scoped to the stack. */
+  workingAgents: readonly WorkingAgentTile[];
+  workingLoaded: boolean;
+  workingError: string | null;
+  /** Attention queue (whole-dashboard) — scoped to the stack. */
+  attention: readonly AttentionEntry[];
+  attentionLoaded: boolean;
+  /** Governance audit (whole-dashboard) — scoped to the stack. */
+  governance: GovernanceState;
+  /** Open the F-7 drill-down overlay (working tile / attention session link). */
+  onOpenDrill: (assignmentId: string) => void;
+  /** Open the work-item-detail surface (attention work-item deep link). */
+  onOpenWorkItem?: (workItemId: string) => void;
+  /**
+   * Dispatch DIRECTLY to a local agent via the FND-6-gated `/api/sessions` path
+   * (App owns the call + identity context). Admin-posture + own-local only.
+   */
+  onDispatchDirect?: (agent: AgentPresenceTile) => void;
+  /** Agent keys with an in-flight dispatch (busy state for the button). */
+  dispatchingAgentKeys?: ReadonlySet<string>;
+}
+
+export function McCockpit({
+  stack,
+  posture,
+  servingPrincipal,
+  presenceAgents,
+  workingAgents,
+  workingLoaded,
+  workingError,
+  attention,
+  attentionLoaded,
+  governance,
+  onOpenDrill,
+  onOpenWorkItem,
+  onDispatchDirect,
+  dispatchingAgentKeys,
+}: McCockpitProps) {
+  // A federated peer is AGGREGATE-ONLY (ADR-0005) — none of the local operational
+  // lanes are ours to render. Show the honest boundary instead.
+  if (stack.federated) {
+    return (
+      <div className="mc-cockpit mc-cockpit--peer" aria-label="stack cockpit">
+        <PeerAggregateNotice stack={stack} />
+      </div>
+    );
+  }
+
+  const scopedAttention = scopeAttention(attention, stack);
+  const scopedWorking = scopeWorkingTiles(workingAgents, stack);
+  const scopedGovernance: GovernanceState = {
+    ...governance,
+    data: governance.data ? scopeGovernance(governance.data, stack) : null,
+  };
+
+  const isAdmin = posture === "admin";
+  const dispatchTarget = cockpitDispatchAgent(presenceAgents, stack, servingPrincipal);
+
+  return (
+    <div className="mc-cockpit" aria-label="stack cockpit">
+      {/* ── ATTENTION — who needs me, on this stack ─────────────────────────── */}
+      <section className="mc-cockpit-lane" aria-label="Attention (stack)">
+        <AttentionView
+          entries={scopedAttention}
+          loaded={attentionLoaded}
+          {...(onOpenWorkItem ? { onOpenWorkItem } : {})}
+          onOpenAssignment={onOpenDrill}
+        />
+      </section>
+
+      {/* ── WORKING — whose hands are working, on this stack ────────────────── */}
+      <section className="mc-cockpit-lane" aria-label="Working (stack)">
+        <WorkingGrid
+          agents={scopedWorking}
+          loaded={workingLoaded}
+          error={workingError}
+          // focusItemCount 0 keeps the lane always-present (never the "hide when a
+          // focus row exists" branch — the cockpit lane is not the focus row).
+          focusItemCount={0}
+          drillOpen={false}
+          onOpen={onOpenDrill}
+        />
+      </section>
+
+      {/* ── GOVERN — read-only audit + the posture-gated DISPATCH verb ──────── */}
+      <section className="mc-cockpit-lane mc-cockpit-govern" aria-label="Govern (stack)">
+        <div className="mc-cockpit-lane-head">
+          <span className="mc-cockpit-lane-title">GOVERN</span>
+        </div>
+
+        <GovernanceView state={scopedGovernance} />
+
+        <div className="mc-cockpit-dispatch">
+          {isAdmin ? (
+            dispatchTarget && onDispatchDirect ? (
+              <div className="mc-cockpit-dispatch-row">
+                <span className="mc-cockpit-dispatch-label">
+                  Dispatch to <strong>{dispatchTarget.label}</strong>
+                </span>
+                <DispatchButton
+                  agentLabel={dispatchTarget.label}
+                  busy={dispatchingAgentKeys?.has(dispatchTarget.tile.key) ?? false}
+                  onConfirm={() => onDispatchDirect(dispatchTarget.tile)}
+                  className="mc-cockpit-dispatch-btn"
+                />
+              </div>
+            ) : (
+              <p className="mc-cockpit-note dim">
+                No local agent online to dispatch to on this stack.
+              </p>
+            )
+          ) : (
+            <MemberGovernNote posture={posture} />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/**
+ * The member-posture govern note. Govern verbs (admission, keys, dispatch) are the
+ * network admin's — a member observes. Leave is deliberately NOT a button (it is
+ * CLI-only by design, invariant 16); CK-7 owns the fuller member footer.
+ */
+function MemberGovernNote({ posture }: { posture: NetworkPosture | null }) {
+  return (
+    <p className="mc-cockpit-note dim">
+      {posture === "member"
+        ? "You participate in this network — admission, keys, and dispatch are the network admin's."
+        : "Govern verbs are the network admin's."}
+    </p>
+  );
+}
+
+/**
+ * The federated-peer aggregate notice. Across the sovereignty boundary (ADR-0005)
+ * a peer's attention / working / governance interiors are not ours — only the
+ * aggregate face (rendered by the CK-2 stack header). The cockpit says so honestly
+ * rather than showing empty local lanes.
+ */
+function PeerAggregateNotice({ stack }: { stack: StackCoord }) {
+  return (
+    <div className="mc-cockpit-peer-notice">
+      <div className="mc-cockpit-lane-head">
+        <span className="mc-cockpit-lane-title">AGGREGATE ONLY</span>
+      </div>
+      <p className="mc-cockpit-note dim">
+        <strong>{stackLabel(stack)}</strong> is a federated peer. Its attention,
+        working sessions, and governance audit stay on its own Mission Control —
+        the sovereignty boundary (ADR-0005) exposes aggregate metadata here, never a
+        peer&rsquo;s operational interiors.
+      </p>
+    </div>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/mc-shell.css
+++ b/src/surface/mc/dashboard-v2/components/mc-shell.css
@@ -30,6 +30,35 @@
   overflow: auto;
 }
 
+/* ── CK-3 cockpit dock ────────────────────────────────────────────────────── */
+/* When a stack is dived into, the content splits into the framed pane (left) +
+   the stack-scoped cockpit dock (right). Above STACK the pane renders full-width
+   and neither of these selectors applies (non-regressive). */
+.mc-shell-split {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+  min-height: 100%;
+}
+.mc-shell-pane {
+  flex: 1;
+  min-width: 0;
+}
+.mc-cockpit-dock {
+  width: 360px;
+  flex-shrink: 0;
+}
+
+/* Narrow viewports: drop the dock below the pane rather than squeezing both. */
+@media (max-width: 1100px) {
+  .mc-shell-split {
+    flex-direction: column;
+  }
+  .mc-cockpit-dock {
+    width: 100%;
+  }
+}
+
 /* ── Command bar (64px top chrome) ───────────────────────────────────────── */
 .mc-command-bar {
   display: flex;

--- a/src/surface/mc/dashboard-v2/components/mc-shell.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-shell.tsx
@@ -61,6 +61,14 @@ export interface McShellProps {
    * from the live agent snapshot + the transport overlay (`buildStackHeader`).
    */
   stackHeader?: StackHeaderModel | null;
+  /**
+   * CK-3 — the stack-scoped right-panel cockpit (ATTENTION / WORKING / GOVERN /
+   * DISPATCH folded). Present ONLY when a stack is dived into; `null`/absent above
+   * STACK → the framed pane renders full-width exactly as pre-CK-3 (non-regressive).
+   * The caller (`network-view`) builds it from the app-scope snapshots scoped to
+   * the dived stack.
+   */
+  cockpit?: ReactNode | null;
   /** The framed pane (the existing Network view body). */
   children: ReactNode;
 }
@@ -73,10 +81,20 @@ export function McShell({
   sessionTargets = [],
   onOpenSession,
   stackHeader = null,
+  cockpit = null,
   children,
 }: McShellProps) {
   const breadcrumb = buildBreadcrumb(selection);
   const posture = selectedNetworkPosture(networks, selection);
+
+  // The framed pane (stack header + the Network body). Shared between the
+  // cockpit-docked and full-width layouts so `children` renders identically.
+  const pane = (
+    <>
+      {stackHeader ? <McStackHeader model={stackHeader} /> : null}
+      {children}
+    </>
+  );
 
   return (
     <div className="mc-skin mc-shell">
@@ -100,8 +118,20 @@ export function McShell({
           {...(onOpenSession ? { onOpenSession } : {})}
         />
         <div className="mc-shell-content">
-          {stackHeader ? <McStackHeader model={stackHeader} /> : null}
-          {children}
+          {cockpit ? (
+            // CK-3 — dived into a stack: split the content into the framed pane +
+            // the stack-scoped right-panel cockpit dock.
+            <div className="mc-shell-split">
+              <div className="mc-shell-pane">{pane}</div>
+              <aside className="mc-cockpit-dock" aria-label="Stack cockpit">
+                {cockpit}
+              </aside>
+            </div>
+          ) : (
+            // Above STACK (or no cockpit): the pane renders full-width, exactly as
+            // pre-CK-3 — non-regressive.
+            pane
+          )}
         </div>
       </div>
     </div>

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -79,6 +79,7 @@ import { NetworkSpotlight } from "./network-spotlight";
 import { NetworkRosterPanel } from "./network-roster-panel";
 import { PierQueue } from "./pier-queue";
 import { McShell } from "./mc-shell";
+import { McCockpit } from "./mc-cockpit";
 import {
   ROOT_SELECTION,
   diveToStack,
@@ -86,8 +87,11 @@ import {
   openSession,
   drillToNetwork,
   stackReachesSession,
+  selectedNetworkPosture,
   type AltitudeSelection,
 } from "../lib/mc-shell-model";
+import type { AttentionEntry } from "../../api/attention";
+import type { GovernanceState } from "../hooks/use-governance";
 import {
   stackCoordFromHub,
   stackCoordFromTile,
@@ -186,9 +190,26 @@ export interface NetworkViewProps {
    * REUSED F-7 drill-down overlay (App owns `setDrillId`). Never called for a
    * federated peer (ADR-0005 — `openSession` refuses one). Omitted → the SESSION
    * targets still dive the rail, but no interior mounts (a host without the drill
-   * wired, e.g. a test harness).
+   * wired, e.g. a test harness). ALSO the cockpit's working-tile / attention-session
+   * drill opener (CK-3) — a bare overlay open, without diving the rail.
    */
   onOpenSession?: (sessionId: string) => void;
+  /**
+   * CK-3 (cortex#1289) — the app-scope attention queue (whole-dashboard), scoped
+   * to the dived stack inside the cockpit. Omitted → the cockpit's ATTENTION lane
+   * shows its loading/empty state.
+   */
+  attention?: { entries: readonly AttentionEntry[]; loaded: boolean };
+  /**
+   * CK-3 — the app-scope governance audit (whole-dashboard), scoped to the dived
+   * stack inside the cockpit. Omitted → the GOVERN lane shows its loading state.
+   */
+  governance?: GovernanceState;
+  /** CK-3 — working-agents load/error, forwarded to the cockpit WORKING lane. */
+  workingLoaded?: boolean;
+  workingError?: string | null;
+  /** CK-3 — open the work-item-detail surface (attention work-item deep link). */
+  onOpenWorkItem?: (workItemId: string) => void;
 }
 
 export function NetworkView({
@@ -201,6 +222,11 @@ export function NetworkView({
   transportRoster = [],
   networks = [],
   onOpenSession,
+  attention = { entries: [], loaded: false },
+  governance = { data: null, loaded: false, error: null },
+  workingLoaded = false,
+  workingError = null,
+  onOpenWorkItem,
 }: NetworkViewProps) {
   const mode = pickAgentsPanelMode(state);
 
@@ -529,6 +555,47 @@ export function NetworkView({
     [state.agents, shellSelection.stack, fullTransportOverlay, servingPrincipal],
   );
 
+  // CK-3 — the stack-scoped right-panel cockpit, present ONLY when a stack is
+  // dived into. Folds ATTENTION/WORKING/GOVERN/DISPATCH scoped to `shellSelection.
+  // stack`, fed by the app-scope snapshots (single subscription). Posture is the
+  // dived network's (admin/member); the dispatch verb is admin-gated + own-local.
+  // Above STACK → null (McShell renders the pane full-width, exactly as pre-CK-3).
+  const cockpit = useMemo(() => {
+    if (shellSelection.stack === null) return null;
+    return (
+      <McCockpit
+        stack={shellSelection.stack}
+        posture={selectedNetworkPosture(networks, shellSelection)}
+        servingPrincipal={servingPrincipal}
+        presenceAgents={state.agents}
+        workingAgents={workingAgents}
+        workingLoaded={workingLoaded}
+        workingError={workingError}
+        attention={attention.entries}
+        attentionLoaded={attention.loaded}
+        governance={governance}
+        onOpenDrill={(id) => onOpenSession?.(id)}
+        {...(onOpenWorkItem ? { onOpenWorkItem } : {})}
+        {...(onDispatchDirect ? { onDispatchDirect } : {})}
+        {...(dispatchingAgentKeys ? { dispatchingAgentKeys } : {})}
+      />
+    );
+  }, [
+    shellSelection,
+    networks,
+    servingPrincipal,
+    state.agents,
+    workingAgents,
+    workingLoaded,
+    workingError,
+    attention,
+    governance,
+    onOpenSession,
+    onOpenWorkItem,
+    onDispatchDirect,
+    dispatchingAgentKeys,
+  ]);
+
   return (
     <McShell
       principal={servingPrincipal}
@@ -538,6 +605,7 @@ export function NetworkView({
       sessionTargets={sessionTargets}
       onOpenSession={handleOpenSession}
       stackHeader={stackHeader}
+      cockpit={cockpit}
     >
     <section className="scaffold-section network-view" aria-label="Network (agent topology)">
       <h2>Network</h2>

--- a/src/surface/mc/dashboard-v2/lib/mc-cockpit-scope.ts
+++ b/src/surface/mc/dashboard-v2/lib/mc-cockpit-scope.ts
@@ -1,0 +1,233 @@
+/**
+ * CK-3 (cortex#1289) — pure re-scoping for the **right-panel cockpit**.
+ *
+ * The cockpit folds the four legacy standalone surfaces (ATTENTION / WORKING /
+ * GOVERN / DISPATCH) into a stack-scoped panel inside `.mc-skin`. The legacy
+ * surfaces were WHOLE-DASHBOARD; the cockpit is scoped to the DIVED stack
+ * (`AltitudeSelection.stack`). This module is the DOM-free, I/O-free projection
+ * that turns the app-scope snapshots (already fetched once + WS-kept-fresh — the
+ * "single snapshot subscription" CK-3 replaces fetch-on-tab-visible with) into
+ * the per-stack view the folded components render.
+ *
+ * ## Sovereignty boundary (ADR-0005)
+ *
+ * ATTENTION / WORKING / GOVERN are LOCAL operational surfaces. Across the
+ * federation boundary a peer principal's stacks expose AGGREGATE metadata only —
+ * never their attention queue, session interiors, or governance audit. So the
+ * scoping functions here are only ever called for an OWN-LOCAL stack
+ * (`stack.federated === false`); the cockpit renders a peer as an honest
+ * aggregate notice instead of calling them (see `mc-cockpit.tsx`). The functions
+ * still fail-closed on a federated coord (empty) as defense in depth.
+ *
+ * ## The list-cap caveat (governance)
+ *
+ * `/api/governance` returns capped row lists (`GOVERNANCE_LIST_CAP`) plus SQL
+ * window aggregates that are NOT re-derivable client-side. So `scopeGovernance`
+ * filters the capped rows to the stack and RE-DERIVES the summary/alarm FROM the
+ * filtered rows — honest at the row level (the numbers match the rows shown), a
+ * recent-window view rather than the full-window aggregate. A precise per-stack
+ * window aggregate is a server-side filter (deferred; not CK-3). The reused
+ * `GovernanceView` empty-state copy already carries "absence is not an all-clear".
+ */
+
+import type { StackCoord } from "./mc-shell-model";
+import { stackCoordFromTile } from "./mc-dive";
+import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import type { AttentionEntry } from "../../api/attention";
+import type { GovernanceResponse } from "../../api/governance";
+import type {
+  GovernanceLayer,
+  GovernanceSummary,
+  GovernanceVerdictRow,
+  GovernanceDenialRow,
+  GovernanceDenialSummary,
+} from "../../db/governance";
+
+/** Seconds in a day — the 24h alarm window uses one day. */
+const DAY_SECONDS = 86_400;
+
+/**
+ * Whether a working tile belongs to the dived stack. Mirrors the CK-1 rail
+ * semantics (`mc-dive.tileMatchesStack`): a `"local"`-origin tile is the serving
+ * stack's own projection (own-local by construction), a sibling-tagged tile must
+ * match the dived `{principal, stack}` exactly. Cross-sibling precision is CK-4a's
+ * schema-origin work — this stays row-honest for CK-3.
+ */
+function tileOnStack(tile: WorkingAgentTile, stack: StackCoord): boolean {
+  const origin = tile.origin ?? "local";
+  if (origin === "local") return true;
+  return origin.principal === stack.principal && origin.stack === stack.stack;
+}
+
+/**
+ * The working tiles on the dived stack. Own-local only: a federated coord returns
+ * empty (defense in depth — the cockpit never calls this for a peer).
+ */
+export function scopeWorkingTiles(
+  tiles: readonly WorkingAgentTile[],
+  stack: StackCoord,
+): WorkingAgentTile[] {
+  if (stack.federated) return [];
+  return tiles.filter((t) => tileOnStack(t, stack));
+}
+
+/**
+ * The attention entries for the dived stack. `AttentionItem.stackId` carries the
+ * owning stack (multi-stack federation), so we filter on it — this is what lets a
+ * pane-of-glass aggregation (sibling stacks' items merged) narrow to the one the
+ * principal dived into. Own-local only (a federated coord returns empty).
+ */
+export function scopeAttention(
+  entries: readonly AttentionEntry[],
+  stack: StackCoord,
+): AttentionEntry[] {
+  if (stack.federated) return [];
+  return entries.filter((e) => e.item.stackId === stack.stack);
+}
+
+/** Does a governance row (verdict or denial) attribute to the dived stack? */
+function rowOnStack(
+  principal: string | null,
+  rowStack: string | null,
+  stack: StackCoord,
+): boolean {
+  // A row with no stack tag is not attributable to any single stack — exclude it
+  // from a stack-scoped view (it still shows in the whole-dashboard `?legacy=1`
+  // governance tab). Principal, when present, must also match.
+  if (rowStack === null || rowStack !== stack.stack) return false;
+  if (principal !== null && principal !== stack.principal) return false;
+  return true;
+}
+
+/** Is this verdict row a "denial" for alarm purposes (mirrors summarizeGovernance)? */
+function verdictIsDenial(v: GovernanceVerdictRow): boolean {
+  return v.layer === "resolved"
+    ? v.decision === "deny"
+    : v.decision === "deny" || v.decision === "fail";
+}
+
+/**
+ * Re-derive the deterministic alarm tier from a combined 24h denial count. Inlined
+ * (NOT imported from `api/governance`) so this browser-bundle module never pulls in
+ * that file's `bun:sqlite` value dependencies — mirrors `alarmFor` exactly.
+ */
+function deriveAlarm(denials24h: number): GovernanceResponse["alarm"] {
+  const tier =
+    denials24h === 0 ? "none" : denials24h < 5 ? "elevated" : "high";
+  const note =
+    tier === "none"
+      ? "0 denials in the last 24h (window measured: 24h — absence of denials is not absence of risk)"
+      : `${denials24h} denial${denials24h === 1 ? "" : "s"} in the last 24h (verdict denials + access denials/refusals)`;
+  return { tier, denials24h, note };
+}
+
+/**
+ * Re-scope the governance response to the dived stack. Filters the capped verdict
+ * + denial rows to the stack and RE-DERIVES `summary`/`denialSummary`/`alarm` from
+ * the filtered rows (honest at the row level — see the module header caveat).
+ *
+ * `nowSec` is injectable for deterministic tests; it defaults to wall-clock. A
+ * federated coord returns an empty-but-shaped response (defense in depth).
+ */
+export function scopeGovernance(
+  data: GovernanceResponse,
+  stack: StackCoord,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): GovernanceResponse {
+  const cutoff24h = nowSec - DAY_SECONDS;
+  const federated = stack.federated;
+
+  const verdicts: GovernanceVerdictRow[] = federated
+    ? []
+    : data.verdicts.filter((v) => rowOnStack(v.principal, v.stack, stack));
+  const denials: GovernanceDenialRow[] = federated
+    ? []
+    : data.denials.filter((d) => rowOnStack(d.principal, d.stack, stack));
+
+  const byLayer: Record<GovernanceLayer, number> = {
+    l0: 0,
+    tribunal: 0,
+    gate: 0,
+    resolved: 0,
+  };
+  let allows = 0;
+  let vDenials = 0;
+  let defers = 0;
+  let vDenials24h = 0;
+  for (const v of verdicts) {
+    byLayer[v.layer] += 1;
+    if (v.layer === "resolved") {
+      if (v.decision === "allow") allows += 1;
+      else if (v.decision === "deny") vDenials += 1;
+      else if (v.decision === "defer") defers += 1;
+    }
+    if (verdictIsDenial(v) && v.createdAt >= cutoff24h) vDenials24h += 1;
+  }
+  const summary: GovernanceSummary = {
+    total: verdicts.length,
+    allows,
+    denials: vDenials,
+    defers,
+    byLayer,
+    denials24h: vDenials24h,
+  };
+
+  const byReasonKind: Record<string, number> = {};
+  let refusals = 0;
+  let dDenials24h = 0;
+  for (const d of denials) {
+    byReasonKind[d.reasonKind] = (byReasonKind[d.reasonKind] ?? 0) + 1;
+    if (d.isRefusal) refusals += 1;
+    if (d.createdAt >= cutoff24h) dDenials24h += 1;
+  }
+  const denialSummary: GovernanceDenialSummary = {
+    total: denials.length,
+    refusals,
+    otherDenials: denials.length - refusals,
+    byReasonKind,
+    denials24h: dDenials24h,
+  };
+
+  return {
+    verdicts,
+    summary,
+    denials,
+    denialSummary,
+    alarm: deriveAlarm(summary.denials24h + denialSummary.denials24h),
+    windowDays: data.windowDays,
+    listCap: data.listCap,
+  };
+}
+
+/** The stack-scoped dispatch target — a local agent + its display label. */
+export interface CockpitDispatchAgent {
+  tile: AgentPresenceTile;
+  label: string;
+}
+
+/**
+ * Pick the dispatch target for the dived stack's GOVERN lane: a LOCAL
+ * (non-federated) presence agent on the stack, preferring an `online` one. Dispatch
+ * is local-only (ADR-0005 / CK-4a boundary — dispatch-to-peer is FLG-10), so a
+ * federated coord — or a stack with no local presence agent — yields `null` and the
+ * affordance renders disabled/absent (honest, never a dead button).
+ */
+export function cockpitDispatchAgent(
+  agents: readonly AgentPresenceTile[],
+  stack: StackCoord,
+  servingPrincipal: string | null,
+): CockpitDispatchAgent | null {
+  if (stack.federated) return null;
+  const onStack = agents.filter((a) => {
+    const coord = stackCoordFromTile(a, servingPrincipal);
+    return (
+      !coord.federated &&
+      coord.principal === stack.principal &&
+      coord.stack === stack.stack
+    );
+  });
+  const chosen = onStack.find((a) => a.state === "online") ?? onStack[0];
+  if (!chosen) return null;
+  return { tile: chosen, label: chosen.assistant_name ?? chosen.agent_id };
+}


### PR DESCRIPTION
R1 slice **CK-3** — the core reskin. The four legacy standalone tabs (ATTENTION / WORKING / GOVERN / DISPATCH) **fold** into a single stack-scoped right-panel cockpit inside `.mc-skin`, beside the altitude rail + CK-2 header. FOLD not rebuild — the components are reused verbatim; a pure re-scope lib + a McShell slot + a scoped CSS reskin do the work.

- `mc-cockpit-scope.ts` (pure) scopes each feed to `AltitudeSelection.stack`; `mc-cockpit.tsx` folds the four views; scoped CSS reskin (zero blast on `?legacy=1` tabs).
- **Single subscription** — consumes app-scope snapshots (WS-kept-fresh); fetch-on-tab-visible gone.
- **`?legacy=1` escape hatch** (D-1c) — standalone tabs survive one release; CK-10 deletes them.
- **Posture fail-closed** — DISPATCH renders ONLY for admin on an own-local stack (reuses the FND-6-gated route, no bypass); member → honest note, **no Leave button** (inv. 16); federated peer → ADR-0005 aggregate notice, no local lanes.
- Vocab admin/member. **Browser-QA 23/23** (real DOM, Playwright): panels mount, stack-scoped, interactive (dispatch popover), posture fail-closed, peer aggregate, no deprecated word. tsc 0; eslint 0; 1028 tests; vocab PASS.

Residuals (documented, non-blocking): governance re-scope is row-honest (server-side window aggregate deferred); cross-sibling WORKING precision is CK-4a's schema-origin job. CK-6b + CK-7 plug into the mount points left.

Generated by the R1 opus fleet (ck3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c