### PR TITLE
fix(registry): roster projects derived stack_id — stop the client fabricating {principal}/default (#1852 half A)

### DIFF
--- a/src/services/network-registry/__tests__/roster-stack-id.test.ts
+++ b/src/services/network-registry/__tests__/roster-stack-id.test.ts
@@ -1,0 +1,186 @@
+/**
+ * cortex#1852 half (A) — the roster must PROJECT each member's `stack_id`,
+ * derived from the principal record exactly as the admission reads already do
+ * (cortex#1723), so the client never has to invent `{principal}/default`.
+ *
+ * Derivation posture (inherited verbatim from `deriveAdmissionStackId`):
+ *   - join `row.peer_pubkey` against the principal's LIVE (non-retired) stacks
+ *   - emit `stack_id` ONLY on a unique match
+ *   - on no match / ambiguous match: OMIT the key. Never `null`, never a guess.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { rosterFromAdmissions } from "../src/store";
+import type { AdmissionRequest, Capability, PrincipalRecord, StackIdentity } from "../src/types";
+
+const NETWORK = "metafactory";
+
+const PUBKEY = {
+  andreasRoot: "AAAAandreas_root_pubkey_base64_padding_44char=",
+  andreasMetaFactory: "AAAAandreas_meta_factory_stack_pubkey_44char=",
+  jcRoot: "BBBBjc_root_pubkey_base64_padding_value_44ch=",
+  jcDefault: "BBBBjc_default_stack_pubkey_base64_val_44char=",
+  jcClawbox: "BBBBjc_clawbox_stack_pubkey_base64_val_44char=",
+  unknown: "ZZZZunknown_pubkey_matching_no_live_stack_44=",
+} as const;
+
+function stack(stackId: string, stackPubkey: string, retiredAt?: string): StackIdentity {
+  return { stack_id: stackId, stack_pubkey: stackPubkey, ...(retiredAt !== undefined && { retired_at: retiredAt }) };
+}
+
+function principal(
+  principalId: string,
+  principalPubkey: string,
+  stacks: StackIdentity[],
+  capabilities: Capability[] = [],
+): PrincipalRecord {
+  return {
+    principal_id: principalId,
+    principal_pubkey: principalPubkey,
+    stacks,
+    capabilities,
+    updated_at: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+function admission(principalId: string, peerPubkey: string): AdmissionRequest {
+  return {
+    request_id: `req-${principalId}`,
+    principal_id: principalId,
+    peer_pubkey: peerPubkey,
+    requested_scope: "federation",
+    network_id: NETWORK,
+    status: "ADMITTED",
+    created_at: "2026-07-10T00:00:00.000Z",
+    updated_at: "2026-07-10T00:00:00.000Z",
+    granted_by: "admin",
+    sealed_secret: null,
+    hub_authorized_at: null,
+  };
+}
+
+/** The single member of a one-member roster. */
+function onlyMember(admitted: AdmissionRequest[], principals: PrincipalRecord[]) {
+  const roster = rosterFromAdmissions(admitted, principals, NETWORK);
+  expect(roster.members).toHaveLength(1);
+  return roster.members[0]!;
+}
+
+describe("cortex#1852 — roster projects a derived stack_id", () => {
+  test("single live stack with a NON-default slug → stack_id is projected", () => {
+    const member = onlyMember(
+      [admission("andreas", PUBKEY.andreasMetaFactory)],
+      [
+        principal("andreas", PUBKEY.andreasRoot, [
+          stack("andreas/meta-factory", PUBKEY.andreasMetaFactory),
+        ]),
+      ],
+    );
+    // The exact bug: this used to be absent, and the client invented "andreas/default".
+    expect(member.stack_id).toBe("andreas/meta-factory");
+  });
+
+  test("TWO live stacks → peer_pubkey selects the right one uniquely", () => {
+    const principals = [
+      principal("jc", PUBKEY.jcRoot, [
+        stack("jc/default", PUBKEY.jcDefault),
+        stack("jc/clawbox", PUBKEY.jcClawbox),
+      ]),
+    ];
+
+    expect(onlyMember([admission("jc", PUBKEY.jcDefault)], principals).stack_id).toBe("jc/default");
+    expect(onlyMember([admission("jc", PUBKEY.jcClawbox)], principals).stack_id).toBe("jc/clawbox");
+  });
+
+  test("AMBIGUOUS (pubkey matches >1 live stack) → stack_id key is ABSENT, never guessed", () => {
+    const member = onlyMember(
+      [admission("jc", PUBKEY.jcDefault)],
+      [
+        principal("jc", PUBKEY.jcRoot, [
+          stack("jc/default", PUBKEY.jcDefault),
+          stack("jc/clone", PUBKEY.jcDefault), // same pubkey ⇒ ambiguous
+        ]),
+      ],
+    );
+    expect("stack_id" in member).toBe(false);
+    expect(member.stack_id).toBeUndefined();
+  });
+
+  test("NO match → stack_id key is ABSENT (no `{principal}/default` fabrication, no null)", () => {
+    const member = onlyMember(
+      [admission("andreas", PUBKEY.unknown)],
+      [
+        principal("andreas", PUBKEY.andreasRoot, [
+          stack("andreas/meta-factory", PUBKEY.andreasMetaFactory),
+        ]),
+      ],
+    );
+    expect("stack_id" in member).toBe(false);
+    // Neither the key (⇒ never serialised as `"stack_id":null`) nor a guess.
+    expect(JSON.stringify(member)).not.toContain("stack_id");
+    expect(JSON.stringify(member)).not.toContain("andreas/default");
+  });
+
+  test("a RETIRED stack is excluded from the match", () => {
+    const member = onlyMember(
+      [admission("andreas", PUBKEY.andreasMetaFactory)],
+      [
+        principal("andreas", PUBKEY.andreasRoot, [
+          stack("andreas/meta-factory", PUBKEY.andreasMetaFactory, "2026-07-01T00:00:00.000Z"),
+        ]),
+      ],
+    );
+    expect("stack_id" in member).toBe(false);
+  });
+
+  test("a retired stack does not make a live one ambiguous", () => {
+    const member = onlyMember(
+      [admission("andreas", PUBKEY.andreasMetaFactory)],
+      [
+        principal("andreas", PUBKEY.andreasRoot, [
+          stack("andreas/old", PUBKEY.andreasMetaFactory, "2026-07-01T00:00:00.000Z"),
+          stack("andreas/meta-factory", PUBKEY.andreasMetaFactory),
+        ]),
+      ],
+    );
+    expect(member.stack_id).toBe("andreas/meta-factory");
+  });
+
+  test("enrichment is ADDITIVE — existing member fields are untouched", () => {
+    const roster = rosterFromAdmissions(
+      [{ ...admission("andreas", PUBKEY.andreasMetaFactory), sealed_secret: "ciphertext" }],
+      [
+        principal(
+          "andreas",
+          PUBKEY.andreasRoot,
+          [stack("andreas/meta-factory", PUBKEY.andreasMetaFactory)],
+          [{ id: "dev.implement", networks: [NETWORK] }],
+        ),
+      ],
+      NETWORK,
+    );
+    expect(roster.members[0]).toEqual({
+      principal_id: "andreas",
+      principal_pubkey: PUBKEY.andreasRoot,
+      capabilities: ["dev.implement"],
+      admission_state: "ADMITTED",
+      sealed: true, // boolean DELIVERY signal — never the ciphertext
+      hub_authorized_at: null,
+      stack_id: "andreas/meta-factory",
+    });
+  });
+
+  test("the andreas⇄jc regression: both members carry their REAL stack ids", () => {
+    const roster = rosterFromAdmissions(
+      [admission("andreas", PUBKEY.andreasMetaFactory), admission("jc", PUBKEY.jcDefault)],
+      [
+        principal("andreas", PUBKEY.andreasRoot, [
+          stack("andreas/meta-factory", PUBKEY.andreasMetaFactory),
+        ]),
+        principal("jc", PUBKEY.jcRoot, [stack("jc/default", PUBKEY.jcDefault)]),
+      ],
+      NETWORK,
+    );
+    expect(roster.members.map((m) => m.stack_id)).toEqual(["andreas/meta-factory", "jc/default"]);
+  });
+});

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -1304,6 +1304,12 @@ export function rosterFromAdmissions(
     const capabilities = record.capabilities
       .filter((cap) => (cap.networks ?? []).includes(networkId))
       .map((cap) => cap.id);
+    // cortex#1852 — project the member's DERIVED `stack_id` (same read-time join
+    // the admission reads use, cortex#1723). `undefined` ⇒ underivable (no live
+    // stack matches `peer_pubkey`, or more than one does): OMIT the key entirely.
+    // Never `null`, never a guessed `{principal}/default` — the client's silent
+    // fabrication of that default is precisely the defect this closes.
+    const stackId = deriveAdmissionStackId(row, principals);
     members.push({
       principal_id: record.principal_id,
       principal_pubkey: record.principal_pubkey,
@@ -1315,6 +1321,7 @@ export function rosterFromAdmissions(
       admission_state: "ADMITTED",
       sealed: row.sealed_secret !== null,
       hub_authorized_at: row.hub_authorized_at,
+      ...(stackId !== undefined && { stack_id: stackId }),
     });
   }
   members.sort((a, b) => a.principal_id.localeCompare(b.principal_id));

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -211,6 +211,20 @@ export interface NetworkRoster {
     admission_state?: AdmissionStatus;
     sealed?: boolean;
     hub_authorized_at?: string | null;
+    /**
+     * cortex#1852 — the member's `{principal_id}/{stack_slug}` stack id, DERIVED
+     * at read time by joining the admission row's `peer_pubkey` against the
+     * principal record's LIVE stacks (see `deriveAdmissionStackId`, cortex#1723).
+     *
+     * ADDITIVE + OPTIONAL, and deliberately so: the field is **omitted** (never
+     * `null`, never a fabricated `{principal}/default`) when the pubkey matches
+     * no live stack or MORE than one. Absence means "underivable" — a consumer
+     * must treat it as a fault and drop the peer, not fill in a default. The
+     * silent `{principal}/default` fallback the client used to apply is exactly
+     * the bug this field closes: it mis-scoped `andreas/meta-factory` presence
+     * to `federated.andreas.default.agent.>` and dropped it at Gate 1.
+     */
+    stack_id?: string;
   }[];
 }
 


### PR DESCRIPTION
Part of #1852 (root cause of #1812). Epic #1818. **Half (A) — registry.** Half (B) (client fail-loud) lands AFTER this deploys.

## The bug
`GET /networks/{id}/roster` projected `members[]` **without `stack_id`**, so the client (`roster-read.ts:236`) did `member.stack_id ?? ${principal}/default` — **inventing** `andreas/default` for a stack whose real id is `andreas/meta-factory`. The reconciler then derived `federated.andreas.default.agent.>`, which never matches the peer's real presence subject → dropped at Gate 1, silently, forever. For `jc` the invented `jc/default` is coincidentally correct, masking the defect in one direction.

The registry **already knew** the answer: the admission row derives `stack_id` (cortex#1723) and the principal record holds `stacks[]`. Only the roster projection dropped it.

## The fix — additive, reuses the proven derive
`rosterFromAdmissions` (`store.ts`) now enriches each member via the EXISTING exported `deriveAdmissionStackId(row, principals)` — join `peer_pubkey` → the principal's **live** (non-retired) `stacks[]`, accept only a **unique** match:
```ts
const stackId = deriveAdmissionStackId(row, principals);
members.push({ …, ...(stackId !== undefined && { stack_id: stackId }) });
```
`undefined` (no match, or **ambiguous** >1 match) ⇒ the key is **omitted**. Never `null`, never `{principal}/default`. The helper's own posture — *"ambiguous — never guess"* — is preserved end to end. `NetworkRoster["members"]` gains optional `stack_id?: string`.

Both roster call sites (`routes/networks.ts:295` public, `:400` member-gated) go through `rosterFromAdmissions` and inherit it — no duplicated logic.

**Deliberately NOT touched:** the `/networks/{id}` descriptor's `members[]` is a `string[]` of principal ids; objectifying it is a *breaking* shape change to a signed payload, not additive. Tracked as an open decision on #1852. `roster-read.ts` consumes the roster, which this fully fixes.

## Backward compatibility
Purely additive: no field reordered or renamed, so the DD-9 signed payload stays verifiable and pre-fix clients ignore the new key. Existing clients already prefer `member.stack_id` when present — so **this deploy alone fixes the fold, with no cortex upgrade on either side**.

## Verification
- 8 new TDD cases (`__tests__/roster-stack-id.test.ts`): non-default slug derives; two live stacks disambiguate by `peer_pubkey` (both directions); ambiguous ⇒ key absent; no-match ⇒ JSON contains neither `stack_id` nor `andreas/default`; retired stack excluded, and a retired stack doesn't make a live one ambiguous; full `toEqual` additivity check; andreas⇄jc regression → `["andreas/meta-factory", "jc/default"]`.
- `bun test src/services/network-registry/__tests__` → **343 pass, 0 fail** (1605 expects, 28 files)
- `bunx tsc --noEmit` (repo root, the CI gate) → **0 errors**; `bunx eslint --quiet` → clean; VOCAB carve-out → PASS
- Additive: `--diff-filter=D` empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)