### PR TITLE
feat(gw): emit system.gateway.routing_decision — gateway inbound routing observable on the bus (#596)

### DIFF
--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1597,3 +1597,98 @@ export function createSystemDispatchStageEvent(
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// system.gateway.routing_decision — cortex#596 gateway inbound observability
+// ---------------------------------------------------------------------------
+
+/**
+ * Outcome of the SurfaceGateway's inbound routing decision.
+ *
+ *   - `routed`      — the inbound message matched a binding and its canonical
+ *                     `tasks.@{agent}.chat` dispatch envelope was published to
+ *                     the bound stack. `stack` / `subject` carry the target the
+ *                     inbound reached.
+ *   - `unroutable`  — the message matched a binding but the dispatch to the
+ *                     bound stack was REFUSED by the dispatch-source publisher
+ *                     (`{ published: false }`); `reason` carries the refusal
+ *                     (`invalid-originator`, `missing-runtime`, …). Nothing
+ *                     reached a stack — the inbound is dropped.
+ *
+ * Two outcomes of ONE decision, so they share a single envelope type
+ * discriminated on `outcome` — the same shape the sibling
+ * `system.bus.notify_discord` (`posted`/`failed`/`skipped`) and
+ * `system.bus.process` (`started`/`completed`/`failed`) visibility events use,
+ * rather than two near-identical `.routed` / `.unroutable` types.
+ */
+export type SystemGatewayRoutingOutcome = "routed" | "unroutable";
+
+export interface SystemGatewayRoutingDecisionOpts {
+  source: SystemEventSource;
+  /** Routing outcome — see {@link SystemGatewayRoutingOutcome}. */
+  outcome: SystemGatewayRoutingOutcome;
+  /** Platform the inbound arrived on (`discord` / `slack` / `mattermost` / …). */
+  platform: string;
+  /** Adapter connection-instance key (`msg.instanceId`) that received it. */
+  instanceId: string;
+  /** Target agent id from the binding match. */
+  agent: string;
+  /** Target principal from the binding match, when resolved. */
+  principal?: string;
+  /**
+   * Target stack from the binding match. Present on `routed`; may still be
+   * absent for a stackless (binding-resolver gap-4) binding.
+   */
+  stack?: string;
+  /** Canonical dispatch subject the routed envelope landed on — `routed` only. */
+  subject?: string;
+  /** Dispatch-source publisher refusal reason — `unroutable` only. */
+  reason?: string;
+  /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"` (principal-private), matching the rest of `system.*`.
+   */
+  classification?: Classification;
+}
+
+/**
+ * Construct a `system.gateway.routing_decision` envelope (cortex#596).
+ *
+ * The SurfaceGateway is a thin demux in front of the per-stack runners; it
+ * carries its own source identity `{principal}.gateway.{instance}` (see
+ * `gatewaySource()` in `src/gateway/gateway-adapters.ts`). This event is the
+ * structured replacement for the interim stdout routing hunt-line the gateway
+ * dry-run relied on — a dashboard glance instead of a stdout tail (#596).
+ *
+ * **New `system.gateway.*` family — why its own leaf.** The sibling `system.*`
+ * families are concern-scoped: `system.adapter.*` = adapter connection
+ * lifecycle, `system.inbound.*` = STACK-side inbound dispatch lifecycle
+ * (`system.inbound.aborted` is a timeout during an already-routed dispatch),
+ * `system.bus.*` = bus listener/handler visibility. The gateway's demux
+ * routing decision — which stack an inbound reached, or why it did not — fits
+ * none of those and PRECEDES the stack-side `system.inbound.*` lifecycle, so it
+ * takes its own `gateway` leaf. `git grep system.gateway` was empty before this
+ * event: an unclaimed, natural namespace.
+ *
+ * Subject convention: `local.{principal}.system.gateway.routing_decision` —
+ * surfaces subscribe to `system.gateway.>` (or the broader `system.>`).
+ */
+export function createSystemGatewayRoutingDecisionEvent(
+  opts: SystemGatewayRoutingDecisionOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.gateway.routing_decision",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    payload: {
+      outcome: opts.outcome,
+      platform: opts.platform,
+      instance_id: opts.instanceId,
+      agent: opts.agent,
+      ...(opts.principal !== undefined && { principal: opts.principal }),
+      ...(opts.stack !== undefined && { stack: opts.stack }),
+      ...(opts.subject !== undefined && { subject: opts.subject }),
+      ...(opts.reason !== undefined && { reason: opts.reason }),
+    },
+  });
+}

--- a/src/gateway/__tests__/bus-inbound-sink.test.ts
+++ b/src/gateway/__tests__/bus-inbound-sink.test.ts
@@ -26,6 +26,7 @@ import type { InboundChatDispatchPublishOpts, DispatchSourcePublishResult } from
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { PolicyEngine } from "../../common/policy/engine";
 import type { SystemEventSource } from "../../bus/system-events";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
 
 // =============================================================================
 // Fixtures
@@ -423,5 +424,102 @@ describe("BusInboundSink", () => {
     // undefined threads through; the publisher's `?? source.principal` yields
     // the gateway principal — the intended gap-4 default.
     expect(calls[0]?.subjectPrincipal).toBeUndefined();
+  });
+
+  // ── cortex#596: system.gateway.routing_decision bus events ──────────────────
+  //
+  // The sink emits a structured routing-decision event on both branches so
+  // signal + Mission Control observe the gateway's demux decision instead of
+  // tailing stdout. Emission is fire-and-forget via `runtime.publish` and
+  // guarded on the optional runtime/source deps.
+
+  /** Runtime stub that captures every published envelope. */
+  function makeCapturingRuntime(): {
+    runtime: MyelinRuntime;
+    published: Envelope[];
+  } {
+    const published: Envelope[] = [];
+    const runtime = {
+      publish: (env: Envelope): Promise<void> => {
+        published.push(env);
+        return Promise.resolve();
+      },
+    } as unknown as MyelinRuntime;
+    return { runtime, published };
+  }
+
+  test("routed publish → emits system.gateway.routing_decision { outcome: routed, stack, subject }", async () => {
+    const { runtime, published } = makeCapturingRuntime();
+    const { sink } = makeSink(
+      [{ published: true, subject: "local.andreas.meta-factory.tasks.@luna.chat" }],
+      { runtime },
+    );
+
+    await sink.publish(makeDecision(), makeMsg());
+
+    const evt = published.find(
+      (e) => e.type === "system.gateway.routing_decision",
+    );
+    expect(evt).toBeDefined();
+    const payload = evt!.payload;
+    expect(payload.outcome).toBe("routed");
+    expect(payload.platform).toBe("discord");
+    expect(payload.agent).toBe("luna");
+    expect(payload.stack).toBe("meta-factory");
+    expect(payload.principal).toBe("andreas");
+    expect(payload.subject).toBe("local.andreas.meta-factory.tasks.@luna.chat");
+    // No refusal reason on the routed branch.
+    expect(payload.reason).toBeUndefined();
+  });
+
+  test("refused publish → emits system.gateway.routing_decision { outcome: unroutable, reason }", async () => {
+    const { runtime, published } = makeCapturingRuntime();
+    // Silence the expected stderr refusal breadcrumb.
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (() => true);
+    const { sink } = makeSink(
+      [
+        {
+          published: false,
+          reason: "invalid-originator",
+          subject: "local.andreas.meta-factory.tasks.@luna.chat",
+        },
+      ],
+      { runtime },
+    );
+
+    try {
+      await sink.publish(makeDecision(), makeMsg());
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    const evt = published.find(
+      (e) => e.type === "system.gateway.routing_decision",
+    );
+    expect(evt).toBeDefined();
+    const payload = evt!.payload;
+    expect(payload.outcome).toBe("unroutable");
+    expect(payload.reason).toBe("invalid-originator");
+    expect(payload.agent).toBe("luna");
+    expect(payload.platform).toBe("discord");
+  });
+
+  test("source undefined → routing-decision emit is skipped (optional-dep guard, no throw)", async () => {
+    const { runtime, published } = makeCapturingRuntime();
+    const { sink } = makeSink([{ published: true, subject: "s" }], {
+      runtime,
+      source: undefined,
+    });
+
+    await expect(sink.publish(makeDecision(), makeMsg())).resolves.toBeUndefined();
+    expect(published).toHaveLength(0);
+  });
+
+  test("runtime without publish (stub) → routing-decision emit is skipped, no throw", async () => {
+    // STUB_RUNTIME is `{}` — `typeof runtime.publish !== "function"` must
+    // short-circuit the emit rather than throwing inside the sink.
+    const { sink } = makeSink([{ published: true, subject: "s" }]);
+    await expect(sink.publish(makeDecision(), makeMsg())).resolves.toBeUndefined();
   });
 });

--- a/src/gateway/bus-inbound-sink.ts
+++ b/src/gateway/bus-inbound-sink.ts
@@ -36,7 +36,8 @@ import type { GatewayInboundSink, GatewayInboundDecision } from "./surface-gatew
 import type { InboundMessage } from "../adapters/types";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { PolicyEngine } from "../common/policy/engine";
-import type { SystemEventSource } from "../bus/system-events";
+import type { SystemEventSource, SystemGatewayRoutingDecisionOpts } from "../bus/system-events";
+import { createSystemGatewayRoutingDecisionEvent } from "../bus/system-events";
 import {
   publishInboundChatDispatchEnvelope,
   type InboundChatDispatchPublishOpts,
@@ -101,6 +102,13 @@ export interface BusInboundSinkDeps {
  * full context (platform / instanceId / subject / reason) — a publish refusal
  * must surface, not silently drop. The method never throws; callers (the
  * `SurfaceGateway.handleInbound` catch-swallow loop) are free to rely on this.
+ *
+ * cortex#596 — on BOTH branches the sink also emits a structured
+ * `system.gateway.routing_decision` bus event (`outcome: "routed"` on success,
+ * `"unroutable"` on refusal) via {@link source}, so signal + Mission Control
+ * observe the gateway's demux decision instead of tailing stdout. The emit is
+ * fire-and-forget and guarded on the optional runtime/source deps (see
+ * {@link emitRoutingDecision}) — it never throws and never blocks the sink.
  */
 export class BusInboundSink implements GatewayInboundSink {
   private readonly runtime: MyelinRuntime | undefined;
@@ -196,19 +204,86 @@ export class BusInboundSink implements GatewayInboundSink {
 
     const result = await this.publishFn(opts);
 
-    if (!result.published) {
-      // A publish refusal must surface. Log with full context so the principal
-      // can diagnose invalid-originator, missing-runtime, etc. Not an empty
-      // catch — this is the error path.
-      process.stderr.write(
-        `[bus-inbound-sink] publish refused — dropping inbound message. ` +
-          `platform=${msg.platform} instanceId=${msg.instanceId} ` +
-          `agent=${match.agent} ` +
-          `stack=${match.stack ?? "<unresolved>"} ` +
-          `principal=${match.principal ?? "<unresolved>"} ` +
-          (result.subject !== undefined ? `subject=${result.subject} ` : "") +
-          `reason=${result.reason ?? "<unknown>"}\n`,
-      );
+    if (result.published) {
+      // cortex#596 — routed: the inbound matched a binding and its canonical
+      // dispatch envelope reached the bound stack. Emit the structured
+      // routing-decision event (the signal/MC-consumable replacement for the
+      // interim stdout hunt-line the gateway dry-run complained about).
+      this.emitRoutingDecision({
+        outcome: "routed",
+        platform: msg.platform,
+        instanceId: msg.instanceId,
+        agent: match.agent,
+        ...(match.principal !== undefined && { principal: match.principal }),
+        ...(match.stack !== undefined && { stack: match.stack }),
+        ...(result.subject !== undefined && { subject: result.subject }),
+      });
+      return;
     }
+
+    // A publish refusal must surface. Log with full context so the principal
+    // can diagnose invalid-originator, missing-runtime, etc. Not an empty
+    // catch — this is the error path. Kept as a local breadcrumb because a
+    // `missing-runtime` refusal means the bus is unavailable, so the
+    // routing-decision emit below is skipped and stderr is the only signal.
+    process.stderr.write(
+      `[bus-inbound-sink] publish refused — dropping inbound message. ` +
+        `platform=${msg.platform} instanceId=${msg.instanceId} ` +
+        `agent=${match.agent} ` +
+        `stack=${match.stack ?? "<unresolved>"} ` +
+        `principal=${match.principal ?? "<unresolved>"} ` +
+        (result.subject !== undefined ? `subject=${result.subject} ` : "") +
+        `reason=${result.reason ?? "<unknown>"}\n`,
+    );
+
+    // cortex#596 — unroutable: matched a binding but the dispatch was refused.
+    // Emit the structured event too (a no-op when the refusal is
+    // `missing-runtime`, since `this.runtime` is then undefined and the guard
+    // in `emitRoutingDecision` short-circuits — stderr above is the fallback).
+    this.emitRoutingDecision({
+      outcome: "unroutable",
+      platform: msg.platform,
+      instanceId: msg.instanceId,
+      agent: match.agent,
+      ...(match.principal !== undefined && { principal: match.principal }),
+      ...(match.stack !== undefined && { stack: match.stack }),
+      ...(result.subject !== undefined && { subject: result.subject }),
+      ...(result.reason !== undefined && { reason: result.reason }),
+    });
+  }
+
+  /**
+   * cortex#596 — emit a `system.gateway.routing_decision` bus event, the
+   * structured replacement for the gateway's interim stdout routing hunt-line.
+   *
+   * Fire-and-forget and guarded on BOTH optional deps: the gateway may run
+   * before the bus connects (`runtime === undefined`) or without a configured
+   * source identity (`source === undefined`), and `runtime.publish` is treated
+   * defensively (a stub runtime without the method must not throw). In any of
+   * those cases emission is skipped rather than raised — this sink's `publish`
+   * MUST NOT throw. Matches the optional-source guard the dispatch-handler
+   * `system.*` emitters use (`canPublishSystemEvent` → skip when unwired).
+   */
+  private emitRoutingDecision(
+    fields: Omit<SystemGatewayRoutingDecisionOpts, "source">,
+  ): void {
+    const source = this.source;
+    const runtime = this.runtime;
+    if (
+      source === undefined ||
+      runtime === undefined ||
+      typeof runtime.publish !== "function"
+    ) {
+      return;
+    }
+    const env = createSystemGatewayRoutingDecisionEvent({ source, ...fields });
+    // MyelinRuntime.publish signs + swallows its own errors; the extra catch is
+    // defence-in-depth so a runtime contract change can't crash the sink.
+    void runtime.publish(env).catch((err: unknown) => {
+      process.stderr.write(
+        `[bus-inbound-sink] publish(system.gateway.routing_decision) failed — ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    });
   }
 }


### PR DESCRIPTION
Addresses #596 (does **not** close it — see "Remaining" below).

The SurfaceGateway's `BusInboundSink` logged its routing decision to stderr only — a gateway dry-run was a stdout hunt. This emits a structured `system.gateway.routing_decision` bus event so signal + Mission Control observe the demux decision instead.

## Change (3 files, +281/−13)
- **`src/bus/system-events.ts`** — new `system.gateway.*` family: `SystemGatewayRoutingOutcome` + `createSystemGatewayRoutingDecisionEvent()`. Single type discriminated on `outcome` (`routed` | `unroutable`), matching the `system.bus.process` / `system.bus.notify_discord` sibling convention (two outcomes of one decision share one type). Namespace was unclaimed (`git grep system.gateway` = 0); justified as its own leaf because the gateway demux decision precedes the stack-side `system.inbound.*` lifecycle and carries its own `{principal}.gateway.{instance}` source identity.
- **`src/gateway/bus-inbound-sink.ts`** — emits on both publish-result branches: `routed` (published; carries stack + subject) / `unroutable` (dispatch refused; carries reason). The original publish-refusal stderr breadcrumb is **preserved** (it's the fallback when the refusal is `missing-runtime`, i.e. the bus is down). New `emitRoutingDecision()` helper is fire-and-forget and guarded on the optional `source`/`runtime` deps (undefined → skip, never throw) with a defence-in-depth catch. The sink's `publish() never throws` invariant is intact.
- **`src/gateway/__tests__/bus-inbound-sink.test.ts`** — +4 tests (routed payload, unroutable reason, undefined-source guard, stub-runtime no-throw).

## Verification
- `bunx tsc --noEmit` clean.
- `bun test src/gateway/__tests__/bus-inbound-sink.test.ts` → 19 pass (+4); `bun test src/gateway/` → 176 pass; `bun test src/bus/__tests__/system-events.test.ts` → 37 pass.

## Remaining (why this doesn't close #596)
1. **No-binding-match `unroutable`** — `surface-gateway.ts onUnroutable` (a message that matched *no* binding: "no binding for discord guildId X") is still `console.warn` only. That's arguably the primary dry-run miss; tracked as a follow-up (same event type, upstream of this sink).
2. **Signal tap allow-list** — this event is dropped by the signal tap until `system.gateway.>` is added to `ENVELOPE_DOMAIN_SUFFIXES` (signal `envelope-tap.ts` + `relay/receivers/nats.ts`). Separate signal slice.
3. **MC display** — the observability-renderer fold arm to *show* it is cortex#1661.

Part of the signal observability capability (the-metafactory/signal#161). Connection-health (`system.adapter.*`) already covered; outbound-mux events are out of scope per the issue.
