### PR TITLE
fix(network): C-1723 — derived stack_id on admission reads + fail-loud seal + real --leaf-user

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-secret-lib.test.ts
@@ -275,14 +275,54 @@ describe("cortex#1598 — operator-mode add-member (scoped mint + v2 seal)", () 
     expect(JSON.stringify(report.data)).not.toContain(FAKE_CREDS);
   });
 
-  test("stack_id absent → the username stack segment defaults to 'default'", async () => {
+  // cortex#1723 — the OLD behavior here (silently defaulting to "alice.default")
+  // caused the live jc↔andreas mis-seal: a scope the member's real stack can
+  // never receive on. A stackless row now FAILS LOUD; --leaf-user (validated,
+  // same-principal) drives the mint when the row can't.
+  test("stack_id absent + no override → FAILS LOUD, no mint, no post (cortex#1723)", async () => {
     const r = makePorts({
       admitted: { request_id: "req1", principal_id: "alice" },
       scopedMint: { creds: FAKE_CREDS },
     });
-    await runNetworkSecret(operatorInputs(), r.ports);
-    expect(r.scopedMints).toEqual(["alice.default"]);
-    expect(r.posted[0]!.blob).toContain('"leaf_user":"alice/default"');
+    const report = await runNetworkSecret(operatorInputs(), r.ports);
+    expect(report.ok).toBe(false);
+    expect(report.reason).toContain("no stack_id");
+    expect(report.reason).toContain("--leaf-user alice.<stack>");
+    expect(r.scopedMints).toEqual([]);
+    expect(r.posted).toEqual([]);
+  });
+
+  test("stack_id absent + --leaf-user drives the ACTUAL mint (not display-only) (cortex#1723)", async () => {
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      scopedMint: { creds: FAKE_CREDS },
+    });
+    const report = await runNetworkSecret(operatorInputs({ leafUserOverride: "alice.laptop" }), r.ports);
+    expect(report.ok).toBe(true);
+    expect(r.scopedMints).toEqual(["alice.laptop"]);
+    expect(r.posted[0]!.blob).toContain('"leaf_user":"alice/laptop"');
+  });
+
+  test("--leaf-user naming a DIFFERENT principal is refused (cross-principal mint guard) (cortex#1723)", async () => {
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      scopedMint: { creds: FAKE_CREDS },
+    });
+    const report = await runNetworkSecret(operatorInputs({ leafUserOverride: "mallory.laptop" }), r.ports);
+    expect(report.ok).toBe(false);
+    expect(report.reason).toContain("cross-principal");
+    expect(r.scopedMints).toEqual([]);
+  });
+
+  test("--leaf-user must be the dotted <principal>.<stack> form (cortex#1723)", async () => {
+    const r = makePorts({
+      admitted: { request_id: "req1", principal_id: "alice" },
+      scopedMint: { creds: FAKE_CREDS },
+    });
+    const report = await runNetworkSecret(operatorInputs({ leafUserOverride: "alice" }), r.ports);
+    expect(report.ok).toBe(false);
+    expect(report.reason).toContain("dotted");
+    expect(r.scopedMints).toEqual([]);
   });
 
   test("a second add-member re-exports → userAlreadyPresent (idempotency, C2)", async () => {

--- a/src/cli/cortex/commands/network-secret-lib.ts
+++ b/src/cli/cortex/commands/network-secret-lib.ts
@@ -596,17 +596,45 @@ async function addOrRotate(
  * the admitted row's `stack_id` trailing segment (the part after the last "/"
  * for the canonical `{principal}/{stack}` form); a present-but-slashless
  * `stack_id` is used VERBATIM (never silently collapsed to "default" — that
- * would target the wrong scoped username); only a wholly-absent `stack_id` falls
- * back to "default".
+ * would target the wrong scoped username).
+ *
+ * cortex#1723 — a wholly-absent `stack_id` NO LONGER falls back to "default":
+ * the live jc↔andreas join mis-sealed exactly that way (registry rows carried
+ * no stack_id; the "default" fallback minted scope `federated.andreas.default.>`
+ * for a stack whose wire identity is `andreas.meta-factory` — a silent one-way
+ * link). An explicit `--leaf-user` override (the DOTTED nsc form) wins and MUST
+ * name this row's principal (a cross-principal override would mint someone
+ * else's scope sealed to this member's pubkey); else a present `stack_id`
+ * derives; else `null` — the caller fails loud with the fix options.
  */
-function deriveScopedUserNames(row: { principal_id: string; stack_id?: string }): {
-  natsUser: string;
-  leafUserSlash: string;
-} {
-  const stackSeg =
-    row.stack_id === undefined || row.stack_id.length === 0
-      ? "default"
-      : row.stack_id.slice(row.stack_id.lastIndexOf("/") + 1) || "default";
+function deriveScopedUserNames(
+  row: { principal_id: string; stack_id?: string },
+  leafUserOverride?: string,
+): { natsUser: string; leafUserSlash: string } | { error: string } {
+  if (leafUserOverride !== undefined && leafUserOverride.length > 0) {
+    const dotted = /^[a-z0-9-]+\.[a-z0-9_-]+$/;
+    if (!dotted.test(leafUserOverride)) {
+      return { error: `--leaf-user "${leafUserOverride}" must be the dotted scoped-user form "<principal>.<stack>" (e.g. "andreas.meta-factory")` };
+    }
+    const [p, stackSeg] = leafUserOverride.split(".", 2) as [string, string];
+    if (p !== row.principal_id) {
+      return { error: `--leaf-user "${leafUserOverride}" names principal "${p}" but the admission row is for "${row.principal_id}" — refusing a cross-principal scoped mint` };
+    }
+    return { natsUser: leafUserOverride, leafUserSlash: `${p}/${stackSeg}` };
+  }
+  if (row.stack_id === undefined || row.stack_id.length === 0) {
+    return {
+      error:
+        `admission row for "${row.principal_id}" carries no stack_id, so the scoped-user name (and with it the ` +
+        `SUB scope) cannot be derived — refusing to default to "${row.principal_id}.default" (cortex#1723: that mints ` +
+        `a scope the member's real stack can never receive on). Fix: upgrade the registry (it derives stack_id from ` +
+        `the principal record), or pass --leaf-user ${row.principal_id}.<stack>.`,
+    };
+  }
+  const stackSeg = row.stack_id.slice(row.stack_id.lastIndexOf("/") + 1);
+  if (stackSeg.length === 0) {
+    return { error: `admission row stack_id "${row.stack_id}" has an empty trailing segment — cannot derive the scoped-user name` };
+  }
   return { natsUser: `${row.principal_id}.${stackSeg}`, leafUserSlash: `${row.principal_id}/${stackSeg}` };
 }
 
@@ -649,11 +677,21 @@ async function operatorModeSeal(
       `operator-mode admit needs an arc that provides 'add-federated-user' (arc#269) — the scoped-mint port is not wired. Run 'arc upgrade'.`);
   }
   if (inputs.hubFedAccount === undefined || inputs.hubFedAccount.length === 0) {
+    // cortex#1723 (runbook finding) — the old hint named a `--hub-fed-account`
+    // flag that does not exist on `secret add-member`; the real options are the
+    // config field or `--hub-account <account-pubkey>`.
     return fail(action, inputs, steps, data,
-      `operator-mode admit needs the hub federation account — pass --hub-fed-account <ACCOUNT> or set policy.federated.networks[${inputs.networkId}].hub_fed_account.`);
+      `operator-mode admit needs the hub federation account — set policy.federated.networks[${inputs.networkId}].hub_fed_account in the hub stack config (load it with --config <pointer>), or pass --hub-account <account-pubkey>.`);
   }
 
-  const { natsUser, leafUserSlash } = deriveScopedUserNames(row);
+  // cortex#1723 — the override now DRIVES the mint (it was display-only: the
+  // echo showed it while the nsc user re-derived from the row); an absent
+  // stack_id fails loud instead of silently minting "<principal>.default".
+  const derived = deriveScopedUserNames(row, inputs.leafUserOverride);
+  if ("error" in derived) {
+    return fail(action, inputs, steps, data, derived.error);
+  }
+  const { natsUser, leafUserSlash } = derived;
   data.leaf_user = leafUserSlash;
   data.nats_user = natsUser;
 
@@ -886,7 +924,15 @@ async function revokeMemberOperator(
   const action: SecretAction = "revoke-member";
   const { row, steps, data } = ctx;
   data.hub_mode = "operator";
-  const { natsUser } = deriveScopedUserNames(row);
+  // cortex#1723 — same loud failure as the seal: revoking "<principal>.default"
+  // when the real user is "<principal>.<stack>" would silently cut NOTHING
+  // (the revoke targets a user that isn't the live one). Override or stack_id
+  // required; never guess.
+  const derived = deriveScopedUserNames(row, inputs.leafUserOverride);
+  if ("error" in derived) {
+    return fail(action, inputs, steps, data, derived.error);
+  }
+  const { natsUser } = derived;
   data.nats_user = natsUser;
 
   // Guard (§5.1): the revoke push targets the FED account JWT — a preloaded

--- a/src/services/network-registry/__tests__/admission-requests.test.ts
+++ b/src/services/network-registry/__tests__/admission-requests.test.ts
@@ -174,6 +174,60 @@ describe("POST /principals/:id/register — admission request side-effect", () =
     expect(bobRequests.length).toBe(1);
     expect(bobRequests[0]!.request_id).toBe(req1.request_id);
   });
+
+  // cortex#1723 — admission reads DERIVE stack_id from the principal record
+  // (peer_pubkey joined against live stacks). Rows never stored it; the
+  // custodian seal then defaulted the scoped-user name to "<principal>.default"
+  // — the live jc↔andreas mis-seal (a SUB scope the member's real stack can
+  // never receive on).
+  test("admission reads carry the DERIVED stack_id (list + by-id) (cortex#1723)", async () => {
+    const req = await registerAndGetRequest("carol");
+    // The list read already carried it (registerAndGetRequest reads the list):
+    expect((req as AdmissionRequest & { stack_id?: string }).stack_id).toBe("carol/main");
+
+    // The single-row admin read derives it too.
+    const signedRead = await makeSignedAdminRead(admin);
+    const byId = await get(
+      `/admission-requests/${req.request_id}`,
+      env,
+      { "x-admin-signed": JSON.stringify(signedRead) },
+    );
+    expect(byId.status).toBe(200);
+    const row = (await byId.json()) as AdmissionRequest & { stack_id?: string };
+    expect(row.stack_id).toBe("carol/main");
+  });
+
+  test("stack_id derivation is fail-safe: no matching live stack ⇒ absent, never 'default' (cortex#1723)", async () => {
+    // Register with a DIFFERENT stack pubkey than the admission row's peer
+    // pubkey (the row is keyed on stacks[0] here, so register a second stack
+    // whose pubkey the row does NOT use — then retire-simulate by asserting the
+    // unmatched case directly through the derivation on a mismatched record).
+    const req = await registerAndGetRequest("dave");
+    const enriched = req as AdmissionRequest & { stack_id?: string };
+    // Sanity: dave DID match (same pubkey) — now assert the negative via the
+    // exported derivation helper with a mismatched record.
+    expect(enriched.stack_id).toBe("dave/main");
+    const { deriveAdmissionStackId } = await import("../src/store");
+    expect(
+      deriveAdmissionStackId(
+        { principal_id: "dave", peer_pubkey: "someOtherPubkeyThatMatchesNoStack=" },
+        [{ principal_id: "dave", principal_pubkey: "x", stacks: [{ stack_id: "dave/main", stack_pubkey: principal.publicKeyB64 }], capabilities: [], updated_at: "now" }],
+      ),
+    ).toBeUndefined();
+    // Ambiguity (same pubkey on TWO live stacks) is also fail-safe: absent.
+    expect(
+      deriveAdmissionStackId(
+        { principal_id: "dave", peer_pubkey: principal.publicKeyB64 },
+        [{
+          principal_id: "dave", principal_pubkey: "x", capabilities: [], updated_at: "now",
+          stacks: [
+            { stack_id: "dave/main", stack_pubkey: principal.publicKeyB64 },
+            { stack_id: "dave/lab", stack_pubkey: principal.publicKeyB64 },
+          ],
+        }],
+      ),
+    ).toBeUndefined();
+  });
 });
 
 // =============================================================================

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -51,7 +51,7 @@
 
 import { Hono, type Context } from "hono";
 import { parseAdminPubkeys, parseHubAdminPubkeys, parseNetworkAdminPubkeys, type Env } from "../index";
-import { getNonceCache, getIssuanceStore, getStore, AlreadyDecidedError } from "../store";
+import { getNonceCache, getIssuanceStore, getStore, AlreadyDecidedError, withDerivedStackId } from "../store";
 import {
   validateSignedAdmissionDecision,
   validateAdmissionDecisionClaim,
@@ -749,7 +749,11 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     // ADR-0020 §3). Filtering here (not in SQL) keeps the store interface intact;
     // the admission queue is small and the filtered set never leaves the worker.
     const scoped = auth.scope === null ? requests : requests.filter((r) => r.network_id === auth.scope);
-    return c.json(scoped, 200);
+    // cortex#1723 — enrich each row with the DERIVED stack_id (peer_pubkey joined
+    // against the principal record's live stacks) so the custodian seal derives
+    // the scoped-user name from the row instead of defaulting to "<principal>.default".
+    const principals = await getStore(c.env).listPrincipals();
+    return c.json(scoped.map((r) => withDerivedStackId(r, principals)), 200);
   });
 
   // ---------------------------------------------------------------------------
@@ -818,7 +822,9 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     // the holder of the matching seed (ADR-0018 Q4 b′).
     const store = getIssuanceStore(c.env);
     const rows = await store.listIssuanceRequestsByPeer(signed.claim.peer_pubkey);
-    const mine: AdmissionMineRow[] = rows;
+    // cortex#1723 — same derived stack_id enrichment as the admin list read.
+    const minePrincipals = await getStore(c.env).listPrincipals();
+    const mine: AdmissionMineRow[] = rows.map((r) => withDerivedStackId(r, minePrincipals));
     return c.json(mine, 200);
   });
 
@@ -850,7 +856,8 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     if (auth.scope !== null && request.network_id !== auth.scope) {
       return c.json({ error: "not_found" }, 404);
     }
-    return c.json(request, 200);
+    // cortex#1723 — derived stack_id enrichment (see the list read).
+    return c.json(withDerivedStackId(request, await getStore(c.env).listPrincipals()), 200);
   });
 
   return app;

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -1337,6 +1337,35 @@ export function membersFromAdmissions(
 }
 
 /**
+ * cortex#1723 — derive an admission row's `stack_id` at READ time by joining
+ * `peer_pubkey` against the principal record's LIVE stacks (same
+ * derived-not-stored posture as roster membership). Admission rows never stored
+ * a stack segment, so the custodian seal tooling defaulted the scoped-user name
+ * to `<principal>.default` — minting a SUB scope the member's real stack can
+ * never receive on (the live jc↔andreas mis-seal). Returns undefined when the
+ * pubkey matches no live stack or MORE than one (ambiguous — never guess; the
+ * seal side fails loud and asks for --leaf-user).
+ */
+export function deriveAdmissionStackId(
+  row: Pick<AdmissionRequest, "principal_id" | "peer_pubkey">,
+  principals: PrincipalRecord[],
+): string | undefined {
+  const record = principals.find((p) => p.principal_id === row.principal_id);
+  if (!record) return undefined;
+  const live = record.stacks.filter((s) => s.retired_at === undefined && s.stack_pubkey === row.peer_pubkey);
+  return live.length === 1 ? live[0]?.stack_id : undefined;
+}
+
+/** cortex#1723 — an admission row enriched with the derived `stack_id` (absent when underivable). */
+export function withDerivedStackId(
+  row: AdmissionRequest,
+  principals: PrincipalRecord[],
+): AdmissionRequest & { stack_id?: string } {
+  const stackId = deriveAdmissionStackId(row, principals);
+  return stackId !== undefined ? { ...row, stack_id: stackId } : row;
+}
+
+/**
  * Search capabilities across all principals. The query is a substring
  * match against `capability.id` (lowercase, dotted) and against
  * `description`. v1 returns all hits unsorted — pagination is a


### PR DESCRIPTION
## The live mis-seal (jc↔andreas, final join leg)
The custodian's re-seal minted scope `federated.andreas.default.>` for a stack whose wire identity is `andreas.meta-factory` — a **silent one-way link**. Three coupled defects:

| # | Defect | Fix |
|---|---|---|
| 1 | **Registry rows never carry `stack_id`** (no column, no derivation — the client type documented it aspirationally, #1598) | Reads (list, by-id, `/mine`) **derive it at read time**: `peer_pubkey` joined against the principal record's **live** stacks — the same derived-not-stored posture as roster membership. Fail-safe: no match or **ambiguous** (same pubkey on two live stacks) ⇒ absent, never a guess. No migration. |
| 2 | **Seal silently defaulted** a stackless row to `<principal>.default` | **Fails loud** naming both fixes (upgrade registry / pass `--leaf-user`). Same guard on operator **revoke** — revoking `.default` when the live user is `.<stack>` would silently cut *nothing*. |
| 3 | **`--leaf-user` was display-only** on the operator path (echoed, while the nsc user re-derived from the row) — found live by the hub custodian | Now **drives the actual mint**, validated: dotted `<principal>.<stack>` form, MUST name the row's principal (a cross-principal override would mint someone else's scope sealed to this member's pubkey). |

Also fixes the phantom-flag hint (runbook finding): the operator-seal error pointed at `--hub-fed-account`, which doesn't exist on `secret add-member`.

## Verification
- Registry suites **335/0** (new: derive on list + by-id; fail-safe negative + ambiguity)
- secret-lib **64/0** (the old *defaults-to-default* test **flipped** to fail-loud + 3 override tests)
- tsc clean · eslint clean

## Ops note
The registry half activates on the next `wrangler deploy --env production`; until then the client half **fails loud** (never mis-seals).

Closes #1723 · Refs #1652 · epic #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)