### PR TITLE
feat: bin cutover to ~/.local/bin — repoint + plist re-render/reload + forward-symlink bridge (#1866, XDG wave 3)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.7.1"
+version: "6.7.2"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"
@@ -27,11 +27,11 @@ repository: "the-metafactory/cortex"
 #     does NOT touch them while grove is installed. Sequence:
 #       1. `arc uninstall Grove` (legacy)
 #       2. `arc upgrade cortex`
-#       3. Verify `~/bin/cortex` resolves and `~/bin/grove-bot` is gone.
+#       3. Verify `~/.local/bin/cortex` resolves and `~/bin/grove-bot` is gone.
 #
 # Deprecation shim (separate manual step, not part of this manifest):
 #   - Install `scripts/grove-bot-shim.sh` as `~/bin/grove-bot`. It prints
-#     "use cortex instead" and execs `~/bin/cortex "$@"`. Operator can keep
+#     "use cortex instead" and execs `~/.local/bin/cortex "$@"`. Operator can keep
 #     this in place during cutover so old aliases keep working. Removed in
 #     MIG-8.4.
 #
@@ -41,9 +41,9 @@ provides:
   files:
     # ─── Bot + relay binaries ─────────────────────────────────
     - source: src/cortex.ts
-      target: ~/bin/cortex
+      target: ~/.local/bin/cortex
     - source: src/taps/cc-events/relay.ts
-      target: ~/bin/cortex-relay
+      target: ~/.local/bin/cortex-relay
 
     # ─── Operator CLIs (carried forward from MIG-6) ──────────
     # The Discord CLI + its wrapping skill (formerly src/cli/discord/discord.ts →
@@ -53,7 +53,7 @@ provides:
     # cortex declares it under `dependencies:` below. The live Discord ADAPTER
     # (src/adapters/discord/) STAYS in cortex — only the tooling moved.
     - source: src/cli/cldyo-live
-      target: ~/bin/cldyo-live
+      target: ~/.local/bin/cldyo-live
 
     # ─── Claude Code hooks ────────────────────────────────────
     # Hook source filenames are kebab-case (event-logger.hook.ts,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -386,7 +386,7 @@ Reference: `the-metafactory/arc` — the metafactory package manager. Like compa
 | Aspect | Detail |
 |--------|--------|
 | Cortex is a metafactory bundle | Installable via `arc upgrade cortex` once MIG-7 lands. Pre-cutover the package name is `Grove`; the rename to `Cortex` happens at MIG-7.7. |
-| Cortex's `arc-manifest.yaml` | Declares `provides:` — `~/bin/cortex` (the bot binary), `~/bin/discord` (principal CLI), `~/bin/cldyo-live` (CC instrumentation wrapper), CC hooks, skills. The same shape grove-v2 has today. |
+| Cortex's `arc-manifest.yaml` | Declares `provides:` — `~/.local/bin/cortex` (the bot binary), `~/.local/bin/cortex-relay` (event relay), `~/.local/bin/cldyo-live` (CC instrumentation wrapper), CC hooks, skills. (The `discord` CLI moved to the separate `metafactory-discord` bundle.) |
 | Cortex consumes other bundles indirectly | Principals install `myelin` (via arc) for the bus protocol; `signal` (via arc) for the observability tap; `cortex` (via arc) for the surface. Each is independently rolled out. |
 | Cortex does NOT runtime-import arc | arc is a build/install-time tool. At runtime cortex doesn't know it was installed by arc — it just finds its config at the configured path and runs. |
 | Cross-bundle dependencies | Declared via the `arc-manifest.yaml` `dependsOn:` field. Cortex declares `myelin` (the schema is vendored, but principals need myelin's CLI for identity-key provisioning per MIG-7's `nats.identity` config). signal is *recommended* but not required (cortex tolerates absent collector). |

--- a/docs/sop-stack-onboarding.md
+++ b/docs/sop-stack-onboarding.md
@@ -175,7 +175,7 @@ presence:
 
 ### Step 4 — Write + load the cortex plist
 
-`~/Library/LaunchAgents/ai.meta-factory.cortex.<slug>.plist` → `/Users/<you>/bin/cortex start --config ~/.config/cortex/<slug>/<slug>.yaml`, `WorkingDirectory` = the installed pkg, `CORTEX_CHANNEL=<slug>`, logs to `~/.config/cortex/logs/cortex-<slug>.{log,error.log}`. Then `launchctl load …`.
+`~/Library/LaunchAgents/ai.meta-factory.cortex.<slug>.plist` → `/Users/<you>/.local/bin/cortex start --config ~/.config/cortex/<slug>/<slug>.yaml`, `WorkingDirectory` = the installed pkg, `CORTEX_CHANNEL=<slug>`, logs to `~/.config/cortex/logs/cortex-<slug>.{log,error.log}`. Then `launchctl load …`.
 
 ### Step 5 — Verify
 

--- a/scripts/__tests__/plist-render-bin-cutover.sh
+++ b/scripts/__tests__/plist-render-bin-cutover.sh
@@ -272,6 +272,85 @@ assert_grep_file "guard: new arc → guard-pass line printed" "${GOOD_OUT_FILE}"
   'no-throw symlink installer present (arc#295)'
 rm -rf "${NEW_BIN}" "${NEW_HOME}" "${STOP_LOG_NEW}" "${GOOD_OUT_FILE}"
 
+# ─── Section 4: skip-restart (CORTEX_UPGRADE_SKIP_RESTART) ────────
+printf '\n=== skip-restart ===\n'
+
+# Membership predicate.
+( export CORTEX_UPGRADE_SKIP_RESTART="work,halden"
+  assert_true  "member: 'work' is in the skip list"        stack_restart_skipped work
+  assert_true  "member: 'halden' is in the skip list"      stack_restart_skipped halden
+  assert_false "member: 'meta-factory' is NOT in the list"  stack_restart_skipped meta-factory )
+( unset CORTEX_UPGRADE_SKIP_RESTART
+  assert_false "member: empty list → nothing skipped"       stack_restart_skipped work )
+
+# reload_stack_unless_skipped: a skip-listed slug is NOT bootout/bootstrapped;
+# a non-listed slug IS; the relay is never routed through this predicate.
+SKIP_LAUNCH_DIR="${TMPHOME}/skip-launch"
+mkdir -p "${SKIP_LAUNCH_DIR}"
+for s in work meta-factory relay; do
+  printf '<plist/>\n' > "${SKIP_LAUNCH_DIR}/ai.meta-factory.cortex.${s}.plist"
+done
+
+export CORTEX_UPGRADE_SKIP_RESTART="work"
+
+# Skip-listed 'work' → zero launchctl calls (kept on its live process).
+: > "${LAUNCHCTL_LOG}"
+reload_stack_unless_skipped "${SKIP_LAUNCH_DIR}" work >/dev/null
+assert_eq "skip: listed slug 'work' NOT passed to reload_plist (0 launchctl calls)" \
+  "0" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
+
+# Non-listed 'meta-factory' → bootout+bootstrap (2 launchctl calls).
+: > "${LAUNCHCTL_LOG}"
+reload_stack_unless_skipped "${SKIP_LAUNCH_DIR}" meta-factory >/dev/null
+assert_eq "skip: non-listed slug 'meta-factory' IS reloaded (2 launchctl calls)" \
+  "2" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
+
+# Relay bypasses the skip check entirely: even were 'relay' skip-listed,
+# postupgrade reloads it via reload_plist directly (not the predicate).
+( export CORTEX_UPGRADE_SKIP_RESTART="relay"
+  : > "${LAUNCHCTL_LOG}"
+  reload_plist "${SKIP_LAUNCH_DIR}/ai.meta-factory.cortex.relay.plist"
+  assert_eq "skip: relay always reloads (2 launchctl calls, never skip-checked)" \
+    "2" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')" )
+
+unset CORTEX_UPGRADE_SKIP_RESTART
+
+# filter_out_skipped_pids: drop the skip-listed stack's PID from a kill list,
+# matched by the daemon's --config path. Mock `ps -o command= -p <pid>` from a
+# pid→cmdline map so no real process table is consulted.
+SKIP_CONFIG_DIR="${TMPHOME}/skip-config"
+mkdir -p "${SKIP_CONFIG_DIR}"
+WORK_CFG="$(resolve_stack_config_path "${SKIP_CONFIG_DIR}" work)"
+MF_CFG="$(resolve_stack_config_path "${SKIP_CONFIG_DIR}" meta-factory)"
+export PSMAP="${TMPHOME}/psmap"
+{
+  printf '1001 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${WORK_CFG}"
+  printf '1002 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${MF_CFG}"
+} > "${PSMAP}"
+cat > "${MOCK_BIN}/ps" <<'EOF'
+#!/bin/sh
+pid=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -p) pid="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "${pid}" ] && sed -n "s/^${pid} //p" "${PSMAP:-/dev/null}"
+exit 0
+EOF
+chmod +x "${MOCK_BIN}/ps"
+
+( export CORTEX_UPGRADE_SKIP_RESTART="work"
+  KEPT="$(filter_out_skipped_pids "1001 1002" "${SKIP_CONFIG_DIR}")"
+  assert_eq "filter: skip-listed 'work' PID 1001 dropped; 1002 kept" "1002" "${KEPT}" )
+( export CORTEX_UPGRADE_SKIP_RESTART="meta-factory"
+  KEPT="$(filter_out_skipped_pids "1001 1002" "${SKIP_CONFIG_DIR}")"
+  assert_eq "filter: skip-listed 'meta-factory' PID 1002 dropped; 1001 kept" "1001" "${KEPT}" )
+( unset CORTEX_UPGRADE_SKIP_RESTART
+  KEPT="$(filter_out_skipped_pids "1001 1002" "${SKIP_CONFIG_DIR}")"
+  assert_eq "filter: empty skip list → both PIDs kept" "1001 1002" "${KEPT}" )
+
 # ─── Results ──────────────────────────────────────────────────────
 printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" -eq 0 ]

--- a/scripts/__tests__/plist-render-bin-cutover.sh
+++ b/scripts/__tests__/plist-render-bin-cutover.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# cortex#1866 (XDG wave 3) — unit tests for the bin-cutover T13 safety
+# mechanisms in plist-render.sh: forward_link_legacy_bin (the ~/bin →
+# ~/.local/bin forward-symlink bridge) and reload_plist (bootout+bootstrap).
+#
+# These are the exact mechanisms that keep an in-place upgrade from bricking a
+# live fleet, so they get direct coverage. Tests run entirely in a scratch
+# $HOME; no live ~/bin, ~/.local/bin, or launchctl is touched (launchctl is
+# mocked via PATH override, same pattern as plist-render-stack-discovery.sh).
+#
+# Run:
+#   bash scripts/__tests__/plist-render-bin-cutover.sh
+#
+# Exit code: 0 = all pass, non-zero = failure count.
+
+set -euo pipefail
+
+# ─── Test harness ─────────────────────────────────────────────────
+PASS=0
+FAIL=0
+
+pass() { printf '  ✓ %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  ✗ %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    pass "${label}"
+  else
+    fail "${label}: expected «${expected}» got «${actual}»"
+  fi
+}
+
+assert_symlink_to() {
+  local label="$1" link="$2" expected_target="$3"
+  if [ -L "${link}" ] && [ "$(readlink "${link}")" = "${expected_target}" ]; then
+    pass "${label}"
+  else
+    fail "${label}: ${link} is not a symlink → ${expected_target} (got «$(readlink "${link}" 2>/dev/null || echo NONE)»)"
+  fi
+}
+
+assert_true() {
+  local label="$1"; shift
+  if "$@"; then pass "${label}"; else fail "${label}"; fi
+}
+
+assert_false() {
+  local label="$1"; shift
+  if "$@"; then fail "${label}"; else pass "${label}"; fi
+}
+
+# ─── Fixtures ─────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Scratch $HOME — every ~/bin and ~/.local/bin reference in the functions
+# resolves under here, so the real home is never touched.
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "${TMPHOME}"' EXIT
+export HOME="${TMPHOME}"
+
+# Source AFTER HOME is set (the functions read ${HOME} at call time, so this
+# ordering does not actually matter, but keep it explicit).
+source "${SCRIPT_DIR}/lib/plist-render.sh"
+
+# Mock launchctl: emit a trace line per call so reload_plist ordering can be
+# asserted. LAUNCHCTL_LOG is exported so the mock subprocess inherits it.
+MOCK_BIN="${TMPHOME}/mock-bin"
+mkdir -p "${MOCK_BIN}"
+export LAUNCHCTL_LOG="${TMPHOME}/launchctl.log"
+cat > "${MOCK_BIN}/launchctl" <<'EOF'
+#!/bin/sh
+printf 'launchctl %s\n' "$*" >> "${LAUNCHCTL_LOG:-/dev/null}"
+EOF
+chmod +x "${MOCK_BIN}/launchctl"
+export PATH="${MOCK_BIN}:${PATH}"
+
+# Reset ~/bin + ~/.local/bin to a clean slate between cases. Both dirs are
+# created empty so a case can pre-seed a legacy ~/bin entry before calling the
+# function (the function also mkdir -p's ~/bin itself; an empty ~/bin is not a
+# "legacy entry").
+reset_home_bins() {
+  # ${HOME:?} guards against an empty HOME ever expanding rm -rf to /bin
+  # (SC2115); HOME is the mktemp scratch dir set above, but belt-and-braces.
+  rm -rf "${HOME:?}/bin" "${HOME:?}/.local/bin"
+  mkdir -p "${HOME}/bin" "${HOME}/.local/bin"
+}
+
+# ─── Section 1: forward_link_legacy_bin ───────────────────────────
+printf '\n=== forward_link_legacy_bin ===\n'
+
+# Case A — target exists, no legacy link → forward-symlink created.
+reset_home_bins
+printf '#!/bin/sh\n' > "${HOME}/.local/bin/cortex"
+forward_link_legacy_bin cortex
+assert_symlink_to "A: fresh → forward-symlink to target" \
+  "${HOME}/bin/cortex" "${HOME}/.local/bin/cortex"
+
+# Case B — a stale symlink at the legacy path is repointed, no sidecar.
+reset_home_bins
+printf '#!/bin/sh\n' > "${HOME}/.local/bin/cortex"
+ln -sfn "/some/old/target" "${HOME}/bin/cortex"
+forward_link_legacy_bin cortex
+assert_symlink_to "B: stale symlink repointed" \
+  "${HOME}/bin/cortex" "${HOME}/.local/bin/cortex"
+assert_false "B: no sidecar left for a replaced symlink" \
+  test -e "${HOME}/bin/cortex.pre-arc"
+
+# Case C — a real regular file at the legacy path is backed up to .pre-arc,
+# its contents preserved, and the link created over the vacated path.
+reset_home_bins
+printf '#!/bin/sh\n' > "${HOME}/.local/bin/cortex"
+printf 'seed data\n' > "${HOME}/bin/cortex"
+forward_link_legacy_bin cortex
+assert_symlink_to "C: regular file → now a forward-symlink" \
+  "${HOME}/bin/cortex" "${HOME}/.local/bin/cortex"
+assert_eq "C: seed data preserved in .pre-arc sidecar" \
+  "seed data" "$(cat "${HOME}/bin/cortex.pre-arc")"
+
+# Case C2 — a SECOND regular-file conflict must NOT clobber the first backup.
+# (data-loss hardening: new backup lands at .pre-arc.<epoch>[.n]).
+rm -f "${HOME}/bin/cortex"                 # drop the symlink from case C
+printf 'seed data TWO\n' > "${HOME}/bin/cortex"
+forward_link_legacy_bin cortex
+assert_eq "C2: first backup intact (not clobbered)" \
+  "seed data" "$(cat "${HOME}/bin/cortex.pre-arc")"
+# Exactly one timestamped sidecar exists, holding the second file.
+mapfile -t STAMPED < <(find "${HOME}/bin" -maxdepth 1 -name 'cortex.pre-arc.*' | sort)
+assert_eq "C2: one timestamped sidecar created" "1" "${#STAMPED[@]}"
+if [ "${#STAMPED[@]}" -eq 1 ]; then
+  assert_eq "C2: second file preserved at timestamped sidecar" \
+    "seed data TWO" "$(cat "${STAMPED[0]}")"
+fi
+assert_symlink_to "C2: link is the forward-symlink" \
+  "${HOME}/bin/cortex" "${HOME}/.local/bin/cortex"
+
+# Case D — target missing → no-op, no dangling forward-symlink.
+reset_home_bins
+# note: ~/.local/bin/cldyo-live intentionally absent
+forward_link_legacy_bin cldyo-live
+assert_false "D: no dangling forward-symlink when target absent" \
+  test -e "${HOME}/bin/cldyo-live"
+assert_false "D: not even a broken symlink is created" \
+  test -L "${HOME}/bin/cldyo-live"
+
+# ─── Section 2: reload_plist (bootout → bootstrap) ────────────────
+printf '\n=== reload_plist ===\n'
+
+# A rendered plist that execs the NEW ~/.local/bin path.
+RENDERED_PLIST="${TMPHOME}/ai.meta-factory.cortex.work.plist"
+cat > "${RENDERED_PLIST}" <<EOF
+<plist><dict>
+  <key>ProgramArguments</key>
+  <array><string>${HOME}/.local/bin/cortex</string><string>start</string></array>
+</dict></plist>
+EOF
+
+: > "${LAUNCHCTL_LOG}"
+reload_plist "${RENDERED_PLIST}"
+
+# Two calls, in order: bootout THEN bootstrap, both naming the re-rendered plist.
+LINE1="$(sed -n '1p' "${LAUNCHCTL_LOG}")"
+LINE2="$(sed -n '2p' "${LAUNCHCTL_LOG}")"
+assert_true "reload: first call is bootout" \
+  bash -c "printf '%s' \"${LINE1}\" | grep -q 'launchctl bootout'"
+assert_true "reload: second call is bootstrap" \
+  bash -c "printf '%s' \"${LINE2}\" | grep -q 'launchctl bootstrap'"
+assert_true "reload: bootstrap targets the re-rendered plist" \
+  bash -c "printf '%s' \"${LINE2}\" | grep -qF \"${RENDERED_PLIST}\""
+assert_true "reload: bootout targets the same plist" \
+  bash -c "printf '%s' \"${LINE1}\" | grep -qF \"${RENDERED_PLIST}\""
+assert_eq "reload: exactly two launchctl calls" "2" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
+
+# Missing plist → no-op (no launchctl invocation at all).
+: > "${LAUNCHCTL_LOG}"
+reload_plist "${TMPHOME}/does-not-exist.plist"
+assert_eq "reload: missing plist → no launchctl calls" "0" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
+
+# ─── Results ──────────────────────────────────────────────────────
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/scripts/__tests__/plist-render-bin-cutover.sh
+++ b/scripts/__tests__/plist-render-bin-cutover.sh
@@ -45,6 +45,15 @@ assert_true() {
   if "$@"; then pass "${label}"; else fail "${label}"; fi
 }
 
+# assert_grep_file LABEL FILE FIXED_STRING — pass iff FIXED_STRING (a literal,
+# -F) occurs in FILE. Greps a file rather than re-parsing captured output
+# through `bash -c`, so backticks in the captured text can never be
+# command-substituted (the mandated refuse message contains backticks).
+assert_grep_file() {
+  local label="$1" file="$2" needle="$3"
+  if grep -qF -- "${needle}" "${file}"; then pass "${label}"; else fail "${label}"; fi
+}
+
 assert_false() {
   local label="$1"; shift
   if "$@"; then fail "${label}"; else pass "${label}"; fi
@@ -175,6 +184,93 @@ assert_eq "reload: exactly two launchctl calls" "2" "$(wc -l < "${LAUNCHCTL_LOG}
 : > "${LAUNCHCTL_LOG}"
 reload_plist "${TMPHOME}/does-not-exist.plist"
 assert_eq "reload: missing plist → no launchctl calls" "0" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
+
+# ─── Section 3: arc-version guard (cortex#1866 / arc#295) ─────────
+printf '\n=== arc-version guard ===\n'
+
+# Unit — semver comparison (pure bash, no sort -V).
+assert_true  "ge: 0.38.0 >= 0.38.0"        arc_version_ge 0.38.0 0.38.0
+assert_true  "ge: 0.38.1 >= 0.38.0"        arc_version_ge 0.38.1 0.38.0
+assert_true  "ge: 1.0.0  >= 0.38.0"        arc_version_ge 1.0.0  0.38.0
+assert_false "ge: 0.37.9 >= 0.38.0"        arc_version_ge 0.37.9 0.38.0
+assert_false "ge: 0.9.0  >= 0.38.0"        arc_version_ge 0.9.0  0.38.0
+assert_true  "ge: 0.38.0-rc.1 >= 0.38.0 (prerelease core equal)" \
+  arc_version_ge 0.38.0-rc.1 0.38.0
+
+# Integration — drive the real preupgrade.sh with a fake `arc` on PATH and
+# mocked stop primitives, and assert the guard aborts BEFORE any stop/kill.
+PREUP="${SCRIPT_DIR}/preupgrade.sh"
+
+# Build a scratch bin dir that fakes `arc --version` (arg $1) and mocks every
+# stop primitive preupgrade might reach (pgrep/kill/launchctl/sleep) so a real
+# fleet is never touched. Each stop primitive appends to STOP_LOG; an empty
+# STOP_LOG proves nothing was stopped.
+make_preupgrade_env() {
+  local ver="$1" dir
+  dir="$(mktemp -d)"
+  cat > "${dir}/arc" <<EOF
+#!/bin/sh
+[ "\$1" = "--version" ] && echo "arc ${ver}"
+exit 0
+EOF
+  # pgrep: emit nothing (no matching processes) but log that it was consulted.
+  cat > "${dir}/pgrep" <<'EOF'
+#!/bin/sh
+printf 'pgrep %s\n' "$*" >> "${STOP_LOG:-/dev/null}"
+exit 1
+EOF
+  cat > "${dir}/kill" <<'EOF'
+#!/bin/sh
+printf 'kill %s\n' "$*" >> "${STOP_LOG:-/dev/null}"
+EOF
+  cat > "${dir}/launchctl" <<'EOF'
+#!/bin/sh
+printf 'launchctl %s\n' "$*" >> "${STOP_LOG:-/dev/null}"
+EOF
+  cat > "${dir}/sleep" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+  chmod +x "${dir}"/arc "${dir}"/pgrep "${dir}"/kill "${dir}"/launchctl "${dir}"/sleep
+  printf '%s' "${dir}"
+}
+
+# arc too old → exit 1, refuse message on stderr, and NOTHING stopped.
+OLD_BIN="$(make_preupgrade_env 0.37.9)"
+OLD_HOME="$(mktemp -d)"
+STOP_LOG_OLD="$(mktemp)"
+GUARD_OUT_FILE="$(mktemp)"
+set +e
+STOP_LOG="${STOP_LOG_OLD}" HOME="${OLD_HOME}" \
+  PATH="${OLD_BIN}:${PATH}" bash "${PREUP}" > "${GUARD_OUT_FILE}" 2>&1
+GUARD_CODE=$?
+set -e
+assert_eq "guard: old arc (0.37.9) → preupgrade exits 1" "1" "${GUARD_CODE}"
+assert_grep_file "guard: old arc → refuse message printed" "${GUARD_OUT_FILE}" \
+  'cortex bin cutover requires arc >= 0.38.0 (no-throw symlink installer, arc#295).'
+assert_grep_file "guard: old arc → self-update remediation printed" "${GUARD_OUT_FILE}" \
+  'Run `arc self-update` first, then retry `arc upgrade cortex`.'
+assert_eq "guard: old arc → NO stop/kill/unload ran (STOP_LOG empty)" \
+  "0" "$(wc -l < "${STOP_LOG_OLD}" | tr -d ' ')"
+rm -rf "${OLD_BIN}" "${OLD_HOME}" "${STOP_LOG_OLD}" "${GUARD_OUT_FILE}"
+
+# arc new enough → guard passes; preupgrade proceeds to completion (exit 0).
+# Scratch HOME has no stacks + mocked launchctl, so it stops nothing and exits
+# cleanly — proving the guard did not abort.
+NEW_BIN="$(make_preupgrade_env 0.38.0)"
+NEW_HOME="$(mktemp -d)"
+mkdir -p "${NEW_HOME}/.config/cortex" "${NEW_HOME}/Library/LaunchAgents"
+STOP_LOG_NEW="$(mktemp)"
+GOOD_OUT_FILE="$(mktemp)"
+set +e
+STOP_LOG="${STOP_LOG_NEW}" HOME="${NEW_HOME}" \
+  PATH="${NEW_BIN}:${PATH}" bash "${PREUP}" > "${GOOD_OUT_FILE}" 2>&1
+GOOD_CODE=$?
+set -e
+assert_eq "guard: new arc (0.38.0) → preupgrade proceeds (exit 0)" "0" "${GOOD_CODE}"
+assert_grep_file "guard: new arc → guard-pass line printed" "${GOOD_OUT_FILE}" \
+  'no-throw symlink installer present (arc#295)'
+rm -rf "${NEW_BIN}" "${NEW_HOME}" "${STOP_LOG_NEW}" "${GOOD_OUT_FILE}"
 
 # ─── Results ──────────────────────────────────────────────────────
 printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/scripts/__tests__/plist-render-bin-cutover.sh
+++ b/scripts/__tests__/plist-render-bin-cutover.sh
@@ -21,6 +21,10 @@ FAIL=0
 
 pass() { printf '  ✓ %s\n' "$1"; PASS=$((PASS + 1)); }
 fail() { printf '  ✗ %s\n' "$1"; FAIL=$((FAIL + 1)); }
+# skip: count a case as passed on hosts where it does not apply (e.g. a
+# Darwin-gated integration test on the Linux CI runner). Keeps the count stable
+# and the suite green without asserting behaviour the host doesn't exercise.
+skip() { printf '  ↷ %s (skipped: not applicable on %s)\n' "$1" "$(uname)"; PASS=$((PASS + 1)); }
 
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
@@ -430,7 +434,18 @@ chmod +x "${MOCK_BIN}/ps"
 
 # ── Integration: preupgrade ABORTS before any kill on an unclassifiable daemon
 # when a skip-list is set (advw3b 3a fail-safe, end-to-end). ──
+#
+# DARWIN-GATED: this drives the real preupgrade.sh, whose entire kill / abort
+# block is itself gated behind `[ "$(uname)" = "Darwin" ]` (the launchctl bin
+# cutover is macOS-only; Linux/systemd skip-restart + abort parity rides with
+# cortex#1909). On a non-Darwin CI runner that block is a no-op → preupgrade
+# exits 0 with no abort, so the test's own preconditions don't hold. The
+# host-INDEPENDENT unit-level abort tests above (filter_out_skipped_pids rc 2)
+# still run everywhere and cover the fail-safe logic itself.
 printf '\n=== skip-restart: preupgrade fail-safe abort (integration) ===\n'
+if [ "$(uname)" != "Darwin" ]; then
+  skip "abort: preupgrade fail-safe integration (Darwin-only kill/abort block)"
+else
 ABORT_BIN="$(mktemp -d)"
 cat > "${ABORT_BIN}/arc" <<'EOF'
 #!/bin/sh
@@ -484,6 +499,7 @@ assert_eq "abort: NO launchctl unload ran before the abort" "0" \
 assert_grep_file "abort: reason printed (names PID 4242)" "${ABORT_ERR}" \
   'cannot determine slug for running daemon PID 4242'
 rm -rf "${ABORT_BIN}" "${ABORT_HOME}" "${STOP_LOG_ABORT}" "${ABORT_ERR}"
+fi
 
 # ─── Results ──────────────────────────────────────────────────────
 printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/scripts/__tests__/plist-render-bin-cutover.sh
+++ b/scripts/__tests__/plist-render-bin-cutover.sh
@@ -315,17 +315,54 @@ assert_eq "skip: non-listed slug 'meta-factory' IS reloaded (2 launchctl calls)"
 
 unset CORTEX_UPGRADE_SKIP_RESTART
 
-# filter_out_skipped_pids: drop the skip-listed stack's PID from a kill list,
-# matched by the daemon's --config path. Mock `ps -o command= -p <pid>` from a
-# pid→cmdline map so no real process table is consulted.
-SKIP_CONFIG_DIR="${TMPHOME}/skip-config"
-mkdir -p "${SKIP_CONFIG_DIR}"
-WORK_CFG="$(resolve_stack_config_path "${SKIP_CONFIG_DIR}" work)"
-MF_CFG="$(resolve_stack_config_path "${SKIP_CONFIG_DIR}" meta-factory)"
+# ── slug unification (advw3b 3a): argv --config → slug ──
+printf '\n=== slug resolution (kill/reload key unification) ===\n'
+
+# extract_config_arg — both `--config X` and `--config=X` and none.
+assert_eq "extract: '--config X' → X" "/a/b.yaml" \
+  "$(extract_config_arg 'cortex start --config /a/b.yaml')"
+assert_eq "extract: '--config=X' → X" "/a/b.yaml" \
+  "$(extract_config_arg 'cortex start --config=/a/b.yaml')"
+assert_eq "extract: no --config → empty" "" \
+  "$(extract_config_arg 'cortex start')"
+
+# Real on-disk config fixtures so realpath canonicalizes (dir-layout sentinel +
+# a monolith). slug_from_config_arg must key IDENTICALLY to discover_stack_slugs.
+REAL_CFG="${TMPHOME}/real-config"
+mkdir -p "${REAL_CFG}/work/system"
+: > "${REAL_CFG}/work/work.yaml"           # dir-layout sentinel <slug>/<slug>.yaml
+: > "${REAL_CFG}/work/system/system.yaml"  # dir-layout marker
+: > "${REAL_CFG}/cortex.yaml"              # monolith default (meta-factory)
+
+assert_eq "slug: monolith cortex.yaml → meta-factory" "meta-factory" \
+  "$(slug_from_config_arg "${REAL_CFG}/cortex.yaml")"
+assert_eq "slug: monolith cortex.work.yaml → work" "work" \
+  "$(slug_from_config_arg "${REAL_CFG}/cortex.work.yaml")"
+assert_eq "slug: dir-layout sentinel work/work.yaml → work" "work" \
+  "$(slug_from_config_arg "${REAL_CFG}/work/work.yaml")"
+# The 3a case: a NON-CANONICAL argv path (with ..) still resolves to the slug.
+assert_eq "slug: non-canonical path (realpath) → work" "work" \
+  "$(slug_from_config_arg "${REAL_CFG}/work/../work/work.yaml")"
+assert_false "slug: unclassifiable path → non-zero" \
+  slug_from_config_arg "${REAL_CFG}/random/other.yaml"
+assert_false "slug: empty --config → non-zero" \
+  slug_from_config_arg ""
+
+# filter_out_skipped_pids: reclassify a kill-list by SLUG and drop skip-listed
+# stacks. Mock `ps -o command= -p <pid>` from a pid→cmdline map (no real process
+# table consulted). Every mapped cmdline points at a REAL fixture path so slug
+# resolution exercises the actual realpath + filename→slug logic.
+printf '\n=== skip-restart: kill-filter (slug-keyed + fail-safe) ===\n'
 export PSMAP="${TMPHOME}/psmap"
 {
-  printf '1001 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${WORK_CFG}"
-  printf '1002 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${MF_CFG}"
+  printf '1001 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${REAL_CFG}/work/work.yaml"
+  printf '1002 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${REAL_CFG}/cortex.yaml"
+  # 1003: SAME work stack, but argv spells its --config non-canonically (..).
+  printf '1003 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${REAL_CFG}/work/../work/work.yaml"
+  # 1004: unclassifiable --config (parent≠stem, not a cortex.* monolith).
+  printf '1004 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${REAL_CFG}/random/other.yaml"
+  # 1005: no --config at all.
+  printf '1005 %s/.local/bin/cortex start\n' "${HOME}"
 } > "${PSMAP}"
 cat > "${MOCK_BIN}/ps" <<'EOF'
 #!/bin/sh
@@ -341,15 +378,112 @@ exit 0
 EOF
 chmod +x "${MOCK_BIN}/ps"
 
+# (c) existing behaviour preserved — drop the skip-listed slug, keep the rest.
 ( export CORTEX_UPGRADE_SKIP_RESTART="work"
-  KEPT="$(filter_out_skipped_pids "1001 1002" "${SKIP_CONFIG_DIR}")"
+  KEPT="$(filter_out_skipped_pids "1001 1002" "${REAL_CFG}")"
   assert_eq "filter: skip-listed 'work' PID 1001 dropped; 1002 kept" "1002" "${KEPT}" )
 ( export CORTEX_UPGRADE_SKIP_RESTART="meta-factory"
-  KEPT="$(filter_out_skipped_pids "1001 1002" "${SKIP_CONFIG_DIR}")"
+  KEPT="$(filter_out_skipped_pids "1001 1002" "${REAL_CFG}")"
   assert_eq "filter: skip-listed 'meta-factory' PID 1002 dropped; 1001 kept" "1001" "${KEPT}" )
 ( unset CORTEX_UPGRADE_SKIP_RESTART
-  KEPT="$(filter_out_skipped_pids "1001 1002" "${SKIP_CONFIG_DIR}")"
+  KEPT="$(filter_out_skipped_pids "1001 1002" "${REAL_CFG}")"
   assert_eq "filter: empty skip list → both PIDs kept" "1001 1002" "${KEPT}" )
+
+# (a) drift: the work daemon's argv --config is non-canonical, but slug keying
+# still spares it (path-substring keying would have MISSED and killed it).
+( export CORTEX_UPGRADE_SKIP_RESTART="work"
+  KEPT="$(filter_out_skipped_pids "1003 1002" "${REAL_CFG}")"
+  assert_eq "filter: drift — non-canonical --config work PID 1003 still spared" "1002" "${KEPT}" )
+
+# (b) fail-safe: an unresolvable slug while a skip-list is set → ABORT (rc 2),
+# no survivors printed, reason on stderr.
+( export CORTEX_UPGRADE_SKIP_RESTART="work"
+  ERR="$(mktemp)"
+  set +e
+  filter_out_skipped_pids "1001 1004" "${REAL_CFG}" >/dev/null 2>"${ERR}"
+  RC=$?
+  set -e
+  assert_eq "filter: unclassifiable daemon + skip-list → abort rc 2" "2" "${RC}"
+  assert_grep_file "filter: abort names the PID + remediation" "${ERR}" \
+    'cannot determine slug for running daemon PID 1004'
+  assert_grep_file "filter: abort tells how to recover" "${ERR}" \
+    'resolve or unset CORTEX_UPGRADE_SKIP_RESTART'
+  rm -f "${ERR}" )
+
+# (b) no --config at all + skip-list → also aborts.
+( export CORTEX_UPGRADE_SKIP_RESTART="work"
+  set +e
+  filter_out_skipped_pids "1005" "${REAL_CFG}" >/dev/null 2>/dev/null
+  RC=$?
+  set -e
+  assert_eq "filter: daemon with no --config + skip-list → abort rc 2" "2" "${RC}" )
+
+# No skip-list requested → an unclassifiable daemon is NOT an abort (a normal
+# upgrade must never be blocked); pass through unchanged.
+( unset CORTEX_UPGRADE_SKIP_RESTART
+  set +e
+  KEPT="$(filter_out_skipped_pids "1004" "${REAL_CFG}")"
+  RC=$?
+  set -e
+  assert_eq "filter: unclassifiable daemon, NO skip-list → rc 0 (pass-through)" "0" "${RC}"
+  assert_eq "filter: unclassifiable daemon, NO skip-list → PID kept" "1004" "${KEPT}" )
+
+# ── Integration: preupgrade ABORTS before any kill on an unclassifiable daemon
+# when a skip-list is set (advw3b 3a fail-safe, end-to-end). ──
+printf '\n=== skip-restart: preupgrade fail-safe abort (integration) ===\n'
+ABORT_BIN="$(mktemp -d)"
+cat > "${ABORT_BIN}/arc" <<'EOF'
+#!/bin/sh
+[ "$1" = "--version" ] && echo "arc 0.38.0"
+exit 0
+EOF
+# pgrep: return a fake PID ONLY for the cortex-start match; nothing else.
+cat > "${ABORT_BIN}/pgrep" <<'EOF'
+#!/bin/sh
+printf 'pgrep %s\n' "$*" >> "${STOP_LOG:-/dev/null}"
+case "$*" in
+  *"cortex start"*) echo 4242; exit 0 ;;
+  *) exit 1 ;;
+esac
+EOF
+# ps: PID 4242 has an UNCLASSIFIABLE --config.
+cat > "${ABORT_BIN}/ps" <<'EOF'
+#!/bin/sh
+pid=""
+while [ $# -gt 0 ]; do
+  case "$1" in -p) pid="$2"; shift 2 ;; *) shift ;; esac
+done
+[ "${pid}" = "4242" ] && echo "/x/.local/bin/cortex start --config /tmp/garbage/nope.yaml"
+exit 0
+EOF
+cat > "${ABORT_BIN}/kill" <<'EOF'
+#!/bin/sh
+printf 'kill %s\n' "$*" >> "${STOP_LOG:-/dev/null}"
+EOF
+cat > "${ABORT_BIN}/launchctl" <<'EOF'
+#!/bin/sh
+printf 'launchctl %s\n' "$*" >> "${STOP_LOG:-/dev/null}"
+EOF
+printf '#!/bin/sh\nexit 0\n' > "${ABORT_BIN}/sleep"
+chmod +x "${ABORT_BIN}"/arc "${ABORT_BIN}"/pgrep "${ABORT_BIN}"/ps "${ABORT_BIN}"/kill "${ABORT_BIN}"/launchctl "${ABORT_BIN}"/sleep
+
+ABORT_HOME="$(mktemp -d)"
+mkdir -p "${ABORT_HOME}/.config/cortex" "${ABORT_HOME}/Library/LaunchAgents"
+STOP_LOG_ABORT="$(mktemp)"
+ABORT_ERR="$(mktemp)"
+set +e
+STOP_LOG="${STOP_LOG_ABORT}" HOME="${ABORT_HOME}" CORTEX_UPGRADE_SKIP_RESTART="work" \
+  PATH="${ABORT_BIN}:${PATH}" bash "${PREUP}" >"${ABORT_ERR}" 2>&1
+ABORT_CODE=$?
+set -e
+assert_eq "abort: preupgrade exits non-zero on unclassifiable daemon + skip-list" "1" "${ABORT_CODE}"
+assert_eq "abort: NO kill ran before the abort" "0" \
+  "$(grep -c '^kill' "${STOP_LOG_ABORT}" || true)"
+assert_eq "abort: NO launchctl unload ran before the abort" "0" \
+  "$(grep -c '^launchctl' "${STOP_LOG_ABORT}" || true)"
+assert_grep_file "abort: reason printed (names PID 4242)" "${ABORT_ERR}" \
+  'cannot determine slug for running daemon PID 4242'
+rm -rf "${ABORT_BIN}" "${ABORT_HOME}" "${STOP_LOG_ABORT}" "${ABORT_ERR}"
 
 # ─── Results ──────────────────────────────────────────────────────
 printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/scripts/__tests__/plist-render-bin-cutover.test.ts
+++ b/scripts/__tests__/plist-render-bin-cutover.test.ts
@@ -1,0 +1,25 @@
+// bun-test wrapper for scripts/__tests__/plist-render-bin-cutover.sh so the
+// bin-cutover T13 safety mechanisms (forward_link_legacy_bin + reload_plist)
+// are gated by CI's `bun test`, not just runnable by hand. Mirrors the
+// check-carveouts.test.ts pattern (spawn the shell suite, assert exit 0).
+//
+// The shell suite runs entirely in a scratch $HOME with a mocked launchctl —
+// no live ~/bin, ~/.local/bin, or launchctl is touched.
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SUITE = join(REPO_ROOT, "scripts", "__tests__", "plist-render-bin-cutover.sh");
+
+describe("plist-render bin-cutover shell suite (cortex#1866 T13)", () => {
+  test("forward_link_legacy_bin + reload_plist pass (exit 0)", () => {
+    const res = spawnSync("bash", [SUITE], { cwd: REPO_ROOT, encoding: "utf8" });
+    const out = `${res.stdout}${res.stderr}`;
+    // Surface the shell suite's own trace when it fails so the failing case is
+    // visible in the bun-test output.
+    if (res.status !== 0) throw new Error(`shell suite failed (exit ${res.status}):\n${out}`);
+    expect(res.status).toBe(0);
+    expect(out).toContain("0 failed");
+  });
+});

--- a/scripts/federation-selftest.sh
+++ b/scripts/federation-selftest.sh
@@ -29,7 +29,7 @@ set -uo pipefail
 # ── Layout & ports (all high, isolated) ──────────────────────────────────────
 ROOT="${CORTEX_SELFTEST_DIR:-$HOME/.cache/cortex-selftest}"
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CORTEX="${CORTEX_BIN:-$HOME/bin/cortex}"
+CORTEX="${CORTEX_BIN:-$HOME/.local/bin/cortex}"
 
 NET="selftest"                       # throwaway network id
 # Two PRINCIPALS (mirrors the real cross-principal jc↔andreas scenario), each one
@@ -246,7 +246,7 @@ EOF
 #      makes cortex refuse with a clear ARC_TOO_OLD error (by design).
 #   2. cortex's `--hub-mode`/`--resolver-mode`/`--hub-fed-account` flags + the
 #      operator-mode admit branch are on THIS branch but not in the deployed
-#      `~/bin/cortex` — so $CORTEX (CORTEX_BIN) must point at a worktree build.
+#      `~/.local/bin/cortex` — so $CORTEX (CORTEX_BIN) must point at a worktree build.
 # Until both land, `operator` preflights and SKIPS with the gate reason — it
 # never false-fails. Set CORTEX_BIN to a worktree cortex to exercise the flags.
 # =============================================================================

--- a/scripts/grove-bot-shim.sh
+++ b/scripts/grove-bot-shim.sh
@@ -25,4 +25,4 @@
 # Removal: deleted at MIG-8.4 (`rm ~/bin/grove-bot`).
 
 echo "warning: grove-bot is a deprecation shim — use 'cortex' directly. See cortex#9 MIG-7." >&2
-exec "${HOME}/bin/cortex" "$@"
+exec "${HOME}/.local/bin/cortex" "$@"

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -435,8 +435,22 @@ forward_link_legacy_bin() {
     : # existing symlink (possibly stale) — ln -sfn replaces it atomically
   elif [ -e "${link}" ]; then
     # A real regular file / directory occupies the legacy path — preserve it.
-    mv -f "${link}" "${link}.pre-arc"
-    echo "  ↪ backed up existing ${link} → ${link}.pre-arc"
+    # Never clobber an earlier backup: if `<link>.pre-arc` already holds a prior
+    # preserved file, fall back to a timestamped `<link>.pre-arc.<epoch>[.n]`
+    # sidecar (mirrors arc createSymlink's resolveBackupPath — data-loss nit).
+    local sidecar="${link}.pre-arc"
+    if [ -e "${sidecar}" ]; then
+      local stamp
+      stamp="$(date +%s)"
+      sidecar="${link}.pre-arc.${stamp}"
+      local n=1
+      while [ -e "${sidecar}" ]; do
+        sidecar="${link}.pre-arc.${stamp}.${n}"
+        n=$((n + 1))
+      done
+    fi
+    mv -f "${link}" "${sidecar}"
+    echo "  ↪ backed up existing ${link} → ${sidecar}"
   fi
 
   ln -sfn "${target}" "${link}"
@@ -456,7 +470,17 @@ forward_link_legacy_bin() {
 #
 # Domain: gui/<uid> — the per-user Aqua session that owns ~/Library/LaunchAgents.
 # Both calls are `|| true`: bootout errors when the label isn't loaded (fine),
-# bootstrap errors (code 5) when it somehow already is (harmless).
+# bootstrap errors (code 5) when it somehow already is.
+#
+# ⚠ #1904 PREREQUISITE: the `bootstrap … || true` swallows a code-5 ("service
+# already loaded") failure. That failure would leave the daemon on its OLD
+# ~/bin exec path — harmless TODAY *only* because the forward-symlink bridge
+# (forward_link_legacy_bin) keeps ~/bin/<name> resolving. When wave 6 (#1904)
+# DELETES ~/bin, that masking disappears and a swallowed code-5 becomes a
+# daemon execing a missing binary. Before #1904 prunes ~/bin, this needs a
+# settle-then-verify/retry here (bootout, wait for teardown, bootstrap, assert
+# the new exec path is live) — NOT built now, deliberately, to keep this wave's
+# blast radius minimal. Tracked as a #1904 gate.
 #
 # Args: $1 plist path
 reload_plist() {

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -578,6 +578,13 @@ extract_config_arg() {
 #     resolve_stack_config_path stamps and discover_stack_slugs derives from).
 # Returns non-zero (prints nothing) when the path is empty or unclassifiable —
 # the caller treats that as a fail-safe abort when a skip-list is set.
+#
+# Known pathological corner (revw3c, non-deployment): a stack literally slugged
+# `cortex` in the dir layout has sentinel <config_dir>/cortex/cortex.yaml, whose
+# basename `cortex.yaml` hits the monolith special-case → meta-factory, while
+# discover_stack_slugs (dir basename) would call it `cortex`. This is a
+# pre-existing repo-wide ambiguity in config_file_to_slug's meta-factory
+# special-case, not introduced here; `cortex` is not a real deployed slug.
 slug_from_config_arg() {
   local raw="$1" path base slug parent
   [ -n "${raw}" ] || return 1

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -74,7 +74,7 @@ extract_stack_id_slug() {
 # this filename/dirname convention MUST equal it. We deliberately do NOT
 # re-derive the locator from stack.id here: the on-disk files (the sentinel,
 # stacks/<slug>.yaml, the dir itself) are keyed on this name, so reconciling a
-# drifted stack is an operator rename, not an automatic rewrite (high blast
+# drifted stack is a principal rename, not an automatic rewrite (high blast
 # radius on a live pipeline — see cortex#810). cortex#700: centralised so
 # preupgrade/postupgrade/plist-render all agree on the locator.
 config_file_to_slug() {
@@ -230,7 +230,7 @@ discover_stack_slugs() {
 #
 # WARN, do not fail: a hard error would brick `arc upgrade` for a drifted stack
 # (high blast radius on a live review pipeline — #810). The fix is a one-time
-# operator rename of the dir/file to match stack.id; we surface it loudly every
+# principal rename of the dir/file to match stack.id; we surface it loudly every
 # upgrade until reconciled. Emitted to STDERR so it never pollutes the slug list
 # that discover_stack_slugs streams on stdout to its callers.
 #
@@ -490,4 +490,62 @@ reload_plist() {
   domain="gui/$(id -u)"
   launchctl bootout "${domain}" "${plist}" 2>/dev/null || true
   launchctl bootstrap "${domain}" "${plist}" 2>/dev/null || true
+}
+
+# ── Arc-version guard: refuse the cutover on an arc without arc#295 ──────────
+#
+# The bin cutover moves cortex/cortex-relay/cldyo-live to ~/.local/bin, where
+# regular files (`~/.local/bin/{cldyo-live,lucid}`) already live. arc#295's
+# no-throw createSymlink backs those up to a `.pre-arc` sidecar; an OLDER arc's
+# createSymlink THROWS on them and aborts the upgrade — and preupgrade has by
+# then already stopped the fleet, so the box is left DOWN. This guard refuses
+# up-front (BEFORE any daemon is stopped) unless the installed arc is new enough.
+
+# Print the installed arc CLI version (bare semver), or nothing if undetectable.
+detect_arc_version() {
+  command -v arc >/dev/null 2>&1 || return 0
+  arc --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1
+}
+
+# True if semver $1 >= semver $2 (numeric major.minor.patch; any pre-release /
+# build suffix is ignored). Pure bash — no `sort -V` (BSD/macOS sort lacks it).
+arc_version_ge() {
+  local a b i ai bi
+  local -a av=() bv=()
+  # Strip anything after the numeric.dotted core (e.g. "-rc.1", "+build").
+  a="${1%%[!0-9.]*}"
+  b="${2%%[!0-9.]*}"
+  IFS='.' read -ra av <<< "${a}"
+  IFS='.' read -ra bv <<< "${b}"
+  for i in 0 1 2; do
+    ai="${av[i]:-0}"; bi="${bv[i]:-0}"
+    [[ "${ai}" =~ ^[0-9]+$ ]] || ai=0
+    [[ "${bi}" =~ ^[0-9]+$ ]] || bi=0
+    if (( ai > bi )); then return 0; fi
+    if (( ai < bi )); then return 1; fi
+  done
+  return 0  # equal
+}
+
+# Preflight: REFUSE (return non-zero, clear message) unless the installed arc is
+# >= $1. Call at the VERY TOP of preupgrade, BEFORE stopping any daemon.
+# Args: $1 minimum arc semver (e.g. 0.38.0)
+require_min_arc_version() {
+  local min="$1"
+  local ver
+  ver="$(detect_arc_version)"
+  # The mandated refuse line (verbatim; message contract for the deploy gate).
+  local refuse="cortex bin cutover requires arc >= ${min} (no-throw symlink installer, arc#295). Run \`arc self-update\` first, then retry \`arc upgrade cortex\`."
+  if [ -z "${ver}" ]; then
+    echo "  ✗ arc not found or its version was unparseable." >&2
+    echo "${refuse}" >&2
+    return 1
+  fi
+  if ! arc_version_ge "${ver}" "${min}"; then
+    echo "  ✗ installed arc is ${ver}." >&2
+    echo "${refuse}" >&2
+    return 1
+  fi
+  echo "  ✓ arc ${ver} >= ${min} — no-throw symlink installer present (arc#295)"
+  return 0
 }

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -492,6 +492,84 @@ reload_plist() {
   launchctl bootstrap "${domain}" "${plist}" 2>/dev/null || true
 }
 
+# ── Skip-restart: spare a production stack (cortex#1866 principal req.) ──────
+#
+# CORTEX_UPGRADE_SKIP_RESTART is a comma-list of stack slugs whose LIVE daemon
+# must NOT be force-restarted by `arc upgrade cortex` (verified live: the `work`
+# stack serves production). A skipped stack:
+#   - is NOT stopped by preupgrade (its PID is excluded from the pgrep kill and
+#     it is not launchctl-unloaded), so it keeps running on its live process;
+#   - has its binary moved + forward-symlink bridged + plist re-rendered as
+#     normal, but is NOT bootout/bootstrapped by postupgrade;
+#   - migrates to ~/.local/bin at its NEXT natural restart / a maintenance
+#     window (the re-rendered plist takes effect then); until then the
+#     forward-symlink (forward_link_legacy_bin) keeps ~/bin valid.
+# Relay is never routed through the skip check — it always reloads.
+
+# True if $1 (a slug) is in CORTEX_UPGRADE_SKIP_RESTART. Word-splitting on the
+# comma-normalized list trims incidental whitespace; slugs are [a-zA-Z0-9_-] so
+# there is no quoting hazard.
+stack_restart_skipped() {
+  local slug="$1"
+  local list="${CORTEX_UPGRADE_SKIP_RESTART:-}"
+  [ -n "${list}" ] || return 1
+  local entry
+  for entry in $(printf '%s' "${list}" | tr ',' ' '); do
+    [ "${entry}" = "${slug}" ] && return 0
+  done
+  return 1
+}
+
+# Reload ONE stack's plist unless its slug is skip-listed. Encapsulates the
+# postupgrade reload decision so the recorded-running loop and the discover-all
+# fallback loop stay identical (and both honor the skip list).
+#
+# Args: $1 launch_dir  $2 slug
+reload_stack_unless_skipped() {
+  local launch_dir="$1" slug="$2"
+  local plist="${launch_dir}/ai.meta-factory.cortex.${slug}.plist"
+  if [ ! -f "${plist}" ]; then
+    echo "  ⚠ ${slug} plist not found after render — skipping restart" >&2
+    return 0
+  fi
+  if stack_restart_skipped "${slug}"; then
+    echo "  ⏸ ${slug} left running on its live process (CORTEX_UPGRADE_SKIP_RESTART) — plist re-rendered to ~/.local/bin; migrates at next natural restart"
+    return 0
+  fi
+  reload_plist "${plist}"
+  echo "  ✓ ${slug} daemon reloaded"
+}
+
+# Drop from a PID list any cortex daemon whose --config path belongs to a
+# skip-listed stack, so preupgrade's kill never stops a spared production stack.
+# Matches each skip slug's resolved --config path (resolve_stack_config_path —
+# the SAME path render_stack_plist stamps into the plist) as a substring of the
+# process command line. Prints the surviving PIDs (space-separated).
+#
+# Args: $1 space/newline-separated pid list  $2 config_dir
+filter_out_skipped_pids() {
+  local pids="$1" config_dir="$2"
+  local list="${CORTEX_UPGRADE_SKIP_RESTART:-}"
+  if [ -z "${list}" ] || [ -z "${pids}" ]; then
+    printf '%s' "${pids}"
+    return 0
+  fi
+  local kept="" pid cmdline skip_slug skip_cfg drop
+  for pid in ${pids}; do
+    cmdline="$(ps -o command= -p "${pid}" 2>/dev/null || true)"
+    drop=0
+    for skip_slug in $(printf '%s' "${list}" | tr ',' ' '); do
+      [ -n "${skip_slug}" ] || continue
+      skip_cfg="$(resolve_stack_config_path "${config_dir}" "${skip_slug}")"
+      case "${cmdline}" in
+        *"${skip_cfg}"*) drop=1; break ;;
+      esac
+    done
+    [ "${drop}" -eq 0 ] && kept="${kept}${kept:+ }${pid}"
+  done
+  printf '%s' "${kept}"
+}
+
 # ── Arc-version guard: refuse the cutover on an arc without arc#295 ──────────
 #
 # The bin cutover moves cortex/cortex-relay/cldyo-live to ~/.local/bin, where

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -326,12 +326,18 @@ render_stack_plist() {
     echo "  ⚠ Template missing: ${src}" >&2
     return 1
   fi
+  # G-30 (cortex#1866, XDG wave 3): render atomically. A bare `sed > dst`
+  # onto a live LaunchAgents path leaves a truncated/partial plist visible if
+  # the render is interrupted — launchd would then load garbage. Render to a
+  # same-dir temp and `mv` (atomic rename within one filesystem) so the
+  # installed plist only ever transitions whole-old → whole-new.
   sed -e "s|__CORTEX_DIR__|${cortex_dir}|g" \
       -e "s|__BUN_PATH__|${bun_path}|g" \
       -e "s|__HOME__|${HOME}|g" \
       -e "s|__STACK_SLUG__|${slug}|g" \
       -e "s|__CONFIG_PATH__|${config_yaml}|g" \
-      "${src}" > "${dst}"
+      "${src}" > "${dst}.tmp"
+  mv -f "${dst}.tmp" "${dst}"
   echo "  ✓ ${slug} plist rendered → ${dst} (config=${config_yaml})"
 }
 
@@ -365,10 +371,12 @@ render_cortex_plists() {
   local relay_src="${cortex_dir}/src/services/ai.meta-factory.cortex.relay.plist"
   local relay_dst="${launch_dir}/ai.meta-factory.cortex.relay.plist"
   if [ -f "${relay_src}" ]; then
+    # G-30: atomic render (same rationale as render_stack_plist).
     sed -e "s|__CORTEX_DIR__|${cortex_dir}|g" \
         -e "s|__BUN_PATH__|${bun_path}|g" \
         -e "s|__HOME__|${HOME}|g" \
-        "${relay_src}" > "${relay_dst}"
+        "${relay_src}" > "${relay_dst}.tmp"
+    mv -f "${relay_dst}.tmp" "${relay_dst}"
     echo "  ✓ Relay plist rendered → ${relay_dst}"
   fi
 
@@ -383,4 +391,79 @@ render_cortex_plists() {
   if [ "${rendered_count}" -eq 0 ]; then
     echo "  ⚠ No stacks discovered in ${config_dir} (no per-stack dirs or cortex*.yaml) — no stack plists rendered" >&2
   fi
+}
+
+# ── Bin cutover helpers (cortex#1866, XDG wave 3) ────────────────────────────
+
+# Leave a legacy ~/bin/<name> in place as a forward-symlink → ~/.local/bin/<name>.
+#
+# The bin cutover moved cortex/cortex-relay/cldyo-live from ~/bin to
+# ~/.local/bin (arc-manifest provides.files + arc#293 host-adapter defaults).
+# Already-installed launchd plists may still exec ~/bin/<name> until they are
+# re-rendered + reloaded. To guarantee ~/bin/<name> keeps resolving through ANY
+# interrupt in that window, the legacy path is converted to a forward-symlink
+# pointing at the new location.
+#
+# INTERRUPT-WINDOW RULE (cortex#1866 T13, non-negotiable): we NEVER delete
+# ~/bin/<name> here — deletion is wave 6 (#1904). Deleting it in the same
+# operation that re-renders plists would, on any interrupt (pull conflict,
+# missing bun, reboot), leave every plist execing a missing binary under
+# KeepAlive:true → throttled respawn forever.
+#
+# Safety:
+#   - Only bridge when the ~/.local/bin target exists — never create a dangling
+#     forward-symlink.
+#   - An existing symlink at ~/bin/<name> is replaced atomically (`ln -sfn`).
+#   - A REAL file/dir at ~/bin/<name> is backed up to <path>.pre-arc rather than
+#     clobbered (mirrors arc's occupied-destination preflight, arc#293).
+#
+# Host-independent: both macOS (launchd) and Linux (systemd) now exec
+# ~/.local/bin, so the bridge is created regardless of platform.
+#
+# Args: $1 binary basename (e.g. cortex, cortex-relay, cldyo-live)
+forward_link_legacy_bin() {
+  local name="$1"
+  local target="${HOME}/.local/bin/${name}"
+  local link="${HOME}/bin/${name}"
+
+  # Nothing to point at → do not create a dangling forward-symlink.
+  [ -e "${target}" ] || return 0
+
+  mkdir -p "${HOME}/bin"
+
+  if [ -L "${link}" ]; then
+    : # existing symlink (possibly stale) — ln -sfn replaces it atomically
+  elif [ -e "${link}" ]; then
+    # A real regular file / directory occupies the legacy path — preserve it.
+    mv -f "${link}" "${link}.pre-arc"
+    echo "  ↪ backed up existing ${link} → ${link}.pre-arc"
+  fi
+
+  ln -sfn "${target}" "${link}"
+  echo "  ✓ forward-symlink ${link} → ${target}"
+}
+
+# Reload a (freshly re-rendered) installed plist so a CHANGED ProgramArguments
+# actually takes effect — specifically the ~/bin → ~/.local/bin exec-path move.
+#
+# Uses the modern launchctl domain API: `bootout` the plist if currently
+# loaded, then `bootstrap` it back from disk. The legacy `launchctl load`/
+# `unload` pair is unreliable for a repoint — `load` can silently no-op when the
+# label is already registered, leaving the OLD exec path live under launchd.
+# bootout+bootstrap forces launchd to re-read the plist, so the daemon comes
+# back on the new binary path. Also self-healing: if preupgrade's stop somehow
+# left the old service registered, bootout evicts it before bootstrap.
+#
+# Domain: gui/<uid> — the per-user Aqua session that owns ~/Library/LaunchAgents.
+# Both calls are `|| true`: bootout errors when the label isn't loaded (fine),
+# bootstrap errors (code 5) when it somehow already is (harmless).
+#
+# Args: $1 plist path
+reload_plist() {
+  local plist="$1"
+  [ -f "${plist}" ] || return 0
+  local domain
+  domain="gui/$(id -u)"
+  launchctl bootout "${domain}" "${plist}" 2>/dev/null || true
+  launchctl bootstrap "${domain}" "${plist}" 2>/dev/null || true
 }

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -501,10 +501,20 @@ reload_plist() {
 #     it is not launchctl-unloaded), so it keeps running on its live process;
 #   - has its binary moved + forward-symlink bridged + plist re-rendered as
 #     normal, but is NOT bootout/bootstrapped by postupgrade;
-#   - migrates to ~/.local/bin at its NEXT natural restart / a maintenance
-#     window (the re-rendered plist takes effect then); until then the
-#     forward-symlink (forward_link_legacy_bin) keeps ~/bin valid.
+#   - migrates to ~/.local/bin on its NEXT bootout+bootstrap (reboot / logout /
+#     manual `launchctl` reload / maintenance window), when the re-rendered plist
+#     takes effect. A KeepAlive relaunch of the SAME job does NOT migrate it — a
+#     relaunched process keeps launchd's in-memory ProgramArguments (the OLD
+#     ~/bin exec path); the forward-symlink (forward_link_legacy_bin) keeps that
+#     ~/bin path valid until the job is bootstrapped from the new plist on disk.
 # Relay is never routed through the skip check — it always reloads.
+#
+# KEY UNIFICATION (advw3b 3a): BOTH sides key on SLUG. preupgrade's kill-filter
+# resolves each running daemon's slug from its argv `--config` (canonicalized
+# via realpath, then the repo's filename→slug map), NOT by path-substring — so a
+# daemon whose argv spells its config differently (relative path, or the
+# cortex#717 monolith-vs-dir-layout coexistence) can't desync the kill side from
+# postupgrade's slug-keyed reload side and get killed-but-never-restarted.
 
 # True if $1 (a slug) is in CORTEX_UPGRADE_SKIP_RESTART. Word-splitting on the
 # comma-normalized list trims incidental whitespace; slugs are [a-zA-Z0-9_-] so
@@ -533,41 +543,96 @@ reload_stack_unless_skipped() {
     return 0
   fi
   if stack_restart_skipped "${slug}"; then
-    echo "  ⏸ ${slug} left running on its live process (CORTEX_UPGRADE_SKIP_RESTART) — plist re-rendered to ~/.local/bin; migrates at next natural restart"
+    echo "  ⏸ ${slug} left running on its live process (CORTEX_UPGRADE_SKIP_RESTART) — plist re-rendered to ~/.local/bin; migrates on its next bootout+bootstrap (reboot / logout / manual reload)"
     return 0
   fi
   reload_plist "${plist}"
   echo "  ✓ ${slug} daemon reloaded"
 }
 
-# Drop from a PID list any cortex daemon whose --config path belongs to a
-# skip-listed stack, so preupgrade's kill never stops a spared production stack.
-# Matches each skip slug's resolved --config path (resolve_stack_config_path —
-# the SAME path render_stack_plist stamps into the plist) as a substring of the
-# process command line. Prints the surviving PIDs (space-separated).
+# Extract the `--config` argument value from a process command line. Handles
+# both `--config <path>` (two tokens) and `--config=<path>`. Prints the value,
+# or nothing if there is no --config. Word-splits on whitespace — cortex config
+# paths live under ~/.config/cortex and contain no spaces.
+extract_config_arg() {
+  local cmdline="$1" tok take_next=0
+  for tok in ${cmdline}; do
+    if [ "${take_next}" = "1" ]; then printf '%s' "${tok}"; return 0; fi
+    case "${tok}" in
+      --config=*) printf '%s' "${tok#--config=}"; return 0 ;;
+      --config)   take_next=1 ;;
+    esac
+  done
+  return 0
+}
+
+# Resolve the canonical stack SLUG from a daemon's argv `--config` value.
 #
-# Args: $1 space/newline-separated pid list  $2 config_dir
+# Canonicalizes with realpath (so a relative / non-canonical / symlinked argv
+# path resolves to the same absolute path discover_stack_slugs sees), then maps
+# filename → slug the SAME way discovery does:
+#   - monolith: cortex.yaml → meta-factory, cortex.<slug>.yaml → <slug>
+#     (config_file_to_slug — the repo's canonical filename map);
+#   - dir-layout sentinel <config_dir>/<slug>/<slug>.yaml → <slug>, validated by
+#     requiring the parent-dir basename to equal the file stem (the exact shape
+#     resolve_stack_config_path stamps and discover_stack_slugs derives from).
+# Returns non-zero (prints nothing) when the path is empty or unclassifiable —
+# the caller treats that as a fail-safe abort when a skip-list is set.
+slug_from_config_arg() {
+  local raw="$1" path base slug parent
+  [ -n "${raw}" ] || return 1
+  path="$(realpath "${raw}" 2>/dev/null || printf '%s' "${raw}")"
+  base="$(basename "${path}")"
+  if slug="$(config_file_to_slug "${base}")"; then
+    printf '%s' "${slug}"
+    return 0
+  fi
+  slug="${base%.yaml}"
+  parent="$(basename "$(dirname "${path}")")"
+  if [ -n "${slug}" ] && [ "${base}" != "${slug}" ] && [ "${slug}" = "${parent}" ]; then
+    printf '%s' "${slug}"
+    return 0
+  fi
+  return 1
+}
+
+# Reclassify a kill-list by SLUG and drop skip-listed stacks, so preupgrade's
+# kill never stops a spared production stack. For each PID, the slug is resolved
+# from the LIVE daemon's argv `--config` (slug_from_config_arg) — identical
+# keying to postupgrade's reload side.
+#
+# FAIL-SAFE (advw3b 3a): when CORTEX_UPGRADE_SKIP_RESTART is non-empty and a
+# running daemon's slug cannot be resolved from its argv, this returns 2 (abort)
+# WITHOUT printing survivors — the caller must abort the upgrade before any kill,
+# rather than risk killing an unclassifiable stack that might be the spare.
+#
+# Prints surviving PIDs (space-separated) on stdout on success.
+# Returns: 0 = ok, 2 = abort (reason on stderr).
+#
+# Args: $1 space/newline-separated pid list  $2 config_dir (accepted for symmetry
+#       with the discovery callers; slug resolution is argv-driven).
 filter_out_skipped_pids() {
-  local pids="$1" config_dir="$2"
+  local pids="$1"
   local list="${CORTEX_UPGRADE_SKIP_RESTART:-}"
+  # No skip-list requested → no reclassification, no abort: pass through so a
+  # normal upgrade is never blocked and behaviour matches the pre-feature path.
   if [ -z "${list}" ] || [ -z "${pids}" ]; then
     printf '%s' "${pids}"
     return 0
   fi
-  local kept="" pid cmdline skip_slug skip_cfg drop
+  local kept="" pid cmdline cfg slug
   for pid in ${pids}; do
     cmdline="$(ps -o command= -p "${pid}" 2>/dev/null || true)"
-    drop=0
-    for skip_slug in $(printf '%s' "${list}" | tr ',' ' '); do
-      [ -n "${skip_slug}" ] || continue
-      skip_cfg="$(resolve_stack_config_path "${config_dir}" "${skip_slug}")"
-      case "${cmdline}" in
-        *"${skip_cfg}"*) drop=1; break ;;
-      esac
-    done
-    [ "${drop}" -eq 0 ] && kept="${kept}${kept:+ }${pid}"
+    cfg="$(extract_config_arg "${cmdline}")"
+    if ! slug="$(slug_from_config_arg "${cfg}")"; then
+      echo "  ✗ cannot determine slug for running daemon PID ${pid} (config: ${cfg:-${cmdline:-<none>}}); refusing to proceed with a skip-list set, to avoid killing an unclassifiable stack — resolve or unset CORTEX_UPGRADE_SKIP_RESTART" >&2
+      return 2
+    fi
+    stack_restart_skipped "${slug}" && continue   # spare the skip-listed stack
+    kept="${kept}${kept:+ }${pid}"
   done
   printf '%s' "${kept}"
+  return 0
 }
 
 # ── Arc-version guard: refuse the cutover on an arc without arc#295 ──────────
@@ -599,6 +664,9 @@ arc_version_ge() {
     ai="${av[i]:-0}"; bi="${bv[i]:-0}"
     [[ "${ai}" =~ ^[0-9]+$ ]] || ai=0
     [[ "${bi}" =~ ^[0-9]+$ ]] || bi=0
+    # Force base-10 so a hypothetical zero-padded component (e.g. "08") can't be
+    # read as octal and fail open. Unreachable with today's tags — free hardening.
+    ai=$((10#${ai})); bi=$((10#${bi}))
     if (( ai > bi )); then return 0; fi
     if (( ai < bi )); then return 1; fi
   done

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -28,7 +28,7 @@ echo "Running Cortex postinstall..."
 mkdir -p "${EVENTS_DIR}/raw" "${EVENTS_DIR}/published" \
          "${CLAUDE_DIR}/logs" "${CLAUDE_DIR}/relay" \
          "${CONFIG_DIR}/logs" "${CONFIG_DIR}/state" \
-         "${HOME}/bin"
+         "${HOME}/.local/bin"
 chmod 700 "${EVENTS_DIR}/raw"
 chmod 755 "${EVENTS_DIR}/published"
 echo "  ✓ Runtime directories created (~/.claude/events — hook event buffer; ~/.config/cortex/{logs,state} — daemon logs + state)"

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLAUDE_DIR="${HOME}/.claude"
 CONFIG_DIR="${HOME}/.config/cortex"
 
-mkdir -p "${HOME}/bin" "${CLAUDE_DIR}/relay" \
+mkdir -p "${HOME}/.local/bin" "${CLAUDE_DIR}/relay" \
          "${CLAUDE_DIR}/skills" "${CONFIG_DIR}/logs"
 
 echo "Upgrading Cortex (${PAI_OLD_VERSION:-?} → ${PAI_NEW_VERSION:-?})..."

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -112,12 +112,13 @@ if [ "$(uname)" = "Darwin" ]; then
 
   # Read the running-stacks state file written by preupgrade.sh.
   RUNNING_STACKS_FILE="${TMPDIR:-/tmp}/cortex-upgrade-running-stacks"
-  # cortex#1866 skip-restart: reload_stack_unless_skipped re-renders honor the
+  # cortex#1866 skip-restart: reload_stack_unless_skipped honors the
   # CORTEX_UPGRADE_SKIP_RESTART list — a skip-listed slug's plist was already
   # re-rendered above (via render_cortex_plists), but it is NOT bootout/
   # bootstrapped here, so it keeps running on its live process and migrates to
-  # ~/.local/bin on its next natural restart. All other recorded-running stacks
-  # (and the relay, above) reload normally.
+  # ~/.local/bin on its next bootout+bootstrap (reboot / logout / manual reload),
+  # NOT on a KeepAlive relaunch (which keeps the old in-memory exec path). All
+  # other recorded-running stacks (and the relay, above) reload normally.
   if [ -f "${RUNNING_STACKS_FILE}" ]; then
     while IFS= read -r slug; do
       [ -z "${slug}" ] && continue

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -112,29 +112,26 @@ if [ "$(uname)" = "Darwin" ]; then
 
   # Read the running-stacks state file written by preupgrade.sh.
   RUNNING_STACKS_FILE="${TMPDIR:-/tmp}/cortex-upgrade-running-stacks"
+  # cortex#1866 skip-restart: reload_stack_unless_skipped re-renders honor the
+  # CORTEX_UPGRADE_SKIP_RESTART list — a skip-listed slug's plist was already
+  # re-rendered above (via render_cortex_plists), but it is NOT bootout/
+  # bootstrapped here, so it keeps running on its live process and migrates to
+  # ~/.local/bin on its next natural restart. All other recorded-running stacks
+  # (and the relay, above) reload normally.
   if [ -f "${RUNNING_STACKS_FILE}" ]; then
     while IFS= read -r slug; do
       [ -z "${slug}" ] && continue
-      plist="${LAUNCH_DIR}/ai.meta-factory.cortex.${slug}.plist"
-      if [ -f "${plist}" ]; then
-        reload_plist "${plist}"
-        echo "  ✓ ${slug} daemon reloaded"
-      else
-        echo "  ⚠ ${slug} plist not found after render — skipping restart" >&2
-      fi
+      reload_stack_unless_skipped "${LAUNCH_DIR}" "${slug}"
     done < "${RUNNING_STACKS_FILE}"
     rm -f "${RUNNING_STACKS_FILE}"
   else
     # No state file — preupgrade.sh may not have run (e.g. manual upgrade or
     # first install via arc). Fall back to starting all discovered stacks so
-    # the operator doesn't end up with a silent no-daemon state.
+    # the principal doesn't end up with a silent no-daemon state. The skip list
+    # is still honored here.
     echo "  ⚠ No preupgrade state file found — starting all discovered stacks" >&2
     while IFS= read -r slug; do
-      plist="${LAUNCH_DIR}/ai.meta-factory.cortex.${slug}.plist"
-      if [ -f "${plist}" ]; then
-        reload_plist "${plist}"
-        echo "  ✓ ${slug} daemon reloaded (fallback)"
-      fi
+      reload_stack_unless_skipped "${LAUNCH_DIR}" "${slug}"
     done < <(discover_stack_slugs "${CONFIG_DIR}")
   fi
 fi

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -38,6 +38,20 @@ ln -sf "${CORTEX_DIR}/src/taps/cc-events"          "${CLAUDE_DIR}/relay/cortex"
 # Discord skill; cortex declares it as a dependency in arc-manifest.yaml.
 echo "  ✓ Nested symlinks refreshed"
 
+# ─── 1b. Forward-symlink bridge for the bin cutover (cortex#1866 T13) ──────
+# arc's provides.files now installs cortex/cortex-relay/cldyo-live at
+# ~/.local/bin (was ~/bin). Any plist not yet re-rendered below still execs
+# ~/bin/<name>, so we leave ~/bin/<name> as a forward-symlink → ~/.local/bin so
+# it keeps resolving through any interrupt in the render+reload window. We NEVER
+# delete ~/bin/<name> here — deletion is wave 6 (#1904). Host-independent (both
+# launchd and systemd exec ~/.local/bin now); source of the helper is the shared
+# plist-render lib (loaded in §2 below, but we need it here first).
+source "${SCRIPT_DIR}/lib/plist-render.sh"
+echo "  Bridging legacy ~/bin entries → ~/.local/bin (forward-symlinks)..."
+for bin_name in cortex cortex-relay cldyo-live; do
+  forward_link_legacy_bin "${bin_name}"
+done
+
 # ─── 2. Auto-provision stack signing identity ─────────────────────
 # cortex#324 / v2.0.3: stack signing is ON by default. When a config file
 # lacks `stack.nkey_seed_path`, the helper generates an NKey and wires it
@@ -54,7 +68,7 @@ echo "  ✓ Nested symlinks refreshed"
 # us that path — the file where agents[].id and stack.id live.
 echo "  Provisioning stack signing identity..."
 source "${SCRIPT_DIR}/lib/stack-identity-provision.sh"
-source "${SCRIPT_DIR}/lib/plist-render.sh"
+# plist-render.sh already sourced in §1b (forward-symlink bridge).
 
 while IFS= read -r slug; do
   stack_config="$(resolve_stack_agent_config_path "${CONFIG_DIR}" "${slug}")"
@@ -87,11 +101,14 @@ if [ "$(uname)" = "Darwin" ]; then
   # Stacks are restarted based on the running-set recorded by preupgrade.sh.
   # This gives symmetry: no stack left down; none started that wasn't running.
   #
-  # `|| true` keeps a partial upgrade non-fatal — if a daemon was already
-  # unloaded by preupgrade.sh, load just re-loads cleanly.
+  # cortex#1866: reload via bootout+bootstrap (reload_plist), NOT `launchctl
+  # load`. The plists were just re-rendered to exec ~/.local/bin/<name> instead
+  # of ~/bin/<name>; `load` can silently no-op on an already-registered label
+  # and leave the OLD exec path live. bootout+bootstrap forces launchd to re-read
+  # from disk so the daemon comes back on the new binary path.
 
-  launchctl load "${LAUNCH_DIR}/ai.meta-factory.cortex.relay.plist" 2>/dev/null || true
-  echo "  ✓ Relay daemon started"
+  reload_plist "${LAUNCH_DIR}/ai.meta-factory.cortex.relay.plist"
+  echo "  ✓ Relay daemon reloaded"
 
   # Read the running-stacks state file written by preupgrade.sh.
   RUNNING_STACKS_FILE="${TMPDIR:-/tmp}/cortex-upgrade-running-stacks"
@@ -100,8 +117,8 @@ if [ "$(uname)" = "Darwin" ]; then
       [ -z "${slug}" ] && continue
       plist="${LAUNCH_DIR}/ai.meta-factory.cortex.${slug}.plist"
       if [ -f "${plist}" ]; then
-        launchctl load "${plist}" 2>/dev/null || true
-        echo "  ✓ ${slug} daemon started"
+        reload_plist "${plist}"
+        echo "  ✓ ${slug} daemon reloaded"
       else
         echo "  ⚠ ${slug} plist not found after render — skipping restart" >&2
       fi
@@ -115,8 +132,8 @@ if [ "$(uname)" = "Darwin" ]; then
     while IFS= read -r slug; do
       plist="${LAUNCH_DIR}/ai.meta-factory.cortex.${slug}.plist"
       if [ -f "${plist}" ]; then
-        launchctl load "${plist}" 2>/dev/null || true
-        echo "  ✓ ${slug} daemon started (fallback)"
+        reload_plist "${plist}"
+        echo "  ✓ ${slug} daemon reloaded (fallback)"
       fi
     done < <(discover_stack_slugs "${CONFIG_DIR}")
   fi

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -39,11 +39,18 @@ if [ "$(uname)" = "Darwin" ]; then
   # match both so a host mid-upgrade (daemon still running from the old
   # location) is still caught.
   CORTEX_PIDS=$(pgrep -f "${HOME}/(bin|\.local/bin)/cortex start" 2>/dev/null || true)
-  # cortex#1866 skip-restart: drop any skip-listed stack's PID from the blanket
-  # kill so a spared production stack (e.g. `work`) keeps running on its live
-  # process. Matching is by the daemon's --config path (the same path the plist
-  # stamps), so only the intended stack is spared.
-  CORTEX_PIDS=$(filter_out_skipped_pids "${CORTEX_PIDS}" "${CONFIG_DIR}")
+  # cortex#1866 skip-restart (advw3b 3a): reclassify the kill-list by SLUG —
+  # resolved from each live daemon's argv --config — and drop any skip-listed
+  # stack's PID so a spared production stack (e.g. `work`) keeps running. Keying
+  # by slug (not path substring) matches postupgrade's reload side exactly, so
+  # config-path drift can't kill a daemon here that postupgrade then skips.
+  # FAIL-SAFE: if a running daemon's slug is unresolvable while a skip-list is
+  # set, filter_out_skipped_pids returns non-zero → abort BEFORE any kill rather
+  # than risk stopping an unclassifiable stack. (`if !` keeps set -e happy and
+  # still captures the survivors on the success path.)
+  if ! CORTEX_PIDS=$(filter_out_skipped_pids "${CORTEX_PIDS}" "${CONFIG_DIR}"); then
+    exit 1
+  fi
   if [ -n "${CORTEX_PIDS}" ]; then
     echo "  Killing existing cortex processes: ${CORTEX_PIDS}"
     kill ${CORTEX_PIDS} 2>/dev/null || true
@@ -149,7 +156,9 @@ if [ "$(uname)" = "Darwin" ]; then
         # cortex#1866 skip-restart: record it as running (so postupgrade knows
         # it was up) but do NOT unload it — it keeps serving on its live
         # process. postupgrade re-renders its plist but skips the reload; the
-        # stack migrates to ~/.local/bin on its next natural restart.
+        # stack migrates to ~/.local/bin on its next bootout+bootstrap (reboot /
+        # logout / manual reload) — NOT on a KeepAlive relaunch, which keeps the
+        # old in-memory exec path.
         printf '%s\n' "${slug}" >> "${RUNNING_STACKS_FILE}"
         echo "  ⏸ ${slug} daemon left running (CORTEX_UPGRADE_SKIP_RESTART) — recorded, not stopped"
       else

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -10,9 +10,9 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# cortex#700 / cortex#1866: source the shared lib for slug discovery AND the
-# arc-version guard. Sourced up-front (before ANY daemon is stopped) so the
-# guard below can abort as a safe no-op.
+# cortex#700 / cortex#1866: source the shared lib for slug discovery, the
+# skip-restart PID filter, AND the arc-version guard. Sourced up-front (before
+# ANY daemon is stopped) so the guard below can abort as a safe no-op.
 source "${SCRIPT_DIR}/lib/plist-render.sh"
 
 # ── Arc-version guard (cortex#1866 / arc#295) — MUST run before any stop/kill/
@@ -39,6 +39,11 @@ if [ "$(uname)" = "Darwin" ]; then
   # match both so a host mid-upgrade (daemon still running from the old
   # location) is still caught.
   CORTEX_PIDS=$(pgrep -f "${HOME}/(bin|\.local/bin)/cortex start" 2>/dev/null || true)
+  # cortex#1866 skip-restart: drop any skip-listed stack's PID from the blanket
+  # kill so a spared production stack (e.g. `work`) keeps running on its live
+  # process. Matching is by the daemon's --config path (the same path the plist
+  # stamps), so only the intended stack is spared.
+  CORTEX_PIDS=$(filter_out_skipped_pids "${CORTEX_PIDS}" "${CONFIG_DIR}")
   if [ -n "${CORTEX_PIDS}" ]; then
     echo "  Killing existing cortex processes: ${CORTEX_PIDS}"
     kill ${CORTEX_PIDS} 2>/dev/null || true
@@ -112,8 +117,8 @@ if [ "$(uname)" = "Darwin" ]; then
     echo "  ✓ Removed legacy ${legacy_plist}"
   done
 
-  # cortex#700: slug-discovery helpers come from plist-render.sh, already
-  # sourced at the top of this script (before the arc-version guard).
+  # cortex#700: slug-discovery + skip-restart helpers come from plist-render.sh,
+  # already sourced at the top of this script (before the arc-version guard).
 
   # Write running-stacks state to a well-known temp path so postupgrade.sh
   # can restore exactly the stacks that were running before the upgrade.
@@ -140,9 +145,18 @@ if [ "$(uname)" = "Darwin" ]; then
     label="ai.meta-factory.cortex.${slug}"
     plist="${LAUNCH_DIR}/${label}.plist"
     if launchctl list 2>/dev/null | awk '{print $3}' | grep -qx "${label}"; then
-      launchctl unload "${plist}" 2>/dev/null || true
-      printf '%s\n' "${slug}" >> "${RUNNING_STACKS_FILE}"
-      echo "  ✓ ${slug} daemon stopped (recorded for restart)"
+      if stack_restart_skipped "${slug}"; then
+        # cortex#1866 skip-restart: record it as running (so postupgrade knows
+        # it was up) but do NOT unload it — it keeps serving on its live
+        # process. postupgrade re-renders its plist but skips the reload; the
+        # stack migrates to ~/.local/bin on its next natural restart.
+        printf '%s\n' "${slug}" >> "${RUNNING_STACKS_FILE}"
+        echo "  ⏸ ${slug} daemon left running (CORTEX_UPGRADE_SKIP_RESTART) — recorded, not stopped"
+      else
+        launchctl unload "${plist}" 2>/dev/null || true
+        printf '%s\n' "${slug}" >> "${RUNNING_STACKS_FILE}"
+        echo "  ✓ ${slug} daemon stopped (recorded for restart)"
+      fi
     else
       echo "  ⊘ ${slug} daemon not running — will not be restarted by postupgrade"
     fi

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -19,8 +19,11 @@ if [ "$(uname)" = "Darwin" ]; then
   # Holly cortex#52 round 1 nit-3: previous `pgrep -f "cortex start"` matched
   # any commandline containing that substring (`grep cortex start`, vim
   # buffers, other users' editors on shared hosts). Constrain to the
-  # `~/bin/cortex` symlink path so only the actual daemon is matched.
-  CORTEX_PIDS=$(pgrep -f "${HOME}/bin/cortex start" 2>/dev/null || true)
+  # `cortex` symlink path so only the actual daemon is matched. cortex#1866:
+  # the symlink target moved from `~/bin/cortex` to `~/.local/bin/cortex`;
+  # match both so a host mid-upgrade (daemon still running from the old
+  # location) is still caught.
+  CORTEX_PIDS=$(pgrep -f "${HOME}/(bin|\.local/bin)/cortex start" 2>/dev/null || true)
   if [ -n "${CORTEX_PIDS}" ]; then
     echo "  Killing existing cortex processes: ${CORTEX_PIDS}"
     kill ${CORTEX_PIDS} 2>/dev/null || true
@@ -29,10 +32,11 @@ if [ "$(uname)" = "Darwin" ]; then
     echo "  ✓ Old cortex agent processes terminated"
   fi
 
-  # Kill running cortex-relay processes — anchor to ~/bin path for the same
+  # Kill running cortex-relay processes — anchor to the bin path for the same
   # specificity reason. Also catches the legacy grove-relay binary path
-  # (`~/bin/grove-relay`) during the cutover window.
-  RELAY_PIDS=$(pgrep -f "${HOME}/bin/(cortex-relay|grove-relay)" 2>/dev/null || true)
+  # (`~/bin/grove-relay`) during the cutover window. cortex#1866: cortex-relay
+  # moved from `~/bin` to `~/.local/bin`; match both locations.
+  RELAY_PIDS=$(pgrep -f "${HOME}/(bin/(cortex-relay|grove-relay)|\.local/bin/cortex-relay)" 2>/dev/null || true)
   if [ -n "${RELAY_PIDS}" ]; then
     echo "  Killing existing relay processes: ${RELAY_PIDS}"
     kill ${RELAY_PIDS} 2>/dev/null || true

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -26,6 +26,11 @@ require_min_arc_version 0.38.0 || exit 1
 
 echo "Stopping Cortex services for upgrade (${PAI_OLD_VERSION:-?} → ${PAI_NEW_VERSION:-?})..."
 
+# NOTE (cortex#1909): the entire stop/kill block below — including the
+# CORTEX_UPGRADE_SKIP_RESTART skip-restart + its fail-safe abort — is Darwin/
+# launchctl only. The principal's production `work` stack is macOS (launchd), so
+# this PR covers it. Linux/systemd skip-restart + abort PARITY is NOT built here
+# and rides with cortex#1909 — do not assume the skip/abort protects a Linux box.
 if [ "$(uname)" = "Darwin" ]; then
   LAUNCH_DIR="${HOME}/Library/LaunchAgents"
   CONFIG_DIR="${HOME}/.config/cortex"

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -8,12 +8,27 @@ set -e
 # file so postupgrade.sh can restore exactly that set (no stack left down;
 # none started that wasn't running before the upgrade).
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# cortex#700 / cortex#1866: source the shared lib for slug discovery AND the
+# arc-version guard. Sourced up-front (before ANY daemon is stopped) so the
+# guard below can abort as a safe no-op.
+source "${SCRIPT_DIR}/lib/plist-render.sh"
+
+# ── Arc-version guard (cortex#1866 / arc#295) — MUST run before any stop/kill/
+# unload. The bin cutover moves cortex/cortex-relay/cldyo-live to ~/.local/bin,
+# where regular files (~/.local/bin/{cldyo-live,lucid}) already live. arc#295's
+# no-throw createSymlink backs those up to a .pre-arc sidecar; an OLDER arc's
+# createSymlink THROWS on them → provides.files aborts the upgrade AFTER this
+# script has already stopped the fleet → box left DOWN. Refusing up-front makes
+# an old-arc upgrade a safe no-op abort instead of a fleet-down.
+require_min_arc_version 0.38.0 || exit 1
+
 echo "Stopping Cortex services for upgrade (${PAI_OLD_VERSION:-?} → ${PAI_NEW_VERSION:-?})..."
 
 if [ "$(uname)" = "Darwin" ]; then
   LAUNCH_DIR="${HOME}/Library/LaunchAgents"
   CONFIG_DIR="${HOME}/.config/cortex"
-  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
   # Kill running cortex agent processes before upgrading symlinks.
   # Holly cortex#52 round 1 nit-3: previous `pgrep -f "cortex start"` matched
@@ -59,7 +74,7 @@ if [ "$(uname)" = "Darwin" ]; then
   fi
 
   # Clean up legacy grove-bot symlink if it's still owned by a stale install
-  # (operator pre-flight should have run `arc uninstall Grove` already; this
+  # (principal pre-flight should have run `arc uninstall Grove` already; this
   # is a belt-and-braces clean-up so the deprecation shim install step has a
   # clean slate to work with).
   if [ -L "${HOME}/bin/grove-bot" ]; then
@@ -97,9 +112,8 @@ if [ "$(uname)" = "Darwin" ]; then
     echo "  ✓ Removed legacy ${legacy_plist}"
   done
 
-  # cortex#700: source slug-discovery helpers from plist-render.sh.
-  # Only the discovery functions are used here — no plist is rendered.
-  source "${SCRIPT_DIR}/lib/plist-render.sh"
+  # cortex#700: slug-discovery helpers come from plist-render.sh, already
+  # sourced at the top of this script (before the arc-version guard).
 
   # Write running-stacks state to a well-known temp path so postupgrade.sh
   # can restore exactly the stacks that were running before the upgrade.

--- a/src/__tests__/xdg-migration-guard.e2e.test.ts
+++ b/src/__tests__/xdg-migration-guard.e2e.test.ts
@@ -49,6 +49,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "fs";
 import { tmpdir } from "os";
@@ -176,8 +177,18 @@ function renderFleet(): {
 
   // Materialize every path the templates reference so a correctly-installed
   // fleet verifies fully extant.
+  // cortex#1866 (XDG wave 3): the stack plist now execs ~/.local/bin/cortex.
+  // Materialize it there as the real binary, and leave ~/bin/cortex as the
+  // forward-symlink → ~/.local/bin/cortex that the cutover installs and never
+  // deletes (deletion is wave 6, #1904). This mirrors the post-cutover on-disk
+  // shape so invariant (iii) verifies the exec path the daemon actually runs.
+  mkdirSync(join(home, ".local", "bin"), { recursive: true });
   mkdirSync(join(home, "bin"), { recursive: true });
-  writeFileSync(join(home, "bin", "cortex"), "#!/bin/sh\n", { mode: 0o755 });
+  const cortexBin = join(home, ".local", "bin", "cortex");
+  writeFileSync(cortexBin, "#!/bin/sh\n", { mode: 0o755 });
+  symlinkSync(cortexBin, join(home, "bin", "cortex"));
+  // bun stays a system binary resolved via `command -v bun` (BUN_PATH token);
+  // the cutover does not move it.
   const bunPath = join(home, "bin", "bun");
   writeFileSync(bunPath, "#!/bin/sh\n", { mode: 0o755 });
   mkdirSync(join(cortexDir, "src", "taps", "cc-events"), { recursive: true });

--- a/src/bootstrap/ws-transport.ts
+++ b/src/bootstrap/ws-transport.ts
@@ -19,7 +19,7 @@
  *
  * Placement contract: this module MUST be imported before any transitive
  * `discord.js` import. cortex runs UNBUNDLED from source under Bun
- * (`~/bin/cortex` → `src/cortex.ts`), so there is no tree-shake/bundle step
+ * (`~/.local/bin/cortex` → `src/cortex.ts`), so there is no tree-shake/bundle step
  * to defeat the override — being the first import of the entry module is
  * sufficient. ESM evaluates imported modules depth-first in source order, so
  * `import "./bootstrap/ws-transport"` on line 1 runs its side effect before

--- a/src/services/ai.meta-factory.cortex.stack.plist
+++ b/src/services/ai.meta-factory.cortex.stack.plist
@@ -6,7 +6,7 @@
     <string>ai.meta-factory.cortex.__STACK_SLUG__</string>
     <key>ProgramArguments</key>
     <array>
-        <string>__HOME__/bin/cortex</string>
+        <string>__HOME__/.local/bin/cortex</string>
         <string>start</string>
         <string>--config</string>
         <string>__CONFIG_PATH__</string>
@@ -26,7 +26,7 @@
         <key>HOME</key>
         <string>__HOME__</string>
         <key>PATH</key>
-        <string>__HOME__/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+        <string>__HOME__/.local/bin:__HOME__/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
         <key>CORTEX_CHANNEL</key>
         <string>__STACK_SLUG__</string>
     </dict>


### PR DESCRIPTION
Part of epic **#1867**, **wave 3** (bin cutover). **Coupled with arc [#295](https://github.com/the-metafactory/arc/pull/295) — these two must merge together.** Rebased onto `origin/main` (was 19 commits behind) and extended per the v3 gap-review + gap amendment (G-30 / G-40 / G-41, traps T12/T13/T20).

## Scope

### 1. Repoint (original PR, rebased)
- `arc-manifest.yaml`: `provides.files` targets for **cortex, cortex-relay, cldyo-live** → `~/.local/bin/*`.
- `src/services/ai.meta-factory.cortex.stack.plist`: `ProgramArguments[0]` → `__HOME__/.local/bin/cortex`; PATH keeps `__HOME__/bin` after `.local/bin` for backward compat.
- Lifecycle scripts prep `~/.local/bin`; docs/self-test/shim updated.
- **Widened preupgrade kill-guard preserved**: `preupgrade.sh` pgrep matches `${HOME}/(bin|\.local/bin)/…` for both cortex and cortex-relay, so a daemon still running from the old location mid-upgrade is still caught.

### 2. Extension — the machinery that makes an *installed* fleet actually move (this rebase)
The v3 note flagged: **the template change alone does not touch plists already on disk**, and deleting `~/bin` in the same op that re-renders is a brick risk. Addressed:

- **Plist re-render on upgrade** — `postupgrade.sh §3` already calls `render_cortex_plists`, which re-templates installed plists to the new `~/.local/bin` exec path. Confirmed in place.
- **`reload_plist()` — bootout + bootstrap** (`gui/<uid>` domain), replacing legacy `launchctl load`. `load` can silently no-op on an already-registered label and leave the OLD `~/bin` exec path live; bootout+bootstrap forces launchd to re-read the re-rendered plist. Applied to relay + recorded-running stacks + fallback loop. Self-healing if preupgrade's stop left the service registered.
- **`forward_link_legacy_bin()` — forward-symlink bridge (T13)** — leaves `~/bin/<name>` as a symlink → `~/.local/bin/<name>` (`postupgrade.sh §1b`, host-independent, before the render+reload window). **Never deletes `~/bin/<name>`** — deletion is wave 6 (#1904). Backs a real occupying file up to `.pre-arc`; only bridges when the target exists (no dangling links).
- **G-30 atomic render** — both `sed`-template sites (stack + relay) now render to a same-dir `<dst>.tmp` and `mv` into place, so an interrupted render never leaves a truncated plist for launchd to load.

### 3. Guard (#1933) kept green
`xdg-migration-guard.e2e.test.ts` `renderFleet` now materializes `~/.local/bin/cortex` (the template's new exec path) and leaves `~/bin/cortex` as the forward-symlink the cutover installs. Without this, invariant (iii) "every installed plist path is extant" failed after the rebase (template execs `.local/bin/cortex`; fixture only created `~/bin/cortex`). **All 5 invariants green.**

## Interrupt-window / no-delete enforcement (T13)
At every point in the upgrade both `~/bin/<name>` and `~/.local/bin/<name>` resolve:
1. arc installs `~/.local/bin/*` (provides.files, before scripts run).
2. `postupgrade §1b` bridges `~/bin/<name>` → `~/.local/bin/<name>` (`ln -sfn`, atomic; never deletes).
3. `render_cortex_plists` re-renders plists to `~/.local/bin` (atomic tmp+mv).
4. `reload_plist` bootout+bootstrap.
A crash at *any* step leaves every plist execing a resolvable binary — no "deleted binary under KeepAlive → throttled respawn forever" window. `~/bin` deletion is explicitly deferred to #1904.

## Inventory (G-40) — what THIS wave moves vs. what's tracked elsewhere
This wave moves **cortex's own 3 binaries** (cortex, cortex-relay, cldyo-live) and sets **arc's host-adapter default** (arc#295: `darwin-launchd` + `linux-systemd` binDir → shared `~/.local/bin` resolution; occupied-destination preflight). The broader suite still has `~/bin` consumers that repoint when their own repos adopt (their own issues), NOT silently assumed moved here:
- `~/bin/discord` — metafactory-discord bundle (its own adoption).
- Legacy `~/bin/grove-bot`, `~/bin/grove-relay` — the grove-bot deprecation shim (intentionally retained; comments in `arc-manifest.yaml`).
- Live machine symlinks (`signal-*`×5, `lucid`, `pilot`, `grove-agent-runtime`) — repoint under wave 5 arc#287 / downstream issues.

## Occupied-destination coupling (arc#295)
Verified live: `~/.local/bin/{cldyo-live,lucid}` are regular files today. arc#295 changes `createSymlink` to back an occupying regular file up to `<dest>.pre-arc` instead of throwing `SymlinkConflictError`, so this cutover cannot abort mid-way on the principal's machine. cortex's own `forward_link_legacy_bin` mirrors that (`.pre-arc` backup for a real file at the `~/bin` link path).

## Wave-3 audit
`bun scripts/xdg-audit.ts --repos --wave 3` scans the canonical `~/Developer/{cortex,arc}` checkouts (on `main`) → **82** (unchanged baseline until these PRs merge). On this branch the **operational** sites are fully migrated: all 3 manifest `target:` lines and the plist `ProgramArguments` exec path are on `~/.local/bin`. The residual `bin-home` hits are historical migration/design docs, the legacy grove-bot shim, the intentional both-location kill-guard, and the forward-symlink bridge code — the doc/compat tail (consistent with ff2da47a not annotating its own kill-guard), converging to 0 as the merge lands and `~/bin` is pruned in wave 6 (#1904).

## Verification
- Guard `xdg-migration-guard.e2e.test.ts`: 15 pass / 0 fail (5 invariants green).
- `scripts/__tests__/plist-render-stack-discovery.sh`: 80/80 pass.
- `bunx tsc --noEmit -p .`: 0 errors. `eslint`: clean. `shellcheck -S warning` on touched scripts: clean. `bash -n` on all lifecycle scripts: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ⚠ Deploy ordering (must-merge-together + rollout sequence)
This PR and arc #295 are coupled. Beyond merging together, the **rollout order per machine** matters:

> **arc #295 must be merged AND each machine `arc self-update`d (onto the no-throw `createSymlink`) BEFORE this PR's manifest reaches that machine.**

This PR alone, landing on a machine still running an **old arc** (the throwing `createSymlink`), hits the live `~/.local/bin/{cldyo-live,lucid}` regular files and **aborts the upgrade mid-way with the fleet down**. Sequence: merge arc #295 → `arc self-update` the fleet → then this PR's manifest is safe to reach them. (A code guard enforcing this ordering is a planned follow-up.)

## Fix round (wave-3 review)
- `forward_link_legacy_bin`: never clobbers a prior `.pre-arc` backup — a second occupying file lands at `<link>.pre-arc.<epoch>[.n]` (mirrors arc #295's `resolveBackupPath`).
- `reload_plist`: added a **#1904-prerequisite** comment on the `bootstrap … || true` code-5 swallow (harmless today only because the forward-symlink bridge keeps `~/bin` resolving; becomes load-bearing when #1904 deletes `~/bin` → needs settle-then-verify/retry before that wave).
- **New tests** (`scripts/__tests__/plist-render-bin-cutover.sh` + a `.test.ts` wrapper so `bun test`/CI gates them): `forward_link_legacy_bin` across fresh / stale-symlink / regular-file-sidecar / sidecar-collision / missing-target; `reload_plist` bootout→bootstrap ordering (mocked launchctl) + missing-plist no-op. Previously zero-coverage.


## Follow-up (this update): deploy-safety guard + skip-restart for a live stack

Two behaviors added on top of the wave-3 work (head `d14f45e9`):

### 1. Arc-version guard — turns the deploy-ordering hazard above into a safe no-op abort
`scripts/preupgrade.sh` now runs an **arc-version guard at the VERY TOP**, before any daemon-stop / kill / unload. It requires **arc ≥ 0.38.0** (the version carrying arc #295's no-throw `createSymlink`). On an older, undetectable, or missing arc it prints the remediation and `exit 1` **before stopping anything**:

> `cortex bin cutover requires arc >= 0.38.0 (no-throw symlink installer, arc#295). Run \`arc self-update\` first, then retry \`arc upgrade cortex\`.`

This closes the "planned follow-up" noted in *Deploy ordering* above: an old-arc upgrade can no longer stop the fleet and then abort in `provides.files` — it refuses first, leaving the running fleet untouched (safe no-op). Detection: `arc --version` parsed to bare semver; pure-bash `major.minor.patch` compare (no `sort -V`).

### 2. `CORTEX_UPGRADE_SKIP_RESTART` — spare a live production stack during the on-box cutover
Comma-list of stack slugs whose **live daemon must not be force-restarted**. This is what makes the on-box cutover safe for the live `work` production stack (pid-verified). A skip-listed stack:
- **preupgrade:** its PID is dropped from the blanket cortex kill (matched by the daemon's `--config` path) and it is recorded-running but **not** launchctl-unloaded → keeps serving on its live process;
- **postupgrade:** gets binary-move + forward-symlink + plist re-render **as normal**, but is **not** passed to `reload_plist` (no bootout/bootstrap). Its forward-symlinked `~/bin` plist stays valid; it migrates to `~/.local/bin` on its next natural restart.

All other recorded-running stacks — and the relay, which never routes through the skip predicate — reload normally.

### Tests / gates (scoped)
- `scripts/__tests__/plist-render-bin-cutover.sh`: **31/31 pass** (added: semver-compare unit cases; an integration test driving the real `preupgrade.sh` with a fake `arc` on PATH + mocked stop primitives — `0.37.9` ⇒ exit 1 with an empty stop-log (nothing stopped), `0.38.0` ⇒ proceeds; skip-restart predicate + `reload_stack_unless_skipped` skip/reload + relay-always-reloads + `filter_out_skipped_pids` by `--config` path). `.test.ts` wrapper gates it under `bun test`.
- `shellcheck -S warning` on the touched scripts: clean. Vocab carve-out gate: PASS (whole-tree + touched files; R13 `operator`→`principal` prose fixes applied on touched lines).


## Fix (advw3b 3a): skip-restart kill/reload key unified on slug + fail-safe abort — `e668f0ca`
Adversarial review found a prod-down key asymmetry in the skip-restart: preupgrade's kill-filter matched by `--config` **path substring** while postupgrade skipped reload by **slug**. A live daemon whose argv `--config` differed from the canonical path (relative/non-canonical spelling, or the cortex#717 monolith-vs-dir-layout coexistence) would slip the path filter → be **killed**, then get its reload skipped by slug → **killed, never restarted** — and drifted long-lived prod daemons are exactly the ones the feature exists to spare.

- **Both sides now key on SLUG.** `slug_from_config_arg` extracts the daemon's argv `--config` (`extract_config_arg`), canonicalizes with `realpath`, and maps filename→slug the same way `discover_stack_slugs` does (`config_file_to_slug` for monoliths; the `<slug>/<slug>.yaml` dir-sentinel validated by parent==stem). `filter_out_skipped_pids` filters the kill-list by this slug — no path-substring matching. Drift can't desync the two sides.
- **Fail-safe abort.** If `CORTEX_UPGRADE_SKIP_RESTART` is non-empty and a running daemon's slug is unresolvable from its argv, preupgrade **aborts before any kill/unload** rather than risk stopping an unclassifiable stack that might be the spare. With no skip-list set, an unclassifiable daemon is a harmless pass-through (a normal upgrade is never blocked).
- Folded in: `arc_version_ge` forces base-10 (no octal fail-open on zero-padded components); comment/message precision — a spared stack migrates on its next **bootout+bootstrap** (reboot/logout/manual reload), not on a KeepAlive relaunch.
- Tests: **44/44 pass** — added `extract_config_arg` + `slug_from_config_arg` (monolith / dir-sentinel / non-canonical-realpath / unclassifiable / empty); drift case (non-canonical argv work daemon still spared); fail-safe abort at the function level (rc 2, names PID + remediation) **and** an end-to-end preupgrade integration test asserting exit non-zero with **zero kill/launchctl calls** before the abort. shellcheck `-S warning` clean; vocab gate PASS.


## CI fix (revw3c): Darwin-gate the abort integration test — Linux Test job green — `6103ab97`
The "44/44" reported for the 3a fix was **macOS-local**; the Linux CI Test job was RED. The new fail-safe-abort **integration** test drives `bash preupgrade.sh`, but preupgrade's whole kill/abort block is gated behind `[ "$(uname)" = "Darwin" ]` (the launchctl bin cutover is macOS-only) — on the Linux runner that block no-ops, preupgrade exits 0, and the test's preconditions don't hold.

- **Fix:** Darwin-gate the integration block (skip + count-pass on non-Darwin); the host-independent unit-level abort tests (`filter_out_skipped_pids` → rc 2) keep running everywhere. Verified: **Darwin 44/44, simulated Linux (mock `uname`) 41/41** (the 4 integration assertions collapse to 1 skip), and the **actual Linux CI Test job is now green** (run 29213953139 — all 7 CI jobs + confidentiality-gate success).
- **Design note (cortex#1909):** the entire skip-restart + fail-safe abort is Darwin/launchctl only. The principal's production `work` stack is macOS (launchd), so this PR covers it; **Linux/systemd skip-restart + abort parity rides with cortex#1909** and is not assumed working on Linux (one-line comment added at the preupgrade Darwin gate).
- **Pathological corner (revw3c, non-blocking):** a stack literally slugged `cortex` would map argv-side to `meta-factory` (config_file_to_slug special-case) vs discovery's `cortex` — a pre-existing repo-wide ambiguity, not a real deployed slug; noted in `slug_from_config_arg`'s comment.
