### PR TITLE
feat(cc-events): CORTEX_INGEST_URL override + document the JSONL fallback (#1677)

### DIFF
--- a/src/taps/cc-events/hooks/EventLogger.hook.ts
+++ b/src/taps/cc-events/hooks/EventLogger.hook.ts
@@ -81,7 +81,19 @@ function isHookEventName(v: string): v is HookEventName {
 
 const EVENTS_DIR = join(process.env.HOME ?? "~", ".claude", "events");
 const RAW_DIR = join(EVENTS_DIR, "raw");
-const INGEST_URL = "http://localhost:8766/api/events/ingest";
+// cortex#1677: the relay is OPTIONAL. The env var below overrides the
+// default target for a moved/rebound relay; when unset, the literal
+// fallback is used (fresh installs with no relay configured will
+// fast-fail here). Either way, `postEvent()` below has a 500ms timeout
+// and swallows all errors, and every event is ALSO always written to
+// JSONL under `~/.claude/events/raw/*.jsonl` via `writeToJsonl()`
+// regardless of POST outcome — the relay is a nice-to-have forwarder,
+// not a dependency, and this hook never blocks the agent on it. No
+// `GROVE_*` fallback here: this is a new var (cortex#774's
+// CORTEX_*/GROVE_* dual-read pattern is only for names being migrated,
+// not newly introduced ones).
+const INGEST_URL =
+  process.env.CORTEX_INGEST_URL ?? "http://localhost:8766/api/events/ingest";
 
 // =============================================================================
 // Session Scoping (T-2.2)


### PR DESCRIPTION
Closes #1677 (epic #1678 — Vincent's fresh-install feedback, Wave 1).

## What

`src/taps/cc-events/hooks/EventLogger.hook.ts` only:

- `INGEST_URL` now resolves `process.env.CORTEX_INGEST_URL ?? "http://localhost:8766/api/events/ingest"`. New var — deliberately **no** GROVE_* fallback (per issue; the CORTEX-first pattern of cortex#774 applies to legacy vars only).
- Doc comment above it states the contract: the relay is **optional** — when absent, events land in `~/.claude/events/*.jsonl` only and the POST fast-fails within 500ms; the hook never blocks the agent.

Scope note: the issue's step 3 (a postinstall output line) is **intentionally deferred to #1675** — that lane owns `scripts/postinstall.sh` and already specs the events-buffer line. Noted on the issue.

## Verification (implementer)

- grep: exactly 1 `CORTEX_INGEST_URL` hit at the const
- Behavioral: scratch `Bun.serve` listener on :9999 + `CORTEX_INGEST_URL` override → POST received, exit 0; unset env → behavior identical to today
- `bun test src/taps/cc-events` → **184 pass / 0 fail** · `bunx tsc --noEmit` → 0 errors (baseline also 0)

Independent fresh-context review to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)