### PR TITLE
fix(federation): roster drops peers with absent/malformed stack_id — never fabricate {principal}/default (#1852 half B)

### DIFF
--- a/src/bus/agent-network/__tests__/roster-read.test.ts
+++ b/src/bus/agent-network/__tests__/roster-read.test.ts
@@ -121,7 +121,7 @@ describe("resolveNetworkRoster — resolve (happy path)", () => {
     expect(jc.principal_pubkey!.startsWith("U")).toBe(true);
   });
 
-  test("defaults stack to `{principal}/default` when the roster omits stack_id", async () => {
+  test("DROPS a member (never fabricates `{principal}/default`) when the roster omits stack_id (cortex#1852)", async () => {
     const client = fakeClient({
       fetch: {
         status: "ok",
@@ -137,9 +137,11 @@ describe("resolveNetworkRoster — resolve (happy path)", () => {
     const result = await resolveNetworkRoster(NET, LOCAL, client);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    const jc = result.peers[0]!;
-    expect(jc.stack_id).toBe("jc/default");
-    expect(jc.stack).toBe("default");
+    // Fail loud, don't guess: a stack_id-less member is dropped, not projected
+    // as `jc/default` (which would be a wrong-but-plausible accept-subject).
+    expect(result.peers.some((p) => p.principal_id === "jc")).toBe(false);
+    expect(result.peers.length).toBe(0);
+    expect(result.emptyRoster).toBe(true);
   });
 
   test("leaves principal_pubkey OFF when the roster key is not re-encodable (DD-5: declare by id)", async () => {
@@ -308,5 +310,26 @@ describe("buildRosterPeers — projection", () => {
       ]),
     );
     expect(peers.map((p) => p.principal)).toEqual(["jc", "kim"]);
+  });
+
+  test("drops (with a named reason) a member whose stack_id is absent OR malformed — never fabricates default (cortex#1852)", () => {
+    const drops: { principal: string; reason: string }[] = [];
+    const peers = buildRosterPeers(
+      LOCAL,
+      roster(NET, [
+        { principal_id: "jc", stack_id: "jc/sage-host", principal_pubkey: VALID_B64_PUBKEY },
+        { principal_id: "noStack", principal_pubkey: VALID_B64_PUBKEY }, // absent
+        { principal_id: "bad", stack_id: "bad", principal_pubkey: VALID_B64_PUBKEY }, // no slash
+        { principal_id: "trailing", stack_id: "trailing/", principal_pubkey: VALID_B64_PUBKEY }, // slash at end
+      ]),
+      (principal, reason) => drops.push({ principal, reason }),
+    );
+    // Only the well-formed peer survives; no `noStack/default` etc. fabricated.
+    expect(peers.map((p) => p.principal)).toEqual(["jc"]);
+    expect(peers.some((p) => p.stack === "default")).toBe(false);
+    // Each dropped member is reported with its principal id and a reason.
+    expect(drops.map((d) => d.principal).sort()).toEqual(["bad", "noStack", "trailing"]);
+    expect(drops.find((d) => d.principal === "noStack")?.reason).toContain("no stack_id");
+    expect(drops.find((d) => d.principal === "bad")?.reason).toContain("malformed");
   });
 });

--- a/src/bus/agent-network/roster-read.ts
+++ b/src/bus/agent-network/roster-read.ts
@@ -226,15 +226,49 @@ export async function resolveNetworkRoster(
  *
  * Exported for direct unit testing of the projection in isolation.
  */
+/**
+ * Called for each roster member DROPPED from the peer projection because its
+ * `stack_id` is absent or malformed. Default: a loud stderr warning. The
+ * reconciler passes its own sink so the drop reaches the event pipeline.
+ * cortex#1852 half B — fail loud, never fabricate `{principal}/default`.
+ */
+export type RosterPeerDropSink = (principalId: string, reason: string) => void;
+
+const warnDroppedPeer: RosterPeerDropSink = (principalId, reason) => {
+  process.stderr.write(
+    `WARNING federation roster: dropping peer "${principalId}" — ${reason}. ` +
+      "Its presence/dispatch will NOT be accepted until the registry roster carries a valid " +
+      "{principal}/{stack} stack_id. (cortex#1852)\n",
+  );
+};
+
 export function buildRosterPeers(
   localPrincipalId: string,
   roster: NetworkRosterResult,
+  onDrop: RosterPeerDropSink = warnDroppedPeer,
 ): RosterPeer[] {
   const peers: RosterPeer[] = [];
   for (const member of roster.members) {
     if (member.principal_id === localPrincipalId) continue; // never self
-    const stackId = member.stack_id ?? `${member.principal_id}/default`;
-    const stackSlug = stackSlugOf(stackId, member.principal_id);
+    // cortex#1852 half B — NEVER fabricate `{principal}/default`. A missing or
+    // malformed stack_id is a FAULT (registry roster projection gap / underivable
+    // stack), not a default: drop the peer and warn loudly rather than derive a
+    // wrong-but-plausible accept-subject that silently never matches. (Half A —
+    // #1854 — makes the registry project stack_id, so this path is now rare.)
+    const stackId = member.stack_id;
+    if (stackId === undefined) {
+      onDrop(member.principal_id, "roster carries no stack_id");
+      continue;
+    }
+    const slash = stackId.indexOf("/");
+    if (slash < 0 || slash >= stackId.length - 1) {
+      onDrop(
+        member.principal_id,
+        `malformed stack_id "${stackId}" (expected {principal}/{stack})`,
+      );
+      continue;
+    }
+    const stackSlug = stackId.slice(slash + 1);
     const nkey = base64PubkeyToNkey(member.principal_pubkey);
     const peer: RosterPeer = {
       principal: member.principal_id,
@@ -246,21 +280,4 @@ export function buildRosterPeers(
     peers.push(peer);
   }
   return peers;
-}
-
-/**
- * The `{stack}` wire segment — the part after the `/` in a `{principal}/{stack}`
- * stack id. Falls back to the whole id, then to `default`, for a malformed id
- * (defensive: the roster is registry-shaped, but a missing `/` should not throw
- * inside a long-running reconciler).
- */
-function stackSlugOf(stackId: string, principalId: string): string {
-  const slash = stackId.indexOf("/");
-  if (slash >= 0 && slash < stackId.length - 1) {
-    return stackId.slice(slash + 1);
-  }
-  // No usable slash — derive from `{principal}/default` shape if it matches,
-  // else fall back to `default`.
-  if (stackId === principalId || stackId.length === 0) return "default";
-  return stackId;
 }


### PR DESCRIPTION
Part of #1852 (root cause of #1812). Epic #1818. **Half B — client fail-loud.** Half A (#1854, registry projects `stack_id`) is merged + deployed, so this is safe to land now.

## The defect
`buildRosterPeers` fabricated `{principal}/default` when a roster member lacked `stack_id`, producing a wrong-but-plausible accept-subject (`federated.andreas.default.agent.>`) that silently never matches the peer's real presence subject → dropped at Gate 1 forever. A peer whose real stack genuinely IS `default` masked the bug. Derive-don't-guess violation (design-federation-simplification §Principle 5).

## Fix
`buildRosterPeers` now **drops** a member with an absent or malformed (`no {principal}/{stack}` slash) `stack_id` and reports it via a `RosterPeerDropSink` (default: a loud stderr warning naming the principal + reason) — instead of guessing. Removed the fabricating `stackSlugOf`. Fail-closed: an unidentifiable peer never gets an accept-subject (was already the intent; now it's honest instead of a silent mis-scope).

## Scope
- **This PR:** the roster-projection path (`buildRosterPeers`) — the actual #1812 bug path.
- **Follow-up (tracked on #1852):** the config-peer `peerToWireIdentity` twins (`federation-reconciler.ts:456`, `network-lib.ts:1072`) still fall back to `"default"` for a malformed *config* `stack_id`. Lower-value — config ids are correct post-half-A (the reconciler writes them) — so batched separately.

## Verification
- `bunx tsc --noEmit` 0 · `bunx eslint --quiet` clean (fixed the array-type rule) · VOCAB carve-out PASS.
- `bun test roster-read.test.ts` → 12 pass / 0 fail. Flipped the old "fabricates jc/default" test to assert the **drop**; added a `buildRosterPeers` test covering absent + malformed (no-slash, trailing-slash) `stack_id` → each dropped with a named reason, only the well-formed peer survives, no `stack === "default"` fabricated.
- Additive-ish; `--diff-filter=D` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)