### PR TITLE
feat(mc): MC-D1 — radial constellation layout + glowing circle nodes (Network graph)

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-elk-edge.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-elk-edge.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from "bun:test";
 import {
   elkPointsToPath,
   clampElkPointsToFaces,
+  radialCurvePath,
 } from "../components/network-elk-edge";
 
 describe("elkPointsToPath (#1008)", () => {
@@ -55,6 +56,28 @@ describe("elkPointsToPath (#1008)", () => {
     );
     expect(path).toContain("L 0 100");
     expect(path).not.toContain("Q");
+  });
+});
+
+describe("radialCurvePath (MC-D1)", () => {
+  it("emits a single quadratic bezier from hub centre to agent centre", () => {
+    const p = radialCurvePath({ x: 0, y: 0 }, { x: 100, y: 0 });
+    expect(p.startsWith("M 0 0")).toBe(true);
+    // A quadratic (curved spoke) with one control point + the endpoint.
+    expect(p).toContain("Q ");
+    expect(p.endsWith("100 0")).toBe(true);
+  });
+
+  it("bows the chord — the control point is offset off the straight line", () => {
+    // A horizontal chord bows vertically (perpendicular), so the control point's
+    // y is non-zero even though both endpoints are at y=0.
+    const p = radialCurvePath({ x: 0, y: 0 }, { x: 100, y: 0 }, 0.2);
+    const m = p.match(/Q ([\-0-9.]+) ([\-0-9.]+)/)!;
+    expect(Math.abs(parseFloat(m[2]!))).toBeGreaterThan(0);
+  });
+
+  it("falls back to a straight line for a zero-length route", () => {
+    expect(radialCurvePath({ x: 5, y: 5 }, { x: 5, y: 5 })).toBe("M 5 5 L 5 5");
   });
 });
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
@@ -1,24 +1,23 @@
 /**
- * G-1114.D.3 — ELK layout tests.
+ * MC-D1 (netui-constellation) — radial constellation layout tests.
  *
- * The real ELK engine is WASM-backed + async and non-trivial to assert
- * positions on, so we test the pure translation (`toElkGraph`) exactly and the
- * async `layoutNetworkGraph` against a deterministic ELK STUB — verifying the
- * orchestration (short-circuit on empty, apply returned positions, defensive
- * fallback for an unpositioned node) without depending on ELK's exact geometry.
- * A separate smoke test in network-view.test exercises the real elk import path.
+ * The old ELK layout was async + WASM-backed, so it was tested against a
+ * deterministic stub. The constellation layout is a PURE, SYNCHRONOUS function of
+ * the graph data, so we can assert exact positions directly: clustering (agents
+ * bucketed under their hub), ring geometry (agents evenly distributed around the
+ * hub centre at the count-scaled radius), cluster-grid placement, and the
+ * 2-point centre-to-centre edge routes.
  */
 
 import { describe, it, expect } from "bun:test";
 import {
-  toElkGraph,
   layoutNetworkGraph,
-  NETWORK_ELK_OPTIONS,
+  clusterNetworkGraph,
+  clusterCentre,
+  ringRadiusForCount,
+  RADIAL_LAYOUT,
   HUB_NODE_SIZE,
   AGENT_NODE_SIZE,
-  type ElkLike,
-  type ElkInputGraph,
-  type ElkLaidOutGraph,
 } from "../lib/network-graph-layout";
 import { buildNetworkGraph, STACK_HUB_NODE_ID } from "../lib/network-graph-adapter";
 import type { AgentPresenceTile } from "../hooks/use-agents";
@@ -62,173 +61,178 @@ function foreignTile(
   });
 }
 
-describe("toElkGraph (G-1114.D.3)", () => {
-  it("maps nodes to ELK children with the right footprints", () => {
-    const graph = buildNetworkGraph([tile({ agent_id: "luna" })]);
-    const elk = toElkGraph(graph);
-    expect(elk.id).toBe("root");
-    expect(elk.layoutOptions).toEqual(NETWORK_ELK_OPTIONS);
-
-    const hub = elk.children.find((c) => c.id === STACK_HUB_NODE_ID)!;
-    expect(hub.width).toBe(HUB_NODE_SIZE.width);
-    expect(hub.height).toBe(HUB_NODE_SIZE.height);
-
-    const agent = elk.children.find((c) => c.id !== STACK_HUB_NODE_ID)!;
-    expect(agent.width).toBe(AGENT_NODE_SIZE.width);
-    expect(agent.height).toBe(AGENT_NODE_SIZE.height);
+describe("ringRadiusForCount (MC-D1)", () => {
+  it("returns the base radius for a single-agent cluster", () => {
+    expect(ringRadiusForCount(1)).toBe(RADIAL_LAYOUT.baseRingRadius);
   });
 
-  it("maps each edge to an ELK source/target pair", () => {
+  it("grows the radius with the agent count", () => {
+    expect(ringRadiusForCount(3)).toBe(
+      RADIAL_LAYOUT.baseRingRadius + 2 * RADIAL_LAYOUT.radiusPerAgent,
+    );
+  });
+
+  it("clamps to the max radius for a very dense cluster", () => {
+    expect(ringRadiusForCount(1000)).toBe(RADIAL_LAYOUT.maxRingRadius);
+  });
+});
+
+describe("clusterCentre (MC-D1)", () => {
+  it("centres a single cluster on the origin", () => {
+    expect(clusterCentre(0, 1)).toEqual({ x: 0, y: 0 });
+  });
+
+  it("spreads two clusters symmetrically about the origin, one stride apart", () => {
+    const a = clusterCentre(0, 2);
+    const b = clusterCentre(1, 2);
+    expect(b.x - a.x).toBe(RADIAL_LAYOUT.clusterStride);
+    // Symmetric about x=0.
+    expect(a.x).toBe(-RADIAL_LAYOUT.clusterStride / 2);
+    expect(b.x).toBe(RADIAL_LAYOUT.clusterStride / 2);
+  });
+
+  it("lays four clusters out on a 2×2 grid", () => {
+    // cols = ceil(sqrt(4)) = 2 → indices 0,1 on row 0; 2,3 on row 1.
+    const c0 = clusterCentre(0, 4);
+    const c3 = clusterCentre(3, 4);
+    expect(c3.x - c0.x).toBe(RADIAL_LAYOUT.clusterStride);
+    expect(c3.y - c0.y).toBe(RADIAL_LAYOUT.clusterStride);
+  });
+});
+
+describe("clusterNetworkGraph (MC-D1)", () => {
+  it("buckets each agent under its hub", () => {
     const graph = buildNetworkGraph([
       tile({ agent_id: "luna" }),
       tile({ agent_id: "echo" }),
     ]);
-    const elk = toElkGraph(graph);
-    expect(elk.edges).toHaveLength(2);
-    for (const e of elk.edges) {
-      expect(e.sources).toEqual([STACK_HUB_NODE_ID]);
-      expect(e.targets).toHaveLength(1);
-    }
+    const clusters = clusterNetworkGraph(graph);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]!.hubId).toBe(STACK_HUB_NODE_ID);
+    expect(clusters[0]!.agentIds).toHaveLength(2);
   });
 
-  it("uses the layered algorithm + orthogonal routing with component separation (#1008)", () => {
-    // #1008: cortex's topology is a SET of hub→agents trees. `layered` (DOWN)
-    // places each hub above its agents (tidy per-stack tree), ORTHOGONAL routing
-    // gives right-angled bend points (rendered as rounded polylines, no diagonal
-    // crossings), and separateConnectedComponents packs each stack-tree apart.
-    expect(NETWORK_ELK_OPTIONS["elk.algorithm"]).toContain("layered");
-    expect(NETWORK_ELK_OPTIONS["elk.direction"]).toBe("DOWN");
-    expect(NETWORK_ELK_OPTIONS["elk.edgeRouting"]).toBe("ORTHOGONAL");
-    expect(NETWORK_ELK_OPTIONS["elk.separateConnectedComponents"]).toBe("true");
-  });
-
-  it("maps a multi-stack graph into ELK children + per-cluster edges (E.3)", () => {
+  it("emits one cluster per stack, local hub first", () => {
     const graph = buildNetworkGraph([
       tile({ agent_id: "luna" }),
       foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
     ]);
-    const elk = toElkGraph(graph);
-    // 2 hubs (local + jc/research) + 2 agents = 4 children
-    expect(elk.children).toHaveLength(4);
-    // 2 edges, each sourced from its own cluster's hub (disconnected components)
-    expect(elk.edges).toHaveLength(2);
-    const sources = elk.edges.flatMap((e) => e.sources).sort();
-    expect(sources).toContain(STACK_HUB_NODE_ID);
-    expect(sources).toContain("__stack__:jc/research");
+    const clusters = clusterNetworkGraph(graph);
+    expect(clusters).toHaveLength(2);
+    // Local hub cluster is first (the adapter emits the local hub first).
+    expect(clusters[0]!.hubId).toBe(STACK_HUB_NODE_ID);
+    expect(clusters[0]!.agentIds).toHaveLength(1);
+    expect(clusters[1]!.hubId).toBe("__stack__:jc/research");
+    expect(clusters[1]!.agentIds).toHaveLength(1);
   });
 });
 
-/**
- * Deterministic ELK stub: lays nodes out on a fixed grid, no WASM, and emits a
- * simple orthogonal `sections[0]` per edge (start → one bend → end) so the
- * edge-route extraction has something to read back.
- */
-function stubElk(): ElkLike {
-  return {
-    async layout(graph: ElkInputGraph): Promise<ElkLaidOutGraph> {
-      return {
-        children: graph.children.map((c, i) => ({
-          id: c.id,
-          x: i * 100,
-          y: i * 50,
-          width: c.width,
-          height: c.height,
-        })),
-        edges: graph.edges.map((e) => ({
-          id: e.id,
-          sections: [
-            {
-              startPoint: { x: 0, y: 0 },
-              bendPoints: [{ x: 0, y: 25 }],
-              endPoint: { x: 0, y: 50 },
-            },
-          ],
-        })),
-      };
-    },
-  };
-}
-
-describe("layoutNetworkGraph (G-1114.D.3)", () => {
-  it("short-circuits on an empty graph without calling ELK", async () => {
-    let called = false;
-    const spy: ElkLike = {
-      async layout() {
-        called = true;
-        return {};
-      },
-    };
-    const out = await layoutNetworkGraph(spy, { nodes: [], edges: [] });
-    expect(out).toEqual({ nodes: [], edges: [] });
-    expect(called).toBe(false);
+describe("layoutNetworkGraph (MC-D1)", () => {
+  it("short-circuits on an empty graph", () => {
+    expect(layoutNetworkGraph({ nodes: [], edges: [] })).toEqual({
+      nodes: [],
+      edges: [],
+    });
   });
 
-  it("applies ELK-returned positions to the nodes", async () => {
+  it("places the hub at the cluster centre and rings its agents around it", () => {
     const graph = buildNetworkGraph([
       tile({ agent_id: "luna" }),
       tile({ agent_id: "echo" }),
+      tile({ agent_id: "sage" }),
     ]);
-    const { nodes } = await layoutNetworkGraph(stubElk(), graph);
-    // 1 hub + 2 agents
-    expect(nodes).toHaveLength(3);
-    // The hub is index 0 in the adapter output → stub put it at (0,0).
+    const { nodes } = layoutNetworkGraph(graph);
+    // 1 hub + 3 agents.
+    expect(nodes).toHaveLength(4);
+
     const hub = nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    // Single cluster → centred on the origin.
     expect(hub.position).toEqual({ x: 0, y: 0 });
-    // The 2nd node got (100,50) from the stub.
-    expect(nodes[1]!.position).toEqual({ x: 100, y: 50 });
-    expect(nodes[2]!.position).toEqual({ x: 200, y: 100 });
+
+    const agents = nodes.filter((n) => n.type === "agent");
+    const radius = ringRadiusForCount(3);
+    for (const a of agents) {
+      // Every agent sits on the ring: distance from the hub centre == radius.
+      const dist = Math.hypot(a.position.x - 0, a.position.y - 0);
+      expect(dist).toBeCloseTo(radius, 6);
+    }
+    // The first agent sits at the deterministic start angle (straight up: the
+    // ring's -90° spoke, so x≈0, y≈-radius).
+    const first = agents[0]!;
+    expect(first.position.x).toBeCloseTo(0, 6);
+    expect(first.position.y).toBeCloseTo(-radius, 6);
   });
 
-  it("extracts ELK's edge bend points into each edge's layout payload (#1008)", async () => {
+  it("distributes agents evenly by angle (no two agents overlap)", () => {
+    const graph = buildNetworkGraph([
+      tile({ agent_id: "a" }),
+      tile({ agent_id: "b" }),
+      tile({ agent_id: "c" }),
+      tile({ agent_id: "d" }),
+    ]);
+    const { nodes } = layoutNetworkGraph(graph);
+    const agents = nodes.filter((n) => n.type === "agent");
+    const seen = new Set(agents.map((a) => `${a.position.x.toFixed(3)},${a.position.y.toFixed(3)}`));
+    // Four distinct positions on the ring.
+    expect(seen.size).toBe(4);
+  });
+
+  it("separates multiple stacks into their own cluster centres", () => {
     const graph = buildNetworkGraph([
       tile({ agent_id: "luna" }),
-      tile({ agent_id: "echo" }),
+      foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
     ]);
-    const { edges } = await layoutNetworkGraph(stubElk(), graph);
-    expect(edges).toHaveLength(2);
-    for (const e of edges) {
-      // [startPoint, ...bendPoints, endPoint] — the stub emits 3 points.
-      expect(e.layout.elkPoints).toEqual([
-        { x: 0, y: 0 },
-        { x: 0, y: 25 },
-        { x: 0, y: 50 },
-      ]);
-      // Source/target face geometry is populated (for face-clamping).
-      expect(typeof e.layout.layoutSourceX).toBe("number");
-      expect(typeof e.layout.targetBottomY).toBe("number");
-    }
+    const { nodes } = layoutNetworkGraph(graph);
+    const localHub = nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    const foreignHub = nodes.find((n) => n.id === "__stack__:jc/research")!;
+    // Two clusters, one stride apart on the x axis.
+    expect(Math.abs(foreignHub.position.x - localHub.position.x)).toBe(
+      RADIAL_LAYOUT.clusterStride,
+    );
   });
 
-  it("preserves the origin-grouped edge id/source/target through layout (#1008)", async () => {
-    const graph = buildNetworkGraph([tile({ agent_id: "luna" })]);
-    const { edges } = await layoutNetworkGraph(stubElk(), graph);
-    expect(edges[0]!.id).toBe(graph.edges[0]!.id);
-    expect(edges[0]!.source).toBe(graph.edges[0]!.source);
-    expect(edges[0]!.target).toBe(graph.edges[0]!.target);
-  });
-
-  it("preserves node data while only replacing position", async () => {
+  it("preserves node data + type, only replacing position", () => {
     const graph = buildNetworkGraph([
       tile({ agent_id: "luna", assistant_name: "Luna" }),
     ]);
-    const { nodes } = await layoutNetworkGraph(stubElk(), graph);
+    const { nodes } = layoutNetworkGraph(graph);
     const agent = nodes.find((n) => n.type === "agent")!;
     expect(agent.data).toEqual(
       graph.nodes.find((n) => n.type === "agent")!.data,
     );
   });
 
-  it("falls back to the incoming position for a node ELK omitted", async () => {
+  it("routes each edge as a 2-point hub-centre → agent-centre spoke", () => {
+    const graph = buildNetworkGraph([
+      tile({ agent_id: "luna" }),
+      tile({ agent_id: "echo" }),
+    ]);
+    const { nodes, edges } = layoutNetworkGraph(graph);
+    expect(edges).toHaveLength(2);
+    const hub = nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    for (const e of edges) {
+      const pts = e.layout.elkPoints!;
+      expect(pts).toHaveLength(2);
+      // First point is the hub centre.
+      expect(pts[0]).toEqual({ x: hub.position.x, y: hub.position.y });
+      // Second point is the target agent's centre.
+      const agent = nodes.find((n) => n.id === e.target)!;
+      expect(pts[1]).toEqual({ x: agent.position.x, y: agent.position.y });
+      // Face geometry is populated for the edge's dragged-node fallback.
+      expect(typeof e.layout.layoutSourceX).toBe("number");
+      expect(typeof e.layout.targetBottomY).toBe("number");
+    }
+  });
+
+  it("preserves the edge id/source/target through layout", () => {
     const graph = buildNetworkGraph([tile({ agent_id: "luna" })]);
-    const partial: ElkLike = {
-      async layout() {
-        // Return positions for nothing — every node should keep its {0,0}.
-        return { children: [] };
-      },
-    };
-    const { nodes, edges } = await layoutNetworkGraph(partial, graph);
-    for (const n of nodes) expect(n.position).toEqual({ x: 0, y: 0 });
-    // An edge ELK didn't route carries no elkPoints (the edge falls back).
-    expect(edges[0]!.layout.elkPoints).toBeUndefined();
+    const { edges } = layoutNetworkGraph(graph);
+    expect(edges[0]!.id).toBe(graph.edges[0]!.id);
+    expect(edges[0]!.source).toBe(graph.edges[0]!.source);
+    expect(edges[0]!.target).toBe(graph.edges[0]!.target);
+  });
+
+  it("exposes the circle-node footprints (hub larger than agent)", () => {
+    expect(HUB_NODE_SIZE.width).toBeGreaterThan(AGENT_NODE_SIZE.width);
   });
 });

--- a/src/surface/mc/dashboard-v2/components/constellation-canvas.css
+++ b/src/surface/mc/dashboard-v2/components/constellation-canvas.css
@@ -63,82 +63,176 @@
   opacity: 0.35;
 }
 
-/* ── Agent orbs ─────────────────────────────────────────────────────────────
- * The agent card becomes a glowing orb-card keyed to its stack hue. The glow
- * tint is the inline `--stack-color` each node already carries. */
-.mc-skin .network-node-agent {
-  position: relative;
-  border: 1px solid color-mix(in oklch, var(--stack-color, var(--mer)) 45%, var(--line));
-  border-left-width: 3px;
-  border-left-color: var(--stack-color, var(--mer));
-  border-radius: 12px;
-  background:
-    radial-gradient(
-      circle at 18% 0%,
-      color-mix(in oklch, var(--stack-color, var(--mer)) 22%, transparent) 0%,
-      transparent 60%
-    ),
-    color-mix(in oklch, var(--panel) 86%, var(--bg));
-  box-shadow:
-    0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 22%, transparent),
-    0 0 18px -2px color-mix(in oklch, var(--stack-color, var(--mer)) 30%, transparent);
+/* ══ MC-D1 (netui-constellation) — CIRCLE NODES ══════════════════════════════
+ * The nodes are glowing CIRCLES (an orb) with the label BELOW, not cards. The
+ * node root becomes a transparent flex-column that CENTRES its orb + label on
+ * the node's layout position; the orb carries the glow, the `.network-node-below`
+ * block holds the (small, dim, mono) label + chips underneath. All the presence
+ * data attributes + classes are unchanged — only the visual is a circle now.
+ *
+ * React Flow positions a node by its top-left corner; we translate the whole
+ * node up+left by half its own size so the ORB sits centred on the layout
+ * position (which the edges route to centre-to-centre). */
+.mc-skin .network-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  border-radius: 0;
+  transform: translate(-50%, -50%);
+  font-family: var(--mono);
+  /* Let the (wider) label overflow the orb without clipping or reflowing it. */
+  width: max-content;
+  max-width: 220px;
 }
 
-/* Liveness glow — ONLY when the agent is actually online (truth, not theater).
- * Breathes the orb's halo; offline orbs are dimmed + static. */
-.mc-skin .network-node-agent.network-node-online {
+/* The orb — the glowing circle. Hue is the inline `--stack-color`. */
+.mc-skin .network-node-orb {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in oklch, var(--stack-color, var(--mer)) 80%, var(--fg));
+  background:
+    radial-gradient(
+      circle at 50% 38%,
+      color-mix(in oklch, var(--stack-color, var(--mer)) 55%, transparent) 0%,
+      color-mix(in oklch, var(--stack-color, var(--mer)) 18%, transparent) 55%,
+      transparent 72%
+    ),
+    color-mix(in oklch, var(--stack-color, var(--mer)) 12%, var(--bg));
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 30%, transparent),
+    0 0 18px -2px color-mix(in oklch, var(--stack-color, var(--mer)) 55%, transparent);
+}
+
+/* Agent orb — small teal circle. */
+.mc-skin .network-node-orb-agent {
+  width: 24px;
+  height: 24px;
+}
+/* Hub orb — larger bright cyan core with a centred diamond glyph + brighter ring. */
+.mc-skin .network-node-orb-hub {
+  width: 56px;
+  height: 56px;
+  border-width: 2px;
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 45%, transparent),
+    0 0 34px -2px color-mix(in oklch, var(--stack-color, var(--mer)) 65%, transparent);
+}
+.mc-skin .network-node-orb-glyph {
+  font-size: 18px;
+  line-height: 1;
+  color: color-mix(in oklch, var(--fg) 92%, var(--stack-color, var(--mer)));
+  text-shadow: 0 0 8px color-mix(in oklch, var(--stack-color, var(--mer)) 70%, transparent);
+}
+
+/* The label block that sits UNDER the orb: dim mono, centred, small. */
+.mc-skin .network-node-below {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  text-align: center;
+  font-size: 10px;
+  line-height: 1.25;
+}
+.mc-skin .network-node-below .network-node-caps,
+.mc-skin .network-node-below .network-node-liveness,
+.mc-skin .network-node-below .network-node-identity {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 3px;
+}
+.mc-skin .network-node-name {
+  font-weight: 600;
+  color: var(--fg);
+}
+.mc-skin .network-node-id {
+  font-size: 9px;
+}
+
+/* Liveness — ONLY when the agent is actually online (truth, not theater).
+ * A bright cyan ring + a subtle breathing pulse; offline orbs are DIMMED (low
+ * opacity, no glow, grey ring), ttl-lapse gets an amber accent. */
+.mc-skin .network-node-agent.network-node-online .network-node-orb {
   animation: mcOrbBreathe 3.4s ease-in-out infinite;
 }
-.mc-skin .network-node-agent.network-node-offline {
-  opacity: 0.55;
-  filter: saturate(0.6);
+.mc-skin .network-node-agent.network-node-offline .network-node-orb {
+  opacity: 0.4;
+  filter: saturate(0.35);
+  border-color: color-mix(in oklch, var(--fg) 30%, var(--line));
+  background: color-mix(in oklch, var(--panel) 70%, var(--bg));
   box-shadow: none;
+}
+.mc-skin .network-node-agent.network-node-offline .network-node-below {
+  opacity: 0.6;
 }
 @keyframes mcOrbBreathe {
   0%, 100% {
     box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 22%, transparent),
-      0 0 16px -3px color-mix(in oklch, var(--stack-color, var(--mer)) 26%, transparent);
+      0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 30%, transparent),
+      0 0 16px -3px color-mix(in oklch, var(--stack-color, var(--mer)) 45%, transparent);
   }
   50% {
     box-shadow:
-      0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 38%, transparent),
-      0 0 26px 0 color-mix(in oklch, var(--stack-color, var(--mer)) 42%, transparent);
+      0 0 0 2px color-mix(in oklch, var(--stack-color, var(--mer)) 45%, transparent),
+      0 0 28px 0 color-mix(in oklch, var(--stack-color, var(--mer)) 62%, transparent);
   }
 }
 
-/* TTL-lapse (silent drop) reads as a warn-tinted orb. */
-.mc-skin .network-node-agent.network-node-ttl-lapse {
-  border-color: color-mix(in oklch, var(--warn) 55%, var(--line));
+/* TTL-lapse (silent drop) reads as an AMBER-accented orb + a "!" attention dot. */
+.mc-skin .network-node-agent.network-node-ttl-lapse .network-node-orb {
+  border-color: color-mix(in oklch, var(--warn) 75%, var(--line));
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--warn) 40%, transparent),
+    0 0 16px -2px color-mix(in oklch, var(--warn) 50%, transparent);
+}
+/* The "!" attention dot, top-right of the orb. */
+.mc-skin .network-node-attention {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 13px;
+  height: 13px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--bg);
+  background: var(--warn);
+  border-radius: 50%;
+  box-shadow: 0 0 8px -1px color-mix(in oklch, var(--warn) 70%, transparent);
 }
 
 /* ── Stack hubs (the cluster cores) ─────────────────────────────────────────
- * The hub is a brighter core glowing in its stack hue. */
-.mc-skin .network-node-hub {
-  border-radius: 14px;
-  border-color: var(--stack-color, var(--mer));
-  background:
-    radial-gradient(
-      circle at 50% 35%,
-      color-mix(in oklch, var(--stack-color, var(--mer)) 30%, transparent) 0%,
-      transparent 70%
-    ),
-    color-mix(in oklch, var(--panel) 80%, var(--bg));
-  box-shadow:
-    0 0 0 1px color-mix(in oklch, var(--stack-color, var(--mer)) 40%, transparent),
-    0 0 28px -2px color-mix(in oklch, var(--stack-color, var(--mer)) 45%, transparent);
-}
+ * The hub label glows brighter in its stack hue; the orb styling is above. */
 .mc-skin .network-hub-label {
   color: var(--fg);
-  text-shadow: 0 0 10px color-mix(in oklch, var(--stack-color, var(--mer)) 50%, transparent);
+  font-weight: 600;
+  text-shadow: 0 0 10px color-mix(in oklch, var(--stack-color, var(--mer)) 55%, transparent);
+}
+.mc-skin .network-hub-eyebrow {
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
-/* ● YOU ARE HERE — the serving (local) stack anchor. A glowing pill. */
+/* ◦ YOU ARE HERE — the serving (local) stack anchor pill, ABOVE the hub orb. */
 .mc-skin .network-hub-you-are-here {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  margin: 1px 0 2px 0;
+  margin: 0 0 2px 0;
   padding: 1px 8px;
   font-family: var(--mono);
   font-size: 9px;
@@ -161,10 +255,10 @@
  * badge reads its admitted `{principal}/{stack}`. This is the sovereignty
  * boundary made legible — these orbs show aggregate presence only and are not
  * drillable into sessions. */
-.mc-skin .network-node-foreign,
-.mc-skin .network-node-hub-foreign {
+.mc-skin .network-node-foreign .network-node-orb,
+.mc-skin .network-node-hub-foreign .network-node-orb {
   border-style: dashed;
-  border-color: color-mix(in oklch, var(--tide) 55%, var(--line));
+  border-color: color-mix(in oklch, var(--tide) 65%, var(--fg));
 }
 .mc-skin .network-node-provenance {
   color: color-mix(in oklch, var(--tide) 75%, var(--fg));
@@ -185,9 +279,15 @@
 .mc-skin .network-node-state.state-offline { color: var(--warn); }
 .mc-skin .network-node-reason-ttl-lapse { color: var(--warn); }
 
-/* ── Edges — glowing connectors; federated = dashed + flowing + labelled ─────*/
+/* ── Edges — thin, gently-curved teal spokes; federated = dashed + flowing ───
+ * MC-D1: hub→agent spokes are thin and softly glowing. Each edge strokes in its
+ * hub's hue (inline `stroke` from the edge component); the teal `--tide` is the
+ * fallback when no stack color is set. */
 .mc-skin .react-flow__edge-path {
-  filter: drop-shadow(0 0 3px color-mix(in oklch, var(--mer) 30%, transparent));
+  stroke: color-mix(in oklch, var(--tide) 70%, var(--mer));
+  stroke-width: 1.25;
+  opacity: 0.72;
+  filter: drop-shadow(0 0 3px color-mix(in oklch, var(--tide) 35%, transparent));
 }
 /* The federated edge label — `● federated · admitted peer`. */
 .mc-skin .mc-edge-fed-label {

--- a/src/surface/mc/dashboard-v2/components/network-canvas.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-canvas.tsx
@@ -1,27 +1,26 @@
 /**
  * G-1114.D.1 — Network graph CANVAS (the code-split heavy half).
  *
- * This module is the ONLY place `@xyflow/react` + `elkjs` are imported, so it
- * lands in a **lazily-loaded chunk** that the dashboard pulls only when the
- * principal first opens the Network tab (`network-view.tsx` `React.lazy`-imports
- * it). The default dashboard view is the working grid, not Network — splitting
- * the graph engine (+0.62 MB gzip) out of the entry bundle keeps it off the
- * common load path (PR #905 review: fold the code-split in). This is the
- * dashboard's first code-split; it establishes the pattern for D.4/D.5
- * (DetailPanel, SpotlightSearch) which will only add to this chunk.
+ * This module is the ONLY place `@xyflow/react` is imported, so it lands in a
+ * **lazily-loaded chunk** that the dashboard pulls only when the principal first
+ * opens the Network tab (`network-view.tsx` `React.lazy`-imports it). The default
+ * dashboard view is the working grid, not Network — splitting the graph engine
+ * out of the entry bundle keeps it off the common load path (PR #905 review:
+ * fold the code-split in). This is the dashboard's first code-split; it
+ * establishes the pattern for D.4/D.5 (DetailPanel, SpotlightSearch).
  *
- * It owns the ELK layout effect (ELK is async + WASM-Worker-backed, so it only
- * runs once this chunk is loaded and mounted) and renders the React Flow canvas.
- * The pure adapter/layout/legend/card-inners stay in the main bundle — they're
- * tiny + unit-tested and don't pull the engine.
+ * MC-D1 (netui-constellation) — the ELK dependency is GONE. The old canvas ran an
+ * async, WASM-Worker-backed ELK layout in an effect; the constellation redesign
+ * replaced it with a PURE, SYNCHRONOUS radial layout ({@link layoutNetworkGraph}),
+ * so the canvas positions the nodes inline with a `useMemo` — no effect, no
+ * generation guard, no "laying out…" placeholder. Simpler + no worker.
  *
  * ADR-0007: nodes carry presence + lifecycle only — never session interiors.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import {
   ReactFlow,
-  Background,
   Controls,
   ReactFlowProvider,
   type Node as RfNode,
@@ -30,7 +29,6 @@ import {
   type EdgeTypes,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import ELK from "elkjs/lib/elk.bundled.js";
 import {
   collectLegendStacks,
   type NetworkGraph,
@@ -57,21 +55,13 @@ const nodeTypes: NodeTypes = {
   agent: AgentNode,
 };
 
-// #1008 — the custom ELK orthogonal edge (rounded-corner polyline from ELK's
-// bend points). Registered once at module scope, same as `nodeTypes`.
+// The custom constellation edge (MC-D1: a gently-curved teal spoke from the hub
+// core to each orbiting agent). Still keyed `elk` — the edge type name is a
+// stable registration key, not an engine reference. Registered once at module
+// scope, same as `nodeTypes`.
 const edgeTypes: EdgeTypes = {
   elk: NetworkElkEdge,
 };
-
-// One ELK engine for this chunk's lifetime, instantiated lazily on first layout.
-// Module-scope `new ELK()` spins up a Web Worker, which is unavailable in the
-// (DOM-less) unit-test env — deferring it keeps `import`ing this module safe in
-// tests while the browser bundle still gets a single shared engine.
-let elkSingleton: InstanceType<typeof ELK> | null = null;
-function getElk(): InstanceType<typeof ELK> {
-  if (!elkSingleton) elkSingleton = new ELK();
-  return elkSingleton;
-}
 
 export interface NetworkCanvasProps {
   /** The pre-built (un-positioned) graph from the main-bundle adapter. */
@@ -211,7 +201,8 @@ function FlowCanvas({
       onPaneClick={onPaneClick}
       proOptions={{ hideAttribution: true }}
     >
-      <Background gap={20} size={1} />
+      {/* MC-D1 — no <Background>: the constellation reads against a clean
+          near-black atmosphere (painted by `.network-canvas-wrap`), not a grid. */}
       <Controls position="bottom-left" showInteractive={false} />
       <NetworkLegend stacks={legendStacks} />
     </ReactFlow>
@@ -219,9 +210,12 @@ function FlowCanvas({
 }
 
 /**
- * The lazy canvas entry. Runs ELK over the incoming graph (async) and mounts the
- * React Flow canvas once positioned. A generation guard drops a stale layout if
- * the graph changed (a presence frame landed) while ELK was mid-flight.
+ * The lazy canvas entry. Positions the incoming graph with the SYNCHRONOUS
+ * radial layout ({@link layoutNetworkGraph}) and mounts the React Flow canvas.
+ *
+ * MC-D1: the layout is now a pure function of the graph, so a `useMemo` replaces
+ * the old async ELK effect + generation guard + "laying out…" placeholder. When
+ * the graph changes (a presence frame lands) the memo recomputes inline.
  *
  * Default export so `React.lazy(() => import("./network-canvas"))` resolves it.
  */
@@ -231,44 +225,14 @@ export default function NetworkCanvas({
   hover,
   live = false,
 }: NetworkCanvasProps) {
-  const [positioned, setPositioned] = useState<NetworkGraphNode[]>([]);
-  const [laidOutEdges, setLaidOutEdges] = useState<LaidOutNetworkEdge[]>([]);
-  const genRef = useRef(0);
-
-  useEffect(() => {
-    const myGen = ++genRef.current;
-    if (graph.nodes.length === 0) {
-      setPositioned([]);
-      setLaidOutEdges([]);
-      return;
-    }
-    let cancelled = false;
-    void layoutNetworkGraph(getElk(), graph)
-      .then((result) => {
-        // Drop a stale layout: the graph changed (new gen) or the effect was
-        // torn down while ELK was mid-flight.
-        if (cancelled || genRef.current !== myGen) return;
-        setPositioned(result.nodes);
-        setLaidOutEdges(result.edges);
-      })
-      .catch((err: unknown) => {
-        if (cancelled || genRef.current !== myGen) return;
-        // Layout failure shouldn't blank the tab — log and leave the last-good
-        // graph. `console.warn` is the only emit path in the bundle.
-        // eslint-disable-next-line no-console
-        console.warn(
-          "[network-canvas] ELK layout failed:",
-          err instanceof Error ? err.message : String(err),
-        );
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [graph]);
+  const { nodes: positioned, edges: laidOutEdges } = useMemo(
+    () => layoutNetworkGraph(graph),
+    [graph],
+  );
 
   if (positioned.length === 0) {
-    // Engine loaded + mounted, ELK still computing the first layout.
-    return <div className="network-view-empty">Laying out topology…</div>;
+    // No topology yet (empty snapshot) — nothing to constellate.
+    return <div className="network-view-empty">No agents on the network yet.</div>;
   }
 
   const canvas = (

--- a/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
@@ -1,17 +1,20 @@
 /**
- * #1008 (network-graph-rendering) — custom React Flow edge that renders ELK's
- * ORTHOGONAL route as a rounded-corner SVG polyline.
+ * #1008 (network-graph-rendering) — custom React Flow edge for the Network graph.
  *
- * Adapted from Strata's `ElkEdge.tsx` (`arc-library/strata/ui/src/components/`):
- * the layout step (`network-graph-layout.ts`) extracts ELK's bend points into
- * `data.elkPoints`; this edge converts them to a path with rounded corners
- * (`elkPointsToPath`) and clamps the endpoints to the source/target node faces
- * so a connector never starts inside a card. This is the key to the
- * non-crossing edges — ELK already routed the right angles; we just draw them.
+ * MC-D1 (netui-constellation) — the radial constellation layout hands this edge a
+ * 2-point centre-to-centre route (`data.elkPoints = [hubCentre, agentCentre]`).
+ * The edge draws that as a GENTLY CURVED teal spoke (`radialCurvePath`) from the
+ * hub core out to the orbiting agent — the organic star-map connector, not the
+ * boxy DAG elbow. For a multi-point route (defensive / legacy) it still renders
+ * the rounded-corner polyline (`elkPointsToPath`). No route at all → a straight
+ * chord.
+ *
+ * The pure geometry helpers (`elkPointsToPath`, `clampElkPointsToFaces`,
+ * `radialCurvePath`) are exported + unit-tested; the SVG component itself imports
+ * `@xyflow/react` so it can't mount under `renderToStaticMarkup`.
  *
  * Lives in the LAZY canvas chunk (it imports `@xyflow/react`), registered on the
- * canvas's `edgeTypes` as `elk`. Edges with no `elkPoints` (defensive — ELK
- * didn't route them) fall back to a straight line.
+ * canvas's `edgeTypes` as `elk`.
  */
 
 import { useMemo, type CSSProperties } from "react";
@@ -73,6 +76,37 @@ export function elkPointsToPath(points: Point[], radius = 8): string {
   const last = points[points.length - 1]!;
   parts.push(`L ${last.x} ${last.y}`);
   return parts.join(" ");
+}
+
+/**
+ * MC-D1 — a GENTLY CURVED spoke between two points (hub centre → agent centre),
+ * for the radial constellation. Bows the straight chord by offsetting its
+ * midpoint PERPENDICULARLY to the chord by `curvature × chordLength`, then draws
+ * a single quadratic bezier through the offset control point. The sign of the
+ * offset is derived deterministically from the endpoint geometry (so the same
+ * edge always bows the same way — no ambient state), giving the star-map its
+ * organic, non-straight spokes. A degenerate (<2 point or zero-length) route
+ * falls back to a straight line.
+ */
+export function radialCurvePath(
+  from: Point,
+  to: Point,
+  curvature = 0.12,
+): string {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const len = Math.hypot(dx, dy);
+  if (len < 1) return `M ${from.x} ${from.y} L ${to.x} ${to.y}`;
+  // Unit perpendicular to the chord.
+  const px = -dy / len;
+  const py = dx / len;
+  // Deterministic bow direction: bow "outward" consistently by keying the sign
+  // off the chord orientation (dx >= 0), so mirror-image spokes fan apart rather
+  // than all bowing the same screen-direction.
+  const sign = dx >= 0 ? 1 : -1;
+  const mx = (from.x + to.x) / 2 + px * len * curvature * sign;
+  const my = (from.y + to.y) / 2 + py * len * curvature * sign;
+  return `M ${from.x} ${from.y} Q ${mx} ${my} ${to.x} ${to.y}`;
 }
 
 /**
@@ -154,6 +188,12 @@ export default function NetworkElkEdge(props: EdgeProps) {
   const targetBottomY = edgeData?.["targetBottomY"] as number | undefined;
 
   const path = useMemo(() => {
+    // MC-D1 — the radial layout emits a 2-point centre-to-centre route; draw it
+    // as a gently curved constellation spoke (hub core → orbiting agent). The
+    // circle nodes are centred on their position, so centre-to-centre is exact.
+    if (elkPoints && elkPoints.length === 2) {
+      return radialCurvePath(elkPoints[0]!, elkPoints[1]!);
+    }
     if (elkPoints && elkPoints.length >= 2) {
       // Detect a dragged node: large drift between the live handle and the
       // ELK-expected face → fall back to a live smoothstep.

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -1,12 +1,20 @@
 /**
  * G-1114.D.1 — custom React Flow node components for the Network graph.
  *
- * Two node types: the synthetic **stack-hub** (the layout centre, labelled
- * `{principal}/{stack}`) and the **agent** card (identity + capability chips +
+ * MC-D1 (netui-constellation) — these nodes render as glowing CIRCLES (an orb +
+ * a label BELOW it), not cards/boxes: the star-map aesthetic. The stack-hub is a
+ * larger bright cyan core with a "◦ YOU ARE HERE" pill on the serving stack; the
+ * agents are smaller teal orbs ringed around it. The circle + glow live in
+ * `constellation-canvas.css` (`.network-node-orb`, keyed by `data-state` /
+ * origin / attention). The DOM still carries EVERY data attribute + class + text
+ * the presence model needs (identity, capabilities, state, reason, heartbeat) —
+ * this is a restyle, not a re-model — so the C.4 display language + tests hold.
+ *
+ * Two node types: the synthetic **stack-hub** (the cluster core, labelled
+ * `{principal}/{stack}`) and the **agent** orb (identity + capability chips +
  * online/offline state with the TTL-lapse-vs-graceful distinction + last
- * heartbeat). The agent card reuses the SAME display helpers + class-name
- * language as the C.4 panel (`agents-display.ts`) so the graph and the legacy
- * panel read identically.
+ * heartbeat). Both reuse the SAME display helpers + class-name language as the
+ * C.4 panel (`agents-display.ts`).
  *
  * ## Why each node is split inner / wrapper
  *
@@ -166,27 +174,36 @@ export function StackHubCard({
           : undefined
       }
     >
-      <span className="network-hub-eyebrow dim">
-        {foreign ? "federated stack" : "stack"}
-      </span>
+      {/* MC-D1 — the "◦ YOU ARE HERE" pill floats ABOVE the hub orb. */}
       {isSelfStack && (
         <span className="network-hub-you-are-here" data-you-are-here="true">
-          <span aria-hidden="true">●</span> YOU ARE HERE
+          <span aria-hidden="true">◦</span> YOU ARE HERE
         </span>
       )}
-      <span className="network-hub-label">{label}</span>
-      {badge && (
-        <span
-          className={badge.className}
-          data-verdict={badge.verdict}
-          data-severity={badge.severity}
-          title={badge.title}
-        >
-          {badge.label}
+      {/* MC-D1 — the glowing hub core: a bright cyan circle with a thin ring and
+          a centred diamond glyph. The glow hue is the inline `--stack-color`. */}
+      <span className="network-node-orb network-node-orb-hub" aria-hidden="true">
+        <span className="network-node-orb-glyph">◆</span>
+      </span>
+      {/* MC-D1 — label block BELOW the orb: eyebrow · name · sub-count. */}
+      <span className="network-node-below">
+        <span className="network-hub-eyebrow dim">
+          {foreign ? "federated stack" : "stack"}
         </span>
-      )}
-      <span className="network-hub-count dim">
-        {data.agentCount} agent{data.agentCount === 1 ? "" : "s"}
+        <span className="network-hub-label">{label}</span>
+        {badge && (
+          <span
+            className={badge.className}
+            data-verdict={badge.verdict}
+            data-severity={badge.severity}
+            title={badge.title}
+          >
+            {badge.label}
+          </span>
+        )}
+        <span className="network-hub-count dim">
+          {data.agentCount} agent{data.agentCount === 1 ? "" : "s"}
+        </span>
       </span>
     </div>
   );
@@ -305,6 +322,14 @@ export function AgentNodeCard({
       onMouseEnter={onHoverAgent ? () => onHoverAgent(data.key) : undefined}
       onMouseLeave={onHoverAgent ? () => onHoverAgent(null) : undefined}
     >
+      {/* MC-D1 — the agent orb: a small teal circle with a thin glowing ring.
+          online = bright ring + pulse; offline/ttl-lapse = dimmed/amber (keyed
+          off the wrapper's `network-node-{state}` / `-ttl-lapse` classes in CSS).
+          The "!" attention dot surfaces a TTL-lapse (silent drop). */}
+      <span className="network-node-orb network-node-orb-agent" aria-hidden="true">
+        {ttlLapse && <span className="network-node-attention">!</span>}
+      </span>
+      <div className="network-node-below">
       <div className="network-node-identity">
         <span className="network-node-name">{name}</span>
         <span className="network-node-id dim">{data.agentId}</span>
@@ -404,6 +429,7 @@ export function AgentNodeCard({
               : "no leaf"}
           </span>
         )}
+      </div>
       </div>
     </div>
   );

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -1,22 +1,23 @@
 /**
- * G-1114.D.1 — Network graph view (React Flow + ELK).
+ * G-1114.D.1 — Network graph view (React Flow constellation).
  *
  * Replaces the simple agents PANEL (the G-1114.B.4 `NetworkPreviewView`) with a
- * laid-out topology graph: the stack as a hub, every agent as a node fanned
- * around it (radial ELK layout). Same data source — `useAgents` → `/api/agents`
- * + the `agent.presence` WS frame — so the graph pops agents in on boot and
- * drops them off when they go offline, live.
+ * laid-out topology graph: each stack as a glowing hub core, every agent as an
+ * orb ringed around it (MC-D1 deterministic RADIAL layout — the constellation
+ * star-map). Same data source — `useAgents` → `/api/agents` + the
+ * `agent.presence` WS frame — so the graph pops agents in on boot and drops them
+ * off when they go offline, live.
  *
  * ## Code-split (PR #905 review)
  *
  * This module stays in the MAIN bundle: it's the chrome (heading + subtitle +
  * empty/loading/error states) plus the PURE `buildNetworkGraph` adapter — all
- * tiny and engine-free. The heavy half — `@xyflow/react` + `elkjs` (the
- * GWT-compiled ELK engine, +0.62 MB gzip) + the async layout effect — lives in
- * `./network-canvas`, which this view `React.lazy`-imports so the engine chunk
+ * tiny and engine-free. The heavy half — `@xyflow/react` — lives in
+ * `./network-canvas`, which this view `React.lazy`-imports so the graph chunk
  * downloads ONLY when the principal first opens the Network tab. The dashboard's
  * default view is the working grid, so the common load path never pays for the
- * graph engine. This is the dashboard's first code-split.
+ * graph engine. This is the dashboard's first code-split. (MC-D1 removed the
+ * `elkjs` WASM engine — the layout is now a pure synchronous function.)
  *
  * ## State precedence
  *
@@ -338,7 +339,7 @@ export function NetworkView({
 
   // Pure: filtered snapshot → React-Flow graph (re-derived when agents OR the
   // filter change). Tiny + engine-free, so it stays in the main bundle; the lazy
-  // canvas takes the built graph and runs ELK over it.
+  // canvas takes the built graph and runs the radial layout over it.
   const baseGraph = useMemo(() => buildNetworkGraph(filteredAgents), [filteredAgents]);
 
   // U2.3 — fold signal's transport verdicts + leaf liveness/RTT into the overlay

--- a/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
@@ -1,40 +1,41 @@
 /**
- * G-1114.D.3 — ELK layout for the Network graph.
+ * G-1114.D.3 — layout for the Network graph.
  * G-1114.E.3 — + multi-cluster (one star per stack-hub) layout.
  * #1008 (network-graph-rendering) — Strata-style LAYERED + ORTHOGONAL routing.
+ * MC-D1 (netui-constellation) — REPLACED the async ELK layered DAG with a PURE,
+ *   synchronous, deterministic RADIAL layout: each stack-hub sits at a cluster
+ *   centre and its agents ring around it, the clusters spread across a coarse
+ *   grid. This turns the boxy DAG into the organic "constellation" star-map.
  *
- * Positions the stack-hub + agent nodes (from {@link buildNetworkGraph}) using
- * elkjs and returns BOTH the positioned nodes AND ELK's computed edge bend
- * points (`elkPoints`), so the canvas can render clean orthogonal connectors
- * (see `network-elk-edge.tsx`) instead of React Flow's default crossing-prone
- * straight/bezier edges.
- *
- * ## Algorithm choice — `layered` (DOWN), not `force`
- *
- * Phase D used `radial`; Phase E switched to `force` to handle several
- * disconnected stack-clusters. But `force` (stress) is a physics scatter: it has
- * no notion of "hub above its agents", so clusters drift, overlap edges cross,
- * and with several stacks the whole thing converges on the densest hub — exactly
- * the crossing-lines mess #1008 reported.
+ * ## Algorithm choice — deterministic radial, not ELK `layered`/`force`
  *
  * cortex's topology is a SET of 2-level trees: each stack-hub PARENTS its agents
  * (hub → agent edges), one such tree per stack (the serving stack, each local
- * sibling, each federated peer). `org.eclipse.elk.layered` with `direction: DOWN`
- * is the natural fit — it places each hub on the top layer and its agents on the
- * layer below, a tidy top-down cluster per stack. `separateConnectedComponents`
- * packs the per-stack trees side by side (each stack its own clean column-group),
- * and `crossingMinimization` + `nodePlacement: NETWORK_SIMPLEX` straighten the
- * hub→agent edges. With `edgeRouting: ORTHOGONAL`, ELK emits right-angled bend
- * points we render as rounded-corner polylines — no diagonal crossings.
+ * sibling, each federated peer). The old renderer laid this out with
+ * `org.eclipse.elk.layered` (DOWN) — a tidy top-down DAG. The constellation
+ * redesign wants an ORGANIC RADIAL reading instead: the hub is a glowing core
+ * and its agents orbit it on a ring.
  *
- * A single-cluster (local-only) graph lays out as one tidy hub-over-agents tree,
- * preserving the Phase-D "your stack, agents fanned below" reading.
+ * The layout is a pure function of the graph data — no physics simulation, no
+ * ambient randomness (`Math.random()` is banned in this codebase, and a
+ * deterministic layout is also far easier to unit-test than a force scatter):
  *
- * ELK runs asynchronously (`elk.layout` returns a promise), so the view computes
- * the layout in an effect and stores the positioned nodes in state (see
- * `network-view.tsx`). This module keeps the ELK wiring isolated and injectable:
- * `layoutNetworkGraph` takes an `ElkLike` so a test can pass a deterministic stub
- * instead of spinning up the real WASM-backed engine.
+ *   1. GROUP — bucket each agent under its hub via the hub→agent edges (an agent
+ *      with no incoming edge, defensive, forms its own singleton cluster).
+ *   2. PLACE CLUSTERS — lay the cluster centres out on a coarse grid (columns =
+ *      ceil(sqrt(clusterCount))), a fixed stride apart. Deterministic + tidy;
+ *      no overlap for the small stack counts cortex renders.
+ *   3. RING THE AGENTS — within each cluster the hub sits at the centre and its
+ *      agents are distributed EVENLY by angle on a ring whose radius scales with
+ *      the agent count (so a 12-agent stack ring is wider than a 2-agent one).
+ *
+ * Because it's synchronous + pure, the canvas no longer needs the async ELK
+ * effect (no WASM worker): it calls {@link layoutNetworkGraph} directly and
+ * renders. The engine import (`elkjs`) is gone.
+ *
+ * Edges carry a 2-point route (`[hubCentre, agentCentre]`) in `layout.elkPoints`
+ * — the constellation edge (`network-elk-edge.tsx`) draws that as a gently
+ * curved teal connector rather than a straight/orthogonal DAG elbow.
  */
 
 import type {
@@ -43,143 +44,49 @@ import type {
   NetworkGraphEdge,
 } from "./network-graph-adapter";
 
-/** Rendered footprint of each node, fed to ELK so it reserves real space. */
-export const HUB_NODE_SIZE = { width: 180, height: 64 } as const;
-export const AGENT_NODE_SIZE = { width: 200, height: 96 } as const;
+/**
+ * Rendered footprint of each node. The circle nodes are small; the values are
+ * the diameter of the glowing orb (hub larger than agent) — used to reserve
+ * spacing and to centre the ring on the hub.
+ */
+export const HUB_NODE_SIZE = { width: 64, height: 64 } as const;
+export const AGENT_NODE_SIZE = { width: 28, height: 28 } as const;
 
 /**
- * ELK layout options for the multi-cluster LAYERED layout (#1008). Tuned for
- * one-or-more hub→agents trees laid top-down, adapted from Strata's layered
- * config (`arc-library/strata/ui/src/constants.ts`):
- *   - `algorithm: layered` + `direction: DOWN` — each stack-hub on the top layer,
- *     its agents on the layer below: a tidy top-down cluster per stack (replaces
- *     the `force` scatter that crossed edges + converged on the densest hub).
- *   - `edgeRouting: ORTHOGONAL` — right-angled connectors; ELK emits the bend
- *     points we render as rounded polylines (no diagonal crossings).
- *   - `crossingMinimization.strategy: LAYER_SWEEP` + `thoroughness` — minimise
- *     edge crossings within each cluster.
- *   - `nodePlacement.strategy: NETWORK_SIMPLEX` — straighten hub→agent edges so
- *     agents sit cleanly under their hub.
- *   - `separateConnectedComponents` + `spacing.componentComponent` — pack each
- *     disconnected stack-tree (serving stack + each sibling + each peer) as its
- *     own side-by-side group, NOT one giant overlapping scatter.
- *   - `spacing.*` keep agent cards (≤200px) and the per-stack columns apart.
+ * Radial-layout tuning constants (all in layout px). Exported so the tests can
+ * assert positions against the same geometry the renderer uses.
  */
-export const NETWORK_ELK_OPTIONS: Record<string, string> = {
-  "elk.algorithm": "org.eclipse.elk.layered",
-  "elk.direction": "DOWN",
-  "elk.edgeRouting": "ORTHOGONAL",
-  "elk.spacing.nodeNode": "48",
-  "elk.layered.spacing.nodeNodeBetweenLayers": "72",
-  "elk.layered.spacing.edgeNodeBetweenLayers": "32",
-  "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
-  "elk.layered.thoroughness": "7",
-  "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
-  // Pack each disconnected stack-tree (serving stack + each sibling + each peer)
-  // as its own side-by-side group rather than overlapping them.
-  "elk.separateConnectedComponents": "true",
-  "elk.spacing.componentComponent": "120",
-};
+export const RADIAL_LAYOUT = {
+  /** Base ring radius (px) for a single-agent cluster. */
+  baseRingRadius: 160,
+  /** Extra ring radius per additional agent, so dense clusters ring wider. */
+  radiusPerAgent: 14,
+  /** Upper bound on the ring radius so a very dense cluster stays compact. */
+  maxRingRadius: 340,
+  /** Centre-to-centre distance between adjacent cluster centres on the grid. */
+  clusterStride: 900,
+  /**
+   * Start angle (radians) for the first agent on every ring. A slight offset
+   * from straight-up keeps the first spoke from always pointing due north.
+   */
+  startAngle: -Math.PI / 2,
+} as const;
 
-/** One ELK input node (subset of the elkjs node shape we set). */
-interface ElkInputNode {
-  id: string;
-  width: number;
-  height: number;
-}
-
-/** One ELK input edge. */
-interface ElkInputEdge {
-  id: string;
-  sources: string[];
-  targets: string[];
-}
-
-/** The ELK graph we hand to `elk.layout`. */
-export interface ElkInputGraph {
-  id: string;
-  layoutOptions: Record<string, string>;
-  children: ElkInputNode[];
-  edges: ElkInputEdge[];
-}
-
-/** One positioned node ELK returns (only the fields we read). */
-export interface ElkLaidOutNode {
-  id: string;
-  x?: number;
-  y?: number;
-  width?: number;
-  height?: number;
-}
-
-/** A 2D point in ELK's layout coordinate space. */
-export interface ElkPoint {
+/** A 2D point in the layout coordinate space. */
+export interface Point {
   x: number;
   y: number;
 }
 
 /**
- * One routed edge ELK returns. ORTHOGONAL routing populates `sections[0]` with a
- * `startPoint`, optional `bendPoints`, and an `endPoint` — the right-angled path
- * we render as a rounded polyline. (Strata reads the same `sections[0]` shape.)
- */
-export interface ElkLaidOutEdge {
-  id: string;
-  sections?: {
-    startPoint: ElkPoint;
-    bendPoints?: ElkPoint[];
-    endPoint: ElkPoint;
-  }[];
-}
-
-/** The ELK result shape we read back. */
-export interface ElkLaidOutGraph {
-  children?: ElkLaidOutNode[];
-  edges?: ElkLaidOutEdge[];
-}
-
-/** The minimal elkjs surface we depend on — injectable for tests. */
-export interface ElkLike {
-  layout(graph: ElkInputGraph): Promise<ElkLaidOutGraph>;
-}
-
-/** Size lookup: the hub gets the hub footprint, agents the agent footprint. */
-function sizeFor(node: NetworkGraphNode): { width: number; height: number } {
-  return node.type === "stackHub" ? HUB_NODE_SIZE : AGENT_NODE_SIZE;
-}
-
-/**
- * Build the ELK input graph from the React-Flow graph. Pure — separated from the
- * async `elk.layout` call so the translation (node sizing, edge mapping, options)
- * is unit-testable without running the engine.
- */
-export function toElkGraph(graph: NetworkGraph): ElkInputGraph {
-  return {
-    id: "root",
-    layoutOptions: NETWORK_ELK_OPTIONS,
-    children: graph.nodes.map((n) => {
-      const { width, height } = sizeFor(n);
-      return { id: n.id, width, height };
-    }),
-    edges: graph.edges.map((e) => ({
-      id: e.id,
-      sources: [e.source],
-      targets: [e.target],
-    })),
-  };
-}
-
-/**
- * #1008 — the per-edge layout payload the canvas hands to the custom ELK edge
- * (`network-elk-edge.tsx`). `elkPoints` is ELK's orthogonal route
- * (`[startPoint, ...bendPoints, endPoint]`); the `layout*`/`*Y` fields are the
- * source/target node faces, used by the edge to clamp endpoints to the node
- * boundary and to detect a dragged node (fall back to a smoothstep then). All
- * optional — an edge ELK didn't route (defensive) carries no `elkPoints` and the
- * edge component falls back to a straight line.
+ * #1008 — the per-edge layout payload the canvas hands to the constellation edge
+ * (`network-elk-edge.tsx`). `elkPoints` is the edge route — for the radial
+ * layout a 2-point `[hubCentre, agentCentre]` list the edge draws as a gentle
+ * curve. The `layout*`/`*Y` fields are the node centres/faces (kept for the
+ * edge's dragged-node fallback). All optional.
  */
 export interface NetworkEdgeLayout {
-  elkPoints?: ElkPoint[];
+  elkPoints?: Point[];
   layoutSourceX?: number;
   layoutSourceY?: number;
   layoutTargetX?: number;
@@ -188,77 +95,175 @@ export interface NetworkEdgeLayout {
   targetBottomY?: number;
 }
 
-/** One laid-out edge: the base graph edge + its computed ELK route payload. */
+/** One laid-out edge: the base graph edge + its computed route payload. */
 export interface LaidOutNetworkEdge extends NetworkGraphEdge {
   layout: NetworkEdgeLayout;
 }
 
-/** The layout result: positioned nodes + edges carrying ELK's bend points. */
+/** The layout result: positioned nodes + edges carrying their route points. */
 export interface LaidOutNetworkGraph {
   nodes: NetworkGraphNode[];
   edges: LaidOutNetworkEdge[];
 }
 
+/** Size lookup: the hub gets the hub footprint, agents the agent footprint. */
+function sizeFor(node: NetworkGraphNode): { width: number; height: number } {
+  return node.type === "stackHub" ? HUB_NODE_SIZE : AGENT_NODE_SIZE;
+}
+
+/** The ring radius for a cluster of `agentCount` agents (clamped). */
+export function ringRadiusForCount(agentCount: number): number {
+  const raw =
+    RADIAL_LAYOUT.baseRingRadius +
+    Math.max(0, agentCount - 1) * RADIAL_LAYOUT.radiusPerAgent;
+  return Math.min(raw, RADIAL_LAYOUT.maxRingRadius);
+}
+
 /**
- * Run ELK over the graph and return the positioned nodes AND the edges carrying
- * ELK's computed orthogonal bend points (`layout.elkPoints`), so the canvas can
- * render clean right-angled connectors instead of crossing-prone straight/bezier
- * edges. The bend points are extracted from each edge's `sections[0]`
- * (`startPoint` + `bendPoints` + `endPoint`), exactly as Strata's layout does.
- *
- * An empty graph short-circuits (no ELK call) and returns empty nodes + edges. A
- * node ELK didn't position (shouldn't happen, but defensive) keeps its incoming
- * `{0,0}`; an edge ELK didn't route carries no `elkPoints` (the edge component
- * falls back to a straight line).
+ * Grid position (column, row) of the `i`-th cluster centre. Columns =
+ * `ceil(sqrt(total))` so N clusters form a roughly-square grid, filled
+ * left-to-right, top-to-bottom. Deterministic — the same `i`/`total` always
+ * yields the same cell.
  */
-export async function layoutNetworkGraph(
-  elk: ElkLike,
-  graph: NetworkGraph,
-): Promise<LaidOutNetworkGraph> {
-  if (graph.nodes.length === 0) return { nodes: [], edges: [] };
+export function clusterCentre(i: number, total: number): Point {
+  const cols = Math.max(1, Math.ceil(Math.sqrt(total)));
+  const rows = Math.max(1, Math.ceil(total / cols));
+  const col = i % cols;
+  const row = Math.floor(i / cols);
+  // Centre the whole grid on the origin so `fitView` frames it symmetrically.
+  const x = (col - (cols - 1) / 2) * RADIAL_LAYOUT.clusterStride;
+  const y = (row - (rows - 1) / 2) * RADIAL_LAYOUT.clusterStride;
+  return { x, y };
+}
 
-  const result = await elk.layout(toElkGraph(graph));
+/**
+ * One cluster: its hub node id and the ordered agent node ids ringed around it.
+ * A hub with no agents is still a cluster (a lone glowing core).
+ */
+interface Cluster {
+  hubId: string;
+  agentIds: string[];
+}
 
-  // Index the laid-out nodes by id — for positions AND for the source/target
-  // face geometry the edge clamps to.
-  const laidOut = new Map<string, ElkLaidOutNode>();
-  for (const c of result.children ?? []) laidOut.set(c.id, c);
-
-  const nodes = graph.nodes.map((n) => {
-    const c = laidOut.get(n.id);
-    return c ? { ...n, position: { x: c.x ?? 0, y: c.y ?? 0 } } : n;
-  });
-
-  // Extract each edge's orthogonal route from ELK's `sections[0]`.
-  const routes = new Map<string, ElkPoint[]>();
-  for (const e of result.edges ?? []) {
-    const section = e.sections?.[0];
-    if (section) {
-      routes.set(e.id, [
-        section.startPoint,
-        ...(section.bendPoints ?? []),
-        section.endPoint,
-      ]);
+/**
+ * GROUP the graph into clusters — one per stack-hub — by walking the hub→agent
+ * edges. Hubs are emitted in their graph order (the adapter emits the local hub
+ * first, then peers), so the cluster grid reads local-first. An agent with no
+ * incoming hub edge (defensive — shouldn't happen) becomes its own singleton
+ * cluster so it's never dropped.
+ *
+ * Pure + exported for unit testing.
+ */
+export function clusterNetworkGraph(graph: NetworkGraph): Cluster[] {
+  const hubOrder: string[] = [];
+  const agentsByHub = new Map<string, string[]>();
+  for (const n of graph.nodes) {
+    if (n.type === "stackHub") {
+      hubOrder.push(n.id);
+      if (!agentsByHub.has(n.id)) agentsByHub.set(n.id, []);
     }
   }
 
-  const edges = graph.edges.map((e): LaidOutNetworkEdge => {
-    const elkPoints = routes.get(e.id);
-    const src = laidOut.get(e.source);
-    const tgt = laidOut.get(e.target);
-    const layout: NetworkEdgeLayout = elkPoints ? { elkPoints } : {};
-    if (elkPoints && src) {
-      layout.layoutSourceX = (src.x ?? 0) + (src.width ?? 0) / 2;
-      layout.layoutSourceY = (src.y ?? 0) + (src.height ?? 0);
-      layout.sourceTopY = src.y ?? 0;
+  // Map each agent to its hub via the (hub → agent) edge.
+  const hubOfAgent = new Map<string, string>();
+  for (const e of graph.edges) {
+    if (agentsByHub.has(e.source)) hubOfAgent.set(e.target, e.source);
+  }
+
+  const orphanCluster: string[] = [];
+  for (const n of graph.nodes) {
+    if (n.type !== "agent") continue;
+    const hub = hubOfAgent.get(n.id);
+    if (hub !== undefined) {
+      agentsByHub.get(hub)!.push(n.id);
+    } else {
+      orphanCluster.push(n.id);
     }
-    if (elkPoints && tgt) {
-      layout.layoutTargetX = (tgt.x ?? 0) + (tgt.width ?? 0) / 2;
-      layout.layoutTargetY = tgt.y ?? 0;
-      layout.targetBottomY = (tgt.y ?? 0) + (tgt.height ?? 0);
+  }
+
+  const clusters: Cluster[] = hubOrder.map((hubId) => ({
+    hubId,
+    agentIds: agentsByHub.get(hubId) ?? [],
+  }));
+  // Each orphan agent forms its own hub-less singleton cluster (defensive).
+  for (const agentId of orphanCluster) {
+    clusters.push({ hubId: agentId, agentIds: [] });
+  }
+  return clusters;
+}
+
+/**
+ * Position every node with the deterministic RADIAL layout and return the nodes
+ * (with `position` set to each node's CENTRE) plus the edges carrying a 2-point
+ * `[hubCentre, agentCentre]` route in `layout.elkPoints`.
+ *
+ * SYNCHRONOUS + PURE — a pure function of the graph data (no engine, no worker,
+ * no randomness), so the canvas calls it directly and the tests assert exact
+ * positions. An empty graph short-circuits to empty nodes + edges.
+ *
+ * Positions are the node CENTRES (React Flow with the circle nodes centres each
+ * node on its position via CSS `translate(-50%, -50%)`), which also makes the
+ * hub→agent edge geometry trivial: the route is just centre-to-centre.
+ */
+export function layoutNetworkGraph(graph: NetworkGraph): LaidOutNetworkGraph {
+  if (graph.nodes.length === 0) return { nodes: [], edges: [] };
+
+  const clusters = clusterNetworkGraph(graph);
+  const centres = new Map<string, Point>();
+
+  clusters.forEach((cluster, i) => {
+    const centre = clusterCentre(i, clusters.length);
+    // The hub sits at the cluster centre.
+    centres.set(cluster.hubId, centre);
+
+    const count = cluster.agentIds.length;
+    if (count === 0) return;
+    const radius = ringRadiusForCount(count);
+    cluster.agentIds.forEach((agentId, j) => {
+      // Even angular distribution around the ring, deterministic start angle.
+      const angle = RADIAL_LAYOUT.startAngle + (2 * Math.PI * j) / count;
+      centres.set(agentId, {
+        x: centre.x + radius * Math.cos(angle),
+        y: centre.y + radius * Math.sin(angle),
+      });
+    });
+  });
+
+  const nodes = graph.nodes.map((n) => {
+    const c = centres.get(n.id);
+    return c ? { ...n, position: { x: c.x, y: c.y } } : n;
+  });
+
+  const edges = graph.edges.map((e): LaidOutNetworkEdge => {
+    const src = centres.get(e.source);
+    const tgt = centres.get(e.target);
+    const layout: NetworkEdgeLayout = {};
+    if (src && tgt) {
+      // A 2-point centre-to-centre route; the edge draws it as a gentle curve.
+      layout.elkPoints = [
+        { x: src.x, y: src.y },
+        { x: tgt.x, y: tgt.y },
+      ];
+      const srcSize = sizeForId(graph, e.source);
+      const tgtSize = sizeForId(graph, e.target);
+      layout.layoutSourceX = src.x;
+      layout.layoutSourceY = src.y;
+      layout.sourceTopY = src.y - srcSize.height / 2;
+      layout.layoutTargetX = tgt.x;
+      layout.layoutTargetY = tgt.y;
+      layout.targetBottomY = tgt.y + tgtSize.height / 2;
     }
     return { ...e, layout };
   });
 
   return { nodes, edges };
+}
+
+/** Footprint of the node with `id` (falls back to the agent size if unknown). */
+function sizeForId(
+  graph: NetworkGraph,
+  id: string,
+): { width: number; height: number } {
+  const node = graph.nodes.find((n) => n.id === id);
+  return node ? sizeFor(node) : AGENT_NODE_SIZE;
 }


### PR DESCRIPTION
First slice of the Network-graph visual redesign (principal direction: replace the boxy ELK-DAG with an organic constellation like the target mockup). Keeps `@xyflow/react`; swaps the layout + node rendering underneath it.

## What
- **`lib/network-graph-layout.ts`** — replaced the ELK layered layout with a deterministic **hub-centric radial** layout (each stack hub centered, agents on a ring around it; clusters spread across the canvas). Pure + unit-testable, no async WASM worker.
- **`components/network-nodes.tsx`** — stack-hub + agent nodes rendered as **glowing circles** (presence ring, health colour, attention accent) instead of card boxes.
- **`components/network-canvas.tsx`** — swapped the async ELK effect for the synchronous radial layout; React Flow pan/zoom/nodes/edges plumbing kept.
- **`components/network-elk-edge.tsx`** + **`constellation-canvas.css`** — curved edge + glow styling.

## Scope
This is D1 (layout) + D2 (nodes) only. Next slices (separate): D4 federated peers as dimmed nodes + cross-network dotted link; D3 RTT labels + traffic; then the PEOPLE view.

## Tests
network-graph-layout + network-elk-edge suites → 26 pass / 0 fail. tsc 0, eslint clean, additive-only. Rebased onto main (clean w/ the strip PR #1765).

Note: frontend-only — needs `bun run build:dashboard` to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)