### PR TITLE
refactor(metrics): consume signal_* instead of pai_* (lock-step with signal rename)

### DIFF
--- a/docs/design-federation-simplification.md
+++ b/docs/design-federation-simplification.md
@@ -6,7 +6,7 @@
 
 ## 1. Problem — the evidence
 
-To see one admitted peer's presence dot, a principal currently traverses **seven concepts across four config surfaces owned by two operators**: registry admission → `peers[]` → acceptance offerings → hub-minted cred `allow-sub` → NSC account import → signing posture → ADR-0001 subject grammar.
+To see one admitted peer's presence dot, a principal currently traverses **seven concepts across four config surfaces owned by two principals**: registry admission → `peers[]` → acceptance offerings → hub-minted cred `allow-sub` → NSC account import → signing posture → ADR-0001 subject grammar.
 
 What the live session actually hit:
 

--- a/src/common/sideband/metrics.ts
+++ b/src/common/sideband/metrics.ts
@@ -46,7 +46,7 @@ export interface SidebandMetricSample {
 }
 
 /**
- * Hook-latency p50 / p95 / p99 of `pai_duration_ms`, in milliseconds. A field
+ * Hook-latency p50 / p95 / p99 of `signal_duration_ms`, in milliseconds. A field
  * is `null` when the histogram had no samples in the window.
  *
  * Mirrors signal `SidebandLatencyPercentiles`.
@@ -61,8 +61,8 @@ export interface SidebandLatencyPercentiles {
  * The signal-overview panels as JSON. Rates are per-second over `window`.
  *
  * Mirrors signal `SidebandMetricsSummary`. Metric provenance (signal
- * `architecture.md` §3.2): `pai_tool_calls_total`, `pai_agent_spawns_total`,
- * `pai_events_total` (counters → rates), `pai_duration_ms` (histogram → p50/95/99).
+ * `architecture.md` §3.2): `signal_tool_calls_total`, `signal_agent_spawns_total`,
+ * `signal_events_total` (counters → rates), `signal_duration_ms` (histogram → p50/95/99).
  */
 export interface SidebandMetricsSummary {
   /** The rate window the panels were evaluated over (e.g. `5m`). */

--- a/src/surface/mc/dashboard-v2/components/obs-metrics-panels.tsx
+++ b/src/surface/mc/dashboard-v2/components/obs-metrics-panels.tsx
@@ -5,7 +5,7 @@
  * (PromQL over VictoriaMetrics), proxied per U0.1:
  *   1. **Rates** — per-second tool-call rate (by tool), agent-spawn rate, and
  *      overall event rate, evaluated over the selected window.
- *   2. **Hook latency** — p50 / p95 / p99 of `pai_duration_ms`, in ms.
+ *   2. **Hook latency** — p50 / p95 / p99 of `signal_duration_ms`, in ms.
  *   3. **>14d history** — events past MC's 14-day local projection prune, sourced
  *      from VictoriaLogs via `/search?since=30d`. This is the HONEST source: the
  *      local `observability_events` table prunes at 14 days


### PR DESCRIPTION
signal renamed its metric contract `pai_*` → `signal_*` (the-metafactory/signal#209, drops the PAI-ism). Updates the two cortex consumers — `surface/mc/dashboard-v2/components/obs-metrics-panels.tsx` + `common/sideband/metrics.ts` (PromQL + labels for tool-call/event/spawn rates + `signal_duration_ms` p50/95/99) — to match. Part of the-metafactory/signal#161.