### PR TITLE
feat(mc): CK-4b — WORKING panel render (cross-stack aggregation) (R1)

### DIFF
--- a/src/surface/mc/api/__tests__/working-aggregation-handler.test.ts
+++ b/src/surface/mc/api/__tests__/working-aggregation-handler.test.ts
@@ -1,0 +1,135 @@
+/**
+ * CK-4b (cortex#1295) — GET /api/working-aggregation handler tests.
+ *
+ * Pins that the local daemon endpoint projects CK-4a's `listWorkingAggregation`
+ * read model onto the wire as `{ aggregation: WorkingStackAggregate[] }`, and
+ * that the wire payload stays METADATA-ONLY (ADR-0005): a federated PEER origin
+ * yields the same counts-only rollup as a local origin — never a session id or
+ * interior. Provider-retry (local-only back-pressure) is populated here.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+import { initDatabase } from "../../db/init";
+import { handleListWorkingAggregation } from "../handlers";
+import type { ListWorkingAggregationResponse } from "../types";
+
+function seedAgent(db: Database, id: string): void {
+  db.query(`INSERT OR IGNORE INTO agents (id, name, type) VALUES (?, ?, 'hands')`).run(id, `Agent ${id}`);
+}
+function seedTask(db: Database, id: string): void {
+  db.query(
+    `INSERT OR IGNORE INTO tasks (id, title, priority, principal_id, source_system)
+     VALUES (?, ?, 2, 'andreas', 'internal')`
+  ).run(id, `Task ${id}`);
+}
+function seedAssignment(
+  db: Database,
+  opts: { id: string; agentId: string; taskId: string; state: string; retryAfterMs?: number | null }
+): void {
+  const blockReason =
+    opts.state === "blocked"
+      ? JSON.stringify({ kind: "permission.request", payload: { requested_action: "tool.edit" } })
+      : null;
+  db.query(
+    `INSERT INTO agent_task_assignment (id, agent_id, task_id, state, block_reason, retry_after_ms)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(opts.id, opts.agentId, opts.taskId, opts.state, blockReason, opts.retryAfterMs ?? null);
+}
+function seedSession(
+  db: Database,
+  opts: { id: string; assignmentId: string; originStackId?: string | null; parentSessionId?: string | null }
+): void {
+  db.query(
+    `INSERT INTO sessions
+       (id, assignment_id, endpoint_kind, started_at, ended_at, parent_session_id, origin_stack_id)
+     VALUES (?, ?, 'local.process.controlled', datetime('now'), NULL, ?, ?)`
+  ).run(opts.id, opts.assignmentId, opts.parentSessionId ?? null, opts.originStackId ?? null);
+}
+
+async function body(db: Database): Promise<ListWorkingAggregationResponse> {
+  const res = handleListWorkingAggregation(db);
+  expect(res.status).toBe(200);
+  return (await res.json()) as ListWorkingAggregationResponse;
+}
+
+describe("GET /api/working-aggregation", () => {
+  let db: Database;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mc-ck4b-handler-${Date.now()}-${Math.random()}`);
+    db = initDatabase(join(tmpDir, "test.db"));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty aggregation array on a fresh DB", async () => {
+    const b = await body(db);
+    expect(b.aggregation).toEqual([]);
+  });
+
+  it("projects per-origin active + sub-agent counts across stacks", async () => {
+    seedAgent(db, "ag-1");
+    seedTask(db, "t-1");
+    // Own/local origin (null): a root session + a sub-agent (child) session.
+    // Each session owns its OWN assignment — the sessions table enforces one
+    // active session per assignment (partial unique index on assignment_id), so
+    // a root and its sub-agent are distinct assignments linked by
+    // parent_session_id (mirrors the canonical CK-4a read-model test).
+    seedAssignment(db, { id: "a-local-root", agentId: "ag-1", taskId: "t-1", state: "running" });
+    seedAssignment(db, { id: "a-local-child", agentId: "ag-1", taskId: "t-1", state: "running" });
+    seedSession(db, { id: "s-root", assignmentId: "a-local-root", originStackId: null });
+    seedSession(db, { id: "s-child", assignmentId: "a-local-child", originStackId: null, parentSessionId: "s-root" });
+    // A federated peer origin: one working session, metadata-only.
+    seedAssignment(db, { id: "a-peer", agentId: "ag-1", taskId: "t-1", state: "running" });
+    seedSession(db, { id: "s-peer", assignmentId: "a-peer", originStackId: "jc/home" });
+
+    const b = await body(db);
+    // null (own/local) first, then origin id ASC.
+    expect(b.aggregation.map((r) => r.originStackId)).toEqual([null, "jc/home"]);
+    const local = b.aggregation[0]!;
+    expect(local.activeSessionCount).toBe(2);
+    expect(local.subAgentCount).toBe(1);
+    const peer = b.aggregation[1]!;
+    expect(peer.originStackId).toBe("jc/home");
+    expect(peer.activeSessionCount).toBe(1);
+    expect(peer.subAgentCount).toBe(0);
+  });
+
+  it("folds provider-retry (not_now/retry_after_ms) — pre-spawn, session-less", async () => {
+    seedAgent(db, "ag-1");
+    seedTask(db, "t-1");
+    // A queued assignment with a retry hint but NO session yet (pure pre-spawn).
+    seedAssignment(db, { id: "a-q", agentId: "ag-1", taskId: "t-1", state: "queued", retryAfterMs: 4000 });
+
+    const b = await body(db);
+    // Attributes to the null/own bucket (session-less pre-spawn).
+    const own = b.aggregation.find((r) => r.originStackId === null);
+    expect(own?.providerRetry).toEqual({ state: "not_now", retryAfterMs: 4000 });
+  });
+
+  it("wire payload is METADATA-ONLY — no session id / interior leaks across the boundary", async () => {
+    seedAgent(db, "ag-1");
+    seedTask(db, "t-1");
+    seedAssignment(db, { id: "a-peer", agentId: "ag-1", taskId: "t-1", state: "running" });
+    seedSession(db, { id: "s-secret", assignmentId: "a-peer", originStackId: "jc/home" });
+
+    const res = handleListWorkingAggregation(db);
+    const raw = await res.text();
+    // The peer's session id must never appear on the cross-stack feed.
+    expect(raw).not.toContain("s-secret");
+    const parsed = JSON.parse(raw) as ListWorkingAggregationResponse;
+    for (const r of parsed.aggregation) {
+      expect(Object.keys(r).sort()).toEqual(
+        ["activeSessionCount", "originStackId", "providerRetry", "subAgentCount"].sort()
+      );
+    }
+  });
+});

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -30,6 +30,7 @@ import type {
   ListIterationsResponse,
   ListTasksResponse,
   ListWorkingAgentsResponse,
+  ListWorkingAggregationResponse,
   SendInputRequest,
   SendInputResponse,
 } from "./types";
@@ -51,6 +52,7 @@ import {
   listTasks,
 } from "../db/tasks";
 import { listWorkingAgents } from "../db/working-agents";
+import { listWorkingAggregation } from "../db/working-aggregation";
 import {
   aggregateWorkingAgents,
   type LocalAggregationContext,
@@ -472,6 +474,36 @@ export function handleListWorkingAgents(
     );
     return error(
       `Failed to list working agents: ${(err as Error).message}`,
+      500
+    );
+  }
+}
+
+// ---------- GET /api/working-aggregation ----------
+
+/**
+ * CK-4b (cortex#1295) — cross-stack WORKING aggregation feed for the cockpit's
+ * pane-of-glass lane. Projects CK-4a's `listWorkingAggregation` read model: one
+ * METADATA rollup per origin stack (schema `origin_stack_id`), with active +
+ * sub-agent (session-tree child) counts and a provider-retry hint.
+ *
+ * On an aggregating (#1008 MC-DB) daemon the local db already holds each readable
+ * sibling stack's sessions tagged with their `origin_stack_id`, so a single
+ * `listWorkingAggregation(db)` naturally spans the principal's own stacks — no
+ * `LocalAggregationContext` fan-out needed (unlike `/api/working-agents`). The
+ * result is metadata-only (ADR-0005): no session id, prompt, or interior crosses
+ * this feed, so a federated PEER's rollup is the same shape as a local one.
+ */
+export function handleListWorkingAggregation(db: Database): Response {
+  try {
+    const aggregation = listWorkingAggregation(db);
+    return json({ aggregation } satisfies ListWorkingAggregationResponse);
+  } catch (err) {
+    process.stderr.write(
+      `[api] GET /api/working-aggregation failed: ${(err as Error).message}\n`
+    );
+    return error(
+      `Failed to list working aggregation: ${(err as Error).message}`,
       500
     );
   }

--- a/src/surface/mc/api/types.ts
+++ b/src/surface/mc/api/types.ts
@@ -5,6 +5,7 @@
 import type { AssignmentListItem, MostActiveAgent } from "../db/assignments";
 import type { TaskListItem } from "../db/tasks";
 import type { WorkingAgentTile } from "../db/working-agents";
+import type { WorkingStackAggregate } from "../db/working-aggregation";
 import type { AgentOrigin } from "./agents";
 import type {
   InboxItem,
@@ -73,6 +74,26 @@ export interface ListTasksResponse {
  */
 export interface ListWorkingAgentsResponse {
   agents: (WorkingAgentTile & { origin?: AgentOrigin })[];
+}
+
+// --- GET /api/working-aggregation ---
+
+/**
+ * CK-4b (cortex#1295) — cross-stack WORKING aggregation feed for the cockpit's
+ * pane-of-glass lane. One METADATA rollup per origin stack (keyed on the schema
+ * `origin_stack_id`, decision D-8) from CK-4a's `listWorkingAggregation`: active
+ * + sub-agent (session-tree child) counts and a provider-retry hint.
+ *
+ * Metadata ONLY — the shape carries NO session id, prompt, or interior (ADR-0005
+ * / the `db/working-aggregation.ts` scope boundary). A federated PEER's origin
+ * yields the SAME metadata rollup as a local origin; dispatch + interior drill
+ * stay LOCAL-only (served by `/api/working-agents` + the F-7 drill-down).
+ *
+ * `providerRetry` is local-only back-pressure and is populated here (the cloud
+ * `/api/state` DashboardSnapshot projection carries the same field but null).
+ */
+export interface ListWorkingAggregationResponse {
+  aggregation: WorkingStackAggregate[];
 }
 
 // --- POST /api/sessions ---

--- a/src/surface/mc/dashboard-v2/__tests__/mc-cockpit.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-cockpit.test.tsx
@@ -153,6 +153,28 @@ describe("McCockpit — own-local stack", () => {
     expect(html).not.toContain("dispatch-btn");
     expect(html).toContain("No local agent online to dispatch");
   });
+
+  it("renders the CK-4b cross-stack 'Across stacks' lane above the LOCAL grid", () => {
+    const html = render({
+      workingAggregation: [
+        { originStackId: null, activeSessionCount: 2, subAgentCount: 1, providerRetry: null },
+        { originStackId: "jc/home", activeSessionCount: 1, subAgentCount: 0, providerRetry: null },
+      ],
+      workingAggregationLoaded: true,
+    });
+    // the pane-of-glass rollup mounts inside the WORKING lane…
+    expect(html).toContain("working-aggregate-section");
+    expect(html).toContain("Across stacks");
+    expect(html).toContain('data-origin="local"');
+    expect(html).toContain('data-origin="jc/home"');
+    expect(html).toContain("1 sub-agent");
+    // …ABOVE the local, drillable grid (both present, aggregate first).
+    expect(html.indexOf("working-aggregate-section")).toBeLessThan(
+      html.indexOf("working-grid-section")
+    );
+    // metadata-only: the cross-stack lane exposes no drill control.
+    expect(html).not.toContain(FORBIDDEN);
+  });
 });
 
 describe("McCockpit — federated peer (ADR-0005)", () => {
@@ -165,5 +187,20 @@ describe("McCockpit — federated peer (ADR-0005)", () => {
     expect(html).not.toContain("attention-view");
     expect(html).not.toContain("working-grid-section");
     expect(html).not.toContain("dispatch-btn");
+  });
+
+  it("does NOT render the CK-4b cross-stack lane for a federated peer", () => {
+    // The peer branch bottoms out at the aggregate notice before the WORKING
+    // lane — the "Across stacks" rollup never renders under a peer dive.
+    const html = render({
+      stack: PEER,
+      posture: "member",
+      workingAggregation: [
+        { originStackId: null, activeSessionCount: 3, subAgentCount: 0, providerRetry: null },
+      ],
+      workingAggregationLoaded: true,
+    });
+    expect(html).not.toContain("working-aggregate-section");
+    expect(html).not.toContain("Across stacks");
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/working-aggregate-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/working-aggregate-display.test.ts
@@ -1,0 +1,132 @@
+/**
+ * CK-4b (cortex#1295) — cross-stack WORKING aggregate pure-helper tests.
+ *
+ * The component needs a React renderer; the branching that decides the mode,
+ * the schema-origin keying, and the honest (queued-only, NO "awaiting hands")
+ * copy live in `lib/working-aggregate-display.ts` so they stay DOM-free-testable.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  pickWorkingAggregateMode,
+  aggregateTileKey,
+  originStackLabel,
+  activeSessionSummary,
+  subAgentSummary,
+  queuedRetryLabel,
+  formatRetryAfter,
+} from "../lib/working-aggregate-display";
+import type { WorkingStackAggregate } from "../hooks/use-working-aggregation";
+
+function agg(over: Partial<WorkingStackAggregate> = {}): WorkingStackAggregate {
+  return {
+    originStackId: null,
+    activeSessionCount: 1,
+    subAgentCount: 0,
+    providerRetry: null,
+    ...over,
+  };
+}
+
+describe("pickWorkingAggregateMode", () => {
+  it("returns 'tiles' whenever there is ≥1 rollup, regardless of loaded/error", () => {
+    expect(pickWorkingAggregateMode({ aggregates: [agg()], loaded: true, error: null })).toBe("tiles");
+    expect(pickWorkingAggregateMode({ aggregates: [agg()], loaded: false, error: "boot" })).toBe("tiles");
+  });
+
+  it("returns 'error' when empty + boot error", () => {
+    expect(pickWorkingAggregateMode({ aggregates: [], loaded: true, error: "HTTP 500" })).toBe("error");
+  });
+
+  it("returns 'loading' pre-boot with empty rollups + no error", () => {
+    expect(pickWorkingAggregateMode({ aggregates: [], loaded: false, error: null })).toBe("loading");
+  });
+
+  it("returns 'empty' when loaded + no origins working", () => {
+    expect(pickWorkingAggregateMode({ aggregates: [], loaded: true, error: null })).toBe("empty");
+  });
+
+  it("has NO 'hidden' branch — the cross-stack lane is always-present context", () => {
+    // tiles win even when a boot error is stale alongside real rollups.
+    expect(pickWorkingAggregateMode({ aggregates: [agg()], loaded: true, error: "stale" })).toBe("tiles");
+  });
+});
+
+describe("aggregateTileKey — keyed on SCHEMA origin (not the React-key hack)", () => {
+  it("keys distinct origin stacks distinctly", () => {
+    const local = aggregateTileKey(null);
+    const work = aggregateTileKey("andreas/work");
+    const peer = aggregateTileKey("jc/home");
+    expect(local).toBe("local");
+    expect(work).toBe("andreas/work");
+    expect(peer).toBe("jc/home");
+    expect(new Set([local, work, peer]).size).toBe(3);
+  });
+
+  it("maps a null origin (own/local bucket) to a stable 'local' key", () => {
+    expect(aggregateTileKey(null)).toBe("local");
+  });
+});
+
+describe("originStackLabel", () => {
+  it("labels null as own/local", () => {
+    expect(originStackLabel(null)).toBe("local");
+  });
+  it("labels a non-null origin verbatim (own sibling OR federated peer)", () => {
+    expect(originStackLabel("andreas/work")).toBe("andreas/work");
+    expect(originStackLabel("jc/home")).toBe("jc/home");
+  });
+});
+
+describe("activeSessionSummary", () => {
+  it("renders 'N working'", () => {
+    expect(activeSessionSummary(0)).toBe("0 working");
+    expect(activeSessionSummary(3)).toBe("3 working");
+  });
+});
+
+describe("subAgentSummary — session-tree child counts (accessible text)", () => {
+  it("pluralizes correctly and is honest about zero", () => {
+    expect(subAgentSummary(0)).toBe("no sub-agents");
+    expect(subAgentSummary(1)).toBe("1 sub-agent");
+    expect(subAgentSummary(4)).toBe("4 sub-agents");
+  });
+  it("treats negatives defensively as zero", () => {
+    expect(subAgentSummary(-2)).toBe("no sub-agents");
+  });
+});
+
+describe("queuedRetryLabel — honest queued (D-9: NO 'awaiting hands')", () => {
+  it("returns null when there is no pending back-pressure", () => {
+    expect(queuedRetryLabel(null)).toBeNull();
+  });
+
+  it("renders 'queued · retry in <delay>' for a pending not_now", () => {
+    expect(queuedRetryLabel({ state: "not_now", retryAfterMs: 3000 })).toBe("queued · retry in 3s");
+  });
+
+  it("NEVER renders the deferred 'awaiting hands' copy", () => {
+    const label = queuedRetryLabel({ state: "not_now", retryAfterMs: 5000 }) ?? "";
+    expect(label).not.toContain("awaiting hands");
+    expect(label).not.toContain("hands");
+  });
+});
+
+describe("formatRetryAfter — deterministic, no Date/Intl", () => {
+  it("floors sub-second to <1s and clamps non-positive to 0s", () => {
+    expect(formatRetryAfter(0)).toBe("0s");
+    expect(formatRetryAfter(-100)).toBe("0s");
+    expect(formatRetryAfter(NaN)).toBe("0s");
+    expect(formatRetryAfter(400)).toBe("<1s");
+  });
+  it("rounds to whole seconds under a minute", () => {
+    expect(formatRetryAfter(1000)).toBe("1s");
+    expect(formatRetryAfter(2600)).toBe("3s");
+    expect(formatRetryAfter(59_000)).toBe("59s");
+  });
+  it("renders minutes (+ seconds) at/above a minute", () => {
+    expect(formatRetryAfter(60_000)).toBe("1m");
+    expect(formatRetryAfter(90_000)).toBe("1m 30s");
+    expect(formatRetryAfter(125_000)).toBe("2m 5s");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/working-aggregate.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/working-aggregate.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * CK-4b (cortex#1295) — cross-stack WORKING aggregate render tests (DOM-free via
+ * renderToStaticMarkup). Pins: tiles keyed on schema origin, session-tree child
+ * (sub-agent) counts, honest queued/provider-retry copy (NO "awaiting hands" —
+ * D-9), and the metadata-only boundary (no drill affordance, ADR-0005).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { WorkingAggregate } from "../components/working-aggregate";
+import type { WorkingStackAggregate } from "../hooks/use-working-aggregation";
+
+function agg(over: Partial<WorkingStackAggregate> = {}): WorkingStackAggregate {
+  return {
+    originStackId: null,
+    activeSessionCount: 1,
+    subAgentCount: 0,
+    providerRetry: null,
+    ...over,
+  };
+}
+
+function render(aggregates: WorkingStackAggregate[], loaded = true, error: string | null = null): string {
+  return renderToStaticMarkup(
+    createElement(WorkingAggregate, { aggregates, loaded, error })
+  );
+}
+
+describe("WorkingAggregate — cross-stack metadata tiles", () => {
+  it("renders one tile per origin, labelled by schema origin (local + cross-stack)", () => {
+    const html = render([
+      agg({ originStackId: null, activeSessionCount: 2 }),
+      agg({ originStackId: "andreas/work", activeSessionCount: 3 }),
+      agg({ originStackId: "jc/home", activeSessionCount: 1 }),
+    ]);
+    expect(html).toContain('data-origin="local"');
+    expect(html).toContain('data-origin="andreas/work"');
+    expect(html).toContain('data-origin="jc/home"');
+    // three distinct tiles.
+    expect((html.match(/working-aggregate-tile/g) ?? []).length).toBe(3);
+  });
+
+  it("tags the own/local origin distinctly from a cross-stack (peer/sibling) origin", () => {
+    const html = render([
+      agg({ originStackId: null }),
+      agg({ originStackId: "jc/home" }),
+    ]);
+    expect(html).toContain('data-origin-kind="local"');
+    expect(html).toContain('data-origin-kind="cross-stack"');
+    expect(html).toContain("this stack");
+  });
+
+  it("renders session-tree child (sub-agent) counts as accessible text", () => {
+    const html = render([agg({ activeSessionCount: 4, subAgentCount: 2 })]);
+    expect(html).toContain("4 working");
+    expect(html).toContain("2 sub-agents");
+  });
+
+  it("renders singular sub-agent + honest zero", () => {
+    expect(render([agg({ subAgentCount: 1 })])).toContain("1 sub-agent");
+    expect(render([agg({ subAgentCount: 0 })])).toContain("no sub-agents");
+  });
+
+  it("renders the honest queued/provider-retry chip — NEVER 'awaiting hands' (D-9)", () => {
+    const html = render([
+      agg({ activeSessionCount: 0, providerRetry: { state: "not_now", retryAfterMs: 4000 } }),
+    ]);
+    expect(html).toContain("queued");
+    expect(html).toContain("retry in 4s");
+    // The deferred SPX-3 capacity copy must not appear pre-release.
+    expect(html).not.toContain("awaiting hands");
+    expect(html).not.toContain("hands");
+  });
+
+  it("omits the queued chip entirely when there is no pending back-pressure", () => {
+    const html = render([agg({ providerRetry: null })]);
+    expect(html).not.toContain("working-aggregate-queued");
+    expect(html).not.toContain("queued");
+  });
+
+  it("is METADATA-ONLY: no drill affordance (no button / onClick target)", () => {
+    const html = render([
+      agg({ originStackId: "jc/home", activeSessionCount: 5, subAgentCount: 1 }),
+    ]);
+    // A federated peer tile must never expose an interactive drill control.
+    expect(html).not.toContain("<button");
+    expect(html).not.toContain('role="button"');
+  });
+
+  it("shows an honest empty state when loaded with no rollups", () => {
+    expect(render([])).toContain("No stacks working right now.");
+  });
+
+  it("shows a loading state pre-boot", () => {
+    expect(render([], false, null)).toContain("Loading…");
+  });
+
+  it("surfaces a boot error", () => {
+    const html = render([], true, "HTTP 500");
+    expect(html).toContain("HTTP 500");
+  });
+});

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -18,6 +18,7 @@ import { WorkingGrid } from "./components/working-grid";
 import { useIterations } from "./hooks/use-iterations";
 import { useMetrics } from "./hooks/use-metrics";
 import { useWorkingAgents } from "./hooks/use-working-agents";
+import { useWorkingAggregation } from "./hooks/use-working-aggregation";
 import { MetricsPanel } from "./components/metrics-panel";
 import { SourcesView } from "./components/sources-view";
 import { RepositoriesView } from "./components/repositories-view";
@@ -97,6 +98,10 @@ export function App() {
   const focus = useFocusArea(ws);
   const tasks = useTasks(ws);
   const working = useWorkingAgents(ws);
+  // CK-4b (cortex#1295) — cross-stack WORKING rollup feed for the cockpit's
+  // "Across stacks" pane-of-glass lane. App-level (principal-wide, own stacks),
+  // mirroring `useWorkingAgents`; forwarded through NetworkView → McCockpit.
+  const workingAgg = useWorkingAggregation(ws);
   const iterations = useIterations(ws);
 
   // G-1113.C.6 — batch-fetch PR/branch links for the visible github-sourced
@@ -643,6 +648,11 @@ export function App() {
             governance={governance}
             workingLoaded={working.loaded}
             workingError={working.error}
+            // CK-4b — cross-stack WORKING rollup (metadata-only, ADR-0005) for
+            // the cockpit's "Across stacks" lane above the LOCAL working grid.
+            workingAggregation={workingAgg.aggregation}
+            workingAggregationLoaded={workingAgg.loaded}
+            workingAggregationError={workingAgg.error}
             // CK-3 — cockpit attention work-item deep link → work-item-detail
             // (returns to the Network view). Needs software mode (the surface is
             // software-mode-gated); honest toast otherwise.

--- a/src/surface/mc/dashboard-v2/components/mc-cockpit.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-cockpit.tsx
@@ -36,6 +36,7 @@
 
 import { AttentionView } from "./attention-view";
 import { WorkingGrid } from "./working-grid";
+import { WorkingAggregate } from "./working-aggregate";
 import { GovernanceView } from "./governance-view";
 import { DispatchButton } from "./dispatch-button";
 import {
@@ -47,6 +48,7 @@ import {
 import { stackLabel, type StackCoord, type NetworkPosture } from "../lib/mc-shell-model";
 import type { AgentPresenceTile } from "../hooks/use-agents";
 import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import type { WorkingStackAggregate } from "../hooks/use-working-aggregation";
 import type { AttentionEntry } from "../../api/attention";
 import type { GovernanceState } from "../hooks/use-governance";
 import "./mc-cockpit.css";
@@ -64,6 +66,17 @@ export interface McCockpitProps {
   workingAgents: readonly WorkingAgentTile[];
   workingLoaded: boolean;
   workingError: string | null;
+  /**
+   * CK-4b (cortex#1295) — the cross-stack WORKING rollup: one METADATA tile per
+   * origin stack (ADR-0005 metadata-only), rendered as the "Across stacks"
+   * pane-of-glass lane ABOVE the LOCAL, drillable `WorkingGrid`. Optional so a
+   * caller that doesn't wire the feed simply omits the lane (the hook lives at
+   * App level, mirroring `workingAgents`). Own-local render only — a federated
+   * peer bottoms out at the aggregate notice before this lane.
+   */
+  workingAggregation?: readonly WorkingStackAggregate[];
+  workingAggregationLoaded?: boolean;
+  workingAggregationError?: string | null;
   /** Attention queue (whole-dashboard) — scoped to the stack. */
   attention: readonly AttentionEntry[];
   attentionLoaded: boolean;
@@ -90,6 +103,9 @@ export function McCockpit({
   workingAgents,
   workingLoaded,
   workingError,
+  workingAggregation = [],
+  workingAggregationLoaded = false,
+  workingAggregationError = null,
   attention,
   attentionLoaded,
   governance,
@@ -132,6 +148,13 @@ export function McCockpit({
 
       {/* ── WORKING — whose hands are working, on this stack ────────────────── */}
       <section className="mc-cockpit-lane" aria-label="Working (stack)">
+        {/* CK-4b — the cross-stack "Across stacks" pane-of-glass rollup
+            (metadata-only, ADR-0005) sits ABOVE the LOCAL, drillable grid. */}
+        <WorkingAggregate
+          aggregates={workingAggregation}
+          loaded={workingAggregationLoaded}
+          error={workingAggregationError}
+        />
         <WorkingGrid
           agents={scopedWorking}
           loaded={workingLoaded}

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -30,6 +30,7 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
 import type { AgentPresenceTile, AgentsState } from "../hooks/use-agents";
 import type { WorkingAgentTile } from "../hooks/use-working-agents";
+import type { WorkingStackAggregate } from "../hooks/use-working-aggregation";
 import { pickAgentsPanelMode } from "../lib/agents-display";
 import {
   buildNetworkGraph,
@@ -208,6 +209,14 @@ export interface NetworkViewProps {
   /** CK-3 — working-agents load/error, forwarded to the cockpit WORKING lane. */
   workingLoaded?: boolean;
   workingError?: string | null;
+  /**
+   * CK-4b (cortex#1295) — the cross-stack WORKING rollup (metadata-only,
+   * ADR-0005), forwarded to the cockpit's "Across stacks" pane-of-glass lane.
+   * Omitted → the lane shows its loading/empty state.
+   */
+  workingAggregation?: readonly WorkingStackAggregate[];
+  workingAggregationLoaded?: boolean;
+  workingAggregationError?: string | null;
   /** CK-3 — open the work-item-detail surface (attention work-item deep link). */
   onOpenWorkItem?: (workItemId: string) => void;
 }
@@ -226,6 +235,9 @@ export function NetworkView({
   governance = { data: null, loaded: false, error: null },
   workingLoaded = false,
   workingError = null,
+  workingAggregation = [],
+  workingAggregationLoaded = false,
+  workingAggregationError = null,
   onOpenWorkItem,
 }: NetworkViewProps) {
   const mode = pickAgentsPanelMode(state);
@@ -571,6 +583,9 @@ export function NetworkView({
         workingAgents={workingAgents}
         workingLoaded={workingLoaded}
         workingError={workingError}
+        workingAggregation={workingAggregation}
+        workingAggregationLoaded={workingAggregationLoaded}
+        workingAggregationError={workingAggregationError}
         attention={attention.entries}
         attentionLoaded={attention.loaded}
         governance={governance}
@@ -588,6 +603,9 @@ export function NetworkView({
     workingAgents,
     workingLoaded,
     workingError,
+    workingAggregation,
+    workingAggregationLoaded,
+    workingAggregationError,
     attention,
     governance,
     onOpenSession,

--- a/src/surface/mc/dashboard-v2/components/working-aggregate.css
+++ b/src/surface/mc/dashboard-v2/components/working-aggregate.css
@@ -1,0 +1,120 @@
+/*
+ * CK-4b (cortex#1295) — cross-stack WORKING aggregate lane styles.
+ *
+ * Metadata-only pane-of-glass rollup that sits above the cockpit's local,
+ * drillable WorkingGrid. Uses the mc-skin D1 tokens (already in scope under
+ * `.mc-cockpit`) so it re-skins cleanly with zero blast radius on `?legacy=1`.
+ */
+
+.working-aggregate-section {
+  margin-bottom: 12px;
+}
+
+.working-aggregate-title {
+  font: 700 10px var(--mono);
+  color: var(--faint);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin: 0 0 8px;
+}
+
+.working-aggregate-empty,
+.working-aggregate-error {
+  font: 500 11px var(--sans);
+  color: var(--dim);
+  padding: 8px 10px;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+}
+
+.working-aggregate-error {
+  color: var(--warn, var(--dim));
+  border-style: solid;
+}
+
+.working-aggregate-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 8px;
+}
+
+.working-aggregate-tile {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel2);
+  padding: 9px 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* A cross-stack (non-local) origin gets a subtle accent edge so the pane-of-glass
+   reads at a glance which tiles are OTHER stacks vs this one. */
+.working-aggregate-tile[data-origin-kind="cross-stack"] {
+  border-left: 2px solid var(--accent, var(--mer));
+}
+
+.working-aggregate-origin {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.working-aggregate-origin-mark {
+  color: var(--dim);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.working-aggregate-origin-label {
+  font: 600 11px var(--mono);
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.working-aggregate-origin-tag {
+  font: 600 8px var(--mono);
+  color: var(--faint);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.working-aggregate-counts {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font: 500 10px var(--mono);
+  color: var(--dim);
+}
+
+.working-aggregate-dot {
+  color: var(--faint);
+}
+
+/* Honest queued / provider back-pressure chip (D-9: queued-only, no capacity copy). */
+.working-aggregate-queued {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font: 600 9px var(--mono);
+  color: var(--warn, var(--dim));
+  letter-spacing: 0.02em;
+}
+
+.working-aggregate-queued-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--warn, var(--dim));
+  flex-shrink: 0;
+}

--- a/src/surface/mc/dashboard-v2/components/working-aggregate.tsx
+++ b/src/surface/mc/dashboard-v2/components/working-aggregate.tsx
@@ -1,0 +1,109 @@
+/**
+ * CK-4b (cortex#1295) — the cross-stack WORKING aggregate lane.
+ *
+ * Renders one METADATA tile per origin stack from CK-4a's `workingAggregation`
+ * read model — the pane-of-glass rollup that sits above the cockpit's LOCAL,
+ * drillable `WorkingGrid`. Each tile is keyed on the SCHEMA origin
+ * (`origin_stack_id`), the deliberate replacement for the `working-grid`
+ * `workingTileKey` React-key hack.
+ *
+ * ── Scope boundary (ADR-0005 / CK-4a) ────────────────────────────────────────
+ * These tiles are METADATA ONLY — per-origin session counts, a sub-agent
+ * (session-tree child) count, and an honest provider-retry hint. They carry NO
+ * session id, prompt, or interior, and they are NOT interactive: there is no
+ * drill affordance here. A federated PEER's origin renders the SAME metadata
+ * tile as a local origin — the cross-stack lane SEES that a peer is working, but
+ * dispatch + interior drill stay LOCAL-only (the `WorkingGrid` below, own-local).
+ *
+ * ── Honest pre-release copy (decision D-9) ───────────────────────────────────
+ * The provider-retry chip reads "queued · retry in <delay>". The mockup's
+ * "awaiting hands" capacity narrative is DEFERRED to SPX-3 and is never rendered
+ * here (see `working-aggregate-display.queuedRetryLabel`).
+ */
+
+import "./working-aggregate.css";
+import {
+  pickWorkingAggregateMode,
+  aggregateTileKey,
+  originStackLabel,
+  activeSessionSummary,
+  subAgentSummary,
+  queuedRetryLabel,
+} from "../lib/working-aggregate-display";
+import type { WorkingStackAggregate } from "../hooks/use-working-aggregation";
+
+export interface WorkingAggregateProps {
+  aggregates: readonly WorkingStackAggregate[];
+  loaded: boolean;
+  /** Boot error only (refetch failures are swallowed by the hook). */
+  error: string | null;
+}
+
+export function WorkingAggregate({ aggregates, loaded, error }: WorkingAggregateProps) {
+  const mode = pickWorkingAggregateMode({
+    aggregates: [...aggregates],
+    loaded,
+    error,
+  });
+
+  return (
+    <section className="working-aggregate-section" aria-label="Working across stacks">
+      <h3 className="working-aggregate-title">Across stacks</h3>
+
+      {mode === "error" && (
+        <div className="working-aggregate-error" role="status">
+          ⚠ {error}
+        </div>
+      )}
+      {mode === "loading" && (
+        <div className="working-aggregate-empty">Loading…</div>
+      )}
+      {mode === "empty" && (
+        <div className="working-aggregate-empty">No stacks working right now.</div>
+      )}
+      {mode === "tiles" && (
+        <ul className="working-aggregate-grid">
+          {aggregates.map((a) => (
+            <WorkingAggregateTile key={aggregateTileKey(a.originStackId)} aggregate={a} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function WorkingAggregateTile({ aggregate }: { aggregate: WorkingStackAggregate }) {
+  const { originStackId, activeSessionCount, subAgentCount, providerRetry } = aggregate;
+  const label = originStackLabel(originStackId);
+  const isLocal = originStackId === null;
+  const retry = queuedRetryLabel(providerRetry);
+
+  return (
+    <li
+      className="working-aggregate-tile"
+      data-origin={label}
+      data-origin-kind={isLocal ? "local" : "cross-stack"}
+    >
+      <div className="working-aggregate-origin">
+        <span className="working-aggregate-origin-mark" aria-hidden="true">⬣</span>
+        <span className="working-aggregate-origin-label">{label}</span>
+        {isLocal && (
+          <span className="working-aggregate-origin-tag">this stack</span>
+        )}
+      </div>
+
+      <div className="working-aggregate-counts">
+        <span className="working-aggregate-active">{activeSessionSummary(activeSessionCount)}</span>
+        <span className="working-aggregate-dot" aria-hidden="true">·</span>
+        <span className="working-aggregate-subagents">{subAgentSummary(subAgentCount)}</span>
+      </div>
+
+      {retry && (
+        <div className="working-aggregate-queued" data-state="not_now">
+          <span className="working-aggregate-queued-dot" aria-hidden="true" />
+          {retry}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/src/surface/mc/dashboard-v2/hooks/use-working-aggregation.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-working-aggregation.ts
@@ -1,0 +1,159 @@
+/**
+ * CK-4b (cortex#1295) — cross-stack WORKING aggregation hook.
+ *
+ * Fetches `GET /api/working-aggregation` (the CK-4a `listWorkingAggregation`
+ * read model served by the local daemon) and keeps it fresh via the same
+ * WS `state.transition` debounce + `mc.projection` refetch discipline the F-9
+ * working grid uses. This is the DATA feed for the cockpit's cross-stack WORKING
+ * lane — one metadata rollup per origin stack, keyed on the SCHEMA origin
+ * (`origin_stack_id`, decision D-8), NOT the runtime federation tag the
+ * `working-grid` `workingTileKey` React-key hack derives.
+ *
+ * ── SCOPE BOUNDARY (mirrors db/working-aggregation.ts) ───────────────────────
+ * The rollup carries METADATA ONLY — per-origin counts + a provider-retry hint.
+ * NEVER a session id, prompt, tool call, or any interior. A federated PEER's
+ * origin yields the SAME metadata-only tile as a local origin (ADR-0005): the
+ * cross-stack lane SEES that a peer is working (counts) but never drills its
+ * interior. Dispatch + interior drill stay LOCAL-only (the cockpit's per-agent
+ * `WorkingGrid`, not this lane).
+ *
+ * Boot-vs-refetch error handling matches `use-working-agents`: first-paint
+ * failures surface to the caller's error pill; later refetch failures warn only.
+ * On a daemon that doesn't serve the endpoint yet (older build) the boot error
+ * simply yields an empty lane — honest degradation, never a fabricated tile.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiFailure, getJson } from "../lib/api";
+import type { WsClient, WsMessage } from "./use-websocket";
+import { useProjectionRefetch } from "./use-projection-refetch";
+
+/**
+ * Provider back-pressure for an origin's WORKING lane. Byte-shape-mirror of the
+ * server's `ProviderRetryStatus` (`db/working-aggregation.ts`) — a semantic state
+ * tag + a delay in ms; metadata only, never an interior. Mirrored (not imported)
+ * because the server module pulls `bun:sqlite`, which the browser bundle can't.
+ */
+export interface ProviderRetryStatus {
+  /** The dispatch lifecycle's back-pressure state. `not_now` ⇒ rate/capacity exhausted. */
+  state: "not_now";
+  /** Earliest-retry delay in ms (soonest across the origin's pending assignments). */
+  retryAfterMs: number;
+}
+
+/**
+ * One origin-stack's WORKING rollup — pure lifecycle METADATA. Byte-shape-mirror
+ * of the server's `WorkingStackAggregate` (`db/working-aggregation.ts`) and the
+ * worker's `WorkingOriginRollup` (`worker/src/routes/state.ts`); the three are
+ * kept congruent by their respective shape guards.
+ */
+export interface WorkingStackAggregate {
+  /**
+   * The stack these WORKING sessions originated on. `null` ⇒ own/local-stack
+   * origin (or a session-less pending dispatch on this daemon). A non-null value
+   * that is not this daemon's own stack is a federated PEER — still metadata-only.
+   */
+  originStackId: string | null;
+  /** Count of active (non-terminal, working-state) sessions on this origin stack. */
+  activeSessionCount: number;
+  /**
+   * Of those active sessions, how many are SUB-AGENTS — i.e. carry a
+   * `parent_session_id` (the substrate-projection edge; CONTEXT.md §Session tree).
+   */
+  subAgentCount: number;
+  /** Provider back-pressure across this origin's assignments; `null` ⇒ none pending. */
+  providerRetry: ProviderRetryStatus | null;
+}
+
+interface ListWorkingAggregationResponse {
+  aggregation: WorkingStackAggregate[];
+}
+
+export interface WorkingAggregationState {
+  aggregation: WorkingStackAggregate[];
+  loaded: boolean;
+  /** Boot error only — refetch failures are swallowed (warn-only). */
+  error: string | null;
+}
+
+/** Same window as the F-9 grid so a burst of transitions collapses into one refresh. */
+const REFETCH_DEBOUNCE_MS = 100;
+
+export function useWorkingAggregation(ws: WsClient): WorkingAggregationState {
+  const [aggregation, setAggregation] = useState<WorkingStackAggregate[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const genRef = useRef(0);
+  const aliveRef = useRef(true);
+  const bootedRef = useRef(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const fetchAggregation = useCallback(async (signal?: AbortSignal) => {
+    const myGen = ++genRef.current;
+    try {
+      const body = await getJson<ListWorkingAggregationResponse>(
+        "/api/working-aggregation",
+        signal ? { signal } : undefined
+      );
+      if (!aliveRef.current || genRef.current !== myGen) return;
+      setAggregation(body.aggregation ?? []);
+      setError(null);
+      bootedRef.current = true;
+    } catch (e) {
+      if (!aliveRef.current || genRef.current !== myGen) return;
+      if ((e as { name?: string })?.name === "AbortError") return;
+      const msg = e instanceof ApiFailure ? e.info.message : (e instanceof Error ? e.message : String(e));
+      // Only surface boot errors; refetch failures stay quiet (F-9 parity).
+      if (!bootedRef.current) {
+        setError(msg);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn("[use-working-aggregation] refetch failed:", msg);
+      }
+    } finally {
+      if (aliveRef.current && genRef.current === myGen) setLoaded(true);
+    }
+  }, []);
+
+  // Boot fetch.
+  useEffect(() => {
+    const ac = new AbortController();
+    void fetchAggregation(ac.signal);
+    return () => ac.abort();
+  }, [fetchAggregation]);
+
+  // WS subscription — debounced refetch on every state.transition (mirrors
+  // use-working-agents F-9 Decision 8: an over-broad superset trigger, tightened
+  // to working-touching transitions in a future pass).
+  const subscribe = ws.subscribe;
+  useEffect(() => {
+    function onTransition(_msg: WsMessage) {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        debounceRef.current = null;
+        void fetchAggregation();
+      }, REFETCH_DEBOUNCE_MS);
+    }
+    return subscribe("state.transition", onTransition);
+  }, [subscribe, fetchAggregation]);
+
+  // Also refresh off the S6 `mc.projection` broadcast so bus→MC projection writes
+  // (dispatch-lifecycle transitions, provider back-pressure) push the cross-stack
+  // lane live. The aggregation is derived from the SAME working-session data as the
+  // F-9 grid, so it rides the existing `working-agents` projection view — every
+  // family that invalidates the grid (dispatch.lifecycle / review.verdict /
+  // agent.heartbeat) invalidates this rollup too. Zero-arg refetch is stable.
+  const refetch = useCallback(() => { void fetchAggregation(); }, [fetchAggregation]);
+  useProjectionRefetch(ws, "working-agents", refetch);
+
+  return { aggregation, loaded, error };
+}

--- a/src/surface/mc/dashboard-v2/lib/working-aggregate-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/working-aggregate-display.ts
@@ -1,0 +1,104 @@
+/**
+ * CK-4b (cortex#1295) — pure helpers for the cross-stack WORKING aggregate
+ * render. The component uses hooks + a React renderer; this keeps the
+ * per-state branching, the schema-origin keying, and the honest copy
+ * derivation unit-testable without a DOM (same split as `working-grid-display`).
+ *
+ * ── Honest pre-release semantics (decision D-9) ──────────────────────────────
+ * The mockup's WORKING tile reads "queued — awaiting hands". Pre-release we
+ * render the assignment's honest `queued` / provider-retry state ONLY; the
+ * `awaiting hands` capacity narrative (the SPX-2 hands-pool model) is DEFERRED
+ * to SPX-3. `queuedRetryLabel` therefore NEVER emits "awaiting hands".
+ */
+
+import type {
+  WorkingStackAggregate,
+  ProviderRetryStatus,
+} from "../hooks/use-working-aggregation";
+
+/**
+ * One of four rendering modes. No "hidden" branch (unlike the F-9 grid): the
+ * cross-stack lane is always-present context inside the cockpit, never suppressed
+ * by a sibling focus row.
+ *
+ * - `error`   — boot fetch failed; lane empty, error pill shown.
+ * - `loading` — pre-boot, lane empty, no error.
+ * - `empty`   — loaded, no origins working anywhere.
+ * - `tiles`   — loaded, ≥1 origin rollup: render one metadata tile per origin.
+ */
+export type WorkingAggregateMode = "error" | "loading" | "empty" | "tiles";
+
+export interface WorkingAggregateDisplayInput {
+  aggregates: WorkingStackAggregate[];
+  loaded: boolean;
+  error: string | null;
+}
+
+export function pickWorkingAggregateMode(
+  input: WorkingAggregateDisplayInput
+): WorkingAggregateMode {
+  const { aggregates, loaded, error } = input;
+  if (aggregates.length > 0) return "tiles";
+  if (error) return "error";
+  if (!loaded) return "loading";
+  return "empty";
+}
+
+/**
+ * The tile's React key — keyed on the SCHEMA origin (`origin_stack_id`, CK-4a),
+ * the deliberate replacement for the `working-grid` `workingTileKey` React-key
+ * hack (which derived the key from the runtime federation tag). `null` ⇒ the
+ * own/local bucket. Origin ids are unique per stack, so this never collides.
+ */
+export function aggregateTileKey(originStackId: string | null): string {
+  return originStackId ?? "local";
+}
+
+/**
+ * Display label for a tile's origin. `null` ⇒ own/local stack; a value ⇒ the
+ * origin stack id verbatim (own sibling or federated peer — both metadata-only).
+ */
+export function originStackLabel(originStackId: string | null): string {
+  return originStackId ?? "local";
+}
+
+/**
+ * Active-session summary text — "N working". Metadata only.
+ */
+export function activeSessionSummary(activeSessionCount: number): string {
+  return `${activeSessionCount} working`;
+}
+
+/**
+ * Session-tree child-count (sub-agent) summary — accessible full text (not
+ * color-only). A "sub-agent" is a child session (`parent_session_id`); the
+ * count is CK-4a's `subAgentCount`. `0` ⇒ honest "no sub-agents".
+ */
+export function subAgentSummary(subAgentCount: number): string {
+  if (subAgentCount <= 0) return "no sub-agents";
+  return `${subAgentCount} sub-agent${subAgentCount === 1 ? "" : "s"}`;
+}
+
+/**
+ * Honest queued / provider back-pressure label for a tile — PRE-SPAWN semantics
+ * (decision D-9). `null` ⇒ no pending back-pressure (render nothing). A pending
+ * `not_now` ⇒ "queued · retry in <delay>". NEVER "awaiting hands" (SPX-3).
+ */
+export function queuedRetryLabel(retry: ProviderRetryStatus | null): string | null {
+  if (!retry) return null;
+  return `queued · retry in ${formatRetryAfter(retry.retryAfterMs)}`;
+}
+
+/**
+ * Format a retry delay (ms) into a compact, deterministic human string. No
+ * `Date`/`Intl` — pure arithmetic so it's stable across environments and tests.
+ */
+export function formatRetryAfter(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "0s";
+  if (ms < 1000) return "<1s";
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return rem === 0 ? `${mins}m` : `${mins}m ${rem}s`;
+}

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -32,6 +32,7 @@ import {
   handleListIterations,
   handleListTasks,
   handleListWorkingAgents,
+  handleListWorkingAggregation,
   handlePatchIteration,
   handlePreviewTask,
   handleRequeueAssignment,
@@ -531,6 +532,7 @@ export function startServer(
  *   GET  /api/focus-area                 — blocked-only feed for dashboard §8.2
  *   GET  /api/tasks                      — task-keyed feed for dashboard §8.4 (F-8)
  *   GET  /api/working-agents             — agent-keyed feed for dashboard §8.3 (F-9)
+ *   GET  /api/working-aggregation        — cross-stack WORKING rollup (CK-4b, metadata-only)
  *   GET  /api/assignments/:id/events     — paged event feed (F-7 drill-down)
  *   POST /api/sessions                   — create controlled session
  *   POST /api/assignments/:id/input      — write turn to an active session
@@ -776,6 +778,16 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListWorkingAgents(db, localAggregation);
+  }
+
+  // CK-4b (cortex#1295) — GET /api/working-aggregation — cross-stack WORKING
+  // rollup (schema-origin-keyed metadata) for the cockpit's pane-of-glass lane.
+  // Metadata-only (ADR-0005): counts + provider-retry, never a session interior.
+  if (pathname === "/api/working-aggregation") {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    return handleListWorkingAggregation(db);
   }
 
   // G-1114.B.4 — GET /api/agents — stack-local runtime agent-presence snapshot


### PR DESCRIPTION
R1 slice **CK-4b** — renders CK-4a's cross-stack WORKING aggregation in the cockpit. Clean re-implementation from current main (the original branch went stale + would have deleted FLG-1/CK-3 — data-loss trap avoided; this is **purely additive, 0 deletions**, verified `--diff-filter=D` empty).

- `working-aggregate.tsx` + `use-working-aggregation.ts` + `working-aggregate-display.ts` + `GET /api/working-aggregation` (route coexists with FLG-1 handoff @ and FLG-3 doctor @, verified). Mounted in the cockpit WORKING lane.
- Cross-stack tiles keyed on `origin_stack_id`; `subAgentCount` from `parent_session_id`; honest `queued · retry in <delay>` (**NO 'awaiting hands'** — deferred to SPX-3 per D-9); metadata-only across the boundary (ADR-0005 — a peer origin yields counts-only, no interior; the lane is hidden on a peer dive).
- Fixed the stale branch's 1 failing test (seed reconciliation, not a prod bug). 2442 tests pass; tsc 0; eslint 0; vocab PASS.

Note (non-blocking, for a later call): the cross-stack rollup renders principal-wide inside a per-stack cockpit — whether it belongs at shell-altitude is a placement refinement (CK-7-era).

Generated by the R1 opus fleet (ck4b2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019f6FUVjU9AP1LvZLiuKC1c