### PR TITLE
feat(mc): declutter Network view — Guided-join + Pier-queue out, admissions → Governance

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/governance-view-admissions.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/governance-view-admissions.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * MC-B1/B2 (cortex#1278/#1279) — the Pier queue (pending admission requests +
+ * Tier-2 grant/reject) was RELOCATED out of the Network topology view into the
+ * Governance tab's "Admissions" subsection. These tests lock that placement:
+ *
+ *   - the admin queue renders under an "Admissions" heading when the principal
+ *     admins a network with pending requests;
+ *   - the whole Admissions subsection self-effaces (no heading, no panel) when
+ *     the principal admins no networks — the SAME admin-posture gate PierQueue
+ *     itself uses, so the Governance tab is byte-identical for a pure member;
+ *   - it self-effaces when `networks` is omitted (the scoped cockpit mount).
+ *
+ * The verdict/denial audit surface is covered elsewhere; here we render with an
+ * empty governance snapshot and assert only the relocated admissions affordance.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { GovernanceView } from "../components/governance-view";
+import type { GovernanceState } from "../hooks/use-governance";
+import type { NetworkMembershipDTO, MembershipMemberDTO } from "../hooks/use-networks";
+
+/** An empty, loaded governance snapshot — no verdicts, no denials. */
+const EMPTY_STATE: GovernanceState = { data: null, loaded: true, error: null };
+
+function member(
+  over: Partial<MembershipMemberDTO> & { principal: string },
+): MembershipMemberDTO {
+  return { verdict: "pending", present_stacks: [], accepts: "not-accepted", ...over };
+}
+
+function net(over: Partial<NetworkMembershipDTO> & { network_id: string }): NetworkMembershipDTO {
+  return {
+    leaf_node: `${over.network_id}-leaf`,
+    roster_status: "ok",
+    roster_scope: "complete",
+    members: [],
+    confidentiality: { mode: "off", key_present: false, key_id: null },
+    ...over,
+  };
+}
+
+function render(networks?: readonly NetworkMembershipDTO[]): string {
+  return renderToStaticMarkup(
+    createElement(GovernanceView, { state: EMPTY_STATE, networks }),
+  );
+}
+
+describe("GovernanceView — Admissions subsection (relocated Pier queue)", () => {
+  it("renders the Admissions heading + Pier queue for an admin network with pending", () => {
+    const html = render([
+      net({
+        network_id: "alpha",
+        members: [member({ principal: "jc", verdict: "pending" })],
+      }),
+    ]);
+    expect(html).toContain("governance-admissions");
+    expect(html).toContain(">Admissions<");
+    // the relocated queue itself
+    expect(html).toContain("Pier queue");
+    expect(html).toContain("jc");
+  });
+
+  it("self-effaces (no Admissions heading, no queue) when the principal admins no networks", () => {
+    const html = render([net({ network_id: "beta", roster_scope: "self" })]);
+    expect(html).not.toContain("governance-admissions");
+    expect(html).not.toContain(">Admissions<");
+    expect(html).not.toContain("Pier queue");
+  });
+
+  it("self-effaces when networks is omitted (the scoped cockpit mount)", () => {
+    const html = render();
+    expect(html).not.toContain("governance-admissions");
+    expect(html).not.toContain("Pier queue");
+  });
+});

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -155,7 +155,10 @@ export function App() {
   // MC-A1 (cortex#1275) — joined networks + admitted roster ⋈ presence, for the
   // Network view's first-class trust-group panel. Fetched only when the tab is
   // visible; refreshes off the same `agent.presence` signal as `useAgents`.
-  const networks = useNetworks(ws, view === "network");
+  // Also enabled on the Governance tab: its "Admissions" subsection (the
+  // relocated Pier queue) reads the joined-networks roster to surface pending
+  // admission requests for networks the principal admins.
+  const networks = useNetworks(ws, view === "network" || view === "governance");
   // G-1115 — governance verdicts. Enabled on the legacy Governance tab AND on the
   // Network tab (CK-3): the cockpit's GOVERN lane folds this audit scoped to the
   // dived stack. Same single-snapshot rationale as `attention` above.
@@ -614,7 +617,7 @@ export function App() {
           /* G-1115 — read-only governance audit surface: verdicts from the
              governed-action stack (pulse P-702) read back off the bus. CK-3/D-1:
              folded into the stack cockpit; this whole-dashboard tab is `?legacy=1`. */
-          <GovernanceView state={governance} />
+          <GovernanceView state={governance} networks={networks.networks} />
         )}
 
         {view === "observability" && (

--- a/src/surface/mc/dashboard-v2/components/governance-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/governance-view.tsx
@@ -21,6 +21,13 @@ import type {
   GovernanceVerdictRow,
   GovernanceDenialRow,
 } from "../../db/governance";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+// MC-B1/B2 (cortex#1278/#1279) — the Pier queue (pending admission requests +
+// Tier-2 grant/reject) lives here in Governance rather than cluttering the
+// Network topology view. Self-effacing under its own admin-posture gate: renders
+// nothing for a principal who admins no networks (§Posture in pier-queue.tsx).
+import { PierQueue } from "./pier-queue";
+import { selectPierQueue } from "../lib/pier-queue-adapter";
 
 const LAYER_LABEL: Record<string, string> = {
   l0: "L0 policy",
@@ -42,9 +49,16 @@ function when(createdAt: number): string {
 
 export interface GovernanceViewProps {
   state: GovernanceState;
+  /**
+   * Joined networks (admitted roster ⋈ presence). Feeds the "Admissions"
+   * subsection (the relocated Pier queue). Optional: the scoped cockpit mount
+   * omits it, so the admissions affordance appears only on the full Governance
+   * tab. `PierQueue` self-effaces when the principal admins no networks.
+   */
+  networks?: readonly NetworkMembershipDTO[];
 }
 
-export function GovernanceView({ state }: GovernanceViewProps) {
+export function GovernanceView({ state, networks }: GovernanceViewProps) {
   const { data, loaded, error } = state;
 
   const hasAnyData =
@@ -89,6 +103,18 @@ export function GovernanceView({ state }: GovernanceViewProps) {
           <DenialsSection data={data} />
         </>
       )}
+
+      {/* MC-B1/B2 — Admissions: the Pier queue (pending admission requests +
+          Tier-2 grant/reject), relocated here from the Network view. Rendered
+          independent of the verdict/denial window above; self-effaces (renders
+          nothing) when the principal admins no networks or no networks were
+          passed (the scoped cockpit mount). */}
+      {networks && selectPierQueue(networks).adminNetworkCount > 0 ? (
+        <div className="governance-subsection governance-admissions" aria-label="Admissions">
+          <h3>Admissions</h3>
+          <PierQueue networks={networks} />
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
@@ -27,16 +27,6 @@ import {
   rosterStatusBadge,
   summarizeMembership,
 } from "../lib/network-membership-adapter";
-// FLG-1 (docs/plan-mc-future-state.md §4.D) — the guided-join handoff banner, a
-// strip per joined network (R1 render home; CK-7 rehomes it into the cockpit).
-// Self-fetching + SSR-inert (renders nothing until the read resolves), so the
-// panel stays effectively pure and a non-federated stack is unchanged.
-import { HandoffBannerLive } from "./handoff-banner";
-// FLG-3 (docs/plan-mc-future-state.md §4.D) — the network doctor drill ("why is
-// this red"), an on-demand control per joined network (R1 render home; CK-7
-// rehomes it into the cockpit + wires red-edge drilling). Self-fetching only on
-// click, so the panel stays effectively pure.
-import { DoctorDrill } from "./network-doctor-panel";
 
 export interface NetworkRosterPanelProps {
   networks: readonly NetworkMembershipDTO[];
@@ -106,15 +96,10 @@ export function NetworkRosterPanel({
                     : ""}
                 </span>
               </div>
-              {/* FLG-1 — the guided-join handoff banner for THIS stack's own
-                  join to this network (member = the local principal). Self-
-                  fetching + SSR-inert: renders nothing until the read resolves,
-                  and nothing at all on a stack with no local principal. */}
-              <HandoffBannerLive networkId={net.network_id} member={localPrincipal} />
-              {/* FLG-3 — the doctor drill for THIS network. On-demand (a live
-                  per-peer probe), collapsed to a button until the principal
-                  asks "why is this red?". */}
-              <DoctorDrill networkId={net.network_id} />
+              {/* Guided-join handoff banner + doctor drill removed from the
+                  roster (they are join/onboarding affordances, not roster
+                  state). The roster stays a pure trust-group view: group header
+                  + membership rows + former members. */}
               {net.members.length === 0 ? (
                 <div className="dim network-roster-empty">
                   No admitted members resolved.

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -89,7 +89,6 @@ import { NetworkFilterBar } from "./network-filter-bar";
 import "./constellation-canvas.css";
 import { NetworkSpotlight } from "./network-spotlight";
 import { NetworkRosterPanel } from "./network-roster-panel";
-import { PierQueue } from "./pier-queue";
 import { McShell } from "./mc-shell";
 import { McCockpit } from "./mc-cockpit";
 import {
@@ -718,10 +717,10 @@ export function NetworkView({
           presence → membership verdict). Renders nothing when none are joined. */}
       <NetworkRosterPanel networks={networks} localPrincipal={servingPrincipal} />
 
-      {/* MC-B1 (cortex#1278) — Pier queue: PENDING admission requests for the
-          networks this principal ADMINS (admin posture). Read-only; renders
-          nothing when the principal admins no networks. */}
-      <PierQueue networks={networks} />
+      {/* MC-B1 (cortex#1278) — the Pier queue (PENDING admission requests +
+          Tier-2 grant/reject) is an admin/onboarding control, relocated OUT of
+          the Network topology view into the Governance tab's "Admissions"
+          subsection to keep this view focused on topology (roster + graph). */}
 
       {mode === "error" && (
         <div className="network-view-error">⚠ {state.error}</div>


### PR DESCRIPTION
Principal direction (live UI review): the main **Network** view should show topology, not admin/onboarding blocks.

## What
- **network-view.tsx** — removed the `<PierQueue>` mount + import. Roster + constellation untouched.
- **network-roster-panel.tsx** — removed the **Guided-join / handoff banner** (`HandoffBannerLive`) + the **"Diagnose — why is this red?"** drill (`DoctorDrill`). **Kept**: group header (id · leaf · roster-status · encrypted chip · present/absent summary), all per-principal membership rows, and the Former-members group. (Both removed components remain in the tree, still tested standalone — relocatable later.)
- **governance-view.tsx** — mounted `<PierQueue>` in a new **"Admissions"** subsection (grant/reject travels with it via `PierDecideForm`), gated by the same admin-posture check PierQueue uses internally.
- **app.tsx** — enabled `useNetworks` on the Governance tab + passed `networks` through.

## Tests
`governance-view-admissions.test.tsx` (3 new cases) + touched-component suites → 27 pass / 0 fail. tsc 0, eslint clean, additive (no deletions).

## Residual (follow-up, not blocking)
The full-tab Governance mount is `?legacy=1`-gated, so Admissions currently surfaces on the legacy Governance tab; the cockpit's scoped Governance fold intentionally omits `networks`. Where Admissions primarily lives is a follow-up decision (and the target design moves admit to a compact per-stack GOVERN affordance anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)