### PR TITLE
feat(network): C-1728 guard 4 — leafz-aware ping/doctor timeout half-disambiguation

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
@@ -28,6 +28,7 @@ import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-con
 import {
   DOCTOR_EXIT_CODE,
   runDoctorChecks,
+  selectNetworkLeaf,
   type DoctorCheck,
 } from "../network-doctor-lib";
 import type {
@@ -62,6 +63,9 @@ function loadedConfig(peers: { principal_id: string; stack_id: string }[]): Load
         networks: [
           {
             id: "metafactory-community",
+            // cortex#1728 — leaf_node so derivePingInputs resolves the scoping
+            // key the leafz sampler is invoked with (matches network() fixture).
+            leaf_node: "hub",
             peers,
           } as unknown as NonNullable<
             NonNullable<LoadedConfig["policy"]>["federated"]
@@ -138,7 +142,7 @@ function fakeProbe(
   if (leafzReadings !== undefined) {
     let call = 0;
     ports.leafz = {
-      sample: async () => {
+      sample: async (_leafNode: string) => {
         const r = leafzReadings[call];
         call++;
         return r;
@@ -745,5 +749,53 @@ describe("runDoctorChecks — sealed-secret-hub-authorized (Pair 3, documented s
     expect(c.detail).toContain("opaque ciphertext");
     // A skip never blocks a healthy verdict.
     expect(res.verdict).toBe("healthy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#1728 (guard 4) — selectNetworkLeaf: SCOPED leaf attribution
+// (the #1731 review BLOCK — never sum sibling leaves' counters)
+// ---------------------------------------------------------------------------
+
+describe("selectNetworkLeaf — multi-leaf attribution (cortex#1728)", () => {
+  // A real host runs several leaves that share the hub ip:port.
+  const MULTI_LEAF: LeafzResponse = {
+    leafs: [
+      { name: "metafactory", account: "ACCT_MF", in_msgs: 5, out_msgs: 5 },
+      { name: "community", account: "ACCT_COMM", in_msgs: 99, out_msgs: 99 },
+      { name: "halden", account: "ACCT_HAL", in_msgs: 7, out_msgs: 7 },
+    ],
+  };
+
+  test("matches ONLY the named leaf — sibling counters are never included", () => {
+    const m = selectNetworkLeaf(MULTI_LEAF, "metafactory");
+    expect(m?.match).toBe("named");
+    expect(m?.leaf.out_msgs).toBe(5); // metafactory's own, NOT the summed 111
+    expect(m?.leaf.in_msgs).toBe(5);
+  });
+
+  test("matches on account as a secondary key", () => {
+    const m = selectNetworkLeaf(MULTI_LEAF, "ACCT_COMM");
+    expect(m?.match).toBe("named");
+    expect(m?.leaf.out_msgs).toBe(99);
+  });
+
+  test("multi-leaf bus with NO name/account match ⇒ undefined (never misattribute)", () => {
+    // This is the core of the review BLOCK: metafactory egress could be dead
+    // (out+0) while community ticks — if we summed, we'd mask the break. With no
+    // match on a 3-leaf bus we refuse to attribute.
+    expect(selectNetworkLeaf(MULTI_LEAF, "unknown-leaf")).toBeUndefined();
+  });
+
+  test("lone-leaf bus ⇒ attributes the single leaf even without a name match", () => {
+    const lone: LeafzResponse = { leafs: [{ name: "hub", in_msgs: 3, out_msgs: 4 }] };
+    const m = selectNetworkLeaf(lone, "some-network-leaf");
+    expect(m?.match).toBe("lone-fallback");
+    expect(m?.leaf.out_msgs).toBe(4);
+  });
+
+  test("empty leafs ⇒ undefined", () => {
+    expect(selectNetworkLeaf({ leafs: [] }, "hub")).toBeUndefined();
+    expect(selectNetworkLeaf({}, "hub")).toBeUndefined();
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
@@ -36,6 +36,7 @@ import type {
   NetworkDoctorPorts,
 } from "../network-doctor-ports";
 import type {
+  LeafzCounters,
   NetworkPingPorts,
   ProbeFireInputs,
   ProbeRoundTripResult,
@@ -119,9 +120,10 @@ function fakeMonitorPort(opts: {
 /** A fake probe-bus port (the exact `NetworkPingPorts` shape `pingPeer` consumes). */
 function fakeProbe(
   respond: (fired: ProbeFireInputs, seq: number) => ProbeRoundTripResult,
+  leafzReadings?: (LeafzCounters | undefined)[],
 ): NetworkPingPorts {
   let seq = 0;
-  return {
+  const ports: NetworkPingPorts = {
     bus: {
       fireProbe: async (f) => {
         seq++;
@@ -131,6 +133,19 @@ function fakeProbe(
     newNonce: () => `nonce-${seq}`,
     newCorrelationId: () => `corr-${seq}`,
   };
+  // cortex#1728 (guard 4) — inject a scripted before/after leafz sampler so the
+  // doctor timeout leg can fold the half-disambiguation.
+  if (leafzReadings !== undefined) {
+    let call = 0;
+    ports.leafz = {
+      sample: async () => {
+        const r = leafzReadings[call];
+        call++;
+        return r;
+      },
+    };
+  }
+  return ports;
 }
 
 /** Build a conformant echo reply for a fired probe (mock responder). */
@@ -456,6 +471,45 @@ describe("runDoctorChecks — (e) peer timeout", () => {
     // peer is entirely unreachable ⇒ the federation path is broken.
     expect(res.verdict).toBe("broken");
     expect(res.exitCode).toBe(DOCTOR_EXIT_CODE.broken);
+  });
+
+  test("cortex#1728 — leafz out+/in0 sharpens the timeout fix to the REMOTE half", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe(() => ({ kind: "timeout" }), [
+        { outMsgs: 10, inMsgs: 5 }, // before
+        { outMsgs: 11, inMsgs: 5 }, // after: probe crossed, no echo back ⇒ remote
+      ]),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const peerCheck = findCheck(res.checks, "peer-reachable:jc/default");
+    expect(peerCheck.status).toBe("fail");
+    expect(peerCheck.detail).toContain("REMOTE");
+    expect(peerCheck.fix).toContain("peer/echo leg");
+    expect(peerCheck.fix).not.toContain("peer/hub"); // the sharper remediation wins
+  });
+
+  test("cortex#1728 — leafz out+0 sharpens the timeout fix to the LOCAL-egress half", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe(() => ({ kind: "timeout" }), [
+        { outMsgs: 10, inMsgs: 5 }, // before
+        { outMsgs: 10, inMsgs: 5 }, // after: nothing left the leaf ⇒ local egress
+      ]),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const peerCheck = findCheck(res.checks, "peer-reachable:jc/default");
+    expect(peerCheck.status).toBe("fail");
+    expect(peerCheck.detail).toContain("LOCAL egress");
+    expect(peerCheck.fix).toContain("local egress");
   });
 
   test("partial peer failure (one of two peers times out) ⇒ degraded, not broken", async () => {

--- a/src/cli/cortex/commands/__tests__/network-ping-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-ping-lib.test.ts
@@ -26,11 +26,14 @@ import {
   buildReplySubjectPattern,
   classifyRoundTrip,
   derivePingInputs,
+  diagnoseLeafzDelta,
   pingPeer,
   VERDICT_EXIT_CODE,
   type PingInputs,
 } from "../network-ping-lib";
 import type {
+  LeafzCounters,
+  LeafzSamplerPort,
   NetworkPingPorts,
   ProbeFireInputs,
   ProbeRoundTripResult,
@@ -424,5 +427,130 @@ describe("VERDICT_EXIT_CODE — spec §3.3 mapping", () => {
     expect(VERDICT_EXIT_CODE["no-responder"]).toBe(3);
     expect(VERDICT_EXIT_CODE.timeout).toBe(4);
     expect(VERDICT_EXIT_CODE.refused).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#1728 (guard 4) — leafz-aware half-disambiguation
+// ---------------------------------------------------------------------------
+
+/**
+ * A fake leafz sampler that returns a scripted sequence of readings — one per
+ * `sample()` call, so a before/after pair can encode a controlled delta. A
+ * `undefined` entry (or exhausting the script) models a failed read.
+ */
+function fakeLeafz(
+  readings: (LeafzCounters | undefined)[],
+): { port: LeafzSamplerPort; calls: number } {
+  const state = { calls: 0 };
+  const port: LeafzSamplerPort = {
+    sample: async () => {
+      const r = readings[state.calls];
+      state.calls++;
+      return r;
+    },
+  };
+  return { port, calls: 0 };
+}
+
+describe("diagnoseLeafzDelta — pure half-disambiguation (cortex#1728)", () => {
+  test("out +N, in +0 ⇒ remote (echo leg / peer responder)", () => {
+    const d = diagnoseLeafzDelta({ outMsgs: 100, inMsgs: 50 }, { outMsgs: 103, inMsgs: 50 });
+    expect(d?.half).toBe("remote");
+    expect(d?.outDelta).toBe(3);
+    expect(d?.inDelta).toBe(0);
+    expect(d?.line).toContain("REMOTE");
+    expect(d?.line).toContain("out +3");
+  });
+
+  test("out +0 ⇒ local-egress (leaf account/binding, not the peer)", () => {
+    const d = diagnoseLeafzDelta({ outMsgs: 100, inMsgs: 50 }, { outMsgs: 100, inMsgs: 50 });
+    expect(d?.half).toBe("local-egress");
+    expect(d?.outDelta).toBe(0);
+    expect(d?.line).toContain("LOCAL egress");
+  });
+
+  test("out +N, in +N ⇒ inconclusive (both legs advanced, not a clean split)", () => {
+    const d = diagnoseLeafzDelta({ outMsgs: 100, inMsgs: 50 }, { outMsgs: 103, inMsgs: 53 });
+    expect(d?.half).toBe("inconclusive");
+    expect(d?.outDelta).toBe(3);
+    expect(d?.inDelta).toBe(3);
+  });
+
+  test("negative delta (counter reset / reconnect) ⇒ inconclusive", () => {
+    const d = diagnoseLeafzDelta({ outMsgs: 100, inMsgs: 50 }, { outMsgs: 2, inMsgs: 0 });
+    expect(d?.half).toBe("inconclusive");
+    expect(d?.line).toContain("reconnected");
+  });
+
+  test("missing before/after sample ⇒ undefined (nothing to diff)", () => {
+    expect(diagnoseLeafzDelta(undefined, { outMsgs: 1, inMsgs: 1 })).toBeUndefined();
+    expect(diagnoseLeafzDelta({ outMsgs: 1, inMsgs: 1 }, undefined)).toBeUndefined();
+    expect(diagnoseLeafzDelta(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("pingPeer — folds leafz delta into a timeout verdict (cortex#1728)", () => {
+  test("timeout + out+ / in0 ⇒ leafz.half=remote on the result", async () => {
+    const { ports } = fakeBus(() => ({ kind: "timeout" }));
+    const { port: leafz } = fakeLeafz([
+      { outMsgs: 100, inMsgs: 50 }, // before
+      { outMsgs: 101, inMsgs: 50 }, // after: 1 probe crossed, no echo back
+    ]);
+    const res = await pingPeer(inputs(), { ...ports, leafz });
+    expect(res.verdict).toBe("timeout");
+    expect(res.leafz?.half).toBe("remote");
+    expect(res.leafz?.outDelta).toBe(1);
+    expect(res.leafz?.inDelta).toBe(0);
+  });
+
+  test("timeout + out+0 ⇒ leafz.half=local-egress on the result", async () => {
+    const { ports } = fakeBus(() => ({ kind: "timeout" }));
+    const { port: leafz } = fakeLeafz([
+      { outMsgs: 100, inMsgs: 50 }, // before
+      { outMsgs: 100, inMsgs: 50 }, // after: nothing left the leaf
+    ]);
+    const res = await pingPeer(inputs(), { ...ports, leafz });
+    expect(res.verdict).toBe("timeout");
+    expect(res.leafz?.half).toBe("local-egress");
+    expect(res.leafz?.outDelta).toBe(0);
+  });
+
+  test("reachable ⇒ NO leafz diagnosis folded (only timeout is disambiguated)", async () => {
+    const { ports } = fakeBus((f) => echoReply(f, 12));
+    const { port: leafz } = fakeLeafz([
+      { outMsgs: 100, inMsgs: 50 },
+      { outMsgs: 101, inMsgs: 51 },
+    ]);
+    const res = await pingPeer(inputs(), { ...ports, leafz });
+    expect(res.verdict).toBe("reachable");
+    expect(res.leafz).toBeUndefined();
+  });
+
+  test("no leafz sampler wired ⇒ timeout carries no leafz field (best-effort)", async () => {
+    const { ports } = fakeBus(() => ({ kind: "timeout" }));
+    const res = await pingPeer(inputs(), ports); // no `leafz` on ports
+    expect(res.verdict).toBe("timeout");
+    expect(res.leafz).toBeUndefined();
+  });
+
+  test("leafz sampler throws ⇒ ping still succeeds, no leafz line", async () => {
+    const { ports } = fakeBus(() => ({ kind: "timeout" }));
+    const leafz: LeafzSamplerPort = {
+      sample: async () => {
+        throw new Error("monitor exploded");
+      },
+    };
+    const res = await pingPeer(inputs(), { ...ports, leafz });
+    expect(res.verdict).toBe("timeout"); // never fails the ping
+    expect(res.leafz).toBeUndefined();
+  });
+
+  test("leafz sampler returns undefined (monitor unreachable) ⇒ no line", async () => {
+    const { ports } = fakeBus(() => ({ kind: "timeout" }));
+    const { port: leafz } = fakeLeafz([undefined, undefined]);
+    const res = await pingPeer(inputs(), { ...ports, leafz });
+    expect(res.verdict).toBe("timeout");
+    expect(res.leafz).toBeUndefined();
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-ping-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-ping-lib.test.ts
@@ -54,6 +54,10 @@ function inputs(overrides: Partial<PingInputs> = {}): PingInputs {
     count: 1,
     timeoutMs: 2000,
     isConfiguredPeer: true,
+    // cortex#1728 (guard 4) — a resolved leaf_node so the leafz sampler runs in
+    // the fold tests. Tests that assert the "no leaf_node" omit-path override
+    // this to `undefined`.
+    networkLeafNode: "hub",
     ...overrides,
   };
 }
@@ -328,6 +332,7 @@ describe("pingPeer — --count aggregation", () => {
 function loadedConfig(
   peers: { principal_id: string; stack_id: string }[],
   networkId = "metafactory-community",
+  leafNode = "hub",
 ): LoadedConfig {
   return {
     config: {} as unknown as LoadedConfig["config"],
@@ -337,10 +342,34 @@ function loadedConfig(
     policy: {
       federated: {
         networks: [
-          { id: networkId, peers } as unknown as NonNullable<
+          { id: networkId, leaf_node: leafNode, peers } as unknown as NonNullable<
             NonNullable<LoadedConfig["policy"]>["federated"]
           >["networks"][number],
         ],
+      },
+    } as unknown as LoadedConfig["policy"],
+  };
+}
+
+/** A two-network config where a peer sits on BOTH networks (distinct leaves). */
+function loadedConfigTwoNetworks(
+  peer: { principal_id: string; stack_id: string },
+  leafA: string,
+  leafB: string,
+): LoadedConfig {
+  return {
+    config: {} as unknown as LoadedConfig["config"],
+    inlineAgents: [{ id: "luna" } as unknown as LoadedConfig["inlineAgents"][number]],
+    principal: { id: "andreas" },
+    stack: { id: "andreas/community" },
+    policy: {
+      federated: {
+        networks: [
+          { id: "net-a", leaf_node: leafA, peers: [peer] },
+          { id: "net-b", leaf_node: leafB, peers: [peer] },
+        ] as unknown as NonNullable<
+          NonNullable<LoadedConfig["policy"]>["federated"]
+        >["networks"],
       },
     } as unknown as LoadedConfig["policy"],
   };
@@ -362,6 +391,56 @@ describe("derivePingInputs", () => {
     expect(r.inputs?.requesterAssistant).toBe("luna");
     expect(r.inputs?.targetAssistantDid).toBe("did:mf:jc-default");
     expect(r.inputs?.isConfiguredPeer).toBe(true);
+  });
+
+  test("cortex#1728 — resolves the peer's network leaf_node for leafz scoping", () => {
+    const cfg = loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }], "metafactory-community", "mfleaf");
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "jc",
+      targetStack: "default",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.inputs?.networkLeafNode).toBe("mfleaf");
+  });
+
+  test("cortex#1728 — peer on TWO networks with distinct leaves ⇒ leaf_node undefined (ambiguous, no --network)", () => {
+    const cfg = loadedConfigTwoNetworks({ principal_id: "jc", stack_id: "jc/default" }, "leaf-a", "leaf-b");
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "jc",
+      targetStack: "default",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.inputs?.isConfiguredPeer).toBe(true);
+    expect(r.inputs?.networkLeafNode).toBeUndefined(); // never guess which leaf
+  });
+
+  test("cortex#1728 — --network selector disambiguates the leaf_node", () => {
+    const cfg = loadedConfigTwoNetworks({ principal_id: "jc", stack_id: "jc/default" }, "leaf-a", "leaf-b");
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "jc",
+      targetStack: "default",
+      network: "net-b",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.inputs?.networkLeafNode).toBe("leaf-b");
+  });
+
+  test("cortex#1728 — two networks SHARING one leaf_node collapse to that leaf", () => {
+    const cfg = loadedConfigTwoNetworks({ principal_id: "jc", stack_id: "jc/default" }, "shared", "shared");
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "jc",
+      targetStack: "default",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.inputs?.networkLeafNode).toBe("shared"); // one distinct leaf ⇒ unambiguous
   });
 
   test("a target NOT in peers[] resolves isConfiguredPeer=false", () => {
@@ -441,16 +520,18 @@ describe("VERDICT_EXIT_CODE — spec §3.3 mapping", () => {
  */
 function fakeLeafz(
   readings: (LeafzCounters | undefined)[],
-): { port: LeafzSamplerPort; calls: number } {
-  const state = { calls: 0 };
+): { port: LeafzSamplerPort; leafNodes: string[] } {
+  const leafNodes: string[] = [];
+  let calls = 0;
   const port: LeafzSamplerPort = {
-    sample: async () => {
-      const r = readings[state.calls];
-      state.calls++;
+    sample: async (leafNode: string) => {
+      leafNodes.push(leafNode); // record the scoping key each call received
+      const r = readings[calls];
+      calls++;
       return r;
     },
   };
-  return { port, calls: 0 };
+  return { port, leafNodes };
 }
 
 describe("diagnoseLeafzDelta — pure half-disambiguation (cortex#1728)", () => {
@@ -493,15 +574,17 @@ describe("diagnoseLeafzDelta — pure half-disambiguation (cortex#1728)", () => 
 describe("pingPeer — folds leafz delta into a timeout verdict (cortex#1728)", () => {
   test("timeout + out+ / in0 ⇒ leafz.half=remote on the result", async () => {
     const { ports } = fakeBus(() => ({ kind: "timeout" }));
-    const { port: leafz } = fakeLeafz([
+    const { port: leafz, leafNodes } = fakeLeafz([
       { outMsgs: 100, inMsgs: 50 }, // before
       { outMsgs: 101, inMsgs: 50 }, // after: 1 probe crossed, no echo back
     ]);
-    const res = await pingPeer(inputs(), { ...ports, leafz });
+    const res = await pingPeer(inputs({ networkLeafNode: "mfleaf" }), { ...ports, leafz });
     expect(res.verdict).toBe("timeout");
     expect(res.leafz?.half).toBe("remote");
     expect(res.leafz?.outDelta).toBe(1);
     expect(res.leafz?.inDelta).toBe(0);
+    // The sampler was scoped to the network's leaf_node on BOTH before/after.
+    expect(leafNodes).toEqual(["mfleaf", "mfleaf"]);
   });
 
   test("timeout + out+0 ⇒ leafz.half=local-egress on the result", async () => {
@@ -552,5 +635,17 @@ describe("pingPeer — folds leafz delta into a timeout verdict (cortex#1728)", 
     const res = await pingPeer(inputs(), { ...ports, leafz });
     expect(res.verdict).toBe("timeout");
     expect(res.leafz).toBeUndefined();
+  });
+
+  test("cortex#1728 — no resolved leaf_node ⇒ sampler NOT called, no line (never misattribute)", async () => {
+    const { ports } = fakeBus(() => ({ kind: "timeout" }));
+    const { port: leafz, leafNodes } = fakeLeafz([
+      { outMsgs: 100, inMsgs: 50 },
+      { outMsgs: 200, inMsgs: 50 }, // would look like "remote" if wrongly sampled
+    ]);
+    const res = await pingPeer(inputs({ networkLeafNode: undefined }), { ...ports, leafz });
+    expect(res.verdict).toBe("timeout");
+    expect(res.leafz).toBeUndefined(); // ambiguous leaf ⇒ omit rather than guess
+    expect(leafNodes).toEqual([]); // sampler never invoked
   });
 });

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -452,12 +452,37 @@ async function checkMonitorReachable(
 // Leg 3 — leaf-established
 // ---------------------------------------------------------------------------
 
-interface LeafMatch {
+/**
+ * How a `/leafz` entry was attributed to a network's `leaf_node`:
+ *   - `named`         — a `name`/`account` match against the configured leaf_node;
+ *   - `lone-fallback` — no name match, but the bus has exactly ONE leaf, so it
+ *                       necessarily carries this network's traffic.
+ */
+export type LeafMatchKind = "named" | "lone-fallback";
+
+export interface LeafMatch {
   leaf: LeafzEntry;
-  match: "named" | "lone-fallback";
+  match: LeafMatchKind;
 }
 
-function findEstablishedLeaf(
+/**
+ * cortex#1728 (guard 4) — select the SINGLE `/leafz` entry attributable to a
+ * network's `leaf_node`, or `undefined` when it cannot be uniquely identified.
+ *
+ * The leaves on a host share ip:port (they all dial the same hub) and the leaf
+ * `account` is the field config famously disagrees with (guard 3), so the
+ * ONLY reliable key is the rendered leaf-remote `name` cortex controls when it
+ * writes `leafnodes-<network>.conf`. Match on `name` (or `account` as a
+ * secondary), else fall back to the lone leaf on a single-leaf bus. On a
+ * MULTI-leaf bus with no name match we return `undefined` — we must NEVER
+ * attribute another network's leaf (e.g. summing community's heartbeat traffic
+ * onto metafactory's dead egress would mask the exact break guard 4 exists to
+ * catch, #1731 review BLOCK).
+ *
+ * PURE — the caller supplies the `/leafz` snapshot. Shared by `doctor`'s
+ * leaf-established leg and the ping leafz sampler so both attribute identically.
+ */
+export function selectNetworkLeaf(
   leafz: LeafzResponse,
   leafNode: string,
 ): LeafMatch | undefined {
@@ -472,6 +497,13 @@ function findEstablishedLeaf(
   return leafs.length === 1 && leafs[0] !== undefined
     ? { leaf: leafs[0], match: "lone-fallback" }
     : undefined;
+}
+
+function findEstablishedLeaf(
+  leafz: LeafzResponse,
+  leafNode: string,
+): LeafMatch | undefined {
+  return selectNetworkLeaf(leafz, leafNode);
 }
 
 /**

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -592,15 +592,22 @@ function peerCheckFromPingResult(label: string, pr: PingResult): DoctorCheck {
       const rtt = pr.stats.rttAvgMs !== undefined ? `${pr.stats.rttAvgMs.toFixed(0)}ms` : "?ms";
       return check(id, title, "pass", `echo round-trip ok, rtt=${rtt}`, "peer");
     }
-    case "timeout":
-      return check(
-        id,
-        title,
-        "fail",
-        pr.detail ?? `no echo from ${label} within the probe timeout`,
-        "peer",
-        "peer/hub — peer offline, its leaf is down, or the hub is partitioned; check the peer's own `cortex network doctor` and the hub authorization",
-      );
+    case "timeout": {
+      // cortex#1728 (guard 4) — when the local `/leafz` counter delta localised
+      // the timeout to a half, fold it into the detail + remediation so doctor
+      // points at the broken leg instead of the undifferentiated peer/hub guess.
+      const detail =
+        pr.leafz !== undefined
+          ? `${pr.detail ?? `no echo from ${label} within the probe timeout`} — ${pr.leafz.line}`
+          : (pr.detail ?? `no echo from ${label} within the probe timeout`);
+      const remediation =
+        pr.leafz?.half === "remote"
+          ? "peer/echo leg — probes crossed OUR leaf but no echo returned; the failure is on the peer side (their responder/leaf). Check the peer's own `cortex network doctor`"
+          : pr.leafz?.half === "local-egress"
+            ? "local egress — no probes left OUR leaf; the failure is on OUR side (leaf account/binding, not the peer). Check `leaf-account-bound` above and our leaf remote"
+            : "peer/hub — peer offline, its leaf is down, or the hub is partitioned; check the peer's own `cortex network doctor` and the hub authorization";
+      return check(id, title, "fail", detail, "peer", remediation);
+    }
     case "no-responder":
       return check(
         id,

--- a/src/cli/cortex/commands/network-ping-adapters.ts
+++ b/src/cli/cortex/commands/network-ping-adapters.ts
@@ -16,11 +16,18 @@
  * `--count N` reuses one NATS connection.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+
 import type { AgentConfig } from "../../../common/types/config";
 import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { LoadedConfig } from "../../../common/config/loader";
+import { expandTilde } from "../../../common/config/loader";
+import { natsConfigMonitorUrl } from "../../../common/nats/leaf-remote-renderer";
 import type { MyelinRuntime, BusEnvelopeSigner } from "../../../bus/myelin/runtime";
 import { startMyelinRuntime } from "../../../bus/myelin/runtime";
 import type {
+  LeafzCounters,
+  LeafzSamplerPort,
   ProbeBusPort,
   ProbeFireInputs,
   ProbeRoundTripResult,
@@ -145,4 +152,81 @@ function replyScopePrefix(pattern: string): string {
   // Strip a trailing `>` wildcard; keep the dotted literal prefix.
   if (pattern.endsWith(".>")) return pattern.slice(0, -1); // keep trailing dot
   return pattern;
+}
+
+// =============================================================================
+// cortex#1728 (guard 4) — live `/leafz` sampler
+// =============================================================================
+
+/** Upstream-default nats-server HTTP monitor base (the `http_port` default). */
+const DEFAULT_MONITOR_BASE = "http://127.0.0.1:8222";
+
+/** Bound the monitor fetch so a hung monitor can't stall the ping. */
+const LEAFZ_FETCH_TIMEOUT_MS = 2000;
+
+/**
+ * cortex#1728 (guard 4) — resolve the nats-server HTTP monitor base from the
+ * loaded config, mirroring `network-adapters.ts`'s `resolveMonitorBase`
+ * precedence but from a {@link LoadedConfig}: derive from the stack's nats
+ * config file (`http_port`/`monitor_port`/`http`), else the upstream default.
+ * Pure/read-only; a missing/unreadable config falls back to the default base.
+ */
+function resolveMonitorBaseFromLoaded(cfg: LoadedConfig): string {
+  const configPath = expandTilde(cfg.stack?.nats_infra?.config_path ?? "");
+  if (configPath.length > 0 && existsSync(configPath)) {
+    try {
+      const derived = natsConfigMonitorUrl(readFileSync(configPath, "utf-8"));
+      if (derived !== undefined) return derived.replace(/\/+$/, "");
+    } catch {
+      // Unreadable nats config — fall back to the default base. Best-effort:
+      // the sampler is additive diagnostic context, never a gate (see below).
+    }
+  }
+  return DEFAULT_MONITOR_BASE;
+}
+
+/**
+ * cortex#1728 (guard 4) — a live {@link LeafzSamplerPort} over the nats-server
+ * `/leafz` monitor endpoint. Sums `out_msgs` / `in_msgs` across the reported
+ * leaf connections (a federating stack typically carries the network on a single
+ * leaf; summing yields the aggregate egress/ingress the delta test needs).
+ *
+ * BEST-EFFORT by contract: every failure path (monitor unreachable, non-200,
+ * malformed body, timeout) resolves `undefined`, so the ping proceeds without a
+ * diagnostic line and NEVER fails on account of the sampler.
+ */
+export function createLiveLeafzSampler(cfg: LoadedConfig): LeafzSamplerPort {
+  const base = resolveMonitorBaseFromLoaded(cfg);
+  return {
+    async sample(): Promise<LeafzCounters | undefined> {
+      // Bound the fetch: a monitor that accepts the TCP connection but never
+      // responds (hung nats-server) must not hang the ping.
+      const controller = new AbortController();
+      const timer = setTimeout(() => {
+        controller.abort();
+      }, LEAFZ_FETCH_TIMEOUT_MS);
+      try {
+        const res = await fetch(`${base}/leafz`, { signal: controller.signal });
+        if (!res.ok) return undefined;
+        const body = (await res.json()) as {
+          leafs?: { in_msgs?: number; out_msgs?: number }[];
+        };
+        const leafs = body.leafs ?? [];
+        if (leafs.length === 0) return undefined;
+        let outMsgs = 0;
+        let inMsgs = 0;
+        for (const leaf of leafs) {
+          if (typeof leaf.out_msgs === "number") outMsgs += leaf.out_msgs;
+          if (typeof leaf.in_msgs === "number") inMsgs += leaf.in_msgs;
+        }
+        return { outMsgs, inMsgs };
+      } catch {
+        // Monitor genuinely unreachable / aborted — degrade to "no sample".
+        // The orchestrator omits the diagnostic line; the ping is unaffected.
+        return undefined;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
 }

--- a/src/cli/cortex/commands/network-ping-adapters.ts
+++ b/src/cli/cortex/commands/network-ping-adapters.ts
@@ -25,6 +25,7 @@ import { expandTilde } from "../../../common/config/loader";
 import { natsConfigMonitorUrl } from "../../../common/nats/leaf-remote-renderer";
 import type { MyelinRuntime, BusEnvelopeSigner } from "../../../bus/myelin/runtime";
 import { startMyelinRuntime } from "../../../bus/myelin/runtime";
+import { selectNetworkLeaf } from "./network-doctor-lib";
 import type {
   LeafzCounters,
   LeafzSamplerPort,
@@ -187,18 +188,28 @@ function resolveMonitorBaseFromLoaded(cfg: LoadedConfig): string {
 
 /**
  * cortex#1728 (guard 4) — a live {@link LeafzSamplerPort} over the nats-server
- * `/leafz` monitor endpoint. Sums `out_msgs` / `in_msgs` across the reported
- * leaf connections (a federating stack typically carries the network on a single
- * leaf; summing yields the aggregate egress/ingress the delta test needs).
+ * `/leafz` monitor endpoint, SCOPED to the pinged network's own leaf.
+ *
+ * A host runs SEVERAL leaves that all dial the same hub ip:port (this stack:
+ * metafactory + community + halden), so summing `out_msgs`/`in_msgs` across all
+ * of them picks up other networks' heartbeat traffic and MISATTRIBUTES the
+ * diagnosis — e.g. metafactory egress dead (out+0 on that leaf) while community
+ * ticks out+2 would sum to out+2 and MASK the local-egress break, the exact
+ * failure guard 4 exists to catch (#1731 review BLOCK). We therefore select the
+ * ONE leaf attributable to the `leafNode` via the SHARED {@link selectNetworkLeaf}
+ * attribution `doctor` uses (name/account match, or the lone-leaf fallback on a
+ * single-leaf bus), and read only that leaf's counters. When the target leaf
+ * cannot be uniquely identified (2+ leaves, no name match) we return `undefined`
+ * — omit the diagnostic, never misattribute.
  *
  * BEST-EFFORT by contract: every failure path (monitor unreachable, non-200,
- * malformed body, timeout) resolves `undefined`, so the ping proceeds without a
- * diagnostic line and NEVER fails on account of the sampler.
+ * malformed body, timeout, no unique leaf) resolves `undefined`, so the ping
+ * proceeds without a diagnostic line and NEVER fails on account of the sampler.
  */
 export function createLiveLeafzSampler(cfg: LoadedConfig): LeafzSamplerPort {
   const base = resolveMonitorBaseFromLoaded(cfg);
   return {
-    async sample(): Promise<LeafzCounters | undefined> {
+    async sample(leafNode: string): Promise<LeafzCounters | undefined> {
       // Bound the fetch: a monitor that accepts the TCP connection but never
       // responds (hung nats-server) must not hang the ping.
       const controller = new AbortController();
@@ -209,17 +220,15 @@ export function createLiveLeafzSampler(cfg: LoadedConfig): LeafzSamplerPort {
         const res = await fetch(`${base}/leafz`, { signal: controller.signal });
         if (!res.ok) return undefined;
         const body = (await res.json()) as {
-          leafs?: { in_msgs?: number; out_msgs?: number }[];
+          leafs?: { account?: string; name?: string; in_msgs?: number; out_msgs?: number }[];
         };
-        const leafs = body.leafs ?? [];
-        if (leafs.length === 0) return undefined;
-        let outMsgs = 0;
-        let inMsgs = 0;
-        for (const leaf of leafs) {
-          if (typeof leaf.out_msgs === "number") outMsgs += leaf.out_msgs;
-          if (typeof leaf.in_msgs === "number") inMsgs += leaf.in_msgs;
-        }
-        return { outMsgs, inMsgs };
+        // Scope to THIS network's leaf only — never sum across sibling leaves.
+        const match = selectNetworkLeaf(body, leafNode);
+        if (match === undefined) return undefined;
+        return {
+          outMsgs: typeof match.leaf.out_msgs === "number" ? match.leaf.out_msgs : 0,
+          inMsgs: typeof match.leaf.in_msgs === "number" ? match.leaf.in_msgs : 0,
+        };
       } catch {
         // Monitor genuinely unreachable / aborted — degrade to "no sample".
         // The orchestrator omits the diagnostic line; the ping is unaffected.

--- a/src/cli/cortex/commands/network-ping-lib.ts
+++ b/src/cli/cortex/commands/network-ping-lib.ts
@@ -35,7 +35,10 @@ import {
   type ProbeEchoReplyPayload,
 } from "../../../bus/probe-responder";
 import type { LoadedConfig } from "../../../common/config/loader";
-import type { NetworkPingPorts } from "./network-ping-ports";
+import type {
+  LeafzCounters,
+  NetworkPingPorts,
+} from "./network-ping-ports";
 
 // ---------------------------------------------------------------------------
 // Config derivation (the #753 config-derivation seam, ping subset)
@@ -225,6 +228,39 @@ export interface PingStats {
   rttMaxMs?: number;
 }
 
+/**
+ * cortex#1728 (guard 4) — which half of the leaf path a `timeout` failure lives
+ * on, folded from the local `/leafz` counter delta measured across the probe
+ * volley.
+ *
+ *   - `remote`       — probes crossed the leaf (`out` +N) but no echo returned
+ *                      (`in` +0): the peer responder / echo leg is broken, NOT
+ *                      our egress.
+ *   - `local-egress` — nothing left the leaf (`out` +0): OUR egress is broken
+ *                      (leaf account / binding), not the peer.
+ *   - `inconclusive` — counters moved in a shape that does not cleanly
+ *                      disambiguate (e.g. `out` +0 AND `in` +N, or unchanged
+ *                      because another sender shares the leaf): report the raw
+ *                      delta without a directional claim.
+ */
+export type LeafzHalf = "remote" | "local-egress" | "inconclusive";
+
+/**
+ * cortex#1728 (guard 4) — the structured leafz diagnosis attached to a ping
+ * result. Present only when a before/after `/leafz` sample was obtained AND the
+ * verdict is `timeout` (the only verdict the half-disambiguation informs).
+ */
+export interface LeafzDiagnosis {
+  /** Which half the failure is on. */
+  half: LeafzHalf;
+  /** `out_msgs` delta across the probe volley (probes that left the leaf). */
+  outDelta: number;
+  /** `in_msgs` delta across the probe volley (echoes that returned). */
+  inDelta: number;
+  /** The rendered, human-facing diagnostic line. */
+  line: string;
+}
+
 export interface PingResult {
   /** The overall verdict — the worst/most-informative across all probes. */
   verdict: PingVerdict;
@@ -233,6 +269,12 @@ export interface PingResult {
   stats: PingStats;
   /** Human-facing reason when not reachable (surfaced in the CLI output). */
   detail?: string;
+  /**
+   * cortex#1728 (guard 4) — best-effort local-`/leafz` half-disambiguation for a
+   * `timeout` verdict. Absent when no leafz sampler was wired, a sample failed,
+   * or the verdict is not `timeout`. Additive diagnostic context; never gates.
+   */
+  leafz?: LeafzDiagnosis;
 }
 
 // ---------------------------------------------------------------------------
@@ -365,6 +407,84 @@ export function classifyRoundTrip(
 }
 
 // ---------------------------------------------------------------------------
+// cortex#1728 (guard 4) — leafz half-disambiguation
+// ---------------------------------------------------------------------------
+
+/**
+ * cortex#1728 (guard 4) — diagnose WHICH half of the leaf path a `timeout`
+ * failure lives on, from the local `/leafz` counter delta measured across the
+ * probe volley.
+ *
+ * Live evidence (the first two-principal join): the monitor delta was decisive
+ * both times.
+ *
+ *   - `out` incremented, `in` +0 ⇒ probes crossed the leaf but no echo returned
+ *     ⇒ the failure is REMOTE (peer responder / echo leg), not local egress;
+ *   - `out` +0 ⇒ nothing left the leaf ⇒ LOCAL egress is broken (leaf
+ *     account/binding), not the peer.
+ *
+ * Any other shape (e.g. `out` +0 AND `in` +N, or a negative delta from a
+ * counter reset / reconnect between samples) is `inconclusive` — report the raw
+ * numbers without a directional claim rather than assert a wrong half.
+ *
+ * PURE — no I/O; the ports supply the two samples. Returns `undefined` when
+ * either sample is missing (nothing to diff) so the caller omits the line.
+ */
+export function diagnoseLeafzDelta(
+  before: LeafzCounters | undefined,
+  after: LeafzCounters | undefined,
+): LeafzDiagnosis | undefined {
+  if (before === undefined || after === undefined) return undefined;
+  const outDelta = after.outMsgs - before.outMsgs;
+  const inDelta = after.inMsgs - before.inMsgs;
+
+  // A negative delta means the counter went BACKWARDS between samples (leaf
+  // reconnect / server restart reset the counters) — the diff is meaningless,
+  // so we cannot claim a half.
+  if (outDelta < 0 || inDelta < 0) {
+    return {
+      half: "inconclusive",
+      outDelta,
+      inDelta,
+      line: `leafz counters moved unexpectedly (out ${fmtDelta(outDelta)}, in ${fmtDelta(inDelta)}) — leaf may have reconnected mid-probe; cannot localise the failure`,
+    };
+  }
+
+  if (outDelta > 0 && inDelta === 0) {
+    return {
+      half: "remote",
+      outDelta,
+      inDelta,
+      line: `${outDelta} probe(s) crossed the leaf (out ${fmtDelta(outDelta)}) but no echo returned (in +0) — the failure is REMOTE (peer responder / echo leg), not local egress`,
+    };
+  }
+
+  if (outDelta === 0) {
+    return {
+      half: "local-egress",
+      outDelta,
+      inDelta,
+      line: `0 probes left the leaf (out +0) — LOCAL egress is broken (leaf account/binding, not the peer)`,
+    };
+  }
+
+  // out +N AND in +N, or any other non-directional shape: a reply DID come back
+  // over the leaf yet the ping still timed out (nonce mismatch, slow echo,
+  // shared-leaf noise). Report the raw delta without asserting a half.
+  return {
+    half: "inconclusive",
+    outDelta,
+    inDelta,
+    line: `leaf counters advanced on both legs (out ${fmtDelta(outDelta)}, in ${fmtDelta(inDelta)}) but the probe timed out — traffic crossed both ways; the failure is not a clean egress/echo split`,
+  };
+}
+
+/** Format a non-negative counter delta as `+N` (negatives kept as-is). */
+function fmtDelta(n: number): string {
+  return n >= 0 ? `+${n}` : String(n);
+}
+
+// ---------------------------------------------------------------------------
 // The orchestrator
 // ---------------------------------------------------------------------------
 
@@ -394,6 +514,11 @@ export async function pingPeer(
     inputs.requesterPrincipal,
     inputs.requesterStack,
   );
+
+  // cortex#1728 (guard 4) — sample the local leaf's `/leafz` counters BEFORE the
+  // probe volley so a `timeout` verdict can be localised to a half from the
+  // delta. Best-effort: a missing/failed sample just omits the diagnostic line.
+  const leafzBefore = await sampleLeafzBestEffort(ports);
 
   for (let seq = 1; seq <= inputs.count; seq++) {
     const nonce = ports.newNonce();
@@ -430,6 +555,13 @@ export async function pingPeer(
     }
   }
 
+  // cortex#1728 (guard 4) — sample AFTER the volley; diff against the before
+  // sample to localise the failure. Only meaningful for `timeout` (the verdict
+  // whose four-way cause list this delta disambiguates); computed here but
+  // attached below only when the overall verdict is `timeout`.
+  const leafzAfter = await sampleLeafzBestEffort(ports);
+  const leafzDiagnosis = diagnoseLeafzDelta(leafzBefore, leafzAfter);
+
   // Overall verdict: reachable iff at least one probe got a conformant echo.
   // Otherwise pick the most-informative failure across the probes
   // (no-responder > refused > timeout > not-configured precedence — a
@@ -458,7 +590,35 @@ export async function pingPeer(
     ...(detail !== undefined && overall !== "reachable"
       ? { detail: failureDetail(overall, inputs) }
       : {}),
+    // cortex#1728 (guard 4) — fold the leafz half-disambiguation into a
+    // `timeout` verdict only (the verdict whose ambiguous cause list it
+    // resolves). Omitted for reachable / not-configured, and whenever no
+    // before/after sample was obtained.
+    ...(overall === "timeout" && leafzDiagnosis !== undefined
+      ? { leafz: leafzDiagnosis }
+      : {}),
   };
+}
+
+/**
+ * cortex#1728 (guard 4) — read the local `/leafz` counters if a sampler is
+ * wired, swallowing ANY failure to a `undefined`. The whole guard is additive
+ * diagnostic context: a leafz read must NEVER fail or perturb the ping.
+ */
+async function sampleLeafzBestEffort(
+  ports: NetworkPingPorts,
+): Promise<LeafzCounters | undefined> {
+  if (ports.leafz === undefined) return undefined;
+  try {
+    return await ports.leafz.sample();
+  } catch (err) {
+    // Best-effort: a failed leafz read degrades to "no diagnostic line", never
+    // a failed ping. Log to stderr so the read failure is not silent.
+    process.stderr.write(
+      `network-ping: leafz sample failed (diagnostic line omitted): ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return undefined;
+  }
 }
 
 /** Pick the overall verdict from the per-probe verdicts. */

--- a/src/cli/cortex/commands/network-ping-lib.ts
+++ b/src/cli/cortex/commands/network-ping-lib.ts
@@ -126,12 +126,26 @@ export function derivePingInputs(opts: {
     opts.network !== undefined
       ? networks.filter((n) => n.id === opts.network)
       : networks;
-  const isConfiguredPeer = scoped.some((n) =>
+  const matchingNetworks = scoped.filter((n) =>
     n.peers.some(
       (p) =>
         p.principal_id === opts.targetPrincipal && p.stack_id === targetStackId,
     ),
   );
+  const isConfiguredPeer = matchingNetworks.length > 0;
+
+  // cortex#1728 (guard 4) — the network's `leaf_node` scopes the leafz sampler.
+  // Resolve it ONLY when exactly one network carries this peer with a distinct
+  // leaf_node: if the peer sits on multiple networks with DIFFERENT leaves (no
+  // `--network` selector), we can't tell which leaf the probe rides, so we leave
+  // it undefined (the sampler omits the diagnostic rather than sample the wrong
+  // leaf). Two networks that share ONE `leaf_node` (the pool-key case) collapse
+  // to that single unambiguous leaf.
+  const distinctLeafNodes = [
+    ...new Set(matchingNetworks.map((n) => n.leaf_node)),
+  ];
+  const networkLeafNode =
+    distinctLeafNodes.length === 1 ? distinctLeafNodes[0] : undefined;
 
   return {
     ok: true,
@@ -145,6 +159,7 @@ export function derivePingInputs(opts: {
       count: opts.count,
       timeoutMs: opts.timeoutMs,
       isConfiguredPeer,
+      ...(networkLeafNode !== undefined && { networkLeafNode }),
     },
   };
 }
@@ -209,6 +224,16 @@ export interface PingInputs {
    * caller from config; `false` ⇒ `not-configured` (nothing emitted).
    */
   isConfiguredPeer: boolean;
+  /**
+   * cortex#1728 (guard 4) — the `leaf_node` name of the network the probe rides
+   * (the network whose `peers[]` contains the target). The leafz sampler scopes
+   * its `/leafz` read to THIS leaf so the counter delta reflects only this
+   * network's traffic, never a sibling leaf's heartbeats. `undefined` when the
+   * network's `leaf_node` can't be resolved (peer in multiple networks with no
+   * `--network` selector, or none declares a leaf_node) — the sampler then omits
+   * the diagnostic rather than misattribute.
+   */
+  networkLeafNode?: string;
 }
 
 /** One probe's result row (for per-seq reporting). */
@@ -515,10 +540,12 @@ export async function pingPeer(
     inputs.requesterStack,
   );
 
-  // cortex#1728 (guard 4) — sample the local leaf's `/leafz` counters BEFORE the
-  // probe volley so a `timeout` verdict can be localised to a half from the
-  // delta. Best-effort: a missing/failed sample just omits the diagnostic line.
-  const leafzBefore = await sampleLeafzBestEffort(ports);
+  // cortex#1728 (guard 4) — sample THIS network's leaf `/leafz` counters BEFORE
+  // the probe volley so a `timeout` verdict can be localised to a half from the
+  // delta. Scoped to `inputs.networkLeafNode` (never summed across sibling
+  // leaves — the #1731 review BLOCK). Best-effort: an unresolvable leaf_node or
+  // a failed sample just omits the diagnostic line.
+  const leafzBefore = await sampleLeafzBestEffort(ports, inputs.networkLeafNode);
 
   for (let seq = 1; seq <= inputs.count; seq++) {
     const nonce = ports.newNonce();
@@ -559,7 +586,7 @@ export async function pingPeer(
   // sample to localise the failure. Only meaningful for `timeout` (the verdict
   // whose four-way cause list this delta disambiguates); computed here but
   // attached below only when the overall verdict is `timeout`.
-  const leafzAfter = await sampleLeafzBestEffort(ports);
+  const leafzAfter = await sampleLeafzBestEffort(ports, inputs.networkLeafNode);
   const leafzDiagnosis = diagnoseLeafzDelta(leafzBefore, leafzAfter);
 
   // Overall verdict: reachable iff at least one probe got a conformant echo.
@@ -601,16 +628,20 @@ export async function pingPeer(
 }
 
 /**
- * cortex#1728 (guard 4) — read the local `/leafz` counters if a sampler is
- * wired, swallowing ANY failure to a `undefined`. The whole guard is additive
- * diagnostic context: a leafz read must NEVER fail or perturb the ping.
+ * cortex#1728 (guard 4) — read THIS network's leaf `/leafz` counters if a
+ * sampler is wired AND the network's `leaf_node` is known, swallowing ANY
+ * failure to `undefined`. The whole guard is additive diagnostic context: a
+ * leafz read must NEVER fail or perturb the ping. A missing `leafNode` (peer on
+ * multiple networks with no `--network` selector) omits the sample rather than
+ * risk sampling the wrong leaf.
  */
 async function sampleLeafzBestEffort(
   ports: NetworkPingPorts,
+  leafNode: string | undefined,
 ): Promise<LeafzCounters | undefined> {
-  if (ports.leafz === undefined) return undefined;
+  if (ports.leafz === undefined || leafNode === undefined) return undefined;
   try {
-    return await ports.leafz.sample();
+    return await ports.leafz.sample(leafNode);
   } catch (err) {
     // Best-effort: a failed leafz read degrades to "no diagnostic line", never
     // a failed ping. Log to stderr so the read failure is not silent.

--- a/src/cli/cortex/commands/network-ping-ports.ts
+++ b/src/cli/cortex/commands/network-ping-ports.ts
@@ -71,10 +71,57 @@ export interface ProbeBusPort {
   fireProbe(inputs: ProbeFireInputs): Promise<ProbeRoundTripResult>;
 }
 
+/**
+ * cortex#1728 (guard 4) — a single `/leafz` counter reading for the local leaf
+ * carrying THIS network's federated traffic.
+ *
+ * `out_msgs` / `in_msgs` from the nats-server monitor `/leafz` surface, keyed to
+ * the network's own leaf. The orchestrator samples this BEFORE and AFTER the
+ * probe volley and diffs the two, so a `timeout` verdict can say WHICH half is
+ * broken instead of listing four undifferentiated candidate causes:
+ *
+ *   - `out` incremented, `in` did not ⇒ probes crossed the leaf but no echo
+ *     returned ⇒ the failure is REMOTE (peer responder / echo leg);
+ *   - `out` did not move ⇒ nothing left the leaf ⇒ LOCAL egress is broken
+ *     (leaf account/binding), not the peer.
+ */
+export interface LeafzCounters {
+  /** Messages SENT over the network's leaf since connect (`out_msgs`). */
+  outMsgs: number;
+  /** Messages RECEIVED over the network's leaf since connect (`in_msgs`). */
+  inMsgs: number;
+}
+
+/**
+ * cortex#1728 (guard 4) — best-effort sampler for the local leaf's `/leafz`
+ * counters. The live adapter reads the nats-server monitor; tests inject a fake
+ * returning controlled deltas.
+ *
+ * OPTIONAL on {@link NetworkPingPorts} and BEST-EFFORT: a `sample()` returning
+ * `undefined` (monitor unreachable, no matching leaf, malformed body) MUST NOT
+ * fail the ping — the orchestrator simply omits the extra diagnostic line. This
+ * is additive diagnostic context, never a gate.
+ */
+export interface LeafzSamplerPort {
+  /**
+   * Read the current `out_msgs` / `in_msgs` for the network's leaf, or
+   * `undefined` when it cannot be read. NEVER throws — a failed read resolves
+   * `undefined` so the ping proceeds unaffected.
+   */
+  sample(): Promise<LeafzCounters | undefined>;
+}
+
 /** The ports bundle (room to grow — clock, etc., stay injectable). */
 export interface NetworkPingPorts {
   bus: ProbeBusPort;
   /** Monotonic-ish nonce + correlation id source (testable). */
   newNonce(): string;
   newCorrelationId(): string;
+  /**
+   * cortex#1728 (guard 4) — OPTIONAL local-`/leafz` sampler. When present, the
+   * orchestrator samples before/after the probes and folds the counter delta
+   * into a `timeout` verdict ("probes crossed the leaf — failure is remote" vs
+   * "nothing left the leaf — local egress broken"). Absent ⇒ no extra line.
+   */
+  leafz?: LeafzSamplerPort;
 }

--- a/src/cli/cortex/commands/network-ping-ports.ts
+++ b/src/cli/cortex/commands/network-ping-ports.ts
@@ -94,21 +94,30 @@ export interface LeafzCounters {
 
 /**
  * cortex#1728 (guard 4) — best-effort sampler for the local leaf's `/leafz`
- * counters. The live adapter reads the nats-server monitor; tests inject a fake
- * returning controlled deltas.
+ * counters, SCOPED to a single network's leaf. The live adapter reads the
+ * nats-server monitor; tests inject a fake returning controlled deltas.
  *
  * OPTIONAL on {@link NetworkPingPorts} and BEST-EFFORT: a `sample()` returning
- * `undefined` (monitor unreachable, no matching leaf, malformed body) MUST NOT
- * fail the ping — the orchestrator simply omits the extra diagnostic line. This
- * is additive diagnostic context, never a gate.
+ * `undefined` (monitor unreachable, no UNIQUELY-identifiable leaf for this
+ * network, malformed body) MUST NOT fail the ping — the orchestrator simply
+ * omits the extra diagnostic line. Additive diagnostic context, never a gate.
+ *
+ * SCOPING (the #1731 review BLOCK): a host runs several leaves that share the
+ * same hub ip:port, so summing counters across ALL of them picks up other
+ * networks' heartbeat traffic and MISATTRIBUTES the diagnosis. `sample()` takes
+ * the pinged network's `leafNode` name and reads ONLY that leaf's counters;
+ * when the target leaf cannot be uniquely identified it returns `undefined`
+ * (omit the line — never misattribute).
  */
 export interface LeafzSamplerPort {
   /**
-   * Read the current `out_msgs` / `in_msgs` for the network's leaf, or
-   * `undefined` when it cannot be read. NEVER throws — a failed read resolves
-   * `undefined` so the ping proceeds unaffected.
+   * Read the current `out_msgs` / `in_msgs` for THE `leafNode` network's leaf
+   * only, or `undefined` when that leaf cannot be uniquely identified / read.
+   * `leafNode` is the network's configured `leaf_node` (the rendered leaf-remote
+   * name cortex writes into `leafnodes-<network>.conf`). NEVER throws — a failed
+   * read resolves `undefined` so the ping proceeds unaffected.
    */
-  sample(): Promise<LeafzCounters | undefined>;
+  sample(leafNode: string): Promise<LeafzCounters | undefined>;
 }
 
 /** The ports bundle (room to grow — clock, etc., stay injectable). */

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -1786,7 +1786,7 @@ function renderPingResult(
     lines.push(`verdict: ${res.verdict}${res.detail !== undefined ? ` — ${res.detail}` : ""}`);
   }
   // cortex#1728 (guard 4) — when local `/leafz` was sampled around a `timeout`,
-  // append the half-disambiguation line so the operator knows WHICH leg to chase
+  // append the half-disambiguation line so it is clear WHICH leg to chase
   // instead of the four-way guess in the verdict detail.
   if (res.leafz !== undefined) {
     lines.push(`leafz: ${res.leafz.line}`);

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -159,6 +159,7 @@ import {
   type OwnAdmissionState,
 } from "../../../common/registry/admission-state";
 import {
+  createLiveLeafzSampler,
   createLiveProbeBus,
   type LiveProbeBus,
 } from "./network-ping-adapters";
@@ -1618,6 +1619,11 @@ const DEFAULT_PING_BUS_FACTORY: PingBusFactory = async (cfg) => {
     bus,
     newNonce: () => crypto.randomUUID(),
     newCorrelationId: () => crypto.randomUUID(),
+    // cortex#1728 (guard 4) — wire the best-effort local `/leafz` sampler so a
+    // `timeout` verdict is localised to a half (our egress vs the peer's echo
+    // leg) from the counter delta. Best-effort: a failed read just omits the
+    // extra line.
+    leafz: createLiveLeafzSampler(cfg),
   };
   return { ports, stop: () => bus.stop() };
 };
@@ -1744,6 +1750,14 @@ function renderPingResult(
         ...(res.stats.rttAvgMs !== undefined && { rtt_avg_ms: res.stats.rttAvgMs.toFixed(1) }),
         ...(res.stats.rttMaxMs !== undefined && { rtt_max_ms: String(res.stats.rttMaxMs) }),
         ...(res.detail !== undefined && { detail: res.detail }),
+        // cortex#1728 (guard 4) — machine-readable leafz half-disambiguation for
+        // a `timeout` verdict. Present only when a before/after sample was read.
+        ...(res.leafz !== undefined && {
+          leafz_half: res.leafz.half,
+          leafz_out_delta: String(res.leafz.outDelta),
+          leafz_in_delta: String(res.leafz.inDelta),
+          leafz_diagnosis: res.leafz.line,
+        }),
       },
     );
     // JSON goes to stdout regardless of exit code so a verdict is always
@@ -1770,6 +1784,12 @@ function renderPingResult(
   }
   if (res.verdict !== "reachable") {
     lines.push(`verdict: ${res.verdict}${res.detail !== undefined ? ` — ${res.detail}` : ""}`);
+  }
+  // cortex#1728 (guard 4) — when local `/leafz` was sampled around a `timeout`,
+  // append the half-disambiguation line so the operator knows WHICH leg to chase
+  // instead of the four-way guess in the verdict detail.
+  if (res.leafz !== undefined) {
+    lines.push(`leafz: ${res.leafz.line}`);
   }
   const body = lines.join("\n") + "\n";
   // Reachable → stdout/exit 0; any failure verdict → stderr + the verdict's
@@ -1815,6 +1835,10 @@ const DEFAULT_DOCTOR_PORTS_FACTORY: DoctorPortsFactory = async (cfg, livePortsCf
       bus,
       newNonce: () => crypto.randomUUID(),
       newCorrelationId: () => crypto.randomUUID(),
+      // cortex#1728 (guard 4) — the same best-effort `/leafz` sampler `ping`
+      // wires, so doctor's peer-reachable leg can localise a `timeout` to a half
+      // (our egress vs the peer's echo leg). Best-effort: a failed read omits it.
+      leafz: createLiveLeafzSampler(cfg),
     },
   };
   return { ports, stop: () => bus.stop() };


### PR DESCRIPTION
## What

Guard 4 from **#1728** (its own lane — guards 1-3 land separately). `cortex network ping` (and `doctor`'s peer-reachable leg) now fold the local nats-server `/leafz` counter delta into a `timeout` verdict, so a failure says **which half is broken** instead of the current four-way guess (*"peer offline, leaf down, hub partition, or not gated in"*).

## Why (live evidence)

During the first two-principal operator-mode join (#1728), the `/leafz` counters were decisive **every time**:

- `out` incrementing + `in` +0 ⇒ probes are crossing the leaf but no echo returns ⇒ the failure is **REMOTE** (peer responder / echo leg).
- `out` static (+0) ⇒ nothing left the leaf ⇒ **LOCAL egress** is broken (leaf account/binding), not the peer.

That distinction re-routed ~an hour of debugging each time it was read by hand. This makes the tool read it automatically.

## How (additive + best-effort)

- New **optional** `LeafzSamplerPort` on `NetworkPingPorts`. `pingPeer` samples before/after the probe volley; a failed/absent read (monitor unreachable, non-200, malformed, timeout, no sampler wired) **omits the diagnostic line and never fails the ping**.
- Pure `diagnoseLeafzDelta(before, after)` computes the delta + half + rendered line. `out+/in0 ⇒ remote`, `out+0 ⇒ local-egress`; negative deltas (counter reset / reconnect) and `out+/in+` shapes report `inconclusive` rather than assert a wrong half.
- Structured `PingResult.leafz` field + a rendered `leafz:` line (human) and `leafz_half` / `leafz_*_delta` / `leafz_diagnosis` keys (`--json`).
- `doctor`'s `timeout` remediation is sharpened to the localised half when the delta disambiguates it (else the existing peer/hub guidance).
- Live `createLiveLeafzSampler` reads the monitor URL from the stack's nats config (`http_port`/`monitor_port`/`http`, default `:8222`), bounded fetch, sums counters across leafs.

**Unchanged:** the probe envelope, subjects, and the verdict enum semantics — this is additive diagnostic context only.

## Files

- `network-ping-ports.ts` — `LeafzCounters`, `LeafzSamplerPort`, optional `leafz` on `NetworkPingPorts`
- `network-ping-lib.ts` — `LeafzHalf`/`LeafzDiagnosis` types, pure `diagnoseLeafzDelta`, sample+fold in `pingPeer`, `PingResult.leafz`
- `network-ping-adapters.ts` — live `createLiveLeafzSampler` (`/leafz` reader)
- `network-doctor-lib.ts` — timeout leg folds the half into detail + remediation
- `network.ts` — wires the live sampler into the ping + doctor factories; renders the line (human + `--json`)

## Tests

Fake leafz sampler with controlled counter deltas:
- pure `diagnoseLeafzDelta`: out+/in0 ⇒ remote, out+0 ⇒ local-egress, both-legs ⇒ inconclusive, negative ⇒ inconclusive, missing sample ⇒ undefined
- `pingPeer` fold: remote/local-egress on `timeout`; reachable ⇒ no fold; no-sampler / throws / undefined ⇒ no line, ping still succeeds
- doctor timeout leg: out+/in0 ⇒ REMOTE detail + `peer/echo leg` fix; out+0 ⇒ LOCAL egress detail + `local egress` fix

## Verify

- `bunx tsc --noEmit` — clean
- `bun test network-ping-*.test.ts network-doctor*.test.ts` — 80 pass / 0 fail
- `bunx eslint --quiet <changed>` — clean

Refs #1728 (guard 4; guards 1-3 land separately — do NOT auto-close the umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)