### PR TITLE
feat(wire): WP-2 — canonical wire-identity codec + branded types (additive, migrates nothing)

### DIFF
--- a/src/common/wire/__tests__/identity.test.ts
+++ b/src/common/wire/__tests__/identity.test.ts
@@ -1,0 +1,378 @@
+/**
+ * WP-2 (cortex#1878) — canonical wire-identity codec.
+ *
+ * Table-driven happy path + EVERY fail-loud path. The single most important
+ * property under test: no input, anywhere, ever yields a fabricated `default`.
+ * That fabrication lives today at `federation-reconciler.ts:459` and is the
+ * class of bug this module exists to make unrepresentable.
+ *
+ * Property tests are WP-3. Call-site migration is WP-5.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  AGENT_ID_RE,
+  agentDid,
+  federatedSubject,
+  parseDid,
+  parseFederatedSubject,
+  parsePrincipalId,
+  parseStackId,
+  parseStackSlug,
+  principalDid,
+  PRINCIPAL_ID_RE,
+  stackDid,
+  stackId,
+  STACK_SLUG_RE,
+  WIRE_DID_RE,
+  WireIdentityError,
+} from "../identity.ts";
+
+/** Unwrap an `ok:true` result or fail the test loudly. */
+function unwrap<T>(r: { ok: true; value: T } | { ok: false; reason: string }): T {
+  if (!r.ok) throw new Error(`expected ok, got reason="${r.reason}"`);
+  return r.value;
+}
+
+/**
+ * Widen a branded id back to `string` for assertion.
+ *
+ * This helper has to exist, and that is the point: `expect(principalDid(p))
+ * .toBe("did:mf:andreas")` does not typecheck, because a `PrincipalDid` is not
+ * a `string` literal. The brand is real, not decorative.
+ */
+function raw(s: string): string {
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// parsePrincipalId
+// ---------------------------------------------------------------------------
+
+describe("parsePrincipalId", () => {
+  const ACCEPT = ["andreas", "jc", "a1", "meta-factory", "a-b-c"];
+  const REJECT: [string, string][] = [
+    ["", "empty"],
+    [" ", "space"],
+    ["Andreas", "uppercase"],
+    ["1andreas", "leading digit"],
+    ["-andreas", "leading hyphen"],
+    ["andreas_x", "underscore not permitted for a principal id"],
+    ["andreas.x", "dot not permitted"],
+    ["andreas/x", "slash"],
+    ["did:mf:andreas", "a DID is not a bare principal id"],
+  ];
+
+  test.each(ACCEPT)("accepts %p", (s) => {
+    expect(raw(unwrap(parsePrincipalId(s)))).toBe(s);
+  });
+
+  test.each(REJECT)("rejects %p (%s)", (s) => {
+    const r = parsePrincipalId(s);
+    expect(r.ok).toBe(false);
+  });
+
+  test("the encoded rule is today's PRINCIPAL_ID_RE, not a new invention", () => {
+    expect(PRINCIPAL_ID_RE.source).toBe("^[a-z][a-z0-9-]*$");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseStackSlug
+// ---------------------------------------------------------------------------
+
+describe("parseStackSlug", () => {
+  const ACCEPT = ["meta-factory", "work", "a", "a_b", "s1", "meta_factory-2"];
+  const REJECT: [string, string][] = [
+    ["", "empty"],
+    ["Work", "uppercase"],
+    ["1work", "leading digit"],
+    ["_work", "leading underscore"],
+    ["-work", "leading hyphen"],
+    ["work.x", "dot would collide with the NATS subject separator"],
+    ["work/x", "slash"],
+  ];
+
+  test.each(ACCEPT)("accepts %p", (s) => {
+    expect(raw(unwrap(parseStackSlug(s)))).toBe(s);
+  });
+
+  test.each(REJECT)("rejects %p (%s)", (s) => {
+    expect(parseStackSlug(s).ok).toBe(false);
+  });
+
+  test("stack slugs permit `_` where principal ids do not — today's asymmetry", () => {
+    expect(STACK_SLUG_RE.source).toBe("^[a-z][a-z0-9_-]*$");
+    expect(parseStackSlug("a_b").ok).toBe(true);
+    expect(parsePrincipalId("a_b").ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseStackId — the `default`-fabrication guard
+// ---------------------------------------------------------------------------
+
+describe("parseStackId", () => {
+  test("parses a well-formed `{principal}/{stack}`", () => {
+    const scope = unwrap(parseStackId("andreas/meta-factory"));
+    expect(raw(scope.principal)).toBe("andreas");
+    expect(raw(scope.stack)).toBe("meta-factory");
+  });
+
+  // Every one of these is an input that some site in the tree today would
+  // silently resolve to a `default` stack. None may parse here.
+  const REJECT: [string, string][] = [
+    ["andreas", "no slash — must NOT become andreas/default"],
+    ["andreas/", "trailing slash — must NOT become andreas/default"],
+    ["/default", "leading slash — empty principal"],
+    ["", "empty"],
+    ["/", "bare slash"],
+    ["//", "double slash"],
+    ["andreas//meta", "empty middle segment"],
+    ["andreas/meta/factory", "two slashes — ambiguous under first-vs-last split"],
+    ["Andreas/meta", "uppercase principal"],
+    ["andreas/Meta", "uppercase stack"],
+    ["andreas_x/meta", "underscore in principal"],
+    ["did:mf:andreas-meta", "a DID is not a stack id"],
+  ];
+
+  test.each(REJECT)("rejects %p (%s)", (s) => {
+    expect(parseStackId(s).ok).toBe(false);
+  });
+
+  test("NO input whatsoever fabricates a `default` stack", () => {
+    const inputs = [
+      "andreas",
+      "andreas/",
+      "/default",
+      "",
+      "/",
+      "andreas/meta/factory",
+      "default",
+      "andreas/default",
+    ];
+    for (const s of inputs) {
+      const r = parseStackId(s);
+      if (r.ok) {
+        // The ONLY way `default` may appear is if the caller literally wrote it.
+        expect(s).toContain(r.value.stack);
+        expect(s.endsWith(`/${r.value.stack}`)).toBe(true);
+      }
+    }
+    // The two shapes that most tempt a fallback stay hard failures.
+    expect(parseStackId("andreas").ok).toBe(false);
+    expect(parseStackId("andreas/").ok).toBe(false);
+  });
+
+  test("an explicit `andreas/default` parses as-written (not fabricated)", () => {
+    const scope = unwrap(parseStackId("andreas/default"));
+    expect(raw(scope.stack)).toBe("default");
+  });
+
+  test("rejects a 2-slash id rather than picking first- or last-slash", () => {
+    // roster-read.ts splits on the FIRST slash; stack-id.ts's
+    // `stackSlugFromStackId` splits on the LAST. They disagree on a 3-segment
+    // id. This codec refuses to arbitrate — it fails loud instead.
+    const r = parseStackId("andreas/meta/factory");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("exactly one");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Render constructors
+// ---------------------------------------------------------------------------
+
+describe("render constructors", () => {
+  const scope = {
+    principal: unwrap(parsePrincipalId("andreas")),
+    stack: unwrap(parseStackSlug("meta-factory")),
+  };
+
+  test("stackId round-trips through parseStackId", () => {
+    const id = stackId(scope);
+    expect(raw(id)).toBe("andreas/meta-factory");
+    const back = unwrap(parseStackId(id));
+    expect(back).toEqual(scope);
+  });
+
+  test("principalDid renders the `did:mf:` form", () => {
+    expect(raw(principalDid(scope.principal))).toBe("did:mf:andreas");
+  });
+
+  test("stackDid renders `did:mf:{principal}-{stack}`", () => {
+    expect(raw(stackDid(scope))).toBe("did:mf:andreas-meta-factory");
+  });
+
+  test("agentDid renders + validates against today's AGENT_ID_RE", () => {
+    expect(raw(agentDid("echo"))).toBe("did:mf:echo");
+    expect(AGENT_ID_RE.source).toBe("^[a-z0-9-]+$");
+  });
+
+  test("every rendered DID satisfies the myelin wire grammar", () => {
+    expect(WIRE_DID_RE.test(principalDid(scope.principal))).toBe(true);
+    expect(WIRE_DID_RE.test(stackDid(scope))).toBe(true);
+    expect(WIRE_DID_RE.test(agentDid("echo"))).toBe(true);
+  });
+
+  test("agentDid fails loud on an id today's AGENT_ID_RE rejects", () => {
+    expect(() => agentDid("Echo")).toThrow(WireIdentityError);
+    expect(() => agentDid("")).toThrow(WireIdentityError);
+    expect(() => agentDid("ec_ho")).toThrow(WireIdentityError);
+  });
+
+  test("stackDid fails loud rather than emitting a `--` DID the wire rejects", () => {
+    // `andreas-` is a legal principal id today (trailing hyphen permitted) and
+    // `meta` a legal slug — yet `did:mf:andreas--meta` violates WIRE_DID_RE's
+    // no-consecutive-hyphen rule. cortex.ts:1024 silently collapses the run;
+    // this codec refuses to emit an invalid DID and refuses to mutate the
+    // caller's identity behind their back. TODO(WP-4) owns the real encoding.
+    const bad = {
+      principal: unwrap(parsePrincipalId("andreas-")),
+      stack: unwrap(parseStackSlug("meta")),
+    };
+    expect(() => stackDid(bad)).toThrow(WireIdentityError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The compile-time guarantee (the whole point of the branding)
+// ---------------------------------------------------------------------------
+
+describe("compile-time guarantee", () => {
+  test("a StackDid can never be `===` compared to a PrincipalDid", () => {
+    const p = unwrap(parsePrincipalId("andreas"));
+    const scope = { principal: p, stack: unwrap(parseStackSlug("meta-factory")) };
+
+    // THE regression guard for the jc-fold bug: this comparison silently
+    // returned `false` at runtime and dropped presence. It is now a type error.
+    // If this line ever compiles, `tsc` fails on the unused directive and this
+    // test file is the thing that catches it.
+    // @ts-expect-error — StackDid and PrincipalDid are distinct brands.
+    const _never = stackDid(scope) === principalDid(p);
+
+    expect(typeof _never).toBe("boolean");
+  });
+
+  test("a StackId cannot be passed where a PrincipalId is expected", () => {
+    const scope = {
+      principal: unwrap(parsePrincipalId("andreas")),
+      stack: unwrap(parseStackSlug("work")),
+    };
+    // @ts-expect-error — StackId is not a PrincipalId.
+    const _did = principalDid(stackId(scope));
+    expect(typeof _did).toBe("string");
+  });
+
+  test("a raw string cannot be passed where a branded id is expected", () => {
+    // @ts-expect-error — unbranded strings must go through a parse constructor.
+    const _did = principalDid("andreas");
+    expect(typeof _did).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDid — must never guess (WP-4 owns disambiguation)
+// ---------------------------------------------------------------------------
+
+describe("parseDid", () => {
+  test("rejects anything failing the myelin wire grammar", () => {
+    for (const s of ["", "andreas", "did:mf:", "did:mf:1a", "did:mf:a--b", "did:xx:a", "did:mf:A"]) {
+      const r = parseDid(s);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("malformed");
+    }
+  });
+
+  test("returns `ambiguous` — never a guess — when classes overlap", () => {
+    // `did:mf:andreas-meta-factory` is simultaneously a legal principal id
+    // (hyphens permitted), a legal agent id, and a legal {p}-{s} stack pair.
+    const r = parseDid("did:mf:andreas-meta-factory");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ambiguous");
+  });
+
+  test("a hyphen-free DID is ambiguous between principal and agent", () => {
+    // `did:mf:echo` is minted as an AGENT did at dispatch-source-publisher.ts:203
+    // and as a PRINCIPAL did at identity-registry.ts:178. Structurally identical.
+    const r = parseDid("did:mf:echo");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ambiguous");
+  });
+
+  test("well-formed but unclassifiable DIDs fail loud, not silently", () => {
+    // `_` and `.` pass WIRE_DID_RE but no identity-class rule admits them.
+    for (const s of ["did:mf:a_b", "did:mf:a.b"]) {
+      const r = parseDid(s);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("unclassifiable");
+    }
+  });
+
+  test("parseDid NEVER returns ok:true under today's rules — that is WP-4's forcing function", () => {
+    // Documented, deliberate result. Every identity class' rule set overlaps
+    // every other's, so no well-formed DID is uniquely classifiable. When WP-4
+    // (#1880) picks an encoding, the class predicates change and this test
+    // becomes the thing that proves the ambiguity is gone.
+    const samples = [
+      "did:mf:andreas",
+      "did:mf:echo",
+      "did:mf:andreas-meta-factory",
+      "did:mf:jc-work",
+      "did:mf:a1",
+    ];
+    for (const s of samples) {
+      expect(parseDid(s).ok).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Federated subjects
+// ---------------------------------------------------------------------------
+
+describe("federated subjects", () => {
+  const scope = {
+    principal: unwrap(parsePrincipalId("andreas")),
+    stack: unwrap(parseStackSlug("meta-factory")),
+  };
+
+  test("renders `federated.{principal}.{stack}.{rest}`", () => {
+    expect(raw(federatedSubject(scope, "tasks", "code-review"))).toBe(
+      "federated.andreas.meta-factory.tasks.code-review",
+    );
+  });
+
+  test("round-trips through parseFederatedSubject", () => {
+    const subject = federatedSubject(scope, "tasks", "code-review");
+    const parsed = unwrap(parseFederatedSubject(subject));
+    expect(parsed.scope).toEqual(scope);
+    expect(parsed.rest).toEqual(["tasks", "code-review"]);
+  });
+
+  const REJECT: [string, string][] = [
+    ["", "empty"],
+    ["federated", "prefix only"],
+    ["federated.andreas", "no stack"],
+    ["federated.andreas.meta-factory", "no trailing segments"],
+    ["local.andreas.meta-factory.tasks", "wrong prefix — `local` is not federated"],
+    ["federated..meta-factory.tasks", "empty principal"],
+    ["federated.andreas..tasks", "empty stack"],
+    ["federated.Andreas.meta-factory.tasks", "uppercase principal"],
+    ["federated.andreas.meta-factory.", "empty trailing segment"],
+    ["federated.andreas_x.meta.tasks", "underscore in principal"],
+  ];
+
+  test.each(REJECT)("rejects %p (%s)", (s) => {
+    expect(parseFederatedSubject(s).ok).toBe(false);
+  });
+
+  test("federatedSubject fails loud on a segment that would break the subject", () => {
+    expect(() => federatedSubject(scope, "")).toThrow(WireIdentityError);
+    expect(() => federatedSubject(scope, "a.b")).toThrow(WireIdentityError);
+    expect(() => federatedSubject(scope, "*")).toThrow(WireIdentityError);
+    expect(() => federatedSubject(scope, ">")).toThrow(WireIdentityError);
+    expect(() => federatedSubject(scope)).toThrow(WireIdentityError);
+  });
+});

--- a/src/common/wire/identity.ts
+++ b/src/common/wire/identity.ts
@@ -1,0 +1,339 @@
+/**
+ * The canonical wire-identity codec (WP-2, cortex#1878; epic #1876).
+ *
+ * ## Why this module exists
+ *
+ * `did:mf:` is overloaded across three structurally-indistinguishable identity
+ * classes — **principal**, **stack**, and **agent** — minted independently at
+ * ~8 sites and compared with `===`. A `StackDid === PrincipalDid` comparison
+ * silently returns `false` and drops presence. That is the open jc-fold bug.
+ *
+ * Two mechanisms make that class of bug unrepresentable:
+ *
+ * 1. **Branded types.** `StackDid` and `PrincipalDid` are nominally distinct
+ *    (zero runtime cost), so `stackDid(x) === principalDid(y)` is a *compile*
+ *    error, not a silent runtime `false`.
+ * 2. **One module owns every transform.** Parsing and rendering of principal
+ *    ids, stack slugs, stack ids, DIDs, and federated subjects happen here and
+ *    only here.
+ *
+ * ## Fail loud, never fabricate
+ *
+ * Parse constructors return a discriminated {@link ParseResult}. They never
+ * throw and — critically — they **never fabricate a `default`**. The live
+ * fabrication this rules out is `federation-reconciler.ts:459`, which turns a
+ * malformed `stack_id` into a silent `"default"` stack.
+ *
+ * Render constructors are total over *branded* inputs. Where an input pair is
+ * individually legal yet renders a DID the wire grammar rejects (see
+ * {@link stackDid}), they throw {@link WireIdentityError} rather than emit an
+ * invalid identity or silently mutate the caller's identity.
+ *
+ * ## Scope discipline
+ *
+ * - This module **encodes today's rules**; it invents none. Every regex below
+ *   is transcribed from a live call site, cited inline.
+ * - It **does not decide the DID encoding**. Because slugs permit `-`,
+ *   `did:mf:{p}-{s}` is ambiguous with `did:mf:{principal}`. That decision is
+ *   **WP-4 (#1880)**. {@link parseDid} therefore reports `"ambiguous"` and
+ *   never guesses.
+ * - It **migrates no call site**. That is WP-5, held behind review.
+ *
+ * @see docs/adr/0004-stack-slug-authority.md
+ */
+
+// ---------------------------------------------------------------------------
+// Branded types — nominal typing, zero runtime cost
+// ---------------------------------------------------------------------------
+
+declare const brand: unique symbol;
+
+/** Attach a compile-time-only nominal tag `B` to the structural type `T`. */
+type Brand<T, B extends string> = T & { readonly [brand]: B };
+
+/** A principal's id — the human/org authority. e.g. `"andreas"`. */
+export type PrincipalId = Brand<string, "PrincipalId">;
+
+/** The trailing segment of a stack id. e.g. `"meta-factory"`. */
+export type StackSlug = Brand<string, "StackSlug">;
+
+/** The canonical `{principal}/{stack}` literal. e.g. `"andreas/meta-factory"`. */
+export type StackId = Brand<string, "StackId">;
+
+/** A principal's DID. e.g. `"did:mf:andreas"`. */
+export type PrincipalDid = Brand<string, "PrincipalDid">;
+
+/** A stack's DID. e.g. `"did:mf:andreas-meta-factory"`. */
+export type StackDid = Brand<string, "StackDid">;
+
+/** An agent's DID. e.g. `"did:mf:echo"`. */
+export type AgentDid = Brand<string, "AgentDid">;
+
+/** A `federated.{principal}.{stack}.{...}` NATS subject. */
+export type FederatedSubject = Brand<string, "FederatedSubject">;
+
+/** A parsed `{principal}/{stack}` pair — the two halves, never re-spliced by hand. */
+export interface StackScope {
+  principal: PrincipalId;
+  stack: StackSlug;
+}
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+/** Discriminated parse outcome. Parse constructors never throw and never default. */
+export type ParseResult<T> = { ok: true; value: T } | { ok: false; reason: string };
+
+/** Thrown by a render constructor when its inputs cannot produce a valid wire identity. */
+export class WireIdentityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WireIdentityError";
+  }
+}
+
+const ok = <T>(value: T): ParseResult<T> => ({ ok: true, value });
+const err = <T>(reason: string): ParseResult<T> => ({ ok: false, reason });
+
+// ---------------------------------------------------------------------------
+// Today's rules — transcribed, not invented. Each cites its live source.
+// ---------------------------------------------------------------------------
+
+/** The `did:mf:` method prefix. */
+export const DID_PREFIX = "did:mf:";
+
+/**
+ * A principal id. Source: `src/cli/cortex/commands/network.ts:244`,
+ * `provision-stack.ts:86`, `stack.ts:74`. Note: **no** `_`.
+ */
+export const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * A stack slug. Source: `src/cli/cortex/commands/network.ts:3832`,
+ * `stack.ts:73`, `src/common/nats/hub-leaf-authorization.ts:48`.
+ * Note: permits `_`, where {@link PRINCIPAL_ID_RE} does not. That asymmetry is
+ * today's reality, not a choice made here.
+ */
+export const STACK_SLUG_RE = /^[a-z][a-z0-9_-]*$/;
+
+/** An agent id. Source: `src/cli/cortex/commands/creds.ts:77`. */
+export const AGENT_ID_RE = /^[a-z0-9-]+$/;
+
+/**
+ * The authoritative wire DID grammar. Source: myelin
+ * `src/identity/types.ts:1` (`DID_RE`), mirrored by
+ * `src/bus/myelin/vendor/envelope.schema.json`. Permits `.` and `_`, forbids
+ * **consecutive** hyphens — which is why `cortex.ts:1024` collapses `-+` runs.
+ */
+export const WIRE_DID_RE = /^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$/;
+
+/** A single NATS subject token: no separator, no wildcard, non-empty. */
+const SUBJECT_SEGMENT_RE = /^[a-zA-Z0-9_-]+$/;
+
+/** The federated subject prefix. Source: `src/bus/jetstream/review-subjects.ts:49`. */
+const FEDERATED_PREFIX = "federated";
+
+// ---------------------------------------------------------------------------
+// Parse constructors — fail loud, never fabricate
+// ---------------------------------------------------------------------------
+
+/** Parse a bare principal id. Rejects DIDs, slashes, uppercase, `_`, and `""`. */
+export function parsePrincipalId(s: string): ParseResult<PrincipalId> {
+  if (s.length === 0) return err("empty principal id");
+  if (!PRINCIPAL_ID_RE.test(s)) return err(`principal id "${s}" violates ${String(PRINCIPAL_ID_RE)}`);
+  return ok(s as PrincipalId);
+}
+
+/** Parse a bare stack slug. Rejects `.` (the NATS separator), slashes, and `""`. */
+export function parseStackSlug(s: string): ParseResult<StackSlug> {
+  if (s.length === 0) return err("empty stack slug");
+  if (!STACK_SLUG_RE.test(s)) return err(`stack slug "${s}" violates ${String(STACK_SLUG_RE)}`);
+  return ok(s as StackSlug);
+}
+
+/**
+ * Parse a `{principal}/{stack}` stack id into its two halves.
+ *
+ * **Never fabricates a `default`.** `"andreas"`, `"andreas/"`, `"/default"` and
+ * `""` all fail. Contrast `federation-reconciler.ts:459`, which today resolves
+ * a malformed id to `stack = "default"` and silently mis-addresses the stack.
+ *
+ * Requires **exactly one** `/`. A 3-segment id is rejected rather than
+ * arbitrated: `roster-read.ts:263` splits on the FIRST slash while
+ * `stack-id.ts`'s `stackSlugFromStackId` splits on the LAST. They disagree, so
+ * this codec refuses to pick a winner and fails loud instead.
+ */
+export function parseStackId(s: string): ParseResult<StackScope> {
+  if (s.length === 0) return err("empty stack id");
+
+  const parts = s.split("/");
+  if (parts.length !== 2) {
+    return err(`stack id "${s}" must contain exactly one "/" (got ${String(parts.length - 1)})`);
+  }
+
+  const [rawPrincipal, rawStack] = parts;
+  const principal = parsePrincipalId(rawPrincipal ?? "");
+  if (!principal.ok) return err(`stack id "${s}": ${principal.reason}`);
+
+  const stack = parseStackSlug(rawStack ?? "");
+  if (!stack.ok) return err(`stack id "${s}": ${stack.reason}`);
+
+  return ok({ principal: principal.value, stack: stack.value });
+}
+
+/**
+ * Classify a `did:mf:` identity into exactly one of the three classes.
+ *
+ * TODO(WP-4, cortex#1880) — **the disambiguation decision belongs here.**
+ * Today every class' rule set overlaps every other's:
+ *
+ * - `did:mf:echo` is a legal principal id AND a legal agent id.
+ * - `did:mf:andreas-meta-factory` is additionally a legal `{p}-{s}` stack pair,
+ *   because {@link PRINCIPAL_ID_RE} permits `-`.
+ *
+ * So **no** well-formed DID is uniquely classifiable, and this function returns
+ * `{ ok: false, reason: "ambiguous" }` for all of them rather than guessing.
+ * `review-consumer.ts:1453` guesses today (splits on the first hyphen, assuming
+ * principals contain none) — an assumption `PRINCIPAL_ID_RE` does not enforce.
+ *
+ * When WP-4 picks an encoding (a class prefix, a reserved separator, or a
+ * hyphen ban in one class), amend the predicates below; the signature and every
+ * caller stay unchanged, and `ok:true` becomes reachable.
+ */
+export function parseDid(s: string): ParseResult<PrincipalDid | StackDid | AgentDid> {
+  if (!WIRE_DID_RE.test(s)) return err("malformed");
+
+  const body = s.slice(DID_PREFIX.length);
+
+  const couldBePrincipal = PRINCIPAL_ID_RE.test(body);
+  const couldBeAgent = AGENT_ID_RE.test(body);
+  const couldBeStack = splitsIntoStackPair(body);
+
+  const candidates = [couldBePrincipal, couldBeStack, couldBeAgent].filter(Boolean).length;
+
+  if (candidates === 0) return err("unclassifiable");
+  if (candidates > 1) return err("ambiguous");
+
+  // Unreachable today — retained so WP-4's decision lands as a predicate edit.
+  if (couldBePrincipal) return ok(s as PrincipalDid);
+  if (couldBeStack) return ok(s as StackDid);
+  return ok(s as AgentDid);
+}
+
+/** True when `body` admits at least one `{principal}-{stack}` split. */
+function splitsIntoStackPair(body: string): boolean {
+  for (let i = 1; i < body.length - 1; i += 1) {
+    if (body[i] !== "-") continue;
+    if (PRINCIPAL_ID_RE.test(body.slice(0, i)) && STACK_SLUG_RE.test(body.slice(i + 1))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Parse a `federated.{principal}.{stack}.{...rest}` subject.
+ * Requires the `federated` prefix and at least one trailing segment.
+ */
+export function parseFederatedSubject(
+  s: string,
+): ParseResult<{ scope: StackScope; rest: string[] }> {
+  if (s.length === 0) return err("empty subject");
+
+  const segments = s.split(".");
+  if (segments[0] !== FEDERATED_PREFIX) {
+    return err(`subject "${s}" is not federated (expected "${FEDERATED_PREFIX}." prefix)`);
+  }
+  if (segments.length < 4) {
+    return err(`subject "${s}" must be federated.{principal}.{stack}.{...} (≥1 trailing segment)`);
+  }
+
+  const principal = parsePrincipalId(segments[1] ?? "");
+  if (!principal.ok) return err(`subject "${s}": ${principal.reason}`);
+
+  const stack = parseStackSlug(segments[2] ?? "");
+  if (!stack.ok) return err(`subject "${s}": ${stack.reason}`);
+
+  const rest = segments.slice(3);
+  for (const segment of rest) {
+    if (!SUBJECT_SEGMENT_RE.test(segment)) {
+      return err(`subject "${s}": invalid trailing segment "${segment}"`);
+    }
+  }
+
+  return ok({ scope: { principal: principal.value, stack: stack.value }, rest });
+}
+
+// ---------------------------------------------------------------------------
+// Render constructors — total over branded inputs
+// ---------------------------------------------------------------------------
+
+/** Render the canonical `{principal}/{stack}` literal. */
+export function stackId(scope: StackScope): StackId {
+  return `${scope.principal}/${scope.stack}` as StackId;
+}
+
+/** Render a principal's DID. */
+export function principalDid(p: PrincipalId): PrincipalDid {
+  return `${DID_PREFIX}${p}` as PrincipalDid;
+}
+
+/**
+ * Render a stack's DID as `did:mf:{principal}-{stack}`.
+ *
+ * Throws {@link WireIdentityError} when the naive render violates
+ * {@link WIRE_DID_RE} — reachable today because a trailing-hyphen principal
+ * (`"andreas-"`, legal per {@link PRINCIPAL_ID_RE}) yields `did:mf:andreas--x`,
+ * and consecutive hyphens are forbidden on the wire.
+ *
+ * `cortex.ts:1024` instead collapses `-+` runs, which is **lossy** — it maps two
+ * distinct stacks onto one DID — while `probe-responder.ts:433` does not collapse
+ * at all, so the two minters disagree. Rather than adopt either behaviour, this
+ * refuses to emit an invalid DID. TODO(WP-4, cortex#1880) owns the encoding.
+ */
+export function stackDid(scope: StackScope): StackDid {
+  const did = `${DID_PREFIX}${scope.principal}-${scope.stack}`;
+  if (!WIRE_DID_RE.test(did)) {
+    throw new WireIdentityError(
+      `cannot render a valid stack DID from "${scope.principal}" + "${scope.stack}": ` +
+        `"${did}" violates the wire DID grammar. See TODO(WP-4, cortex#1880).`,
+    );
+  }
+  return did as StackDid;
+}
+
+/**
+ * Render an agent's DID. Validates against today's {@link AGENT_ID_RE} and
+ * throws {@link WireIdentityError} on a rejected id — the mint sites
+ * (`dispatch-source-publisher.ts:203`, `reflex-activation-listener.ts:268`)
+ * perform no validation at all today.
+ */
+export function agentDid(a: string): AgentDid {
+  if (!AGENT_ID_RE.test(a)) {
+    throw new WireIdentityError(`agent id "${a}" violates ${String(AGENT_ID_RE)}`);
+  }
+  const did = `${DID_PREFIX}${a}`;
+  if (!WIRE_DID_RE.test(did)) {
+    throw new WireIdentityError(`agent DID "${did}" violates the wire DID grammar`);
+  }
+  return did as AgentDid;
+}
+
+/**
+ * Render a `federated.{principal}.{stack}.{...segments}` subject.
+ * Throws {@link WireIdentityError} on an empty segment list or any segment that
+ * would corrupt the subject (embedded `.`, a `*`/`>` wildcard, or `""`).
+ */
+export function federatedSubject(scope: StackScope, ...segments: string[]): FederatedSubject {
+  if (segments.length === 0) {
+    throw new WireIdentityError("a federated subject needs ≥1 trailing segment");
+  }
+  for (const segment of segments) {
+    if (!SUBJECT_SEGMENT_RE.test(segment)) {
+      throw new WireIdentityError(`invalid federated subject segment "${segment}"`);
+    }
+  }
+  const tail = segments.join(".");
+  return `${FEDERATED_PREFIX}.${scope.principal}.${scope.stack}.${tail}` as FederatedSubject;
+}

--- a/src/common/wire/index.ts
+++ b/src/common/wire/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Wire-identity primitives (WP-2, cortex#1878).
+ *
+ * The single module that owns every principal / stack / agent identity
+ * transform on the wire. Import from here, not from the file directly.
+ *
+ * No production call site consumes this yet — migration is WP-5 (#1881),
+ * held behind review.
+ */
+
+export {
+  AGENT_ID_RE,
+  agentDid,
+  DID_PREFIX,
+  federatedSubject,
+  parseDid,
+  parseFederatedSubject,
+  parsePrincipalId,
+  parseStackId,
+  parseStackSlug,
+  principalDid,
+  PRINCIPAL_ID_RE,
+  stackDid,
+  stackId,
+  STACK_SLUG_RE,
+  WIRE_DID_RE,
+  WireIdentityError,
+} from "./identity.ts";
+
+export type {
+  AgentDid,
+  FederatedSubject,
+  ParseResult,
+  PrincipalDid,
+  PrincipalId,
+  StackDid,
+  StackId,
+  StackScope,
+  StackSlug,
+} from "./identity.ts";


### PR DESCRIPTION
Closes #1878. Epic #1876, Wave 1. **Purely additive** — 3 new files under `src/common/wire/`, zero call sites migrated, `verify-signed-by-chain.ts` / `identity-registry.ts` untouched.

## Why
`did:mf:` is overloaded across three structurally-indistinguishable identity classes, minted at 8 independent sites and compared with `===`. A `StackDid === PrincipalDid` comparison silently returns `false` and drops presence — the open jc-fold bug. This makes that a **compile error**.

Proved in both directions: removing the `@ts-expect-error` yields `TS2367: types 'StackDid' and 'PrincipalDid' have no overlap`. (An *unused* `@ts-expect-error` is itself an error, so `tsc == 0` only means something with that control run.)

## What it found
The implementer corrected the issue's evidence in eight places, verified against `origin/main`:
- **The ambiguity is 3-way, not 2-way.** `AGENT_ID_RE` fully overlaps `PRINCIPAL_ID_RE`, so `did:mf:echo` is minted as both an agent DID and a principal DID. **No well-formed DID is uniquely classifiable today** — `parseDid` therefore returns `ok:true` for nothing, faithfully, with `TODO(WP-4)`.
- **The two stack-DID minters disagree.** `cortex.ts:1024` collapses hyphen runs (`.replace(/-+/g,"-")`) to satisfy the wire DID pattern — **lossy**, two distinct stacks map to one DID. `probe-responder.ts:433` does not collapse.
- **A prior partial authority conflicts**: `stack-id.ts:26` splits on `lastIndexOf("/")`; `roster-read.ts:263` on `indexOf("/")`. `parseStackId` refuses to arbitrate — requires exactly one `/`, fails loud on `a/b/c`.
- ~12 splice sites, not ~6. Corrections propagated to #1880, #1881, #1884.

## Design
Branded `PrincipalId` / `StackSlug` / `StackId` / `PrincipalDid` / `StackDid` / `AgentDid`. Parse constructors fail loud (`parseStackId` never fabricates a `default` — the #1812 defect made unrepresentable). **Render constructors throw** rather than emit a DID the wire grammar rejects; adopting either minter's behaviour would have decided the encoding, which belongs to #1880. Endorsed on the issue.

## Verification
`bun test src/common/wire/__tests__/identity.test.ts` → **73 pass / 0 fail**. `tsc` 0 · eslint clean · carve-outs PASS. Files changed outside `src/common/wire/`: **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)