### PR TITLE
fix(ping): probe envelope target_assistant + valid capability type (first-contact ping) (#1728)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-ping-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-ping-lib.test.ts
@@ -138,6 +138,11 @@ describe("buildProbeRequestEnvelope — FG conformance", () => {
     expect(env.source).toBe("jc.default.luna");
     // FG-3: requester rides in originator.identity = our DID.
     expect(env.originator?.identity).toBe("did:mf:andreas-community");
+    // cortex#1728: a Direct probe carries target_assistant (F-021 requires it
+    // for distribution_mode:direct — omitting it got every probe dropped at the
+    // peer's envelope validator before the responder saw it).
+    expect(env.distribution_mode).toBe("direct");
+    expect(env.target_assistant).toBe("did:mf:jc-default");
     expect(env.sovereignty.classification).toBe("federated");
     expect(env.sovereignty.max_hop).toBe(1);
     expect(env.distribution_mode).toBe("direct");

--- a/src/cli/cortex/commands/network-ping-lib.ts
+++ b/src/cli/cortex/commands/network-ping-lib.ts
@@ -30,6 +30,7 @@ import { encodeDidSegment } from "@the-metafactory/myelin/subjects";
 
 import type { Envelope } from "../../../bus/myelin/envelope-validator";
 import {
+  PROBE_ECHO_CAPABILITY,
   PROBE_REPLY_ECHO_TYPE,
   type ProbeEchoReplyPayload,
 } from "../../../bus/probe-responder";
@@ -272,13 +273,20 @@ export function buildProbeRequestEnvelope(opts: {
   seq: number;
 }): Envelope {
   const { inputs, nonce, correlationId, seq } = opts;
-  const enc = encodeDidSegment(inputs.targetAssistantDid);
   return {
     id: crypto.randomUUID(),
     // `source` addresses the TARGET stack (ADR-0002 §1) — the sender assistant
     // is our own assistant id.
     source: `${inputs.targetPrincipal}.${inputs.targetStack}.${inputs.requesterAssistant}`,
-    type: `tasks.${enc}.probe.echo`,
+    // cortex#1728 — the envelope `type` is the plain CAPABILITY (`probe.echo`),
+    // schema-valid under the envelope `type` pattern. The `@{enc-did}` DID
+    // segment is a SUBJECT-routing construct (encodeDidSegment → the subject's
+    // `tasks.@{assistant}.{capability}` form, built in buildProbeRequestSubject)
+    // — putting it in `type` made the type schema-INVALID (`@` fails the
+    // pattern), so the peer's envelope validator dropped every probe. Direct
+    // addressing rides in distribution_mode:"direct" + target_assistant, not the
+    // type. isProbeEcho() recognises the bare `probe.echo` capability.
+    type: PROBE_ECHO_CAPABILITY,
     distribution_mode: "direct",
     timestamp: new Date().toISOString(),
     correlation_id: correlationId,
@@ -295,6 +303,13 @@ export function buildProbeRequestEnvelope(opts: {
       identity: `did:mf:${inputs.requesterPrincipal}-${inputs.requesterStack}`,
       attribution: "federated",
     },
+    // cortex#1728 — a Direct probe IS a direct-addressed dispatch, so the F-021
+    // envelope rule (`target_assistant` required when distribution_mode ===
+    // "direct" | "delegate", envelope-validator.ts) applies. The emitter already
+    // has the target DID (it encodes it into the subject above) — omitting it
+    // here made every probe schema-invalid, dropped at the peer's subscriber
+    // BEFORE the probe-responder saw it (0 echoes, the whole ping gap). Stamp it.
+    target_assistant: inputs.targetAssistantDid,
     payload: {
       nonce,
       sent_at: new Date().toISOString(),


### PR DESCRIPTION
## The last gap in first-contact
The jc↔andreas federated ping dropped at the peer's `myelin-subscriber` envelope validator — **before** the (live, gated-in) probe-responder saw it. Two envelope defects:

1. **Missing `target_assistant`.** A Direct probe is `distribution_mode:"direct"`; F-021 requires `target_assistant` on direct/delegate envelopes. The emitter had the target DID (it encodes it into the subject) but never stamped the field. → JC's v6.3.5 validator flagged exactly this.
2. **Invalid `type`.** The envelope `type` was `tasks.@{enc-did}.probe.echo` — but `@{enc-did}` is a **subject**-routing construct (`encodeDidSegment`), and `@` fails the envelope `type` pattern `^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$`. Type is now the plain capability **`probe.echo`** (schema-valid, `isProbeEcho()`-recognised); the `@`-DID routing stays in the **subject** (`buildProbeRequestSubject`, unchanged); direct-ness rides in `distribution_mode` + `target_assistant`.

## Verification (round-trip against the real validator)
- `validateEnvelope(probe).ok === true` — was **false on both counts** before
- `isProbeEcho("probe.echo") === true`; subject unchanged (`federated.jc.default.tasks.@did-mf-jc-default.probe.echo`)
- ping-lib **64/0**, signer + probe-responder suites green, tsc + eslint clean

## Scope
Emitter-side only (the probe envelope). No schema change, no subject/routing change, no responder change.

Refs #1728

🤖 Generated with [Claude Code](https://claude.com/claude-code)