### PR TITLE
chore: bump to v6.5.0 — RegenerateDashboard on terminal resolve (#1720 S4a)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.4.0"
+version: "6.5.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump for #1757: dashboard regeneration after terminal dispatch resolve for stateful agents. S4b (dev-session-store retirement) deferred pending agent-state#12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)