### PR TITLE
feat(mc): MC-D4 federated peers on the graph + fullscreen constellation toggle

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
@@ -12,14 +12,18 @@ import {
   buildNetworkGraph,
   collectLegendStacks,
   deriveServingPrincipal,
+  federatedPeerIdForPrincipal,
   STACK_HUB_NODE_ID,
   FOREIGN_HUB_ID_PREFIX,
+  FEDERATED_PEER_ID_PREFIX,
   type AgentNodeData,
   type StackHubNodeData,
+  type FederatedPeerNodeData,
 } from "../lib/network-graph-adapter";
 import { classifyOrigin } from "../lib/agents-display";
 import { LOCAL_STACK_COLOR } from "../lib/stack-color";
 import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
 
 function tile(
   over: Partial<AgentPresenceTile> & { agent_id: string },
@@ -602,5 +606,142 @@ describe("buildNetworkGraph — federated edge flag (MC-D3 #1290)", () => {
       "foreign",
     );
     expect(foreignEdge?.data?.federated).toBe(true);
+  });
+});
+
+/**
+ * MC-D4 — a minimal `NetworkMembershipDTO` fixture. Only the fields the adapter
+ * reads (`network_id`, `members[].{principal,verdict,present_stacks}`) matter;
+ * the rest are filled with honest defaults.
+ */
+function membership(
+  over: Partial<NetworkMembershipDTO> & {
+    network_id: string;
+    members: NetworkMembershipDTO["members"];
+  },
+): NetworkMembershipDTO {
+  return {
+    leaf_node: "leaf-1",
+    roster_status: "ok",
+    roster_scope: "complete",
+    confidentiality: { mode: "off", key_present: false, key_id: null },
+    ...over,
+  };
+}
+
+/** One roster member DTO. */
+function member(
+  principal: string,
+  present_stacks: string[],
+  verdict: NetworkMembershipDTO["members"][number]["verdict"] = present_stacks.length
+    ? "admitted-present"
+    : "admitted-absent",
+): NetworkMembershipDTO["members"][number] {
+  return { principal, verdict, present_stacks, accepts: "accepted-network" };
+}
+
+describe("buildNetworkGraph — absent federated peers (MC-D4)", () => {
+  it("emits a dimmed federated-peer node + a dotted anchor edge for an absent non-local member", () => {
+    const g = buildNetworkGraph(
+      [tile({ agent_id: "luna" })], // one present LOCAL agent (⇒ a local hub exists)
+      [
+        membership({
+          network_id: "mfnet",
+          members: [
+            member("andreas", ["research"]), // the serving principal — present
+            member("jc", []), // admitted but ABSENT (no present stacks)
+          ],
+        }),
+      ],
+    );
+
+    const peerId = federatedPeerIdForPrincipal("jc");
+    expect(peerId.startsWith(FEDERATED_PEER_ID_PREFIX)).toBe(true);
+
+    const peerNode = g.nodes.find((n) => n.id === peerId);
+    expect(peerNode).toBeDefined();
+    expect(peerNode?.type).toBe("federatedPeer");
+    const data = peerNode?.data as FederatedPeerNodeData;
+    expect(data.kind).toBe("federated-peer");
+    expect(data.principal).toBe("jc");
+    expect(data.networkId).toBe("mfnet");
+    expect(data.verdict).toBe("admitted-absent");
+
+    // The dotted anchor edge: local hub → the peer placeholder, flagged absent.
+    const edge = g.edges.find((e) => e.target === peerId);
+    expect(edge).toBeDefined();
+    expect(edge?.source).toBe(STACK_HUB_NODE_ID);
+    expect(edge?.data?.federatedAbsent).toBe(true);
+    // It is NOT the present-peer `federated` (dashed) edge treatment.
+    expect(edge?.data?.federated ?? false).toBe(false);
+  });
+
+  it("produces nothing extra when an absent member has NO roster (networks omitted)", () => {
+    const withRoster = buildNetworkGraph([tile({ agent_id: "luna" })], []);
+    const withoutRoster = buildNetworkGraph([tile({ agent_id: "luna" })]);
+    // Byte-identical: no roster ⇒ no absent-peer nodes/edges (pre-D4 shape).
+    expect(withRoster).toEqual(withoutRoster);
+    expect(
+      withRoster.nodes.some((n) => n.type === "federatedPeer"),
+    ).toBe(false);
+    expect(
+      withRoster.edges.some((e) => e.data?.federatedAbsent === true),
+    ).toBe(false);
+  });
+
+  it("does NOT emit a placeholder for the serving (local) principal", () => {
+    const g = buildNetworkGraph(
+      [tile({ agent_id: "luna" })],
+      [membership({ network_id: "mfnet", members: [member("andreas", [])] })],
+    );
+    expect(g.nodes.some((n) => n.type === "federatedPeer")).toBe(false);
+  });
+
+  it("does NOT emit a placeholder for a PRESENT foreign peer (already a stack hub — E.3 folding preserved)", () => {
+    const g = buildNetworkGraph(
+      [
+        tile({ agent_id: "luna" }),
+        foreignTile({ agent_id: "sage", principal: "jc", stack: "research" }),
+      ],
+      [
+        membership({
+          network_id: "mfnet",
+          members: [member("andreas", ["research"]), member("jc", ["research"])],
+        }),
+      ],
+    );
+    // jc is present (has an agent tile ⇒ its own stack hub); no absent placeholder.
+    expect(g.nodes.some((n) => n.type === "federatedPeer")).toBe(false);
+    // The present foreign peer still renders as its stack hub (E.3 unchanged).
+    expect(
+      g.nodes.some(
+        (n) =>
+          n.type === "stackHub" &&
+          n.id === `${FOREIGN_HUB_ID_PREFIX}jc/research`,
+      ),
+    ).toBe(true);
+  });
+
+  it("de-duplicates an absent peer that appears on multiple networks (first-seen wins)", () => {
+    const g = buildNetworkGraph(
+      [tile({ agent_id: "luna" })],
+      [
+        membership({ network_id: "net-a", members: [member("jc", [])] }),
+        membership({ network_id: "net-b", members: [member("jc", [])] }),
+      ],
+    );
+    const peers = g.nodes.filter((n) => n.type === "federatedPeer");
+    expect(peers).toHaveLength(1);
+    expect((peers[0]?.data as FederatedPeerNodeData).networkId).toBe("net-a");
+  });
+
+  it("emits no placeholder when there is no LOCAL hub to anchor to (foreign-only snapshot)", () => {
+    // A snapshot of ONLY a foreign agent ⇒ no local `__stack__` hub. An absent
+    // peer would have nothing to anchor to, so none is emitted.
+    const g = buildNetworkGraph(
+      [foreignTile({ agent_id: "sage", principal: "jc", stack: "research" })],
+      [membership({ network_id: "mfnet", members: [member("kim", [])] })],
+    );
+    expect(g.nodes.some((n) => n.type === "federatedPeer")).toBe(false);
   });
 });

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
@@ -18,11 +18,13 @@ import { createElement } from "react";
 import {
   AgentNodeCard,
   StackHubCard,
+  FederatedPeerCard,
 } from "../components/network-nodes";
 import { NetworkLegend } from "../components/network-legend";
 import type {
   AgentNodeData,
   StackHubNodeData,
+  FederatedPeerNodeData,
 } from "../lib/network-graph-adapter";
 
 function agentData(over: Partial<AgentNodeData> = {}): AgentNodeData {
@@ -463,5 +465,38 @@ describe("#1068 — hub-subtree selection (a11y + emphasis/dim)", () => {
     );
     expect(html).toContain('data-dimmed="true"');
     expect(html).toContain("network-node-dimmed");
+  });
+});
+
+describe("FederatedPeerCard (MC-D4 — absent admitted peer)", () => {
+  function render(over: Partial<FederatedPeerNodeData> = {}): string {
+    const data: FederatedPeerNodeData = {
+      kind: "federated-peer",
+      principal: "jc",
+      verdict: "admitted-absent",
+      networkId: "mfnet",
+      ...over,
+    };
+    return renderToStaticMarkup(createElement(FederatedPeerCard, { data }));
+  }
+
+  it("renders a dimmed federated-peer node labelled with the peer principal", () => {
+    const html = render();
+    expect(html).toContain('data-node-kind="federated-peer"');
+    expect(html).toContain('data-fed-peer-principal="jc"');
+    expect(html).toContain('data-fed-peer-absent="true"');
+    // The principal id is the visible label.
+    expect(html).toContain(">jc<");
+    // The `federated · absent` sublabel.
+    expect(html).toContain("federated · absent");
+    // The muted orb class (no glow — styled in CSS).
+    expect(html).toContain("network-node-orb-fed-peer");
+    // An accessible name marking it admitted + absent.
+    expect(html).toContain("federated peer (admitted, absent)");
+  });
+
+  it("carries the membership verdict as a data attribute", () => {
+    const html = render({ verdict: "admitted-absent" });
+    expect(html).toContain('data-fed-peer-verdict="admitted-absent"');
   });
 });

--- a/src/surface/mc/dashboard-v2/components/constellation-canvas.css
+++ b/src/surface/mc/dashboard-v2/components/constellation-canvas.css
@@ -264,6 +264,49 @@
   color: color-mix(in oklch, var(--tide) 75%, var(--fg));
 }
 
+/* ── MC-D4 — absent admitted federated peers ─────────────────────────────────
+ * An admitted roster member with NO present tile: a DIMMED grey orb (muted ring,
+ * NO glow) + a `federated · absent` eyebrow. It marks the federation you belong
+ * to even before the peer's stack comes up. Deliberately low-contrast so it never
+ * reads as a live node; a dotted anchor edge ties it to the local hub. */
+.mc-skin .network-node-orb-fed-peer {
+  width: 22px;
+  height: 22px;
+  border: 1.5px dotted color-mix(in oklch, var(--faint) 70%, var(--fg));
+  background: color-mix(in oklch, var(--panel) 70%, transparent);
+  /* No box-shadow: absent peers do not glow. */
+  box-shadow: none;
+  opacity: 0.6;
+}
+.mc-skin .network-node-fed-peer-absent {
+  opacity: 0.72;
+}
+.mc-skin .network-fed-peer-eyebrow {
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: color-mix(in oklch, var(--faint) 60%, var(--fg));
+}
+.mc-skin .network-fed-peer-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: color-mix(in oklch, var(--fg) 60%, var(--faint));
+}
+
+/* The dotted anchor edge (local hub → absent peer) + its label. */
+.mc-skin .edge-fed-absent {
+  stroke-dasharray: 2 5;
+  opacity: 0.5;
+  /* Static — an absent peer carries no flow. */
+}
+.mc-skin .mc-edge-fed-absent-label {
+  color: color-mix(in oklch, var(--faint) 70%, var(--fg));
+  border-color: color-mix(in oklch, var(--faint) 45%, var(--line));
+}
+.mc-skin .mc-edge-fed-absent-label span[aria-hidden="true"] {
+  color: var(--faint);
+}
+
 /* ── Capability + state chips ───────────────────────────────────────────────*/
 .mc-skin .network-node-cap {
   font-family: var(--mono);

--- a/src/surface/mc/dashboard-v2/components/constellation-canvas.css
+++ b/src/surface/mc/dashboard-v2/components/constellation-canvas.css
@@ -349,6 +349,87 @@
   color: var(--tide);
 }
 
+/* ── Fullscreen / expand ─────────────────────────────────────────────────────
+ * The canvas wrapper can expand to fill the whole viewport. Two paths land the
+ * SAME visual:
+ *   - the browser Fullscreen API — the native `:fullscreen` pseudo matches the
+ *     element the browser promoted; and
+ *   - a CSS fixed-overlay fallback — `.is-fullscreen` (position:fixed, inset:0),
+ *     used when the Fullscreen API is unavailable/denied.
+ * Both fill the viewport with the constellation atmosphere so the surrounding
+ * dashboard chrome is hidden, and the React Flow canvas re-fits inside them. */
+.mc-skin .network-canvas-fullscreen-target {
+  /* Boxed default — fills its parent panel; the flow canvas already sizes to it. */
+  width: 100%;
+  height: 100%;
+}
+.mc-skin .network-canvas-fullscreen-target.is-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  width: 100vw;
+  height: 100vh;
+  /* Match the constellation atmosphere so the fullscreen surface reads the same. */
+  background:
+    radial-gradient(
+      ellipse 120% 80% at 50% -10%,
+      color-mix(in oklch, var(--mer) 14%, transparent) 0%,
+      transparent 55%
+    ),
+    var(--bg);
+}
+/* Native Fullscreen API path — the promoted element fills the screen; give it the
+ * same atmosphere + let the flow canvas fill it. */
+.mc-skin .network-canvas-fullscreen-target:fullscreen {
+  width: 100vw;
+  height: 100vh;
+  background:
+    radial-gradient(
+      ellipse 120% 80% at 50% -10%,
+      color-mix(in oklch, var(--mer) 14%, transparent) 0%,
+      transparent 55%
+    ),
+    var(--bg);
+}
+/* In BOTH fullscreen paths the inner React Flow region must fill the promoted
+ * target (the boxed layout used the parent panel's height). */
+.mc-skin .network-canvas-fullscreen-target.is-fullscreen .react-flow,
+.mc-skin .network-canvas-fullscreen-target:fullscreen .react-flow {
+  width: 100%;
+  height: 100%;
+}
+
+/* The fullscreen toggle button — a React Flow Panel, top-right by the zoom
+ * controls. Low-ceremony pill; icon + label. */
+.mc-skin .network-fullscreen-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  padding: 4px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  color: color-mix(in oklch, var(--fg) 80%, var(--mer));
+  border: 1px solid color-mix(in oklch, var(--mer) 35%, var(--line));
+  background: color-mix(in oklch, var(--panel) 82%, var(--bg));
+  box-shadow: 0 0 12px -4px color-mix(in oklch, var(--mer) 45%, transparent);
+}
+.mc-skin .network-fullscreen-btn:hover {
+  border-color: color-mix(in oklch, var(--mer) 55%, var(--line));
+  color: var(--fg);
+}
+.mc-skin .network-fullscreen-btn[aria-pressed="true"] {
+  color: var(--bg);
+  background: color-mix(in oklch, var(--mer) 80%, var(--fg));
+  border-color: var(--mer);
+}
+.mc-skin .network-fullscreen-btn span[aria-hidden="true"] {
+  font-size: 13px;
+  line-height: 1;
+}
+
 /* ── On-canvas network header — `<NETWORK> · admin|member · N stacks` ─────────
  * Overlays the top of the star-map (the mockup's network header strip). */
 .mc-skin .mc-constellation-header {

--- a/src/surface/mc/dashboard-v2/components/network-canvas.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-canvas.tsx
@@ -18,11 +18,13 @@
  * ADR-0007: nodes carry presence + lifecycle only — never session interiors.
  */
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ReactFlow,
   Controls,
+  Panel,
   ReactFlowProvider,
+  useReactFlow,
   type Node as RfNode,
   type Edge as RfEdge,
   type NodeTypes,
@@ -90,12 +92,58 @@ export interface NetworkCanvasProps {
   live?: boolean;
 }
 
+/**
+ * MC — the fullscreen/expand control, rendered as a React Flow `Panel` in the
+ * top-right so it sits alongside the zoom controls (bottom-left). A real
+ * `<button>` with an `aria-label`, it toggles the canvas wrapper between boxed
+ * and viewport-filling. On EVERY toggle it re-fits the graph to the new size
+ * (`fitView`) after a paint so the constellation re-centers. Uses `useReactFlow`,
+ * so it must render INSIDE the `ReactFlowProvider`.
+ */
+function FullscreenToggle({
+  isFullscreen,
+  onToggle,
+}: {
+  isFullscreen: boolean;
+  onToggle: () => void;
+}) {
+  const { fitView } = useReactFlow();
+  // Re-fit whenever the fullscreen state flips: the viewport just resized, so the
+  // radial layout should re-center to the new bounds. Deferred to the next frame
+  // so the DOM has taken the new size before we measure + fit.
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      void fitView({ duration: 200 });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isFullscreen, fitView]);
+  return (
+    <button
+      type="button"
+      className="network-fullscreen-btn"
+      onClick={onToggle}
+      aria-pressed={isFullscreen}
+      aria-label={
+        isFullscreen ? "Exit fullscreen network graph" : "Expand network graph to fullscreen"
+      }
+      title={isFullscreen ? "Exit fullscreen (Esc)" : "Fullscreen"}
+    >
+      <span aria-hidden="true">⛶</span>
+      <span className="network-fullscreen-btn-label">
+        {isFullscreen ? "Exit" : "Fullscreen"}
+      </span>
+    </button>
+  );
+}
+
 /** The React Flow canvas — rendered once ELK has positioned the nodes. */
 function FlowCanvas({
   nodes,
   laidOutEdges,
   onSelectAgent,
   live = false,
+  isFullscreen = false,
+  onToggleFullscreen,
 }: {
   nodes: NetworkGraphNode[];
   laidOutEdges: LaidOutNetworkEdge[];
@@ -106,6 +154,10 @@ function FlowCanvas({
    * static dash (truth-not-theater — zero flow never animates).
    */
   live?: boolean;
+  /** MC — the canvas wrapper is currently viewport-filling. Drives the button label. */
+  isFullscreen?: boolean;
+  /** MC — toggle the canvas wrapper between boxed and fullscreen. */
+  onToggleFullscreen?: () => void;
 }) {
   // React Flow's node `data` is typed `Record<string, unknown>`; our discriminated
   // `NetworkNodeData` is structurally compatible but lacks the index signature, so
@@ -211,6 +263,16 @@ function FlowCanvas({
       {/* MC-D1 — no <Background>: the constellation reads against a clean
           near-black atmosphere (painted by `.network-canvas-wrap`), not a grid. */}
       <Controls position="bottom-left" showInteractive={false} />
+      {/* MC — the fullscreen/expand control, top-right by the zoom controls. Only
+          rendered when a toggle is wired (the host may omit it in a test). */}
+      {onToggleFullscreen && (
+        <Panel position="top-right">
+          <FullscreenToggle
+            isFullscreen={isFullscreen}
+            onToggle={onToggleFullscreen}
+          />
+        </Panel>
+      )}
       <NetworkLegend stacks={legendStacks} />
     </ReactFlow>
   );
@@ -237,10 +299,80 @@ export default function NetworkCanvas({
     [graph],
   );
 
-  if (positioned.length === 0) {
-    // No topology yet (empty snapshot) — nothing to constellate.
-    return <div className="network-view-empty">No agents on the network yet.</div>;
-  }
+  // MC — fullscreen/expand. The wrapper ref is the fullscreen target; we PREFER
+  // the browser Fullscreen API (`requestFullscreen`/`exitFullscreen`) and fall
+  // back to a CSS fixed-overlay when it's unavailable/denied (both drive the same
+  // `is-fullscreen` class the CSS keys off, so the visual is identical). The
+  // browser fires `fullscreenchange` on the API path (incl. the user pressing
+  // Esc), and we mirror Esc for the CSS-overlay path ourselves.
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  // True while we're in the CSS-overlay fallback (no Fullscreen API), so Esc is
+  // handled by us rather than the browser.
+  const cssFallbackRef = useRef(false);
+
+  const enterFullscreen = useCallback(() => {
+    const el = wrapRef.current;
+    if (el && typeof el.requestFullscreen === "function") {
+      el.requestFullscreen().catch((err: unknown) => {
+        // Denied / unsupported → CSS-overlay fallback (still fills the viewport).
+        // eslint-disable-next-line no-console
+        console.warn("[network-canvas] requestFullscreen failed:", err);
+        cssFallbackRef.current = true;
+        setIsFullscreen(true);
+      });
+      return;
+    }
+    // No Fullscreen API at all → CSS-overlay fallback.
+    cssFallbackRef.current = true;
+    setIsFullscreen(true);
+  }, []);
+
+  const exitFullscreen = useCallback(() => {
+    if (cssFallbackRef.current) {
+      cssFallbackRef.current = false;
+      setIsFullscreen(false);
+      return;
+    }
+    if (
+      typeof document !== "undefined" &&
+      document.fullscreenElement &&
+      typeof document.exitFullscreen === "function"
+    ) {
+      void document.exitFullscreen();
+    }
+    // The `fullscreenchange` handler flips state for the API path.
+  }, []);
+
+  const toggleFullscreen = useCallback(() => {
+    if (isFullscreen) exitFullscreen();
+    else enterFullscreen();
+  }, [isFullscreen, enterFullscreen, exitFullscreen]);
+
+  // Fullscreen API path: mirror the browser's fullscreen state (covers the user
+  // pressing Esc or the browser exiting fullscreen for any reason).
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onChange = () => {
+      if (cssFallbackRef.current) return; // CSS fallback owns its own state
+      setIsFullscreen(document.fullscreenElement === wrapRef.current);
+    };
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
+
+  // CSS-overlay fallback path: Esc exits (the Fullscreen API handles Esc itself).
+  useEffect(() => {
+    if (!isFullscreen || !cssFallbackRef.current) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        exitFullscreen();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isFullscreen, exitFullscreen]);
 
   const canvas = (
     <ReactFlowProvider>
@@ -249,17 +381,39 @@ export default function NetworkCanvas({
         laidOutEdges={laidOutEdges}
         onSelectAgent={onSelectAgent}
         live={live}
+        isFullscreen={isFullscreen}
+        onToggleFullscreen={toggleFullscreen}
       />
     </ReactFlowProvider>
   );
 
-  // F.2 — bridge the view's hover-highlight into the node tree. When no hover
-  // value is supplied, the context's inert default applies (no highlight).
-  return hover ? (
-    <NetworkHoverContext.Provider value={hover}>
-      {canvas}
-    </NetworkHoverContext.Provider>
-  ) : (
-    canvas
+  // The fullscreen wrapper is ALWAYS mounted (so the ref is stable across the
+  // empty/non-empty transition and hooks run unconditionally). When there's no
+  // topology yet we render the empty state inside it.
+  const inner =
+    positioned.length === 0 ? (
+      // No topology yet (empty snapshot) — nothing to constellate.
+      <div className="network-view-empty">No agents on the network yet.</div>
+    ) : hover ? (
+      // F.2 — bridge the view's hover-highlight into the node tree. When no hover
+      // value is supplied, the context's inert default applies (no highlight).
+      <NetworkHoverContext.Provider value={hover}>
+        {canvas}
+      </NetworkHoverContext.Provider>
+    ) : (
+      canvas
+    );
+
+  return (
+    <div
+      ref={wrapRef}
+      className={
+        "network-canvas-fullscreen-target" +
+        (isFullscreen ? " is-fullscreen" : "")
+      }
+      data-fullscreen={isFullscreen ? "true" : undefined}
+    >
+      {inner}
+    </div>
   );
 }

--- a/src/surface/mc/dashboard-v2/components/network-canvas.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-canvas.tsx
@@ -39,7 +39,7 @@ import {
   layoutNetworkGraph,
   type LaidOutNetworkEdge,
 } from "../lib/network-graph-layout";
-import { AgentNode, StackHubNode } from "./network-nodes";
+import { AgentNode, StackHubNode, FederatedPeerNode } from "./network-nodes";
 import NetworkElkEdge from "./network-elk-edge";
 import { NetworkLegend } from "./network-legend";
 import {
@@ -53,6 +53,8 @@ import {
 const nodeTypes: NodeTypes = {
   stackHub: StackHubNode,
   agent: AgentNode,
+  // MC-D4 — the absent admitted-federated-peer placeholder (dimmed grey orb).
+  federatedPeer: FederatedPeerNode,
 };
 
 // The custom constellation edge (MC-D1: a gently-curved teal spoke from the hub
@@ -141,6 +143,11 @@ function FlowCanvas({
           // edge draws a federated (cross-principal admitted-peer) connector
           // dashed + flowing, and labels it. Local/sibling edges stay solid.
           federated: e.data?.federated ?? false,
+          // MC-D4 — the DOTTED anchor edge from the local hub to an ABSENT
+          // admitted-federated-peer placeholder. Rendered dotted + static
+          // (absent = no flow), distinct from the solid local edge and the dashed
+          // present-peer `federated` edge.
+          federatedAbsent: e.data?.federatedAbsent ?? false,
           // CK-5 (#1292) — bind the admitted-peer dash-flow to REAL bus flow.
           // The edge animates ONLY when `live`; otherwise it renders a static
           // dash (the relationship is still legible, but nothing pretends to

--- a/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
@@ -173,6 +173,11 @@ export default function NetworkElkEdge(props: EdgeProps) {
   // flow here is the relationship treatment, not REAL bus traffic — binding the
   // dash-flow to live envelope flow is D5 (#1292).
   const federated = edgeData?.["federated"] === true;
+  // MC-D4 — the DOTTED anchor edge to an ABSENT admitted-federated-peer
+  // placeholder (`localHub → federatedPeer`). Distinct from the solid local edge
+  // AND the dashed present-peer `federated` edge; always static (absent = no
+  // flow). The constellation skin's `.edge-fed-absent` supplies the dotted dash.
+  const federatedAbsent = edgeData?.["federatedAbsent"] === true;
   // CK-5 (#1292) — bind the admitted-peer dash-flow to REAL bus flow. `live` is
   // true only when there IS envelope flow AND liveTraffic is on AND motion is
   // permitted; the canvas threads it through the edge `data`. When false the
@@ -287,14 +292,32 @@ export default function NetworkElkEdge(props: EdgeProps) {
         // (scoped under `.mc-skin`; inert in the un-skinned legacy render).
         // CK-5: animate ONLY on real flow; otherwise a static dash.
         className={
-          federated
-            ? live
-              ? "edge-live--fed"
-              : "edge-fed-static"
-            : undefined
+          federatedAbsent
+            ? "edge-fed-absent"
+            : federated
+              ? live
+                ? "edge-live--fed"
+                : "edge-fed-static"
+              : undefined
         }
       />
-      {federated && (
+      {federatedAbsent && (
+        <EdgeLabelRenderer>
+          <div
+            className="mc-edge-fed-label mc-edge-fed-absent-label"
+            data-edge-federated-absent="true"
+            style={{
+              position: "absolute",
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: "none",
+            }}
+            title="Federated peer — admitted to the network but not currently present"
+          >
+            <span aria-hidden="true">○</span> federated · absent
+          </div>
+        </EdgeLabelRenderer>
+      )}
+      {federated && !federatedAbsent && (
         <EdgeLabelRenderer>
           <div
             className="mc-edge-fed-label"

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -44,6 +44,7 @@ import {
 import type {
   AgentNodeData,
   StackHubNodeData,
+  FederatedPeerNodeData,
 } from "../lib/network-graph-adapter";
 import { isAgentHighlighted } from "../lib/capability-highlight";
 import { useNetworkHover } from "../lib/network-hover-context";
@@ -467,6 +468,62 @@ export function AgentNode({ data }: NodeProps) {
           setHoverTarget(key === null ? null : { kind: "agent", agentKey: key })
         }
       />
+    </>
+  );
+}
+
+// --- Federated peer (MC-D4: absent admitted peer) --------------------------
+
+export interface FederatedPeerCardProps {
+  data: FederatedPeerNodeData;
+}
+
+/**
+ * MC-D4 — pure presentational card for an ABSENT admitted federated peer.
+ *
+ * The peer principal is on the network roster (admitted) but has NO present agent
+ * tile, so it draws as a DIMMED orb — a muted grey ring, NO glow — labelled with
+ * the peer principal and a `federated · absent` sublabel. It marks "you are
+ * federated with this principal; their stack just isn't live right now", so the
+ * principal can see the whole federation, not only the parts currently online.
+ *
+ * Presence-level only (ADR-0007): identity + membership verdict, never a session
+ * interior. Not interactive — an absent peer has nothing local to open. Split
+ * inner/wrapper like the other nodes (the wrapper adds the xyflow `Handle`).
+ */
+export function FederatedPeerCard({ data }: FederatedPeerCardProps) {
+  return (
+    <div
+      className="network-node network-node-fed-peer network-node-fed-peer-absent"
+      data-node-kind="federated-peer"
+      data-fed-peer-principal={data.principal}
+      data-fed-peer-verdict={data.verdict}
+      data-fed-peer-absent="true"
+      aria-label={`${data.principal} — federated peer (admitted, absent)`}
+    >
+      {/* A muted grey ring — deliberately NO glow, distinct from the live orbs. */}
+      <span
+        className="network-node-orb network-node-orb-fed-peer"
+        aria-hidden="true"
+      />
+      <span className="network-node-below">
+        <span className="network-fed-peer-eyebrow dim">federated · absent</span>
+        <span className="network-fed-peer-label">{data.principal}</span>
+      </span>
+    </div>
+  );
+}
+
+/**
+ * xyflow node wrapper for an absent federated peer — adds the target handle so
+ * the dotted anchor edge from the local hub lands on it. Purely presentational
+ * (no hover/selection wiring — an absent peer is inert).
+ */
+export function FederatedPeerNode({ data }: NodeProps) {
+  return (
+    <>
+      <Handle type="target" position={Position.Top} isConnectable={false} />
+      <FederatedPeerCard data={data as unknown as FederatedPeerNodeData} />
     </>
   );
 }

--- a/src/surface/mc/dashboard-v2/components/network-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-view.tsx
@@ -337,10 +337,16 @@ export function NetworkView({
     [state.agents, filter],
   );
 
-  // Pure: filtered snapshot → React-Flow graph (re-derived when agents OR the
-  // filter change). Tiny + engine-free, so it stays in the main bundle; the lazy
-  // canvas takes the built graph and runs the radial layout over it.
-  const baseGraph = useMemo(() => buildNetworkGraph(filteredAgents), [filteredAgents]);
+  // Pure: filtered snapshot → React-Flow graph (re-derived when agents, the
+  // filter, OR the roster change). Tiny + engine-free, so it stays in the main
+  // bundle; the lazy canvas takes the built graph and runs the radial layout over
+  // it. MC-D4 — the `networks` roster is threaded in so an admitted-but-ABSENT
+  // federated peer (no present tile) still draws a dimmed placeholder node, so the
+  // principal sees the federation they belong to, not only who's currently online.
+  const baseGraph = useMemo(
+    () => buildNetworkGraph(filteredAgents, networks),
+    [filteredAgents, networks],
+  );
 
   // U2.3 — fold signal's transport verdicts + leaf liveness/RTT into the overlay
   // model, then onto the base graph WHEN the overlay toggle is on. Built off the

--- a/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-adapter.ts
@@ -38,6 +38,7 @@
  */
 
 import type { AgentPresenceTile, AgentOrigin } from "../hooks/use-agents";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
 import type {
   TransportOverlay,
   TransportVerdict,
@@ -51,6 +52,21 @@ export const STACK_HUB_NODE_ID = "__stack__";
 
 /** Prefix for a synthetic FOREIGN stack-hub id (`__stack__:{principal}/{stack}`). */
 export const FOREIGN_HUB_ID_PREFIX = "__stack__:";
+
+/**
+ * MC-D4 — prefix for a synthetic ABSENT-federated-peer placeholder node id
+ * (`__fed__:{principal}`). Namespaced under a reserved prefix so it can never
+ * collide with an agent key (`{principal}/{stack}/{agent_id}`) NOR a stack-hub id
+ * (`__stack__` / `__stack__:…`). One node per admitted-but-absent peer PRINCIPAL —
+ * an absent peer has no present stack/agent tile to derive a hub from, so it's
+ * keyed on the principal alone.
+ */
+export const FEDERATED_PEER_ID_PREFIX = "__fed__:";
+
+/** MC-D4 — the synthetic id for the absent-federated-peer node of `principal`. */
+export function federatedPeerIdForPrincipal(principal: string): string {
+  return `${FEDERATED_PEER_ID_PREFIX}${principal}`;
+}
 
 /**
  * Compute the hub node id for an agent's origin.
@@ -153,14 +169,42 @@ export interface AgentNodeData {
   transportLeaf?: { present: boolean; rttMs: number | null };
 }
 
+/**
+ * MC-D4 — React Flow node `data` payload for an ABSENT admitted federated peer.
+ *
+ * The principal is admitted to the network (an ADR-0018 roster member) but has NO
+ * present agent tile — `buildNetworkGraph` derives its hubs from present tiles, so
+ * without this the principal can't see the federation they're part of. This node
+ * is a DIMMED placeholder: a muted grey ring, no glow, labelled with the peer
+ * principal id and a `federated · absent` sublabel. Presence-level metadata only
+ * (ADR-0007) — it carries the principal and its membership verdict, never a
+ * session interior. It is never drillable (absent = nothing local to open).
+ */
+export interface FederatedPeerNodeData {
+  kind: "federated-peer";
+  /** The admitted-but-absent peer PRINCIPAL id (e.g. `jc`). The node label. */
+  principal: string;
+  /**
+   * The membership verdict for this peer on its network (from the roster ⋈
+   * presence reconciliation). Always an absent-family verdict here (the peer has
+   * no present stacks); carried so the card can nuance the sublabel if needed.
+   */
+  verdict: string;
+  /** The network id this peer is admitted to (first-seen when a peer spans several). */
+  networkId: string;
+}
+
 /** Discriminated union of every node `data` shape in the graph. */
-export type NetworkNodeData = StackHubNodeData | AgentNodeData;
+export type NetworkNodeData =
+  | StackHubNodeData
+  | AgentNodeData
+  | FederatedPeerNodeData;
 
 /** A React-Flow-shaped node BEFORE ELK assigns a position (position is 0,0). */
 export interface NetworkGraphNode {
   id: string;
-  /** Custom node type registered on the canvas (`stackHub` | `agent`). */
-  type: "stackHub" | "agent";
+  /** Custom node type registered on the canvas (`stackHub` | `agent` | `federatedPeer`). */
+  type: "stackHub" | "agent" | "federatedPeer";
   data: NetworkNodeData;
   position: { x: number; y: number };
 }
@@ -209,6 +253,14 @@ export interface NetworkGraphEdge {
   data?: {
     stackColor?: string;
     federated?: boolean;
+    /**
+     * MC-D4 — true when this edge wires the local stack hub to an ABSENT
+     * admitted-federated-peer placeholder node. Styled as a DOTTED federated link
+     * (distinct from the solid local hub→agent edge AND from the dashed present-
+     * peer `federated` edge), marking "admitted but no live presence". Never
+     * animates (absent = no flow).
+     */
+    federatedAbsent?: boolean;
     transport?: NetworkEdgeTransportData;
   };
 }
@@ -267,13 +319,29 @@ function originScope(a: AgentPresenceTile): { principal: string; stack: string }
  * roots up front; agent nodes follow in snapshot order. A local-only snapshot is
  * byte-identical to Phase D (a single `__stack__` hub).
  *
+ * ## MC-D4 — absent admitted federated peers
+ *
+ * `agents` derives hubs from PRESENT tiles only, so an admitted-but-ABSENT peer
+ * (a roster member with no `present_stacks`, e.g. `jc` before its stack comes up)
+ * draws NO node — the principal can't see the federation they belong to. When the
+ * optional `networks` roster is supplied, this ALSO emits a DIMMED
+ * "federated peer" placeholder node per admitted non-local peer that has NO
+ * present tile already in the graph, wired to the LOCAL stack hub by a DOTTED
+ * federated-absent edge. The present-peer folding (E.3) is untouched — a present
+ * foreign peer keeps rendering as its own stack hub; only truly-absent admitted
+ * peers get a placeholder. When `networks` is omitted (or carries no absent
+ * non-local member), the graph is byte-identical to the pre-D4 shape.
+ *
  * Pure and order-preserving for the agents within a snapshot, so the layout is
  * deterministic for a given snapshot.
  */
 export function buildNetworkGraph(
   agents: readonly AgentPresenceTile[],
+  networks: readonly NetworkMembershipDTO[] = [],
 ): NetworkGraph {
   if (agents.length === 0) {
+    // No present tiles → no LOCAL stack hub to anchor an absent-peer placeholder
+    // to. Render the empty state rather than floating unanchored placeholders.
     return { nodes: [], edges: [] };
   }
 
@@ -381,7 +449,97 @@ export function buildNetworkGraph(
     }
   }
 
+  // MC-D4 — emit a DIMMED placeholder per admitted-but-ABSENT federated peer:
+  // a roster member that is NOT the local principal AND has no present agent tile
+  // already in the graph. Anchored to the LOCAL stack hub by a DOTTED
+  // federated-absent edge, so the principal sees the federation they belong to
+  // even before the peer's stack comes up. No-op when `networks` is empty or every
+  // member is local/present — the graph stays byte-identical to the pre-D4 shape.
+  appendAbsentFederatedPeers(nodes, edges, networks, servingPrincipal);
+
   return { nodes, edges };
+}
+
+/**
+ * MC-D4 — the principal ids that ALREADY have a stack-hub OR agent node in the
+ * graph (present locally or as a present foreign peer). An admitted peer whose
+ * principal is in this set is NOT absent — it's already rendered as its stack —
+ * so no placeholder is emitted for it.
+ */
+function presentPrincipals(nodes: readonly NetworkGraphNode[]): Set<string> {
+  const present = new Set<string>();
+  for (const n of nodes) {
+    if (n.data.kind === "stack-hub") {
+      if (n.data.principal !== null) present.add(n.data.principal);
+    } else if (n.data.kind === "agent") {
+      // A local agent's principal is its origin scope; a foreign agent's is its
+      // origin's principal. `key` is `{principal}/{stack}/{agent_id}` — the first
+      // segment is the principal either way.
+      const principal = n.data.key.split("/")[0];
+      if (principal !== undefined && principal.length > 0) present.add(principal);
+    }
+  }
+  return present;
+}
+
+/**
+ * MC-D4 — mutate `nodes`/`edges` in place, appending one dimmed federated-peer
+ * placeholder node + one dotted anchor edge per admitted-but-absent non-local
+ * peer. The anchor is the LOCAL stack hub ({@link STACK_HUB_NODE_ID}); when the
+ * graph has no local hub (a foreign-only snapshot) there's nothing to anchor to,
+ * so no placeholders are emitted.
+ *
+ * A peer is a candidate when, across all supplied networks, its `principal` is
+ * NOT the serving principal AND NOT already present in the graph AND it has no
+ * `present_stacks` on that network membership row. De-duplicated by principal
+ * (first-seen network wins), and emitted in first-seen order, so the layout stays
+ * deterministic.
+ */
+function appendAbsentFederatedPeers(
+  nodes: NetworkGraphNode[],
+  edges: NetworkGraphEdge[],
+  networks: readonly NetworkMembershipDTO[],
+  servingPrincipal: string | null,
+): void {
+  if (networks.length === 0) return;
+  // The placeholder anchors to the LOCAL hub; without one there's nothing to
+  // connect to (a foreign-only snapshot) — skip rather than float unanchored.
+  const hasLocalHub = nodes.some(
+    (n) => n.data.kind === "stack-hub" && n.id === STACK_HUB_NODE_ID,
+  );
+  if (!hasLocalHub) return;
+
+  const present = presentPrincipals(nodes);
+  const emitted = new Set<string>();
+
+  for (const net of networks) {
+    for (const m of net.members) {
+      if (m.principal === servingPrincipal) continue; // the local principal
+      if (present.has(m.principal)) continue; // already a present stack/agent
+      if (m.present_stacks.length > 0) continue; // has live presence → not absent
+      if (emitted.has(m.principal)) continue; // de-dupe across networks
+      emitted.add(m.principal);
+
+      const id = federatedPeerIdForPrincipal(m.principal);
+      nodes.push({
+        id,
+        type: "federatedPeer",
+        position: { x: 0, y: 0 },
+        data: {
+          kind: "federated-peer",
+          principal: m.principal,
+          verdict: m.verdict,
+          networkId: net.network_id,
+        },
+      });
+      edges.push({
+        id: `fed-absent-${m.principal}`,
+        source: STACK_HUB_NODE_ID,
+        target: id,
+        data: { federatedAbsent: true },
+      });
+    }
+  }
 }
 
 /** #1068 — one legend entry: a stack's hub id, display label, and color. */
@@ -448,6 +606,9 @@ export function applyTransportOverlay(
         data: { ...node.data, transportVerdict: peer.verdict },
       };
     }
+    // MC-D4 — an absent-federated-peer placeholder carries no leaf/stack to
+    // overlay (it's admitted-but-absent, no live transport); return it unchanged.
+    if (node.data.kind === "federated-peer") return node;
     // An agent node's leaf liveness keys on the agent's ORIGIN stack (a foreign
     // peer's leaf lives on ITS stack, exactly like its hub grouping). originScope
     // resolves a foreign origin's {principal,stack}; a local agent's own.

--- a/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
@@ -164,16 +164,19 @@ export function clusterNetworkGraph(graph: NetworkGraph): Cluster[] {
     }
   }
 
-  // Map each agent to its hub via the (hub → agent) edge.
-  const hubOfAgent = new Map<string, string>();
+  // Map each orbiting node to its hub via the (hub → node) edge. This covers both
+  // agent nodes (`hub → agent`) and MC-D4 absent-federated-peer placeholders
+  // (`localHub → federatedPeer`) — both ring around their source hub.
+  const hubOfChild = new Map<string, string>();
   for (const e of graph.edges) {
-    if (agentsByHub.has(e.source)) hubOfAgent.set(e.target, e.source);
+    if (agentsByHub.has(e.source)) hubOfChild.set(e.target, e.source);
   }
 
   const orphanCluster: string[] = [];
   for (const n of graph.nodes) {
-    if (n.type !== "agent") continue;
-    const hub = hubOfAgent.get(n.id);
+    // Both agents and absent-federated-peer placeholders orbit a hub.
+    if (n.type !== "agent" && n.type !== "federatedPeer") continue;
+    const hub = hubOfChild.get(n.id);
     if (hub !== undefined) {
       agentsByHub.get(hub)!.push(n.id);
     } else {


### PR DESCRIPTION
Two Network-graph features (principal direction from live review). Salvaged from an agent that committed D4, then stalled mid-verify on fullscreen.

## MC-D4 — federated peers visible
`buildNetworkGraph` derived hubs from present **agent tiles** only, so an admitted-but-**absent** federated peer (e.g. `jc`, `present_stacks=[]`) drew no node — the principal couldn't see the federation they're in. Now the `networks` roster is threaded into the adapter; each admitted **non-local, absent** member renders as a **dimmed federated-peer node** on a **dotted cross-network edge**. Present foreign peers (E.3) keep folding as full stack hubs. (141-line adapter test.)

## Fullscreen
An expand/fullscreen toggle on the graph canvas — the constellation fills the viewport (dark overlay), Escape/button to exit, React Flow re-fits on toggle.

## Tests
network-graph-adapter + layout + elk-edge + network-nodes suites → green (67 + 32). tsc 0, eslint clean, additive-only, rebased onto main.

Frontend-only — needs `bun run build:dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)