### PR TITLE
fix(network): C-1652 — admit seeds descriptor cache on miss (operator re-seal gap)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-operator-attestation.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-operator-attestation.test.ts
@@ -17,7 +17,7 @@ import { mkdtempSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
-import { resolveOperatorAttestation, seedAdminDescriptorCache } from "../network";
+import { resolveOperatorAttestation, seedAdminDescriptorCache, seedDescriptorCacheOnMiss } from "../network";
 import { NetworkCache } from "../../../../common/registry/network-cache";
 import type { LoadedConfig } from "../../../../common/config/loader";
 
@@ -126,5 +126,47 @@ describe("cortex#1652 — seedAdminDescriptorCache", () => {
       return { fetchAndCache: async () => ({ status: "ok" }) };
     });
     expect(seenCfg).toEqual({ url: "http://reg", pubkey: "PINNEDPUB" });
+  });
+});
+
+describe("cortex#1652 — seedDescriptorCacheOnMiss (admit-path re-seal gap)", () => {
+  test("cache MISS → calls the seed fn (so admit resolves operator, not PSK)", async () => {
+    let called = 0;
+    let seenArgs: [string, string, string | undefined] | undefined;
+    const seedSpy = async (id: string, url: string, pk?: string) => {
+      called += 1;
+      seenArgs = [id, url, pk];
+      return { seeded: true };
+    };
+    const r = await seedDescriptorCacheOnMiss(NET, "http://reg", "PIN", freshCache(), seedSpy);
+    expect(called).toBe(1);
+    expect(seenArgs).toEqual([NET, "http://reg", "PIN"]);
+    expect(r.seeded).toBe(true);
+    expect(r.skipped).toBeUndefined();
+  });
+
+  test("cache HIT → skips the network fetch entirely (warm cache, no seed call)", async () => {
+    const cache = freshCache();
+    cache.store(
+      NET,
+      { network_id: NET, hub_url: "tls://h:7422", leaf_port: 7422, members: [], hub_mode: "operator" },
+      { network_id: NET, members: [] },
+    );
+    let called = 0;
+    const seedSpy = async () => {
+      called += 1;
+      return { seeded: true };
+    };
+    const r = await seedDescriptorCacheOnMiss(NET, "http://reg", undefined, cache, seedSpy);
+    expect(called).toBe(0);
+    expect(r.seeded).toBe(true);
+    expect(r.skipped).toBe(true);
+  });
+
+  test("cache MISS + seed reports NOT seeded → propagates the reason (admit warns, stays best-effort)", async () => {
+    const seedSpy = async () => ({ seeded: false, reason: "unreachable" });
+    const r = await seedDescriptorCacheOnMiss(NET, "http://reg", undefined, freshCache(), seedSpy);
+    expect(r.seeded).toBe(false);
+    expect(r.reason).toBe("unreachable");
   });
 });

--- a/src/cli/cortex/commands/network-admit-lib.ts
+++ b/src/cli/cortex/commands/network-admit-lib.ts
@@ -224,10 +224,16 @@ export interface AdmitInputs {
    * the row's `network_id` is in hand; the result gates the seal onto the scoped-
    * mint path. Omitted ⇒ the simple/PSK seal (unchanged) — the CLI binds the real
    * resolver (descriptor cache + `--hub-fed-account`/config), tests omit it.
+   *
+   * cortex#1652 — may be async: the production resolver seeds the admin's
+   * descriptor cache on a miss (nothing populated it on an admit-only machine),
+   * so the call site awaits. Tests may still pass a synchronous resolver.
    */
   resolveOperatorAttestation?: (
     networkId: string,
-  ) => { hubMode?: "operator" | "simple"; resolverMode?: "nats" | "memory"; hubFedAccount?: string };
+  ) =>
+    | { hubMode?: "operator" | "simple"; resolverMode?: "nats" | "memory"; hubFedAccount?: string }
+    | Promise<{ hubMode?: "operator" | "simple"; resolverMode?: "nats" | "memory"; hubFedAccount?: string }>;
 }
 
 /** Discriminated on `ok` so a caller narrows to `sealOutcome`/`principalId`
@@ -337,7 +343,7 @@ export async function runNetworkAdmit(inputs: AdmitInputs, ports: AdmitPorts): P
     // a scoped user + seals v2 instead of a PSK; absent ⇒ the simple seal.
     const op =
       requestNetworkId !== null && inputs.resolveOperatorAttestation !== undefined
-        ? inputs.resolveOperatorAttestation(requestNetworkId)
+        ? await inputs.resolveOperatorAttestation(requestNetworkId)
         : {};
     sealOutcome = await ports.seal.sealMember({
       networkId: requestNetworkId,

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2205,6 +2205,28 @@ export async function seedAdminDescriptorCache(
   }
 }
 
+/**
+ * cortex#1652 — seed the descriptor cache for `admit` ONLY on a MISS. Unlike
+ * create/join, the admit path never populated the cache, so a custodian who runs
+ * `admit` without a prior create/join on this machine resolved hub_mode=undefined
+ * → silent PSK fallback (the re-seal gap: `network join` then re-renders a PSK
+ * leaf remote the operator hub rejects). A warm cache → NO network call. Delegates
+ * to {@link seedAdminDescriptorCache} (never throws). Injectable cache + seed fn
+ * for tests. `skipped` marks the warm-cache no-op (still `seeded: true`).
+ */
+export async function seedDescriptorCacheOnMiss(
+  networkId: string,
+  registryUrl: string,
+  registryPubkey: string | undefined,
+  cache: NetworkCache = new NetworkCache({
+    cacheDir: expandTilde(join("~", ".config", "cortex", "network-cache")),
+  }),
+  seed: typeof seedAdminDescriptorCache = seedAdminDescriptorCache,
+): Promise<{ seeded: boolean; reason?: string; skipped?: boolean }> {
+  if (cache.load(networkId)?.descriptor !== undefined) return { seeded: true, skipped: true };
+  return seed(networkId, registryUrl, registryPubkey);
+}
+
 async function runCreate(
   networkId: string,
   flags: FlagMap,
@@ -2985,8 +3007,30 @@ async function runAdmit(
       ...(admitHubAccount !== undefined && { hubAccount: admitHubAccount }),
       // cortex#1598 — DEFERRED operator-mode attestation resolver (the network id
       // is only known after the row fetch inside runNetworkAdmit).
-      resolveOperatorAttestation: (networkId: string) =>
-        resolveOperatorAttestation(flags, networkId, DEFAULT_READER),
+      // cortex#1652 — nothing populated the descriptor cache on an admit-only
+      // machine (create/join do; #1653 seeds it on create). A custodian who only
+      // runs `admit` therefore resolved hub_mode=undefined → silent PSK fallback:
+      // the re-seal gap, where `network join` then re-renders a PSK leaf remote
+      // the operator hub rejects. Seed the VERIFIED descriptor on a cache MISS
+      // before resolving. Best-effort — seedAdminDescriptorCache never throws,
+      // and resolveOperatorAttestation's local-config fallback still applies if
+      // the registry is unreachable; the seal only stays PSK if genuinely so.
+      resolveOperatorAttestation: async (networkId: string) => {
+        const seed = await seedDescriptorCacheOnMiss(
+          networkId,
+          registryUrl,
+          optionalValueFlag(flags, "--registry-pubkey"),
+        );
+        if (!seed.seeded) {
+          process.stderr.write(
+            `cortex network admit: could not seed the "${networkId}" descriptor ` +
+              `(${seed.reason ?? "unknown"}); operator-mode resolution falls back to ` +
+              `local config. If this network's hub is operator-mode and no local ` +
+              `hub_mode is set, the seal may take the simple/PSK path.\n`,
+          );
+        }
+        return resolveOperatorAttestation(flags, networkId, DEFAULT_READER);
+      },
       ...(discordMember !== undefined && {
         discord: {
           member: discordMember,


### PR DESCRIPTION
## The re-seal gap
First live operator-mode validation (Ivy, 2026-07-07): `network join` rendered a leaf remote from jc's **stale PSK admission row** (`tls://jc:<psk>@…`), which the operator hub rejects — forcing a hand-edited leaf conf. The proper fix is re-sealing the admission row via an admit pass, **but re-running admit today would just re-seal another PSK.**

## Root cause
admit's `resolveOperatorAttestation` reads the descriptor **cache** then local config. #1653 seeds that cache on `network create` — but a **custodian who runs `admit`** on a machine that never ran create/join (e.g. the hub owner minting on their own box) has an **empty cache** → `hub_mode` resolves `undefined` → admit **silently takes the SIMPLE/PSK seal path** (the fail-open Sage flagged, now a confirmed live gap — #1652 item 1).

## Fix
The admit-side resolver now **seeds the VERIFIED descriptor on a cache MISS** (reusing the shipped `seedAdminDescriptorCache`) before resolving. An operator network then resolves `hub_mode: operator` and admit takes the scoped-mint + v2-seal path — so the re-seal produces operator creds and `network join` renders cleanly, no hand-edit.

- New **`seedDescriptorCacheOnMiss`** seam — exported, injectable cache + seed fn; **warm cache → no network call**.
- admit's `resolveOperatorAttestation` port is now **async** (seed-then-resolve); the admit-lib call site awaits it. The port type accepts sync-or-async so **test injections stay synchronous**.
- Best-effort: `seedAdminDescriptorCache` never throws, the local-config fallback still applies, and a seed failure warns on stderr — the seal only stays PSK if the network is *genuinely* simple.

## Tests
3 new: cache-miss → seeds (admit resolves operator not PSK); cache-hit → skips the fetch; miss + not-seeded → propagates the reason (admit warns, stays best-effort). **Touched-path suite 76/0, tsc clean, eslint clean.**

> Note: ~20 pre-existing `network secret add-member/revoke-member` tests fail in a **fresh worktree** (exit 1, env-only — reproduce on clean `main`, green in CI). Unrelated to this change (admit-only). CI is the full-suite backstop.

## Scope
Closes the admit-side of **#1652 item 1** (create-side was #1653). Item 2 (push the FED-account JWT after the scoped-key edit — mostly handled by the #1626 resolver migration) and item 3 (self-test harness recipe) remain as follow-ups.

Refs #1652

🤖 Generated with [Claude Code](https://claude.com/claude-code)