### PR TITLE
feat(adapters): SurfacePluginRegistry — platform-keyed registry for adapters and renderers (#1788)

### DIFF
--- a/src/adapters/__tests__/registry.test.ts
+++ b/src/adapters/__tests__/registry.test.ts
@@ -1,0 +1,208 @@
+/**
+ * cortex#1788 (S3, ADR-0024 D5) — `SurfacePluginRegistry` + in-tree plugin
+ * descriptor tests.
+ *
+ * `buildGatewayAdapters` (`src/gateway/__tests__/gateway-adapters.test.ts`)
+ * and `wireSurfaceAdapters` (`src/runner/__tests__/surface-adapter-boot.test.ts`)
+ * already exercise construction END-TO-END through these plugins. This file
+ * pins the registry primitive itself — register/get/list, duplicate-id
+ * rejection, and the SHAPE of each in-tree plugin descriptor (id, platform/
+ * rendererKind, demuxKey, secretFields, groupBindings presence) so a future
+ * change to any one plugin's metadata fails a fast, targeted test instead of
+ * only showing up as a construction-behavior regression three layers away.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  SurfacePluginRegistry,
+  createDefaultSurfacePluginRegistry,
+  registryFromFactory,
+  registryToLegacyFactory,
+  type AdapterPlugin,
+  type RendererPlugin,
+} from "../registry";
+import { discordAdapterPlugin } from "../discord/plugin";
+import { slackAdapterPlugin } from "../slack/plugin";
+import { mattermostAdapterPlugin } from "../mattermost/plugin";
+import { webAdapterPlugin } from "../web/plugin";
+
+function makeStubAdapterPlugin(id: string): AdapterPlugin {
+  return {
+    kind: "adapter",
+    id,
+    platform: id,
+    bindingSchema: undefined,
+    secretFields: [],
+    demuxKey: () => id,
+    buildGatewayConstructArgs: (_group, base) => ({ instanceId: base.instanceId }),
+    createAdapter: () => {
+      throw new Error("stub — never constructed in this test");
+    },
+  };
+}
+
+function makeStubRendererPlugin(id: string): RendererPlugin {
+  return {
+    kind: "renderer",
+    id,
+    rendererKind: id,
+    configSchema: undefined,
+    createRenderer: () => {
+      throw new Error("stub — never constructed in this test");
+    },
+  };
+}
+
+describe("SurfacePluginRegistry", () => {
+  test("registers and retrieves an adapter plugin by id", () => {
+    const registry = new SurfacePluginRegistry();
+    const plugin = makeStubAdapterPlugin("fake-platform");
+    registry.registerAdapter(plugin);
+    expect(registry.getAdapter("fake-platform")).toBe(plugin);
+    expect(registry.getAdapter("nonexistent")).toBeUndefined();
+  });
+
+  test("registers and retrieves a renderer plugin by id", () => {
+    const registry = new SurfacePluginRegistry();
+    const plugin = makeStubRendererPlugin("fake-renderer");
+    registry.registerRenderer(plugin);
+    expect(registry.getRenderer("fake-renderer")).toBe(plugin);
+    expect(registry.getRenderer("nonexistent")).toBeUndefined();
+  });
+
+  test("adapter and renderer namespaces are independent — same id in both kinds does not collide", () => {
+    const registry = new SurfacePluginRegistry();
+    registry.registerAdapter(makeStubAdapterPlugin("dashboard"));
+    registry.registerRenderer(makeStubRendererPlugin("dashboard"));
+    expect(registry.getAdapter("dashboard")?.kind).toBe("adapter");
+    expect(registry.getRenderer("dashboard")?.kind).toBe("renderer");
+  });
+
+  test("registering a duplicate adapter id throws", () => {
+    const registry = new SurfacePluginRegistry();
+    registry.registerAdapter(makeStubAdapterPlugin("dup"));
+    expect(() => registry.registerAdapter(makeStubAdapterPlugin("dup"))).toThrow(/already registered/);
+  });
+
+  test("registering a duplicate renderer id throws", () => {
+    const registry = new SurfacePluginRegistry();
+    registry.registerRenderer(makeStubRendererPlugin("dup"));
+    expect(() => registry.registerRenderer(makeStubRendererPlugin("dup"))).toThrow(/already registered/);
+  });
+
+  test("listAdapters/listRenderers return insertion order", () => {
+    const registry = new SurfacePluginRegistry();
+    registry.registerAdapter(makeStubAdapterPlugin("a"));
+    registry.registerAdapter(makeStubAdapterPlugin("b"));
+    registry.registerRenderer(makeStubRendererPlugin("x"));
+    registry.registerRenderer(makeStubRendererPlugin("y"));
+    expect(registry.listAdapters().map((p) => p.id)).toEqual(["a", "b"]);
+    expect(registry.listRenderers().map((p) => p.id)).toEqual(["x", "y"]);
+  });
+});
+
+describe("createDefaultSurfacePluginRegistry", () => {
+  test("registers exactly the 4 in-tree adapters, discord→slack→mattermost→web", () => {
+    const registry = createDefaultSurfacePluginRegistry();
+    expect(registry.listAdapters().map((p) => p.id)).toEqual([
+      "discord",
+      "slack",
+      "mattermost",
+      "web",
+    ]);
+  });
+
+  test("registers exactly the 2 in-tree renderers, dashboard→pagerduty", () => {
+    const registry = createDefaultSurfacePluginRegistry();
+    expect(registry.listRenderers().map((p) => p.id)).toEqual(["dashboard", "pagerduty"]);
+  });
+
+  test("does NOT register cli-tail or webhook-out (S6 owns shipping them as bundles)", () => {
+    const registry = createDefaultSurfacePluginRegistry();
+    expect(registry.getRenderer("cli-tail")).toBeUndefined();
+    expect(registry.getRenderer("webhook-out")).toBeUndefined();
+  });
+});
+
+describe("in-tree AdapterPlugin descriptors — shape", () => {
+  test("discord: platform id, token-field secret, groupBindings present (token-grouping)", () => {
+    expect(discordAdapterPlugin.platform).toBe("discord");
+    expect(discordAdapterPlugin.id).toBe("discord");
+    expect(discordAdapterPlugin.secretFields).toEqual(["token"]);
+    expect(typeof discordAdapterPlugin.groupBindings).toBe("function");
+  });
+
+  test("discord: demuxKey falls back to guildId (ungrouped spec-completeness path)", () => {
+    expect(discordAdapterPlugin.demuxKey({ guildId: "123" })).toBe("123");
+    expect(discordAdapterPlugin.demuxKey({})).toBe("");
+  });
+
+  test("discord: groupBindings groups same-token bindings, one group per distinct token+stack", () => {
+    const groups = discordAdapterPlugin.groupBindings!([
+      { agent: "juniper", stack: "jc/default", binding: { token: "tok-a", guildId: "111" } },
+      { agent: "juniper", stack: "jc/default", binding: { token: "tok-a", guildId: "222" } },
+      { agent: "vega", stack: "andreas/research", binding: { token: "tok-b", guildId: "333" } },
+    ]);
+    expect(groups.length).toBe(2);
+    const tokenAGroup = groups.find((g) => g.entries.length === 2);
+    expect(tokenAGroup?.entries.map((e) => e.binding.guildId)).toEqual(["111", "222"]);
+  });
+
+  test("slack: platform id, botToken+appToken secrets, no groupBindings (one adapter per binding)", () => {
+    expect(slackAdapterPlugin.platform).toBe("slack");
+    expect(slackAdapterPlugin.secretFields).toEqual(["botToken", "appToken"]);
+    expect(slackAdapterPlugin.groupBindings).toBeUndefined();
+    expect(slackAdapterPlugin.demuxKey({ workspaceId: "T0123" })).toBe("T0123");
+  });
+
+  test("mattermost: platform id, apiToken secret, demuxKey falls back to <unset>", () => {
+    expect(mattermostAdapterPlugin.platform).toBe("mattermost");
+    expect(mattermostAdapterPlugin.secretFields).toEqual(["apiToken"]);
+    expect(mattermostAdapterPlugin.demuxKey({ apiUrl: "https://mm.example.com" })).toBe(
+      "https://mm.example.com",
+    );
+    expect(mattermostAdapterPlugin.demuxKey({})).toBe("<unset>");
+  });
+
+  test("web: platform id, no secrets (CF Access at the edge, not a bot token)", () => {
+    expect(webAdapterPlugin.platform).toBe("web");
+    expect(webAdapterPlugin.secretFields).toEqual([]);
+    expect(webAdapterPlugin.demuxKey({ instanceId: "acme" })).toBe("acme");
+  });
+});
+
+describe("registryFromFactory / registryToLegacyFactory — round trip", () => {
+  test("registryFromFactory delegates each platform's createAdapter to the matching legacy method", () => {
+    const calls: string[] = [];
+    const stubAdapter = { platform: "x", instanceId: "y" } as never;
+    const registry = registryFromFactory({
+      discord: () => { calls.push("discord"); return stubAdapter; },
+      slack: () => { calls.push("slack"); return stubAdapter; },
+      mattermost: () => { calls.push("mattermost"); return stubAdapter; },
+      web: () => { calls.push("web"); return stubAdapter; },
+    });
+    registry.getAdapter("discord")!.createAdapter({});
+    registry.getAdapter("slack")!.createAdapter({});
+    registry.getAdapter("mattermost")!.createAdapter({});
+    registry.getAdapter("web")!.createAdapter({});
+    expect(calls).toEqual(["discord", "slack", "mattermost", "web"]);
+  });
+
+  test("registryToLegacyFactory routes each legacy method to the matching registry entry", () => {
+    const registry = new SurfacePluginRegistry();
+    const calls: string[] = [];
+    const stubAdapter = { platform: "x", instanceId: "y" } as never;
+    for (const id of ["discord", "slack", "mattermost", "web"]) {
+      registry.registerAdapter({
+        ...makeStubAdapterPlugin(id),
+        createAdapter: () => { calls.push(id); return stubAdapter; },
+      });
+    }
+    const factory = registryToLegacyFactory(registry);
+    factory.discord({});
+    factory.slack({});
+    factory.mattermost({});
+    factory.web({});
+    expect(calls).toEqual(["discord", "slack", "mattermost", "web"]);
+  });
+});

--- a/src/adapters/discord/plugin.ts
+++ b/src/adapters/discord/plugin.ts
@@ -1,0 +1,119 @@
+/**
+ * cortex#1788 (S3, ADR-0024 D5) — Discord `AdapterPlugin`.
+ *
+ * Carries discord's platform id, its binding→demux-key rule, its
+ * token-grouping rule (design-pluggable-adapters.md §3.4 — "no discord
+ * special-case survives in the generic loop"; it lives HERE instead of in
+ * `buildGatewayAdapters`), the field that must clear the cortex#1209
+ * unresolved-placeholder guard, and the construction function itself.
+ * `createAdapter`'s body is `defaultGatewayAdapterFactory.discord`'s
+ * pre-registry body (`src/gateway/gateway-adapters.ts`, GW.a.3b.2b /
+ * S9-cortex#1523), relocated verbatim — behavior is UNCHANGED, only the home
+ * moved. `gateway-adapters.ts` keeps a thin back-compat
+ * `defaultGatewayAdapterFactory` shim delegating here.
+ */
+
+import { DiscordAdapter } from "./index";
+import {
+  DiscordPresenceSchema,
+  type DiscordPresence,
+  type Agent,
+} from "../../common/types/cortex-config";
+import type { SystemEventSource } from "../../bus/system-events";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../../common/policy";
+import type {
+  AdapterPlugin,
+  BindingGroup,
+  GatewayConstructBase,
+} from "../registry";
+import { resolveFactoryAgent, stringBindingField } from "../plugin-support";
+import { groupDiscordBindingsByToken } from "../../gateway/discord-token-groups";
+
+/**
+ * Construction args `createAdapter` accepts — the same shape
+ * `defaultGatewayAdapterFactory.discord` accepted pre-registry
+ * (`DiscordFactoryArgs`, `src/gateway/gateway-adapters.ts`), redeclared here
+ * so this module has no compile-time dependency on `gateway-adapters.ts`.
+ */
+interface DiscordCreateArgs {
+  instanceId: string;
+  source: SystemEventSource | undefined;
+  presence: DiscordPresence;
+  runtime: MyelinRuntime | undefined;
+  allowedGuildIds: ReadonlySet<string>;
+  presenceByGuildId: ReadonlyMap<string, DiscordPresence>;
+  agent?: Agent;
+  principal?: Record<string, unknown>;
+  policyEngine?: PolicyEngine;
+  policyLookup?: PlatformPrincipalIndex;
+  policyRegistry?: PrincipalRegistry;
+  trustedBotIds?: ReadonlySet<string>;
+  surfaceSubjects?: string[];
+  surfaceFallbackChannelId?: string;
+}
+
+export const discordAdapterPlugin: AdapterPlugin = {
+  kind: "adapter",
+  id: "discord",
+  platform: "discord",
+  // Nearest available schema — S4 decides whether SurfacesSchema composes
+  // from this or a dedicated looser binding schema. Inert in this slice.
+  bindingSchema: DiscordPresenceSchema,
+  secretFields: ["token"],
+  // Used only as the ungrouped-fallback demux key; `groupBindings` below
+  // always runs for discord, so this is a spec-completeness fallback, not a
+  // live code path today.
+  demuxKey: (binding) => stringBindingField(binding, "guildId"),
+  // Discord delivers every guild event for a bot token over ONE gateway
+  // session — bindings are token-keyed, not guild-keyed
+  // (`gateway-adapters.ts` GW.a.3b.2b module doc). This is the only in-tree
+  // adapter with non-default grouping.
+  groupBindings: (entries) =>
+    groupDiscordBindingsByToken(
+      entries as unknown as Parameters<typeof groupDiscordBindingsByToken>[0],
+    ),
+  buildGatewayConstructArgs: (group: BindingGroup, base: GatewayConstructBase) => {
+    const presences = group.entries.map((entry) => DiscordPresenceSchema.parse(entry.binding));
+    const presenceByGuildId = new Map(presences.map((p) => [p.guildId, p] as const));
+    const allowedGuildIds = new Set(presenceByGuildId.keys());
+    return {
+      instanceId: base.instanceId,
+      source: base.source,
+      // The FIRST entry's binding — matches the pre-registry loop's
+      // `binding: firstBinding` (forwarded for observability/test
+      // assertions only; `presence` below is what construction consumes).
+      binding: group.entries[0]?.binding,
+      runtime: base.runtime,
+      presence: presences[0],
+      allowedGuildIds,
+      presenceByGuildId,
+    };
+  },
+  createAdapter: (args) => {
+    const a = args as unknown as DiscordCreateArgs;
+    const {
+      instanceId, source, presence, runtime, allowedGuildIds, presenceByGuildId,
+      principal, policyEngine, policyLookup, policyRegistry,
+      trustedBotIds, surfaceSubjects, surfaceFallbackChannelId,
+    } = a;
+    return new DiscordAdapter(
+      resolveFactoryAgent(a, { discord: presence }),
+      presence,
+      {
+        instanceId,
+        principal: principal ?? {},
+        ...(runtime !== undefined && { runtime }),
+        ...(source !== undefined && { systemEventSource: source }),
+        allowedGuildIds,
+        presenceByGuildId,
+        ...(trustedBotIds !== undefined && { trustedBotIds }),
+        ...(policyEngine !== undefined && { policyEngine }),
+        ...(policyLookup !== undefined && { policyLookup }),
+        ...(policyRegistry !== undefined && { policyRegistry }),
+        ...(surfaceSubjects !== undefined && { surfaceSubjects }),
+        ...(surfaceFallbackChannelId !== undefined && { surfaceFallbackChannelId }),
+      },
+    );
+  },
+};

--- a/src/adapters/mattermost/plugin.ts
+++ b/src/adapters/mattermost/plugin.ts
@@ -1,0 +1,75 @@
+/**
+ * cortex#1788 (S3, ADR-0024 D5) — Mattermost `AdapterPlugin`.
+ *
+ * `createAdapter`'s body is `defaultGatewayAdapterFactory.mattermost`'s
+ * pre-registry body (`src/gateway/gateway-adapters.ts`), relocated verbatim
+ * — behavior is UNCHANGED, only the home moved. Mattermost has no grouping
+ * (one adapter per binding, demuxed by apiUrl, single-binding fallback).
+ */
+
+import { MattermostAdapter } from "./index";
+import {
+  MattermostPresenceSchema,
+  type MattermostPresence,
+  type Agent,
+} from "../../common/types/cortex-config";
+import type { SystemEventSource } from "../../bus/system-events";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../../common/policy";
+import type { AdapterPlugin } from "../registry";
+import { resolveFactoryAgent, stringBindingField } from "../plugin-support";
+
+/** Construction args `createAdapter` accepts — the same shape
+ *  `defaultGatewayAdapterFactory.mattermost` accepted pre-registry
+ *  (`MattermostFactoryArgs`, `src/gateway/gateway-adapters.ts`). */
+interface MattermostCreateArgs {
+  instanceId: string;
+  source: SystemEventSource | undefined;
+  presence: MattermostPresence;
+  runtime: MyelinRuntime | undefined;
+  agent?: Agent;
+  principal?: Record<string, unknown>;
+  policyEngine?: PolicyEngine;
+  policyLookup?: PlatformPrincipalIndex;
+  policyRegistry?: PrincipalRegistry;
+}
+
+export const mattermostAdapterPlugin: AdapterPlugin = {
+  kind: "adapter",
+  id: "mattermost",
+  platform: "mattermost",
+  bindingSchema: MattermostPresenceSchema,
+  secretFields: ["apiToken"],
+  // apiUrl is optional on the presence schema but required on the binding
+  // schema; the binding-resolver keys the interim instance on it too.
+  demuxKey: (binding) => stringBindingField(binding, "apiUrl", "<unset>"),
+  // No groupBindings — one adapter per binding.
+  buildGatewayConstructArgs: (group, base) => {
+    const firstEntry = group.entries[0];
+    const presence = MattermostPresenceSchema.parse(firstEntry?.binding ?? {});
+    return {
+      instanceId: base.instanceId,
+      source: base.source,
+      binding: firstEntry?.binding,
+      runtime: base.runtime,
+      presence,
+    };
+  },
+  createAdapter: (args) => {
+    const a = args as unknown as MattermostCreateArgs;
+    const { instanceId, source, presence, runtime, principal, policyEngine, policyLookup, policyRegistry } = a;
+    return new MattermostAdapter(
+      resolveFactoryAgent(a, { mattermost: presence }),
+      presence,
+      {
+        instanceId,
+        principal: principal ?? {},
+        ...(runtime !== undefined && { runtime }),
+        ...(source !== undefined && { systemEventSource: source }),
+        ...(policyEngine !== undefined && { policyEngine }),
+        ...(policyLookup !== undefined && { policyLookup }),
+        ...(policyRegistry !== undefined && { policyRegistry }),
+      },
+    );
+  },
+};

--- a/src/adapters/plugin-support.ts
+++ b/src/adapters/plugin-support.ts
@@ -1,0 +1,69 @@
+/**
+ * cortex#1788 (S3) — shared helpers every in-tree `AdapterPlugin.createAdapter`
+ * body needs. Moved verbatim out of `src/gateway/gateway-adapters.ts`'s
+ * `defaultGatewayAdapterFactory` closures (GW.a.3b.2b, S9/cortex#1523) so the
+ * four platform plugin modules (`discord/plugin.ts`, `slack/plugin.ts`,
+ * `mattermost/plugin.ts`, `web/plugin.ts`) can share them without each
+ * reaching into `gateway-adapters.ts` for gateway-only construction logic.
+ * Behavior is UNCHANGED — this is a relocation, not a rewrite.
+ */
+
+import type { Agent } from "../common/types/cortex-config";
+import type { SystemEventSource } from "../bus/system-events";
+
+/**
+ * The gateway owns one connection per binding but is NOT a stack — it has no
+ * persona file and dispatches nothing locally (inbound is rebound to the
+ * gateway's sink, bypassing `dispatchHandler.handleMessage`). The adapter
+ * constructor still requires an `Agent`; build a minimal synthetic one keyed
+ * to the binding's `agent` id so log lines and the trust set are coherent.
+ *
+ * `persona` is a sentinel — the gateway never spawns a CC session through this
+ * adapter, so the persona file is never read.
+ */
+export function syntheticGatewayAgent(
+  agentId: string,
+  presence: Agent["presence"],
+): Agent {
+  return {
+    id: agentId,
+    displayName: agentId,
+    persona: "(gateway-owned — no local dispatch)",
+    trust: [],
+    presence,
+  };
+}
+
+/**
+ * S9 (cortex#1523) — resolve the `Agent` a factory call constructs the
+ * adapter with. `args.agent` (the per-stack boot path always supplies it)
+ * wins; the gateway never supplies `agent`, so it falls through to the
+ * synthetic gateway-owned placeholder keyed off `args.source`. Throws if
+ * NEITHER is present — a caller must supply one or the other so the
+ * constructed adapter always has a real identity.
+ */
+export function resolveFactoryAgent(
+  args: { agent?: Agent; source: SystemEventSource | undefined },
+  presence: Agent["presence"],
+): Agent {
+  if (args.agent) return args.agent;
+  if (!args.source) {
+    throw new Error(
+      "AdapterPlugin.createAdapter: constructing an adapter requires either `agent` or `source` (neither was supplied)",
+    );
+  }
+  return syntheticGatewayAgent(args.source.agent, presence);
+}
+
+/**
+ * Safely read a string-typed field off a raw `Record<string, unknown>`
+ * binding for `AdapterPlugin.demuxKey`'s ungrouped fallback. Bare
+ * `String(binding.x ?? "")` trips `@typescript-eslint/no-base-to-string`
+ * because `binding.x` is `unknown` and could stringify to
+ * `"[object Object]"` for a non-string value; a demux key built from that
+ * would silently misgroup bindings instead of failing loudly.
+ */
+export function stringBindingField(binding: Record<string, unknown>, field: string, fallback = ""): string {
+  const value = binding[field];
+  return typeof value === "string" ? value : fallback;
+}

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,0 +1,309 @@
+/**
+ * cortex#1788 (S3, ADR-0024 D5 / design-pluggable-adapters.md §3.3) —
+ * `SurfacePluginRegistry`.
+ *
+ * Registry-izes the shared adapter/renderer construction seam. Before this
+ * slice, `buildGatewayAdapters` (`src/gateway/gateway-adapters.ts`) hardcoded
+ * four per-platform loops against a fixed 4-method `GatewayAdapterFactory`,
+ * and `createRenderer` (`src/renderers/index.ts`) switched on a closed
+ * `RendererKind` enum. Both are the SAME structural blocker — "adding a
+ * plugin means editing code that already exists" — so this registry replaces
+ * both with ONE `(kind, id)`-keyed store (ADR-0024 D5: two plugin classes,
+ * one loader).
+ *
+ * ## Scope of THIS slice (S3)
+ *
+ * S3 registry-izes construction. It does NOT wire the registry into config
+ * validation (S4 — `SurfacesSchema`/`RendererSchema` stay exactly as they
+ * are; `bindingSchema`/`configSchema` are carried on each plugin so S4 has
+ * somewhere to read from, but nothing consumes them yet), does not build the
+ * plugin SDK barrel (S5), and does not add boot-time discovery / a compat
+ * gate for OUT-OF-TREE bundles (S6). Every plugin registered today is
+ * in-tree, registered synchronously at boot (`createDefaultSurfacePluginRegistry`)
+ * — the same "dogfooding" pattern ADR-0024 §3.3 describes: extraction later
+ * is "delete the in-tree registration + move the module out," not "rewire
+ * the core."
+ *
+ * ## The registry keys plugin CLASSES, not instances
+ *
+ * `(kind, id)` identifies the *code* — `("adapter", "discord")`,
+ * `("renderer", "pagerduty")`. Live *instances* are keyed separately: an
+ * adapter instances per binding (`PlatformAdapter.instanceId`), a renderer
+ * instances per `renderers[]` entry (`Renderer.id`, defaulting to `kind` —
+ * OQ10, see `cortex-config.ts`'s renderer schemas). Two `kind: pagerduty`
+ * config entries share ONE registry entry (`("renderer","pagerduty")`) but
+ * construct two distinct renderer INSTANCES with distinct `id`s.
+ */
+
+import type { PlatformAdapter } from "./types";
+import type { Renderer } from "../renderers/types";
+
+export type PluginKind = "adapter" | "renderer";
+
+/**
+ * A `surfaces.{platform}[]` entry — `{ agent, stack?, binding }`. Structurally
+ * matches every platform's array element in `Surfaces`
+ * (`src/common/types/surfaces.ts`); kept loosely typed here (`binding` as a
+ * plain record) so the registry has no compile-time dependency on any one
+ * platform's Zod-inferred binding shape.
+ */
+export interface SurfaceBindingEntry {
+  readonly agent: string;
+  readonly stack?: string;
+  readonly binding: Record<string, unknown>;
+}
+
+/**
+ * One construction group — the binding entries that share ONE live
+ * connection, plus the instance id that connection registers under. Mirrors
+ * `DiscordTokenGroup` (`src/gateway/discord-token-groups.ts`), generalised:
+ * every platform's default (ungrouped) case is a one-entry group whose
+ * `instanceId` is `{platform}:{demuxKey(binding)}`; Discord's `groupBindings`
+ * returns the token-keyed groups computed today.
+ */
+export interface BindingGroup {
+  readonly entries: readonly SurfaceBindingEntry[];
+  readonly instanceId: string;
+}
+
+/** The three fields `buildGatewayAdapters`' generic loop threads into
+ *  {@link AdapterPlugin.buildGatewayConstructArgs} for every platform. */
+export interface GatewayConstructBase {
+  readonly instanceId: string;
+  readonly source: unknown;
+  readonly runtime: unknown;
+}
+
+/**
+ * Per-platform adapter plugin descriptor. `createAdapter`'s args type is
+ * intentionally loose (`Record<string, unknown>`, cast internally to the
+ * platform's own Factory-args shape) — the registry stores plugins for every
+ * platform in one map, and each platform's construction args genuinely
+ * diverge (Discord needs `allowedGuildIds` + `presenceByGuildId`; Slack/
+ * Mattermost/Web don't). Each plugin module owns the single internal cast,
+ * the same convention `wireSurfaceAdapters` already uses for its concrete-
+ * adapter casts (`as DiscordAdapter` etc.) — never unsafe in practice because
+ * a plugin is only ever invoked with the args its own call sites build for it.
+ */
+export interface AdapterPlugin {
+  readonly kind: "adapter";
+  /** Registry key. Equals `platform`. */
+  readonly id: string;
+  /** `surfaces.{platform}` key (e.g. "discord"). */
+  readonly platform: string;
+  /**
+   * The schema this platform would contribute to `SurfacesSchema` once S4
+   * composes it from the registry instead of 4 hardcoded keys. Carried here
+   * so S4 has somewhere to read from — **inert in this slice**:
+   * `SurfacesSchema` stays `.strict()` over its 4 hardcoded platform keys
+   * (`src/common/types/surfaces.ts:327-341`) until then.
+   */
+  readonly bindingSchema: unknown;
+  /**
+   * Binding fields that must be free of unresolved `__ENV__` placeholders
+   * before construction (cortex#1209 belt-and-suspenders) — checked against
+   * the RAW binding value on every entry in a construction group.
+   */
+  readonly secretFields: readonly string[];
+  /** binding → demux key. Used to build the default `{platform}:{demuxKey}`
+   *  instance id when {@link groupBindings} is absent. */
+  demuxKey(binding: Record<string, unknown>): string;
+  /**
+   * Optional: platforms that group multiple bindings onto ONE live
+   * connection (Discord's token grouping — one gateway session per bot
+   * token, not per guild). Absent = one adapter per binding entry, using
+   * `demuxKey` to build the instance id.
+   */
+  groupBindings?(entries: readonly SurfaceBindingEntry[]): BindingGroup[];
+  /**
+   * Gateway-path ONLY. `buildGatewayAdapters`' generic loop calls this to
+   * turn a raw-binding construction group into {@link createAdapter}'s args.
+   * The per-stack boot path (`wireSurfaceAdapters`) NEVER calls this — it
+   * already holds a fully-typed presence built from the richer `AgentConfig`
+   * shape (`contextDepth`, `enableAgentLog`, `trust`, …) that a raw binding
+   * does not carry, and calls {@link createAdapter} directly with its own
+   * hand-built args (see `surface-adapter-boot.ts`'s `baseFactoryArgs`).
+   */
+  buildGatewayConstructArgs(group: BindingGroup, base: GatewayConstructBase): Record<string, unknown>;
+  /** Construct (never start) the adapter. */
+  createAdapter(args: Record<string, unknown>): PlatformAdapter;
+}
+
+/**
+ * Per-kind renderer plugin descriptor (ADR-0024 D5). `configSchema` mirrors
+ * {@link AdapterPlugin.bindingSchema} — carried for S4, inert until then
+ * (`RendererSchema` stays the fixed discriminated union it is today,
+ * `src/common/types/cortex-config.ts:1193`).
+ */
+export interface RendererPlugin {
+  readonly kind: "renderer";
+  /** Registry key. Equals `rendererKind`. */
+  readonly id: string;
+  /** `renderers[].kind` discriminant (e.g. "pagerduty"). */
+  readonly rendererKind: string;
+  /** The config schema this kind would contribute to `RendererSchema` (S4).
+   *  Inert in this slice. */
+  readonly configSchema: unknown;
+  /** Construct (never start) the renderer. */
+  createRenderer(config: unknown): Renderer;
+}
+
+export type SurfacePlugin = AdapterPlugin | RendererPlugin;
+
+/**
+ * `(kind, id)`-keyed registry (ADR-0024 D5, design doc §3.3). Two independent
+ * maps keep `getAdapter`/`getRenderer` precisely typed without a runtime
+ * kind-narrowing cast at every call site — structurally still "one registry
+ * keyed by (kind, id)"; `kind` selects which map, `id` looks up within it.
+ */
+export class SurfacePluginRegistry {
+  private readonly adapterPlugins = new Map<string, AdapterPlugin>();
+  private readonly rendererPlugins = new Map<string, RendererPlugin>();
+
+  registerAdapter(plugin: AdapterPlugin): void {
+    if (this.adapterPlugins.has(plugin.id)) {
+      throw new Error(
+        `SurfacePluginRegistry: adapter plugin "${plugin.id}" is already registered`,
+      );
+    }
+    this.adapterPlugins.set(plugin.id, plugin);
+  }
+
+  registerRenderer(plugin: RendererPlugin): void {
+    if (this.rendererPlugins.has(plugin.id)) {
+      throw new Error(
+        `SurfacePluginRegistry: renderer plugin "${plugin.id}" is already registered`,
+      );
+    }
+    this.rendererPlugins.set(plugin.id, plugin);
+  }
+
+  getAdapter(id: string): AdapterPlugin | undefined {
+    return this.adapterPlugins.get(id);
+  }
+
+  getRenderer(id: string): RendererPlugin | undefined {
+    return this.rendererPlugins.get(id);
+  }
+
+  /** Insertion order — `createDefaultSurfacePluginRegistry` registers
+   *  discord → slack → mattermost → web, matching the pre-registry
+   *  `buildGatewayAdapters`' fixed platform order byte-for-byte. */
+  listAdapters(): readonly AdapterPlugin[] {
+    return [...this.adapterPlugins.values()];
+  }
+
+  listRenderers(): readonly RendererPlugin[] {
+    return [...this.rendererPlugins.values()];
+  }
+}
+
+// =============================================================================
+// Default (production) registry — in-tree plugins, dogfooding the registry
+// =============================================================================
+
+import { discordAdapterPlugin } from "./discord/plugin";
+import { slackAdapterPlugin } from "./slack/plugin";
+import { mattermostAdapterPlugin } from "./mattermost/plugin";
+import { webAdapterPlugin } from "./web/plugin";
+import { dashboardRendererPlugin } from "../renderers/dashboard";
+import { pagerdutyRendererPlugin } from "../renderers/pagerduty";
+
+/**
+ * Compose ONE registry carrying every in-tree plugin — discord → slack →
+ * mattermost → web (adapters, in the pre-registry `buildGatewayAdapters`
+ * order) then dashboard → pagerduty (renderers, in the pre-registry
+ * `createRenderer` switch order). Boot (`cortex.ts`) calls this ONCE and
+ * threads the result to the gateway path (`buildGatewayAdapters`), the
+ * per-stack path (`wireSurfaceAdapters`), and the renderer boot loop.
+ */
+export function createDefaultSurfacePluginRegistry(): SurfacePluginRegistry {
+  const registry = new SurfacePluginRegistry();
+  registry.registerAdapter(discordAdapterPlugin);
+  registry.registerAdapter(slackAdapterPlugin);
+  registry.registerAdapter(mattermostAdapterPlugin);
+  registry.registerAdapter(webAdapterPlugin);
+  registry.registerRenderer(dashboardRendererPlugin);
+  registry.registerRenderer(pagerdutyRendererPlugin);
+  return registry;
+}
+
+// =============================================================================
+// Back-compat test seam — `registryFromFactory`
+// =============================================================================
+
+/**
+ * The pre-registry adapter-construction seam (`src/gateway/gateway-adapters.ts`'s
+ * `GatewayAdapterFactory`) — four platform methods, still exported there and
+ * still the type a dozen tests build recording/counting fakes against
+ * (`gateway-adapters.test.ts`, `start-gateway.test.ts`,
+ * `cross-principal-routing.integration.test.ts`, `web-adapter.test.ts`,
+ * `surface-adapter-boot.test.ts`). Declared structurally here (not imported)
+ * to avoid a dependency cycle with `gateway-adapters.ts`, which imports
+ * {@link createDefaultSurfacePluginRegistry} (via `registry.ts` re-exports)
+ * for its own default. Each method's param is deliberately `any`, not
+ * `Record<string, unknown>` — `gateway-adapters.ts`'s real
+ * `GatewayAdapterFactory` types each method's arg with a NARROWER,
+ * platform-specific interface (`DiscordFactoryArgs` etc.), and
+ * `strictFunctionTypes` contravariance would reject assigning that stricter
+ * factory to a `Record<string, unknown>`-param shape. `any` is the standard
+ * escape for "adapt an external, more specifically-typed callback shape."
+ */
+interface LegacyGatewayAdapterFactory {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  discord(args: any): PlatformAdapter;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  slack(args: any): PlatformAdapter;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mattermost(args: any): PlatformAdapter;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  web(args: any): PlatformAdapter;
+}
+
+/**
+ * Adapt a legacy `GatewayAdapterFactory`-shaped fake into a registry whose
+ * four adapter plugins delegate `createAdapter` straight to the fake's
+ * matching method. Existing test doubles built against the pre-registry
+ *4-method interface keep working UNCHANGED — only the one call site that
+ * used to pass `{ factory }` now passes `{ registry: registryFromFactory(factory) }`.
+ * `demuxKey`/`groupBindings`/`buildGatewayConstructArgs` are borrowed from
+ * the real in-tree plugins (grouping/demux logic isn't what these tests
+ * fake — only the terminal construction call is).
+ */
+export function registryFromFactory(factory: LegacyGatewayAdapterFactory): SurfacePluginRegistry {
+  const registry = new SurfacePluginRegistry();
+  registry.registerAdapter({ ...discordAdapterPlugin, createAdapter: (args) => factory.discord(args) });
+  registry.registerAdapter({ ...slackAdapterPlugin, createAdapter: (args) => factory.slack(args) });
+  registry.registerAdapter({ ...mattermostAdapterPlugin, createAdapter: (args) => factory.mattermost(args) });
+  registry.registerAdapter({ ...webAdapterPlugin, createAdapter: (args) => factory.web(args) });
+  registry.registerRenderer(dashboardRendererPlugin);
+  registry.registerRenderer(pagerdutyRendererPlugin);
+  return registry;
+}
+
+/**
+ * The inverse of {@link registryFromFactory} — wrap a registry back into the
+ * legacy 4-method shape. Lets `wireSurfaceAdapters`
+ * (`src/runner/surface-adapter-boot.ts`) accept an explicit `registry` param
+ * (cortex.ts's "boot composes the registry once, threads it to both paths")
+ * while its internal per-platform descriptors keep calling
+ * `factory.discord(args)` / `.slack(args)` / `.mattermost(args)` unchanged —
+ * every construction call still ends up at the SAME registry entry either
+ * way.
+ */
+function requireAdapterPlugin(registry: SurfacePluginRegistry, platform: string): AdapterPlugin {
+  const plugin = registry.getAdapter(platform);
+  if (!plugin) {
+    throw new Error(`registryToLegacyFactory: no adapter plugin registered for platform "${platform}"`);
+  }
+  return plugin;
+}
+
+export function registryToLegacyFactory(registry: SurfacePluginRegistry): LegacyGatewayAdapterFactory {
+  return {
+    discord: (args: Record<string, unknown>) => requireAdapterPlugin(registry, "discord").createAdapter(args),
+    slack: (args: Record<string, unknown>) => requireAdapterPlugin(registry, "slack").createAdapter(args),
+    mattermost: (args: Record<string, unknown>) => requireAdapterPlugin(registry, "mattermost").createAdapter(args),
+    web: (args: Record<string, unknown>) => requireAdapterPlugin(registry, "web").createAdapter(args),
+  };
+}

--- a/src/adapters/slack/plugin.ts
+++ b/src/adapters/slack/plugin.ts
@@ -1,0 +1,83 @@
+/**
+ * cortex#1788 (S3, ADR-0024 D5) — Slack `AdapterPlugin`.
+ *
+ * `createAdapter`'s body is `defaultGatewayAdapterFactory.slack`'s
+ * pre-registry body (`src/gateway/gateway-adapters.ts`), relocated verbatim
+ * — behavior is UNCHANGED, only the home moved. Slack has no grouping (one
+ * adapter per binding, demuxed by workspace id) — `groupBindings` is absent.
+ */
+
+import { SlackAdapter } from "./index";
+import {
+  SlackPresenceSchema,
+  type SlackPresence,
+  type Agent,
+} from "../../common/types/cortex-config";
+import type { SystemEventSource } from "../../bus/system-events";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../../common/policy";
+import type { AdapterPlugin } from "../registry";
+import { resolveFactoryAgent, stringBindingField } from "../plugin-support";
+
+/** Construction args `createAdapter` accepts — the same shape
+ *  `defaultGatewayAdapterFactory.slack` accepted pre-registry
+ *  (`SlackFactoryArgs`, `src/gateway/gateway-adapters.ts`). */
+interface SlackCreateArgs {
+  instanceId: string;
+  source: SystemEventSource | undefined;
+  presence: SlackPresence;
+  runtime: MyelinRuntime | undefined;
+  agent?: Agent;
+  principal?: Record<string, unknown>;
+  policyEngine?: PolicyEngine;
+  policyLookup?: PlatformPrincipalIndex;
+  policyRegistry?: PrincipalRegistry;
+  trustedBotIds?: ReadonlySet<string>;
+  surfaceSubjects?: string[];
+  surfaceFallbackChannelId?: string;
+}
+
+export const slackAdapterPlugin: AdapterPlugin = {
+  kind: "adapter",
+  id: "slack",
+  platform: "slack",
+  bindingSchema: SlackPresenceSchema,
+  secretFields: ["botToken", "appToken"],
+  demuxKey: (binding) => stringBindingField(binding, "workspaceId"),
+  // No groupBindings — one adapter per binding, demuxed on workspaceId.
+  buildGatewayConstructArgs: (group, base) => {
+    const firstEntry = group.entries[0];
+    const presence = SlackPresenceSchema.parse(firstEntry?.binding ?? {});
+    return {
+      instanceId: base.instanceId,
+      source: base.source,
+      binding: firstEntry?.binding,
+      runtime: base.runtime,
+      presence,
+    };
+  },
+  createAdapter: (args) => {
+    const a = args as unknown as SlackCreateArgs;
+    const {
+      instanceId, source, presence, runtime,
+      principal, policyEngine, policyLookup, policyRegistry,
+      trustedBotIds, surfaceSubjects, surfaceFallbackChannelId,
+    } = a;
+    return new SlackAdapter(
+      resolveFactoryAgent(a, { slack: presence }),
+      presence,
+      {
+        instanceId,
+        principal: principal ?? {},
+        ...(runtime !== undefined && { runtime }),
+        ...(source !== undefined && { systemEventSource: source }),
+        ...(trustedBotIds !== undefined && { trustedBotIds }),
+        ...(policyEngine !== undefined && { policyEngine }),
+        ...(policyLookup !== undefined && { policyLookup }),
+        ...(policyRegistry !== undefined && { policyRegistry }),
+        ...(surfaceSubjects !== undefined && { surfaceSubjects }),
+        ...(surfaceFallbackChannelId !== undefined && { surfaceFallbackChannelId }),
+      },
+    );
+  },
+};

--- a/src/adapters/web/__tests__/web-adapter.test.ts
+++ b/src/adapters/web/__tests__/web-adapter.test.ts
@@ -15,6 +15,7 @@ import type { WebBinding } from "../../../common/types/surfaces";
 import type { InboundMessage } from "../../types";
 import { buildGatewayAdapters } from "../../../gateway/gateway-adapters";
 import type { GatewayAdapterFactory } from "../../../gateway/gateway-adapters";
+import { registryFromFactory } from "../../registry";
 import type { Surfaces } from "../../../common/types/surfaces";
 import type { PlatformAdapter } from "../../types";
 
@@ -730,7 +731,7 @@ describe("buildGatewayAdapters — web bindings", () => {
     const adapters = buildGatewayAdapters(surfaces, {
       principal: "andreas",
       runtime: RUNTIME_STUB,
-      factory,
+      registry: registryFromFactory(factory),
     });
     expect(adapters).toHaveLength(1);
     expect(calls[0]?.instanceId).toBe("web:acme");
@@ -748,7 +749,7 @@ describe("buildGatewayAdapters — web bindings", () => {
     const adapters = buildGatewayAdapters(surfaces, {
       principal: "andreas",
       runtime: RUNTIME_STUB,
-      factory,
+      registry: registryFromFactory(factory),
     });
     expect(adapters).toHaveLength(2);
     expect(calls.map((c) => c.instanceId)).toEqual(["web:app-a", "web:app-b"]);
@@ -759,7 +760,7 @@ describe("buildGatewayAdapters — web bindings", () => {
     const adapters = buildGatewayAdapters({}, {
       principal: "andreas",
       runtime: RUNTIME_STUB,
-      factory,
+      registry: registryFromFactory(factory),
     });
     expect(adapters).toHaveLength(0);
     expect(calls.filter((c) => c.platform === "web")).toHaveLength(0);
@@ -778,7 +779,7 @@ describe("buildGatewayAdapters — web bindings", () => {
     };
     buildGatewayAdapters(
       { web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "acme", broadcastUrl: "http://x.com", port: 8090, transport: "ws", authScheme: "none" } }] },
-      { principal: "andreas", runtime: RUNTIME_STUB, factory },
+      { principal: "andreas", runtime: RUNTIME_STUB, registry: registryFromFactory(factory) },
     );
     expect(capturedSource).toMatchObject({
       principal: "andreas",
@@ -800,7 +801,7 @@ describe("buildGatewayAdapters — web bindings", () => {
     };
     buildGatewayAdapters(
       { web: [{ agent: "ivy", binding: { host: "127.0.0.1", instanceId: "acme", broadcastUrl: "http://x.com/b", port: 8090, transport: "sse", authScheme: "header", authHeader: "X-User" } }] },
-      { principal: "andreas", runtime: RUNTIME_STUB, factory },
+      { principal: "andreas", runtime: RUNTIME_STUB, registry: registryFromFactory(factory) },
     );
     const b = capturedWebBinding as Record<string, unknown>;
     expect(b.instanceId).toBe("acme");
@@ -820,7 +821,7 @@ describe("buildGatewayAdapters — web bindings", () => {
     const adapters = buildGatewayAdapters(surfaces, {
       principal: "p",
       runtime: RUNTIME_STUB,
-      factory,
+      registry: registryFromFactory(factory),
     });
     // The WebAdapter produced by the default factory has no surfaceConfig getter
     // (no surfaceSubjects field). Verify the interface contract only exposes
@@ -879,7 +880,7 @@ describe("WebAdapter — tenant agnosticism", () => {
     };
 
     const RUNTIME_STUB = { enabled: false, publish: async () => {}, publishFederated: async () => {}, subscribe: undefined, onEnvelope: () => ({ unregister: () => {} }), stop: async () => {} } as unknown as Parameters<typeof buildGatewayAdapters>[1]["runtime"];
-    buildGatewayAdapters(surfaces, { principal: "p", runtime: RUNTIME_STUB, factory });
+    buildGatewayAdapters(surfaces, { principal: "p", runtime: RUNTIME_STUB, registry: registryFromFactory(factory) });
 
     const webCalls = calls.filter((c) => c.platform === "web");
     expect(webCalls).toHaveLength(2);

--- a/src/adapters/web/plugin.ts
+++ b/src/adapters/web/plugin.ts
@@ -1,0 +1,63 @@
+/**
+ * cortex#1788 (S3, ADR-0024 D5) — Web/SSE `AdapterPlugin`.
+ *
+ * `createAdapter`'s body is `defaultGatewayAdapterFactory.web`'s pre-registry
+ * body (`src/gateway/gateway-adapters.ts`, C-110), relocated verbatim —
+ * behavior is UNCHANGED, only the home moved. No binding secrets (auth is CF
+ * Access at the edge, not a bot token — `secretFields` is empty) and no
+ * presence re-parse (the `WebBinding` already carries every field the
+ * adapter needs, unlike Discord/Slack/Mattermost's presence schemas).
+ */
+
+import { WebAdapter } from "./index";
+import type { WebBinding } from "../../common/types/surfaces";
+import type { Agent } from "../../common/types/cortex-config";
+import type { SystemEventSource } from "../../bus/system-events";
+import type { AdapterPlugin } from "../registry";
+import { resolveFactoryAgent, stringBindingField } from "../plugin-support";
+
+/** Construction args `createAdapter` accepts — the same shape
+ *  `defaultGatewayAdapterFactory.web` accepted pre-registry
+ *  (`WebFactoryArgs`, `src/gateway/gateway-adapters.ts`). `source` is used
+ *  only by {@link resolveFactoryAgent}'s synthetic-agent fallback — like the
+ *  pre-registry factory, it is never forwarded into `WebAdapterInfra`. */
+interface WebCreateArgs {
+  instanceId: string;
+  webBinding: WebBinding;
+  source: SystemEventSource | undefined;
+  agent?: Agent;
+}
+
+export const webAdapterPlugin: AdapterPlugin = {
+  kind: "adapter",
+  id: "web",
+  platform: "web",
+  bindingSchema: undefined,
+  // No secrets in a web binding — auth is CF Access at the edge, not a bot
+  // token (`broadcastUrl` is a non-secret endpoint).
+  secretFields: [],
+  demuxKey: (binding) => stringBindingField(binding, "instanceId"),
+  // No groupBindings — one adapter per binding, demuxed on the configured
+  // tenant instanceId.
+  buildGatewayConstructArgs: (group, base) => {
+    const firstEntry = group.entries[0];
+    const webBinding = (firstEntry?.binding ?? {}) as unknown as WebBinding;
+    return {
+      instanceId: base.instanceId,
+      binding: firstEntry?.binding,
+      webBinding,
+      source: base.source,
+    };
+  },
+  createAdapter: (args) => {
+    const a = args as unknown as WebCreateArgs;
+    return new WebAdapter(
+      resolveFactoryAgent(a, {}),
+      a.webBinding,
+      {
+        instanceId: a.instanceId,
+        principal: {},
+      },
+    );
+  },
+};

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1108,6 +1108,14 @@ export type RendererVisibility = z.infer<typeof RendererVisibilitySchema>;
  */
 export const DashboardRendererSchema = z.object({
   kind: z.literal("dashboard"),
+  /**
+   * cortex#1788 (S3, ADR-0024 OQ10) — optional instance id, defaulting to
+   * `kind`. `renderers[]` is an array; two `kind: dashboard` entries would
+   * otherwise both construct with the same hardcoded id, colliding in
+   * router metrics and making a future `unload` verb ambiguous. Additive,
+   * non-breaking — an unset `id` preserves today's behaviour exactly.
+   */
+  id: z.string().min(1).optional(),
   port: z.number().int().positive().default(8767),
   publicUrl: z.url().optional(),
   subscribe: z.array(z.string().min(1)).default(["local.{principal}.>"]),
@@ -1138,6 +1146,13 @@ export type DashboardRendererConfig = z.infer<typeof DashboardRendererSchema>;
  */
 export const PagerDutyRendererSchema = z.object({
   kind: z.literal("pagerduty"),
+  /**
+   * cortex#1788 (S3, ADR-0024 OQ10) — optional instance id, defaulting to
+   * `kind`. See {@link DashboardRendererSchema.id} for the rationale; the
+   * pagerduty case is the one OQ10 names explicitly (two `kind: pagerduty`
+   * entries with different routing keys are otherwise indistinguishable).
+   */
+  id: z.string().min(1).optional(),
   /** Integration / routing key for PagerDuty events-v2. */
   routingKey: z.string().min(1),
   /** Subject patterns to subscribe to. Principal chooses what counts as page-worthy. */
@@ -1157,6 +1172,9 @@ export type PagerDutyRendererConfig = z.infer<typeof PagerDutyRendererSchema>;
  */
 export const CliTailRendererSchema = z.object({
   kind: z.literal("cli-tail"),
+  /** cortex#1788 (S3, ADR-0024 OQ10) — optional instance id, defaulting to
+   *  `kind`. See {@link DashboardRendererSchema.id}. */
+  id: z.string().min(1).optional(),
   subscribe: z.array(z.string().min(1)).default(["local.{principal}.>"]),
   /**
    * IAW Phase A.4 — optional visibility guardrails. See
@@ -1173,6 +1191,9 @@ export type CliTailRendererConfig = z.infer<typeof CliTailRendererSchema>;
  */
 export const WebhookOutRendererSchema = z.object({
   kind: z.literal("webhook-out"),
+  /** cortex#1788 (S3, ADR-0024 OQ10) — optional instance id, defaulting to
+   *  `kind`. See {@link DashboardRendererSchema.id}. */
+  id: z.string().min(1).optional(),
   url: z.url(),
   subscribe: z.array(z.string().min(1)).default([]),
   /** Optional auth header (e.g. `Bearer <token>`). */

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -132,6 +132,7 @@ import {
 
 import { attachLegacyOutboundLog } from "./adapters/discord";
 import { createRenderer, type Renderer } from "./renderers";
+import { createDefaultSurfacePluginRegistry } from "./adapters/registry";
 import { RendererSchema, deriveStackId, DEFAULT_STREAM_MAX_BYTES } from "./common/types/cortex-config";
 import type {
   Agent,
@@ -3103,6 +3104,15 @@ export async function startCortex(
   const adapters: PlatformAdapter[] = [];
   const adapterCleanup: (() => void)[] = [];
 
+  // cortex#1788 (S3, ADR-0024 D5) — compose ONE `(kind, id)`-keyed
+  // adapter/renderer registry for this boot and thread it to every
+  // construction site below: the per-stack boot path (`wireSurfaceAdapters`),
+  // the renderer boot loop (`createRenderer`), and the shared surface
+  // gateway (`startGatewayIfEnabled`). All three paths dogfood the SAME
+  // in-tree registrations (ADR-0024 §3.3) — extraction later moves a plugin
+  // out, it never rewires this composition.
+  const surfacePluginRegistry = createDefaultSurfacePluginRegistry();
+
   // GW.a.3b.2c (cortex#524) — the surface ownership plan. When
   // `CORTEX_GATEWAY` is set, the shared surface gateway (constructed below via
   // `startGatewayIfEnabled`) builds ONE adapter per `surfaces:` binding on the
@@ -3198,6 +3208,7 @@ export async function startCortex(
     adapters,
     adapterCleanup,
     liveSurfaces,
+    registry: surfacePluginRegistry,
   });
 
   // MIG-7.2d: non-agent-bound renderers (dashboard, pagerduty, …).
@@ -3252,7 +3263,7 @@ export async function startCortex(
       subscribe: subjectPlaceholderSubstituter(parseResult.data.subscribe),
     };
     try {
-      const renderer = createRenderer(rendererConfig);
+      const renderer = createRenderer(rendererConfig, surfacePluginRegistry);
       await renderer.start();
       router.register(renderer.surfaceConfig);
       renderers.push(renderer);
@@ -5494,6 +5505,7 @@ export async function startCortex(
     source: systemEventSource,
     policyEngine: adapterPolicyEngine,
     ownershipPlan: surfaceOwnershipPlan,
+    registry: surfacePluginRegistry,
   });
   const gw: SurfaceGateway | undefined = startedGateway?.gateway;
 

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -20,6 +20,7 @@ import {
   type GatewayAdapterDeps,
   type GatewayAdapterFactory,
 } from "../gateway-adapters";
+import { registryFromFactory } from "../../adapters/registry";
 import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
 import type { Surfaces } from "../../common/types/surfaces";
 import type { SystemEventSource } from "../../bus/system-events";
@@ -147,7 +148,7 @@ function makeDeps(factory: GatewayAdapterFactory): GatewayAdapterDeps {
   return {
     principal: "andreas",
     runtime: RUNTIME_STUB,
-    factory,
+    registry: registryFromFactory(factory),
   };
 }
 
@@ -394,7 +395,7 @@ describe("buildGatewayAdapters", () => {
     buildGatewayAdapters(DISCORD_SURFACES, {
       principal: "andreas",
       runtime: RUNTIME_STUB,
-      factory,
+      registry: registryFromFactory(factory),
     });
     // builder is synchronous + construct-only
     expect(started).toEqual([]);

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -69,27 +69,28 @@
  * inline construction.
  */
 
-import { DiscordAdapter } from "../adapters/discord";
-import { SlackAdapter } from "../adapters/slack";
-import { MattermostAdapter } from "../adapters/mattermost";
-import { WebAdapter } from "../adapters/web";
 import type { PlatformAdapter } from "../adapters/types";
 import type { Surfaces } from "../common/types/surfaces";
 import type { WebBinding } from "../common/types/surfaces";
-import {
-  DiscordPresenceSchema,
-  SlackPresenceSchema,
-  MattermostPresenceSchema,
-  type DiscordPresence,
-  type SlackPresence,
-  type MattermostPresence,
-  type Agent,
+import type {
+  DiscordPresence,
+  SlackPresence,
+  MattermostPresence,
+  Agent,
 } from "../common/types/cortex-config";
 import type { SystemEventSource } from "../bus/system-events";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../common/policy";
 import { assertNoUnresolvedPlaceholder } from "../common/config/resolve-env-placeholders";
-import { groupDiscordBindingsByToken } from "./discord-token-groups";
+import type {
+  BindingGroup,
+  SurfaceBindingEntry,
+  SurfacePluginRegistry,
+} from "../adapters/registry";
+import { discordAdapterPlugin } from "../adapters/discord/plugin";
+import { slackAdapterPlugin } from "../adapters/slack/plugin";
+import { mattermostAdapterPlugin } from "../adapters/mattermost/plugin";
+import { webAdapterPlugin } from "../adapters/web/plugin";
 // Back-compat re-export for callers that still import the old suppression helper here.
 export { gatewayOwnedSurfaceKeys } from "./surface-ownership-plan";
 
@@ -200,150 +201,36 @@ export interface GatewayAdapterDeps {
   principal: string;
   /** Myelin runtime (may be dormant — adapters track state locally either way). */
   runtime: MyelinRuntime | undefined;
-  /** Adapter-construction seam. Defaults to {@link defaultGatewayAdapterFactory}. */
-  factory: GatewayAdapterFactory;
+  /**
+   * cortex#1788 (S3, ADR-0024 D5) — the `(kind, id)`-keyed adapter/renderer
+   * registry. Replaces the pre-registry `factory: GatewayAdapterFactory`
+   * field: `buildGatewayAdapters` no longer hardcodes 4 platform methods, it
+   * iterates `registry.listAdapters()`. Production passes
+   * `createDefaultSurfacePluginRegistry()` (`src/adapters/registry.ts`);
+   * tests build one from a recording fake via `registryFromFactory`.
+   */
+  registry: SurfacePluginRegistry;
 }
 
 // =============================================================================
-// Synthetic agent for gateway-owned adapters
+// Legacy back-compat shim — `defaultGatewayAdapterFactory`
 // =============================================================================
 
 /**
- * The gateway owns one connection per binding but is NOT a stack — it has no
- * persona file and dispatches nothing locally (inbound is rebound to the
- * gateway's sink, bypassing `dispatchHandler.handleMessage`). The adapter
- * constructor still requires an `Agent`; build a minimal synthetic one keyed
- * to the binding's `agent` id so log lines and the trust set are coherent.
- *
- * `persona` is a sentinel — the gateway never spawns a CC session through this
- * adapter, so the persona file is never read.
- */
-function syntheticGatewayAgent(
-  agentId: string,
-  presence: Agent["presence"],
-): Agent {
-  return {
-    id: agentId,
-    displayName: agentId,
-    persona: "(gateway-owned — no local dispatch)",
-    trust: [],
-    presence,
-  };
-}
-
-/**
- * S9 (cortex#1523) — resolve the `Agent` a factory call constructs the
- * adapter with. `args.agent` (the per-stack boot path always supplies it)
- * wins; the gateway never supplies `agent`, so it falls through to the
- * synthetic gateway-owned placeholder keyed off `args.source`. Throws if
- * NEITHER is present — a caller must supply one or the other so the
- * constructed adapter always has a real identity.
- */
-function resolveFactoryAgent(
-  args: Pick<FactoryArgsBase, "agent" | "source">,
-  presence: Agent["presence"],
-): Agent {
-  if (args.agent) return args.agent;
-  if (!args.source) {
-    throw new Error(
-      "GatewayAdapterFactory: constructing an adapter requires either `agent` or `source` (neither was supplied)",
-    );
-  }
-  return syntheticGatewayAgent(args.source.agent, presence);
-}
-
-// =============================================================================
-// Default (production) factory — constructs the real adapters
-// =============================================================================
-
-/**
- * Production factory. Constructs the concrete platform adapters with an empty
- * principal-DM block (the gateway is shadow/log-only; see module doc). The
- * adapters are CONSTRUCTED only — `buildGatewayAdapters` does not start them.
+ * cortex#1788 (S3) — pre-registry construction seam, RETAINED so existing
+ * imports (`start-gateway.ts`, `surface-adapter-boot.ts`, and their tests'
+ * recording/counting fakes) keep resolving. The actual construction logic
+ * moved verbatim into each platform's `AdapterPlugin.createAdapter`
+ * (`src/adapters/{discord,slack,mattermost,web}/plugin.ts`) — this object is
+ * now a thin delegating shim, not the source of truth. New code should
+ * thread a {@link SurfacePluginRegistry} (`createDefaultSurfacePluginRegistry`)
+ * instead of this factory.
  */
 export const defaultGatewayAdapterFactory: GatewayAdapterFactory = {
-  discord: (args) => {
-    const {
-      instanceId, source, presence, runtime, allowedGuildIds, presenceByGuildId,
-      principal, policyEngine, policyLookup, policyRegistry,
-      trustedBotIds, surfaceSubjects, surfaceFallbackChannelId,
-    } = args;
-    return new DiscordAdapter(
-      resolveFactoryAgent(args, { discord: presence }),
-      presence,
-      {
-        instanceId,
-        principal: principal ?? {},
-        ...(runtime !== undefined && { runtime }),
-        ...(source !== undefined && { systemEventSource: source }),
-        allowedGuildIds,
-        presenceByGuildId,
-        ...(trustedBotIds !== undefined && { trustedBotIds }),
-        ...(policyEngine !== undefined && { policyEngine }),
-        ...(policyLookup !== undefined && { policyLookup }),
-        ...(policyRegistry !== undefined && { policyRegistry }),
-        ...(surfaceSubjects !== undefined && { surfaceSubjects }),
-        ...(surfaceFallbackChannelId !== undefined && { surfaceFallbackChannelId }),
-      },
-    );
-  },
-
-  slack: (args) => {
-    const {
-      instanceId, source, presence, runtime,
-      principal, policyEngine, policyLookup, policyRegistry,
-      trustedBotIds, surfaceSubjects, surfaceFallbackChannelId,
-    } = args;
-    return new SlackAdapter(
-      resolveFactoryAgent(args, { slack: presence }),
-      presence,
-      {
-        instanceId,
-        principal: principal ?? {},
-        ...(runtime !== undefined && { runtime }),
-        ...(source !== undefined && { systemEventSource: source }),
-        ...(trustedBotIds !== undefined && { trustedBotIds }),
-        ...(policyEngine !== undefined && { policyEngine }),
-        ...(policyLookup !== undefined && { policyLookup }),
-        ...(policyRegistry !== undefined && { policyRegistry }),
-        ...(surfaceSubjects !== undefined && { surfaceSubjects }),
-        ...(surfaceFallbackChannelId !== undefined && { surfaceFallbackChannelId }),
-      },
-    );
-  },
-
-  mattermost: (args) => {
-    const { instanceId, source, presence, runtime, principal, policyEngine, policyLookup, policyRegistry } = args;
-    return new MattermostAdapter(
-      resolveFactoryAgent(args, { mattermost: presence }),
-      presence,
-      {
-        instanceId,
-        principal: principal ?? {},
-        ...(runtime !== undefined && { runtime }),
-        ...(source !== undefined && { systemEventSource: source }),
-        ...(policyEngine !== undefined && { policyEngine }),
-        ...(policyLookup !== undefined && { policyLookup }),
-        ...(policyRegistry !== undefined && { policyRegistry }),
-      },
-    );
-  },
-
-  /**
-   * C-110: Generic web/SSE surface adapter. No presence schema re-parse
-   * needed — the WebBinding carries everything the adapter needs directly.
-   * No reconnect credentials to guard (no bot token); the binding's
-   * `broadcastUrl` is already validated by `WebBindingSchema`.
-   */
-  web: (args) =>
-    new WebAdapter(
-      resolveFactoryAgent(args, {}),
-      args.webBinding,
-      {
-        instanceId: args.instanceId,
-        principal: {},
-      },
-    ),
+  discord: (args) => discordAdapterPlugin.createAdapter(args as unknown as Record<string, unknown>),
+  slack: (args) => slackAdapterPlugin.createAdapter(args as unknown as Record<string, unknown>),
+  mattermost: (args) => mattermostAdapterPlugin.createAdapter(args as unknown as Record<string, unknown>),
+  web: (args) => webAdapterPlugin.createAdapter(args as unknown as Record<string, unknown>),
 };
 
 // =============================================================================
@@ -356,12 +243,21 @@ function gatewaySource(principal: string, instance: string): SystemEventSource {
 }
 
 /**
+ * cortex#1788 (S3, ADR-0024 D5 / design-pluggable-adapters.md §3.3) — ONE
+ * generic loop over `deps.registry.listAdapters()`, replacing the four
+ * near-identical per-platform loops this function used to hardcode. No
+ * platform-specific branching survives here: grouping (Discord's token
+ * grouping), demuxing, and the secret-placeholder guard are all plugin-owned
+ * (`AdapterPlugin.groupBindings` / `.demuxKey` / `.secretFields`).
+ *
  * Construct ONE {@link PlatformAdapter} per surface binding.
  *
  * Synchronous + construct-only: it never calls `adapter.start()` (that is the
- * {@link SurfaceGateway}'s responsibility). Returns the adapters in
- * discord→slack→mattermost order. An empty/absent `Surfaces` map yields `[]`
- * and never touches the factory.
+ * {@link SurfaceGateway}'s responsibility). Returns the adapters in the
+ * registry's platform order (discord→slack→mattermost→web, matching the
+ * pre-registry fixed order — `createDefaultSurfacePluginRegistry` registers
+ * in that sequence). An empty/absent `Surfaces` map yields `[]` and never
+ * touches a plugin's `createAdapter`.
  *
  * @throws re-throws any error from the canonical presence parse (a binding
  *   that the binding-schema admitted but the presence-schema rejects) or from
@@ -373,99 +269,42 @@ export function buildGatewayAdapters(
   surfaces: Surfaces,
   deps: GatewayAdapterDeps,
 ): PlatformAdapter[] {
-  const { principal, runtime, factory } = deps;
+  const { principal, runtime, registry } = deps;
   const adapters: PlatformAdapter[] = [];
+  const surfacesByPlatform = surfaces as unknown as Record<string, SurfaceBindingEntry[] | undefined>;
 
-  // ── Discord — one gateway connection per bot token ────────────────────────
-  //
-  // Discord delivers every guild event for a bot token over that token's one
-  // gateway session. Surface routing remains guild-keyed, but the platform
-  // connection is token-keyed so one assistant can serve multiple guilds
-  // without opening duplicate sessions for the same bot identity.
-  for (const group of groupDiscordBindingsByToken(surfaces.discord ?? [])) {
-    const presences = group.entries.map((entry) => DiscordPresenceSchema.parse(entry.binding));
-    const presence = presences[0];
-    const firstBinding = group.entries[0]?.binding;
-    if (!presence || !firstBinding) continue;
-    // cortex#1209 belt-and-suspenders — a resolved binding can never carry a
-    // literal `__X__` token; fail-fast if one slipped past the load-time
-    // resolver before it reaches Discord `connect()`.
-    for (const p of presences) {
-      assertNoUnresolvedPlaceholder(p.token, "surfaces.discord[].binding.token");
+  for (const plugin of registry.listAdapters()) {
+    const bindings = surfacesByPlatform[plugin.platform] ?? [];
+    if (bindings.length === 0) continue;
+
+    const groups: BindingGroup[] = plugin.groupBindings
+      ? plugin.groupBindings(bindings)
+      : bindings.map((entry) => ({
+          entries: [entry],
+          instanceId: `${plugin.platform}:${plugin.demuxKey(entry.binding)}`,
+        }));
+
+    for (const group of groups) {
+      const firstEntry = group.entries[0];
+      if (!firstEntry) continue;
+
+      // cortex#1209 belt-and-suspenders — a resolved binding can never carry
+      // a literal `__X__` token; fail-fast if one slipped past the
+      // load-time resolver before it reaches the platform's `connect()`.
+      // Checked against every entry in the group (matches the pre-registry
+      // Discord loop, which checked every grouped presence, not just the
+      // first) — the RAW binding value, equivalent to the parsed presence's
+      // value since schema parsing never rewrites a required string field.
+      for (const field of plugin.secretFields) {
+        for (const entry of group.entries) {
+          assertNoUnresolvedPlaceholder(entry.binding[field], `surfaces.${plugin.platform}[].binding.${field}`);
+        }
+      }
+
+      const source = gatewaySource(principal, group.instanceId);
+      const args = plugin.buildGatewayConstructArgs(group, { instanceId: group.instanceId, source, runtime });
+      adapters.push(plugin.createAdapter(args));
     }
-    const presenceByGuildId = new Map(presences.map((p) => [p.guildId, p] as const));
-    const allowedGuildIds = new Set(presenceByGuildId.keys());
-    adapters.push(
-      factory.discord({
-        instanceId: group.instanceId,
-        source: gatewaySource(principal, group.instanceId),
-        binding: firstBinding,
-        runtime,
-        presence,
-        allowedGuildIds,
-        presenceByGuildId,
-      }),
-    );
-  }
-
-  // ── Slack — demux key = workspaceId ───────────────────────────────────────
-  for (const entry of surfaces.slack ?? []) {
-    const presence = SlackPresenceSchema.parse(entry.binding);
-    assertNoUnresolvedPlaceholder(presence.botToken, "surfaces.slack[].binding.botToken");
-    assertNoUnresolvedPlaceholder(presence.appToken, "surfaces.slack[].binding.appToken");
-    const instanceId = `slack:${presence.workspaceId}`;
-    adapters.push(
-      factory.slack({
-        instanceId,
-        source: gatewaySource(principal, instanceId),
-        binding: entry.binding,
-        runtime,
-        presence,
-      }),
-    );
-  }
-
-  // ── Mattermost — demux key = apiUrl (single-binding fallback) ─────────────
-  for (const entry of surfaces.mattermost ?? []) {
-    const presence = MattermostPresenceSchema.parse(entry.binding);
-    assertNoUnresolvedPlaceholder(presence.apiToken, "surfaces.mattermost[].binding.apiToken");
-    // apiUrl is optional on the presence schema but required on the binding
-    // schema; the binding-resolver keys the interim instance on it too.
-    const instanceId = `mattermost:${presence.apiUrl ?? "<unset>"}`;
-    adapters.push(
-      factory.mattermost({
-        instanceId,
-        source: gatewaySource(principal, instanceId),
-        binding: entry.binding,
-        runtime,
-        presence,
-      }),
-    );
-  }
-
-  // ── Web/SSE — demux key = binding.instanceId ──────────────────────────────
-  //
-  // C-110: generic web/SSE surface. No presence schema re-parse (the
-  // WebBinding already carries all runtime fields via WebBindingSchema). The
-  // instanceId is `web:{binding.instanceId}` — the tenant slug the binding
-  // declares. Unlike Discord (token-keyed) or Slack/Mattermost (URL-keyed),
-  // the web binding carries an explicit `instanceId` so multi-tenant
-  // deployments can give each surface a stable, configured name.
-  //
-  // No placeholder guard: the web binding carries no secrets (broadcastUrl
-  // is a non-secret endpoint; auth is CF Access at the edge, not a bot token).
-  for (const entry of surfaces.web ?? []) {
-    const webBinding: WebBinding = entry.binding;
-    const instanceId = `web:${webBinding.instanceId}`;
-    adapters.push(
-      factory.web({
-        instanceId,
-        source: gatewaySource(principal, instanceId),
-        binding: entry.binding,
-        runtime,
-        webBinding,
-      }),
-    );
   }
 
   return adapters;

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -53,6 +53,7 @@ import {
   defaultGatewayAdapterFactory,
   type GatewayAdapterFactory,
 } from "./gateway-adapters";
+import { registryFromFactory, type SurfacePluginRegistry } from "../adapters/registry";
 import { BusInboundSink } from "./bus-inbound-sink";
 import { defaultUnroutableWarn } from "./surface-gateway";
 import { makeEmittingUnroutable } from "./gateway-unroutable-emit";
@@ -97,9 +98,19 @@ export interface StartGatewayOpts {
   /**
    * Adapter-construction seam. Production omits this and gets
    * {@link defaultGatewayAdapterFactory}; tests inject a recording fake that
-   * returns construct-only stubs (no platform connection).
+   * returns construct-only stubs (no platform connection). Superseded by
+   * {@link registry} when both are supplied.
    */
   factory?: GatewayAdapterFactory;
+  /**
+   * cortex#1788 (S3, ADR-0024 D5) — the `(kind, id)`-keyed registry
+   * (`src/adapters/registry.ts`). cortex.ts composes ONE registry and
+   * threads it here and to the per-stack boot path
+   * (`wireSurfaceAdapters`). Takes priority over {@link factory} when both
+   * are supplied; existing `factory`-based test doubles keep working
+   * unchanged via {@link registryFromFactory}.
+   */
+  registry?: SurfacePluginRegistry;
   /** Optional unroutable-message hook forwarded to the gateway. */
   onUnroutable?: (msg: InboundMessage, reason: string) => void;
   /**
@@ -225,7 +236,7 @@ export async function startGatewayIfEnabled(
   const adapters = buildGatewayAdapters(surfaces, {
     principal: opts.principal,
     runtime: opts.runtime,
-    factory: opts.factory ?? defaultGatewayAdapterFactory,
+    registry: opts.registry ?? registryFromFactory(opts.factory ?? defaultGatewayAdapterFactory),
   });
 
   // Sink selection — the SECOND opt-in gate.

--- a/src/renderers/__tests__/dashboard.test.ts
+++ b/src/renderers/__tests__/dashboard.test.ts
@@ -30,6 +30,19 @@ function makeEnvelope(id: string): Envelope {
 }
 
 describe("DashboardRenderer", () => {
+  // cortex#1788 (S3, ADR-0024 OQ10) — id defaults to kind; two `kind:
+  // dashboard` instances need distinct configured ids to avoid colliding in
+  // router metrics.
+  test("id defaults to \"dashboard\" when config.id is unset", () => {
+    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: [], projections: [] });
+    expect(r.id).toBe("dashboard");
+  });
+
+  test("id honors config.id when set (OQ10)", () => {
+    const r = new DashboardRenderer({ kind: "dashboard", id: "dashboard-2", port: 8768, subscribe: [], projections: [] });
+    expect(r.id).toBe("dashboard-2");
+  });
+
   test("buffers rendered envelopes in insertion order", async () => {
     const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] });
     await r.render(makeEnvelope("e1"));

--- a/src/renderers/__tests__/factory.test.ts
+++ b/src/renderers/__tests__/factory.test.ts
@@ -9,6 +9,15 @@
 
 import { describe, expect, test } from "bun:test";
 import { createRenderer, DashboardRenderer, PagerDutyRenderer, UnimplementedRendererKindError } from "../index";
+import { createDefaultSurfacePluginRegistry } from "../../adapters/registry";
+
+// cortex#1788 (S3, ADR-0024 D5) — `createRenderer` now resolves through the
+// registry instead of switching on `RendererKind`. `cli-tail`/`webhook-out`
+// are NOT registered in this slice (S6 owns shipping them as bundles), so
+// they still hit `UnimplementedRendererKindError` — same observable
+// behavior, different mechanism (unregistered vs. schema-recognised-but-
+// unimplemented).
+const registry = createDefaultSurfacePluginRegistry();
 
 describe("createRenderer", () => {
   test("dispatches kind=dashboard → DashboardRenderer", () => {
@@ -17,7 +26,7 @@ describe("createRenderer", () => {
       port: 8767,
       subscribe: ["local.{principal}.>"],
       projections: [],
-    });
+    }, registry);
     expect(r).toBeInstanceOf(DashboardRenderer);
     expect(r.kind).toBe("dashboard");
   });
@@ -27,30 +36,30 @@ describe("createRenderer", () => {
       kind: "pagerduty",
       routingKey: "rk-test",
       subscribe: ["local.{principal}.system.>"],
-    });
+    }, registry);
     expect(r).toBeInstanceOf(PagerDutyRenderer);
     expect(r.kind).toBe("pagerduty");
   });
 
-  test("kind=cli-tail throws UnimplementedRendererKindError (deferred)", () => {
+  test("kind=cli-tail throws UnimplementedRendererKindError (not registered in this slice)", () => {
     expect(() =>
-      createRenderer({ kind: "cli-tail", subscribe: ["local.{principal}.>"] }),
+      createRenderer({ kind: "cli-tail", subscribe: ["local.{principal}.>"] }, registry),
     ).toThrow(UnimplementedRendererKindError);
   });
 
-  test("kind=webhook-out throws UnimplementedRendererKindError (deferred)", () => {
+  test("kind=webhook-out throws UnimplementedRendererKindError (not registered in this slice)", () => {
     expect(() =>
       createRenderer({
         kind: "webhook-out",
         url: "https://example.com/hook",
         subscribe: ["local.{principal}.>"],
-      }),
+      }, registry),
     ).toThrow(UnimplementedRendererKindError);
   });
 
   test("error message names the offending kind", () => {
     expect(() =>
-      createRenderer({ kind: "cli-tail", subscribe: [] }),
+      createRenderer({ kind: "cli-tail", subscribe: [] }, registry),
     ).toThrow(/kind "cli-tail"/);
   });
 });

--- a/src/renderers/__tests__/pagerduty.test.ts
+++ b/src/renderers/__tests__/pagerduty.test.ts
@@ -66,6 +66,19 @@ function makeEnvelope(overrides: Partial<Envelope> = {}): Envelope {
 }
 
 describe("PagerDutyRenderer", () => {
+  // cortex#1788 (S3, ADR-0024 OQ10) — id defaults to kind; two `kind:
+  // pagerduty` entries (different routing keys) need distinct configured
+  // ids to avoid colliding in router metrics / a future `unload` verb.
+  test("id defaults to \"pagerduty\" when config.id is unset", () => {
+    const renderer = new PagerDutyRenderer({ kind: "pagerduty", routingKey: "rk", subscribe: [] });
+    expect(renderer.id).toBe("pagerduty");
+  });
+
+  test("id honors config.id when set (OQ10)", () => {
+    const renderer = new PagerDutyRenderer({ kind: "pagerduty", id: "pagerduty-secondary", routingKey: "rk-2", subscribe: [] });
+    expect(renderer.id).toBe("pagerduty-secondary");
+  });
+
   test("POSTs to the events-v2 endpoint with the routing key in the body", async () => {
     const { fetchImpl, calls } = makeFetch(() => new Response("", { status: 202 }));
     const renderer = new PagerDutyRenderer(

--- a/src/renderers/dashboard.ts
+++ b/src/renderers/dashboard.ts
@@ -36,6 +36,7 @@ import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { SurfaceAdapter } from "../bus/surface-router";
 import type { DashboardRendererConfig } from "../common/types/cortex-config";
 import type { Renderer } from "./types";
+import type { RendererPlugin } from "../adapters/registry";
 
 export interface DashboardRendererOptions {
   /** Max envelopes retained in the ring buffer. Default 1000 — generous
@@ -54,9 +55,11 @@ export class DashboardRenderer implements Renderer {
   private readonly visibility: DashboardRendererConfig["visibility"];
 
   constructor(config: DashboardRendererConfig, options: DashboardRendererOptions = {}) {
-    // Single dashboard per cortex deployment; the bare kind is a stable
-    // surface-router id without needing per-port disambiguation.
-    this.id = "dashboard";
+    // cortex#1788 (S3, ADR-0024 OQ10) — `config.id` defaults to `kind`,
+    // preserving the pre-OQ10 single-dashboard-per-deployment id exactly
+    // when unset. Two `kind: dashboard` entries now need distinct
+    // `id:` values in config to avoid colliding in router metrics.
+    this.id = config.id ?? "dashboard";
     this.subjects = config.subscribe;
     this.bufferSize = options.bufferSize ?? 1000;
     // IAW Phase A.4 — capture the optional visibility block. Forwarded to
@@ -138,3 +141,21 @@ export class DashboardRenderer implements Renderer {
     return [...this.buffer];
   }
 }
+
+/**
+ * cortex#1788 (S3, ADR-0024 D2/OQ8) — `dashboard`'s `RendererPlugin`.
+ * `dashboard` is a permanent in-tree contract anchor (never extracts — D2,
+ * design-pluggable-adapters.md §7.1): removing `kind: dashboard` from the
+ * registered set is config-breaking, and it is one half of the G-1111 §4.6
+ * fail-safe pair. It registers through the SAME registry a bundle would
+ * (dogfooding, ADR-0024 §3.3) even though it never ships as one.
+ */
+export const dashboardRendererPlugin: RendererPlugin = {
+  kind: "renderer",
+  id: "dashboard",
+  rendererKind: "dashboard",
+  // S4 inert placeholder — RendererSchema stays the fixed discriminated
+  // union it is today until then.
+  configSchema: undefined,
+  createRenderer: (config) => new DashboardRenderer(config as DashboardRendererConfig),
+};

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -1,18 +1,21 @@
 /**
  * MIG-7.2d — Renderer factory.
  *
- * Dispatches on `RendererKind` (the discriminated `kind` literal on each
- * renderer config) and returns a concrete `Renderer` instance. The
- * `cli-tail` and `webhook-out` kinds are recognised by the schema but
- * not yet implemented; this slice covers the G-1111 §4.6 recommended
- * pair (dashboard + pagerduty) only. Calling `createRenderer` with an
- * unimplemented kind throws a tagged error so a config typo doesn't
- * silently produce a no-op renderer.
+ * cortex#1788 (S3, ADR-0024 D5) — `createRenderer` no longer switches on a
+ * closed `RendererKind` enum. It resolves the `("renderer", kind)` entry from
+ * the injected `SurfacePluginRegistry` instead — the registry-side twin of
+ * `buildGatewayAdapters`' generic loop (`src/gateway/gateway-adapters.ts`).
+ * `dashboard` and `pagerduty` register through it exactly as an out-of-tree
+ * bundle eventually would (dogfooding, ADR-0024 §3.3); `cli-tail` and
+ * `webhook-out` are NOT registered in this slice (S6 owns shipping them as
+ * bundles, design-pluggable-adapters.md OQ11) — an unregistered kind hits the
+ * SAME `UnimplementedRendererKindError` a config author saw before, so a
+ * typo or an unimplemented kind still fails loudly rather than silently
+ * producing a no-op renderer.
  */
 
 import type { RendererConfig } from "../common/types/cortex-config";
-import { DashboardRenderer } from "./dashboard";
-import { PagerDutyRenderer } from "./pagerduty";
+import type { SurfacePluginRegistry } from "../adapters/registry";
 import type { Renderer } from "./types";
 
 export type { Renderer } from "./types";
@@ -22,29 +25,18 @@ export { PagerDutyRenderer } from "./pagerduty";
 export class UnimplementedRendererKindError extends Error {
   constructor(kind: string) {
     super(
-      `cortex-renderers: kind "${kind}" is recognised by the schema but not implemented in this slice. ` +
-        `Only "dashboard" and "pagerduty" are available; "cli-tail" and "webhook-out" land in a follow-on iteration.`,
+      `cortex-renderers: kind "${kind}" is not registered. ` +
+        `Only "dashboard" and "pagerduty" are registered in-tree; "cli-tail" and "webhook-out" ` +
+        `land as bundles (ADR-0024 §8.1 OQ11).`,
     );
     this.name = "UnimplementedRendererKindError";
   }
 }
 
-export function createRenderer(config: RendererConfig): Renderer {
-  switch (config.kind) {
-    case "dashboard":
-      return new DashboardRenderer(config);
-    case "pagerduty":
-      return new PagerDutyRenderer(config);
-    case "cli-tail":
-    case "webhook-out":
-      throw new UnimplementedRendererKindError(config.kind);
-    default: {
-      // The discriminated union should be exhaustive; this guard catches
-      // a future kind added to the schema before the factory ships an
-      // implementation for it. The `never` widens to `string` at runtime,
-      // which is exactly what the error message wants.
-      const _exhaustive: never = config;
-      throw new UnimplementedRendererKindError((_exhaustive as { kind: string }).kind);
-    }
+export function createRenderer(config: RendererConfig, registry: SurfacePluginRegistry): Renderer {
+  const plugin = registry.getRenderer(config.kind);
+  if (!plugin) {
+    throw new UnimplementedRendererKindError(config.kind);
   }
+  return plugin.createRenderer(config);
 }

--- a/src/renderers/pagerduty.ts
+++ b/src/renderers/pagerduty.ts
@@ -39,6 +39,7 @@ import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { SurfaceAdapter } from "../bus/surface-router";
 import type { PagerDutyRendererConfig } from "../common/types/cortex-config";
 import type { Renderer } from "./types";
+import type { RendererPlugin } from "../adapters/registry";
 
 const EVENTS_V2_URL = "https://events.pagerduty.com/v2/enqueue";
 const SUMMARY_MAX_LEN = 1024;
@@ -65,12 +66,13 @@ export class PagerDutyRenderer implements Renderer {
   private readonly visibility: PagerDutyRendererConfig["visibility"];
 
   constructor(config: PagerDutyRendererConfig, options: PagerDutyRendererOptions = {}) {
-    // The surface-router uses `id` as the metrics key and error-reporting
-    // tag. Renderer kinds are unique per cortex deployment so the bare
-    // kind is a stable id; only one PagerDuty integration runs at a time
-    // (a deployment with multiple PD integrations should split into
-    // multiple cortex instances per separation-of-concerns).
-    this.id = "pagerduty";
+    // cortex#1788 (S3, ADR-0024 OQ10) — `config.id` defaults to `kind`,
+    // preserving the pre-OQ10 single-integration-per-deployment id exactly
+    // when unset. Two `kind: pagerduty` entries (different routing keys)
+    // now need distinct `id:` values in config to avoid colliding in
+    // router metrics and to be independently addressable by a future
+    // `unload` verb.
+    this.id = config.id ?? "pagerduty";
     this.subjects = config.subscribe;
     this.routingKey = config.routingKey;
     this.endpoint = options.endpoint ?? EVENTS_V2_URL;
@@ -183,3 +185,19 @@ export class PagerDutyRenderer implements Renderer {
     return "warning";
   }
 }
+
+/**
+ * cortex#1788 (S3, ADR-0024 §8.1) — `pagerduty`'s `RendererPlugin`. The
+ * renderer track's extraction pilot (leaf-y, zero npm deps, R10) — it
+ * registers through the registry now (dogfooding, ADR-0024 §3.3) and stays
+ * in-tree until S12b extracts it (gated on OQ9, the boot-coverage hard-fail).
+ */
+export const pagerdutyRendererPlugin: RendererPlugin = {
+  kind: "renderer",
+  id: "pagerduty",
+  rendererKind: "pagerduty",
+  // S4 inert placeholder — RendererSchema stays the fixed discriminated
+  // union it is today until then.
+  configSchema: undefined,
+  createRenderer: (config) => new PagerDutyRenderer(config as PagerDutyRendererConfig),
+};

--- a/src/runner/surface-adapter-boot.ts
+++ b/src/runner/surface-adapter-boot.ts
@@ -111,6 +111,7 @@ import {
   defaultGatewayAdapterFactory,
   type GatewayAdapterFactory,
 } from "../gateway/gateway-adapters";
+import { registryToLegacyFactory, type SurfacePluginRegistry } from "../adapters/registry";
 
 // =============================================================================
 // Per-platform boot descriptor — the divergent bits `bootPlatformAdapters` needs
@@ -525,8 +526,17 @@ export interface WireSurfaceAdaptersOpts {
   adapterCleanup: (() => void)[];
   /** Shared, NOT owned. */
   liveSurfaces: Set<string>;
-  /** Adapter-construction seam. Production omits this and gets {@link defaultGatewayAdapterFactory}; tests inject a recording fake. */
+  /** Adapter-construction seam. Production omits this and gets {@link defaultGatewayAdapterFactory}; tests inject a recording fake. Superseded by {@link registry} when both are supplied. */
   factory?: GatewayAdapterFactory;
+  /**
+   * cortex#1788 (S3, ADR-0024 D5) — the `(kind, id)`-keyed registry
+   * (`src/adapters/registry.ts`). cortex.ts composes ONE registry and
+   * threads it to both this boot path and the gateway path
+   * (`buildGatewayAdapters`). Takes priority over {@link factory} when both
+   * are supplied; existing `factory`-based test doubles keep working
+   * unchanged via {@link registryToLegacyFactory}.
+   */
+  registry?: SurfacePluginRegistry;
 }
 
 /**
@@ -543,7 +553,9 @@ export interface WireSurfaceAdaptersOpts {
  * doc's "PRESERVE ORDER" section.
  */
 export async function wireSurfaceAdapters(opts: WireSurfaceAdaptersOpts): Promise<void> {
-  const factory = opts.factory ?? defaultGatewayAdapterFactory;
+  const factory = opts.registry
+    ? registryToLegacyFactory(opts.registry)
+    : (opts.factory ?? defaultGatewayAdapterFactory);
   const ctx: BootCtx = {
     gatewayOwned: opts.gatewayOwned,
     router: opts.router,


### PR DESCRIPTION
Closes #1788. Epic #1784, W2 lane A. First build slice after **ADR-0024** was ratified.

Registry-izes surface construction for **both** plugin kinds (ADR-0024 D5: two classes, one SDK). Behaviour-preserving — no adapter or renderer changes behaviour, no instance id moves.

## What landed

- **`src/adapters/registry.ts`** — `SurfacePluginRegistry`, keyed by plugin **class** `(kind, id)`. Live *instances* stay keyed separately (adapters already carry `instanceId`), exactly as the ADR requires.
- **Adapter plugins** — each in-tree adapter exports a descriptor. `buildGatewayAdapters` is now **one generic loop**; the four platform-named branches are gone (verified: 0 matches). Discord's token-grouping travels inside `src/adapters/discord/plugin.ts`'s `groupBindings`, wrapping the untouched `groupDiscordBindingsByToken`. No discord special-case survives in the loop.
- **Renderer plugins (new in this slice)** — `dashboard` and `pagerduty` export descriptors; the closed `createRenderer` switch becomes a registry lookup. `cli-tail`/`webhook-out` enum arms untouched (S6 owns them) — same observable behaviour, now via "unregistered" rather than "recognized-but-unimplemented".
- **OQ10 (ratified)** — optional `renderers[].id` on all four renderer schemas, defaulting to `kind`. Unset preserves today's ids byte-for-byte; tests pin both default and override.
- `cortex.ts` composes **one** registry (`:3114`) and threads it to all three construction sites: per-stack (`:3211`), renderer loop (`:3266`), gateway (`:5508`).

## Two deliberate deviations — reviewer, look here

**1. `buildGatewayConstructArgs` is a separate plugin hook, not folded into `createAdapter`.** The design doc sketches one `createAdapter(args)`. Reality: the two callers build *fundamentally different-shaped inputs*. The gateway path holds a raw binding and must presence-parse it; the per-stack path (`wireSurfaceAdapters`) holds an already-typed `presence` and **cannot** re-derive one — `presenceAsBinding()` allowlists via `SAFE_BINDING_KEYS` and deliberately strips `token`/`botToken`/`appToken`/`apiToken` (`surface-adapter-boot.ts:805-815`). Forcing one shape would have required re-parsing a binding whose secrets are gone. Splitting the gateway-only step keeps `createAdapter` genuinely shared. *(Verified independently before opening this PR.)*

**2. `GatewayAdapterFactory`/`defaultGatewayAdapterFactory` are RETAINED as a thin back-compat shim** — so #1788's acceptance criterion "the four named methods are gone" is **not literally met**. They delegate into the four plugin objects; `registryFromFactory`/`registryToLegacyFactory` convert both directions. Reason: ~2000 lines across 4 test files build recording fakes against the 4-method shape, and rewriting them is churn+risk inside a slice whose entire point is behaviour preservation. **Production takes the registry path**; the legacy factory survives only as a fallback default and test seam. Follow-up filed to retire it.

## Proof of behaviour preservation

`gateway-adapters.test.ts` keeps its exact pre-existing assertions — `discord:{guildId}`, `discord:token:{hash}`, `slack:T…`, `mattermost:{apiUrl}`, `web:{instanceId}`, and discord→slack→mattermost construction order. Only the `deps` plumbing changed. All pass unchanged.

## Gates

`bun test src/gateway src/adapters src/renderers src/runner src/common` → **3293 pass / 0 fail** (177 files) · `tsc --noEmit` 0 · `eslint --quiet` 0 (14 findings fixed en route) · `scripts/check-carveouts.sh` **PASS** (vocab gate) · +17 registry tests, +4 OQ10 id tests.

## Known-inert, by design

`bindingSchema`/`configSchema` are placeholders — **S4 (#1789)** decides their real shape when it composes `SurfacesSchema`/`RendererSchema` from the registry. The renderer `router.register()` handle is still discarded and `renderers/types.ts:45-57` still carries the reversed doc comment — both are **S8 (#1793)**'s, per the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)