### PR TITLE
refactor(adapters): move legacy outbound-log/worklog inside discord adapter (#1787)

### DIFF
--- a/src/adapters/discord/__tests__/worklog-formatter.test.ts
+++ b/src/adapters/discord/__tests__/worklog-formatter.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import { formatThreadName, formatEventForThread, formatCompletionSummary } from "../worklog-formatter";
-import type { PublishedEvent } from "../../taps/cc-events/hooks/lib/event-types";
+import type { PublishedEvent } from "../../../taps/cc-events/hooks/lib/event-types";
 
 function makeEvent(overrides: Partial<PublishedEvent> = {}): PublishedEvent {
   return {

--- a/src/adapters/discord/__tests__/worklog-manager-surface.test.ts
+++ b/src/adapters/discord/__tests__/worklog-manager-surface.test.ts
@@ -19,15 +19,15 @@
 
 import { describe, expect, test } from "bun:test";
 import type { Client, TextChannel, ThreadChannel } from "discord.js";
-import type { Envelope } from "../../bus/myelin/envelope-validator";
-import type { PublishedEvent } from "../../taps/cc-events/hooks/lib/event-types";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { PublishedEvent } from "../../../taps/cc-events/hooks/lib/event-types";
 import { WorklogManager } from "../worklog-manager";
 import {
   createDispatchTaskAbortedEvent,
   createDispatchTaskCompletedEvent,
   createDispatchTaskFailedEvent,
   createDispatchTaskStartedEvent,
-} from "../../bus/dispatch-events";
+} from "../../../bus/dispatch-events";
 
 // ---------------------------------------------------------------------------
 // Fake Discord client

--- a/src/adapters/discord/event-utils.ts
+++ b/src/adapters/discord/event-utils.ts
@@ -1,7 +1,10 @@
 /**
- * Runner-side event utilities for the `PublishedEvent` shape (CC hook events
- * lifted by the relay). Used by `dashboard-state` and `worklog-manager` to
- * detect project / extract GitHub references / surface activity entries.
+ * Event utilities for the `PublishedEvent` shape (CC hook events lifted by
+ * the relay), used by the discord adapter's `worklog-manager` /
+ * `worklog-formatter` to detect project / extract GitHub references /
+ * surface activity entries. Moved here from `src/runner/` (cortex#1787 — S2)
+ * alongside `worklog-manager.ts`, since it has no consumers outside the
+ * worklog family.
  *
  * Distinct from `src/common/event-utils.ts`, which serves the `IngestEvent`
  * shape used by the mc API + cc-events tap. The two files share function
@@ -13,13 +16,13 @@
  * really on. No consolidation is planned.
  *
  * If you find yourself wanting to call one from the other, you're probably
- * on the wrong side of the surface boundary — the runner shouldn't be
- * inspecting IngestEvents, and the mc/tap layer shouldn't be inspecting
- * PublishedEvents. Reach for the projection at the boundary instead.
+ * on the wrong side of the surface boundary — the mc/tap layer shouldn't be
+ * inspecting PublishedEvents. Reach for the projection at the boundary
+ * instead.
  */
 
-import type { PublishedEvent } from "../taps/cc-events/hooks/lib/event-types";
-import { formatDuration } from "../shared/format-utils";
+import type { PublishedEvent } from "../../taps/cc-events/hooks/lib/event-types";
+import { formatDuration } from "../../shared/format-utils";
 
 /**
  * Coerce an `unknown` payload field to string. Avoids the

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -1524,3 +1524,12 @@ export class DiscordAdapter implements PlatformAdapter {
     void wiring.runtime.publish(env);
   }
 }
+
+/**
+ * Public seam for the legacy JSONL→`#agent-log`/worklog outbound bridge
+ * (cortex#1787, S2). `cortex.ts` calls this instead of reaching through
+ * `DiscordAdapter.getClient()` / importing `formatEventForDiscord` /
+ * constructing `WorklogManager` directly — all of that now lives entirely
+ * inside this adapter's module tree.
+ */
+export { attachLegacyOutboundLog } from "./outbound-log";

--- a/src/adapters/discord/outbound-log.ts
+++ b/src/adapters/discord/outbound-log.ts
@@ -1,0 +1,125 @@
+/**
+ * Legacy outbound-log/worklog bridge — moved here from `cortex.ts`
+ * (cortex#1787, S2) so the discord.js-specific coupling
+ * (`DiscordAdapter.getClient()`, `WorklogManager`-with-`Client`,
+ * `formatEventForDiscord`) lives on the adapter's side of the boundary
+ * instead of leaking into the platform-neutral entrypoint. This is a
+ * RELOCATION, not a redesign — the JSONL polling and the events it
+ * produces are byte-for-byte the same as before the move. Migrating this
+ * off the JSONL-polling model onto the Renderer model is MIG-7.2d's job,
+ * still pending; see the docstring on `attachLegacyOutboundLog` below for
+ * the same "legacy direct-call path" framing the pre-move code carried.
+ */
+
+import { existsSync, readdirSync } from "fs";
+import { join } from "path";
+import type { TextChannel } from "discord.js";
+import type { AgentConfig } from "../../common/types/config";
+import type { SurfaceRouter } from "../../bus/surface-router";
+import type { SystemEventSource } from "../../bus/system-events";
+import { JsonlReader } from "../../taps/cc-events/lib/jsonl-reader";
+import { PublishedEventSchema } from "../../taps/cc-events/hooks/lib/event-types";
+import type { DiscordAdapter } from "./index";
+import { WorklogManager } from "./worklog-manager";
+import { formatEventForDiscord } from "./event-formatter";
+
+/**
+ * Subscribe a Discord adapter to the published-events JSONL stream so
+ * legacy `#agent-log` and per-task worklog threads keep working. Mirrors
+ * grove-bot's `setupOutboundLog`. The dispatch.task.* projection has
+ * migrated to `worklog-manager.surfaceConfig` (router-driven); this
+ * function runs the legacy direct-call path while MIG-7.2d Renderer
+ * cutover is pending.
+ */
+export function attachLegacyOutboundLog(
+  discordAdapter: DiscordAdapter,
+  instance: import("../../common/types/config").DiscordInstance,
+  config: AgentConfig,
+  router: SurfaceRouter,
+  systemEventSource: SystemEventSource,
+): (() => void) | null {
+  const eventsDir = config.paths.publishedEventsDir.replace(/^~/, process.env.HOME ?? "~");
+  const client = discordAdapter.getClient();
+  if (!client) {
+    console.log("cortex: discord client not available for outbound log");
+    return null;
+  }
+
+  let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+  // discord.js v15 prep — see comment in adapters/discord/client.ts.
+  client.on("clientReady", () => {
+    if (!existsSync(eventsDir)) {
+      console.log(`cortex: published events dir not found (${eventsDir}), skipping outbound`);
+      return;
+    }
+
+    const reader = new JsonlReader();
+    reader.skipAllToEnd(eventsDir);
+    const logChannelId = instance.logChannelId;
+    const guildId = instance.guildId;
+    const postedEventIds = new Set<string>();
+
+    let worklog: WorklogManager | null = null;
+    if (instance.worklogChannelId) {
+      worklog = new WorklogManager(client, instance.worklogChannelId);
+      console.log(`cortex: worklog enabled → channel ${instance.worklogChannelId}`);
+      // Register the worklog manager's `dispatch.task.*` surface so the
+      // bus-driven path projects into the same threads as the JSONL path.
+      router.register(
+        worklog.surfaceConfig({
+          principal: systemEventSource.principal,
+          adapterId: `worklog-${discordAdapter.instanceId}`,
+        }),
+      );
+    }
+
+    const processFile = async (path: string) => {
+      const events = reader.readNew(path);
+      if (events.length > 0) {
+        console.log(`cortex: processing ${events.length} event(s) from ${path.split("/").pop()}`);
+      }
+      for (const raw of events) {
+        try {
+          const event = PublishedEventSchema.parse(raw);
+          if (postedEventIds.has(event.event_id)) continue;
+          postedEventIds.add(event.event_id);
+          if (worklog) await worklog.handleEvent(event);
+          if (instance.enableAgentLog) {
+            const formatted = formatEventForDiscord(event);
+            if (!formatted) continue;
+            const guild = client.guilds.cache.get(guildId);
+            const channel =
+              (guild?.channels.cache.get(logChannelId) as TextChannel | null)
+              ?? ((await client.channels.fetch(logChannelId).catch(() => null)) as TextChannel | null);
+            if (channel && "send" in channel) {
+              await channel.send(formatted);
+            } else {
+              console.error(`cortex: could not resolve log channel ${logChannelId} — check bot permissions and channel ID`);
+            }
+          }
+        } catch (err) {
+          console.error("cortex: outbound error:", err instanceof Error ? err.message : err);
+        }
+      }
+    };
+
+    pollInterval = setInterval(() => {
+      try {
+        const files = readdirSync(eventsDir).filter((f: string) => f.endsWith(".jsonl"));
+        for (const file of files) void processFile(join(eventsDir, file));
+      } catch (err) {
+        console.error("cortex: poll error:", err instanceof Error ? err.message : String(err));
+      }
+    }, 2000);
+
+    console.log(`cortex: polling ${eventsDir} for outbound events (every 2s)`);
+  });
+
+  return () => {
+    if (pollInterval !== null) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    }
+  };
+}

--- a/src/adapters/discord/worklog-formatter.ts
+++ b/src/adapters/discord/worklog-formatter.ts
@@ -9,7 +9,7 @@
  * - Thread names are human-scannable at a glance
  */
 
-import type { PublishedEvent } from "../taps/cc-events/hooks/lib/event-types";
+import type { PublishedEvent } from "../../taps/cc-events/hooks/lib/event-types";
 import { formatDuration } from "./event-utils";
 
 /**

--- a/src/adapters/discord/worklog-manager.ts
+++ b/src/adapters/discord/worklog-manager.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Client, TextChannel, ThreadChannel } from "discord.js";
-import type { PublishedEvent } from "../taps/cc-events/hooks/lib/event-types";
+import type { PublishedEvent } from "../../taps/cc-events/hooks/lib/event-types";
 import {
   formatEventForThread,
   formatThreadName,
@@ -24,8 +24,8 @@ import { detectProject, extractGitHubIssue } from "./event-utils";
 function asString(v: unknown): string {
   return typeof v === "string" ? v : "";
 }
-import type { Envelope } from "../bus/myelin/envelope-validator";
-import type { SurfaceAdapter } from "../bus/surface-router";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { SurfaceAdapter } from "../../bus/surface-router";
 
 export class WorklogManager {
   private client: Client;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -18,11 +18,10 @@
 import "./bootstrap/ws-transport";
 
 import { Command } from "commander";
-import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, readdirSync } from "fs";
+import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync } from "fs";
 import { join, dirname, isAbsolute } from "path";
 import { homedir } from "os";
 import { parse as parseYaml } from "yaml";
-import type { TextChannel } from "discord.js";
 
 import {
   loadConfigWithAgents,
@@ -131,7 +130,7 @@ import {
   type Envelope,
 } from "./bus/myelin/envelope-validator";
 
-import { DiscordAdapter } from "./adapters/discord";
+import { attachLegacyOutboundLog } from "./adapters/discord";
 import { createRenderer, type Renderer } from "./renderers";
 import { RendererSchema, deriveStackId, DEFAULT_STREAM_MAX_BYTES } from "./common/types/cortex-config";
 import type {
@@ -303,7 +302,6 @@ import type {
 } from "./surface/mc/local-aggregation/sibling-db-reader";
 import type { SiblingStackDescriptor } from "./surface/mc/local-aggregation/sibling-discovery";
 import { createProbeResponder, type ProbeResponder } from "./bus/probe-responder";
-import { WorklogManager } from "./runner/worklog-manager";
 
 // #752 — the `network` + `provision-stack` subcommand dispatchers. Registered
 // as passthrough commander subcommands below so `cortex network join …` and
@@ -341,9 +339,6 @@ import type {
 } from "./common/registry";
 import { resolveBootFederatedPeers } from "./common/registry/resolve-federated-peers-boot";
 import type { NetworkRosterProvider } from "./common/registry/resolve-federated-peers";
-import { JsonlReader } from "./taps/cc-events/lib/jsonl-reader";
-import { PublishedEventSchema } from "./taps/cc-events/hooks/lib/event-types";
-import { formatEventForDiscord } from "./adapters/discord/event-formatter";
 import {
   startGithubWebhookReceiver,
   type GithubWebhookReceiverHandle,
@@ -3199,7 +3194,7 @@ export async function startCortex(
     trustResolver,
     inboundWithGateBridge,
     disableOutboundPoller: options.disableOutboundPoller ?? false,
-    setupOutboundLog,
+    setupOutboundLog: attachLegacyOutboundLog,
     adapters,
     adapterCleanup,
     liveSurfaces,
@@ -5999,104 +5994,6 @@ async function resolveReviewProvisioningJsm(
     );
     return null;
   }
-}
-
-/** Subscribe a Discord adapter to the published-events JSONL stream so legacy
- *  `#agent-log` and per-task worklog threads keep working. Mirrors grove-bot's
- *  `setupOutboundLog`. The dispatch.task.* projection has migrated to
- *  `worklog-manager.surfaceConfig` (router-driven); this function runs the
- *  legacy direct-call path while MIG-7.2d Renderer cutover is pending. */
-function setupOutboundLog(
-  discordAdapter: DiscordAdapter,
-  instance: import("./common/types/config").DiscordInstance,
-  config: AgentConfig,
-  router: SurfaceRouter,
-  systemEventSource: SystemEventSource,
-): (() => void) | null {
-  const eventsDir = config.paths.publishedEventsDir.replace(/^~/, process.env.HOME ?? "~");
-  const client = discordAdapter.getClient();
-  if (!client) {
-    console.log("cortex: discord client not available for outbound log");
-    return null;
-  }
-
-  let pollInterval: ReturnType<typeof setInterval> | null = null;
-
-  // discord.js v15 prep — see comment in adapters/discord/client.ts.
-  client.on("clientReady", () => {
-    if (!existsSync(eventsDir)) {
-      console.log(`cortex: published events dir not found (${eventsDir}), skipping outbound`);
-      return;
-    }
-
-    const reader = new JsonlReader();
-    reader.skipAllToEnd(eventsDir);
-    const logChannelId = instance.logChannelId;
-    const guildId = instance.guildId;
-    const postedEventIds = new Set<string>();
-
-    let worklog: WorklogManager | null = null;
-    if (instance.worklogChannelId) {
-      worklog = new WorklogManager(client, instance.worklogChannelId);
-      console.log(`cortex: worklog enabled → channel ${instance.worklogChannelId}`);
-      // Register the worklog manager's `dispatch.task.*` surface so the
-      // bus-driven path projects into the same threads as the JSONL path.
-      router.register(
-        worklog.surfaceConfig({
-          principal: systemEventSource.principal,
-          adapterId: `worklog-${discordAdapter.instanceId}`,
-        }),
-      );
-    }
-
-    const processFile = async (path: string) => {
-      const events = reader.readNew(path);
-      if (events.length > 0) {
-        console.log(`cortex: processing ${events.length} event(s) from ${path.split("/").pop()}`);
-      }
-      for (const raw of events) {
-        try {
-          const event = PublishedEventSchema.parse(raw);
-          if (postedEventIds.has(event.event_id)) continue;
-          postedEventIds.add(event.event_id);
-          if (worklog) await worklog.handleEvent(event);
-          if (instance.enableAgentLog) {
-            const formatted = formatEventForDiscord(event);
-            if (!formatted) continue;
-            const guild = client.guilds.cache.get(guildId);
-            const channel =
-              (guild?.channels.cache.get(logChannelId) as TextChannel | null)
-              ?? ((await client.channels.fetch(logChannelId).catch(() => null)) as TextChannel | null);
-            if (channel && "send" in channel) {
-              await channel.send(formatted);
-            } else {
-              console.error(`cortex: could not resolve log channel ${logChannelId} — check bot permissions and channel ID`);
-            }
-          }
-        } catch (err) {
-          console.error("cortex: outbound error:", err instanceof Error ? err.message : err);
-        }
-      }
-    };
-
-    pollInterval = setInterval(() => {
-      try {
-        const files = readdirSync(eventsDir).filter((f: string) => f.endsWith(".jsonl"));
-        for (const file of files) void processFile(join(eventsDir, file));
-      } catch (err) {
-        console.error("cortex: poll error:", err instanceof Error ? err.message : String(err));
-      }
-    }, 2000);
-
-    console.log(`cortex: polling ${eventsDir} for outbound events (every 2s)`);
-  });
-
-  return () => {
-    if (pollInterval !== null) {
-      clearInterval(pollInterval);
-      pollInterval = null;
-    }
-  };
 }
 
 // CLI

--- a/src/runner/surface-adapter-boot.ts
+++ b/src/runner/surface-adapter-boot.ts
@@ -501,11 +501,16 @@ export interface WireSurfaceAdaptersOpts {
   ) => (msg: InboundMessage) => Promise<void>;
   disableOutboundPoller: boolean;
   /**
-   * The legacy JSONL→`#agent-log`/worklog bridge (`cortex.ts`'s
-   * `setupOutboundLog`), threaded as a function reference rather than
-   * imported — it stays defined in `cortex.ts` to avoid a circular import
-   * (this module → cortex.ts → this module) for a Discord-only, otherwise
-   * unrelated legacy path.
+   * The legacy JSONL→`#agent-log`/worklog bridge. Cortex#1787 (S2) moved
+   * the implementation into `adapters/discord/outbound-log.ts` (exported
+   * as `attachLegacyOutboundLog` from the adapter's index) so the
+   * discord.js-specific coupling — `DiscordAdapter.getClient()`,
+   * `formatEventForDiscord`, `WorklogManager`-with-`Client` — lives on the
+   * adapter's side of the boundary instead of in `cortex.ts`. Still
+   * threaded through as a function reference (not imported directly here)
+   * to keep this Discord-only, otherwise-unrelated legacy path opt-in via
+   * `cortex.ts`'s wiring rather than a hard import from this shared boot
+   * module.
    */
   setupOutboundLog: (
     discordAdapter: DiscordAdapter,


### PR DESCRIPTION
Closes #1787. Part of epic #1784 (W1, S2).

Relocates the legacy JSONL outbound-log + worklog concern out of `cortex.ts` and behind a single adapter seam, so core no longer reaches into discord.js internals (`getClient()`, `formatEventForDiscord`). This is the load-bearing decoupling for the discord adapter extraction (S12).

**Moves**
- `setupOutboundLog` + helpers → `src/adapters/discord/outbound-log.ts`, exposed as `attachLegacyOutboundLog()` (re-exported via the discord index). `cortex.ts` (:3197) + `surface-adapter-boot.ts` call the seam.
- `worklog-manager.ts`, `worklog-formatter.ts`, `event-utils.ts` → `src/adapters/discord/`. The moved `event-utils` has exactly two importers (the two worklog files, which moved with it); it is distinct from the untouched `src/common/event-utils.ts` (IngestEvent path).

**Behaviour-preserving:** JSONL polling + router worklog-surface registration unchanged — no MIG-7.2d renderer redesign (out of scope).

**Provenance note:** built as a salvage-and-finish — the first implementer agent died mid-task (API error); its rebased WIP was preserved and completed. Verified from scratch against #1787's acceptance criteria.

**Gates:** `tsc --noEmit` 0 · `bun test src/adapters/discord src/runner src/bus` 2407 pass / 0 fail · `eslint --quiet` 0 · rebased on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)