### PR TITLE
chore: bump to v6.6.0 — MC system.* events, radial network layout, cc-events compat shims, pylon pack retirement

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.5.0"
+version: "6.6.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version cut covering, since v6.5.0:
- #1766 — MC folds access/dispatch/reflex `system.*` families (migration + renderer + attention)
- #1768 — MC-D1 radial constellation layout + circle nodes for the Network graph
- #1750 — cc-events compat shims at pre-#1739 hook names: upgraded installs' `~/.claude/hooks` symlinks heal on next serving-tree ff (fixes #1749)
- #1771 — `personas/pylon.md` retired from core; Pylon ships as the `amt/pylon-pack` agent pack (cutover verified live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)