### PR TITLE
feat(mc): FLG-3 — doctor-on-glass (why is this link red) (R1)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -163,6 +163,20 @@ import type { HandoffView } from "./surface/mc/api/handoff";
 import { gatherHandoffSignals } from "./cli/cortex/commands/network-handoff-lib";
 import { buildLiveHandoffPorts } from "./cli/cortex/commands/network-handoff-adapters";
 import type { LivePortsConfig } from "./cli/cortex/commands/network-adapters";
+// FLG-3 (docs/plan-mc-future-state.md §4.D) — network doctor-on-glass: the MC
+// read seam + the pure orchestrator / live ports the daemon wires it to. The
+// daemon reuses its ALREADY-RUNNING runtime as the peer-reachable probe bus
+// (`wrapRuntimeAsProbeBus`) — same probe transport `cortex network ping` /
+// `doctor` use, without opening a second NATS connection.
+import type { DoctorView } from "./surface/mc/api/doctor";
+import { runDoctorChecks } from "./cli/cortex/commands/network-doctor-lib";
+import {
+  buildDoctorConfigPort,
+  buildMonitorPort,
+} from "./cli/cortex/commands/network-doctor-adapters";
+import type { NetworkDoctorPorts } from "./cli/cortex/commands/network-doctor-ports";
+import { wrapRuntimeAsProbeBus } from "./cli/cortex/commands/network-ping-adapters";
+import type { LoadedConfig } from "./common/config/loader";
 import type {
   AdmissionDecider,
   AdmissionDecisionResult,
@@ -4024,6 +4038,14 @@ export async function startCortex(
   // + live ports). `null` until then ⇒ the handoff route 503s honestly. Read-only
   // — signs/mutates nothing; the leaf-up leg reads the LOCAL `/leafz`.
   let handoffViewForApi: HandoffView | null = null;
+  // FLG-3 (docs/plan-mc-future-state.md §4.D) — the network doctor view for
+  // `GET /api/networks/:net/doctor`. Assigned in the federation block below
+  // alongside `handoffViewForApi` (it reuses the SAME resolved policy + the
+  // daemon's already-running `runtime` as the probe bus). `null` until then ⇒
+  // the doctor route 503s honestly. Read-only — signs/mutates nothing beyond the
+  // ONE bounded probe echo per peer (the SAME transport `cortex network ping`
+  // uses).
+  let doctorViewForApi: DoctorView | null = null;
   // MC-B2 (cortex#1279) — the admission-decision signer for the mutating
   // `POST /api/networks/admission-decision` action. Assigned in the federation
   // block below alongside `networksViewForApi` (it reuses the SAME stack
@@ -4116,6 +4138,10 @@ export async function startCortex(
         // view (lazy; assigned in the federation block). null ⇒
         // `GET /api/networks/:net/handoff/:member` 503s honestly.
         handoffView: () => handoffViewForApi,
+        // FLG-3 (docs/plan-mc-future-state.md §4.D) — the network doctor view
+        // (lazy; assigned in the federation block). null ⇒
+        // `GET /api/networks/:net/doctor` 503s honestly.
+        doctorView: () => doctorViewForApi,
         // #1008 — DB-read pane-of-glass aggregation. The getter returns a context
         // only when discovery produced a resolve-opts (dbRead on); otherwise null
         // ⇒ single-db feeds. Lazy so the roster can be (re)read consistently.
@@ -4654,6 +4680,56 @@ export async function startCortex(
               member,
               selfPrincipal: principalId,
             });
+          },
+        };
+
+        // FLG-3 (docs/plan-mc-future-state.md §4.D) — the network doctor view.
+        // Runs the SAME pure `runDoctorChecks` + config/monitor adapters the
+        // `cortex network doctor` CLI uses, over the daemon's ALREADY-RUNNING
+        // `runtime` as the peer-reachable probe bus (`wrapRuntimeAsProbeBus`) —
+        // NOT a second NATS connection (the standalone CLI must open one; the
+        // daemon already holds one, and `wrapRuntimeAsProbeBus` declares its own
+        // per-probe reply subscription, so reuse is the intended path). The lib
+        // never calls `bus.stop()`, so the daemon runtime is never torn down.
+        // Read-only; never-throw ports degrade a leg to warn/skip rather than
+        // failing the whole read. Reuses the resolved policy + stack identity
+        // already loaded for the networks view above.
+        doctorViewForApi = {
+          localPrincipal: principalId,
+          runDoctor: async (networkId) => {
+            const fedNetworks = resolvedPolicy?.federated?.networks ?? [];
+            if (!fedNetworks.some((n) => n.id === networkId)) return null;
+            // A minimal LoadedConfig for the pure orchestrator: it reads only
+            // `principal.id`, `stack.id`/`stack.nkey_pub`, `inlineAgents[0].id`,
+            // and `policy.federated.networks[]` (via `derivePingInputs` + the
+            // representation-pair legs) — all already resolved at boot.
+            const loadedForDoctor: LoadedConfig = {
+              config,
+              inlineAgents: [...inlineAgents],
+              principal: { id: principalId },
+              ...(options.stack !== undefined && { stack: options.stack }),
+              ...(resolvedPolicy !== undefined && { policy: resolvedPolicy }),
+            };
+            const livePortsCfg: LivePortsConfig = {
+              networkId,
+              principalId,
+              stackId: options.stack?.id ?? principalId,
+            };
+            const ports: NetworkDoctorPorts = {
+              // The composed networks (config-split-aware); `runDoctorChecks`
+              // finds the one by id. Same adapter the CLI factory builds.
+              config: buildDoctorConfigPort({ networks: fedNetworks }),
+              // No daemon-known monitor config path ⇒ monitor-reachable warns
+              // and the leaf legs skip (HONEST degradation) rather than guess a
+              // monitor URL and risk a false "unreachable" fail.
+              monitor: buildMonitorPort(livePortsCfg),
+              probe: {
+                bus: wrapRuntimeAsProbeBus(runtime),
+                newNonce: () => crypto.randomUUID(),
+                newCorrelationId: () => crypto.randomUUID(),
+              },
+            };
+            return runDoctorChecks(ports, { cfg: loadedForDoctor, networkId });
           },
         };
 

--- a/src/surface/mc/api/__tests__/doctor.test.ts
+++ b/src/surface/mc/api/__tests__/doctor.test.ts
@@ -1,0 +1,167 @@
+/**
+ * FLG-3 (docs/plan-mc-future-state.md §4.D) — `handleGetDoctor` tests.
+ *
+ * Two things this file locks down:
+ *   1. Availability + verbatim projection: 503 (no federation), 404 (not
+ *      joined), and — on a real run — that every leg's status/detail/fix/owner
+ *      and the aggregate verdict pass through the endpoint UNCHANGED (invariant:
+ *      verdicts sourced, never re-derived), INCLUDING the two legs the plan
+ *      names explicitly (`sealed-secret-hub-authorized`, `peer-reachable:<p>`).
+ *   2. The no-interiors SHAPE guard (invariant 1 — the daemon analog of
+ *      `worker/src/__tests__/dashboard-snapshot-contract.test.ts`): the
+ *      `NetworkDoctorDTO` and its legs carry ONLY the allow-listed metadata keys
+ *      at every position. This is how the read "flows through the DashboardSnapshot
+ *      guard" on the daemon side — a metadata-only contract, asserted here. A new
+ *      field that could leak an interior / secret fails HERE, consciously.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  handleGetDoctor,
+  type DoctorView,
+  type NetworkDoctorDTO,
+} from "../doctor";
+import type {
+  DoctorRunResult,
+  DoctorCheck,
+} from "../../../../cli/cortex/commands/network-doctor-lib";
+import { DOCTOR_EXIT_CODE } from "../../../../cli/cortex/commands/network-doctor-lib";
+
+/** A representative 8-leg result — includes the two plan-named legs + every status. */
+function sampleResult(): DoctorRunResult {
+  const checks: DoctorCheck[] = [
+    { id: "config-network", title: 'network "research" configured', status: "pass", detail: "2 peer(s), 3 accept_subjects", owner: "member" },
+    { id: "registered-vs-fed-account", title: "registered pubkey vs FED account (Pair 1)", status: "pass", detail: "different keys, as expected (ADR-0018)", owner: "member" },
+    { id: "resolver-preload-account", title: "leaf account preloaded on this bus (Pair 2)", status: "pass", detail: "account U123456789012… is preloaded on this bus", owner: "member" },
+    {
+      id: "sealed-secret-hub-authorized",
+      title: "registry sealed-secret ⟷ hub authorization (Pair 3)",
+      status: "skip",
+      detail: "not implemented from the member side — the registry holds only an opaque ciphertext (ADR-0018 Q1)",
+      owner: "hub-owner",
+    },
+    { id: "monitor-reachable", title: "local NATS monitor reachable", status: "warn", detail: "no monitor configured for this bus", fix: "enable http_port/monitor_port on the local bus", owner: "member" },
+    { id: "leaf-established", title: "leaf established", status: "skip", detail: "skipped — no /leafz data (see monitor-reachable)", owner: "member" },
+    { id: "leaf-account-bound", title: "leaf account binding", status: "skip", detail: "skipped — no established leaf (see leaf-established)", owner: "member" },
+    {
+      id: "peer-reachable:jc/default",
+      title: "peer reachable: jc/default",
+      status: "fail",
+      detail: "no echo from jc/default within the probe timeout",
+      fix: "peer/hub — peer offline, its leaf is down, or the hub is partitioned; check the peer's own `cortex network doctor`",
+      owner: "peer",
+    },
+  ];
+  return { checks, verdict: "degraded", exitCode: DOCTOR_EXIT_CODE.degraded };
+}
+
+/** A stub view resolving a fixed result for one network id (else `null`). */
+function stubView(networkId: string, result: DoctorRunResult): DoctorView {
+  return {
+    localPrincipal: "andreas",
+    runDoctor: (net): Promise<DoctorRunResult | null> =>
+      Promise.resolve(net === networkId ? result : null),
+  };
+}
+
+async function body(res: Response): Promise<NetworkDoctorDTO> {
+  return (await res.json()) as NetworkDoctorDTO;
+}
+
+describe("handleGetDoctor — availability", () => {
+  it("503s when no doctor view is wired (no federation)", async () => {
+    const res = await handleGetDoctor(null, { networkId: "research" });
+    expect(res.status).toBe(503);
+  });
+
+  it("404s for a network this stack has not joined", async () => {
+    const res = await handleGetDoctor(stubView("research", sampleResult()), {
+      networkId: "not-joined",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("500s (honest, not a crash) when the run throws unexpectedly", async () => {
+    const view: DoctorView = {
+      localPrincipal: "andreas",
+      runDoctor: () => Promise.reject(new Error("boom")),
+    };
+    const res = await handleGetDoctor(view, { networkId: "research" });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("handleGetDoctor — verbatim projection", () => {
+  it("projects verdict + every leg's status/detail/fix/owner unchanged", async () => {
+    const result = sampleResult();
+    const dto = await body(
+      await handleGetDoctor(stubView("research", result), { networkId: "research" }),
+    );
+    expect(dto.network_id).toBe("research");
+    expect(dto.verdict).toBe("degraded");
+    expect(dto.checks.length).toBe(result.checks.length);
+    for (let i = 0; i < result.checks.length; i++) {
+      const src = result.checks[i]!;
+      const out = dto.checks[i]!;
+      expect(out.id).toBe(src.id);
+      expect(out.title).toBe(src.title);
+      expect(out.status).toBe(src.status);
+      expect(out.detail).toBe(src.detail);
+      expect(out.owner).toBe(src.owner);
+      // fix passes through, normalized to null when absent.
+      expect(out.fix).toBe(src.fix ?? null);
+    }
+  });
+
+  it("surfaces the two plan-named legs (sealed-secret-hub-authorized + peer-reachable:<p>)", async () => {
+    const dto = await body(
+      await handleGetDoctor(stubView("research", sampleResult()), { networkId: "research" }),
+    );
+    const sealed = dto.checks.find((c) => c.id === "sealed-secret-hub-authorized")!;
+    expect(sealed.status).toBe("skip");
+    expect(sealed.owner).toBe("hub-owner");
+
+    const peer = dto.checks.find((c) => c.id.startsWith("peer-reachable:"))!;
+    expect(peer.id).toBe("peer-reachable:jc/default");
+    expect(peer.status).toBe("fail");
+    expect(peer.owner).toBe("peer");
+    expect(peer.fix).not.toBeNull();
+  });
+
+  it("normalizes a pass leg's absent fix to explicit null", async () => {
+    const dto = await body(
+      await handleGetDoctor(stubView("research", sampleResult()), { networkId: "research" }),
+    );
+    const pass = dto.checks.find((c) => c.id === "config-network")!;
+    expect(pass.status).toBe("pass");
+    expect(pass.fix).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-interiors SHAPE guard — the daemon analog of the worker's
+// dashboard-snapshot-contract.test.ts. Asserts the DTO carries ONLY the
+// allow-listed metadata keys at every position. A new field that could leak an
+// interior / secret fails HERE, consciously (grow the allow-list = a real edit).
+// ---------------------------------------------------------------------------
+
+const DTO_KEYS = new Set(["network_id", "verdict", "checks"]);
+const CHECK_KEYS = new Set(["id", "title", "status", "detail", "fix", "owner"]);
+
+function assertKeys(obj: Record<string, unknown>, allowed: Set<string>, label: string): void {
+  const unexpected = Object.keys(obj).filter((k) => !allowed.has(k));
+  expect([label, unexpected]).toEqual([label, []]);
+}
+
+describe("handleGetDoctor — no-interiors SHAPE guard (invariant 1)", () => {
+  it("the DTO + its legs carry only the allow-listed metadata keys", async () => {
+    const dto = await body(
+      await handleGetDoctor(stubView("research", sampleResult()), { networkId: "research" }),
+    );
+    assertKeys(dto as unknown as Record<string, unknown>, DTO_KEYS, "NetworkDoctorDTO");
+    expect(dto.checks.length).toBeGreaterThan(0);
+    for (const leg of dto.checks) {
+      assertKeys(leg as unknown as Record<string, unknown>, CHECK_KEYS, `checks[${leg.id}]`);
+    }
+  });
+});

--- a/src/surface/mc/api/doctor.ts
+++ b/src/surface/mc/api/doctor.ts
@@ -1,0 +1,174 @@
+/**
+ * FLG-3 (docs/plan-mc-future-state.md §4.D) — `GET /api/networks/:net/doctor`.
+ *
+ * Surfaces the guided-join **network doctor** (epic #1479's pure
+ * `runDoctorChecks`, cortex#1484/#1482) on the glass — the "why is this link
+ * red" drill. The 8-leg `DoctorCheck` matrix already exists CLI-side (`cortex
+ * network doctor --json`) with ZERO MC call sites; this endpoint is the first.
+ * It verifies the WHOLE federation path from THIS member's own machine and
+ * reports, PER LEG: a `status` (pass/fail/warn/skip), a `detail`, an owner-
+ * actionable `fix`, and WHOSE job the fix is (`owner` ∈ member/hub-owner/admin/
+ * peer) — plus an aggregate `verdict` (healthy/degraded/broken). The read is a
+ * pure projection of what `runDoctorChecks` returns; this handler signs/mutates
+ * nothing.
+ *
+ * Mirrors the FLG-1 handoff endpoint (`./handoff.ts`) exactly: a minimal
+ * read-only {@link DoctorView} seam the server depends on, a metadata-only
+ * snake_case DTO, `null` view → 503 honest, unknown network → 404, and a
+ * daemon-side SHAPE-contract test (`__tests__/doctor.test.ts`).
+ *
+ * ## No-interiors discipline (plan invariant 1 — the DashboardSnapshot guard)
+ *
+ * The plan routes every new cockpit/aggregation READ through the worker-scoped
+ * `DashboardSnapshot` no-interiors guard. That guard is the CF worker's SHAPE
+ * contract on the public `/api/state` projection; this endpoint is a DAEMON
+ * read, so the equivalent enforcement is (a) the metadata-only
+ * {@link NetworkDoctorDTO} below and (b) the daemon-side SHAPE contract test
+ * (`__tests__/doctor.test.ts`) — the direct analog of the worker's. The DTO
+ * carries ONLY lifecycle/diagnostic metadata: per-leg id/title/status/detail/
+ * fix/owner + the aggregate verdict. Critically NO secret material: the doctor
+ * legs deal in PUBLIC keys (truncated to a 12-char prefix for readability) and
+ * traffic COUNTS — never a seed, a payload key K, or a sealed PSK. The
+ * `sealed-secret-hub-authorized` leg is a documented `skip` stub precisely
+ * because the sealed ciphertext is opaque from the member side (ADR-0018 Q1);
+ * it reports the gap, it never surfaces the secret (invariant 6).
+ *
+ * ## Verdicts verbatim (plan invariant — sourced-not-re-derived)
+ *
+ * Every `status`, `detail`, `fix`, `owner`, and the aggregate `verdict` is
+ * passed through from `runDoctorChecks` UNCHANGED — the handler re-derives no
+ * diagnosis of its own. The glass shows exactly what the CLI would.
+ *
+ * ## Dependency direction (surface must not import the bus)
+ *
+ * Like `/api/networks/:net/handoff/:member`, the server depends only on the
+ * minimal {@link DoctorView} seam + the PURE result TYPES; `cortex.ts` adapts
+ * the live port wiring (config + monitor adapters + the daemon runtime as the
+ * probe bus) to it at boot. The surface imports pure TYPES only — never the
+ * ports/adapters/bus. The one intentional divergence from the CLI's live wiring
+ * (documented at the `cortex.ts` seam): the daemon reuses its ALREADY-RUNNING
+ * runtime as the peer-reachable probe bus (`wrapRuntimeAsProbeBus`) rather than
+ * opening a second NATS connection the way the standalone CLI must — same
+ * probe transport, same config/monitor adapters, same pure `runDoctorChecks`.
+ */
+
+import type {
+  DoctorRunResult,
+  DoctorCheckStatus,
+  DoctorCheckOwner,
+  DoctorVerdict,
+} from "../../../cli/cortex/commands/network-doctor-lib";
+
+export type { DoctorCheckStatus, DoctorCheckOwner, DoctorVerdict };
+
+/**
+ * The minimal read-only seam the MC server depends on to serve the doctor
+ * endpoint. `cortex.ts` supplies a live implementation (running `runDoctorChecks`
+ * over the live config/monitor adapters + the daemon runtime as the probe bus);
+ * tests supply a stub. `null` (no federation/registry) → the route 503s honestly.
+ */
+export interface DoctorView {
+  /** The serving (local) principal — the member the doctor reports FROM. */
+  localPrincipal: string;
+  /**
+   * Run the full doctor matrix for `networkId` from this member's machine.
+   * Resolves to `null` when `networkId` is not a network this stack has joined
+   * (→ 404). Any unexpected throw propagates to the handler's catch (→ 500);
+   * the pure `runDoctorChecks` + its never-throw ports make that path
+   * structural belt-and-braces, not an expected outcome.
+   */
+  runDoctor(networkId: string): Promise<DoctorRunResult | null>;
+}
+
+/** One doctor leg, snake_case for the wire DTO. */
+export interface DoctorCheckDTO {
+  id: string;
+  title: string;
+  status: DoctorCheckStatus;
+  detail: string;
+  /**
+   * Owner-actionable remediation, or `null` when the leg needs none (a `pass`
+   * or an unactionable `skip`). Normalized to an explicit `null` (never absent)
+   * so the no-interiors shape contract has a fixed key set at every position.
+   */
+  fix: string | null;
+  owner: DoctorCheckOwner;
+}
+
+/**
+ * `GET /api/networks/:net/doctor` response body — metadata ONLY (the
+ * no-interiors DTO; see the module doc + `__tests__/doctor.test.ts`).
+ */
+export interface NetworkDoctorDTO {
+  network_id: string;
+  /** Aggregate verdict, verbatim from `runDoctorChecks`. */
+  verdict: DoctorVerdict;
+  /** Every leg, in `runDoctorChecks` order (config → pairs → monitor/leaf → peers). */
+  checks: DoctorCheckDTO[];
+}
+
+export interface HandleGetDoctorOpts {
+  networkId: string;
+}
+
+/**
+ * Handle `GET /api/networks/:net/doctor`.
+ *
+ * `view === null` → 503 (no federation configured — honest). Unknown network →
+ * 404. Otherwise run the doctor (never-throw ports + pure orchestration) and
+ * project the result into the metadata-only DTO. The catch is a structural
+ * belt-and-braces (same posture as `handleGetHandoff`).
+ */
+export async function handleGetDoctor(
+  view: DoctorView | null,
+  opts: HandleGetDoctorOpts,
+): Promise<Response> {
+  try {
+    if (view === null) {
+      return Response.json(
+        {
+          error:
+            "network doctor unavailable — no federation/registry configured on this stack",
+        },
+        { status: 503 },
+      );
+    }
+
+    const result = await view.runDoctor(opts.networkId);
+    if (result === null) {
+      return Response.json(
+        { error: `network "${opts.networkId}" is not one this stack has joined` },
+        { status: 404 },
+      );
+    }
+
+    // Verbatim projection — status/detail/fix/owner + the aggregate verdict are
+    // passed through unchanged (invariant: verdicts sourced, never re-derived).
+    // `fix` is normalized to an explicit `null` so the shape contract sees a
+    // fixed key set on every leg.
+    const dto: NetworkDoctorDTO = {
+      network_id: opts.networkId,
+      verdict: result.verdict,
+      checks: result.checks.map((c) => ({
+        id: c.id,
+        title: c.title,
+        status: c.status,
+        detail: c.detail,
+        fix: c.fix ?? null,
+        owner: c.owner,
+      })),
+    };
+
+    return Response.json(dto);
+  } catch (err) {
+    process.stderr.write(
+      `[api] GET /api/networks/:net/doctor failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return Response.json(
+      {
+        error: `Failed to run network doctor: ${err instanceof Error ? err.message : String(err)}`,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/surface/mc/dashboard-v2/__tests__/network-doctor-panel.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-doctor-panel.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * FLG-3 (docs/plan-mc-future-state.md §4.D) — DoctorReport render tests.
+ *
+ * The report is a PURE component (props-only, no hooks), so it renders under
+ * `renderToStaticMarkup`. These assert the acceptance: the renderer shows
+ * status / fix / owner per leg (including the two plan-named legs
+ * `sealed-secret-hub-authorized` + `peer-reachable:<p>`) + the aggregate
+ * verdict, and that verdict strings render VERBATIM (sourced, never re-derived).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { DoctorReport } from "../components/network-doctor-panel";
+import type { NetworkDoctorDTO } from "../hooks/use-doctor";
+
+function sample(): NetworkDoctorDTO {
+  return {
+    network_id: "research",
+    verdict: "degraded",
+    checks: [
+      {
+        id: "config-network",
+        title: 'network "research" configured',
+        status: "pass",
+        detail: "2 peer(s), 3 accept_subjects",
+        fix: null,
+        owner: "member",
+      },
+      {
+        id: "sealed-secret-hub-authorized",
+        title: "registry sealed-secret ⟷ hub authorization (Pair 3)",
+        status: "skip",
+        detail: "not implemented from the member side (ADR-0018 Q1)",
+        fix: null,
+        owner: "hub-owner",
+      },
+      {
+        id: "peer-reachable:jc/default",
+        title: "peer reachable: jc/default",
+        status: "fail",
+        detail: "no echo from jc/default within the probe timeout",
+        fix: "peer/hub — peer offline, its leaf is down, or the hub is partitioned",
+        owner: "peer",
+      },
+    ],
+  };
+}
+
+describe("DoctorReport", () => {
+  it("renders the aggregate verdict verbatim", () => {
+    const html = renderToStaticMarkup(
+      createElement(DoctorReport, { report: sample() }),
+    );
+    expect(html).toContain('data-verdict="degraded"');
+    expect(html).toContain(">degraded<");
+  });
+
+  it("renders every leg with its status + owner as data attributes", () => {
+    const html = renderToStaticMarkup(
+      createElement(DoctorReport, { report: sample() }),
+    );
+    // status/owner surfaced as stable tokens for automation/tests.
+    expect(html).toContain('data-leg="config-network"');
+    expect(html).toContain('data-status="pass"');
+    expect(html).toContain('data-status="skip"');
+    expect(html).toContain('data-status="fail"');
+    expect(html).toContain('data-owner="peer"');
+    expect(html).toContain('data-owner="hub-owner"');
+  });
+
+  it("renders the two plan-named legs (sealed-secret + peer-reachable)", () => {
+    const html = renderToStaticMarkup(
+      createElement(DoctorReport, { report: sample() }),
+    );
+    expect(html).toContain('data-leg="sealed-secret-hub-authorized"');
+    expect(html).toContain('data-leg="peer-reachable:jc/default"');
+  });
+
+  it("renders the fix + its owner label only for legs that have a fix", () => {
+    const html = renderToStaticMarkup(
+      createElement(DoctorReport, { report: sample() }),
+    );
+    // The failing peer leg shows its fix with the owner label ("peer").
+    expect(html).toContain("fix (peer):");
+    expect(html).toContain("peer offline");
+    // The passing config leg has no fix → no "fix (" prefix for member here.
+    expect(html).not.toContain("fix (you (member)):");
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/network-doctor-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-doctor-panel.tsx
@@ -1,0 +1,190 @@
+/**
+ * FLG-3 (docs/plan-mc-future-state.md §4.D) — the network doctor DRILL.
+ *
+ * The "why is this link red" affordance surfaced per joined network on the
+ * roster panel (R1 render home; CK-7 rehomes it into the cockpit GOVERN bar +
+ * wires it to red-edge/node drilling in R2). It runs the 8-leg `DoctorCheck`
+ * matrix (epic #1479, cortex#1484/#1482) FROM this member's machine and renders,
+ * PER LEG: a status glyph, the leg id/title, the detail, an owner-actionable
+ * fix, and WHOSE job the fix is (member / hub owner / admin / peer) — plus the
+ * aggregate verdict. Includes the two plan-named legs
+ * (`sealed-secret-hub-authorized`, `peer-reachable:<p>`).
+ *
+ * ## On-demand, not a live banner (truth-not-theater)
+ *
+ * Unlike the FLG-1 handoff banner (a cheap read that self-fetches on mount),
+ * the doctor runs a LIVE echo round-trip per configured peer (a real probe with
+ * a multi-second per-peer timeout). Auto-running it on every roster-panel mount
+ * would fire probes across the fleet on every render. So {@link DoctorDrill}
+ * renders a collapsed "Diagnose" button and fetches ONLY when the principal
+ * clicks — matching the plan's "drill from a red edge/node". It is SSR-inert
+ * (no effect fires until the click), so the roster panel stays effectively pure.
+ *
+ * {@link DoctorReport} is PURE (props-only, SSR-renderable — the shape the tests
+ * assert). {@link DoctorDrill} is the thin self-fetching wrapper the roster
+ * panel mounts.
+ */
+
+import type {
+  NetworkDoctorDTO,
+  DoctorCheckDTO,
+  DoctorCheckStatus,
+  DoctorCheckOwner,
+  DoctorVerdict,
+} from "../hooks/use-doctor";
+import { useDoctor } from "../hooks/use-doctor";
+
+/** Tone token per leg status — reused by the `.tone-*` styles in global.css. */
+function statusTone(
+  status: DoctorCheckStatus,
+): "ok" | "danger" | "warn" | "muted" {
+  switch (status) {
+    case "pass":
+      return "ok";
+    case "fail":
+      return "danger";
+    case "warn":
+      return "warn";
+    case "skip":
+      return "muted";
+  }
+}
+
+/** Status glyph per leg — pass / fail / warn / skip. */
+function statusGlyph(status: DoctorCheckStatus): string {
+  switch (status) {
+    case "pass":
+      return "✓";
+    case "fail":
+      return "✗";
+    case "warn":
+      return "⚠";
+    case "skip":
+      return "·";
+  }
+}
+
+/** Tone for the aggregate verdict chip. */
+function verdictTone(verdict: DoctorVerdict): "ok" | "warn" | "danger" {
+  switch (verdict) {
+    case "healthy":
+      return "ok";
+    case "degraded":
+      return "warn";
+    case "broken":
+      return "danger";
+  }
+}
+
+/** Human label for who owns a leg's fix ("whose job"). The member is the local you. */
+function ownerLabel(owner: DoctorCheckOwner): string {
+  switch (owner) {
+    case "member":
+      return "you (member)";
+    case "hub-owner":
+      return "hub owner";
+    case "admin":
+      return "admin";
+    case "peer":
+      return "peer";
+  }
+}
+
+export interface DoctorReportProps {
+  report: NetworkDoctorDTO;
+}
+
+/**
+ * PURE presentational report — props only, no fetching. The drill mounts
+ * {@link DoctorDrill} (which feeds this); tests render THIS directly.
+ *
+ * Verdicts are shown VERBATIM: the status, detail, fix, and owner come straight
+ * from the DTO (sourced from `runDoctorChecks`, never re-derived here).
+ */
+export function DoctorReport({ report }: DoctorReportProps) {
+  return (
+    <div
+      className="doctor-report"
+      data-network={report.network_id}
+      data-verdict={report.verdict}
+      aria-label={`Network doctor for ${report.network_id}`}
+    >
+      <div className="doctor-report-head">
+        <span className="doctor-report-title">Doctor</span>
+        <span className="dim doctor-report-network">{report.network_id}</span>
+        <span
+          className={`doctor-report-verdict tone-${verdictTone(report.verdict)}`}
+          data-verdict={report.verdict}
+        >
+          {report.verdict}
+        </span>
+      </div>
+
+      <ul className="doctor-legs">
+        {report.checks.map((leg: DoctorCheckDTO) => (
+          <li
+            key={leg.id}
+            className={`doctor-leg tone-${statusTone(leg.status)}`}
+            data-leg={leg.id}
+            data-status={leg.status}
+            data-owner={leg.owner}
+          >
+            <span className="doctor-leg-status">
+              <span className="doctor-leg-glyph" aria-hidden="true">
+                {statusGlyph(leg.status)}
+              </span>{" "}
+              <span className="doctor-leg-id">{leg.id}</span>
+            </span>
+            <span className="dim doctor-leg-detail">{leg.detail}</span>
+            {leg.fix !== null ? (
+              <span className="doctor-leg-fix">
+                <span className="dim doctor-leg-fix-owner">
+                  fix ({ownerLabel(leg.owner)}):
+                </span>{" "}
+                {leg.fix}
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export interface DoctorDrillProps {
+  networkId: string;
+}
+
+/**
+ * Self-fetching wrapper the roster panel mounts. Renders a collapsed "Diagnose"
+ * button; on click it runs the doctor (a live per-peer probe) and renders the
+ * {@link DoctorReport}. SSR-inert — no effect fires until the click, so the
+ * roster panel stays effectively pure and a non-federated stack is unchanged.
+ */
+export function DoctorDrill({ networkId }: DoctorDrillProps) {
+  const { report, loading, error, hasRun, run } = useDoctor(networkId);
+
+  return (
+    <div className="doctor-drill" data-network={networkId}>
+      <button
+        type="button"
+        className="doctor-drill-run"
+        onClick={run}
+        disabled={loading}
+        data-testid="doctor-run"
+      >
+        {loading
+          ? "Diagnosing…"
+          : hasRun
+            ? "Re-run doctor"
+            : "Diagnose — why is this red?"}
+      </button>
+      {error !== null ? (
+        <div className="dim doctor-drill-error" role="status">
+          {error}
+        </div>
+      ) : null}
+      {report !== null ? <DoctorReport report={report} /> : null}
+    </div>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
@@ -27,6 +27,11 @@ import {
 // Self-fetching + SSR-inert (renders nothing until the read resolves), so the
 // panel stays effectively pure and a non-federated stack is unchanged.
 import { HandoffBannerLive } from "./handoff-banner";
+// FLG-3 (docs/plan-mc-future-state.md §4.D) — the network doctor drill ("why is
+// this red"), an on-demand control per joined network (R1 render home; CK-7
+// rehomes it into the cockpit + wires red-edge drilling). Self-fetching only on
+// click, so the panel stays effectively pure.
+import { DoctorDrill } from "./network-doctor-panel";
 
 export interface NetworkRosterPanelProps {
   networks: readonly NetworkMembershipDTO[];
@@ -96,6 +101,10 @@ export function NetworkRosterPanel({
                   fetching + SSR-inert: renders nothing until the read resolves,
                   and nothing at all on a stack with no local principal. */}
               <HandoffBannerLive networkId={net.network_id} member={localPrincipal} />
+              {/* FLG-3 — the doctor drill for THIS network. On-demand (a live
+                  per-peer probe), collapsed to a button until the principal
+                  asks "why is this red?". */}
+              <DoctorDrill networkId={net.network_id} />
               {net.members.length === 0 ? (
                 <div className="dim network-roster-empty">
                   No admitted members resolved.

--- a/src/surface/mc/dashboard-v2/hooks/use-doctor.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-doctor.ts
@@ -1,0 +1,92 @@
+/**
+ * FLG-3 (docs/plan-mc-future-state.md §4.D) — network doctor drill hook.
+ *
+ * Fetches `GET /api/networks/:net/doctor` (the 8-leg status/fix/owner matrix +
+ * aggregate verdict) for ONE network. Unlike the FLG-1 handoff hook, this is
+ * ON-DEMAND (a `run()` trigger), NOT fetch-on-mount: the doctor runs a LIVE
+ * echo round-trip per configured peer (a real probe with a multi-second
+ * per-peer timeout), so auto-running it on every roster-panel mount would fire
+ * probes across the fleet on every render. It is the "why is this link red"
+ * DRILL — the principal asks for it (matching the plan's "drill from a red
+ * edge/node").
+ *
+ * A failed/unavailable read (503 no-federation, 404 not-joined, network error)
+ * surfaces an honest one-line `error` on the drill rather than silently
+ * vanishing — the principal explicitly asked to diagnose, so "nothing to show"
+ * must be visible, not swallowed.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getJson } from "../lib/api";
+import type { NetworkDoctorDTO } from "../../api/doctor";
+
+export type {
+  NetworkDoctorDTO,
+  DoctorCheckDTO,
+  DoctorCheckStatus,
+  DoctorCheckOwner,
+  DoctorVerdict,
+} from "../../api/doctor";
+
+export interface DoctorHookState {
+  /** The latest doctor report, or `null` before the first successful run. */
+  report: NetworkDoctorDTO | null;
+  /** Whether a run is in flight (the probes take a few seconds). */
+  loading: boolean;
+  /** An honest one-line failure (unavailable/not-joined/network error), or `null`. */
+  error: string | null;
+  /** Whether at least one run has been triggered (drives the collapsed vs open UI). */
+  hasRun: boolean;
+  /** Trigger (or re-run) the doctor. */
+  run: () => void;
+}
+
+export function useDoctor(networkId: string): DoctorHookState {
+  const [report, setReport] = useState<NetworkDoctorDTO | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasRun, setHasRun] = useState(false);
+
+  // Lifetime + race guard (mirrors use-handoff/use-networks): a stale in-flight
+  // response from a superseded run (older gen) or an unmounted component
+  // (aliveRef false) is dropped rather than written.
+  const genRef = useRef(0);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const run = useCallback(() => {
+    const myGen = ++genRef.current;
+    setHasRun(true);
+    setLoading(true);
+    setError(null);
+    const path = `/api/networks/${encodeURIComponent(networkId)}/doctor`;
+    void (async () => {
+      try {
+        const body = await getJson<NetworkDoctorDTO>(path);
+        if (!aliveRef.current || genRef.current !== myGen) return;
+        setReport(body);
+        setLoading(false);
+      } catch (e) {
+        if (!aliveRef.current || genRef.current !== myGen) return;
+        const msg = e instanceof Error ? e.message : String(e);
+        // The principal explicitly asked — surface the failure, don't swallow.
+        setError(
+          msg.includes("503")
+            ? "Doctor unavailable — no federation configured on this stack."
+            : msg.includes("404")
+              ? "This stack has not joined that network."
+              : `Doctor run failed: ${msg}`,
+        );
+        setLoading(false);
+      }
+    })();
+  }, [networkId]);
+
+  return { report, loading, error, hasRun, run };
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -1032,6 +1032,54 @@ html, body {
 }
 .handoff-banner-confirm-caption { font-size: 10px; }
 
+/* FLG-3 (docs/plan-mc-future-state.md §4.D) — the network doctor drill: the
+   "why is this link red" affordance per joined network. Collapsed to a button
+   until the principal drills; the report renders the 8-leg status/fix/owner
+   matrix + aggregate verdict. A strip on the roster panel (R1 render home; CK-7
+   rehomes it into the cockpit). */
+.doctor-drill { margin: 0 0 8px; }
+.doctor-drill-run {
+  font: inherit; font-size: 11px; cursor: pointer;
+  padding: 2px 10px; border-radius: 999px;
+  color: var(--fg); background: var(--panel-2);
+  border: 1px solid var(--line-soft);
+}
+.doctor-drill-run:hover:not(:disabled) { border-color: var(--accent); }
+.doctor-drill-run:disabled { cursor: default; opacity: 0.7; }
+.doctor-drill-error { font-size: 11px; margin-top: 4px; }
+.doctor-report {
+  margin: 6px 0 4px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--panel));
+  border: 1px solid var(--line-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  font-size: 12px;
+}
+.doctor-report-head {
+  display: flex; align-items: baseline; gap: 8px; margin-bottom: 6px;
+}
+.doctor-report-title { font-weight: 600; }
+.doctor-report-network { font-size: 11px; font-family: var(--mono); }
+.doctor-report-verdict {
+  font-size: 10px; margin-left: auto; text-transform: uppercase;
+  letter-spacing: 0.04em; font-weight: 600;
+}
+.doctor-legs {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.doctor-leg {
+  display: flex; flex-direction: column; gap: 1px;
+  padding-left: 8px; border-left: 2px solid currentColor;
+}
+.doctor-leg-status { font-size: 12px; }
+.doctor-leg-glyph { font-size: 11px; }
+.doctor-leg-id { font-family: var(--mono); font-size: 11px; }
+.doctor-leg-detail { font-size: 11px; }
+.doctor-leg-fix { font-size: 11px; }
+.doctor-leg-fix-owner { font-style: italic; }
+
 /* MC-B1 (cortex#1278) — Pier queue (operator inbox of pending admission
    requests). Additive section in the Network view, below the roster panel. */
 .pier-queue-panel {

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -27,6 +27,8 @@ import type { NetworksView } from "./api/networks";
 import type { AdmissionDecider } from "./api/networks-admission";
 // FLG-1 (docs/plan-mc-future-state.md §4.D) — guided-join handoff view passthrough.
 import type { HandoffView } from "./api/handoff";
+// FLG-3 (docs/plan-mc-future-state.md §4.D) — network doctor view passthrough.
+import type { DoctorView } from "./api/doctor";
 import type { LocalAggregationProvider } from "./local-aggregation/sibling-db-reader";
 
 export interface MissionControlHandle {
@@ -116,6 +118,14 @@ export interface StartMissionControlOptions {
    */
   handoffView?: () => HandoffView | null;
   /**
+   * FLG-3 (docs/plan-mc-future-state.md §4.D) — lazy accessor for the network
+   * doctor view, forwarded verbatim to `startServer` so
+   * `GET /api/networks/:net/doctor` surfaces the 8-leg status/fix/owner matrix.
+   * A GETTER (like `handoffView`) because the registry client + stack identity +
+   * runtime boot AFTER the embed. Omitted → the route 503s honestly.
+   */
+  doctorView?: () => DoctorView | null;
+  /**
    * P-14 U0.1 — Tier-3 sideband base URL (`config.mc.sideband`). Loopback-
    * enforced at config-parse time; forwarded verbatim to `startServer`, which
    * wires it onto `ApiDeps.sidebandUrl` so the `/api/observability/*` proxy can
@@ -201,6 +211,7 @@ export async function startMissionControl(
       ...(opts.networks ? { networks: opts.networks } : {}),
       ...(opts.admissionDecider ? { admissionDecider: opts.admissionDecider } : {}),
       ...(opts.handoffView ? { handoffView: opts.handoffView } : {}),
+      ...(opts.doctorView ? { doctorView: opts.doctorView } : {}),
       ...(opts.localAggregation ? { localAggregation: opts.localAggregation } : {}),
       ...(opts.sidebandUrl ? { sidebandUrl: opts.sidebandUrl } : {}),
     });

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -43,6 +43,8 @@ import { handleListAgents, type AgentPresenceView } from "./api/agents";
 import { handleListNetworks, type NetworksView } from "./api/networks";
 // FLG-1 (docs/plan-mc-future-state.md §4.D) — guided-join handoff banner read seam.
 import { handleGetHandoff, type HandoffView } from "./api/handoff";
+// FLG-3 (docs/plan-mc-future-state.md §4.D) — network doctor-on-glass read seam.
+import { handleGetDoctor, type DoctorView } from "./api/doctor";
 import {
   handleAdmissionDecision,
   CF_ACCESS_EMAIL_HEADER,
@@ -231,6 +233,16 @@ export interface StartServerOptions {
    */
   handoffView?: () => HandoffView | null;
   /**
+   * FLG-3 (docs/plan-mc-future-state.md §4.D) — lazy accessor for the network
+   * doctor view (serves `GET /api/networks/:net/doctor`: the 8-leg
+   * status/fix/owner matrix via the pure `runDoctorChecks`). A GETTER like
+   * `handoffView` because the registry client + stack identity + runtime boot
+   * AFTER the embed in `cortex.ts`; resolved per request. Read-only (no signing —
+   * one bounded probe echo per peer, the SAME transport `cortex network ping`
+   * uses); `null` ⇒ no federation/registry → the route 503s honestly.
+   */
+  doctorView?: () => DoctorView | null;
+  /**
    * P-14 U0.1 — Tier-3 sideband base URL (`mc.sideband`). When present, the
    * `/api/observability/*` routes proxy to it server-side. Loopback-enforced
    * at config-parse time; the proxy re-checks at the request boundary.
@@ -356,6 +368,9 @@ export function startServer(
         // FLG-1 — resolve the handoff view lazily (same boot-order reason as
         // `networks`). null ⇒ the handoff route 503s honestly.
         const handoffView = options.handoffView?.() ?? null;
+        // FLG-3 — resolve the doctor view lazily (same boot-order reason).
+        // null ⇒ the doctor route 503s honestly.
+        const doctorView = options.doctorView?.() ?? null;
         // FND-6 — finalize the guard context with the ACTUAL bound port.
         const guard: MutationGuardContext = {
           ...guardBase,
@@ -372,6 +387,7 @@ export function startServer(
           admissionDecider,
           guard,
           handoffView,
+          doctorView,
         );
       }
 
@@ -532,6 +548,7 @@ async function handleApi(
   admissionDecider: AdmissionDecider | null = null,
   guard: MutationGuardContext,
   handoffView: HandoffView | null = null,
+  doctorView: DoctorView | null = null,
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -808,6 +825,27 @@ async function handleApi(
     // (absent, "false", garbage) is treated as no attestation.
     const confirmed = url.searchParams.get("confirmed") === "true";
     return handleGetHandoff(handoffView, { networkId, member, confirmed });
+  }
+
+  // FLG-3 (docs/plan-mc-future-state.md §4.D) — GET /api/networks/:net/doctor —
+  // the "why is this link red" drill. Wraps the PURE `runDoctorChecks` (#1484/
+  // #1482) via the injected DoctorView. Read-only (GET), so it is NOT identity-
+  // gated — the FND-6 guard above only wraps MUTATING_METHODS; this read carries
+  // a metadata-only DTO (no interiors/secrets — invariant 1). The `/doctor`
+  // suffix disambiguates from the exact-match `/api/networks` +
+  // `/api/networks/admission-decision` routes and the `/handoff/` route above,
+  // so registration order is immaterial.
+  const networkDoctorMatch = /^\/api\/networks\/([^/]+)\/doctor$/.exec(pathname);
+  if (networkDoctorMatch) {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    const netCaptured = networkDoctorMatch[1];
+    if (!netCaptured) {
+      return new Response("Not Found", { status: 404 });
+    }
+    const networkId = decodeURIComponent(netCaptured);
+    return handleGetDoctor(doctorView, { networkId });
   }
 
   // MC-B2 (cortex#1279) — POST /api/networks/admission-decision — the mutating


### PR DESCRIPTION
R1 slice **FLG-3** — surfaces the 8-leg `runDoctor` matrix read-only on the glass (mirrors the FLG-1 endpoint pattern).

- `GET /api/networks/:net/doctor` via a `doctorView` seam wired live in `cortex.ts`; metadata-only DTO + daemon-side shape-contract test; `null`→503, unjoined→404. **Reuses the running daemon runtime** for peer-reachable probes (no 2nd NATS conn), never tears it down.
- `network-doctor-panel.tsx`: status / **fix** / **owner** per leg (incl. `sealed-secret-hub-authorized` + `peer-reachable:<p>`); `DoctorDrill` ("Diagnose — why is this red?") mounted beside the FLG-1 handoff banner. On-demand run (doctor does live probes, not fetch-on-mount).
- tsc 0; eslint 0; vocab PASS; 20 doctor + 22 lib + 86 server tests. Additive server.ts (both handoff + doctor routes coexist — verified).

Browser-QA deferred to CK-7 (needs a live federated stack + red-edge drilling, where the plan already mandates it); covered here by the render test asserting the status/fix/owner columns. Monitor/leaf legs honestly degrade on the daemon (no monitor URL) — high-value legs run live.

Generated by the R1 opus fleet (flg3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c