### PR TITLE
feat(mc): FS-8a — legacy standalone MC entry exits with a pointer (no blank-screen trapdoor)

### DIFF
--- a/src/surface/mc/__tests__/index.test.ts
+++ b/src/surface/mc/__tests__/index.test.ts
@@ -20,8 +20,11 @@ async function spawnBoot(
   env: Record<string, string>,
   timeoutMs = 8000
 ): Promise<{ exitCode: number; stderr: string }> {
+  // The standalone entry is retired for production (FS-8a, #1822): run as a
+  // plain entrypoint it prints a pointer and exits non-zero. The integration
+  // harness opts into the real boot via the `--legacy` escape hatch.
   const proc = Bun.spawn({
-    cmd: ["bun", "run", ENTRY],
+    cmd: ["bun", "run", ENTRY, "--legacy"],
     env: { ...process.env, ...env },
     stderr: "pipe",
     stdout: "pipe",

--- a/src/surface/mc/__tests__/legacy-entry-guard.test.ts
+++ b/src/surface/mc/__tests__/legacy-entry-guard.test.ts
@@ -14,6 +14,17 @@ import { legacyBootAllowed, RETIRED_POINTER } from "../index";
 
 const ENTRY = new URL("../index.ts", import.meta.url).pathname;
 
+/**
+ * A config path that EXISTS but cannot be read as a file — this test directory
+ * itself. `loadConfig` does `existsSync(path)` (true for a dir) then
+ * `readFileSync(path)`, which throws `EISDIR`; loadConfig rethrows and
+ * `bootLegacy` maps it to the `[mission-control] FATAL: <msg>` + exit-1 NFR
+ * contract. A *nonexistent* path would instead fall through to DEFAULT_CONFIG
+ * and boot a real long-lived server on :8767 — hanging the test until timeout.
+ * We want the boot path REACHED and then failed fast, not a live server.
+ */
+const UNREADABLE_CONFIG_DIR = new URL(".", import.meta.url).pathname;
+
 async function spawnEntry(
   argv: string[],
   env: Record<string, string>,
@@ -57,12 +68,13 @@ describe("mission-control legacy entry — production-entrypoint guard (FS-8a)",
   });
 
   it("attempts the legacy boot under the --legacy escape hatch (test-harness path unaffected)", async () => {
-    // With the hatch present, the guard hands off to the real boot. We give it
-    // no config, so it hits the NFR failure contract (FATAL + exit 1) rather
-    // than the retirement pointer — proving the boot path was reached, not the
-    // guard's refusal.
+    // With the hatch present, the guard hands off to the real boot. We point it
+    // at an unreadable config (a directory), so it hits the NFR failure contract
+    // (FATAL + exit 1) rather than the retirement pointer — proving the boot
+    // path was reached, not the guard's refusal, and without standing up a
+    // real long-lived server on :8767.
     const { exitCode, stderr } = await spawnEntry(["--legacy"], {
-      MC_CONFIG_PATH: "/nonexistent/definitely/not/here/mc.yaml",
+      MC_CONFIG_PATH: UNREADABLE_CONFIG_DIR,
     });
 
     expect(stderr).not.toContain("retired for production");
@@ -73,7 +85,7 @@ describe("mission-control legacy entry — production-entrypoint guard (FS-8a)",
   it("attempts the legacy boot under the MC_LEGACY_BOOT env escape hatch", async () => {
     const { exitCode, stderr } = await spawnEntry([], {
       MC_LEGACY_BOOT: "1",
-      MC_CONFIG_PATH: "/nonexistent/definitely/not/here/mc.yaml",
+      MC_CONFIG_PATH: UNREADABLE_CONFIG_DIR,
     });
 
     expect(stderr).not.toContain("retired for production");

--- a/src/surface/mc/__tests__/legacy-entry-guard.test.ts
+++ b/src/surface/mc/__tests__/legacy-entry-guard.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "bun:test";
+import { legacyBootAllowed, RETIRED_POINTER } from "../index";
+
+/**
+ * FS-8a (#1822): the legacy standalone Grove MC v2 entry is retired for
+ * production. Run as a plain production entrypoint it MUST print a pointer to
+ * the in-process MC and exit non-zero — never squat :8767 with a dead server.
+ * The integration-test harness keeps working via the `--legacy` / MC_LEGACY_BOOT
+ * escape hatch.
+ *
+ * These tests spawn the entry as a real subprocess (the production-shaped
+ * invocation) to assert the guard at the boundary the principal actually hits.
+ */
+
+const ENTRY = new URL("../index.ts", import.meta.url).pathname;
+
+async function spawnEntry(
+  argv: string[],
+  env: Record<string, string>,
+  timeoutMs = 8000
+): Promise<{ exitCode: number; stderr: string }> {
+  const proc = Bun.spawn({
+    cmd: ["bun", "run", ENTRY, ...argv],
+    env: { ...process.env, ...env },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const timer = setTimeout(() => proc.kill(), timeoutMs);
+  const exitCode = await proc.exited;
+  clearTimeout(timer);
+
+  const stderr = await new Response(proc.stderr).text();
+  return { exitCode: exitCode ?? -1, stderr };
+}
+
+describe("mission-control legacy entry — production-entrypoint guard (FS-8a)", () => {
+  it("prints the retirement pointer and exits non-zero when run as a prod entry", async () => {
+    // No escape hatch: neither --legacy nor MC_LEGACY_BOOT. Strip any inherited
+    // MC_LEGACY_BOOT so the parent env can't accidentally satisfy the hatch.
+    const { exitCode, stderr } = await spawnEntry([], { MC_LEGACY_BOOT: "" });
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("retired for production");
+    expect(stderr).toContain("mc.enabled: true");
+    expect(stderr).toContain("agent-presence registry");
+    // It must NOT have tried to boot the dead server.
+    expect(stderr).not.toContain("listening on http://localhost");
+  });
+
+  it("does NOT boot a server on the prod-entry path (no :8767 squat)", async () => {
+    const { exitCode, stderr } = await spawnEntry([], { MC_LEGACY_BOOT: "0" });
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).not.toContain("listening on http://localhost");
+    expect(stderr).not.toContain("hook poller");
+  });
+
+  it("attempts the legacy boot under the --legacy escape hatch (test-harness path unaffected)", async () => {
+    // With the hatch present, the guard hands off to the real boot. We give it
+    // no config, so it hits the NFR failure contract (FATAL + exit 1) rather
+    // than the retirement pointer — proving the boot path was reached, not the
+    // guard's refusal.
+    const { exitCode, stderr } = await spawnEntry(["--legacy"], {
+      MC_CONFIG_PATH: "/nonexistent/definitely/not/here/mc.yaml",
+    });
+
+    expect(stderr).not.toContain("retired for production");
+    expect(stderr).toContain("[mission-control] FATAL:");
+    expect(exitCode).toBe(1);
+  });
+
+  it("attempts the legacy boot under the MC_LEGACY_BOOT env escape hatch", async () => {
+    const { exitCode, stderr } = await spawnEntry([], {
+      MC_LEGACY_BOOT: "1",
+      MC_CONFIG_PATH: "/nonexistent/definitely/not/here/mc.yaml",
+    });
+
+    expect(stderr).not.toContain("retired for production");
+    expect(stderr).toContain("[mission-control] FATAL:");
+    expect(exitCode).toBe(1);
+  });
+});
+
+describe("legacyBootAllowed — escape-hatch predicate (unit)", () => {
+  it("is true for the --legacy flag", () => {
+    expect(legacyBootAllowed(["--legacy"], {})).toBe(true);
+  });
+
+  it("is true for a truthy MC_LEGACY_BOOT", () => {
+    expect(legacyBootAllowed([], { MC_LEGACY_BOOT: "1" })).toBe(true);
+    expect(legacyBootAllowed([], { MC_LEGACY_BOOT: "true" })).toBe(true);
+  });
+
+  it("is false with no escape hatch and for falsy env sentinels", () => {
+    expect(legacyBootAllowed([], {})).toBe(false);
+    expect(legacyBootAllowed([], { MC_LEGACY_BOOT: "" })).toBe(false);
+    expect(legacyBootAllowed([], { MC_LEGACY_BOOT: "0" })).toBe(false);
+    expect(legacyBootAllowed([], { MC_LEGACY_BOOT: "false" })).toBe(false);
+  });
+
+  it("exposes a pointer that names the in-process replacement", () => {
+    expect(RETIRED_POINTER).toContain("mc.enabled: true");
+    expect(RETIRED_POINTER).toContain("agent-presence registry");
+  });
+});

--- a/src/surface/mc/index.ts
+++ b/src/surface/mc/index.ts
@@ -1,10 +1,23 @@
 /**
- * Grove Mission Control v2 — entry point.
+ * Grove Mission Control v2 — legacy standalone entry point.
  *
- * Usage: bun run src/mission-control/index.ts
+ * RETIRED FOR PRODUCTION (FS-8a, issue #1822). Mission Control now runs
+ * IN-PROCESS inside the cortex daemon: set `mc.enabled: true` in your stack
+ * config and it serves on the daemon's port, fed by the agent-presence
+ * registry (`startAgentPresenceRegistry`). This standalone entry used to boot
+ * a server on :8767 fed by nothing current — a blank Network view that cost a
+ * principal a day before they learned the MC had moved in-process.
+ *
+ * The boot path below is preserved ONLY for the integration-test harness,
+ * which spawns this file as a subprocess to exercise the boot failure modes.
+ * The harness opts in via the `--legacy` flag or `MC_LEGACY_BOOT=1` env. Run
+ * as a plain production entrypoint (no escape hatch), it prints a pointer and
+ * exits non-zero instead of squatting the port with a dead server.
+ *
+ * Usage (test harness only): bun run src/surface/mc/index.ts --legacy
  *
  * Honors MC_CONFIG_PATH env var to override the default config location
- * (used by integration tests; production reads ~/.config/grove/mission-control.yaml).
+ * (used by integration tests; production reads the daemon's stack config).
  *
  * Boot is wrapped in try/catch to honor the spec NFR contract:
  *   - On any boot failure: write `[mission-control] FATAL: <msg>` to stderr
@@ -17,39 +30,84 @@ import { startServer } from "./server";
 import { ProcessManager } from "./session/process-manager";
 import { HookStreamPoller } from "./hooks/poller";
 
-try {
-  const config = loadConfig(process.env.MC_CONFIG_PATH);
-  const db = initDatabase(config.db.path);
-  const processManager = new ProcessManager();
-  const serverCtx = startServer(config, db, { processManager });
-  const { server, wsRegistry } = serverCtx;
-  const hookPoller = new HookStreamPoller(db, config.hooks, wsRegistry);
+/**
+ * The pointer shown when the legacy standalone entry is run as a production
+ * entrypoint. Directs the principal to the in-process MC.
+ */
+const RETIRED_POINTER =
+  "[mission-control] This standalone Grove MC v2 entry is retired for production.\n" +
+  "[mission-control] Mission Control now runs IN-PROCESS in the cortex daemon:\n" +
+  "[mission-control]   - set `mc.enabled: true` in your stack config\n" +
+  "[mission-control]   - it serves on the daemon's port, fed by the agent-presence registry\n" +
+  "[mission-control] See docs/design-federation-simplification.md (FS-8) for context.\n" +
+  "[mission-control] Run with --legacy (or MC_LEGACY_BOOT=1) only for the integration-test harness.\n";
 
-  hookPoller.start();
-
-  process.stderr.write(
-    `[mission-control] v0.1.0 listening on http://localhost:${server.port}\n` +
-      `[mission-control] db: ${config.db.path}\n` +
-      `[mission-control] hook poller: ${config.hooks.rawEventsDir} (${config.hooks.pollInterval}ms)\n`
-  );
-
-  const shutdown = async () => {
-    process.stderr.write("[mission-control] shutting down...\n");
-    hookPoller.stop();
-    const killed = await processManager.closeAll();
-    if (killed > 0) {
-      process.stderr.write(`[mission-control] killed ${killed} managed process(es)\n`);
-    }
-    serverCtx.stop(true);
-    db.close();
-    process.exit(0);
-  };
-
-  process.on("SIGINT", () => { void shutdown(); });
-  process.on("SIGTERM", () => { void shutdown(); });
-} catch (err) {
-  process.stderr.write(
-    `[mission-control] FATAL: ${(err as Error).message}\n`
-  );
-  process.exit(1);
+/**
+ * True when the caller has explicitly opted into the retired standalone boot
+ * via the `--legacy` argv flag or the `MC_LEGACY_BOOT` env var. This is the
+ * escape hatch the integration-test harness uses; a plain production
+ * invocation carries neither and is refused.
+ */
+function legacyBootAllowed(argv: string[], env: NodeJS.ProcessEnv): boolean {
+  if (argv.includes("--legacy")) return true;
+  const flag = env.MC_LEGACY_BOOT;
+  return flag !== undefined && flag !== "" && flag !== "0" && flag !== "false";
 }
+
+/**
+ * Boot the retired standalone Mission Control server. Only reachable via the
+ * escape hatch (test harness). Preserves the prior NFR contract: any boot
+ * failure writes `[mission-control] FATAL: <msg>` to stderr and exits 1.
+ */
+function bootLegacy(): void {
+  try {
+    const config = loadConfig(process.env.MC_CONFIG_PATH);
+    const db = initDatabase(config.db.path);
+    const processManager = new ProcessManager();
+    const serverCtx = startServer(config, db, { processManager });
+    const { server, wsRegistry } = serverCtx;
+    const hookPoller = new HookStreamPoller(db, config.hooks, wsRegistry);
+
+    hookPoller.start();
+
+    process.stderr.write(
+      `[mission-control] v0.1.0 listening on http://localhost:${server.port}\n` +
+        `[mission-control] db: ${config.db.path}\n` +
+        `[mission-control] hook poller: ${config.hooks.rawEventsDir} (${config.hooks.pollInterval}ms)\n`
+    );
+
+    const shutdown = async () => {
+      process.stderr.write("[mission-control] shutting down...\n");
+      hookPoller.stop();
+      const killed = await processManager.closeAll();
+      if (killed > 0) {
+        process.stderr.write(`[mission-control] killed ${killed} managed process(es)\n`);
+      }
+      serverCtx.stop(true);
+      db.close();
+      process.exit(0);
+    };
+
+    process.on("SIGINT", () => { void shutdown(); });
+    process.on("SIGTERM", () => { void shutdown(); });
+  } catch (err) {
+    process.stderr.write(
+      `[mission-control] FATAL: ${(err as Error).message}\n`
+    );
+    process.exit(1);
+  }
+}
+
+// Production-entrypoint guard: only runs when this file is executed directly
+// (not when imported). Importing the module — e.g. to reach `legacyBootAllowed`
+// or `bootLegacy` from a test — has no side effects.
+if (import.meta.main) {
+  if (legacyBootAllowed(process.argv.slice(2), process.env)) {
+    bootLegacy();
+  } else {
+    process.stderr.write(RETIRED_POINTER);
+    process.exit(2);
+  }
+}
+
+export { legacyBootAllowed, bootLegacy, RETIRED_POINTER };


### PR DESCRIPTION
Closes #1822. Part of epic #1818 (Federation simplification), Wave 0.

The retired standalone Grove-MC entrypoint (`src/surface/mc/index.ts`) could still be booted and would serve a blank screen — a trapdoor that cost real debugging time. This makes the prod entry print a RETIRED pointer and `exit(2)`; the legacy boot is gated behind an explicit `--legacy` / `MC_LEGACY_BOOT` opt-in for any transitional need.

## Verification
- Scoped tests green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)