### PR TITLE
feat(cortex): dispatch lifecycle → agent-state work items (#1720 S3)

### DIFF
--- a/src/bus/__tests__/brain-consumer.test.ts
+++ b/src/bus/__tests__/brain-consumer.test.ts
@@ -171,6 +171,54 @@ function published(runtime: RecordingRuntime, type: string): Envelope[] {
 }
 
 // ---------------------------------------------------------------------------
+// cortex#1720 S3 — dispatch-lifecycle state recorder fixtures
+// ---------------------------------------------------------------------------
+
+import type {
+  DispatchStateRecorder,
+  DispatchWorkItemMeta,
+  DispatchResolveStatus,
+} from "../../common/agents/dispatch-state-recorder";
+
+interface RecorderCall {
+  op: "accept" | "resolve";
+  meta?: DispatchWorkItemMeta;
+  correlationId?: string;
+  status?: DispatchResolveStatus;
+}
+
+/** An in-memory fake recorder — records calls, spawns nothing. */
+function fakeRecorder(): { recorder: DispatchStateRecorder; calls: RecorderCall[] } {
+  const calls: RecorderCall[] = [];
+  const recorder: DispatchStateRecorder = {
+    onDispatchAccepted(meta) {
+      calls.push({ op: "accept", meta });
+    },
+    onDispatchResolved(correlationId, status) {
+      calls.push({ op: "resolve", correlationId, status });
+    },
+  };
+  return { recorder, calls };
+}
+
+/**
+ * A recorder whose methods THROW — proves the consumer's fire-and-forget call
+ * never lets a state-write failure fail the dispatch. (In production the
+ * SubprocessDispatchStateRecorder is itself total; this is the belt-and-braces
+ * probe that the consumer does not depend on that.)
+ */
+function throwingRecorder(): DispatchStateRecorder {
+  return {
+    onDispatchAccepted() {
+      throw new Error("state enqueue blew up");
+    },
+    onDispatchResolved() {
+      throw new Error("state resolve blew up");
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Pure helpers
 // ---------------------------------------------------------------------------
 
@@ -828,6 +876,168 @@ describe("BrainConsumer — backpressure + failure", () => {
     const failed = published(runtime, "dispatch.task.failed");
     expect(failed.length).toBe(1);
     expect((failed[0]?.payload as { reason?: { kind?: string } }).reason?.kind).toBe("not_now");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#1720 S3 — dispatch lifecycle → AgentState work_items
+// ---------------------------------------------------------------------------
+
+describe("BrainConsumer — dispatch state recording (cortex#1720 S3)", () => {
+  test("STATEFUL: accepted dispatch enqueues+claims, completed resolves done", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    const { recorder, calls } = fakeRecorder();
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        stateRecorder: recorder,
+        runBrainTask: stubRunner(completeResult(env.id, "done")),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(env, "local.jc.s.brain.soc.compose.flow", null, "soc.compose.flow");
+
+    expect(decision).toEqual({ kind: "ack" });
+    // Accept recorded once (enqueue+claim happen INSIDE the recorder), then a
+    // single done-resolve on the completed terminal.
+    expect(calls.length).toBe(2);
+    const accept = calls[0]!;
+    expect(accept.op).toBe("accept");
+    expect(accept.meta?.correlationId).toBe(env.id);
+    expect(accept.meta?.capability).toBe("soc.compose.flow");
+    expect(accept.meta?.subject).toBe("local.jc.s.brain.soc.compose.flow");
+    // Payload discipline is enforced in the recorder's own unit tests; here we
+    // assert the consumer hands it QUEUE METADATA (a timestamp, no payload body).
+    expect(typeof accept.meta?.acceptedAt).toBe("string");
+    const resolve = calls[1]!;
+    expect(resolve).toEqual({ op: "resolve", correlationId: env.id, status: "done" });
+  });
+
+  test("STATEFUL: genuinely-terminal failure (wont_do) resolves failed", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    const { recorder, calls } = fakeRecorder();
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        stateRecorder: recorder,
+        runBrainTask: stubRunner({
+          v: 1,
+          type: "result",
+          task_id: env.id,
+          status: "failed",
+          reason: { kind: "wont_do", detail: "policy" },
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    // wont_do → term (genuinely terminal) → resolve failed.
+    expect(decision.kind).toBe("term");
+    expect(calls[0]?.op).toBe("accept");
+    expect(calls[1]).toEqual({ op: "resolve", correlationId: env.id, status: "failed" });
+  });
+
+  test("STATEFUL: not_now failure is a RETRY (nak) — does NOT resolve the work_item", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    const { recorder, calls } = fakeRecorder();
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        stateRecorder: recorder,
+        runBrainTask: stubRunner({
+          v: 1,
+          type: "result",
+          task_id: env.id,
+          status: "failed",
+          reason: { kind: "not_now", detail: "transient", retry_after_ms: 100 },
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+
+    // not_now → nak-with-redelivery: the row stays in_flight for the retry.
+    expect(decision.kind).toBe("nak");
+    expect(calls.length).toBe(1); // accept only, NO resolve.
+    expect(calls[0]?.op).toBe("accept");
+  });
+
+  test("STATELESS: no recorder → dispatch takes ZERO state code paths (never records)", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    // baseOpts with NO stateRecorder — the stateless default.
+    const consumer = new BrainConsumer(
+      baseOpts({ runtime, runBrainTask: stubRunner(completeResult(env.id, "done")) }),
+    );
+
+    // The proof that matters is at construction (recorder undefined); the
+    // behavioural check is simply that the dispatch completes normally with no
+    // recorder to consult. A throwing recorder test below covers the wired path.
+    const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+    expect(decision).toEqual({ kind: "ack" });
+    expect(published(runtime, "dispatch.task.completed").length).toBe(1);
+  });
+
+  test("backpressure-rejected dispatch is NEVER recorded (rejected before accept)", async () => {
+    const runtime = createRecordingRuntime();
+    const { recorder, calls } = fakeRecorder();
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const env1 = makeTaskEnvelope();
+    const env2 = makeTaskEnvelope();
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        stateRecorder: recorder,
+        agent: buildAgent({ maxConcurrent: 1 }),
+        runBrainTask: async (task): Promise<BrainTaskRunResult> => {
+          await gate;
+          return { result: completeResult(task.task_id), logs: [], stderrTail: "", exitCode: 0 };
+        },
+      }),
+    );
+
+    const first = consumer.processEnvelope(env1, "s", null, "soc.compose.flow");
+    await new Promise((r) => setTimeout(r, 20));
+    const second = await consumer.processEnvelope(env2, "s", null, "soc.compose.flow");
+
+    expect(second.kind).toBe("nak");
+    // The first task was accepted → exactly ONE accept for env1. The second was
+    // backpressure-rejected BEFORE the accept point → no accept for env2.
+    const accepts = calls.filter((c) => c.op === "accept");
+    expect(accepts.length).toBe(1);
+    expect(accepts[0]?.meta?.correlationId).toBe(env1.id);
+
+    release();
+    await first;
+    // After env1 completes, its done-resolve lands — still nothing for env2.
+    const acceptCorrIds = calls.filter((c) => c.op === "accept").map((c) => c.meta?.correlationId);
+    expect(acceptCorrIds).not.toContain(env2.id);
+  });
+
+  test("a state-write failure NEVER fails the dispatch (fire-and-forget, non-fatal)", async () => {
+    const runtime = createRecordingRuntime();
+    const env = makeTaskEnvelope();
+    const consumer = new BrainConsumer(
+      baseOpts({
+        runtime,
+        stateRecorder: throwingRecorder(),
+        runBrainTask: stubRunner(completeResult(env.id, "done")),
+      }),
+    );
+
+    // Both the accept-side and resolve-side recorder calls throw; the dispatch
+    // must still complete cleanly (ack + completed envelope published).
+    const decision = await consumer.processEnvelope(env, "subj", null, "soc.compose.flow");
+    expect(decision).toEqual({ kind: "ack" });
+    expect(published(runtime, "dispatch.task.started").length).toBe(1);
+    expect(published(runtime, "dispatch.task.completed").length).toBe(1);
   });
 });
 

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -98,6 +98,7 @@ import type {
   BrainTaskHooks,
 } from "../brain/exec-brain-runner";
 import type { DaemonBrainHost } from "../brain/daemon-brain-host";
+import type { DispatchStateRecorder } from "../common/agents/dispatch-state-recorder";
 import type {
   TaskEvent,
   TaskSource,
@@ -241,6 +242,20 @@ export interface BrainConsumerBaseOpts {
   sovereigntyEnforce?: boolean;
   /** Test seam — clock. Defaults to `() => new Date()`. */
   clock?: () => Date;
+  /**
+   * cortex#1720 S3 — OPT-IN dispatch-lifecycle → AgentState work_items recorder.
+   *
+   * Present ONLY for a `state:`-declaring (STATEFUL) agent — the boot wiring
+   * constructs it behind `if (agent.state)` and threads it here. A stateless
+   * agent omits it, so the consumer's `this.stateRecorder?.…` calls short-circuit
+   * to undefined and stateless dispatch takes ZERO new code paths (the gate is at
+   * construction, not a per-envelope string check).
+   *
+   * The recorder is FIRE-AND-FORGET + NON-FATAL: the consumer never awaits it on
+   * the dispatch hot path and never fails a dispatch because a state write
+   * failed. See {@link DispatchStateRecorder}.
+   */
+  stateRecorder?: DispatchStateRecorder;
 }
 
 /**
@@ -336,6 +351,11 @@ export class BrainConsumer {
   private readonly principalGate: PrincipalGate;
   private readonly sovereigntyEnforce: boolean;
   private readonly clock: () => Date;
+  /**
+   * cortex#1720 S3 — the dispatch-lifecycle state recorder, or undefined for a
+   * stateless agent. Undefined ⇒ every `this.stateRecorder?.…` call is a no-op.
+   */
+  private readonly stateRecorder: DispatchStateRecorder | undefined;
 
   /** The manifest dispatch allow-list, as a Set for O(1) membership. */
   private readonly dispatchAllow: Set<string>;
@@ -368,6 +388,7 @@ export class BrainConsumer {
     this.principalGate = opts.principalGate ?? new DenyAllPrincipalGate();
     this.sovereigntyEnforce = opts.sovereigntyEnforce ?? false;
     this.clock = opts.clock ?? (() => new Date());
+    this.stateRecorder = opts.stateRecorder;
     this.dispatchAllow = new Set(opts.agent.dispatchCapabilities);
   }
 
@@ -444,13 +465,17 @@ export class BrainConsumer {
    * Pipeline:
    *   1. backpressure gate (over `maxConcurrent` → nak `not_now`);
    *   2. sovereignty gate (envelope demand vs. agent model class);
-   *   3. emit `dispatch.task.started`;
+   *   3. emit `dispatch.task.started` + (cortex#1720 S3, stateful only)
+   *      enqueue+claim the AgentState work_item — the ACCEPT point, AFTER the
+   *      gates, so a backpressure-rejected dispatch is never recorded;
    *   4. run the brain (effects routed to host hooks);
-   *   5. publish the terminal `dispatch.task.completed`/`failed` + map the ack.
+   *   5. publish the terminal `dispatch.task.completed`/`failed` + map the ack
+   *      + (S3, stateful only) resolve the work_item done/failed on a genuine
+   *      terminal (a nak-redelivery leaves the row `in_flight` for the retry).
    */
   async processEnvelope(
     envelope: Envelope,
-    _subject: string,
+    subject: string,
     msg: JsMsg | null,
     capability: string,
   ): Promise<AckDecision> {
@@ -515,6 +540,12 @@ export class BrainConsumer {
     }
 
     // 3. Emit dispatch.task.started — paired with the terminal via correlation.
+    //
+    //    This is the ACCEPT point: the task cleared backpressure, sovereignty,
+    //    and the shutdown guard, so we now durably owe a response. A `not_now`
+    //    backpressure rejection returned ABOVE (before this line), so a
+    //    backpressure-rejected dispatch is NEVER enqueued — there is no work item
+    //    to record for a task we did not accept (cortex#1720 S3 design decision).
     const startedAt = this.clock();
     await this.safePublish(
       createDispatchTaskStartedEvent({
@@ -525,6 +556,20 @@ export class BrainConsumer {
         startedAt,
       }),
       "dispatch.task.started",
+    );
+
+    // cortex#1720 S3 — record the accepted dispatch as an AgentState work_item
+    // (enqueue → claim). OPT-IN: `stateRecorder` is undefined for a stateless
+    // agent, so this is a no-op. NON-FATAL: wrapped so a state-write failure
+    // (even a synchronous throw from a mis-behaving recorder) NEVER fails the
+    // dispatch — the production recorder is itself total, this is belt-and-braces.
+    this.recordState(() =>
+      this.stateRecorder?.onDispatchAccepted({
+        correlationId,
+        capability,
+        subject,
+        acceptedAt: startedAt.toISOString(),
+      }),
     );
 
     // 4+5. Run the brain, then publish the terminal envelope + map the ack.
@@ -667,8 +712,15 @@ export class BrainConsumer {
       if (!ok) {
         // Terminal publish lost — redeliver so the result is not silently
         // dropped. `delayMs: 0` lets JetStream re-deliver on its own cadence.
+        // Deliberately DO NOT resolve the work_item here: the task is being
+        // redelivered, not finished — the row stays `in_flight` and S2's
+        // ReplayPending re-surfaces it if the daemon stops before the retry.
         return { kind: "nak", delayMs: 0 };
       }
+      // cortex#1720 S3 — GENUINE terminal success: the completed envelope
+      // published, so the work_item is done. Resolve (no-op for a stateless
+      // agent; non-fatal on any failure).
+      this.recordState(() => this.stateRecorder?.onDispatchResolved(correlationId, "done"));
       return { kind: "ack" };
     }
 
@@ -678,10 +730,44 @@ export class BrainConsumer {
     if (!failedOk) {
       // Same rule as the completed path: a dropped `dispatch.task.failed` is a
       // lost terminal result — nak-with-redelivery rather than ack the failure
-      // into the void.
+      // into the void. As above, leave the work_item `in_flight` for the retry.
       return { kind: "nak", delayMs: 0 };
     }
-    return failedReasonToAckDecision(reason);
+    // cortex#1720 S3 — resolve the work_item to `failed` ONLY on a GENUINELY
+    // terminal failure. A `not_now` reason maps to a nak-with-redelivery (the
+    // brain asked to be retried): the row must stay `in_flight` so the redelivery
+    // re-runs and S2's ReplayPending re-surfaces it across a restart — resolving
+    // it `failed` here would strand a task that is going to run again. Every
+    // other reason (`wont_do` / `cant_do` / `policy_denied` / …) maps to `term`
+    // (the task is done, unsuccessfully) → resolve `failed`.
+    const ackDecision = failedReasonToAckDecision(reason);
+    if (ackDecision.kind !== "nak") {
+      this.recordState(() => this.stateRecorder?.onDispatchResolved(correlationId, "failed"));
+    }
+    return ackDecision;
+  }
+
+  /**
+   * cortex#1720 S3 — run a state-recording call defensively. The dispatch hot
+   * path must NEVER see a state-write failure: a thrown recorder call is caught
+   * and logged, and the dispatch proceeds. The production
+   * `SubprocessDispatchStateRecorder` is itself total (it logs + returns on any
+   * bundle miss), so this is the belt-and-braces layer that also covers a
+   * mis-behaving injected recorder. Synchronous by design — the recorder's
+   * subprocesses are a few ms and off the awaited critical path (called after the
+   * lifecycle envelope is already published), so blocking the caller is not worth
+   * the added concurrency surface of an un-awaited promise here.
+   */
+  private recordState(fn: () => void): void {
+    if (this.stateRecorder === undefined) return;
+    try {
+      fn();
+    } catch (err) {
+      process.stderr.write(
+        `brain-consumer: dispatch state recording failed for agent=${this.agent.id} ` +
+          `(non-fatal): ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
   }
 
   /**

--- a/src/common/agents/__tests__/agent-state-scaffold.test.ts
+++ b/src/common/agents/__tests__/agent-state-scaffold.test.ts
@@ -290,3 +290,119 @@ describe("replayPending — bundle-absent path", () => {
     expect(result.pendingCount).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#1720 stack-top hardening pass (S1/S2 review findings)
+// ---------------------------------------------------------------------------
+
+describe("replayPending — hardening", () => {
+  test("ENOBUFS (maxBuffer overflow) → distinct output-too-large skip, NOT spawn-error", () => {
+    const errandsScript = join(root, "errands.ts");
+    writeFileSync(errandsScript, "// stub\n");
+    const enobufs = Object.assign(new Error("stdout maxBuffer exceeded"), {
+      code: "ENOBUFS",
+    });
+    const spawn: ReplaySpawn = () => ({ status: null, error: enobufs });
+
+    const result = replayPending(AGENT, { instanceDir, errandsScript, spawn });
+
+    expect(result.ran).toBe(false);
+    // A legit large backlog is NOT a broken install — it gets its own reason.
+    expect(result.skipReason).toBe("output-too-large");
+  });
+
+  test("a non-ENOBUFS spawn error still maps to spawn-error", () => {
+    const errandsScript = join(root, "errands.ts");
+    writeFileSync(errandsScript, "// stub\n");
+    const timedOut = Object.assign(new Error("spawnSync bun ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    const spawn: ReplaySpawn = () => ({ status: null, error: timedOut });
+
+    const result = replayPending(AGENT, { instanceDir, errandsScript, spawn });
+
+    expect(result.skipReason).toBe("spawn-error");
+  });
+
+  test("only lines starting with `{` are counted (diagnostic banner ignored)", () => {
+    const errandsScript = join(root, "errands.ts");
+    writeFileSync(errandsScript, "// stub\n");
+    const spawn: ReplaySpawn = () => ({
+      status: 0,
+      stdout:
+        "warning: bundle diagnostic line\n" +
+        JSON.stringify({ id: "wi-1", status: "pending" }) +
+        "\n" +
+        JSON.stringify({ id: "wi-2", status: "pending" }) +
+        "\n",
+    });
+
+    const result = replayPending(AGENT, { instanceDir, errandsScript, spawn });
+
+    expect(result.ran).toBe(true);
+    // 3 non-blank lines, but only 2 start with `{`.
+    expect(result.pendingCount).toBe(2);
+  });
+
+  test("$HOME unset + no explicit instanceDir → home-unset soft-skip, no spawn", () => {
+    const savedHome = process.env.HOME;
+    delete process.env.HOME;
+    let spawned = false;
+    const spawn: ReplaySpawn = () => {
+      spawned = true;
+      return { status: 0 };
+    };
+    try {
+      // No instanceDir passed — forces the HOME-derived path resolution.
+      const result = replayPending(AGENT, { spawn });
+      expect(spawned).toBe(false);
+      expect(result.ran).toBe(false);
+      expect(result.skipReason).toBe("home-unset");
+    } finally {
+      if (savedHome !== undefined) process.env.HOME = savedHome;
+    }
+  });
+});
+
+describe("scaffoldInstance — hardening", () => {
+  test("$HOME unset + no explicit instanceDir → skipped-home-unset, no mkdir/spawn", () => {
+    const savedHome = process.env.HOME;
+    delete process.env.HOME;
+    let spawned = false;
+    const spawn: ScaffoldSpawn = () => {
+      spawned = true;
+      return { status: 0 };
+    };
+    try {
+      const result = scaffoldInstance(AGENT, { spawn });
+      expect(spawned).toBe(false);
+      expect(result.strategy).toBe("skipped-home-unset");
+      expect(result.created).toEqual([]);
+    } finally {
+      if (savedHome !== undefined) process.env.HOME = savedHome;
+    }
+  });
+
+  test("MF_AGENT_STATE_ERRANDS_SCRIPT is read PER CALL, not frozen at import", () => {
+    // Point the errands resolver at a real file via env AFTER module import;
+    // replayPending must honour it (proves the resolver isn't a frozen const).
+    const errandsScript = join(root, "late-errands.ts");
+    writeFileSync(errandsScript, "// stub\n");
+    const savedEnv = process.env.MF_AGENT_STATE_ERRANDS_SCRIPT;
+    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT = errandsScript;
+    let sawScript: string | undefined;
+    const spawn: ReplaySpawn = (_cmd, args) => {
+      sawScript = args[0];
+      return { status: 0, stdout: "" };
+    };
+    try {
+      // No errandsScript in opts — forces the env/default resolution path.
+      const result = replayPending(AGENT, { instanceDir, spawn });
+      expect(result.ran).toBe(true);
+      expect(sawScript).toBe(errandsScript);
+    } finally {
+      if (savedEnv !== undefined) process.env.MF_AGENT_STATE_ERRANDS_SCRIPT = savedEnv;
+      else delete process.env.MF_AGENT_STATE_ERRANDS_SCRIPT;
+    }
+  });
+});

--- a/src/common/agents/__tests__/dispatch-state-recorder.test.ts
+++ b/src/common/agents/__tests__/dispatch-state-recorder.test.ts
@@ -1,0 +1,323 @@
+/**
+ * cortex#1720 S3 — unit tests for the dispatch-lifecycle state recorder.
+ *
+ * Covers the enqueue→claim on accept, resolve on terminal, the in-flight
+ * correlation→work_item map, and the SOFT-SKIP / NON-FATAL guarantees:
+ *   - accept spawns `errands.ts enqueue` (payload = QUEUE METADATA ONLY, no
+ *     prompt/message body) then `errands.ts claim`, with the standard env
+ *     (MF_AGENT_NAME / MF_HOST / MF_INSTANCE_DIR);
+ *   - a completed dispatch spawns `resolve --status=done`; a failed one
+ *     `resolve --status=failed`, targeting the id `enqueue` returned;
+ *   - a resolve for an id we never enqueued is a logged no-op (never fabricates);
+ *   - a missing bundle script SOFT-SKIPS the whole accept (no spawn), and the
+ *     paired resolve is itself a logged no-op;
+ *   - a non-zero exit / spawn error on any subcommand logs one line and NEVER
+ *     throws (the dispatch hot path must not see a state failure).
+ *
+ * No real `bun` subprocess, no `~/.config` touch — every path is driven through
+ * the `errandsScript` / `spawn` / `log` test seams.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  SubprocessDispatchStateRecorder,
+  type RecorderSpawn,
+  type RecorderSpawnResult,
+} from "../dispatch-state-recorder";
+
+const AGENT = { id: "luna" };
+
+let root: string;
+let errandsScript: string;
+let instanceDir: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cortex-recorder-"));
+  errandsScript = join(root, "errands.ts");
+  instanceDir = join(root, "agents", "luna");
+  writeFileSync(errandsScript, "// stub errands.ts\n");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+interface SpawnCall {
+  cmd: string;
+  args: string[];
+  env?: NodeJS.ProcessEnv;
+}
+
+/** A recording spawn that returns a scripted result per subcommand. */
+function recordingSpawn(
+  results: Record<string, RecorderSpawnResult>,
+): { spawn: RecorderSpawn; calls: SpawnCall[] } {
+  const calls: SpawnCall[] = [];
+  const spawn: RecorderSpawn = (cmd, args, opts) => {
+    calls.push({ cmd, args, env: opts.env });
+    // args = [errandsScript, subcommand, ...]. Route on the subcommand.
+    const sub = args[1] ?? "";
+    return results[sub] ?? { status: 0 };
+  };
+  return { spawn, calls };
+}
+
+/** The `{ inserted, row }` shape the real `errands.ts enqueue` prints. */
+function enqueueStdout(id: string): string {
+  return JSON.stringify({ inserted: true, row: { id, kind: "k", status: "pending" } });
+}
+
+describe("SubprocessDispatchStateRecorder — accept: enqueue + claim", () => {
+  test("spawns enqueue then claim with the standard env + payload discipline", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-1") },
+      claim: { status: 0 },
+    });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchAccepted({
+      correlationId: "corr-1",
+      capability: "soc.review",
+      subject: "local.jc.stack.brain.soc.review",
+      acceptedAt: "2026-07-09T00:00:00.000Z",
+    });
+
+    expect(calls.length).toBe(2);
+
+    // 1) enqueue --id corr-1 --kind soc.review --payload <json> --owner luna
+    const enqueue = calls[0]!;
+    expect(enqueue.cmd).toBe("bun");
+    expect(enqueue.args[1]).toBe("enqueue");
+    expect(enqueue.args).toContain("--id");
+    expect(enqueue.args[enqueue.args.indexOf("--id") + 1]).toBe("corr-1");
+    expect(enqueue.args[enqueue.args.indexOf("--kind") + 1]).toBe("soc.review");
+    expect(enqueue.args[enqueue.args.indexOf("--owner") + 1]).toBe("luna");
+
+    // Payload is QUEUE METADATA ONLY — correlation id + subject + capability +
+    // timestamp. NEVER a prompt / message body (§3).
+    const payloadStr = enqueue.args[enqueue.args.indexOf("--payload") + 1]!;
+    const payload = JSON.parse(payloadStr) as Record<string, unknown>;
+    expect(payload).toEqual({
+      correlation_id: "corr-1",
+      subject: "local.jc.stack.brain.soc.review",
+      capability: "soc.review",
+      accepted_at: "2026-07-09T00:00:00.000Z",
+    });
+    // Belt-and-braces: no content-ish keys leaked into the payload.
+    for (const forbidden of ["text", "prompt", "message", "scenario", "content", "payload"]) {
+      expect(forbidden in payload).toBe(false);
+    }
+
+    // Standard env contract, exactly as S1/S2.
+    expect(enqueue.env?.MF_AGENT_NAME).toBe("luna");
+    expect(enqueue.env?.MF_HOST).toBe("cortex");
+    expect(enqueue.env?.MF_INSTANCE_DIR).toBe(instanceDir);
+
+    // 2) claim --id corr-1 --owner luna (the id echoed by enqueue's row).
+    const claim = calls[1]!;
+    expect(claim.args[1]).toBe("claim");
+    expect(claim.args[claim.args.indexOf("--id") + 1]).toBe("corr-1");
+    expect(claim.args[claim.args.indexOf("--owner") + 1]).toBe("luna");
+  });
+
+  test("claims the work_item id echoed by enqueue's row, not the correlation id", () => {
+    // The bundle echoes `--id`, so row.id === correlationId here; but the
+    // recorder reads it BACK from the row to stay honest to the bundle's id.
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("bundle-id-xyz") },
+      claim: { status: 0 },
+    });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchAccepted({
+      correlationId: "corr-2",
+      capability: "c",
+      subject: "s",
+      acceptedAt: "t",
+    });
+
+    const claim = calls[1]!;
+    expect(claim.args[claim.args.indexOf("--id") + 1]).toBe("bundle-id-xyz");
+  });
+});
+
+describe("SubprocessDispatchStateRecorder — terminal: resolve", () => {
+  test("completed → resolve --status=done targeting the enqueued id", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-3") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+    });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-3", capability: "c", subject: "s", acceptedAt: "t" });
+    recorder.onDispatchResolved("corr-3", "done");
+
+    const resolve = calls.find((c) => c.args[1] === "resolve")!;
+    expect(resolve).toBeDefined();
+    expect(resolve.args[resolve.args.indexOf("--id") + 1]).toBe("corr-3");
+    expect(resolve.args[resolve.args.indexOf("--status") + 1]).toBe("done");
+    expect(resolve.env?.MF_INSTANCE_DIR).toBe(instanceDir);
+  });
+
+  test("failed → resolve --status=failed", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-4") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+    });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-4", capability: "c", subject: "s", acceptedAt: "t" });
+    recorder.onDispatchResolved("corr-4", "failed");
+
+    const resolve = calls.find((c) => c.args[1] === "resolve")!;
+    expect(resolve.args[resolve.args.indexOf("--status") + 1]).toBe("failed");
+  });
+
+  test("resolve for an id we never enqueued is a logged no-op (never fabricates)", () => {
+    const { spawn, calls } = recordingSpawn({ resolve: { status: 0 } });
+    const logs: string[] = [];
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: (l) => logs.push(l),
+    });
+
+    recorder.onDispatchResolved("unknown-corr", "done");
+
+    // No resolve spawned — we only resolve ids we created.
+    expect(calls.length).toBe(0);
+    expect(logs.join("")).toMatch(/no-work-item/);
+  });
+
+  test("the in-flight id is cleared after resolve (a second resolve is a no-op)", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-5") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+    });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-5", capability: "c", subject: "s", acceptedAt: "t" });
+    recorder.onDispatchResolved("corr-5", "done");
+    const afterFirst = calls.filter((c) => c.args[1] === "resolve").length;
+    recorder.onDispatchResolved("corr-5", "done"); // second call — no row left.
+    const afterSecond = calls.filter((c) => c.args[1] === "resolve").length;
+
+    expect(afterFirst).toBe(1);
+    expect(afterSecond).toBe(1); // unchanged — no duplicate resolve.
+  });
+});
+
+describe("SubprocessDispatchStateRecorder — soft-skip + non-fatal", () => {
+  test("missing bundle script → accept SOFT-SKIPS (no spawn), resolve is a no-op", () => {
+    const { spawn, calls } = recordingSpawn({});
+    const logs: string[] = [];
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript: join(root, "does-not-exist.ts"),
+      spawn,
+      log: (l) => logs.push(l),
+    });
+
+    expect(() =>
+      recorder.onDispatchAccepted({ correlationId: "c", capability: "k", subject: "s", acceptedAt: "t" }),
+    ).not.toThrow();
+    expect(calls.length).toBe(0);
+    expect(logs.join("")).toMatch(/script-absent/);
+
+    // No id landed → resolve is a logged no-op, never a spawn.
+    recorder.onDispatchResolved("c", "done");
+    expect(calls.length).toBe(0);
+  });
+
+  test("enqueue non-zero exit → logged, claim NOT attempted, never throws", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 1, stderr: "boom" },
+    });
+    const logs: string[] = [];
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: (l) => logs.push(l),
+    });
+
+    expect(() =>
+      recorder.onDispatchAccepted({ correlationId: "c", capability: "k", subject: "s", acceptedAt: "t" }),
+    ).not.toThrow();
+
+    // enqueue failed → NO claim spawned.
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.args[1]).toBe("enqueue");
+    expect(logs.join("")).toMatch(/enqueue.*FAILED/);
+  });
+
+  test("spawn error on resolve → logged, never throws", () => {
+    const { spawn } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-6") },
+      claim: { status: 0 },
+      resolve: { status: null, error: new Error("ENOENT bun") },
+    });
+    const logs: string[] = [];
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: (l) => logs.push(l),
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-6", capability: "c", subject: "s", acceptedAt: "t" });
+    expect(() => recorder.onDispatchResolved("corr-6", "done")).not.toThrow();
+    expect(logs.join("")).toMatch(/resolve.*FAILED.*spawn-error/);
+  });
+
+  test("a throwing spawn seam is caught (belt-and-braces), never propagates", () => {
+    const throwingSpawn: RecorderSpawn = () => {
+      throw new Error("spawn blew up");
+    };
+    const logs: string[] = [];
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn: throwingSpawn,
+      log: (l) => logs.push(l),
+    });
+
+    expect(() =>
+      recorder.onDispatchAccepted({ correlationId: "c", capability: "k", subject: "s", acceptedAt: "t" }),
+    ).not.toThrow();
+    expect(logs.join("")).toMatch(/spawn threw/);
+  });
+});

--- a/src/common/agents/__tests__/dispatch-state-recorder.test.ts
+++ b/src/common/agents/__tests__/dispatch-state-recorder.test.ts
@@ -320,4 +320,32 @@ describe("SubprocessDispatchStateRecorder — soft-skip + non-fatal", () => {
     ).not.toThrow();
     expect(logs.join("")).toMatch(/spawn threw/);
   });
+
+  test("MF_AGENT_STATE_ERRANDS_SCRIPT is read PER CALL, not frozen at import", () => {
+    // A recorder with NO errandsScript opt resolves the path from the env at
+    // CONSTRUCTION via defaultErrandsScript(); set the env (to a real file)
+    // after module import and confirm it's honoured (proves it's not a frozen
+    // module const).
+    const lateScript = join(root, "late-errands.ts");
+    writeFileSync(lateScript, "// stub\n");
+    const savedEnv = process.env.MF_AGENT_STATE_ERRANDS_SCRIPT;
+    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT = lateScript;
+    let sawScript: string | undefined;
+    const spawn: RecorderSpawn = (_cmd, args) => {
+      sawScript = args[0];
+      return { status: 0, stdout: enqueueStdout("corr-env") };
+    };
+    try {
+      const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+        instanceDir,
+        spawn,
+        log: () => {},
+      });
+      recorder.onDispatchAccepted({ correlationId: "corr-env", capability: "c", subject: "s", acceptedAt: "t" });
+      expect(sawScript).toBe(lateScript);
+    } finally {
+      if (savedEnv !== undefined) process.env.MF_AGENT_STATE_ERRANDS_SCRIPT = savedEnv;
+      else delete process.env.MF_AGENT_STATE_ERRANDS_SCRIPT;
+    }
+  });
 });

--- a/src/common/agents/agent-state-scaffold.ts
+++ b/src/common/agents/agent-state-scaffold.ts
@@ -42,9 +42,12 @@ import { spawnSync } from "node:child_process";
  * `scaffold.ts` (`bun scaffold.ts <instance-dir> --host=<h> --agent=<a>`).
  * `MF_AGENT_STATE_SCRIPT` overrides for non-standard installs.
  */
-const DEFAULT_AGENT_STATE_SCRIPT =
-  process.env.MF_AGENT_STATE_SCRIPT ??
-  `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/scaffold.ts`;
+function defaultScaffoldScript(): string {
+  return (
+    process.env.MF_AGENT_STATE_SCRIPT ??
+    `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/scaffold.ts`
+  );
+}
 
 /**
  * cortex#1720 S2 — canonical AgentState bundle errands script.
@@ -52,19 +55,29 @@ const DEFAULT_AGENT_STATE_SCRIPT =
  * The `ReplayPending` workflow (`agent-state/skill/Workflows/ReplayPending.md`)
  * lists pending work via `bun <bundle>/skill/scripts/errands.ts pending` — a
  * SIBLING of `scaffold.ts` in the same `skill/scripts/` dir, NOT the scaffold
- * entrypoint. Kept as its own constant (rather than deriving from
- * `DEFAULT_AGENT_STATE_SCRIPT`) so a principal can install / override the two
+ * entrypoint. Kept as its own resolver (rather than deriving from
+ * `defaultScaffoldScript`) so a principal can install / override the two
  * independently. `MF_AGENT_STATE_ERRANDS_SCRIPT` overrides for non-standard
  * installs.
+ *
+ * Resolved PER CALL (not frozen at module import) so an env override set after
+ * import — e.g. by a test or a late-configured host — is honoured, matching the
+ * `opts ?? DEFAULT` pattern used throughout this module.
  */
-const DEFAULT_AGENT_STATE_ERRANDS_SCRIPT =
-  process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
-  `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`;
+function defaultErrandsScript(): string {
+  return (
+    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
+    `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`
+  );
+}
 
 /** Default host label baked into cortex-scaffolded instance dirs. */
 const DEFAULT_HOST = "cortex";
 
-export type ScaffoldStrategy = "agent-state-bundle" | "fallback-manual";
+export type ScaffoldStrategy =
+  | "agent-state-bundle"
+  | "fallback-manual"
+  | "skipped-home-unset"; // $HOME unset + no explicit instanceDir → nothing scaffolded
 
 export interface ScaffoldResult {
   strategy: ScaffoldStrategy;
@@ -129,8 +142,26 @@ export function scaffoldInstance(
   opts: ScaffoldOptions = {},
 ): ScaffoldResult {
   const host = opts.host ?? DEFAULT_HOST;
+
+  // $HOME unset with no explicit instanceDir → `resolveInstanceDir` yields a
+  // CWD-relative path that we'd then `mkdir`. Rather than scatter a state dir
+  // into the daemon's cwd, soft-skip with one log line; the fragment still
+  // activates stateless (the caller's log surfaces the strategy).
+  if (opts.instanceDir === undefined && !process.env.HOME) {
+    process.stderr.write(
+      `agent-state-scaffold: $HOME unset for agent=${agent.id} — skipping scaffold ` +
+        `(cannot resolve ~/.config/${host}/agents/${agent.id} safely)\n`,
+    );
+    return { strategy: "skipped-home-unset", instanceDir: "", created: [], skipped: [] };
+  }
+
   const instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, host);
-  const agentStateScript = opts.agentStateScript ?? DEFAULT_AGENT_STATE_SCRIPT;
+  // Resolve the bundle script PER CALL (not frozen at module import) so a late
+  // env override is honoured — matches the `opts ?? DEFAULT` pattern.
+  const agentStateScript =
+    opts.agentStateScript ??
+    process.env.MF_AGENT_STATE_SCRIPT ??
+    defaultScaffoldScript();
 
   const created: string[] = [];
   const skipped: string[] = [];
@@ -230,14 +261,32 @@ export function scaffoldInstance(
   return { strategy: "fallback-manual", instanceDir, created, skipped };
 }
 
+/**
+ * Wall-clock ceiling for a bundle subprocess. A hanging `scaffold.ts` (bad
+ * install, wedged bun) must NOT freeze the daemon — worst during a hot-reload
+ * where consumers are already drained. On timeout spawnSync SIGTERMs the child
+ * and returns `error` (code `ETIMEDOUT`) / a signal, which flows into the same
+ * non-zero-exit fallback the caller already handles.
+ */
+const SPAWN_TIMEOUT_MS = 30_000;
+
 function defaultSpawn(
   cmd: string,
   args: string[],
   opts: { stdio: "inherit" | "pipe"; env?: NodeJS.ProcessEnv },
 ): ScaffoldSpawnResult {
-  const r = spawnSync(cmd, args, opts);
+  // stdin is IGNORED (not an open pipe): a bundle that blocks on stdin would
+  // otherwise hang forever. stdout/stderr keep the caller's mode. `timeout`
+  // caps the wall clock so a wedged child can't freeze the daemon.
+  const r = spawnSync(cmd, args, {
+    ...opts,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: SPAWN_TIMEOUT_MS,
+  });
   // With stdio:"pipe" (the path this scaffolder always uses), r.stderr is a
-  // Buffer; TS narrows it non-null here, so we pass it straight through.
+  // Buffer; TS narrows it non-null here, so we pass it straight through. A
+  // timeout surfaces as a non-null `r.error` (ETIMEDOUT) — treated as a failed
+  // invocation by the caller (falls back to manual scaffold).
   return { status: r.status, error: r.error, stderr: r.stderr };
 }
 
@@ -318,8 +367,10 @@ export type ReplaySpawn = (
 
 /** Why a replay did no work (for structured logging / test assertions). */
 export type ReplaySkipReason =
+  | "home-unset" // $HOME unset → can't resolve the instance dir safely
   | "script-absent" // bundle errands.ts not installed → soft-skip
-  | "spawn-error" // spawn threw (ENOENT on bun, etc.)
+  | "spawn-error" // spawn threw (ENOENT on bun, timeout, etc.)
+  | "output-too-large" // stdout exceeded maxBuffer (ENOBUFS) — legit large backlog
   | "nonzero-exit"; // errands.ts exited non-zero
 
 export interface ReplayResult {
@@ -344,12 +395,23 @@ export interface ReplayOptions {
   spawn?: ReplaySpawn;
 }
 
-/** Count NDJSON rows in a `errands.ts pending` stdout dump (blank-line safe). */
+/**
+ * Count NDJSON rows in a `errands.ts pending` stdout dump. Blank-line safe, and
+ * counts ONLY lines that start with `{` — cheap insurance against a future
+ * diagnostic/banner line on stdout being miscounted as a work_item.
+ */
 function countPendingRows(stdout: Buffer | string | undefined): number {
   if (stdout === undefined) return 0;
   return String(stdout)
     .split("\n")
-    .filter((line) => line.trim().length > 0).length;
+    .filter((line) => line.trim().startsWith("{")).length;
+}
+
+/** True when a spawn error is a maxBuffer overflow (ENOBUFS). */
+function isEnobufs(err: Error | undefined): boolean {
+  return (
+    err !== undefined && (err as NodeJS.ErrnoException).code === "ENOBUFS"
+  );
 }
 
 /**
@@ -367,8 +429,20 @@ export function replayPending(
   opts: ReplayOptions = {},
 ): ReplayResult {
   const host = opts.host ?? DEFAULT_HOST;
+
+  // $HOME unset with no explicit instanceDir → `resolveInstanceDir` would return
+  // a CWD-relative path. Rather than replay against a stray dir, soft-skip.
+  if (opts.instanceDir === undefined && !process.env.HOME) {
+    return { ran: false, pendingCount: 0, instanceDir: "", skipReason: "home-unset" };
+  }
+
   const instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, host);
-  const errandsScript = opts.errandsScript ?? DEFAULT_AGENT_STATE_ERRANDS_SCRIPT;
+  // Resolve the script path PER CALL (not frozen at module import) so an env
+  // override set after import is honoured — matches the `opts ?? DEFAULT` pattern.
+  const errandsScript =
+    opts.errandsScript ??
+    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
+    defaultErrandsScript();
 
   // Bundle not installed → soft-skip (S1 already logged this class of miss on
   // the scaffold side; here we degrade the onStart hook to a no-op).
@@ -387,7 +461,12 @@ export function replayPending(
   });
 
   if (result.error) {
-    return { ran: false, pendingCount: 0, instanceDir, skipReason: "spawn-error" };
+    // A legit large pending backlog overflows maxBuffer (ENOBUFS) — distinguish
+    // it from a broken install / wedged bun so the log is honest.
+    const skipReason: ReplaySkipReason = isEnobufs(result.error)
+      ? "output-too-large"
+      : "spawn-error";
+    return { ran: false, pendingCount: 0, instanceDir, skipReason };
   }
   if (result.status !== 0) {
     return { ran: false, pendingCount: 0, instanceDir, skipReason: "nonzero-exit" };
@@ -400,12 +479,23 @@ export function replayPending(
   };
 }
 
+/** stdout ceiling for the replay listing — a large pending backlog is legit. */
+const REPLAY_MAX_BUFFER = 16 * 1024 * 1024; // 16 MB
+
 function defaultReplaySpawn(
   cmd: string,
   args: string[],
   opts: { env?: NodeJS.ProcessEnv },
 ): ReplaySpawnResult {
-  const r = spawnSync(cmd, args, { stdio: "pipe", env: opts.env });
+  // stdin IGNORED (no open pipe to hang on), wall-clock `timeout`, and an
+  // explicit 16MB `maxBuffer` so a big-but-legitimate pending backlog doesn't
+  // ENOBUFS at Bun's 1MB default and get miscategorised as a broken install.
+  const r = spawnSync(cmd, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: opts.env,
+    timeout: SPAWN_TIMEOUT_MS,
+    maxBuffer: REPLAY_MAX_BUFFER,
+  });
   return { status: r.status, error: r.error, stdout: r.stdout, stderr: r.stderr };
 }
 

--- a/src/common/agents/dispatch-state-recorder.ts
+++ b/src/common/agents/dispatch-state-recorder.ts
@@ -50,10 +50,30 @@ const DEFAULT_HOST = "cortex";
  * SAME `errands.ts` the S2 `pending` path uses. Kept as its own env override so
  * a principal can point the dispatch-wiring at a non-standard install
  * independently. `MF_AGENT_STATE_ERRANDS_SCRIPT` overrides.
+ *
+ * Resolved PER CALL (not frozen at module import) so a late env override is
+ * honoured — matches the `opts ?? DEFAULT` pattern used throughout.
  */
-const DEFAULT_ERRANDS_SCRIPT =
-  process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
-  `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`;
+function defaultErrandsScript(): string {
+  return (
+    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
+    `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`
+  );
+}
+
+/**
+ * Wall-clock ceiling for a bundle subprocess on the LIVE daemon. A hanging
+ * `errands.ts` must never freeze the dispatch path; on timeout spawnSync
+ * SIGTERMs the child and returns an error the caller logs + soft-skips.
+ */
+const RECORDER_SPAWN_TIMEOUT_MS = 30_000;
+
+/**
+ * stdout ceiling for the enqueue output read. The `{ inserted, row }` dump is
+ * tiny, but an explicit 16MB cap (matching the S2 replay lib) is cheap insurance
+ * against a wedged/verbose bundle overflowing Bun's 1MB default (ENOBUFS).
+ */
+const RECORDER_MAX_BUFFER = 16 * 1024 * 1024;
 
 /** Terminal outcome an accepted dispatch resolves to. */
 export type DispatchResolveStatus = "done" | "failed";
@@ -156,7 +176,7 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
     this.agent = agent;
     this.host = opts.host ?? DEFAULT_HOST;
     this.instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, this.host);
-    this.errandsScript = opts.errandsScript ?? DEFAULT_ERRANDS_SCRIPT;
+    this.errandsScript = opts.errandsScript ?? defaultErrandsScript();
     this.spawn = opts.spawn ?? defaultRecorderSpawn;
     this.log = opts.log ?? ((line) => process.stderr.write(line));
   }
@@ -296,6 +316,17 @@ function defaultRecorderSpawn(
   args: string[],
   opts: { env?: NodeJS.ProcessEnv },
 ): RecorderSpawnResult {
-  const r = spawnSync(cmd, args, { stdio: "pipe", env: opts.env });
+  // Live-daemon hardening (mirrors S2's replay spawn): stdin IGNORED so a
+  // bundle that blocks on stdin can't hang the dispatch path, a wall-clock
+  // `timeout` caps a wedged child (SIGTERM → error → run() logs + soft-skips),
+  // and an explicit 16MB `maxBuffer` avoids a spurious ENOBUFS on a verbose
+  // bundle. A timeout / ENOBUFS both surface via `r.error` → the caller's
+  // non-zero/error branch logs one line and never throws.
+  const r = spawnSync(cmd, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: opts.env,
+    timeout: RECORDER_SPAWN_TIMEOUT_MS,
+    maxBuffer: RECORDER_MAX_BUFFER,
+  });
   return { status: r.status, error: r.error, stdout: r.stdout, stderr: r.stderr };
 }

--- a/src/common/agents/dispatch-state-recorder.ts
+++ b/src/common/agents/dispatch-state-recorder.ts
@@ -1,0 +1,301 @@
+/**
+ * cortex#1720 S3 — dispatch lifecycle → AgentState work_items.
+ *
+ * The dispatch half of the agent-state contract. When a STATEFUL agent's
+ * BrainConsumer ACCEPTS a dispatch (the point where `dispatch.task.started` is
+ * emitted — after the backpressure, sovereignty, and shutdown gates pass), the
+ * host durably records "we owe a response to this task" as a `work_item`:
+ *
+ *   accepted  → `errands.ts enqueue` (status=pending) + `errands.ts claim` (→ in_flight)
+ *   completed → `errands.ts resolve --status=done`
+ *   failed    → `errands.ts resolve --status=failed`
+ *
+ * Same contract as the S1 scaffold + S2 replay libs:
+ *   - SUBPROCESS ONLY — cortex imports NOTHING from the bundle (platform
+ *     no-coupling rule). The only contract is the `errands.ts` CLI + the
+ *     standard env (`MF_AGENT_NAME`, `MF_HOST=cortex`, `MF_INSTANCE_DIR`).
+ *   - NON-BLOCKING + NON-FATAL — state writes must NEVER add a latency-blocking
+ *     failure mode to the dispatch hot path. Every subprocess is wrapped in a
+ *     try/catch, logs ONE line on failure, and never fails the dispatch because
+ *     state recording failed. The BrainConsumer fires these fire-and-forget
+ *     (`void recorder.onDispatchAccepted(...)`) so they stay off the critical
+ *     path entirely.
+ *   - OPT-IN — a recorder is only constructed for a `state:`-declaring agent
+ *     (the `if (agent.state)` guard lives at the boot wiring site). A stateless
+ *     agent's BrainConsumer never gets a recorder, so it takes ZERO new code
+ *     paths — the `this.stateRecorder?.…` calls short-circuit to undefined.
+ *
+ * IMPORTANT contract detail (ReplayPending.md / errands.ts header): the bundle's
+ * lib EMITS the lifecycle events itself (`work_item_created` / `_claimed` /
+ * `_resolved`). Hosts MUST NOT separately append events for these transitions —
+ * this module only calls the `enqueue` / `claim` / `resolve` subcommands and
+ * never touches the `events` table.
+ *
+ * PAYLOAD DISCIPLINE (§3): the work_item payload is QUEUE METADATA only —
+ * correlation id, subject, capability, timestamp, and safe envelope metadata.
+ * NEVER the prompt / message body. The session interior stays in the substrate;
+ * `work_items` is the durable queue, not document storage.
+ */
+
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolveInstanceDir } from "./agent-state-scaffold";
+
+/** Default host label baked into cortex work_item env. */
+const DEFAULT_HOST = "cortex";
+
+/**
+ * cortex#1720 S3 — canonical AgentState bundle errands script (shared shape with
+ * S2's replay lib). The `enqueue` / `claim` / `resolve` subcommands live on the
+ * SAME `errands.ts` the S2 `pending` path uses. Kept as its own env override so
+ * a principal can point the dispatch-wiring at a non-standard install
+ * independently. `MF_AGENT_STATE_ERRANDS_SCRIPT` overrides.
+ */
+const DEFAULT_ERRANDS_SCRIPT =
+  process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
+  `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`;
+
+/** Terminal outcome an accepted dispatch resolves to. */
+export type DispatchResolveStatus = "done" | "failed";
+
+/** Result shape of the injectable spawn seam (captures stdout for the id). */
+export interface RecorderSpawnResult {
+  status: number | null;
+  error?: Error;
+  /** Captured stdout — the `enqueue` JSON row (for the work_item id). */
+  stdout?: Buffer | string;
+  stderr?: Buffer | string;
+}
+
+export type RecorderSpawn = (
+  cmd: string,
+  args: string[],
+  opts: { env?: NodeJS.ProcessEnv },
+) => RecorderSpawnResult;
+
+/** Minimal shape of the agent this recorder needs (id only). */
+export interface RecorderAgent {
+  id: string;
+}
+
+export interface DispatchStateRecorderOptions {
+  /** Override the resolved instance dir (test seam). Default: ~/.config/cortex/agents/<id>. */
+  instanceDir?: string;
+  /** Override the host label baked into the env (test seam). Default: "cortex". */
+  host?: string;
+  /** Override path to the bundle's errands.ts (test seam). */
+  errandsScript?: string;
+  /** Override the spawn used to invoke the bundle (test seam). */
+  spawn?: RecorderSpawn;
+  /** Override the logger (test seam). Default: stderr. */
+  log?: (line: string) => void;
+}
+
+/**
+ * Compact, payload-disciplined queue metadata for one accepted dispatch.
+ * NEVER carries prompt / message content — correlation id + subject + safe
+ * envelope metadata only (§3). Serialized to the `--payload` JSON.
+ */
+export interface DispatchWorkItemMeta {
+  /** The dispatch correlation id — also the enqueue `--id` (stable per task). */
+  correlationId: string;
+  /** The capability the dispatch targets — the work_item `--kind`. */
+  capability: string;
+  /** The bus subject the envelope arrived on (routing metadata, not content). */
+  subject: string;
+  /** ISO-8601 accept timestamp. */
+  acceptedAt: string;
+}
+
+/**
+ * The seam the BrainConsumer talks to. A stateful agent's consumer holds ONE of
+ * these (constructed at boot wiring behind `if (agent.state)`); a stateless
+ * agent holds `undefined` and the consumer's `this.stateRecorder?.…` calls are
+ * no-ops. Both methods are TOTAL and NON-THROWING — a bundle miss, spawn error,
+ * or non-zero exit logs one line and returns; the dispatch is never affected.
+ */
+export interface DispatchStateRecorder {
+  /**
+   * An accepted dispatch (post-gates, at `dispatch.task.started`): enqueue a
+   * pending work_item then atomically claim it (→ in_flight). Idempotent on the
+   * correlation id (re-delivery of the same envelope is a bundle-side no-op).
+   */
+  onDispatchAccepted(meta: DispatchWorkItemMeta): void;
+  /**
+   * A terminal dispatch outcome: resolve the previously-enqueued work_item to
+   * `done` (completed) or `failed` (failed). A resolve for an id we never
+   * enqueued (bundle miss on accept, or a stateless→stateful reload race) is a
+   * logged no-op — we only resolve ids we hold in the in-flight map.
+   */
+  onDispatchResolved(correlationId: string, status: DispatchResolveStatus): void;
+}
+
+/**
+ * The production recorder: subprocesses to the bundle's `errands.ts`. Holds an
+ * in-memory map from correlation id → work_item id so `resolve` targets the row
+ * `enqueue` created. The map is best-effort: it survives only for the process
+ * lifetime (a restart re-surfaces unfinished rows via S2's ReplayPending, not
+ * this map). A recorder is scoped to ONE agent (one instance dir).
+ */
+export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
+  private readonly agent: RecorderAgent;
+  private readonly host: string;
+  private readonly instanceDir: string;
+  private readonly errandsScript: string;
+  private readonly spawn: RecorderSpawn;
+  private readonly log: (line: string) => void;
+
+  /**
+   * correlation id → work_item id. Populated on a successful `enqueue`; read +
+   * cleared on `resolve`. An entry is only present for a row we actually created,
+   * so `resolve` never fabricates an id.
+   */
+  private readonly inFlightIds = new Map<string, string>();
+
+  constructor(agent: RecorderAgent, opts: DispatchStateRecorderOptions = {}) {
+    this.agent = agent;
+    this.host = opts.host ?? DEFAULT_HOST;
+    this.instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, this.host);
+    this.errandsScript = opts.errandsScript ?? DEFAULT_ERRANDS_SCRIPT;
+    this.spawn = opts.spawn ?? defaultRecorderSpawn;
+    this.log = opts.log ?? ((line) => process.stderr.write(line));
+  }
+
+  onDispatchAccepted(meta: DispatchWorkItemMeta): void {
+    // Bundle not installed → soft-skip (S1/S2 already log this class of miss on
+    // their own hooks). No enqueue, so no id lands in the map and the paired
+    // resolve later is itself a logged no-op — symmetric, no orphaned rows.
+    if (!existsSync(this.errandsScript)) {
+      this.log(
+        `cortex: agent-state — dispatch enqueue SKIPPED for "${this.agent.id}" ` +
+          `(reason=script-absent; correlation=${meta.correlationId})\n`,
+      );
+      return;
+    }
+
+    // §3 payload discipline — QUEUE METADATA ONLY. No prompt / message body.
+    const payload = JSON.stringify({
+      correlation_id: meta.correlationId,
+      subject: meta.subject,
+      capability: meta.capability,
+      accepted_at: meta.acceptedAt,
+    });
+
+    // enqueue --id <correlationId> --kind <capability> --payload <json> --owner <agent>
+    // The `--id` is the correlation id (stable per task → idempotent on
+    // re-delivery). `--owner` is the agent, so the immediate claim reads clean.
+    const enqueue = this.run([
+      "enqueue",
+      "--id",
+      meta.correlationId,
+      "--kind",
+      meta.capability,
+      "--payload",
+      payload,
+      "--owner",
+      this.agent.id,
+    ]);
+    if (enqueue === null) return; // run() already logged the failure.
+
+    // Capture the work_item id from the enqueue output. The CLI prints
+    // `{ inserted, row }`; `row.id` is the correlation id we passed, but we read
+    // it back from the row to stay honest to the bundle's own id (it echoes the
+    // `--id`). Fall back to the correlation id if the shape is unexpected.
+    const workItemId = this.extractRowId(enqueue) ?? meta.correlationId;
+    this.inFlightIds.set(meta.correlationId, workItemId);
+
+    // claim --id <workItemId> --owner <agent> → pending → in_flight.
+    const claim = this.run(["claim", "--id", workItemId, "--owner", this.agent.id]);
+    if (claim === null) {
+      // Enqueue landed but claim failed — leave the id in the map so a later
+      // resolve still targets the row (it is `pending`, not `in_flight`, but
+      // `resolve` accepts either). One log line was already written by run().
+      return;
+    }
+  }
+
+  onDispatchResolved(correlationId: string, status: DispatchResolveStatus): void {
+    const workItemId = this.inFlightIds.get(correlationId);
+    if (workItemId === undefined) {
+      // No row for this id — either the accept-side enqueue was skipped (bundle
+      // absent) or this is a resolve for a task we never recorded. Logged no-op;
+      // we NEVER resolve an id we did not create.
+      this.log(
+        `cortex: agent-state — dispatch resolve SKIPPED for "${this.agent.id}" ` +
+          `(reason=no-work-item; correlation=${correlationId}; status=${status})\n`,
+      );
+      return;
+    }
+    this.inFlightIds.delete(correlationId);
+
+    // resolve --id <workItemId> --status done|failed. Terminal; the bundle
+    // emits `work_item_resolved` itself (no host-side event append).
+    this.run(["resolve", "--id", workItemId, "--status", status]);
+  }
+
+  /**
+   * Run one `errands.ts` subcommand. TOTAL + NON-THROWING: a spawn error or
+   * non-zero exit logs one line and returns null; success returns the captured
+   * stdout string. Never throws — the dispatch hot path must not see a state
+   * failure.
+   */
+  private run(args: string[]): string | null {
+    let result: RecorderSpawnResult;
+    try {
+      result = this.spawn("bun", [this.errandsScript, ...args], {
+        env: {
+          ...process.env,
+          MF_AGENT_NAME: this.agent.id,
+          MF_HOST: this.host,
+          MF_INSTANCE_DIR: this.instanceDir,
+        },
+      });
+    } catch (err) {
+      // A THROWING spawn (belt-and-braces — defaultRecorderSpawn returns an
+      // error field rather than throwing, but a test seam might throw).
+      this.log(
+        `cortex: agent-state — dispatch "${args[0]}" FAILED for "${this.agent.id}" ` +
+          `(non-fatal; spawn threw: ${err instanceof Error ? err.message : String(err)})\n`,
+      );
+      return null;
+    }
+    if (result.error) {
+      this.log(
+        `cortex: agent-state — dispatch "${args[0]}" FAILED for "${this.agent.id}" ` +
+          `(non-fatal; spawn-error: ${result.error.message})\n`,
+      );
+      return null;
+    }
+    if (result.status !== 0) {
+      const stderr = result.stderr ? String(result.stderr).slice(0, 200) : "";
+      this.log(
+        `cortex: agent-state — dispatch "${args[0]}" FAILED for "${this.agent.id}" ` +
+          `(non-fatal; nonzero-exit status=${result.status}${stderr ? `; stderr: ${stderr}` : ""})\n`,
+      );
+      return null;
+    }
+    return result.stdout !== undefined ? String(result.stdout) : "";
+  }
+
+  /** Parse `row.id` out of an `enqueue` stdout dump. Null on any shape miss. */
+  private extractRowId(stdout: string): string | null {
+    const trimmed = stdout.trim();
+    if (trimmed.length === 0) return null;
+    try {
+      const parsed = JSON.parse(trimmed) as { row?: { id?: unknown } };
+      const id = parsed.row?.id;
+      return typeof id === "string" && id.length > 0 ? id : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function defaultRecorderSpawn(
+  cmd: string,
+  args: string[],
+  opts: { env?: NodeJS.ProcessEnv },
+): RecorderSpawnResult {
+  const r = spawnSync(cmd, args, { stdio: "pipe", env: opts.env });
+  return { status: r.status, error: r.error, stdout: r.stdout, stderr: r.stderr };
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1383,7 +1383,13 @@ export async function startCortex(
       // exist). The next activation retries both from a clean footing.
       return;
     }
-    // cortex#1720 S2 — onStart replay, only after a clean scaffold.
+    // cortex#1720 S2 — onStart replay, reached only when scaffold did NOT throw.
+    // Note: a bundle that EXITS NON-ZERO does not throw — `scaffoldInstance`
+    // degrades to the manual fallback and returns `fallback-manual`, so replay
+    // still runs. That is benign: `errands.ts pending` creates `state.sqlite`
+    // itself (via the bundle's own `openState`), so a first-run replay against a
+    // fallback-scaffolded dir simply finds an empty, freshly-created queue. Only
+    // a THROWN scaffold (caught above) skips replay.
     replayStatefulAgent(agent);
   };
   for (const agent of mergedAgents) {

--- a/src/runner/__tests__/brain-consumer-boot.test.ts
+++ b/src/runner/__tests__/brain-consumer-boot.test.ts
@@ -200,6 +200,73 @@ describe("wireBrainConsumers — daemon lifecycle", () => {
   });
 });
 
+describe("wireBrainConsumers — dispatch state recorder gating (cortex#1720 S3)", () => {
+  test("a STATEFUL agent (declares state) gets a dispatch state recorder", async () => {
+    const runtime = fakeRuntime();
+    const madeFor: string[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({
+        runtime,
+        makeDispatchStateRecorder: (a) => {
+          madeFor.push(a.id);
+          return { onDispatchAccepted() {}, onDispatchResolved() {} };
+        },
+      }),
+    );
+
+    await startForAgent({
+      ...agent("luna", ["soc.compose.flow"]),
+      state: { blueprint: "AgentState", version: ">=0.1.0" },
+    });
+
+    // The factory was consulted exactly once, for the stateful agent — proof the
+    // recorder is constructed behind `if (agent.state)`.
+    expect(madeFor).toEqual(["luna"]);
+  });
+
+  test("REGRESSION: a STATELESS agent (no state) gets NO recorder — zero new code paths", async () => {
+    const runtime = fakeRuntime();
+    const madeFor: string[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({
+        runtime,
+        makeDispatchStateRecorder: (a) => {
+          madeFor.push(a.id);
+          return { onDispatchAccepted() {}, onDispatchResolved() {} };
+        },
+      }),
+    );
+
+    // No `state` block — the stateless default.
+    await startForAgent(agent("yarrow", ["soc.compose.flow"]));
+
+    // The factory was NEVER consulted — the `if (agent.state)` guard short-circuits.
+    expect(madeFor).toEqual([]);
+  });
+
+  test("a mixed roster wires a recorder ONLY for the stateful fragment", async () => {
+    const runtime = fakeRuntime();
+    const madeFor: string[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({
+        runtime,
+        makeDispatchStateRecorder: (a) => {
+          madeFor.push(a.id);
+          return { onDispatchAccepted() {}, onDispatchResolved() {} };
+        },
+      }),
+    );
+
+    await startForAgent(agent("yarrow", ["soc.compose.flow"])); // stateless
+    await startForAgent({
+      ...agent("luna", ["soc.compose.flow"]),
+      state: { blueprint: "AgentState", version: ">=0.2.0" },
+    }); // stateful
+
+    expect(madeFor).toEqual(["luna"]);
+  });
+});
+
 describe("wireBrainConsumers — per-agent failure isolation", () => {
   test("a synchronous failure inside startForAgent is caught and logged, not thrown", async () => {
     // A runtime whose `subscribePull` throws synchronously — simulates the

--- a/src/runner/brain-consumer-boot.ts
+++ b/src/runner/brain-consumer-boot.ts
@@ -68,6 +68,10 @@ import {
   BRAIN_TASK_SUBJECT_FAMILY,
   type BrainConsumerAgent,
 } from "../bus/brain-consumer";
+import {
+  SubprocessDispatchStateRecorder,
+  type DispatchStateRecorder,
+} from "../common/agents/dispatch-state-recorder";
 import { provisionReviewConsumer, type ProvisionJsm } from "../bus/jetstream/provision";
 import { makeExecBrainRunner } from "../brain/exec-brain-runner";
 import { DaemonBrainHost } from "../brain/daemon-brain-host";
@@ -91,6 +95,15 @@ export interface BrainBootAgent {
   id: string;
   /** Path to the agent's persona markdown file (Architecture §9.3). */
   persona: string;
+  /**
+   * cortex#1720 S1 — OPT-IN per-instance durable state declaration. Present ⇒
+   * this fragment is STATEFUL: the boot wiring constructs a
+   * {@link DispatchStateRecorder} (S3) so its dispatch lifecycle records
+   * AgentState work_items. Absent ⇒ stateless, zero new code paths. The full
+   * Zod `Agent` carries this (added in S1); this structural projection re-declares
+   * it so the wiring can gate on it without a cast.
+   */
+  state?: { blueprint: string; version: string };
   runtime?: {
     capabilities?: readonly string[];
     maxConcurrent?: number;
@@ -155,6 +168,16 @@ export interface WireBrainConsumersOpts {
   brainTasksStream: string;
   /** Durable max-deliver, shared with the review/release lanes. */
   reviewConsumerMaxDeliver: number;
+  /**
+   * cortex#1720 S3 — factory for the dispatch-lifecycle state recorder (test
+   * seam). Called ONLY for a `state:`-declaring (stateful) agent, behind the
+   * `if (agent.state)` guard below. Defaults to the real
+   * {@link SubprocessDispatchStateRecorder} (subprocesses to the bundle's
+   * `errands.ts`). A stateless agent never reaches this factory, so its consumer
+   * gets no recorder and takes zero new dispatch code paths. Injected so tests
+   * assert which agents are wired with a recorder without a real bundle.
+   */
+  makeDispatchStateRecorder?: (agent: { id: string }) => DispatchStateRecorder;
 }
 
 /** The callable `cortex.ts` invokes per agent, at both the boot loop and the `agents.d/` hot-reload sites. */
@@ -282,6 +305,18 @@ export function wireBrainConsumers(
       // Sovereignty audit-parity by default, mirroring ReviewConsumer (a
       // self-declared modelClass is spoofable until bound to the signing
       // identity, cortex#327).
+      // cortex#1720 S3 — OPT-IN dispatch-lifecycle state recorder. Constructed
+      // ONLY for a `state:`-declaring (STATEFUL) fragment, so the gate is at
+      // CONSTRUCTION (not a per-envelope string check inside the consumer). A
+      // stateless fragment leaves `stateRecorder` undefined and its consumer's
+      // `this.stateRecorder?.…` calls short-circuit — zero new dispatch paths.
+      const makeRecorder =
+        opts.makeDispatchStateRecorder ??
+        ((a: { id: string }) => new SubprocessDispatchStateRecorder(a));
+      const stateRecorder: DispatchStateRecorder | undefined = agent.state
+        ? makeRecorder({ id: agent.id })
+        : undefined;
+
       const baseConsumerOpts = {
         agent: consumerAgent,
         source: opts.systemEventSource,
@@ -290,6 +325,7 @@ export function wireBrainConsumers(
         ...(opts.surfacePrincipalGate !== undefined && {
           principalGate: opts.surfacePrincipalGate,
         }),
+        ...(stateRecorder !== undefined && { stateRecorder }),
       };
       let daemonHost: DaemonBrainHost | undefined;
       let consumer: BrainConsumer;


### PR DESCRIPTION
## Summary

S3 of #1720 — the **dispatch half** of the agent-state contract. When a
STATEFUL agent's `BrainConsumer` **accepts** a dispatch (the
`dispatch.task.started` point), cortex durably records "we owe a response" as an
AgentState `work_item`; on a terminal outcome it resolves that row.

```
accepted  → errands.ts enqueue (pending) + errands.ts claim (→ in_flight)
completed → errands.ts resolve --status=done
failed    → errands.ts resolve --status=failed
```

> **Stacked on #1722 (S2), which is stacked on #1721 (S1).**
> Stack: **#1721 (S1 scaffold) → #1722 (S2 ReplayPending) → this (S3 dispatch)**.
> Base branch is `feat/1720-s2-replay-pending`, **not** `main` — S3 reuses S1's
> `state` schema + `resolveInstanceDir`, and mirrors S1/S2's subprocess+env
> contract. Review/merge #1721 then #1722 first; this PR's diff is S3-only.

## What S3 covers (this PR)

1. **`src/common/agents/dispatch-state-recorder.ts`** — a `DispatchStateRecorder`
   interface + `SubprocessDispatchStateRecorder`:
   - **Subprocess only** — no imports from the bundle (platform no-coupling rule).
     Subprocesses `errands.ts enqueue/claim/resolve` with the standard env
     (`MF_AGENT_NAME` / `MF_HOST=cortex` / `MF_INSTANCE_DIR`), reusing S1's
     `resolveInstanceDir`. Default script path is the S2 `errands.ts` sibling,
     overridable via `MF_AGENT_STATE_ERRANDS_SCRIPT`.
   - **No double-recording** — the bundle's lib emits `work_item_created` /
     `_claimed` / `_resolved` itself (per `ReplayPending.md` / `errands.ts`
     header); the host only calls the subcommands, never appends events.
   - Holds an in-memory **correlation → work_item id** map so `resolve` targets
     the row `enqueue` created; never fabricates an id it did not enqueue.
   - **Total + non-throwing** — a missing bundle soft-skips (no spawn); a
     non-zero exit / spawn error / thrown seam logs one line and returns.

2. **`src/bus/brain-consumer.ts`** — optional `stateRecorder` on the consumer opts.
   - Accept-side **enqueue+claim** fires at `dispatch.task.started`, **after** the
     backpressure / sovereignty / shutdown gates.
   - Terminal **resolve** fires only on a genuine terminal.
   - All recorder calls run through a defensive `recordState()` wrapper.

3. **`src/runner/brain-consumer-boot.ts`** — the recorder is constructed **only
   behind `if (agent.state)`** (a `makeDispatchStateRecorder` factory seam,
   defaulting to the real subprocess recorder). Gated at **construction**, not
   per-envelope. A stateless agent's consumer gets no recorder ⇒
   `this.stateRecorder?.…` short-circuits ⇒ **zero new dispatch code paths**.

## Design decisions

- **Backpressure → NOT enqueued.** A `not_now` backpressure rejection returns
  *before* the accept point, so a rejected dispatch is never recorded — there is
  no work item for a task we did not accept. Enqueue happens only after the
  backpressure + sovereignty + shutdown gates pass. (Requested call: made this
  way.)
- **`not_now` failure is a RETRY, not a terminal.** `failedReasonToAckDecision`
  maps `not_now` → nak-with-redelivery. Resolving `failed` there would strand a
  task that is going to run again, so the row stays `in_flight` (and S2's
  ReplayPending re-surfaces it across a restart). Resolve `failed` fires only for
  genuinely-terminal reasons (`wont_do` / `cant_do` / `policy_denied` → `term`).
  A dropped terminal publish (nak-redelivery) likewise does not resolve.
- **Awaiting: NOT awaited on the critical path.** The recorder calls are
  synchronous but fire *after* the lifecycle envelope is already published and
  are wrapped in `recordState()` (try/catch + one log line). A subprocess is a
  few ms and off the awaited path; blocking the caller there is not worth the
  added concurrency surface of an un-awaited promise. A state-write failure never
  fails the dispatch.

## Payload discipline (§3)

The `work_item` payload is QUEUE METADATA ONLY — `correlation_id`, `subject`,
`capability`, `accepted_at`. **Never** prompt / message content — the session
interior stays in the substrate. Asserted in the recorder unit tests.

## Verification

- `bunx tsc --noEmit` — clean.
- `bunx eslint` on all changed files — clean.
- Vocab carve-out gate (`scripts/check-carveouts.sh`) — **PASS** ("principal",
  not "operator").
- **New tests (all green):**
  - **recorder** (`dispatch-state-recorder.test.ts`, 10): enqueue+claim env +
    payload discipline; claims the bundle-echoed id; resolve done/failed;
    resolve of an un-enqueued id is a logged no-op; in-flight id cleared after
    resolve; missing bundle soft-skips (no spawn); nonzero-exit / spawn-error /
    throwing-seam all log + never throw.
  - **lifecycle** (`brain-consumer.test.ts`, +7): stateful accept
    enqueues+claims + completed resolves done; wont_do resolves failed; not_now
    does NOT resolve (nak-redelivery); stateless never records; backpressure
    never records; a throwing recorder never fails the dispatch.
  - **boot gating** (`brain-consumer-boot.test.ts`, +3): stateful gets a
    recorder; **REGRESSION** — stateless gets none; mixed roster wires only the
    stateful one.
- **Full suite:** `9466 pass / 20 fail / 2 skip / 8 todo` across 565 files. The
  **20 failures are the pre-existing, unrelated** baseline documented in #1721 /
  #1722 (network-secret-cli add-member/revoke-member + one ConfigWatcher
  hot-reload flake) — count **unchanged** vs S2's `9447 pass / 20 fail` (this PR
  adds 19 passing tests: 9447 + 19 = 9466).

## Out of scope (S4)

- **S4** — `RegenerateDashboard` on transitions; retire the `dev-session-store.ts`
  bridge onto agent-state (F-2 errand→session map).

Refs #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)