### PR TITLE
feat(mc): CK-6b — attention resolve/dismiss buttons (render half) (R2)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/attention-view.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/attention-view.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * CK-6b (cortex#1289 Track A) — attention lifecycle render tests.
+ *
+ * Pins the render half of the resolve/dismiss affordance:
+ *   - Resolve + Dismiss buttons render when the host wires `onLifecycle`, and
+ *     each button drives the callback with the right `(id, action)` (the CK-6a
+ *     `POST /api/attention/:id/{resolve,dismiss}` contract).
+ *   - No mutation affordance when `onLifecycle` is omitted (read-only queue —
+ *     the legacy tab / a scope with no host handler).
+ *   - TRUTH-NOT-THEATER: NO Approve/Deny affordance is EVER rendered. Approve/
+ *     Deny is SPX-7/SPX-8 (the runner arbitration channel doesn't exist yet), so
+ *     shipping those buttons would be theater. This test is the standing guard.
+ *
+ * DOM-free, matching the suite convention (`renderToStaticMarkup` + a direct
+ * element-tree walk of the pure component — AttentionView uses no hooks).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement, isValidElement, type ReactElement, type ReactNode } from "react";
+import { AttentionView, type AttentionViewProps } from "../components/attention-view";
+import type { AttentionEntry } from "../../api/attention";
+
+function attn(id: string, over: Partial<AttentionEntry["item"]> = {}): AttentionEntry {
+  return {
+    item: {
+      id,
+      stackId: "meta-factory",
+      workItemId: null,
+      sessionId: null,
+      kind: "review",
+      severity: "high",
+      status: "open",
+      ...over,
+    },
+    link: { kind: "none" },
+  };
+}
+
+/** Flatten a React children blob (element | array | string | null) to a list. */
+function childList(children: ReactNode): ReactNode[] {
+  if (Array.isArray(children)) return children.flatMap(childList);
+  return children == null || children === false ? [] : [children];
+}
+
+/** Recursively collect every intrinsic element of `tag` in a rendered tree. */
+function collect(node: ReactNode, tag: string, acc: ReactElement[] = []): ReactElement[] {
+  if (!isValidElement(node)) return acc;
+  const el = node as ReactElement<{ children?: ReactNode }>;
+  if (el.type === tag) acc.push(el);
+  for (const child of childList(el.props?.children)) collect(child, tag, acc);
+  return acc;
+}
+
+/** Render the pure component to its element tree (no DOM needed). */
+function tree(over: Partial<AttentionViewProps>): ReactElement {
+  const props: AttentionViewProps = { entries: [], loaded: true, ...over };
+  return AttentionView(props) as ReactElement;
+}
+
+function buttonsByClass(el: ReactElement, cls: string): ReactElement<{ className?: string; onClick?: () => void }>[] {
+  return collect(el, "button").filter((b) =>
+    ((b.props as { className?: string }).className ?? "").includes(cls),
+  ) as ReactElement<{ className?: string; onClick?: () => void }>[];
+}
+
+describe("AttentionView — CK-6b lifecycle buttons", () => {
+  it("renders Resolve + Dismiss for each open item when onLifecycle is wired", () => {
+    const html = renderToStaticMarkup(
+      createElement(AttentionView, {
+        entries: [attn("a1"), attn("a2")],
+        loaded: true,
+        onLifecycle: () => {},
+      }),
+    );
+    expect(html).toContain("attention-resolve");
+    expect(html).toContain("attention-dismiss");
+    expect(html).toContain("Resolve");
+    expect(html).toContain("Dismiss");
+    // one Resolve + one Dismiss per open item.
+    expect((html.match(/attention-resolve/g) ?? []).length).toBe(2);
+    expect((html.match(/attention-dismiss/g) ?? []).length).toBe(2);
+  });
+
+  it("renders NO lifecycle buttons when onLifecycle is omitted (read-only queue)", () => {
+    const html = renderToStaticMarkup(
+      createElement(AttentionView, { entries: [attn("a1")], loaded: true }),
+    );
+    expect(html).not.toContain("attention-action");
+    expect(html).not.toContain("attention-resolve");
+    expect(html).not.toContain("attention-dismiss");
+  });
+
+  it("wires Resolve → onLifecycle(id,'resolve') and Dismiss → onLifecycle(id,'dismiss')", () => {
+    const calls: Array<[string, "resolve" | "dismiss"]> = [];
+    const el = tree({
+      entries: [attn("attn-42")],
+      onLifecycle: (id, action) => calls.push([id, action]),
+    });
+    buttonsByClass(el, "attention-resolve")[0]!.props.onClick?.();
+    buttonsByClass(el, "attention-dismiss")[0]!.props.onClick?.();
+    expect(calls).toEqual([
+      ["attn-42", "resolve"],
+      ["attn-42", "dismiss"],
+    ]);
+  });
+
+  it("TRUTH-NOT-THEATER — never renders an Approve/Deny affordance", () => {
+    // Wired (buttons present) is the worst case for leaking a theater verb.
+    const html = renderToStaticMarkup(
+      createElement(AttentionView, {
+        entries: [attn("a1"), attn("a2", { kind: "permission" }), attn("a3", { kind: "input_needed" })],
+        loaded: true,
+        onLifecycle: () => {},
+      }),
+    );
+    const lower = html.toLowerCase();
+    expect(lower).not.toContain("approve");
+    expect(lower).not.toContain("deny");
+    // And no button carries an approve/deny handle at the element level.
+    const el = tree({ entries: [attn("a1")], onLifecycle: () => {} });
+    expect(buttonsByClass(el, "approve").length).toBe(0);
+    expect(buttonsByClass(el, "deny").length).toBe(0);
+    // The full lifecycle surface is exactly {resolve, dismiss}.
+    expect(buttonsByClass(el, "attention-resolve").length).toBe(1);
+    expect(buttonsByClass(el, "attention-dismiss").length).toBe(1);
+  });
+
+  it("keeps the deep-link button alongside the lifecycle actions", () => {
+    const entry: AttentionEntry = {
+      item: attn("wi-1").item,
+      link: { kind: "work-item", workItemId: "wi-1", label: "Fix the thing" },
+    };
+    const html = renderToStaticMarkup(
+      createElement(AttentionView, {
+        entries: [entry],
+        loaded: true,
+        onOpenWorkItem: () => {},
+        onLifecycle: () => {},
+      }),
+    );
+    expect(html).toContain("attention-link");
+    expect(html).toContain("Fix the thing");
+    expect(html).toContain("attention-resolve");
+    expect(html).toContain("attention-dismiss");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/mc-cockpit.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/mc-cockpit.test.tsx
@@ -154,6 +154,27 @@ describe("McCockpit — own-local stack", () => {
     expect(html).toContain("No local agent online to dispatch");
   });
 
+  it("CK-6b — renders Resolve/Dismiss on the ATTENTION lane when onAttentionLifecycle is wired", () => {
+    const html = render({
+      attention: [attn("mine", "meta-factory")],
+      onAttentionLifecycle: () => {},
+    });
+    expect(html).toContain("attention-resolve");
+    expect(html).toContain("attention-dismiss");
+    expect(html).toContain("Resolve");
+    expect(html).toContain("Dismiss");
+    // truth-not-theater: no Approve/Deny leaks through the fold.
+    expect(html.toLowerCase()).not.toContain("approve");
+    expect(html.toLowerCase()).not.toContain("deny");
+    expect(html).not.toContain(FORBIDDEN);
+  });
+
+  it("CK-6b — renders NO lifecycle buttons when onAttentionLifecycle is omitted", () => {
+    const html = render({ attention: [attn("mine", "meta-factory")] });
+    expect(html).not.toContain("attention-action");
+    expect(html).not.toContain("attention-resolve");
+  });
+
   it("renders the CK-4b cross-stack 'Across stacks' lane above the LOCAL grid", () => {
     const html = render({
       workingAggregation: [
@@ -187,6 +208,21 @@ describe("McCockpit — federated peer (ADR-0005)", () => {
     expect(html).not.toContain("attention-view");
     expect(html).not.toContain("working-grid-section");
     expect(html).not.toContain("dispatch-btn");
+  });
+
+  it("CK-6b — never renders resolve/dismiss for a federated peer (ADR-0005 scope)", () => {
+    // Even with the lifecycle handler wired + open items, a peer bottoms out at
+    // the aggregate notice — its attention interior (and mutations) never render.
+    const html = render({
+      stack: PEER,
+      posture: "member",
+      attention: [attn("theirs", "home")],
+      onAttentionLifecycle: () => {},
+    });
+    expect(html).toContain("AGGREGATE ONLY");
+    expect(html).not.toContain("attention-resolve");
+    expect(html).not.toContain("attention-dismiss");
+    expect(html).not.toContain("attention-action");
   });
 
   it("does NOT render the CK-4b cross-stack lane for a federated peer", () => {

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -669,6 +669,36 @@ export function App() {
               setWorkItemBackView("network");
               setView("work-item-detail");
             }}
+            // CK-6b — resolve/dismiss an attention item via the CK-6a route
+            // (`POST /api/attention/:id/{resolve,dismiss}` over `db/attention
+            // setStatus`), gated by FND-6 identity. App owns the call + identity
+            // context (mirrors `onDispatchDirect`). Optimistic: drop the row now,
+            // then reconcile — `refetch` restores it if the POST failed (the item
+            // is still `open` server-side). Approve/Deny is NOT wired (SPX-7/SPX-8).
+            onAttentionLifecycle={async (attentionId, action) => {
+              attention.dropOptimistic(attentionId);
+              try {
+                await postJson<Record<string, never>, unknown>(
+                  `/api/attention/${encodeURIComponent(attentionId)}/${action}`,
+                  {},
+                );
+                showToast(
+                  action === "resolve" ? "Attention resolved" : "Attention dismissed",
+                  "ok",
+                );
+              } catch (e) {
+                const msg =
+                  e instanceof ApiFailure
+                    ? e.info.message
+                    : e instanceof Error
+                      ? e.message
+                      : String(e);
+                showToast(`Could not ${action} attention: ${msg}`, "error");
+              } finally {
+                // Reconcile with server truth (restores the row on failure).
+                attention.refetch();
+              }
+            }}
             onViewInWorkingGrid={() => setView("default")}
             // CK-1 (cortex#1289) — diving the altitude rail to SESSION (an
             // own-local assistant's session) opens the REUSED F-7 drill-down —

--- a/src/surface/mc/dashboard-v2/components/attention-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/attention-view.tsx
@@ -22,9 +22,24 @@ export interface AttentionViewProps {
   onOpenWorkItem?: (workItemId: string) => void;
   /** Open the drill-down for an assignment (E.3 deep-link for session items). */
   onOpenAssignment?: (assignmentId: string) => void;
+  /**
+   * CK-6b — the attention lifecycle affordance. When wired (the cockpit's
+   * own-local ATTENTION lane), each open item renders **Resolve** / **Dismiss**
+   * buttons that drive the CK-6a `POST /api/attention/:id/{resolve,dismiss}`
+   * route through the host (App owns the call + FND-6 identity context, exactly
+   * like the DISPATCH verb). Omitted ⇒ read-only queue (the legacy tab, a
+   * federated-peer scope) — no mutation affordance renders.
+   *
+   * TRUTH-NOT-THEATER: this is the FULL set of lifecycle affordances for the
+   * slice. **Approve/Deny is deliberately absent** — it is SPX-7/SPX-8 (the
+   * runner arbitration channel + escalation envelope don't exist yet), so an
+   * Approve/Deny button here would be theater. Do not add one until that channel
+   * lands. See plan §4.A note under the Track A table.
+   */
+  onLifecycle?: (attentionId: string, action: "resolve" | "dismiss") => void;
 }
 
-export function AttentionView({ entries, loaded, onOpenWorkItem, onOpenAssignment }: AttentionViewProps) {
+export function AttentionView({ entries, loaded, onOpenWorkItem, onOpenAssignment, onLifecycle }: AttentionViewProps) {
   return (
     <section className="scaffold-section attention-view" aria-label="Attention">
       <h2>
@@ -54,6 +69,29 @@ export function AttentionView({ entries, loaded, onOpenWorkItem, onOpenAssignmen
                 ) : (
                   <span className="dim faint">{link.kind === "work-item" ? link.label : "—"}</span>
                 )}
+                {/*
+                  CK-6b — Resolve / Dismiss ONLY. No Approve/Deny here (theater
+                  until the SPX-7/SPX-8 arbitration channel exists). Optimistic
+                  removal + server reconcile is the host's job (App owns the call).
+                */}
+                {onLifecycle ? (
+                  <span className="attention-actions">
+                    <button
+                      type="button"
+                      className="attention-action attention-resolve"
+                      onClick={() => onLifecycle(item.id, "resolve")}
+                    >
+                      Resolve
+                    </button>
+                    <button
+                      type="button"
+                      className="attention-action attention-dismiss"
+                      onClick={() => onLifecycle(item.id, "dismiss")}
+                    >
+                      Dismiss
+                    </button>
+                  </span>
+                ) : null}
               </li>
             );
           })}

--- a/src/surface/mc/dashboard-v2/components/mc-cockpit.css
+++ b/src/surface/mc/dashboard-v2/components/mc-cockpit.css
@@ -113,6 +113,31 @@
 .mc-cockpit .attention-link:hover {
   text-decoration: underline;
 }
+/* CK-6b — resolve / dismiss lifecycle buttons (own-local stack only). */
+.mc-cockpit .attention-actions {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 6px;
+}
+.mc-cockpit .attention-action {
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: var(--dim);
+  font: 600 9px var(--mono);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  cursor: pointer;
+}
+.mc-cockpit .attention-action:hover {
+  color: var(--fg);
+  border-color: var(--fg);
+}
+.mc-cockpit .attention-resolve:hover {
+  color: var(--ok);
+  border-color: var(--ok);
+}
 
 /* ── WORKING lane ─────────────────────────────────────────────────────────── */
 /* Single-column tiles — the dock is narrow, so the multi-column grid collapses. */

--- a/src/surface/mc/dashboard-v2/components/mc-cockpit.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-cockpit.tsx
@@ -87,6 +87,15 @@ export interface McCockpitProps {
   /** Open the work-item-detail surface (attention work-item deep link). */
   onOpenWorkItem?: (workItemId: string) => void;
   /**
+   * CK-6b — resolve/dismiss an attention item via the FND-6-gated CK-6a route
+   * (`POST /api/attention/:id/{resolve,dismiss}`). App owns the call + identity
+   * context (mirrors `onDispatchDirect`). Only wired on the own-local render path
+   * below — a federated peer bottoms out at the aggregate notice, so its attention
+   * interior (and these mutations) never render (ADR-0005). Approve/Deny is NOT
+   * part of this contract (SPX-7/SPX-8, post-release).
+   */
+  onAttentionLifecycle?: (attentionId: string, action: "resolve" | "dismiss") => void;
+  /**
    * Dispatch DIRECTLY to a local agent via the FND-6-gated `/api/sessions` path
    * (App owns the call + identity context). Admin-posture + own-local only.
    */
@@ -111,6 +120,7 @@ export function McCockpit({
   governance,
   onOpenDrill,
   onOpenWorkItem,
+  onAttentionLifecycle,
   onDispatchDirect,
   dispatchingAgentKeys,
 }: McCockpitProps) {
@@ -143,6 +153,7 @@ export function McCockpit({
           loaded={attentionLoaded}
           {...(onOpenWorkItem ? { onOpenWorkItem } : {})}
           onOpenAssignment={onOpenDrill}
+          {...(onAttentionLifecycle ? { onLifecycle: onAttentionLifecycle } : {})}
         />
       </section>
 

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -231,6 +231,12 @@ export interface NetworkViewProps {
   /** CK-3 — open the work-item-detail surface (attention work-item deep link). */
   onOpenWorkItem?: (workItemId: string) => void;
   /**
+   * CK-6b — resolve/dismiss an attention item (drives the CK-6a route). Forwarded
+   * to the cockpit's own-local ATTENTION lane; the host (App) owns the POST +
+   * identity context + optimistic reconcile. Omitted → the queue is read-only.
+   */
+  onAttentionLifecycle?: (attentionId: string, action: "resolve" | "dismiss") => void;
+  /**
    * CK-5 (cortex#1292) — the app-scope WebSocket client. The constellation's live
    * traffic (dash-flow + atmosphere + bus-traffic strip) rides this ONE socket as
    * a wildcard subscriber (decision D-10 — no second feed, no poll). Omitted → a
@@ -269,6 +275,7 @@ export function NetworkView({
   workingAggregationLoaded = false,
   workingAggregationError = null,
   onOpenWorkItem,
+  onAttentionLifecycle,
   ws,
 }: NetworkViewProps) {
   const mode = pickAgentsPanelMode(state);
@@ -656,6 +663,7 @@ export function NetworkView({
         governance={governance}
         onOpenDrill={(id) => onOpenSession?.(id)}
         {...(onOpenWorkItem ? { onOpenWorkItem } : {})}
+        {...(onAttentionLifecycle ? { onAttentionLifecycle } : {})}
         {...(onDispatchDirect ? { onDispatchDirect } : {})}
         {...(dispatchingAgentKeys ? { dispatchingAgentKeys } : {})}
       />
@@ -675,6 +683,7 @@ export function NetworkView({
     governance,
     onOpenSession,
     onOpenWorkItem,
+    onAttentionLifecycle,
     onDispatchDirect,
     dispatchingAgentKeys,
   ]);

--- a/src/surface/mc/dashboard-v2/hooks/use-attention.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-attention.ts
@@ -19,10 +19,27 @@ interface AttentionResponse {
   attention: AttentionEntry[];
 }
 
+export interface AttentionQueue {
+  entries: AttentionEntry[];
+  loaded: boolean;
+  /**
+   * CK-6b — reconcile the queue with server truth. Called after a resolve/dismiss
+   * POST settles: on success it confirms the drop, on failure it RESTORES the row
+   * (the item is still `open` server-side), so the optimistic removal self-heals.
+   * Ungated (a mutation implies the surface is live), unlike the projection refetch.
+   */
+  refetch: () => void;
+  /**
+   * CK-6b — optimistically remove an item by id for instant feedback the moment a
+   * lifecycle button is pressed, before the POST resolves. `refetch` reconciles.
+   */
+  dropOptimistic: (attentionId: string) => void;
+}
+
 export function useAttention(
   ws: WsClient,
   enabled: boolean
-): { entries: AttentionEntry[]; loaded: boolean } {
+): AttentionQueue {
   const [entries, setEntries] = useState<AttentionEntry[]>([]);
   const [loaded, setLoaded] = useState(false);
 
@@ -75,5 +92,15 @@ export function useAttention(
   }, [load]);
   useProjectionRefetch(ws, "attention", refetch);
 
-  return { entries, loaded };
+  // CK-6b — ungated reload for post-mutation reconcile (see AttentionQueue.refetch).
+  const reload = useCallback(() => {
+    void load();
+  }, [load]);
+
+  const dropOptimistic = useCallback((attentionId: string) => {
+    if (!aliveRef.current) return;
+    setEntries((prev) => prev.filter((e) => e.item.id !== attentionId));
+  }, []);
+
+  return { entries, loaded, refetch: reload, dropOptimistic };
 }


### PR DESCRIPTION
R2 slice **CK-6b** — the glass affordance for the CK-6a attention lifecycle route (which landed in FND-6).

- Resolve/Dismiss buttons in the cockpit ATTENTION lane → `POST /api/attention/:id/{resolve,dismiss}` (the CK-6a route, FND-6 identity-gated — no client auth header). Optimistic drop + refetch reconcile.
- **Truth-not-theater — NO Approve/Deny:** SPX-7/8 arbitration doesn't exist, so those would be theater. Guarded 3 ways (element-tree test asserts exactly {resolve,dismiss} + 0 approve/deny, cockpit-fold test, code comments).
- Own-local-scoped (peer → ADR-0005 aggregate notice); NOT network-posture-gated (attention is the principal's own queue, not a govern verb).
- 1087 tests; tsc 0; eslint 0; vocab PASS; dashboard build clean (chunk held). **Browser-QA real-DOM PASS** (2 resolve + 2 dismiss, 0 approve/deny, routes fire, optimistic drop works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)