### PR TITLE
feat(cortex): SES-1 (schema half) — session attribution_target column + migration 0007 (#1709)

### DIFF
--- a/src/surface/mc/db/canonical-session.ts
+++ b/src/surface/mc/db/canonical-session.ts
@@ -262,6 +262,16 @@ export const CANONICAL_SESSION_COLUMNS: CanonicalSessionColumn[] = [
     note:
       "The stack this session ORIGINATED on — the schema-level attribution the cross-stack WORKING aggregation groups by (#1295). D-8 adopts a column + backfill that EXTENDS the ADR-0011 canonical row rather than forking a parallel origin table, so both substrates carry it and the read model stays a plain GROUP BY. NULL ⇒ own/local-stack origin (the pre-CK-4a and single-stack case) — an honest 'unattributed to a specific peer stack', never fabricated. Never sourced from an attacker-controlled payload; stamped from the stack's own resolved identity on write / backfill.",
   },
+  // --- attribution (SES-1 / #1709 / decision D-16) ---
+  {
+    d1Name: "attribution_target",
+    localName: "attribution_target",
+    type: "TEXT",
+    notNull: false,
+    default: null,
+    note:
+      "The controlled-vocabulary target a session's spend rolls up to — a repo / domain, seeded from repos/domains and EXTENSIBLE (D-16, #1679). A schema field extending the ADR-0011 canonical row, NOT a naming convention. The vocabulary is enforced at WRITE time (like classification/substrate), so this stays plain nullable TEXT — ALTER-safe on a table with rows, and the vocabulary grows without a schema migration. NULL ⇒ the read model renders `unattributed` (an honest 'not yet attributed'), NEVER inferred or defaulted to a principal/project (D-16 honesty; §6 invariant 20).",
+  },
 ];
 
 /** The two indices the session-tree refactor adds to BOTH substrates (Phase 0). */
@@ -306,5 +316,6 @@ export const CANONICAL_ADDED_COLUMNS = CANONICAL_SESSION_COLUMNS.filter((c) =>
     "data_residency",
     "home_principal",
     "origin_stack_id",
+    "attribution_target",
   ].includes(c.d1Name)
 );

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -154,10 +154,11 @@ export const SCHEMA_SQL: string[] = [
     -- same #961/#1048 pre-existing-DB rule as parent_session_id/substrate below.
     origin_stack_id TEXT,
     -- SES-1 / #1709 / decision D-16 canonical: the controlled-vocab ATTRIBUTION
-    -- target a session's spend rolls up to (repo/domain, extensible). NULL ⇒ the
-    -- read model renders `unattributed`, NEVER inferred (D-16 honesty). Its lookup
-    -- index idx_sessions_attribution_target is created by the attribution_target
-    -- COLUMN_ADD_MIGRATIONS post[] (NOT here) — same pre-existing-DB rule as above.
+    -- target a session's spend rolls up to (repo/domain, extensible). NULL means
+    -- the read model renders 'unattributed', NEVER inferred (D-16 honesty). Its
+    -- lookup index idx_sessions_attribution_target is created by the
+    -- attribution_target COLUMN_ADD_MIGRATIONS post[] (NOT here) — same
+    -- pre-existing-DB rule as above.
     attribution_target TEXT
   )`,
 
@@ -769,6 +770,23 @@ export const COLUMN_ADD_MIGRATIONS: ColumnAddMigration[] = [
     ddl: `ALTER TABLE sessions ADD COLUMN origin_stack_id TEXT`,
     post: [
       `CREATE INDEX IF NOT EXISTS idx_sessions_origin_stack_id ON sessions(origin_stack_id)`,
+    ],
+  },
+
+  // SES-1 / #1709 / decision D-16 — session ATTRIBUTION for EXISTING DBs.
+  // Fresh DBs get the column from the sessions CREATE TABLE above; an already-
+  // initialised DB backfills it here via the same pragma_table_info gate.
+  // Nullable TEXT, no CHECK/NOT NULL (the controlled vocabulary is enforced at
+  // WRITE time, like classification/substrate) so the ALTER is safe on a table
+  // with rows. NULL ⇒ the read model renders `unattributed`, NEVER inferred
+  // (D-16 honesty). The lookup index runs in post[] (unconditional, so fresh
+  // DBs get it too) — mirrors origin_stack_id above.
+  {
+    table: "sessions",
+    column: "attribution_target",
+    ddl: `ALTER TABLE sessions ADD COLUMN attribution_target TEXT`,
+    post: [
+      `CREATE INDEX IF NOT EXISTS idx_sessions_attribution_target ON sessions(attribution_target)`,
     ],
   },
 

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -152,7 +152,13 @@ export const SCHEMA_SQL: string[] = [
     -- NULL ⇒ own/local-stack origin. Its lookup index idx_sessions_origin_stack_id
     -- is created by the origin_stack_id COLUMN_ADD_MIGRATIONS post[] (NOT here) —
     -- same #961/#1048 pre-existing-DB rule as parent_session_id/substrate below.
-    origin_stack_id TEXT
+    origin_stack_id TEXT,
+    -- SES-1 / #1709 / decision D-16 canonical: the controlled-vocab ATTRIBUTION
+    -- target a session's spend rolls up to (repo/domain, extensible). NULL ⇒ the
+    -- read model renders `unattributed`, NEVER inferred (D-16 honesty). Its lookup
+    -- index idx_sessions_attribution_target is created by the attribution_target
+    -- COLUMN_ADD_MIGRATIONS post[] (NOT here) — same pre-existing-DB rule as above.
+    attribution_target TEXT
   )`,
 
   // --- events ---

--- a/src/surface/mc/worker/migrations/0007_session_attribution.sql
+++ b/src/surface/mc/worker/migrations/0007_session_attribution.sql
@@ -1,0 +1,40 @@
+-- SES-1 / #1709 / decision D-16 — session ATTRIBUTION on the D1 (cloud) snapshot.
+--
+-- Adds the canonical `attribution_target` field to the deployed D1 `sessions`
+-- table so the cloud schema matches the local bun:sqlite schema and the shared
+-- canonical source (../../db/canonical-session.ts, CANONICAL_SESSION_COLUMNS):
+--   - sessions.attribution_target  (the controlled-vocab target a session's spend
+--     rolls up to — a repo / domain, extensible per D-16; NULL ⇒ `unattributed`).
+--
+-- D-16 (ratified #1679): attribution is a `sessions` COLUMN with a controlled
+-- vocabulary seeded from repos/domains — a schema field EXTENDING the ADR-0011
+-- canonical row, NOT a naming convention and NOT a parallel table. This keeps the
+-- SES-1 cost read model a plain projection/GROUP BY over the existing usage columns
+-- (input_tokens/output_tokens/cache_read_tokens/cost_usd) already on the row.
+--
+-- D-16 HONESTY: the column is nullable TEXT with NO server-side default. Unset ⇒
+-- the read model renders `unattributed` — an honest "not yet attributed", NEVER
+-- inferred or silently defaulted to a principal or project. The controlled
+-- vocabulary is enforced at WRITE time (seeded from repos/domains, extensible), not
+-- by a CHECK constraint here — mirroring how `classification` / `substrate` carry
+-- controlled values as plain TEXT so the ALTER stays safe on a table with rows and
+-- the vocabulary can grow without a schema migration per new value.
+--
+-- Apply: wrangler d1 execute grove-events --file=./migrations/0007_session_attribution.sql
+--   (registry/D1 deploys are principal-hands + `--env production`; file only here.
+--    The APPLY is HELD [principal-hands], with CK-4a's 0006 — see #1709 scope.)
+--
+-- Additive + idempotent-friendly: ADD COLUMN is one-shot (errors if re-applied on a
+-- DB that already has the column), the index uses IF NOT EXISTS. Mirrors 0006.
+--
+-- Scope note: the local SQLite `sessions` table gets this column from ../../db/schema.ts
+-- (fresh DBs via CREATE TABLE; existing DBs via the COLUMN_ADD_MIGRATIONS pragma-gated
+-- ALTER). SES-1 does NOT touch CK-4a's 0006 — this is a NEW migration in the same lane.
+
+ALTER TABLE sessions ADD COLUMN attribution_target TEXT;
+
+-- The SESSIONS ledger (SES-2) and the spend rollups (SES-3) group by attribution.
+CREATE INDEX IF NOT EXISTS idx_sessions_attribution_target ON sessions(attribution_target);
+
+-- Bump the schema_version row (0006 seeded version 3).
+INSERT OR IGNORE INTO schema_version (version) VALUES (4);

--- a/src/surface/mc/worker/schema.sql
+++ b/src/surface/mc/worker/schema.sql
@@ -45,7 +45,12 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- CK-4a / #1295 / D-8 canonical: the ORIGIN-stack attribution the cross-stack
   -- WORKING aggregation (DashboardSnapshot.workingAggregation) groups by. NULL ⇒
   -- own/local-stack origin. Added to deployed D1 via migrations/0006_session_origin_stack.sql.
-  origin_stack_id TEXT
+  origin_stack_id TEXT,
+  -- SES-1 / #1709 / decision D-16 canonical: the controlled-vocab ATTRIBUTION
+  -- target a session's spend rolls up to (repo/domain, extensible). NULL means
+  -- the read model renders 'unattributed', NEVER inferred (D-16 honesty). Added
+  -- to deployed D1 via migrations/0007_session_attribution.sql.
+  attribution_target TEXT
 );
 
 CREATE TABLE IF NOT EXISTS github_events (
@@ -158,6 +163,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent_session_id ON sessions(parent_ses
 CREATE INDEX IF NOT EXISTS idx_sessions_substrate ON sessions(substrate);
 -- CK-4a / #1295 — cross-stack aggregation groups WORKING metadata by origin stack.
 CREATE INDEX IF NOT EXISTS idx_sessions_origin_stack_id ON sessions(origin_stack_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_attribution_target ON sessions(attribution_target);
 CREATE INDEX IF NOT EXISTS idx_github_repo ON github_events(repo, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_agent ON github_events(agent_authored, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_principal ON github_events(principal_id);

--- a/src/surface/mc/worker/src/__tests__/dashboard-snapshot-contract.test.ts
+++ b/src/surface/mc/worker/src/__tests__/dashboard-snapshot-contract.test.ts
@@ -79,6 +79,13 @@ const ALLOWED_COLUMNS: Record<string, string[]> = {
     "data_residency", "home_principal", "parent_session_id", "substrate",
     // CK-4a / #1295 — the cross-stack origin the workingAggregation groups by.
     "origin_stack_id",
+    // SES-1 / #1709 / D-16 — the controlled-vocab attribution target. Schema-KNOWN
+    // and vetted here, but NOT projected into the public DTO by this slice
+    // (buildSnapshot does not read it yet). Whether the future SES-1 cost read
+    // model exposes it in the public /api/state vs keeps it own-local (ADR-0005)
+    // is a deliberate decision made WHEN that projection lands + its DTO key is
+    // added below — never a silent pass-through.
+    "attribution_target",
   ],
   session_activity: ["id", "session_id", "timestamp", "icon", "label", "detail"],
   // `payload` IS a raw-JSON-blob column (see the file header) — it exists,


### PR DESCRIPTION
**Advances #1709** (does not close it — the cost read-model + tests are the remaining half, tracked below).

Salvaged from the opus implementer (died mid-task on an environment rate-limit) + completed/corrected. This PR is the **schema half** of SES-1: the D-16 attribution column landing across all physical schemas. Additive, nullable, parity-green — safe to land independently, and it unblocks the read model (SES-1 cont.) + SES-2/SES-3.

## What
- `db/canonical-session.ts` — `attribution_target` added to `CANONICAL_SESSION_COLUMNS` + `CANONICAL_ADDED_COLUMNS` (D-16: controlled-vocab column extending the ADR-0011 row; NULL ⇒ `unattributed`, never inferred).
- `db/schema.ts` — column in the local `sessions` CREATE TABLE **and** the `COLUMN_ADD_MIGRATIONS` ALTER + index (the existing-DB backfill path — the #1048 class the salvaged WIP had missed).
- `worker/schema.sql` — column + index in the D1 base schema (fresh-D1 parity).
- `worker/migrations/0007_session_attribution.sql` — the deployed-D1 ALTER + index (apply is HELD [principal-hands], with CK-4a's 0006).

## Corrections applied to the salvaged WIP
1. Added the missing `COLUMN_ADD_MIGRATIONS` ALTER (existing DBs would otherwise never get the column).
2. Removed markdown backticks around `unattributed` that were **inside** the backtick-delimited `SCHEMA_SQL` template literal (a syntax error).
3. Added the column to `worker/schema.sql` (the parity test reads the D1 CREATE TABLE from there, not the migrations).

## Tests
`bun test src/surface/mc/__tests__/session-schema-parity.test.ts` → **7/7**. tsc 0, eslint clean, additive-only.

## Remaining (SES-1 cont.)
The token/cost read-model projection (GROUP BY over `input_tokens`/`output_tokens`/`cache_read_tokens`/`cost_usd`, sub-agent rollup, `DashboardSnapshot`-guarded, `for_principal` from session identity) + its tests. Re-dispatched once the rate-limit clears.

## References
docs/plan-mc-future-state.md §4.E SES-1 · D-16 (#1679) · ADR-0011 · CK-4a lane · epic #1671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)