### PR TITLE
fix: remove vestigial hooks/lib symlink + manifest casing guard (#1676)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.3.2"
+version: "6.3.3"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -79,8 +79,17 @@ provides:
     # reference the installed absolute path.
     - source: src/runner/hooks/skill-guard.hook.ts
       target: ~/.claude/hooks/CortexSkillGuard.hook.ts
-    - source: src/taps/cc-events/hooks/lib
-      target: ~/.claude/hooks/lib/cortex-events
+    # cortex#1676: deliberately NO `hooks/lib` symlink under ~/.claude. Hook
+    # files import their lib modules with paths relative to their own file
+    # (e.g. `./lib/...`, or `../../taps/cc-events/hooks/lib/...` for
+    # bash-guard.hook.ts, which lives outside src/taps/cc-events/hooks/).
+    # Bun/Node resolve relative imports against the REALPATH of the
+    # importing module (symlinks resolved, no --preserve-symlinks), so those
+    # imports reach directly into this repo's checkout — nothing ever
+    # resolves through an installed lib link. The `~/.claude/hooks/lib/`
+    # symlink this manifest used to declare (pointing at this same source
+    # dir) was vestigial dead weight (Vincent's fresh-install feedback,
+    # 8 Jul 2026 thread).
 
     # ─── Relay policy directory ───────────────────────────────
     - source: src/taps/cc-events

--- a/scripts/__tests__/manifest-hooks-casing.test.ts
+++ b/scripts/__tests__/manifest-hooks-casing.test.ts
@@ -1,0 +1,78 @@
+// Linux case-sensitivity guard for arc-manifest.yaml (cortex#1676 addendum,
+// 2026-07-08 — Vincent's fresh-Linux-install thread).
+//
+// macOS's default filesystem is case-INSENSITIVE, so a `provides.hooks[].command`
+// path that's cased differently from its `provides.files[].target` counterpart
+// still resolves there — the drift is invisible. Linux hosts are case-sensitive:
+// the same drift means Claude Code's hook invocation 404s on a symlink that
+// "should" exist by macOS-eyeball but doesn't by exact-string comparison.
+//
+// This asserts, for every registered hook, that its command basename EXACTLY
+// (case-sensitively) matches the basename of some installed `provides.files[]`
+// target. Verified true as of 2026-07-08 (one spelling per hook across the
+// manifest, src/runner/session-settings.ts:208, and the existing test suite) —
+// this test keeps it true going forward.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parse } from "yaml";
+
+const MANIFEST_PATH = join(import.meta.dir, "..", "..", "arc-manifest.yaml");
+
+interface ManifestFile {
+  source: string;
+  target: string;
+}
+
+interface ManifestHook {
+  event: string;
+  command: string;
+  matcher?: string;
+}
+
+interface Manifest {
+  provides: {
+    files: ManifestFile[];
+    hooks: ManifestHook[];
+  };
+}
+
+function basename(p: string): string {
+  return p.split("/").pop() ?? p;
+}
+
+describe("arc-manifest.yaml — provides.hooks/provides.files casing guard", () => {
+  const manifest = parse(readFileSync(MANIFEST_PATH, "utf-8")) as Manifest;
+
+  test("manifest declares at least one hook and one file (sanity — guards against a parse regression silently passing everything)", () => {
+    expect(manifest.provides.hooks.length).toBeGreaterThan(0);
+    expect(manifest.provides.files.length).toBeGreaterThan(0);
+  });
+
+  test("every provides.hooks[].command basename exactly (case-sensitively) matches a provides.files[].target basename", () => {
+    const fileTargetBasenames = manifest.provides.files.map((f) => basename(f.target));
+    const fileTargetBasenameSet = new Set(fileTargetBasenames);
+
+    for (const hook of manifest.provides.hooks) {
+      const hookBasename = basename(hook.command);
+      const exactMatch = fileTargetBasenameSet.has(hookBasename);
+
+      if (!exactMatch) {
+        const nearMiss = fileTargetBasenames.find(
+          (b) => b.toLowerCase() === hookBasename.toLowerCase(),
+        );
+        const detail = nearMiss
+          ? `only a differently-cased target exists: "${nearMiss}". This would install ` +
+            `cleanly on case-insensitive filesystems (macOS) but the hook would silently ` +
+            `fail to resolve on case-sensitive ones (Linux).`
+          : `no provides.files[].target has a matching basename at all.`;
+        throw new Error(
+          `provides.hooks[].command "${hook.command}" (basename "${hookBasename}") does ` +
+            `not exactly match any provides.files[].target basename — ${detail}`,
+        );
+      }
+
+      expect(exactMatch).toBe(true);
+    }
+  });
+});

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -18,17 +18,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLAUDE_DIR="${HOME}/.claude"
 CONFIG_DIR="${HOME}/.config/cortex"
 
-mkdir -p "${HOME}/bin" "${CLAUDE_DIR}/hooks/lib" "${CLAUDE_DIR}/relay" \
+mkdir -p "${HOME}/bin" "${CLAUDE_DIR}/relay" \
          "${CLAUDE_DIR}/skills" "${CONFIG_DIR}/logs"
 
 echo "Upgrading Cortex (${PAI_OLD_VERSION:-?} → ${PAI_NEW_VERSION:-?})..."
 
 # ─── 1. Belt-and-braces symlink refresh ───────────────────────────
-# arc's provides.files already handled the primary symlinks; these are the
-# nested-target ones (hook lib + relay dir) where arc's behaviour around
-# directory targets has varied historically.
+# arc's provides.files already handled the primary symlinks; this is the
+# nested-target one (relay dir) where arc's behaviour around directory
+# targets has varied historically.
+# cortex#1676: the vestigial `hooks/lib/` link that used to be refreshed
+# here was removed — nothing resolved through it (hook imports are relative
+# to their own file and resolve via realpath; see arc-manifest.yaml).
 echo "  Refreshing nested-target symlinks..."
-ln -sf "${CORTEX_DIR}/src/taps/cc-events/hooks/lib" "${CLAUDE_DIR}/hooks/lib/cortex-events"
 ln -sf "${CORTEX_DIR}/src/taps/cc-events"          "${CLAUDE_DIR}/relay/cortex"
 # The ~/.claude/skills/Discord symlink is no longer cortex's to manage: the
 # Discord CLI + skill were extracted to the metafactory-discord arc bundle


### PR DESCRIPTION
Closes #1676 (epic #1678 — Vincent's fresh-install feedback, final cortex slice).

## What

- **`arc-manifest.yaml`** — removed the `provides.files` entry mapping the hooks lib dir to `~/.claude/hooks/lib/…`; nothing resolves through that installed symlink (hooks import via realpath). Explanatory comment added. Version → **6.3.3** (separate chore commit).
- **`scripts/postupgrade.sh`** — removed the re-link line (:31), plus the now-pointless `hooks/lib` mkdir target and its stale comment (one line beyond the issue's literal checklist — dead weight caused directly by this removal; flagged for reviewer judgement).
- **New `scripts/__tests__/manifest-hooks-casing.test.ts`** — the issue-addendum's Linux casing guard: every `provides.hooks[].command` basename must exactly (case-sensitively) match a `provides.files[].target` basename. Guard was **verified to fire** (mismatch injected pre-commit → clear failure → reverted).

## Stop-and-ask gate (ran first, per issue)

`git grep` beyond the two expected lines found only: Cloudflare **D1 database names** in `wrangler.toml` (substring collision, not the installed path) and ~40 source-tree-relative TS imports (realpath-resolved, never via the symlink). Gate passed.

## Verification (implementer)

- `bash -n` pass · `cortex-events` grep on the two files: 0 hits · `tsc --noEmit`: 0 errors
- New test: 2 pass · scoped suite: 262 pass / 0 fail
- **Real fresh install** (`arc install file://… --yes` into scratch HOME): `✅ Installed cortex v6.3.3`, no `~/.claude/hooks/lib/` at all, all 4 installed hooks execute standalone (imports resolve)
- Full suite: 9359 pass / 20 fail — all 20 in `network-secret-cli.test.ts`, **confirmed pre-existing at merge-base 4efcf0c5** (identical failures in a throwaway worktree at that commit; this diff never touches the file). Tracked separately.

Independent fresh-context review to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)