### PR TITLE
feat(mc): CK-8 — task→trace deep-link on WORKING rows (R2) — Closes #1672

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/working-grid.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/working-grid.test.tsx
@@ -265,3 +265,59 @@ describe("workingTileKey — #1065 stack-namespaced unique key", () => {
     );
   });
 });
+
+describe("CK-8 — WORKING row → signal-trace deep link", () => {
+  const ANCHOR = "mc-dispatch-task-";
+
+  it("LOCAL + anchored tile renders the 'View signal trace' toggle", () => {
+    const html = renderGrid({
+      origin: "local",
+      primary_assignment: {
+        id: "a-1",
+        task_id: `${ANCHOR}corr-42`,
+        task_title: "Dispatched work",
+        task_priority: 1,
+        updated_at: "2026-04-26T00:00:00.000Z",
+      },
+    });
+    expect(html).toContain("working-trace-toggle");
+    expect(html).toContain("View signal trace");
+    // Collapsed by default — the SidebandSource panel is not mounted yet.
+    expect(html).not.toContain("working-trace-panel");
+    // Honest: no degrade line on a local row.
+    expect(html).not.toContain("working-trace-degrade");
+  });
+
+  it("CROSS-STACK tile renders the honest degrade line — never a toggle/link", () => {
+    const html = renderGrid({
+      origin: { principal: "jc", stack: "work" },
+      primary_assignment: {
+        id: "a-1",
+        // Even a perfectly anchored task id must degrade off-origin (ADR-0005).
+        task_id: `${ANCHOR}corr-42`,
+        task_title: "Peer work",
+        task_priority: 1,
+        updated_at: "2026-04-26T00:00:00.000Z",
+      },
+    });
+    expect(html).toContain("working-trace-degrade");
+    expect(html).toContain("trace lives on jc/work");
+    expect(html).not.toContain("working-trace-toggle");
+    // The degrade line is a <div role=note>, not an anchor — no dead link.
+    expect(html).not.toContain("/api/observability/traces/");
+  });
+
+  it("LOCAL + non-anchored tile renders NO trace affordance (honest absence)", () => {
+    const html = renderGrid({
+      origin: "local",
+      primary_assignment: {
+        id: "a-1",
+        task_id: "orphan-task-99",
+        task_title: "Observed orphan",
+        task_priority: 1,
+        updated_at: "2026-04-26T00:00:00.000Z",
+      },
+    });
+    expect(html).not.toContain("working-trace");
+  });
+});

--- a/src/surface/mc/dashboard-v2/__tests__/working-trace-deeplink.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/working-trace-deeplink.test.ts
@@ -1,0 +1,84 @@
+/**
+ * CK-8 — unit tests for the WORKING row → signal-trace deep-link resolver.
+ *
+ * Pins the three honest states and the load-bearing invariants:
+ *   - LOCAL + anchored     → a link to the loopback timeline endpoint
+ *   - CROSS-STACK          → honest degrade (NEVER a link; ADR-0005)
+ *   - LOCAL + non-anchored → honest absence (no correlatable trace)
+ *
+ * A separate `describe` asserts PARITY with the server-side `ANCHOR_TASK_PREFIX`
+ * so the browser-safe mirror can never silently drift from the projection that
+ * mints the anchor task id.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveTraceDeepLink,
+  traceTimelineHref,
+  crossStackLabel,
+  DISPATCH_ANCHOR_TASK_PREFIX,
+} from "../lib/working-trace-deeplink";
+import { ANCHOR_TASK_PREFIX } from "../../projection/anchor";
+
+describe("resolveTraceDeepLink", () => {
+  it("LOCAL + anchored task → a timeline deep link on the derived trace_id", () => {
+    const link = resolveTraceDeepLink({
+      taskId: `${DISPATCH_ANCHOR_TASK_PREFIX}abc-123`,
+      origin: "local",
+    });
+    expect(link.kind).toBe("local");
+    if (link.kind !== "local") throw new Error("unreachable");
+    expect(link.traceId).toBe("abc-123");
+    expect(link.timelineHref).toBe(
+      "/api/observability/traces/abc-123/timeline",
+    );
+  });
+
+  it("undefined origin is treated as LOCAL (pre-#1008 responses)", () => {
+    const link = resolveTraceDeepLink({
+      taskId: `${DISPATCH_ANCHOR_TASK_PREFIX}deadbeef`,
+      origin: undefined,
+    });
+    expect(link.kind).toBe("local");
+  });
+
+  it("CROSS-STACK origin → honest degrade, NEVER a link (ADR-0005)", () => {
+    const link = resolveTraceDeepLink({
+      // Even a perfectly anchored task id must NOT produce a link off-origin:
+      // the peer's trace is unreachable through this daemon's loopback proxy.
+      taskId: `${DISPATCH_ANCHOR_TASK_PREFIX}abc-123`,
+      origin: { principal: "jc", stack: "work" },
+    });
+    expect(link.kind).toBe("cross-stack");
+    if (link.kind !== "cross-stack") throw new Error("unreachable");
+    expect(link.stackLabel).toBe("jc/work");
+  });
+
+  it("LOCAL + non-anchored task → honest absence (no correlatable trace)", () => {
+    for (const taskId of ["orphan-abc", "mc-shadow", "", DISPATCH_ANCHOR_TASK_PREFIX]) {
+      const link = resolveTraceDeepLink({ taskId, origin: "local" });
+      expect(link.kind).toBe("none");
+    }
+  });
+
+  it("traceTimelineHref encodes the trace id (path-injection safe)", () => {
+    expect(traceTimelineHref("a/b?c")).toBe(
+      "/api/observability/traces/a%2Fb%3Fc/timeline",
+    );
+  });
+
+  it("crossStackLabel renders {principal}/{stack}", () => {
+    expect(crossStackLabel({ principal: "andreas", stack: "meta-factory" })).toBe(
+      "andreas/meta-factory",
+    );
+  });
+});
+
+describe("anchor-prefix parity", () => {
+  it("the browser-safe mirror equals the server ANCHOR_TASK_PREFIX", () => {
+    // If the dispatch-lifecycle projection ever renames its anchor prefix, this
+    // fails and forces the mirror to be updated in lockstep — the deep link
+    // would otherwise silently stop correlating.
+    expect(DISPATCH_ANCHOR_TASK_PREFIX).toBe(ANCHOR_TASK_PREFIX);
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/working-grid.css
+++ b/src/surface/mc/dashboard-v2/components/working-grid.css
@@ -182,3 +182,49 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* ── CK-8 — task→signal-trace deep link on a WORKING row ───────────────────── */
+.working-trace {
+  margin-top: 4px;
+  padding-left: 2px;
+  font-size: 11px;
+}
+
+/* LOCAL, correlatable — the "View signal trace" toggle. */
+.working-trace-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.working-trace-toggle:hover {
+  background: color-mix(in oklch, var(--accent) 10%, transparent);
+}
+.working-trace-toggle .chevron { color: var(--fg-faint); }
+
+.working-trace-panel {
+  margin-top: 4px;
+  border-left: 2px solid color-mix(in oklch, var(--accent) 30%, transparent);
+  padding-left: 6px;
+}
+
+/* CROSS-STACK — the honest degrade line (never a link; ADR-0005). */
+.working-trace-degrade {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  color: var(--fg-faint);
+  font-style: italic;
+}
+.working-trace-degrade-mark {
+  font-style: normal;
+  color: var(--fg-dim);
+}

--- a/src/surface/mc/dashboard-v2/components/working-grid.tsx
+++ b/src/surface/mc/dashboard-v2/components/working-grid.tsx
@@ -26,7 +26,7 @@
  * <button>s — Enter/Space toggle them for free (G-1114.F a11y bar).
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
 import "./working-grid.css";
 import { priorityBorderClass } from "../lib/block-reason";
 import { pickWorkingGridMode, priorityLabel } from "../lib/working-grid-display";
@@ -36,10 +36,20 @@ import {
   type SessionTreeRow,
 } from "../lib/session-tree-rows";
 import { substrateLabel } from "../lib/substrate-label";
+import { resolveTraceDeepLink } from "../lib/working-trace-deeplink";
 import type {
   WorkingAgentTile,
   SessionTreeNode,
 } from "../hooks/use-working-agents";
+
+/**
+ * CK-8 — the signal-trace timeline source, LAZY-imported so its fetch + the
+ * `sideband-timeline` mapper land in the SAME split chunk the drill-down already
+ * pays for (never the working-grid entry bundle). Reused verbatim: it fetches
+ * `/api/observability/traces/{id}/timeline`, renders the trace rows, and degrades
+ * HONESTLY on a `SidebandError` (interior-absent line + backend `deep_link`).
+ */
+const SidebandSource = lazy(() => import("./sideband-source"));
 
 /**
  * #1065 — a globally-unique React key for a working tile. The pane-of-glass
@@ -176,6 +186,11 @@ export function WorkingGrid({
                 expanded={expanded}
                 onToggleExpand={onToggleExpand}
               />
+              <WorkingTraceDrill
+                taskId={a.primary_assignment.task_id}
+                origin={a.origin}
+                agentName={a.agent_name}
+              />
             </div>
           ))}
         </div>
@@ -279,5 +294,76 @@ function SessionTreeItem({ row, onToggleExpand }: SessionTreeItemProps) {
         <span className={`session-state state-${node.state}`}>{node.state}</span>
       )}
     </li>
+  );
+}
+
+interface WorkingTraceDrillProps {
+  /** The tile's primary-assignment task id — carries the anchor correlation_id. */
+  taskId: string;
+  /** The tile's origin — drives the local-only scoping (ADR-0005). */
+  origin: WorkingAgentTile["origin"];
+  /** Owning agent display name — for the trace panel's aria-label. */
+  agentName: string;
+}
+
+/**
+ * CK-8 — the task→signal-trace deep link on a WORKING row.
+ *
+ * Three honest states, decided by `resolveTraceDeepLink` (pure):
+ *   - LOCAL, correlatable  → a "View signal trace" toggle that lazily mounts
+ *     `SidebandSource` for the derived trace_id. The trace timeline, its
+ *     `SidebandError` degrade, and the backend `deep_link` exit are all owned
+ *     downstream by `SidebandSource` — this component just opens it.
+ *   - CROSS-STACK          → an HONEST degrade line ("trace lives on ⟨stack⟩ —
+ *     open its MC"). NOT a link: the loopback proxy can't resolve a peer's trace
+ *     on this daemon (ADR-0005 / truth-not-theater — never a dead affordance).
+ *   - NONE (local, non-anchored) → nothing. There is no correlatable trace, so
+ *     honest absence is rendering no affordance at all.
+ */
+function WorkingTraceDrill({ taskId, origin, agentName }: WorkingTraceDrillProps) {
+  const [open, setOpen] = useState(false);
+  const link = resolveTraceDeepLink({ taskId, origin });
+
+  if (link.kind === "none") return null;
+
+  if (link.kind === "cross-stack") {
+    return (
+      <div className="working-trace working-trace-degrade" role="note">
+        <span className="working-trace-degrade-mark" aria-hidden="true">⟿</span>
+        trace lives on {link.stackLabel} — open its MC
+      </div>
+    );
+  }
+
+  // Local + correlatable: the real drill affordance.
+  return (
+    <div className="working-trace">
+      <button
+        type="button"
+        className="working-trace-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="chevron" aria-hidden="true">{open ? "▾" : "▸"}</span>
+        {open ? "Hide signal trace" : "View signal trace"}
+      </button>
+      {open && (
+        <div
+          className="working-trace-panel"
+          role="log"
+          aria-label={`Signal trace for ${agentName}`}
+        >
+          <Suspense
+            fallback={
+              <div className="drill-log-wrap">
+                <div className="drill-log-empty">Loading trace…</div>
+              </div>
+            }
+          >
+            <SidebandSource correlationId={link.traceId} />
+          </Suspense>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/surface/mc/dashboard-v2/lib/working-trace-deeplink.ts
+++ b/src/surface/mc/dashboard-v2/lib/working-trace-deeplink.ts
@@ -1,0 +1,84 @@
+/**
+ * CK-8 (docs/plan-mc-future-state.md §4.A) — resolve a WORKING row's
+ * task → signal-trace deep link, honoring the ADR-0005 local-origin boundary.
+ *
+ * The signal sideband proxy (`src/common/sideband/proxy.ts`) is
+ * LOOPBACK-ENFORCED and LOCAL-STACK-ONLY: it forwards
+ * `/api/observability/traces/{trace_id}/timeline` to `127.0.0.1:9092` on THIS
+ * daemon. A federated PEER's trace lives on the PEER's daemon and is
+ * unreachable through this loopback proxy — so the deep link is scoped to
+ * LOCAL-origin rows, and a cross-stack row (CK-4a aggregation) gets an HONEST
+ * degrade ("trace lives on ⟨stack⟩ — open its MC"), never a dead or fabricated
+ * link (truth-not-theater; ADR-0005 — a peer has no resolvable trace here).
+ *
+ * `trace_id ≡ correlation_id` (W3C). A dispatch-anchored WORKING tile carries
+ * its correlation_id INSIDE its task id: the dispatch-lifecycle projection mints
+ * the anchor task as `mc-dispatch-task-{correlation_id}`
+ * (`projection/anchor.ts` → `ANCHOR_TASK_PREFIX`). So the correlation_id is
+ * derived by stripping that prefix — no schema/DTO change, which is exactly the
+ * render-layer affordance this slice scopes to. A NON-anchored task (a
+ * `local.observed` orphan, a legacy row) has no derivable trace id → honest
+ * ABSENCE (no affordance): there is no correlatable trace, and we never
+ * fabricate one.
+ *
+ * Pure — no fetch, no DOM. The `SidebandError` degrade + `deep_link` exit + the
+ * signal-dark honest-absence line all live DOWNSTREAM in `SidebandSource`, which
+ * this deep link opens; this module only decides WHICH of the three states a row
+ * is in.
+ */
+
+import type { AgentOrigin } from "../../api/agents";
+
+/**
+ * Browser-safe mirror of `projection/anchor.ts` → `ANCHOR_TASK_PREFIX`. It is
+ * duplicated (not imported) DELIBERATELY: `anchor.ts` value-imports `db/work-items`
+ * which pulls `bun:sqlite` — server-only code that must never enter the dashboard
+ * bundle. `working-trace-deeplink.parity.test.ts` asserts this constant equals the
+ * server constant so the two can never silently drift.
+ */
+export const DISPATCH_ANCHOR_TASK_PREFIX = "mc-dispatch-task-";
+
+export interface TraceDeepLinkInput {
+  /** The WORKING tile's primary-assignment task id. */
+  taskId: string;
+  /** The tile's origin — `"local"` or a foreign `{principal, stack}`. Absent ⇒ local. */
+  origin: AgentOrigin | undefined;
+}
+
+export type TraceDeepLink =
+  /** Local origin + a derivable trace id: open the sideband timeline drill. */
+  | { kind: "local"; traceId: string; timelineHref: string }
+  /** Foreign origin: the trace lives on the peer's daemon — honest degrade. */
+  | { kind: "cross-stack"; stackLabel: string }
+  /** Local origin but no correlatable trace id — honest absence (no affordance). */
+  | { kind: "none" };
+
+/** Same-origin path MC proxies (server-side) to the loopback sideband. */
+export function traceTimelineHref(traceId: string): string {
+  return `/api/observability/traces/${encodeURIComponent(traceId)}/timeline`;
+}
+
+/** `{principal}/{stack}` — the peer identity shown in the honest degrade line. */
+export function crossStackLabel(origin: { principal: string; stack: string }): string {
+  return `${origin.principal}/${origin.stack}`;
+}
+
+/**
+ * Decide a WORKING row's trace-deep-link state. Foreign origin is checked FIRST:
+ * a peer's trace is unreachable through this daemon's loopback proxy regardless
+ * of the task's shape (ADR-0005), so it always degrades honestly — never a link.
+ */
+export function resolveTraceDeepLink({ taskId, origin }: TraceDeepLinkInput): TraceDeepLink {
+  if (origin && origin !== "local") {
+    return { kind: "cross-stack", stackLabel: crossStackLabel(origin) };
+  }
+  // Local origin: derive correlation_id ≡ trace_id from the anchor task id.
+  if (taskId.startsWith(DISPATCH_ANCHOR_TASK_PREFIX)) {
+    const traceId = taskId.slice(DISPATCH_ANCHOR_TASK_PREFIX.length);
+    if (traceId.length > 0) {
+      return { kind: "local", traceId, timelineHref: traceTimelineHref(traceId) };
+    }
+  }
+  // Local but non-anchored (no correlatable trace) — honest absence.
+  return { kind: "none" };
+}


### PR DESCRIPTION
R2 slice **CK-8**. WORKING row → sideband timeline drill (`/api/observability/traces/{id}/timeline`, lazy-mounted). **LOCAL-origin rows only** (sideband proxy is loopback+local-stack-only); a cross-stack row renders an **honest degrade** ('trace lives on ⟨stack⟩ — open its MC'), never a dead link (ADR-0005); local-non-anchored → honest absence. All three paths tested.

Clean re-apply from current main (the stale salvage branch was retired): **additive (0 deletions)**, `.ck8-qa/` scratch dropped. Notably `use-attention.ts` was correctly NOT touched (the stale diff against it was a CK-6b reversion). tsc 0; eslint 0; vocab PASS; 31/31 tests. Closes #1672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)