### PR TITLE
feat(cortex): SES-1 (read-model) — per-session cost/attribution projection, own-local (#1709)

### DIFF
--- a/src/surface/mc/__tests__/cost-attribution.test.ts
+++ b/src/surface/mc/__tests__/cost-attribution.test.ts
@@ -1,0 +1,318 @@
+/**
+ * SES-1 / #1709 / decision D-16 — unit tests for the per-session token/cost +
+ * attribution read model (db/cost-attribution.ts).
+ *
+ * Pins:
+ *   - per-session projection of the EXISTING usage columns (input/output/cache
+ *     tokens + cost) into the cost row, NULL usage reading as an honest 0;
+ *   - SUB-AGENT rollup: a session's rolledUp total includes every descendant's
+ *     spend, folded up the parent_session_id edge (multi-level + siblings);
+ *   - forPrincipal comes from the session identity (principal_id, then
+ *     home_principal), NEVER inferred; a row with neither is null;
+ *   - attribution_target NULL renders as `unattributed`, NEVER a principal/project;
+ *   - a child whose parent is out-of-set is emitted as its own row (never dropped);
+ *   - cycle safety (a→b→a self/loop edges never hang the rollup);
+ *   - OWN-LOCAL guard: the model is a local projection — this test also documents
+ *     that the read model is NOT wired into the public DashboardSnapshot (that
+ *     boundary carries CK-4a metadata only; see the file header + the
+ *     dashboard-snapshot-contract test's attribution_target note).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+import { initDatabase } from "../db/init";
+import {
+  listSessionCostAttribution,
+  UNATTRIBUTED,
+  type SessionCostRow,
+} from "../db/cost-attribution";
+
+function seedAgent(db: Database, id: string): void {
+  db.query(`INSERT OR IGNORE INTO agents (id, name, type) VALUES (?, ?, 'hands')`).run(
+    id,
+    `Agent ${id}`
+  );
+}
+
+function seedTask(db: Database, id: string): void {
+  db.query(
+    `INSERT OR IGNORE INTO tasks (id, title, priority, principal_id, source_system)
+     VALUES (?, ?, 2, 'andreas', 'internal')`
+  ).run(id, `Task ${id}`);
+}
+
+function seedAssignment(db: Database, id: string, agentId: string, taskId: string): void {
+  db.query(
+    `INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
+     VALUES (?, ?, ?, 'running')`
+  ).run(id, agentId, taskId);
+}
+
+interface SessionOpts {
+  id: string;
+  assignmentId: string;
+  parentSessionId?: string | null;
+  principalId?: string | null;
+  homePrincipal?: string | null;
+  agentId?: string | null;
+  agentName?: string | null;
+  attributionTarget?: string | null;
+  substrate?: string;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cacheReadTokens?: number | null;
+  costUsd?: number | null;
+}
+
+function seedSession(db: Database, o: SessionOpts): void {
+  db.query(
+    `INSERT INTO sessions
+       (id, assignment_id, endpoint_kind, started_at,
+        parent_session_id, substrate, agent_id, agent_name, principal_id,
+        home_principal, attribution_target,
+        input_tokens, output_tokens, cache_read_tokens, cost_usd)
+     VALUES (?, ?, 'local.process.controlled', datetime('now'),
+             ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    o.id,
+    o.assignmentId,
+    o.parentSessionId ?? null,
+    o.substrate ?? "claude-code",
+    o.agentId ?? null,
+    o.agentName ?? null,
+    o.principalId ?? null,
+    o.homePrincipal ?? null,
+    o.attributionTarget ?? null,
+    o.inputTokens ?? null,
+    o.outputTokens ?? null,
+    o.cacheReadTokens ?? null,
+    o.costUsd ?? null
+  );
+}
+
+function byId(rows: SessionCostRow[]): Map<string, SessionCostRow> {
+  return new Map(rows.map((r) => [r.sessionId, r]));
+}
+
+describe("listSessionCostAttribution", () => {
+  let db: Database;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `mc-ses1-cost-${Date.now()}-${Math.random()}`);
+    db = initDatabase(join(tmpDir, "test.db"));
+    seedAgent(db, "ag");
+    seedTask(db, "t");
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty when there are no sessions", () => {
+    expect(listSessionCostAttribution(db)).toEqual([]);
+  });
+
+  it("projects the existing usage columns per session", () => {
+    seedAssignment(db, "a1", "ag", "t");
+    seedSession(db, {
+      id: "s1",
+      assignmentId: "a1",
+      principalId: "andreas",
+      agentId: "ag",
+      agentName: "Marcus",
+      attributionTarget: "the-metafactory/cortex",
+      substrate: "claude-code",
+      inputTokens: 120,
+      outputTokens: 45,
+      cacheReadTokens: 30,
+      costUsd: 0.42,
+    });
+
+    const rows = listSessionCostAttribution(db);
+    expect(rows).toHaveLength(1);
+    const r = rows[0]!;
+    expect(r.sessionId).toBe("s1");
+    expect(r.agentId).toBe("ag");
+    expect(r.agentName).toBe("Marcus");
+    expect(r.forPrincipal).toBe("andreas");
+    expect(r.attributionTarget).toBe("the-metafactory/cortex");
+    expect(r.substrate).toBe("claude-code");
+    expect(r.isSubAgent).toBe(false);
+    expect(r.own).toEqual({ tokensIn: 120, tokensOut: 45, cacheRead: 30, cost: 0.42 });
+    // A leaf's rolledUp equals its own.
+    expect(r.rolledUp).toEqual(r.own);
+  });
+
+  it("reads NULL usage columns as an honest 0, never a fabricated estimate", () => {
+    seedAssignment(db, "a1", "ag", "t");
+    seedSession(db, { id: "s1", assignmentId: "a1", principalId: "andreas" });
+
+    const r = listSessionCostAttribution(db)[0]!;
+    expect(r.own).toEqual({ tokensIn: 0, tokensOut: 0, cacheRead: 0, cost: 0 });
+    expect(r.rolledUp).toEqual({ tokensIn: 0, tokensOut: 0, cacheRead: 0, cost: 0 });
+  });
+
+  it("renders unattributed (never a principal) when attribution_target is NULL", () => {
+    seedAssignment(db, "a1", "ag", "t");
+    seedSession(db, { id: "s1", assignmentId: "a1", principalId: "andreas", attributionTarget: null });
+
+    const r = listSessionCostAttribution(db)[0]!;
+    expect(r.attributionTarget).toBe(UNATTRIBUTED);
+    expect(r.attributionTarget).toBe("unattributed");
+    // The honest bucket is NOT the principal — attribution and identity stay distinct.
+    expect(r.attributionTarget).not.toBe(r.forPrincipal);
+  });
+
+  it("takes forPrincipal from principal_id, then home_principal, never inferred", () => {
+    seedAssignment(db, "a1", "ag", "t");
+    seedAssignment(db, "a2", "ag", "t");
+    seedAssignment(db, "a3", "ag", "t");
+    // principal_id present → used directly
+    seedSession(db, { id: "s-pid", assignmentId: "a1", principalId: "andreas", homePrincipal: "jc" });
+    // principal_id NULL, home_principal present → falls back to home_principal
+    seedSession(db, { id: "s-home", assignmentId: "a2", principalId: null, homePrincipal: "jc" });
+    // neither → null (honest, never fabricated from repo/attribution)
+    seedSession(db, {
+      id: "s-none",
+      assignmentId: "a3",
+      principalId: null,
+      homePrincipal: null,
+      attributionTarget: "the-metafactory/cortex",
+    });
+
+    const m = byId(listSessionCostAttribution(db));
+    expect(m.get("s-pid")!.forPrincipal).toBe("andreas");
+    expect(m.get("s-home")!.forPrincipal).toBe("jc");
+    expect(m.get("s-none")!.forPrincipal).toBeNull();
+    // attribution present but principal absent — the two are independent.
+    expect(m.get("s-none")!.attributionTarget).toBe("the-metafactory/cortex");
+  });
+
+  it("rolls a sub-agent's spend UP to its initiating parent", () => {
+    seedAssignment(db, "a-root", "ag", "t");
+    seedAssignment(db, "a-child", "ag", "t");
+    seedSession(db, {
+      id: "s-root",
+      assignmentId: "a-root",
+      inputTokens: 100,
+      outputTokens: 10,
+      cacheReadTokens: 5,
+      costUsd: 1.0,
+    });
+    seedSession(db, {
+      id: "s-child",
+      assignmentId: "a-child",
+      parentSessionId: "s-root",
+      inputTokens: 40,
+      outputTokens: 8,
+      cacheReadTokens: 2,
+      costUsd: 0.5,
+    });
+
+    const m = byId(listSessionCostAttribution(db));
+    const root = m.get("s-root")!;
+    const child = m.get("s-child")!;
+
+    expect(child.isSubAgent).toBe(true);
+    expect(child.parentSessionId).toBe("s-root");
+    // The child's OWN is unchanged; the PARENT's rolledUp includes the child.
+    expect(child.own).toEqual({ tokensIn: 40, tokensOut: 8, cacheRead: 2, cost: 0.5 });
+    expect(root.own).toEqual({ tokensIn: 100, tokensOut: 10, cacheRead: 5, cost: 1.0 });
+    expect(root.rolledUp).toEqual({ tokensIn: 140, tokensOut: 18, cacheRead: 7, cost: 1.5 });
+  });
+
+  it("rolls up across multiple levels and sibling sub-agents", () => {
+    // root → mid → leaf, plus a second child directly under root.
+    seedAssignment(db, "a-root", "ag", "t");
+    seedAssignment(db, "a-mid", "ag", "t");
+    seedAssignment(db, "a-leaf", "ag", "t");
+    seedAssignment(db, "a-sib", "ag", "t");
+    seedSession(db, { id: "s-root", assignmentId: "a-root", inputTokens: 1, costUsd: 0.1 });
+    seedSession(db, { id: "s-mid", assignmentId: "a-mid", parentSessionId: "s-root", inputTokens: 2, costUsd: 0.2 });
+    seedSession(db, { id: "s-leaf", assignmentId: "a-leaf", parentSessionId: "s-mid", inputTokens: 4, costUsd: 0.4 });
+    seedSession(db, { id: "s-sib", assignmentId: "a-sib", parentSessionId: "s-root", inputTokens: 8, costUsd: 0.8 });
+
+    const m = byId(listSessionCostAttribution(db));
+    // leaf: only its own
+    expect(m.get("s-leaf")!.rolledUp.tokensIn).toBe(4);
+    // mid: own(2) + leaf(4)
+    expect(m.get("s-mid")!.rolledUp.tokensIn).toBe(6);
+    // root: own(1) + mid(2) + leaf(4) + sib(8) = 15
+    expect(m.get("s-root")!.rolledUp.tokensIn).toBe(15);
+    expect(m.get("s-root")!.rolledUp.cost).toBeCloseTo(1.5, 6);
+  });
+
+  it("FK guarantees every parent ref resolves in-set (a dangling parent can't be built)", () => {
+    // sessions.parent_session_id REFERENCES sessions(id) — SQLite rejects both an
+    // INSERT and an UPDATE that would point at a missing parent. So for this
+    // full-table read every non-null parent_session_id is in-set; the source's
+    // out-of-set-parent branch is defense-in-depth (mirrors the session-tree
+    // assembler's contract), NOT a DB-reachable state. Assert the FK holds so the
+    // rollup can rely on it.
+    seedAssignment(db, "a1", "ag", "t");
+    seedSession(db, { id: "s1", assignmentId: "a1", inputTokens: 7, costUsd: 0.7 });
+    expect(() =>
+      db.query(`UPDATE sessions SET parent_session_id = ? WHERE id = ?`).run("s-missing", "s1")
+    ).toThrow(/FOREIGN KEY/);
+
+    // The lone in-set session projects cleanly, rolledUp == own.
+    const rows = listSessionCostAttribution(db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.rolledUp).toEqual(rows[0]!.own);
+  });
+
+  it("is cycle-safe: a self/loop parent edge never hangs the rollup", () => {
+    seedAssignment(db, "a-a", "ag", "t");
+    seedAssignment(db, "a-b", "ag", "t");
+    // a → b and b → a (a 2-cycle). Insert with a deferred edge would violate the
+    // self-ref FK on insert order, so build the loop with a raw UPDATE after insert.
+    seedSession(db, { id: "s-a", assignmentId: "a-a", inputTokens: 1, costUsd: 0.1 });
+    seedSession(db, { id: "s-b", assignmentId: "a-b", parentSessionId: "s-a", inputTokens: 2, costUsd: 0.2 });
+    db.query(`UPDATE sessions SET parent_session_id = ? WHERE id = ?`).run("s-b", "s-a");
+
+    // Must terminate (the visited-set + depth cap break the loop) and return both.
+    const rows = listSessionCostAttribution(db);
+    expect(rows).toHaveLength(2);
+    const m = byId(rows);
+    // Both rows exist with their own usage intact; the cycle is severed for rollup.
+    expect(m.get("s-a")!.own.tokensIn).toBe(1);
+    expect(m.get("s-b")!.own.tokensIn).toBe(2);
+  });
+
+  it("guard — the read model is a plain per-session projection, no interiors leak beyond its own shape", () => {
+    seedAssignment(db, "a1", "ag", "t");
+    seedSession(db, {
+      id: "s1",
+      assignmentId: "a1",
+      principalId: "andreas",
+      attributionTarget: "the-metafactory/cortex",
+      inputTokens: 5,
+      costUsd: 0.05,
+    });
+
+    const rows = listSessionCostAttribution(db);
+    const allowedKeys = new Set([
+      "sessionId",
+      "agentId",
+      "agentName",
+      "forPrincipal",
+      "attributionTarget",
+      "substrate",
+      "isSubAgent",
+      "parentSessionId",
+      "own",
+      "rolledUp",
+    ]);
+    const usageKeys = new Set(["tokensIn", "tokensOut", "cacheRead", "cost"]);
+    for (const r of rows) {
+      expect(Object.keys(r).filter((k) => !allowedKeys.has(k))).toEqual([]);
+      expect(Object.keys(r.own).filter((k) => !usageKeys.has(k))).toEqual([]);
+      expect(Object.keys(r.rolledUp).filter((k) => !usageKeys.has(k))).toEqual([]);
+    }
+  });
+});

--- a/src/surface/mc/db/cost-attribution.ts
+++ b/src/surface/mc/db/cost-attribution.ts
@@ -1,0 +1,226 @@
+/**
+ * SES-1 / #1709 / decision D-16 — per-session token/cost + attribution read model
+ * (LOCAL read model).
+ *
+ * The data half of Layout G's SESSIONS ledger ("every session runs on behalf of
+ * an accountable human; spend rolls up"). This projects the token/cost usage the
+ * `sessions` row already carries (`input_tokens` / `output_tokens` /
+ * `cache_read_tokens` / `cost_usd`, populated on write) into a per-session cost +
+ * attribution shape, with SUB-AGENT spend rolled UP to its initiating parent along
+ * the `parent_session_id` edge. A plain projection — no new collection, no new
+ * write path — the sibling of the CK-4a WORKING rollup (`db/working-aggregation.ts`).
+ *
+ * ── OWN-LOCAL ONLY (ADR-0005 — stated once, enforced by absence) ─────────────
+ * Token counts, cost, and `attribution_target` are session INTERIORS in the
+ * ADR-0005 sense: they describe what a session did and what it cost, not just
+ * that it exists. This read model is therefore LOCAL-scope ONLY. It is NOT wired
+ * into the public, unauthenticated `DashboardSnapshot` (`worker/src/routes/state.ts`)
+ * / `/api/state` projection: the cross-stack boundary there carries CK-4a
+ * METADATA only (per-origin active/sub-agent COUNTS — `WorkingOriginRollup`),
+ * never a per-session cost or attribution interior. A FOREIGN (cross-stack) peer's
+ * rows must never surface their token/cost/attribution here in a form that leaves
+ * local scope. SES-2 (the ledger UI) consumes THIS model locally; if a future
+ * slice ever surfaces any of these fields in the public DTO, that is a deliberate
+ * decision made WHEN the DTO key is added + justified in
+ * `worker/src/__tests__/dashboard-snapshot-contract.test.ts` — never a silent
+ * pass-through (that test's `attribution_target` note records exactly this).
+ *
+ * ── Honest attribution (D-16) ───────────────────────────────────────────────
+ *   - `forPrincipal` comes from the EXISTING session identity (`principal_id`,
+ *     falling back to `home_principal`), NEVER inferred from repo/branch/heuristic.
+ *     A session with neither is `null` — an honest "no principal on the row", never
+ *     fabricated.
+ *   - `attributionTarget` unset (NULL) renders as {@link UNATTRIBUTED} — an honest
+ *     bucket, NEVER silently defaulted to a principal or project (D-16 honesty;
+ *     plan-mc-future-state §6 invariant 20).
+ */
+
+import type { Database } from "bun:sqlite";
+
+/**
+ * The honest bucket a session with no `attribution_target` rolls up to. NEVER a
+ * principal or project — an explicit "not yet attributed" (D-16). Exported so the
+ * SES-2 ledger renderer and this model's tests share the one literal.
+ */
+export const UNATTRIBUTED = "unattributed" as const;
+
+/**
+ * Defense-in-depth cap on the rollup walk depth — a corrupt `parent_session_id`
+ * edge (a cycle a visited-set somehow missed, or a pathologically deep tree) can
+ * never make the rollup loop unboundedly or blow the stack. Mirrors the session
+ * tree assembler's cap (`lib/session-tree.ts` MAX_TREE_DEPTH); real spawn trees
+ * are single-digit deep.
+ */
+const MAX_ROLLUP_DEPTH = 64;
+
+/**
+ * One session's cost/attribution row. Own-local interior (see the header) — never
+ * projected across the cross-stack boundary. `tokensIn` / `tokensOut` /
+ * `cacheRead` / `cost` are the session's OWN usage; {@link SessionCostRow.rolledUp}
+ * carries the parent-inclusive totals (own + all descendant sub-agents).
+ */
+export interface SessionCostRow {
+  sessionId: string;
+  /** Owning agent id, when known (a session is not an agent). NULL until synced. */
+  agentId: string | null;
+  /** Owning agent display name, when known. */
+  agentName: string | null;
+  /**
+   * The accountable principal, from the EXISTING session identity
+   * (`principal_id`, then `home_principal`). NEVER inferred. `null` ⇒ no principal
+   * on the row (honest, never fabricated).
+   */
+  forPrincipal: string | null;
+  /**
+   * The controlled-vocab attribution target (repo/domain, D-16), or
+   * {@link UNATTRIBUTED} when the column is NULL. NEVER defaulted to a principal.
+   */
+  attributionTarget: string;
+  /** The substrate/model this session ran on (claude-code | codex | …). */
+  substrate: string;
+  /** `true` ⇒ this session is a SUB-AGENT (carries a `parent_session_id`). */
+  isSubAgent: boolean;
+  /** The initiating session, or `null` for an agent-rooted session. */
+  parentSessionId: string | null;
+  /** This session's OWN usage (excludes descendants). Zeroes when the row is unpopulated. */
+  own: SessionUsage;
+  /**
+   * Parent-inclusive totals: this session's own usage PLUS every descendant
+   * sub-agent's, rolled up the `parent_session_id` edge. For a leaf (no children)
+   * this equals {@link SessionCostRow.own}.
+   */
+  rolledUp: SessionUsage;
+}
+
+/** A token/cost tuple. All fields are non-negative; a NULL column reads as 0. */
+export interface SessionUsage {
+  tokensIn: number;
+  tokensOut: number;
+  cacheRead: number;
+  cost: number;
+}
+
+/** The `sessions` columns this read model projects. */
+interface CostRow {
+  id: string;
+  agent_id: string | null;
+  agent_name: string | null;
+  principal_id: string | null;
+  home_principal: string | null;
+  attribution_target: string | null;
+  substrate: string;
+  parent_session_id: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_tokens: number | null;
+  cost_usd: number | null;
+}
+
+/** A NULL usage column reads as an honest 0, never a fabricated estimate. */
+function usageOf(row: CostRow): SessionUsage {
+  return {
+    tokensIn: row.input_tokens ?? 0,
+    tokensOut: row.output_tokens ?? 0,
+    cacheRead: row.cache_read_tokens ?? 0,
+    cost: row.cost_usd ?? 0,
+  };
+}
+
+/** Add `b` into `a` in place (accumulator fold for the rollup). */
+function addInto(a: SessionUsage, b: SessionUsage): void {
+  a.tokensIn += b.tokensIn;
+  a.tokensOut += b.tokensOut;
+  a.cacheRead += b.cacheRead;
+  a.cost += b.cost;
+}
+
+/**
+ * Project the `sessions` usage columns into per-session cost/attribution rows,
+ * rolling SUB-AGENT spend up to the initiating parent.
+ *
+ * Rollup rule (D-16 "spend rolls up"): a session's {@link SessionCostRow.rolledUp}
+ * total is its own usage plus the rolled-up total of every session whose
+ * `parent_session_id` names it — recursively. A child whose parent is NOT in the
+ * result set (terminal/pruned/foreign) still contributes its OWN row (never
+ * dropped); its usage simply has no in-set parent to roll into.
+ *
+ * `forPrincipal` is read from the row's identity (`principal_id ?? home_principal`),
+ * NEVER inferred. `attribution_target` NULL ⇒ {@link UNATTRIBUTED}.
+ *
+ * Cycle/orphan safety mirrors the session-tree assembler: a self-edge or a
+ * multi-node loop can never make the walk hang (visited-set + {@link MAX_ROLLUP_DEPTH}),
+ * and a child of an out-of-set parent is emitted as its own row.
+ *
+ * Deterministic order: initiating parents (roots) first in `started_at` order,
+ * then descendants — the same fold order the ledger renders. Rows are returned in
+ * the DB's `started_at ASC, id ASC` order (stable) for a caller that just wants a
+ * flat list; the rollup itself is order-independent.
+ */
+export function listSessionCostAttribution(db: Database): SessionCostRow[] {
+  const rows = db
+    .query(
+      `SELECT id, agent_id, agent_name, principal_id, home_principal,
+              attribution_target, substrate, parent_session_id,
+              input_tokens, output_tokens, cache_read_tokens, cost_usd
+       FROM sessions
+       ORDER BY started_at ASC, id ASC`
+    )
+    .all() as CostRow[];
+
+  if (rows.length === 0) return [];
+
+  // 1. Build one output row per session, keyed by id, with its OWN usage. Seed
+  //    rolledUp as a COPY of own (the leaf case); step 2 folds descendants in.
+  const byId = new Map<string, SessionCostRow>();
+  const order: string[] = [];
+
+  for (const row of rows) {
+    if (byId.has(row.id)) continue; // PK — first wins; a dup id never double-counts.
+    const own = usageOf(row);
+    const forPrincipal = row.principal_id ?? row.home_principal ?? null;
+    byId.set(row.id, {
+      sessionId: row.id,
+      agentId: row.agent_id,
+      agentName: row.agent_name,
+      forPrincipal,
+      attributionTarget: row.attribution_target ?? UNATTRIBUTED,
+      substrate: row.substrate,
+      isSubAgent: row.parent_session_id !== null,
+      parentSessionId: row.parent_session_id,
+      own,
+      rolledUp: { ...own },
+    });
+    order.push(row.id);
+  }
+
+  // 2. Roll each session's total UP to its ancestors. Walk from every node up its
+  //    parent chain, adding the node's OWN usage into each in-set ancestor's
+  //    rolledUp. A visited-set per walk + the depth cap break any cycle; an
+  //    out-of-set parent simply ends the walk (the orphan is its own root).
+  for (const id of order) {
+    // `order` is built from `byId.set` above, so every id resolves.
+    const node = byId.get(id);
+    if (node === undefined) continue; // unreachable (order mirrors byId); defensive.
+    const ownUsage = node.own;
+    let parentId = node.parentSessionId;
+    const seen = new Set<string>([id]);
+    let depth = 0;
+    while (parentId !== null && depth < MAX_ROLLUP_DEPTH) {
+      if (seen.has(parentId)) break; // cycle — stop before re-adding.
+      seen.add(parentId);
+      const ancestor = byId.get(parentId);
+      if (ancestor === undefined) break; // out-of-set parent — orphan chain ends.
+      addInto(ancestor.rolledUp, ownUsage);
+      parentId = ancestor.parentSessionId;
+      depth += 1;
+    }
+  }
+
+  return order.map((id) => {
+    const node = byId.get(id);
+    // `order` is derived from `byId`, so this always resolves; the guard keeps the
+    // map access total for the type checker without a non-null assertion.
+    if (node === undefined) throw new Error(`cost-attribution: missing row ${id}`);
+    return node;
+  });
+}


### PR DESCRIPTION
Closes #1709. The read-model half of SES-1 (schema half landed in #1714) — completes the Layout G SESSIONS attribution data model.

## What
- `src/surface/mc/db/cost-attribution.ts` — `listSessionCostAttribution(db)`: projects the existing `sessions` usage columns (`input_tokens`/`output_tokens`/`cache_read_tokens`/`cost_usd`) into per-session `SessionCostRow`, with **sub-agent spend rolled UP** to the initiating parent along `parent_session_id`. Plain projection, no new write path — the sibling of the CK-4a `working-aggregation.ts`.
- `src/surface/mc/__tests__/cost-attribution.test.ts` — 10 cases.

## Honesty invariants (D-16)
- `forPrincipal` = `principal_id ?? home_principal ?? null` — from the row's own identity, **never inferred**; `null` is an honest "no principal", not fabricated.
- `attribution_target` NULL ⇒ `UNATTRIBUTED` — an honest bucket, **never** defaulted to a principal/project.
- NULL usage column ⇒ `0`, never an estimate. `own` vs `rolledUp` kept distinct (a leaf's rolledUp == own).
- Cycle/orphan safe: visited-set + `MAX_ROLLUP_DEPTH` (mirrors the session-tree assembler); a child of an out-of-set parent is emitted as its own row, never dropped.

## Privacy — own-local per ADR-0005 (security-first default)
Token counts, cost, and `attribution_target` are session **interiors** (they describe what a session did + cost). This model is **LOCAL-scope only** — NOT wired into the public `DashboardSnapshot`/`/api/state` (that boundary carries CK-4a metadata-only, `WorkingOriginRollup` counts). **No DTO key added, no allow-list edit** — `state.ts` + `dashboard-snapshot-contract.test.ts` are deliberately untouched (verified: 6/6 contract test still green, confirming the public projection is unchanged). SES-2 (ledger UI) consumes this locally.

## Tests
`bun test cost-attribution.test.ts session-schema-parity.test.ts` → 17/17; worker `dashboard-snapshot-contract.test.ts` → 6/6 (public DTO unchanged). tsc 0, eslint clean, additive-only (`--diff-filter=D` empty).

## Follow-up (not this slice)
`Session`/`rowToSession` in `db/sessions.ts` don't yet carry `attribution_target` — needed by the write path (who sets attribution values), not by this read. Candidate cleanup when the write path lands.

## References
docs/plan-mc-future-state.md §4.E SES-1 · D-16 (#1679) · ADR-0005 · CK-4a `working-aggregation.ts` sibling · schema half #1714 · epic #1671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)