### PR TITLE
fix(mc): drop duplicate federated-absent edge label (double-print on jc node)

### DIFF
--- a/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-elk-edge.tsx
@@ -301,22 +301,10 @@ export default function NetworkElkEdge(props: EdgeProps) {
               : undefined
         }
       />
-      {federatedAbsent && (
-        <EdgeLabelRenderer>
-          <div
-            className="mc-edge-fed-label mc-edge-fed-absent-label"
-            data-edge-federated-absent="true"
-            style={{
-              position: "absolute",
-              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-              pointerEvents: "none",
-            }}
-            title="Federated peer — admitted to the network but not currently present"
-          >
-            <span aria-hidden="true">○</span> federated · absent
-          </div>
-        </EdgeLabelRenderer>
-      )}
+      {/* No edge label for the federated-absent spoke: the absent PEER NODE
+          already carries the canonical "federated · absent" eyebrow, so an edge
+          label here just double-prints it right next to the node. The dashed
+          `.edge-fed-absent` styling alone conveys "federated link". */}
       {federated && !federatedAbsent && (
         <EdgeLabelRenderer>
           <div


### PR DESCRIPTION
Live-DOM diagnosis: the jc federated-peer node showed 'federated · absent' TWICE — once as the node's eyebrow (canonical) and once as an edge label on the dotted spoke, rendered right at the node. Removes the edge label; the node eyebrow + the dashed edge styling convey it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)