### PR TITLE
fix(network): C-1652 — seed the admin's descriptor cache on network create (operator admit resolution)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-operator-attestation.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-operator-attestation.test.ts
@@ -17,7 +17,7 @@ import { mkdtempSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
-import { resolveOperatorAttestation } from "../network";
+import { resolveOperatorAttestation, seedAdminDescriptorCache } from "../network";
 import { NetworkCache } from "../../../../common/registry/network-cache";
 import type { LoadedConfig } from "../../../../common/config/loader";
 
@@ -85,5 +85,46 @@ describe("cortex#1598 — resolveOperatorAttestation", () => {
   test("an unreadable config is non-fatal (undefined, never throws)", () => {
     const r = resolveOperatorAttestation({}, NET, throwingLoader, freshCache());
     expect(r.hubMode).toBeUndefined();
+  });
+});
+
+describe("cortex#1652 — seedAdminDescriptorCache", () => {
+  test("reports seeded on a verified fetch (ok)", async () => {
+    let seenId = "";
+    const r = await seedAdminDescriptorCache("metafactory", "http://reg", undefined, () => ({
+      fetchAndCache: async (id: string) => {
+        seenId = id;
+        return { status: "ok" };
+      },
+    }));
+    expect(r.seeded).toBe(true);
+    expect(seenId).toBe("metafactory");
+  });
+
+  test("reports NOT seeded (with the status as reason) on a non-ok fetch — never throws", async () => {
+    const r = await seedAdminDescriptorCache("metafactory", "http://reg", undefined, () => ({
+      fetchAndCache: async () => ({ status: "unreachable" }),
+    }));
+    expect(r.seeded).toBe(false);
+    expect(r.reason).toBe("unreachable");
+  });
+
+  test("a throwing client is swallowed (best-effort — never fails the create)", async () => {
+    const r = await seedAdminDescriptorCache("metafactory", "http://reg", undefined, () => ({
+      fetchAndCache: async () => {
+        throw new Error("connection refused");
+      },
+    }));
+    expect(r.seeded).toBe(false);
+    expect(r.reason).toContain("connection refused");
+  });
+
+  test("passes a pinned registry pubkey through to the client when supplied", async () => {
+    let seenCfg: { url: string; pubkey?: string } | undefined;
+    await seedAdminDescriptorCache("metafactory", "http://reg", "PINNEDPUB", (cfg) => {
+      seenCfg = cfg;
+      return { fetchAndCache: async () => ({ status: "ok" }) };
+    });
+    expect(seenCfg).toEqual({ url: "http://reg", pubkey: "PINNEDPUB" });
   });
 });

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2175,6 +2175,36 @@ async function adminMaterialFromSeedFile(
   }
 }
 
+/** A minimal fetch-and-cache client seam — the subset of {@link NetworkRegistryClient}
+ *  the descriptor-cache seed needs. Injectable so the seed is unit-testable. */
+type DescriptorCacheClient = { fetchAndCache: (id: string) => Promise<{ status: string }> };
+
+/**
+ * cortex#1652 — best-effort: fetch + VERIFY + cache the network's descriptor so a
+ * subsequent `admit` on this machine resolves the operator-mode attestation off
+ * the verified descriptor (nothing else populates the cache for the create-then-
+ * admit hub-owner flow — only `join` does). NEVER throws; returns whether the
+ * cache was seeded + a reason on failure. The client factory is injectable for
+ * tests; production uses {@link NetworkRegistryClient} (TOFU on the registry
+ * pubkey when none is pinned — the admin is writing to a registry they hold the
+ * admin seed for).
+ */
+export async function seedAdminDescriptorCache(
+  networkId: string,
+  registryUrl: string,
+  registryPubkey: string | undefined,
+  makeClient: (cfg: { url: string; pubkey?: string }) => DescriptorCacheClient = (cfg) =>
+    new NetworkRegistryClient(cfg),
+): Promise<{ seeded: boolean; reason?: string }> {
+  try {
+    const client = makeClient({ url: registryUrl, ...(registryPubkey !== undefined ? { pubkey: registryPubkey } : {}) });
+    const cached = await client.fetchAndCache(networkId);
+    return cached.status === "ok" ? { seeded: true } : { seeded: false, reason: cached.status };
+  } catch (err) {
+    return { seeded: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 async function runCreate(
   networkId: string,
   flags: FlagMap,
@@ -2310,32 +2340,20 @@ async function runCreate(
 
   // #1652 — seed THIS admin's descriptor cache with the network they just wrote,
   // so a subsequent `admit` on the SAME machine resolves the operator-mode
-  // attestation (hub_mode / resolver_mode) off the VERIFIED descriptor. Nothing else
-  // populates the cache for the create-then-admit hub-owner flow — only `join`
-  // does — so without this the hub owner's admit sees no hub_mode and silently
-  // falls back to the simple/PSK path (the #1610 fail-open, confirmed live in
-  // #1652). Best-effort + verified: a fetch/verify failure NEVER fails the create
-  // (the row IS written); the hub owner can still declare hub_mode in their local
-  // config (the resolveOperatorAttestation fallback).
-  try {
-    const registryPubkey = optionalValueFlag(flags, "--registry-pubkey");
-    const client = new NetworkRegistryClient({
-      url: registryUrl,
-      ...(registryPubkey !== undefined ? { pubkey: registryPubkey } : {}),
-    });
-    const cached = await client.fetchAndCache(networkId);
-    if (cached.status !== "ok" && !json) {
-      process.stderr.write(
-        `cortex network create: (note) could not cache the verified descriptor for "${networkId}" ` +
-          `(${cached.status}) — admit will fall back to your local config's hub_mode\n`,
-      );
-    }
-  } catch (err) {
-    if (!json) {
-      process.stderr.write(
-        `cortex network create: (note) descriptor-cache seed skipped (${err instanceof Error ? err.message : String(err)})\n`,
-      );
-    }
+  // attestation (hub_mode / resolver_mode) off the VERIFIED descriptor. Nothing
+  // else populates the cache for the create-then-admit hub-owner flow — only
+  // `join` does — so without this the hub owner's admit sees no hub_mode and
+  // silently falls back to the simple/PSK path (the #1610 fail-open, confirmed
+  // live in #1652). Best-effort + verified: a failure NEVER fails the create (the
+  // row IS written), but it IS surfaced (stderr + the --json `descriptor_cached`
+  // field) so an operator knows admit will fall back to local-config hub_mode
+  // rather than silently going PSK.
+  const seed = await seedAdminDescriptorCache(networkId, registryUrl, optionalValueFlag(flags, "--registry-pubkey"));
+  if (!seed.seeded) {
+    process.stderr.write(
+      `cortex network create: (note) descriptor cache NOT seeded for "${networkId}" (${seed.reason ?? "unknown"}) — ` +
+        `a subsequent admit will fall back to your local config's hub_mode (declare policy.federated.networks[${networkId}].hub_mode)\n`,
+    );
   }
 
   if (json) {
@@ -2346,6 +2364,7 @@ async function runCreate(
           registry_url: registryUrl,
           applied: "true",
           admin_fingerprint: matRes.material.fingerprint,
+          descriptor_cached: String(seed.seeded),
         }),
       ),
     );

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2338,21 +2338,15 @@ async function runCreate(
     return opError("create", reason, json);
   }
 
-  // #1652 — seed THIS admin's descriptor cache with the network they just wrote,
-  // so a subsequent `admit` on the SAME machine resolves the operator-mode
-  // attestation (hub_mode / resolver_mode) off the VERIFIED descriptor. Nothing
-  // else populates the cache for the create-then-admit hub-owner flow — only
-  // `join` does — so without this the hub owner's admit sees no hub_mode and
-  // silently falls back to the simple/PSK path (the #1610 fail-open, confirmed
-  // live in #1652). Best-effort + verified: a failure NEVER fails the create (the
-  // row IS written), but it IS surfaced (stderr + the --json `descriptor_cached`
-  // field) so an operator knows admit will fall back to local-config hub_mode
-  // rather than silently going PSK.
+  // #1652 — seed this admin's descriptor cache so a later `admit` here resolves
+  // the operator-mode attestation (see {@link seedAdminDescriptorCache}). Never
+  // fails create; surfaced on failure so admit doesn't silently go PSK.
   const seed = await seedAdminDescriptorCache(networkId, registryUrl, optionalValueFlag(flags, "--registry-pubkey"));
   if (!seed.seeded) {
     process.stderr.write(
-      `cortex network create: (note) descriptor cache NOT seeded for "${networkId}" (${seed.reason ?? "unknown"}) — ` +
-        `a subsequent admit will fall back to your local config's hub_mode (declare policy.federated.networks[${networkId}].hub_mode)\n`,
+      `cortex network create: (note) descriptor cache NOT seeded for "${networkId}" (${seed.reason ?? "unknown"}). ` +
+        `A later admit here resolves hub_mode from this cache OR the networks[] entry whose id is "${networkId}". ` +
+        `If NEITHER is present, admit takes the simple/PSK path (the #1610 fail-open) — set hub_mode on that networks[] entry, or re-run create when the registry is reachable, before admitting on an operator network.\n`,
     );
   }
 

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -48,6 +48,7 @@ import { expandTilde, loadConfigWithAgents } from "../../../common/config/loader
 import type { LoadedConfig } from "../../../common/config/loader";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
 import { NetworkCache } from "../../../common/registry/network-cache";
+import { NetworkRegistryClient } from "../../../common/registry/network-client";
 import {
   materialFromSeedString,
   buildNetworkCreateClaim,
@@ -2305,6 +2306,36 @@ async function runCreate(
         : String(result.response);
     const reason = `registry rejected network create (HTTP ${result.status.toString()}): ${detail}`;
     return opError("create", reason, json);
+  }
+
+  // #1652 — seed THIS admin's descriptor cache with the network they just wrote,
+  // so a subsequent `admit` on the SAME machine resolves the operator-mode
+  // attestation (hub_mode / resolver_mode) off the VERIFIED descriptor. Nothing else
+  // populates the cache for the create-then-admit hub-owner flow — only `join`
+  // does — so without this the hub owner's admit sees no hub_mode and silently
+  // falls back to the simple/PSK path (the #1610 fail-open, confirmed live in
+  // #1652). Best-effort + verified: a fetch/verify failure NEVER fails the create
+  // (the row IS written); the hub owner can still declare hub_mode in their local
+  // config (the resolveOperatorAttestation fallback).
+  try {
+    const registryPubkey = optionalValueFlag(flags, "--registry-pubkey");
+    const client = new NetworkRegistryClient({
+      url: registryUrl,
+      ...(registryPubkey !== undefined ? { pubkey: registryPubkey } : {}),
+    });
+    const cached = await client.fetchAndCache(networkId);
+    if (cached.status !== "ok" && !json) {
+      process.stderr.write(
+        `cortex network create: (note) could not cache the verified descriptor for "${networkId}" ` +
+          `(${cached.status}) — admit will fall back to your local config's hub_mode\n`,
+      );
+    }
+  } catch (err) {
+    if (!json) {
+      process.stderr.write(
+        `cortex network create: (note) descriptor-cache seed skipped (${err instanceof Error ? err.message : String(err)})\n`,
+      );
+    }
   }
 
   if (json) {


### PR DESCRIPTION
Closes the descriptor-resolution half of #1652 (surfaced by the first e2e operator validation).

**Problem:** `cortex network admit` on an operator network couldn't resolve `hub_mode` — nothing populates the admin's DD-10 descriptor cache except `join`'s verified fetch, but the hub owner runs `create`, not `join`. So admit saw no attestation and silently took the simple/PSK path (the #1610 fail-open, confirmed live).

**Fix:** after a successful `network create --apply`, best-effort fetch + verify + cache the descriptor (`seedAdminDescriptorCache`, over the same `fetchAndCache` `join` uses). The hub owner who creates + admits on the same machine then resolves the attestation off the verified descriptor. A seed failure NEVER fails create (the row is written) but IS surfaced — stderr **and** the `--json` `descriptor_cached` field — so a `--json` operator knows admit will fall back to local-config `hub_mode` rather than silently going PSK.

### Verification
- `seedAdminDescriptorCache` is **unit-tested** (4 cases: ok→seeded, non-ok→not-seeded+reason, throw→swallowed, pinned-pubkey pass-through) via an injected client seam.
- tsc clean; 24 attestation+create tests pass; carveouts green.
- The full create→cache→admit→resolve integration (real registry + real descriptor) is out of this diff; it's exercised by the operator validation tracked on #1626 (mechanism proven there). This PR is the seam that seeds the cache; the read side (`resolveOperatorAttestation`) is unchanged + already tested (#1610).

### Out of Scope (rest of #1652, tracked)
- **Account-JWT push after the scoped-key edit** — resolved by the #1626 migration recipe pre-creating the scoped key + pushing once (per-member admits stay pushless).
- **Operator self-test harness bugs** — a separate dev-tooling PR; fixes captured on #1652.

Part of #1652.