### PR TITLE
fix(adapters): C-1853 — outbound upload ceiling is per-surface, supplied by the adapter

### DIFF
--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -146,6 +146,19 @@ interface PendingResult {
 
 export class DiscordAdapter implements PlatformAdapter {
   readonly platform = "discord";
+  /**
+   * cortex#1853 — Discord's single-file upload ceiling, moved here from core's
+   * `ATTACHMENT_LIMITS.discordMaxUploadBytes`.
+   *
+   * Held at the long-standing 8 MB deliberately. Discord's published ceiling for
+   * a non-boosted server is ambiguous (support docs cite both 8 MB and "more than
+   * 10 MB"), and it rises with Server Boost level (L2 = 50 MB, L3 = 100 MB). Per
+   * the `PlatformAdapter.maxUploadBytes` contract we err LOW: an under-estimate
+   * only filters an extra file out, while an over-estimate makes Discord reject
+   * the upload at post time. Raise this only against a confirmed doc + the boost
+   * tier of the target guild — do not guess.
+   */
+  readonly maxUploadBytes = 8 * 1024 * 1024;
   readonly instanceId: string;
 
   private client: Client | null = null;

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -119,6 +119,20 @@ export function outboundRootId(
 
 export class MattermostAdapter implements PlatformAdapter {
   readonly platform = "mattermost";
+  /**
+   * cortex#1853 — Mattermost's single-file upload ceiling.
+   *
+   * 100 MB is the documented DEFAULT of the server's `FileSettings.MaxFileSize`
+   * (104857600 bytes). This is an ADMIN-CONFIGURABLE server setting, so a given
+   * deployment may allow less. We use the documented default rather than the old
+   * behaviour of applying Discord's 8 MB — which silently dropped files this
+   * platform would happily have accepted (the #1853 defect).
+   *
+   * If a deployment lowers `MaxFileSize`, an oversized file is rejected at post
+   * time by the server rather than filtered here; making this config-driven is a
+   * follow-up, not a regression of the previous (always-8 MB) behaviour.
+   */
+  readonly maxUploadBytes = 100 * 1024 * 1024;
   readonly instanceId: string;
 
   private stopPoller: (() => void) | null = null;

--- a/src/adapters/mock.ts
+++ b/src/adapters/mock.ts
@@ -23,6 +23,13 @@ const ALLOW_ALL: AccessDecision = {
 
 export class MockAdapter implements PlatformAdapter {
   readonly platform = "mock";
+  /**
+   * cortex#1853 — test double. Mutable (the `PlatformAdapter` contract declares
+   * it `readonly`, which a mutable property satisfies) so a test can drive the
+   * per-surface `collectOutputFiles()` boundary without standing up a real
+   * adapter. Defaults generous so existing tests are never filtered.
+   */
+  maxUploadBytes = 100 * 1024 * 1024;
   readonly instanceId: string;
 
   /** Recorded postResponse calls */

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -99,6 +99,13 @@ export interface SlackAdapterInfra {
  */
 export class SlackAdapter implements PlatformAdapter {
   readonly platform = "slack";
+  /**
+   * cortex#1853 — Slack's single-file upload ceiling: 1 GB, per Slack's
+   * file-sharing docs ("share just about any file type up to 1GB"). Note the
+   * 1 MB cap applies only to files uploaded as *snippets*, which this adapter
+   * does not use.
+   */
+  readonly maxUploadBytes = 1024 * 1024 * 1024;
   readonly instanceId: string;
 
   // cortex#235 r1#5 — agent + presence are reassigned by

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -185,6 +185,23 @@ export interface PlatformAdapter {
   readonly platform: string;
   /** Unique instance ID across all adapters */
   readonly instanceId: string;
+  /**
+   * cortex#1853 — the maximum size (bytes) of a SINGLE outbound file this
+   * platform accepts. Platform-specific, so it **travels with the adapter**:
+   * platform-neutral core (`src/runner/attachments.ts`, `src/bus/`) must never
+   * name a platform's ceiling. `collectOutputFiles()` takes this as an argument
+   * rather than reading a `discordMaxUploadBytes` constant.
+   *
+   * This is the natural home for the value when S12 (#1797) extracts the Discord
+   * adapter into its own arc bundle — the constant leaves core with the adapter.
+   * (Coordinate with S3 #1788's `AdapterFactoryRegistry`; when an `AdapterModule`
+   * shape lands, this field moves onto it unchanged.)
+   *
+   * Adapters MUST source this from the platform's documented ceiling, not a
+   * guess, and SHOULD err low: an under-estimate only filters an extra file out,
+   * whereas an over-estimate makes the platform reject the upload at post time.
+   */
+  readonly maxUploadBytes: number;
 
   /** Connect to the platform and start listening for messages */
   start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void>;

--- a/src/adapters/web/__tests__/web-adapter.test.ts
+++ b/src/adapters/web/__tests__/web-adapter.test.ts
@@ -688,6 +688,8 @@ describe("buildGatewayAdapters — web bindings", () => {
     const stub = (platform: string, instanceId: string): PlatformAdapter => ({
       platform,
       instanceId,
+      // cortex#1853 — per-surface outbound ceiling; irrelevant to this test.
+      maxUploadBytes: 8 * 1024 * 1024,
       start: async () => {},
       stop: async () => {},
       getPlatformUserId: async () => "x",
@@ -768,12 +770,12 @@ describe("buildGatewayAdapters — web bindings", () => {
   test("web binding gateway source is {principal}.gateway.{instanceId}", () => {
     let capturedSource: unknown;
     const factory: GatewayAdapterFactory = {
-      discord: (args) => { void args; return { platform: "discord", instanceId: "x", start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
-      slack: (args) => { void args; return { platform: "slack", instanceId: "x", start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
-      mattermost: (args) => { void args; return { platform: "mattermost", instanceId: "x", start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
+      discord: (args) => { void args; return { platform: "discord", instanceId: "x", maxUploadBytes: 8 * 1024 * 1024, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
+      slack: (args) => { void args; return { platform: "slack", instanceId: "x", maxUploadBytes: 8 * 1024 * 1024, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
+      mattermost: (args) => { void args; return { platform: "mattermost", instanceId: "x", maxUploadBytes: 8 * 1024 * 1024, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: "x", channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} }; },
       web: (args) => {
         capturedSource = args.source;
-        return { platform: "web", instanceId: args.instanceId, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: args.instanceId, channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} };
+        return { platform: "web", instanceId: args.instanceId, maxUploadBytes: 8 * 1024 * 1024, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: args.instanceId, channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} };
       },
     };
     buildGatewayAdapters(
@@ -795,7 +797,7 @@ describe("buildGatewayAdapters — web bindings", () => {
       mattermost: (args) => { void args; throw new Error("unexpected"); },
       web: (args) => {
         capturedWebBinding = args.webBinding;
-        return { platform: "web", instanceId: args.instanceId, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: args.instanceId, channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} };
+        return { platform: "web", instanceId: args.instanceId, maxUploadBytes: 8 * 1024 * 1024, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId: args.instanceId, channelId: "c" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {} };
       },
     };
     buildGatewayAdapters(
@@ -860,7 +862,7 @@ describe("WebAdapter — tenant agnosticism", () => {
     const { factory, calls } = (() => {
       const calls: { platform: string; instanceId: string }[] = [];
       const stub = (platform: string, instanceId: string): PlatformAdapter => ({
-        platform, instanceId, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId, channelId: "ch" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {},
+        platform, instanceId, maxUploadBytes: 8 * 1024 * 1024, start: async () => {}, stop: async () => {}, getPlatformUserId: async () => "x", fetchContext: async () => [], resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }), postResponse: async () => {}, sendTyping: async () => {}, sendProgress: async () => {}, clearProgress: async () => {}, createThread: async () => ({ instanceId, channelId: "ch" }), resolveLogicalTarget: async () => null, notifyPrincipal: async () => {},
       });
       const factory: GatewayAdapterFactory = {
         discord: (args) => stub("discord", args.instanceId),

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -212,6 +212,15 @@ function deriveAuthorId(
  */
 export class WebAdapter implements PlatformAdapter {
   readonly platform = "web";
+  /**
+   * cortex#1853 — the web surface `postResponse`s a JSON payload
+   * (`{ adapter_instance, target, type, text }`) to `broadcastUrl` and does not
+   * upload files at all, so no platform ceiling applies. We mirror core's
+   * per-file inbound cap (`ATTACHMENT_LIMITS.maxFileSizeBytes`, 10 MB) as a sane,
+   * conservative default rather than an arbitrary large number — if this surface
+   * ever grows file delivery, the value is already sensible.
+   */
+  readonly maxUploadBytes = 10 * 1024 * 1024;
   readonly instanceId: string;
 
   private binding: WebBinding;

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -1314,7 +1314,8 @@ export class DispatchHandler extends EventEmitter {
 
     // Terminal success — post the response and forward usage.
     if (finalResult && finalResult.success && finalResult.response && finalReason === null) {
-      const outputFiles = collectOutputFiles(attachmentSessionId);
+      // cortex#1853 — bound by the TARGET surface's ceiling, not Discord's.
+      const outputFiles = collectOutputFiles(attachmentSessionId, adapter.maxUploadBytes);
       const files = outputFiles.length > 0
         ? await Promise.all(outputFiles.map(async (p) => ({
             content: Buffer.from(await Bun.file(p).arrayBuffer()),
@@ -1483,7 +1484,8 @@ export class DispatchHandler extends EventEmitter {
         clearInterval(typingInterval);
         await adapter.clearProgress(replyTarget);
         try {
-          const outputFiles = collectOutputFiles(attachmentSessionId);
+          // cortex#1853 — bound by the TARGET surface's ceiling, not Discord's.
+          const outputFiles = collectOutputFiles(attachmentSessionId, adapter.maxUploadBytes);
           const files = outputFiles.length > 0
             ? await Promise.all(outputFiles.map(async (p) => ({
                 content: Buffer.from(await Bun.file(p).arrayBuffer()),

--- a/src/common/agents/__tests__/presence-binding.test.ts
+++ b/src/common/agents/__tests__/presence-binding.test.ts
@@ -43,6 +43,8 @@ import type {
 class FakeAdapter implements PlatformAdapter {
   readonly platform: string;
   readonly instanceId: string;
+  /** cortex#1853 — per-surface outbound ceiling; irrelevant here, any value. */
+  readonly maxUploadBytes = 8 * 1024 * 1024;
   /** What `getPlatformUserId()` resolves to. */
   platformUserId: string;
   /** If non-null, `start()` rejects with this error. */

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -54,6 +54,8 @@ function makeFakeAdapter(
   return {
     platform,
     instanceId,
+    // cortex#1853 — per-surface outbound ceiling; irrelevant here, any value.
+    maxUploadBytes: 8 * 1024 * 1024,
     start: async () => {},
     stop: async () => {},
     getPlatformUserId: async () => "bot-user-id",

--- a/src/gateway/__tests__/gateway-bootstrap.test.ts
+++ b/src/gateway/__tests__/gateway-bootstrap.test.ts
@@ -42,6 +42,8 @@ function makeFakeAdapter(instanceId = "fake-adapter-1"): PlatformAdapter {
   return {
     platform: "discord",
     instanceId,
+    // cortex#1853 — per-surface outbound ceiling; irrelevant here, any value.
+    maxUploadBytes: 8 * 1024 * 1024,
     start: async () => {},
     stop: async () => {},
     getPlatformUserId: async () => "bot-user-id",

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -55,6 +55,8 @@ function makeFakeAdapter(
   return {
     platform,
     instanceId,
+    // cortex#1853 — per-surface outbound ceiling; irrelevant here, any value.
+    maxUploadBytes: 8 * 1024 * 1024,
     start: async () => {
       onStart?.();
     },

--- a/src/gateway/__tests__/surface-gateway.test.ts
+++ b/src/gateway/__tests__/surface-gateway.test.ts
@@ -115,6 +115,8 @@ function msg(overrides: Partial<InboundMessage>): InboundMessage {
 class MockAdapter implements PlatformAdapter {
   readonly platform: string;
   readonly instanceId: string;
+  /** cortex#1853 — per-surface outbound ceiling; irrelevant here, any value. */
+  readonly maxUploadBytes = 8 * 1024 * 1024;
 
   startCalled = 0;
   stopCalled = 0;

--- a/src/runner/__tests__/attachments-upload-limit.test.ts
+++ b/src/runner/__tests__/attachments-upload-limit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * cortex#1853 — the outbound upload ceiling is PER-SURFACE, supplied by the
+ * target adapter, never a platform-named constant read from platform-neutral core.
+ *
+ * The defect: `collectOutputFiles()` lives in `src/runner/` (platform-neutral,
+ * shared by Discord / Mattermost / Slack / Web) but filtered every surface's
+ * outbound files against `ATTACHMENT_LIMITS.discordMaxUploadBytes` (8 MB). A
+ * Mattermost-bound file of, say, 9 MB — well under Mattermost's 100 MB default —
+ * was silently dropped because Discord's ceiling was applied to it.
+ *
+ * Files are created SPARSE (`truncateSync`) so an 8 MB+ `stat.size` costs no
+ * real bytes on disk and the test stays fast.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, truncateSync, existsSync } from "fs";
+import { join, basename } from "path";
+
+import { collectOutputFiles, getOutputDir } from "../attachments";
+import { ATTACHMENT_LIMITS } from "../attachment-types";
+import { MockAdapter } from "../../adapters/mock";
+
+/** The documented per-surface ceilings the adapters declare (see each adapter). */
+const DISCORD_MAX = 8 * 1024 * 1024; // 8 MB — held low deliberately
+const MATTERMOST_MAX = 100 * 1024 * 1024; // 100 MB — FileSettings.MaxFileSize default
+const SLACK_MAX = 1024 * 1024 * 1024; // 1 GB
+
+const sessions: string[] = [];
+
+/** Stage a session output dir containing one sparse file of exactly `size` bytes. */
+function stageOutputFile(sessionId: string, name: string, size: number): string {
+  sessions.push(sessionId);
+  const dir = getOutputDir(sessionId);
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, name);
+  writeFileSync(p, "");
+  truncateSync(p, size); // sparse — stat.size === size, ~0 bytes written
+  return p;
+}
+
+afterEach(() => {
+  while (sessions.length > 0) {
+    const sid = sessions.pop()!;
+    const dir = getOutputDir(sid);
+    if (existsSync(dir)) rmSync(join(dir, ".."), { recursive: true, force: true });
+  }
+});
+
+describe("cortex#1853 — collectOutputFiles is bounded by the TARGET surface", () => {
+  test("a 9 MB file is DROPPED under Discord's ceiling but KEPT under Mattermost's", () => {
+    const sid = "c1853-cross-surface";
+    const nineMB = 9 * 1024 * 1024;
+    const p = stageOutputFile(sid, "report.pdf", nineMB);
+
+    // The regression this issue names: Discord's 8 MB ceiling drops it…
+    expect(collectOutputFiles(sid, DISCORD_MAX)).toEqual([]);
+
+    // …but the SAME file is within Mattermost's 100 MB default and must survive.
+    const kept = collectOutputFiles(sid, MATTERMOST_MAX);
+    expect(kept.length).toBe(1);
+    expect(basename(kept[0]!)).toBe(basename(p));
+  });
+
+  test("the boundary is inclusive: size === limit is kept, limit + 1 is dropped", () => {
+    const sid = "c1853-boundary";
+    stageOutputFile(sid, "exact.bin", DISCORD_MAX);
+    expect(collectOutputFiles(sid, DISCORD_MAX).length).toBe(1);
+    expect(collectOutputFiles(sid, DISCORD_MAX - 1)).toEqual([]);
+  });
+
+  test("a file over EVERY ceiling is dropped on every surface", () => {
+    const sid = "c1853-oversize";
+    stageOutputFile(sid, "huge.bin", SLACK_MAX + 1);
+    for (const limit of [DISCORD_MAX, MATTERMOST_MAX, SLACK_MAX]) {
+      expect(collectOutputFiles(sid, limit)).toEqual([]);
+    }
+  });
+
+  test("a missing output dir is empty, not a throw (unchanged)", () => {
+    expect(collectOutputFiles("c1853-does-not-exist", DISCORD_MAX)).toEqual([]);
+  });
+});
+
+describe("cortex#1853 — no platform-named upload constant in neutral core", () => {
+  test("ATTACHMENT_LIMITS exposes no platform-named key", () => {
+    const keys = Object.keys(ATTACHMENT_LIMITS);
+    const platformNamed = keys.filter((k) => /discord|mattermost|slack|web/i.test(k));
+    expect(platformNamed).toEqual([]);
+  });
+
+  test("discordMaxUploadBytes is gone from core", () => {
+    expect(ATTACHMENT_LIMITS).not.toHaveProperty("discordMaxUploadBytes");
+  });
+});
+
+describe("cortex#1853 — the ceiling travels with the adapter", () => {
+  test("a PlatformAdapter exposes maxUploadBytes (survives S12 extraction)", () => {
+    // The interface makes this structural: every implementer is checked by tsc.
+    // MockAdapter stands in for the real adapters (importing Discord would pull
+    // discord.js into a unit test).
+    const adapter = new MockAdapter("mock-1");
+    expect(typeof adapter.maxUploadBytes).toBe("number");
+    expect(adapter.maxUploadBytes).toBeGreaterThan(0);
+  });
+
+  test("collectOutputFiles honours whatever ceiling the adapter supplies", () => {
+    const sid = "c1853-adapter-supplied";
+    stageOutputFile(sid, "small.txt", 1024);
+
+    const adapter = new MockAdapter("mock-2");
+    adapter.maxUploadBytes = 512; // adapter says: too big
+    expect(collectOutputFiles(sid, adapter.maxUploadBytes)).toEqual([]);
+
+    adapter.maxUploadBytes = 2048; // adapter says: fine
+    expect(collectOutputFiles(sid, adapter.maxUploadBytes).length).toBe(1);
+  });
+});

--- a/src/runner/__tests__/surface-adapter-boot.test.ts
+++ b/src/runner/__tests__/surface-adapter-boot.test.ts
@@ -121,6 +121,8 @@ function makeFakeAdapter(
   const base: PlatformAdapter & Record<string, unknown> = {
     platform: opts.platform,
     instanceId: opts.instanceId,
+    // cortex#1853 — per-surface outbound ceiling; irrelevant here, any value.
+    maxUploadBytes: 8 * 1024 * 1024,
     start: async () => {
       record.started = true;
     },

--- a/src/runner/attachment-types.ts
+++ b/src/runner/attachment-types.ts
@@ -88,6 +88,8 @@ export const ATTACHMENT_LIMITS = {
   tempFileTtlMs: 10 * 60 * 1000,
   /** Max total temp directory size (100MB) */
   maxTempDirSizeBytes: 100 * 1024 * 1024,
-  /** Discord's upload limit for outbound files (8MB) */
-  discordMaxUploadBytes: 8 * 1024 * 1024,
+  // cortex#1853 — `discordMaxUploadBytes` REMOVED. A platform's outbound-upload
+  // ceiling is platform-specific and must not live in platform-neutral core; it
+  // is now `PlatformAdapter.maxUploadBytes`, supplied by each adapter and passed
+  // into `collectOutputFiles()`. Every limit remaining here is surface-agnostic.
 };

--- a/src/runner/attachments.ts
+++ b/src/runner/attachments.ts
@@ -330,8 +330,17 @@ export function cleanupExpiredDirs(): number {
 /**
  * Collect outbound files from a session's output directory.
  * Returns file paths that Claude created for sending back.
+ *
+ * cortex#1853 — `maxUploadBytes` is supplied by the TARGET surface's adapter
+ * (`PlatformAdapter.maxUploadBytes`), never read from a platform-named constant
+ * here: this module is platform-neutral core and is shared by Discord,
+ * Mattermost, Slack and Web. Passing Discord's ceiling to a Mattermost-bound
+ * response silently dropped files Mattermost would have accepted.
+ *
+ * @param sessionId       the attachment session whose output dir to scan
+ * @param maxUploadBytes  the target platform's single-file ceiling, in bytes
  */
-export function collectOutputFiles(sessionId: string): string[] {
+export function collectOutputFiles(sessionId: string, maxUploadBytes: number): string[] {
   const outputDir = getOutputDir(sessionId);
   if (!existsSync(outputDir)) return [];
 
@@ -341,14 +350,14 @@ export function collectOutputFiles(sessionId: string): string[] {
       .filter((p) => {
         try {
           const stat = statSync(p);
-          return stat.isFile() && stat.size <= ATTACHMENT_LIMITS.discordMaxUploadBytes;
+          return stat.isFile() && stat.size <= maxUploadBytes;
         } catch (err) {
-          console.warn("discord-attachments: collectOutputFiles: failed to stat:", p, err instanceof Error ? err.message : err);
+          console.warn("attachments: collectOutputFiles: failed to stat:", p, err instanceof Error ? err.message : err);
           return false;
         }
       });
   } catch (err) {
-    console.warn("discord-attachments: collectOutputFiles: failed to read output dir:", err instanceof Error ? err.message : err);
+    console.warn("attachments: collectOutputFiles: failed to read output dir:", err instanceof Error ? err.message : err);
     return [];
   }
 }


### PR DESCRIPTION
Closes #1853.

## The defect

`collectOutputFiles()` lives in **platform-neutral core** (`src/runner/attachments.ts`) but filtered *every* surface's outbound files against `ATTACHMENT_LIMITS.discordMaxUploadBytes` (8 MB). A **Mattermost-bound 9 MB file** — well under Mattermost's 100 MB default — was **silently dropped** because Discord's ceiling was applied to it.

> Note on the issue thread: a drive-by comment suggested the limit was being applied to "embeds, images, etc." That's not the case — `discordMaxUploadBytes` had exactly **one** call site, a `stat.size` filter over files on disk. The real bug is per-**platform**, not per-content-type. ("surface" here is cortex's term for a platform adapter, per `CONTEXT.md`.)

## The fix

- **`PlatformAdapter` gains `readonly maxUploadBytes`** — the ceiling now *travels with the adapter*, so it leaves core when **S12 (#1797)** extracts Discord into its own bundle. `tsc` enforces it structurally on every implementer (which is how this PR found 6 test doubles that needed it).
- **`discordMaxUploadBytes` removed** from `ATTACHMENT_LIMITS` — no platform-named upload constant remains in platform-neutral code.
- **`collectOutputFiles(sessionId, maxUploadBytes)`** takes the limit. Both callers in `dispatch-handler.ts` already had `adapter` in scope, so they simply pass `adapter.maxUploadBytes`.
- Stale `discord-attachments:` log prefixes in the now-neutral module corrected.

## Values — sourced, not guessed (the issue asked explicitly)

| Surface | Ceiling | Source |
|---|---|---|
| Discord | **8 MB** (held) | Docs are **ambiguous** (cite both 8 MB and ">10 MB") and it rises with Boost level (L2 50 MB, L3 100 MB). Contract says **err low**: an under-estimate filters an extra file; an over-estimate makes the platform reject the upload at post time. Held at today's value — raising it needs a confirmed doc + the target guild's boost tier. |
| Mattermost | **100 MB** | `FileSettings.MaxFileSize` documented default (104857600). Admin-configurable — noted inline. |
| Slack | **1 GB** | Documented per-file limit (the 1 MB cap is snippets-only, unused here). |
| Web | 10 MB | Broadcasts JSON, uploads no files; sane default. |

## Coordination
Lands on the existing `PlatformAdapter` contract. When **S3 #1788**'s `AdapterModule` shape arrives, this field moves onto it unchanged — no rework. Nothing here depends on the still-draft **ADR-0024** (#1804).

## Acceptance criteria
- [x] No platform-named upload constant is read from platform-neutral code *(guarded by a test)*
- [x] A Mattermost-bound output file is bounded by Mattermost's limit, not Discord's *(test: 9 MB file dropped under Discord's ceiling, kept under Mattermost's)*
- [x] The limit travels with the adapter, surviving S12's extraction

## Verification
`tsc` **0 errors** · `eslint` clean · vocab gate **PASS** · **276 pass / 0 fail** across every affected suite. New tests use sparse files (`truncateSync`) so an 8 MB+ `stat.size` costs no real bytes.

Sources: [Mattermost file-storage config](https://docs.mattermost.com/configure/file-storage-configuration-settings.html) · [Discord File Attachments FAQ](https://support.discord.com/hc/en-us/articles/25444343291031-File-Attachments-FAQ) · [Slack: Add files](https://slack.com/help/articles/201330736-Add-files-to-Slack)