### PR TITLE
chore: bump to v6.4.0 — agent-state host wiring (#1720)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.3.10"
+version: "6.4.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump for the #1720 S1–S3 release: optional `state` field on agent fragments, AgentState scaffold on activation, ReplayPending on start, dispatch lifecycle → work_items, plus the review hardening pass (spawn timeouts, maxBuffer, HOME/env safety). Merged as #1721 / #1722 / #1751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)