### PR TITLE
sync(pylon): regenerate persona schema from AMT grill contract (AMT #3277, #3279-#3284)

### DIFF
--- a/personas/pylon.md
+++ b/personas/pylon.md
@@ -111,12 +111,12 @@ When the room reaches a settled decision, PROPOSE it — phrase the message as "
 Field shapes:
 - `message` — markdown, <=120 words.
 - `term` (kind=result) — `{term, definition, aka?, avoid?, source?}`. `aka` — other names participants actually use for the same concept; recording many names is expected and correct; never pick a winner; when adding a name to a settled term, copy its definition verbatim.
-- `contract_new` (kind=contract_create) — `{from, to, name?, transport?, payload?, key_fields?, owner?}`; direction from→to is the authoritative flow.
+- `contract_new` (kind=contract_create) — `{from, to, name?, transport?, payload?, purpose?, owner?}`; direction from→to is the authoritative flow.
 - `adr` (optional, only a hard-to-reverse + surprising trade-off) — `{title, body}`.
-- `ci_fact` (kind=cmdb_fact) — `{ci, field, value, reason?}`; field ∈ owner | lifecycle | type | note.
-- `contract_fact` (kind=contract_fact) — `{field, value, reason?}`; field ∈ transport | payload | key_fields | owner | status | description | completeness | interface_owner | data_owner | business_data_steward | technical_data_steward.
+- `ci_fact` (kind=cmdb_fact) — `{ci, field, value, reason?}`; field ∈ owner | lifecycle | type | note. When field=lifecycle, value ∈ target | phase-in | current | retiring | retired; when field=type, value ∈ application | saas | platform | database | integration | infrastructure; owner/note are free text.
+- `contract_fact` (kind=contract_fact) — `{field, value, reason?}`; field ∈ transport | payload | purpose | owner | description | completeness | interface_owner.
 - `route_to` (kind=route) — `{email, reason?}`; email must be one listed under '## Routable people' in the grounding — never invent one. Use when a participant says the open question is for a named person ("that's one for X" / "hand over to X" / "ask X"); the question moves to that person's inbox.
-- `master` (kind=master_fact) — `{ci, data_domain, sor_status, evidence, context, subject_term?, share?, notes?, reason?}`; records which GOVERNED DATA DOMAIN this system is the system-of-record for. `data_domain` ∈ the governed taxonomy (docs/registry/data-domains.yaml); `sor_status` ∈ confirmed | candidate | not_authoritative; `evidence` ∈ owner_confirmed | assumed_from_mapping; `context` is a context-slug; `subject_term` optionally links a finer glossary term. A broker/transport CI is `not_authoritative`, not omitted.
+- `master` (kind=master_fact) — `{ci, data_asset, sor_status, evidence, subject_term?, notes?, reason?}`; records which GOVERNED DATA ASSET this system is the system-of-record for — a GLOBAL claim, one per (system, data_asset), never per-context. `data_asset` ∈ the governed taxonomy (docs/registry/data-domains.yaml); `sor_status` ∈ confirmed | candidate | not_authoritative; `evidence` ∈ owner_confirmed | assumed_from_mapping; `subject_term` optionally links a finer glossary term. A broker/transport CI is `not_authoritative`, not omitted.
 - `topic` — always include (<=60 chars).
 - `next_question` / `next_topic` (with a result follow-up) — <=400 / <=60 chars.
 <!-- END GENERATED: pylon-persona-schema -->


### PR DESCRIPTION
Batched persona re-sync from the AMT model-review feedback session. Same mechanism as #1726 — mechanical splice between the GENERATED markers in `personas/pylon.md` from `amt/shared/generated/pylon-persona-schema.md` (source: `shared/src/grill-schema.ts`, amt main `58e40ae`).

**What Pylon learns:**
- `master_fact` is now a **global** claim — `{ci, data_asset, sor_status, evidence, subject_term?, notes?}`; `data_domain`→`data_asset`, per-context `context`/`share` gone (AMT #3277, ADR-0006)
- `contract_fact` is lean: `transport | payload | purpose | owner | description | completeness | interface_owner` — status + governance fields removed, `key_fields`→`purpose` (AMT #3279/#3280/#3281)
- `contract_new` proposes `purpose` instead of `key_fields` (AMT #3284)
- `ci_fact` states the value vocabularies inline: lifecycle ∈ `target|phase-in|current|retiring|retired`, type ∈ `application|saas|platform|database|integration|infrastructure` (AMT #3282/#3273)

**Rollout safety:** AMT receivers tolerate stale-persona fields (map or refuse-with-vocabulary, never wedge), and legacy names stay accepted transitionally — so persona and app can deploy in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)