### PR TITLE
fix(network): C-1652 — thread --network into admit's read claim (per-network admin 403)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-admit.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-admit.test.ts
@@ -1120,6 +1120,49 @@ describe("cortex network admit — live registry round-trip (cortex#1517 S3)", (
     });
   });
 
+  // cortex#1652 — the PER-NETWORK admin read path (#1321 + FND-5). The live
+  // incident: a per-network admin's `admit --apply` 403'd `admin_not_authorized`
+  // on the row GET because the CLI's read claim carried no `network_id` (the
+  // registry authorizes a non-global admin ONLY for a claim naming a network
+  // they administer). `--network <id>` now threads into the signed read claim.
+  test("READ: per-network admin is 403 unscoped, authorized with --network (cortex#1652)", async () => {
+    const { env, adminSeedPath } = await liveRegistryEnv();
+
+    // A second admin identity that is NOT on the global allowlist…
+    const { seedPath: perNetSeedPath, adminPubkey: perNetPubkey } = await mintAdminSeed();
+    expect(env.REGISTRY_ADMIN_PUBKEYS).not.toContain(perNetPubkey);
+
+    await withLiveRegistry(env, async () => {
+      // …but IS the per-network admin of "netx" (global admin attests it).
+      const created = await dispatchNetwork([
+        "create", "netx",
+        "--hub", "tls://hub.example:7422", "--leaf-port", "7422",
+        "--network-admins", perNetPubkey,
+        "--admin-seed", adminSeedPath,
+        "--apply",
+      ]);
+      expect(created.exitCode).toBe(0);
+
+      // UNSCOPED read claim from the per-network admin → the registry's FND-5
+      // gate refuses (a non-global admin may not read all networks).
+      const unscoped = await dispatchNetwork([
+        "admit", "--list-pending",
+        "--admin-seed", perNetSeedPath,
+        "--json",
+      ]);
+      expect(unscoped.exitCode).not.toBe(0);
+
+      // SCOPED to their own network → authorized (list may be empty — the
+      // assertion is the AUTH outcome, not row contents).
+      const scoped = await dispatchNetwork([
+        "admit", "--list-pending", "--network", "netx",
+        "--admin-seed", perNetSeedPath,
+        "--json",
+      ]);
+      expect(scoped.exitCode).toBe(0);
+    });
+  });
+
   test("WRITE: --apply admit's buildAdmissionDecisionBody output is accepted by the live registry (PENDING -> ADMITTED)", async () => {
     const { env, adminSeedPath } = await liveRegistryEnv();
 

--- a/src/cli/cortex/commands/network-admit-adapters.ts
+++ b/src/cli/cortex/commands/network-admit-adapters.ts
@@ -73,6 +73,14 @@ export interface LiveAdmitPortsConfig {
    *  add-member`). Only meaningful for `admit` (`reject` never seals).
    *  Production omits it → the live secret-ports adapters. */
   secretPortsFactory?: SecretPortsFactory;
+  /**
+   * cortex#1652 — OPTIONAL network scope for the admin-signed READS
+   * (`getRequest`/`listRequests`). REQUIRED for a per-network admin (#1321):
+   * the registry's FND-5 read gate 403s an unscoped read claim from a
+   * non-global admin. A global admin may omit it (unscoped) or supply it
+   * (registry narrows the read). Wired from `--network`.
+   */
+  networkId?: string;
   /** Injectable fetch (tests). Production omits → globalThis.fetch. */
   fetchImpl?: typeof globalThis.fetch;
 }
@@ -99,7 +107,7 @@ function buildLiveAdmitRegistryPort(cfg: LiveAdmitPortsConfig): AdmitRegistryPor
 
   return {
     async getRequest(requestId): Promise<GetRequestResult> {
-      const readHeader = await buildAdmissionReadHeader(material);
+      const readHeader = await buildAdmissionReadHeader(material, cfg.networkId);
       const getUrl = `${base}/admission-requests/${encodeURIComponent(requestId)}`;
       const resp = await fetchImpl(getUrl, {
         method: "GET",
@@ -115,7 +123,7 @@ function buildLiveAdmitRegistryPort(cfg: LiveAdmitPortsConfig): AdmitRegistryPor
     },
 
     async listRequests(status): Promise<ListRequestsResult> {
-      const readHeader = await buildAdmissionReadHeader(material);
+      const readHeader = await buildAdmissionReadHeader(material, cfg.networkId);
       const getUrl = `${base}/admission-requests?status=${encodeURIComponent(status)}`;
       const resp = await fetchImpl(getUrl, {
         method: "GET",

--- a/src/cli/cortex/commands/network-admit-lib.ts
+++ b/src/cli/cortex/commands/network-admit-lib.ts
@@ -45,10 +45,20 @@ import type {
  * (the live-registry round-trip test, cortex#1517 S3, deliberately drives
  * this only through the real `dispatchNetwork` command path).
  */
-export async function buildAdmissionReadHeader(material: StackIdentityMaterial): Promise<string> {
+export async function buildAdmissionReadHeader(
+  material: StackIdentityMaterial,
+  // cortex#1652 — OPTIONAL network scope. The registry's read gate (FND-5)
+  // authorizes a GLOBAL admin with or without it, but a PER-NETWORK admin
+  // (#1321) is authorized ONLY when the signed claim names a network they
+  // administer — an unscoped read claim from a per-network admin is a hard 403
+  // (`admin_not_authorized`). Omitted ⇒ the historical unscoped claim
+  // (byte-identical for existing global-admin callers).
+  networkId?: string,
+): Promise<string> {
   const claim = {
     admin_pubkey: material.pubkeyB64,
     issued_at: new Date().toISOString(),
+    ...(networkId !== undefined && { network_id: networkId }),
   };
   return JSON.stringify(await signAdminRequest(material.seed, claim));
 }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -2827,7 +2827,14 @@ async function runListPending(
   if (!matRes.ok) return opError("admit", matRes.reason, json);
   const material = matRes.material;
 
-  const ports = admitPortsFactory({ registryUrl, material });
+  // cortex#1652 — thread the --network scope into the admin-signed read claim:
+  // a per-network admin (#1321) is only authorized when the claim names their
+  // network (FND-5); a global admin's unscoped read is unchanged when omitted.
+  const ports = admitPortsFactory({
+    registryUrl,
+    material,
+    ...(networkFilter !== undefined && { networkId: networkFilter }),
+  });
   const report = await runNetworkListPending(
     { status, ...(networkFilter !== undefined && { networkFilter }), registryUrl, material },
     ports,
@@ -2991,7 +2998,18 @@ async function runAdmit(
 
   // APPLY path — fetch/decision/seal/Discord all live in network-admit-lib.ts
   // over network-admit-ports.ts.
-  const ports = admitPortsFactory({ registryUrl, material, secretPortsFactory });
+  // cortex#1652 — `--network <id>` threads into the admin-signed read claim.
+  // A PER-NETWORK admin (#1321) MUST pass it: the registry's FND-5 read gate
+  // 403s (`admin_not_authorized`) an unscoped read claim from a non-global
+  // admin — the row fetch is the first apply-path leg, so without the scope
+  // the whole admit fails before any decision/seal. A global admin may omit it.
+  const admitNetworkScope = optionalValueFlag(flags, "--network");
+  const ports = admitPortsFactory({
+    registryUrl,
+    material,
+    secretPortsFactory,
+    ...(admitNetworkScope !== undefined && { networkId: admitNetworkScope }),
+  });
   const report = await runNetworkAdmit(
     {
       requestId,


### PR DESCRIPTION
## Live incident
jc's metafactory re-seal: `cortex network admit d7cb0118… --seal-only --apply` → `registry GET failed (HTTP 403): admin_not_authorized`, while dry-run passed (local fingerprint only, no authenticated GET).

## Root cause — claim shape, not the grant
The per-network-admin grant (#1321) IS live on the registry. But the FND-5 read gate authorizes a **non-global** admin only when the signed read claim **names a network they administer** — and `buildAdmissionReadHeader` never carried `network_id`. The CLI had no way to express the scope → every per-network-admin read was unscoped → hard 403 on the apply path's first leg (the row GET). Chicken-and-egg: the CLI learns the network *from* the row it can't read.

Server side needs **nothing**: scoped list AND single-row reads already work (incl. the cross-network 404-not-403 existence-oracle guard).

## Fix
- `buildAdmissionReadHeader(material, networkId?)` — claim gains `network_id` when supplied; omitted ⇒ **byte-identical** historical claim (global-admin flows unchanged)
- `LiveAdmitPortsConfig.networkId` → both admin-signed reads (`getRequest`, `listRequests`)
- The admit **decision** path and `--list-pending` both thread the already-parsed `--network` flag

## Regression test
Live-registry round-trip (same #1517 S3 harness — real registry Worker, real `dispatchNetwork`): a per-network admin **unscoped → 403**, **`--network <their net>` → authorized**.

## Verification
network-admit 39/0 · admit-lib/adapters/attestation 56/0 · tsc clean · eslint clean

Refs #1652 · Refs #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)