### PR TITLE
fix(network): FS-5a — doctor defaults the monitor URL (status/C-797 parity) → no false 'broken'

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
@@ -392,6 +392,89 @@ describe("runDoctorChecks — (c) no monitor configured", () => {
 });
 
 // ---------------------------------------------------------------------------
+// FS-5a (cortex#1814) — doctor DEFAULTS the monitor URL like status/C-797:
+// an UNCONFIGURED monitor is still PROBED (at DEFAULT_MONITOR_URL). A reachable
+// default now PASSES (leaf legs run → a healthy leaf reads healthy) instead of
+// short-circuiting to WARN + skip. A genuinely-down default still degrades to
+// WARN (never a hard `broken`, never a crash).
+// ---------------------------------------------------------------------------
+
+describe("runDoctorChecks — FS-5a monitor-URL default (status/C-797 parity)", () => {
+  test("absent --monitor-url but the DEFAULT monitor responds ⇒ monitor-reachable PASSES and leaf legs run", async () => {
+    // `configured: false` models "no explicit --monitor-url and no derivable
+    // http_port" — resolveMonitorBase's DEFAULT_MONITOR_URL fallback. The
+    // default `:8222` is reachable (leafz present), so the leaf on this healthy
+    // bus must be VISIBLE, not skipped.
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: false, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 33)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    const monitorCheck = findCheck(res.checks, "monitor-reachable");
+    expect(monitorCheck.status).toBe("pass");
+    expect(monitorCheck.detail).toContain("127.0.0.1:8222");
+    // The leaf legs now RUN off the default-probed /leafz instead of skipping.
+    expect(findCheck(res.checks, "leaf-established").status).toBe("pass");
+    expect(findCheck(res.checks, "leaf-account-bound").status).toBe("pass");
+    // The healthy leaf is no longer mislabelled broken.
+    expect(res.verdict).toBe("healthy");
+    expect(res.exitCode).toBe(0);
+  });
+
+  test("explicit --monitor-url is honored — a CONFIGURED reachable monitor PASSES", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({
+        configured: true,
+        url: "http://127.0.0.1:8224",
+        leafz: ESTABLISHED_LEAFZ,
+      }),
+      probe: fakeProbe((f) => echoReply(f, 27)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    const monitorCheck = findCheck(res.checks, "monitor-reachable");
+    expect(monitorCheck.status).toBe("pass");
+    // The explicit URL (a community bus on :8224) is probed, not the default.
+    expect(monitorCheck.detail).toContain("127.0.0.1:8224");
+    expect(findCheck(res.checks, "leaf-established").status).toBe("pass");
+    expect(res.verdict).toBe("healthy");
+  });
+
+  test("a genuinely-down DEFAULT monitor degrades to WARN (not broken, not a crash)", async () => {
+    // `configured: false` + no leafz ⇒ we probed the default and it did not
+    // respond. That is INCONCLUSIVE — WARN + skip the leaf legs — never a hard
+    // FAIL/`broken`. (This is the acceptance's genuinely-down-monitor case; it
+    // shares the pre-FS-5a "(c)" assertions, kept here for FS-5a locality.)
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()]),
+      monitor: fakeMonitorPort({ configured: false }), // default probed, no response
+      probe: fakeProbe((f) => echoReply(f, 30)),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+
+    const monitorCheck = findCheck(res.checks, "monitor-reachable");
+    expect(monitorCheck.status).toBe("warn");
+    expect(monitorCheck.fix).toContain("http_port/monitor_port");
+    expect(findCheck(res.checks, "leaf-established").status).toBe("skip");
+    expect(findCheck(res.checks, "leaf-account-bound").status).toBe("skip");
+    // A warn never blocks healthy — the verdict must not be broken.
+    expect(res.verdict).not.toBe("broken");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // (d) leaf down
 // ---------------------------------------------------------------------------
 

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -414,37 +414,54 @@ async function checkMonitorReachable(
   const title = "local NATS monitor reachable";
   const resolved = ports.monitor.resolve();
 
-  // #831 — absent monitor is INCONCLUSIVE, not a failure: warn, and let
-  // downstream leaf checks skip (they have no /leafz to read).
+  // FS-5a (cortex#1814) — PROBE the resolved monitor even when it is the
+  // unconfigured `DEFAULT_MONITOR_URL` fallback, so `doctor` reaches the SAME
+  // verdict as `status`/C-797. `status`'s `buildLeafStatePort` always fetches
+  // `resolveMonitorBase(cfg).url` — default `127.0.0.1:8222` included — and only
+  // degrades to "unknown" on a genuine fetch failure; the pre-FS-5a doctor
+  // instead SHORT-CIRCUITED to WARN on `!configured` and never probed, so a
+  // HEALTHY leaf on a bus with no explicit monitor knob read `broken` (the leaf
+  // legs skipped for want of `/leafz`). We now always attempt the probe.
+  const leafz = await ports.monitor.fetchLeafz();
+  if (leafz !== undefined) {
+    return {
+      result: check(id, title, "pass", `${resolved.url}/leafz responded`, "member"),
+      leafz,
+    };
+  }
+
+  // Probe failed. #831 — an UNCONFIGURED monitor (bus declares no
+  // `--monitor-url` / `http_port` / `monitor_port`; we probed the upstream
+  // default) is INCONCLUSIVE, not a failure: WARN and let the leaf legs skip
+  // (they have no `/leafz`). This is the graceful path the FS-5a acceptance
+  // demands — a genuinely-down monitor ⇒ WARN/unknown, never `broken`-by-default
+  // and never a crash (the fetch catch already swallowed the error to
+  // `undefined`).
   if (!resolved.configured) {
     return {
       result: check(
         id,
         title,
         "warn",
-        "no monitor configured for this bus (no --monitor-url / http_port / monitor_port)",
+        `no monitor reachable for this bus (probed ${resolved.url}; no --monitor-url / http_port / monitor_port configured)`,
         "member",
         "enable http_port/monitor_port on the local bus for full leaf verification",
       ),
     };
   }
 
-  const leafz = await ports.monitor.fetchLeafz();
-  if (leafz === undefined) {
-    return {
-      result: check(
-        id,
-        title,
-        "fail",
-        `monitor at ${resolved.url} did not respond to /leafz`,
-        "member",
-        "confirm the local nats-server is running and its monitor port is reachable",
-      ),
-    };
-  }
+  // A CONFIGURED monitor (explicit flag or derived from the nats config) that
+  // did not respond is a genuine FAIL — the principal asked for this monitor and
+  // it is down.
   return {
-    result: check(id, title, "pass", `${resolved.url}/leafz responded`, "member"),
-    leafz,
+    result: check(
+      id,
+      title,
+      "fail",
+      `monitor at ${resolved.url} did not respond to /leafz`,
+      "member",
+      "confirm the local nats-server is running and its monitor port is reachable",
+    ),
   };
 }
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -4920,18 +4920,31 @@ export async function startCortex(
               ...(options.stack !== undefined && { stack: options.stack }),
               ...(resolvedPolicy !== undefined && { policy: resolvedPolicy }),
             };
+            // FS-5a (cortex#1814) — thread the daemon's OWN nats-server config
+            // path so `resolveMonitorBase` config-derives the monitor URL (a
+            // community bus on `:8224`, not the wrong `:8222`) and, absent an
+            // `http_port`, falls back to `DEFAULT_MONITOR_URL` — the SAME
+            // resolution `status`/`buildLeafStatePort` use. Combined with the
+            // FS-5a `checkMonitorReachable` change (probe the default, not
+            // skip), the glass doctor now reaches the same verdict as the CLI
+            // for a healthy leaf instead of pessimistically warning + skipping.
+            const daemonNatsConfigPath = options.stack?.nats_infra?.config_path;
             const livePortsCfg: LivePortsConfig = {
               networkId,
               principalId,
               stackId: options.stack?.id ?? principalId,
+              ...(daemonNatsConfigPath !== undefined && daemonNatsConfigPath !== ""
+                ? { natsConfigPath: daemonNatsConfigPath }
+                : {}),
             };
             const ports: NetworkDoctorPorts = {
               // The composed networks (config-split-aware); `runDoctorChecks`
               // finds the one by id. Same adapter the CLI factory builds.
               config: buildDoctorConfigPort({ networks: fedNetworks }),
-              // No daemon-known monitor config path ⇒ monitor-reachable warns
-              // and the leaf legs skip (HONEST degradation) rather than guess a
-              // monitor URL and risk a false "unreachable" fail.
+              // FS-5a — resolve the monitor via `resolveMonitorBase` (explicit →
+              // config-derive from the threaded nats config → DEFAULT_MONITOR_URL)
+              // and PROBE it, matching `status`. A genuinely-down monitor still
+              // degrades to WARN/unknown (never a hard `broken`), never a crash.
               monitor: buildMonitorPort(livePortsCfg),
               probe: {
                 bus: wrapRuntimeAsProbeBus(runtime),


### PR DESCRIPTION
Closes #1814. First FS Wave 0 slice (federation-simplification, #1813). `doctor`'s `checkMonitorReachable` short-circuited to WARN on `!configured` and never probed → leaf legs skipped → healthy leaf read `broken`. Now it always probes the resolved monitor (default `:8222` included, like `status`/C-797); reachable ⇒ leaf legs run, unconfigured-and-down ⇒ WARN (never broken/crash), configured-and-down ⇒ FAIL. MC daemon doctor threads `nats_infra.config_path` so the glass verdict matches the CLI. 55 doctor tests green, tsc 0, eslint clean, additive. 🤖 Generated with [Claude Code](https://claude.com/claude-code)