### PR TITLE
fix(conf): neutralize real platform IDs + internal-domain emails in src/ tests (conf-1552 slice 2)

### DIFF
--- a/src/adapters/discord/__tests__/author-is-principal.test.ts
+++ b/src/adapters/discord/__tests__/author-is-principal.test.ts
@@ -65,7 +65,7 @@ afterEach(() => {
 const SELF_BOT_ID = "self-bot-id";
 const PRINCIPAL_AUTHOR_ID = "principal-author";
 const STRANGER_AUTHOR_ID = "stranger-author";
-const GUILD_ID = "1487023327791808592";
+const GUILD_ID = "111111111111111111";
 
 class FakeClient extends EventEmitter {
   public user = { id: SELF_BOT_ID };

--- a/src/adapters/discord/__tests__/auto-thread.test.ts
+++ b/src/adapters/discord/__tests__/auto-thread.test.ts
@@ -53,7 +53,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 const BOT_ID = "999000111";
-const HUMAN_ID = "285727653603049472";
+const HUMAN_ID = "555555555555555555";
 const CHANNEL_ID = "ch-cortex-1";
 const PARENT_NAME = "cortex";
 

--- a/src/adapters/discord/__tests__/dm-ownership.test.ts
+++ b/src/adapters/discord/__tests__/dm-ownership.test.ts
@@ -155,8 +155,8 @@ async function fireMessageCreate(
 // ---------------------------------------------------------------------------
 
 describe("DiscordAdapter: DM stack-ownership (cortex#709)", () => {
-  const GUILD_A = "1487023327791808592";
-  const GUILD_B = "1512054429023731884";
+  const GUILD_A = "111111111111111111";
+  const GUILD_B = "444444444444444444";
 
   test("same token, one owner + one non-owner: a DM dispatches ONLY on the owner", async () => {
     const owner = makeAdapter({ instanceId: "discord-A", guildId: GUILD_A, dmOwner: true });

--- a/src/adapters/discord/__tests__/guild-filter.test.ts
+++ b/src/adapters/discord/__tests__/guild-filter.test.ts
@@ -201,8 +201,8 @@ async function fireMessageCreate(
 // ---------------------------------------------------------------------------
 
 describe("DiscordAdapter: guild filter (cortex#704)", () => {
-  const GUILD_A = "1487023327791808592"; // meta-factory
-  const GUILD_B = "1512054429023731884"; // halden
+  const GUILD_A = "111111111111111111"; // guild A (placeholder snowflake)
+  const GUILD_B = "444444444444444444"; // guild B (placeholder snowflake)
 
   test("same token, different guildId: guild-A message dispatches only on the guild-A adapter", async () => {
     const a = makeAdapter({ instanceId: "discord-A", guildId: GUILD_A });

--- a/src/adapters/discord/__tests__/trusted-bots.test.ts
+++ b/src/adapters/discord/__tests__/trusted-bots.test.ts
@@ -20,9 +20,9 @@ import { isMentionForBot } from "../client";
 import { DiscordInstanceSchema } from "../../../common/types/config";
 
 const SELF_ID = "1111";
-const PEER_BOT_ID = "1497898452351455393"; // Holly's id from cortex#84 timeline
+const PEER_BOT_ID = "4444444444444444444"; // peer bot (placeholder snowflake)
 const UNTRUSTED_BOT_ID = "9999";
-const HUMAN_ID = "285727653603049472";
+const HUMAN_ID = "555555555555555555";
 
 function makeClient(): Client {
   // isMentionForBot reads `client.user.id` and `message.mentions.has(client.user)`.
@@ -125,15 +125,15 @@ describe("DiscordInstanceSchema.trustedBotIds (cortex#84)", () => {
   test("accepts a populated array of Discord user ids", () => {
     const parsed = DiscordInstanceSchema.parse({
       ...minInstance,
-      trustedBotIds: [PEER_BOT_ID, "1487024060411023491"],
+      trustedBotIds: [PEER_BOT_ID, "2222222222222222222"],
     });
-    expect(parsed.trustedBotIds).toEqual([PEER_BOT_ID, "1487024060411023491"]);
+    expect(parsed.trustedBotIds).toEqual([PEER_BOT_ID, "2222222222222222222"]);
   });
 
   test("coerces numeric ids to strings (snowflakes-as-numbers in YAML)", () => {
     const parsed = DiscordInstanceSchema.parse({
       ...minInstance,
-      trustedBotIds: [1497898452351455393n.toString(), 1487024060411023491n.toString()],
+      trustedBotIds: [4444444444444444444n.toString(), 2222222222222222222n.toString()],
     });
     expect(parsed.trustedBotIds.every((id) => typeof id === "string")).toBe(true);
   });

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -30,7 +30,7 @@ import { readLogicalRouting } from "../../adapters/response-routing-delivery";
  * builds an engine that resolves the two `(platform, authorId)` tuples
  * the publish-path tests use:
  *
- *   - `(discord, 1487204875912609844)` → `andreas`
+ *   - `(discord, 888888888888888888)` → `andreas`
  *   - `(mattermost, 8wkrnxq3abcdef)` → `andreas`
  *
  * Tests that exercise unresolvable inputs (the cortex#420 nit-5
@@ -48,7 +48,7 @@ function makePublishPolicyEngine(): PolicyEngine {
         role: ["operator"],
         trust: [],
         platform_ids: {
-          discord: ["1487204875912609844"],
+          discord: ["888888888888888888"],
           mattermost: ["8wkrnxq3abcdef"],
         },
       },
@@ -61,7 +61,7 @@ function makePublishPolicyEngine(): PolicyEngine {
  * cortex#1167 — the PRODUCTION engine shape: built via `policyEngineFromConfig`
  * (exactly how cortex.ts wires it) so the synthetic `public` principal is
  * registered with `dispatch.<agentId>` per flagged agent. Maps
- * (discord, 1487204875912609844) → andreas (a fully-privileged principal). Used
+ * (discord, 888888888888888888) → andreas (a fully-privileged principal). Used
  * by the round-trip tests that prove the listener's engine.check passes for `public`.
  */
 function makeWiredEngineWithPublic(openOnboardingAgentIds: string[]): PolicyEngine {
@@ -73,7 +73,7 @@ function makeWiredEngineWithPublic(openOnboardingAgentIds: string[]): PolicyEngi
         home_stack: "andreas/meta-factory",
         role: ["operator"],
         trust: [],
-        platform_ids: { discord: ["1487204875912609844"] },
+        platform_ids: { discord: ["888888888888888888"] },
       },
     ],
     roles: [{ id: "operator", capabilities: ["operator", "keyword.chat", "dispatch.test-agent", "dispatch.pier"] }],
@@ -1593,7 +1593,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     taskId: "11111111-1111-4111-8111-111111111111",
     msg: makeMsg({
       platform: "discord",
-      authorId: "1487204875912609844",
+      authorId: "888888888888888888",
       content: "hello",
     }),
     prompt: "user prompt here",
@@ -1710,7 +1710,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       stack: "meta-factory",
       // PRODUCTION engine: built via the factory WITH the public principal
       // granted dispatch.pier (exactly how cortex.ts wires it). It maps
-      // (discord, 1487204875912609844) → andreas; JC's id below is UNMAPPED.
+      // (discord, 888888888888888888) → andreas; JC's id below is UNMAPPED.
       policyEngine: makeWiredEngineWithPublic(["pier"]),
     });
     const adapter = new MockAdapter();
@@ -1723,7 +1723,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
 
     await handler.handleMessage(
       adapter,
-      makeMsg({ platform: "discord", authorId: "285727653603049472", authorName: "JC", content: "hi, I'm new here" }),
+      makeMsg({ platform: "discord", authorId: "555555555555555555", authorName: "JC", content: "hi, I'm new here" }),
       { id: "pier", displayName: "Pier", openOnboarding: true, openOnboardingAllowedTools: ["Read"] },
     );
 
@@ -1787,7 +1787,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
 
     await handler.handleMessage(
       adapter,
-      makeMsg({ platform: "discord", authorId: "1487204875912609844", authorName: "andreas", content: "hello" }),
+      makeMsg({ platform: "discord", authorId: "888888888888888888", authorName: "andreas", content: "hello" }),
       { id: "pier", displayName: "Pier", openOnboarding: true, openOnboardingAllowedTools: ["Read"] },
     );
 
@@ -1823,7 +1823,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       dispatchOpts({
         msg: makeMsg({
           platform: "discord",
-          authorId: "1487204875912609844",
+          authorId: "888888888888888888",
           instanceId: "discord-pai-collab",
           channelId: "C100",
           threadId: "T200",
@@ -2141,7 +2141,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       makeMsg({
         content: "hello",
         platform: "discord",
-        authorId: "1487204875912609844",
+        authorId: "888888888888888888",
       }),
     );
     expect(runtime.subjectPublishes.length).toBe(1);
@@ -2179,7 +2179,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         makeMsg({
           content: "hello",
           platform: "discord",
-          authorId: "1487204875912609844",
+          authorId: "888888888888888888",
         }),
         { id: "juniper", displayName: "Juniper", persona: personaPath },
       );
@@ -2238,7 +2238,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         makeMsg({
           content: "hello",
           platform: "discord",
-          authorId: "1487204875912609844",
+          authorId: "888888888888888888",
         }),
       );
       expect(runtime.subjectPublishes.length).toBe(1);

--- a/src/bus/__tests__/dispatch-source-publisher.test.ts
+++ b/src/bus/__tests__/dispatch-source-publisher.test.ts
@@ -58,7 +58,7 @@ function makePolicyEngine(): PolicyEngine {
         home_stack: "andreas/research",
         role: ["operator"],
         trust: [],
-        platform_ids: { discord: ["1487204875912609844"] },
+        platform_ids: { discord: ["888888888888888888"] },
       },
       {
         id: "holly",
@@ -103,7 +103,7 @@ function makeMsg(overrides: Partial<InboundMessage> = {}): InboundMessage {
   return {
     platform: "discord",
     instanceId: "discord:111222333",
-    authorId: "1487204875912609844",
+    authorId: "888888888888888888",
     authorName: "TestUser",
     channelId: "channel-aaa",
     content: "Hello!",

--- a/src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts
@@ -51,7 +51,7 @@ function loadCortexShape(yamlStr: string): LegacyBotYaml {
 const CORTEX_SHAPE_SINGLE_ADAPTER = `
 operator:
   id: andreas
-  discordId: "1134325176796987522"
+  discordId: "666666666666666666"
   dataResidency: NZ
 stack:
   id: andreas/meta-factory
@@ -70,14 +70,14 @@ agents:
         logChannelId: "3"
         roles:
           - name: operator
-            users: ["1134325176796987522"]
+            users: ["666666666666666666"]
             features: [chat, async, team]
           - name: user
-            users: ["285727653603049472"]
+            users: ["555555555555555555"]
             features: [chat]
             disallowedTools: [Write, Edit, NotebookEdit]
           - name: agent-echo
-            users: ["1497872105067253800"]
+            users: ["3333333333333333333"]
             features: [chat]
         defaultRole: denied
 `;
@@ -91,7 +91,7 @@ describe("convertBotYaml — single-adapter policy synthesis", () => {
     const legacy = loadCortexShape(`
 operator:
   id: andreas
-  discordId: "1134325176796987522"
+  discordId: "666666666666666666"
 stack:
   id: andreas/meta-factory
 agents:
@@ -109,14 +109,14 @@ agents:
         logChannelId: "3"
         roles:
           - name: operator
-            users: ["1134325176796987522"]
+            users: ["666666666666666666"]
             features: [chat, async, team]
           - name: user
-            users: ["285727653603049472"]
+            users: ["555555555555555555"]
             features: [chat]
             disallowedTools: [Write, Edit, NotebookEdit]
           - name: agent-echo
-            users: ["1497872105067253800"]
+            users: ["3333333333333333333"]
             features: [chat]
   - id: echo
     displayName: Echo
@@ -141,17 +141,17 @@ agents:
     // echo is a declared agent → role agent-echo maps to principal "echo"
     expect(ids).toContain("echo");
 
-    // user mike via Discord 285... → user-d049472
-    expect(ids).toContain("user-d049472");
+    // user mike via Discord 555... → user-d555555
+    expect(ids).toContain("user-d555555");
 
     const operator = policy.principals.find((p) => p.id === "operator")!;
-    expect(operator.platform_ids.discord).toContain("1134325176796987522");
+    expect(operator.platform_ids.discord).toContain("666666666666666666");
     expect(operator.role).toContain("operator");
     expect(operator.home_principal).toBe("andreas");
     expect(operator.home_stack).toBe("andreas/meta-factory");
 
-    const user = policy.principals.find((p) => p.id === "user-d049472")!;
-    expect(user.platform_ids.discord).toContain("285727653603049472");
+    const user = policy.principals.find((p) => p.id === "user-d555555")!;
+    expect(user.platform_ids.discord).toContain("555555555555555555");
     expect(user.role).toContain("user");
 
     // operator role got [keyword.chat, keyword.async, keyword.team, dispatch.echo, dispatch.luna, operator, tool.*]
@@ -467,7 +467,7 @@ describe("idempotency", () => {
 describe("--labels override", () => {
   test("label takes precedence over synthesised principal id", () => {
     const labels = new Map<string, string>([
-      ["discord:285727653603049472", "mike"],
+      ["discord:555555555555555555", "mike"],
     ]);
     const legacy = loadCortexShape(`
 operator:
@@ -489,13 +489,13 @@ agents:
         logChannelId: "3"
         roles:
           - name: user
-            users: ["285727653603049472"]
+            users: ["555555555555555555"]
             features: [chat]
 `);
     const result = convertBotYaml(legacy, { labels });
     const ids = result.cortex.policy!.principals.map((p) => p.id);
     expect(ids).toContain("mike");
-    expect(ids).not.toContain("user-d049472");
+    expect(ids).not.toContain("user-d555555");
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -214,7 +214,7 @@ describe("convertBotYaml — trustedAgentBots", () => {
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
       trustedAgentBots: [
         // production shape — id + role only, no symbolic name
-        { id: "1487180524542890144", role: "agent-restricted" },
+        { id: "777777777777777777", role: "agent-restricted" },
       ],
     };
     const result = convertBotYaml(legacy);
@@ -222,7 +222,7 @@ describe("convertBotYaml — trustedAgentBots", () => {
     const warn = result.warnings.find((w) => w.field === "trustedAgentBots");
     expect(warn).toBeDefined();
     expect(warn!.message).toMatch(/missing symbolic `name`/);
-    expect(warn!.message).toMatch(/1487180524542890144/);
+    expect(warn!.message).toMatch(/777777777777777777/);
     expect(warn!.message).toMatch(/role="agent-restricted"/);
   });
 
@@ -1043,7 +1043,7 @@ describe("convertBotYaml — shared agentChannelId warning (cortex#88 item 4)", 
     // because grove's bot.yaml carried one shared #agent-log channel.
     // After migrate-config, all three cortex agents emit with the same
     // id — per-agent log routing silently no-ops.
-    const sharedChannel = "1487029848164536361";
+    const sharedChannel = "999999999999999999";
     const legacy: LegacyBotYaml = {
       agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
       discord: [
@@ -1073,7 +1073,7 @@ describe("convertBotYaml — shared agentChannelId warning (cortex#88 item 4)", 
     const result = convertBotYaml(legacy, {});
     const sharedWarns = result.warnings.filter((w) => w.field === "agents.agentChannelId");
     expect(sharedWarns).toHaveLength(1);
-    expect(sharedWarns[0]!.message).toMatch(/agents \[luna,echo,forge\] share agentChannelId 1487029848164536361/);
+    expect(sharedWarns[0]!.message).toMatch(/agents \[luna,echo,forge\] share agentChannelId 999999999999999999/);
     expect(sharedWarns[0]!.message).toMatch(/set distinct channels in cortex.yaml for per-agent log routing/);
     // The channel id is NOT blanked — operator may want shared logging.
     for (const a of result.cortex.agents) {

--- a/src/common/agents/__tests__/trust-resolver.test.ts
+++ b/src/common/agents/__tests__/trust-resolver.test.ts
@@ -394,12 +394,12 @@ describe("cortex#98 (part B) — auto-populate trustedBotIds from agents[].trust
       agentFixture({ id: "forge" }),
     ));
     resolver.register("discord", ECHO_DISCORD_ID, "echo");
-    resolver.register("discord", "1497954389736947876", "forge");
+    resolver.register("discord", "5555555555555555555", "forge");
 
     const merged = mergeFor(resolver, ["echo", "forge"], "luna", []);
     expect(merged.size).toBe(2);
     expect(merged.has(ECHO_DISCORD_ID)).toBe(true);
-    expect(merged.has("1497954389736947876")).toBe(true);
+    expect(merged.has("5555555555555555555")).toBe(true);
   });
 
   test("operator-explicit trustedBotIds (cross-process bridge) merge with resolver-derived ids", () => {

--- a/src/common/config/__tests__/composer.test.ts
+++ b/src/common/config/__tests__/composer.test.ts
@@ -53,7 +53,7 @@ function fullCortexConfig(): Record<string, unknown> {
     principal: {
       id: "jc",
       displayName: "Jens-Christian",
-      discordId: "285727653603049472",
+      discordId: "555555555555555555",
     },
     claude: { timeoutMs: 300000 },
     nats: {
@@ -73,9 +73,9 @@ function fullCortexConfig(): Record<string, unknown> {
         presence: {
           discord: {
             token: "fake-token-ivy",
-            guildId: "1487023327791808592",
-            agentChannelId: "1487029848164536361",
-            logChannelId: "1487029942129524786",
+            guildId: "111111111111111111",
+            agentChannelId: "999999999999999999",
+            logChannelId: "1111111111111111111",
           },
         },
       },

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -378,7 +378,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
       principal: {
         id: "jc",
         displayName: "Jens-Christian",
-        discordId: "285727653603049472",
+        discordId: "555555555555555555",
       },
       agents: [
         {
@@ -390,9 +390,9 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
           presence: {
             discord: {
               token: "fake-token-ivy",
-              guildId: "1487023327791808592",
-              agentChannelId: "1487029848164536361",
-              logChannelId: "1487029942129524786",
+              guildId: "111111111111111111",
+              agentChannelId: "999999999999999999",
+              logChannelId: "1111111111111111111",
             },
           },
         },
@@ -420,7 +420,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     // `LoadedConfig.principal`.
     expect(principal?.id).toBe("jc");
     expect(principal?.displayName).toBe("Jens-Christian");
-    expect(principal?.discordId).toBe("285727653603049472");
+    expect(principal?.discordId).toBe("555555555555555555");
   });
 
   // fix/c-844 — the mc:/cockpit: blocks must survive the cortex-shape parse.
@@ -488,9 +488,9 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
       presence: {
         discord: {
           token: "fake-token-holly",
-          guildId: "1487023327791808592",
-          agentChannelId: "1487029848164536361",
-          logChannelId: "1487029942129524786",
+          guildId: "111111111111111111",
+          agentChannelId: "999999999999999999",
+          logChannelId: "1111111111111111111",
         },
       },
     });
@@ -719,7 +719,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
 
   test("rejects cortex.yaml carrying legacy top-level `trustedAgentBots:`", () => {
     const cfg = minimalCortex();
-    cfg.trustedAgentBots = [{ id: "1487180524542890144", role: "agent-restricted" }];
+    cfg.trustedAgentBots = [{ id: "777777777777777777", role: "agent-restricted" }];
     const path = writeCortexConfig(testDir, cfg);
     expect(() => loadConfigWithAgents(path)).toThrow(/legacy `trustedAgentBots:`/);
   });
@@ -835,7 +835,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     // `logChannelId`, etc. all quote Discord snowflakes as strings. Verify
     // a quoted snowflake survives the round-trip without any digit-loss
     // from JS Number precision.
-    const snowflake = "1487029848164536361"; // Echo's actual agent-channel snowflake
+    const snowflake = "999999999999999999"; // shared agent-channel snowflake (placeholder)
     const cfg = minimalCortex();
     const firstAgent = (cfg.agents as Record<string, unknown>[])[0]!;
     const discordPresence = (firstAgent.presence as Record<string, unknown>).discord as Record<string, unknown>;
@@ -1024,7 +1024,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     // cortex#429 PR-C — `config.agent.operatorId` retired; principal id
     // is sole-sourced from `LoadedConfig.principal.id` now.
     expect(loaded.principal?.id).toBe("jc");
-    expect(loaded.principal?.discordId).toBe("285727653603049472");
+    expect(loaded.principal?.discordId).toBe("555555555555555555");
   });
 
   // v4.0.0 BREAKING CUT — cortex.yaml requires the canonical `principal:`
@@ -1157,9 +1157,9 @@ describe("S1 (cortex#1159) — exported presence-flatten helpers + boot-path app
   const discordPresence = (over: Record<string, unknown> = {}) => ({
     discord: {
       token: `tok-${Math.random().toString(36).slice(2)}`,
-      guildId: "1487023327791808592",
-      agentChannelId: "1487029848164536361",
-      logChannelId: "1487029942129524786",
+      guildId: "111111111111111111",
+      agentChannelId: "999999999999999999",
+      logChannelId: "1111111111111111111",
       ...over,
     },
   });

--- a/src/common/config/__tests__/surfaces-layer.test.ts
+++ b/src/common/config/__tests__/surfaces-layer.test.ts
@@ -89,9 +89,9 @@ function systemBlocks(): Record<string, unknown> {
 
 const DISCORD_BINDING = {
   token: "fake-token-ivy",
-  guildId: "1487023327791808592",
-  agentChannelId: "1487029848164536361",
-  logChannelId: "1487029942129524786",
+  guildId: "111111111111111111",
+  agentChannelId: "999999999999999999",
+  logChannelId: "1111111111111111111",
 };
 
 const SLACK_BINDING = {

--- a/src/common/config/__tests__/surfaces-on-loaded-config.test.ts
+++ b/src/common/config/__tests__/surfaces-on-loaded-config.test.ts
@@ -56,9 +56,9 @@ afterEach(() => {
 
 const DISCORD_BINDING = {
   token: "fake-token-ivy",
-  guildId: "1487023327791808592",
-  agentChannelId: "1487029848164536361",
-  logChannelId: "1487029942129524786",
+  guildId: "111111111111111111",
+  agentChannelId: "999999999999999999",
+  logChannelId: "1111111111111111111",
 };
 
 const SLACK_BINDING = {

--- a/src/common/config/__tests__/system-layer.test.ts
+++ b/src/common/config/__tests__/system-layer.test.ts
@@ -97,9 +97,9 @@ function stackBlocks(): Record<string, unknown> {
         presence: {
           discord: {
             token: "fake-token-ivy",
-            guildId: "1487023327791808592",
-            agentChannelId: "1487029848164536361",
-            logChannelId: "1487029942129524786",
+            guildId: "111111111111111111",
+            agentChannelId: "999999999999999999",
+            logChannelId: "1111111111111111111",
           },
         },
       },

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -46,7 +46,7 @@ import { join } from "path";
 
 const DESCRIPTOR: NetworkDescriptor = {
   network_id: "metafactory",
-  hub_url: "tls://nats.meta-factory.dev:7422",
+  hub_url: "tls://nats.example.com:7422",
   leaf_port: 7422,
   members: ["andreas", "jc"],
 };
@@ -61,7 +61,7 @@ const BINDING: StackLeafBinding = {
 describe("renderLeafRemote", () => {
   test("produces a structured remote from a descriptor + binding", () => {
     const remote = renderLeafRemote(DESCRIPTOR, BINDING);
-    expect(remote.url).toBe("tls://nats.meta-factory.dev:7422");
+    expect(remote.url).toBe("tls://nats.example.com:7422");
     expect(remote.credentials).toBe(
       "/Users/andreas/.config/nats/andreas.creds",
     );
@@ -78,16 +78,16 @@ describe("renderLeafRemote", () => {
     // / reconstruct the dial URL independently of URL parsing.
     const bareHost: NetworkDescriptor = {
       ...DESCRIPTOR,
-      hub_url: "nats.meta-factory.dev",
+      hub_url: "nats.example.com",
     };
     const remote = renderLeafRemote(bareHost, BINDING);
-    expect(remote.url).toBe("tls://nats.meta-factory.dev:7422");
+    expect(remote.url).toBe("tls://nats.example.com:7422");
   });
 
   test("preserves an explicit port in hub_url over leaf_port (url wins, no double-port)", () => {
     const remote = renderLeafRemote(DESCRIPTOR, BINDING);
     // hub_url already has :7422 — must not become :7422:7422.
-    expect(remote.url).toBe("tls://nats.meta-factory.dev:7422");
+    expect(remote.url).toBe("tls://nats.example.com:7422");
     expect(remote.url).not.toContain(":7422:7422");
   });
 
@@ -108,7 +108,7 @@ describe("renderLeafRemote", () => {
     const noAccount: StackLeafBinding = { credentials: BINDING.credentials };
     const remote = renderLeafRemote(DESCRIPTOR, noAccount);
     expect(remote.account).toBeUndefined();
-    expect(remote.url).toBe("tls://nats.meta-factory.dev:7422");
+    expect(remote.url).toBe("tls://nats.example.com:7422");
     expect(remote.credentials).toBe(BINDING.credentials);
   });
 
@@ -286,12 +286,12 @@ describe("mergeLeafRemotes — idempotency key = network_id", () => {
     // Hub relocated (DD-12) — same network, new url. Must replace in place.
     const relocated: NetworkDescriptor = {
       ...DESCRIPTOR,
-      hub_url: "tls://hub2.meta-factory.dev:7422",
+      hub_url: "tls://hub2.example.com:7422",
     };
     const r2 = renderLeafRemote(relocated, BINDING);
     const twice = mergeLeafRemotes(once, r2);
     expect(twice).toHaveLength(1);
-    expect(twice[0]?.url).toBe("tls://hub2.meta-factory.dev:7422");
+    expect(twice[0]?.url).toBe("tls://hub2.example.com:7422");
   });
 
   test("multi-network (OQ3) composes distinct networks into one array", () => {
@@ -343,7 +343,7 @@ describe("renderLeafIncludeFile — HOCON fragment for a single network", () => 
     const conf = renderLeafIncludeFile(DESCRIPTOR, BINDING);
     expect(conf).toContain("leafnodes");
     expect(conf).toContain("remotes");
-    expect(conf).toContain('url: "tls://nats.meta-factory.dev:7422"');
+    expect(conf).toContain('url: "tls://nats.example.com:7422"');
     expect(conf).toContain(
       'credentials: "/Users/andreas/.config/nats/andreas.creds"',
     );
@@ -372,7 +372,7 @@ describe("renderLeafIncludeFile — HOCON fragment for a single network", () => 
     const noAccount: StackLeafBinding = { credentials: BINDING.credentials };
     const conf = renderLeafIncludeFile(DESCRIPTOR, noAccount);
     // url + credentials still present...
-    expect(conf).toContain('url: "tls://nats.meta-factory.dev:7422"');
+    expect(conf).toContain('url: "tls://nats.example.com:7422"');
     expect(conf).toContain(
       'credentials: "/Users/andreas/.config/nats/andreas.creds"',
     );
@@ -724,7 +724,7 @@ describe("renderLeafRemote — C-1224 Model B secret-auth", () => {
     const remote = renderLeafRemote(DESCRIPTOR, SECRET_BINDING);
     // Clean dial URL — the secret is NOT spliced into the structured url
     // (status/logging surfaces stay secret-free).
-    expect(remote.url).toBe("tls://nats.meta-factory.dev:7422");
+    expect(remote.url).toBe("tls://nats.example.com:7422");
     expect(remote.url).not.toContain("s3cr3t");
     expect(remote.credentials).toBeUndefined();
     expect(remote.secretAuth).toEqual({
@@ -779,7 +779,7 @@ describe("renderLeafIncludeFile — C-1224 Model B secret-auth serialization", (
     const conf = renderLeafIncludeFile(DESCRIPTOR, SECRET_BINDING);
     // userinfo spliced into the dial URL (URL-encoded user:secret@host).
     expect(conf).toContain(
-      'url: "tls://andreas:s3cr3t-leaf-pipe@nats.meta-factory.dev:7422"',
+      'url: "tls://andreas:s3cr3t-leaf-pipe@nats.example.com:7422"',
     );
     // No `.creds` file on a Model-B leaf.
     expect(conf).not.toContain("credentials:");
@@ -804,11 +804,11 @@ describe("renderLeafIncludeFile — C-1224 Model B secret-auth serialization", (
 
   test("the creds path is unchanged — no userinfo, keeps the credentials line", () => {
     const conf = renderLeafIncludeFile(DESCRIPTOR, BINDING);
-    expect(conf).toContain('url: "tls://nats.meta-factory.dev:7422"');
+    expect(conf).toContain('url: "tls://nats.example.com:7422"');
     expect(conf).toContain(
       'credentials: "/Users/andreas/.config/nats/andreas.creds"',
     );
-    expect(conf).not.toContain("@nats.meta-factory.dev");
+    expect(conf).not.toContain("@nats.example.com");
   });
 });
 

--- a/src/common/policy/__tests__/engine.test.ts
+++ b/src/common/policy/__tests__/engine.test.ts
@@ -238,7 +238,7 @@ describe("PolicyEngine — platform-id reverse lookup (cortex#482 / cortex#486)"
   // layer so `originator.identity` carries the RESOLVED principal DID
   // (`did:mf:<principal-id>`), per CONTEXT.md §Dispatch-source. The
   // post-#486 dispatch-listener no longer calls this surface; an
-  // illustrative example like `did:mf:discord-1134325176796987522` is
+  // illustrative example like `did:mf:discord-666666666666666666` is
   // therefore no longer produced anywhere in cortex.
 
   test("registered (platform, author_id) tuple → principal id", () => {
@@ -246,14 +246,14 @@ describe("PolicyEngine — platform-id reverse lookup (cortex#482 / cortex#486)"
       principals: [
         principal({
           id: "andreas",
-          platform_ids: { discord: ["1134325176796987522"] },
+          platform_ids: { discord: ["666666666666666666"] },
         }),
       ],
       roles: [role("operator", ["dispatch.cortex"])],
     });
 
     expect(
-      engine.lookupPrincipalIdByPlatformId("discord", "1134325176796987522"),
+      engine.lookupPrincipalIdByPlatformId("discord", "666666666666666666"),
     ).toBe("andreas");
   });
 
@@ -262,7 +262,7 @@ describe("PolicyEngine — platform-id reverse lookup (cortex#482 / cortex#486)"
       principals: [
         principal({
           id: "andreas",
-          platform_ids: { discord: ["1134325176796987522"] },
+          platform_ids: { discord: ["666666666666666666"] },
         }),
       ],
       roles: [role("operator", [])],
@@ -274,7 +274,7 @@ describe("PolicyEngine — platform-id reverse lookup (cortex#482 / cortex#486)"
     ).toBeUndefined();
     // Known author_id but on a platform this principal doesn't claim.
     expect(
-      engine.lookupPrincipalIdByPlatformId("slack", "1134325176796987522"),
+      engine.lookupPrincipalIdByPlatformId("slack", "666666666666666666"),
     ).toBeUndefined();
     // Platform with no declared principals at all.
     expect(
@@ -301,7 +301,7 @@ describe("PolicyEngine — platform-id reverse lookup (cortex#482 / cortex#486)"
         principal({
           id: "andreas",
           platform_ids: {
-            discord: ["1134325176796987522"],
+            discord: ["666666666666666666"],
             mattermost: ["mm-andreas-id"],
           },
         }),
@@ -310,7 +310,7 @@ describe("PolicyEngine — platform-id reverse lookup (cortex#482 / cortex#486)"
     });
 
     expect(
-      engine.lookupPrincipalIdByPlatformId("discord", "1134325176796987522"),
+      engine.lookupPrincipalIdByPlatformId("discord", "666666666666666666"),
     ).toBe("andreas");
     expect(
       engine.lookupPrincipalIdByPlatformId("mattermost", "mm-andreas-id"),

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -332,7 +332,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
             platform_ids: {
               discord: ["1487123456789012345"],
               slack: ["U01ABCDEF"],
-              email: ["luna@meta-factory.ai"],
+              email: ["luna@example.com"],
               mcp: ["mcp://luna/inbox"],
               http: ["bearer:abc123"],
             },
@@ -343,7 +343,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
       expect(policy.principals[0]?.platform_ids).toEqual({
         discord: ["1487123456789012345"],
         slack: ["U01ABCDEF"],
-        email: ["luna@meta-factory.ai"],
+        email: ["luna@example.com"],
         mcp: ["mcp://luna/inbox"],
         http: ["bearer:abc123"],
       });

--- a/src/common/policy/__tests__/policy-gate.test.ts
+++ b/src/common/policy/__tests__/policy-gate.test.ts
@@ -33,28 +33,28 @@ function principal(overrides: Partial<PolicyPrincipal> = {}): PolicyPrincipal {
 describe("PlatformPrincipalIndex", () => {
   test("resolves (platform, id) → principal id when the principal claims the tuple", () => {
     const idx = new PlatformPrincipalIndex([
-      principal({ id: "luna", platform_ids: { discord: ["1487180524542890144"] } }),
+      principal({ id: "luna", platform_ids: { discord: ["777777777777777777"] } }),
     ]);
-    expect(idx.resolve("discord", "1487180524542890144")).toBe("luna");
+    expect(idx.resolve("discord", "777777777777777777")).toBe("luna");
   });
 
   test("returns undefined for unknown platform", () => {
     const idx = new PlatformPrincipalIndex([
-      principal({ id: "luna", platform_ids: { discord: ["1487180524542890144"] } }),
+      principal({ id: "luna", platform_ids: { discord: ["777777777777777777"] } }),
     ]);
-    expect(idx.resolve("mattermost", "1487180524542890144")).toBeUndefined();
+    expect(idx.resolve("mattermost", "777777777777777777")).toBeUndefined();
   });
 
   test("returns undefined for unknown id on a known platform", () => {
     const idx = new PlatformPrincipalIndex([
-      principal({ id: "luna", platform_ids: { discord: ["1487180524542890144"] } }),
+      principal({ id: "luna", platform_ids: { discord: ["777777777777777777"] } }),
     ]);
     expect(idx.resolve("discord", "9999")).toBeUndefined();
   });
 
   test("returns undefined for an empty index", () => {
     const idx = new PlatformPrincipalIndex([]);
-    expect(idx.resolve("discord", "1487180524542890144")).toBeUndefined();
+    expect(idx.resolve("discord", "777777777777777777")).toBeUndefined();
     expect(idx.size).toBe(0);
   });
 
@@ -63,23 +63,23 @@ describe("PlatformPrincipalIndex", () => {
       principal({
         id: "operator",
         platform_ids: {
-          discord: ["1134325176796987522"],
+          discord: ["666666666666666666"],
           slack: ["U01234"],
         },
       }),
     ]);
-    expect(idx.resolve("discord", "1134325176796987522")).toBe("operator");
+    expect(idx.resolve("discord", "666666666666666666")).toBe("operator");
     expect(idx.resolve("slack", "U01234")).toBe("operator");
     expect(idx.size).toBe(2);
   });
 
   test("indexes multiple principals on different ids", () => {
     const idx = new PlatformPrincipalIndex([
-      principal({ id: "luna", platform_ids: { discord: ["1487180524542890144"] } }),
-      principal({ id: "echo", platform_ids: { discord: ["1497872105067253800"] } }),
+      principal({ id: "luna", platform_ids: { discord: ["777777777777777777"] } }),
+      principal({ id: "echo", platform_ids: { discord: ["3333333333333333333"] } }),
     ]);
-    expect(idx.resolve("discord", "1487180524542890144")).toBe("luna");
-    expect(idx.resolve("discord", "1497872105067253800")).toBe("echo");
+    expect(idx.resolve("discord", "777777777777777777")).toBe("luna");
+    expect(idx.resolve("discord", "3333333333333333333")).toBe("echo");
   });
 
   test("PR #310 r1 N-1 — uses `:` separator so prefix-aliased platform names don't collide", () => {
@@ -100,11 +100,11 @@ describe("PlatformPrincipalIndex", () => {
       principal({
         id: "operator",
         platform_ids: {
-          discord: ["1134325176796987522"],
+          discord: ["666666666666666666"],
           slack: ["U01234", "U05678"],
         },
       }),
-      principal({ id: "luna", platform_ids: { discord: ["1487180524542890144"] } }),
+      principal({ id: "luna", platform_ids: { discord: ["777777777777777777"] } }),
     ]);
     expect(idx.size).toBe(4);
   });
@@ -123,13 +123,13 @@ describe("buildPlatformPrincipalIndex", () => {
   test("returns a populated index when principals are declared", () => {
     const policy: Policy = {
       principals: [
-        principal({ id: "luna", platform_ids: { discord: ["1487180524542890144"] } }),
+        principal({ id: "luna", platform_ids: { discord: ["777777777777777777"] } }),
       ],
       roles: [],
     };
     const idx = buildPlatformPrincipalIndex(policy);
     expect(idx).toBeDefined();
-    expect(idx?.resolve("discord", "1487180524542890144")).toBe("luna");
+    expect(idx?.resolve("discord", "777777777777777777")).toBe("luna");
   });
 });
 

--- a/src/common/policy/__tests__/resolve-access.test.ts
+++ b/src/common/policy/__tests__/resolve-access.test.ts
@@ -33,11 +33,11 @@ import type { InboundMessage } from "../../../adapters/types";
 function msg(overrides: Partial<InboundMessage> = {}): InboundMessage {
   return {
     platform: "discord",
-    instanceId: "1487023327791808592",
-    authorId: "1134325176796987522",
+    instanceId: "111111111111111111",
+    authorId: "666666666666666666",
     authorName: "andreas",
     content: "hello",
-    channelId: "1487029848164536361",
+    channelId: "999999999999999999",
     timestamp: new Date("2026-05-17T00:00:00Z"),
     ...overrides,
   } as InboundMessage;
@@ -60,7 +60,7 @@ const OPERATOR_POLICY: Policy = {
       home_stack: "andreas/meta-factory",
       role: ["operator"],
       trust: [],
-      platform_ids: { discord: ["1134325176796987522"] },
+      platform_ids: { discord: ["666666666666666666"] },
     },
   ],
   roles: [
@@ -88,7 +88,7 @@ const USER_POLICY: Policy = {
       home_stack: "andreas/meta-factory",
       role: ["user"],
       trust: [],
-      platform_ids: { discord: ["285727653603049472"] },
+      platform_ids: { discord: ["555555555555555555"] },
     },
   ],
   roles: [
@@ -194,7 +194,7 @@ describe("resolvePolicyAccess — unknown principal deny path", () => {
 
 describe("anonOnboardingAccess — zero-authority anonymous principal (cortex#1165)", () => {
   test("allows chat ONLY — async + team stay false (no privileged keywords)", () => {
-    const result = anonOnboardingAccess(msg({ authorId: "285727653603049472" }));
+    const result = anonOnboardingAccess(msg({ authorId: "555555555555555555" }));
     expect(result.allowed).toBe(true);
     expect(result.features.chat).toBe(true);
     expect(result.features.async).toBe(false);
@@ -227,12 +227,12 @@ describe("anonOnboardingAccess — zero-authority anonymous principal (cortex#11
   });
 
   test("marks the decision as anon, keeping the per-sender id as an AUDIT label only", () => {
-    const result = anonOnboardingAccess(msg({ platform: "discord", authorId: "285727653603049472" }));
+    const result = anonOnboardingAccess(msg({ platform: "discord", authorId: "555555555555555555" }));
     expect(result.anonPrincipal).toBe(true);
     // cortex#1167 — this is an audit label, NOT the authority. Authority is the
     // single `public` principal (proven in the buildPublicPrincipalEntries +
     // dispatch-handler round-trip tests).
-    expect(result.anonPrincipalId).toBe("anon:discord:285727653603049472");
+    expect(result.anonPrincipalId).toBe("anon:discord:555555555555555555");
   });
 
   test("threads isDM through when the inbound was a DM", () => {
@@ -344,7 +344,7 @@ describe("buildPublicPrincipalEntries — single minimal-privilege public princi
 describe("resolvePolicyAccess — happy path (user)", () => {
   test("user principal with keyword.chat allows chat feature only", () => {
     const result = resolvePolicyAccess({
-      msg: msg({ authorId: "285727653603049472" }),
+      msg: msg({ authorId: "555555555555555555" }),
       ...buildHarness(USER_POLICY),
     });
     expect(result.allowed).toBe(true);
@@ -357,7 +357,7 @@ describe("resolvePolicyAccess — happy path (user)", () => {
     // The content-filter trust gate keys off `trusted`. A recognized peer
     // principal must NOT carry it — they keep the prompt-injection hard block.
     const result = resolvePolicyAccess({
-      msg: msg({ authorId: "285727653603049472" }),
+      msg: msg({ authorId: "555555555555555555" }),
       ...buildHarness(USER_POLICY),
     });
     expect(result.allowed).toBe(true);
@@ -366,7 +366,7 @@ describe("resolvePolicyAccess — happy path (user)", () => {
 
   test("user without async or team caps gets toolRestrictions for ungranted tools", () => {
     const result = resolvePolicyAccess({
-      msg: msg({ authorId: "285727653603049472" }),
+      msg: msg({ authorId: "555555555555555555" }),
       ...buildHarness(USER_POLICY),
     });
     expect(result.allowed).toBe(true);
@@ -393,7 +393,7 @@ describe("resolvePolicyAccess — operator short-circuit", () => {
       ],
     };
     const result = resolvePolicyAccess({
-      msg: msg({ authorId: "1134325176796987522" }),
+      msg: msg({ authorId: "666666666666666666" }),
       ...buildHarness(operatorOnly),
     });
     expect(result.allowed).toBe(true);
@@ -408,7 +408,7 @@ describe("resolvePolicyAccess — operator short-circuit", () => {
     // set ONLY for the operator role (conservative boundary) — see the
     // companion peer-principal assertion in the user happy-path block.
     const result = resolvePolicyAccess({
-      msg: msg({ authorId: "1134325176796987522" }),
+      msg: msg({ authorId: "666666666666666666" }),
       ...buildHarness(OPERATOR_POLICY),
     });
     expect(result.allowed).toBe(true);
@@ -437,7 +437,7 @@ describe("resolvePolicyAccess — session_config selection", () => {
       roles: USER_POLICY.roles,
     };
     const result = resolvePolicyAccess({
-      msg: msg({ authorId: "285727653603049472", isDM: false }),
+      msg: msg({ authorId: "555555555555555555", isDM: false }),
       ...buildHarness(withSession),
     });
     expect(result.dirRestrictions).toEqual(["~/Developer/grove"]);
@@ -463,7 +463,7 @@ describe("resolvePolicyAccess — session_config selection", () => {
       roles: USER_POLICY.roles,
     };
     const result = resolvePolicyAccess({
-      msg: msg({ authorId: "285727653603049472", isDM: true }),
+      msg: msg({ authorId: "555555555555555555", isDM: true }),
       ...buildHarness(withSession),
     });
     expect(result.dirRestrictions).toEqual([
@@ -489,7 +489,7 @@ describe("resolvePolicyAccess — session_config selection", () => {
       roles: USER_POLICY.roles,
     };
     const result = resolvePolicyAccess({
-      msg: msg({ authorId: "285727653603049472", isDM: true }),
+      msg: msg({ authorId: "555555555555555555", isDM: true }),
       ...buildHarness(withSession),
     });
     expect(result.dirRestrictions).toEqual(["~/Developer/grove"]);
@@ -529,12 +529,12 @@ describe("resolvePolicyAccess — lockout path", () => {
 describe("isOperatorPrincipal", () => {
   test("returns true when the resolved principal has the operator capability", () => {
     const { engine, index } = buildHarness(OPERATOR_POLICY);
-    expect(isOperatorPrincipal("discord", "1134325176796987522", engine, index)).toBe(true);
+    expect(isOperatorPrincipal("discord", "666666666666666666", engine, index)).toBe(true);
   });
 
   test("returns false when the resolved principal lacks the operator capability", () => {
     const { engine, index } = buildHarness(USER_POLICY);
-    expect(isOperatorPrincipal("discord", "285727653603049472", engine, index)).toBe(false);
+    expect(isOperatorPrincipal("discord", "555555555555555555", engine, index)).toBe(false);
   });
 
   test("returns false when the (platform, id) tuple resolves to no principal", () => {
@@ -543,7 +543,7 @@ describe("isOperatorPrincipal", () => {
   });
 
   test("returns false when engine is undefined (no-policy deployment)", () => {
-    expect(isOperatorPrincipal("discord", "1134325176796987522", undefined, undefined)).toBe(false);
+    expect(isOperatorPrincipal("discord", "666666666666666666", undefined, undefined)).toBe(false);
   });
 });
 
@@ -601,7 +601,7 @@ describe("resolvePolicyAccess — facilitator-role: pylon locked-out as sender (
           home_stack: "andreas/work",
           role: ["operator"],
           trust: [],
-          platform_ids: { discord: ["1134325176796987522"] },
+          platform_ids: { discord: ["666666666666666666"] },
         },
       ],
       roles: [

--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -263,7 +263,7 @@ describe("CapabilitySchema.provided_by", () => {
     // letter-prefix regex; once one tightens, the other must too — that's
     // why they're enforced as a single coordinated edit in cortex#145.
     expect(() =>
-      CapabilitySchema.parse(minCapability({ provided_by: ["1497204875912609844"] })),
+      CapabilitySchema.parse(minCapability({ provided_by: ["6666666666666666666"] })),
     ).toThrow(/starting with a letter/);
   });
 

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -277,7 +277,7 @@ describe("AgentSchema", () => {
   });
 
   test("rejects all-digit agent id (Discord-snowflake paste-bug)", () => {
-    expect(() => AgentSchema.parse(minAgent({ id: "1497204875912609844" }))).toThrow(
+    expect(() => AgentSchema.parse(minAgent({ id: "6666666666666666666" }))).toThrow(
       /starting with a letter/,
     );
   });
@@ -301,7 +301,7 @@ describe("AgentSchema", () => {
     // deterministically — pre-#145 the regex was `^[a-z0-9-]+$` and digit-only
     // entries silently slipped past the structural check.
     expect(() => AgentSchema.parse(minAgent({
-      trust: ["echo", "1497898452351455393"], // ← Discord id, all digits
+      trust: ["echo", "4444444444444444444"], // ← Discord id, all digits
     }))).toThrow(/starting with a letter/);
     expect(() => AgentSchema.parse(minAgent({ trust: ["Echo"] }))).toThrow();
     expect(() => AgentSchema.parse(minAgent({ trust: ["echo bot"] }))).toThrow();

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -173,9 +173,9 @@ const SAME_TOKEN_DISCORD_SURFACES: Surfaces = {
       stack: "jc/default",
       binding: {
         token: "tok-juniper",
-        guildId: "1487023327791808592",
-        agentChannelId: "1487023328324616266",
-        logChannelId: "1487023328324616266",
+        guildId: "111111111111111111",
+        agentChannelId: "222222222222222222",
+        logChannelId: "222222222222222222",
       },
     },
     {
@@ -184,8 +184,8 @@ const SAME_TOKEN_DISCORD_SURFACES: Surfaces = {
       binding: {
         token: "tok-juniper",
         guildId: "555666777888999000",
-        agentChannelId: "1513296336739635322",
-        logChannelId: "1513296336739635322",
+        agentChannelId: "333333333333333333",
+        logChannelId: "333333333333333333",
       },
     },
   ],
@@ -198,9 +198,9 @@ const SAME_TOKEN_DIFFERENT_STACKS_DISCORD_SURFACES: Surfaces = {
       stack: "jc/default",
       binding: {
         token: "tok-juniper",
-        guildId: "1487023327791808592",
-        agentChannelId: "1487023328324616266",
-        logChannelId: "1487023328324616266",
+        guildId: "111111111111111111",
+        agentChannelId: "222222222222222222",
+        logChannelId: "222222222222222222",
       },
     },
     {
@@ -209,8 +209,8 @@ const SAME_TOKEN_DIFFERENT_STACKS_DISCORD_SURFACES: Surfaces = {
       binding: {
         token: "tok-juniper",
         guildId: "555666777888999000",
-        agentChannelId: "1513296336739635322",
-        logChannelId: "1513296336739635322",
+        agentChannelId: "333333333333333333",
+        logChannelId: "333333333333333333",
       },
     },
   ],
@@ -314,17 +314,17 @@ describe("buildGatewayAdapters", () => {
     expect(calls[0]?.platform).toBe("discord");
     expect(calls[0]?.instanceId).toMatch(/^discord:token:[0-9a-f]{12}$/);
     expect(calls[0]?.allowedGuildIds).toEqual([
-      "1487023327791808592",
+      "111111111111111111",
       "555666777888999000",
     ]);
     expect(calls[0]?.presenceByGuildId).toEqual({
-      "1487023327791808592": {
-        agentChannelId: "1487023328324616266",
-        logChannelId: "1487023328324616266",
+      "111111111111111111": {
+        agentChannelId: "222222222222222222",
+        logChannelId: "222222222222222222",
       },
       "555666777888999000": {
-        agentChannelId: "1513296336739635322",
-        logChannelId: "1513296336739635322",
+        agentChannelId: "333333333333333333",
+        logChannelId: "333333333333333333",
       },
     });
   });
@@ -338,11 +338,11 @@ describe("buildGatewayAdapters", () => {
 
     expect(adapters.length).toBe(2);
     expect(calls.map((call) => call.instanceId)).toEqual([
-      "discord:1487023327791808592",
+      "discord:111111111111111111",
       "discord:555666777888999000",
     ]);
     expect(calls.map((call) => call.allowedGuildIds)).toEqual([
-      ["1487023327791808592"],
+      ["111111111111111111"],
       ["555666777888999000"],
     ]);
   });

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -271,9 +271,9 @@ describe("startGatewayIfEnabled — flag on", () => {
           stack: "jc/default",
           binding: {
             token: "tok-juniper",
-            guildId: "1487023327791808592",
-            agentChannelId: "1487023328324616266",
-            logChannelId: "1487023328324616266",
+            guildId: "111111111111111111",
+            agentChannelId: "222222222222222222",
+            logChannelId: "222222222222222222",
           },
         },
         {
@@ -282,8 +282,8 @@ describe("startGatewayIfEnabled — flag on", () => {
           binding: {
             token: "tok-juniper",
             guildId: "555666777888999000",
-            agentChannelId: "1513296336739635322",
-            logChannelId: "1513296336739635322",
+            agentChannelId: "333333333333333333",
+            logChannelId: "333333333333333333",
           },
         },
       ],


### PR DESCRIPTION
## What

Slice 2 of the **cortex#1552** confidentiality sweep — the **test files / fixtures under `src/` ONLY** slice. Docs, SOPs, and migration-examples are a separate parallel slice and are **not** touched here (nothing under `docs/` or `CLAUDE.md`).

Removes from committed test files:
- The **real** Discord guild / channel / user snowflakes confirmed real by the principal (see #1552) — two real guilds, two real channels, one real user, one real user/bot.
- The **high-entropy sibling snowflakes** used as fixtures across the same suites that carry the real-snowflake signature (non-round timestamp-encoded values, incl. one commented as a real peer-bot id) — per the issue's "when in doubt, neutralize" directive and the committed-path rule.
- The **3 tier2 internal-domain-email BLOCKs** under `src/` (two email fixtures on the org domain, plus a Model-B leaf URL whose userinfo segment read as an org-domain email shape).

PR #1670 (slice 1) already neutralized its 4 gate-flagged files — those are not re-touched. The sentinel this PR uses for the primary real guild matches the `discord:` instance form #1670 established, so the two slices stay coherent.

## Method

- Each distinct real / suspect snowflake maps to a **distinct all-same-digit sentinel** (18-19 digits) that satisfies both the engine allow-rule and the config-schema snowflake **shape** (several sites flow through the config loader/schema).
- Applied **tree-wide across the touched files** so fixtures, expectations, embedded id strings, regex-match assertions, and BigInt literals all stay coherent.
- Internal-domain email fixtures rewritten to the `example.com` domain; the NATS Model-B leaf URL host rewritten likewise.
- Revealing deployment / person labels in trailing comments scrubbed to generic placeholders.
- One derived synthetic-id expectation (computed by the migrate-config policy synthesis from the snowflake's trailing digits) updated to track the new sentinel.

## Verification

- **Zero** real / suspect snowflakes remain under `src/` (grep verified).
- **Zero** internal-domain email shapes remain under `src/`.
- **24 modified suites green: 876 pass / 0 fail.**
- `bunx tsc --noEmit` clean; `bunx eslint --quiet` on changed files clean.
- Broad scoped run parity with pristine `origin/main` (same ~20 pre-existing environmental / flaky failures in **untouched** `network-*` / `stack-cli` / `e2e-lifecycle` files under parallel temp-dir/port contention — not introduced here).

## Intentionally left (out of scope)

The tier2 platform-snowflake shape-check still flags **pre-existing synthetic placeholders** that aren't all-same-digit (sequential, patterned, or round-prefix fixture values). These are the **#1392 synthetic-backlog tuning question**, which the #1552 inventory explicitly calls distinct from the real-ID sweep. None are real; all pre-date this branch. Left untouched to keep this slice scoped to real-ID + internal-domain-email eradication.

Refs #1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)