### PR TITLE
fix(cli): C-1742 — provision-stack register auto-derives --registry-pubkey from config pin

### DIFF
--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -17,7 +17,7 @@ import { mkdtempSync, rmSync, statSync, readFileSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { dispatchProvisionStack } from "../provision-stack";
+import { dispatchProvisionStack, resolveRegistryPubkey } from "../provision-stack";
 // C-819 — seed an existing principal that ALREADY announces network caps (the
 // CLI register path announces none), so the add-stack preservation can be
 // asserted end-to-end. Same NKey root the CLI uses, so the rotation gate admits
@@ -549,13 +549,17 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
       ]);
       expect(first.exitCode).toBe(0);
 
-      // Add-stack WITHOUT --registry-pubkey: the destructive merge-read cannot be
-      // verified, so the command MUST fail closed rather than re-attest off an
-      // unverifiable read. The existing meta-factory stack is preserved.
+      // Add-stack WITHOUT --registry-pubkey AND with a --config that carries no
+      // pin (cortex#1742 — the fallback source): the destructive merge-read
+      // cannot be verified, so the command MUST fail closed rather than re-attest
+      // off an unverifiable read. The existing meta-factory stack is preserved.
+      // (--config points at a nonexistent path so the fallback finds no pin AND
+      // the test never reads the real ~/.config/cortex/cortex.yaml — hermetic.)
       const add = await dispatchProvisionStack([
         "register", "andreas", "--seed-path", communitySeed,
         "--stack-id", "andreas/community", "--principal-seed", rootSeed,
         "--registry-url", "http://registry.test",
+        "--config", join(dir, "no-such-config.yaml"),
       ]);
       expect(add.exitCode).toBe(1);
       expect(add.stderr).toMatch(/no pinned registry pubkey|unverif/i);
@@ -1073,5 +1077,51 @@ describe("cortex provision-stack retire (C-1351 Slice 2 #1351)", () => {
     ]);
     expect(res.exitCode).toBe(2);
     expect(res.stderr).toMatch(/--stack-id is required/);
+  });
+});
+
+// =============================================================================
+// cortex#1742 — resolveRegistryPubkey precedence (flag > config pin > none)
+// =============================================================================
+describe("cortex#1742 — resolveRegistryPubkey", () => {
+  const ctx = (flags: Record<string, string | boolean | undefined>) => ({
+    principalId: "andreas",
+    flags: flags as Parameters<typeof resolveRegistryPubkey>[0]["flags"],
+    json: false,
+  });
+  const CONFIG_PIN = "ErrjFoLzi4jw7TuTqjPMg5OnQCH0oKUClWgr8VyYHmk=";
+  const cfgWithPin = () => ({ policy: { federated: { registry: { pubkey: CONFIG_PIN } } } });
+  const cfgNoPin = () => ({ policy: { federated: {} } });
+  const cfgThrows = () => { throw new Error("ENOENT: no cortex.yaml"); };
+
+  test("flag WINS over the config pin", () => {
+    const r = resolveRegistryPubkey(ctx({ "--registry-pubkey": "FLAGPIN=" }), cfgWithPin);
+    expect(r).toEqual({ ok: true, pubkey: "FLAGPIN=" });
+  });
+
+  test("no flag → falls back to policy.federated.registry.pubkey from config", () => {
+    const r = resolveRegistryPubkey(ctx({}), cfgWithPin);
+    expect(r).toEqual({ ok: true, pubkey: CONFIG_PIN });
+  });
+
+  test("no flag + config has no pin → undefined (downstream fail-closed)", () => {
+    const r = resolveRegistryPubkey(ctx({}), cfgNoPin);
+    expect(r).toEqual({ ok: true, pubkey: undefined });
+  });
+
+  test("no flag + unreadable config → undefined, never throws (best-effort)", () => {
+    const r = resolveRegistryPubkey(ctx({}), cfgThrows);
+    expect(r).toEqual({ ok: true, pubkey: undefined });
+  });
+
+  test("malformed flag value (bare --registry-pubkey) → usage error", () => {
+    const r = resolveRegistryPubkey(ctx({ "--registry-pubkey": true }), cfgWithPin);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/requires a value/);
+  });
+
+  test("empty-string config pin is treated as absent (undefined)", () => {
+    const r = resolveRegistryPubkey(ctx({}), () => ({ policy: { federated: { registry: { pubkey: "" } } } }));
+    expect(r).toEqual({ ok: true, pubkey: undefined });
   });
 });

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -49,7 +49,7 @@
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 
-import { expandTilde } from "../../../common/config/loader";
+import { expandTilde, loadConfigWithAgents } from "../../../common/config/loader";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
 import {
   resolveOwnAdmissionState,
@@ -148,6 +148,11 @@ const SPEC: SubcommandSpec<ProvisionSubcommand> = {
         // admission into. Signed into the claim; the register hook stamps it
         // onto the PENDING admission row (per-network idempotency).
         "--network": "value",
+        // C-1742 — override the config file resolveRegistryPubkey reads the
+        // pinned pubkey from when --registry-pubkey is omitted. Defaults to
+        // ~/.config/cortex/cortex.yaml; scoped per-stack deployments point it
+        // at their stack's config.
+        "--config": "value",
       },
     },
   },
@@ -253,6 +258,57 @@ interface HandlerCtx {
   principalId: string;
   flags: FlagMap;
   json: boolean;
+}
+
+/** Default cortex config path — mirrors `cortex network`'s DEFAULT_CONFIG_PATH. */
+const DEFAULT_CONFIG_PATH = "~/.config/cortex/cortex.yaml";
+
+/**
+ * cortex#1742 — resolve the pinned registry pubkey with precedence
+ * `--registry-pubkey` flag > `policy.federated.registry.pubkey` from the cortex
+ * config (the SAME pin `cortex network join` reads), so an add-stack register
+ * need not re-supply on the command line.
+ *
+ * Best-effort on the config read: a missing/unreadable config or an absent pin
+ * returns `undefined`, leaving the add-stack merge-read to FAIL CLOSED downstream
+ * (C-791 — abort rather than overwrite; the June cap-wipe guard is untouched).
+ * Never throws. Returns `{ ok:false }` only for a malformed FLAG value (a
+ * usage error the caller surfaces), never for a config-read failure.
+ */
+/** Minimal config shape this resolver needs — an injection seam for tests. */
+type RegistryPinConfigReader = (path: string) => {
+  policy?: { federated?: { registry?: { pubkey?: string } } };
+};
+
+export function resolveRegistryPubkey(
+  ctx: HandlerCtx,
+  // Injectable for tests; production uses the real loader (reads ~/.config/cortex).
+  loadConfig: RegistryPinConfigReader = loadConfigWithAgents,
+): { ok: true; pubkey: string | undefined } | { ok: false; reason: string } {
+  const pubkeyFlag = ctx.flags["--registry-pubkey"];
+  if (pubkeyFlag !== undefined) {
+    if (pubkeyFlag === true || typeof pubkeyFlag !== "string") {
+      return { ok: false, reason: "--registry-pubkey requires a value" };
+    }
+    return { ok: true, pubkey: pubkeyFlag };
+  }
+  // Flag absent — fall back to the config pin (best-effort).
+  const cfgFlag = ctx.flags["--config"];
+  const cfgPath = expandTilde(typeof cfgFlag === "string" ? cfgFlag : DEFAULT_CONFIG_PATH);
+  try {
+    const cfg = loadConfig(cfgPath);
+    const pin = cfg.policy?.federated?.registry?.pubkey;
+    return { ok: true, pubkey: typeof pin === "string" && pin.length > 0 ? pin : undefined };
+  } catch (err) {
+    // Config unreadable/absent → no fallback pin. The add-stack path fail-closes
+    // downstream with its own actionable message; log per the no-empty-catch rule.
+    process.stderr.write(
+      `provision-stack register: could not read policy.federated.registry.pubkey from ${cfgPath} ` +
+        `(${err instanceof Error ? err.message : String(err)}) — pass --registry-pubkey explicitly ` +
+        `if this add-stack register needs the pinned merge-read.\n`,
+    );
+    return { ok: true, pubkey: undefined };
+  }
 }
 
 async function runGenerate(ctx: HandlerCtx): Promise<ExitResult> {
@@ -403,16 +459,14 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
     rootMaterial = rootRes.material;
   }
 
-  // C-791 (security) — optional pinned registry pubkey. The add-stack merge-read
-  // is verified against it (fail closed when absent on the add-stack path).
-  const pubkeyFlag = ctx.flags["--registry-pubkey"];
-  let registryPubkey: string | undefined;
-  if (pubkeyFlag !== undefined) {
-    if (pubkeyFlag === true || typeof pubkeyFlag !== "string") {
-      return usageError("register", "--registry-pubkey requires a value", ctx.json);
-    }
-    registryPubkey = pubkeyFlag;
-  }
+  // C-791 (security) — the pinned registry pubkey verifies the add-stack
+  // merge-read (fail closed when absent on the add-stack path).
+  // cortex#1742 — precedence: --registry-pubkey flag > policy.federated.registry.pubkey
+  // from config, so the principal need not re-supply a pin their config already has.
+  // Absent from BOTH on the add-stack path stays fail-closed downstream.
+  const pubkeyRes = resolveRegistryPubkey(ctx);
+  if (!pubkeyRes.ok) return usageError("register", pubkeyRes.reason, ctx.json);
+  const registryPubkey = pubkeyRes.pubkey;
 
   // ADR-0018 Gap-A — optional target network for the admission request.
   const networkRes = resolveNetworkId(ctx.flags["--network"]);

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -294,8 +294,12 @@ export function resolveRegistryPubkey(
   }
   // Flag absent — fall back to the config pin (best-effort).
   const cfgFlag = ctx.flags["--config"];
-  const cfgPath = expandTilde(typeof cfgFlag === "string" ? cfgFlag : DEFAULT_CONFIG_PATH);
+  const cfgRaw = typeof cfgFlag === "string" ? cfgFlag : DEFAULT_CONFIG_PATH;
+  // expandTilde inside the try: it throws when $HOME is unset (loader.ts), and
+  // the best-effort contract must hold there too — degrade to undefined, never throw.
+  let cfgPath = cfgRaw;
   try {
+    cfgPath = expandTilde(cfgRaw);
     const cfg = loadConfig(cfgPath);
     const pin = cfg.policy?.federated?.registry?.pubkey;
     return { ok: true, pubkey: typeof pin === "string" && pin.length > 0 ? pin : undefined };


### PR DESCRIPTION
## What

`cortex provision-stack register` now derives the pinned registry pubkey from `policy.federated.registry.pubkey` in config when `--registry-pubkey` is omitted, so a principal adding a 2nd+ stack no longer has to re-type a pin their config already carries.

**Precedence:** `--registry-pubkey` flag → `policy.federated.registry.pubkey` (read from `--config` or the default `~/.config/cortex/cortex.yaml`) → `undefined`.

## Why

The add-stack path (`--principal-seed`) uses the pinned pubkey to signature-verify the merge-read of the principal's existing stacks **before** the destructive full-overwrite re-attestation (C-791 fail-closed, the June cap-wipe fix). The pin is already in config; requiring it on the flag every time was pure friction. #1742 is filed as ergonomic — the safety is already fail-closed.

## Safety unchanged

A missing pin on the add-stack path still fails closed downstream (`fetchExistingStacks` returns `kind:"error"`, aborting rather than overwriting). This PR only changes where the pin is *sourced* from, never whether it's *required* for the verified read.

- Config read is **best-effort**: an unreadable/absent config → `undefined` + a one-line stderr hint, never a throw (a first registration doesn't need it).
- `resolveRegistryPubkey` is exported + takes an injectable config reader for hermetic unit testing.

## Tests

- New `resolveRegistryPubkey` unit suite: flag-wins-over-config, config-fallback, empty/absent pin → undefined, unreadable config → undefined (never throws), bare `--registry-pubkey` → usage error.
- Existing C-791 fail-closed test pinned to a nonexistent `--config` for hermeticity (the suite doesn't isolate `HOME`, so the default-config fallback would otherwise read the real `~/.config/cortex/cortex.yaml`).
- 33/33 provision-stack tests pass · tsc 0 · eslint clean · vocab carve-out gate PASS.

Closes #1742