### PR TITLE
fix(mc): loopback identity posture — revive local dashboard + structurally gate all mutating routes (#1859, #1640)

### DIFF
--- a/src/cli/cortex/commands/__tests__/config-validate.test.ts
+++ b/src/cli/cortex/commands/__tests__/config-validate.test.ts
@@ -102,6 +102,59 @@ describe("cortex config validate — valid config", () => {
   });
 });
 
+describe("cortex config validate — FND-6 governance drift (posture A, warning-level)", () => {
+  /** Cortex config that enables MC and points at a sibling MC yaml. */
+  function configWithMc(mcConfigPath: string): Record<string, unknown> {
+    const cfg = validConfig();
+    cfg.claude = {};
+    cfg.mc = { enabled: true, configPath: mcConfigPath };
+    return cfg;
+  }
+
+  function writeMcYaml(body: string): string {
+    const path = join(testDir, "mission-control.yaml");
+    writeFileSync(path, body);
+    return path;
+  }
+
+  test("surfaces a WARNING (exit 0) when the MC yaml sets principals without a listed local_principal", async () => {
+    const mcPath = writeMcYaml("governance:\n  principals:\n    - andreas@x.io\n");
+    const path = writeConfig(configWithMc(mcPath));
+    const result = await dispatchConfig(["validate", "--config", path]);
+
+    // The cortex config is VALID → exit 0, ✓ line still printed …
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("✓ config valid:");
+    // … but the governance footgun is surfaced pre-write on stderr.
+    expect(result.stderr).toContain("mc.governance");
+    expect(result.stderr).toContain("local_principal is unset");
+    expect(result.stderr).toContain("403");
+  });
+
+  test("--json carries the warning under a warnings[] key (still ok:true)", async () => {
+    const mcPath = writeMcYaml("governance:\n  principals:\n    - andreas@x.io\n");
+    const path = writeConfig(configWithMc(mcPath));
+    const result = await dispatchConfig(["validate", "--config", path, "--json"]);
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout) as { ok: boolean; warnings?: string[] };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.warnings?.length).toBe(1);
+    expect(parsed.warnings?.[0]).toContain("mc.governance");
+  });
+
+  test("NO warning (clean stderr) when local_principal is a listed principal", async () => {
+    const mcPath = writeMcYaml(
+      "governance:\n  principals:\n    - andreas@x.io\n  local_principal: andreas@x.io\n",
+    );
+    const path = writeConfig(configWithMc(mcPath));
+    const result = await dispatchConfig(["validate", "--config", path]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+});
+
 describe("cortex config validate — invalid config", () => {
   /**
    * Take the valid config and add an OUT-OF-SCOPE second accept_subject at

--- a/src/cli/cortex/commands/config.ts
+++ b/src/cli/cortex/commands/config.ts
@@ -47,6 +47,7 @@
 
 import { loadConfigWithAgents, expandTilde } from "../../../common/config/loader";
 import { formatConfigLoadError } from "../../../common/config/validate-on-write";
+import { loadConfig as loadMcConfig } from "../../../surface/mc/config";
 import { DEFAULT_CONFIG } from "../../../common/pidfile";
 
 import { CliArgsError } from "./_shared/arg-error";
@@ -124,14 +125,43 @@ function runValidate(flags: FlagMap, json: boolean): ExitResult {
     const networks = loaded.policy?.federated?.networks.length ?? 0;
     const summary: ValidateSummary = { path: resolvedPath, stacks, networks };
 
+    // FND-6 posture A — surface the mc.governance local_principal drift pre-write
+    // (the misconfig that silently 403s the headerless local dashboard). The
+    // governance block lives in the Mission Control yaml (`mc.configPath`), NOT
+    // the cortex schema, so we load that file and reuse the SAME pure detector
+    // the daemon runs at boot. Only when `mc.configPath` is explicitly set — an
+    // empty path resolves to the daemon's default MC yaml, which we must not read
+    // for an unrelated `validate` (it would make the finding environment-
+    // dependent). Warning-level: it never flips exit code (the cortex config is
+    // valid); it is a heads-up, not a rejection.
+    const warnings: string[] = [];
+    const mcConfigPath = loaded.config.mc.configPath.trim();
+    if (loaded.config.mc.enabled && mcConfigPath !== "") {
+      try {
+        loadMcConfig(expandTilde(mcConfigPath), {
+          onWarning: (m) => warnings.push(m),
+        });
+      } catch (err) {
+        // The MC yaml itself is malformed/unreadable — surfaced at daemon boot
+        // (MC loadConfig throws there too); `cortex config validate`'s contract
+        // is the cortex config, so we note it without failing validation.
+        warnings.push(
+          `NOTE mc: could not read the Mission Control config at ${mcConfigPath} to check governance ` +
+            `(${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
+    }
+    const warnStderr = warnings.length > 0 ? warnings.map((w) => `${w}\n`).join("") : "";
+
     if (json) {
       const payload = {
         ok: true,
         path: summary.path,
         stacks: summary.stacks,
         networks: summary.networks,
+        ...(warnings.length > 0 ? { warnings } : {}),
       };
-      return { exitCode: 0, stdout: JSON.stringify(payload) + "\n", stderr: "" };
+      return { exitCode: 0, stdout: JSON.stringify(payload) + "\n", stderr: warnStderr };
     }
 
     const stackWord = stacks === 1 ? "stack" : "stacks";
@@ -141,7 +171,7 @@ function runValidate(flags: FlagMap, json: boolean): ExitResult {
       stdout:
         `✓ config valid: ${summary.path}\n` +
         `  ${stacks} ${stackWord}, ${networks} ${networkWord}\n`,
-      stderr: "",
+      stderr: warnStderr,
     };
   } catch (err) {
     const errors = formatConfigLoadError(err);

--- a/src/surface/mc/__tests__/config.test.ts
+++ b/src/surface/mc/__tests__/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { loadConfig, DEFAULT_CONFIG } from "../config";
+import { loadConfig, detectLocalPrincipalDrift, DEFAULT_CONFIG } from "../config";
+import { DEFAULT_LOCAL_PRINCIPAL } from "../api/networks-admission";
 import { mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -103,5 +104,109 @@ describe("mission-control config", () => {
     expect(config.ws.maxClients).toBe(50);
     expect(config.ws.idleTimeoutSec).toBe(30);
     expect(config.ws.maxPayloadLength).toBe(DEFAULT_CONFIG.ws.maxPayloadLength);
+  });
+
+  // ── FND-6 posture A — governance.local_principal parsing + drift warning ──
+
+  it("parses governance.local_principal from YAML", () => {
+    const configPath = join(tmpDir, "mc.yaml");
+    writeFileSync(
+      configPath,
+      "governance:\n  principals:\n    - andreas@x.io\n  local_principal: andreas@x.io\n",
+    );
+    const config = loadConfig(configPath, { onWarning: () => {} });
+    expect(config.governance?.localPrincipal).toBe("andreas@x.io");
+    expect(config.governance?.principals).toEqual(["andreas@x.io"]);
+  });
+
+  it("throws when governance.local_principal is an empty string", () => {
+    const configPath = join(tmpDir, "mc.yaml");
+    writeFileSync(configPath, "governance:\n  principals: []\n  local_principal: ''\n");
+    expect(() => loadConfig(configPath)).toThrow(/local_principal must be a non-empty string/);
+  });
+
+  it("throws when governance.local_principal is whitespace-only", () => {
+    const configPath = join(tmpDir, "mc.yaml");
+    writeFileSync(configPath, "governance:\n  principals: []\n  local_principal: '   '\n");
+    expect(() => loadConfig(configPath)).toThrow(/local_principal must be a non-empty string/);
+  });
+
+  it("throws when governance.local_principal is a number", () => {
+    const configPath = join(tmpDir, "mc.yaml");
+    writeFileSync(configPath, "governance:\n  principals: []\n  local_principal: 42\n");
+    expect(() => loadConfig(configPath)).toThrow(/local_principal must be a non-empty string/);
+  });
+
+  it("throws when governance.local_principal is an array", () => {
+    const configPath = join(tmpDir, "mc.yaml");
+    writeFileSync(configPath, "governance:\n  principals: []\n  local_principal:\n    - a@b.io\n");
+    expect(() => loadConfig(configPath)).toThrow(/local_principal must be a non-empty string/);
+  });
+
+  it("WARNS (via onWarning) when principals is set but local_principal is unset", () => {
+    const configPath = join(tmpDir, "mc.yaml");
+    writeFileSync(configPath, "governance:\n  principals:\n    - andreas@x.io\n");
+    const warnings: string[] = [];
+    loadConfig(configPath, { onWarning: (m) => warnings.push(m) });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("mc.governance");
+    expect(warnings[0]).toContain("local_principal is unset");
+    expect(warnings[0]).toContain("403");
+  });
+
+  it("does NOT warn when principals is set and local_principal is a listed value", () => {
+    const configPath = join(tmpDir, "mc.yaml");
+    writeFileSync(
+      configPath,
+      "governance:\n  principals:\n    - andreas@x.io\n  local_principal: andreas@x.io\n",
+    );
+    const warnings: string[] = [];
+    loadConfig(configPath, { onWarning: (m) => warnings.push(m) });
+    expect(warnings).toHaveLength(0);
+  });
+});
+
+describe("detectLocalPrincipalDrift (FND-6 posture A, pure)", () => {
+  it("returns null when governance is undefined", () => {
+    expect(detectLocalPrincipalDrift(undefined)).toBeNull();
+  });
+
+  it("returns null when principals is empty (permissive-on-loopback path)", () => {
+    expect(detectLocalPrincipalDrift({ principals: [] })).toBeNull();
+    expect(detectLocalPrincipalDrift({ principals: [], localPrincipal: "x@y.io" })).toBeNull();
+  });
+
+  it("warns when principals set + local_principal unset (would 403 the sentinel)", () => {
+    const msg = detectLocalPrincipalDrift({ principals: ["andreas@x.io"] });
+    expect(msg).toContain("unset");
+    expect(msg).toContain("403");
+    // The sentinel the headerless caller would resolve to is not in the allowlist.
+    expect(DEFAULT_LOCAL_PRINCIPAL).not.toBe("andreas@x.io");
+  });
+
+  it("warns when local_principal is set but NOT in principals", () => {
+    const msg = detectLocalPrincipalDrift({
+      principals: ["andreas@x.io"],
+      localPrincipal: "someone@else.io",
+    });
+    expect(msg).toContain("not one of the listed principals");
+  });
+
+  it("is case-insensitive when matching local_principal against principals", () => {
+    expect(
+      detectLocalPrincipalDrift({
+        principals: ["Andreas@X.io"],
+        localPrincipal: "andreas@x.io",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when local_principal IS a listed principal", () => {
+    expect(
+      detectLocalPrincipalDrift({
+        principals: ["a@b.io", "andreas@x.io"],
+        localPrincipal: "andreas@x.io",
+      }),
+    ).toBeNull();
   });
 });

--- a/src/surface/mc/__tests__/mutation-guard-rebinding.test.ts
+++ b/src/surface/mc/__tests__/mutation-guard-rebinding.test.ts
@@ -45,14 +45,21 @@ interface Ctx {
   tmpDir: string;
 }
 
-function start(governance?: string[]): Ctx {
+function start(principals?: string[], localPrincipal?: string): Ctx {
   const tmpDir = join(tmpdir(), `mc-fnd6-${Date.now()}-${Math.random()}`);
   const db = initDatabase(join(tmpDir, "test.db"));
   const pm = new ProcessManager();
   const config: Config = {
     ...DEFAULT_CONFIG,
     port: 0, // ephemeral — bound port read back from ctx.server.port
-    ...(governance ? { governance: { principals: governance } } : {}),
+    ...(principals || localPrincipal
+      ? {
+          governance: {
+            principals: principals ?? [],
+            ...(localPrincipal ? { localPrincipal } : {}),
+          },
+        }
+      : {}),
   };
   const ctx = startServer(config, db, { processManager: pm, spawn: fakeCatSpawn });
   const port = ctx.server.port;
@@ -187,39 +194,108 @@ describe("FND-6 — foreign-Origin rejection", () => {
   });
 });
 
-describe("FND-6 — identity gate on the session-control routes", () => {
+describe("FND-6 posture A — legitimate loopback dashboard requests succeed (headerless, same-origin)", () => {
+  // The regression FND-6 shipped: the dashboard calls the daemon over loopback
+  // with a same-origin Origin, the correct Host, and NO CF-Access header (there
+  // is no CF Access in front of a bare loopback daemon). On main every mutating
+  // route 401s. Posture A resolves the headerless loopback caller to the local
+  // principal so these succeed — the Host+Origin allowlist is the real boundary.
   let c: Ctx;
   afterEach(() => teardown(c));
 
-  it("REJECTS unauthenticated POST /api/sessions — 401 (no unauthenticated mutation tier)", async () => {
+  it("ALLOWS a headerless, same-origin POST /api/sessions on loopback — 201 (was 401 on main)", async () => {
     c = start();
-    // fetch → Host is the valid loopback authority; NO CF-Access identity header.
     const res = await fetch(`${c.baseUrl}/api/sessions`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", origin: c.baseUrl },
       body: SESSION_BODY,
     });
-    expect(res.status).toBe(401);
-    expect((await res.json()).error).toBe("unauthenticated");
-    expect(c.pm.size).toBe(0);
+    expect(res.status).toBe(201); // NOT 401 — the regression is fixed.
   });
 
-  it("ALLOWS an authenticated POST /api/sessions on loopback (unset allowlist) — 201", async () => {
+  it("ALLOWS a headerless attention resolve on loopback — 200 (auth-pass, not 401)", async () => {
+    c = start();
+    upsertAttentionItem(c.db, {
+      id: "dash-att",
+      stackId: "s",
+      workItemId: null,
+      sessionId: null,
+      kind: "review",
+      severity: "normal",
+      status: "open",
+    });
+    const res = await fetch(`${c.baseUrl}/api/attention/dash-att/resolve`, {
+      method: "POST",
+      headers: { origin: c.baseUrl },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("does NOT 401 a headerless requeue/abandon on loopback (auth-pass; handler-level status only)", async () => {
+    c = start();
+    for (const route of ["requeue", "abandon"] as const) {
+      const res = await fetch(
+        `${c.baseUrl}/api/assignments/nonexistent/${route}`,
+        { method: "POST", headers: { "content-type": "application/json", origin: c.baseUrl }, body: "{}" },
+      );
+      // Auth passed → the handler runs; it may 4xx on the unknown assignment,
+      // but it must NOT be the 401 the pre-posture-A gate produced.
+      expect(res.status).not.toBe(401);
+    }
+  });
+
+  it("uses the header for audit attribution when present (still 201)", async () => {
     c = start();
     const res = await fetch(`${c.baseUrl}/api/sessions`, {
       method: "POST",
-      headers: { "content-type": "application/json", ...AUTH_HEADER },
+      headers: { "content-type": "application/json", origin: c.baseUrl, ...AUTH_HEADER },
       body: SESSION_BODY,
     });
     expect(res.status).toBe(201);
   });
+});
 
-  it("REJECTS unauthenticated POST /api/assignments/:id/requeue — 401", async () => {
-    c = start();
-    const res = await fetch(`${c.baseUrl}/api/assignments/does-not-matter/requeue`, {
+describe("FND-6 — the tasks/iterations family is now identity-gated (cortex#1640, invariant 3)", () => {
+  // These reach their handlers on main (400/404, not 401) — unauthenticated.
+  // `POST /api/tasks` enqueues work the runner spawns as a principal-credentialed
+  // CC session; `/api/iterations/from-github` shells out to `gh`. Posture A keeps
+  // the headerless local dashboard working (unset allowlist ⇒ permissive on
+  // loopback), while the authorization binding below proves the gate is real.
+  let c: Ctx;
+  afterEach(() => teardown(c));
+
+  it("403s a headerless POST /api/tasks when the local-principal fallback is unlisted", async () => {
+    // Allowlist set + local_principal deliberately NOT in it → the headerless
+    // fallback identity is refused. This is the gate the family lacked entirely.
+    c = start(["allowed@principal.test"], "unlisted@local.box");
+    const res = await fetch(`${c.baseUrl}/api/tasks`, {
       method: "POST",
+      headers: { "content-type": "application/json", origin: c.baseUrl },
+      body: JSON.stringify({ source: "x" }),
     });
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("not_authorized");
+  });
+
+  it("403s a headerless POST /api/iterations/from-github when the fallback is unlisted", async () => {
+    c = start(["allowed@principal.test"], "unlisted@local.box");
+    const res = await fetch(`${c.baseUrl}/api/iterations/from-github`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: c.baseUrl },
+      body: JSON.stringify({ url: "https://github.com/x/y/issues/1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("REJECTS a foreign Host on POST /api/tasks — 403 (rebind guard still applies)", async () => {
+    c = start();
+    const status = await rawHttp(c.port, {
+      path: "/api/tasks",
+      host: "evil.attacker.example",
+      email: PRINCIPAL,
+      body: JSON.stringify({ source: "x" }),
+    });
+    expect(status).toBe(403);
   });
 });
 
@@ -266,13 +342,13 @@ describe("FND-6 — CK-6a attention lifecycle rides the same gate", () => {
     });
   }
 
-  it("REJECTS unauthenticated resolve — 401", async () => {
+  it("resolves the headerless loopback caller to the local principal — 200 (posture A), not 401", async () => {
     c = start();
     seedAttention(c.db, "att-1");
     const res = await fetch(`${c.baseUrl}/api/attention/att-1/resolve`, {
       method: "POST",
     });
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
   });
 
   it("ALLOWS an authenticated resolve — 200 and flips db status", async () => {

--- a/src/surface/mc/__tests__/mutation-guard-rebinding.test.ts
+++ b/src/surface/mc/__tests__/mutation-guard-rebinding.test.ts
@@ -231,9 +231,11 @@ describe("FND-6 posture A — legitimate loopback dashboard requests succeed (he
     expect(res.status).toBe(200);
   });
 
-  it("does NOT 401 a headerless requeue/abandon on loopback (auth-pass; handler-level status only)", async () => {
+  it("does NOT 401 a headerless requeue/abandon/input on loopback (auth-pass; handler-level status only)", async () => {
     c = start();
-    for (const route of ["requeue", "abandon"] as const) {
+    // Send-input (`/input`) is a dashboard control too — cover it here so the
+    // "every mutating control" claim is real (finding #2).
+    for (const route of ["requeue", "abandon", "input"] as const) {
       const res = await fetch(
         `${c.baseUrl}/api/assignments/nonexistent/${route}`,
         { method: "POST", headers: { "content-type": "application/json", origin: c.baseUrl }, body: "{}" },
@@ -242,6 +244,24 @@ describe("FND-6 posture A — legitimate loopback dashboard requests succeed (he
       // but it must NOT be the 401 the pre-posture-A gate produced.
       expect(res.status).not.toBe(401);
     }
+  });
+
+  it("ALLOWS a headerless attention DISMISS on loopback — 200 (auth-pass, not 401)", async () => {
+    c = start();
+    upsertAttentionItem(c.db, {
+      id: "dash-att-dismiss",
+      stackId: "s",
+      workItemId: null,
+      sessionId: null,
+      kind: "review",
+      severity: "normal",
+      status: "open",
+    });
+    const res = await fetch(`${c.baseUrl}/api/attention/dash-att-dismiss/dismiss`, {
+      method: "POST",
+      headers: { origin: c.baseUrl },
+    });
+    expect(res.status).toBe(200);
   });
 
   it("uses the header for audit attribution when present (still 201)", async () => {

--- a/src/surface/mc/__tests__/networks-admission-http.test.ts
+++ b/src/surface/mc/__tests__/networks-admission-http.test.ts
@@ -27,6 +27,7 @@ import { rmSync } from "fs";
 import { startServer, type ServerContext } from "../server";
 import { initDatabase } from "../db/init";
 import { DEFAULT_CONFIG } from "../config";
+import { DEFAULT_LOCAL_PRINCIPAL } from "../api/networks-admission";
 import type {
   AdmissionDecider,
   AdmissionDecisionInput,
@@ -92,7 +93,13 @@ describe("POST /api/networks/admission-decision — loopback invariant", () => {
     expect(DEFAULT_CONFIG.hostname).toBe("127.0.0.1");
   });
 
-  it("enforces Gate 1 (401 without the CF-Access header) on the loopback bind", async () => {
+  it("resolves to the local principal (FND-6 posture A) when the CF-Access header is absent on loopback — reaches the signer, no 401", async () => {
+    // Posture A: on loopback the CF-Access email header is audit metadata, not
+    // authentication (a local process can forge it; Host+Origin is the
+    // boundary). A headerless request therefore resolves to the default local
+    // principal and reaches the signer rather than 401ing — this is what keeps
+    // the headerless local dashboard working. Authorization is still enforced
+    // (principals unset here → permissive on loopback).
     c = startWithDecider();
     const res = await fetch(`${c.baseUrl}/api/networks/admission-decision`, {
       method: "POST",
@@ -104,9 +111,9 @@ describe("POST /api/networks/admission-decision — loopback invariant", () => {
         confirm: "req-abc-123",
       }),
     });
-    expect(res.status).toBe(401);
-    // The signer must NOT run when the identity header is absent.
-    expect(c.calls).toHaveLength(0);
+    expect(res.status).toBe(200);
+    expect(c.calls).toHaveLength(1);
+    expect(c.calls[0]?.principal).toBe(DEFAULT_LOCAL_PRINCIPAL);
   });
 
   it("reaches the wired signer over loopback when the CF-Access header is present", async () => {

--- a/src/surface/mc/api/__tests__/mutation-guard.test.ts
+++ b/src/surface/mc/api/__tests__/mutation-guard.test.ts
@@ -159,12 +159,27 @@ describe("isIdentityGatedMutation", () => {
     expect(isIdentityGatedMutation("POST", "/api/attention/xyz/resolve")).toBe(true);
     expect(isIdentityGatedMutation("POST", "/api/attention/xyz/dismiss")).toBe(true);
   });
-  it("does NOT gate reads or non-governed routes", () => {
+  it("also gates the previously-unauthenticated tasks/iterations family (cortex#1640, invariant 3)", () => {
+    // These spawn principal-credentialed CC sessions / shell out to `gh` with
+    // the principal's creds, yet were rebind-guarded but NOT identity-gated.
+    expect(isIdentityGatedMutation("POST", "/api/tasks")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/tasks/t1/abandon")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/tasks/preview")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/iterations")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/iterations/from-github")).toBe(true);
+    expect(isIdentityGatedMutation("PATCH", "/api/iterations/i1")).toBe(true);
+    expect(isIdentityGatedMutation("POST", "/api/iterations/i1/tasks")).toBe(true);
+    expect(isIdentityGatedMutation("DELETE", "/api/iterations/i1/tasks/t1")).toBe(true);
+  });
+  it("does NOT gate reads, or the HMAC-authed M2M webhook (no CF principal)", () => {
     expect(isIdentityGatedMutation("GET", "/api/sessions")).toBe(false);
     expect(isIdentityGatedMutation("GET", "/api/assignments/abc/requeue")).toBe(false);
-    expect(isIdentityGatedMutation("POST", "/api/tasks")).toBe(false);
-    expect(isIdentityGatedMutation("POST", "/api/github/webhook")).toBe(false);
+    expect(isIdentityGatedMutation("GET", "/api/tasks")).toBe(false);
     expect(isIdentityGatedMutation("GET", "/api/attention")).toBe(false);
+    // The webhook is the ONE mutating route left un-identity-gated — it
+    // authenticates by HMAC, which a browser cannot forge, and carries no
+    // CF-Access principal.
+    expect(isIdentityGatedMutation("POST", "/api/github/webhook")).toBe(false);
   });
 });
 

--- a/src/surface/mc/api/__tests__/networks-admission.test.ts
+++ b/src/surface/mc/api/__tests__/networks-admission.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeAll, beforeEach } from "bun:test";
 import {
   handleAdmissionDecision,
+  DEFAULT_LOCAL_PRINCIPAL,
   type AdmissionDecider,
   type AdmissionDecisionInput,
   type AdmissionDecisionResult,
@@ -58,9 +59,21 @@ const OK_BODY = {
   confirm: "req-abc-123",
 };
 
-/** Loopback auth context (current behavior): trusts the email header. */
-function loopbackAuth(email: string | undefined): AdmissionAuthContext {
-  return { isLoopback: true, emailHeader: email, jwtAssertion: undefined };
+/**
+ * Loopback auth context. The email header is audit metadata on loopback (FND-6
+ * posture A); when absent the request resolves to `localPrincipal` (or the
+ * built-in `DEFAULT_LOCAL_PRINCIPAL` sentinel), never 401.
+ */
+function loopbackAuth(
+  email: string | undefined,
+  localPrincipal?: string,
+): AdmissionAuthContext {
+  return {
+    isLoopback: true,
+    emailHeader: email,
+    jwtAssertion: undefined,
+    ...(localPrincipal ? { localPrincipal } : {}),
+  };
 }
 
 /**
@@ -152,21 +165,28 @@ beforeEach(() => {
   resetCfAccessJwksCache();
 });
 
-describe("handleAdmissionDecision — gate 1 (loopback): CF-Access email header", () => {
-  it("401 when the principal identity is absent", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth(undefined), OK_BODY);
-    expect(res.status).toBe(401);
-    expect((await body(res)).error).toBe("unauthenticated");
-  });
-
-  it("401 when the principal identity is blank/whitespace", async () => {
-    const res = await handleAdmissionDecision(throwingDecider, loopbackAuth("   "), OK_BODY);
-    expect(res.status).toBe(401);
-  });
-
-  it("trusts the email header on loopback (no JWT needed) — reaches the decider", async () => {
+describe("handleAdmissionDecision — gate 1 (loopback): audit-metadata email + local-principal fallback (FND-6 posture A)", () => {
+  it("falls back to the configured local principal when the header is absent — reaches the decider (no 401)", async () => {
     const { decider: d, calls } = recordingDecider();
-    const res = await handleAdmissionDecision(d, loopbackAuth("op@x.io"), OK_BODY);
+    const res = await handleAdmissionDecision(
+      d,
+      loopbackAuth(undefined, "local@dev.box"),
+      OK_BODY,
+    );
+    expect(res.status).toBe(200);
+    expect(calls[0]?.principal).toBe("local@dev.box");
+  });
+
+  it("falls back to the DEFAULT_LOCAL_PRINCIPAL sentinel when neither header nor local_principal is set", async () => {
+    const { decider: d, calls } = recordingDecider();
+    const res = await handleAdmissionDecision(d, loopbackAuth("   "), OK_BODY);
+    expect(res.status).toBe(200);
+    expect(calls[0]?.principal).toBe(DEFAULT_LOCAL_PRINCIPAL);
+  });
+
+  it("uses the email header when present (audit attribution), ignoring the local-principal fallback", async () => {
+    const { decider: d, calls } = recordingDecider();
+    const res = await handleAdmissionDecision(d, loopbackAuth("op@x.io", "local@dev.box"), OK_BODY);
     expect(res.status).toBe(200);
     expect(calls[0]?.principal).toBe("op@x.io");
   });

--- a/src/surface/mc/api/mutation-guard.ts
+++ b/src/surface/mc/api/mutation-guard.ts
@@ -87,6 +87,13 @@ export interface MutationGuardContext {
    * EMPTY = unset (fail-closed off loopback; permissive on loopback).
    */
   principals: ReadonlySet<string>;
+  /**
+   * FND-6 posture A — `mc.governance.local_principal`: the identity a headerless
+   * loopback mutation resolves to (the CF-Access email header is self-asserted
+   * on loopback → audit metadata). Undefined ⇒ the resolver's built-in
+   * `DEFAULT_LOCAL_PRINCIPAL` sentinel. Only consulted on a loopback bind.
+   */
+  localPrincipal?: string;
   /** CF-Access JWT verifier, present iff `cfAccess.aud` is configured. */
   verifyJwt?: AdmissionAuthContext["verifyJwt"];
 }
@@ -277,6 +284,7 @@ export async function enforceMutationAuth(
     isLoopback: ctx.isLoopback,
     emailHeader: req.headers.get(CF_ACCESS_EMAIL_HEADER) ?? undefined,
     jwtAssertion: req.headers.get(CF_ACCESS_JWT_HEADER) ?? undefined,
+    ...(ctx.localPrincipal ? { localPrincipal: ctx.localPrincipal } : {}),
     ...(ctx.verifyJwt ? { verifyJwt: ctx.verifyJwt } : {}),
   };
   const who = await resolveRequestPrincipal(auth);
@@ -290,24 +298,27 @@ export async function enforceMutationAuth(
 
 /**
  * Which mutating routes carry the full identity+authorization gate (c)+(d).
- * The governed glass-mutation set: local session spawn/control (strictly higher
- * blast than dispatch-to-peer — must not be the least-gated route), the Tier-2
- * federation admission decision, and the attention lifecycle (CK-6a).
+ *
+ * Invariant 3 (docs/plan-mc-future-state.md §6): "there is no unauthenticated
+ * mutation tier." So EVERY mutating route is identity-gated — except the
+ * HMAC-authed M2M webhook ({@link isRebindExempt}), which authenticates by a
+ * signature no browser can forge and carries no CF-Access principal.
+ *
+ * This is deliberately a single predicate (all mutating non-exempt routes)
+ * rather than a hand-maintained allowlist: the allowlist is exactly how the
+ * `tasks`/`iterations` family (`POST /api/tasks` spawns a principal-credentialed
+ * CC session; `/api/iterations/from-github` shells out to `gh` with the
+ * principal's creds) slipped through rebind-guarded-but-not-identity-gated
+ * (cortex#1640). A new mutating route is gated by default, never by remembering
+ * to add it here. Posture A makes this safe on loopback — a headerless local
+ * caller resolves to `mc.governance.local_principal` rather than 401.
  */
 export function isIdentityGatedMutation(
   method: string,
   pathname: string,
 ): boolean {
   if (!MUTATING_METHODS.has(method)) return false;
-  if (pathname === "/api/sessions") return true;
-  if (pathname === "/api/networks/admission-decision") return true;
-  if (/^\/api\/assignments\/[^/]+\/(requeue|abandon|handoff|input)$/.test(pathname)) {
-    return true;
-  }
-  if (/^\/api\/attention\/[^/]+\/(resolve|dismiss)$/.test(pathname)) {
-    return true;
-  }
-  return false;
+  return !isRebindExempt(pathname);
 }
 
 /**

--- a/src/surface/mc/api/networks-admission.ts
+++ b/src/surface/mc/api/networks-admission.ts
@@ -87,6 +87,17 @@ export const CF_ACCESS_EMAIL_HEADER = "Cf-Access-Authenticated-User-Email";
 /** The signed `Cf-Access-Jwt-Assertion` header (the JWT CF Access injects at the edge). */
 export const CF_ACCESS_JWT_HEADER = "Cf-Access-Jwt-Assertion";
 
+/**
+ * FND-6 posture A — the identity a headerless loopback mutation is attributed
+ * to when `mc.governance.local_principal` is unset. On a loopback bind the
+ * CF-Access email header is self-asserted (audit metadata, not authentication —
+ * Host+Origin is the boundary), so its ABSENCE is not an auth failure; the
+ * request resolves to this sentinel and is still enforced against
+ * `mc.governance.principals`. A principal exposing MC off loopback never reaches
+ * this path (a verified JWT is mandatory there).
+ */
+export const DEFAULT_LOCAL_PRINCIPAL = "local-principal@loopback";
+
 /** Hostnames that denote a loopback bind. Single source of "is this loopback". */
 const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(["127.0.0.1", "::1", "localhost"]);
 
@@ -111,8 +122,20 @@ export function isLoopbackBind(hostname: string): boolean {
 export interface AdmissionAuthContext {
   /** True when MC is bound to a loopback interface. */
   isLoopback: boolean;
-  /** Raw `Cf-Access-Authenticated-User-Email` — trusted ONLY on a loopback bind. */
+  /**
+   * Raw `Cf-Access-Authenticated-User-Email`. On a loopback bind this is
+   * self-asserted AUDIT METADATA — used when present, but its absence is not an
+   * auth failure (see `localPrincipal`). Off loopback it is ignored entirely (a
+   * verified JWT is the only accepted identity).
+   */
   emailHeader: string | undefined;
+  /**
+   * FND-6 posture A — the loopback fallback identity when `emailHeader` is
+   * absent (`mc.governance.local_principal`; defaults to
+   * `DEFAULT_LOCAL_PRINCIPAL`). Only consulted on a loopback bind. The resolved
+   * identity is still enforced against `mc.governance.principals`.
+   */
+  localPrincipal?: string;
   /** Raw `Cf-Access-Jwt-Assertion` — verified on a non-loopback bind. */
   jwtAssertion: string | undefined;
   /**
@@ -217,9 +240,15 @@ function parseBody(
 /**
  * Resolve the CF-Access principal for Gate 1 — bind-conditioned (#1410):
  *
- *  - **Loopback bind:** trust the `Cf-Access-Authenticated-User-Email` header
- *    as-is (unchanged pre-#1410 behavior; the loopback boundary is the gate,
- *    locked by the #1279 http test). Empty ⇒ 401.
+ *  - **Loopback bind (FND-6 posture A):** the `Cf-Access-Authenticated-User-Email`
+ *    header is self-asserted here (any local process can set an arbitrary value),
+ *    so it is AUDIT METADATA, not authentication — Host+Origin (enforced in
+ *    `mutation-guard.ts`) is the real loopback boundary. Used as the identity
+ *    when present; when ABSENT the request resolves to `auth.localPrincipal`
+ *    (`mc.governance.local_principal`, default {@link DEFAULT_LOCAL_PRINCIPAL})
+ *    rather than 401 — so the headerless local dashboard is not refused. Either
+ *    way the resolved identity is still enforced against `mc.governance.principals`
+ *    downstream (`checkAuthorization`).
  *  - **Non-loopback bind:** the raw email header is forgeable, so REQUIRE a
  *    CF-Access JWT verified against the team JWKS; the principal comes from the
  *    verified `email` claim. Fails closed on every branch:
@@ -241,19 +270,14 @@ export async function resolveRequestPrincipal(
   auth: AdmissionAuthContext,
 ): Promise<string | Response> {
   if (auth.isLoopback) {
-    const who = (auth.emailHeader ?? "").trim();
-    if (who.length === 0) {
-      return json(
-        {
-          error: "unauthenticated",
-          detail:
-            "a CF-Access authenticated principal identity is required for this mutation " +
-            `(missing/empty ${CF_ACCESS_EMAIL_HEADER}). This control-plane mutation is not available on an unauthenticated request.`,
-        },
-        401,
-      );
-    }
-    return who;
+    // Header present → attribute to it (audit metadata). Absent → fall back to
+    // the configured local principal (posture A); NEVER 401 on loopback for a
+    // missing header — Host+Origin is the boundary, and the resolved identity is
+    // still authorization-checked against `mc.governance.principals`.
+    const header = (auth.emailHeader ?? "").trim();
+    if (header.length > 0) return header;
+    const fallback = (auth.localPrincipal ?? "").trim();
+    return fallback.length > 0 ? fallback : DEFAULT_LOCAL_PRINCIPAL;
   }
 
   // Non-loopback: do NOT trust the raw email header — verify the JWT.

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -145,6 +145,20 @@ export function loadConfig(configPath?: string): Readonly<Config> {
       }
       principals.push(entry.trim());
     }
+    // FND-6 posture A — optional `local_principal`: the identity a headerless
+    // loopback mutation is attributed to (the CF-Access email header is
+    // self-asserted on loopback → audit metadata, not authentication). A
+    // malformed value throws rather than silently defaulting.
+    const localPrincipalRaw: unknown = governanceRaw.local_principal;
+    let localPrincipal: string | undefined;
+    if (localPrincipalRaw !== undefined) {
+      if (typeof localPrincipalRaw !== "string" || localPrincipalRaw.trim() === "") {
+        throw new Error(
+          `governance.local_principal must be a non-empty string in ${resolvedPath}`,
+        );
+      }
+      localPrincipal = localPrincipalRaw.trim();
+    }
     // FND-3 — optional step-up MFA knobs. Only `secretPath` (a string) is
     // accepted today; a malformed block throws rather than silently ignoring a
     // security-relevant override.
@@ -166,7 +180,11 @@ export function loadConfig(configPath?: string): Readonly<Config> {
         stepUp = {};
       }
     }
-    governance = stepUp ? { principals, stepUp } : { principals };
+    governance = {
+      principals,
+      ...(stepUp ? { stepUp } : {}),
+      ...(localPrincipal ? { localPrincipal } : {}),
+    };
   }
 
   let level: LogLevel = DEFAULT_CONFIG.log.level;

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -51,7 +51,49 @@ export const DEFAULT_CONFIG: Config = {
  * - If the file is partial, missing fields get defaults.
  * - If the file is malformed YAML, throws with a clear message.
  */
-export function loadConfig(configPath?: string): Readonly<Config> {
+/**
+ * FND-6 posture A — detect the misconfiguration that silently re-breaks the
+ * headerless local dashboard: `mc.governance.principals` is set (authorization
+ * binding active) but `mc.governance.local_principal` is unset OR set to a value
+ * NOT in `principals`. In that state a headerless loopback request resolves to
+ * `DEFAULT_LOCAL_PRINCIPAL` (or the unlisted local principal), which is not in
+ * the allowlist → 403 on every control — the exact regression posture A fixes,
+ * reintroduced the moment a principal hardens with an allowlist (the natural
+ * post-#1640 step).
+ *
+ * Pure (no I/O) so both the loader (boot warning) and `cortex config validate`
+ * (pre-write finding) share ONE detection. Returns the warning text, or `null`
+ * when the config is fine. Comparison is case-insensitive, matching
+ * `checkAuthorization` (which lowercases both sides).
+ */
+export function detectLocalPrincipalDrift(
+  governance: GovernanceConfig | undefined,
+): string | null {
+  if (!governance || governance.principals.length === 0) return null;
+  const listed = new Set(governance.principals.map((p) => p.trim().toLowerCase()));
+  const local = (governance.localPrincipal ?? "").trim().toLowerCase();
+  if (local.length > 0 && listed.has(local)) return null;
+  const cause =
+    local.length === 0
+      ? "unset"
+      : `set to "${governance.localPrincipal}", which is not one of the listed principals`;
+  return (
+    `WARNING mc.governance: principals is set but local_principal is ${cause} — ` +
+    "the headerless local dashboard will be refused (403 on every mutating control). " +
+    "Set mc.governance.local_principal to one of the listed principals."
+  );
+}
+
+/** Default warning sink for {@link loadConfig} — one line to stderr. */
+function defaultWarn(message: string): void {
+  process.stderr.write(message.endsWith("\n") ? message : `${message}\n`);
+}
+
+export function loadConfig(
+  configPath?: string,
+  opts?: { onWarning?: (message: string) => void },
+): Readonly<Config> {
+  const warn = opts?.onWarning ?? defaultWarn;
   // GV-1: cortex-first, grove-fallback for the default mission-control.yaml.
   const resolvedPath =
     configPath ??
@@ -242,6 +284,13 @@ export function loadConfig(configPath?: string): Readonly<Config> {
     ...(cfAccess ? { cfAccess } : {}),
     ...(governance ? { governance } : {}),
   };
+
+  // FND-6 posture A — loud, non-fatal warning when an allowlist is set without a
+  // listed local_principal (would silently 403 the headerless local dashboard).
+  // Warn, never hard-fail: bricking an existing deployment over this is worse
+  // than the 403 it predicts.
+  const drift = detectLocalPrincipalDrift(governance);
+  if (drift) warn(drift);
 
   return Object.freeze(config);
 }

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -328,6 +328,9 @@ export function startServer(
     principals: new Set(
       (config.governance?.principals ?? []).map((p) => p.trim().toLowerCase()),
     ),
+    ...(config.governance?.localPrincipal
+      ? { localPrincipal: config.governance.localPrincipal }
+      : {}),
     ...(cfAccessVerifier ? { verifyJwt: cfAccessVerifier } : {}),
   };
 
@@ -980,6 +983,7 @@ async function handleApi(
       isLoopback: guard.isLoopback,
       emailHeader,
       jwtAssertion,
+      ...(guard.localPrincipal ? { localPrincipal: guard.localPrincipal } : {}),
       ...(guard.verifyJwt ? { verifyJwt: guard.verifyJwt } : {}),
     };
     return handleAdmissionDecision(admissionDecider, auth, body.value);

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -591,6 +591,19 @@ export interface GovernanceConfig {
   /** Principal emails (CF-Access identities) allowed to run glass mutations. */
   principals: string[];
   /**
+   * FND-6 posture A (loopback: audit-vs-authentication) — the principal a
+   * loopback mutation is ATTRIBUTED to when the request carries no
+   * `Cf-Access-Authenticated-User-Email` header. On a loopback bind that header
+   * is self-asserted (any local process can set an arbitrary value), so it is
+   * AUDIT METADATA, not authentication — Host+Origin is the real loopback
+   * boundary. When the header is absent the resolved identity falls back to
+   * this value (default `DEFAULT_LOCAL_PRINCIPAL`) and is STILL enforced against
+   * `principals`. If you configure `principals` on a loopback bind, set this to
+   * a listed principal or the headerless local dashboard is refused (403).
+   * Ignored off loopback, where a verified CF-Access JWT is mandatory.
+   */
+  localPrincipal?: string;
+  /**
    * FND-3 — step-up MFA (LOCAL TOTP) knobs. Optional; when omitted the daemon
    * reads the enrolled secret from the default path
    * (`~/.config/cortex/step-up-totp.json`). Absent enrollment fails high-blast


### PR DESCRIPTION
Closes #1859. Closes #1640. Epic #1826. Posture decided with Andreas 2026-07-10 (posture A). **[frontier-review]** — relaxes a loopback control, gets an adversarial pass.

## Problem
FND-6 (#1636) required a `Cf-Access-Authenticated-User-Email` header on loopback that the dashboard never sends → every mutating MC control 401-dead on `localhost:8767` (#1859). And that header is **self-asserted** on loopback, so requiring it authenticated nothing — it only broke the one honest caller.

## Fix (posture A) — 5 source files, additive
- **Loopback resolver** (`networks-admission.ts`): header when present → audit attribution; else configured `local_principal`; else sentinel `local-principal@loopback`. **Never 401 on loopback for a missing header.** Resolved identity is STILL checked against `mc.governance.principals`. **Off-loopback JWT path byte-for-byte unchanged** (503 not_configured / 401 no-token / fail-closed).
- **Structural gating** (`mutation-guard.ts`): `isIdentityGatedMutation = MUTATING_METHODS.has(method) && !isRebindExempt(pathname)` — **every** mutating route except the HMAC webhook is now identity-gated by default. Removed the allowlist that let `/api/tasks`, `/api/tasks/:id/abandon`, `/api/iterations/from-github` slip through (#1640). A future mutating route is gated by default, not by remembering to list it.
- **Config**: `mc.governance.local_principal` (optional string). Unset ⇒ sentinel ⇒ loopback dashboard just works. If you set `mc.governance.principals` on a loopback bind you must also set `local_principal` to a listed value (else the headerless dashboard 403s — authz still enforced).

## Verification
- **Dashboard-succeeds test** (no fetch monkeypatch — exercises the real no-header path): headerless + same-origin + correct Host ⇒ `/api/sessions` 201, attention resolve 200, requeue/abandon ≠ 401.
- Every rebinding test still 403s (attacker Origin / spoofed Host / self-set header), incl. foreign-Host on the newly-gated `/api/tasks`.
- Live end-to-end (real Bun.serve), before→after: `401→201` Dispatch, `401→200` Attention resolve, tasks/iterations now gated.
- `tsc` 0 · eslint clean · VOCAB PASS · `bun test src/surface/mc/api/__tests__ src/surface/mc/__tests__` → 1350 pass / 1 skip (pre-existing dist/ SPA test) / 0 fail · additive (`--diff-filter=D` empty).

## Posture note for the reviewer (deliberate, refute-or-bless)
On loopback, `mc.governance.principals` is **defense-in-depth, not a hard boundary** — a local process can send any header/Origin-less request. The hard loopback boundary is **Host+Origin** (unchanged from #1636). Truly separating browser-from-local-curl needs a transport control (unix socket / `SO_PEERCRED`) — flagged as a separate concern, not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)