### PR TITLE
feat(mc): fold access/dispatch/reflex system.* families into Mission Control (migration + renderer + attention) (#1661)

### DIFF
--- a/src/surface/mc/__tests__/1661-observability-family-migration.test.ts
+++ b/src/surface/mc/__tests__/1661-observability-family-migration.test.ts
@@ -1,0 +1,189 @@
+/**
+ * #1661 (MC folds) — existing-DB rebuild migration for observability_events.family.
+ *
+ * Proves the table-rebuild (widen the 4-family CHECK to 7 families) is DATA-SAFE
+ * and BOOT-SAFE on an existing DB. This table's migration ordering caused the MC
+ * embed boot crashes #1048/#961, so the test models the HARD case: a faithful
+ * pre-U3.3 DB (OLD 4-family CHECK, and NO origin_kind/origin_peer columns), then
+ * reopens via initDatabase. That exercises the real ordering — COLUMN_ADD_MIGRATIONS
+ * adds the origin columns FIRST, then REBUILD_MIGRATIONS copies them — and asserts
+ * initDatabase does not throw, every row/column survives, and the CHECK is relaxed.
+ *
+ * No table references observability_events (append-only projection), so there is
+ * no FK-rollback case to cover (unlike tasks in d7c-source-system-migration.test).
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { SCHEMA_SQL, COLUMN_ADD_MIGRATIONS } from "../db/schema";
+import { initDatabase } from "../db/init";
+
+// The pre-U3.3 observability_events shape — base columns WITH the OLD 4-family
+// CHECK and WITHOUT origin_kind/origin_peer (those are added by the U3.3
+// COLUMN_ADD_MIGRATIONS, exactly as on a real running U2.1 stack).
+const OLD_OBSERVABILITY = `CREATE TABLE IF NOT EXISTS observability_events (
+  id TEXT PRIMARY KEY,
+  envelope_id TEXT NOT NULL UNIQUE,
+  family TEXT NOT NULL
+    CHECK(family IN ('signal','collector','federation','transport')),
+  type TEXT NOT NULL,
+  stack_id TEXT,
+  summary TEXT,
+  payload TEXT NOT NULL DEFAULT '{}',
+  timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+)`;
+
+/** Build a faithful pre-#1661 DB: full schema, but the OLD (4-family CHECK, no
+ *  origin columns) observability_events table + the U3.3 column-adds applied. */
+function buildOldDb(path: string): Database {
+  const db = new Database(path, { create: true });
+  db.run("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) {
+    db.run(
+      sql.includes("CREATE TABLE IF NOT EXISTS observability_events (")
+        ? OLD_OBSERVABILITY
+        : sql,
+    );
+  }
+  // Apply the column-adds exactly as the old code would have (adds
+  // origin_kind/origin_peer to observability_events + its origin index).
+  for (const m of COLUMN_ADD_MIGRATIONS) {
+    const present = db.query(`SELECT 1 FROM pragma_table_info(?) WHERE name = ?`).get(m.table, m.column);
+    if (!present) db.run(m.ddl);
+    if (m.post) for (const s of m.post) db.run(s);
+  }
+  return db;
+}
+
+describe("#1661 — observability_events.family CHECK rebuild migration", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) {
+      for (const suffix of ["", "-wal", "-shm"]) if (existsSync(p + suffix)) rmSync(p + suffix);
+    }
+    paths.length = 0;
+  });
+  function freshPath() {
+    const p = join(tmpdir(), `mc1661-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return p;
+  }
+
+  it("does not crash boot, preserves rows + origin columns, and widens the CHECK", () => {
+    const path = freshPath();
+
+    // --- seed a pre-#1661 DB: one row per OLD family, incl. a foreign-origin row.
+    const old = buildOldDb(path);
+    old.run(
+      `INSERT INTO observability_events (id, envelope_id, family, type, summary, payload, origin_kind, origin_peer)
+       VALUES ('o-1', 'env-1', 'signal', 'system.signal.tap.started', 'tap up', '{"a":1}', 'local', NULL)`,
+    );
+    old.run(
+      `INSERT INTO observability_events (id, envelope_id, family, type, origin_kind, origin_peer)
+       VALUES ('o-2', 'env-2', 'federation', 'system.federation.peer.sealed', 'foreign', 'nikita/main')`,
+    );
+    // The OLD CHECK rejects a #1661 family before the rebuild.
+    expect(() =>
+      old.run(
+        `INSERT INTO observability_events (id, envelope_id, family, type) VALUES ('o-bad', 'env-bad', 'access', 'system.access.denied')`,
+      ),
+    ).toThrow();
+    old.close();
+
+    // --- reopen via initDatabase → column-adds (no-op, columns present) THEN the rebuild.
+    const db = initDatabase(path);
+
+    // CHECK widened — the stored schema now lists the three #1661 families.
+    const sql = (db.query(`SELECT sql FROM sqlite_master WHERE name='observability_events'`).get() as { sql: string }).sql;
+    expect(sql).toMatch(/'access'/);
+    expect(sql).toMatch(/'dispatch'/);
+    expect(sql).toMatch(/'reflex'/);
+
+    // Data preserved exactly — including the U3.3 origin columns.
+    const r1 = db.query(`SELECT * FROM observability_events WHERE id='o-1'`).get() as Record<string, unknown>;
+    expect(r1.family).toBe("signal");
+    expect(r1.envelope_id).toBe("env-1");
+    expect(r1.origin_kind).toBe("local");
+    expect(r1.payload).toBe('{"a":1}');
+    const r2 = db.query(`SELECT * FROM observability_events WHERE id='o-2'`).get() as Record<string, unknown>;
+    expect(r2.origin_kind).toBe("foreign");
+    expect(r2.origin_peer).toBe("nikita/main");
+
+    // All three new families now insert (CHECK relaxed).
+    for (const [i, fam, type] of [
+      [1, "access", "system.access.denied"],
+      [2, "dispatch", "system.dispatch.stage"],
+      [3, "reflex", "reflex.activation.fired"],
+    ] as const) {
+      expect(() =>
+        db.run(
+          `INSERT INTO observability_events (id, envelope_id, family, type) VALUES ('n-${i}', 'nenv-${i}', '${fam}', '${type}')`,
+        ),
+      ).not.toThrow();
+    }
+
+    // A bogus family is still rejected (the CHECK is widened, not dropped).
+    expect(() =>
+      db.run(
+        `INSERT INTO observability_events (id, envelope_id, family, type) VALUES ('o-x', 'env-x', 'nonsense', 't')`,
+      ),
+    ).toThrow();
+
+    // The origin_kind CHECK still holds, and envelope_id UNIQUE survived the rebuild.
+    expect(() =>
+      db.run(
+        `INSERT INTO observability_events (id, envelope_id, family, type, origin_kind) VALUES ('o-ok', 'env-ok', 'signal', 't', 'bogus')`,
+      ),
+    ).toThrow();
+    expect(() =>
+      db.run(
+        `INSERT INTO observability_events (id, envelope_id, family, type) VALUES ('o-dup', 'env-1', 'signal', 't')`,
+      ),
+    ).toThrow();
+
+    // Indexes recreated (timestamp, family, and the U3.3 origin composite).
+    const names = (db.query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='observability_events'`).all() as { name: string }[]).map((r) => r.name);
+    expect(names).toContain("idx_observability_timestamp");
+    expect(names).toContain("idx_observability_family");
+    expect(names).toContain("idx_observability_origin");
+
+    // Integrity intact.
+    expect(db.query(`PRAGMA foreign_key_check`).all()).toEqual([]);
+    db.close();
+  });
+
+  it("is idempotent — a second init does not re-rebuild or error, data intact", () => {
+    const path = freshPath();
+    const old = buildOldDb(path);
+    old.run(
+      `INSERT INTO observability_events (id, envelope_id, family, type) VALUES ('o-1', 'env-1', 'signal', 't')`,
+    );
+    old.close();
+
+    const db1 = initDatabase(path);
+    db1.close();
+    // Second open: detect() sees the widened CHECK → skips the rebuild cleanly.
+    const db2 = initDatabase(path);
+    expect((db2.query(`SELECT COUNT(*) c FROM observability_events`).get() as { c: number }).c).toBe(1);
+    // Still accepts a new family (proves the widened CHECK persisted, not re-narrowed).
+    expect(() =>
+      db2.run(`INSERT INTO observability_events (id, envelope_id, family, type) VALUES ('o-2', 'env-2', 'reflex', 'reflex.activation.fired')`),
+    ).not.toThrow();
+    db2.close();
+  });
+
+  it("a fresh DB is born wide — 7-family CHECK, no rebuild needed", () => {
+    const path = freshPath();
+    const db = initDatabase(path);
+    const sql = (db.query(`SELECT sql FROM sqlite_master WHERE name='observability_events'`).get() as { sql: string }).sql;
+    expect(sql).toMatch(/'access'/);
+    for (const fam of ["access", "dispatch", "reflex"]) {
+      expect(() =>
+        db.run(`INSERT INTO observability_events (id, envelope_id, family, type) VALUES ('f-${fam}', 'fenv-${fam}', '${fam}', 't')`),
+      ).not.toThrow();
+    }
+    db.close();
+  });
+});

--- a/src/surface/mc/__tests__/observability-renderer.test.ts
+++ b/src/surface/mc/__tests__/observability-renderer.test.ts
@@ -24,8 +24,12 @@ import {
   projectForeignObservability,
   familyForType,
 } from "../projection/observability-renderer";
-import { produceObservabilityAttention } from "../projection/observability-attention";
+import {
+  produceObservabilityAttention,
+  ACCESS_DENIED_ATTENTION_PREFIX,
+} from "../projection/observability-attention";
 import { ADAPTER_ATTENTION_PREFIX } from "../projection/adapter-lifecycle";
+import { resolveAttentionItem } from "../db/attention";
 import {
   listObservabilityEvents,
   countObservabilityByFamily,
@@ -345,5 +349,170 @@ describe("createObservabilityProjectionRenderer", () => {
     const r = createObservabilityProjectionRenderer(db);
     await r.render(envelope("system.signal.received", {}), undefined, "local.andreas.work.system.signal.received");
     expect(countObservabilityByFamily(db).signal).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1661 (MC folds) — the three cortex-LOCAL families (access/dispatch/reflex)
+// ---------------------------------------------------------------------------
+
+describe("#1661 — familyForType routes the cortex-local families", () => {
+  it("routes access (denied/filtered) + admission (throttled/degraded)", () => {
+    expect(familyForType("system.access.denied")).toBe("access");
+    expect(familyForType("system.access.filtered")).toBe("access");
+    expect(familyForType("system.admission.throttled")).toBe("access");
+    expect(familyForType("system.admission.degraded")).toBe("access");
+  });
+
+  it("routes dispatch (stage / inbound.aborted / bus.process)", () => {
+    expect(familyForType("system.dispatch.stage")).toBe("dispatch");
+    expect(familyForType("system.inbound.aborted")).toBe("dispatch");
+    expect(familyForType("system.bus.process")).toBe("dispatch");
+  });
+
+  it("routes reflex.activation.*", () => {
+    expect(familyForType("reflex.activation.fired")).toBe("reflex");
+    expect(familyForType("reflex.activation.decision")).toBe("reflex");
+  });
+
+  it("EXCLUDES high-volume siblings by design (narrow type set, not a prefix)", () => {
+    expect(familyForType("system.access.allowed")).toBeNull();
+    expect(familyForType("system.bus.peer_dispatch_received")).toBeNull();
+    expect(familyForType("system.bus.notify_discord")).toBeNull();
+    expect(familyForType("system.dispatch.dead_letter")).toBeNull();
+  });
+});
+
+describe("#1661 — projectObservability folds each new family into a row", () => {
+  let db: Database;
+  let broadcasts: WsServerMessage[];
+  let fakeRegistry: WsClientRegistry;
+
+  beforeEach(() => {
+    db = setupDb();
+    broadcasts = [];
+    fakeRegistry = {
+      broadcast: (msg: WsServerMessage) => broadcasts.push(msg),
+    } as unknown as WsClientRegistry;
+  });
+  afterEach(() => db.close());
+
+  it("a synthetic emit of EACH new family lands exactly one row", () => {
+    expect(
+      projectObservability(db, envelope("system.access.denied", { principal_id: "andreas", capability: "dispatch.task.received" }), fakeRegistry),
+    ).toBe("access");
+    expect(
+      projectObservability(db, envelope("system.dispatch.stage", { stack_id: "work" }), fakeRegistry),
+    ).toBe("dispatch");
+    expect(
+      projectObservability(db, envelope("reflex.activation.fired", { summary: "reflex ran" }), fakeRegistry),
+    ).toBe("reflex");
+
+    const counts = countObservabilityByFamily(db);
+    expect(counts.access).toBe(1);
+    expect(counts.dispatch).toBe(1);
+    expect(counts.reflex).toBe(1);
+    expect(listObservabilityEvents(db, 10, "reflex")[0]?.summary).toBe("reflex ran");
+  });
+});
+
+describe("#1661 — attention: admission lifecycle + access.denied", () => {
+  let db: Database;
+  beforeEach(() => (db = setupDb()));
+  afterEach(() => db.close());
+
+  it("admission.degraded OPENS (mode=degraded-local) and RESOLVES (mode=recovered) — ONE type", () => {
+    const open = produceObservabilityAttention(db, {
+      type: "system.admission.degraded",
+      payload: { mode: "degraded-local", bucket: "admission_andreas_work", detail: "kv down" },
+    });
+    expect(open).toMatchObject({ action: "opened" });
+    expect(open?.itemId).toBe(`${ADAPTER_ATTENTION_PREFIX}admission:admission_andreas_work`);
+    expect(attentionRow(db, open!.itemId)?.status).toBe("open");
+
+    const recovered = produceObservabilityAttention(db, {
+      type: "system.admission.degraded",
+      payload: { mode: "recovered", bucket: "admission_andreas_work", detail: "kv back" },
+    });
+    expect(recovered).toMatchObject({ action: "resolved" });
+    expect(recovered?.itemId).toBe(open?.itemId);
+    expect(attentionRow(db, open!.itemId)?.status).toBe("resolved");
+  });
+
+  it("admission.degraded falls back to the 'admission' id when bucket is absent", () => {
+    const open = produceObservabilityAttention(db, {
+      type: "system.admission.degraded",
+      payload: { mode: "degraded-local", detail: "x" },
+    });
+    expect(open?.itemId).toBe(`${ADAPTER_ATTENTION_PREFIX}admission:admission`);
+  });
+
+  it("admission.throttled is history-only (no attention)", () => {
+    expect(
+      produceObservabilityAttention(db, { type: "system.admission.throttled", payload: { principal_id: "a", capability: "c" } }),
+    ).toBeNull();
+  });
+
+  it("access.denied opens a HIGH-severity item collapsed by (principal_id + capability)", () => {
+    const one = produceObservabilityAttention(db, {
+      type: "system.access.denied",
+      payload: { principal_id: "andreas", capability: "dispatch.task.received" },
+    });
+    expect(one).toMatchObject({ action: "opened" });
+    expect(one?.itemId).toBe(`${ACCESS_DENIED_ATTENTION_PREFIX}andreas:dispatch.task.received`);
+    const row = db.query(`SELECT severity, status FROM attention_items WHERE id = ?`).get(one!.itemId) as { severity: string; status: string };
+    expect(row.severity).toBe("high");
+    expect(row.status).toBe("open");
+
+    // A second denial for the SAME key collapses into the same one item.
+    const two = produceObservabilityAttention(db, {
+      type: "system.access.denied",
+      payload: { principal_id: "andreas", capability: "dispatch.task.received" },
+    });
+    expect(two?.itemId).toBe(one?.itemId);
+    expect((db.query(`SELECT COUNT(*) AS n FROM attention_items`).get() as { n: number }).n).toBe(1);
+
+    // A different capability is a DIFFERENT item (collapse key includes capability).
+    produceObservabilityAttention(db, {
+      type: "system.access.denied",
+      payload: { principal_id: "andreas", capability: "other.cap" },
+    });
+    expect((db.query(`SELECT COUNT(*) AS n FROM attention_items`).get() as { n: number }).n).toBe(2);
+  });
+
+  it("access.denied has NO auto-resolve and is principal-acked (a cleared key is never resurrected)", () => {
+    const payload = { principal_id: "andreas", capability: "dispatch.task.received" };
+    const open = produceObservabilityAttention(db, { type: "system.access.denied", payload });
+    expect(open).toMatchObject({ action: "opened" });
+    // The principal resolves it (CK-6b resolve/dismiss).
+    resolveAttentionItem(db, open!.itemId);
+    expect(attentionRow(db, open!.itemId)?.status).toBe("resolved");
+    // A redelivered (or fresh) denial for the same key does NOT reopen it.
+    const again = produceObservabilityAttention(db, { type: "system.access.denied", payload });
+    expect(again).toBeNull();
+    expect(attentionRow(db, open!.itemId)?.status).toBe("resolved");
+  });
+
+  it("dispatch + reflex families are fold-only (never attention)", () => {
+    expect(produceObservabilityAttention(db, { type: "system.dispatch.stage", payload: {} })).toBeNull();
+    expect(produceObservabilityAttention(db, { type: "system.inbound.aborted", payload: {} })).toBeNull();
+    expect(produceObservabilityAttention(db, { type: "system.bus.process", payload: {} })).toBeNull();
+    expect(produceObservabilityAttention(db, { type: "reflex.activation.fired", payload: {} })).toBeNull();
+  });
+});
+
+describe("#1661 — renderer subjects include the new families (still local-only)", () => {
+  it("subscribes to the exact access/dispatch/reflex local subjects", () => {
+    const db = setupDb();
+    const r = createObservabilityProjectionRenderer(db);
+    expect(r.subjects.some((s) => s.includes("system.access.denied"))).toBe(true);
+    expect(r.subjects.some((s) => s.includes("system.admission.degraded"))).toBe(true);
+    expect(r.subjects.some((s) => s.includes("system.dispatch.stage"))).toBe(true);
+    expect(r.subjects.some((s) => s.includes("system.bus.process"))).toBe(true);
+    expect(r.subjects.some((s) => s.includes("reflex.activation"))).toBe(true);
+    // The U3.3 local-only invariant still holds for the added subjects.
+    expect(r.subjects.every((s) => s.startsWith("local."))).toBe(true);
+    expect(r.subjects.some((s) => s.startsWith("federated."))).toBe(false);
+    db.close();
   });
 });

--- a/src/surface/mc/db/observability.ts
+++ b/src/surface/mc/db/observability.ts
@@ -16,14 +16,35 @@
 
 import type { Database } from "bun:sqlite";
 
-/** The four section families. `signal` + `collector` together are "signal health". */
-export type ObservabilityFamily = "signal" | "collector" | "federation" | "transport";
+/**
+ * The section families. `signal` + `collector` together are "signal health".
+ *
+ * The first four are signal-side. #1661 (MC folds) adds three cortex-LOCAL
+ * families for gateway/dispatch/reflex system envelopes:
+ *   - `access`   — `system.access.*` + `system.admission.*`
+ *   - `dispatch` — `system.dispatch.stage` + `system.inbound.aborted` + `system.bus.process`
+ *   - `reflex`   — `reflex.activation.*`
+ * The DB `family` CHECK is widened to match (schema.ts + the #1661 rebuild
+ * migration). Frontend sections for these families are a DEFERRED fast-follow
+ * (#1661 (C)) — the rows land and the API returns them regardless.
+ */
+export type ObservabilityFamily =
+  | "signal"
+  | "collector"
+  | "federation"
+  | "transport"
+  | "access"
+  | "dispatch"
+  | "reflex";
 
 export const OBSERVABILITY_FAMILIES: readonly ObservabilityFamily[] = [
   "signal",
   "collector",
   "federation",
   "transport",
+  "access",
+  "dispatch",
+  "reflex",
 ] as const;
 
 /**

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -634,11 +634,18 @@ export const SCHEMA_SQL: string[] = [
   //     never from the attacker-controlled payload — so a peer row can NEVER be
   //     shown as local (the negative control's identity half).
   // Fresh DBs get them here; existing DBs backfill via COLUMN_ADD_MIGRATIONS.
+  // #1661 (MC folds) — three cortex-LOCAL families join the four signal-side
+  // ones: `access` (system.access.* + system.admission.*), `dispatch`
+  // (system.dispatch.stage + system.inbound.aborted + system.bus.process), and
+  // `reflex` (reflex.activation.*). The `family` CHECK below is widened for
+  // fresh DBs; existing DBs migrate via the guarded observability_events entry
+  // in REBUILD_MIGRATIONS (SQLite can't ALTER a CHECK). Grouping decision
+  // (3 families, not 6) is the principal's #1661 (B) call.
   `CREATE TABLE IF NOT EXISTS observability_events (
     id TEXT PRIMARY KEY,
     envelope_id TEXT NOT NULL UNIQUE,
     family TEXT NOT NULL
-      CHECK(family IN ('signal','collector','federation','transport')),
+      CHECK(family IN ('signal','collector','federation','transport','access','dispatch','reflex')),
     type TEXT NOT NULL,
     stack_id TEXT,
     summary TEXT,
@@ -908,6 +915,67 @@ export const REBUILD_MIGRATIONS: RebuildMigration[] = [
          ON tasks(status, priority, updated_at DESC)`,
       `CREATE INDEX IF NOT EXISTS idx_tasks_iteration ON tasks(iteration_id)`,
       `CREATE INDEX IF NOT EXISTS idx_tasks_work_item ON tasks(work_item_id)`,
+    ],
+  },
+
+  // #1661 (MC folds) — widen the observability_events `family` CHECK for
+  // EXISTING DBs. Fresh DBs already get the 7-family CHECK from SCHEMA_SQL;
+  // this rebuild relaxes the OLD 4-family CHECK the running U2.1/U3.3 stacks
+  // carry (SQLite can't `ALTER ... DROP CONSTRAINT`). Same recipe as tasks:
+  // new table → copy (explicit column list) → drop → rename → recreate indexes,
+  // run by init.ts AFTER COLUMN_ADD_MIGRATIONS with foreign_keys OFF, inside a
+  // transaction, verified by foreign_key_check.
+  //
+  // ⚠️ FULL-SHAPE: `steps` reproduces the table's ENTIRE current shape = base
+  // SCHEMA_SQL columns + every COLUMN_ADD_MIGRATIONS column (origin_kind,
+  // origin_peer — P-14 U3.3 / #937). Because init.ts runs COLUMN_ADD_MIGRATIONS
+  // before this rebuild, on a pre-U3.3 old-shape DB both origin columns already
+  // exist on the live table by the time the INSERT copies them. If a future
+  // column-add lands on observability_events, it MUST be added to the DDL below
+  // until this migration is retired. No table references observability_events
+  // (append-only projection), so foreign_key_check is trivially clean here.
+  {
+    table: "observability_events",
+    // Old shape carried exactly the 4-family CHECK. Match it precisely so the
+    // rebuild is idempotent: post-migration the CHECK lists 7 families and this
+    // regex no longer matches, so it never re-runs.
+    detect: (sql) =>
+      /CHECK\s*\(\s*family\s+IN\s*\(\s*'signal'\s*,\s*'collector'\s*,\s*'federation'\s*,\s*'transport'\s*\)\s*\)/i.test(
+        sql,
+      ),
+    steps: [
+      // New observability_events shape: identical to SCHEMA_SQL's CREATE TABLE
+      // (incl. origin_kind/origin_peer from U3.3) with the family CHECK widened
+      // to the 7 families. envelope_id keeps its UNIQUE (idempotent redelivery).
+      `CREATE TABLE observability_events_new (
+        id TEXT PRIMARY KEY,
+        envelope_id TEXT NOT NULL UNIQUE,
+        family TEXT NOT NULL
+          CHECK(family IN ('signal','collector','federation','transport','access','dispatch','reflex')),
+        type TEXT NOT NULL,
+        stack_id TEXT,
+        summary TEXT,
+        payload TEXT NOT NULL DEFAULT '{}',
+        origin_kind TEXT NOT NULL DEFAULT 'local'
+          CHECK(origin_kind IN ('local','foreign')),
+        origin_peer TEXT,
+        timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+      )`,
+      // Explicit column list (never SELECT *) so a shape mismatch errors loudly.
+      `INSERT INTO observability_events_new
+         (id, envelope_id, family, type, stack_id, summary, payload,
+          origin_kind, origin_peer, timestamp)
+       SELECT
+          id, envelope_id, family, type, stack_id, summary, payload,
+          origin_kind, origin_peer, timestamp
+       FROM observability_events`,
+      `DROP TABLE observability_events`,
+      `ALTER TABLE observability_events_new RENAME TO observability_events`,
+      // Recreate the indexes (SCHEMA_SQL's timestamp + family, and the U3.3
+      // origin composite that COLUMN_ADD_MIGRATIONS' post[] declares).
+      `CREATE INDEX IF NOT EXISTS idx_observability_timestamp ON observability_events(timestamp)`,
+      `CREATE INDEX IF NOT EXISTS idx_observability_family ON observability_events(family, timestamp DESC)`,
+      `CREATE INDEX IF NOT EXISTS idx_observability_origin ON observability_events(origin_kind, origin_peer)`,
     ],
   },
 ];

--- a/src/surface/mc/projection/observability-attention.ts
+++ b/src/surface/mc/projection/observability-attention.ts
@@ -28,9 +28,22 @@
 
 import type { Database } from "bun:sqlite";
 
-import { upsertAttentionItem, resolveAttentionItem } from "../db/attention";
+import {
+  upsertAttentionItem,
+  resolveAttentionItem,
+  getAttentionItem,
+} from "../db/attention";
 import { ADAPTER_ATTENTION_PREFIX } from "./adapter-lifecycle";
 import type { AttentionItem } from "../types";
+
+/**
+ * #1661 (MC folds) — attention id prefix for `system.access.denied`. Distinct
+ * from the substrate-health `att:adapter:` namespace: a denial is a governance
+ * event, not an adapter outage. The id COLLAPSES BY KEY on `{principal_id}:{
+ * capability}` (decision D) so a storm of denials for the same principal+
+ * capability is ONE high-severity item, not a flood.
+ */
+export const ACCESS_DENIED_ATTENTION_PREFIX = "att:access:denied:";
 
 export interface ProjectableObservabilityEnvelope {
   id?: string;
@@ -86,14 +99,29 @@ export function produceObservabilityAttention(
   db: Database,
   envelope: ProjectableObservabilityEnvelope,
 ): ObservabilityAttentionResult | null {
-  const mapping = classify(envelope.type);
-  if (mapping === null) return null;
-
   const rawPayload: unknown = envelope.payload;
   const payload: Record<string, unknown> =
     typeof rawPayload === "object" && rawPayload !== null
       ? (rawPayload as Record<string, unknown>)
       : {};
+
+  // #1661 — admission degraded/recovered lifecycle. Decision (D): ONE type
+  // (`system.admission.degraded`) carries a `mode` field, NOT a `.recovered`
+  // twin. Branch the open/resolve lifecycle on payload.mode, keyed by the
+  // admission KV `bucket` so a multi-stack view groups by store.
+  if (envelope.type === "system.admission.degraded") {
+    return admissionAttention(db, payload);
+  }
+
+  // #1661 — access.denied → high-severity, collapse-by-key, principal-acked,
+  // NO auto-resolve (decision D). No producer branch ever resolves it — only
+  // the principal (CK-6b resolve/dismiss) clears it.
+  if (envelope.type === "system.access.denied") {
+    return accessDeniedAttention(db, payload);
+  }
+
+  const mapping = classify(envelope.type);
+  if (mapping === null) return null;
 
   let originId: string | null = null;
   for (const key of mapping.idKeys) {
@@ -122,5 +150,70 @@ export function produceObservabilityAttention(
     status: "open",
   };
   upsertAttentionItem(db, item);
+  return { action: "opened", itemId };
+}
+
+/**
+ * #1661 — `system.admission.degraded` open/resolve, branched on payload.mode
+ * (decision D: ONE type + mode field, not a `.recovered` twin). `mode ===
+ * "recovered"` resolves the item; any other transition (`"degraded-local"`)
+ * opens it. Keyed by the admission KV `bucket` (falls back to `admission` so a
+ * payload missing the bucket still yields a deterministic, resolvable item).
+ */
+function admissionAttention(
+  db: Database,
+  payload: Record<string, unknown>,
+): ObservabilityAttentionResult | null {
+  const bucket = asString(payload.bucket) ?? "admission";
+  const itemId = `${ADAPTER_ATTENTION_PREFIX}admission:${bucket}`;
+
+  if (asString(payload.mode) === "recovered") {
+    resolveAttentionItem(db, itemId);
+    return { action: "resolved", itemId };
+  }
+
+  upsertAttentionItem(db, {
+    id: itemId,
+    stackId: `admission:${bucket}`,
+    workItemId: null,
+    sessionId: null,
+    kind: "blocked",
+    severity: "high",
+    status: "open",
+  });
+  return { action: "opened", itemId };
+}
+
+/**
+ * #1661 — `system.access.denied` → a HIGH-severity attention item that COLLAPSES
+ * BY KEY on `{principal_id}:{capability}` (decision D). Principal-acked with NO
+ * auto-resolve: no producer branch ever resolves it, and — unlike the collector
+ * health signals — a redelivered (or fresh) denial for a key the principal has
+ * already resolved/dismissed does NOT resurrect it. That divergence from the
+ * plain upsert is deliberate: a HIGH-severity item the principal cleared must not
+ * pop back on the next at-least-once redelivery. The denial always lands as an
+ * observability ROW regardless, so nothing is lost — only the queue stays quiet.
+ */
+function accessDeniedAttention(
+  db: Database,
+  payload: Record<string, unknown>,
+): ObservabilityAttentionResult | null {
+  const principalId = asString(payload.principal_id) ?? "unknown";
+  const capability = asString(payload.capability) ?? "unknown";
+  const itemId = `${ACCESS_DENIED_ATTENTION_PREFIX}${principalId}:${capability}`;
+
+  // Respect the principal's ack: never reopen a resolved/dismissed key.
+  const existing = getAttentionItem(db, itemId);
+  if (existing !== null && existing.status !== "open") return null;
+
+  upsertAttentionItem(db, {
+    id: itemId,
+    stackId: `access:${principalId}:${capability}`,
+    workItemId: null,
+    sessionId: null,
+    kind: "blocked",
+    severity: "high",
+    status: "open",
+  });
   return { action: "opened", itemId };
 }

--- a/src/surface/mc/projection/observability-renderer.ts
+++ b/src/surface/mc/projection/observability-renderer.ts
@@ -92,6 +92,32 @@ export const OBSERVABILITY_PROJECTION_SUBJECTS: string[] = [
   // transport (hub-emitted; non-hub stacks just never see these)
   "local.*.system.transport.>",
   "local.*.*.system.transport.>",
+
+  // #1661 (MC folds) — the cortex-LOCAL families. Subscribed to the EXACT
+  // subjects the folded types publish on (`local.{principal}[.{stack}].{type}`),
+  // NOT broad `system.access.>` / `system.bus.>` prefixes — so high-volume
+  // sibling types (`system.access.allowed`, `system.bus.peer_dispatch_received`)
+  // never reach the renderer's dispatch loop at all. `familyForType` remains the
+  // authoritative belt-filter for anything that does arrive.
+  // access:
+  "local.*.system.access.denied",
+  "local.*.*.system.access.denied",
+  "local.*.system.access.filtered",
+  "local.*.*.system.access.filtered",
+  "local.*.system.admission.throttled",
+  "local.*.*.system.admission.throttled",
+  "local.*.system.admission.degraded",
+  "local.*.*.system.admission.degraded",
+  // dispatch:
+  "local.*.system.dispatch.stage",
+  "local.*.*.system.dispatch.stage",
+  "local.*.system.inbound.aborted",
+  "local.*.*.system.inbound.aborted",
+  "local.*.system.bus.process",
+  "local.*.*.system.bus.process",
+  // reflex:
+  "local.*.reflex.activation.>",
+  "local.*.*.reflex.activation.>",
 ];
 
 /** A structural view of an envelope the projection reads. */
@@ -112,6 +138,34 @@ export function familyForType(type: string): ObservabilityFamily | null {
   if (type.startsWith("system.signal.")) return "signal";
   if (type.startsWith("system.federation.")) return "federation";
   if (type.startsWith("system.transport.")) return "transport";
+
+  // #1661 (MC folds) — three cortex-LOCAL families. Consumer-side ONLY (#97):
+  // this renderer READS these system envelopes; the producer emit sites in
+  // bus/system-events.ts are OUT of scope and untouched. Routed by EXACT type,
+  // not broad prefix — sibling types like `system.access.allowed` (high-volume)
+  // or `system.bus.peer_dispatch_received` stay OUT of the fold by design
+  // (decision B is 3 SECTIONS, not "everything under the prefix"). Widening a
+  // family's type set is a deliberate follow-up, never an accidental default.
+  //   access   = system.access.{denied,filtered} + system.admission.{throttled,degraded}
+  if (
+    type === "system.access.denied" ||
+    type === "system.access.filtered" ||
+    type === "system.admission.throttled" ||
+    type === "system.admission.degraded"
+  ) {
+    return "access";
+  }
+  //   dispatch = system.dispatch.stage + system.inbound.aborted + system.bus.process
+  if (
+    type === "system.dispatch.stage" ||
+    type === "system.inbound.aborted" ||
+    type === "system.bus.process"
+  ) {
+    return "dispatch";
+  }
+  //   reflex   = reflex.activation.* (fired, decision, …)
+  if (type.startsWith("reflex.activation.")) return "reflex";
+
   return null;
 }
 


### PR DESCRIPTION
Closes #1661 (backend; frontend deferred per decision C — fast-follow tracked separately). Folds the emitted-but-unconsumed `system.*` families into the MC observability tab. Principal decisions A–D recorded on #1661.

## Commit 1 (isolated, boot-critical) — schema migration `67cfe9b`
Widens `observability_events.family` CHECK from 4 → 7 families (adds `access`/`dispatch`/`reflex`, decision B). Fresh DBs via SCHEMA_SQL; existing DBs via ONE guarded REBUILD_MIGRATION cloned from the `tasks.source_system` recipe:
- `detect()` matches ONLY the old 4-family CHECK → **idempotent** (won't re-fire post-migration).
- Explicit column-list copy (never SELECT *) → loud on shape mismatch; reproduces the full U3.3 shape (incl. origin_kind/origin_peer, added by COLUMN_ADD_MIGRATIONS which runs first); recreates all 3 indexes; FK-off + txn + foreign_key_check.
- New migration test builds a real **pre-U3.3 DB** and asserts `initDatabase()` doesn't crash, rows + origin columns preserved, CHECK widened, indexes present, FK-check clean; + idempotent-second-init + fresh-DB-born-wide. (Addresses the #1048/#961 boot-crash history.)

## Commit 2 — renderer + attention `6e5df3b`
3 grouped families routed by **EXACT type** (high-volume siblings like system.access.allowed stay out, tested null):
- `access` = access.{denied,filtered} + admission.{throttled,degraded} · `dispatch` = dispatch.stage + inbound.aborted + bus.process · `reflex` = reflex.activation.*
- Attention: admission.degraded open/resolve on `payload.mode` (one type + mode field, no .recovered twin); access.denied → HIGH-sev, collapse-by-key(principal_id+capability), operator-acked, no auto-resolve. **Deliberate divergence:** access.denied does NOT reopen an operator-cleared key on redelivery (avoids resurrecting a just-acked HIGH-sev item; the row still lands regardless). Fold-only for throttled/dispatch.stage/inbound.aborted/bus.process/reflex.
- LOCAL-only subjects (U3.3 invariant preserved + tested). #97 boundary: producer emits untouched (consumer-only).

## Verification
`bunx tsc --noEmit` clean · eslint clean (6 files) · targeted 91 pass/0 fail · full `src/surface/mc/__tests__/` 1244 pass / 1 pre-existing skip / 0 fail.

All 7 families tap-admitted signal-side (signal#200). Part of the-metafactory/signal#161.