### PR TITLE
feat(cortex): AgentStateDevSessionStore — retire the file bridge (#1720 S4b)

### DIFF
--- a/src/common/agents/agent-state-spawn.ts
+++ b/src/common/agents/agent-state-spawn.ts
@@ -1,0 +1,74 @@
+/**
+ * cortex#1720 — shared, live-daemon-hardened spawn for AgentState bundle
+ * subprocesses.
+ *
+ * S1 (scaffold), S2 (replay), S3/S4a (dispatch recorder) each grew a private
+ * `spawnSync` wrapper with the SAME hardening. S4b retires the file-backed
+ * `dev-session-store` onto the bundle's KV surface (`errands.ts get/annotate`),
+ * which needs the identical wrapper again. Rather than a fourth copy, the
+ * hardening lives here ONCE and the recorder + the new session store import it.
+ *
+ * The contract every AgentState subprocess must hold on the LIVE daemon:
+ *   - **stdin IGNORED** (`stdio: ["ignore", "pipe", "pipe"]`) — a bundle that
+ *     blocks on stdin can never hang the hot path.
+ *   - **30s wall-clock `timeout`** — a wedged child is SIGTERM'd and surfaces as
+ *     `r.error` (ETIMEDOUT), which the caller treats as a failed invocation.
+ *   - **16MB `maxBuffer`** — explicit cap so a verbose bundle never trips Bun's
+ *     1MB default (spurious ENOBUFS → `r.error`).
+ *
+ * NON-THROWING by construction: `spawnSync` reports failures via `r.error` /
+ * `r.status`, not exceptions, so callers wrap in a single try/catch (belt) and
+ * branch on the returned fields (braces) to log one line + soft-skip.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/** Wall-clock ceiling for a bundle subprocess on the live daemon. */
+export const AGENT_STATE_SPAWN_TIMEOUT_MS = 30_000;
+
+/**
+ * stdout ceiling for a bundle subprocess read. The JSON dumps these CLIs print
+ * (`{ inserted, row }`, a `list` page, a `get` row) are tiny; the explicit 16MB
+ * cap is cheap insurance against a wedged/verbose bundle overflowing Bun's 1MB
+ * default (ENOBUFS).
+ */
+export const AGENT_STATE_SPAWN_MAX_BUFFER = 16 * 1024 * 1024;
+
+/** Result shape of the injectable AgentState spawn seam (captures stdout). */
+export interface AgentStateSpawnResult {
+  status: number | null;
+  error?: Error;
+  /** Captured stdout — a JSON row / page a caller may parse. */
+  stdout?: Buffer | string;
+  stderr?: Buffer | string;
+}
+
+/**
+ * The injectable spawn seam. Production wires {@link defaultAgentStateSpawn};
+ * tests inject a recording fake so no real `bun` runs and no `~/.config` is
+ * touched.
+ */
+export type AgentStateSpawn = (
+  cmd: string,
+  args: string[],
+  opts: { env?: NodeJS.ProcessEnv },
+) => AgentStateSpawnResult;
+
+/**
+ * The production spawn: `spawnSync` with the live-daemon hardening above. A
+ * timeout / ENOBUFS both surface via `r.error` so the caller's error branch
+ * logs one line and never throws.
+ */
+export function defaultAgentStateSpawn(
+  cmd: string,
+  args: string[],
+  opts: { env?: NodeJS.ProcessEnv },
+): AgentStateSpawnResult {
+  const r = spawnSync(cmd, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: opts.env,
+    timeout: AGENT_STATE_SPAWN_TIMEOUT_MS,
+    maxBuffer: AGENT_STATE_SPAWN_MAX_BUFFER,
+  });
+  return { status: r.status, error: r.error, stdout: r.stdout, stderr: r.stderr };
+}

--- a/src/common/agents/dispatch-state-recorder.ts
+++ b/src/common/agents/dispatch-state-recorder.ts
@@ -50,9 +50,12 @@
  */
 
 import { existsSync } from "node:fs";
-import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { resolveInstanceDir } from "./agent-state-scaffold";
+import {
+  defaultAgentStateSpawn,
+  type AgentStateSpawnResult,
+} from "./agent-state-spawn";
 
 /** Default host label baked into cortex work_item env. */
 const DEFAULT_HOST = "cortex";
@@ -74,31 +77,17 @@ function defaultErrandsScript(): string {
   );
 }
 
-/**
- * Wall-clock ceiling for a bundle subprocess on the LIVE daemon. A hanging
- * `errands.ts` must never freeze the dispatch path; on timeout spawnSync
- * SIGTERMs the child and returns an error the caller logs + soft-skips.
- */
-const RECORDER_SPAWN_TIMEOUT_MS = 30_000;
-
-/**
- * stdout ceiling for the enqueue output read. The `{ inserted, row }` dump is
- * tiny, but an explicit 16MB cap (matching the S2 replay lib) is cheap insurance
- * against a wedged/verbose bundle overflowing Bun's 1MB default (ENOBUFS).
- */
-const RECORDER_MAX_BUFFER = 16 * 1024 * 1024;
-
 /** Terminal outcome an accepted dispatch resolves to. */
 export type DispatchResolveStatus = "done" | "failed";
 
-/** Result shape of the injectable spawn seam (captures stdout for the id). */
-export interface RecorderSpawnResult {
-  status: number | null;
-  error?: Error;
-  /** Captured stdout — the `enqueue` JSON row (for the work_item id). */
-  stdout?: Buffer | string;
-  stderr?: Buffer | string;
-}
+/**
+ * Result shape of the injectable spawn seam (captures stdout for the id). Now an
+ * alias of the shared {@link AgentStateSpawnResult} (cortex#1720 S4b extracted
+ * the hardened spawn into `agent-state-spawn.ts` so the S3/S4a recorder and the
+ * S4b session store share ONE wrapper). Re-exported here so existing importers
+ * (and the S3 tests) keep the `RecorderSpawnResult` name.
+ */
+export type RecorderSpawnResult = AgentStateSpawnResult;
 
 export type RecorderSpawn = (
   cmd: string,
@@ -208,7 +197,7 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
       opts.dashboardScript ??
       process.env.MF_AGENT_STATE_DASHBOARD_SCRIPT ??
       join(dirname(this.errandsScript), "dashboard.ts");
-    this.spawn = opts.spawn ?? defaultRecorderSpawn;
+    this.spawn = opts.spawn ?? defaultAgentStateSpawn;
     this.log = opts.log ?? ((line) => process.stderr.write(line));
   }
 
@@ -305,7 +294,7 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
         env: this.stdEnv(),
       });
     } catch (err) {
-      // A THROWING spawn (belt-and-braces — defaultRecorderSpawn returns an
+      // A THROWING spawn (belt-and-braces — defaultAgentStateSpawn returns an
       // error field rather than throwing, but a test seam might throw).
       this.log(
         `cortex: agent-state — dispatch "${args[0]}" FAILED for "${this.agent.id}" ` +
@@ -406,24 +395,4 @@ export class SubprocessDispatchStateRecorder implements DispatchStateRecorder {
       return null;
     }
   }
-}
-
-function defaultRecorderSpawn(
-  cmd: string,
-  args: string[],
-  opts: { env?: NodeJS.ProcessEnv },
-): RecorderSpawnResult {
-  // Live-daemon hardening (mirrors S2's replay spawn): stdin IGNORED so a
-  // bundle that blocks on stdin can't hang the dispatch path, a wall-clock
-  // `timeout` caps a wedged child (SIGTERM → error → run() logs + soft-skips),
-  // and an explicit 16MB `maxBuffer` avoids a spurious ENOBUFS on a verbose
-  // bundle. A timeout / ENOBUFS both surface via `r.error` → the caller's
-  // non-zero/error branch logs one line and never throws.
-  const r = spawnSync(cmd, args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: opts.env,
-    timeout: RECORDER_SPAWN_TIMEOUT_MS,
-    maxBuffer: RECORDER_MAX_BUFFER,
-  });
-  return { status: r.status, error: r.error, stdout: r.stdout, stderr: r.stderr };
 }

--- a/src/runner/__tests__/agent-state-dev-session-store.test.ts
+++ b/src/runner/__tests__/agent-state-dev-session-store.test.ts
@@ -1,0 +1,321 @@
+/**
+ * cortex#1720 S4b — unit tests for the AgentState-backed warm-session store.
+ *
+ * `AgentStateDevSessionStore` retires the file-backed `dev-session-store`
+ * bridge onto agent-state's KV surface (`errands.ts list`/`enqueue`/`annotate`)
+ * WITHOUT changing the `DevSessionStore` seam the dev-consumer depends on.
+ *
+ * The invariants under test (all seam-driven — no real `bun`, no `~/.config`):
+ *   - rehydrate-on-start: ONE `list`-style pass at construction fills the
+ *     in-memory map from work_items whose notes carry a `session_id`;
+ *   - hot read never spawns: `get(chainId)` is a pure `Map.get` — zero spawns
+ *     after construction;
+ *   - write off-path: `set()` updates the map synchronously (a following `get`
+ *     sees it before any subprocess), then fire-and-forget `enqueue`(idempotent)
+ *     + `annotate --notes-json {"session_id":…}` targeting the chainId row;
+ *   - failure non-fatal: a spawn error / non-zero exit / throw on the write path
+ *     logs one line and never rejects; the map still holds the value;
+ *   - bundle-missing fallback lives in the factory (`createDevSessionStore`):
+ *     a stateful agent with an absent bundle script → FileDevSessionStore, one
+ *     log line; a stateless agent → FileDevSessionStore with no bundle probe.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  AgentStateDevSessionStore,
+  createDevSessionStore,
+  DEV_SESSION_WORK_ITEM_KIND,
+} from "../agent-state-dev-session-store";
+import { FileDevSessionStore } from "../dev-session-store";
+import type { AgentStateSpawn, AgentStateSpawnResult } from "../../common/agents/agent-state-spawn";
+
+const AGENT = { id: "coder", state: { blueprint: "dev", version: "1" } };
+
+let root: string;
+let errandsScript: string;
+let instanceDir: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cortex-devsession-"));
+  errandsScript = join(root, "errands.ts");
+  instanceDir = join(root, "agents", "coder");
+  writeFileSync(errandsScript, "// stub errands.ts\n");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+interface SpawnCall {
+  cmd: string;
+  args: string[];
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * A recording spawn that returns a scripted result per subcommand. `args` is
+ * `[errandsScript, subcommand, ...]`, so we route on `args[1]`.
+ */
+function recordingSpawn(results: Record<string, AgentStateSpawnResult>): {
+  spawn: AgentStateSpawn;
+  calls: SpawnCall[];
+} {
+  const calls: SpawnCall[] = [];
+  const spawn: AgentStateSpawn = (cmd, args, opts) => {
+    calls.push({ cmd, args, env: opts.env });
+    const sub = args[1] ?? "";
+    return results[sub] ?? { status: 0, stdout: "" };
+  };
+  return { spawn, calls };
+}
+
+/** One `list` row (a work_item as `errands.ts list` prints it, JSON-per-line). */
+function listRow(id: string, notes: Record<string, unknown> | null): string {
+  return JSON.stringify({
+    id,
+    kind: DEV_SESSION_WORK_ITEM_KIND,
+    payload: "{}",
+    status: "pending",
+    owner_agent: "coder",
+    notes: notes === null ? null : JSON.stringify(notes),
+  });
+}
+
+/** The `{ inserted, row }` an `enqueue` prints; the `row` from `annotate`. */
+function enqueueStdout(id: string): string {
+  return JSON.stringify({ inserted: true, row: { id, kind: DEV_SESSION_WORK_ITEM_KIND } });
+}
+
+/** Drain the fire-and-forget write microtask so assertions see the spawn. */
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("AgentStateDevSessionStore — rehydrate on start", () => {
+  test("ONE list pass fills the map from work_items whose notes carry session_id", async () => {
+    const { spawn, calls } = recordingSpawn({
+      list: {
+        status: 0,
+        stdout:
+          listRow("chain-a", { session_id: "ccs-a" }) +
+          "\n" +
+          listRow("chain-b", { session_id: "ccs-b" }) +
+          "\n" +
+          // a row with no session_id must NOT land in the map
+          listRow("chain-c", { note: "unrelated" }) +
+          "\n",
+      },
+    });
+    const store = new AgentStateDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+
+    // Exactly one subprocess (the rehydrate `list`), and it is a `list`.
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.args[1]).toBe("list");
+    // Scoped to the dev-session kind + standard env.
+    expect(calls[0]?.args).toContain("--kind");
+    expect(calls[0]?.args).toContain(DEV_SESSION_WORK_ITEM_KIND);
+    expect(calls[0]?.env?.MF_AGENT_NAME).toBe("coder");
+    expect(calls[0]?.env?.MF_INSTANCE_DIR).toBe(instanceDir);
+
+    expect(await store.get("chain-a")).toBe("ccs-a");
+    expect(await store.get("chain-b")).toBe("ccs-b");
+    expect(await store.get("chain-c")).toBeUndefined();
+  });
+
+  test("a rehydrate list failure is non-fatal — an empty (cold) map, one log line", async () => {
+    const logs: string[] = [];
+    const { spawn } = recordingSpawn({ list: { status: 1, stderr: "boom" } });
+    const store = new AgentStateDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: (l) => logs.push(l),
+    });
+    expect(await store.get("chain-a")).toBeUndefined();
+    expect(logs.length).toBe(1);
+    expect(logs[0]).toContain("rehydrate");
+  });
+});
+
+describe("AgentStateDevSessionStore — hot read never spawns", () => {
+  test("get() after construction issues ZERO subprocesses", async () => {
+    const { spawn, calls } = recordingSpawn({
+      list: { status: 0, stdout: listRow("chain-a", { session_id: "ccs-a" }) + "\n" },
+    });
+    const store = new AgentStateDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+    const spawnsAfterCtor = calls.length; // the single rehydrate list
+
+    await store.get("chain-a");
+    await store.get("missing");
+    await store.get("chain-a");
+
+    // Not one extra spawn for any read.
+    expect(calls.length).toBe(spawnsAfterCtor);
+  });
+});
+
+describe("AgentStateDevSessionStore — set() writes off-path", () => {
+  test("map updates synchronously; enqueue+annotate fire AFTER, targeting the chainId row", async () => {
+    const { spawn, calls } = recordingSpawn({
+      list: { status: 0, stdout: "" },
+      enqueue: { status: 0, stdout: enqueueStdout("chain-x") },
+      annotate: { status: 0, stdout: "" },
+    });
+    const store = new AgentStateDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+    const beforeSet = calls.length;
+
+    await store.set("chain-x", "ccs-x");
+
+    // The awaited `set` resolves with the value already in the map: a following
+    // get sees it WITHOUT waiting on any subprocess (the write is off-path).
+    expect(await store.get("chain-x")).toBe("ccs-x");
+
+    await flush();
+
+    const writeCalls = calls.slice(beforeSet).map((c) => c.args[1]);
+    expect(writeCalls).toEqual(["enqueue", "annotate"]);
+
+    const annotate = calls.find((c) => c.args[1] === "annotate");
+    // annotate --id chain-x --notes-json {"session_id":"ccs-x"}
+    expect(annotate?.args).toContain("--id");
+    expect(annotate?.args).toContain("chain-x");
+    const notesIdx = annotate?.args.indexOf("--notes-json") ?? -1;
+    expect(notesIdx).toBeGreaterThanOrEqual(0);
+    const notes = JSON.parse(annotate?.args[notesIdx + 1] ?? "{}") as { session_id?: string };
+    expect(notes.session_id).toBe("ccs-x");
+
+    // enqueue is host-namespaced to the dev-session kind, keyed by the chainId.
+    const enqueue = calls.find((c) => c.args[1] === "enqueue");
+    expect(enqueue?.args).toContain(DEV_SESSION_WORK_ITEM_KIND);
+    expect(enqueue?.args).toContain("chain-x");
+  });
+
+  test("set() on a chain already in the map SKIPS enqueue and only annotates", async () => {
+    const { spawn, calls } = recordingSpawn({
+      list: { status: 0, stdout: listRow("chain-known", { session_id: "old" }) + "\n" },
+      annotate: { status: 0, stdout: "" },
+    });
+    const store = new AgentStateDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+    });
+    const beforeSet = calls.length;
+
+    await store.set("chain-known", "new");
+    await flush();
+
+    // Row already exists (seen at rehydrate) → no re-enqueue, just annotate.
+    const writeCalls = calls.slice(beforeSet).map((c) => c.args[1]);
+    expect(writeCalls).toEqual(["annotate"]);
+    expect(await store.get("chain-known")).toBe("new");
+  });
+
+  test("a write-path spawn failure is non-fatal: set() resolves, map holds, one log line", async () => {
+    const logs: string[] = [];
+    const { spawn } = recordingSpawn({
+      list: { status: 0, stdout: "" },
+      enqueue: { status: 1, stderr: "enqueue exploded" },
+    });
+    const store = new AgentStateDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: (l) => logs.push(l),
+    });
+
+    // Must NOT reject even though the write path errors.
+    await store.set("chain-fail", "ccs-fail");
+    await flush();
+
+    expect(await store.get("chain-fail")).toBe("ccs-fail");
+    expect(logs.length).toBeGreaterThanOrEqual(1);
+    expect(logs.join("")).toContain("chain-fail");
+  });
+
+  test("a THROWING spawn on the write path never propagates", async () => {
+    const logs: string[] = [];
+    const throwingSpawn: AgentStateSpawn = (_cmd, args) => {
+      if (args[1] === "list") return { status: 0, stdout: "" };
+      throw new Error("spawn threw");
+    };
+    const store = new AgentStateDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn: throwingSpawn,
+      log: (l) => logs.push(l),
+    });
+    await store.set("chain-t", "ccs-t");
+    await flush();
+    expect(await store.get("chain-t")).toBe("ccs-t");
+    expect(logs.join("")).toContain("chain-t");
+  });
+});
+
+describe("createDevSessionStore — per-agent selection + fallback", () => {
+  test("stateful agent + present bundle → AgentStateDevSessionStore", () => {
+    const { spawn } = recordingSpawn({ list: { status: 0, stdout: "" } });
+    const store = createDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript,
+      spawn,
+      log: () => {},
+      fileStorePath: join(root, "warm.json"),
+    });
+    expect(store).toBeInstanceOf(AgentStateDevSessionStore);
+  });
+
+  test("stateless agent → FileDevSessionStore, NO bundle probe, no spawn", () => {
+    const { spawn, calls } = recordingSpawn({ list: { status: 0, stdout: "" } });
+    const store = createDevSessionStore(
+      { id: "plain" },
+      {
+        instanceDir,
+        errandsScript,
+        spawn,
+        log: () => {},
+        fileStorePath: join(root, "warm.json"),
+      },
+    );
+    expect(store).toBeInstanceOf(FileDevSessionStore);
+    // Stateless takes zero new code paths — the bundle is never invoked.
+    expect(calls.length).toBe(0);
+  });
+
+  test("stateful agent + absent bundle script → FileDevSessionStore fallback, one log line", () => {
+    const logs: string[] = [];
+    const { spawn, calls } = recordingSpawn({ list: { status: 0, stdout: "" } });
+    const store = createDevSessionStore(AGENT, {
+      instanceDir,
+      errandsScript: join(root, "does-not-exist.ts"),
+      spawn,
+      log: (l) => logs.push(l),
+      fileStorePath: join(root, "warm.json"),
+    });
+    expect(store).toBeInstanceOf(FileDevSessionStore);
+    // No rehydrate spawn (we fell back before constructing the AgentState store).
+    expect(calls.length).toBe(0);
+    expect(logs.length).toBe(1);
+    expect(logs[0]).toContain("fallback");
+  });
+});

--- a/src/runner/agent-state-dev-session-store.ts
+++ b/src/runner/agent-state-dev-session-store.ts
@@ -1,0 +1,383 @@
+/**
+ * cortex#1720 S4b — AgentState-backed warm-session store for the `dev.implement`
+ * consumer. Retires the file-backed bridge (`FileDevSessionStore`) onto
+ * agent-state's KV surface (agent-state v0.3.0 / PR #13: `errands.ts get`,
+ * `annotate`) WITHOUT touching the `DevSessionStore` seam the dev-consumer
+ * depends on — callers are byte-identical.
+ *
+ * ## What this maps, and why it owns its own work_items
+ *
+ * The seam maps `correlationChainId → ccSessionId` (a chain spans the implement
+ * dispatch AND its fix cycles — the SAME chain id, per `devCorrelationChainId`).
+ * The dispatch-state recorder (S3) keys work_items by the PER-DISPATCH
+ * `envelope.id`, and — crucially — the `dev.implement` path runs through
+ * `DevConsumer`, which does NOT flow through the BrainConsumer, so NO recorder
+ * work_item exists for a dev dispatch to hang the session id off of. Threading
+ * the recorder's private per-dispatch map into a different consumer would also
+ * conflate two concerns the S4b assessment deliberately kept apart: "the durable
+ * dispatch queue" vs "session continuity per chain."
+ *
+ * So this store owns a SEPARATE, host-namespaced slice of `work_items`: kind
+ * `dev-session`, one row per chain, keyed by the chainId as the work_item id.
+ * That id is stable across the whole chain (the chain's FIRST dispatch and every
+ * fix cycle carry it), which is exactly constraint (4)'s "annotate the work item
+ * for the chain's first dispatch" — resolved without any recorder change.
+ *
+ * ## Latency contract (the load-bearing rule — AnnotateWorkItem.md / GetWorkItem.md)
+ *
+ *   - **Hot read stays in-process.** `get(chainId)` is a pure `Map.get` — it
+ *     NEVER spawns. The warm-resume read is correctness-affecting (a missed read
+ *     means a wrong/cold resume), so it must not depend on a subprocess.
+ *   - **Rehydrate ONCE at construction.** A single `errands.ts list` pass reads
+ *     the `dev-session` rows and parses each row's `notes.session_id` into the
+ *     map — NOT a `get` per read.
+ *   - **Writes go off-path.** `set()` updates the map SYNCHRONOUSLY (so the very
+ *     next `get` sees it), then fire-and-forgets `enqueue` (idempotent — the
+ *     bundle no-ops on an existing id) + `annotate --notes-json {"session_id":…}`.
+ *     A spawn error / non-zero exit / throw logs ONE line and never rejects.
+ *
+ * ## Field ownership (the annotate contract)
+ *
+ * `annotate` is metadata-only: it merges host-namespaced keys into `notes` and
+ * NEVER touches `status`/`kind`/`payload`/`owner_agent`, and the bundle emits
+ * `work_item_annotated` itself (this host never appends events). The row is
+ * created once by `enqueue` (empty payload — the session interior lives in the
+ * substrate, not here) and thereafter only annotated.
+ */
+
+import { existsSync } from "node:fs";
+import { resolveInstanceDir } from "../common/agents/agent-state-scaffold";
+import {
+  defaultAgentStateSpawn,
+  type AgentStateSpawn,
+} from "../common/agents/agent-state-spawn";
+import { FileDevSessionStore, type DevSessionStore } from "./dev-session-store";
+
+/** Host label baked into the bundle env (matches the S1–S4a recorder). */
+const DEFAULT_HOST = "cortex";
+
+/**
+ * The `work_items.kind` this store owns. Host-namespaced (§ the `kind` column is
+ * agent-defined) so the session-continuity KV never collides with the dispatch
+ * recorder's per-dispatch rows. The `notes.session_id` key is likewise host-owned.
+ */
+export const DEV_SESSION_WORK_ITEM_KIND = "dev-session";
+
+/** The host-namespaced notes key carrying the CC session id. */
+const SESSION_ID_NOTE_KEY = "session_id";
+
+/**
+ * Canonical AgentState `errands.ts` path (shared shape with the S3 recorder).
+ * `MF_AGENT_STATE_ERRANDS_SCRIPT` overrides; resolved lazily so a late env
+ * override is honoured.
+ */
+function defaultErrandsScript(): string {
+  return (
+    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
+    `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`
+  );
+}
+
+/** Minimal shape this store needs off an agent — id, plus the opt-in `state`. */
+export interface DevSessionStoreAgent {
+  id: string;
+  /** Present ⇒ stateful (AgentState-backed); absent ⇒ stateless (file store). */
+  state?: { blueprint: string; version: string };
+}
+
+export interface AgentStateDevSessionStoreOptions {
+  /** Override the resolved instance dir (test seam). Default: ~/.config/cortex/agents/<id>. */
+  instanceDir?: string;
+  /** Override the host label baked into the env (test seam). Default: "cortex". */
+  host?: string;
+  /** Override path to the bundle's errands.ts (test seam / non-standard install). */
+  errandsScript?: string;
+  /** Override the spawn used to invoke the bundle (test seam). */
+  spawn?: AgentStateSpawn;
+  /** Override the logger (test seam). Default: stderr. */
+  log?: (line: string) => void;
+}
+
+/**
+ * AgentState-backed `DevSessionStore`. Durable across restarts (the §3.6b
+ * requirement the file store also met), but now the durable backing is the
+ * bundle's `work_items` rather than a JSON file. The hot read is a process-local
+ * map, rehydrated once on construction — the file store's read cost profile,
+ * with agent-state as the source of truth.
+ */
+export class AgentStateDevSessionStore implements DevSessionStore {
+  private readonly agentId: string;
+  private readonly host: string;
+  private readonly instanceDir: string;
+  private readonly errandsScript: string;
+  private readonly spawn: AgentStateSpawn;
+  private readonly log: (line: string) => void;
+
+  /**
+   * chainId → ccSessionId. THE hot-read source. Rehydrated once at construction
+   * from the bundle's `dev-session` rows; updated synchronously on every `set`.
+   */
+  private readonly map = new Map<string, string>();
+
+  /**
+   * chainIds we have already `enqueue`d a row for (seen at rehydrate or created
+   * by a prior `set`). Lets a repeat `set` on the same chain skip the redundant
+   * (idempotent-anyway) enqueue and go straight to `annotate`.
+   */
+  private readonly enqueued = new Set<string>();
+
+  constructor(agent: DevSessionStoreAgent, opts: AgentStateDevSessionStoreOptions = {}) {
+    this.agentId = agent.id;
+    this.host = opts.host ?? DEFAULT_HOST;
+    this.instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, this.host);
+    this.errandsScript = opts.errandsScript ?? defaultErrandsScript();
+    this.spawn = opts.spawn ?? defaultAgentStateSpawn;
+    this.log = opts.log ?? ((line) => process.stderr.write(line));
+    this.rehydrate();
+  }
+
+  /** Hot path — pure in-memory read. NEVER spawns (the load-bearing rule). */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async get(chainId: string): Promise<string | undefined> {
+    return this.map.get(chainId);
+  }
+
+  /**
+   * Record the session id for a chain. Updates the map SYNCHRONOUSLY (the very
+   * next `get` sees it), then fires the durable write OFF-PATH (fire-and-forget)
+   * so a slow/failed bundle never blocks or fails the dispatch. Resolves as soon
+   * as the map is updated — it does NOT await the subprocesses.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async set(chainId: string, sessionId: string): Promise<void> {
+    this.map.set(chainId, sessionId);
+    // Off-path: do not await. A throw inside the async IIFE can't escape (it is
+    // caught within), so this never produces an unhandled rejection.
+    void this.persist(chainId, sessionId);
+  }
+
+  /**
+   * Drop a chain's entry (optional terminal cleanup). Synchronous map delete,
+   * then an off-path best-effort `resolve --status cancelled` on the row (the
+   * only lifecycle verb that closes it — annotate can't change status).
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async delete(chainId: string): Promise<void> {
+    const had = this.map.delete(chainId);
+    this.enqueued.delete(chainId);
+    if (had) void this.retire(chainId);
+  }
+
+  /**
+   * Rehydrate the map from the bundle's `dev-session` rows in ONE `list` pass.
+   * Bundle absent / spawn error / non-zero exit → empty (cold) map + one log
+   * line. A cold map degrades to cold-resume (slower-but-correct), never a boot
+   * crash — same failure posture as the file store's corrupt-file path.
+   */
+  private rehydrate(): void {
+    if (!existsSync(this.errandsScript)) {
+      this.log(
+        `cortex: agent-state — dev-session rehydrate SKIPPED for "${this.agentId}" ` +
+          `(reason=script-absent) — starting with a cold warm-session map\n`,
+      );
+      return;
+    }
+    const stdout = this.run([
+      "list",
+      "--kind",
+      DEV_SESSION_WORK_ITEM_KIND,
+      "--owner",
+      this.agentId,
+    ]);
+    if (stdout === null) {
+      // run() already logged the failure with the rehydrate context.
+      return;
+    }
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      const parsed = this.parseRow(trimmed);
+      if (parsed === null) continue;
+      this.enqueued.add(parsed.id);
+      if (parsed.sessionId !== undefined) this.map.set(parsed.id, parsed.sessionId);
+    }
+  }
+
+  /**
+   * The durable write behind a `set`. enqueue-if-absent (idempotent — the bundle
+   * no-ops on an existing id) then annotate the `session_id`. TOTAL +
+   * NON-THROWING: any failure logs one line and returns; the map already holds
+   * the value.
+   */
+  private async persist(chainId: string, sessionId: string): Promise<void> {
+    // Yield so `set` resolves (map-updated) before the subprocesses run — keeps
+    // the write strictly off the awaited path even for an in-process spawn seam.
+    await Promise.resolve();
+    if (!existsSync(this.errandsScript)) {
+      this.log(
+        `cortex: agent-state — dev-session write SKIPPED for "${this.agentId}" ` +
+          `(reason=script-absent; chain=${chainId})\n`,
+      );
+      return;
+    }
+    if (!this.enqueued.has(chainId)) {
+      // enqueue --id <chainId> --kind dev-session --payload {} --owner <agent>.
+      // Empty payload: the session interior lives in the substrate, not here.
+      // The bundle inserts-or-no-ops on the id, so a race that double-enqueues
+      // is harmless. Mark enqueued regardless so we don't loop on re-enqueue.
+      this.enqueued.add(chainId);
+      const enqueue = this.run([
+        "enqueue",
+        "--id",
+        chainId,
+        "--kind",
+        DEV_SESSION_WORK_ITEM_KIND,
+        "--payload",
+        "{}",
+        "--owner",
+        this.agentId,
+      ]);
+      if (enqueue === null) {
+        // Enqueue failed — drop the optimistic mark so a later `set` retries it,
+        // and skip the annotate (nothing to annotate). One line already logged.
+        this.enqueued.delete(chainId);
+        return;
+      }
+    }
+    // annotate --id <chainId> --notes-json {"session_id":<sessionId>}. Merges
+    // the host-namespaced key; the bundle emits `work_item_annotated` itself.
+    this.run([
+      "annotate",
+      "--id",
+      chainId,
+      "--notes-json",
+      JSON.stringify({ [SESSION_ID_NOTE_KEY]: sessionId }),
+    ]);
+  }
+
+  /** Off-path terminal close for `delete`. Best-effort; failure logged, non-fatal. */
+  private async retire(chainId: string): Promise<void> {
+    await Promise.resolve();
+    if (!existsSync(this.errandsScript)) return;
+    this.run(["resolve", "--id", chainId, "--status", "cancelled"]);
+  }
+
+  /**
+   * Run one `errands.ts` subcommand. TOTAL + NON-THROWING: a spawn error /
+   * non-zero exit / throw logs one line (naming the subcommand + chain context)
+   * and returns null; success returns the captured stdout. The dispatch path
+   * must never see a state failure.
+   */
+  private run(args: string[]): string | null {
+    let result;
+    try {
+      result = this.spawn("bun", [this.errandsScript, ...args], { env: this.stdEnv() });
+    } catch (err) {
+      this.log(this.failLine(args, `spawn threw: ${errText(err)}`));
+      return null;
+    }
+    if (result.error) {
+      this.log(this.failLine(args, `spawn-error: ${result.error.message}`));
+      return null;
+    }
+    if (result.status !== 0) {
+      const stderr = result.stderr ? String(result.stderr).slice(0, 200) : "";
+      this.log(
+        this.failLine(args, `nonzero-exit status=${result.status}${stderr ? `; stderr: ${stderr}` : ""}`),
+      );
+      return null;
+    }
+    return result.stdout !== undefined ? String(result.stdout) : "";
+  }
+
+  /** One consistent failure line naming the subcommand + chain (when present). */
+  private failLine(args: string[], reason: string): string {
+    const sub = args[0] === "list" ? "rehydrate" : `dev-session ${args[0]}`;
+    const idIdx = args.indexOf("--id");
+    const chain = idIdx >= 0 ? `; chain=${args[idIdx + 1]}` : "";
+    return (
+      `cortex: agent-state — ${sub} FAILED for "${this.agentId}" ` +
+      `(non-fatal; ${reason}${chain})\n`
+    );
+  }
+
+  /** The standard bundle env (`MF_AGENT_NAME`, `MF_HOST`, `MF_INSTANCE_DIR`). */
+  private stdEnv(): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      MF_AGENT_NAME: this.agentId,
+      MF_HOST: this.host,
+      MF_INSTANCE_DIR: this.instanceDir,
+    };
+  }
+
+  /** Parse one `list` JSON row → `{ id, sessionId? }`. Null on any shape miss. */
+  private parseRow(line: string): { id: string; sessionId?: string } | null {
+    let row: { id?: unknown; notes?: unknown };
+    try {
+      row = JSON.parse(line) as { id?: unknown; notes?: unknown };
+    } catch {
+      return null;
+    }
+    if (typeof row.id !== "string" || row.id.length === 0) return null;
+    const out: { id: string; sessionId?: string } = { id: row.id };
+    // `notes` is a JSON-object string per the annotate contract; a session id we
+    // wrote lives under `session_id`. A NULL / non-object / non-JSON notes cell
+    // simply means "no session yet" for this chain — the id still counts as
+    // enqueued so a later `set` skips the re-enqueue.
+    if (typeof row.notes === "string" && row.notes.length > 0) {
+      try {
+        const notes = JSON.parse(row.notes) as Record<string, unknown>;
+        const sid = notes[SESSION_ID_NOTE_KEY];
+        if (typeof sid === "string" && sid.length > 0) out.sessionId = sid;
+      } catch {
+        /* non-JSON freeform notes → no session id; leave undefined. */
+      }
+    }
+    return out;
+  }
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Options for the per-agent store factory. */
+export interface CreateDevSessionStoreOptions extends AgentStateDevSessionStoreOptions {
+  /** Path the FileDevSessionStore fallback writes to (the pre-S4b file bridge). */
+  fileStorePath: string;
+}
+
+/**
+ * Choose the warm-session store for an agent at wiring time (constraint 5 + 6):
+ *
+ *   - **Stateless agent** (no `state`) → {@link FileDevSessionStore}, with ZERO
+ *     bundle probing. A stateless agent takes no new code paths.
+ *   - **Stateful agent, bundle present** → {@link AgentStateDevSessionStore}
+ *     (rehydrates on construction).
+ *   - **Stateful agent, bundle ABSENT** → {@link FileDevSessionStore} FALLBACK
+ *     with ONE log line, so a machine without the v0.3.0 bundle never regresses.
+ */
+export function createDevSessionStore(
+  agent: DevSessionStoreAgent,
+  opts: CreateDevSessionStoreOptions,
+): DevSessionStore {
+  const log = opts.log ?? ((line: string) => process.stderr.write(line));
+
+  // Stateless — the pre-S4b behaviour, unchanged. No bundle probe.
+  if (!agent.state) {
+    return new FileDevSessionStore(opts.fileStorePath);
+  }
+
+  // Stateful — prefer the bundle, but fall back to the file store (loud) when
+  // the bundle isn't installed so nothing regresses on a bundle-less machine.
+  const errandsScript = opts.errandsScript ?? defaultErrandsScript();
+  if (!existsSync(errandsScript)) {
+    log(
+      `cortex: agent-state — dev-session store fallback to FILE for "${agent.id}" ` +
+        `(reason=bundle-absent at ${errandsScript}) — warm-resume still durable via the JSON bridge\n`,
+    );
+    return new FileDevSessionStore(opts.fileStorePath);
+  }
+  return new AgentStateDevSessionStore(agent, { ...opts, errandsScript });
+}

--- a/src/runner/dev-consumer-boot.ts
+++ b/src/runner/dev-consumer-boot.ts
@@ -64,7 +64,8 @@ import {
   type DevGitInspector,
   type DevOfferAdmissionGate,
 } from "./dev-consumer";
-import { FileDevSessionStore, type DevSessionStore } from "./dev-session-store";
+import type { DevSessionStore } from "./dev-session-store";
+import { createDevSessionStore } from "./agent-state-dev-session-store";
 import { readCommitSignatures, type CommitSigningIO } from "./commit-signing";
 import {
   createWorktreeHandlingExistingBranch,
@@ -86,6 +87,16 @@ export { DevConsumer } from "./dev-consumer";
 export interface DevBootAgent {
   id: string;
   displayName?: string;
+  /**
+   * cortex#1720 S4b — OPT-IN per-instance durable state declaration (the SAME
+   * structural projection the brain-consumer boot gates on). Present ⇒ STATEFUL:
+   * the warm-session store is the AgentState-backed
+   * {@link AgentStateDevSessionStore} (durable via the bundle's `work_items`).
+   * Absent ⇒ stateless: the pre-S4b {@link FileDevSessionStore}, zero new code
+   * paths. The full Zod `Agent` carries this (added in S1); this projection
+   * re-declares it so the wiring can select the store without a cast.
+   */
+  state?: { blueprint: string; version: string };
   runtime?: {
     capabilities?: readonly string[];
     maxConcurrent?: number;
@@ -136,9 +147,13 @@ export interface WireDevConsumersOpts {
   /** Repo-root worktrees are cut from; defaults to `process.cwd()`. */
   repoRoot?: string;
   /**
-   * Warm-session store path. Defaults to
-   * `~/.config/cortex/dev-warm-sessions.json`. The file-backed store is the
-   * §3.6b durability bridge until F-3's agent-state store lands.
+   * BASE path for the FILE-store FALLBACK. Defaults to
+   * `~/.config/cortex/dev-warm-sessions.json`. cortex#1720 S4b retired the file
+   * bridge as the DEFAULT: a stateful agent's warm-session store is now the
+   * AgentState-backed store (durable via the bundle's `work_items`). This path
+   * only backs the fallback — a STATELESS agent, or a stateful agent on a
+   * machine WITHOUT the v0.3.0 bundle — and is made per-agent by
+   * {@link perAgentFileStorePath} so two agents never share one file.
    */
   sessionStorePath?: string;
   /** Env var name carrying the scoped forge token. Default `CORTEX_DEV_GH_TOKEN`. */
@@ -248,9 +263,6 @@ export function wireDevConsumers(opts: WireDevConsumersOpts): WiredDevConsumer[]
     opts.seamsOverride ??
     buildShellSeams({
       repoRoot,
-      sessionStorePath:
-        opts.sessionStorePath ??
-        `${env.HOME ?? "."}/.config/cortex/dev-warm-sessions.json`,
       scopedToken,
       env,
     });
@@ -262,6 +274,26 @@ export function wireDevConsumers(opts: WireDevConsumersOpts): WiredDevConsumer[]
       ? opts.offeringPatterns
       : [`local.${opts.principalId}.${opts.stack}.tasks.dev.implement`];
 
+  // cortex#1720 S4b — the base path for the FILE-store fallback (the pre-S4b
+  // JSON bridge). Per-agent file stores are derived from it so two agents never
+  // share one file; the AgentState store (stateful agents) instead scopes to the
+  // agent's own `~/.config/cortex/agents/<id>/state.sqlite` instance dir.
+  const baseSessionStorePath =
+    opts.sessionStorePath ?? `${env.HOME ?? "."}/.config/cortex/dev-warm-sessions.json`;
+
+  // cortex#1720 S4b — SELECT the warm-session store PER AGENT (constraint 5+6):
+  //   - a test `seamsOverride` wins wholesale (the injected store, unchanged);
+  //   - a STATEFUL agent → AgentStateDevSessionStore (durable via the bundle),
+  //     falling back to the file store (loud) when the bundle is absent;
+  //   - a STATELESS agent → FileDevSessionStore, zero new code paths.
+  const resolveSessionStore = (agent: DevBootAgent): DevSessionStore => {
+    if (opts.seamsOverride !== undefined) return opts.seamsOverride.sessionStore;
+    return createDevSessionStore(agent, {
+      // Per-agent file fallback path so two agents' file stores never collide.
+      fileStorePath: perAgentFileStorePath(baseSessionStorePath, agent.id),
+    });
+  };
+
   const wired: WiredDevConsumer[] = [];
   for (const agent of capable) {
     const consumerAgent: DevConsumerAgent = {
@@ -272,6 +304,9 @@ export function wireDevConsumers(opts: WireDevConsumersOpts): WiredDevConsumer[]
       }),
     };
     const sessionOpts = buildDevSessionOpts(agent, opts.guardrails);
+    // ONE store per agent, shared across that agent's per-scope consumers (the
+    // map is chain-keyed, so all scopes of one agent read/write the same map).
+    const sessionStore = resolveSessionStore(agent);
     // NIT-fix (review): a NEW DevConsumer instance PER (agent × scope) so each
     // bound subject is its own pull consumer — never one instance `.start()`-ed
     // twice (the second `.start()` would silently drop the extra filter).
@@ -293,7 +328,7 @@ export function wireDevConsumers(opts: WireDevConsumersOpts): WiredDevConsumer[]
           commandRunner: seams.commandRunner,
           forge: seams.forge,
           gitInspector: seams.gitInspector,
-          sessionStore: seams.sessionStore,
+          sessionStore,
           sessionOpts,
           ...(opts.offerAdmission !== undefined && {
             offerAdmission: opts.offerAdmission,
@@ -394,23 +429,45 @@ export function devDurableName(principalId: string, agentId: string): string {
   return `cortex-dev-consumer-${principalId}-${agentId}`;
 }
 
+/**
+ * cortex#1720 S4b — per-agent path for the FILE-store FALLBACK. Derived from the
+ * shared base path by inserting the agent id before the extension, so a
+ * bundle-less stack running two dev agents never shares one warm-session file.
+ * `~/.config/cortex/dev-warm-sessions.json` → `…/dev-warm-sessions.<agent>.json`.
+ */
+export function perAgentFileStorePath(basePath: string, agentId: string): string {
+  const slug = agentId.replace(/[^A-Za-z0-9_-]+/g, "-");
+  const dot = basePath.lastIndexOf(".");
+  const slash = basePath.lastIndexOf("/");
+  // Only treat a dot as an extension when it is in the final path segment.
+  if (dot > slash && dot !== -1) {
+    return `${basePath.slice(0, dot)}.${slug}${basePath.slice(dot)}`;
+  }
+  return `${basePath}.${slug}`;
+}
+
 // ---------------------------------------------------------------------------
 // Shell-backed production seams
 // ---------------------------------------------------------------------------
 
 interface ShellSeamsOpts {
   repoRoot: string;
-  sessionStorePath: string;
   scopedToken: string | undefined;
   env: Record<string, string | undefined>;
 }
 
+/**
+ * The shell-backed seams. cortex#1720 S4b — `sessionStore` is NO LONGER built
+ * here: the warm-session store is selected PER AGENT by `createDevSessionStore`
+ * (stateful → AgentState, stateless → file), so a single shared shell store
+ * would be both wrong (one store for N agents) and dead. Tests still inject a
+ * `sessionStore` via `seamsOverride`, which is a separate opts shape.
+ */
 interface BuiltSeams {
   workspace: DevWorkspace;
   commandRunner: DevCommandRunner;
   forge: DevForge;
   gitInspector: DevGitInspector;
-  sessionStore: DevSessionStore;
 }
 
 /**
@@ -638,8 +695,7 @@ function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
     },
   };
 
-  const sessionStore = new FileDevSessionStore(opts.sessionStorePath);
-  return { workspace, commandRunner, forge, gitInspector, sessionStore };
+  return { workspace, commandRunner, forge, gitInspector };
 }
 
 interface RunResult {


### PR DESCRIPTION
Final slice of #1720. The dev consumer's warm-session map (correlation chain → CC session id) moves from the JSON file bridge onto agent-state's KV surface (v0.3.0).

**Design (per the S4b assessment):**
- **Chain→work_item mapping resolved without recorder coupling**: this store owns a host-namespaced `dev-session` work_items slice, one row per chain, the chainId as the row id. The dev.implement path never flowed through BrainConsumer, so no recorder row existed to reuse — separate slices keep 'durable dispatch queue' and 'session continuity' apart.
- **Hot read in-process** (pure Map.get, never spawns); rehydrated by one `list` pass at construction. A failed rehydrate degrades to cold-resume, never a boot crash.
- **Writes off-path**: synchronous map update, then fire-and-forget `enqueue`-if-absent + `annotate {"session_id"}` (bundle emits its own events; annotate is metadata-only per AnnotateWorkItem.md).
- **Selection at wiring time**: no `state` → FileDevSessionStore, zero probing; stateful + bundle absent → loud file-store fallback (bundle-less machines never regress).
- `delete()` retires the row via `resolve --status cancelled` (the only lifecycle verb — annotate can't touch status).

**Provenance & verification:** the implementing engineer's session died on an auth failure mid-flight; work recovered from its `s4b-wip` stash, rebased onto current main, and independently verified — every CLI invocation checked against the real bundle's `errands.ts` argument contract; 190 targeted tests green; full suite at the pre-existing 20-fail baseline (network-secret-cli; the ConfigWatcher flake appeared once and did not reproduce); `tsc`/`eslint` clean; vocab gate pass.

Refs #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)