### PR TITLE
fix: postinstall enumerates + explains every ~/.claude install drop (#1675)

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -57,7 +57,7 @@ if [ ! -f "${CLAUDE_DIR}/relay/relay-policy.yaml" ]; then
     echo "  ✓ Default relay policy created (~/.claude/relay/relay-policy.yaml — controls which session events the relay forwards)"
   fi
 else
-  echo "  ⊘ Relay policy exists (not overwriting)"
+  echo "  ⊘ Relay policy exists (~/.claude/relay/relay-policy.yaml — not overwriting)"
 fi
 
 # ─── 4. Launchd plist rendering (macOS only) ─────────────────────
@@ -75,6 +75,16 @@ fi
 
 echo ""
 echo "✓ Cortex postinstall complete"
+echo ""
+echo "  What was installed into ~/.claude:"
+echo "    • hooks/CortexSkillGuard.hook.ts — installed but NOT registered globally by"
+echo "      design; used per-session by bot sessions carrying skill grants (cortex#710)"
+echo "    • statusline-command.sh, cortex-status.sh — status line renderer + data source;"
+echo "      wiring is optional/manual — add to ~/.claude/settings.json:"
+echo "      \"statusLine\": {\"type\": \"command\", \"command\": \"~/.claude/statusline-command.sh\"}"
+echo "    • relay/cortex/, relay/relay-policy.yaml — relay tap source + forwarding policy"
+echo "    • Events buffer locally to ~/.claude/events; run the relay to forward them"
+echo "      (optional)"
 echo ""
 echo "  Next steps:"
 echo "    1. (Only if migrating from grove — fresh installs skip this step)"
@@ -96,7 +106,8 @@ if [ "$(uname)" = "Darwin" ]; then
 else
   echo "    4. Linux: service management is manual for now — see docs/"
 fi
-echo "    5. (Optional) Install grove-bot deprecation shim — see"
+echo "    5. (Only if migrating from grove — fresh installs skip this step)"
+echo "       Install grove-bot deprecation shim — see"
 echo "       ${CORTEX_DIR}/scripts/grove-bot-shim.sh"
 echo ""
 echo "  Note: Claude Code hooks are auto-registered into ~/.claude/settings.json"


### PR DESCRIPTION
Closes #1675 (epic #1678 — Vincent's fresh-install feedback, Wave 2). Builds on merged #1693.

## What

`scripts/postinstall.sh` only (+13/−2): a new **"What was installed into ~/.claude"** section (10 lines, under the issue's 12-line cap) between the completion banner and Next steps:

- **CortexSkillGuard.hook.ts** — explicitly explained as *installed but NOT registered globally by design* (per-session use by bot sessions with skill grants, cortex#710). This was Vincent's "hook that wasn't stated and is not wired up."
- **statusline-command.sh / cortex-status.sh** — what they are + the exact manual wiring key (`"statusLine": {"type": "command", "command": "~/.claude/statusline-command.sh"}` — standard Claude Code settings schema; no repo doc named the key, so the platform contract is the source).
- **relay/cortex + relay-policy.yaml** — relay tap + forwarding policy, one line.
- **events/** — verbatim contract line deferred from #1677: "Events buffer locally to ~/.claude/events; run the relay to forward them (optional)".

Also lands both non-blocking nits from PR #1693's review (same file): the `⊘ Relay policy exists` branch now names its path, and step 5 (grove-bot shim) carries the same "(Only if migrating from grove — fresh installs skip this step)" marker as step 1.

Stop-and-ask in the issue (auto-wire statusline?) — not triggered; kept manual/documented per the issue's instruction.

## Verification (implementer, scratch HOMEs)

- `bash -n` pass · SkillGuard grep: 1 hit · section length: 10 lines (≤12 cap)
- Double-run against the same scratch HOME to exercise the `⊘` already-exists branch — path prints
- `git diff --stat`: one file; arc-manifest.yaml untouched

Independent fresh-context review to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)