### PR TITLE
feat(mc): FLG-1 — handoff-status-on-glass (banner) (R1)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -157,6 +157,12 @@ import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/r
 import { startMissionControl, type MissionControlHandle } from "./surface/mc/embed";
 import type { AgentPresenceView } from "./surface/mc/api/agents";
 import type { NetworksView } from "./surface/mc/api/networks";
+// FLG-1 (docs/plan-mc-future-state.md §4.D) — guided-join handoff banner: the MC
+// read seam + the shared signal-gathering / live-ports the daemon wires it to.
+import type { HandoffView } from "./surface/mc/api/handoff";
+import { gatherHandoffSignals } from "./cli/cortex/commands/network-handoff-lib";
+import { buildLiveHandoffPorts } from "./cli/cortex/commands/network-handoff-adapters";
+import type { LivePortsConfig } from "./cli/cortex/commands/network-adapters";
 import type {
   AdmissionDecider,
   AdmissionDecisionResult,
@@ -4011,6 +4017,13 @@ export async function startCortex(
   // `resolvedPolicy` is known); `null` until then ⇒ the route serves an empty
   // list. The MC server resolves it per request.
   let networksViewForApi: NetworksView | null = null;
+  // FLG-1 (docs/plan-mc-future-state.md §4.D) — the guided-join handoff view for
+  // `GET /api/networks/:net/handoff/:member`. Assigned in the federation block
+  // below alongside `networksViewForApi` (it reuses the SAME resolved registry +
+  // stack seed to gather the 3 leg signals via the shared `gatherHandoffSignals`
+  // + live ports). `null` until then ⇒ the handoff route 503s honestly. Read-only
+  // — signs/mutates nothing; the leaf-up leg reads the LOCAL `/leafz`.
+  let handoffViewForApi: HandoffView | null = null;
   // MC-B2 (cortex#1279) — the admission-decision signer for the mutating
   // `POST /api/networks/admission-decision` action. Assigned in the federation
   // block below alongside `networksViewForApi` (it reuses the SAME stack
@@ -4099,6 +4112,10 @@ export async function startCortex(
         // registry are resolved). null ⇒ `POST /api/networks/admission-decision`
         // 503s honestly.
         admissionDecider: () => admissionDeciderForApi,
+        // FLG-1 (docs/plan-mc-future-state.md §4.D) — the guided-join handoff
+        // view (lazy; assigned in the federation block). null ⇒
+        // `GET /api/networks/:net/handoff/:member` 503s honestly.
+        handoffView: () => handoffViewForApi,
         // #1008 — DB-read pane-of-glass aggregation. The getter returns a context
         // only when discovery produced a resolve-opts (dbRead on); otherwise null
         // ⇒ single-db feeds. Lazy so the roster can be (re)read consistently.
@@ -4599,6 +4616,46 @@ export async function startCortex(
             `as first-class trust groups (admission roster: ${live ? "LIVE member-read (A2)" : "not_configured — self-only"}; ` +
             "per-principal acceptance from offerings)",
         );
+
+        // FLG-1 (docs/plan-mc-future-state.md §4.D) — the guided-join handoff
+        // view. Gathers the 3 leg signals (seal via admission `/mine`,
+        // hub-authorize via the #1498 registry marker, leaf-up via the LOCAL
+        // `/leafz`) through the SAME `gatherHandoffSignals` + live ports the
+        // `cortex network handoff status` CLI uses — the surface never re-derives
+        // them. Read-only; never-throw (a degraded read fails closed to a
+        // `pending` leg + a note). Reuses the resolved registry + stack seed
+        // already loaded for the networks view above.
+        handoffViewForApi = {
+          localPrincipal: principalId,
+          resolveHandoffSignals: async (networkId, member) => {
+            const network = networksList.find((n) => n.id === networkId);
+            if (network === undefined) return null;
+            // A minimal per-network LivePortsConfig — `networkId` varies per
+            // request; the registry + seed come from the already-resolved
+            // federation context. Absent knobs (monitor url, nats config) fall
+            // back to the live adapters' local defaults; a missing seed/registry
+            // simply degrades the reads to fail-closed signals + notes.
+            const cfg: LivePortsConfig = {
+              networkId,
+              principalId,
+              stackId: options.stack?.id ?? principalId,
+              ...(resolvedRegistry?.url !== undefined && {
+                registryUrl: resolvedRegistry.url,
+              }),
+              ...(resolvedRegistry?.pubkey !== undefined && {
+                registryPubkey: resolvedRegistry.pubkey,
+              }),
+              ...(options.stack?.nkey_seed_path !== undefined && {
+                seedPath: expandTilde(options.stack.nkey_seed_path),
+              }),
+            };
+            return gatherHandoffSignals(buildLiveHandoffPorts(cfg, [network]), {
+              networkId,
+              member,
+              selfPrincipal: principalId,
+            });
+          },
+        };
 
         // MC-B2 (cortex#1279) — the WRITE sibling of the member-roster read:
         // sign a Tier-2 admit/reject with the SAME `stackMaterial` and POST it to

--- a/src/surface/mc/api/__tests__/handoff.test.ts
+++ b/src/surface/mc/api/__tests__/handoff.test.ts
@@ -1,0 +1,186 @@
+/**
+ * FLG-1 (docs/plan-mc-future-state.md §4.D) — `handleGetHandoff` tests.
+ *
+ * Two things this file locks down:
+ *   1. The three-valued attestation (invariant 9 / Sage #1499): `confirmed=true`
+ *      upgrades an `undefined` hub-authorize signal to done, but NEVER a real
+ *      `false` — a hub-DENIED network stays blocked through the endpoint even
+ *      under confirmed=true.
+ *   2. The no-interiors SHAPE guard (invariant 1 — the daemon analog of
+ *      `worker/src/__tests__/dashboard-snapshot-contract.test.ts`): the
+ *      `HandoffStatusDTO` and its legs carry ONLY the allow-listed metadata keys
+ *      at every position. This is how the read "flows through the DashboardSnapshot
+ *      guard" on the daemon side — a metadata-only contract, asserted here.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  handleGetHandoff,
+  type HandoffView,
+  type HandoffSignalsResult,
+  type HandoffStatusDTO,
+} from "../handoff";
+import type { HandoffSignals } from "../../../../cli/cortex/commands/network-handoff-lib";
+
+/** A stub view resolving fixed signals for one network id (else `null`). */
+function stubView(
+  networkId: string,
+  signals: HandoffSignals,
+  notes: string[] = [],
+): HandoffView {
+  return {
+    localPrincipal: "andreas",
+    resolveHandoffSignals: (net): Promise<HandoffSignalsResult | null> =>
+      Promise.resolve(net === networkId ? { signals, notes } : null),
+  };
+}
+
+async function body(res: Response): Promise<HandoffStatusDTO> {
+  return (await res.json()) as HandoffStatusDTO;
+}
+
+describe("handleGetHandoff — availability", () => {
+  it("503s when no handoff view is wired (no federation)", async () => {
+    const res = await handleGetHandoff(null, {
+      networkId: "research",
+      member: "andreas",
+      confirmed: false,
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it("404s for a network this stack has not joined", async () => {
+    const view = stubView("research", { sealed: true, hubAuthorized: true, leafUp: true });
+    const res = await handleGetHandoff(view, {
+      networkId: "not-joined",
+      member: "andreas",
+      confirmed: false,
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("handleGetHandoff — 3-leg state", () => {
+  it("reports all legs done + no next owner when the join is complete", async () => {
+    const view = stubView("research", { sealed: true, hubAuthorized: true, leafUp: true });
+    const dto = await body(
+      await handleGetHandoff(view, { networkId: "research", member: "andreas", confirmed: false }),
+    );
+    expect(dto.legs.map((l) => l.status)).toEqual(["done", "done", "done"]);
+    expect(dto.next_leg).toBeNull();
+    expect(dto.next_owner).toBeNull();
+    expect(dto.can_bring_leaf_up).toBe(true);
+    expect(dto.leaf_up_blocked_reason).toBeNull();
+  });
+
+  it("names the admin as the next owner when the seal leg is pending", async () => {
+    const view = stubView("research", { sealed: false, hubAuthorized: undefined, leafUp: undefined });
+    const dto = await body(
+      await handleGetHandoff(view, { networkId: "research", member: "andreas", confirmed: false }),
+    );
+    expect(dto.legs[0]!.status).toBe("pending"); // seal
+    expect(dto.next_owner).toBe("admin");
+    expect(dto.can_bring_leaf_up).toBe(false);
+    expect(dto.leaf_up_blocked_reason).toBe("seal-pending");
+  });
+
+  it("blocks leaf-up as hub-unverifiable when the hub signal is undefined", async () => {
+    const view = stubView("research", { sealed: true, hubAuthorized: undefined, leafUp: undefined });
+    const dto = await body(
+      await handleGetHandoff(view, { networkId: "research", member: "andreas", confirmed: false }),
+    );
+    expect(dto.next_owner).toBe("hub-owner");
+    expect(dto.can_bring_leaf_up).toBe(false);
+    expect(dto.leaf_up_blocked_reason).toBe("hub-unverifiable");
+    expect(dto.hub_attestable).toBe(true); // undefined ⇒ attestable
+    expect(dto.attested).toBe(false);
+  });
+});
+
+describe("handleGetHandoff — three-valued attestation (Sage #1499)", () => {
+  it("confirmed=true UPGRADES an undefined hub-authorize signal to done", async () => {
+    const view = stubView("research", { sealed: true, hubAuthorized: undefined, leafUp: undefined });
+    const dto = await body(
+      await handleGetHandoff(view, { networkId: "research", member: "andreas", confirmed: true }),
+    );
+    // The hub leg is now treated done via the attestation → leaf-up is unblocked
+    // and the next move is the MEMBER (leaf-up), not the hub owner.
+    const hubLeg = dto.legs.find((l) => l.id === "hub-authorize")!;
+    expect(hubLeg.status).toBe("done");
+    expect(dto.can_bring_leaf_up).toBe(true);
+    expect(dto.leaf_up_blocked_reason).toBeNull();
+    expect(dto.next_owner).toBe("member");
+    expect(dto.attested).toBe(true);
+    expect(dto.hub_attestable).toBe(true); // the raw signal is still undefined
+  });
+
+  it("confirmed=true NEVER upgrades a real `false` (hub-denied stays blocked)", async () => {
+    // The load-bearing guarantee: a real NOT-authorized signal is a hard
+    // negative a member attestation cannot override.
+    const view = stubView("research", { sealed: true, hubAuthorized: false, leafUp: undefined });
+    const dto = await body(
+      await handleGetHandoff(view, { networkId: "research", member: "andreas", confirmed: true }),
+    );
+    const hubLeg = dto.legs.find((l) => l.id === "hub-authorize")!;
+    expect(hubLeg.status).not.toBe("done"); // still pending — NOT upgraded
+    expect(dto.can_bring_leaf_up).toBe(false);
+    expect(dto.leaf_up_blocked_reason).toBe("hub-denied");
+    // And the glass must NOT be told this is attestable — no override affordance
+    // for a hard denial.
+    expect(dto.hub_attestable).toBe(false);
+  });
+});
+
+describe("handleGetHandoff — notes pass through", () => {
+  it("surfaces the gathered degradation notes verbatim", async () => {
+    const view = stubView(
+      "research",
+      { sealed: true, hubAuthorized: undefined, leafUp: undefined },
+      ["hub-authorize leg: registry unreachable"],
+    );
+    const dto = await body(
+      await handleGetHandoff(view, { networkId: "research", member: "andreas", confirmed: false }),
+    );
+    expect(dto.notes).toEqual(["hub-authorize leg: registry unreachable"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-interiors SHAPE guard — the daemon analog of the worker's
+// dashboard-snapshot-contract.test.ts. Asserts the DTO carries ONLY the
+// allow-listed metadata keys at every position. A new field that could leak an
+// interior / secret fails HERE, consciously (grow the allow-list = a real edit).
+// ---------------------------------------------------------------------------
+
+const DTO_KEYS = new Set([
+  "network_id", "member", "legs", "next_leg", "next_owner",
+  "can_bring_leaf_up", "leaf_up_blocked_reason", "hub_attestable", "attested", "notes",
+]);
+const LEG_KEYS = new Set(["id", "title", "status", "owner", "detail"]);
+
+function assertKeys(obj: Record<string, unknown>, allowed: Set<string>, label: string): void {
+  const unexpected = Object.keys(obj).filter((k) => !allowed.has(k));
+  expect([label, unexpected]).toEqual([label, []]);
+}
+
+describe("handleGetHandoff — no-interiors SHAPE guard (invariant 1)", () => {
+  it("the DTO + its legs carry only the allow-listed metadata keys", async () => {
+    // Exercise a state that populates the optional fields (blocked reason, a
+    // non-null next owner) so the walk sees them.
+    const view = stubView(
+      "research",
+      { sealed: true, hubAuthorized: false, leafUp: undefined },
+      ["leaf-up leg: not observable"],
+    );
+    const dto = await body(
+      await handleGetHandoff(view, { networkId: "research", member: "andreas", confirmed: false }),
+    );
+    assertKeys(dto as unknown as Record<string, unknown>, DTO_KEYS, "HandoffStatusDTO");
+    expect(dto.legs.length).toBe(3);
+    for (const leg of dto.legs) {
+      assertKeys(leg as unknown as Record<string, unknown>, LEG_KEYS, `legs[${leg.id}]`);
+    }
+    // notes is a string[] — no nested objects that could smuggle a key.
+    expect(dto.notes.every((n) => typeof n === "string")).toBe(true);
+  });
+});

--- a/src/surface/mc/api/handoff.ts
+++ b/src/surface/mc/api/handoff.ts
@@ -1,0 +1,226 @@
+/**
+ * FLG-1 (docs/plan-mc-future-state.md §4.D) — `GET /api/networks/:net/handoff/:member`.
+ *
+ * Surfaces the guided-join **two-party handoff** (epic #1479's pure
+ * `deriveHandoffState`, cortex#1485) on the glass — the model shipped with ZERO
+ * MC call sites; this endpoint is the first. A network join is a 3-leg handoff
+ * across ≤3 people/machines:
+ *
+ *     seal (admin) → hub-authorize (hub owner) → leaf-up (member)
+ *
+ * The read reports each leg's status + owner, WHOSE MOVE is next (`next_owner`),
+ * and — when the leaf-up leg is blocked — WHY (`leaf_up_blocked_reason` ∈
+ * {seal-pending, hub-unverifiable, hub-denied}). The daemon signs/mutates
+ * nothing here; it is a pure projection of the injected leg signals.
+ *
+ * ## No-interiors discipline (plan invariant 1 — the DashboardSnapshot guard)
+ *
+ * The plan routes every new cockpit/aggregation READ through the worker-scoped
+ * `DashboardSnapshot` no-interiors guard. That guard is the CF worker's SHAPE
+ * contract on the public `/api/state` projection
+ * (`worker/src/routes/state.ts` + `dashboard-snapshot-contract.test.ts`); this
+ * endpoint is a DAEMON read, so the equivalent enforcement is (a) the
+ * metadata-only {@link HandoffStatusDTO} below and (b) the daemon-side SHAPE
+ * contract test (`__tests__/handoff-contract.test.ts`) — the direct analog of
+ * the worker's. The DTO carries ONLY lifecycle metadata: leg statuses, owners,
+ * the next-owner + blocked-reason, and human-readable notes/details. No session
+ * interior, and — critically — no secret material: the seal leg is a BOOLEAN
+ * "is a leaf secret sealed?" signal, NEVER the sealed ciphertext / K / a PSK
+ * (secret-material discipline, invariant 6). "Never beside it" ⇒ the read flows
+ * through the SAME {@link HandoffView} seam `cortex.ts` wires, not a fresh
+ * unguarded registry/bus path opened inside the surface layer.
+ *
+ * ## Three-valued attestation (plan invariant 9 — Sage #1499)
+ *
+ * The glass "confirmed" toggle (`?confirmed=true`) maps to the member ATTESTATION
+ * that `deriveHandoffState({ attested })` accepts. The pure model's
+ * `hubAuthorizeDone` upgrades ONLY an `undefined` hub-authorize signal to
+ * treated-done — NEVER a real `false`. So a hub-DENIED network stays blocked
+ * even when the glass sends `confirmed=true`; the attestation is a
+ * degraded-connectivity confirmation, not a naive boolean override. This handler
+ * is a thin wrapper: it adds no boolean check of its own — the guarantee lives in
+ * the model, and the contract test asserts it end-to-end.
+ *
+ * ## Dependency direction (surface must not import the bus)
+ *
+ * Like `/api/networks`, the server depends only on the minimal {@link HandoffView}
+ * seam + the PURE `deriveHandoffState`; `cortex.ts` adapts the live signal
+ * gathering (`gatherHandoffSignals` + the live ports) to it at boot. The surface
+ * imports the pure model + types only — never the ports/adapters/bus.
+ */
+
+import {
+  deriveHandoffState,
+  type HandoffSignals,
+  type HandoffLegId,
+  type HandoffLegStatus,
+  type HandoffOwner,
+  type LeafUpBlockedReason,
+} from "../../../cli/cortex/commands/network-handoff-lib";
+
+export type { HandoffLegId, HandoffLegStatus, HandoffOwner, LeafUpBlockedReason };
+
+/**
+ * The raw 3-leg signals for one `(network, member)`, plus non-fatal degradation
+ * notes. Byte-shape-identical to the CLI's `GatheredHandoffSignals` (the shared
+ * `gatherHandoffSignals` return) so `cortex.ts` can hand its result straight
+ * through — never re-derived here.
+ */
+export interface HandoffSignalsResult {
+  signals: HandoffSignals;
+  /** Non-fatal context (a degraded port read, the remote-member caveat). Never secrets. */
+  notes: string[];
+}
+
+/**
+ * The minimal read-only seam the MC server depends on to serve the handoff
+ * endpoint. `cortex.ts` supplies a live implementation (gathering the 3 leg
+ * signals via the shared `gatherHandoffSignals` + live ports); tests supply a
+ * stub. `null` (no federation/registry) → the route 503s honestly.
+ */
+export interface HandoffView {
+  /** The serving (local) principal — the member the roster banner reports on. */
+  localPrincipal: string;
+  /**
+   * Gather the 3 leg signals for `member` on `networkId`. NEVER throws (a
+   * degraded read becomes a fail-closed signal + a note — the
+   * `gatherHandoffSignals` contract). Resolves to `null` when `networkId` is not
+   * a network this stack has joined.
+   */
+  resolveHandoffSignals(
+    networkId: string,
+    member: string,
+  ): Promise<HandoffSignalsResult | null>;
+}
+
+/** One leg of the handoff, snake_case for the wire DTO. */
+export interface HandoffLegDTO {
+  id: HandoffLegId;
+  title: string;
+  status: HandoffLegStatus;
+  owner: HandoffOwner;
+  detail: string;
+}
+
+/**
+ * `GET /api/networks/:net/handoff/:member` response body — metadata ONLY (the
+ * no-interiors DTO; see the module doc + `__tests__/handoff-contract.test.ts`).
+ */
+export interface HandoffStatusDTO {
+  network_id: string;
+  member: string;
+  /** Always exactly 3 legs, in `seal → hub-authorize → leaf-up` order. */
+  legs: HandoffLegDTO[];
+  /** The next outstanding leg's id ("whose move"), or `null` when every leg is done. */
+  next_leg: HandoffLegId | null;
+  /** The owner of {@link next_leg}, or `null` when done. */
+  next_owner: HandoffOwner | null;
+  /** `true` only when seal is done AND hub-authorize is effectively done. */
+  can_bring_leaf_up: boolean;
+  /** Why leaf-up is blocked, or `null` when it is not. */
+  leaf_up_blocked_reason: LeafUpBlockedReason | null;
+  /**
+   * Whether the hub-authorize signal is `undefined` (un-auto-verifiable) and can
+   * therefore be raised by the member attestation. This is the ONLY state in
+   * which the glass may offer the "confirm" toggle: a real `false` (hub-denied)
+   * has `hub_attestable === false`, so the UI never presents an override for a
+   * hard negative (Sage #1499). Derived from the RAW signal, not the leg status.
+   */
+  hub_attestable: boolean;
+  /**
+   * Whether the member "confirmed" attestation was requested. Echoes the
+   * `?confirmed=` toggle — the LEGS reflect whether it actually took effect (an
+   * `undefined` hub leg upgrades; a real `false` never does).
+   */
+  attested: boolean;
+  /** Non-fatal degradation context (never secrets/interiors). */
+  notes: string[];
+}
+
+export interface HandleGetHandoffOpts {
+  networkId: string;
+  member: string;
+  /**
+   * The glass "confirmed" toggle → the member attestation. Fail-closed: only an
+   * explicit `true` attests; the model upgrades an `undefined` hub-authorize
+   * signal to done, NEVER a real `false` (Sage #1499).
+   */
+  confirmed: boolean;
+}
+
+/**
+ * Handle `GET /api/networks/:net/handoff/:member`.
+ *
+ * `view === null` → 503 (no federation configured — honest). Unknown network →
+ * 404. Otherwise gather the leg signals (never-throw) and wrap the PURE
+ * `deriveHandoffState`, mapping the `confirmed` toggle to the attestation. Never
+ * a 5xx-splat: the signal gathering is never-throw and the derive is pure; the
+ * catch is a structural belt-and-braces (same posture as `handleListNetworks`).
+ */
+export async function handleGetHandoff(
+  view: HandoffView | null,
+  opts: HandleGetHandoffOpts,
+): Promise<Response> {
+  try {
+    if (view === null) {
+      return Response.json(
+        {
+          error:
+            "handoff status unavailable — no federation/registry configured on this stack",
+        },
+        { status: 503 },
+      );
+    }
+
+    const gathered = await view.resolveHandoffSignals(opts.networkId, opts.member);
+    if (gathered === null) {
+      return Response.json(
+        { error: `network "${opts.networkId}" is not one this stack has joined` },
+        { status: 404 },
+      );
+    }
+
+    // The 3-valued attestation (Sage #1499): `confirmed` maps to `attested`,
+    // which `deriveHandoffState` upgrades an `undefined` hub-authorize signal
+    // with — but NEVER a real `false`. This handler adds no boolean override of
+    // its own; the model is the guard. A hub-denied network therefore stays
+    // blocked here even under `confirmed=true`.
+    const state = deriveHandoffState(gathered.signals, { attested: opts.confirmed });
+
+    const dto: HandoffStatusDTO = {
+      network_id: opts.networkId,
+      member: opts.member,
+      legs: state.legs.map((l) => ({
+        id: l.id,
+        title: l.title,
+        status: l.status,
+        owner: l.owner,
+        detail: l.detail,
+      })),
+      next_leg: state.nextLeg ?? null,
+      next_owner: state.nextOwner ?? null,
+      can_bring_leaf_up: state.canBringLeafUp,
+      leaf_up_blocked_reason: state.leafUpBlockedReason ?? null,
+      // Derived from the RAW hub-authorize signal — `undefined` (un-verifiable)
+      // is the only attestable state. A real `false` is NOT attestable, so the
+      // glass never offers a "confirm" override for a hard hub denial (Sage
+      // #1499). Independent of `confirmed`: a member toggling confirm off must
+      // still see the toggle, so this reflects the signal, not the leg status.
+      hub_attestable: gathered.signals.hubAuthorized === undefined,
+      attested: opts.confirmed,
+      notes: gathered.notes,
+    };
+
+    return Response.json(dto);
+  } catch (err) {
+    process.stderr.write(
+      `[api] GET /api/networks/:net/handoff/:member failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return Response.json(
+      {
+        error: `Failed to resolve handoff status: ${err instanceof Error ? err.message : String(err)}`,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/surface/mc/dashboard-v2/__tests__/handoff-banner.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/handoff-banner.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * FLG-1 (docs/plan-mc-future-state.md §4.D) — HandoffBanner render tests.
+ *
+ * The banner is PURE (props only), so it renders under `renderToStaticMarkup`.
+ * These assert what the strip actually shows: the 3 legs (seal → hub-authorize →
+ * leaf-up) with their owners, whose move is next, why leaf-up is blocked, and —
+ * the load-bearing UX honesty — that the "confirm" toggle is offered ONLY when
+ * the hub-authorize signal is attestable (undefined), never for a hard hub
+ * denial (Sage #1499).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { HandoffBanner } from "../components/handoff-banner";
+import type { HandoffStatusDTO } from "../hooks/use-handoff";
+
+function dto(partial: Partial<HandoffStatusDTO>): HandoffStatusDTO {
+  return {
+    network_id: "research",
+    member: "andreas",
+    legs: [
+      { id: "seal", title: "seal", status: "done", owner: "admin", detail: "" },
+      { id: "hub-authorize", title: "hub-authorize", status: "done", owner: "hub-owner", detail: "" },
+      { id: "leaf-up", title: "leaf-up", status: "done", owner: "member", detail: "" },
+    ],
+    next_leg: null,
+    next_owner: null,
+    can_bring_leaf_up: true,
+    leaf_up_blocked_reason: null,
+    hub_attestable: false,
+    attested: false,
+    notes: [],
+    ...partial,
+  };
+}
+
+function render(status: HandoffStatusDTO): string {
+  return renderToStaticMarkup(
+    createElement(HandoffBanner, {
+      status,
+      confirmed: status.attested,
+      onToggleConfirmed: () => {},
+    }),
+  );
+}
+
+describe("HandoffBanner — legs + whose move", () => {
+  it("renders all three legs with their ids, statuses and owners", () => {
+    const html = render(dto({}));
+    expect(html).toContain('data-leg="seal"');
+    expect(html).toContain('data-leg="hub-authorize"');
+    expect(html).toContain('data-leg="leaf-up"');
+    expect(html).toContain('data-owner="admin"');
+    expect(html).toContain('data-owner="hub-owner"');
+    expect(html).toContain('data-owner="member"');
+  });
+
+  it("shows completion when every leg is done", () => {
+    const html = render(dto({}));
+    expect(html).toContain('data-next-owner="complete"');
+    expect(html).toContain("All legs complete");
+  });
+
+  it("names the next owner mid-handoff", () => {
+    const html = render(
+      dto({
+        legs: [
+          { id: "seal", title: "seal", status: "pending", owner: "admin", detail: "" },
+          { id: "hub-authorize", title: "hub-authorize", status: "blocked", owner: "hub-owner", detail: "" },
+          { id: "leaf-up", title: "leaf-up", status: "blocked", owner: "member", detail: "" },
+        ],
+        next_leg: "seal",
+        next_owner: "admin",
+        can_bring_leaf_up: false,
+        leaf_up_blocked_reason: "seal-pending",
+      }),
+    );
+    expect(html).toContain('data-next-owner="admin"');
+    expect(html).toContain('data-blocked-reason="seal-pending"');
+    expect(html).toContain("Next move");
+  });
+});
+
+describe("HandoffBanner — attestation toggle (Sage #1499 UX honesty)", () => {
+  it("offers the confirm toggle ONLY when the hub leg is attestable (undefined)", () => {
+    const html = render(
+      dto({
+        legs: [
+          { id: "seal", title: "seal", status: "done", owner: "admin", detail: "" },
+          { id: "hub-authorize", title: "hub-authorize", status: "pending", owner: "hub-owner", detail: "" },
+          { id: "leaf-up", title: "leaf-up", status: "blocked", owner: "member", detail: "" },
+        ],
+        next_leg: "hub-authorize",
+        next_owner: "hub-owner",
+        can_bring_leaf_up: false,
+        leaf_up_blocked_reason: "hub-unverifiable",
+        hub_attestable: true,
+      }),
+    );
+    expect(html).toContain('data-testid="handoff-confirm-toggle"');
+  });
+
+  it("does NOT offer the toggle for a hard hub denial — shows an honest note instead", () => {
+    const html = render(
+      dto({
+        legs: [
+          { id: "seal", title: "seal", status: "done", owner: "admin", detail: "" },
+          { id: "hub-authorize", title: "hub-authorize", status: "pending", owner: "hub-owner", detail: "" },
+          { id: "leaf-up", title: "leaf-up", status: "blocked", owner: "member", detail: "" },
+        ],
+        next_leg: "hub-authorize",
+        next_owner: "hub-owner",
+        can_bring_leaf_up: false,
+        leaf_up_blocked_reason: "hub-denied",
+        hub_attestable: false,
+      }),
+    );
+    expect(html).not.toContain('data-testid="handoff-confirm-toggle"');
+    expect(html).toContain("cannot be confirmed away");
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/handoff-banner.tsx
+++ b/src/surface/mc/dashboard-v2/components/handoff-banner.tsx
@@ -1,0 +1,230 @@
+/**
+ * FLG-1 (docs/plan-mc-future-state.md §4.D) — the guided-join handoff BANNER.
+ *
+ * A strip surfaced per joined network on the roster panel (R1 render home; CK-7
+ * rehomes it into the cockpit GOVERN bar in R2). It renders the two-party
+ * handoff (#1479) as it actually is: three ordered legs — **seal (admin) →
+ * hub-authorize (hub owner) → leaf-up (member)** — each with its owner + status,
+ * WHOSE MOVE is next, and — when leaf-up is blocked — WHY.
+ *
+ * ## Three-valued attestation (invariant 9 — Sage #1499)
+ *
+ * The "confirm" toggle is offered ONLY when `status.hub_attestable` — i.e. the
+ * hub-authorize signal is `undefined` (un-auto-verifiable), the one state a
+ * member attestation may raise. A real `false` (hub-denied) has
+ * `hub_attestable === false`, so the UI NEVER presents an override for a hard
+ * negative — it shows an honest "cannot be confirmed away" note instead. The
+ * server is the actual guard (`deriveHandoffState` never upgrades a real
+ * `false`); this is the matching UX honesty.
+ *
+ * `HandoffBanner` is PURE (props-only, SSR-renderable — the shape the tests
+ * assert). `HandoffBannerLive` is the thin self-fetching wrapper the roster
+ * panel mounts; it renders nothing until the read resolves, so it is inert under
+ * `renderToStaticMarkup` (no effects fire) and a non-federated stack is
+ * byte-identical to the pre-FLG-1 panel.
+ */
+
+import type {
+  HandoffStatusDTO,
+  HandoffLegDTO,
+  HandoffOwner,
+  LeafUpBlockedReason,
+} from "../hooks/use-handoff";
+import { useHandoff } from "../hooks/use-handoff";
+
+/** Human label for a leg owner ("whose move"). The member is the local you. */
+function ownerLabel(owner: HandoffOwner): string {
+  switch (owner) {
+    case "admin":
+      return "admin";
+    case "hub-owner":
+      return "hub owner";
+    case "member":
+      return "you (member)";
+  }
+}
+
+/** Tone token per leg status — reused by the `.tone-*` styles in global.css. */
+function legTone(status: HandoffLegDTO["status"]): "ok" | "warn" | "muted" {
+  switch (status) {
+    case "done":
+      return "ok";
+    case "pending":
+      return "warn";
+    case "blocked":
+      return "muted";
+  }
+}
+
+/** Status glyph per leg — done / outstanding / blocked-by-an-earlier-leg. */
+function legGlyph(status: HandoffLegDTO["status"]): string {
+  switch (status) {
+    case "done":
+      return "✓";
+    case "pending":
+      return "●";
+    case "blocked":
+      return "○";
+  }
+}
+
+/** Short leg label (the id reads well enough as the chain label). */
+function legLabel(id: HandoffLegDTO["id"]): string {
+  return id;
+}
+
+/** Honest one-liner for why leaf-up is blocked. */
+function blockedReasonText(reason: LeafUpBlockedReason): string {
+  switch (reason) {
+    case "seal-pending":
+      return "Leaf-up blocked — waiting on the admin to seal your leaf secret.";
+    case "hub-unverifiable":
+      return "Leaf-up blocked — hub authorization can’t be auto-verified from here yet.";
+    case "hub-denied":
+      return "Leaf-up blocked — the hub owner has not authorized you (a real negative — it cannot be overridden).";
+  }
+}
+
+export interface HandoffBannerProps {
+  status: HandoffStatusDTO;
+  /** Whether the member attestation toggle is on. */
+  confirmed: boolean;
+  /** Flip the attestation (re-reads the handoff with `?confirmed=`). */
+  onToggleConfirmed: (next: boolean) => void;
+}
+
+/**
+ * PURE presentational banner — props only, no fetching. The roster panel mounts
+ * {@link HandoffBannerLive} (which feeds this); tests render THIS directly.
+ */
+export function HandoffBanner({
+  status,
+  confirmed,
+  onToggleConfirmed,
+}: HandoffBannerProps) {
+  const complete = status.next_owner === null;
+  return (
+    <div
+      className="handoff-banner"
+      data-network={status.network_id}
+      data-member={status.member}
+      data-next-owner={status.next_owner ?? "complete"}
+      data-can-leaf-up={String(status.can_bring_leaf_up)}
+      {...(status.leaf_up_blocked_reason !== null
+        ? { "data-blocked-reason": status.leaf_up_blocked_reason }
+        : {})}
+      aria-label={`Guided-join handoff for ${status.network_id}`}
+    >
+      <div className="handoff-banner-head">
+        <span className="handoff-banner-title">Guided join</span>
+        <span className="dim handoff-banner-network">{status.network_id}</span>
+      </div>
+
+      <ol className="handoff-legs">
+        {status.legs.map((leg, i) => (
+          <li
+            key={leg.id}
+            className={`handoff-leg tone-${legTone(leg.status)}`}
+            data-leg={leg.id}
+            data-status={leg.status}
+            data-owner={leg.owner}
+            title={leg.detail}
+          >
+            <span className="handoff-leg-glyph" aria-hidden="true">
+              {legGlyph(leg.status)}
+            </span>
+            <span className="handoff-leg-label">{legLabel(leg.id)}</span>
+            <span className="dim handoff-leg-owner">{ownerLabel(leg.owner)}</span>
+            {i < status.legs.length - 1 ? (
+              <span className="dim handoff-leg-arrow" aria-hidden="true">
+                →
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+
+      <div className="handoff-banner-next" data-complete={String(complete)}>
+        {complete ? (
+          <span className="tone-ok">All legs complete — leaf established.</span>
+        ) : (
+          <span>
+            Next move:{" "}
+            <strong>{ownerLabel(status.next_owner as HandoffOwner)}</strong>
+            {status.next_leg !== null ? (
+              <span className="dim"> — {legLabel(status.next_leg)}</span>
+            ) : null}
+          </span>
+        )}
+      </div>
+
+      {status.leaf_up_blocked_reason !== null ? (
+        <div
+          className="dim handoff-banner-blocked"
+          data-blocked-reason={status.leaf_up_blocked_reason}
+        >
+          {blockedReasonText(status.leaf_up_blocked_reason)}
+        </div>
+      ) : null}
+
+      {status.hub_attestable ? (
+        // The ONLY attestable state (hub-authorize signal is `undefined`). The
+        // toggle upgrades that un-verifiable leg to treated-done; the server
+        // never upgrades a real `false` (Sage #1499).
+        <label className="handoff-banner-confirm">
+          <input
+            type="checkbox"
+            checked={confirmed}
+            onChange={(e) => onToggleConfirmed(e.target.checked)}
+            data-testid="handoff-confirm-toggle"
+          />{" "}
+          <span>
+            The hub owner confirmed to me that they applied my authorization
+          </span>
+          <span className="dim handoff-banner-confirm-caption">
+            {" "}
+            — treats the un-verifiable hub leg as done. It cannot un-block a real
+            hub denial.
+          </span>
+        </label>
+      ) : status.leaf_up_blocked_reason === "hub-denied" ? (
+        <div className="dim handoff-banner-denied">
+          The hub owner has not authorized you — this cannot be confirmed away.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export interface HandoffBannerLiveProps {
+  networkId: string;
+  /** The member the banner reports on (the local principal). `null` ⇒ no fetch. */
+  member: string | null;
+  /** Gate the fetch to when the Network view is visible. Defaults to true. */
+  enabled?: boolean;
+}
+
+/**
+ * Self-fetching wrapper the roster panel mounts. Renders NOTHING until the read
+ * resolves — so it is SSR-inert (the roster panel stays effectively pure) and a
+ * non-federated / unreachable read shows no strip at all.
+ */
+export function HandoffBannerLive({
+  networkId,
+  member,
+  enabled = true,
+}: HandoffBannerLiveProps) {
+  const { status, confirmed, setConfirmed } = useHandoff(
+    networkId,
+    member,
+    enabled,
+  );
+  if (status === null) return null;
+  return (
+    <HandoffBanner
+      status={status}
+      confirmed={confirmed}
+      onToggleConfirmed={setConfirmed}
+    />
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
@@ -22,6 +22,11 @@ import {
   rosterStatusBadge,
   summarizeMembership,
 } from "../lib/network-membership-adapter";
+// FLG-1 (docs/plan-mc-future-state.md §4.D) — the guided-join handoff banner, a
+// strip per joined network (R1 render home; CK-7 rehomes it into the cockpit).
+// Self-fetching + SSR-inert (renders nothing until the read resolves), so the
+// panel stays effectively pure and a non-federated stack is unchanged.
+import { HandoffBannerLive } from "./handoff-banner";
 
 export interface NetworkRosterPanelProps {
   networks: readonly NetworkMembershipDTO[];
@@ -86,6 +91,11 @@ export function NetworkRosterPanel({
                     : ""}
                 </span>
               </div>
+              {/* FLG-1 — the guided-join handoff banner for THIS stack's own
+                  join to this network (member = the local principal). Self-
+                  fetching + SSR-inert: renders nothing until the read resolves,
+                  and nothing at all on a stack with no local principal. */}
+              <HandoffBannerLive networkId={net.network_id} member={localPrincipal} />
               {net.members.length === 0 ? (
                 <div className="dim network-roster-empty">
                   No admitted members resolved.

--- a/src/surface/mc/dashboard-v2/hooks/use-handoff.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-handoff.ts
@@ -1,0 +1,100 @@
+/**
+ * FLG-1 (docs/plan-mc-future-state.md §4.D) — guided-join handoff banner hook.
+ *
+ * Fetches `GET /api/networks/:net/handoff/:member` (the 3-leg seal →
+ * hub-authorize → leaf-up state, whose move is next, and why leaf-up is blocked)
+ * for ONE network + member. The "confirm" toggle re-reads with `?confirmed=true`
+ * — mapping to the member attestation the daemon applies via the pure
+ * `deriveHandoffState` (an `undefined` hub-authorize leg upgrades to done; a real
+ * `false` NEVER does — the guarantee is server-side, Sage #1499).
+ *
+ * Deliberately LIGHT (no WebSocket refresh): handoff legs change on discrete
+ * human acts (seal / authorize / leaf-up), not on the presence firehose, so a
+ * fetch-on-mount + refetch-on-confirm is honest for an R1 read-glass slice. A
+ * failed/unavailable read (503 no-federation, 404 not-joined, network error) is
+ * swallowed to `status: null` — the banner simply renders nothing rather than
+ * surfacing an error chip on a non-federated stack.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getJson } from "../lib/api";
+import type { HandoffStatusDTO } from "../../api/handoff";
+
+export type {
+  HandoffStatusDTO,
+  HandoffLegDTO,
+  HandoffLegId,
+  HandoffLegStatus,
+  HandoffOwner,
+  LeafUpBlockedReason,
+} from "../../api/handoff";
+
+export interface HandoffHookState {
+  /** The latest handoff status, or `null` while unloaded / when the read failed. */
+  status: HandoffStatusDTO | null;
+  loaded: boolean;
+  /** Whether the member "confirm hub authorization" attestation is toggled on. */
+  confirmed: boolean;
+  /** Toggle the attestation; flips the query and refetches. */
+  setConfirmed: (next: boolean) => void;
+}
+
+export function useHandoff(
+  networkId: string,
+  member: string | null,
+  enabled: boolean,
+): HandoffHookState {
+  const [status, setStatus] = useState<HandoffStatusDTO | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [confirmed, setConfirmedState] = useState(false);
+
+  // Lifetime + race guard (mirrors use-networks/use-agents): a stale in-flight
+  // response from a superseded fetch (older gen) or an unmounted component
+  // (aliveRef false) is dropped rather than written.
+  const genRef = useRef(0);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const fetchHandoff = useCallback(
+    async (confirmedNow: boolean, signal?: AbortSignal) => {
+      if (member === null) return;
+      const myGen = ++genRef.current;
+      const query = confirmedNow ? "?confirmed=true" : "";
+      const path = `/api/networks/${encodeURIComponent(networkId)}/handoff/${encodeURIComponent(member)}${query}`;
+      try {
+        const body = await getJson<HandoffStatusDTO>(
+          path,
+          signal ? { signal } : undefined,
+        );
+        if (!aliveRef.current || genRef.current !== myGen) return;
+        setStatus(body);
+        setLoaded(true);
+      } catch (e) {
+        if (!aliveRef.current || genRef.current !== myGen) return;
+        if ((e as { name?: string })?.name === "AbortError") return;
+        // Swallow: a 503 (no federation), 404 (not joined), or network error
+        // means "no handoff to show here" — the banner hides, never an error.
+        setStatus(null);
+        setLoaded(true);
+      }
+    },
+    [networkId, member],
+  );
+
+  useEffect(() => {
+    if (!enabled || member === null) return;
+    const ctrl = new AbortController();
+    void fetchHandoff(confirmed, ctrl.signal);
+    return () => ctrl.abort();
+  }, [enabled, member, confirmed, fetchHandoff]);
+
+  const setConfirmed = useCallback((next: boolean) => setConfirmedState(next), []);
+
+  return { status, loaded, confirmed, setConfirmed };
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -993,6 +993,44 @@ html, body {
 .tone-warn { color: var(--warn); }
 .tone-danger { color: var(--bad); }
 .tone-pending { color: var(--accent); }
+.tone-muted { color: var(--dim, #8a8f98); }
+
+/* FLG-1 (docs/plan-mc-future-state.md §4.D) — the guided-join handoff banner:
+   the 3-leg seal → hub-authorize → leaf-up chain per joined network. A strip on
+   the roster panel (R1 render home; CK-7 rehomes it into the cockpit). */
+.handoff-banner {
+  margin: 4px 0 8px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--panel));
+  border: 1px solid var(--line-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  font-size: 12px;
+}
+.handoff-banner-head {
+  display: flex; align-items: baseline; gap: 8px; margin-bottom: 6px;
+}
+.handoff-banner-title { font-weight: 600; }
+.handoff-banner-network { font-size: 11px; font-family: var(--mono); }
+.handoff-legs {
+  list-style: none; margin: 0 0 6px; padding: 0;
+  display: flex; align-items: center; flex-wrap: wrap; gap: 6px;
+}
+.handoff-leg {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 1px 6px; border-radius: 999px;
+  border: 1px solid currentColor; white-space: nowrap;
+}
+.handoff-leg-glyph { font-size: 11px; }
+.handoff-leg-label { font-family: var(--mono); font-size: 11px; }
+.handoff-leg-owner { font-size: 10px; }
+.handoff-leg-arrow { margin: 0 2px; border: 0; }
+.handoff-banner-next { margin-bottom: 2px; }
+.handoff-banner-blocked, .handoff-banner-denied { font-size: 11px; margin-top: 2px; }
+.handoff-banner-confirm {
+  display: block; margin-top: 6px; font-size: 11px; cursor: pointer;
+}
+.handoff-banner-confirm-caption { font-size: 10px; }
 
 /* MC-B1 (cortex#1278) — Pier queue (operator inbox of pending admission
    requests). Additive section in the Network view, below the roster panel. */

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -25,6 +25,8 @@ import type { WsClientRegistry } from "./ws/client-registry";
 import type { AgentPresenceView } from "./api/agents";
 import type { NetworksView } from "./api/networks";
 import type { AdmissionDecider } from "./api/networks-admission";
+// FLG-1 (docs/plan-mc-future-state.md §4.D) — guided-join handoff view passthrough.
+import type { HandoffView } from "./api/handoff";
 import type { LocalAggregationProvider } from "./local-aggregation/sibling-db-reader";
 
 export interface MissionControlHandle {
@@ -104,6 +106,15 @@ export interface StartMissionControlOptions {
    * embed. Omitted → the route 503s honestly.
    */
   admissionDecider?: () => AdmissionDecider | null;
+  /**
+   * FLG-1 (docs/plan-mc-future-state.md §4.D) — lazy accessor for the guided-join
+   * handoff view, forwarded verbatim to `startServer` so
+   * `GET /api/networks/:net/handoff/:member` surfaces the 3-leg seal →
+   * hub-authorize → leaf-up state. A GETTER (like `networks`) because the
+   * registry client + stack identity boot AFTER the embed. Omitted → the route
+   * 503s honestly.
+   */
+  handoffView?: () => HandoffView | null;
   /**
    * P-14 U0.1 — Tier-3 sideband base URL (`config.mc.sideband`). Loopback-
    * enforced at config-parse time; forwarded verbatim to `startServer`, which
@@ -189,6 +200,7 @@ export async function startMissionControl(
       ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
       ...(opts.networks ? { networks: opts.networks } : {}),
       ...(opts.admissionDecider ? { admissionDecider: opts.admissionDecider } : {}),
+      ...(opts.handoffView ? { handoffView: opts.handoffView } : {}),
       ...(opts.localAggregation ? { localAggregation: opts.localAggregation } : {}),
       ...(opts.sidebandUrl ? { sidebandUrl: opts.sidebandUrl } : {}),
     });

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -41,6 +41,8 @@ import {
 import { handleListGitLinks } from "./api/git-links";
 import { handleListAgents, type AgentPresenceView } from "./api/agents";
 import { handleListNetworks, type NetworksView } from "./api/networks";
+// FLG-1 (docs/plan-mc-future-state.md §4.D) — guided-join handoff banner read seam.
+import { handleGetHandoff, type HandoffView } from "./api/handoff";
 import {
   handleAdmissionDecision,
   CF_ACCESS_EMAIL_HEADER,
@@ -220,6 +222,15 @@ export interface StartServerOptions {
    */
   admissionDecider?: () => AdmissionDecider | null;
   /**
+   * FLG-1 (docs/plan-mc-future-state.md §4.D) — lazy accessor for the guided-join
+   * handoff view (serves `GET /api/networks/:net/handoff/:member`: the 3-leg
+   * seal → hub-authorize → leaf-up state via the pure `deriveHandoffState`). A
+   * GETTER like `networks` because the registry client + stack identity boot
+   * AFTER the embed in `cortex.ts`; resolved per request. Read-only (no signing);
+   * `null` ⇒ no federation/registry → the route 503s honestly.
+   */
+  handoffView?: () => HandoffView | null;
+  /**
    * P-14 U0.1 — Tier-3 sideband base URL (`mc.sideband`). When present, the
    * `/api/observability/*` routes proxy to it server-side. Loopback-enforced
    * at config-parse time; the proxy re-checks at the request boundary.
@@ -342,6 +353,9 @@ export function startServer(
         // MC-B2 — resolve the admission-decision signer lazily too (stack
         // identity + registry client boot after the server). null ⇒ 503.
         const admissionDecider = options.admissionDecider?.() ?? null;
+        // FLG-1 — resolve the handoff view lazily (same boot-order reason as
+        // `networks`). null ⇒ the handoff route 503s honestly.
+        const handoffView = options.handoffView?.() ?? null;
         // FND-6 — finalize the guard context with the ACTUAL bound port.
         const guard: MutationGuardContext = {
           ...guardBase,
@@ -357,6 +371,7 @@ export function startServer(
           networks,
           admissionDecider,
           guard,
+          handoffView,
         );
       }
 
@@ -516,6 +531,7 @@ async function handleApi(
   networks: NetworksView | null = null,
   admissionDecider: AdmissionDecider | null = null,
   guard: MutationGuardContext,
+  handoffView: HandoffView | null = null,
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -764,6 +780,34 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListNetworks(networks, agentPresence);
+  }
+
+  // FLG-1 (docs/plan-mc-future-state.md §4.D) — GET
+  // /api/networks/:net/handoff/:member — the guided-join two-party handoff
+  // banner's read seam. Wraps the PURE `deriveHandoffState` (#1479) via the
+  // injected HandoffView. Read-only (GET), so it is NOT identity-gated — the
+  // FND-6 guard above only wraps MUTATING_METHODS; this read carries
+  // metadata-only DTO (no interiors — invariant 1). The `?confirmed=` toggle
+  // maps to the member attestation (`undefined`→done only, NEVER a real
+  // `false` — invariant 9 / Sage #1499). The `/handoff/` segment disambiguates
+  // from the exact-match `/api/networks` + `/api/networks/admission-decision`
+  // routes, so registration order is immaterial.
+  const networkHandoffMatch = /^\/api\/networks\/([^/]+)\/handoff\/([^/]+)$/.exec(pathname);
+  if (networkHandoffMatch) {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    const netCaptured = networkHandoffMatch[1];
+    const memberCaptured = networkHandoffMatch[2];
+    if (!netCaptured || !memberCaptured) {
+      return new Response("Not Found", { status: 404 });
+    }
+    const networkId = decodeURIComponent(netCaptured);
+    const member = decodeURIComponent(memberCaptured);
+    // Fail-closed: only an explicit `?confirmed=true` attests. Any other value
+    // (absent, "false", garbage) is treated as no attestation.
+    const confirmed = url.searchParams.get("confirmed") === "true";
+    return handleGetHandoff(handoffView, { networkId, member, confirmed });
   }
 
   // MC-B2 (cortex#1279) — POST /api/networks/admission-decision — the mutating


### PR DESCRIPTION
R1 slice **FLG-1** — surfaces the guided-join two-party handoff (which had a pure model but zero MC call sites).

- **Endpoint** `GET /api/networks/:net/handoff/:member` wraps `deriveHandoffState`; metadata-only `HandoffStatusDTO`; wired via a `handoffView` seam using the SAME shared gatherer as the `cortex network handoff status` CLI; `null` → **503 honest** (not dead glass). GET → **not** identity-gated (FND-6 wraps mutating methods only). No-interiors enforced daemon-side (metadata DTO + shape-contract test; seal leg is a boolean, never ciphertext) — the faithful daemon analog of the worker DashboardSnapshot guard.
- **Banner** (render home: `network-roster-panel.tsx`) — 3 legs (seal → hub-authorize → leaf-up), per-leg owner, whose-move-next, blocked-reason.
- **Sage #1499 3-valued attestation:** the `confirmed` toggle upgrades ONLY `undefined`→done, never a real `false` — a hub-**denied** network stays blocked even under `confirmed=true` (tested); the toggle is offered only when `hub_attestable`.
- tsc 0; 21 + 1276 regression tests; eslint clean; vocab PASS; browser-QA (3 banner states).

Minimal server.ts change (rebased on CK-3). CK-7 rehomes the banner into the cockpit later.

Generated by the R1 opus fleet (flg1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c