### PR TITLE
feat(cortex): FS-5b — per-peer 'can I hear X?' staged doctor leg (cred→import→arriving→gate→fold)

### DIFF
--- a/src/bus/agent-network/__tests__/federated-subscriber.test.ts
+++ b/src/bus/agent-network/__tests__/federated-subscriber.test.ts
@@ -491,6 +491,46 @@ describe("E.5 — TRUST: signed_by chain verification", () => {
     await handle.stop();
   });
 
+  test("FS-6 (cortex#1842) — a peer dropped at GATE 2 (chain-verify) STILL records a receipt", async () => {
+    // The receipt is recorded at federated-subscriber.ts:381, BEFORE both trust
+    // gates run — so a peer we can physically HEAR on the wire but whose chain
+    // fails verification (dropped at GATE 2, not GATE 1) is still "heard", never
+    // the misleading `absent-unheard`. Today only the GATE-1 drop path was
+    // receipt-tested; this locks the GATE-2 drop path too.
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const receipts = new FederatedPresenceReceipts();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      // joel IS accept-listed ⇒ passes GATE 1, so the drop is unambiguously GATE 2.
+      federated: federatedPolicy([networkWithJoel()]),
+      source: SYSTEM_SOURCE,
+      trustResolver: emptyTrustResolver(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      cryptoVerify: false,
+      receipts,
+      now: () => 8888,
+    });
+    const signed = foreignOnline({
+      signedBy: [
+        { method: "ed25519", identity: "did:mf:stranger", signature: "x", timestamp: "t" } as unknown as SignedBy,
+      ],
+    });
+    runtime.fire(signed, FED_SUBJECT, "primary");
+    await flush();
+    // DROPPED at GATE 2 (chain-verify) — not folded…
+    expect(registry.getAgents().length).toBe(0);
+    const denied = runtime.published.find((e) => e.type === "system.access.denied");
+    expect(denied).toBeDefined();
+    expect((denied!.payload as { reason: { kind: string } }).reason.kind).toBe("chain_verify_failed");
+    // …yet the receipt WAS recorded (heard on the wire, before the gates).
+    expect(receipts.everReceived("joel")).toBe(true);
+    expect(receipts.get("joel")).toEqual({ count: 1, lastAt: 8888 });
+    await handle.stop();
+  });
+
   test("verifier THREW ⇒ DROPPED + system.access.denied chain_verify_fault (cortex#932)", async () => {
     const runtime = makeFakeRuntime();
     const registry = new AgentPresenceRegistry();

--- a/src/bus/agent-network/federated-presence-receipts.ts
+++ b/src/bus/agent-network/federated-presence-receipts.ts
@@ -63,6 +63,18 @@ export interface FederatedPresenceReceipt {
  * semantics — "unheard" is about NEVER having heard, and a peer that goes stale
  * is "offline", surfaced by the ABSENCE of live presence, not by forgetting we
  * heard it).
+ *
+ * ## Daemon-restart transience (FS-6 review, cortex#1835 — accepted limitation)
+ *
+ * The ledger is PROCESS-LOCAL, so a freshly-booted daemon starts with an empty
+ * map: a genuinely-online peer reads `absent-unheard` (import/cred gap) until its
+ * NEXT presence heartbeat arrives and records the first receipt. This is
+ * transient and SELF-HEALS within one heartbeat interval — not a real import/cred
+ * gap — so a `absent-unheard` verdict on a just-restarted daemon should be read
+ * as "not heard YET this process", not "deaf to this peer". Persisting receipts
+ * across restarts was deliberately NOT done (it would resurrect stale "heard"
+ * claims for peers that departed while we were down); the momentary post-boot
+ * false-unheard is the accepted cost of the honest, memory-only tally.
  */
 export class FederatedPresenceReceipts {
   private readonly receipts = new Map<string, FederatedPresenceReceipt>();

--- a/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-doctor-lib.test.ts
@@ -35,6 +35,7 @@ import type {
   DoctorConfigPort,
   LeafzResponse,
   NetworkDoctorPorts,
+  PeerHearingPorts,
 } from "../network-doctor-ports";
 import type {
   LeafzCounters,
@@ -178,6 +179,36 @@ function echoReply(fired: ProbeFireInputs, rttMs: number): ProbeRoundTripResult 
   return { kind: "reply", rttMs, reply };
 }
 
+/**
+ * FS-5b (cortex#1842) — a fake {@link PeerHearingPorts}. Each field defaults to
+ * `undefined` ("undeterminable" ⇒ the stage warns); set a field to drive a
+ * pass/fail. A fully-`true` + `admitted-present` port makes all four non-gate
+ * hearing stages pass (the gate stage is pure — it passes on a healthy config).
+ */
+function fakeHearingPort(opts: {
+  credAllows?: boolean;
+  imported?: boolean;
+  arriving?: boolean;
+  fold?: string;
+} = {}): PeerHearingPorts {
+  return {
+    credAllowsScope: () => opts.credAllows,
+    scopeImported: async () => opts.imported,
+    presenceArriving: async () => opts.arriving,
+    foldVerdict: () => opts.fold,
+  };
+}
+
+/** A hearing port where every non-gate stage passes (healthy peer). */
+function healthyHearingPort(): PeerHearingPorts {
+  return fakeHearingPort({
+    credAllows: true,
+    imported: true,
+    arriving: true,
+    fold: "admitted-present",
+  });
+}
+
 function findCheck(checks: DoctorCheck[], id: string): DoctorCheck {
   const c = checks.find((x) => x.id === id);
   if (c === undefined) throw new Error(`no check with id "${id}" in ${JSON.stringify(checks.map((x) => x.id))}`);
@@ -198,6 +229,7 @@ describe("runDoctorChecks — (a) all-green", () => {
       config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
       monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
       probe: fakeProbe((f) => echoReply(f, 41)),
+      hearing: healthyHearingPort(),
     };
     const res = await runDoctorChecks(ports, {
       cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
@@ -209,8 +241,9 @@ describe("runDoctorChecks — (a) all-green", () => {
     expect(res.exitCode).toBe(DOCTOR_EXIT_CODE.healthy);
     // 5 pre-#1482 legs + registered-vs-fed-account + resolver-preload-account
     // + the sealed-secret-hub-authorized stub (always present, always skip)
-    // + the cortex#1728 leafnode-authorization-bomb leg.
-    expect(res.checks).toHaveLength(9);
+    // + the cortex#1728 leafnode-authorization-bomb leg + FS-5b's 5-stage
+    // "can I hear X?" chain for the single configured peer (9 + 5 = 14).
+    expect(res.checks).toHaveLength(14);
     expect(findCheck(res.checks, "config-network").status).toBe("pass");
     expect(findCheck(res.checks, "leafnode-authorization-bomb").status).toBe("pass");
     expect(findCheck(res.checks, "registered-vs-fed-account").status).toBe("pass");
@@ -223,6 +256,12 @@ describe("runDoctorChecks — (a) all-green", () => {
     expect(peerCheck.status).toBe("pass");
     expect(peerCheck.owner).toBe("peer");
     expect(peerCheck.detail).toContain("rtt=41ms");
+    // FS-5b — all five hearing stages pass on a healthy peer.
+    for (const stage of ["cred-perms", "import", "envelopes-arriving", "gate", "fold"]) {
+      const c = findCheck(res.checks, `peer-hearing:${stage}:jc/default`);
+      expect(c.status).toBe("pass");
+      expect(c.owner).toBe("peer");
+    }
     // A skip'd leg (Pair 3) is a valid outcome, not a broken/degraded verdict.
     expect(res.verdict).not.toBe("broken");
     // Every check carries a responsible owner.
@@ -880,5 +919,177 @@ describe("selectNetworkLeaf — multi-leaf attribution (cortex#1728)", () => {
   test("empty leafs ⇒ undefined", () => {
     expect(selectNetworkLeaf({ leafs: [] }, "hub")).toBeUndefined();
     expect(selectNetworkLeaf({}, "hub")).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// FS-5b (cortex#1842) — per-peer "can I hear X?" staged chain
+// ===========================================================================
+
+/** The FS-5b stage ids for the single fixture peer `jc/default`, in order. */
+const HEARING_IDS = [
+  "peer-hearing:cred-perms:jc/default",
+  "peer-hearing:import:jc/default",
+  "peer-hearing:envelopes-arriving:jc/default",
+  "peer-hearing:gate:jc/default",
+  "peer-hearing:fold:jc/default",
+];
+
+describe("runDoctorChecks — FS-5b hearing chain", () => {
+  test("healthy peer ⇒ all five stages pass, owner peer, in order", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 12)),
+      hearing: healthyHearingPort(),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    for (const id of HEARING_IDS) {
+      const c = findCheck(res.checks, id);
+      expect(c.status).toBe("pass");
+      expect(c.owner).toBe("peer");
+    }
+    // The five hearing checks appear in canonical stage order.
+    const emitted = res.checks.filter((c) => c.id.startsWith("peer-hearing:")).map((c) => c.id);
+    expect(emitted).toEqual(HEARING_IDS);
+    expect(res.verdict).toBe("healthy");
+  });
+
+  test("fold-broken peer (the jc case) ⇒ stages 1-4 pass, stage 5 (fold) FAILs pointing at source-binding/pubkey", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 12)),
+      // cred/import/arriving all pass, but the roster verdict is absent — the peer
+      // is heard + gate-accepted yet does not fold (missing/wrong pubkey).
+      hearing: fakeHearingPort({
+        credAllows: true,
+        imported: true,
+        arriving: true,
+        fold: "absent-unheard",
+      }),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "peer-hearing:cred-perms:jc/default").status).toBe("pass");
+    expect(findCheck(res.checks, "peer-hearing:import:jc/default").status).toBe("pass");
+    expect(findCheck(res.checks, "peer-hearing:envelopes-arriving:jc/default").status).toBe("pass");
+    expect(findCheck(res.checks, "peer-hearing:gate:jc/default").status).toBe("pass");
+    const fold = findCheck(res.checks, "peer-hearing:fold:jc/default");
+    expect(fold.status).toBe("fail");
+    expect(fold.detail).toContain("does NOT fold");
+    expect(fold.fix).toContain("source-bound");
+    expect(fold.fix).toContain("FS-1");
+    // A fold fail is non-critical ⇒ degraded (leaf + echo still work).
+    expect(res.verdict).toBe("degraded");
+  });
+
+  test("cred-broken peer ⇒ stage 1 FAILs and stages 2-5 SKIP (don't probe what can't work)", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 12)),
+      // credAllows:false ⇒ the leaf cred can't even subscribe X's scope. Later
+      // stages must NOT run (they'd probe a subscription that can't exist).
+      hearing: fakeHearingPort({
+        credAllows: false,
+        imported: true,
+        arriving: true,
+        fold: "admitted-present",
+      }),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const cred = findCheck(res.checks, "peer-hearing:cred-perms:jc/default");
+    expect(cred.status).toBe("fail");
+    expect(cred.fix).toContain("allow-sub");
+    for (const id of HEARING_IDS.slice(1)) {
+      const c = findCheck(res.checks, id);
+      expect(c.status).toBe("skip");
+      expect(c.detail).toContain("cred-perms");
+    }
+  });
+
+  test("envelopes-arriving silent (subscribed but nothing arrives) ⇒ stage 3 FAILs, gate+fold SKIP", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 12)),
+      hearing: fakeHearingPort({ credAllows: true, imported: true, arriving: false }),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "peer-hearing:cred-perms:jc/default").status).toBe("pass");
+    expect(findCheck(res.checks, "peer-hearing:import:jc/default").status).toBe("pass");
+    const arriving = findCheck(res.checks, "peer-hearing:envelopes-arriving:jc/default");
+    expect(arriving.status).toBe("fail");
+    expect(arriving.detail).toContain("jc case");
+    expect(findCheck(res.checks, "peer-hearing:gate:jc/default").status).toBe("skip");
+    expect(findCheck(res.checks, "peer-hearing:fold:jc/default").status).toBe("skip");
+  });
+
+  test("gate stage is PURE — a denied subject FAILs the gate stage", async () => {
+    // joel's presence subject is on the deny-list ⇒ evaluateFederationGate drops
+    // it ⇒ the gate stage fails (no injected port — the REAL gate runs).
+    const denyNet = network({
+      deny_subjects: ["federated.jc.default.agent.>"],
+    });
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([denyNet], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 12)),
+      hearing: fakeHearingPort({ credAllows: true, imported: true, arriving: true }),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    const gate = findCheck(res.checks, "peer-hearing:gate:jc/default");
+    expect(gate.status).toBe("fail");
+    expect(gate.detail).toContain("peer_deny_list");
+    expect(findCheck(res.checks, "peer-hearing:fold:jc/default").status).toBe("skip");
+  });
+
+  test("no hearing port wired ⇒ non-gate stages WARN, gate still yields a hard verdict, verdict stays healthy", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([network()], "ACCOUNT_A", (acct) => acct === "ACCOUNT_A"),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 12)),
+      // hearing omitted
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    expect(findCheck(res.checks, "peer-hearing:cred-perms:jc/default").status).toBe("warn");
+    expect(findCheck(res.checks, "peer-hearing:import:jc/default").status).toBe("warn");
+    expect(findCheck(res.checks, "peer-hearing:envelopes-arriving:jc/default").status).toBe("warn");
+    expect(findCheck(res.checks, "peer-hearing:gate:jc/default").status).toBe("pass");
+    expect(findCheck(res.checks, "peer-hearing:fold:jc/default").status).toBe("warn");
+    // Warns never block healthy.
+    expect(res.verdict).toBe("healthy");
+  });
+
+  test("no peer-hearing checks are emitted when config-network fails (early return)", async () => {
+    const ports: NetworkDoctorPorts = {
+      config: fakeConfigPort([]),
+      monitor: fakeMonitorPort({ configured: true, leafz: ESTABLISHED_LEAFZ }),
+      probe: fakeProbe((f) => echoReply(f, 12)),
+      hearing: healthyHearingPort(),
+    };
+    const res = await runDoctorChecks(ports, {
+      cfg: loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]),
+      networkId: "metafactory-community",
+    });
+    expect(res.checks.some((c) => c.id.startsWith("peer-hearing:"))).toBe(false);
   });
 });

--- a/src/cli/cortex/commands/network-doctor-adapters.ts
+++ b/src/cli/cortex/commands/network-doctor-adapters.ts
@@ -32,7 +32,9 @@ import type {
   DoctorNetworksSnapshot,
   LeafzResponse,
   MonitorPort,
+  PeerHearingPorts,
 } from "./network-doctor-ports";
+import type { PresenceListenerPort } from "./network-ping-adapters";
 import {
   resolveConfigIncludes,
   scanForLeafnodeAuthorizationBomb,
@@ -225,6 +227,53 @@ const doctorConfigFileReader: ConfigFileReader = {
     return join(dir, file);
   },
 };
+
+// =============================================================================
+// FS-5b (cortex#1842) — live per-peer "can I hear X?" hearing port.
+// =============================================================================
+
+/**
+ * The live {@link PeerHearingPorts}. Only the STAGE-3 seam (`presenceArriving`,
+ * the one bounded live subscribe — the headline diagnosis of the two-day
+ * zero-presence hunt) is fully wired here, via the injected
+ * {@link PresenceListenerPort} (`wrapRuntimeAsPresenceListener`, reusing `ping`'s
+ * runtime transport). The other three seams degrade to `undefined` ("could not
+ * determine from here" ⇒ the stage `warn`s, NEVER a false `fail`), each for an
+ * HONEST reason the pure orchestrator + unit tests already exercise fully with
+ * fakes:
+ *
+ *   - `credAllowsScope` — parsing the leaf cred's JWT `allow-sub` is a follow-up
+ *     (a false negative here would be a false alarm; a documented stub is more
+ *     honest than a half-parse, mirroring the Pair-3 sealed-secret leg).
+ *   - `scopeImported` — the federated presence interest is a SINGLE firehose
+ *     (`federated.*.*.agent.>`, per `federatedAgentPresenceSubject`), so live
+ *     leaf-import detection largely restates `leaf-established`; left as a
+ *     follow-up rather than risk a false negative from fuzzy subs matching.
+ *   - `foldVerdict` — the roster verdict lives in the RUNNING daemon's memory
+ *     (the `FederatedPresenceReceipts` ledger), unreadable from a standalone CLI
+ *     without a new daemon/MC read endpoint (the option-b coupling FS-5b's stage
+ *     3 deliberately avoids).
+ */
+export function buildPeerHearingPort(presence: PresenceListenerPort): PeerHearingPorts {
+  return {
+    // Follow-up: parse the leaf cred JWT allow-sub. Undeterminable ⇒ warn.
+    credAllowsScope(_scope: string): boolean | undefined {
+      return undefined;
+    },
+    // Follow-up: read leaf subscription interest. Undeterminable ⇒ warn.
+    scopeImported(_scope: string, _leafNode: string): Promise<boolean | undefined> {
+      return Promise.resolve(undefined);
+    },
+    // The live stage-3 probe: one bounded subscribe on X's presence scope.
+    presenceArriving(scope: string, timeoutMs: number): Promise<boolean | undefined> {
+      return presence.listen(scope, timeoutMs);
+    },
+    // The roster verdict is daemon-memory-resident; unreadable from the CLI.
+    foldVerdict(_principal: string): string | undefined {
+      return undefined;
+    },
+  };
+}
 
 /**
  * The live {@link MonitorPort}: resolves the monitor base via the SAME

--- a/src/cli/cortex/commands/network-doctor-lib.ts
+++ b/src/cli/cortex/commands/network-doctor-lib.ts
@@ -38,6 +38,11 @@
  * gracefully (warn/skip) rather than block downstream legs.
  */
 
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import {
+  evaluateFederationGate,
+  type FederationGateDecision,
+} from "../../../bus/surface-router";
 import type { LoadedConfig } from "../../../common/config/loader";
 import { stackSlugFromStackId } from "../../../common/stack-id";
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
@@ -52,6 +57,7 @@ import type {
   LeafzEntry,
   LeafzResponse,
   NetworkDoctorPorts,
+  PeerHearingPorts,
 } from "./network-doctor-ports";
 
 // ---------------------------------------------------------------------------
@@ -720,6 +726,277 @@ async function checkPeerReachable(
 }
 
 // ---------------------------------------------------------------------------
+// Leg 5b — per-peer "can I hear X?" staged chain (FS-5b, cortex#1842)
+// ---------------------------------------------------------------------------
+
+/**
+ * FS-5b (cortex#1842) — decompose the one-directional presence path (X → me)
+ * into FIVE ordered stages so the FIRST failing stage names WHERE the break is,
+ * instead of a broken fold looking identical to a broken cred:
+ *
+ *   1. cred-perms          — my leaf cred's allow-sub permits X's scope?
+ *   2. import              — the live leaf is actually subscribed to X's scope?
+ *   3. envelopes-arriving  — X's presence physically reaches my bus? (the ONE
+ *                            bounded live subscribe per peer — see the seam note)
+ *   4. gate                — evaluateFederationGate ACCEPTS an envelope from X?
+ *   5. fold                — X's presence actually folds onto the roster?
+ *
+ * ## Stage-3 transport seam (option a — live bounded subscribe)
+ *
+ * envelopes-arriving PREFERS a live bounded subscribe on
+ * `federated.{X.principal}.{X.stack}.agent.>` for `probeTimeoutMs`, reusing the
+ * SAME runtime transport `ping`'s probe rides (`wrapRuntimeAsPresenceListener`,
+ * network-ping-adapters.ts) — self-contained (no daemon dependency), matching
+ * the doctor's read-only + one-probe-per-peer contract. The rejected
+ * alternative (option b) — querying a running daemon's
+ * `FederatedPresenceReceipts.everReceived(X)` via an MC endpoint — is more
+ * faithful to what the daemon actually heard but couples the CLI to a live
+ * daemon + a new read endpoint; option a keeps the doctor standalone. The
+ * `undefined` (no-runtime) path degrades to `warn`, never a false `fail`.
+ *
+ * ## Chain semantics
+ *
+ * A stage FAIL stops the chain — every later stage is `skip` (running a probe a
+ * broken prerequisite can't support is noise; the first failing stage IS the
+ * diagnosis). A `warn` (undeterminable, e.g. `hearing` port absent) does NOT
+ * stop the chain. The `gate` stage is computed PURELY (no injected port) via the
+ * real {@link evaluateFederationGate}; the other four ride {@link PeerHearingPorts}.
+ */
+type HearingStage =
+  | "cred-perms"
+  | "import"
+  | "envelopes-arriving"
+  | "gate"
+  | "fold";
+
+function hearingCheckId(stage: HearingStage, label: string): string {
+  return `peer-hearing:${stage}:${label}`;
+}
+
+function hearingTitle(stage: HearingStage, label: string): string {
+  return `can I hear ${label}? — ${stage}`;
+}
+
+/**
+ * The gate stage, computed PURELY by calling the REAL
+ * {@link evaluateFederationGate} against a representative presence envelope from
+ * peer X — the doctor exercises the exact accept-list/deny/hop logic the live
+ * federated subscriber runs (reuse, not reinvent).
+ *
+ * `sourceLink` is deliberately left undefined: the anti-spoof cross-check is a
+ * LIVE delivering-link property, not a config one — supplying a synthetic link
+ * would test something other than "would my posture accept X's presence". The
+ * gate skips that check when `sourceLink` is undefined, matching an
+ * un-attributed / primary-routed inbound.
+ */
+function evaluatePeerPresenceGate(
+  ports: NetworkDoctorPorts,
+  targetPrincipal: string,
+  targetStack: string,
+): FederationGateDecision {
+  const networksById = new Map<string, PolicyFederatedNetwork>();
+  for (const n of ports.config.readNetworks().networks) networksById.set(n.id, n);
+
+  const subject = `federated.${targetPrincipal}.${targetStack}.agent.presence`;
+  const envelope: Envelope = {
+    id: "00000000-0000-4000-8000-000000000000",
+    // `source` leads with the SOURCE PRINCIPAL — the gate resolves the source
+    // network from `principalFromEnvelope(envelope)` (the first `source` segment).
+    source: `${targetPrincipal}.${targetStack}.presence`,
+    type: "agent.presence.online",
+    timestamp: "1970-01-01T00:00:00.000Z",
+    sovereignty: {
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 1,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: {},
+  };
+  return evaluateFederationGate(subject, envelope, networksById);
+}
+
+/**
+ * Run the five-stage "can I hear X?" chain for ONE configured peer, returning
+ * one {@link DoctorCheck} per stage (owner `"peer"`), in order. Read-only apart
+ * from the ONE bounded presence subscribe (stage 3), matching Leg 5's contract.
+ */
+async function checkPeerHearing(
+  ports: NetworkDoctorPorts,
+  opts: DoctorOptions,
+  network: PolicyFederatedNetwork,
+  peer: PolicyFederatedNetwork["peers"][number],
+): Promise<DoctorCheck[]> {
+  const targetStack = stackSlugFromStackId(peer.stack_id);
+  const label = `${peer.principal_id}/${targetStack}`;
+  const scope = `federated.${peer.principal_id}.${targetStack}.>`;
+  const timeoutMs = opts.probeTimeoutMs ?? DEFAULT_DOCTOR_PROBE_TIMEOUT_MS;
+  const hearing: PeerHearingPorts | undefined = ports.hearing;
+
+  const results: DoctorCheck[] = [];
+  // Once a stage FAILS, every later stage is `skip` — the first failing stage
+  // names the break. A `warn` (undeterminable) does NOT stop the chain.
+  let brokenBy: HearingStage | undefined;
+
+  const hc = (
+    stage: HearingStage,
+    status: DoctorCheckStatus,
+    detail: string,
+    fix?: string,
+  ): DoctorCheck =>
+    check(hearingCheckId(stage, label), hearingTitle(stage, label), status, detail, "peer", fix);
+
+  const skipStage = (stage: HearingStage): DoctorCheck =>
+    check(
+      hearingCheckId(stage, label),
+      hearingTitle(stage, label),
+      "skip",
+      `skipped — an earlier hearing stage (${brokenBy ?? "?"}) failed; fix that first`,
+      "peer",
+    );
+
+  // --- Stage 1: cred-perms ---------------------------------------------------
+  const allowed = hearing?.credAllowsScope(scope);
+  if (allowed === undefined) {
+    results.push(
+      hc(
+        "cred-perms",
+        "warn",
+        `could not read my leaf cred's allow-sub to verify it permits ${scope} (cred unreadable / not operator-mode / not wired)`,
+        "confirm the leaf cred named in leafnodes-<network>.conf permits sub on this peer's federated scope",
+      ),
+    );
+  } else if (!allowed) {
+    results.push(
+      hc(
+        "cred-perms",
+        "fail",
+        `my leaf credential's allow-sub does NOT permit ${scope} — I can never subscribe X's presence`,
+        "widen the leaf cred's allow-sub to include this peer's federated scope, then reconnect the leaf",
+      ),
+    );
+    brokenBy = "cred-perms";
+  } else {
+    results.push(hc("cred-perms", "pass", `leaf cred allow-sub permits ${scope}`));
+  }
+
+  // --- Stage 2: import -------------------------------------------------------
+  if (brokenBy !== undefined) {
+    results.push(skipStage("import"));
+  } else {
+    const imported =
+      hearing !== undefined ? await hearing.scopeImported(scope, network.leaf_node) : undefined;
+    if (imported === undefined) {
+      results.push(
+        hc(
+          "import",
+          "warn",
+          `could not read the leaf's subscription interest to confirm ${scope} is imported`,
+          "enable the nats-server monitor (http_port/monitor_port) so leaf import interest is visible to doctor",
+        ),
+      );
+    } else if (!imported) {
+      results.push(
+        hc(
+          "import",
+          "fail",
+          `the cred allows ${scope} but the live leaf "${network.leaf_node}" is NOT subscribed to it — an import/reconnect gap`,
+          "reconnect the leaf (or restart the daemon) so the federated presence interest is re-imported onto the leaf",
+        ),
+      );
+      brokenBy = "import";
+    } else {
+      results.push(hc("import", "pass", `${scope} is imported on leaf "${network.leaf_node}"`));
+    }
+  }
+
+  // --- Stage 3: envelopes-arriving (the ONE bounded live subscribe) ----------
+  if (brokenBy !== undefined) {
+    results.push(skipStage("envelopes-arriving"));
+  } else {
+    const arriving =
+      hearing !== undefined ? await hearing.presenceArriving(scope, timeoutMs) : undefined;
+    if (arriving === undefined) {
+      results.push(
+        hc(
+          "envelopes-arriving",
+          "warn",
+          `could not run the bounded presence subscribe on ${scope} (no runtime wired / bus disabled)`,
+          "run doctor against a reachable bus so it can subscribe this peer's presence scope",
+        ),
+      );
+    } else if (!arriving) {
+      results.push(
+        hc(
+          "envelopes-arriving",
+          "fail",
+          `subscribed ${scope} but NO presence envelope arrived within ${timeoutMs.toString()}ms — nothing is reaching my bus (hub-side import/pub gap; this was the jc case)`,
+          "check the HUB imports/exports X's scope onto my leaf, and that X's stack is actually publishing presence",
+        ),
+      );
+      brokenBy = "envelopes-arriving";
+    } else {
+      results.push(
+        hc("envelopes-arriving", "pass", `≥1 presence envelope from ${scope} arrived on my bus`),
+      );
+    }
+  }
+
+  // --- Stage 4: gate (PURE — the real evaluateFederationGate) ----------------
+  if (brokenBy !== undefined) {
+    results.push(skipStage("gate"));
+  } else {
+    const decision = evaluatePeerPresenceGate(ports, peer.principal_id, targetStack);
+    if (decision === "allow") {
+      results.push(
+        hc("gate", "pass", `evaluateFederationGate ACCEPTS a presence envelope from ${label}`),
+      );
+    } else {
+      results.push(
+        hc(
+          "gate",
+          "fail",
+          `a presence envelope from ${label} is DROPPED by evaluateFederationGate (${decision.kind}) under my current posture/accept-list/peers`,
+          "fix the accept_subjects/deny_subjects/peers[]/hop budget for this network so X's presence subject is accepted",
+        ),
+      );
+      brokenBy = "gate";
+    }
+  }
+
+  // --- Stage 5: fold ---------------------------------------------------------
+  if (brokenBy !== undefined) {
+    results.push(skipStage("fold"));
+  } else {
+    const verdict = hearing?.foldVerdict(peer.principal_id);
+    if (verdict === undefined) {
+      results.push(
+        hc(
+          "fold",
+          "warn",
+          `the roster fold verdict for ${peer.principal_id} is not determinable from the CLI (it lives in the running daemon's memory)`,
+          "check the daemon / Mission Control roster for this peer's membership verdict",
+        ),
+      );
+    } else if (verdict !== "admitted-present") {
+      results.push(
+        hc(
+          "fold",
+          "fail",
+          `${label} passes the gate but does NOT fold onto the roster (verdict "${verdict}", not "admitted-present") — source-binding/pubkey (FS-1 territory)`,
+          "verify X's presence is source-bound to a pubkey I trust (FS-1 #1825): the fold drops presence whose signer pubkey is missing/wrong",
+        ),
+      );
+    } else {
+      results.push(hc("fold", "pass", `${label} folds onto the roster (admitted-present)`));
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
 // Verdict aggregation
 // ---------------------------------------------------------------------------
 
@@ -825,6 +1102,17 @@ export async function runDoctorChecks(
     network.peers.map((peer) => checkPeerReachable(ports, opts, peer)),
   );
   checks.push(...peerChecks);
+
+  // 5b. FS-5b (cortex#1842) — per-peer "can I hear X?" staged chain. One ordered
+  // five-stage sub-report per configured peer (cred-perms → import →
+  // envelopes-arriving → gate → fold), so the FIRST failing stage names WHERE
+  // the one-directional presence path (X → me) breaks. Read-only apart from the
+  // ONE bounded presence subscribe per peer (stage 3), matching Leg 5's
+  // read-only+one-probe contract. Concurrent per peer (each chain is independent).
+  const peerHearing = await Promise.all(
+    network.peers.map((peer) => checkPeerHearing(ports, opts, network, peer)),
+  );
+  for (const chain of peerHearing) checks.push(...chain);
 
   const verdict = aggregateVerdict(checks);
   return { checks, verdict, exitCode: DOCTOR_EXIT_CODE[verdict] };

--- a/src/cli/cortex/commands/network-doctor-ports.ts
+++ b/src/cli/cortex/commands/network-doctor-ports.ts
@@ -111,6 +111,65 @@ export interface MonitorPort {
 // The ports bundle
 // =============================================================================
 
+// =============================================================================
+// FS-5b (cortex#1842) — per-peer "can I hear X?" staged-chain seams
+// =============================================================================
+
+/**
+ * FS-5b (cortex#1842) — the four INJECTED data needs of the per-peer "can I hear
+ * X?" staged chain (`cred-perms → import → envelopes-arriving → …→ fold`). The
+ * FIFTH stage — `gate` — is NOT here: it is computed PURELY in the orchestrator
+ * by calling the real `evaluateFederationGate` (`surface-router.ts:1057`) against
+ * a representative presence envelope, so the doctor exercises the exact accept-
+ * list/deny/hop/anti-spoof logic the live subscriber runs (reuse, not reinvent).
+ *
+ * Every method is BEST-EFFORT: a `undefined` return means "could not determine
+ * from here" and the stage degrades to `warn` (never a false `fail`), exactly
+ * like the monitor-inconclusive and Pair-3-stub legs already do. A `false`
+ * return is a POSITIVE negative — the stage FAILs and the chain stops (later
+ * stages `skip`), because the first failing stage names the break.
+ *
+ * OPTIONAL on {@link NetworkDoctorPorts}: when the whole port is absent (no
+ * runtime wired), the four non-gate stages all `warn` and only the pure `gate`
+ * stage yields a hard verdict — a coherent, honest partial diagnosis.
+ */
+export interface PeerHearingPorts {
+  /**
+   * cred-perms — does my leaf credential's `allow-sub` permit `scope`
+   * (`federated.{X.principal}.{X.stack}.>`)? `true` = permitted, `false` = the
+   * cred cannot subscribe X's scope (widen `allow-sub`), `undefined` = the cred
+   * / its permissions could not be read (degrade to warn). Synchronous — a
+   * static file/JWT read.
+   */
+  credAllowsScope(scope: string): boolean | undefined;
+  /**
+   * import — is `scope` actually imported/subscribed on the live leaf named
+   * `leafNode`? Read from the nats-server monitor's subscription interest.
+   * `false` = the cred allows it but the leaf is not subscribed (import/reconnect
+   * gap); `undefined` = subscription interest could not be read (warn).
+   */
+  scopeImported(scope: string, leafNode: string): Promise<boolean | undefined>;
+  /**
+   * envelopes-arriving — are X's presence envelopes physically reaching my bus?
+   * A LIVE bounded subscribe on `federated.{X.principal}.{X.stack}.agent.>` for
+   * `timeoutMs` (the SAME runtime transport `ping`'s probe uses — the doctor's
+   * one bounded read-side probe per peer, matching Leg 5's read-only+one-probe
+   * contract). `true` = ≥1 envelope arrived, `false` = subscribed but silent
+   * (hub-side import/pub gap — the jc case), `undefined` = could not probe (no
+   * runtime; warn).
+   */
+  presenceArriving(scope: string, timeoutMs: number): Promise<boolean | undefined>;
+  /**
+   * fold — does X's presence actually fold onto the roster? Returns the peer
+   * principal's membership verdict (`admitted-present` when folded; an `absent-*`
+   * string when gate-passed-but-not-folding — FS-1 source-binding/pubkey
+   * territory). `undefined` = the roster verdict is not determinable from the CLI
+   * (it lives in the running daemon's memory — warn, "run on the daemon / check
+   * Mission Control").
+   */
+  foldVerdict(principal: string): string | undefined;
+}
+
 export interface NetworkDoctorPorts {
   config: DoctorConfigPort;
   monitor: MonitorPort;
@@ -121,4 +180,10 @@ export interface NetworkDoctorPorts {
    * check per configured peer instead of a `ping -c` report.
    */
   probe: NetworkPingPorts;
+  /**
+   * FS-5b (cortex#1842) — OPTIONAL per-peer "can I hear X?" staged-chain seams.
+   * Absent ⇒ the four non-gate stages degrade to `warn` and only the pure `gate`
+   * stage yields a hard verdict.
+   */
+  hearing?: PeerHearingPorts;
 }

--- a/src/cli/cortex/commands/network-ping-adapters.ts
+++ b/src/cli/cortex/commands/network-ping-adapters.ts
@@ -64,6 +64,40 @@ export async function createLiveProbeBus(
 }
 
 /**
+ * FS-5b (cortex#1842) — a probe bus + presence listener sharing ONE runtime,
+ * so `doctor` opens a SINGLE NATS connection for BOTH read-sides (Leg 5's echo
+ * round-trip and Leg 5b stage-3's bounded presence subscribe). The shared
+ * {@link stop} drains that one runtime.
+ */
+export interface LiveProbeAndPresence {
+  bus: LiveProbeBus;
+  presence: PresenceListenerPort;
+  /** Arrow-typed (not a method) so destructuring `stop` never trips the
+   *  unbound-method lint — it captures the runtime, not `this`. */
+  stop: () => Promise<void>;
+}
+
+/**
+ * Start ONE runtime from the stack's `AgentConfig` and derive both the probe
+ * bus and the presence listener from it. Mirrors {@link createLiveProbeBus}'s
+ * signer handling; the runtime stays the single owner of the NATS connection.
+ */
+export async function createLiveProbeAndPresence(
+  config: AgentConfig,
+  signer?: BusEnvelopeSigner,
+): Promise<LiveProbeAndPresence> {
+  const runtime: MyelinRuntime = await startMyelinRuntime(
+    config,
+    signer !== undefined ? { signer } : undefined,
+  );
+  return {
+    bus: wrapRuntimeAsProbeBus(runtime),
+    presence: wrapRuntimeAsPresenceListener(runtime),
+    stop: () => runtime.stop(),
+  };
+}
+
+/**
  * Wrap an already-started runtime as a probe bus. Exported separately so an
  * integration test (or a future caller that already holds a runtime) can reuse
  * the fire/await logic without re-starting NATS.
@@ -139,6 +173,79 @@ export function wrapRuntimeAsProbeBus(runtime: MyelinRuntime): LiveProbeBus {
 
     async stop() {
       await runtime.stop();
+    },
+  };
+}
+
+// =============================================================================
+// FS-5b (cortex#1842) — live bounded presence listener (doctor stage 3)
+// =============================================================================
+
+/**
+ * FS-5b (cortex#1842) — a bounded, one-directional presence LISTENER, the live
+ * transport for the doctor's stage-3 "envelopes-arriving" probe. Reuses the
+ * SAME runtime primitives {@link wrapRuntimeAsProbeBus} rides (declare interest
+ * via `runtime.subscribe`, match on `runtime.onEnvelope`, race a timeout) but as
+ * a pure READ: no request goes on the wire — we only listen for X's presence.
+ */
+export interface PresenceListenerPort {
+  /**
+   * Subscribe `scope` (`federated.{X}.{stack}.>`) and resolve `true` on the
+   * FIRST envelope whose subject falls under it, else `false` after `timeoutMs`.
+   * Best-effort: a disabled runtime (or one lacking `subscribe`) resolves
+   * `undefined` so the stage warns rather than emitting a false `fail`.
+   */
+  listen(scope: string, timeoutMs: number): Promise<boolean | undefined>;
+}
+
+/**
+ * Wrap an already-started runtime as a {@link PresenceListenerPort}. Exported
+ * separately (like {@link wrapRuntimeAsProbeBus}) so the doctor factory can
+ * derive BOTH the probe bus and the presence listener from ONE runtime — a
+ * single NATS connection for the whole `doctor` run.
+ */
+export function wrapRuntimeAsPresenceListener(runtime: MyelinRuntime): PresenceListenerPort {
+  return {
+    async listen(scope: string, timeoutMs: number): Promise<boolean | undefined> {
+      // No bus / no self-subscribe seam ⇒ we cannot declare interest, so a
+      // silent timeout would be a FALSE negative. Report "undeterminable".
+      if (!runtime.enabled || typeof runtime.subscribe !== "function") return undefined;
+
+      // `scope` is `federated.{X}.{stack}.>`; the literal prefix (minus the `>`)
+      // is what an arriving subject must start with.
+      const prefix = scope.endsWith(".>") ? scope.slice(0, -1) : scope;
+
+      let resolveArrived: ((v: boolean) => void) | undefined;
+      const arrivedPromise = new Promise<boolean>((resolve) => {
+        resolveArrived = resolve;
+      });
+      const registration = runtime.onEnvelope((_env, subject) => {
+        if (subject.startsWith(prefix)) resolveArrived?.(true);
+      });
+
+      // Declare interest BEFORE racing the timeout so a fast heartbeat can't slip
+      // past our listener. May be null if the runtime declines — treat as
+      // undeterminable (we never declared interest, so a `false` would lie).
+      const sub = await runtime.subscribe(scope);
+      if (sub === null) {
+        registration.unregister();
+        return undefined;
+      }
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<false>((resolve) => {
+        timer = setTimeout(() => {
+          resolve(false);
+        }, timeoutMs);
+      });
+
+      try {
+        return await Promise.race([arrivedPromise, timeoutPromise]);
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+        registration.unregister();
+        await sub.stop();
+      }
     },
   };
 }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -161,6 +161,7 @@ import {
 import {
   createLiveLeafzSampler,
   createLiveProbeBus,
+  createLiveProbeAndPresence,
   type LiveProbeBus,
 } from "./network-ping-adapters";
 import { buildPingSignerFromConfig } from "./network-ping-signer";
@@ -173,6 +174,7 @@ import {
 import {
   buildDoctorConfigPort,
   buildMonitorPort,
+  buildPeerHearingPort,
 } from "./network-doctor-adapters";
 import type { NetworkDoctorPorts } from "./network-doctor-ports";
 import {
@@ -1819,8 +1821,11 @@ export type DoctorPortsFactory = (
 const DEFAULT_DOCTOR_PORTS_FACTORY: DoctorPortsFactory = async (cfg, livePortsCfg) => {
   // Reuse the SAME posture-gated signer + live probe bus `ping` uses, so
   // doctor's peer-reachable leg is byte-identical to `ping`'s round-trip.
+  // FS-5b (cortex#1842) — derive BOTH the probe bus (Leg 5 echo) and the
+  // presence listener (Leg 5b stage-3 bounded subscribe) from ONE runtime, so
+  // doctor opens a single NATS connection for both read-sides.
   const signer = await buildPingSignerFromConfig(cfg);
-  const bus: LiveProbeBus = await createLiveProbeBus(cfg.config, signer);
+  const { bus, presence, stop } = await createLiveProbeAndPresence(cfg.config, signer);
   const ports: NetworkDoctorPorts = {
     config: buildDoctorConfigPort({
       // Read the COMPOSED networks off the already-loaded config — NOT a raw
@@ -1840,8 +1845,12 @@ const DEFAULT_DOCTOR_PORTS_FACTORY: DoctorPortsFactory = async (cfg, livePortsCf
       // (our egress vs the peer's echo leg). Best-effort: a failed read omits it.
       leafz: createLiveLeafzSampler(cfg),
     },
+    // FS-5b (cortex#1842) — the per-peer "can I hear X?" staged chain. Only the
+    // stage-3 bounded live subscribe is wired here (via the shared runtime); the
+    // other seams degrade to warn (see buildPeerHearingPort).
+    hearing: buildPeerHearingPort(presence),
   };
-  return { ports, stop: () => bus.stop() };
+  return { ports, stop };
 };
 
 async function runDoctor(


### PR DESCRIPTION
Closes #1842. Part of epic #1818 (Federation simplification), Wave 0 — the last Wave-0 slice. Design §4 FS-5.

Answers the question this session's two-day hunt couldn't: **"can I hear X, and if not, WHERE does it break?"**

## Additive Leg 5b — one-directional hearing chain
Left the existing single-echo Leg 5 (bidirectional) untouched; ADDED a per-peer "can I hear X?" chain. Per configured peer, emits FIVE ordered `DoctorCheck`s (owner `peer`, `peer-hearing:<stage>:<label>`): **cred-perms → import → envelopes-arriving → gate → fold**. First FAIL stops the chain (later stages `skip`); a `warn` (undeterminable) does not.
- **healthy peer** → 5×pass
- **fold-broken (the jc case: missing/wrong pubkey)** → stages 1-4 pass, **stage 5 (fold) FAILs**, pointing at source-binding/pubkey (FS-1 territory)
- **cred-broken** → stage 1 fail, 2-5 skip

## Seam decisions (reuse, not reinvent)
- **gate** = PURE: calls the real `evaluateFederationGate` (`surface-router.ts`) against a representative presence envelope (deny-subject test proves it).
- **envelopes-arriving** = live bounded subscribe on `federated.{X}.{stack}.agent.>` via `wrapRuntimeAsPresenceListener`, reusing ping's runtime transport; doctor shares ONE runtime for probe+presence. Seam choice documented in a header comment.
- **cred/import/fold** live seams degrade to `warn` (documented, no false-fails) when the optional `hearing` port is unwired; gate still yields a hard verdict.

## FS-6 review nits folded in
- daemon-restart-transience doc comment on `FederatedPresenceReceipts`.
- test: a peer dropped at TRUST GATE 2 (chain-verify) STILL records a receipt (recorded before both gates at `:381`).

## Verification
- `bunx tsc --noEmit` → 0; `bunx eslint --quiet` (8 files) → clean; Vocab carve-out → PASS.
- 72 pass / 0 fail (chain taxonomy: healthy/fold-broken/cred-broken/gate-deny/arriving-silent/no-port-warn/GATE-2-records) + 61 pass regression (doctor-cli/adapters/ping).
- Additive (785 insertions, `--diff-filter=D` empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)