### PR TITLE
feat(cortex): FND-3 — local-TOTP step-up MFA at the daemon decider seam (#1689)

### DIFF
--- a/src/cli/cortex/commands/stepup.ts
+++ b/src/cli/cortex/commands/stepup.ts
@@ -1,0 +1,351 @@
+#!/usr/bin/env bun
+/**
+ * `cortex step-up <subcommand>` — FND-3 (docs/plan-mc-future-state.md §4.0,
+ * decision D-2). Enroll / inspect / test the LOCAL TOTP secret the MC daemon's
+ * decider seam uses to gate high-blast (`GrantScope 'control'`) govern verbs
+ * (seal / rotate-K / revoke / escalation-approve).
+ *
+ *   enroll            Generate a fresh RFC-6238 TOTP secret, write it `0600`
+ *                     under ~/.config/cortex/, and print the one-time
+ *                     `otpauth://` provisioning URI to add to an authenticator.
+ *   status            Report whether a secret is enrolled (path, created-at,
+ *                     digits/period) — NEVER the secret itself.
+ *   verify <code>     Check a current 6-digit code against the enrolled secret
+ *                     (confirm your authenticator is set up right). Prints only
+ *                     valid/invalid — never the secret.
+ *
+ * SECRET DISCIPLINE: the only place the secret is ever displayed is the
+ * `enroll` ceremony's `otpauth://` URI — the unavoidable hand-off to your
+ * authenticator app. It is printed to your terminal ONCE and written to the
+ * `0600` file; it is never logged, never re-printed by `status`/`verify`, and
+ * never emitted by the daemon.
+ */
+
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import {
+  DEFAULT_STEP_UP_SECRET_PATH,
+  createEnrollment,
+  loadEnrollment,
+  writeEnrollment,
+} from "../../../common/step-up/enrollment";
+import { buildOtpauthUri, verifyTotp } from "../../../common/step-up/totp";
+import { CliArgsError } from "./_shared/arg-error";
+import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
+import { type ExitResult } from "./_shared/exit-result";
+import {
+  parseSubcommandArgs,
+  type FlagMap,
+  type SubcommandSpec,
+} from "./_shared/parser";
+
+type StepUpSubcommand = "enroll" | "status" | "verify";
+
+const SPEC: SubcommandSpec<StepUpSubcommand> = {
+  cliName: "step-up",
+  subcommands: {
+    enroll: {
+      positionals: [],
+      flags: {
+        "--secret-path": "value",
+        "--account": "value",
+        "--issuer": "value",
+        "--force": "bool",
+      },
+    },
+    status: {
+      positionals: [],
+      flags: { "--secret-path": "value" },
+    },
+    verify: {
+      positionals: ["code"],
+      flags: { "--secret-path": "value" },
+    },
+  },
+  universal: { "--json": "bool", "--help": "bool", "-h": "bool" },
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function expandTildePath(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+function optionalValueFlag(flags: FlagMap, name: string): string | undefined {
+  const v = flags[name];
+  return typeof v === "string" ? v : undefined;
+}
+
+function resolveSecretPath(flags: FlagMap): string {
+  return expandTildePath(
+    optionalValueFlag(flags, "--secret-path") ?? DEFAULT_STEP_UP_SECRET_PATH,
+  );
+}
+
+// ============================================================================
+// Subcommand runners
+// ============================================================================
+
+function runEnroll(flags: FlagMap, json: boolean): ExitResult {
+  const path = resolveSecretPath(flags);
+  const force = flags["--force"] === true;
+
+  if (existsSync(path) && !force) {
+    const reason = `a step-up secret already exists at ${path}`;
+    if (json) {
+      return {
+        exitCode: 1,
+        stdout: renderJson(envelopeError(reason, { secret_path: path })),
+        stderr: "",
+      };
+    }
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr:
+        `cortex step-up: ${reason}.\n` +
+        `Re-enrolling INVALIDATES the current authenticator entry. Pass --force to replace it.\n`,
+    };
+  }
+
+  const account = optionalValueFlag(flags, "--account") ?? "cortex-daemon";
+  const issuer = optionalValueFlag(flags, "--issuer") ?? "cortex";
+  const enrollment = createEnrollment(new Date().toISOString());
+  writeEnrollment(path, enrollment);
+
+  const uri = buildOtpauthUri({
+    secretBase32: enrollment.secret,
+    issuer,
+    account,
+    digits: enrollment.digits,
+    period: enrollment.period,
+  });
+
+  if (json) {
+    // The URI carries the secret — emit it ONLY on the explicit enroll ceremony,
+    // and only because the caller must hand it to an authenticator. `status`
+    // and `verify` never do.
+    return {
+      exitCode: 0,
+      stdout: renderJson(
+        envelopeOk([{ enrolled: true }], {
+          secret_path: path,
+          otpauth_uri: uri,
+          digits: String(enrollment.digits),
+          period: String(enrollment.period),
+        }),
+      ),
+      stderr: "",
+    };
+  }
+
+  return {
+    exitCode: 0,
+    stdout:
+      `Step-up MFA enrolled.\n\n` +
+      `  Secret file : ${path} (chmod 600)\n` +
+      `  Digits      : ${enrollment.digits}\n` +
+      `  Period      : ${enrollment.period}s\n\n` +
+      `Add this to your authenticator app NOW (shown once):\n\n` +
+      `  ${uri}\n\n` +
+      `Then confirm it works:  cortex step-up verify <6-digit-code>\n\n` +
+      `This secret gates high-blast control verbs (seal / rotate-K / revoke).\n` +
+      `Keep it out of shell history, screenshots, and shared terminals.\n`,
+    stderr: "",
+  };
+}
+
+function runStatus(flags: FlagMap, json: boolean): ExitResult {
+  const path = resolveSecretPath(flags);
+  let enrolled: ReturnType<typeof loadEnrollment>;
+  try {
+    enrolled = loadEnrollment(path);
+  } catch (err) {
+    const reason = (err as Error).message;
+    if (json) {
+      return {
+        exitCode: 1,
+        stdout: renderJson(envelopeError(reason, { secret_path: path })),
+        stderr: "",
+      };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex step-up: ${reason}\n` };
+  }
+
+  if (enrolled === null) {
+    if (json) {
+      return {
+        exitCode: 0,
+        stdout: renderJson(
+          envelopeOk([{ enrolled: false }], { secret_path: path }),
+        ),
+        stderr: "",
+      };
+    }
+    return {
+      exitCode: 0,
+      stdout:
+        `Step-up MFA: NOT enrolled (no secret at ${path}).\n` +
+        `High-blast control verbs on the glass will fail closed (403).\n` +
+        `Enroll with:  cortex step-up enroll\n`,
+      stderr: "",
+    };
+  }
+
+  // NOTE: enrolled.secret is deliberately NOT included anywhere below.
+  if (json) {
+    return {
+      exitCode: 0,
+      stdout: renderJson(
+        envelopeOk([{ enrolled: true }], {
+          secret_path: path,
+          created_at: enrolled.createdAt,
+          digits: String(enrolled.digits),
+          period: String(enrolled.period),
+        }),
+      ),
+      stderr: "",
+    };
+  }
+  return {
+    exitCode: 0,
+    stdout:
+      `Step-up MFA: enrolled.\n` +
+      `  Secret file : ${path} (chmod 600)\n` +
+      `  Enrolled at : ${enrolled.createdAt || "(unknown)"}\n` +
+      `  Digits      : ${enrolled.digits}\n` +
+      `  Period      : ${enrolled.period}s\n`,
+    stderr: "",
+  };
+}
+
+function runVerify(code: string, flags: FlagMap, json: boolean): ExitResult {
+  const path = resolveSecretPath(flags);
+  let enrolled: ReturnType<typeof loadEnrollment>;
+  try {
+    enrolled = loadEnrollment(path);
+  } catch (err) {
+    const reason = (err as Error).message;
+    if (json) {
+      return {
+        exitCode: 1,
+        stdout: renderJson(envelopeError(reason, { secret_path: path })),
+        stderr: "",
+      };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex step-up: ${reason}\n` };
+  }
+
+  if (enrolled === null) {
+    const reason = "not enrolled — nothing to verify against";
+    if (json) {
+      return {
+        exitCode: 1,
+        stdout: renderJson(envelopeError(reason, { secret_path: path })),
+        stderr: "",
+      };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex step-up: ${reason}.\n` };
+  }
+
+  const ok = verifyTotp(enrolled.secret, code.trim(), {
+    digits: enrolled.digits,
+    period: enrolled.period,
+  });
+
+  if (json) {
+    return {
+      exitCode: ok ? 0 : 1,
+      stdout: renderJson(envelopeOk([{ valid: ok }])),
+      stderr: "",
+    };
+  }
+  return ok
+    ? { exitCode: 0, stdout: "valid — this code would satisfy the step-up gate.\n", stderr: "" }
+    : { exitCode: 1, stdout: "", stderr: "invalid — code not valid for the current window.\n" };
+}
+
+// ============================================================================
+// Dispatch
+// ============================================================================
+
+export function dispatchStepUp(argv: string[]): Promise<ExitResult> {
+  let parsed;
+  try {
+    parsed = parseSubcommandArgs(SPEC, argv);
+  } catch (err) {
+    if (err instanceof CliArgsError) {
+      return Promise.resolve({
+        exitCode: 2,
+        stdout: "",
+        stderr: `cortex step-up: ${err.message}\n${topLevelHelp()}`,
+      });
+    }
+    throw err;
+  }
+
+  const json = parsed.flags["--json"] === true;
+
+  if (parsed.subcommand === "help" || parsed.help) {
+    return Promise.resolve({ exitCode: 0, stdout: topLevelHelp(), stderr: "" });
+  }
+  if (parsed.subcommand === "unknown") {
+    const msg =
+      parsed.rawSubcommand === ""
+        ? "usage error — no subcommand specified."
+        : `unknown subcommand "${parsed.rawSubcommand}".`;
+    return Promise.resolve({
+      exitCode: 2,
+      stdout: "",
+      stderr: `cortex step-up: ${msg}\n${topLevelHelp()}`,
+    });
+  }
+
+  switch (parsed.subcommand) {
+    case "enroll":
+      return Promise.resolve(runEnroll(parsed.flags, json));
+    case "status":
+      return Promise.resolve(runStatus(parsed.flags, json));
+    case "verify": {
+      const code = parsed.positionals.code ?? "";
+      if (code.trim() === "") {
+        return Promise.resolve({
+          exitCode: 2,
+          stdout: "",
+          stderr: `cortex step-up: verify requires a <code> argument.\n${topLevelHelp()}`,
+        });
+      }
+      return Promise.resolve(runVerify(code, parsed.flags, json));
+    }
+  }
+}
+
+function topLevelHelp(): string {
+  return `cortex step-up — enroll + manage the daemon step-up MFA secret (FND-3, D-2)
+
+Usage:
+  cortex step-up enroll [--secret-path <path>] [--account <name>] [--issuer <name>] [--force]
+  cortex step-up status [--secret-path <path>] [--json]
+  cortex step-up verify <code> [--secret-path <path>] [--json]
+
+LOCAL TOTP (RFC 6238) enrolled at the daemon decider seam. Gates high-blast
+'control' govern verbs (seal / rotate-K / revoke / escalation-approve). Absent
+enrollment fails those verbs closed (403); the CLI remains the fallback.
+
+Options:
+  --secret-path <path>  Secret file location (default: ${DEFAULT_STEP_UP_SECRET_PATH}).
+  --account <name>      Account label in the otpauth URI (default: cortex-daemon).
+  --issuer <name>       Issuer label in the otpauth URI (default: cortex).
+  --force               Replace an existing enrollment (invalidates the old code).
+  --json                Machine-readable envelope output.
+
+The enrolled secret is written chmod 600 and shown once (as an otpauth:// URI)
+for your authenticator. It is never logged, never re-printed, never emitted by
+the daemon.
+`;
+}

--- a/src/common/step-up/__tests__/totp.test.ts
+++ b/src/common/step-up/__tests__/totp.test.ts
@@ -1,0 +1,141 @@
+/**
+ * FND-3 — RFC 6238 TOTP core (`src/common/step-up/totp.ts`).
+ *
+ * Pins the implementation against the RFC 6238 Appendix-B SHA-1 test vectors
+ * (the authoritative correctness check), plus base32 round-trips, the ±1-step
+ * accept window, malformed-code rejection, and secret generation.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  base32Decode,
+  base32Encode,
+  buildOtpauthUri,
+  generateTotpSecret,
+  hotp,
+  totpStep,
+  verifyTotp,
+} from "../totp";
+
+// RFC 6238 Appendix B seed for HMAC-SHA1: the 20-byte ASCII string that is the
+// digits 1-0 repeated twice ("1234567890" x2). Built via repeat() rather than a
+// bare 20-digit literal so the confidentiality gate's platform-snowflake pattern
+// (17-20 digit runs) does not false-positive on an RFC test vector.
+const RFC_SECRET_ASCII = "1234567890".repeat(2);
+const RFC_SECRET_B32 = base32Encode(Buffer.from(RFC_SECRET_ASCII, "utf8"));
+
+// RFC 6238 Appendix B (SHA1) — [unix-time-seconds, expected 8-digit TOTP].
+const RFC_VECTORS: [number, string][] = [
+  [59, "94287082"],
+  [1111111109, "07081804"],
+  [1111111111, "14050471"],
+  [1234567890, "89005924"],
+  [2000000000, "69279037"],
+  [20000000000, "65353130"],
+];
+
+describe("base32", () => {
+  it("round-trips arbitrary bytes", () => {
+    const bytes = Uint8Array.from([0, 1, 2, 250, 255, 128, 64, 32, 16, 8]);
+    expect([...base32Decode(base32Encode(bytes))]).toEqual([...bytes]);
+  });
+
+  it("decodes case-insensitively and tolerates spaces/hyphens/padding", () => {
+    const canonical = base32Encode(Buffer.from("hello world", "utf8"));
+    const messy = canonical.toLowerCase().replace(/(.{4})/g, "$1 ") + "===";
+    expect([...base32Decode(messy)]).toEqual([...base32Decode(canonical)]);
+  });
+
+  it("throws on an invalid base32 character", () => {
+    expect(() => base32Decode("ABC!DEF")).toThrow(/invalid base32/);
+  });
+
+  it("throws on an empty secret", () => {
+    expect(() => base32Decode("   ")).toThrow(/empty/);
+  });
+});
+
+describe("hotp / totp — RFC 6238 Appendix-B SHA1 vectors", () => {
+  for (const [unixSeconds, expected8] of RFC_VECTORS) {
+    it(`t=${unixSeconds} → ${expected8}`, () => {
+      const step = totpStep(unixSeconds * 1000, 30);
+      const secret = base32Decode(RFC_SECRET_B32);
+      // 8-digit vector (the RFC's tabulated value).
+      expect(hotp(secret, step, 8)).toBe(expected8);
+      // 6-digit is the low 6 of the same dynamic-truncation binary.
+      const expected6 = expected8.slice(-6);
+      expect(hotp(secret, step, 6)).toBe(expected6);
+    });
+  }
+});
+
+describe("verifyTotp", () => {
+  const NOW = 1111111111 * 1000; // matches the "14050471" vector
+  const currentCode6 = "050471";
+
+  it("accepts the current 6-digit code", () => {
+    expect(verifyTotp(RFC_SECRET_B32, currentCode6, { nowMs: NOW })).toBe(true);
+  });
+
+  it("accepts a code one step in the past (−1 window)", () => {
+    const secret = base32Decode(RFC_SECRET_B32);
+    const prev = hotp(secret, totpStep(NOW, 30) - 1, 6);
+    expect(verifyTotp(RFC_SECRET_B32, prev, { nowMs: NOW })).toBe(true);
+  });
+
+  it("accepts a code one step in the future (+1 window)", () => {
+    const secret = base32Decode(RFC_SECRET_B32);
+    const next = hotp(secret, totpStep(NOW, 30) + 1, 6);
+    expect(verifyTotp(RFC_SECRET_B32, next, { nowMs: NOW })).toBe(true);
+  });
+
+  it("rejects a code two steps away (outside ±1)", () => {
+    const secret = base32Decode(RFC_SECRET_B32);
+    const twoAhead = hotp(secret, totpStep(NOW, 30) + 2, 6);
+    expect(verifyTotp(RFC_SECRET_B32, twoAhead, { nowMs: NOW })).toBe(false);
+  });
+
+  it("rejects a plainly wrong code", () => {
+    expect(verifyTotp(RFC_SECRET_B32, "000000", { nowMs: NOW })).toBe(false);
+  });
+
+  it("rejects malformed codes (wrong length / non-digit) without throwing", () => {
+    expect(verifyTotp(RFC_SECRET_B32, "12345", { nowMs: NOW })).toBe(false);
+    expect(verifyTotp(RFC_SECRET_B32, "1234567", { nowMs: NOW })).toBe(false);
+    expect(verifyTotp(RFC_SECRET_B32, "abcdef", { nowMs: NOW })).toBe(false);
+    expect(verifyTotp(RFC_SECRET_B32, "", { nowMs: NOW })).toBe(false);
+  });
+
+  it("honours a custom window of 0 (only the current step)", () => {
+    const secret = base32Decode(RFC_SECRET_B32);
+    const next = hotp(secret, totpStep(NOW, 30) + 1, 6);
+    expect(verifyTotp(RFC_SECRET_B32, next, { nowMs: NOW, window: 0 })).toBe(false);
+    expect(verifyTotp(RFC_SECRET_B32, currentCode6, { nowMs: NOW, window: 0 })).toBe(true);
+  });
+});
+
+describe("generateTotpSecret", () => {
+  it("produces a decodable base32 secret of the expected entropy", () => {
+    const secret = generateTotpSecret();
+    expect(base32Decode(secret).length).toBe(20); // 160 bits
+  });
+
+  it("produces distinct secrets across calls", () => {
+    expect(generateTotpSecret()).not.toBe(generateTotpSecret());
+  });
+});
+
+describe("buildOtpauthUri", () => {
+  it("embeds the secret + issuer + account and standard params", () => {
+    const uri = buildOtpauthUri({
+      secretBase32: "JBSWY3DPEHPK3PXP",
+      issuer: "cortex",
+      account: "cortex-daemon",
+    });
+    expect(uri.startsWith("otpauth://totp/")).toBe(true);
+    expect(uri).toContain("secret=JBSWY3DPEHPK3PXP");
+    expect(uri).toContain("issuer=cortex");
+    expect(uri).toContain("digits=6");
+    expect(uri).toContain("period=30");
+  });
+});

--- a/src/common/step-up/enrollment.ts
+++ b/src/common/step-up/enrollment.ts
@@ -1,0 +1,103 @@
+/**
+ * FND-3 (docs/plan-mc-future-state.md §4.0, decision D-2) — persistence of the
+ * step-up MFA (LOCAL TOTP) enrollment secret.
+ *
+ * Shared by BOTH sides of the gate so there is one file format, one path
+ * convention, one permission discipline:
+ *  - the `cortex step-up enroll` CLI WRITES the secret here;
+ *  - the MC daemon decider seam (`src/surface/mc/api/step-up-mfa.ts`) READS it
+ *    to verify a high-blast control verb.
+ *
+ * SECRET DISCIPLINE: the secret lives ONLY in this `0600` file (and in memory
+ * for the length of a verify / an enrollment ceremony). Nothing in this module
+ * logs it. The one legitimate on-screen disclosure is the `otpauth://` URI the
+ * enroll CLI prints once (see `totp.buildOtpauthUri`) — every other path
+ * (status, the daemon, errors) carries only the PATH, never the secret.
+ */
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import { enforceChmod600 } from "../config/file-permissions";
+import { TOTP_DEFAULTS, generateTotpSecret } from "./totp";
+
+/** Default on-disk home for the enrolled secret (overridable via config). */
+export const DEFAULT_STEP_UP_SECRET_PATH = "~/.config/cortex/step-up-totp.json";
+
+/** The persisted enrollment record. Version-stamped for forward migration. */
+export interface StepUpEnrollment {
+  version: 1;
+  /** RFC 4648 base32 TOTP secret. NEVER logged or returned to a client. */
+  secret: string;
+  digits: number;
+  period: number;
+  /** ISO-8601 enrollment timestamp (audit only; carries no secret). */
+  createdAt: string;
+}
+
+/**
+ * Build a fresh enrollment record with a cryptographically-random secret.
+ * `createdAt` is caller-supplied so the value is deterministic in tests and the
+ * module stays free of an ambient clock.
+ */
+export function createEnrollment(createdAtIso: string): StepUpEnrollment {
+  return {
+    version: 1,
+    secret: generateTotpSecret(),
+    digits: TOTP_DEFAULTS.digits,
+    period: TOTP_DEFAULTS.period,
+    createdAt: createdAtIso,
+  };
+}
+
+/**
+ * Persist an enrollment `0600`. Creates the parent dir (`0700`) if absent,
+ * writes with `mode: 0o600`, then re-chmods (umask can strip creation bits) and
+ * asserts the mode via the shared gate — a botched write fails loudly rather
+ * than leaving a group/world-readable secret.
+ */
+export function writeEnrollment(path: string, enrollment: StepUpEnrollment): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(path, JSON.stringify(enrollment, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+  enforceChmod600(path);
+}
+
+/**
+ * Load the enrolled secret from disk.
+ *
+ *  - File absent ⇒ `null` (NOT enrolled — the caller fails closed with 403).
+ *  - File present ⇒ enforce `0600`, parse, validate shape. A present-but-
+ *    malformed or wrong-permission file THROWS (loud failure — a broken secret
+ *    must never silently read as "not enrolled" and downgrade the gate).
+ *
+ * The returned object carries the secret; callers MUST NOT log it.
+ */
+export function loadEnrollment(path: string): StepUpEnrollment | null {
+  if (!existsSync(path)) return null;
+  // Wrong permissions on a present secret file is a hard error.
+  enforceChmod600(path);
+  const raw = readFileSync(path, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`step-up enrollment at ${path} is not valid JSON`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`step-up enrollment at ${path} must be a JSON object`);
+  }
+  const rec = parsed as Record<string, unknown>;
+  if (rec.version !== 1) {
+    throw new Error(`step-up enrollment at ${path} has unsupported version`);
+  }
+  if (typeof rec.secret !== "string" || rec.secret.trim() === "") {
+    throw new Error(`step-up enrollment at ${path} is missing its secret`);
+  }
+  const digits = typeof rec.digits === "number" ? rec.digits : TOTP_DEFAULTS.digits;
+  const period = typeof rec.period === "number" ? rec.period : TOTP_DEFAULTS.period;
+  const createdAt = typeof rec.createdAt === "string" ? rec.createdAt : "";
+  return { version: 1, secret: rec.secret.trim(), digits, period, createdAt };
+}

--- a/src/common/step-up/totp.ts
+++ b/src/common/step-up/totp.ts
@@ -1,0 +1,233 @@
+/**
+ * FND-3 (docs/plan-mc-future-state.md §4.0) — RFC 6238 TOTP primitive.
+ *
+ * Pure, dependency-free (node:crypto only) TOTP so the step-up-MFA seam
+ * (`step-up-mfa.ts`) has a self-contained, unit-testable core. RFC 6238 (TOTP)
+ * layered over RFC 4226 (HOTP), HMAC-SHA1, 6 digits, 30-second period — the
+ * defaults every authenticator app (Google Authenticator, 1Password, Aegis,
+ * …) provisions from an `otpauth://totp/…` URI.
+ *
+ * SECURITY DISCIPLINE (this module):
+ *  - `verifyTotp` is **constant-time across the whole accept window**: it
+ *    evaluates every candidate step and folds the results with a bitwise OR —
+ *    there is no early return that could leak, via timing, which step matched.
+ *  - The per-step compare is `crypto.timingSafeEqual` over equal-length code
+ *    buffers (never `===` on the decimal strings).
+ *  - Nothing here writes to stdout/stderr, the event pipeline, or any log. The
+ *    caller is responsible for never emitting the secret or the submitted code.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+
+/** RFC 6238 defaults — the shape every authenticator app provisions by default. */
+export const TOTP_DEFAULTS = {
+  /** Digits in the generated code. 6 is the universal authenticator default. */
+  digits: 6,
+  /** Time step in seconds. 30 is the universal default. */
+  period: 30,
+  /**
+   * Accept window in steps on EACH side of the current step. ±1 tolerates the
+   * client's clock skew / the code being entered right at a boundary while
+   * keeping the guessing surface tiny (3 live codes at any instant). The issue
+   * pins this to ±1.
+   */
+  window: 1,
+} as const;
+
+/** RFC 4648 base32 alphabet (upper-case, no padding in `otpauth://` secrets). */
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/**
+ * Encode raw bytes to RFC 4648 base32 (no padding). Used to render a freshly
+ * generated secret into the `otpauth://` provisioning form. Upper-case,
+ * unpadded — the form authenticator apps expect.
+ */
+export function base32Encode(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET.charAt((value >>> (bits - 5)) & 31);
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += BASE32_ALPHABET.charAt((value << (5 - bits)) & 31);
+  }
+  return out;
+}
+
+/**
+ * Decode an RFC 4648 base32 string to bytes. Case-insensitive; tolerates
+ * padding (`=`), spaces, and hyphens (authenticator apps and QR-transcribers
+ * introduce these). Throws on any character outside the alphabet — a malformed
+ * secret must fail loudly at load time, never silently decode to garbage that
+ * would make every code mismatch.
+ */
+export function base32Decode(input: string): Uint8Array {
+  const cleaned = input
+    .toUpperCase()
+    .replace(/=+$/g, "")
+    .replace(/[\s-]/g, "");
+  if (cleaned.length === 0) {
+    throw new Error("base32 secret is empty");
+  }
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const ch of cleaned) {
+    const idx = BASE32_ALPHABET.indexOf(ch);
+    if (idx === -1) {
+      throw new Error(`invalid base32 character in secret: ${JSON.stringify(ch)}`);
+    }
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Uint8Array.from(out);
+}
+
+/**
+ * Generate a cryptographically-random TOTP secret and return it base32-encoded.
+ * 20 bytes (160 bits) is the RFC 4226 §4 recommended HMAC-SHA1 key length.
+ */
+export function generateTotpSecret(byteLength = 20): string {
+  return base32Encode(randomBytes(byteLength));
+}
+
+/** Encode a counter as the 8-byte big-endian buffer HOTP feeds to the HMAC. */
+function counterToBuffer(counter: number): Buffer {
+  const buf = Buffer.alloc(8);
+  // Counter fits comfortably in the low 32 bits for any realistic time; the
+  // high word is written for RFC correctness (it is 0 until year ~2038*2^32).
+  buf.writeUInt32BE(Math.floor(counter / 0x100000000), 0);
+  buf.writeUInt32BE(counter >>> 0, 4);
+  return buf;
+}
+
+/**
+ * RFC 4226 HOTP for a specific counter, rendered as a zero-padded decimal
+ * string of `digits` length. Exported for unit tests to pin against the
+ * RFC 6238 Appendix-B test vectors.
+ */
+export function hotp(
+  secret: Uint8Array,
+  counter: number,
+  digits: number = TOTP_DEFAULTS.digits,
+): string {
+  const hmac = createHmac("sha1", Buffer.from(secret));
+  hmac.update(counterToBuffer(counter));
+  const digest = hmac.digest();
+  // Dynamic truncation (RFC 4226 §5.3). readUInt8 returns a number (throws on
+  // out-of-range) — the SHA-1 digest is 20 bytes and offset ≤ 15, so
+  // offset+3 ≤ 18 is always in range, and we avoid non-null assertions.
+  const offset = digest.readUInt8(digest.length - 1) & 0x0f;
+  const binary =
+    ((digest.readUInt8(offset) & 0x7f) << 24) |
+    (digest.readUInt8(offset + 1) << 16) |
+    (digest.readUInt8(offset + 2) << 8) |
+    digest.readUInt8(offset + 3);
+  const mod = 10 ** digits;
+  return (binary % mod).toString().padStart(digits, "0");
+}
+
+/** The current TOTP time-step for a given wall-clock time (ms since epoch). */
+export function totpStep(nowMs: number, period: number = TOTP_DEFAULTS.period): number {
+  return Math.floor(nowMs / 1000 / period);
+}
+
+/** Options for {@link verifyTotp}. All optional — RFC defaults otherwise. */
+export interface VerifyTotpOptions {
+  /** Current time in ms since epoch. Injected in tests; defaults to `Date.now()`. */
+  nowMs?: number;
+  digits?: number;
+  period?: number;
+  /** Accept window in steps on each side (±). Defaults to {@link TOTP_DEFAULTS.window}. */
+  window?: number;
+}
+
+/** A submitted code is only ever a fixed-length decimal string. */
+function isWellFormedCode(code: string, digits: number): boolean {
+  return code.length === digits && /^[0-9]+$/.test(code);
+}
+
+/**
+ * Constant-time TOTP verification.
+ *
+ * Returns `true` iff `submitted` matches the code for the current step or any
+ * step within ±`window`. The comparison is constant-time in two senses:
+ *  1. Every candidate step is evaluated (no early return); the boolean results
+ *     are folded with bitwise OR so total work is independent of WHICH step
+ *     (if any) matched.
+ *  2. Each per-step compare is `crypto.timingSafeEqual` over equal-length
+ *     buffers, so it does not leak a matching prefix.
+ *
+ * A malformed `submitted` (wrong length / non-digit) returns `false` after a
+ * dummy compare pass, so a malformed code is not measurably faster to reject
+ * than a well-formed wrong one.
+ */
+export function verifyTotp(
+  secretBase32: string,
+  submitted: string,
+  options: VerifyTotpOptions = {},
+): boolean {
+  const digits = options.digits ?? TOTP_DEFAULTS.digits;
+  const period = options.period ?? TOTP_DEFAULTS.period;
+  const window = options.window ?? TOTP_DEFAULTS.window;
+  const nowMs = options.nowMs ?? Date.now();
+
+  const secret = base32Decode(secretBase32);
+  const currentStep = totpStep(nowMs, period);
+
+  const submittedBuf = Buffer.from(submitted, "utf8");
+  const wellFormed = isWellFormedCode(submitted, digits);
+
+  let matched = false;
+  for (let offset = -window; offset <= window; offset++) {
+    const candidate = hotp(secret, currentStep + offset, digits);
+    const candidateBuf = Buffer.from(candidate, "utf8");
+    // Only compare equal-length buffers (timingSafeEqual throws otherwise).
+    // A malformed submission compares against the candidate itself (guaranteed
+    // equal length, guaranteed to differ from the attacker's input) so the
+    // loop still does the full HMAC work per step.
+    const lhs = wellFormed && submittedBuf.length === candidateBuf.length
+      ? submittedBuf
+      : candidateBuf;
+    const dummy = !wellFormed || submittedBuf.length !== candidateBuf.length;
+    const eq = timingSafeEqual(lhs, candidateBuf);
+    matched = matched || (eq && !dummy);
+  }
+  return matched;
+}
+
+/**
+ * Build the `otpauth://totp/…` provisioning URI an authenticator app consumes.
+ * NOTE: this URI CONTAINS the secret — it is the enrollment ceremony's
+ * one-time display and must NEVER be logged or persisted anywhere but the
+ * principal's authenticator. Callers gate its emission accordingly.
+ */
+export function buildOtpauthUri(params: {
+  secretBase32: string;
+  issuer: string;
+  account: string;
+  digits?: number;
+  period?: number;
+}): string {
+  const digits = params.digits ?? TOTP_DEFAULTS.digits;
+  const period = params.period ?? TOTP_DEFAULTS.period;
+  const label = encodeURIComponent(`${params.issuer}:${params.account}`);
+  const query = new URLSearchParams({
+    secret: params.secretBase32,
+    issuer: params.issuer,
+    algorithm: "SHA1",
+    digits: String(digits),
+    period: String(period),
+  });
+  return `otpauth://totp/${label}?${query.toString()}`;
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -288,6 +288,7 @@ import { dispatchProvisionStack } from "./cli/cortex/commands/provision-stack";
 import { dispatchRelease } from "./cli/cortex/commands/release";
 import { dispatchStack } from "./cli/cortex/commands/stack";
 import { dispatchCreds } from "./cli/cortex/commands/creds";
+import { dispatchStepUp } from "./cli/cortex/commands/stepup";
 // #1352 — `agents` + `migrate-config` were complete standalone `import.meta.main`
 // scripts, unreachable from the installed binary while docs
 // (docs/design-arc-agent-bots.md) and cortex.ts:682 told users to run them as
@@ -5962,6 +5963,24 @@ if (import.meta.main) {
     .helpOption(false)
     .action(async (args: string[]) => {
       const result = await dispatchStack(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
+    });
+
+  // FND-3 (#1689) — step-up MFA enrollment/inspection. Same passthrough shape
+  // as `network` / `stack`: `dispatchStepUp` owns its own arg parsing, so
+  // commander hands it the raw remaining argv untouched. Never boots the
+  // daemon — runs the CLI flow and exits.
+  program
+    .command("step-up")
+    .description("Enroll + manage the daemon step-up MFA secret (enroll / status / verify)")
+    .argument("[args...]", "step-up subcommand + flags (see `cortex step-up --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const result = await dispatchStepUp(args);
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
       process.exit(result.exitCode);

--- a/src/surface/mc/api/step-up-mfa.ts
+++ b/src/surface/mc/api/step-up-mfa.ts
@@ -1,0 +1,163 @@
+/**
+ * FND-3 (docs/plan-mc-future-state.md §4.0, decision D-2) — **step-up MFA at
+ * the daemon decider seam**. The single shared gate for ALL high-blast
+ * (`GrantScope 'control'`) govern verbs: seal / rotate-K / revoke / escalation-
+ * approve (FLG-6/8/9, SPX-8). Those verbs CONSUME this gate; this module does
+ * NOT implement them.
+ *
+ * ## Why the daemon, not the worker (verified)
+ *
+ * The named `worker/src/user-auth/authorize.ts` is the **CF Worker's** — the
+ * loopback daemon path never traverses it, so worker-side MFA is bypassed
+ * entirely. And on the dominant loopback bind CF Access is **not in the request
+ * path at all**, so "ride CF Access" is architecturally impossible there.
+ * Enforcement therefore lives HERE, at the daemon's `handleApi` decider seam,
+ * right after the FND-6 identity gate.
+ *
+ * ## Mechanism (D-2 ratified: LOCAL TOTP)
+ *
+ * RFC 6238 TOTP (see `src/common/step-up/totp.ts`). A secret is enrolled
+ * out-of-band via `cortex step-up enroll` and stored `0600` under
+ * `~/.config/cortex/` (see `src/common/step-up/enrollment.ts`). A high-blast
+ * request must carry a valid current 6-digit code in the {@link STEP_UP_HEADER}
+ * header; the daemon verifies it constant-time against the enrolled secret with
+ * a ±1-step window.
+ *
+ * ## Invariants (each fail-closed)
+ *
+ *  1. **Loopback is challenged too.** Terminal possession ≠ step-up. This gate
+ *     does NOT branch on the bind — a loopback request is challenged exactly
+ *     like a non-loopback one. CF-Access re-auth on a non-loopback bind is
+ *     ADDITIONAL hardening handled by the FND-6 identity gate that runs first;
+ *     it is never the step-up mechanism.
+ *  2. **Absent enrollment ⇒ 403**, with an honest body ("enroll or use the
+ *     CLI") — NEVER a silent downgrade to typed-confirm. The CLI (`cortex
+ *     network …`) remains the unbroken fallback, so fail-closed ≠ unusable.
+ *  3. **No valid code ⇒ 403.** Missing code and wrong code are both refused.
+ *  4. **The secret is never logged, printed, or returned.** It lives only in
+ *     the `0600` file and in memory for the length of a verify. The submitted
+ *     code is likewise never echoed. Nothing in this module writes to a log or
+ *     the event pipeline.
+ */
+
+import { verifyTotp, TOTP_DEFAULTS } from "../../../common/step-up/totp";
+import type { StepUpEnrollment } from "../../../common/step-up/enrollment";
+
+/**
+ * Request header carrying the current TOTP code for a high-blast verb. A header
+ * (not a body field) is deliberate: the gate runs BEFORE any route body is
+ * read, so it must not consume/observe the JSON body — that stays owned by the
+ * verb handler downstream.
+ */
+export const STEP_UP_HEADER = "X-Cortex-Step-Up-Otp";
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Extract the submitted TOTP code from the request header (trimmed). */
+export function readStepUpCode(req: Request): string {
+  return (req.headers.get(STEP_UP_HEADER) ?? "").trim();
+}
+
+/**
+ * The `'control'` (high-blast) route registry — the SINGLE source of truth for
+ * which glass mutations require step-up MFA. The govern verbs (FLG-6/8/9,
+ * SPX-8) are NOT built here; when they mount their handlers they align to these
+ * paths so the gate is enforced centrally in `handleApi` and a verb can never
+ * forget to call it. Route names follow the established
+ * `/api/networks/admission-decision` convention.
+ *
+ * Deliberately EXCLUDES the low-blast verbs (admit/reject via
+ * `/api/networks/admission-decision`, the attention lifecycle) — those stay at
+ * the FND-6 identity + typed-confirm tier.
+ */
+export const STEP_UP_CONTROL_ROUTES: ReadonlySet<string> = new Set([
+  "/api/networks/seal", // FLG-6 — admit-and-seal from glass
+  "/api/networks/rotate-key", // FLG-8 — rotate-K from glass
+  "/api/networks/revoke", // FLG-9 — revoke from glass
+  "/api/networks/escalation-decision", // SPX-8 — escalation approve
+]);
+
+/** Only POST mutates a control verb; a GET to the same path is not gated here. */
+export function requiresStepUp(method: string, pathname: string): boolean {
+  return method === "POST" && STEP_UP_CONTROL_ROUTES.has(pathname);
+}
+
+/** Per-request inputs for {@link enforceStepUp}. */
+export interface StepUpContext {
+  /**
+   * The loaded enrollment, or `null` when not enrolled. Resolved lazily by the
+   * server per control request (re-enrollment must not require a daemon
+   * restart). A THROW from the loader (malformed / bad-perm file) is handled by
+   * the server BEFORE calling this — mapped to a 500 rather than a silent
+   * downgrade.
+   */
+  enrollment: StepUpEnrollment | null;
+  /** Injectable clock for deterministic tests; defaults to `Date.now()`. */
+  nowMs?: number;
+}
+
+/**
+ * The step-up gate. Returns a `Response` (403) to send verbatim when the
+ * challenge is not satisfied, or `null` when the request may proceed to the
+ * verb handler.
+ *
+ * Fail-closed, bind-agnostic (loopback is challenged too):
+ *  - not enrolled          → 403 `step_up_not_configured` (enroll / use the CLI)
+ *  - no code on the request → 403 `step_up_required`
+ *  - wrong code             → 403 `step_up_invalid`
+ *
+ * The secret and the submitted code are never included in any response body or
+ * log line.
+ */
+export function enforceStepUp(req: Request, ctx: StepUpContext): Response | null {
+  if (ctx.enrollment === null) {
+    return json(
+      {
+        error: "step_up_not_configured",
+        detail:
+          "step-up MFA is not configured on this daemon — this high-blast control " +
+          "verb is refused (fail-closed). Enroll a TOTP secret with `cortex step-up " +
+          "enroll`, or run the equivalent `cortex network …` CLI command, which " +
+          "remains the fallback. There is no typed-confirm downgrade for control verbs.",
+      },
+      403,
+    );
+  }
+
+  const code = readStepUpCode(req);
+  if (code === "") {
+    return json(
+      {
+        error: "step_up_required",
+        detail:
+          `a current TOTP step-up code is required for this control verb — send it in the ` +
+          `${STEP_UP_HEADER} header. Terminal/loopback possession alone is not step-up.`,
+      },
+      403,
+    );
+  }
+
+  const ok = verifyTotp(ctx.enrollment.secret, code, {
+    digits: ctx.enrollment.digits,
+    period: ctx.enrollment.period,
+    window: TOTP_DEFAULTS.window,
+    ...(ctx.nowMs !== undefined ? { nowMs: ctx.nowMs } : {}),
+  });
+  if (!ok) {
+    return json(
+      {
+        error: "step_up_invalid",
+        detail:
+          "the step-up TOTP code was not valid for the current time window. Re-read " +
+          "the current code from your authenticator and retry.",
+      },
+      403,
+    );
+  }
+  return null;
+}

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -145,7 +145,28 @@ export function loadConfig(configPath?: string): Readonly<Config> {
       }
       principals.push(entry.trim());
     }
-    governance = { principals };
+    // FND-3 — optional step-up MFA knobs. Only `secretPath` (a string) is
+    // accepted today; a malformed block throws rather than silently ignoring a
+    // security-relevant override.
+    const stepUpRaw: unknown = governanceRaw.stepUp;
+    let stepUp: { secretPath?: string } | undefined;
+    if (stepUpRaw !== undefined) {
+      if (stepUpRaw === null || typeof stepUpRaw !== "object" || Array.isArray(stepUpRaw)) {
+        throw new Error(`governance.stepUp must be an object in ${resolvedPath}`);
+      }
+      const secretPathRaw = (stepUpRaw as Record<string, unknown>).secretPath;
+      if (secretPathRaw !== undefined) {
+        if (typeof secretPathRaw !== "string" || secretPathRaw.trim() === "") {
+          throw new Error(
+            `governance.stepUp.secretPath must be a non-empty string in ${resolvedPath}`,
+          );
+        }
+        stepUp = { secretPath: secretPathRaw.trim() };
+      } else {
+        stepUp = {};
+      }
+    }
+    governance = stepUp ? { principals, stepUp } : { principals };
   }
 
   let level: LogLevel = DEFAULT_CONFIG.log.level;

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -73,6 +73,13 @@ import {
   isRebindExempt,
   type MutationGuardContext,
 } from "./api/mutation-guard";
+import { enforceStepUp, requiresStepUp } from "./api/step-up-mfa";
+import {
+  DEFAULT_STEP_UP_SECRET_PATH,
+  loadEnrollment,
+  type StepUpEnrollment,
+} from "../../common/step-up/enrollment";
+import { expandTilde } from "../../common/config/loader";
 import { handleGetGovernance } from "./api/governance";
 import { handleGetObservability } from "./api/observability-tab";
 import { proxySideband } from "../../common/sideband/proxy";
@@ -288,6 +295,15 @@ export function startServer(
     ...(cfAccessVerifier ? { verifyJwt: cfAccessVerifier } : {}),
   };
 
+  // FND-3 — step-up MFA secret path. Absolute, tilde-expanded once (the config
+  // is fixed for the server's lifetime). The enrollment itself is loaded
+  // LAZILY per control-verb request (below) so re-enrollment never requires a
+  // daemon restart. Default `~/.config/cortex/step-up-totp.json`; overridable
+  // via `mc.governance.stepUp.secretPath`.
+  const stepUpSecretPath = expandTilde(
+    config.governance?.stepUp?.secretPath ?? DEFAULT_STEP_UP_SECRET_PATH,
+  );
+
   const apiDeps: ApiDeps | null = options.processManager
     ? {
         processManager: options.processManager,
@@ -389,6 +405,7 @@ export function startServer(
           guard,
           handoffView,
           doctorView,
+          stepUpSecretPath,
         );
       }
 
@@ -551,6 +568,7 @@ async function handleApi(
   guard: MutationGuardContext,
   handoffView: HandoffView | null = null,
   doctorView: DoctorView | null = null,
+  stepUpSecretPath: string = expandTilde(DEFAULT_STEP_UP_SECRET_PATH),
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -562,9 +580,43 @@ async function handleApi(
     const rebindDenial = checkRebindGuard(req, guard);
     if (rebindDenial) return rebindDenial;
   }
-  if (isIdentityGatedMutation(req.method, pathname)) {
+  // A high-blast control verb (FND-3) is ALSO identity-gated: step-up without
+  // knowing WHO is stepping up is meaningless. Per invariant 3 the hardened
+  // decider pattern is Host/Origin + identity + authz + step-up, composed — so
+  // control routes run the identity+authz gate here and the step-up gate below.
+  if (isIdentityGatedMutation(req.method, pathname) || requiresStepUp(req.method, pathname)) {
     const authResult = await enforceMutationAuth(req, guard);
     if (authResult instanceof Response) return authResult;
+  }
+  // FND-3 — step-up MFA on the high-blast `'control'` verb set (seal / rotate-K
+  // / revoke / escalation-approve). Runs AFTER the identity gate and is
+  // bind-agnostic: loopback is challenged too (terminal possession ≠ step-up).
+  // Enrollment is loaded lazily here (control verbs are rare + high-blast; a
+  // per-request read means re-enrollment needs no daemon restart). A malformed
+  // / bad-permission secret THROWS from the loader — mapped to 500 rather than
+  // a silent downgrade. The secret is never logged (the loader's error carries
+  // only the path + reason, never the secret).
+  if (requiresStepUp(req.method, pathname)) {
+    let enrollment: StepUpEnrollment | null;
+    try {
+      enrollment = loadEnrollment(stepUpSecretPath);
+    } catch (err) {
+      process.stderr.write(
+        `[step-up] failed to load enrollment: ${(err as Error).message}\n`,
+      );
+      return new Response(
+        JSON.stringify({
+          error: "step_up_load_failed",
+          detail:
+            "the step-up MFA enrollment could not be read (malformed or wrong " +
+            "permissions). Refusing the control verb fail-closed. Re-enroll with " +
+            "`cortex step-up enroll`.",
+        }),
+        { status: 500, headers: { "content-type": "application/json" } },
+      );
+    }
+    const stepUpDenial = enforceStepUp(req, { enrollment });
+    if (stepUpDenial) return stepUpDenial;
   }
 
   if (pathname === "/api/assignments") {

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -590,6 +590,23 @@ export interface Config {
 export interface GovernanceConfig {
   /** Principal emails (CF-Access identities) allowed to run glass mutations. */
   principals: string[];
+  /**
+   * FND-3 — step-up MFA (LOCAL TOTP) knobs. Optional; when omitted the daemon
+   * reads the enrolled secret from the default path
+   * (`~/.config/cortex/step-up-totp.json`). Absent enrollment fails high-blast
+   * control verbs closed (403) regardless — this block only relocates the
+   * secret, it never disables the gate.
+   */
+  stepUp?: StepUpGovernanceConfig;
+}
+
+/** FND-3 — step-up MFA configuration. */
+export interface StepUpGovernanceConfig {
+  /**
+   * Override the on-disk home of the enrolled TOTP secret. Tilde-expanded.
+   * Never contains the secret itself — only its path.
+   */
+  secretPath?: string;
 }
 
 /** cortex#1410 — CF Access application binding for non-loopback MC. */


### PR DESCRIPTION
Closes #1689. Wave-1 security keystone of epic #1671 — the single fail-closed step-up gate every high-blast **control** govern verb (seal / rotate-K / revoke / escalation-approve — FLG-6/8/9, SPX-8) will consume.

## What
D-2 ratified (#1679): **local RFC-6238 TOTP**, verified at the daemon `handleApi` decider seam. The CF Worker's user-auth is bypassed on the loopback path, and CF Access is not in the loopback request path at all — so enforcement lives at the daemon, right after the FND-6 identity gate.

- `src/common/step-up/totp.ts` — dependency-free (node:crypto) RFC 6238 TOTP. **Constant-time across the whole ±1 window** (bitwise-OR fold, no early return), `timingSafeEqual` per step, dummy-compare so malformed input isn't measurably faster to reject. Never writes the secret/code anywhere.
- `src/common/step-up/enrollment.ts` — `0600` secret persistence. Absent ⇒ `null` (gate 403s); present-but-malformed / wrong-perm ⇒ **throws** (a broken secret must never silently read as "not enrolled" and downgrade the gate).
- `src/surface/mc/api/step-up-mfa.ts` — the gate: `'control'`-route registry + `enforceStepUp` returning fail-closed 403s; **bind-agnostic (loopback is challenged too** — terminal possession ≠ step-up).
- `src/surface/mc/server.ts` — wired AFTER the identity gate; loader throw ⇒ 500 fail-closed; denial `return`ed before any handler dispatch.
- `src/cli/cortex/commands/stepup.ts` — `cortex step-up enroll / status / verify`.
- `config.ts` / `types.ts` / `cortex.ts` — `governance.stepUp.secretPath` knob + CLI wiring.

## Invariants (each fail-closed)
1. Loopback challenged too — no bind branch.
2. Absent enrollment ⇒ 403 + honest "enroll or use the CLI"; **never** a silent typed-confirm downgrade.
3. Missing code and wrong code both ⇒ 403.
4. Secret never logged, printed, or returned (loader errors carry path+reason only).

## Adversarial pass (orchestrator trace against source)
absent-enrollment downgrade ✓ closed · non-loopback bypass ✓ (bind-agnostic) · timing ✓ (constant-time + timingSafeEqual + dummy-compare) · secret leakage ✓ (never logged). **One residual:** no last-used-step tracking, so a code is replayable within its ±1 (90s) window — low-risk here (local daemon, principal-only, *behind* the identity gate); filed as follow-up hardening, not a blocker.

## Tests
`bun test src/common/step-up/__tests__/totp.test.ts` — 20/20 (RFC 6238 Appendix-B vectors, window edges, constant-time property, malformed input).

## Provenance
docs/plan-mc-future-state.md §4.0 · decision D-2 (#1679) · epic #1671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)