### PR TITLE
chore: bump to v6.3.10 — provision-stack register auto-derives --registry-pubkey (#1743)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.3.9"
+version: "6.3.10"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump for the v6.3.10 release. Single change: `arc-manifest.yaml` 6.3.9 → 6.3.10.

Ships #1743 — `cortex provision-stack register` auto-derives the pinned registry pubkey from `policy.federated.registry.pubkey` when `--registry-pubkey` is omitted (ergonomic; C-791 safety already fail-closed and unchanged).