### PR TITLE
feat(mc): MC-D4 vis2 — absent federated peers visible + distinct on the constellation

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
@@ -19,8 +19,13 @@ import {
   HUB_NODE_SIZE,
   AGENT_NODE_SIZE,
 } from "../lib/network-graph-layout";
-import { buildNetworkGraph, STACK_HUB_NODE_ID } from "../lib/network-graph-adapter";
+import {
+  buildNetworkGraph,
+  STACK_HUB_NODE_ID,
+  federatedPeerIdForPrincipal,
+} from "../lib/network-graph-adapter";
 import type { AgentPresenceTile } from "../hooks/use-agents";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
 
 function tile(
   over: Partial<AgentPresenceTile> & { agent_id: string },
@@ -59,6 +64,39 @@ function foreignTile(
     stack,
     origin: { principal, stack },
   });
+}
+
+/**
+ * MC-D4 — a minimal `NetworkMembershipDTO` fixture (only the fields the adapter
+ * reads matter). Mirrors the network-graph-adapter test helper so the layout
+ * test can build a graph that carries an absent-federated-peer node.
+ */
+function membership(
+  over: Partial<NetworkMembershipDTO> & {
+    network_id: string;
+    members: NetworkMembershipDTO["members"];
+  },
+): NetworkMembershipDTO {
+  return {
+    leaf_node: "leaf-1",
+    roster_status: "ok",
+    roster_scope: "complete",
+    confidentiality: { mode: "off", key_present: false, key_id: null },
+    ...over,
+  };
+}
+
+/** One roster member DTO (absent when it has no present stacks). */
+function member(
+  principal: string,
+  present_stacks: string[] = [],
+): NetworkMembershipDTO["members"][number] {
+  return {
+    principal,
+    verdict: present_stacks.length ? "admitted-present" : "admitted-absent",
+    present_stacks,
+    accepts: "accepted-network",
+  };
 }
 
 describe("ringRadiusForCount (MC-D1)", () => {
@@ -125,6 +163,33 @@ describe("clusterNetworkGraph (MC-D1)", () => {
     expect(clusters[1]!.hubId).toBe("__stack__:jc/research");
     expect(clusters[1]!.agentIds).toHaveLength(1);
   });
+
+  it("gives an ABSENT federated-peer node its OWN singleton cluster (not the local hub ring)", () => {
+    // MC-D4 vis2: an admitted-but-absent peer must NOT be bucketed onto the
+    // local hub's agent ring (where it drowns among the local agents). It gets
+    // its own singleton cluster so it lands on a distinct cluster-grid cell.
+    const graph = buildNetworkGraph(
+      [tile({ agent_id: "luna" }), tile({ agent_id: "echo" })],
+      [
+        membership({
+          network_id: "mfnet",
+          members: [member("andreas", ["research"]), member("jc")],
+        }),
+      ],
+    );
+    const peerId = federatedPeerIdForPrincipal("jc");
+    const clusters = clusterNetworkGraph(graph);
+
+    // The local hub keeps ONLY its two local agents — the peer is not in its ring.
+    const localCluster = clusters.find((c) => c.hubId === STACK_HUB_NODE_ID)!;
+    expect(localCluster.agentIds).not.toContain(peerId);
+    expect(localCluster.agentIds).toHaveLength(2);
+
+    // The peer forms its own hub-less singleton cluster (hubId === the peer id).
+    const peerCluster = clusters.find((c) => c.hubId === peerId);
+    expect(peerCluster).toBeDefined();
+    expect(peerCluster!.agentIds).toHaveLength(0);
+  });
 });
 
 describe("layoutNetworkGraph (MC-D1)", () => {
@@ -189,6 +254,72 @@ describe("layoutNetworkGraph (MC-D1)", () => {
     expect(Math.abs(foreignHub.position.x - localHub.position.x)).toBe(
       RADIAL_LAYOUT.clusterStride,
     );
+  });
+
+  it("places an ABSENT federated peer at its OWN cluster cell, NOT on the local hub ring", () => {
+    // MC-D4 vis2: the peer node must land at a distinct position — neither the
+    // local cluster centre nor anywhere on the local hub's agent ring — so it
+    // reads as a separate federated presence, not a faint dot among local agents.
+    const graph = buildNetworkGraph(
+      [tile({ agent_id: "luna" }), tile({ agent_id: "echo" })],
+      [
+        membership({
+          network_id: "mfnet",
+          members: [member("andreas", ["research"]), member("jc")],
+        }),
+      ],
+    );
+    const peerId = federatedPeerIdForPrincipal("jc");
+    const { nodes } = layoutNetworkGraph(graph);
+
+    const localHub = nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    const peer = nodes.find((n) => n.id === peerId)!;
+    expect(peer.type).toBe("federatedPeer");
+
+    // Not co-located with the local hub centre.
+    expect(peer.position).not.toEqual(localHub.position);
+
+    // A distinct cluster (2 clusters: local + peer singleton) → a full stride
+    // away from the local hub, NOT on its (much smaller) agent ring radius.
+    const distFromLocalHub = Math.hypot(
+      peer.position.x - localHub.position.x,
+      peer.position.y - localHub.position.y,
+    );
+    expect(distFromLocalHub).toBe(RADIAL_LAYOUT.clusterStride);
+    // Sanity: a cluster stride is well beyond any local agent ring radius.
+    expect(distFromLocalHub).toBeGreaterThan(ringRadiusForCount(2));
+
+    // No LOCAL agent sits at the peer's position (it's off the local ring).
+    const localAgents = nodes.filter(
+      (n) => n.type === "agent" && n.id.startsWith("andreas/"),
+    );
+    for (const a of localAgents) {
+      expect(a.position).not.toEqual(peer.position);
+    }
+  });
+
+  it("still routes the dotted fed-absent edge local-hub → peer across the clusters", () => {
+    const graph = buildNetworkGraph(
+      [tile({ agent_id: "luna" })],
+      [
+        membership({
+          network_id: "mfnet",
+          members: [member("andreas", ["research"]), member("jc")],
+        }),
+      ],
+    );
+    const peerId = federatedPeerIdForPrincipal("jc");
+    const { nodes, edges } = layoutNetworkGraph(graph);
+    const fedEdge = edges.find((e) => e.target === peerId)!;
+    expect(fedEdge.source).toBe(STACK_HUB_NODE_ID);
+    expect(fedEdge.data?.federatedAbsent).toBe(true);
+    // The route is the long cross-cluster spoke (local hub centre → peer centre).
+    const localHub = nodes.find((n) => n.id === STACK_HUB_NODE_ID)!;
+    const peer = nodes.find((n) => n.id === peerId)!;
+    const pts = fedEdge.layout.elkPoints!;
+    expect(pts).toHaveLength(2);
+    expect(pts[0]).toEqual({ x: localHub.position.x, y: localHub.position.y });
+    expect(pts[1]).toEqual({ x: peer.position.x, y: peer.position.y });
   });
 
   it("preserves node data + type, only replacing position", () => {

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
@@ -499,4 +499,19 @@ describe("FederatedPeerCard (MC-D4 — absent admitted peer)", () => {
     const html = render({ verdict: "admitted-absent" });
     expect(html).toContain('data-fed-peer-verdict="admitted-absent"');
   });
+
+  it("renders a cross-network glyph so it reads as a federated (not local) node", () => {
+    // MC-D4 vis2: the absent peer must look DELIBERATELY different from a local
+    // agent orb — a small cross-network glyph (⇄) marks the federation boundary.
+    const html = render();
+    expect(html).toContain("⇄");
+    // The glyph sits in its own decorative span, aria-hidden (label carries meaning).
+    expect(html).toContain("network-fed-peer-glyph");
+  });
+
+  it("keeps the peer principal as the primary label", () => {
+    const html = render({ principal: "vincent" });
+    expect(html).toContain(">vincent<");
+    expect(html).toContain('data-fed-peer-principal="vincent"');
+  });
 });

--- a/src/surface/mc/dashboard-v2/components/constellation-canvas.css
+++ b/src/surface/mc/dashboard-v2/components/constellation-canvas.css
@@ -264,47 +264,75 @@
   color: color-mix(in oklch, var(--tide) 75%, var(--fg));
 }
 
-/* ── MC-D4 — absent admitted federated peers ─────────────────────────────────
- * An admitted roster member with NO present tile: a DIMMED grey orb (muted ring,
- * NO glow) + a `federated · absent` eyebrow. It marks the federation you belong
- * to even before the peer's stack comes up. Deliberately low-contrast so it never
- * reads as a live node; a dotted anchor edge ties it to the local hub. */
+/* ── MC-D4 vis2 — absent admitted federated peers (VISIBLE + distinct) ────────
+ * An admitted roster member with NO present tile. The first cut rendered this as
+ * a ~0.6-opacity grey dot with no glow, which VANISHED on the near-black canvas.
+ * vis2 makes it clearly visible AND deliberately unlike a local agent orb: a
+ * DASHED ring in the desaturated federation accent (--fed, violet/indigo — apart
+ * from the bright-cyan local --mer and the vivid present-foreign --tide), a
+ * SUBTLE glow (present but quieter than a live orb's), a cross-network ⇄ glyph,
+ * and a `federated · absent` eyebrow above the peer principal. It reads as a real
+ * federation node that just isn't live — never a faint speck. */
 .mc-skin .network-node-orb-fed-peer {
-  width: 22px;
-  height: 22px;
-  border: 1.5px dotted color-mix(in oklch, var(--faint) 70%, var(--fg));
-  background: color-mix(in oklch, var(--panel) 70%, transparent);
-  /* No box-shadow: absent peers do not glow. */
-  box-shadow: none;
-  opacity: 0.6;
+  width: 30px;
+  height: 30px;
+  /* Dashed federation-accent ring — the "federated link" signature. */
+  border: 1.75px dashed color-mix(in oklch, var(--fed) 82%, var(--fg));
+  background:
+    radial-gradient(
+      circle at 50% 40%,
+      color-mix(in oklch, var(--fed) 30%, transparent) 0%,
+      color-mix(in oklch, var(--fed) 10%, transparent) 60%,
+      transparent 74%
+    ),
+    color-mix(in oklch, var(--fed) 10%, var(--bg));
+  /* Subtle glow — present so it's legible, quieter than a live orb's bloom. */
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--fed) 35%, transparent),
+    0 0 16px -3px color-mix(in oklch, var(--fed) 50%, transparent);
+  opacity: 1;
 }
+/* The cross-network glyph centred in the orb, in the federation accent. */
+.mc-skin .network-fed-peer-glyph {
+  font-size: 15px;
+  line-height: 1;
+  color: color-mix(in oklch, var(--fg) 80%, var(--fed));
+  text-shadow: 0 0 7px color-mix(in oklch, var(--fed) 65%, transparent);
+}
+/* Card-level opacity is now near-full — the node is meant to be seen. */
 .mc-skin .network-node-fed-peer-absent {
-  opacity: 0.72;
+  opacity: 0.9;
 }
 .mc-skin .network-fed-peer-eyebrow {
   font-size: 9px;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: color-mix(in oklch, var(--faint) 60%, var(--fg));
+  color: color-mix(in oklch, var(--fed) 55%, var(--fg));
 }
 .mc-skin .network-fed-peer-label {
   font-family: var(--mono);
   font-size: 11px;
-  color: color-mix(in oklch, var(--fg) 60%, var(--faint));
+  font-weight: 600;
+  color: color-mix(in oklch, var(--fg) 82%, var(--fed));
+  text-shadow: 0 0 8px color-mix(in oklch, var(--fed) 45%, transparent);
 }
 
-/* The dotted anchor edge (local hub → absent peer) + its label. */
+/* The dotted anchor edge (local hub → absent peer) + its label. Raised opacity
+ * (was 0.5 → invisible) and coloured in the federation accent so the long
+ * cross-cluster spoke reads as the "federated link". Kept dotted + static (an
+ * absent peer carries no flow). */
 .mc-skin .edge-fed-absent {
+  stroke: var(--fed);
   stroke-dasharray: 2 5;
-  opacity: 0.5;
+  opacity: 0.75;
   /* Static — an absent peer carries no flow. */
 }
 .mc-skin .mc-edge-fed-absent-label {
-  color: color-mix(in oklch, var(--faint) 70%, var(--fg));
-  border-color: color-mix(in oklch, var(--faint) 45%, var(--line));
+  color: color-mix(in oklch, var(--fed) 70%, var(--fg));
+  border-color: color-mix(in oklch, var(--fed) 45%, var(--line));
 }
 .mc-skin .mc-edge-fed-absent-label span[aria-hidden="true"] {
-  color: var(--faint);
+  color: var(--fed);
 }
 
 /* ── Capability + state chips ───────────────────────────────────────────────*/

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -482,10 +482,13 @@ export interface FederatedPeerCardProps {
  * MC-D4 — pure presentational card for an ABSENT admitted federated peer.
  *
  * The peer principal is on the network roster (admitted) but has NO present agent
- * tile, so it draws as a DIMMED orb — a muted grey ring, NO glow — labelled with
- * the peer principal and a `federated · absent` sublabel. It marks "you are
- * federated with this principal; their stack just isn't live right now", so the
- * principal can see the whole federation, not only the parts currently online.
+ * tile. MC-D4 vis2 makes it clearly VISIBLE + DISTINCT (its first cut was a faint
+ * ~0.6-opacity grey dot that vanished on the near-black canvas): the orb now
+ * carries a DASHED ring in a desaturated federation-accent (violet/indigo —
+ * distinct from the bright-cyan local hub and every per-stack color), a subtle
+ * glow, a cross-network glyph (`⇄`), and a `federated · absent` sublabel above the
+ * peer principal. It reads as "you are federated with this principal; their stack
+ * just isn't live right now" — deliberately NOT a local agent circle.
  *
  * Presence-level only (ADR-0007): identity + membership verdict, never a session
  * interior. Not interactive — an absent peer has nothing local to open. Split
@@ -501,11 +504,16 @@ export function FederatedPeerCard({ data }: FederatedPeerCardProps) {
       data-fed-peer-absent="true"
       aria-label={`${data.principal} — federated peer (admitted, absent)`}
     >
-      {/* A muted grey ring — deliberately NO glow, distinct from the live orbs. */}
+      {/* A dashed federation-accent ring with a cross-network glyph — visible and
+          deliberately distinct from a local agent orb (which is a solid cyan
+          circle). The subtle glow + dashed treatment live in
+          constellation-canvas.css. */}
       <span
         className="network-node-orb network-node-orb-fed-peer"
         aria-hidden="true"
-      />
+      >
+        <span className="network-fed-peer-glyph">⇄</span>
+      </span>
       <span className="network-node-below">
         <span className="network-fed-peer-eyebrow dim">federated · absent</span>
         <span className="network-fed-peer-label">{data.principal}</span>

--- a/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-graph-layout.ts
@@ -152,6 +152,17 @@ interface Cluster {
  * incoming hub edge (defensive — shouldn't happen) becomes its own singleton
  * cluster so it's never dropped.
  *
+ * ## MC-D4 vis2 — absent federated peers cluster on their OWN cell
+ *
+ * An absent-federated-peer placeholder (`federatedPeer`) is anchored to the LOCAL
+ * hub only for its DOTTED cross-cluster edge (`localHub → federatedPeer`). It must
+ * NOT ring around the local hub — bucketed there it becomes a faint dot lost among
+ * the local agents. So a `federatedPeer` node is deliberately EXCLUDED from its
+ * source hub's ring and instead forms its OWN hub-less singleton cluster (exactly
+ * like a defensive orphan agent), earning a distinct `clusterCentre` grid cell
+ * apart from every local stack. The dotted `fed-absent-*` edge still routes
+ * local-hub → peer, so it draws as a long cross-cluster "federated link".
+ *
  * Pure + exported for unit testing.
  */
 export function clusterNetworkGraph(graph: NetworkGraph): Cluster[] {
@@ -164,18 +175,24 @@ export function clusterNetworkGraph(graph: NetworkGraph): Cluster[] {
     }
   }
 
-  // Map each orbiting node to its hub via the (hub → node) edge. This covers both
-  // agent nodes (`hub → agent`) and MC-D4 absent-federated-peer placeholders
-  // (`localHub → federatedPeer`) — both ring around their source hub.
+  // Map each ORBITING AGENT to its hub via the (hub → agent) edge. Absent-
+  // federated-peer placeholders are intentionally NOT ringed around their source
+  // hub (see doc-comment) — they cluster standalone below.
   const hubOfChild = new Map<string, string>();
   for (const e of graph.edges) {
     if (agentsByHub.has(e.source)) hubOfChild.set(e.target, e.source);
   }
 
   const orphanCluster: string[] = [];
+  // Absent-federated-peer placeholders, in graph order — each its OWN singleton
+  // cluster so it lands on a distinct grid cell, not the local hub ring.
+  const federatedPeerClusters: string[] = [];
   for (const n of graph.nodes) {
-    // Both agents and absent-federated-peer placeholders orbit a hub.
-    if (n.type !== "agent" && n.type !== "federatedPeer") continue;
+    if (n.type === "federatedPeer") {
+      federatedPeerClusters.push(n.id);
+      continue;
+    }
+    if (n.type !== "agent") continue;
     const hub = hubOfChild.get(n.id);
     if (hub !== undefined) {
       agentsByHub.get(hub)!.push(n.id);
@@ -191,6 +208,11 @@ export function clusterNetworkGraph(graph: NetworkGraph): Cluster[] {
   // Each orphan agent forms its own hub-less singleton cluster (defensive).
   for (const agentId of orphanCluster) {
     clusters.push({ hubId: agentId, agentIds: [] });
+  }
+  // Each absent federated peer forms its own hub-less singleton cluster, so it
+  // gets a distinct cluster-grid cell away from the local stacks (MC-D4 vis2).
+  for (const peerId of federatedPeerClusters) {
+    clusters.push({ hubId: peerId, agentIds: [] });
   }
   return clusters;
 }

--- a/src/surface/mc/dashboard-v2/styles/constellation.css
+++ b/src/surface/mc/dashboard-v2/styles/constellation.css
@@ -62,6 +62,12 @@
   /* network accents — meridian / tide */
   --mer: oklch(0.76 0.13 224);
   --tide: oklch(0.72 0.13 288);
+  /* federation accent — desaturated violet/indigo for ABSENT admitted peers.
+     Distinct from the bright-cyan local hub (--mer) AND from the vivid present-
+     foreign tide (--tide, hue 288): pushed toward indigo (hue 300) and pulled
+     DOWN in chroma so an absent peer reads as a quiet-but-visible federation
+     marker, not a live orb. */
+  --fed: oklch(0.66 0.085 300);
 
   /* status */
   --ok: oklch(0.80 0.13 162);


### PR DESCRIPTION
Fixes the "can't see jc / the federated network" issue from live review. The federated-peer node was emitting correctly but (1) placed on the local hub's ring (lost among local agents) and (2) styled as a faint 0.6-opacity grey dot. Both fixed.

## What
- **`lib/network-graph-layout.ts`** — `federatedPeer` nodes now form their OWN singleton cluster (own `clusterCentre` cell, ~900px from local stacks) instead of bucketing onto the local hub's agent ring. The dotted `fed-absent-*` edge still routes localHub→peer, so it draws as a long cross-cluster "federated link". Layout stays pure (test asserts the peer lands `clusterStride` away, off the local ring).
- **`components/network-nodes.tsx` + css** — the orb is now a **violet/indigo dashed ring** (`--fed` token, distinct from cyan local + present-foreign) at full opacity, with a subtle glow, a `⇄` glyph, and legible `federated · absent` + principal labels.
- Dotted federated edge opacity 0.5→0.75, `--fed`-colored.

## Tests
layout 19/19, nodes 34/34, adapter 41/41, edge — green. tsc 0, eslint clean, additive-only, 0 behind main.

Frontend-only — needs `bun run build:dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)