### PR TITLE
fix(lint): DescriptorCacheClient type->interface (restore green)

### DIFF
--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2177,7 +2177,7 @@ async function adminMaterialFromSeedFile(
 
 /** A minimal fetch-and-cache client seam — the subset of {@link NetworkRegistryClient}
  *  the descriptor-cache seed needs. Injectable so the seed is unit-testable. */
-type DescriptorCacheClient = { fetchAndCache: (id: string) => Promise<{ status: string }> };
+interface DescriptorCacheClient { fetchAndCache: (id: string) => Promise<{ status: string }> }
 
 /**
  * cortex#1652 — best-effort: fetch + VERIFY + cache the network's descriptor so a


### PR DESCRIPTION
main red on Lint — network.ts:2180 `consistent-type-definitions` (from C-1652 #1655). eslint --fix; tsc 0. Unblocks in-flight PRs.