### PR TITLE
feat(mc): FLG-4 — roster states on glass (seal/authorize timestamps + DEPARTED≠REVOKED + authorship) (R1)

### DIFF
--- a/src/bus/agent-network/__tests__/admission-read-states.test.ts
+++ b/src/bus/agent-network/__tests__/admission-read-states.test.ts
@@ -1,0 +1,105 @@
+/**
+ * FLG-4 — tests for the per-member lifecycle STATE projection added to
+ * `resolveAdmittedRoster`. The `admitted`/`pending` arrays are UNCHANGED
+ * (back-compat); `states` is the additive superset covering EVERY row incl.
+ * former members (revoked/departed/rejected), with honest defaults for the
+ * optional facets.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveAdmittedRoster,
+  type AdmissionRow,
+  type AdmissionRowsProvider,
+  type AdmissionRowsResult,
+} from "../admission-read";
+
+function provider(rows: AdmissionRow[], scope: "complete" | "self" = "complete"): AdmissionRowsProvider {
+  return {
+    readAdmissionRows: (): Promise<AdmissionRowsResult> =>
+      Promise.resolve({ ok: true, rows, scope }),
+  };
+}
+
+const NET = "metafactory";
+
+describe("resolveAdmittedRoster — FLG-4 states projection", () => {
+  it("projects every row (incl. former members) into states, keeping admitted/pending unchanged", async () => {
+    const rows: AdmissionRow[] = [
+      { principal_id: "andreas", network_id: NET, status: "ADMITTED", sealed: true, hub_authorized_at: "2026-07-08T00:00:00.000Z" },
+      { principal_id: "newcomer", network_id: NET, status: "PENDING" },
+      { principal_id: "leaver", network_id: NET, status: "DEPARTED" },
+      { principal_id: "kicked", network_id: NET, status: "REVOKED" },
+      { principal_id: "declined", network_id: NET, status: "REJECTED" },
+    ];
+    const res = await resolveAdmittedRoster(NET, provider(rows));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+
+    // Back-compat: admitted/pending arrays unchanged.
+    expect(res.roster.admitted).toEqual(["andreas"]);
+    expect(res.roster.pending).toEqual(["newcomer"]);
+
+    // States: EVERY row, with honest defaults.
+    const states = res.roster.states ?? [];
+    expect(states.map((s) => s.principal_id)).toEqual([
+      "andreas",
+      "newcomer",
+      "leaver",
+      "kicked",
+      "declined",
+    ]);
+    const andreas = states.find((s) => s.principal_id === "andreas");
+    expect(andreas).toEqual({
+      principal_id: "andreas",
+      status: "ADMITTED",
+      sealed: true,
+      hub_authorized_at: "2026-07-08T00:00:00.000Z",
+      authorship: "unchecked",
+    });
+    // DEPARTED and REVOKED are DISTINCT statuses in the projection.
+    expect(states.find((s) => s.principal_id === "leaver")?.status).toBe("DEPARTED");
+    expect(states.find((s) => s.principal_id === "kicked")?.status).toBe("REVOKED");
+  });
+
+  it("defaults optional facets to honest absence (sealed:false, hub_authorized_at:null, authorship:unchecked)", async () => {
+    const rows: AdmissionRow[] = [
+      { principal_id: "andreas", network_id: NET, status: "ADMITTED" },
+    ];
+    const res = await resolveAdmittedRoster(NET, provider(rows));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.roster.states?.[0]).toEqual({
+      principal_id: "andreas",
+      status: "ADMITTED",
+      sealed: false,
+      hub_authorized_at: null,
+      authorship: "unchecked",
+    });
+  });
+
+  it("dedupes states by principal (first-seen), ignoring rows for other networks", async () => {
+    const rows: AdmissionRow[] = [
+      { principal_id: "andreas", network_id: NET, status: "ADMITTED", sealed: true },
+      { principal_id: "andreas", network_id: NET, status: "REVOKED" }, // dup — dropped
+      { principal_id: "other", network_id: "different-net", status: "ADMITTED" }, // wrong net
+    ];
+    const res = await resolveAdmittedRoster(NET, provider(rows));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const states = res.roster.states ?? [];
+    expect(states).toHaveLength(1);
+    expect(states[0]?.status).toBe("ADMITTED"); // first-seen wins
+    expect(states[0]?.sealed).toBe(true);
+  });
+
+  it("carries a pre-resolved authorship verdict through verbatim", async () => {
+    const rows: AdmissionRow[] = [
+      { principal_id: "andreas", network_id: NET, status: "ADMITTED", authorship: "verified" },
+    ];
+    const res = await resolveAdmittedRoster(NET, provider(rows));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.roster.states?.[0]?.authorship).toBe("verified");
+  });
+});

--- a/src/bus/agent-network/__tests__/admission-rows-member-provider.test.ts
+++ b/src/bus/agent-network/__tests__/admission-rows-member-provider.test.ts
@@ -133,9 +133,12 @@ describe("createMemberRosterAdmissionProvider — happy path", () => {
     expect(res.ok).toBe(true);
     if (!res.ok) return;
     expect(res.scope).toBe("complete");
+    // FLG-4 — rows now carry a resolved `authorship` verdict (default "unchecked"
+    // when no admin key is pinned + no material on the row). `sealed`/
+    // `hub_authorized_at` are omitted here (this fixture emits neither facet).
     expect(res.rows).toEqual([
-      { principal_id: "andreas", network_id: "research-collab", status: "ADMITTED" },
-      { principal_id: "jc", network_id: "research-collab", status: "ADMITTED" },
+      { principal_id: "andreas", network_id: "research-collab", status: "ADMITTED", authorship: "unchecked" },
+      { principal_id: "jc", network_id: "research-collab", status: "ADMITTED", authorship: "unchecked" },
     ]);
   });
 
@@ -153,6 +156,118 @@ describe("createMemberRosterAdmissionProvider — happy path", () => {
     });
     const res = await provider.readAdmissionRows("research-collab");
     expect(res).toEqual({ ok: true, rows: [], scope: "complete" });
+  });
+});
+
+describe("createMemberRosterAdmissionProvider — FLG-4 roster-state facets", () => {
+  it("parses the additive facets (admission_state / sealed / hub_authorized_at) when the registry emits them", async () => {
+    const reg = await registryKeypair();
+    const roster = {
+      network_id: "research-collab",
+      members: [
+        {
+          principal_id: "andreas",
+          principal_pubkey: "x",
+          capabilities: [],
+          admission_state: "ADMITTED",
+          sealed: true,
+          hub_authorized_at: "2026-07-08T00:00:00.000Z",
+        },
+      ],
+    };
+    const assertion = await signAssertion(reg.privateKey, reg.publicKeyB64, roster);
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      fetchImpl: fakeFetch(200, assertion),
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.rows[0]).toEqual({
+      principal_id: "andreas",
+      network_id: "research-collab",
+      status: "ADMITTED",
+      sealed: true,
+      hub_authorized_at: "2026-07-08T00:00:00.000Z",
+      authorship: "unchecked",
+    });
+  });
+
+  it("#1600 — resolves authorship to 'verified' when the row carries valid material AND an admin key is pinned", async () => {
+    // Hub-admin keypair — signs the sealed-row authorship claim.
+    const hubAdmin = await registryKeypair();
+    const claim = { request_id: "req-1", hub_admin_pubkey: hubAdmin.publicKeyB64, issued_at: "2026-07-08T00:00:00.000Z", nonce: "n1" };
+    const claimSig = await crypto.subtle.sign(
+      { name: "Ed25519" },
+      hubAdmin.privateKey,
+      new TextEncoder().encode(canonicalJSON(claim)),
+    );
+    const claimSigB64 = bytesToBase64(new Uint8Array(claimSig));
+
+    const reg = await registryKeypair();
+    const roster = {
+      network_id: "research-collab",
+      members: [
+        {
+          principal_id: "andreas",
+          principal_pubkey: "x",
+          capabilities: [],
+          seal_claim: claim,
+          seal_signature: claimSigB64,
+          sealed_by: hubAdmin.publicKeyB64,
+        },
+      ],
+    };
+    const assertion = await signAssertion(reg.privateKey, reg.publicKeyB64, roster);
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      networkAdminPubkey: hubAdmin.publicKeyB64,
+      fetchImpl: fakeFetch(200, assertion),
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.rows[0]?.authorship).toBe("verified");
+  });
+
+  it("#1600 — authorship stays 'unchecked' when material is present but NO admin key is pinned (never a fabricated pass)", async () => {
+    const hubAdmin = await registryKeypair();
+    const claim = { request_id: "req-1", hub_admin_pubkey: hubAdmin.publicKeyB64, issued_at: "2026-07-08T00:00:00.000Z", nonce: "n1" };
+    const claimSig = await crypto.subtle.sign(
+      { name: "Ed25519" },
+      hubAdmin.privateKey,
+      new TextEncoder().encode(canonicalJSON(claim)),
+    );
+    const reg = await registryKeypair();
+    const roster = {
+      network_id: "research-collab",
+      members: [
+        {
+          principal_id: "andreas",
+          principal_pubkey: "x",
+          capabilities: [],
+          seal_claim: claim,
+          seal_signature: bytesToBase64(new Uint8Array(claimSig)),
+          sealed_by: hubAdmin.publicKeyB64,
+        },
+      ],
+    };
+    const assertion = await signAssertion(reg.privateKey, reg.publicKeyB64, roster);
+    const provider = createMemberRosterAdmissionProvider({
+      registryUrl: "https://registry.example",
+      registryPubkey: reg.publicKeyB64,
+      material: stackMaterial(),
+      // networkAdminPubkey deliberately omitted.
+      fetchImpl: fakeFetch(200, assertion),
+    });
+    const res = await provider.readAdmissionRows("research-collab");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.rows[0]?.authorship).toBe("unchecked");
   });
 });
 

--- a/src/bus/agent-network/__tests__/roster-authorship.test.ts
+++ b/src/bus/agent-network/__tests__/roster-authorship.test.ts
@@ -1,0 +1,115 @@
+/**
+ * FLG-4 / #1600 — tests for `verifyRosterAuthorship`, the pure hub-admin
+ * authorship check. The security-load-bearing property: the ONLY path to
+ * `"verified"` is a REAL Ed25519 verify passing against the PINNED admin key.
+ * Everything else is `"unchecked"` (couldn't run) or `"unverifiable"` (ran, did
+ * not pass) — never a fabricated pass.
+ *
+ * Hermetic: a real WebCrypto Ed25519 keypair signs the claim; the check verifies
+ * against it end-to-end (no stubbed crypto).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  verifyRosterAuthorship,
+  type RosterAuthorshipMaterial,
+} from "../roster-authorship";
+import { canonicalJSON } from "../../../common/registry/canonical-json";
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+async function keypair(): Promise<{ privateKey: CryptoKey; pubB64: string }> {
+  const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+  const raw = await crypto.subtle.exportKey("raw", kp.publicKey);
+  return { privateKey: kp.privateKey, pubB64: bytesToBase64(new Uint8Array(raw)) };
+}
+
+/** Sign a claim the way the hub-admin does — canonicalJSON(claim), Ed25519. */
+async function signClaim(
+  privateKey: CryptoKey,
+  hubAdminPubkey: string,
+  claim: unknown,
+): Promise<RosterAuthorshipMaterial> {
+  const sig = await crypto.subtle.sign(
+    { name: "Ed25519" },
+    privateKey,
+    new TextEncoder().encode(canonicalJSON(claim)),
+  );
+  return { claim, signature: bytesToBase64(new Uint8Array(sig)), hub_admin_pubkey: hubAdminPubkey };
+}
+
+const CLAIM = {
+  request_id: "req-abc",
+  sealed_secret: "OPAQUE-CIPHERTEXT",
+  hub_admin_pubkey: "", // filled below to the real key
+  issued_at: "2026-07-08T00:00:00.000Z",
+  nonce: "n1",
+};
+
+describe("verifyRosterAuthorship (#1600)", () => {
+  it("returns 'verified' ONLY when the signature verifies against the pinned admin key", async () => {
+    const admin = await keypair();
+    const claim = { ...CLAIM, hub_admin_pubkey: admin.pubB64 };
+    const material = await signClaim(admin.privateKey, admin.pubB64, claim);
+
+    const result = await verifyRosterAuthorship(material, admin.pubB64);
+    expect(result).toBe("verified");
+  });
+
+  it("returns 'unverifiable' when the pinned key differs from the claimed admin", async () => {
+    const admin = await keypair();
+    const otherPinned = await keypair();
+    const claim = { ...CLAIM, hub_admin_pubkey: admin.pubB64 };
+    const material = await signClaim(admin.privateKey, admin.pubB64, claim);
+
+    // Material asserts `admin`, but we pin a DIFFERENT key — a definitive negative.
+    const result = await verifyRosterAuthorship(material, otherPinned.pubB64);
+    expect(result).toBe("unverifiable");
+  });
+
+  it("returns 'unverifiable' when the signature does not verify (tampered claim)", async () => {
+    const admin = await keypair();
+    const claim = { ...CLAIM, hub_admin_pubkey: admin.pubB64 };
+    const material = await signClaim(admin.privateKey, admin.pubB64, claim);
+    // Tamper the claim AFTER signing — same pinned+claimed key, but the signature
+    // no longer matches the canonical bytes.
+    const tampered: RosterAuthorshipMaterial = {
+      ...material,
+      claim: { ...claim, sealed_secret: "SWAPPED-CIPHERTEXT" },
+    };
+
+    const result = await verifyRosterAuthorship(tampered, admin.pubB64);
+    expect(result).toBe("unverifiable");
+  });
+
+  it("returns 'unverifiable' for a garbage signature (never throws)", async () => {
+    const admin = await keypair();
+    const claim = { ...CLAIM, hub_admin_pubkey: admin.pubB64 };
+    const material: RosterAuthorshipMaterial = {
+      claim,
+      signature: "!!!not-base64!!!",
+      hub_admin_pubkey: admin.pubB64,
+    };
+    const result = await verifyRosterAuthorship(material, admin.pubB64);
+    expect(result).toBe("unverifiable");
+  });
+
+  it("returns 'unchecked' when no admin key is pinned (never verifies against the row's own key)", async () => {
+    const admin = await keypair();
+    const claim = { ...CLAIM, hub_admin_pubkey: admin.pubB64 };
+    const material = await signClaim(admin.privateKey, admin.pubB64, claim);
+
+    expect(await verifyRosterAuthorship(material, undefined)).toBe("unchecked");
+    expect(await verifyRosterAuthorship(material, "")).toBe("unchecked");
+  });
+
+  it("returns 'unchecked' when the row carries no authorship material (today's live case)", async () => {
+    const admin = await keypair();
+    const result = await verifyRosterAuthorship(undefined, admin.pubB64);
+    expect(result).toBe("unchecked");
+  });
+});

--- a/src/bus/agent-network/admission-read.ts
+++ b/src/bus/agent-network/admission-read.ts
@@ -38,24 +38,85 @@
  * crypto, or auth specifics itself.
  */
 
+import type { RosterAuthorship } from "./roster-authorship";
+
+export type { RosterAuthorship } from "./roster-authorship";
+
 /**
  * Admission lifecycle status, mirroring the registry's `AdmissionStatus`
  * (`src/services/network-registry/src/types.ts`). Re-declared on the consumer
  * side (the registry is a separate deploy target — same redeclare rationale as
  * `src/common/registry/types.ts`).
+ *
+ * FLG-4 (docs/plan-mc-future-state.md §4.D) adds `DEPARTED` to keep lockstep with
+ * the registry's C-1350 status set — a member that LEFT voluntarily (ADMITTED →
+ * DEPARTED). It is the honesty hinge the roster glass must keep visually distinct
+ * from `REVOKED` (admin-kicked): "left" ≠ "kicked".
  */
-export type AdmissionStatus = "PENDING" | "ADMITTED" | "REJECTED" | "REVOKED";
+export type AdmissionStatus =
+  | "PENDING"
+  | "ADMITTED"
+  | "REJECTED"
+  | "REVOKED"
+  | "DEPARTED";
 
 /**
  * One admission row, narrowed to the membership-relevant fields. A row binds a
  * principal to a network at a status. `network_id === null` is a network-less
  * registration row (registered-but-not-joined) — never a member of any specific
  * network, so {@link resolveAdmittedRoster} ignores it.
+ *
+ * FLG-4 adds the OPTIONAL roster-state facets a richer read may carry (the
+ * extended registry member-read, or an admin-list read). A provider that cannot
+ * observe them simply omits them — {@link resolveAdmittedRoster} defaults each to
+ * an honest absence (`sealed:false`, `hub_authorized_at:null`,
+ * `authorship:"unchecked"`). NONE of these are secret material: `sealed` is a
+ * BOOLEAN delivery signal (never the ciphertext), `hub_authorized_at` is a
+ * timestamp, and `authorship` is the RESOLVED tri-state verdict (never the raw
+ * signature/claim) — secret-material discipline (invariant 6) is preserved.
  */
 export interface AdmissionRow {
   principal_id: string;
   network_id: string | null;
   status: AdmissionStatus;
+  /**
+   * FLG-4 — whether a sealed leaf secret has been DELIVERED onto this row. A
+   * boolean signal only (`sealed_secret !== null` on the registry row); NEVER the
+   * sealed ciphertext. Optional — a reader that cannot observe delivery omits it.
+   */
+  sealed?: boolean;
+  /**
+   * FLG-4 — ISO-8601 UTC the hub-admin stamped hub-authorize (cortex#1498), or
+   * `null` when not authorized. Optional — a reader that cannot observe it omits
+   * it (defaults to `null`).
+   */
+  hub_authorized_at?: string | null;
+  /**
+   * FLG-4 / #1600 — the RESOLVED hub-admin authorship verdict for this row (the
+   * provider ran {@link verifyRosterAuthorship} against the pinned network-admin
+   * pubkey). Optional — absent ⇒ `"unchecked"`. The raw `{claim, signature}` is
+   * NOT carried here (it is verified at the provider and discarded); only the
+   * tri-state verdict crosses this seam.
+   */
+  authorship?: RosterAuthorship;
+}
+
+/**
+ * FLG-4 — one member's roster LIFECYCLE state, projected from an admission row.
+ * The metadata-only, no-secrets record the `/api/networks` read surfaces per
+ * member (including FORMER members — departed/revoked — which are NOT in the
+ * admitted/pending sets but ARE lifecycle states the glass must show honestly).
+ */
+export interface AdmittedMemberState {
+  principal_id: string;
+  /** The row's lifecycle status, verbatim (incl. `DEPARTED` vs `REVOKED`). */
+  status: AdmissionStatus;
+  /** Sealed-secret DELIVERED (boolean signal; never the ciphertext). */
+  sealed: boolean;
+  /** ISO-8601 UTC hub-authorize timestamp (cortex#1498), or `null`. */
+  hub_authorized_at: string | null;
+  /** #1600 — resolved hub-admin authorship verdict (default `"unchecked"`). */
+  authorship: RosterAuthorship;
 }
 
 /**
@@ -93,6 +154,18 @@ export interface AdmittedRoster {
   admitted: string[];
   /** Principal ids whose admission row for this network is `PENDING`. */
   pending: string[];
+  /**
+   * FLG-4 — per-member roster lifecycle STATE for EVERY row on this network
+   * (admitted, pending, AND former: revoked/departed/rejected), first-seen order,
+   * deduped by principal. This is the FLG-4 carrier: seal-delivery, hub-authorize
+   * timestamp, admission state, and the #1600 authorship verdict. The
+   * `admitted`/`pending` string arrays above are UNCHANGED (back-compat for the
+   * membership reconciler); `states` is the additive superset the roster glass
+   * reads for lifecycle. OPTIONAL for back-compat with older stub literals that
+   * predate FLG-4 (a consumer treats absent as `[]` — honest absence);
+   * {@link resolveAdmittedRoster} ALWAYS populates it.
+   */
+  states?: AdmittedMemberState[];
   /**
    * True when the underlying read was the COMPLETE roster (admin-authoritative).
    * False for a SELF-only member read — the caller MUST NOT treat a present
@@ -147,8 +220,40 @@ export async function resolveAdmittedRoster(
   const pending = dedupePreserveOrder(
     forNetwork.filter((r) => r.status === "PENDING").map((r) => r.principal_id),
   );
+  // FLG-4 — project EVERY row (incl. former: revoked/departed/rejected) into a
+  // per-member lifecycle state, deduped by principal, first-seen order (matching
+  // the admitted/pending dedupe above; a principal with multiple rows keeps its
+  // first-seen row — deterministic without server-supplied ordering).
+  const states = projectMemberStates(forNetwork);
   return {
     ok: true,
-    roster: { admitted, pending, authoritative: res.scope === "complete" },
+    roster: {
+      admitted,
+      pending,
+      states,
+      authoritative: res.scope === "complete",
+    },
   };
+}
+
+/**
+ * Project admission rows → per-member {@link AdmittedMemberState}, deduped by
+ * principal (first-seen order). Defaults each optional facet to an honest
+ * absence: `sealed:false`, `hub_authorized_at:null`, `authorship:"unchecked"`.
+ */
+function projectMemberStates(rows: readonly AdmissionRow[]): AdmittedMemberState[] {
+  const seen = new Set<string>();
+  const out: AdmittedMemberState[] = [];
+  for (const r of rows) {
+    if (seen.has(r.principal_id)) continue;
+    seen.add(r.principal_id);
+    out.push({
+      principal_id: r.principal_id,
+      status: r.status,
+      sealed: r.sealed ?? false,
+      hub_authorized_at: r.hub_authorized_at ?? null,
+      authorship: r.authorship ?? "unchecked",
+    });
+  }
+  return out;
 }

--- a/src/bus/agent-network/admission-rows-member-provider.ts
+++ b/src/bus/agent-network/admission-rows-member-provider.ts
@@ -59,7 +59,13 @@ import type {
   AdmissionRow,
   AdmissionRowsProvider,
   AdmissionRowsResult,
+  AdmissionStatus,
 } from "./admission-read";
+import {
+  verifyRosterAuthorship,
+  type RosterAuthorship,
+  type RosterAuthorshipMaterial,
+} from "./roster-authorship";
 
 /**
  * Injectable `fetch`, narrowed to what this provider needs. Production omits it
@@ -89,6 +95,14 @@ export interface MemberRosterAdmissionProviderOptions {
    */
   registryPubkey?: string;
   /**
+   * FLG-4 / #1600 — the PINNED network-admin pubkey (base64 Ed25519) the sealed
+   * row's hub-admin `{claim, signature}` is verified against. When absent, or
+   * when the read carries no authorship material, per-member `authorship`
+   * resolves to `"unchecked"` (honest — never a fabricated pass). No config field
+   * pins this yet (residual risk in the FLG-4 PR), so this is normally undefined.
+   */
+  networkAdminPubkey?: string;
+  /**
    * The stack's identity material — its registered `SU…` seed + base64 pubkey.
    * The pubkey is the registry `peer_pubkey`; the seed signs the PoP claim.
    * SECRET (the seed) — never logged.
@@ -104,17 +118,54 @@ export interface MemberRosterAdmissionProviderOptions {
   logError?: (msg: string) => void;
 }
 
-/** The minimal verified-roster shape the member endpoint returns (admission-sourced). */
+/** One parsed roster member — `principal_id` plus the OPTIONAL FLG-4 facets. */
+interface VerifiedRosterMember {
+  principal_id: string;
+  /** FLG-4 — the row's lifecycle status when the registry emits it (else ADMITTED). */
+  admission_state?: AdmissionStatus;
+  /** FLG-4 — sealed-secret delivered (boolean signal; never the ciphertext). */
+  sealed?: boolean;
+  /** FLG-4 — ISO-8601 UTC hub-authorize timestamp, or null. */
+  hub_authorized_at?: string | null;
+  /** #1600 — hub-admin authorship material (verified against the pinned admin key). */
+  authorship?: RosterAuthorshipMaterial;
+}
+
+/** The verified-roster shape the member endpoint returns (admission-sourced). */
 interface VerifiedRosterPayload {
   network_id: string;
-  members: { principal_id: string }[];
+  members: VerifiedRosterMember[];
+}
+
+/** The registry's `AdmissionStatus` values (guard for the optional `admission_state`). */
+const ADMISSION_STATES: readonly AdmissionStatus[] = [
+  "PENDING",
+  "ADMITTED",
+  "REJECTED",
+  "REVOKED",
+  "DEPARTED",
+];
+
+/** Parse a member's OPTIONAL FLG-4 authorship material, or `undefined` when absent/malformed. */
+function parseAuthorshipMaterial(m: Record<string, unknown>): RosterAuthorshipMaterial | undefined {
+  const claim = m.seal_claim;
+  const signature = m.seal_signature;
+  const hubAdmin = m.sealed_by;
+  if (claim === undefined || claim === null) return undefined;
+  if (typeof signature !== "string" || signature.length === 0) return undefined;
+  if (typeof hubAdmin !== "string" || hubAdmin.length === 0) return undefined;
+  return { claim, signature, hub_admin_pubkey: hubAdmin };
 }
 
 /**
  * Parse a DD-9-verified payload as the member roster — `{ network_id,
- * members: [{ principal_id }] }`. A verified-but-wrong-shape payload is a
- * wire-contract violation, not a value to trust → `undefined` (caller maps to
- * `unreachable`). Mirrors `network-client`'s `parseRoster` discipline.
+ * members: [{ principal_id, ...FLG-4 facets }] }`. The FLG-4 facets
+ * (`admission_state`, `sealed`, `hub_authorized_at`, and the authorship material)
+ * are all OPTIONAL and ADDITIVE: a pre-FLG-4 registry omits them and the member
+ * simply carries `{ principal_id }`, so this stays backward-compatible. A
+ * verified-but-wrong-shape payload is a wire-contract violation, not a value to
+ * trust → `undefined` (caller maps to `unreachable`). Mirrors `network-client`'s
+ * `parseRoster` discipline.
  */
 function parseVerifiedRoster(
   payload: unknown,
@@ -124,14 +175,29 @@ function parseVerifiedRoster(
   const p = payload as Record<string, unknown>;
   if (p.network_id !== networkId) return undefined;
   if (!Array.isArray(p.members)) return undefined;
-  const members: { principal_id: string }[] = [];
+  const members: VerifiedRosterMember[] = [];
   for (const raw of p.members) {
     if (raw === null || typeof raw !== "object") return undefined;
     const m = raw as Record<string, unknown>;
     if (typeof m.principal_id !== "string" || m.principal_id.length === 0) {
       return undefined;
     }
-    members.push({ principal_id: m.principal_id });
+    const member: VerifiedRosterMember = { principal_id: m.principal_id };
+    if (
+      typeof m.admission_state === "string" &&
+      (ADMISSION_STATES as readonly string[]).includes(m.admission_state)
+    ) {
+      member.admission_state = m.admission_state as AdmissionStatus;
+    }
+    if (typeof m.sealed === "boolean") member.sealed = m.sealed;
+    if (typeof m.hub_authorized_at === "string") {
+      member.hub_authorized_at = m.hub_authorized_at;
+    } else if (m.hub_authorized_at === null) {
+      member.hub_authorized_at = null;
+    }
+    const authorship = parseAuthorshipMaterial(m);
+    if (authorship !== undefined) member.authorship = authorship;
+    members.push(member);
   }
   return { network_id: networkId, members };
 }
@@ -271,11 +337,30 @@ export function createMemberRosterAdmissionProvider(
         detail: "member roster payload was not a valid roster shape",
       };
     }
-    const rows: AdmissionRow[] = roster.members.map((m) => ({
-      principal_id: m.principal_id,
-      network_id: networkId,
-      status: "ADMITTED" as const,
-    }));
+    // FLG-4 — project each member into an AdmissionRow, carrying the OPTIONAL
+    // state facets. The member-read serves the ADMITTED roster, so `status`
+    // defaults to ADMITTED unless the registry emits an explicit `admission_state`.
+    // #1600 — resolve authorship per member: verify the hub-admin {claim,
+    // signature} (when present) against the pinned network-admin pubkey. Absent
+    // material or no pinned key ⇒ "unchecked" (honest — never a fabricated pass).
+    const rows: AdmissionRow[] = await Promise.all(
+      roster.members.map(async (m): Promise<AdmissionRow> => {
+        const authorship: RosterAuthorship = await verifyRosterAuthorship(
+          m.authorship,
+          options.networkAdminPubkey,
+        );
+        return {
+          principal_id: m.principal_id,
+          network_id: networkId,
+          status: m.admission_state ?? "ADMITTED",
+          ...(m.sealed !== undefined && { sealed: m.sealed }),
+          ...(m.hub_authorized_at !== undefined && {
+            hub_authorized_at: m.hub_authorized_at,
+          }),
+          authorship,
+        };
+      }),
+    );
     return { ok: true, rows, scope: "complete" };
   }
 

--- a/src/bus/agent-network/roster-authorship.ts
+++ b/src/bus/agent-network/roster-authorship.ts
@@ -1,0 +1,128 @@
+/**
+ * FLG-4 / §3.5 / #1600 (docs/plan-mc-future-state.md §3.5, §4.D) — the
+ * **hub-admin authorship check** for a member's sealed roster row.
+ *
+ * The R1-anchor finding #1600: *"member never checks admin authorship on the
+ * sealed row"*. The glass trust plane must SURFACE and VERIFY the hub-admin
+ * `{claim, signature}` that was posted alongside a member's sealed secret
+ * (`network secret add-member` → `POST /admission-requests/:id/sealed-secret`,
+ * signed by the hub-admin — see `network-secret-adapters.ts` `buildLiveSealDeliveryPort`)
+ * against the **pinned** network-admin pubkey, BEFORE the glass presents the row
+ * as trustworthy. The honesty invariant (plan §3.5, invariant "truth-not-theater"):
+ * **never render "verified" without actually running the check.**
+ *
+ * This module is the PURE verification primitive. It is deliberately tiny,
+ * side-effect-free (one WebCrypto verify), and never-throws — so it is trivially
+ * unit-testable and safe to call from the never-throw admission-read path.
+ *
+ * ## The three honest outcomes (never a fourth, never a fabricated pass)
+ *
+ *   - `"verified"`      — authorship material is present, a pinned network-admin
+ *                         pubkey is configured, the claim asserts THAT admin, and
+ *                         the Ed25519 signature over `canonicalJSON(claim)`
+ *                         verifies. This is the ONLY path that returns verified,
+ *                         and it requires the real signature check to pass.
+ *   - `"unverifiable"`  — material is present but the check does NOT pass: the
+ *                         claimed admin pubkey differs from the pinned one, or the
+ *                         signature fails to verify. A NEGATIVE result — the row's
+ *                         authorship is asserted but wrong/mismatched. Surfaced,
+ *                         never hidden.
+ *   - `"unchecked"`     — the check could not be RUN: no pinned network-admin
+ *                         pubkey is configured, or the row carries no authorship
+ *                         material (today the registry does not yet persist the
+ *                         hub-admin `{claim, signature}` on the row — see the
+ *                         residual-risk note in the FLG-4 PR). Distinct from
+ *                         `unverifiable`: "we didn't check" ≠ "we checked and it
+ *                         failed". The glass presents it as an honest gap, not a
+ *                         pass and not a failure.
+ *
+ * ## Why not fold `unchecked` into `unverifiable`
+ *
+ * Collapsing "couldn't check" into "check failed" would either over-warn (a
+ * correctly-sealed row with no pinned key looks compromised) or, worse, tempt a
+ * consumer to treat the absence of a negative as a positive. Keeping the third
+ * state forces the UI to say exactly what is true: verified, contradicted, or
+ * not-yet-checkable.
+ */
+
+import { verifyEd25519 } from "../../common/registry/signing";
+import { canonicalJSON } from "../../common/registry/canonical-json";
+
+/**
+ * The hub-admin authorship material carried alongside a member's sealed row —
+ * the signed claim + signature the hub-admin posted with the sealed secret
+ * (`sealed-secret` route claim: `{ request_id, sealed_secret, hub_admin_pubkey,
+ * issued_at, nonce }`, signed with the hub-admin seed). Present ONLY when the
+ * read surfaces it; today's registry member-read does not (residual risk).
+ *
+ * The `sealed_secret` field of the original claim is deliberately NOT required
+ * here — a consumer verifying authorship must be able to pass the claim WITHOUT
+ * re-transiting the sealed ciphertext (secret-material discipline, invariant 6).
+ * Whatever claim object is passed is canonicalised + verified verbatim; the
+ * caller is responsible for handing over the SAME claim bytes that were signed.
+ */
+export interface RosterAuthorshipMaterial {
+  /**
+   * The hub-admin's signed claim object, verbatim as it was signed (verified via
+   * `canonicalJSON(claim)`). Opaque here — the caller supplies the exact bytes.
+   */
+  claim: unknown;
+  /** Base64 Ed25519 signature over `canonicalJSON(claim)`. */
+  signature: string;
+  /** Base64 Ed25519 pubkey the claim asserts authorship for (the hub-admin key). */
+  hub_admin_pubkey: string;
+}
+
+/**
+ * The resolved authorship verdict for a roster row — the honest tri-state above.
+ * Stable, non-localized tokens (safe for `data-*` attributes + tests).
+ */
+export type RosterAuthorship = "verified" | "unverifiable" | "unchecked";
+
+/**
+ * Verify a member row's hub-admin authorship against the PINNED network-admin
+ * pubkey (#1600). Never throws — a malformed claim / bad base64 / crypto failure
+ * all resolve to `"unverifiable"` (a definitive negative), never a thrown error
+ * and never a silent pass.
+ *
+ * Fail-closed by construction: the ONLY branch that returns `"verified"` is the
+ * one where a real Ed25519 verify PASSES against the pinned key. Every other
+ * path is `unchecked` (couldn't run) or `unverifiable` (ran, did not pass).
+ *
+ * @param material            The row's authorship material, or `undefined` when
+ *                            the read carries none → `"unchecked"`.
+ * @param pinnedAdminPubkey   The base64 network-admin pubkey pinned in config, or
+ *                            `undefined`/empty when none is configured →
+ *                            `"unchecked"` (we refuse to verify against an
+ *                            unpinned/attacker-suppliable key — the pin is the
+ *                            trust anchor, mandatory + fail-closed per §3.5).
+ */
+export async function verifyRosterAuthorship(
+  material: RosterAuthorshipMaterial | undefined,
+  pinnedAdminPubkey: string | undefined,
+): Promise<RosterAuthorship> {
+  // No pinned trust anchor ⇒ we cannot verify authorship against anything
+  // trustworthy. Never verify against the pubkey the row itself supplies (that
+  // would let a forged row assert its own authorship). Honest "unchecked".
+  if (pinnedAdminPubkey === undefined || pinnedAdminPubkey === "") {
+    return "unchecked";
+  }
+  // No material on the row ⇒ nothing to check (today's common live case — the
+  // registry does not yet persist the hub-admin {claim,signature}). "unchecked",
+  // NOT "unverifiable": we did not run a check that failed.
+  if (material === undefined) {
+    return "unchecked";
+  }
+  // The claim must assert authorship for the SAME admin we pinned. A claim signed
+  // by (and asserting) a DIFFERENT key than the pinned network-admin is a
+  // definitive negative — the row's authorship does not match the trusted admin.
+  if (material.hub_admin_pubkey !== pinnedAdminPubkey) {
+    return "unverifiable";
+  }
+  // Run the real signature check over the canonical claim bytes. verifyEd25519
+  // is itself never-throw (returns false on any malformed input), so this is the
+  // complete decision: pass ⇒ verified, fail ⇒ unverifiable.
+  const message = new TextEncoder().encode(canonicalJSON(material.claim));
+  const ok = await verifyEd25519(pinnedAdminPubkey, material.signature, message);
+  return ok ? "verified" : "unverifiable";
+}

--- a/src/services/network-registry/__tests__/roster-member-read.test.ts
+++ b/src/services/network-registry/__tests__/roster-member-read.test.ts
@@ -155,6 +155,13 @@ describe("GET /networks/:id/roster/member — member PoP-read (ADR-0018 Q4)", ()
     // capabilities are joined as a facet on the roster
     const alphaRow = json.payload.members.find((m) => m.principal_id === "alpha");
     expect(alphaRow?.capabilities).toEqual(["tasks.code-review"]);
+    // FLG-4 — additive roster lifecycle facets: this read serves the ADMITTED
+    // roster, so `admission_state` is ADMITTED; `sealed` is a boolean delivery
+    // signal (false — no sealed secret delivered in this fixture); hub-authorize
+    // is null (not yet authorized). NONE of these carry secret material.
+    expect(alphaRow?.admission_state).toBe("ADMITTED");
+    expect(alphaRow?.sealed).toBe(false);
+    expect(alphaRow?.hub_authorized_at).toBeNull();
   });
 
   test("the response is a registry-signed assertion (verifies against the registry pubkey)", async () => {

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -1308,6 +1308,13 @@ export function rosterFromAdmissions(
       principal_id: record.principal_id,
       principal_pubkey: record.principal_pubkey,
       capabilities,
+      // FLG-4 — ADDITIVE roster lifecycle facets (cortex MC roster glass). This
+      // read is the ADMITTED roster, so `admission_state` is ADMITTED; `sealed`
+      // is a boolean DELIVERY signal (`sealed_secret !== null` — NEVER the
+      // ciphertext); `hub_authorized_at` is the cortex#1498 authorize timestamp.
+      admission_state: "ADMITTED",
+      sealed: row.sealed_secret !== null,
+      hub_authorized_at: row.hub_authorized_at,
     });
   }
   members.sort((a, b) => a.principal_id.localeCompare(b.principal_id));

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -194,6 +194,23 @@ export interface NetworkRoster {
     principal_id: string;
     principal_pubkey: string;
     capabilities: string[];
+    /**
+     * FLG-4 (cortex, docs/plan-mc-future-state.md §4.D) — the OPTIONAL roster
+     * lifecycle facets the MC roster glass surfaces per member. ADDITIVE: a
+     * pre-FLG-4 consumer ignores them; the cortex member-read provider
+     * (`admission-rows-member-provider.ts`) parses them when present, else
+     * defaults to honest absence. NONE are secret material:
+     *
+     *  - `admission_state` — the row's `AdmissionStatus` (the member-read serves
+     *    the ADMITTED roster, so this is `"ADMITTED"` here; the field exists so
+     *    an admin-list read can reuse the same shape for former members).
+     *  - `sealed` — whether a sealed leaf secret has been DELIVERED
+     *    (`sealed_secret !== null`). A boolean signal ONLY — never the ciphertext.
+     *  - `hub_authorized_at` — the cortex#1498 hub-authorize timestamp, or null.
+     */
+    admission_state?: AdmissionStatus;
+    sealed?: boolean;
+    hub_authorized_at?: string | null;
   }[];
 }
 

--- a/src/surface/mc/__tests__/networks-flg4-roster-states.test.ts
+++ b/src/surface/mc/__tests__/networks-flg4-roster-states.test.ts
@@ -1,0 +1,109 @@
+/**
+ * FLG-4 (docs/plan-mc-future-state.md §4.D) — `handleListNetworks` roster-state
+ * projection + the DAEMON-SIDE SHAPE CONTRACT (the DashboardSnapshot no-interiors
+ * analog for this read, mirroring the FLG-1/FLG-3 contract tests).
+ *
+ * Two load-bearing properties:
+ *   1. `roster_states` flows through the handler verbatim from the read (seal /
+ *      hub-authorize / admission-state incl. departed vs revoked / authorship).
+ *   2. NO SECRET MATERIAL crosses the seam: the wire carries a boolean `sealed`
+ *      signal + a timestamp + a resolved authorship verdict — never a sealed
+ *      ciphertext, a payload key, a PSK, or a raw `{claim, signature}` (invariant
+ *      6 / ADR-0005 no-interiors, enforced here the way the worker's
+ *      `dashboard-snapshot-contract` test enforces it on `/api/state`).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  handleListNetworks,
+  type NetworksView,
+  type ListNetworksResponse,
+} from "../api/networks";
+import type { NetworkConfidentialityPosture } from "../../../common/crypto/network-encryption-policy";
+import type {
+  AdmittedMemberState,
+  ResolveAdmittedRosterResult,
+} from "../../../bus/agent-network/admission-read";
+
+const CLEARTEXT: NetworkConfidentialityPosture = { mode: "off", keyPresent: false, keyId: null };
+
+function viewWithStates(networkId: string, states: AdmittedMemberState[], admitted: string[], pending: string[] = []): NetworksView {
+  const result: ResolveAdmittedRosterResult = {
+    ok: true,
+    roster: { admitted, pending, states, authoritative: true },
+  };
+  return {
+    localPrincipal: "andreas",
+    networks: () => [{ networkId, leafNode: `${networkId}-leaf`, confidentiality: CLEARTEXT }],
+    resolveAdmittedRoster: () => Promise.resolve(result),
+  };
+}
+
+async function body(res: Response): Promise<ListNetworksResponse> {
+  return (await res.json()) as ListNetworksResponse;
+}
+
+const STATES: AdmittedMemberState[] = [
+  { principal_id: "andreas", status: "ADMITTED", sealed: true, hub_authorized_at: "2026-07-08T00:00:00.000Z", authorship: "verified" },
+  { principal_id: "jc", status: "ADMITTED", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+  { principal_id: "leaver", status: "DEPARTED", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+  { principal_id: "kicked", status: "REVOKED", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+];
+
+describe("handleListNetworks — FLG-4 roster_states", () => {
+  it("projects per-member states onto the wire DTO (seal / hub-authorize / state / authorship)", async () => {
+    const res = await handleListNetworks(viewWithStates("metafactory", STATES, ["andreas", "jc"]), null);
+    expect(res.status).toBe(200);
+    const net = (await body(res)).networks[0];
+    expect(net).toBeDefined();
+    const rs = net?.roster_states ?? [];
+    expect(rs).toHaveLength(4);
+
+    const andreas = rs.find((s) => s.principal === "andreas");
+    expect(andreas).toEqual({
+      principal: "andreas",
+      admission_state: "admitted",
+      sealed: true,
+      hub_authorized_at: "2026-07-08T00:00:00.000Z",
+      authorship: "verified",
+    });
+  });
+
+  it("keeps DEPARTED and REVOKED as DISTINCT wire states ('left' ≠ 'kicked')", async () => {
+    const res = await handleListNetworks(viewWithStates("metafactory", STATES, ["andreas", "jc"]), null);
+    const rs = (await body(res)).networks[0]?.roster_states ?? [];
+    expect(rs.find((s) => s.principal === "leaver")?.admission_state).toBe("departed");
+    expect(rs.find((s) => s.principal === "kicked")?.admission_state).toBe("revoked");
+  });
+
+  it("emits an empty roster_states array when the read carries none (honest absence, never omitted)", async () => {
+    const view: NetworksView = {
+      localPrincipal: "andreas",
+      networks: () => [{ networkId: "metafactory", leafNode: "l", confidentiality: CLEARTEXT }],
+      resolveAdmittedRoster: () =>
+        Promise.resolve({ ok: true, roster: { admitted: ["andreas"], pending: [], authoritative: true } }),
+    };
+    const res = await handleListNetworks(view, null);
+    const net = (await body(res)).networks[0];
+    expect(net?.roster_states).toEqual([]);
+  });
+
+  // --- SHAPE CONTRACT: no-interiors / no-secret-material (invariant 6) --------
+  it("SHAPE CONTRACT: no secret material or interior on any roster_state key", async () => {
+    const res = await handleListNetworks(viewWithStates("metafactory", STATES, ["andreas", "jc"]), null);
+    const rs = (await body(res)).networks[0]?.roster_states ?? [];
+    const ALLOWED = new Set(["principal", "admission_state", "sealed", "hub_authorized_at", "authorship"]);
+    const FORBIDDEN = /secret|cipher|payload_key|psk|creds|seed|signature|claim|private|nkey/i;
+    for (const state of rs) {
+      // Exactly the allowed metadata keys — no extra fields leak through.
+      for (const key of Object.keys(state)) {
+        expect(ALLOWED.has(key)).toBe(true);
+      }
+      // `sealed` is a boolean signal, never a string ciphertext.
+      expect(typeof state.sealed).toBe("boolean");
+      // No key or value smells like secret material.
+      const serialized = JSON.stringify(state);
+      expect(FORBIDDEN.test(serialized)).toBe(false);
+    }
+  });
+});

--- a/src/surface/mc/api/networks.ts
+++ b/src/surface/mc/api/networks.ts
@@ -49,7 +49,11 @@
  */
 
 import type { AgentPresenceView } from "./agents";
-import type { ResolveAdmittedRosterResult } from "../../../bus/agent-network/admission-read";
+import type {
+  AdmissionStatus,
+  ResolveAdmittedRosterResult,
+} from "../../../bus/agent-network/admission-read";
+import type { RosterAuthorship } from "../../../bus/agent-network/roster-authorship";
 import type { PeerAcceptance } from "../../../bus/agent-network/peer-acceptance";
 import type {
   EncryptionMode,
@@ -143,6 +147,44 @@ export interface NetworkConfidentialityDTO {
   key_id: string | null;
 }
 
+export type { RosterAuthorship } from "../../../bus/agent-network/roster-authorship";
+
+/**
+ * FLG-4 (docs/plan-mc-future-state.md §4.D) — a member's admission LIFECYCLE
+ * state, snake_case + lower-cased for the wire. Mirrors the registry's
+ * `AdmissionStatus` (incl. the C-1350 `departed` vs `revoked` distinction the
+ * glass must keep visually separable: "left" ≠ "kicked"). `unknown` when a read
+ * cannot resolve the state.
+ */
+export type RosterAdmissionState =
+  | "admitted"
+  | "pending"
+  | "rejected"
+  | "revoked" // admin-kicked
+  | "departed" // voluntary leave
+  | "unknown";
+
+/**
+ * FLG-4 — one member's roster lifecycle STATE on the `/api/networks` wire DTO:
+ * seal-delivery, hub-authorize timestamp, admission state, and the #1600 hub-admin
+ * authorship verdict. METADATA ONLY — no secret material crosses this seam:
+ * `sealed` is a boolean delivery signal (never the ciphertext), and `authorship`
+ * is the RESOLVED tri-state (never the raw `{claim, signature}`). This is the
+ * carrier for BOTH current members (matched to a `MembershipMemberDTO` by
+ * principal) and FORMER members (departed/revoked — not in the reconciled member
+ * set but surfaced honestly as lifecycle state).
+ */
+export interface RosterMemberStateDTO {
+  principal: string;
+  admission_state: RosterAdmissionState;
+  /** Sealed leaf secret DELIVERED (boolean signal; never the ciphertext). */
+  sealed: boolean;
+  /** ISO-8601 UTC the hub-admin authorized this member's leaf, or `null`. */
+  hub_authorized_at: string | null;
+  /** #1600 — hub-admin authorship verdict vs the pinned network-admin pubkey. */
+  authorship: RosterAuthorship;
+}
+
 /** One reconciled roster member, snake_case for the DTO. */
 export interface MembershipMemberDTO {
   principal: string;
@@ -178,6 +220,17 @@ export interface NetworkMembershipDTO {
   confidentiality: NetworkConfidentialityDTO;
   /** Admitted roster reconciled ⋈ presence into per-member verdicts. */
   members: MembershipMemberDTO[];
+  /**
+   * FLG-4 — per-member roster lifecycle states (seal-delivery, hub-authorize
+   * timestamp, admission state incl. departed/revoked, #1600 authorship). Covers
+   * BOTH current members (join to `members[]` by `principal` for the seal/authorize
+   * badges) and FORMER members (departed/revoked — rendered as a distinct former-
+   * members group). `[]` when the read carries no state facets (honest absence).
+   * OPTIONAL on the wire so an older server (pre-FLG-4) that omits it still
+   * deserializes; the daemon handler ALWAYS emits it (possibly `[]`), and the
+   * panel treats absent as `[]`.
+   */
+  roster_states?: RosterMemberStateDTO[];
 }
 
 /** `GET /api/networks` response body. */
@@ -190,6 +243,44 @@ function failureStatus(
   reason: "unreachable" | "unauthorized" | "not_configured",
 ): RosterStatus {
   return reason;
+}
+
+/** FLG-4 — map the registry `AdmissionStatus` → the lower-cased wire state. */
+function toWireAdmissionState(status: AdmissionStatus): RosterAdmissionState {
+  switch (status) {
+    case "ADMITTED":
+      return "admitted";
+    case "PENDING":
+      return "pending";
+    case "REJECTED":
+      return "rejected";
+    case "REVOKED":
+      return "revoked";
+    case "DEPARTED":
+      return "departed";
+  }
+}
+
+/**
+ * FLG-4 — project an admission-read `AdmittedMemberState` → the metadata-only
+ * {@link RosterMemberStateDTO}. Total over the status union (compiler-enforced via
+ * {@link toWireAdmissionState}). Carries NO secret material: `sealed` is a boolean,
+ * `authorship` is the resolved verdict string.
+ */
+function toRosterMemberStateDTO(s: {
+  principal_id: string;
+  status: AdmissionStatus;
+  sealed: boolean;
+  hub_authorized_at: string | null;
+  authorship: RosterAuthorship;
+}): RosterMemberStateDTO {
+  return {
+    principal: s.principal_id,
+    admission_state: toWireAdmissionState(s.status),
+    sealed: s.sealed,
+    hub_authorized_at: s.hub_authorized_at,
+    authorship: s.authorship,
+  };
 }
 
 /**
@@ -267,6 +358,11 @@ export async function handleListNetworks(
       let pending: string[] = [];
       let rosterStatus: RosterStatus;
       let rosterScope: RosterScope | null;
+      // FLG-4 — per-member lifecycle states, projected verbatim from the read
+      // (empty for a failed/facet-less read — honest absence).
+      const rosterStates: RosterMemberStateDTO[] = result.ok
+        ? (result.roster.states ?? []).map(toRosterMemberStateDTO)
+        : [];
 
       if (result.ok) {
         for (const p of result.roster.admitted) admitted.push(p);
@@ -316,6 +412,7 @@ export async function handleListNetworks(
                 ? "self"
                 : "not-accepted",
         })),
+        roster_states: rosterStates,
       };
     });
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-roster-panel-flg4.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-roster-panel-flg4.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * FLG-4 — NetworkRosterPanel render tests for the roster-state row (seal /
+ * hub-authorize / authorship) and the FORMER-members group. The panel is pure,
+ * so it renders under `renderToStaticMarkup`.
+ *
+ * Acceptance-critical assertions:
+ *   - a member's seal + hub-authorize timestamp + #1600 authorship render on the row;
+ *   - DEPARTED ('left') is visually SEPARABLE from REVOKED ('kicked') — distinct
+ *     `data-admission-state` tokens + labels in a dedicated former-members group;
+ *   - depart/leave/retire appear as STATE ONLY — the former group carries no
+ *     button affordance (retire is root-seed-signed; leave/depart are CLI-side).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { NetworkRosterPanel } from "../components/network-roster-panel";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import type { NetworkConfidentialityDTO, RosterMemberStateDTO } from "../../api/networks";
+
+const CLEARTEXT: NetworkConfidentialityDTO = { mode: "off", key_present: false, key_id: null };
+
+function net(states: RosterMemberStateDTO[]): NetworkMembershipDTO {
+  return {
+    network_id: "metafactory",
+    leaf_node: "metafactory-leaf",
+    roster_status: "ok",
+    roster_scope: "complete",
+    confidentiality: CLEARTEXT,
+    members: [
+      { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
+      { principal: "jc", verdict: "admitted-absent", present_stacks: [], accepts: "accepted-network" },
+    ],
+    roster_states: states,
+  };
+}
+
+function render(dto: NetworkMembershipDTO): string {
+  return renderToStaticMarkup(
+    createElement(NetworkRosterPanel, { networks: [dto], localPrincipal: "andreas" }),
+  );
+}
+
+const STATES: RosterMemberStateDTO[] = [
+  { principal: "andreas", admission_state: "admitted", sealed: true, hub_authorized_at: "2026-07-08T00:00:00.000Z", authorship: "verified" },
+  { principal: "jc", admission_state: "admitted", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+  { principal: "leaver", admission_state: "departed", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+  { principal: "kicked", admission_state: "revoked", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+];
+
+describe("NetworkRosterPanel — FLG-4 roster states", () => {
+  it("renders seal, hub-authorize timestamp, and #1600 authorship on the member row", () => {
+    const html = render(net(STATES));
+    expect(html).toContain('data-seal="sealed"');
+    expect(html).toContain("2026-07-08T00:00:00.000Z");
+    expect(html).toContain('data-hub-authorized="true"');
+    expect(html).toContain('data-authorship="verified"');
+  });
+
+  it("renders unsealed / hub-authorize-pending / authorship-unchecked honestly for a member without progress", () => {
+    const html = render(net(STATES));
+    expect(html).toContain('data-seal="unsealed"');
+    expect(html).toContain('data-hub-authorized="false"');
+    expect(html).toContain('data-authorship="unchecked"');
+    // Honesty: unchecked authorship must not be dressed up as verified.
+    expect(html).not.toContain('data-authorship="verified"><');
+  });
+
+  it("keeps DEPARTED ('left') visually separable from REVOKED ('kicked')", () => {
+    const html = render(net(STATES));
+    expect(html).toContain('data-admission-state="departed"');
+    expect(html).toContain('data-admission-state="revoked"');
+    expect(html).toContain(">left<");
+    expect(html).toContain(">revoked<");
+    // Distinct CSS tones (warn for departed, danger for revoked).
+    expect(html).toContain("network-roster-badge tone-warn");
+    expect(html).toContain("network-roster-badge tone-danger");
+  });
+
+  it("surfaces former members as STATE ONLY — no button/verb affordance", () => {
+    const html = render(net(STATES));
+    expect(html).toContain("network-roster-former");
+    expect(html).toContain("Former members");
+    expect(html.toLowerCase()).toContain("cli-side by design");
+    // No interactive control is rendered WITHIN the former-members group (the
+    // panel elsewhere has the FLG-3 doctor button — that's a different feature).
+    const formerStart = html.indexOf('class="network-roster-former"');
+    expect(formerStart).toBeGreaterThan(-1);
+    const formerRegion = html.slice(formerStart);
+    expect(formerRegion).not.toContain("<button");
+    expect(formerRegion).not.toContain("<input");
+  });
+
+  it("renders no state badges when the read carries no roster_states (honest absence)", () => {
+    const html = render(net([]));
+    expect(html).not.toContain("data-seal=");
+    expect(html).not.toContain("data-authorship=");
+    expect(html).not.toContain("network-roster-former");
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
@@ -17,7 +17,12 @@
 import type { NetworkMembershipDTO } from "../hooks/use-networks";
 import {
   acceptanceBadge,
+  admissionStateBadge,
+  authorshipBadge,
   confidentialityBadge,
+  formatHubAuthorized,
+  partitionRosterStates,
+  sealBadge,
   verdictBadge,
   rosterStatusBadge,
   summarizeMembership,
@@ -65,6 +70,11 @@ export function NetworkRosterPanel({
           const status = rosterStatusBadge(net.roster_status, net.roster_scope);
           const confidentiality = confidentialityBadge(net.confidentiality);
           const summary = summarizeMembership(net);
+          // FLG-4 — per-member lifecycle states: seal/authorize/authorship badges
+          // on live rows (keyed by principal), plus FORMER members (departed vs
+          // revoked, kept visually distinct) rendered as a separate group.
+          const { byPrincipal: stateByPrincipal, former: formerMembers } =
+            partitionRosterStates(net.roster_states ?? []);
           return (
             <li key={net.network_id} className="network-roster-group">
               <div className="network-roster-group-header">
@@ -115,6 +125,13 @@ export function NetworkRosterPanel({
                     const badge = verdictBadge(m.verdict);
                     const acceptance = acceptanceBadge(m.accepts);
                     const isYou = localPrincipal !== null && m.principal === localPrincipal;
+                    // FLG-4 — the member's lifecycle state (seal / hub-authorize /
+                    // authorship), when the read carries it. Absent ⇒ no extra
+                    // badges (honest: pre-FLG-4 server or facet-less read).
+                    const st = stateByPrincipal.get(m.principal);
+                    const seal = st ? sealBadge(st.sealed) : null;
+                    const hubAuth = st ? formatHubAuthorized(st.hub_authorized_at) : null;
+                    const authorship = st ? authorshipBadge(st.authorship) : null;
                     return (
                       <li
                         key={m.principal}
@@ -145,6 +162,34 @@ export function NetworkRosterPanel({
                             {acceptance.label}
                           </span>
                         ) : null}
+                        {/* FLG-4 — seal delivery + hub-authorize + #1600 authorship. */}
+                        {seal ? (
+                          <span
+                            className={`network-roster-seal tone-${seal.tone}`}
+                            data-seal={seal.token}
+                            title={seal.title}
+                          >
+                            {seal.label}
+                          </span>
+                        ) : null}
+                        {hubAuth ? (
+                          <span
+                            className={`network-roster-hubauth ${hubAuth.authorized ? "tone-ok" : "tone-warn"}`}
+                            data-hub-authorized={hubAuth.authorized ? "true" : "false"}
+                            title={hubAuth.title}
+                          >
+                            {hubAuth.label}
+                          </span>
+                        ) : null}
+                        {authorship ? (
+                          <span
+                            className={`network-roster-authorship tone-${authorship.tone}`}
+                            data-authorship={authorship.token}
+                            title={authorship.title}
+                          >
+                            {authorship.label}
+                          </span>
+                        ) : null}
                         {m.present_stacks.length > 0 ? (
                           <span className="dim network-roster-stacks">
                             {m.present_stacks.join(", ")}
@@ -155,6 +200,34 @@ export function NetworkRosterPanel({
                   })}
                 </ul>
               )}
+              {/* FLG-4 — FORMER members (departed vs revoked, kept visually
+                  distinct). Depart/leave/retire are surfaced as STATE ONLY —
+                  there are NO glass verbs here (retire is root-seed-signed and
+                  never a button; leave/depart are CLI-side by design). */}
+              {formerMembers.length > 0 ? (
+                <div className="network-roster-former" data-former-count={formerMembers.length}>
+                  <div className="dim network-roster-former-title">
+                    Former members <span className="dim">— state only (leave / retire are CLI-side by design)</span>
+                  </div>
+                  <ul className="network-roster-members network-roster-former-list">
+                    {formerMembers.map((f) => {
+                      const stateBadge = admissionStateBadge(f.admission_state);
+                      return (
+                        <li key={`former:${f.principal}`} className="network-roster-member network-roster-former-member">
+                          <span className="network-roster-principal">{f.principal}</span>
+                          <span
+                            className={`network-roster-badge tone-${stateBadge.tone}`}
+                            data-admission-state={stateBadge.token}
+                            title={stateBadge.title}
+                          >
+                            {stateBadge.label}
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ) : null}
             </li>
           );
         })}

--- a/src/surface/mc/dashboard-v2/lib/__tests__/network-membership-adapter-flg4.test.ts
+++ b/src/surface/mc/dashboard-v2/lib/__tests__/network-membership-adapter-flg4.test.ts
@@ -1,0 +1,83 @@
+/**
+ * FLG-4 — tests for the roster-state presentation adapters. The acceptance-
+ * critical property: `departed` ("left") is VISUALLY SEPARABLE from `revoked`
+ * ("kicked") — distinct label, tone, and stable token. Plus the #1600 authorship
+ * honesty (verified only shows for a real pass) and the former-member partition.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  admissionStateBadge,
+  authorshipBadge,
+  sealBadge,
+  formatHubAuthorized,
+  isFormerMemberState,
+  partitionRosterStates,
+} from "../network-membership-adapter";
+import type { RosterMemberStateDTO } from "../../../api/networks";
+
+describe("admissionStateBadge — departed ≠ revoked (FLG-4 honesty)", () => {
+  it("departed reads 'left', revoked reads 'revoked', with different tones + tokens", () => {
+    const left = admissionStateBadge("departed");
+    const kicked = admissionStateBadge("revoked");
+    expect(left.label).toBe("left");
+    expect(kicked.label).toBe("revoked");
+    expect(left.token).toBe("departed");
+    expect(kicked.token).toBe("revoked");
+    // Distinct tones — the two states are never rendered identically.
+    expect(left.tone).not.toBe(kicked.tone);
+  });
+
+  it("covers every state without falling through", () => {
+    for (const s of ["admitted", "pending", "departed", "revoked", "rejected", "unknown"] as const) {
+      expect(admissionStateBadge(s).label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("authorshipBadge — #1600 honesty", () => {
+  it("verified is 'ok', unverifiable is 'danger', unchecked is 'warn' (never a fabricated pass)", () => {
+    expect(authorshipBadge("verified").tone).toBe("ok");
+    expect(authorshipBadge("unverifiable").tone).toBe("danger");
+    expect(authorshipBadge("unchecked").tone).toBe("warn");
+    // unchecked must NOT read as verified.
+    expect(authorshipBadge("unchecked").label.toLowerCase()).not.toContain("verified authorship");
+    expect(authorshipBadge("unchecked").token).toBe("unchecked");
+  });
+});
+
+describe("sealBadge + formatHubAuthorized", () => {
+  it("sealed vs unsealed carry distinct tokens", () => {
+    expect(sealBadge(true).token).toBe("sealed");
+    expect(sealBadge(false).token).toBe("unsealed");
+  });
+  it("hub-authorize surfaces the timestamp verbatim or a pending label", () => {
+    expect(formatHubAuthorized("2026-07-08T00:00:00.000Z").authorized).toBe(true);
+    expect(formatHubAuthorized("2026-07-08T00:00:00.000Z").label).toContain("2026-07-08T00:00:00.000Z");
+    expect(formatHubAuthorized(null).authorized).toBe(false);
+    expect(formatHubAuthorized(null).label).toContain("pending");
+  });
+});
+
+describe("partitionRosterStates", () => {
+  const states: RosterMemberStateDTO[] = [
+    { principal: "andreas", admission_state: "admitted", sealed: true, hub_authorized_at: null, authorship: "unchecked" },
+    { principal: "newcomer", admission_state: "pending", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+    { principal: "leaver", admission_state: "departed", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+    { principal: "kicked", admission_state: "revoked", sealed: false, hub_authorized_at: null, authorship: "unchecked" },
+  ];
+
+  it("splits former members (departed/revoked/rejected) from current, keyed by principal", () => {
+    const { byPrincipal, former } = partitionRosterStates(states);
+    expect([...byPrincipal.keys()].sort()).toEqual(["andreas", "newcomer"]);
+    expect(former.map((f) => f.principal).sort()).toEqual(["kicked", "leaver"]);
+  });
+
+  it("isFormerMemberState classifies correctly", () => {
+    expect(isFormerMemberState("departed")).toBe(true);
+    expect(isFormerMemberState("revoked")).toBe(true);
+    expect(isFormerMemberState("rejected")).toBe(true);
+    expect(isFormerMemberState("admitted")).toBe(false);
+    expect(isFormerMemberState("pending")).toBe(false);
+  });
+});

--- a/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
@@ -14,6 +14,9 @@ import type {
   NetworkConfidentialityDTO,
   NetworkMembershipDTO,
   PeerAcceptance,
+  RosterAdmissionState,
+  RosterAuthorship,
+  RosterMemberStateDTO,
   RosterStatus,
   RosterScope,
 } from "../../api/networks";
@@ -282,6 +285,187 @@ export function confidentialityBadge(
       };
     }
   }
+}
+
+// --- FLG-4: per-member roster lifecycle state (seal / authorize / departed) ---
+
+/**
+ * A render-ready admission-state badge. The load-bearing distinction FLG-4
+ * demands: `departed` ("left") is visually SEPARABLE from `revoked` ("kicked") —
+ * different label, different tone, different stable token — so the glass never
+ * blurs a voluntary leave into an admin kick.
+ */
+export interface AdmissionStateBadge {
+  label: string;
+  tone: VerdictTone;
+  /** Stable token (data-* / tests); never localized. */
+  token: RosterAdmissionState;
+  title: string;
+}
+
+/**
+ * Map a member's {@link RosterAdmissionState} → a badge. Total over the union
+ * (compiler-enforced via the `never` guard), so a new state cannot silently fall
+ * through. `departed` vs `revoked` are deliberately given DIFFERENT tones + labels
+ * (the FLG-4 honesty invariant: "left" ≠ "kicked").
+ */
+export function admissionStateBadge(state: RosterAdmissionState): AdmissionStateBadge {
+  switch (state) {
+    case "admitted":
+      return { label: "admitted", tone: "ok", token: "admitted", title: "Admitted to the network roster" };
+    case "pending":
+      return { label: "pending", tone: "pending", token: "pending", title: "Admission request pending — not yet admitted" };
+    case "departed":
+      return {
+        label: "left",
+        tone: "warn",
+        token: "departed",
+        title:
+          "DEPARTED — this member left the network voluntarily (ADMITTED → DEPARTED). A voluntary leave, NOT an admin kick.",
+      };
+    case "revoked":
+      return {
+        label: "revoked",
+        tone: "danger",
+        token: "revoked",
+        title:
+          "REVOKED — an admin kicked this member from the network (admin-signed revoke). Distinct from a voluntary 'left'.",
+      };
+    case "rejected":
+      return {
+        label: "rejected",
+        tone: "danger",
+        token: "rejected",
+        title: "REJECTED — this admission request was declined by an admin (never admitted).",
+      };
+    case "unknown":
+      return {
+        label: "state unknown",
+        tone: "warn",
+        token: "unknown",
+        title: "Admission state not resolvable from the current read — not assumed admitted.",
+      };
+    default: {
+      const _exhaustive: never = state;
+      return {
+        label: "state unknown",
+        tone: "warn",
+        token: "unknown",
+        title: `Unrecognized admission state '${String(_exhaustive)}' — not assumed admitted.`,
+      };
+    }
+  }
+}
+
+/** A render-ready seal-delivery badge. */
+export interface SealBadge {
+  label: string;
+  tone: VerdictTone;
+  /** Stable token (data-* / tests). */
+  token: "sealed" | "unsealed";
+  title: string;
+}
+
+/**
+ * Map the boolean seal-delivery signal → a badge. `sealed` is a DELIVERY signal
+ * only (a leaf secret ciphertext has been placed on the row) — never the secret
+ * itself. An admitted member with no sealed delivery is a real, honest state
+ * (the handoff's seal leg is still outstanding), shown as `warn`.
+ */
+export function sealBadge(sealed: boolean): SealBadge {
+  return sealed
+    ? { label: "sealed", tone: "ok", token: "sealed", title: "A sealed leaf secret has been delivered onto this member's row (delivery signal only — never the secret)." }
+    : { label: "unsealed", tone: "warn", token: "unsealed", title: "No sealed leaf secret delivered yet — the guided-join seal leg is still outstanding." };
+}
+
+/**
+ * Format the hub-authorize timestamp for display, or a stable "not authorized"
+ * label when `null`. Kept pure (no `toLocaleString` locale drift in tests): the
+ * ISO string is surfaced verbatim, the UI can prettify in the DOM layer.
+ */
+export function formatHubAuthorized(ts: string | null): { label: string; authorized: boolean; title: string } {
+  return ts === null
+    ? { label: "hub-authorize pending", authorized: false, title: "The hub owner has not yet authorized this member's leaf (no hub_authorized_at)." }
+    : { label: `hub-authorized ${ts}`, authorized: true, title: `Hub owner authorized this member's leaf at ${ts} (cortex#1498).` };
+}
+
+/** A render-ready #1600 authorship badge. */
+export interface AuthorshipBadge {
+  label: string;
+  tone: VerdictTone;
+  /** Stable token (data-* / tests). */
+  token: RosterAuthorship;
+  title: string;
+}
+
+/**
+ * Map the #1600 hub-admin authorship verdict → a badge. The honesty invariant:
+ * `verified` is shown ONLY when the daemon actually ran the signature check and
+ * it passed; `unverifiable` is a surfaced NEGATIVE (checked, did not pass);
+ * `unchecked` is an honest gap (no pinned admin key / no material) — NEVER
+ * dressed up as a pass. Total over the union (compiler-enforced).
+ */
+export function authorshipBadge(a: RosterAuthorship): AuthorshipBadge {
+  switch (a) {
+    case "verified":
+      return {
+        label: "authorship verified",
+        tone: "ok",
+        token: "verified",
+        title: "The hub-admin's signature on this member's sealed row verified against the pinned network-admin pubkey (#1600).",
+      };
+    case "unverifiable":
+      return {
+        label: "authorship UNVERIFIABLE",
+        tone: "danger",
+        token: "unverifiable",
+        title: "The hub-admin authorship signature did NOT verify against the pinned network-admin pubkey (mismatched admin or bad signature). Treat with suspicion (#1600).",
+      };
+    case "unchecked":
+      return {
+        label: "authorship unchecked",
+        tone: "warn",
+        token: "unchecked",
+        title: "Authorship not checked — no pinned network-admin pubkey configured, or the row carries no hub-admin {claim, signature}. Not a pass and not a failure (#1600).",
+      };
+    default: {
+      const _exhaustive: never = a;
+      return {
+        label: "authorship unchecked",
+        tone: "warn",
+        token: "unchecked",
+        title: `Unrecognized authorship verdict '${String(_exhaustive)}' — not assumed verified.`,
+      };
+    }
+  }
+}
+
+/** Whether an admission state denotes a FORMER member (left / kicked / declined). */
+export function isFormerMemberState(state: RosterAdmissionState): boolean {
+  return state === "departed" || state === "revoked" || state === "rejected";
+}
+
+/**
+ * Partition a network's `roster_states` into current-member states (keyed by
+ * principal for the seal/authorize/authorship badges on live rows) and FORMER
+ * members (departed/revoked/rejected — rendered as a distinct group). Pure.
+ */
+export function partitionRosterStates(states: readonly RosterMemberStateDTO[]): {
+  byPrincipal: Map<string, RosterMemberStateDTO>;
+  former: RosterMemberStateDTO[];
+} {
+  const byPrincipal = new Map<string, RosterMemberStateDTO>();
+  const former: RosterMemberStateDTO[] = [];
+  for (const s of states) {
+    if (isFormerMemberState(s.admission_state)) {
+      former.push(s);
+    } else {
+      // First-seen wins (matches the server-side dedupe); don't let a later
+      // duplicate silently overwrite the canonical current state.
+      if (!byPrincipal.has(s.principal)) byPrincipal.set(s.principal, s);
+    }
+  }
+  return { byPrincipal, former };
 }
 
 /** Per-verdict counts for a network's member set (for the panel summary). */


### PR DESCRIPTION
R1 slice **FLG-4** — the last read-glass slice. Mirrors the FLG-1/FLG-3 read pattern (metadata-only DTO through the guard, daemon-side shape-contract test, GET/not-identity-gated, honest degradation).

- **Per-member states:** `/api/networks` DTO gains `roster_states[]` (seal-delivery, `hub_authorized_at`, admission state) via the existing `resolveAdmittedRoster` seam (not bloating the static `JoinedNetworkInfo`).
- **DEPARTED ≠ REVOKED:** a distinct 'Former members' group renders `left` (warn) vs `revoked` (danger); depart/leave/retire are STATE-ONLY, no buttons.
- **§3.5 / #1600 authorship:** `verifyRosterAuthorship` → honest tri-state **verified / unverifiable / unchecked**; never 'verified' without a real Ed25519 pass against the *pinned* admin key.
- tsc 0; eslint clean; vocab PASS; FLG-4 39/39 + 252 touched + 333 registry tests. Display-only (no interactions) → render test covers the exact DOM.

**Honest gaps (follow-ups, not defects — the logic ships correct + degrades honestly):** #1600 authorship resolves `unchecked` until (a) the registry persists the hub-admin `{claim,signature}` on the sealed row + (b) a per-network admin-pubkey pin config exists (filing both under #1600). Former-member live data flows when FLG-5 wires the admin-list. Per-member peer state needs a registry deploy (principal-hands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)