### PR TITLE
fix(network): C-1652 — secret path network scope + descriptor seed (unblocks the re-seal)

### DIFF
--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -339,12 +339,17 @@ function buildLiveAdmissionLookupPort(cfg: LiveSecretPortsConfig): AdmissionLook
   const fetchImpl = cfg.fetchImpl ?? globalThis.fetch;
   return {
     async findAdmittedRow(networkId, memberPubkey) {
-      // Admin-signed read of the ADMITTED list (x-admin-signed header). NOTE: the
-      // registry's read gate checks the REGISTRY-admin allowlist; for metafactory
-      // the hub-admin seed IS the registry-admin (Q5 collapse), so this works. A
-      // fully-separable deployment must put the hub-admin on REGISTRY_ADMIN_PUBKEYS
-      // for the lookup (documented in the PR).
-      const claim = { admin_pubkey: cfg.material.pubkeyB64, issued_at: new Date().toISOString() };
+      // Admin-signed read of the ADMITTED list (x-admin-signed header).
+      // cortex#1652 — the claim CARRIES the network scope: the registry's FND-5
+      // read gate authorizes a GLOBAL admin with or without it, but a
+      // PER-NETWORK admin (#1321) only when the claim names a network they
+      // administer — the pre-#1652 unscoped claim 403'd every per-network
+      // custodian (the decision-A separated-authorities deployment).
+      const claim = {
+        admin_pubkey: cfg.material.pubkeyB64,
+        issued_at: new Date().toISOString(),
+        network_id: networkId,
+      };
       const signed = await signAdminRequest(cfg.material.seed, claim);
       const resp = await fetchImpl(`${base}/admission-requests?status=ADMITTED`, {
         method: "GET",
@@ -817,9 +822,14 @@ function buildLiveAdmittedListPort(cfg: LiveKeyRotationPortsConfig): AdmittedLis
   return {
     async listAdmittedRows(networkId) {
       // The SAME admin-signed read `findAdmittedRow` / `admit --list-pending` use.
-      // ADR-0020 scopes admin reads to GLOBAL admins; a per-network admin 403s
-      // here — surfaced readably rather than as a silent empty list.
-      const claim = { admin_pubkey: cfg.material.pubkeyB64, issued_at: new Date().toISOString() };
+      // cortex#1652 (the ADR-0020 fast-follow) — the claim carries the network
+      // scope, so a PER-NETWORK admin (#1321) of `networkId` is authorized by
+      // the FND-5 read gate; a global admin's read narrows to the same network.
+      const claim = {
+        admin_pubkey: cfg.material.pubkeyB64,
+        issued_at: new Date().toISOString(),
+        network_id: networkId,
+      };
       const signed = await signAdminRequest(cfg.material.seed, claim);
       const resp = await fetchImpl(`${base}/admission-requests?status=ADMITTED`, {
         method: "GET",
@@ -827,9 +837,9 @@ function buildLiveAdmittedListPort(cfg: LiveKeyRotationPortsConfig): AdmittedLis
       });
       if (resp.status === 403) {
         throw new Error(
-          `registry refused the ADMITTED list (HTTP 403 admin_not_authorized): admission reads are ` +
-            `GLOBAL-admin-only today (ADR-0020), so a per-network admin cannot enumerate members for ` +
-            `"${networkId}" to rotate the key. Use a global-admin seed; per-network read-scoping is the ADR-0020 fast-follow.`,
+          `registry refused the ADMITTED list (HTTP 403 admin_not_authorized): the signing seed is ` +
+            `neither a GLOBAL registry admin nor a per-network admin of "${networkId}" (#1321). ` +
+            `Use a seed on one of those allowlists.`,
         );
       }
       if (!resp.ok) {

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -3519,8 +3519,11 @@ async function runSecret(
   // create/join has an empty cache, so the attestation would resolve undefined
   // and the seal would SILENTLY take the PSK path — exactly the artifact an
   // operator hub rejects. Best-effort: never throws; local-config fallback
-  // still applies when the registry is unreachable.
-  {
+  // still applies when the registry is unreachable. LIVE-ONLY: gated on the
+  // production ports factory — an injected test factory means a hermetic run,
+  // and the seed's registry GET would escape the test's fakes (in CI it reached
+  // the REAL registry and flipped fixture networks onto the operator path).
+  if (portsFactory === DEFAULT_SECRET_PORTS_FACTORY) {
     const seed = await seedDescriptorCacheOnMiss(
       networkId,
       registryUrl,

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -3514,6 +3514,27 @@ async function runSecret(
   // cortex#1598 — operator-mode attestation (hub_mode/resolver_mode off the
   // verified descriptor + the hub FED account). Absent ⇒ the simple/PSK path
   // (unchanged); present + operator-mode ⇒ addOrRotate mints a scoped user + seals v2.
+  // cortex#1652 — seed the VERIFIED descriptor on a cache MISS first (same
+  // fail-open as the admit path, #1669): a custodian machine that never ran
+  // create/join has an empty cache, so the attestation would resolve undefined
+  // and the seal would SILENTLY take the PSK path — exactly the artifact an
+  // operator hub rejects. Best-effort: never throws; local-config fallback
+  // still applies when the registry is unreachable.
+  {
+    const seed = await seedDescriptorCacheOnMiss(
+      networkId,
+      registryUrl,
+      optionalValueFlag(flags, "--registry-pubkey"),
+    );
+    if (!seed.seeded) {
+      process.stderr.write(
+        `cortex network secret: could not seed the "${networkId}" descriptor ` +
+          `(${seed.reason ?? "unknown"}); operator-mode resolution falls back to local ` +
+          `config — on an operator-mode network without a local hub_mode declaration, ` +
+          `the seal may take the simple/PSK path.\n`,
+      );
+    }
+  }
   const op = resolveOperatorAttestation(flags, networkId, load);
 
   const ports = portsFactory({ hubConfigPath, registryUrl, material: matRes.material });

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -3522,7 +3522,7 @@ async function runSecret(
   // still applies when the registry is unreachable. LIVE-ONLY: gated on the
   // production ports factory — an injected test factory means a hermetic run,
   // and the seed's registry GET would escape the test's fakes (in CI it reached
-  // the REAL registry and flipped fixture networks onto the operator path).
+  // the REAL registry and flipped fixture networks onto the operator-mode path).
   if (portsFactory === DEFAULT_SECRET_PORTS_FACTORY) {
     const seed = await seedDescriptorCacheOnMiss(
       networkId,


### PR DESCRIPTION
## Context — the live re-seal chain (jc↔andreas)
After #1697, jc's `admit --seal-only --apply` correctly reaches the row — and correctly **refuses**: the row is ADMITTED, and `admit` is the *decision* verb (the PENDING gate is right, not a bug). The re-seal of an existing member belongs to **`network secret add-member`**. But that path had the same two per-network-custodian fail-modes:

## Fixes
1. **Unscoped read claims** — `findAdmittedRow` (add-member/rotate lookup) and `listAdmittedRows` (rotate-key enumeration) signed claims without `network_id` → FND-5 403s a per-network admin (#1321). Both now carry the `networkId` they already take as a parameter. The rotate-key 403 message stops claiming admission reads are global-only (pre-fast-follow ADR-0020 text).
2. **Silent PSK fallback** — `runSecret` resolved the operator attestation from the cache-only resolver; an empty cache (custodian never ran create/join) ⇒ `hubMode` undefined ⇒ PSK seal — exactly the artifact an operator hub rejects. `runSecret` now seeds the **verified** descriptor on cache-miss first (reuses #1669's `seedDescriptorCacheOnMiss`; best-effort, local-config fallback intact, loud stderr warning when unseeded).

## Verification
- tsc clean · eslint clean
- Secret suites **baseline-identical to clean main** in the worktree (the 20 known env-only fails; CI Test gate is the real validator — green on #1669/#1670)

With this + #1697 + the `REGISTRY_HUB_ADMIN_PUBKEYS` grant, the custodian re-seal is fully self-service: `secret add-member metafactory <member-pubkey> --seal-only --hub-account <A…> --admin-seed <custodian-seed> --apply`.

Refs #1652 · Refs #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)