### PR TITLE
docs(conf): neutralize real platform IDs in docs + generated CLAUDE.md (#1552)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ The `discord` CLI is provided by the **`metafactory-discord`** arc bundle (ADR-0
 ```bash
 discord post "PR merged, tests passing"              # Default channel
 discord post --channel tasks "Deployed v0.5.0"       # Specific channel
-discord post --thread 1487204875912609844 "Done"     # Specific thread
+discord post --thread 111111111111111111 "Done"     # Specific thread
 discord read                                          # Read last 10 messages
 ```
 

--- a/docs/agents-md/pai-integration.md
+++ b/docs/agents-md/pai-integration.md
@@ -32,7 +32,7 @@ The `discord` CLI is provided by the **`metafactory-discord`** arc bundle (ADR-0
 ```bash
 discord post "PR merged, tests passing"              # Default channel
 discord post --channel tasks "Deployed v0.5.0"       # Specific channel
-discord post --thread 1487204875912609844 "Done"     # Specific thread
+discord post --thread 111111111111111111 "Done"     # Specific thread
 discord read                                          # Read last 10 messages
 ```
 

--- a/docs/design-dm-operator-channel.md
+++ b/docs/design-dm-operator-channel.md
@@ -111,7 +111,7 @@ discord:
             - "mellanon/arc"
       defaultRole: denied                      # Unknown DMs are ignored
       userRoles:                               # Optional: per-user DM roles
-        - users: ["285727653603049472"]        # Jens-Christian Fischer
+        - users: ["222222222222222222"]        # Jens-Christian Fischer
           features: ["chat"]
           disallowedTools: ["Write", "Edit", "NotebookEdit"]
           bashGuard: true                      # Same guards as guild channel

--- a/docs/design-operator-driven-dev-loop.md
+++ b/docs/design-operator-driven-dev-loop.md
@@ -17,7 +17,7 @@ The current dev-loop entry is `pilot tick`: a **standalone `pilot` daemon** scan
 ## 2. The model
 
 ```
-Andreas (Discord, gated to user 1134325176796987522)
+Andreas (Discord, gated to user 333333333333333333)
    │  "@vega implement cortex#1196"        (or: review cortex#1204)
    ▼
 Pilot/vega  — IN-PROCESS meta-factory agent (agents.d fragment, rides the stack identity + runtime)

--- a/docs/design-pilot-restructure.md
+++ b/docs/design-pilot-restructure.md
@@ -138,7 +138,7 @@ Below: every file, one-line responsibility, line count, primary concern.
 
 ### §2.3 Hardcoded `LUNA_DISCORD_ID` and friends — every site
 
-Despite the task framing referring to `LUNA_DISCORD_ID`, the codebase does **not** carry that env var. Instead `src/reviewers.ts:46` hardcodes `discordId: "1487180524542890144"` in the `REVIEWERS.luna` record. The same pattern hardcodes Echo, Ivy, Holly. Fern (GitLab-only) has no `discordId`.
+Despite the task framing referring to `LUNA_DISCORD_ID`, the codebase does **not** carry that env var. Instead `src/reviewers.ts:46` hardcodes `discordId: "444444444444444444"` in the `REVIEWERS.luna` record. The same pattern hardcodes Echo, Ivy, Holly. Fern (GitLab-only) has no `discordId`.
 
 The fragility is the **registry of Discord IDs**, not a single var. Every site:
 
@@ -153,7 +153,7 @@ The fragility is the **registry of Discord IDs**, not a single var. Every site:
 | `src/cli.ts:41` | `import { REVIEWERS, reviewerMentionOrName }` | Used in `pilot release` claim-re-announcement flow. |
 | `src/merge-orchestrator.ts:64-77` | `validateReviewerIdentity(prState.reviews, config.reviewerInfo)` | Reviewer-identity check; reads `reviewer.githubLogin`, NOT `discordId`, but couples the bot-identity model to a static registry. |
 | `src/agent-state.ts:142-148` | `claim.requested-by-mention` event payload carries reviewer identity through the work-item event log | Soft coupling — not a literal `discordId`, but a reviewer-name field whose semantics derive from the static `REVIEWERS` registry. Phase D's "retire LUNA_DISCORD_ID" deliverable retires this too. (Echo cortex#238 round 1 suggestion.) |
-| `tests/discord.test.ts:53-54` | `expect(REVIEWERS.luna.discordId).toBe("1487180524542890144")` | Test pins the literal snowflake. |
+| `tests/discord.test.ts:53-54` | `expect(REVIEWERS.luna.discordId).toBe("444444444444444444")` | Test pins the literal snowflake. |
 
 **Why the registry is a fragility:** every reviewer addition is a source change. Adding a sixth reviewer (e.g. Sage when sage subscribes to `tasks.code-review.generic`) requires editing `reviewers.ts`, updating tests, redeploying. Replacing the static registry with capability-dispatch retires this: pilot publishes a task, the bus dispatches to whatever agent claims the capability. The reviewer's Discord ID becomes a presence detail, not a routing key.
 
@@ -188,7 +188,7 @@ These bear special attention during the move (decide retire-vs-keep):
 
 47 test files, 1:1 with src files for the most part. The pattern is consistent — `src/X.ts` ↔ `tests/X.test.ts`. Some files split (`agent-state.test.ts` + `agent-state-principal-cols.test.ts` + `agent-state-transition.test.ts` + `agent-state-work-items.test.ts`).
 
-**`tests/discord.test.ts:53-54`** is the test that pins `REVIEWERS.luna.discordId === "1487180524542890144"`. This test moves with `reviewers.ts` into `bus/legacy/` and survives unchanged across the restructure; it retires alongside the legacy registry post-cutover.
+**`tests/discord.test.ts:53-54`** is the test that pins `REVIEWERS.luna.discordId === "444444444444444444"`. This test moves with `reviewers.ts` into `bus/legacy/` and survives unchanged across the restructure; it retires alongside the legacy registry post-cutover.
 
 **Test moves track source moves 1:1.** Tests live in `tests/` rather than co-located. The restructure does NOT change that — tests stay flat. Test file paths get a path prefix update on imports (`./fetch` → `../workflow/review/fetch`) but no test rewrites.
 

--- a/docs/design-policy-cutover.md
+++ b/docs/design-policy-cutover.md
@@ -240,9 +240,9 @@ For each `presence.<platform>[instance].roles[]` entry:
 
 ### 6.1 Principal id synthesis from platform IDs
 
-Discord snowflake `1487123456789012345` doesn't fit letter-prefix grammar. The CLI generates a synthetic id:
+Discord snowflake `111111111111111111` doesn't fit letter-prefix grammar. The CLI generates a synthetic id:
 - Use existing display name if reachable (CLI prompts principal to label each platform id during migration)
-- Otherwise `user-{platform[0]}{last-6-of-id}` → e.g. `user-d567890`
+- Otherwise `user-{platform[0]}{last-6-of-id}` → e.g. `user-d111111`
 
 **Open question:** should the migrate-config CLI prompt for friendly names interactively? Or generate synthetic ids and let the principal edit post-migration? Echo's earlier framing on cortex#243 said "Idempotent: running twice produces the same output" — interactive prompting breaks idempotency. Recommendation: synthetic-by-default, optional `--labels labels.yaml` flag for principal-curated names.
 
@@ -340,16 +340,16 @@ Anchoring the design in operational config. Two files: `~/.config/cortex/cortex.
 
 | Role name | Identity | Discord IDs | Cross-agent agreement |
 |---|---|---|---|
-| `operator` | Andreas (the operator human) | `1134325176796987522` | ✓ identical on all 3 agents — features `[chat, async, team]` |
-| `user` | Mike (restricted human user) | `285727653603049472` | ✓ identical on all 3 agents — features `[chat]`, deny `[Write, Edit, NotebookEdit]` |
+| `operator` | Andreas (the operator human) | `333333333333333333` | ✓ identical on all 3 agents — features `[chat, async, team]` |
+| `user` | Mike (restricted human user) | `222222222222222222` | ✓ identical on all 3 agents — features `[chat]`, deny `[Write, Edit, NotebookEdit]` |
 | `agent-restricted` | template, no users assigned | `[]` | ✓ same shape, no holders — could be retired in migration |
-| `agent-luna` | Luna's bot | `1487180524542890144` | ⚠ Luna has it empty (self); Echo + Forge declare it |
-| `agent-echo` | Echo's bot | `1497872105067253800` | ⚠ Luna + Forge declare it with bare `features: [chat]`; Echo's view of itself has tighter tool denies + `allowedSkills: [code-review]` (dead config — self-loop guarded) |
-| `agent-forge` | Forge's bot | `1497954389736947876` | ⚠ Luna declares it with extra `allowedDirs` + `allowedSkills`; Echo declares minimally; Forge's view of itself is dead config |
-| `agent-ivy` | external Ivy bot | `1487024060411023491` | ✓ identical bare `features: [chat]` on all 3 |
-| `agent-holly` | external Holly bot | `1497898452351455393` | ✓ identical bare `features: [chat]` on all 3 |
-| `agent-pilot` | external Pilot bot | `1498571063582392390` | ✓ identical bare `features: [chat]` on all 3 |
-| `agent-juniper` | external Juniper bot | `1498328127259021404` | ✓ identical bare `features: [chat]` on all 3 |
+| `agent-luna` | Luna's bot | `444444444444444444` | ⚠ Luna has it empty (self); Echo + Forge declare it |
+| `agent-echo` | Echo's bot | `555555555555555555` | ⚠ Luna + Forge declare it with bare `features: [chat]`; Echo's view of itself has tighter tool denies + `allowedSkills: [code-review]` (dead config — self-loop guarded) |
+| `agent-forge` | Forge's bot | `666666666666666666` | ⚠ Luna declares it with extra `allowedDirs` + `allowedSkills`; Echo declares minimally; Forge's view of itself is dead config |
+| `agent-ivy` | external Ivy bot | `777777777777777777` | ✓ identical bare `features: [chat]` on all 3 |
+| `agent-holly` | external Holly bot | `888888888888888888` | ✓ identical bare `features: [chat]` on all 3 |
+| `agent-pilot` | external Pilot bot | `999999999999999999` | ✓ identical bare `features: [chat]` on all 3 |
+| `agent-juniper` | external Juniper bot | `000000000000000000` | ✓ identical bare `features: [chat]` on all 3 |
 
 **Total distinct principals after unification: 13** — counted as:
 - 3 local agent bots (luna, echo, forge)
@@ -620,7 +620,7 @@ They CAN share capability id strings — that's good ergonomics — but they don
 **Walk-through within Andreas's own cortex instances:**
 - Within `cortex.yaml`, `policy.principals[]` has ONE entry for `luna` with `home_stack: andreas/meta-factory`
 - Within `cortex.work.yaml`, separate file, ONE entry for `luna` with `home_stack: andreas/work`
-- The Discord bot id `1487180524542890144` appears in `platform_ids.discord` in both files
+- The Discord bot id `444444444444444444` appears in `platform_ids.discord` in both files
 - Each stack reads its own config — no cross-file collision detection needed within Andreas's deployment
 - Federated envelopes carry `signed_by[].principal` AND the chain identifies the originating stack via the stack NKey — the receiving cortex resolves which Luna by `(principal_id, originating_stack)` not just principal_id
 

--- a/docs/migration-examples/after-single-adapter.yaml
+++ b/docs/migration-examples/after-single-adapter.yaml
@@ -1,7 +1,7 @@
 operator:
   id: andreas
   displayName: Andreas
-  discordId: "1134325176796987522"
+  discordId: "333333333333333333"
   dataResidency: NZ
 stack:
   id: andreas/example
@@ -31,7 +31,7 @@ policy:
       trust: []
       platform_ids:
         discord:
-          - "1134325176796987522"
+          - "333333333333333333"
       session_config:
         default:
           bash_guard: true
@@ -47,7 +47,7 @@ policy:
       trust: []
       platform_ids:
         discord:
-          - "285727653603049472"
+          - "222222222222222222"
   roles:
     - id: agent-echo
       capabilities:
@@ -126,14 +126,14 @@ agents:
         roles:
           - name: operator
             users:
-              - "1134325176796987522"
+              - "333333333333333333"
             features:
               - chat
               - async
               - team
           - name: user
             users:
-              - "285727653603049472"
+              - "222222222222222222"
             features:
               - chat
           - name: agent-echo

--- a/docs/migration-examples/before-single-adapter.yaml
+++ b/docs/migration-examples/before-single-adapter.yaml
@@ -5,7 +5,7 @@
 operator:
   id: andreas
   displayName: Andreas
-  discordId: "1134325176796987522"
+  discordId: "333333333333333333"
   dataResidency: NZ
 
 stack:
@@ -27,10 +27,10 @@ agents:
         defaultRole: denied
         roles:
           - name: operator
-            users: ["1134325176796987522"]
+            users: ["333333333333333333"]
             features: [chat, async, team]
           - name: user
-            users: ["285727653603049472"]
+            users: ["222222222222222222"]
             features: [chat]
           - name: agent-echo
             users: ["999000111"]

--- a/docs/sop-migrate-config.md
+++ b/docs/sop-migrate-config.md
@@ -107,8 +107,8 @@ file:
 
 ```yaml
 # labels.yaml
-discord:285727653603049472: mike
-discord:1134325176796987522: andreas
+discord:222222222222222222: mike
+discord:333333333333333333: andreas
 mattermost:abc123: mike
 ```
 


### PR DESCRIPTION
## What

Slice 3 of the cortex#1552 confidentiality sweep — the **docs / SOP / migration-example** tier. Neutralizes every real Discord user/bot snowflake used as a worked example across `docs/**` and the generated `CLAUDE.md`, replacing each with a distinct **all-same-digit sentinel** that clears the `confidentiality-gate` allow-rule (`^0+$` / `^(\d)\1+$`).

Scope is **docs-only**: this PR touches `docs/**` + `CLAUDE.md`. The `src/` fixtures are a separate parallel slice (`fix/conf-1552-src-sweep`) and are **not** touched here. Slicing per the inventory comment on #1552.

## How

- Each distinct real id → a distinct sentinel, applied **consistently within each doc** so worked examples stay coherent (e.g. the operator id and the restricted-user id map to stable sentinels across `design-policy-cutover.md`, the `migration-examples/*.yaml` before/after pair, and `sop-migrate-config.md`).
- YAML keys and `did:`/`discord:` wrappers left intact — only the id literal changes.
- One **derived** worked example (`user-{platform[0]}{last-6-of-id}`) updated so its last-6 stays consistent with its now-sentinel source snowflake.

## CLAUDE.md (generated) discipline

The single flagged `CLAUDE.md` line is the `discord` CLI **thread example**, which is injected from the section file `docs/agents-md/pai-integration.md`. Both were fixed **byte-consistently**. The thread id originates in the **section file**, not the compass template, so **no upstream `compass/templates/CLAUDE.md.template` change is required**. `arc upgrade compass` was deliberately NOT run (it would regenerate ~165 repos).

## Verify

- Block-rule grep over `docs/` + `CLAUDE.md` returns **zero** non-conforming 17–20-digit runs (all remaining runs are all-zero / all-same-digit sentinels).
- Diff is 9 files, 29↔29 line swaps; no `src/` files in the diff.
- Docs-only change — no test suite applies.

Refs #1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)