### PR TITLE
feat(federation): FS-6 — roster splits absent(offline) vs absent(unheard) — honest verdicts

### DIFF
--- a/src/bus/agent-network/__tests__/federated-presence-receipts.test.ts
+++ b/src/bus/agent-network/__tests__/federated-presence-receipts.test.ts
@@ -1,0 +1,64 @@
+/**
+ * FS-6 (cortex#1821) — per-peer received-presence ledger tests.
+ *
+ * The ledger is the honest-absence hinge: `everReceived(peer)` is what splits an
+ * admitted-but-absent peer into `absent-offline` (heard, went away) vs
+ * `absent-unheard` (never heard — an import/cred gap). These assert the pure
+ * state semantics: monotonic count, max-wins `lastAt`, never-heard ⇒ false.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { FederatedPresenceReceipts } from "../federated-presence-receipts";
+
+describe("FederatedPresenceReceipts", () => {
+  test("never-recorded principal ⇒ everReceived false, get undefined", () => {
+    const r = new FederatedPresenceReceipts();
+    expect(r.everReceived("jc")).toBe(false);
+    expect(r.get("jc")).toBeUndefined();
+  });
+
+  test("first record ⇒ everReceived true, count 1, lastAt stamped", () => {
+    const r = new FederatedPresenceReceipts();
+    r.record("jc", 1000);
+    expect(r.everReceived("jc")).toBe(true);
+    expect(r.get("jc")).toEqual({ count: 1, lastAt: 1000 });
+  });
+
+  test("repeated records ⇒ count increments monotonically", () => {
+    const r = new FederatedPresenceReceipts();
+    r.record("jc", 1000);
+    r.record("jc", 2000);
+    r.record("jc", 3000);
+    expect(r.get("jc")).toEqual({ count: 3, lastAt: 3000 });
+  });
+
+  test("out-of-order older observation never rewinds lastAt (max wins)", () => {
+    const r = new FederatedPresenceReceipts();
+    r.record("jc", 5000);
+    r.record("jc", 2000); // older — must not rewind lastAt
+    expect(r.get("jc")).toEqual({ count: 2, lastAt: 5000 });
+  });
+
+  test("distinct principals are tracked independently", () => {
+    const r = new FederatedPresenceReceipts();
+    r.record("jc", 1000);
+    r.record("zeta", 2000);
+    expect(r.everReceived("jc")).toBe(true);
+    expect(r.everReceived("zeta")).toBe(true);
+    expect(r.everReceived("nyx")).toBe(false);
+  });
+
+  test("get / snapshot return copies — mutation can't corrupt internal state", () => {
+    const r = new FederatedPresenceReceipts();
+    r.record("jc", 1000);
+    const copy = r.get("jc")!;
+    copy.count = 999;
+    expect(r.get("jc")?.count).toBe(1);
+
+    const snap = r.snapshot();
+    snap.get("jc")!.count = 42;
+    snap.set("ghost", { count: 1, lastAt: 0 });
+    expect(r.get("jc")?.count).toBe(1);
+    expect(r.everReceived("ghost")).toBe(false);
+  });
+});

--- a/src/bus/agent-network/__tests__/federated-subscriber.test.ts
+++ b/src/bus/agent-network/__tests__/federated-subscriber.test.ts
@@ -22,6 +22,7 @@ import {
   federatedAgentPresenceSubject,
 } from "../federated-subscriber";
 import { AgentPresenceRegistry, isForeignOrigin } from "../registry";
+import { FederatedPresenceReceipts } from "../federated-presence-receipts";
 import {
   createAgentOnlineEvent,
   type AgentPresenceSource,
@@ -291,6 +292,115 @@ describe("E.2 — fold accept-listed foreign presence", () => {
     const foreign = registry.getAgents().find((a) => a.agentId === "sage");
     expect(local?.origin).toBe("local");
     expect(foreign?.origin).toMatchObject({ kind: "foreign" });
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FS-6 (cortex#1821) — per-peer received-presence receipts (offline vs unheard)
+// ---------------------------------------------------------------------------
+
+describe("FS-6 — records received-presence receipts (folded OR gated)", () => {
+  test("a FOLDED accept-listed peer's presence records a receipt", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const receipts = new FederatedPresenceReceipts();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      receipts,
+      now: () => 4242,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    // Folded (accept-listed) AND recorded.
+    expect(registry.getAgents().length).toBe(1);
+    expect(receipts.everReceived("joel")).toBe(true);
+    expect(receipts.get("joel")).toEqual({ count: 1, lastAt: 4242 });
+    await handle.stop();
+  });
+
+  test("a GATED (non-accept-listed) peer's presence STILL records a receipt — heard on the wire, not unheard", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const receipts = new FederatedPresenceReceipts();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      // joel is NOT a peer here ⇒ the accept-list gate DROPS the envelope.
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      receipts,
+      now: () => 7000,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    // DROPPED (not folded) — but we DID hear it on the wire, so it is recorded.
+    // This is the FS-6 honesty invariant: "unheard" must mean nothing arrived,
+    // NOT arrived-but-policy-dropped. A gated peer is `absent-offline`, never the
+    // misleading `absent-unheard`.
+    expect(registry.getAgents().length).toBe(0);
+    expect(receipts.everReceived("joel")).toBe(true);
+    expect(receipts.get("joel")?.count).toBe(1);
+    await handle.stop();
+  });
+
+  test("a NEVER-heard peer has no receipt (⇒ absent-unheard downstream)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const receipts = new FederatedPresenceReceipts();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      receipts,
+    });
+    // Fire nothing for `nyx` — never heard.
+    await flush();
+    expect(receipts.everReceived("nyx")).toBe(false);
+    await handle.stop();
+  });
+
+  test("a non-presence subject (local.*) does NOT record a federated receipt", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const receipts = new FederatedPresenceReceipts();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      receipts,
+    });
+    // A `local.*` presence envelope is B.3's, not the federated subscriber's —
+    // it must be ignored entirely (no fold, no receipt).
+    runtime.fire(foreignOnline(), "local.joel.research.agent.online", "primary");
+    await flush();
+    expect(receipts.everReceived("joel")).toBe(false);
+    await handle.stop();
+  });
+
+  test("repeated heartbeats bump the receipt count (monotonic)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const receipts = new FederatedPresenceReceipts();
+    let clock = 1000;
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      receipts,
+      now: () => clock,
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    clock = 2000;
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    expect(receipts.get("joel")).toEqual({ count: 2, lastAt: 2000 });
     await handle.stop();
   });
 });

--- a/src/bus/agent-network/federated-presence-receipts.ts
+++ b/src/bus/agent-network/federated-presence-receipts.ts
@@ -1,0 +1,107 @@
+/**
+ * FS-6 (cortex#1821) — per-peer FEDERATED-PRESENCE RECEIPT ledger.
+ *
+ * The single distinction that turns a 2-day andreas⇄jc federation hunt into a
+ * 5-minute one: an admitted-but-not-present peer is either
+ *
+ *   - **offline** — we HAVE received its federated presence before; it has since
+ *     gone stale (the peer's stack went away), OR
+ *   - **unheard** — we have NEVER received a single `federated.{peer}.{stack}.agent.*`
+ *     envelope from it. The peer may be perfectly healthy; WE are deaf to it — an
+ *     import / cred / accept-list gap (the cortex#1812 root-cause class).
+ *
+ * The system already KNOWS which: the federated-presence subscriber sees zero
+ * inbound envelopes for an unheard peer and a non-zero stream for a heard one. It
+ * just never SAID so. This ledger is where it says so.
+ *
+ * ## What it counts (the FS-6 acceptance boundary)
+ *
+ * EVERY `federated.{principal}.{stack}.agent.*` envelope that REACHES the
+ * subscriber for a peer principal is recorded here — **folded OR gated**. We
+ * record it BEFORE the accept-list / chain-verify gates run, so a peer we can
+ * physically hear on the wire but that the gate later DROPS (denied subject,
+ * over-hop, un-accept-listed) is still "heard", not "unheard". That is the honest
+ * signal: "unheard" must mean *nothing arrived on the wire at all* (an import/cred
+ * gap), not *arrived-but-policy-dropped* (a config choice the roster already
+ * surfaces elsewhere). Conflating the two would re-hide the exact bug FS-6 exists
+ * to expose.
+ *
+ * ## Identity
+ *
+ * Keyed by the SOURCE PRINCIPAL (`envelope.source`'s first segment) — the same
+ * principal the membership verdict is keyed on (ADR-0018 Q3, roster is
+ * principal-keyed). A peer with two stacks that we hear from either counts as one
+ * heard principal; that is correct — "have we EVER heard this principal" is a
+ * principal-level question. (The subscriber derives the source principal the same
+ * way it always has; this ledger never re-parses the wire.)
+ *
+ * ## Read path
+ *
+ * The MC `/api/networks` verdict projection reads {@link everReceived} through the
+ * `NetworksView.receivedPresenceFrom` seam (wired in `cortex.ts`). Pure state, no
+ * bus, no I/O — trivially unit-testable by calling {@link record} directly.
+ */
+
+/** One peer principal's received-presence receipt. */
+export interface FederatedPresenceReceipt {
+  /**
+   * Count of `federated.{principal}.{stack}.agent.*` envelopes ever seen from
+   * this peer principal (folded OR gated). A monotonic tally — never decremented.
+   */
+  count: number;
+  /**
+   * Epoch-ms (receiver clock) the most recent envelope from this peer was seen.
+   * The receiver's observation time, NOT any wire timestamp.
+   */
+  lastAt: number;
+}
+
+/**
+ * In-memory per-peer received-presence ledger. Owned by the federated-presence
+ * subscriber; read by the MC verdict projection. A pure tally — no eviction (a
+ * heard peer stays "heard" for the life of the process; that is the intended
+ * semantics — "unheard" is about NEVER having heard, and a peer that goes stale
+ * is "offline", surfaced by the ABSENCE of live presence, not by forgetting we
+ * heard it).
+ */
+export class FederatedPresenceReceipts {
+  private readonly receipts = new Map<string, FederatedPresenceReceipt>();
+
+  /**
+   * Record one received federated-presence envelope from `principal` at `atMs`
+   * (receiver clock). Increments the count and advances `lastAt` to the max of
+   * the current and the new observation (so an out-of-order older observation
+   * never rewinds `lastAt`). Idempotent in shape — every call bumps the count.
+   */
+  record(principal: string, atMs: number): void {
+    const existing = this.receipts.get(principal);
+    if (existing === undefined) {
+      this.receipts.set(principal, { count: 1, lastAt: atMs });
+      return;
+    }
+    existing.count += 1;
+    if (atMs > existing.lastAt) existing.lastAt = atMs;
+  }
+
+  /**
+   * True when we have EVER received a federated-presence envelope from this peer
+   * principal. The FS-6 hinge: `false` ⇒ `absent-unheard` (import/cred gap);
+   * `true` + not-present ⇒ `absent-offline` (heard, went away).
+   */
+  everReceived(principal: string): boolean {
+    return this.receipts.has(principal);
+  }
+
+  /** The full receipt for a peer principal, or `undefined` when never heard. */
+  get(principal: string): FederatedPresenceReceipt | undefined {
+    const r = this.receipts.get(principal);
+    return r ? { ...r } : undefined;
+  }
+
+  /** Snapshot of every heard principal → its receipt (copies — caller-safe). */
+  snapshot(): Map<string, FederatedPresenceReceipt> {
+    const out = new Map<string, FederatedPresenceReceipt>();
+    for (const [principal, r] of this.receipts) out.set(principal, { ...r });
+    return out;
+  }
+}

--- a/src/bus/agent-network/federated-subscriber.ts
+++ b/src/bus/agent-network/federated-subscriber.ts
@@ -112,6 +112,7 @@ import {
 } from "../access-denied-dedup";
 import { AgentPresenceRegistry } from "./registry";
 import { AGENT_PRESENCE_TYPES } from "./envelopes";
+import type { FederatedPresenceReceipts } from "./federated-presence-receipts";
 
 /**
  * Subject pattern the FEDERATED subscriber binds — every peer principal/stack's
@@ -226,6 +227,23 @@ export interface StartFederatedAgentPresenceSubscriberOptions {
    * rather than re-spamming the audit subject every tick.
    */
   onDenialBubbleUp?: (info: DenialBubbleUp) => void;
+  /**
+   * FS-6 (cortex#1821) — per-peer received-presence ledger. When supplied, EVERY
+   * `federated.{principal}.{stack}.agent.*` envelope that REACHES this subscriber
+   * is recorded against its source principal here — **folded OR gated** (recorded
+   * BEFORE the accept-list / chain-verify gates, so a peer we can physically hear
+   * on the wire but that the gate later drops still reads as "heard"). The MC
+   * verdict projection reads {@link FederatedPresenceReceipts.everReceived} to
+   * split an absent peer into `absent-offline` (heard, went stale) vs
+   * `absent-unheard` (never heard — an import/cred gap). OPTIONAL: omit it (tests
+   * that don't exercise the ledger) and the subscriber behaves byte-identically.
+   */
+  receipts?: FederatedPresenceReceipts;
+  /**
+   * FS-6 — receiver clock stamped onto a received-presence receipt. Injectable so
+   * a test can assert deterministic `lastAt` values. Defaults to `Date.now`.
+   */
+  now?: () => number;
 }
 
 /** cortex#1213 — payload handed to {@link StartFederatedAgentPresenceSubscriberOptions.onDenialBubbleUp}. */
@@ -259,8 +277,11 @@ export async function startFederatedAgentPresenceSubscriber(
     stackIdentity,
     stackNKeyPub,
     resolveFederatedPeer,
+    receipts,
   } = opts;
   const cryptoVerify = opts.cryptoVerify ?? true;
+  // FS-6 — receiver clock for received-presence receipts.
+  const now = opts.now ?? Date.now;
   // cortex#1213 — dedupe the `system.access.denied` audit emits. Default to a
   // fresh 60s-window deduper; tests inject one with an injected clock.
   const denialDeduper = opts.denialDeduper ?? new AccessDeniedDeduper();
@@ -346,6 +367,18 @@ export async function startFederatedAgentPresenceSubscriber(
     if (!presenceTypes.has(envelope.type)) return;
 
     const sourcePrincipal = envelope.source.split(".")[0] ?? envelope.source;
+
+    // === FS-6 (cortex#1821) — RECEIVED-PRESENCE RECEIPT ===================
+    // Record that we HEARD a federated-presence envelope from this source
+    // principal, BEFORE any gate runs — folded OR gated. This is the whole
+    // point: "unheard" must mean nothing arrived on the wire (an import/cred
+    // gap), not arrived-but-policy-dropped. A peer we can physically hear but
+    // whose envelope the accept-list gate later drops is still HEARD here, so
+    // the roster reports it `absent-offline` (a config choice, visible
+    // elsewhere), never the misleading `absent-unheard`. The self-loopback of
+    // our OWN presence is recorded too, but our own principal is never
+    // evaluated as an absent peer, so it is inert in the verdict.
+    receipts?.record(sourcePrincipal, now());
 
     // === SELF-LOOPBACK SHORT-CIRCUIT (cortex#1213, mirrors cortex#480) =====
     // A federated stack publishes its OWN presence onto `federated.{us}.agent.>`

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -265,6 +265,8 @@ import {
   startFederatedAgentPresenceSubscriber,
   type FederatedAgentPresenceSubscriberHandle,
 } from "./bus/agent-network/federated-subscriber";
+// FS-6 (cortex#1821) — per-peer received-presence ledger (offline vs unheard split).
+import { FederatedPresenceReceipts } from "./bus/agent-network/federated-presence-receipts";
 // P3 (cortex#1088) — continuous federation roster reconciler. Mutates the LIVE
 // `policy.federated.networks[]` the gate reads so a later-joining roster peer is
 // admitted within one reconcile interval, no manual `network join`.
@@ -4484,6 +4486,14 @@ export async function startCortex(
   // G-1114.E.2 — trust-verified federated presence subscriber (folds peers'
   // agents into the SAME registry, tagged with foreign provenance).
   let federatedPresenceHandle: FederatedAgentPresenceSubscriberHandle | null = null;
+  // FS-6 (cortex#1821) — per-peer received-presence ledger. The federated-presence
+  // subscriber records every federated presence envelope it hears (folded OR
+  // gated) against its source principal here; the `/api/networks` view reads
+  // `everReceived` to split an absent peer into `absent-offline` (heard, went
+  // stale) vs `absent-unheard` (never heard — an import/cred gap). One instance
+  // shared subscriber→view; constructed unconditionally (inert until the
+  // subscriber records into it — a stack with no federation records nothing).
+  const federatedPresenceReceipts = new FederatedPresenceReceipts();
   // P3 (cortex#1088) — continuous federation roster reconciler. Mutates the
   // LIVE `resolvedPolicy.federated.networks[]` (the SAME objects the gate above
   // reads) so a later-joining roster peer's presence is admitted within one
@@ -4660,6 +4670,9 @@ export async function startCortex(
         registry: presenceRegistryHandle.registry,
         federated: resolvedPolicy?.federated,
         source: systemEventSource,
+        // FS-6 — the per-peer received-presence ledger the `/api/networks` view
+        // reads to split absent-offline vs absent-unheard.
+        receipts: federatedPresenceReceipts,
         trustResolver,
         receivingAgentId: mergedAgents[0]?.id,
         principalId,
@@ -4844,6 +4857,12 @@ export async function startCortex(
               memberPrincipal,
               principalId,
             ),
+          // FS-6 (cortex#1821) — have we EVER heard this peer's federated
+          // presence? Reads the subscriber's per-peer receipt ledger so the
+          // handler splits an absent peer into offline (heard, went stale) vs
+          // unheard (never heard — an import/cred gap).
+          receivedPresenceFrom: (memberPrincipal) =>
+            federatedPresenceReceipts.everReceived(memberPrincipal),
         };
         const live =
           resolvedRegistry?.pubkey !== undefined && stackMaterial !== undefined;

--- a/src/surface/mc/__tests__/networks-api.test.ts
+++ b/src/surface/mc/__tests__/networks-api.test.ts
@@ -145,7 +145,7 @@ describe("handleListNetworks — graceful states", () => {
 });
 
 describe("handleListNetworks — authoritative reconciliation", () => {
-  it("admitted peer present → admitted-present; admitted peer absent → admitted-absent", async () => {
+  it("admitted peer present → admitted-present; admitted peer absent (no receipt seam) → absent-offline", async () => {
     const res = await handleListNetworks(
       view({
         "research-collab": {
@@ -167,7 +167,34 @@ describe("handleListNetworks — authoritative reconciliation", () => {
     expect(byPrincipal).toEqual({
       andreas: "admitted-present",
       jc: "admitted-present",
-      zeta: "admitted-absent",
+      zeta: "absent-offline",
+    });
+  });
+
+  it("FS-6 — splits absent into offline (heard) vs unheard (never heard) off the receipt seam", async () => {
+    // Two admitted peers, both absent. `zeta` we have HEARD before (a receipt);
+    // `nyx` we have NEVER heard. The verdict must honestly distinguish them.
+    const base = view({
+      "research-collab": {
+        ok: true,
+        roster: { admitted: ["zeta", "nyx"], pending: [], authoritative: true },
+      },
+    });
+    const heard = new Set(["zeta"]);
+    const withReceipts: NetworksView = {
+      ...base,
+      receivedPresenceFrom: (principal) => heard.has(principal),
+    };
+    const res = await handleListNetworks(
+      withReceipts,
+      presenceView([rec({ agentId: "luna" })]), // only andreas/main present
+    );
+    const net = (await body(res)).networks[0]!;
+    const byPrincipal = Object.fromEntries(net.members.map((m) => [m.principal, m.verdict]));
+    expect(byPrincipal).toEqual({
+      andreas: "admitted-present",
+      zeta: "absent-offline", // heard before → offline
+      nyx: "absent-unheard", // never heard → unheard (import/cred gap)
     });
   });
 

--- a/src/surface/mc/__tests__/networks-http.test.ts
+++ b/src/surface/mc/__tests__/networks-http.test.ts
@@ -119,7 +119,10 @@ describe("GET /api/networks (HTTP)", () => {
         m.verdict,
       ]),
     );
-    expect(byPrincipal).toEqual({ andreas: "admitted-present", jc: "admitted-absent" });
+    // FS-6 — the view stub exposes no `receivedPresenceFrom`, so the absent
+    // family collapses to the conservative `absent-offline` (never over-claim
+    // "unheard" without the receipt ledger).
+    expect(byPrincipal).toEqual({ andreas: "admitted-present", jc: "absent-offline" });
   });
 
   it("rejects non-GET methods", async () => {

--- a/src/surface/mc/__tests__/networks-membership.test.ts
+++ b/src/surface/mc/__tests__/networks-membership.test.ts
@@ -51,13 +51,66 @@ describe("reconcileNetworkMembership — verdict semantics", () => {
     ]);
   });
 
-  it("admitted + absent → admitted-absent (no present stacks)", () => {
+  it("admitted + absent, no receipt ledger → absent-offline (conservative default)", () => {
+    // FS-6 — without `everReceivedPresence` the absent family collapses to
+    // absent-offline: we never over-claim "unheard" (a config gap) unless we can
+    // prove we truly heard nothing.
     const members = reconcileNetworkMembership({
       admitted: ["jc"],
       presentStacksByPrincipal: present({}),
     });
     expect(members).toEqual([
-      { principal: "jc", verdict: "admitted-absent", presentStacks: [] },
+      { principal: "jc", verdict: "absent-offline", presentStacks: [] },
+    ]);
+  });
+
+  // --- FS-6 (cortex#1821): honest absence — the 3 verdict cases -------------
+
+  it("FS-6 live: admitted + present → admitted-present (receipt ledger irrelevant)", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["jc"],
+      presentStacksByPrincipal: present({ jc: ["research"] }),
+      // Even with a receipt, a PRESENT peer is present — the ledger only splits
+      // the ABSENT family.
+      everReceivedPresence: new Set(["jc"]),
+    });
+    expect(members).toEqual([
+      { principal: "jc", verdict: "admitted-present", presentStacks: ["research"] },
+    ]);
+  });
+
+  it("FS-6 offline: admitted + absent + PREVIOUSLY-received → absent-offline (heard, went stale)", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["jc"],
+      presentStacksByPrincipal: present({}),
+      everReceivedPresence: new Set(["jc"]), // we HAVE heard jc before
+    });
+    expect(members).toEqual([
+      { principal: "jc", verdict: "absent-offline", presentStacks: [] },
+    ]);
+  });
+
+  it("FS-6 unheard: admitted + absent + NEVER-received → absent-unheard (deaf to it — import/cred gap)", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["jc"],
+      presentStacksByPrincipal: present({}),
+      everReceivedPresence: new Set<string>(), // never heard jc
+    });
+    expect(members).toEqual([
+      { principal: "jc", verdict: "absent-unheard", presentStacks: [] },
+    ]);
+  });
+
+  it("FS-6 mixed roster: splits offline vs unheard per-peer off the same ledger", () => {
+    const members = reconcileNetworkMembership({
+      admitted: ["heard-peer", "deaf-peer", "live-peer"],
+      presentStacksByPrincipal: present({ "live-peer": ["main"] }),
+      everReceivedPresence: new Set(["heard-peer", "live-peer"]),
+    });
+    expect(members).toEqual([
+      { principal: "heard-peer", verdict: "absent-offline", presentStacks: [] },
+      { principal: "deaf-peer", verdict: "absent-unheard", presentStacks: [] },
+      { principal: "live-peer", verdict: "admitted-present", presentStacks: ["main"] },
     ]);
   });
 
@@ -137,14 +190,14 @@ describe("reconcileNetworkMembership — precedence + determinism", () => {
     expect(members.find((m) => m.principal === "a")?.presentStacks).toEqual(["s1", "s2"]);
   });
 
-  it("capabilities never confer membership — an admitted-absent member with no presence stays absent regardless of any capability facet", () => {
+  it("capabilities never confer membership — an absent member with no presence stays absent regardless of any capability facet", () => {
     // The helper has no capability input at all; this asserts the contract by
     // construction — membership is roster ⋈ presence only.
     const members = reconcileNetworkMembership({
       admitted: ["offerer"],
       presentStacksByPrincipal: present({}),
     });
-    expect(members[0]?.verdict).toBe("admitted-absent");
+    expect(members[0]?.verdict).toBe("absent-offline");
   });
 });
 

--- a/src/surface/mc/api/networks-membership.ts
+++ b/src/surface/mc/api/networks-membership.ts
@@ -24,7 +24,17 @@
  *
  * The verdict per member:
  *   - `admitted-present`        — on the roster AND observed present.
- *   - `admitted-absent`         — on the roster but not observed present.
+ *   - `absent-offline`          — on the roster, not observed present, but we
+ *                                 HAVE received its federated presence before
+ *                                 (FS-6): we heard it, it went away. A real,
+ *                                 transient outage of the peer's stack.
+ *   - `absent-unheard`          — on the roster, not observed present, and we
+ *                                 have NEVER received a single federated-presence
+ *                                 envelope from it (FS-6): we are DEAF to it —
+ *                                 the peer may be healthy, but an import / cred /
+ *                                 accept-list gap (the cortex#1812 class) means
+ *                                 nothing reaches us. Actionable: "check
+ *                                 import/cred", not "wait for the peer".
  *   - `present-but-unadmitted`  — observed present (federated) but on no roster
  *                                 — an ANOMALY worth surfacing (e.g. a stale
  *                                 roster, or a hand-pinned static peer with no
@@ -34,6 +44,17 @@
  *                                 roster carries ADMITTED rows only — so the
  *                                 endpoint passes none; the verdict exists so
  *                                 A2/A3/B build on a complete model.)
+ *
+ * ## FS-6 (cortex#1821) — honest absence
+ *
+ * The absent family is SPLIT by whether we have ever received the peer's
+ * federated presence (the `everReceivedPresence` set, sourced from the
+ * federated-presence subscriber's per-peer receipt ledger). Never-received ⇒
+ * `absent-unheard`; previously-received-now-stale ⇒ `absent-offline`. When the
+ * set is not supplied (an older wiring / a self-only read that carries no
+ * federation receipts), the absent family collapses to `absent-offline` — the
+ * conservative default: we do not claim "unheard" (which asserts a config gap)
+ * unless we have the receipt ledger to prove we truly heard nothing.
  *
  * Pure + dependency-light: no I/O, no bus, no registry client. The only import
  * is the structural presence-record TYPE from the sibling `/api/agents`
@@ -49,7 +70,8 @@ import type { AgentPresenceSnapshotRecord } from "./agents";
  */
 export type MembershipVerdict =
   | "admitted-present"
-  | "admitted-absent"
+  | "absent-offline"
+  | "absent-unheard"
   | "present-but-unadmitted"
   | "pending";
 
@@ -96,6 +118,32 @@ export interface ReconcileMembershipInput {
    * `admitted` / `pending` is never an anomaly.
    */
   anomalyCandidates?: readonly string[];
+  /**
+   * FS-6 (cortex#1821) — the set of peer principals from whom we have EVER
+   * received a federated-presence envelope (folded OR gated), sourced from the
+   * federated-presence subscriber's per-peer receipt ledger. Splits the absent
+   * family: an admitted-but-absent principal IN this set ⇒ `absent-offline`
+   * (heard, went stale); NOT in it ⇒ `absent-unheard` (never heard — an
+   * import/cred gap). OMITTED (undefined) ⇒ the absent family collapses to
+   * `absent-offline`: without the receipt ledger we never assert "unheard" (the
+   * conservative default — do not claim a config gap we cannot prove).
+   */
+  everReceivedPresence?: ReadonlySet<string>;
+}
+
+/**
+ * FS-6 (cortex#1821) — the absent-family verdict for an admitted-but-not-present
+ * principal. Heard-before (in `everReceived`) ⇒ `absent-offline`; never-heard ⇒
+ * `absent-unheard`. When `everReceived` is undefined (no receipt ledger wired)
+ * the honest default is `absent-offline` — we do NOT assert "unheard" (a config
+ * gap) unless we can prove we truly heard nothing.
+ */
+function absentVerdict(
+  principal: string,
+  everReceived: ReadonlySet<string> | undefined,
+): "absent-offline" | "absent-unheard" {
+  if (everReceived === undefined) return "absent-offline";
+  return everReceived.has(principal) ? "absent-offline" : "absent-unheard";
 }
 
 /**
@@ -114,6 +162,7 @@ export function reconcileNetworkMembership(
   const { admitted, presentStacksByPrincipal } = input;
   const pending = input.pending ?? [];
   const anomalyCandidates = input.anomalyCandidates ?? [];
+  const everReceivedPresence = input.everReceivedPresence;
 
   const seen = new Set<string>();
   const members: MembershipMember[] = [];
@@ -127,14 +176,21 @@ export function reconcileNetworkMembership(
   const isPresent = (principal: string): boolean =>
     stacksOf(principal).length > 0;
 
-  // 1) Admitted roster (intent). Present → admitted-present, else admitted-absent.
+  // 1) Admitted roster (intent). Present → admitted-present; else FS-6 splits
+  //    absent by whether we have EVER received this peer's federated presence:
+  //    heard-before ⇒ absent-offline (it went away), never-heard ⇒ absent-unheard
+  //    (we are deaf to it — an import/cred gap). Without the receipt ledger the
+  //    absent family collapses to absent-offline (never over-claim "unheard").
   for (const principal of admitted) {
     if (seen.has(principal)) continue;
     seen.add(principal);
     const presentStacks = stacksOf(principal);
     members.push({
       principal,
-      verdict: presentStacks.length > 0 ? "admitted-present" : "admitted-absent",
+      verdict:
+        presentStacks.length > 0
+          ? "admitted-present"
+          : absentVerdict(principal, everReceivedPresence),
       presentStacks,
     });
   }

--- a/src/surface/mc/api/networks.ts
+++ b/src/surface/mc/api/networks.ts
@@ -110,6 +110,16 @@ export interface NetworksView {
    * otherwise (default-deny). `cortex.ts` supplies the live resolver.
    */
   acceptsPeer?(networkId: string, memberPrincipal: string): PeerAcceptance;
+  /**
+   * FS-6 (cortex#1821) — have we EVER received a federated-presence envelope from
+   * this peer principal (folded OR gated)? Sourced from the federated-presence
+   * subscriber's per-peer receipt ledger. The handler uses it to split an
+   * admitted-but-absent member into `absent-offline` (true — heard, went stale)
+   * vs `absent-unheard` (false — never heard; an import/cred gap). OPTIONAL: when
+   * omitted (older wiring / a test stub / a stack with no federation) the absent
+   * family collapses to `absent-offline` — we never over-claim "unheard".
+   */
+  receivedPresenceFrom?: (memberPrincipal: string) => boolean;
 }
 
 /** Provenance/availability of a network's admission-rows read. */
@@ -284,6 +294,25 @@ function toRosterMemberStateDTO(s: {
 }
 
 /**
+ * FS-6 (cortex#1821) — build the "ever received federated presence" set for a
+ * network's roster, querying the view's receipt seam once per candidate
+ * principal. Covers admitted + pending members (the set the absent-family split
+ * evaluates). Pure; the predicate is the only side of the seam.
+ */
+function buildEverReceived(
+  admitted: readonly string[],
+  pending: readonly string[],
+  receivedPresenceFrom: (memberPrincipal: string) => boolean,
+): Set<string> {
+  const heard = new Set<string>();
+  for (const principal of [...admitted, ...pending]) {
+    if (heard.has(principal)) continue;
+    if (receivedPresenceFrom(principal)) heard.add(principal);
+  }
+  return heard;
+}
+
+/**
  * Handle `GET /api/networks`.
  *
  * `view === null` → empty list (no federation / no registry — graceful). Else,
@@ -377,11 +406,20 @@ export async function handleListNetworks(
       // Attach anomalies ONLY for an authoritative roster — a self-scoped or
       // failed read cannot prove a present peer is unadmitted.
       const authoritative = result.ok && result.roster.authoritative;
+      // FS-6 (cortex#1821) — the receipt-derived "ever heard" set for THIS
+      // network's roster members. Built ONLY when the view exposes the receipt
+      // seam; otherwise omitted so the reconciler collapses the absent family to
+      // `absent-offline` (never over-claim "unheard" without the ledger).
+      const everReceivedPresence =
+        view.receivedPresenceFrom !== undefined
+          ? buildEverReceived(admitted, pending, view.receivedPresenceFrom)
+          : undefined;
       const members = reconcileNetworkMembership({
         admitted,
         presentStacksByPrincipal,
         pending,
         ...(authoritative ? { anomalyCandidates: globalAnomalies } : {}),
+        ...(everReceivedPresence !== undefined ? { everReceivedPresence } : {}),
       });
 
       return {

--- a/src/surface/mc/dashboard-v2/__tests__/network-constellation-header.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-constellation-header.test.ts
@@ -65,7 +65,7 @@ describe("buildConstellationHeader", () => {
           { principal: "andreas", verdict: "admitted-present", present_stacks: ["research", "work"], accepts: "self" },
           { principal: "jc", verdict: "admitted-present", present_stacks: ["research"], accepts: "accepted-network" },
           // duplicate principal/stack must not double-count
-          { principal: "andreas", verdict: "admitted-absent", present_stacks: ["research"], accepts: "self" },
+          { principal: "andreas", verdict: "absent-offline", present_stacks: ["research"], accepts: "self" },
         ],
       }),
     ]);
@@ -77,7 +77,7 @@ describe("buildConstellationHeader", () => {
     const [row] = buildConstellationHeader([
       net({
         members: [
-          { principal: "jc", verdict: "admitted-absent", present_stacks: [], accepts: "accepted-network" },
+          { principal: "jc", verdict: "absent-offline", present_stacks: [], accepts: "accepted-network" },
         ],
       }),
     ]);

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-adapter.test.ts
@@ -635,7 +635,7 @@ function member(
   present_stacks: string[],
   verdict: NetworkMembershipDTO["members"][number]["verdict"] = present_stacks.length
     ? "admitted-present"
-    : "admitted-absent",
+    : "absent-offline",
 ): NetworkMembershipDTO["members"][number] {
   return { principal, verdict, present_stacks, accepts: "accepted-network" };
 }
@@ -665,7 +665,7 @@ describe("buildNetworkGraph — absent federated peers (MC-D4)", () => {
     expect(data.kind).toBe("federated-peer");
     expect(data.principal).toBe("jc");
     expect(data.networkId).toBe("mfnet");
-    expect(data.verdict).toBe("admitted-absent");
+    expect(data.verdict).toBe("absent-offline");
 
     // The dotted anchor edge: local hub → the peer placeholder, flagged absent.
     const edge = g.edges.find((e) => e.target === peerId);

--- a/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-graph-layout.test.ts
@@ -93,7 +93,7 @@ function member(
 ): NetworkMembershipDTO["members"][number] {
   return {
     principal,
-    verdict: present_stacks.length ? "admitted-present" : "admitted-absent",
+    verdict: present_stacks.length ? "admitted-present" : "absent-offline",
     present_stacks,
     accepts: "accepted-network",
   };

--- a/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/network-membership-adapter.test.ts
@@ -16,7 +16,10 @@ import type { NetworkConfidentialityDTO, PeerAcceptance } from "../../api/networ
 describe("verdictBadge", () => {
   it("maps each verdict to a distinct tone", () => {
     expect(verdictBadge("admitted-present").tone).toBe("ok");
-    expect(verdictBadge("admitted-absent").tone).toBe("warn");
+    // FS-6 — the absent family split: offline is a warn, unheard is danger
+    // (we are deaf to it — an import/cred gap, the more serious signal).
+    expect(verdictBadge("absent-offline").tone).toBe("warn");
+    expect(verdictBadge("absent-unheard").tone).toBe("danger");
     expect(verdictBadge("present-but-unadmitted").tone).toBe("danger");
     expect(verdictBadge("pending").tone).toBe("pending");
   });
@@ -24,7 +27,8 @@ describe("verdictBadge", () => {
   it("gives every verdict a non-empty label + title", () => {
     for (const v of [
       "admitted-present",
-      "admitted-absent",
+      "absent-offline",
+      "absent-unheard",
       "present-but-unadmitted",
       "pending",
     ] as const) {
@@ -171,18 +175,20 @@ describe("summarizeMembership", () => {
     const summary = summarizeMembership({
       members: [
         { principal: "a", verdict: "admitted-present", present_stacks: ["s"], accepts: "accepted-network" },
-        { principal: "b", verdict: "admitted-absent", present_stacks: [], accepts: "not-accepted" },
+        { principal: "b", verdict: "absent-offline", present_stacks: [], accepts: "not-accepted" },
         { principal: "c", verdict: "admitted-present", present_stacks: ["s"], accepts: "accepted-named" },
         { principal: "d", verdict: "present-but-unadmitted", present_stacks: ["x"], accepts: "not-accepted" },
         { principal: "e", verdict: "pending", present_stacks: [], accepts: "not-accepted" },
+        // FS-6 — both absent-family verdicts roll into the single `absent` tally.
+        { principal: "f", verdict: "absent-unheard", present_stacks: [], accepts: "not-accepted" },
       ],
     });
     expect(summary).toEqual({
       present: 2,
-      absent: 1,
+      absent: 2,
       unadmitted: 1,
       pending: 1,
-      total: 5,
+      total: 6,
     });
   });
 

--- a/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-nodes.test.tsx
@@ -473,7 +473,7 @@ describe("FederatedPeerCard (MC-D4 — absent admitted peer)", () => {
     const data: FederatedPeerNodeData = {
       kind: "federated-peer",
       principal: "jc",
-      verdict: "admitted-absent",
+      verdict: "absent-offline",
       networkId: "mfnet",
       ...over,
     };
@@ -487,17 +487,32 @@ describe("FederatedPeerCard (MC-D4 — absent admitted peer)", () => {
     expect(html).toContain('data-fed-peer-absent="true"');
     // The principal id is the visible label.
     expect(html).toContain(">jc<");
-    // The `federated · absent` sublabel.
-    expect(html).toContain("federated · absent");
+    // FS-6 — an offline peer carries the `federated · offline` sublabel + token.
+    expect(html).toContain("federated · offline");
+    expect(html).toContain('data-fed-peer-absence="offline"');
     // The muted orb class (no glow — styled in CSS).
     expect(html).toContain("network-node-orb-fed-peer");
-    // An accessible name marking it admitted + absent.
-    expect(html).toContain("federated peer (admitted, absent)");
+    // An accessible name marking it admitted + offline.
+    expect(html).toContain("federated peer (admitted, offline)");
   });
 
   it("carries the membership verdict as a data attribute", () => {
-    const html = render({ verdict: "admitted-absent" });
-    expect(html).toContain('data-fed-peer-verdict="admitted-absent"');
+    const html = render({ verdict: "absent-offline" });
+    expect(html).toContain('data-fed-peer-verdict="absent-offline"');
+  });
+
+  it("FS-6 — an UNHEARD peer renders the distinct check-import/cred reason", () => {
+    // The absent-unheard case: we are DEAF to this peer (never received its
+    // federated presence). It must read distinct from a plain offline peer —
+    // different eyebrow, different stable absence token, a danger tone class.
+    const html = render({ verdict: "absent-unheard" });
+    expect(html).toContain('data-fed-peer-verdict="absent-unheard"');
+    expect(html).toContain('data-fed-peer-absence="unheard"');
+    expect(html).toContain("federated · unheard");
+    expect(html).toContain("tone-danger");
+    expect(html).toContain("federated peer (admitted, unheard)");
+    // NOT the offline label.
+    expect(html).not.toContain("federated · offline");
   });
 
   it("renders a cross-network glyph so it reads as a federated (not local) node", () => {
@@ -524,7 +539,7 @@ describe("FederatedPeerCard (MC-D4 — absent admitted peer)", () => {
     const html = render();
     const eyebrows = html.match(/network-fed-peer-eyebrow/g) ?? [];
     expect(eyebrows).toHaveLength(1);
-    const sublabels = html.match(/federated · absent/g) ?? [];
+    const sublabels = html.match(/federated · offline/g) ?? [];
     expect(sublabels).toHaveLength(1);
     // The card must NOT hand React Flow a default `label` prop it would render
     // as a second (bordered, lowercase) label box.

--- a/src/surface/mc/dashboard-v2/__tests__/network-roster-panel-flg4.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-roster-panel-flg4.test.tsx
@@ -29,7 +29,7 @@ function net(states: RosterMemberStateDTO[]): NetworkMembershipDTO {
     confidentiality: CLEARTEXT,
     members: [
       { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
-      { principal: "jc", verdict: "admitted-absent", present_stacks: [], accepts: "accepted-network" },
+      { principal: "jc", verdict: "absent-offline", present_stacks: [], accepts: "accepted-network" },
     ],
     roster_states: states,
   };

--- a/src/surface/mc/dashboard-v2/__tests__/network-roster-panel.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-roster-panel.test.tsx
@@ -101,7 +101,7 @@ describe("NetworkRosterPanel — per-principal acceptance chip (MC-A2)", () => {
       netWithMembers([
         { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
         { principal: "jc", verdict: "admitted-present", present_stacks: ["research"], accepts: "accepted-network" },
-        { principal: "mallory", verdict: "admitted-absent", present_stacks: [], accepts: "not-accepted" },
+        { principal: "mallory", verdict: "absent-offline", present_stacks: [], accepts: "not-accepted" },
       ]),
     ]);
     expect(html).toContain('data-acceptance="accepted-network"');

--- a/src/surface/mc/dashboard-v2/__tests__/pier-queue-adapter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/pier-queue-adapter.test.ts
@@ -82,7 +82,7 @@ describe("selectPierQueue", () => {
         network_id: "alpha",
         members: [
           member({ principal: "a", verdict: "admitted-present", present_stacks: ["s"] }),
-          member({ principal: "b", verdict: "admitted-absent" }),
+          member({ principal: "b", verdict: "absent-offline" }),
           member({ principal: "c", verdict: "present-but-unadmitted", present_stacks: ["x"] }),
           member({ principal: "d", verdict: "pending" }),
         ],

--- a/src/surface/mc/dashboard-v2/components/network-nodes.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-nodes.tsx
@@ -53,6 +53,7 @@ import {
   isInSubtreeHighlight,
 } from "../lib/network-subtree-highlight";
 import { verdictBadge, formatRtt } from "../lib/network-transport-overlay";
+import { federatedAbsenceReason } from "../lib/network-membership-adapter";
 
 // --- Stack hub -------------------------------------------------------------
 
@@ -495,14 +496,19 @@ export interface FederatedPeerCardProps {
  * inner/wrapper like the other nodes (the wrapper adds the xyflow `Handle`).
  */
 export function FederatedPeerCard({ data }: FederatedPeerCardProps) {
+  // FS-6 (cortex#1821) — the honest absence reason (offline vs unheard) drives
+  // the eyebrow + a tone class, so an admitted peer we are DEAF to (unheard —
+  // import/cred gap) reads distinct from a peer that merely went offline.
+  const reason = federatedAbsenceReason(data.verdict);
   return (
     <div
-      className="network-node network-node-fed-peer network-node-fed-peer-absent"
+      className={`network-node network-node-fed-peer network-node-fed-peer-absent tone-${reason.tone}`}
       data-node-kind="federated-peer"
       data-fed-peer-principal={data.principal}
       data-fed-peer-verdict={data.verdict}
       data-fed-peer-absent="true"
-      aria-label={`${data.principal} — federated peer (admitted, absent)`}
+      data-fed-peer-absence={reason.token}
+      aria-label={`${data.principal} — federated peer (admitted, ${reason.token})`}
     >
       {/* A dashed federation-accent ring with a cross-network glyph — visible and
           deliberately distinct from a local agent orb (which is a solid cyan
@@ -515,7 +521,7 @@ export function FederatedPeerCard({ data }: FederatedPeerCardProps) {
         <span className="network-fed-peer-glyph">⇄</span>
       </span>
       <span className="network-node-below">
-        <span className="network-fed-peer-eyebrow dim">federated · absent</span>
+        <span className="network-fed-peer-eyebrow dim">{reason.eyebrow}</span>
         <span className="network-fed-peer-label">{data.principal}</span>
       </span>
     </div>

--- a/src/surface/mc/dashboard-v2/hooks/use-networks.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-networks.ts
@@ -4,7 +4,7 @@
  * Fetches `GET /api/networks` (joined networks + their admitted roster ⋈
  * presence → membership verdict) and keeps it fresh off the same
  * `agent.presence` WebSocket refresh signal `use-agents` uses — a presence
- * mutation can flip a member between `admitted-present` / `admitted-absent`, so a
+ * mutation can flip a member between `admitted-present` / `absent-offline` / `absent-unheard`, so a
  * presence frame re-reads the membership too.
  *
  * Mirrors `use-agents` exactly (lifetime/race guard via `aliveRef` + `genRef` +

--- a/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
@@ -45,11 +45,19 @@ export function verdictBadge(verdict: MembershipVerdict): VerdictBadge {
         tone: "ok",
         title: "Admitted to the roster and observed present",
       };
-    case "admitted-absent":
+    case "absent-offline":
       return {
-        label: "absent",
+        label: "absent (offline)",
         tone: "warn",
-        title: "Admitted to the roster but not observed present",
+        title:
+          "Admitted to the roster but not observed present. We HAVE received this peer's federated presence before — it has since gone away (a transient outage of the peer's stack). Wait for it to return.",
+      };
+    case "absent-unheard":
+      return {
+        label: "absent (unheard — check import/cred)",
+        tone: "danger",
+        title:
+          "Admitted to the roster but not observed present, AND we have NEVER received a single federated-presence envelope from it. We are DEAF to this peer: the peer may be healthy, but an import / cred / accept-list gap means nothing reaches us. Actionable: check the import/cred wiring, not the peer.",
       };
     case "present-but-unadmitted":
       return {
@@ -64,6 +72,37 @@ export function verdictBadge(verdict: MembershipVerdict): VerdictBadge {
         tone: "pending",
         title: "Admission request pending — not yet admitted",
       };
+  }
+}
+
+/**
+ * FS-6 (cortex#1821) — the absent federated-peer NODE's eyebrow + tone, derived
+ * from its absent-family verdict. The constellation node can't fit the full
+ * roster badge, so this gives it a compact, HONEST sublabel:
+ *
+ *   - `absent-offline` → `federated · offline` (heard before, went away).
+ *   - `absent-unheard` → `federated · unheard` (never heard — an import/cred gap),
+ *     flagged `danger` so the deaf-to-peer case is visually distinct from a plain
+ *     transient outage.
+ *   - any other/legacy absent value → `federated · absent` (the pre-FS-6 label),
+ *     so an older server DTO still renders sensibly.
+ *
+ * `token` is a stable, non-localized `data-*` value for tests/automation.
+ */
+export interface FederatedAbsenceReason {
+  eyebrow: string;
+  tone: VerdictTone;
+  token: "offline" | "unheard" | "absent";
+}
+
+export function federatedAbsenceReason(verdict: string): FederatedAbsenceReason {
+  switch (verdict) {
+    case "absent-offline":
+      return { eyebrow: "federated · offline", tone: "warn", token: "offline" };
+    case "absent-unheard":
+      return { eyebrow: "federated · unheard", tone: "danger", token: "unheard" };
+    default:
+      return { eyebrow: "federated · absent", tone: "warn", token: "absent" };
   }
 }
 
@@ -493,7 +532,11 @@ export function summarizeMembership(
       case "admitted-present":
         summary.present += 1;
         break;
-      case "admitted-absent":
+      case "absent-offline":
+      case "absent-unheard":
+        // Both absent-family verdicts roll up into the single `absent` tally for
+        // the panel header summary (the row badge + node eyebrow carry the FS-6
+        // offline/unheard distinction; the header stays a coarse count).
         summary.absent += 1;
         break;
       case "present-but-unadmitted":


### PR DESCRIPTION
Closes #1821. Part of epic #1818 (Federation simplification), Wave 0.

Splits an admitted-but-absent peer into **`absent-offline`** (heard, went away) vs **`absent-unheard`** (never heard — import/cred gap). The system already knew which case it was in (zero inbound `federated.{peer}.{stack}.agent.*` ⇒ unheard); it just never said. This is the diagnostic that turns "jc shows absent" from a mystery into an actionable "unheard — check import/cred".

## What changed
- New `FederatedPresenceReceipts` ledger — records the source principal on **every** subject-matched presence envelope, **before** the accept-list/chain gates (so a peer we can physically hear but policy drops reads `absent-offline`, never the misleading `absent-unheard` — the honesty invariant).
- `MembershipVerdict` union splits `admitted-absent` → `absent-offline | absent-unheard`; reconciler consumes an `everReceivedPresence` set.
- Roster badge + constellation node render the distinct reason (`unheard` flagged danger — the actionable signal).
- Conservative default: receipt seam absent ⇒ collapses to `absent-offline` (never over-claims a config gap).

## Verification (fresh worktree)
- `bunx tsc --noEmit` → 0 errors; `bunx eslint --quiet` → clean.
- `bun test` affected sweep → 2427 pass, 1 skip, 0 fail (172 files).
- Additive (`--diff-filter=D` empty); no id-shaped literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)