### PR TITLE
feat(gw): emit routing_decision for no-binding unroutable inbounds — closes the #596 stdout gap

### DIFF
--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1609,11 +1609,18 @@ export function createSystemDispatchStageEvent(
  *                     `tasks.@{agent}.chat` dispatch envelope was published to
  *                     the bound stack. `stack` / `subject` carry the target the
  *                     inbound reached.
- *   - `unroutable`  — the message matched a binding but the dispatch to the
- *                     bound stack was REFUSED by the dispatch-source publisher
- *                     (`{ published: false }`); `reason` carries the refusal
- *                     (`invalid-originator`, `missing-runtime`, …). Nothing
- *                     reached a stack — the inbound is dropped.
+ *   - `unroutable`  — the inbound reached NO bound stack. Two sub-cases share
+ *                     this outcome, discriminated by whether `agent` is present:
+ *                       (1) NO binding matched at all (cortex#596) — emitted from
+ *                           the gateway's `onUnroutable` path; `reason` carries
+ *                           the `unroutableReason()` string (e.g. `no binding for
+ *                           discord guildId "X"`) and `agent`/`stack` are absent.
+ *                       (2) a binding matched but the dispatch to the bound stack
+ *                           was REFUSED by the dispatch-source publisher
+ *                           (`{ published: false }`) — `reason` carries the refusal
+ *                           (`invalid-originator`, `missing-runtime`, …) and
+ *                           `agent` is the matched agent.
+ *                     In both cases nothing reached a stack — the inbound is dropped.
  *
  * Two outcomes of ONE decision, so they share a single envelope type
  * discriminated on `outcome` — the same shape the sibling
@@ -1631,8 +1638,15 @@ export interface SystemGatewayRoutingDecisionOpts {
   platform: string;
   /** Adapter connection-instance key (`msg.instanceId`) that received it. */
   instanceId: string;
-  /** Target agent id from the binding match. */
-  agent: string;
+  /**
+   * Target agent id from the binding match. Optional because the no-binding-match
+   * unroutable case (cortex#596) has NO binding and therefore NO agent — the
+   * inbound arrived on a `(platform, instance)` the gateway owns but matched no
+   * surface binding, so there is genuinely nothing to attribute an agent to. The
+   * routed branch (and the publish-refusal unroutable branch) DO carry a matched
+   * agent and always set it. Omitted from the payload when absent.
+   */
+  agent?: string;
   /** Target principal from the binding match, when resolved. */
   principal?: string;
   /**
@@ -1684,7 +1698,7 @@ export function createSystemGatewayRoutingDecisionEvent(
       outcome: opts.outcome,
       platform: opts.platform,
       instance_id: opts.instanceId,
-      agent: opts.agent,
+      ...(opts.agent !== undefined && { agent: opts.agent }),
       ...(opts.principal !== undefined && { principal: opts.principal }),
       ...(opts.stack !== undefined && { stack: opts.stack }),
       ...(opts.subject !== undefined && { subject: opts.subject }),

--- a/src/gateway/__tests__/gateway-unroutable-emit.test.ts
+++ b/src/gateway/__tests__/gateway-unroutable-emit.test.ts
@@ -1,0 +1,178 @@
+/**
+ * cortex#596 — no-binding-match routing_decision emit tests (TDD Red→Green).
+ *
+ * Covers the UPSTREAM unroutable case PR #1667 left as stdout-only: an inbound
+ * that matches NO binding. Mirrors the emit-assertion shape of
+ * `bus-inbound-sink.test.ts` (the publish-refusal twin).
+ *
+ * Tests:
+ *   1. no-binding inbound → emits system.gateway.routing_decision
+ *      { outcome: "unroutable", reason, platform, instanceId } and NO agent.
+ *   2. source undefined → no emit, no throw (optional-dep guard).
+ *   3. runtime undefined → no emit, no throw.
+ *   4. runtime without publish (stub `{}`) → no emit, no throw.
+ *   5. makeEmittingUnroutable → runs the base breadcrumb AND emits (deps live).
+ *   6. makeEmittingUnroutable → still runs the base breadcrumb when deps are
+ *      absent (emit skipped) — the console.warn fallback survives a bus outage.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  emitUnroutableRoutingDecision,
+  makeEmittingUnroutable,
+} from "../gateway-unroutable-emit";
+import type { InboundMessage } from "../../adapters/types";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { SystemEventSource } from "../../bus/system-events";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const STUB_SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "gateway",
+  instance: "gateway-0",
+  dataResidency: "NZ",
+};
+
+/** A no-binding inbound — DM on Discord (no guildId), or an unbound guild. */
+function makeMsg(overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    platform: "discord",
+    instanceId: "discord:999888777",
+    authorId: "user-discord-55555",
+    authorName: "Stranger",
+    channelId: "channel-zzz",
+    content: "hello?",
+    attachments: [],
+    timestamp: new Date("2026-07-08T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+/** Runtime stub that captures every published envelope. */
+function makeCapturingRuntime(): {
+  runtime: MyelinRuntime;
+  published: Envelope[];
+} {
+  const published: Envelope[] = [];
+  const runtime = {
+    publish: (env: Envelope): Promise<void> => {
+      published.push(env);
+      return Promise.resolve();
+    },
+  } as unknown as MyelinRuntime;
+  return { runtime, published };
+}
+
+const REASON = 'no binding for discord guildId "111222333"';
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("emitUnroutableRoutingDecision", () => {
+  test("no-binding inbound → emits system.gateway.routing_decision { unroutable, reason }, no agent", () => {
+    const { runtime, published } = makeCapturingRuntime();
+
+    emitUnroutableRoutingDecision(
+      { runtime, source: STUB_SOURCE },
+      makeMsg(),
+      REASON,
+    );
+
+    const evt = published.find(
+      (e) => e.type === "system.gateway.routing_decision",
+    );
+    expect(evt).toBeDefined();
+    const payload = evt!.payload;
+    expect(payload.outcome).toBe("unroutable");
+    expect(payload.reason).toBe(REASON);
+    expect(payload.platform).toBe("discord");
+    expect(payload.instance_id).toBe("discord:999888777");
+    // No binding matched → no agent / stack / principal / subject stamped.
+    expect(payload.agent).toBeUndefined();
+    expect(payload.stack).toBeUndefined();
+    expect(payload.principal).toBeUndefined();
+    expect(payload.subject).toBeUndefined();
+  });
+
+  test("source undefined → emit skipped, no throw", () => {
+    const { runtime, published } = makeCapturingRuntime();
+    expect(() =>
+      emitUnroutableRoutingDecision(
+        { runtime, source: undefined },
+        makeMsg(),
+        REASON,
+      ),
+    ).not.toThrow();
+    expect(published).toHaveLength(0);
+  });
+
+  test("runtime undefined → emit skipped, no throw", () => {
+    expect(() =>
+      emitUnroutableRoutingDecision(
+        { runtime: undefined, source: STUB_SOURCE },
+        makeMsg(),
+        REASON,
+      ),
+    ).not.toThrow();
+  });
+
+  test("runtime without publish (stub {}) → emit skipped, no throw", () => {
+    const stubRuntime = {} as MyelinRuntime;
+    expect(() =>
+      emitUnroutableRoutingDecision(
+        { runtime: stubRuntime, source: STUB_SOURCE },
+        makeMsg(),
+        REASON,
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("makeEmittingUnroutable", () => {
+  test("live deps → runs the base breadcrumb AND emits the event", () => {
+    const { runtime, published } = makeCapturingRuntime();
+    const baseCalls: { msg: InboundMessage; reason: string }[] = [];
+    const base = (msg: InboundMessage, reason: string): void => {
+      baseCalls.push({ msg, reason });
+    };
+
+    const handler = makeEmittingUnroutable(base, {
+      runtime,
+      source: STUB_SOURCE,
+    });
+    const msg = makeMsg();
+    handler(msg, REASON);
+
+    // Breadcrumb ran with the same args…
+    expect(baseCalls).toHaveLength(1);
+    expect(baseCalls[0]?.msg).toBe(msg);
+    expect(baseCalls[0]?.reason).toBe(REASON);
+    // …and the event was emitted.
+    const evt = published.find(
+      (e) => e.type === "system.gateway.routing_decision",
+    );
+    expect(evt).toBeDefined();
+    expect(evt!.payload.outcome).toBe("unroutable");
+    expect(evt!.payload.reason).toBe(REASON);
+  });
+
+  test("deps absent → breadcrumb still runs, emit skipped, no throw", () => {
+    let baseRan = false;
+    const base = (): void => {
+      baseRan = true;
+    };
+
+    const handler = makeEmittingUnroutable(base, {
+      runtime: undefined,
+      source: undefined,
+    });
+
+    expect(() => handler(makeMsg(), REASON)).not.toThrow();
+    expect(baseRan).toBe(true);
+  });
+});

--- a/src/gateway/gateway-unroutable-emit.ts
+++ b/src/gateway/gateway-unroutable-emit.ts
@@ -1,0 +1,126 @@
+/**
+ * cortex#596 — no-binding-match `system.gateway.routing_decision` emit.
+ *
+ * PR #1667 added the routed / publish-refusal routing-decision event, emitted
+ * from {@link BusInboundSink} once an inbound has MATCHED a binding. The OTHER
+ * unroutable case — an inbound that matches NO binding at all — happens UPSTREAM
+ * in {@link SurfaceGateway.handleInbound}'s `onUnroutable` path (default
+ * `console.warn`, stdout-only) and never reached the sink, so it stayed a
+ * stdout-hunt. That no-binding drop is arguably the primary dry-run miss #596
+ * was raised for.
+ *
+ * This module supplies the composition-root seam (design option (b)): the
+ * gateway boot path (`start-gateway.ts`) already holds the `runtime` + `source`
+ * it uses to build {@link BusInboundSink}, so it injects an `onUnroutable` that
+ * (1) preserves the existing `console.warn` breadcrumb (the fallback when the
+ * bus is down) and (2) fire-and-forget emits a `system.gateway.routing_decision`
+ * with `outcome: "unroutable"` and `reason` = the `unroutableReason()` string.
+ * `SurfaceGateway` itself stays free of any bus/system-event coupling — it keeps
+ * its injected-interface design; the bus knowledge lives only here + at the boot
+ * site, exactly where `BusInboundSink` already lives.
+ *
+ * ## Live-only, by symmetry with the sink
+ *
+ * The emit is wired ONLY on the LIVE gateway path (`CORTEX_GATEWAY_PUBLISH=1`),
+ * where `start-gateway.ts` constructs `BusInboundSink`. SHADOW mode's contract
+ * is "touch nothing on the bus", so no routing-decision event is emitted there —
+ * the same reason the sink is absent in shadow. The guard below is
+ * defence-in-depth on top of that: undefined `source`/`runtime`, or a runtime
+ * without a `publish` method, skip the emit silently.
+ *
+ * ## No agent, by construction
+ *
+ * A no-binding inbound has no matched agent/stack/principal. Only what the
+ * {@link InboundMessage} carries — `platform` + `instanceId` — is stamped; the
+ * event type's `agent` field was relaxed to optional for exactly this case
+ * (see `SystemGatewayRoutingDecisionOpts.agent`).
+ */
+
+import type { InboundMessage } from "../adapters/types";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { SystemEventSource } from "../bus/system-events";
+import { createSystemGatewayRoutingDecisionEvent } from "../bus/system-events";
+
+/**
+ * The optional bus deps the emit is guarded on. Both come from the gateway boot
+ * path, where they are also handed to {@link BusInboundSink}. Either being
+ * `undefined` (the bus has not connected / no source identity is configured)
+ * skips the emit silently.
+ */
+export interface GatewayUnroutableEmitDeps {
+  /**
+   * The gateway's Myelin runtime. `undefined` before the bus connects; a stub
+   * runtime without a `publish` method is also tolerated (skip, never throw).
+   */
+  runtime: MyelinRuntime | undefined;
+  /**
+   * The gateway's dispatch-source identity (`{principal}.gateway.{instance}`) —
+   * the envelope `source`. `undefined` when no source identity is configured.
+   */
+  source: SystemEventSource | undefined;
+}
+
+/**
+ * Fire-and-forget emit a `system.gateway.routing_decision` for a NO-BINDING
+ * unroutable inbound. Guarded on both optional deps and on the runtime actually
+ * exposing `publish`; on any miss it returns without emitting. Never throws —
+ * the caller runs inside `SurfaceGateway`'s never-throw `onUnroutable` contract.
+ *
+ * Mirrors `BusInboundSink.emitRoutingDecision`: the emit is `void`-discarded and
+ * carries a defence-in-depth `.catch` so a runtime contract change can't crash
+ * the adapter loop.
+ */
+export function emitUnroutableRoutingDecision(
+  deps: GatewayUnroutableEmitDeps,
+  msg: InboundMessage,
+  reason: string,
+): void {
+  const { runtime, source } = deps;
+  if (
+    source === undefined ||
+    runtime === undefined ||
+    typeof runtime.publish !== "function"
+  ) {
+    return;
+  }
+  const env = createSystemGatewayRoutingDecisionEvent({
+    source,
+    outcome: "unroutable",
+    platform: msg.platform,
+    instanceId: msg.instanceId,
+    reason,
+    // No binding matched → no agent / stack / principal / subject to stamp.
+  });
+  // MyelinRuntime.publish signs + swallows its own errors; the extra catch is
+  // defence-in-depth so a runtime contract change can't crash the caller.
+  void runtime.publish(env).catch((err: unknown) => {
+    process.stderr.write(
+      `[surface-gateway] publish(system.gateway.routing_decision) failed — ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  });
+}
+
+/**
+ * Build an `onUnroutable` hook that runs `base` (the breadcrumb — preserves the
+ * stdout fallback) and THEN emits the structured routing-decision event.
+ *
+ * `base` is `SurfaceGateway`'s {@link defaultUnroutableWarn} in production; a
+ * caller-supplied `onUnroutable` is threaded through here instead when one was
+ * passed to the boot path, so its breadcrumb is preserved too. The breadcrumb
+ * runs FIRST so it survives even if the emit is skipped (bus down).
+ *
+ * A throw from `base` is NOT caught here — that is the existing `onUnroutable`
+ * contract, enforced by `SurfaceGateway.handleInbound`'s outer try/catch (the
+ * one adapter-loop firewall). This wrapper adds no new throw surface: the emit
+ * is fully guarded + catch-wrapped.
+ */
+export function makeEmittingUnroutable(
+  base: (msg: InboundMessage, reason: string) => void,
+  deps: GatewayUnroutableEmitDeps,
+): (msg: InboundMessage, reason: string) => void {
+  return (msg, reason) => {
+    base(msg, reason);
+    emitUnroutableRoutingDecision(deps, msg, reason);
+  };
+}

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -54,6 +54,8 @@ import {
   type GatewayAdapterFactory,
 } from "./gateway-adapters";
 import { BusInboundSink } from "./bus-inbound-sink";
+import { defaultUnroutableWarn } from "./surface-gateway";
+import { makeEmittingUnroutable } from "./gateway-unroutable-emit";
 import type { BoundPrincipalStack } from "./binding-resolver";
 import type { SurfaceOwnershipPlan } from "./surface-ownership-plan";
 import type { SurfaceGateway } from "./surface-gateway";
@@ -252,6 +254,25 @@ export async function startGatewayIfEnabled(
       })
     : undefined;
 
+  // cortex#596 — on the LIVE path, decorate `onUnroutable` so a NO-BINDING-match
+  // inbound emits a `system.gateway.routing_decision { outcome: "unroutable" }`
+  // bus event (the signal/MC-consumable replacement for the stdout hunt-line),
+  // NOT just the `console.warn` breadcrumb. This is the upstream twin of the
+  // publish-refusal emit `BusInboundSink` already does (that case matched a
+  // binding; this one matched none). Only wired when the gateway is LIVE
+  // (`publish`), symmetric with the sink: SHADOW mode publishes nothing to the
+  // bus, so it keeps the plain breadcrumb (`opts.onUnroutable` unchanged). The
+  // breadcrumb is preserved as the emit's base (the fallback when the bus is
+  // down); a caller-supplied `onUnroutable` is decorated in its place when one
+  // was passed. The emit itself is fully guarded on runtime/source (see
+  // `emitUnroutableRoutingDecision`).
+  const onUnroutable = publish
+    ? makeEmittingUnroutable(opts.onUnroutable ?? defaultUnroutableWarn, {
+        runtime: opts.runtime,
+        source: opts.source,
+      })
+    : opts.onUnroutable;
+
   process.stdout.write(
     publish
       ? "[surface-gateway] CORTEX_GATEWAY_PUBLISH set — gateway LIVE" +
@@ -265,7 +286,7 @@ export async function startGatewayIfEnabled(
     surfaces,
     adapters,
     ...(sink !== undefined && { sink }),
-    ...(opts.onUnroutable !== undefined && { onUnroutable: opts.onUnroutable }),
+    ...(onUnroutable !== undefined && { onUnroutable }),
   });
 
   // `gw` is defined here (bindings > 0 + adapters built), but the factory

--- a/src/gateway/surface-gateway.ts
+++ b/src/gateway/surface-gateway.ts
@@ -139,15 +139,7 @@ export class SurfaceGateway {
     this.adapters = adapters;
     this.index = index;
     this.sink = sink;
-    this.onUnroutable =
-      opts?.onUnroutable ??
-      ((msg, reason) => {
-        console.warn(
-          `[surface-gateway] unroutable inbound message — dropping. ` +
-            `platform=${msg.platform} instanceId=${msg.instanceId} ` +
-            `channelId=${msg.channelId} reason="${reason}"`,
-        );
-      });
+    this.onUnroutable = opts?.onUnroutable ?? defaultUnroutableWarn;
   }
 
   /**
@@ -320,6 +312,30 @@ export class LoggingInboundSink implements GatewayInboundSink {
 // =============================================================================
 // Internal helpers
 // =============================================================================
+
+/**
+ * The gateway's default `onUnroutable` breadcrumb — a `console.warn` naming the
+ * dropped inbound and the reason.
+ *
+ * Exported (cortex#596) as the single source of truth for the breadcrumb string
+ * so the composition-root's bus-emitting `onUnroutable` (see
+ * `makeEmittingUnroutable` in `gateway-unroutable-emit.ts`) can PRESERVE the
+ * exact stdout breadcrumb — it stays the fallback when the bus is down — while
+ * ALSO emitting the structured `system.gateway.routing_decision` event. Reusing
+ * this function keeps the two in lockstep instead of duplicating the format.
+ *
+ * `onUnroutable` must never throw; `console.warn` does not.
+ */
+export function defaultUnroutableWarn(
+  msg: InboundMessage,
+  reason: string,
+): void {
+  console.warn(
+    `[surface-gateway] unroutable inbound message — dropping. ` +
+      `platform=${msg.platform} instanceId=${msg.instanceId} ` +
+      `channelId=${msg.channelId} reason="${reason}"`,
+  );
+}
 
 /**
  * Derive a human-readable reason string for an unroutable inbound message.


### PR DESCRIPTION
Completes the producer half of #596 (with PR #1667). The no-binding-match unroutable case — an inbound that matches NO surface binding — was still `console.warn` only (`surface-gateway.ts` default `onUnroutable`); arguably the primary dry-run miss the issue names. It now also emits the structured `system.gateway.routing_decision` event (`outcome: unroutable`, `reason` from `unroutableReason()`).

## Design
Composition-root injection (option b): `start-gateway.ts` already holds `runtime` + `source` (it builds `BusInboundSink` from them), so the LIVE path wraps the breadcrumb with `makeEmittingUnroutable(base, {runtime, source})`. `SurfaceGateway` stays free of bus coupling; SHADOW mode ("touch nothing on the bus") keeps the plain warn.

## Changes (5 files, +373/−18)
- `src/gateway/gateway-unroutable-emit.ts` (new) — guarded fire-and-forget emit + decorator (breadcrumb FIRST, so it survives a bus outage; never throws).
- `src/gateway/surface-gateway.ts` — default breadcrumb extracted to exported `defaultUnroutableWarn` (byte-identical string; single source of truth). Zero behavior change.
- `src/bus/system-events.ts` — `agent` relaxed to optional (a no-binding inbound genuinely has no agent; a sentinel would lie). Conditional payload spread; both existing call sites always pass it → backward compatible. JSDoc documents the two unroutable sub-cases discriminated by agent presence.
- `src/gateway/start-gateway.ts` — LIVE path wires the decorator; SHADOW unchanged.
- `src/gateway/__tests__/gateway-unroutable-emit.test.ts` (new, 6 tests) — event shape, all three guard cases, decorator base+emit / base-only-no-throw.

## Verification
`bunx tsc --noEmit` clean · eslint clean · `bun test src/gateway/ src/bus/__tests__/system-events.test.ts` → 219 pass / 0 fail.

## Remaining on #596 after this
Signal tap allow-list (the-metafactory/signal#200, PR in flight) and the MC display fold (#1661). Part of the-metafactory/signal#161.