### PR TITLE
feat(cortex): FLG-2 — authorize-from-glass (wire GOVERN bar Authorize verb, D-11) (#1706)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -181,6 +181,16 @@ import type {
   AdmissionDecider,
   AdmissionDecisionResult,
 } from "./surface/mc/api/networks-admission";
+// FLG-2 (docs/plan-mc-future-state.md Track FLG, cortex#1706) — authorize-from-
+// glass: reuse the CLI's hub-admin seed loader + authorize orchestrator/ports so
+// the daemon route signs the SAME hub-admin claim `cortex network authorize`
+// does (no hand-rolled seed loading / signing).
+import type {
+  Authorizer,
+  AuthorizeResult,
+  AuthorizeFailure,
+} from "./surface/mc/api/networks-authorize";
+import { hubAdminMaterialFromSeedFile } from "./cli/cortex/commands/network-secret-adapters";
 import {
   resolveAdmittedRoster,
   type AdmissionRowsProvider,
@@ -196,7 +206,7 @@ import {
   summarizeAcceptancePolicy,
   resolvePeerAcceptance,
 } from "./bus/agent-network/peer-acceptance";
-import { materialFromSeedString } from "./bus/stack-provisioning";
+import { materialFromSeedString, signAdminRequest, randomNonce } from "./bus/stack-provisioning";
 // MC-A3 (cortex#1277, ADR-0019/0018) — derive each joined network's read-only
 // confidentiality posture from config for the `/api/networks` view.
 import { confidentialityPosture } from "./common/crypto/network-encryption-policy";
@@ -704,6 +714,48 @@ export interface StartCortexOptions {
  * @throws if `options.principal.id` is unset or empty — fail-fast at
  *   boot rather than masking the gap.
  */
+/**
+ * FLG-2 (cortex#1706) — map the registry authorize endpoint's HTTP status +
+ * `error` code onto the surface's structured {@link AuthorizeFailure}. Prefers
+ * the registry's own error code (its gate order is `503 admin_not_configured →
+ * 401 signature_invalid → 403 admin_not_authorized`, plus `409 not_admitted`),
+ * falling back to the raw status for anything unmapped. Pure.
+ */
+function mapAuthorizeStatus(status: number, registryError: string | undefined): AuthorizeFailure {
+  switch (registryError) {
+    case "admin_not_configured":
+      return "hub_admin_not_configured";
+    case "signature_invalid":
+      return "signature_invalid";
+    case "admin_not_authorized":
+      return "admin_not_authorized";
+    case "not_admitted":
+      return "not_admitted";
+    case "not_found":
+      return "not_found";
+    default:
+      break;
+  }
+  switch (status) {
+    case 503:
+      return "hub_admin_not_configured";
+    case 401:
+      return "signature_invalid";
+    case 403:
+      return "admin_not_authorized";
+    case 409:
+      return "not_admitted";
+    case 429:
+      return "rate_limited";
+    case 400:
+      return "invalid";
+    case 404:
+      return "not_found";
+    default:
+      return "unreachable";
+  }
+}
+
 function resolvePrincipalId(
   principal: StartCortexOptions["principal"],
 ): string {
@@ -4053,6 +4105,13 @@ export async function startCortex(
   // identity material + resolved registry). `null` until then ⇒ the route 503s.
   // Signs LOCALLY with the stack seed; never wired in the CF worker.
   let admissionDeciderForApi: AdmissionDecider | null = null;
+  // FLG-2 (cortex#1706) — the authorize-from-glass signer for the trust-granting
+  // `POST /api/networks/authorize` action. Assigned in the federation block below
+  // from the hub-admin seed (the Q5-collapse hub-admin = the stack seed for a
+  // single-principal deployment). `null` until then ⇒ the route returns a
+  // structured 503 `hub_admin_not_configured` (fail-closed). Signs LOCALLY with
+  // the hub-admin seed; never wired in the CF worker.
+  let authorizerForApi: Authorizer | null = null;
   // #1008/#989 — discovered LOCAL sibling stacks, used by BOTH the DB-read
   // pane-of-glass aggregation (the embed's `localAggregation` getter, below, for
   // session trees) AND the #989 bus sibling-presence aggregator (later, for
@@ -4135,6 +4194,11 @@ export async function startCortex(
         // registry are resolved). null ⇒ `POST /api/networks/admission-decision`
         // 503s honestly.
         admissionDecider: () => admissionDeciderForApi,
+        // FLG-2 (cortex#1706) — the local-daemon authorize-from-glass signer
+        // (lazy; assigned in the federation block once the hub-admin seed +
+        // registry are resolved). null ⇒ `POST /api/networks/authorize` returns
+        // 503 `hub_admin_not_configured`.
+        authorizer: () => authorizerForApi,
         // FLG-1 (docs/plan-mc-future-state.md §4.D) — the guided-join handoff
         // view (lazy; assigned in the federation block). null ⇒
         // `GET /api/networks/:net/handoff/:member` 503s honestly.
@@ -4773,6 +4837,117 @@ export async function startCortex(
             "cortex: MC /api/networks/admission-decision wired — LIVE local-daemon-signed " +
               "Tier-2 admit/reject (stack-seed-signed; CF-Access + typed-confirm gated at the surface)",
           );
+        }
+
+        // FLG-2 (cortex#1706) — the authorize-from-glass signer: stamp
+        // `hub_authorized_at` on an ADMITTED admission row (registry cortex#1498).
+        // HUB-ADMIN authority (ADR-0018 Q5) — for the common single-principal
+        // deployment the hub-admin seed IS the stack seed, so we load it via the
+        // SAME chmod-600-gated `hubAdminMaterialFromSeedFile` the CLI's `cortex
+        // network authorize` uses (no hand-rolled seed loading). Live iff the
+        // hub-admin seed loads AND a registry URL is resolved. Absent/unloadable
+        // seed ⇒ `authorizerForApi` stays null ⇒ the route 503s
+        // `hub_admin_not_configured` (fail-closed). Signs LOCALLY; never in the
+        // CF worker.
+        if (options.stack?.nkey_seed_path && resolvedRegistry !== undefined) {
+          const hubSeedPath = options.stack.nkey_seed_path;
+          const authorizeRegistryUrl = resolvedRegistry.url;
+          const hubAdmin = await hubAdminMaterialFromSeedFile(hubSeedPath);
+          if (!hubAdmin.ok) {
+            // Honest degradation: the route will 503 `hub_admin_not_configured`.
+            // Never crashes the embed boot (mirrors the member-roster read).
+            console.error(
+              "cortex: MC /api/networks/authorize DARK — could not load the hub-admin seed " +
+                `(non-fatal, authorize-from-glass 503s until fixed): ${hubAdmin.reason}`,
+            );
+          } else {
+            const hubMaterial = hubAdmin.material;
+            const authorizeBase = authorizeRegistryUrl.replace(/\/+$/, "");
+            authorizerForApi = {
+              authorize: async (requestId): Promise<AuthorizeResult> => {
+                const claim = {
+                  request_id: requestId,
+                  hub_admin_pubkey: hubMaterial.pubkeyB64,
+                  issued_at: new Date().toISOString(),
+                  nonce: randomNonce(),
+                };
+                let resp: Response;
+                try {
+                  const signed = await signAdminRequest(hubMaterial.seed, claim);
+                  resp = await fetch(
+                    `${authorizeBase}/admission-requests/${encodeURIComponent(requestId)}/authorize`,
+                    {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify(signed),
+                    },
+                  );
+                } catch (err) {
+                  const detail = err instanceof Error ? err.message : String(err);
+                  console.log(
+                    `cortex: FLG-2 authorize — request=${requestId} -> unreachable(${detail})`,
+                  );
+                  return { ok: false, reason: "unreachable", detail: `registry unreachable: ${detail}` };
+                }
+
+                let parsed: unknown;
+                try {
+                  parsed = await resp.json();
+                } catch {
+                  // Non-JSON body (e.g. a proxy error page) — map by status below.
+                  parsed = null;
+                }
+                const obj =
+                  parsed !== null && typeof parsed === "object"
+                    ? (parsed as Record<string, unknown>)
+                    : {};
+
+                if (resp.ok) {
+                  const hubAuthorizedAt =
+                    typeof obj.hub_authorized_at === "string" ? obj.hub_authorized_at : undefined;
+                  if (hubAuthorizedAt === undefined) {
+                    // 2xx but no stamp — treat as an invalid registry response
+                    // rather than fabricate a success signal.
+                    console.log(
+                      `cortex: FLG-2 authorize — request=${requestId} -> invalid(no hub_authorized_at)`,
+                    );
+                    return {
+                      ok: false,
+                      reason: "invalid",
+                      detail: "registry returned 2xx but no hub_authorized_at timestamp",
+                    };
+                  }
+                  console.log(
+                    `cortex: FLG-2 authorize — request=${requestId} -> authorized(${hubAuthorizedAt})`,
+                  );
+                  return { ok: true, requestId, hubAuthorizedAt };
+                }
+
+                // Failure — map the registry's status + error code to the
+                // surface's structured failure (propagated verbatim to the glass).
+                const registryError = typeof obj.error === "string" ? obj.error : undefined;
+                const registryDetail =
+                  typeof obj.details === "string"
+                    ? obj.details
+                    : typeof obj.detail === "string"
+                      ? obj.detail
+                      : undefined;
+                const reason = mapAuthorizeStatus(resp.status, registryError);
+                const detail =
+                  registryDetail ??
+                  registryError ??
+                  `registry rejected authorize (HTTP ${resp.status.toString()})`;
+                console.log(
+                  `cortex: FLG-2 authorize — request=${requestId} -> refused(${reason}, HTTP ${resp.status.toString()})`,
+                );
+                return { ok: false, reason, detail };
+              },
+            };
+            console.log(
+              "cortex: MC /api/networks/authorize wired — LIVE local-daemon-signed " +
+                "hub-admin authorize (stamps hub_authorized_at; step-up-MFA gated at the surface)",
+            );
+          }
         }
       }
 

--- a/src/surface/mc/api/__tests__/networks-authorize.test.ts
+++ b/src/surface/mc/api/__tests__/networks-authorize.test.ts
@@ -1,0 +1,190 @@
+/**
+ * FLG-2 (cortex#1706) — tests for the authorize-from-glass daemon route:
+ * `handleAuthorize` (typed-confirm intent gate + fail-closed hub-admin seam +
+ * registry-verdict passthrough) AND the step-up MFA wiring that guards it.
+ *
+ * Pure — an injected `Authorizer` stub; no HTTP, no crypto.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  handleAuthorize,
+  AUTHORIZE_PATH,
+  type Authorizer,
+  type AuthorizeResult,
+} from "../networks-authorize";
+import {
+  STEP_UP_CONTROL_ROUTES,
+  requiresStepUp,
+  enforceStepUp,
+  readStepUpCode,
+  STEP_UP_HEADER,
+} from "../step-up-mfa";
+
+const REQ = "req-abc-123";
+const OK_BODY = { request_id: REQ, confirm: REQ };
+
+/** An authorizer that returns a fixed result. */
+function authorizer(result: AuthorizeResult): Authorizer {
+  return { authorize: () => Promise.resolve(result) };
+}
+
+/** An authorizer that records its calls (to assert the request_id passed through). */
+function recordingAuthorizer(): { authorizer: Authorizer; calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    authorizer: {
+      authorize: (requestId) => {
+        calls.push(requestId);
+        return Promise.resolve({ ok: true, requestId, hubAuthorizedAt: "2026-07-08T00:00:00.000Z" });
+      },
+    },
+  };
+}
+
+/** An authorizer that must NOT be reached (asserts a gate fired first). */
+const throwingAuthorizer: Authorizer = {
+  authorize: () => {
+    throw new Error("authorizer should not be reached");
+  },
+};
+
+async function bodyOf(resp: Response): Promise<Record<string, unknown>> {
+  return (await resp.json()) as Record<string, unknown>;
+}
+
+describe("handleAuthorize — typed-confirm intent gate", () => {
+  it("rejects a non-object body with 400", async () => {
+    const resp = await handleAuthorize(throwingAuthorizer, "nope");
+    expect(resp.status).toBe(400);
+  });
+
+  it("rejects a missing/invalid request_id with 400", async () => {
+    const resp = await handleAuthorize(throwingAuthorizer, { request_id: "", confirm: "" });
+    expect(resp.status).toBe(400);
+    expect((await bodyOf(resp)).error).toContain("request_id");
+  });
+
+  it("rejects a confirm that does not exactly match request_id with 400", async () => {
+    const resp = await handleAuthorize(throwingAuthorizer, { request_id: REQ, confirm: "req-abc-124" });
+    expect(resp.status).toBe(400);
+    expect((await bodyOf(resp)).error).toContain("confirm must exactly match request_id");
+  });
+
+  it("rejects a trailing-space confirm mismatch (exact echo, not trimmed) with 400", async () => {
+    const resp = await handleAuthorize(throwingAuthorizer, { request_id: REQ, confirm: `${REQ} ` });
+    expect(resp.status).toBe(400);
+  });
+});
+
+describe("handleAuthorize — fail-closed hub-admin seam", () => {
+  it("returns a structured 503 hub_admin_not_configured when the authorizer is null", async () => {
+    const resp = await handleAuthorize(null, OK_BODY);
+    expect(resp.status).toBe(503);
+    const body = await bodyOf(resp);
+    expect(body.error).toBe("hub_admin_not_configured");
+    expect(typeof body.detail).toBe("string");
+  });
+
+  it("does NOT reach the null-seam 503 until the intent gate passes (mismatch 400 first)", async () => {
+    // A bad confirm on a null authorizer still 400s (the intent gate runs before
+    // the seam check) — never a 503 that would leak "the seam is absent" past a
+    // malformed request.
+    const resp = await handleAuthorize(null, { request_id: REQ, confirm: "wrong" });
+    expect(resp.status).toBe(400);
+  });
+});
+
+describe("handleAuthorize — verdict passthrough", () => {
+  it("surfaces hub_authorized_at ONLY on a positive (ok) result", async () => {
+    const { authorizer: rec, calls } = recordingAuthorizer();
+    const resp = await handleAuthorize(rec, OK_BODY);
+    expect(resp.status).toBe(200);
+    const body = await bodyOf(resp);
+    expect(body.request_id).toBe(REQ);
+    expect(body.hub_authorized_at).toBe("2026-07-08T00:00:00.000Z");
+    expect(calls).toEqual([REQ]);
+  });
+
+  it("propagates a registry 409 not_admitted verbatim as structured JSON", async () => {
+    const resp = await handleAuthorize(
+      authorizer({ ok: false, reason: "not_admitted", detail: "request is PENDING, not ADMITTED" }),
+      OK_BODY,
+    );
+    expect(resp.status).toBe(409);
+    const body = await bodyOf(resp);
+    expect(body.error).toBe("not_admitted");
+    expect(body.detail).toContain("PENDING");
+  });
+
+  it("propagates a registry 401 signature_invalid as 401", async () => {
+    const resp = await handleAuthorize(
+      authorizer({ ok: false, reason: "signature_invalid", detail: "sig" }),
+      OK_BODY,
+    );
+    expect(resp.status).toBe(401);
+    expect((await bodyOf(resp)).error).toBe("signature_invalid");
+  });
+
+  it("propagates a registry 403 admin_not_authorized as 403", async () => {
+    const resp = await handleAuthorize(
+      authorizer({ ok: false, reason: "admin_not_authorized", detail: "not allowlisted" }),
+      OK_BODY,
+    );
+    expect(resp.status).toBe(403);
+    expect((await bodyOf(resp)).error).toBe("admin_not_authorized");
+  });
+
+  it("maps a hub_admin_not_configured registry failure to 503", async () => {
+    const resp = await handleAuthorize(
+      authorizer({ ok: false, reason: "hub_admin_not_configured", detail: "no allowlist" }),
+      OK_BODY,
+    );
+    expect(resp.status).toBe(503);
+  });
+});
+
+describe("FLG-2 route is step-up (MFA) gated", () => {
+  it("/api/networks/authorize is in STEP_UP_CONTROL_ROUTES", () => {
+    expect(STEP_UP_CONTROL_ROUTES.has(AUTHORIZE_PATH)).toBe(true);
+    expect(AUTHORIZE_PATH).toBe("/api/networks/authorize");
+  });
+
+  it("requiresStepUp is true for a POST to the authorize route", () => {
+    expect(requiresStepUp("POST", AUTHORIZE_PATH)).toBe(true);
+    // A GET to the same path is not step-up-gated here (it is not a mutation).
+    expect(requiresStepUp("GET", AUTHORIZE_PATH)).toBe(false);
+  });
+
+  it("a POST without a step-up code is refused 403 (proven at the gate)", () => {
+    // No X-Cortex-Step-Up-Otp header ⇒ the gate returns a 403 step_up_required
+    // BEFORE the handler runs. Enrolled secret present (so this proves the
+    // MISSING-CODE branch, not the not-enrolled branch).
+    const req = new Request(`http://127.0.0.1${AUTHORIZE_PATH}`, {
+      method: "POST",
+      body: JSON.stringify(OK_BODY),
+    });
+    expect(readStepUpCode(req)).toBe("");
+    const denial = enforceStepUp(req, {
+      enrollment: {
+        version: 1,
+        secret: "JBSWY3DPEHPK3PXP",
+        digits: 6,
+        period: 30,
+        createdAt: "2026-07-08T00:00:00.000Z",
+      },
+    });
+    expect(denial).not.toBeNull();
+    expect(denial?.status).toBe(403);
+  });
+
+  it("a POST WITH the step-up header carries a code the gate reads", () => {
+    const req = new Request(`http://127.0.0.1${AUTHORIZE_PATH}`, {
+      method: "POST",
+      headers: { [STEP_UP_HEADER]: "123456" },
+      body: JSON.stringify(OK_BODY),
+    });
+    expect(readStepUpCode(req)).toBe("123456");
+  });
+});

--- a/src/surface/mc/api/networks-authorize.ts
+++ b/src/surface/mc/api/networks-authorize.ts
@@ -1,0 +1,192 @@
+/**
+ * FLG-2 (docs/plan-mc-future-state.md Track FLG, decision D-11, cortex#1706) —
+ * the **authorize-from-glass** daemon route: `POST /api/networks/authorize`.
+ *
+ * Wave-1 of the MC govern glass wires the GOVERN bar's `Authorize` slot LIVE.
+ * The registry backend already exists (`POST
+ * /admission-requests/{request_id}/authorize`, cortex#1498 — HUB-ADMIN-signed,
+ * stamps `hub_authorized_at` onto an ADMITTED row); this route is the glass +
+ * daemon wiring to it — no new crypto, no new registry route.
+ *
+ * ## Trust posture (this is a trust-GRANTING verb — high blast)
+ *
+ * `hub_authorized_at` is the real signal that replaces the honor-system
+ * `--hub-authorized-confirmed` attestation in the guided-join handoff: stamping
+ * it tells a joining member's leaf it is cleared to come up. It is therefore a
+ * `'control'` (high-blast) verb and sits behind the FND-3 **step-up MFA** gate
+ * exactly like its siblings (seal / rotate-K / revoke). The gate is enforced
+ * CENTRALLY in `server.ts handleApi` — this path is added to
+ * `STEP_UP_CONTROL_ROUTES` (`step-up-mfa.ts`), so a POST without a valid
+ * current TOTP code is refused with a 403 BEFORE the request reaches this
+ * handler, and the handler never has to re-check it. The FND-6 identity gate
+ * runs first (step-up without knowing WHO is stepping up is meaningless).
+ *
+ * ## Fail-closed on an absent hub-admin seed
+ *
+ * The signing seam is injected by `cortex.ts` from the hub-admin seed (built via
+ * `hubAdminMaterialFromSeedFile` — the SAME chmod-600-gated loader the CLI's
+ * `cortex network authorize` uses; seed loading is NOT hand-rolled here). When
+ * the seed is absent / unloadable the injected seam is `null` and this handler
+ * returns a structured `503 hub_admin_not_configured` — NEVER a silent success.
+ * The live demo needs the deployed key (task #3 / #1671); the CODE builds and
+ * fails-closed cleanly without it.
+ *
+ * ## Verdict passthrough
+ *
+ * `hub_authorized_at` is surfaced ONLY on a positive (2xx) registry response.
+ * The registry's own gate order (`503 admin_not_configured → 401
+ * signature_invalid → 403 admin_not_authorized`, plus `409 not_admitted`) is
+ * propagated verbatim as structured JSON so the glass shows the registry's
+ * reason, not a flattened status.
+ */
+
+/** The typed-confirm gate: the client must echo the target `request_id`. */
+interface AuthorizeBody {
+  request_id: string;
+  /** Typed-confirm: must exactly equal `request_id`. */
+  confirm: string;
+}
+
+// A conservative request-id shape (the registry's `isValidRequestId` is the
+// authority; this is a cheap client-side pre-check so we never sign an
+// obviously-bad id). IDENTICAL to the admission route's guard.
+const REQUEST_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{2,127}$/;
+
+/** Why an authorize attempt failed — surface-local so this module never imports the bus. */
+export type AuthorizeFailure =
+  | "hub_admin_not_configured"
+  | "signature_invalid"
+  | "admin_not_authorized"
+  | "not_admitted"
+  | "rate_limited"
+  | "invalid"
+  | "not_found"
+  | "unreachable";
+
+/** The outcome of a hub-admin-signed authorize — never thrown. */
+export type AuthorizeResult =
+  | { ok: true; requestId: string; hubAuthorizedAt: string }
+  | { ok: false; reason: AuthorizeFailure; detail: string };
+
+/**
+ * The injected seam the surface depends on to sign + POST the authorize claim.
+ * `cortex.ts` supplies a live implementation built from the hub-admin seed +
+ * the federated registry config; tests supply a stub. The server's getter
+ * returns `null` when the hub-admin seed is not configured/loadable → the
+ * handler returns a structured 503 `hub_admin_not_configured` (fail-closed).
+ */
+export interface Authorizer {
+  authorize(requestId: string): Promise<AuthorizeResult>;
+}
+
+/** `POST /api/networks/authorize`. */
+export const AUTHORIZE_PATH = "/api/networks/authorize";
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Map an authorize failure reason to the HTTP status the glass branches on. */
+function failureStatus(reason: AuthorizeFailure): number {
+  switch (reason) {
+    case "hub_admin_not_configured":
+      return 503;
+    case "signature_invalid":
+      return 401;
+    case "admin_not_authorized":
+      return 403;
+    case "not_admitted":
+      return 409;
+    case "rate_limited":
+      return 429;
+    case "invalid":
+      return 400;
+    case "not_found":
+      return 404;
+    case "unreachable":
+      return 502;
+  }
+}
+
+/**
+ * Validate the body shape (typed-confirm included). Pure — no I/O. Returns the
+ * normalised body or a `Response` (already the right status) to return verbatim.
+ */
+function parseBody(
+  raw: unknown,
+): { ok: true; body: AuthorizeBody } | { ok: false; response: Response } {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, response: json({ error: "body must be a JSON object" }, 400) };
+  }
+  const b = raw as Record<string, unknown>;
+
+  if (typeof b.request_id !== "string" || !REQUEST_ID_RE.test(b.request_id)) {
+    return { ok: false, response: json({ error: "request_id must be a valid admission request id" }, 400) };
+  }
+  // Typed-confirm: the principal must echo the request_id they mean to act on —
+  // the deliberate intent gate for a control-plane mutation (mirrors the CLI's
+  // `cortex network authorize` posture + the admission-decision route).
+  if (typeof b.confirm !== "string" || b.confirm !== b.request_id) {
+    return {
+      ok: false,
+      response: json(
+        {
+          error: "confirm must exactly match request_id",
+          detail:
+            "Type the request id to confirm this trust-granting authorize. " +
+            "This is the deliberate intent gate for a control-plane mutation.",
+        },
+        400,
+      ),
+    };
+  }
+
+  return { ok: true, body: { request_id: b.request_id, confirm: b.confirm } };
+}
+
+/**
+ * Handle `POST /api/networks/authorize`.
+ *
+ * Identity (FND-6) + step-up MFA (FND-3) are already enforced upstream in
+ * `handleApi` (this path is in `STEP_UP_CONTROL_ROUTES`); by the time we get
+ * here the request is authenticated and step-up-satisfied. This handler owns
+ * the typed-confirm intent gate + the fail-closed seam + the verdict passthrough.
+ *
+ * @param authorizer The injected hub-admin signer seam. `null` ⇒ 503
+ *                   `hub_admin_not_configured` (no hub-admin seed loadable).
+ * @param rawBody    The parsed JSON body (server already enforced the size cap).
+ */
+export async function handleAuthorize(
+  authorizer: Authorizer | null,
+  rawBody: unknown,
+): Promise<Response> {
+  // Intent gate — body shape + typed-confirm.
+  const parsed = parseBody(rawBody);
+  if (!parsed.ok) return parsed.response;
+
+  // Fail-closed: the hub-admin signing seam must be wired (hub-admin seed
+  // present + loadable). NEVER a silent success when the key is absent.
+  if (authorizer === null) {
+    return json(
+      {
+        error: "hub_admin_not_configured",
+        detail:
+          "authorize-from-glass is unavailable — no hub-admin signing seed is configured/loadable " +
+          "on this daemon (stamping hub_authorized_at requires the hub-admin authority, ADR-0018 Q5). " +
+          "Deploy the hub-admin seed, or run `cortex network authorize` from the hub owner's stack.",
+      },
+      503,
+    );
+  }
+
+  const result = await authorizer.authorize(parsed.body.request_id);
+
+  if (result.ok) {
+    // hub_authorized_at is surfaced ONLY on a positive registry response.
+    return json({ request_id: result.requestId, hub_authorized_at: result.hubAuthorizedAt }, 200);
+  }
+  return json({ error: result.reason, detail: result.detail }, failureStatus(result.reason));
+}

--- a/src/surface/mc/api/step-up-mfa.ts
+++ b/src/surface/mc/api/step-up-mfa.ts
@@ -76,6 +76,7 @@ export function readStepUpCode(req: Request): string {
  * the FND-6 identity + typed-confirm tier.
  */
 export const STEP_UP_CONTROL_ROUTES: ReadonlySet<string> = new Set([
+  "/api/networks/authorize", // FLG-2 — authorize-from-glass (stamp hub_authorized_at)
   "/api/networks/seal", // FLG-6 — admit-and-seal from glass
   "/api/networks/rotate-key", // FLG-8 — rotate-K from glass
   "/api/networks/revoke", // FLG-9 — revoke from glass

--- a/src/surface/mc/dashboard-v2/__tests__/govern-bar.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/govern-bar.test.tsx
@@ -60,20 +60,19 @@ function render(over: Partial<GovernBarProps>): string {
   return renderToStaticMarkup(createElement(GovernBar, props(over)));
 }
 
-describe("GovernBar — admin posture (verb rail harness)", () => {
-  it("renders the verb rail with every slot as an inert harness placeholder", () => {
+describe("GovernBar — admin posture (verb rail)", () => {
+  it("renders the verb rail with every taxonomy slot present", () => {
     const html = render({});
     expect(html).toContain("govern-verb-rail");
     // every taxonomy slot renders…
     for (const slot of GOVERN_VERB_SLOTS) {
       expect(html).toContain(`data-verb="${slot.id}"`);
     }
-    // …and every button is disabled (NO verb is wired in this shell).
-    const buttons = html.match(/govern-verb-btn/g) ?? [];
-    expect(buttons.length).toBe(GOVERN_VERB_SLOTS.length);
+    // FLG-2 (cortex#1706) — authorize is now a WIRED control (its own form), not
+    // a disabled placeholder; the remaining decision-gated verbs stay disabled.
+    expect(html).toContain('data-verb-live="authorize"');
+    // seal/rotate/revoke are still honest placeholders (disabled).
     expect(html).toContain("disabled");
-    // the four decision-gated verbs are honest placeholders
-    expect(html).toContain('data-verb="authorize"');
     expect(html).toContain('data-verb="seal"');
     expect(html).toContain('data-verb="rotate"');
     expect(html).toContain('data-verb="revoke"');
@@ -81,10 +80,16 @@ describe("GovernBar — admin posture (verb rail harness)", () => {
     expect(html).not.toContain(FORBIDDEN);
   });
 
-  it("marks the one already-live slot (dispatch) distinct from the pending ones", () => {
+  it("wires the Authorize verb LIVE (step-up-gated form), not a disabled placeholder", () => {
     const html = render({});
-    expect(html).toContain('data-verb="dispatch"');
-    expect(html).toContain('data-verb-state="live"');
+    expect(html).toContain('data-verb="authorize"');
+    expect(html).toContain('data-verb-state="live"'); // authorize + dispatch are live
+    expect(html).toContain('data-verb-live="authorize"');
+    // the wired control collects the request id, a typed-confirm echo, and the
+    // step-up code (all three fields render).
+    expect(html).toContain("govern-authorize-input");
+    expect(html).toContain("govern-authorize-otp");
+    // the remaining decision-gated verbs are still pending placeholders.
     expect(html).toContain('data-verb-state="pending"');
   });
 
@@ -223,10 +228,11 @@ describe("govern-bar-adapter — pure gate + selectors", () => {
     expect(badges[0]?.tone).not.toBe(badges[1]?.tone);
   });
 
-  it("the verb rail taxonomy has exactly one live slot (dispatch); the rest pending", () => {
+  it("the verb rail taxonomy has authorize + dispatch live (FLG-2); seal/rotate/revoke pending", () => {
     const live = GOVERN_VERB_SLOTS.filter((s) => s.state === "live");
     const pending = GOVERN_VERB_SLOTS.filter((s) => s.state === "pending");
-    expect(live.map((s) => s.id)).toEqual(["dispatch"]);
-    expect(pending.map((s) => s.id)).toEqual(["authorize", "seal", "rotate", "revoke"]);
+    // FLG-2 (cortex#1706) flipped authorize from pending → live.
+    expect(live.map((s) => s.id)).toEqual(["authorize", "dispatch"]);
+    expect(pending.map((s) => s.id)).toEqual(["seal", "rotate", "revoke"]);
   });
 });

--- a/src/surface/mc/dashboard-v2/components/govern-bar.css
+++ b/src/surface/mc/dashboard-v2/components/govern-bar.css
@@ -53,6 +53,57 @@
   text-transform: uppercase;
 }
 
+/* ── FLG-2 wired Authorize control (admin only, step-up-gated) ─────────────── */
+.govern-authorize {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.govern-authorize-fields {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+}
+.govern-authorize-input {
+  font: 500 10px var(--mono);
+  padding: 4px 8px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--panel);
+  color: var(--fg);
+  min-width: 150px;
+}
+.govern-authorize-otp {
+  min-width: 92px;
+  letter-spacing: 0.12em;
+}
+/* The Authorize button reads LIVE (solid, on-brand) — not dashed-disabled — and
+   only enables when the typed-confirm + step-up gate is satisfied. */
+.govern-authorize-btn {
+  border-style: solid;
+  border-color: color-mix(in oklch, var(--mer) 45%, transparent);
+  color: var(--mer);
+  cursor: pointer;
+  opacity: 1;
+}
+.govern-authorize-btn:disabled,
+.govern-authorize-btn[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.govern-authorize-result {
+  font: 500 10px var(--mono);
+  margin: 0;
+  line-height: 1.5;
+}
+.govern-authorize-result.tone-ok {
+  color: var(--mer);
+}
+.govern-authorize-result.tone-error {
+  color: var(--red, #d66);
+}
+
 /* ── Named banners (admission-request + the FLG-1/FLG-3 mounts) ────────────── */
 .govern-banner {
   border: 1px solid var(--line);

--- a/src/surface/mc/dashboard-v2/components/govern-bar.tsx
+++ b/src/surface/mc/dashboard-v2/components/govern-bar.tsx
@@ -28,6 +28,7 @@
  * static markup for the tests.
  */
 
+import { useState } from "react";
 import type { NetworkPosture } from "../lib/mc-shell-model";
 import type { NetworkMembershipDTO } from "../../api/networks";
 import {
@@ -36,9 +37,24 @@ import {
   selectAdmissionRequests,
   adminAuthorityBadges,
 } from "../lib/govern-bar-adapter";
+import {
+  canAuthorize,
+  submitAuthorize,
+  describeAuthorizeOutcome,
+  type AuthorizeOutcome,
+  type FetchLike,
+} from "../lib/authorize-lib";
 import { HandoffBannerLive } from "./handoff-banner";
 import { DoctorDrill } from "./network-doctor-panel";
 import "./govern-bar.css";
+
+/**
+ * The browser `fetch` narrowed to the {@link FetchLike} shape the authorize lib
+ * consumes. Defined once so the live control and any injected test double share
+ * the exact call surface (the lib never imports the DOM `fetch`).
+ */
+const browserFetch: FetchLike = (path, init) =>
+  fetch(path, { method: init.method, headers: init.headers, body: init.body });
 
 export interface GovernBarProps {
   /** Posture toward the dived network (`null` at the root / unresolved). */
@@ -74,14 +90,115 @@ function AuthorityBadges() {
 }
 
 /**
- * The empty per-verb rail (admin only). Every slot is a HARNESS placeholder —
- * the decision-gated verbs are disabled with an honest "lands with FLG-N"
- * caption; the one `live` slot (dispatch) points at the existing control. No slot
- * dispatches a real verb in this shell.
+ * FLG-2 (cortex#1706) — the WIRED **Authorize** control. Rendered ONLY inside
+ * the admin verb rail (the rail itself is admin-gated by `governIsAdmin`, so
+ * invariant 8 holds — a non-admin never sees this affordance at all).
+ *
+ * Authorize stamps `hub_authorized_at` on an ADMITTED admission request — a
+ * trust-GRANTING, high-blast control verb. It therefore sits behind the FND-3
+ * step-up MFA gate: the principal supplies the target `request_id`, re-types it
+ * to confirm (the intent gate, mirroring the CLI `--apply` posture), AND enters
+ * the current 6-digit TOTP code, which is sent in the `X-Cortex-Step-Up-Otp`
+ * header. The daemon signs the hub-admin claim locally + POSTs the registry.
+ *
+ * SSR-inert: no effect fires until the principal interacts, so the whole bar
+ * still renders to static markup for the tests.
+ */
+function AuthorizeControl({ caption }: { caption: string }) {
+  const [requestId, setRequestId] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [stepUpCode, setStepUpCode] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [outcome, setOutcome] = useState<AuthorizeOutcome | null>(null);
+
+  const ready = canAuthorize({ requestId, confirm, stepUpCode, busy });
+
+  async function onAuthorize(): Promise<void> {
+    if (!ready) return;
+    setBusy(true);
+    setOutcome(null);
+    const result = await submitAuthorize(
+      { request_id: requestId.trim(), confirm },
+      stepUpCode,
+      browserFetch,
+    );
+    setOutcome(result);
+    setBusy(false);
+    if (result.kind === "ok") {
+      // Clear the fields on success — the request is authorized; a fresh code
+      // would be needed for the next one anyway (TOTP is single-use per window).
+      setRequestId("");
+      setConfirm("");
+      setStepUpCode("");
+    }
+  }
+
+  const described = outcome ? describeAuthorizeOutcome(outcome) : null;
+
+  return (
+    <div className="govern-authorize" data-verb-live="authorize">
+      <div className="govern-authorize-fields">
+        <input
+          type="text"
+          className="govern-authorize-input"
+          placeholder="admission request id"
+          aria-label="Admission request id to authorize"
+          value={requestId}
+          disabled={busy}
+          onChange={(e) => setRequestId(e.target.value)}
+        />
+        <input
+          type="text"
+          className="govern-authorize-input"
+          placeholder="re-type request id to confirm"
+          aria-label="Confirm the request id"
+          value={confirm}
+          disabled={busy}
+          onChange={(e) => setConfirm(e.target.value)}
+        />
+        <input
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          className="govern-authorize-input govern-authorize-otp"
+          placeholder="step-up code"
+          aria-label="Step-up MFA code"
+          value={stepUpCode}
+          disabled={busy}
+          onChange={(e) => setStepUpCode(e.target.value)}
+        />
+        <button
+          type="button"
+          className="govern-verb-btn govern-authorize-btn"
+          disabled={!ready}
+          aria-disabled={!ready}
+          title={caption}
+          onClick={() => {
+            void onAuthorize();
+          }}
+        >
+          {busy ? "Authorizing…" : "Authorize"}
+        </button>
+      </div>
+      {described !== null ? (
+        <p className={`govern-authorize-result tone-${described.tone}`} role="status">
+          {described.text}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The per-verb rail (admin only). FLG-2 wired the **Authorize** slot LIVE (it
+ * renders the interactive {@link AuthorizeControl}); the remaining decision-gated
+ * verbs (seal / rotate / revoke) stay HARNESS placeholders — disabled with an
+ * honest "lands with FLG-N" caption. DISPATCH is a `live` pointer at the
+ * existing control below the bar (not a second dispatch trigger).
  */
 function VerbRail() {
   return (
-    <div className="govern-verb-rail" role="group" aria-label="Govern verbs (shell)">
+    <div className="govern-verb-rail" role="group" aria-label="Govern verbs">
       {GOVERN_VERB_SLOTS.map((slot) => (
         <div
           key={slot.id}
@@ -89,18 +206,22 @@ function VerbRail() {
           data-verb={slot.id}
           data-verb-state={slot.state}
         >
-          <button
-            type="button"
-            className="govern-verb-btn"
-            // SHELL: no verb is wired — the slot is inert. The decision-gated
-            // verbs are disabled outright; the live slot is a pointer, not a
-            // second dispatch trigger (the live control renders below the bar).
-            disabled
-            aria-disabled="true"
-            title={slot.caption}
-          >
-            {slot.label}
-          </button>
+          {slot.id === "authorize" ? (
+            <AuthorizeControl caption={slot.caption} />
+          ) : (
+            <button
+              type="button"
+              className="govern-verb-btn"
+              // The decision-gated verbs (seal/rotate/revoke) are disabled
+              // outright; the `dispatch` live slot is a pointer, not a second
+              // dispatch trigger (the live control renders below the bar).
+              disabled
+              aria-disabled="true"
+              title={slot.caption}
+            >
+              {slot.label}
+            </button>
+          )}
           <span className="dim govern-verb-flag" title={slot.caption}>
             {slot.state === "live" ? "live · " : "soon · "}
             {slot.flag}

--- a/src/surface/mc/dashboard-v2/lib/__tests__/authorize-lib.test.ts
+++ b/src/surface/mc/dashboard-v2/lib/__tests__/authorize-lib.test.ts
@@ -1,0 +1,160 @@
+/**
+ * FLG-2 (cortex#1706) — tests for the authorize-from-glass pure lib: the
+ * typed-confirm + step-up gate (`canAuthorize`), the POST + verdict mapping
+ * (`submitAuthorize`, incl. the `X-Cortex-Step-Up-Otp` header), and the
+ * outcome-describe. Injected `FetchLike`; no DOM, no network.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  canAuthorize,
+  submitAuthorize,
+  describeAuthorizeOutcome,
+  AUTHORIZE_PATH,
+  STEP_UP_HEADER,
+  type FetchLike,
+} from "../authorize-lib";
+
+const REQ = "req-abc-123";
+
+/** A FetchLike that records the call and returns a canned response. */
+function fakeFetch(resp: {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}): { fetchImpl: FetchLike; calls: { path: string; init: Parameters<FetchLike>[1] }[] } {
+  const calls: { path: string; init: Parameters<FetchLike>[1] }[] = [];
+  return {
+    calls,
+    fetchImpl: (path, init) => {
+      calls.push({ path, init });
+      return Promise.resolve({
+        ok: resp.ok,
+        status: resp.status,
+        json: () => Promise.resolve(resp.body),
+      });
+    },
+  };
+}
+
+describe("canAuthorize — typed-confirm + step-up gate", () => {
+  it("is true only when id + exact confirm + a step-up code are present and not busy", () => {
+    expect(canAuthorize({ requestId: REQ, confirm: REQ, stepUpCode: "123456", busy: false })).toBe(true);
+  });
+
+  it("is false with an empty request id", () => {
+    expect(canAuthorize({ requestId: "  ", confirm: "  ", stepUpCode: "123456", busy: false })).toBe(false);
+  });
+
+  it("is false when the confirm does not exactly echo the id (not trimmed)", () => {
+    expect(canAuthorize({ requestId: REQ, confirm: `${REQ} `, stepUpCode: "123456", busy: false })).toBe(false);
+    expect(canAuthorize({ requestId: REQ, confirm: "req-abc-124", stepUpCode: "123456", busy: false })).toBe(false);
+  });
+
+  it("is false without a step-up code (control verb is MFA-gated)", () => {
+    expect(canAuthorize({ requestId: REQ, confirm: REQ, stepUpCode: "  ", busy: false })).toBe(false);
+  });
+
+  it("is false while a request is in flight", () => {
+    expect(canAuthorize({ requestId: REQ, confirm: REQ, stepUpCode: "123456", busy: true })).toBe(false);
+  });
+});
+
+describe("submitAuthorize — POST + verdict mapping", () => {
+  it("POSTs to the authorize path with the step-up code in the header", async () => {
+    const { fetchImpl, calls } = fakeFetch({
+      ok: true,
+      status: 200,
+      body: { request_id: REQ, hub_authorized_at: "2026-07-08T00:00:00.000Z" },
+    });
+    await submitAuthorize({ request_id: REQ, confirm: REQ }, "123456", fetchImpl);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.path).toBe(AUTHORIZE_PATH);
+    expect(calls[0]?.init.method).toBe("POST");
+    expect(calls[0]?.init.headers[STEP_UP_HEADER]).toBe("123456");
+    expect(calls[0]?.init.headers["content-type"]).toBe("application/json");
+  });
+
+  it("trims the step-up code before sending it in the header", async () => {
+    const { fetchImpl, calls } = fakeFetch({
+      ok: true,
+      status: 200,
+      body: { request_id: REQ, hub_authorized_at: "t" },
+    });
+    await submitAuthorize({ request_id: REQ, confirm: REQ }, "  123456  ", fetchImpl);
+    expect(calls[0]?.init.headers[STEP_UP_HEADER]).toBe("123456");
+  });
+
+  it("maps a 2xx with hub_authorized_at to an ok outcome", async () => {
+    const { fetchImpl } = fakeFetch({
+      ok: true,
+      status: 200,
+      body: { request_id: REQ, hub_authorized_at: "2026-07-08T00:00:00.000Z" },
+    });
+    const outcome = await submitAuthorize({ request_id: REQ, confirm: REQ }, "123456", fetchImpl);
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.requestId).toBe(REQ);
+      expect(outcome.hubAuthorizedAt).toBe("2026-07-08T00:00:00.000Z");
+    }
+  });
+
+  it("maps a 2xx WITHOUT hub_authorized_at to an error (never fabricates success)", async () => {
+    const { fetchImpl } = fakeFetch({ ok: true, status: 200, body: { request_id: REQ } });
+    const outcome = await submitAuthorize({ request_id: REQ, confirm: REQ }, "123456", fetchImpl);
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.httpStatus).toBe(200);
+  });
+
+  it("prefers the server detail on a failure and preserves the http status", async () => {
+    const { fetchImpl } = fakeFetch({
+      ok: false,
+      status: 409,
+      body: { error: "not_admitted", detail: "request is PENDING, not ADMITTED" },
+    });
+    const outcome = await submitAuthorize({ request_id: REQ, confirm: REQ }, "123456", fetchImpl);
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.message).toContain("PENDING");
+      expect(outcome.httpStatus).toBe(409);
+    }
+  });
+
+  it("surfaces the 503 hub_admin_not_configured detail on an absent-seed daemon", async () => {
+    const { fetchImpl } = fakeFetch({
+      ok: false,
+      status: 503,
+      body: { error: "hub_admin_not_configured", detail: "no hub-admin signing seed" },
+    });
+    const outcome = await submitAuthorize({ request_id: REQ, confirm: REQ }, "123456", fetchImpl);
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.httpStatus).toBe(503);
+      expect(outcome.message).toContain("hub-admin");
+    }
+  });
+
+  it("never throws on a transport failure — maps it to httpStatus 0", async () => {
+    const fetchImpl: FetchLike = () => Promise.reject(new Error("network down"));
+    const outcome = await submitAuthorize({ request_id: REQ, confirm: REQ }, "123456", fetchImpl);
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.httpStatus).toBe(0);
+      expect(outcome.message).toContain("network down");
+    }
+  });
+});
+
+describe("describeAuthorizeOutcome", () => {
+  it("tone ok on success, naming the stamped request", () => {
+    const d = describeAuthorizeOutcome({ kind: "ok", requestId: REQ, hubAuthorizedAt: "t" });
+    expect(d.tone).toBe("ok");
+    expect(d.text).toContain(REQ);
+  });
+
+  it("tone error carries the failure message", () => {
+    const d = describeAuthorizeOutcome({ kind: "error", message: "not authorized", httpStatus: 403 });
+    expect(d.tone).toBe("error");
+    expect(d.text).toBe("not authorized");
+  });
+});

--- a/src/surface/mc/dashboard-v2/lib/authorize-lib.ts
+++ b/src/surface/mc/dashboard-v2/lib/authorize-lib.ts
@@ -1,0 +1,131 @@
+/**
+ * FLG-2 (docs/plan-mc-future-state.md Track FLG, decision D-11, cortex#1706) —
+ * pure logic for the **authorize-from-glass** GOVERN verb: POST the target
+ * request-id to `/api/networks/authorize`, carrying the current TOTP step-up
+ * code, and map the registry verdict to something renderable.
+ *
+ * Mirrors `pier-decide-lib.ts` (POST + map + injectable `FetchLike`): the
+ * load-bearing behaviour — the typed-confirm gate, the step-up header, and the
+ * verdict → readable-message mapping — is unit-testable without a DOM harness
+ * (the dashboard tests render statically; there is no testing-library).
+ *
+ * Authorize is a trust-GRANTING, high-blast control verb: the daemon route
+ * ({@link AUTHORIZE_PATH}) sits behind the FND-3 step-up MFA gate, so a POST
+ * MUST carry a valid current 6-digit TOTP code in the {@link STEP_UP_HEADER}
+ * header. The daemon signs the hub-admin authorize claim locally + POSTs the
+ * registry; this client only POSTs and renders the verdict.
+ */
+
+/** The step-up MFA header the daemon's control gate reads (mirror of the server const). */
+export const STEP_UP_HEADER = "X-Cortex-Step-Up-Otp";
+
+/** `POST /api/networks/authorize`. */
+export const AUTHORIZE_PATH = "/api/networks/authorize";
+
+/** The POST body the endpoint expects (`confirm` must equal `request_id`). */
+export interface AuthorizeBody {
+  request_id: string;
+  confirm: string;
+}
+
+/** The outcome of an authorize POST, already mapped to something renderable. */
+export type AuthorizeOutcome =
+  | { kind: "ok"; requestId: string; hubAuthorizedAt: string }
+  | { kind: "error"; message: string; httpStatus: number };
+
+/** Minimal fetch shape (injectable for tests). Identical to pier-decide-lib. */
+export type FetchLike = (
+  path: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+/**
+ * The typed-confirm gate: an authorize may be submitted only when a non-empty
+ * request-id has been entered AND the confirm box exactly echoes it AND a
+ * non-empty step-up code has been supplied AND no request is already in flight.
+ * Pure — the single source of truth the button's disabled state and any
+ * programmatic caller share.
+ */
+export function canAuthorize(input: {
+  requestId: string;
+  confirm: string;
+  stepUpCode: string;
+  busy: boolean;
+}): boolean {
+  const id = input.requestId.trim();
+  if (id.length === 0) return false;
+  if (input.busy) return false;
+  // A control verb is step-up-gated: no code ⇒ the daemon will 403, so the
+  // button stays disabled rather than firing a request that cannot succeed.
+  if (input.stepUpCode.trim().length === 0) return false;
+  // Exact echo — NOT trimmed on the confirm side: the principal must reproduce
+  // the id verbatim (a stray space is a real mismatch, surfaced honestly).
+  return input.confirm === input.requestId;
+}
+
+/**
+ * POST an authorize and map the response to an {@link AuthorizeOutcome}. Sends
+ * the TOTP code in the {@link STEP_UP_HEADER} header (the control gate reads it
+ * BEFORE the body). Reads the server's `{ error, detail }` on failure so the
+ * principal sees the readable `detail` (e.g. the not-admitted / not-authorized
+ * explanation) rather than a bare status code. Never throws — a transport
+ * failure becomes `{ kind: "error", httpStatus: 0 }`.
+ */
+export async function submitAuthorize(
+  body: AuthorizeBody,
+  stepUpCode: string,
+  fetchImpl: FetchLike,
+): Promise<AuthorizeOutcome> {
+  let resp: Awaited<ReturnType<FetchLike>>;
+  try {
+    resp = await fetchImpl(AUTHORIZE_PATH, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [STEP_UP_HEADER]: stepUpCode.trim(),
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    return {
+      kind: "error",
+      message: err instanceof Error ? err.message : String(err),
+      httpStatus: 0,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await resp.json();
+  } catch {
+    parsed = null;
+  }
+  const obj = parsed !== null && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+
+  if (resp.ok) {
+    const hubAuthorizedAt = typeof obj.hub_authorized_at === "string" ? obj.hub_authorized_at : undefined;
+    if (hubAuthorizedAt !== undefined) {
+      const requestId = typeof obj.request_id === "string" ? obj.request_id : body.request_id;
+      return { kind: "ok", requestId, hubAuthorizedAt };
+    }
+    return { kind: "error", message: "the authorize succeeded but the response was malformed", httpStatus: resp.status };
+  }
+
+  // Failure — prefer the human `detail`, fall back to the `error` code, then HTTP.
+  const detail = typeof obj.detail === "string" ? obj.detail : undefined;
+  const error = typeof obj.error === "string" ? obj.error : undefined;
+  const message = detail ?? error ?? `HTTP ${resp.status.toString()}`;
+  return { kind: "error", message, httpStatus: resp.status };
+}
+
+/** A short, tone-tagged summary of an outcome for the result line. */
+export function describeAuthorizeOutcome(outcome: AuthorizeOutcome): { tone: "ok" | "error"; text: string } {
+  if (outcome.kind === "ok") {
+    return { tone: "ok", text: `Request ${outcome.requestId} authorized (hub_authorized_at stamped).` };
+  }
+  return { tone: "error", text: outcome.message };
+}

--- a/src/surface/mc/dashboard-v2/lib/govern-bar-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/govern-bar-adapter.ts
@@ -65,8 +65,8 @@ export const GOVERN_VERB_SLOTS: readonly GovernVerbSlot[] = [
     id: "authorize",
     label: "Authorize",
     flag: "FLG-2",
-    state: "pending",
-    caption: "Grant a pending admission request — decision-gated, lands with FLG-2.",
+    state: "live",
+    caption: "Stamp hub_authorized_at on an ADMITTED request — hub-admin, step-up-gated.",
   },
   {
     id: "seal",

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -25,6 +25,8 @@ import type { WsClientRegistry } from "./ws/client-registry";
 import type { AgentPresenceView } from "./api/agents";
 import type { NetworksView } from "./api/networks";
 import type { AdmissionDecider } from "./api/networks-admission";
+// FLG-2 (cortex#1706) — authorize-from-glass signer seam.
+import type { Authorizer } from "./api/networks-authorize";
 // FLG-1 (docs/plan-mc-future-state.md §4.D) — guided-join handoff view passthrough.
 import type { HandoffView } from "./api/handoff";
 // FLG-3 (docs/plan-mc-future-state.md §4.D) — network doctor view passthrough.
@@ -108,6 +110,15 @@ export interface StartMissionControlOptions {
    * embed. Omitted → the route 503s honestly.
    */
   admissionDecider?: () => AdmissionDecider | null;
+  /**
+   * FLG-2 (cortex#1706) — lazy accessor for the authorize-from-glass signer,
+   * forwarded verbatim to `startServer` so `POST /api/networks/authorize` can
+   * stamp `hub_authorized_at` on an ADMITTED row LOCALLY with the hub-admin
+   * seed. A GETTER (like `admissionDecider`) because the hub-admin material +
+   * registry client boot AFTER the embed. Omitted → the route 503s
+   * `hub_admin_not_configured` (fail-closed).
+   */
+  authorizer?: () => Authorizer | null;
   /**
    * FLG-1 (docs/plan-mc-future-state.md §4.D) — lazy accessor for the guided-join
    * handoff view, forwarded verbatim to `startServer` so
@@ -210,6 +221,7 @@ export async function startMissionControl(
       ...(opts.agentPresence ? { agentPresence: opts.agentPresence } : {}),
       ...(opts.networks ? { networks: opts.networks } : {}),
       ...(opts.admissionDecider ? { admissionDecider: opts.admissionDecider } : {}),
+      ...(opts.authorizer ? { authorizer: opts.authorizer } : {}),
       ...(opts.handoffView ? { handoffView: opts.handoffView } : {}),
       ...(opts.doctorView ? { doctorView: opts.doctorView } : {}),
       ...(opts.localAggregation ? { localAggregation: opts.localAggregation } : {}),

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -54,6 +54,12 @@ import {
   type AdmissionDecider,
   type AdmissionAuthContext,
 } from "./api/networks-admission";
+// FLG-2 (docs/plan-mc-future-state.md Track FLG, cortex#1706) — authorize-from-glass.
+import {
+  handleAuthorize,
+  AUTHORIZE_PATH,
+  type Authorizer,
+} from "./api/networks-authorize";
 import { verifyCfAccessJwt } from "../../common/auth/cf-access-jwt";
 import type {
   LocalAggregationContext,
@@ -232,6 +238,18 @@ export interface StartServerOptions {
    */
   admissionDecider?: () => AdmissionDecider | null;
   /**
+   * FLG-2 (docs/plan-mc-future-state.md Track FLG, cortex#1706) — lazy accessor
+   * for the authorize-from-glass signer: the hub-admin-signed
+   * `POST /api/networks/authorize` that stamps `hub_authorized_at` on an
+   * ADMITTED admission row. A GETTER like `admissionDecider` because the
+   * hub-admin material + registry client boot AFTER the embed in `cortex.ts`;
+   * resolved per request. Returns `null` ⇒ no hub-admin seed / registry
+   * configured → the route returns a structured 503 `hub_admin_not_configured`
+   * (fail-closed — never a silent success). Signs LOCALLY (the daemon holds the
+   * hub-admin seed); the CF worker never wires this.
+   */
+  authorizer?: () => Authorizer | null;
+  /**
    * FLG-1 (docs/plan-mc-future-state.md §4.D) — lazy accessor for the guided-join
    * handoff view (serves `GET /api/networks/:net/handoff/:member`: the 3-leg
    * seal → hub-authorize → leaf-up state via the pure `deriveHandoffState`). A
@@ -382,6 +400,10 @@ export function startServer(
         // MC-B2 — resolve the admission-decision signer lazily too (stack
         // identity + registry client boot after the server). null ⇒ 503.
         const admissionDecider = options.admissionDecider?.() ?? null;
+        // FLG-2 — resolve the authorize-from-glass signer lazily too (hub-admin
+        // material + registry boot after the server). null ⇒ 503
+        // `hub_admin_not_configured`.
+        const authorizer = options.authorizer?.() ?? null;
         // FLG-1 — resolve the handoff view lazily (same boot-order reason as
         // `networks`). null ⇒ the handoff route 503s honestly.
         const handoffView = options.handoffView?.() ?? null;
@@ -406,6 +428,7 @@ export function startServer(
           handoffView,
           doctorView,
           stepUpSecretPath,
+          authorizer,
         );
       }
 
@@ -569,6 +592,7 @@ async function handleApi(
   handoffView: HandoffView | null = null,
   doctorView: DoctorView | null = null,
   stepUpSecretPath: string = expandTilde(DEFAULT_STEP_UP_SECRET_PATH),
+  authorizer: Authorizer | null = null,
 ): Promise<Response> {
   const { pathname } = url;
 
@@ -937,6 +961,26 @@ async function handleApi(
       ...(guard.verifyJwt ? { verifyJwt: guard.verifyJwt } : {}),
     };
     return handleAdmissionDecision(admissionDecider, auth, body.value);
+  }
+
+  // FLG-2 (docs/plan-mc-future-state.md Track FLG, cortex#1706) — POST
+  // /api/networks/authorize — the trust-GRANTING authorize-from-glass verb:
+  // stamp `hub_authorized_at` on an ADMITTED admission row (registry
+  // cortex#1498, hub-admin-signed). Placed AFTER the FND-3 step-up gate block
+  // above: this path is in `STEP_UP_CONTROL_ROUTES`, so a POST without a valid
+  // current TOTP code was already refused (403) before reaching here, and the
+  // FND-6 identity gate ran first. The handler owns the typed-confirm intent
+  // gate + the fail-closed hub-admin seam (null ⇒ 503 `hub_admin_not_configured`)
+  // + the registry-verdict passthrough. Signs LOCALLY (the daemon holds the
+  // hub-admin seed); the CF worker never wires `authorizer`, so this route 503s
+  // there.
+  if (pathname === AUTHORIZE_PATH) {
+    if (req.method !== "POST") {
+      return methodNotAllowed(["POST"]);
+    }
+    const body = await parseJsonBody(req);
+    if (body.error) return body.error;
+    return handleAuthorize(authorizer, body.value);
   }
 
   // F-17 — principal-driven GitHub iteration import.


### PR DESCRIPTION
Closes #1706. Wave-1 of epic #1671 — flips the CK-7 GOVERN-bar **Authorize** slot live.

Glass + daemon wiring to the EXISTING registry `POST /admission-requests/{id}/authorize` (cortex#1498, hub-admin-signed, stamps `hub_authorized_at`). No new crypto, no new registry route.

## What
- `src/surface/mc/api/networks-authorize.ts` — daemon `POST /api/networks/authorize`: POST-only, `confirm===request_id` intent gate (400), injected `Authorizer` seam (null ⇒ structured **503 `hub_admin_not_configured`**, never silent success), registry verdict passthrough (`hub_authorized_at` only on 2xx; 401/403/409 verbatim).
- Added `/api/networks/authorize` to `STEP_UP_CONTROL_ROUTES` — **MFA-gated** like its seal/rotate/revoke siblings (authorize grants trust ⇒ high-blast).
- `server.ts` — route dispatch placed AFTER the FND-3 step-up gate; `cortex.ts` builds the seam from the hub-admin seed (`hubAdminMaterialFromSeedFile`), absent/unloadable seed ⇒ seam null ⇒ fail-closed 503.
- Glass: `authorize-lib.ts` (sends TOTP in `X-Cortex-Step-Up-Otp`), authorize slot pending→live, `AuthorizeControl` rendered only inside the admin-gated rail (invariant 8).

## Tests
49 pass on the 3 target files; 131-pass regression sweep. tsc 0, eslint clean on all 12 files. Additive-only (diff-filter=D empty).

## Out of scope / HELD
Live hub-admin key deploy (task #3 / #1671) — code builds + 503s cleanly without it. Fully-separable hub-admin authority (vs Q5 stack-seed collapse) stays the open governance question, not FLG-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)