### PR TITLE
feat(cortex): optional agent state field + AgentState scaffold on activation (#1720 S1)

### DIFF
--- a/src/__tests__/cortex.agents-reload.test.ts
+++ b/src/__tests__/cortex.agents-reload.test.ts
@@ -687,3 +687,145 @@ describe("startCortex — surface principal gate boot (B-3, cortex#1021 W-2)", (
     expect(line).toContain("gate=surface");
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#1720 S1 — AgentState scaffold-on-activation (opt-in + regression)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a fragment optionally declaring a `state:` block. Reuses the reload
+ * harness's tmp agents.d/ + personas dirs.
+ */
+function writeStateFragment(
+  id: string,
+  opts: { state?: { blueprint: string; version: string } } = {},
+): void {
+  const personaPath = join(tmpPersonasDir, `${id}.md`);
+  writeFileSync(personaPath, `# ${id} persona\n`);
+  let yaml = `id: ${id}
+displayName: ${id.charAt(0).toUpperCase() + id.slice(1)}
+persona: "${personaPath}"
+presence: {}
+runtime:
+  substrate: claude-code
+  mode: in-process
+  capabilities:
+    - "code-review.typescript"
+`;
+  if (opts.state) {
+    yaml += `state:
+  blueprint: ${opts.state.blueprint}
+  version: "${opts.state.version}"
+`;
+  }
+  writeFileSync(join(tmpAgentsDir, `${id}.yaml`), yaml);
+}
+
+describe("startCortex — AgentState scaffold-on-activation (cortex#1720 S1)", () => {
+  // Records every scaffold invocation the boot/reload path makes, WITHOUT
+  // touching ~/.config or spawning bun. Each element is the agent id passed.
+  function recordingScaffold(): {
+    calls: string[];
+    fn: NonNullable<Parameters<typeof startCortex>[1]>["scaffoldAgentState"];
+  } {
+    const calls: string[] = [];
+    return {
+      calls,
+      fn: (agent) => {
+        calls.push(agent.id);
+        return {
+          strategy: "fallback-manual",
+          instanceDir: `/tmp/fake/agents/${agent.id}`,
+          created: [],
+          skipped: [],
+        };
+      },
+    };
+  }
+
+  async function bootWithScaffold(
+    runtime: RecordingRuntime,
+    scaffold: NonNullable<Parameters<typeof startCortex>[1]>["scaffoldAgentState"],
+  ): Promise<CortexHandle> {
+    const handle = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      disableAgentsWatcher: true,
+      agentsDir: tmpAgentsDir,
+      configPath: join(tmpAgentsDir, "cortex.yaml"),
+      injectRuntime: runtime,
+      principal: { id: "test-op" },
+      scaffoldAgentState: scaffold,
+    });
+    handles.push(handle);
+    return handle;
+  }
+
+  test("a fragment declaring state IS scaffolded at boot with its id", async () => {
+    const runtime = createRecordingRuntime();
+    const scaffold = recordingScaffold();
+    writeStateFragment("luna", { state: { blueprint: "AgentState", version: ">=0.1.0" } });
+
+    await bootWithScaffold(runtime, scaffold.fn);
+
+    expect(scaffold.calls).toEqual(["luna"]);
+  });
+
+  test("REGRESSION — a stateless fragment activates with NO scaffold attempt", async () => {
+    const runtime = createRecordingRuntime();
+    const scaffold = recordingScaffold();
+    // No `state:` block → must take zero new code paths.
+    writeStateFragment("echo");
+
+    const handle = await bootWithScaffold(runtime, scaffold.fn);
+
+    // Agent activated normally (registry + consumer), but scaffold never fired.
+    expect(handle.agentRegistry.getAll().map((a) => a.id)).toEqual(["echo"]);
+    expect(runtime.subscribePullCalls.length).toBe(1); // echo's review consumer
+    expect(scaffold.calls).toEqual([]);
+  });
+
+  test("mixed roster — only the stateful fragment is scaffolded", async () => {
+    const runtime = createRecordingRuntime();
+    const scaffold = recordingScaffold();
+    writeStateFragment("echo"); // stateless
+    writeStateFragment("luna", { state: { blueprint: "AgentState", version: ">=0.2.0" } });
+
+    await bootWithScaffold(runtime, scaffold.fn);
+
+    expect(scaffold.calls).toEqual(["luna"]);
+  });
+
+  test("hot-ADDED stateful fragment is scaffolded on reload; stateless add is not", async () => {
+    const runtime = createRecordingRuntime();
+    const scaffold = recordingScaffold();
+    writeStateFragment("echo"); // stateless at boot
+    const handle = await bootWithScaffold(runtime, scaffold.fn);
+    expect(scaffold.calls).toEqual([]); // nothing stateful yet
+
+    // Add a stateful agent + another stateless one, reload.
+    writeStateFragment("luna", { state: { blueprint: "AgentState", version: ">=0.1.0" } });
+    writeStateFragment("holly"); // stateless add
+    await handle.reloadAgents("cli");
+
+    // Only luna (the stateful add) was scaffolded on reload.
+    expect(scaffold.calls).toEqual(["luna"]);
+  });
+
+  test("NON-FATAL — a throwing scaffolder does not crash boot; the agent still activates", async () => {
+    const runtime = createRecordingRuntime();
+    const throwingScaffold: NonNullable<
+      Parameters<typeof startCortex>[1]
+    >["scaffoldAgentState"] = () => {
+      throw new Error("bundle exploded");
+    };
+    writeStateFragment("luna", { state: { blueprint: "AgentState", version: ">=0.1.0" } });
+
+    // Must NOT reject — the scaffold fault is swallowed.
+    const handle = await bootWithScaffold(runtime, throwingScaffold);
+
+    // The agent activated despite the scaffold failure.
+    expect(handle.agentRegistry.getAll().map((a) => a.id)).toEqual(["luna"]);
+  });
+});

--- a/src/common/agents/__tests__/agent-state-scaffold.test.ts
+++ b/src/common/agents/__tests__/agent-state-scaffold.test.ts
@@ -1,0 +1,182 @@
+/**
+ * cortex#1720 S1 — unit tests for the AgentState scaffolder.
+ *
+ * Covers the two strategies + idempotency:
+ *   - bundle-preferred: when the bundle script exists, the scaffolder spawns it
+ *     with the correct CLI args + env (MF_AGENT_NAME / MF_HOST / MF_INSTANCE_DIR)
+ *     and reports strategy "agent-state-bundle" on exit 0.
+ *   - fallback-manual: when the bundle script is ABSENT, the scaffolder lays down
+ *     the principal-facing skeleton itself (CLAUDE.md, dashboard.md, context/,
+ *     retros/) WITHOUT a state.sqlite, and reports "fallback-manual".
+ *   - fallback-on-nonzero: a present bundle that exits non-zero degrades to the
+ *     manual fallback (principal not blocked).
+ *   - idempotent: a second run over a scaffolded dir creates nothing.
+ *
+ * No real `bun` subprocess, no `~/.config` touch — every path is driven through
+ * the `instanceDir` / `agentStateScript` / `spawn` test seams into a tmp dir.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  isFullyScaffolded,
+  resolveInstanceDir,
+  scaffoldInstance,
+  type ScaffoldSpawn,
+} from "../agent-state-scaffold";
+
+const AGENT = { id: "luna", displayName: "Luna" };
+
+let root: string;
+let instanceDir: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cortex-scaffold-"));
+  instanceDir = join(root, "agents", "luna");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("scaffoldInstance — bundle-preferred path", () => {
+  test("spawns the bundle script with correct args + env when it exists", () => {
+    // A real (empty) file standing in for the installed bundle scaffold.ts.
+    const bundleScript = join(root, "scaffold.ts");
+    writeFileSync(bundleScript, "// stub bundle scaffold\n");
+
+    const calls: {
+      cmd: string;
+      args: string[];
+      env?: NodeJS.ProcessEnv;
+    }[] = [];
+    const spawn: ScaffoldSpawn = (cmd, args, opts) => {
+      calls.push({ cmd, args, env: opts.env });
+      return { status: 0 };
+    };
+
+    const result = scaffoldInstance(AGENT, {
+      instanceDir,
+      agentStateScript: bundleScript,
+      spawn,
+      host: "cortex",
+    });
+
+    expect(result.strategy).toBe("agent-state-bundle");
+    expect(result.instanceDir).toBe(instanceDir);
+
+    // Exactly one spawn, invoking `bun <script> <instanceDir> --host=cortex --agent=luna`.
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.cmd).toBe("bun");
+    expect(call.args[0]).toBe(bundleScript);
+    expect(call.args).toContain(instanceDir);
+    expect(call.args).toContain("--host=cortex");
+    expect(call.args).toContain("--agent=luna");
+
+    // Env carries the standard subprocess contract.
+    expect(call.env?.MF_AGENT_NAME).toBe("luna");
+    expect(call.env?.MF_HOST).toBe("cortex");
+    expect(call.env?.MF_INSTANCE_DIR).toBe(instanceDir);
+  });
+
+  test("does NOT write manual skeleton when the bundle succeeds", () => {
+    const bundleScript = join(root, "scaffold.ts");
+    writeFileSync(bundleScript, "// stub\n");
+    const spawn: ScaffoldSpawn = () => ({ status: 0 });
+
+    scaffoldInstance(AGENT, { instanceDir, agentStateScript: bundleScript, spawn });
+
+    // The bundle owns the skeleton; the host must not double-write it.
+    expect(existsSync(join(instanceDir, "CLAUDE.md"))).toBe(false);
+    expect(existsSync(join(instanceDir, "dashboard.md"))).toBe(false);
+    // But the instance dir itself is created up front so the bundle can land.
+    expect(existsSync(instanceDir)).toBe(true);
+  });
+
+  test("falls back to manual scaffold when the bundle exits non-zero", () => {
+    const bundleScript = join(root, "scaffold.ts");
+    writeFileSync(bundleScript, "// stub\n");
+    const spawn: ScaffoldSpawn = () => ({ status: 3, stderr: "boom" });
+
+    const result = scaffoldInstance(AGENT, {
+      instanceDir,
+      agentStateScript: bundleScript,
+      spawn,
+    });
+
+    expect(result.strategy).toBe("fallback-manual");
+    // Manual skeleton is now present.
+    expect(isFullyScaffolded(instanceDir)).toBe(true);
+  });
+});
+
+describe("scaffoldInstance — fallback-manual path (bundle absent)", () => {
+  test("lays down the principal skeleton without a state.sqlite", () => {
+    // agentStateScript points at a path that does NOT exist → manual fallback.
+    const missingScript = join(root, "does-not-exist", "scaffold.ts");
+
+    const result = scaffoldInstance(AGENT, {
+      instanceDir,
+      agentStateScript: missingScript,
+    });
+
+    expect(result.strategy).toBe("fallback-manual");
+    expect(isFullyScaffolded(instanceDir)).toBe(true);
+
+    // CLAUDE.md + dashboard.md exist and name the agent.
+    expect(readFileSync(join(instanceDir, "CLAUDE.md"), "utf8")).toContain("Luna");
+    expect(existsSync(join(instanceDir, "dashboard.md"))).toBe(true);
+    expect(existsSync(join(instanceDir, "context", "repos.md"))).toBe(true);
+    expect(existsSync(join(instanceDir, "retros"))).toBe(true);
+
+    // The host must NOT create state.sqlite — the bundle owns that schema.
+    expect(existsSync(join(instanceDir, "state.sqlite"))).toBe(false);
+  });
+
+  test("forceFallback bypasses an existing bundle script", () => {
+    const bundleScript = join(root, "scaffold.ts");
+    writeFileSync(bundleScript, "// stub\n");
+    let spawned = false;
+    const spawn: ScaffoldSpawn = () => {
+      spawned = true;
+      return { status: 0 };
+    };
+
+    const result = scaffoldInstance(AGENT, {
+      instanceDir,
+      agentStateScript: bundleScript,
+      forceFallback: true,
+      spawn,
+    });
+
+    expect(spawned).toBe(false);
+    expect(result.strategy).toBe("fallback-manual");
+  });
+});
+
+describe("scaffoldInstance — idempotency", () => {
+  test("a second manual run creates nothing new", () => {
+    const missingScript = join(root, "nope", "scaffold.ts");
+    const first = scaffoldInstance(AGENT, { instanceDir, agentStateScript: missingScript });
+    expect(first.created.length).toBeGreaterThan(0);
+
+    const second = scaffoldInstance(AGENT, { instanceDir, agentStateScript: missingScript });
+    expect(second.created).toHaveLength(0);
+    // Everything the second run saw was already there.
+    expect(second.skipped.length).toBeGreaterThan(0);
+  });
+});
+
+describe("resolveInstanceDir", () => {
+  test("honors the ~/.config/<host>/agents/<id>/ convention", () => {
+    const home = process.env.HOME ?? "";
+    expect(resolveInstanceDir("luna")).toBe(join(home, ".config", "cortex", "agents", "luna"));
+    expect(resolveInstanceDir("echo", "grove")).toBe(
+      join(home, ".config", "grove", "agents", "echo"),
+    );
+  });
+});

--- a/src/common/agents/agent-state-scaffold.ts
+++ b/src/common/agents/agent-state-scaffold.ts
@@ -1,0 +1,281 @@
+/**
+ * cortex#1720 S1 — per-instance state scaffolding for stateful agent fragments.
+ *
+ * Ported from grove's proven host-side implementation
+ * (`grove/src/bot/lib/agent-state-scaffold.ts`) and the forge contract
+ * (`forge/agent/scaffold-instance.sh`). Per the agent-platform design
+ * (`forge/design/agent-platform.md` §"Instantiation flow"), the HOST lays down
+ * `~/.config/<host>/agents/<id>/` by SUBPROCESSING to the AgentState bundle's
+ * `ScaffoldFolders` workflow — cortex imports NOTHING from the bundle
+ * (platform no-coupling rule); the only contract is the subprocess CLI + env.
+ *
+ * When the bundle's `scaffold.ts` is on disk, that delegate path is preferred.
+ * When it isn't (fresh dev box, bundle not yet installed), we fall back to a
+ * manual scaffold that lays down the same principal-facing skeleton — WITHOUT
+ * touching `state.sqlite` (the bundle owns that schema; creating it here would
+ * bake in a shape we'd later have to migrate).
+ *
+ * OPT-IN: this is invoked ONLY for a fragment that declares `state:` (see
+ * `AgentSchema.state`). A stateless fragment never reaches this module — the
+ * `if (agent.state)` guard at the call site keeps stateless activation on
+ * exactly the code path it had before #1720.
+ *
+ * Idempotent: re-running on an existing dir leaves principal-authored files
+ * untouched and only fills what's missing.
+ *
+ * Non-fatal: the call site treats a thrown error / non-zero bundle exit as a
+ * logged warning — activation continues, the daemon does not crash.
+ */
+
+import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Canonical AgentState bundle scaffold script.
+ *
+ * NOTE: this is `skill/scripts/scaffold.ts`, NOT `scripts/errands.ts`. Grove's
+ * own default (`grove/src/bot/lib/agent-state-scaffold.ts`) points at the wrong
+ * path — it omits the `skill/` segment and names `errands.ts` (a filed grove
+ * bug). The bundle installed by arc lays the workflow scripts down under
+ * `.../agent-state/skill/scripts/`, and the scaffold entrypoint is
+ * `scaffold.ts` (`bun scaffold.ts <instance-dir> --host=<h> --agent=<a>`).
+ * `MF_AGENT_STATE_SCRIPT` overrides for non-standard installs.
+ */
+const DEFAULT_AGENT_STATE_SCRIPT =
+  process.env.MF_AGENT_STATE_SCRIPT ??
+  `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/scaffold.ts`;
+
+/** Default host label baked into cortex-scaffolded instance dirs. */
+const DEFAULT_HOST = "cortex";
+
+export type ScaffoldStrategy = "agent-state-bundle" | "fallback-manual";
+
+export interface ScaffoldResult {
+  strategy: ScaffoldStrategy;
+  instanceDir: string;
+  /** Files/dirs created on this run (for principal visibility). */
+  created: string[];
+  /** Files that already existed and were NOT touched. */
+  skipped: string[];
+}
+
+/** Minimal shape of the agent this scaffolder needs (id only). */
+export interface ScaffoldAgent {
+  id: string;
+  displayName?: string;
+}
+
+/** Result shape of the injectable spawn seam. */
+export interface ScaffoldSpawnResult {
+  status: number | null;
+  error?: Error;
+  stderr?: Buffer | string;
+}
+
+export type ScaffoldSpawn = (
+  cmd: string,
+  args: string[],
+  opts: { stdio: "inherit" | "pipe"; env?: NodeJS.ProcessEnv },
+) => ScaffoldSpawnResult;
+
+export interface ScaffoldOptions {
+  /** Override the resolved instance dir (test seam). Default: ~/.config/cortex/agents/<id>. */
+  instanceDir?: string;
+  /** Override the host label baked into the scaffold (test seam). Default: "cortex". */
+  host?: string;
+  /** Override path to the AgentState bundle scaffold script (test seam). */
+  agentStateScript?: string;
+  /** Force the manual fallback even if the bundle is present (test seam). */
+  forceFallback?: boolean;
+  /** Override the spawn used to invoke the bundle (test seam). */
+  spawn?: ScaffoldSpawn;
+}
+
+/**
+ * Resolve the per-instance state directory for an agent id, honoring the
+ * `~/.config/<host>/agents/<id>/` convention. Exposed so the call site can log
+ * the path without re-deriving it.
+ */
+export function resolveInstanceDir(agentId: string, host: string = DEFAULT_HOST): string {
+  const home = process.env.HOME ?? "";
+  return join(home, ".config", host, "agents", agentId);
+}
+
+/**
+ * Scaffold the per-instance state directory for a stateful agent.
+ *
+ * Strategy preference: the AgentState bundle if its `scaffold.ts` is on disk,
+ * otherwise the manual fallback. The manual fallback never creates
+ * `state.sqlite` — that is owned by the bundle's schema.
+ */
+export function scaffoldInstance(
+  agent: ScaffoldAgent,
+  opts: ScaffoldOptions = {},
+): ScaffoldResult {
+  const host = opts.host ?? DEFAULT_HOST;
+  const instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, host);
+  const agentStateScript = opts.agentStateScript ?? DEFAULT_AGENT_STATE_SCRIPT;
+
+  const created: string[] = [];
+  const skipped: string[] = [];
+
+  // Always make the dir up front so the bundle path can land into it.
+  if (!existsSync(instanceDir)) {
+    mkdirSync(instanceDir, { recursive: true });
+    created.push(instanceDir);
+  } else {
+    skipped.push(instanceDir);
+  }
+
+  // ── Preferred path: delegate to the bundle's scaffold.ts ────────────────
+  if (!opts.forceFallback && existsSync(agentStateScript)) {
+    const spawn = opts.spawn ?? defaultSpawn;
+    const result = spawn(
+      "bun",
+      [
+        agentStateScript,
+        instanceDir,
+        `--host=${host}`,
+        `--agent=${agent.id}`,
+      ],
+      {
+        stdio: "pipe",
+        env: {
+          ...process.env,
+          MF_AGENT_NAME: agent.id,
+          MF_HOST: host,
+          MF_INSTANCE_DIR: instanceDir,
+        },
+      },
+    );
+    if (result.status === 0) {
+      return { strategy: "agent-state-bundle", instanceDir, created, skipped };
+    }
+    // Bundle invocation failed — surface and fall back to manual so the
+    // principal isn't blocked while the bundle is being debugged. The call
+    // site's own non-fatal guard also covers a thrown spawn; this branch
+    // covers a clean spawn that exited non-zero.
+    process.stderr.write(
+      `agent-state-scaffold: bundle invocation failed for agent=${agent.id} ` +
+        `(status=${result.status}); falling back to manual scaffold. ` +
+        (result.stderr ? `stderr: ${String(result.stderr).slice(0, 200)}\n` : "\n"),
+    );
+  }
+
+  // ── Fallback: manual scaffold (mirrors forge/agent/scaffold-instance.sh) ──
+  const ctxDir = join(instanceDir, "context");
+  const retrosDir = join(instanceDir, "retros");
+
+  for (const dir of [ctxDir, retrosDir]) {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+      created.push(dir);
+    } else {
+      skipped.push(dir);
+    }
+  }
+
+  // CLAUDE.md — the per-instance bridge file.
+  const claudeMdPath = join(instanceDir, "CLAUDE.md");
+  if (!existsSync(claudeMdPath)) {
+    writeFileSync(claudeMdPath, defaultClaudeMd(agent, host), "utf8");
+    created.push(claudeMdPath);
+  } else {
+    skipped.push(claudeMdPath);
+  }
+
+  // dashboard.md — placeholder; the bundle regenerates it on the first event.
+  const dashboardPath = join(instanceDir, "dashboard.md");
+  if (!existsSync(dashboardPath)) {
+    writeFileSync(dashboardPath, defaultDashboardMd(agent), "utf8");
+    created.push(dashboardPath);
+  } else {
+    skipped.push(dashboardPath);
+  }
+
+  // context/repos.md (principal-owned seed).
+  const reposPath = join(ctxDir, "repos.md");
+  const label = agent.displayName ?? agent.id;
+  if (!existsSync(reposPath)) {
+    writeFileSync(
+      reposPath,
+      `# Repos this ${label} instance handles\n\n(Principal: list scoped repos here.)\n`,
+      "utf8",
+    );
+    created.push(reposPath);
+  } else {
+    skipped.push(reposPath);
+  }
+
+  // NOTE: state.sqlite is intentionally NOT created. The AgentState bundle owns
+  // the schema; touching it here would commit us to a layout we'd have to
+  // migrate.
+
+  return { strategy: "fallback-manual", instanceDir, created, skipped };
+}
+
+function defaultSpawn(
+  cmd: string,
+  args: string[],
+  opts: { stdio: "inherit" | "pipe"; env?: NodeJS.ProcessEnv },
+): ScaffoldSpawnResult {
+  const r = spawnSync(cmd, args, opts);
+  // With stdio:"pipe" (the path this scaffolder always uses), r.stderr is a
+  // Buffer; TS narrows it non-null here, so we pass it straight through.
+  return { status: r.status, error: r.error, stderr: r.stderr };
+}
+
+function defaultClaudeMd(agent: ScaffoldAgent, host: string): string {
+  const label = agent.displayName ?? agent.id;
+  return `# ${label} — instance bridge
+
+This file bridges the per-instance state directory
+(\`~/.config/${host}/agents/${agent.id}/\`) and the Claude Code session the host
+spawns when ${label} is invoked.
+
+## Identity
+
+You are **${label}** (agent id: \`${agent.id}\`).
+
+Read your persona file before answering — it defines your voice, defaults, and
+the routing table for which blueprint to invoke when.
+
+## Where state lives
+
+This directory (\`~/.config/${host}/agents/${agent.id}/\`):
+
+- \`state.sqlite\` — work_items + events (managed by the AgentState bundle).
+- \`dashboard.md\` — derived snapshot, regenerated on every state transition.
+- \`context/\` — principal-owned seed files (repos in scope, channels, etc.).
+- \`retros/YYYY-Wxx.md\` — weekly retros.
+
+## Hard rules
+
+- Authority lives in the host (cortex config), translated from the agent
+  fragment's declarations. Do not invent new authority mechanisms here — if a
+  guardrail blocks you, ask the principal to widen the fragment and reload.
+`;
+}
+
+function defaultDashboardMd(agent: ScaffoldAgent): string {
+  const label = agent.displayName ?? agent.id;
+  return `# ${label} — dashboard
+
+(Empty — regenerated by the AgentState bundle on the first state transition.
+Until the bundle ships and runs once, this file stays empty.)
+`;
+}
+
+/**
+ * Pure helper: would scaffolding this agent into the given instance dir be a
+ * no-op? Used by tests and by any future \`--dry-run\`.
+ */
+export function isFullyScaffolded(instanceDir: string): boolean {
+  if (!existsSync(instanceDir)) return false;
+  if (!statSync(instanceDir).isDirectory()) return false;
+  for (const required of ["CLAUDE.md", "dashboard.md", "context", "retros"]) {
+    if (!existsSync(join(instanceDir, required))) return false;
+  }
+  return true;
+}

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -350,6 +350,43 @@ describe("AgentSchema", () => {
     }));
     expect(parsed.presence.discord?.guildId).toBe("1487");
   });
+
+  // ---------------------------------------------------------------------
+  // cortex#1720 S1 — optional `state:` field (opt-in instance state)
+  // ---------------------------------------------------------------------
+
+  test("stateless by default — a fragment WITHOUT state parses, state is undefined", () => {
+    const parsed = AgentSchema.parse(minAgent());
+    expect(parsed.state).toBeUndefined();
+  });
+
+  test("accepts a fragment declaring state: { blueprint, version }", () => {
+    const parsed = AgentSchema.parse(
+      minAgent({ state: { blueprint: "AgentState", version: ">=0.1.0" } }),
+    );
+    expect(parsed.state).toEqual({ blueprint: "AgentState", version: ">=0.1.0" });
+  });
+
+  test("rejects a state block missing blueprint", () => {
+    expect(() =>
+      AgentSchema.parse(minAgent({ state: { version: ">=0.1.0" } })),
+    ).toThrow();
+  });
+
+  test("rejects a state block missing version", () => {
+    expect(() =>
+      AgentSchema.parse(minAgent({ state: { blueprint: "AgentState" } })),
+    ).toThrow();
+  });
+
+  test("rejects empty-string blueprint / version", () => {
+    expect(() =>
+      AgentSchema.parse(minAgent({ state: { blueprint: "", version: ">=0.1.0" } })),
+    ).toThrow();
+    expect(() =>
+      AgentSchema.parse(minAgent({ state: { blueprint: "AgentState", version: "" } })),
+    ).toThrow();
+  });
 });
 
 // =============================================================================

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -940,6 +940,44 @@ export const AgentSchema = z.object({
    * Default `false`/absent.
    */
   strictMcpConfig: z.boolean().optional(),
+  /**
+   * cortex#1720 S1 — OPT-IN per-instance durable state.
+   *
+   * Names the blueprint (state bundle) that owns this agent's instance state,
+   * per the agent-platform contract (`forge/design/agent-platform.md`
+   * §"the `state` field"): `state: { blueprint: AgentState, version: ">=0.1.0" }`.
+   *
+   * **Stateless is the default — "bring your own grounding".** A fragment
+   * WITHOUT `state` behaves exactly as before: no instance dir is scaffolded,
+   * no lifecycle hook fires, zero new code paths. Every downstream step (the
+   * scaffold-on-activation in `agent-state-scaffold.ts`, and S2–S4's replay /
+   * dispatch / dashboard wiring) is guarded behind `if (agent.state)`.
+   *
+   * When present, on activation (boot + agents.d hot-reload) cortex ensures the
+   * per-instance dir `~/.config/cortex/agents/{id}/` exists by SUBPROCESSING to
+   * the state bundle's `ScaffoldFolders` workflow (no code imports from the
+   * bundle — subprocess contract only). Scaffolding is idempotent and non-fatal:
+   * a failure logs and never blocks activation or crashes the daemon.
+   *
+   * Additive: existing fragments omit this key and are unaffected.
+   */
+  state: z
+    .object({
+      /**
+       * The state bundle that owns this instance's durable state. Free-form
+       * string (the bundle name, e.g. `AgentState`); cortex does not enumerate
+       * or validate bundle names — the platform's no-coupling rule keeps cortex
+       * ignorant of the bundle's identity beyond "there is one".
+       */
+      blueprint: z.string().min(1),
+      /**
+       * Semver range the agent requires of the state bundle (e.g. `">=0.1.0"`).
+       * Recorded for provenance; cortex does not resolve or enforce the range
+       * in S1 (that is the installer/registry's job).
+       */
+      version: z.string().min(1),
+    })
+    .optional(),
 });
 // cortex#245 — the previous `at least one presence block` refine was
 // dropped to admit headless agents (bus-only participants with no

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -45,6 +45,11 @@ import { resolveSigningKnobs } from "./common/security-posture";
 import { buildHttpsMtlsMaterial } from "./common/config/transport-mtls";
 import { AgentRegistry } from "./common/agents/registry";
 import { TrustResolver } from "./common/agents/trust-resolver";
+import {
+  scaffoldInstance,
+  type ScaffoldOptions,
+  type ScaffoldResult,
+} from "./common/agents/agent-state-scaffold";
 // cortex#79 — creds minting moved to `arc nats … --json` (shelled out from
 // `src/cli/cortex/commands/creds.ts`). No daemon-side RPC handler in
 // cortex; the account-signature verifier in TrustResolver keeps using
@@ -590,6 +595,21 @@ export interface StartCortexOptions {
    * @internal — not part of the public API; semver does not apply.
    */
   inlineAgents?: readonly Agent[];
+  /**
+   * cortex#1720 S1 — override the AgentState scaffolder invoked on activation
+   * of a fragment that declares `state:`. Production omits this and the real
+   * `scaffoldInstance` (subprocess to the bundle, ~/.config/cortex/agents/<id>/
+   * fallback) runs. Tests inject a recorder so the opt-in / idempotency /
+   * regression-stateless assertions run WITHOUT touching the principal's real
+   * `~/.config` or spawning `bun`.
+   *
+   * The default is a thin wrapper so a test can pass either just a `spawn` seam
+   * (to exercise the real `scaffoldInstance` with a stub script) or replace the
+   * whole scaffolder.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  scaffoldAgentState?: (agent: Agent, opts?: ScaffoldOptions) => ScaffoldResult;
   /**
    * IAW Phase A.5 (refs cortex#113) — optional `stack:` block from
    * `CortexConfig`, threaded through from the loader so the boot path can
@@ -1261,6 +1281,52 @@ export async function startCortex(
     );
   } else {
     console.log("cortex: agent registry assembled — 0 agents (no inline agents, no fragments)");
+  }
+
+  // ===========================================================================
+  // cortex#1720 S1 — AgentState scaffold-on-activation (OPT-IN).
+  // ===========================================================================
+  //
+  // For each agent that declares `state:`, ensure its per-instance dir
+  // (`~/.config/cortex/agents/<id>/`) exists by delegating to the AgentState
+  // bundle (subprocess; manual fallback when the bundle isn't installed).
+  //
+  // Three guarantees the S1 spec pins down:
+  //   (a) OPT-IN — `if (agent.state)` guards EVERY invocation. A stateless
+  //       fragment takes ZERO new code paths: `scaffoldStatefulAgent` returns
+  //       immediately and never touches the filesystem or spawns anything.
+  //   (b) IDEMPOTENT — the underlying `scaffoldInstance` skips existing files,
+  //       so re-activation (a reload, a restart) is a safe no-op.
+  //   (c) NON-FATAL — a thrown error or a bundle non-zero exit is logged and
+  //       swallowed; activation continues and the daemon never crashes on a
+  //       scaffold fault.
+  //
+  // The scaffolder is injectable (`options.scaffoldAgentState`) so tests assert
+  // the opt-in / idempotency / regression behaviour without touching the
+  // principal's real `~/.config` or spawning `bun`.
+  const doScaffold = options.scaffoldAgentState ?? scaffoldInstance;
+  const scaffoldStatefulAgent = (agent: Agent): void => {
+    // (a) Opt-in guard — a stateless fragment returns before any work.
+    if (!agent.state) return;
+    try {
+      // (b) Idempotent by construction of scaffoldInstance (skip-if-exists).
+      const result = doScaffold(agent);
+      console.log(
+        `cortex: agent-state — scaffolded instance for "${agent.id}" via ${result.strategy} ` +
+          `(dir=${result.instanceDir}, created=${result.created.length}, skipped=${result.skipped.length})`,
+      );
+    } catch (err) {
+      // (c) Non-fatal — log and carry on. A failed scaffold must never block
+      //     activation or crash the daemon (the fragment still activates
+      //     stateless; the principal can re-run once the bundle is fixed).
+      process.stderr.write(
+        `cortex: agent-state — scaffold FAILED for "${agent.id}" (non-fatal; agent still activates): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  };
+  for (const agent of mergedAgents) {
+    scaffoldStatefulAgent(agent);
   }
 
   // cortex#98 (part B) — in-process trust map. Each Discord adapter
@@ -3872,6 +3938,17 @@ export async function startCortex(
     liveMergedAgents = freshMerged;
     agentRegistry = AgentRegistry.fromAgents(freshMerged);
     agentGeneration += 1;
+
+    // ── cortex#1720 S1 — scaffold-on-activation for added + changed agents. ──
+    //    Same opt-in / idempotent / non-fatal helper boot uses. A hot-added (or
+    //    changed-into-stateful) fragment gets its instance dir ensured here; a
+    //    stateless add is a no-op (the `if (agent.state)` guard inside). Removed
+    //    agents are intentionally NOT torn down — the events log is append-only
+    //    and the principal owns the instance dir's lifecycle.
+    for (const id of [...added, ...changed]) {
+      const agent = freshById.get(id);
+      if (agent !== undefined) scaffoldStatefulAgent(agent);
+    }
 
     // ── Start consumers for added + changed (new definition) agents via the
     //    SAME construction path boot uses — concurrently (sage round 2),


### PR DESCRIPTION
## Summary

S1 of #1720 — make cortex honor the pack `state` field. Adds **opt-in**
per-instance durable state for agent fragments. The design north star:
**stateless is the default — "bring your own grounding".** A fragment without a
`state:` block behaves exactly as it does today; every new code path is guarded
behind `if (agent.state)`.

## What S1 covers (this PR)

1. **Schema** — additive optional `state: { blueprint, version }` on
   `AgentSchema` (`src/common/types/cortex-config.ts`). Both fields required
   *within* the block (min-length strings); the block itself is optional.
   Existing fragments omit it and are unaffected.
2. **Scaffold lib** — `src/common/agents/agent-state-scaffold.ts`, ported from
   grove's proven `agent-state-scaffold.ts`:
   - **Bundle-preferred**: subprocesses to the AgentState bundle's
     `scaffold.ts` with the standard env contract
     (`MF_AGENT_NAME`, `MF_HOST=cortex`, `MF_INSTANCE_DIR`) and CLI
     `<instance-dir> --host=<host> --agent=<id>`.
   - **Manual fallback** when the bundle isn't installed — lays the same
     operator-facing skeleton (CLAUDE.md, dashboard.md, context/, retros/)
     **without** creating `state.sqlite` (the bundle owns that schema).
   - **No imports from `agent-state`** — subprocess contract only, per the
     platform no-coupling rule.
   - Instance dir convention: `~/.config/cortex/agents/{id}/`.
   - **Corrects grove's default script path bug**: the canonical bundle
     script is `.../agent-state/skill/scripts/scaffold.ts`, not grove's
     `.../agent-state/scripts/errands.ts` (grove omits the `skill/` segment;
     bug filed against grove separately). Overridable via
     `MF_AGENT_STATE_SCRIPT`.
3. **Scaffold-on-activation call site** (`src/cortex.ts`) — `scaffoldStatefulAgent()`
   runs at **boot** (over `mergedAgents`) and in the **agents.d hot-reload
   reconcile** (over `added + changed`). It is:
   - **(a) opt-in** — `if (agent.state)` guards every invocation; a stateless
     fragment takes zero new code paths;
   - **(b) idempotent** — the underlying `scaffoldInstance` skips existing
     files, so re-activation (reload / restart) is a safe no-op;
   - **(c) non-fatal** — a thrown error or bundle non-zero exit logs and is
     swallowed; activation continues, the daemon never crashes.
   - Injectable via the `options.scaffoldAgentState` test seam.

## Out of scope (S2–S4, follow-up slices of #1720)

- **S2** — `ReplayPending` on consumer start
- **S3** — dispatch lifecycle → `EnqueueWorkItem` / `ClaimWorkItem` / `ResolveWorkItem`
- **S4** — `RegenerateDashboard` on transitions; retire the `dev-session-store.ts` bridge

No dispatch wiring, no replay, no dashboard regeneration here.

## Verification

- `bunx tsc --noEmit` — clean.
- `bunx eslint` on all changed files — clean.
- Vocab carve-out gate (`scripts/check-carveouts.sh`) — PASS (new code uses
  "principal", not the deprecated "operator" vocabulary).
- **New tests (all green, 40+ assertions):**
  - Schema: accepts fragment *with* and *without* `state`; rejects a `state`
    block missing `blueprint`/`version` or with empty strings.
  - Scaffold lib: bundle-preferred spawns with correct args + env; does not
    double-write the skeleton on bundle success; falls back to manual on a
    non-zero bundle exit; manual fallback lays the skeleton with **no**
    `state.sqlite`; idempotent re-run creates nothing; `resolveInstanceDir`
    honors `~/.config/<host>/agents/<id>/`.
  - Boot + reload integration: a stateful fragment **is** scaffolded with its
    id; **REGRESSION** — a stateless fragment activates with **no** scaffold
    attempt; mixed roster scaffolds only the stateful one; hot-added stateful
    fragment is scaffolded on reload (stateless add is not); **non-fatal** — a
    throwing scaffolder does not crash boot and the agent still activates.
- **Full suite:** `9435 pass / 20 fail / 2 skip / 8 todo` across 564 files.
  **The 20 failures are pre-existing and unrelated** — all in
  `src/cli/cortex/commands/__tests__/network-secret-cli.test.ts` (`cortex
  network secret add-member` / `revoke-member`). I confirmed they fail
  identically (20/35 in that file) on a clean `origin/main` worktree with a
  fresh `bun install`, with zero overlap with the schema / loader / activation
  / scaffold code this PR touches.

## Notes on conventions

- **blueprint.yaml** has no feature ID matching #1720 / agent-state / scaffold,
  so per CLAUDE.md guidance I did **not** invent one — flagging here instead.
- **Migration-phase citation:** #1720 is a post-cutover F-series feature (honor
  the pack `state` field), not a MIG-N.x file-move; there is no
  `docs/plan-cortex-migration.md` checklist item to cite. The design-of-record
  is `docs/design-agentic-dev-pipeline.md` §Composition (agent-state hook
  wiring) referenced by the issue.
- `CLAUDE.md` is generated — untouched.

Refs #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)