### PR TITLE
feat(mc): CK-7-shell — GOVERN bar shell (posture-gated rail + banners + member footer) (R2) — Closes #1673

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/govern-bar.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/govern-bar.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * CK-7 (cortex#1673) — GOVERN bar SHELL render tests (DOM-free via
+ * renderToStaticMarkup).
+ *
+ * Pins the shell contract: the admin verb rail is an EMPTY per-verb harness (no
+ * live verbs), the admin gate is the pier-queue `roster_scope==='complete'` gate
+ * (fail-closed for a member/degraded read), the two named banners + doctor drill
+ * mount, the member footer surfaces Leave as CLI TEXT (never a button, invariant
+ * 16), the registry-admin vs hub-admin badges are distinct, and no copy renders
+ * the deprecated posture word (built from fragments so THIS file stays
+ * carve-out-gate-clean).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { GovernBar, type GovernBarProps } from "../components/govern-bar";
+import {
+  GOVERN_VERB_SLOTS,
+  selectAdmissionRequests,
+  governIsAdmin,
+  adminAuthorityBadges,
+} from "../lib/govern-bar-adapter";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+
+const FORBIDDEN = ["oper", "ator"].join(""); // the deprecated posture word
+
+function net(over: Partial<NetworkMembershipDTO> = {}): NetworkMembershipDTO {
+  return {
+    network_id: "tide",
+    leaf_node: "leaf-1",
+    roster_status: "ok",
+    roster_scope: "complete",
+    confidentiality: { mode: "cleartext", key_present: false, key_id: null },
+    members: [],
+    ...over,
+  } as NetworkMembershipDTO;
+}
+
+function member(principal: string, verdict: string): NetworkMembershipDTO["members"][number] {
+  return {
+    principal,
+    verdict: verdict as NetworkMembershipDTO["members"][number]["verdict"],
+    present_stacks: [],
+    accepts: "accepted-network",
+  } as NetworkMembershipDTO["members"][number];
+}
+
+function props(over: Partial<GovernBarProps>): GovernBarProps {
+  return {
+    posture: "admin",
+    networkId: "tide",
+    localPrincipal: "aria",
+    network: net(),
+    ...over,
+  };
+}
+
+function render(over: Partial<GovernBarProps>): string {
+  return renderToStaticMarkup(createElement(GovernBar, props(over)));
+}
+
+describe("GovernBar — admin posture (verb rail harness)", () => {
+  it("renders the verb rail with every slot as an inert harness placeholder", () => {
+    const html = render({});
+    expect(html).toContain("govern-verb-rail");
+    // every taxonomy slot renders…
+    for (const slot of GOVERN_VERB_SLOTS) {
+      expect(html).toContain(`data-verb="${slot.id}"`);
+    }
+    // …and every button is disabled (NO verb is wired in this shell).
+    const buttons = html.match(/govern-verb-btn/g) ?? [];
+    expect(buttons.length).toBe(GOVERN_VERB_SLOTS.length);
+    expect(html).toContain("disabled");
+    // the four decision-gated verbs are honest placeholders
+    expect(html).toContain('data-verb="authorize"');
+    expect(html).toContain('data-verb="seal"');
+    expect(html).toContain('data-verb="rotate"');
+    expect(html).toContain('data-verb="revoke"');
+    // never the deprecated posture word
+    expect(html).not.toContain(FORBIDDEN);
+  });
+
+  it("marks the one already-live slot (dispatch) distinct from the pending ones", () => {
+    const html = render({});
+    expect(html).toContain('data-verb="dispatch"');
+    expect(html).toContain('data-verb-state="live"');
+    expect(html).toContain('data-verb-state="pending"');
+  });
+
+  it("mounts the admission-request banner with an honest pending count (no ids yet)", () => {
+    const html = render({
+      network: net({
+        members: [
+          member("aria", "present"),
+          member("rob", "pending"),
+          member("vincent", "pending"),
+        ],
+      }),
+    });
+    expect(html).toContain("govern-admission-banner");
+    expect(html).toContain('data-pending="2"');
+    expect(html).toContain("2 request");
+    expect(html).toContain("FLG-5");
+    // truth-not-theater: the shell offers no grant/deny action.
+    expect(html.toLowerCase()).not.toContain("grant<");
+    expect(html).not.toContain(FORBIDDEN);
+  });
+
+  it("renders both authority badges (registry-admin vs hub-admin) distinct", () => {
+    const html = render({});
+    expect(html).toContain('data-authority="registry-admin"');
+    expect(html).toContain('data-authority="hub-admin"');
+    expect(html).toContain("registry admin");
+    expect(html).toContain("hub admin");
+  });
+
+  it("mounts the two named banners area (handoff FLG-1 + doctor FLG-3) when a network is dived", () => {
+    const html = render({});
+    expect(html).toContain("govern-banners");
+  });
+
+  it("never renders a Leave button for an admin", () => {
+    const html = render({});
+    expect(html).not.toContain("Leave</button>");
+  });
+});
+
+describe("GovernBar — member posture (footer, no verbs)", () => {
+  it("renders the participate footer and NO verb rail (fail-closed)", () => {
+    const html = render({ posture: "member", network: null });
+    expect(html).not.toContain("govern-verb-rail");
+    expect(html).toContain("govern-member-footer");
+    expect(html).toContain("participate in");
+    expect(html).toContain("tide");
+    expect(html).not.toContain(FORBIDDEN);
+  });
+
+  it("surfaces Leave as CLI TEXT, never a button (invariant 16)", () => {
+    const html = render({ posture: "member", network: null });
+    expect(html).toContain('data-leave="cli-only"');
+    expect(html).toContain("cortex network leave tide");
+    // the deviation from the mockup: Leave is text/state, not a button
+    expect(html).not.toContain("Leave</button>");
+    expect(html).not.toContain("govern-verb-btn");
+  });
+
+  it("keeps the two authority badges distinct in the member footer", () => {
+    const html = render({ posture: "member", network: null });
+    expect(html).toContain('data-authority="registry-admin"');
+    expect(html).toContain('data-authority="hub-admin"');
+  });
+
+  it("falls back to 'this network' copy when no network id is known", () => {
+    const html = render({ posture: "member", networkId: null, network: null });
+    expect(html).toContain("this network");
+    expect(html).toContain("cortex network leave this network");
+  });
+});
+
+describe("GovernBar — fail-closed gate (never trusts posture alone)", () => {
+  it("does NOT render the admin rail for a self-scoped (non-authoritative) read", () => {
+    // roster_scope 'self' ⇒ NOT admin-authoritative, even if a stale posture said admin.
+    const html = render({
+      posture: "admin",
+      network: net({ roster_scope: "self" }),
+    });
+    expect(html).not.toContain("govern-verb-rail");
+    expect(html).not.toContain("govern-admission-banner");
+  });
+
+  it("does NOT render the admin rail for an unreachable roster read", () => {
+    const html = render({
+      posture: "admin",
+      network: net({ roster_status: "unreachable", roster_scope: null }),
+    });
+    expect(html).not.toContain("govern-verb-rail");
+  });
+
+  it("renders a neutral note (no rail, no footer verbs) for unknown posture", () => {
+    const html = render({ posture: null, network: null });
+    expect(html).not.toContain("govern-verb-rail");
+    expect(html).toContain("govern-unknown-note");
+    expect(html).not.toContain(FORBIDDEN);
+  });
+
+  it("does NOT mount the banners area when no network is dived", () => {
+    const html = render({ posture: null, networkId: null, network: null });
+    expect(html).not.toContain("govern-banners");
+  });
+});
+
+describe("govern-bar-adapter — pure gate + selectors", () => {
+  it("governIsAdmin reuses the pier-queue admin-authoritative gate", () => {
+    expect(governIsAdmin(net(), null)).toBe(true);
+    expect(governIsAdmin(net({ roster_scope: "self" }), "admin")).toBe(false);
+    expect(governIsAdmin(net({ roster_status: "unreachable", roster_scope: null }), "admin")).toBe(false);
+  });
+
+  it("governIsAdmin falls back to posture when no network DTO is present", () => {
+    expect(governIsAdmin(null, "admin")).toBe(true);
+    expect(governIsAdmin(null, "member")).toBe(false);
+    expect(governIsAdmin(undefined, null)).toBe(false);
+  });
+
+  it("selectAdmissionRequests returns null for a network the principal does not admin", () => {
+    expect(selectAdmissionRequests(net({ roster_scope: "self" }))).toBeNull();
+    expect(selectAdmissionRequests(null)).toBeNull();
+  });
+
+  it("selectAdmissionRequests counts pending verdicts for an admin network", () => {
+    const summary = selectAdmissionRequests(
+      net({ members: [member("a", "present"), member("b", "pending"), member("c", "pending")] }),
+    );
+    expect(summary).not.toBeNull();
+    expect(summary?.pending).toBe(2);
+    expect(summary?.networkId).toBe("tide");
+  });
+
+  it("exposes two distinct authority badges", () => {
+    const badges = adminAuthorityBadges();
+    expect(badges.map((b) => b.token)).toEqual(["registry-admin", "hub-admin"]);
+    expect(badges[0]?.tone).not.toBe(badges[1]?.tone);
+  });
+
+  it("the verb rail taxonomy has exactly one live slot (dispatch); the rest pending", () => {
+    const live = GOVERN_VERB_SLOTS.filter((s) => s.state === "live");
+    const pending = GOVERN_VERB_SLOTS.filter((s) => s.state === "pending");
+    expect(live.map((s) => s.id)).toEqual(["dispatch"]);
+    expect(pending.map((s) => s.id)).toEqual(["authorize", "seal", "rotate", "revoke"]);
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/govern-bar.css
+++ b/src/surface/mc/dashboard-v2/components/govern-bar.css
@@ -1,0 +1,151 @@
+/*
+ * CK-7 (cortex#1673) — the GOVERN bar SHELL styling.
+ *
+ * Scoped under `.govern-bar`, mounted inside `.mc-cockpit-govern`, so it inherits
+ * the D1 mc-skin tokens (--line/--dim/--faint/--fg/--mono/--sans/--mer/--panel…)
+ * exactly like the rest of the cockpit. SHELL only — the verb slots are inert
+ * placeholders, styled to read as disabled harness affordances (never live).
+ */
+
+.govern-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+}
+
+/* ── The empty per-verb rail (admin only) ─────────────────────────────────── */
+.govern-verb-rail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.govern-verb-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 74px;
+}
+.govern-verb-btn {
+  font: 600 10px var(--mono);
+  letter-spacing: 0.04em;
+  padding: 5px 12px;
+  border: 1px dashed var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--faint);
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+/* The one already-wired slot (dispatch) reads on-brand, not dashed-disabled. */
+.govern-verb-slot.state-live .govern-verb-btn {
+  border-style: solid;
+  border-color: color-mix(in oklch, var(--mer) 40%, transparent);
+  color: var(--mer);
+  opacity: 0.85;
+}
+.govern-verb-flag {
+  font: 500 9px var(--mono);
+  letter-spacing: 0.05em;
+  color: var(--faint);
+  text-transform: uppercase;
+}
+
+/* ── Named banners (admission-request + the FLG-1/FLG-3 mounts) ────────────── */
+.govern-banner {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel);
+  padding: 9px 11px;
+}
+.govern-banner-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 5px;
+}
+.govern-banner-title {
+  font: 700 10px var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.govern-banner-network {
+  font: 500 10px var(--mono);
+  color: var(--dim);
+}
+.govern-banner-body {
+  font: 500 11px var(--mono);
+  color: var(--fg);
+  margin: 0;
+  line-height: 1.5;
+}
+.govern-admission-banner[data-pending="0"] {
+  opacity: 0.8;
+}
+.govern-banners {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* ── Authority badges (registry-admin vs hub-admin — visually distinct) ────── */
+.govern-authority-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.govern-authority-badge {
+  font: 600 9px var(--mono);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+.govern-authority-badge.tone-info {
+  color: var(--tide);
+  border-color: color-mix(in oklch, var(--tide) 45%, transparent);
+  background: color-mix(in oklch, var(--tide) 10%, transparent);
+}
+.govern-authority-badge.tone-accent {
+  color: var(--mer);
+  border-color: color-mix(in oklch, var(--mer) 45%, transparent);
+  background: color-mix(in oklch, var(--mer) 10%, transparent);
+}
+
+/* ── Member footer (participate + CLI-only Leave, invariant 16) ────────────── */
+.govern-member-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.govern-member-note {
+  font: 500 11px var(--mono);
+  color: var(--dim);
+  margin: 0;
+  line-height: 1.5;
+}
+.govern-leave-guidance {
+  font: 500 10px var(--mono);
+  color: var(--faint);
+  margin: 0;
+  line-height: 1.5;
+}
+.govern-leave-cmd {
+  font: 600 10px var(--mono);
+  color: var(--fg);
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--panel);
+}
+
+.govern-unknown-note {
+  font: 500 11px var(--mono);
+  color: var(--faint);
+  margin: 0;
+  line-height: 1.5;
+}

--- a/src/surface/mc/dashboard-v2/components/govern-bar.tsx
+++ b/src/surface/mc/dashboard-v2/components/govern-bar.tsx
@@ -1,0 +1,246 @@
+/**
+ * CK-7 (cortex#1673, docs/plan-mc-future-state.md §4.A) — the **GOVERN bar SHELL**.
+ *
+ * The posture-gated verb rail that the future govern verbs plug into, mounted in
+ * the cockpit's GOVERN lane (`mc-cockpit.tsx`). This slice is the SHELL only —
+ * NO real verbs are wired. It renders:
+ *
+ *   1. ADMIN posture (the pier-queue gate — `governIsAdmin`): the verb RAIL, an
+ *      empty per-verb harness (authorize / seal / rotate / revoke = decision-gated
+ *      placeholders; dispatch = the one already-live slot, CK-3), plus the
+ *      admission-request banner (pending count, NO grant/deny — FLG-5 brings the
+ *      request ids) and the two distinct authority badges (registry / hub admin).
+ *   2. MEMBER posture: the member footer — "You participate in ⟨net⟩ — admission &
+ *      keys are the admin's" — with Leave surfaced as STATE + CLI guidance TEXT,
+ *      explicitly NOT a button (invariant 16), and the two authority badges.
+ *   3. BOTH postures: the two NAMED banners the govern area owns — the handoff
+ *      banner (FLG-1, self-effacing) — and the doctor drill (FLG-3, on-demand).
+ *
+ * Every admin affordance gates on {@link governIsAdmin} (the SAME
+ * `roster_scope === "complete"` admin-authoritative gate the Pier queue uses), so
+ * a non-admin never sees a verb slot — fail-closed. The mockup's on-screen
+ * posture word is the deprecated pre-migration term; this bar renders **admin /
+ * member** only (never lifts the mockup string verbatim).
+ *
+ * PURE (props-only, SSR-renderable) apart from the two self-fetching banner
+ * wrappers ({@link HandoffBannerLive}, {@link DoctorDrill}), which are SSR-inert
+ * (no effect fires until their read/click resolves), so the whole bar renders to
+ * static markup for the tests.
+ */
+
+import type { NetworkPosture } from "../lib/mc-shell-model";
+import type { NetworkMembershipDTO } from "../../api/networks";
+import {
+  GOVERN_VERB_SLOTS,
+  governIsAdmin,
+  selectAdmissionRequests,
+  adminAuthorityBadges,
+} from "../lib/govern-bar-adapter";
+import { HandoffBannerLive } from "./handoff-banner";
+import { DoctorDrill } from "./network-doctor-panel";
+import "./govern-bar.css";
+
+export interface GovernBarProps {
+  /** Posture toward the dived network (`null` at the root / unresolved). */
+  posture: NetworkPosture | null;
+  /** The dived network id — feeds the banners, doctor drill, and footer copy. */
+  networkId: string | null;
+  /** The serving (local) principal — the handoff member + the footer's "you". */
+  localPrincipal: string | null;
+  /**
+   * The dived network's membership DTO, when resolved. Used for the exact
+   * admin-authoritative gate (`isAdminPosture`) and the admission-request count.
+   * `null` above a resolved network ⇒ gate falls back to `posture`.
+   */
+  network?: NetworkMembershipDTO | null;
+}
+
+/** The two authority badges (registry-admin vs hub-admin), kept visually distinct. */
+function AuthorityBadges() {
+  return (
+    <div className="govern-authority-badges" aria-label="Network authorities">
+      {adminAuthorityBadges().map((b) => (
+        <span
+          key={b.token}
+          className={`govern-authority-badge tone-${b.tone}`}
+          data-authority={b.token}
+          title={b.title}
+        >
+          {b.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The empty per-verb rail (admin only). Every slot is a HARNESS placeholder —
+ * the decision-gated verbs are disabled with an honest "lands with FLG-N"
+ * caption; the one `live` slot (dispatch) points at the existing control. No slot
+ * dispatches a real verb in this shell.
+ */
+function VerbRail() {
+  return (
+    <div className="govern-verb-rail" role="group" aria-label="Govern verbs (shell)">
+      {GOVERN_VERB_SLOTS.map((slot) => (
+        <div
+          key={slot.id}
+          className={`govern-verb-slot state-${slot.state}`}
+          data-verb={slot.id}
+          data-verb-state={slot.state}
+        >
+          <button
+            type="button"
+            className="govern-verb-btn"
+            // SHELL: no verb is wired — the slot is inert. The decision-gated
+            // verbs are disabled outright; the live slot is a pointer, not a
+            // second dispatch trigger (the live control renders below the bar).
+            disabled
+            aria-disabled="true"
+            title={slot.caption}
+          >
+            {slot.label}
+          </button>
+          <span className="dim govern-verb-flag" title={slot.caption}>
+            {slot.state === "live" ? "live · " : "soon · "}
+            {slot.flag}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The admission-request banner (admin only). Surfaces the pending COUNT for the
+ * dived network; it deliberately offers NO grant/deny action — the per-request
+ * ids that action needs arrive with FLG-5, so the shell is honest that the
+ * decision affordance is not yet here.
+ */
+function AdmissionRequestBanner({
+  network,
+}: {
+  network: NetworkMembershipDTO | null;
+}) {
+  const summary = selectAdmissionRequests(network);
+  if (summary === null) return null;
+  const plural = summary.pending === 1 ? "" : "s";
+  return (
+    <div
+      className="govern-banner govern-admission-banner"
+      data-network={summary.networkId}
+      data-pending={summary.pending}
+      aria-label={`Admission requests for ${summary.networkId}`}
+    >
+      <div className="govern-banner-head">
+        <span className="govern-banner-title">Admission requests</span>
+        <span className="dim govern-banner-network">{summary.networkId}</span>
+      </div>
+      {summary.pending === 0 ? (
+        <p className="dim govern-banner-body">
+          No pending admission requests on this network.
+        </p>
+      ) : (
+        <p className="govern-banner-body">
+          <strong>
+            {summary.pending} request{plural}
+          </strong>{" "}
+          awaiting admission.{" "}
+          <span className="dim">
+            Grant / deny arrives with FLG-5 (per-request ids) — this shell shows
+            the count honestly, no action yet.
+          </span>
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The member-posture footer. Govern verbs (admission, keys) are the network
+ * admin's — a member participates. Leave is surfaced as STATE + CLI guidance
+ * TEXT, explicitly NOT a button (invariant 16, a recorded deviation from the
+ * mockup). The two authority badges keep registry-admin vs hub-admin distinct.
+ */
+function MemberFooter({
+  networkId,
+  localPrincipal,
+}: {
+  networkId: string | null;
+  localPrincipal: string | null;
+}) {
+  const netLabel = networkId ?? "this network";
+  return (
+    <div className="govern-member-footer" aria-label="Member posture">
+      <p className="govern-member-note">
+        {localPrincipal !== null ? (
+          <>
+            <strong>{localPrincipal}</strong>,{" "}
+          </>
+        ) : null}
+        {/* Kept as one contiguous phrase (no inline element splitting it) so the
+            copy reads plainly and stays greppable. */}
+        you participate in {netLabel} — admission &amp; keys are the network
+        admin&rsquo;s.
+      </p>
+      <AuthorityBadges />
+      {/* Invariant 16 — Leave is CLI-side by design; it is STATE + guidance TEXT,
+          never a button. */}
+      <p
+        className="dim govern-leave-guidance"
+        data-leave="cli-only"
+      >
+        To leave, run{" "}
+        <code className="govern-leave-cmd">cortex network leave {netLabel}</code>{" "}
+        from your stack — leaving is CLI-side by design (there is no Leave button).
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The GOVERN bar shell. Admin ⇒ verb rail + admission banner + authority badges;
+ * member ⇒ member footer; both ⇒ the handoff banner + doctor drill. Unknown
+ * posture (`null`) ⇒ an honest neutral note.
+ */
+export function GovernBar({
+  posture,
+  networkId,
+  localPrincipal,
+  network = null,
+}: GovernBarProps) {
+  const isAdmin = governIsAdmin(network, posture);
+
+  return (
+    <div
+      className="govern-bar"
+      data-posture={posture ?? "unknown"}
+      aria-label="Govern bar"
+    >
+      {isAdmin ? (
+        <>
+          <VerbRail />
+          <AdmissionRequestBanner network={network} />
+          <AuthorityBadges />
+        </>
+      ) : posture === "member" ? (
+        <MemberFooter networkId={networkId} localPrincipal={localPrincipal} />
+      ) : (
+        <p className="dim govern-unknown-note">
+          Govern verbs are the network admin&rsquo;s.
+        </p>
+      )}
+
+      {/* Both postures: the two named banners the govern area owns. Both are
+          self-effacing — the handoff banner renders nothing until its read
+          resolves (and nothing with no local principal); the doctor drill is a
+          collapsed on-demand button. Mounted only when a network is dived. */}
+      {networkId !== null ? (
+        <div className="govern-banners">
+          <HandoffBannerLive networkId={networkId} member={localPrincipal} />
+          <DoctorDrill networkId={networkId} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/mc-cockpit.tsx
+++ b/src/surface/mc/dashboard-v2/components/mc-cockpit.tsx
@@ -39,6 +39,7 @@ import { WorkingGrid } from "./working-grid";
 import { WorkingAggregate } from "./working-aggregate";
 import { GovernanceView } from "./governance-view";
 import { DispatchButton } from "./dispatch-button";
+import { GovernBar } from "./govern-bar";
 import {
   scopeAttention,
   scopeWorkingTiles,
@@ -46,6 +47,7 @@ import {
   cockpitDispatchAgent,
 } from "../lib/mc-cockpit-scope";
 import { stackLabel, type StackCoord, type NetworkPosture } from "../lib/mc-shell-model";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
 import type { AgentPresenceTile } from "../hooks/use-agents";
 import type { WorkingAgentTile } from "../hooks/use-working-agents";
 import type { WorkingStackAggregate } from "../hooks/use-working-aggregation";
@@ -58,6 +60,23 @@ export interface McCockpitProps {
   stack: StackCoord;
   /** Posture toward the selected network (`null` at the root / no network). */
   posture: NetworkPosture | null;
+  /**
+   * CK-7 (cortex#1673) — the dived network id, feeding the GOVERN bar's two
+   * named banners (handoff + admission-request), the doctor drill, and the
+   * member footer copy. `null` when no network is resolved.
+   */
+  networkId?: string | null;
+  /**
+   * CK-7 — the serving (local) principal: the handoff banner's member and the
+   * member footer's "you". `null` ⇒ the handoff banner self-effaces.
+   */
+  localPrincipal?: string | null;
+  /**
+   * CK-7 — the dived network's membership DTO, when resolved. Feeds the GOVERN
+   * bar's admin-authoritative gate (`isAdminPosture`) and the admission-request
+   * count. `null` ⇒ the bar falls back to `posture` for the gate.
+   */
+  network?: NetworkMembershipDTO | null;
   /** Serving principal — classifies own-local vs federated for the dispatch pick. */
   servingPrincipal: string | null;
   /** Live presence agents (whole-dashboard) — scoped to the stack for dispatch. */
@@ -107,6 +126,9 @@ export interface McCockpitProps {
 export function McCockpit({
   stack,
   posture,
+  networkId = null,
+  localPrincipal = null,
+  network = null,
   servingPrincipal,
   presenceAgents,
   workingAgents,
@@ -178,7 +200,7 @@ export function McCockpit({
         />
       </section>
 
-      {/* ── GOVERN — read-only audit + the posture-gated DISPATCH verb ──────── */}
+      {/* ── GOVERN — read-only audit + the CK-7 posture-gated GOVERN bar shell ─ */}
       <section className="mc-cockpit-lane mc-cockpit-govern" aria-label="Govern (stack)">
         <div className="mc-cockpit-lane-head">
           <span className="mc-cockpit-lane-title">GOVERN</span>
@@ -186,9 +208,25 @@ export function McCockpit({
 
         <GovernanceView state={scopedGovernance} />
 
-        <div className="mc-cockpit-dispatch">
-          {isAdmin ? (
-            dispatchTarget && onDispatchDirect ? (
+        {/* CK-7 (cortex#1673) — the GOVERN bar SHELL: the posture-gated verb rail
+            (empty per-verb harness — NO verbs wired), the two named banners
+            (handoff FLG-1 + admission-request), the doctor drill (FLG-3), and the
+            member footer (participate + CLI-only Leave, invariant 16). Every admin
+            affordance gates on the same admin-authoritative read the Pier queue
+            uses (fail-closed). */}
+        <GovernBar
+          posture={posture}
+          networkId={networkId}
+          localPrincipal={localPrincipal}
+          network={network}
+        />
+
+        {/* CK-3 — the one already-LIVE govern verb (direct dispatch), admin
+            posture + own-local + a local agent present. The GOVERN bar's rail
+            names a `dispatch` slot as `live`; THIS is the control it points at. */}
+        {isAdmin ? (
+          <div className="mc-cockpit-dispatch">
+            {dispatchTarget && onDispatchDirect ? (
               <div className="mc-cockpit-dispatch-row">
                 <span className="mc-cockpit-dispatch-label">
                   Dispatch to <strong>{dispatchTarget.label}</strong>
@@ -204,28 +242,11 @@ export function McCockpit({
               <p className="mc-cockpit-note dim">
                 No local agent online to dispatch to on this stack.
               </p>
-            )
-          ) : (
-            <MemberGovernNote posture={posture} />
-          )}
-        </div>
+            )}
+          </div>
+        ) : null}
       </section>
     </div>
-  );
-}
-
-/**
- * The member-posture govern note. Govern verbs (admission, keys, dispatch) are the
- * network admin's — a member observes. Leave is deliberately NOT a button (it is
- * CLI-only by design, invariant 16); CK-7 owns the fuller member footer.
- */
-function MemberGovernNote({ posture }: { posture: NetworkPosture | null }) {
-  return (
-    <p className="mc-cockpit-note dim">
-      {posture === "member"
-        ? "You participate in this network — admission, keys, and dispatch are the network admin's."
-        : "Govern verbs are the network admin's."}
-    </p>
   );
 }
 

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -650,6 +650,13 @@ export function NetworkView({
       <McCockpit
         stack={shellSelection.stack}
         posture={selectedNetworkPosture(networks, shellSelection)}
+        networkId={shellSelection.networkId}
+        localPrincipal={servingPrincipal}
+        network={
+          networks.find(
+            (n) => n.network_id === shellSelection.networkId,
+          ) ?? null
+        }
         servingPrincipal={servingPrincipal}
         presenceAgents={state.agents}
         workingAgents={workingAgents}

--- a/src/surface/mc/dashboard-v2/lib/govern-bar-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/govern-bar-adapter.ts
@@ -1,0 +1,178 @@
+/**
+ * CK-7 (cortex#1673, docs/plan-mc-future-state.md §4.A) — pure model for the
+ * **GOVERN bar SHELL**: the posture-gated verb rail the future govern verbs
+ * (FLG-2/6/8/9) plug into.
+ *
+ * ## SHELL only — no verbs are wired here
+ *
+ * This slice builds the HARNESS, not the verbs. The four govern verbs
+ * (authorize / seal / rotate / revoke) are DECISION-GATED and land later
+ * (FLG-2/6/8/9); this module names the rail's slots and the honest "lands with
+ * FLG-N" captions so the shell is truthful about what is not yet wired. The one
+ * already-LIVE govern verb is DISPATCH (CK-3, cortex#1289) — the rail carries it
+ * as a `live` slot that points at the existing dispatch control rather than
+ * duplicating it.
+ *
+ * ## The gate is the pier-queue gate (they must never drift)
+ *
+ * Every admin affordance gates on {@link isAdminPosture} — the SAME
+ * admin-authoritative (`roster_status === "ok" && roster_scope === "complete"`)
+ * gate the Pier queue (MC-B1) and the command-bar posture pill
+ * (`mc-shell-model.ts`) use. Reusing it is deliberate: an admin rail can never
+ * render on a network the principal cannot prove they administer. Fail-closed —
+ * absent the complete-roster proof, no verb slot renders (buttons never render
+ * for non-admin posture, invariant 8).
+ *
+ * ## Admission requests without ids (honest — FLG-5 brings the ids)
+ *
+ * The admission-request banner surfaces the COUNT of pending admission requests
+ * for a network the principal admins. The per-request ids that a Grant/Deny
+ * action needs arrive with FLG-5; until then the banner renders the pending
+ * count honestly and says so — it offers NO grant/deny affordance (truth-not-
+ * theater).
+ *
+ * Pure: no I/O, no bus, no crypto. Trivially unit-testable.
+ */
+
+import type { NetworkMembershipDTO } from "../../api/networks";
+import { isAdminPosture } from "./pier-queue-adapter";
+
+/** Whether a rail slot is a decision-gated placeholder or an already-wired verb. */
+export type GovernVerbState = "pending" | "live";
+
+/** One slot in the GOVERN verb rail — a per-verb harness, NOT a wired verb. */
+export interface GovernVerbSlot {
+  /** Stable token (also the `data-verb` attribute + React key). */
+  id: "authorize" | "seal" | "rotate" | "revoke" | "dispatch";
+  /** Human label rendered on the (disabled) slot. */
+  label: string;
+  /** The slice that wires this slot LIVE (honest provenance). */
+  flag: string;
+  /** `pending` ⇒ decision-gated placeholder (disabled); `live` ⇒ already wired. */
+  state: GovernVerbState;
+  /** Honest one-liner: what the verb will do + when it lands (or where it lives). */
+  caption: string;
+}
+
+/**
+ * The GOVERN verb rail taxonomy. The four decision-gated verbs are `pending`
+ * placeholders (FLG-2/6/8/9); DISPATCH is `live` (CK-3) and points at the
+ * existing dispatch control below the bar — the rail names it so the taxonomy is
+ * complete, but does NOT re-wire it.
+ */
+export const GOVERN_VERB_SLOTS: readonly GovernVerbSlot[] = [
+  {
+    id: "authorize",
+    label: "Authorize",
+    flag: "FLG-2",
+    state: "pending",
+    caption: "Grant a pending admission request — decision-gated, lands with FLG-2.",
+  },
+  {
+    id: "seal",
+    label: "Seal",
+    flag: "FLG-6",
+    state: "pending",
+    caption: "Seal a member's leaf secret — decision-gated, lands with FLG-6.",
+  },
+  {
+    id: "rotate",
+    label: "Rotate key",
+    flag: "FLG-8",
+    state: "pending",
+    caption: "Rotate the network payload key — decision-gated, lands with FLG-8.",
+  },
+  {
+    id: "revoke",
+    label: "Revoke",
+    flag: "FLG-9",
+    state: "pending",
+    caption: "Revoke a member — decision-gated, lands with FLG-9.",
+  },
+  {
+    id: "dispatch",
+    label: "Dispatch",
+    flag: "CK-3",
+    state: "live",
+    caption: "Already wired — the live dispatch control is below the bar.",
+  },
+] as const;
+
+/**
+ * The admin gate for the GOVERN bar — reuses the Pier-queue gate verbatim so the
+ * two surfaces can never disagree. When a network DTO is present we gate on the
+ * admin-authoritative read (`isAdminPosture`); when only the derived posture
+ * string is available (e.g. above a resolved network) we fall back to it.
+ */
+export function governIsAdmin(
+  network: NetworkMembershipDTO | null | undefined,
+  posture: "admin" | "member" | null,
+): boolean {
+  if (network) return isAdminPosture(network);
+  return posture === "admin";
+}
+
+/** The admin-facing admission-request summary for ONE network (count only, FLG-5 brings ids). */
+export interface AdmissionRequestSummary {
+  networkId: string;
+  leafNode: string;
+  /** Pending admission requests awaiting Tier-2 grant. Ids come with FLG-5. */
+  pending: number;
+}
+
+/**
+ * Project a network DTO into its admission-request summary — ONLY for a network
+ * the principal admins (complete-roster read). A member/degraded read returns
+ * `null` (the pending list is not theirs to see — the same trust boundary the
+ * Pier queue enforces). Pending is counted from the server-computed `pending`
+ * membership verdict; NO request ids are surfaced (FLG-5).
+ */
+export function selectAdmissionRequests(
+  network: NetworkMembershipDTO | null,
+): AdmissionRequestSummary | null {
+  if (!network || !isAdminPosture(network)) return null;
+  const pending = network.members.filter(
+    (m: NetworkMembershipDTO["members"][number]) => m.verdict === "pending",
+  ).length;
+  return {
+    networkId: network.network_id,
+    leafNode: network.leaf_node,
+    pending,
+  };
+}
+
+/** A distinct network-authority badge — registry-admin vs hub-admin (two authorities). */
+export interface AdminAuthorityBadge {
+  /** Stable token (`data-authority`). */
+  token: "registry-admin" | "hub-admin";
+  label: string;
+  /** `.tone-*` class suffix — the two authorities read visually distinct. */
+  tone: "info" | "accent";
+  title: string;
+}
+
+/**
+ * The two network authorities, kept visually distinct (CK-7 acceptance): the
+ * REGISTRY admin owns the admission gate + the roster (who is in the network),
+ * the HUB admin owns the NATS hub + the payload keys (transport + confidentiality).
+ * They are two authorities, not one — a member footer names both so "admission &
+ * keys are the admin's" is honest about which authority owns which.
+ */
+export function adminAuthorityBadges(): readonly AdminAuthorityBadge[] {
+  return [
+    {
+      token: "registry-admin",
+      label: "registry admin",
+      tone: "info",
+      title:
+        "Owns the admission gate and the roster — who is admitted to the network.",
+    },
+    {
+      token: "hub-admin",
+      label: "hub admin",
+      tone: "accent",
+      title:
+        "Owns the NATS hub and the payload keys — transport auth and confidentiality.",
+    },
+  ];
+}


### PR DESCRIPTION
R2 slice **CK-7-shell** — the GOVERN bar SHELL (no live verbs; the govern verbs FLG-2/6/8/9 plug in later).

- `govern-bar.tsx` + `govern-bar-adapter.ts`: a posture-gated verb rail — **fail-closed on `roster_scope==='complete'`** (member/degraded read ⇒ no rail); the rail is an **EMPTY per-verb harness** (authorize/seal/rotate/revoke/dispatch slots), no live verbs.
- **Two named banners** (handoff FLG-1 + admission-request) + **doctor drill** (FLG-3) mounted in the cockpit GOVERN area.
- **Member footer:** Leave surfaced as CLI **text, never a button** (invariant 16); registry-admin vs hub-admin badges distinct.
- Posture vocab admin/member (deprecated word guarded via runtime-assembled test constant). 20 shell-contract tests; tsc 0; eslint 0; vocab PASS.

Rebased onto current main (additive, 0 deletions — CK-8 + gateway intact). Closes #1673. Salvaged from a stalled builder + re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)