### PR TITLE
feat(cortex): FS-7 — validate-on-write for config verbs + D-3 last-known-good boot

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-config-write.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-config-write.test.ts
@@ -11,6 +11,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, readFileSync, statSync, existsSync, readdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { stringify } from "yaml";
 import { readNetworksFromConfig, writeNetworksGuarded } from "../network-config-write";
 import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
 
@@ -74,5 +75,53 @@ describe("writeNetworksGuarded", () => {
   test("readNetworksFromConfig returns [] for a missing file", () => {
     expect(readNetworksFromConfig(join(tmp, "nope.yaml"))).toEqual([]);
     expect(existsSync(join(tmp, "nope.yaml"))).toBe(false);
+  });
+});
+
+// FS-7 (cortex#1839) — whole-config validate-on-write via `validateComposePath`.
+describe("writeNetworksGuarded — FS-7 whole-config validation", () => {
+  let tmp2: string;
+  let monolith: string;
+
+  /** A complete, loadable single-file cortex config (monolith). */
+  function validMonolith(): Record<string, unknown> {
+    return {
+      principal: { id: "jc", displayName: "JC", discordId: "555555555555555555" },
+      agents: [
+        { id: "ivy", displayName: "Ivy", persona: "./personas/ivy.md", roles: [], trust: [], presence: {} },
+      ],
+      claude: {},
+    };
+  }
+
+  beforeEach(() => {
+    tmp2 = mkdtempSync(join(tmpdir(), "cfgwrite-whole-"));
+    monolith = join(tmp2, "cortex.yaml");
+    // 0600 — the single-file loader enforces it (and the guard preserves the mode).
+    writeFileSync(monolith, stringify(validMonolith()), { mode: 0o600 });
+  });
+  afterEach(() => rmSync(tmp2, { recursive: true, force: true }));
+
+  test("rejects a write that composes to an INVALID whole config, leaving the file byte-identical", () => {
+    const before = readFileSync(monolith, "utf-8");
+    // Valid payload_key (passes the scoped guard) but an INVALID network id →
+    // the payload_key + round-trip checks pass, yet `loadConfigWithAgents`
+    // rejects the composed whole (the ADR-0001-class defence FS-7 adds).
+    const badWhole = net({ id: "Bad Network!" });
+    expect(() =>
+      writeNetworksGuarded(monolith, [badWhole], { validateComposePath: monolith }),
+    ).toThrow(/config write verification failed/);
+    // Byte-identical: the guard restored the original.
+    expect(readFileSync(monolith, "utf-8")).toBe(before);
+    // 0600 preserved across the failed write.
+    expect(statSync(monolith).mode & 0o777).toBe(0o600);
+  });
+
+  test("without validateComposePath, the scoped guard alone does NOT catch a whole-config violation", () => {
+    // Regression guard for the FS-7 gap: the same bad-id write WITHOUT the compose
+    // path passes (scoped guard only checks payload_key + round-trip) — proving the
+    // new whole-config check is what closes the hole.
+    const badWhole = net({ id: "Bad Network!" });
+    expect(() => writeNetworksGuarded(monolith, [badWhole])).not.toThrow();
   });
 });

--- a/src/cli/cortex/commands/config-merge.ts
+++ b/src/cli/cortex/commands/config-merge.ts
@@ -81,10 +81,9 @@ import { dirname, join, resolve } from "path";
 import YAML from "yaml";
 import { z } from "zod/v4";
 
-import { composeRawConfig } from "../../../common/config/loader";
+import { validateConfigLoads } from "../../../common/config/validate-on-write";
 import { CapabilitySchema } from "../../../common/types/capability";
 import {
-  CortexConfigSchema,
   PolicyPrincipalSchema,
   PolicyRoleSchema,
 } from "../../../common/types/cortex-config";
@@ -747,25 +746,25 @@ export async function runConfigMerge(argv: string[]): Promise<number> {
     return 1;
   }
 
-  // 9. Re-compose from disk + re-validate (belt-and-braces; the in-memory
-  //    validation in step 5 already passed, but a disk re-compose catches any
-  //    serialization surprise — e.g. a YAML anchor the stringify introduced).
+  // 9. Re-load from disk through the boot validator (belt-and-braces; the
+  //    in-memory validation in step 5 already passed, but a disk re-load catches
+  //    any serialization surprise — e.g. a YAML anchor the stringify introduced).
+  //    FS-7 (cortex#1839): the SAME `loadConfigWithAgents` seam as step 5.
   try {
-    const recomposed = composeRawConfig(target.composePath);
-    const reval = CortexConfigSchema.safeParse(recomposed);
-    if (!reval.success) {
+    const reval = validateConfigLoads(target.composePath);
+    if (!reval.ok) {
       // Restore from backup — never leave the stack in an unloadable state.
       writeFileSync(target.filePath, originalText, "utf-8");
       process.stderr.write(
-        `config ${verb}: post-write re-compose FAILED validation — restored original from backup.\n` +
-          `  ${reval.error.message}\n`,
+        `config ${verb}: post-write re-load FAILED validation — restored original from backup.\n` +
+          `  ${reval.errors.join("\n  ")}\n`,
       );
       return 1;
     }
   } catch (err) {
     writeFileSync(target.filePath, originalText, "utf-8");
     process.stderr.write(
-      `config ${verb}: post-write re-compose threw — restored original from backup.\n` +
+      `config ${verb}: post-write re-load threw — restored original from backup.\n` +
         `  ${err instanceof Error ? err.message : String(err)}\n`,
     );
     return 1;
@@ -776,43 +775,36 @@ export async function runConfigMerge(argv: string[]): Promise<number> {
 }
 
 /**
- * Validate the composed whole with the merged layer substituted in. For the
- * single-file form the merged layer IS the whole config. For the split form we
- * compose with the on-disk layers but swap our merged candidate in for the
- * target layer by writing it, composing, then restoring — done here behind a
- * try/finally so a validation failure never leaves the disk dirty.
+ * Validate the composed whole with the merged layer substituted in, through the
+ * daemon's OWN boot validator (`loadConfigWithAgents`, via `validateConfigLoads`)
+ * — FS-7 (cortex#1839): the SAME validator `cortex config validate` and the boot
+ * path run, not a `CortexConfigSchema`-only fork that could accept a config the
+ * daemon rejects at boot (a legacy authorisation field, an agents.d fragment
+ * error, the AgentConfig projection).
+ *
+ * Both forms stage the candidate bytes on disk, point the validator at the
+ * config-split pointer (or the single file), then ALWAYS restore the original in
+ * a `finally` so this validation is pure from the disk's point of view. A
+ * `writeFileSync` over an existing file preserves that file's mode (0600 on a
+ * single-file cortex.yaml), so the loader's chmod-600 gate still passes on the
+ * staged bytes.
  */
 function validateComposed(
   target: ResolvedTarget,
   newLayerText: string,
   originalLayerText: string,
 ): { ok: true } | { ok: false; error: string } {
-  if (target.singleFile) {
-    // The whole config is the single file — validate the merged candidate.
-    let parsed: unknown;
-    try {
-      parsed = YAML.parse(newLayerText);
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
-    const res = CortexConfigSchema.safeParse(parsed);
-    return res.success ? { ok: true } : { ok: false, error: res.error.message };
-  }
-
-  // Split form: temporarily stage the candidate layer on disk, compose, then
-  // ALWAYS restore the original (try/finally) so this validation is pure from
-  // the disk's point of view.
-  let composed: Record<string, unknown>;
   try {
     writeFileSync(target.filePath, newLayerText, "utf-8");
-    composed = composeRawConfig(target.composePath);
+    const result = validateConfigLoads(target.composePath);
+    if (result.ok) return { ok: true };
+    return { ok: false, error: result.errors.join("\n  ") };
   } catch (err) {
+    // A stage-write / restore fs error (not a validation failure) — surface it.
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   } finally {
     writeFileSync(target.filePath, originalLayerText, "utf-8");
   }
-  const res = CortexConfigSchema.safeParse(composed);
-  return res.success ? { ok: true } : { ok: false, error: res.error.message };
 }
 
 /** A minimal line-oriented diff for --dry-run output (added/removed prefixes). */

--- a/src/cli/cortex/commands/config.ts
+++ b/src/cli/cortex/commands/config.ts
@@ -45,9 +45,8 @@
  *             · 2 CLI usage error (bad subcommand / unknown flag).
  */
 
-import { ZodError } from "zod";
-
 import { loadConfigWithAgents, expandTilde } from "../../../common/config/loader";
+import { formatConfigLoadError } from "../../../common/config/validate-on-write";
 import { DEFAULT_CONFIG } from "../../../common/pidfile";
 
 import { CliArgsError } from "./_shared/arg-error";
@@ -96,51 +95,10 @@ interface ValidateSummary {
   networks: number;
 }
 
-/**
- * Format a Zod issue the way the boot path surfaces it: dotted/bracketed path +
- * message. `policy.federated.networks[0].accept_subjects[1]: <message>`. Array
- * indices render as `[n]`, object keys as `.key`. Matches the field-pathed
- * shape principals already see when the daemon rejects a bad config at boot.
- */
-function formatZodIssue(issue: ZodError["issues"][number]): string {
-  let path = "";
-  for (const seg of issue.path) {
-    if (typeof seg === "number") {
-      path += `[${seg}]`;
-    } else {
-      path += path === "" ? String(seg) : `.${String(seg)}`;
-    }
-  }
-  if (path === "") return issue.message;
-  // Some schema `custom` issues (e.g. the ADR-0001 accept_subjects scope check)
-  // already lead their message with the same field path. Don't prepend it twice
-  // — surface the message verbatim when it already begins with the path.
-  if (issue.message.startsWith(path)) return issue.message;
-  return `${path}: ${issue.message}`;
-}
-
-/**
- * Extract the list of precise validation error strings from any error the boot
- * load path can throw. A `ZodError` (the schema-validation failure — the common
- * case, including the `accept_subjects` cross-check) yields one string per
- * issue, each field-pathed. Any other error (unreadable file, malformed YAML,
- * chmod gate) yields its single message.
- */
-function errorsFrom(err: unknown): string[] {
-  if (err instanceof ZodError) {
-    return err.issues.map(formatZodIssue);
-  }
-  if (err instanceof Error) {
-    // A schema failure may be wrapped: unwrap a nested ZodError cause so the
-    // precise per-issue paths still surface rather than an opaque wrapper.
-    const cause = (err as { cause?: unknown }).cause;
-    if (cause instanceof ZodError) {
-      return cause.issues.map(formatZodIssue);
-    }
-    return [err.message];
-  }
-  return [String(err)];
-}
+// FS-7 (cortex#1839) — the precise per-issue error formatter that was local here
+// now lives in `validate-on-write.ts` as `formatConfigLoadError`, so `cortex
+// config validate` (this file) and the write-time validators share ONE formatter
+// and surface byte-identical errors. `runValidate` calls it directly below.
 
 // =============================================================================
 // validate
@@ -186,7 +144,7 @@ function runValidate(flags: FlagMap, json: boolean): ExitResult {
       stderr: "",
     };
   } catch (err) {
-    const errors = errorsFrom(err);
+    const errors = formatConfigLoadError(err);
     if (json) {
       const payload = { ok: false, path: resolvedPath, errors };
       return { exitCode: 1, stdout: "", stderr: JSON.stringify(payload) + "\n" };

--- a/src/cli/cortex/commands/migrate-config.ts
+++ b/src/cli/cortex/commands/migrate-config.ts
@@ -20,10 +20,11 @@
  *   2  — strict-mode warnings (would have succeeded without --strict)
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
 import YAML from "yaml";
 
+import { validateConfigLoads } from "../../../common/config/validate-on-write";
 import {
   convertBotYaml,
   formatCheckReport,
@@ -226,7 +227,35 @@ export async function runMigrateConfig(argv: string[]): Promise<number> {
     // writeFileSync ENOENTs unless we ensure the parent exists. mkdir
     // recursive is idempotent — pre-existing dirs are a no-op.
     mkdirSync(dirname(outPath), { recursive: true });
-    writeFileSync(outPath, yamlOut, "utf-8");
+    // FS-7 (cortex#1839) — validate-on-write: capture any pre-existing bytes so
+    // a validation failure can restore the target byte-identical (or remove a
+    // freshly-created file), never leaving a written-but-unloadable config.
+    const preExisted = existsSync(outPath);
+    const originalBytes = preExisted ? readFileSync(outPath, "utf-8") : undefined;
+    // 0600 — a migrated cortex.yaml is a single-file config carrying inline
+    // platform tokens, so it is a secret-at-rest AND the single-file loader
+    // enforces chmod-600 (which the FS-7 validation below re-reads through). The
+    // create mode is umask-masked, so chmod explicitly.
+    writeFileSync(outPath, yamlOut, { encoding: "utf-8", mode: 0o600 });
+    chmodSync(outPath, 0o600);
+    // Run the daemon's OWN boot validator against the just-written file. On a
+    // throw we restore/remove and exit non-zero with the precise error — the
+    // same seam `cortex config validate` + the boot path use.
+    const validation = validateConfigLoads(outPath);
+    if (!validation.ok) {
+      if (originalBytes !== undefined) {
+        writeFileSync(outPath, originalBytes, { encoding: "utf-8", mode: 0o600 });
+        chmodSync(outPath, 0o600);
+      } else {
+        rmSync(outPath, { force: true });
+      }
+      process.stderr.write(
+        `migrate-config: converted config failed validation — ${
+          originalBytes !== undefined ? "restored original" : "removed the written file"
+        }; NOT leaving an unloadable config.\n  ${validation.errors.join("\n  ")}\n`,
+      );
+      return 1;
+    }
     const policySummary = result.cortex.policy
       ? `, ${result.cortex.policy.principals.length} principal(s), ${result.cortex.policy.roles.length} role(s)`
       : "";

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -1072,7 +1072,17 @@ function buildConfigStorePort(cfg: LivePortsConfig, mutate: boolean): ConfigStor
       // the per-network payload key K (a secret at rest) here; `rotate-key` calls
       // the SAME guard hub-side, so the two can never drift. `assertDaemonLoadsConfig`
       // (join-only) stays above — it is NOT part of the reusable core.
-      writeNetworksGuarded(path, networks, { backupLabel: "join" });
+      //
+      // FS-7 (cortex#1839) — thread the daemon's real `--config` pointer so the
+      // guard ALSO validates the COMPOSED WHOLE (`loadConfigWithAgents`) after the
+      // write, not just the payload-key + networks round-trip. A join that composes
+      // to a config the daemon would reject at boot is aborted + rolled back here.
+      writeNetworksGuarded(path, networks, {
+        backupLabel: "join",
+        ...(cfg.cortexConfigPath !== undefined && cfg.cortexConfigPath !== ""
+          ? { validateComposePath: expandTilde(cfg.cortexConfigPath) }
+          : {}),
+      });
     },
   };
 }

--- a/src/cli/cortex/commands/network-config-write.ts
+++ b/src/cli/cortex/commands/network-config-write.ts
@@ -22,6 +22,7 @@
 import {
   existsSync,
   readFileSync,
+  statSync,
   writeFileSync,
   chmodSync,
   mkdirSync,
@@ -30,6 +31,7 @@ import {
 } from "fs";
 import { dirname } from "path";
 import { parse as parseYaml, parseDocument } from "yaml";
+import { validateConfigLoads } from "../../../common/config/validate-on-write";
 import {
   PolicyFederatedNetworkSchema,
   type PolicyFederatedNetwork,
@@ -44,10 +46,20 @@ export function readNetworksFromConfig(path: string): PolicyFederatedNetwork[] {
   return raw?.policy?.federated?.networks ?? [];
 }
 
-/** POSIX-atomic write (temp + same-dir rename → old-or-new, never partial). */
-function atomicWriteFileSync(path: string, contents: string): void {
+/**
+ * POSIX-atomic write (temp + same-dir rename → old-or-new, never partial).
+ *
+ * `mode`, when given, is applied to the temp file (umask-proof re-chmod) BEFORE
+ * the rename, so the live file's permissions are preserved across the write. FS-7
+ * (cortex#1839) needs this: a monolith `cortex.yaml` is chmod-600-gated by the
+ * loader, and the post-write whole-config validation re-reads it through the
+ * loader — a non-atomic write that dropped the mode to the umask default (0644)
+ * would trip that gate and spuriously fail validation.
+ */
+function atomicWriteFileSync(path: string, contents: string, mode?: number): void {
   const tmpPath = `${path}.tmp`;
-  writeFileSync(tmpPath, contents, "utf-8");
+  writeFileSync(tmpPath, contents, mode !== undefined ? { encoding: "utf-8", mode } : "utf-8");
+  if (mode !== undefined) chmodSync(tmpPath, mode); // create mode is umask-masked; re-chmod.
   renameSync(tmpPath, path);
 }
 
@@ -81,7 +93,7 @@ function backupStamp(): string {
 export function writeNetworksGuarded(
   path: string,
   networks: readonly PolicyFederatedNetwork[],
-  opts: { backupLabel?: string } = {},
+  opts: { backupLabel?: string; validateComposePath?: string } = {},
 ): void {
   const backupLabel = opts.backupLabel ?? "write";
 
@@ -103,6 +115,18 @@ export function writeNetworksGuarded(
 
   const existed = existsSync(path);
   const originalText = existed ? readFileSync(path, "utf-8") : undefined;
+  // FS-7 (cortex#1839) — preserve the live file's mode across the atomic write so
+  // the post-write whole-config validation (which re-reads through the loader's
+  // chmod-600 gate on a monolith cortex.yaml) sees the same permissions.
+  const originalMode = existed ? statSync(path).mode & 0o777 : undefined;
+  // FS-7 — only ENFORCE the whole-config check when the config was ALREADY
+  // loadable BEFORE this write. The invariant this writer guarantees is "a write
+  // must not BREAK a working config"; it is not this writer's job to fix a config
+  // that was already unloadable. In production the daemon loaded the config (so it
+  // IS loadable → the check runs); a partial/stub config or an already-broken one
+  // is skipped rather than have the write blamed for a pre-existing fault.
+  const enforceWholeConfig =
+    opts.validateComposePath !== undefined && validateConfigLoads(opts.validateComposePath).ok;
   const doc = parseDocument(originalText ?? "");
   doc.setIn(["policy", "federated", "networks"], networks);
   const nextText = doc.toString();
@@ -120,7 +144,7 @@ export function writeNetworksGuarded(
   // failure / mismatch means the write corrupted the file → RESTORE the original
   // (or remove a freshly-created file) and rethrow.
   try {
-    atomicWriteFileSync(path, nextText);
+    atomicWriteFileSync(path, nextText, originalMode);
     const reparsed = parseYaml(readFileSync(path, "utf-8")) as
       | { policy?: { federated?: { networks?: PolicyFederatedNetwork[] } } }
       | null;
@@ -140,8 +164,23 @@ export function writeNetworksGuarded(
     if (project(readBack) !== project(networks)) {
       throw new Error("policy.federated.networks did not round-trip after write");
     }
+    // FS-7 (cortex#1839) — VALIDATE THE COMPOSED WHOLE. The payload_key + round-trip
+    // checks above are SCOPED to the networks array; a write can still compose to a
+    // config the daemon rejects at boot (e.g. an `accept_subjects` ADR-0001 scope
+    // violation — a `policy.federated.networks` field!). When the caller threads the
+    // config-split pointer AND the config was loadable before this write, run the
+    // daemon's OWN boot validator over the composed whole; a throw here trips the
+    // same restore-and-rethrow path as a bad round-trip.
+    if (enforceWholeConfig && opts.validateComposePath !== undefined) {
+      const validation = validateConfigLoads(opts.validateComposePath);
+      if (!validation.ok) {
+        throw new Error(
+          `composed config failed boot validation:\n  ${validation.errors.join("\n  ")}`,
+        );
+      }
+    }
   } catch (err) {
-    if (originalText !== undefined) atomicWriteFileSync(path, originalText);
+    if (originalText !== undefined) atomicWriteFileSync(path, originalText, originalMode);
     else rmSync(path, { force: true });
     throw new Error(
       `config write verification failed for ${path} — restored original${backupPath ? ` (backup ${backupPath})` : ""}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -37,7 +37,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, chmodSync, renameSync, mkdtempSync, rmSync } from "fs";
-import { resolve as resolvePath, join as joinPath } from "path";
+import { resolve as resolvePath, join as joinPath, dirname as pathDirname } from "path";
 import { tmpdir } from "os";
 import { hostname as osHostname, networkInterfaces as osNetworkInterfaces } from "os";
 import { lookup as dnsLookup } from "dns/promises";
@@ -855,6 +855,15 @@ function buildLiveAdmittedListPort(cfg: LiveKeyRotationPortsConfig): AdmittedLis
 
 function buildLiveHubKeyStorePort(hubStackConfigPath: string): HubKeyStorePort {
   const path = expandTilde(hubStackConfigPath);
+  // FS-7 (cortex#1839) — whole-config validate-on-write. For a MONOLITH (single-
+  // file) hub config, `path` IS the whole config, so we can point the boot
+  // validator straight at it. For a config-split hub, `path` is the `stacks/*.yaml`
+  // that holds `policy.federated.networks`; composing the whole needs the POINTER,
+  // which is not threaded to this hub-key store — so we fall back to the scoped
+  // payload_key + round-trip guard there (rotate-key only advances the K fields,
+  // which that guard already validates; it never touches whole-config fields like
+  // accept_subjects). The single-file case (JC's deployment) gets the full check.
+  const isConfigSplit = existsSync(joinPath(pathDirname(path), "system", "system.yaml"));
   return {
     configPath: path,
     readNetworks() {
@@ -864,7 +873,10 @@ function buildLiveHubKeyStorePort(hubStackConfigPath: string): HubKeyStorePort {
       // The SAME offer.ts write-guard Slice 1 added (validate → backup → atomic →
       // verify → restore → chmod 600). NO daemon-loads assertion — rotate-key is
       // the hub admin editing their OWN stack config; they restart the daemon.
-      writeNetworksGuarded(path, networks, { backupLabel: "rotate-key" });
+      writeNetworksGuarded(path, networks, {
+        backupLabel: "rotate-key",
+        ...(isConfigSplit ? {} : { validateComposePath: path }),
+      });
       return Promise.resolve();
     },
   };

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -38,6 +38,7 @@ import { execFileSync } from "child_process";
 import { dirname, join } from "path";
 import { homedir } from "os";
 
+import { validateConfigLoads } from "../../../common/config/validate-on-write";
 import { CliArgsError } from "./_shared/arg-error";
 import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
 import { type ExitResult } from "./_shared/exit-result";
@@ -332,6 +333,29 @@ function runCreate(
     return opError(
       "create",
       `write failed (partial scaffold rolled back): ${err instanceof Error ? err.message : String(err)}`,
+      json,
+    );
+  }
+
+  // FS-7 (cortex#1839) — validate-on-write: the scaffold is designed to load
+  // cleanly out of the box (every file parses; secrets are valid-FORMAT
+  // placeholders). Confirm that by running the daemon's OWN boot validator
+  // against the just-written pointer. On failure, roll back the whole scaffold
+  // (targetDir was confirmed absent before the write, so it is wholly owned by
+  // this command) so `stack create --apply` never leaves an unloadable stack.
+  const pointerPath = join(targetDir, `${slug}.yaml`);
+  const validation = validateConfigLoads(pointerPath);
+  if (!validation.ok) {
+    try {
+      rmSync(targetDir, { recursive: true, force: true });
+    } catch (cleanupErr) {
+      process.stderr.write(
+        `  ⚠ stack create: rollback of ${targetDir} failed: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}\n`,
+      );
+    }
+    return opError(
+      "create",
+      `scaffold failed validation (rolled back) — refusing to leave an unloadable stack:\n  ${validation.errors.join("\n  ")}`,
       json,
     );
   }

--- a/src/common/config/__tests__/last-good.test.ts
+++ b/src/common/config/__tests__/last-good.test.ts
@@ -1,0 +1,85 @@
+/**
+ * FS-7 / D-3 (cortex#1839) — tests for the last-known-good config snapshot.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { basename, dirname, join } from "path";
+import { stringify } from "yaml";
+
+import { loadConfigWithAgents } from "../loader";
+import {
+  lastGoodDir,
+  lastGoodSnapshotPath,
+  readLastGoodSnapshotPath,
+  writeLastGoodSnapshot,
+} from "../last-good";
+
+function validCortex(): Record<string, unknown> {
+  return {
+    principal: { id: "jc", displayName: "JC", discordId: "555555555555555555" },
+    agents: [
+      { id: "ivy", displayName: "Ivy", persona: "./personas/ivy.md", roles: [], trust: [], presence: {} },
+    ],
+    claude: {},
+  };
+}
+
+describe("FS-7 / D-3 — last-good snapshot", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "fs7-lastgood-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeSingleFile(config: Record<string, unknown>, name = "cortex.yaml"): string {
+    const path = join(dir, name);
+    writeFileSync(path, stringify(config), { mode: 0o600 });
+    return path;
+  }
+
+  test("snapshot path is <config-dir>/.last-good/<basename>.snapshot", () => {
+    const path = join(dir, "research.yaml");
+    expect(lastGoodDir(path)).toBe(join(dir, ".last-good"));
+    expect(lastGoodSnapshotPath(path)).toBe(join(dir, ".last-good", "research.snapshot"));
+  });
+
+  test("writeLastGoodSnapshot persists a 0600 snapshot that readLastGoodSnapshotPath finds", () => {
+    const path = writeSingleFile(validCortex());
+    expect(readLastGoodSnapshotPath(path)).toBeNull();
+
+    const result = writeLastGoodSnapshot(path);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+
+    expect(existsSync(result.path)).toBe(true);
+    expect(readLastGoodSnapshotPath(path)).toBe(result.path);
+    // 0600 (owner rw only).
+    expect(statSync(result.path).mode & 0o777).toBe(0o600);
+    // Lives under .last-good/ keyed by the pointer basename.
+    expect(dirname(result.path)).toBe(join(dir, ".last-good"));
+    expect(basename(result.path)).toBe("cortex.snapshot");
+  });
+
+  test("the snapshot round-trips: loadConfigWithAgents accepts it", () => {
+    const path = writeSingleFile(validCortex());
+    const result = writeLastGoodSnapshot(path);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    // Reloading the snapshot through the daemon's validator must succeed — this
+    // is exactly what the D-3 fallback does at boot.
+    const loaded = loadConfigWithAgents(result.path);
+    expect(loaded.inlineAgents).toHaveLength(1);
+    expect(loaded.principal?.id).toBe("jc");
+  });
+
+  test("writeLastGoodSnapshot returns ok:false (never throws) when the pointer is missing", () => {
+    const result = writeLastGoodSnapshot(join(dir, "nope.yaml"));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.error.length).toBeGreaterThan(0);
+  });
+});

--- a/src/common/config/__tests__/validate-on-write.test.ts
+++ b/src/common/config/__tests__/validate-on-write.test.ts
@@ -1,0 +1,92 @@
+/**
+ * FS-7 (cortex#1839) — tests for the shared validate-on-write seam.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { stringify } from "yaml";
+
+import {
+  assertConfigLoads,
+  formatConfigLoadError,
+  validateConfigLoads,
+} from "../validate-on-write";
+
+/** A minimal cortex-shape config that loads cleanly. */
+function validCortex(): Record<string, unknown> {
+  return {
+    principal: { id: "jc", displayName: "JC", discordId: "555555555555555555" },
+    agents: [
+      {
+        id: "ivy",
+        displayName: "Ivy",
+        persona: "./personas/ivy.md",
+        roles: [],
+        trust: [],
+        presence: {},
+      },
+    ],
+    claude: {},
+  };
+}
+
+describe("FS-7 validate-on-write — validateConfigLoads / assertConfigLoads", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "fs7-validate-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeSingleFile(config: Record<string, unknown>): string {
+    const path = join(dir, "cortex.yaml");
+    // The single-file loader enforces chmod 600 — write fixtures 0600.
+    writeFileSync(path, stringify(config), { mode: 0o600 });
+    return path;
+  }
+
+  test("validateConfigLoads returns ok for a valid config", () => {
+    const path = writeSingleFile(validCortex());
+    const result = validateConfigLoads(path);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("validateConfigLoads returns precise field-pathed errors for an invalid config", () => {
+    // Drop the required `persona` from the agent → CortexConfigSchema rejects.
+    const bad = validCortex();
+    (bad.agents as Record<string, unknown>[])[0]!.persona = undefined;
+    delete (bad.agents as Record<string, unknown>[])[0]!.persona;
+    const path = writeSingleFile(bad);
+    const result = validateConfigLoads(path);
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    // The error names the offending field path (agents[0].persona).
+    expect(result.errors.join("\n")).toContain("persona");
+  });
+
+  test("validateConfigLoads reports a missing config file (not a throw)", () => {
+    const result = validateConfigLoads(join(dir, "does-not-exist.yaml"));
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test("assertConfigLoads is a no-op on a valid config", () => {
+    const path = writeSingleFile(validCortex());
+    expect(() => assertConfigLoads(path)).not.toThrow();
+  });
+
+  test("assertConfigLoads throws a precise multi-line error on an invalid config", () => {
+    const bad = validCortex();
+    delete (bad.agents as Record<string, unknown>[])[0]!.persona;
+    const path = writeSingleFile(bad);
+    expect(() => assertConfigLoads(path)).toThrow(/refusing to write/);
+  });
+
+  test("formatConfigLoadError stringifies a plain Error to its message", () => {
+    expect(formatConfigLoadError(new Error("boom"))).toEqual(["boom"]);
+  });
+});

--- a/src/common/config/degraded-state.ts
+++ b/src/common/config/degraded-state.ts
@@ -1,0 +1,81 @@
+/**
+ * FS-7 / D-3 (cortex#1839) — DEGRADED-boot state marker.
+ *
+ * When the daemon boots on the last-known-good snapshot after `loadConfigWithAgents`
+ * threw on the LIVE config (D-3 fallback, see `src/cortex.ts` boot + `last-good.ts`),
+ * it is running DEGRADED: serving the previous config while the live one is broken.
+ * That state must be VISIBLE — design Principle 5's whole point is "never a silent
+ * crash-loop", and a silent degraded boot is just a quieter failure.
+ *
+ * This module is the single source of truth for the degraded state, persisted as a
+ * small JSON marker file so it is visible across processes:
+ *   - the daemon WRITES it at degraded boot / CLEARS it on a healthy boot;
+ *   - `cortex status` (a separate process) READS it to print DEGRADED + the error;
+ *   - the in-process MC server surfaces it on `/health` (threaded in at boot).
+ *
+ * The marker path is derived from the SAME `pidFileFor` locator the lifecycle
+ * uses (`<pid>.pid` → `<pid>.degraded.json`), so the daemon that writes it and the
+ * `cortex status` that reads it always agree on the file across config-path
+ * spellings.
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { dirname } from "path";
+
+import { pidFileFor } from "../pidfile";
+
+/** Persisted shape of a degraded boot. */
+export interface DegradedInfo {
+  /** Precise config-load error that forced the fallback (multi-line allowed). */
+  error: string;
+  /** Absolute path of the last-good snapshot the daemon booted from. */
+  snapshotPath: string;
+  /** ISO-8601 timestamp the degraded boot happened. */
+  since: string;
+}
+
+/**
+ * Marker path for a `--config` value: the PID file path with `.pid` swapped for
+ * `.degraded.json`. Reuses `pidFileFor` so writer (daemon) and reader
+ * (`cortex status`) resolve the same file across path spellings.
+ */
+export function degradedMarkerPath(configPath: string | undefined): string {
+  return pidFileFor(configPath).replace(/\.pid$/, ".degraded.json");
+}
+
+/** Persist the degraded-boot marker (0600 — the error text can name config internals). */
+export function writeDegradedMarker(configPath: string | undefined, info: DegradedInfo): void {
+  const path = degradedMarkerPath(configPath);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(info, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+}
+
+/** Read the degraded-boot marker, or `null` when the daemon booted healthy. */
+export function readDegradedMarker(configPath: string | undefined): DegradedInfo | null {
+  const path = degradedMarkerPath(configPath);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as DegradedInfo;
+  } catch (err) {
+    // A corrupt marker is not fatal — report it and treat as "no marker" so a
+    // parse glitch never masks the real status output or crashes the reader.
+    process.stderr.write(
+      `cortex: could not parse degraded marker ${path}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return null;
+  }
+}
+
+/** Remove the degraded-boot marker (a healthy boot clears any prior degraded state). Best-effort. */
+export function clearDegradedMarker(configPath: string | undefined): void {
+  const path = degradedMarkerPath(configPath);
+  try {
+    if (existsSync(path)) unlinkSync(path);
+  } catch (err) {
+    // Best-effort cleanup — a stale marker is surfaced as DEGRADED, which is
+    // strictly safer than crashing the boot on an unlink race. Log and proceed.
+    process.stderr.write(
+      `cortex: could not clear degraded marker ${path}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}

--- a/src/common/config/last-good.ts
+++ b/src/common/config/last-good.ts
@@ -1,0 +1,92 @@
+/**
+ * FS-7 / D-3 (cortex#1839, epic #1818 Wave 0) — last-known-good config snapshot.
+ *
+ * Design §3 D-3 (RATIFIED #1819): *"At boot, a broken config falls back to
+ * last-known-good — never a keepalive crash-loop."* On every SUCCESSFUL boot the
+ * daemon persists a snapshot of the config it just loaded; on a subsequent boot
+ * where `loadConfigWithAgents` throws, the boot path loads this snapshot and
+ * boots DEGRADED instead of crash-looping (see `src/cortex.ts` boot + the
+ * degraded-state marker in `degraded-state.ts`).
+ *
+ * WHAT is snapshotted: the COMPOSED RAW config object (`composeRawConfig` — the
+ * deep-merged config-split layers, or the verbatim single-file cortex.yaml),
+ * serialized back to YAML. Reloading the snapshot via `loadConfigWithAgents`
+ * re-runs the FULL validate + env-placeholder resolution on it, so the fallback
+ * boots through the identical path a normal boot uses — just against the
+ * last-good bytes. `__ENV__` surface-token placeholders stay UNRESOLVED in the
+ * snapshot (resolution happens inside the loader), so no live secret is written
+ * to the snapshot for config-split stacks; a legacy single-file cortex.yaml that
+ * carries inline tokens is copied verbatim, which is why the snapshot is 0600.
+ *
+ * Known limitation (acceptable for a degraded fallback): a config-split stack's
+ * `networks/` fragment directory is resolved relative to the config dir, so a
+ * single-file snapshot in `.last-good/` does not carry those fragments. Inline
+ * `policy.federated.networks[]` (what `cortex network join` writes) IS in the
+ * composed raw and survives; the legacy G-500 `networks/*.yaml` mechanism does
+ * not. Degraded mode trades that fidelity for staying up.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+} from "fs";
+import { basename, dirname, join } from "path";
+import { stringify as stringifyYaml } from "yaml";
+
+import { composeRawConfig, expandTilde } from "./loader";
+
+/** The `.last-good/` directory beside the config pointer. */
+export function lastGoodDir(pointerPath: string): string {
+  return join(dirname(expandTilde(pointerPath)), ".last-good");
+}
+
+/**
+ * Well-known snapshot path for a pointer: `<config-dir>/.last-good/<basename>.snapshot`.
+ * Keyed by the pointer BASENAME (without `.yaml`/`.yml`) so per-stack pointers in
+ * a shared config dir get distinct snapshots — the same per-stack identity the
+ * PID file derives from the pointer basename.
+ */
+export function lastGoodSnapshotPath(pointerPath: string): string {
+  const base = basename(expandTilde(pointerPath)).replace(/\.ya?ml$/i, "");
+  return join(lastGoodDir(pointerPath), `${base.length > 0 ? base : "config"}.snapshot`);
+}
+
+/** Return the snapshot path if one exists for this pointer, else `null`. */
+export function readLastGoodSnapshotPath(pointerPath: string): string | null {
+  const snapshotPath = lastGoodSnapshotPath(pointerPath);
+  return existsSync(snapshotPath) ? snapshotPath : null;
+}
+
+/** Outcome of a snapshot write — success carries the path; failure the reason. */
+export type SnapshotResult =
+  | { ok: true; path: string }
+  | { ok: false; error: string };
+
+/**
+ * Persist the composed raw config at `pointerPath` as a 0600 YAML snapshot in
+ * `<config-dir>/.last-good/`. Called on every SUCCESSFUL boot.
+ *
+ * NEVER throws — a snapshot-write failure must not turn a good boot into a
+ * failed one (the snapshot is a recovery convenience, not a boot dependency).
+ * The failure is returned so the boot path can log it; the daemon boots normally
+ * regardless.
+ */
+export function writeLastGoodSnapshot(pointerPath: string): SnapshotResult {
+  try {
+    const raw = composeRawConfig(expandTilde(pointerPath));
+    const yaml = stringifyYaml(raw, { indent: 2, lineWidth: 0 });
+    const dir = lastGoodDir(pointerPath);
+    mkdirSync(dir, { recursive: true });
+    const snapshotPath = lastGoodSnapshotPath(pointerPath);
+    // 0600: a legacy single-file cortex.yaml carries inline platform tokens, so
+    // its verbatim snapshot is a secret-at-rest. The create `mode` is masked by
+    // the umask, so re-chmod explicitly (mirrors the cortex.yaml chmod-600 floor).
+    writeFileSync(snapshotPath, yaml, { encoding: "utf-8", mode: 0o600 });
+    chmodSync(snapshotPath, 0o600);
+    return { ok: true, path: snapshotPath };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/common/config/validate-on-write.ts
+++ b/src/common/config/validate-on-write.ts
@@ -1,0 +1,117 @@
+/**
+ * FS-7 (cortex#1839, epic #1818 Wave 0) — validate-on-write.
+ *
+ * Principle 5 of the federation-simplification design: *"Fail loud early, fail
+ * soft late. Validate at write time, every path that touches config."* #1808
+ * shipped `cortex config validate` but it is OPT-IN — nothing runs it
+ * automatically, so a bad edit still reaches boot and crash-loops the daemon.
+ *
+ * This module is the SINGLE seam every config-writing verb (`config merge`,
+ * `migrate-config`, `stack create --apply`, `network join/leave/create/secret`)
+ * runs BEFORE committing a write: it composes the WHOLE resolved config and
+ * feeds it through the daemon's OWN boot validator — `loadConfigWithAgents`
+ * (loader.ts) — exactly as `cortex config validate` does
+ * (`config.ts:160`). There is deliberately NO second validator: reusing
+ * `loadConfigWithAgents` is what guarantees a write that passes here is a write
+ * the daemon can boot.
+ *
+ * Why compose-the-whole (not the single layer): a config-split LAYER can be
+ * individually valid yet compose to an invalid WHOLE — e.g. the `accept_subjects`
+ * ADR-0001 scope violation that only surfaces once the layers merge. So the
+ * writers stage their candidate bytes on disk (behind an existing backup/restore
+ * path), point this validator at the config-split POINTER, and roll back on a
+ * throw — never leaving a half-written or unloadable live config.
+ */
+
+import { ZodError } from "zod";
+
+import { loadConfigWithAgents } from "./loader";
+
+/**
+ * Format a Zod issue the way the boot path surfaces it: dotted/bracketed path +
+ * message (`policy.federated.networks[0].accept_subjects[1]: <message>`). Array
+ * indices render as `[n]`, object keys as `.key`. Single source of truth for the
+ * field-pathed shape principals already see when the daemon rejects a bad config
+ * at boot; `cortex config validate` (config.ts) imports this same formatter so
+ * write-time and boot-time errors read identically.
+ */
+export function formatZodIssue(issue: ZodError["issues"][number]): string {
+  let path = "";
+  for (const seg of issue.path) {
+    if (typeof seg === "number") {
+      path += `[${seg}]`;
+    } else {
+      path += path === "" ? String(seg) : `.${String(seg)}`;
+    }
+  }
+  if (path === "") return issue.message;
+  // Some schema `custom` issues (e.g. the ADR-0001 accept_subjects scope check)
+  // already lead their message with the same field path. Don't prepend it twice
+  // — surface the message verbatim when it already begins with the path.
+  if (issue.message.startsWith(path)) return issue.message;
+  return `${path}: ${issue.message}`;
+}
+
+/**
+ * Extract the list of precise validation error strings from any error the boot
+ * load path can throw. A `ZodError` (the schema-validation failure — the common
+ * case, including the `accept_subjects` cross-check) yields one string per issue,
+ * each field-pathed. Any other error (unreadable file, malformed YAML, chmod
+ * gate) yields its single message. A nested `ZodError` cause is unwrapped so the
+ * precise per-issue paths still surface rather than an opaque wrapper.
+ */
+export function formatConfigLoadError(err: unknown): string[] {
+  if (err instanceof ZodError) {
+    return err.issues.map(formatZodIssue);
+  }
+  if (err instanceof Error) {
+    const cause = (err as { cause?: unknown }).cause;
+    if (cause instanceof ZodError) {
+      return cause.issues.map(formatZodIssue);
+    }
+    return [err.message];
+  }
+  return [String(err)];
+}
+
+/** Result of a compose-then-validate check. */
+export interface ConfigValidation {
+  ok: boolean;
+  /** Precise, field-pathed error strings; empty when `ok`. */
+  errors: string[];
+}
+
+/**
+ * Compose the WHOLE resolved config at `pointerPath` and validate it through the
+ * daemon's boot validator (`loadConfigWithAgents`). Never throws — a failure is
+ * returned as `{ ok: false, errors }` so callers with their own restore/rollback
+ * scaffolding can branch on it. `pointerPath` is the config-split pointer (or a
+ * legacy single-file cortex.yaml) — the SAME path the daemon's `--config` names.
+ */
+export function validateConfigLoads(pointerPath: string): ConfigValidation {
+  try {
+    loadConfigWithAgents(pointerPath);
+    return { ok: true, errors: [] };
+  } catch (err) {
+    return { ok: false, errors: formatConfigLoadError(err) };
+  }
+}
+
+/**
+ * Throw a precise, multi-line error when the composed config at `pointerPath`
+ * does not load. For writers that have NO backup/restore scaffolding of their
+ * own and want a single-line "abort on invalid" call — the caller's own
+ * try/catch converts the throw into a clean non-zero exit + original-config
+ * restore. Writers that ALREADY have a restore path (config-merge) call
+ * `validateConfigLoads` and route through it instead.
+ */
+export function assertConfigLoads(pointerPath: string): void {
+  const result = validateConfigLoads(pointerPath);
+  if (!result.ok) {
+    throw new Error(
+      `config validation failed — refusing to write:\n${result.errors
+        .map((e) => `  ${e}`)
+        .join("\n")}`,
+    );
+  }
+}

--- a/src/cortex.test.ts
+++ b/src/cortex.test.ts
@@ -1,0 +1,135 @@
+/**
+ * FS-7 / D-3 (cortex#1839) — tests for `resolveBootConfig`, the last-known-good
+ * boot fallback. Covers the four ratified D-3 cases + the good-boot snapshot:
+ *   - good boot → refreshes the snapshot, clears any degraded marker;
+ *   - bad live + snapshot present → boots DEGRADED (marker written);
+ *   - bad live + no snapshot → fail-hard (throws);
+ *   - --strict + bad live (even with a snapshot) → fail-hard (throws).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { basename, join } from "path";
+import { stringify } from "yaml";
+
+import { resolveBootConfig } from "./cortex";
+import { readLastGoodSnapshotPath } from "./common/config/last-good";
+import { clearDegradedMarker, readDegradedMarker } from "./common/config/degraded-state";
+
+function validCortex(): Record<string, unknown> {
+  return {
+    principal: { id: "jc", displayName: "JC", discordId: "555555555555555555" },
+    agents: [
+      { id: "ivy", displayName: "Ivy", persona: "./personas/ivy.md", roles: [], trust: [], presence: {} },
+    ],
+    claude: {},
+  };
+}
+
+/** A cortex-shape config that fails schema validation (agent missing `persona`). */
+function invalidCortex(): Record<string, unknown> {
+  const c = validCortex();
+  delete (c.agents as Record<string, unknown>[])[0]!.persona;
+  return c;
+}
+
+const FIXED_NOW = "2026-07-10T00:00:00.000Z";
+
+describe("FS-7 / D-3 — resolveBootConfig last-known-good fallback", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "fs7-boot-"));
+    // Per-test-unique pointer basename so the STATE_DIR degraded marker (keyed off
+    // the config basename via pidFileFor) never collides across tests.
+    configPath = join(dir, `${basename(dir)}.yaml`);
+  });
+  afterEach(() => {
+    clearDegradedMarker(configPath);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(config: Record<string, unknown>): void {
+    writeFileSync(configPath, stringify(config), { mode: 0o600 });
+  }
+
+  test("good boot returns no degraded, writes the last-good snapshot, clears any marker", () => {
+    write(validCortex());
+    const { loaded, degraded } = resolveBootConfig(configPath, { strict: false, now: () => FIXED_NOW });
+    expect(degraded).toBeUndefined();
+    expect(loaded.inlineAgents).toHaveLength(1);
+    // Snapshot persisted; degraded marker absent.
+    expect(readLastGoodSnapshotPath(configPath)).not.toBeNull();
+    expect(readDegradedMarker(configPath)).toBeNull();
+  });
+
+  test("bad live config WITH a snapshot boots DEGRADED (marker written, snapshot loaded)", () => {
+    // 1. Good boot → snapshot exists.
+    write(validCortex());
+    resolveBootConfig(configPath, { strict: false, now: () => FIXED_NOW });
+    expect(readLastGoodSnapshotPath(configPath)).not.toBeNull();
+
+    // 2. Break the live config, boot again → DEGRADED fallback.
+    write(invalidCortex());
+    const snapshotPath = readLastGoodSnapshotPath(configPath);
+    expect(snapshotPath).not.toBeNull();
+    const { loaded, degraded } = resolveBootConfig(configPath, { strict: false, now: () => FIXED_NOW });
+    expect(degraded).toBeDefined();
+    expect(degraded!.since).toBe(FIXED_NOW);
+    expect(degraded!.snapshotPath).toBe(snapshotPath!);
+    expect(degraded!.error).toContain("persona");
+    // Booted on the (valid) snapshot — the agent is present.
+    expect(loaded.inlineAgents).toHaveLength(1);
+    // Marker persisted for `cortex status` / MC to read.
+    const marker = readDegradedMarker(configPath);
+    expect(marker).not.toBeNull();
+    expect(marker!.snapshotPath).toBe(degraded!.snapshotPath);
+  });
+
+  test("bad live config with NO snapshot fails hard (throws)", () => {
+    write(invalidCortex());
+    expect(readLastGoodSnapshotPath(configPath)).toBeNull();
+    expect(() => resolveBootConfig(configPath, { strict: false, now: () => FIXED_NOW })).toThrow(
+      /no last-known-good snapshot/,
+    );
+    // No degraded marker written on a fail-hard.
+    expect(readDegradedMarker(configPath)).toBeNull();
+  });
+
+  test("--strict disables the fallback: fails hard even WITH a snapshot present", () => {
+    // Establish a snapshot via a good boot.
+    write(validCortex());
+    resolveBootConfig(configPath, { strict: false, now: () => FIXED_NOW });
+    expect(readLastGoodSnapshotPath(configPath)).not.toBeNull();
+
+    // Break it and boot --strict → fail hard, no fallback.
+    write(invalidCortex());
+    expect(() => resolveBootConfig(configPath, { strict: true, now: () => FIXED_NOW })).toThrow(
+      /--strict is set/,
+    );
+  });
+
+  test("good boot after a degraded boot clears the stale degraded marker", () => {
+    // Snapshot + degraded marker.
+    write(validCortex());
+    resolveBootConfig(configPath, { strict: false, now: () => FIXED_NOW });
+    write(invalidCortex());
+    resolveBootConfig(configPath, { strict: false, now: () => FIXED_NOW });
+    expect(readDegradedMarker(configPath)).not.toBeNull();
+
+    // Fix the live config → healthy boot clears the marker.
+    write(validCortex());
+    const { degraded } = resolveBootConfig(configPath, { strict: false, now: () => FIXED_NOW });
+    expect(degraded).toBeUndefined();
+    expect(readDegradedMarker(configPath)).toBeNull();
+  });
+
+  test("first boot with a bad config and no snapshot is unaffected by the snapshot dir existing empty", () => {
+    // Guard against a false-positive: an empty .last-good dir must not look like a snapshot.
+    write(invalidCortex());
+    expect(existsSync(join(dir, ".last-good"))).toBe(false);
+    expect(() => resolveBootConfig(configPath, { strict: false })).toThrow(/no last-known-good snapshot/);
+  });
+});

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -348,6 +348,15 @@ import {
 // PID (to signal a reload) without importing this whole module graph. Re-import
 // here so cortex.ts's lifecycle paths stay on the single source of truth.
 import { STATE_DIR, DEFAULT_CONFIG, pidFileFor } from "./common/pidfile";
+// FS-7 / D-3 (cortex#1839) — last-known-good boot fallback + degraded state.
+import { readLastGoodSnapshotPath, writeLastGoodSnapshot } from "./common/config/last-good";
+import {
+  clearDegradedMarker,
+  readDegradedMarker,
+  writeDegradedMarker,
+  type DegradedInfo,
+} from "./common/config/degraded-state";
+import { formatConfigLoadError } from "./common/config/validate-on-write";
 
 /**
  * Resolve the PID file path for a given `--config` value.
@@ -491,6 +500,14 @@ export interface CortexHandle {
 export interface StartCortexOptions {
   /** Override config-file path. Defaults to no watching. */
   configPath?: string;
+  /**
+   * FS-7 / D-3 (cortex#1839) — set when the daemon booted DEGRADED on the
+   * last-known-good snapshot because the LIVE config failed to load. Carries the
+   * precise load error + the snapshot path. Surfaced on the MC `/health` endpoint
+   * (via the embed) so the degraded state is visible, never silent. Undefined on
+   * a healthy boot.
+   */
+  degraded?: DegradedInfo;
   /** Skip the config-watcher (tests). */
   disableConfigWatcher?: boolean;
   /** Skip the Mission Control embed even if config.mc.enabled is set (tests). */
@@ -4332,6 +4349,8 @@ export async function startCortex(
         dbPath,
         port: config.mc.port,
         ...(mcHeadless ? { headless: true } : {}),
+        // FS-7 / D-3 (cortex#1839) — surface a degraded boot on MC `/health`.
+        ...(options.degraded !== undefined ? { degraded: options.degraded } : {}),
         agentPresence: () => presenceViewForApi,
         // MC-A1 (cortex#1275) — networks view (lazy; assigned in the federation
         // block once `resolvedPolicy` is known). null ⇒ empty `/api/networks`.
@@ -6131,6 +6150,72 @@ export async function bootOrDie<T>(
   }
 }
 
+/** Result of the D-3 boot-config resolution: the loaded config + optional degraded marker. */
+export interface BootConfigResolution {
+  loaded: ReturnType<typeof loadConfigWithAgents>;
+  /** Set when the LIVE config failed to load and the daemon fell back to last-good. */
+  degraded?: DegradedInfo;
+}
+
+/**
+ * FS-7 / D-3 (cortex#1839) — resolve the boot config with a last-known-good
+ * fallback. On a healthy load it refreshes the last-good snapshot and clears any
+ * stale degraded marker; on a load THROW it either fails hard (`strict`, or no
+ * snapshot to fall back to) or loads the last-good snapshot, writes a degraded
+ * marker, and returns the config tagged `degraded` so the daemon boots DEGRADED
+ * instead of crash-looping.
+ *
+ * `now` is injectable so tests get a deterministic `since` timestamp.
+ * Exported for unit testing.
+ */
+export function resolveBootConfig(
+  configPath: string,
+  opts: { strict: boolean; now?: () => string } = { strict: false },
+): BootConfigResolution {
+  const nowIso = opts.now ?? (() => new Date().toISOString());
+  try {
+    const loaded = loadConfigWithAgents(configPath);
+    // Healthy boot: refresh the last-good snapshot + clear any prior degraded state.
+    const snap = writeLastGoodSnapshot(configPath);
+    if (!snap.ok) {
+      // Non-fatal — a snapshot-write failure must not fail a good boot; log it.
+      process.stderr.write(
+        `cortex: WARN could not write last-good config snapshot: ${snap.error}\n`,
+      );
+    }
+    clearDegradedMarker(configPath);
+    return { loaded };
+  } catch (err) {
+    const preciseError = formatConfigLoadError(err).join("\n");
+    // `--strict` (CI / provisioning) never falls back — fail hard, loudly.
+    if (opts.strict) {
+      throw new Error(
+        `config load failed and --strict is set (no last-known-good fallback):\n  ${preciseError.replace(/\n/g, "\n  ")}`,
+        { cause: err },
+      );
+    }
+    const snapshotPath = readLastGoodSnapshotPath(configPath);
+    if (snapshotPath === null) {
+      // No snapshot to fall back to (first boot with a bad config) — fail hard.
+      throw new Error(
+        `config load failed and no last-known-good snapshot exists to fall back to:\n  ${preciseError.replace(/\n/g, "\n  ")}`,
+        { cause: err },
+      );
+    }
+    // D-3 fallback: boot DEGRADED on the last-good snapshot. A snapshot that
+    // itself fails to load (e.g. an env var it needs is now unset) is fatal —
+    // there is nothing safe left to boot, so let this throw propagate.
+    console.error(
+      `cortex: LIVE config failed to load — booting DEGRADED on last-known-good snapshot ${snapshotPath}.\n` +
+        `  Underlying error:\n  ${preciseError.replace(/\n/g, "\n  ")}`,
+    );
+    const loaded = loadConfigWithAgents(snapshotPath);
+    const info: DegradedInfo = { error: preciseError, snapshotPath, since: nowIso() };
+    writeDegradedMarker(configPath, info);
+    return { loaded, degraded: info };
+  }
+}
+
 if (import.meta.main) {
   const program = new Command()
     .name("cortex")
@@ -6147,7 +6232,11 @@ if (import.meta.main) {
     .description("Start the agent")
     .option("--config <path>", "Path to agent config YAML", DEFAULT_CONFIG)
     .option("--dry-run", "Validate config file and exit (no adapter / NATS / daemon startup)")
-    .action(async (options: { config: string; dryRun?: boolean }) => {
+    .option(
+      "--strict",
+      "FS-7/D-3: disable the last-known-good fallback — fail hard on an invalid config (CI / provisioning)",
+    )
+    .action(async (options: { config: string; dryRun?: boolean; strict?: boolean }) => {
       // cortex#88 item 2 — short-circuit: skip PID file, signal handlers,
       // and the full startCortex pipeline. Just parse + validate the config.
       if (options.dryRun) {
@@ -6183,8 +6272,16 @@ if (import.meta.main) {
       // exits the process non-zero instead of being swallowed as a "non-fatal"
       // unhandled rejection. The daemon must not survive a failed security gate.
       const handle = await bootOrDie(async () => {
+        // FS-7 / D-3 (cortex#1839) — resolve the boot config with a last-known-good
+        // fallback. A healthy load refreshes the snapshot + clears any degraded
+        // marker; a bad load either fails hard (`--strict` / no snapshot) or boots
+        // DEGRADED on the last-good snapshot (never a keepalive crash-loop). A
+        // fail-hard throw propagates to bootOrDie → FATAL exit, as before.
+        const { loaded, degraded } = resolveBootConfig(options.config, {
+          strict: options.strict === true,
+        });
         const { config, inlineAgents, stack, policy, principal, bus, surfaces, reflexActivation, notify, surfaceWarnings } =
-          loadConfigWithAgents(options.config);
+          loaded;
         // cortex#1217 — a surface secret placeholder with an unset env var no
         // longer FATAL-boots the daemon (which crash-looped the whole stack).
         // The resolver disabled that ONE surface; thread the inline/gateway
@@ -6193,6 +6290,8 @@ if (import.meta.main) {
         return startCortex(config, {
           ...(surfaceWarnings !== undefined && surfaceWarnings.length > 0 && { surfaceWarnings }),
           configPath: options.config,
+          // FS-7 / D-3 — thread the degraded marker so MC `/health` surfaces it.
+          ...(degraded !== undefined && { degraded }),
           ...(inlineAgents.length > 0 && { inlineAgents }),
           ...(stack !== undefined && { stack }),
           ...(policy !== undefined && { policy }),
@@ -6260,7 +6359,17 @@ if (import.meta.main) {
       const pid = parseInt(readFileSync(pidFile, "utf-8").trim());
       try {
         process.kill(pid, 0);
-        console.log(`cortex: running (PID ${pid}, ${pidFile})`);
+        // FS-7 / D-3 (cortex#1839) — surface a DEGRADED boot (running on the
+        // last-known-good snapshot because the LIVE config failed to load).
+        const degraded = readDegradedMarker(options.config);
+        if (degraded !== null) {
+          console.log(`cortex: running DEGRADED (PID ${pid}, ${pidFile})`);
+          console.log(`  booted on last-known-good snapshot: ${degraded.snapshotPath} (since ${degraded.since})`);
+          console.log(`  LIVE config load error:\n    ${degraded.error.replace(/\n/g, "\n    ")}`);
+          console.log(`  fix the live config, then restart to clear degraded state.`);
+        } else {
+          console.log(`cortex: running (PID ${pid}, ${pidFile})`);
+        }
       } catch {
         console.log(`cortex: stale PID file ${pidFile}`);
         unlinkSync(pidFile);

--- a/src/surface/mc/__tests__/server.test.ts
+++ b/src/surface/mc/__tests__/server.test.ts
@@ -77,6 +77,30 @@ describe("mission-control server", () => {
     expect(res.status).toBe(404);
   });
 
+  // FS-7 / D-3 (cortex#1839) — a degraded boot surfaces on /health.
+  it("reports status=degraded on /health when the daemon booted DEGRADED", async () => {
+    const degradedPort = 18768;
+    const degradedDb = initDatabase(join(tmpDir, "degraded.db"));
+    const ctx = startServer({ ...DEFAULT_CONFIG, port: degradedPort }, degradedDb, {
+      degraded: {
+        error: "agents[0].persona: Invalid input: expected string, received undefined",
+        snapshotPath: "/tmp/x/.last-good/x.snapshot",
+        since: "2026-07-10T00:00:00.000Z",
+      },
+    });
+    try {
+      const res = await fetch(`http://localhost:${degradedPort}/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("degraded");
+      expect(body.degraded.snapshotPath).toBe("/tmp/x/.last-good/x.snapshot");
+      expect(body.degraded.error).toContain("persona");
+    } finally {
+      ctx.server.stop(true);
+      degradedDb.close();
+    }
+  });
+
   // cortex#89 — this case depends on the bundled dashboard artifact at
   // `dist/dashboard-v2/index.html`. The build is not part of `bun test`
   // (option 2 from cortex#89: self-skip rather than bloat every run with

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -15,6 +15,7 @@
 import type { Database } from "bun:sqlite";
 import { dirname, join } from "path";
 
+import type { DegradedInfo } from "../../common/config/degraded-state";
 import { loadConfig } from "./config";
 import { initDatabase } from "./db/init";
 import { startServer } from "./server";
@@ -144,6 +145,12 @@ export interface StartMissionControlOptions {
    * a structured not-available error.
    */
   sidebandUrl?: string;
+  /**
+   * FS-7 / D-3 (cortex#1839) — set when the daemon booted DEGRADED on the
+   * last-known-good config snapshot. Forwarded verbatim to `startServer` so
+   * `GET /health` reports the degraded state. Omitted on a healthy boot.
+   */
+  degraded?: DegradedInfo;
 }
 
 /**
@@ -226,6 +233,7 @@ export async function startMissionControl(
       ...(opts.doctorView ? { doctorView: opts.doctorView } : {}),
       ...(opts.localAggregation ? { localAggregation: opts.localAggregation } : {}),
       ...(opts.sidebandUrl ? { sidebandUrl: opts.sidebandUrl } : {}),
+      ...(opts.degraded ? { degraded: opts.degraded } : {}),
     });
     const { server, wsRegistry } = serverCtx;
     hookPoller = new HookStreamPoller(db, config.hooks, wsRegistry);

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -61,6 +61,7 @@ import {
   type Authorizer,
 } from "./api/networks-authorize";
 import { verifyCfAccessJwt } from "../../common/auth/cf-access-jwt";
+import type { DegradedInfo } from "../../common/config/degraded-state";
 import type {
   LocalAggregationContext,
   LocalAggregationProvider,
@@ -144,12 +145,22 @@ export interface ServerContext {
 }
 
 export interface HealthResponse {
-  status: "ok";
+  /**
+   * `"ok"` on a healthy boot; `"degraded"` when the daemon booted on the
+   * last-known-good config snapshot because the LIVE config failed to load
+   * (FS-7 / D-3, cortex#1839). A monitor can alert on `status !== "ok"`.
+   */
+  status: "ok" | "degraded";
   version: string;
   /** Seconds since startServer. */
   uptime: number;
   /** Count of currently-connected WebSocket clients. */
   wsClients: number;
+  /**
+   * FS-7 / D-3 — present ONLY on a degraded boot: the precise live-config load
+   * error + the snapshot path the daemon fell back to. Absent on a healthy boot.
+   */
+  degraded?: DegradedInfo;
 }
 
 export interface StartServerOptions {
@@ -160,6 +171,13 @@ export interface StartServerOptions {
    * 503. The tests that don't exercise REST can keep calling without it.
    */
   processManager?: ProcessManager;
+  /**
+   * FS-7 / D-3 (cortex#1839) — set when the daemon booted DEGRADED on the
+   * last-known-good config snapshot (the LIVE config failed to load). Surfaced on
+   * `GET /health` so the degraded state is visible to monitors + the dashboard.
+   * Static (degraded status is fixed at boot); absent on a healthy boot.
+   */
+  degraded?: DegradedInfo;
   /**
    * Spawn override for CC children. Tests inject a `cat`-based fake; in
    * production this is left undefined and endpoint-resolver's default
@@ -377,11 +395,15 @@ export function startServer(
       // response or gate /health behind auth. Principal-liveness probes should
       // only see `status` + `version`.
       if (req.method === "GET" && url.pathname === "/health") {
+        // FS-7 / D-3 (cortex#1839) — a degraded boot flips `status` to
+        // `"degraded"` and attaches the load error + snapshot path so a monitor
+        // or the dashboard can alert on it instead of a silent fallback.
         const body: HealthResponse = {
-          status: "ok",
+          status: options.degraded !== undefined ? "degraded" : "ok",
           version: VERSION,
           uptime: Math.floor((Date.now() - startTime) / 1000),
           wsClients: wsRegistry.size,
+          ...(options.degraded !== undefined && { degraded: options.degraded }),
         };
         return Response.json(body);
       }


### PR DESCRIPTION
Closes #1839. Part of epic #1818 (Federation simplification), Wave 0. Design §4 FS-7 + §3 D-3 (RATIFIED #1819).

Closes the config-crash-loop class from this session's incident log: **fail loud early (validate on every config write), fail soft late (boot falls back to last-known-good, never keepalive-crash-loops)**.

## A. Validate-on-write — one shared validator, reused everywhere
- `src/common/config/validate-on-write.ts` — `validateConfigLoads`/`assertConfigLoads` wrap the existing #1808 `loadConfigWithAgents`; `formatConfigLoadError` extracted here (single formatter, byte-identical errors; `config.ts` imports it).
- Converged every writer onto it: **config-merge** (dropped its `CortexConfigSchema`-only fork onto `loadConfigWithAgents` + existing restore path), **migrate-config** (validate written file; also fixed a latent **0644→0600** perms gap), **stack `--apply`** (validate scaffold, roll back), **network join/leave/rotate-key** (extended `writeNetworksGuarded` with `validateComposePath` — validates the composed WHOLE, catching e.g. the accept_subjects ADR-0001 violation the scoped payload_key guard misses). Whole-config check is gated on "config loaded BEFORE the write" so it protects working configs without breaking stub-writing plumbing; atomic write now preserves file mode so the 0600 gate holds.

## B. D-3 last-known-good boot (`cortex.ts resolveBootConfig`)
- `src/common/config/last-good.ts` — 0600 composed snapshot (`.last-good/<basename>.snapshot`), round-trips through `loadConfigWithAgents`.
- `src/common/config/degraded-state.ts` — degraded marker keyed off `pidFileFor` (daemon-writer ⇄ `cortex status`-reader agree).
- Good boot → writes snapshot + clears marker. Bad load → fail-hard under `--strict`/no-snapshot, else boot **DEGRADED** on last-good (no crash-loop). New `--strict` flag. DEGRADED surfaced in `cortex status` + MC `/health`.

## Verification
- `bunx tsc --noEmit` → 0 errors; `bunx eslint --quiet` → clean.
- 319 pass / 0 fail (validate-on-write, last-good, D-3 all 5 acceptance cases, network-config-write byte-identity, config-merge/validate, migrate-config, stack-cli) + MC server /health degraded + config __tests__ 276.
- Additive (`--diff-filter=D` empty).

Note: `network-secret-cli.test.ts` has 20 **pre-existing** failures (env-dependent, read `~/.config/cortex`; fail identically on clean `origin/main`) — untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)