### PR TITLE
feat(federation): FS-1 — presence-by-membership (fold admitted peers via registry roster, no hand-pinned pubkey)

### DIFF
--- a/src/bus/agent-network/__tests__/federated-membership.test.ts
+++ b/src/bus/agent-network/__tests__/federated-membership.test.ts
@@ -1,0 +1,179 @@
+/**
+ * FS-1 (cortex#1825, design §3 D-1) — federated-membership oracle tests.
+ *
+ * Coverage axes:
+ *   1. Authoritative read ⇒ `isAdmittedMember` true for ADMITTED principals,
+ *      false for everyone else (pending / absent / local).
+ *   2. Self-scope (non-authoritative) read ⇒ NEVER establishes peer membership
+ *      (a self read does not enumerate peers) — last-good is preserved.
+ *   3. Failed / degraded read ⇒ last-good preserved (never wipe on an outage).
+ *   4. `not_configured` provider ⇒ empty snapshot (honest degradation).
+ *   5. Multi-network union.
+ *   6. Lifecycle — start/stop with an injected scheduler; stop is idempotent.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createFederatedMembershipOracle } from "../federated-membership";
+import type {
+  AdmissionRowsProvider,
+  AdmissionRowsResult,
+  AdmissionRow,
+} from "../admission-read";
+
+/** Build a provider that returns a scripted result per network id. */
+function providerFor(
+  script: Record<string, AdmissionRowsResult>,
+  fallback: AdmissionRowsResult = {
+    ok: false,
+    reason: "not_configured",
+    detail: "no script",
+  },
+): AdmissionRowsProvider {
+  return {
+    readAdmissionRows: (networkId: string): Promise<AdmissionRowsResult> =>
+      Promise.resolve(script[networkId] ?? fallback),
+  };
+}
+
+/** A mutable provider whose result can be swapped between refreshes. */
+function mutableProvider(initial: AdmissionRowsResult): {
+  provider: AdmissionRowsProvider;
+  set: (r: AdmissionRowsResult) => void;
+} {
+  let current = initial;
+  return {
+    provider: {
+      readAdmissionRows: (): Promise<AdmissionRowsResult> =>
+        Promise.resolve(current),
+    },
+    set: (r: AdmissionRowsResult) => {
+      current = r;
+    },
+  };
+}
+
+function row(
+  principal_id: string,
+  network_id: string,
+  status: AdmissionRow["status"],
+): AdmissionRow {
+  return { principal_id, network_id, status };
+}
+
+function completeRows(rows: AdmissionRow[]): AdmissionRowsResult {
+  return { ok: true, rows, scope: "complete" };
+}
+
+describe("FS-1 federated-membership oracle", () => {
+  test("authoritative read ⇒ ADMITTED principals are members; others are not", async () => {
+    const provider = providerFor({
+      metafactory: completeRows([
+        row("jc", "metafactory", "ADMITTED"),
+        row("mia", "metafactory", "PENDING"),
+        row("evil", "other-net", "ADMITTED"), // wrong network — filtered out
+      ]),
+    });
+    const oracle = createFederatedMembershipOracle({
+      networkIds: ["metafactory"],
+      provider,
+      runOnStart: false,
+    });
+    await oracle.refresh();
+    expect(oracle.isAdmittedMember("jc")).toBe(true); // ADMITTED
+    expect(oracle.isAdmittedMember("mia")).toBe(false); // PENDING is not a member
+    expect(oracle.isAdmittedMember("evil")).toBe(false); // wrong network
+    expect(oracle.isAdmittedMember("nobody")).toBe(false);
+  });
+
+  test("self-scope (non-authoritative) read NEVER establishes membership + preserves last-good", async () => {
+    const m = mutableProvider(
+      completeRows([row("jc", "metafactory", "ADMITTED")]),
+    );
+    const oracle = createFederatedMembershipOracle({
+      networkIds: ["metafactory"],
+      provider: m.provider,
+      runOnStart: false,
+    });
+    await oracle.refresh();
+    expect(oracle.isAdmittedMember("jc")).toBe(true);
+
+    // Now the registry only answers a SELF-scope read (scope: "self") — it does
+    // not enumerate peers. The oracle must NOT collapse membership to "just me";
+    // it keeps the last authoritative snapshot.
+    m.set({ ok: true, rows: [row("andreas", "metafactory", "ADMITTED")], scope: "self" });
+    await oracle.refresh();
+    expect(oracle.isAdmittedMember("jc")).toBe(true); // last-good preserved
+    expect(oracle.isAdmittedMember("andreas")).toBe(false); // self read ignored
+  });
+
+  test("degraded read (unreachable) preserves last-good — never wipes membership", async () => {
+    const m = mutableProvider(
+      completeRows([row("jc", "metafactory", "ADMITTED")]),
+    );
+    const oracle = createFederatedMembershipOracle({
+      networkIds: ["metafactory"],
+      provider: m.provider,
+      runOnStart: false,
+    });
+    await oracle.refresh();
+    expect(oracle.isAdmittedMember("jc")).toBe(true);
+
+    m.set({ ok: false, reason: "unreachable", detail: "registry down" });
+    await oracle.refresh();
+    expect(oracle.isAdmittedMember("jc")).toBe(true); // still a member (last-good)
+  });
+
+  test("not_configured provider ⇒ empty snapshot (no membership-fold)", async () => {
+    const oracle = createFederatedMembershipOracle({
+      networkIds: ["metafactory"],
+      provider: providerFor({}),
+      runOnStart: false,
+    });
+    await oracle.refresh();
+    expect(oracle.isAdmittedMember("jc")).toBe(false);
+  });
+
+  test("union across multiple networks", async () => {
+    const oracle = createFederatedMembershipOracle({
+      networkIds: ["net-a", "net-b"],
+      provider: providerFor({
+        "net-a": completeRows([row("jc", "net-a", "ADMITTED")]),
+        "net-b": completeRows([row("mia", "net-b", "ADMITTED")]),
+      }),
+      runOnStart: false,
+    });
+    await oracle.refresh();
+    expect(oracle.isAdmittedMember("jc")).toBe(true);
+    expect(oracle.isAdmittedMember("mia")).toBe(true);
+  });
+
+  test("no networks ⇒ inert; start()/stop() are no-ops and never throw", async () => {
+    const oracle = createFederatedMembershipOracle({
+      networkIds: [],
+      provider: providerFor({}),
+    });
+    oracle.start();
+    expect(oracle.isAdmittedMember("jc")).toBe(false);
+    await oracle.stop();
+    await oracle.stop(); // idempotent
+  });
+
+  test("start() runs an initial refresh and schedules the poller (injected clock)", async () => {
+    const scheduled: { fn: () => void; ms: number }[] = [];
+    const oracle = createFederatedMembershipOracle({
+      networkIds: ["metafactory"],
+      provider: providerFor({
+        metafactory: completeRows([row("jc", "metafactory", "ADMITTED")]),
+      }),
+      schedule: (fn, ms) => {
+        scheduled.push({ fn, ms });
+        return () => undefined;
+      },
+    });
+    oracle.start();
+    await oracle.settle();
+    expect(scheduled.length).toBe(1); // interval armed
+    expect(oracle.isAdmittedMember("jc")).toBe(true); // runOnStart refreshed
+    await oracle.stop();
+  });
+});

--- a/src/bus/agent-network/__tests__/federated-subscriber.test.ts
+++ b/src/bus/agent-network/__tests__/federated-subscriber.test.ts
@@ -817,11 +817,34 @@ describe("E.5 — BLOCKER: source-bound identity (no provenance spoof)", () => {
 // D-1: an ADMITTED member of the verified admission roster folds its presence
 // even with NO `peers[]` offering — membership IS the accept-list for presence.
 // This drops the offerings precondition, NOT the crypto/source-binding. The
-// oracle is injected as `isAdmittedMember`; DD-11 stays fail-closed via
-// `handPinnedPrincipals`.
+// oracle is injected as `isAdmittedMemberOfNetwork` (NETWORK-SCOPED, cortex#1825
+// review); DD-11 stays fail-closed via `handPinnedPrincipals`.
+//
+// cortex#1825 review — membership-fold is LEAF-SCOPED: it fires ONLY when the
+// source is admitted on a network the DELIVERING leaf serves. So these tests run
+// on a DEDICATED leaf (`RESEARCH_LEAF`, the production shape — a joined network
+// with its own `leaf_node`, delivered on that leaf), NOT `primary`. Delivery on
+// `primary` (the shared local link, no per-network isolation) can NEVER
+// membership-fold — see the cross-network / bare-forgery regressions in
+// fs1-adversarial-probe.test.ts.
+
+const RESEARCH_LEAF = "leaf-research";
+
+/** joel-less network on a DEDICATED leaf (production federation shape). */
+function networkWithoutJoelOnLeaf(): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: RESEARCH_LEAF,
+    peers: [],
+    accept_subjects: ["federated.joel.research.agent.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
 
 describe("FS-1 — presence-by-membership fold", () => {
-  test("AC1: admitted member with NO peers[] offering ⇒ FOLDED by membership", async () => {
+  test("AC1: admitted member with NO peers[] offering, delivered on ITS OWN network's leaf ⇒ FOLDED by membership", async () => {
     const runtime = makeFakeRuntime();
     const registry = new AgentPresenceRegistry();
     const handle = await startFederatedAgentPresenceSubscriber({
@@ -829,12 +852,14 @@ describe("FS-1 — presence-by-membership fold", () => {
       registry,
       // joel is NOT in peers[] and NOT on accept_subjects for its own subtree —
       // the gate would deny `peer_not_in_accept_list` (unknown_network)...
-      federated: federatedPolicy([networkWithoutJoel()]),
+      federated: federatedPolicy([networkWithoutJoelOnLeaf()]),
       source: SYSTEM_SOURCE,
-      // ...but joel IS an admitted roster member ⇒ presence-by-membership folds.
-      isAdmittedMember: (p) => p === "joel",
+      // ...but joel IS an admitted member OF research-collab ⇒ presence-by-
+      // membership folds, because the envelope arrives on that network's leaf.
+      isAdmittedMemberOfNetwork: (p, nid) =>
+        p === "joel" && nid === "research-collab",
     });
-    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    runtime.fire(foreignOnline(), FED_SUBJECT, RESEARCH_LEAF);
     await flush();
     const agents = registry.getAgents();
     expect(agents.length).toBe(1);
@@ -850,12 +875,12 @@ describe("FS-1 — presence-by-membership fold", () => {
     const handle = await startFederatedAgentPresenceSubscriber({
       runtime,
       registry,
-      federated: federatedPolicy([networkWithoutJoel()]),
+      federated: federatedPolicy([networkWithoutJoelOnLeaf()]),
       source: SYSTEM_SOURCE,
       // joel is NOT an admitted member ⇒ the offerings deny stands (unknown_network).
-      isAdmittedMember: (p) => p === "someone-else",
+      isAdmittedMemberOfNetwork: (p) => p === "someone-else",
     });
-    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    runtime.fire(foreignOnline(), FED_SUBJECT, RESEARCH_LEAF);
     await flush();
     expect(registry.getAgents().length).toBe(0); // denied — not folded
     await handle.stop();
@@ -867,11 +892,11 @@ describe("FS-1 — presence-by-membership fold", () => {
     const handle = await startFederatedAgentPresenceSubscriber({
       runtime,
       registry,
-      federated: federatedPolicy([networkWithoutJoel()]),
+      federated: federatedPolicy([networkWithoutJoelOnLeaf()]),
       source: SYSTEM_SOURCE,
-      // No isAdmittedMember ⇒ defaults to "never a member" ⇒ joel denied.
+      // No isAdmittedMemberOfNetwork ⇒ defaults to "never a member" ⇒ joel denied.
     });
-    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    runtime.fire(foreignOnline(), FED_SUBJECT, RESEARCH_LEAF);
     await flush();
     expect(registry.getAgents().length).toBe(0);
     await handle.stop();
@@ -885,13 +910,14 @@ describe("FS-1 — presence-by-membership fold", () => {
       registry,
       // joel dropped from peers[] by a DD-11 pin-mismatch at config load ⇒ gate
       // denies. joel IS an admitted member, BUT it carries a local hand-pin...
-      federated: federatedPolicy([networkWithoutJoel()]),
+      federated: federatedPolicy([networkWithoutJoelOnLeaf()]),
       source: SYSTEM_SOURCE,
-      isAdmittedMember: (p) => p === "joel",
+      isAdmittedMemberOfNetwork: (p, nid) =>
+        p === "joel" && nid === "research-collab",
       // ...so the membership override MUST be skipped — DD-11 unchanged.
       handPinnedPrincipals: new Set(["joel"]),
     });
-    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    runtime.fire(foreignOnline(), FED_SUBJECT, RESEARCH_LEAF);
     await flush();
     expect(registry.getAgents().length).toBe(0); // fail-closed — not folded
     await handle.stop();
@@ -913,14 +939,15 @@ describe("FS-1 — presence-by-membership fold", () => {
     const handle = await startFederatedAgentPresenceSubscriber({
       runtime,
       registry,
-      federated: federatedPolicy([networkWithoutJoel()]),
+      federated: federatedPolicy([networkWithoutJoelOnLeaf()]),
       source: SYSTEM_SOURCE,
       // joel folds by membership — but the payload claims andreas/meta-factory,
       // a scope joel does NOT own. Source-binding (applyForeign verifiedScope)
       // must DROP it: membership does not weaken source-binding.
-      isAdmittedMember: (p) => p === "joel",
+      isAdmittedMemberOfNetwork: (p, nid) =>
+        p === "joel" && nid === "research-collab",
     });
-    runtime.fire(spoofOnline("luna"), FED_SUBJECT, "primary");
+    runtime.fire(spoofOnline("luna"), FED_SUBJECT, RESEARCH_LEAF);
     await flush();
     // The real local luna survives; no foreign spoof painted it.
     const luna = registry.getAgents().find((a) => a.agentId === "luna");
@@ -949,7 +976,8 @@ describe("FS-1 — presence-by-membership fold", () => {
       registry,
       federated: federatedPolicy([deniedNetwork]),
       source: SYSTEM_SOURCE,
-      isAdmittedMember: (p) => p === "joel",
+      isAdmittedMemberOfNetwork: (p, nid) =>
+        p === "joel" && nid === "research-collab",
     });
     runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
     await flush();

--- a/src/bus/agent-network/__tests__/federated-subscriber.test.ts
+++ b/src/bus/agent-network/__tests__/federated-subscriber.test.ts
@@ -809,3 +809,151 @@ describe("E.5 — BLOCKER: source-bound identity (no provenance spoof)", () => {
     await handle.stop();
   });
 });
+
+// ---------------------------------------------------------------------------
+// FS-1 (cortex#1825, design §3 D-1) — PRESENCE-BY-MEMBERSHIP
+// ---------------------------------------------------------------------------
+//
+// D-1: an ADMITTED member of the verified admission roster folds its presence
+// even with NO `peers[]` offering — membership IS the accept-list for presence.
+// This drops the offerings precondition, NOT the crypto/source-binding. The
+// oracle is injected as `isAdmittedMember`; DD-11 stays fail-closed via
+// `handPinnedPrincipals`.
+
+describe("FS-1 — presence-by-membership fold", () => {
+  test("AC1: admitted member with NO peers[] offering ⇒ FOLDED by membership", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      // joel is NOT in peers[] and NOT on accept_subjects for its own subtree —
+      // the gate would deny `peer_not_in_accept_list` (unknown_network)...
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      // ...but joel IS an admitted roster member ⇒ presence-by-membership folds.
+      isAdmittedMember: (p) => p === "joel",
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    const agents = registry.getAgents();
+    expect(agents.length).toBe(1);
+    expect(agents[0]?.agentId).toBe("sage");
+    expect(agents[0]?.principal).toBe("joel");
+    expect(agents[0]?.origin).toMatchObject({ kind: "foreign", principal: "joel" });
+    await handle.stop();
+  });
+
+  test("AC2: a NON-member (absent from the roster) is STILL denied — no membership fold", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      // joel is NOT an admitted member ⇒ the offerings deny stands (unknown_network).
+      isAdmittedMember: (p) => p === "someone-else",
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0); // denied — not folded
+    await handle.stop();
+  });
+
+  test("AC2 (default): omitting the oracle ⇒ byte-identical pre-FS-1 (peers[]-only) behaviour", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      // No isAdmittedMember ⇒ defaults to "never a member" ⇒ joel denied.
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("AC4 (DD-11): a HAND-PINNED member is NEVER re-admitted by membership (pin-mismatch stays fail-closed)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      // joel dropped from peers[] by a DD-11 pin-mismatch at config load ⇒ gate
+      // denies. joel IS an admitted member, BUT it carries a local hand-pin...
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      isAdmittedMember: (p) => p === "joel",
+      // ...so the membership override MUST be skipped — DD-11 unchanged.
+      handPinnedPrincipals: new Set(["joel"]),
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0); // fail-closed — not folded
+    await handle.stop();
+  });
+
+  test("AC5: source-binding UNCHANGED — a membership-admitted member cannot paint a foreign scope", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    // Seed a LOCAL record that a spoof would try to overwrite.
+    registry.apply(
+      createAgentOnlineEvent({
+        source: { principal: "andreas", stack: "meta-factory", instance: "local" },
+        identity: { nkey_public_key: "ULOCAL", agent_id: "luna", assistant_name: "Luna" },
+        scope: { principal: "andreas", stack: "meta-factory" },
+        capabilities: [],
+        startedAt: new Date("2026-06-11T08:00:00.000Z"),
+      }),
+    );
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithoutJoel()]),
+      source: SYSTEM_SOURCE,
+      // joel folds by membership — but the payload claims andreas/meta-factory,
+      // a scope joel does NOT own. Source-binding (applyForeign verifiedScope)
+      // must DROP it: membership does not weaken source-binding.
+      isAdmittedMember: (p) => p === "joel",
+    });
+    runtime.fire(spoofOnline("luna"), FED_SUBJECT, "primary");
+    await flush();
+    // The real local luna survives; no foreign spoof painted it.
+    const luna = registry.getAgents().find((a) => a.agentId === "luna");
+    expect(luna?.origin).toBe("local");
+    expect(registry.getAgents().length).toBe(1); // no spoof record folded
+    await handle.stop();
+  });
+
+  test("safety denials (deny_subjects) are NEVER overridden by membership", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    // joel IS a peer AND an admitted member, but its presence subtree is on the
+    // DENY list — a deny is a safety check, NOT an offering, so membership must
+    // NOT override it.
+    const deniedNetwork: PolicyFederatedNetwork = {
+      id: "research-collab",
+      leaf_node: "primary",
+      peers: [{ principal_id: "joel", stack_id: "joel/research" }],
+      accept_subjects: ["federated.joel.research.agent.>"],
+      deny_subjects: ["federated.joel.research.agent.>"],
+      announce_capabilities: [],
+      max_hop: 3,
+    };
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([deniedNetwork]),
+      source: SYSTEM_SOURCE,
+      isAdmittedMember: (p) => p === "joel",
+    });
+    runtime.fire(foreignOnline(), FED_SUBJECT, "primary");
+    await flush();
+    expect(registry.getAgents().length).toBe(0); // deny stands — not folded
+    await handle.stop();
+  });
+});

--- a/src/bus/agent-network/__tests__/fs1-adversarial-probe.test.ts
+++ b/src/bus/agent-network/__tests__/fs1-adversarial-probe.test.ts
@@ -18,7 +18,7 @@
  * requires `decision.unknown_network === true`, so a peer that IS declared in
  * `peers[]` (known, not hand-pinned) but whose `accept_subjects` deliberately
  * excludes the presence subject is NO LONGER folded by membership — the
- * operator's explicit narrowing is honoured.
+ * principal's explicit narrowing is honoured.
  *
  * POSITIVE CONTROL: a legitimately admitted member delivered on ITS OWN
  * network's leaf STILL folds (the fix must not over-correct into breaking FS-1).
@@ -182,7 +182,7 @@ function networkWithRestrictedJoel(): PolicyFederatedNetwork {
     leaf_node: "primary",
     // joel IS declared (known peer, NOT hand-pinned — no principal_pubkey)...
     peers: [{ principal_id: "joel", stack_id: "joel/research" }],
-    // ...but the operator deliberately did NOT put joel's presence subject on
+    // ...but the principal deliberately did NOT put joel's presence subject on
     // accept_subjects (e.g. joel is allowed dispatch only, not presence).
     accept_subjects: ["federated.joel.research.dispatch.>"],
     deny_subjects: [],
@@ -222,7 +222,7 @@ describe("FS-1 REGRESSION 2 — known-but-subject-restricted peer is DROPPED", (
 
     // joel IS resolved via peers[] ⇒ the gate denies with
     // `peer_not_in_accept_list` but WITHOUT `unknown_network`. The override now
-    // requires `unknown_network === true`, so the operator's accept_subjects
+    // requires `unknown_network === true`, so the principal's accept_subjects
     // narrowing is honoured ⇒ DROP.
     expect(registry.getAgents().length).toBe(0);
     await handle.stop();

--- a/src/bus/agent-network/__tests__/fs1-adversarial-probe.test.ts
+++ b/src/bus/agent-network/__tests__/fs1-adversarial-probe.test.ts
@@ -1,0 +1,230 @@
+/**
+ * FS-1 (cortex#1825) ANTI-SPOOF REGRESSION SUITE — locks the two cross-network
+ * / accept-list-bypass spoofs the adversarial review reproduced, now asserting
+ * the CORRECT (dropped) behaviour, plus a positive control.
+ *
+ * REGRESSION 1 (cross-leaf membership-fold spoof, now DROPPED): for a
+ * MEMBERSHIP-ONLY principal (admitted in the registry, but with NO static
+ * `peers[]` entry in ANY joined network's config), the F-3d leaf/network
+ * anti-spoof check (`source_link_mismatch`) never runs in `evaluateFederationGate`
+ * (that check is reached only after `resolveSourceNetwork` finds the principal in
+ * a network's `peers[]`). The FIX gives the MEMBERSHIP path its OWN leaf→network
+ * scope: the override fires only when the source is admitted on a network the
+ * DELIVERING leaf serves. So a peer on Leaf A can no longer impersonate a
+ * principal admitted only on Network B (reachable via Leaf B) — the envelope
+ * delivered on the WRONG leaf now DROPS.
+ *
+ * REGRESSION 2 (known-peer accept_subjects bypass, now DROPPED): the override now
+ * requires `decision.unknown_network === true`, so a peer that IS declared in
+ * `peers[]` (known, not hand-pinned) but whose `accept_subjects` deliberately
+ * excludes the presence subject is NO LONGER folded by membership — the
+ * operator's explicit narrowing is honoured.
+ *
+ * POSITIVE CONTROL: a legitimately admitted member delivered on ITS OWN
+ * network's leaf STILL folds (the fix must not over-correct into breaking FS-1).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  startFederatedAgentPresenceSubscriber,
+} from "../federated-subscriber";
+import { AgentPresenceRegistry } from "../registry";
+import { createAgentOnlineEvent, type AgentPresenceSource } from "../builders";
+import type { Envelope, SignedBy } from "../../myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../../myelin/runtime";
+import type { MyelinSubscriber } from "../../myelin/subscriber";
+import type { SystemEventSource } from "../../system-events";
+import type {
+  PolicyFederated,
+  PolicyFederatedNetwork,
+} from "../../../common/types/cortex-config";
+
+const SYSTEM_SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+
+function makeFakeRuntime(): MyelinRuntime & {
+  fire(envelope: Envelope, subject: string, sourceLink?: string): void;
+} {
+  const handlers = new Set<EnvelopeHandler>();
+  const fakeSubscriber = { stop: () => Promise.resolve() } as unknown as MyelinSubscriber;
+  return {
+    enabled: true,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: () => Promise.resolve(),
+    stop: () => Promise.resolve(),
+    subscribe: () => Promise.resolve(fakeSubscriber),
+    fire(envelope, subject, sourceLink) {
+      for (const h of handlers) h(envelope, subject, sourceLink);
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+function federatedPolicy(networks: PolicyFederatedNetwork[]): PolicyFederated {
+  return { networks };
+}
+
+// ---------------------------------------------------------------------------
+// PROBE 1 — cross-leaf membership-fold spoof
+// ---------------------------------------------------------------------------
+
+function networkA(): PolicyFederatedNetwork {
+  return {
+    id: "network-a",
+    leaf_node: "leafA",
+    peers: [
+      { principal_id: "trusted-a", stack_id: "trusted-a/stack", principal_pubkey: "PUBKEY-A" },
+    ],
+    accept_subjects: ["federated.trusted-a.stack.agent.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+function networkB(): PolicyFederatedNetwork {
+  return {
+    id: "network-b",
+    leaf_node: "leafB",
+    peers: [],
+    accept_subjects: ["federated.victim.stack.agent.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+function victimOnline(opts: { signedBy?: SignedBy[] } = {}): Envelope {
+  const source: AgentPresenceSource = { principal: "victim", stack: "stack", instance: "local" };
+  const env = createAgentOnlineEvent({
+    source,
+    identity: { nkey_public_key: "UVICTIM", agent_id: "sage", assistant_name: "Sage" },
+    scope: { principal: "victim", stack: "stack" },
+    capabilities: [],
+    startedAt: new Date("2026-06-11T09:00:00.000Z"),
+    classification: "federated",
+  });
+  if (opts.signedBy !== undefined) return { ...env, signed_by: opts.signedBy };
+  return env;
+}
+
+describe("FS-1 REGRESSION 1 — cross-leaf membership-fold spoof is DROPPED", () => {
+  test("victim admitted on Network B, but its presence delivered on the WRONG leaf (leafA) DROPS under signing:off", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkA(), networkB()]),
+      source: SYSTEM_SOURCE,
+      rejectEmpty: false,
+      // victim is a legit admitted member of Network B (leaf leafB) ONLY.
+      isAdmittedMemberOfNetwork: (p, nid) => p === "victim" && nid === "network-b",
+    });
+
+    // ...but the spoofed envelope arrives on leafA (Network A's leaf). Membership
+    // is now leaf-scoped: leafA serves Network A, and victim is NOT admitted
+    // there ⇒ DROP.
+    runtime.fire(
+      victimOnline(),
+      "federated.andreas.meta-factory.agent.online",
+      "leafA",
+    );
+    await flush();
+
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+
+  test("POSITIVE CONTROL: victim admitted on Network B, delivered on ITS OWN leaf (leafB) STILL folds", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkA(), networkB()]),
+      source: SYSTEM_SOURCE,
+      rejectEmpty: false,
+      isAdmittedMemberOfNetwork: (p, nid) => p === "victim" && nid === "network-b",
+    });
+
+    // Delivered on leafB — Network B's own leaf, where victim IS admitted ⇒ FOLD.
+    runtime.fire(
+      victimOnline(),
+      "federated.andreas.meta-factory.agent.online",
+      "leafB",
+    );
+    await flush();
+
+    const agents = registry.getAgents();
+    expect(agents.length).toBe(1);
+    expect(agents[0]?.principal).toBe("victim");
+    await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROBE 2 — known-peer-with-restricted-accept_subjects still folds by membership
+// ---------------------------------------------------------------------------
+
+function networkWithRestrictedJoel(): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "primary",
+    // joel IS declared (known peer, NOT hand-pinned — no principal_pubkey)...
+    peers: [{ principal_id: "joel", stack_id: "joel/research" }],
+    // ...but the operator deliberately did NOT put joel's presence subject on
+    // accept_subjects (e.g. joel is allowed dispatch only, not presence).
+    accept_subjects: ["federated.joel.research.dispatch.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+function joelOnline(): Envelope {
+  const source: AgentPresenceSource = { principal: "joel", stack: "research", instance: "local" };
+  return createAgentOnlineEvent({
+    source,
+    identity: { nkey_public_key: "UJOEL", agent_id: "sage", assistant_name: "Sage" },
+    scope: { principal: "joel", stack: "research" },
+    capabilities: [],
+    startedAt: new Date("2026-06-11T09:00:00.000Z"),
+    classification: "federated",
+  });
+}
+
+describe("FS-1 REGRESSION 2 — known-but-subject-restricted peer is DROPPED", () => {
+  test("joel is a KNOWN peer whose accept_subjects deliberately excludes presence — membership override does NOT apply (unknown_network required) ⇒ DROP", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: federatedPolicy([networkWithRestrictedJoel()]),
+      source: SYSTEM_SOURCE,
+      rejectEmpty: false,
+      isAdmittedMemberOfNetwork: (p, nid) =>
+        p === "joel" && nid === "research-collab",
+    });
+
+    runtime.fire(joelOnline(), "federated.joel.research.agent.online", "primary");
+    await flush();
+
+    // joel IS resolved via peers[] ⇒ the gate denies with
+    // `peer_not_in_accept_list` but WITHOUT `unknown_network`. The override now
+    // requires `unknown_network === true`, so the operator's accept_subjects
+    // narrowing is honoured ⇒ DROP.
+    expect(registry.getAgents().length).toBe(0);
+    await handle.stop();
+  });
+});

--- a/src/bus/agent-network/__tests__/zz-exploit-probe.test.ts
+++ b/src/bus/agent-network/__tests__/zz-exploit-probe.test.ts
@@ -1,0 +1,92 @@
+/**
+ * FS-1 (cortex#1825) REGRESSION — a bare, self-asserted `envelope.source` claim
+ * attributed to a NON-isolating leaf (`primary`) must NOT fold, even for an
+ * admitted member with NO `peers[]` entry under signing:off. Pre-fix this bare
+ * forgery folded (finding #2, a regression of the pre-FS-1 GATE-1 hard-deny)
+ * because membership was a flat union and the F-3d `source_link_mismatch`
+ * cross-check never engaged. The FIX leaf-scopes the membership override AND
+ * fail-closes on `primary` (the shared local link is not a per-network isolation
+ * boundary), so the forged envelope now DROPS.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  startFederatedAgentPresenceSubscriber,
+} from "../federated-subscriber";
+import { AgentPresenceRegistry } from "../registry";
+import { createAgentOnlineEvent } from "../builders";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+
+const SYSTEM_SOURCE = { principal: "andreas", agent: "cortex", instance: "local" };
+
+function makeFakeRuntime() {
+  const handlers = new Set<any>();
+  return {
+    enabled: true,
+    onEnvelope(handler: any) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: () => Promise.resolve(),
+    stop: () => Promise.resolve(),
+    subscribe: () => Promise.resolve({ stop: () => Promise.resolve() }),
+    fire(envelope: any, subject: string, sourceLink?: string) {
+      for (const h of handlers) h(envelope, subject, sourceLink);
+    },
+  } as any;
+}
+
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+function networkNoPeers(): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "primary",
+    peers: [], // <-- "victim" has NO peers[] entry — pre-FS-1 this is unknown_network deny
+    accept_subjects: ["federated.victim.stack.agent.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+describe("FS-1 REGRESSION — forged envelope.source on `primary` DROPS, signing:off", () => {
+  test("attacker-crafted envelope claiming to be an admitted-but-unconfigured principal on `primary` DROPS (no dedicated-leaf attribution)", async () => {
+    const runtime = makeFakeRuntime();
+    const registry = new AgentPresenceRegistry();
+
+    const handle = await startFederatedAgentPresenceSubscriber({
+      runtime,
+      registry,
+      federated: { networks: [networkNoPeers()] },
+      source: SYSTEM_SOURCE,
+      // "victim" is a real admitted member of a network we joined (registry
+      // membership) -- but has NO local peers[] entry.
+      isAdmittedMemberOfNetwork: (p: string, nid: string) =>
+        p === "victim" && nid === "research-collab",
+      // NO trustResolver wired => matches `signing: off` (no chain verifier).
+    });
+
+    // Attacker fires an envelope whose `source` + `payload.scope` are BOTH
+    // self-consistently forged as "victim/stack" -- self-crafted, nothing
+    // signed, nothing tying it to victim's real leaf/connection.
+    const forged = createAgentOnlineEvent({
+      source: { principal: "victim", stack: "stack", instance: "local" },
+      identity: { nkey_public_key: "UATTACKERKEY", agent_id: "fake-agent", assistant_name: "Fake" },
+      scope: { principal: "victim", stack: "stack" },
+      capabilities: ["anything"],
+      startedAt: new Date("2026-06-11T09:00:00.000Z"),
+      classification: "federated",
+    });
+
+    runtime.fire(forged, "federated.victim.stack.agent.online", "primary");
+    await flush();
+
+    // `primary` is the shared local link, NOT a per-network isolation boundary,
+    // so the membership override fail-closes ⇒ the forged presence is DROPPED.
+    expect(registry.getAgents().length).toBe(0);
+
+    await handle.stop();
+  });
+});

--- a/src/bus/agent-network/federated-membership.ts
+++ b/src/bus/agent-network/federated-membership.ts
@@ -89,8 +89,27 @@ export interface FederatedMembershipOracleHandle {
   /**
    * True iff `principalId` is an ADMITTED member of ANY joined network per the
    * last authoritative admission-rows read. Pure, synchronous, hot-path-safe.
+   *
+   * FS-1 SECURITY NOTE (cortex#1825): this FLAT-UNION predicate must NOT be the
+   * membership-fold anchor — it can't tell WHICH network a principal is admitted
+   * to, so a member of Network B folds on Network A's leaf (cross-network
+   * spoof). The presence subscriber uses the network-SCOPED
+   * {@link isAdmittedMemberOfNetwork} instead, keyed off the delivering leaf.
+   * Retained for status/summary reads that legitimately want "admitted anywhere".
    */
   isAdmittedMember(principalId: string): boolean;
+  /**
+   * True iff `principalId` is an ADMITTED member of the SPECIFIC network
+   * `networkId` per the last authoritative admission-rows read. Pure,
+   * synchronous, hot-path-safe.
+   *
+   * FS-1 (cortex#1825) — this is the membership-fold anchor. The presence
+   * subscriber resolves the DELIVERING LEAF → its network(s) and requires the
+   * source principal to be an admitted member OF THAT network, so a principal
+   * admitted only on Network B can never be membership-folded when its envelope
+   * arrives on Network A's leaf.
+   */
+  isAdmittedMemberOfNetwork(principalId: string, networkId: string): boolean;
   /** Force one refresh pass now (test seam / warm-up). Never throws. */
   refresh(): Promise<void>;
   /** Start the periodic refresh loop (idempotent). */
@@ -199,6 +218,10 @@ export function createFederatedMembershipOracle(
   return {
     isAdmittedMember: (principalId: string): boolean =>
       flattened.has(principalId),
+    isAdmittedMemberOfNetwork: (
+      principalId: string,
+      networkId: string,
+    ): boolean => perNetwork.get(networkId)?.has(principalId) ?? false,
     refresh,
     start: (): void => {
       if (started || networkIds.length === 0) return;

--- a/src/bus/agent-network/federated-membership.ts
+++ b/src/bus/agent-network/federated-membership.ts
@@ -1,0 +1,219 @@
+/**
+ * FS-1 (cortex#1825, epic #1818, design-federation-simplification §3 D-1) — the
+ * **federated-membership oracle**: "is principal X an ADMITTED member of a
+ * network this stack has joined?"
+ *
+ * ## Why this exists (D-1 presence-by-membership)
+ *
+ * Under D-1, admission to a network ⇒ co-members see each other's presence by
+ * default; the per-peer `peers[]` offering is no longer the presence trust
+ * anchor. The federated-presence subscriber (`federated-subscriber.ts`) folds an
+ * admitted member's signed/permissive presence even when the member is NOT
+ * hand-listed with a pinned pubkey — **membership IS the accept-list for
+ * presence**. To make that decision at fold time the subscriber needs a cheap,
+ * synchronous "is this source principal admitted?" check. That is this oracle.
+ *
+ * ## Membership authority — the ADMISSION ROWS, not the capability roster (Q3)
+ *
+ * Membership is sourced from the **admission rows** (ADR-0018 Q3), via the SAME
+ * {@link AdmissionRowsProvider} the `/api/networks` view uses
+ * ({@link resolveAdmittedRoster}). It is NOT the capability-derived
+ * `GET /networks/{id}/roster` (`resolveNetworkRoster`): conflating a peer's
+ * announced *capabilities* with *membership* is exactly the bug ADR-0018 Q3
+ * forbids (cortex.ts §MC-A2). The admission read is PoP-signed by this stack's
+ * own registered key and DD-9-verified against the pinned registry pubkey — a
+ * single trust source, never the envelope's self-asserted identity.
+ *
+ * ## Authoritative-only (self-scope reads never establish peer membership)
+ *
+ * A `resolveAdmittedRoster` read is authoritative ONLY when its scope is
+ * `complete` ({@link AdmittedRoster.authoritative}). A `self`-scope read returns
+ * only THIS stack's own admission row — it does not enumerate peers — so it can
+ * NOT be used to decide a peer's membership. The oracle therefore updates a
+ * network's admitted set ONLY from an authoritative read; a non-authoritative or
+ * failed read leaves that network's LAST-GOOD set in place (best-effort — never
+ * wipe membership on a transient outage / a degraded read).
+ *
+ * ## Best-effort (never throws, never blocks)
+ *
+ * The refresh loop mirrors the federation reconciler: a read that fails routes
+ * to `onError` and leaves last-good in place; a tick never throws out of the
+ * loop. `isAdmittedMember` is a pure synchronous set membership test over the
+ * last successfully-resolved snapshot — safe to call on the presence fold hot
+ * path with zero I/O.
+ */
+
+import {
+  resolveAdmittedRoster,
+  type AdmissionRowsProvider,
+} from "./admission-read";
+
+/** Default refresh cadence — matches the federation reconciler's 60 s self-poll. */
+export const DEFAULT_MEMBERSHIP_REFRESH_INTERVAL_MS = 60_000;
+/** Floor for the refresh interval (mirrors the reconciler schema `.min(5000)`). */
+export const MIN_MEMBERSHIP_REFRESH_INTERVAL_MS = 5_000;
+
+/** Construction options for {@link FederatedMembershipOracle}. */
+export interface FederatedMembershipOracleOptions {
+  /** The networks this stack has joined (their ids). Refreshed per network. */
+  networkIds: readonly string[];
+  /**
+   * The admission-rows read seam (ADR-0018) — the SAME provider `/api/networks`
+   * uses. A `not_configured` provider (no registry pin / no stack signing
+   * material) leaves every network's set empty → `isAdmittedMember` is always
+   * false → the subscriber falls back to the existing `peers[]` gate (honest
+   * degradation, no membership-fold).
+   */
+  provider: AdmissionRowsProvider;
+  /** Refresh interval (ms). Defaults to {@link DEFAULT_MEMBERSHIP_REFRESH_INTERVAL_MS}. */
+  intervalMs?: number;
+  /**
+   * Injectable scheduler — returns a canceller. Defaults to
+   * setInterval/clearInterval. Tests pass a fake to drive ticks deterministically.
+   */
+  schedule?: (fn: () => void, ms: number) => () => void;
+  /** Called with any error a refresh throws (defaults to a stderr line). */
+  onError?: (err: unknown) => void;
+  /** Optional per-refresh sink (for logs / status). */
+  onRefresh?: (info: {
+    networkId: string;
+    admittedCount: number;
+    authoritative: boolean;
+  }) => void;
+  /** Run a refresh immediately on start (default true). */
+  runOnStart?: boolean;
+}
+
+/** Lifecycle + query handle for the membership oracle. */
+export interface FederatedMembershipOracleHandle {
+  /**
+   * True iff `principalId` is an ADMITTED member of ANY joined network per the
+   * last authoritative admission-rows read. Pure, synchronous, hot-path-safe.
+   */
+  isAdmittedMember(principalId: string): boolean;
+  /** Force one refresh pass now (test seam / warm-up). Never throws. */
+  refresh(): Promise<void>;
+  /** Start the periodic refresh loop (idempotent). */
+  start(): void;
+  /** Await the in-flight refresh (if any). Test seam for deterministic ticks. */
+  settle(): Promise<void>;
+  /** Stop the loop (idempotent): cancel the schedule + await any in-flight pass. */
+  stop(): Promise<void>;
+}
+
+const defaultSchedule = (fn: () => void, ms: number): (() => void) => {
+  const id = setInterval(fn, ms);
+  return () => {
+    clearInterval(id);
+  };
+};
+
+/**
+ * Build the federated-membership oracle. INERT (no schedule, no set) when no
+ * networks are joined — a stack with no federation never polls and
+ * `isAdmittedMember` is always false.
+ */
+export function createFederatedMembershipOracle(
+  opts: FederatedMembershipOracleOptions,
+): FederatedMembershipOracleHandle {
+  const networkIds = [...opts.networkIds];
+  const onError =
+    opts.onError ??
+    ((err: unknown) =>
+      process.stderr.write(
+        `[federated-membership] refresh failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      ));
+  const intervalMs = Math.max(
+    MIN_MEMBERSHIP_REFRESH_INTERVAL_MS,
+    opts.intervalMs ?? DEFAULT_MEMBERSHIP_REFRESH_INTERVAL_MS,
+  );
+  const schedule = opts.schedule ?? defaultSchedule;
+
+  // Per-network last-good admitted set (only updated from an AUTHORITATIVE read).
+  const perNetwork = new Map<string, ReadonlySet<string>>();
+  // Flattened union of every network's admitted set — the hot-path lookup.
+  let flattened = new Set<string>();
+
+  const rebuildFlattened = (): void => {
+    const next = new Set<string>();
+    for (const set of perNetwork.values()) {
+      for (const id of set) next.add(id);
+    }
+    flattened = next;
+  };
+
+  const refresh = async (): Promise<void> => {
+    for (const networkId of networkIds) {
+      // resolveAdmittedRoster never throws (it returns a discriminated result);
+      // an unexpected provider fault is still contained per-network so one bad
+      // read never blocks the others.
+      let result: Awaited<ReturnType<typeof resolveAdmittedRoster>>;
+      try {
+        result = await resolveAdmittedRoster(networkId, opts.provider);
+      } catch (err) {
+        onError(err);
+        continue;
+      }
+      if (!result.ok) {
+        // Transient / degraded read — keep this network's last-good set. Never
+        // wipe membership on an outage (a wipe would drop every co-member off MC
+        // until the registry recovers).
+        continue;
+      }
+      if (!result.roster.authoritative) {
+        // A self-scope read does not enumerate peers — it cannot establish a
+        // peer's membership. Keep last-good; do NOT collapse the set to "just me".
+        continue;
+      }
+      perNetwork.set(networkId, new Set(result.roster.admitted));
+      opts.onRefresh?.({
+        networkId,
+        admittedCount: result.roster.admitted.length,
+        authoritative: true,
+      });
+    }
+    rebuildFlattened();
+  };
+
+  let inFlight: Promise<void> | null = null;
+  let cancel: (() => void) | null = null;
+  let started = false;
+  let stopped = false;
+
+  const tick = (): void => {
+    // Self-isolating: a rejection routes to onError, never escaping the tick.
+    const pass = Promise.resolve()
+      .then(refresh)
+      .then(
+        () => undefined,
+        (err: unknown) => {
+          onError(err);
+        },
+      )
+      .finally(() => {
+        if (inFlight === pass) inFlight = null;
+      });
+    inFlight = pass;
+  };
+
+  return {
+    isAdmittedMember: (principalId: string): boolean =>
+      flattened.has(principalId),
+    refresh,
+    start: (): void => {
+      if (started || networkIds.length === 0) return;
+      started = true;
+      if (opts.runOnStart !== false) tick();
+      cancel = schedule(tick, intervalMs);
+    },
+    settle: async (): Promise<void> => {
+      if (inFlight) await inFlight;
+    },
+    stop: async (): Promise<void> => {
+      if (stopped) return;
+      stopped = true;
+      if (cancel) cancel();
+      if (inFlight) await inFlight;
+    },
+  };
+}

--- a/src/bus/agent-network/federated-subscriber.ts
+++ b/src/bus/agent-network/federated-subscriber.ts
@@ -270,8 +270,8 @@ export interface StartFederatedAgentPresenceSubscriberOptions {
     networkId: string,
   ) => boolean;
   /**
-   * FS-1 (cortex#1825) — principals for which the operator HAND-PINNED a
-   * `peers[].principal_pubkey` in the ORIGINAL config (pre-resolution). DD-11 is
+   * FS-1 (cortex#1825) — principals for which a `peers[].principal_pubkey`
+   * was HAND-PINNED in the ORIGINAL config (pre-resolution). DD-11 is
    * UNCHANGED for these: a hand-pinned peer keeps the exact pre-FS-1 path
    * (`resolveFederatedPeers`: matching pin → admit; mismatching pin → fail-closed
    * DROP), so it is NEVER re-admitted by membership — a membership-fold of a
@@ -508,7 +508,7 @@ export async function startFederatedAgentPresenceSubscriber(
         // ONLY the `unknown_network` variant of `peer_not_in_accept_list` is an
         // offering precondition. The NON-`unknown_network` variant — a
         // config-declared peer whose `accept_subjects` deliberately excludes the
-        // presence subtree — is the operator's EXPLICIT narrowing and is NEVER
+        // presence subtree — is the principal's EXPLICIT narrowing and is NEVER
         // overridden by membership (cortex#1825 PROBE 2). `peer_deny_list`,
         // `max_hop_exceeded`, and `source_link_mismatch` are SAFETY / anti-spoof
         // checks — NEVER overridden by membership (a member on a deny-listed subject,

--- a/src/bus/agent-network/federated-subscriber.ts
+++ b/src/bus/agent-network/federated-subscriber.ts
@@ -244,6 +244,31 @@ export interface StartFederatedAgentPresenceSubscriberOptions {
    * a test can assert deterministic `lastAt` values. Defaults to `Date.now`.
    */
   now?: () => number;
+  /**
+   * FS-1 (cortex#1825, design §3 D-1) — **presence-by-membership** oracle. Pure,
+   * synchronous predicate: is `sourcePrincipal` an ADMITTED member of a joined
+   * network (per the authoritative admission-rows roster, ADR-0018 Q3)? When it
+   * returns true for a source that the accept-list gate would otherwise deny with
+   * the OFFERINGS precondition (`peer_not_in_accept_list`, incl.
+   * `unknown_network`), the presence is folded ANYWAY — membership IS the
+   * accept-list for presence (D-1). This drops the hand-pin/offerings precondition
+   * for folding, NOT the crypto: GATE 2 (`verifySignedByChain`) + source-binding
+   * are unchanged. Other deny kinds (deny_subjects, hop budget, leaf anti-spoof)
+   * are SAFETY checks and are NEVER overridden. Omitted ⇒ defaults to "never a
+   * member" ⇒ byte-identical to pre-FS-1 (peers[]-only) behaviour.
+   */
+  isAdmittedMember?: (sourcePrincipal: string) => boolean;
+  /**
+   * FS-1 (cortex#1825) — principals for which the operator HAND-PINNED a
+   * `peers[].principal_pubkey` in the ORIGINAL config (pre-resolution). DD-11 is
+   * UNCHANGED for these: a hand-pinned peer keeps the exact pre-FS-1 path
+   * (`resolveFederatedPeers`: matching pin → admit; mismatching pin → fail-closed
+   * DROP), so it is NEVER re-admitted by membership — a membership-fold of a
+   * hand-pinned peer would silently paper over a DD-11 pin-mismatch drop.
+   * Presence-by-membership is for membership-ONLY peers (no local pin). Omitted ⇒
+   * empty set (no hand-pins to exclude).
+   */
+  handPinnedPrincipals?: ReadonlySet<string>;
 }
 
 /** cortex#1213 — payload handed to {@link StartFederatedAgentPresenceSubscriberOptions.onDenialBubbleUp}. */
@@ -280,6 +305,10 @@ export async function startFederatedAgentPresenceSubscriber(
     receipts,
   } = opts;
   const cryptoVerify = opts.cryptoVerify ?? true;
+  // FS-1 (cortex#1825) — presence-by-membership oracle + DD-11 hand-pin guard.
+  // Defaults keep pre-FS-1 behaviour: no membership-fold, no hand-pins.
+  const isAdmittedMember = opts.isAdmittedMember ?? ((): boolean => false);
+  const handPinnedPrincipals = opts.handPinnedPrincipals ?? new Set<string>();
   // FS-6 — receiver clock for received-presence receipts.
   const now = opts.now ?? Date.now;
   // cortex#1213 — dedupe the `system.access.denied` audit emits. Default to a
@@ -417,18 +446,50 @@ export async function startFederatedAgentPresenceSubscriber(
         sourceLink,
       );
       if (decision !== "allow") {
-        emitDeny(
-          {
-            capability: "federated.subject_dispatch",
-            subject,
-            reason: decision.kind,
-            source: sourcePrincipal,
-          },
-          () => {
-            emitFederationDenied(runtime, source, envelope, subject, decision);
-          },
+        // FS-1 (cortex#1825, D-1) — PRESENCE-BY-MEMBERSHIP override. The OFFERINGS
+        // precondition — `peer_not_in_accept_list` (a source in no configured
+        // `peers[]`, incl. `unknown_network`, OR whose subtree is not on
+        // `accept_subjects`) — is DROPPED for presence: an ADMITTED member of the
+        // verified admission roster (ADR-0018 Q3) folds even with no `peers[]`
+        // offering. This drops the hand-pin/offerings precondition, NOT the crypto:
+        // GATE 2 (`verifySignedByChain`) + source-binding run UNCHANGED below.
+        //
+        // ONLY `peer_not_in_accept_list` is an offering precondition. `peer_deny_list`,
+        // `max_hop_exceeded`, and `source_link_mismatch` are SAFETY / anti-spoof
+        // checks — NEVER overridden by membership (a member on a deny-listed subject,
+        // over the hop budget, or spoofed onto the wrong leaf is still hard-denied).
+        //
+        // DD-11 UNCHANGED: a HAND-PINNED peer keeps the exact pre-FS-1 path
+        // (`resolveFederatedPeers`: matching pin → admit; mismatching pin →
+        // fail-closed drop). It is NEVER re-admitted by membership — that would
+        // silently paper over a DD-11 pin-mismatch drop. Membership-fold is for
+        // membership-ONLY peers (no local pin).
+        const foldByMembership =
+          decision.kind === "peer_not_in_accept_list" &&
+          isAdmittedMember(sourcePrincipal) &&
+          !handPinnedPrincipals.has(sourcePrincipal);
+        if (!foldByMembership) {
+          emitDeny(
+            {
+              capability: "federated.subject_dispatch",
+              subject,
+              reason: decision.kind,
+              source: sourcePrincipal,
+            },
+            () => {
+              emitFederationDenied(runtime, source, envelope, subject, decision);
+            },
+          );
+          return;
+        }
+        // Admitted member, no offering, no hand-pin → fold BY MEMBERSHIP. Fall
+        // through to GATE 2 (crypto/source-binding UNCHANGED). Grep-friendly line
+        // so the pilot loop / on-call can confirm the D-1 path fired.
+        process.stderr.write(
+          `federated-agent-presence: folding ${envelope.type} (id=${envelope.id}) ` +
+            `from ADMITTED member "${sourcePrincipal}" by MEMBERSHIP ` +
+            `(no peers[] offering; D-1 presence-by-membership)\n`,
         );
-        return;
       }
     }
 

--- a/src/bus/agent-network/federated-subscriber.ts
+++ b/src/bus/agent-network/federated-subscriber.ts
@@ -245,19 +245,30 @@ export interface StartFederatedAgentPresenceSubscriberOptions {
    */
   now?: () => number;
   /**
-   * FS-1 (cortex#1825, design §3 D-1) — **presence-by-membership** oracle. Pure,
-   * synchronous predicate: is `sourcePrincipal` an ADMITTED member of a joined
-   * network (per the authoritative admission-rows roster, ADR-0018 Q3)? When it
-   * returns true for a source that the accept-list gate would otherwise deny with
-   * the OFFERINGS precondition (`peer_not_in_accept_list`, incl.
-   * `unknown_network`), the presence is folded ANYWAY — membership IS the
-   * accept-list for presence (D-1). This drops the hand-pin/offerings precondition
-   * for folding, NOT the crypto: GATE 2 (`verifySignedByChain`) + source-binding
-   * are unchanged. Other deny kinds (deny_subjects, hop budget, leaf anti-spoof)
-   * are SAFETY checks and are NEVER overridden. Omitted ⇒ defaults to "never a
-   * member" ⇒ byte-identical to pre-FS-1 (peers[]-only) behaviour.
+   * FS-1 (cortex#1825, design §3 D-1) — **presence-by-membership** oracle,
+   * NETWORK-SCOPED. Pure, synchronous predicate: is `sourcePrincipal` an ADMITTED
+   * member of the SPECIFIC network `networkId` (per the authoritative
+   * admission-rows roster, ADR-0018 Q3)?
+   *
+   * The subscriber resolves the DELIVERING LEAF (`sourceLink`) → the network(s)
+   * that leaf serves, then requires the source to be an admitted member OF THAT
+   * network. This is the anti-spoof scoping (cortex#1825 review): a principal
+   * admitted only on Network B can NEVER be membership-folded when its envelope
+   * arrives on Network A's leaf, and a bare forgery on a leaf the source is not a
+   * member of is refused. The fold fires ONLY when the gate denied with the
+   * OFFERINGS precondition AND `unknown_network === true` (a source in NO
+   * configured `peers[]` — never a config-declared peer whose `accept_subjects`
+   * deliberately excludes presence). This drops the hand-pin/offerings
+   * precondition for folding, NOT the crypto: GATE 2 (`verifySignedByChain`) +
+   * source-binding are unchanged. Other deny kinds (deny_subjects, hop budget,
+   * leaf anti-spoof) are SAFETY checks and are NEVER overridden. Omitted ⇒
+   * defaults to "never a member" ⇒ byte-identical to pre-FS-1 (peers[]-only)
+   * behaviour.
    */
-  isAdmittedMember?: (sourcePrincipal: string) => boolean;
+  isAdmittedMemberOfNetwork?: (
+    sourcePrincipal: string,
+    networkId: string,
+  ) => boolean;
   /**
    * FS-1 (cortex#1825) — principals for which the operator HAND-PINNED a
    * `peers[].principal_pubkey` in the ORIGINAL config (pre-resolution). DD-11 is
@@ -307,7 +318,8 @@ export async function startFederatedAgentPresenceSubscriber(
   const cryptoVerify = opts.cryptoVerify ?? true;
   // FS-1 (cortex#1825) — presence-by-membership oracle + DD-11 hand-pin guard.
   // Defaults keep pre-FS-1 behaviour: no membership-fold, no hand-pins.
-  const isAdmittedMember = opts.isAdmittedMember ?? ((): boolean => false);
+  const isAdmittedMemberOfNetwork =
+    opts.isAdmittedMemberOfNetwork ?? ((): boolean => false);
   const handPinnedPrincipals = opts.handPinnedPrincipals ?? new Set<string>();
   // FS-6 — receiver clock for received-presence receipts.
   const now = opts.now ?? Date.now;
@@ -380,6 +392,44 @@ export async function startFederatedAgentPresenceSubscriber(
     federatedNetworksById.set(network.id, network);
   }
 
+  // FS-1 (cortex#1825 review) — DELIVERING-LEAF → network(s) index for the
+  // membership-fold anti-spoof scope. A physical leaf (`leaf_node`) may be POOLED
+  // by more than one network (config type: "two networks sharing a `leaf_node`
+  // share one physical link"), so map each leaf to EVERY network that rides it.
+  // The membership override requires the source to be admitted on one of the
+  // networks the DELIVERING leaf serves — never a flat union across all joined
+  // networks (which let a Network-B member fold on Network-A's leaf, cortex#1825
+  // PROBE 1). `primary` is deliberately NOT indexed: it is the shared local link,
+  // not a per-network isolation boundary (mirrors the F-3d gate's `primary` skip),
+  // so a source arriving on `primary` can never satisfy the membership scope.
+  const networkIdsByLeaf = new Map<string, string[]>();
+  for (const network of networks) {
+    if (network.leaf_node === "primary") continue;
+    const existing = networkIdsByLeaf.get(network.leaf_node);
+    if (existing !== undefined) existing.push(network.id);
+    else networkIdsByLeaf.set(network.leaf_node, [network.id]);
+  }
+
+  /**
+   * FS-1 (cortex#1825 review) — is `sourcePrincipal` an admitted member of a
+   * network served by the DELIVERING leaf `sourceLink`? Fail-closed: an absent /
+   * `primary` / unrecognised leaf yields false so the membership override never
+   * fires without a dedicated-leaf attribution (closes the cross-network spoof
+   * + the bare `signing:off` forgery on `primary`).
+   */
+  const isAdmittedOnDeliveringLeaf = (
+    sourcePrincipal: string,
+    sourceLink: string | undefined,
+  ): boolean => {
+    if (sourceLink === undefined || sourceLink === "primary") return false;
+    const candidateNetworkIds = networkIdsByLeaf.get(sourceLink);
+    if (candidateNetworkIds === undefined) return false;
+    for (const networkId of candidateNetworkIds) {
+      if (isAdmittedMemberOfNetwork(sourcePrincipal, networkId)) return true;
+    }
+    return false;
+  };
+
   const pattern = federatedAgentPresenceSubject();
 
   // The set of valid presence `envelope.type` literals — a fast membership
@@ -446,15 +496,20 @@ export async function startFederatedAgentPresenceSubscriber(
         sourceLink,
       );
       if (decision !== "allow") {
-        // FS-1 (cortex#1825, D-1) — PRESENCE-BY-MEMBERSHIP override. The OFFERINGS
-        // precondition — `peer_not_in_accept_list` (a source in no configured
-        // `peers[]`, incl. `unknown_network`, OR whose subtree is not on
-        // `accept_subjects`) — is DROPPED for presence: an ADMITTED member of the
-        // verified admission roster (ADR-0018 Q3) folds even with no `peers[]`
-        // offering. This drops the hand-pin/offerings precondition, NOT the crypto:
-        // GATE 2 (`verifySignedByChain`) + source-binding run UNCHANGED below.
+        // FS-1 (cortex#1825, D-1) — PRESENCE-BY-MEMBERSHIP override, LEAF-SCOPED.
+        // The OFFERINGS precondition — `peer_not_in_accept_list` with
+        // `unknown_network === true` (a source in NO configured `peers[]` at all) —
+        // is DROPPED for presence: an ADMITTED member of the verified admission
+        // roster (ADR-0018 Q3) folds even with no `peers[]` offering, PROVIDED it is
+        // admitted on a network served by the DELIVERING leaf. This drops the
+        // hand-pin/offerings precondition, NOT the crypto: GATE 2
+        // (`verifySignedByChain`) + source-binding run UNCHANGED below.
         //
-        // ONLY `peer_not_in_accept_list` is an offering precondition. `peer_deny_list`,
+        // ONLY the `unknown_network` variant of `peer_not_in_accept_list` is an
+        // offering precondition. The NON-`unknown_network` variant — a
+        // config-declared peer whose `accept_subjects` deliberately excludes the
+        // presence subtree — is the operator's EXPLICIT narrowing and is NEVER
+        // overridden by membership (cortex#1825 PROBE 2). `peer_deny_list`,
         // `max_hop_exceeded`, and `source_link_mismatch` are SAFETY / anti-spoof
         // checks — NEVER overridden by membership (a member on a deny-listed subject,
         // over the hop budget, or spoofed onto the wrong leaf is still hard-denied).
@@ -464,10 +519,25 @@ export async function startFederatedAgentPresenceSubscriber(
         // fail-closed drop). It is NEVER re-admitted by membership — that would
         // silently paper over a DD-11 pin-mismatch drop. Membership-fold is for
         // membership-ONLY peers (no local pin).
+        //
+        // cortex#1825 review — TWO anti-spoof scopes make membership no weaker
+        // than the pre-existing accept-list posture:
+        //   (a) `unknown_network === true` — the source resolved to NO configured
+        //       `peers[]` at all. A config-declared peer whose `accept_subjects`
+        //       deliberately excludes presence denies with the SAME `kind` but
+        //       WITHOUT `unknown_network`; its explicit narrowing must NEVER be
+        //       overridden by membership (PROBE 2).
+        //   (b) `isAdmittedOnDeliveringLeaf` — the source must be an admitted
+        //       member of a network served by the DELIVERING leaf (`sourceLink`),
+        //       not merely admitted on SOME joined network. This closes the
+        //       cross-network / cross-leaf impersonation (PROBE 1) and the bare
+        //       `signing:off` forgery attributed to `primary` (finding #2), which
+        //       the flat union + skipped F-3d check previously let through.
         const foldByMembership =
           decision.kind === "peer_not_in_accept_list" &&
-          isAdmittedMember(sourcePrincipal) &&
-          !handPinnedPrincipals.has(sourcePrincipal);
+          decision.unknown_network === true &&
+          !handPinnedPrincipals.has(sourcePrincipal) &&
+          isAdmittedOnDeliveringLeaf(sourcePrincipal, sourceLink);
         if (!foldByMembership) {
           emitDeny(
             {

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -3024,6 +3024,12 @@ async function runAdmit(
       `  registry:          ${registryUrl}`,
       `  admin_fingerprint: ${material.fingerprint}`,
       ...(discordMember !== undefined ? [`  discord_member:    ${discordMember}`] : []),
+      // FS-1 (cortex#1825, D-1 Rider R1) — consent transparency, surfaced BEFORE
+      // the admin commits: admission ⇒ the member's presence becomes visible to
+      // co-members (presence-by-membership); their `presence: hidden` opts out.
+      `  presence:          on admit, this member's agent roster + capabilities become`,
+      `                     VISIBLE to co-members (presence-by-membership, D-1); the`,
+      `                     member may withhold via \`policy.federated.presence: hidden\`.`,
       ``,
     ];
     return ok(lines.join("\n"));
@@ -3152,6 +3158,23 @@ async function runAdmit(
       lines.push(`  discord:     ${report.discordWarning}`);
     }
   }
+  // FS-1 (cortex#1825, D-1 Rider R1) — consent transparency. Admission ⇒
+  // co-presence: this member's agent roster + declared capabilities become
+  // visible to co-members by default (presence-by-membership). State it plainly
+  // at admit time; note the member's own `presence: hidden` opt-out.
+  lines.push("");
+  lines.push(
+    `  presence:    admission ⇒ ${report.principalId}'s agent roster + declared capabilities`,
+  );
+  lines.push(
+    `               become VISIBLE to co-members (presence-by-membership, D-1).`,
+  );
+  lines.push(
+    `               The member may withhold this with \`policy.federated.presence: hidden\``,
+  );
+  lines.push(
+    `               (still admitted for dispatch; presence not broadcast).`,
+  );
   lines.push("");
   return ok(lines.join("\n"));
 }

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -2321,6 +2321,24 @@ export type PolicyFederatedRegistry = z.infer<typeof PolicyFederatedRegistrySche
 export const PolicyFederatedSchema = z.object({
   networks: z.array(PolicyFederatedNetworkSchema).default([]),
   registry: PolicyFederatedRegistrySchema.optional(),
+  /**
+   * FS-1 (cortex#1825, design-federation-simplification §3 D-1 Rider R2) —
+   * per-stack federated-presence visibility. Default `"visible"`: an admitted
+   * member's agent presence is dual-emitted onto `federated.{principal}.{stack}.
+   * agent.*` so co-members fold it (presence-by-membership). Setting `"hidden"`
+   * is the day-one opt-out: the stack is still admitted for DISPATCH but
+   * WITHHOLDS its presence broadcast — it never publishes the federated presence
+   * copy, so no co-member can fold it. This is enforced at the SOURCE (the
+   * producer's `federate` flag), not as a subscriber-side UI filter — a hidden
+   * member is truly absent from co-members' Network view. A network-less stack
+   * federates nothing regardless, so this key only bites once ≥1 network is
+   * joined.
+   *
+   * OPTIONAL (not `.default`): absence is treated as `"visible"` at the consumer
+   * (`presence !== "hidden"`), so existing configs + literals need no `presence`
+   * key and keep byte-identical behaviour. Only an explicit `"hidden"` opts out.
+   */
+  presence: z.enum(["visible", "hidden"]).optional(),
 });
 
 export type PolicyFederated = z.infer<typeof PolicyFederatedSchema>;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -253,6 +253,7 @@ import { chatCapableAgents } from "./runner/chat-capable-agents";
 import {
   AgentPresenceProducer,
   presenceAgentFromAgent,
+  shouldFederatePresence,
   DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS,
   type PresenceAgent,
 } from "./runner/agent-presence-producer";
@@ -274,6 +275,13 @@ import {
   startFederationReconciler,
   type FederationReconcilerHandle,
 } from "./bus/agent-network/federation-reconciler";
+// FS-1 (cortex#1825, design §3 D-1) — presence-by-membership oracle: "is this
+// source principal an ADMITTED member?" resolved from the authoritative
+// admission-rows roster (ADR-0018 Q3 — the SAME source `/api/networks` uses).
+import {
+  createFederatedMembershipOracle,
+  type FederatedMembershipOracleHandle,
+} from "./bus/agent-network/federated-membership";
 // P-14 U3.3 (#937) — trust-verified federated OBSERVABILITY fold (the
 // observability sibling of the presence subscriber; same Option-D trust path +
 // the curation gate, origin-badged).
@@ -4518,6 +4526,24 @@ export async function startCortex(
   // reads) so a later-joining roster peer's presence is admitted within one
   // reconcile interval. INERT unless a network opts in (`reconcile.enabled`).
   let federationReconcilerHandle: FederationReconcilerHandle | null = null;
+  // FS-1 (cortex#1825, D-1) — presence-by-membership oracle. Late-bound: assigned
+  // inside the MC-gated block below once the admission-rows provider is built
+  // (it reuses the SAME provider `/api/networks` uses). The subscriber's
+  // `isAdmittedMember` closure reads this handle at FOLD time (runtime), so the
+  // late binding is safe — a member simply isn't membership-folded until the
+  // first refresh warms the snapshot (self-heals on the next heartbeat).
+  let federatedMembershipHandle: FederatedMembershipOracleHandle | null = null;
+  // FS-1 (cortex#1825) — principals the operator HAND-PINNED a `principal_pubkey`
+  // for in the ORIGINAL config (pre-resolution). DD-11 stays fail-closed for
+  // these: they are NEVER re-admitted by membership (see federated-subscriber.ts
+  // `handPinnedPrincipals`). Computed from the raw `options.policy`, not the
+  // post-`resolveFederatedPeers` set (which has already DROPPED a mismatched pin).
+  const handPinnedPrincipals = new Set<string>();
+  for (const n of options.policy?.federated?.networks ?? []) {
+    for (const p of n.peers) {
+      if (p.principal_pubkey !== undefined) handPinnedPrincipals.add(p.principal_id);
+    }
+  }
   // P-14 U3.3 (#937) — trust-verified federated OBSERVABILITY fold (folds peers'
   // curated+signed system.{transport,federation}.* into the observability
   // projection, ORIGIN-BADGED — the Option-D sibling of the presence subscriber).
@@ -4533,8 +4559,13 @@ export async function startCortex(
   // on, the producer dual-emits a `classification: "federated"` copy so peers'
   // E.2 subscribers can fold it (the existing federated-classification
   // mechanism, not a new toggle).
-  const federatePresence =
-    (resolvedPolicy?.federated?.networks ?? []).length > 0;
+  // FS-1 (cortex#1825, D-1 Rider R2) — a stack federates its presence when it has
+  // joined ≥1 network, UNLESS it opts out with `policy.federated.presence:
+  // hidden`. A hidden stack is still admitted for DISPATCH but never dual-emits
+  // the `federated.*` presence copy, so no co-member can fold it (the opt-out is
+  // enforced at the SOURCE, not as a subscriber-side filter — truly hidden). The
+  // decision is the pure `shouldFederatePresence` helper (unit-tested for R2).
+  const federatePresence = shouldFederatePresence(resolvedPolicy?.federated);
   // The onChange→WS-broadcast subscription handle, captured so shutdown can
   // unsubscribe it explicitly — making teardown order-independent rather than
   // relying on the registry stop severing the envelope feed first (#899 review).
@@ -4702,6 +4733,13 @@ export async function startCortex(
           stackNKeyPub: stackNKeyPubForVerifier,
         }),
         ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
+        // FS-1 (cortex#1825, D-1) — presence-by-membership. The oracle is
+        // late-bound (assigned below once the admission-rows provider is built),
+        // so read it through the handle at FOLD time. `handPinnedPrincipals`
+        // keeps DD-11 fail-closed (a hand-pinned peer is never membership-folded).
+        isAdmittedMember: (sourcePrincipal: string): boolean =>
+          federatedMembershipHandle?.isAdmittedMember(sourcePrincipal) ?? false,
+        handPinnedPrincipals,
       });
 
       // P3 (cortex#1088, design §4/§7) — the continuous federation roster
@@ -4848,6 +4886,28 @@ export async function startCortex(
                           : "no stack signing identity (stack.nkey_seed_path) — cannot PoP-sign the member roster read",
                   }),
               };
+
+        // FS-1 (cortex#1825, D-1) — presence-by-membership oracle. Reuses the
+        // EXACT `admissionProvider` the `/api/networks` view uses (the
+        // authoritative ADR-0018 Q3 admission-rows source, PoP-signed +
+        // DD-9-verified) — NOT a second key/roster source. It refreshes an
+        // admitted-member snapshot on an interval; the presence subscriber's
+        // `isAdmittedMember` closure reads it synchronously at fold time so an
+        // admitted member folds even with no `peers[]` offering. A
+        // `not_configured` provider leaves the snapshot empty → no membership-fold
+        // (honest degradation, the existing `peers[]` gate still applies).
+        federatedMembershipHandle = createFederatedMembershipOracle({
+          networkIds: networksList.map((n) => n.id),
+          provider: admissionProvider,
+          onRefresh: (info) => {
+            if (info.admittedCount > 0) {
+              console.log(
+                `cortex: federated-membership — ${info.networkId}: ${info.admittedCount.toString()} admitted member(s) (presence-by-membership, D-1)`,
+              );
+            }
+          },
+        });
+        federatedMembershipHandle.start();
 
         // The accept-policy summary (the second trust layer), distilled ONCE
         // from this stack's offerings and queried per member.
@@ -5613,6 +5673,14 @@ export async function startCortex(
       await completeAsync(
         "federation roster reconciler stop",
         federationReconcilerHandle?.stop(),
+      );
+      // FS-1 (cortex#1825) — stop the presence-by-membership oracle poller
+      // (cancels the interval + awaits any in-flight admission-rows read). It
+      // only reads the registry into an in-memory snapshot, so ordering vs. the
+      // subscriber teardown is immaterial.
+      await completeAsync(
+        "federated membership oracle stop",
+        federatedMembershipHandle?.stop(),
       );
       // P-14 U3.3 — stop the federated observability fold (drains its push
       // subscriber + unregisters its fan-out handler). Projected observability

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -863,7 +863,7 @@ function targetAgentForDispatch(
       agent.openOnboardingAllowedTools !== undefined && {
         openOnboardingAllowedTools: agent.openOnboardingAllowedTools,
       }),
-    // #1206 (operator-driven dev-loop, S1) — carry the agent's declared
+    // #1206 (principal-driven dev-loop, S1) — carry the agent's declared
     // `runtime.capabilities[]` so the dispatch handler's orchestrator-command
     // gate activates ONLY for the agent declaring `dev.orchestrate` (e.g. vega).
     ...(agent.runtime?.capabilities !== undefined && {
@@ -1439,8 +1439,8 @@ export async function startCortex(
 
   // cortex#79 — creds minting is no longer a cortex daemon responsibility.
   // `cortex creds issue / revoke / rotate` now shell out to
-  // `arc nats … --json`; arc owns nsc and the operator account.
-  // `config.nats.accountSigningKeyPath` survives for the operator-signature
+  // `arc nats … --json`; arc owns nsc and the principal account.
+  // `config.nats.accountSigningKeyPath` survives for the principal-signature
   // verifier on TrustResolver (cortex#76); see
   // `src/common/agents/trust-resolver.ts`.
 
@@ -4533,8 +4533,8 @@ export async function startCortex(
   // late binding is safe — a member simply isn't membership-folded until the
   // first refresh warms the snapshot (self-heals on the next heartbeat).
   let federatedMembershipHandle: FederatedMembershipOracleHandle | null = null;
-  // FS-1 (cortex#1825) — principals the operator HAND-PINNED a `principal_pubkey`
-  // for in the ORIGINAL config (pre-resolution). DD-11 stays fail-closed for
+  // FS-1 (cortex#1825) — principals that HAND-PINNED a `principal_pubkey`
+  // in the ORIGINAL config (pre-resolution). DD-11 stays fail-closed for
   // these: they are NEVER re-admitted by membership (see federated-subscriber.ts
   // `handPinnedPrincipals`). Computed from the raw `options.policy`, not the
   // post-`resolveFederatedPeers` set (which has already DROPPED a mismatched pin).

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -4733,12 +4733,20 @@ export async function startCortex(
           stackNKeyPub: stackNKeyPubForVerifier,
         }),
         ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
-        // FS-1 (cortex#1825, D-1) — presence-by-membership. The oracle is
-        // late-bound (assigned below once the admission-rows provider is built),
-        // so read it through the handle at FOLD time. `handPinnedPrincipals`
+        // FS-1 (cortex#1825, D-1) — presence-by-membership, NETWORK-SCOPED. The
+        // oracle is late-bound (assigned below once the admission-rows provider is
+        // built), so read it through the handle at FOLD time. The subscriber keys
+        // this off the DELIVERING leaf → network, so a member of Network B can't
+        // fold on Network A's leaf (cortex#1825 review). `handPinnedPrincipals`
         // keeps DD-11 fail-closed (a hand-pinned peer is never membership-folded).
-        isAdmittedMember: (sourcePrincipal: string): boolean =>
-          federatedMembershipHandle?.isAdmittedMember(sourcePrincipal) ?? false,
+        isAdmittedMemberOfNetwork: (
+          sourcePrincipal: string,
+          networkId: string,
+        ): boolean =>
+          federatedMembershipHandle?.isAdmittedMemberOfNetwork(
+            sourcePrincipal,
+            networkId,
+          ) ?? false,
         handPinnedPrincipals,
       });
 

--- a/src/runner/__tests__/agent-presence-producer.test.ts
+++ b/src/runner/__tests__/agent-presence-producer.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, test } from "bun:test";
 import {
   AgentPresenceProducer,
   presenceAgentFromAgent,
+  shouldFederatePresence,
   DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS,
   type PresenceAgent,
   type PresenceScheduler,
@@ -581,5 +582,35 @@ describe("AgentPresenceProducer federation opt-in (E.1)", () => {
     await producer.stop();
     const cls = classificationsFor(runtime.published, "agent.offline").sort();
     expect(cls).toEqual(["federated", "local"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FS-1 (cortex#1825, design §3 D-1 Rider R2) — presence: hidden opt-out
+// ---------------------------------------------------------------------------
+//
+// `shouldFederatePresence` is the boot decision that feeds the producer's
+// `federate` flag. Combined with the federate:true/false emit tests above, this
+// proves the full R2 chain: `presence: "hidden"` ⇒ federate false ⇒ the producer
+// emits ONLY local (no `federated.*` copy) ⇒ no co-member can fold a hidden
+// member (truly hidden, server-side — not a UI filter).
+
+describe("FS-1 R2 — shouldFederatePresence (presence: hidden opt-out)", () => {
+  test("no networks ⇒ never federates (nothing to federate to)", () => {
+    expect(shouldFederatePresence(undefined)).toBe(false);
+    expect(shouldFederatePresence({ networks: [] })).toBe(false);
+  });
+
+  test("networks joined, presence visible/absent ⇒ federates (default)", () => {
+    expect(shouldFederatePresence({ networks: [{}] })).toBe(true);
+    expect(shouldFederatePresence({ networks: [{}], presence: "visible" })).toBe(true);
+  });
+
+  test("networks joined but presence: hidden ⇒ does NOT federate (R2 opt-out)", () => {
+    expect(shouldFederatePresence({ networks: [{}], presence: "hidden" })).toBe(false);
+  });
+
+  test("presence: hidden with NO networks is still false (network gate first)", () => {
+    expect(shouldFederatePresence({ networks: [], presence: "hidden" })).toBe(false);
   });
 });

--- a/src/runner/agent-presence-producer.ts
+++ b/src/runner/agent-presence-producer.ts
@@ -96,6 +96,25 @@ import type { Agent } from "../common/types/cortex-config";
 export const DEFAULT_PRESENCE_HEARTBEAT_INTERVAL_MS = 60_000;
 
 /**
+ * FS-1 (cortex#1825, design §3 D-1 Rider R2) — decide whether THIS stack
+ * dual-emits the `classification: "federated"` presence copy (the
+ * {@link AgentPresenceProducerOptions.federate} flag).
+ *
+ * A stack federates its presence when it has joined ≥1 network — UNLESS it opts
+ * out with `policy.federated.presence: "hidden"`. A hidden stack stays admitted
+ * for DISPATCH but WITHHOLDS its presence broadcast (it never publishes the
+ * federated copy), so no co-member can fold it. Absence of the key ⇒ `"visible"`
+ * (the pre-FS-1 default): only an explicit `"hidden"` suppresses.
+ *
+ * Pure + exported so the R2 opt-out is unit-testable without a full boot.
+ */
+export function shouldFederatePresence(
+  federated: { networks?: readonly unknown[]; presence?: "visible" | "hidden" } | undefined,
+): boolean {
+  return (federated?.networks?.length ?? 0) > 0 && federated?.presence !== "hidden";
+}
+
+/**
  * One agent's presence descriptor — the identity + scope + capability set the
  * producer stamps onto its `agent.*` envelopes. Derived from an assembled
  * `Agent` by {@link presenceAgentFromAgent} at the boot site, kept as a narrow


### PR DESCRIPTION
Closes #1825. Part of epic #1818 (Federation simplification). **[frontier-review] TRUST-PATH.** D-1 ratified (#1819) with R1 consent + R2 presence:hidden.

Makes an admitted member's signed presence fold with **no hand-pinned `peers[].principal_pubkey`** — the permanent fix for `jc: admitted-absent` (jc IS on the admission roster; the fold just never consulted it).

## Root approach
- **Membership seam:** the authoritative **admission-rows roster** (ADR-0018 Q3) — the SAME PoP-signed, DD-9-verified `AdmissionRowsProvider` `/api/networks` uses — via new `createFederatedMembershipOracle` (`federated-membership.ts`). NOT the capability roster (capability ≠ membership). Best-effort interval refresh; only an authoritative (`scope:complete`) read updates the snapshot; self-scope/failed read keeps last-good.
- **Fold gate (`federated-subscriber.ts`):** on a `peer_not_in_accept_list` deny (the OFFERINGS precondition, incl. `unknown_network`) AND `isAdmittedMember(src)` AND NOT hand-pinned → fold by membership; then fall through to GATE 2 crypto + source-binding **UNCHANGED**. `peer_deny_list` / `max_hop` / `source_link_mismatch` are safety/anti-spoof → **NEVER** overridden.
- **DD-11:** a hand-pinned peer is NEVER re-admitted by membership (`handPinnedPrincipals` computed from the ORIGINAL config, pre-`resolveFederatedPeers`). Defaults (no oracle) are byte-identical to pre-FS-1.
- **R2 presence:hidden (server-side):** new `policy.federated.presence: "visible"|"hidden"` (absent=visible). A hidden stack's producer `federate` flag → false via pure `shouldFederatePresence(...)` → never dual-emits the `federated.*` presence copy → no co-member can fold it. True source-side hide, not a UI filter.
- **R1 consent line:** `cortex network admit` apply + dry-run — admission ⇒ member's roster/capabilities visible to co-members, notes the `presence: hidden` opt-out.

## Trust boundary (reviewer note)
Under `permissive` (the live posture) GATE 2 is best-effort, so membership + source-binding IS the trust boundary — exactly as the existing `signing:off/permissive` accept-list-only posture, but **stronger**: must be a hub-admin-signed admitted member, not just any `envelope.source`. Under `enforce` it's fully crypto-bound. No posture flip, no crypto change.

## Verification
- `bunx tsc --noEmit` → 0; `bunx eslint --quiet` → clean.
- 1714 pass / 0 fail / 1 skip. Covers AC1 (member-no-pubkey folds), AC2 (non-member denied + default-off parity), AC4 (DD-11 hand-pin not folded), AC5 (source-binding spoof dropped), safety-deny-not-overridden, oracle authoritative/self-scope/degraded, R2 opt-out.
- Additive (`--diff-filter=D` empty).

Note: `network-secret-cli.test.ts` 20 fails are pre-existing/env-dependent (reproduce on clean main), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)