### PR TITLE
feat(cortex): RegenerateDashboard on terminal resolve (#1720 S4a)

### DIFF
--- a/src/common/agents/__tests__/dispatch-state-recorder.test.ts
+++ b/src/common/agents/__tests__/dispatch-state-recorder.test.ts
@@ -33,13 +33,19 @@ const AGENT = { id: "luna" };
 
 let root: string;
 let errandsScript: string;
+let dashboardScript: string;
 let instanceDir: string;
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "cortex-recorder-"));
   errandsScript = join(root, "errands.ts");
+  // cortex#1720 S4a — the dashboard.ts sibling. Written by default so the
+  // regen path is exercised; individual tests point at a missing path to drive
+  // the soft-skip branch.
+  dashboardScript = join(root, "dashboard.ts");
   instanceDir = join(root, "agents", "luna");
   writeFileSync(errandsScript, "// stub errands.ts\n");
+  writeFileSync(dashboardScript, "// stub dashboard.ts\n");
 });
 
 afterEach(() => {
@@ -346,6 +352,202 @@ describe("SubprocessDispatchStateRecorder — soft-skip + non-fatal", () => {
     } finally {
       if (savedEnv !== undefined) process.env.MF_AGENT_STATE_ERRANDS_SCRIPT = savedEnv;
       else delete process.env.MF_AGENT_STATE_ERRANDS_SCRIPT;
+    }
+  });
+});
+
+// ===========================================================================
+// cortex#1720 S4a — RegenerateDashboard on terminal resolve.
+// ===========================================================================
+describe("SubprocessDispatchStateRecorder — S4a: dashboard regen on resolve", () => {
+  /** The `regen` spawn, if one fired. */
+  function regenCall(calls: SpawnCall[]): SpawnCall | undefined {
+    return calls.find((c) => c.args[1] === "regen");
+  }
+
+  test("completed resolve ALSO regenerates the dashboard (regen subcommand, std env)", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-d1") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+      regen: { status: 0 },
+    });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      dashboardScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-d1", capability: "c", subject: "s", acceptedAt: "t" });
+    recorder.onDispatchResolved("corr-d1", "done");
+
+    const regen = regenCall(calls);
+    expect(regen).toBeDefined();
+    // Invokes `bun <dashboardScript> regen` — the REQUIRED subcommand (agent-state#6).
+    expect(regen!.cmd).toBe("bun");
+    expect(regen!.args[0]).toBe(dashboardScript);
+    expect(regen!.args[1]).toBe("regen");
+    // Standard bundle env, same instance dir as the errands calls.
+    expect(regen!.env?.MF_AGENT_NAME).toBe(AGENT.id);
+    expect(regen!.env?.MF_HOST).toBe("cortex");
+    expect(regen!.env?.MF_INSTANCE_DIR).toBe(instanceDir);
+    // Ordering: regen fires AFTER the resolve (it reflects the transition).
+    const idxResolve = calls.findIndex((c) => c.args[1] === "resolve");
+    const idxRegen = calls.findIndex((c) => c.args[1] === "regen");
+    expect(idxRegen).toBeGreaterThan(idxResolve);
+  });
+
+  test("failed resolve ALSO regenerates the dashboard", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-d2") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+      regen: { status: 0 },
+    });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      dashboardScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-d2", capability: "c", subject: "s", acceptedAt: "t" });
+    recorder.onDispatchResolved("corr-d2", "failed");
+
+    expect(regenCall(calls)).toBeDefined();
+  });
+
+  test("a no-work-item resolve does NOT regenerate (no transition, no regen)", () => {
+    const { spawn, calls } = recordingSpawn({ regen: { status: 0 } });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      dashboardScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchResolved("never-enqueued", "done");
+
+    expect(calls.length).toBe(0); // no resolve, and therefore no regen.
+  });
+
+  test("dashboard script ABSENT → regen SOFT-SKIPS (no regen spawn), resolve still runs, no throw", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-d3") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+    });
+    const logs: string[] = [];
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      dashboardScript: join(root, "no-dashboard.ts"), // missing
+      spawn,
+      log: (l) => logs.push(l),
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-d3", capability: "c", subject: "s", acceptedAt: "t" });
+    expect(() => recorder.onDispatchResolved("corr-d3", "done")).not.toThrow();
+
+    // resolve fired, regen did NOT (soft-skip logged).
+    expect(calls.find((c) => c.args[1] === "resolve")).toBeDefined();
+    expect(regenCall(calls)).toBeUndefined();
+    expect(logs.join("")).toMatch(/dashboard regen SKIPPED.*script-absent/);
+  });
+
+  test("regen non-zero exit → logged FAILED, never throws, resolve unaffected", () => {
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-d4") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+      regen: { status: 2, stderr: "usage: dashboard.ts regen" },
+    });
+    const logs: string[] = [];
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      dashboardScript,
+      spawn,
+      log: (l) => logs.push(l),
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-d4", capability: "c", subject: "s", acceptedAt: "t" });
+    expect(() => recorder.onDispatchResolved("corr-d4", "done")).not.toThrow();
+    expect(calls.find((c) => c.args[1] === "resolve")).toBeDefined();
+    expect(logs.join("")).toMatch(/dashboard regen FAILED.*nonzero-exit/);
+  });
+
+  test("regen spawn error → logged FAILED, never throws", () => {
+    const { spawn } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-d5") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+      regen: { status: null, error: new Error("ENOENT bun") },
+    });
+    const logs: string[] = [];
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      dashboardScript,
+      spawn,
+      log: (l) => logs.push(l),
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-d5", capability: "c", subject: "s", acceptedAt: "t" });
+    expect(() => recorder.onDispatchResolved("corr-d5", "done")).not.toThrow();
+    expect(logs.join("")).toMatch(/dashboard regen FAILED.*spawn-error/);
+  });
+
+  test("dashboard script defaults to the errands.ts SIBLING when not overridden", () => {
+    // No `dashboardScript` opt → derived as dirname(errandsScript)/dashboard.ts,
+    // which beforeEach wrote — so regen fires and targets exactly that sibling.
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-d6") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+      regen: { status: 0 },
+    });
+    const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+
+    recorder.onDispatchAccepted({ correlationId: "corr-d6", capability: "c", subject: "s", acceptedAt: "t" });
+    recorder.onDispatchResolved("corr-d6", "done");
+
+    expect(regenCall(calls)?.args[0]).toBe(dashboardScript);
+  });
+
+  test("MF_AGENT_STATE_DASHBOARD_SCRIPT overrides the derived sibling", () => {
+    const overrideScript = join(root, "override-dashboard.ts");
+    writeFileSync(overrideScript, "// stub\n");
+    const saved = process.env.MF_AGENT_STATE_DASHBOARD_SCRIPT;
+    process.env.MF_AGENT_STATE_DASHBOARD_SCRIPT = overrideScript;
+    const { spawn, calls } = recordingSpawn({
+      enqueue: { status: 0, stdout: enqueueStdout("corr-d7") },
+      claim: { status: 0 },
+      resolve: { status: 0 },
+      regen: { status: 0 },
+    });
+    try {
+      const recorder = new SubprocessDispatchStateRecorder(AGENT, {
+        instanceDir,
+        errandsScript,
+        spawn,
+        log: () => {},
+      });
+      recorder.onDispatchAccepted({ correlationId: "corr-d7", capability: "c", subject: "s", acceptedAt: "t" });
+      recorder.onDispatchResolved("corr-d7", "done");
+      expect(regenCall(calls)?.args[0]).toBe(overrideScript);
+    } finally {
+      if (saved !== undefined) process.env.MF_AGENT_STATE_DASHBOARD_SCRIPT = saved;
+      else delete process.env.MF_AGENT_STATE_DASHBOARD_SCRIPT;
     }
   });
 });

--- a/src/common/agents/dispatch-state-recorder.ts
+++ b/src/common/agents/dispatch-state-recorder.ts
@@ -7,8 +7,20 @@
  * host durably records "we owe a response to this task" as a `work_item`:
  *
  *   accepted  → `errands.ts enqueue` (status=pending) + `errands.ts claim` (→ in_flight)
- *   completed → `errands.ts resolve --status=done`
- *   failed    → `errands.ts resolve --status=failed`
+ *   completed → `errands.ts resolve --status=done`   → `dashboard.ts regen`
+ *   failed    → `errands.ts resolve --status=failed` → `dashboard.ts regen`
+ *
+ * cortex#1720 S4a — a terminal resolve is a state transition, so it also
+ * refreshes the derived `dashboard.md` by subprocessing to the bundle's
+ * `dashboard.ts regen` (the CLI REQUIRES the explicit `regen` subcommand —
+ * agent-state#6; a bare invocation prints usage and exits 2). The regen is
+ * fire-and-forget: the dashboard is a DERIVED snapshot (never the source of
+ * truth), so a miss just leaves the previous file, which the next terminal
+ * resolve rebuilds. NO debounce/coalesce for v1 — one regen per terminal
+ * resolve is acceptable (the resolve subprocesses already dominate the cost).
+ * It runs under the SAME soft-skip + non-fatal + hardening contract as the
+ * errands calls and is entirely inside this recorder — the BrainConsumer is
+ * untouched, and a STATELESS agent (which has no recorder) never regenerates.
  *
  * Same contract as the S1 scaffold + S2 replay libs:
  *   - SUBPROCESS ONLY — cortex imports NOTHING from the bundle (platform
@@ -39,6 +51,7 @@
 
 import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
 import { resolveInstanceDir } from "./agent-state-scaffold";
 
 /** Default host label baked into cortex work_item env. */
@@ -105,6 +118,14 @@ export interface DispatchStateRecorderOptions {
   host?: string;
   /** Override path to the bundle's errands.ts (test seam). */
   errandsScript?: string;
+  /**
+   * Override path to the bundle's dashboard.ts (test seam / non-standard
+   * install). Default: the `dashboard.ts` SIBLING of the resolved errands
+   * script — the two always co-locate in the bundle's `skill/scripts/` dir, so
+   * deriving it keeps a single install path to configure while still allowing
+   * an independent override via this seam or `MF_AGENT_STATE_DASHBOARD_SCRIPT`.
+   */
+  dashboardScript?: string;
   /** Override the spawn used to invoke the bundle (test seam). */
   spawn?: RecorderSpawn;
   /** Override the logger (test seam). Default: stderr. */
@@ -162,6 +183,7 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
   private readonly host: string;
   private readonly instanceDir: string;
   private readonly errandsScript: string;
+  private readonly dashboardScript: string;
   private readonly spawn: RecorderSpawn;
   private readonly log: (line: string) => void;
 
@@ -177,6 +199,15 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
     this.host = opts.host ?? DEFAULT_HOST;
     this.instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, this.host);
     this.errandsScript = opts.errandsScript ?? defaultErrandsScript();
+    // cortex#1720 S4a — the dashboard script is the `dashboard.ts` SIBLING of
+    // the errands script (both live in the bundle's `skill/scripts/` dir).
+    // Deriving it from the resolved errands path means a principal who repoints
+    // the errands install automatically repoints the dashboard too, while the
+    // explicit opt / `MF_AGENT_STATE_DASHBOARD_SCRIPT` still allow decoupling.
+    this.dashboardScript =
+      opts.dashboardScript ??
+      process.env.MF_AGENT_STATE_DASHBOARD_SCRIPT ??
+      join(dirname(this.errandsScript), "dashboard.ts");
     this.spawn = opts.spawn ?? defaultRecorderSpawn;
     this.log = opts.log ?? ((line) => process.stderr.write(line));
   }
@@ -251,6 +282,14 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
     // resolve --id <workItemId> --status done|failed. Terminal; the bundle
     // emits `work_item_resolved` itself (no host-side event append).
     this.run(["resolve", "--id", workItemId, "--status", status]);
+
+    // cortex#1720 S4a — the resolve is a state transition; refresh the derived
+    // dashboard. Fire-and-forget (result ignored) and unconditional on the
+    // resolve's own outcome: `dashboard.ts regen` rebuilds from the CURRENT DB
+    // state, so it is truthful whether or not this resolve landed (a failed
+    // resolve leaves the row `in_flight`, which the regenerated dashboard then
+    // shows honestly). One regen per terminal resolve; no debounce for v1.
+    this.regenerateDashboard(correlationId);
   }
 
   /**
@@ -263,12 +302,7 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
     let result: RecorderSpawnResult;
     try {
       result = this.spawn("bun", [this.errandsScript, ...args], {
-        env: {
-          ...process.env,
-          MF_AGENT_NAME: this.agent.id,
-          MF_HOST: this.host,
-          MF_INSTANCE_DIR: this.instanceDir,
-        },
+        env: this.stdEnv(),
       });
     } catch (err) {
       // A THROWING spawn (belt-and-braces — defaultRecorderSpawn returns an
@@ -295,6 +329,69 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
       return null;
     }
     return result.stdout !== undefined ? String(result.stdout) : "";
+  }
+
+  /**
+   * The standard bundle env every subprocess carries (`MF_AGENT_NAME`,
+   * `MF_HOST`, `MF_INSTANCE_DIR`). Shared by the errands `run()` path and the
+   * S4a dashboard regen so both target the SAME instance dir.
+   */
+  private stdEnv(): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      MF_AGENT_NAME: this.agent.id,
+      MF_HOST: this.host,
+      MF_INSTANCE_DIR: this.instanceDir,
+    };
+  }
+
+  /**
+   * cortex#1720 S4a — regenerate the derived `dashboard.md` after a terminal
+   * state transition. TOTAL + NON-THROWING + fire-and-forget, mirroring the
+   * errands soft-skip contract:
+   *   - bundle `dashboard.ts` absent  → logged soft-skip, no spawn;
+   *   - spawn throws / errors / exits non-zero → one log line, no throw.
+   *
+   * The dashboard is a DERIVED snapshot — a miss just leaves the previous file
+   * for the next terminal resolve to rebuild, so failure is never fatal and
+   * never affects the dispatch outcome. Invokes the REQUIRED `regen`
+   * subcommand (agent-state#6): a bare invocation prints usage and exits 2.
+   */
+  private regenerateDashboard(correlationId: string): void {
+    if (!existsSync(this.dashboardScript)) {
+      this.log(
+        `cortex: agent-state — dashboard regen SKIPPED for "${this.agent.id}" ` +
+          `(reason=script-absent; correlation=${correlationId})\n`,
+      );
+      return;
+    }
+
+    let result: RecorderSpawnResult;
+    try {
+      result = this.spawn("bun", [this.dashboardScript, "regen"], {
+        env: this.stdEnv(),
+      });
+    } catch (err) {
+      this.log(
+        `cortex: agent-state — dashboard regen FAILED for "${this.agent.id}" ` +
+          `(non-fatal; spawn threw: ${err instanceof Error ? err.message : String(err)})\n`,
+      );
+      return;
+    }
+    if (result.error) {
+      this.log(
+        `cortex: agent-state — dashboard regen FAILED for "${this.agent.id}" ` +
+          `(non-fatal; spawn-error: ${result.error.message})\n`,
+      );
+      return;
+    }
+    if (result.status !== 0) {
+      const stderr = result.stderr ? String(result.stderr).slice(0, 200) : "";
+      this.log(
+        `cortex: agent-state — dashboard regen FAILED for "${this.agent.id}" ` +
+          `(non-fatal; nonzero-exit status=${result.status}${stderr ? `; stderr: ${stderr}` : ""})\n`,
+      );
+    }
   }
 
   /** Parse `row.id` out of an `enqueue` stdout dump. Null on any shape miss. */


### PR DESCRIPTION
## What

Slice **S4a** of #1720. A dispatch terminal resolve (done/failed) for a **stateful** agent is a state transition, so the dispatch-state-recorder now also refreshes the derived `dashboard.md` by subprocessing to the AgentState bundle's `dashboard.ts regen`.

Builds on S1–S3 (merged, v6.4.0): the optional `state` field, the scaffold lib, `ReplayPending` on activation, and the enqueue/claim/resolve recorder.

## S4a — implementation

- New private `regenerateDashboard()` on `SubprocessDispatchStateRecorder`, called after the `resolve` in `onDispatchResolved`. **Entirely inside the recorder** — the `BrainConsumer` is untouched, so there are zero new dispatch code paths and a **stateless agent (which has no recorder) never regenerates.**
- Invokes the **required** `regen` subcommand — verified against the bundle's actual `skill/scripts/dashboard.ts` + `RegenerateDashboard.md`: a bare invocation prints usage and exits 2 (agent-state#6). We pass `regen`.
- Standard env (`MF_AGENT_NAME`, `MF_HOST=cortex`, `MF_INSTANCE_DIR`) and the **same hardening as the S2/S3 spawns**: stdin ignored, 30s wall-clock timeout, 16 MB maxBuffer (via the shared injected spawn seam).
- **Soft-skip + non-fatal**, symmetric with the errands calls: bundle absent → one logged skip, no spawn; spawn throw / error / non-zero exit → one log line, never throws, never affects the dispatch outcome. The dashboard is a *derived snapshot* — a miss just leaves the previous file for the next terminal resolve to rebuild.
- **Fire-and-forget, off the awaited path.** The recorder methods are synchronous by design (documented in `brain-consumer.ts`) and fire *after* the terminal lifecycle envelope is already published, so they never block the dispatch reply. The regen follows that same model; its result is ignored.
- **No debounce/coalesce for v1** — one regen per terminal resolve is accepted. The resolve subprocesses already dominate the per-dispatch cost, and terminal resolves are not hot enough to warrant coalescing yet. (Noted as a deliberate v1 choice.)
- Dashboard script **derives as the `dashboard.ts` sibling** of the resolved errands script (they co-locate in the bundle's `skill/scripts/`), so a principal who repoints the install moves both. Overridable via the `dashboardScript` opt or `MF_AGENT_STATE_DASHBOARD_SCRIPT`. This also keeps the existing S3 tests hermetic (the temp-dir sibling doesn't exist ⇒ soft-skip ⇒ no stray spawns).

## Tests

8 new recorder cases (`dispatch-state-recorder.test.ts`):
- completed resolve regenerates — asserts `bun <dashboardScript> regen`, standard env, and ordering (regen **after** resolve);
- failed resolve regenerates;
- **no-work-item resolve does NOT regenerate** (no transition ⇒ no regen);
- bundle `dashboard.ts` absent → soft-skip (no regen spawn, resolve still runs, logged `script-absent`, no throw);
- regen non-zero exit → logged `nonzero-exit`, non-fatal;
- regen spawn error → logged `spawn-error`, non-fatal;
- sibling-derivation default targets the errands sibling;
- `MF_AGENT_STATE_DASHBOARD_SCRIPT` override.

"Stateless never regenerates" is covered transitively by the existing boot tests (a stateless fragment gets no recorder).

**Full `bun test`:** 9553 pass / **20 fail** / 9583 tests. Baseline on clean `origin/main` was 9545 pass / **20 fail** — all 20 are the pre-existing `network-secret-cli.test.ts` failures (unrelated to this slice). Fail count **unchanged**; the +8 pass delta is exactly these new tests. `tsc --noEmit` clean, `eslint .` clean.

## S4b — retire `dev-session-store.ts` onto agent-state: **DEFERRED (assessment on #1720)**

Explored and intentionally kept out of this PR. Short version: it needs **new read + payload-upsert CLI surface** on the agent-state bundle (today `errands.ts` exposes only `list|enqueue|claim|resolve|pending` — no read-by-id, no payload mutation), and it would move an **awaited warm-resume read** (`sessionStore.get(chainId)` in `dev-consumer.runPipeline`) from an in-memory `Map.get` onto a subprocess hot path — the opposite of S1–S3's fire-and-forget/off-path/non-fatal contract. Design §3.6b itself scopes "session affinity per correlation chain" as its own F-2 cortex slice. Full rationale, proposed shape, and blockers are in a comment on #1720.

Refs #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)